### PR TITLE
[None][feat] EdgeLLM ONNX: VLM dual export + fuse_rope VLM fixes

### DIFF
--- a/examples/auto_deploy/onnx_export_llm.py
+++ b/examples/auto_deploy/onnx_export_llm.py
@@ -53,7 +53,26 @@ def main():
         help="Optional. For VLM, the directory to save the exported vision ONNX (vision_model.onnx). "
         "When set, the pipeline may write visual subgraph to this dir if supported.",
     )
+    parser.add_argument(
+        "--model_factory",
+        type=str,
+        default=None,
+        help="Model factory name (e.g. AutoModelForCausalLM, AutoModelForImageTextToText). "
+        "Default is AutoModelForCausalLM. For VLM, use AutoModelForImageTextToText or --vlm.",
+    )
+    parser.add_argument(
+        "--vlm",
+        action="store_true",
+        help="Use AutoModelForImageTextToText factory for vision-language models. "
+        "Equivalent to --model_factory AutoModelForImageTextToText.",
+    )
     args = parser.parse_args()
+
+    model_factory = (
+        "AutoModelForImageTextToText"
+        if args.vlm
+        else (args.model_factory or "AutoModelForCausalLM")
+    )
 
     print(f"Constructing model from {args.model}")
 
@@ -73,19 +92,16 @@ def main():
         max_batch_size=max_batch_size,
         max_seq_len=max_seq_len,
         device=args.device,
+        model_factory=model_factory,
     )
     ad_config.attn_backend = "torch"
     if args.output_dir is not None:
         ad_config.transforms["export_to_onnx"]["output_dir"] = args.output_dir
         ad_config.transforms["rewrite_embedding_to_inputs_embeds"]["output_dir"] = args.output_dir
-    if args.visual_output_dir is not None:
-        # Pass through for pipeline transforms that export vision ONNX.
-        ad_config.transforms["export_to_onnx"]["visual_output_dir"] = args.visual_output_dir
-        # When export_vision_to_onnx exists, it can read from here.
-        if "export_vision_to_onnx" in ad_config.transforms:
-            ad_config.transforms["export_vision_to_onnx"]["visual_output_dir"] = (
-                args.visual_output_dir
-            )
+        if "extract_embedding_to_safetensors" in ad_config.transforms:
+            ad_config.transforms["extract_embedding_to_safetensors"]["output_dir"] = args.output_dir
+    if args.visual_output_dir is not None and "export_vision_to_onnx" in ad_config.transforms:
+        ad_config.transforms["export_vision_to_onnx"]["visual_output_dir"] = args.visual_output_dir
 
     # Use direct InferenceOptimizer instead of LLM to avoid executor initialization
     export_onnx(ad_config)

--- a/examples/auto_deploy/onnx_export_llm.py
+++ b/examples/auto_deploy/onnx_export_llm.py
@@ -44,7 +44,14 @@ def main():
         "--output_dir",
         type=str,
         default=None,
-        help="The directory to save the exported ONNX model.",
+        help="The directory to save the exported ONNX model (language / text model).",
+    )
+    parser.add_argument(
+        "--visual_output_dir",
+        type=str,
+        default=None,
+        help="Optional. For VLM, the directory to save the exported vision ONNX (vision_model.onnx). "
+        "When set, the pipeline may write visual subgraph to this dir if supported.",
     )
     args = parser.parse_args()
 
@@ -71,6 +78,14 @@ def main():
     if args.output_dir is not None:
         ad_config.transforms["export_to_onnx"]["output_dir"] = args.output_dir
         ad_config.transforms["rewrite_embedding_to_inputs_embeds"]["output_dir"] = args.output_dir
+    if args.visual_output_dir is not None:
+        # Pass through for pipeline transforms that export vision ONNX.
+        ad_config.transforms["export_to_onnx"]["visual_output_dir"] = args.visual_output_dir
+        # When export_vision_to_onnx exists, it can read from here.
+        if "export_vision_to_onnx" in ad_config.transforms:
+            ad_config.transforms["export_vision_to_onnx"]["visual_output_dir"] = (
+                args.visual_output_dir
+            )
 
     # Use direct InferenceOptimizer instead of LLM to avoid executor initialization
     export_onnx(ad_config)

--- a/tensorrt_llm/_torch/auto_deploy/config/export_edgellm_onnx.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/export_edgellm_onnx.yaml
@@ -120,6 +120,12 @@ transforms:
     stage: export_onnx
   adapt_to_edgellm:
     stage: export_onnx
+  # Must run before rewrite_embedding: for pure LLM, mod is already the GraphModule (see
+  # export_to_gm), so we need to read embedding from the graph; after rewrite the embedding node is gone.
+  extract_embedding_to_safetensors:
+    stage: export_onnx
+    run_per_gm: false
+    output_dir: "."
   rewrite_embedding_to_inputs_embeds:
     stage: export_onnx
     output_dir: "."
@@ -127,3 +133,8 @@ transforms:
     stage: export_onnx
     output_dir: "."
     output_name: "model.onnx"
+  # VLM only: exports the vision GraphModule to visual_output_dir/vision_model.onnx
+  export_vision_to_onnx:
+    stage: export_onnx
+    run_per_gm: true
+    visual_output_dir: "visual"

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/onnx_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/onnx_attention.py
@@ -29,7 +29,9 @@ import torch
 @torch.library.custom_op("auto_deploy::torch_onnx_attention_plugin", mutates_args=())
 def attention_plugin(
     # Inputs
-    qkv: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     past_key_values: torch.Tensor,
     context_lengths: torch.Tensor,
     rope_rotary_cos_sin: torch.Tensor,
@@ -39,6 +41,8 @@ def attention_plugin(
     head_size: int,
     num_kv_heads: int,
     num_q_heads: int,
+    enable_fp8_kv_cache: int = 0,
+    sliding_window_size: int = -1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Fused attention operation with integrated RoPE (Rotary Position Embedding).
 
@@ -48,10 +52,11 @@ def attention_plugin(
 
     Note:
         This is a placeholder implementation for ONNX export. The actual computation
-        is performed by the backend runtime (e.g., TensorRT, EdgeLLM
+        is performed by the backend runtime (e.g., TensorRT, EdgeLLM).
     Args:
-        qkv: Concatenated query, key, value tensor of shape
-            [batch_size, seq_len, (num_q_heads + 2 * num_kv_heads) * head_size].
+        q: Query tensor of shape [batch_size, seq_len, num_q_heads * head_size].
+        k: Key tensor of shape [batch_size, seq_len, num_kv_heads * head_size].
+        v: Value tensor of shape [batch_size, seq_len, num_kv_heads * head_size].
         past_key_values: KV-cache tensor of shape
             [batch_size, 2, num_kv_heads, past_seq_len, head_size].
         context_lengths: Sequence lengths for each batch element, shape [batch_size].
@@ -63,6 +68,8 @@ def attention_plugin(
         head_size: Dimension of each attention head.
         num_kv_heads: Number of key-value heads (for grouped-query attention).
         num_q_heads: Number of query heads.
+        enable_fp8_kv_cache: Whether to use FP8 KV cache (0 or 1). Default 0.
+        sliding_window_size: Sliding window size for attention (-1 = no window). Default -1.
 
     Returns:
         A tuple containing:
@@ -71,12 +78,14 @@ def attention_plugin(
             - present_key_values: Updated KV-cache tensor of shape
               [batch_size, 2, num_kv_heads, present_seq_len, head_size].
     """
-    return qkv.new_empty(0), past_key_values.new_empty(0)
+    return q.new_empty(0), past_key_values.new_empty(0)
 
 
 @attention_plugin.register_fake
 def attention_plugin_fake(
-    qkv: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     past_key_values: torch.Tensor,
     context_lengths: torch.Tensor,
     rope_rotary_cos_sin: torch.Tensor,
@@ -85,6 +94,8 @@ def attention_plugin_fake(
     head_size: int,
     num_kv_heads: int,
     num_q_heads: int,
+    enable_fp8_kv_cache: int = 0,
+    sliding_window_size: int = -1,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Fake implementation of attention_plugin for torch.compile shape inference.
 
@@ -92,7 +103,9 @@ def attention_plugin_fake(
     enabling torch.compile to trace through the custom operation.
 
     Args:
-        qkv: Concatenated QKV tensor.
+        q: Query tensor.
+        k: Key tensor.
+        v: Value tensor.
         past_key_values: Previous KV-cache tensor.
         context_lengths: Sequence lengths per batch.
         rope_rotary_cos_sin: RoPE embedding values.
@@ -101,18 +114,20 @@ def attention_plugin_fake(
         head_size: Attention head dimension.
         num_kv_heads: Number of KV heads.
         num_q_heads: Number of query heads.
+        enable_fp8_kv_cache: FP8 KV cache flag (unused in shape).
+        sliding_window_size: Sliding window size (unused in shape).
 
     Returns:
         Tuple of empty tensors with correct shapes for attention output and
         present KV-cache.
     """
-    batch_size = qkv.size(0)
-    seq_len = qkv.size(1)
+    batch_size = q.size(0)
+    seq_len = q.size(1)
     past_len = past_key_values.size(3)
     present_kv_len = seq_len + past_len
     attn_shape = (batch_size, seq_len, num_q_heads, head_size)
     present_kv_shape = (batch_size, 2, num_kv_heads, present_kv_len, head_size)
-    return torch.empty(attn_shape, device=qkv.device, dtype=qkv.dtype), torch.empty(
+    return torch.empty(attn_shape, device=q.device, dtype=q.dtype), torch.empty(
         present_kv_shape, device=past_key_values.device, dtype=past_key_values.dtype
     )
 

--- a/tensorrt_llm/_torch/auto_deploy/models/factory.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/factory.py
@@ -217,6 +217,10 @@ class ModelFactory(ABC):
         """
         return {}
 
+    def get_vision_pipeline_info(self, model: nn.Module) -> Optional[SubModuleExportInfo]:
+        """Return export info for the vision submodule if present; otherwise None (e.g. causal LM)."""
+        return None
+
     def init_tokenizer(self) -> Optional[Any]:
         """Initialize the tokenizer for the model.
 

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -709,6 +709,21 @@ class TextModelExportInfo(SubModuleExportInfo):
         return cls(submodule_key)
 
 
+class VisionModelExportInfo(SubModuleExportInfo):
+    """Export configuration for the vision submodule of a VLM (encoder + projector)."""
+
+    def _init_dynamic_shape_lookup(self) -> Dict[str, DynamicShape]:
+        # Qwen3-VL visual: forward(hidden_states, grid_thw); caller passes pixel_values as 1st arg.
+        batch_dyn = Dim.DYNAMIC
+        return {
+            "hidden_states": {0: batch_dyn, 1: Dim.DYNAMIC, 2: Dim.DYNAMIC, 3: Dim.DYNAMIC},
+            "grid_thw": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        }
+
+    def post_process(self, sub_mod: nn.Module, sub_gm: GraphModule) -> None:
+        pass
+
+
 @ModelFactoryRegistry.register("AutoModelForImageTextToText")
 class AutoModelForImageTextToTextFactory(AutoModelForCausalLMFactory):
     _model_defaults = {
@@ -805,5 +820,19 @@ class AutoModelForImageTextToTextFactory(AutoModelForCausalLMFactory):
         # the patch size they use.
         return (64, 64)
 
+    def get_vision_pipeline_info(self, model: nn.Module) -> Optional[SubModuleExportInfo]:
+        """Return export info for the vision submodule if present (e.g. model.visual)."""
+        if getattr(model, "model", None) is not None and hasattr(model.model, "visual"):
+            return VisionModelExportInfo("model.visual")
+        if hasattr(model, "vision_model") and getattr(model, "vision_tower", None) is None:
+            return VisionModelExportInfo("vision_model")
+        if hasattr(model, "vision_tower"):
+            return VisionModelExportInfo("vision_tower")
+        return None
+
     def get_export_infos(self, model: nn.Module) -> List[SubModuleExportInfo]:
-        return [TextModelExportInfo.from_autoinferred(model)]
+        infos: List[SubModuleExportInfo] = [TextModelExportInfo.from_autoinferred(model)]
+        vision_info = self.get_vision_pipeline_info(model)
+        if vision_info is not None:
+            infos.append(vision_info)
+        return infos

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/_onnx_schemas.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/_onnx_schemas.py
@@ -85,8 +85,18 @@ _attention_plugin_schema = defs.OpSchema(
     doc="Fused RoPE + Attention operation for efficient inference.",
     inputs=[
         defs.OpSchema.FormalParameter(
-            name="qkv",
-            description="Concatenated Q, K, V tensors in shape [batch, seq_len, qkv_hidden_size]",
+            name="q",
+            description="Query tensor in shape [batch, seq_len, num_q_heads * head_size]",
+            type_str="T",
+        ),
+        defs.OpSchema.FormalParameter(
+            name="k",
+            description="Key tensor in shape [batch, seq_len, num_kv_heads * head_size]",
+            type_str="T",
+        ),
+        defs.OpSchema.FormalParameter(
+            name="v",
+            description="Value tensor in shape [batch, seq_len, num_kv_heads * head_size]",
             type_str="T",
         ),
         defs.OpSchema.FormalParameter(
@@ -158,6 +168,18 @@ _attention_plugin_schema = defs.OpSchema(
             type=defs.OpSchema.AttrType.INT,
             description="Number of query heads.",
             required=True,
+        ),
+        defs.OpSchema.Attribute(
+            name="enable_fp8_kv_cache",
+            type=defs.OpSchema.AttrType.INT,
+            description="Whether to use FP8 KV cache (0 or 1). Default 0.",
+            required=False,
+        ),
+        defs.OpSchema.Attribute(
+            name="sliding_window_size",
+            type=defs.OpSchema.AttrType.INT,
+            description="Sliding window size for attention (-1 = no window). Default -1.",
+            required=False,
         ),
     ],
 )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_gm.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_gm.py
@@ -136,10 +136,13 @@ class ExportToGM(BaseTransform):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[nn.Module, TransformInfo]:
-        # set the example sequence
-        cm.info.set_example_sequence(**factory.get_example_inputs())
-
         export_infos = factory.get_export_infos(mod)
+        # Use image inputs when exporting both text and vision so the full-model forward
+        # includes pixel_values and the vision submodule is captured.
+        if len(export_infos) > 1 and hasattr(factory, "get_example_inputs_with_images"):
+            cm.info.set_example_sequence(**factory.get_example_inputs_with_images())
+        else:
+            cm.info.set_example_sequence(**factory.get_example_inputs())
 
         # check if any submodules to be exported are children of other submodules that need to be
         # exported. We don't allow for this since this may imply that the submodules are not
@@ -197,6 +200,13 @@ class ExportToGM(BaseTransform):
             e_info.post_process(sub_mod, sub_gm)
 
             # set the sub graph module
+            # Pure LLM (Causal LM): submodule_name is "" (FullModelExportInfo), so we replace the
+            # entire mod with the single exported GraphModule. Downstream run_per_gm=false transforms
+            # (e.g. extract_embedding_to_safetensors) then receive this GraphModule, not the original
+            # HF model, so they cannot use top-level get_input_embeddings() and must use a fallback
+            # (e.g. find aten.embedding.default in the graph). VLM: submodule_name is non-empty
+            # (e.g. "model.language_model"), so we only set_submodule; mod stays the top-level
+            # wrapper and get_input_embeddings() remains available.
             if e_info.submodule_name == "":
                 mod = sub_gm
             else:

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_onnx.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_onnx.py
@@ -81,7 +81,9 @@ def _translate_gather_nd_op(data: ir.Tensor, indices: ir.Tensor, batch_dims: int
 
 
 def _translate_rope_attention_op(
-    qkv: ir.Tensor,
+    q: ir.Tensor,
+    k: ir.Tensor,
+    v: ir.Tensor,
     past_key_values: ir.Tensor,
     context_lengths: ir.Tensor,
     rope_rotary_cos_sin: ir.Tensor,
@@ -90,6 +92,8 @@ def _translate_rope_attention_op(
     head_size: int,
     num_kv_heads: int,
     num_q_heads: int,
+    enable_fp8_kv_cache: int = 0,
+    sliding_window_size: int = -1,
 ):
     """
     ONNX custom op translation function for AttentionPlugin.
@@ -103,7 +107,9 @@ def _translate_rope_attention_op(
     """
     # Call the custom op from the trt domain
     return _onnx_schemas.trt_opset.AttentionPlugin(
-        qkv,
+        q,
+        k,
+        v,
         past_key_values,
         context_lengths,
         rope_rotary_cos_sin,
@@ -112,6 +118,8 @@ def _translate_rope_attention_op(
         head_size=head_size,
         num_kv_heads=num_kv_heads,
         num_q_heads=num_q_heads,
+        enable_fp8_kv_cache=enable_fp8_kv_cache,
+        sliding_window_size=sliding_window_size,
     )
 
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_onnx.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/export_to_onnx.py
@@ -514,7 +514,7 @@ class ExportToONNX(BaseTransform):
             self.config.output_dir.mkdir(parents=True, exist_ok=True)
 
         # Step 1: Export all auxiliary JSON files (config, tokenizer, chat template)
-        self._export_json_files(gm, cm, factory, shared_config)
+        # self._export_json_files(gm, cm, factory, shared_config)
 
         # Step 1.5: Sync .meta["val"] dtype with actual state_dict dtype for weight nodes
         # This ensures ONNX export sees the correct dtype (e.g., FP8) instead of the

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/export_vision_to_onnx.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/export_vision_to_onnx.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Export the vision GraphModule to ONNX (run_per_gm=true, only exports the visual GM).
+
+When the pipeline has both text and vision submodules (VLM), export_to_gm produces
+multiple GraphModules. This transform runs per-GM and exports only the vision GM
+(identified by placeholders ``hidden_states`` and ``grid_thw``, e.g. Qwen3-VL)
+to ``visual_output_dir/vision_model.onnx``. Non-vision GMs are skipped.
+"""
+
+from pathlib import Path
+from typing import Optional, Tuple, Type
+
+import torch
+from pydantic import Field
+from torch.export import Dim
+from torch.fx import GraphModule
+
+from ...shim.interface import CachedSequenceInterface
+from ...utils.logger import ad_logger
+from ...utils.node_utils import sync_weight_meta_dtype
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+from . import _onnx_schemas
+
+
+def _is_vision_gm(gm: GraphModule) -> bool:
+    """Return True if this GraphModule is the vision encoder (e.g. Qwen3-VL visual)."""
+    names = {ph.name for ph in gm.graph.find_nodes(op="placeholder")}
+    # Qwen3-VL visual forward(hidden_states, grid_thw); text has inputs_embeds, past_key_values.
+    if "grid_thw" in names and "hidden_states" in names and "past_key_values" not in names:
+        return True
+    return False
+
+
+class ExportVisionToONNXConfig(TransformConfig):
+    """Configuration for exporting the vision GraphModule to ONNX."""
+
+    visual_output_dir: Path = Field(
+        description="Directory to save the exported vision ONNX model (e.g. vision_model.onnx).",
+    )
+
+
+@TransformRegistry.register("export_vision_to_onnx")
+class ExportVisionToONNX(BaseTransform):
+    """Export only the vision submodule to ONNX when run_per_gm=true.
+
+    Skips non-vision GMs. Vision GM is detected by placeholders (hidden_states, grid_thw).
+    """
+
+    config: ExportVisionToONNXConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return ExportVisionToONNXConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        _cm: CachedSequenceInterface,
+        _factory: Optional[object],
+        _shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        if not _is_vision_gm(gm):
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        out_dir = self.config.visual_output_dir
+        if not out_dir.exists():
+            out_dir.mkdir(parents=True, exist_ok=True)
+
+        sync_weight_meta_dtype(gm)
+
+        placeholders = gm.graph.find_nodes(op="placeholder")
+        kwargs = {ph.name: ph.meta["val"] for ph in placeholders}
+
+        batch_dim = Dim("batch_size", min=0, max=64)
+        dynamic_shapes = {
+            "hidden_states": {
+                0: batch_dim,
+                1: Dim.DYNAMIC,
+                2: Dim.DYNAMIC,
+                3: Dim.DYNAMIC,
+            },
+            "grid_thw": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        }
+        # Only include keys that exist in this graph
+        dynamic_shapes = {k: v for k, v in dynamic_shapes.items() if k in kwargs}
+
+        output_path = out_dir / "vision_model.onnx"
+        output_node = gm.graph.find_nodes(op="output")[0]
+        outputs = output_node.args[0]
+        output_names = [t.name for t in outputs]
+
+        _onnx_schemas.register_onnx_schemas()
+
+        ad_logger.info("Exporting vision GraphModule to ONNX: %s", output_path)
+        torch.onnx.export(
+            gm,
+            (),
+            output_path,
+            opset_version=20,
+            kwargs=kwargs,
+            dynamo=True,
+            dynamic_shapes=dynamic_shapes,
+            report=False,
+            output_names=output_names,
+        )
+        ad_logger.info("Exported vision ONNX to %s", output_path)
+
+        return gm, TransformInfo(
+            skipped=False,
+            num_matches=1,
+            is_clean=True,
+            has_valid_shapes=True,
+        )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/extract_embedding_to_safetensors.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/extract_embedding_to_safetensors.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this license except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Extract token embedding weights from the full model and save to safetensors.
+
+This is the single place that writes embedding.safetensors for EdgeLLM export.
+run_per_gm=false so we see the full model. Two paths:
+
+1. Top-level API: when mod still has get_input_embeddings() (e.g. VLM after export_to_gm:
+   mod is the top-level wrapper, only text/vision submodules were replaced by GraphModules).
+   Use mod.get_input_embeddings().weight.
+
+2. GraphModule fallback: when mod is already a single GraphModule (pure LLM after export_to_gm:
+   submodule_name was "", so the whole model was replaced by the exported GM; see
+   export_to_gm.py). The GM has no get_input_embeddings(). Find aten.embedding.default
+   in the graph and get the weight tensor via get_weight_tensor(embedding_node).
+
+This transform must run before rewrite_embedding_to_inputs_embeds so that for pure LLM
+the graph still contains the embedding node.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import safetensors.torch
+import torch
+import torch.nn as nn
+from pydantic import Field
+from torch.fx import GraphModule
+
+from ...shim.interface import CachedSequenceInterface
+from ...utils.logger import ad_logger
+from ...utils.node_utils import get_weight_tensor
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+
+class ExtractEmbeddingToSafetensorsConfig(TransformConfig):
+    """Configuration for the extract embedding to safetensors transform."""
+
+    output_dir: Path = Field(
+        description="The directory to save the extracted embedding weights.",
+        default=Path("."),
+    )
+
+
+def _get_embedding_weight_from_module(mod: nn.Module) -> Optional[torch.Tensor]:
+    """Get embedding weight via top-level get_input_embeddings() if available."""
+    if not hasattr(mod, "get_input_embeddings"):
+        return None
+    embed = mod.get_input_embeddings()
+    if embed is None:
+        return None
+    weight = getattr(embed, "weight", None)
+    if weight is None or not isinstance(weight, torch.Tensor):
+        return None
+    return weight
+
+
+def _get_embedding_weight_from_graph(gm: GraphModule) -> Optional[torch.Tensor]:
+    """Get embedding weight from the first aten.embedding.default node in the graph."""
+    for node in gm.graph.nodes:
+        if node.op == "call_function" and node.target == torch.ops.aten.embedding.default:
+            try:
+                return get_weight_tensor(node)
+            except Exception as e:
+                ad_logger.debug("get_weight_tensor(embedding_node) failed: %s", e)
+                return None
+    return None
+
+
+@TransformRegistry.register("extract_embedding_to_safetensors")
+class ExtractEmbeddingToSafetensors(BaseTransform):
+    """Extract token embedding weights and write to embedding.safetensors.
+
+    Tries (1) top-level get_input_embeddings().weight, then (2) embedding node in
+    the graph when mod is a GraphModule (pure LLM after export_to_gm). See module docstring.
+    """
+
+    config: ExtractEmbeddingToSafetensorsConfig
+
+    @classmethod
+    def get_config_class(cls):
+        """Return the configuration class for this transform."""
+        return ExtractEmbeddingToSafetensorsConfig
+
+    def _apply_to_full_model(
+        self,
+        mod: nn.Module,
+        _cm: CachedSequenceInterface,
+        _factory: object,
+        _shared_config: SharedConfig,
+    ) -> tuple[nn.Module, TransformInfo]:
+        weight = _get_embedding_weight_from_module(mod)
+        if weight is None and isinstance(mod, GraphModule):
+            weight = _get_embedding_weight_from_graph(mod)
+        if weight is None:
+            ad_logger.info(
+                "Could not get embedding weight (no get_input_embeddings() and no "
+                "embedding node in graph), skipping"
+            )
+            return mod, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+        output_path = self.config.output_dir / "embedding.safetensors"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        safetensors.torch.save_file({"weight": weight.detach().cpu()}, output_path)
+        ad_logger.info(f"Saved embedding to {output_path} (shape {weight.shape})")
+        return mod, TransformInfo(
+            skipped=False, num_matches=1, is_clean=True, has_valid_shapes=True
+        )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_attention.py
@@ -345,11 +345,10 @@ class FuseRopeAttention(BaseTransform):
         For each matched pattern, this method:
             1. Creates a past_key_values input placeholder for KV-cache
             2. Reshape Q, K, V to (batch_size, seq_len, -1)
-            3. Concatenates reshaped Q, K, V tensors into a single QKV tensor
-            4. Inserts the fused AttentionPlugin operation
-            5. Creates getitem nodes to extract attention output and present KV-cache
-            6. Replaces the original attention node with the fused output
-            7. Adds present_key_values to graph outputs
+            3. Cast Q, K, V to float16 and insert the fused AttentionPlugin (q, k, v separate)
+            4. Creates getitem nodes to extract attention output and present KV-cache
+            5. Replaces the original attention node with the fused output
+            6. Adds present_key_values to graph outputs
 
         Args:
             gm: The GraphModule being transformed.
@@ -410,28 +409,22 @@ class FuseRopeAttention(BaseTransform):
                 f"Reshaped Q, K, V to (batch_size, seq_len, -1): {q_node.name}, {k_node.name}, {v_node.name}"
             )
 
-            # 3. Concatenate reshaped Q, K, V to (batch_size, seq_len, -1)
-            with graph.inserting_before(match.attn_node):
-                qkv_node = graph.call_function(
-                    torch.ops.aten.cat.default, args=([q_node, k_node, v_node], -1)
-                )
-
-            ad_logger.debug(f"Created qkv concat node: {qkv_node.name}")
-
-            # 4. Create AttentionPlugin node
+            # 3. Cast Q, K, V to float16 and create AttentionPlugin node (q, k, v as separate inputs)
             enable_tree_attention = 0
             head_dim = match.head_dim
             num_kv_heads = match.num_kv_heads
             num_q_heads = match.num_q_heads
 
             with graph.inserting_before(match.attn_node):
-                cast_node = graph.call_function(
-                    torch.ops.aten.to.dtype, args=(qkv_node, torch.float16)
-                )
+                cast_q = graph.call_function(torch.ops.aten.to.dtype, args=(q_node, torch.float16))
+                cast_k = graph.call_function(torch.ops.aten.to.dtype, args=(k_node, torch.float16))
+                cast_v = graph.call_function(torch.ops.aten.to.dtype, args=(v_node, torch.float16))
                 rope_attn_node = graph.call_function(
                     torch.ops.auto_deploy.torch_onnx_attention_plugin.default,
                     args=(
-                        cast_node,
+                        cast_q,
+                        cast_k,
+                        cast_v,
                         past_key_values_node,
                         context_lengths_node,
                         rope_rotary_cos_sin_node,
@@ -441,6 +434,7 @@ class FuseRopeAttention(BaseTransform):
                         num_kv_heads,
                         num_q_heads,
                     ),
+                    kwargs={"enable_fp8_kv_cache": 0, "sliding_window_size": -1},
                 )
 
             ad_logger.debug(f"Created AttentionPlugin node: {rope_attn_node.name}")

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_attention.py
@@ -27,6 +27,15 @@ from ...utils.node_utils import extract_op_args, is_op
 from ..interface import BaseTransform, SharedConfig, TransformInfo, TransformRegistry
 
 
+def _resolve_text_config(
+    config: "transformers.PretrainedConfig",
+) -> "transformers.PretrainedConfig":
+    """Use text_config for VLM so transforms that expect causal-LM config get the right attributes."""
+    if hasattr(config, "text_config") and config.text_config is not None:
+        return config.text_config
+    return config
+
+
 class MatchResult:
     """Container for matched RoPE + attention pattern nodes.
 
@@ -135,35 +144,68 @@ class FuseRopeAttention(BaseTransform):
             used in operations like view or reshape.
         """
         graph = gm.graph
-        input_ids_node = graph.find_nodes(op="placeholder", target="input_ids")[0]
-        position_ids_node = graph.find_nodes(op="placeholder", target="position_ids")[0]
-        input_ids_meta = input_ids_node.meta.get("val")
-        batch_size_dim = input_ids_meta.size(0)
-        max_seq_len_dim = input_ids_meta.size(1)
+        input_ids_nodes = graph.find_nodes(op="placeholder", target="input_ids")
+        position_ids_nodes = graph.find_nodes(op="placeholder", target="position_ids")
+        inputs_embeds_nodes = graph.find_nodes(op="placeholder", target="inputs_embeds")
+        if not position_ids_nodes:
+            raise ValueError("Graph has no position_ids placeholder")
+        if not input_ids_nodes and not inputs_embeds_nodes:
+            raise ValueError(
+                "Graph has neither input_ids nor inputs_embeds placeholder; "
+                "need at least one to infer batch and seq length."
+            )
+        position_ids_node = position_ids_nodes[0]
+        # Use whichever of input_ids or inputs_embeds has meta['val'] (VLM text GM may only use inputs_embeds)
+        shape_node = None
+        meta_val = None
+        if input_ids_nodes and input_ids_nodes[0].meta.get("val") is not None:
+            shape_node = input_ids_nodes[0]
+            meta_val = shape_node.meta["val"]
+        if (
+            meta_val is None
+            and inputs_embeds_nodes
+            and inputs_embeds_nodes[0].meta.get("val") is not None
+        ):
+            shape_node = inputs_embeds_nodes[0]
+            meta_val = shape_node.meta["val"]
+        if meta_val is None:
+            raise ValueError(
+                "Neither input_ids nor inputs_embeds placeholder has meta['val']; "
+                "shape propagation may be required."
+            )
+        batch_size_dim = meta_val.size(0)
+        max_seq_len_dim = meta_val.size(1)
 
-        # We scan all the sym_size.int nodes to find the symbolic nodes for
-        # batch size and max sequence length. The symbolic nodes has two sources.
-        # 1. The input_ids placeholder.
-        # 2. The position_ids placeholder.
-        # Both of their shapes are (batch_size, max_seq_len).
+        # Sym_size nodes may come from the placeholder we used for shape or from position_ids
+        acceptable_sym_sources = {position_ids_node, shape_node}
+        if input_ids_nodes:
+            acceptable_sym_sources.add(input_ids_nodes[0])
+        if inputs_embeds_nodes:
+            acceptable_sym_sources.add(inputs_embeds_nodes[0])
+        batch_size_sym_node = None
+        max_seq_len_sym_node = None
         sym_ints = graph.find_nodes(op="call_function", target=torch.ops.aten.sym_size.int)
         for sym_int in sym_ints:
-            if sym_int.args[0] != input_ids_node and sym_int.args[0] != position_ids_node:
+            if sym_int.args[0] not in acceptable_sym_sources:
                 continue
             if sym_int.args[1] == 0:
                 batch_size_sym_node = sym_int
             elif sym_int.args[1] == 1:
                 max_seq_len_sym_node = sym_int
-        assert batch_size_sym_node is not None and max_seq_len_sym_node is not None
+        if batch_size_sym_node is None or max_seq_len_sym_node is None:
+            raise ValueError(
+                "Could not find sym_size.int nodes for batch size and seq length from "
+                "input_ids, position_ids, or inputs_embeds; shape propagation may be required."
+            )
 
         return batch_size_dim, max_seq_len_dim, batch_size_sym_node, max_seq_len_sym_node
 
     def _get_config_head_dim(self, model_config: transformers.PretrainedConfig) -> int:
         """Get head dimension from model config."""
-        if hasattr(model_config, "head_dim"):
-            return model_config.head_dim
-        else:
-            return model_config.hidden_size // model_config.num_attention_heads
+        config = _resolve_text_config(model_config)
+        if hasattr(config, "head_dim"):
+            return config.head_dim
+        return config.hidden_size // config.num_attention_heads
 
     def _match_rope_attention_pattern(
         self, gm: GraphModule, model_config: transformers.PretrainedConfig
@@ -187,6 +229,7 @@ class FuseRopeAttention(BaseTransform):
         """
         matches = []
         graph = gm.graph
+        config = _resolve_text_config(model_config)
         head_dim = self._get_config_head_dim(model_config)
 
         # Iterate through all nodes to find attention ops
@@ -248,8 +291,8 @@ class FuseRopeAttention(BaseTransform):
             cos_node = rope_node.args[2]
             sin_node = rope_node.args[3]
 
-            num_q_heads = model_config.num_attention_heads
-            num_kv_heads = model_config.num_key_value_heads
+            num_q_heads = config.num_attention_heads
+            num_kv_heads = config.num_key_value_heads
 
             # Successfully matched the pattern!
             match = MatchResult(

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/rewrite_embedding_to_inputs_embeds.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/rewrite_embedding_to_inputs_embeds.py
@@ -15,7 +15,6 @@
 from pathlib import Path
 from typing import Optional, Tuple
 
-import safetensors.torch
 import torch
 from pydantic import Field
 from torch.fx import GraphModule, Node
@@ -52,13 +51,11 @@ class RewriteEmbeddingToInputsEmbeds(BaseTransform):
 
     This transform performs the following operations:
     1. Detects the pattern: input_ids (placeholder) → embedding(weight, input_ids)
-    2. Extracts the embedding weight tensor
-    3. Exports the embedding weight to safetensors format
-    4. Removes the embedding node from the graph
-    5. Replaces the input_ids placeholder with inputs_embeds placeholder
+    2. Removes the embedding node from the graph
+    3. Replaces the input_ids placeholder with inputs_embeds placeholder
 
-    This is necessary for EdgeLLM to support multimodal models where the embedding
-    lookup is performed at runtime before passing to the TensorRT engine.
+    Embedding weight export to embedding.safetensors is done by
+    extract_embedding_to_safetensors (top-level get_input_embeddings()).
     """
 
     config: RewriteEmbeddingToInputsEmbedsConfig
@@ -119,38 +116,6 @@ class RewriteEmbeddingToInputsEmbeds(BaseTransform):
             f"weight shape: {weight_tensor.shape}"
         )
         return (input_ids_node, embedding_node, weight_tensor)
-
-    def _export_embedding_weights(self, weight: torch.Tensor, output_path: Path):
-        """Export embedding weight to safetensors format.
-
-        The weight tensor should already be float16 after adapt_to_edgellm transform.
-
-        Args:
-            weight: The embedding weight tensor (should be float16)
-            output_path: Path to save the safetensors file
-        """
-        # Ensure the output directory exists
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Ensure the weight is on CPU and contiguous
-        weight_cpu = weight.detach().cpu().contiguous()
-
-        # Verify that the weight is already float16
-        if weight_cpu.dtype != torch.float16:
-            raise ValueError(
-                f"Embedding weight must be float16 (should be converted by adapt_to_edgellm), "
-                f"got {weight_cpu.dtype}"
-            )
-
-        # Create state dict
-        state_dict = {"weight": weight_cpu}
-
-        # Save to safetensors
-        safetensors.torch.save_file(state_dict, output_path)
-        ad_logger.info(
-            f"Exported embedding weights to {output_path} with dtype {weight_cpu.dtype} "
-            f"and shape {weight_cpu.shape}"
-        )
 
     def _replace_with_inputs_embeds(
         self,
@@ -265,13 +230,9 @@ class RewriteEmbeddingToInputsEmbeds(BaseTransform):
                 skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
             )
 
-        input_ids_node, embedding_node, weight_tensor = pattern_result
+        input_ids_node, embedding_node, _weight_tensor = pattern_result
 
-        # Step 2: Export embedding weights to safetensors
-        output_path = self.config.output_dir / "embedding.safetensors"
-        self._export_embedding_weights(weight_tensor, output_path)
-
-        # Step 3: Replace input_ids with inputs_embeds and remove embedding node
+        # Step 2: Replace input_ids with inputs_embeds and remove embedding node
         self._replace_with_inputs_embeds(gm, input_ids_node, embedding_node)
 
         ad_logger.info("Successfully rewrote graph to use inputs_embeds")

--- a/tests/integration/defs/examples/test_ad_export_onnx.py
+++ b/tests/integration/defs/examples/test_ad_export_onnx.py
@@ -36,10 +36,11 @@ def test_ad_export_onnx(model: str, output_dir: str, num_attn_ops: int):
         max_batch_size=13,
         max_seq_len=4,
     )
-    # Set output directory for both transforms to ensure embedding.safetensors
-    # and model.onnx are in the same location
+    # Set output directory so embedding.safetensors and model.onnx are in the same location
     ad_config.transforms["rewrite_embedding_to_inputs_embeds"]["output_dir"] = output_dir
     ad_config.transforms["export_to_onnx"]["output_dir"] = output_dir
+    if "extract_embedding_to_safetensors" in ad_config.transforms:
+        ad_config.transforms["extract_embedding_to_safetensors"]["output_dir"] = output_dir
     export_onnx(ad_config)
 
     # check if the output directory exists

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_rewrite_embedding_to_inputs_embeds.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_rewrite_embedding_to_inputs_embeds.py
@@ -50,6 +50,10 @@ class EmbeddingModel(torch.nn.Module):
         self.embed_tokens = torch.nn.Embedding(vocab_size, hidden_size)
         self.proj = torch.nn.Linear(hidden_size, hidden_size, bias=False)
 
+    def get_input_embeddings(self) -> torch.nn.Module:
+        """HF-style API used by extract_embedding_to_safetensors."""
+        return self.embed_tokens
+
     def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
         """Forward pass through embedding and projection.
 
@@ -161,28 +165,38 @@ def _run_test(
             f"embedding node should be removed, but found {len(embedding_nodes_after)}"
         )
 
-        # 5. Verify safetensors file is created with correct content
-        safetensors_path = output_dir / "embedding.safetensors"
-        assert safetensors_path.exists(), f"safetensors file should exist at {safetensors_path}"
-
-        # Load and verify the safetensors content
-        loaded_weights = safetensors.torch.load_file(str(safetensors_path))
-        assert "weight" in loaded_weights, "safetensors should contain 'weight' key"
-
-        weight_tensor = loaded_weights["weight"]
-        assert weight_tensor.dtype == torch.float16, (
-            f"weight dtype should be float16, got {weight_tensor.dtype}"
-        )
-        assert weight_tensor.shape == (vocab_size, hidden_size), (
-            f"weight shape should be ({vocab_size}, {hidden_size}), got {weight_tensor.shape}"
-        )
-
-        # 6. Verify the graph signature is updated (recompile was called)
+        # 5. Verify the graph signature is updated (recompile was called)
 
         sig = inspect.signature(gm_transformed.forward)
         param_names = list(sig.parameters.keys())
         assert "input_ids" not in param_names, "input_ids should not be in signature"
         assert "inputs_embeds" in param_names, "inputs_embeds should be in signature"
+
+
+@torch.inference_mode()
+def test_extract_embedding_to_safetensors():
+    """Test that extract_embedding_to_safetensors writes embedding.safetensors via top-level get_input_embeddings()."""
+    vocab_size = 1000
+    hidden_size = 64
+    model = EmbeddingModel(vocab_size=vocab_size, hidden_size=hidden_size).to("cuda", torch.float16)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_dir = Path(tmp_dir)
+        optimizer = InferenceOptimizer(
+            None,
+            {
+                "extract_embedding_to_safetensors": {
+                    "stage": "export_onnx",
+                    "run_per_gm": False,
+                    "output_dir": str(output_dir),
+                },
+            },
+        )
+        optimizer(None, model)
+        safetensors_path = output_dir / "embedding.safetensors"
+        assert safetensors_path.exists(), "embedding.safetensors should be written"
+        loaded = safetensors.torch.load_file(str(safetensors_path))
+        assert "weight" in loaded
+        assert loaded["weight"].shape == (vocab_size, hidden_size)
 
 
 @pytest.mark.parametrize(
@@ -250,13 +264,7 @@ def test_rewrite_embedding_skips_when_no_input_ids():
         )
         gm_transformed = optimizer(None, gm)
 
-        # Should be skipped - no safetensors file created
-        safetensors_path = output_dir / "embedding.safetensors"
-        assert not safetensors_path.exists(), (
-            "safetensors should not be created when transform is skipped"
-        )
-
-        # Graph should remain unchanged
+        # Graph should remain unchanged (rewrite skipped; no extract_embedding in this test)
         placeholder_nodes = gm_transformed.graph.find_nodes(op="placeholder")
         placeholder_names = {node.target for node in placeholder_nodes}
         assert "input_ids" not in placeholder_names


### PR DESCRIPTION
## Description

This PR extends the **AutoDeploy `export_edgellm_onnx` pipeline** from “single LLM GraphModule + ONNX” toward **EdgeLLM-aligned dual outputs for VLMs** (language + vision), while fixing **rope fusion** when the text path uses **VLM configs** and **inputs_embeds**-style graphs.

The second commit is explicitly **WIP** for full VLM ONNX export (vision branch / E2E still failing in some environments); reviewers should treat **design and layering** as the main deliverable, not only line-by-line correctness.

---

## Design (for design review)

### 1. Baseline: how LLM-only export worked

- **`ModelFactory.get_export_infos(model)`** returns a list of **`SubModuleExportInfo`** entries that tell **`export_to_gm`** which submodules to `torch.export` and replace with **`GraphModule`s**.
- For **Causal LM**, the typical case is **`FullModelExportInfo`** with **`submodule_name=""`**: the **entire root `nn.Module` is replaced** by one `GraphModule` (`mod = sub_gm` in `export_to_gm`).
- Downstream transforms then see **`mod` as that single GM**, not the original HF `PreTrainedModel`.

This replacement is **intentional** but creates a **contract problem**: any transform that assumes “`mod` is still the HF model with `get_input_embeddings()`” breaks after `export_to_gm` for pure LLM.

### 2. Extension: VLM = multiple export units + different `mod` shape

**Goal (EdgeLLM / adel alignment):** produce **two artifact roots** — **lang** (`model.onnx`, `embedding.safetensors`, tokenizer, etc.) and **visual** (`vision_model.onnx`), wired from CLI as `--output_dir` / `--visual_output_dir`.

**Factory layer (`tensorrt_llm/_torch/auto_deploy/models/`):**

| Area | Change |
|------|--------|
| **`ModelFactory` (`factory.py`)** | New hook **`get_vision_pipeline_info(model) -> Optional[SubModuleExportInfo]`** (default `None`). Lets non-VLM factories stay unchanged. |
| **`AutoModelForImageTextToTextFactory` (`hf.py`)** | **`get_vision_pipeline_info`**: heuristics for vision submodule path (`model.visual`, `vision_model`, `vision_tower`). |
| | **`VisionModelExportInfo`**: `SubModuleExportInfo` subclass with **dynamic dims** for Qwen3-VL-style visual inputs (`hidden_states`, `grid_thw` — first arg is pixel values in practice). |
| | **`get_export_infos` override**: returns **`[TextModelExportInfo.from_autoinferred(model), vision_info]`** when a vision info is resolved (was previously text-only). |

**Export stage (`export_to_gm.py`):**

- If **`len(export_infos) > 1`** and the factory exposes **`get_example_inputs_with_images()`**, **`CachedSequenceInterface`** is seeded with **image-bearing example inputs** so a **full-model forward** actually exercises the **vision submodule** and capture can produce a **vision GM**.
- After export, for VLM **`mod` remains the top-level wrapper** with **`set_submodule` on text + vision**; only submodules become GMs. This **differs from pure LLM** where **`mod` becomes the GM**.

**Rope fusion (`fuse_rope_attention.py`, first commit):**

- VLM configs often expose **`text_config`** instead of top-level **`hidden_size` / head counts** — **`_resolve_text_config`** and related helpers read from the resolved config.
- Text graphs may lack **`input_ids.meta["val"]`** but have **`inputs_embeds`** — batch / seq symbolic nodes can be derived from **`inputs_embeds`** / **`position_ids`** as well as **`input_ids`**.

### 3. Embedding file ownership and ordering (EdgeLLM contract)

**Problem:** VLM **text GM** often has **no `aten.embedding`** in the captured graph (embedding happened outside the text submodule). Pure LLM after `export_to_gm` is a **GM without `get_input_embeddings()`**.

**Approach:**

- **`extract_embedding_to_safetensors`** (new): **only** place that writes **`embedding.safetensors`**, with **two strategies**:
  1. **Top-level `get_input_embeddings().weight`** when `mod` is still the HF wrapper (typical **VLM after partial submodule replacement**).
  2. **Graph fallback:** scan for **`aten.embedding.default`** and use **`get_weight_tensor`** when **`mod` is the sole root GM** (typical **pure LLM**).
- **`rewrite_embedding_to_inputs_embeds`**: **graph rewrite only**; **no longer writes** safetensors (avoids duplication and wrong assumptions about `mod` type).

**Ordering constraint:** **`extract_embedding_to_safetensors` must run before `rewrite_embedding_to_inputs_embeds`** in YAML, because rewrite **removes** the embedding node from the graph.

### 4. Vision ONNX (`export_vision_to_onnx.py`)

- **`run_per_gm: true`**: iterates **`named_graphmodules`**; **only** exports a GM that **looks like** the Qwen3-VL visual signature via **placeholder names** (`hidden_states` + `grid_thw`, no `past_key_values`).
- Output: **`visual_output_dir / vision_model.onnx`**.

This is **deliberately heuristic** — alternative designs (factory tags per-GM, passing submodule name into per-GM transforms) would be cleaner but need **pipeline / `BaseTransform` API** changes.

### 5. CLI (`examples/auto_deploy/onnx_export_llm.py`)

- **`--model_factory`**, **`--vlm`** (forces **`AutoModelForImageTextToText`**).
- Wires **`output_dir` / `visual_output_dir`** into transform configs (`export_to_onnx`, `rewrite_embedding_*`, `extract_embedding_*`, `export_vision_to_onnx`).

---

## Design risks / questions for owners (please review)

1. **`mod` type split after `export_to_gm`:** Should we **formalize** “root GM vs wrapper + submodule GMs” in **`SharedConfig`** or a small **context object** so transforms don’t rely on `isinstance(mod, GraphModule)` heuristics?
2. **Vision GM detection:** Placeholder-name matching will **not generalize** to all VLMs. Prefer **explicit mapping** from `get_export_infos` names to “this GM is vision” without parsing the graph?
3. **`VisionModelExportInfo` / dynamic shapes:** Currently **Qwen3-VL-oriented**. Other families (Llama 4, Mistral3) need **different submodule composition** (projector split/merge) — is **factory-only** encapsulation sufficient, or do we need **per-model patches** like existing text export?
4. **VLM build on `meta` + image forward:** Full VLM export still hits **meta-tensor / `.item()`** issues in vision code paths in some setups; **device / example-input policy** for `build_model` vs capture may need a **separate design** (out of scope for “just add transforms”). **`run_forward_for_capture()`** failed because of it `lift_to_meta()` and there are `torch.linespace()` which requires real vector instead of meta tensor.
---

## Test Coverage

- `tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_rewrite_embedding_to_inputs_embeds.py`
  - `test_rewrite_embedding_to_inputs_embeds[...]`
  - `test_rewrite_embedding_skips_when_no_input_ids`
  - `test_extract_embedding_to_safetensors`
- `tests/integration/defs/examples/test_ad_export_onnx.py` (sets `extract_embedding_to_safetensors` output dir when present)
- **Manual:** `python examples/auto_deploy/onnx_export_llm.py --model <HF or local> --output_dir ...`  
  - Verified **pure LLM** path produces **`embedding.safetensors`** under `output_dir` (e.g. Qwen2.5-0.5B-Instruct).
  - **VLM** path may still fail earlier in **`export_to_gm`** depending on model/device/meta constraints — not claimed as fixed in the WIP commit.

---

## PR Checklist

- PR description clearly explains what and why
- Follows [TRT-LLM CODING_GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md)
- Test cases provided for new code paths
- New dependencies scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- Reviewers assigned appropriately
- [ ] Please check this after reviewing the above items as appropriate for this PR.

---

## Commit reference

1. `d279fcec1` — `[None][feat] VLM, enhance fuse_rope_attention` (`fuse_rope_attention.py`, `onnx_export_llm.py` factory flags)
2. `f6fa93dad` — `[None][feat][wip] VLM, add visual branch, not working still` (dual export, embedding split, vision ONNX, YAML, tests)
