### PR TITLE
[#12324][fix] Fixed wrong token suppressed with ignore_eos in torch sampler

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -1033,6 +1033,9 @@ def executor_request_to_llm_request(
                               LogprobMode.RAW),
     )
 
+    llm_request.py_original_end_id = getattr(executor_request,
+                                             "py_original_end_id",
+                                             llm_request.py_end_id)
     llm_request.py_disaggregated_params = getattr(executor_request,
                                                   "py_disaggregated_params",
                                                   None)

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -3932,19 +3932,25 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             current_offset = 0
             for index, r in enumerate(requests):
                 if r.py_min_length:
-                    for beam_idx in range(num_beams[index]):
-                        for step in range(num_steps[index]):
-                            if (
-                                r.get_num_tokens(beam_idx) - r.py_orig_prompt_len
-                            ) + step < r.py_min_length[0]:
-                                # NOTE(jthomson04): We can NOT just assign logits[...] = float("-inf").
-                                # This introduces a pageable HtoD transfer, which wreaks havoc on TPOT (up to ~20%)
-                                # Instead, we create a little tensor on device, then assign to that.
-                                # This way, we avoid the pageable transfer.
-                                neg_inf_tensor = torch.full((), float("-inf"), device=logits.device)
-                                logits[
-                                    current_offset + num_steps[index] * beam_idx + step, r.py_end_id
-                                ] = neg_inf_tensor
+                    # Use the original end_id (before ignore_eos override)
+                    # so we suppress the real EOS token, not token -1.
+                    end_id = getattr(r, "py_original_end_id", r.py_end_id)
+                    if end_id is not None and end_id > -1:
+                        for beam_idx in range(num_beams[index]):
+                            for step in range(num_steps[index]):
+                                if (
+                                    r.get_num_tokens(beam_idx) - r.py_orig_prompt_len
+                                ) + step < r.py_min_length[0]:
+                                    # NOTE(jthomson04): We can NOT just assign logits[...] = float("-inf").
+                                    # This introduces a pageable HtoD transfer, which wreaks havoc on TPOT (up to ~20%)
+                                    # Instead, we create a little tensor on device, then assign to that.
+                                    # This way, we avoid the pageable transfer.
+                                    neg_inf_tensor = torch.full(
+                                        (), float("-inf"), device=logits.device
+                                    )
+                                    logits[
+                                        current_offset + num_steps[index] * beam_idx + step, end_id
+                                    ] = neg_inf_tensor
                             else:
                                 # early exit
                                 break

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -565,6 +565,7 @@ class BaseWorker(GenerationExecutor):
                 cache_salt_id=request.cache_salt_id,
                 disagg_request_id=disagg_request_id,
                 priority=request.priority)
+            executor_request.py_original_end_id = request.sampling_params.end_id
             executor_request.py_num_logprobs = request.sampling_params.logprobs
             executor_request.py_lora_path = py_lora_path
             executor_request.py_logprobs_mode = request.sampling_params.logprobs_mode

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import pathlib
 import random
 import time
 from contextlib import contextmanager, nullcontext
@@ -43,6 +44,20 @@ from tensorrt_llm.executor.request import LoRARequest
 import tempfile
 
 import torch
+from transformers.configuration_utils import PretrainedConfig
+
+from tensorrt_llm._torch.model_config import ModelConfig as _ModelConfig
+from tensorrt_llm._torch.models.checkpoints import \
+    HfCheckpointLoader as _HfCheckpointLoader
+from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
+    BaseConfigLoader as _BaseConfigLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
+    BaseWeightLoader as _BaseWeightLoader
+from tensorrt_llm._torch.models.modeling_utils import (
+    register_auto_model as _register_auto_model,
+    register_checkpoint_weight_loader as _register_checkpoint_weight_loader,
+    register_config_loader as _register_config_loader)
+
 from peft import LoraConfig as PeftLoraConfig
 from peft import get_peft_model
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -1120,6 +1135,131 @@ def test_min_tokens_long_prompt():
     assert generated_len >= min_tok, (
         f"Generated only {generated_len} tokens with min_tokens={min_tok} "
         f"and a long prompt.  Bug 5823135 regression.")
+
+
+_LAST_VOCAB_TOKEN_ID = 255
+_LAST_VOCAB_EOS_TOKEN_ID = 2
+
+
+class _LastVocabConfig(PretrainedConfig):
+
+    def __init__(self):
+        self.architectures = ["_LastVocabModel"]
+        self.torch_dtype = torch.float16
+        self.num_key_value_heads = 4
+        self.num_attention_heads = 4
+        self.hidden_size = 64
+        self.vocab_size = 256
+        self.num_hidden_layers = 1
+        self.eos_token_id = _LAST_VOCAB_EOS_TOKEN_ID
+
+    @property
+    def head_dim(self):
+        return self.hidden_size // self.num_attention_heads
+
+
+@_register_auto_model("_LastVocabModel")
+class _LastVocabModel(torch.nn.Module):
+    """Dummy model whose logits always favour the last vocab token (id 255).
+
+    The original bug made logits[..., -1] suppress this token via Python
+    negative indexing when ignore_eos + min_tokens were both set.
+    """
+
+    def __init__(self, model_config: _ModelConfig):
+        super().__init__()
+        self.model_config = model_config
+
+    def infer_max_seq_len(self):
+        return 2048
+
+    @property
+    def config(self):
+        return self.model_config.pretrained_config
+
+    def forward(self, *, input_ids, attn_metadata, **kwargs):
+        num_batch_tokens = input_ids.size(0)
+        last_tokens = torch.cumsum(
+            attn_metadata.seq_lens_cuda, dim=0, dtype=torch.long) - 1
+
+        logits = torch.zeros((num_batch_tokens, self.config.vocab_size),
+                             device="cuda",
+                             dtype=self.config.torch_dtype)
+        logits[:, _LAST_VOCAB_TOKEN_ID] = 100.0
+
+        if not kwargs.get("return_context_logits", False):
+            logits = logits[last_tokens]
+        return {"logits": logits}
+
+    def load_weights(self, weights, weight_mapper=None, skip_modules=None):
+        pass
+
+
+@_register_checkpoint_weight_loader("_LAST_VOCAB_FMT")
+class _LastVocabWeightLoader(_BaseWeightLoader):
+
+    def load_weights(self, checkpoint_dir, **kwargs):
+        return {}
+
+
+@_register_config_loader("_LAST_VOCAB_FMT")
+class _LastVocabConfigLoader(_BaseConfigLoader):
+
+    def load(self, checkpoint_dir, **kwargs):
+        return _ModelConfig(pretrained_config=_LastVocabConfig())
+
+
+@pytest.mark.part0
+def test_min_tokens_with_ignore_eos():
+    """Check ignore_eos + min_tokens does not suppress the last vocab token.
+
+    The original bug: ignore_eos sets end_id to -1. The min_length penalty
+    used that value, so logits[..., -1] suppressed the last vocab token
+    (id 255) instead of the actual EOS token.
+
+    Uses a dummy model that always outputs the last vocab token (id 255).
+    Verifies that token still appears in the output when ignore_eos + min_tokens
+    are both set.
+    """
+    max_tok = 20
+
+    llm = LLM(
+        model=pathlib.Path("dummy_last_vocab_path"),
+        backend="pytorch",
+        max_batch_size=2,
+        max_seq_len=128,
+        max_num_tokens=32,
+        kv_cache_config=KvCacheConfig(enable_block_reuse=False),
+        disable_overlap_scheduler=True,
+        checkpoint_loader=_HfCheckpointLoader(
+            weight_loader=_LastVocabWeightLoader(),
+            config_loader=_LastVocabConfigLoader()),
+    )
+
+    sampling_params = SamplingParams(
+        max_tokens=max_tok,
+        min_tokens=10,
+        ignore_eos=True,
+        temperature=0.0,
+        end_id=_LAST_VOCAB_EOS_TOKEN_ID,
+    )
+
+    with llm:
+        res = llm.generate([[1, 2, 3]], sampling_params=sampling_params)
+
+    assert len(res) == 1
+    token_ids = res[0].outputs[0].token_ids
+
+    # With ignore_eos, generation must run for exactly max_tokens.
+    assert len(token_ids) == max_tok, (
+        f"Generated {len(token_ids)} tokens, expected {max_tok}.")
+
+    # The dummy model always outputs the last vocab token (id 255).
+    # The original bug suppressed logits[..., -1] which is this token.
+    # After the fix, the last vocab token must NOT be suppressed.
+    assert all(t == _LAST_VOCAB_TOKEN_ID for t in token_ids), (
+        f"Expected all tokens to be {_LAST_VOCAB_TOKEN_ID}, got {token_ids}. "
+        f"logits[..., -1] may be incorrectly suppressing the last vocab token.")
 
 
 @skip_ray


### PR DESCRIPTION
The model was hitting EOS before 1024 tokens. min_tokens was supposed to prevent that but didn't work due to two bugs:

  1. Fixed  in [PR already](https://github.com/NVIDIA/TensorRT-LLM/pull/12166): Prompt length counted toward min_tokens: The check compared min_tokens against total tokens (prompt + generated). With ISL=1024 and min_tokens=1024, the condition was already satisfied before the first
   generated token — so EOS was never suppressed.
  2. Wrong token suppressed with ignore_eos: ignore_eos sets end_id to -1. The penalty used that value, so logits[..., -1] suppressed the last vocab token (a random Chinese character) instead of the actual
  EOS token (id 11).

  The model generated EOS early for some requests, producing fewer than 1024 output tokens. aiperf 0.6.0 added detection for this and reported the mismatch warnings. The bug was always there — aiperf just started catching it.

Why did The model generated EOS early for some requests?

Because the model decided it was done answering. The prompts are synthetic Shakespeare text — at some point the model produces a natural completion and emits the EOS token. That's normal model behavior. min_tokens exists precisely to override that for benchmarking, but it wasn't working.


TLDR:
  What is the Sampler?

  When an LLM generates text, it produces logits — a score for every token in the vocabulary — at each step.
   The sampler picks the next token from those scores. Before picking, it can apply penalties that
  manipulate logits to enforce constraints like "generate at least N tokens."

  What is min_tokens (min_length)?

  A user-facing parameter: "I want at least N generated tokens (not counting the prompt)." The sampler
  enforces this by setting the EOS (end-of-sequence) token's logit to -infinity so the model can never pick
  "stop" until it has generated enough tokens.

  The Request Flow (and where the bugs lived)

  When a user sends a request, it passes through three layers before the sampler sees it:

  1. BaseWorker (base_worker.py) — creates an ExecutorRequest, sets end_id. If ignore_eos=True, it
  overwrites end_id to -1 (meaning "no EOS").
  2. LlmRequest (llm_request.py) — converts the executor request into the internal request object. Copies
  end_id → py_end_id.
  3. TorchSampler (sampler.py) — at each generation step, calls _apply_min_length_penalty() to suppress EOS
  if the request hasn't generated enough tokens yet.

  The Two Bugs

  Bug 1 — Prompt length included in comparison:

  The code compared min_tokens against total sequence length (prompt + generated), not just generated
  tokens. With a prompt of 1024 tokens and min_tokens=1024, the check 1024 < 1024 was immediately False, so
  the penalty was never applied and the model could stop after generating just 1 token.

  Bug 2 — Wrong token suppressed with ignore_eos:

  When ignore_eos=True, end_id gets overwritten to -1. The penalty code did logits[..., py_end_id] which
  became logits[..., -1] — Python negative indexing! This suppressed the last vocabulary token (some random
  token) instead of the actual EOS token.

In more details:
_apply_min_length_penalty() in sampler.py had two bugs that made min_tokens ineffective:

  1. Prompt length included in comparison: The guard condition compared min_tokens against total sequence length (prompt + generated tokens) instead of just generated tokens. When ISL >= min_tokens, the
  penalty was never applied — e.g., with ISL=1024 and min_tokens=1024, the check 1024 < 1024 was always False.
  2. Wrong token suppressed with ignore_eos: When ignore_eos=true, end_id is overwritten to -1. The penalty used this overridden value, so logits[..., -1] suppressed the last token in the vocabulary (Python negative indexing) instead of the actual EOS token.

  Fix: Three files changed:

  - sampler.py: Subtract py_orig_prompt_len from token counts so the comparison is against generated tokens only. Use py_original_end_id (the real EOS token) instead of py_end_id (which may be -1).
  - base_worker.py: Stash the original end_id on the executor request before the ignore_eos override.
  - llm_request.py: Propagate py_original_end_id to the LlmRequest so the sampler can access it.

  Testing: Verified with trtllm-serve + aiperf benchmarks on Nemotron-3-Nano-30B (AutoDeploy backend, ISL=1024, OSL=1024, concurrency 16/32/64). Before: 5-10% of requests terminated early with OSL mismatch
  warnings. After: zero mismatches across all concurrency levels.

Key Takeaway

  The fix ensures that min_tokens actually means "generate at least N tokens" regardless of prompt length,
  and that the correct EOS token is suppressed even when ignore_eos is enabled. Without the fix, 5–10% of
  requests terminated early; after the fix, zero early terminations.




sequence diagram:

<img width="5479" height="8192" alt="Untitled diagram-2026-03-22-163510" src="https://github.com/user-attachments/assets/0b7aaa62-5e4e-4634-bd82-7cbcd52f1280" />

<!-- This is an 

auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected minimum length penalty calculation to properly account for prompt length during token generation.
  * Fixed end-token handling in sampling logic to preserve and use the original token configuration when applying penalties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
