### PR TITLE
[https://nvbugs/5998489][feat] Adding support for request priority in LLM API

### DIFF
--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -758,6 +758,7 @@ void initRequestBindings(nb::module_& m)
         .def_prop_rw("cache_salt_id", &tle::Request::getCacheSaltID, &tle::Request::setCacheSaltID)
         .def_prop_rw("context_phase_params", &tle::Request::getContextPhaseParams, &tle::Request::setContextPhaseParams)
         .def_prop_rw("disagg_request_id", &tle::Request::getDisaggRequestId, &tle::Request::setDisaggRequestId)
+        .def_prop_rw("priority", &tle::Request::getPriority, &tle::Request::setPriority)
         .def("__getstate__", requestGetstate)
         .def("__setstate__", requestSetstate);
     request.attr("BATCHED_POST_PROCESSOR_NAME") = tle::Request::kBatchedPostProcessorName;

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -1019,7 +1019,7 @@ def executor_request_to_llm_request(
         return_encoder_output=False,
         client_id=executor_request.client_id
         if executor_request.client_id is not None else req_id,
-        priority=0.5,
+        priority=executor_request.priority,
         llm_request_type=llm_request_type,
         context_phase_params=executor_request.context_phase_params,
         cache_salt_id=executor_request.cache_salt_id,

--- a/tensorrt_llm/_torch/pyexecutor/request_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/request_utils.py
@@ -152,7 +152,7 @@ def get_from_waiting_queue(
 
     # Put the pending requests back to the waiting queue
     # All ranks should have the same waiting queue
-    waiting_queue.prepend_requests(reversed(pending_requests))
+    waiting_queue.prepend_requests(pending_requests)
 
     return items
 

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/__init__.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/__init__.py
@@ -17,7 +17,7 @@ Scheduler module for TensorRT-LLM PyExecutor.
 
 This module contains:
 - Request schedulers (capacity, micro-batch, unified)
-- Waiting queues (FCFS)
+- Waiting queues (FCFS, Priority)
 """
 
 # Re-export from scheduler.py
@@ -40,7 +40,12 @@ from .scheduler import (
 )
 
 # Re-export from waiting_queue.py
-from .waiting_queue import FCFSWaitingQueue, WaitingQueue, create_waiting_queue
+from .waiting_queue import (
+    FCFSWaitingQueue,
+    PriorityWaitingQueue,
+    WaitingQueue,
+    create_waiting_queue,
+)
 
 __all__ = [
     # Schedulers
@@ -64,6 +69,7 @@ __all__ = [
     "RankState",
     # Waiting queues
     "FCFSWaitingQueue",
+    "PriorityWaitingQueue",
     "WaitingQueue",
     "create_waiting_queue",
 ]

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -1,4 +1,4 @@
-import bisect
+import heapq
 import warnings
 from abc import ABC, abstractmethod
 from collections import deque
@@ -135,71 +135,81 @@ class FCFSWaitingQueue(deque, WaitingQueue):
 class PriorityWaitingQueue(WaitingQueue):
     """A priority queue that serves higher-priority requests first.
 
-    Requests with equal priority are served in FCFS order.
-    Priority is read from ``item.request.priority``; the default priority is 0.5.
+    Requests with equal priority are served in FCFS order (arrival order).
+    Priority is read from ``item.request.priority``; the default is 0.5.
+
+    Heap entries are ``(neg_priority, insertion_counter, item)`` tuples.
+    Because ``insertion_counter`` is strictly monotonically increasing, no two
+    entries share the same first two elements, so ``item`` is never compared
+    and does not need to implement ``__lt__``.
+
+    Complexity:
+        - add_request / add_requests: O(log n)
+        - pop_request / peek_request: O(log n) / O(1)
+        - remove_by_ids: O(n) rebuild + O(n) heapify
+        - __iter__: O(n log n) over a sorted copy (priority order)
     """
 
-    _DEFAULT_PRIORITY: float = DEFAULT_REQUEST_PRIORITY
-
     def __init__(self) -> None:
-        self._queue: list[RequestQueueItem] = []
-        # Parallel list of sort keys: (neg_priority, insertion_counter).
-        # bisect operates on this list so insertions stay O(log n).
-        self._keys: list[tuple] = []
+        # Min-heap of (neg_priority, insertion_counter, RequestQueueItem).
+        self._heap: list[tuple] = []
         self._insertion_counter: int = 0
 
     def _get_priority(self, item: RequestQueueItem) -> float:
         if item.request is not None:
             return item.request.priority
-        return self._DEFAULT_PRIORITY
+        return DEFAULT_REQUEST_PRIORITY
 
-    def _insert(self, item: RequestQueueItem) -> None:
-        key = (-self._get_priority(item), self._insertion_counter)
+    def _push(self, item: RequestQueueItem) -> None:
+        entry = (-self._get_priority(item), self._insertion_counter, item)
         self._insertion_counter += 1
-        idx = bisect.bisect_right(self._keys, key)
-        self._keys.insert(idx, key)
-        self._queue.insert(idx, item)
+        heapq.heappush(self._heap, entry)
 
     def add_request(self, request: RequestQueueItem) -> None:
-        self._insert(request)
+        """Add a request to the queue in priority order."""
+        self._push(request)
 
     def add_requests(self, requests: Iterable[RequestQueueItem]) -> None:
+        """Add multiple requests to the queue in priority order."""
         for request in requests:
-            self._insert(request)
+            self._push(request)
 
     def pop_request(self) -> RequestQueueItem:
-        self._keys.pop(0)
-        return self._queue.pop(0)
+        """Pop the highest-priority request (FCFS tiebreak)."""
+        if not self._heap:
+            raise IndexError("pop from an empty queue")
+        _, _, item = heapq.heappop(self._heap)
+        return item
 
     def peek_request(self) -> RequestQueueItem:
-        if not self._queue:
+        """Return the highest-priority request without removing it."""
+        if not self._heap:
             raise IndexError("peek from an empty queue")
-        return self._queue[0]
+        return self._heap[0][2]
 
     def prepend_request(self, request: RequestQueueItem) -> None:
         """Re-insert the request at the position dictated by its priority."""
-        self._insert(request)
+        self._push(request)
 
     def prepend_requests(self, requests: Iterable[RequestQueueItem]) -> None:
         """Re-insert requests at the positions dictated by their priorities."""
         for request in requests:
-            self._insert(request)
+            self._push(request)
 
     def remove_by_ids(self, request_ids: set[int]) -> None:
-        pairs = [(k, r) for k, r in zip(self._keys, self._queue) if r.id not in request_ids]
-        if pairs:
-            self._keys, self._queue = map(list, zip(*pairs))
-        else:
-            self._keys, self._queue = [], []
+        """Remove requests with the given IDs."""
+        self._heap = [e for e in self._heap if e[2].id not in request_ids]
+        heapq.heapify(self._heap)
 
     def __bool__(self) -> bool:
-        return len(self._queue) > 0
+        return len(self._heap) > 0
 
     def __len__(self) -> int:
-        return len(self._queue)
+        return len(self._heap)
 
     def __iter__(self) -> Iterator[RequestQueueItem]:
-        return iter(self._queue)
+        """Iterate over requests in descending priority order."""
+        return (e[2] for e in sorted(self._heap))
 
 
 def create_waiting_queue(

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -1,3 +1,4 @@
+import bisect
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Iterable, Iterator
@@ -114,6 +115,77 @@ class FCFSWaitingQueue(deque, WaitingQueue):
         return super().__iter__()
 
 
+class PriorityWaitingQueue(WaitingQueue):
+    """A priority queue that serves higher-priority requests first.
+
+    Requests with equal priority are served in FCFS order.
+    Priority is read from ``item.request.priority``; requests whose priority
+    is ``None`` are treated as having the default priority of 0.5.
+    """
+
+    _DEFAULT_PRIORITY: float = 0.5
+
+    def __init__(self) -> None:
+        self._queue: list[RequestQueueItem] = []
+        # Parallel list of sort keys: (neg_priority, insertion_counter).
+        # bisect operates on this list so insertions stay O(log n).
+        self._keys: list[tuple] = []
+        self._insertion_counter: int = 0
+
+    def _get_priority(self, item: RequestQueueItem) -> float:
+        if item.request is not None and item.request.priority is not None:
+            return float(item.request.priority)
+        return self._DEFAULT_PRIORITY
+
+    def _insert(self, item: RequestQueueItem) -> None:
+        key = (-self._get_priority(item), self._insertion_counter)
+        self._insertion_counter += 1
+        idx = bisect.bisect_right(self._keys, key)
+        self._keys.insert(idx, key)
+        self._queue.insert(idx, item)
+
+    def add_request(self, request: RequestQueueItem) -> None:
+        self._insert(request)
+
+    def add_requests(self, requests: Iterable[RequestQueueItem]) -> None:
+        for request in requests:
+            self._insert(request)
+
+    def pop_request(self) -> RequestQueueItem:
+        self._keys.pop(0)
+        return self._queue.pop(0)
+
+    def peek_request(self) -> RequestQueueItem:
+        if not self._queue:
+            raise IndexError("peek from an empty queue")
+        return self._queue[0]
+
+    def prepend_request(self, request: RequestQueueItem) -> None:
+        """Re-insert the request at the position dictated by its priority."""
+        self._insert(request)
+
+    def prepend_requests(self, requests: Iterable[RequestQueueItem]) -> None:
+        """Re-insert requests at the positions dictated by their priorities."""
+        for request in requests:
+            self._insert(request)
+
+    def remove_by_ids(self, request_ids: set[int]) -> None:
+        pairs = [(k, r) for k, r in zip(self._keys, self._queue) if r.id not in request_ids]
+        if pairs:
+            self._keys, self._queue = map(list, zip(*pairs))
+        else:
+            self._keys, self._queue = [], []
+
+    def __bool__(self) -> bool:
+        return len(self._queue) > 0
+
+    def __len__(self) -> int:
+        return len(self._queue)
+
+    def __iter__(self) -> Iterator[RequestQueueItem]:
+        return iter(self._queue)
+
+
 def create_waiting_queue(
     policy: WaitingQueuePolicy = WaitingQueuePolicy.FCFS,
     priority_fn: Optional[Callable[[RequestQueueItem], float]] = None,
@@ -121,14 +193,15 @@ def create_waiting_queue(
     """Create a waiting queue based on the specified policy.
 
     Args:
-        policy: The scheduling policy to use. Currently only FCFS is supported.
+        policy: The scheduling policy to use.
         priority_fn: Reserved for future use.
 
     Returns:
         A WaitingQueue instance.
     """
-    # Currently only FCFS is implemented
     if policy == WaitingQueuePolicy.FCFS:
         return FCFSWaitingQueue()
+    elif policy == WaitingQueuePolicy.PRIORITY:
+        return PriorityWaitingQueue()
     else:
         raise ValueError(f"Unsupported waiting queue policy: {policy}")

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -1,4 +1,5 @@
 import heapq
+import itertools
 import warnings
 from abc import ABC, abstractmethod
 from collections import deque
@@ -153,7 +154,9 @@ class PriorityWaitingQueue(WaitingQueue):
     def __init__(self) -> None:
         # Min-heap of (neg_priority, insertion_counter, RequestQueueItem).
         self._heap: list[tuple] = []
-        self._insertion_counter: int = 0
+        # itertools.count() is thread-safe (backed by a C-level atomic),
+        # ensuring correct FCFS tiebreaking under concurrent access.
+        self._counter = itertools.count()
 
     def _get_priority(self, item: RequestQueueItem) -> float:
         if item.request is not None:
@@ -161,8 +164,7 @@ class PriorityWaitingQueue(WaitingQueue):
         return DEFAULT_REQUEST_PRIORITY
 
     def _push(self, item: RequestQueueItem) -> None:
-        entry = (-self._get_priority(item), self._insertion_counter, item)
-        self._insertion_counter += 1
+        entry = (-self._get_priority(item), next(self._counter), item)
         heapq.heappush(self._heap, entry)
 
     def add_request(self, request: RequestQueueItem) -> None:

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -1,3 +1,18 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import heapq
 import itertools
 from abc import ABC, abstractmethod
@@ -39,7 +54,8 @@ class WaitingQueue(ABC):
         """Re-insert a request that could not be scheduled.
 
         Implementations must ensure the request is served before any request
-        that was added *after* it originally arrived (i.e. it does not lose
+        (of equal priority in the case of a priority queue) that was added
+        *after* it originally arrived (i.e. it does not lose
         its place to later-arriving requests of equal priority).  For FCFS
         queues this means inserting at the front; for priority queues this
         means using a tiebreaker that sorts ahead of normally-added entries.

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -1,4 +1,5 @@
 import bisect
+import warnings
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Iterable, Iterator
@@ -67,12 +68,27 @@ class WaitingQueue(ABC):
 class FCFSWaitingQueue(deque, WaitingQueue):
     """A first-come-first-served queue that supports deque operations."""
 
+    @staticmethod
+    def _warn_if_priority_set(request: RequestQueueItem) -> None:
+        if request.request is not None and request.request.priority != DEFAULT_REQUEST_PRIORITY:
+            warnings.warn(
+                "A request has a non-default priority but the FCFS waiting "
+                "queue is in use; the priority value will be ignored. "
+                "Use WaitingQueuePolicy.PRIORITY to enable priority scheduling.",
+                UserWarning,
+                stacklevel=3,
+            )
+
     def add_request(self, request: RequestQueueItem) -> None:
         """Add a request to the queue according to FCFS policy."""
+        self._warn_if_priority_set(request)
         self.append(request)
 
     def add_requests(self, requests: Iterable[RequestQueueItem]) -> None:
         """Add multiple requests to the queue according to FCFS policy."""
+        requests = list(requests)
+        for request in requests:
+            self._warn_if_priority_set(request)
         self.extend(requests)
 
     def pop_request(self) -> RequestQueueItem:

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -37,12 +37,24 @@ class WaitingQueue(ABC):
 
     @abstractmethod
     def prepend_request(self, request: RequestQueueItem) -> None:
-        """Prepend a request to the front of the queue."""
+        """Re-insert a request that could not be scheduled.
+
+        Implementations must ensure the request is served before any request
+        that was added *after* it originally arrived (i.e. it does not lose
+        its place to later-arriving requests of equal priority).  For FCFS
+        queues this means inserting at the front; for priority queues this
+        means using a tiebreaker that sorts ahead of normally-added entries.
+        """
         pass
 
     @abstractmethod
     def prepend_requests(self, requests: Iterable[RequestQueueItem]) -> None:
-        """Prepend all requests from another iterable to the front of this queue."""
+        """Re-insert multiple requests that could not be scheduled.
+
+        See prepend_request for the ordering contract.  Callers should pass
+        requests in *reverse* original order so that the first request in the
+        original queue comes out first after re-insertion.
+        """
         pass
 
     @abstractmethod
@@ -70,26 +82,28 @@ class FCFSWaitingQueue(deque, WaitingQueue):
     """A first-come-first-served queue that supports deque operations."""
 
     @staticmethod
-    def _warn_if_priority_set(request: RequestQueueItem) -> None:
+    def _warn_if_priority_set(request: RequestQueueItem, stacklevel: int = 3) -> None:
         if request.request is not None and request.request.priority != DEFAULT_REQUEST_PRIORITY:
             warnings.warn(
                 "A request has a non-default priority but the FCFS waiting "
                 "queue is in use; the priority value will be ignored. "
                 "Use WaitingQueuePolicy.PRIORITY to enable priority scheduling.",
                 UserWarning,
-                stacklevel=3,
+                stacklevel=stacklevel,
             )
 
     def add_request(self, request: RequestQueueItem) -> None:
         """Add a request to the queue according to FCFS policy."""
-        self._warn_if_priority_set(request)
+        # stacklevel=3: caller → add_request → _warn_if_priority_set
+        self._warn_if_priority_set(request, stacklevel=3)
         self.append(request)
 
     def add_requests(self, requests: Iterable[RequestQueueItem]) -> None:
         """Add multiple requests to the queue according to FCFS policy."""
         requests = list(requests)
         for request in requests:
-            self._warn_if_priority_set(request)
+            # stacklevel=2: caller → add_requests → _warn_if_priority_set
+            self._warn_if_priority_set(request, stacklevel=2)
         self.extend(requests)
 
     def pop_request(self) -> RequestQueueItem:
@@ -154,9 +168,13 @@ class PriorityWaitingQueue(WaitingQueue):
     def __init__(self) -> None:
         # Min-heap of (neg_priority, insertion_counter, RequestQueueItem).
         self._heap: list[tuple] = []
-        # itertools.count() is thread-safe (backed by a C-level atomic),
-        # ensuring correct FCFS tiebreaking under concurrent access.
+        # _counter assigns strictly increasing non-negative integers to
+        # normally-added requests for FCFS tiebreaking within a priority cohort.
+        # _prepend_counter assigns strictly decreasing negative integers to
+        # prepended requests, guaranteeing they sort before any normally-added
+        # request of the same priority.
         self._counter = itertools.count()
+        self._prepend_counter = itertools.count(-1, -1)
 
     def _get_priority(self, item: RequestQueueItem) -> float:
         if item.request is not None:
@@ -165,6 +183,10 @@ class PriorityWaitingQueue(WaitingQueue):
 
     def _push(self, item: RequestQueueItem) -> None:
         entry = (-self._get_priority(item), next(self._counter), item)
+        heapq.heappush(self._heap, entry)
+
+    def _push_front(self, item: RequestQueueItem) -> None:
+        entry = (-self._get_priority(item), next(self._prepend_counter), item)
         heapq.heappush(self._heap, entry)
 
     def add_request(self, request: RequestQueueItem) -> None:
@@ -190,13 +212,26 @@ class PriorityWaitingQueue(WaitingQueue):
         return self._heap[0][2]
 
     def prepend_request(self, request: RequestQueueItem) -> None:
-        """Re-insert the request at the position dictated by its priority."""
-        self._push(request)
+        """Re-insert a request ahead of all normally-added requests of the same priority.
+
+        Uses a strictly decreasing counter so the request sorts before any
+        request added via add_request / add_requests, preserving FCFS order
+        within a priority cohort when requests are returned to the queue.
+        """
+        self._push_front(request)
 
     def prepend_requests(self, requests: Iterable[RequestQueueItem]) -> None:
-        """Re-insert requests at the positions dictated by their priorities."""
+        """Re-insert requests ahead of all normally-added requests of the same priority.
+
+        Requests are pushed in iteration order; because _prepend_counter
+        decreases on each call, the first item in ``requests`` ends up with
+        the largest (least-negative) prepend counter and therefore the last
+        item ends up at the front within its priority cohort.  Callers that
+        need the original queue order to be restored should pass the requests
+        in *reverse* original order (as request_utils.py does).
+        """
         for request in requests:
-            self._push(request)
+            self._push_front(request)
 
     def remove_by_ids(self, request_ids: set[int]) -> None:
         """Remove requests with the given IDs."""
@@ -210,7 +245,11 @@ class PriorityWaitingQueue(WaitingQueue):
         return len(self._heap)
 
     def __iter__(self) -> Iterator[RequestQueueItem]:
-        """Iterate over requests in descending priority order."""
+        """Iterate over requests in descending priority order.
+
+        Returns a generator over a snapshot of the heap taken at call time.
+        Modifications to the queue after iteration begins are not reflected.
+        """
         return (e[2] for e in sorted(self._heap))
 
 

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -51,9 +51,9 @@ class WaitingQueue(ABC):
     def prepend_requests(self, requests: Iterable[RequestQueueItem]) -> None:
         """Re-insert multiple requests that could not be scheduled.
 
-        See prepend_request for the ordering contract.  Callers should pass
-        requests in *reverse* original order so that the first request in the
-        original queue comes out first after re-insertion.
+        See prepend_request for the ordering contract.  Requests are
+        re-inserted such that the first request in the iterable comes out
+        first after re-insertion (i.e. original queue order is preserved).
         """
         pass
 
@@ -102,8 +102,7 @@ class FCFSWaitingQueue(deque, WaitingQueue):
         """Add multiple requests to the queue according to FCFS policy."""
         requests = list(requests)
         for request in requests:
-            # stacklevel=2: caller → add_requests → _warn_if_priority_set
-            self._warn_if_priority_set(request, stacklevel=2)
+            self._warn_if_priority_set(request, stacklevel=3)
         self.extend(requests)
 
     def pop_request(self) -> RequestQueueItem:
@@ -123,10 +122,10 @@ class FCFSWaitingQueue(deque, WaitingQueue):
     def prepend_requests(self, requests: Iterable[RequestQueueItem]) -> None:
         """Prepend all requests from another iterable to the front of this queue.
 
-        Note: The requests will be prepended in reverse order of their
-        appearance in the `requests` iterable.
+        Requests are inserted in input order: the first item in ``requests``
+        ends up at the front of the queue.
         """
-        self.extendleft(requests)
+        self.extendleft(reversed(list(requests)))
 
     def remove_by_ids(self, request_ids: set[int]) -> None:
         """Remove requests with the given IDs."""
@@ -151,7 +150,7 @@ class PriorityWaitingQueue(WaitingQueue):
     """A priority queue that serves higher-priority requests first.
 
     Requests with equal priority are served in FCFS order (arrival order).
-    Priority is read from ``item.request.priority``; the default is 0.5.
+    Priority is read from ``item.request.priority``; the default is DEFAULT_REQUEST_PRIORITY.
 
     Heap entries are ``(neg_priority, insertion_counter, item)`` tuples.
     Because ``insertion_counter`` is strictly monotonically increasing, no two
@@ -223,14 +222,13 @@ class PriorityWaitingQueue(WaitingQueue):
     def prepend_requests(self, requests: Iterable[RequestQueueItem]) -> None:
         """Re-insert requests ahead of all normally-added requests of the same priority.
 
-        Requests are pushed in iteration order; because _prepend_counter
-        decreases on each call, the first item in ``requests`` ends up with
-        the largest (least-negative) prepend counter and therefore the last
-        item ends up at the front within its priority cohort.  Callers that
-        need the original queue order to be restored should pass the requests
-        in *reverse* original order (as request_utils.py does).
+        Requests are pushed in *reverse* iteration order so that the first
+        item in ``requests`` ends up with the most-negative prepend counter
+        and therefore sorts first within its priority cohort.  This means
+        the first request in the iterable comes out first after re-insertion,
+        preserving original queue order without any reversal by the caller.
         """
-        for request in requests:
+        for request in reversed(list(requests)):
             self._push_front(request)
 
     def remove_by_ids(self, request_ids: set[int]) -> None:
@@ -266,6 +264,13 @@ def create_waiting_queue(
     Returns:
         A WaitingQueue instance.
     """
+    if priority_fn is not None:
+        warnings.warn(
+            "priority_fn is not supported and will be ignored. "
+            "Use WaitingQueuePolicy.PRIORITY to enable priority scheduling.",
+            UserWarning,
+            stacklevel=2,
+        )
     if policy == WaitingQueuePolicy.FCFS:
         return FCFSWaitingQueue()
     elif policy == WaitingQueuePolicy.PRIORITY:

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -4,6 +4,7 @@ from collections import deque
 from collections.abc import Iterable, Iterator
 from typing import Callable, Optional
 
+from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
 from tensorrt_llm.llmapi.llm_args import WaitingQueuePolicy
 
 from ..executor_request_queue import RequestQueueItem
@@ -119,11 +120,10 @@ class PriorityWaitingQueue(WaitingQueue):
     """A priority queue that serves higher-priority requests first.
 
     Requests with equal priority are served in FCFS order.
-    Priority is read from ``item.request.priority``; requests whose priority
-    is ``None`` are treated as having the default priority of 0.5.
+    Priority is read from ``item.request.priority``; the default priority is 0.5.
     """
 
-    _DEFAULT_PRIORITY: float = 0.5
+    _DEFAULT_PRIORITY: float = DEFAULT_REQUEST_PRIORITY
 
     def __init__(self) -> None:
         self._queue: list[RequestQueueItem] = []
@@ -133,8 +133,8 @@ class PriorityWaitingQueue(WaitingQueue):
         self._insertion_counter: int = 0
 
     def _get_priority(self, item: RequestQueueItem) -> float:
-        if item.request is not None and item.request.priority is not None:
-            return float(item.request.priority)
+        if item.request is not None:
+            return item.request.priority
         return self._DEFAULT_PRIORITY
 
     def _insert(self, item: RequestQueueItem) -> None:

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -1,13 +1,12 @@
 import heapq
 import itertools
-import warnings
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Iterable, Iterator
-from typing import Callable, Optional
 
 from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
 from tensorrt_llm.llmapi.llm_args import WaitingQueuePolicy
+from tensorrt_llm.logger import logger
 
 from ..executor_request_queue import RequestQueueItem
 
@@ -82,27 +81,24 @@ class FCFSWaitingQueue(deque, WaitingQueue):
     """A first-come-first-served queue that supports deque operations."""
 
     @staticmethod
-    def _warn_if_priority_set(request: RequestQueueItem, stacklevel: int = 3) -> None:
+    def _warn_if_priority_set(request: RequestQueueItem) -> None:
         if request.request is not None and request.request.priority != DEFAULT_REQUEST_PRIORITY:
-            warnings.warn(
+            logger.warning(
                 "A request has a non-default priority but the FCFS waiting "
                 "queue is in use; the priority value will be ignored. "
-                "Use WaitingQueuePolicy.PRIORITY to enable priority scheduling.",
-                UserWarning,
-                stacklevel=stacklevel,
+                "Use WaitingQueuePolicy.PRIORITY to enable priority scheduling."
             )
 
     def add_request(self, request: RequestQueueItem) -> None:
         """Add a request to the queue according to FCFS policy."""
-        # stacklevel=3: caller → add_request → _warn_if_priority_set
-        self._warn_if_priority_set(request, stacklevel=3)
+        self._warn_if_priority_set(request)
         self.append(request)
 
     def add_requests(self, requests: Iterable[RequestQueueItem]) -> None:
         """Add multiple requests to the queue according to FCFS policy."""
         requests = list(requests)
         for request in requests:
-            self._warn_if_priority_set(request, stacklevel=3)
+            self._warn_if_priority_set(request)
         self.extend(requests)
 
     def pop_request(self) -> RequestQueueItem:
@@ -253,24 +249,15 @@ class PriorityWaitingQueue(WaitingQueue):
 
 def create_waiting_queue(
     policy: WaitingQueuePolicy = WaitingQueuePolicy.FCFS,
-    priority_fn: Optional[Callable[[RequestQueueItem], float]] = None,
 ) -> WaitingQueue:
     """Create a waiting queue based on the specified policy.
 
     Args:
         policy: The scheduling policy to use.
-        priority_fn: Reserved for future use.
 
     Returns:
         A WaitingQueue instance.
     """
-    if priority_fn is not None:
-        warnings.warn(
-            "priority_fn is not supported and will be ignored. "
-            "Use WaitingQueuePolicy.PRIORITY to enable priority scheduling.",
-            UserWarning,
-            stacklevel=2,
-        )
     if policy == WaitingQueuePolicy.FCFS:
         return FCFSWaitingQueue()
     elif policy == WaitingQueuePolicy.PRIORITY:

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -563,7 +563,9 @@ class BaseWorker(GenerationExecutor):
                 context_phase_params=context_phase_params,
                 type=request_type,
                 cache_salt_id=request.cache_salt_id,
-                disagg_request_id=disagg_request_id)
+                disagg_request_id=disagg_request_id,
+                priority=request.priority
+                if request.priority is not None else 0.5)
             executor_request.py_num_logprobs = request.sampling_params.logprobs
             executor_request.py_lora_path = py_lora_path
             executor_request.py_logprobs_mode = request.sampling_params.logprobs_mode

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -564,8 +564,7 @@ class BaseWorker(GenerationExecutor):
                 type=request_type,
                 cache_salt_id=request.cache_salt_id,
                 disagg_request_id=disagg_request_id,
-                priority=request.priority
-                if request.priority is not None else 0.5)
+                priority=request.priority)
             executor_request.py_num_logprobs = request.sampling_params.logprobs
             executor_request.py_lora_path = py_lora_path
             executor_request.py_logprobs_mode = request.sampling_params.logprobs_mode

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -131,6 +131,7 @@ class GenerationExecutor(ABC):
         scheduling_params: Optional[SchedulingParams] = None,
         cache_salt_id: Optional[int] = None,
         arrival_time: Optional[float] = None,
+        priority: Optional[float] = None,
     ) -> GenerationResult:
         """Generate output for the given prompt token ids in the asynchronous mode.
         Asynchronous generation accepts single prompt only.
@@ -157,7 +158,8 @@ class GenerationExecutor(ABC):
             multimodal_params=multimodal_params,
             scheduling_params=scheduling_params,
             cache_salt_id=cache_salt_id,
-            arrival_time=arrival_time)
+            arrival_time=arrival_time,
+            priority=priority)
         result = self.submit(request)
         # release memory in time
         if hasattr(request, "multimodal_params"):

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -35,7 +35,8 @@ from ..sampling_params import (BatchedLogitsProcessor, LogprobParams,
 from ..scheduling_params import SchedulingParams
 from .ipc import FusedIpcQueue
 from .postproc_worker import PostprocParams, PostprocWorkerConfig
-from .request import GenerationRequest, LoRARequest, PromptAdapterRequest
+from .request import (DEFAULT_REQUEST_PRIORITY, GenerationRequest, LoRARequest,
+                      PromptAdapterRequest)
 from .result import GenerationResult, IterationResult
 from .utils import IntraProcessQueue, ProcessPoolExecutorSession, RequestError
 
@@ -131,7 +132,7 @@ class GenerationExecutor(ABC):
         scheduling_params: Optional[SchedulingParams] = None,
         cache_salt_id: Optional[int] = None,
         arrival_time: Optional[float] = None,
-        priority: Optional[float] = None,
+        priority: float = DEFAULT_REQUEST_PRIORITY,
     ) -> GenerationResult:
         """Generate output for the given prompt token ids in the asynchronous mode.
         Asynchronous generation accepts single prompt only.

--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -1,4 +1,3 @@
-import math
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -135,7 +134,7 @@ class GenerationRequest:
         self.scheduling_params = scheduling_params
         self.cache_salt_id = cache_salt_id
         self.arrival_time = arrival_time
-        if math.isnan(priority) or not (0.0 <= priority <= 1.0):
+        if not (0.0 <= priority <= 1.0):
             raise ValueError(
                 f"priority must be a float in [0.0, 1.0], got {priority}")
         self.priority = priority

--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -1,3 +1,4 @@
+import math
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -134,6 +135,9 @@ class GenerationRequest:
         self.scheduling_params = scheduling_params
         self.cache_salt_id = cache_salt_id
         self.arrival_time = arrival_time
+        if math.isnan(priority) or not (0.0 <= priority <= 1.0):
+            raise ValueError(
+                f"priority must be a float in [0.0, 1.0], got {priority}")
         self.priority = priority
 
     def set_id(self, id):

--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -15,10 +15,14 @@ from ..scheduling_params import SchedulingParams
 from .postproc_worker import PostprocParams
 
 __all__ = [
+    "DEFAULT_REQUEST_PRIORITY",
     "LoRARequest",
     "PromptAdapterRequest",
     "GenerationRequest",
 ]
+
+# Mirrors C++ executor.h Request::kDefaultPriority
+DEFAULT_REQUEST_PRIORITY: float = 0.5
 
 
 @dataclass(slots=True)
@@ -101,7 +105,7 @@ class GenerationRequest:
         scheduling_params: Optional[SchedulingParams] = None,
         cache_salt_id: Optional[int] = None,
         arrival_time: Optional[float] = None,
-        priority: Optional[float] = None,
+        priority: float = DEFAULT_REQUEST_PRIORITY,
     ):
         if isinstance(prompt_token_ids, list):
             self.prompt_token_ids = prompt_token_ids

--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -101,6 +101,7 @@ class GenerationRequest:
         scheduling_params: Optional[SchedulingParams] = None,
         cache_salt_id: Optional[int] = None,
         arrival_time: Optional[float] = None,
+        priority: Optional[float] = None,
     ):
         if isinstance(prompt_token_ids, list):
             self.prompt_token_ids = prompt_token_ids
@@ -129,6 +130,7 @@ class GenerationRequest:
         self.scheduling_params = scheduling_params
         self.cache_salt_id = cache_salt_id
         self.arrival_time = arrival_time
+        self.priority = priority
 
     def set_id(self, id):
         assert self.id is None, f"Request ID is already set: {self.id}"

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -326,7 +326,7 @@ class BaseLLM:
             scheduling_params (tensorrt_llm.scheduling_params.SchedulingParams, List[tensorrt_llm.scheduling_params.SchedulingParams], optional):
                 Scheduling parameters. Defaults to None.
             cache_salt (str, Sequence[str], optional): If specified, KV cache will be salted with the provided string to limit the kv cache reuse to the requests with the same string. Defaults to None.
-            priority (float, List[float], optional): The scheduling priority for the request(s), in the range [0, 1]. Higher values indicate higher priority. Defaults to 0.5.
+            priority (float, List[float]): The scheduling priority for the request(s), in the range [0, 1]. Higher values indicate higher priority. Defaults to 0.5.
         Returns:
             Union[tensorrt_llm.llmapi.RequestOutput, List[tensorrt_llm.llmapi.RequestOutput]]: The output data of the completion request to the LLM.
         """
@@ -339,6 +339,11 @@ class BaseLLM:
             inputs = [inputs]
 
         inputs = [prompt_inputs(i) for i in inputs]
+
+        if isinstance(priority, list) and len(priority) != len(inputs):
+            raise ValueError(
+                f"priority list length ({len(priority)}) does not match "
+                f"number of prompts ({len(inputs)})")
 
         def _item_at(maybe_batched: Union[Any, Sequence[Any]], pos: int) -> Any:
             if isinstance(maybe_batched, list):
@@ -405,7 +410,7 @@ class BaseLLM:
             trace_headers (Mapping[str, str], optional): Trace headers. Defaults to None.
             scheduling_params (tensorrt_llm.scheduling_params.SchedulingParams, optional): Scheduling parameters. Defaults to None.
             cache_salt (str, optional): If specified, KV cache will be salted with the provided string to limit the kv cache reuse to the requests with the same string. Defaults to None.
-            priority (float, optional): The scheduling priority for the request, in the range [0, 1]. Higher values indicate higher priority. Defaults to 0.5.
+            priority (float): The scheduling priority for the request, in the range [0, 1]. Higher values indicate higher priority. Defaults to 0.5.
         Returns:
             tensorrt_llm.llmapi.RequestOutput: The output data of the completion request to the LLM.
         """

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -340,10 +340,18 @@ class BaseLLM:
 
         inputs = [prompt_inputs(i) for i in inputs]
 
-        if isinstance(priority, list) and len(priority) != len(inputs):
-            raise ValueError(
-                f"priority list length ({len(priority)}) does not match "
-                f"number of prompts ({len(inputs)})")
+        if isinstance(priority, list):
+            if len(priority) != len(inputs):
+                raise ValueError(
+                    f"priority list length ({len(priority)}) does not match "
+                    f"number of prompts ({len(inputs)})")
+            for p in priority:
+                if not 0.0 <= p <= 1.0:
+                    raise ValueError(
+                        f"each priority must be in [0, 1], got {p}")
+        else:
+            if not 0.0 <= priority <= 1.0:
+                raise ValueError(f"priority must be in [0, 1], got {priority}")
 
         def _item_at(maybe_batched: Union[Any, Sequence[Any]], pos: int) -> Any:
             if isinstance(maybe_batched, list):

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -345,6 +345,14 @@ class BaseLLM:
                 raise ValueError(
                     f"priority list length ({len(priority)}) does not match "
                     f"number of prompts ({len(inputs)})")
+            for p in priority:
+                if not (0.0 <= p <= 1.0):
+                    raise ValueError(
+                        f"priority must be a float in [0.0, 1.0], got {p}")
+        else:
+            if not (0.0 <= priority <= 1.0):
+                raise ValueError(
+                    f"priority must be a float in [0.0, 1.0], got {priority}")
 
         def _item_at(maybe_batched: Union[Any, Sequence[Any]], pos: int) -> Any:
             if isinstance(maybe_batched, list):

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -410,6 +410,9 @@ class BaseLLM:
             tensorrt_llm.llmapi.RequestOutput: The output data of the completion request to the LLM.
         """
 
+        if not 0.0 <= priority <= 1.0:
+            raise ValueError(f"priority must be in [0, 1], got {priority}")
+
         # Check if the worker is shutting down
         if self._executor is None or self._executor.is_shutdown():
             raise RuntimeError("LLM is shutting down")

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -303,6 +303,7 @@ class BaseLLM:
         scheduling_params: Optional[Union[SchedulingParams,
                                           List[SchedulingParams]]] = None,
         cache_salt: Optional[Union[str, Sequence[str]]] = None,
+        priority: Optional[Union[float, List[float]]] = None,
     ) -> Union[RequestOutput, List[RequestOutput]]:
         """Generate output for the given prompts in the synchronous mode.
         Synchronous generation accepts either single prompt or batched prompts.
@@ -324,6 +325,7 @@ class BaseLLM:
             scheduling_params (tensorrt_llm.scheduling_params.SchedulingParams, List[tensorrt_llm.scheduling_params.SchedulingParams], optional):
                 Scheduling parameters. Defaults to None.
             cache_salt (str, Sequence[str], optional): If specified, KV cache will be salted with the provided string to limit the kv cache reuse to the requests with the same string. Defaults to None.
+            priority (float, List[float], optional): The scheduling priority for the request(s), in the range [0, 1]. Higher values indicate higher priority. Defaults to None (uses the backend default of 0.5).
         Returns:
             Union[tensorrt_llm.llmapi.RequestOutput, List[tensorrt_llm.llmapi.RequestOutput]]: The output data of the completion request to the LLM.
         """
@@ -355,6 +357,7 @@ class BaseLLM:
                 disaggregated_params=_item_at(disaggregated_params, i),
                 scheduling_params=_item_at(scheduling_params, i),
                 cache_salt=_item_at(cache_salt, i),
+                priority=_item_at(priority, i),
                 streaming=False,
             )
             futures.append(future)
@@ -384,6 +387,7 @@ class BaseLLM:
         _postproc_params: Optional[PostprocParams] = None,
         scheduling_params: Optional[SchedulingParams] = None,
         cache_salt: Optional[str] = None,
+        priority: Optional[float] = None,
     ) -> RequestOutput:
         """Generate output for the given prompt in the asynchronous mode.
         Asynchronous generation accepts single prompt only.
@@ -400,6 +404,7 @@ class BaseLLM:
             trace_headers (Mapping[str, str], optional): Trace headers. Defaults to None.
             scheduling_params (tensorrt_llm.scheduling_params.SchedulingParams, optional): Scheduling parameters. Defaults to None.
             cache_salt (str, optional): If specified, KV cache will be salted with the provided string to limit the kv cache reuse to the requests with the same string. Defaults to None.
+            priority (float, optional): The scheduling priority for the request, in the range [0, 1]. Higher values indicate higher priority. Defaults to None (uses the backend default of 0.5).
         Returns:
             tensorrt_llm.llmapi.RequestOutput: The output data of the completion request to the LLM.
         """
@@ -456,6 +461,7 @@ class BaseLLM:
             scheduling_params=scheduling_params,
             cache_salt_id=cache_salt_id,
             arrival_time=arrival_time,
+            priority=priority,
         )
 
         if sampling_params.return_perf_metrics:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -345,13 +345,6 @@ class BaseLLM:
                 raise ValueError(
                     f"priority list length ({len(priority)}) does not match "
                     f"number of prompts ({len(inputs)})")
-            for p in priority:
-                if not 0.0 <= p <= 1.0:
-                    raise ValueError(
-                        f"each priority must be in [0, 1], got {p}")
-        else:
-            if not 0.0 <= priority <= 1.0:
-                raise ValueError(f"priority must be in [0, 1], got {priority}")
 
         def _item_at(maybe_batched: Union[Any, Sequence[Any]], pos: int) -> Any:
             if isinstance(maybe_batched, list):
@@ -422,9 +415,6 @@ class BaseLLM:
         Returns:
             tensorrt_llm.llmapi.RequestOutput: The output data of the completion request to the LLM.
         """
-
-        if not 0.0 <= priority <= 1.0:
-            raise ValueError(f"priority must be in [0, 1], got {priority}")
 
         # Check if the worker is shutting down
         if self._executor is None or self._executor.is_shutdown():

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -32,6 +32,7 @@ from ..executor import (DetokenizedGenerationResultBase, GenerationExecutor,
                         GenerationResult, IterationResult, LoRARequest,
                         PostprocWorkerConfig, PromptAdapterRequest)
 from ..executor.postproc_worker import PostprocParams
+from ..executor.request import DEFAULT_REQUEST_PRIORITY
 from ..executor.utils import (RequestError, create_mpi_comm_session,
                               get_spawn_proxy_process_env)
 from ..inputs import (PromptInputs, create_input_processor,
@@ -303,7 +304,7 @@ class BaseLLM:
         scheduling_params: Optional[Union[SchedulingParams,
                                           List[SchedulingParams]]] = None,
         cache_salt: Optional[Union[str, Sequence[str]]] = None,
-        priority: Optional[Union[float, List[float]]] = None,
+        priority: Union[float, List[float]] = DEFAULT_REQUEST_PRIORITY,
     ) -> Union[RequestOutput, List[RequestOutput]]:
         """Generate output for the given prompts in the synchronous mode.
         Synchronous generation accepts either single prompt or batched prompts.
@@ -325,7 +326,7 @@ class BaseLLM:
             scheduling_params (tensorrt_llm.scheduling_params.SchedulingParams, List[tensorrt_llm.scheduling_params.SchedulingParams], optional):
                 Scheduling parameters. Defaults to None.
             cache_salt (str, Sequence[str], optional): If specified, KV cache will be salted with the provided string to limit the kv cache reuse to the requests with the same string. Defaults to None.
-            priority (float, List[float], optional): The scheduling priority for the request(s), in the range [0, 1]. Higher values indicate higher priority. Defaults to None (uses the backend default of 0.5).
+            priority (float, List[float], optional): The scheduling priority for the request(s), in the range [0, 1]. Higher values indicate higher priority. Defaults to 0.5.
         Returns:
             Union[tensorrt_llm.llmapi.RequestOutput, List[tensorrt_llm.llmapi.RequestOutput]]: The output data of the completion request to the LLM.
         """
@@ -387,7 +388,7 @@ class BaseLLM:
         _postproc_params: Optional[PostprocParams] = None,
         scheduling_params: Optional[SchedulingParams] = None,
         cache_salt: Optional[str] = None,
-        priority: Optional[float] = None,
+        priority: float = DEFAULT_REQUEST_PRIORITY,
     ) -> RequestOutput:
         """Generate output for the given prompt in the asynchronous mode.
         Asynchronous generation accepts single prompt only.
@@ -404,7 +405,7 @@ class BaseLLM:
             trace_headers (Mapping[str, str], optional): Trace headers. Defaults to None.
             scheduling_params (tensorrt_llm.scheduling_params.SchedulingParams, optional): Scheduling parameters. Defaults to None.
             cache_salt (str, optional): If specified, KV cache will be salted with the provided string to limit the kv cache reuse to the requests with the same string. Defaults to None.
-            priority (float, optional): The scheduling priority for the request, in the range [0, 1]. Higher values indicate higher priority. Defaults to None (uses the backend default of 0.5).
+            priority (float, optional): The scheduling priority for the request, in the range [0, 1]. Higher values indicate higher priority. Defaults to 0.5.
         Returns:
             tensorrt_llm.llmapi.RequestOutput: The output data of the completion request to the LLM.
         """

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1857,6 +1857,7 @@ class WaitingQueuePolicy(StrEnum):
     """Waiting queue scheduling policy for managing pending requests."""
 
     FCFS = "fcfs"  # First-Come-First-Served
+    PRIORITY = "priority"  # Higher request.priority value is served first; ties broken by FCFS
 
 
 @PybindMirror.mirror_pybind_fields(_DynamicBatchConfig)

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -92,6 +92,7 @@ l0_a10:
   - unittest/llmapi/test_llm_args.py
   - unittest/llmapi/test_kv_cache_dtype_override.py
   - unittest/llmapi/test_additional_model_outputs.py -m "gpu1"
+  - unittest/llmapi/test_request_priority.py
   # executor
   - unittest/executor/test_rpc.py
   - unittest/executor/test_ipc.py

--- a/tests/unittest/_torch/executor/test_waiting_queue.py
+++ b/tests/unittest/_torch/executor/test_waiting_queue.py
@@ -113,12 +113,12 @@ class TestFCFSWaitingQueue:
         queue = FCFSWaitingQueue()
         queue.add_request(create_mock_request_item(3))
 
-        # Prepend items [1, 2] - note: extendleft reverses order
+        # Prepend items [1, 2] — first item in the list ends up at the front
         queue.prepend_requests([create_mock_request_item(i) for i in [1, 2]])
 
-        # After extendleft([1, 2]), order is: 2, 1, 3
-        assert queue.pop_request().id == 2
+        # Expected order: 1, 2, 3
         assert queue.pop_request().id == 1
+        assert queue.pop_request().id == 2
         assert queue.pop_request().id == 3
 
     def test_remove_by_ids(self):
@@ -361,8 +361,8 @@ class TestPriorityWaitingQueue:
 
     def test_prepend_requests_restores_original_queue_order(self):
         """Simulates the request_utils.py pattern: pop several requests that
-        cannot be scheduled, then prepend them back in reversed order.  The
-        resulting pop sequence must match the original queue order."""
+        cannot be scheduled, then prepend them back.  The resulting pop
+        sequence must match the original queue order."""
         q = PriorityWaitingQueue()
         # Original queue: A(0.9) > B(0.5) > C(0.5) — B and C tied on priority,
         # so B comes before C by FCFS.
@@ -377,11 +377,47 @@ class TestPriorityWaitingQueue:
         pending = [q.pop_request(), q.pop_request(), q.pop_request()]
         assert [r.id for r in pending] == [1, 2, 3]
 
-        # Put them back using the reversed-order convention from request_utils.py.
-        q.prepend_requests(reversed(pending))
+        # Put them back — prepend_requests preserves input order internally.
+        q.prepend_requests(pending)
 
         # Order must be fully restored.
         assert [q.pop_request().id for _ in range(3)] == [1, 2, 3]
+
+    def test_prepend_requests_restores_order_with_existing_queue_entries(self):
+        """Simulates the request_utils.py pattern when new requests have
+        arrived while the scheduler was trying to place the popped ones.
+
+        Returned requests must come out ahead of any same-priority request
+        that arrived after they were originally enqueued, and the relative
+        order among the returned requests must be preserved.
+        """
+        q = PriorityWaitingQueue()
+        # Original queue: A(0.9) > B(0.5) > C(0.5)
+        req_a = create_priority_request_item(1, priority=0.9)
+        req_b = create_priority_request_item(2, priority=0.5)
+        req_c = create_priority_request_item(3, priority=0.5)
+        q.add_request(req_a)
+        q.add_request(req_b)
+        q.add_request(req_c)
+
+        # Scheduler dequeues all three but cannot schedule them.
+        pending = [q.pop_request(), q.pop_request(), q.pop_request()]
+        assert [r.id for r in pending] == [1, 2, 3]
+
+        # While the scheduler was working, new requests arrive at various
+        # priorities: one higher (0.9), one equal (0.5), one lower (0.1).
+        q.add_request(create_priority_request_item(4, priority=0.9))
+        q.add_request(create_priority_request_item(5, priority=0.5))
+        q.add_request(create_priority_request_item(6, priority=0.1))
+
+        # Put the pending requests back.
+        q.prepend_requests(pending)
+
+        # Expected order:
+        #   priority 0.9: A(1) before D(4) — A arrived first
+        #   priority 0.5: B(2) before C(3) before E(5) — B and C arrived first, in FCFS order
+        #   priority 0.1: F(6)
+        assert [q.pop_request().id for _ in range(6)] == [1, 4, 2, 3, 5, 6]
 
     def test_prepend_requests_does_not_starve_across_multiple_rounds(self):
         """A request returned to the queue multiple times still comes out

--- a/tests/unittest/_torch/executor/test_waiting_queue.py
+++ b/tests/unittest/_torch/executor/test_waiting_queue.py
@@ -335,6 +335,72 @@ class TestPriorityWaitingQueue:
         )
         assert [q.pop_request().id for _ in range(3)] == [2, 1, 3]
 
+    def test_prepend_request_beats_later_arrivals_of_same_priority(self):
+        """A prepended request comes out before same-priority requests added after it."""
+        q = PriorityWaitingQueue()
+        # Add two requests, then pop the first one to simulate the DP-constraint path.
+        req_a = create_priority_request_item(1, priority=0.5)
+        req_b = create_priority_request_item(2, priority=0.5)
+        q.add_request(req_a)
+        q.add_request(req_b)
+        popped = q.pop_request()  # removes req_a (earliest arrival)
+        assert popped.id == 1
+
+        # A new request arrives while req_a was being processed.
+        req_c = create_priority_request_item(3, priority=0.5)
+        q.add_request(req_c)
+
+        # req_a is returned to the queue (couldn't be scheduled).
+        q.prepend_request(popped)
+
+        # req_a should still come out before req_c despite req_c being in the
+        # queue before the prepend call.
+        assert q.pop_request().id == 1  # req_a
+        assert q.pop_request().id == 2  # req_b
+        assert q.pop_request().id == 3  # req_c
+
+    def test_prepend_requests_restores_original_queue_order(self):
+        """Simulates the request_utils.py pattern: pop several requests that
+        cannot be scheduled, then prepend them back in reversed order.  The
+        resulting pop sequence must match the original queue order."""
+        q = PriorityWaitingQueue()
+        # Original queue: A(0.9) > B(0.5) > C(0.5) — B and C tied on priority,
+        # so B comes before C by FCFS.
+        req_a = create_priority_request_item(1, priority=0.9)
+        req_b = create_priority_request_item(2, priority=0.5)
+        req_c = create_priority_request_item(3, priority=0.5)
+        q.add_request(req_a)
+        q.add_request(req_b)
+        q.add_request(req_c)
+
+        # Simulate the scheduler dequeuing all three but failing to schedule them.
+        pending = [q.pop_request(), q.pop_request(), q.pop_request()]
+        assert [r.id for r in pending] == [1, 2, 3]
+
+        # Put them back using the reversed-order convention from request_utils.py.
+        q.prepend_requests(reversed(pending))
+
+        # Order must be fully restored.
+        assert [q.pop_request().id for _ in range(3)] == [1, 2, 3]
+
+    def test_prepend_requests_does_not_starve_across_multiple_rounds(self):
+        """A request returned to the queue multiple times still comes out
+        ahead of newly-arrived requests of the same priority."""
+        q = PriorityWaitingQueue()
+        req_a = create_priority_request_item(1, priority=0.5)
+        q.add_request(req_a)
+
+        # Simulate req_a being returned to the queue twice (two scheduling rounds
+        # where it couldn't run due to resource constraints).
+        for _ in range(2):
+            popped = q.pop_request()
+            # New request arrives while req_a couldn't be scheduled.
+            q.add_request(create_priority_request_item(99, priority=0.5))
+            q.prepend_request(popped)
+
+        # req_a must still be served before the newly-arrived requests.
+        assert q.pop_request().id == 1
+
     # ------------------------------------------------------------------
     # remove_by_ids
     # ------------------------------------------------------------------

--- a/tests/unittest/_torch/executor/test_waiting_queue.py
+++ b/tests/unittest/_torch/executor/test_waiting_queue.py
@@ -2,6 +2,7 @@
 
 This module tests the waiting queue functionality including:
 - FCFSWaitingQueue operations
+- PriorityWaitingQueue operations
 - WaitingQueue abstract interface
 - create_waiting_queue factory function
 """
@@ -16,12 +17,23 @@ from tensorrt_llm._torch.pyexecutor.scheduler import (
     WaitingQueue,
     create_waiting_queue,
 )
+from tensorrt_llm._torch.pyexecutor.scheduler.waiting_queue import PriorityWaitingQueue
+from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
 from tensorrt_llm.llmapi.llm_args import WaitingQueuePolicy
 
 
 def create_mock_request_item(request_id: int) -> RequestQueueItem:
     """Create a mock RequestQueueItem for testing."""
     mock_request = Mock()
+    return RequestQueueItem(request_id, mock_request)
+
+
+def create_priority_request_item(
+    request_id: int, priority: float = DEFAULT_REQUEST_PRIORITY
+) -> RequestQueueItem:
+    """Create a mock RequestQueueItem with an explicit float priority."""
+    mock_request = Mock()
+    mock_request.priority = priority
     return RequestQueueItem(request_id, mock_request)
 
 
@@ -187,3 +199,232 @@ class TestCreateWaitingQueue:
         """Test creating queue with default policy."""
         queue = create_waiting_queue()
         assert isinstance(queue, FCFSWaitingQueue)
+
+    def test_create_priority_queue(self):
+        """Test creating a PriorityWaitingQueue via PRIORITY policy."""
+        queue = create_waiting_queue(WaitingQueuePolicy.PRIORITY)
+        assert isinstance(queue, PriorityWaitingQueue)
+
+
+class TestPriorityWaitingQueue:
+    """Tests for PriorityWaitingQueue.
+
+    Covers priority ordering, FCFS tiebreak for equal priorities, and
+    the full WaitingQueue interface (add, pop, peek, prepend, remove,
+    bool, len, iter).
+    """
+
+    # ------------------------------------------------------------------
+    # Ordering
+    # ------------------------------------------------------------------
+
+    def test_high_priority_served_before_low(self):
+        """Higher priority requests are popped before lower priority ones."""
+        q = PriorityWaitingQueue()
+        q.add_request(create_priority_request_item(1, priority=0.1))
+        q.add_request(create_priority_request_item(2, priority=0.9))
+        q.add_request(create_priority_request_item(3, priority=0.5))
+        assert [q.pop_request().id for _ in range(3)] == [2, 3, 1]
+
+    def test_equal_priority_falls_back_to_fcfs(self):
+        """Requests with equal priority are served in arrival (FCFS) order."""
+        q = PriorityWaitingQueue()
+        for req_id in [10, 20, 30]:
+            q.add_request(create_priority_request_item(req_id, priority=0.7))
+        assert [q.pop_request().id for _ in range(3)] == [10, 20, 30]
+
+    def test_default_priority_is_fcfs(self):
+        """Requests using the default priority are served in arrival order."""
+        q = PriorityWaitingQueue()
+        for req_id in range(5):
+            q.add_request(create_priority_request_item(req_id))
+        assert [q.pop_request().id for _ in range(5)] == [0, 1, 2, 3, 4]
+
+    def test_mixed_priorities_correct_order(self):
+        """Mixed priorities are served strictly in descending priority order."""
+        q = PriorityWaitingQueue()
+        items = [
+            (1, 0.3),
+            (2, 1.0),
+            (3, 0.0),
+            (4, 0.8),
+            (5, 0.5),
+        ]
+        for req_id, priority in items:
+            q.add_request(create_priority_request_item(req_id, priority))
+        # Expected order: 2 (1.0), 4 (0.8), 5 (0.5), 1 (0.3), 3 (0.0)
+        assert [q.pop_request().id for _ in range(5)] == [2, 4, 5, 1, 3]
+
+    def test_interleaved_add_and_pop(self):
+        """Priority order is maintained when requests are added between pops."""
+        q = PriorityWaitingQueue()
+        q.add_request(create_priority_request_item(1, priority=0.5))
+        q.add_request(create_priority_request_item(2, priority=0.2))
+        assert q.pop_request().id == 1  # highest so far
+
+        # Add a higher-priority request after the first pop
+        q.add_request(create_priority_request_item(3, priority=0.9))
+        assert q.pop_request().id == 3
+        assert q.pop_request().id == 2
+
+    # ------------------------------------------------------------------
+    # add_requests (batch insert)
+    # ------------------------------------------------------------------
+
+    def test_add_requests_batch(self):
+        """add_requests inserts all items and respects priority ordering."""
+        q = PriorityWaitingQueue()
+        q.add_requests(
+            [
+                create_priority_request_item(1, priority=0.2),
+                create_priority_request_item(2, priority=0.8),
+                create_priority_request_item(3, priority=0.5),
+            ]
+        )
+        assert len(q) == 3
+        assert [q.pop_request().id for _ in range(3)] == [2, 3, 1]
+
+    # ------------------------------------------------------------------
+    # peek_request
+    # ------------------------------------------------------------------
+
+    def test_peek_returns_highest_priority_without_removing(self):
+        """peek_request returns the highest-priority item and does not remove it."""
+        q = PriorityWaitingQueue()
+        q.add_request(create_priority_request_item(1, priority=0.3))
+        q.add_request(create_priority_request_item(2, priority=0.9))
+
+        peeked = q.peek_request()
+        assert peeked.id == 2
+        assert len(q) == 2  # not consumed
+
+    def test_peek_from_empty_raises(self):
+        """peek_request raises IndexError on an empty queue."""
+        with pytest.raises(IndexError):
+            PriorityWaitingQueue().peek_request()
+
+    def test_pop_from_empty_raises(self):
+        """pop_request raises IndexError on an empty queue."""
+        with pytest.raises(IndexError):
+            PriorityWaitingQueue().pop_request()
+
+    # ------------------------------------------------------------------
+    # prepend_request / prepend_requests
+    # ------------------------------------------------------------------
+
+    def test_prepend_request_respects_priority(self):
+        """prepend_request re-inserts by priority, not unconditionally to front."""
+        q = PriorityWaitingQueue()
+        q.add_request(create_priority_request_item(1, priority=0.8))
+        q.add_request(create_priority_request_item(2, priority=0.6))
+
+        # Prepend a low-priority item — it should not jump to the front
+        q.prepend_request(create_priority_request_item(3, priority=0.1))
+
+        assert [q.pop_request().id for _ in range(3)] == [1, 2, 3]
+
+    def test_prepend_requests_respects_priority(self):
+        """prepend_requests re-inserts all items by priority."""
+        q = PriorityWaitingQueue()
+        q.add_request(create_priority_request_item(1, priority=0.5))
+        q.prepend_requests(
+            [
+                create_priority_request_item(2, priority=0.9),
+                create_priority_request_item(3, priority=0.1),
+            ]
+        )
+        assert [q.pop_request().id for _ in range(3)] == [2, 1, 3]
+
+    # ------------------------------------------------------------------
+    # remove_by_ids
+    # ------------------------------------------------------------------
+
+    def test_remove_by_ids_removes_correct_items(self):
+        """remove_by_ids removes exactly the specified requests."""
+        q = PriorityWaitingQueue()
+        for i, p in enumerate([0.9, 0.7, 0.5, 0.3, 0.1]):
+            q.add_request(create_priority_request_item(i, priority=p))
+
+        q.remove_by_ids({1, 3})
+
+        assert len(q) == 3
+        remaining = [q.pop_request().id for _ in range(3)]
+        assert remaining == [0, 2, 4]
+
+    def test_remove_by_ids_nonexistent_is_noop(self):
+        """remove_by_ids with unknown IDs does not change the queue."""
+        q = PriorityWaitingQueue()
+        q.add_request(create_priority_request_item(1, priority=0.8))
+        q.add_request(create_priority_request_item(2, priority=0.4))
+
+        q.remove_by_ids({99, 100})
+
+        assert len(q) == 2
+
+    def test_remove_all_ids_leaves_empty_queue(self):
+        """remove_by_ids can empty the queue entirely."""
+        q = PriorityWaitingQueue()
+        q.add_request(create_priority_request_item(1, priority=0.8))
+        q.add_request(create_priority_request_item(2, priority=0.4))
+
+        q.remove_by_ids({1, 2})
+
+        assert len(q) == 0
+        assert not q
+
+    def test_priority_order_preserved_after_remove(self):
+        """Priority ordering is intact after remove_by_ids."""
+        q = PriorityWaitingQueue()
+        for i, p in enumerate([0.9, 0.7, 0.5, 0.3]):
+            q.add_request(create_priority_request_item(i, priority=p))
+
+        q.remove_by_ids({1})  # remove priority=0.7
+
+        assert [q.pop_request().id for _ in range(3)] == [0, 2, 3]
+
+    # ------------------------------------------------------------------
+    # bool / len / iter
+    # ------------------------------------------------------------------
+
+    def test_bool_empty(self):
+        """Empty queue is falsy."""
+        assert not PriorityWaitingQueue()
+
+    def test_bool_nonempty(self):
+        """Non-empty queue is truthy."""
+        q = PriorityWaitingQueue()
+        q.add_request(create_priority_request_item(1, priority=0.5))
+        assert q
+
+    def test_len_tracks_adds_and_pops(self):
+        """__len__ accurately reflects the number of items."""
+        q = PriorityWaitingQueue()
+        assert len(q) == 0
+        q.add_request(create_priority_request_item(1, priority=0.5))
+        assert len(q) == 1
+        q.add_requests([create_priority_request_item(i, priority=0.5) for i in range(2, 5)])
+        assert len(q) == 4
+        q.pop_request()
+        assert len(q) == 3
+
+    def test_iter_yields_in_priority_order(self):
+        """__iter__ yields items in descending priority order."""
+        q = PriorityWaitingQueue()
+        for i, p in enumerate([0.1, 0.9, 0.5]):
+            q.add_request(create_priority_request_item(i, priority=p))
+
+        iterated_ids = [item.id for item in q]
+        assert iterated_ids == [1, 2, 0]  # 0.9, 0.5, 0.1
+
+    def test_iter_does_not_consume_items(self):
+        """Iterating over the queue does not remove items."""
+        q = PriorityWaitingQueue()
+        q.add_request(create_priority_request_item(1, priority=0.8))
+        q.add_request(create_priority_request_item(2, priority=0.4))
+
+        _ = list(q)
+        assert len(q) == 2
+
+    def test_is_waiting_queue_subclass(self):
+        """PriorityWaitingQueue is a WaitingQueue."""
+        assert isinstance(PriorityWaitingQueue(), WaitingQueue)

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -269,6 +269,7 @@ methods:
       priority:
         annotation: Union[float, List[float]]
         default: 0.5
+        status: prototype
     return_annotation: Union[tensorrt_llm.llmapi.llm.RequestOutput, List[tensorrt_llm.llmapi.llm.RequestOutput]]
   generate_async:
     parameters:
@@ -292,6 +293,7 @@ methods:
       priority:
         annotation: float
         default: 0.5
+        status: prototype
     return_annotation: tensorrt_llm.llmapi.llm.RequestOutput
   preprocess:
     parameters:

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -266,6 +266,9 @@ methods:
       cache_salt:
         annotation: Union[str, Sequence[str], NoneType]
         default: null
+      priority:
+        annotation: Union[float, List[float], NoneType]
+        default: null
     return_annotation: Union[tensorrt_llm.llmapi.llm.RequestOutput, List[tensorrt_llm.llmapi.llm.RequestOutput]]
   generate_async:
     parameters:
@@ -286,6 +289,9 @@ methods:
         annotation: Optional[Mapping[str, str]]
         default: null
         status: prototype
+      priority:
+        annotation: Optional[float]
+        default: null
     return_annotation: tensorrt_llm.llmapi.llm.RequestOutput
   preprocess:
     parameters:

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -267,8 +267,8 @@ methods:
         annotation: Union[str, Sequence[str], NoneType]
         default: null
       priority:
-        annotation: Union[float, List[float], NoneType]
-        default: null
+        annotation: Union[float, List[float]]
+        default: 0.5
     return_annotation: Union[tensorrt_llm.llmapi.llm.RequestOutput, List[tensorrt_llm.llmapi.llm.RequestOutput]]
   generate_async:
     parameters:
@@ -290,8 +290,8 @@ methods:
         default: null
         status: prototype
       priority:
-        annotation: Optional[float]
-        default: null
+        annotation: float
+        default: 0.5
     return_annotation: tensorrt_llm.llmapi.llm.RequestOutput
   preprocess:
     parameters:

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -116,9 +116,6 @@ methods:
       use_tqdm:
         annotation: bool
         default: true
-      priority:
-        annotation: Union[float, List[float]]
-        default: 0.5
     return_annotation: Union[tensorrt_llm.llmapi.llm.RequestOutput, List[tensorrt_llm.llmapi.llm.RequestOutput]]
   generate_async:
     parameters:
@@ -138,9 +135,6 @@ methods:
       streaming:
         annotation: bool
         default: false
-      priority:
-        annotation: float
-        default: 0.5
     return_annotation: tensorrt_llm.llmapi.llm.RequestOutput
 properties:
   tokenizer:

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -117,8 +117,8 @@ methods:
         annotation: bool
         default: true
       priority:
-        annotation: Union[float, List[float], NoneType]
-        default: null
+        annotation: Union[float, List[float]]
+        default: 0.5
     return_annotation: Union[tensorrt_llm.llmapi.llm.RequestOutput, List[tensorrt_llm.llmapi.llm.RequestOutput]]
   generate_async:
     parameters:
@@ -139,8 +139,8 @@ methods:
         annotation: bool
         default: false
       priority:
-        annotation: Optional[float]
-        default: null
+        annotation: float
+        default: 0.5
     return_annotation: tensorrt_llm.llmapi.llm.RequestOutput
 properties:
   tokenizer:

--- a/tests/unittest/api_stability/references_committed/llm.yaml
+++ b/tests/unittest/api_stability/references_committed/llm.yaml
@@ -116,6 +116,9 @@ methods:
       use_tqdm:
         annotation: bool
         default: true
+      priority:
+        annotation: Union[float, List[float], NoneType]
+        default: null
     return_annotation: Union[tensorrt_llm.llmapi.llm.RequestOutput, List[tensorrt_llm.llmapi.llm.RequestOutput]]
   generate_async:
     parameters:
@@ -135,6 +138,9 @@ methods:
       streaming:
         annotation: bool
         default: false
+      priority:
+        annotation: Optional[float]
+        default: null
     return_annotation: tensorrt_llm.llmapi.llm.RequestOutput
 properties:
   tokenizer:

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -1526,6 +1526,9 @@ async def test_llm_disagg_gen_cancelled():
         llm_gen.shutdown()
 
 
+@pytest.mark.threadleak(enabled=False)
+@pytest.mark.part0
+@skip_ray
 @pytest.mark.timeout(60)
 def test_priority_request_completes_before_low_priority():
     """High-priority request must be scheduled before a lower-priority one.

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -1534,7 +1534,7 @@ def test_priority_request_completes_before_low_priority():
     """High-priority request must be scheduled before a lower-priority one.
 
     Setup (max_batch_size=1, WaitingQueuePolicy.PRIORITY):
-      - Request 1: no explicit priority (default 0.5), max_tokens=50  – long, ignore_eos
+      - Request 1: no explicit priority (default 0.5), max_tokens=500  – long, ignore_eos
       - Request 2: no explicit priority (default 0.5), max_tokens=5   – short
       - Request 3: priority=0.9,                       max_tokens=5   – short + high priority
 
@@ -1560,9 +1560,8 @@ def test_priority_request_completes_before_low_priority():
         # Request 1 uses ignore_eos so it keeps the batch slot busy for the
         # full max_tokens count rather than stopping at an early EOS token.
         out1 = llm.generate_async(
-            prompt, SamplingParams(max_tokens=50,
-                                   temperature=0,
-                                   ignore_eos=True))
+            prompt,
+            SamplingParams(max_tokens=500, temperature=0, ignore_eos=True))
         out2 = llm.generate_async(prompt,
                                   SamplingParams(max_tokens=5, temperature=0))
         out3 = llm.generate_async(prompt,

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import random
 import time
@@ -11,7 +12,8 @@ from tensorrt_llm.disaggregated_params import DisaggregatedParams
 from tensorrt_llm.executor import GenerationExecutorWorker, RequestError
 from tensorrt_llm.executor.rpc_proxy import GenerationExecutorRpcProxy
 from tensorrt_llm.llmapi import CacheTransceiverConfig, KvCacheConfig
-from tensorrt_llm.llmapi.llm_args import NGramDecodingConfig, PeftCacheConfig
+from tensorrt_llm.llmapi.llm_args import (NGramDecodingConfig, PeftCacheConfig,
+                                          SchedulerConfig, WaitingQueuePolicy)
 from tensorrt_llm.llmapi.tokenizer import TransformersTokenizer
 from tensorrt_llm.metrics import MetricNames
 from tensorrt_llm.sampling_params import SamplingParams
@@ -1522,6 +1524,71 @@ async def test_llm_disagg_gen_cancelled():
     finally:
         llm_ctx.shutdown()
         llm_gen.shutdown()
+
+
+@pytest.mark.timeout(60)
+def test_priority_request_completes_before_low_priority():
+    """High-priority request must be scheduled before a lower-priority one.
+
+    Setup (max_batch_size=1, WaitingQueuePolicy.PRIORITY):
+      - Request 1: no explicit priority (default 0.5), max_tokens=50  – long, ignore_eos
+      - Request 2: no explicit priority (default 0.5), max_tokens=5   – short
+      - Request 3: priority=0.9,                       max_tokens=5   – short + high priority
+
+    All three requests are submitted before the executor has a chance to
+    schedule any of them.  With a PRIORITY waiting queue the executor will
+    pick Request 3 ahead of Request 2.  Therefore Request 3 must complete
+    before Request 2 regardless of how long Request 1 takes.
+    """
+    llm = LLM(
+        model=llama_model_path,
+        max_batch_size=1,
+        kv_cache_config=KvCacheConfig(enable_block_reuse=False),
+        scheduler_config=SchedulerConfig(
+            waiting_queue_policy=WaitingQueuePolicy.PRIORITY),
+    )
+
+    prompt = "A B C D E F G H I J"
+    completion_order = []
+
+    async def run():
+        # Submit all three requests before the event loop can schedule any of
+        # them – they all land in the waiting queue simultaneously.
+        # Request 1 uses ignore_eos so it keeps the batch slot busy for the
+        # full max_tokens count rather than stopping at an early EOS token.
+        out1 = llm.generate_async(
+            prompt, SamplingParams(max_tokens=50,
+                                   temperature=0,
+                                   ignore_eos=True))
+        out2 = llm.generate_async(prompt,
+                                  SamplingParams(max_tokens=5, temperature=0))
+        out3 = llm.generate_async(prompt,
+                                  SamplingParams(max_tokens=5, temperature=0),
+                                  priority=0.9)
+
+        async def await_and_record(output, req_id: int):
+            await output.aresult()
+            completion_order.append(req_id)
+
+        await asyncio.wait_for(
+            asyncio.gather(
+                await_and_record(out1, 1),
+                await_and_record(out2, 2),
+                await_and_record(out3, 3),
+            ),
+            timeout=55,
+        )
+
+    asyncio.run(run())
+    del llm
+
+    assert 2 in completion_order and 3 in completion_order, (
+        f"Not all requests completed. Completion order: {completion_order}")
+    idx_req2 = completion_order.index(2)
+    idx_req3 = completion_order.index(3)
+    assert idx_req3 < idx_req2, (
+        f"Request 3 (priority=0.9) should complete before Request 2 (no priority). "
+        f"Completion order: {completion_order}")
 
 
 @pytest.mark.threadleak(enabled=False)

--- a/tests/unittest/llmapi/test_request_priority.py
+++ b/tests/unittest/llmapi/test_request_priority.py
@@ -24,7 +24,7 @@ Tests cover priority propagation through:
 
 from unittest.mock import MagicMock, patch
 
-from tensorrt_llm.executor.request import GenerationRequest
+from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY, GenerationRequest
 from tensorrt_llm.sampling_params import SamplingParams
 
 # ---------------------------------------------------------------------------
@@ -40,9 +40,9 @@ class TestGenerationRequestPriority:
             **kwargs,
         )
 
-    def test_priority_defaults_to_none(self):
+    def test_priority_defaults_to_half(self):
         req = self._make_request()
-        assert req.priority is None
+        assert req.priority == DEFAULT_REQUEST_PRIORITY
 
     def test_priority_stored_correctly(self):
         req = self._make_request(priority=0.8)
@@ -57,8 +57,8 @@ class TestGenerationRequestPriority:
         assert req.priority == 1.0
 
     def test_priority_midpoint(self):
-        req = self._make_request(priority=0.5)
-        assert req.priority == 0.5
+        req = self._make_request(priority=DEFAULT_REQUEST_PRIORITY)
+        assert req.priority == DEFAULT_REQUEST_PRIORITY
 
 
 # ---------------------------------------------------------------------------
@@ -105,13 +105,13 @@ class TestGenerationExecutorPriorityPropagation:
         assert len(executor.submitted) == 1
         assert executor.submitted[0].priority == 0.9
 
-    def test_no_priority_leaves_none(self):
+    def test_no_priority_defaults_to_half(self):
         executor = self._make_executor()
         executor.generate_async(
             prompt_token_ids=[1, 2, 3],
             sampling_params=SamplingParams(max_tokens=5),
         )
-        assert executor.submitted[0].priority is None
+        assert executor.submitted[0].priority == DEFAULT_REQUEST_PRIORITY
 
     def test_priority_zero_propagated(self):
         executor = self._make_executor()
@@ -129,10 +129,7 @@ class TestGenerationExecutorPriorityPropagation:
 
 
 class TestBaseWorkerPriorityDefault:
-    """Verify that BaseWorker passes request.priority to tllm.Request.
-
-    Falls back to 0.5 when priority is None.
-    """
+    """Verify that BaseWorker passes request.priority to tllm.Request."""
 
     def _captured_tllm_request_priority(self, request_priority):
         """Run _enqueue_request with a mocked engine.
@@ -186,9 +183,9 @@ class TestBaseWorkerPriorityDefault:
         priority = self._captured_tllm_request_priority(0.8)
         assert priority == 0.8
 
-    def test_none_priority_defaults_to_half(self):
-        priority = self._captured_tllm_request_priority(None)
-        assert priority == 0.5
+    def test_default_priority_is_half(self):
+        priority = self._captured_tllm_request_priority(DEFAULT_REQUEST_PRIORITY)
+        assert priority == DEFAULT_REQUEST_PRIORITY
 
     def test_low_priority_is_forwarded(self):
         priority = self._captured_tllm_request_priority(0.1)
@@ -261,14 +258,14 @@ class TestBaseLLMGeneratePriority:
         assert calls[0]["priority"] == 0.2
         assert calls[1]["priority"] == 0.9
 
-    def test_no_priority_passes_none(self):
+    def test_no_priority_passes_default(self):
         llm, calls = self._make_llm_spy()
         llm.generate(
             ["hello"],
             sampling_params=SamplingParams(max_tokens=5),
             use_tqdm=False,
         )
-        assert calls[0]["priority"] is None
+        assert calls[0]["priority"] == DEFAULT_REQUEST_PRIORITY
 
 
 # ---------------------------------------------------------------------------
@@ -326,7 +323,7 @@ class TestPriorityWaitingQueueSchedulingOrder:
     downstream C++ capacity scheduler sees them in the right order.
     """
 
-    def _make_queue_item(self, req_id: int, priority: float | None = None):
+    def _make_queue_item(self, req_id: int, priority: float = 0.5):
         from unittest.mock import MagicMock
 
         from tensorrt_llm._torch.pyexecutor.executor_request_queue import RequestQueueItem
@@ -341,7 +338,7 @@ class TestPriorityWaitingQueueSchedulingOrder:
         q = PriorityWaitingQueue()
         q.add_request(self._make_queue_item(1, priority=0.1))
         q.add_request(self._make_queue_item(2, priority=0.9))
-        q.add_request(self._make_queue_item(3, priority=0.5))
+        q.add_request(self._make_queue_item(3, priority=DEFAULT_REQUEST_PRIORITY))
         served = [q.pop_request().id for _ in range(3)]
         assert served == [2, 3, 1], "Requests must be served in descending priority order"
 

--- a/tests/unittest/llmapi/test_request_priority.py
+++ b/tests/unittest/llmapi/test_request_priority.py
@@ -311,3 +311,64 @@ class TestExecutorRequestToLlmRequestPriority:
             "Hard-coded priority=0.5 should not appear in "
             "executor_request_to_llm_request; use executor_request.priority instead."
         )
+
+
+# ---------------------------------------------------------------------------
+# PriorityWaitingQueue – requests served in priority order
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityWaitingQueueSchedulingOrder:
+    """Verify that PriorityWaitingQueue serves requests in descending priority order.
+
+    This is the key integration point: the waiting queue must dequeue
+    higher-priority requests before lower-priority ones so that the
+    downstream C++ capacity scheduler sees them in the right order.
+    """
+
+    def _make_queue_item(self, req_id: int, priority: float | None = None):
+        from unittest.mock import MagicMock
+
+        from tensorrt_llm._torch.pyexecutor.executor_request_queue import RequestQueueItem
+
+        mock_req = MagicMock()
+        mock_req.priority = priority
+        return RequestQueueItem(id=req_id, request=mock_req)
+
+    def test_high_priority_served_before_low(self):
+        from tensorrt_llm._torch.pyexecutor.scheduler.waiting_queue import PriorityWaitingQueue
+
+        q = PriorityWaitingQueue()
+        q.add_request(self._make_queue_item(1, priority=0.1))
+        q.add_request(self._make_queue_item(2, priority=0.9))
+        q.add_request(self._make_queue_item(3, priority=0.5))
+        served = [q.pop_request().id for _ in range(3)]
+        assert served == [2, 3, 1], "Requests must be served in descending priority order"
+
+    def test_equal_priority_falls_back_to_fcfs(self):
+        from tensorrt_llm._torch.pyexecutor.scheduler.waiting_queue import PriorityWaitingQueue
+
+        q = PriorityWaitingQueue()
+        q.add_request(self._make_queue_item(10, priority=0.7))
+        q.add_request(self._make_queue_item(20, priority=0.7))
+        q.add_request(self._make_queue_item(30, priority=0.7))
+        served = [q.pop_request().id for _ in range(3)]
+        assert served == [10, 20, 30], (
+            "Requests with equal priority must be served in arrival (FCFS) order"
+        )
+
+    def test_create_waiting_queue_priority_policy(self):
+        """create_waiting_queue(PRIORITY) returns a PriorityWaitingQueue."""
+        from tensorrt_llm._torch.pyexecutor.scheduler.waiting_queue import (
+            PriorityWaitingQueue,
+            create_waiting_queue,
+        )
+        from tensorrt_llm.llmapi.llm_args import WaitingQueuePolicy
+
+        q = create_waiting_queue(WaitingQueuePolicy.PRIORITY)
+        assert isinstance(q, PriorityWaitingQueue)
+
+        q.add_request(self._make_queue_item(1, priority=0.2))
+        q.add_request(self._make_queue_item(2, priority=0.8))
+        assert q.pop_request().id == 2
+        assert q.pop_request().id == 1

--- a/tests/unittest/llmapi/test_request_priority.py
+++ b/tests/unittest/llmapi/test_request_priority.py
@@ -124,7 +124,7 @@ class TestGenerationExecutorPriorityPropagation:
 
 
 # ---------------------------------------------------------------------------
-# BaseWorker._enqueue_request  –  priority default of 0.5
+# BaseWorker._enqueue_request  -  priority default of 0.5
 # ---------------------------------------------------------------------------
 
 
@@ -197,7 +197,7 @@ class TestBaseWorkerPriorityDefault:
 
 
 # ---------------------------------------------------------------------------
-# BaseLLM.generate – scalar and list priority
+# BaseLLM.generate - scalar and list priority
 # ---------------------------------------------------------------------------
 
 
@@ -269,7 +269,7 @@ class TestBaseLLMGeneratePriority:
 
 
 # ---------------------------------------------------------------------------
-# executor_request_to_llm_request – priority not hard-coded
+# executor_request_to_llm_request - priority not hard-coded
 # ---------------------------------------------------------------------------
 
 
@@ -311,7 +311,7 @@ class TestExecutorRequestToLlmRequestPriority:
 
 
 # ---------------------------------------------------------------------------
-# PriorityWaitingQueue – requests served in priority order
+# PriorityWaitingQueue - requests served in priority order
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unittest/llmapi/test_request_priority.py
+++ b/tests/unittest/llmapi/test_request_priority.py
@@ -24,6 +24,8 @@ Tests cover priority propagation through:
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY, GenerationRequest
 from tensorrt_llm.sampling_params import SamplingParams
 
@@ -59,6 +61,11 @@ class TestGenerationRequestPriority:
     def test_priority_midpoint(self):
         req = self._make_request(priority=DEFAULT_REQUEST_PRIORITY)
         assert req.priority == DEFAULT_REQUEST_PRIORITY
+
+    @pytest.mark.parametrize("bad_priority", [-0.1, 1.1, float("nan"), float("inf"), -float("inf")])
+    def test_invalid_priority_raises(self, bad_priority):
+        with pytest.raises(ValueError):
+            self._make_request(priority=bad_priority)
 
 
 # ---------------------------------------------------------------------------
@@ -267,6 +274,28 @@ class TestBaseLLMGeneratePriority:
         )
         assert calls[0]["priority"] == DEFAULT_REQUEST_PRIORITY
 
+    @pytest.mark.parametrize("bad_priority", [-0.1, 1.5, float("nan")])
+    def test_invalid_scalar_priority_raises(self, bad_priority):
+        llm, _ = self._make_llm_spy()
+        # generate delegates to generate_async which validates the scalar value
+        with pytest.raises((ValueError, Exception)):
+            llm.generate(
+                ["hello"],
+                sampling_params=SamplingParams(max_tokens=5),
+                priority=bad_priority,
+                use_tqdm=False,
+            )
+
+    def test_invalid_list_priority_raises(self):
+        llm, _ = self._make_llm_spy()
+        with pytest.raises(ValueError):
+            llm.generate(
+                ["hello", "world"],
+                sampling_params=SamplingParams(max_tokens=5),
+                priority=[0.2, 1.5],
+                use_tqdm=False,
+            )
+
 
 # ---------------------------------------------------------------------------
 # executor_request_to_llm_request - priority not hard-coded
@@ -291,22 +320,6 @@ class TestExecutorRequestToLlmRequestPriority:
         assert "priority=executor_request.priority" in source, (
             "executor_request_to_llm_request must pass executor_request.priority "
             "to LlmRequest, not a hard-coded value."
-        )
-
-    def test_no_hardcoded_priority_in_function(self):
-        """Ensure the old hard-coded priority=0.5 was removed from the function."""
-        import inspect
-        import re
-
-        import tensorrt_llm._torch.pyexecutor.llm_request as lr_mod
-
-        source = inspect.getsource(lr_mod.executor_request_to_llm_request)
-        # Should not have a standalone priority=0.5 assignment (the default in
-        # tllm.Request.__init__ is fine, but not inside this converter function)
-        hardcoded_matches = re.findall(r"\bpriority\s*=\s*0\.5\b", source)
-        assert not hardcoded_matches, (
-            "Hard-coded priority=0.5 should not appear in "
-            "executor_request_to_llm_request; use executor_request.priority instead."
         )
 
 

--- a/tests/unittest/llmapi/test_request_priority.py
+++ b/tests/unittest/llmapi/test_request_priority.py
@@ -1,0 +1,313 @@
+# Copyright 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for request priority support in the LLM API.
+
+Tests cover priority propagation through:
+  - GenerationRequest storage
+  - GenerationExecutor.generate_async -> GenerationRequest
+  - BaseLLM.generate (scalar and list priority)
+  - BaseLLM.generate_async -> executor.generate_async
+  - BaseWorker._enqueue_request (default fallback to 0.5)
+  - executor_request_to_llm_request (no override)
+"""
+
+from unittest.mock import MagicMock, patch
+
+from tensorrt_llm.executor.request import GenerationRequest
+from tensorrt_llm.sampling_params import SamplingParams
+
+# ---------------------------------------------------------------------------
+# GenerationRequest
+# ---------------------------------------------------------------------------
+
+
+class TestGenerationRequestPriority:
+    def _make_request(self, **kwargs):
+        return GenerationRequest(
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(max_tokens=10),
+            **kwargs,
+        )
+
+    def test_priority_defaults_to_none(self):
+        req = self._make_request()
+        assert req.priority is None
+
+    def test_priority_stored_correctly(self):
+        req = self._make_request(priority=0.8)
+        assert req.priority == 0.8
+
+    def test_priority_zero(self):
+        req = self._make_request(priority=0.0)
+        assert req.priority == 0.0
+
+    def test_priority_one(self):
+        req = self._make_request(priority=1.0)
+        assert req.priority == 1.0
+
+    def test_priority_midpoint(self):
+        req = self._make_request(priority=0.5)
+        assert req.priority == 0.5
+
+
+# ---------------------------------------------------------------------------
+# GenerationExecutor.generate_async  ->  GenerationRequest
+# ---------------------------------------------------------------------------
+
+
+class TestGenerationExecutorPriorityPropagation:
+    """Verify that GenerationExecutor.generate_async builds a GenerationRequest.
+
+    Checks that the correct priority is set and the request is passed to submit().
+    """
+
+    def _make_executor(self):
+        """Return a concrete subclass of GenerationExecutor with a spy submit."""
+        from tensorrt_llm.executor.executor import GenerationExecutor
+
+        class _FakeExecutor(GenerationExecutor):
+            def __init__(self):
+                super().__init__()
+                self.submitted = []
+
+            def submit(self, request):
+                self.submitted.append(request)
+                result = MagicMock()
+                result.request_id = 0
+                return result
+
+            def abort_request(self, request_id):
+                pass
+
+            def shutdown(self):
+                pass
+
+        return _FakeExecutor()
+
+    def test_priority_propagated_to_request(self):
+        executor = self._make_executor()
+        executor.generate_async(
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(max_tokens=5),
+            priority=0.9,
+        )
+        assert len(executor.submitted) == 1
+        assert executor.submitted[0].priority == 0.9
+
+    def test_no_priority_leaves_none(self):
+        executor = self._make_executor()
+        executor.generate_async(
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(max_tokens=5),
+        )
+        assert executor.submitted[0].priority is None
+
+    def test_priority_zero_propagated(self):
+        executor = self._make_executor()
+        executor.generate_async(
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(max_tokens=5),
+            priority=0.0,
+        )
+        assert executor.submitted[0].priority == 0.0
+
+
+# ---------------------------------------------------------------------------
+# BaseWorker._enqueue_request  –  priority default of 0.5
+# ---------------------------------------------------------------------------
+
+
+class TestBaseWorkerPriorityDefault:
+    """Verify that BaseWorker passes request.priority to tllm.Request.
+
+    Falls back to 0.5 when priority is None.
+    """
+
+    def _captured_tllm_request_priority(self, request_priority):
+        """Run _enqueue_request with a mocked engine.
+
+        Returns the priority value that was passed to tllm.Request.
+        """
+        import tensorrt_llm.executor.base_worker as bw_mod
+
+        captured = {}
+
+        class CapturingRequest:
+            def __init__(self, *args, **kwargs):
+                captured["priority"] = kwargs.get("priority")
+                # Mimic minimal interface used by _enqueue_request
+                self.py_num_logprobs = None
+                self.py_lora_path = None
+                self.py_logprobs_mode = None
+
+            def __setattr__(self, name, value):
+                object.__setattr__(self, name, value)
+
+        req = GenerationRequest(
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(max_tokens=5),
+            priority=request_priority,
+        )
+        req.set_id(42)
+
+        # Build a minimal mock worker.
+        # max_seq_len=None causes _deduce_max_tokens to return max_tokens early
+        # (via the "cannot be deduced" path), avoiding arithmetic on MagicMocks.
+        worker = MagicMock()
+        worker.llm_args = MagicMock()
+        worker.llm_args.max_beam_width = 1
+        worker.llm_args.return_perf_metrics = False
+        worker._executor_config = None
+        worker._is_pytorch_backend = False
+        worker.max_seq_len = None
+        worker.engine = MagicMock()
+        worker.engine.enqueue_request = MagicMock(return_value=42)
+
+        with patch.object(bw_mod.tllm, "Request", CapturingRequest):
+            # Call the unbound method directly with our mock worker as self
+            from tensorrt_llm.executor.base_worker import BaseWorker
+
+            BaseWorker._enqueue_request(worker, req, result_wait_queue=None)
+
+        return captured.get("priority")
+
+    def test_explicit_priority_is_forwarded(self):
+        priority = self._captured_tllm_request_priority(0.8)
+        assert priority == 0.8
+
+    def test_none_priority_defaults_to_half(self):
+        priority = self._captured_tllm_request_priority(None)
+        assert priority == 0.5
+
+    def test_low_priority_is_forwarded(self):
+        priority = self._captured_tllm_request_priority(0.1)
+        assert priority == 0.1
+
+    def test_high_priority_is_forwarded(self):
+        priority = self._captured_tllm_request_priority(1.0)
+        assert priority == 1.0
+
+
+# ---------------------------------------------------------------------------
+# BaseLLM.generate – scalar and list priority
+# ---------------------------------------------------------------------------
+
+
+class TestBaseLLMGeneratePriority:
+    """Verify that BaseLLM.generate forwards the correct priority value(s).
+
+    Covers both scalar and list forms passed to generate_async.
+    """
+
+    def _make_llm_spy(self):
+        """Return (llm, calls) where calls accumulates generate_async kwargs."""
+        from tensorrt_llm.llmapi.llm import BaseLLM
+
+        calls = []
+
+        class SpyLLM(BaseLLM):
+            def generate_async(self, inputs, **kwargs):
+                calls.append(kwargs)
+                result = MagicMock()
+                result.result.return_value = MagicMock()
+                return result
+
+            # Satisfy abstract-ish requirements without a real model
+            def _preprocess(self, *a, **kw):
+                raise NotImplementedError
+
+            def shutdown(self, *a, **kw):
+                pass
+
+        llm = SpyLLM.__new__(SpyLLM)
+        llm._executor = MagicMock()
+        llm._executor.is_shutdown.return_value = False
+        llm.args = MagicMock()
+        llm.args.return_perf_metrics = False
+        return llm, calls
+
+    def test_scalar_priority_passed_to_each_request(self):
+        llm, calls = self._make_llm_spy()
+        prompts = ["hello", "world"]
+        llm.generate(
+            prompts,
+            sampling_params=SamplingParams(max_tokens=5),
+            priority=0.7,
+            use_tqdm=False,
+        )
+        assert len(calls) == 2
+        assert all(c["priority"] == 0.7 for c in calls)
+
+    def test_list_priority_per_request(self):
+        llm, calls = self._make_llm_spy()
+        prompts = ["hello", "world"]
+        llm.generate(
+            prompts,
+            sampling_params=SamplingParams(max_tokens=5),
+            priority=[0.2, 0.9],
+            use_tqdm=False,
+        )
+        assert calls[0]["priority"] == 0.2
+        assert calls[1]["priority"] == 0.9
+
+    def test_no_priority_passes_none(self):
+        llm, calls = self._make_llm_spy()
+        llm.generate(
+            ["hello"],
+            sampling_params=SamplingParams(max_tokens=5),
+            use_tqdm=False,
+        )
+        assert calls[0]["priority"] is None
+
+
+# ---------------------------------------------------------------------------
+# executor_request_to_llm_request – priority not hard-coded
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorRequestToLlmRequestPriority:
+    """Verify that executor_request_to_llm_request passes executor_request.priority.
+
+    Ensures no hard-coded value is substituted. Because the function interacts
+    heavily with C++ pybind types, we verify the source-code contract instead of
+    calling the function end-to-end.
+    """
+
+    def test_priority_uses_executor_request_not_hardcoded(self):
+        """The function must read priority from executor_request, not use 0.5."""
+        import inspect
+
+        import tensorrt_llm._torch.pyexecutor.llm_request as lr_mod
+
+        source = inspect.getsource(lr_mod.executor_request_to_llm_request)
+        assert "priority=executor_request.priority" in source, (
+            "executor_request_to_llm_request must pass executor_request.priority "
+            "to LlmRequest, not a hard-coded value."
+        )
+
+    def test_no_hardcoded_priority_in_function(self):
+        """Ensure the old hard-coded priority=0.5 was removed from the function."""
+        import inspect
+        import re
+
+        import tensorrt_llm._torch.pyexecutor.llm_request as lr_mod
+
+        source = inspect.getsource(lr_mod.executor_request_to_llm_request)
+        # Should not have a standalone priority=0.5 assignment (the default in
+        # tllm.Request.__init__ is fine, but not inside this converter function)
+        hardcoded_matches = re.findall(r"\bpriority\s*=\s*0\.5\b", source)
+        assert not hardcoded_matches, (
+            "Hard-coded priority=0.5 should not appear in "
+            "executor_request_to_llm_request; use executor_request.priority instead."
+        )


### PR DESCRIPTION

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Summary

### New Features

- Added optional `priority` parameter to generation requests, enabling users to specify scheduling priority in the `[0, 1]` range (default `0.5`, mirroring the C++ `Req
- Supports both scalar and per-prompt priority specification in batch `generate` / `generate_async` calls.
- New `PriorityWaitingQueue` in the PyTorch executor replaces the FCFS queue when `WaitingQueuePolicy.PRIORITY` is selected: requests are served in descending priority
- Priority is propagated end-to-end: `LLM.generate_async` → `GenerationExecutor` → `GenerationRequest` → `tllm.Request` (via new nanobind binding) → `LlmRequest`.
- `generate_async` validates that priority is in `[0, 1]` and raises `ValueError` otherwise.
- `FCFSWaitingQueue` emits a `UserWarning` when a request with non-default priority is enqueued, indicating the priority will be ignored under FCFS scheduling.

### Tests

- New test suite `tests/unittest/llmapi/test_request_priority.py` validates priority propagation across all layers: `GenerationRequest`, `GenerationExecutor`, `BaseWork
- Integration test in `test_llm_pytorch.py` verifies end-to-end that a high-priority request (`priority=0.9`) completes before a normal-priority request when `max_batch

### Description

Request priority allows callers to influence the order in which queued requests are dispatched to the model. A priority of `1.0` is highest, `0.0` is lowest, and `0.5`

**Key implementation details:**

| Layer | Change |
|---|---|
| `tensorrt_llm/executor/request.py` | `DEFAULT_REQUEST_PRIORITY = 0.5` constant; `GenerationRequest.priority: float` (non-Optional) |
| `tensorrt_llm/executor/executor.py` | `generate_async(priority=DEFAULT_REQUEST_PRIORITY)` |
| `tensorrt_llm/executor/base_worker.py` | Passes `request.priority` directly to `tllm.Request` |
| `cpp/.../nanobind/executor/request.cpp` | `def_prop_rw("priority", ...)` exposes C++ getter/setter to Python |
| `tensorrt_llm/_torch/pyexecutor/llm_request.py` | `executor_request_to_llm_request` passes `executor_request.priority` |
| `tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py` | New `PriorityWaitingQueue` (sorted list + bisect, O(log n) search); FCFS warns on non-default priority |
| `tensorrt_llm/llmapi/llm.py` | `generate` / `generate_async` accept `priority`; range validation added |
| `tensorrt_llm/llmapi/llm_args.py` | `WaitingQueuePolicy.PRIORITY` added to enum |
## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `priority` parameter to request generation methods, enabling per-request priority control (0.0–1.0 range).
  * New priority-based waiting queue policy for request scheduling and execution ordering.

* **Tests**
  * Added unit tests for priority scheduling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->