### PR TITLE
[#12049][feat] AutoDeploy: Enable the gather logits and piecewise cg by default

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -216,7 +216,7 @@ transforms:
   gather_logits_before_lm_head:
     stage: post_load_fusion
     # TODO: fix https://github.com/NVIDIA/TensorRT-LLM/issues/9878 to enable by default
-    enabled: false
+    enabled: true
   ############################################################################################
   # VISUALIZE GRAPH
   ############################################################################################
@@ -277,5 +277,5 @@ transforms:
     run_per_gm: false
     cuda_graph_batch_sizes: null
     backend: torch-compile
-    piecewise_enabled: false
+    piecewise_enabled: true
     piecewise_num_tokens: null


### PR DESCRIPTION
#12049 

Per offline decision, will exclude the gather logits from the piecewise Cudagraph. And turn on the gather logits and piecewise Cudagraph by default. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default model compilation configuration to enable enhanced graph transformations and piecewise compilation strategies for optimized model deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


