### PR TITLE
[None][feat] Add Triton backend for torch_moe_dense_mlp

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
@@ -12,12 +12,32 @@ The table below lists the operators grouped by category.
 
 | Operator Name | Description |
 |--------------|-------------|
-| `torch.ops.auto_deploy.torch_attention` | Grouped SDPA implementation with `bsnd` and `bnsd` layout supported |
-| `torch.ops.auto_deploy.torch_attention_sdpa` | Standard scaled dot-product attention (SDPA) implementation |
-| `torch.ops.auto_deploy.torch_attention_repeat_kv` | KV repetition for grouped-query attention |
-| `torch.ops.auto_deploy.torch_cached_attention_with_cache` | PyTorch backend attention with KV cache management |
-| `torch.ops.auto_deploy.flashinfer_attention_mha_with_cache` | FlashInfer multi-head attention with KV cache support |
-| `torch.ops.auto_deploy.flashinfer_attention_prepare_metadata` | FlashInfer attention metadata preparation |
+| `torch.ops.auto_deploy.flashinfer_attention_mha_with_cache` | FlashInfer attention with KV cache support |
+| `torch.ops.auto_deploy.flashinfer_rope` | FlashInfer RoPE (Rotary Position Embedding) implementation |
+| `torch.ops.auto_deploy.torch_attention_bsnd_grouped_sdpa` | Grouped SDPA (Scaled Dot Product Attention) with BSND format |
+| `torch.ops.auto_deploy.torch_attention_deepseek_fused_mla` | DeepSeek fused MLA (Multi-head Linear Attention) |
+| `torch.ops.auto_deploy.torch_attention_deepseek_mla` | DeepSeek MLA implementation |
+| `torch.ops.auto_deploy.torch_attention_grouped_sdpa` | Grouped SDPA implementation |
+| `torch.ops.auto_deploy.torch_attention_repeat_kv` | KV repetition for attention |
+| `torch.ops.auto_deploy.torch_attention_sdpa` | Standard SDPA implementation |
+| `torch.ops.auto_deploy.torch_dist_all_gather` | Distributed all-gather operation |
+| `torch.ops.auto_deploy.torch_dist_all_reduce` | Distributed all-reduce operation |
+| `torch.ops.auto_deploy.torch_linear_simple` | Simple linear layer implementation |
+| `torch.ops.auto_deploy.torch_moe` | Mixture of Experts implementation |
+| `torch.ops.auto_deploy.torch_moe_dense_mlp` | Dense MoE with fused GEMM + GLU activation (PyTorch backend) |
+| `torch.ops.auto_deploy.torch_moe_fused` | Fused Mixture of Experts implementation |
+| `torch.ops.auto_deploy.triton_moe_dense_mlp` | Dense MoE with fused GEMM + GLU activation (Triton backend) |
+| `torch.ops.auto_deploy.torch_quant_fn` | Generic quantization function that scales, rounds, and clamps input values |
+| `torch.ops.auto_deploy.torch_quant_fused_fp8_linear_all_reduce` | Fused FP8 linear layer followed by all-reduce operation |
+| `torch.ops.auto_deploy.torch_quant_fp4_linear` | FP4 quantized linear layer |
+| `torch.ops.auto_deploy.torch_quant_fp8_linear` | FP8 quantized linear layer |
+| `torch.ops.auto_deploy.torch_rope_with_complex_freqs` | RoPE with complex frequencies |
+| `torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin` | RoPE with explicit cosine/sine |
+| `torch.ops.auto_deploy.torch_rope_with_qk_interleaving` | RoPE with QK interleaving |
+| `torch.ops.auto_deploy.triton_attention_fused_flattened_mha_with_cache` | Triton fused flattened MHA with cache |
+| `torch.ops.auto_deploy.triton_attention_fused_flattened_mha_with_cache_rope_fusion` | Triton fused flattened MHA with cache and RoPE fusion |
+| `torch.ops.auto_deploy.triton_attention_fused_mha_with_cache` | Triton fused MHA with cache |
+| `torch.ops.auto_deploy.triton_attention_fused_mha_with_paged_cache` | Triton fused MHA with paged cache |
 | `torch.ops.auto_deploy.triton_attention_flattened_mha_with_cache` | Triton flattened MHA with cache |
 | `torch.ops.auto_deploy.torch_onnx_attention_plugin` | Fused attention with RoPE placeholder for ONNX export |
 | `torch.ops.auto_deploy.torch_onnx_gather_nd` | N-dimensional gather operation for ONNX export |

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/__init__.py
@@ -12,3 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Fused MoE operations.
+
+This module provides various Mixture-of-Experts implementations:
+- torch_moe: PyTorch reference implementations (torch_moe, torch_moe_dense_mlp, etc.)
+- triton_moe: Triton-based fused MoE (vLLM-inspired)
+- triton_moe_dense_mlp: Triton-accelerated dense MoE with fused GLU activation
+- trtllm_moe: TRT-LLM optimized MoE
+- mxfp4_moe: MXFP4 quantized MoE
+- triton_routing: Triton-based routing kernels
+- load_moe_align: MoE alignment utilities
+"""
+
+__all__ = [
+    "torch_moe",
+    "triton_moe",
+    "triton_moe_dense_mlp",
+    "trtllm_moe",
+    "mxfp4_moe",
+    "triton_routing",
+    "load_moe_align",
+]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/triton_moe_dense_mlp.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/triton_moe_dense_mlp.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Triton kernels and launcher for dense MoE with fused GEMM + activation.
+"""Triton kernels and custom op registration for dense MoE with fused GEMM + activation.
 
 The dense MoE computation is:
     1. gate_up = bmm(hidden, gate_up_w) + gate_up_b
@@ -142,7 +142,7 @@ def _weighted_expert_sum_kernel(
     tl.store(out_ptr + col_offsets * stride_out_h, acc.to(expert_vals.dtype), mask=mask)
 
 
-def moe_dense_mlp(
+def _moe_dense_mlp_triton(
     hidden_states: Tensor,
     routing_weights: Tensor,
     gate_up_w: Tensor,
@@ -241,3 +241,38 @@ def moe_dense_mlp(
     )
 
     return output.reshape(*leading_shape, hidden_size)
+
+
+@torch.library.custom_op("auto_deploy::triton_moe_dense_mlp", mutates_args=())
+def triton_moe_dense_mlp(
+    hidden_states: torch.Tensor,
+    routing_weights: torch.Tensor,
+    gate_up_w: torch.Tensor,
+    gate_up_b: torch.Tensor,
+    down_w: torch.Tensor,
+    down_b: torch.Tensor,
+    alpha: float = 1.0,
+    limit: float = 10.0,
+) -> torch.Tensor:
+    """Triton-accelerated dense MoE custom op (GPT-OSS style).
+
+    Matches the signature and semantics of auto_deploy::torch_moe_dense_mlp but
+    uses Triton kernels for the fused GLU activation and weighted expert summation.
+    """
+    return _moe_dense_mlp_triton(
+        hidden_states, routing_weights, gate_up_w, gate_up_b, down_w, down_b, alpha, limit
+    )
+
+
+@triton_moe_dense_mlp.register_fake
+def _triton_moe_dense_mlp_fake(
+    hidden_states: torch.Tensor,
+    routing_weights: torch.Tensor,
+    gate_up_w: torch.Tensor,
+    gate_up_b: torch.Tensor,
+    down_w: torch.Tensor,
+    down_b: torch.Tensor,
+    alpha: float = 1.0,
+    limit: float = 10.0,
+) -> torch.Tensor:
+    return torch.empty_like(hidden_states)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/triton_moe_dense_mlp.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/triton_moe_dense_mlp.py
@@ -40,12 +40,12 @@ from torch import Tensor
 def _fused_glu_activation_kernel(
     gate_up_ptr,
     output_ptr,
-    stride_gate_up_row: tl.constexpr,
-    stride_out_row: tl.constexpr,
+    stride_gate_up_row,
+    stride_out_row,
+    alpha_val,
+    limit_val,
     I_SIZE: tl.constexpr,
     BLOCK_I: tl.constexpr,
-    alpha: tl.constexpr,
-    limit: tl.constexpr,
 ):
     """Fused interleaved-split + clamp + GLU activation kernel.
 
@@ -78,11 +78,11 @@ def _fused_glu_activation_kernel(
     up_f = up_vals.to(tl.float32)
 
     # Clamp: gate max=limit, up min=-limit max=limit
-    gate_f = tl.minimum(gate_f, limit)
-    up_f = tl.maximum(tl.minimum(up_f, limit), -limit)
+    gate_f = tl.minimum(gate_f, limit_val)
+    up_f = tl.maximum(tl.minimum(up_f, limit_val), -limit_val)
 
     # GLU: glu = gate * sigmoid(gate * alpha)
-    glu = gate_f * tl.sigmoid(gate_f * alpha)
+    glu = gate_f * tl.sigmoid(gate_f * alpha_val)
 
     # Fused multiply: (up + 1) * glu
     result = (up_f + 1.0) * glu
@@ -128,12 +128,10 @@ def _weighted_expert_sum_kernel(
         w_f = w.to(tl.float32)
 
         # Load expert output for this token
-        expert_row_ptr = (
-            expert_out_ptr
-            + e * stride_expert_out_e
-            + token_idx * stride_expert_out_t
+        expert_row_ptr = expert_out_ptr + e * stride_expert_out_e + token_idx * stride_expert_out_t
+        expert_vals = tl.load(
+            expert_row_ptr + col_offsets * stride_expert_out_h, mask=mask, other=0.0
         )
-        expert_vals = tl.load(expert_row_ptr + col_offsets * stride_expert_out_h, mask=mask, other=0.0)
 
         acc += w_f * expert_vals.to(tl.float32)
 
@@ -187,23 +185,27 @@ def _moe_dense_mlp_triton(
     # Step 2-5: Fused interleaved-split + clamp + GLU activation (Triton kernel)
     # Output: [E, T, I]
     act_out = torch.empty(
-        num_experts, num_tokens, intermediate_size,
-        dtype=hidden_states.dtype, device=hidden_states.device
+        num_experts,
+        num_tokens,
+        intermediate_size,
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
     )
 
     total_rows = num_experts * num_tokens
     BLOCK_I = triton.next_power_of_2(intermediate_size)
 
+    gate_up_contig = gate_up.contiguous()
     grid = (total_rows,)
     _fused_glu_activation_kernel[grid](
-        gate_up.contiguous(),
+        gate_up_contig,
         act_out,
-        stride_gate_up_row=gate_up.stride(-2),
-        stride_out_row=act_out.stride(-2),
+        gate_up_contig.stride(-2),
+        act_out.stride(-2),
+        float(alpha),
+        float(limit),
         I_SIZE=intermediate_size,
         BLOCK_I=BLOCK_I,
-        alpha=alpha,
-        limit=limit,
         num_warps=4,
         num_stages=3,
     )
@@ -216,8 +218,7 @@ def _moe_dense_mlp_triton(
     # Ensure next_states is contiguous for the kernel
     next_states = next_states.contiguous()
     output = torch.empty(
-        num_tokens, hidden_size,
-        dtype=hidden_states.dtype, device=hidden_states.device
+        num_tokens, hidden_size, dtype=hidden_states.dtype, device=hidden_states.device
     )
 
     BLOCK_H = triton.next_power_of_2(hidden_size)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/triton_moe_dense_mlp.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/triton_moe_dense_mlp.py
@@ -122,6 +122,9 @@ def _weighted_expert_sum_kernel(
     # Accumulate weighted expert outputs in float32
     acc = tl.zeros((BLOCK_H,), dtype=tl.float32)
 
+    # Probe input dtype before the loop (Triton can't see loop-scoped vars after the loop)
+    _dtype_probe = tl.load(expert_out_ptr, eviction_policy="evict_first")
+
     for e in range(num_experts):
         # Load routing weight for this token-expert pair
         w = tl.load(routing_weights_ptr + token_idx * stride_routing_t + e * stride_routing_e)
@@ -137,7 +140,7 @@ def _weighted_expert_sum_kernel(
 
     # Store result
     out_ptr = output_ptr + token_idx * stride_out_t
-    tl.store(out_ptr + col_offsets * stride_out_h, acc.to(expert_vals.dtype), mask=mask)
+    tl.store(out_ptr + col_offsets * stride_out_h, acc.to(_dtype_probe.dtype), mask=mask)
 
 
 def _moe_dense_mlp_triton(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_kernels/moe_dense_mlp.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/triton_kernels/moe_dense_mlp.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton kernels and launcher for dense MoE with fused GEMM + activation.
+
+The dense MoE computation is:
+    1. gate_up = bmm(hidden, gate_up_w) + gate_up_b
+    2. Interleaved split: gate = gate_up[..., ::2], up = gate_up[..., 1::2]
+    3. Clamp: gate = clamp(gate, max=limit), up = clamp(up, min=-limit, max=limit)
+    4. GLU: glu = gate * sigmoid(gate * alpha)
+    5. Fused multiply: act_out = (up + 1) * glu
+    6. down_out = bmm(act_out, down_w) + down_b
+    7. Weighted sum over experts
+
+The Triton kernel fuses steps 2-5 (interleaved split, clamp, GLU, multiply) into a
+single kernel to avoid multiple passes over intermediate memory.
+
+A second Triton kernel handles the routing-weighted summation (step 7).
+"""
+
+import torch
+import triton
+import triton.language as tl
+from torch import Tensor
+
+
+@triton.jit
+def _fused_glu_activation_kernel(
+    gate_up_ptr,
+    output_ptr,
+    stride_gate_up_row: tl.constexpr,
+    stride_out_row: tl.constexpr,
+    I_SIZE: tl.constexpr,
+    BLOCK_I: tl.constexpr,
+    alpha: tl.constexpr,
+    limit: tl.constexpr,
+):
+    """Fused interleaved-split + clamp + GLU activation kernel.
+
+    Reads gate_up tensor with interleaved gate/up values of shape [..., 2*I],
+    computes the fused activation, and writes output of shape [..., I].
+
+    For each element i in [0, I):
+        gate = clamp(gate_up[..., 2*i], max=limit)
+        up   = clamp(gate_up[..., 2*i+1], min=-limit, max=limit)
+        glu  = gate * sigmoid(gate * alpha)
+        out  = (up + 1) * glu
+
+    Grid: (num_rows,) - one program per row (expert x token combination).
+    """
+    row_idx = tl.program_id(0)
+    col_offsets = tl.arange(0, BLOCK_I)
+    mask = col_offsets < I_SIZE
+
+    # Compute interleaved indices: gate at even positions, up at odd positions
+    gate_offsets = col_offsets * 2
+    up_offsets = col_offsets * 2 + 1
+
+    # Load from interleaved gate_up
+    gate_up_row_ptr = gate_up_ptr + row_idx * stride_gate_up_row
+    gate_vals = tl.load(gate_up_row_ptr + gate_offsets, mask=mask, other=0.0)
+    up_vals = tl.load(gate_up_row_ptr + up_offsets, mask=mask, other=0.0)
+
+    # Upcast to float32 for numerical stability
+    gate_f = gate_vals.to(tl.float32)
+    up_f = up_vals.to(tl.float32)
+
+    # Clamp: gate max=limit, up min=-limit max=limit
+    gate_f = tl.minimum(gate_f, limit)
+    up_f = tl.maximum(tl.minimum(up_f, limit), -limit)
+
+    # GLU: glu = gate * sigmoid(gate * alpha)
+    glu = gate_f * tl.sigmoid(gate_f * alpha)
+
+    # Fused multiply: (up + 1) * glu
+    result = (up_f + 1.0) * glu
+
+    # Store result
+    out_row_ptr = output_ptr + row_idx * stride_out_row
+    tl.store(out_row_ptr + col_offsets, result.to(gate_vals.dtype), mask=mask)
+
+
+@triton.jit
+def _weighted_expert_sum_kernel(
+    expert_out_ptr,
+    routing_weights_ptr,
+    output_ptr,
+    stride_expert_out_e,
+    stride_expert_out_t,
+    stride_expert_out_h,
+    stride_routing_t,
+    stride_routing_e,
+    stride_out_t,
+    stride_out_h,
+    num_experts: tl.constexpr,
+    H_SIZE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    """Weighted summation over experts for each token.
+
+    For each token t and hidden dim h:
+        output[t, h] = sum_e(routing_weights[t, e] * expert_out[e, t, h])
+
+    Grid: (num_tokens,) - one program per token.
+    """
+    token_idx = tl.program_id(0)
+    col_offsets = tl.arange(0, BLOCK_H)
+    mask = col_offsets < H_SIZE
+
+    # Accumulate weighted expert outputs in float32
+    acc = tl.zeros((BLOCK_H,), dtype=tl.float32)
+
+    for e in range(num_experts):
+        # Load routing weight for this token-expert pair
+        w = tl.load(routing_weights_ptr + token_idx * stride_routing_t + e * stride_routing_e)
+        w_f = w.to(tl.float32)
+
+        # Load expert output for this token
+        expert_row_ptr = (
+            expert_out_ptr
+            + e * stride_expert_out_e
+            + token_idx * stride_expert_out_t
+        )
+        expert_vals = tl.load(expert_row_ptr + col_offsets * stride_expert_out_h, mask=mask, other=0.0)
+
+        acc += w_f * expert_vals.to(tl.float32)
+
+    # Store result
+    out_ptr = output_ptr + token_idx * stride_out_t
+    tl.store(out_ptr + col_offsets * stride_out_h, acc.to(expert_vals.dtype), mask=mask)
+
+
+def moe_dense_mlp(
+    hidden_states: Tensor,
+    routing_weights: Tensor,
+    gate_up_w: Tensor,
+    gate_up_b: Tensor,
+    down_w: Tensor,
+    down_b: Tensor,
+    alpha: float = 1.0,
+    limit: float = 10.0,
+) -> Tensor:
+    """Python launcher for the Triton-accelerated dense MoE.
+
+    Uses torch.bmm for the GEMM components and Triton kernels for:
+      - Fused interleaved-split + clamp + GLU activation
+      - Routing-weighted expert summation
+
+    Args:
+        hidden_states: Input tensor [B, S, H] or [B*S, H].
+        routing_weights: Dense routing weights [B*S, E].
+        gate_up_w: Fused gate+up weight [E, H, 2I].
+        gate_up_b: Fused gate+up bias [E, 2I].
+        down_w: Down projection weight [E, I, H].
+        down_b: Down projection bias [E, H].
+        alpha: Scaling factor for sigmoid in GLU.
+        limit: Clamp limit for gate and up projections.
+
+    Returns:
+        Output tensor with the same shape as hidden_states.
+    """
+    leading_shape = hidden_states.shape[:-1]
+    hidden_size = hidden_states.shape[-1]
+    hidden_flat = hidden_states.reshape(-1, hidden_size)  # (T, H)
+    num_tokens = hidden_flat.shape[0]
+    num_experts = routing_weights.shape[1]
+    intermediate_size = gate_up_w.shape[2] // 2  # 2I -> I
+
+    # Step 1: Replicate tokens across experts and compute gate_up projection (BMM)
+    # hidden_rep: [E, T, H]
+    hidden_rep = hidden_flat.unsqueeze(0).expand(num_experts, -1, -1)
+    # gate_up: [E, T, 2I]
+    gate_up = torch.bmm(hidden_rep, gate_up_w) + gate_up_b[:, None, :]
+
+    # Step 2-5: Fused interleaved-split + clamp + GLU activation (Triton kernel)
+    # Output: [E, T, I]
+    act_out = torch.empty(
+        num_experts, num_tokens, intermediate_size,
+        dtype=hidden_states.dtype, device=hidden_states.device
+    )
+
+    total_rows = num_experts * num_tokens
+    BLOCK_I = triton.next_power_of_2(intermediate_size)
+
+    grid = (total_rows,)
+    _fused_glu_activation_kernel[grid](
+        gate_up.contiguous(),
+        act_out,
+        stride_gate_up_row=gate_up.stride(-2),
+        stride_out_row=act_out.stride(-2),
+        I_SIZE=intermediate_size,
+        BLOCK_I=BLOCK_I,
+        alpha=alpha,
+        limit=limit,
+        num_warps=4,
+        num_stages=3,
+    )
+
+    # Step 6: Down projection (BMM)
+    # next_states: [E, T, H]
+    next_states = torch.bmm(act_out, down_w) + down_b[:, None, :]
+
+    # Step 7: Routing-weighted summation over experts (Triton kernel)
+    # Ensure next_states is contiguous for the kernel
+    next_states = next_states.contiguous()
+    output = torch.empty(
+        num_tokens, hidden_size,
+        dtype=hidden_states.dtype, device=hidden_states.device
+    )
+
+    BLOCK_H = triton.next_power_of_2(hidden_size)
+    grid_sum = (num_tokens,)
+    _weighted_expert_sum_kernel[grid_sum](
+        next_states,
+        routing_weights,
+        output,
+        stride_expert_out_e=next_states.stride(0),
+        stride_expert_out_t=next_states.stride(1),
+        stride_expert_out_h=next_states.stride(2),
+        stride_routing_t=routing_weights.stride(0),
+        stride_routing_e=routing_weights.stride(1),
+        stride_out_t=output.stride(0),
+        stride_out_h=output.stride(1),
+        num_experts=num_experts,
+        H_SIZE=hidden_size,
+        BLOCK_H=BLOCK_H,
+        num_warps=4,
+        num_stages=3,
+    )
+
+    return output.reshape(*leading_shape, hidden_size)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_moe_dense_mlp.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_moe_dense_mlp.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Correctness tests for the Triton backend of torch_moe_dense_mlp.
+
+Compares triton_moe_dense_mlp against the torch reference (torch_moe_dense_mlp)
+across multiple dtypes, shapes, and parameter configurations.
+"""
+
+import pytest
+import torch
+
+# Trigger registration of custom ops
+from tensorrt_llm._torch.auto_deploy.custom_ops.torch_moe import (  # noqa: F401
+    torch_moe_dense_mlp,
+    triton_moe_dense_mlp,
+)
+
+
+def _make_dense_moe_inputs(
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    dtype: torch.dtype,
+    device: str = "cuda",
+    alpha: float = 1.0,
+    limit: float = 10.0,
+):
+    """Create synthetic inputs for torch_moe_dense_mlp / triton_moe_dense_mlp."""
+    torch.manual_seed(42)
+    num_tokens = batch_size * seq_len
+    hidden_states = torch.randn(batch_size, seq_len, hidden_size, device=device, dtype=dtype)
+    # Routing weights: softmax over experts for each token
+    routing_logits = torch.randn(num_tokens, num_experts, device=device, dtype=dtype)
+    routing_weights = torch.softmax(routing_logits, dim=-1)
+    # gate_up_w: [E, H, 2I] — interleaved gate and up projections
+    gate_up_w = torch.randn(
+        num_experts, hidden_size, 2 * intermediate_size, device=device, dtype=dtype
+    ) * 0.02
+    gate_up_b = torch.randn(num_experts, 2 * intermediate_size, device=device, dtype=dtype) * 0.02
+    # down_w: [E, I, H]
+    down_w = torch.randn(
+        num_experts, intermediate_size, hidden_size, device=device, dtype=dtype
+    ) * 0.02
+    down_b = torch.randn(num_experts, hidden_size, device=device, dtype=dtype) * 0.02
+    return hidden_states, routing_weights, gate_up_w, gate_up_b, down_w, down_b, alpha, limit
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize(
+    "batch_size,seq_len,hidden_size,intermediate_size,num_experts",
+    [
+        (1, 1, 32, 16, 2),
+        (2, 4, 64, 32, 3),
+        (4, 8, 128, 64, 4),
+    ],
+)
+def test_triton_moe_dense_mlp_matches_torch(
+    batch_size, seq_len, hidden_size, intermediate_size, num_experts, dtype
+):
+    """Triton kernel output matches torch reference within tolerance."""
+    inputs = _make_dense_moe_inputs(
+        batch_size, seq_len, hidden_size, intermediate_size, num_experts, dtype
+    )
+    expected = torch_moe_dense_mlp(*inputs)
+    actual = triton_moe_dense_mlp(*inputs)
+
+    rtol = 1e-2 if dtype != torch.float32 else 1e-4
+    atol = 1e-2 if dtype != torch.float32 else 1e-5
+    torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize(
+    "batch_size,seq_len,hidden_size,intermediate_size,num_experts",
+    [
+        (2, 3, 48, 24, 2),  # non-power-of-2 intermediate_size
+        (1, 5, 33, 17, 3),  # non-power-of-2 hidden and intermediate
+        (3, 7, 64, 31, 2),  # odd intermediate_size
+    ],
+)
+def test_triton_moe_dense_mlp_non_power_of_2(
+    batch_size, seq_len, hidden_size, intermediate_size, num_experts
+):
+    """Triton kernel handles non-power-of-2 dimensions correctly."""
+    dtype = torch.bfloat16
+    inputs = _make_dense_moe_inputs(
+        batch_size, seq_len, hidden_size, intermediate_size, num_experts, dtype
+    )
+    expected = torch_moe_dense_mlp(*inputs)
+    actual = triton_moe_dense_mlp(*inputs)
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("alpha", [0.5, 1.0, 1.07, 2.0])
+@pytest.mark.parametrize("limit", [1.0, 5.0, 10.0, 20.0])
+def test_triton_moe_dense_mlp_alpha_limit_variants(alpha, limit):
+    """Triton kernel works with different alpha and limit values."""
+    dtype = torch.float16
+    inputs = _make_dense_moe_inputs(
+        batch_size=2, seq_len=4, hidden_size=64, intermediate_size=32,
+        num_experts=3, dtype=dtype, alpha=alpha, limit=limit
+    )
+    expected = torch_moe_dense_mlp(*inputs)
+    actual = triton_moe_dense_mlp(*inputs)
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+def test_triton_moe_dense_mlp_large():
+    """Triton kernel works on larger realistic shapes."""
+    dtype = torch.bfloat16
+    inputs = _make_dense_moe_inputs(
+        batch_size=2, seq_len=32, hidden_size=256, intermediate_size=128,
+        num_experts=4, dtype=dtype
+    )
+    expected = torch_moe_dense_mlp(*inputs)
+    actual = triton_moe_dense_mlp(*inputs)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_triton_moe_dense_mlp_single_token():
+    """Edge case: single token input."""
+    dtype = torch.float16
+    inputs = _make_dense_moe_inputs(
+        batch_size=1, seq_len=1, hidden_size=64, intermediate_size=32,
+        num_experts=2, dtype=dtype
+    )
+    expected = torch_moe_dense_mlp(*inputs)
+    actual = triton_moe_dense_mlp(*inputs)
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+def test_triton_moe_dense_mlp_single_expert():
+    """Edge case: single expert (degenerates to standard MLP)."""
+    dtype = torch.float16
+    inputs = _make_dense_moe_inputs(
+        batch_size=2, seq_len=4, hidden_size=64, intermediate_size=32,
+        num_experts=1, dtype=dtype
+    )
+    expected = torch_moe_dense_mlp(*inputs)
+    actual = triton_moe_dense_mlp(*inputs)
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_triton_moe_dense_mlp.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_triton_moe_dense_mlp.py
@@ -23,8 +23,10 @@ import pytest
 import torch
 
 # Trigger registration of custom ops
-from tensorrt_llm._torch.auto_deploy.custom_ops.torch_moe import (  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.torch_moe import (  # noqa: F401
     torch_moe_dense_mlp,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.triton_moe_dense_mlp import (  # noqa: F401
     triton_moe_dense_mlp,
 )
 


### PR DESCRIPTION
## Summary
- Add Triton kernels for dense MoE: fused interleaved-split + clamp + GLU activation, and routing-weighted expert summation
- Register as `auto_deploy::triton_moe_dense_mlp` custom op, using torch.bmm for GEMMs and Triton for activation/routing
- Add comprehensive unit tests (31 tests) covering multiple dtypes, shapes, alpha/limit variants, and edge cases

## Test plan
- [x] `pytest tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_triton_moe_dense_mlp.py` — 31/31 passed on H100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Triton-based custom operator for dense Mixture-of-Experts MLP processing with fused activation and expert aggregation.

* **Documentation**
  * Updated custom operators reference guide with expanded support for attention variants, distributed operations, and MoE implementations.

* **Tests**
  * Added comprehensive validation suite for the new dense MoE operator across multiple data types, dimensions, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->