### PR TITLE
[https://nvbugs/5962591][fix] Fix Triton resmooth kernel crash on SM100f for large MoE grids

### DIFF
--- a/tensorrt_llm/quantization/utils/fp8_utils.py
+++ b/tensorrt_llm/quantization/utils/fp8_utils.py
@@ -115,22 +115,38 @@ def resmooth_to_fp8_e8m0(
     num_batches = w_view.shape[0]
     BLOCK_M, BLOCK_K = block_size
 
-    grid = (num_batches, triton.cdiv(M, BLOCK_M), triton.cdiv(K, BLOCK_K))
+    grid_m = triton.cdiv(M, BLOCK_M)
+    grid_k = triton.cdiv(K, BLOCK_K)
+    blocks_per_batch = grid_m * grid_k
 
-    _resmooth_kernel[grid](
-        w_view,
-        s_view,
-        M,
-        K,
-        w_view.stride(0),
-        w_view.stride(1),
-        w_view.stride(2),
-        s_view.stride(0),
-        s_view.stride(1),
-        s_view.stride(2),
-        BLOCK_M=BLOCK_M,
-        BLOCK_K=BLOCK_K,
-    )
+    # Workaround for Triton compiler/runtime bug on SM100f (Blackwell):
+    # CUDA illegal memory access when total grid blocks exceed ~65K.
+    # Split launches along the batch dimension to stay under the limit.
+    MAX_GRID_BLOCKS = 65536
+    if blocks_per_batch > 0:
+        max_batches_per_launch = max(1, MAX_GRID_BLOCKS // blocks_per_batch)
+    else:
+        max_batches_per_launch = num_batches
+
+    for batch_offset in range(0, num_batches, max_batches_per_launch):
+        batch_count = min(max_batches_per_launch,
+                          num_batches - batch_offset)
+        grid = (batch_count, grid_m, grid_k)
+
+        _resmooth_kernel[grid](
+            w_view[batch_offset:],
+            s_view[batch_offset:],
+            M,
+            K,
+            w_view.stride(0),
+            w_view.stride(1),
+            w_view.stride(2),
+            s_view.stride(0),
+            s_view.stride(1),
+            s_view.stride(2),
+            BLOCK_M=BLOCK_M,
+            BLOCK_K=BLOCK_K,
+        )
     # this is an in-place operation, however, we return for simplicity
     return weight, weight_scale
 

--- a/tensorrt_llm/quantization/utils/fp8_utils.py
+++ b/tensorrt_llm/quantization/utils/fp8_utils.py
@@ -129,8 +129,7 @@ def resmooth_to_fp8_e8m0(
         max_batches_per_launch = num_batches
 
     for batch_offset in range(0, num_batches, max_batches_per_launch):
-        batch_count = min(max_batches_per_launch,
-                          num_batches - batch_offset)
+        batch_count = min(max_batches_per_launch, num_batches - batch_offset)
         grid = (batch_count, grid_m, grid_k)
 
         _resmooth_kernel[grid](

--- a/tests/unittest/_torch/modules/moe/moe_test_utils.py
+++ b/tests/unittest/_torch/modules/moe/moe_test_utils.py
@@ -516,37 +516,6 @@ def should_skip_deepgemm(
     if backend_type != MoeBackendType.DEEPGEMM:
         return None
 
-    # Issue: DEEPGEMM + FP8_BLOCK_SCALES crashes with CUDA illegal memory access
-    # in _resmooth_kernel (Triton JIT) during post_load_weights() FP8 E8M0 scale
-    # resmoothing on SM100f (Blackwell). Root cause is a Triton compiler/runtime
-    # bug on SM100f: the kernel crashes when total grid blocks exceed ~65K.
-    # The crash depends on grid size, not just num_experts — Grok-1 (e8, h=6144,
-    # i=32768) crashes despite having only 8 experts because its weight tensors
-    # produce grids with 196K+ blocks.
-    # Weight shapes: w3_w1=[E, I*2, H], w2=[E, H, I] (from quantization.py)
-    # Grid for resmooth: (E, cdiv(M,128), cdiv(K,128))
-    # Verified boundary: max_blocks <= 57344 passes, >= 98304 crashes.
-    # Threshold: 65536 blocks (64K). Affected: DeepSeek-V3, Kimi-K2, Grok-1.
-    _RESMOOTH_GRID_BLOCK_LIMIT = 65536
-    if quant_algo == QuantAlgo.FP8_BLOCK_SCALES and model_config is not None:
-        num_e = model_config.num_experts
-        hidden = model_config.hidden_size
-        inter = model_config.intermediate_size
-
-        def _cdiv(x, y):
-            return (x + y - 1) // y
-
-        w31_blocks = num_e * _cdiv(inter * 2, 128) * _cdiv(hidden, 128)
-        w2_blocks = num_e * _cdiv(hidden, 128) * _cdiv(inter, 128)
-        max_blocks = max(w31_blocks, w2_blocks)
-        if max_blocks > _RESMOOTH_GRID_BLOCK_LIMIT:
-            return (
-                f"[Triton Bug] DeepGemmFusedMoE FP8_BLOCK_SCALES crashes in "
-                f"_resmooth_kernel on SM100f when grid blocks exceed ~64K "
-                f"(max_blocks={max_blocks:,} > {_RESMOOTH_GRID_BLOCK_LIMIT:,}). "
-                f"Affected: E={num_e}, H={hidden}, I={inter}."
-            )
-
     # TP per-shard alignment: FP8_BLOCK_SCALES requires 128-aligned per-shard
     # intermediate_size for block scale tensor operations.
     if moe_tp_size > 1 and quant_algo == QuantAlgo.FP8_BLOCK_SCALES and model_config is not None:


### PR DESCRIPTION
Split _resmooth_kernel launches along the batch dimension to keep total grid blocks under 65K, working around a Triton compiler/runtime bug on SM100f (Blackwell) that causes CUDA illegal memory access when grids exceed ~65K blocks. This affects large MoE models like DeepSeek-V3, Kimi-K2, and Grok-1.

Also removes the corresponding skip condition in test utils since the kernel-side fix makes it unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved execution efficiency for FP8 quantization operations.

* **Tests**
  * Removed a kernel limitation workaround, enabling additional test coverage for quantization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->