### PR TITLE
[https://nvbugs/5991576][fix] fix dummy request crash with PP + ADP + disagg + block reuse

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3276,7 +3276,12 @@ class PyExecutor:
             self._terminate_request(request)
 
     def _terminate_request(self, request: LlmRequest):
-        if self._disagg_pp_termination_handler is not None:
+        # Dummy requests don't participate in disagg KV cache transfers,
+        # so they must bypass the PP termination handler to avoid stale
+        # sequences in the KV cache manager (the handler delays removal,
+        # but the dummy ID is reused every iteration).
+        if (self._disagg_pp_termination_handler is not None
+                and not request.is_dummy_request):
             self._disagg_pp_termination_handler.terminate(request)
         else:
             self._do_terminate_request(request)

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2ep2pp2_gentp4_deepseek_v3_lite_one_mtp_block_reuse.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2ep2pp2_gentp4_deepseek_v3_lite_one_mtp_block_reuse.yaml
@@ -1,0 +1,32 @@
+hostname: localhost
+model: DeepSeek-V3-Lite/fp8
+free_gpu_memory_fraction: 0.1
+backend: pytorch
+cuda_graph_config: null
+context_servers:
+  num_instances: 1
+  tensor_parallel_size: 2
+  pipeline_parallel_size: 2
+  moe_expert_parallel_size: 2
+  enable_attention_dp: true
+  disable_overlap_scheduler: true
+  speculative_config:
+    decoding_type: MTP
+    num_nextn_predict_layers: 1
+  kv_cache_config:
+    enable_block_reuse: true
+  cache_transceiver_config:
+    backend: DEFAULT
+generation_servers:
+  num_instances: 1
+  tensor_parallel_size: 4
+  pipeline_parallel_size: 1
+  moe_expert_parallel_size: 4
+  enable_attention_dp: true
+  speculative_config:
+    decoding_type: MTP
+    num_nextn_predict_layers: 1
+  kv_cache_config:
+    enable_block_reuse: true
+  cache_transceiver_config:
+    backend: DEFAULT

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -229,6 +229,8 @@ def get_test_config(test_desc, example_dir, test_root):
         f"{test_configs_root}/disagg_config_ctxtp1_gentp1_deepseek_v3_lite_two_mtp.yaml",
         "deepseek_v3_lite_fp8_ctxpp2_gentp2_one_mtp":
         f"{test_configs_root}/disagg_config_ctxtp1_gentp1_deepseek_v3_lite_one_mtp_ctxpp2_gentp2.yaml",
+        "deepseek_v3_lite_fp8_ctxtp2ep2pp2_gentp4_one_mtp_block_reuse":
+        f"{test_configs_root}/disagg_config_ctxtp2ep2pp2_gentp4_deepseek_v3_lite_one_mtp_block_reuse.yaml",
         "deepseek_v3_lite_bf16_empty_batch":
         f"{test_configs_root}/disagg_config_deepseek_v3_lite_empty_batch.yaml",
         "llama4_kv_cache_overflow":
@@ -1173,6 +1175,24 @@ def test_disaggregated_deepseek_v3_lite_fp8_ctxpp2_gentp2_one_mtp(
                            env=llm_venv._new_env,
                            model_path=deepseek_v3_model_root,
                            cwd=llm_venv.get_working_directory())
+
+
+@pytest.mark.skip_less_device(8)
+@skip_no_hopper
+@pytest.mark.parametrize("deepseek_v3_model_root", ['DeepSeek-V3-Lite-fp8'],
+                         indirect=True)
+def test_disaggregated_deepseek_v3_lite_fp8_ctxtp2ep2pp2_gentp4_one_mtp_block_reuse(
+        disaggregated_test_root, disaggregated_example_root, llm_venv,
+        deepseek_v3_model_root):
+    setup_model_symlink(llm_venv, deepseek_v3_model_root,
+                        "DeepSeek-V3-Lite/fp8")
+
+    run_disaggregated_test(
+        disaggregated_example_root,
+        "deepseek_v3_lite_fp8_ctxtp2ep2pp2_gentp4_one_mtp_block_reuse",
+        env=llm_venv._new_env,
+        model_path=deepseek_v3_model_root,
+        cwd=llm_venv.get_working_directory())
 
 
 @skip_no_hopper

--- a/tests/integration/test_lists/test-db/l0_dgx_h200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h200.yml
@@ -40,6 +40,7 @@ l0_dgx_h200:
   - accuracy/test_llm_api_pytorch.py::TestQwen3NextInstruct::test_bf16_4gpu[tp4ep4_cudagraph_overlap_adp_on]
   - disaggregated/test_disaggregated.py::test_disaggregated_ctxtp2pp2_gentp2pp2[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated.py::test_disaggregated_ctxpp4_genpp4[TinyLlama-1.1B-Chat-v1.0]
+  - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_ctxtp2ep2pp2_gentp4_one_mtp_block_reuse[DeepSeek-V3-Lite-fp8]
   - unittest/llmapi/test_llm_pytorch.py::test_nemotron_nas_lora
 - condition:
     ranges:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pipeline-parallel termination coordination to properly skip the termination handler for dummy requests, preventing unnecessary handler invocations during cleanup.

* **Tests**
  * Added new integration test configuration and corresponding test function for validating distributed inference scenarios with advanced parallelism configurations and speculative decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

When using pipeline parallelism (PP) on the context server in disaggregated serving with attention DP (ADP) and KV cache block reuse enabled, the system crashes with:

```
RuntimeError: Assertion failed: emplaceDone (kvCacheManager.cpp:2497)
```

**Root cause:** The attention DP dummy request (hardcoded `request_id=0`) is routed through `DisaggPPTerminationHandler`, which delays sequence removal via a ring protocol across PP ranks. Since the dummy ID is reused every iteration by `_pad_attention_dp_dummy_request`, the delayed removal causes a collision in the KV cache manager's `mSequences` map when the dummy is re-added.

**Fix:** Bypass `DisaggPPTerminationHandler` for dummy requests since they don't participate in disagg KV cache transfers and must be terminated immediately.

## Test Coverage

- New integration test: `test_disaggregated_deepseek_v3_lite_fp8_ctxtp2ep2pp2_gentp4_one_mtp_block_reuse`
  - CTX server: TP=2, PP=2, EP=2, ADP, block reuse enabled, MTP
  - GEN server: TP=4, EP=4, ADP, block reuse enabled, MTP
  - Model: DeepSeek-V3-Lite/fp8
  - Requires 8 GPUs (Hopper+)
- Verified on EOS (8x H100):
  - **Without fix:** Test fails with `emplaceDone` assertion (timeout after 5 min)
  - **With fix:** Test passes in ~3 min

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.