### PR TITLE
[None][fix] Correct reused block counting on corner case

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2261,6 +2261,7 @@ SizeType32 KVCacheManager::getNeededBlocksOneStep(
             // `addSequence()` ignores the last prompt token because its KV cannot be recovered.
             // When the prompt lands exactly on a block boundary, counting reusable full blocks from
             // all unique tokens can over-credit one extra shared block.
+            TLLM_CHECK_WITH_INFO(promptInputLen > 0, "Unexpected: promptInputLen == 0");
             auto const maxRecoverableSharedBlocks = (promptInputLen - 1) / getTokensPerBlock();
             // Only subtract from shared blocks (reusable blocks are always shared)
             auto const reusableSharedBlocks

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2255,10 +2255,16 @@ SizeType32 KVCacheManager::getNeededBlocksOneStep(
         if (mEnableBlockReuse && !mBlockManager.isVariableWindow() && !isCrossKv()
             && !req.isDisaggGenerationInitState())
         {
-            auto const uniqueTokens = req.getUniqueTokens(0);
+            auto const& uniqueTokens = req.getUniqueTokens(0);
             auto const numReusableBlocks = countReusableBlocks(uniqueTokens, req, /*onlyAllocated=*/true);
+            auto const promptInputLen = std::min(req.mPromptLen, windowSize + chunkSize);
+            // `addSequence()` ignores the last prompt token because its KV cannot be recovered.
+            // When the prompt lands exactly on a block boundary, counting reusable full blocks from
+            // all unique tokens can over-credit one extra shared block.
+            auto const maxRecoverableSharedBlocks = (promptInputLen - 1) / getTokensPerBlock();
             // Only subtract from shared blocks (reusable blocks are always shared)
-            auto const reusableSharedBlocks = std::min(numReusableBlocks, numSharedBlocks);
+            auto const reusableSharedBlocks
+                = std::min({numReusableBlocks, numSharedBlocks, maxRecoverableSharedBlocks});
             numRequiredBlocks -= reusableSharedBlocks;
             // Store on request so the micro batch scheduler can use it for token budget
             req.setEstimatedReusableTokens(reusableSharedBlocks * getTokensPerBlock());

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -5835,6 +5835,77 @@ TEST(KVCacheManagerReuseAccountingTest, ReuseAwareBlockEstimatesStayConsistentAf
 
     auto const remainingAfterContextAlloc = kvCacheManager->getRemainingBlocksToCompletion(req1, onlyWindowSize);
     EXPECT_EQ(remainingAfterContextAlloc, maxNewTokens / tokensPerBlock);
+}
+
+TEST(KVCacheManagerReuseAccountingTest, NeededBlocksOneStepCapsAllocatedReuseAtExactBlockBoundary)
+{
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto constexpr tokensPerBlock = 16;
+    auto constexpr promptLength = 48; // 3 full context blocks
+    auto constexpr reusablePrefixLength = promptLength + 1;
+    auto constexpr maxNewTokens = 32;
+    auto constexpr maxBeamWidth = 1;
+    auto constexpr maxAttentionWindow = 512;
+    auto constexpr maxNumTokens = 1024;
+
+    auto kvCacheManager = createKvCacheManager(
+        KvCacheManagerInstantiationParameters{
+            /* numLayers */ 1,
+            /* numHeads */ 1,
+            /* sizePerHead */ 1,
+            /* tokensPerBlock */ tokensPerBlock,
+            /* blocksPerWindow */ blocksAndWindow(/* numPrimaryBlocks */ 256, /* windowSize */ maxAttentionWindow),
+            /* sinkTokenLength */ 0,
+            /* maxAttentionWindow */ maxAttentionWindow,
+            /* maxBeamWidth */ maxBeamWidth,
+            /* maxNumTokens */ maxNumTokens,
+            /* kvCacheBlockReuse */ true,
+        },
+        stream);
+    kvCacheManager->allocatePools(/*useUvm=*/false);
+    auto const onlyWindowSize = theOnlyWindowSize(*kvCacheManager);
+    auto const samplingConfig = tensorrt_llm::runtime::SamplingConfig{maxBeamWidth};
+    auto constexpr isStreaming = true;
+    auto makeRequest = [&](LlmRequest::RequestIdType requestId, std::vector<TokenIdType> const& tokens)
+    {
+        return LlmRequest(
+            requestId, maxNewTokens, std::make_shared<std::vector<TokenIdType>>(tokens), samplingConfig, isStreaming);
+    };
+
+    auto reusableTokens = std::vector<TokenIdType>(static_cast<std::size_t>(reusablePrefixLength));
+    std::iota(reusableTokens.begin(), reusableTokens.end(), 0);
+
+    auto seedReq = makeRequest(0, reusableTokens);
+    kvCacheManager->addSequence(seedReq.mRequestId, seedReq.getPromptLen(), maxBeamWidth, seedReq);
+    kvCacheManager->removeSequence(seedReq.mRequestId, seedReq);
+
+    // Keep a request with 49 prompt tokens active so all 3 full prefix blocks remain
+    // both reusable and allocated.
+    auto holderReq = makeRequest(1, reusableTokens);
+    kvCacheManager->addSequence(holderReq.mRequestId, holderReq.getPromptLen(), maxBeamWidth, holderReq);
+    EXPECT_EQ(holderReq.getContextCurrentPosition(), promptLength);
+
+    auto promptTokens = std::vector<TokenIdType>(static_cast<std::size_t>(promptLength));
+    std::iota(promptTokens.begin(), promptTokens.end(), 0);
+
+    auto req1 = makeRequest(2, promptTokens);
+
+    // Simulate a recompute-style context request: prompt length stays at the exact block
+    // boundary, but one generated token already exists in the token history.
+    req1.addNewToken(promptLength, 0);
+
+    auto const reusableAllocatedBlocks
+        = kvCacheManager->countReusableBlocks(req1.getUniqueTokens(0), req1, /*onlyAllocated=*/true);
+    EXPECT_EQ(reusableAllocatedBlocks, promptLength / tokensPerBlock);
+
+    auto const neededOneStep
+        = kvCacheManager->getNeededBlocksOneStep(req1, /*twoStepsLookAhead=*/false, onlyWindowSize);
+    EXPECT_EQ(neededOneStep, 1);
+
+    auto const numAllocBlocksBeforeAdd = kvCacheManager->getNumAllocTotalBlocks();
+    kvCacheManager->addSequence(req1.mRequestId, req1.getPromptLen(), maxBeamWidth, req1);
+    auto const numAllocBlocksAfterAdd = kvCacheManager->getNumAllocTotalBlocks();
+    EXPECT_EQ(numAllocBlocksAfterAdd - numAllocBlocksBeforeAdd, neededOneStep);
 }
 
 TEST(KVCacheManagerReuseAccountingTest, CountReusableBlocksNoMatchReturnsZero)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected KV cache block reuse accounting to prevent over-allocation at prompt boundaries, ensuring accurate block demand calculation.

* **Tests**
  * Added unit test coverage for KV cache reuse behavior at exact block boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This PR fixes an off-by-one KV-cache block estimation bug in the reuse-aware scheduler. For prompts that end exactly on a block boundary, `getNeededBlocksOneStep()` could count one more reusable block than `addSequence()` can actually recover, causing underestimation of required blocks and eventual No free blocks left failures under load. The fix caps reusable-block credit to the truly recoverable prefix so scheduling and allocation stay consistent.

## Test Coverage

`KVCacheManagerReuseAccountingTest.NeededBlocksOneStepCapsAllocatedReuseAtExactBlockBoundary` added to exercise the code path.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
