### PR TITLE
[https://nvbugs/5841976][fix] Remove test_fused_moe_alltoall_fp4[DeepEP] from waives

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -248,7 +248,6 @@ cpp/test_multi_gpu.py::test_cache_transceiver[8proc-mooncake_kvcache-90] SKIP (h
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_4gpus[v1_kv_cache-dp4-cutlass-auto] SKIP (https://nvbugs/5838211)
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_4gpus[v2_kv_cache-dp4-cutlass-auto] SKIP (https://nvbugs/5838211)
 full:A10/unittest/kv_cache_manager_v2_tests/ SKIP (https://nvbugs/5841954)
-unittest/_torch/modules/test_fused_moe.py::test_fused_moe_alltoall_fp4[DeepEP] SKIP (https://nvbugs/5841976)
 unittest/_torch/modeling/test_modeling_nemotron_h.py::test_nemotron_h_cuda_graph_overlap_scheduler SKIP (https://nvbugs/5843316)
 examples/test_mistral.py::test_mistral_with_bf16_lora_torch[mistral-7b-v0.1] SKIP (https://nvbugs/5846178)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[latency] SKIP (https://nvbugs/5846024)


### PR DESCRIPTION
## Summary
- Remove `test_fused_moe_alltoall_fp4[DeepEP]` from `waives.txt` — the test was waived due to CUDA error timeout on B300 (https://nvbugs/5841976)
- Verified on latest `main` with B300 (SM100) that the test passes successfully (1 passed in 236s)
- The underlying issue appears to have been resolved by recent MoE/DeepEP fixes

## Test plan
- [x] Reproduced test on B300 with latest main code — test passes
- [x] CI should confirm the test no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled a previously skipped test related to fused operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->