### PR TITLE
[TRTLLM-10938][feat] Enable block reuse with overlap scheduler

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -231,7 +231,7 @@ class AsyncTransferManager:
             logger.warning(
                 f"Request {request.py_request_id} not found in transfer manager"
             )
-            return
+            return False
 
         if transfer_metadata.end_transfer():
             self._requests_in_transfer.pop(request.py_request_id)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3526,6 +3526,36 @@ class PyExecutor:
 
         self._enqueue_responses(new_responses)
 
+    def _maybe_update_speculation_gate(self, request: LlmRequest):
+        """Record per-request acceptance stats and permanently disable
+        speculation if the rolling average drops below threshold."""
+        if self.drafter is None or self.speculation_gate is None:
+            return
+        if not getattr(self.model_engine, 'enable_spec_decode', False):
+            return
+        if self.speculation_permanently_disabled or request.is_dummy or self.is_warmup:
+            return
+        if getattr(self.dist, 'has_pp',
+                   False) and not self.dist.is_last_pp_rank:
+            return
+
+        avg_decoded = getattr(request, 'avg_decoded_tokens_per_iter', None)
+        if avg_decoded is None:
+            logger.debug(
+                f"Request {request.py_request_id} has no avg_decoded_tokens_per_iter"
+            )
+            return
+
+        disabled_now, _ = self.speculation_gate.record_avg_decoded(
+            avg_decoded, request_id=getattr(request, 'py_request_id', None))
+        if disabled_now:
+            self.speculation_permanently_disabled = True
+
+    def _should_emit_response(self, request: LlmRequest) -> bool:
+        """Whether a response (streaming or final) should be emitted."""
+        return (request.py_decoding_iter == 1 or request.is_finished
+                or request.py_decoding_iter % self.stream_interval == 0)
+
     @nvtx_range("_handle_responses")
     def _handle_responses(self):
         new_responses = []
@@ -3539,12 +3569,11 @@ class PyExecutor:
 
         for request in self.active_requests:
             req_id = request.py_request_id
-            # no responses for dummy request, and finish it
+
             if request.is_attention_dp_dummy:
                 requests_to_terminate.append(request)
                 continue
 
-            # Check if generation request needs cleanup due to KV cache transfer timeout
             if request.py_kv_transfer_timed_out:
                 is_cancelled = self.kv_cache_transceiver.cancel_request(request)
                 if is_cancelled:
@@ -3553,10 +3582,9 @@ class PyExecutor:
                         requests=[request])
                 continue
 
+            # Generation-only requests in transmission or at their first
+            # overlap iteration don't need a response yet.
             if request.is_generation_only_request() and not request.is_finished:
-                # If request is in transmission, so we don't need to emit a response
-                # Also, for the first iteration with overlap, we should skip since first
-                # token has already been emitted previously
                 if request.is_disagg_generation_transmission_in_progress or (
                         not self.disable_overlap_scheduler
                         and request.py_decoding_iter <= 1):
@@ -3567,68 +3595,41 @@ class PyExecutor:
                     new_active_requests.append(request)
                     continue
 
-            request.draft_tokens = request.py_draft_tokens if get_draft_token_length(
-                request) > 0 else []
+            request.draft_tokens = (request.py_draft_tokens if
+                                    get_draft_token_length(request) > 0 else [])
             request.decoding_iter = request.py_decoding_iter
 
             self.perf_manager.append_step_metrics(
                 request, self.iter_counter, batch_token_time=batch_token_time)
 
-            # Ensure C++ perf metrics (lastTokenTime, etc.) are always updated
-            # independently of whether append_step_metrics early-returned.
-            # This is critical for E2E latency computation in tracing/Prometheus.
             if request.return_perf_metrics and request.py_decoding_iter >= 1:
                 request.update_perf_metrics(self.iter_counter)
 
             request_done = False
-            if request.py_decoding_iter == 1 or request.is_finished or \
-                    request.py_decoding_iter % self.stream_interval == 0:
+            if self._should_emit_response(request):
                 response = request.create_response(False, self.dist.rank)
                 if response:
                     request_done = request.is_finished
                     response.result.cached_tokens = request.cached_tokens
                     new_responses.append((req_id, response))
 
-            if request_done:
-                if (self.drafter is not None and getattr(
-                        self.model_engine, 'enable_spec_decode', False)
-                        and not self.speculation_permanently_disabled
-                        and not request.is_dummy and not self.is_warmup):
-                    if self.speculation_gate is not None:
-                        # Response handling runs on multiple PP ranks. Only the last PP rank performs
-                        # sampling; restrict rolling stat updates to it to avoid overcounting.
-                        if (not getattr(self.dist, 'has_pp',
-                                        False)) or self.dist.is_last_pp_rank:
-                            avg_decoded = getattr(
-                                request, 'avg_decoded_tokens_per_iter', None)
-                            if avg_decoded is not None:
-                                disabled_now, _ = self.speculation_gate.record_avg_decoded(
-                                    avg_decoded,
-                                    request_id=getattr(request, 'py_request_id',
-                                                       None))
-                                if disabled_now:
-                                    # disable speculation permanently
-                                    # starting from next iteration, _prepare_and_schedule_batch will set self.use_spec_decode to False
-                                    self.speculation_permanently_disabled = True
-                            else:
-                                logger.debug(
-                                    f"Request {request.py_request_id} has no avg_decoded_tokens_per_iter"
-                                )
-
-                # If partial reuse is enabled, and the KV cache manager is not VSWA, and the PP size is 1,
-                # then we need to terminate the request. TODO: Remove this once disagg support from KVCache reuse
-                # path is fixed.
-                if self.enable_partial_reuse_for_disagg and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1:
-                    requests_to_terminate.append(request)
-                else:
-                    if not request.is_disagg_context_transmission_state:
-                        requests_to_terminate.append(request)
-            else:
+            if not request_done:
                 new_active_requests.append(request)
+                continue
+
+            self._maybe_update_speculation_gate(request)
+
+            # Don't terminate requests whose KV cache is still being
+            # transferred to the generation server.  The async transfer
+            # manager will call _end_transfer_and_maybe_terminate once
+            # the transfer completes.
+            if not request.is_disagg_context_transmission_state:
+                requests_to_terminate.append(request)
 
         self.active_requests.clear()
         self.active_requests.extend(new_active_requests)
-        # Request should be terminated after enqueueing response to ensure we can enqueue response successfully.
+        # Terminate after enqueueing so the response consumer can still
+        # read from the result wait queue.
         self._enqueue_responses(new_responses)
         for request in requests_to_terminate:
             self._terminate_request(request)

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -450,14 +450,6 @@ class BaseWorker(GenerationExecutor):
                 context_phase_params = request.disaggregated_params.get_context_phase_params(
                 )
 
-        if self._is_pytorch_backend and not self.llm_args.disable_overlap_scheduler \
-                and self.llm_args.kv_cache_config.enable_block_reuse \
-                and self.engine.kv_cache_transceiver is not None \
-                and request_type == tllm.RequestType.REQUEST_TYPE_CONTEXT_ONLY:
-            raise ValueError(
-                "Context only requests are not supported in pytorch backend when overlap is enabled with block reuse."
-            )
-
         assert request.id is not None
 
         def _deduce_max_tokens(request: GenerationRequest,

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -1510,7 +1510,7 @@ class TestQwen3_8B(LlmapiAccuracyTestHarness):
         max_batch_size = 32
 
         kv_cache_config = {
-            "enable_block_reuse": True if ctx_pp == 1 else False,
+            "enable_block_reuse": True,
         }
 
         ctx_server_config = {

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -598,10 +598,6 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
     def test_auto_dtype(self, ctx_disable_overlap_scheduler,
                         gen_disable_overlap_scheduler, ctx_enable_block_reuse,
                         gen_enable_block_reuse):
-        if ctx_enable_block_reuse and not ctx_disable_overlap_scheduler:
-            pytest.skip(
-                "Skip this test because overlap scheduler is not supported with block reuse for context server"
-            )
         ctx_server_config = {
             "disable_overlap_scheduler": ctx_disable_overlap_scheduler,
             "kv_cache_config": {

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap.yaml
@@ -11,9 +11,8 @@ context_servers:
   tensor_parallel_size: 1
   pipeline_parallel_size: 1
   kv_cache_config:
-    enable_block_reuse: false
+    enable_block_reuse: true
     free_gpu_memory_fraction: 0.2
-    enable_partial_reuse: false
   cache_transceiver_config:
     backend: DEFAULT
 generation_servers:
@@ -24,8 +23,7 @@ generation_servers:
   max_num_tokens: 4096
   max_seq_len: 4096
   kv_cache_config:
-    enable_block_reuse: false
+    enable_block_reuse: true
     free_gpu_memory_fraction: 0.2
-    enable_partial_reuse: false
   cache_transceiver_config:
     backend: DEFAULT

--- a/tests/unittest/_torch/executor/test_overlap_scheduler.py
+++ b/tests/unittest/_torch/executor/test_overlap_scheduler.py
@@ -100,7 +100,8 @@ def test_overlap_scheduler_consistency(model_path, test_case, sampler_type,
 
     # Verify outputs are consistent
     for with_overlap, without_overlap in zip(texts_with_overlap,
-                                             texts_without_overlap):
+                                             texts_without_overlap,
+                                             strict=True):
         assert with_overlap == without_overlap
 
 
@@ -154,8 +155,48 @@ def test_overlap_scheduler_with_block_reuse(model_path, test_case, sampler_type,
         ] for request_output in outputs_without_overlap]
 
     for with_overlap, without_overlap in zip(texts_with_overlap,
-                                             texts_without_overlap):
+                                             texts_without_overlap,
+                                             strict=True):
         assert with_overlap == without_overlap
+
+
+@pytest.mark.parametrize("sampler_type", ["TorchSampler", "TRTLLMSampler"])
+@pytest.mark.high_cuda_memory
+@pytest.mark.mpi_ray_parity
+def test_overlap_scheduler_block_reuse_cache_hit(model_path, test_case,
+                                                 sampler_type):
+    """Verify that blocks are actually reused when sending the same prompts
+    twice with the overlap scheduler enabled."""
+    prompts = test_case["prompts"]
+    max_new_tokens = test_case["max_new_tokens"]
+    temperature = test_case["temperature"]
+    top_p = test_case["top_p"]
+    stop_words = test_case["stop_words"]
+
+    sampling_config = SamplingParams(max_tokens=max_new_tokens,
+                                     stop=stop_words,
+                                     temperature=temperature,
+                                     top_p=top_p,
+                                     n=1,
+                                     use_beam_search=True)
+
+    with create_llm(model_path,
+                    disable_overlap_scheduler=False,
+                    sampler_type=sampler_type,
+                    enable_block_reuse=True) as llm:
+        outputs_first = llm.generate(prompts,
+                                     sampling_params=sampling_config,
+                                     use_tqdm=True)
+        for output in outputs_first:
+            assert output.outputs[0].cached_tokens == 0, (
+                "First pass should have no cached tokens (cold cache)")
+
+        outputs_second = llm.generate(prompts,
+                                      sampling_params=sampling_config,
+                                      use_tqdm=True)
+        for output in outputs_second:
+            assert output.outputs[0].cached_tokens > 0, (
+                "Second pass should reuse cached blocks")
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/executor/test_overlap_scheduler.py
+++ b/tests/unittest/_torch/executor/test_overlap_scheduler.py
@@ -53,10 +53,13 @@ def create_llm(model_dir,
 @pytest.mark.parametrize("sampler_type", ["TorchSampler", "TRTLLMSampler"])
 @pytest.mark.parametrize("use_python_scheduler", [False, True],
                          ids=["cpp_scheduler", "python_scheduler"])
+@pytest.mark.parametrize("enable_block_reuse", [False, True],
+                         ids=["no_reuse", "block_reuse"])
 @pytest.mark.high_cuda_memory
 @pytest.mark.mpi_ray_parity
 def test_overlap_scheduler_consistency(model_path, test_case, sampler_type,
-                                       use_python_scheduler):
+                                       use_python_scheduler,
+                                       enable_block_reuse):
     scheduler_config = SchedulerConfig(
         use_python_scheduler=use_python_scheduler)
 
@@ -78,7 +81,8 @@ def test_overlap_scheduler_consistency(model_path, test_case, sampler_type,
     with create_llm(model_path,
                     disable_overlap_scheduler=False,
                     sampler_type=sampler_type,
-                    scheduler_config=scheduler_config) as llm:
+                    scheduler_config=scheduler_config,
+                    enable_block_reuse=enable_block_reuse) as llm:
         outputs_with_overlap = llm.generate(prompts,
                                             sampling_params=sampling_config,
                                             use_tqdm=True)
@@ -90,7 +94,8 @@ def test_overlap_scheduler_consistency(model_path, test_case, sampler_type,
     with create_llm(model_path,
                     disable_overlap_scheduler=True,
                     sampler_type=sampler_type,
-                    scheduler_config=scheduler_config) as llm:
+                    scheduler_config=scheduler_config,
+                    enable_block_reuse=enable_block_reuse) as llm:
         outputs_without_overlap = llm.generate(prompts,
                                                sampling_params=sampling_config,
                                                use_tqdm=True)
@@ -99,61 +104,6 @@ def test_overlap_scheduler_consistency(model_path, test_case, sampler_type,
         ] for request_output in outputs_without_overlap]
 
     # Verify outputs are consistent
-    for with_overlap, without_overlap in zip(texts_with_overlap,
-                                             texts_without_overlap,
-                                             strict=True):
-        assert with_overlap == without_overlap
-
-
-@pytest.mark.parametrize("sampler_type", ["TorchSampler", "TRTLLMSampler"])
-@pytest.mark.parametrize("use_python_scheduler", [False, True],
-                         ids=["cpp_scheduler", "python_scheduler"])
-@pytest.mark.high_cuda_memory
-@pytest.mark.mpi_ray_parity
-def test_overlap_scheduler_with_block_reuse(model_path, test_case, sampler_type,
-                                            use_python_scheduler):
-    """Verify that overlap scheduler with block_reuse produces the same
-    results as without overlap scheduler (with block_reuse enabled in both)."""
-    scheduler_config = SchedulerConfig(
-        use_python_scheduler=use_python_scheduler)
-
-    prompts = test_case["prompts"]
-    max_new_tokens = test_case["max_new_tokens"]
-    temperature = test_case["temperature"]
-    top_p = test_case["top_p"]
-    stop_words = test_case["stop_words"]
-
-    sampling_config = SamplingParams(max_tokens=max_new_tokens,
-                                     stop=stop_words,
-                                     temperature=temperature,
-                                     top_p=top_p,
-                                     n=1,
-                                     use_beam_search=True)
-
-    with create_llm(model_path,
-                    disable_overlap_scheduler=False,
-                    sampler_type=sampler_type,
-                    scheduler_config=scheduler_config,
-                    enable_block_reuse=True) as llm:
-        outputs_with_overlap = llm.generate(prompts,
-                                            sampling_params=sampling_config,
-                                            use_tqdm=True)
-        texts_with_overlap = [[
-            completion.text for completion in request_output.outputs
-        ] for request_output in outputs_with_overlap]
-
-    with create_llm(model_path,
-                    disable_overlap_scheduler=True,
-                    sampler_type=sampler_type,
-                    scheduler_config=scheduler_config,
-                    enable_block_reuse=True) as llm:
-        outputs_without_overlap = llm.generate(prompts,
-                                               sampling_params=sampling_config,
-                                               use_tqdm=True)
-        texts_without_overlap = [[
-            completion.text for completion in request_output.outputs
-        ] for request_output in outputs_without_overlap]
-
     for with_overlap, without_overlap in zip(texts_with_overlap,
                                              texts_without_overlap,
                                              strict=True):

--- a/tests/unittest/_torch/executor/test_overlap_scheduler.py
+++ b/tests/unittest/_torch/executor/test_overlap_scheduler.py
@@ -188,14 +188,14 @@ def test_overlap_scheduler_block_reuse_cache_hit(model_path, test_case,
                                      sampling_params=sampling_config,
                                      use_tqdm=True)
         for output in outputs_first:
-            assert output.outputs[0].cached_tokens == 0, (
+            assert output.cached_tokens == 0, (
                 "First pass should have no cached tokens (cold cache)")
 
         outputs_second = llm.generate(prompts,
                                       sampling_params=sampling_config,
                                       use_tqdm=True)
         for output in outputs_second:
-            assert output.outputs[0].cached_tokens > 0, (
+            assert output.cached_tokens > 0, (
                 "Second pass should reuse cached blocks")
 
 

--- a/tests/unittest/_torch/executor/test_overlap_scheduler.py
+++ b/tests/unittest/_torch/executor/test_overlap_scheduler.py
@@ -25,14 +25,16 @@ def model_path():
 def create_llm(model_dir,
                disable_overlap_scheduler,
                sampler_type,
-               scheduler_config=None):
+               scheduler_config=None,
+               enable_block_reuse=False):
     """Create LLM with specific overlap scheduler setting"""
     if scheduler_config is None:
         scheduler_config = SchedulerConfig()
     pytorch_config = dict(disable_overlap_scheduler=disable_overlap_scheduler,
                           sampler_type=sampler_type)
 
-    trt_kv_cache_config = TRT_KvCacheConfig(enable_block_reuse=False)
+    trt_kv_cache_config = TRT_KvCacheConfig(
+        enable_block_reuse=enable_block_reuse)
 
     return LLM(
         model=str(model_dir),
@@ -97,6 +99,60 @@ def test_overlap_scheduler_consistency(model_path, test_case, sampler_type,
         ] for request_output in outputs_without_overlap]
 
     # Verify outputs are consistent
+    for with_overlap, without_overlap in zip(texts_with_overlap,
+                                             texts_without_overlap):
+        assert with_overlap == without_overlap
+
+
+@pytest.mark.parametrize("sampler_type", ["TorchSampler", "TRTLLMSampler"])
+@pytest.mark.parametrize("use_python_scheduler", [False, True],
+                         ids=["cpp_scheduler", "python_scheduler"])
+@pytest.mark.high_cuda_memory
+@pytest.mark.mpi_ray_parity
+def test_overlap_scheduler_with_block_reuse(model_path, test_case, sampler_type,
+                                            use_python_scheduler):
+    """Verify that overlap scheduler with block_reuse produces the same
+    results as without overlap scheduler (with block_reuse enabled in both)."""
+    scheduler_config = SchedulerConfig(
+        use_python_scheduler=use_python_scheduler)
+
+    prompts = test_case["prompts"]
+    max_new_tokens = test_case["max_new_tokens"]
+    temperature = test_case["temperature"]
+    top_p = test_case["top_p"]
+    stop_words = test_case["stop_words"]
+
+    sampling_config = SamplingParams(max_tokens=max_new_tokens,
+                                     stop=stop_words,
+                                     temperature=temperature,
+                                     top_p=top_p,
+                                     n=1,
+                                     use_beam_search=True)
+
+    with create_llm(model_path,
+                    disable_overlap_scheduler=False,
+                    sampler_type=sampler_type,
+                    scheduler_config=scheduler_config,
+                    enable_block_reuse=True) as llm:
+        outputs_with_overlap = llm.generate(prompts,
+                                            sampling_params=sampling_config,
+                                            use_tqdm=True)
+        texts_with_overlap = [[
+            completion.text for completion in request_output.outputs
+        ] for request_output in outputs_with_overlap]
+
+    with create_llm(model_path,
+                    disable_overlap_scheduler=True,
+                    sampler_type=sampler_type,
+                    scheduler_config=scheduler_config,
+                    enable_block_reuse=True) as llm:
+        outputs_without_overlap = llm.generate(prompts,
+                                               sampling_params=sampling_config,
+                                               use_tqdm=True)
+        texts_without_overlap = [[
+            completion.text for completion in request_output.outputs
+        ] for request_output in outputs_without_overlap]
+
     for with_overlap, without_overlap in zip(texts_with_overlap,
                                              texts_without_overlap):
         assert with_overlap == without_overlap


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disaggregated serving now supports KV cache block reuse and overlap scheduler enabled simultaneously.

* **Tests**
  * Added comprehensive test coverage for overlap scheduler configurations with block reuse enabled across different sampler types and scheduler settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Re-enable KV cache block reuse (prefix caching) when the overlap scheduler is active. Block reuse and the overlap scheduler were previously mutually exclusive due to an explicit guard in `base_worker.py` that rejected context-only requests in disaggregated serving when both features were enabled.

### Problem

Block reuse (`enable_block_reuse`, default `True`) and the overlap scheduler (`disable_overlap_scheduler=False`, default) are both enabled by default, but their combination was explicitly blocked for disaggregated context-only requests. Analysis shows the combination is functionally correct with the original loop ordering. The only effect is a one-iteration delay in block availability for the radix-tree lookup, which is a minor performance miss, not a correctness issue.

### Root cause

Removing the guard exposed a latent issue in `_handle_responses`: when `enable_partial_reuse_for_disagg` was True, context-only requests were terminated unconditionally — even while their KV cache was still being transferred to the generation server. This caused double-termination when `_end_transfer_and_maybe_terminate` later processed the same request, leading to hangs in the disaggregated context-only + overlap + block_reuse flow.

The underlying issue is that the early-termination path assumed pinned blocks were sufficient protection during KV transfer. While pinning does protect the blocks themselves from eviction, the request lifecycle was not accounted for: the `end_transfer` callback later attempts to terminate the same request again. Under the non-overlap scheduler this was benign (the transfer typically completed before `_handle_responses` ran), but under the overlap scheduler the deferred processing created a window where both code paths could race on the same request.

### Changes

**`tensorrt_llm/executor/base_worker.py`**
- Remove the `ValueError` guard that rejected context-only requests when overlap scheduler, block reuse, and KV cache transceiver were all active.

**`tensorrt_llm/_torch/pyexecutor/py_executor.py`**
- Fix the root cause: in `_handle_responses`, skip termination for requests whose KV cache is still being transferred  (`is_disagg_context_transmission_state`). The async transfer manager handles termination when the transfer completes via `_end_transfer_and_maybe_terminate`.
- Fix `end_transfer` to return `False` (instead of bare `return`) on `KeyError`, preventing unintended termination by the caller.
- Refactor `_handle_responses` for readability:
- Extract `_maybe_update_speculation_gate()` — flattens the 5-level-deep speculation gate nesting into a guard-clause helper.
- Extract `_should_emit_response()` — names the streaming/final response condition.
- Collapse the duplicate termination branches (both branches had the same `is_disagg_context_transmission_state` check after the fix).
- Use early `continue` to flatten the done/not-done flow.

**`tests/unittest/_torch/executor/test_overlap_scheduler.py`**
- Add `enable_block_reuse` parameter to `create_llm` helper and to `test_overlap_scheduler_consistency` as a parametrized axis (`[False, True]`), so the existing consistency test now covers both block reuse configurations.
- Add `test_overlap_scheduler_block_reuse_cache_hit` — sends the same prompts twice and verifies blocks are actually reused (`cached_tokens > 0` on second pass).
- Add `strict=True` to all `zip()` calls for length-mismatch safety.

**`tests/integration/defs/accuracy/test_disaggregated_serving.py`**
- Remove `pytest.skip` for the overlap + block reuse combination on context servers.
- Enable `enable_block_reuse` unconditionally in `_test_chunked_prefill_helper` (was gated on `ctx_pp == 1`; regular block reuse has no PP restriction).

**`tests/integration/defs/disaggregated/test_configs/disagg_config_overlap.yaml`**
- Enable `enable_block_reuse: true` on both context and generation servers to exercise the full block reuse path in the disaggregated overlap test.

## Test Coverage

| Test | What it covers |
|------|---------------|
| `test_overlap_scheduler_consistency[no_reuse-*]` | Existing: overlap vs. non-overlap consistency (block reuse OFF) |
| `test_overlap_scheduler_consistency[block_reuse-*]` | **New parameter**: overlap vs. non-overlap consistency (block reuse ON) |
| `test_overlap_scheduler_block_reuse_cache_hit` | **New**: verifies blocks are actually reused (`cached_tokens > 0`) |
| `test_auto_dtype` (disaggregated) | **Unblocked**: overlap + block reuse + context-only + disaggregated serving |
| `disagg_config_overlap.yaml` test | **Updated**: now exercises block reuse in disaggregated overlap config |


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
