### PR TITLE
[None][feat] Add SJF (Shortest Job First) waiting queue scheduling policy

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1327,6 +1327,8 @@ def create_py_executor_instance(
     waiting_queue_policy = (scheduler_config.waiting_queue_policy
                             if scheduler_config is not None else
                             WaitingQueuePolicy.FCFS)
+    sjf_config = (scheduler_config.sjf_config
+                  if scheduler_config is not None else None)
     return PyExecutor(
         resource_manager,
         scheduler,
@@ -1351,7 +1353,8 @@ def create_py_executor_instance(
         peft_cache_config=peft_cache_config,
         virtual_memory_pools=virtual_memory_pools,
         execution_stream=execution_stream,
-        waiting_queue_policy=waiting_queue_policy)
+        waiting_queue_policy=waiting_queue_policy,
+        sjf_config=sjf_config)
 
 
 def create_torch_sampler_args(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -31,7 +31,8 @@ from tensorrt_llm.bindings.executor import (DisServingRequestStats,
                                             StaticBatchingStats)
 from tensorrt_llm.bindings.internal.batch_manager import (LlmRequestType,
                                                           ReqIdsSet)
-from tensorrt_llm.llmapi.llm_args import PeftCacheConfig, WaitingQueuePolicy
+from tensorrt_llm.llmapi.llm_args import (PeftCacheConfig, SjfConfig,
+                                          WaitingQueuePolicy)
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import CpType
 from tensorrt_llm.runtime.generation import CUASSERT
@@ -286,6 +287,7 @@ class PyExecutor:
             hang_detection_timeout: Optional[int] = None,
             execution_stream: Optional[torch.cuda.Stream] = None,
             waiting_queue_policy: WaitingQueuePolicy = WaitingQueuePolicy.FCFS,
+            sjf_config: Optional[SjfConfig] = None,
             adp_router: Optional[ADPRouter] = None):
         super(PyExecutor, self).__init__()
         self.device_id = torch.cuda.current_device()
@@ -497,7 +499,7 @@ class PyExecutor:
 
         # Waiting queue for requests that have been fetched but not yet scheduled
         self.waiting_queue: WaitingQueue = create_waiting_queue(
-            waiting_queue_policy)
+            waiting_queue_policy, sjf_config=sjf_config)
 
         self.control_request_barrier = threading.Event()
         self.control_action_done = threading.Event()

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/__init__.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@ Scheduler module for TensorRT-LLM PyExecutor.
 
 This module contains:
 - Request schedulers (capacity, micro-batch, unified)
-- Waiting queues (FCFS)
+- Waiting queues (FCFS, SJF)
 """
 
 # Re-export from scheduler.py
@@ -40,7 +40,7 @@ from .scheduler import (
 from .scheduler_v2 import KVCacheV2Scheduler
 
 # Re-export from waiting_queue.py
-from .waiting_queue import FCFSWaitingQueue, WaitingQueue, create_waiting_queue
+from .waiting_queue import FCFSWaitingQueue, SJFWaitingQueue, WaitingQueue, create_waiting_queue
 
 __all__ = [
     # Schedulers
@@ -64,6 +64,7 @@ __all__ = [
     "RankState",
     # Waiting queues
     "FCFSWaitingQueue",
+    "SJFWaitingQueue",
     "WaitingQueue",
     "create_waiting_queue",
 ]

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -1,9 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import time
 from abc import ABC, abstractmethod
 from collections import deque
 from collections.abc import Iterable, Iterator
 from typing import Callable, Optional
 
-from tensorrt_llm.llmapi.llm_args import WaitingQueuePolicy
+from tensorrt_llm.llmapi.llm_args import SjfConfig, WaitingQueuePolicy
 
 from ..executor_request_queue import RequestQueueItem
 
@@ -114,21 +131,149 @@ class FCFSWaitingQueue(deque, WaitingQueue):
         return super().__iter__()
 
 
+class SJFWaitingQueue(WaitingQueue):
+    """Shortest-Job-First waiting queue with wait-time aging.
+
+    Prioritizes shorter requests while using aging to prevent starvation.
+    Score = length_weight * length_score + time_weight * time_score
+    where length_score = 1/(1 + prompt_len/length_median) and
+    time_score = wait_time/time_median.
+
+    Internally maintains two lists:
+    - _prepended: requests returned via prepend_request(s), served first
+    - _requests: new requests, lazily sorted by SJF score on peek/pop
+    """
+
+    def __init__(self, sjf_config: Optional[SjfConfig] = None):
+        # _requests is sorted ascending so the best item is at the end (O(1) pop)
+        self._requests: list[RequestQueueItem] = []
+        self._prepended: deque[RequestQueueItem] = deque()
+        self._sorted = False
+        self._config = sjf_config or SjfConfig()
+        self._arrival_times: dict[int, float] = {}
+
+    def _get_arrival_time(self, item: RequestQueueItem,
+                          now: float) -> float:
+        arrival = getattr(item.request, "py_arrival_time",
+                          None) if item.request else None
+        if arrival is not None:
+            return arrival
+        return self._arrival_times.get(item.id, now)
+
+    def _compute_score(self, item: RequestQueueItem, now: float) -> float:
+        prompt_len = (
+            len(item.request.input_token_ids)
+            if item.request and item.request.input_token_ids
+            else 0
+        )
+        wait_time = max(0.0, now - self._get_arrival_time(item, now))
+        length_score = 1.0 / (1.0 + prompt_len / self._config.length_median)
+        time_score = wait_time / self._config.time_median
+        return self._config.length_weight * length_score + self._config.time_weight * time_score
+
+    def _ensure_sorted(self) -> None:
+        if not self._sorted and self._requests:
+            now = time.time()
+            # Sort ascending so highest-score item is at the end (O(1) pop)
+            self._requests.sort(
+                key=lambda item: self._compute_score(item, now))
+            self._sorted = True
+
+    def add_request(self, request: RequestQueueItem) -> None:
+        """Add a request to the queue."""
+        if (
+            not request.request
+            or not hasattr(request.request, "py_arrival_time")
+            or request.request.py_arrival_time is None
+        ):
+            self._arrival_times[request.id] = time.time()
+        self._requests.append(request)
+        self._sorted = False
+
+    def add_requests(self, requests: Iterable[RequestQueueItem]) -> None:
+        """Add multiple requests to the queue."""
+        for request in requests:
+            self.add_request(request)
+
+    def pop_request(self) -> RequestQueueItem:
+        """Pop the highest-priority request."""
+        if self._prepended:
+            item = self._prepended.popleft()
+            self._arrival_times.pop(item.id, None)
+            return item
+        self._ensure_sorted()
+        if not self._requests:
+            raise IndexError("pop from an empty queue")
+        item = self._requests.pop()  # O(1) from end (highest score)
+        self._arrival_times.pop(item.id, None)
+        return item
+
+    def peek_request(self) -> RequestQueueItem:
+        """Peek at the highest-priority request without removing it."""
+        if self._prepended:
+            return self._prepended[0]
+        self._ensure_sorted()
+        if not self._requests:
+            raise IndexError("peek from an empty queue")
+        return self._requests[-1]  # highest score is at the end
+
+    def prepend_request(self, request: RequestQueueItem) -> None:
+        """Prepend a request to the front of the queue."""
+        self._prepended.appendleft(request)
+
+    def prepend_requests(self, requests: Iterable[RequestQueueItem]) -> None:
+        """Prepend requests to the front of the queue.
+
+        Note: Matches FCFSWaitingQueue semantics — uses extendleft which
+        reverses the order. The caller (request_utils.py) passes
+        reversed(pending_requests), so the net effect is that
+        pending_requests appear at the front in their original order.
+        """
+        self._prepended.extendleft(requests)
+
+    def remove_by_ids(self, request_ids: set[int]) -> None:
+        """Remove requests with the given IDs."""
+        self._prepended = deque(
+            req for req in self._prepended if req.id not in request_ids)
+        self._requests = [
+            req for req in self._requests if req.id not in request_ids]
+        for rid in request_ids:
+            self._arrival_times.pop(rid, None)
+
+    def __bool__(self) -> bool:
+        """Check if queue has any requests."""
+        return bool(self._prepended) or bool(self._requests)
+
+    def __len__(self) -> int:
+        """Get number of requests in queue."""
+        return len(self._prepended) + len(self._requests)
+
+    def __iter__(self) -> Iterator[RequestQueueItem]:
+        """Iterate over the queue (prepended first, then sorted requests)."""
+        self._ensure_sorted()
+        return itertools.chain(self._prepended,
+                               reversed(self._requests)).__iter__()
+
+
 def create_waiting_queue(
     policy: WaitingQueuePolicy = WaitingQueuePolicy.FCFS,
     priority_fn: Optional[Callable[[RequestQueueItem], float]] = None,
+    sjf_config: Optional[SjfConfig] = None,
 ) -> WaitingQueue:
     """Create a waiting queue based on the specified policy.
 
     Args:
-        policy: The scheduling policy to use. Currently only FCFS is supported.
+        policy: The scheduling policy to use.
         priority_fn: Reserved for future use.
+        sjf_config: Configuration for SJF scheduling. Only used when
+            policy is SJF.
 
     Returns:
         A WaitingQueue instance.
     """
-    # Currently only FCFS is implemented
     if policy == WaitingQueuePolicy.FCFS:
         return FCFSWaitingQueue()
+    elif policy == WaitingQueuePolicy.SJF:
+        return SJFWaitingQueue(sjf_config)
     else:
         raise ValueError(f"Unsupported waiting queue policy: {policy}")

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1857,6 +1857,39 @@ class WaitingQueuePolicy(StrEnum):
     """Waiting queue scheduling policy for managing pending requests."""
 
     FCFS = "fcfs"  # First-Come-First-Served
+    SJF = "sjf"  # Shortest-Job-First
+
+
+class SjfConfig(StrictBaseModel):
+    """Configuration for SJF (Shortest Job First) waiting queue scheduling.
+
+    SJF prioritizes shorter requests while using wait-time aging to prevent
+    starvation of longer requests. The score is computed as:
+        score = length_weight * length_score + time_weight * time_score
+    where:
+        length_score = 1 / (1 + prompt_len / length_median)
+        time_score = wait_time / time_median
+    """
+
+    length_median: PositiveInt = Field(
+        default=32768,
+        description=
+        "Median prompt length (in tokens) for normalization. Requests shorter "
+        "than this get a length_score > 0.5, longer ones get < 0.5.")
+
+    time_median: float = Field(
+        default=5.0,
+        gt=0.0,
+        description=
+        "Median wait time (in seconds) for normalization. After waiting this "
+        "long, a request's time_score reaches 1.0.")
+
+    length_weight: NonNegativeFloat = Field(
+        default=0.5, description="Weight for the length-based score component.")
+
+    time_weight: NonNegativeFloat = Field(
+        default=0.5,
+        description="Weight for the wait-time-based score component.")
 
 
 @PybindMirror.mirror_pybind_fields(_DynamicBatchConfig)
@@ -1907,9 +1940,23 @@ class SchedulerConfig(StrictBaseModel, PybindMirror):
         default=WaitingQueuePolicy.FCFS,
         description="The waiting queue scheduling policy")
 
+    sjf_config: Optional[SjfConfig] = Field(
+        default=None,
+        description=
+        "Configuration for SJF waiting queue scheduling. Only used when "
+        "waiting_queue_policy is 'sjf'. If not provided, defaults are used.")
+
     use_python_scheduler: bool = Field(
         default=False,
         description="Use pure-Python scheduler instead of C++ scheduler.")
+
+    @model_validator(mode='after')
+    def validate_sjf_config(self) -> 'SchedulerConfig':
+        if (self.sjf_config is not None
+                and self.waiting_queue_policy != WaitingQueuePolicy.SJF):
+            raise ValueError(
+                "sjf_config is only used when waiting_queue_policy is 'sjf'")
+        return self
 
     def _to_pybind(self):
         return _SchedulerConfig(

--- a/tests/unittest/_torch/executor/test_waiting_queue.py
+++ b/tests/unittest/_torch/executor/test_waiting_queue.py
@@ -1,11 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Tests for WaitingQueue implementations.
 
 This module tests the waiting queue functionality including:
 - FCFSWaitingQueue operations
+- SJFWaitingQueue operations
 - WaitingQueue abstract interface
 - create_waiting_queue factory function
 """
 
+import time
 from unittest.mock import Mock
 
 import pytest
@@ -13,15 +29,27 @@ import pytest
 from tensorrt_llm._torch.pyexecutor.executor_request_queue import RequestQueueItem
 from tensorrt_llm._torch.pyexecutor.scheduler import (
     FCFSWaitingQueue,
+    SJFWaitingQueue,
     WaitingQueue,
     create_waiting_queue,
 )
-from tensorrt_llm.llmapi.llm_args import WaitingQueuePolicy
+from tensorrt_llm.llmapi.llm_args import (SchedulerConfig, SjfConfig,
+                                          WaitingQueuePolicy)
 
 
 def create_mock_request_item(request_id: int) -> RequestQueueItem:
     """Create a mock RequestQueueItem for testing."""
     mock_request = Mock()
+    return RequestQueueItem(request_id, mock_request)
+
+
+def create_sjf_request_item(
+    request_id: int, prompt_len: int, arrival_time: float = None
+) -> RequestQueueItem:
+    """Create a RequestQueueItem with SJF-relevant fields set."""
+    mock_request = Mock()
+    mock_request.input_token_ids = list(range(prompt_len))
+    mock_request.py_arrival_time = arrival_time
     return RequestQueueItem(request_id, mock_request)
 
 
@@ -175,6 +203,263 @@ class TestFCFSWaitingQueue:
         assert isinstance(queue, WaitingQueue)
 
 
+class TestSJFWaitingQueue:
+    """Tests for SJFWaitingQueue."""
+
+    def test_short_requests_pop_first(self):
+        """Short requests should be popped before long requests."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        # Long request (10000 tokens) added first
+        queue.add_request(create_sjf_request_item(1, 10000, now))
+        # Short request (100 tokens) added second
+        queue.add_request(create_sjf_request_item(2, 100, now))
+
+        # Short request should pop first despite arriving second
+        assert queue.pop_request().id == 2
+        assert queue.pop_request().id == 1
+
+    def test_equal_length_pops_by_wait_time(self):
+        """Equal-length requests should pop in order of wait time (older first)."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        queue.add_request(create_sjf_request_item(1, 1000, now - 10))
+        queue.add_request(create_sjf_request_item(2, 1000, now - 1))
+
+        # Older request (waited 10s) should pop first
+        assert queue.pop_request().id == 1
+        assert queue.pop_request().id == 2
+
+    def test_aging_prevents_starvation(self):
+        """Long requests with enough wait time should eventually get priority."""
+        now = time.time()
+        # Use config where time aging is strong
+        config = SjfConfig(length_weight=0.5, time_weight=0.5, time_median=1.0)
+        queue = SJFWaitingQueue(config)
+
+        # Long request that has been waiting 100 seconds
+        queue.add_request(create_sjf_request_item(1, 50000, now - 100))
+        # Short request that just arrived
+        queue.add_request(create_sjf_request_item(2, 100, now))
+
+        # Long request should pop first due to massive wait time
+        # score_long = 0.5 * 1/(1+50000/32768) + 0.5 * 100/1.0 = ~0.20 + 50 = ~50.2
+        # score_short = 0.5 * 1/(1+100/32768) + 0.5 * 0/1.0 = ~0.498 + 0 = ~0.498
+        assert queue.pop_request().id == 1
+
+    def test_peek_pop_consistency(self):
+        """peek_request and pop_request should return the same item."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        queue.add_request(create_sjf_request_item(1, 5000, now))
+        queue.add_request(create_sjf_request_item(2, 100, now))
+        queue.add_request(create_sjf_request_item(3, 20000, now))
+
+        peeked = queue.peek_request()
+        popped = queue.pop_request()
+        assert peeked.id == popped.id
+
+    def test_add_request(self):
+        """Test adding a single request."""
+        queue = SJFWaitingQueue()
+        item = create_sjf_request_item(1, 100, time.time())
+        queue.add_request(item)
+        assert len(queue) == 1
+
+    def test_add_requests(self):
+        """Test adding multiple requests."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        items = [create_sjf_request_item(i, 100 * (i + 1), now) for i in range(3)]
+        queue.add_requests(items)
+        assert len(queue) == 3
+
+    def test_pop_from_empty_queue(self):
+        """Test that pop_request raises IndexError on empty queue."""
+        queue = SJFWaitingQueue()
+        with pytest.raises(IndexError):
+            queue.pop_request()
+
+    def test_peek_from_empty_queue(self):
+        """Test that peek_request raises IndexError on empty queue."""
+        queue = SJFWaitingQueue()
+        with pytest.raises(IndexError):
+            queue.peek_request()
+
+    def test_prepend_request(self):
+        """Prepended request should be popped first."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        # Add a short request
+        queue.add_request(create_sjf_request_item(1, 100, now))
+        # Prepend a long request — should still pop first
+        queue.prepend_request(create_sjf_request_item(2, 99999, now))
+
+        assert queue.pop_request().id == 2
+        assert queue.pop_request().id == 1
+
+    def test_prepend_requests_order(self):
+        """Prepended requests maintain extendleft semantics (reversed)."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        queue.add_request(create_sjf_request_item(3, 100, now))
+
+        # Simulate caller pattern: reversed([item1, item2])
+        items = [create_sjf_request_item(i, 100, now) for i in [1, 2]]
+        queue.prepend_requests(items)
+
+        # After extendleft-style reversal of [1, 2], order is: 2, 1, 3
+        assert queue.pop_request().id == 2
+        assert queue.pop_request().id == 1
+        assert queue.pop_request().id == 3
+
+    def test_remove_by_ids(self):
+        """Test removing requests by their IDs."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        for i in range(5):
+            queue.add_request(create_sjf_request_item(i, 100, now))
+
+        queue.remove_by_ids({1, 3})
+        assert len(queue) == 3
+        remaining_ids = [item.id for item in queue]
+        assert set(remaining_ids) == {0, 2, 4}
+
+    def test_remove_from_prepended(self):
+        """Test removing IDs that are in the prepended list."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        queue.add_request(create_sjf_request_item(1, 100, now))
+        queue.prepend_request(create_sjf_request_item(2, 100, now))
+
+        queue.remove_by_ids({2})
+        assert len(queue) == 1
+        assert queue.pop_request().id == 1
+
+    def test_bool_empty_queue(self):
+        """Test bool conversion for empty queue."""
+        queue = SJFWaitingQueue()
+        assert not queue
+
+    def test_bool_nonempty_queue(self):
+        """Test bool conversion for non-empty queue."""
+        queue = SJFWaitingQueue()
+        queue.add_request(create_sjf_request_item(1, 100, time.time()))
+        assert queue
+
+    def test_bool_only_prepended(self):
+        """Queue with only prepended items should be truthy."""
+        queue = SJFWaitingQueue()
+        queue.prepend_request(create_sjf_request_item(1, 100, time.time()))
+        assert queue
+        assert len(queue) == 1
+
+    def test_len(self):
+        """Test length includes both prepended and regular requests."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        queue.add_request(create_sjf_request_item(1, 100, now))
+        queue.add_request(create_sjf_request_item(2, 100, now))
+        queue.prepend_request(create_sjf_request_item(3, 100, now))
+        assert len(queue) == 3
+
+    def test_iter(self):
+        """Test iteration returns prepended first, then sorted requests."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        # Add long then short
+        queue.add_request(create_sjf_request_item(1, 10000, now))
+        queue.add_request(create_sjf_request_item(2, 100, now))
+        # Prepend one
+        queue.prepend_request(create_sjf_request_item(3, 50000, now))
+
+        iterated_ids = [item.id for item in queue]
+        # Prepended first (3), then sorted by score: short (2), long (1)
+        assert iterated_ids == [3, 2, 1]
+        # Iteration should not consume items
+        assert len(queue) == 3
+
+    def test_is_waiting_queue_subclass(self):
+        """Test that SJFWaitingQueue is a WaitingQueue."""
+        queue = SJFWaitingQueue()
+        assert isinstance(queue, WaitingQueue)
+
+    def test_custom_config(self):
+        """Test that custom SjfConfig parameters are respected."""
+        now = time.time()
+        # Heavy length weight, no time weight
+        config = SjfConfig(length_weight=1.0, time_weight=0.0)
+        queue = SJFWaitingQueue(config)
+
+        # Even though request 1 has waited much longer, length_weight=1, time_weight=0
+        queue.add_request(create_sjf_request_item(1, 10000, now - 1000))
+        queue.add_request(create_sjf_request_item(2, 100, now))
+
+        # Short request should still win since time_weight=0
+        assert queue.pop_request().id == 2
+
+    def test_no_arrival_time_fallback(self):
+        """Requests without py_arrival_time should still work."""
+        queue = SJFWaitingQueue()
+        # Create request without arrival time
+        item = create_sjf_request_item(1, 100, arrival_time=None)
+        queue.add_request(item)
+        assert len(queue) == 1
+        assert queue.pop_request().id == 1
+
+    def test_dirty_flag_reset_on_add(self):
+        """Adding a request after sort should trigger re-sort on next peek."""
+        now = time.time()
+        queue = SJFWaitingQueue()
+        queue.add_request(create_sjf_request_item(1, 10000, now))
+        queue.add_request(create_sjf_request_item(2, 5000, now))
+
+        # Trigger sort
+        assert queue.peek_request().id == 2
+
+        # Add a shorter request — should become new best
+        queue.add_request(create_sjf_request_item(3, 100, now))
+        assert queue.peek_request().id == 3
+
+    def test_remove_by_ids_cleans_arrival_times(self):
+        """remove_by_ids should also clean up _arrival_times entries."""
+        queue = SJFWaitingQueue()
+        # Add items without py_arrival_time so _arrival_times is populated
+        item = create_sjf_request_item(1, 100, arrival_time=None)
+        queue.add_request(item)
+        assert 1 in queue._arrival_times
+
+        queue.remove_by_ids({1})
+        assert 1 not in queue._arrival_times
+        assert len(queue._arrival_times) == 0
+
+
+class TestSchedulerConfigValidation:
+    """Tests for SchedulerConfig.sjf_config validation."""
+
+    def test_sjf_config_with_sjf_policy(self):
+        """sjf_config with SJF policy should work."""
+        config = SchedulerConfig(
+            waiting_queue_policy=WaitingQueuePolicy.SJF,
+            sjf_config=SjfConfig(),
+        )
+        assert config.sjf_config is not None
+
+    def test_sjf_config_with_fcfs_policy_raises(self):
+        """sjf_config with FCFS policy should raise ValueError."""
+        with pytest.raises(ValueError, match="sjf_config is only used"):
+            SchedulerConfig(
+                waiting_queue_policy=WaitingQueuePolicy.FCFS,
+                sjf_config=SjfConfig(),
+            )
+
+    def test_sjf_policy_without_config(self):
+        """SJF policy without sjf_config should use defaults."""
+        config = SchedulerConfig(
+            waiting_queue_policy=WaitingQueuePolicy.SJF)
+        assert config.sjf_config is None
+
+
 class TestCreateWaitingQueue:
     """Tests for create_waiting_queue factory function."""
 
@@ -187,3 +472,16 @@ class TestCreateWaitingQueue:
         """Test creating queue with default policy."""
         queue = create_waiting_queue()
         assert isinstance(queue, FCFSWaitingQueue)
+
+    def test_create_sjf_queue(self):
+        """Test creating SJF queue."""
+        queue = create_waiting_queue(WaitingQueuePolicy.SJF)
+        assert isinstance(queue, SJFWaitingQueue)
+
+    def test_create_sjf_queue_with_config(self):
+        """Test creating SJF queue with custom config."""
+        config = SjfConfig(length_median=1024, time_median=10.0)
+        queue = create_waiting_queue(WaitingQueuePolicy.SJF, sjf_config=config)
+        assert isinstance(queue, SJFWaitingQueue)
+        assert queue._config.length_median == 1024
+        assert queue._config.time_median == 10.0


### PR DESCRIPTION
## Summary

Add a Shortest-Job-First (SJF) waiting queue policy that prioritizes shorter requests while using wait-time aging to prevent starvation of longer requests.

### Changes
- Add `SJF` enum value to `WaitingQueuePolicy` and `SjfConfig` Pydantic model in `llm_args.py`
- Implement `SJFWaitingQueue` with lazy sort and dual-list design (`deque` for prepended, sorted `list` for scored requests)
- Wire `sjf_config` through `SchedulerConfig` → `_util.py` → `PyExecutor`
- Add comprehensive unit tests (25+ tests) covering SJF ordering, aging, prepend semantics, config validation, and factory function
- Add `model_validator` on `SchedulerConfig` to reject `sjf_config` when policy is not SJF

### SJF Score Formula
```
score = length_weight * 1/(1 + prompt_len/length_median) + time_weight * wait_time/time_median
```
- Shorter requests get higher scores (prioritized)
- Wait-time aging prevents starvation of longer requests

### Configuration via YAML
```yaml
scheduler_config:
  waiting_queue_policy: sjf
  sjf_config:
    length_median: 32768
    time_median: 5.0
    length_weight: 0.5
    time_weight: 0.5
```

### Design Notes
- **Lazy sorting**: Scores are computed once per scheduling round (on `peek`/`pop`), not on every heap comparison — avoids the `time.time()` overhead seen in vLLM's implementation
- **O(1) pop**: List sorted ascending so `pop()` from end is O(1); `deque` for prepended items gives O(1) `popleft()`
- **Dual-list architecture**: Prepended items (returned by scheduler) are served first without re-scoring; new items are lazily sorted

### Benchmark Results (GB200 x 8, DeepSeek-R1 671B FP8, Agentic Coding workload)
| Metric | FCFS | SJF | Change |
|--------|------|-----|--------|
| TTFT p50 | 289ms | 271ms | **-6.2%** |
| Short request (ISL 0-5K) E2E | 28.4s | 13.8s | **-51%** |
| E2E p99 (ISL 5K-20K) | 396s | 149s | **-62%** |
| Output throughput | 298.5 tok/s | 299.3 tok/s | +0.3% |

## Test plan
- [x] Unit tests pass (`pytest tests/unittest/_torch/executor/test_waiting_queue.py`)
- [x] SJF ordering: short requests pop before long ones
- [x] Aging: long-waiting requests eventually get priority
- [x] Config validation: `sjf_config` rejected with FCFS policy
- [x] Prepend semantics match `FCFSWaitingQueue` (extendleft reversal)
- [ ] CI: `/bot run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shortest-Job-First (SJF) scheduling policy as a new waiting queue scheduling option for improved request prioritization
  * Introduced SjfConfig parameters for tuning SJF behavior with configurable request length and wait time weights, plus normalization medians
  * Added configuration validation to ensure SJF settings are only applied when using SJF scheduling policy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->