### PR TITLE
[TRTLLM-10061][feat] Add stride support for conv1d and fused_sigmoid_gating_delta_rule_update

### DIFF
--- a/cpp/tensorrt_llm/thop/causalConv1dOp.cpp
+++ b/cpp/tensorrt_llm/thop/causalConv1dOp.cpp
@@ -264,9 +264,9 @@ void causalConv1dUpdate(at::Tensor const& x, at::Tensor const& conv_state, at::T
     if (conv_state_indices_.has_value())
     {
         auto conv_state_indices = conv_state_indices_.value();
-        TORCH_CHECK(conv_state_indices.scalar_type() == torch::kInt32)
+        TORCH_CHECK(conv_state_indices.scalar_type() == torch::kInt32);
         TORCH_CHECK(conv_state_indices.is_cuda());
-        TORCH_CHECK(conv_state_indices.stride(0) == 1)
+        TORCH_CHECK(conv_state_indices.is_contiguous());
         CHECK_SHAPE(conv_state_indices, batch_size);
 
         int conv_state_entries = conv_state.size(0);

--- a/tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py
+++ b/tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py
@@ -30,6 +30,8 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     cu_seqlens,
     scale,
     T,
+    s_h0_0,
+    h0_dim0,
     B: tl.constexpr,
     H: tl.constexpr,
     HV: tl.constexpr,
@@ -79,10 +81,12 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
 
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
     if USE_INITIAL_STATE:
-        idx = tl.load(h0_indices + i_n)
+        idx = tl.load(h0_indices + i_n).to(tl.int64)  # prevent int32 overflow
         if idx >= 0:
-            p_h0 = (h0_source + idx * HV * K * V + i_hv * K * V +
-                    o_k[:, None] * V + o_v[None, :])
+            tl.device_assert(idx < h0_dim0,
+                             "idx out of bounds in h0_source load")
+            p_h0 = (h0_source + idx * s_h0_0 + i_hv * K * V + o_k[:, None] * V +
+                    o_v[None, :])
             b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
     for _ in range(0, T):
@@ -145,14 +149,16 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
 
     # Store final state back to h0_source with bounds checking
     if USE_INITIAL_STATE:
-        idx = tl.load(h0_indices + i_n)
+        idx = tl.load(h0_indices + i_n).to(tl.int64)
         if idx >= 0:
-            p_h0 = (h0_source + idx * HV * K * V + i_hv * K * V +
-                    o_k[:, None] * V + o_v[None, :])
+            tl.device_assert(idx < h0_dim0,
+                             "idx out of bounds in h0_source store")
+            p_h0 = (h0_source + idx * s_h0_0 + i_hv * K * V + o_k[:, None] * V +
+                    o_v[None, :])
             tl.store(p_h0, b_h.to(p_h0.dtype.element_ty), mask=mask_h)
 
 
-@input_guard
+@input_guard(exclude_args=["initial_state_source"])
 def fused_sigmoid_gating_delta_rule_update(
     A_log: torch.Tensor,
     a: torch.Tensor,
@@ -191,6 +197,16 @@ def fused_sigmoid_gating_delta_rule_update(
     o = q.new_empty(NK, *v.shape)
     grid = (N * HV, NV, NK)
 
+    if initial_state_source is not None:
+        s_h0_0, s_h0_1, s_h0_2, s_h0_3 = initial_state_source.stride()
+        slot_num = initial_state_source.shape[0]
+        assert s_h0_3 == 1, f"s_h0_3: {s_h0_3} is not 1"
+        assert s_h0_2 == V, f"s_h0_2: {s_h0_2} is not {V}"
+        assert s_h0_1 == K * V, f"s_h0_1: {s_h0_1} is not {K * V}"
+    else:
+        s_h0_0 = 0
+        slot_num = 0
+
     fused_sigmoid_gating_delta_rule_update_kernel[grid](
         A_log=A_log,
         a=a,
@@ -207,6 +223,8 @@ def fused_sigmoid_gating_delta_rule_update(
         cu_seqlens=cu_seqlens,
         scale=scale,
         T=T,
+        s_h0_0=s_h0_0,
+        h0_dim0=slot_num,
         B=B,
         H=H,
         HV=HV,

--- a/tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py
+++ b/tensorrt_llm/_torch/modules/fla/fused_sigmoid_gating_recurrent.py
@@ -151,8 +151,6 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
     if USE_INITIAL_STATE:
         idx = tl.load(h0_indices + i_n).to(tl.int64)
         if idx >= 0:
-            tl.device_assert(idx < h0_dim0,
-                             "idx out of bounds in h0_source store")
             p_h0 = (h0_source + idx * s_h0_0 + i_hv * K * V + o_k[:, None] * V +
                     o_v[None, :])
             tl.store(p_h0, b_h.to(p_h0.dtype.element_ty), mask=mask_h)

--- a/tensorrt_llm/_torch/modules/fla/utils.py
+++ b/tensorrt_llm/_torch/modules/fla/utils.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import functools
+import inspect
 import logging
 import os
 import sys
@@ -130,40 +131,75 @@ def tensor_cache(
     return wrapper
 
 
-def input_guard(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
+def input_guard(fn=None, *, exclude_args: Optional[list[str]] = None):
     """
-    A decorator to make sure all input tensors are contiguous and set the device based on input tensors.
+    A decorator to make sure all input tensors are contiguous and set the
+    device based on input tensors.
+
+    Args:
+        exclude_args: Optional list of parameter names whose tensor arguments
+            should not be made contiguous.
+
+    Usage::
+
+        @input_guard
+        def foo(a, b): ...
+
+        @input_guard(exclude_args=["initial_state_source"])
+        def bar(a, initial_state_source): ...
     """
 
-    @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
-        contiguous_args = (i if not isinstance(i, torch.Tensor) else
-                           i.contiguous() for i in args)
-        contiguous_kwargs = {
-            k: (v if not isinstance(v, torch.Tensor) else v.contiguous())
-            for k, v in kwargs.items()
-        }
+    def decorator(
+            func: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
+        sig = inspect.signature(func) if exclude_args else None
 
-        tensor = None
-        for arg in args:
-            if isinstance(arg, torch.Tensor):
-                tensor = arg
-                break
-        if tensor is None:
-            for value in kwargs.values():
-                if isinstance(value, torch.Tensor):
-                    tensor = value
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if exclude_args and sig is not None:
+                bound = sig.bind(*args, **kwargs)
+                bound.apply_defaults()
+                for name, value in bound.arguments.items():
+                    if isinstance(value,
+                                  torch.Tensor) and name not in exclude_args:
+                        bound.arguments[name] = value.contiguous()
+                contiguous_args = bound.args
+                contiguous_kwargs = bound.kwargs
+            else:
+                contiguous_args = tuple(
+                    i if not isinstance(i, torch.Tensor) else i.contiguous()
+                    for i in args)
+                contiguous_kwargs = {
+                    k:
+                    (v if not isinstance(v, torch.Tensor) else v.contiguous())
+                    for k, v in kwargs.items()
+                }
+
+            tensor = None
+            for arg in args:
+                if isinstance(arg, torch.Tensor):
+                    tensor = arg
                     break
+            if tensor is None:
+                for value in kwargs.values():
+                    if isinstance(value, torch.Tensor):
+                        tensor = value
+                        break
 
-        if tensor is not None:
-            ctx = custom_device_ctx(tensor.device.index)
-        else:
-            ctx = contextlib.nullcontext()
+            if tensor is not None:
+                ctx = custom_device_ctx(tensor.device.index)
+            else:
+                ctx = contextlib.nullcontext()
 
-        with ctx:
-            return fn(*contiguous_args, **contiguous_kwargs)
+            with ctx:
+                return func(*contiguous_args, **contiguous_kwargs)
 
-    return wrapper
+        return wrapper
+
+    if fn is not None:
+        # Called as @input_guard without arguments
+        return decorator(fn)
+    # Called as @input_guard(exclude_args=[...])
+    return decorator
 
 
 contiguous = input_guard


### PR DESCRIPTION
## Summary
- Replace hardcoded `stride(0)==1` check with `is_contiguous()` in `causalConv1dUpdate`
- Use explicit stride parameter (`s_h0_0`) instead of hardcoded `HV*K*V` for `h0_source` indexing in the fused_sigmoid_gating_delta_rule_update triton kernel, enabling non-contiguous `initial_state_source` layouts
- Add `input_guard_exclude` decorator to selectively skip `contiguous()` on specified tensor arguments
- Add int64 cast and device_assert bounds check for safer index computation

## Test plan
- [ ] Existing unit tests pass
- [ ] Integration tests with hybrid linear models using non-contiguous state layouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Optimizations**
  * Improved tensor validation logic for convolutional operations to enhance compatibility
  * Enhanced bounds checking and memory safety in kernel operations
  * Added support for flexible tensor layout handling to improve robustness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->