### PR TITLE
[https://nvbugs/5983390][fix] Remove redundant D2H sync to optimize perf

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -82,7 +82,7 @@ def _compute_slot_mappings(
 
     # on_update_kv_lens() calls this during CUDA graph capture;
     # .all()/.item() would trigger host-device sync and invalidate capture.
-    if not torch.cuda.is_current_stream_capturing():
+    if not block_indices_in_seq.is_cuda:
         max_blocks = block_offsets.shape[1]
         assert (block_indices_in_seq < max_blocks).all(), \
             f"Block index out of bounds: max={max_blocks}, got indices up to {block_indices_in_seq.max().item()}"


### PR DESCRIPTION
## Description

`_compute_slot_mappings()` guards a debug assert with `not is_current_stream_capturing()`, which only skips it during CUDA graph capture. During eager execution, `on_update_kv_lens()` calls this function with GPU tensors from `_preprocess_inputs()` (model_engine.py:1507,1543), and `.all()` triggers a `reduce_kernel<bool>` + 1-byte D2H memcpy + `cudaStreamSynchronize` that stalls **12-15ms** waiting for the GPU queue to drain. This happens **twice per context forward step** (once unconditionally, once for overlap scheduler + MTP), adding ~25ms of GPU bubble per iteration with context requests. Decode-only steps are unaffected.

**Fix**: Guard with `not block_indices_in_seq.is_cuda` instead. The assert still fires on the CPU path (`Indexer.prepare()`) at zero cost, but is skipped on the GPU path (`on_update_kv_lens()`) where block offsets were already validated and clamped during `prepare()`.

**nsys evidence** (DeepSeek-V3.2, TP8, piecewise CUDA graph, c16):
- Context forward steps: 2 syncs/GPU, 12-15ms each → ~25ms total bubble
- Decode-only forward steps: 0 syncs

## Test Coverage

Existing DSA accuracy tests cover correctness. The change only removes a redundant assert on the GPU path; the CPU-path assert is unchanged.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sparse attention backend assertion logic to properly determine when to skip bounds checking based on tensor device placement instead of CUDA stream capture state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->