### PR TITLE
[NVBUG-5941229][fix] Sync CUDA streams before graph capture in PP mode

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -357,6 +357,15 @@ class CUDAGraphRunner:
                 if postprocess_fn is not None:
                     postprocess_fn(capture_inputs)
 
+            # Ensure all async operations from warmup complete before capture.
+            # In PP mode, PPCommNCCL.send uses a separate send_stream for
+            # warmup runs but the capturing stream during capture. Without
+            # this sync, in-flight warmup sends on send_stream can race with
+            # the captured graph's NCCL send during replay, causing NCCL
+            # operation mismatching between PP ranks and a deadlock.
+            if self.config.mapping is not None and self.config.mapping.pp_size > 1:
+                torch.cuda.synchronize()
+
             with torch.cuda.graph(graph, pool=self.memory_pool):
                 output = _setup_spec_decoding_and_forward(
                     key, forward_fn, capture_inputs)


### PR DESCRIPTION
## Summary

- Fixes intermittent deadlock in `TestDeepSeekV3Lite::test_nvfp4_4gpus` (PP4 + CUDA graph + MTP) on GB200 CI ([NVBug 5941229](https://nvbugspro.nvidia.com/bug/5941229))
- Root cause: during CUDA graph warmup, `PPCommNCCL.send` dispatches NCCL sends on a separate `send_stream`. When graph capture begins, sends switch to the capturing stream. Without a sync barrier, in-flight warmup sends on `send_stream` can overlap with the captured graph's NCCL operations during replay, causing NCCL operation mismatching between PP ranks
- Fix: add `torch.cuda.synchronize()` between warmup runs and `torch.cuda.graph()` capture when `pp_size > 1`. This is a one-time cost per graph capture, not per replay

## Details

The race condition occurs in this sequence:
1. Warmup run N: `PPCommNCCL.send` → `is_current_stream_capturing()` returns False → sends on `send_stream`
2. Graph capture begins immediately after warmup
3. During capture: `PPCommNCCL.send` → `is_current_stream_capturing()` returns True → sends on capturing stream
4. The warmup's `send_stream` NCCL send from step 1 may still be in-flight, creating a NCCL operation ordering mismatch between PP ranks

The `torch.cuda.synchronize()` drains all streams (including `send_stream`) before capture begins.

## Test plan

- [ ] Existing CI test `TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=2-pp4-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-low_precision_combine=False-torch_compile=False]` should pass consistently (currently ~2% failure rate, flakiness score 33/100)
- [ ] No performance regression expected — sync only happens during graph capture, not replay

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of CUDA graph execution in pipeline-parallel distributed training scenarios by adding synchronization before graph capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->