### PR TITLE
[None][fix] Enable chunked prefill for SM90

### DIFF
--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -2132,13 +2132,10 @@ class MLA(nn.Module):
                     self.qk_rope_head_dim, self.kv_lora_rank, self.v_head_dim,
                     q.dtype, q.device)
             if trtllm_attention.is_chunked_prefill_for_mla_context(
-                    attn_metadata) and get_sm_version() >= 100:
+                    attn_metadata):
                 return self.forward_context_with_chunked_prefill(
                     q, compressed_kv, latent_cache, attn_metadata, output)
-            elif trtllm_attention.has_cached_kv_for_mla_context(
-                    attn_metadata
-            ) or trtllm_attention.is_chunked_prefill_for_mla_context(
-                    attn_metadata):
+            elif trtllm_attention.has_cached_kv_for_mla_context(attn_metadata):
                 return self.forward_context_with_cached_kv(
                     q, latent_cache, attn_metadata, output)
         return self.forward_context_default(q, compressed_kv, k_pe,


### PR DESCRIPTION
Chunked prefill is [supported](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py#L564) for SM90.

But in [PR](https://github.com/NVIDIA/TensorRT-LLM/pull/11677) it was disabled for no reason because for non DSA MLA models chunked prefill is supported on SM90. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved GPU compatibility for attention context operations by removing hardware-specific version requirements and streamlining dispatch logic for better efficiency across a broader range of GPU architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->