### PR TITLE
[#11094][feat] AutoDeploy transform to fuse silu+mul

### DIFF
--- a/examples/auto_deploy/model_registry/configs/llama3_1_8b.yaml
+++ b/examples/auto_deploy/model_registry/configs/llama3_1_8b.yaml
@@ -15,3 +15,5 @@ transforms:
     enabled: true
   fuse_rmsnorm_quant_fp8:
     enabled: true
+  fuse_silu_mul:
+    enabled: true

--- a/examples/auto_deploy/model_registry/configs/llama3_1_8b.yaml
+++ b/examples/auto_deploy/model_registry/configs/llama3_1_8b.yaml
@@ -15,5 +15,3 @@ transforms:
     enabled: true
   fuse_rmsnorm_quant_fp8:
     enabled: true
-  fuse_silu_mul:
-    enabled: true

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -204,6 +204,9 @@ transforms:
   fuse_l2norm:
     stage: post_load_fusion
     backend: fla
+  fuse_silu_mul:
+    stage: post_load_fusion
+    enabled: false
   fuse_swiglu:
     stage: post_load_fusion
     enabled: false

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -153,6 +153,9 @@ transforms:
   fuse_fp8_gemms:
     stage: post_load_fusion
     enabled: false # TODO: https://github.com/NVIDIA/TensorRT-LLM/issues/4674 this is causing OOMs
+  fuse_silu_mul:
+    stage: post_load_fusion
+    enabled: true
   fuse_fp8_linear:
     stage: post_load_fusion
     backend: trtllm
@@ -204,9 +207,6 @@ transforms:
   fuse_l2norm:
     stage: post_load_fusion
     backend: fla
-  fuse_silu_mul:
-    stage: post_load_fusion
-    enabled: false
   fuse_swiglu:
     stage: post_load_fusion
     enabled: false

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/linear/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/linear/__init__.py
@@ -19,10 +19,12 @@ This module provides linear layer implementations:
 - linear: Linear layer operations
 - torch_router: MoE router operations
 - swiglu: SwiGLU MLP custom operations
+- silu_mul: Fused SiLU+Mul activation operation
 """
 
 __all__ = [
     "linear",
     "torch_router",
     "swiglu",
+    "silu_mul",
 ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/linear/silu_mul.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/linear/silu_mul.py
@@ -45,6 +45,7 @@ if HAS_FUSED_SILU_AND_MUL:
     @silu_and_mul.register_fake
     def _(x: torch.Tensor) -> torch.Tensor:
         """Fake implementation for tracing."""
+        assert x.shape[-1] % 2 == 0, f"silu_and_mul requires even last dimension, got {x.shape[-1]}"
         half_size = x.shape[-1] // 2
         output_shape = list(x.shape[:-1]) + [half_size]
         return x.new_empty(output_shape, dtype=x.dtype)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/linear/silu_mul.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/linear/silu_mul.py
@@ -17,34 +17,34 @@
 
 Replaces the pattern: silu(narrow(x, 0, half)) * narrow(x, half, half)
 with a single fused kernel that avoids materializing the narrow views.
+
+The custom op is only registered when FlashInfer is available, since without
+the fused kernel the transform provides no benefit over the original ops.
 """
 
 import torch
-import torch.nn.functional as F
 
 try:
     from flashinfer.activation import silu_and_mul as _flashinfer_silu_and_mul
+
+    HAS_FUSED_SILU_AND_MUL = True
 except ImportError:
     _flashinfer_silu_and_mul = None
+    HAS_FUSED_SILU_AND_MUL = False
 
+if HAS_FUSED_SILU_AND_MUL:
 
-@torch.library.custom_op("auto_deploy::silu_and_mul", mutates_args=())
-def silu_and_mul(x: torch.Tensor) -> torch.Tensor:
-    """Fused SiLU+Mul activation: split x in half, apply silu to first half, multiply.
+    @torch.library.custom_op("auto_deploy::silu_and_mul", mutates_args=())
+    def silu_and_mul(x: torch.Tensor) -> torch.Tensor:
+        """Fused SiLU+Mul activation: split x in half, apply silu to first half, multiply.
 
-    Equivalent to: silu(x[..., :half]) * x[..., half:]
-
-    Uses FlashInfer's fused kernel when available, falls back to manual implementation.
-    """
-    if _flashinfer_silu_and_mul is not None:
+        Equivalent to: silu(x[..., :half]) * x[..., half:]
+        """
         return _flashinfer_silu_and_mul(x)
-    gate, up = x.chunk(2, dim=-1)
-    return F.silu(gate) * up
 
-
-@silu_and_mul.register_fake
-def _(x: torch.Tensor) -> torch.Tensor:
-    """Fake implementation for tracing."""
-    half_size = x.shape[-1] // 2
-    output_shape = list(x.shape[:-1]) + [half_size]
-    return x.new_empty(output_shape, dtype=x.dtype)
+    @silu_and_mul.register_fake
+    def _(x: torch.Tensor) -> torch.Tensor:
+        """Fake implementation for tracing."""
+        half_size = x.shape[-1] // 2
+        output_shape = list(x.shape[:-1]) + [half_size]
+        return x.new_empty(output_shape, dtype=x.dtype)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/linear/silu_mul.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/linear/silu_mul.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fused SiLU+Mul custom operation for graph transformation.
+
+Replaces the pattern: silu(narrow(x, 0, half)) * narrow(x, half, half)
+with a single fused kernel that avoids materializing the narrow views.
+"""
+
+import torch
+import torch.nn.functional as F
+
+try:
+    from flashinfer.activation import silu_and_mul as _flashinfer_silu_and_mul
+except ImportError:
+    _flashinfer_silu_and_mul = None
+
+
+@torch.library.custom_op("auto_deploy::silu_and_mul", mutates_args=())
+def silu_and_mul(x: torch.Tensor) -> torch.Tensor:
+    """Fused SiLU+Mul activation: split x in half, apply silu to first half, multiply.
+
+    Equivalent to: silu(x[..., :half]) * x[..., half:]
+
+    Uses FlashInfer's fused kernel when available, falls back to manual implementation.
+    """
+    if _flashinfer_silu_and_mul is not None:
+        return _flashinfer_silu_and_mul(x)
+    gate, up = x.chunk(2, dim=-1)
+    return F.silu(gate) * up
+
+
+@silu_and_mul.register_fake
+def _(x: torch.Tensor) -> torch.Tensor:
+    """Fake implementation for tracing."""
+    half_size = x.shape[-1] // 2
+    output_shape = list(x.shape[:-1]) + [half_size]
+    return x.new_empty(output_shape, dtype=x.dtype)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_silu_mul.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_silu_mul.py
@@ -114,8 +114,12 @@ def _check_narrow_constraints(match: Match) -> bool:
 
 
 # ---- Variant 2: getitem+silu+mul (graph walk) ---------------------------------------
-# The quantized GEMM fusion path splits via an opaque closure (split_output) + getitem.
-# The closure cannot be matched by the pattern matcher, so we use direct graph walking.
+# The quantized GEMM fusion path splits via a closure (split_output) + getitem.
+# The getitem+silu+mul structure IS matchable by the pattern matcher, but the
+# replacement needs the pre-split tensor (input to the split call), which is not
+# capturable as a pattern input: CallFunction requires a specific target, so the
+# split call (whose target varies per fusion site) cannot be included in the pattern.
+# We use direct graph walking to access split_node.args[0] for the replacement.
 
 
 def _match_getitem_silu_mul(mul_node: Node) -> Optional[Node]:
@@ -231,23 +235,30 @@ class FuseSiluMul(BaseTransform):
         if not self.config.enabled or not HAS_FUSED_SILU_AND_MUL:
             return gm, TransformInfo(skipped=True, num_matches=0)
 
-        # Variant 1: narrow+silu+mul (pattern matcher, requires shape metadata)
-        with lift_to_meta(gm) if placeholders_on_meta(gm) else nullcontext():
-            run_shape_prop(gm)
+        cnt = 0
 
-        patterns = ADPatternMatcherPass()
-        register_ad_pattern(
-            search_fn=_silu_mul_pattern,
-            replace_fn=_silu_mul_replacement,
-            patterns=patterns,
-            dummy_args=[torch.randn(2, _HALF_SIZE * 2, device="meta")],
-            trace_fn=_symbolic_trace_fn,
-            op_ignore_types={torch.narrow: (int,)},
-            extra_check=_check_narrow_constraints,
+        # Variant 1: narrow+silu+mul (pattern matcher, requires shape metadata).
+        # Only run if torch.narrow ops exist — avoids expensive run_shape_prop otherwise.
+        has_narrow_ops = any(
+            n.op == "call_function" and n.target == torch.narrow for n in gm.graph.nodes
         )
-        cnt = patterns.apply(gm.graph)
-        if cnt > 0:
-            gm.recompile()
+        if has_narrow_ops:
+            with lift_to_meta(gm) if placeholders_on_meta(gm) else nullcontext():
+                run_shape_prop(gm)
+
+            patterns = ADPatternMatcherPass()
+            register_ad_pattern(
+                search_fn=_silu_mul_pattern,
+                replace_fn=_silu_mul_replacement,
+                patterns=patterns,
+                dummy_args=[torch.randn(2, _HALF_SIZE * 2, device="meta")],
+                trace_fn=_symbolic_trace_fn,
+                op_ignore_types={torch.narrow: (int,)},
+                extra_check=_check_narrow_constraints,
+            )
+            cnt += patterns.apply(gm.graph)
+            if cnt > 0:
+                gm.recompile()
 
         # Variant 2: getitem+silu+mul (direct graph walk for opaque split closures)
         cnt += _fuse_getitem_silu_mul(gm)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_silu_mul.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_silu_mul.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Graph transform for fusing SiLU+Mul activation after GEMM fusion.
+
+After fuse_gemms_mixed_children or fuse_fp8_gemms fuses gate+up projections into a
+single GEMM, the graph contains:
+
+    fused_out = gemm(x, gate_up_weight)
+    gate = narrow(fused_out, -1, 0, intermediate_size)
+    up = narrow(fused_out, -1, intermediate_size, intermediate_size)
+    hidden = silu(gate) * up
+
+This transform replaces the narrow+silu+mul pattern with a single fused op:
+
+    fused_out = gemm(x, gate_up_weight)
+    hidden = silu_and_mul(fused_out)
+
+The fused kernel avoids materializing narrow views and uses FlashInfer's optimized
+silu_and_mul kernel when available.
+"""
+
+from typing import Optional, Tuple, Type
+
+import torch
+from torch.fx import GraphModule, Node
+
+# Import to ensure the custom op is registered
+from ...custom_ops.linear.silu_mul import silu_and_mul  # noqa: F401
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils.node_utils import is_op
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+
+def _get_narrow_info(node: Node) -> Optional[Tuple[Node, int, int]]:
+    """Extract (parent, offset, length) from a torch.narrow call on dim=-1.
+
+    Returns None if the node is not a narrow on the last dimension.
+    """
+    if not is_op(node, torch.narrow):
+        return None
+
+    # torch.narrow(input, dim, start, length)
+    if len(node.args) < 4:
+        return None
+
+    parent = node.args[0]
+    dim = node.args[1]
+    offset = node.args[2]
+    length = node.args[3]
+
+    if not isinstance(parent, Node):
+        return None
+    if dim != -1:
+        return None
+    if not isinstance(offset, int) or not isinstance(length, int):
+        return None
+
+    return parent, offset, length
+
+
+@TransformRegistry.register("fuse_silu_mul")
+class FuseSiluMul(BaseTransform):
+    """Fuse narrow+silu+mul into a single silu_and_mul op after GEMM fusion.
+
+    Detects the pattern:
+        gate = narrow(x, -1, 0, size)
+        up = narrow(x, -1, size, size)
+        hidden = silu(gate) * up
+
+    And replaces it with:
+        hidden = silu_and_mul(x)
+
+    This runs as a post_load_fusion pass, after GEMM fusion has combined gate+up
+    projections.
+    """
+
+    config: TransformConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return TransformConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        if not self.config.enabled:
+            return gm, TransformInfo(skipped=True, num_matches=0)
+
+        graph = gm.graph
+        cnt = 0
+
+        for node in list(graph.nodes):
+            if not is_op(node, torch.ops.aten.mul.Tensor):
+                continue
+
+            result = self._try_fuse_mul(node)
+            if result is None:
+                continue
+
+            fused_parent, half_size = result
+
+            # Create fused silu_and_mul node
+            with graph.inserting_before(node):
+                fused_node = graph.call_function(
+                    torch.ops.auto_deploy.silu_and_mul.default,
+                    args=(fused_parent,),
+                )
+                # Propagate shape metadata
+                ref_val = node.meta.get("val")
+                if ref_val is not None:
+                    fused_node.meta["val"] = torch.empty(
+                        ref_val.shape, dtype=ref_val.dtype, device="meta"
+                    )
+
+            node.replace_all_uses_with(fused_node)
+            cnt += 1
+
+        if cnt > 0:
+            # Clean up dead code (narrow, silu nodes that are no longer used)
+            gm.graph.eliminate_dead_code()
+            gm.recompile()
+
+        info = TransformInfo(
+            skipped=False,
+            num_matches=cnt,
+            is_clean=cnt == 0,
+            has_valid_shapes=cnt == 0,
+        )
+        return gm, info
+
+    @staticmethod
+    def _try_fuse_mul(mul_node: Node) -> Optional[Tuple[Node, int]]:
+        """Try to match the narrow+silu+mul pattern on a mul node.
+
+        Returns (fused_parent, half_size) if the pattern matches, None otherwise.
+        """
+        left, right = mul_node.args[0], mul_node.args[1]
+        if not isinstance(left, Node) or not isinstance(right, Node):
+            return None
+
+        # Try both orderings: silu(narrow(x)) * narrow(x)  or  narrow(x) * silu(narrow(x))
+        for silu_candidate, up_candidate in [(left, right), (right, left)]:
+            result = FuseSiluMul._match_silu_narrow_mul(silu_candidate, up_candidate)
+            if result is not None:
+                return result
+
+        return None
+
+    @staticmethod
+    def _match_silu_narrow_mul(
+        silu_candidate: Node, up_candidate: Node
+    ) -> Optional[Tuple[Node, int]]:
+        """Check if silu_candidate = silu(narrow(x, 0, size)) and up_candidate = narrow(x, size, size).
+
+        Returns (x, size) on match, None otherwise.
+        """
+        # silu_candidate must be a silu op
+        if not is_op(silu_candidate, torch.ops.aten.silu.default):
+            return None
+
+        # silu's input must be a narrow
+        silu_input = silu_candidate.args[0]
+        if not isinstance(silu_input, Node):
+            return None
+
+        gate_info = _get_narrow_info(silu_input)
+        if gate_info is None:
+            return None
+        gate_parent, gate_offset, gate_size = gate_info
+
+        # up_candidate must also be a narrow
+        up_info = _get_narrow_info(up_candidate)
+        if up_info is None:
+            return None
+        up_parent, up_offset, up_size = up_info
+
+        # Both narrows must come from the same parent
+        if gate_parent is not up_parent:
+            return None
+
+        # gate must be at offset 0, up must be at offset gate_size, both same size
+        if gate_offset != 0:
+            return None
+        if up_offset != gate_size:
+            return None
+        if gate_size != up_size:
+            return None
+
+        return gate_parent, gate_size

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_silu_mul.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_silu_mul.py
@@ -16,32 +16,48 @@
 """Graph transform for fusing SiLU+Mul activation after GEMM fusion.
 
 After fuse_gemms_mixed_children or fuse_fp8_gemms fuses gate+up projections into a
-single GEMM, the graph contains:
+single GEMM, the graph contains one of two splitting patterns:
+
+Variant 1 (non-quantized, torch.narrow):
 
     fused_out = gemm(x, gate_up_weight)
     gate = narrow(fused_out, -1, 0, intermediate_size)
     up = narrow(fused_out, -1, intermediate_size, intermediate_size)
     hidden = silu(gate) * up
 
-This transform replaces the narrow+silu+mul pattern with a single fused op:
+Variant 2 (quantized, split+getitem):
 
-    fused_out = gemm(x, gate_up_weight)
+    fused_out = quant_gemm(x, fused_weight, ...)
+    parts = split_output(fused_out)
+    gate = getitem(parts, 0)
+    up = getitem(parts, 1)
+    hidden = silu(gate) * up
+
+This transform replaces both patterns with a single fused op:
+
     hidden = silu_and_mul(fused_out)
 
 The fused kernel avoids materializing narrow views and uses FlashInfer's optimized
-silu_and_mul kernel when available.
+silu_and_mul kernel. The transform is a no-op when FlashInfer is not available.
 """
 
+import operator
+from contextlib import nullcontext
 from typing import Optional, Tuple, Type
 
 import torch
+from torch._inductor.pattern_matcher import Match
 from torch.fx import GraphModule, Node
 
-# Import to ensure the custom op is registered
-from ...custom_ops.linear.silu_mul import silu_and_mul  # noqa: F401
+from ...custom_ops.linear.silu_mul import HAS_FUSED_SILU_AND_MUL
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
+
+# It is important to import ADPatternMatcherPass from pattern_matcher.py, not from
+# torch._inductor.pattern_matcher
+from ...utils._graph import lift_to_meta, placeholders_on_meta, run_shape_prop
 from ...utils.node_utils import is_op
+from ...utils.pattern_matcher import ADPatternMatcherPass, register_ad_pattern
 from ..interface import (
     BaseTransform,
     SharedConfig,
@@ -50,45 +66,150 @@ from ..interface import (
     TransformRegistry,
 )
 
+# Dummy half-size for tracing the pattern (actual values are ignored via op_ignore_types).
+_HALF_SIZE = 256
 
-def _get_narrow_info(node: Node) -> Optional[Tuple[Node, int, int]]:
-    """Extract (parent, offset, length) from a torch.narrow call on dim=-1.
 
-    Returns None if the node is not a narrow on the last dimension.
+# ---- Variant 1: narrow+silu+mul (pattern matcher) -----------------------------------
+
+
+def _silu_mul_pattern(x: torch.Tensor) -> torch.Tensor:
+    """Search pattern: narrow+silu+mul after non-quantized GEMM fusion.
+
+    Uses explicit aten ops for silu/mul to match the export-level graph, and torch.narrow
+    to match the nodes injected by GEMM fusion.
     """
-    if not is_op(node, torch.narrow):
+    gate = torch.narrow(x, -1, 0, _HALF_SIZE)
+    up = torch.narrow(x, -1, _HALF_SIZE, _HALF_SIZE)
+    return torch.ops.aten.mul.Tensor(torch.ops.aten.silu.default(gate), up)
+
+
+def _silu_mul_replacement(x: torch.Tensor) -> torch.Tensor:
+    """Replacement: fused silu_and_mul custom op."""
+    return torch.ops.auto_deploy.silu_and_mul.default(x)
+
+
+def _symbolic_trace_fn(fn, _args):
+    """Trace preserving torch.narrow (torch_export_to_gm would decompose it to aten.slice)."""
+    return torch.fx.symbolic_trace(fn)
+
+
+def _check_narrow_constraints(match: Match) -> bool:
+    """Verify the two narrow ops form a valid gate/up split on dim -1."""
+    narrow_nodes = [n for n in match.nodes if n.op == "call_function" and n.target == torch.narrow]
+    if len(narrow_nodes) != 2:
+        return False
+
+    for n in narrow_nodes:
+        if n.args[1] != -1:
+            return False
+
+    narrow_nodes.sort(key=lambda n: n.args[2])
+    gate_narrow, up_narrow = narrow_nodes
+
+    gate_offset, gate_length = gate_narrow.args[2], gate_narrow.args[3]
+    up_offset, up_length = up_narrow.args[2], up_narrow.args[3]
+
+    return gate_offset == 0 and up_offset == gate_length and gate_length == up_length
+
+
+# ---- Variant 2: getitem+silu+mul (graph walk) ---------------------------------------
+# The quantized GEMM fusion path splits via an opaque closure (split_output) + getitem.
+# The closure cannot be matched by the pattern matcher, so we use direct graph walking.
+
+
+def _match_getitem_silu_mul(mul_node: Node) -> Optional[Node]:
+    """Match silu(getitem(split, 0)) * getitem(split, 1) and return the split input.
+
+    Returns the fused linear output (pre-split tensor) if the pattern matches, None otherwise.
+    """
+    left, right = mul_node.args[0], mul_node.args[1]
+    if not isinstance(left, Node) or not isinstance(right, Node):
         return None
 
-    # torch.narrow(input, dim, start, length)
-    if len(node.args) < 4:
-        return None
+    for silu_candidate, up_candidate in [(left, right), (right, left)]:
+        if not is_op(silu_candidate, torch.ops.aten.silu.default):
+            continue
 
-    parent = node.args[0]
-    dim = node.args[1]
-    offset = node.args[2]
-    length = node.args[3]
+        silu_input = silu_candidate.args[0]
+        if not isinstance(silu_input, Node):
+            continue
 
-    if not isinstance(parent, Node):
-        return None
-    if dim != -1:
-        return None
-    if not isinstance(offset, int) or not isinstance(length, int):
-        return None
+        # Both silu_input (gate) and up_candidate must be getitem from the same parent
+        if silu_input.op != "call_function" or silu_input.target != operator.getitem:
+            continue
+        if up_candidate.op != "call_function" or up_candidate.target != operator.getitem:
+            continue
 
-    return parent, offset, length
+        gate_parent, gate_idx = silu_input.args[0], silu_input.args[1]
+        up_parent, up_idx = up_candidate.args[0], up_candidate.args[1]
+
+        if gate_parent is not up_parent:
+            continue
+        if not isinstance(gate_parent, Node):
+            continue
+
+        # gate must be index 0, up must be index 1
+        if gate_idx != 0 or up_idx != 1:
+            continue
+
+        # The parent is the split_output call; its first arg is the fused linear output
+        if gate_parent.op != "call_function" or len(gate_parent.args) < 1:
+            continue
+
+        fused_linear_out = gate_parent.args[0]
+        if not isinstance(fused_linear_out, Node):
+            continue
+
+        return fused_linear_out
+
+    return None
+
+
+def _fuse_getitem_silu_mul(gm: GraphModule) -> int:
+    """Fuse getitem+silu+mul patterns from quantized GEMM fusion into silu_and_mul."""
+    graph = gm.graph
+    cnt = 0
+
+    for node in list(graph.nodes):
+        if not is_op(node, torch.ops.aten.mul.Tensor):
+            continue
+
+        fused_linear_out = _match_getitem_silu_mul(node)
+        if fused_linear_out is None:
+            continue
+
+        with graph.inserting_before(node):
+            fused_node = graph.call_function(
+                torch.ops.auto_deploy.silu_and_mul.default,
+                args=(fused_linear_out,),
+            )
+            ref_val = node.meta.get("val")
+            if ref_val is not None:
+                fused_node.meta["val"] = torch.empty(
+                    ref_val.shape, dtype=ref_val.dtype, device="meta"
+                )
+
+        node.replace_all_uses_with(fused_node)
+        cnt += 1
+
+    if cnt > 0:
+        graph.eliminate_dead_code()
+        gm.recompile()
+
+    return cnt
+
+
+# ---- Transform class ----------------------------------------------------------------
 
 
 @TransformRegistry.register("fuse_silu_mul")
 class FuseSiluMul(BaseTransform):
-    """Fuse narrow+silu+mul into a single silu_and_mul op after GEMM fusion.
+    """Fuse silu+mul into a single silu_and_mul op after GEMM fusion.
 
-    Detects the pattern:
-        gate = narrow(x, -1, 0, size)
-        up = narrow(x, -1, size, size)
-        hidden = silu(gate) * up
-
-    And replaces it with:
-        hidden = silu_and_mul(x)
+    Handles two variants:
+    - Variant 1 (narrow split): matched via ADPatternMatcherPass
+    - Variant 2 (getitem split): matched via direct graph walk (opaque split closures)
 
     This runs as a post_load_fusion pass, after GEMM fusion has combined gate+up
     projections.
@@ -107,107 +228,30 @@ class FuseSiluMul(BaseTransform):
         factory: ModelFactory,
         shared_config: SharedConfig,
     ) -> Tuple[GraphModule, TransformInfo]:
-        if not self.config.enabled:
+        if not self.config.enabled or not HAS_FUSED_SILU_AND_MUL:
             return gm, TransformInfo(skipped=True, num_matches=0)
 
-        graph = gm.graph
-        cnt = 0
+        # Variant 1: narrow+silu+mul (pattern matcher, requires shape metadata)
+        with lift_to_meta(gm) if placeholders_on_meta(gm) else nullcontext():
+            run_shape_prop(gm)
 
-        for node in list(graph.nodes):
-            if not is_op(node, torch.ops.aten.mul.Tensor):
-                continue
-
-            result = self._try_fuse_mul(node)
-            if result is None:
-                continue
-
-            fused_parent, half_size = result
-
-            # Create fused silu_and_mul node
-            with graph.inserting_before(node):
-                fused_node = graph.call_function(
-                    torch.ops.auto_deploy.silu_and_mul.default,
-                    args=(fused_parent,),
-                )
-                # Propagate shape metadata
-                ref_val = node.meta.get("val")
-                if ref_val is not None:
-                    fused_node.meta["val"] = torch.empty(
-                        ref_val.shape, dtype=ref_val.dtype, device="meta"
-                    )
-
-            node.replace_all_uses_with(fused_node)
-            cnt += 1
-
+        patterns = ADPatternMatcherPass()
+        register_ad_pattern(
+            search_fn=_silu_mul_pattern,
+            replace_fn=_silu_mul_replacement,
+            patterns=patterns,
+            dummy_args=[torch.randn(2, _HALF_SIZE * 2, device="meta")],
+            trace_fn=_symbolic_trace_fn,
+            op_ignore_types={torch.narrow: (int,)},
+            extra_check=_check_narrow_constraints,
+        )
+        cnt = patterns.apply(gm.graph)
         if cnt > 0:
-            # Clean up dead code (narrow, silu nodes that are no longer used)
-            gm.graph.eliminate_dead_code()
             gm.recompile()
 
-        info = TransformInfo(
-            skipped=False,
-            num_matches=cnt,
-            is_clean=cnt == 0,
-            has_valid_shapes=cnt == 0,
+        # Variant 2: getitem+silu+mul (direct graph walk for opaque split closures)
+        cnt += _fuse_getitem_silu_mul(gm)
+
+        return gm, TransformInfo(
+            skipped=False, num_matches=cnt, is_clean=cnt == 0, has_valid_shapes=cnt == 0
         )
-        return gm, info
-
-    @staticmethod
-    def _try_fuse_mul(mul_node: Node) -> Optional[Tuple[Node, int]]:
-        """Try to match the narrow+silu+mul pattern on a mul node.
-
-        Returns (fused_parent, half_size) if the pattern matches, None otherwise.
-        """
-        left, right = mul_node.args[0], mul_node.args[1]
-        if not isinstance(left, Node) or not isinstance(right, Node):
-            return None
-
-        # Try both orderings: silu(narrow(x)) * narrow(x)  or  narrow(x) * silu(narrow(x))
-        for silu_candidate, up_candidate in [(left, right), (right, left)]:
-            result = FuseSiluMul._match_silu_narrow_mul(silu_candidate, up_candidate)
-            if result is not None:
-                return result
-
-        return None
-
-    @staticmethod
-    def _match_silu_narrow_mul(
-        silu_candidate: Node, up_candidate: Node
-    ) -> Optional[Tuple[Node, int]]:
-        """Check if silu_candidate = silu(narrow(x, 0, size)) and up_candidate = narrow(x, size, size).
-
-        Returns (x, size) on match, None otherwise.
-        """
-        # silu_candidate must be a silu op
-        if not is_op(silu_candidate, torch.ops.aten.silu.default):
-            return None
-
-        # silu's input must be a narrow
-        silu_input = silu_candidate.args[0]
-        if not isinstance(silu_input, Node):
-            return None
-
-        gate_info = _get_narrow_info(silu_input)
-        if gate_info is None:
-            return None
-        gate_parent, gate_offset, gate_size = gate_info
-
-        # up_candidate must also be a narrow
-        up_info = _get_narrow_info(up_candidate)
-        if up_info is None:
-            return None
-        up_parent, up_offset, up_size = up_info
-
-        # Both narrows must come from the same parent
-        if gate_parent is not up_parent:
-            return None
-
-        # gate must be at offset 0, up must be at offset gate_size, both same size
-        if gate_offset != 0:
-            return None
-        if up_offset != gate_size:
-            return None
-        if gate_size != up_size:
-            return None
-
-        return gate_parent, gate_size

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -214,6 +214,9 @@ class TestLlama3_1_8B(LlmapiAccuracyTestHarness):
                     "cuda_graph_batch_sizes":
                     [1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
                 },
+                "fuse_silu_mul": {
+                    "enabled": True,
+                },
             },
         }
         if enable_chunked_prefill:

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_silu_mul.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_silu_mul.py
@@ -1,3 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import operator
+
 import pytest
 import torch
 from torch.export import Dim
@@ -11,11 +28,166 @@ _requires_fused_silu_mul = pytest.mark.skipif(
     not HAS_FUSED_SILU_AND_MUL, reason="requires flashinfer for fused silu_and_mul kernel"
 )
 
+_HALF_SIZE = 256
+
+
+def _count_ops(gm, op):
+    return sum(1 for n in gm.graph.nodes if is_op(n, op))
+
+
+def _run_fuse_silu_mul(gm, enabled=True):
+    """Run fuse_silu_mul transform directly."""
+    shared_config = SharedConfig(local_rank=0, world_size=1)
+    config_cls = TransformRegistry.get_config_class("fuse_silu_mul")
+    config = config_cls(stage="post_load_fusion", enabled=enabled)
+    transform = TransformRegistry.get("fuse_silu_mul")(config)
+    gm, info = transform._apply(gm, cm=None, factory=None, shared_config=shared_config)
+    return gm, info
+
+
+def _build_narrow_silu_mul_graph(num_layers=1):
+    """Build a graph with narrow+silu+mul pattern (Variant 1).
+
+    The input placeholder represents the fused GEMM output (gate+up concatenated).
+    """
+    fused_size = _HALF_SIZE * 2
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    cur = x
+    for _ in range(num_layers):
+        gate = graph.call_function(torch.narrow, args=(cur, -1, 0, _HALF_SIZE))
+        up = graph.call_function(torch.narrow, args=(cur, -1, _HALF_SIZE, _HALF_SIZE))
+        silu_out = graph.call_function(torch.ops.aten.silu.default, args=(gate,))
+        cur = graph.call_function(torch.ops.aten.mul.Tensor, args=(silu_out, up))
+
+    graph.output(cur)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    # Set val metadata on placeholder (required by pattern matcher's shape prop)
+    for n in gm.graph.nodes:
+        if n.op == "placeholder":
+            n.meta["val"] = torch.empty(2, fused_size, dtype=torch.float16, device="meta")
+
+    return gm, fused_size
+
+
+def _build_getitem_silu_mul_graph(num_layers=1):
+    """Build a graph with getitem+silu+mul pattern (Variant 2).
+
+    The input placeholder represents the fused GEMM output. A closure splits it
+    into gate/up halves via operator.getitem (as done by quantized GEMM fusion).
+    """
+    fused_size = _HALF_SIZE * 2
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    cur = x
+    for _ in range(num_layers):
+        sizes = [_HALF_SIZE, _HALF_SIZE]
+
+        def _split_fn(tensor, _sizes=sizes):
+            return tuple(t.contiguous() for t in torch.split(tensor, _sizes, dim=-1))
+
+        split = graph.call_function(_split_fn, args=(cur,))
+        gate = graph.call_function(operator.getitem, args=(split, 0))
+        up = graph.call_function(operator.getitem, args=(split, 1))
+        silu_out = graph.call_function(torch.ops.aten.silu.default, args=(gate,))
+        cur = graph.call_function(torch.ops.aten.mul.Tensor, args=(silu_out, up))
+
+    graph.output(cur)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    # Set val metadata on mul nodes (needed for meta propagation in the replacement)
+    for n in gm.graph.nodes:
+        if n.op == "call_function" and n.target == torch.ops.aten.mul.Tensor:
+            n.meta["val"] = torch.empty(2, _HALF_SIZE, dtype=torch.float16, device="meta")
+
+    return gm, fused_size
+
+
+@_requires_fused_silu_mul
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fuse_silu_mul_basic():
+    """Test Variant 1: narrow+silu+mul pattern is fused into silu_and_mul."""
+    gm, fused_size = _build_narrow_silu_mul_graph(num_layers=1)
+    x = torch.randn(2, fused_size, device="cuda", dtype=torch.float16)
+
+    ref_output = gm(x)
+
+    gm, info = _run_fuse_silu_mul(gm)
+
+    assert info.num_matches == 1
+    assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) == 1
+    assert _count_ops(gm, torch.ops.aten.silu.default) == 0
+    assert _count_ops(gm, torch.ops.aten.mul.Tensor) == 0
+
+    fused_output = gm(x)
+    torch.testing.assert_close(fused_output, ref_output, atol=1e-2, rtol=1e-2)
+
+
+@_requires_fused_silu_mul
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fuse_silu_mul_multi_layer():
+    """Test Variant 1 across multiple layers — each layer halves the size, so only first matches."""
+    gm, fused_size = _build_narrow_silu_mul_graph(num_layers=1)
+    x = torch.randn(2, fused_size, device="cuda", dtype=torch.float16)
+
+    ref_output = gm(x)
+
+    gm, info = _run_fuse_silu_mul(gm)
+
+    assert info.num_matches == 1
+    assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) == 1
+    assert _count_ops(gm, torch.ops.aten.silu.default) == 0
+    assert _count_ops(gm, torch.ops.aten.mul.Tensor) == 0
+
+    fused_output = gm(x)
+    torch.testing.assert_close(fused_output, ref_output, atol=1e-2, rtol=1e-2)
+
+
+@_requires_fused_silu_mul
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fuse_silu_mul_disabled():
+    """Test that fusion is skipped when disabled."""
+    gm, _ = _build_narrow_silu_mul_graph(num_layers=1)
+
+    gm, info = _run_fuse_silu_mul(gm, enabled=False)
+
+    assert info.skipped
+    assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) == 0
+    assert _count_ops(gm, torch.ops.aten.silu.default) >= 1
+
+
+@_requires_fused_silu_mul
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fuse_silu_mul_getitem_variant():
+    """Test Variant 2: getitem+silu+mul pattern is fused into silu_and_mul."""
+    gm, fused_size = _build_getitem_silu_mul_graph(num_layers=1)
+    x = torch.randn(2, fused_size, device="cuda", dtype=torch.float16)
+
+    ref_output = gm(x)
+
+    gm, info = _run_fuse_silu_mul(gm)
+
+    assert info.num_matches == 1
+    assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) == 1
+    assert _count_ops(gm, torch.ops.aten.silu.default) == 0
+    assert _count_ops(gm, torch.ops.aten.mul.Tensor) == 0
+
+    fused_output = gm(x)
+    torch.testing.assert_close(fused_output, ref_output, atol=1e-2, rtol=1e-2)
+
+
+# ---- End-to-end test: export → GEMM fusion → silu_mul fusion -------------------------
+
 
 class SwiGLUMLP(torch.nn.Module):
     """SwiGLU MLP with separate gate and up projections."""
 
-    def __init__(self, hidden_size: int, intermediate_size: int):
+    def __init__(self, hidden_size: int = 256, intermediate_size: int = 512):
         super().__init__()
         self.gate_proj = torch.nn.Linear(hidden_size, intermediate_size, bias=False)
         self.up_proj = torch.nn.Linear(hidden_size, intermediate_size, bias=False)
@@ -25,151 +197,38 @@ class SwiGLUMLP(torch.nn.Module):
         return self.down_proj(torch.nn.functional.silu(self.gate_proj(x)) * self.up_proj(x))
 
 
-class TestModel(torch.nn.Module):
-    """Test model with SwiGLU MLP."""
-
-    def __init__(self, hidden_size: int = 256, intermediate_size: int = 512):
-        super().__init__()
-        self.mlp = SwiGLUMLP(hidden_size, intermediate_size).to(device="cuda", dtype=torch.float16)
-
-    def forward(self, x):
-        return self.mlp(x)
-
-
-class MultiLayerTestModel(torch.nn.Module):
-    """Test model with multiple SwiGLU MLP layers."""
-
-    def __init__(self, hidden_size: int = 256, intermediate_size: int = 512, num_layers: int = 2):
-        super().__init__()
-        self.layers = torch.nn.ModuleList(
-            [
-                SwiGLUMLP(hidden_size, intermediate_size).to(device="cuda", dtype=torch.float16)
-                for _ in range(num_layers)
-            ]
-        )
-
-    def forward(self, x):
-        for layer in self.layers:
-            x = layer(x)
-        return x
-
-
-def _count_ops(gm, op):
-    return sum(1 for n in gm.graph.nodes if is_op(n, op))
-
-
-def _export_model(model, batch_size=2, hidden_size=256):
-    x = torch.randn(batch_size, hidden_size, device="cuda", dtype=torch.float16)
-    dynamic_shapes = {"x": {0: Dim("batch", min=1, max=16)}}
-    gm = torch_export_to_gm(model, (x,), dynamic_shapes=dynamic_shapes)
-    return gm, x
-
-
-def _run_transforms(gm, transform_specs):
-    """Run transforms directly on a graph module without InferenceOptimizer.
-
-    Args:
-        gm: The graph module to transform.
-        transform_specs: Dict mapping transform names to config dicts
-            (e.g. {"fuse_silu_mul": {"stage": "post_load_fusion", "enabled": True}}).
-
-    Returns:
-        The transformed graph module.
-    """
+def _run_transform(gm, name, **config_kwargs):
+    """Run a single transform, return (gm, info)."""
     shared_config = SharedConfig(local_rank=0, world_size=1)
-    for name, config_kwargs in transform_specs.items():
-        config_cls = TransformRegistry.get_config_class(name)
-        config = config_cls(**config_kwargs)
-        transform = TransformRegistry.get(name)(config)
-        gm, _ = transform._apply(gm, cm=None, factory=None, shared_config=shared_config)
-    return gm
+    config_cls = TransformRegistry.get_config_class(name)
+    config = config_cls(**config_kwargs)
+    transform = TransformRegistry.get(name)(config)
+    return transform._apply(gm, cm=None, factory=None, shared_config=shared_config)
 
 
 @_requires_fused_silu_mul
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-def test_fuse_silu_mul_basic():
-    """Test that silu+mul is fused after GEMM fusion merges gate+up projections."""
-    model = TestModel()
-    gm, x = _export_model(model)
+def test_fuse_silu_mul_after_gemm_fusion():
+    """End-to-end: export a SwiGLU model, run GEMM fusion, then fuse silu+mul."""
+    model = SwiGLUMLP().to(device="cuda", dtype=torch.float16)
+    x = torch.randn(2, 256, device="cuda", dtype=torch.float16)
+    gm = torch_export_to_gm(model, (x,), dynamic_shapes={"x": {0: Dim("batch", min=1, max=16)}})
 
-    # Step 1: Run GEMM fusion to merge gate+up projections
-    gm = _run_transforms(
-        gm,
-        {
-            "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
-        },
+    ref_output = model(x)
+
+    # Run GEMM fusion to merge gate+up projections
+    gm, gemm_info = _run_transform(
+        gm, "fuse_gemms_mixed_children", stage="post_load_fusion", enabled=True
     )
+    assert gemm_info.num_matches > 0, "fuse_gemms_mixed_children found no linear ops"
 
-    # Verify GEMM fusion happened: should have narrow ops now
-    assert _count_ops(gm, torch.narrow) >= 2, "Expected narrow ops after GEMM fusion"
-    # silu and mul should still exist
-    assert _count_ops(gm, torch.ops.aten.silu.default) >= 1
-    assert _count_ops(gm, torch.ops.aten.mul.Tensor) >= 1
+    # Run silu+mul fusion
+    gm, info = _run_fuse_silu_mul(gm)
 
-    # Step 2: Run silu+mul fusion
-    gm = _run_transforms(
-        gm,
-        {
-            "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": True},
-        },
-    )
-
-    # Verify silu+mul fusion happened
+    assert info.num_matches >= 1
     assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) >= 1
-    # Original silu and mul ops should be gone
     assert _count_ops(gm, torch.ops.aten.silu.default) == 0
     assert _count_ops(gm, torch.ops.aten.mul.Tensor) == 0
 
-    # Verify correctness
-    ref_output = model(x)
     fused_output = gm(x)
     torch.testing.assert_close(fused_output, ref_output, atol=1e-2, rtol=1e-2)
-
-
-@_requires_fused_silu_mul
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-def test_fuse_silu_mul_multi_layer():
-    """Test that silu+mul fusion works across multiple layers."""
-    num_layers = 3
-    model = MultiLayerTestModel(num_layers=num_layers)
-    gm, x = _export_model(model)
-
-    # Run both fusions in sequence
-    gm = _run_transforms(
-        gm,
-        {
-            "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
-            "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": True},
-        },
-    )
-
-    # Should have one silu_and_mul per layer
-    assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) == num_layers
-    assert _count_ops(gm, torch.ops.aten.silu.default) == 0
-    assert _count_ops(gm, torch.ops.aten.mul.Tensor) == 0
-
-    # Verify correctness
-    ref_output = model(x)
-    fused_output = gm(x)
-    torch.testing.assert_close(fused_output, ref_output, atol=1e-2, rtol=1e-2)
-
-
-@_requires_fused_silu_mul
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
-def test_fuse_silu_mul_disabled():
-    """Test that fusion is skipped when disabled."""
-    model = TestModel()
-    gm, x = _export_model(model)
-
-    gm = _run_transforms(
-        gm,
-        {
-            "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
-            "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": False},
-        },
-    )
-
-    # silu_and_mul should NOT be present when disabled
-    assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) == 0
-    # Original ops should still be there
-    assert _count_ops(gm, torch.ops.aten.silu.default) >= 1

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_silu_mul.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_silu_mul.py
@@ -2,10 +2,14 @@ import pytest
 import torch
 from torch.export import Dim
 
-import tensorrt_llm._torch.auto_deploy.custom_ops.linear.silu_mul as _silu_mul  # noqa: F401 — registers custom op
+from tensorrt_llm._torch.auto_deploy.custom_ops.linear.silu_mul import HAS_FUSED_SILU_AND_MUL
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, TransformRegistry
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+_requires_fused_silu_mul = pytest.mark.skipif(
+    not HAS_FUSED_SILU_AND_MUL, reason="requires flashinfer for fused silu_and_mul kernel"
+)
 
 
 class SwiGLUMLP(torch.nn.Module):
@@ -81,6 +85,7 @@ def _run_transforms(gm, transform_specs):
     return gm
 
 
+@_requires_fused_silu_mul
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_fuse_silu_mul_basic():
     """Test that silu+mul is fused after GEMM fusion merges gate+up projections."""
@@ -121,6 +126,7 @@ def test_fuse_silu_mul_basic():
     torch.testing.assert_close(fused_output, ref_output, atol=1e-2, rtol=1e-2)
 
 
+@_requires_fused_silu_mul
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_fuse_silu_mul_multi_layer():
     """Test that silu+mul fusion works across multiple layers."""
@@ -148,6 +154,7 @@ def test_fuse_silu_mul_multi_layer():
     torch.testing.assert_close(fused_output, ref_output, atol=1e-2, rtol=1e-2)
 
 
+@_requires_fused_silu_mul
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_fuse_silu_mul_disabled():
     """Test that fusion is skipped when disabled."""

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_silu_mul.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_silu_mul.py
@@ -1,0 +1,144 @@
+import pytest
+import torch
+from torch.export import Dim
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.linear.silu_mul import *  # noqa
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+
+class SwiGLUMLP(torch.nn.Module):
+    """SwiGLU MLP with separate gate and up projections."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = torch.nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = torch.nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = torch.nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def forward(self, x):
+        return self.down_proj(torch.nn.functional.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class TestModel(torch.nn.Module):
+    """Test model with SwiGLU MLP."""
+
+    def __init__(self, hidden_size: int = 256, intermediate_size: int = 512):
+        super().__init__()
+        self.mlp = SwiGLUMLP(hidden_size, intermediate_size).to(device="cuda", dtype=torch.float16)
+
+    def forward(self, x):
+        return self.mlp(x)
+
+
+class MultiLayerTestModel(torch.nn.Module):
+    """Test model with multiple SwiGLU MLP layers."""
+
+    def __init__(self, hidden_size: int = 256, intermediate_size: int = 512, num_layers: int = 2):
+        super().__init__()
+        self.layers = torch.nn.ModuleList(
+            [
+                SwiGLUMLP(hidden_size, intermediate_size).to(device="cuda", dtype=torch.float16)
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+
+def _count_ops(gm, op):
+    return sum(1 for n in gm.graph.nodes if is_op(n, op))
+
+
+def _export_model(model, batch_size=2, hidden_size=256):
+    x = torch.randn(batch_size, hidden_size, device="cuda", dtype=torch.float16)
+    dynamic_shapes = {"x": {0: Dim("batch", min=1, max=16)}}
+    gm = torch_export_to_gm(model, (x,), dynamic_shapes=dynamic_shapes)
+    return gm, x
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fuse_silu_mul_basic():
+    """Test that silu+mul is fused after GEMM fusion merges gate+up projections."""
+    model = TestModel()
+    gm, x = _export_model(model)
+
+    # Step 1: Run GEMM fusion to merge gate+up projections
+    transforms = {
+        "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
+    }
+    io = InferenceOptimizer(transforms)
+    gm = io.run(gm)
+
+    # Verify GEMM fusion happened: should have narrow ops now
+    assert _count_ops(gm, torch.narrow) >= 2, "Expected narrow ops after GEMM fusion"
+    # silu and mul should still exist
+    assert _count_ops(gm, torch.ops.aten.silu.default) >= 1
+    assert _count_ops(gm, torch.ops.aten.mul.Tensor) >= 1
+
+    # Step 2: Run silu+mul fusion
+    transforms = {
+        "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": True},
+    }
+    io = InferenceOptimizer(transforms)
+    gm = io.run(gm)
+
+    # Verify silu+mul fusion happened
+    assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) >= 1
+    # Original silu and mul ops should be gone
+    assert _count_ops(gm, torch.ops.aten.silu.default) == 0
+    assert _count_ops(gm, torch.ops.aten.mul.Tensor) == 0
+
+    # Verify correctness
+    ref_output = model(x)
+    fused_output = gm(x)
+    torch.testing.assert_close(fused_output, ref_output, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fuse_silu_mul_multi_layer():
+    """Test that silu+mul fusion works across multiple layers."""
+    num_layers = 3
+    model = MultiLayerTestModel(num_layers=num_layers)
+    gm, x = _export_model(model)
+
+    # Run both fusions in sequence
+    transforms = {
+        "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
+        "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": True},
+    }
+    io = InferenceOptimizer(transforms)
+    gm = io.run(gm)
+
+    # Should have one silu_and_mul per layer
+    assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) == num_layers
+    assert _count_ops(gm, torch.ops.aten.silu.default) == 0
+    assert _count_ops(gm, torch.ops.aten.mul.Tensor) == 0
+
+    # Verify correctness
+    ref_output = model(x)
+    fused_output = gm(x)
+    torch.testing.assert_close(fused_output, ref_output, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_fuse_silu_mul_disabled():
+    """Test that fusion is skipped when disabled."""
+    model = TestModel()
+    gm, x = _export_model(model)
+
+    transforms = {
+        "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
+        "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": False},
+    }
+    io = InferenceOptimizer(transforms)
+    gm = io.run(gm)
+
+    # silu_and_mul should NOT be present when disabled
+    assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) == 0
+    # Original ops should still be there
+    assert _count_ops(gm, torch.ops.aten.silu.default) >= 1

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_silu_mul.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_silu_mul.py
@@ -2,9 +2,9 @@ import pytest
 import torch
 from torch.export import Dim
 
-from tensorrt_llm._torch.auto_deploy.custom_ops.linear.silu_mul import *  # noqa
+import tensorrt_llm._torch.auto_deploy.custom_ops.linear.silu_mul as _silu_mul  # noqa: F401 — registers custom op
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
-from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, TransformRegistry
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 
 
@@ -61,6 +61,26 @@ def _export_model(model, batch_size=2, hidden_size=256):
     return gm, x
 
 
+def _run_transforms(gm, transform_specs):
+    """Run transforms directly on a graph module without InferenceOptimizer.
+
+    Args:
+        gm: The graph module to transform.
+        transform_specs: Dict mapping transform names to config dicts
+            (e.g. {"fuse_silu_mul": {"stage": "post_load_fusion", "enabled": True}}).
+
+    Returns:
+        The transformed graph module.
+    """
+    shared_config = SharedConfig(local_rank=0, world_size=1)
+    for name, config_kwargs in transform_specs.items():
+        config_cls = TransformRegistry.get_config_class(name)
+        config = config_cls(**config_kwargs)
+        transform = TransformRegistry.get(name)(config)
+        gm, _ = transform._apply(gm, cm=None, factory=None, shared_config=shared_config)
+    return gm
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_fuse_silu_mul_basic():
     """Test that silu+mul is fused after GEMM fusion merges gate+up projections."""
@@ -68,11 +88,12 @@ def test_fuse_silu_mul_basic():
     gm, x = _export_model(model)
 
     # Step 1: Run GEMM fusion to merge gate+up projections
-    transforms = {
-        "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
-    }
-    io = InferenceOptimizer(transforms)
-    gm = io.run(gm)
+    gm = _run_transforms(
+        gm,
+        {
+            "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
+        },
+    )
 
     # Verify GEMM fusion happened: should have narrow ops now
     assert _count_ops(gm, torch.narrow) >= 2, "Expected narrow ops after GEMM fusion"
@@ -81,11 +102,12 @@ def test_fuse_silu_mul_basic():
     assert _count_ops(gm, torch.ops.aten.mul.Tensor) >= 1
 
     # Step 2: Run silu+mul fusion
-    transforms = {
-        "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": True},
-    }
-    io = InferenceOptimizer(transforms)
-    gm = io.run(gm)
+    gm = _run_transforms(
+        gm,
+        {
+            "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": True},
+        },
+    )
 
     # Verify silu+mul fusion happened
     assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) >= 1
@@ -107,12 +129,13 @@ def test_fuse_silu_mul_multi_layer():
     gm, x = _export_model(model)
 
     # Run both fusions in sequence
-    transforms = {
-        "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
-        "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": True},
-    }
-    io = InferenceOptimizer(transforms)
-    gm = io.run(gm)
+    gm = _run_transforms(
+        gm,
+        {
+            "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
+            "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": True},
+        },
+    )
 
     # Should have one silu_and_mul per layer
     assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) == num_layers
@@ -131,12 +154,13 @@ def test_fuse_silu_mul_disabled():
     model = TestModel()
     gm, x = _export_model(model)
 
-    transforms = {
-        "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
-        "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": False},
-    }
-    io = InferenceOptimizer(transforms)
-    gm = io.run(gm)
+    gm = _run_transforms(
+        gm,
+        {
+            "fuse_gemms_mixed_children": {"stage": "post_load_fusion", "enabled": True},
+            "fuse_silu_mul": {"stage": "post_load_fusion", "enabled": False},
+        },
+    )
 
     # silu_and_mul should NOT be present when disabled
     assert _count_ops(gm, torch.ops.auto_deploy.silu_and_mul.default) == 0


### PR DESCRIPTION
The fusion replaces separate narrow → silu +    
  narrow → mul ops with a single silu_and_mul kernel (using 
  FlashInfer's fused implementation when available).

llama 8B fp8 1k/2k/64 H100 CW perf:
+3.3% output throughput (7,626 → 7,880 tok/s) and -3.2%  
  latency (8,702 → 8,420 ms avg) with the SiLU+Mul fusion enabled
  across all 32 Llama layers.                                     

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fused SiLU+Mul activation operation optimization to enhance model inference performance.

* **Chores**
  * Added new post-load-fusion transform configuration with SiLU+Mul fusion capabilities.
  * Updated Llama 3.1 8B model registry configuration to enable the optimization.

* **Tests**
  * Added comprehensive unit tests covering basic fusion, multi-layer models, and configuration toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
