### PR TITLE
[https://nvbugs/6008710][fix] Adjust prompt logprobs to use the correct prompt token id

### DIFF
--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -856,9 +856,15 @@ def _compute_pytorch_prompt_logprobs(
             )  # generation logprobs, if requested, is provided directly in response.result.log_probs from the sampler.
     context_logits = response.result.context_logits
     assert context_logits is not None, "context_logits cannot be None when prompt_logprobs is requested."
+    result = response.result.get_result()
+    assert result is not None, "result cannot be None when prompt_logprobs is requested."
+    # Single element list
+    first_generation_token = result.output_token_ids[0][:1]
+    assert first_generation_token, "first generation token cannot be empty when prompt_logprobs is requested."
     # Pass prompt_token_ids with an offset of 1 for correct mapping to the context logits
     prompt_token_ids = generation_result._generation_request.prompt_token_ids[
-        1:]
+        1:] + first_generation_token
+
     logprobs_result = compute_logprobs(logprob_params.prompt_logprobs, None,
                                        context_logits, None, None,
                                        prompt_token_ids)

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -855,12 +855,12 @@ def _compute_pytorch_prompt_logprobs(
                 prompt=cached, generation=None
             )  # generation logprobs, if requested, is provided directly in response.result.log_probs from the sampler.
     context_logits = response.result.context_logits
-    assert context_logits is not None, "context_logits cannot be None when prompt_logprobs is requested."
+    assert context_logits is not None, "context_logits must not be None when prompt_logprobs is requested."
     result = response.result.get_result()
-    assert result is not None, "result cannot be None when prompt_logprobs is requested."
+    assert result is not None, "result must not be None when prompt_logprobs is requested."
     # Single element list
     first_generation_token = result.output_token_ids[0][:1]
-    assert first_generation_token, "first generation token cannot be empty when prompt_logprobs is requested."
+    assert first_generation_token, "first generation token must not be empty when prompt_logprobs is requested."
     # Pass prompt_token_ids with an offset of 1 for correct mapping to the context logits
     prompt_token_ids = generation_result._generation_request.prompt_token_ids[
         1:] + first_generation_token

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -856,7 +856,9 @@ def _compute_pytorch_prompt_logprobs(
             )  # generation logprobs, if requested, is provided directly in response.result.log_probs from the sampler.
     context_logits = response.result.context_logits
     assert context_logits is not None, "context_logits cannot be None when prompt_logprobs is requested."
-    prompt_token_ids = generation_result._generation_request.prompt_token_ids
+    # Pass prompt_token_ids with an offset of 1 for correct mapping to the context logits
+    prompt_token_ids = generation_result._generation_request.prompt_token_ids[
+        1:]
     logprobs_result = compute_logprobs(logprob_params.prompt_logprobs, None,
                                        context_logits, None, None,
                                        prompt_token_ids)

--- a/tests/unittest/_torch/sampler/test_logits_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_logits_logprobs.py
@@ -303,7 +303,7 @@ def test_sampled_token_always_in_prompt_logprobs(logprobs_k: int, simple_llm: LL
         print(f"Prompt token IDs: {output.prompt_token_ids}")
 
         logprobs = output.outputs[0].prompt_logprobs
-        token_ids = output.prompt_token_ids[1:]
+        token_ids = output.prompt_token_ids[1:] + output.outputs[0].token_ids[:1]
 
         assert len(logprobs) == len(token_ids), (
             f"Expected {len(token_ids)} logprob entries, got {len(logprobs)}"
@@ -431,7 +431,7 @@ def test_logprobs_against_logits(
                 logprobs_offset=0,
             )
         if prompt_logprobs_k is not None:
-            context_tokens = output.prompt_token_ids
+            context_tokens = output.prompt_token_ids + output.outputs[0].token_ids[:1]
             context_logprobs = output.outputs[0].prompt_logprobs
             context_logits = output.context_logits.to(device="cuda")
             check_logprobs(
@@ -442,6 +442,47 @@ def test_logprobs_against_logits(
                 "context",
                 logprobs_offset=1,  # Prompt logprobs are offset by 1 relative to the prompt token ids
             )
+        # The last context logprob dict and the first generation logprob dict should agree on
+        # the top-n entries (n = min(prompt_logprobs_k, logprobs_k)) and the sampled token's logprob.
+        if prompt_logprobs_k is not None and logprobs_k is not None:
+            last_context_logprob = context_logprobs[-1]
+            first_generation_logprob = generation_logprobs[0]
+            less_prompt_logprobs = prompt_logprobs_k <= logprobs_k
+            expected = last_context_logprob if less_prompt_logprobs else first_generation_logprob
+            compare = first_generation_logprob if less_prompt_logprobs else last_context_logprob
+            sampled_token_id = generation_tokens[0]
+            assert sampled_token_id in last_context_logprob, (
+                f"Sampled token {sampled_token_id} is not a valid key in the last entry "
+                f"of the context logprob dict: {list(last_context_logprob.keys())}"
+            )
+            assert sampled_token_id in first_generation_logprob, (
+                f"Sampled token {sampled_token_id} is not a valid key in the first entry "
+                f"of the generation logprob dict: {list(first_generation_logprob.keys())}"
+            )
+            torch.testing.assert_close(
+                last_context_logprob[sampled_token_id].logprob,
+                first_generation_logprob[sampled_token_id].logprob,
+                msg=(
+                    f"logprob {last_context_logprob[sampled_token_id].logprob} in the last "
+                    f"entry of the context logprob dict does not match the corresponding "
+                    f"logprob {first_generation_logprob[sampled_token_id].logprob} in the "
+                    f"first entry of the generation logprob dict for token {sampled_token_id}"
+                ),
+            )
+            for key, value in expected.items():
+                assert key in compare, (
+                    f"Token {key} is not a valid key in the other dict: {list(compare.keys())}"
+                )
+                expected_logprob = value.logprob
+                compare_logprob = compare[key].logprob
+                torch.testing.assert_close(
+                    expected_logprob,
+                    compare_logprob,
+                    msg=(
+                        f"logprob {expected_logprob} does not match the corresponding "
+                        f"logprob {compare_logprob} in the other dict for token {key}"
+                    ),
+                )
 
 
 @pytest.mark.parametrize("logprobs_k", [0, 2], ids=["top_0", "top_2"])

--- a/tests/unittest/_torch/sampler/test_logits_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_logits_logprobs.py
@@ -303,7 +303,7 @@ def test_sampled_token_always_in_prompt_logprobs(logprobs_k: int, simple_llm: LL
         print(f"Prompt token IDs: {output.prompt_token_ids}")
 
         logprobs = output.outputs[0].prompt_logprobs
-        token_ids = output.prompt_token_ids
+        token_ids = output.prompt_token_ids[1:]
 
         assert len(logprobs) == len(token_ids), (
             f"Expected {len(token_ids)} logprob entries, got {len(logprobs)}"
@@ -372,6 +372,7 @@ def test_logprobs_against_logits(
         logprobs: TokenLogprobs,
         logits_cuda: torch.Tensor,
         case_str: str,
+        logprobs_offset: int = 0,
     ):
         """Checks if the provided logprobs match the logprobs calculated from the logits"""
         expected_logprobs = torch.nn.functional.log_softmax(logits_cuda, dim=-1).to(device="cpu")
@@ -385,7 +386,7 @@ def test_logprobs_against_logits(
             processed_ranks_and_logprobs: dict[int, float] = {}
             for token_id, logprob_obj in token_logprobs.items():
                 # the sampled token may have any rank > 0
-                if token_id != tokens[generation_idx]:
+                if token_id != tokens[generation_idx + logprobs_offset]:
                     # All other tokens should have a rank <= num_logprobs
                     assert logprob_obj.rank <= num_logprobs, (
                         f"{case_str} logprob rank is greater than {num_logprobs}"
@@ -427,6 +428,7 @@ def test_logprobs_against_logits(
                 generation_logprobs,
                 generation_logits,
                 "generation",
+                logprobs_offset=0,
             )
         if prompt_logprobs_k is not None:
             context_tokens = output.prompt_token_ids
@@ -438,6 +440,7 @@ def test_logprobs_against_logits(
                 context_logprobs,
                 context_logits,
                 "context",
+                logprobs_offset=1,  # Prompt logprobs are offset by 1 relative to the prompt token ids
             )
 
 

--- a/tests/unittest/_torch/sampler/test_logits_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_logits_logprobs.py
@@ -469,18 +469,18 @@ def test_logprobs_against_logits(
                     f"first entry of the generation logprob dict for token {sampled_token_id}"
                 ),
             )
-            for key, value in expected.items():
-                assert key in compare, (
-                    f"Token {key} is not a valid key in the other dict: {list(compare.keys())}"
+            for token_id, logprob_obj in expected.items():
+                assert token_id in compare, (
+                    f"Token {token_id} is not a valid key in the other dict: {list(compare.keys())}"
                 )
-                expected_logprob = value.logprob
-                compare_logprob = compare[key].logprob
+                expected_logprob = logprob_obj.logprob
+                compare_logprob = compare[token_id].logprob
                 torch.testing.assert_close(
                     expected_logprob,
                     compare_logprob,
                     msg=(
                         f"logprob {expected_logprob} does not match the corresponding "
-                        f"logprob {compare_logprob} in the other dict for token {key}"
+                        f"logprob {compare_logprob} in the other dict for token {token_id}"
                     ),
                 )
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation for log probability calculations to ensure accuracy.

* **Tests**
  * Enhanced test coverage for log probability computations with improved validation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

When determining the logprob of the prompt-token, the current implementation used the prompt token, which was used as input to create the logits/logprobs instead of the prompt-token which would come next. This PR adjusts this such that the prompt-token in the prompt-logprobs output are matched correctly

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
