### PR TITLE
[None][feat] Fix _waiting_requests to use compute tokens with KV cache reuse

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2723,8 +2723,11 @@ class PyExecutor:
         - The number of waiting iterations is smaller than `self.batch_wait_timeout_iters`.
         """
 
-        num_scheduled_ctx_tokens = sum(
-            len(ctx_req.get_tokens(0)) for ctx_req in context_requests)
+        num_scheduled_ctx_tokens = 0
+        for ctx_req in context_requests:
+            req_tokens = len(ctx_req.get_tokens(0))
+            reusable = ctx_req.estimated_reusable_tokens if ctx_req.is_first_context_chunk else 0
+            num_scheduled_ctx_tokens += max(1, req_tokens - reusable)
         num_scheduled_gen_tokens = sum(1 + gen_req.num_draft_tokens
                                        for gen_req in generation_requests)
         num_scheduled_tokens = num_scheduled_ctx_tokens + num_scheduled_gen_tokens


### PR DESCRIPTION
  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token counting accuracy in request scheduling, which may enhance performance efficiency in certain usage scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

  ## Description

  `_waiting_requests()` in `py_executor.py` uses `get_tokens(0)` to compute the scheduled context token count for the batch_wait decision. `get_tokens(0)` returns the **full input
  sequence length** (e.g., ~34K tokens for agentic workloads), which always exceeds the `batch_wait_max_tokens_ratio * max_num_tokens` threshold. This makes `batch_wait_timeout_iters` a
  complete no-op when KV cache block reuse is enabled.

  **Fix**: Subtract `estimated_reusable_tokens` (already set by the capacity scheduler's radix tree lookup) to get the actual compute tokens, matching how the micro batch scheduler
  itself accounts for cache reuse.

  **Before** (always False → never waits):
  ```python
  num_scheduled_ctx_tokens = sum(
      len(ctx_req.get_tokens(0)) for ctx_req in context_requests)
  # → 34742 tokens >> 4096 threshold → should_waiting = False

  After (correctly reflects compute cost):
  for ctx_req in context_requests:
      req_tokens = len(ctx_req.get_tokens(0))
      reusable = ctx_req.estimated_reusable_tokens if ctx_req.is_first_context_chunk else 0
      num_scheduled_ctx_tokens += max(1, req_tokens - reusable)
  # → 1106 compute tokens < 4096 threshold → should_waiting = True

  Impact: On DeepSeek-V3.2-NVFP4 8×B200 with agentic coding workload (closed-loop, c=16, 97% cache hit), batch_wait_timeout_iters=30 improves output throughput by +12% (710 → 794 tok/s).

  Test Coverage

  - Validated with AA-RWLT agentic coding benchmark (DeepSeek-V3.2-NVFP4, 8×B200, c=16, settling=300s)
  - Tested bw=0, bw=30, bw=100 configurations with debug logging confirming should_waiting engages correctly
  - Existing unit tests for _waiting_requests should be extended to cover the estimated_reusable_tokens path

  PR Checklist

  - Please check this after reviewing the above items as appropriate for this PR.