### PR TITLE
[None][feat] Improve disaggregated benchmark slurm scripts

### DIFF
--- a/examples/disaggregated/slurm/benchmark/README.md
+++ b/examples/disaggregated/slurm/benchmark/README.md
@@ -14,8 +14,8 @@ The benchmarking process is orchestrated through a combination of Python scripts
    - `start_server.sh`: Starts the disaggregated serving coordinator
    - `wait_server.sh`: Waits for server readiness before benchmarking
    - `run_benchmark.sh` / `run_benchmark_nv_sa.sh`: Execute benchmark workloads
-   - `accuracy_eval.sh`: Runs accuracy evaluation using lm_eval
-   - `gen_server_config.py`: Generates server configuration from worker settings
+   - `benchmark_utils.sh`: Shared utility functions for benchmark log processing
+   - `get_env.py`: Collects TensorRT-LLM version and commit info into `env_vars.json`
 
 ## Configuration (config.yaml)
 
@@ -37,15 +37,17 @@ slurm:
 ### 2. Benchmark Configuration
 ```yaml
 benchmark:
-  mode: "e2e"  # Options: e2e (end-to-end), gen_only (generation only)
+  mode: "e2e"  # Options: e2e, gen_only, gen_only_no_context
+  enable_benchmark: true  # Set false to skip benchmarking (e.g., accuracy-only runs)
   use_nv_sa_benchmark: false  # Use NVIDIA SA benchmark script
   multi_round: 8  # Number of benchmark rounds
-  benchmark_ratio: 0.8  # Fraction of requests to benchmark
+  benchmark_ratio: 0.8  # Fraction of requests to benchmark (SA benchmark only)
   streaming: true  # Enable streaming mode
   concurrency_list: "16"  # Comma-separated list of concurrency levels to test
   input_length: 1024  # Input sequence length
   output_length: 1024  # Output sequence length
   dataset_file: "<dataset_file>"  # Path to dataset file
+  env_var: {}  # Optional environment variables for benchmark client
 ```
 
 ### 3. Hardware Configuration
@@ -64,10 +66,14 @@ environment:
   model_path: "<model_path>"  # Path to model checkpoint
   trtllm_repo: "<trtllm_repo>"  # Path to TensorRT-LLM repository
   build_wheel: false  # Set true to build TensorRT-LLM from source
+  cuda_architectures: ""  # CUDA architectures to build for (e.g., "90-real;100-real"). Empty = all
   trtllm_wheel_path: ""  # Path to pre-built wheel (if not building from source)
   work_dir: "<full_path_to_work_dir>"  # Working directory for outputs
-  worker_env_var: "TLLM_LOG_LEVEL=INFO ..."  # Environment variables for workers
+  log_dir: ""  # Optional: override the auto-generated log directory path
+  worker_env_var: "TLLM_LOG_LEVEL=INFO ..."  # Environment variables for all workers
   server_env_var: "TRTLLM_SERVER_DISABLE_GC=1"  # Environment variables for server
+  ctx_worker_env_var: ""  # Additional environment variables for context workers only
+  gen_worker_env_var: ""  # Additional environment variables for generation workers only
 ```
 
 ### 5. Worker Configuration
@@ -126,8 +132,14 @@ Use the `submit.py` script to submit your benchmark job:
 # Submit a single configuration
 python3 submit.py -c my_benchmark.yaml
 
-# Or submit multiple configurations from a directory
+# Submit multiple configurations from a directory
 python3 submit.py -d ./configs/
+
+# Override the log directory
+python3 submit.py -c my_benchmark.yaml --log-dir /path/to/logs
+
+# Dry run (validate config and print sbatch command without submitting)
+python3 submit.py -c my_benchmark.yaml --dry-run
 ```
 
 The submission script will:
@@ -162,15 +174,18 @@ ls <work_dir>/<date>/<isl-osl>/<config>/logs/
 
 Results are automatically organized in the work directory:
 ```
-<work_dir>/
-  └── <YYYYMMDD>/
+<work_dir>/logs/
+  └── <YYYYMMDD-HHMMSS>-<config_name>/
       └── <isl>-<osl>/
-          └── ctx<N>_gen<M>_dep<X>_batch<Y>_eplb<Z>_mtp<W>/
-              ├── logs/
+          └── disagg_ctx<N>_gen<M>_dep<X>_batch<Y>_eplb<Z>_mtp<W>/
               ├── ctx_config.yaml
               ├── gen_config.yaml
-              ├── job_info.txt
-              └── bench.log
+              ├── server_config_base.yaml
+              ├── allocations.json
+              ├── env_vars.json
+              ├── start_server_cmds_base.sh
+              ├── client_cmds_base.sh
+              └── slurm-<job_id>.out
 ```
 
 ### Benchmark Modes
@@ -203,17 +218,24 @@ Metrics are automatically collected from worker iteration logs and stored in the
 
 #### 1. Accuracy Evaluation
 
-Enable accuracy evaluation using the lm_eval framework:
+Enable accuracy evaluation using the lm_eval framework. Tasks are configured as a nested dictionary, allowing per-task settings:
 
 ```yaml
 accuracy:
   enable_accuracy_test: true
-  model: "local-completions"
-  tasks: "gsm8k,hellaswag,mmlu"  # Comma-separated task list
-  model_args_extra: "num_concurrent=512,max_retries=3,tokenized_requests=false,timeout=1200,max_gen_toks=256,max_length=4096"
+  env_var: {}  # Optional environment variables for accuracy evaluation
+  tasks:
+    gsm8k:
+      model: "local-completions"  # or "local-chat-completions"
+      model_args_extra: "num_concurrent=512,max_retries=3,tokenized_requests=false,timeout=7200,max_gen_toks=16384"
+      extra_kwargs:
+        trust_remote_code: true
+    hellaswag:
+      model: "local-completions"
+      model_args_extra: "num_concurrent=512,max_retries=3,tokenized_requests=false,timeout=1200"
 ```
 
-Accuracy results will be saved in `<log_dir>/accuracy_eval/` after benchmark completion.
+Accuracy results will be saved in `<log_dir>/accuracy_eval_<task>/` after benchmark completion.
 
 #### 2. NVIDIA Nsight Systems Profiling
 
@@ -252,6 +274,7 @@ Build from source:
 environment:
   trtllm_repo: "/path/to/TensorRT-LLM"
   build_wheel: true  # Builds wheel on one node
+  cuda_architectures: "90-real;100-real"  # Optional: limit architectures for faster builds
 ```
 
 Or install from pre-built wheel:

--- a/examples/disaggregated/slurm/benchmark/benchmark_utils.sh
+++ b/examples/disaggregated/slurm/benchmark/benchmark_utils.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Shared utility functions for disaggregated benchmark scripts.
+#
+# Globals set by setup_start_logs (used by do_process_all_logs "clean" mode):
+#   tmp_start_logs  — path to temporary start log directory
+
+do_get_logs(){
+    local input_file=$1
+    local output_file=$2
+    local mode=$3
+    local start_line=$4
+    # check mode is ctx or gen
+    if [ "${mode}" = "ctx" ]; then
+        sed -n "${start_line},\$p" ${input_file} | grep -a "'num_generation_tokens': 0" > ${output_file} || true
+    elif [ "${mode}" = "gen" ]; then
+        sed -n "${start_line},\$p" ${input_file} | grep -a "'num_ctx_requests': 0, 'num_ctx_tokens': 0" > ${output_file} || true
+    else
+        echo "Invalid mode: ${mode}"
+        return 1
+    fi
+    return 0
+}
+
+do_process_all_logs(){
+    local input_folder=$1
+    local output_folder=$2
+    local mode=$3
+    local log_path=$4
+    if [ "${mode}" != "line" ] && [ "${mode}" != "log" ] && [ "${mode}" != "clean" ]; then
+        echo "Invalid mode: ${mode}"
+        exit 1
+    fi
+    local ctx_log
+    local ctx_num
+    local gen_log
+    local gen_num
+    local line_count
+    local start_line
+    for ctx_log in ${input_folder}/3_output_CTX_*.log; do
+        if [ -f "${ctx_log}" ]; then
+            ctx_num=$(basename "${ctx_log}" | sed 's/3_output_CTX_\([0-9]*\)\.log/\1/')
+            if [ "${mode}" = "line" ]; then
+                line_count=$(wc -l < ${ctx_log})
+                echo ${line_count} > ${output_folder}/ctx_only_line_${ctx_num}.txt
+            elif [ "${mode}" = "log" ]; then
+                if [ ! -f "${output_folder}/ctx_only_line_${ctx_num}.txt" ]; then
+                    start_line=0
+                else
+                    start_line=$(cat ${output_folder}/ctx_only_line_${ctx_num}.txt)
+                    rm -f ${output_folder}/ctx_only_line_${ctx_num}.txt
+                fi
+                do_get_logs ${ctx_log} ${output_folder}/ctx_only_${ctx_num}.txt "ctx" ${start_line}
+            elif [ "${mode}" = "clean" ]; then
+                rm -f ${ctx_log}
+            fi
+        fi
+    done
+    # process all the gen log files in the input folder
+    for gen_log in ${input_folder}/3_output_GEN_*.log; do
+        if [ -f "${gen_log}" ]; then
+            gen_num=$(basename "${gen_log}" | sed 's/3_output_GEN_\([0-9]*\)\.log/\1/')
+            if [ "${mode}" = "line" ]; then
+                line_count=$(wc -l < ${gen_log})
+                echo ${line_count} > ${output_folder}/gen_only_line_${gen_num}.txt
+            elif [ "${mode}" = "log" ]; then
+                if [ ! -f "${output_folder}/gen_only_line_${gen_num}.txt" ]; then
+                    start_line=0
+                else
+                    start_line=$(cat ${output_folder}/gen_only_line_${gen_num}.txt)
+                    rm -f ${output_folder}/gen_only_line_${gen_num}.txt
+                fi
+                do_get_logs ${gen_log} ${output_folder}/gen_only_${gen_num}.txt "gen" ${start_line}
+            elif [ "${mode}" = "clean" ]; then
+                rm -f ${gen_log}
+            fi
+        fi
+    done
+    if [ "${mode}" = "clean" ]; then
+        if [ -d "${tmp_start_logs}" ]; then
+            mkdir -p ${log_path}/start_logs
+            cp ${tmp_start_logs}/3_output_CTX_*.log ${log_path}/start_logs/ 2>/dev/null || true
+            cp ${tmp_start_logs}/3_output_GEN_*.log ${log_path}/start_logs/ 2>/dev/null || true
+            rm -rf ${tmp_start_logs}
+        fi
+    fi
+}
+
+setup_start_logs(){
+    local job_id=$1
+    local log_path=$2
+    tmp_start_logs=/tmp/${job_id}/start_logs
+    mkdir -p ${tmp_start_logs}
+    cp ${log_path}/3_output_CTX_*.log ${tmp_start_logs}/ 2>/dev/null || true
+    cp ${log_path}/3_output_GEN_*.log ${tmp_start_logs}/ 2>/dev/null || true
+}

--- a/examples/disaggregated/slurm/benchmark/benchmark_utils.sh
+++ b/examples/disaggregated/slurm/benchmark/benchmark_utils.sh
@@ -5,15 +5,15 @@
 #   tmp_start_logs  — path to temporary start log directory
 
 do_get_logs(){
-    local input_file=$1
-    local output_file=$2
-    local mode=$3
-    local start_line=$4
+    local input_file="$1"
+    local output_file="$2"
+    local mode="$3"
+    local start_line="$4"
     # check mode is ctx or gen
     if [ "${mode}" = "ctx" ]; then
-        sed -n "${start_line},\$p" ${input_file} | grep -a "'num_generation_tokens': 0" > ${output_file} || true
+        sed -n "${start_line},\$p" "${input_file}" | grep -a "'num_generation_tokens': 0" > "${output_file}" || true
     elif [ "${mode}" = "gen" ]; then
-        sed -n "${start_line},\$p" ${input_file} | grep -a "'num_ctx_requests': 0, 'num_ctx_tokens': 0" > ${output_file} || true
+        sed -n "${start_line},\$p" "${input_file}" | grep -a "'num_ctx_requests': 0, 'num_ctx_tokens': 0" > "${output_file}" || true
     else
         echo "Invalid mode: ${mode}"
         return 1
@@ -22,10 +22,10 @@ do_get_logs(){
 }
 
 do_process_all_logs(){
-    local input_folder=$1
-    local output_folder=$2
-    local mode=$3
-    local log_path=$4
+    local input_folder="$1"
+    local output_folder="$2"
+    local mode="$3"
+    local log_path="$4"
     if [ "${mode}" != "line" ] && [ "${mode}" != "log" ] && [ "${mode}" != "clean" ]; then
         echo "Invalid mode: ${mode}"
         exit 1
@@ -36,60 +36,60 @@ do_process_all_logs(){
     local gen_num
     local line_count
     local start_line
-    for ctx_log in ${input_folder}/3_output_CTX_*.log; do
+    for ctx_log in "${input_folder}"/3_output_CTX_*.log; do
         if [ -f "${ctx_log}" ]; then
             ctx_num=$(basename "${ctx_log}" | sed 's/3_output_CTX_\([0-9]*\)\.log/\1/')
             if [ "${mode}" = "line" ]; then
-                line_count=$(wc -l < ${ctx_log})
-                echo ${line_count} > ${output_folder}/ctx_only_line_${ctx_num}.txt
+                line_count=$(wc -l < "${ctx_log}")
+                echo "${line_count}" > "${output_folder}/ctx_only_line_${ctx_num}.txt"
             elif [ "${mode}" = "log" ]; then
                 if [ ! -f "${output_folder}/ctx_only_line_${ctx_num}.txt" ]; then
                     start_line=0
                 else
-                    start_line=$(cat ${output_folder}/ctx_only_line_${ctx_num}.txt)
-                    rm -f ${output_folder}/ctx_only_line_${ctx_num}.txt
+                    start_line=$(cat "${output_folder}/ctx_only_line_${ctx_num}.txt")
+                    rm -f "${output_folder}/ctx_only_line_${ctx_num}.txt"
                 fi
-                do_get_logs ${ctx_log} ${output_folder}/ctx_only_${ctx_num}.txt "ctx" ${start_line}
+                do_get_logs "${ctx_log}" "${output_folder}/ctx_only_${ctx_num}.txt" "ctx" "${start_line}"
             elif [ "${mode}" = "clean" ]; then
-                rm -f ${ctx_log}
+                rm -f "${ctx_log}"
             fi
         fi
     done
     # process all the gen log files in the input folder
-    for gen_log in ${input_folder}/3_output_GEN_*.log; do
+    for gen_log in "${input_folder}"/3_output_GEN_*.log; do
         if [ -f "${gen_log}" ]; then
             gen_num=$(basename "${gen_log}" | sed 's/3_output_GEN_\([0-9]*\)\.log/\1/')
             if [ "${mode}" = "line" ]; then
-                line_count=$(wc -l < ${gen_log})
-                echo ${line_count} > ${output_folder}/gen_only_line_${gen_num}.txt
+                line_count=$(wc -l < "${gen_log}")
+                echo "${line_count}" > "${output_folder}/gen_only_line_${gen_num}.txt"
             elif [ "${mode}" = "log" ]; then
                 if [ ! -f "${output_folder}/gen_only_line_${gen_num}.txt" ]; then
                     start_line=0
                 else
-                    start_line=$(cat ${output_folder}/gen_only_line_${gen_num}.txt)
-                    rm -f ${output_folder}/gen_only_line_${gen_num}.txt
+                    start_line=$(cat "${output_folder}/gen_only_line_${gen_num}.txt")
+                    rm -f "${output_folder}/gen_only_line_${gen_num}.txt"
                 fi
-                do_get_logs ${gen_log} ${output_folder}/gen_only_${gen_num}.txt "gen" ${start_line}
+                do_get_logs "${gen_log}" "${output_folder}/gen_only_${gen_num}.txt" "gen" "${start_line}"
             elif [ "${mode}" = "clean" ]; then
-                rm -f ${gen_log}
+                rm -f "${gen_log}"
             fi
         fi
     done
     if [ "${mode}" = "clean" ]; then
-        if [ -d "${tmp_start_logs}" ]; then
-            mkdir -p ${log_path}/start_logs
-            cp ${tmp_start_logs}/3_output_CTX_*.log ${log_path}/start_logs/ 2>/dev/null || true
-            cp ${tmp_start_logs}/3_output_GEN_*.log ${log_path}/start_logs/ 2>/dev/null || true
-            rm -rf ${tmp_start_logs}
+        if [ -n "${tmp_start_logs:-}" ] && [ -d "${tmp_start_logs}" ]; then
+            mkdir -p "${log_path}/start_logs"
+            cp "${tmp_start_logs}"/3_output_CTX_*.log "${log_path}/start_logs/" 2>/dev/null || true
+            cp "${tmp_start_logs}"/3_output_GEN_*.log "${log_path}/start_logs/" 2>/dev/null || true
+            rm -rf "${tmp_start_logs}"
         fi
     fi
 }
 
 setup_start_logs(){
-    local job_id=$1
-    local log_path=$2
-    tmp_start_logs=/tmp/${job_id}/start_logs
-    mkdir -p ${tmp_start_logs}
-    cp ${log_path}/3_output_CTX_*.log ${tmp_start_logs}/ 2>/dev/null || true
-    cp ${log_path}/3_output_GEN_*.log ${tmp_start_logs}/ 2>/dev/null || true
+    local job_id="$1"
+    local log_path="$2"
+    tmp_start_logs="/tmp/${job_id}/start_logs"
+    mkdir -p "${tmp_start_logs}"
+    cp "${log_path}"/3_output_CTX_*.log "${tmp_start_logs}/" 2>/dev/null || true
+    cp "${log_path}"/3_output_GEN_*.log "${tmp_start_logs}/" 2>/dev/null || true
 }

--- a/examples/disaggregated/slurm/benchmark/config.yaml
+++ b/examples/disaggregated/slurm/benchmark/config.yaml
@@ -87,7 +87,6 @@ worker_config:
       - 768
       - 1024
       - 2048
-      - 256
     print_iter_log: true
     trust_remote_code: true
     kv_cache_config:

--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -172,10 +172,7 @@ echo "Server is ready!"
 echo "Starting client commands from ${client_cmds_file}..."
 while read -r cmd <&3; do
     echo "Starting client command: ${cmd}"
-    eval "${cmd}"
-    if [ $? -ne 0 ]; then
-        cleanup_on_failure "Command failed: ${cmd}."
-    fi
+    eval "${cmd}" || cleanup_on_failure "Command failed: ${cmd}."
 done 3< "${client_cmds_file}"
 
 echo "Job completed successfully, total runtime: $SECONDS seconds"

--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -17,6 +17,7 @@ while [[ $# -gt 0 ]]; do
         --build-wheel) build_wheel="$2"; shift 2 ;;
         --cuda-architectures) cuda_architectures="$2"; shift 2 ;;
         --trtllm-wheel-path) trtllm_wheel_path="$2"; shift 2 ;;
+        --enable-nsys) enable_nsys="$2"; shift 2 ;;
         *)
             echo "Unknown argument: $1"
             exit 1
@@ -39,6 +40,7 @@ echo "  container_image: ${container_image}"
 echo "  build_wheel: ${build_wheel}"
 echo "  cuda_architectures: ${cuda_architectures}"
 echo "  trtllm_wheel_path: ${trtllm_wheel_path}"
+echo "  enable_nsys: ${enable_nsys}"
 
 # Set TRTLLM_DISAGG_BENCHMARK_GEN_ONLY=1 for gen_only_no_context mode
 if [ "${benchmark_mode}" = "gen_only_no_context" ]; then
@@ -178,8 +180,10 @@ done 3< "${client_cmds_file}"
 echo "Job completed successfully, total runtime: $SECONDS seconds"
 
 # Wait for nsys to flush traces before killing workers
-echo "Waiting 120s for nsys trace flush..."
-sleep 120
+if [ "${enable_nsys}" = "true" ]; then
+    echo "Waiting 120s for nsys trace flush..."
+    sleep 120
+fi
 
 # try to kill the server and workers
 scancel ${SLURM_JOB_ID}

--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -177,5 +177,9 @@ done 3< "${client_cmds_file}"
 
 echo "Job completed successfully, total runtime: $SECONDS seconds"
 
+# Wait for nsys to flush traces before killing workers
+echo "Waiting 120s for nsys trace flush..."
+sleep 120
+
 # try to kill the server and workers
 scancel ${SLURM_JOB_ID}

--- a/examples/disaggregated/slurm/benchmark/run_benchmark.sh
+++ b/examples/disaggregated/slurm/benchmark/run_benchmark.sh
@@ -29,90 +29,10 @@ if [[ ${SLURM_PROCID} != "0" ]]; then
     exit 0
 fi
 
-do_get_logs(){
-    local input_file=$1
-    local output_file=$2
-    local mode=$3
-    local start_line=$4
-    # check mode is ctx or gen
-    if [ "${mode}" = "ctx" ]; then
-        sed -n "${start_line},\$p" ${input_file} | grep -a "'num_generation_tokens': 0" > ${output_file} || true
-    elif [ "${mode}" = "gen" ]; then
-        sed -n "${start_line},\$p" ${input_file} | grep -a "'num_ctx_requests': 0, 'num_ctx_tokens': 0" > ${output_file} || true
-    else
-        echo "Invalid mode: ${mode}"
-        return 1
-    fi
-    return 0
-}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/benchmark_utils.sh"
 
-do_process_all_logs(){
-    local input_folder=$1
-    local output_folder=$2
-    local mode=$3
-    if [ "${mode}" != "line" ] && [ "${mode}" != "log" ] && [ "${mode}" != "clean" ]; then
-        echo "Invalid mode: ${mode}"
-        exit 1
-    fi
-    local ctx_log
-    local ctx_num
-    local gen_log
-    local gen_num
-    local line_count
-    local start_line
-    for ctx_log in ${input_folder}/3_output_CTX_*.log; do
-        if [ -f "${ctx_log}" ]; then
-            ctx_num=$(basename "${ctx_log}" | sed 's/3_output_CTX_\([0-9]*\)\.log/\1/')
-            if [ "${mode}" = "line" ]; then
-                line_count=$(wc -l < ${ctx_log})
-                echo ${line_count} > ${output_folder}/ctx_only_line_${ctx_num}.txt
-            elif [ "${mode}" = "log" ]; then
-                if [ ! -f "${output_folder}/ctx_only_line_${ctx_num}.txt" ]; then
-                    start_line=0
-                else
-                    start_line=$(cat ${output_folder}/ctx_only_line_${ctx_num}.txt)
-                    rm -f ${output_folder}/ctx_only_line_${ctx_num}.txt
-                fi
-                do_get_logs ${ctx_log} ${output_folder}/ctx_only_${ctx_num}.txt "ctx" ${start_line}
-            elif [ "${mode}" = "clean" ]; then
-                rm -f ${ctx_log}
-            fi
-        fi
-    done
-    # process all the gen log files in the input folder
-    for gen_log in ${input_folder}/3_output_GEN_*.log; do
-        if [ -f "${gen_log}" ]; then
-            gen_num=$(basename "${gen_log}" | sed 's/3_output_GEN_\([0-9]*\)\.log/\1/')
-            if [ "${mode}" = "line" ]; then
-                line_count=$(wc -l < ${gen_log})
-                echo ${line_count} > ${output_folder}/gen_only_line_${gen_num}.txt
-            elif [ "${mode}" = "log" ]; then
-                if [ ! -f "${output_folder}/gen_only_line_${gen_num}.txt" ]; then
-                    start_line=0
-                else
-                    start_line=$(cat ${output_folder}/gen_only_line_${gen_num}.txt)
-                    rm -f ${output_folder}/gen_only_line_${gen_num}.txt
-                fi
-                do_get_logs ${gen_log} ${output_folder}/gen_only_${gen_num}.txt "gen" ${start_line}
-            elif [ "${mode}" = "clean" ]; then
-                rm -f ${gen_log}
-            fi
-        fi
-    done
-    if [ "${mode}" = "clean" ]; then
-        if [ -d "${tmp_start_logs}" ]; then
-            mkdir -p ${log_path}/start_logs
-            cp ${tmp_start_logs}/3_output_CTX_*.log ${log_path}/start_logs/ 2>/dev/null || true
-            cp ${tmp_start_logs}/3_output_GEN_*.log ${log_path}/start_logs/ 2>/dev/null || true
-            rm -rf ${tmp_start_logs}
-        fi
-    fi
-}
-
-tmp_start_logs=/tmp/${SLURM_JOB_ID}/start_logs
-mkdir -p ${tmp_start_logs}
-cp ${log_path}/3_output_CTX_*.log ${tmp_start_logs}/ 2>/dev/null || true
-cp ${log_path}/3_output_GEN_*.log ${tmp_start_logs}/ 2>/dev/null || true
+setup_start_logs "${SLURM_JOB_ID}" "${log_path}"
 
 # warmup requests for ucx connections
 if [ "${ucx_warmup_requests}" -gt 0 ]; then
@@ -138,7 +58,7 @@ for concurrency in ${concurrency_list}; do
     num_prompts=$((concurrency * multi_round))
     echo "Benchmarking with concurrency ${concurrency} ... ${num_prompts} prompts"
     mkdir -p ${log_path}/concurrency_${concurrency}
-    do_process_all_logs ${log_path}/ ${log_path}/concurrency_${concurrency} "line"
+    do_process_all_logs ${log_path}/ ${log_path}/concurrency_${concurrency} "line" "${log_path}"
     python -m tensorrt_llm.serve.scripts.benchmark_serving \
         --model ${model_name} \
         --backend openai \
@@ -157,6 +77,5 @@ for concurrency in ${concurrency_list}; do
         --percentile-metrics "ttft,tpot,itl,e2el" \
         $(if [ "${streaming}" = "false" ]; then echo "--non-streaming"; fi)
     echo "Benchmark with concurrency ${concurrency} done"
-    do_process_all_logs ${log_path}/ ${log_path}/concurrency_${concurrency} "log"
+    do_process_all_logs ${log_path}/ ${log_path}/concurrency_${concurrency} "log" "${log_path}"
 done
-# do_process_all_logs ${log_path}/ ${log_path}/concurrency_${concurrency} "clean"

--- a/examples/disaggregated/slurm/benchmark/run_benchmark_nv_sa.sh
+++ b/examples/disaggregated/slurm/benchmark/run_benchmark_nv_sa.sh
@@ -11,24 +11,25 @@ readonly BENCH_SCRIPT="${BENCH_SERVING_DIR}/benchmark_serving.py"
 
 usage() {
     cat << EOF
-Usage: $0 model_name input_seq_len output_seq_len ratio multi_round num_gen_servers concurrency_list streaming log_path
-    model_name      : Name of the model to benchmark
-    input_seq_len   : Input sequence length
-    output_seq_len  : Output sequence length
-    ratio          : Random range ratio
-    multi_round    : Number of multi rounds
-    num_gen_servers: Number of generation servers
-    concurrency_list: List of concurrency values
-    streaming      : Enable/disable streaming (true/false)
-    log_path       : Path to store logs
-    hostname       : Hostname of the server
-    port           : Port of the server
+Usage: $0 model_name input_seq_len output_seq_len ratio multi_round num_gen_servers concurrency_list streaming log_path hostname port ucx_warmup_requests
+    model_name          : Name of the model to benchmark
+    input_seq_len       : Input sequence length
+    output_seq_len      : Output sequence length
+    ratio               : Random range ratio
+    multi_round         : Number of multi rounds
+    num_gen_servers     : Number of generation servers
+    concurrency_list    : List of concurrency values
+    streaming           : Enable/disable streaming (true/false)
+    log_path            : Path to store logs
+    hostname            : Hostname of the server
+    port                : Port of the server
+    ucx_warmup_requests : Number of UCX warmup requests
 EOF
     exit 1
 }
 
 # Validate arguments
-[[ $# -lt 11 ]] && usage
+[[ $# -lt 12 ]] && usage
 
 # Parse arguments
 model_name=$1
@@ -52,6 +53,9 @@ fi
 
 echo "Hostname: ${hostname}, Port: ${port}"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/benchmark_utils.sh"
+
 # Clean up and clone benchmark repository
 if [ -d "${BENCH_SERVING_DIR}" ]; then
     echo "Removing existing benchmark directory..."
@@ -60,90 +64,7 @@ fi
 echo "Cloning benchmark repository..."
 git clone "${BENCH_SERVING_REPO}" "${BENCH_SERVING_DIR}"
 
-do_get_logs(){
-    local input_file=$1
-    local output_file=$2
-    local mode=$3
-    local start_line=$4
-    # check mode is ctx or gen
-    if [ "${mode}" = "ctx" ]; then
-        sed -n "${start_line},\$p" ${input_file} | grep -a "'num_generation_tokens': 0" > ${output_file} || true
-    elif [ "${mode}" = "gen" ]; then
-        sed -n "${start_line},\$p" ${input_file} | grep -a "'num_ctx_requests': 0, 'num_ctx_tokens': 0" > ${output_file} || true
-    else
-        echo "Invalid mode: ${mode}"
-        return 1
-    fi
-    return 0
-}
-
-do_process_all_logs(){
-    local input_folder=$1
-    local output_folder=$2
-    local mode=$3
-    if [ "${mode}" != "line" ] && [ "${mode}" != "log" ] && [ "${mode}" != "clean" ]; then
-        echo "Invalid mode: ${mode}"
-        exit 1
-    fi
-    local ctx_log
-    local ctx_num
-    local gen_log
-    local gen_num
-    local line_count
-    local start_line
-    for ctx_log in ${input_folder}/3_output_CTX_*.log; do
-        if [ -f "${ctx_log}" ]; then
-            ctx_num=$(basename "${ctx_log}" | sed 's/3_output_CTX_\([0-9]*\)\.log/\1/')
-            if [ "${mode}" = "line" ]; then
-                line_count=$(wc -l < ${ctx_log})
-                echo ${line_count} > ${output_folder}/ctx_only_line_${ctx_num}.txt
-            elif [ "${mode}" = "log" ]; then
-                if [ ! -f "${output_folder}/ctx_only_line_${ctx_num}.txt" ]; then
-                    start_line=0
-                else
-                    start_line=$(cat ${output_folder}/ctx_only_line_${ctx_num}.txt)
-                    rm -f ${output_folder}/ctx_only_line_${ctx_num}.txt
-                fi
-                do_get_logs ${ctx_log} ${output_folder}/ctx_only_${ctx_num}.txt "ctx" ${start_line}
-            elif [ "${mode}" = "clean" ]; then
-                rm -f ${ctx_log}
-            fi
-        fi
-    done
-    # process all the gen log files in the input folder
-    for gen_log in ${input_folder}/3_output_GEN_*.log; do
-        if [ -f "${gen_log}" ]; then
-            gen_num=$(basename "${gen_log}" | sed 's/3_output_GEN_\([0-9]*\)\.log/\1/')
-            if [ "${mode}" = "line" ]; then
-                line_count=$(wc -l < ${gen_log})
-                echo ${line_count} > ${output_folder}/gen_only_line_${gen_num}.txt
-            elif [ "${mode}" = "log" ]; then
-                if [ ! -f "${output_folder}/gen_only_line_${gen_num}.txt" ]; then
-                    start_line=0
-                else
-                    start_line=$(cat ${output_folder}/gen_only_line_${gen_num}.txt)
-                    rm -f ${output_folder}/gen_only_line_${gen_num}.txt
-                fi
-                do_get_logs ${gen_log} ${output_folder}/gen_only_${gen_num}.txt "gen" ${start_line}
-            elif [ "${mode}" = "clean" ]; then
-                rm -f ${gen_log}
-            fi
-        fi
-    done
-    if [ "${mode}" = "clean" ]; then
-        if [ -d "${tmp_start_logs}" ]; then
-            mkdir -p ${log_path}/start_logs
-            cp ${tmp_start_logs}/3_output_CTX_*.log ${log_path}/start_logs/ 2>/dev/null || true
-            cp ${tmp_start_logs}/3_output_GEN_*.log ${log_path}/start_logs/ 2>/dev/null || true
-            rm -rf ${tmp_start_logs}
-        fi
-    fi
-}
-
-tmp_start_logs=/tmp/${SLURM_JOB_ID}/start_logs
-mkdir -p ${tmp_start_logs}
-cp ${log_path}/3_output_CTX_*.log ${tmp_start_logs}/ 2>/dev/null || true
-cp ${log_path}/3_output_GEN_*.log ${tmp_start_logs}/ 2>/dev/null || true
+setup_start_logs "${SLURM_JOB_ID}" "${log_path}"
 
 # warmup requests for ucx connections
 if [ "${ucx_warmup_requests}" -gt 0 ]; then
@@ -170,7 +91,7 @@ for concurrency in ${concurrency_list}; do
     output_dir="${log_path}/concurrency_${concurrency}"
     echo "Benchmarking with concurrency ${concurrency} ... ${num_prompts} prompts"
     mkdir -p "${output_dir}"
-    do_process_all_logs ${log_path}/ ${log_path}/concurrency_${concurrency} "line"
+    do_process_all_logs ${log_path}/ ${log_path}/concurrency_${concurrency} "line" "${log_path}"
 
     python "${BENCH_SCRIPT}" \
         --model "${model_name}" \
@@ -206,6 +127,5 @@ for concurrency in ${concurrency_list}; do
 	PYEOF
 
     echo "Benchmark with concurrency ${concurrency} done"
-    do_process_all_logs ${log_path}/ ${log_path}/concurrency_${concurrency} "log"
+    do_process_all_logs ${log_path}/ ${log_path}/concurrency_${concurrency} "log" "${log_path}"
 done
-# do_process_all_logs ${log_path}/ ${log_path}/concurrency_${concurrency} "clean"

--- a/examples/disaggregated/slurm/benchmark/start_worker.sh
+++ b/examples/disaggregated/slurm/benchmark/start_worker.sh
@@ -39,7 +39,7 @@ if [ "${enable_nsys}" != "true" ]; then
 else
     nsys_file=${log_dir}/nsys_worker_proc_${role}_${instance_id}_${SLURM_PROCID}
     echo "nsys is enabled on ${role} GPUs, TLLM_PROFILE_START_STOP=${TLLM_PROFILE_START_STOP}"
-    nsys_prefix="nsys profile -o ${nsys_file} -f true -t cuda,nvtx,python-gil -c cudaProfilerApi --cuda-graph-trace node --capture-range-end=stop --gpu-metrics-devices=none"
+    nsys_prefix="nsys profile -o ${nsys_file} -f true -t cuda,nvtx,python-gil -c cudaProfilerApi --cuda-graph-trace node --capture-range-end=stop --gpu-metrics-devices=all --gpu-metrics-frequency=10000"
 fi
 
 ${nsys_prefix} trtllm-llmapi-launch ${numa_bind_cmd} \

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -346,7 +346,7 @@ def save_env_file(env_file, server_env_var, worker_env_var, ctx_worker_env_var,
     print(f"Environment variables saved to {env_file}")
 
 
-def submit_job(config, log_dir, dry_run):
+def submit_job(config, log_dir, dry_run, config_file=None):
     # Extract configurations
     slurm_config = config['slurm']
     slurm_config.setdefault('extra_args', '')
@@ -436,6 +436,10 @@ def submit_job(config, log_dir, dry_run):
         log_base = os.path.join(script_dir, "logs")
 
         date_prefix = datetime.now().strftime("%Y%m%d-%H%M%S")
+        config_name = os.path.splitext(
+            os.path.basename(config_file))[0] if config_file else ""
+        if config_name:
+            date_prefix = f"{date_prefix}-{config_name}"
         log_base = os.path.join(log_base, f"{date_prefix}/{isl}-{osl}")
 
         # Determine directory suffix based on attention_dp
@@ -761,7 +765,7 @@ def main():
         print(f"Processing: {config_file}")
         try:
             config = load_config(config_file)
-            submit_job(config, args.log_dir, args.dry_run)
+            submit_job(config, args.log_dir, args.dry_run, config_file)
             print(f"Successfully submitted job for: {config_file}\n")
         except Exception as e:
             traceback.print_exc()

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import traceback
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import yaml
 
@@ -62,7 +62,7 @@ def allocate_gpus(
     gen_world_size: int,
     ctx_world_size: int,
     base_port: int = 8000,
-) -> List[Dict[str, Any]]:
+) -> Dict[str, Any]:
     allocations = {}
     hostnames = [f"<node{i}_placeholder>" for i in range(total_nodes)]
 
@@ -117,12 +117,14 @@ def convert_allocations_to_server_config(allocations, server_port=8333):
     generation_servers = {}
     context_servers = {}
     server_hostname = None
+    used_ports = set()
 
     for server_type in allocations.keys():
         num_servers = len(allocations[server_type])
         urls = []
         for server_id in allocations[server_type].keys():
             instance = allocations[server_type][server_id]
+            used_ports.add(instance['port'])
             urls.append(
                 f"{list(instance['nodes'].keys())[0]}:{instance['port']}")
 
@@ -131,10 +133,12 @@ def convert_allocations_to_server_config(allocations, server_port=8333):
         if server_type == "GEN":
             generation_servers = server_config_entry
             server_hostname = urls[0].split(':')[0]
-            if allocations[server_type][server_id]['port'] == server_port:
-                server_port += 1  # Avoid port conflict
         elif server_type == "CTX":
             context_servers = server_config_entry
+
+    # Avoid port conflict with any allocated worker port
+    while server_port in used_ports:
+        server_port += 1
 
     server_config = {
         'backend': 'pytorch',
@@ -166,8 +170,9 @@ def replace_env_in_file(log_dir, file_path, env_var):
     with open(file_path, 'r', encoding='utf-8') as f:
         config_content = f.read()
 
+    file_content = config_content
     for env_name, env_value in env_var.items():
-        file_content = config_content.replace(env_name, env_value)
+        file_content = file_content.replace(env_name, env_value)
 
     tmp_dir = os.path.join(log_dir, "lm_eval_configs")
     os.makedirs(tmp_dir, exist_ok=True)

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -722,6 +722,7 @@ def submit_job(config, log_dir, dry_run, config_file=None):
         '--build-wheel', str(env_config['build_wheel']).lower(),
         '--cuda-architectures', env_config['cuda_architectures'],
         '--trtllm-wheel-path', env_config['trtllm_wheel_path'],
+        '--enable-nsys', str(profiling_config['nsys_on']).lower(),
     ]
     # yapf: enable
 

--- a/examples/disaggregated/slurm/benchmark/wait_server.sh
+++ b/examples/disaggregated/slurm/benchmark/wait_server.sh
@@ -14,7 +14,7 @@ readonly STATUS_UPDATE_INTERVAL=30
 # Wait for server to be healthy
 echo "Waiting for server ${hostname}:${port} to be healthy..."
 start_time=$(date +%s)
-while ! curl -s -o /dev/null -w "%{http_code}" "http://${hostname}:${port}/health" > /dev/null 2>&1; do
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' "http://${hostname}:${port}/health" 2>/dev/null)" != "200" ]]; do
     current_time=$(date +%s)
     elapsed=$((current_time - start_time))
 


### PR DESCRIPTION
## Summary
- Extract shared benchmark log-processing into `benchmark_utils.sh` to reduce duplication
- Add new config options: per-worker env vars (`ctx_worker_env_var`, `gen_worker_env_var`), `cuda_architectures`, `log_dir` override, benchmark `env_var`, and per-task accuracy evaluation config
- Enable GPU metrics in nsys profiling and add 120s nsys trace flush wait before job teardown
- Include config file name in benchmark log directory prefix for easier identification
- Update README to document all new options and revised output directory structure

## Test plan
- [ ] Submit a disaggregated benchmark job with updated config and verify logs are organized correctly
- [ ] Verify nsys profiling traces are fully flushed before workers are killed
- [ ] Confirm per-worker env vars are passed correctly to context and generation workers
- [ ] Test `--dry-run` and `--log-dir` CLI options in `submit.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated configuration schema documentation with new options for benchmarking modes and CUDA architecture selection.
  * Revised logs and results directory structure for improved organization.

* **New Features**
  * Added `enable_benchmark` option to skip benchmarking phases.
  * Added generation-only mode for flexible testing scenarios.

* **Improvements**
  * Enhanced error handling for job submission.
  * Improved GPU metrics collection during profiling.
  * Refined server health monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->