### PR TITLE
[https://nvbugs/6015329][fix] Use model-level warmup cache key for visual gen pipelines

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -184,15 +184,12 @@ class DiffusionExecutor:
 
     def process_request(self, req: DiffusionRequest):
         """Process a single request."""
-        if (
-            self.pipeline._warmed_up_shapes
-            and (req.height, req.width, req.num_frames) not in self.pipeline._warmed_up_shapes
-        ):
+        cache_key = self.pipeline.warmup_cache_key(req.height, req.width, req.num_frames)
+        if self.pipeline._warmed_up_shapes and cache_key not in self.pipeline._warmed_up_shapes:
             logger.warning(
-                f"Requested shape (height={req.height}, width={req.width}, "
-                f"num_frames={req.num_frames}) "
-                f"was not warmed up. First request with this shape will be slower due to "
-                f"torch.compile recompilation or CUDA graph capture."
+                f"Requested shape {cache_key} was not warmed up. "
+                f"First request with this shape will be slower due to "
+                f"torch.compile recompilation or CUDA graph capture. "
                 f"Warmed-up shapes: {self.pipeline._warmed_up_shapes}"
             )
         try:

--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -184,7 +184,7 @@ class DiffusionExecutor:
 
     def process_request(self, req: DiffusionRequest):
         """Process a single request."""
-        cache_key = self.pipeline.warmup_cache_key(req.height, req.width, req.num_frames)
+        cache_key = self.pipeline.warmup_cache_key(req.height, req.width, num_frames=req.num_frames)
         if self.pipeline._warmed_up_shapes and cache_key not in self.pipeline._warmed_up_shapes:
             logger.warning(
                 f"Requested shape {cache_key} was not warmed up. "

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -106,7 +106,7 @@ class FluxPipeline(BasePipeline):
     def default_warmup_num_frames(self):
         return [1]
 
-    def warmup_cache_key(self, height: int, width: int, num_frames: int) -> tuple:
+    def warmup_cache_key(self, height: int, width: int, **kwargs) -> tuple:
         return (height, width)
 
     def _init_transformer(self) -> None:

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -106,6 +106,9 @@ class FluxPipeline(BasePipeline):
     def default_warmup_num_frames(self):
         return [1]
 
+    def warmup_cache_key(self, height: int, width: int, num_frames: int) -> tuple:
+        return (height, width)
+
     def _init_transformer(self) -> None:
         """Initialize FLUX transformer with quantization support."""
         logger.info("Creating FLUX transformer with quantization support...")

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -174,7 +174,7 @@ class Flux2Pipeline(BasePipeline):
     def default_warmup_num_frames(self):
         return [1]
 
-    def warmup_cache_key(self, height: int, width: int, num_frames: int) -> tuple:
+    def warmup_cache_key(self, height: int, width: int, **kwargs) -> tuple:
         return (height, width)
 
     def _init_transformer(self) -> None:

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -174,6 +174,9 @@ class Flux2Pipeline(BasePipeline):
     def default_warmup_num_frames(self):
         return [1]
 
+    def warmup_cache_key(self, height: int, width: int, num_frames: int) -> tuple:
+        return (height, width)
+
     def _init_transformer(self) -> None:
         """Initialize FLUX.2 transformer with quantization support."""
         logger.info("Creating FLUX.2 transformer with quantization support...")

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -32,7 +32,7 @@ class BasePipeline(nn.Module):
         self.mapping: Mapping = getattr(model_config, "mapping", None) or Mapping()
         self._cuda_graph_runners: Dict[str, CUDAGraphRunner] = {}
         self._parallel_vae_enabled: bool = False
-        self._warmed_up_shapes: Set[Tuple[int, int, int]] = set()
+        self._warmed_up_shapes: Set[tuple] = set()
 
         # Components
         self.transformer: Optional[nn.Module] = None
@@ -100,6 +100,15 @@ class BasePipeline(nn.Module):
     def transformer_components(self) -> list:
         """Return list of transformer components this pipeline needs."""
         return [PipelineComponent.TRANSFORMER] if self.transformer is not None else []
+
+    def warmup_cache_key(self, height: int, width: int, num_frames: int) -> tuple:
+        """Return the cache key for a given warmup shape.
+
+        Image models (FLUX) override to return (height, width), ignoring
+        num_frames.  Video models use the default (height, width, num_frames).
+        The executor uses this to check whether a request shape was warmed up.
+        """
+        return (height, width, num_frames)
 
     @property
     def default_warmup_resolutions(self) -> List[Tuple[int, int]]:
@@ -436,7 +445,7 @@ class BasePipeline(nn.Module):
             self._run_warmup(height, width, num_frames, steps)
             torch.cuda.synchronize()
 
-        self._warmed_up_shapes = set(tuple(s) for s in shapes)
+        self._warmed_up_shapes = set(self.warmup_cache_key(h, w, f) for h, w, f in shapes)
         elapsed = time.time() - warmup_start
         logger.info(f"Warmup completed in {elapsed:.2f}s")
 

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -445,7 +445,9 @@ class BasePipeline(nn.Module):
             self._run_warmup(height, width, num_frames, steps)
             torch.cuda.synchronize()
 
-        self._warmed_up_shapes = set(self.warmup_cache_key(h, w, f) for h, w, f in shapes)
+        self._warmed_up_shapes = set(
+            self.warmup_cache_key(h, w, num_frames=f) for h, w, f in shapes
+        )
         elapsed = time.time() - warmup_start
         logger.info(f"Warmup completed in {elapsed:.2f}s")
 


### PR DESCRIPTION
## Summary
- Add `warmup_cache_key()` method to `BasePipeline` so each model controls which dimensions matter for warmup cache matching
- FLUX (image-only) overrides to `(height, width)`, ignoring `num_frames`
- Video models (WAN, LTX2) use the default `(height, width, num_frames)`
- Executor uses `pipeline.warmup_cache_key()` instead of hardcoded `(h, w, num_frames)` tuple

## Motivation
FLUX is image-only — `num_frames` has no effect on its computation. But the warmup cache key included `num_frames`, so requests with a non-default `num_frames` value at the same resolution would trigger a false "not warmed up" warning and potentially unnecessary recompilation.

## Test plan
- [x] Verify FLUX warmup with different `num_frames` values no longer triggers warning
- [x] Verify WAN/LTX2 warmup still differentiates by `num_frames`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the caching mechanism for visual generation models by introducing a unified cache key computation system. Different model implementations can now customize their caching strategy based on spatial resolution, improving cache efficiency across pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->