### PR TITLE
[#11992][fix] Support include_stop_token_in_output in gRPC request manager

### DIFF
--- a/tensorrt_llm/grpc/grpc_request_manager.py
+++ b/tensorrt_llm/grpc/grpc_request_manager.py
@@ -246,6 +246,7 @@ def create_sampling_params_from_proto(
     bad_token_ids: Optional[List[int]] = None,
     guided_decoding: Optional[pb2.GuidedDecodingParams] = None,
     embedding_bias: Optional[List[float]] = None,
+    include_stop_token_in_output: bool = False,
 ) -> SamplingParams:
     """Convert protobuf configuration to TensorRT-LLM SamplingParams.
 
@@ -332,6 +333,8 @@ def create_sampling_params_from_proto(
         kwargs["stop_token_ids"] = stop_token_ids
     if ignore_eos:
         kwargs["ignore_eos"] = True
+    if include_stop_token_in_output:
+        kwargs["include_stop_str_in_output"] = True
 
     # Bad words (TRT-LLM's _setup() tokenizes bad word strings)
     if bad:

--- a/tensorrt_llm/grpc/grpc_servicer.py
+++ b/tensorrt_llm/grpc/grpc_servicer.py
@@ -106,6 +106,7 @@ class TrtllmServiceServicer(trtllm_service_pb2_grpc.TrtllmServiceServicer):
                 if request.HasField("guided_decoding")
                 else None,
                 embedding_bias=list(request.embedding_bias) if request.embedding_bias else None,
+                include_stop_token_in_output=request.include_stop_token_in_output,
             )
 
             # Build LoRA request if present


### PR DESCRIPTION
## Description

TRT-LLM strips stop tokens from `CompletionOutput.token_ids` by default (via `include_stop_str_in_output=False`). For Harmony (gpt-oss) models, stop tokens like `<|call|>` (200012) mark channel boundaries that downstream parsers need to see in the output token IDs. sglang and vLLM include stop tokens in output by default.

This PR adds `include_stop_token_in_output` support to the gRPC path:
- `create_sampling_params_from_proto()` accepts the new parameter and maps it to `include_stop_str_in_output` in SamplingParams
- The gRPC servicer passes `request.include_stop_token_in_output` through from the proto

The proto field itself is defined in [SMG PR #879](https://github.com/lightseekorg/smg/pull/879) (`smg-grpc-proto >= 0.4.5`).

## Test Coverage

Tested locally with gpt-oss-20b on TRT-LLM gRPC backend through SMG gateway:

<details>
<summary>Responses API — tool_choice=required (before: empty output, after: tool call returned)</summary>

**Before (without fix):** model generates `<|call|>`, TRT-LLM strips it, parser sees no channel boundary → empty output

**After (with fix):**
```json
{
  "output": [
    {
      "type": "function_call",
      "name": "get_weather",
      "arguments": "{\"location\":\"Tokyo\"}",
      "status": "completed"
    }
  ]
}
```
</details>

<details>
<summary>Chat Completions API — tool_choice=auto</summary>

```json
{
  "choices": [{
    "message": {
      "role": "assistant",
      "tool_calls": [{
        "type": "function",
        "function": {"name": "get_weather", "arguments": "{\"location\":\"Tokyo\"}"}
      }],
      "reasoning_content": "We need to call the function get_weather with location \"Tokyo\"."
    },
    "finish_reason": "tool_calls"
  }]
}
```
</details>

## PR Checklist

- [x] `pre-commit` passes on changed files
- [x] No new dependencies

- [x] Please check this after reviewing the above items as appropriate for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional control to include stop token strings in the generated output, providing more granular customization of text generation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->