### PR TITLE
[None][fix] Replace assertions with warnings for unsupported logits/logprobs in speculative sampler

### DIFF
--- a/tensorrt_llm/_torch/speculative/spec_sampler_base.py
+++ b/tensorrt_llm/_torch/speculative/spec_sampler_base.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+
+from tensorrt_llm.logger import logger
 
 from ..pyexecutor.llm_request import LlmRequest, LlmRequestState
 from ..pyexecutor.resource_manager import BaseResourceManager
@@ -142,15 +144,23 @@ class SpecSamplerBase(Sampler[SampleStateSpec], AsyncWorkerMixin):
         runtime_draft_len: Optional[int],
     ) -> None:
         """Common handling for both context and generation requests."""
-        assert not request.py_return_context_logits, (
-            "return_context_logits not implemented for speculative sampler"
-        )
-        assert not request.py_return_generation_logits, (
-            "return_generation_logits not implemented for speculative sampler"
-        )
-        assert not request.py_return_log_probs, (
-            "return_log_probs not implemented for speculative sampler"
-        )
+        if request.py_return_context_logits:
+            logger.warning(
+                "return_context_logits not supported with speculative decoding, "
+                "skipping for request %s",
+                request.py_request_id,
+            )
+        if request.py_return_generation_logits:
+            logger.warning(
+                "return_generation_logits not supported with speculative decoding, "
+                "skipping for request %s",
+                request.py_request_id,
+            )
+        if request.py_return_log_probs:
+            logger.warning(
+                "return_log_probs not supported with speculative decoding, skipping for request %s",
+                request.py_request_id,
+            )
         request.py_draft_tokens = next_draft_tokens[request.py_seq_slot][:runtime_draft_len]
         request.py_decoding_iter += 1
 


### PR DESCRIPTION
## Summary
- When `return_context_logits`, `return_generation_logits`, or `return_log_probs` is requested with speculative decoding, the server crashes with an `AssertionError` in `spec_sampler_base.py`.
- Replace these fatal assertions with `logger.warning()` so the server stays alive. The request completes normally — the unsupported fields are simply not populated.

### Background
We encountered this crash in production on build.nvidia.com when serving Qwen3-Coder-480B with MTP speculative decoding. Some API clients send `logprobs=True` in their requests, which triggers the assertion and kills the engine. Repeated assertion failures may also cause resource leakage (unreleased KV cache blocks, dangling request state) in the serving integration layer before the crash.

After deploying this fix, the server handles `logprobs=True` requests gracefully — it returns a response without the logprobs field and logs a warning, instead of crashing.

### History
These assertions have been present since April 2025 (PR #3221), originally in the individual MTP/Eagle sampler files. They were consolidated into the shared `SpecSamplerBase` class in March 2026 (PR #11434).

## Test plan
- [x] Deployed in production on build.nvidia.com — no more crashes from logprobs requests
- [x] Send a request with `logprobs=True` to a model serving with speculative decoding (e.g. MTP) — verify server logs a warning instead of crashing
- [x] Verify the response completes successfully (without logprobs)
- [x] Existing speculative decoding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)