### PR TITLE
[None][chore] Better Empty File Error Handling for trtllm-bench

### DIFF
--- a/tensorrt_llm/bench/benchmark/low_latency.py
+++ b/tensorrt_llm/bench/benchmark/low_latency.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from __future__ import annotations
 
 import asyncio

--- a/tensorrt_llm/bench/benchmark/low_latency.py
+++ b/tensorrt_llm/bench/benchmark/low_latency.py
@@ -25,7 +25,8 @@ from tensorrt_llm.bench.benchmark.utils.general import (
     get_settings_from_engine, get_settings,
     update_sampler_args_with_extra_options, ALL_SUPPORTED_BACKENDS)
 # isort: on
-from tensorrt_llm.bench.utils.data import (create_dataset_from_stream,
+from tensorrt_llm.bench.utils.data import (DatasetFormatError,
+                                           create_dataset_from_stream,
                                            initialize_tokenizer,
                                            update_metadata_for_multimodal)
 from tensorrt_llm.logger import logger
@@ -214,14 +215,17 @@ def latency_command(
 
     # Dataset Loading and Preparation
     with open(options.dataset_path, "r") as dataset:
-        metadata, requests = create_dataset_from_stream(
-            tokenizer,
-            dataset,
-            num_requests=options.num_requests,
-            model_dir=options.checkpoint_path,
-            model_type=options.model_type,
-            modality=options.modality,
-            max_input_seq_len_for_multimodal=options.max_input_len)
+        try:
+            metadata, requests = create_dataset_from_stream(
+                tokenizer,
+                dataset,
+                num_requests=options.num_requests,
+                model_dir=options.checkpoint_path,
+                model_type=options.model_type,
+                modality=options.modality,
+                max_input_seq_len_for_multimodal=options.max_input_len)
+        except DatasetFormatError as e:
+            raise click.UsageError(str(e))
 
         metadata.dataset_path = options.dataset_path
 

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from __future__ import annotations
 
 import asyncio

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -294,8 +294,8 @@ from tensorrt_llm.sampling_params import SamplingParams
     "--scheduler_policy",
     type=click.Choice(["guaranteed_no_evict", "max_utilization"]),
     default="guaranteed_no_evict",
-    help=
-    "KV cache scheduler policy: guaranteed_no_evict prevents request eviction, max_utilization optimizes for throughput.",
+    help=("KV cache scheduler policy: guaranteed_no_evict prevents request"
+          " eviction, max_utilization optimizes for throughput."),
 )
 @click.pass_obj
 def throughput_command(
@@ -412,8 +412,9 @@ def throughput_command(
     exec_settings["settings_config"]["max_batch_size"] = runtime_max_bs
     exec_settings["settings_config"]["max_num_tokens"] = runtime_max_tokens
     exec_settings["settings_config"]["beam_width"] = options.beam_width
-    exec_settings["settings_config"][
-        "scheduler_policy"] = CapacitySchedulerPolicy.GUARANTEED_NO_EVICT if scheduler_policy == "guaranteed_no_evict" else CapacitySchedulerPolicy.MAX_UTILIZATION
+    exec_settings["settings_config"]["scheduler_policy"] = (
+        CapacitySchedulerPolicy.GUARANTEED_NO_EVICT if scheduler_policy
+        == "guaranteed_no_evict" else CapacitySchedulerPolicy.MAX_UTILIZATION)
     exec_settings["settings_config"]["chunking"] = enable_chunked_context
 
     # Dynamic runtime features.

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -25,7 +25,8 @@ from tensorrt_llm.bench.benchmark.utils.general import (
 from tensorrt_llm.bench.dataclasses.configuration import RuntimeConfig
 from tensorrt_llm.bench.dataclasses.general import BenchmarkEnvironment
 from tensorrt_llm.bench.dataclasses.reporting import ReportUtility
-from tensorrt_llm.bench.utils.data import (create_dataset_from_stream,
+from tensorrt_llm.bench.utils.data import (DatasetFormatError,
+                                           create_dataset_from_stream,
                                            initialize_tokenizer,
                                            update_metadata_for_multimodal)
 from tensorrt_llm.llmapi import CapacitySchedulerPolicy
@@ -340,16 +341,19 @@ def throughput_command(
 
     # Dataset Loading and Preparation
     with open(options.dataset_path, "r") as dataset:
-        metadata, requests = create_dataset_from_stream(
-            tokenizer,
-            dataset,
-            num_requests=options.num_requests,
-            model_dir=options.checkpoint_path,
-            model_type=options.model_type,
-            modality=options.modality,
-            image_data_format=image_data_format,
-            data_device=data_device,
-            max_input_seq_len_for_multimodal=options.max_input_len)
+        try:
+            metadata, requests = create_dataset_from_stream(
+                tokenizer,
+                dataset,
+                num_requests=options.num_requests,
+                model_dir=options.checkpoint_path,
+                model_type=options.model_type,
+                modality=options.modality,
+                image_data_format=image_data_format,
+                data_device=data_device,
+                max_input_seq_len_for_multimodal=options.max_input_len)
+        except DatasetFormatError as e:
+            raise click.UsageError(str(e))
         metadata.dataset_path = options.dataset_path
         params["target_input_len"] = params.get(
             "target_input_len") or metadata.avg_isl

--- a/tensorrt_llm/bench/utils/data.py
+++ b/tensorrt_llm/bench/utils/data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorrt_llm/bench/utils/data.py
+++ b/tensorrt_llm/bench/utils/data.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import json
 from functools import partial
 from typing import List, TextIO, Tuple
@@ -9,6 +23,11 @@ from tensorrt_llm.bench.dataclasses.general import (DatasetMetadata,
 from tensorrt_llm.bench.dataclasses.statistics import PercentileStats
 from tensorrt_llm.executor.request import LoRARequest
 from tensorrt_llm.inputs import default_multimodal_input_loader
+
+
+class DatasetFormatError(ValueError):
+    """Raised when the input dataset stream is empty, corrupted, or incorrectly formatted."""
+
 
 
 def initialize_tokenizer(model_name: str,
@@ -170,7 +189,7 @@ def create_dataset_from_stream(
 
     # Early validation: check if any data was actually read from the stream
     if len(prompts) == 0:
-        raise ValueError(
+        raise DatasetFormatError(
             "No data was read from the dataset stream. "
             "The dataset file may be empty, corrupted, or in an incorrect format. "
             "Expected JSON lines with at least 'prompt', 'task_id' and 'output_tokens' fields."

--- a/tensorrt_llm/bench/utils/data.py
+++ b/tensorrt_llm/bench/utils/data.py
@@ -168,6 +168,14 @@ def create_dataset_from_stream(
         else:
             lora_requests.append(None)
 
+    # Early validation: check if any data was actually read from the stream
+    if len(prompts) == 0:
+        raise ValueError(
+            "No data was read from the dataset stream. "
+            "The dataset file may be empty, corrupted, or in an incorrect format. "
+            "Expected JSON lines with at least 'prompt', 'task_id' and 'output_tokens' fields."
+        )
+
     if modality is not None:
         # Multimodal data need extra preprocessing
         assert modality in [

--- a/tensorrt_llm/bench/utils/data.py
+++ b/tensorrt_llm/bench/utils/data.py
@@ -29,7 +29,6 @@ class DatasetFormatError(ValueError):
     """Raised when the input dataset stream is empty, corrupted, or incorrectly formatted."""
 
 
-
 def initialize_tokenizer(model_name: str,
                          custom_tokenizer: str = None) -> PreTrainedTokenizer:
     """Initialize a tokenizer.

--- a/tests/unittest/bindings/test_transfer_agent_bindings.py
+++ b/tests/unittest/bindings/test_transfer_agent_bindings.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import pytest
 
 # Try to import the transfer agent binding module

--- a/tests/unittest/others/test_bench_data.py
+++ b/tests/unittest/others/test_bench_data.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import io
+
+import pytest
+
+from tensorrt_llm.bench.utils.data import DatasetFormatError, create_dataset_from_stream
+
+
+class _FakeTokenizer:
+    """Minimal tokenizer stub for testing create_dataset_from_stream."""
+
+    def __call__(self, text, **kwargs):
+        ids = list(range(len(text.split())))
+        return {"input_ids": ids}
+
+    def encode(self, text, **kwargs):
+        return list(range(len(text.split())))
+
+
+def test_empty_stream_raises_dataset_format_error():
+    tokenizer = _FakeTokenizer()
+    empty_stream = io.StringIO("")
+
+    with pytest.raises(DatasetFormatError, match="No data was read from the dataset stream"):
+        create_dataset_from_stream(tokenizer, empty_stream)

--- a/tests/unittest/others/test_bench_data.py
+++ b/tests/unittest/others/test_bench_data.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description

If the input dataset file happens to be empty due to process killed, trtllm-bench will throw a seemingly confusing error. To help user debug, add an early empty dataset check and throw a meaningful error in case the input dataset is empty.

Edit:
During CI debugging, Claude found a unit test failure at `tests/unittest/bindings/test_transfer_agent_bindings.py` and fixed the test by using the new agent binding interface. For simplicity, the fix is incorporated into this PR as well.

## Test Coverage

No new test added.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added input validation for dataset streams to detect and report empty, corrupted, or incorrectly formatted data with clearer error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->