### PR TITLE
[None][fix] Fail fast on FP4 quant modes the GPU cannot run

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -28,6 +28,9 @@ from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.functional import AllReduceFusionOp, AllReduceStrategy
 from tensorrt_llm.logger import logger
 from tensorrt_llm.plugin.plugin import CustomAllReduceHelper
+from tensorrt_llm.quantization.mode import (
+    QuantAlgo, get_mxfp4_support_error_message, get_sm_version_from_torch,
+    is_mxfp4_supported)
 from tensorrt_llm.quantization.utils import fp8_quantize
 
 from ..autotuner import (AutoTuner, ConstraintSpec, DistributedTuningStrategy,
@@ -53,6 +56,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
 # BufferKind is bound from C++; see cpp/tensorrt_llm/thop/outputTensor.h (torch_ext::BufferKind).
 from tensorrt_llm.bindings.internal.thop import BufferKind
+
+
+def _validate_fp4_runtime_support(quant_mode: Union[QuantAlgo, str]) -> None:
+    sm = get_sm_version_from_torch()
+    if not is_mxfp4_supported(sm, quant_mode):
+        raise RuntimeError(get_mxfp4_support_error_message(sm, quant_mode))
 
 
 # Used to WAR an issue in torch.bmm that it would break the graph when the out is not contiguous.
@@ -1000,6 +1009,7 @@ def nvfp4_gemm(
     Raises:
         ValueError: If backend is invalid/unavailable
     """
+    _validate_fp4_runtime_support(QuantAlgo.NVFP4)
 
     valid_individual_backends = {'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'}
 
@@ -1286,6 +1296,7 @@ def w4a8_mxfp4_fp8_gemm(
         output_dtype: torch.dtype,
         output_buffer_kind: int = int(BufferKind.DEFAULT),
 ) -> torch.Tensor:
+    _validate_fp4_runtime_support(QuantAlgo.W4A8_MXFP4_FP8)
 
     tuner = AutoTuner.get()
 

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -58,7 +58,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
 from tensorrt_llm.bindings.internal.thop import BufferKind
 
 
-def _validate_fp4_runtime_support(quant_mode: Union[QuantAlgo, str]) -> None:
+def _validate_fp4_runtime_support(
+        quant_mode: Union[QuantAlgo, QuantMode, str]) -> None:
     sm = get_sm_version_from_torch()
     if not is_mxfp4_supported(sm, quant_mode):
         raise RuntimeError(get_mxfp4_support_error_message(sm, quant_mode))

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -29,8 +29,8 @@ from tensorrt_llm.functional import AllReduceFusionOp, AllReduceStrategy
 from tensorrt_llm.logger import logger
 from tensorrt_llm.plugin.plugin import CustomAllReduceHelper
 from tensorrt_llm.quantization.mode import (
-    QuantAlgo, get_mxfp4_support_error_message, get_sm_version_from_torch,
-    is_mxfp4_supported)
+    QuantAlgo, QuantMode, get_mxfp4_support_error_message,
+    get_sm_version_from_torch, is_mxfp4_supported)
 from tensorrt_llm.quantization.utils import fp8_quantize
 
 from ..autotuner import (AutoTuner, ConstraintSpec, DistributedTuningStrategy,
@@ -1009,7 +1009,7 @@ def nvfp4_gemm(
     Raises:
         ValueError: If backend is invalid/unavailable
     """
-    _validate_fp4_runtime_support(QuantAlgo.NVFP4)
+    _validate_fp4_runtime_support(QuantMode.from_quant_algo(QuantAlgo.NVFP4))
 
     valid_individual_backends = {'cutlass', 'cublaslt', 'cutedsl', 'cuda_core'}
 
@@ -1296,7 +1296,8 @@ def w4a8_mxfp4_fp8_gemm(
         output_dtype: torch.dtype,
         output_buffer_kind: int = int(BufferKind.DEFAULT),
 ) -> torch.Tensor:
-    _validate_fp4_runtime_support(QuantAlgo.W4A8_MXFP4_FP8)
+    _validate_fp4_runtime_support(
+        QuantMode.from_quant_algo(QuantAlgo.W4A8_MXFP4_FP8))
 
     tuner = AutoTuner.get()
 

--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -7,6 +7,9 @@ import torch
 
 from tensorrt_llm.logger import logger
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+from tensorrt_llm.quantization.mode import (
+    get_mxfp4_support_error_message, get_sm_version_from_torch,
+    is_mxfp4_supported)
 
 from ...model_config import ModelConfig
 from ...utils import ActivationType, AuxStreamType
@@ -23,6 +26,49 @@ from .interface import MoE, MoEWeightLoadingMode
 from .mega_moe import MegaMoEDeepGemm
 from .moe_load_balancer import get_moe_load_balancer
 from .routing import BaseMoeRoutingMethod
+
+
+def _validate_fp4_quant_config_support(
+        quant_config: Optional[QuantConfig]) -> None:
+    if quant_config is None:
+        return
+
+    quant_mode = quant_config.layer_quant_mode
+    if not (quant_mode.has_nvfp4() or quant_mode.has_w4a8_nvfp4_fp8()
+            or quant_mode.has_mxfp4()):
+        return
+
+    sm = get_sm_version_from_torch()
+    if not is_mxfp4_supported(sm, quant_mode):
+        raise ValueError(get_mxfp4_support_error_message(sm, quant_mode))
+
+
+def _validate_moe_backend_support(
+        moe_cls: Type[MoE], quant_config: Optional[QuantConfig],
+        dtype: Optional[torch.dtype], swiglu_alpha: Optional[torch.Tensor],
+        swiglu_beta: Optional[torch.Tensor],
+        swiglu_limit: Optional[torch.Tensor]) -> None:
+    _validate_fp4_quant_config_support(quant_config)
+
+    if quant_config is None or not hasattr(moe_cls, "can_implement"):
+        return
+
+    can_implement, skip_reason = moe_cls.can_implement(
+        quant_config.quant_algo,
+        dtype_activation=dtype or torch.bfloat16,
+        swiglu_gptoss_style=any(param is not None
+                                for param in (swiglu_alpha, swiglu_beta,
+                                              swiglu_limit)),
+    )
+    if can_implement:
+        return
+
+    quant_mode_name = "UNQUANTIZED" if quant_config.quant_algo is None else quant_config.quant_algo.name
+    if skip_reason is not None:
+        raise ValueError(f"{quant_mode_name}: {skip_reason}")
+    raise ValueError(
+        f"{moe_cls.__name__} does not support quantization mode {quant_mode_name}."
+    )
 
 
 def get_moe_cls(
@@ -460,6 +506,9 @@ def create_moe(
         dtype = pretrained_config.torch_dtype
 
     moe_cls = get_moe_cls(model_config, override_quant_config)
+    quant_config = override_quant_config or model_config.quant_config
+    _validate_moe_backend_support(moe_cls, quant_config, dtype, swiglu_alpha,
+                                  swiglu_beta, swiglu_limit)
 
     enable_configurable_moe = os.environ.get("ENABLE_CONFIGURABLE_MOE",
                                              "1") == "1"

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import enum
@@ -23,7 +26,9 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.quantization.functional import \
     preprocess_weights_for_mixed_gemm
-from tensorrt_llm.quantization.mode import QuantAlgo
+from tensorrt_llm.quantization.mode import (
+    QuantAlgo, get_mxfp4_support_error_message, get_sm_version_from_torch,
+    is_mxfp4_supported)
 from tensorrt_llm.quantization.utils.fp8_utils import (
     per_token_quant_and_transform, resmooth_to_fp8_e8m0,
     transform_sf_into_required_layout)
@@ -96,6 +101,39 @@ class TensorParallelMode(str, enum.Enum):
     @classmethod
     def flip(cls, mode):
         return cls.ROW if mode == cls.COLUMN else cls.COLUMN
+
+
+def _get_fp4_quant_mode(quant_config: Optional[QuantConfig]):
+    if quant_config is None:
+        return None
+
+    quant_mode = quant_config.layer_quant_mode
+    if (quant_mode.has_nvfp4() or quant_mode.has_w4a8_nvfp4_fp8()
+            or quant_mode.has_mxfp4()):
+        return quant_mode
+    return None
+
+
+def _validate_fp4_quant_config_support(
+        quant_config: Optional[QuantConfig]) -> None:
+    quant_mode = _get_fp4_quant_mode(quant_config)
+    if quant_mode is None:
+        return
+
+    sm = get_sm_version_from_torch()
+    if not is_mxfp4_supported(sm, quant_mode):
+        raise ValueError(get_mxfp4_support_error_message(sm, quant_mode))
+
+
+def _require_fp4_metadata(
+        tensor: Optional[torch.Tensor], metadata_name: str,
+        quant_mode) -> torch.Tensor:
+    if tensor is not None:
+        return tensor
+
+    sm = get_sm_version_from_torch()
+    raise ValueError(
+        f"Missing FP4 metadata: {metadata_name} for {quant_mode} on SM{sm}.")
 
 
 def load_weight_shard(
@@ -1935,6 +1973,7 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
         tp_size: int = 1,
         tp_rank: int = 0,
         tp_mode: Optional[TensorParallelMode] = None,
+        quant_mode=None,
     ):
         # For concatenated weights (qkv_proj / up_gate_proj), the global scaling factors and input scaling factors should be shared.
         input_scale = None
@@ -1966,6 +2005,10 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
                         f"The weight_scale_2 should be same for all the weights: {weight_scale_2} vs. {w['weight_scale_2']}"
                     )
 
+        input_scale = _require_fp4_metadata(input_scale, "input_scale",
+                                            quant_mode)
+        weight_scale_2 = _require_fp4_metadata(weight_scale_2,
+                                               "weight_scale_2", quant_mode)
         # TODO: ModelOpt's o_proj.weight_scale_2 is bfloat16, which should be float32
         input_scale = input_scale.to(torch.float32)
         weight_scale_2 = weight_scale_2.to(torch.float32)
@@ -1982,7 +2025,8 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
             weights,
             tp_size=module.tp_size,
             tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
+            tp_mode=module.tp_mode,
+            quant_mode=module.quant_config.quant_algo)
 
         assert len(weights) == 1
         weight_scale = weight_scale[0]
@@ -2005,7 +2049,8 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
             weights,
             tp_size=module.tp_size,
             tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
+            tp_mode=module.tp_mode,
+            quant_mode=module.quant_config.quant_algo)
         # Swizzle weight scales after concatenation
         weight_scale = torch.cat(weight_scales, 0)
         # Shuffle and Swizzle weight scale
@@ -2036,7 +2081,8 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
             weights,
             tp_size=module.tp_size,
             tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
+            tp_mode=module.tp_mode,
+            quant_mode=module.quant_config.quant_algo)
         # Swizzle weight scales after concatenation
         weight_scale = torch.cat(weight_scales, 0)
         # Shuffle and Swizzle weight scale
@@ -2872,7 +2918,7 @@ class Linear(nn.Module):
             return
 
         self.rebuild_tensor_metadata = {}
-
+        _validate_fp4_quant_config_support(self.quant_config)
         self.quant_method = self.get_quant_method(self.quant_config)
         self.quant_method.create_weights(self, self.in_features,
                                          self.out_features, self.has_bias,

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -132,8 +132,9 @@ def _require_fp4_metadata(
         return tensor
 
     sm = get_sm_version_from_torch()
+    sm_str = f"SM{sm}" if sm is not None else "unknown GPU"
     raise ValueError(
-        f"Missing FP4 metadata: {metadata_name} for {quant_mode} on SM{sm}.")
+        f"Missing FP4 metadata: {metadata_name} for {quant_mode} on {sm_str}.")
 
 
 def load_weight_shard(

--- a/tensorrt_llm/quantization/mode.py
+++ b/tensorrt_llm/quantization/mode.py
@@ -497,17 +497,28 @@ def get_sm_version_from_torch() -> Optional[int]:
 
 
 def is_mxfp4_supported(sm, quant_mode):
-    name = str(quant_mode)
+    if quant_mode is None or sm is None:
+        return True
 
-    if "W4A8_MXFP4" in name:
+    if hasattr(quant_mode,
+               "has_w4a8_mxfp4_fp8") and quant_mode.has_w4a8_mxfp4_fp8():
         return sm in (100, 103)
-    if "W4A16_MXFP4" in name:
+    if hasattr(
+            quant_mode,
+            "has_w4a8_mxfp4_mxfp8") and quant_mode.has_w4a8_mxfp4_mxfp8():
+        return sm in (100, 103)
+    if hasattr(quant_mode,
+               "has_w4a16_mxfp4") and quant_mode.has_w4a16_mxfp4():
         return sm == 90
-    if "NVFP4" in name:
+    if hasattr(quant_mode,
+               "has_w4a8_nvfp4_fp8") and quant_mode.has_w4a8_nvfp4_fp8():
+        return sm in (100, 103, 120, 121)
+    if hasattr(quant_mode, "has_nvfp4") and quant_mode.has_nvfp4():
         return sm in (100, 103, 120, 121)
 
     return True
 
 
 def get_mxfp4_support_error_message(sm, quant_mode):
-    return f"{quant_mode} is not supported on SM{sm}. Supported on newer architectures only."
+    sm_str = f"SM{sm}" if sm is not None else "unknown GPU"
+    return f"{quant_mode} is not supported on {sm_str}. Supported on newer architectures only."

--- a/tensorrt_llm/quantization/mode.py
+++ b/tensorrt_llm/quantization/mode.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -481,3 +481,33 @@ class GroupwiseQuantAlgo:
     PRE_QUANT_SCALE = 4
     W4A8_ALPHA = 8
     INT8_WEIGHT = 16
+
+
+def get_sm_version_from_torch() -> Optional[int]:
+    try:
+        import torch
+    except ImportError:
+        return None
+
+    if not torch.cuda.is_available():
+        return None
+
+    major, minor = torch.cuda.get_device_capability(torch.device("cuda:0"))
+    return major * 10 + minor
+
+
+def is_mxfp4_supported(sm, quant_mode):
+    name = str(quant_mode)
+
+    if "W4A8_MXFP4" in name:
+        return sm in (100, 103)
+    if "W4A16_MXFP4" in name:
+        return sm == 90
+    if "NVFP4" in name:
+        return sm in (100, 103, 120, 121)
+
+    return True
+
+
+def get_mxfp4_support_error_message(sm, quant_mode):
+    return f"{quant_mode} is not supported on SM{sm}. Supported on newer architectures only."


### PR DESCRIPTION
This PR adds early validation for MXFP4/NVFP4 quantization on Hopper (SM90)

Currently, unsupported FP4 configurations (including W4A8 variants) are not consistently rejected and can propagate through checkpoint loading, module initialization, and GEMM dispatch, leading to runtime errors such as unsupported kernel dispatch, missing kernels, NoneType failures, and occasional segfaults

This change introduces simple SM-aware checks before Linear/MoE initialization and FP4 GEMM dispatch, along with minimal metadata validation to catch missing scales early .Unsupported configurations now fail fast with clear error messages instead of reaching backend execution

This does not add FP4 support for Hopper, only ensures invalid configurations are handled correctly

Fixes #12558


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added algorithm-specific FP4 architecture validation for MXFP4, NVFP4, and W4A8 variants.
- Unsupported configurations now fail before weight creation, autotuning, or backend execution.
- Added clear errors for unsupported architectures and missing scale metadata.
- Updated `load_weight_scales` to accept `quant_algo` across W4A8 NVFP4 scale-loading paths.
- Marlin remains an explicit compatibility path for supported NVFP4 configurations.
- Review finding counts are unavailable.

## QA Engineer Review

- Added CPU-only tests for `Linear` construction, FP4 GEMM gating, quantization-mode support, Marlin behavior, unknown architectures, and missing-scale errors.
- Coverage verdict: **sufficient** for the changed validation paths.
- No integration test-list changes are present.

## Per-File QA Perspective

- `tensorrt_llm/_torch/custom_ops/torch_custom_ops.py`: Verify unsupported configurations fail before GEMM dispatch and Marlin-enabled paths remain valid.
- `tensorrt_llm/_torch/modules/linear.py`: Verify algorithm-aware validation and scale loading across vanilla and fused W4A8 paths.
- `tensorrt_llm/quantization/mode.py`: Verify supported SM ranges, unknown SM handling, and error-message guidance.
- `tests/unittest/_torch/modules/test_fp4_arch_fail_fast.py`: Covers fail-fast `Linear` construction and scale metadata errors.
- `tests/unittest/_torch/thop/parallel_hw_agnostic/test_fp4_gemm_arch_fail_fast.py`: Covers FP4 GEMM architecture and backend validation.
- `tests/unittest/quantization/test_mode.py`: Covers FP4 architecture compatibility, Marlin fallback, support reporting, and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->