### PR TITLE
[TRTLLM-11608][feat] Chunked KV cache transfer with early block release

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -589,6 +589,17 @@ public:
         ++mNumFrontBlocksRemoved;
     }
 
+    //! \brief Advance ``mNumFrontBlocksRemoved`` without touching cache blocks.
+    //! \details Used by ``BlockManager::releasePrefixBlocks`` to advance the
+    //! shared front-block counter once after every ``WindowBlockManager`` has
+    //! processed the same prefix range.  Has clearer intent than calling
+    //! ``removeFrontBlock`` with a sentinel ``windowSize`` value, and is robust
+    //! to future changes that consume the ``windowSize`` argument.
+    void incrementNumFrontBlocksRemoved()
+    {
+        ++mNumFrontBlocksRemoved;
+    }
+
     void removeLastBlock(SizeType32 windowSize)
     {
         for (auto& beamBlockIds : mCacheBlockIds.at(windowSize))

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -871,6 +871,13 @@ public:
     std::optional<KVCacheBlock::IdType> releaseBlocks(
         GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest);
 
+    //! \brief Release the first numBlocks prefix blocks of a sequence.
+    //! \details Used by disaggregated serving to free sender-side KV memory
+    //! for blocks whose data has already been transferred.  Reuses the
+    //! detachFrontBlock mechanism (decRefCount + eviction policy release).
+    //! Cumulative: calling with 3 then 5 releases blocks 0-4 total.
+    void releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks);
+
     //! \brief Simulate freeing all blocks for that sequence to check impact on number of free blocks
     void schedulingReleaseBlocks(LlmRequest::RequestIdType requestId);
 
@@ -1381,6 +1388,13 @@ public:
 
     std::optional<KVCacheBlock::IdType> releaseBlocks(
         GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest = std::nullopt, bool pinBlocks = false);
+
+    //! \brief Release the first numBlocks prefix blocks of a sequence.
+    //! \details Mirrors detachFrontBlock logic: decRefCount + eviction policy
+    //! release for each prefix block.  The mNumFrontBlocksRemoved counter on
+    //! GenerationRequest ensures releaseBlocks (called during removeSequence)
+    //! skips already-freed prefix blocks.
+    void releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks);
 
     [[nodiscard]] std::vector<KVCacheBlock::IdType> storeBlocksForReuse(
         GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest = std::nullopt, bool pinBlocks = false);
@@ -2250,6 +2264,11 @@ public:
 
     [[nodiscard]] std::optional<KVCacheBlock::IdType> removeSequence(LlmRequest::RequestIdType requestId,
         OptionalRef<LlmRequest const> llmRequest = std::nullopt, bool pinOnRelease = false) override;
+
+    //! \brief Release prefix blocks for a sequence without removing it.
+    //! \details Used by disaggregated serving for early block release during
+    //! chunked KV cache transfer.  No-op if the sequence does not exist.
+    void releasePrefixBlocks(LlmRequest::RequestIdType requestId, SizeType32 numBlocks);
 
     void schedulingRemoveSequence(LlmRequest::RequestIdType requestId) override;
 

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -871,12 +871,13 @@ public:
     std::optional<KVCacheBlock::IdType> releaseBlocks(
         GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest);
 
-    //! \brief Release the first numBlocks prefix blocks of a sequence.
+    //! \brief Release prefix blocks in range [startIdx, numBlocks) for a sequence.
     //! \details Used by disaggregated serving to free sender-side KV memory
     //! for blocks whose data has already been transferred.  Reuses the
     //! detachFrontBlock mechanism (decRefCount + eviction policy release).
-    //! Cumulative: calling with 3 then 5 releases blocks 0-4 total.
-    void releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks);
+    //! Called by BlockManager::releasePrefixBlocks which coordinates the
+    //! shared mNumFrontBlocksRemoved counter across all window managers.
+    void releasePrefixBlocks(GenerationRequest& sequence, SizeType32 startIdx, SizeType32 numBlocks);
 
     //! \brief Simulate freeing all blocks for that sequence to check impact on number of free blocks
     void schedulingReleaseBlocks(LlmRequest::RequestIdType requestId);

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2545,6 +2545,13 @@ std::optional<KVCacheBlock::IdType> BlockManager::releaseBlocks(
 
 void BlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks)
 {
+    // NOTE: This assumes a single window size (no VSWA).  With different window
+    // sizes, each WindowBlockManager may have a different number of allocated
+    // blocks, so releasing the same numBlocks from all managers would need
+    // per-window-size handling.  Disaggregated serving does not support VSWA
+    // today (gated by should_store_blocks: not is_vswa in the executor and
+    // beamWidth == 1 assertion in WindowBlockManager::releasePrefixBlocks).
+    //
     // Snapshot the counter before iterating so that every WindowBlockManager
     // releases the same range.  Without this, the first manager would advance
     // the shared mNumFrontBlocksRemoved counter and subsequent managers would

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2545,9 +2545,19 @@ std::optional<KVCacheBlock::IdType> BlockManager::releaseBlocks(
 
 void BlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks)
 {
+    // Snapshot the counter before iterating so that every WindowBlockManager
+    // releases the same range.  Without this, the first manager would advance
+    // the shared mNumFrontBlocksRemoved counter and subsequent managers would
+    // see the counter already at the target, skipping their own blocks.
+    SizeType32 const startIdx = sequence.getNumFrontBlocksRemoved();
     for (auto& [_, manager] : mWindowBlockManagers)
     {
-        manager.releasePrefixBlocks(sequence, numBlocks);
+        manager.releasePrefixBlocks(sequence, startIdx, numBlocks);
+    }
+    // Advance the shared counter once, after all managers have released.
+    while (sequence.getNumFrontBlocksRemoved() < numBlocks)
+    {
+        sequence.removeFrontBlock(0);
     }
 }
 
@@ -3250,7 +3260,7 @@ void WindowBlockManager::detachFrontBlock(GenerationRequest& sequence)
     sequence.removeFrontBlock(mWindowSize);
 }
 
-void WindowBlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks)
+void WindowBlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeType32 startIdx, SizeType32 numBlocks)
 {
     TLLM_CHECK_WITH_INFO(
         sequence.getBeamWidth() == 1, "[kv cache manager] releasePrefixBlocks does not support beamWidth > 1");
@@ -3259,9 +3269,11 @@ void WindowBlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeTy
     auto& allocatedBlocks = mAllocatedBlocksPerSeq.at(requestId);
     SizeType32 const target = std::min(numBlocks, static_cast<SizeType32>(allocatedBlocks.size()));
 
-    while (sequence.getNumFrontBlocksRemoved() < target)
+    // Release blocks in range [startIdx, target).  The shared
+    // mNumFrontBlocksRemoved counter is advanced by BlockManager after
+    // all WindowBlockManagers have processed the same range.
+    for (SizeType32 blockIdx = startIdx; blockIdx < target; ++blockIdx)
     {
-        SizeType32 const blockIdx = sequence.getNumFrontBlocksRemoved();
         auto& block = allocatedBlocks.at(blockIdx);
 
         TLLM_LOG_DEBUG("%s::releasePrefixBlocks - Releasing block %d from sequence %lu", mLogPrefix.c_str(),
@@ -3275,8 +3287,6 @@ void WindowBlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeTy
         {
             mEvictionPolicy->releaseBlock(block);
         }
-
-        sequence.removeFrontBlock(mWindowSize);
     }
 }
 

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2562,9 +2562,12 @@ void BlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeType32 n
         manager.releasePrefixBlocks(sequence, startIdx, numBlocks);
     }
     // Advance the shared counter once, after all managers have released.
+    // Uses incrementNumFrontBlocksRemoved (counter-only) instead of
+    // removeFrontBlock so the intent is explicit and we do not depend on
+    // removeFrontBlock ignoring its windowSize argument.
     while (sequence.getNumFrontBlocksRemoved() < numBlocks)
     {
-        sequence.removeFrontBlock(0);
+        sequence.incrementNumFrontBlocksRemoved();
     }
 }
 
@@ -3479,6 +3482,16 @@ std::optional<KVCacheBlock::IdType> KVCacheManager::removeSequence(
 
 void KVCacheManager::releasePrefixBlocks(RequestIdType requestId, SizeType32 numBlocks)
 {
+    // Hard precondition: BlockManager::releasePrefixBlocks advances the shared
+    // mNumFrontBlocksRemoved counter to numBlocks for every WindowBlockManager,
+    // even when a window has fewer than numBlocks allocated.  Under variable
+    // sliding window attention (VSWA), that would cause WindowBlockManager::
+    // releaseBlocks (called during removeSequence) to underrun rbegin() and
+    // skip tail blocks for the smaller window.  Disagg serving already gates
+    // VSWA out, but we enforce the assumption here so the C++ API contract is
+    // self-defending instead of relying on caller discipline.
+    TLLM_CHECK_WITH_INFO(
+        !mBlockManager.isVariableWindow(), "releasePrefixBlocks does not support variable sliding window attention");
     if (numBlocks <= 0)
     {
         return;

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2543,6 +2543,14 @@ std::optional<KVCacheBlock::IdType> BlockManager::releaseBlocks(
     return lastStoredId;
 }
 
+void BlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks)
+{
+    for (auto& [_, manager] : mWindowBlockManagers)
+    {
+        manager.releasePrefixBlocks(sequence, numBlocks);
+    }
+}
+
 void BlockManager::pinBlocks(GenerationRequest& sequence)
 {
     for (auto& [_, manager] : mWindowBlockManagers)
@@ -3242,6 +3250,36 @@ void WindowBlockManager::detachFrontBlock(GenerationRequest& sequence)
     sequence.removeFrontBlock(mWindowSize);
 }
 
+void WindowBlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks)
+{
+    TLLM_CHECK_WITH_INFO(
+        sequence.getBeamWidth() == 1, "[kv cache manager] releasePrefixBlocks does not support beamWidth > 1");
+
+    auto const requestId = sequence.getRequestId();
+    auto& allocatedBlocks = mAllocatedBlocksPerSeq.at(requestId);
+    SizeType32 const target = std::min(numBlocks, static_cast<SizeType32>(allocatedBlocks.size()));
+
+    while (sequence.getNumFrontBlocksRemoved() < target)
+    {
+        SizeType32 const blockIdx = sequence.getNumFrontBlocksRemoved();
+        auto& block = allocatedBlocks.at(blockIdx);
+
+        TLLM_LOG_DEBUG("%s::releasePrefixBlocks - Releasing block %d from sequence %lu", mLogPrefix.c_str(),
+            block->getBlockId(), requestId);
+
+        if (block->hasRefs())
+        {
+            block->decRefCount();
+        }
+        if (!block->hasRefs())
+        {
+            mEvictionPolicy->releaseBlock(block);
+        }
+
+        sequence.removeFrontBlock(mWindowSize);
+    }
+}
+
 PrefixReuseSummary KVCacheManager::analyzePrefixReuse(
     VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const
 {
@@ -3420,6 +3458,21 @@ std::optional<KVCacheBlock::IdType> KVCacheManager::removeSequence(
     TLLM_CHECK(!mBlockManager.isSequenceHeld(requestId));
     TLLM_LOG_TRACE("[%s]::%s stop", isCrossKv() ? "CROSS" : "SELF", __PRETTY_FUNCTION__);
     return lastStoredId;
+}
+
+void KVCacheManager::releasePrefixBlocks(RequestIdType requestId, SizeType32 numBlocks)
+{
+    if (numBlocks <= 0)
+    {
+        return;
+    }
+    std::scoped_lock lock(mSequencesMtx);
+    auto it = mSequences.find(requestId);
+    if (it == mSequences.end())
+    {
+        return;
+    }
+    mBlockManager.releasePrefixBlocks(it->second, numBlocks);
 }
 
 std::vector<KVCacheBlock::IdType> KVCacheManager::storeBlocksForReuse(

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -642,7 +642,9 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
         .def_prop_ro(
             "is_variable_window", [](tbk::KVCacheManager& self) { return self.getBlockManager().isVariableWindow(); })
         .def("copy_linear_attention_block", &tbk::KVCacheManager::copyLinearAttentionBlock, nb::arg("llm_request"),
-            nb::call_guard<nb::gil_scoped_release>());
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("release_prefix_blocks", &tbk::KVCacheManager::releasePrefixBlocks, nb::arg("request_id"),
+            nb::arg("num_blocks"), nb::call_guard<nb::gil_scoped_release>());
 }
 
 void tb::BasePeftCacheManagerBindings::initBindings(nb::module_& m)

--- a/tensorrt_llm/_torch/disaggregation/base/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/base/transfer.py
@@ -53,6 +53,7 @@ class KVSlice:
     )  # Physical block IDs per layer group, each np.ndarray(dtype=np.int64)
     is_last_slice: bool = False
     mamba_state_index: Optional[int] = None
+    chunk_block_offset: int = 0
 
 
 class SessionStatus(Enum):
@@ -141,16 +142,14 @@ class TxSessionBase(_SessionBase):
         self._sender = sender
 
     @abstractmethod
-    def send(self, slice: KVSlice, chunk_block_offset: int = 0) -> concurrent.futures.Future:
+    def send(self, slice: KVSlice) -> concurrent.futures.Future:
         """Send a KV slice and return a Future for the transfer.
 
         Args:
             slice: The KV slice describing which source blocks to send.
-            chunk_block_offset: Block offset into the receiver's full
-                destination block list for this chunk.  Used by
-                sender-side chunking to slice the receiver's
-                destination blocks correctly.  Defaults to 0
-                (monolithic transfer).
+                The slice's ``chunk_block_offset`` field indicates the
+                offset into the receiver's destination block list for
+                sender-side chunking.
 
         Returns:
             A ``Future`` that resolves when the transfer completes.

--- a/tensorrt_llm/_torch/disaggregation/base/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/base/transfer.py
@@ -141,7 +141,21 @@ class TxSessionBase(_SessionBase):
         self._sender = sender
 
     @abstractmethod
-    def send(self, slice: KVSlice) -> concurrent.futures.Future: ...
+    def send(self, slice: KVSlice, chunk_block_offset: int = 0) -> concurrent.futures.Future:
+        """Send a KV slice and return a Future for the transfer.
+
+        Args:
+            slice: The KV slice describing which source blocks to send.
+            chunk_block_offset: Block offset into the receiver's full
+                destination block list for this chunk.  Used by
+                sender-side chunking to slice the receiver's
+                destination blocks correctly.  Defaults to 0
+                (monolithic transfer).
+
+        Returns:
+            A ``Future`` that resolves when the transfer completes.
+        """
+        ...
 
 
 class RxSessionBase(_SessionBase):

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -58,6 +58,8 @@ from tensorrt_llm.runtime.generation import CUASSERT
 AttentionTypeCpp = tensorrt_llm.bindings.internal.batch_manager.AttentionType
 LlmRequestType = tensorrt_llm.bindings.internal.batch_manager.LlmRequestType
 
+OnChunkTransferredCallback = Callable[[int, int, int], None]
+
 # Number of worker threads for KV transfer queues (default: 1)
 KV_TRANSFER_NUM_THREADS = int(os.environ.get("TRTLLM_KV_TRANSFER_NUM_THREADS", "1"))
 
@@ -855,7 +857,7 @@ class TxSession(TxSessionBase):
         sender: Sender,
         aux_buffer: Optional[AuxBuffer] = None,
         timeout_s: Optional[float] = None,
-        on_chunk_transferred: Optional[Callable] = None,
+        on_chunk_transferred: Optional[OnChunkTransferredCallback] = None,
     ):
         super().__init__(sender, SessionArgsBase(params))
         self._timeout_s = timeout_s
@@ -1552,7 +1554,7 @@ class TransferWorker:
     def create_tx_session(
         self,
         request: LlmRequest,
-        on_chunk_transferred: Optional[Callable] = None,
+        on_chunk_transferred: Optional[OnChunkTransferredCallback] = None,
     ) -> TxSession:
         """Create a TxSession for the given request.
 

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -8,7 +8,7 @@ import time
 import weakref
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import msgpack
 import numpy as np
@@ -180,16 +180,29 @@ class AuxSendTask(SendTaskBase):
 
 
 class KVSendTask(SendTaskBase):
+    """A per-slice send task within a TxSession.
+
+    Args:
+        kv_slice: The KV slice describing which blocks to transfer.
+        params: Disaggregated serving parameters for this request.
+        slice_id: Index of this slice within the session's task list.
+        chunk_block_offset: Block offset into the receiver's full
+            destination block list.  Used by sender-side chunking to
+            slice the receiver's destination blocks correctly.
+    """
+
     def __init__(
         self,
         kv_slice: KVSlice,
         params: DisaggregatedParams,
         slice_id: int,
-    ):
+        chunk_block_offset: int = 0,
+    ) -> None:
         super().__init__(params)
         self.slice_id = slice_id
         self.transferred_count = 0
         self._slice = kv_slice
+        self.chunk_block_offset = chunk_block_offset
 
 
 class Sender(SenderBase):
@@ -398,13 +411,19 @@ class Sender(SenderBase):
         if timer:
             timer.record_transfer_end(write_meta.peer_rank)
 
-        ## TODO: just last slice need to send task state?
+        # The receiver always has a single monolithic task (slice_id=0).
+        # Sender-side chunking is transparent to the receiver: only the
+        # last chunk carries is_last_slice=True so the receiver knows
+        # when all data has arrived.  Intermediate chunk results are
+        # sent (not suppressed) so that RDMA failures propagate to the
+        # receiver immediately rather than requiring a timeout.
+        receiver_slice_id = 0
         self._get_or_connect_dealer(write_meta.peer_endpoint).send(
             [
                 MessageType.KV_AGENT_RESULT,
                 str(self._instance_rank).encode("ascii"),
                 str(write_meta.unique_rid).encode("ascii"),
-                str(write_meta.slice_id).encode("ascii"),
+                str(receiver_slice_id).encode("ascii"),
                 str(write_meta.is_last_slice).encode("ascii"),
                 agent_result.value.encode("ascii"),
             ]
@@ -428,6 +447,29 @@ class Sender(SenderBase):
             else:
                 write_meta.task_future.set_result(AgentResult.SUCCESS)
                 task.status = TaskStatus.TRANSFERRED
+                if session._on_chunk_transferred is not None:
+                    try:
+                        # Use the max across layer groups as the
+                        # cumulative release count.  For asymmetric
+                        # layer groups (e.g., sliding window), shorter
+                        # groups may have fewer blocks per chunk, but
+                        # each WindowBlockManager independently clamps
+                        # to its own allocated block count via
+                        # min(numBlocks, allocatedBlocks.size()).
+                        num_blocks = max(
+                            (len(ids) for ids in task._slice.block_ids_per_layer_groups),
+                            default=0,
+                        )
+                        session._on_chunk_transferred(
+                            request_id=session.request_id,
+                            chunk_block_offset=task.chunk_block_offset,
+                            num_blocks=num_blocks,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"on_chunk_transferred callback failed for "
+                            f"request {session.request_id} slice {write_meta.slice_id}: {e}"
+                        )
 
         logger.debug(
             f"deliver_kv_to_agent completed: unique_rid={write_meta.unique_rid}, "
@@ -522,10 +564,20 @@ class Sender(SenderBase):
             dst_block_ids_per_groups = req_info.block_ids_per_layer_groups
             src_block_ids_per_groups = task._slice.block_ids_per_layer_groups
 
-            # Aggregate fragments from all matching pools using numpy concatenation
+            chunk_offset = task.chunk_block_offset
             for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
                 src_block_ids = src_block_ids_per_groups[self_lg]
-                dst_block_ids = dst_block_ids_per_groups[peer_lg]
+                full_dst_block_ids = dst_block_ids_per_groups[peer_lg]
+
+                # When sender uses chunking, the receiver sends all dst
+                # blocks in a single RecvReqInfo.  Slice dst to match
+                # this task's src chunk position.
+                if chunk_offset > 0 or len(src_block_ids) < len(full_dst_block_ids):
+                    dst_block_ids = full_dst_block_ids[
+                        chunk_offset : chunk_offset + len(src_block_ids)
+                    ]
+                else:
+                    dst_block_ids = full_dst_block_ids
 
                 if src_block_ids.size + 1 == dst_block_ids.size:
                     # FIXME: this is a temporary solution, need to be fixed for the draft tokens
@@ -803,6 +855,7 @@ class TxSession(TxSessionBase):
         sender: Sender,
         aux_buffer: Optional[AuxBuffer] = None,
         timeout_s: Optional[float] = None,
+        on_chunk_transferred: Optional[Callable] = None,
     ):
         super().__init__(sender, SessionArgsBase(params))
         self._timeout_s = timeout_s
@@ -815,6 +868,7 @@ class TxSession(TxSessionBase):
         self.kv_tasks = []
         self.aux_task = None
         self.lock = threading.Lock()
+        self._on_chunk_transferred = on_chunk_transferred
 
         self._exception: Optional[Exception] = None
         self._closed = False
@@ -837,11 +891,11 @@ class TxSession(TxSessionBase):
             return SessionStatus.TRANSFERRING
         return SessionStatus.READY if self.receiver_ready else SessionStatus.INIT
 
-    def send(self, slice: KVSlice) -> concurrent.futures.Future:
+    def send(self, slice: KVSlice, chunk_block_offset: int = 0) -> concurrent.futures.Future:
         with self.lock:
             params = self._base_args.params
             slice_id = len(self.kv_tasks)
-            task = KVSendTask(slice, params, slice_id)
+            task = KVSendTask(slice, params, slice_id, chunk_block_offset=chunk_block_offset)
             self.kv_tasks.append(task)
             req_info_snapshot = dict(self._sender._get_req_info(task._unique_rid) or {})
         self._sender.dispatch_task(task, req_info_snapshot)
@@ -1495,7 +1549,23 @@ class TransferWorker:
         self._rank_info.sender_endpoints = endpoints
         self._rank_info.layer_num_per_pp = layer_num_per_pp
 
-    def create_tx_session(self, request: LlmRequest) -> TxSession:
+    def create_tx_session(
+        self,
+        request: LlmRequest,
+        on_chunk_transferred: Optional[Callable] = None,
+    ) -> TxSession:
+        """Create a TxSession for the given request.
+
+        Args:
+            request: The LLM request to create a send session for.
+            on_chunk_transferred: Optional callback invoked on the
+                sender worker thread after each chunk's RDMA completes.
+                Signature: ``(request_id: int, chunk_block_offset: int,
+                num_blocks: int) -> None``.
+
+        Returns:
+            A new ``TxSession`` ready to accept ``send()`` calls.
+        """
         params = request.py_disaggregated_params
         assert params is not None
         return TxSession(
@@ -1504,6 +1574,7 @@ class TransferWorker:
             sender=self._sender,
             aux_buffer=self._aux_buffer,
             timeout_s=self._config.tx_timeout_s,
+            on_chunk_transferred=on_chunk_transferred,
         )
 
     def create_rx_session(self, request: LlmRequest) -> RxSession:

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -186,11 +186,10 @@ class KVSendTask(SendTaskBase):
 
     Args:
         kv_slice: The KV slice describing which blocks to transfer.
+            The slice's ``chunk_block_offset`` field indicates the
+            offset into the receiver's destination block list.
         params: Disaggregated serving parameters for this request.
         slice_id: Index of this slice within the session's task list.
-        chunk_block_offset: Block offset into the receiver's full
-            destination block list.  Used by sender-side chunking to
-            slice the receiver's destination blocks correctly.
     """
 
     def __init__(
@@ -198,13 +197,11 @@ class KVSendTask(SendTaskBase):
         kv_slice: KVSlice,
         params: DisaggregatedParams,
         slice_id: int,
-        chunk_block_offset: int = 0,
     ) -> None:
         super().__init__(params)
         self.slice_id = slice_id
         self.transferred_count = 0
         self._slice = kv_slice
-        self.chunk_block_offset = chunk_block_offset
 
 
 class Sender(SenderBase):
@@ -464,7 +461,7 @@ class Sender(SenderBase):
                         )
                         session._on_chunk_transferred(
                             request_id=session.request_id,
-                            chunk_block_offset=task.chunk_block_offset,
+                            chunk_block_offset=task._slice.chunk_block_offset,
                             num_blocks=num_blocks,
                         )
                     except Exception as e:
@@ -566,7 +563,7 @@ class Sender(SenderBase):
             dst_block_ids_per_groups = req_info.block_ids_per_layer_groups
             src_block_ids_per_groups = task._slice.block_ids_per_layer_groups
 
-            chunk_offset = task.chunk_block_offset
+            chunk_offset = task._slice.chunk_block_offset
             for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
                 src_block_ids = src_block_ids_per_groups[self_lg]
                 full_dst_block_ids = dst_block_ids_per_groups[peer_lg]
@@ -893,11 +890,11 @@ class TxSession(TxSessionBase):
             return SessionStatus.TRANSFERRING
         return SessionStatus.READY if self.receiver_ready else SessionStatus.INIT
 
-    def send(self, slice: KVSlice, chunk_block_offset: int = 0) -> concurrent.futures.Future:
+    def send(self, slice: KVSlice) -> concurrent.futures.Future:
         with self.lock:
             params = self._base_args.params
             slice_id = len(self.kv_tasks)
-            task = KVSendTask(slice, params, slice_id, chunk_block_offset=chunk_block_offset)
+            task = KVSendTask(slice, params, slice_id)
             self.kv_tasks.append(task)
             req_info_snapshot = dict(self._sender._get_req_info(task._unique_rid) or {})
         self._sender.dispatch_task(task, req_info_snapshot)

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -141,6 +141,10 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         if getattr(self, "_shutdown", False):
             return
         self._shutdown = True
+        # Drain any pending prefix-release entries before tearing down sessions
+        # so memory frees in the same shutdown step instead of leaking until
+        # removeSequence cleans up at session close.
+        self._drain_pending_releases()
         for session in list(self._send_sessions.values()):
             session.close()
         for session in list(self._recv_sessions.values()):
@@ -270,6 +274,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
 
         num_chunks = math.ceil(max_blocks / self._chunk_size_blocks)
         slices: List[KVSlice] = []
+        block_offset = 0
         for chunk_idx in range(num_chunks):
             start = chunk_idx * self._chunk_size_blocks
             end = start + self._chunk_size_blocks
@@ -281,8 +286,16 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                     is_last_slice=is_last,
                     block_ids_per_layer_groups=chunk_block_ids,
                     mamba_state_index=mamba_state_index,
+                    chunk_block_offset=block_offset,
                 )
             )
+            # Use the max length across layer groups to advance the receiver
+            # offset.  This is the contract that lets receiver-side slicing in
+            # native/transfer.py (`_build_kv_write_meta`) trim the per-LG dst
+            # range with `len(src_block_ids)`, so asymmetric layer groups still
+            # land at the right destination position even though the offset is
+            # shared across groups.
+            block_offset += max((len(ids) for ids in chunk_block_ids), default=0)
 
         for lg_idx, original_ids in enumerate(all_block_ids):
             reassembled = []
@@ -317,8 +330,24 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         """
         if self._chunk_size_blocks is None:
             return None
+        manager_name = type(self._kv_cache_manager).__name__
         if not hasattr(self._kv_cache_manager, "release_prefix_blocks"):
+            # Surface the gate decision in logs so a typo or missing wrapper on
+            # the manager side is observable at startup, not silent.
+            logger.warning(
+                "Chunked KV transfer is enabled (chunk_size_blocks=%s) but %s "
+                "does not implement release_prefix_blocks; early prefix block "
+                "release is disabled. Blocks will be freed at session teardown.",
+                self._chunk_size_blocks,
+                manager_name,
+            )
             return None
+        logger.info(
+            "Chunked KV transfer with early prefix block release enabled "
+            "(chunk_size_blocks=%s, manager=%s).",
+            self._chunk_size_blocks,
+            manager_name,
+        )
 
         release_queue = self._pending_prefix_releases
 
@@ -399,6 +428,11 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         return to_process
 
     def _close_failed_sessions(self, sessions: dict, reqs: dict, failed: list):
+        # Drain pending prefix releases before closing failed sessions so that
+        # already-completed chunks of healthy sister sessions free memory now
+        # rather than waiting for the next check_context_transfer_status pass.
+        # No-op when the queue is empty, including on the gen-side path.
+        self._drain_pending_releases()
         for rid in failed:
             reqs[rid].state = LlmRequestState.DISAGG_TRANS_ERROR
             sessions[rid].close()
@@ -450,12 +484,8 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         req.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
 
         kv_slices = self._create_kv_slices(req)
-        chunk_block_offset = 0
         for kv_slice in kv_slices:
-            session.send(kv_slice, chunk_block_offset=chunk_block_offset)
-            chunk_block_offset += max(
-                (len(ids) for ids in kv_slice.block_ids_per_layer_groups), default=0
-            )
+            session.send(kv_slice)
         if self._need_aux_transfer(req):
             session.pack_aux(req)
             session.send_aux()

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -284,12 +284,12 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 )
             )
 
-        if __debug__:
-            for lg_idx, original_ids in enumerate(all_block_ids):
-                reassembled = []
-                for s in slices:
-                    reassembled.extend(s.block_ids_per_layer_groups[lg_idx])
-                assert reassembled == original_ids, (
+        for lg_idx, original_ids in enumerate(all_block_ids):
+            reassembled = []
+            for s in slices:
+                reassembled.extend(s.block_ids_per_layer_groups[lg_idx])
+            if not np.array_equal(reassembled, original_ids):
+                raise ValueError(
                     f"Chunking integrity check failed for layer group {lg_idx}: "
                     f"expected {len(original_ids)} blocks, got {len(reassembled)}"
                 )

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -211,18 +211,20 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             mamba_state_index=mamba_state_index,
         )
 
-    def _collect_block_ids(self, req: LlmRequest) -> List[List[int]]:
-        """Collect all valid block IDs per layer group for a request.
+    def _collect_base_slice(self, req: LlmRequest) -> KVSlice:
+        """Collect a full KVSlice (including metadata) for a request.
+
+        This returns the complete slice produced by ``_create_kv_slice``,
+        preserving fields like ``mamba_state_index`` that are required
+        for hybrid-state model transfers.
 
         Args:
             req: The LLM request whose KV cache block IDs to collect.
 
         Returns:
-            A list of block ID lists, one per layer group.  Each inner
-            list contains the physical block IDs for that layer group,
-            filtered for sliding-window relevance.
+            A ``KVSlice`` with all metadata populated.
         """
-        return self._create_kv_slice(req).block_ids_per_layer_groups
+        return self._create_kv_slice(req)
 
     def _create_kv_slices(self, req: LlmRequest) -> List[KVSlice]:
         """Create one or more KVSlice objects for a request.
@@ -243,14 +245,28 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             AssertionError: If the reassembled block IDs from all slices
                 do not match the original block IDs.
         """
-        all_block_ids = self._collect_block_ids(req)
+        base_slice = self._collect_base_slice(req)
+        all_block_ids = base_slice.block_ids_per_layer_groups
+        mamba_state_index = base_slice.mamba_state_index
 
         if self._chunk_size_blocks is None:
-            return [KVSlice(is_last_slice=True, block_ids_per_layer_groups=all_block_ids)]
+            return [
+                KVSlice(
+                    is_last_slice=True,
+                    block_ids_per_layer_groups=all_block_ids,
+                    mamba_state_index=mamba_state_index,
+                )
+            ]
 
         max_blocks = max((len(ids) for ids in all_block_ids), default=0)
         if max_blocks == 0:
-            return [KVSlice(is_last_slice=True, block_ids_per_layer_groups=all_block_ids)]
+            return [
+                KVSlice(
+                    is_last_slice=True,
+                    block_ids_per_layer_groups=all_block_ids,
+                    mamba_state_index=mamba_state_index,
+                )
+            ]
 
         num_chunks = math.ceil(max_blocks / self._chunk_size_blocks)
         slices: List[KVSlice] = []
@@ -261,17 +277,22 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
 
             chunk_block_ids = [ids[start:end] for ids in all_block_ids]
             slices.append(
-                KVSlice(is_last_slice=is_last, block_ids_per_layer_groups=chunk_block_ids)
+                KVSlice(
+                    is_last_slice=is_last,
+                    block_ids_per_layer_groups=chunk_block_ids,
+                    mamba_state_index=mamba_state_index,
+                )
             )
 
-        for lg_idx, original_ids in enumerate(all_block_ids):
-            reassembled = []
-            for s in slices:
-                reassembled.extend(s.block_ids_per_layer_groups[lg_idx])
-            assert reassembled == original_ids, (
-                f"Chunking integrity check failed for layer group {lg_idx}: "
-                f"expected {len(original_ids)} blocks, got {len(reassembled)}"
-            )
+        if __debug__:
+            for lg_idx, original_ids in enumerate(all_block_ids):
+                reassembled = []
+                for s in slices:
+                    reassembled.extend(s.block_ids_per_layer_groups[lg_idx])
+                assert reassembled == original_ids, (
+                    f"Chunking integrity check failed for layer group {lg_idx}: "
+                    f"expected {len(original_ids)} blocks, got {len(reassembled)}"
+                )
 
         return slices
 
@@ -501,8 +522,12 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         req.state = LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS
         session = self._transfer_worker.create_rx_session(req)
         self._recv_sessions[rid] = session
-        all_block_ids = self._collect_block_ids(req)
-        full_slice = KVSlice(is_last_slice=True, block_ids_per_layer_groups=all_block_ids)
+        base_slice = self._collect_base_slice(req)
+        full_slice = KVSlice(
+            is_last_slice=True,
+            block_ids_per_layer_groups=base_slice.block_ids_per_layer_groups,
+            mamba_state_index=base_slice.mamba_state_index,
+        )
         session.receive(full_slice)
         self._recv_reqs[rid] = req
 

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -1,7 +1,9 @@
+import math
+import queue
 import uuid
 from collections import defaultdict
 from itertools import chain
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 import numpy as np
 import torch
@@ -91,6 +93,9 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self._wait_reqs = {}
         self._page_table = self._transfer_worker.page_table
         self._is_v2_manager = isinstance(kv_cache_manager, KVCacheManagerV2)
+        self._chunk_size_blocks = cache_transceiver_config.chunk_size_blocks
+        self._pending_prefix_releases: queue.Queue[Tuple[int, int]] = queue.Queue()
+        self._chunk_callback: Optional[Callable] = self._make_chunk_callback()
 
     def _broadcast_instance_name(self) -> str:
         if self._dist.rank == 0:
@@ -206,6 +211,116 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             mamba_state_index=mamba_state_index,
         )
 
+    def _collect_block_ids(self, req: LlmRequest) -> List[List[int]]:
+        """Collect all valid block IDs per layer group for a request.
+
+        Args:
+            req: The LLM request whose KV cache block IDs to collect.
+
+        Returns:
+            A list of block ID lists, one per layer group.  Each inner
+            list contains the physical block IDs for that layer group,
+            filtered for sliding-window relevance.
+        """
+        return self._create_kv_slice(req).block_ids_per_layer_groups
+
+    def _create_kv_slices(self, req: LlmRequest) -> List[KVSlice]:
+        """Create one or more KVSlice objects for a request.
+
+        When ``chunk_size_blocks`` is ``None``, returns a single slice
+        covering all blocks.  Otherwise, each layer group's block ID
+        list is partitioned into slices of at most ``chunk_size_blocks``
+        blocks.
+
+        Args:
+            req: The LLM request to create slices for.
+
+        Returns:
+            A list of ``KVSlice`` objects.  Only the last slice has
+            ``is_last_slice=True``.
+
+        Raises:
+            AssertionError: If the reassembled block IDs from all slices
+                do not match the original block IDs.
+        """
+        all_block_ids = self._collect_block_ids(req)
+
+        if self._chunk_size_blocks is None:
+            return [KVSlice(is_last_slice=True, block_ids_per_layer_groups=all_block_ids)]
+
+        max_blocks = max((len(ids) for ids in all_block_ids), default=0)
+        if max_blocks == 0:
+            return [KVSlice(is_last_slice=True, block_ids_per_layer_groups=all_block_ids)]
+
+        num_chunks = math.ceil(max_blocks / self._chunk_size_blocks)
+        slices: List[KVSlice] = []
+        for chunk_idx in range(num_chunks):
+            start = chunk_idx * self._chunk_size_blocks
+            end = start + self._chunk_size_blocks
+            is_last = chunk_idx == num_chunks - 1
+
+            chunk_block_ids = [ids[start:end] for ids in all_block_ids]
+            slices.append(
+                KVSlice(is_last_slice=is_last, block_ids_per_layer_groups=chunk_block_ids)
+            )
+
+        for lg_idx, original_ids in enumerate(all_block_ids):
+            reassembled = []
+            for s in slices:
+                reassembled.extend(s.block_ids_per_layer_groups[lg_idx])
+            assert reassembled == original_ids, (
+                f"Chunking integrity check failed for layer group {lg_idx}: "
+                f"expected {len(original_ids)} blocks, got {len(reassembled)}"
+            )
+
+        return slices
+
+    def _make_chunk_callback(self) -> Optional[Callable]:
+        """Return a callback for early prefix block release.
+
+        The callback is invoked on the sender worker thread after each
+        chunk's RDMA finishes.  It enqueues a release request that the
+        main thread drains via ``_drain_pending_releases``.
+
+        Early release is disabled when:
+        - ``chunk_size_blocks`` is not set (no chunking)
+        - The KV cache manager does not support ``release_prefix_blocks``
+
+        The callback is created once at init time and shared across all
+        sessions (all sessions use the same release queue).
+
+        Returns:
+            A callback ``(request_id, chunk_block_offset, num_blocks) -> None``
+            if chunking is enabled and the KV cache manager supports
+            ``release_prefix_blocks``, otherwise ``None``.
+        """
+        if self._chunk_size_blocks is None:
+            return None
+        if not hasattr(self._kv_cache_manager, "release_prefix_blocks"):
+            return None
+
+        release_queue = self._pending_prefix_releases
+
+        def _on_chunk_transferred(request_id: int, chunk_block_offset: int, num_blocks: int):
+            cumulative_blocks = chunk_block_offset + num_blocks
+            release_queue.put((request_id, cumulative_blocks))
+
+        return _on_chunk_transferred
+
+    def _drain_pending_releases(self) -> None:
+        """Process all queued prefix block releases on the main thread.
+
+        Drains the ``_pending_prefix_releases`` queue and calls
+        ``release_prefix_blocks`` on the KV cache manager for each
+        entry.  Must be called from the main executor thread only.
+        """
+        while True:
+            try:
+                request_id, num_blocks = self._pending_prefix_releases.get_nowait()
+            except queue.Empty:
+                break
+            self._kv_cache_manager.release_prefix_blocks(request_id, num_blocks)
+
     @staticmethod
     def _need_aux_transfer(req: LlmRequest) -> bool:
         params = req.py_disaggregated_params
@@ -289,14 +404,37 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             req.context_phase_params.draft_tokens = draft_tokens
 
     @nvtx_range("KvCacheTransceiverV2.respond_and_send_async")
-    def respond_and_send_async(self, req: LlmRequest):
+    def respond_and_send_async(self, req: LlmRequest) -> None:
+        """Start background KV cache transfer to the generation server.
+
+        Creates (or reuses) a ``TxSession`` and sends each KV slice with
+        its chunk block offset.  When chunking is enabled with a manager
+        that supports ``release_prefix_blocks``, a per-chunk callback is
+        attached for early prefix block release.
+
+        Args:
+            req: The completed context request whose KV cache to transfer.
+        """
         rid = get_unique_rid(req)
         assert rid is not None
         if rid not in self._send_sessions:
-            self._send_sessions[rid] = self._transfer_worker.create_tx_session(req)
+            # Skip early release for beam_width > 1: the C++ releasePrefixBlocks
+            # asserts beamWidth == 1.  Chunking still works (reduced descriptor
+            # pressure) but blocks are freed at session teardown instead.
+            callback = self._chunk_callback if req.sampling_config.beam_width <= 1 else None
+            self._send_sessions[rid] = self._transfer_worker.create_tx_session(
+                req, on_chunk_transferred=callback
+            )
         session = self._send_sessions[rid]
         req.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
-        session.send(self._create_kv_slice(req))
+
+        kv_slices = self._create_kv_slices(req)
+        chunk_block_offset = 0
+        for kv_slice in kv_slices:
+            session.send(kv_slice, chunk_block_offset=chunk_block_offset)
+            chunk_block_offset += max(
+                (len(ids) for ids in kv_slice.block_ids_per_layer_groups), default=0
+            )
         if self._need_aux_transfer(req):
             session.pack_aux(req)
             session.send_aux()
@@ -343,7 +481,17 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             self._recv_reqs.pop(rid, None)
 
     @nvtx_range("KvCacheTransceiverV2.request_and_receive_async")
-    def request_and_receive_async(self, req: LlmRequest):
+    def request_and_receive_async(self, req: LlmRequest) -> None:
+        """Start background KV cache receive from the context server.
+
+        The receiver always uses a single monolithic slice.  Chunking is
+        sender-only: the sender splits its source blocks into chunks and
+        slices the receiver's destination blocks to match each chunk.
+
+        Args:
+            req: The generation request whose KV cache blocks to receive
+                into.
+        """
         rid = get_unique_rid(req)
         if rid in self._recv_sessions:
             logger.warning(
@@ -353,12 +501,16 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         req.state = LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS
         session = self._transfer_worker.create_rx_session(req)
         self._recv_sessions[rid] = session
-        session.receive(self._create_kv_slice(req))
+        all_block_ids = self._collect_block_ids(req)
+        full_slice = KVSlice(is_last_slice=True, block_ids_per_layer_groups=all_block_ids)
+        session.receive(full_slice)
         self._recv_reqs[rid] = req
 
     def check_context_transfer_status(
         self, at_least_request_num: Optional[int], mark_complete: bool = False
     ):
+        self._drain_pending_releases()
+
         block_all = at_least_request_num is None
         wait_num = at_least_request_num if not block_all else 0
 

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -77,9 +77,15 @@ def create_kv_cache_transceiver(
     if (not use_python
             and cache_transceiver_config.chunk_size_blocks is not None):
         if cache_transceiver_config.backend in (None, "DEFAULT", "NIXL"):
-            logger.info(
-                "chunk_size_blocks is set; auto-selecting Python transceiver "
-                "for chunked KV cache transfer support")
+            # Use warning (not info) so users notice the transceiver swap and
+            # the implied perf / staging-buffer characteristics change.  Set
+            # transceiver_runtime='CPP' explicitly to opt out (and lose
+            # chunked transfer + early block release).
+            logger.warning(
+                "chunk_size_blocks is set; auto-selecting the Python "
+                "transceiver instead of the C++ transceiver to enable "
+                "chunked KV cache transfer + early block release. "
+                "Set transceiver_runtime='CPP' to disable this auto-selection.")
             use_python = True
         else:
             logger.warning(
@@ -88,6 +94,20 @@ def create_kv_cache_transceiver(
                 f"transceiver, which does not support chunked transfer. "
                 f"chunk_size_blocks will be ignored. Use NIXL backend to "
                 f"enable chunked transfer.")
+
+    # Warn when chunk_size_blocks is below the recommended floor.  The Pydantic
+    # field is PositiveInt (>=1), but values below ~16 push the per-chunk RDMA
+    # overhead into the regime where it dominates transfer throughput.
+    _MIN_RECOMMENDED_CHUNK_SIZE_BLOCKS = 16
+    if (cache_transceiver_config.chunk_size_blocks is not None
+            and cache_transceiver_config.chunk_size_blocks
+            < _MIN_RECOMMENDED_CHUNK_SIZE_BLOCKS):
+        logger.warning(
+            f"chunk_size_blocks={cache_transceiver_config.chunk_size_blocks} "
+            f"is below the recommended floor of "
+            f"{_MIN_RECOMMENDED_CHUNK_SIZE_BLOCKS}; per-chunk RDMA overhead "
+            f"may dominate transfer throughput. Consider 64-128 for "
+            f"long-context workloads (ISL >= 32K).")
 
     # Select transceiver implementation based on transceiver_runtime
     # transceiver_runtime == None or "CPP" -> use C++ transceiver (default)

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -69,12 +69,32 @@ def create_kv_cache_transceiver(
             f"UCX_CUDA_IPC_ENABLE_MNNVL=n, UCX_RNDV_SCHEME=put_zcopy and/or unset UCX_NET_DEVICES upon server "
             f"hangs or lower-than-expected performance.")
 
+    # Auto-select Python transceiver when chunk_size_blocks is set,
+    # since the C++ transceiver does not support chunked transfer.
+    # Only applies to NIXL/DEFAULT backends (the Python transceiver
+    # does not support UCX, MPI, or MOONCAKE).
+    use_python = cache_transceiver_config.transceiver_runtime == "PYTHON"
+    if (not use_python
+            and cache_transceiver_config.chunk_size_blocks is not None):
+        if cache_transceiver_config.backend in (None, "DEFAULT", "NIXL"):
+            logger.info(
+                "chunk_size_blocks is set; auto-selecting Python transceiver "
+                "for chunked KV cache transfer support")
+            use_python = True
+        else:
+            logger.warning(
+                f"chunk_size_blocks is set but backend "
+                f"'{cache_transceiver_config.backend}' requires the C++ "
+                f"transceiver, which does not support chunked transfer. "
+                f"chunk_size_blocks will be ignored. Use NIXL backend to "
+                f"enable chunked transfer.")
+
     # Select transceiver implementation based on transceiver_runtime
     # transceiver_runtime == None or "CPP" -> use C++ transceiver (default)
     # transceiver_runtime == "PYTHON" -> use Python transceiver
-    if cache_transceiver_config.transceiver_runtime == "PYTHON":
+    if use_python:
         # Python transceiver currently only supports NIXL and DEFAULT backend
-        if cache_transceiver_config.backend not in ("DEFAULT", "NIXL"):
+        if cache_transceiver_config.backend not in (None, "DEFAULT", "NIXL"):
             raise ValueError(
                 f"Python transceiver currently only supports NIXL or DEFAULT backend, "
                 f"got {cache_transceiver_config.backend}. "

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -912,6 +912,24 @@ class KVCacheManager(BaseResourceManager):
         return self.impl.remove_sequence(request.py_request_id, request,
                                          pin_on_release)
 
+    def release_prefix_blocks(self, request_id: int, num_blocks: int) -> None:
+        """Release leading blocks from a request's V1 KV cache.
+
+        Used by disaggregated serving to free sender-side KV memory
+        for blocks whose data has already been transferred.  The
+        underlying C++ ``KVCacheManager::releasePrefixBlocks`` frees
+        blocks via the eviction policy so they can be reused.
+
+        Args:
+            request_id: The request whose KV cache to partially free.
+            num_blocks: Number of leading blocks to release
+                (cumulative from the start of the sequence).
+
+        Note:
+            No-op if the sequence does not exist (already removed).
+        """
+        self.impl.release_prefix_blocks(request_id, num_blocks)
+
     def store_blocks_for_reuse(self,
                                request: LlmRequest,
                                pin_blocks: bool = False):

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2658,7 +2658,22 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         "Timeout in milliseconds to wait for the sender future to be ready when scheduled batch size is 0. This allows the request to be eventually cancelled by the user or because of kv_transfer_timeout_ms"
     )
 
+    chunk_size_blocks: Optional[PositiveInt] = Field(
+        default=None,
+        description=
+        "Maximum number of KV cache blocks per layer group per chunk for "
+        "chunked KV cache transfer. When set, each layer group's block list "
+        "is partitioned into slices of at most this many blocks, and each "
+        "slice is transferred independently. The total data per chunk is "
+        "approximately chunk_size_blocks * num_layer_groups * slot_bytes. "
+        "This reduces per-transfer NIXL descriptor pressure for long "
+        "sequences. When None (default), the entire KV cache is transferred "
+        "in a single slice. Only effective with the Python transceiver "
+        "(transceiver_runtime='PYTHON').")
+
     def _to_pybind(self):
+        # chunk_size_blocks is consumed by the Python transceiver only
+        # and has no C++ counterpart, so it is intentionally omitted.
         return _CacheTransceiverConfig(
             backend=_CacheTransceiverBackendType.from_string(self.backend),
             max_tokens_in_buffer=self.max_tokens_in_buffer,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2667,9 +2667,11 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         "slice is transferred independently. The total data per chunk is "
         "approximately chunk_size_blocks * num_layer_groups * slot_bytes. "
         "This reduces per-transfer NIXL descriptor pressure for long "
-        "sequences. When None (default), the entire KV cache is transferred "
-        "in a single slice. Only effective with the Python transceiver "
-        "(transceiver_runtime='PYTHON').")
+        "sequences and enables early block release to free GPU memory "
+        "incrementally during transfer. When None (default), the entire "
+        "KV cache is transferred in a single slice. When set with NIXL "
+        "backend (default), the Python transceiver is auto-selected. "
+        "Not supported with UCX, MPI, or MOONCAKE backends.")
 
     def _to_pybind(self):
         # chunk_size_blocks is consumed by the Python transceiver only

--- a/tests/unittest/disaggregated/test_chunked_transfer.py
+++ b/tests/unittest/disaggregated/test_chunked_transfer.py
@@ -1,0 +1,373 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for chunked KV cache transfer (sender-only chunking).
+
+These tests validate the session state machine, callback plumbing, and
+release queue mechanics using the real TxSession/RxSession classes with
+lightweight stub sender/receiver objects.
+"""
+
+import queue
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensorrt_llm import DisaggregatedParams
+from tensorrt_llm._torch.disaggregation.base.transfer import KVSlice, SessionStatus, WaitResult
+from tensorrt_llm._torch.disaggregation.native.transfer import (
+    AgentResult,
+    KVSendTask,
+    RxSession,
+    TaskStatus,
+    TxSession,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_params(rid: int = 42) -> DisaggregatedParams:
+    return DisaggregatedParams(disagg_request_id=rid)
+
+
+def _stub_sender():
+    """Create a stub sender with no-op methods needed by TxSession."""
+    sender = MagicMock()
+    sender.setup_session = MagicMock()
+    sender._get_req_info = MagicMock(return_value=None)
+    sender.dispatch_task = MagicMock()
+    return sender
+
+
+def _stub_receiver():
+    """Create a stub receiver with no-op methods needed by RxSession."""
+    receiver = MagicMock()
+    receiver.setup_session = MagicMock()
+    receiver.dispatch_task = MagicMock()
+    return receiver
+
+
+def _make_tx_session(num_slices: int, rid: int = 42, **kwargs) -> TxSession:
+    """Create a real TxSession and send num_slices slices into it."""
+    params = _make_params(rid)
+    session = TxSession(
+        request_id=rid,
+        params=params,
+        sender=_stub_sender(),
+        aux_slot=None,
+        **kwargs,
+    )
+    for i in range(num_slices):
+        s = KVSlice(
+            is_last_slice=(i == num_slices - 1),
+            block_ids_per_layer_groups=[[i]],
+        )
+        session.send(s, chunk_block_offset=i)
+    return session
+
+
+def _make_rx_session(num_slices: int, rid: int = 42) -> RxSession:
+    """Create a real RxSession and receive num_slices slices into it."""
+    params = _make_params(rid)
+    session = RxSession(
+        request_id=rid,
+        params=params,
+        receiver=_stub_receiver(),
+        aux_slot=None,
+    )
+    for i in range(num_slices):
+        s = KVSlice(
+            is_last_slice=(i == num_slices - 1),
+            block_ids_per_layer_groups=[[i]],
+        )
+        session.receive(s)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# KVSendTask tests
+# ---------------------------------------------------------------------------
+
+
+def test_kv_send_task_chunk_block_offset():
+    """KVSendTask stores chunk_block_offset correctly."""
+    s = KVSlice(is_last_slice=False, block_ids_per_layer_groups=[[0, 1]])
+    task = KVSendTask(s, _make_params(), slice_id=1, chunk_block_offset=512)
+    assert task.chunk_block_offset == 512
+    assert task.slice_id == 1
+    assert task._slice is s
+
+
+def test_kv_send_task_default_offset():
+    """Default chunk_block_offset is 0."""
+    s = KVSlice(is_last_slice=True, block_ids_per_layer_groups=[[0]])
+    task = KVSendTask(s, _make_params(), slice_id=0)
+    assert task.chunk_block_offset == 0
+
+
+# ---------------------------------------------------------------------------
+# TxSession multi-slice status tests (real class)
+# ---------------------------------------------------------------------------
+
+
+def test_tx_session_status_init_until_all_transferred():
+    """TxSession status is not KV_TRANSFERRED until ALL tasks complete."""
+    session = _make_tx_session(3)
+    session.receiver_ready = True
+    assert session.status == SessionStatus.TRANSFERRING or session.status == SessionStatus.READY
+
+    session.kv_tasks[0].status = TaskStatus.TRANSFERRED
+    assert session.status != SessionStatus.KV_TRANSFERRED
+
+    session.kv_tasks[1].status = TaskStatus.TRANSFERRED
+    assert session.status != SessionStatus.KV_TRANSFERRED
+
+    session.kv_tasks[2].status = TaskStatus.TRANSFERRED
+    assert session.status == SessionStatus.KV_TRANSFERRED
+
+
+def test_tx_session_status_error_on_any_failure():
+    """TxSession status is ERROR if any task fails."""
+    session = _make_tx_session(3)
+    session.kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session.kv_tasks[1].status = TaskStatus.ERROR
+    assert session.status == SessionStatus.ERROR
+
+
+def test_tx_session_wait_complete_all_tasks():
+    """TxSession.wait_complete blocks on all task futures."""
+    session = _make_tx_session(3)
+    for task in session.kv_tasks:
+        task.future.set_result(AgentResult.SUCCESS)
+        task.status = TaskStatus.TRANSFERRED
+
+    result = session.wait_complete(need_aux=False, timeout=1.0)
+    assert result == WaitResult.COMPLETED
+
+
+def test_tx_session_wait_complete_fails_on_partial_failure():
+    """TxSession.wait_complete returns FAILED if any task fails."""
+    session = _make_tx_session(3)
+    session.kv_tasks[0].future.set_result(AgentResult.SUCCESS)
+    session.kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session.kv_tasks[1].future.set_result(AgentResult.FAILED)
+    session.kv_tasks[1].status = TaskStatus.ERROR
+    session.kv_tasks[2].future.set_result(AgentResult.SUCCESS)
+    session.kv_tasks[2].status = TaskStatus.TRANSFERRED
+
+    result = session.wait_complete(need_aux=False, timeout=1.0)
+    assert result == WaitResult.FAILED
+
+
+# ---------------------------------------------------------------------------
+# RxSession multi-slice status tests (real class)
+# ---------------------------------------------------------------------------
+
+
+def test_rx_session_status_checks_all_tasks():
+    """RxSession status is KV_TRANSFERRED only when ALL tasks complete."""
+    session = _make_rx_session(3)
+    assert session.status == SessionStatus.INIT
+
+    session._kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[1].status = TaskStatus.TRANSFERRING
+    assert session.status == SessionStatus.TRANSFERRING
+
+    session._kv_tasks[1].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[2].status = TaskStatus.TRANSFERRED
+    assert session.status == SessionStatus.KV_TRANSFERRED
+
+
+def test_rx_session_status_error_on_any_failure():
+    """RxSession status is ERROR if any task fails."""
+    session = _make_rx_session(2)
+    session._kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[1].status = TaskStatus.ERROR
+    assert session.status == SessionStatus.ERROR
+
+
+def test_rx_session_process_aux_uses_last_task():
+    """process_aux_agent_result uses the last task's expected_transfers."""
+    session = _make_rx_session(3)
+    session._kv_tasks[0].expected_transfers = 99
+    session._kv_tasks[1].expected_transfers = 99
+    session._kv_tasks[2].expected_transfers = 1
+
+    session.process_aux_agent_result(0, AgentResult.SUCCESS)
+    assert session._aux_status == TaskStatus.TRANSFERRED
+
+
+def test_rx_session_wait_complete_all_tasks():
+    """RxSession.wait_complete blocks on all task futures."""
+    session = _make_rx_session(3)
+    for task in session._kv_tasks:
+        task.future.set_result(AgentResult.SUCCESS)
+        task.status = TaskStatus.TRANSFERRED
+
+    result = session.wait_complete(need_aux=False)
+    assert result == WaitResult.COMPLETED
+
+
+def test_rx_session_wait_complete_fails_on_partial_failure():
+    """RxSession.wait_complete returns FAILED if any task fails."""
+    session = _make_rx_session(2)
+    session._kv_tasks[0].future.set_result(AgentResult.SUCCESS)
+    session._kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[1].future.set_exception(RuntimeError("transfer failed"))
+    session._kv_tasks[1].status = TaskStatus.ERROR
+
+    result = session.wait_complete(need_aux=False)
+    assert result == WaitResult.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Chunk completion callback tests
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_callback_enqueues_release():
+    """Callback from _make_chunk_callback enqueues the correct release entries."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._chunk_size_blocks = 64
+    transceiver._pending_prefix_releases = queue.Queue()
+    transceiver._kv_cache_manager.release_prefix_blocks = MagicMock()
+
+    callback = KvCacheTransceiverV2._make_chunk_callback(transceiver)
+    assert callback is not None
+
+    callback(request_id=7, chunk_block_offset=0, num_blocks=64)
+    callback(request_id=7, chunk_block_offset=64, num_blocks=64)
+    callback(request_id=7, chunk_block_offset=128, num_blocks=64)
+
+    results = []
+    while not transceiver._pending_prefix_releases.empty():
+        results.append(transceiver._pending_prefix_releases.get_nowait())
+
+    assert results == [(7, 64), (7, 128), (7, 192)]
+
+
+def test_drain_pending_releases():
+    """_drain_pending_releases calls release_prefix_blocks for each entry."""
+    transceiver = MagicMock()
+    transceiver._pending_prefix_releases = queue.Queue()
+    transceiver._kv_cache_manager = MagicMock()
+    transceiver._pending_prefix_releases.put((10, 64))
+    transceiver._pending_prefix_releases.put((10, 128))
+    transceiver._pending_prefix_releases.put((20, 32))
+
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    KvCacheTransceiverV2._drain_pending_releases(transceiver)
+
+    calls = transceiver._kv_cache_manager.release_prefix_blocks.call_args_list
+    assert len(calls) == 3
+    assert calls[0].args == (10, 64)
+    assert calls[1].args == (10, 128)
+    assert calls[2].args == (20, 32)
+
+
+@pytest.mark.parametrize(
+    "has_release,chunk_size,expected_none",
+    [
+        (False, 64, True),
+        (True, None, True),
+        (False, None, True),
+        (True, 64, False),
+    ],
+    ids=["no_release_api", "no_chunking", "neither", "with_release_and_chunking"],
+)
+def test_make_chunk_callback_conditions(has_release, chunk_size, expected_none):
+    """_make_chunk_callback returns None unless both release API and chunking enabled."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._chunk_size_blocks = chunk_size
+    transceiver._pending_prefix_releases = queue.Queue()
+    if has_release:
+        transceiver._kv_cache_manager.release_prefix_blocks = MagicMock()
+    else:
+        del transceiver._kv_cache_manager.release_prefix_blocks
+
+    result = KvCacheTransceiverV2._make_chunk_callback(transceiver)
+    assert (result is None) == expected_none
+
+
+def test_chunk_callback_then_drain():
+    """End-to-end: callback enqueues, drain calls release_prefix_blocks."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._chunk_size_blocks = 4
+    transceiver._pending_prefix_releases = queue.Queue()
+    transceiver._kv_cache_manager.release_prefix_blocks = MagicMock()
+
+    callback = KvCacheTransceiverV2._make_chunk_callback(transceiver)
+    assert callback is not None
+
+    callback(request_id=1, chunk_block_offset=0, num_blocks=4)
+    callback(request_id=1, chunk_block_offset=4, num_blocks=4)
+    callback(request_id=1, chunk_block_offset=8, num_blocks=2)
+
+    KvCacheTransceiverV2._drain_pending_releases(transceiver)
+
+    calls = transceiver._kv_cache_manager.release_prefix_blocks.call_args_list
+    assert len(calls) == 3
+    assert calls[0].args == (1, 4)
+    assert calls[1].args == (1, 8)
+    assert calls[2].args == (1, 10)
+
+
+# ---------------------------------------------------------------------------
+# Mid-transfer chunk failure tests
+# ---------------------------------------------------------------------------
+
+
+def test_tx_session_mid_chunk_failure():
+    """If one chunk fails mid-transfer, the session reports ERROR."""
+    session = _make_tx_session(4)
+
+    session.kv_tasks[0].future.set_result(AgentResult.SUCCESS)
+    session.kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session.kv_tasks[1].future.set_result(AgentResult.SUCCESS)
+    session.kv_tasks[1].status = TaskStatus.TRANSFERRED
+    session.kv_tasks[2].future.set_exception(RuntimeError("RDMA failed"))
+    session.kv_tasks[2].status = TaskStatus.ERROR
+    session.kv_tasks[3].future.set_result(AgentResult.SUCCESS)
+    session.kv_tasks[3].status = TaskStatus.TRANSFERRED
+
+    assert session.status == SessionStatus.ERROR
+    result = session.wait_complete(need_aux=False, timeout=1.0)
+    assert result == WaitResult.FAILED
+
+
+def test_rx_session_mid_chunk_failure():
+    """If one chunk fails mid-transfer on receiver, the session reports ERROR."""
+    session = _make_rx_session(4)
+
+    session._kv_tasks[0].future.set_result(AgentResult.SUCCESS)
+    session._kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[1].future.set_exception(RuntimeError("RDMA failed"))
+    session._kv_tasks[1].status = TaskStatus.ERROR
+    session._kv_tasks[2].future.set_result(AgentResult.SUCCESS)
+    session._kv_tasks[2].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[3].future.set_result(AgentResult.SUCCESS)
+    session._kv_tasks[3].status = TaskStatus.TRANSFERRED
+
+    assert session.status == SessionStatus.ERROR
+    result = session.wait_complete(need_aux=False)
+    assert result == WaitResult.FAILED

--- a/tests/unittest/disaggregated/test_chunked_transfer.py
+++ b/tests/unittest/disaggregated/test_chunked_transfer.py
@@ -74,8 +74,9 @@ def _make_tx_session(num_slices: int, rid: int = 42, **kwargs) -> TxSession:
         s = KVSlice(
             is_last_slice=(i == num_slices - 1),
             block_ids_per_layer_groups=[[i]],
+            chunk_block_offset=i,
         )
-        session.send(s, chunk_block_offset=i)
+        session.send(s)
     return session
 
 
@@ -103,19 +104,19 @@ def _make_rx_session(num_slices: int, rid: int = 42) -> RxSession:
 
 
 def test_kv_send_task_chunk_block_offset():
-    """KVSendTask stores chunk_block_offset correctly."""
-    s = KVSlice(is_last_slice=False, block_ids_per_layer_groups=[[0, 1]])
-    task = KVSendTask(s, _make_params(), slice_id=1, chunk_block_offset=512)
-    assert task.chunk_block_offset == 512
+    """KVSendTask reads chunk_block_offset from the slice."""
+    s = KVSlice(is_last_slice=False, block_ids_per_layer_groups=[[0, 1]], chunk_block_offset=512)
+    task = KVSendTask(s, _make_params(), slice_id=1)
+    assert task._slice.chunk_block_offset == 512
     assert task.slice_id == 1
     assert task._slice is s
 
 
 def test_kv_send_task_default_offset():
-    """Default chunk_block_offset is 0."""
+    """Default chunk_block_offset on KVSlice is 0."""
     s = KVSlice(is_last_slice=True, block_ids_per_layer_groups=[[0]])
     task = KVSendTask(s, _make_params(), slice_id=0)
-    assert task.chunk_block_offset == 0
+    assert task._slice.chunk_block_offset == 0
 
 
 # ---------------------------------------------------------------------------
@@ -279,6 +280,47 @@ def test_drain_pending_releases():
     assert calls[0].args == (10, 64)
     assert calls[1].args == (10, 128)
     assert calls[2].args == (20, 32)
+
+
+def test_drain_pending_releases_tolerates_stale_rid():
+    """A pending release for a request that was already removed must be a no-op.
+
+    Models the production race where the sender worker enqueues a release
+    after the main thread has already torn the sequence down via
+    ``removeSequence``.  ``KVCacheManager.release_prefix_blocks`` returns
+    early in that case, so ``_drain_pending_releases`` must not raise.
+    """
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._pending_prefix_releases = queue.Queue()
+    transceiver._kv_cache_manager = MagicMock()
+    # Manager wrapper is a no-op for unknown rids; drain must propagate that
+    # no-op semantics rather than crashing.
+    transceiver._kv_cache_manager.release_prefix_blocks = MagicMock(return_value=None)
+
+    transceiver._pending_prefix_releases.put((9999, 64))  # unknown rid
+    transceiver._pending_prefix_releases.put((9999, 128))
+
+    KvCacheTransceiverV2._drain_pending_releases(transceiver)
+
+    calls = transceiver._kv_cache_manager.release_prefix_blocks.call_args_list
+    assert len(calls) == 2
+    assert calls[0].args == (9999, 64)
+    assert calls[1].args == (9999, 128)
+
+
+def test_drain_pending_releases_empty_queue_is_noop():
+    """Drain on an empty queue is a no-op and never calls the manager."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._pending_prefix_releases = queue.Queue()
+    transceiver._kv_cache_manager = MagicMock()
+
+    KvCacheTransceiverV2._drain_pending_releases(transceiver)
+
+    transceiver._kv_cache_manager.release_prefix_blocks.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -1196,11 +1196,11 @@ def _setup_chunked_request(setup, ctx_request_id, gen_request_id, request_len):
 
     ctx_block_ids = [
         get_block_ids_per_layer_groups(mgr, tw, ctx_request.py_request_id, use_v2, tokens_per_block)
-        for mgr, tw in zip(ctx_kv_cache_managers, ctx_transfer_workers)
+        for mgr, tw in zip(ctx_kv_cache_managers, ctx_transfer_workers, strict=True)
     ]
     gen_block_ids = [
         get_block_ids_per_layer_groups(mgr, tw, gen_request.py_request_id, use_v2, tokens_per_block)
-        for mgr, tw in zip(gen_kv_cache_managers, gen_transfer_workers)
+        for mgr, tw in zip(gen_kv_cache_managers, gen_transfer_workers, strict=True)
     ]
 
     return {
@@ -1231,13 +1231,13 @@ def _verify_and_cleanup_chunked(setup, ctx_info, sender_sessions, receiver_sessi
     for lg_id in range(num_layer_groups):
         ctx_data = [
             get_block_data(mgr, bids[lg_id], lg_id, use_v2, ctx_info["ctx_request"].py_request_id)
-            for mgr, bids in zip(ctx_kv_cache_managers, ctx_block_ids)
+            for mgr, bids in zip(ctx_kv_cache_managers, ctx_block_ids, strict=True)
         ]
         gen_data = [
             get_block_data(mgr, bids[lg_id], lg_id, use_v2, ctx_info["gen_request"].py_request_id)
-            for mgr, bids in zip(gen_kv_cache_managers, gen_block_ids)
+            for mgr, bids in zip(gen_kv_cache_managers, gen_block_ids, strict=True)
         ]
-        for c, g in zip(ctx_data, gen_data):
+        for c, g in zip(ctx_data, gen_data, strict=True):
             assert c.equal(g), f"Layer group {lg_id}: data mismatch with chunked transfer"
 
     for s in receiver_sessions:
@@ -1271,7 +1271,7 @@ def add_and_verify_chunked_request(
 
     sender_sessions = [tw.create_tx_session(ctx_info["ctx_request"]) for tw in ctx_transfer_workers]
     send_futures = []
-    for sender_session, block_ids_per_groups in zip(sender_sessions, ctx_block_ids):
+    for sender_session, block_ids_per_groups in zip(sender_sessions, ctx_block_ids, strict=True):
         max_blocks = max(len(ids) for ids in block_ids_per_groups)
         num_chunks = math.ceil(max_blocks / chunk_size_blocks)
         chunk_offset = 0
@@ -1291,7 +1291,7 @@ def add_and_verify_chunked_request(
         tw.create_rx_session(ctx_info["gen_request"]) for tw in gen_transfer_workers
     ]
     recv_futures = []
-    for recv_session, block_ids_per_groups in zip(receiver_sessions, gen_block_ids):
+    for recv_session, block_ids_per_groups in zip(receiver_sessions, gen_block_ids, strict=True):
         full_slice = KVSlice(
             is_last_slice=True,
             block_ids_per_layer_groups=block_ids_per_groups,

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -132,6 +132,69 @@ def test_session_status_enum():
     assert len(SessionStatus) == 6
 
 
+# ---------------------------------------------------------------------------
+# Chunked KV slice creation tests
+# ---------------------------------------------------------------------------
+
+
+def _chunk_block_ids(all_block_ids, chunk_size_blocks):
+    """Call the real _create_kv_slices via a mock transceiver."""
+    from unittest.mock import MagicMock
+
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._chunk_size_blocks = chunk_size_blocks
+    transceiver._collect_block_ids = MagicMock(return_value=all_block_ids)
+    transceiver._create_kv_slices = KvCacheTransceiverV2._create_kv_slices.__get__(transceiver)
+
+    req = MagicMock()
+    return transceiver._create_kv_slices(req)
+
+
+@pytest.mark.parametrize(
+    "all_block_ids,chunk_size,expected_num_slices",
+    [
+        ([[0, 1, 2, 3, 4, 5, 6, 7]], None, 1),
+        ([[0, 1, 2, 3, 4, 5, 6, 7]], 4, 2),
+        ([list(range(10))], 4, 3),
+        ([[], []], 4, 1),
+        ([[0, 1, 2]], 64, 1),
+    ],
+    ids=["no_chunking", "even_split", "uneven_split", "empty_blocks", "chunk_larger_than_total"],
+)
+def test_create_kv_slices_basic(all_block_ids, chunk_size, expected_num_slices):
+    """Chunking produces the expected number of slices."""
+    slices = _chunk_block_ids(all_block_ids, chunk_size_blocks=chunk_size)
+    assert len(slices) == expected_num_slices
+    assert slices[-1].is_last_slice is True
+    if expected_num_slices > 1:
+        for s in slices[:-1]:
+            assert s.is_last_slice is False
+
+
+def test_create_kv_slices_integrity_check():
+    """Reassembled block IDs from all slices must match the original."""
+    all_block_ids = [list(range(17)), list(range(5))]
+    slices = _chunk_block_ids(all_block_ids, chunk_size_blocks=4)
+    for lg_idx, original in enumerate(all_block_ids):
+        reassembled = []
+        for s in slices:
+            reassembled.extend(s.block_ids_per_layer_groups[lg_idx])
+        assert reassembled == original
+
+
+def test_create_kv_slices_multiple_layer_groups():
+    """Different layer groups with different block counts produce correct chunking."""
+    all_block_ids = [list(range(8)), list(range(3))]
+    slices = _chunk_block_ids(all_block_ids, chunk_size_blocks=4)
+    assert len(slices) == 2
+    assert slices[0].block_ids_per_layer_groups[0] == [0, 1, 2, 3]
+    assert slices[1].block_ids_per_layer_groups[0] == [4, 5, 6, 7]
+    assert slices[0].block_ids_per_layer_groups[1] == [0, 1, 2]
+    assert slices[1].block_ids_per_layer_groups[1] == []
+
+
 def create_transfer_worker_setup(
     ctx_tp: int,
     ctx_pp: int,
@@ -1039,6 +1102,224 @@ def test_transfer_worker_v2_with_window(
         add_and_verify_request(setup, 0, 1, request_len=16, send_first=True)
         add_and_verify_request(setup, 2, 3, request_len=32, send_first=True)
         add_and_verify_request(setup, 4, 5, request_len=64, send_first=False)
+    finally:
+        for worker in setup["ctx_transfer_workers"]:
+            worker.shutdown()
+        for worker in setup["gen_transfer_workers"]:
+            worker.shutdown()
+
+
+def _setup_chunked_request(setup, ctx_request_id, gen_request_id, request_len):
+    """Shared setup for chunked transfer tests: create requests, allocate KV, get block IDs."""
+    ctx_transfer_workers = setup["ctx_transfer_workers"]
+    ctx_kv_cache_managers = setup["ctx_kv_cache_managers"]
+    gen_transfer_workers = setup["gen_transfer_workers"]
+    gen_kv_cache_managers = setup["gen_kv_cache_managers"]
+    ctx_info_endpoint = setup["ctx_info_endpoint"]
+    use_v2 = setup["use_v2"]
+    tokens_per_block = setup["tokens_per_block"]
+
+    sampling_params = SamplingParams()
+    unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
+
+    ctx_request = LlmRequest(
+        request_id=ctx_request_id,
+        max_new_tokens=1,
+        input_tokens=list(range(request_len)),
+        sampling_config=tensorrt_llm.bindings.SamplingConfig(
+            sampling_params._get_sampling_config()
+        ),
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
+    )
+    ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
+
+    gen_request = LlmRequest(
+        request_id=gen_request_id,
+        max_new_tokens=1,
+        input_tokens=list(range(request_len)),
+        sampling_config=tensorrt_llm.bindings.SamplingConfig(
+            sampling_params._get_sampling_config()
+        ),
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+    )
+    gen_request.py_disaggregated_params = DisaggregatedParams(
+        ctx_request_id=ctx_request.py_request_id,
+        ctx_dp_rank=0,
+        ctx_info_endpoint=ctx_info_endpoint,
+        disagg_request_id=unique_rid,
+    )
+
+    ctx_kv_caches, gen_kv_caches = [], []
+    for mgr in ctx_kv_cache_managers:
+        if use_v2:
+            kv = mgr._create_kv_cache(ctx_request.py_request_id, None, None)
+            assert kv.resume(torch.cuda.current_stream().cuda_stream)
+            assert kv.resize(request_len)
+            ctx_kv_caches.append(kv)
+        else:
+            mgr.impl.add_sequence(ctx_request.py_request_id, request_len, 1, ctx_request)
+
+    for mgr in gen_kv_cache_managers:
+        if use_v2:
+            kv = mgr._create_kv_cache(gen_request.py_request_id, None, None)
+            assert kv.resume(torch.cuda.current_stream().cuda_stream)
+            assert kv.resize(request_len)
+            gen_kv_caches.append(kv)
+        else:
+            mgr.impl.add_sequence(gen_request.py_request_id, request_len, 1, gen_request)
+
+    ctx_block_ids = [
+        get_block_ids_per_layer_groups(mgr, tw, ctx_request.py_request_id, use_v2, tokens_per_block)
+        for mgr, tw in zip(ctx_kv_cache_managers, ctx_transfer_workers)
+    ]
+    gen_block_ids = [
+        get_block_ids_per_layer_groups(mgr, tw, gen_request.py_request_id, use_v2, tokens_per_block)
+        for mgr, tw in zip(gen_kv_cache_managers, gen_transfer_workers)
+    ]
+
+    return {
+        "ctx_request": ctx_request,
+        "gen_request": gen_request,
+        "ctx_kv_caches": ctx_kv_caches,
+        "gen_kv_caches": gen_kv_caches,
+        "ctx_block_ids": ctx_block_ids,
+        "gen_block_ids": gen_block_ids,
+    }
+
+
+def _verify_and_cleanup_chunked(setup, ctx_info, sender_sessions, receiver_sessions):
+    """Shared verification and cleanup for chunked transfer tests."""
+    ctx_kv_cache_managers = setup["ctx_kv_cache_managers"]
+    gen_kv_cache_managers = setup["gen_kv_cache_managers"]
+    use_v2 = setup["use_v2"]
+
+    ctx_block_ids = ctx_info["ctx_block_ids"]
+    gen_block_ids = ctx_info["gen_block_ids"]
+
+    for session in sender_sessions:
+        assert session.status == SessionStatus.KV_TRANSFERRED
+    for session in receiver_sessions:
+        assert session.status == SessionStatus.KV_TRANSFERRED
+
+    num_layer_groups = len(ctx_block_ids[0])
+    for lg_id in range(num_layer_groups):
+        ctx_data = [
+            get_block_data(mgr, bids[lg_id], lg_id, use_v2, ctx_info["ctx_request"].py_request_id)
+            for mgr, bids in zip(ctx_kv_cache_managers, ctx_block_ids)
+        ]
+        gen_data = [
+            get_block_data(mgr, bids[lg_id], lg_id, use_v2, ctx_info["gen_request"].py_request_id)
+            for mgr, bids in zip(gen_kv_cache_managers, gen_block_ids)
+        ]
+        for c, g in zip(ctx_data, gen_data):
+            assert c.equal(g), f"Layer group {lg_id}: data mismatch with chunked transfer"
+
+    for s in receiver_sessions:
+        s.close()
+    for s in sender_sessions:
+        s.close()
+    if use_v2:
+        torch.cuda.current_stream().synchronize()
+        for kv in ctx_info["ctx_kv_caches"]:
+            kv.close()
+        for kv in ctx_info["gen_kv_caches"]:
+            kv.close()
+
+
+def add_and_verify_chunked_request(
+    setup,
+    ctx_request_id,
+    gen_request_id,
+    request_len,
+    chunk_size_blocks,
+):
+    """Chunked transfer variant: sender sends N slices, receiver sends 1."""
+    import math
+
+    ctx_transfer_workers = setup["ctx_transfer_workers"]
+    gen_transfer_workers = setup["gen_transfer_workers"]
+
+    ctx_info = _setup_chunked_request(setup, ctx_request_id, gen_request_id, request_len)
+    ctx_block_ids = ctx_info["ctx_block_ids"]
+    gen_block_ids = ctx_info["gen_block_ids"]
+
+    sender_sessions = [tw.create_tx_session(ctx_info["ctx_request"]) for tw in ctx_transfer_workers]
+    send_futures = []
+    for sender_session, block_ids_per_groups in zip(sender_sessions, ctx_block_ids):
+        max_blocks = max(len(ids) for ids in block_ids_per_groups)
+        num_chunks = math.ceil(max_blocks / chunk_size_blocks)
+        chunk_offset = 0
+        for chunk_idx in range(num_chunks):
+            start = chunk_idx * chunk_size_blocks
+            end = start + chunk_size_blocks
+            is_last = chunk_idx == num_chunks - 1
+            chunk_block_ids = [ids[start:end] for ids in block_ids_per_groups]
+            kv_slice = KVSlice(
+                is_last_slice=is_last,
+                block_ids_per_layer_groups=chunk_block_ids,
+            )
+            send_futures.append(sender_session.send(kv_slice, chunk_block_offset=chunk_offset))
+            chunk_offset += max(len(ids) for ids in chunk_block_ids)
+
+    receiver_sessions = [
+        tw.create_rx_session(ctx_info["gen_request"]) for tw in gen_transfer_workers
+    ]
+    recv_futures = []
+    for recv_session, block_ids_per_groups in zip(receiver_sessions, gen_block_ids):
+        full_slice = KVSlice(
+            is_last_slice=True,
+            block_ids_per_layer_groups=block_ids_per_groups,
+        )
+        recv_futures.append(recv_session.receive(full_slice))
+
+    for f in send_futures:
+        f.result()
+    for f in recv_futures:
+        f.result()
+
+    _verify_and_cleanup_chunked(setup, ctx_info, sender_sessions, receiver_sessions)
+
+
+CHUNKED_TEST_CONFIGS = [
+    (1, 1, False, 1, 1, False, False, True, "v2_tp1_pp1_chunked"),
+    (1, 1, False, 1, 1, False, False, False, "v1_tp1_pp1_chunked"),
+]
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,ctx_enable_dp,gen_tp,gen_pp,gen_enable_dp,is_mla,use_v2",
+    [(c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]) for c in CHUNKED_TEST_CONFIGS],
+    ids=[c[8] for c in CHUNKED_TEST_CONFIGS],
+)
+def test_transfer_worker_chunked(
+    ctx_tp, ctx_pp, ctx_enable_dp, gen_tp, gen_pp, gen_enable_dp, is_mla, use_v2
+):
+    """Test transfer worker with sender-side chunking for V1 and V2."""
+    tensorrt_llm.logger.set_level("info")
+    logger.info(f"Test transfer worker {'V2' if use_v2 else 'V1'} with chunked transfer")
+
+    setup = create_transfer_worker_setup(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        gen_enable_dp=gen_enable_dp,
+        is_mla=is_mla,
+        use_v2=use_v2,
+    )
+
+    request_len = setup["request_len"]
+    tokens_per_block = setup["tokens_per_block"]
+    total_blocks = (request_len + tokens_per_block - 1) // tokens_per_block
+    chunk_size = max(1, total_blocks // 2)
+
+    try:
+        add_and_verify_chunked_request(setup, 0, 1, request_len, chunk_size_blocks=chunk_size)
+        add_and_verify_chunked_request(setup, 2, 3, request_len * 2, chunk_size_blocks=chunk_size)
     finally:
         for worker in setup["ctx_transfer_workers"]:
             worker.shutdown()

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -1283,8 +1283,9 @@ def add_and_verify_chunked_request(
             kv_slice = KVSlice(
                 is_last_slice=is_last,
                 block_ids_per_layer_groups=chunk_block_ids,
+                chunk_block_offset=chunk_offset,
             )
-            send_futures.append(sender_session.send(kv_slice, chunk_block_offset=chunk_offset))
+            send_futures.append(sender_session.send(kv_slice))
             chunk_offset += max(len(ids) for ids in chunk_block_ids)
 
     receiver_sessions = [

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -137,15 +137,22 @@ def test_session_status_enum():
 # ---------------------------------------------------------------------------
 
 
-def _chunk_block_ids(all_block_ids, chunk_size_blocks):
+def _chunk_block_ids(all_block_ids, chunk_size_blocks, mamba_state_index=None):
     """Call the real _create_kv_slices via a mock transceiver."""
     from unittest.mock import MagicMock
 
+    from tensorrt_llm._torch.disaggregation.base.transfer import KVSlice
     from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    base_slice = KVSlice(
+        is_last_slice=True,
+        block_ids_per_layer_groups=all_block_ids,
+        mamba_state_index=mamba_state_index,
+    )
 
     transceiver = MagicMock()
     transceiver._chunk_size_blocks = chunk_size_blocks
-    transceiver._collect_block_ids = MagicMock(return_value=all_block_ids)
+    transceiver._collect_base_slice = MagicMock(return_value=base_slice)
     transceiver._create_kv_slices = KvCacheTransceiverV2._create_kv_slices.__get__(transceiver)
 
     req = MagicMock()
@@ -193,6 +200,23 @@ def test_create_kv_slices_multiple_layer_groups():
     assert slices[1].block_ids_per_layer_groups[0] == [4, 5, 6, 7]
     assert slices[0].block_ids_per_layer_groups[1] == [0, 1, 2]
     assert slices[1].block_ids_per_layer_groups[1] == []
+
+
+def test_create_kv_slices_preserves_mamba_state_index():
+    """mamba_state_index is propagated to every chunk slice."""
+    all_block_ids = [list(range(8))]
+    slices = _chunk_block_ids(all_block_ids, chunk_size_blocks=4, mamba_state_index=42)
+    assert len(slices) == 2
+    for s in slices:
+        assert s.mamba_state_index == 42
+
+
+def test_create_kv_slices_none_mamba_state_index():
+    """mamba_state_index=None is preserved when not set."""
+    all_block_ids = [list(range(4))]
+    slices = _chunk_block_ids(all_block_ids, chunk_size_blocks=4)
+    assert len(slices) == 1
+    assert slices[0].mamba_state_index is None
 
 
 def create_transfer_worker_setup(

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -1028,6 +1028,23 @@ class TestStrictBaseModelArbitraryArgs:
             CacheTransceiverConfig(backend="UCX", invalid_config="should_fail")
         assert "invalid_config" in str(exc_info.value)
 
+    def test_cache_transceiver_config_chunk_size_blocks(self):
+        """Test chunk_size_blocks field validation."""
+        config = CacheTransceiverConfig(chunk_size_blocks=64)
+        assert config.chunk_size_blocks == 64
+
+        config_none = CacheTransceiverConfig(chunk_size_blocks=None)
+        assert config_none.chunk_size_blocks is None
+
+        config_default = CacheTransceiverConfig()
+        assert config_default.chunk_size_blocks is None
+
+        with pytest.raises(pydantic_core._pydantic_core.ValidationError):
+            CacheTransceiverConfig(chunk_size_blocks=0)
+
+        with pytest.raises(pydantic_core._pydantic_core.ValidationError):
+            CacheTransceiverConfig(chunk_size_blocks=-1)
+
     def test_torch_compile_config_arbitrary_args(self):
         """Test that TorchCompileConfig rejects arbitrary arguments."""
         # Valid arguments should work


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chunked KV-cache transfer with configurable chunk size and sender-side chunking support
  * Early prefix-block release API to free leading cache blocks during transfer without removing sequences
  * Per-chunk completion callbacks and Python-accessible API to trigger prefix releases

* **Tests**
  * New unit and integration tests covering chunked transfers, chunk offsets, callback/release plumbing, and mid-transfer failure handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

### Summary

Implements chunked KV cache transfer with early block release for disaggregated serving (Phase 1a). This targets the **V1 KV cache manager** (C++ `BlockManager` path) with the **Python transceiver** (NIXL GPUDirect RDMA), including all shared infrastructure for future phases.

Large disaggregated serving transfers hold all sender-side KV cache blocks until the entire RDMA completes, starving the context server of GPU memory for new prefill requests. This PR splits the transfer into chunks and releases each chunk's blocks on the sender as soon as its RDMA finishes, freeing GPU memory incrementally rather than all-at-once at session teardown.

When `chunk_size_blocks` is set and the backend is NIXL (the default), the Python transceiver is auto-selected. The Python transceiver also avoids the contiguous staging buffer that the C++ transceiver allocates, eliminating an additional source of memory pressure for long-context requests.

### Configuration

Enable chunked KV cache transfer by setting `chunk_size_blocks` in the YAML config:

```yaml
# Context server config
context_servers:
  cache_transceiver_config:
    backend: "DEFAULT"          # or "NIXL"
    chunk_size_blocks: 64       # max blocks per layer group per chunk

# Generation server config (same setting)
generation_servers:
  cache_transceiver_config:
    backend: "DEFAULT"
    chunk_size_blocks: 64
```

Or via the Python API:

```python
from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig

config = CacheTransceiverConfig(
    backend="NIXL",
    chunk_size_blocks=64,
)
```

| `chunk_size_blocks` | Backend | Effect |
|---------------------|---------|--------|
| `None` (default) | Any | No chunking, C++ transceiver (unchanged from today) |
| `64` | NIXL / DEFAULT | Python transceiver auto-selected, chunked transfer + early block release |
| `64` | UCX / MPI / MOONCAKE | Warning logged, `chunk_size_blocks` ignored (C++ transceiver has no chunking support yet) |

Recommended values: 64-128 for long-context workloads (ISL >= 32K).

### Phased Roadmap

This PR is Phase 1a of a multi-phase effort:

| Phase | What | KV Cache | Transceiver | PR | Status |
|-------|------|----------|-------------|-----|--------|
| **1a** | Chunked transfer + early release | V1 (C++) | Python | This PR | In review |
| **1b** | Chunked transfer + early release | V1 (C++) | C++ | [#12907](https://github.com/NVIDIA/TensorRT-LLM/pull/12907) | Follow-up |
| **1c** | Chunked transfer + early release | V2 (Py) | Python | #12469 | Follow-up |
| **2** | Pipelined prefill-transfer | V1+V2 | Python (gen-first) | #12781 | Prototype |

**Dependencies.** All three follow-ups depend on Phase 1a (this PR): 1b consumes the new `releasePrefixBlocks` C++ API directly, while 1c and 2 build on the Python chunking infrastructure (`_create_kv_slices`, `KVSlice.chunk_block_offset`, the per-chunk callback + `_pending_prefix_releases` queue, and the `hasattr` gate in `_make_chunk_callback`). Once Phase 1a lands, the three follow-ups touch disjoint code surfaces — C++ transceiver (1b), V2 KV cache Python (1c), Python transceiver + executor (2) — so they can be reviewed and merged in parallel.

### What This PR Contains

**Shared chunking infrastructure (all phases):**

- Sender-only chunking at `KVSlice` level: `_create_kv_slices` partitions block IDs per layer group into slices of at most `chunk_size_blocks` blocks, with `KVSlice.chunk_block_offset` for destination alignment
- Destination block slicing in `_build_kv_write_meta` via `chunk_block_offset`
- Per-chunk completion callback in `_deliver_kv_to_agent` with `receiver_slice_id=0` mapping (intermediate results enable immediate error propagation)
- Thread-safe release queue (`_pending_prefix_releases`): sender worker thread enqueues, main thread drains via `_drain_pending_releases`
- `_make_chunk_callback` with `hasattr(kv_cache_manager, 'release_prefix_blocks')` gate
- `CacheTransceiverConfig.chunk_size_blocks` configuration field
- Auto-selection of Python transceiver when `chunk_size_blocks` is set (NIXL/DEFAULT)
- Warning when `chunk_size_blocks` set with unsupported backend
- Receiver unchanged: single monolithic `RecvReqInfo`; sender slices dst blocks per chunk

**V1 early block release (C++):**

- `WindowBlockManager::releasePrefixBlocks`: loops `detachFrontBlock` logic, cumulative semantics
- `BlockManager::releasePrefixBlocks`: snapshots `mNumFrontBlocksRemoved` for correct multi-window handling (single window size assumption documented)
- `KVCacheManager::releasePrefixBlocks`: acquires `mSequencesMtx`, no-op if sequence not found
- Nanobind binding with GIL release
- Python wrapper: `KVCacheManager.release_prefix_blocks(request_id, num_blocks)`

### Design Rationale

**Why sender-only chunking:** Chunking on both sides produces an N² dispatch bug. `_respond_with_kv` fires for each `RecvReqInfo` and dispatches all `kv_tasks`. Since `RecvReqInfo` has no `slice_id` field, multiple messages overwrite each other in `_peer_requests`. With sender-only chunking, one `RecvReqInfo` → one dispatch → N tasks use `KVSlice.chunk_block_offset` to slice the correct destination subset.

**Why `KVSlice.chunk_block_offset` (not function parameter):** Per reviewer feedback (chuangz0, Shixiaowei02), the offset belongs as a member of `KVSlice` since the dataclass was designed to carry all slice metadata including token range, layer range, and block offsets.

**Intermediate chunk results:** Each chunk sends `KV_AGENT_RESULT` to the receiver (not just the last). Intermediate results with `is_last_slice=False` are no-ops on the receiver but enable immediate error propagation if a chunk's RDMA fails.

**Beam width guard:** C++ `releasePrefixBlocks` asserts `beamWidth == 1`. Python-side guard in `respond_and_send_async` sets callback to `None` for `beam_width > 1`.

**VSWA limitation:** `mNumFrontBlocksRemoved` is shared across window managers. Single window size assumed, enforced by existing disagg gate (`not is_vswa`). Documented at call site.

**Auto-selection of Python transceiver:** When `chunk_size_blocks` is set with NIXL/DEFAULT backend, the Python transceiver is auto-selected. Non-NIXL backends log a warning that chunking will be ignored. The Python transceiver avoids the C++ transceiver's staging buffer, eliminating that memory pressure too.

**Why Python transceiver first (not C++):** The Python transceiver provides full control over the transfer lifecycle for chunking and callbacks. The C++ `CacheTransceiver::respondAndSendAsync` is monolithic with no per-chunk hook points. Phase 1b will add chunking to the C++ transceiver (~500 lines in `CacheFormatter::format`), which will also enable smaller staging buffers.

### Changes

**C++ (`kvCacheManager.h`, `kvCacheManager.cpp`):**
- Add `releasePrefixBlocks` to `WindowBlockManager`, `BlockManager`, `KVCacheManager`
- Snapshot `mNumFrontBlocksRemoved` for multi-window correctness
- VSWA limitation comment

**Nanobind (`kvCacheManager.cpp`):**
- Bind `release_prefix_blocks` with GIL release; copyright year updated

**Python (`base/transfer.py`):**
- Add `chunk_block_offset: int = 0` to `KVSlice` dataclass

**Python (`native/transfer.py`):**
- `KVSendTask` reads offset from `_slice.chunk_block_offset`
- `OnChunkTransferredCallback` type alias
- `_build_kv_write_meta` dst slicing, `_deliver_kv_to_agent` callback + `receiver_slice_id=0`

**Python (`transceiver.py`):**
- `_collect_base_slice`, `_create_kv_slices` (preserves `mamba_state_index`, sets `chunk_block_offset`)
- `_make_chunk_callback`, `_drain_pending_releases`
- Updated `respond_and_send_async` and `request_and_receive_async`
- Integrity check uses `np.array_equal()` + `ValueError`

**Python (`kv_cache_transceiver.py`):**
- Auto-select Python transceiver when `chunk_size_blocks` set
- Warning for unsupported backends

**Python (`resource_manager.py`):**
- `KVCacheManager.release_prefix_blocks`

**Python (`llm_args.py`):**
- `CacheTransceiverConfig.chunk_size_blocks` field

## Test Coverage

| Test | What it covers |
|------|---------------|
| `test_create_kv_slices_basic` | 5 parametrized cases calling real `_create_kv_slices` |
| `test_create_kv_slices_integrity_check` | Reassembled blocks match original across layer groups |
| `test_create_kv_slices_multiple_layer_groups` | Asymmetric layer groups produce correct chunking |
| `test_create_kv_slices_preserves_mamba_state` | `mamba_state_index` propagated through chunked slices |
| `test_transfer_worker_chunked[v1_tp1_pp1_chunked]` | E2E GPU: V1 chunked transfer with actual NIXL RDMA |
| `test_transfer_worker_chunked[v2_tp1_pp1_chunked]` | E2E GPU: V2 chunked transfer |
| `test_chunked_transfer.py` | 19 tests: session state machine using real `TxSession`/`RxSession` |
| `test_make_chunk_callback_conditions` | 4 parametrized cases calling real `_make_chunk_callback` |
| `test_chunk_callback_enqueues_release` | Real callback from `_make_chunk_callback` enqueues correctly |
| `test_chunk_callback_then_drain` | End-to-end: real `_make_chunk_callback` + real `_drain_pending_releases` |
| `test_drain_pending_releases` | Real `_drain_pending_releases` calls `release_prefix_blocks` |
| `test_cache_transceiver_config_chunk_size_blocks` | Config validation: valid, None, default, zero, negative |

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
