### PR TITLE
[https://nvbugs/6008468][fix] Fix top-K logprobs size for PP

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -270,8 +270,6 @@ class PyResult:
         generation_logits_list: list[torch.Tensor] = field(default_factory=list)
         reset_log_probs: tuple[list[TokenLogprobs],
                                list[float] | None] | None = None
-        log_probs_list: list[tuple[list[TokenLogprobs], list[float]
-                                   | None]] = field(default_factory=list)
         mm_embeddings: list[dict[str, Any] | None] = None
         mrope_position_ids: dict[str, Any] | None = None
         mrope_position_deltas: dict[str, Any] | None = None
@@ -349,9 +347,6 @@ class PyResult:
                 self._generation_logits.append(generation_logits)
         if diff.reset_log_probs is not None:
             self._log_probs.set_log_probs(*diff.reset_log_probs)
-        if len(diff.log_probs_list) > 0:
-            for log_probs, cum_log_probs in diff.log_probs_list:
-                self._log_probs.append(log_probs, cum_log_probs)
         if diff.mm_embeddings is not None:
             self._mm_embeddings = diff.mm_embeddings
         if diff.mrope_position_ids is not None:
@@ -386,7 +381,6 @@ class PyResult:
                          cum_log_probs: Optional[list[float]] = None):
         if self._log_probs:
             self._log_probs.append(log_probs, cum_log_probs)
-            self.diff.log_probs_list.append((log_probs, cum_log_probs))
 
     def append_mm_embeddings(self, mm_embeddings: torch.Tensor,
                              multimodal_lengths: List[int]):
@@ -447,7 +441,6 @@ class PyResult:
         if self._log_probs:
             self._log_probs.set_log_probs(log_probs, cum_log_probs)
             self.diff.reset_log_probs = (log_probs, cum_log_probs)
-            self.diff.log_probs_list.clear()
 
     @property
     def context_logits(self) -> torch.Tensor | None:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1649,6 +1649,13 @@ class PyExecutor:
             with torch.cuda.nvtx.range("_handle_executed_batch_pp"):
                 self._update_requests(executed_batch.sample_state)
 
+                # In PP, logprobs have been broadcast via
+                # sample_state.host.logprobs_state. Clear the logprobs from the
+                # py_result.diff so they are not sent again in next round.
+                if self.dist.pp_size > 1:
+                    for request in executed_batch.sample_state.requests:
+                        request.py_result.diff.log_probs_list.clear()
+
                 scheduled_requests = executed_batch.scheduled_requests
                 if self.kv_cache_transceiver:
                     finished_ctx_reqs = scheduled_requests.context_requests_last_chunk

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1649,13 +1649,6 @@ class PyExecutor:
             with torch.cuda.nvtx.range("_handle_executed_batch_pp"):
                 self._update_requests(executed_batch.sample_state)
 
-                # In PP, logprobs have been broadcast via
-                # sample_state.host.logprobs_state. Clear the logprobs from the
-                # py_result.diff so they are not sent again in next round.
-                if self.dist.pp_size > 1:
-                    for request in executed_batch.sample_state.requests:
-                        request.py_result.diff.log_probs_list.clear()
-
                 scheduled_requests = executed_batch.scheduled_requests
                 if self.kv_cache_transceiver:
                     finished_ctx_reqs = scheduled_requests.context_requests_last_chunk

--- a/tests/unittest/_torch/sampler/test_logits_logprobs.py
+++ b/tests/unittest/_torch/sampler/test_logits_logprobs.py
@@ -759,3 +759,36 @@ def test_logprobs_match_hf_tp2():
     print(f"Diff: {(trtllm_logprobs - hf_logprobs).abs()}")
 
     torch.testing.assert_close(trtllm_logprobs, hf_logprobs, atol=0.15, rtol=0)
+
+
+@pytest.mark.gpu2
+def test_logprobs_pp2():
+    """Test that logprobs count matches generated token count with PP=2.
+
+    Regression test for https://github.com/NVIDIA/TensorRT-LLM/issues/12444
+    Without the fix, logprobs length = 2N-1 instead of N due to duplication
+    in the PP ring broadcast diff mechanism.
+    """
+    model_path = os.path.join(llm_models_root(), "llama-models-v2", "TinyLlama-1.1B-Chat-v1.0")
+    max_tokens = 16
+    llm = LLM(
+        model=model_path,
+        pipeline_parallel_size=2,
+        max_batch_size=1,
+        max_num_tokens=128,
+        max_seq_len=256,
+    )
+
+    sampling_params = SamplingParams(
+        max_tokens=max_tokens,
+        logprobs=5,
+    )
+
+    output = list(llm.generate(["The future of the AI is"], sampling_params=sampling_params))[0]
+
+    num_tokens = len(output.outputs[0].token_ids)
+    num_logprobs = len(output.outputs[0].logprobs)
+    assert num_logprobs == num_tokens, (
+        f"logprobs length {num_logprobs} != generated tokens {num_tokens} "
+        f"(expected 1:1 ratio, got {num_logprobs / num_tokens:.2f}:1)"
+    )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicated logprobs propagation in pipeline parallel execution mode.

* **Tests**
  * Added test coverage for logprobs generation with pipeline parallel size 2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

fixes #12444 

We will get `AssertionError: logprobs length: 127 != output.length: 64` when using PP and enabling top-K logprobs. See related issue for details.

This is due to logprobs being broadcast twice. First through `sample_state.host.logprobs_state` in current iteration and then through `py_result_diffs` in next iteration.


## Test Coverage

`tests/unittest/_torch/sampler/test_logits_logprobs.py::test_logprobs_pp2`

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
