### PR TITLE
[None][fix] Fix disagg KV cache assertion failures with enable_partial_reuse

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheUtils.h
@@ -69,7 +69,7 @@ public:
         return BlockRange(cacheManager, requestId);
     }
 
-    static BlockRange fromReuseTree(
+    static std::optional<BlockRange> fromReuseTree(
         BaseKVCacheManager& cacheManager, BlockKey const& lastBlockKey, int32_t indexFromEnd)
     {
 
@@ -80,8 +80,12 @@ public:
         auto windowSize = cacheManager.getBlockManager().getWindowSizesMetadata().begin()->first;
         // Find the last block in the reuse tree for the provided full sequence of block keys
         auto lastBlock = cacheManager.findBlocksInReuseTreeByBlockKey(lastBlockKey, windowSize);
-        // TODO: handle the case where the last block is not found
-        TLLM_CHECK_WITH_INFO(lastBlock, "Couldn't find the requested block in the reuse tree");
+        if (!lastBlock)
+        {
+            // Block not found in reuse tree (e.g., duplicate block IDs caused a partial store).
+            // Caller should fall back to fromAllBlockIds.
+            return std::nullopt;
+        }
         int32_t const numBlocksToCollect = indexFromEnd + 1;
 
         std::vector<SizeType32> blockIds;

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -221,7 +221,15 @@ BlockRange getBlockRangeForSending(BaseKVCacheManager* cacheManager, LlmRequest 
     }
 
     TLLM_CHECK_WITH_INFO(lastBlockKey.uniqueTokens.size() > 0, "lastBlockKey must be non-empty when reuse is enabled");
-    return BlockRange::fromReuseTree(*cacheManager, lastBlockKey, indexFromEnd);
+    auto reuseRange = BlockRange::fromReuseTree(*cacheManager, lastBlockKey, indexFromEnd);
+    if (reuseRange.has_value())
+    {
+        return std::move(reuseRange.value());
+    }
+    // Reuse tree lookup failed (e.g., duplicate block IDs in the sequence prevented
+    // full tree insertion). Fall back to sending all blocks.
+    TLLM_LOG_WARNING("fromReuseTree failed for request %lu, falling back to fromAllBlockIds", llmRequest.mRequestId);
+    return BlockRange::fromAllBlockIds(*cacheManager, llmRequest.mRequestId);
 }
 
 BlockRange getBlockRangeForReceiving(BaseKVCacheManager* cacheManager, LlmRequest const& llmRequest,

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -344,13 +344,26 @@ void KVCacheBlock::addNextBlock(BlockKey const& blockKey, BlockPtr block)
     }
     // Find existing child node or create a new one, then wire the block into it.
     auto childNode = mLookupNode->findOrInsertChild(blockKey, mLookupNode);
-    // Only attach if there is no block already stored for this window size (matches old
-    // behaviour: addNextBlock was a no-op when the key already existed in mNextBlocks).
     auto existing = childNode->getValue(mWindowSize);
-    if (!existing.has_value())
+    if (existing.has_value())
     {
-        block->attachToLookupNode(childNode, mWindowSize);
+        auto& existingBlock = existing.value();
+        if (existingBlock.get() == block.get())
+        {
+            // Same block already in the right slot — nothing to do.
+            return;
+        }
+        // The slot is occupied by a different block. Detach it so the new block
+        // can take its place. This keeps getPrevBlock() consistent for callers
+        // that rely on the tree link (e.g., storeBlocks during disagg transfers).
+        // detachFromLookupNode may cascade-prune the now-empty child node from
+        // the tree, so we must re-lookup/create the child afterwards.
+        TLLM_LOG_DEBUG("addNextBlock: evicting existing block %d from slot to insert block %d",
+            existingBlock->getBlockId(), block->getBlockId());
+        existingBlock->detachFromLookupNode();
+        childNode = mLookupNode->findOrInsertChild(blockKey, mLookupNode);
     }
+    block->attachToLookupNode(childNode, mWindowSize);
 }
 
 std::tuple<bool, SizeType32, BlockPtr> KVCacheBlock::findMatchingBlock(
@@ -1662,29 +1675,41 @@ std::pair<SizeType32, std::vector<KVCacheBlock::IdType>> WindowBlockManager::sto
                     "Block id mismatch " + std::to_string(block->getBlockId()) + " != " + std::to_string(bid));
                 needMatch = false; // no matching needed for following blocks
 
-                if (block->getPrevBlock() != nullptr)
+                // Skip if this block is already the current searchRoot (duplicate block ID in
+                // the sequence's block list). Trying to insert a block as its own child would
+                // corrupt the lookup tree by moving it from parent to child position.
+                if (block.get() == searchRoot.get())
                 {
-                    block->getPrevBlock()->removeNextBlock(block->getBlockKey());
+                    TLLM_LOG_DEBUG("%s::storeBlocks - block %d is already searchRoot, skipping duplicate",
+                        mLogPrefix.c_str(), bid);
                 }
-                block->setBlockKey(blockKey, static_cast<SizeType32>(blockKey.uniqueTokens.size()) == mTokensPerBlock);
-                block->setPrevBlockInSeq(searchRoot);
-                searchRoot->addNextBlock(blockKey, block);
-
-                // Sanity check. The list of stored blocks should be connected.
-                TLLM_CHECK(storedBlocks.empty() || block->getPrevBlock() == storedBlocks.back());
-
-                storedBlocks.push_back(block);
-                TLLM_CHECK(block->getPrevBlockInSeq() == nullptr
-                    || block->getPrevBlockInSeq()->getHash() == searchRoot->getHash());
-                auto oldHash = block->getHash();
-                auto newHash = BlockKeyHasher()(blockKey, searchRoot->getHash());
-                if (oldHash != newHash)
+                else
                 {
-                    TLLM_LOG_DEBUG("#%d block hash %zx -> %zx", block->getBlockId(), oldHash, newHash);
-                    block->setHash(newHash);
+                    if (block->getPrevBlock() != nullptr)
+                    {
+                        block->getPrevBlock()->removeNextBlock(block->getBlockKey());
+                    }
+                    block->setBlockKey(
+                        blockKey, static_cast<SizeType32>(blockKey.uniqueTokens.size()) == mTokensPerBlock);
+                    block->setPrevBlockInSeq(searchRoot);
+                    searchRoot->addNextBlock(blockKey, block);
+
+                    // Sanity check. The list of stored blocks should be connected.
+                    TLLM_CHECK(storedBlocks.empty() || block->getPrevBlock() == storedBlocks.back());
+
+                    storedBlocks.push_back(block);
+                    TLLM_CHECK(block->getPrevBlockInSeq() == nullptr
+                        || block->getPrevBlockInSeq()->getHash() == searchRoot->getHash());
+                    auto oldHash = block->getHash();
+                    auto newHash = BlockKeyHasher()(blockKey, searchRoot->getHash());
+                    if (oldHash != newHash)
+                    {
+                        TLLM_LOG_DEBUG("#%d block hash %zx -> %zx", block->getBlockId(), oldHash, newHash);
+                        block->setHash(newHash);
+                    }
+                    searchRoot = block;
+                    numBlocksStoredForReuse++;
                 }
-                searchRoot = block;
-                numBlocksStoredForReuse++;
             }
             if (pinBlocks)
             {

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3529,14 +3529,8 @@ class PyExecutor:
                                     f"Request {request.py_request_id} has no avg_decoded_tokens_per_iter"
                                 )
 
-                # If partial reuse is enabled, and the KV cache manager is not VSWA, and the PP size is 1,
-                # then we need to terminate the request. TODO: Remove this once disagg support from KVCache reuse
-                # path is fixed.
-                if self.enable_partial_reuse_for_disagg and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1:
+                if not request.is_disagg_context_transmission_state:
                     requests_to_terminate.append(request)
-                else:
-                    if not request.is_disagg_context_transmission_state:
-                        requests_to_terminate.append(request)
             else:
                 new_active_requests.append(request)
 


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Fixes three chained assertion failures in disaggregated serving when enable_partial_reuse=True (the default) and requests lack a common prefix.

1. Duplicate block IDs in storeBlocks (kvCacheManager.cpp): The same physical block can appear at multiple positions in a sequence's block list. storeBlocks now skips insertion when the block is already the current searchRoot, preventing self-referential tree corruption.

2. addNextBlock silent no-op (kvCacheManager.cpp): After PR #11919 replaced setPrevBlock() with lookup-node navigation, addNextBlock silently skipped attachment when a slot was occupied. Changed to evict-and-replace: detach the existing block and attach the new one, keeping getPrevBlock() consistent.

3. fromReuseTree fallback (kvCacheUtils.h, cacheFormatter.cpp): When storeBlocks skips a duplicate, the reuse tree is incomplete. Changed fromReuseTree to return std::optional and fall back to fromAllBlockIds in getBlockRangeForSending. Resolves the existing TODO about handling missing blocks.

4. Termination race (py_executor.py): When enable_partial_reuse_for_disagg was True, _handle_responses terminated requests without checking is_disagg_context_transmission_state, racing with the async CacheSender thread. Unified the termination guard to always check transmission state before terminating.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
