### PR TITLE
[TRTLLM-11268][feat] Video temporal compression to Nemotron Nano and RADIO

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -570,42 +570,49 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         """
         is_2d = mm_embed.dim() == 2
         hidden_size = mm_embed.shape[-1]
+        T = self.video_temporal_patch_size
         start_idx, mm_embed_list, num_tokens_per_video = 0, [], []
         for video_size in video_sizes:
             # Fetch mm_embed correctly for the flattened temporal/patches dimension.
             t, p, ih, iw = video_size
+            # When temporal compression is active, T consecutive frames are
+            # grouped into one tubelet; the embedding has num_tubelets temporal
+            # tokens, not the raw num_frames (t).
+            num_tubelets = math.ceil(t / T) if T > 1 else t
             # Compute spatial token count per tile from pixel dimensions.
             wh = int(ih // self.patch_size * self.downsample_ratio) * int(
                 iw // self.patch_size * self.downsample_ratio
             )
 
             if is_2d:
-                total_tokens = t * p * wh
+                total_tokens = num_tubelets * p * wh
                 partial_mm_embed = mm_embed[start_idx : start_idx + total_tokens]
-                partial_mm_embed = partial_mm_embed.reshape(t * p, wh, hidden_size)
+                partial_mm_embed = partial_mm_embed.reshape(num_tubelets * p, wh, hidden_size)
                 start_idx += total_tokens
             else:
-                partial_mm_embed = mm_embed[start_idx : start_idx + t * p]
-                # -> [num_frames * num_patches_per_frame, h*w, hidden_size]
-                start_idx += t * p
+                partial_mm_embed = mm_embed[start_idx : start_idx + num_tubelets * p]
+                # -> [num_tubelets * num_patches_per_frame, h*w, hidden_size]
+                start_idx += num_tubelets * p
 
             # Need to expose temporal dimension for EVS.
-            reshaped_partial_mm_embed = partial_mm_embed.reshape(t, p, wh, hidden_size).reshape(
-                t, p * wh, hidden_size
-            )
-            # -> [num_frames, num_patches_per_frame*h*w, hidden_size]
+            reshaped_partial_mm_embed = partial_mm_embed.reshape(
+                num_tubelets, p, wh, hidden_size
+            ).reshape(num_tubelets, p * wh, hidden_size)
+            # -> [num_tubelets, num_patches_per_frame*h*w, hidden_size]
 
             original_retention_mask = compute_retention_mask(
                 video_embeds=reshaped_partial_mm_embed,
-                video_size=(t, p * ih, iw),
+                video_size=(num_tubelets, p * ih, iw),
                 spatial_merge_size=self.spatial_merge_size,
                 pruning_ratio=self.video_pruning_rate,
                 flatten_output=False,
             ).flatten(start_dim=1)
-            # -> [num_frames, num_patches_per_frame*h*w]
+            # -> [num_tubelets, num_patches_per_frame*h*w]
             num_tokens_per_frame = original_retention_mask.sum(dim=1)
-            retention_mask = original_retention_mask.reshape(t, p, wh).reshape(t * p, wh)
-            # -> [num_frames * num_patches_per_frame, h*w]
+            retention_mask = original_retention_mask.reshape(num_tubelets, p, wh).reshape(
+                num_tubelets * p, wh
+            )
+            # -> [num_tubelets * num_patches_per_frame, h*w]
 
             partial_mm_embed = partial_mm_embed[retention_mask]
             mm_embed_list.append(partial_mm_embed)
@@ -795,14 +802,23 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         self.video_pruning_rate = video_pruning_rate
         self.img_context_token = self.config.img_context_token
         self.video_context_token = self.config.video_context_token
+        self.video_context_token_id = self.config.video_context_token_id
         self.img_start_token = self.config.img_start_token
         self.img_end_token = self.config.img_end_token
-        self.image_start_token_id = self.tokenizer.encode(
+        # Pre-tokenize special tokens for video EVS processing (following vLLM).
+        # These may be multi-token under BPE, so we store the full ID list.
+        self._img_start_token_ids = self.tokenizer.encode(
             self.img_start_token, add_special_tokens=False
-        )[0]
-        self.image_end_token_id = self.tokenizer.encode(
+        )
+        self._img_end_token_ids = self.tokenizer.encode(
             self.img_end_token, add_special_tokens=False
-        )[0]
+        )
+        self._img_context_token_ids = self.tokenizer.encode(
+            self.img_context_token, add_special_tokens=False
+        )
+        # Keep single-ID aliases for backward compat.
+        self.image_start_token_id = self._img_start_token_ids[0]
+        self.image_end_token_id = self._img_end_token_ids[0]
 
         # Detect dynamic resolution from config.
         self.dynamic_tiler = None
@@ -1057,7 +1073,6 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
 
         num_special_tokens_per_frame = 2  # <img> and </img>
         if video_pruning_rate > 0:
-            # TODO(EVS): Verify EVS interaction with temporal compression.
             num_tokens_per_frame = self.get_num_tokens_per_image(
                 image=video[0],
                 max_num_tiles=VIDEO_MAX_NUM_TILES,
@@ -1072,7 +1087,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                 pruning_ratio=video_pruning_rate,
             )
             # Add special tokens for each tubelet.
-            num_total_tokens += num_frames * num_special_tokens_per_frame
+            num_total_tokens += num_tubelets * num_special_tokens_per_frame
         else:
             # No pruning: tokens_per_unit * num_tubelets + special tokens.
             num_total_tokens = num_tubelets * (tokens_per_unit + num_special_tokens_per_frame)
@@ -1263,7 +1278,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                     frame_separators = self._build_tubelet_separators(timestamps, frames_indices, T)
                 else:
                     frame_separators = [
-                        ("\n" if i > 0 else "") + f"Frame {i + 1} sampled at {ts:.2f} seconds: "
+                        f"Frame {i + 1} sampled at {ts:.2f} seconds: "
                         for i, ts in enumerate(timestamps)
                     ]
             else:
@@ -1273,9 +1288,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                         ("\n" if t > 0 else "") + f"Frame {t + 1}: " for t in range(num_tubelets)
                     ]
                 else:
-                    frame_separators = [
-                        ("\n" if i > 0 else "") + f"Frame {i + 1}: " for i in range(num_frames)
-                    ]
+                    frame_separators = [f"Frame {i + 1}: " for i in range(num_frames)]
             frame_separators_lst.append(frame_separators)
 
         return frame_separators_lst
@@ -1313,10 +1326,10 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         split_text_prompt: List[str],
         num_tokens_per_frame_lst: List[List[int] | None],
         frame_separators_lst: List[List[str]],
-    ) -> Tuple[torch.Tensor, Optional[List[torch.Tensor]]]:
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         # Process videos one by one to get correct processed_query.
         processed_query = []
-        evs_query = []
+        evs_token_ids: List[int] = []
         for video_index, (num_tokens_per_frame, frame_separators) in enumerate(
             zip(num_tokens_per_frame_lst, frame_separators_lst)
         ):
@@ -1332,20 +1345,23 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                     self.img_end_token,
                 ]
                 processed_query.extend(frame_prompts)
-            # Video_context_token as placeholder,
-            # it will be replaced with the real image_tokens_per_frames during model forward.
+            # Build EVS token IDs at the token-ID level (following vLLM's
+            # get_video_repl approach) to avoid BPE splitting special tokens.
+            # Each tubelet gets a single video_context_token_id placeholder
+            # that merge_evs_mm_embeds will replace with the actual EVS count.
             if self.video_pruning_rate > 0:
-                evs_query.append(split_text_prompt[video_index])
+                evs_token_ids.extend(
+                    self.tokenizer.encode(split_text_prompt[video_index], add_special_tokens=False)
+                )
                 if self._add_video_prefix:
-                    evs_query.append("This is a video:\n")
+                    evs_token_ids.extend(
+                        self.tokenizer.encode("This is a video:\n", add_special_tokens=False)
+                    )
                 for frame_sep in frame_separators:
-                    frame_prompts = [
-                        frame_sep,
-                        self.img_start_token,
-                        self.video_context_token,
-                        self.img_end_token,
-                    ]
-                    evs_query.extend(frame_prompts)
+                    evs_token_ids.extend(self.tokenizer.encode(frame_sep, add_special_tokens=False))
+                    evs_token_ids.extend(self._img_start_token_ids)
+                    evs_token_ids.append(self.video_context_token_id)
+                    evs_token_ids.extend(self._img_end_token_ids)
         # Append the last part of the text prompt.
         processed_query.append(split_text_prompt[-1])
 
@@ -1361,15 +1377,10 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         input_ids = torch.cat(input_ids_lst, dim=1)
 
         if self.video_pruning_rate > 0:
-            evs_query.append(split_text_prompt[-1])
-            evs_ids = [
-                self.tokenizer.encode(
-                    query,
-                    add_special_tokens=False,
-                    return_tensors="pt",
-                )[0]
-                for query in evs_query
-            ]
+            evs_token_ids.extend(
+                self.tokenizer.encode(split_text_prompt[-1], add_special_tokens=False)
+            )
+            evs_ids = torch.tensor(evs_token_ids, dtype=torch.long)
         else:
             evs_ids = None
 
@@ -1378,9 +1389,8 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
     def _compute_token_numbers_per_video(self, video_size_lst: List[Tuple]) -> List[List[int]]:
         """Compute the number of embedding tokens per tubelet (or per frame when T=1).
 
-        With video_temporal_patch_size > 1, T consecutive frames are grouped
-        into tubelets, so the returned list has `ceil(num_frames / T)` entries
-        instead of `num_frames`.
+        With `video_temporal_patch_size > 1`, T consecutive frames are grouped into tubelets, so the
+        returned list has `ceil(num_frames / T)` entries instead of `num_frames`.
         """
         T = self.video_temporal_patch_size
         num_tokens_per_frame_lst = []
@@ -1391,15 +1401,13 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             img_width = video_size[3]
             num_tubelets = math.ceil(num_frames / T) if T > 1 else num_frames
 
-            # Compute per-frame (or per-tubelet) token count from actual
-            # frame dimensions, not the default self.num_image_token, since
-            # video_target_num_patches may change the frame size.
+            # Compute per-frame (or per-tubelet) token count from actual frame dimensions, not the
+            # default `self.num_image_token`, since video_target_num_patches may change the frame size.
             tokens_per_unit = int(
                 (img_height * img_width // self.patch_size**2) * (self.downsample_ratio**2)
             )
 
             if self.video_pruning_rate > 0:
-                # TODO(EVS): Adjust EVS computation for temporal compression.
                 desired_num_tokens = compute_retained_tokens_count(
                     video_size=(num_tubelets, num_patches_per_frame * img_height, img_width),
                     spatial_merge_size=self.spatial_merge_size,
@@ -1706,31 +1714,44 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
             multimodal_data[modality]["evs_ids"]
             for modality, multimodal_data in zip(modalities, multimodal_data_lst)
         ]
-        # Iterate over batch.
-        context_ids = []
+        # Iterate over batch, replacing video_context_token_id placeholders with
+        # the actual per-tubelet img_context_token counts from EVS.
+        context_parts = []
         for evs_ids, modality, num_tokens_in_video in zip(
             evs_ids_lst, modalities, num_tokens_in_videos
         ):
-            # Special handling for image modality when mixing image and video modalities during inflight-batching.
+            # Image modality: keep input_ids unchanged during inflight-batching.
             if modality == "image":
-                context_ids.append(evs_ids)
+                context_parts.append(evs_ids)
                 continue
 
+            # evs_ids is a flat 1-D tensor built at token-ID level.
+            # Find placeholder positions and replace each with the EVS count.
+            placeholder_mask = evs_ids == self.video_context_token_id
+            placeholder_positions = placeholder_mask.nonzero(as_tuple=True)[0]
             image_idx = 0
-            for evs_id in evs_ids:
-                if len(evs_id) == 1 and evs_id[0] == self.video_context_token_id:
-                    image_mm = torch.full(
-                        (num_tokens_in_video[image_idx],),
+            prev_end = 0
+            for pos in placeholder_positions:
+                pos = pos.item()
+                # Append tokens before this placeholder.
+                if pos > prev_end:
+                    context_parts.append(evs_ids[prev_end:pos])
+                # Replace placeholder with actual img_context_token count.
+                context_parts.append(
+                    torch.full(
+                        (int(num_tokens_in_video[image_idx]),),
                         fill_value=self.img_context_token_id,
-                        dtype=evs_id.dtype,
-                        device=evs_id.device,
+                        dtype=evs_ids.dtype,
+                        device=evs_ids.device,
                     )
-                    context_ids.append(image_mm)
-                    image_idx += 1
-                else:
-                    context_ids.append(evs_id)
+                )
+                image_idx += 1
+                prev_end = pos + 1
+            # Append remaining tokens after the last placeholder.
+            if prev_end < len(evs_ids):
+                context_parts.append(evs_ids[prev_end:])
 
-        context_ids = torch.cat(context_ids, dim=0)
+        context_ids = torch.cat(context_parts, dim=0)
         # -> [num_tokens, ]
 
         # Special handling for inflight-batching.

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -49,6 +49,151 @@ VIDEO_PLACEHOLDER = "<video>"
 AUDIO_PLACEHOLDER = "<so_embedding>"
 
 
+def _compute_aspect_preserving_size(
+    orig_w: int,
+    orig_h: int,
+    target_num_patches: int,
+    patch_size: int,
+    downsample_ratio: float,
+) -> Tuple[int, int]:
+    """Compute target pixel dimensions preserving aspect ratio.
+
+    Mirrors Megatron-LM / vLLM video frame resizing: target area in patch-grid
+    space is *target_num_patches*, distributed according to the source aspect
+    ratio, then snapped to a multiple of the required divisor (2 for pixel-shuffle).
+
+    Returns:
+        (target_w, target_h) in pixels.
+    """
+    aspect_wh = orig_w / max(orig_h, 1)
+    ph = round(math.sqrt(target_num_patches / aspect_wh))
+    pw = round(math.sqrt(target_num_patches * aspect_wh))
+    ph = max(ph, 1)
+    pw = max(pw, 1)
+
+    reduction_factor = int(round(1 / downsample_ratio))
+    required_divisor = reduction_factor
+    if required_divisor > 1:
+        rem_h = ph % required_divisor
+        rem_w = pw % required_divisor
+        ph_up = ph + (required_divisor - rem_h if rem_h else 0)
+        ph_down = ph - rem_h
+        pw_up = pw + (required_divisor - rem_w if rem_w else 0)
+        pw_down = pw - rem_w
+        if ph_up * pw_up <= target_num_patches:
+            ph, pw = ph_up, pw_up
+        else:
+            ph = max(required_divisor, ph_down)
+            pw = max(required_divisor, pw_down)
+
+    return pw * patch_size, ph * patch_size  # (width, height) in pixels
+
+
+def get_video_target_size_and_feature_size(
+    orig_w: int,
+    orig_h: int,
+    target_patches: int,
+    maintain_aspect_ratio: bool,
+    patch_size: int,
+    downsample_ratio: float,
+) -> Tuple[int, int, int]:
+    """Compute target (width, height) and feature_size for video resize.
+
+    Returns:
+        (target_w, target_h, feature_size) where feature_size is the
+        post-pixel-shuffle token count per frame.
+    """
+    if maintain_aspect_ratio:
+        target_w, target_h = _compute_aspect_preserving_size(
+            orig_w=orig_w,
+            orig_h=orig_h,
+            target_num_patches=target_patches,
+            patch_size=patch_size,
+            downsample_ratio=downsample_ratio,
+        )
+    else:
+        reduction_factor = int(round(1 / downsample_ratio))
+        side = int(math.sqrt(target_patches))
+        side = max(reduction_factor, (side // reduction_factor) * reduction_factor)
+        target_w = side * patch_size
+        target_h = side * patch_size
+
+    feature_size = int((target_h // patch_size) * downsample_ratio) * int(
+        (target_w // patch_size) * downsample_ratio
+    )
+    return target_w, target_h, feature_size
+
+
+def video_to_pixel_values(
+    video_frames: List[Union[Image.Image, torch.Tensor]],
+    *,
+    input_size: int,
+    video_target_num_patches: Optional[int] = None,
+    video_maintain_aspect_ratio: bool = False,
+    patch_size: int = 16,
+    downsample_ratio: float = 0.5,
+    norm_mean: Optional[torch.Tensor] = None,
+    norm_std: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Convert video frames (PIL Images or tensors) to a normalized pixel-value tensor.
+
+    Resizes in [0, 255] float range via bicubic interpolation, clamps
+    overshoot to [0, 255], rescales to [0, 1], then applies mean/std
+    normalization.
+
+    Returns:
+        Tensor of shape [num_frames, 3, H, W].
+    """
+    # Build a [N, 3, H, W] float tensor in [0, 255] range.
+    frame_tensors = []
+    for f in video_frames:
+        if isinstance(f, Image.Image):
+            img = f.convert("RGB") if f.mode != "RGB" else f
+            frame_tensors.append(torch.from_numpy(np.array(img)).permute(2, 0, 1).float())
+        elif isinstance(f, torch.Tensor):
+            # Tensor is float [0, 1] from ToTensor(); scale to [0, 255].
+            frame_tensors.append(f * 255.0)
+        else:
+            raise TypeError(f"Unsupported frame type: {type(f)}")
+    video_tensor = torch.stack(frame_tensors)  # [N, 3, H, W] float
+
+    if video_target_num_patches is not None:
+        orig_h, orig_w = video_tensor.shape[2], video_tensor.shape[3]
+        target_w, target_h, _ = get_video_target_size_and_feature_size(
+            orig_w=orig_w,
+            orig_h=orig_h,
+            target_patches=video_target_num_patches,
+            maintain_aspect_ratio=video_maintain_aspect_ratio,
+            patch_size=patch_size,
+            downsample_ratio=downsample_ratio,
+        )
+        if video_tensor.shape[2] != target_h or video_tensor.shape[3] != target_w:
+            video_tensor = torch.nn.functional.interpolate(
+                video_tensor,
+                size=(target_h, target_w),
+                mode="bicubic",
+                align_corners=False,
+                antialias=True,
+            )
+    elif video_tensor.shape[2] != input_size or video_tensor.shape[3] != input_size:
+        video_tensor = torch.nn.functional.interpolate(
+            video_tensor,
+            size=(input_size, input_size),
+            mode="bicubic",
+            align_corners=False,
+            antialias=True,
+        )
+
+    # Clamp bicubic overshoot to valid pixel range and rescale to [0, 1].
+    video_tensor = video_tensor.clamp(0, 255) / 255.0
+
+    # Apply mean/std normalization (matches vLLM's input_conditioner).
+    if norm_mean is not None and norm_std is not None:
+        video_tensor = (video_tensor - norm_mean) / norm_std
+
+    return video_tensor
+
+
 @dataclass
 class DynamicResolutionParams:
     media: Image.Image
@@ -261,6 +406,10 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
             model_config.video_pruning_rate if model_config.video_pruning_rate is not None else 0.0
         )
 
+        # Temporal compression config (for video).
+        vision_config = config.vision_config if hasattr(config, "vision_config") else config
+        self.video_temporal_patch_size = getattr(vision_config, "video_temporal_patch_size", 1)
+
         # Construct the vision projection.
         self.vit_hidden_size = config.vit_hidden_size
         self.vision_projection_hidden_size = config.projector_hidden_size
@@ -332,17 +481,34 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
             x = x.permute(0, 2, 1, 3).contiguous()
         return x
 
-    def extract_feature(self, pixel_values):
-        # Use micro-batch to avoid OOM, especially for long video inputs.
-        micro_batch_size = 128
+    def extract_feature(self, pixel_values, num_frames=None):
+        """Extract vision features, optionally with temporal compression.
+
+        Args:
+            pixel_values: [N, 3, H, W] tensor of frames/images.
+            num_frames: When provided and video_temporal_patch_size > 1,
+                enables temporal compression (tubelet embedding).
+        """
+        # When temporal compression is active, align micro-batch boundaries
+        # to multiples of T so chunk splits don't break tubelets.
+        T = self.video_temporal_patch_size if num_frames is not None else 1
+        micro_batch_size = 128 - (128 % T) if T > 1 else 128
+
         n = pixel_values.shape[0]
+        H_patches = pixel_values.shape[2] // self.patch_size
+        W_patches = pixel_values.shape[3] // self.patch_size
+
         vit_embeds_lst = []
         for i in range(0, n, micro_batch_size):
             micro_batch_pixel_values = pixel_values[i : i + micro_batch_size]
-            vit_embeds = self.vision_model(micro_batch_pixel_values)
+            if num_frames is not None and T > 1:
+                vit_embeds = self.vision_model(
+                    micro_batch_pixel_values, num_frames=micro_batch_pixel_values.shape[0]
+                )
+            else:
+                vit_embeds = self.vision_model(micro_batch_pixel_values)
             # Down-sampling and projection.
-            h = w = int(vit_embeds.shape[1] ** 0.5)
-            vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], h, w, -1)
+            vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], H_patches, W_patches, -1)
             vit_embeds = self.pixel_shuffle(vit_embeds, scale_factor=self.downsample_ratio)
             vit_embeds = vit_embeds.reshape(vit_embeds.shape[0], -1, vit_embeds.shape[-1])
             vit_embeds = self.mlp1(vit_embeds)
@@ -397,16 +563,33 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
     def apply_evs_per_video(
         self, mm_embed: torch.Tensor, video_sizes: List[Tuple]
     ) -> Tuple[torch.Tensor, List[int]]:
-        """Apply EVS to the multimodal embedding for a single video."""
+        """Apply EVS to the multimodal embedding for a single video.
+
+        mm_embed may be 2D [total_tokens, hidden] (mixed aspect ratios) or
+        3D [total_tiles, spatial_tokens, hidden] (uniform aspect ratios).
+        """
+        is_2d = mm_embed.dim() == 2
+        hidden_size = mm_embed.shape[-1]
         start_idx, mm_embed_list, num_tokens_per_video = 0, [], []
         for video_size in video_sizes:
             # Fetch mm_embed correctly for the flattened temporal/patches dimension.
             t, p, ih, iw = video_size
-            partial_mm_embed = mm_embed[start_idx : start_idx + t * p]
-            # -> [num_frames * num_patches_per_frame, h*w, hidden_size]
+            # Compute spatial token count per tile from pixel dimensions.
+            wh = int(ih // self.patch_size * self.downsample_ratio) * int(
+                iw // self.patch_size * self.downsample_ratio
+            )
+
+            if is_2d:
+                total_tokens = t * p * wh
+                partial_mm_embed = mm_embed[start_idx : start_idx + total_tokens]
+                partial_mm_embed = partial_mm_embed.reshape(t * p, wh, hidden_size)
+                start_idx += total_tokens
+            else:
+                partial_mm_embed = mm_embed[start_idx : start_idx + t * p]
+                # -> [num_frames * num_patches_per_frame, h*w, hidden_size]
+                start_idx += t * p
 
             # Need to expose temporal dimension for EVS.
-            _, wh, hidden_size = partial_mm_embed.shape
             reshaped_partial_mm_embed = partial_mm_embed.reshape(t, p, wh, hidden_size).reshape(
                 t, p * wh, hidden_size
             )
@@ -423,9 +606,6 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
             num_tokens_per_frame = original_retention_mask.sum(dim=1)
             retention_mask = original_retention_mask.reshape(t, p, wh).reshape(t * p, wh)
             # -> [num_frames * num_patches_per_frame, h*w]
-
-            # Skip by temporal/patch dimension.
-            start_idx += t * p
 
             partial_mm_embed = partial_mm_embed[retention_mask]
             mm_embed_list.append(partial_mm_embed)
@@ -470,6 +650,39 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
                 num_tokens_in_videos.append(num_tokens_per_frames)
         return mm_embedding_evs, num_tokens_in_videos
 
+    def _extract_video_embeddings_temporal(self, video_data: Dict[str, Any]) -> torch.Tensor:
+        """Extract video embeddings with temporal compression.
+
+        Each video is processed separately through extract_feature with num_frames, which enables
+        the tubelet embedding path in RADIO.
+
+        `pixel_values` may be a single concatenated tensor (all videos share the same frame size)
+        or a list of per-video tensors (mixed aspect ratios).
+        """
+        pixel_values = video_data["pixel_values"]
+        video_size_list = video_data.get("video_size", [])
+        per_video = isinstance(pixel_values, list)
+
+        all_embeds = []
+        frame_offset = 0
+        for idx, video_size in enumerate(video_size_list):
+            num_frames = video_size[0]
+            num_tiles_per_frame = video_size[1]
+            total_tiles = num_frames * num_tiles_per_frame
+            if per_video:
+                video_frames = pixel_values[idx]
+            else:
+                video_frames = pixel_values[frame_offset : frame_offset + total_tiles]
+                frame_offset += total_tiles
+
+            vit_embeds = self.extract_feature(video_frames, num_frames=num_frames)
+            # Flatten to 2D [tokens, hidden] so videos with different spatial
+            # resolutions (different dim-1) can be concatenated.
+            all_embeds.append(vit_embeds.reshape(-1, vit_embeds.shape[-1]))
+
+        # Concatenate all videos' embeddings (2D).
+        return torch.cat(all_embeds, dim=0)
+
     def forward(
         self, multimodal_params: List[MultimodalParams]
     ) -> Tuple[List[torch.Tensor], List[List[int] | None]]:
@@ -491,7 +704,12 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
                 embeds = self.extract_feature_dynamic(pixel_values_flat, image_sizes)
                 # Keep 3D shape for apply_evs, will reshape to 2D after EVS
                 mm_embedding.append(embeds)
-            # This applies to images without dynamic resolution, or videos.
+            elif modality_type == "video" and self.video_temporal_patch_size > 1:
+                # Temporal compression: process each video separately through
+                # extract_feature with num_frames to enable tubelet embedding.
+                embeds = self._extract_video_embeddings_temporal(data)
+                mm_embedding.append(embeds)
+            # This applies to images without dynamic resolution, or videos with T=1.
             else:
                 # Fallback to fixed-tile extraction for this modality.
                 pixel_values = data["pixel_values"]
@@ -606,6 +824,38 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                 norm_std=config.norm_std,
             )
             logger.info("Dynamic resolution enabled for NanoV2VL input processor")
+
+        # Video temporal compression and sizing config.
+        vision_config = getattr(config, "vision_config", config)
+        self.video_temporal_patch_size = getattr(vision_config, "video_temporal_patch_size", 1)
+        self.video_maintain_aspect_ratio = getattr(
+            vision_config, "video_maintain_aspect_ratio", False
+        )
+        # Resolve video target size: video_target_num_patches or video_target_img_size.
+        target_num_patches = getattr(vision_config, "video_target_num_patches", None)
+        target_img_size = getattr(vision_config, "video_target_img_size", None)
+        if target_num_patches is not None and target_img_size is not None:
+            raise ValueError(
+                "Exactly one of video_target_num_patches or "
+                "video_target_img_size must be set, got both"
+            )
+        if target_num_patches is not None:
+            self.video_target_num_patches = target_num_patches
+        elif target_img_size is not None:
+            base_patches = math.ceil(target_img_size / self.patch_size)
+            self.video_target_num_patches = base_patches * base_patches
+        else:
+            self.video_target_num_patches = None
+
+        # The original model used a "This is a video:\n" prefix before frame separators.
+        # Newer models may not. Unfortunately, both map to the same "NemotronH_Nano_VL_V2"
+        # transformers architecture, so the only way to distinguish is via the presence / absence
+        # of certain fields.
+        self._add_video_prefix = self.video_target_num_patches is None
+
+        # Normalization mean/std for video frames (used by video_to_pixel_values).
+        self._video_norm_mean = torch.tensor(config.norm_mean).reshape(3, 1, 1)
+        self._video_norm_std = torch.tensor(config.norm_std).reshape(3, 1, 1)
 
         self._audio_extractor = None
         self._sound_context_token = getattr(config, "sound_context_token", AUDIO_PLACEHOLDER)
@@ -758,6 +1008,34 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         num_image_tokens += 2  # <img> and </img>
         return num_image_tokens
 
+    def _get_video_tokens_per_frame(
+        self, orig_w: Optional[int] = None, orig_h: Optional[int] = None
+    ) -> int:
+        """Token count per video frame (or tubelet).
+
+        This accounts for `video_target_num_patches`, which may change the frame size.
+
+        When `video_maintain_aspect_ratio` is enabled, the result depends on the source frame
+        dimensions, so callers should pass the real `orig_w` and `orig_h`.
+
+        Falls back to `self.image_size` (square) when not provided - correct only for square inputs.
+        """
+        if self.video_target_num_patches is not None:
+            if orig_w is None:
+                orig_w = self.image_size
+            if orig_h is None:
+                orig_h = self.image_size
+            _, _, feature_size = get_video_target_size_and_feature_size(
+                orig_w=orig_w,
+                orig_h=orig_h,
+                target_patches=self.video_target_num_patches,
+                maintain_aspect_ratio=self.video_maintain_aspect_ratio,
+                patch_size=self.patch_size,
+                downsample_ratio=self.downsample_ratio,
+            )
+            return feature_size
+        return self.num_image_token
+
     def get_num_tokens_per_video(
         self,
         *,
@@ -769,35 +1047,35 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         if video_pruning_rate is None:
             video_pruning_rate = self.video_pruning_rate
 
+        T = self.video_temporal_patch_size
         num_frames = len(video)
+        num_tubelets = math.ceil(num_frames / T) if T > 1 else num_frames
+        # Use actual frame dimensions so aspect-ratio-preserving resize is computed correctly
+        # (instead of assuming square frames).
+        frame = video[0]
+        tokens_per_unit = self._get_video_tokens_per_frame(orig_w=frame.width, orig_h=frame.height)
+
+        num_special_tokens_per_frame = 2  # <img> and </img>
         if video_pruning_rate > 0:
+            # TODO(EVS): Verify EVS interaction with temporal compression.
             num_tokens_per_frame = self.get_num_tokens_per_image(
                 image=video[0],
                 max_num_tiles=VIDEO_MAX_NUM_TILES,
                 **kwargs,
             )
-            num_special_tokens_per_frame = 2  # <img> and </img>
             num_image_tokens_per_frame = num_tokens_per_frame - num_special_tokens_per_frame
             blocks = num_image_tokens_per_frame // self.num_image_token
-            video_size = (num_frames, blocks * self.image_size, self.image_size)
+            video_size = (num_tubelets, blocks * self.image_size, self.image_size)
             num_total_tokens = compute_retained_tokens_count(
                 video_size=video_size,
                 spatial_merge_size=self.spatial_merge_size,
                 pruning_ratio=video_pruning_rate,
             )
-            # Add special tokens for each frame.
+            # Add special tokens for each tubelet.
             num_total_tokens += num_frames * num_special_tokens_per_frame
         else:
-            # No pruning - sum tokens for all frames
-            num_total_tokens = sum(
-                self.get_num_tokens_per_image(
-                    image=frame,
-                    video_pruning_rate=None,
-                    max_num_tiles=VIDEO_MAX_NUM_TILES,
-                    **kwargs,
-                )
-                for frame in video
-            )
+            # No pruning: tokens_per_unit * num_tubelets + special tokens.
+            num_total_tokens = num_tubelets * (tokens_per_unit + num_special_tokens_per_frame)
         return num_total_tokens
 
     def _process_images(
@@ -902,55 +1180,133 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
     def _process_videos_frames(
         self, videos: List[List[Image.Image | torch.Tensor]]
     ) -> Dict[str, Any]:
+        """Process video frames using custom video preprocessing.
+
+        Uses video_to_pixel_values for proper resize (optionally
+        aspect-ratio-preserving) and mean/std normalization, matching vLLM.
+        Falls back to the HF image processor when video_target_num_patches
+        is not configured.
+        """
         num_patches_list = []
         pixel_values_list = []
         video_size_list = []
         for video in videos:
             num_frames = len(video)
 
-            # Use VIDEO_MAX_NUM_TILES for video modality to match the training behaviors.
-            orig_max_num_tiles = self.processor.max_num_tiles
-            self.processor.max_num_tiles = VIDEO_MAX_NUM_TILES
-            processed_images = self.processor(images=video, return_tensors="pt").to(self.device)
-            self.processor.max_num_tiles = orig_max_num_tiles
+            if self.video_target_num_patches is not None:
+                # Custom video preprocessing matching vLLM.
+                pixel_values = video_to_pixel_values(
+                    video,
+                    input_size=self.image_size,
+                    video_target_num_patches=self.video_target_num_patches,
+                    video_maintain_aspect_ratio=self.video_maintain_aspect_ratio,
+                    patch_size=self.patch_size,
+                    downsample_ratio=self.downsample_ratio,
+                    norm_mean=self._video_norm_mean,
+                    norm_std=self._video_norm_std,
+                ).to(self.device)
+                t, _, h, w = pixel_values.shape
+                num_patches_list.append(torch.tensor([num_frames]))
+                pixel_values_list.append(pixel_values)
+                video_size_list.append([num_frames, t // num_frames, h, w])
+            else:
+                # Fallback: use HF image processor with VIDEO_MAX_NUM_TILES.
+                orig_max_num_tiles = self.processor.max_num_tiles
+                self.processor.max_num_tiles = VIDEO_MAX_NUM_TILES
+                processed_images = self.processor(images=video, return_tensors="pt").to(self.device)
+                self.processor.max_num_tiles = orig_max_num_tiles
 
-            t, _, h, w = processed_images["pixel_values"].shape
-            num_patches_list.append(processed_images["num_patches"])
-            pixel_values_list.append(processed_images["pixel_values"])
-            video_size_list.append([num_frames, t // num_frames, h, w])
+                t, _, h, w = processed_images["pixel_values"].shape
+                num_patches_list.append(processed_images["num_patches"])
+                pixel_values_list.append(processed_images["pixel_values"])
+                video_size_list.append([num_frames, t // num_frames, h, w])
 
-        processed_images["num_patches"] = torch.tensor(
-            [sum(num_patches) for num_patches in num_patches_list]
-        )
-        processed_images["pixel_values"] = torch.cat(pixel_values_list, dim=0)
-        processed_images["video_size"] = video_size_list
-        return processed_images
+        # When aspect-ratio-preserving resize is active, different videos may have different (H, W).
+        # Keep per-video tensors to avoid a concat mismatch; fall back to a flat tensor when all
+        # shapes agree.
+        shapes = {pv.shape[1:] for pv in pixel_values_list}
+        if len(shapes) == 1:
+            all_pixel_values = torch.cat(pixel_values_list, dim=0)
+        else:
+            # Store as a list - `_extract_video_embeddings_temporal` handles both.
+            all_pixel_values = pixel_values_list
+        result = {
+            "num_patches": torch.tensor(
+                [sum(np) if isinstance(np, torch.Tensor) else np.item() for np in num_patches_list]
+            ),
+            "pixel_values": all_pixel_values,
+            "video_size": video_size_list,
+        }
+
+        return result
 
     def _get_frame_separators(
         self, video_size_lst: List[Tuple], video_metadatas: List[Dict[str, Any] | None]
     ) -> List[List[str]]:
-        # Process videos one by one to get correct processed_query.
+        """Build per-tubelet (or per-frame when T=1) separator strings.
+
+        When video_temporal_patch_size > 1, groups T consecutive frames into a
+        single separator matching vLLM's `get_video_repl` format.
+        """
+        T = self.video_temporal_patch_size
         frame_separators_lst = []
         for metadata, video_size in zip(video_metadatas, video_size_lst):
             num_frames = video_size[0]
 
-            # Get frame separators.
             if metadata is not None:
-                metedata_fps = metadata["fps"]
-                frame_duration_ms = int(1000.0 / metedata_fps)
+                metadata_fps = metadata["fps"]
+                frame_duration_ms = int(1000.0 / metadata_fps)
                 frames_indices = metadata["frames_indices"]
-                timestamps = [
-                    int(frame_index) * frame_duration_ms / 1000.0 for frame_index in frames_indices
-                ]
-                frame_separators = [
-                    f"Frame {i + 1} sampled at {timestamp:.2f} seconds: "
-                    for i, timestamp in enumerate(timestamps)
-                ]
+                timestamps = [int(fi) * frame_duration_ms / 1000.0 for fi in frames_indices]
+
+                if T > 1:
+                    frame_separators = self._build_tubelet_separators(timestamps, frames_indices, T)
+                else:
+                    frame_separators = [
+                        ("\n" if i > 0 else "") + f"Frame {i + 1} sampled at {ts:.2f} seconds: "
+                        for i, ts in enumerate(timestamps)
+                    ]
             else:
-                frame_separators = [f"Frame {i + 1}: " for i in range(num_frames)]
+                if T > 1:
+                    num_tubelets = math.ceil(num_frames / T)
+                    frame_separators = [
+                        ("\n" if t > 0 else "") + f"Frame {t + 1}: " for t in range(num_tubelets)
+                    ]
+                else:
+                    frame_separators = [
+                        ("\n" if i > 0 else "") + f"Frame {i + 1}: " for i in range(num_frames)
+                    ]
             frame_separators_lst.append(frame_separators)
 
         return frame_separators_lst
+
+    @staticmethod
+    def _build_tubelet_separators(
+        timestamps: List[float],
+        frames_indices: List[int],
+        T: int,
+    ) -> List[str]:
+        """Build frame separator strings for tubelets of T frames.
+
+        For T > 1:
+        `"Frame 1 and frame 2 sampled at X.XX and Y.YY seconds: "`
+        """
+        num_frames = len(timestamps)
+        separators = []
+        for group_idx, i in enumerate(range(0, num_frames, T)):
+            group_frames = []
+            for j in range(T):
+                frame_idx = i + j
+                if frame_idx < num_frames:
+                    ts = timestamps[frame_idx]
+                    frame_str = "Frame" if j == 0 else "frame"
+                    group_frames.append(f"{frame_str} {frame_idx + 1} sampled at {ts:.2f} seconds")
+            if group_frames:
+                sep = " and ".join(group_frames) + ": "
+                if group_idx > 0:
+                    sep = "\n" + sep
+                separators.append(sep)
+        return separators
 
     def _process_video_prompts(
         self,
@@ -966,7 +1322,8 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         ):
             # Prepare video and EVS query.
             processed_query.append(split_text_prompt[video_index])
-            processed_query.append("This is a video:\n")
+            if self._add_video_prefix:
+                processed_query.append("This is a video:\n")
             for frame_sep, num_tokens in zip(frame_separators, num_tokens_per_frame):
                 frame_prompts = [
                     frame_sep,
@@ -979,7 +1336,8 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             # it will be replaced with the real image_tokens_per_frames during model forward.
             if self.video_pruning_rate > 0:
                 evs_query.append(split_text_prompt[video_index])
-                evs_query.append("This is a video:\n")
+                if self._add_video_prefix:
+                    evs_query.append("This is a video:\n")
                 for frame_sep in frame_separators:
                     frame_prompts = [
                         frame_sep,
@@ -1018,25 +1376,39 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         return input_ids, evs_ids
 
     def _compute_token_numbers_per_video(self, video_size_lst: List[Tuple]) -> List[List[int]]:
+        """Compute the number of embedding tokens per tubelet (or per frame when T=1).
+
+        With video_temporal_patch_size > 1, T consecutive frames are grouped
+        into tubelets, so the returned list has `ceil(num_frames / T)` entries
+        instead of `num_frames`.
+        """
+        T = self.video_temporal_patch_size
         num_tokens_per_frame_lst = []
         for video_size in video_size_lst:
             num_frames = video_size[0]
             num_patches_per_frame = video_size[1]
             img_height = video_size[2]
             img_width = video_size[3]
+            num_tubelets = math.ceil(num_frames / T) if T > 1 else num_frames
+
+            # Compute per-frame (or per-tubelet) token count from actual
+            # frame dimensions, not the default self.num_image_token, since
+            # video_target_num_patches may change the frame size.
+            tokens_per_unit = int(
+                (img_height * img_width // self.patch_size**2) * (self.downsample_ratio**2)
+            )
 
             if self.video_pruning_rate > 0:
+                # TODO(EVS): Adjust EVS computation for temporal compression.
                 desired_num_tokens = compute_retained_tokens_count(
-                    video_size=(num_frames, num_patches_per_frame * img_height, img_width),
+                    video_size=(num_tubelets, num_patches_per_frame * img_height, img_width),
                     spatial_merge_size=self.spatial_merge_size,
                     pruning_ratio=self.video_pruning_rate,
                 )
-                # It is dummy tokens and will be adjusted in VisionEncoder after applied EVS.
-                # Need to know the length of the full input ids ahead,
-                # to make Mamba-mixer and inflight-batching work.
-                num_tokens_per_frame = [desired_num_tokens] + [0] * (num_frames - 1)
+                # Dummy tokens; adjusted in VisionEncoder after EVS.
+                num_tokens_per_frame = [desired_num_tokens] + [0] * (num_tubelets - 1)
             else:
-                num_tokens_per_frame = [num_patches_per_frame * self.num_image_token] * num_frames
+                num_tokens_per_frame = [num_patches_per_frame * tokens_per_unit] * num_tubelets
 
             num_tokens_per_frame_lst.append(num_tokens_per_frame)
         return num_tokens_per_frame_lst
@@ -1114,7 +1486,10 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             input_ids, evs_ids = self._process_video_prompts(
                 split_text_prompt, num_tokens_per_frame_lst, frame_separators_lst
             )
-            modality_data["pixel_values"] = processed_images["pixel_values"].to(self.dtype)
+            pv = processed_images["pixel_values"]
+            modality_data["pixel_values"] = (
+                [v.to(self.dtype) for v in pv] if isinstance(pv, list) else pv.to(self.dtype)
+            )
             modality_data["num_patches"] = processed_images["num_patches"].sum(dim=0, keepdim=True)
             modality_data["video_size"] = processed_images["video_size"]
             modality_data["evs_ids"] = evs_ids
@@ -1466,6 +1841,7 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
             mm_embedding,
             mm_token_ids=torch.tensor(mm_token_ids_list, dtype=torch.int32),
         )
+
         output_prob = self.llm.forward(
             attn_metadata=attn_metadata,
             input_ids=input_ids,

--- a/tensorrt_llm/_torch/models/modeling_radio.py
+++ b/tensorrt_llm/_torch/models/modeling_radio.py
@@ -114,6 +114,8 @@ class ViTPatchGenerator(nn.Module):
         register_multiple: Optional[int] = None,
         num_registers: Optional[int] = None,
         patch_bias: bool = False,
+        temporal_patch_size: int = 1,
+        separate_video_embedder: bool = True,
     ):
         super().__init__()
 
@@ -133,6 +135,7 @@ class ViTPatchGenerator(nn.Module):
         self.patch_size = patch_size
         self.abs_pos = abs_pos
         self.embed_dim = embed_dim
+        self.temporal_patch_size = temporal_patch_size
         self.num_rows = max_input_dims[0] // patch_size
         self.num_cols = max_input_dims[1] // patch_size
         self.input_dims = tuple(d // patch_size for d in input_dims)
@@ -141,6 +144,20 @@ class ViTPatchGenerator(nn.Module):
 
         self.im_to_patches = Im2Patches(patch_size)
         self.embedder = ViTPatchLinear(patch_size, embed_dim, bias=patch_bias)
+
+        if temporal_patch_size > 1:
+            if not separate_video_embedder:
+                raise NotImplementedError(
+                    "Only separate_video_embedder=True is supported for "
+                    "temporal compression (temporal_patch_size > 1).")
+            self.video_embedder = ViTPatchLinear(
+                patch_size,
+                embed_dim,
+                bias=patch_bias,
+                temporal_patch_size=temporal_patch_size,
+            )
+        self._video_embedder_loaded = False
+
         self.pos_embed = None
         if abs_pos:
             scale = embed_dim**-0.5
@@ -156,7 +173,15 @@ class ViTPatchGenerator(nn.Module):
         self.patch_normalizer = nn.LayerNorm(
             embed_dim) if normalize_patches else nn.Identity()
 
-    def forward(
+    def forward(self,
+                x: torch.Tensor,
+                image_sizes: Optional[List[Tuple[int, int]]] = None,
+                num_frames: Optional[int] = None) -> torch.Tensor:
+        if num_frames is not None and self.temporal_patch_size > 1:
+            return self.forward_video(x)
+        return self.forward_image(x, image_sizes=image_sizes)
+
+    def forward_image(
             self,
             x: torch.Tensor,
             image_sizes: Optional[List[Tuple[int,
@@ -171,6 +196,54 @@ class ViTPatchGenerator(nn.Module):
             patches, pos_enc = self.apply_pos_enc(patches,
                                                   input_size=x.shape[2:])
             patches = self.cls_token(patches)
+        patches = self.patch_normalizer(patches)
+        return patches
+
+    def forward_video(self, x: torch.Tensor) -> torch.Tensor:
+        """Process video frames with temporal compression.
+
+        Groups T consecutive frames into tubelets before embedding.
+
+        Args:
+            x: [num_frames, 3, H, W] tensor of video frames.
+
+        Returns:
+            Embedded patches with temporal compression applied,
+            shape [num_tubelets, seq_per_tubelet, embed_dim].
+        """
+        if not self._video_embedder_loaded:
+            raise ValueError(
+                "Temporal compression (video_temporal_patch_size > 1) requires "
+                "video_embedder weights, but they were never loaded. "
+                "Ensure the checkpoint was trained with temporal compression.")
+        T = self.temporal_patch_size
+        input_size = x.shape[2:]
+
+        patches = self.im_to_patches(x)  # [N, num_patches, 3*P*P]
+        num_frames, num_spatial, feat_dim = patches.shape
+
+        # Pad to a multiple of T by repeating the last frame.
+        num_pad_frames = (-num_frames) % T
+        if num_pad_frames > 0:
+            last_frame_dup = patches[-1:].expand(num_pad_frames, -1, -1)
+            patches = torch.cat([patches, last_frame_dup], dim=0)
+
+        # Group T frames per tubelet: concatenate features across T consecutive
+        # frames for each spatial position (matches Megatron training order).
+        num_frames_padded = patches.shape[0]
+        num_tubelets = num_frames_padded // T
+        patches = rearrange(
+            patches,
+            '(tubelets frames) spatial feat -> tubelets spatial (frames feat)',
+            tubelets=num_tubelets,
+            frames=T,
+            spatial=num_spatial,
+            feat=feat_dim,
+        )
+
+        patches = self.video_embedder(patches)
+        patches, _ = self.apply_pos_enc(patches, input_size=input_size)
+        patches = self.cls_token(patches)
         patches = self.patch_normalizer(patches)
         return patches
 
@@ -288,7 +361,7 @@ class ViTPatchGenerator(nn.Module):
             max_dim = max(input_dims)
             pos_embed = F.interpolate(pos_embed.float(),
                                       size=(max_dim, max_dim),
-                                      align_corners=True,
+                                      align_corners=False,
                                       mode='bilinear').to(pos_embed.dtype)
             pos_embed = window_select(pos_embed)
         else:
@@ -297,7 +370,7 @@ class ViTPatchGenerator(nn.Module):
         if pos_embed.shape[-2:] != input_dims:
             pos_embed = F.interpolate(pos_embed.float(),
                                       size=input_dims,
-                                      align_corners=True,
+                                      align_corners=False,
                                       mode='bilinear').to(pos_embed.dtype)
 
         pos_embed = pos_embed.flatten(2).permute(0, 2, 1)
@@ -338,9 +411,13 @@ class ViTPatchLinear(nn.Linear):
         patch_size: int,
         embed_dim: int,
         bias: bool = False,
+        temporal_patch_size: int = 1,
     ):
-        super().__init__(3 * (patch_size**2), embed_dim, bias=bias)
+        super().__init__(3 * temporal_patch_size * (patch_size**2),
+                         embed_dim,
+                         bias=bias)
         self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
 
 
 class Block(nn.Module):
@@ -629,6 +706,12 @@ class VisionTransformer(nn.Module):
         register_multiple = getattr(special_args, 'register_multiple', None)
         num_registers = getattr(special_args, 'cpe_num_registers', None)
 
+        # Temporal compression config (for video).
+        self.temporal_patch_size = getattr(self.config,
+                                           'video_temporal_patch_size', 1)
+        separate_video_embedder = getattr(self.config,
+                                          'separate_video_embedder', True)
+
         self.patch_generator = ViTPatchGenerator(
             patch_size=patch_size,
             embed_dim=embed_dim,
@@ -640,6 +723,8 @@ class VisionTransformer(nn.Module):
             num_cls_tokens=num_cls_tokens,
             register_multiple=register_multiple,
             num_registers=num_registers,
+            temporal_patch_size=self.temporal_patch_size,
+            separate_video_embedder=separate_video_embedder,
         )
         self.patch_embed = None
         self.cls_token = None
@@ -688,15 +773,32 @@ class VisionTransformer(nn.Module):
         attn_metadata.prepare()
         return attn_metadata
 
-    def forward_features(
-            self,
-            x: torch.Tensor,
-            image_sizes: Optional[List[Tuple[int,
-                                             int]]] = None) -> torch.Tensor:
-        """Forward pass through feature layers (embeddings, transformer blocks, post-transformer norm)."""
-        x = self.patch_generator(x, image_sizes=image_sizes)
+    def forward_features(self,
+                         x: torch.Tensor,
+                         image_sizes: Optional[List[Tuple[int, int]]] = None,
+                         num_frames: Optional[int] = None) -> torch.Tensor:
+        """Forward pass through feature layers (embeddings, transformer blocks, post-transformer norm).
 
-        if image_sizes is not None:
+        Args:
+            x: Input pixel values.
+            image_sizes: Per-image pixel sizes for dynamic resolution.
+            num_frames: Number of video frames. When provided with
+                temporal_patch_size > 1, enables temporal compression.
+        """
+        T = self.temporal_patch_size
+        packed_batch_size = None  # set when we pack tubelets
+
+        x = self.patch_generator(x,
+                                 image_sizes=image_sizes,
+                                 num_frames=num_frames)
+
+        if num_frames is not None and T > 1:
+            packed_batch_size, seq_per_tubelet, hidden_size = x.shape
+            # Pack all tubelets into one sequence for attention.
+            x = x.reshape(1, -1, hidden_size)
+            seq_lengths = [seq_per_tubelet] * packed_batch_size
+            batch_size = packed_batch_size
+        elif image_sizes is not None:
             # Dynamic resolution: each image is a separate "context".
             num_skip = self.patch_generator.num_skip
             seq_lengths = [
@@ -717,7 +819,10 @@ class VisionTransformer(nn.Module):
         for block in self.blocks:
             x = block(x, attn_metadata=attn_metadata)
 
-        if image_sizes is not None:
+        # Reshape back from flattened.
+        if packed_batch_size is not None:
+            x = x.reshape(packed_batch_size, seq_per_tubelet, hidden_size)
+        elif image_sizes is not None:
             x = x.reshape(1, -1, hidden_size)
         else:
             x = x.reshape(batch_size, seq_lengths[0], hidden_size)
@@ -824,12 +929,11 @@ class RADIOVisionModelBase(nn.Module):
         width = max(width, self.min_resolution_step)
         return Resolution(height=height, width=width)
 
-    def forward(
-            self,
-            x: torch.Tensor,
-            feature_fmt: str = 'NLC',
-            image_sizes: Optional[List[Tuple[int,
-                                             int]]] = None) -> torch.Tensor:
+    def forward(self,
+                x: torch.Tensor,
+                feature_fmt: str = 'NLC',
+                image_sizes: Optional[List[Tuple[int, int]]] = None,
+                num_frames: Optional[int] = None) -> torch.Tensor:
         if image_sizes is None:
             res_step = self.min_resolution_step
             if res_step is not None and (x.shape[-2] % res_step != 0
@@ -840,7 +944,9 @@ class RADIOVisionModelBase(nn.Module):
                     f'Input: {x.shape[-2:]}, Nearest: {self.get_nearest_supported_resolution(*x.shape[-2:])}'
                 )
             x = self.input_conditioner(x)
-        y = self.model.forward_features(x, image_sizes=image_sizes)
+        y = self.model.forward_features(x,
+                                        image_sizes=image_sizes,
+                                        num_frames=num_frames)
         ret = self._extract_final(x,
                                   y,
                                   feature_fmt=feature_fmt,
@@ -1012,10 +1118,21 @@ class RADIOVisionModel(PreTrainedModel):
             if not m.startswith('model.blocks.'):
                 raise ValueError(f"Missing key: {m}")
         for u in unexpected_keys:
-            # TODO(TRTLLM-11269): Add support for the conv3d layer.
+            # model.blocks weights are loaded separately below via
+            # _load_weights_impl (to handle qkv splitting).
+            # video_embedder is only unexpected when temporal_patch_size==1
+            # (model doesn't have the submodule).
             if not u.startswith(
                 ('model.blocks.', 'model.patch_generator.video_embedder')):
                 raise ValueError(f"Unexpected key: {u}")
+
+        # Mark video_embedder as loaded only when the submodule exists and its weights were actually
+        # present in the checkpoint (i.e. not reported as unexpected).
+        patch_gen = self.radio_model.model.patch_generator
+        if (getattr(patch_gen, 'video_embedder', None) is not None
+                and 'model.patch_generator.video_embedder.weight'
+                not in unexpected_keys):
+            patch_gen._video_embedder_loaded = True
 
         # Load weights for vision transformer module.
         model_weights = {
@@ -1047,5 +1164,8 @@ class RADIOVisionModel(PreTrainedModel):
 
     def forward(self,
                 x: torch.Tensor,
-                image_sizes: Optional[List[Tuple[int, int]]] = None):
-        return self.radio_model.forward(x, image_sizes=image_sizes)
+                image_sizes: Optional[List[Tuple[int, int]]] = None,
+                num_frames: Optional[int] = None):
+        return self.radio_model.forward(x,
+                                        image_sizes=image_sizes,
+                                        num_frames=num_frames)

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -1,5 +1,7 @@
 """Preprocessing unit tests for modeling_nemotron_nano.py."""
 
+import functools
+import math
 import random
 from types import SimpleNamespace
 from unittest import mock
@@ -15,6 +17,9 @@ from tensorrt_llm._torch.models.modeling_nemotron_nano import (
     DynamicResolutionParams,
     NanoV2VLInputProcessor,
     NanoV2VLVisionEncoder,
+    _compute_aspect_preserving_size,
+    get_video_target_size_and_feature_size,
+    video_to_pixel_values,
 )
 
 
@@ -206,6 +211,15 @@ def _make_nano_processor(*, sound_config, **overrides):
     }
     config.sound_config = sound_config
     config.sound_context_token = AUDIO_PLACEHOLDER
+
+    # Video temporal compression config - must be explicit so `Mock` doesn't auto-create truthy
+    # attributes that trigger the mutual-exclusion guard.
+    config.vision_config.video_temporal_patch_size = overrides.get("video_temporal_patch_size", 1)
+    config.vision_config.video_target_num_patches = overrides.get("video_target_num_patches", None)
+    config.vision_config.video_target_img_size = overrides.get("video_target_img_size", None)
+    config.vision_config.video_maintain_aspect_ratio = overrides.get(
+        "video_maintain_aspect_ratio", False
+    )
 
     with mock.patch(
         "tensorrt_llm._torch.models.modeling_nemotron_nano.transformers"
@@ -470,3 +484,272 @@ class TestAudioInputProcessor:
         proc._audio_extractor = None
         with pytest.raises(ValueError, match="no audio preprocessing"):
             proc._process_audio("test", [np.zeros(100)])
+
+
+class TestComputeAspectPreservingSize:
+    """Tests for `_compute_aspect_preserving_size`."""
+
+    @pytest.mark.parametrize(
+        "orig_w, orig_h, target_num_patches, patch_size, ds, desc",
+        [
+            pytest.param(640, 640, 256, 16, 0.5, "square", id="square"),
+            pytest.param(1280, 720, 256, 16, 0.5, "landscape", id="landscape"),
+            pytest.param(720, 1280, 256, 16, 0.5, "portrait", id="portrait"),
+            pytest.param(100, 1, 64, 16, 0.5, "extreme_landscape", id="extreme_landscape"),
+        ],
+    )
+    def test_dimensions_valid(self, orig_w, orig_h, target_num_patches, patch_size, ds, desc):
+        w, h = _compute_aspect_preserving_size(orig_w, orig_h, target_num_patches, patch_size, ds)
+        # Both positive.
+        assert w > 0 and h > 0
+        reduction_factor = int(round(1 / ds))
+        divisor = reduction_factor * patch_size
+        # Dimensions must be multiples of patch_size.
+        assert w % patch_size == 0, f"{desc}: {w=} not multiple of patch_size."
+        assert h % patch_size == 0, f"{desc}: {h=} not multiple of patch_size."
+        # Dimensions must be multiples of reduction_factor * patch_size (pixel-shuffle).
+        assert w % divisor == 0, f"{desc}: {w=} not multiple of {divisor}."
+        assert h % divisor == 0, f"{desc}: {h=} not multiple of {divisor}."
+
+    def test_square_input_gives_square_output(self):
+        w, h = _compute_aspect_preserving_size(640, 640, 256, 16, 0.5)
+        assert w == h
+
+    def test_landscape_wider_than_tall(self):
+        w, h = _compute_aspect_preserving_size(1280, 720, 256, 16, 0.5)
+        assert w > h
+
+    def test_portrait_taller_than_wide(self):
+        w, h = _compute_aspect_preserving_size(720, 1280, 256, 16, 0.5)
+        assert h > w
+
+    def test_aspect_ratio_approximately_preserved(self):
+        orig_w, orig_h = 1280, 720
+        w, h = _compute_aspect_preserving_size(orig_w, orig_h, 256, 16, 0.5)
+        orig_ratio = orig_w / orig_h
+        result_ratio = w / h
+        # Allow tolerance for grid snapping.
+        assert abs(result_ratio - orig_ratio) / orig_ratio < 0.5
+
+
+class TestGetVideoTargetSizeAndFeatureSize:
+    """Tests for `get_video_target_size_and_feature_size`."""
+
+    def test_square_mode(self):
+        """maintain_aspect_ratio=False should lead to square output."""
+        patch_size = 16
+        w, h, feat = get_video_target_size_and_feature_size(
+            orig_w=1280,
+            orig_h=720,
+            target_patches=256,
+            maintain_aspect_ratio=False,
+            patch_size=patch_size,
+            downsample_ratio=0.5,
+        )
+        assert w == h
+        side_patches = w // patch_size
+        expected_feat = int(side_patches * 0.5) ** 2
+        assert feat == expected_feat
+
+    def test_aspect_preserving_mode(self):
+        """maintain_aspect_ratio=True -> delegates to _compute_aspect_preserving_size."""
+        patch_size = 16
+        w, h, feat = get_video_target_size_and_feature_size(
+            orig_w=1280,
+            orig_h=720,
+            target_patches=256,
+            maintain_aspect_ratio=True,
+            patch_size=patch_size,
+            downsample_ratio=0.5,
+        )
+        # Feature size matches formula.
+        expected_feat = int((h // patch_size) * 0.5) * int((w // patch_size) * 0.5)
+        assert feat == expected_feat
+        # Landscape should be wider.
+        assert w > h
+
+    @pytest.mark.parametrize("maintain", [True, False])
+    def test_feature_size_positive(self, maintain):
+        _, _, feat = get_video_target_size_and_feature_size(
+            orig_w=320,
+            orig_h=240,
+            target_patches=64,
+            maintain_aspect_ratio=maintain,
+            patch_size=16,
+            downsample_ratio=0.5,
+        )
+        assert feat > 0
+
+
+class TestVideoToPixelValues:
+    """Tests for `video_to_pixel_values`."""
+
+    @pytest.mark.parametrize(
+        "image_func",
+        [
+            functools.partial(Image.new, "RGB", (64, 48)),
+            functools.partial(torch.rand, 3, 64, 48),
+        ],
+    )
+    def test_frames(self, image_func):
+        num_frames = 5
+        frames = [image_func() for _ in range(num_frames)]
+        out = video_to_pixel_values(
+            frames,
+            input_size=512,
+            video_target_num_patches=16,
+            patch_size=16,
+            downsample_ratio=0.5,
+        )
+        assert out.ndim == 4
+        assert out.shape[0] == num_frames
+        # 3 channels.
+        assert out.shape[1] == 3
+        # Output H, W should be multiples of patch_size.
+        assert out.shape[2] % 16 == 0
+        assert out.shape[3] % 16 == 0
+
+    def test_normalization_applied(self):
+        """With norm_mean / norm_std, output should not be in [0, 1]."""
+        frames = [Image.new("RGB", (32, 32), color=(128, 128, 128)) for _ in range(2)]
+        norm_mean = torch.tensor([0.5, 0.5, 0.5]).reshape(3, 1, 1)
+        norm_std = torch.tensor([0.5, 0.5, 0.5]).reshape(3, 1, 1)
+        out = video_to_pixel_values(
+            frames,
+            input_size=32,
+            norm_mean=norm_mean,
+            norm_std=norm_std,
+        )
+        # 128/255 ≈ 0.502, after normalization: (0.502 - 0.5) / 0.5 ≈ 0.004
+        # The key check is that normalization was applied (values near 0, not near 0.5).
+        assert out.abs().max() < 0.1
+
+    def test_fallback_resizes_to_input_size(self):
+        frames = [Image.new("RGB", (64, 48)) for _ in range(2)]
+        out = video_to_pixel_values(frames, input_size=128)
+        assert out.shape[2] == 128
+        assert out.shape[3] == 128
+
+
+class TestBuildTubeletSeparators:
+    """Tests for `NanoV2VLInputProcessor._build_tubelet_separators`."""
+
+    def test_4_frames_T2(self):
+        timestamps = [0.0, 0.5, 1.0, 1.5]
+        seps = NanoV2VLInputProcessor._build_tubelet_separators(
+            timestamps=timestamps, frames_indices=[0, 1, 2, 3], T=2
+        )
+        assert len(seps) == 2
+        # First separator has no leading newline.
+        assert not seps[0].startswith("\n")
+        # Second separator has leading newline.
+        assert seps[1].startswith("\n")
+        # Both mention "and" (joining two frames).
+        assert " and " in seps[0]
+        assert " and " in seps[1]
+        # Check frame numbering.
+        assert "Frame 1" in seps[0]
+        assert "frame 2" in seps[0]
+        assert "Frame 3" in seps[1]
+        assert "frame 4" in seps[1]
+
+    def test_5_frames_T2_last_group_has_1(self):
+        timestamps = [0.0, 0.5, 1.0, 1.5, 2.0]
+        seps = NanoV2VLInputProcessor._build_tubelet_separators(
+            timestamps=timestamps, frames_indices=list(range(5)), T=2
+        )
+        # ceil(5/2) = 3 groups.
+        assert len(seps) == 3
+        # Last group has single frame, no "and".
+        assert " and " not in seps[2]
+        assert "Frame 5" in seps[2]
+
+    def test_3_frames_T1(self):
+        timestamps = [0.0, 1.0, 2.0]
+        seps = NanoV2VLInputProcessor._build_tubelet_separators(
+            timestamps=timestamps, frames_indices=[0, 1, 2], T=1
+        )
+        assert len(seps) == 3
+        # T=1 means each separator has a single frame, no "and".
+        for sep in seps:
+            assert " and " not in sep
+
+    def test_separator_ends_with_colon_space(self):
+        timestamps = [0.0, 0.5]
+        seps = NanoV2VLInputProcessor._build_tubelet_separators(
+            timestamps=timestamps, frames_indices=[0, 1], T=2
+        )
+        assert len(seps) > 0
+        for sep in seps:
+            assert sep.rstrip().endswith(":")
+
+
+class TestGetNumTokensPerVideoTemporal:
+    """Test get_num_tokens_per_video with temporal compression."""
+
+    # Use non-square frames to exercise the aspect-ratio-dependent code path
+    # inside _get_video_tokens_per_frame.
+    FRAME_SIZE = (480, 270)  # 16:9 landscape
+
+    def test_temporal_compression_reduces_tokens(self):
+        """With `video_temporal_patch_size=2`, token count should be about half of T=1."""
+        proc_t1 = _make_processor(max_num_patches=256, min_num_patches=4)
+        # Override temporal config for T=1 (default).
+        proc_t1.video_temporal_patch_size = 1
+        proc_t1.video_target_num_patches = 256
+        proc_t1.video_maintain_aspect_ratio = True
+
+        proc_t2 = _make_processor(max_num_patches=256, min_num_patches=4)
+        proc_t2.video_temporal_patch_size = 2
+        proc_t2.video_target_num_patches = 256
+        proc_t2.video_maintain_aspect_ratio = True
+
+        frames = [Image.new("RGB", self.FRAME_SIZE) for _ in range(4)]
+        tokens_t1 = proc_t1.get_num_tokens_per_video(video=frames)
+        tokens_t2 = proc_t2.get_num_tokens_per_video(video=frames)
+
+        # T=2 should have fewer tokens (half the tubelets).
+        assert tokens_t2 < tokens_t1
+        # With 4 frames: T=1 -> 4 tubelets, T=2 -> 2 tubelets.
+        # So tokens_t2 should be roughly half of tokens_t1.
+        assert tokens_t2 == pytest.approx(tokens_t1 / 2, rel=0.1)
+
+    def test_odd_frame_count_rounds_up(self):
+        """5 frames with T=2 -> ceil(5/2)=3 tubelets."""
+        w, h = self.FRAME_SIZE
+        proc = _make_processor(max_num_patches=256, min_num_patches=4)
+        proc.video_temporal_patch_size = 2
+        proc.video_target_num_patches = 256
+        proc.video_maintain_aspect_ratio = True
+
+        frames = [Image.new("RGB", self.FRAME_SIZE) for _ in range(5)]
+        tokens = proc.get_num_tokens_per_video(video=frames)
+
+        # Compute expected: 3 tubelets * (tokens_per_frame + special_tokens).
+        tokens_per_frame = proc._get_video_tokens_per_frame(orig_w=w, orig_h=h)
+        num_special = len(proc.get_mm_special_token_ids())
+        expected = 3 * (tokens_per_frame + num_special)
+        assert tokens == expected
+
+    def test_predicted_vs_actual_token_count(self):
+        w, h = self.FRAME_SIZE
+        proc = _make_processor(max_num_patches=256, min_num_patches=4)
+        proc.video_temporal_patch_size = 2
+        proc.video_target_num_patches = 256
+        proc.video_maintain_aspect_ratio = True
+
+        frames = [Image.new("RGB", self.FRAME_SIZE) for _ in range(8)]
+
+        # Predicted count (used for token budget accounting).
+        predicted = proc.get_num_tokens_per_video(video=frames)
+
+        # Actual count from the preprocessing pipeline.
+        preprocessed = proc._process_videos_frames([frames])
+        video_size_lst = preprocessed["video_size"]
+        actual_tokens_per_frame_lst = proc._compute_token_numbers_per_video(video_size_lst)
+        T = proc.video_temporal_patch_size
+        num_tubelets = math.ceil(len(frames) / T) if T > 1 else len(frames)
+        num_special = len(proc.get_mm_special_token_ids())
+        actual = sum(actual_tokens_per_frame_lst[0]) + num_tubelets * num_special
+
+        assert predicted == actual

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -17,10 +17,12 @@ from tensorrt_llm._torch.models.modeling_nemotron_nano import (
     DynamicResolutionParams,
     NanoV2VLInputProcessor,
     NanoV2VLVisionEncoder,
+    NemotronH_Nano_VL_V2,
     _compute_aspect_preserving_size,
     get_video_target_size_and_feature_size,
     video_to_pixel_values,
 )
+from tensorrt_llm.inputs.multimodal import MultimodalParams
 
 
 def make_tiler(**overrides):
@@ -186,7 +188,7 @@ def _make_nano_processor(*, sound_config, **overrides):
 
     tokenizer = mock.Mock()
     tokenizer.encode = mock.Mock(
-        side_effect=lambda text, **kw: torch.tensor(list(range(len(text))))
+        side_effect=lambda text, **kw: torch.tensor(list(range(len(text)))).unsqueeze(0)
         if kw.get("return_tensors") == "pt"
         else list(range(len(text)))
     )
@@ -197,6 +199,7 @@ def _make_nano_processor(*, sound_config, **overrides):
     config.patch_size = overrides.get("patch_size", 16)
     config.downsample_ratio = overrides.get("downsample_ratio", 0.5)
     config.img_context_token_id = 20
+    config.video_context_token_id = overrides.get("video_context_token_id", 21)
     config.img_context_token = "<image>"
     config.video_context_token = "<video>"
     config.img_start_token = "<img>"
@@ -753,3 +756,165 @@ class TestGetNumTokensPerVideoTemporal:
         actual = sum(actual_tokens_per_frame_lst[0]) + num_tubelets * num_special
 
         assert predicted == actual
+
+
+# Arbitrary token IDs used across the merge_evs tests.
+_IMG_CTX_ID = 20
+_VIDEO_CTX_ID = 21
+_TEXT_TOKEN = 99  # stand-in for any non-special token
+_IMG_START = 50
+_IMG_END = 51
+
+
+def _make_merge_model():
+    """Create a minimal mock with the two token-ID attrs that `merge_evs_mm_embeds` reads."""
+    model = mock.MagicMock(spec=NemotronH_Nano_VL_V2)
+    model.img_context_token_id = _IMG_CTX_ID
+    model.video_context_token_id = _VIDEO_CTX_ID
+    return model
+
+
+def _make_mm_param(modality: str, evs_ids):
+    """Build a MultimodalParams for merge_evs_mm_embeds."""
+    return MultimodalParams(
+        multimodal_data={
+            "modality_type": modality,
+            modality: {"evs_ids": evs_ids},
+        }
+    )
+
+
+class TestMergeEvsMMEmbeds:
+    """Tests for `NemotronH_Nano_VL_V2.merge_evs_mm_embeds`."""
+
+    def test_single_video_two_tubelets(self):
+        """Each video_context_token_id placeholder is replaced with the right count."""
+        model = _make_merge_model()
+        evs_ids = torch.tensor(
+            [
+                _TEXT_TOKEN,
+                _IMG_START,
+                # This first item will be expanded to 5 * image context token ID.
+                _VIDEO_CTX_ID,
+                _IMG_END,
+                _IMG_START,
+                # This first item will be expanded to 3 * image context token ID.
+                _VIDEO_CTX_ID,
+                _IMG_END,
+                _TEXT_TOKEN,
+            ],
+            dtype=torch.long,
+        )
+        param = _make_mm_param("video", evs_ids)
+        num_tokens_in_videos = [torch.tensor([5, 3])]
+        input_ids = torch.zeros(30, dtype=torch.long)
+
+        result = NemotronH_Nano_VL_V2.merge_evs_mm_embeds(
+            model, num_tokens_in_videos, [param], input_ids
+        )
+
+        expected = torch.tensor(
+            [_TEXT_TOKEN, _IMG_START]
+            + [_IMG_CTX_ID] * 5
+            + [_IMG_END, _IMG_START]
+            + [_IMG_CTX_ID] * 3
+            + [_IMG_END, _TEXT_TOKEN],
+            dtype=torch.long,
+        )
+        assert result.shape == input_ids.shape
+        assert (result[: len(expected)] == expected).all()
+
+    def test_mixed_image_video_batch(self):
+        """Image entry passes through; video entry gets placeholders replaced."""
+        model = _make_merge_model()
+        image_evs = torch.tensor([10, 11], dtype=torch.long)
+        video_evs = torch.tensor(
+            [
+                _TEXT_TOKEN,
+                _IMG_START,
+                _VIDEO_CTX_ID,
+                _IMG_END,
+                _IMG_START,
+                _VIDEO_CTX_ID,
+                _IMG_END,
+            ],
+            dtype=torch.long,
+        )
+        params = [
+            _make_mm_param("video", video_evs),
+            _make_mm_param("image", image_evs),
+        ]
+        num_tokens_in_videos = [torch.tensor([4, 2]), image_evs]
+        input_ids = torch.zeros(20, dtype=torch.long)
+
+        result = NemotronH_Nano_VL_V2.merge_evs_mm_embeds(
+            model, num_tokens_in_videos, params, input_ids
+        )
+
+        expected = torch.tensor(
+            # Video: text + <start> img_ctx*4 <end> <start> img_ctx*2 <end>
+            [_TEXT_TOKEN, _IMG_START]
+            + [_IMG_CTX_ID] * 4
+            + [_IMG_END, _IMG_START]
+            + [_IMG_CTX_ID] * 2
+            + [_IMG_END]
+            # Image: passthrough
+            + [10, 11],
+            dtype=torch.long,
+        )
+        assert result.shape == input_ids.shape
+        assert (result[: len(expected)] == expected).all()
+
+    def test_trailing_tokens_preserved(self):
+        """Tokens after the last placeholder are not dropped."""
+        model = _make_merge_model()
+        evs_ids = torch.tensor(
+            [_VIDEO_CTX_ID, _TEXT_TOKEN, _TEXT_TOKEN],
+            dtype=torch.long,
+        )
+        param = _make_mm_param("video", evs_ids)
+        num_tokens_in_videos = [torch.tensor([1])]
+        input_ids = torch.zeros(10, dtype=torch.long)
+
+        result = NemotronH_Nano_VL_V2.merge_evs_mm_embeds(
+            model, num_tokens_in_videos, [param], input_ids
+        )
+
+        expected = torch.tensor(
+            [_IMG_CTX_ID, _TEXT_TOKEN, _TEXT_TOKEN],
+            dtype=torch.long,
+        )
+        assert result.shape == input_ids.shape
+        assert (result[: len(expected)] == expected).all()
+
+
+class TestProcessVideoPromptsEvs:
+    """Verify the EVS token-ID output of _process_video_prompts."""
+
+    def _make_evs_processor(self, num_tubelets_frames=4, T=2):
+        """Create a processor with video_pruning_rate > 0 and temporal compression."""
+        proc = _make_processor(
+            max_num_patches=256,
+            min_num_patches=4,
+            video_target_num_patches=256,
+        )
+        proc.video_pruning_rate = 0.5
+        proc.video_temporal_patch_size = T
+        proc.video_target_num_patches = 256
+        proc._add_video_prefix = False
+        return proc
+
+    @pytest.mark.parametrize("num_seps", [2, 3, 5, 7])
+    def test_placeholder_count_matches_tubelets(self, num_seps):
+        proc = self._make_evs_processor()
+        separators = [f"Frame {i + 1}: " for i in range(num_seps)]
+        num_tokens = [[11] * num_seps]
+
+        _, evs_ids = proc._process_video_prompts(
+            split_text_prompt=["Start ", " end"],
+            num_tokens_per_frame_lst=num_tokens,
+            frame_separators_lst=[separators],
+        )
+
+        placeholder_count = (evs_ids == proc.video_context_token_id).sum().item()
+        assert placeholder_count == num_seps


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added video preprocessing with aspect-ratio preservation for improved frame handling.
  * Introduced temporal compression support for efficient video frame grouping and processing.
  * Extended vision models to support video inputs with configurable temporal and spatial parameters.

* **Tests**
  * Added comprehensive test coverage for video preprocessing utilities and temporal compression workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Implement tubelet-based temporal compression for video inputs, matching the Megatron-LM / vLLM video processing pipeline. T consecutive frames are grouped into tubelets before embedding, reducing the token count by a factor of `video_temporal_patch_size`.

Key additions:
- Aspect-ratio-preserving video frame resize and normalization
- Separate video embedder in RADIO ViT for tubelet projection
- Tubelet-aware token counting, frame separators, and EVS paths
- Fix align_corners=True -> False in position embedding interpolation

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
