### PR TITLE
[TRTLLM-11707][feat] Add CUDA graph support (torch compile compatible) for LTX-2

### DIFF
--- a/examples/visual_gen/visual_gen_ltx2.py
+++ b/examples/visual_gen/visual_gen_ltx2.py
@@ -148,6 +148,11 @@ def parse_args():
         help="Ulysses (sequence) parallel size within each CFG group.",
     )
 
+    # CUDA graph
+    parser.add_argument(
+        "--enable_cudagraph", action="store_true", help="Enable CudaGraph acceleration"
+    )
+
     # torch.compile
     parser.add_argument(
         "--disable_torch_compile", action="store_true", help="Disable TorchCompile acceleration"
@@ -215,6 +220,7 @@ def _build_diffusion_args(args) -> VisualGenArgs:
             "enable_fullgraph": args.enable_fullgraph,
             "enable_autotune": not args.disable_autotune,
         },
+        cuda_graph={"enable_cuda_graph": args.enable_cudagraph},
         pipeline={
             "enable_layerwise_nvtx_marker": args.enable_layerwise_nvtx_marker,
         },

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/rope.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/rope.py
@@ -146,7 +146,6 @@ def _generate_freqs(
         indices_grid = indices_grid[..., 0]
 
     fractional_positions = _get_fractional_positions(indices_grid, max_pos)
-    indices = indices.to(device=fractional_positions.device)
     freqs = (indices * (fractional_positions.unsqueeze(-1) * 2 - 1)).transpose(-1, -2).flatten(2)
     return freqs
 
@@ -190,6 +189,7 @@ def precompute_freqs_cis(
     num_attention_heads: int = 32,
     rope_type: LTXRopeType = LTXRopeType.INTERLEAVED,
     freq_grid_generator: Callable[[float, int, int], torch.Tensor] = _generate_freq_grid_pytorch,
+    freq_grid_cache: dict | None = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Precompute cos/sin RoPE embeddings for the given position indices.
 
@@ -203,6 +203,10 @@ def precompute_freqs_cis(
         num_attention_heads: Number of attention heads (for split mode reshaping).
         rope_type: INTERLEAVED or SPLIT.
         freq_grid_generator: Function to generate the frequency grid.
+        freq_grid_cache: Optional dict for caching GPU copies of frequency grids.
+            When provided, CPU→GPU transfers happen only once (first call) and
+            subsequent calls reuse the cached GPU tensor.  This avoids H2D
+            transfers that would block CUDA graph capture.
 
     Returns:
         Tuple of (cos_freq, sin_freq) tensors.
@@ -211,6 +215,19 @@ def precompute_freqs_cis(
         max_pos = [20, 2048, 2048]
 
     indices = freq_grid_generator(theta, indices_grid.shape[1], dim)
+    # When a cache is provided, move indices to the target device once and
+    # reuse.  The freq_grid_generator returns a CPU tensor (via lru_cache);
+    # repeated H2D transfers would block CUDA graph capture.
+    device = indices_grid.device
+    if freq_grid_cache is not None and indices.device != device:
+        cache_key = (freq_grid_generator, theta, indices_grid.shape[1], dim, device)
+        cached = freq_grid_cache.get(cache_key)
+        if cached is None:
+            cached = indices.to(device=device)
+            freq_grid_cache[cache_key] = cached
+        indices = cached
+    else:
+        indices = indices.to(device=device)
     freqs = _generate_freqs(indices, indices_grid, max_pos, use_middle_indices_grid)
 
     if rope_type == LTXRopeType.SPLIT:

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/transformer_args.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/transformer_args.py
@@ -66,6 +66,7 @@ class TransformerArgsPreprocessor:
         self.double_precision_rope = double_precision_rope
         self.positional_embedding_theta = positional_embedding_theta
         self.rope_type = rope_type
+        self._freq_grid_cache: dict = {}
 
     def _prepare_timestep(
         self,
@@ -121,6 +122,7 @@ class TransformerArgsPreprocessor:
             num_attention_heads=num_attention_heads,
             rope_type=self.rope_type,
             freq_grid_generator=freq_grid_generator,
+            freq_grid_cache=self._freq_grid_cache,
         )
 
     def prepare(self, modality: Modality) -> TransformerArgs:

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: LicenseRef-LTX-2
 
 import copy
+import gc
 import json
 import time
 from pathlib import Path
@@ -13,7 +14,9 @@ import torch
 import torch.distributed as dist
 from transformers import Gemma3ForConditionalGeneration, GemmaTokenizerFast
 
+from tensorrt_llm._torch.utils import make_weak_ref
 from tensorrt_llm._torch.visual_gen.config import PipelineComponent
+from tensorrt_llm._torch.visual_gen.cuda_graph_runner import CUDAGraphRunner, CUDAGraphRunnerConfig
 from tensorrt_llm._torch.visual_gen.output import MediaOutput
 from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
 from tensorrt_llm._torch.visual_gen.pipeline_registry import register_pipeline
@@ -182,6 +185,151 @@ class LTX2TeaCacheExtractor:
             run_transformer_blocks=run_blocks,
             postprocess=postprocess,
         )
+
+
+# ---------------------------------------------------------------------------
+# CUDA graph runner for Modality-based transformer interface
+# ---------------------------------------------------------------------------
+
+
+class _LTX2CUDAGraphRunner(CUDAGraphRunner):
+    """CUDAGraphRunner extended for LTX-2's ``Modality``-based transformer.
+
+    The base runner derives graph keys from flat ``torch.Tensor`` args.
+    LTX-2's transformer takes ``Modality`` dataclasses (bundles of tensors)
+    and optional ``BatchedPerturbationConfig`` objects that affect control flow.
+
+    This subclass overrides key derivation, capture, and replay so that
+    ``Modality`` tensors are included in the graph key, cloned into static
+    buffers at capture time, and copied in-place at replay time.
+    """
+
+    @staticmethod
+    def _perturbation_fingerprint(perturbations):
+        """Return a hashable fingerprint of a ``BatchedPerturbationConfig``."""
+        parts = []
+        for pc in perturbations.perturbations:
+            if pc.perturbations is None:
+                parts.append(None)
+            else:
+                for p in pc.perturbations:
+                    blocks = tuple(p.blocks) if p.blocks is not None else None
+                    parts.append((p.type.value, blocks))
+        return tuple(parts)
+
+    # -- key derivation ------------------------------------------------------
+
+    def _key_parts_for(self, prefix, v):
+        """Yield ``(label, shape_or_tag)`` pairs for a single argument."""
+        if isinstance(v, torch.Tensor):
+            yield (prefix, tuple(v.shape))
+        elif isinstance(v, Modality):
+            yield (f"{prefix}.latent", tuple(v.latent.shape))
+            yield (f"{prefix}.timesteps", tuple(v.timesteps.shape))
+            yield (f"{prefix}.positions", tuple(v.positions.shape))
+            yield (f"{prefix}.context", tuple(v.context.shape))
+            if v.context_mask is not None:
+                yield (f"{prefix}.context_mask", tuple(v.context_mask.shape))
+        elif isinstance(v, BatchedPerturbationConfig):
+            fp = self._perturbation_fingerprint(v)
+            yield (prefix, f"perturbed:{fp}")
+        elif v is None:
+            yield (prefix, None)
+
+    def get_graph_key(self, *args, **kwargs):
+        parts = []
+        for i, arg in enumerate(args):
+            parts.extend(self._key_parts_for(f"a{i}", arg))
+        for k in sorted(kwargs.keys()):
+            parts.extend(self._key_parts_for(k, kwargs[k]))
+        return tuple(parts)
+
+    # -- clone / copy helpers ------------------------------------------------
+
+    @staticmethod
+    def _clone_value(v):
+        if isinstance(v, torch.Tensor):
+            return v.clone()
+        if isinstance(v, Modality):
+            # NOTE: must be kept in sync with Modality dataclass fields.
+            return Modality(
+                latent=v.latent.clone(),
+                timesteps=v.timesteps.clone(),
+                positions=v.positions.clone(),
+                context=v.context.clone(),
+                enabled=v.enabled,
+                context_mask=v.context_mask.clone() if v.context_mask is not None else None,
+            )
+        return v
+
+    @staticmethod
+    def _copy_value(dst, src):
+        """Copy data from *src* into *dst* static buffer in-place."""
+        if isinstance(src, torch.Tensor) and isinstance(dst, torch.Tensor):
+            dst.copy_(src)
+            return dst
+        if isinstance(src, Modality) and isinstance(dst, Modality):
+            dst.latent.copy_(src.latent)
+            dst.timesteps.copy_(src.timesteps)
+            dst.positions.copy_(src.positions)
+            dst.context.copy_(src.context)
+            if src.context_mask is not None and dst.context_mask is not None:
+                dst.context_mask.copy_(src.context_mask)
+            return dst
+        return src
+
+    @staticmethod
+    def _make_output_ref(x):
+        """``make_weak_ref`` variant that tolerates ``None`` in tuples.
+
+        The LTX-2 transformer returns ``(video_vel, audio_vel)`` where
+        either element may be ``None`` for modality-isolated passes.
+        """
+        if x is None:
+            return None
+        if isinstance(x, tuple):
+            return tuple(_LTX2CUDAGraphRunner._make_output_ref(i) for i in x)
+        if isinstance(x, list):
+            return [_LTX2CUDAGraphRunner._make_output_ref(i) for i in x]
+        return make_weak_ref(x)
+
+    # -- capture / replay ----------------------------------------------------
+
+    def capture(self, key, fn, args, kwargs):
+        logger.info(
+            f"Capturing CUDA graph for LTX2 transformer (key hash={hash(key) & 0xFFFF:04x})"
+        )
+
+        static_args = [self._clone_value(arg) for arg in args]
+        static_kwargs = {k: self._clone_value(v) for k, v in kwargs.items()}
+
+        graph = torch.cuda.CUDAGraph()
+        for _ in range(self.WARMUP_STEPS):
+            fn(*static_args, **static_kwargs)
+            torch.cuda.synchronize()
+            gc.collect()
+            torch.cuda.empty_cache()
+
+        with torch.cuda.graph(graph, pool=self._get_pool()):
+            output = fn(*static_args, **static_kwargs)
+
+        self.graphs[key] = graph
+        self.static_inputs[key] = (static_args, static_kwargs)
+        self.graph_outputs[key] = self._make_output_ref(output)
+        self.memory_pool = graph.pool()
+
+        if self._shared_pool is not None and self._shared_pool.handle is None:
+            self._shared_pool.handle = self.memory_pool
+
+    def replay(self, key, args, kwargs):
+        static_args, static_kwargs = self.static_inputs[key]
+        for i, arg in enumerate(args):
+            static_args[i] = self._copy_value(static_args[i], arg)
+        for k, v in kwargs.items():
+            if k in static_kwargs:
+                static_kwargs[k] = self._copy_value(static_kwargs[k], v)
+        self.graphs[key].replay()
+        return self.graph_outputs[key]
 
 
 # ---------------------------------------------------------------------------
@@ -400,6 +548,41 @@ class LTX2Pipeline(BasePipeline):
             model_config=self.model_config,
         )
         self.transformer._transformer_config = vars(cfg)
+
+    # ------------------------------------------------------------------
+    # CUDA graph setup (Modality-aware override)
+    # ------------------------------------------------------------------
+
+    def _setup_cuda_graphs(self):
+        """Wrap the transformer with Modality-aware CUDA graph capture/replay.
+
+        Overrides the base implementation because LTX-2's transformer forward
+        takes ``Modality`` dataclass inputs and optional
+        ``BatchedPerturbationConfig``, neither of which the base
+        ``CUDAGraphRunner`` can handle (it only processes flat tensors).
+
+        Uses ``_LTX2CUDAGraphRunner`` which extends key derivation, cloning,
+        and in-place copy to support these types.
+
+        Compatible with torch.compile: when both are enabled, the CUDA graph
+        runner wraps the compiled transformer.  The graph capture happens
+        during warmup — by that time torch.compile's lazy compilation has
+        already been triggered by the CUDAGraphRunner's internal warmup
+        iterations (WARMUP_STEPS=2), so the captured graph contains the
+        optimized compiled kernels.
+        """
+        if not self.model_config.cuda_graph.enable_cuda_graph:
+            return
+
+        runner = _LTX2CUDAGraphRunner(CUDAGraphRunnerConfig(use_cuda_graph=True))
+        compile_note = (
+            " (with torch.compile)" if self.model_config.torch_compile.enable_torch_compile else ""
+        )
+        logger.info(
+            f"CUDA graph runner: wrapping transformer.forward (Modality-aware){compile_note}"
+        )
+        self.transformer.forward = runner.wrap(self.transformer.forward)
+        self._cuda_graph_runners["transformer"] = runner
 
     # ------------------------------------------------------------------
     # Component loading

--- a/tests/unittest/_torch/visual_gen/test_ltx2_transformer.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_transformer.py
@@ -519,5 +519,131 @@ class TestLTX2QuantExcludeModuleRemapping(unittest.TestCase):
         self.fail("transformer_blocks.0.attn1.qkv_proj not found in model")
 
 
+class TestLTX2CUDAGraphCapture(unittest.TestCase):
+    """Test CUDA graph capture/replay produces identical results to eager forward.
+
+    Uses AudioVideo mode (the most complex path) with video self-attention,
+    audio self-attention, bidirectional AV cross-attention, text cross-attention,
+    and RoPE — all captured in a single monolithic graph.
+    """
+
+    DEVICE = "cuda"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_cuda_graph_audio_video_correctness(self):
+        """Graph capture + replay output must match eager forward bitwise."""
+        from tensorrt_llm._torch.visual_gen.cuda_graph_runner import CUDAGraphRunnerConfig
+        from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.modality import Modality
+        from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import _LTX2CUDAGraphRunner
+        from tensorrt_llm._torch.visual_gen.models.ltx2.transformer_ltx2 import (
+            LTXModel,
+            LTXModelType,
+        )
+
+        torch.manual_seed(42)
+        dtype = torch.bfloat16
+        model_config = _create_model_config()
+
+        model = (
+            LTXModel(
+                model_type=LTXModelType.AudioVideo,
+                model_config=model_config,
+                **AUDIO_VIDEO_CONFIG,
+            )
+            .to(self.DEVICE, dtype=dtype)
+            .eval()
+        )
+        _init_all_weights(model)
+
+        batch = 1
+        v_frames, v_h, v_w = 1, 4, 4
+        v_patches = v_frames * v_h * v_w
+        a_patches = 8
+        in_channels = AUDIO_VIDEO_CONFIG["in_channels"]
+        audio_in_channels = AUDIO_VIDEO_CONFIG["audio_in_channels"]
+        caption_channels = AUDIO_VIDEO_CONFIG["caption_channels"]
+        text_len = 8
+
+        def _make_modalities(timestep_val=0.5):
+            video = Modality(
+                latent=torch.randn(batch, v_patches, in_channels, device=self.DEVICE, dtype=dtype)
+                * 0.02,
+                timesteps=torch.tensor([timestep_val], device=self.DEVICE),
+                positions=_make_video_positions(batch, v_patches, v_frames, v_h, v_w, self.DEVICE),
+                context=torch.randn(
+                    batch, text_len, caption_channels, device=self.DEVICE, dtype=dtype
+                )
+                * 0.02,
+            )
+            audio = Modality(
+                latent=torch.randn(
+                    batch, a_patches, audio_in_channels, device=self.DEVICE, dtype=dtype
+                )
+                * 0.02,
+                timesteps=torch.tensor([timestep_val], device=self.DEVICE),
+                positions=_make_audio_positions(batch, a_patches, self.DEVICE),
+                context=torch.randn(
+                    batch, text_len, caption_channels, device=self.DEVICE, dtype=dtype
+                )
+                * 0.02,
+            )
+            return video, audio
+
+        # 1. Eager forward — baseline
+        torch.manual_seed(100)
+        video_mod, audio_mod = _make_modalities(0.5)
+        with torch.no_grad():
+            eager_v, eager_a = model(video=video_mod, audio=audio_mod)
+        eager_v = eager_v.clone()
+        eager_a = eager_a.clone()
+
+        # 2. Wrap with CUDA graph runner
+        original_forward = model.forward
+        runner = _LTX2CUDAGraphRunner(CUDAGraphRunnerConfig(use_cuda_graph=True))
+        model.forward = runner.wrap(original_forward)
+
+        # 3. First call — triggers capture (same inputs as eager)
+        torch.manual_seed(100)
+        video_mod, audio_mod = _make_modalities(0.5)
+        with torch.no_grad():
+            graph_v1, graph_a1 = model(video=video_mod, audio=audio_mod)
+
+        self.assertTrue(
+            torch.equal(eager_v, graph_v1),
+            f"Capture video output differs from eager. Max diff: {(eager_v - graph_v1).abs().max():.6e}",
+        )
+        self.assertTrue(
+            torch.equal(eager_a, graph_a1),
+            f"Capture audio output differs from eager. Max diff: {(eager_a - graph_a1).abs().max():.6e}",
+        )
+
+        # 4. Second call with different timestep — replay
+        torch.manual_seed(200)
+        video_mod2, audio_mod2 = _make_modalities(0.3)
+
+        # Eager baseline for new inputs
+        model.forward = original_forward
+        with torch.no_grad():
+            eager_v2, eager_a2 = model(video=video_mod2, audio=audio_mod2)
+        eager_v2 = eager_v2.clone()
+        eager_a2 = eager_a2.clone()
+
+        # Graph replay for new inputs
+        model.forward = runner.wrap(original_forward)
+        torch.manual_seed(200)
+        video_mod2, audio_mod2 = _make_modalities(0.3)
+        with torch.no_grad():
+            graph_v2, graph_a2 = model(video=video_mod2, audio=audio_mod2)
+
+        self.assertTrue(
+            torch.equal(eager_v2, graph_v2),
+            f"Replay video output differs from eager. Max diff: {(eager_v2 - graph_v2).abs().max():.6e}",
+        )
+        self.assertTrue(
+            torch.equal(eager_a2, graph_a2),
+            f"Replay audio output differs from eager. Max diff: {(eager_a2 - graph_a2).abs().max():.6e}",
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
@coderabbitai summary

## Description

Add CUDA graph support for the LTX-2 diffusion transformer to reduce CPU dispatch overhead and eliminate inter-rank synchronization drift in multi-GPU Ulysses sequence parallelism.

**Related PR:** #12603 (alternative LTX-2 CUDA graph implementation)

### Problem

In 8-GPU FP4 inference with Ulysses parallelism, each GPU processes 1/8 of the sequence. The resulting small kernels (~24us) are shorter than CPU dispatch interval (~35us), making kern/gap < 1. This exposes CPU jitter (~2us/launch) which accumulates into ~10-20ms rank drift per denoising step, degrading NCCL AllGather latency from 133us to 310us (2.3x).

### Solution

Monolithic CUDA graph capture of the full `LTXModel.forward()`, including NCCL all-to-all collectives. This eliminates all per-kernel CPU dispatch gaps, reducing rank drift from ~10-20ms to ~0.02ms per step.

### Key Changes

**`pipeline_ltx2.py`** — `_LTX2CUDAGraphRunner` subclass of `CUDAGraphRunner`:
- Handles `Modality` dataclass arguments (key derivation from nested tensor shapes, static buffer clone/copy)
- `BatchedPerturbationConfig` fingerprinting ensures different STG configurations get separate graph captures
- None-tolerant output refs for modality-isolated passes `(video_vel, None)` or `(None, audio_vel)`
- Overrides `_setup_cuda_graphs()` to remove the torch.compile mutual exclusion — both work together

**`rope.py`** + **`transformer_args.py`** — GPU-side frequency grid cache:
- `_generate_freq_grid_np/pytorch()` returns CPU tensors via `lru_cache`
- Previously copied CPU→GPU every forward call (H2D transfer blocks graph capture)
- Added `freq_grid_cache` parameter to `precompute_freqs_cis()`: first call does H2D and caches the GPU tensor; subsequent calls (including inside `torch.cuda.graph()`) reuse the cached tensor
- Cache dict is owned by `TransformerArgsPreprocessor` instance (lifecycle tied to pipeline, not global)

**`visual_gen_ltx2.py`** — CLI support:
- Added `--enable_cudagraph` argument for the example script

**`test_ltx2_transformer.py`** — CUDA graph correctness test:
- `TestLTX2CUDAGraphCapture`: verifies graph capture + replay produces bitwise-identical output to eager forward in AudioVideo mode (the most complex path with video/audio self-attention, bidirectional AV cross-attention, text cross-attention, and RoPE)

### How to Enable

```yaml
# In YAML config:
cuda_graph:
  enable_cuda_graph: true

# Works with or without torch.compile:
torch_compile:
  enable_torch_compile: true   # optional, compatible
```

Or via CLI: `python examples/visual_gen/visual_gen_ltx2.py --enable_cudagraph ...`

### torch.compile Compatibility

The previous implementation had torch.compile and CUDA graphs as mutually exclusive. This PR removes that restriction:
- `torch.compile` operates at the **block level** (each of 48 transformer blocks compiled individually)
- CUDA graph operates at the **transformer.forward level** (captures the entire forward including compiled blocks)
- Graph capture happens during warmup, after torch.compile's lazy compilation is triggered by the CUDAGraphRunner's internal warmup iterations (WARMUP_STEPS=2), so the captured graph contains optimized compiled kernels

### Performance Results

**8-GPU B200 FP4, 768x1280x121 frames, Ulysses=8:**

Per-step synced GPU time (with `torch.cuda.synchronize()`, steady-state step 20-40 of 40-step run):

| Config | Per-step | Improvement |
|--------|----------|-------------|
| compile, no graph | 204.2 ms | baseline |
| **compile + graph** | **200.2 ms** | **-4.1ms (-2.0%)** |

Rank drift (from nsys analysis):

| Config | Rank spread per step |
|--------|---------------------|
| No graph | ~10-20ms |
| **CUDA graph** | **~0.02ms** |

The 4.1ms/step improvement comes from eliminating straggler CPU bubble and NCCL wait time. All 21 measured steady-state steps consistently showed improvement (-1.0 to -6.0ms).

### Tests

- `TestLTX2CUDAGraphCapture::test_cuda_graph_audio_video_correctness` — bitwise correctness for both capture and replay paths (AudioVideo mode)
- All existing 12 tests in `test_ltx2_transformer.py` pass (no regression)

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
