### PR TITLE
[https://nvbugs/6032056][fix] Clamp block indices to prevent OOB in DSA with MTP

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -80,10 +80,12 @@ def _compute_slot_mappings(
     block_indices_in_seq = global_positions // tokens_per_block
     pos_in_blocks = global_positions % tokens_per_block
 
-    # on_update_kv_lens() calls this during CUDA graph capture;
-    # .all()/.item() would trigger host-device sync and invalidate capture.
-    if not block_indices_in_seq.is_cuda:
-        max_blocks = block_offsets.shape[1]
+    max_blocks = block_offsets.shape[1]
+    if block_indices_in_seq.is_cuda:
+        # Clamp to prevent OOB from stale token-to-seq mappings during
+        # CUDA graph capture/replay with MTP + DSA.
+        block_indices_in_seq = block_indices_in_seq.clamp(0, max_blocks - 1)
+    else:
         assert (block_indices_in_seq < max_blocks).all(), \
             f"Block index out of bounds: max={max_blocks}, got indices up to {block_indices_in_seq.max().item()}"
 


### PR DESCRIPTION
## Summary
- Fix out-of-bounds block index access in `_compute_slot_mappings` when using DSA (Dense Sparse Attention) with MTP (Multi-Token Prediction) during CUDA graph capture/replay.
- Stale token-to-sequence mappings during CUDA graph padding can produce block indices that exceed `block_offsets.shape[1]`, causing illegal memory access. This fix clamps the indices on GPU to stay within bounds.

## Changes
- `tensorrt_llm/_torch/attention_backend/sparse/dsa.py`: Move `max_blocks` computation before the branch. On CUDA tensors, clamp `block_indices_in_seq` to `[0, max_blocks-1]` instead of skipping the check entirely. CPU path retains the assertion.

## Test plan
- [x] Run MTP + DSA throughput benchmark with GLM-5-NVFP4 on 4 GPUs (TP=4, EP=4)
- [x] Verify no OOB errors during CUDA graph capture/replay
- [x] CI pre-merge tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved sparse attention operation handling on CUDA devices to prevent out-of-bounds errors during graph execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->