### PR TITLE
[None][fix] Fix KV cache reuse crashes

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2335,6 +2335,8 @@ SizeType32 KVCacheManager::getRemainingBlocksToCompletion(LlmRequest const& req,
     // comment in getNeededBlocksOneStep for the full rationale — free reusable blocks must
     // not be subtracted because they are already counted in the eviction policy's free count.
     SizeType32 numReusableContextBlocks = 0;
+    SizeType32 numReusableBlocksAllocated = 0;
+    SizeType32 numReusableBlocksAll = 0;
     if (mEnableBlockReuse && !mBlockManager.isVariableWindow() && req.isContextInitState() && req.isFirstContextChunk()
         && numAllocBlocksPerBeam == 0)
     {
@@ -2342,18 +2344,13 @@ SizeType32 KVCacheManager::getRemainingBlocksToCompletion(LlmRequest const& req,
         // Block budget: only subtract blocks that are already allocated (have active refs).
         // Free cached blocks are already counted in the eviction policy's free pool and
         // must not be double-counted against the capacity estimate.
-        auto const numReusableBlocksAllocated = countReusableBlocks(uniqueTokens, req, /*onlyAllocated=*/true);
+        numReusableBlocksAllocated = countReusableBlocks(uniqueTokens, req, /*onlyAllocated=*/true);
         numReusableContextBlocks = std::min(numReusableBlocksAllocated, numContextBlocks);
-        // Token budget: count all reusable blocks (free or allocated). Cached tokens need
-        // not be recomputed regardless of whether their blocks currently have active refs.
-        auto const numReusableBlocksAll = countReusableBlocks(uniqueTokens, req, /*onlyAllocated=*/false);
-        req.setEstimatedReusableTokens(std::min(numReusableBlocksAll, numContextBlocks) * getTokensPerBlock());
-        TLLM_LOG_DEBUG(
-            "getRemainingBlocksToCompletion: request ID %lu, numContextBlocks=%d, "
-            "numReusableBlocksAllocated=%d, numReusableBlocksAll=%d, "
-            "numReusableContextBlocks=%d, numGenBlocksPerBeam=%d",
-            req.mRequestId, numContextBlocks, numReusableBlocksAllocated, numReusableBlocksAll,
-            numReusableContextBlocks, numGenBlocksPerBeam);
+        // Token budget must remain conservative with respect to what addSequence can
+        // realize later. Free reusable blocks are not reserved across scheduling, so
+        // only already-allocated reusable blocks are safe to credit here.
+        numReusableBlocksAll = countReusableBlocks(uniqueTokens, req, /*onlyAllocated=*/false);
+        req.setEstimatedReusableTokens(numReusableContextBlocks * getTokensPerBlock());
     }
 
     // In case of sliding window attention, a new block is allocated when the
@@ -2372,14 +2369,31 @@ SizeType32 KVCacheManager::getRemainingBlocksToCompletion(LlmRequest const& req,
     // Adjust for reusable context blocks (only allocated ones)
     SizeType32 const effectiveContextBlocks = numContextBlocks - numReusableContextBlocks;
 
+    SizeType32 remainingBlocksToCompletion = 0;
     if (numAllocBlocksPerBeam < effectiveContextBlocks) // Still haven't allocated all context blocks
     {
-        return effectiveContextBlocks - numAllocBlocksPerBeam
+        remainingBlocksToCompletion = effectiveContextBlocks - numAllocBlocksPerBeam
             + (numGenBlocksPerBeam + numExtraBlocksPerBeam) * req.mSamplingConfig.beamWidth;
     }
+    else
+    {
+        SizeType32 const effectiveTotalBlocks = numTotalBlocksPerBeam - numReusableContextBlocks;
+        remainingBlocksToCompletion
+            = (effectiveTotalBlocks - numAllocBlocksPerBeam + numExtraBlocksPerBeam) * req.mSamplingConfig.beamWidth;
+    }
 
-    SizeType32 const effectiveTotalBlocks = numTotalBlocksPerBeam - numReusableContextBlocks;
-    return (effectiveTotalBlocks - numAllocBlocksPerBeam + numExtraBlocksPerBeam) * req.mSamplingConfig.beamWidth;
+    TLLM_LOG_DEBUG(
+        "getRemainingBlocksToCompletion: request ID %lu, windowSize=%d, promptLen=%d, "
+        "contextCurrentPosition=%d, estimatedReusableTokens=%d, numContextBlocks=%d, "
+        "numReusableBlocksAllocated=%d, numReusableBlocksAll=%d, numReusableContextBlocks=%d, "
+        "numAllocBlocksPerBeam=%d, effectiveContextBlocks=%d, numGenBlocksPerBeam=%d, "
+        "numExtraBlocksPerBeam=%d, remainingBlocksToCompletion=%d",
+        req.mRequestId, windowSize, req.mPromptLen, req.getContextCurrentPosition(), req.getEstimatedReusableTokens(),
+        numContextBlocks, numReusableBlocksAllocated, numReusableBlocksAll, numReusableContextBlocks,
+        numAllocBlocksPerBeam, effectiveContextBlocks, numGenBlocksPerBeam, numExtraBlocksPerBeam,
+        remainingBlocksToCompletion);
+
+    return remainingBlocksToCompletion;
 }
 
 void BlockManager::updateSequenceCacheBlockOffsets(GenerationRequest& sequence, SizeType32 windowSize)

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -5823,8 +5823,9 @@ TEST(KVCacheManagerReuseAccountingTest, ReuseAwareBlockEstimatesStayConsistentAf
     auto const remainingBeforeAdd = kvCacheManager->getRemainingBlocksToCompletion(req1, onlyWindowSize);
     EXPECT_EQ(remainingBeforeAdd, numContextBlocks + numGenBlocks);
 
-    // Verify estimatedReusableTokens is still set after getRemainingBlocksToCompletion
-    EXPECT_EQ(req1.getEstimatedReusableTokens(), expectedReusableBlocks * tokensPerBlock);
+    // Free reusable blocks are not reserved by getRemainingBlocksToCompletion, so
+    // estimatedReusableTokens must stay conservative at 0.
+    EXPECT_EQ(req1.getEstimatedReusableTokens(), 0);
 
     // After addSequence, context blocks are allocated (reuse already applied during allocation)
     // Only generation blocks remain to be allocated
@@ -6010,11 +6011,9 @@ TEST(KVCacheManagerReuseAccountingTest, GetRemainingBlocksToCompletionWithPartia
     auto const numGenBlocks = maxNewTokens / tokensPerBlock;     // 3 blocks
     EXPECT_EQ(remaining, numContextBlocks + numGenBlocks);       // 5 context + 3 generation = 8
 
-    // storeContextBlocks stores (promptLength - 1) / tokensPerBlock = 4 full blocks.
-    // getRemainingBlocksToCompletion counts ALL reusable blocks (free or allocated) for the
-    // TOKEN budget, so estimatedReusableTokens = min(4, 5) * tokensPerBlock = 64.
-    auto const numStoredBlocks = (promptLength - 1) / tokensPerBlock; // 4
-    EXPECT_EQ(req1.getEstimatedReusableTokens(), std::min(numStoredBlocks, numContextBlocks) * tokensPerBlock);
+    // Free reusable blocks are visible in the radix tree but are not reserved by
+    // getRemainingBlocksToCompletion, so estimatedReusableTokens must stay 0.
+    EXPECT_EQ(req1.getEstimatedReusableTokens(), 0);
 }
 
 TEST(KVCacheManagerReuseAccountingTest, GetNeededBlocksOneStepWithFullReuse)

--- a/cpp/tests/unit_tests/batch_manager/microBatchSchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/microBatchSchedulerTest.cpp
@@ -1466,6 +1466,58 @@ TEST_F(CombinedSchedulerTest, NoReuseMicroBatchUnchanged)
     EXPECT_EQ(gen.size(), 0u);
 }
 
+TEST_F(CombinedSchedulerTest, GuaranteedNoEvictDoesNotCreditFreeReusableBlocks)
+{
+    // In GUARANTEED_NO_EVICT, free reusable blocks are not reserved across
+    // scheduling to addSequence. The token estimate must therefore stay
+    // conservative and avoid crediting those free blocks.
+    constexpr SizeType32 tokensPerBlock = 10;
+    constexpr SizeType32 kvCacheMaxNumTokens = 100;
+    constexpr SizeType32 kvCacheMaxNumTokensPerSeq = 50;
+    constexpr SizeType32 maxNumRequests = 4;
+    constexpr SizeType32 chunkUnitSize = 5;
+    constexpr SizeType32 maxNumTokensBudget = 15;
+    constexpr SizeType32 maxBatchSize = 4;
+
+    auto kvCacheManager = createKvCacheManager(
+        maxNumRequests, tokensPerBlock, kvCacheMaxNumTokens, kvCacheMaxNumTokensPerSeq, /*enableReuse=*/true);
+
+    auto microBatchScheduler = MicroBatchScheduler(
+        ContextChunkingConfig{ContextChunkingPolicy::kFIRST_COME_FIRST_SERVED, chunkUnitSize}, std::nullopt);
+
+    constexpr int32_t promptLen = 30;
+    constexpr int32_t maxNewTokens = 5;
+    auto inputTokens = std::make_shared<std::vector<int32_t>>(promptLen);
+    std::iota(inputTokens->begin(), inputTokens->end(), 0);
+
+    auto req0 = createRequestWithTokens(inputTokens, maxNewTokens, 0);
+    auto req1 = createRequestWithTokens(inputTokens, maxNewTokens, 1);
+
+    // Populate the reuse tree, then release the sequence so matching blocks are
+    // free rather than allocated.
+    kvCacheManager->addSequence(req0->mRequestId, promptLen, /*beamWidth=*/1, req0);
+    req0->moveToNextContextChunk();
+    kvCacheManager->storeContextBlocks(*req0);
+    kvCacheManager->removeSequence(req0->mRequestId, req0);
+
+    auto const onlyWindowSize = kvCacheMaxNumTokensPerSeq;
+    auto const remaining = kvCacheManager->getRemainingBlocksToCompletion(*req1, onlyWindowSize);
+    EXPECT_EQ(remaining, 4) << "3 context blocks + 1 generation block should still be reserved";
+    EXPECT_EQ(req1->getEstimatedReusableTokens(), 0)
+        << "Free reusable blocks must not be credited in GUARANTEED_NO_EVICT token budgeting";
+
+    RequestVector microBatchActive;
+    microBatchActive.push_back(req1);
+
+    ReqIdsSet inflightReqIds;
+    auto [ctx, gen] = microBatchScheduler(microBatchActive, inflightReqIds, maxBatchSize, maxNumTokensBudget);
+
+    ASSERT_EQ(ctx.size(), 1u);
+    EXPECT_EQ(gen.size(), 0u);
+    EXPECT_EQ(ctx.at(0)->getContextChunkSize(), 15)
+        << "Without reserved reusable-token credit, the first context chunk must be bounded by the raw token budget";
+}
+
 class ContextChunkingTest : public MicroBatchSchedulerTest
 {
 protected:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined KV cache block reuse accounting to prevent overcounting of available resources during request processing.

* **Tests**
  * Updated test assertions to reflect corrected block reuse behavior and added new test case validating resource allocation under constrained budgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

A recent MR seems to introduce a regression where we can exceed max_num_tokens during prefill with lots of cache reuse, causing this error. 

```
[04/01/2026-19:23:18] [TRT-LLM] [E] Traceback (most recent call last):
  File "/code/tensorrt_llm/tensorrt_llm/serve/openai_server.py", line 1186, in completion_generator
    async for output in promise:
  File "/code/tensorrt_llm/tensorrt_llm/executor/result.py", line 876, in __anext__
    await self._aresult_step()
  File "/code/tensorrt_llm/tensorrt_llm/executor/result.py", line 831, in _aresult_step
    self._handle_response(response)
  File "/code/tensorrt_llm/tensorrt_llm/executor/result.py", line 697, in _handle_response
    GenerationResultBase._handle_response(self, response)
  File "/code/tensorrt_llm/tensorrt_llm/llmapi/utils.py", line 56, in wrapper
    raise e
  File "/code/tensorrt_llm/tensorrt_llm/llmapi/utils.py", line 52, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/code/tensorrt_llm/tensorrt_llm/executor/result.py", line 544, in _handle_response
    handler(response.error_msg)
  File "/code/tensorrt_llm/tensorrt_llm/executor/executor.py", line 287, in _handle_background_error
    raise error
tensorrt_llm.executor.utils.RequestError: total_num_tokens (13985) should be less than or equal to max_num_tokens (8192)
```

Issue

In the legacy GUARANTEED_NO_EVICT path, first-chunk scheduling could over-credit KV-cache reuse by counting free reusable blocks in estimatedReusableTokens. Those blocks are visible in the radix tree, but they are not reserved between scheduling and addSequence(), so the estimate could be larger than the reusable prefix actually realized at execution time. In practice, this let chunked prefill admit a request whose scheduled first context chunk looked under max_num_tokens, but later materialized as an oversized compute pass and failed with total_num_tokens > max_num_tokens.

Fix

Make the scheduler’s reuse estimate conservative. estimatedReusableTokens is now derived only from already-allocated reusable blocks, not from free cached matches. This keeps first-chunk token budgeting aligned with what addSequence() can reliably realize, so chunked prefill will split large prompts instead of admitting an oversized first context chunk. Existing reuse-accounting tests were updated accordingly, and a regression test was added to cover the GUARANTEED_NO_EVICT + chunked-prefill case.


<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
