### PR TITLE
[None][fix] Fix mypy errors in sampling_utils and sampler breaking CI

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -289,8 +289,8 @@ class SampleStateWithMMResult(SampleState[SampleStateTensors, SampleStateTensors
     data: MultimodalResult
 
 
-@dataclass(kw_only=True, frozen=True, slots=True)
-class RequestGroupKey(Generic[GenericStrategyKeyType]):  # type: ignore[misc]
+@dataclass(kw_only=True, frozen=True)
+class RequestGroupKey(Generic[GenericStrategyKeyType]):
     strategy_key: GenericStrategyKeyType
     needs_probs: bool
 

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -477,52 +477,64 @@ def sample(
     return_probs: bool = True,
 ) -> tuple[torch.Tensor, torch.Tensor | None, float | None]:
     softmax: torch.Tensor | None
-    # 'cast' needed b/c of https://github.com/python/mypy/issues/19081
-    match strategy:
-        case ("top_k", top_k, temperature):
-            tokens, softmax = top_k_sampling_batch(
-                logits,
-                top_k=cast(int, top_k),
-                temperature=cast(float, temperature),
-                generator=generator,
-            )
-        case ("top_p", top_p, temperature):
-            tokens, softmax = top_p_sampling_batch(
-                logits,
-                top_p=cast(float, top_p),
-                generator=generator,
-                temperature=cast(float, temperature),
-            )
-        case ("top_k_top_p", top_k, top_p, temperature):
-            tokens, softmax = top_k_top_p_sampling_batch(
-                logits,
-                top_k=cast(int, top_k),
-                top_p=cast(float, top_p),
-                temperature=cast(float, temperature),
-                generator=generator,
-            )
-        case ("temperature", temperature):
-            tokens, softmax = temperature_sampling_batch(
-                logits,
-                temperature=cast(float, temperature),
-                generator=generator,
-            )
-        case ("greedy", None):
-            tokens, softmax = greedy_search_sampling_batch(logits, return_probs=return_probs)
-            temperature = None
-        case ("beam_search", beam_width_in, beam_width_out, temperature):
-            assert group_metadata is not None and isinstance(group_metadata, BeamSearchMetadata), (
-                "BeamSearchMetadata is required for beam_search_sampling_batch"
-            )
-            tokens, softmax = beam_search_sampling_batch(
-                logits,
-                beam_width_in=cast(int, beam_width_in),
-                beam_width_out=cast(int, beam_width_out),
-                beam_search_args=group_metadata,
-                temperature=cast(float, temperature),
-                return_probs=return_probs,
-            )
-    return tokens, softmax, cast(float, temperature)
+    temperature_out: float | None = None
+    tag = strategy[0]
+    if tag == "top_k":
+        sk = cast(TopK, strategy)
+        tokens, softmax = top_k_sampling_batch(
+            logits,
+            top_k=sk[1],
+            temperature=sk[2],
+            generator=generator,
+        )
+        temperature_out = sk[2]
+    elif tag == "top_p":
+        sp = cast(TopP, strategy)
+        tokens, softmax = top_p_sampling_batch(
+            logits,
+            top_p=sp[1],
+            generator=generator,
+            temperature=sp[2],
+        )
+        temperature_out = sp[2]
+    elif tag == "top_k_top_p":
+        skp = cast(TopKTopP, strategy)
+        tokens, softmax = top_k_top_p_sampling_batch(
+            logits,
+            top_k=skp[1],
+            top_p=skp[2],
+            temperature=skp[3],
+            generator=generator,
+        )
+        temperature_out = skp[3]
+    elif tag == "temperature":
+        st = cast(TemperatureOnly, strategy)
+        tokens, softmax = temperature_sampling_batch(
+            logits,
+            temperature=st[1],
+            generator=generator,
+        )
+        temperature_out = st[1]
+    elif tag == "greedy":
+        tokens, softmax = greedy_search_sampling_batch(logits, return_probs=return_probs)
+        temperature_out = None
+    elif tag == "beam_search":
+        sb = cast(BeamSearch, strategy)
+        assert group_metadata is not None and isinstance(group_metadata, BeamSearchMetadata), (
+            "BeamSearchMetadata is required for beam_search_sampling_batch"
+        )
+        tokens, softmax = beam_search_sampling_batch(
+            logits,
+            beam_width_in=sb[1],
+            beam_width_out=sb[2],
+            beam_search_args=group_metadata,
+            temperature=sb[3],
+            return_probs=return_probs,
+        )
+        temperature_out = sb[3]
+    else:
+        raise ValueError(f"Unknown sampling strategy: {tag}")
+    return tokens, softmax, temperature_out
 
 
 GenericStrategyKeyType = TypeVar("GenericStrategyKeyType", bound=Hashable)


### PR DESCRIPTION
## Summary
- Replace per-field `cast()` calls in `sample()` with a single `cast()` per branch that narrows the `Strategy` union to the concrete tuple type. This avoids both `redundant-cast` errors in mypy>=1.19 (which resolves python/mypy#19081) and `arg-type` errors in older mypy that cannot narrow structural pattern-match captures.
- Remove `slots=True` from `RequestGroupKey` dataclass to fix the `__slots__` conflict with `Generic[T]` that required a `# type: ignore[misc]` suppression (flagged as `unused-ignore` by mypy>=1.19).

These 14 mypy errors are currently breaking CI `PackageSanityCheck` stages (`B200_PCIe-PackageSanityCheck-PY312-DLFW`, `RTX5090-PackageSanityCheck-PY312-UB2404`) for all PRs.

## Test plan
- [x] CI `PackageSanityCheck` stages pass (mypy 1.19.1 with compiled bindings)
- [x] Local pre-commit mypy (lightweight, no bindings) passes on these two files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization improvements to sampling logic and request handling mechanisms for enhanced performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->