### PR TITLE
[None][perf] Fuse add + norm + fp8 quant pattern

### DIFF
--- a/tensorrt_llm/_torch/compilation/backend.py
+++ b/tensorrt_llm/_torch/compilation/backend.py
@@ -15,7 +15,8 @@ from tensorrt_llm.mapping import Mapping
 
 from .multi_stream.auto_multi_stream import multi_stream_schedule
 from .patterns.ar_residual_norm import register_ar_fusions
-from .patterns.residual_add_norm import register_add_norm
+from .patterns.residual_add_norm import (register_add_norm,
+                                         register_add_norm_quant)
 from .piecewise_optimizer import piecewise_optimizer
 from .recover_pass import recover_pass
 from .remove_copy_pass import remove_copy_for_mutates_args
@@ -82,7 +83,10 @@ class Backend:
                 cls._custom_pass_instances.append(PatternMatcherPass())
                 register_add_norm(cls._custom_pass_instances[-1])
             else:
-                register_add_norm(cls._custom_pass_instances[0])
+                # Add fp8 quant pattern before fp16/bf16 pattern
+                register_add_norm_quant(cls._custom_pass_instances[-1])
+                cls._custom_pass_instances.append(PatternMatcherPass())
+                register_add_norm(cls._custom_pass_instances[-1])
         return cls._custom_pass_instances
 
     def bypass_optimization(self):

--- a/tensorrt_llm/_torch/compilation/patterns/residual_add_norm.py
+++ b/tensorrt_llm/_torch/compilation/patterns/residual_add_norm.py
@@ -1,3 +1,5 @@
+from operator import getitem
+
 import torch
 from torch._inductor.pattern_matcher import (MULTIPLE, CallFunction, KeywordArg,
                                              Match, MultiOutputPattern,
@@ -65,5 +67,79 @@ def register_add_norm(custom_pass: PatternMatcherPass):
         fwd_only,
         custom_pass,
         search_fn_pattern=add_norm_pattern,
+        extra_check=extra_check,
+    )
+
+
+def register_add_norm_quant(custom_pass: PatternMatcherPass):
+    residual_out = CallFunction(aten.add.Tensor,
+                                KeywordArg("input"),
+                                KeywordArg("residual"),
+                                _users=MULTIPLE)
+
+    flashinfer_norm_default = CallFunction(
+        torch.ops.trtllm.flashinfer_rmsnorm.default,
+        residual_out,
+        KeywordArg("norm_weight"),
+        KeywordArg("eps"),
+        _users=1)
+
+    static_quantize = CallFunction(
+        torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor.default,
+        flashinfer_norm_default,
+        KeywordArg("scale"),
+        _users=1)
+
+    quant_out = CallFunction(getitem, static_quantize, 0, _users=1)
+    add_norm_quant_pattern = MultiOutputPattern([quant_out, residual_out])
+
+    def empty_pattern(
+        input: torch.Tensor,
+        residual: torch.Tensor,
+        norm_weight: torch.nn.Parameter,
+        scale: torch.Tensor,
+        eps: float,
+    ):
+        return
+
+    def target_pattern(
+        input: torch.Tensor,
+        residual: torch.Tensor,
+        norm_weight: torch.nn.Parameter,
+        scale: torch.Tensor,
+        eps: float,
+    ):
+        out = torch.empty_like(input, dtype=torch.float8_e4m3fn)
+        at = auto_functionalized(
+            torch.ops.trtllm.flashinfer_fused_add_rmsnorm_quant.default,
+            out=out,
+            input=input,
+            residual=residual,
+            weight=norm_weight,
+            scale=scale,
+            eps=eps,
+        )
+        # at[1]=out (fp8 quant), at[2]=residual (updated)
+        return at[1], at[2]
+
+    def extra_check(match: Match) -> bool:
+        # flashinfer_fused_add_rmsnorm_quant mutates residual in-place. Check that the original
+        # residual tensor has the add node as its last user so no downstream node sees a stale pre-mutation value.
+        add_node = match.ctx.pattern_to_node[residual_out]
+        if not isinstance(add_node, torch.fx.graph.Node):
+            return False
+
+        if list(add_node.args[1].users.keys())[-1] != add_node:
+            return False
+
+        return True
+
+    register_replacement(
+        empty_pattern,
+        target_pattern,
+        [],
+        fwd_only,
+        custom_pass,
+        search_fn_pattern=add_norm_quant_pattern,
         extra_check=extra_check,
     )

--- a/tensorrt_llm/_torch/compilation/utils.py
+++ b/tensorrt_llm/_torch/compilation/utils.py
@@ -62,6 +62,10 @@ def inplace_info():
             1: "input",
             2: "residual"
         },
+        torch.ops.trtllm.flashinfer_fused_add_rmsnorm_quant.default: {
+            1: "out",
+            2: "residual"
+        },
         torch.ops.trtllm.attn_custom_op_inplace.default: {
             1: "output",
             2: "output_sf"

--- a/tensorrt_llm/_torch/custom_ops/flashinfer_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/flashinfer_custom_ops.py
@@ -4,8 +4,9 @@ from ..flashinfer_utils import IS_FLASHINFER_AVAILABLE, get_env_enable_pdl
 
 if IS_FLASHINFER_AVAILABLE:
     from flashinfer.activation import gelu_tanh_and_mul, silu_and_mul
-    from flashinfer.norm import (fused_add_rmsnorm, gemma_fused_add_rmsnorm,
-                                 gemma_rmsnorm, rmsnorm)
+    from flashinfer.norm import (fused_add_rmsnorm, fused_add_rmsnorm_quant,
+                                 gemma_fused_add_rmsnorm, gemma_rmsnorm,
+                                 rmsnorm)
     from flashinfer.rope import apply_rope_with_cos_sin_cache_inplace
 
     # Warp this into custom op since flashinfer didn't warp it properly and we want to avoid graph break between mlp layer for user buffer optimization
@@ -61,6 +62,27 @@ if IS_FLASHINFER_AVAILABLE:
                           weight,
                           eps,
                           enable_pdl=get_env_enable_pdl())
+
+    @torch.library.custom_op("trtllm::flashinfer_fused_add_rmsnorm_quant",
+                             mutates_args=("out", "residual"))
+    def flashinfer_fused_add_rmsnorm_quant(out: torch.Tensor,
+                                           input: torch.Tensor,
+                                           residual: torch.Tensor,
+                                           weight: torch.Tensor,
+                                           scale: torch.Tensor,
+                                           eps: float) -> None:
+        fused_add_rmsnorm_quant(out,
+                                input,
+                                residual,
+                                weight,
+                                scale,
+                                eps,
+                                enable_pdl=get_env_enable_pdl())
+
+    @flashinfer_fused_add_rmsnorm_quant.register_fake
+    def _(out: torch.Tensor, input: torch.Tensor, residual: torch.Tensor,
+          weight: torch.Tensor, scale: torch.Tensor, eps: float) -> None:
+        pass
 
     @torch.library.custom_op("trtllm::flashinfer_gemma_fused_add_rmsnorm",
                              mutates_args=("input", "residual"))

--- a/tests/unittest/_torch/compilation/test_add_norm.py
+++ b/tests/unittest/_torch/compilation/test_add_norm.py
@@ -38,7 +38,9 @@ def test_add_norm_fusion(dtype, enable_inductor):
     final_output, inter_output = func(x.clone(), residual.clone(), norm_weight,
                                       eps)
 
-    assert backend.match_count[0] == 1, "Pattern Matching Failed"
+    add_norm_fusion_pass_id = 1
+    assert backend.match_count[
+        add_norm_fusion_pass_id] == 1, "Pattern Matching Failed"
 
     torch_inter_output = x + residual
     torch_final_output = rms_norm(torch_inter_output, norm_weight, eps)

--- a/tests/unittest/_torch/compilation/test_add_norm_quant.py
+++ b/tests/unittest/_torch/compilation/test_add_norm_quant.py
@@ -1,0 +1,72 @@
+import pytest
+import torch
+
+from tensorrt_llm._torch.compilation.backend import Backend
+from tensorrt_llm._torch.custom_ops import flashinfer_rmsnorm
+
+
+@torch.inference_mode()
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("enable_inductor", [False, True])
+def test_add_norm_quant_fusion(dtype, enable_inductor):
+    backend = Backend(enable_inductor)
+    SEQ_LEN = 16
+    HIDDEN_SIZE = 1024
+    eps = 1e-6
+
+    torch.manual_seed(42)
+    x = torch.randn(SEQ_LEN, HIDDEN_SIZE, dtype=dtype, device="cuda")
+    residual = torch.randn_like(x)
+    norm_weight = torch.randn((HIDDEN_SIZE,), dtype=dtype, device="cuda")
+    scale = torch.tensor(1.0, dtype=torch.float32, device="cuda")
+
+    # Compiled function that is being tested
+    @torch.compile(backend=backend)
+    def func(
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        norm_weight: torch.Tensor,
+        scale: torch.Tensor,
+        eps: float,
+    ):
+        inter_out = x + residual
+        normed = flashinfer_rmsnorm(inter_out, norm_weight, eps)
+        fp8_out, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(normed, scale)
+        return fp8_out, inter_out
+
+    # Reference unfused path
+    def ref_func(
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        norm_weight: torch.Tensor,
+        scale: torch.Tensor,
+        eps: float,
+    ):
+        inter_out = x + residual
+        normed = flashinfer_rmsnorm(inter_out, norm_weight, eps)
+        fp8_out, _ = torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor(normed, scale)
+        return fp8_out, inter_out
+
+    ref_fp8, ref_inter = ref_func(x.clone(), residual.clone(), norm_weight, scale, eps)
+    actual_fp8, actual_inter = func(x.clone(), residual.clone(), norm_weight, scale, eps)
+
+    add_norm_quant_fusion_pass_id = 0
+    assert backend.match_count[add_norm_quant_fusion_pass_id] == 1, "Pattern Matching Failed"
+    torch.testing.assert_close(
+        actual_inter,
+        ref_inter,
+        rtol=0.05,
+        atol=0.15,
+    )
+    # fused kernel applies norm and quant in a single pass with different rounding than
+    # the two-step reference, yielding up to 1 fp8 ULP difference (~0.5 in float)
+    torch.testing.assert_close(
+        actual_fp8.to(dtype),
+        ref_fp8.to(dtype),
+        rtol=0.125,
+        atol=0.5,
+    )
+
+
+if __name__ == "__main__":
+    test_add_norm_quant_fusion(torch.bfloat16, True)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added quantization-aware fusion optimization for residual add and RMSNorm operations, enabling improved inference performance through fused kernel execution. Supports float16 and bfloat16 precision levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Add an additional `PatternMatcherPass()` in compilation backend to fuse (residual_add, rms_norm, fp8 static quantization) pattern. This pattern is replaced by a fused kernel from FlashInfer.


**~8% speedup for Qwen3-4B-FP8 checkpoint**

ISL=OSL=1000, concurrency=1, requests=10

 Config | req/sec | P50 e2e |
-- | -- | -- | 
Before | 0.31 | 3255 | 
After | 0.33 | 3020 | 

ISL=OSL=1000, concurrency=8 requests=80
Config | req/sec | P50 e2e |
-- | -- | -- | 
Before | 2.09 | 3824 |
After | 2.26 | 3542 | 7.90% |

</pre>

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

New unittest in `unittest/_torch/compilation/test_add_norm_quant.py`
Existing integration tests will cover e2e FP8 accuracy.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
