### PR TITLE
[TRTLLM-11733][perf] Cache constant text computations across denoise steps in LTX2

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/transformer_args.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/transformer_args.py
@@ -83,12 +83,11 @@ class TransformerArgsPreprocessor:
     def _prepare_context(
         self,
         context: torch.Tensor,
-        x: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        batch_size = x.shape[0]
+        batch_size = context.shape[0]
         context = self.caption_projection(context.contiguous())
-        context = context.view(batch_size, -1, x.shape[-1])
+        context = context.view(batch_size, -1, self.inner_dim)
         return context, attention_mask
 
     def _prepare_attention_mask(
@@ -125,28 +124,54 @@ class TransformerArgsPreprocessor:
             freq_grid_cache=self._freq_grid_cache,
         )
 
-    def prepare(self, modality: Modality) -> TransformerArgs:
-        x = self.patchify_proj(modality.latent.contiguous())
-        timestep, embedded_timestep = self._prepare_timestep(
-            modality.timesteps, x.shape[0], modality.latent.dtype
-        )
-        context, attention_mask = self._prepare_context(modality.context, x, modality.context_mask)
-        attention_mask = self._prepare_attention_mask(attention_mask, modality.latent.dtype)
+    def prepare_text_cache(
+        self,
+        context: torch.Tensor,
+        context_mask: torch.Tensor | None,
+        positions: torch.Tensor,
+        dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor | None, tuple[torch.Tensor, torch.Tensor], None]:
+        """Compute step-invariant outputs: (context, mask, PE, cross_PE).
+
+        Called once before the denoise loop.  Does not require latent data.
+        Returns cross_PE=None (only MultiModal subclass produces it).
+        """
+        context, attention_mask = self._prepare_context(context, context_mask)
+        attention_mask = self._prepare_attention_mask(attention_mask, dtype)
         pe = self._prepare_positional_embeddings(
-            positions=modality.positions,
+            positions=positions,
             inner_dim=self.inner_dim,
             max_pos=self.max_pos,
             use_middle_indices_grid=self.use_middle_indices_grid,
             num_attention_heads=self.num_attention_heads,
-            x_dtype=modality.latent.dtype,
+            x_dtype=dtype,
+        )
+        return context, attention_mask, pe, None
+
+    def prepare(
+        self,
+        modality: Modality,
+        static_context: torch.Tensor,
+        static_mask: torch.Tensor | None,
+        static_pe: tuple[torch.Tensor, torch.Tensor],
+        static_cross_pe: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> TransformerArgs:
+        """Build TransformerArgs for one denoise step.
+
+        Step-invariant static args are always required.  *static_cross_pe*
+        is only used by the MultiModal subclass; ignored here.
+        """
+        x = self.patchify_proj(modality.latent.contiguous())
+        timestep, embedded_timestep = self._prepare_timestep(
+            modality.timesteps, x.shape[0], modality.latent.dtype
         )
         return TransformerArgs(
             x=x,
-            context=context,
-            context_mask=attention_mask,
+            context=static_context,
+            context_mask=static_mask,
             timesteps=timestep,
             embedded_timestep=embedded_timestep,
-            positional_embeddings=pe,
+            positional_embeddings=static_pe,
             cross_positional_embeddings=None,
             cross_scale_shift_timestep=None,
             cross_gate_timestep=None,
@@ -195,15 +220,48 @@ class MultiModalTransformerArgsPreprocessor:
         self.audio_cross_attention_dim = audio_cross_attention_dim
         self.av_ca_timestep_scale_multiplier = av_ca_timestep_scale_multiplier
 
-    def prepare(self, modality: Modality) -> TransformerArgs:
-        transformer_args = self.simple_preprocessor.prepare(modality)
-        cross_pe = self.simple_preprocessor._prepare_positional_embeddings(
-            positions=modality.positions[:, 0:1, :],
+    def prepare_text_cache(
+        self,
+        context: torch.Tensor,
+        context_mask: torch.Tensor | None,
+        positions: torch.Tensor,
+        dtype: torch.dtype,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor | None,
+        tuple[torch.Tensor, torch.Tensor],
+        tuple[torch.Tensor, torch.Tensor],
+    ]:
+        """Compute step-invariant outputs including cross-PE.
+
+        Returns (context, mask, pe, cross_pe).
+        """
+        sp = self.simple_preprocessor
+        context, mask, pe, _ = sp.prepare_text_cache(context, context_mask, positions, dtype)
+        cross_pe = sp._prepare_positional_embeddings(
+            positions=positions[:, 0:1, :],
             inner_dim=self.audio_cross_attention_dim,
             max_pos=[self.cross_pe_max_pos],
             use_middle_indices_grid=True,
-            num_attention_heads=self.simple_preprocessor.num_attention_heads,
-            x_dtype=modality.latent.dtype,
+            num_attention_heads=sp.num_attention_heads,
+            x_dtype=dtype,
+        )
+        return context, mask, pe, cross_pe
+
+    def prepare(
+        self,
+        modality: Modality,
+        static_context: torch.Tensor,
+        static_mask: torch.Tensor | None,
+        static_pe: tuple[torch.Tensor, torch.Tensor],
+        static_cross_pe: tuple[torch.Tensor, torch.Tensor],
+    ) -> TransformerArgs:
+        """Build TransformerArgs for one denoise step with pre-computed static outputs."""
+        transformer_args = self.simple_preprocessor.prepare(
+            modality,
+            static_context=static_context,
+            static_mask=static_mask,
+            static_pe=static_pe,
         )
         cross_scale_shift_timestep, cross_gate_timestep = self._prepare_cross_attention_timestep(
             timestep=modality.timesteps,
@@ -213,7 +271,7 @@ class MultiModalTransformerArgsPreprocessor:
         )
         return replace(
             transformer_args,
-            cross_positional_embeddings=cross_pe,
+            cross_positional_embeddings=static_cross_pe,
             cross_scale_shift_timestep=cross_scale_shift_timestep,
             cross_gate_timestep=cross_gate_timestep,
         )

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -202,12 +202,16 @@ class _LTX2CUDAGraphRunner(CUDAGraphRunner):
     """CUDAGraphRunner extended for LTX-2's ``Modality``-based transformer.
 
     The base runner derives graph keys from flat ``torch.Tensor`` args.
-    LTX-2's transformer takes ``Modality`` dataclasses (bundles of tensors)
-    and optional ``BatchedPerturbationConfig`` objects that affect control flow.
+    LTX-2's transformer takes ``Modality`` dataclasses (bundles of tensors),
+    optional ``BatchedPerturbationConfig``, and a ``TextCache`` kwarg.
 
     This subclass overrides key derivation, capture, and replay so that
     ``Modality`` tensors are included in the graph key, cloned into static
     buffers at capture time, and copied in-place at replay time.
+
+    ``TextCache`` is step-invariant (constant across the denoise loop),
+    so it is excluded from the graph key and passed through without
+    cloning or copying.
     """
 
     @staticmethod
@@ -227,7 +231,18 @@ class _LTX2CUDAGraphRunner(CUDAGraphRunner):
 
     def _key_parts_for(self, prefix, v):
         """Yield ``(label, shape_or_tag)`` pairs for a single argument."""
-        if isinstance(v, torch.Tensor):
+        from .text_cache import TextCache
+
+        if isinstance(v, TextCache):
+            # Step-invariant contents, but shape must still drive graph key:
+            # warmup and denoise may use different context lengths, which
+            # would otherwise silently reuse the wrong graph.
+            if v.video_context is not None:
+                yield (f"{prefix}.vctx", tuple(v.video_context.shape))
+            if v.audio_context is not None:
+                yield (f"{prefix}.actx", tuple(v.audio_context.shape))
+            return
+        elif isinstance(v, torch.Tensor):
             yield (prefix, tuple(v.shape))
         elif isinstance(v, Modality):
             yield (f"{prefix}.latent", tuple(v.latent.shape))
@@ -253,7 +268,35 @@ class _LTX2CUDAGraphRunner(CUDAGraphRunner):
     # -- clone / copy helpers ------------------------------------------------
 
     @staticmethod
+    def _clone_tensor_pair(pair):
+        return (pair[0].clone(), pair[1].clone()) if pair is not None else None
+
+    @staticmethod
+    def _copy_tensor_pair(dst, src):
+        if dst is None or src is None:
+            return
+        dst[0].copy_(src[0])
+        dst[1].copy_(src[1])
+
+    @staticmethod
     def _clone_value(v):
+        from .text_cache import TextCache
+
+        if isinstance(v, TextCache):
+            # Clone every tensor into static buffers — replay copies into these.
+            clone_pair = _LTX2CUDAGraphRunner._clone_tensor_pair
+            return TextCache(
+                video_context=v.video_context.clone() if v.video_context is not None else None,
+                video_mask=v.video_mask.clone() if v.video_mask is not None else None,
+                video_pe=clone_pair(v.video_pe),
+                video_cross_pe=clone_pair(v.video_cross_pe),
+                video_kv=[clone_pair(kv) for kv in v.video_kv] if v.video_kv is not None else None,
+                audio_context=v.audio_context.clone() if v.audio_context is not None else None,
+                audio_mask=v.audio_mask.clone() if v.audio_mask is not None else None,
+                audio_pe=clone_pair(v.audio_pe),
+                audio_cross_pe=clone_pair(v.audio_cross_pe),
+                audio_kv=[clone_pair(kv) for kv in v.audio_kv] if v.audio_kv is not None else None,
+            )
         if isinstance(v, torch.Tensor):
             return v.clone()
         if isinstance(v, Modality):
@@ -271,6 +314,29 @@ class _LTX2CUDAGraphRunner(CUDAGraphRunner):
     @staticmethod
     def _copy_value(dst, src):
         """Copy data from *src* into *dst* static buffer in-place."""
+        from .text_cache import TextCache
+
+        if isinstance(src, TextCache) and isinstance(dst, TextCache):
+            copy_pair = _LTX2CUDAGraphRunner._copy_tensor_pair
+            if dst.video_context is not None and src.video_context is not None:
+                dst.video_context.copy_(src.video_context)
+            if dst.video_mask is not None and src.video_mask is not None:
+                dst.video_mask.copy_(src.video_mask)
+            copy_pair(dst.video_pe, src.video_pe)
+            copy_pair(dst.video_cross_pe, src.video_cross_pe)
+            if dst.video_kv is not None and src.video_kv is not None:
+                for d, s in zip(dst.video_kv, src.video_kv):
+                    copy_pair(d, s)
+            if dst.audio_context is not None and src.audio_context is not None:
+                dst.audio_context.copy_(src.audio_context)
+            if dst.audio_mask is not None and src.audio_mask is not None:
+                dst.audio_mask.copy_(src.audio_mask)
+            copy_pair(dst.audio_pe, src.audio_pe)
+            copy_pair(dst.audio_cross_pe, src.audio_cross_pe)
+            if dst.audio_kv is not None and src.audio_kv is not None:
+                for d, s in zip(dst.audio_kv, src.audio_kv):
+                    copy_pair(d, s)
+            return dst
         if isinstance(src, torch.Tensor) and isinstance(dst, torch.Tensor):
             dst.copy_(src)
             return dst
@@ -1426,7 +1492,66 @@ class LTX2Pipeline(BasePipeline):
         if do_stg and stg_blocks:
             stg_perturbation = build_stg_perturbation_config(stg_blocks)
 
-        # ---- 8. Denoising loop ------------------------------------------
+        # ---- 8. Pre-compute text cache(s) for the denoise loop ---------------
+        # Determine which text context this rank needs:
+        #   batched CFG (1 GPU, no multi-modal guidance): cat([neg, cond]) batch=2
+        #   CFG parallel rank 1: neg context only
+        #   everything else: cond context only
+        has_audio = audio_latents is not None
+        batched_cfg = do_cfg and cfg_size < 2 and not use_multi_modal_guidance
+        is_uncond_rank = cfg_size >= 2 and cfg_rank != 0 and do_cfg
+
+        if batched_cfg:
+            v_ctx = torch.cat([neg_video_embeds, video_embeds])
+            v_mask = (
+                torch.cat([neg_connector_mask, connector_mask])
+                if connector_mask is not None
+                else None
+            )
+            a_ctx = torch.cat([neg_audio_embeds, audio_embeds]) if has_audio else None
+            a_mask = (
+                torch.cat([neg_connector_mask, connector_mask])
+                if has_audio and connector_mask is not None
+                else None
+            )
+        elif is_uncond_rank:
+            v_ctx, v_mask = neg_video_embeds, neg_connector_mask
+            a_ctx = neg_audio_embeds if has_audio else None
+            a_mask = neg_connector_mask if has_audio else None
+        else:
+            v_ctx, v_mask = video_embeds, connector_mask
+            a_ctx = audio_embeds if has_audio else None
+            a_mask = connector_mask if has_audio else None
+
+        _text_cache = self.transformer.prepare_text_cache(
+            video_context=v_ctx,
+            video_context_mask=v_mask,
+            video_positions=video_positions,
+            audio_context=a_ctx,
+            audio_context_mask=a_mask,
+            audio_positions=audio_positions if has_audio else None,
+            dtype=self.dtype,
+        )
+
+        # Uncond cache — only when multi-modal guidance runs separate uncond passes.
+        _text_cache_uncond = (
+            self.transformer.prepare_text_cache(
+                video_context=neg_video_embeds,
+                video_context_mask=neg_connector_mask,
+                video_positions=video_positions,
+                audio_context=neg_audio_embeds if has_audio else None,
+                audio_context_mask=neg_connector_mask if has_audio else None,
+                audio_positions=audio_positions if has_audio else None,
+                dtype=self.dtype,
+            )
+            if use_multi_modal_guidance and do_cfg
+            else None
+        )
+
+        # Cache encoder output for two-stage Stage 2 reuse.
+        self._cached_encoder_output = (video_embeds, audio_embeds, connector_mask)
+
+        # ---- 9. Denoising loop ------------------------------------------
         def _run_transformer(
             v_latents,
             a_latents,
@@ -1435,6 +1560,8 @@ class LTX2Pipeline(BasePipeline):
             a_context,
             mask,
             perturbations=None,
+            *,
+            text_cache,
         ):
             """Single transformer pass → (denoised_video, denoised_audio).
 
@@ -1484,6 +1611,7 @@ class LTX2Pipeline(BasePipeline):
                 video=video_mod,
                 audio=audio_mod,
                 perturbations=perturbations,
+                text_cache=text_cache,
             )
 
             dn_v = None
@@ -1527,6 +1655,7 @@ class LTX2Pipeline(BasePipeline):
                     encoder_hidden_states,
                     extra_tensors.get("audio_embeds", audio_embeds),
                     extra_tensors.get("attention_mask", connector_mask),
+                    text_cache=_text_cache,
                 )
                 return dn_v, {"audio": dn_a}
 
@@ -1542,6 +1671,7 @@ class LTX2Pipeline(BasePipeline):
                         video_embeds,
                         audio_embeds,
                         connector_mask,
+                        text_cache=_text_cache,
                     )
                 else:
                     local_v, local_a = _run_transformer(
@@ -1551,6 +1681,7 @@ class LTX2Pipeline(BasePipeline):
                         neg_video_embeds,
                         neg_audio_embeds,
                         neg_connector_mask,
+                        text_cache=_text_cache_uncond,
                     )
 
                 local_v = local_v.contiguous()
@@ -1576,6 +1707,7 @@ class LTX2Pipeline(BasePipeline):
                     video_embeds,
                     audio_embeds,
                     connector_mask,
+                    text_cache=_text_cache,
                 )
                 uncond_v = 0.0
                 uncond_a = 0.0
@@ -1587,6 +1719,7 @@ class LTX2Pipeline(BasePipeline):
                         neg_video_embeds,
                         neg_audio_embeds,
                         neg_connector_mask,
+                        text_cache=_text_cache_uncond,
                     )
 
             # STG: perturbed attention pass
@@ -1604,6 +1737,7 @@ class LTX2Pipeline(BasePipeline):
                     audio_embeds,
                     connector_mask,
                     perturbations=batched,
+                    text_cache=_text_cache,
                 )
 
             # Modality guidance: disable cross-modal attention
@@ -1617,6 +1751,7 @@ class LTX2Pipeline(BasePipeline):
                     video_embeds,
                     None,
                     connector_mask,
+                    text_cache=_text_cache,
                 )
                 if audio_latents_in is not None:
                     _, iso_a = _run_transformer(
@@ -1626,6 +1761,7 @@ class LTX2Pipeline(BasePipeline):
                         None,
                         audio_embeds,
                         connector_mask,
+                        text_cache=_text_cache,
                     )
 
             guided_v = video_guider.calculate(cond_v, uncond_v, perturbed_v, iso_v)

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -14,6 +14,7 @@ from tensorrt_llm._torch.visual_gen.output import MediaOutput
 from tensorrt_llm._torch.visual_gen.pipeline_registry import register_pipeline
 from tensorrt_llm._torch.visual_gen.quantization.ops import quantize_fp8_blockwise, quantize_nvfp4
 from tensorrt_llm._torch.visual_gen.utils import postprocess_video_tensor
+from tensorrt_llm._utils import nvtx_range
 from tensorrt_llm.logger import logger
 from tensorrt_llm.quantization.utils.fp8_utils import (
     align,
@@ -797,16 +798,10 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         logger.info("Stage 2: refinement denoising...")
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
-        # --- Text conditioning (positive only, no CFG) ---
-        prompt_embeds, prompt_attention_mask = self._encode_prompt(
-            prompt,
-            num_videos_per_prompt=1,
-            max_sequence_length=max_sequence_length,
-        )
-        video_embeds, audio_embeds, connector_mask = self._process_connectors(
-            prompt_embeds,
-            prompt_attention_mask,
-        )
+        # --- Text conditioning: reuse Stage 1 encoder output ---
+        # Gemma3 + Connector outputs depend only on prompt text, not on
+        # resolution or LoRA weights.
+        video_embeds, audio_embeds, connector_mask = self._cached_encoder_output
 
         # --- Shapes at full resolution ---
         pixel_shape = VideoPixelShape(
@@ -908,63 +903,76 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             a_noise = torch.randn_like(a_working, generator=generator)
             a_working = a_noise * sigma_0 + a_working * (1.0 - sigma_0)
 
+        # --- Pre-compute static preproc (context, PE, KV) for Stage 2 ---
+        _s2_static = self.transformer.prepare_text_cache(
+            video_context=video_embeds,
+            video_context_mask=connector_mask,
+            video_positions=video_positions,
+            audio_context=audio_embeds if a_working is not None else None,
+            audio_context_mask=connector_mask if a_working is not None else None,
+            audio_positions=audio_positions if a_working is not None else None,
+            dtype=self.dtype,
+        )
+
         # --- Euler denoising loop (no guidance) ---
         for i in range(len(sigmas) - 1):
-            sigma = sigmas[i]
-            sigma_next = sigmas[i + 1]
-            dt = sigma_next - sigma
-            timestep = sigma.unsqueeze(0).expand(v_working.shape[0])
+            with nvtx_range(f"refinement_step {i}"):
+                sigma = sigmas[i]
+                sigma_next = sigmas[i + 1]
+                dt = sigma_next - sigma
+                timestep = sigma.unsqueeze(0).expand(v_working.shape[0])
 
-            if denoise_mask is not None:
-                v_timestep = denoise_mask * sigma
-            else:
-                v_timestep = timestep
+                if denoise_mask is not None:
+                    v_timestep = denoise_mask * sigma
+                else:
+                    v_timestep = timestep
 
-            video_mod = Modality(
-                latent=v_working.to(self.dtype),
-                timesteps=v_timestep,
-                positions=video_positions,
-                context=video_embeds,
-                context_mask=connector_mask,
-            )
-
-            audio_mod = None
-            if a_working is not None:
-                audio_mod = Modality(
-                    latent=a_working.to(self.dtype),
-                    timesteps=timestep,
-                    positions=audio_positions,
-                    context=audio_embeds,
+                video_mod = Modality(
+                    latent=v_working.to(self.dtype),
+                    timesteps=v_timestep,
+                    positions=video_positions,
+                    context=video_embeds,
                     context_mask=connector_mask,
                 )
 
-            vel_v, vel_a = self.transformer(
-                video=video_mod,
-                audio=audio_mod,
-            )
+                audio_mod = None
+                if a_working is not None:
+                    audio_mod = Modality(
+                        latent=a_working.to(self.dtype),
+                        timesteps=timestep,
+                        positions=audio_positions,
+                        context=audio_embeds,
+                        context_mask=connector_mask,
+                    )
 
-            # Video: velocity → x0 → post-process → Euler step
-            sigma_v = sigma.float()
-            while sigma_v.dim() < vel_v.dim():
-                sigma_v = sigma_v.unsqueeze(-1)
+                vel_v, vel_a = self.transformer(
+                    video=video_mod,
+                    audio=audio_mod,
+                    text_cache=_s2_static,
+                )
 
-            denoised_v = v_working.float() - vel_v.float() * sigma_v
+                # Video: velocity → x0 → post-process → Euler step
+                sigma_v = sigma.float()
+                while sigma_v.dim() < vel_v.dim():
+                    sigma_v = sigma_v.unsqueeze(-1)
 
-            if denoise_mask is not None and clean_latent is not None:
-                dm = denoise_mask.unsqueeze(-1)
-                denoised_v = denoised_v * dm + clean_latent.float() * (1.0 - dm)
+                denoised_v = v_working.float() - vel_v.float() * sigma_v
 
-            velocity_v = (v_working.float() - denoised_v) / sigma_v
-            v_working = (v_working.float() + velocity_v * dt).to(v_working.dtype)
+                if denoise_mask is not None and clean_latent is not None:
+                    dm = denoise_mask.unsqueeze(-1)
+                    denoised_v = denoised_v * dm + clean_latent.float() * (1.0 - dm)
 
-            # Audio: velocity → x0 → Euler step
-            if vel_a is not None and a_working is not None:
-                sigma_a = sigma.float()
-                while sigma_a.dim() < vel_a.dim():
-                    sigma_a = sigma_a.unsqueeze(-1)
-                denoised_a = a_working.float() - vel_a.float() * sigma_a
-                velocity_a = (a_working.float() - denoised_a) / sigma_a
-                a_working = (a_working.float() + velocity_a * dt).to(a_working.dtype)
+                velocity_v = (v_working.float() - denoised_v) / sigma_v
+                v_working = (v_working.float() + velocity_v * dt).to(v_working.dtype)
+
+                # Audio: velocity → x0 → Euler step
+                if vel_a is not None and a_working is not None:
+                    sigma_a = sigma.float()
+                    while sigma_a.dim() < vel_a.dim():
+                        sigma_a = sigma_a.unsqueeze(-1)
+                    denoised_a = a_working.float() - vel_a.float() * sigma_a
+                    velocity_a = (a_working.float() - denoised_a) / sigma_a
+                    a_working = (a_working.float() + velocity_a * dt).to(a_working.dtype)
 
         # --- Unpatchify ---
         video_out = self.video_patchifier.unpatchify(v_working, video_shape)

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/text_cache.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/text_cache.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Step-invariant preprocessor outputs for the LTX2 denoise loop.
+
+Computed once before the denoise loop and passed into each ``LTXModel.forward()``
+call.  Keeps ``forward()`` free of data-dependent branches, making it safe
+for CUDA graph capture/replay.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+
+
+@dataclass
+class TextCache:
+    """Pre-computed text-derived tensors that are constant across denoise steps.
+
+    Attributes:
+        video_context: Projected text embedding for video cross-attention.
+        video_mask: Attention mask for video text cross-attention.
+        video_pe: RoPE (cos, sin) for video.
+        audio_context: Projected text embedding for audio cross-attention.
+        audio_mask: Attention mask for audio text cross-attention.
+        audio_pe: RoPE (cos, sin) for audio.
+        video_cross_pe: Cross-modal RoPE for video (audio-video model only).
+        audio_cross_pe: Cross-modal RoPE for audio (audio-video model only).
+        video_kv: Per-layer pre-projected text K/V for video cross-attention.
+        audio_kv: Per-layer pre-projected text K/V for audio cross-attention.
+    """
+
+    video_context: Optional[torch.Tensor] = None
+    video_mask: Optional[torch.Tensor] = None
+    video_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
+    video_cross_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
+    video_kv: Optional[list[tuple[torch.Tensor, torch.Tensor]]] = None
+    audio_context: Optional[torch.Tensor] = None
+    audio_mask: Optional[torch.Tensor] = None
+    audio_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
+    audio_cross_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
+    audio_kv: Optional[list[tuple[torch.Tensor, torch.Tensor]]] = None

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -48,6 +48,7 @@ from .ltx2_core.transformer_args import (
     TransformerArgsPreprocessor,
 )
 from .ltx2_core.utils_ltx2 import rms_norm
+from .text_cache import TextCache
 
 if TYPE_CHECKING:
     from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
@@ -481,12 +482,17 @@ class BasicAVTransformerBlock(nn.Module):
         video: TransformerArgs | None,
         audio: TransformerArgs | None,
         perturbations=None,
+        text_kv_video: tuple[torch.Tensor, torch.Tensor] | None = None,
+        text_kv_audio: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> tuple[TransformerArgs | None, TransformerArgs | None]:
         """Forward with optional perturbation masking for STG.
 
         Args:
             perturbations: Optional ``BatchedPerturbationConfig`` that masks
                 attention outputs for selected blocks/modalities.
+            text_kv_video: Pre-projected (K, V) for video text cross-attention.
+                Falls back to inline computation if ``None``.
+            text_kv_audio: Pre-projected (K, V) for audio text cross-attention.
         """
         if video is None and audio is None:
             raise ValueError("At least one of video or audio must be provided")
@@ -525,6 +531,7 @@ class BasicAVTransformerBlock(nn.Module):
             vx = vx + self.attn2(
                 rms_norm(vx, eps=self.norm_eps),
                 context=video.context,
+                pre_projected_kv=text_kv_video,
             )
             del vshift_msa, vscale_msa, vgate_msa
 
@@ -549,6 +556,7 @@ class BasicAVTransformerBlock(nn.Module):
             ax = ax + self.audio_attn2(
                 rms_norm(ax, eps=self.norm_eps),
                 context=audio.context,
+                pre_projected_kv=text_kv_audio,
             )
             del ashift_msa, ascale_msa, agate_msa
 
@@ -704,6 +712,14 @@ class LTX2CacheDiTPattern0BlockWrapper(nn.Module):
             aa: Optional[TransformerArgs] = replace(aa_src, x=encoder_hidden_states)
         else:
             aa = aa_src
+        # Cache-DiT's CachedBlocks iterates all inner blocks with the same kwargs,
+        # so looking up per-block text_kv via inner.idx is required — passing
+        # text_kv via the outer loop would feed every block block-0's KV.
+        idx = inner_mod.idx
+        v_kv_list = getattr(p, "_cache_dit_v_kv", None)
+        a_kv_list = getattr(p, "_cache_dit_a_kv", None)
+        kwargs.setdefault("text_kv_video", v_kv_list[idx] if v_kv_list else None)
+        kwargs.setdefault("text_kv_audio", a_kv_list[idx] if a_kv_list else None)
         out_v, out_a = inner_mod(video=va, audio=aa, perturbations=perturbations, **kwargs)
         return (
             out_v.x if out_v is not None else None,
@@ -838,6 +854,10 @@ class LTXModel(nn.Module):
         self._audio_is_sharded = False
         self._cache_dit_video_args: Optional[TransformerArgs] = None
         self._cache_dit_audio_args: Optional[TransformerArgs] = None
+        # Per-block text cross-attn KV lists, looked up by inner.idx in the
+        # Pattern_0 wrapper. Set once per forward in the Cache-DiT path.
+        self._cache_dit_v_kv: Optional[list] = None
+        self._cache_dit_a_kv: Optional[list] = None
 
         self._init_transformer_blocks(
             num_layers=num_layers,
@@ -1231,11 +1251,58 @@ class LTXModel(nn.Module):
 
     # -- Forward -------------------------------------------------------------
 
+    def prepare_text_cache(
+        self,
+        *,
+        video_context: torch.Tensor | None = None,
+        video_context_mask: torch.Tensor | None = None,
+        video_positions: torch.Tensor | None = None,
+        audio_context: torch.Tensor | None = None,
+        audio_context_mask: torch.Tensor | None = None,
+        audio_positions: torch.Tensor | None = None,
+        dtype: torch.dtype,
+    ) -> TextCache:
+        """Compute step-invariant preprocessor outputs and text KV projections.
+
+        Called once before the denoise loop.  The returned ``TextCache``
+        is passed to ``forward()`` on every step.  Does not require latent
+        data — only text context, positions, and dtype are needed.
+        """
+        v_ctx = v_mask = v_pe = v_cross_pe = v_kv = None
+        a_ctx = a_mask = a_pe = a_cross_pe = a_kv = None
+
+        if video_context is not None:
+            v_ctx, v_mask, v_pe, v_cross_pe = self.video_args_preprocessor.prepare_text_cache(
+                video_context, video_context_mask, video_positions, dtype
+            )
+            v_kv = [block.attn2.project_kv(v_ctx) for block in self.transformer_blocks]
+
+        if audio_context is not None:
+            a_ctx, a_mask, a_pe, a_cross_pe = self.audio_args_preprocessor.prepare_text_cache(
+                audio_context, audio_context_mask, audio_positions, dtype
+            )
+            a_kv = [block.audio_attn2.project_kv(a_ctx) for block in self.transformer_blocks]
+
+        return TextCache(
+            video_context=v_ctx,
+            video_mask=v_mask,
+            video_pe=v_pe,
+            video_cross_pe=v_cross_pe,
+            video_kv=v_kv,
+            audio_context=a_ctx,
+            audio_mask=a_mask,
+            audio_pe=a_pe,
+            audio_cross_pe=a_cross_pe,
+            audio_kv=a_kv,
+        )
+
     def forward(
         self,
         video: Modality | None,
         audio: Modality | None,
         perturbations=None,
+        *,
+        text_cache: TextCache,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         """Forward pass through the LTX-2 transformer.
 
@@ -1243,6 +1310,8 @@ class LTXModel(nn.Module):
             video: Video modality input (or None).
             audio: Audio modality input (or None).
             perturbations: Optional ``BatchedPerturbationConfig`` for STG.
+            text_cache: Pre-computed step-invariant outputs from ``prepare_text_cache()``.
+                Always required — callers must invoke ``prepare_text_cache()`` first.
 
         Returns:
             Tuple of (video_output, audio_output) velocity predictions.
@@ -1252,35 +1321,66 @@ class LTXModel(nn.Module):
         if not self.model_type.is_audio_enabled() and audio is not None:
             raise ValueError("Audio is not enabled for this model")
 
-        video_args = self.video_args_preprocessor.prepare(video) if video is not None else None
-        audio_args = self.audio_args_preprocessor.prepare(audio) if audio is not None else None
+        video_args = (
+            self.video_args_preprocessor.prepare(
+                video,
+                text_cache.video_context,
+                text_cache.video_mask,
+                text_cache.video_pe,
+                text_cache.video_cross_pe,
+            )
+            if video is not None
+            else None
+        )
+        audio_args = (
+            self.audio_args_preprocessor.prepare(
+                audio,
+                text_cache.audio_context,
+                text_cache.audio_mask,
+                text_cache.audio_pe,
+                text_cache.audio_cross_pe,
+            )
+            if audio is not None
+            else None
+        )
 
         # Shard sequences for Ulysses parallelism.
-        # Video is always sharded.  Audio sharding is decided once by
-        # configure_audio_ulysses() and cached in self._audio_is_sharded.
         if self.use_ulysses:
             if video_args is not None:
                 video_args = self._shard_transformer_args(video_args)
             if self._audio_is_sharded and audio_args is not None:
                 audio_args = self._shard_transformer_args(audio_args)
 
+        v_kv = text_cache.video_kv
+        a_kv = text_cache.audio_kv
+
         if self._uses_cache_dit():
+            # Cache-DiT path: wrapper consumes (vx, ax) positional args and
+            # reads full TransformerArgs from self._cache_dit_*_args. text_kv
+            # must be looked up by inner.idx inside the wrapper — Cache-DiT's
+            # CachedBlocks iterates inner blocks with a single shared kwargs
+            # dict, so passing text_kv[i] through the outer loop would feed
+            # every inner block block-0's KV.
+            self._cache_dit_video_args = video_args
+            self._cache_dit_audio_args = audio_args
+            self._cache_dit_v_kv = v_kv
+            self._cache_dit_a_kv = a_kv
             vx = video_args.x if video_args is not None else None
             ax = audio_args.x if audio_args is not None else None
             for block in self.transformer_blocks:
-                self._cache_dit_video_args = video_args
-                self._cache_dit_audio_args = audio_args
                 vx, ax = block(vx, ax, perturbations=perturbations)
                 if video_args is not None and vx is not None:
                     video_args = replace(video_args, x=vx)
                 if audio_args is not None and ax is not None:
                     audio_args = replace(audio_args, x=ax)
         else:
-            for block in self.transformer_blocks:
+            for i, block in enumerate(self.transformer_blocks):
                 video_args, audio_args = block(
                     video=video_args,
                     audio=audio_args,
                     perturbations=perturbations,
+                    text_kv_video=v_kv[i] if v_kv else None,
+                    text_kv_audio=a_kv[i] if a_kv else None,
                 )
 
         # Gather sequences back to full length for output processing.

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -82,19 +82,29 @@ def _get_ltx2_transformer_inputs(transformer, device="cuda", dtype=torch.bfloat1
     for i in range(a_patches):
         a_positions[:, 0, i, :] = torch.tensor([i, i + 1], dtype=torch.float32)
 
+    v_context = torch.randn(batch, text_len, caption_channels, device=device, dtype=dtype)
+    a_context = torch.randn(batch, text_len, caption_channels, device=device, dtype=dtype)
+
     video = Modality(
         latent=torch.randn(batch, v_patches, in_channels, device=device, dtype=dtype),
         timesteps=torch.tensor([0.5], device=device),
         positions=v_positions,
-        context=torch.randn(batch, text_len, caption_channels, device=device, dtype=dtype),
+        context=v_context,
     )
     audio = Modality(
         latent=torch.randn(batch, a_patches, audio_in_channels, device=device, dtype=dtype),
         timesteps=torch.tensor([0.5], device=device),
         positions=a_positions,
-        context=torch.randn(batch, text_len, caption_channels, device=device, dtype=dtype),
+        context=a_context,
     )
-    return video, audio
+    text_cache = transformer.prepare_text_cache(
+        video_context=v_context,
+        video_positions=v_positions,
+        audio_context=a_context,
+        audio_positions=a_positions,
+        dtype=dtype,
+    )
+    return video, audio, text_cache
 
 
 def _extract_output(output):
@@ -349,11 +359,15 @@ class TestLTX2AttentionBackend:
         pipeline_baseline = PipelineLoader(args_baseline).load(skip_warmup=True)
         transformer_baseline = pipeline_baseline.transformer
 
-        video_input, audio_input = _get_ltx2_transformer_inputs(transformer_baseline)
+        video_input, audio_input, text_cache_baseline = _get_ltx2_transformer_inputs(
+            transformer_baseline
+        )
 
         print("[Attention Backend Test] Running VANILLA transformer forward...")
         with torch.no_grad():
-            output_baseline = transformer_baseline(video=video_input, audio=audio_input)
+            output_baseline = transformer_baseline(
+                video=video_input, audio=audio_input, text_cache=text_cache_baseline
+            )
         vout_baseline, aout_baseline = _extract_output(output_baseline)
         vout_baseline_cpu = vout_baseline.cpu() if vout_baseline is not None else None
 
@@ -373,8 +387,11 @@ class TestLTX2AttentionBackend:
         transformer_trtllm = pipeline_trtllm.transformer
 
         print("[Attention Backend Test] Running TRTLLM transformer forward...")
+        _, _, text_cache_trtllm = _get_ltx2_transformer_inputs(transformer_trtllm)
         with torch.no_grad():
-            output_trtllm = transformer_trtllm(video=video_input, audio=audio_input)
+            output_trtllm = transformer_trtllm(
+                video=video_input, audio=audio_input, text_cache=text_cache_trtllm
+            )
         vout_trtllm, aout_trtllm = _extract_output(output_trtllm)
         vout_trtllm_cpu = vout_trtllm.cpu() if vout_trtllm is not None else None
 

--- a/tests/unittest/_torch/visual_gen/test_ltx2_transformer.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_transformer.py
@@ -175,19 +175,27 @@ class TestLTX2VideoOnlyModel(unittest.TestCase):
         caption_channels = VIDEO_ONLY_CONFIG["caption_channels"]
         text_len = 8
 
+        v_context = (
+            torch.randn(batch, text_len, caption_channels, device=self.DEVICE, dtype=dtype) * 0.02
+        )
+        v_positions = _make_video_positions(batch, n_patches, n_frames, grid_h, grid_w, self.DEVICE)
+
         video_modality = Modality(
             latent=torch.randn(batch, n_patches, in_channels, device=self.DEVICE, dtype=dtype)
             * 0.02,
             timesteps=torch.tensor([0.5], device=self.DEVICE),
-            positions=_make_video_positions(
-                batch, n_patches, n_frames, grid_h, grid_w, self.DEVICE
-            ),
-            context=torch.randn(batch, text_len, caption_channels, device=self.DEVICE, dtype=dtype)
-            * 0.02,
+            positions=v_positions,
+            context=v_context,
+        )
+
+        text_cache = model.prepare_text_cache(
+            video_context=v_context,
+            video_positions=v_positions,
+            dtype=dtype,
         )
 
         with torch.no_grad():
-            video_out, audio_out = model(video=video_modality, audio=None)
+            video_out, audio_out = model(video=video_modality, audio=None, text_cache=text_cache)
 
         self.assertIsNotNone(video_out)
         self.assertIsNone(audio_out)
@@ -270,13 +278,21 @@ class TestLTX2AudioVideoModel(unittest.TestCase):
         caption_channels = AUDIO_VIDEO_CONFIG["caption_channels"]
         text_len = 8
 
+        v_context = (
+            torch.randn(batch, text_len, caption_channels, device=self.DEVICE, dtype=dtype) * 0.02
+        )
+        a_context = (
+            torch.randn(batch, text_len, caption_channels, device=self.DEVICE, dtype=dtype) * 0.02
+        )
+        v_positions = _make_video_positions(batch, v_patches, v_frames, v_h, v_w, self.DEVICE)
+        a_positions = _make_audio_positions(batch, a_patches, self.DEVICE)
+
         video_modality = Modality(
             latent=torch.randn(batch, v_patches, in_channels, device=self.DEVICE, dtype=dtype)
             * 0.02,
             timesteps=torch.tensor([0.5], device=self.DEVICE),
-            positions=_make_video_positions(batch, v_patches, v_frames, v_h, v_w, self.DEVICE),
-            context=torch.randn(batch, text_len, caption_channels, device=self.DEVICE, dtype=dtype)
-            * 0.02,
+            positions=v_positions,
+            context=v_context,
         )
 
         audio_in_channels = AUDIO_VIDEO_CONFIG["audio_in_channels"]
@@ -284,13 +300,22 @@ class TestLTX2AudioVideoModel(unittest.TestCase):
             latent=torch.randn(batch, a_patches, audio_in_channels, device=self.DEVICE, dtype=dtype)
             * 0.02,
             timesteps=torch.tensor([0.5], device=self.DEVICE),
-            positions=_make_audio_positions(batch, a_patches, self.DEVICE),
-            context=torch.randn(batch, text_len, caption_channels, device=self.DEVICE, dtype=dtype)
-            * 0.02,
+            positions=a_positions,
+            context=a_context,
+        )
+
+        text_cache = model.prepare_text_cache(
+            video_context=v_context,
+            video_positions=v_positions,
+            audio_context=a_context,
+            audio_positions=a_positions,
+            dtype=dtype,
         )
 
         with torch.no_grad():
-            video_out, audio_out = model(video=video_modality, audio=audio_modality)
+            video_out, audio_out = model(
+                video=video_modality, audio=audio_modality, text_cache=text_cache
+            )
 
         self.assertIsNotNone(video_out)
         self.assertIsNotNone(audio_out)
@@ -334,17 +359,27 @@ class TestLTX2AudioVideoModel(unittest.TestCase):
         caption_channels = AUDIO_VIDEO_CONFIG["caption_channels"]
         text_len = 8
 
+        v_context = (
+            torch.randn(batch, text_len, caption_channels, device=self.DEVICE, dtype=dtype) * 0.02
+        )
+        v_positions = _make_video_positions(batch, v_patches, v_frames, v_h, v_w, self.DEVICE)
+
         video_modality = Modality(
             latent=torch.randn(batch, v_patches, in_channels, device=self.DEVICE, dtype=dtype)
             * 0.02,
             timesteps=torch.tensor([0.5], device=self.DEVICE),
-            positions=_make_video_positions(batch, v_patches, v_frames, v_h, v_w, self.DEVICE),
-            context=torch.randn(batch, text_len, caption_channels, device=self.DEVICE, dtype=dtype)
-            * 0.02,
+            positions=v_positions,
+            context=v_context,
+        )
+
+        text_cache = model.prepare_text_cache(
+            video_context=v_context,
+            video_positions=v_positions,
+            dtype=dtype,
         )
 
         with torch.no_grad():
-            video_out, audio_out = model(video=video_modality, audio=None)
+            video_out, audio_out = model(video=video_modality, audio=None, text_cache=text_cache)
 
         self.assertIsNotNone(video_out)
         self.assertIsNone(audio_out)
@@ -592,8 +627,17 @@ class TestLTX2CUDAGraphCapture(unittest.TestCase):
         # 1. Eager forward — baseline
         torch.manual_seed(100)
         video_mod, audio_mod = _make_modalities(0.5)
+        text_cache = model.prepare_text_cache(
+            video_context=video_mod.context,
+            video_context_mask=video_mod.context_mask,
+            video_positions=video_mod.positions,
+            audio_context=audio_mod.context,
+            audio_context_mask=audio_mod.context_mask,
+            audio_positions=audio_mod.positions,
+            dtype=dtype,
+        )
         with torch.no_grad():
-            eager_v, eager_a = model(video=video_mod, audio=audio_mod)
+            eager_v, eager_a = model(video=video_mod, audio=audio_mod, text_cache=text_cache)
         eager_v = eager_v.clone()
         eager_a = eager_a.clone()
 
@@ -606,7 +650,7 @@ class TestLTX2CUDAGraphCapture(unittest.TestCase):
         torch.manual_seed(100)
         video_mod, audio_mod = _make_modalities(0.5)
         with torch.no_grad():
-            graph_v1, graph_a1 = model(video=video_mod, audio=audio_mod)
+            graph_v1, graph_a1 = model(video=video_mod, audio=audio_mod, text_cache=text_cache)
 
         self.assertTrue(
             torch.equal(eager_v, graph_v1),
@@ -621,10 +665,10 @@ class TestLTX2CUDAGraphCapture(unittest.TestCase):
         torch.manual_seed(200)
         video_mod2, audio_mod2 = _make_modalities(0.3)
 
-        # Eager baseline for new inputs
+        # Eager baseline for new inputs (same static — context/PE don't change)
         model.forward = original_forward
         with torch.no_grad():
-            eager_v2, eager_a2 = model(video=video_mod2, audio=audio_mod2)
+            eager_v2, eager_a2 = model(video=video_mod2, audio=audio_mod2, text_cache=text_cache)
         eager_v2 = eager_v2.clone()
         eager_a2 = eager_a2.clone()
 
@@ -633,7 +677,7 @@ class TestLTX2CUDAGraphCapture(unittest.TestCase):
         torch.manual_seed(200)
         video_mod2, audio_mod2 = _make_modalities(0.3)
         with torch.no_grad():
-            graph_v2, graph_a2 = model(video=video_mod2, audio=audio_mod2)
+            graph_v2, graph_a2 = model(video=video_mod2, audio=audio_mod2, text_cache=text_cache)
 
         self.assertTrue(
             torch.equal(eager_v2, graph_v2),
@@ -642,6 +686,224 @@ class TestLTX2CUDAGraphCapture(unittest.TestCase):
         self.assertTrue(
             torch.equal(eager_a2, graph_a2),
             f"Replay audio output differs from eager. Max diff: {(eager_a2 - graph_a2).abs().max():.6e}",
+        )
+
+
+class TestLTX2TextCache(unittest.TestCase):
+    """Test TextCache: correctness, different context, reuse across steps."""
+
+    DEVICE = "cuda"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_text_cache(self):
+        """TextCache correctness tests.
+
+        1. Same inputs + same cache → deterministic (bitwise identical).
+        2. Different context → different text_cache → different output.
+        3. Reusing text_cache across steps produces correct results.
+        """
+        from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.modality import Modality
+        from tensorrt_llm._torch.visual_gen.models.ltx2.transformer_ltx2 import (
+            LTXModel,
+            LTXModelType,
+        )
+
+        torch.manual_seed(42)
+        dtype = torch.bfloat16
+        model_config = _create_model_config()
+        model = (
+            LTXModel(
+                model_type=LTXModelType.AudioVideo, model_config=model_config, **AUDIO_VIDEO_CONFIG
+            )
+            .to(self.DEVICE, dtype=dtype)
+            .eval()
+        )
+        _init_all_weights(model)
+
+        batch, v_frames, v_h, v_w = 1, 1, 4, 4
+        v_patches, a_patches, text_len = v_frames * v_h * v_w, 8, 8
+        in_ch = AUDIO_VIDEO_CONFIG["in_channels"]
+        a_in_ch = AUDIO_VIDEO_CONFIG["audio_in_channels"]
+        cap_ch = AUDIO_VIDEO_CONFIG["caption_channels"]
+        v_ctx_A = torch.randn(batch, text_len, cap_ch, device=self.DEVICE, dtype=dtype) * 0.02
+        a_ctx_A = torch.randn(batch, text_len, cap_ch, device=self.DEVICE, dtype=dtype) * 0.02
+        v_ctx_B = torch.randn(batch, text_len, cap_ch, device=self.DEVICE, dtype=dtype) * 0.02
+        a_ctx_B = torch.randn(batch, text_len, cap_ch, device=self.DEVICE, dtype=dtype) * 0.02
+        v_pos = _make_video_positions(batch, v_patches, v_frames, v_h, v_w, self.DEVICE)
+        a_pos = _make_audio_positions(batch, a_patches, self.DEVICE)
+
+        def make_mods(ts, v_ctx, a_ctx):
+            return (
+                Modality(
+                    latent=torch.randn(batch, v_patches, in_ch, device=self.DEVICE, dtype=dtype)
+                    * 0.02,
+                    timesteps=torch.tensor([ts], device=self.DEVICE),
+                    positions=v_pos,
+                    context=v_ctx,
+                ),
+                Modality(
+                    latent=torch.randn(batch, a_patches, a_in_ch, device=self.DEVICE, dtype=dtype)
+                    * 0.02,
+                    timesteps=torch.tensor([ts], device=self.DEVICE),
+                    positions=a_pos,
+                    context=a_ctx,
+                ),
+            )
+
+        static_A = model.prepare_text_cache(
+            video_context=v_ctx_A,
+            video_positions=v_pos,
+            audio_context=a_ctx_A,
+            audio_positions=a_pos,
+            dtype=dtype,
+        )
+
+        with torch.no_grad():
+            # -- Part 1: deterministic — same inputs + same cache → same output --
+            torch.manual_seed(200)
+            v_mod, a_mod = make_mods(0.5, v_ctx_A, a_ctx_A)
+            v_out1, a_out1 = model(video=v_mod, audio=a_mod, text_cache=static_A)
+
+            torch.manual_seed(200)
+            v_mod, a_mod = make_mods(0.5, v_ctx_A, a_ctx_A)
+            v_out2, a_out2 = model(video=v_mod, audio=a_mod, text_cache=static_A)
+
+        self.assertTrue(
+            torch.equal(v_out1, v_out2),
+            f"Video diff: {(v_out1 - v_out2).abs().max():.6e}",
+        )
+        self.assertTrue(
+            torch.equal(a_out1, a_out2),
+            f"Audio diff: {(a_out1 - a_out2).abs().max():.6e}",
+        )
+
+        with torch.no_grad():
+            # -- Part 2: different context → different output --
+            torch.manual_seed(200)
+            v_mod_B, a_mod_B = make_mods(0.5, v_ctx_B, a_ctx_B)
+            static_B = model.prepare_text_cache(
+                video_context=v_ctx_B,
+                video_positions=v_pos,
+                audio_context=a_ctx_B,
+                audio_positions=a_pos,
+                dtype=dtype,
+            )
+            v_B, _ = model(video=v_mod_B, audio=a_mod_B, text_cache=static_B)
+
+        self.assertFalse(torch.equal(v_out1, v_B), "Different context must differ")
+
+        with torch.no_grad():
+            # -- Part 3: reuse static across steps --
+            torch.manual_seed(300)
+            v_mod1, a_mod1 = make_mods(0.8, v_ctx_A, a_ctx_A)
+            v_step1, _ = model(video=v_mod1, audio=a_mod1, text_cache=static_A)
+
+            torch.manual_seed(400)
+            v_mod2, a_mod2 = make_mods(0.5, v_ctx_A, a_ctx_A)
+            v_step2, _ = model(video=v_mod2, audio=a_mod2, text_cache=static_A)
+
+        # Different timestep/latent → different output
+        self.assertFalse(torch.equal(v_step1, v_step2), "Steps should differ")
+
+
+class TestLTX2CacheDiTWrapperPassthrough(unittest.TestCase):
+    """Pattern_0 wrapper path must be bitwise-equivalent to direct block path
+    when Cache-DiT skips are disabled. Validates text_kv_* kwargs forwarding
+    and TransformerArgs reassembly in the merged Cache-DiT / TextCache loop.
+    """
+
+    DEVICE = "cuda"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_wrapper_path_matches_direct_path(self):
+        import torch.nn as nn
+
+        from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.modality import Modality
+        from tensorrt_llm._torch.visual_gen.models.ltx2.transformer_ltx2 import (
+            LTX2CacheDiTPattern0BlockWrapper,
+            LTXModel,
+            LTXModelType,
+        )
+
+        torch.manual_seed(7)
+        dtype = torch.bfloat16
+        model_config = _create_model_config()
+        model = (
+            LTXModel(
+                model_type=LTXModelType.AudioVideo, model_config=model_config, **AUDIO_VIDEO_CONFIG
+            )
+            .to(self.DEVICE, dtype=dtype)
+            .eval()
+        )
+        _init_all_weights(model)
+
+        batch, v_frames, v_h, v_w = 1, 1, 4, 4
+        v_patches, a_patches, text_len = v_frames * v_h * v_w, 8, 8
+        in_ch = AUDIO_VIDEO_CONFIG["in_channels"]
+        a_in_ch = AUDIO_VIDEO_CONFIG["audio_in_channels"]
+        cap_ch = AUDIO_VIDEO_CONFIG["caption_channels"]
+
+        v_ctx = torch.randn(batch, text_len, cap_ch, device=self.DEVICE, dtype=dtype) * 0.02
+        a_ctx = torch.randn(batch, text_len, cap_ch, device=self.DEVICE, dtype=dtype) * 0.02
+        v_pos = _make_video_positions(batch, v_patches, v_frames, v_h, v_w, self.DEVICE)
+        a_pos = _make_audio_positions(batch, a_patches, self.DEVICE)
+
+        def make_mods():
+            torch.manual_seed(99)
+            return (
+                Modality(
+                    latent=torch.randn(batch, v_patches, in_ch, device=self.DEVICE, dtype=dtype)
+                    * 0.02,
+                    timesteps=torch.tensor([0.5], device=self.DEVICE),
+                    positions=v_pos,
+                    context=v_ctx,
+                ),
+                Modality(
+                    latent=torch.randn(batch, a_patches, a_in_ch, device=self.DEVICE, dtype=dtype)
+                    * 0.02,
+                    timesteps=torch.tensor([0.5], device=self.DEVICE),
+                    positions=a_pos,
+                    context=a_ctx,
+                ),
+            )
+
+        static = model.prepare_text_cache(
+            video_context=v_ctx,
+            video_positions=v_pos,
+            audio_context=a_ctx,
+            audio_positions=a_pos,
+            dtype=dtype,
+        )
+
+        # Baseline: direct path (no wrappers)
+        with torch.no_grad():
+            v_mod, a_mod = make_mods()
+            v_direct, a_direct = model(video=v_mod, audio=a_mod, text_cache=static)
+        v_direct = v_direct.clone()
+        a_direct = a_direct.clone()
+
+        # Wrap blocks with Pattern_0 wrapper and force cache-dit path.
+        # Wrapper only re-routes arg shape; with no cache skip it must match direct.
+        original_blocks = list(model.transformer_blocks)
+        wrapped = [LTX2CacheDiTPattern0BlockWrapper(b, parent=model) for b in original_blocks]
+        model.transformer_blocks = nn.ModuleList(wrapped)
+        model._uses_cache_dit = lambda: True  # type: ignore[method-assign]
+
+        try:
+            with torch.no_grad():
+                v_mod, a_mod = make_mods()
+                v_wrap, a_wrap = model(video=v_mod, audio=a_mod, text_cache=static)
+        finally:
+            model.transformer_blocks = nn.ModuleList(original_blocks)
+            del model._uses_cache_dit
+
+        self.assertTrue(
+            torch.equal(v_direct, v_wrap),
+            f"Video differs. Max abs diff: {(v_direct - v_wrap).abs().max():.6e}",
+        )
+        self.assertTrue(
+            torch.equal(a_direct, a_wrap),
+            f"Audio differs. Max abs diff: {(a_direct - a_wrap).abs().max():.6e}",
         )
 
 


### PR DESCRIPTION
## Summary

Cache text-derived computations that are constant across denoise steps in the LTX2 pipeline.

LTX2 uses text context (prompt embeddings) that is **constant throughout the entire denoising loop** — the same prompt produces the same text embedding every step. Currently, several expensive operations on this constant input are redundantly recomputed at every step:

1. **Preprocessor level**: `caption_projection(context)` (Linear GEMM), attention mask construction, and RoPE positional embeddings
2. **Block level**: K/V projections (`to_k`, `to_v`) and K-normalization (`norm_k`) in 48 layers × 2 modalities (video + audio) of text cross-attention (`attn2` / `audio_attn2`)

Together these produce ~678 redundant kernels per step.

### Approach

**Two-level caching:**

1. **Preprocessor caching** (`transformer_args.py`): Cache `caption_projection(context)`, `attention_mask`, and RoPE across denoise steps using `data_ptr()` as cache key. Runs outside `torch.compile` (in `LTXModel.forward()`), so `data_ptr()` is safe.

2. **Block-level KV cache** (`transformer_ltx2.py`): Each `BasicAVTransformerBlock` stores cached KV as plain tuple attributes (`_text_kv_video`, `_text_kv_audio`). On first use per generate() call (`is None` check), `project_kv()` fills the cache. Subsequent denoise steps reuse it via `pre_projected_kv=` parameter.

3. **Cache lifecycle** (`pipeline_ltx2.py`): `invalidate_text_kv_cache()` resets both block-level KV caches and preprocessor caches before each denoising loop, preventing stale `data_ptr()` hits across `generate()` calls.

4. **Two-stage pipeline support** (`pipeline_ltx2_two_stages.py`): Stage 2 uses LoRA-merged weights for refinement denoising. `invalidate()` is called after LoRA merge so the cache refills with the merged weights on the first Stage 2 step. Stage 2 only uses `CfgPass.COND` (no CFG). NVTX markers (`refinement_step {i}`) are added to the stage 2 denoise loop for profiling.

5. **Encoder output caching** (`pipeline_ltx2.py`, `pipeline_ltx2_two_stages.py`): Text encoder output (Gemma3 + Connector) is cached in `LTX2TextContextCache` after Stage 1 and reused in Stage 2, skipping redundant `_encode_prompt()` + `_process_connectors()` calls. These outputs are prompt-only dependent — not affected by resolution or LoRA weights — so they survive `invalidate()`. Saves ~27ms GPU time per two-stage run.

**torch.compile compatibility**: All cache logic (fill, invalidate, store/get) runs outside compiled blocks in `LTXModel.forward()`. Compiled blocks only receive pre-projected KV as parameters — no conditional logic, no guards, no recompilation.

### Single-Stage 40-Step Performance (NVFP4, B200, 736×1280, 121 frames, torch.compile ON)

All measurements on same node (umbriel-b200-048). Steady-state runs (excludes first-run recompile overhead from unrelated NVFP4 dtype guards).

**Step denoising time (avg of steps 2–40):**

| GPU | Baseline | Optimized | Δ | Δ % |
|-----|----------|-----------|---|-----|
| 1GPU | 710ms | 702ms | -8ms | **-1.2%** |
| 2GPU | 452ms | 446ms | -6ms | **-1.3%** |
| 4GPU | 270ms | 266ms | -4ms | **-1.5%** |
| 8GPU | 190ms | 180ms | -10ms | **-5.3%** |

**E2E (total generate() wall time):**

| GPU | Baseline | Optimized | Δ | Δ % |
|-----|----------|-----------|---|-----|
| 1GPU | 30.89s | 30.57s | -0.32s | **-1.0%** |
| 2GPU | 20.60s | 20.32s | -0.29s | **-1.4%** |
| 4GPU | 13.34s | 13.11s | -0.23s | **-1.7%** |
| 8GPU | 9.94s | 9.69s | -0.25s | **-2.5%** |

### Two-Stage 40-Step Performance (NVFP4, B200, 768×1280, 121 frames, 40+3 steps)

Two-stage pipeline: stage 1 at half resolution (384×640, 40 steps) + LoRA merge + spatial upsample + stage 2 at full resolution (768×1280, 3 steps). Same code, cache disabled via env var for baseline.

**E2E (total generate() wall time, 1GPU):**

| | Baseline | Optimized | Δ | Δ % |
|--|----------|-----------|---|-----|
| 1GPU | 15.233s | 14.884s | -0.35s | **-2.3%** |

### 1GPU Kernel-Level Breakdown (nsys, per step, verified match=Y)

Kernel sequences verified identical via `diff` on stripped triton kernel names. Two-pointer alignment confirms exact match.

**Single-stage (denoise_step 2, 736×1280, NVFP4): 678 kernels eliminated per step**

| What was eliminated | Kernels saved | GPU time saved |
|---------------------|:---:|---:|
| GEMM (nvjet, KV projection) | 196 | 2.13ms |
| QK RMSNorm (K normalization) | 96 | 1.03ms |
| FP4 Quantize (KV quantization) | 168 | 0.99ms |
| RMSNorm (FlashInfer, context norm) | 168 | 0.65ms |
| BF16 GEMM (excluded layers) | 28 | 0.56ms |
| Elementwise | 47 | 0.55ms |
| CatArrayBatchedCopy | 3 | 0.12ms |
| **Total** | **678** | **~6.0ms** |

**Two-stage Stage 1 (denoise_step 2, 384×640): 678 kernels eliminated per step**

| What was eliminated | Kernels saved | GPU time saved |
|---------------------|:---:|---:|
| GEMM (nvjet, KV projection) | 196 | 1.76ms |
| QK RMSNorm (K normalization) | 96 | 0.85ms |
| FP4 Quantize (KV quantization) | 168 | 0.79ms |
| RMSNorm (FlashInfer, context norm) | 168 | 0.53ms |
| Elementwise | 47 | 0.17ms |
| CatArrayBatchedCopy | 3 | 0.03ms |
| **Total** | **678** | **4.13ms** |

**Stage 2 (refinement_step 1, 768×1280): 678 kernels eliminated per step**

| What was eliminated | Kernels saved | GPU time saved |
|---------------------|:---:|---:|
| GEMM (nvjet, KV projection) | 196 | 2.13ms |
| QK RMSNorm (K normalization) | 96 | 1.03ms |
| FP4 Quantize (KV quantization) | 168 | 0.99ms |
| RMSNorm (FlashInfer, context norm) | 168 | 0.65ms |
| Elementwise | 47 | 0.58ms |
| CatArrayBatchedCopy | 3 | 0.13ms |
| **Total** | **678** | **5.50ms** |

Note: Stage 2 kernels are slower per-kernel than Stage 1 due to higher resolution (768×1280 vs 384×640).

### Tests

- Unit test covering cache numerical equivalence (bitwise identical), invalidation correctness (different context → different output), CFG slot isolation, and single-GPU CFG simulation
- All existing LTX2 tests pass (12/12)

## PR Checklist

- [x] Please check this if you have read the [contribution guidelines](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CONTRIBUTING.md).
