### PR TITLE
[None][feat] Optimize MoE DenseGEMM FC2 kernel

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -3471,8 +3471,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
             l = 1  # dense GEMM
 
             # Define candidates together
-            mma_tiler_mn_candidates = [(128, 64), (128, 128), (128, 256)]
-            cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4)]
+            mma_tiler_mn_candidates = [(128, 64), (128, 128), (128, 256),
+                                      (256, 128)]
+            cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4), (2, 1)]
 
             # Map torch dtype to cutlass dtype
             if self.output_dtype not in self._CUTLASS_DTYPE_MAP:

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -3472,7 +3472,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             # Define candidates
             mma_tiler_mn_candidates = [(128, 64), (128, 128), (128, 256),
-                                      (256, 128)]
+                                       (256, 128)]
             cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4), (2, 1)]
             split_k_candidates = [1, 2, 4]
 
@@ -3511,9 +3511,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                         # and each split must contain whole experts.
                         k_tiles = k // _MMA_TILE_K
                         tiles_per_expert = self.weight_per_expert // _MMA_TILE_K
-                        if (k_tiles % split_k == 0
-                                and (k_tiles // split_k) % tiles_per_expert
-                                == 0):
+                        if (k_tiles % split_k == 0 and
+                            (k_tiles // split_k) % tiles_per_expert == 0):
                             tactics.append(
                                 (mma_tiler_mn, cluster_shape_mn, split_k))
 
@@ -3567,8 +3566,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 mma_tiler_mn, cluster_shape_mn = tactic
                 split_k = 1
             else:
-                mma_tiler_mn, cluster_shape_mn, split_k = (128, 128), (1,
-                                                                        1), 1
+                mma_tiler_mn, cluster_shape_mn, split_k = (128, 128), (1, 1), 1
 
             # Allocate output tensor
             c_dtype = self.output_dtype

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -3455,8 +3455,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
             **kwargs,
-        ) -> List[Tuple[Tuple[int, int], Tuple[int, int]]]:
-            """Return valid (mma_tiler_mn, cluster_shape_mn) combinations."""
+        ) -> List[Tuple[Tuple[int, int], Tuple[int, int], int]]:
+            """Return valid (mma_tiler_mn, cluster_shape_mn, split_k) combinations."""
             # Check SM version - only supports SM 100 and SM 103
             major, minor = torch.cuda.get_device_capability()
             if not (major == 10 and minor in [0, 3]):
@@ -3470,10 +3470,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             n = b.shape[0]
             l = 1  # dense GEMM
 
-            # Define candidates together
+            # Define candidates
             mma_tiler_mn_candidates = [(128, 64), (128, 128), (128, 256),
                                       (256, 128)]
             cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4), (2, 1)]
+            split_k_candidates = [1, 2, 4]
 
             # Map torch dtype to cutlass dtype
             if self.output_dtype not in self._CUTLASS_DTYPE_MAP:
@@ -3481,6 +3482,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     f"Unsupported output_dtype {self.output_dtype} for FC2 DenseGEMM runner"
                 )
             c_cutlass_dtype = self._CUTLASS_DTYPE_MAP[self.output_dtype]
+
+            # MMA tile K size for split-K divisibility check
+            _MMA_TILE_K = 256
 
             tactics = []
             for mma_tiler_mn, cluster_shape_mn in itertools.product(
@@ -3502,7 +3506,16 @@ if IS_CUTLASS_DSL_AVAILABLE:
                         self.expert_count,
                         self.weight_per_expert,
                 ):
-                    tactics.append((mma_tiler_mn, cluster_shape_mn))
+                    for split_k in split_k_candidates:
+                        # K-tiles must be evenly divisible by split_k,
+                        # and each split must contain whole experts.
+                        k_tiles = k // _MMA_TILE_K
+                        tiles_per_expert = self.weight_per_expert // _MMA_TILE_K
+                        if (k_tiles % split_k == 0
+                                and (k_tiles // split_k) % tiles_per_expert
+                                == 0):
+                            tactics.append(
+                                (mma_tiler_mn, cluster_shape_mn, split_k))
 
             return tactics
 
@@ -3527,13 +3540,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def forward(
             self,
             inputs: List[torch.Tensor],
-            tactic: Optional[Tuple[Tuple[int, int], Tuple[int, int]]],
+            tactic: Optional[Tuple[Tuple[int, int], Tuple[int, int], int]],
         ) -> torch.Tensor:
             """Execute the dense GEMM FC2.
 
             Args:
                 inputs: [a, b, a_sf, b_sf, alpha_scale]
-                tactic: ((mma_m, mma_n), (cluster_m, cluster_n))
+                tactic: ((mma_m, mma_n), (cluster_m, cluster_n), split_k)
 
             Returns:
                 Output tensor
@@ -3548,14 +3561,22 @@ if IS_CUTLASS_DSL_AVAILABLE:
             l = 1  # dense GEMM
 
             # Default tactic if not provided
-            if isinstance(tactic, tuple):
+            if isinstance(tactic, tuple) and len(tactic) == 3:
+                mma_tiler_mn, cluster_shape_mn, split_k = tactic
+            elif isinstance(tactic, tuple) and len(tactic) == 2:
                 mma_tiler_mn, cluster_shape_mn = tactic
+                split_k = 1
             else:
-                mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
+                mma_tiler_mn, cluster_shape_mn, split_k = (128, 128), (1,
+                                                                        1), 1
 
             # Allocate output tensor
             c_dtype = self.output_dtype
-            c = torch.empty((m, n), dtype=c_dtype, device=a.device)
+            if split_k > 1:
+                # Atomic reduction accumulates onto C; must be zero-initialized
+                c = torch.zeros((m, n), dtype=c_dtype, device=a.device)
+            else:
+                c = torch.empty((m, n), dtype=c_dtype, device=a.device)
 
             # Get CUDA stream
             torch_stream = torch.cuda.current_stream()
@@ -3600,6 +3621,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 self.weight_per_expert,
                 mma_tiler_mn,
                 cluster_shape_mn,
+                split_k,
                 self.scaling_vector_size,
                 self.
                 output_dtype,  # Include output dtype to avoid cache collision
@@ -3617,6 +3639,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     cluster_shape_mn=cluster_shape_mn,
                     expert_count=self.expert_count,
                     weight_per_expert=self.weight_per_expert,
+                    split_k=split_k,
                 )
 
                 # Compile the kernel and cache it

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
@@ -207,15 +207,11 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         )
         self.mma_warp_id = 4
         self.tma_warp_id = 5
-        self.alpha_scale_load_warp_id = 6
-        self.dummy_warp_id = 7
         self.threads_per_cta = 32 * len(
             (
                 self.mma_warp_id,
                 self.tma_warp_id,
                 *self.epilog_warp_id,
-                self.alpha_scale_load_warp_id,
-                self.dummy_warp_id,
             )
         )
         # Set barrier id for cta sync, epilogue sync and tmem ptr sync
@@ -333,7 +329,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         )
 
         # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
-        self.num_acc_stage, self.num_ab_stage, self.num_c_stage, self.num_alpha_scale_stage = (
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = (
             self._compute_stages(
                 tiled_mma,
                 self.mma_tiler,
@@ -348,7 +344,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 self.occupancy,
             )
         )
-
         # Compute A/B/SFA/SFB/C shared memory layout
         self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
             tiled_mma,
@@ -379,17 +374,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.c_layout,
             self.epi_tile,
             self.num_c_stage,
-        )
-
-        self.alpha_scale_smem_layout_staged = cute.make_layout(
-            (
-                self.cta_tile_shape_mnk[0],
-                self.num_alpha_scale_stage,
-            ),
-            stride=(
-                self.num_alpha_scale_stage,
-                1,
-            ),
         )
 
     @cute.jit
@@ -563,9 +547,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
             acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
             acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
-            alpha_scale_load_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.num_alpha_scale_stage * 2
-            ]
             tmem_dealloc_mbar_ptr: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
             # (EPI_TILE_M, EPI_TILE_N, STAGE)
@@ -596,14 +577,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)],
                 self.buffer_align_bytes,
             ]
-            # Alpha scale shared memory
-            sAlphaScale: cute.struct.Align[
-                cute.struct.MemRange[
-                    cutlass.Float32, cute.cosize(self.alpha_scale_smem_layout_staged)
-                ],
-                16,
-            ]
-
         self.shared_storage = SharedStorage
 
         # Launch the kernel synchronously
@@ -627,7 +600,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.b_smem_layout_staged,
             self.sfa_smem_layout_staged,
             self.sfb_smem_layout_staged,
-            self.alpha_scale_smem_layout_staged,
             self.c_smem_layout_staged,
             self.epi_tile,
             self.tile_sched_params,
@@ -664,7 +636,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         b_smem_layout_staged: cute.ComposedLayout,
         sfa_smem_layout_staged: cute.Layout,
         sfb_smem_layout_staged: cute.Layout,
-        alpha_scale_smem_layout_staged: cute.Layout,
         c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
         epi_tile: cute.Tile,
         tile_sched_params: utils.PersistentTileSchedulerParams,
@@ -738,24 +709,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             cta_layout_vmnk=cluster_layout_vmnk,
         )
 
-        # Initialize alpha_scale_pipeline (barrier) and states
-        alpha_scale_pipeline_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            32 * 1,  # alpha_scale_load_warp_id threads
-            32 * 1,
-        )
-        alpha_scale_pipeline_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            32 * len(self.epilog_warp_id),  # epilogue warps
-            32 * len(self.epilog_warp_id),
-        )
-        alpha_scale_pipeline = pipeline.PipelineCpAsync.create(
-            barrier_storage=storage.alpha_scale_load_mbar_ptr.data_ptr(),
-            num_stages=self.num_alpha_scale_stage,
-            producer_group=alpha_scale_pipeline_producer_group,
-            consumer_group=alpha_scale_pipeline_consumer_group,
-        )
-
         # Tensor memory dealloc barrier init
         tmem = utils.TmemAllocator(
             storage.tmem_holding_buf,
@@ -782,8 +735,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
         # (MMA, MMA_N, MMA_K, STAGE)
         sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
-        # Alpha scale shared memory tensor
-        sAlphaScale = storage.sAlphaScale.get_tensor(alpha_scale_smem_layout_staged)
 
         #
         # Compute multicast mask for A/B/SFA/SFB buffer full
@@ -1079,101 +1030,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             ab_pipeline.producer_tail(ab_producer_state)
 
         #
-        # Specialized Alpha Scale Load warp
-        #
-        if warp_idx == self.alpha_scale_load_warp_id:
-            #
-            # Persistent tile scheduling loop
-            #
-            tile_sched = utils.StaticPersistentTileScheduler.create(
-                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
-            )
-            work_tile = tile_sched.initial_work_tile_info()
-
-            alpha_scale_producer_state = pipeline.make_pipeline_state(
-                pipeline.PipelineUserType.Producer, self.num_alpha_scale_stage
-            )
-
-            # Setup copy atom for alpha scale loading
-            atom_copy = cute.make_copy_atom(
-                cute.nvgpu.cpasync.CopyG2SOp(),
-                malpha_scale_mnl.element_type,
-                num_bits_per_copy=malpha_scale_mnl.element_type.width,
-            )
-            tiled_copy_alpha_scale = cute.make_tiled_copy_tv(
-                atom_copy, cute.make_layout((32,)), cute.make_layout((1,))
-            )
-            thr_copy_alpha_scale = tiled_copy_alpha_scale.get_slice(cute.arch.lane_idx())
-
-            while work_tile.is_valid_tile:
-                # Get tile coord from tile scheduler
-                cur_tile_coord = work_tile.tile_idx
-
-                # Reset producer state for this tile
-                alpha_scale_producer_state.reset_count()
-                peek_alpha_scale_empty_status = cutlass.Boolean(1)
-                if alpha_scale_producer_state.count < k_tile_cnt:
-                    peek_alpha_scale_empty_status = alpha_scale_pipeline.producer_try_acquire(
-                        alpha_scale_producer_state
-                    )
-
-                galpha_scale_mnl_current_tile = galpha_scale_mnl[
-                    None, cur_tile_coord[0], None, cur_tile_coord[2]
-                ]
-
-                tAgAlphaScale = thr_copy_alpha_scale.partition_S(galpha_scale_mnl_current_tile)
-                tAsAlphaScale = thr_copy_alpha_scale.partition_D(sAlphaScale)
-
-                # Load alpha scale for each k tile
-                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
-                    # Calculate expert index for this k_tile
-                    expert_idx = k_tile // (self.weight_per_expert // self.mma_tiler[2])
-
-                    # Slice alpha scale for current tile and expert
-                    tAgAlphaScale_slice = tAgAlphaScale[(None, None, expert_idx)]
-                    tAsAlphaScale_slice = tAsAlphaScale[
-                        (None, None, alpha_scale_producer_state.index)
-                    ]
-
-                    # Wait for alpha scale buffer empty
-                    alpha_scale_pipeline.producer_acquire(
-                        alpha_scale_producer_state, peek_alpha_scale_empty_status
-                    )
-
-                    num_iters = cute.size(tAgAlphaScale_slice, mode=[1])
-
-                    # Load alpha scale from global to shared memory
-                    for iter_idx in cutlass.range(num_iters, unroll_full=True):
-                        iter_coord = (None, iter_idx)
-                        pred = cutlass.Boolean(
-                            32 * iter_idx + cute.arch.lane_idx() < malpha_scale_mnl.shape[0]
-                        )
-                        if pred:
-                            cute.copy(
-                                tiled_copy_alpha_scale,
-                                tAgAlphaScale_slice[iter_coord],
-                                tAsAlphaScale_slice[iter_coord],
-                            )
-
-                    # Commit and advance
-                    alpha_scale_pipeline.producer_commit(alpha_scale_producer_state)
-                    alpha_scale_producer_state.advance()
-
-                    # Peek next
-                    peek_alpha_scale_empty_status = cutlass.Boolean(1)
-                    if alpha_scale_producer_state.count < k_tile_cnt:
-                        peek_alpha_scale_empty_status = alpha_scale_pipeline.producer_try_acquire(
-                            alpha_scale_producer_state
-                        )
-
-                # Advance to next tile
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
-
-            # Wait for alpha scale buffer empty
-            alpha_scale_pipeline.producer_tail(alpha_scale_producer_state)
-
-        #
         # Specialized MMA warp
         #
         if warp_idx == self.mma_warp_id:
@@ -1277,21 +1133,31 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                     peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
 
                 #
-                # Mma mainloop
+                # Mma mainloop with expert grouping
+                # Accumulate tiles_per_expert k-tiles per acc buffer to halve
+                # acc pipeline traffic (512 → 256 round-trips).
                 #
+                tiles_per_expert_mma = self.weight_per_expert // self.mma_tiler[2]
+                tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
                 for k_tile in range(k_tile_cnt):
-                    # Set tensor memory buffer for current tile
-                    # (MMA, MMA_M, MMA_N)
-                    tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+                    is_first_of_expert = (k_tile % tiles_per_expert_mma == 0)
+                    is_last_of_expert = (
+                        k_tile % tiles_per_expert_mma == tiles_per_expert_mma - 1
+                    )
+
+                    if is_first_of_expert:
+                        tCtAcc = tCtAcc_base[
+                            (None, None, None, acc_producer_state.index)
+                        ]
 
                     if is_leader_cta:
-                        # Wait for accumulator buffer empty(each kblock)
-                        acc_pipeline.producer_acquire(acc_producer_state)
+                        if is_first_of_expert:
+                            acc_pipeline.producer_acquire(acc_producer_state)
 
-                        # Conditionally wait for AB buffer full
-                        ab_pipeline.consumer_wait(ab_consumer_state, peek_ab_full_status)
+                        ab_pipeline.consumer_wait(
+                            ab_consumer_state, peek_ab_full_status
+                        )
 
-                        #  Copy SFA/SFB from smem to tmem
                         s2t_stage_coord = (
                             None,
                             None,
@@ -1299,8 +1165,12 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             None,
                             ab_consumer_state.index,
                         )
-                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[s2t_stage_coord]
-                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[s2t_stage_coord]
+                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[
+                            s2t_stage_coord
+                        ]
+                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[
+                            s2t_stage_coord
+                        ]
                         cute.copy(
                             tiled_copy_s2t_sfa,
                             tCsSFA_compact_s2t_staged,
@@ -1312,14 +1182,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             tCtSFB_compact_s2t,
                         )
 
-                        #
-                        # Reset the ACCUMULATE field for each tile
-                        #
-                        tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                        if is_first_of_expert:
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
 
-                        # tCtAcc += tCrA * tCrSFA * tCrB * tCrSFB
                         num_kblocks = cute.size(tCrA, mode=[2])
-                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
+                        for kblock_idx in cutlass.range(
+                            num_kblocks, unroll_full=True
+                        ):
                             kblock_coord = (
                                 None,
                                 None,
@@ -1327,7 +1196,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                 ab_consumer_state.index,
                             )
 
-                            # Set SFA/SFB tensor to tiled_mma
                             sf_kblock_coord = (None, None, kblock_idx)
                             tiled_mma.set(
                                 tcgen05.Field.SFA,
@@ -1346,25 +1214,22 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                 tCtAcc,
                             )
 
-                            # Enable accumulate on tCtAcc after first kblock
                             tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
 
-                        # Async arrive AB buffer empty
                         ab_pipeline.consumer_release(ab_consumer_state)
 
-                    # Peek (try_wait) AB buffer full for k_tile = k_tile + 1
                     ab_consumer_state.advance()
                     peek_ab_full_status = cutlass.Boolean(1)
                     if ab_consumer_state.count < k_tile_cnt:
                         if is_leader_cta:
-                            peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
+                            peek_ab_full_status = (
+                                ab_pipeline.consumer_try_wait(ab_consumer_state)
+                            )
 
-                    #
-                    # Async arrive accumulator buffer full
-                    #
-                    if is_leader_cta:
-                        acc_pipeline.producer_commit(acc_producer_state)
-                    acc_producer_state.advance()
+                    if is_last_of_expert:
+                        if is_leader_cta:
+                            acc_pipeline.producer_commit(acc_producer_state)
+                        acc_producer_state.advance()
 
                 #
                 # Advance to next tile
@@ -1432,11 +1297,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 pipeline.PipelineUserType.Consumer, self.num_acc_stage
             )
 
-            # Alpha scale consumer state
-            alpha_scale_consumer_state = pipeline.make_pipeline_state(
-                pipeline.PipelineUserType.Consumer, self.num_alpha_scale_stage
-            )
-
             # Threads/warps participating in tma store pipeline
             c_producer_group = pipeline.CooperativeGroup(
                 pipeline.Agent.Thread,
@@ -1448,18 +1308,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 producer_group=c_producer_group,
             )
 
-            # Create copy atom for loading alpha scale from smem
-            alpha_scale_copy_atom_s2r = cute.make_copy_atom(
-                cute.nvgpu.CopyUniversalOp(),
-                cutlass.Float32,
-                num_bits_per_copy=32,
-            )
-            tiled_copy_alpha_scale_s2r = cute.make_tiled_copy_tv(
-                alpha_scale_copy_atom_s2r,
-                cute.make_layout((32 * len(self.epilog_warp_id),)),
-                cute.make_layout((1,)),
-            )
-            thr_copy_alpha_scale_s2r = tiled_copy_alpha_scale_s2r.get_slice(tidx)
+            tiles_per_expert = self.weight_per_expert // self.mma_tiler[2]
+            m_total = malpha_scale_mnl.shape[0]
 
             while work_tile.is_valid_tile:
                 # Get tile coord from tile scheduler
@@ -1486,54 +1336,35 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 # initialize the final accumulator
                 tTR_rAcc_final.fill(0.0)
 
-                # Initialize alpha_scale consumer state for this tile
-                alpha_scale_consumer_state.reset_count()
-                peek_alpha_scale_full_status = cutlass.Boolean(1)
-                if alpha_scale_consumer_state.count < k_tile_cnt:
-                    peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
-                        alpha_scale_consumer_state
-                    )
+                # Epilogue iterates over experts (not k-tiles) since MMA
+                # accumulates tiles_per_expert k-tiles per acc buffer.
+                num_experts_k = k_tile_cnt // tiles_per_expert
 
                 acc_consumer_state.reset_count()
                 peek_acc_full_status = cutlass.Boolean(1)
-                if acc_consumer_state.count < k_tile_cnt:
+                if acc_consumer_state.count < num_experts_k:
                     peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
 
-                for k_tile in cutlass.range(k_tile_cnt):
-                    # Set tensor memory buffer for current tile
-                    # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
+                m_start = cur_tile_coord[0] * self.cta_tile_shape_mnk[0]
+                batch_idx = cur_tile_coord[2]
+                m_in_bounds = m_start < m_total
+                thread_in_bounds = epi_tidx < (m_total - m_start) if m_in_bounds else False
+
+                # Prologue: prefetch alpha for expert 0
+                prefetched_alpha = cutlass.Float32(0.0)
+                if thread_in_bounds:
+                    prefetched_alpha = galpha_scale_mnl[
+                        epi_tidx, cur_tile_coord[0], cutlass.Int32(0), batch_idx
+                    ]
+
+                for expert_idx in cutlass.range(num_experts_k):
                     tTR_tAcc = tTR_tAcc_base[
                         (None, None, None, None, None, acc_consumer_state.index)
                     ]
                     tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
-                    #
-                    # Update accumulator by scale factor in subtiles
-                    #
                     subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
 
-                    # for subtile_idx in cutlass.range_dynamic(subtile_cnt):
-
-                    #
-                    # Wait for alpha scale buffer full
-                    #
-                    alpha_scale_pipeline.consumer_wait(
-                        alpha_scale_consumer_state, peek_alpha_scale_full_status
-                    )
-
-                    # Load alpha scale from shared memory for current expert
-                    alpha_scale_smem_slice = sAlphaScale[(None, alpha_scale_consumer_state.index)]
-
-                    tAsAlphaScale_slice = thr_copy_alpha_scale_s2r.partition_S(
-                        alpha_scale_smem_slice
-                    )
-                    current_alpha_scale_reg = cute.make_rmem_tensor(
-                        tAsAlphaScale_slice.shape, cutlass.Float32
-                    )
-
-                    cute.copy(
-                        alpha_scale_copy_atom_s2r, tAsAlphaScale_slice, current_alpha_scale_reg
-                    )
-                    current_alpha_scale = current_alpha_scale_reg[0]
+                    current_alpha_scale = prefetched_alpha
 
                     #
                     # Wait for accumulator buffer full
@@ -1559,16 +1390,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         final_vec = acc_vec * current_alpha_scale + final_vec
                         tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
 
-                    # Release alpha scale buffer
-                    alpha_scale_pipeline.consumer_release(alpha_scale_consumer_state)
-                    alpha_scale_consumer_state.advance()
-
-                    # Peek next alpha scale
-                    peek_alpha_scale_full_status = cutlass.Boolean(1)
-                    if alpha_scale_consumer_state.count < k_tile_cnt:
-                        peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
-                            alpha_scale_consumer_state
-                        )
                     #
                     # Async arrive accumulator buffer empty
                     #
@@ -1576,8 +1397,17 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         acc_pipeline.consumer_release(acc_consumer_state)
                     acc_consumer_state.advance()
 
+                    # Prefetch next expert's alpha after releasing acc buffer
+                    next_expert = expert_idx + 1
+                    clamped_expert = next_expert if next_expert < num_experts_k else num_experts_k - 1
+                    prefetched_alpha = cutlass.Float32(0.0)
+                    if thread_in_bounds:
+                        prefetched_alpha = galpha_scale_mnl[
+                            epi_tidx, cur_tile_coord[0], clamped_expert, batch_idx
+                        ]
+
                     peek_acc_full_status = cutlass.Boolean(1)
-                    if acc_consumer_state.count < k_tile_cnt:
+                    if acc_consumer_state.count < num_experts_k:
                         peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
 
                 #
@@ -1856,8 +1686,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         sf_vec_size: int,
         smem_capacity: int,
         occupancy: int,
-    ) -> Tuple[int, int, int, int]:
-        """Computes the number of stages for A/B/C/Alpha_Scale operands based on heuristics.
+    ) -> Tuple[int, int, int]:
+        """Computes the number of stages for A/B/C operands based on heuristics.
 
         :param tiled_mma: The tiled MMA object defining the core computation.
         :type tiled_mma: cute.TiledMma
@@ -1883,21 +1713,16 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :type occupancy: int
 
         :return: A tuple containing the computed number of stages for:
-                 (ACC stages, A/B operand stages, C stages, Alpha_Scale stages)
-        :rtype: tuple[int, int, int, int]
+                 (ACC stages, A/B operand stages, C stages)
+        :rtype: tuple[int, int, int]
         """
-        # ACC stages
-        num_acc_stage = 2
+        # ACC stages: 3 for N=128 to allow MMA to run ahead of epilogue
+        num_acc_stage = 3
         if mma_tiler_mnk[1] == 256:
             num_acc_stage = 1
-        # else if mma_tiler_mnk[1] == 64:
-        #     num_acc_stage = 6
 
         # Default C stages
         num_c_stage = 2
-
-        # Default Alpha scale stages
-        num_alpha_scale_stage = 10
 
         # Calculate smem layout and size for one stage of A, B, SFA, SFB and C
         a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
@@ -1942,21 +1767,12 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
         c_bytes = c_bytes_per_stage * num_c_stage
 
-        # Alpha scale shared memory
-        # hardcode cta tile shape
-        alpha_bytes = cute.size_in_bytes(
-            cutlass.Float32,
-            cute.make_layout(
-                (mma_tiler_mnk[0] // tiled_mma.thr_id.shape, num_alpha_scale_stage),
-                stride=(num_alpha_scale_stage, 1),
-            ),
-        )
         # Calculate A/B/SFA/SFB stages:
         # Start with total smem per CTA (capacity / occupancy)
         # Subtract reserved bytes and initial C stages bytes
         # Divide remaining by bytes needed per A/B/SFA/SFB stage
         num_ab_stage = (
-            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes + alpha_bytes)
+            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
         ) // ab_bytes_per_stage
 
         # Refine epilogue stages:
@@ -1965,10 +1781,10 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         num_c_stage += (
             smem_capacity
             - occupancy * ab_bytes_per_stage * num_ab_stage
-            - occupancy * (mbar_helpers_bytes + c_bytes + alpha_bytes)
+            - occupancy * (mbar_helpers_bytes + c_bytes)
         ) // (occupancy * c_bytes_per_stage)
 
-        return num_acc_stage, num_ab_stage, num_c_stage, num_alpha_scale_stage
+        return num_acc_stage, num_ab_stage, num_c_stage
 
     @staticmethod
     def _compute_grid(

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
@@ -24,6 +24,13 @@ import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
 
+from ..utils import (
+    atomic_add_func,
+    vectorized_atomic_add_bf16x8,
+    vectorized_atomic_add_fp16x8,
+    vectorized_atomic_add_fp32x2,
+)
+
 """
 This example provides an experimental implementation of the SM100 batched dense blockscaled
 GEMM kernel, please note that the APIs and implementation details related to this kernel
@@ -159,6 +166,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         weight_per_expert: int,
         use_prefetch: bool = False,
         prefetch_dist: int = 3,
+        split_k: int = 1,
     ):
         """Initializes the configuration for a Blackwell dense GEMM kernel.
 
@@ -236,6 +244,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         self.use_prefetch = use_prefetch
         self.prefetch_dist = prefetch_dist
+        self.split_k = split_k
 
     def _setup_attributes(self):
         """Set up configurations that are dependent on GEMM inputs
@@ -327,6 +336,31 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.c_layout,
             self.c_dtype,
         )
+
+        # Atomic add parameters for split-K epilogue
+        if self.split_k > 1:
+            epi_tile_m = cute.size(self.epi_tile[0])
+            epi_tile_n = cute.size(self.epi_tile[1])
+            num_epilogue_threads = 32 * len(self.epilog_warp_id)
+            self.ttr_racc_size = (epi_tile_m * epi_tile_n) // num_epilogue_threads
+            if self.c_dtype in (cutlass.Float16, cutlass.BFloat16):
+                self.epi_layout_atomic = cute.make_layout(
+                    shape=(self.ttr_racc_size // 8, 4, 2), stride=(8, 2, 1)
+                )
+                self.epi_loop_size_atomic = self.ttr_racc_size // 8
+                self.element_offset_atomic = 8
+            elif self.c_dtype == cutlass.Float32:
+                self.epi_layout_atomic = cute.make_layout(
+                    shape=(self.ttr_racc_size // 2, 2), stride=(2, 1)
+                )
+                self.epi_loop_size_atomic = self.ttr_racc_size // 2
+                self.element_offset_atomic = 2
+            else:
+                self.epi_layout_atomic = cute.make_layout(
+                    shape=(self.ttr_racc_size,), stride=(1,)
+                )
+                self.epi_loop_size_atomic = self.ttr_racc_size
+                self.element_offset_atomic = 1
 
         # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
         self.num_acc_stage, self.num_ab_stage, self.num_c_stage = (
@@ -530,12 +564,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.epi_tile,
         )
 
-        # Compute grid size
+        # Compute grid size (inflated by split_k for split-K decomposition)
         self.tile_sched_params, grid = self._compute_grid(
             c_tensor,
             self.cta_tile_shape_mnk,
             self.cluster_shape_mn,
             max_active_clusters,
+            self.split_k,
         )
 
         self.buffer_align_bytes = 1024
@@ -604,6 +639,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.epi_tile,
             self.tile_sched_params,
             epilogue_op,
+            c_tensor,
+            self.epi_layout_atomic if self.split_k > 1 else cute.make_layout(1),
         ).launch(
             grid=grid,
             block=[self.threads_per_cta, 1, 1],
@@ -640,6 +677,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         epi_tile: cute.Tile,
         tile_sched_params: utils.PersistentTileSchedulerParams,
         epilogue_op: cutlass.Constexpr,
+        mC_raw: cute.Tensor,
+        epi_layout_atomic: cute.Layout,
     ):
         """
         GPU device kernel performing the Persistent batched GEMM computation.
@@ -790,7 +829,11 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         gC_mnl = cute.local_tile(
             mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
         )
-        k_tile_cnt = cutlass.Int32(cute.size(gA_mkl, mode=[3]))
+        k_tile_total = cute.size(gA_mkl, mode=[3])
+        k_tile_cnt = cutlass.Int32(k_tile_total)
+        # For split-K: each CTA processes k_tile_total // split_k K-tiles
+        k_tiles_per_split = k_tile_total // self.split_k
+        k_tile_cnt_local = cutlass.Int32(k_tiles_per_split)
 
         #
         # Partition global tensor for TiledMMA_A/B/C
@@ -903,10 +946,17 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             while work_tile.is_valid_tile:
                 # Get tile coord from tile scheduler
                 cur_tile_coord = work_tile.tile_idx
+
+                # Split-K: decompose L coord into batch_idx and split_k_idx
+                # Input tensors use batch_idx for L; K-tiles offset by k_start
+                # For split_k=1: batch_idx = coord[2], k_start = 0
+                batch_idx = cur_tile_coord[2] // self.split_k
+                k_start = (cur_tile_coord[2] % self.split_k) * k_tile_cnt_local
+
                 mma_tile_coord_mnl = (
                     cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
                     cur_tile_coord[1],
-                    cur_tile_coord[2],
+                    batch_idx,
                 )
 
                 #
@@ -930,92 +980,92 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 # Prefetch logic: use_prefetch for both A&B, or explicit A-only/B-only
                 if self.use_prefetch:
                     # Prefetch both A and B (default behavior)
-                    for k_tile in cutlass.range(0, min(prefetch_dist, k_tile_cnt), unroll=1):
+                    for k_tile in cutlass.range(0, min(prefetch_dist, k_tile_cnt_local), unroll=1):
                         # Prefetch both A and B (default behavior)
                         cute.prefetch(
                             tma_atom_a,
-                            tAgA_slice[(None, k_tile)],
+                            tAgA_slice[(None, k_tile + k_start)],
                         )
                         cute.prefetch(
                             tma_atom_b,
-                            tBgB_slice[(None, k_tile)],
+                            tBgB_slice[(None, k_tile + k_start)],
                         )
                         cute.prefetch(
                             tma_atom_sfa,
-                            tAgSFA_slice[(None, k_tile)],
+                            tAgSFA_slice[(None, k_tile + k_start)],
                         )
                         cute.prefetch(
                             tma_atom_sfb,
-                            tBgSFB_slice[(None, k_tile)],
+                            tBgSFB_slice[(None, k_tile + k_start)],
                         )
 
                 # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt
                 ab_producer_state.reset_count()
                 peek_ab_empty_status = cutlass.Boolean(1)
-                if ab_producer_state.count < k_tile_cnt:
+                if ab_producer_state.count < k_tile_cnt_local:
                     peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
                 #
                 # Tma load loop
                 #
-                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                for k_tile in cutlass.range(0, k_tile_cnt_local, 1, unroll=1):
                     # Conditionally wait for AB buffer empty
                     ab_pipeline.producer_acquire(ab_producer_state, peek_ab_empty_status)
 
-                    # TMA load A/B/SFA/SFB
+                    # TMA load A/B/SFA/SFB (offset by k_start for split-K)
                     cute.copy(
                         tma_atom_a,
-                        tAgA_slice[(None, ab_producer_state.count)],
+                        tAgA_slice[(None, ab_producer_state.count + k_start)],
                         tAsA[(None, ab_producer_state.index)],
                         tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
                         mcast_mask=a_full_mcast_mask,
                     )
                     cute.copy(
                         tma_atom_b,
-                        tBgB_slice[(None, ab_producer_state.count)],
+                        tBgB_slice[(None, ab_producer_state.count + k_start)],
                         tBsB[(None, ab_producer_state.index)],
                         tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
                         mcast_mask=b_full_mcast_mask,
                     )
                     cute.copy(
                         tma_atom_sfa,
-                        tAgSFA_slice[(None, ab_producer_state.count)],
+                        tAgSFA_slice[(None, ab_producer_state.count + k_start)],
                         tAsSFA[(None, ab_producer_state.index)],
                         tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
                         mcast_mask=sfa_full_mcast_mask,
                     )
                     cute.copy(
                         tma_atom_sfb,
-                        tBgSFB_slice[(None, ab_producer_state.count)],
+                        tBgSFB_slice[(None, ab_producer_state.count + k_start)],
                         tBsSFB[(None, ab_producer_state.index)],
                         tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
                         mcast_mask=sfb_full_mcast_mask,
                     )
 
                     # Prefetch logic in the loop: use_prefetch for both A&B, or explicit A-only/B-only
-                    if k_tile < k_tile_cnt - prefetch_dist:
+                    if k_tile < k_tile_cnt_local - prefetch_dist:
                         if self.use_prefetch:
                             # Prefetch both A and B (default behavior)
                             cute.prefetch(
                                 tma_atom_a,
-                                tAgA_slice[(None, ab_producer_state.count + prefetch_dist)],
+                                tAgA_slice[(None, ab_producer_state.count + k_start + prefetch_dist)],
                             )
                             cute.prefetch(
                                 tma_atom_b,
-                                tBgB_slice[(None, ab_producer_state.count + prefetch_dist)],
+                                tBgB_slice[(None, ab_producer_state.count + k_start + prefetch_dist)],
                             )
                             cute.prefetch(
                                 tma_atom_sfa,
-                                tAgSFA_slice[(None, ab_producer_state.count + prefetch_dist)],
+                                tAgSFA_slice[(None, ab_producer_state.count + k_start + prefetch_dist)],
                             )
                             cute.prefetch(
                                 tma_atom_sfb,
-                                tBgSFB_slice[(None, ab_producer_state.count + prefetch_dist)],
+                                tBgSFB_slice[(None, ab_producer_state.count + k_start + prefetch_dist)],
                             )
 
                     # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt + k_tile + 1
                     ab_producer_state.advance()
                     peek_ab_empty_status = cutlass.Boolean(1)
-                    if ab_producer_state.count < k_tile_cnt:
+                    if ab_producer_state.count < k_tile_cnt_local:
                         peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
 
                 #
@@ -1129,17 +1179,18 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 # Peek (try_wait) AB buffer full for k_tile = 0
                 ab_consumer_state.reset_count()
                 peek_ab_full_status = cutlass.Boolean(1)
-                if ab_consumer_state.count < k_tile_cnt and is_leader_cta:
+                if ab_consumer_state.count < k_tile_cnt_local and is_leader_cta:
                     peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
 
                 #
                 # Mma mainloop with expert grouping
                 # Accumulate tiles_per_expert k-tiles per acc buffer to halve
                 # acc pipeline traffic (512 → 256 round-trips).
+                # For split-K: only process k_tiles_per_split K-tiles (a subset of experts).
                 #
                 tiles_per_expert_mma = self.weight_per_expert // self.mma_tiler[2]
                 tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
-                for k_tile in range(k_tile_cnt):
+                for k_tile in range(k_tiles_per_split):
                     is_first_of_expert = (k_tile % tiles_per_expert_mma == 0)
                     is_last_of_expert = (
                         k_tile % tiles_per_expert_mma == tiles_per_expert_mma - 1
@@ -1220,7 +1271,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
                     ab_consumer_state.advance()
                     peek_ab_full_status = cutlass.Boolean(1)
-                    if ab_consumer_state.count < k_tile_cnt:
+                    if ab_consumer_state.count < k_tile_cnt_local:
                         if is_leader_cta:
                             peek_ab_full_status = (
                                 ab_pipeline.consumer_try_wait(ab_consumer_state)
@@ -1309,19 +1360,28 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             )
 
             tiles_per_expert = self.weight_per_expert // self.mma_tiler[2]
+            # For split-K: each CTA handles experts_per_split experts
+            experts_per_split = k_tiles_per_split // tiles_per_expert
             m_total = malpha_scale_mnl.shape[0]
 
             while work_tile.is_valid_tile:
                 # Get tile coord from tile scheduler
                 cur_tile_coord = work_tile.tile_idx
+
+                # Split-K: decompose L coord into batch_idx and split_k_idx
+                # For split_k=1: batch_idx = coord[2], expert_offset = 0
+                batch_idx = cur_tile_coord[2] // self.split_k
+                expert_offset = (cur_tile_coord[2] % self.split_k) * experts_per_split
+
+                # Use batch_idx for output L coordinate (correct for both split_k=1 and >1)
                 mma_tile_coord_mnl = (
                     cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
                     cur_tile_coord[1],
-                    cur_tile_coord[2],
+                    batch_idx,
                 )
 
                 #
-                # Slice to per mma tile index
+                # Slice to per mma tile index (for TMA store path)
                 #
                 # ((ATOM_V, REST_V), EPI_M, EPI_N)
                 bSG_gC = bSG_gC_partitioned[
@@ -1336,9 +1396,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 # initialize the final accumulator
                 tTR_rAcc_final.fill(0.0)
 
-                # Epilogue iterates over experts (not k-tiles) since MMA
-                # accumulates tiles_per_expert k-tiles per acc buffer.
-                num_experts_k = k_tile_cnt // tiles_per_expert
+                # Epilogue iterates over experts_per_split experts (not full expert_count)
+                num_experts_k = cutlass.Int32(experts_per_split)
 
                 acc_consumer_state.reset_count()
                 peek_acc_full_status = cutlass.Boolean(1)
@@ -1346,15 +1405,14 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                     peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
 
                 m_start = cur_tile_coord[0] * self.cta_tile_shape_mnk[0]
-                batch_idx = cur_tile_coord[2]
                 m_in_bounds = m_start < m_total
                 thread_in_bounds = epi_tidx < (m_total - m_start) if m_in_bounds else False
 
-                # Prologue: prefetch alpha for expert 0
+                # Prologue: prefetch alpha for first expert in this split
                 prefetched_alpha = cutlass.Float32(0.0)
                 if thread_in_bounds:
                     prefetched_alpha = galpha_scale_mnl[
-                        epi_tidx, cur_tile_coord[0], cutlass.Int32(0), batch_idx
+                        epi_tidx, cur_tile_coord[0], expert_offset, batch_idx
                     ]
 
                 for expert_idx in cutlass.range(num_experts_k):
@@ -1403,7 +1461,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                     prefetched_alpha = cutlass.Float32(0.0)
                     if thread_in_bounds:
                         prefetched_alpha = galpha_scale_mnl[
-                            epi_tidx, cur_tile_coord[0], clamped_expert, batch_idx
+                            epi_tidx, cur_tile_coord[0], expert_offset + clamped_expert, batch_idx
                         ]
 
                     peek_acc_full_status = cutlass.Boolean(1)
@@ -1413,52 +1471,90 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 #
                 # Store accumulator to global memory in subtiles
                 #
-                bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
-
                 subtile_cnt = cute.size(tTR_rAcc_final.shape, mode=[3])
-                num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
-                for subtile_idx in cutlass.range(subtile_cnt):
-                    #
-                    # Store accumulator to shared memory or global memory
-                    #
-                    tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
 
+                if cutlass.const_expr(self.split_k > 1):
                     #
-                    # Convert to C type
+                    # Split-K atomic add path: each CTA atomically adds its
+                    # partial result directly to the output C tensor.
+                    # Guard with M bounds check to avoid OOB writes when
+                    # M is not a multiple of tile_M.
                     #
-                    acc_vec = tiled_copy_r2s.retile(tTR_rAcc_subtile).load()
-                    acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
-                    tRS_rC.store(acc_vec)
-
-                    #
-                    # Store C to shared memory
-                    #
-                    c_buffer = (num_prev_subtiles + subtile_idx) % self.num_c_stage
-                    cute.copy(
-                        tiled_copy_r2s,
-                        tRS_rC,
-                        tRS_sC[(None, None, None, c_buffer)],
+                    rOut_epi = cute.make_tensor(
+                        tTR_rC.iterator, epi_layout_atomic
                     )
-                    # Fence and barrier to make sure shared memory store is visible to TMA store
-                    cute.arch.fence_proxy(
-                        cute.arch.ProxyKind.async_shared,
-                        space=cute.arch.SharedSpace.shared_cta,
+                    m_coord = cur_tile_coord[0] * self.cta_tile_shape_mnk[0] + epi_tidx
+                    scatter_base = cute.domain_offset(
+                        (m_coord, 0, batch_idx), mC_raw
                     )
-                    self.epilog_sync_barrier.arrive_and_wait()
 
+                    if thread_in_bounds:
+                        for subtile_idx in cutlass.range(subtile_cnt):
+                            tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                            acc_vec = tTR_rAcc_subtile.load()
+                            acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                            tTR_rC.store(acc_vec)
+
+                            base_coord_n = (
+                                cur_tile_coord[1] * self.cta_tile_shape_mnk[1]
+                                + subtile_idx * cute.size(tTR_rC)
+                            )
+
+                            for index in cutlass.range(
+                                self.epi_loop_size_atomic, unroll_full=True
+                            ):
+                                coord_n = base_coord_n + index * self.element_offset_atomic
+                                scatter_out = cute.domain_offset(
+                                    (0, coord_n, 0), scatter_base
+                                )
+                                if cutlass.const_expr(self.c_dtype == cutlass.Float16):
+                                    vectorized_atomic_add_fp16x8(
+                                        rOut_epi[index, None, None], scatter_out
+                                    )
+                                elif cutlass.const_expr(self.c_dtype == cutlass.BFloat16):
+                                    vectorized_atomic_add_bf16x8(
+                                        rOut_epi[index, None, None], scatter_out
+                                    )
+                                elif cutlass.const_expr(self.c_dtype == cutlass.Float32):
+                                    vectorized_atomic_add_fp32x2(
+                                        rOut_epi[index, None], scatter_out
+                                    )
+                                else:
+                                    atomic_add_func(rOut_epi[index], scatter_out)
+                else:
                     #
-                    # TMA store C to global memory
+                    # Standard TMA store path (split_k=1)
                     #
-                    if warp_idx == self.epilog_warp_id[0]:
+                    bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+                    num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+                    for subtile_idx in cutlass.range(subtile_cnt):
+                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+
+                        acc_vec = tiled_copy_r2s.retile(tTR_rAcc_subtile).load()
+                        acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                        tRS_rC.store(acc_vec)
+
+                        c_buffer = (num_prev_subtiles + subtile_idx) % self.num_c_stage
                         cute.copy(
-                            tma_atom_c,
-                            bSG_sC[(None, c_buffer)],
-                            bSG_gC[(None, subtile_idx)],
+                            tiled_copy_r2s,
+                            tRS_rC,
+                            tRS_sC[(None, None, None, c_buffer)],
                         )
-                        # Fence and barrier to make sure shared memory store is visible to TMA store
-                        c_pipeline.producer_commit()
-                        c_pipeline.producer_acquire()
-                    self.epilog_sync_barrier.arrive_and_wait()
+                        cute.arch.fence_proxy(
+                            cute.arch.ProxyKind.async_shared,
+                            space=cute.arch.SharedSpace.shared_cta,
+                        )
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                        if warp_idx == self.epilog_warp_id[0]:
+                            cute.copy(
+                                tma_atom_c,
+                                bSG_sC[(None, c_buffer)],
+                                bSG_gC[(None, subtile_idx)],
+                            )
+                            c_pipeline.producer_commit()
+                            c_pipeline.producer_acquire()
+                        self.epilog_sync_barrier.arrive_and_wait()
                 #
                 # Advance to next tile
                 #
@@ -1472,9 +1568,10 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.epilog_sync_barrier.arrive_and_wait()
             tmem.free(acc_tmem_ptr)
             #
-            # Wait for C store complete
+            # Wait for C store complete (only needed for TMA store path)
             #
-            c_pipeline.producer_tail()
+            if cutlass.const_expr(self.split_k <= 1):
+                c_pipeline.producer_tail()
 
     def mainloop_s2t_copy_and_partition(
         self,
@@ -1792,6 +1889,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         cta_tile_shape_mnk: Tuple[int, int, int],
         cluster_shape_mn: Tuple[int, int],
         max_active_clusters: cutlass.Constexpr,
+        split_k: int = 1,
     ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
         """Use persistent tile scheduler to compute the grid size for the output tensor C.
 
@@ -1803,6 +1901,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :type cluster_shape_mn: tuple[int, int]
         :param max_active_clusters: Maximum number of active clusters.
         :type max_active_clusters: cutlass.Constexpr
+        :param split_k: Split-K factor to inflate L dimension.
+        :type split_k: int
 
         :return: A tuple containing:
             - tile_sched_params: Parameters for the persistent tile scheduler.
@@ -1812,6 +1912,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         c_shape = cute.slice_(cta_tile_shape_mnk, (None, None, 0))
         gc = cute.zipped_divide(c, tiler=c_shape)
         num_ctas_mnl = gc[(0, (None, None, None))].shape
+        if split_k > 1:
+            num_ctas_mnl = (num_ctas_mnl[0], num_ctas_mnl[1], num_ctas_mnl[2] * split_k)
         cluster_shape_mnl = (*cluster_shape_mn, 1)
 
         tile_sched_params = utils.PersistentTileSchedulerParams(num_ctas_mnl, cluster_shape_mnl)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
@@ -356,27 +356,23 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 self.epi_loop_size_atomic = self.ttr_racc_size // 2
                 self.element_offset_atomic = 2
             else:
-                self.epi_layout_atomic = cute.make_layout(
-                    shape=(self.ttr_racc_size,), stride=(1,)
-                )
+                self.epi_layout_atomic = cute.make_layout(shape=(self.ttr_racc_size,), stride=(1,))
                 self.epi_loop_size_atomic = self.ttr_racc_size
                 self.element_offset_atomic = 1
 
         # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
-        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = (
-            self._compute_stages(
-                tiled_mma,
-                self.mma_tiler,
-                self.a_dtype,
-                self.b_dtype,
-                self.epi_tile,
-                self.c_dtype,
-                self.c_layout,
-                self.sf_dtype,
-                self.sf_vec_size,
-                self.smem_capacity,
-                self.occupancy,
-            )
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.smem_capacity,
+            self.occupancy,
         )
         # Compute A/B/SFA/SFB/C shared memory layout
         self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
@@ -612,6 +608,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)],
                 self.buffer_align_bytes,
             ]
+
         self.shared_storage = SharedStorage
 
         # Launch the kernel synchronously
@@ -830,7 +827,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
         )
         k_tile_total = cute.size(gA_mkl, mode=[3])
-        k_tile_cnt = cutlass.Int32(k_tile_total)
         # For split-K: each CTA processes k_tile_total // split_k K-tiles
         k_tiles_per_split = k_tile_total // self.split_k
         k_tile_cnt_local = cutlass.Int32(k_tiles_per_split)
@@ -1047,19 +1043,27 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             # Prefetch both A and B (default behavior)
                             cute.prefetch(
                                 tma_atom_a,
-                                tAgA_slice[(None, ab_producer_state.count + k_start + prefetch_dist)],
+                                tAgA_slice[
+                                    (None, ab_producer_state.count + k_start + prefetch_dist)
+                                ],
                             )
                             cute.prefetch(
                                 tma_atom_b,
-                                tBgB_slice[(None, ab_producer_state.count + k_start + prefetch_dist)],
+                                tBgB_slice[
+                                    (None, ab_producer_state.count + k_start + prefetch_dist)
+                                ],
                             )
                             cute.prefetch(
                                 tma_atom_sfa,
-                                tAgSFA_slice[(None, ab_producer_state.count + k_start + prefetch_dist)],
+                                tAgSFA_slice[
+                                    (None, ab_producer_state.count + k_start + prefetch_dist)
+                                ],
                             )
                             cute.prefetch(
                                 tma_atom_sfb,
-                                tBgSFB_slice[(None, ab_producer_state.count + k_start + prefetch_dist)],
+                                tBgSFB_slice[
+                                    (None, ab_producer_state.count + k_start + prefetch_dist)
+                                ],
                             )
 
                     # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt + k_tile + 1
@@ -1191,23 +1195,17 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 tiles_per_expert_mma = self.weight_per_expert // self.mma_tiler[2]
                 tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
                 for k_tile in range(k_tiles_per_split):
-                    is_first_of_expert = (k_tile % tiles_per_expert_mma == 0)
-                    is_last_of_expert = (
-                        k_tile % tiles_per_expert_mma == tiles_per_expert_mma - 1
-                    )
+                    is_first_of_expert = k_tile % tiles_per_expert_mma == 0
+                    is_last_of_expert = k_tile % tiles_per_expert_mma == tiles_per_expert_mma - 1
 
                     if is_first_of_expert:
-                        tCtAcc = tCtAcc_base[
-                            (None, None, None, acc_producer_state.index)
-                        ]
+                        tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
 
                     if is_leader_cta:
                         if is_first_of_expert:
                             acc_pipeline.producer_acquire(acc_producer_state)
 
-                        ab_pipeline.consumer_wait(
-                            ab_consumer_state, peek_ab_full_status
-                        )
+                        ab_pipeline.consumer_wait(ab_consumer_state, peek_ab_full_status)
 
                         s2t_stage_coord = (
                             None,
@@ -1216,12 +1214,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             None,
                             ab_consumer_state.index,
                         )
-                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[
-                            s2t_stage_coord
-                        ]
-                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[
-                            s2t_stage_coord
-                        ]
+                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[s2t_stage_coord]
+                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[s2t_stage_coord]
                         cute.copy(
                             tiled_copy_s2t_sfa,
                             tCsSFA_compact_s2t_staged,
@@ -1237,9 +1231,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
 
                         num_kblocks = cute.size(tCrA, mode=[2])
-                        for kblock_idx in cutlass.range(
-                            num_kblocks, unroll_full=True
-                        ):
+                        for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
                             kblock_coord = (
                                 None,
                                 None,
@@ -1273,9 +1265,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                     peek_ab_full_status = cutlass.Boolean(1)
                     if ab_consumer_state.count < k_tile_cnt_local:
                         if is_leader_cta:
-                            peek_ab_full_status = (
-                                ab_pipeline.consumer_try_wait(ab_consumer_state)
-                            )
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
 
                     if is_last_of_expert:
                         if is_leader_cta:
@@ -1457,7 +1447,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
                     # Prefetch next expert's alpha after releasing acc buffer
                     next_expert = expert_idx + 1
-                    clamped_expert = next_expert if next_expert < num_experts_k else num_experts_k - 1
+                    clamped_expert = (
+                        next_expert if next_expert < num_experts_k else num_experts_k - 1
+                    )
                     prefetched_alpha = cutlass.Float32(0.0)
                     if thread_in_bounds:
                         prefetched_alpha = galpha_scale_mnl[
@@ -1480,13 +1472,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                     # Guard with M bounds check to avoid OOB writes when
                     # M is not a multiple of tile_M.
                     #
-                    rOut_epi = cute.make_tensor(
-                        tTR_rC.iterator, epi_layout_atomic
-                    )
+                    rOut_epi = cute.make_tensor(tTR_rC.iterator, epi_layout_atomic)
                     m_coord = cur_tile_coord[0] * self.cta_tile_shape_mnk[0] + epi_tidx
-                    scatter_base = cute.domain_offset(
-                        (m_coord, 0, batch_idx), mC_raw
-                    )
+                    scatter_base = cute.domain_offset((m_coord, 0, batch_idx), mC_raw)
 
                     if thread_in_bounds:
                         for subtile_idx in cutlass.range(subtile_cnt):
@@ -1495,18 +1483,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
                             tTR_rC.store(acc_vec)
 
-                            base_coord_n = (
-                                cur_tile_coord[1] * self.cta_tile_shape_mnk[1]
-                                + subtile_idx * cute.size(tTR_rC)
-                            )
+                            base_coord_n = cur_tile_coord[1] * self.cta_tile_shape_mnk[
+                                1
+                            ] + subtile_idx * cute.size(tTR_rC)
 
-                            for index in cutlass.range(
-                                self.epi_loop_size_atomic, unroll_full=True
-                            ):
+                            for index in cutlass.range(self.epi_loop_size_atomic, unroll_full=True):
                                 coord_n = base_coord_n + index * self.element_offset_atomic
-                                scatter_out = cute.domain_offset(
-                                    (0, coord_n, 0), scatter_base
-                                )
+                                scatter_out = cute.domain_offset((0, coord_n, 0), scatter_base)
                                 if cutlass.const_expr(self.c_dtype == cutlass.Float16):
                                     vectorized_atomic_add_fp16x8(
                                         rOut_epi[index, None, None], scatter_out
@@ -1516,9 +1499,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                         rOut_epi[index, None, None], scatter_out
                                     )
                                 elif cutlass.const_expr(self.c_dtype == cutlass.Float32):
-                                    vectorized_atomic_add_fp32x2(
-                                        rOut_epi[index, None], scatter_out
-                                    )
+                                    vectorized_atomic_add_fp32x2(rOut_epi[index, None], scatter_out)
                                 else:
                                     atomic_add_func(rOut_epi[index], scatter_out)
                 else:

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/utils.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/utils.py
@@ -257,6 +257,28 @@ def vectorized_atomic_add_bf16x8(rOut_epi_packed,
 
 
 @dsl_user_op
+def vectorized_atomic_add_fp16x8(rOut_epi_packed,
+                                 scatter_out_offset,
+                                 loc=None,
+                                 ip=None):
+    llvm.inline_asm(
+        None,
+        [
+            scatter_out_offset.iterator.llvm_ptr,
+            llvm.bitcast(T.i32(), rOut_epi_packed[0, None].load().ir_value()),
+            llvm.bitcast(T.i32(), rOut_epi_packed[1, None].load().ir_value()),
+            llvm.bitcast(T.i32(), rOut_epi_packed[2, None].load().ir_value()),
+            llvm.bitcast(T.i32(), rOut_epi_packed[3, None].load().ir_value()),
+        ],
+        "red.global.v4.f16x2.add.noftz [$0], {$1, $2, $3, $4};",
+        "l,r,r,r,r",
+        has_side_effects=True,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
 def vectorized_atomic_add_fp32x2(rOut_epi_packed,
                                  scatter_out_offset,
                                  loc=None,
@@ -299,6 +321,19 @@ def atomic_add_func(rOut_epi_packed, scatter_out_offset, loc=None, ip=None):
                 llvm.bitcast(T.i16(), rOut_epi_packed.ir_value()),
             ],
             "red.add.noftz.bf16 [$0], $1;",
+            "l,h",
+            has_side_effects=True,
+            loc=loc,
+            ip=ip,
+        )
+    elif cutlass.const_expr(rOut_epi_packed.dtype == cutlass.Float16):
+        llvm.inline_asm(
+            None,
+            [
+                scatter_out_offset.iterator.llvm_ptr,
+                llvm.bitcast(T.i16(), rOut_epi_packed.ir_value()),
+            ],
+            "red.add.noftz.f16 [$0], $1;",
             "l,h",
             has_side_effects=True,
             loc=loc,

--- a/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
+++ b/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
@@ -102,6 +102,7 @@ def run(
     skip_ref_check: bool = False,
     use_cold_l2: bool = False,
     use_cupti: bool = True,
+    split_k: int = 1,
     **kwargs,
 ):
     """Execute a persistent batched dense blockscaled GEMM operation on Blackwell architecture.
@@ -164,6 +165,7 @@ def run(
     print(f"Skip reference checking: {skip_ref_check}")
     print(f"Use cold L2: {'True' if use_cold_l2 else 'False'}")
     print(f"Use CUPTI: {'True' if use_cupti else 'False'}")
+    print(f"Split-K: {split_k}")
 
     # Skip unsupported testcase
     if not Sm100BlockScaledPersistentDenseGemmKernel.can_implement(
@@ -350,7 +352,12 @@ def run(
         weight_per_expert,
         use_prefetch,
         prefetch_dist,
+        split_k,
     )
+
+    # For split-K > 1: zero-initialize C (kernel uses atomic add for reduction)
+    if split_k > 1:
+        c_torch.zero_()
 
     # Compute max active clusters on current device
     hardware_info = cutlass.utils.HardwareInfo()
@@ -438,9 +445,12 @@ def run(
         b_tensor, _ = cutlass_torch.cute_tensor_like(
             b_ref, ab_dtype, is_dynamic_layout=True, assumed_align=16
         )
-        c_tensor, _ = cutlass_torch.cute_tensor_like(
+        c_tensor, c_torch_gen = cutlass_torch.cute_tensor_like(
             c_ref, c_dtype, is_dynamic_layout=True, assumed_align=16
         )
+        # Zero-init C for split-K (atomic adds accumulate onto initial values)
+        if split_k > 1:
+            c_torch_gen.zero_()
 
         # Mark tensor to be byte aligned
         a_tensor.mark_compact_shape_dynamic(
@@ -575,6 +585,12 @@ if __name__ == "__main__":
         default=True,
         help="Use CUPTI for profiling (default: True)",
     )
+    parser.add_argument(
+        "--split_k",
+        type=int,
+        default=1,
+        help="Split-K factor (default: 1)",
+    )
     args = parser.parse_args()
 
     if len(args.mnkl) != 4:
@@ -606,6 +622,7 @@ if __name__ == "__main__":
         args.skip_ref_check,
         args.use_cold_l2,
         args.use_cupti,
+        args.split_k,
     )
     print(f"Execution time: {exec_time:.2f} us")
     print("PASS")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `split_k` parameter support for dense GEMM kernel tuning, enabling finer-grained parallelization strategies.
  * Expanded kernel candidate search space with additional MMA tile and cluster shape options for improved optimization coverage.
  * Enhanced atomic operation support for FP16 data types in kernel operations.

* **Bug Fixes**
  * Improved kernel accumulation handling for split-K scenarios with atomic reduction support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Optimizes the MoE DenseGEMM FC2 CuTe DSL kernel (`fc2.py`) by removing the dedicated alpha-scale pipeline, enabling 2CTA MMA configuration in the autotuner, and adding split‑K support in the benchmark.

### Kernel changes (`fc2.py`)
1. **Remove alpha-scale pipeline**: Eliminates the 10‑stage `PipelineCpAsync` alpha-scale pipeline, its dedicated warp (warp 6), dummy warp (warp 7), and all associated SMEM buffers. Alpha values are now loaded directly from GMEM in the epilogue with a prefetch pattern, reducing CTA thread count from 256 to 192.
2. **Expert‑grouped MMA accumulation**: The MMA mainloop now accumulates `tiles_per_expert` k‑tiles (2 tiles per expert) within a single accumulator buffer before committing, halving the acc pipeline round‑trips (from 512 to 256 for the target shape).
3. **Expert‑iterated epilogue**: The epilogue loop iterates over `num_experts` instead of `k_tile_cnt`, loading alpha once per expert instead of once per k‑tile, reducing redundant GMEM alpha loads by 2x.
4. **Increase `num_acc_stage` from 2 to 3**: Allows MMA to run further ahead of the epilogue, improving pipeline overlap.
5. **Free SMEM budget**: Removing the alpha pipeline frees ~5KB SMEM, enabling more A/B pipeline stages and — critically — making the `(256,128) cluster=(2,1)` 2CTA MMA configuration viable (previously crashed due to SMEM overflow).

### Autotuner changes (`cute_dsl_custom_ops.py`)
- Add `(256, 128)` to `mma_tiler_mn_candidates` for the FC2 runner.
- Add `(2, 1)` to `cluster_shape_mn_candidates` to enable B‑multicast via 2CTA clustering.
- This enables the 2CTA MMA + B‑multicast config, which is the optimal configuration for M≥128 in the FC2 shape (A[M,65536] × B[7168,65536]).

### Benchmark script (`run_moe_as_dense_gemm_fc2.py`)
- Add `split_k` option and pass it through to the kernel.
- For split‑K, initialize C to zero before atomic‑add accumulation.

## Performance (CUPTI, B200, cold L2, warmup=10, iter=50)

**Config `(128,128) cluster=(1,1)`**
| M | Before (us) | After (us) | Speedup |
|---|---|---|---|
| 128 | 76.54 | 75.94 | 1.01x |
| 256 | 80.59 | 76.48 | **1.05x** |
| 288 | 151.40 | 138.26 | **1.09x** |
| 384 | 152.01 | 142.82 | **1.06x** |

**Config `(128,64) cluster=(1,1)`**
| M | Before (us) | After (us) | Speedup |
|---|---|---|---|
| 128 | 65.80 | 62.63 | **1.05x** |
| 192 | 127.81 | 111.89 | **1.14x** |
| 288 | 190.41 | 162.79 | **1.17x** |
| 384 | 190.97 | 169.95 | **1.12x** |

**Config `(256,128) cluster=(2,1)` — NEW, only works after this change**
| M | After (us) | TFLOPS |
|---|---|---|
| 128 | 70.22 | 1712.7 |
| 256 | 72.43 | 3320.5 |
| 288 | 133.01 | 2034.2 |
| 384 | 135.64 | 2659.9 |

The previous code crashes with illegal memory access on `(256,128) cluster=(2,1)` because the `PipelineCpAsync` alpha pipeline does not support 2CTA cluster barrier semantics.

---

## Split‑K perf sweep (B200, N=7168 K=65536 L=1, expert=256, warmup=10, iter=50, skip_ref_check)

CUPTI intermittently failed for `split_k=2/4` with tile `(256,128) cluster=(2,1)` at `M=32/64`; marked as `NA`.

### split_k=1 (us)
| M | 128x128 c1,1 | 128x64 c1,1 | 256x128 c2,1 |
|---|---:|---:|---:|
| 32  | 74.26 | 59.27 | 69.97 |
| 64  | 74.85 | 60.70 | 69.92 |
| 96  | 75.21 | 62.02 | 70.66 |
| 128 | 76.97 | 64.03 | 72.88 |
| 160 | 76.40 | 116.13 | 72.41 |
| 192 | 76.71 | 115.90 | 72.92 |
| 224 | 76.87 | 116.27 | 73.07 |
| 256 | 77.82 | 118.48 | 75.00 |
| 288 | 140.94 | 167.61 | 138.24 |
| 320 | 140.93 | 168.57 | 137.67 |
| 352 | 142.15 | 170.07 | 138.76 |
| 384 | 145.75 | 174.87 | 140.39 |

### split_k=2 (us)
| M | 128x128 c1,1 | 128x64 c1,1 | 256x128 c2,1 |
|---|---:|---:|---:|
| 32  | 52.37 | 63.46 | 71.27 |
| 64  | 52.46 | 63.33 | 72.59 |
| 96  | 52.39 | 63.27 | 75.47 |
| 128 | 54.68 | 65.45 | 77.51 |
| 160 | 82.95 | 117.47 | 77.28 |
| 192 | 82.75 | 117.18 | 77.65 |
| 224 | 83.02 | 118.41 | 78.33 |
| 256 | 83.72 | 121.96 | 79.52 |
| 288 | 115.64 | 139.56 | 146.36 |
| 320 | 115.36 | 140.35 | 146.73 |
| 352 | 116.17 | 141.27 | 148.25 |
| 384 | 118.60 | 144.70 | 150.61 |

### split_k=4 (us)
| M | 128x128 c1,1 | 128x64 c1,1 | 256x128 c2,1 |
|---|---:|---:|---:|
| 32  | 56.76 | 66.43 | 73.62 |
| 64  | 56.52 | 66.65 | 75.73 |
| 96  | 55.83 | 66.17 | 79.48 |
| 128 | 57.34 | 69.85 | 83.43 |
| 160 | 87.70 | 103.33 | 81.76 |
| 192 | 87.50 | 104.17 | 82.08 |
| 224 | 88.46 | 104.14 | 82.72 |
| 256 | 89.84 | 107.74 | 84.74 |
| 288 | 102.52 | 142.82 | 130.29 |
| 320 | 102.68 | 142.88 | 131.23 |
| 352 | 104.00 | 144.23 | 132.10 |
| 384 | 105.76 | 148.22 | 135.69 |

## Test Coverage
- Existing unit tests in `tests/unittest/_torch/thop/parallel/test_moe_densegemm.py` cover functional correctness.
- Existing test script `tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py` covers performance benchmarking across M=32..384 with configurable tile/cluster settings.
- The `can_implement` guard in `fc2.py` already validates `(256,128)+(2,1)` as a legal tactic; no new validation code needed.

## PR Checklist
- [x] Please check this after reviewing the above items as appropriate for this PR.