### PR TITLE
[None][feat] Add radix tree cache priority boost and store chunked context blocks

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/evictionPolicy.h
+++ b/cpp/include/tensorrt_llm/batch_manager/evictionPolicy.h
@@ -45,6 +45,9 @@ public:
     virtual void releaseBlock(BlockPtr block, bool toFront) = 0;
     /// @brief Get the amount of free blocks in the primary memory pool
     virtual SizeType32 getNumFreeBlocks(SizeType32 cacheLevel) = 0;
+    /// @brief Get the amount of free blocks in the primary memory pool that are NOT in the radix tree
+    /// (i.e. blocks at priority < kRadixTreeBlockPriority that will be evicted before cached blocks)
+    virtual SizeType32 getNumTrulyFreeBlocks(SizeType32 cacheLevel) = 0;
     /// @brief Claim a free block. Called when the cache manager allocates or reuses a new block
     virtual void claimBlock(BlockPtr block) = 0;
     virtual void claimBlock(BlockPtr block, std::optional<executor::RetentionPriority> priority,
@@ -78,6 +81,7 @@ public:
     void releaseBlock(BlockPtr block, bool toFront) override;
 
     SizeType32 getNumFreeBlocks(SizeType32 cacheLevel) override;
+    SizeType32 getNumTrulyFreeBlocks(SizeType32 cacheLevel) override;
 
     void claimBlock(BlockPtr block) override;
     void claimBlock(BlockPtr block, std::optional<executor::RetentionPriority> priority,

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -641,6 +641,16 @@ public:
 
     void storeNewBlock(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest);
 
+    //! \brief Store full blocks from a completed context chunk for early reuse.
+    //! \details Makes blocks reusable immediately so concurrent requests sharing the same
+    //! prefix can find them before the full context finishes processing. SWA windows are
+    //! skipped because their block boundaries shift as the context grows.
+    //! \param sequence The generation request whose chunk just completed.
+    //! \param llmRequest The LLM request with token data and metadata.
+    //! \param processedTokens Token count after the chunk end (i.e. getContextCurrentPosition()).
+    void storeChunkedContextBlocks(
+        GenerationRequest& sequence, LlmRequest const& llmRequest, SizeType32 processedTokens);
+
     //! \brief Pin blocks associated with a sequence to prevent eviction.
     void pinBlocks(GenerationRequest& sequence);
 
@@ -681,6 +691,7 @@ public:
 
     // Get num free blocks in the primary memory pool
     [[nodiscard]] SizeType32 getNumFreeBlocks() const noexcept;
+    [[nodiscard]] SizeType32 getNumTrulyFreeBlocks() const noexcept;
 
     [[nodiscard]] SizeType32 getNumAllocTotalBlocks() const
     {
@@ -1182,6 +1193,23 @@ public:
         return numFreeBlocksPerWindowSize;
     }
 
+    [[nodiscard]] std::map<SizeType32, SizeType32> getNumTrulyFreeBlocksPerWindowSize() const
+    {
+        std::map<SizeType32, SizeType32> result;
+        for (auto const& [windowSize, manager] : mWindowBlockManagers)
+        {
+            // In variable-window (multi-window) configs, SWA windows are excluded from
+            // the truly-free count since their eviction behavior differs from full-attention
+            // windows. In single-window configs, even SWA windows are included normally.
+            if (mIsVariableWindow && manager.isSWA())
+            {
+                continue;
+            }
+            result[windowSize] = manager.getNumTrulyFreeBlocks();
+        }
+        return result;
+    }
+
     [[nodiscard]] SizeType32 getNumFreeBlocks() const
     {
         return sumWindows([](auto const& manager) { return manager.getNumFreeBlocks(); });
@@ -1365,6 +1393,11 @@ public:
     //! \brief Store context blocks
     void storeContextBlocks(GenerationRequest& sequence, LlmRequest const& llmRequest);
 
+    //! \brief Store full blocks from a completed context chunk for early reuse.
+    //! \details Delegates to each non-SWA WindowBlockManager.
+    void storeChunkedContextBlocks(
+        GenerationRequest& sequence, LlmRequest const& llmRequest, SizeType32 processedTokens);
+
     //! \brief Store newest block for reuse
     void storeNewBlock(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest);
 
@@ -1529,6 +1562,11 @@ public:
 
     [[nodiscard]] virtual SizeType32 getNumFreeBlocks() const = 0;
 
+    [[nodiscard]] virtual std::map<SizeType32, SizeType32> getNumTrulyFreeBlocksPerWindowSize() const
+    {
+        return {};
+    }
+
     [[nodiscard]] virtual SizeType32 getNumPools() const = 0;
 
     // only used by test
@@ -1633,6 +1671,13 @@ public:
     //! \brief Store full context blocks contributed by llmRequest.
     //! \details These blocks become reusable from next step.
     virtual void storeContextBlocks(LlmRequest const& llmRequest) = 0;
+
+    //! \brief Store full blocks from a completed context chunk for early reuse.
+    //! \details Called after each non-final context chunk. Blocks become reusable
+    //! immediately, enabling prefix sharing with concurrent requests before the full
+    //! context finishes. Implementations that do not support chunked prefill may
+    //! leave this as a no-op.
+    virtual void storeChunkedContextBlocks([[maybe_unused]] LlmRequest const& llmRequest) {}
 
     //! \brief Store newest block for reuse.
     //! \details This block become reusable from next step.
@@ -1859,6 +1904,8 @@ public:
         return mBlockManager.getNumFreeBlocksPerWindowSize();
     }
 
+    [[nodiscard]] std::map<SizeType32, SizeType32> getNumTrulyFreeBlocksPerWindowSize() const override;
+
     [[nodiscard]] KvCacheStats getKvCacheStats() const override
     {
         KvCacheStats kvCacheStats;
@@ -2007,6 +2054,9 @@ public:
     //! \brief Store full context blocks contributed by llmRequest.
     //! \details These blocks become reusable from next step.
     void storeContextBlocks(LlmRequest const& llmRequest) override;
+
+    //! \brief Store full blocks from a completed context chunk for early reuse.
+    void storeChunkedContextBlocks(LlmRequest const& llmRequest) override;
 
     //! \brief Store newest blocks for reuse
     void storeNewBlock(LlmRequest const& llmRequest) override;

--- a/cpp/tensorrt_llm/batch_manager/evictionPolicy.cpp
+++ b/cpp/tensorrt_llm/batch_manager/evictionPolicy.cpp
@@ -30,6 +30,8 @@ auto const kMinPriority = executor::KvCacheRetentionConfig::kMinRetentionPriorit
 auto const kMaxPriority = executor::KvCacheRetentionConfig::kMaxRetentionPriority;
 
 auto const kDefaultPriority = executor::KvCacheRetentionConfig::kDefaultRetentionPriority;
+// No longer used for priority boosting (pinning replaced it), but kept for backward compat.
+auto const kRadixTreeBlockPriority = kDefaultPriority + 10;
 executor::RetentionPriority const kDefaultSecondaryOffloadMinPriority = 30;
 
 int const kNumCacheLevels = 2;
@@ -139,6 +141,15 @@ void LRUEvictionPolicy::releaseBlock(BlockPtr block, bool toFront)
     SizeType32 const cacheLevel = getCacheLevel(block);
     SizeType32 const id = block->getBlockId();
 
+    // Blocks in the radix tree (reusable by future requests) are boosted above the
+    // default priority so truly-free blocks are evicted first. This preserves cached
+    // data longer, increasing reuse opportunities for future requests.
+    // isShared() is only true when block reuse is enabled and the block is in the radix tree.
+    if (block->isShared() && block->getPriority() == kDefaultPriority)
+    {
+        block->setPriority(kRadixTreeBlockPriority);
+    }
+
     // If there are no children, this is a leaf block. Insert into a queue.
     auto& q = mFreeQueues[cacheLevel][getPriorityIdx(block->getPriority())];
     if (toFront)
@@ -223,6 +234,19 @@ void LRUEvictionPolicy::refresh()
         }
         block->setPriority(kDefaultPriority);
     }
+}
+
+SizeType32 LRUEvictionPolicy::getNumTrulyFreeBlocks(SizeType32 cacheLevel)
+{
+    // Count blocks at priority below kRadixTreeBlockPriority (i.e., truly empty blocks
+    // that don't hold cached radix-tree data). These are evicted before cached blocks.
+    SizeType32 count = 0;
+    auto const radixIdx = getPriorityIdx(kRadixTreeBlockPriority);
+    for (SizeType32 level = 0; level < radixIdx; ++level)
+    {
+        count += static_cast<SizeType32>(mFreeQueues[cacheLevel][level].size());
+    }
+    return count;
 }
 
 } // namespace tensorrt_llm::batch_manager::eviction_policy

--- a/cpp/tensorrt_llm/batch_manager/evictionPolicy.cpp
+++ b/cpp/tensorrt_llm/batch_manager/evictionPolicy.cpp
@@ -30,7 +30,6 @@ auto const kMinPriority = executor::KvCacheRetentionConfig::kMinRetentionPriorit
 auto const kMaxPriority = executor::KvCacheRetentionConfig::kMaxRetentionPriority;
 
 auto const kDefaultPriority = executor::KvCacheRetentionConfig::kDefaultRetentionPriority;
-// No longer used for priority boosting (pinning replaced it), but kept for backward compat.
 auto const kRadixTreeBlockPriority = kDefaultPriority + 10;
 executor::RetentionPriority const kDefaultSecondaryOffloadMinPriority = 30;
 

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -806,6 +806,23 @@ void BlockManager::storeContextBlocks(GenerationRequest& sequence, LlmRequest co
     }
 }
 
+void BlockManager::storeChunkedContextBlocks(
+    GenerationRequest& sequence, LlmRequest const& llmRequest, SizeType32 processedTokens)
+{
+    // Iterate in descending window-size order to match storeContextBlocks convention.
+    for (auto it = mWindowBlockManagers.rbegin(); it != mWindowBlockManagers.rend(); ++it)
+    {
+        auto& [windowSize, manager] = *it;
+        // Intermediate storage is only valid for full-attention windows. SWA windows evict
+        // out-of-window blocks as context grows, making intermediate block boundaries unstable.
+        if (manager.isSWA())
+        {
+            continue;
+        }
+        manager.storeChunkedContextBlocks(sequence, llmRequest, processedTokens);
+    }
+}
+
 void WindowBlockManager::createBlockScalePools(SizeType32 quantBlockSize)
 {
     SizeType32 const numEltsPerContainer = getNumEltsPerContainer();
@@ -1786,6 +1803,11 @@ void WindowBlockManager::releaseLastBlock(GenerationRequest& sequence)
     return mEvictionPolicy->getNumFreeBlocks(kPrimaryLevel);
 }
 
+SizeType32 WindowBlockManager::getNumTrulyFreeBlocks() const noexcept
+{
+    return mEvictionPolicy->getNumTrulyFreeBlocks(kPrimaryLevel);
+}
+
 std::deque<tle::KVCacheEvent> BlockManager::getLatestEvents(std::optional<std::chrono::milliseconds> timeout) const
 {
     return mEventManager ? mEventManager->getEvents(timeout) : std::deque<tle::KVCacheEvent>{};
@@ -1948,6 +1970,54 @@ void WindowBlockManager::storeNewBlock(GenerationRequest& sequence, OptionalRef<
         return;
     }
     TLLM_LOG_DEBUG("%s::storeNewBlock - store the last block", mLogPrefix.c_str());
+    (void) storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
+}
+
+void WindowBlockManager::storeChunkedContextBlocks(
+    GenerationRequest& sequence, LlmRequest const& llmRequest, SizeType32 processedTokens)
+{
+    // isSWA() is checked by BlockManager::storeChunkedContextBlocks before calling here,
+    // but guard defensively in case this method is called directly.
+    TLLM_CHECK_WITH_INFO(!mIsSWA, "storeChunkedContextBlocks must not be called for SWA windows");
+
+    auto const requestId = sequence.getRequestId();
+
+    // If a block was evicted from this sequence mid-flight, its KV data may have been
+    // overwritten. Honour the same validity guard used by releaseBlocks.
+    if (!isSequenceValidForStoreForReuse(requestId))
+    {
+        TLLM_LOG_DEBUG("%s::storeChunkedContextBlocks - sequence %lu not valid for store for reuse, skipping",
+            mLogPrefix.c_str(), requestId);
+        return;
+    }
+
+    constexpr int beamIdx = 0;
+    auto const& cacheBlockIds = sequence.getCacheBlockIds(mWindowSize);
+    auto const& uniqueTokens = llmRequest.getUniqueTokens(beamIdx);
+
+    // processedTokens is the position after the chunk completes (getContextCurrentPosition()).
+    // Apply the same -1 convention as storeContextBlocks and storeNewBlock: the last
+    // processed token's KV state is written during the next forward pass, so exclude it.
+    auto const numStorableTokens = std::min(static_cast<SizeType32>(uniqueTokens.size()), processedTokens) - 1;
+
+    if (numStorableTokens <= 0)
+    {
+        return;
+    }
+
+    TLLM_LOG_DEBUG("%s::storeChunkedContextBlocks for request %lu, %d storable tokens (processedTokens=%d)",
+        mLogPrefix.c_str(), requestId, numStorableTokens, processedTokens);
+
+    // allowPartial=false: only complete blocks are stored. The partial block at the end of a
+    // chunk (with fewer than mTokensPerBlock tokens) is not yet stable and will be completed
+    // by a subsequent chunk or left to storeContextBlocks at context completion.
+    auto blockedUniqueTokens
+        = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, numStorableTokens, mTokensPerBlock, false);
+    auto blockKeys = buildBlockKeys(blockedUniqueTokens, llmRequest);
+
+    // storeBlocks is idempotent for already-stored blocks: findMatchingBlock returns the
+    // existing block and the function simply traverses past it without re-insertion.
+    // This means the final storeContextBlocks call will safely re-traverse the same prefix.
     (void) storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
 }
 
@@ -2229,6 +2299,11 @@ void KVCacheManager::releasePools()
 void KVCacheManager::startScheduling()
 {
     mBlockManager.startScheduling();
+}
+
+std::map<SizeType32, SizeType32> KVCacheManager::getNumTrulyFreeBlocksPerWindowSize() const
+{
+    return mBlockManager.getNumTrulyFreeBlocksPerWindowSize();
 }
 
 SizeType32 KVCacheManager::getNeededBlocksOneStep(
@@ -2609,6 +2684,34 @@ void KVCacheManager::storeContextBlocks(LlmRequest const& llmRequest)
     {
         TLLM_LOG_WARNING("[kv cache manager] storeContextBlocks: Can not find sequence for request %lu", requestId);
     }
+}
+
+void KVCacheManager::storeChunkedContextBlocks(LlmRequest const& llmRequest)
+{
+    auto const requestId = llmRequest.mRequestId;
+    bool found = false;
+    {
+        std::scoped_lock lock(mSequencesMtx);
+        found = mSequences.find(requestId) != mSequences.end();
+    }
+    if (!found)
+    {
+        TLLM_LOG_WARNING(
+            "[kv cache manager] storeChunkedContextBlocks: Can not find sequence for request %lu", requestId);
+        return;
+    }
+    if (!mEnableBlockReuse || llmRequest.isDummyRequest())
+    {
+        return;
+    }
+    auto& sequence = getSequence(requestId);
+    // getContextCurrentPosition() has already been advanced by moveToNextContextChunk()
+    // at the call site, so it equals the token count after the chunk end.
+    auto const processedTokens = llmRequest.getContextCurrentPosition();
+    TLLM_CHECK_WITH_INFO(processedTokens > 0,
+        "storeChunkedContextBlocks called with processedTokens=0; "
+        "moveToNextContextChunk() must be called before this method");
+    mBlockManager.storeChunkedContextBlocks(sequence, llmRequest, processedTokens);
 }
 
 void KVCacheManager::storeNewBlock(LlmRequest const& llmRequest)

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -965,6 +965,20 @@ void TrtGptModelInflightBatching::storeContextBlocks(std::shared_ptr<LlmRequest>
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 
+void TrtGptModelInflightBatching::storeChunkedContextBlocks(std::shared_ptr<LlmRequest> const& llmReq)
+{
+    TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
+    if (mKvCacheManager)
+    {
+        mKvCacheManager->storeChunkedContextBlocks(*llmReq);
+    }
+    if (mCrossKvCacheManager)
+    {
+        mCrossKvCacheManager->storeChunkedContextBlocks(*llmReq);
+    }
+    TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
+}
+
 void TrtGptModelInflightBatching::storeNewBlock(std::shared_ptr<LlmRequest> const& llmReq)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
@@ -1165,6 +1179,13 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
                                 // iteration is expected.
                                 llmReq->setState(LlmRequestState::kGENERATION_TO_COMPLETE);
                             }
+                        }
+                        else
+                        {
+                            // Non-final chunk: store completed full blocks immediately so that
+                            // concurrent requests sharing the same prefix can find and reuse them
+                            // before this request finishes its full context phase.
+                            storeChunkedContextBlocks(llmReq);
                         }
                     }
                     else if (llmReq->isGenerationInProgressState())

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -265,6 +265,10 @@ private:
     //! These blocks become reusable from next step.
     void storeContextBlocks(std::shared_ptr<LlmRequest> const& req);
 
+    //! @brief Store full blocks from a completed (non-final) context chunk for early reuse.
+    //! Enables prefix sharing with concurrent requests before the full context finishes.
+    void storeChunkedContextBlocks(std::shared_ptr<LlmRequest> const& req);
+
     //! @brief Store newest kv cache block for reuse.
     //! The block become reusable from next step.
     void storeNewBlock(std::shared_ptr<LlmRequest> const& req);

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -495,6 +495,8 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
         .def("rewind_kv_cache", &BaseKVCacheManager::rewindKVCache, nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro("cross_kv", &BaseKVCacheManager::isCrossKv)
         .def("store_context_blocks", &BaseKVCacheManager::storeContextBlocks, nb::call_guard<nb::gil_scoped_release>())
+        .def("store_chunked_context_blocks", &BaseKVCacheManager::storeChunkedContextBlocks,
+            nb::call_guard<nb::gil_scoped_release>())
         .def("store_blocks_for_reuse", &BaseKVCacheManager::storeBlocksForReuse,
             nb::call_guard<nb::gil_scoped_release>())
         .def("find_new_context_block", &BaseKVCacheManager::findNewContextBlock, nb::arg("unique_tokens"),

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -2647,13 +2647,16 @@ TEST_F(KVCacheManagerTest, KVCacheManagerDecodeTimedEvictionTest)
     kvCacheManager.addSequence(2, inputLength2, beamWidth, llmRequest2);
     (void) kvCacheManager.removeSequence(2, llmRequest2);
 
-    // 12 tokens, reusing block 4, 5. Block 6 is overwritten so no reuse.
+    // 12 tokens. Seq1's context blocks (shared, in radix tree) are boosted to kRadixTreeBlockPriority
+    // so they outlast the 2 truly-free blocks (1 untouched + 1 expired decode) consumed by seq2.
+    // All 3 of seq1's context blocks survive and are reused by seq3.
     auto inputTokens3 = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
     auto const inputLength3 = static_cast<SizeType32>(inputTokens3->size());
     auto llmRequest3 = std::make_shared<LlmRequest>(3, maxNewTokens, inputTokens3, samplingConfig, isStreaming);
     kvCacheManager.addSequence(3, inputLength3, beamWidth, llmRequest3);
 
-    EXPECT_EQ(llmRequest3->getContextCurrentPosition(), 8);
+    // 3 full blocks reused (prepopulated = 3*tokensPerBlock - 1 = 11, following the -1 last-token convention).
+    EXPECT_EQ(llmRequest3->getContextCurrentPosition(), 11);
 }
 
 TEST_F(KVCacheManagerTest, KVCacheManagerSecondaryBlockPrimaryChildTest)
@@ -2747,8 +2750,9 @@ TEST_F(KVCacheManagerTest, KVCacheManagerSecondaryBlockPrimaryChildTest)
     auto const inputLength3 = static_cast<SizeType32>(inputTokens3->size());
     auto llmRequest3 = std::make_shared<LlmRequest>(3, maxNewTokens, inputTokens3, samplingConfig, isStreaming);
     kvCacheManager.addSequence(3, inputLength3, beamWidth, llmRequest3);
-    // Check out FIXME note above. If addressed, this should be 9.
-    EXPECT_EQ(llmRequest3->getContextCurrentPosition(), 4);
+    // With kRadixTreeBlockPriority boosting, radix-tree cached blocks survive eviction,
+    // so all 2 full blocks from seq0 are reused: prepopulated = 2*tokensPerBlock + 1(sink) = 9.
+    EXPECT_EQ(llmRequest3->getContextCurrentPosition(), 9);
 }
 
 TEST_F(KVCacheManagerTest, KVCacheManagerLeafBlockTest)
@@ -3595,40 +3599,38 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStream)
 
     events = getEvents(kvCacheManager);
 
-    // Onboard block 0, in replace, offload block 7
-    // Offload block 6, and write content of [1,1,1,1] to block 1
-    // Upon freeing up block 1, its child block 2, will be removed from the search tree,
-    // which is a remove event.
-    // Offload block 5, in replace onboard block 7, and write content of [0] to block 7.
-    // In total, there are 2 offloads, 1 onboard, 1 removed, total of 4 events.
-    // FIXME: For better improvement, when block 1 is overwritten, child blocks
-    // are removed from the search tree and no longer reusable. Therefore these blocks
-    // should be the first to be called upon when we want a new block.
+    // With kRadixTreeBlockPriority boosting, cached (radix-tree) blocks at priority 45 are
+    // evicted after truly-free blocks at priority 35. This means seq4's allocation consumes
+    // truly-free blocks first, producing fewer offload/onboard/remove events than the
+    // original 4-event scenario (which assumed all free blocks were at the same priority).
     auto onboardedBlocks = 0;
     auto offloadedBlocks = 0;
     auto removedBlocks = 0;
 
-    EXPECT_EQ(events.size(), 4);
+    EXPECT_EQ(events.size(), 2);
 
-    for (int i = 0; i < 4; i++)
+    for (auto const& event : events)
     {
-        if (std::holds_alternative<tle::KVCacheUpdatedData>(events.front().data))
+        if (std::holds_alternative<tle::KVCacheUpdatedData>(event.data))
         {
-            if (std::get<tle::KVCacheUpdatedData>(events.front().data).cacheLevel->oldValue == 0)
+            if (std::get<tle::KVCacheUpdatedData>(event.data).cacheLevel->oldValue == 0)
+            {
                 offloadedBlocks++;
+            }
             else
+            {
                 onboardedBlocks++;
+            }
         }
-        else if (std::holds_alternative<tle::KVCacheRemovedData>(events.front().data))
+        else if (std::holds_alternative<tle::KVCacheRemovedData>(event.data))
+        {
             removedBlocks++;
-        else
-            FAIL();
-        events.pop_front();
+        }
     }
 
     EXPECT_EQ(onboardedBlocks, 1);
-    EXPECT_EQ(offloadedBlocks, 2);
-    EXPECT_EQ(removedBlocks, 1);
+    EXPECT_EQ(offloadedBlocks, 1);
+    EXPECT_EQ(removedBlocks, 0);
 
     kvCacheManager.storeContextBlocks(*llmRequest4);
 

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -884,13 +884,15 @@ class KVCacheManager(BaseResourceManager):
             if request.py_rewind_len > 0:
                 self.rewind_kv_cache(request, request.py_rewind_len)
 
-        # For context requests, store completed context blocks for KV cache reuse.
-        # We wait until context_remaining_length == 0 (all chunks processed) before
-        # storing, so that SWA windows are safe to store — blocks won't go out-of-window
-        # and be evicted while the context is still in-flight.
+        # For context requests, store blocks for KV cache reuse.
         for request in scheduled_batch.context_requests:
             if request.context_remaining_length == 0:
+                # Final chunk: store all context blocks (includes partial last block).
                 self.impl.store_context_blocks(request)
+            elif hasattr(self.impl, 'store_chunked_context_blocks'):
+                # Non-final chunk: store only complete blocks for early prefix sharing.
+                # SWA windows are skipped internally by storeChunkedContextBlocks.
+                self.impl.store_chunked_context_blocks(request)
 
     def free_resources(self, request: LlmRequest, pin_on_release: bool = False):
         return self.impl.remove_sequence(request.py_request_id, request,

--- a/tests/unittest/_torch/executor/test_py_scheduler.py
+++ b/tests/unittest/_torch/executor/test_py_scheduler.py
@@ -2371,3 +2371,115 @@ class TestPyCapacitySchedulerStaticBatchAdvanced:
         fitting, disagg, paused = scheduler.schedule_request([r0, r1, r2])
         assert len(fitting) == 1
         assert fitting[0].request_id == 0
+
+
+# ############################################################################
+#
+# store_chunked_context_blocks mock tests
+#
+# ############################################################################
+
+
+class MockKVCacheManagerWithChunkedStorage(MockKVCacheManager):
+    """Extended mock that tracks store_chunked_context_blocks calls."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.store_context_blocks_calls = []
+        self.store_chunked_context_blocks_calls = []
+
+    def store_context_blocks(self, request):
+        self.store_context_blocks_calls.append(request.request_id)
+
+    def store_chunked_context_blocks(self, request):
+        self.store_chunked_context_blocks_calls.append(request.request_id)
+
+
+class TestStoreChunkedContextBlocks:
+    """
+    Tests for the store_chunked_context_blocks call in resource_manager.py.
+
+    The resource manager should call store_chunked_context_blocks for non-final
+    context chunks and store_context_blocks for the final chunk.
+    Since resource_manager.py uses the C++ impl directly, these tests verify
+    the branching logic using a mock that tracks which method is called.
+    """
+
+    def test_non_final_chunk_dispatches_to_chunked_store(self):
+        """
+        When context_remaining_length > 0 (non-final chunk),
+        the resource_manager branching logic should call
+        store_chunked_context_blocks, not store_context_blocks.
+        """
+        kv = MockKVCacheManagerWithChunkedStorage(
+            num_free_blocks=100,
+            enable_block_reuse=True,
+        )
+        # Simulate the resource_manager branching logic for a non-final chunk:
+        # context_remaining_length > 0
+        context_remaining_length = 100  # non-final
+        if context_remaining_length == 0:
+            kv.store_context_blocks(make_context_request(0))
+        elif hasattr(kv, "store_chunked_context_blocks"):
+            kv.store_chunked_context_blocks(make_context_request(0))
+
+        assert len(kv.store_chunked_context_blocks_calls) == 1
+        assert len(kv.store_context_blocks_calls) == 0
+
+    def test_final_chunk_dispatches_to_full_store(self):
+        """
+        When context_remaining_length == 0 (final chunk),
+        the resource_manager branching logic should call
+        store_context_blocks, not store_chunked_context_blocks.
+        """
+        kv = MockKVCacheManagerWithChunkedStorage(
+            num_free_blocks=100,
+            enable_block_reuse=True,
+        )
+        # Simulate the resource_manager branching logic for a final chunk:
+        # context_remaining_length == 0
+        context_remaining_length = 0  # final
+        if context_remaining_length == 0:
+            kv.store_context_blocks(make_context_request(0))
+        elif hasattr(kv, "store_chunked_context_blocks"):
+            kv.store_chunked_context_blocks(make_context_request(0))
+
+        assert len(kv.store_context_blocks_calls) == 1
+        assert len(kv.store_chunked_context_blocks_calls) == 0
+
+    def test_hasattr_guard_prevents_crash(self):
+        """
+        When impl doesn't have store_chunked_context_blocks (old binary),
+        the hasattr guard prevents a crash — the else branch is skipped.
+        """
+        kv = MockKVCacheManager(num_free_blocks=100)
+        # MockKVCacheManager does NOT have store_chunked_context_blocks
+        assert not hasattr(kv, "store_chunked_context_blocks")
+
+        # Simulate the resource_manager branching logic with missing method:
+        context_remaining_length = 100  # non-final
+        if context_remaining_length == 0:
+            kv.store_context_blocks(make_context_request(0))  # type: ignore
+        elif hasattr(kv, "store_chunked_context_blocks"):
+            kv.store_chunked_context_blocks(make_context_request(0))
+        # No crash — the hasattr guard skips the call
+
+    def test_chunked_storage_tracking(self):
+        """
+        Verify that store_chunked_context_blocks and store_context_blocks
+        can be called in sequence (simulating multi-chunk context).
+        """
+        kv = MockKVCacheManagerWithChunkedStorage(
+            num_free_blocks=100,
+            enable_block_reuse=True,
+        )
+
+        # Simulate chunk 1 (non-final)
+        kv.store_chunked_context_blocks(make_context_request(0))
+        # Simulate chunk 2 (non-final)
+        kv.store_chunked_context_blocks(make_context_request(0))
+        # Simulate final chunk
+        kv.store_context_blocks(make_context_request(0))
+
+        assert len(kv.store_chunked_context_blocks_calls) == 2
+        assert len(kv.store_context_blocks_calls) == 1


### PR DESCRIPTION
## Summary
Cherry-pick Features A and B from PR #12481 (`improve-scheduler`) onto `feat/bench_y`.

- **Feature A: Radix tree cache priority boost** — Blocks in the radix tree get priority boosted (`kRadixTreeBlockPriority = kDefaultPriority + 10`) on release, so truly-free blocks are evicted first, preserving cached data longer. Adds `getNumTrulyFreeBlocks()` to distinguish empty blocks from cached ones.
- **Feature B: Store chunked context blocks** — New `storeChunkedContextBlocks()` stores full blocks from a completed (non-final) context chunk immediately, enabling prefix sharing with concurrent requests before the full context finishes. Integrated into both TRT and PyTorch backends. SWA windows are skipped.
