### PR TITLE
[https://nvbugs/6029864][fix] Fix flaky ray test failure

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -328,7 +328,6 @@ accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_4gpus_python
 perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_v32_fp4_blackwell-v32_fp4_tep8_mtp3_8k1k] SKIP (https://nvbugs/5997092)
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8 SKIP (https://nvbugs/6004530)
 unittest/_torch/modules/moe/test_moe_module.py::test_configurable_moe_multi_gpu[parallel=DEP-comm=DEEPEP-e60_k4_h2048_i1408-seq=8-dtype=torch.bfloat16-backend=TRTLLM-quant=NVFP4-routing=Renormalize] SKIP (https://nvbugs/6007285)
-disaggregated/test_disaggregated.py::test_disaggregated_gpt_oss_120b_harmony[gpt_oss/gpt-oss-120b] SKIP (https://nvbugs/6011317)
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_bf16_4gpu_mtp_ar SKIP (https://nvbugs/5959992)
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_vswa_reuse_4gpus[two_model] SKIP (https://nvbugs/6013562)
 accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_bf16[latency] SKIP (https://nvbugs/6012526)

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -433,6 +433,8 @@ def process_gpu_memory_info_available():
 
 @pytest.fixture(scope="function")
 def setup_ray_cluster() -> Generator[int, None, None]:
+    import time
+
     runtime_env = {
         "env_vars": {
             "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": "1"
@@ -448,6 +450,8 @@ def setup_ray_cluster() -> Generator[int, None, None]:
         ray.init(address="local", **ray_init_args)
         gcs_addr = ray.get_runtime_context().gcs_address
         port = int(gcs_addr.split(":")[1])
+        # Allow raylet to complete GCS registration before tests create actors.
+        time.sleep(2)
         yield port
     finally:
         if ray.is_initialized():


### PR DESCRIPTION
## Description

Note: This MR also unwaives test for https://nvbugspro.nvidia.com/bug/6011317 for CI resource efficiency.

- Background
The test test_cp_tp_broadcast_object[cp_broadcast-dict] in tests/unittest/_torch/ray_orchestrator/multi_gpu/test_ops.py intermittently fails with a Ray cluster timeout error during fixture setup:

```
Exception: The current node timed out during startup. This could happen because some of the raylet failed to startup or the GCS has become overloaded.
INFO node.py:375 -- Failed to get node info 'GCS cannot find the node with node ID ... The node registration may not be complete yet before the timeout.'
```

- Root Cause
The `setup_ray_cluster` fixture calls `ray.init()` which returns successfully, but the raylet nodes have not yet fully registered their resources with the Ray Global Control Store (GCS). When tests immediately attempt to create Ray actors after the fixture yields, they fail because the GCS cannot find the node information.

This is a race condition between ray.init() completing and the raylet finishing its registration with the GCS.

- Fix
Add a 2-second delay after ray.init() to allow the raylet to complete GCS registration before tests create actors. This is a minimal, low-risk fix that addresses the timing issue without adding complex retry or polling logic.

## Test Coverage
```
$ pytest tests/unittest/_torch/ray_orchestrator/multi_gpu/test_ops.py::test_cp_tp_broadcast_object[cp_broadcast-dict] --run-ray -s -v
```


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved test initialization reliability by adding a delay to ensure proper system registration completes before test execution begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->