### PR TITLE
[https://nvbugs/5962106][fix] Exclude NCCL_SYMMETRIC from allreduce auto-tuner tactics

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1802,8 +1802,10 @@ class AllReduceRunner(TunableRunner):
         profile: OptimizationProfile,
         **kwargs,
     ) -> List[int]:
+        # NCCL_SYMMETRIC is excluded from auto-tuning: the autotuner fails to
+        # evaluate it fairly in CPU-starved systems, leading to misleading
+        # benchmark results that cause it to be selected or rejected incorrectly.
         valid_strategies = [
-            AllReduceStrategy.NCCL_SYMMETRIC.value,
             AllReduceStrategy.NCCL.value,
         ]
         # Fallback in allreduceOp is set to NCCL_SYMMETRIC as default


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Optimization**
  * Refined auto-tuning strategies for distributed collective operations to improve selection efficiency during inference and training workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Description

This removes NCCL_SYMMETRIC from the auto-tuned tactics.
In some CPU starved platforms the auto tuner is unable to evaluate the memcpy + kernel workload for nccl_symmetric.
This is a temporary change until https://github.com/NVIDIA/TensorRT-LLM/pull/11589 can be merged. Which removes the 2 part NCCL_SYMMETRIC execution.

See bugs for details.
May have to be cherry picked into release 1.3

## Test Coverage

No specific test necessary.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
