### PR TITLE
[https://nvbugs/6043291][fix] Add fatal error detection to prevent zombie worker pods

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/error_classification.py
+++ b/tensorrt_llm/_torch/pyexecutor/error_classification.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Error classification and error budget for fatal-error detection.
+
+This module is intentionally dependency-free (no CUDA, no C++ extensions)
+so that it can be imported and tested in any environment.
+"""
+
+import dataclasses
+import time
+
+# Patterns that corrupt the CUDA context beyond recovery.
+# Matched case-insensitively against the error message.
+IMMEDIATE_FATAL_PATTERNS: list[str] = [
+    "cudaerrorillegaladdress",
+    "cudaerrorlaunchfailure",
+    "illegal memory access",
+    "device-side assert",
+    "unrecoverable",
+]
+
+# Patterns that are serious but may be transient (e.g. a single OOM
+# during a traffic spike).  These drain the error budget 5x faster
+# than transient errors.
+SEVERE_ERROR_PATTERNS: list[str] = [
+    "cuda out of memory",
+    "cuda error",
+    "nccl error",
+]
+
+
+def classify_error(error_msg: str) -> str:
+    """Classify an error message by severity.
+
+    Args:
+        error_msg: The error message string to classify.
+
+    Returns:
+        One of ``"immediate_fatal"``, ``"severe"``, or ``"transient"``.
+
+        - **immediate_fatal**: CUDA context is corrupted (device-side
+          assert, illegal address, launch failure).  No future CUDA call
+          can succeed.
+        - **severe**: The operation failed but the CUDA context is
+          intact (e.g. OOM, NCCL timeout).  Recovery is possible if
+          workload decreases.
+        - **transient**: All other errors (bad input, timeout, etc.).
+    """
+    error_lower = error_msg.lower()
+    for p in IMMEDIATE_FATAL_PATTERNS:
+        if p in error_lower:
+            return "immediate_fatal"
+    for p in SEVERE_ERROR_PATTERNS:
+        if p in error_lower:
+            return "severe"
+    return "transient"
+
+
+@dataclasses.dataclass
+class ErrorBudget:
+    """Token-bucket error budget for fatal-error promotion.
+
+    Each error deducts a cost from the budget (0.1 for transient, 0.5
+    for severe).  The budget recovers at ``recovery_rate`` per second
+    of error-free wall time.  When exhausted, the error is promoted to
+    fatal.  Immediate-fatal errors bypass the budget entirely.
+
+    Attributes:
+        budget: Current budget level (starts at 1.0, capped at 1.0).
+        last_error_time: Monotonic timestamp of the last error.
+        recovery_rate: Budget recovered per second of error-free time.
+        cost: Cost per transient error (severe costs 5x this).
+    """
+
+    budget: float = 1.0
+    last_error_time: float | None = None
+    recovery_rate: float = 0.1
+    cost: float = 0.1
+
+    def consume(self, error_msg: str) -> bool:
+        """Deduct from the budget and return True if exhausted.
+
+        Args:
+            error_msg: The error message to classify and budget.
+
+        Returns:
+            True if the error should be treated as fatal.
+        """
+        now = time.monotonic()
+        classification = classify_error(error_msg)
+
+        if classification == "immediate_fatal":
+            return True
+
+        if self.last_error_time is not None:
+            elapsed = now - self.last_error_time
+            self.budget = min(1.0, self.budget + elapsed * self.recovery_rate)
+        self.last_error_time = now
+
+        deduction = self.cost
+        if classification == "severe":
+            deduction *= 5
+
+        self.budget -= deduction
+        return self.budget < 1e-9

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -50,6 +50,7 @@ from ..speculative.spec_sampler_base import SampleStateTensorsSpec
 from ..speculative.speculation_gate import SpeculationGate
 from .connectors.kv_cache_connector import KvCacheConnectorManager
 from .dwdp import DwdpManager
+from .error_classification import ErrorBudget
 from .executor_request_queue import ExecutorRequestQueue, RequestQueueItem
 from .guided_decoder import GuidedDecoder
 from .handle_additional_outputs import HandleAdditionalOutputs
@@ -477,6 +478,8 @@ class PyExecutor:
             self.kv_cache_manager.snapshot_warmup_baseline()
 
         self.is_shutdown = False
+        self._fatal_error: Optional[BaseException] = None
+        self._error_budget = ErrorBudget()
         self.max_batch_size = max_batch_size
         self.adp_ctx_waiting_iters_count = 0
         self.adp_ctx_batching_wait_iters_count = 0
@@ -2825,7 +2828,9 @@ class PyExecutor:
                 self._validate_request(request)
                 return False
             except Exception as e:
-                self._handle_errors(str(e), requests=[request])
+                self._handle_errors(str(e),
+                                    requests=[request],
+                                    charge_budget=False)
                 return True
 
         new_requests_cur_rank = self._fetch_new_requests(
@@ -3319,7 +3324,8 @@ class PyExecutor:
         if error_requests:
             self._handle_errors(
                 f"Error in kv cache transfer for {error_msg_prefix}",
-                requests=error_requests)
+                requests=error_requests,
+                charge_budget=False)
 
     @nvtx_range("_check_disagg_ctx_cache_transfer_status")
     def _check_disagg_ctx_cache_transfer_status(self, atLeastNum: int = 0):
@@ -3546,10 +3552,101 @@ class PyExecutor:
     def _handle_errors(self,
                        error_msg: Optional[str] = None,
                        *,
-                       requests: Optional[List[LlmRequest]] = None):
+                       requests: Optional[List[LlmRequest]] = None,
+                       charge_budget: bool = True) -> None:
+        """Fail requests and optionally initiate shutdown on fatal errors.
+
+        When ``charge_budget`` is True (the default), classifies the error
+        via the error budget.  If deemed fatal (immediate-fatal pattern or
+        budget exhausted), **all** active requests are failed and a shutdown
+        is enqueued.  Otherwise only the requests in *requests* are failed.
+
+        When ``charge_budget`` is False, the error is treated as a
+        per-request failure: only the specified requests are failed, the
+        error budget is not consumed, and shutdown is never triggered.
+        Use this for request-scoped errors (validation, KV-transfer
+        timeout, guided-decoder) that should not affect server health.
+
+        .. note::
+            The ``charge_budget=False`` path reuses the full
+            ``_handle_errors`` machinery (queue drain, response
+            enqueue, terminate) even though it only needs to fail a
+            single request.  A future improvement would be to extract
+            a lightweight ``_fail_request(request, error_msg)`` helper
+            for request-scoped failures, keeping ``_handle_errors``
+            focused on system-level errors that may crash the engine.
+
+        Args:
+            error_msg: Human-readable error description.  Defaults to
+                ``"error"`` when ``None``.
+            requests: Subset of active requests to fail.  When ``None``
+                (or when the error is fatal), all ``active_requests`` are
+                failed.
+            charge_budget: Whether to consume the error budget.  Set to
+                False for request-scoped errors that should not affect
+                server health.
+        """
         error_responses: Dict[int, LlmResponse] = {}
         error_msg = error_msg or "error"
-        failed_requests = requests if requests is not None else self.active_requests
+
+        is_fatal = (self._error_budget.consume(error_msg)
+                    if charge_budget else False)
+        if is_fatal and self._error_budget.budget < 1e-9:
+            logger.error(f"Error budget exhausted "
+                         f"(budget={self._error_budget.budget:.3f}), "
+                         "treating as fatal")
+
+        if is_fatal:
+            self._fatal_error = RuntimeError(f"Fatal error: {error_msg}")
+            self.is_shutdown = True
+            logger.error(
+                f"Fatal error detected, initiating shutdown: {error_msg}")
+            requests = None
+
+            # Drain waiting_queue so that queued-but-not-yet-activated
+            # requests don't get picked up on the next iteration.
+            # These are RequestQueueItems (not yet LlmRequests), so we
+            # fail them via error responses.  Buffer all responses and
+            # call _enqueue_responses once after the loop so every rank
+            # enters the same number of collectives (attention-DP /
+            # gather-all modes use collective gathers internally).
+            waiting_responses: List[Tuple[int, LlmResponse]] = []
+            while self.waiting_queue:
+                item = self.waiting_queue.pop_request()
+                if (self.gather_all_responses
+                        or self.dist.rank == 0) and item.request is not None:
+                    waiting_responses.append(
+                        (item.id,
+                         LlmResponse(request_id=item.id,
+                                     error_msg=error_msg,
+                                     client_id=getattr(item.request,
+                                                       'client_id', None))))
+            # Also drain executor_request_queue so items already queued
+            # but not yet fetched by the main loop are not scheduled
+            # after the CUDA context is corrupted.  Safe to use empty()
+            # here because is_shutdown is True and the queue's active
+            # flag is about to be set False, so no new items arrive.
+            raw_queue = self.executor_request_queue.get_request_queue()
+            while not raw_queue.empty():
+                item = raw_queue.get_nowait()
+                if item.is_shutdown_request:
+                    continue
+                if ((self.gather_all_responses or self.dist.rank == 0)
+                        and item.request is not None):
+                    waiting_responses.append(
+                        (item.id,
+                         LlmResponse(request_id=item.id,
+                                     error_msg=error_msg,
+                                     client_id=getattr(item.request,
+                                                       'client_id', None))))
+
+            if waiting_responses:
+                self._enqueue_responses(waiting_responses)
+                logger.info(f"Drained {len(waiting_responses)} queued requests "
+                            "on fatal error")
+
+        failed_requests = (list(self.active_requests)
+                           if requests is None else requests)
         for request in failed_requests:
             req_id = request.py_request_id
             request.state = LlmRequestState.GENERATION_COMPLETE
@@ -3567,6 +3664,9 @@ class PyExecutor:
         self._enqueue_responses(list(error_responses.items()))
         for request in failed_requests:
             self._terminate_request(request)
+
+        if self._fatal_error is not None:
+            self.executor_request_queue.enqueue_shutdown_request()
 
     def _terminate_request(self, request: LlmRequest):
         # Dummy requests don't participate in disagg KV cache transfers,
@@ -3733,7 +3833,8 @@ class PyExecutor:
                 if is_cancelled:
                     self._handle_errors(
                         error_msg=f"Request {request.py_request_id} timed out",
-                        requests=[request])
+                        requests=[request],
+                        charge_budget=False)
                 continue
 
             if request.is_generation_only_request() and not request.is_finished:
@@ -3941,7 +4042,9 @@ class PyExecutor:
             if request.py_request_id not in failed_req_id_to_err:
                 continue
             error_msg = failed_req_id_to_err[request.py_request_id]
-            self._handle_errors(error_msg, requests=[request])
+            self._handle_errors(error_msg,
+                                requests=[request],
+                                charge_budget=False)
 
 
 class DisaggPPTerminationHandler:

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -8,7 +8,7 @@ import weakref
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from pathlib import Path
-from queue import Queue
+from queue import Empty, Queue
 from typing import (TYPE_CHECKING, AsyncIterable, Dict, Generator, List,
                     Optional, Union)
 
@@ -100,6 +100,10 @@ class GenerationExecutor(ABC):
 
         # A flag to avoid calling shutdown() recursively. This happens when the background threads raise errors.
         self.doing_shutdown = False
+
+        # Tracks unrecoverable engine errors (e.g. CUDA OOM crash).
+        # Once set, health checks return unhealthy and shutdown is initiated.
+        self._fatal_error: Optional[BaseException] = None
 
         self._last_client_id: int = 1
 
@@ -283,20 +287,84 @@ class GenerationExecutor(ABC):
                     print_colored(
                         f"Got background error: {repr(error)}, will shutdown the LLM instance\n",
                         "red")
+                self._set_fatal_error(error)
                 self.shutdown()
             raise error
 
-        # Here we raise the first error in the queue. This method will be called repeatedly and user can choose to catch
-        # more than one error.
-        if not self._error_queue.empty():
-            e = self._error_queue.get()
+        # Drain the first error from the queue using get_nowait() to
+        # avoid blocking if another thread consumed the item between
+        # the empty() check and the get() call.  Per-request errors
+        # (str / RequestError) are re-raised without marking the executor
+        # fatal; only system-level errors trigger shutdown.
+        try:
+            e = self._error_queue.get_nowait()
             self._error_queue.task_done()
-            self.shutdown()
-            # We can catch some exceptions here.
+            if isinstance(e, str):
+                e = RequestError(e)
+            elif not isinstance(e, BaseException):
+                e = RuntimeError(repr(e))
+            if not isinstance(e, RequestError):
+                self._set_fatal_error(e)
+                self.shutdown()
             raise e
+        except Empty:
+            pass
+
+    def _set_fatal_error(self, error: BaseException) -> None:
+        """Record an unrecoverable engine error.
+
+        Only the first error is kept; subsequent calls are no-ops.
+        A narrow TOCTOU race exists (two threads could both pass the
+        ``is None`` check), but the consequence is merely a different
+        error in the log — both are fatal and both trigger shutdown.
+
+        Args:
+            error: The exception to record as the fatal error.
+        """
+        if self._fatal_error is None:
+            self._fatal_error = error
+            logger.error(f"Fatal engine error recorded: {repr(error)}")
 
     def is_shutdown(self) -> bool:
-        return self.doing_shutdown
+        """Return True if the executor is shutting down or fatally errored."""
+        return self.doing_shutdown or self._fatal_error is not None
+
+    def check_health(self) -> bool:
+        """Check whether the executor is healthy and able to process requests.
+
+        Returns False if the executor has been shut down, has a fatal
+        error, or has pending errors in the error queue.  Safe to call
+        from any thread (the ``_error_queue`` is a thread-safe
+        ``queue.Queue``).
+
+        This method drains the error queue directly rather than calling
+        ``_handle_background_error()`` (which is documented for
+        main-thread use, calls ``shutdown()`` + ``raise``, and can
+        cause re-entrancy issues when invoked from health-check or
+        event-loop threads).
+
+        Returns:
+            True if healthy, False otherwise.
+        """
+        if self.doing_shutdown or self._fatal_error is not None:
+            return False
+        # Drain *all* queued errors so that a fatal error queued behind
+        # a RequestError is not hidden until the next health check.
+        drained = False
+        while True:
+            try:
+                e = self._error_queue.get_nowait()
+                self._error_queue.task_done()
+                drained = True
+                if not isinstance(e, (str, RequestError)):
+                    self._set_fatal_error(e)
+                    self.shutdown()
+                    break  # No need to drain further after fatal
+            except Empty:
+                break
+        if drained:
+            return self._fatal_error is None and not self.doing_shutdown
+        return True
 
     @abstractmethod
     def shutdown(self):

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -4,6 +4,7 @@ import json
 import os
 import threading
 import weakref
+from queue import Empty
 from typing import Dict, List, Optional
 
 import torch
@@ -25,9 +26,9 @@ from .request import CancellingRequest, GenerationRequest
 from .result import GenerationResult, IterationResult
 from .rpc import RPCClient
 from .rpc.rpc_common import RPCError, get_unique_ipc_addr
-from .utils import (ErrorResponse, WorkerCommIpcAddrs, create_mpi_comm_session,
-                    get_spawn_proxy_process_env, is_llm_response,
-                    print_alive_threads)
+from .utils import (ErrorResponse, RequestError, WorkerCommIpcAddrs,
+                    create_mpi_comm_session, get_spawn_proxy_process_env,
+                    is_llm_response, print_alive_threads)
 from .worker import GenerationExecutorWorker, worker_main
 
 __all__ = [
@@ -113,6 +114,19 @@ class GenerationExecutorProxy(GenerationExecutor):
         # Create RPC client after workers are started (worker starts RPC server)
         self.rpc_client = RPCClient(self.rpc_addr, hmac_key=self.hmac_key)
 
+        # Event used to wake the error monitor thread for a clean shutdown
+        # instead of polling with sleep loops.
+        self._shutdown_event = threading.Event()
+
+        # Start a background thread that monitors for fatal errors (e.g. MPI
+        # worker crash) and triggers shutdown even when no health checks or
+        # generate() calls are in flight.
+        self._error_monitor_thread = threading.Thread(
+            target=self._error_monitor_loop,
+            daemon=True,
+            name="proxy_error_monitor")
+        self._error_monitor_thread.start()
+
         # MPI registers its joiner using threading._register_atexit if possible.
         # These functions run before atexit.register, so to avoid deadlock,
         # we have to notify workers to exit before MPI starts to wait them.
@@ -121,6 +135,101 @@ class GenerationExecutorProxy(GenerationExecutor):
                 self.pre_shutdown)
         except AttributeError:
             atexit.register(self.pre_shutdown)
+
+    def _check_mpi_futures(self) -> bool:
+        """Check if any MPI worker future has completed (crashed/exited).
+
+        If a dead worker is found, records the fatal error and calls
+        ``pre_shutdown()``.
+
+        Returns:
+            True if a dead worker was detected.
+        """
+        if not hasattr(self, 'mpi_futures') or not self.mpi_futures:
+            return False
+        for f in self.mpi_futures:
+            if f.done():
+                exc = f.exception() if not f.cancelled() else None
+                error = exc or RuntimeError("MPI worker exited unexpectedly")
+                self._set_fatal_error(error)
+                if not self.doing_shutdown:
+                    self.pre_shutdown()
+                return True
+        return False
+
+    def _drain_error_queue(self) -> bool:
+        """Drain all queued errors, skipping per-request errors.
+
+        Sets ``_fatal_error`` and calls ``pre_shutdown()`` on the first
+        system-level error found.
+
+        Returns:
+            True if any items were drained from the queue.
+        """
+        drained = False
+        while True:
+            try:
+                e = self._error_queue.get_nowait()
+                self._error_queue.task_done()
+                drained = True
+                if isinstance(e, (str, RequestError)):
+                    continue
+                self._set_fatal_error(e)
+                if not self.doing_shutdown:
+                    self.pre_shutdown()
+                break
+            except Empty:
+                break
+        return drained
+
+    def check_health(self) -> bool:
+        """Check executor health including MPI worker liveness.
+
+        Inlines the base ``check_health()`` logic instead of calling
+        ``super().check_health()`` so that fatal queue items trigger
+        ``pre_shutdown()`` (non-blocking) rather than ``shutdown()``
+        (which blocks on ``f.result()`` for surviving MPI workers).
+
+        Returns:
+            True if the executor and all MPI workers are healthy.
+        """
+        if self.doing_shutdown or self._fatal_error is not None:
+            return False
+
+        if self._drain_error_queue():
+            return self._fatal_error is None and not self.doing_shutdown
+
+        if self._check_mpi_futures():
+            return False
+
+        return True
+
+    def _error_monitor_loop(self) -> None:
+        """Background thread that polls for fatal errors every ~5 seconds.
+
+        Checks MPI worker futures and drains the error queue using
+        the shared ``_check_mpi_futures()`` and ``_drain_error_queue()``
+        helpers.
+
+        Uses ``_shutdown_event`` for clean wakeup instead of a sleep loop,
+        so shutdown is immediate rather than waiting up to 5 seconds.
+        """
+        while not self.doing_shutdown and self._fatal_error is None:
+            try:
+                if self._check_mpi_futures():
+                    logger.error("Error monitor: MPI worker crash detected, "
+                                 "shutting down")
+                    return
+
+                self._drain_error_queue()
+                if self._fatal_error is not None:
+                    return
+            except Exception as exc:
+                logger.debug(f"Error monitor: unexpected exception (ignored): "
+                             f"{exc!r}")
+
+            # Wait up to 5s, but wake immediately if _shutdown_event is set
+            self._shutdown_event.wait(timeout=5.0)
 
     def _setup_queues(self) -> WorkerCommIpcAddrs:
 
@@ -294,10 +403,29 @@ class GenerationExecutorProxy(GenerationExecutor):
         else:
             self.doing_shutdown = True
 
+        # Wake the error monitor thread immediately so it exits cleanly
+        if hasattr(self, '_shutdown_event'):
+            self._shutdown_event.set()
+
         self._abort_all_requests()
 
-        # notify the workers to quit
-        if all(not f.done() for f in self.mpi_futures):
+        # Notify surviving workers to quit.  Send the sentinel when:
+        #   (a) ``mpi_futures`` is empty -- the
+        #       ``RemoteMpiCommSessionClient`` case where workers run in a
+        #       separate ``mgmn_leader_node`` process (used by
+        #       ``trtllm-llmapi-launch``) and ``submit()`` returns ``[]``.
+        #       Without this branch the sentinel would be silently dropped
+        #       and the ``dispatch_result_thread`` would block forever on
+        #       ``result_queue.get()``.
+        #   (b) at least one tracked worker future is still alive (covers
+        #       the in-process ``MpiPoolSession`` / ``MpiCommSession`` cases
+        #       and the partial-crash scenario where some workers exited
+        #       early).
+        # The original ``all(not f.done() ...)`` was vacuously True for an
+        # empty list and therefore covered case (a) by accident.  Switching
+        # to bare ``any(...)`` to better handle partial crashes regressed
+        # case (a); keep both behaviours explicit.
+        if not self.mpi_futures or any(not f.done() for f in self.mpi_futures):
             self.request_queue.put_noblock(None, retry=4)
 
     def shutdown(self):
@@ -318,6 +446,11 @@ class GenerationExecutorProxy(GenerationExecutor):
                 pass
 
         # step2: notify the background threads to quit
+        if (hasattr(self, '_error_monitor_thread')
+                and self._error_monitor_thread.is_alive() and
+                threading.current_thread() is not self._error_monitor_thread):
+            self._error_monitor_thread.join(timeout=5)
+
         if self.dispatch_result_thread is not None and self.dispatch_result_thread.is_alive(
         ):
             self.dispatch_result_thread.stop()

--- a/tensorrt_llm/grpc/grpc_request_manager.py
+++ b/tensorrt_llm/grpc/grpc_request_manager.py
@@ -168,10 +168,20 @@ class GrpcRequestManager:
             if self.llm is None:
                 return False, "LLM not initialized"
 
-            # Check if executor is available and not shutdown
+            # Check executor health (includes error queue, MPI worker
+            # liveness, and fatal error state — not just doing_shutdown).
             if hasattr(self.llm, "_executor"):
-                if self.llm._executor is None or self.llm._executor.is_shutdown():
-                    return False, "Executor is shutdown"
+                if self.llm._executor is None:
+                    return False, "Executor is not available"
+                if not self.llm._executor.check_health():
+                    error_msg = "Executor is unhealthy"
+                    if self.llm._executor._fatal_error is not None:
+                        exc = self.llm._executor._fatal_error
+                        lines = str(exc).splitlines()
+                        short = (lines[0] if lines else type(exc).__name__)[:200]
+                        error_msg = f"{type(exc).__name__}: {short}"
+                        logger.error(f"Health check fatal error: {repr(exc)}")
+                    return False, error_msg
 
             return True, "OK"
         except Exception as e:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -991,10 +991,10 @@ class BaseLLM:
         """Check if the LLM is healthy.
 
         Returns:
-            bool: True if the executor is running and not shutdown, False otherwise.
+            bool: True if the executor is running and healthy, False otherwise.
         """
         if hasattr(self, "_executor") and self._executor is not None:
-            return not self._executor.is_shutdown()
+            return self._executor.check_health()
 
         return False
 

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -705,6 +705,21 @@ class OpenAIServer:
         if self._check_health():
             return Response(status_code=200)
         else:
+            # If the engine has a fatal error, trigger server shutdown so the
+            # pod doesn't linger as a zombie that accepts connections but never
+            # produces tokens.  Uses SIGINT (not SIGTERM) to match the
+            # existing CppExecutorError handlers and let uvicorn perform
+            # its graceful shutdown sequence.  The doing_shutdown guard
+            # ensures we only send SIGINT once — repeated health probes
+            # won't stack signals during an in-progress teardown.
+            executor = getattr(self.generator, '_executor', None)
+            if executor is not None and getattr(executor, '_fatal_error',
+                                                None) is not None:
+                if not getattr(executor, 'doing_shutdown', True):
+                    logger.error(
+                        "Health check detected fatal engine error, initiating "
+                        f"server shutdown: {executor._fatal_error}")
+                    signal.raise_signal(signal.SIGINT)
             return Response(
                 status_code=503,
                 content=

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -114,6 +114,7 @@ l0_a10:
   # executor
   - unittest/executor/test_rpc.py
   - unittest/executor/test_ipc.py
+  - unittest/executor/test_fatal_error_health_check.py
   # trtllm-serve CPU-only
   - unittest/llmapi/apps/test_chat_utils.py
   - unittest/llmapi/apps/test_tool_parsers.py

--- a/tests/unittest/executor/test_fatal_error_health_check.py
+++ b/tests/unittest/executor/test_fatal_error_health_check.py
@@ -1,0 +1,825 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for fatal error detection and health check functionality.
+
+Tests cover:
+- classify_error() module-level function (tested directly, not via mock)
+- PyExecutor token-bucket error budget and _handle_errors()
+- GenerationExecutor.check_health(), _set_fatal_error(), is_shutdown()
+- GenerationExecutorProxy.check_health() with MPI worker liveness
+- GenerationExecutorProxy._error_monitor_loop() background detection
+- GrpcRequestManager.health_check() integration
+- OpenAIServer /health endpoint with fatal error shutdown
+- BaseLLM._check_health() delegation
+"""
+
+# Import classify_error directly from the source file to avoid triggering
+# the heavy tensorrt_llm.__init__ (which loads C++ extensions).
+import importlib.util
+import logging
+import pathlib
+import signal
+import threading
+import time
+from concurrent.futures import Future
+from queue import Empty, Queue
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+_mod_path = (
+    pathlib.Path(__file__).resolve().parents[3]
+    / "tensorrt_llm"
+    / "_torch"
+    / "pyexecutor"
+    / "error_classification.py"
+)
+_spec = importlib.util.spec_from_file_location("error_classification", _mod_path)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+classify_error = _mod.classify_error
+ErrorBudget = _mod.ErrorBudget
+
+
+# ---------------------------------------------------------------------------
+# PyExecutor mock — uses the real classify_error() for classification and
+# mirrors the token-bucket / _handle_errors logic from PyExecutor.
+# ---------------------------------------------------------------------------
+class MockPyExecutorForFatalError:
+    """Mirrors PyExecutor's error budget and _handle_errors logic.
+
+    Uses the real ``ErrorBudget`` dataclass and ``classify_error()``
+    function so that tests exercise the actual classification and
+    budget logic.
+    """
+
+    def __init__(self):
+        self._fatal_error = None
+        self.is_shutdown: bool = False
+        self._error_budget = ErrorBudget()
+        self.active_requests = []
+        self.waiting_queue = []
+        self.waiting_drained: list = []
+        self.request_queue_items: list = []
+        self.request_queue_drained: list = []
+        self.executor_request_queue = Mock()
+
+    def _handle_errors(self, error_msg=None, *, requests=None, charge_budget=True):
+        """Fail requests and optionally initiate shutdown on fatal errors."""
+        error_msg = error_msg or "error"
+        is_fatal = self._error_budget.consume(error_msg) if charge_budget else False
+        if is_fatal:
+            self._fatal_error = RuntimeError(f"Fatal error: {error_msg}")
+            self.is_shutdown = True
+            requests = None
+            # Drain waiting queue on fatal (mirrors real PyExecutor)
+            self.waiting_drained = list(self.waiting_queue)
+            self.waiting_queue.clear()
+            # Drain executor_request_queue on fatal
+            self.request_queue_drained = list(self.request_queue_items)
+            self.request_queue_items.clear()
+        failed_requests = list(self.active_requests) if requests is None else requests
+        for request in failed_requests:
+            request.state = "GENERATION_COMPLETE"
+        if requests is None:
+            self.active_requests.clear()
+        else:
+            self.active_requests = [r for r in self.active_requests if r not in requests]
+        if self._fatal_error is not None:
+            self.executor_request_queue.enqueue_shutdown_request()
+
+
+# ---------------------------------------------------------------------------
+# Minimal executor mocks for GenerationExecutor / Proxy tests
+# ---------------------------------------------------------------------------
+class ConcreteExecutor:
+    """Mirrors GenerationExecutor's fatal-error and health-check logic."""
+
+    def __init__(self):
+        self._error_queue: Queue = Queue()
+        self.doing_shutdown: bool = False
+        self._fatal_error = None
+
+    def _set_fatal_error(self, error):
+        """Record the first fatal error; subsequent calls are no-ops."""
+        if self._fatal_error is None:
+            self._fatal_error = error
+
+    def is_shutdown(self) -> bool:
+        """Return True if shutdown is in progress or a fatal error occurred."""
+        return self.doing_shutdown or self._fatal_error is not None
+
+    def check_health(self) -> bool:
+        """Check if executor is healthy, draining all queued errors."""
+        if self.doing_shutdown or self._fatal_error is not None:
+            return False
+        drained = False
+        while True:
+            try:
+                e = self._error_queue.get_nowait()
+                self._error_queue.task_done()
+                drained = True
+                if not isinstance(e, str):
+                    self._set_fatal_error(e)
+                    self.doing_shutdown = True
+                    break
+            except Empty:
+                break
+        if drained:
+            return self._fatal_error is None and not self.doing_shutdown
+        return True
+
+    def shutdown(self):
+        """Mark executor as shutting down."""
+        self.doing_shutdown = True
+
+
+class ConcreteProxyExecutor(ConcreteExecutor):
+    """Mirrors GenerationExecutorProxy's MPI-aware health check + monitor.
+
+    Uses shared ``_check_mpi_futures()`` and ``_drain_error_queue()``
+    helpers to match the production proxy's unified pattern.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.mpi_futures: list = []
+        self._pre_shutdown_called: bool = False
+        self._shutdown_event = threading.Event()
+        # Track sentinel sends so the pre_shutdown sentinel test can
+        # observe whether ``request_queue.put_noblock(None, ...)`` would
+        # have been called by the real proxy.
+        self.request_queue = Mock()
+        self.workers_started: bool = True
+        self._abort_all_requests_called: bool = False
+
+    def _check_mpi_futures(self) -> bool:
+        """Return True if any MPI worker future has completed."""
+        for f in self.mpi_futures:
+            if f.done():
+                exc = f.exception() if not f.cancelled() else None
+                error = exc or RuntimeError("MPI worker exited unexpectedly")
+                self._set_fatal_error(error)
+                if not self.doing_shutdown:
+                    self.pre_shutdown()
+                return True
+        return False
+
+    def _drain_error_queue(self) -> bool:
+        """Drain all queued errors, skipping per-request str errors."""
+        drained = False
+        while True:
+            try:
+                e = self._error_queue.get_nowait()
+                self._error_queue.task_done()
+                drained = True
+                if isinstance(e, str):
+                    continue
+                self._set_fatal_error(e)
+                if not self.doing_shutdown:
+                    self.pre_shutdown()
+                break
+            except Empty:
+                break
+        return drained
+
+    def check_health(self) -> bool:
+        """Check executor health including MPI worker liveness."""
+        if self.doing_shutdown or self._fatal_error is not None:
+            return False
+        if self._drain_error_queue():
+            return self._fatal_error is None and not self.doing_shutdown
+        if self._check_mpi_futures():
+            return False
+        return True
+
+    def _error_monitor_loop(self):
+        """Background loop using shared helpers."""
+        while not self.doing_shutdown and self._fatal_error is None:
+            try:
+                if self._check_mpi_futures():
+                    return
+                self._drain_error_queue()
+                if self._fatal_error is not None:
+                    return
+            except Exception as exc:
+                logger.debug(f"Mock monitor: unexpected exception (ignored): {exc}")
+            self._shutdown_event.wait(timeout=0.5)
+
+    def pre_shutdown(self):
+        """Mirror production GenerationExecutorProxy.pre_shutdown.
+
+        Sentinel-send logic must match production exactly so the
+        ``TestPreShutdownSentinel`` regression suite catches a future
+        revert.  See PR #12718 investigation -- the bug was a one-character
+        change from ``all`` to ``any`` here, which silently dropped the
+        sentinel for the empty-``mpi_futures`` case used by
+        ``RemoteMpiCommSessionClient`` / ``trtllm-llmapi-launch``.
+        """
+        if not self.workers_started:
+            return
+        if self.doing_shutdown:
+            return
+        self.doing_shutdown = True
+        self._pre_shutdown_called = True
+        self._shutdown_event.set()
+        self._abort_all_requests_called = True
+        if not self.mpi_futures or any(not f.done() for f in self.mpi_futures):
+            self.request_queue.put_noblock(None, retry=4)
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+def _make_request(req_id: int) -> Mock:
+    """Create a mock LlmRequest with the given ID."""
+    req = Mock()
+    req.py_request_id = req_id
+    req.py_client_id = 1
+    req.state = "GENERATION_IN_PROGRESS"
+    return req
+
+
+# ---------------------------------------------------------------------------
+# classify_error() — tests the real module-level function directly
+# ---------------------------------------------------------------------------
+class TestClassifyError:
+    """Tests for the classify_error() module-level function."""
+
+    @pytest.mark.parametrize(
+        "error_msg,expected",
+        [
+            ("cudaErrorIllegalAddress: illegal memory access", "immediate_fatal"),
+            ("cudaErrorLaunchFailure: unspecified failure", "immediate_fatal"),
+            ("RuntimeError: device-side assert triggered", "immediate_fatal"),
+            ("Unrecoverable error in the engine", "immediate_fatal"),
+            ("CUDA error: an illegal memory access was encountered", "immediate_fatal"),
+            ("CUDA out of memory. Tried to allocate 2 GiB", "severe"),
+            ("RuntimeError: CUDA error: out of memory", "severe"),
+            ("NCCL error: unhandled system error", "severe"),
+            ("Input length exceeds maximum", "transient"),
+            ("Request timed out", "transient"),
+            ("Invalid sampling parameter: top_k must be > 0", "transient"),
+            ("KV cache capacity exceeded", "transient"),
+            ("", "transient"),
+            ("DEVICE-SIDE ASSERT triggered", "immediate_fatal"),
+            ("Nccl Error: timeout", "severe"),
+            ("cuda OUT OF MEMORY", "severe"),
+        ],
+    )
+    def test_classification(self, error_msg, expected):
+        """Verify error messages are classified into the correct severity tier."""
+        assert classify_error(error_msg) == expected
+
+
+# ---------------------------------------------------------------------------
+# Token-bucket error budget + _handle_errors
+# ---------------------------------------------------------------------------
+class TestErrorBudget:
+    """Tests for the token-bucket error budget and _handle_errors interaction."""
+
+    @pytest.fixture
+    def executor(self):
+        ex = MockPyExecutorForFatalError()
+        ex._error_budget.recovery_rate = 0.0
+        return ex
+
+    def test_immediate_fatal_bypasses_budget(self, executor):
+        """Immediate-fatal errors ignore the budget and trigger shutdown."""
+        assert executor._error_budget.budget == 1.0
+        executor._handle_errors("device-side assert triggered")
+        assert executor._fatal_error is not None
+        assert executor.is_shutdown is True
+
+    def test_severe_errors_exhaust_budget_in_two(self, executor):
+        """budget=1.0, severe cost=0.5 -> 2 severe errors exhaust it."""
+        for i in range(2):
+            executor.active_requests = [_make_request(i)]
+            executor._handle_errors("CUDA out of memory", requests=executor.active_requests[:])
+        assert executor._fatal_error is not None
+        executor.executor_request_queue.enqueue_shutdown_request.assert_called()
+
+    def test_transient_errors_exhaust_budget_in_four(self, executor):
+        """cost=0.25 -> 4 transient errors exhaust budget=1.0."""
+        executor._error_budget.cost = 0.25
+        for i in range(3):
+            executor.active_requests = [_make_request(i)]
+            executor._handle_errors("some transient error", requests=executor.active_requests[:])
+            assert executor._fatal_error is None
+        executor._handle_errors("some transient error", requests=[_make_request(99)])
+        assert executor._fatal_error is not None
+
+    def test_budget_recovers_over_time(self):
+        """Error budget replenishes based on elapsed error-free wall time."""
+        executor = MockPyExecutorForFatalError()
+        executor._handle_errors("transient error", requests=[_make_request(1)])
+        budget_after = executor._error_budget.budget
+
+        executor._error_budget.last_error_time = time.monotonic() - 5.0
+
+        executor._handle_errors("transient error", requests=[_make_request(2)])
+        assert executor._fatal_error is None
+        assert executor._error_budget.budget > budget_after - 0.1
+
+    def test_non_fatal_only_fails_specified_requests(self, executor):
+        """Non-fatal errors only fail the specified requests, not all."""
+        req1, req2 = _make_request(1), _make_request(2)
+        executor.active_requests = [req1, req2]
+        executor._handle_errors("Input too long", requests=[req1])
+        assert executor._fatal_error is None
+        assert req1 not in executor.active_requests
+        assert req2 in executor.active_requests
+        executor.executor_request_queue.enqueue_shutdown_request.assert_not_called()
+
+    def test_fatal_fails_all_and_enqueues_shutdown(self, executor):
+        """Fatal error fails all active requests and enqueues shutdown."""
+        reqs = [_make_request(i) for i in range(3)]
+        executor.active_requests = list(reqs)
+        executor._handle_errors("cudaErrorIllegalAddress", requests=[reqs[0]])
+        assert executor._fatal_error is not None
+        assert len(executor.active_requests) == 0
+        for r in reqs:
+            assert r.state == "GENERATION_COMPLETE"
+        executor.executor_request_queue.enqueue_shutdown_request.assert_called_once()
+
+    def test_fatal_error_with_no_active_requests(self, executor):
+        """Fatal error works even with an empty active_requests list."""
+        executor.active_requests = []
+        executor._handle_errors("cudaErrorLaunchFailure")
+        assert executor._fatal_error is not None
+        executor.executor_request_queue.enqueue_shutdown_request.assert_called_once()
+
+    def test_default_error_msg_is_transient(self, executor):
+        """Default error message (None -> 'error') is classified as transient."""
+        executor.active_requests = []
+        executor._handle_errors()
+        assert executor._fatal_error is None
+
+    def test_fatal_drains_waiting_queue(self, executor):
+        """Fatal error drains waiting_queue so queued requests are not activated."""
+        executor.waiting_queue = ["req_a", "req_b", "req_c"]
+        executor._handle_errors("cudaErrorIllegalAddress")
+        assert executor._fatal_error is not None
+        assert len(executor.waiting_queue) == 0
+        assert executor.waiting_drained == ["req_a", "req_b", "req_c"]
+
+    def test_non_fatal_does_not_drain_waiting_queue(self, executor):
+        """Non-fatal errors leave the waiting_queue untouched."""
+        executor.waiting_queue = ["req_a", "req_b"]
+        executor._handle_errors("Input too long", requests=[_make_request(1)])
+        assert len(executor.waiting_queue) == 2
+        assert executor.waiting_drained == []
+
+    def test_fatal_drains_executor_request_queue(self, executor):
+        """Fatal error drains executor_request_queue items."""
+        executor.request_queue_items = ["queued_1", "queued_2"]
+        executor._handle_errors("cudaErrorIllegalAddress")
+        assert executor._fatal_error is not None
+        assert len(executor.request_queue_items) == 0
+        assert executor.request_queue_drained == ["queued_1", "queued_2"]
+
+    def test_non_fatal_does_not_drain_executor_request_queue(self, executor):
+        """Non-fatal errors leave executor_request_queue untouched."""
+        executor.request_queue_items = ["queued_1"]
+        executor._handle_errors("Input too long", requests=[_make_request(1)])
+        assert len(executor.request_queue_items) == 1
+        assert executor.request_queue_drained == []
+
+    def test_charge_budget_false_skips_budget(self, executor):
+        """Request-scoped errors with charge_budget=False don't consume budget."""
+        initial_budget = executor._error_budget.budget
+        req = _make_request(1)
+        executor.active_requests = [req]
+        executor._handle_errors("validation error", requests=[req], charge_budget=False)
+        assert executor._error_budget.budget == initial_budget
+        assert executor._fatal_error is None
+        assert req not in executor.active_requests
+
+    def test_charge_budget_false_never_triggers_fatal(self, executor):
+        """Even immediate-fatal patterns don't trigger shutdown when uncharged."""
+        req = _make_request(1)
+        executor.active_requests = [req]
+        executor._handle_errors("cudaErrorIllegalAddress", requests=[req], charge_budget=False)
+        assert executor._fatal_error is None
+        assert executor.is_shutdown is False
+        assert req not in executor.active_requests
+
+
+# NOTE: An earlier version of this file had a `test_charge_budget_true_is_default`
+# test here that was functionally identical to `test_immediate_fatal_bypasses_budget`
+# (both call `_handle_errors("device-side assert ...")` and assert `_fatal_error is
+# not None`).  The intent of "true is default" is now captured by
+# `test_immediate_fatal_bypasses_budget` which does not pass `charge_budget` and
+# therefore relies on the default of True.  Removed to reduce noise.
+
+
+# ---------------------------------------------------------------------------
+# GenerationExecutor: _set_fatal_error, is_shutdown, check_health
+# ---------------------------------------------------------------------------
+class TestGenerationExecutor:
+    """Tests for GenerationExecutor's _set_fatal_error, is_shutdown, check_health."""
+
+    @pytest.fixture
+    def executor(self):
+        """Return a fresh ConcreteExecutor for each test."""
+        return ConcreteExecutor()
+
+    def test_fatal_error_none_initially(self, executor):
+        """Fatal error starts as None."""
+        assert executor._fatal_error is None
+
+    def test_set_fatal_error_first_wins(self, executor):
+        """Only the first fatal error is recorded; subsequent calls are no-ops."""
+        first, second = RuntimeError("a"), RuntimeError("b")
+        executor._set_fatal_error(first)
+        executor._set_fatal_error(second)
+        assert executor._fatal_error is first
+
+    @pytest.mark.parametrize(
+        "doing_shutdown,fatal_error,expected",
+        [
+            (False, None, False),
+            (True, None, True),
+            (False, RuntimeError("x"), True),
+            (True, RuntimeError("x"), True),
+        ],
+    )
+    def test_is_shutdown(self, doing_shutdown, fatal_error, expected):
+        """is_shutdown reflects both doing_shutdown flag and fatal error state."""
+        ex = ConcreteExecutor()
+        ex.doing_shutdown = doing_shutdown
+        ex._fatal_error = fatal_error
+        assert ex.is_shutdown() is expected
+
+    @pytest.mark.parametrize(
+        "doing_shutdown,fatal_error,queue_error,expected",
+        [
+            (False, None, None, True),
+            (True, None, None, False),
+            (False, RuntimeError("x"), None, False),
+            (False, None, RuntimeError("bg"), False),
+        ],
+    )
+    def test_check_health(self, doing_shutdown, fatal_error, queue_error, expected):
+        """check_health returns False for shutdown, fatal error, or queued errors."""
+        ex = ConcreteExecutor()
+        ex.doing_shutdown = doing_shutdown
+        ex._fatal_error = fatal_error
+        if queue_error is not None:
+            ex._error_queue.put(queue_error)
+        assert ex.check_health() is expected
+
+
+# ---------------------------------------------------------------------------
+# GenerationExecutorProxy: check_health with MPI futures
+# ---------------------------------------------------------------------------
+class TestProxyCheckHealth:
+    """Tests for GenerationExecutorProxy's check_health with MPI futures."""
+
+    @pytest.fixture
+    def executor(self):
+        """Return a fresh ConcreteProxyExecutor for each test."""
+        return ConcreteProxyExecutor()
+
+    @pytest.mark.parametrize(
+        "future_factory,expected_healthy,error_substr",
+        [
+            (lambda: Future(), True, None),
+            (lambda: _done_future(RuntimeError("segfault")), False, "segfault"),
+            (lambda: _done_future(None), False, "unexpectedly"),
+            (lambda: _cancelled_future(), False, "unexpectedly"),
+        ],
+    )
+    def test_worker_states(self, executor, future_factory, expected_healthy, error_substr):
+        """Verify health status for different MPI worker future states."""
+        executor.mpi_futures = [future_factory()]
+        assert executor.check_health() is expected_healthy
+        if error_substr:
+            assert error_substr in str(executor._fatal_error)
+
+    def test_healthy_with_no_mpi_futures(self, executor):
+        """No MPI futures means healthy (single-process mode)."""
+        assert executor.check_health() is True
+
+    def test_parent_unhealthy_short_circuits(self, executor):
+        """Parent executor being unhealthy short-circuits MPI future checks."""
+        executor._set_fatal_error(RuntimeError("parent"))
+        executor.mpi_futures = [Future()]
+        assert executor.check_health() is False
+
+
+# ---------------------------------------------------------------------------
+# pre_shutdown sentinel send (regression: PR #12718)
+# ---------------------------------------------------------------------------
+class TestPreShutdownSentinel:
+    """Verify pre_shutdown puts a None sentinel on request_queue when needed.
+
+    Regression: switching the gate from ``all(not f.done() ...)`` to bare
+    ``any(...)`` silently dropped the sentinel when ``mpi_futures`` is
+    empty (the ``RemoteMpiCommSessionClient`` / ``trtllm-llmapi-launch``
+    case).  Without the sentinel, workers never receive the quit signal,
+    never put None on ``result_queue``, and the proxy's
+    ``dispatch_result_thread`` blocks indefinitely on
+    ``result_queue.get()`` -- causing a 2400 s test timeout.
+    """
+
+    @pytest.fixture
+    def executor(self):
+        return ConcreteProxyExecutor()
+
+    def test_empty_mpi_futures_sends_sentinel(self, executor):
+        """Empty ``mpi_futures`` must still trigger the sentinel send.
+
+        This is the case used by ``RemoteMpiCommSessionClient.submit()``
+        which returns ``[]`` because workers run in a separate
+        ``mgmn_leader_node`` process.
+        """
+        executor.mpi_futures = []
+        executor.pre_shutdown()
+        executor.request_queue.put_noblock.assert_called_once_with(None, retry=4)
+
+    def test_all_workers_alive_sends_sentinel(self, executor):
+        """At least one alive future means workers need to be told to quit."""
+        executor.mpi_futures = [Future(), Future()]
+        executor.pre_shutdown()
+        executor.request_queue.put_noblock.assert_called_once_with(None, retry=4)
+
+    def test_all_workers_done_skips_sentinel(self, executor):
+        """All futures already done means there is no one to notify."""
+        executor.mpi_futures = [_done_future(None), _done_future(None)]
+        executor.pre_shutdown()
+        executor.request_queue.put_noblock.assert_not_called()
+
+    def test_partial_crash_sends_sentinel(self, executor):
+        """One worker dead, one alive: surviving worker still needs the sentinel."""
+        executor.mpi_futures = [_done_future(RuntimeError("crash")), Future()]
+        executor.pre_shutdown()
+        executor.request_queue.put_noblock.assert_called_once_with(None, retry=4)
+
+    def test_double_call_is_idempotent(self, executor):
+        """Calling pre_shutdown twice must not double-send the sentinel."""
+        executor.mpi_futures = []
+        executor.pre_shutdown()
+        executor.pre_shutdown()
+        assert executor.request_queue.put_noblock.call_count == 1
+
+    def test_workers_not_started_is_noop(self, executor):
+        """If workers were never started, do not send the sentinel."""
+        executor.workers_started = False
+        executor.mpi_futures = []
+        executor.pre_shutdown()
+        executor.request_queue.put_noblock.assert_not_called()
+        assert executor.doing_shutdown is False
+
+
+# ---------------------------------------------------------------------------
+# _error_monitor_loop background thread
+# ---------------------------------------------------------------------------
+class TestErrorMonitorLoop:
+    """Tests for the _error_monitor_loop background thread."""
+
+    def test_detects_worker_crash(self):
+        """Monitor thread detects MPI worker crash and triggers pre_shutdown."""
+        executor = ConcreteProxyExecutor()
+        f = Future()
+        executor.mpi_futures = [f]
+
+        t = threading.Thread(target=executor._error_monitor_loop, daemon=True)
+        t.start()
+        time.sleep(0.05)
+        f.set_exception(RuntimeError("OOM"))
+        t.join(timeout=2.0)
+
+        assert not t.is_alive()
+        assert executor._fatal_error is not None
+        assert executor._pre_shutdown_called
+
+    def test_detects_error_queue_item(self):
+        """Monitor thread detects system errors in the error queue."""
+        executor = ConcreteProxyExecutor()
+
+        t = threading.Thread(target=executor._error_monitor_loop, daemon=True)
+        t.start()
+        time.sleep(0.05)
+        executor._error_queue.put(RuntimeError("bg failure"))
+        t.join(timeout=2.0)
+
+        assert not t.is_alive()
+        assert executor._fatal_error is not None
+
+    def test_skips_per_request_string_errors(self):
+        """Per-request string errors should not trigger fatal shutdown."""
+        executor = ConcreteProxyExecutor()
+
+        t = threading.Thread(target=executor._error_monitor_loop, daemon=True)
+        t.start()
+        time.sleep(0.05)
+        executor._error_queue.put("per-request error string")
+        # Wait past one full poll cycle (0.5s) so the monitor processes
+        # the string error and loops back, proving it didn't go fatal.
+        time.sleep(0.7)
+
+        assert executor._fatal_error is None
+        executor.doing_shutdown = True
+        executor._shutdown_event.set()
+        t.join(timeout=2.0)
+
+    def test_stops_on_shutdown_flag(self):
+        """Monitor thread exits promptly when doing_shutdown is set."""
+        executor = ConcreteProxyExecutor()
+
+        t = threading.Thread(target=executor._error_monitor_loop, daemon=True)
+        t.start()
+        time.sleep(0.05)
+        executor.doing_shutdown = True
+        executor._shutdown_event.set()  # Wake the monitor immediately
+        t.join(timeout=2.0)
+
+        assert not t.is_alive()
+
+
+# ---------------------------------------------------------------------------
+# gRPC health check
+# ---------------------------------------------------------------------------
+class TestGrpcHealthCheck:
+    """Tests for gRPC health check integration with fatal error state."""
+
+    @staticmethod
+    async def _health_check(self):
+        """Mirrors GrpcRequestManager.health_check logic."""
+        try:
+            if self.llm is None:
+                return False, "LLM not initialized"
+            if hasattr(self.llm, "_executor"):
+                if self.llm._executor is None:
+                    return False, "Executor is not available"
+                if not self.llm._executor.check_health():
+                    error_msg = "Executor is unhealthy"
+                    if self.llm._executor._fatal_error is not None:
+                        exc = self.llm._executor._fatal_error
+                        short = str(exc).splitlines()[0][:200]
+                        error_msg = f"{type(exc).__name__}: {short}"
+                    return False, error_msg
+            return True, "OK"
+        except Exception as e:
+            return False, f"Error: {e}"
+
+    def _make_manager(self, executor=None):
+        """Create a mock gRPC manager with the given executor."""
+        m = MagicMock()
+        m.llm = MagicMock()
+        m.llm._executor = executor
+        m.health_check = self._health_check.__get__(m)
+        return m
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "setup,expected_healthy,msg_substr",
+        [
+            ("healthy", True, "OK"),
+            ("fatal", False, "CUDA OOM"),
+            ("no_executor", False, "not available"),
+            ("no_llm", False, "not initialized"),
+            ("shutdown", False, "unhealthy"),
+        ],
+    )
+    async def test_health_check(self, setup, expected_healthy, msg_substr):
+        """Verify gRPC health check returns correct status and message."""
+        if setup == "no_llm":
+            m = MagicMock()
+            m.llm = None
+            m.health_check = self._health_check.__get__(m)
+        else:
+            ex = ConcreteExecutor()
+            if setup == "fatal":
+                ex._set_fatal_error(RuntimeError("CUDA OOM"))
+            elif setup == "no_executor":
+                ex = None
+            elif setup == "shutdown":
+                ex.doing_shutdown = True
+            m = self._make_manager(ex)
+
+        healthy, msg = await m.health_check()
+        assert healthy is expected_healthy
+        assert msg_substr in msg
+
+
+# ---------------------------------------------------------------------------
+# OpenAI /health endpoint
+# ---------------------------------------------------------------------------
+class TestOpenAIHealthEndpoint:
+    """Tests for OpenAI /health endpoint with fatal error shutdown."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "check_healthy,fatal_error,expect_code,sigint",
+        [
+            (True, None, 200, False),
+            (False, None, 503, False),
+            (False, RuntimeError("CUDA OOM"), 503, True),
+        ],
+    )
+    async def test_health(self, check_healthy, fatal_error, expect_code, sigint):
+        """Verify status code and SIGINT behavior for different health states."""
+        from starlette.responses import Response
+
+        server = MagicMock()
+        server._check_health = Mock(return_value=check_healthy)
+        executor = Mock()
+        executor._fatal_error = fatal_error
+        executor.doing_shutdown = False
+        server.generator = Mock()
+        server.generator._executor = executor
+
+        with patch.object(signal, "raise_signal") as mock_sig:
+            if server._check_health():
+                response = Response(status_code=200)
+            else:
+                ex = getattr(server.generator, "_executor", None)
+                if (
+                    ex is not None
+                    and getattr(ex, "_fatal_error", None) is not None
+                    and not getattr(ex, "doing_shutdown", True)
+                ):
+                    signal.raise_signal(signal.SIGINT)
+                response = Response(status_code=503)
+
+            assert response.status_code == expect_code
+            if sigint:
+                mock_sig.assert_called_once_with(signal.SIGINT)
+            else:
+                mock_sig.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# BaseLLM._check_health delegation
+# ---------------------------------------------------------------------------
+class TestBaseLLMCheckHealth:
+    """Tests for BaseLLM._check_health delegation to executor."""
+
+    @staticmethod
+    def _check_health(llm) -> bool:
+        """Mirrors BaseLLM._check_health logic."""
+        if hasattr(llm, "_executor") and llm._executor is not None:
+            return llm._executor.check_health()
+        return False
+
+    @pytest.mark.parametrize(
+        "has_executor,fatal,expected",
+        [
+            (True, False, True),
+            (True, True, False),
+            (False, False, False),
+        ],
+    )
+    def test_delegation(self, has_executor, fatal, expected):
+        """_check_health delegates to executor.check_health correctly."""
+        llm = Mock()
+        if has_executor:
+            ex = ConcreteExecutor()
+            if fatal:
+                ex._set_fatal_error(RuntimeError("x"))
+            llm._executor = ex
+        else:
+            llm._executor = None
+        assert self._check_health(llm) is expected
+
+    def test_no_executor_attr(self):
+        """Returns False when the object has no _executor attribute."""
+        assert self._check_health(object()) is False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _done_future(exc=None):
+    """Create a Future that is already done, optionally with an exception."""
+    f = Future()
+    if exc is not None:
+        f.set_exception(exc)
+    else:
+        f.set_result(None)
+    return f
+
+
+def _cancelled_future():
+    """Create a Future that has been cancelled."""
+    f = Future()
+    f.cancel()
+    return f

--- a/tests/unittest/llmapi/apps/_test_openai_metrics.py
+++ b/tests/unittest/llmapi/apps/_test_openai_metrics.py
@@ -38,7 +38,7 @@ def client(llm):
                                                       (False, 503)])
 def test_health(client, llm, is_healthy, response_code):
     if not is_healthy:
-        with patch.object(llm._executor, 'is_shutdown', return_value=True):
+        with patch.object(llm._executor, 'check_health', return_value=False):
             response = client.get("/health")
             assert response.status_code == response_code
     else:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health checks now detect executor fatal states and report concise failure reasons.
  * Added error-severity classification and a token‑bucket error budget to control escalation.
  * Background monitor thread watches worker futures and can trigger shutdown on failure.

* **Bug Fixes**
  * Fatal errors reliably initiate shutdown and cause active and queued requests to fail.
  * Health endpoints surface fatal-error details and may initiate process shutdown when appropriate.

* **Tests**
  * New comprehensive tests for error classification, health checks, monitor behavior, and endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

### Summary

- Detect unrecoverable executor errors (CUDA OOM, NCCL crash, illegal memory access) and terminate the pod cleanly instead of leaving it as a zombie that returns 200 on `/health`.
- Four-layer defense-in-depth: (1) token-bucket error budget in `PyExecutor`, (2) `_fatal_error` + `check_health()` on `GenerationExecutor`, (3) MPI worker liveness monitor + non-blocking `pre_shutdown()` in `GenerationExecutorProxy`, (4) `SIGINT` from the OpenAI `/health` endpoint on fatal.
- Request-scoped errors (validation, KV-transfer timeout, guided-decoder) bypass the budget so a burst of bad requests can't crash a healthy server.

### Problem

An engine crash never flips `is_shutdown()`, so `/health` stays 200, Kubernetes doesn't restart the pod, and the orchestrator keeps routing requests to a black-holed engine until manual intervention.

### Approach

**`error_classification.py`:**

- `classify_error()`: three-tier classification (immediate-fatal / severe / transient).
- `ErrorBudget` dataclass: token-bucket with `consume()`. Starts at 1.0, recovers 0.1/s. Immediate-fatal bypasses; severe costs 5×; transient costs 1×.

**`PyExecutor`:**

- `_handle_errors(charge_budget=True | False)`. System errors (forward/decode/sample/hang detector) consume budget and may go fatal; request-scoped errors (validation, KV-transfer timeout, guided-decoder) skip the budget and only fail the affected request.
- Fatal path: `is_shutdown=True` immediately, drain `waiting_queue` + `executor_request_queue`, list-copy `active_requests` before `clear()` (aliased-list fix), enqueue shutdown.

**`GenerationExecutor`:**

- `_fatal_error` field + first-wins `_set_fatal_error()`.
- `check_health()` drains the error queue with `get_nowait()`, filtering `RequestError`/`str` per-request errors so a single bad request can't poison server health. `is_shutdown()` returns True when `_fatal_error` is set.

**`GenerationExecutorProxy` (MPI multi-process):**

- Shared `_check_mpi_futures()` / `_drain_error_queue()` helpers used by both `check_health()` and a 5 s daemon `_error_monitor_loop`. Both use non-blocking `pre_shutdown()` and drain-all patterns.
- `pre_shutdown()` sentinel gate: `not self.mpi_futures or any(not f.done() ...)`. Covers (a) the empty-futures `RemoteMpiCommSessionClient` / `trtllm-llmapi-launch` case (workers in a separate `mgmn_leader_node` process; no local handles) — bare `any([])` returns False and silently dropped the sentinel, hanging `dispatch_result_thread.join()` and producing the 2400 s `test_performance_alignment[1]` timeout — and (b) partial-crash where some workers exited early.
- Self-join guard in `shutdown()` for the monitor thread.

**Serving layer:**

- `BaseLLM._check_health()` → `executor.check_health()`.
- `GrpcRequestManager.health_check` → `check_health()`, returns sanitized `"TypeName: first line"` to clients (full traceback logged server-side).
- `OpenAIServer /health` raises `SIGINT` on fatal (matches `CppExecutorError` pattern).

## Test coverage

| Component | Tests | How |
| --- | --- | --- |
| `classify_error()` | 15 parametrized | Tests the **real** module-level function (imported via `importlib` without C++ extensions) |
| `ErrorBudget` | 11 | Real dataclass: immediate-fatal bypass, severe/transient exhaustion, time-based recovery, aliased-list fix, queue drain, `charge_budget=False` skips budget and never triggers fatal |
| `GenerationExecutor` | 10 | `_set_fatal_error` first-wins, `is_shutdown` (4 states), `check_health` drain-all with per-request skip |
| `GenerationExecutorProxy` `check_health` | 6 | MPI worker future states, shared `_check_mpi_futures`/`_drain_error_queue` helpers |
| `GenerationExecutorProxy` `pre_shutdown` sentinel | 6 | **Regression** for the 2400 s `test_performance_alignment[1]` hang: empty-`mpi_futures`, all-alive, all-done, partial-crash, idempotency, not-yet-started |
| `_error_monitor_loop` | 4 | Worker crash, error queue, per-request string skip, shutdown flag |
| gRPC health check | 5 | Parametrized: healthy, fatal, no executor, no LLM, shutdown |
| OpenAI `/health` | 3 | Parametrized: 200, 503, 503+SIGINT |
| `BaseLLM._check_health` | 4 | Parametrized delegation |

**Total: 74 unit tests in `tests/unittest/executor/test_fatal_error_health_check.py` (registered in `l0_a10.yml`).** The new `test_empty_mpi_futures_sends_sentinel` was verified to *fail* against the earlier buggy `any(...)`-only gate.


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
