### PR TITLE
[None][feat] Add per-request stream_interval support

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -674,6 +674,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_num_accepted_draft_tokens_indices = []
         self.py_rewind_draft_token_separate_adjustment = 0
         self.py_decoding_iter = 0
+        self.py_stream_interval = None
         self.is_attention_dp_dummy = False
         self.is_cuda_graph_dummy = False
         self.py_kv_transfer_start_time = None
@@ -1033,6 +1034,8 @@ def executor_request_to_llm_request(
                               LogprobMode.RAW),
     )
 
+    llm_request.py_stream_interval = getattr(executor_request,
+                                             "py_stream_interval", None)
     llm_request.py_disaggregated_params = getattr(executor_request,
                                                   "py_disaggregated_params",
                                                   None)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3582,7 +3582,7 @@ class PyExecutor:
 
             request_done = False
             if request.py_decoding_iter == 1 or request.is_finished or \
-                    request.py_decoding_iter % self.stream_interval == 0:
+                    request.py_decoding_iter % (request.py_stream_interval or self.stream_interval) == 0:
                 response = request.create_response(False, self.dist.rank)
                 if response:
                     request_done = request.is_finished

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -568,7 +568,7 @@ class BaseWorker(GenerationExecutor):
             executor_request.py_num_logprobs = request.sampling_params.logprobs
             executor_request.py_lora_path = py_lora_path
             executor_request.py_logprobs_mode = request.sampling_params.logprobs_mode
-            executor_request.py_stream_interval = request.sampling_params._stream_interval
+            executor_request.py_stream_interval = request.sampling_params.stream_interval
 
             # here we add executor_request.py_disaggregated_params= request.disaggregated_params for python cache transceiver
             if self._is_pytorch_backend and request.disaggregated_params is not None:

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -568,6 +568,7 @@ class BaseWorker(GenerationExecutor):
             executor_request.py_num_logprobs = request.sampling_params.logprobs
             executor_request.py_lora_path = py_lora_path
             executor_request.py_logprobs_mode = request.sampling_params.logprobs_mode
+            executor_request.py_stream_interval = request.sampling_params._stream_interval
 
             # here we add executor_request.py_disaggregated_params= request.disaggregated_params for python cache transceiver
             if self._is_pytorch_backend and request.disaggregated_params is not None:

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -717,7 +717,7 @@ class DetokenizedGenerationResultBase(GenerationResultBase):
                         prev_text=beam_output.text,
                         states=beam_output._incremental_states,
                         flush=self._done,
-                        stream_interval=self.sampling_params._stream_interval,
+                        stream_interval=self.sampling_params.stream_interval,
                         **kwargs)
                 else:
                     beam_output.text = self.tokenizer.decode(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -816,8 +816,11 @@ class BaseLLM:
                 sampling_params._generation_logits_auto_enabled = True
 
         if sampling_params._stream_interval is None:
-            sampling_params._stream_interval = getattr(self.args,
-                                                       "stream_interval", 1)
+            if sampling_params.stream_interval is not None:
+                sampling_params._stream_interval = sampling_params.stream_interval
+            else:
+                sampling_params._stream_interval = getattr(
+                    self.args, "stream_interval", 1)
         sampling_params.return_perf_metrics = sampling_params.return_perf_metrics or self.args.return_perf_metrics
         return sampling_params
 

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -815,12 +815,9 @@ class BaseLLM:
                 sampling_params.return_generation_logits = True
                 sampling_params._generation_logits_auto_enabled = True
 
-        if sampling_params._stream_interval is None:
-            if sampling_params.stream_interval is not None:
-                sampling_params._stream_interval = sampling_params.stream_interval
-            else:
-                sampling_params._stream_interval = getattr(
-                    self.args, "stream_interval", 1)
+        if sampling_params.stream_interval is None:
+            sampling_params.stream_interval = getattr(
+                self.args, "stream_interval", 1)
         sampling_params.return_perf_metrics = sampling_params.return_perf_metrics or self.args.return_perf_metrics
         return sampling_params
 

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -288,8 +288,8 @@ class SamplingParams:
     truncate_prompt_tokens: Optional[int] = None
     skip_special_tokens: bool = True
     spaces_between_special_tokens: bool = True
-    # Currently, _stream_interval is only used to pass llm.args.stream_interval to tokenizer.
-    # TODO: make this a per-request parameter.
+    stream_interval: Optional[int] = None
+    # _stream_interval is the resolved value (per-request or engine default), used internally.
     _stream_interval: Optional[int] = field(default=None, init=False, repr=False)
 
     def __post_init__(self):
@@ -314,6 +314,10 @@ class SamplingParams:
         For instance, while the greedy decoding with n > 1 is capable in the
         Executor class of C++ runtime, the LLM API disallows such combination.
         """
+        if self.stream_interval is not None and self.stream_interval <= 0:
+            raise ValueError(
+                f"require stream_interval > 0, got stream_interval={self.stream_interval}"
+            )
         if self.top_p is not None and (self.top_p < 0 or self.top_p > 1):
             raise ValueError(f"require 0 <= top_p <= 1, got top_p={self.top_p}")
         if self.top_k is not None and self.top_k < 0:

--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -289,8 +289,6 @@ class SamplingParams:
     skip_special_tokens: bool = True
     spaces_between_special_tokens: bool = True
     stream_interval: Optional[int] = None
-    # _stream_interval is the resolved value (per-request or engine default), used internally.
-    _stream_interval: Optional[int] = field(default=None, init=False, repr=False)
 
     def __post_init__(self):
         if self.pad_id is None:

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -387,6 +387,7 @@ class CompletionRequest(OpenAIBaseModel):
     )
     stream_interval: Optional[int] = Field(
         default=None,
+        gt=0,
         description=(
             "The iteration interval to create responses under the streaming mode. "
             "If not set, the engine-level default is used."),
@@ -756,6 +757,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
          ))
     stream_interval: Optional[int] = Field(
         default=None,
+        gt=0,
         description=(
             "The iteration interval to create responses under the streaming mode. "
             "If not set, the engine-level default is used."),
@@ -913,6 +915,7 @@ class ResponsesRequest(OpenAIBaseModel):
     user: Optional[str] = None
     stream_interval: Optional[int] = Field(
         default=None,
+        gt=0,
         description=(
             "The iteration interval to create responses under the streaming mode. "
             "If not set, the engine-level default is used."),

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -385,6 +385,12 @@ class CompletionRequest(OpenAIBaseModel):
         default=None,
         description=("Parameters for disaggregated serving"),
     )
+    stream_interval: Optional[int] = Field(
+        default=None,
+        description=(
+            "The iteration interval to create responses under the streaming mode. "
+            "If not set, the engine-level default is used."),
+    )
 
     # doc: end-completion-extra-params
 
@@ -431,6 +437,7 @@ class CompletionRequest(OpenAIBaseModel):
 
             # completion-extra-params
             add_special_tokens=self.add_special_tokens,
+            stream_interval=self.stream_interval,
         )
         if self.logprobs:
             if backend == "pytorch":
@@ -747,6 +754,12 @@ class ChatCompletionRequest(OpenAIBaseModel):
         ("If specified, KV cache will be salted with the provided string "
          "to limit the kv cache reuse on with the requests having the same string."
          ))
+    stream_interval: Optional[int] = Field(
+        default=None,
+        description=(
+            "The iteration interval to create responses under the streaming mode. "
+            "If not set, the engine-level default is used."),
+    )
 
     # doc: end-chat-completion-extra-params
 
@@ -792,6 +805,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
             # chat-completion-extra-params
             add_special_tokens=self.add_special_tokens,
+            stream_interval=self.stream_interval,
         )
         if self.logprobs:
             logprobs = 1 if not self.top_logprobs else self.top_logprobs
@@ -897,6 +911,12 @@ class ResponsesRequest(OpenAIBaseModel):
     top_p: Optional[float] = None
     truncation: Optional[Literal["auto", "disabled"]] = "disabled"
     user: Optional[str] = None
+    stream_interval: Optional[int] = Field(
+        default=None,
+        description=(
+            "The iteration interval to create responses under the streaming mode. "
+            "If not set, the engine-level default is used."),
+    )
 
     request_id: str = Field(
         default_factory=lambda: f"resp_{str(uuid.uuid4().hex)}",
@@ -942,6 +962,7 @@ class ResponsesRequest(OpenAIBaseModel):
             logprobs=self.top_logprobs,
             stop_token_ids=stop_token_ids,
             guided_decoding=guided_decoding,
+            stream_interval=self.stream_interval,
         )
 
     @model_validator(mode="before")

--- a/tests/unittest/api_stability/references_committed/sampling_params.yaml
+++ b/tests/unittest/api_stability/references_committed/sampling_params.yaml
@@ -123,6 +123,9 @@ methods:
       spaces_between_special_tokens:
         annotation: bool
         default: true
+      stream_interval:
+        annotation: Optional[int]
+        default: null
       # Returning controls
       logprobs:
         annotation: Optional[int]

--- a/tests/unittest/llmapi/test_executor.py
+++ b/tests/unittest/llmapi/test_executor.py
@@ -172,6 +172,62 @@ def test_invalid_sampling_params():
         SamplingParams(max_tokens=4, n=4, best_of=3, use_beam_search=True)
 
 
+def test_stream_interval_validation():
+    # Valid values
+    sp = SamplingParams(stream_interval=1)
+    assert sp.stream_interval == 1
+    sp = SamplingParams(stream_interval=10)
+    assert sp.stream_interval == 10
+    sp = SamplingParams(stream_interval=None)
+    assert sp.stream_interval is None
+
+    # Invalid values
+    with pytest.raises(ValueError, match="stream_interval"):
+        SamplingParams(stream_interval=0)
+    with pytest.raises(ValueError, match="stream_interval"):
+        SamplingParams(stream_interval=-1)
+
+
+def test_stream_interval_openai_protocol():
+    from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
+                                                     CompletionRequest)
+
+    # CompletionRequest: valid stream_interval passes through
+    req = CompletionRequest(model="m", prompt="hi", stream_interval=5)
+    sp = req.to_sampling_params()
+    assert sp.stream_interval == 5
+
+    # CompletionRequest: None leaves stream_interval unset
+    req = CompletionRequest(model="m", prompt="hi")
+    sp = req.to_sampling_params()
+    assert sp.stream_interval is None
+
+    # CompletionRequest: invalid stream_interval is caught
+    req = CompletionRequest(model="m", prompt="hi", stream_interval=-1)
+    with pytest.raises(ValueError, match="stream_interval"):
+        req.to_sampling_params()
+
+    # ChatCompletionRequest: valid stream_interval passes through
+    req = ChatCompletionRequest(model="m",
+                                messages=[{
+                                    "role": "user",
+                                    "content": "hi"
+                                }],
+                                stream_interval=10)
+    sp = req.to_sampling_params()
+    assert sp.stream_interval == 10
+
+    # ChatCompletionRequest: invalid stream_interval is caught
+    req = ChatCompletionRequest(model="m",
+                                messages=[{
+                                    "role": "user",
+                                    "content": "hi"
+                                }],
+                                stream_interval=0)
+    with pytest.raises(ValueError, match="stream_interval"):
+        req.to_sampling_params()
+
+
 @pytest.mark.skipif(torch.cuda.device_count() < 2 or WORLD_SIZE != 2,
                     reason="Must run on 2 MPI ranks with at least 2 GPUs")
 def test_sync_generation_tp_main_node_only(llama_7b_tp2_path: Path):

--- a/tests/unittest/llmapi/test_executor.py
+++ b/tests/unittest/llmapi/test_executor.py
@@ -189,8 +189,13 @@ def test_stream_interval_validation():
 
 
 def test_stream_interval_openai_protocol():
-    from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
-                                                     CompletionRequest)
+    from pydantic import ValidationError
+
+    from tensorrt_llm.serve.openai_protocol import (
+        ChatCompletionRequest,
+        CompletionRequest,
+        ResponsesRequest,
+    )
 
     # CompletionRequest: valid stream_interval passes through
     req = CompletionRequest(model="m", prompt="hi", stream_interval=5)
@@ -202,10 +207,11 @@ def test_stream_interval_openai_protocol():
     sp = req.to_sampling_params()
     assert sp.stream_interval is None
 
-    # CompletionRequest: invalid stream_interval is caught
-    req = CompletionRequest(model="m", prompt="hi", stream_interval=-1)
-    with pytest.raises(ValueError, match="stream_interval"):
-        req.to_sampling_params()
+    # CompletionRequest: invalid stream_interval rejected at construction
+    with pytest.raises(ValidationError, match="stream_interval"):
+        CompletionRequest(model="m", prompt="hi", stream_interval=-1)
+    with pytest.raises(ValidationError, match="stream_interval"):
+        CompletionRequest(model="m", prompt="hi", stream_interval=0)
 
     # ChatCompletionRequest: valid stream_interval passes through
     req = ChatCompletionRequest(model="m",
@@ -217,15 +223,28 @@ def test_stream_interval_openai_protocol():
     sp = req.to_sampling_params()
     assert sp.stream_interval == 10
 
-    # ChatCompletionRequest: invalid stream_interval is caught
-    req = ChatCompletionRequest(model="m",
-                                messages=[{
-                                    "role": "user",
-                                    "content": "hi"
-                                }],
-                                stream_interval=0)
-    with pytest.raises(ValueError, match="stream_interval"):
-        req.to_sampling_params()
+    # ChatCompletionRequest: invalid stream_interval rejected at construction
+    with pytest.raises(ValidationError, match="stream_interval"):
+        ChatCompletionRequest(model="m",
+                              messages=[{
+                                  "role": "user",
+                                  "content": "hi"
+                              }],
+                              stream_interval=0)
+
+    # ResponsesRequest: valid stream_interval passes through
+    req = ResponsesRequest(model="m", input="hi", stream_interval=5)
+    sp = req.to_sampling_params()
+    assert sp.stream_interval == 5
+
+    # ResponsesRequest: None leaves stream_interval unset
+    req = ResponsesRequest(model="m", input="hi")
+    sp = req.to_sampling_params()
+    assert sp.stream_interval is None
+
+    # ResponsesRequest: invalid stream_interval rejected at construction
+    with pytest.raises(ValidationError, match="stream_interval"):
+        ResponsesRequest(model="m", input="hi", stream_interval=-1)
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2 or WORLD_SIZE != 2,


### PR DESCRIPTION
## Summary

- Adds a per-request `stream_interval` field to `SamplingParams`, `CompletionRequest`, `ChatCompletionRequest`, and `ResponsesRequest`
- Allows callers to override the engine-level `stream_interval` default on individual requests
- Resolution order: per-request value → engine default → fallback (1)
- Fixes a validation bypass where `stream_interval` set post-construction on `SamplingParams` skipped `_validate()`; now passed via the constructor so invalid values (≤ 0) are caught immediately

## Test plan

- [x] `test_stream_interval_validation` — verifies `SamplingParams` rejects `stream_interval=0` and `stream_interval=-1`
- [x] `test_stream_interval_openai_protocol` — verifies `CompletionRequest` and `ChatCompletionRequest` correctly pass `stream_interval` through `to_sampling_params()` and reject invalid values
- [x] Existing `test_llm_generate_async_with_stream_interval` — engine-level stream interval (unchanged)
- [x] `tests/unittest/api_stability/` — API stability tests pass with updated `sampling_params.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `stream_interval` parameter to control the iteration interval for streaming response generation on a per-request basis, providing flexibility beyond the executor-wide default.
  * `stream_interval` is now available in `SamplingParams` and OpenAI API requests (`CompletionRequest`, `ChatCompletionRequest`, `ResponsesRequest`).
  * Added validation to ensure `stream_interval` values are greater than 0 when provided.

* **Tests**
  * Added validation tests for `stream_interval` parameter handling and OpenAI protocol integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->