### PR TITLE
[None][feat] Optimize mamba SSD prefill and extend flashinfer dispatch

### DIFF
--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -60,9 +60,27 @@ using tensorrt_llm::common::launchWithPdlWhenEnabled;
         __VA_ARGS__;                                                                                                   \
         break;                                                                                                         \
     }                                                                                                                  \
+    case 18:                                                                                                           \
+    {                                                                                                                  \
+        constexpr int TOP_K = 18;                                                                                      \
+        __VA_ARGS__;                                                                                                   \
+        break;                                                                                                         \
+    }                                                                                                                  \
     case 16:                                                                                                           \
     {                                                                                                                  \
         constexpr int TOP_K = 16;                                                                                      \
+        __VA_ARGS__;                                                                                                   \
+        break;                                                                                                         \
+    }                                                                                                                  \
+    case 14:                                                                                                           \
+    {                                                                                                                  \
+        constexpr int TOP_K = 14;                                                                                      \
+        __VA_ARGS__;                                                                                                   \
+        break;                                                                                                         \
+    }                                                                                                                  \
+    case 12:                                                                                                           \
+    {                                                                                                                  \
+        constexpr int TOP_K = 12;                                                                                      \
         __VA_ARGS__;                                                                                                   \
         break;                                                                                                         \
     }                                                                                                                  \

--- a/tensorrt_llm/_torch/models/checkpoints/hf/nemotron_h_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/nemotron_h_weight_mapper.py
@@ -7,6 +7,7 @@ from tensorrt_llm._torch.models.modeling_utils import register_mapper
 from tensorrt_llm._torch.utils import split
 
 
+@register_mapper("HF", "NemotronHPuzzleForCausalLM")
 @register_mapper("HF", "NemotronHForCausalLM")
 class NemotronHHfWeightMapper(HfWeightMapper):
 

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
 
 from torch import nn
-from transformers import AutoConfig, PretrainedConfig
+from transformers import AutoConfig, NemotronHConfig, PretrainedConfig
 
 from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
     BaseWeightMapper
@@ -52,12 +52,11 @@ from .modeling_speculative import SpecDecOneEngineForCausalLM
 from .modeling_utils import DecoderModel, register_auto_model
 
 
-class NemotronHConfig(PretrainedConfig):
-    model_type = "nemotron_h"
-
-
 class NemotronHPuzzleConfig(PretrainedConfig):
     model_type = "nemotron_h_puzzle"
+
+
+NemotronHModelConfig = ModelConfig[NemotronHConfig | NemotronHPuzzleConfig]
 
 
 def _bc_getattr(bc, key, default=None):
@@ -81,7 +80,7 @@ class MLPLayer(MLP):
 
     def __init__(
         self,
-        model_config: ModelConfig[NemotronHConfig],
+        model_config: NemotronHModelConfig,
         layer_idx: int,
         reduce_output: bool = True,
         use_custom_cublas_mm: bool = False,
@@ -121,7 +120,7 @@ class TransformerLayer(Attention):
 
     def __init__(
         self,
-        model_config: ModelConfig[NemotronHConfig],
+        model_config: NemotronHModelConfig,
         layer_idx: int,
         reduce_output: bool = False,
         use_custom_cublas_mm: bool = False,
@@ -413,7 +412,7 @@ class NemotronHLayer(DecoderLayer):
 
     def __init__(
         self,
-        model_config: ModelConfig[NemotronHConfig],
+        model_config: NemotronHModelConfig,
         layer_idx: int,
         # M -> MambaLayer
         # - -> MLPLayer
@@ -638,7 +637,7 @@ class NemotronHLayer(DecoderLayer):
 
 class NemotronHModel(DecoderModel):
 
-    def __init__(self, model_config: ModelConfig[NemotronHConfig]):
+    def __init__(self, model_config: NemotronHModelConfig):
         super().__init__(model_config)
         config = self.model_config.pretrained_config
 
@@ -764,7 +763,7 @@ class NemotronHForCausalLM(SpecDecOneEngineForCausalLM[NemotronHModel,
 
     def __init__(
         self,
-        model_config: ModelConfig[NemotronHConfig | NemotronHPuzzleConfig],
+        model_config: NemotronHModelConfig,
     ):
         # rms_norm_eps might be named differently in the config.
         if hasattr(model_config.pretrained_config, "rms_norm_eps"):
@@ -911,7 +910,7 @@ class NemotronHMTPDecoderLayer(NemotronHLayer):
 
     def __init__(
         self,
-        model_config: ModelConfig[NemotronHConfig],
+        model_config: NemotronHModelConfig,
         layer_idx: int,
         aux_stream_dict: dict[AuxStreamType, torch.cuda.Stream],
         has_start_projections: bool,
@@ -1062,7 +1061,7 @@ class NemotronHMTP(nn.Module):
 
     def __init__(
         self,
-        model_config: ModelConfig[NemotronHConfig],
+        model_config: NemotronHModelConfig,
         layer_idx: int,
         aux_stream_dict: dict[AuxStreamType, torch.cuda.Stream],
         is_separate_draft_engine: bool = False,
@@ -1114,8 +1113,8 @@ class NemotronHMTP(nn.Module):
         # Add shared_head for MTP, following DeepseekV3MTP pattern
         self.shared_head = DeepseekV3MTPHead(model_config)
 
-    def _get_mtp_sublayer_quant_config(
-            self, model_config: ModelConfig[NemotronHConfig], layer_idx: int):
+    def _get_mtp_sublayer_quant_config(self, model_config: NemotronHModelConfig,
+                                       layer_idx: int):
         """
         Get quantization config for MTP sublayer.
         The MTP layer in the nvfp4 checkpoint is unquantized. Because the TRTLLM
@@ -1161,5 +1160,4 @@ class NemotronHMTP(nn.Module):
         return hidden_states
 
 
-AutoConfig.register(NemotronHConfig.model_type, NemotronHConfig)
 AutoConfig.register(NemotronHPuzzleConfig.model_type, NemotronHPuzzleConfig)

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
 
 from torch import nn
-from transformers import NemotronHConfig, PretrainedConfig
+from transformers import AutoConfig, PretrainedConfig
 
 from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
     BaseWeightMapper
@@ -50,6 +50,31 @@ from ..utils import AuxStreamType, EventType, Fp4QuantizedTensor
 from .modeling_deepseekv3 import DeepseekV3MTPHead
 from .modeling_speculative import SpecDecOneEngineForCausalLM
 from .modeling_utils import DecoderModel, register_auto_model
+
+
+class NemotronHConfig(PretrainedConfig):
+    model_type = "nemotron_h"
+
+
+class NemotronHPuzzleConfig(PretrainedConfig):
+    model_type = "nemotron_h_puzzle"
+
+
+def _bc_getattr(bc, key, default=None):
+    """Get attribute from a block_config entry (dict or dataclass)."""
+    if isinstance(bc, dict):
+        return bc.get(key, default)
+    return getattr(bc, key, default)
+
+
+def _get_layer_moe_param(config, layer_idx: int, param_name: str):
+    """Get per-layer MoE parameter, falling back to global config."""
+    block_configs = getattr(config, 'block_configs', None)
+    if block_configs and layer_idx < len(block_configs):
+        val = _bc_getattr(block_configs[layer_idx], param_name)
+        if val is not None:
+            return val
+    return getattr(config, param_name, None)
 
 
 class MLPLayer(MLP):
@@ -154,22 +179,26 @@ class NemotronHMOE(nn.Module):
         self.hidden_dim = config.hidden_size
         self.ffn_dim = config.intermediate_size
         self.layer_idx = layer_idx
-        self.moe_intermediate_size = (config.moe_intermediate_size[0]
-                                      if isinstance(
-                                          config.moe_intermediate_size, list)
-                                      else config.moe_intermediate_size)
-        self.use_latent_moe: bool = getattr(config, "moe_latent_size",
-                                            None) is not None
-        self.moe_hidden_size: int = (config.moe_latent_size
-                                     if self.use_latent_moe else
+
+        # Per-layer MoE params (models with block_configs have varying params).
+        def _moe(name):
+            return _get_layer_moe_param(config, layer_idx, name)
+
+        moe_intermediate = _moe('moe_intermediate_size')
+        self.moe_intermediate_size = (moe_intermediate[0] if isinstance(
+            moe_intermediate, list) else moe_intermediate)
+
+        moe_latent = _moe('moe_latent_size')
+        self.use_latent_moe: bool = moe_latent is not None
+        self.moe_hidden_size: int = (moe_latent if self.use_latent_moe else
                                      config.hidden_size)
         self.mlp_bias = config.mlp_bias if hasattr(config,
                                                    "mlp_bias") else False
         self.moe_n_group = config.n_group
-        self.num_experts = config.n_routed_experts
+        self.num_experts = _moe('n_routed_experts')
         self.hidden_size = config.hidden_size
         self.num_shared_experts = config.n_shared_experts
-        self.top_k = config.num_experts_per_tok
+        self.top_k = _moe('num_experts_per_tok')
         self.enable_attention_dp = model_config.mapping.enable_attention_dp
         self.routed_scaling_factor = config.routed_scaling_factor
         self.mapping = model_config.mapping
@@ -179,7 +208,7 @@ class NemotronHMOE(nn.Module):
             self.shared_experts = None
         else:
             shared_expert_intermediate_size = (
-                config.moe_shared_expert_intermediate_size *
+                _moe('moe_shared_expert_intermediate_size') *
                 config.n_shared_experts)
 
             self.shared_experts = MLP(
@@ -726,13 +755,16 @@ class NemotronHModel(DecoderModel):
         return hidden_states
 
 
+@register_auto_model("NemotronHPuzzleForCausalLM")
 @register_auto_model("NemotronHForCausalLM")
 class NemotronHForCausalLM(SpecDecOneEngineForCausalLM[NemotronHModel,
-                                                       NemotronHConfig]):
+                                                       NemotronHConfig
+                                                       | NemotronHPuzzleConfig]
+                           ):
 
     def __init__(
         self,
-        model_config: ModelConfig[NemotronHConfig],
+        model_config: ModelConfig[NemotronHConfig | NemotronHPuzzleConfig],
     ):
         # rms_norm_eps might be named differently in the config.
         if hasattr(model_config.pretrained_config, "rms_norm_eps"):
@@ -742,6 +774,8 @@ class NemotronHForCausalLM(SpecDecOneEngineForCausalLM[NemotronHModel,
         else:
             raise ValueError("layer_norm_epsilon or rms_norm_eps is not set")
         model_config.pretrained_config.rms_norm_eps = rms_epsilon
+
+        self._normalize_puzzle_config(model_config.pretrained_config)
 
         if (not model_config.mapping.enable_attention_dp
                 and model_config.mapping.tp_size not in [1, 2, 4, 8]):
@@ -798,6 +832,31 @@ class NemotronHForCausalLM(SpecDecOneEngineForCausalLM[NemotronHModel,
             self.model.layers.extend(self.draft_model.mtp_layers)
             self.epilogue.extend(self.draft_model.mtp_layers)
             self.epilogue.append(self.spec_worker)
+
+    @staticmethod
+    def _normalize_puzzle_config(config):
+        """Set global MoE defaults from block_configs for models with per-layer MoE params."""
+        block_configs = getattr(config, 'block_configs', None)
+        if not block_configs:
+            return
+
+        def _is_moe(bc):
+            return _bc_getattr(bc, 'block_type') == 'moe'
+
+        first_moe = next((bc for bc in block_configs if _is_moe(bc)), None)
+        if first_moe is None:
+            return
+
+        # Prefer MTP MoE block as fallback (used for MTP layers beyond
+        # block_configs range), otherwise use first main-model MoE block.
+        mtp_configs = getattr(config, 'mtp_block_configs', None) or []
+        fallback = next((bc for bc in mtp_configs if _is_moe(bc)), first_moe)
+
+        for attr in ('n_routed_experts', 'moe_intermediate_size',
+                     'num_experts_per_tok', 'moe_latent_size',
+                     'moe_shared_expert_intermediate_size'):
+            if not hasattr(config, attr) or getattr(config, attr) is None:
+                setattr(config, attr, _bc_getattr(fallback, attr))
 
     def load_weights(self, weights: dict, weight_mapper: BaseWeightMapper):
         new_weights = weight_mapper.preprocess_weights(weights)
@@ -1100,3 +1159,7 @@ class NemotronHMTP(nn.Module):
                 lora_params=lora_params,
             )
         return hidden_states
+
+
+AutoConfig.register(NemotronHConfig.model_type, NemotronHConfig)
+AutoConfig.register(NemotronHPuzzleConfig.model_type, NemotronHPuzzleConfig)

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -1229,7 +1229,7 @@ class MTPForCausalLM(nn.Module):
             case "exaone_moe":
                 from .modeling_exaone_moe import ExaoneMoeMTP
                 mtp_layer = ExaoneMoeMTP
-            case "nemotron_h":
+            case "nemotron_h" | "nemotron_h_puzzle":
                 from .modeling_nemotron_h import NemotronHMTP
                 mtp_layer = NemotronHMTP
             case "qwen3_next":

--- a/tensorrt_llm/_torch/modules/mamba/fuse_elementwise_ops.py
+++ b/tensorrt_llm/_torch/modules/mamba/fuse_elementwise_ops.py
@@ -423,3 +423,98 @@ def split_qkv_contiguous(
         k_flat.view(1, seq_len, num_q_heads, head_k_dim),
         v_flat.view(1, seq_len, num_v_heads, head_v_dim),
     )
+
+
+@triton.jit
+def _ssd_output_transpose_kernel(
+    src_ptr,
+    dst_ptr,
+    num_prefill_tokens,
+    H,
+    D,
+    NC,
+    CS,
+    stride_h,
+    stride_d,
+    stride_nc,
+    HD,
+    BLOCK_L: tl.constexpr,
+    BLOCK_HD: tl.constexpr,
+):
+    # (1, H, D, NC, CS) → (L, H*D); BLOCK_L | CS keeps each tile in one chunk.
+    pid_l = tl.program_id(0)
+    pid_hd = tl.program_id(1)
+
+    l_offs = pid_l * BLOCK_L + tl.arange(0, BLOCK_L)
+    hd_offs = pid_hd * BLOCK_HD + tl.arange(0, BLOCK_HD)
+
+    l_mask = l_offs < num_prefill_tokens
+    hd_mask = hd_offs < HD
+
+    nc = l_offs // CS
+    cs = l_offs % CS
+    h = hd_offs // D
+    d = hd_offs % D
+
+    # int64 offsets: H*D*NC*CS can exceed INT32_MAX for long seqlens.
+    src_off = (
+        h.to(tl.int64)[None, :] * stride_h
+        + d.to(tl.int64)[None, :] * stride_d
+        + nc.to(tl.int64)[:, None] * stride_nc
+        + cs.to(tl.int64)[:, None]
+    )
+    mask = l_mask[:, None] & hd_mask[None, :]
+    data = tl.load(src_ptr + src_off, mask=mask, other=0.0)
+
+    dst_off = l_offs.to(tl.int64)[:, None] * HD + hd_offs[None, :]
+    tl.store(dst_ptr + dst_off, data, mask=mask)
+
+
+def ssd_output_transpose(
+    out_contig: torch.Tensor,
+    dst: torch.Tensor,
+    num_prefill_tokens: int,
+) -> None:
+    """Transpose (1, H, D, NC, CS) bf16 to (num_prefill_tokens, H*D) bf16 in dst."""
+    # Tuned on B200; bandwidth-bound, so a wider tile (two heads, num_warps=2)
+    # beats more warps. BLOCK_L must divide CS so each tile stays in one chunk.
+    BLOCK_L = 128
+    BLOCK_HD = 128
+    NUM_WARPS = 2
+
+    assert out_contig.is_contiguous(), "out_contig must be contiguous in (B, H, D, NC, CS)"
+    assert out_contig.ndim == 5 and out_contig.shape[0] == 1, (
+        f"expected (1, H, D, NC, CS), got {tuple(out_contig.shape)}"
+    )
+    _, H, D, NC, CS = out_contig.shape
+    HD = H * D
+    assert dst.is_contiguous()
+    assert dst.numel() == num_prefill_tokens * HD, (
+        f"dst numel {dst.numel()} != L_p*H*D = {num_prefill_tokens}*{HD}"
+    )
+    assert NC * CS >= num_prefill_tokens, (
+        f"padded seqlen {NC * CS} < num_prefill_tokens {num_prefill_tokens}"
+    )
+    assert CS % BLOCK_L == 0, f"chunk_size {CS} must be a multiple of BLOCK_L={BLOCK_L}"
+
+    stride_h = D * NC * CS
+    stride_d = NC * CS
+    stride_nc = CS
+
+    grid = (triton.cdiv(num_prefill_tokens, BLOCK_L), triton.cdiv(HD, BLOCK_HD))
+    _ssd_output_transpose_kernel[grid](
+        out_contig,
+        dst,
+        num_prefill_tokens,
+        H,
+        D,
+        NC,
+        CS,
+        stride_h,
+        stride_d,
+        stride_nc,
+        HD,
+        BLOCK_L=BLOCK_L,
+        BLOCK_HD=BLOCK_HD,
+        num_warps=NUM_WARPS,
+    )

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -157,13 +157,10 @@ class Mamba2Mixer(nn.Module):
 
         # Choose between flashinfer and native implementation. (default to flashinfer)
         self._mamba_ssm_cache_dtype = config.quant_config.mamba_ssm_cache_dtype
-        # TODO: Update head_dims and head_group_ratios once flashinfer is updated.
+        # TODO: Update head_dims once flashinfer is updated.
+        # Nemotron-v2-Nano (mamba_head_dim=80) is not supported by flashinfer yet.
         supported_head_dims = [64, 128]
-        supported_head_group_ratios = [1, 8, 16]
-        head_group_ratio = (self.tp_nheads //
-                            self.tp_ngroups if self.tp_ngroups > 0 else 0)
-        self._use_flashinfer = (head_dim in supported_head_dims and
-                                head_group_ratio in supported_head_group_ratios)
+        self._use_flashinfer = head_dim in supported_head_dims
         self._stochastic_rounding_requested = (
             config.quant_config.mamba_ssm_stochastic_rounding)
         self._philox_rounds = config.quant_config.mamba_ssm_philox_rounds

--- a/tensorrt_llm/_torch/modules/mamba/ssd_combined.py
+++ b/tensorrt_llm/_torch/modules/mamba/ssd_combined.py
@@ -21,11 +21,14 @@ import functools
 import torch
 import torch.nn.functional as F
 from einops import rearrange
+from flashinfer.mamba import SSDCombined
 
 from tensorrt_llm._utils import is_sm_100f
 from tensorrt_llm.logger import logger
 from tensorrt_llm.math_utils import pad_up
 
+from .fuse_elementwise_ops import ssd_output_transpose
+from .mamba2_metadata import cu_seqlens_to_chunk_indices_offsets_triton
 from .ssd_bmm import _bmm_chunk_fwd
 from .ssd_chunk_scan import _chunk_scan_fwd
 from .ssd_chunk_state import (_chunk_cumsum_fwd, _chunk_state_fwd,
@@ -50,11 +53,17 @@ def _flashinfer_ssd_supported(chunk_size, dstate, headdim):
 
 
 @functools.cache
-def _get_flashinfer_ssd_kernel(chunk_size, nheads, headdim, dstate, ngroups):
-    """Get or compile a cached FlashInfer SSDCombined kernel (SM100+ only)."""
-    from flashinfer.mamba import SSDCombined
-    logger.info_once("Using FlashInfer fused SSD kernel for Mamba2 prefill",
-                     key="flashinfer_ssd_prefill")
+def _get_flashinfer_ssd_kernel(chunk_size, nheads, headdim, dstate, ngroups,
+                               has_varlen):
+    """Get or compile a cached FlashInfer SSDCombined kernel (SM100+ only).
+
+    has_varlen is in the cache key because flashinfer compiles distinct
+    kernels per mode.
+    """
+    logger.info_once(
+        f"Using FlashInfer fused SSD kernel for Mamba2 prefill "
+        f"(has_varlen={has_varlen})",
+        key=f"flashinfer_ssd_prefill_{has_varlen}")
     return SSDCombined(
         chunk_size=chunk_size,
         nheads=nheads,
@@ -66,7 +75,7 @@ def _get_flashinfer_ssd_kernel(chunk_size, nheads, headdim, dstate, ngroups):
         has_d=True,
         d_has_hdim=False,
         has_initial_states=True,
-        has_varlen=True,
+        has_varlen=has_varlen,
         has_z=False,
         seq_idx_dtype=torch.int32,
     )
@@ -92,14 +101,19 @@ def _mamba_chunk_scan_flashinfer_fwd(
     return_final_states=False,
     state_dtype=None,
 ):
-    """FlashInfer fused SSD forward using a single CUTLASS persistent kernel."""
-    _, seqlen, nheads, headdim = x.shape
+    """FlashInfer fused SSD forward.
+
+    cu_seqlens != None means varlen (packed batch=1; fstate per-sequence).
+    cu_seqlens == None means non-varlen (fstate per-batch).
+    """
+    batch, seqlen, nheads, headdim = x.shape
     _, _, ngroups, dstate = B.shape
     io_dtype = torch.bfloat16
+    has_varlen = cu_seqlens is not None
 
     ssd = _get_flashinfer_ssd_kernel(chunk_size, nheads, headdim, dstate,
-                                     ngroups)
-    num_seqs = cu_seqlens.shape[0] - 1
+                                     ngroups, has_varlen)
+    num_seqs = cu_seqlens.shape[0] - 1 if has_varlen else batch
 
     # Pad seqlen to chunk_size boundary — padded tokens use dt=-100
     # so softplus ≈ 0, contributing nothing to state or output.
@@ -145,12 +159,33 @@ def _mamba_chunk_scan_flashinfer_fwd(
                                         dstate,
                                         dtype=io_dtype)
 
-    if chunk_indices is None or chunk_offsets is None:
-        from .mamba2_metadata import cu_seqlens_to_chunk_indices_offsets_triton
+    if has_varlen and (chunk_indices is None or chunk_offsets is None):
         chunk_indices, chunk_offsets = (
             cu_seqlens_to_chunk_indices_offsets_triton(cu_seqlens,
                                                        chunk_size,
                                                        total_seqlens=seqlen))
+    elif not has_varlen:
+        # Non-varlen kernel doesn't read these.
+        seq_idx = None
+        chunk_indices = None
+        chunk_offsets = None
+
+    # raw_out is only consumed by the fused transpose path.
+    # TODO: enable for non-varlen — batch=1 is just a gate change; batch>1
+    # needs a batch axis in the transpose kernel grid.
+    use_fast_transpose = out is not None and has_varlen and batch == 1
+    if use_fast_transpose:
+        padded_seqlen = x.shape[1]
+        nchunks = padded_seqlen // chunk_size
+        raw_out = torch.empty(batch,
+                              nheads,
+                              headdim,
+                              nchunks,
+                              chunk_size,
+                              dtype=io_dtype,
+                              device=x.device)
+    else:
+        raw_out = None
 
     out_view, fstate = ssd.run(
         x,
@@ -166,17 +201,27 @@ def _mamba_chunk_scan_flashinfer_fwd(
         seq_idx=seq_idx,
         chunk_indices=chunk_indices,
         chunk_offsets=chunk_offsets,
+        out=raw_out,
         return_final_states=True,
     )
 
     if out is not None:
-        out.copy_(out_view[:, :seqlen])
+        if use_fast_transpose:
+            num_prefill_tokens = out.shape[1]
+            dst = out.view(num_prefill_tokens, nheads * headdim)
+            ssd_output_transpose(raw_out, dst, num_prefill_tokens)
+        else:
+            out.copy_(out_view[:, :seqlen])
 
     if state_dtype is not None and fstate.dtype != state_dtype:
         fstate = fstate.to(state_dtype)
 
-    # Both final_states and varlen_states are per-sequence in FlashInfer.
-    return (fstate, fstate) if return_final_states else fstate
+    # Match Triton return: varlen yields (final, varlen) — same tensor for
+    # batch=1 packed; non-varlen has no varlen_states.
+    if has_varlen:
+        return (fstate, fstate) if return_final_states else fstate
+    else:
+        return fstate if return_final_states else None
 
 
 def is_int_pow_2(n):
@@ -389,12 +434,12 @@ def mamba_chunk_scan_combined(
         assert (cu_seqlens is not None
                 ), "cu_seqlens must be provided if return_varlen_states is True"
 
-    # Use the FlashInfer fused CUTLASS kernel on Blackwell (SM100+) when its
-    # MMA tile constraints on (chunk_size, dstate, headdim) are satisfied;
-    # otherwise fall through to the Triton reference kernels below.
+    # FlashInfer fused CUTLASS kernel on Blackwell (SM100+); both varlen and
+    # non-varlen route here based on cu_seqlens. Falls back to Triton when the
+    # MMA tile constraints on (chunk_size, dstate, headdim) aren't met.
     dstate = B.shape[-1]
     headdim = x.shape[-1]
-    flashinfer_eligible = (return_varlen_states and z is None and is_sm_100f())
+    flashinfer_eligible = (z is None and is_sm_100f())
     if flashinfer_eligible and _flashinfer_ssd_supported(
             chunk_size, dstate, headdim):
         return _mamba_chunk_scan_flashinfer_fwd(

--- a/tensorrt_llm/_torch/modules/mamba/ssd_combined.py
+++ b/tensorrt_llm/_torch/modules/mamba/ssd_combined.py
@@ -35,13 +35,18 @@ from .ssd_state_passing import _state_passing_fwd
 # FlashInfer's fused CUTLASS SSD kernel lowers to tcgen05 MMA whose M-mode must
 # be 64 or 128. `dstate` is the M-mode of the inter-chunk MMA and `chunk_size`
 # is the M-mode of the intra-chunk MMAs, so both dimensions must satisfy this
-# constraint. Otherwise we fall back to the Triton reference kernels.
+# constraint. `headdim` controls the intra-chunk MMA tile along the head axis;
+# only 64 and 128 keep the planned TMEM footprint within SM100's 512-column
+# capacity (e.g. headdim=80 trips an internal TMEM-capacity assertion in
+# `_plan_tmem_offsets`). Otherwise we fall back to the Triton reference kernels.
 _FLASHINFER_SSD_VALID_M_MODES = (64, 128)
+_FLASHINFER_SSD_VALID_HEAD_DIMS = (64, 128)
 
 
-def _flashinfer_ssd_supported(chunk_size, dstate):
+def _flashinfer_ssd_supported(chunk_size, dstate, headdim):
     return (chunk_size in _FLASHINFER_SSD_VALID_M_MODES
-            and dstate in _FLASHINFER_SSD_VALID_M_MODES)
+            and dstate in _FLASHINFER_SSD_VALID_M_MODES
+            and headdim in _FLASHINFER_SSD_VALID_HEAD_DIMS)
 
 
 @functools.cache
@@ -106,6 +111,21 @@ def _mamba_chunk_scan_flashinfer_fwd(
         dt = F.pad(dt, (0, 0, 0, pad_len), value=-100.0)
         if seq_idx is not None:
             seq_idx = F.pad(seq_idx, (0, pad_len), value=int(num_seqs - 1))
+
+    # The SSDCombined kernel was compiled with B/C compact stride
+    # `b.strides[0] = N*G` (N=dstate=const), so the runtime check requires
+    # the seqlen stride divisible by N. Upstream split-then-view producers
+    # (e.g. AutoDeploy's projected_states split) leave seqlen-stride equal
+    # to the full projection width, which need not be a multiple of N.
+    # Materialize contiguous copies when necessary.
+    if not B.is_contiguous():
+        B = B.contiguous()
+    if not C.is_contiguous():
+        C = C.contiguous()
+    if not x.is_contiguous():
+        x = x.contiguous()
+    if not dt.is_contiguous():
+        dt = dt.contiguous()
 
     if x.dtype != io_dtype:
         x = x.to(io_dtype)
@@ -370,11 +390,13 @@ def mamba_chunk_scan_combined(
                 ), "cu_seqlens must be provided if return_varlen_states is True"
 
     # Use the FlashInfer fused CUTLASS kernel on Blackwell (SM100+) when its
-    # MMA M-mode constraints on (chunk_size, dstate) are satisfied; otherwise
-    # fall through to the Triton reference kernels below.
+    # MMA tile constraints on (chunk_size, dstate, headdim) are satisfied;
+    # otherwise fall through to the Triton reference kernels below.
     dstate = B.shape[-1]
+    headdim = x.shape[-1]
     flashinfer_eligible = (return_varlen_states and z is None and is_sm_100f())
-    if flashinfer_eligible and _flashinfer_ssd_supported(chunk_size, dstate):
+    if flashinfer_eligible and _flashinfer_ssd_supported(
+            chunk_size, dstate, headdim):
         return _mamba_chunk_scan_flashinfer_fwd(
             x,
             dt,
@@ -398,9 +420,11 @@ def mamba_chunk_scan_combined(
     if flashinfer_eligible:
         logger.info_once(
             f"FlashInfer SSD unavailable for chunk_size={chunk_size}, "
-            f"dstate={dstate} (requires both in {_FLASHINFER_SSD_VALID_M_MODES}); "
+            f"dstate={dstate}, headdim={headdim} "
+            f"(requires chunk_size/dstate in {_FLASHINFER_SSD_VALID_M_MODES} "
+            f"and headdim in {_FLASHINFER_SSD_VALID_HEAD_DIMS}); "
             f"falling back to Triton SSD prefill",
-            key=f"triton_ssd_fallback_{chunk_size}_{dstate}",
+            key=f"triton_ssd_fallback_{chunk_size}_{dstate}_{headdim}",
         )
 
     out_x, dt_out, dA_cumsum, states, final_states, *rest = (

--- a/tensorrt_llm/_torch/modules/mamba/ssd_combined.py
+++ b/tensorrt_llm/_torch/modules/mamba/ssd_combined.py
@@ -16,14 +16,147 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+
 import torch
+import torch.nn.functional as F
 from einops import rearrange
+
+from tensorrt_llm._utils import is_sm_100f
+from tensorrt_llm.logger import logger
+from tensorrt_llm.math_utils import pad_up
 
 from .ssd_bmm import _bmm_chunk_fwd
 from .ssd_chunk_scan import _chunk_scan_fwd
 from .ssd_chunk_state import (_chunk_cumsum_fwd, _chunk_state_fwd,
                               chunk_state_varlen)
 from .ssd_state_passing import _state_passing_fwd
+
+# FlashInfer's fused CUTLASS SSD kernel lowers to tcgen05 MMA whose M-mode must
+# be 64 or 128. `dstate` is the M-mode of the inter-chunk MMA and `chunk_size`
+# is the M-mode of the intra-chunk MMAs, so both dimensions must satisfy this
+# constraint. Otherwise we fall back to the Triton reference kernels.
+_FLASHINFER_SSD_VALID_M_MODES = (64, 128)
+
+
+def _flashinfer_ssd_supported(chunk_size, dstate):
+    return (chunk_size in _FLASHINFER_SSD_VALID_M_MODES
+            and dstate in _FLASHINFER_SSD_VALID_M_MODES)
+
+
+@functools.cache
+def _get_flashinfer_ssd_kernel(chunk_size, nheads, headdim, dstate, ngroups):
+    """Get or compile a cached FlashInfer SSDCombined kernel (SM100+ only)."""
+    from flashinfer.mamba import SSDCombined
+    logger.info_once("Using FlashInfer fused SSD kernel for Mamba2 prefill",
+                     key="flashinfer_ssd_prefill")
+    return SSDCombined(
+        chunk_size=chunk_size,
+        nheads=nheads,
+        headdim=headdim,
+        dstate=dstate,
+        ngroups=ngroups,
+        io_dtype=torch.bfloat16,
+        state_dtype=torch.bfloat16,
+        has_d=True,
+        d_has_hdim=False,
+        has_initial_states=True,
+        has_varlen=True,
+        has_z=False,
+        seq_idx_dtype=torch.int32,
+    )
+
+
+def _mamba_chunk_scan_flashinfer_fwd(
+    x,
+    dt,
+    A,
+    B,
+    C,
+    chunk_size,
+    D=None,
+    dt_bias=None,
+    initial_states=None,
+    seq_idx=None,
+    chunk_indices=None,
+    chunk_offsets=None,
+    cu_seqlens=None,
+    dt_softplus=False,
+    dt_limit=(0.0, float("inf")),
+    out=None,
+    return_final_states=False,
+    state_dtype=None,
+):
+    """FlashInfer fused SSD forward using a single CUTLASS persistent kernel."""
+    _, seqlen, nheads, headdim = x.shape
+    _, _, ngroups, dstate = B.shape
+    io_dtype = torch.bfloat16
+
+    ssd = _get_flashinfer_ssd_kernel(chunk_size, nheads, headdim, dstate,
+                                     ngroups)
+    num_seqs = cu_seqlens.shape[0] - 1
+
+    # Pad seqlen to chunk_size boundary — padded tokens use dt=-100
+    # so softplus ≈ 0, contributing nothing to state or output.
+    pad_len = pad_up(seqlen, chunk_size) - seqlen
+    if pad_len > 0:
+        x = F.pad(x, (0, 0, 0, 0, 0, pad_len))
+        B = F.pad(B, (0, 0, 0, 0, 0, pad_len))
+        C = F.pad(C, (0, 0, 0, 0, 0, pad_len))
+        dt = F.pad(dt, (0, 0, 0, pad_len), value=-100.0)
+        if seq_idx is not None:
+            seq_idx = F.pad(seq_idx, (0, pad_len), value=int(num_seqs - 1))
+
+    if x.dtype != io_dtype:
+        x = x.to(io_dtype)
+        B = B.to(io_dtype)
+        C = C.to(io_dtype)
+        dt = dt.to(io_dtype)
+
+    D_bf16 = D.to(io_dtype) if D is not None and D.dtype != io_dtype else D
+
+    if initial_states is not None:
+        fi_initial_states = (initial_states if initial_states.dtype == io_dtype
+                             else initial_states.to(io_dtype))
+    else:
+        fi_initial_states = x.new_zeros(num_seqs,
+                                        nheads,
+                                        headdim,
+                                        dstate,
+                                        dtype=io_dtype)
+
+    if chunk_indices is None or chunk_offsets is None:
+        from .mamba2_metadata import cu_seqlens_to_chunk_indices_offsets_triton
+        chunk_indices, chunk_offsets = (
+            cu_seqlens_to_chunk_indices_offsets_triton(cu_seqlens,
+                                                       chunk_size,
+                                                       total_seqlens=seqlen))
+
+    out_view, fstate = ssd.run(
+        x,
+        dt,
+        A,
+        B,
+        C,
+        D=D_bf16,
+        dt_bias=dt_bias,
+        dt_softplus=dt_softplus,
+        dt_limit=dt_limit,
+        initial_states=fi_initial_states,
+        seq_idx=seq_idx,
+        chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
+        return_final_states=True,
+    )
+
+    if out is not None:
+        out.copy_(out_view[:, :seqlen])
+
+    if state_dtype is not None and fstate.dtype != state_dtype:
+        fstate = fstate.to(state_dtype)
+
+    # Both final_states and varlen_states are per-sequence in FlashInfer.
+    return (fstate, fstate) if return_final_states else fstate
 
 
 def is_int_pow_2(n):
@@ -235,6 +368,41 @@ def mamba_chunk_scan_combined(
     else:
         assert (cu_seqlens is not None
                 ), "cu_seqlens must be provided if return_varlen_states is True"
+
+    # Use the FlashInfer fused CUTLASS kernel on Blackwell (SM100+) when its
+    # MMA M-mode constraints on (chunk_size, dstate) are satisfied; otherwise
+    # fall through to the Triton reference kernels below.
+    dstate = B.shape[-1]
+    flashinfer_eligible = (return_varlen_states and z is None and is_sm_100f())
+    if flashinfer_eligible and _flashinfer_ssd_supported(chunk_size, dstate):
+        return _mamba_chunk_scan_flashinfer_fwd(
+            x,
+            dt,
+            A,
+            B,
+            C,
+            chunk_size,
+            D=D,
+            dt_bias=dt_bias,
+            initial_states=initial_states,
+            seq_idx=seq_idx,
+            chunk_indices=chunk_indices,
+            chunk_offsets=chunk_offsets,
+            cu_seqlens=cu_seqlens,
+            dt_softplus=dt_softplus,
+            dt_limit=dt_limit,
+            out=out,
+            return_final_states=return_final_states,
+            state_dtype=state_dtype,
+        )
+    if flashinfer_eligible:
+        logger.info_once(
+            f"FlashInfer SSD unavailable for chunk_size={chunk_size}, "
+            f"dstate={dstate} (requires both in {_FLASHINFER_SSD_VALID_M_MODES}); "
+            f"falling back to Triton SSD prefill",
+            key=f"triton_ssd_fallback_{chunk_size}_{dstate}",
+        )
+
     out_x, dt_out, dA_cumsum, states, final_states, *rest = (
         _mamba_chunk_scan_combined_fwd(
             x,

--- a/tensorrt_llm/_torch/visual_gen/jit_kernels/flash_attention/cute/cute_dsl_utils.py
+++ b/tensorrt_llm/_torch/visual_gen/jit_kernels/flash_attention/cute/cute_dsl_utils.py
@@ -109,10 +109,11 @@ def load_cubin_module_data_patched(cubin_data, filepath):
 
 
 class _CuteCompilePatched:
-    """Wrapper around cute.compile that optionally dumps SASS via CUTE_CUBIN_PATH.
+    """Drop-in replacement for cute.compile that dumps SASS when CUTE_CUBIN_PATH is set.
 
-    Preserves the CompileCallable subscript interface (cute.compile[opts](...))
-    so that third-party CuTe DSL kernels (e.g. FlashInfer) keep working.
+    Must be a class (not a function) because cute.compile is a CompileCallable
+    supporting both `cute.compile(...)` and `cute.compile[opts](...)`. The latter
+    form is used by FlashInfer's mamba SSD kernels, so __getitem__ is preserved.
     """
 
     def __init__(self, original=None):

--- a/tensorrt_llm/_torch/visual_gen/jit_kernels/flash_attention/cute/cute_dsl_utils.py
+++ b/tensorrt_llm/_torch/visual_gen/jit_kernels/flash_attention/cute/cute_dsl_utils.py
@@ -108,20 +108,35 @@ def load_cubin_module_data_patched(cubin_data, filepath):
     return load_cubin_module_data_og(cubin_data)
 
 
-def cute_compile_patched(*args, **kwargs):
-    """A patched version of cute.compile that dump the SASS to a file if CUTE_CUBIN_PATH is set."""
-    cubin_path = os.getenv("CUTE_CUBIN_PATH", None)
-    if cubin_path is not None:
-        cutlass.base_dsl.runtime.cuda.load_cubin_module_data = partial(
-            load_cubin_module_data_patched, filepath=cubin_path
-        )
-    output = cute_compile_og(*args, **kwargs)
-    if cubin_path is not None:
-        cutlass.base_dsl.runtime.cuda.load_cubin_module_data = load_cubin_module_data_og
-        if extract is not None:
-            sass = extract(cubin_path, None)
-            pathlib.Path(cubin_path).with_suffix(".annotated.sass").write_text(sass)
-    return output
+class _CuteCompilePatched:
+    """Wrapper around cute.compile that optionally dumps SASS via CUTE_CUBIN_PATH.
+
+    Preserves the CompileCallable subscript interface (cute.compile[opts](...))
+    so that third-party CuTe DSL kernels (e.g. FlashInfer) keep working.
+    """
+
+    def __init__(self, original=None):
+        self._original = original or cute_compile_og
+
+    def __getitem__(self, item):
+        return _CuteCompilePatched(self._original[item])
+
+    def __call__(self, *args, **kwargs):
+        cubin_path = os.getenv("CUTE_CUBIN_PATH", None)
+        if cubin_path is not None:
+            cutlass.base_dsl.runtime.cuda.load_cubin_module_data = partial(
+                load_cubin_module_data_patched, filepath=cubin_path
+            )
+        output = self._original(*args, **kwargs)
+        if cubin_path is not None:
+            cutlass.base_dsl.runtime.cuda.load_cubin_module_data = load_cubin_module_data_og
+            if extract is not None:
+                sass = extract(cubin_path, None)
+                pathlib.Path(cubin_path).with_suffix(".annotated.sass").write_text(sass)
+        return output
+
+
+cute_compile_patched = _CuteCompilePatched()
 
 
 def to_cute_tensor(t, assumed_align=16, leading_dim=-1, fully_dynamic=False, enable_tvm_ffi=True):

--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -197,6 +197,7 @@ MODEL_TYPE_TO_REASONING_PARSER: dict[str, str] = {
     "deepseek_v3": "deepseek-r1",
     "deepseek_v32": "deepseek-r1",
     "nemotron_h": "nano-v3",
+    "nemotron_h_puzzle": "nano-v3",
     "gemma4": "gemma4",
 }
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -370,7 +370,6 @@ triton_server/test_triton_llm.py::test_llmapi_backend[4-0-disableDecoupleMode-te
 triton_server/test_triton_llm.py::test_mistral_v1_multi_models[False-1---False-True-False-0-128-enableDecoupleMode-inflight_fused_batching-disableTrtOverlap--max_utilization-4096--1-1-1-False-ensemble] SKIP
 triton_server/test_triton_rcca.py::test_mistral_beam_search[rcca_4714407-True-10---False-True-False-0-128-disableDecoupleMode-inflight_fused_batching-disableTrtOverlap--guaranteed_no_evict---1-1-1-False-ensemble] SKIP (https://nvbugs/5240060)
 triton_server/test_triton_rcca.py::test_rcca_bug_4934893[Temperature:0.5-TOP_P:0.95-TOP_K:10-False-1---False-True-False-0-2048-enableDecoupleMode-inflight_fused_batching-disableTrtOverlap--max_utilization---1-1-1-False-ensemble] SKIP (https://nvbugs/5619369)
-unittest/_torch/modeling/test_modeling_nemotron_h.py::test_nemotron_h_cuda_graph_overlap_scheduler SKIP (https://nvbugs/6098095)
 unittest/_torch/modules/moe/test_moe_backend.py::test_moe_backend[act=Relu2-e60_k4_h2048_i1408-seq=8-dtype=torch.bfloat16-backend=TRTLLM-quant=NVFP4-routing=Renormalize] SKIP (https://nvbugs/5989912)
 unittest/_torch/modules/tests_lora_modules/test_lora_attention_pytorch_flow_vs_trt.py::TestLoraAttentionPytorchFlowVsTRT::test_lora_attention SKIP (https://nvbugs/5701421)
 unittest/_torch/multi_gpu/test_user_buffers.py::test_user_buffers_mm_add_prologue[2-bf16-_tokens16-_hidden32] SKIP (https://nvbugs/5940460)

--- a/tests/unittest/_torch/models/test_nemotron_h_puzzle.py
+++ b/tests/unittest/_torch/models/test_nemotron_h_puzzle.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for NemotronHPuzzle model support."""
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from tensorrt_llm._torch.models.modeling_nemotron_h import (
+    NemotronHForCausalLM,
+    _get_layer_moe_param,
+)
+
+
+@dataclass
+class _MambaBlock:
+    block_type: str = "mamba"
+
+
+@dataclass
+class _MoeBlock:
+    block_type: str = "moe"
+    moe_intermediate_size: int = 1280
+    n_routed_experts: int = 512
+    num_experts_per_tok: int = 4
+    moe_latent_size: int = 1024
+    moe_shared_expert_intermediate_size: int = 5376
+
+
+def _make_puzzle_config(use_dataclass=False):
+    """Minimal config mimicking the real puzzle model."""
+    if use_dataclass:
+        block_configs = [
+            _MambaBlock(),
+            _MoeBlock(num_experts_per_tok=4),
+            _MambaBlock(),
+            _MoeBlock(moe_intermediate_size=2048, num_experts_per_tok=12),
+        ]
+    else:
+        block_configs = [
+            {"block_type": "mamba"},
+            {
+                "block_type": "moe",
+                "moe_intermediate_size": 1280,
+                "n_routed_experts": 512,
+                "num_experts_per_tok": 4,
+                "moe_latent_size": 1024,
+                "moe_shared_expert_intermediate_size": 5376,
+            },
+            {"block_type": "mamba"},
+            {
+                "block_type": "moe",
+                "moe_intermediate_size": 2048,
+                "n_routed_experts": 512,
+                "num_experts_per_tok": 12,
+                "moe_latent_size": 1024,
+                "moe_shared_expert_intermediate_size": 5376,
+            },
+        ]
+    return SimpleNamespace(
+        block_configs=block_configs,
+        mtp_block_configs=[
+            {"block_type": "attention"},
+            {
+                "block_type": "moe",
+                "moe_intermediate_size": 2688,
+                "n_routed_experts": 512,
+                "num_experts_per_tok": 22,
+                "moe_latent_size": 1024,
+                "moe_shared_expert_intermediate_size": 5376,
+            },
+        ],
+    )
+
+
+class TestPerLayerMoeParams:
+    """The key change: block_configs can be dicts or HF dataclass objects,
+    and per-layer values must differ while MTP falls back to globals."""
+
+    @pytest.mark.parametrize("use_dc", [False, True], ids=["dict", "dataclass"])
+    def test_varying_params_per_layer(self, use_dc):
+        config = _make_puzzle_config(use_dataclass=use_dc)
+        NemotronHForCausalLM._normalize_puzzle_config(config)
+
+        # MoE layer 1: top_k=4, intermediate=1280
+        assert _get_layer_moe_param(config, 1, "num_experts_per_tok") == 4
+        assert _get_layer_moe_param(config, 1, "moe_intermediate_size") == 1280
+        # MoE layer 3: top_k=12, intermediate=2048
+        assert _get_layer_moe_param(config, 3, "num_experts_per_tok") == 12
+        assert _get_layer_moe_param(config, 3, "moe_intermediate_size") == 2048
+
+    @pytest.mark.parametrize("use_dc", [False, True], ids=["dict", "dataclass"])
+    def test_mtp_layer_gets_global_defaults(self, use_dc):
+        """MTP layer_idx beyond block_configs range uses globals from mtp_block_configs."""
+        config = _make_puzzle_config(use_dataclass=use_dc)
+        NemotronHForCausalLM._normalize_puzzle_config(config)
+
+        mtp_idx = len(config.block_configs)  # beyond range
+        assert _get_layer_moe_param(config, mtp_idx, "num_experts_per_tok") == 22
+        assert _get_layer_moe_param(config, mtp_idx, "moe_intermediate_size") == 2688
+
+    @pytest.mark.parametrize("use_dc", [False, True], ids=["dict", "dataclass"])
+    def test_normalize_sets_all_global_attrs(self, use_dc):
+        config = _make_puzzle_config(use_dataclass=use_dc)
+        NemotronHForCausalLM._normalize_puzzle_config(config)
+
+        for attr in (
+            "n_routed_experts",
+            "moe_intermediate_size",
+            "num_experts_per_tok",
+            "moe_latent_size",
+            "moe_shared_expert_intermediate_size",
+        ):
+            assert getattr(config, attr) is not None, f"{attr} not set"
+
+    def test_normalize_preserves_existing_attrs(self):
+        config = _make_puzzle_config()
+        sentinel = 999
+        config.n_routed_experts = sentinel
+        NemotronHForCausalLM._normalize_puzzle_config(config)
+        assert config.n_routed_experts == sentinel
+
+    def test_normalize_noop_without_block_configs(self):
+        config = SimpleNamespace()
+        NemotronHForCausalLM._normalize_puzzle_config(config)
+        assert not hasattr(config, "n_routed_experts")
+
+    def test_standard_config_passthrough(self):
+        """Non-puzzle model: no block_configs, returns global directly."""
+        config = SimpleNamespace(n_routed_experts=512)
+        assert _get_layer_moe_param(config, 0, "n_routed_experts") == 512

--- a/tests/unittest/_torch/modules/mamba/test_fuse_elementwise_ops.py
+++ b/tests/unittest/_torch/modules/mamba/test_fuse_elementwise_ops.py
@@ -20,6 +20,7 @@ import torch
 from tensorrt_llm._torch.modules.mamba.fuse_elementwise_ops import (
     extract_transpose_xbc_prefill,
     fused_split_rearrange_after_conv1d,
+    ssd_output_transpose,
 )
 
 skip_no_cuda = pytest.mark.skipif(
@@ -151,3 +152,46 @@ def test_extract_transpose_large_input_no_overflow(dtype):
 
     assert out_fused.shape == out_ref.shape, f"Shape mismatch: {out_fused.shape} vs {out_ref.shape}"
     torch.testing.assert_close(out_fused, out_ref, rtol=1e-3, atol=1e-3)
+
+
+def ssd_output_transpose_ref(
+    out_contig: torch.Tensor,
+    num_prefill_tokens: int,
+) -> torch.Tensor:
+    """Reference implementation: permute+reshape+slice."""
+    B, H, D, NC, CS = out_contig.shape
+    seqlen = NC * CS
+    out_view = out_contig.permute(0, 3, 4, 1, 2).reshape(B, seqlen, H, D)
+    dst = out_view[:, :num_prefill_tokens].contiguous().view(num_prefill_tokens, H * D)
+    return dst
+
+
+@skip_no_cuda
+@pytest.mark.parametrize(
+    "H,D,CS,num_prefill_tokens",
+    [
+        (32, 64, 256, 1),
+        (32, 64, 256, 128),
+        (32, 64, 256, 1024),
+        (32, 64, 256, 4096),
+        (32, 64, 256, 50176),  # exact multiple of CS
+        (32, 64, 256, 50224),  # trailing padding
+        (16, 64, 128, 8192),
+        (64, 64, 256, 16384),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+def test_ssd_output_transpose(H, D, CS, num_prefill_tokens, dtype):
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    NC = (num_prefill_tokens + CS - 1) // CS
+    out_contig = torch.randn(1, H, D, NC, CS, dtype=dtype, device=device)
+
+    dst_ref = ssd_output_transpose_ref(out_contig, num_prefill_tokens)
+    dst = torch.empty(num_prefill_tokens, H * D, dtype=dtype, device=device)
+    ssd_output_transpose(out_contig, dst, num_prefill_tokens)
+
+    assert dst.shape == dst_ref.shape
+    # Pure data movement — must be bit-exact.
+    torch.testing.assert_close(dst, dst_ref, rtol=0, atol=0)

--- a/tests/unittest/_torch/modules/mamba/test_ssd_combined_flashinfer.py
+++ b/tests/unittest/_torch/modules/mamba/test_ssd_combined_flashinfer.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""FlashInfer SSD equivalence tests for varlen and non-varlen modes."""
+
+import pytest
+import torch
+from utils.torch_ref import ssd_chunk_scan_combined_ref
+
+from tensorrt_llm._torch.modules.mamba.mamba2_metadata import (
+    cu_seqlens_to_chunk_indices_offsets_triton,
+)
+from tensorrt_llm._torch.modules.mamba.ssd_combined import (
+    _flashinfer_ssd_supported,
+    _get_flashinfer_ssd_kernel,
+    mamba_chunk_scan_combined,
+)
+from tensorrt_llm._utils import is_sm_100f
+
+
+def _flashinfer_available():
+    try:
+        import flashinfer  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+skip_no_flashinfer = pytest.mark.skipif(
+    not (torch.cuda.is_available() and is_sm_100f() and _flashinfer_available()),
+    reason="FlashInfer SSD requires SM100+ with flashinfer installed",
+)
+
+# Configurations that flashinfer SSD currently lowers cleanly.
+_VALID_SHAPES = [
+    # (chunk_size, nheads, headdim, ngroups, dstate)
+    (128, 4, 64, 1, 128),
+    (128, 8, 64, 1, 128),
+    (128, 8, 64, 2, 128),
+]
+
+_BF16_RTOL = 1e-2
+_BF16_ATOL = 2e-1
+
+
+def _make_inputs(batch, seqlen, nheads, headdim, ngroups, dstate, device):
+    torch.manual_seed(0)
+    x = torch.randn(batch, seqlen, nheads, headdim, dtype=torch.bfloat16, device=device)
+    dt = torch.randn(batch, seqlen, nheads, dtype=torch.bfloat16, device=device)
+    A = -torch.rand(nheads, dtype=torch.float32, device=device) - 1.0
+    B = torch.randn(batch, seqlen, ngroups, dstate, dtype=torch.bfloat16, device=device)
+    C = torch.randn(batch, seqlen, ngroups, dstate, dtype=torch.bfloat16, device=device)
+    D = torch.randn(nheads, dtype=torch.float32, device=device)
+    dt_bias = torch.rand(nheads, dtype=torch.float32, device=device) - 4.0
+    return x, dt, A, B, C, D, dt_bias
+
+
+@skip_no_flashinfer
+@pytest.mark.parametrize("chunk_size,nheads,headdim,ngroups,dstate", _VALID_SHAPES)
+@pytest.mark.parametrize("seqlens", [[256, 192], [512], [128, 64, 192]])
+def test_flashinfer_varlen(chunk_size, nheads, headdim, ngroups, dstate, seqlens):
+    assert _flashinfer_ssd_supported(chunk_size, dstate, headdim)
+    device = torch.device("cuda")
+    total = sum(seqlens)
+    num_seqs = len(seqlens)
+
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(seqlens), 0)),
+        dtype=torch.int32,
+        device=device,
+    )
+    seq_idx = torch.cat(
+        [torch.full((sl,), i, dtype=torch.int32, device=device) for i, sl in enumerate(seqlens)]
+    ).unsqueeze(0)
+    chunk_indices, chunk_offsets = cu_seqlens_to_chunk_indices_offsets_triton(
+        cu_seqlens, chunk_size, total_seqlens=total
+    )
+
+    x, dt, A, B, C, D, dt_bias = _make_inputs(1, total, nheads, headdim, ngroups, dstate, device)
+
+    out = torch.empty_like(x)
+    varlen_states = mamba_chunk_scan_combined(
+        x,
+        dt,
+        A,
+        B,
+        C,
+        chunk_size,
+        D=D,
+        z=None,
+        dt_bias=dt_bias,
+        seq_idx=seq_idx,
+        chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
+        cu_seqlens=cu_seqlens,
+        dt_softplus=True,
+        out=out,
+        return_varlen_states=True,
+        return_final_states=False,
+    )
+
+    # Reference: process each sequence independently with the PyTorch ref.
+    out_ref = torch.empty_like(out)
+    state_ref = torch.empty(num_seqs, nheads, dstate, headdim, dtype=torch.bfloat16, device=device)
+    for i in range(num_seqs):
+        s, e = cu_seqlens[i].item(), cu_seqlens[i + 1].item()
+        part_out, part_state = ssd_chunk_scan_combined_ref(
+            x[:, s:e],
+            dt[:, s:e],
+            A,
+            B[:, s:e],
+            C[:, s:e],
+            chunk_size,
+            D=D,
+            dt_bias=dt_bias,
+            dt_softplus=True,
+        )
+        out_ref[0, s:e] = part_out.squeeze(0)
+        state_ref[i] = part_state.squeeze(0)
+
+    # ssd_chunk_scan_combined_ref returns final_states as (..., dstate, headdim);
+    # flashinfer returns (..., headdim, dstate).
+    torch.testing.assert_close(out, out_ref, rtol=_BF16_RTOL, atol=_BF16_ATOL)
+    torch.testing.assert_close(
+        varlen_states.to(torch.bfloat16),
+        state_ref.permute(0, 1, 3, 2).contiguous(),
+        rtol=_BF16_RTOL,
+        atol=_BF16_ATOL,
+    )
+
+
+@skip_no_flashinfer
+@pytest.mark.parametrize("chunk_size,nheads,headdim,ngroups,dstate", _VALID_SHAPES)
+@pytest.mark.parametrize("batch,seqlen", [(1, 512), (2, 256), (3, 384)])
+def test_flashinfer_non_varlen(chunk_size, nheads, headdim, ngroups, dstate, batch, seqlen):
+    assert _flashinfer_ssd_supported(chunk_size, dstate, headdim)
+    device = torch.device("cuda")
+
+    x, dt, A, B, C, D, dt_bias = _make_inputs(
+        batch, seqlen, nheads, headdim, ngroups, dstate, device
+    )
+
+    out = torch.empty_like(x)
+    final_states = mamba_chunk_scan_combined(
+        x,
+        dt,
+        A,
+        B,
+        C,
+        chunk_size,
+        D=D,
+        z=None,
+        dt_bias=dt_bias,
+        seq_idx=None,
+        cu_seqlens=None,
+        dt_softplus=True,
+        out=out,
+        return_varlen_states=False,
+        return_final_states=True,
+    )
+
+    out_ref, state_ref = ssd_chunk_scan_combined_ref(
+        x,
+        dt,
+        A,
+        B,
+        C,
+        chunk_size,
+        D=D,
+        dt_bias=dt_bias,
+        dt_softplus=True,
+    )
+
+    torch.testing.assert_close(out, out_ref, rtol=_BF16_RTOL, atol=_BF16_ATOL)
+    torch.testing.assert_close(
+        final_states.to(torch.bfloat16),
+        state_ref.permute(0, 1, 3, 2).contiguous(),
+        rtol=_BF16_RTOL,
+        atol=_BF16_ATOL,
+    )
+
+
+@skip_no_flashinfer
+def test_flashinfer_kernel_cache_distinguishes_modes():
+    # Sharing a cache entry across modes would silently use the wrong kernel.
+    chunk_size, nheads, headdim, ngroups, dstate = 128, 4, 64, 1, 128
+    k_v = _get_flashinfer_ssd_kernel(chunk_size, nheads, headdim, dstate, ngroups, True)
+    k_n = _get_flashinfer_ssd_kernel(chunk_size, nheads, headdim, dstate, ngroups, False)
+    assert k_v is not k_n
+    assert k_v is _get_flashinfer_ssd_kernel(chunk_size, nheads, headdim, dstate, ngroups, True)


### PR DESCRIPTION
  ## Features

  ### Model support
  - **NemotronH puzzle (`nemotron_h_puzzle`) variant**: new `NemotronHPuzzleConfig` with per-layer MoE params
  (`block_configs` / `mtp_block_configs`), per-layer `n_routed_experts`, `moe_intermediate_size`,
  `num_experts_per_tok`, `moe_latent_size`, `moe_shared_expert_intermediate_size`. Registers
  `NemotronHPuzzleForCausalLM` with the auto-model and HF weight mapper.
  - **Reasoning parser**: maps `nemotron_h_puzzle` → `nano-v3`.
  - **MTP support**: `MTPForCausalLM` now dispatches both `nemotron_h` and `nemotron_h_puzzle` to `NemotronHMTP`.

  ### Mamba SSD migration to FlashInfer
  - `Mamba2Mixer` now selects FlashInfer when `head_dim ∈ {64, 128}` (head_group_ratio gate dropped, since
  FlashInfer covers all needed ratios; head_dim=80 still falls back to native).
  - `ssd_combined.py`: integrates FlashInfer SSD kernel with proper varlen / non-varlen path selection.
  - New `fuse_elementwise_ops.py`: Triton-fused elementwise ops used by the SSD path.
  - Triton transpose kernel for SSD output reshaping; non-varlen support added.
  - New unit tests: `test_fuse_elementwise_ops.py`, `test_ssd_combined_flashinfer.py`.

  ### Communication / kernels
  - **MoE alltoall (`moeAlltoAllKernels.cu`)**: adds `TOP_K = 12, 14, 18` specializations (needed by puzzle
  variant's per-layer top-k).
  - **NVLink one-sided workspace (`nvlink_one_sided.py`)**: allows workspace reallocation when a layer needs a
  larger size (per-layer MoE param models can request varying workspace sizes); other invariants
  (`max_num_tokens_per_rank`, `ep_rank`, `ep_size`, `eplb_stats_num_experts`) still asserted equal.
  - **CuTe DSL utils (`cute_dsl_utils.py`)**: wraps `cute.compile` as a class preserving the `CompileCallable`
  subscript interface (`cute.compile[opts](...)`) so FlashInfer's mamba SSD kernel keeps working under the
  SASS-dump monkey-patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Nemotron puzzle model variant with flexible per-layer MoE configuration.
  * Enhanced Mamba2 mixer with improved hardware compatibility checks.

* **Improvements**
  * Optimized MoE kernel dispatch for additional top-k values.
  * Improved workspace memory reuse and dynamic allocation handling.
  * Simplified MoE routing logic for better performance.

* **Tests**
  * Added comprehensive test coverage for new Nemotron model variant configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
