### PR TITLE
[#12808][feat] AutoDeploy: Custom attn mask support for attention backends

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -45,6 +45,9 @@ transforms:
   match_attention_layout:
     stage: pattern_matcher
     attn_layout: bsnd
+  inject_custom_attention_mask:
+    stage: pattern_matcher
+    backend: torch_attention
   match_rope_pattern:
     stage: pattern_matcher
   match_rope_layout:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/flashinfer_attention.py
@@ -565,14 +565,7 @@ class FlashInferAttention(AttentionDescriptor):
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         # Sanity check: layout == "bsnd"
-        # Prefer kwargs; fall back to the final positional arg if it's a string.
-        layout = source_attn_node.kwargs.get("layout", None)
-        if (
-            layout is None
-            and len(source_attn_node.args) > 0
-            and isinstance(source_attn_node.args[-1], str)
-        ):
-            layout = source_attn_node.args[-1]
+        layout = extract_op_args(source_attn_node, "layout")[0]
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
@@ -168,6 +168,7 @@ def _torch_context_mha(
     seq_start: torch.Tensor,
     scale: float,
     out: torch.Tensor,
+    custom_attn_mask: Optional[torch.Tensor] = None,
     logit_cap: Optional[float] = None,
     sliding_window_size: Optional[int] = None,
     sinks: Optional[torch.Tensor] = None,
@@ -247,7 +248,14 @@ def _torch_context_mha(
         else:
             combined_mask = causal_mask
 
-        attn_scores.masked_fill_(combined_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+        if custom_attn_mask is not None:
+            # The provider emits the full backend-native allow-mask for prefill in [B, N, S_q, S_k]
+            # form, so we trust it directly instead of layering the default causal mask on top.
+            combined_mask = ~custom_attn_mask[idx, :, :seq_len_i, :kv_seq_len]
+        else:
+            combined_mask = combined_mask.unsqueeze(0)
+
+        attn_scores.masked_fill_(combined_mask.unsqueeze(0), float("-inf"))
 
         # Apply logit softcapping if enabled
         attn_scores = _apply_logit_softcapping(attn_scores, logit_cap)
@@ -304,10 +312,11 @@ def torch_backend_mha_with_cache(
     # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
+    custom_attn_mask: Optional[torch.Tensor] = None,
     # BUFFERS
     # <none>
     # CONSTANTS
-    scale: Optional[float],
+    scale: Optional[float] = None,
     sinks: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = None,
     logit_cap: Optional[float] = None,
@@ -380,6 +389,7 @@ def torch_backend_mha_with_cache(
             seq_start,
             scale,
             y,
+            custom_attn_mask,
             logit_cap,
             sliding_window_size,
             sinks,
@@ -419,10 +429,11 @@ def torch_backend_mha_with_cache_fake(
     # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
+    custom_attn_mask: Optional[torch.Tensor] = None,
     # BUFFERS
     # <none>
     # CONSTANTS
-    scale: Optional[float],
+    scale: Optional[float] = None,
     sinks: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = None,
     logit_cap: Optional[float] = None,
@@ -482,6 +493,10 @@ class TorchBackendAttention(AttentionDescriptor):
         }
 
     @classmethod
+    def get_dynamic_inputs(cls, source_attn_node: Node) -> List[Optional[Node]]:
+        return list(extract_op_args(source_attn_node, "attn_mask"))
+
+    @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         # Sanity check: layout == "bsnd"
         # Prefer kwargs; fall back to the final positional arg if it's a string.
@@ -502,7 +517,7 @@ class TorchBackendAttention(AttentionDescriptor):
         attn_mask, dropout_p, is_causal = extract_op_args(
             source_attn_node, "attn_mask", "dropout_p", "is_causal"
         )
-        if attn_mask is not None or dropout_p != 0.0 or not is_causal:
+        if dropout_p != 0.0 or not is_causal:
             ad_logger.debug(
                 "Unsupported attention arguments for "
                 f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
@@ -499,14 +499,7 @@ class TorchBackendAttention(AttentionDescriptor):
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         # Sanity check: layout == "bsnd"
-        # Prefer kwargs; fall back to the final positional arg if it's a string.
-        layout = source_attn_node.kwargs.get("layout", None)
-        if (
-            layout is None
-            and len(source_attn_node.args) > 0
-            and isinstance(source_attn_node.args[-1], str)
-        ):
-            layout = source_attn_node.args[-1]
+        layout = extract_op_args(source_attn_node, "layout")[0]
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
@@ -16,7 +16,7 @@
 """Torch backend attention using pure PyTorch reference implementations."""
 
 import math
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import torch
 from torch._ops import OpOverloadPacket
@@ -495,8 +495,8 @@ class TorchBackendAttention(AttentionDescriptor):
         }
 
     @classmethod
-    def get_dynamic_inputs(cls, source_attn_node: Node) -> List[Optional[Node]]:
-        return list(extract_op_args(source_attn_node, "attn_mask"))
+    def get_dynamic_inputs(cls, source_attn_node: Node) -> Dict[str, Optional[Node]]:
+        return {"custom_attn_mask": extract_op_args(source_attn_node, "attn_mask")[0]}
 
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
@@ -510,10 +510,9 @@ class TorchBackendAttention(AttentionDescriptor):
         attn_mask, dropout_p, is_causal = extract_op_args(
             source_attn_node, "attn_mask", "dropout_p", "is_causal"
         )
-        if dropout_p != 0.0 or not is_causal:
+        if dropout_p != 0.0:
             ad_logger.debug(
-                "Unsupported attention arguments for "
-                f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"
+                f"Unsupported attention arguments for {source_attn_node=}: {dropout_p=}"
             )
 
         # Get scale from args or kwargs

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
@@ -241,7 +241,7 @@ def _torch_context_mha(
             )  # [seq_len_i, kv_seq_len]
 
             # Sliding window mask: allow attention only if 0 <= pos_diff < sliding_window_size
-            sliding_window_mask = pos_diff >= sliding_window_size
+            sliding_window_mask = (pos_diff < 0) | (pos_diff >= sliding_window_size)
 
             # Combine causal and sliding window masks
             combined_mask = causal_mask | sliding_window_mask
@@ -249,9 +249,11 @@ def _torch_context_mha(
             combined_mask = causal_mask
 
         if custom_attn_mask is not None:
-            # The provider emits the full backend-native allow-mask for prefill in [B, N, S_q, S_k]
-            # form, so we trust it directly instead of layering the default causal mask on top.
-            combined_mask = ~custom_attn_mask[idx, :, :seq_len_i, :kv_seq_len]
+            custom_mask = ~custom_attn_mask[idx, :, :seq_len_i, :kv_seq_len]
+            if sliding_window_size is not None and sliding_window_size > 0:
+                combined_mask = sliding_window_mask.unsqueeze(0) | custom_mask
+            else:
+                combined_mask = custom_mask
         else:
             combined_mask = combined_mask.unsqueeze(0)
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
@@ -295,9 +295,94 @@ def _torch_context_mha(
         out.copy_(torch.cat(attn_outputs, dim=0))
 
 
-@torch.library.custom_op(
-    "auto_deploy::torch_cached_attention_with_cache", mutates_args=("k_cache", "v_cache")
-)
+def _torch_context_mha_readonly(
+    q: torch.Tensor,
+    input_pos: torch.Tensor,
+    slot_idx: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    seq_len: torch.Tensor,
+    seq_start: torch.Tensor,
+    scale: float,
+    out: torch.Tensor,
+    custom_attn_mask: Optional[torch.Tensor] = None,
+    logit_cap: Optional[float] = None,
+    sliding_window_size: Optional[int] = None,
+    sinks: Optional[torch.Tensor] = None,
+) -> None:
+    """Context attention using an existing KV cache without writing current-layer K/V."""
+    attn_outputs = []
+    for idx in range(seq_len.shape[0]):
+        seq_len_i = seq_len[idx].item()
+        input_pos_i = input_pos[idx].item()
+        slot_idx_i = slot_idx[idx].item()
+        seq_start_i = seq_start[idx].item()
+
+        if seq_len_i == 0:
+            continue
+
+        q_seq = q[seq_start_i : seq_start_i + seq_len_i]
+        kv_seq_len = input_pos_i + seq_len_i
+        k_seq = k_cache[slot_idx_i, :kv_seq_len]
+        v_seq = v_cache[slot_idx_i, :kv_seq_len]
+
+        n_heads = q_seq.shape[1]
+        n_kv_heads = k_seq.shape[1]
+
+        q_seq_t = q_seq.transpose(0, 1).unsqueeze(0)
+        k_seq_t = k_seq.transpose(0, 1).unsqueeze(0)
+        v_seq_t = v_seq.transpose(0, 1).unsqueeze(0)
+
+        if n_heads != n_kv_heads:
+            n_rep = n_heads // n_kv_heads
+            k_seq_t = repeat_kv(k_seq_t, n_rep)
+            v_seq_t = repeat_kv(v_seq_t, n_rep)
+
+        attn_scores = torch.matmul(q_seq_t, k_seq_t.transpose(-2, -1)) * scale
+
+        causal_mask = torch.triu(
+            torch.ones(seq_len_i, kv_seq_len, device=q.device, dtype=torch.bool),
+            diagonal=1 + input_pos_i,
+        )
+        combined_mask = causal_mask
+
+        if sliding_window_size is not None and sliding_window_size > 0:
+            query_positions = torch.arange(input_pos_i, input_pos_i + seq_len_i, device=q.device)
+            key_positions = torch.arange(kv_seq_len, device=q.device)
+            pos_diff = query_positions.unsqueeze(1) - key_positions.unsqueeze(0)
+            sliding_window_mask = (pos_diff < 0) | (pos_diff >= sliding_window_size)
+            combined_mask = combined_mask | sliding_window_mask
+
+        if custom_attn_mask is not None:
+            custom_mask = ~custom_attn_mask[idx, :, :seq_len_i, :kv_seq_len]
+            combined_mask = combined_mask.unsqueeze(0) | custom_mask
+        else:
+            combined_mask = combined_mask.unsqueeze(0)
+
+        attn_scores.masked_fill_(combined_mask.unsqueeze(0), float("-inf"))
+
+        attn_scores = _apply_logit_softcapping(attn_scores, logit_cap)
+
+        if sinks is not None:
+            new_sinks = sinks.reshape(1, -1, 1, 1).expand(1, n_heads, seq_len_i, 1)
+            attn_weights = torch.cat([attn_scores, new_sinks], dim=-1)
+            attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+            attn_out = torch.matmul(attn_weights[..., : -new_sinks.size(-1)], v_seq_t)
+        else:
+            attn_weights = torch.softmax(attn_scores, dim=-1, dtype=torch.float32).to(q.dtype)
+            attn_out = torch.matmul(attn_weights, v_seq_t)
+
+        attn_outputs.append(attn_out[0].transpose(0, 1))
+
+    if len(attn_outputs) == 0:
+        out.zero_()
+    elif len(attn_outputs) == 1:
+        out.copy_(attn_outputs[0])
+    else:
+        out.copy_(torch.cat(attn_outputs, dim=0))
+
+
+@torch.library.custom_op("auto_deploy::torch_cached_attention_with_cache", mutates_args=())
 def torch_backend_mha_with_cache(
     # Q, K, V
     q: torch.Tensor,
@@ -314,14 +399,17 @@ def torch_backend_mha_with_cache(
     # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
-    custom_attn_mask: Optional[torch.Tensor] = None,
     # BUFFERS
     # <none>
-    # CONSTANTS
+    # CONSTANTS must come before dynamic tensor inputs. The KV-cache transform
+    # appends constants positionally and forwards dynamic inputs as kwargs.
     scale: Optional[float] = None,
     sinks: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = None,
     logit_cap: Optional[float] = None,
+    read_cache_only: bool = False,
+    # DYNAMIC INPUTS
+    custom_attn_mask: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Torch backend MHA with cache that takes q, k, v in BSND layout."""

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_attention.py
@@ -388,14 +388,7 @@ class TritonAttention(AttentionDescriptor):
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         # Sanity check: layout == "bsnd"
-        # Prefer kwargs; fall back to the final positional arg if it's a string.
-        layout = source_attn_node.kwargs.get("layout", None)
-        if (
-            layout is None
-            and len(source_attn_node.args) > 0
-            and isinstance(source_attn_node.args[-1], str)
-        ):
-            layout = source_attn_node.args[-1]
+        layout = extract_op_args(source_attn_node, "layout")[0]
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -1359,13 +1359,7 @@ class TritonPagedAttention(AttentionDescriptor):
 
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
-        layout = source_attn_node.kwargs.get("layout", None)
-        if (
-            layout is None
-            and len(source_attn_node.args) > 0
-            and isinstance(source_attn_node.args[-1], str)
-        ):
-            layout = source_attn_node.args[-1]
+        layout = extract_op_args(source_attn_node, "layout")[0]
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -761,6 +761,140 @@ def _paged_context_kernel(
     tl.store(o_ptr + o_store_offsets, o, mask=q_load_mask)
 
 
+@triton.autotune(
+    configs=[
+        triton.Config({"Q_BLOCK": 64}, num_stages=2, num_warps=2),
+        triton.Config({"Q_BLOCK": 64}, num_stages=2, num_warps=4),
+        triton.Config({"Q_BLOCK": 64}, num_stages=4, num_warps=4),
+        triton.Config({"Q_BLOCK": 128}, num_stages=2, num_warps=4),
+        triton.Config({"Q_BLOCK": 128}, num_stages=2, num_warps=8),
+        triton.Config({"Q_BLOCK": 128}, num_stages=3, num_warps=8),
+    ],
+    key=["HEAD_DIM", "PAGE_SIZE"],
+)
+@triton.jit
+def _paged_context_masked_kernel(
+    # Inputs
+    q_ptr,
+    kv_cache_ptr,
+    custom_mask_ptr,
+    # Metadata
+    qo_indptr_ptr,
+    kv_indptr_ptr,
+    kv_indices_ptr,
+    seq_len_with_cache_ptr,
+    # Output
+    o_ptr,
+    # Strides
+    q_stride_token: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    o_stride_token: tl.constexpr,
+    o_stride_head: tl.constexpr,
+    cache_stride_block: tl.constexpr,
+    cache_stride_kv: tl.constexpr,
+    cache_stride_head: tl.constexpr,
+    cache_stride_token: tl.constexpr,
+    mask_stride_batch: tl.constexpr,
+    mask_stride_head: tl.constexpr,
+    mask_stride_q: tl.constexpr,
+    mask_stride_k: tl.constexpr,
+    # Autotuned
+    Q_BLOCK: tl.constexpr,
+    # Constants
+    SM_SCALE: tl.constexpr,
+    N_HEADS: tl.constexpr,
+    N_KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+):
+    """Context/prefill attention with paged KV cache and a backend-provided bool allow-mask."""
+    batch_id = tl.program_id(axis=0)
+    head_id = tl.program_id(axis=1)
+    q_block_id = tl.program_id(axis=2)
+
+    HEAD_RATIO: tl.constexpr = N_HEADS // N_KV_HEADS
+    kv_head_id = head_id // HEAD_RATIO
+
+    q_start = tl.load(qo_indptr_ptr + batch_id)
+    q_end = tl.load(qo_indptr_ptr + batch_id + 1)
+    q_len = q_end - q_start
+
+    kv_page_start = tl.load(kv_indptr_ptr + batch_id)
+    kv_page_end = tl.load(kv_indptr_ptr + batch_id + 1)
+    num_kv_pages = kv_page_end - kv_page_start
+    total_kv_len = tl.load(seq_len_with_cache_ptr + batch_id)
+
+    q_block_start = q_block_id * Q_BLOCK
+    q_offsets = q_block_start + tl.arange(0, Q_BLOCK)
+    q_mask = q_offsets < q_len
+    if tl.sum(q_mask.to(tl.int32)) == 0:
+        return
+
+    dhead_offsets = tl.arange(0, HEAD_DIM)
+    q_load_offsets = (
+        (q_start + q_offsets[:, None]) * q_stride_token
+        + head_id * q_stride_head
+        + dhead_offsets[None, :]
+    )
+    q_load_mask = q_mask[:, None]
+    q = tl.load(q_ptr + q_load_offsets, mask=q_load_mask, other=0.0)
+
+    acc = tl.zeros([Q_BLOCK, HEAD_DIM], dtype=tl.float32)
+    m_i = tl.zeros([Q_BLOCK], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([Q_BLOCK], dtype=tl.float32)
+
+    page_offsets = tl.arange(0, PAGE_SIZE)
+    kv_head_offset = kv_head_id * cache_stride_head
+    local_kv = page_offsets[:, None] * cache_stride_token + dhead_offsets[None, :]
+    mask_batch_offset = batch_id * mask_stride_batch
+    mask_head_offset = 0 * mask_stride_head
+
+    for page_idx in range(num_kv_pages):
+        kv_base_pos = page_idx * PAGE_SIZE
+        physical_page = tl.load(kv_indices_ptr + kv_page_start + page_idx)
+        valid_tokens = tl.minimum(PAGE_SIZE, total_kv_len - kv_base_pos)
+        page_mask = page_offsets < valid_tokens
+
+        page_base = physical_page.to(tl.int64) * cache_stride_block + kv_head_offset
+        page_mask_2d = page_mask[:, None]
+        k = tl.load(kv_cache_ptr + page_base + local_kv, mask=page_mask_2d, other=0.0)
+        v = tl.load(
+            kv_cache_ptr + page_base + local_kv + cache_stride_kv,
+            mask=page_mask_2d,
+            other=0.0,
+        )
+
+        qk = tl.dot(q, tl.trans(k)) * SM_SCALE
+        kv_positions = kv_base_pos + page_offsets[None, :]
+        mask_offsets = (
+            mask_batch_offset
+            + mask_head_offset
+            + q_offsets[:, None] * mask_stride_q
+            + kv_positions * mask_stride_k
+        )
+        valid_mask = q_mask[:, None] & page_mask[None, :]
+        custom_mask = tl.load(custom_mask_ptr + mask_offsets, mask=valid_mask, other=0)
+        full_mask = valid_mask & (custom_mask != 0)
+        qk = tl.where(full_mask, qk, float("-inf"))
+
+        m_ij = tl.max(qk, axis=1)
+        m_i_new = tl.maximum(m_i, m_ij)
+        alpha = tl.exp(m_i - m_i_new)
+        p = tl.exp(qk - m_i_new[:, None])
+        acc = tl.dot(p.to(v.dtype), v, acc=acc * alpha[:, None])
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        m_i = m_i_new
+
+    l_i = tl.where(l_i == 0.0, 1.0, l_i)
+    o = acc / l_i[:, None]
+    o_store_offsets = (
+        (q_start + q_offsets[:, None]) * o_stride_token
+        + head_id * o_stride_head
+        + dhead_offsets[None, :]
+    )
+    tl.store(o_ptr + o_store_offsets, o, mask=q_load_mask)
+
+
 @triton.jit
 def _fast_gather_sdpa_kernel(
     kv_cache_ptr,
@@ -781,17 +915,10 @@ def _fast_gather_sdpa_kernel(
     PAGE_SIZE: tl.constexpr,
     HEAD_DIM: tl.constexpr,
 ):
-    """Gather scattered pages into separate K, V buffers in SDPA layout.
-
-    Grid: (total_pages, N_KV_HEADS)
-    Each program copies one page for one KV head into contiguous K and V
-    outputs shaped [num_seq, n_kv_heads, max_kv_len, head_dim].
-    No precomputed mapping needed — seq_id and local_page computed from global index.
-    """
+    """Gather scattered pages into separate K, V buffers in SDPA layout."""
     page_global_idx = tl.program_id(0)
     kv_head_id = tl.program_id(1)
 
-    # Compute seq_id and local_page from global page index
     seq_id = page_global_idx // MAX_PAGES
     local_page = page_global_idx % MAX_PAGES
 
@@ -800,14 +927,12 @@ def _fast_gather_sdpa_kernel(
     token_offsets = tl.arange(0, PAGE_SIZE)
     head_offsets = tl.arange(0, HEAD_DIM)
 
-    # Source: kv_cache[physical_page, 0/1, kv_head_id, :, :]
     src_base = physical_page.to(tl.int64) * cache_stride_block + kv_head_id * cache_stride_head
     src_offsets = token_offsets[:, None] * cache_stride_token + head_offsets[None, :]
 
     k_data = tl.load(kv_cache_ptr + src_base + src_offsets)
     v_data = tl.load(kv_cache_ptr + src_base + cache_stride_kv + src_offsets)
 
-    # Destination: out_k/v[seq_id, kv_head_id, local_page*PAGE_SIZE + :, :]
     local_token_start = local_page * PAGE_SIZE
     dst_base = (
         seq_id * out_stride_seq
@@ -941,24 +1066,6 @@ def triton_paged_context(
     return output
 
 
-def _gather_paged_kv_for_sequence(
-    kv_cache: torch.Tensor,
-    kv_indices: torch.Tensor,
-    kv_indptr: torch.Tensor,
-    seq_idx: int,
-    seq_kv_len: int,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Gather one sequence's paged KV cache into contiguous tensors in BSND layout."""
-    page_start = int(kv_indptr[seq_idx].item())
-    page_end = int(kv_indptr[seq_idx + 1].item())
-    page_ids = kv_indices[page_start:page_end].to(dtype=torch.long)
-
-    gathered = kv_cache.index_select(0, page_ids)
-    gathered = gathered.permute(1, 0, 3, 2, 4).reshape(2, -1, kv_cache.shape[2], kv_cache.shape[4])
-    gathered = gathered[:, :seq_kv_len]
-    return gathered[0], gathered[1]
-
-
 def triton_paged_context_with_custom_mask(
     q: torch.Tensor,
     kv_cache: torch.Tensor,
@@ -970,31 +1077,55 @@ def triton_paged_context_with_custom_mask(
     sm_scale: float,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """Prefill fallback for backend-native custom bool masks."""
+    """Context/prefill attention with paged KV cache and a backend-provided bool allow-mask."""
     output = out if out is not None else torch.empty_like(q)
     num_seq = qo_indptr.shape[0] - 1
+    total_tokens, n_heads, head_dim = q.shape
+    _, _, n_kv_heads, page_size, _ = kv_cache.shape
 
-    for seq_idx in range(num_seq):
-        q_start = int(qo_indptr[seq_idx].item())
-        q_end = int(qo_indptr[seq_idx + 1].item())
-        q_seq = q[q_start:q_end]
-        seq_q_len = q_end - q_start
-        seq_kv_len = int(seq_len_with_cache[seq_idx].item())
-        k_seq, v_seq = _gather_paged_kv_for_sequence(
-            kv_cache, kv_indices, kv_indptr, seq_idx, seq_kv_len
-        )
-        mask_seq = custom_attn_mask[seq_idx : seq_idx + 1, :, :seq_q_len, :seq_kv_len]
-        output[q_start:q_end].copy_(
-            torch.ops.auto_deploy.torch_attention(
-                q_seq.unsqueeze(0),
-                k_seq.unsqueeze(0),
-                v_seq.unsqueeze(0),
-                attn_mask=mask_seq,
-                is_causal=False,
-                scale=sm_scale,
-                layout="bsnd",
-            )[0]
-        )
+    if num_seq == 0 or total_tokens == 0:
+        return output
+
+    if num_seq == 1:
+        max_q_len = total_tokens
+    else:
+        q_lens = qo_indptr[1:] - qo_indptr[:-1]
+        max_q_len = int(q_lens.max().item())
+
+    custom_attn_mask = custom_attn_mask.contiguous().to(dtype=torch.uint8)
+
+    def grid_masked(meta):
+        q_block = meta["Q_BLOCK"]
+        num_q_blocks = (max_q_len + q_block - 1) // q_block
+        return (num_seq, n_heads, num_q_blocks)
+
+    _paged_context_masked_kernel[grid_masked](
+        q,
+        kv_cache,
+        custom_attn_mask,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        seq_len_with_cache,
+        output,
+        q.stride(0),
+        q.stride(1),
+        output.stride(0),
+        output.stride(1),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        custom_attn_mask.stride(0),
+        custom_attn_mask.stride(1),
+        custom_attn_mask.stride(2),
+        custom_attn_mask.stride(3),
+        SM_SCALE=sm_scale,
+        N_HEADS=n_heads,
+        N_KV_HEADS=n_kv_heads,
+        HEAD_DIM=head_dim,
+        PAGE_SIZE=page_size,
+    )
 
     return output
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -941,6 +941,64 @@ def triton_paged_context(
     return output
 
 
+def _gather_paged_kv_for_sequence(
+    kv_cache: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    seq_idx: int,
+    seq_kv_len: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Gather one sequence's paged KV cache into contiguous tensors in BSND layout."""
+    page_start = int(kv_indptr[seq_idx].item())
+    page_end = int(kv_indptr[seq_idx + 1].item())
+    page_ids = kv_indices[page_start:page_end].to(dtype=torch.long)
+
+    gathered = kv_cache.index_select(0, page_ids)
+    gathered = gathered.permute(1, 0, 3, 2, 4).reshape(2, -1, kv_cache.shape[2], kv_cache.shape[4])
+    gathered = gathered[:, :seq_kv_len]
+    return gathered[0], gathered[1]
+
+
+def triton_paged_context_with_custom_mask(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    seq_len_with_cache: torch.Tensor,
+    custom_attn_mask: torch.Tensor,
+    sm_scale: float,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Prefill fallback for backend-native custom bool masks."""
+    output = out if out is not None else torch.empty_like(q)
+    num_seq = qo_indptr.shape[0] - 1
+
+    for seq_idx in range(num_seq):
+        q_start = int(qo_indptr[seq_idx].item())
+        q_end = int(qo_indptr[seq_idx + 1].item())
+        q_seq = q[q_start:q_end]
+        seq_q_len = q_end - q_start
+        seq_kv_len = int(seq_len_with_cache[seq_idx].item())
+        k_seq, v_seq = _gather_paged_kv_for_sequence(
+            kv_cache, kv_indices, kv_indptr, seq_idx, seq_kv_len
+        )
+        mask_seq = custom_attn_mask[seq_idx : seq_idx + 1, :, :seq_q_len, :seq_kv_len]
+        output[q_start:q_end].copy_(
+            torch.ops.auto_deploy.torch_attention(
+                q_seq.unsqueeze(0),
+                k_seq.unsqueeze(0),
+                v_seq.unsqueeze(0),
+                attn_mask=mask_seq,
+                is_causal=False,
+                scale=sm_scale,
+                layout="bsnd",
+            )[0]
+        )
+
+    return output
+
+
 @torch.library.custom_op("auto_deploy::triton_paged_prepare_metadata", mutates_args=())
 def prepare_triton_paged_metadata(
     position_ids: torch.Tensor,
@@ -999,8 +1057,9 @@ def triton_paged_mha_with_cache(
     triton_positions: torch.Tensor,
     # CACHES - combined KV cache
     kv_cache: torch.Tensor,
+    custom_attn_mask: Optional[torch.Tensor] = None,
     # CONSTANTS
-    scale: Optional[float],
+    scale: Optional[float] = None,
 ) -> torch.Tensor:
     """Triton paged attention with mixed batch support."""
     head_dim = kv_cache.shape[-1]
@@ -1037,17 +1096,30 @@ def triton_paged_mha_with_cache(
     if num_prefill > 0:
         cu_seqlen = cu_seqlen_host[: num_prefill + 1].to(q.device, non_blocking=True)
         seq_len_with_cache = seq_len_with_cache_host[:num_prefill].to(q.device, non_blocking=True)
-        triton_paged_context(
-            q[:num_prefill_tokens],
-            kv_cache,
-            cu_seqlen,
-            cu_num_pages[: num_prefill + 1],
-            cache_loc,
-            last_page_len[:num_prefill],
-            seq_len_with_cache,
-            sm_scale,
-            out=y[:num_prefill_tokens],
-        )
+        if custom_attn_mask is None:
+            triton_paged_context(
+                q[:num_prefill_tokens],
+                kv_cache,
+                cu_seqlen,
+                cu_num_pages[: num_prefill + 1],
+                cache_loc,
+                last_page_len[:num_prefill],
+                seq_len_with_cache,
+                sm_scale,
+                out=y[:num_prefill_tokens],
+            )
+        else:
+            triton_paged_context_with_custom_mask(
+                q[:num_prefill_tokens],
+                kv_cache,
+                cu_seqlen,
+                cu_num_pages[: num_prefill + 1],
+                cache_loc,
+                seq_len_with_cache,
+                custom_attn_mask[:num_prefill],
+                sm_scale,
+                out=y[:num_prefill_tokens],
+            )
 
     # Process decode tokens if any
     if num_decode > 0:
@@ -1080,7 +1152,8 @@ def triton_paged_mha_with_cache_fake(
     triton_batch_indices: torch.Tensor,
     triton_positions: torch.Tensor,
     kv_cache: torch.Tensor,
-    scale: Optional[float],
+    custom_attn_mask: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
 ) -> torch.Tensor:
     return torch.empty_like(q.contiguous())
 
@@ -1150,6 +1223,10 @@ class TritonPagedAttention(AttentionDescriptor):
         }
 
     @classmethod
+    def get_dynamic_inputs(cls, source_attn_node: Node) -> List[Optional[Node]]:
+        return list(extract_op_args(source_attn_node, "attn_mask"))
+
+    @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         layout = source_attn_node.kwargs.get("layout", None)
         if (
@@ -1167,7 +1244,7 @@ class TritonPagedAttention(AttentionDescriptor):
         attn_mask, dropout_p, is_causal = extract_op_args(
             source_attn_node, "attn_mask", "dropout_p", "is_causal"
         )
-        if attn_mask is not None or dropout_p != 0.0 or not is_causal:
+        if dropout_p != 0.0 or not is_causal:
             ad_logger.debug(
                 "Unsupported attention arguments for "
                 f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -1282,10 +1282,14 @@ def triton_paged_mha_with_cache(
     triton_positions: torch.Tensor,
     # CACHES - combined KV cache
     kv_cache: torch.Tensor,
-    custom_attn_mask: Optional[torch.Tensor] = None,
-    # CONSTANTS
+    # CONSTANTS must come before dynamic tensor inputs. The KV-cache transform
+    # appends constants positionally and forwards dynamic inputs as kwargs.
     scale: Optional[float] = None,
     sliding_window: Optional[int] = None,
+    # DYNAMIC INPUTS
+    custom_attn_mask: Optional[torch.Tensor] = None,
+    # OPTIONAL PRE-ALLOCATED OUTPUT
+    out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Triton paged attention with mixed batch support."""
     head_dim = kv_cache.shape[-1]
@@ -1381,9 +1385,10 @@ def triton_paged_mha_with_cache_fake(
     triton_batch_indices: torch.Tensor,
     triton_positions: torch.Tensor,
     kv_cache: torch.Tensor,
-    custom_attn_mask: Optional[torch.Tensor] = None,
     scale: Optional[float] = None,
     sliding_window: Optional[int] = None,
+    custom_attn_mask: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return torch.empty_like(q.contiguous())
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -21,7 +21,7 @@ This module provides a Triton-based paged attention implementation with:
 """
 
 import math
-from typing import List, Literal, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple
 
 import flashinfer
 import torch
@@ -1453,8 +1453,8 @@ class TritonPagedAttention(AttentionDescriptor):
         }
 
     @classmethod
-    def get_dynamic_inputs(cls, source_attn_node: Node) -> List[Optional[Node]]:
-        return list(extract_op_args(source_attn_node, "attn_mask"))
+    def get_dynamic_inputs(cls, source_attn_node: Node) -> Dict[str, Optional[Node]]:
+        return {"custom_attn_mask": extract_op_args(source_attn_node, "attn_mask")[0]}
 
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -209,7 +209,7 @@ def _get_num_splits(max_seq_len: int, batch_size: int, n_kv_heads: int, page_siz
         triton.Config({}, num_warps=8, num_stages=2),
         triton.Config({}, num_warps=8, num_stages=3),
     ],
-    key=["HEAD_DIM", "PAGE_SIZE", "HEAD_RATIO_PADDED"],
+    key=["HEAD_DIM", "PAGE_SIZE", "HEAD_RATIO_PADDED", "SLIDING_WINDOW"],
 )
 @triton.jit
 def _flash_decode_stage1_kernel(
@@ -249,6 +249,7 @@ def _flash_decode_stage1_kernel(
     HEAD_RATIO: tl.constexpr,
     HEAD_RATIO_PADDED: tl.constexpr,
     NUM_SPLITS: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr = 0,
 ):
     """
     Key optimizations:
@@ -266,9 +267,20 @@ def _flash_decode_stage1_kernel(
     num_pages = kv_page_end - kv_page_start
     last_page_len = tl.load(kv_last_page_len_ptr + batch_id)
 
-    # Compute this split's page range (page-aligned splits)
-    pages_per_split = (num_pages + NUM_SPLITS - 1) // NUM_SPLITS
-    page_split_start = split_id * pages_per_split
+    # Sliding window: restrict attention to pages within the window.
+    # Compute the total sequence length and the first valid KV position.
+    seq_len = (num_pages - 1) * PAGE_SIZE + last_page_len
+    if SLIDING_WINDOW > 0:
+        first_valid_pos = tl.maximum(0, seq_len - SLIDING_WINDOW)
+        first_window_page = first_valid_pos // PAGE_SIZE
+    else:
+        first_valid_pos = 0
+        first_window_page = 0
+
+    # Only split over pages within the window.
+    window_pages = num_pages - first_window_page
+    pages_per_split = (window_pages + NUM_SPLITS - 1) // NUM_SPLITS
+    page_split_start = first_window_page + split_id * pages_per_split
     page_split_end = tl.minimum(page_split_start + pages_per_split, num_pages)
 
     dhead_offsets = tl.arange(0, HEAD_DIM)
@@ -346,7 +358,13 @@ def _flash_decode_stage1_kernel(
 
         # [HEAD_RATIO_PADDED, HEAD_DIM] @ [HEAD_DIM, PAGE_SIZE] -> [HEAD_RATIO_PADDED, PAGE_SIZE]
         attn = tl.dot(q_all, tl.trans(k)) * SM_SCALE
-        attn = tl.where(page_mask[None, :], attn, float("-inf"))
+
+        if SLIDING_WINDOW > 0:
+            global_pos = page_idx * PAGE_SIZE + page_offsets
+            window_mask = global_pos >= first_valid_pos
+            attn = tl.where(page_mask[None, :] & window_mask[None, :], attn, float("-inf"))
+        else:
+            attn = tl.where(page_mask[None, :], attn, float("-inf"))
 
         # Online softmax update (vectorized over HEAD_RATIO_PADDED)
         m_ij = tl.max(attn, axis=1)  # [HEAD_RATIO_PADDED]
@@ -454,6 +472,7 @@ def triton_paged_decode(
     kv_indptr: torch.Tensor,
     kv_last_page_len: torch.Tensor,
     sm_scale: float,
+    sliding_window: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Optimized paged decode with GQA batching + FlashDecoding + page-aligned iteration.
@@ -465,6 +484,7 @@ def triton_paged_decode(
         kv_indptr: Cumulative page counts [batch_size + 1]
         kv_last_page_len: Valid tokens in last page [batch_size]
         sm_scale: Softmax scale factor
+        sliding_window: If set, only attend to the last sliding_window tokens
         out: Optional output tensor [batch_size, n_heads, head_dim]
 
     Returns:
@@ -477,13 +497,15 @@ def triton_paged_decode(
 
     max_pages = kv_indices.shape[0]
     max_seq_len = max_pages * page_size
+    sw = sliding_window if isinstance(sliding_window, int) and sliding_window > 0 else 0
 
     output = out if out is not None else torch.empty_like(q)
 
     if batch_size == 0:
         return output
 
-    num_splits = _get_num_splits(max_seq_len, batch_size, n_kv_heads, page_size)
+    effective_seq_len = min(max_seq_len, sw) if sw > 0 else max_seq_len
+    num_splits = _get_num_splits(effective_seq_len, batch_size, n_kv_heads, page_size)
 
     # Allocate intermediate buffers for split-K
     partial_o = torch.empty(
@@ -536,6 +558,7 @@ def triton_paged_decode(
         HEAD_RATIO=head_ratio,
         HEAD_RATIO_PADDED=head_ratio_padded,
         NUM_SPLITS=num_splits,
+        SLIDING_WINDOW=sw,
     )
 
     # Stage 2: Combine partial results
@@ -606,6 +629,7 @@ def _paged_context_kernel(
     N_KV_HEADS: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr = 0,
 ):
     """Context/prefill attention with paged KV cache, causal skip, and page-aligned iteration.
 
@@ -669,6 +693,12 @@ def _paged_context_kernel(
     # Number of full pages (all tokens in these pages are attended by all Q tokens)
     num_full_pages = first_q_kv_pos // PAGE_SIZE
 
+    if SLIDING_WINDOW > 0:
+        first_valid_pos = tl.maximum(0, first_q_kv_pos - SLIDING_WINDOW + 1)
+        first_window_page = first_valid_pos // PAGE_SIZE
+    else:
+        first_window_page = 0
+
     # Check if this is a full Q block (no q_mask needed)
     is_full_q_block = (q_block_start + Q_BLOCK) <= q_len
 
@@ -677,39 +707,63 @@ def _paged_context_kernel(
     kv_head_offset = kv_head_id * cache_stride_head
     local_kv = page_offsets[:, None] * cache_stride_token + dhead_offsets[None, :]
 
-    for page_idx in range(num_full_pages):
+    for page_idx in range(first_window_page, num_full_pages):
         physical_page = tl.load(kv_indices_ptr + kv_page_start + page_idx)
 
         # Use int64 to avoid overflow when physical_page * stride > 2^31
         page_base = physical_page.to(tl.int64) * cache_stride_block + kv_head_offset
-        k_block_ptr = tl.make_block_ptr(
-            base=kv_cache_ptr + page_base,
-            shape=(PAGE_SIZE, HEAD_DIM),
-            strides=(cache_stride_token, 1),
-            offsets=(0, 0),
-            block_shape=(PAGE_SIZE, HEAD_DIM),
-            order=(1, 0),
-        )
-        v_block_ptr = tl.make_block_ptr(
-            base=kv_cache_ptr + page_base + cache_stride_kv,
-            shape=(PAGE_SIZE, HEAD_DIM),
-            strides=(cache_stride_token, 1),
-            offsets=(0, 0),
-            block_shape=(PAGE_SIZE, HEAD_DIM),
-            order=(1, 0),
-        )
-        k = tl.load(k_block_ptr)
-        v = tl.load(v_block_ptr)
 
-        qk = tl.dot(q, tl.trans(k)) * SM_SCALE
+        if SLIDING_WINDOW > 0:
+            k = tl.load(
+                kv_cache_ptr + page_base + local_kv,
+                mask=tl.full([PAGE_SIZE, HEAD_DIM], 1, tl.int1),
+                other=0.0,
+            )
+            v = tl.load(
+                kv_cache_ptr + page_base + local_kv + cache_stride_kv,
+                mask=tl.full([PAGE_SIZE, HEAD_DIM], 1, tl.int1),
+                other=0.0,
+            )
 
-        if not is_full_q_block:
-            qk = tl.where(q_mask[:, None], qk, float("-inf"))
+            qk = tl.dot(q, tl.trans(k)) * SM_SCALE
+            kv_positions = page_idx * PAGE_SIZE + page_offsets[None, :]
+            q_kv_pos = q_offsets[:, None] + cache_len
+            sw_mask = (q_kv_pos - kv_positions) < SLIDING_WINDOW
+            full_mask_p1 = q_mask[:, None] & sw_mask
+            qk = tl.where(full_mask_p1, qk, float("-inf"))
+        else:
+            k_block_ptr = tl.make_block_ptr(
+                base=kv_cache_ptr + page_base,
+                shape=(PAGE_SIZE, HEAD_DIM),
+                strides=(cache_stride_token, 1),
+                offsets=(0, 0),
+                block_shape=(PAGE_SIZE, HEAD_DIM),
+                order=(1, 0),
+            )
+            v_block_ptr = tl.make_block_ptr(
+                base=kv_cache_ptr + page_base + cache_stride_kv,
+                shape=(PAGE_SIZE, HEAD_DIM),
+                strides=(cache_stride_token, 1),
+                offsets=(0, 0),
+                block_shape=(PAGE_SIZE, HEAD_DIM),
+                order=(1, 0),
+            )
+            k = tl.load(k_block_ptr)
+            v = tl.load(v_block_ptr)
+
+            qk = tl.dot(q, tl.trans(k)) * SM_SCALE
+
+            if not is_full_q_block:
+                qk = tl.where(q_mask[:, None], qk, float("-inf"))
 
         m_ij = tl.max(qk, axis=1)
         m_i_new = tl.maximum(m_i, m_ij)
-        alpha = tl.exp(m_i - m_i_new)
-        p = tl.exp(qk - m_i_new[:, None])
+        if SLIDING_WINDOW > 0:
+            alpha = tl.where(m_i > float("-inf"), tl.exp(m_i - m_i_new), 0.0)
+            p = tl.where(m_i_new[:, None] > float("-inf"), tl.exp(qk - m_i_new[:, None]), 0.0)
+        else:
+            alpha = tl.exp(m_i - m_i_new)
+            p = tl.exp(qk - m_i_new[:, None])
         acc = tl.dot(p.to(v.dtype), v, acc=acc * alpha[:, None])
         l_i = l_i * alpha + tl.sum(p, axis=1)
         m_i = m_i_new
@@ -740,13 +794,21 @@ def _paged_context_kernel(
             qk = tl.dot(q, tl.trans(k)) * SM_SCALE
             kv_positions = kv_base_pos + page_offsets[None, :]
             causal_mask = q_positions_2d >= kv_positions
-            full_mask = q_mask[:, None] & causal_mask & page_mask[None, :]
+            if SLIDING_WINDOW > 0:
+                sliding_mask = (q_positions_2d - kv_positions) < SLIDING_WINDOW
+                full_mask = q_mask[:, None] & causal_mask & sliding_mask & page_mask[None, :]
+            else:
+                full_mask = q_mask[:, None] & causal_mask & page_mask[None, :]
             qk = tl.where(full_mask, qk, float("-inf"))
 
             m_ij = tl.max(qk, axis=1)
             m_i_new = tl.maximum(m_i, m_ij)
-            alpha = tl.exp(m_i - m_i_new)
-            p = tl.exp(qk - m_i_new[:, None])
+            if SLIDING_WINDOW > 0:
+                alpha = tl.where(m_i > float("-inf"), tl.exp(m_i - m_i_new), 0.0)
+                p = tl.where(m_i_new[:, None] > float("-inf"), tl.exp(qk - m_i_new[:, None]), 0.0)
+            else:
+                alpha = tl.exp(m_i - m_i_new)
+                p = tl.exp(qk - m_i_new[:, None])
             acc = tl.dot(p.to(v.dtype), v, acc=acc * alpha[:, None])
             l_i = l_i * alpha + tl.sum(p, axis=1)
             m_i = m_i_new
@@ -806,6 +868,7 @@ def _paged_context_masked_kernel(
     N_KV_HEADS: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
+    SLIDING_WINDOW: tl.constexpr = 0,
 ):
     """Context/prefill attention with paged KV cache and a backend-provided bool allow-mask."""
     batch_id = tl.program_id(axis=0)
@@ -875,13 +938,24 @@ def _paged_context_masked_kernel(
         )
         valid_mask = q_mask[:, None] & page_mask[None, :]
         custom_mask = tl.load(custom_mask_ptr + mask_offsets, mask=valid_mask, other=0)
-        full_mask = valid_mask & (custom_mask != 0)
+        if SLIDING_WINDOW > 0:
+            query_positions = q_offsets[:, None]
+            sliding_mask = (query_positions >= kv_positions) & (
+                (query_positions - kv_positions) < SLIDING_WINDOW
+            )
+            full_mask = valid_mask & sliding_mask & (custom_mask != 0)
+        else:
+            full_mask = valid_mask & (custom_mask != 0)
         qk = tl.where(full_mask, qk, float("-inf"))
 
         m_ij = tl.max(qk, axis=1)
         m_i_new = tl.maximum(m_i, m_ij)
-        alpha = tl.exp(m_i - m_i_new)
-        p = tl.exp(qk - m_i_new[:, None])
+        if SLIDING_WINDOW > 0:
+            alpha = tl.where(m_i > float("-inf"), tl.exp(m_i - m_i_new), 0.0)
+            p = tl.where(m_i_new[:, None] > float("-inf"), tl.exp(qk - m_i_new[:, None]), 0.0)
+        else:
+            alpha = tl.exp(m_i - m_i_new)
+            p = tl.exp(qk - m_i_new[:, None])
         acc = tl.dot(p.to(v.dtype), v, acc=acc * alpha[:, None])
         l_i = l_i * alpha + tl.sum(p, axis=1)
         m_i = m_i_new
@@ -955,6 +1029,7 @@ def triton_paged_context(
     kv_last_page_len: torch.Tensor,
     seq_len_with_cache: torch.Tensor,
     sm_scale: float,
+    sliding_window: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Context/prefill attention with paged KV cache."""
@@ -977,6 +1052,8 @@ def triton_paged_context(
         q_lens = qo_indptr[1:] - qo_indptr[:-1]
         max_q_len = int(q_lens.max().item())
 
+    sw = sliding_window if isinstance(sliding_window, int) and sliding_window > 0 else 0
+
     # Adaptive dispatch: gather + cuDNN SDPA for seq>=512 (outperforms paged kernel),
     # paged Triton kernel for shorter sequences where gather overhead dominates.
     # Compute max_pages from max_q_len without GPU sync
@@ -988,6 +1065,7 @@ def triton_paged_context(
         and num_seq <= 64
         and max_pages > 0
         and kv_indices.shape[0] == total_expected_pages  # all seqs same page count
+        and sw == 0  # SDPA doesn't support sliding window natively
     )
 
     if use_sdpa:
@@ -1062,6 +1140,7 @@ def triton_paged_context(
             N_KV_HEADS=n_kv_heads,
             HEAD_DIM=head_dim,
             PAGE_SIZE=page_size,
+            SLIDING_WINDOW=sw,
         )
 
     return output
@@ -1076,6 +1155,7 @@ def triton_paged_context_with_custom_mask(
     seq_len_with_cache: torch.Tensor,
     custom_attn_mask: torch.Tensor,
     sm_scale: float,
+    sliding_window: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Context/prefill attention with paged KV cache and a backend-provided bool allow-mask.
@@ -1104,6 +1184,8 @@ def triton_paged_context_with_custom_mask(
 
     if not custom_attn_mask.is_contiguous() or custom_attn_mask.dtype != torch.uint8:
         custom_attn_mask = custom_attn_mask.contiguous().to(dtype=torch.uint8)
+
+    sw = sliding_window if isinstance(sliding_window, int) and sliding_window > 0 else 0
 
     def grid_masked(meta):
         q_block = meta["Q_BLOCK"]
@@ -1136,6 +1218,7 @@ def triton_paged_context_with_custom_mask(
         N_KV_HEADS=n_kv_heads,
         HEAD_DIM=head_dim,
         PAGE_SIZE=page_size,
+        SLIDING_WINDOW=sw,
     )
 
     return output
@@ -1202,6 +1285,7 @@ def triton_paged_mha_with_cache(
     custom_attn_mask: Optional[torch.Tensor] = None,
     # CONSTANTS
     scale: Optional[float] = None,
+    sliding_window: Optional[int] = None,
 ) -> torch.Tensor:
     """Triton paged attention with mixed batch support."""
     head_dim = kv_cache.shape[-1]
@@ -1248,6 +1332,7 @@ def triton_paged_mha_with_cache(
                 last_page_len[:num_prefill],
                 seq_len_with_cache,
                 sm_scale,
+                sliding_window=sliding_window,
                 out=y[:num_prefill_tokens],
             )
         else:
@@ -1260,6 +1345,7 @@ def triton_paged_mha_with_cache(
                 seq_len_with_cache,
                 custom_attn_mask[:num_prefill],
                 sm_scale,
+                sliding_window=sliding_window,
                 out=y[:num_prefill_tokens],
             )
 
@@ -1272,6 +1358,7 @@ def triton_paged_mha_with_cache(
             cu_num_pages[num_prefill : num_seq + 1],
             last_page_len[num_prefill:num_seq],
             sm_scale,
+            sliding_window=sliding_window,
             out=y[num_prefill_tokens:num_total_tokens],
         )
 
@@ -1296,6 +1383,7 @@ def triton_paged_mha_with_cache_fake(
     kv_cache: torch.Tensor,
     custom_attn_mask: Optional[torch.Tensor] = None,
     scale: Optional[float] = None,
+    sliding_window: Optional[int] = None,
 ) -> torch.Tensor:
     return torch.empty_like(q.contiguous())
 
@@ -1389,4 +1477,6 @@ class TritonPagedAttention(AttentionDescriptor):
             ad_logger.warning(f"Provided {scale=}, is not a float. Using default scale instead.")
             scale = None
 
-        return [scale]
+        sliding_window = extract_op_args(source_attn_node, "sliding_window")[0]
+
+        return [scale, sliding_window]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -847,6 +847,7 @@ def _paged_context_masked_kernel(
     kv_head_offset = kv_head_id * cache_stride_head
     local_kv = page_offsets[:, None] * cache_stride_token + dhead_offsets[None, :]
     mask_batch_offset = batch_id * mask_stride_batch
+    # The mask is broadcast over heads (head dim == 1), so the head offset is always 0.
     mask_head_offset = 0 * mask_stride_head
 
     for page_idx in range(num_kv_pages):
@@ -1077,7 +1078,11 @@ def triton_paged_context_with_custom_mask(
     sm_scale: float,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """Context/prefill attention with paged KV cache and a backend-provided bool allow-mask."""
+    """Context/prefill attention with paged KV cache and a backend-provided bool allow-mask.
+
+    The mask must be broadcastable over heads, i.e. shape ``[B, 1, S_q, S_k]``.
+    Per-head masks (``N > 1`` in the head dimension) are **not** supported.
+    """
     output = out if out is not None else torch.empty_like(q)
     num_seq = qo_indptr.shape[0] - 1
     total_tokens, n_heads, head_dim = q.shape
@@ -1086,13 +1091,19 @@ def triton_paged_context_with_custom_mask(
     if num_seq == 0 or total_tokens == 0:
         return output
 
+    assert custom_attn_mask.shape[1] == 1, (
+        f"Per-head masks are not supported; expected mask head dim == 1, "
+        f"got {custom_attn_mask.shape[1]}. Mask shape: {custom_attn_mask.shape}"
+    )
+
     if num_seq == 1:
         max_q_len = total_tokens
     else:
         q_lens = qo_indptr[1:] - qo_indptr[:-1]
         max_q_len = int(q_lens.max().item())
 
-    custom_attn_mask = custom_attn_mask.contiguous().to(dtype=torch.uint8)
+    if not custom_attn_mask.is_contiguous() or custom_attn_mask.dtype != torch.uint8:
+        custom_attn_mask = custom_attn_mask.contiguous().to(dtype=torch.uint8)
 
     def grid_masked(meta):
         q_block = meta["Q_BLOCK"]
@@ -1369,10 +1380,9 @@ class TritonPagedAttention(AttentionDescriptor):
                 f"for node: {source_attn_node.format_node()}"
             )
 
-        if dropout_p != 0.0 or not is_causal:
+        if dropout_p != 0.0:
             ad_logger.debug(
-                "Unsupported attention arguments for "
-                f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"
+                f"Unsupported attention arguments for {source_attn_node=}: {dropout_p=}"
             )
 
         if not (isinstance(scale, float) or scale is None):

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -1359,26 +1359,21 @@ class TritonPagedAttention(AttentionDescriptor):
 
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
-        layout = extract_op_args(source_attn_node, "layout")[0]
+        layout, scale, attn_mask, dropout_p, is_causal = extract_op_args(
+            source_attn_node, "layout", "scale", "attn_mask", "dropout_p", "is_causal"
+        )
+
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "
                 f"for node: {source_attn_node.format_node()}"
             )
 
-        attn_mask, dropout_p, is_causal = extract_op_args(
-            source_attn_node, "attn_mask", "dropout_p", "is_causal"
-        )
         if dropout_p != 0.0 or not is_causal:
             ad_logger.debug(
                 "Unsupported attention arguments for "
                 f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"
             )
-
-        if len(source_attn_node.args) > 6:
-            scale = source_attn_node.args[6]
-        else:
-            scale = source_attn_node.kwargs.get("scale", None)
 
         if not (isinstance(scale, float) or scale is None):
             ad_logger.warning(f"Provided {scale=}, is not a float. Using default scale instead.")

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
@@ -639,13 +639,7 @@ class TrtllmAttention(AttentionDescriptor):
         from tensor shapes or SequenceInfo metadata at runtime.
         """
         # Sanity check: layout == "bsnd"
-        layout = source_attn_node.kwargs.get("layout", None)
-        if (
-            layout is None
-            and len(source_attn_node.args) > 0
-            and isinstance(source_attn_node.args[-1], str)
-        ):
-            layout = source_attn_node.args[-1]
+        layout = extract_op_args(source_attn_node, "layout")[0]
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -1841,6 +1841,7 @@ class AttentionDescriptor(ABC):
             *meta_std,  # standard metadata fields identified by matching arg names!
             *meta_extra,# metadata about the sequences as returned by the prepare_metadata op
             *caches,    # contains layer-specific caches per provided cache initializers
+            *dynamic,   # optional dynamic tensor args forwarded from the source attention node
             *constants, # basic arguments (int, float, str, None) added as CONSTANTS in the graph
         ) -> torch.Tensor: ...
         ```
@@ -1917,7 +1918,17 @@ class AttentionDescriptor(ABC):
         """Provide a list of constant arguments to be passed to the attention op.
 
         The constant arguments are passed to the attention op as additional arguments after the
-        caches. The constants are expected to be of type int, float, str, or None.
+        caches and any backend-owned dynamic inputs. The constants are expected to be of type int,
+        float, str, or None.
+        """
+        return []
+
+    @classmethod
+    def get_dynamic_inputs(cls, source_attn_node: Node) -> List[Optional[Node]]:
+        """Provide backend-owned dynamic inputs to be forwarded to the cached attention op.
+
+        These inputs are extracted from the source attention node after QKV and metadata handling
+        and are inserted before the constant arguments in the cached attention op call.
         """
         return []
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -1958,6 +1958,8 @@ class AttentionDescriptor(ABC):
 
         The constant arguments are passed to the attention op as positional arguments after the
         caches. Dynamic inputs from ``get_dynamic_inputs`` are passed separately as kwargs.
+        Cached attention op signatures should keep these constant parameters before any dynamic
+        tensor inputs so the transform's mixed calling convention binds correctly.
         The constants are expected to be of type int, float, str, or None.
         """
         return []
@@ -1968,7 +1970,7 @@ class AttentionDescriptor(ABC):
 
         Returns a mapping from keyword argument name to the corresponding FX node
         (or ``None``).  These are passed as **kwargs** to the cached attention op,
-        so the position in the op signature does not matter.
+        so custom op signatures should place them after trailing constant parameters.
         """
         return {}
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -26,7 +26,19 @@ and operates on a purely functional paradigm that is compatible with the torch c
 
 import math
 from abc import ABC, abstractmethod
-from typing import Dict, List, Literal, Optional, Protocol, Sequence, Set, Tuple, Type, Union
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 import numpy as np
 import torch
@@ -678,6 +690,14 @@ class SequenceInfo:
 
         # EXTRA TENSOR FIELDS ######################################################################
         self._extra_args: Dict[str, Optional[torch.Tensor]] = {}
+        # Default factories for extra args: callables that accept this SequenceInfo instance
+        # and return a default value.  These are called whenever a key is absent from
+        # ``extra_args`` in ``nest_sequences`` so that initialization-time forward passes
+        # (resize_kv_cache, cuda-graph warmup) always receive valid inputs.
+        # Model-specific transforms (e.g. attention mask providers) can register factories here.
+        self._default_extra_arg_factories: Dict[
+            str, Callable[["SequenceInfo"], Optional[torch.Tensor]]
+        ] = {}
         ############################################################################################
 
         # HOST PREPARE FOR ATTENTION FORWARD #######################################################
@@ -860,6 +880,21 @@ class SequenceInfo:
             self._active_args += (arg_name,)
             return True
         return False
+
+    def register_default_extra_arg(
+        self,
+        name: str,
+        factory: Callable[["SequenceInfo"], Optional[torch.Tensor]],
+    ) -> None:
+        """Register a callable default factory for an extra argument.
+
+        ``factory`` receives this ``SequenceInfo`` instance and returns the
+        default value for ``name``.  It is invoked at the start of every
+        ``nest_sequences`` call so that initialization-time forward passes
+        (e.g. ``resize_kv_cache``, CUDA-graph warmup) always receive a valid
+        tensor for ``name`` even when no per-request data is provided.
+        """
+        self._default_extra_arg_factories[name] = factory
 
     def to(self, *args, **kwargs) -> None:
         # Move the InputBuffer (which recreates views automatically)
@@ -1118,6 +1153,10 @@ class SequenceInfo:
 
         ### UPDATE EXTRA INPUTS ####################################################################
         self._extra_args = {}
+        # Seed with defaults first (callable factories receive ``self`` so they can
+        # access current shape info via unflatten()), then let per-request values override.
+        for key, factory in self._default_extra_arg_factories.items():
+            self._store_extra_arg(key, factory(self))
         for key, value in extra_args.items():
             self._store_extra_arg(key, value)
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -1880,8 +1880,8 @@ class AttentionDescriptor(ABC):
             *meta_std,  # standard metadata fields identified by matching arg names!
             *meta_extra,# metadata about the sequences as returned by the prepare_metadata op
             *caches,    # contains layer-specific caches per provided cache initializers
-            *dynamic,   # optional dynamic tensor args forwarded from the source attention node
             *constants, # basic arguments (int, float, str, None) added as CONSTANTS in the graph
+            **dynamic,  # optional dynamic tensor kwargs forwarded from the source attention node
         ) -> torch.Tensor: ...
         ```
 
@@ -1956,20 +1956,21 @@ class AttentionDescriptor(ABC):
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         """Provide a list of constant arguments to be passed to the attention op.
 
-        The constant arguments are passed to the attention op as additional arguments after the
-        caches and any backend-owned dynamic inputs. The constants are expected to be of type int,
-        float, str, or None.
+        The constant arguments are passed to the attention op as positional arguments after the
+        caches. Dynamic inputs from ``get_dynamic_inputs`` are passed separately as kwargs.
+        The constants are expected to be of type int, float, str, or None.
         """
         return []
 
     @classmethod
-    def get_dynamic_inputs(cls, source_attn_node: Node) -> List[Optional[Node]]:
-        """Provide backend-owned dynamic inputs to be forwarded to the cached attention op.
+    def get_dynamic_inputs(cls, source_attn_node: Node) -> Dict[str, Optional[Node]]:
+        """Provide backend-owned dynamic tensor inputs forwarded to the cached attention op.
 
-        These inputs are extracted from the source attention node after QKV and metadata handling
-        and are inserted before the constant arguments in the cached attention op call.
+        Returns a mapping from keyword argument name to the corresponding FX node
+        (or ``None``).  These are passed as **kwargs** to the cached attention op,
+        so the position in the op signature does not matter.
         """
-        return []
+        return {}
 
     @staticmethod
     def resolve_cache_dtype(dtype_config: str, fallback_dtype: torch.dtype) -> torch.dtype:

--- a/tensorrt_llm/_torch/auto_deploy/transform/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/__init__.py
@@ -1,4 +1,7 @@
 """AutoDeploy's modular graph transform + inference optimizer pipeline."""
 
-from . import library  # ensure all transforms are registered
+from . import (
+    attention_mask_providers,  # noqa: F401
+    library,  # ensure all transforms are registered
+)
 from .interface import *

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_provider.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_provider.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transform-time registry for backend-native attention mask providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from torch.fx import GraphModule, Node
+
+from ..models.factory import ModelFactory
+from ..shim.interface import CachedSequenceInterface
+from ..utils._graph import _NO_VAL, add_graph_input
+from .interface import SharedConfig
+
+AttentionMaskProviderFn = Callable[["AttentionMaskProviderContext", Node], Optional[Node]]
+
+
+def infer_model_type(factory: Optional[ModelFactory]) -> Optional[str]:
+    """Best-effort inference of the source model type for provider lookup."""
+    if factory is None:
+        return None
+
+    model_type = getattr(factory, "model_type", None)
+    if isinstance(model_type, str):
+        return model_type
+
+    get_model_type = getattr(factory, "get_model_type", None)
+    if callable(get_model_type):
+        inferred = get_model_type()
+        if isinstance(inferred, str):
+            return inferred
+
+    get_model_config = getattr(factory, "_get_model_config", None)
+    if callable(get_model_config):
+        try:
+            model_config, _unused_kwargs = get_model_config()
+        except Exception:
+            return None
+        inferred = getattr(model_config, "model_type", None)
+        if isinstance(inferred, str):
+            return inferred
+
+    return None
+
+
+@dataclass
+class AttentionMaskProviderContext:
+    """Context object shared across provider invocations within one transform pass."""
+
+    gm: GraphModule
+    cm: Optional[CachedSequenceInterface]
+    factory: Optional[ModelFactory]
+    shared_config: SharedConfig
+    model_type: str
+    backend: str
+    cache: Dict[str, Node] = field(default_factory=dict)
+
+    def add_or_retrieve_input(
+        self,
+        name: str,
+        *,
+        activate_arg: bool = True,
+        val: Any = _NO_VAL,
+    ) -> Node:
+        """Add or retrieve a graph placeholder for a provider input."""
+        input_nodes = self.gm.graph.find_nodes(op="placeholder", target=name)
+        if len(input_nodes) == 1:
+            return input_nodes[0]
+        if len(input_nodes) > 1:
+            raise ValueError(f"Expected exactly one input node for {name=}, got {input_nodes=}")
+
+        if activate_arg:
+            if self.cm is None:
+                raise ValueError(
+                    f"Cannot activate managed arg {name!r} without CachedSequenceInterface."
+                )
+            self.cm.info.activate_arg(name)
+
+        return add_graph_input(self.gm, name=name, val=val)
+
+    def get_or_create_cached_node(self, key: str, builder: Callable[[], Node]) -> Node:
+        """Memoize provider-created nodes so shared masks are built once per forward."""
+        if key not in self.cache:
+            self.cache[key] = builder()
+        return self.cache[key]
+
+
+class AttentionMaskProviderRegistry:
+    """Registry for backend-native attention mask providers."""
+
+    _registry: Dict[Tuple[str, str], AttentionMaskProviderFn] = {}
+
+    @classmethod
+    def register(
+        cls, model_type: str, backend: str
+    ) -> Callable[[AttentionMaskProviderFn], AttentionMaskProviderFn]:
+        """Register a provider for a specific ``(model_type, backend)`` pair."""
+
+        def decorator(provider: AttentionMaskProviderFn) -> AttentionMaskProviderFn:
+            cls._registry[(model_type, backend)] = provider
+            return provider
+
+        return decorator
+
+    @classmethod
+    def get(
+        cls, model_type: Optional[str], backend: Optional[str]
+    ) -> Optional[AttentionMaskProviderFn]:
+        """Return the provider registered for ``(model_type, backend)``."""
+        if model_type is None or backend is None:
+            return None
+        return cls._registry.get((model_type, backend))
+
+    @classmethod
+    def has(cls, model_type: str, backend: str) -> bool:
+        """Return whether a provider exists for ``(model_type, backend)``."""
+        return (model_type, backend) in cls._registry

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_provider.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_provider.py
@@ -93,6 +93,25 @@ class AttentionMaskProviderContext:
 
         return add_graph_input(self.gm, name=name, val=val)
 
+    def register_default_extra_arg(
+        self,
+        name: str,
+        factory: Callable,
+    ) -> None:
+        """Register a callable default factory for ``name`` in the SequenceInfo.
+
+        ``factory`` receives the ``SequenceInfo`` and returns the default value
+        for ``name``.  It is called at the start of every ``nest_sequences``
+        so that initialization-time forward passes (e.g. ``resize_kv_cache``)
+        always receive a valid tensor for ``name`` even when no per-request data
+        is available.
+
+        Has no effect when ``cm`` is ``None`` (e.g. during DemoLLM export).
+        """
+        if self.cm is None:
+            return
+        self.cm.info.register_default_extra_arg(name, factory)
+
     def get_or_create_cached_node(self, key: str, builder: Callable[[], Node]) -> Node:
         """Memoize provider-created nodes so shared masks are built once per forward."""
         if key not in self.cache:

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
@@ -98,6 +98,11 @@ def _gemma4_torch_paged_mask_provider(ctx, source_attn_node):
     return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
 
 
+@AttentionMaskProviderRegistry.register("gemma4", "triton_paged")
+def _gemma4_triton_paged_mask_provider(ctx, source_attn_node):
+    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
+
+
 @AttentionMaskProviderRegistry.register("gemma4", "torch_attention")
 def _gemma4_torch_attention_mask_provider(ctx, source_attn_node):
     return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model-specific attention mask providers."""
+
+from __future__ import annotations
+
+import torch
+
+from .attention_mask_provider import AttentionMaskProviderRegistry
+
+
+def _build_gemma4_token_type_mask(ctx, source_attn_node):
+    q_meta = source_attn_node.args[0].meta["val"]
+    batch_size, seq_len = q_meta.shape[:2]
+    token_type_ids = ctx.add_or_retrieve_input(
+        "token_type_ids",
+        activate_arg=False,
+        val=torch.zeros(batch_size, seq_len, dtype=torch.int64),
+    )
+    zeros = ctx.gm.graph.call_function(torch.ops.aten.zeros_like.default, args=(token_type_ids,))
+    non_text = ctx.gm.graph.call_function(torch.ops.aten.ne.Scalar, args=(token_type_ids, 0))
+
+    prev_token_types = ctx.gm.graph.call_function(
+        torch.ops.aten.slice.Tensor, args=(token_type_ids, 1, 0, seq_len - 1)
+    )
+    prev_token_types = ctx.gm.graph.call_function(
+        torch.ops.aten.cat.default,
+        args=(
+            [
+                ctx.gm.graph.call_function(torch.ops.aten.slice.Tensor, args=(zeros, 1, 0, 1)),
+                prev_token_types,
+            ],
+            1,
+        ),
+    )
+
+    changed_type = ctx.gm.graph.call_function(
+        torch.ops.aten.ne.Tensor, args=(token_type_ids, prev_token_types)
+    )
+    blob_starts = ctx.gm.graph.call_function(
+        torch.ops.aten.bitwise_and.Tensor, args=(non_text, changed_type)
+    )
+    blob_ids = ctx.gm.graph.call_function(
+        torch.ops.aten.cumsum.default,
+        args=(
+            ctx.gm.graph.call_function(torch.ops.aten.to.dtype, args=(blob_starts, torch.int64)),
+            1,
+        ),
+    )
+    token_blob_ids = ctx.gm.graph.call_function(
+        torch.ops.aten.where.self, args=(non_text, blob_ids, zeros)
+    )
+
+    blob_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(token_blob_ids, 2))
+    blob_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(token_blob_ids, 1))
+    same_blob = ctx.gm.graph.call_function(torch.ops.aten.eq.Tensor, args=(blob_q, blob_k))
+    media_query = ctx.gm.graph.call_function(torch.ops.aten.ne.Scalar, args=(blob_q, 0))
+    bidirectional_media = ctx.gm.graph.call_function(
+        torch.ops.aten.bitwise_and.Tensor, args=(same_blob, media_query)
+    )
+
+    positions = ctx.gm.graph.call_function(torch.ops.aten.arange.default, args=(seq_len,))
+    pos_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(positions, 0))
+    pos_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(positions, 1))
+    causal_mask = ctx.gm.graph.call_function(torch.ops.aten.le.Tensor, args=(pos_q, pos_k))
+    causal_mask = ctx.gm.graph.call_function(
+        torch.ops.aten.unsqueeze.default, args=(causal_mask, 0)
+    )
+
+    combined = ctx.gm.graph.call_function(
+        torch.ops.aten.bitwise_or.Tensor, args=(causal_mask, bidirectional_media)
+    )
+    return ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(combined, 1))
+
+
+def _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node):
+    return ctx.get_or_create_cached_node(
+        "gemma4_token_type_ids_mask",
+        lambda: _build_gemma4_token_type_mask(ctx, source_attn_node),
+    )
+
+
+@AttentionMaskProviderRegistry.register("gemma4", "torch")
+def _gemma4_torch_paged_mask_provider(ctx, source_attn_node):
+    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
+
+
+@AttentionMaskProviderRegistry.register("gemma4", "torch_attention")
+def _gemma4_torch_attention_mask_provider(ctx, source_attn_node):
+    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
@@ -13,96 +13,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Model-specific attention mask providers."""
+"""Model-specific attention mask providers.
+
+Providers registered here add an optional ``custom_attn_mask`` graph input and
+wire it to each ``torch_attention`` node.  The actual mask tensor is computed
+**outside** the graph (e.g. in the VLM wrapper ``forward()``) and passed in at
+runtime.  During warmup, text-only, and decode steps the wrapper passes
+``None``, so the attention backend uses its fast causal kernel.
+"""
 
 from __future__ import annotations
-
-import torch
 
 from .attention_mask_provider import AttentionMaskProviderRegistry
 
 
-def _build_gemma4_token_type_mask(ctx, source_attn_node):
-    q_meta = source_attn_node.args[0].meta["val"]
-    batch_size, seq_len = q_meta.shape[:2]
-    token_type_ids = ctx.add_or_retrieve_input(
-        "token_type_ids",
+def _add_custom_attn_mask_input(ctx, source_attn_node):
+    """Add ``custom_attn_mask`` as an optional graph input (default ``None``).
+
+    No mask computation nodes are inserted into the graph.  The mask is
+    computed outside the graph by the model wrapper and supplied at runtime.
+    """
+    return ctx.add_or_retrieve_input(
+        "custom_attn_mask",
         activate_arg=False,
-        val=torch.zeros(batch_size, seq_len, dtype=torch.int64),
-    )
-    zeros = ctx.gm.graph.call_function(torch.ops.aten.zeros_like.default, args=(token_type_ids,))
-    non_text = ctx.gm.graph.call_function(torch.ops.aten.ne.Scalar, args=(token_type_ids, 0))
-
-    prev_token_types = ctx.gm.graph.call_function(
-        torch.ops.aten.slice.Tensor, args=(token_type_ids, 1, 0, seq_len - 1)
-    )
-    prev_token_types = ctx.gm.graph.call_function(
-        torch.ops.aten.cat.default,
-        args=(
-            [
-                ctx.gm.graph.call_function(torch.ops.aten.slice.Tensor, args=(zeros, 1, 0, 1)),
-                prev_token_types,
-            ],
-            1,
-        ),
-    )
-
-    changed_type = ctx.gm.graph.call_function(
-        torch.ops.aten.ne.Tensor, args=(token_type_ids, prev_token_types)
-    )
-    blob_starts = ctx.gm.graph.call_function(
-        torch.ops.aten.bitwise_and.Tensor, args=(non_text, changed_type)
-    )
-    blob_ids = ctx.gm.graph.call_function(
-        torch.ops.aten.cumsum.default,
-        args=(
-            ctx.gm.graph.call_function(torch.ops.aten.to.dtype, args=(blob_starts, torch.int64)),
-            1,
-        ),
-    )
-    token_blob_ids = ctx.gm.graph.call_function(
-        torch.ops.aten.where.self, args=(non_text, blob_ids, zeros)
-    )
-
-    blob_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(token_blob_ids, 2))
-    blob_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(token_blob_ids, 1))
-    same_blob = ctx.gm.graph.call_function(torch.ops.aten.eq.Tensor, args=(blob_q, blob_k))
-    media_query = ctx.gm.graph.call_function(torch.ops.aten.ne.Scalar, args=(blob_q, 0))
-    bidirectional_media = ctx.gm.graph.call_function(
-        torch.ops.aten.bitwise_and.Tensor, args=(same_blob, media_query)
-    )
-
-    positions = ctx.gm.graph.call_function(torch.ops.aten.arange.default, args=(seq_len,))
-    pos_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(positions, 0))
-    pos_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(positions, 1))
-    causal_mask = ctx.gm.graph.call_function(torch.ops.aten.le.Tensor, args=(pos_q, pos_k))
-    causal_mask = ctx.gm.graph.call_function(
-        torch.ops.aten.unsqueeze.default, args=(causal_mask, 0)
-    )
-
-    combined = ctx.gm.graph.call_function(
-        torch.ops.aten.bitwise_or.Tensor, args=(causal_mask, bidirectional_media)
-    )
-    return ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(combined, 1))
-
-
-def _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node):
-    return ctx.get_or_create_cached_node(
-        "gemma4_token_type_ids_mask",
-        lambda: _build_gemma4_token_type_mask(ctx, source_attn_node),
+        val=None,
     )
 
 
 @AttentionMaskProviderRegistry.register("gemma4", "torch")
 def _gemma4_torch_paged_mask_provider(ctx, source_attn_node):
-    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
+    return _add_custom_attn_mask_input(ctx, source_attn_node)
 
 
 @AttentionMaskProviderRegistry.register("gemma4", "triton_paged")
 def _gemma4_triton_paged_mask_provider(ctx, source_attn_node):
-    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
+    return _add_custom_attn_mask_input(ctx, source_attn_node)
 
 
 @AttentionMaskProviderRegistry.register("gemma4", "torch_attention")
 def _gemma4_torch_attention_mask_provider(ctx, source_attn_node):
-    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
+    return _add_custom_attn_mask_input(ctx, source_attn_node)

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
@@ -40,11 +40,6 @@ def _add_custom_attn_mask_input(ctx, source_attn_node):
     )
 
 
-@AttentionMaskProviderRegistry.register("gemma4", "torch")
-def _gemma4_torch_paged_mask_provider(ctx, source_attn_node):
-    return _add_custom_attn_mask_input(ctx, source_attn_node)
-
-
 @AttentionMaskProviderRegistry.register("gemma4", "triton_paged")
 def _gemma4_triton_paged_mask_provider(ctx, source_attn_node):
     return _add_custom_attn_mask_input(ctx, source_attn_node)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/inject_custom_attention_mask.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/inject_custom_attention_mask.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Inject backend-native custom attention masks into ``torch_attention`` nodes."""
+
+from typing import Optional, Tuple, Type
+
+import torch
+from pydantic import Field
+from torch.fx import GraphModule, Node
+
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils.node_utils import is_op
+from ..attention_mask_provider import (
+    AttentionMaskProviderContext,
+    AttentionMaskProviderRegistry,
+    infer_model_type,
+)
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    Stages,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+
+class InjectCustomAttentionMaskConfig(TransformConfig):
+    """Configuration for injecting backend-native custom attention masks."""
+
+    stage: Stages = Field(default=Stages.PATTERN_MATCHER)
+    backend: str = Field(
+        default="torch_attention",
+        description="Backend key used to resolve the attention mask provider.",
+    )
+    model_type: Optional[str] = Field(
+        default=None,
+        description="Optional explicit model_type override used for provider lookup.",
+    )
+    override_existing_mask: bool = Field(
+        default=False,
+        description="Whether to override an attention node that already has an attn_mask input.",
+    )
+
+
+@TransformRegistry.register("inject_custom_attention_mask")
+class InjectCustomAttentionMask(BaseTransform):
+    """Inject backend-native masks into ``torch_attention`` calls."""
+
+    config: InjectCustomAttentionMaskConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return InjectCustomAttentionMaskConfig
+
+    @staticmethod
+    def _get_attn_mask_arg(node: Node):
+        if "attn_mask" in node.kwargs:
+            return node.kwargs["attn_mask"]
+        if len(node.args) > 3:
+            return node.args[3]
+        return None
+
+    def _set_attn_mask_arg(self, node: Node, attn_mask: Node) -> None:
+        if len(node.args) > 3:
+            node.update_arg(3, attn_mask)
+            return
+
+        kwargs = dict(node.kwargs)
+        kwargs["attn_mask"] = attn_mask
+        node.kwargs = kwargs
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: Optional[CachedSequenceInterface],
+        factory: Optional[ModelFactory],
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        attn_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.torch_attention)]
+        if not attn_nodes:
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        model_type = self.config.model_type or infer_model_type(factory)
+        provider = AttentionMaskProviderRegistry.get(model_type, self.config.backend)
+        if provider is None:
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        assert model_type is not None
+        ctx = AttentionMaskProviderContext(
+            gm=gm,
+            cm=cm,
+            factory=factory,
+            shared_config=shared_config,
+            model_type=model_type,
+            backend=self.config.backend,
+        )
+
+        num_matches = 0
+        for attn_node in attn_nodes:
+            if (
+                not self.config.override_existing_mask
+                and self._get_attn_mask_arg(attn_node) is not None
+            ):
+                continue
+
+            with gm.graph.inserting_before(attn_node):
+                attn_mask = provider(ctx, attn_node)
+
+            if attn_mask is None:
+                continue
+
+            self._set_attn_mask_arg(attn_node, attn_mask)
+            num_matches += 1
+
+        if num_matches == 0:
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        return gm, TransformInfo(
+            skipped=False, num_matches=num_matches, is_clean=False, has_valid_shapes=False
+        )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/inject_custom_attention_mask.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/inject_custom_attention_mask.py
@@ -23,7 +23,7 @@ from torch.fx import GraphModule, Node
 
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
-from ...utils.node_utils import is_op
+from ...utils.node_utils import extract_op_args, is_op
 from ..attention_mask_provider import (
     AttentionMaskProviderContext,
     AttentionMaskProviderRegistry,
@@ -69,20 +69,21 @@ class InjectCustomAttentionMask(BaseTransform):
 
     @staticmethod
     def _get_attn_mask_arg(node: Node):
-        if "attn_mask" in node.kwargs:
-            return node.kwargs["attn_mask"]
-        if len(node.args) > 3:
-            return node.args[3]
-        return None
+        return extract_op_args(node, "attn_mask")[0]
 
-    def _set_attn_mask_arg(self, node: Node, attn_mask: Node) -> None:
-        if len(node.args) > 3:
-            node.update_arg(3, attn_mask)
-            return
+    @staticmethod
+    def _set_attn_mask_arg(node: Node, attn_mask: Node) -> None:
+        from ...utils.node_utils import _get_op_schema
 
-        kwargs = dict(node.kwargs)
-        kwargs["attn_mask"] = attn_mask
-        node.kwargs = kwargs
+        schema = _get_op_schema(node)
+        pos = {a.name: i for i, a in enumerate(schema.arguments)}
+        idx = pos["attn_mask"]
+        if len(node.args) > idx:
+            node.update_arg(idx, attn_mask)
+        else:
+            kwargs = dict(node.kwargs)
+            kwargs["attn_mask"] = attn_mask
+            node.kwargs = kwargs
 
     def _apply(
         self,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -141,6 +141,7 @@ class _InsertCachedOperator(BaseTransform):
         meta_nodes_std: List[Node],
         meta_nodes_extra: List[Node],
         cache_nodes: List[Node],
+        dynamic_inputs: List[Optional[Node]],
         constants: List[Constant],
     ):
         """Insert a cached attention node into the graph."""
@@ -152,6 +153,7 @@ class _InsertCachedOperator(BaseTransform):
                     *meta_nodes_std,
                     *meta_nodes_extra,
                     *cache_nodes,
+                    *dynamic_inputs,
                     *constants,
                 ),
             )
@@ -206,6 +208,7 @@ class _InsertCachedOperator(BaseTransform):
             attn_descriptor.prepare_node_for_cache_insertion(gm, attn_node)
 
             # retrieve constants for attention_op
+            dynamic_inputs = attn_descriptor.get_dynamic_inputs(attn_node)
             constants = attn_descriptor.get_constants(attn_node)
 
             # insert cached attention replacement op
@@ -216,6 +219,7 @@ class _InsertCachedOperator(BaseTransform):
                 meta_nodes_std,
                 meta_nodes_extra,
                 cache_in_nodes,
+                dynamic_inputs,
                 constants,
             )
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -18,7 +18,7 @@
 
 import inspect
 import operator
-from typing import List, Optional, Tuple, Type
+from typing import Dict, List, Optional, Tuple, Type
 
 import torch
 import torch.nn as nn
@@ -141,7 +141,7 @@ class _InsertCachedOperator(BaseTransform):
         meta_nodes_std: List[Node],
         meta_nodes_extra: List[Node],
         cache_nodes: List[Node],
-        dynamic_inputs: List[Optional[Node]],
+        dynamic_kwargs: Dict[str, Optional[Node]],
         constants: List[Constant],
     ):
         """Insert a cached attention node into the graph."""
@@ -153,9 +153,9 @@ class _InsertCachedOperator(BaseTransform):
                     *meta_nodes_std,
                     *meta_nodes_extra,
                     *cache_nodes,
-                    *dynamic_inputs,
                     *constants,
                 ),
+                kwargs=dynamic_kwargs,
             )
         attn_node.replace_all_uses_with(cached_attn_node)
         gm.graph.erase_node(attn_node)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache_transformers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache_transformers.py
@@ -242,6 +242,7 @@ class HFReplaceCachedAttn(_InsertCachedOperator):
         meta_nodes_std: List[Node],
         meta_nodes_extra: List[Node],
         cache_nodes: List[Node],
+        dynamic_kwargs: Dict[str, Optional[Node]],
         constants: List[Constant],
     ):
         """Here we now need to actually do the correct mapping of the cached attn nodes."""

--- a/tests/unittest/auto_deploy/_utils_test/torch_attention_reference.py
+++ b/tests/unittest/auto_deploy/_utils_test/torch_attention_reference.py
@@ -67,6 +67,7 @@ class TorchAttentionReference:
             seq_start,
             k_cache,
             v_cache,
+            None,
             scale,
         )
 
@@ -108,6 +109,7 @@ class TorchAttentionReference:
             seq_start,
             k_cache,
             v_cache,
+            None,
             scale,
         )
 
@@ -162,6 +164,7 @@ class TorchAttentionReference:
             k_cache,
             v_cache,
             None,
+            None,
         )
 
         # Return in flattened format to match flashinfer backend behavior [batch, seq=1, n_heads * head_dim]
@@ -198,6 +201,7 @@ class TorchAttentionReference:
             seq_start,
             k_cache,
             v_cache,
+            None,
             scale,
             None,  # sinks
             sliding_window_size,

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_torch_attention_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_torch_attention_op.py
@@ -10,6 +10,66 @@ import tensorrt_llm._torch.auto_deploy  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo
 
 
+@torch.inference_mode()
+def test_torch_backend_attention_custom_bool_mask_context():
+    device = "cuda"
+    dtype = torch.float16
+    batch_size, seq_len, num_heads, head_dim = 1, 5, 2, 8
+    scale = 1.0 / math.sqrt(head_dim)
+
+    q = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    v = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    k_cache = torch.zeros(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    v_cache = torch.zeros(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+
+    token_type_ids = torch.tensor([[0, 1, 1, 2, 2]], device=device, dtype=torch.int64)
+    non_text = token_type_ids != 0
+    prev = torch.cat(
+        [
+            torch.zeros(batch_size, 1, device=device, dtype=token_type_ids.dtype),
+            token_type_ids[:, :-1],
+        ],
+        dim=1,
+    )
+    blob_starts = non_text & (token_type_ids != prev)
+    blob_ids = torch.cumsum(blob_starts.to(torch.int64), dim=1)
+    token_blob_ids = torch.where(non_text, blob_ids, torch.zeros_like(blob_ids))
+    media_mask = (token_blob_ids.unsqueeze(2) == token_blob_ids.unsqueeze(1)) & (
+        token_blob_ids.unsqueeze(2) != 0
+    )
+    positions = torch.arange(seq_len, device=device)
+    attn_mask = (positions.unsqueeze(0) <= positions.unsqueeze(1)).unsqueeze(0) | media_mask
+    attn_mask = attn_mask.unsqueeze(1)
+
+    batch_info = BatchInfo()
+    batch_info.update([batch_size, batch_size * seq_len, 0, 0, 0, 0])
+    seq_len_tensor = torch.tensor([seq_len], device=device, dtype=torch.int32)
+    input_positions = torch.tensor([0], device=device, dtype=torch.int32)
+    slot_idx = torch.tensor([0], device=device, dtype=torch.int32)
+    seq_start = torch.tensor([0], device=device, dtype=torch.int32)
+
+    expected = torch.ops.auto_deploy.torch_attention(
+        q, k, v, attn_mask=attn_mask, is_causal=False, scale=scale, layout="bsnd"
+    )
+    actual = torch.ops.auto_deploy.torch_cached_attention_with_cache.default(
+        q,
+        k,
+        v,
+        batch_info.serialize(),
+        seq_len_tensor,
+        input_positions,
+        slot_idx,
+        seq_start,
+        k_cache,
+        v_cache,
+        attn_mask,
+        scale,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=5e-2, rtol=5e-2)
+
+
 def numpy_attention_reference(
     q,
     k,

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_torch_attention_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_torch_attention_op.py
@@ -427,13 +427,13 @@ class TestTorchBackendAttention:
             # CACHES
             data["k_cache"],
             data["v_cache"],
-            # DYNAMIC INPUTS
-            None,  # custom_attn_mask
             # CONSTANTS
             scale,
             sinks,
             sliding_window_size,
             logit_cap,
+            # DYNAMIC INPUTS
+            custom_attn_mask=None,
         )
 
     def test_basic_functionality(self):
@@ -451,6 +451,42 @@ class TestTorchBackendAttention:
         )
 
         # Verify output is not NaN or Inf
+        assert torch.isfinite(output).all(), "Output contains NaN or Inf values"
+
+    def test_accepts_positional_constants_with_keyword_custom_mask(self):
+        """Regression test for transform-emitted call style."""
+        batch_size, seq_len, n_heads, n_kv_heads, d_head, max_seq_len = 2, 4, 8, 4, 32, 128
+        data = self._create_test_data(batch_size, seq_len, n_heads, n_kv_heads, d_head, max_seq_len)
+        custom_attn_mask = torch.ones(
+            batch_size,
+            1,
+            seq_len,
+            seq_len,
+            dtype=torch.bool,
+            device=self.device,
+        )
+
+        output = torch.ops.auto_deploy.torch_cached_attention_with_cache(
+            data["q"],
+            data["k"],
+            data["v"],
+            data["batch_info_host"],
+            data["seq_len"],
+            data["input_pos"],
+            data["cache_loc"],
+            data["seq_start"],
+            data["k_cache"],
+            data["v_cache"],
+            None,
+            None,
+            None,
+            None,
+            False,
+            custom_attn_mask=custom_attn_mask,
+        )
+
+        expected_shape = data["q"].shape[:2] + (n_heads * d_head,)
+        assert output.shape == expected_shape
         assert torch.isfinite(output).all(), "Output contains NaN or Inf values"
 
     @pytest.mark.parametrize("logit_cap", [None, 5.0])

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_torch_attention_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_torch_attention_op.py
@@ -357,11 +357,13 @@ class TestTorchBackendAttention:
             # CACHES
             data["k_cache"],
             data["v_cache"],
+            # DYNAMIC INPUTS
+            None,  # custom_attn_mask
             # CONSTANTS
             scale,
             sinks,
             sliding_window_size,
-            logit_cap,  # Updated parameter order
+            logit_cap,
         )
 
     def test_basic_functionality(self):

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_torch_attention_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_torch_attention_op.py
@@ -70,6 +70,76 @@ def test_torch_backend_attention_custom_bool_mask_context():
     torch.testing.assert_close(actual, expected, atol=5e-2, rtol=5e-2)
 
 
+@torch.inference_mode()
+def test_torch_backend_attention_custom_bool_mask_with_sliding_window_context():
+    device = "cuda"
+    dtype = torch.float16
+    batch_size, seq_len, num_heads, head_dim = 1, 6, 2, 8
+    scale = 1.0 / math.sqrt(head_dim)
+    sliding_window_size = 3
+
+    q = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    v = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    k_cache = torch.zeros(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    v_cache = torch.zeros(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+
+    token_type_ids = torch.tensor([[0, 1, 1, 1, 2, 2]], device=device, dtype=torch.int64)
+    non_text = token_type_ids != 0
+    prev = torch.cat(
+        [
+            torch.zeros(batch_size, 1, device=device, dtype=token_type_ids.dtype),
+            token_type_ids[:, :-1],
+        ],
+        dim=1,
+    )
+    blob_starts = non_text & (token_type_ids != prev)
+    blob_ids = torch.cumsum(blob_starts.to(torch.int64), dim=1)
+    token_blob_ids = torch.where(non_text, blob_ids, torch.zeros_like(blob_ids))
+    media_mask = (token_blob_ids.unsqueeze(2) == token_blob_ids.unsqueeze(1)) & (
+        token_blob_ids.unsqueeze(2) != 0
+    )
+    positions = torch.arange(seq_len, device=device)
+    attn_mask = (positions.unsqueeze(0) <= positions.unsqueeze(1)).unsqueeze(0) | media_mask
+    attn_mask = attn_mask.unsqueeze(1)
+
+    batch_info = BatchInfo()
+    batch_info.update([batch_size, batch_size * seq_len, 0, 0, 0, 0])
+    seq_len_tensor = torch.tensor([seq_len], device=device, dtype=torch.int32)
+    input_positions = torch.tensor([0], device=device, dtype=torch.int32)
+    slot_idx = torch.tensor([0], device=device, dtype=torch.int32)
+    seq_start = torch.tensor([0], device=device, dtype=torch.int32)
+
+    expected = torch.ops.auto_deploy.torch_attention(
+        q,
+        k,
+        v,
+        attn_mask=attn_mask,
+        is_causal=False,
+        scale=scale,
+        sliding_window=sliding_window_size,
+        layout="bsnd",
+    )
+    actual = torch.ops.auto_deploy.torch_cached_attention_with_cache.default(
+        q,
+        k,
+        v,
+        batch_info.serialize(),
+        seq_len_tensor,
+        input_positions,
+        slot_idx,
+        seq_start,
+        k_cache,
+        v_cache,
+        attn_mask,
+        scale,
+        None,
+        sliding_window_size,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=5e-2, rtol=5e-2)
+
+
 def numpy_attention_reference(
     q,
     k,

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
@@ -23,6 +23,8 @@ import math
 import pytest
 import torch
 
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
 # Skip all tests if CUDA is not available
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 
@@ -261,6 +263,78 @@ class TestTritonPagedContextKernel:
             q_ref, k_ref, v_ref, scale=sm_scale, is_causal=True
         )
         output_ref = output_ref.transpose(1, 2).reshape(total_tokens, n_heads, head_dim)
+
+        torch.testing.assert_close(output.float(), output_ref.float(), rtol=1e-2, atol=1e-2)
+
+    def test_context_with_custom_bool_mask_matches_torch_attention(self):
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_context_with_custom_mask,
+            update_paged_kv_cache,
+        )
+
+        batch_size, seq_len = 1, 5
+        n_heads, n_kv_heads, head_dim = 8, 8, 64
+        page_size = 16
+        num_pages_per_seq = 1
+        num_blocks = 4
+        total_tokens = batch_size * seq_len
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+        q = torch.randn(total_tokens, n_heads, head_dim, dtype=torch.float16, device="cuda")
+        k = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        v = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+
+        qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+        kv_indptr = torch.tensor([0, num_pages_per_seq], dtype=torch.int32, device="cuda")
+        kv_indices = torch.tensor([0], dtype=torch.int32, device="cuda")
+        seq_len_with_cache = torch.tensor([seq_len], dtype=torch.int32, device="cuda")
+
+        batch_indices = torch.zeros(total_tokens, dtype=torch.int32, device="cuda")
+        positions = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+
+        kv_cache = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        update_paged_kv_cache(k, v, batch_indices, positions, kv_cache, kv_indices, kv_indptr)
+
+        token_type_ids = torch.tensor([[0, 1, 1, 2, 2]], device="cuda", dtype=torch.int64)
+        non_text = token_type_ids != 0
+        prev = torch.cat(
+            [
+                torch.zeros(batch_size, 1, device="cuda", dtype=token_type_ids.dtype),
+                token_type_ids[:, :-1],
+            ],
+            dim=1,
+        )
+        blob_starts = non_text & (token_type_ids != prev)
+        blob_ids = torch.cumsum(blob_starts.to(torch.int64), dim=1)
+        token_blob_ids = torch.where(non_text, blob_ids, torch.zeros_like(blob_ids))
+        media_mask = (token_blob_ids.unsqueeze(2) == token_blob_ids.unsqueeze(1)) & (
+            token_blob_ids.unsqueeze(2) != 0
+        )
+        pos = torch.arange(seq_len, device="cuda")
+        custom_attn_mask = (
+            (pos.unsqueeze(0) <= pos.unsqueeze(1)).unsqueeze(0) | media_mask
+        ).unsqueeze(1)
+
+        output = triton_paged_context_with_custom_mask(
+            q,
+            kv_cache,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            seq_len_with_cache,
+            custom_attn_mask,
+            sm_scale,
+        )
+
+        output_ref = torch.ops.auto_deploy.torch_attention(
+            q.view(batch_size, seq_len, n_heads, head_dim),
+            k.view(batch_size, seq_len, n_kv_heads, head_dim),
+            v.view(batch_size, seq_len, n_kv_heads, head_dim),
+            attn_mask=custom_attn_mask,
+            is_causal=False,
+            scale=sm_scale,
+            layout="bsnd",
+        ).reshape(total_tokens, n_heads, head_dim)
 
         torch.testing.assert_close(output.float(), output_ref.float(), rtol=1e-2, atol=1e-2)
 

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
@@ -490,6 +490,7 @@ class TestTritonPagedMHAIntegration:
             batch_indices,
             positions,
             kv_cache,
+            custom_attn_mask=None,
             scale=None,
         )
 

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
@@ -338,6 +338,85 @@ class TestTritonPagedContextKernel:
 
         torch.testing.assert_close(output.float(), output_ref.float(), rtol=1e-2, atol=1e-2)
 
+    def test_context_with_custom_bool_mask_and_sliding_window_matches_torch_attention(self):
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_context_with_custom_mask,
+            update_paged_kv_cache,
+        )
+
+        batch_size, seq_len = 1, 18
+        n_heads, n_kv_heads, head_dim = 8, 8, 64
+        page_size = 16
+        num_pages_per_seq = (seq_len + page_size - 1) // page_size
+        num_blocks = 4
+        total_tokens = batch_size * seq_len
+        sm_scale = 1.0 / math.sqrt(head_dim)
+        sliding_window = 3
+
+        q = torch.randn(total_tokens, n_heads, head_dim, dtype=torch.float16, device="cuda")
+        k = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        v = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+
+        qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+        kv_indptr = torch.tensor([0, num_pages_per_seq], dtype=torch.int32, device="cuda")
+        kv_indices = torch.arange(num_pages_per_seq, dtype=torch.int32, device="cuda")
+        seq_len_with_cache = torch.tensor([seq_len], dtype=torch.int32, device="cuda")
+
+        batch_indices = torch.zeros(total_tokens, dtype=torch.int32, device="cuda")
+        positions = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+
+        kv_cache = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        update_paged_kv_cache(k, v, batch_indices, positions, kv_cache, kv_indices, kv_indptr)
+
+        token_type_ids = torch.tensor(
+            [[0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2]],
+            device="cuda",
+            dtype=torch.int64,
+        )
+        non_text = token_type_ids != 0
+        prev = torch.cat(
+            [
+                torch.zeros(batch_size, 1, device="cuda", dtype=token_type_ids.dtype),
+                token_type_ids[:, :-1],
+            ],
+            dim=1,
+        )
+        blob_starts = non_text & (token_type_ids != prev)
+        blob_ids = torch.cumsum(blob_starts.to(torch.int64), dim=1)
+        token_blob_ids = torch.where(non_text, blob_ids, torch.zeros_like(blob_ids))
+        media_mask = (token_blob_ids.unsqueeze(2) == token_blob_ids.unsqueeze(1)) & (
+            token_blob_ids.unsqueeze(2) != 0
+        )
+        pos = torch.arange(seq_len, device="cuda")
+        custom_attn_mask = (
+            (pos.unsqueeze(0) <= pos.unsqueeze(1)).unsqueeze(0) | media_mask
+        ).unsqueeze(1)
+
+        output = triton_paged_context_with_custom_mask(
+            q,
+            kv_cache,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            seq_len_with_cache,
+            custom_attn_mask,
+            sm_scale,
+            sliding_window=sliding_window,
+        )
+
+        output_ref = torch.ops.auto_deploy.torch_attention(
+            q.view(batch_size, seq_len, n_heads, head_dim),
+            k.view(batch_size, seq_len, n_kv_heads, head_dim),
+            v.view(batch_size, seq_len, n_kv_heads, head_dim),
+            attn_mask=custom_attn_mask,
+            is_causal=False,
+            scale=sm_scale,
+            sliding_window=sliding_window,
+            layout="bsnd",
+        ).reshape(total_tokens, n_heads, head_dim)
+
+        torch.testing.assert_close(output.float(), output_ref.float(), rtol=1e-2, atol=1e-2)
+
 
 class TestCacheUpdate:
     """Tests for the KV cache update kernel."""

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
@@ -596,6 +596,73 @@ class TestTritonPagedMHAIntegration:
         assert num_prefill_tokens == 96  # 32 + 64
         assert num_decode == 3
 
+    def test_accepts_positional_constants_with_keyword_custom_mask(self):
+        """Regression test for transform-emitted call style.
+
+        The KV-cache transform passes scale/sliding_window positionally and
+        custom_attn_mask by keyword. This should bind correctly.
+        """
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            prepare_triton_paged_metadata,
+            triton_paged_mha_with_cache,
+        )
+
+        n_heads, n_kv_heads, head_dim, page_size = 8, 2, 128, 16
+        seq_len = 8
+        num_pages = (seq_len + page_size - 1) // page_size
+        num_blocks = num_pages + 4
+
+        q = torch.randn(1, seq_len, n_heads, head_dim, dtype=torch.float16, device="cuda")
+        k = torch.randn(1, seq_len, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        v = torch.randn(1, seq_len, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+
+        batch_info_host = self._make_batch_info(
+            num_prefill=1, num_prefill_tokens=seq_len, num_decode=0
+        )
+        cu_seqlen_host = torch.tensor([0, seq_len], dtype=torch.int32)
+        cu_num_pages = torch.tensor([0, num_pages], dtype=torch.int32, device="cuda")
+        cu_num_pages_host = cu_num_pages.cpu()
+        cache_loc = torch.arange(num_pages, dtype=torch.int32, device="cuda")
+        last_page_len = torch.tensor([seq_len], dtype=torch.int32, device="cuda")
+        last_page_len_host = last_page_len.cpu()
+        seq_len_with_cache_host = torch.tensor([seq_len], dtype=torch.int32)
+        kv_cache = torch.zeros(
+            num_blocks, 2, n_kv_heads, page_size, head_dim, dtype=torch.float16, device="cuda"
+        )
+
+        position_ids = torch.arange(seq_len, device="cuda")
+        batch_indices, positions = prepare_triton_paged_metadata(
+            position_ids,
+            batch_info_host,
+            cu_seqlen_host.to("cuda", non_blocking=True),
+            seq_len_with_cache_host.to("cuda", non_blocking=True),
+        )
+        custom_attn_mask = torch.ones(1, 1, seq_len, seq_len, dtype=torch.bool, device="cuda")
+
+        output = triton_paged_mha_with_cache(
+            q,
+            k,
+            v,
+            batch_info_host,
+            cu_seqlen_host,
+            cu_num_pages,
+            cu_num_pages_host,
+            cache_loc,
+            last_page_len,
+            last_page_len_host,
+            seq_len_with_cache_host,
+            batch_indices,
+            positions,
+            kv_cache,
+            1.0,
+            page_size,
+            custom_attn_mask=custom_attn_mask,
+        )
+
+        assert output.shape == q.shape
+        assert not torch.isnan(output).any(), "Output contains NaN"
+        assert not torch.isinf(output).any(), "Output contains Inf"
+
     def test_prepare_metadata_with_12_element_batch_info(self):
         """Test prepare_triton_paged_metadata with 12-element batch_info_host."""
         from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
@@ -74,9 +74,34 @@ class DummyFactory:
         return SimpleNamespace(model_type="unit_test_mask_model"), {}
 
 
+class Gemma4Factory:
+    def _get_model_config(self):
+        return SimpleNamespace(model_type="gemma4"), {}
+
+
 def _build_segment_mask(segment_ids: torch.Tensor) -> torch.Tensor:
     same_segment = segment_ids.unsqueeze(2) == segment_ids.unsqueeze(1)
     return same_segment.unsqueeze(1)
+
+
+def _build_token_type_mask(token_type_ids: torch.Tensor) -> torch.Tensor:
+    non_text = token_type_ids != 0
+    prev = torch.cat(
+        [
+            torch.zeros(token_type_ids.shape[0], 1, dtype=token_type_ids.dtype),
+            token_type_ids[:, :-1],
+        ],
+        dim=1,
+    )
+    blob_starts = non_text & (token_type_ids != prev)
+    blob_ids = torch.cumsum(blob_starts.to(torch.int64), dim=1)
+    token_blob_ids = torch.where(non_text, blob_ids, torch.zeros_like(blob_ids))
+    media_mask = (token_blob_ids.unsqueeze(2) == token_blob_ids.unsqueeze(1)) & (
+        token_blob_ids.unsqueeze(2) != 0
+    )
+    positions = torch.arange(token_type_ids.shape[1])
+    causal_mask = positions.unsqueeze(0) <= positions.unsqueeze(1)
+    return (causal_mask.unsqueeze(0) | media_mask).unsqueeze(1)
 
 
 _provider_build_counts = {"mask": 0}
@@ -143,4 +168,39 @@ def test_inject_custom_attention_mask():
     expected = model.forward_with_mask(input_ids, expected_mask)
     actual = gm_transformed(input_ids, position_ids, segment_ids=segment_ids)
 
+    torch.testing.assert_close(actual, expected)
+
+
+@torch.inference_mode()
+def test_inject_gemma4_custom_attention_mask_for_torch_backend():
+    model = DualAttentionModel().eval()
+    input_ids = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.int64)
+    position_ids = torch.arange(input_ids.shape[1], dtype=torch.int64).repeat(input_ids.shape[0], 1)
+    token_type_ids = torch.tensor([[0, 1, 1, 2, 2]], dtype=torch.int64)
+
+    gm = torch_export_to_gm(model, args=(input_ids, position_ids), clone=True)
+    gm_transformed = InferenceOptimizer(
+        Gemma4Factory(),
+        {
+            "inject_custom_attention_mask": {
+                "stage": "pattern_matcher",
+                "backend": "torch",
+            },
+        },
+    )(None, gm)
+
+    attn_nodes = [
+        node
+        for node in gm_transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_attention)
+    ]
+    assert len(attn_nodes) == 2
+    assert all(
+        (node.args[3] if len(node.args) > 3 else node.kwargs["attn_mask"]) is not None
+        for node in attn_nodes
+    )
+
+    expected_mask = _build_token_type_mask(token_type_ids)
+    expected = model.forward_with_mask(input_ids, expected_mask)
+    actual = gm_transformed(input_ids, position_ids, token_type_ids=token_type_ids)
     torch.testing.assert_close(actual, expected)

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
@@ -204,3 +204,38 @@ def test_inject_gemma4_custom_attention_mask_for_torch_backend():
     expected = model.forward_with_mask(input_ids, expected_mask)
     actual = gm_transformed(input_ids, position_ids, token_type_ids=token_type_ids)
     torch.testing.assert_close(actual, expected)
+
+
+@torch.inference_mode()
+def test_inject_gemma4_custom_attention_mask_for_triton_paged_backend():
+    model = DualAttentionModel().eval()
+    input_ids = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.int64)
+    position_ids = torch.arange(input_ids.shape[1], dtype=torch.int64).repeat(input_ids.shape[0], 1)
+    token_type_ids = torch.tensor([[0, 1, 1, 2, 2]], dtype=torch.int64)
+
+    gm = torch_export_to_gm(model, args=(input_ids, position_ids), clone=True)
+    gm_transformed = InferenceOptimizer(
+        Gemma4Factory(),
+        {
+            "inject_custom_attention_mask": {
+                "stage": "pattern_matcher",
+                "backend": "triton_paged",
+            },
+        },
+    )(None, gm)
+
+    attn_nodes = [
+        node
+        for node in gm_transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_attention)
+    ]
+    assert len(attn_nodes) == 2
+    assert all(
+        (node.args[3] if len(node.args) > 3 else node.kwargs["attn_mask"]) is not None
+        for node in attn_nodes
+    )
+
+    expected_mask = _build_token_type_mask(token_type_ids)
+    expected = model.forward_with_mask(input_ids, expected_mask)
+    actual = gm_transformed(input_ids, position_ids, token_type_ids=token_type_ids)
+    torch.testing.assert_close(actual, expected)

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
@@ -200,10 +200,16 @@ def test_inject_gemma4_custom_attention_mask_for_torch_backend():
         for node in attn_nodes
     )
 
-    expected_mask = _build_token_type_mask(token_type_ids)
-    expected = model.forward_with_mask(input_ids, expected_mask)
-    actual = gm_transformed(input_ids, position_ids, token_type_ids=token_type_ids)
+    # With outside-graph approach, the graph receives the finished mask, not token_type_ids.
+    custom_attn_mask = _build_token_type_mask(token_type_ids)
+    expected = model.forward_with_mask(input_ids, custom_attn_mask)
+    actual = gm_transformed(input_ids, position_ids, custom_attn_mask=custom_attn_mask)
     torch.testing.assert_close(actual, expected)
+
+    # Verify None mask produces standard causal output
+    actual_none = gm_transformed(input_ids, position_ids, custom_attn_mask=None)
+    expected_none = model(input_ids, position_ids)
+    torch.testing.assert_close(actual_none, expected_none)
 
 
 @torch.inference_mode()
@@ -235,7 +241,8 @@ def test_inject_gemma4_custom_attention_mask_for_triton_paged_backend():
         for node in attn_nodes
     )
 
-    expected_mask = _build_token_type_mask(token_type_ids)
-    expected = model.forward_with_mask(input_ids, expected_mask)
-    actual = gm_transformed(input_ids, position_ids, token_type_ids=token_type_ids)
+    # With outside-graph approach, the graph receives the finished mask, not token_type_ids.
+    custom_attn_mask = _build_token_type_mask(token_type_ids)
+    expected = model.forward_with_mask(input_ids, custom_attn_mask)
+    actual = gm_transformed(input_ids, position_ids, custom_attn_mask=custom_attn_mask)
     torch.testing.assert_close(actual, expected)

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for custom attention mask injection into torch_attention nodes."""
+
+from types import SimpleNamespace
+
+import torch
+
+import tensorrt_llm._torch.auto_deploy.custom_ops.attention.torch_attention  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.transform.attention_mask_provider import (
+    AttentionMaskProviderRegistry,
+)
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+
+class DualAttentionModel(torch.nn.Module):
+    """Minimal model with two torch_attention calls sharing one custom mask."""
+
+    def __init__(self, hidden_size: int = 8, num_heads: int = 2):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+
+        self.q_proj_1 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj_1 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.v_proj_1 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.q_proj_2 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj_2 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.v_proj_2 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+
+    def _embed(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return input_ids.unsqueeze(-1).expand(-1, -1, self.hidden_size).to(torch.float32)
+
+    def _run_attention(self, x: torch.Tensor, attn_mask: torch.Tensor | None) -> torch.Tensor:
+        batch_size, seq_len, _ = x.shape
+
+        def _project(q_proj, k_proj, v_proj):
+            q = q_proj(x).view(batch_size, seq_len, self.num_heads, self.head_dim)
+            k = k_proj(x).view(batch_size, seq_len, self.num_heads, self.head_dim)
+            v = v_proj(x).view(batch_size, seq_len, self.num_heads, self.head_dim)
+            return torch.ops.auto_deploy.torch_attention(
+                q, k, v, attn_mask=attn_mask, is_causal=False, layout="bsnd"
+            )
+
+        return _project(self.q_proj_1, self.k_proj_1, self.v_proj_1) + _project(
+            self.q_proj_2, self.k_proj_2, self.v_proj_2
+        )
+
+    def forward(self, input_ids: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        del position_ids
+        return self._run_attention(self._embed(input_ids), attn_mask=None)
+
+    def forward_with_mask(self, input_ids: torch.Tensor, attn_mask: torch.Tensor) -> torch.Tensor:
+        return self._run_attention(self._embed(input_ids), attn_mask=attn_mask)
+
+
+class DummyFactory:
+    def _get_model_config(self):
+        return SimpleNamespace(model_type="unit_test_mask_model"), {}
+
+
+def _build_segment_mask(segment_ids: torch.Tensor) -> torch.Tensor:
+    same_segment = segment_ids.unsqueeze(2) == segment_ids.unsqueeze(1)
+    return same_segment.unsqueeze(1)
+
+
+_provider_build_counts = {"mask": 0}
+
+
+@AttentionMaskProviderRegistry.register("unit_test_mask_model", "torch_attention")
+def _segment_mask_provider(ctx, source_attn_node):
+    del source_attn_node
+
+    def _builder():
+        _provider_build_counts["mask"] += 1
+        segment_ids = ctx.add_or_retrieve_input(
+            "segment_ids",
+            activate_arg=False,
+            val=torch.zeros(2, 4, dtype=torch.int64),
+        )
+        seg_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(segment_ids, 2))
+        seg_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(segment_ids, 1))
+        same_segment = ctx.gm.graph.call_function(torch.ops.aten.eq.Tensor, args=(seg_q, seg_k))
+        return ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(same_segment, 1))
+
+    return ctx.get_or_create_cached_node("segment_ids_mask", _builder)
+
+
+@torch.inference_mode()
+def test_inject_custom_attention_mask():
+    model = DualAttentionModel().eval()
+    input_ids = torch.tensor([[1, 2, 3, 4], [4, 3, 2, 1]], dtype=torch.int64)
+    position_ids = torch.arange(input_ids.shape[1], dtype=torch.int64).repeat(input_ids.shape[0], 1)
+    segment_ids = torch.tensor([[0, 0, 1, 1], [0, 1, 1, 2]], dtype=torch.int64)
+
+    gm = torch_export_to_gm(model, args=(input_ids, position_ids), clone=True)
+
+    _provider_build_counts["mask"] = 0
+    gm_transformed = InferenceOptimizer(
+        DummyFactory(),
+        {
+            "inject_custom_attention_mask": {
+                "stage": "pattern_matcher",
+                "backend": "torch_attention",
+            },
+        },
+    )(None, gm)
+
+    attn_nodes = [
+        node
+        for node in gm_transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_attention)
+    ]
+    assert len(attn_nodes) == 2
+    assert _provider_build_counts["mask"] == 1
+
+    mask_nodes = [
+        node.args[3] if len(node.args) > 3 else node.kwargs["attn_mask"] for node in attn_nodes
+    ]
+    assert mask_nodes[0] is mask_nodes[1]
+
+    placeholder_targets = {
+        node.target for node in gm_transformed.graph.nodes if node.op == "placeholder"
+    }
+    assert "segment_ids" in placeholder_targets
+
+    expected_mask = _build_segment_mask(segment_ids)
+    expected = model.forward_with_mask(input_ids, expected_mask)
+    actual = gm_transformed(input_ids, position_ids, segment_ids=segment_ids)
+
+    torch.testing.assert_close(actual, expected)

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
@@ -184,7 +184,7 @@ def test_inject_gemma4_custom_attention_mask_for_torch_backend():
         {
             "inject_custom_attention_mask": {
                 "stage": "pattern_matcher",
-                "backend": "torch",
+                "backend": "torch_attention",
             },
         },
     )(None, gm)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This branch adds custom attention mask injection infrastructure for the AutoDeploy pipeline, specifically targeting Gemma4's VLM attention patterns. The
   work spans:                                                                                                                                            
  1. A new transform (inject_custom_attention_mask) with a provider registry pattern                                                                      
  2. A new get_dynamic_inputs() hook in the AttentionDescriptor ABC to forward runtime tensors through the cached attention op                            
  3. A default extra-arg factory system on SequenceInfo for warmup/CUDA-graph passes                                                                      
  4. A new Triton kernel (_paged_context_masked_kernel) for masked prefill                                                                                
  5. Mask support plumbed into torch and triton_paged backends                                                                                            
  6. Refactoring of layout extraction to use extract_op_args() consistently 

This is infra only. A follow up Gemma4 multimodal PR PR will implement the end 2 end for the model.



# Custom Attention Mask Flow

## Key Design Points

- Mask is computed **outside** the graph (no mask-building ops in the exported graph). In-graph mask computation hits symbolic shape and device errors after graph recompilation during KV cache transforms
- The graph only receives a `custom_attn_mask` placeholder (defaults to `None`)
- Provider registry maps `(model_type, backend)` → mask wiring function
- `get_dynamic_inputs()` on `AttentionDescriptor` ensures the mask tensor flows through the cached attention op (between caches and constants)
- Triton kernel requires **broadcast mask** `[B, 1, S_q, S_k]`; torch backend supports `[B, N, S_q, S_k]` via slicing
- custom_attn_mask should not be expected to carry sliding-window logic. The backend must apply sliding window on top of whatever user mask is provided.

## Block Diagram

```
┌─────────────────────────────────────────────────────────────────────────┐
│                        TRANSFORM TIME (graph rewrite)                   │
│                                                                         │
│  InferenceOptimizer                                                     │
│    │                                                                    │
│    ▼                                                                    │
│  InjectCustomAttentionMask transform                                    │
│    │                                                                    │
│    ├─ infer_model_type(factory) ──► "gemma4"                           │
│    │                                                                    │
│    ├─ AttentionMaskProviderRegistry.get("gemma4", backend)             │
│    │     │                                                              │
│    │     ▼                                                              │
│    │   _gemma4_*_mask_provider(ctx, attn_node)                         │
│    │     │                                                              │
│    │     ▼                                                              │
│    │   ctx.add_or_retrieve_input("custom_attn_mask", val=None)         │
│    │     │                  ▲                                           │
│    │     │                  │ (cached — built once, shared across       │
│    │     │                  │  all attn nodes in the graph)             │
│    │     ▼                                                              │
│    │   placeholder node: custom_attn_mask                              │
│    │                                                                    │
│    ├─ For each torch_attention node:                                    │
│    │     set attn_mask arg ──► placeholder node                        │
│    │                                                                    │
│    ▼                                                                    │
│  _InsertCachedOperator (kvcache.py)                                    │
│    │                                                                    │
│    ├─ get_dynamic_inputs(attn_node) ──► [attn_mask node]               │
│    │                                                                    │
│    ▼                                                                    │
│  cached_attention_op(q, k, v, *meta, *caches, *dynamic, *constants)    │
│                                            ▲                            │
│                                            │                            │
│                              custom_attn_mask inserted here             │
└─────────────────────────────────────────────────────────────────────────┘

┌─────────────────────────────────────────────────────────────────────────┐
│                        RUNTIME (forward pass)                           │
│                                                                         │
│  VLM Wrapper (outside the graph)                                        │
│    │                                                                    │
│    ├─ Prefill with vision tokens?                                       │
│    │     YES ──► compute mask [B, 1, S_q, S_k] from token_type_ids     │
│    │     NO  ──► pass None (decode / text-only)                        │
│    │                                                                    │
│    ▼                                                                    │
│  graph(input_ids, position_ids, custom_attn_mask=mask_or_none)         │
│    │                                                                    │
│    ▼                                                                    │
│  ┌───────────────────────────────────────────────────────┐              │
│  │  Backend dispatch (per attention layer)                │              │
│  │                                                       │              │
│  │  if custom_attn_mask is None:                         │              │
│  │    ├─ torch_backend ──► standard causal kernel         │              │
│  │    └─ triton_paged  ──► triton_paged_context()        │              │
│  │                                                       │              │
│  │  if custom_attn_mask is not None:                     │              │
│  │    ├─ torch_backend ──► _torch_context_mha()          │              │
│  │    │    mask[idx, :, :S_q, :S_kv] ──► masked_fill_   │              │
│  │    │                                                  │              │
│  │    └─ triton_paged  ──► _paged_context_masked_kernel  │              │
│  │         mask[B, 0, q_pos, kv_pos] ──► per-page load  │              │
│  │         (broadcast over heads, head dim must be 1)    │              │
│  └───────────────────────────────────────────────────────┘              │
│                                                                         │
│  Warmup / CUDA-graph capture passes:                                    │
│    SequenceInfo.nest_sequences()                                        │
│      │                                                                  │
│      ├─ _default_extra_arg_factories["custom_attn_mask"](info)         │
│      │    ──► returns None (no mask during warmup)                      │
│      │                                                                  │
│      └─ per-request extra_args override if present                      │
└─────────────────────────────────────────────────────────────────────────┘
```



## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added custom attention mask support across multiple attention backends (torch, triton_paged, torch_attention). Introduced an attention mask provider registry enabling model-specific mask handling. Enhanced graph transformation pipeline with mask injection capabilities. Extended attention descriptors to support dynamic inputs and shared KV caching.

* **Tests**
  * Added comprehensive test coverage for custom attention mask functionality and provider registry integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->