### PR TITLE
[None][feat] AutoDeploy: Gemma4 multimodal support with custom attention mask

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/evictionPolicy.h
+++ b/cpp/include/tensorrt_llm/batch_manager/evictionPolicy.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,13 +33,14 @@ public:
 
     // TODO(TRTLLM-1564): Don't use a separate `initialize` function. Ensure eviction policies can't be in-between a
     // state of construction and initialization.
-    virtual void initialize(std::vector<BlockPtr>& mAllBlocksById, std::vector<SizeType32> sizes,
+    virtual void initialize(std::vector<BlockPtr>& mAllBlocksById, std::vector<SizeType32> blocksPerCacheLevel,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority)
         = 0;
 
     /// @brief Get a free block from the specified cache level
     /// @returns The pointer to the free block, along with whether it can be offloaded
-    virtual std::tuple<BlockPtr, bool> getFreeBlock(SizeType32 cacheLevel) = 0;
+    /// @param wantPlaceholder If true, return a placeholder block instead of a normal block
+    virtual std::tuple<BlockPtr, bool> getFreeBlock(SizeType32 cacheLevel, bool wantPlaceholder = false) = 0;
     /// @brief Release a block. Prioritize the block for eviction if toFront=true
     virtual void releaseBlock(BlockPtr block) = 0;
     virtual void releaseBlock(BlockPtr block, bool toFront) = 0;
@@ -70,9 +71,14 @@ struct ExpiringBlockComparator
 class LRUEvictionPolicy : public BaseEvictionPolicy
 {
 public:
-    void initialize(std::vector<BlockPtr>& mAllBlocksById, std::vector<SizeType32> sizes,
+    void initialize(std::vector<BlockPtr>& mAllBlocksById, std::vector<SizeType32> blocksPerCacheLevel,
         std::optional<executor::RetentionPriority> secondaryOffloadMinPriority) override;
-    std::tuple<BlockPtr, bool> getFreeBlock(SizeType32 cacheLevel) override;
+
+    /// @brief Initialize placeholder block management.
+    /// @param allPlaceholderBlocksById Vector of placeholder blocks indexed by abs(blockId).
+    void initializePlaceholders(std::vector<BlockPtr>& allPlaceholderBlocksById);
+
+    std::tuple<BlockPtr, bool> getFreeBlock(SizeType32 cacheLevel, bool wantPlaceholder = false) override;
 
     void releaseBlock(BlockPtr block) override;
     void releaseBlock(BlockPtr block, bool toFront) override;
@@ -92,15 +98,31 @@ public:
     bool verifyQueueIntegrity() override;
 
 private:
-    // Queues of available leaf blocks, split by cache level and priority level
+    /// @brief A fixed-size container supporting both non-negative and negative indexing.
+    ///        Non-negative IDs index directly into positive.
+    ///        Negative IDs index into negative by absolute value, i.e. -1 → 1, -2 → 2, etc.
+    template <typename T>
+    struct BidirectionalVector
+    {
+        std::vector<T> positive;
+        std::vector<T> negative;
+
+        T& operator[](KVCacheBlock::IdType id)
+        {
+            return id >= 0 ? positive[id] : negative[-id];
+        }
+    };
+
+    // Queues of available leaf blocks, split by level and priority: [level][priorityIdx]
+    // Levels 0,1 = primary,secondary (real cache); level 2 = placeholder
     std::vector<std::vector<FreeBlocksQueue>> mFreeQueues;
-    // Iterators to block entries in mFreeQueues
-    std::vector<std::optional<FreeBlocksQueue::iterator>> mFreeBlockIterators;
-    // Amount of free blocks at each cache level
+    // Iterators to block entries in mFreeQueues, indexed by block ID
+    BidirectionalVector<std::optional<FreeBlocksQueue::iterator>> mFreeBlockIterators;
+    // Amount of free blocks at each level
     std::vector<SizeType32> mNumFreeBlocksPerLevel;
-    // Secondary offload threshold. Blocks below this priority won't be evicted.
+    // Secondary offload threshold. Blocks below this priority won't be offloaded.
     executor::RetentionPriority mSecondaryOffloadMinPriority;
-    // Heap of block times
+    // Heap of block expiration times
     std::set<BlockPtr, ExpiringBlockComparator> mExpiringBlockHeap;
 };
 

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -31,7 +31,6 @@
 #include "tensorrt_llm/runtime/cudaStream.h"
 #include "tensorrt_llm/runtime/iBuffer.h"
 #include "tensorrt_llm/runtime/iTensor.h"
-#include "tensorrt_llm/runtime/modelConfig.h"
 #include "tensorrt_llm/runtime/worldConfig.h"
 #include <NvInferRuntime.h>
 
@@ -40,8 +39,11 @@
 #include <limits>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <ostream>
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -81,6 +83,7 @@ using LoraTaskIdType = tensorrt_llm::runtime::LoraTaskIdType;
 using BlocksPerWindow = std::map<SizeType32, std::tuple<SizeType32, SizeType32>>;
 using CacheSaltIDType = tensorrt_llm::runtime::CacheSaltIDType;
 using MmKey = tensorrt_llm::executor::MmKey;
+using WindowSizeType = SizeType32;
 
 template <typename T>
 using OptionalRef = tensorrt_llm::common::OptionalRef<T>;
@@ -110,6 +113,89 @@ std::list<std::vector<T>> chopVectorIntoBlocks(
     }
     return blockedVectors;
 }
+
+struct LinearAttentionMetadata
+{
+    enum LinearCacheType : WindowSizeType
+    {
+        kRecurrentStates = static_cast<WindowSizeType>(0x80000001),
+    };
+
+    std::vector<SizeType32> linearLayerIndices;
+    WindowSizeType cacheType;
+    SizeType32 allRecurrentStatesBytes; // Sum of all states like ssm_state and conv_state (1 layer)
+    SizeType32 statesSnapshotInterval;  // Only used for kRecurrentStates
+    bool saveLastSnapshot;              // Take additional snapshot of recurrent states at the end of the input sequence
+
+    // Optional: explicit number of placeholder blocks for this kRecurrentStates manager.
+    // If set, overrides the automatic computation (fullAttention.primaryBlocks - this.primaryBlocks).
+    std::optional<SizeType32> numPlaceholderBlocks;
+
+    [[nodiscard]] bool shouldAllocateRecurrentStates(
+        SizeType32 currentBlockEndTokenIdx, SizeType32 promptLen, SizeType32 tokensPerBlock) const
+    {
+        // Allocate the last full block for maximum reuse opportunity.
+        if (saveLastSnapshot && (currentBlockEndTokenIdx / tokensPerBlock == promptLen / tokensPerBlock))
+        {
+            TLLM_LOG_DEBUG("Allocating recurrent states for block %d, reason: saveLastSnapshot",
+                (currentBlockEndTokenIdx / tokensPerBlock - 1));
+            return true;
+        }
+
+        // Allocate the block that contains the end of the current sequence to save the final state.
+        if (currentBlockEndTokenIdx >= promptLen && currentBlockEndTokenIdx < promptLen + tokensPerBlock)
+        {
+            TLLM_LOG_DEBUG("Allocating recurrent states for block %d, reason: end of sequence",
+                (currentBlockEndTokenIdx / tokensPerBlock - 1));
+            return true;
+        }
+
+        // We have checked statesSnapshotInterval is multiple of mTokensPerBlock during WindowBlockManager
+        // initialization.
+        if ((statesSnapshotInterval > 0) && (currentBlockEndTokenIdx % statesSnapshotInterval == 0))
+        {
+            TLLM_LOG_DEBUG("Allocating recurrent states for block %d, reason: statesSnapshotInterval",
+                (currentBlockEndTokenIdx / tokensPerBlock - 1));
+            return true;
+        }
+        return false;
+    }
+
+    [[nodiscard]] bool hasRecurrentStatesCache() const
+    {
+        return hasRecurrentStatesCache(cacheType);
+    }
+
+    static constexpr bool hasRecurrentStatesCache(WindowSizeType encodedWindowSize)
+    {
+        return (static_cast<uint32_t>(encodedWindowSize) & static_cast<uint32_t>(LinearCacheType::kRecurrentStates))
+            == static_cast<uint32_t>(LinearCacheType::kRecurrentStates);
+    }
+
+    static constexpr bool hasLinearCache(WindowSizeType encodedWindowSize)
+    {
+        return hasRecurrentStatesCache(encodedWindowSize);
+    }
+
+    [[nodiscard]] SizeType32 calcMaxMemoryBlocks(
+        WindowSizeType encodedWindowSize, SizeType32 tokensPerBlock, size_t memoryBudget, SizeType32 numLayers) const
+    {
+        if (hasRecurrentStatesCache(encodedWindowSize))
+        {
+            TLLM_CHECK_WITH_INFO(
+                encodedWindowSize == kRecurrentStates, "each pool must only serve one type of linear cache");
+            TLLM_CHECK_WITH_INFO(statesSnapshotInterval % tokensPerBlock == 0,
+                "statesSnapshotInterval must be multiple of tokensPerBlock");
+            // take a snapshot every `blockAlignment` blocks.
+            auto perBlockBytes = allRecurrentStatesBytes * numLayers;
+            auto numDynamicBlocks = (memoryBudget / perBlockBytes);
+            return static_cast<SizeType32>(numDynamicBlocks);
+        }
+        TLLM_THROW("Unknown linear cache type");
+    }
+};
+
+using SizeType32 = WindowSizeType;
 
 struct TempAttentionWindowInputs
 {
@@ -182,7 +268,7 @@ public:
 
     static constexpr IdType kCachedBlocksRootId = -1;
 
-    explicit KVCacheBlock(IdType blockId, kernels::KVCacheIndex blockIdx);
+    explicit KVCacheBlock(IdType blockId, kernels::KVCacheIndex blockIdx, SizeType32 windowSize = -1);
 
     void startScheduling();
 
@@ -234,6 +320,12 @@ public:
 
     [[nodiscard]] VecUniqueTokens const& getUniqueTokens() const;
 
+    //! \brief Return the lookup-tree node this block is attached to, or nullptr if not cached.
+    [[nodiscard]] radix_block_tree::LookupNodePtr getLookupNode() const
+    {
+        return mLookupNode;
+    }
+
     //! \brief Return the parent block in the lookup tree.
     //! \details Navigates via mLookupNode->getParentNode()->getValue(mWindowSize).
     //! Returns nullptr when:
@@ -261,9 +353,13 @@ public:
     //! \brief Create a placeholder KVCacheBlock with no GPU memory.
     //! \details The placeholder holds a block ID for sequence bookkeeping but mIsPlaceholder
     //! is set so that getCacheBlockIndices returns a nil index and the eviction pool ignores it.
-    static BlockPtr createPlaceholder(IdType blockId);
+    static BlockPtr createPlaceholder(IdType blockId, SizeType32 windowSize);
 
     void detachDescendantsFromLookupTree();
+    //! \brief Detach all placeholder blocks in the previous-block chain from the lookup tree.
+    //! \details Walks upward via getPrevBlock() and calls detachFromLookupNode() on each
+    //! block that is a placeholder. Stops at the root (kCachedBlocksRootId).
+    void detachPreviousPlaceholdersFromLookupTree() const;
     void freeBlockAndAllDescendants();
 
     //! \brief Find block matching blockKey. If allowPartial is true, the returned block may match only a prefix of
@@ -541,6 +637,11 @@ public:
     bool containsBlockScales;
     bool containsIndexerKCache;
 
+    // When true, pool tensor is laid out as {numLayers, numBlocks, kvFactor, blockSize}
+    // instead of the default {numBlocks, numLayers, kvFactor, blockSize}.
+    // Used for recurrent state (linear attention) pools.
+    bool layerFirstLayout;
+
     KVCacheBlockPool(SizeType32 numLayers, SizeType32 kvFactor, SizeType32 numKvHeads, SizeType32 sizePerHead,
         SizeType32 tokensPerBlock, runtime::ITensor::SharedPtr primaryPtr = nullptr,
         runtime::ITensor::SharedPtr secondaryPtr = nullptr, bool containsBlockScales = false,
@@ -555,6 +656,7 @@ public:
         , secondaryPtr(std::move(secondaryPtr))
         , containsBlockScales(containsBlockScales)
         , containsIndexerKCache(containsIndexerKCache)
+        , layerFirstLayout(false)
     {
     }
 };
@@ -595,7 +697,9 @@ public:
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager,
         radix_block_tree::UnifiedBlockTree& lookupTree, std::shared_ptr<kvc::BaseLoopbackAgent> loopbackAgent = nullptr,
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
-        SizeType32 indexerKCacheIndexHeadDim = 0);
+        SizeType32 indexerKCacheIndexHeadDim = 0,
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt,
+        SizeType32 numPlaceholderBlocks = 0);
 
     ~WindowBlockManager();
 
@@ -633,6 +737,10 @@ public:
     //! \brief Allocate new block for each beam of the sequence.
     //! \details Might free cached blocks if no free blocks are available.
     void allocateBlock(GenerationRequest& sequence, bool shareAmongBeams);
+
+    //! \brief According to request's current position, copy data from the last full block to the next block (ignoring
+    //! the placeholder block). It should be called after every context chunk is processed.
+    void copyLinearAttentionBlock(GenerationRequest& sequence, LlmRequest const& llmRequest);
 
     void replaceSharedBlock(GenerationRequest& sequence, SizeType32 blockIdx);
 
@@ -722,10 +830,7 @@ public:
         return static_cast<SizeType32>(mAllBlocksById.size());
     }
 
-    [[nodiscard]] BlockPtr const& getBlockById(KVCacheBlock::IdType blockId) const
-    {
-        return mAllBlocksById.at(blockId);
-    }
+    [[nodiscard]] BlockPtr getBlockById(KVCacheBlock::IdType blockId) const;
 
     [[nodiscard]] SizeType32 getTokensPerBlock() const noexcept
     {
@@ -925,35 +1030,48 @@ public:
     }
 
 private:
+    bool tryAllocatePlaceholderForLinearAttention(GenerationRequest& sequence, bool shareAmongBeams);
+
     //! \brief Add single block to beam of sequence and mAllocatedBlocksPerSeq.
-    void addBlockToBeam(BlockPtr& block, GenerationRequest& sequence, SizeType32 beamIdx);
+    void addBlockToBeam(BlockPtr const& block, GenerationRequest& sequence, SizeType32 beamIdx);
 
     //! \brief Add single block to all beams of sequence.
-    void addBlockToAllBeams(BlockPtr& block, GenerationRequest& sequence);
+    void addBlockToAllBeams(BlockPtr const& block, GenerationRequest& sequence);
 
     //! \brief Try to load blocks from cache. Allocate new blocks if necessary.
     //! \param blockKeys Key of each block.
     //! \param sequence Sequence to which blocks are assigned.
     //! \return Number of matched tokens from loaded blocks.
     SizeType32 loadOrAllocateBlocks(std::vector<BlockKey> const& blockKeys, SizeType32 numContextBlocks,
-        GenerationRequest& sequence, std::vector<executor::RetentionPriorityAndDuration> const& perBlockRetentions,
-        executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "");
+        GenerationRequest& sequence, LlmRequest& llmRequest,
+        std::vector<executor::RetentionPriorityAndDuration> const& perBlockRetentions,
+        bool shareLastContextBlockAmongBeams, executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM,
+        std::string const& directory = "");
 
     //! \brief Free block and all it's descendants. This makes block a claimed leaf block.
     void freeChildren(BlockPtr const& block);
 
     //! \brief Find block least likely to be reused, free it if necessary and return.
     //! \param sequence Sequence which the free block is allocated for
+    //! \param wantPlaceholder If true, return a pre-allocated placeholder block instead of a normal block
     [[nodiscard]] BlockPtr getFreeBlock(GenerationRequest& sequence,
         executor::RetentionPriority = executor::KvCacheRetentionConfig::kDefaultRetentionPriority,
         std::optional<std::chrono::milliseconds> durationMs = std::nullopt,
-        executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "");
+        executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM, std::string const& directory = "",
+        bool wantPlaceholder = false);
 
     //! \brief Calls KVCacheBlock::freeLeafBlock to remove block from search tree.
     void freeLeafBlock(BlockPtr const& block);
 
     //! \brief For FP4 quantization. Creates pool objects for FP4 block scalars.
     void createBlockScalePools(SizeType32 blockSize);
+
+    //! \brief This WindowBlockManager is for holding SSM states for linear attention models.
+    [[nodiscard]] bool isRecurrentState() const
+    {
+        return mLinearAttentionMetadata.has_value()
+            && LinearAttentionMetadata::hasRecurrentStatesCache(mLinearAttentionMetadata->cacheType);
+    }
 
 private:
     nvinfer1::DataType mDataType;
@@ -988,6 +1106,10 @@ private:
     bool mIsSWA;
     // List of all blocks by idx
     std::vector<BlockPtr> mAllBlocksById;
+    // Pre-allocated placeholder blocks for linear attention (recurrent state) managers.
+    // Indexed by abs(blockId): mAllPlaceholderBlocksById[abs(blockId)] gives the block with that negative ID.
+    // Indices 0 and 1 are unused (nullptr); valid blocks start at index 2 (blockId == -2).
+    std::vector<BlockPtr> mAllPlaceholderBlocksById;
     // Pointer to the shared radix lookup tree owned by BlockManager.
     // All WindowBlockManager instances under the same BlockManager share one tree,
     // using window size as the value key so their nodes coexist in the same trie.
@@ -1049,6 +1171,8 @@ private:
     SizeType32 mIndexerKCacheQuantBlockSize;
     // Index head dim for indexer K cache
     SizeType32 mIndexerKCacheIndexHeadDim;
+
+    std::optional<LinearAttentionMetadata> mLinearAttentionMetadata;
 };
 
 class BlockManager
@@ -1069,7 +1193,8 @@ public:
         bool copyOnPartialReuse = true,
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         std::optional<kvc::BaseAgentConfig> agentConfig = std::nullopt, bool enableIndexerKCache = false,
-        SizeType32 indexerKCacheQuantBlockSize = 128, SizeType32 indexerKCacheIndexHeadDim = 0);
+        SizeType32 indexerKCacheQuantBlockSize = 128, SizeType32 indexerKCacheIndexHeadDim = 0,
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
 
     [[nodiscard]] bool isEnableIndexerKCache() const
     {
@@ -1118,6 +1243,10 @@ public:
         GenerationRequest& sequence, SizeType32 numContextBlocks, SizeType32 windowSize, bool isShareLastContextBlock);
 
     void allocateBlock(GenerationRequest& sequence, SizeType32 windowSize);
+
+    //! \brief According to request's current position, copy data from the last full block to the next block (ignoring
+    //! the placeholder block). It should be called after every context chunk is processed.
+    void copyLinearAttentionBlock(GenerationRequest& sequence, LlmRequest const& llmRequest);
 
     void replaceSharedBlock(GenerationRequest& sequence, SizeType32 windowSize, SizeType32 blockIdx);
 
@@ -1184,7 +1313,7 @@ public:
 
     [[nodiscard]] SizeType32 getNumFreeBlocks() const
     {
-        return sumWindows([](auto const& manager) { return manager.getNumFreeBlocks(); });
+        return sumWindows([](WindowBlockManager const& manager) { return manager.getNumFreeBlocks(); });
     }
 
     [[nodiscard]] bool schedulingHasFreeBlocks(SizeType32 numRequired, SizeType32 windowSize) const
@@ -1253,6 +1382,13 @@ public:
         return windowManagerByLayer(layerIdx).getPoolLayerIdx(layerIdx);
     }
 
+    [[nodiscard]] bool isPoolLayerFirst(SizeType32 layerIdx) const
+    {
+        auto const& manager = windowManagerByLayer(layerIdx);
+        auto const relativePoolIndex = manager.getLayerPoolIdx(layerIdx);
+        return manager.getPool(relativePoolIndex).layerFirstLayout;
+    }
+
     [[nodiscard]] SizeType32 getTokensPerBlock() const noexcept
     {
         return mTokensPerBlock;
@@ -1301,6 +1437,11 @@ public:
         return mWindowSizeToMetadata.at(windowSize);
     }
 
+    [[nodiscard]] std::optional<LinearAttentionMetadata> const& getLinearAttentionMetadata() const noexcept
+    {
+        return mLinearAttentionMetadata;
+    }
+
     [[nodiscard]] bool isVariableWindow() const noexcept
     {
         return mIsVariableWindow;
@@ -1341,7 +1482,7 @@ public:
         return sumWindows([](auto const& manager) { return manager.getMaxNumBlocks(); });
     }
 
-    [[nodiscard]] BlockPtr const& getBlockById(KVCacheBlock::IdType blockId, SizeType32 windowSize) const
+    [[nodiscard]] BlockPtr getBlockById(KVCacheBlock::IdType blockId, SizeType32 windowSize) const
     {
         return mWindowBlockManagers.at(windowSize).getBlockById(blockId);
     }
@@ -1374,6 +1515,11 @@ public:
     //! \brief Perform per-request bookkeeping
     void refreshBlocks();
 
+    [[nodiscard]] WindowBlockManager& getWindowBlockManager(SizeType32 windowSize)
+    {
+        return mWindowBlockManagers.at(windowSize);
+    }
+
     [[nodiscard]] runtime::BufferManager const& getBufferManager(SizeType32 windowSize) const
     {
         return mWindowBlockManagers.at(windowSize).getBufferManager();
@@ -1384,6 +1530,11 @@ public:
         auto const windowSize = getPoolWindowSize(poolIdx);
         auto const relativePoolIndex = mAbsolutePoolToRelativePoolIndex.at(poolIdx);
         return mWindowBlockManagers.at(windowSize).getPool(relativePoolIndex);
+    }
+
+    [[nodiscard]] KVCacheBlockPool const& getRecurrentStatesPool() const
+    {
+        return mWindowBlockManagers.at(LinearAttentionMetadata::LinearCacheType::kRecurrentStates).getPool(0);
     }
 
     //! \brief Update cache offsets for blocks initiated from sequence
@@ -1497,6 +1648,7 @@ private:
     bool mIsEnableIndexerKCache{false};
     SizeType32 mIndexerKCacheQuantBlockSize{0};
     SizeType32 mIndexerKCacheIndexHeadDim{0};
+    std::optional<LinearAttentionMetadata> mLinearAttentionMetadata;
 };
 
 struct OffsetTableDimensions
@@ -1565,6 +1717,10 @@ public:
 
     /// @brief Increase size for request at seqSlotIdx. Allocate new KV cache block(s) if needed.
     virtual void addToken(LlmRequest::RequestIdType requestId) = 0;
+
+    /// @brief Get the number of tokens for a request at KVCacheManager's sight. Sometimes it is different from
+    /// LlmRequest::getNumTokens.
+    [[nodiscard]] virtual SizeType32 getTokenCount(LlmRequest::RequestIdType requestId) const = 0;
 
     /// @brief Add new request to the KV cache manager.
     /// @param inputLength Input length for which KV cache need to be allocated.
@@ -1661,6 +1817,7 @@ public:
     [[nodiscard]] virtual runtime::ITensor::SharedPtr getPrimaryPool(SizeType32 layer_idx) const = 0;
     [[nodiscard]] virtual runtime::ITensor::SharedPtr getIndexerKCachePool() const = 0;
     [[nodiscard]] virtual SizeType32 getPoolLayerIdx(SizeType32 layer_idx) const = 0;
+    [[nodiscard]] virtual bool isPoolLayerFirst(SizeType32 layer_idx) const = 0;
 
     virtual void syncTransferManagerWithBufferManager() = 0;
     virtual void refreshBlocks() = 0;
@@ -1671,15 +1828,19 @@ public:
 
     // Sum of numLayers * kvFactor * numKvHeads * sizePerHead for each pool
     [[nodiscard]] static SizeType32 calculateCacheSizePerTokenForSingleWindowSize(
-        tensorrt_llm::runtime::ModelConfig const& modelConfig, std::vector<SizeType32> const& windowSizeLayers,
-        bool isCrossAttention, SizeType32 kvFactor)
+        std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead,
+        std::vector<SizeType32> const& windowSizeLayers, SizeType32 kvFactor)
     {
-        auto const nkvh = modelConfig.getNumKvHeadsForGivenLayers(windowSizeLayers, isCrossAttention);
+        std::vector<SizeType32> nkvh;
+        nkvh.reserve(windowSizeLayers.size());
+        for (auto const layer : windowSizeLayers)
+        {
+            nkvh.push_back(numKvHeadsPerLayer.at(layer));
+        }
         auto const sumLocalHeads = std::reduce(nkvh.cbegin(), nkvh.cend());
-        // NOTE: We expect the initialization of modelConfig to have already taken the tp size into account and do not
-        // address it here
+        // NOTE: We expect the caller to have already taken the tp size into account for numKvHeadsPerLayer
         // consider only local layers for the calculation
-        return sumLocalHeads * kvFactor * modelConfig.getSizePerHead();
+        return sumLocalHeads * kvFactor * sizePerHead;
     }
 
     /// @brief Groups model layers by their attention window size.
@@ -1703,21 +1864,24 @@ public:
     ///          of memory requirements. The weighting considers both the window size and the number of
     ///          layers using each window size, as well as the sum of cache sizes per token for each window.
     /// @param config KV cache configuration parameters
-    /// @param isCrossAttention Whether this is for cross-attention KV cache
     /// @param dtype Data type used for KV cache values
-    /// @param modelConfig Model configuration containing layer and head information
+    /// @param numKvHeadsPerLayer Number of KV heads for each local layer (caller selects self/cross attention heads)
+    /// @param sizePerHead Size of each attention head
+    /// @param tokensPerBlock Number of tokens per KV cache block
     /// @param worldConfig World configuration for multi-GPU setups
     /// @param windowSizeToLayers Map from attention window size to vector of layer indices using that window size
     /// @param allottedPrimaryMemBytes Allotted primary memory
     /// @param allottedSecondaryMemBytes Allotted secondary memory
     /// @param extraCostMemory Additional memory cost to account for CacheTransBufferManager::preAllocBufferSize
     /// @param kvFactor Factor for KV cache size calculation (typically 2 for key+value)
+    /// @param maxBatchSize Maximum batch size
     /// @return Map from window size to tuple of (primary blocks, secondary blocks)
     [[nodiscard]] static BlocksPerWindow calculateMaxNumBlocks(executor::KvCacheConfig const& config,
-        bool isCrossAttention, nvinfer1::DataType dtype, tensorrt_llm::runtime::ModelConfig const& modelConfig,
-        tensorrt_llm::runtime::WorldConfig const& worldConfig,
+        nvinfer1::DataType dtype, std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead,
+        SizeType32 tokensPerBlock, tensorrt_llm::runtime::WorldConfig const& worldConfig,
         std::map<SizeType32, std::vector<SizeType32>> const& windowSizeToLayers, uint64_t allottedPrimaryMemBytes,
-        uint64_t allottedSecondaryMemBytes, size_t extraCostMemory, SizeType32 kvFactor);
+        uint64_t allottedSecondaryMemBytes, size_t extraCostMemory, SizeType32 kvFactor, SizeType32 maxBatchSize,
+        std::optional<LinearAttentionMetadata> const& linearAttentionMetadata = std::nullopt);
 
     /// @brief Calculates the maximum batch size that can fit the kv-cache, given that all sequences in the batch have
     /// the provided input and output length.
@@ -1764,7 +1928,8 @@ public:
         bool copyOnpartialReuse = true,
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
-        SizeType32 indexerKCacheIndexHeadDim = 0);
+        SizeType32 indexerKCacheIndexHeadDim = 0,
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
 
     KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1777,7 +1942,8 @@ public:
         bool copyOnpartialReuse = true,
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
-        SizeType32 indexerKCacheIndexHeadDim = 0);
+        SizeType32 indexerKCacheIndexHeadDim = 0,
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1790,7 +1956,8 @@ public:
         bool copyOnpartialReuse = true,
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
-        SizeType32 indexerKCacheIndexHeadDim = 0);
+        SizeType32 indexerKCacheIndexHeadDim = 0,
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -1799,7 +1966,8 @@ public:
         SizeType32 sinkTokenLength, int64_t stream, SizeType32 maxSequenceLength, bool enableBlockReuse = false,
         bool onboardBlocks = true, CacheType cacheType = CacheType::kSELF, bool enablePartialReuse = true,
         bool copyOnpartialReuse = true, bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
-        SizeType32 indexerKCacheIndexHeadDim = 0);
+        SizeType32 indexerKCacheIndexHeadDim = 0,
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
 
     ~KVCacheManager() override = default;
 
@@ -1916,6 +2084,14 @@ public:
 
     /// @brief Increase size for request with requestId. Allocate new KV cache block(s) if needed.
     void addToken(LlmRequest::RequestIdType requestId) override;
+
+    /// @brief LlmRequest::getNumTokens is out of sync with GenerationRequest when overlap scheduler is enabled.
+    /// This function returns the correct number of tokens from GenerationRequest to keep the behavior consistent.
+    [[nodiscard]] SizeType32 getTokenCount(LlmRequest::RequestIdType requestId) const override;
+
+    //! \brief According to request's current position, copy data from the last full block to the next block (ignoring
+    //! the placeholder block). It should be called before every forward step, after adding new tokens.
+    void copyLinearAttentionBlock(LlmRequest const& llmRequest);
 
     /// @brief Add new request to the KV cache manager.
     /// @param inputLength Input length for which KV cache need to be allocated.
@@ -2062,6 +2238,11 @@ public:
     SizeType32 getPoolLayerIdx(SizeType32 layer_idx) const override
     {
         return mBlockManager.getPoolLayerIdx(layer_idx);
+    }
+
+    bool isPoolLayerFirst(SizeType32 layer_idx) const override
+    {
+        return mBlockManager.isPoolLayerFirst(layer_idx);
     }
 
     void syncTransferManagerWithBufferManager() override

--- a/cpp/include/tensorrt_llm/kernels/kvCacheIndex.h
+++ b/cpp/include/tensorrt_llm/kernels/kvCacheIndex.h
@@ -36,10 +36,15 @@ public:
     static constexpr UnderlyingType kSecondaryPoolFlag = static_cast<UnderlyingType>(1)
         << (8 * sizeof(UnderlyingType) - 1);
 
+    // The illegal value (INT32_MAX) ensures accidental use triggers an obvious OOB failure.
+    static constexpr UnderlyingType kInvalidPoolIndex = std::numeric_limits<UnderlyingType>::max();
+
+    static const KVCacheIndex nullIndex;
+
     explicit KVCacheIndex(UnderlyingType value, bool isSecondary = false)
         : value{isSecondary ? value | kSecondaryPoolFlag : value}
     {
-        TLLM_CHECK_DEBUG(value >= 0);
+        TLLM_CHECK_DEBUG(value >= 0 && this->value != kInvalidPoolIndex);
     }
 
     __host__ __device__ [[nodiscard]] UnderlyingType get() const
@@ -52,9 +57,21 @@ public:
         return (value & kSecondaryPoolFlag) == 0;
     }
 
+    [[nodiscard]] constexpr bool isNull() const
+    {
+        return value == kInvalidPoolIndex;
+    }
+
 private:
     UnderlyingType value;
+
+    constexpr KVCacheIndex()
+        : value{kInvalidPoolIndex}
+    {
+    }
 };
+
+constexpr KVCacheIndex KVCacheIndex::nullIndex{};
 
 } // namespace kernels
 

--- a/cpp/tensorrt_llm/batch_manager/evictionPolicy.cpp
+++ b/cpp/tensorrt_llm/batch_manager/evictionPolicy.cpp
@@ -28,23 +28,31 @@ namespace tensorrt_llm::batch_manager::eviction_policy
 
 auto const kMinPriority = executor::KvCacheRetentionConfig::kMinRetentionPriority;
 auto const kMaxPriority = executor::KvCacheRetentionConfig::kMaxRetentionPriority;
+auto const kNumPriorities = kMaxPriority - kMinPriority + 1;
 
 auto const kDefaultPriority = executor::KvCacheRetentionConfig::kDefaultRetentionPriority;
 executor::RetentionPriority const kDefaultSecondaryOffloadMinPriority = 30;
 
 int const kNumCacheLevels = 2;
+int const kPlaceholderLevel = kNumCacheLevels; // placeholder blocks live at level 2
 
 namespace
 {
 SizeType32 getCacheLevel(BlockPtr const& block)
 {
+    if (block->isPlaceholder())
+    {
+        return kPlaceholderLevel;
+    }
     return block->isPrimary() ? 0 : 1;
 }
 
-SizeType32 getPriorityIdx(executor::RetentionPriority priority)
+constexpr SizeType32 getPriorityIdx(executor::RetentionPriority priority)
 {
     return priority - kMinPriority;
 }
+
+constexpr auto defaultPriorityIdx = getPriorityIdx(kDefaultPriority);
 } // namespace
 
 void LRUEvictionPolicy::initialize(std::vector<BlockPtr>& mAllBlocksById, std::vector<SizeType32> sizes,
@@ -52,48 +60,74 @@ void LRUEvictionPolicy::initialize(std::vector<BlockPtr>& mAllBlocksById, std::v
 {
     SizeType32 startIdx = 0;
 
-    auto const defaultPriorityIdx = getPriorityIdx(kDefaultPriority);
+    // Create queues for all levels: primary, secondary, and placeholder (initially empty).
+    mFreeQueues.resize(kPlaceholderLevel + 1, std::vector<FreeBlocksQueue>(kNumPriorities));
+    mFreeBlockIterators.positive.resize(mAllBlocksById.size());
+    mNumFreeBlocksPerLevel.resize(kPlaceholderLevel + 1, 0);
 
-    // For each cache level, create a separate list of queues.
     for (SizeType32 cacheLevel = 0; cacheLevel < kNumCacheLevels; cacheLevel++)
     {
-        mFreeBlockIterators.reserve(mFreeBlockIterators.size() + sizes[cacheLevel]);
-        mFreeQueues.emplace_back(std::vector<FreeBlocksQueue>(kMaxPriority - kMinPriority + 1));
-
         auto& freeQueue = mFreeQueues[cacheLevel][defaultPriorityIdx];
 
         for (SizeType32 blockId = 0; blockId < sizes[cacheLevel]; blockId++)
         {
             // Initialize all blocks to be the default priority level
-            mFreeBlockIterators.emplace_back(freeQueue.insert(freeQueue.end(), mAllBlocksById[startIdx + blockId]));
+            mFreeBlockIterators[startIdx + blockId]
+                = freeQueue.insert(freeQueue.end(), mAllBlocksById[startIdx + blockId]);
         }
 
+        mNumFreeBlocksPerLevel[cacheLevel] = sizes[cacheLevel];
         startIdx += sizes[cacheLevel];
     }
-    mNumFreeBlocksPerLevel = sizes;
 
     mSecondaryOffloadMinPriority = secondaryOffloadMinPriority.value_or(kDefaultSecondaryOffloadMinPriority);
 }
 
+void LRUEvictionPolicy::initializePlaceholders(std::vector<BlockPtr>& allPlaceholderBlocksById)
+{
+    auto const len = static_cast<SizeType32>(allPlaceholderBlocksById.size());
+
+    // Placeholder IDs -2, -3, ... map to indices 2, 3, ... via abs(id).
+    // Indices 0 and 1 are unused (0 is invalid, 1 corresponds to kCachedBlocksRootId).
+    mFreeBlockIterators.negative.resize(len);
+
+    auto& freeQueue = mFreeQueues[kPlaceholderLevel][defaultPriorityIdx];
+
+    for (auto const& block : allPlaceholderBlocksById)
+    {
+        if (block)
+        {
+            mFreeBlockIterators[block->getBlockId()] = freeQueue.insert(freeQueue.end(), block);
+            mNumFreeBlocksPerLevel[kPlaceholderLevel]++;
+        }
+    }
+}
+
 bool LRUEvictionPolicy::verifyQueueIntegrity()
 {
+    static char const* const levelToStr[] = {"primary", "secondary", "placeholder"};
+    static const std::function<bool(BlockPtr const&)> levelValidators[]
+        = {[](BlockPtr const& block) { return block->isPrimary(); },
+            [](BlockPtr const& block) { return !block->isPrimary(); },
+            [](BlockPtr const& block) { return block->isPlaceholder(); }};
     bool queueCompromised = false;
-    for (SizeType32 cacheLevel = 0; cacheLevel < 2; cacheLevel++)
+    for (SizeType32 queueLevel = 0; queueLevel < kNumCacheLevels + 1; queueLevel++)
     {
-        for (SizeType32 level = 0; level < kMaxPriority - kMinPriority + 1; level++)
+        for (SizeType32 pri = 0; pri < kNumPriorities; pri++)
         {
-            for (auto const& block : mFreeQueues[cacheLevel][level])
+            for (auto const& block : mFreeQueues[queueLevel][pri])
             {
-                if ((cacheLevel == 0 && !block->isPrimary()) || (cacheLevel == 1 && block->isPrimary()))
+                bool const valid = levelValidators[queueLevel](block);
+                if (!valid)
                 {
-                    TLLM_LOG_WARNING("Found %s block (id %d) at cacheLevel %d",
-                        block->isPrimary() ? "primary" : "secondary", block->getBlockId(), cacheLevel);
+                    TLLM_LOG_WARNING("Block (id %d) has level=%s, but misplaced at queueLevel %s", block->getBlockId(),
+                        levelToStr[queueLevel], levelToStr[queueLevel]);
                     queueCompromised = true;
                 }
                 if (block->hasRefs())
                 {
-                    TLLM_LOG_WARNING(
-                        "Found block (id %d) with references at cacheLevel %d", block->getBlockId(), cacheLevel);
+                    TLLM_LOG_WARNING("Found block (id %d) with references at queueLevel %s", block->getBlockId(),
+                        levelToStr[queueLevel]);
                     queueCompromised = true;
                 }
             }
@@ -103,20 +137,24 @@ bool LRUEvictionPolicy::verifyQueueIntegrity()
     return !queueCompromised;
 }
 
-std::tuple<BlockPtr, bool> LRUEvictionPolicy::getFreeBlock(SizeType32 cacheLevel)
+std::tuple<BlockPtr, bool> LRUEvictionPolicy::getFreeBlock(SizeType32 cacheLevel, bool wantPlaceholder)
 {
-    for (SizeType32 level = 0; level < kMaxPriority - kMinPriority + 1; level++)
+    SizeType32 const level = wantPlaceholder ? kPlaceholderLevel : cacheLevel;
+
+    for (SizeType32 pri = 0; pri < kNumPriorities; pri++)
     {
         // Find the first non-empty queue, and return the first block.
-        if (!mFreeQueues[cacheLevel][level].empty())
+        if (!mFreeQueues[level][pri].empty())
         {
-            auto block = mFreeQueues[cacheLevel][level].front();
+            auto block = mFreeQueues[level][pri].front();
 
             // mFreeQueues only contains leaf blocks, so no need to iterate through the next block pointers.
             // It's possible to have a primary block with children in secondary memory. We handle this
             // by freeing all descendants in WindowBlockManager::getFreeBlock. This is done either by
             // offloading (preferred method) or explicitly.
-            return std::make_tuple(block, cacheLevel == 0 && level >= mSecondaryOffloadMinPriority);
+            bool const canOffload
+                = !wantPlaceholder && cacheLevel == 0 && pri >= getPriorityIdx(mSecondaryOffloadMinPriority);
+            return std::make_tuple(block, canOffload);
         }
     }
     TLLM_THROW("No free block found. This shouldn't happen!");
@@ -134,8 +172,6 @@ void LRUEvictionPolicy::releaseBlock(BlockPtr block, bool toFront)
     TLLM_CHECK_WITH_INFO(
         block->getBlockId() != tensorrt_llm::batch_manager::kv_cache_manager::KVCacheBlock::kCachedBlocksRootId,
         "Attempted to release the cached-blocks root into the eviction queue");
-    // Placeholder blocks have no physical GPU memory and must never enter the eviction queue.
-    TLLM_CHECK_WITH_INFO(!block->isPlaceholder(), "Attempted to release a placeholder block into the eviction queue");
     SizeType32 const cacheLevel = getCacheLevel(block);
     SizeType32 const id = block->getBlockId();
 
@@ -218,7 +254,7 @@ void LRUEvictionPolicy::refresh()
         {
             // This is already in another queue. Delete it, and bring it down to the default queue
             mFreeQueues[level][getPriorityIdx(block->getPriority())].erase(*mFreeBlockIterators[id]);
-            auto& q = mFreeQueues[level][getPriorityIdx(kDefaultPriority)];
+            auto& q = mFreeQueues[level][defaultPriorityIdx];
             mFreeBlockIterators[id] = q.insert(q.end(), block);
         }
         block->setPriority(kDefaultPriority);

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -38,6 +38,7 @@
 #include <limits>
 #include <map>
 #include <optional>
+#include <sstream>
 #include <utility>
 
 namespace tc = tensorrt_llm::common;
@@ -90,7 +91,7 @@ std::vector<BlockPtr> getAllSequenceBlocks(BlockPtr lastBlock)
 
 namespace tensorrt_llm::batch_manager::kv_cache_manager
 {
-KVCacheBlock::KVCacheBlock(IdType blockId, tk::KVCacheIndex blockIdx)
+KVCacheBlock::KVCacheBlock(IdType blockId, tk::KVCacheIndex blockIdx, SizeType32 windowSize)
     : mBlockId(blockId)
     , mMemoryPoolBlockIndex{blockIdx}
     , mRefCount(0)
@@ -108,13 +109,11 @@ KVCacheBlock::KVCacheBlock(IdType blockId, tk::KVCacheIndex blockIdx)
 {
 }
 
-BlockPtr KVCacheBlock::createPlaceholder(IdType blockId)
+BlockPtr KVCacheBlock::createPlaceholder(IdType blockId, SizeType32 windowSize)
 {
     // Use an out-of-range pool index as sentinel; the mIsPlaceholder flag gates
     // getCacheBlockIndices to return nil so this index is never submitted to the GPU.
-    // The illegal value (INT32_MAX) ensures accidental use triggers an obvious OOB failure.
-    static constexpr auto kInvalidPoolIndex = std::numeric_limits<tk::KVCacheIndex::UnderlyingType>::max();
-    auto block = std::make_shared<KVCacheBlock>(blockId, tk::KVCacheIndex{kInvalidPoolIndex});
+    auto block = std::make_shared<KVCacheBlock>(blockId, tk::KVCacheIndex::nullIndex, windowSize);
     block->mIsPlaceholder = true;
     return block;
 }
@@ -192,6 +191,8 @@ void KVCacheBlock::setAsRoot(radix_block_tree::LookupNodePtr rootNode, int windo
         static_cast<int>(mBlockId), windowSize, static_cast<int>(wasUpdated));
 }
 
+// This is a logical index. In memory pool, 1 in mMemoryPoolBlockIndex is strided by num_layers * kv_num. (see
+// WindowBlockManager::setOffsets)
 tk::KVCacheIndex::UnderlyingType KVCacheBlock::getMemoryPoolBlockIndex() const
 {
     return mMemoryPoolBlockIndex.get();
@@ -204,11 +205,13 @@ std::vector<MmKey> KVCacheBlock::getExtraKeys() const
 
 bool KVCacheBlock::isPrimary() const
 {
+    TLLM_CHECK_WITH_INFO(!isPlaceholder(), "Not expected to call isPrimary() on placeholder block");
     return mMemoryPoolBlockIndex.isPrimary();
 }
 
 void KVCacheBlock::swapMemoryPoolBlockOffset(std::shared_ptr<KVCacheBlock> otherBlock)
 {
+    TLLM_CHECK(!isPlaceholder() && !otherBlock->isPlaceholder());
     std::swap(mMemoryPoolBlockIndex, otherBlock->mMemoryPoolBlockIndex);
 }
 
@@ -464,9 +467,34 @@ void KVCacheBlock::detachDescendantsFromLookupTree()
     }
 }
 
+void KVCacheBlock::detachPreviousPlaceholdersFromLookupTree() const
+{
+    BlockPtr current = getPrevBlock();
+    while (current != nullptr && current->getBlockId() != KVCacheBlock::kCachedBlocksRootId)
+    {
+        if (!current->isPlaceholder())
+        {
+            return;
+        }
+        auto siblings = current->getNextBlocks();
+        for (auto const& [key, block] : siblings)
+        {
+            if (!block->isPlaceholder() && block.get() != this)
+            {
+                return;
+            }
+        }
+        BlockPtr prev = current->getPrevBlock();
+        current->detachFromLookupNode();
+        current->setPrevBlockInSeq(nullptr);
+        current = prev;
+    }
+}
+
 void KVCacheBlock::freeBlockAndAllDescendants()
 {
     detachDescendantsFromLookupTree();
+    detachPreviousPlaceholdersFromLookupTree();
     detachFromLookupNode();
 }
 
@@ -543,7 +571,7 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager,
     std::optional<BaseAgentConfig> agentConfig, bool enableIndexerKCache, SizeType32 indexerKCacheQuantBlockSize,
-    SizeType32 indexerKCacheIndexHeadDim)
+    SizeType32 indexerKCacheIndexHeadDim, std::optional<LinearAttentionMetadata> linearAttentionMetadata)
     : mNumLayers{static_cast<SizeType32>(numKvHeadsPerLayer.size())}
     , mTokensPerBlock{tokensPerBlock}
     , mEventManager{std::move(eventManager)}
@@ -552,7 +580,22 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
     , mIsEnableIndexerKCache{enableIndexerKCache}
     , mIndexerKCacheQuantBlockSize{indexerKCacheQuantBlockSize}
     , mIndexerKCacheIndexHeadDim{indexerKCacheIndexHeadDim}
+    , mLinearAttentionMetadata{linearAttentionMetadata}
 {
+    if (mLinearAttentionMetadata.has_value())
+    {
+        TLLM_CHECK_WITH_INFO(enablePartialReuse == false, "Partial reuse is not supported with linear attention");
+        if (mLinearAttentionMetadata->hasRecurrentStatesCache())
+        {
+            TLLM_CHECK(mLinearAttentionMetadata->statesSnapshotInterval % mTokensPerBlock == 0);
+            // Enforce that a full-attention window (windowSize == maxSequenceLength) must be present
+            // alongside kRecurrentStates.
+            TLLM_CHECK_WITH_INFO(blocksPerWindow.count(maxSequenceLength) > 0,
+                "kRecurrentStates window size requires a full-attention window size (== maxSequenceLength=%d) "
+                "to be present alongside it.",
+                maxSequenceLength);
+        }
+    }
     if (agentConfig.has_value())
         mLoopbackAgent = makeLoopbackAgent("nixl", &agentConfig.value());
     else
@@ -583,11 +626,34 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
         }
         auto const [allottedPrimaryBlocks, allottedSecondaryBlocks] = blocksPerWindow.at(windowSize);
         TLLM_CHECK(allottedPrimaryBlocks > 0); // You can't have a model with negative primary blocks...
-        mWindowBlockManagers.try_emplace(windowSize, dtype, windowSize, layersWithWindowSize, numKvHeadsPerLayer,
-            sizePerHead, tokensPerBlock, /*isSWA=*/windowSize < maxSequenceLength, allottedPrimaryBlocks,
+
+        // Compute numPlaceholderBlocks for kRecurrentStates managers: the difference between the
+        // full-attention manager's primary block count and this manager's primary block count.
+        SizeType32 numPlaceholderBlocks = 0;
+        if (LinearAttentionMetadata::hasRecurrentStatesCache(windowSize))
+        {
+            if (linearAttentionMetadata.has_value() && linearAttentionMetadata->numPlaceholderBlocks.has_value())
+            {
+                numPlaceholderBlocks = *linearAttentionMetadata->numPlaceholderBlocks;
+                TLLM_CHECK_WITH_INFO(numPlaceholderBlocks >= 0,
+                    "LinearAttentionMetadata::numPlaceholderBlocks must be >= 0, got %d", numPlaceholderBlocks);
+            }
+            else
+            {
+                auto const [fullPrimaryBlocks, unusedSecondaryBlocks] = blocksPerWindow.at(maxSequenceLength);
+                numPlaceholderBlocks
+                    = fullPrimaryBlocks; // The full attention runs out of blocks before we use all placeholders.
+            }
+        }
+
+        mWindowBlockManagers.try_emplace(SizeType32(windowSize), dtype, windowSize, layersWithWindowSize,
+            numKvHeadsPerLayer, sizePerHead, tokensPerBlock,
+            /*isSWA=*/(windowSize < maxSequenceLength) && (windowSize >= 0), allottedPrimaryBlocks,
             allottedSecondaryBlocks, maxNumSequences, stream, onboardBlocks, cacheType, secondaryOffloadMinPriority,
             mEventManager, enablePartialReuse, copyOnPartialReuse, kvCacheConnectorManager, mLookupTree, mLoopbackAgent,
-            enableIndexerKCache, indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim);
+            enableIndexerKCache, indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim,
+            LinearAttentionMetadata::hasLinearCache(windowSize) ? linearAttentionMetadata : std::nullopt,
+            numPlaceholderBlocks);
     }
 
     auto const numAllPools = getNumPools();
@@ -645,7 +711,8 @@ WindowBlockManager::WindowBlockManager(nvinfer1::DataType dtype, SizeType32 wind
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager,
     radix_block_tree::UnifiedBlockTree& lookupTree, std::shared_ptr<kvc::BaseLoopbackAgent> loopbackAgent,
-    bool enableIndexerKCache, SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim)
+    bool enableIndexerKCache, SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim,
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata, SizeType32 numPlaceholderBlocks)
     : mDataType{dtype}
     , mWindowSize{windowSize}
     , mNumPrimaryBlocks{blocksInPrimaryPool}
@@ -669,8 +736,11 @@ WindowBlockManager::WindowBlockManager(nvinfer1::DataType dtype, SizeType32 wind
     , mReusedBlocks{0}
     , mReusedUniqueBlocks{0}
     , mMissedBlocks{0}
-    , mKVFactor{mCacheType == CacheType::kSELFKONLY ? 1 : 2}
-    , mLogPrefix{tensorrt_llm::common::fmtstr("BlockManager[windowSize=%u]", mWindowSize)}
+    , mKVFactor{(mCacheType == CacheType::kSELFKONLY
+                    || (linearAttentionMetadata.has_value() && linearAttentionMetadata->hasRecurrentStatesCache()))
+              ? 1
+              : 2}
+    , mLogPrefix{tensorrt_llm::common::fmtstr("BlockManager[windowSize=%d]", mWindowSize)}
     , mReusedTokens{0.0}
     , mTotalInputTokens{0.0}
     , mEnablePartialReuse{enablePartialReuse}
@@ -679,7 +749,9 @@ WindowBlockManager::WindowBlockManager(nvinfer1::DataType dtype, SizeType32 wind
     , mEnableIndexerKCache{enableIndexerKCache}
     , mIndexerKCacheQuantBlockSize{indexerKCacheQuantBlockSize}
     , mIndexerKCacheIndexHeadDim{indexerKCacheIndexHeadDim}
+    , mLinearAttentionMetadata{std::move(linearAttentionMetadata)}
 {
+    TLLM_LOG_DEBUG("Creating WindowBlockManager for windowSize=%d", windowSize);
     std::map<SizeType32, SizeType32> numLayersPerPool;
 
     for (auto const layerIdx : managedLayers)
@@ -706,7 +778,19 @@ WindowBlockManager::WindowBlockManager(nvinfer1::DataType dtype, SizeType32 wind
                 mLayerToPoolIndex[layerIdx] = poolIndex;
             }
         }
-        mPools.emplace_back(numLayers, mKVFactor, numKvHeads, sizePerHead / numEltsPerContainer, tokensPerBlock);
+        if (isRecurrentState())
+        {
+            TLLM_CHECK(numLayersPerPool.size() == 1);
+            auto bytesPerElement = common::getDTypeSize(mDataType);
+            KVCacheBlockPool pool(numLayers, /*kvFactor=*/1, /*numKvHeads=*/-1,
+                /*sizePerHead=*/-1, tokensPerBlock);
+            pool.blockSize = mLinearAttentionMetadata->allRecurrentStatesBytes / bytesPerElement;
+            mPools.push_back(std::move(pool));
+        }
+        else
+        {
+            mPools.emplace_back(numLayers, mKVFactor, numKvHeads, sizePerHead / numEltsPerContainer, tokensPerBlock);
+        }
         ++poolIndex;
     }
 
@@ -739,9 +823,38 @@ WindowBlockManager::WindowBlockManager(nvinfer1::DataType dtype, SizeType32 wind
     }
     mAllocatedBlocksPerSeq.reserve(maxNumSequences);
 
-    mEvictionPolicy = std::make_shared<LRUEvictionPolicy>();
-    mEvictionPolicy->initialize(
-        mAllBlocksById, {blocksInPrimaryPool, blocksInSecondaryPool}, secondaryOffloadMinPriority);
+    // Pre-allocate placeholder blocks when this is a recurrent-state (linear attention) manager paired with
+    // a full-attention manager. Placeholder IDs start at -2 (since -1 is reserved for kCachedBlocksRootId).
+    // mAllPlaceholderBlocksById is indexed by abs(blockId): index 0 and 1 are unused (nullptr),
+    // index abs(blockId) holds the block with that negative blockId.
+    if (numPlaceholderBlocks > 0)
+    {
+        TLLM_LOG_DEBUG(
+            "%s::ctor - pre-allocating %d placeholder blocks with IDs in range [%d, %d] for recurrent-state manager",
+            mLogPrefix.c_str(), numPlaceholderBlocks, KVCacheBlock::kCachedBlocksRootId - 1 - numPlaceholderBlocks,
+            KVCacheBlock::kCachedBlocksRootId - 2);
+        TLLM_CHECK_WITH_INFO(isRecurrentState(),
+            "numPlaceholderBlocks > 0 is only supported for recurrent-state (kRecurrentStates) managers");
+        mAllPlaceholderBlocksById.resize(numPlaceholderBlocks + 2, nullptr);
+        for (SizeType32 i = 0; i < numPlaceholderBlocks; ++i)
+        {
+            KVCacheBlock::IdType const placeholderBlockId
+                = KVCacheBlock::kCachedBlocksRootId - 1 - static_cast<KVCacheBlock::IdType>(i);
+            auto block = KVCacheBlock::createPlaceholder(placeholderBlockId, windowSize);
+            mAllPlaceholderBlocksById[static_cast<size_t>(-placeholderBlockId)] = block;
+        }
+
+        auto policy = std::make_shared<LRUEvictionPolicy>();
+        policy->initialize(mAllBlocksById, {blocksInPrimaryPool, blocksInSecondaryPool}, secondaryOffloadMinPriority);
+        policy->initializePlaceholders(mAllPlaceholderBlocksById);
+        mEvictionPolicy = policy;
+    }
+    else
+    {
+        mEvictionPolicy = std::make_shared<LRUEvictionPolicy>();
+        mEvictionPolicy->initialize(
+            mAllBlocksById, {blocksInPrimaryPool, blocksInSecondaryPool}, secondaryOffloadMinPriority);
+    }
     if (mEventManager)
     {
         mEventManager->enqueueCreatedEvent({blocksInPrimaryPool, blocksInSecondaryPool}, mWindowSize);
@@ -783,6 +896,21 @@ bool WindowBlockManager::verifyQueueIntegrity()
     return mEvictionPolicy->verifyQueueIntegrity();
 }
 
+[[nodiscard]] BlockPtr WindowBlockManager::getBlockById(KVCacheBlock::IdType blockId) const
+{
+    if (blockId >= 0)
+    {
+        return mAllBlocksById.at(blockId);
+    }
+    // Negative blockIds are placeholder blocks. mAllPlaceholderBlocksById is indexed by abs(blockId).
+    auto const idx = static_cast<size_t>(-blockId);
+    if (idx >= mAllPlaceholderBlocksById.size() || blockId == KVCacheBlock::kCachedBlocksRootId)
+    {
+        return nullptr;
+    }
+    return mAllPlaceholderBlocksById[idx];
+}
+
 void BlockManager::storeContextBlocks(GenerationRequest& sequence, LlmRequest const& llmRequest)
 {
     constexpr int beamIdx = 0; // no need to consider more than one beam for input tokens
@@ -798,9 +926,12 @@ void BlockManager::storeContextBlocks(GenerationRequest& sequence, LlmRequest co
         auto const& uniqueTokens = llmRequest.getUniqueTokens(beamIdx);
         TLLM_LOG_DEBUG("storeContextBlocks for request %lu on window %d with %d unique tokens", llmRequest.mRequestId,
             windowSize, uniqueTokens.size());
+        // only store the tokens that have been completed
+        size_t const completedTokens = llmRequest.getContextCurrentPosition();
+        auto usableSize = std::min(completedTokens, uniqueTokens.size() - 1);
 
         auto blockedUniqueTokens
-            = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, uniqueTokens.size() - 1, getTokensPerBlock(), false);
+            = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, usableSize, getTokensPerBlock(), false);
         auto blockKeys = buildBlockKeys(blockedUniqueTokens, llmRequest);
         (void) manager.storeBlocks(std::move(blockKeys), cacheBlockIds[beamIdx]);
     }
@@ -883,21 +1014,25 @@ void WindowBlockManager::allocatePools(bool useUvm)
             poolDtype = nvinfer1::DataType::kUINT8;
         }
 
-        nvinfer1::Dims cacheShape;
-        cacheShape = ITensor::makeShape({mNumPrimaryBlocks, pool.numLayers, mKVFactor, blockSize});
+        nvinfer1::Dims cacheShape = isRecurrentState()
+            ? ITensor::makeShape({pool.numLayers, mNumPrimaryBlocks, mKVFactor, blockSize})
+            : ITensor::makeShape({mNumPrimaryBlocks, pool.numLayers, mKVFactor, blockSize});
+        pool.layerFirstLayout = isRecurrentState();
 
-        TLLM_LOG_DEBUG("[%s] Allocating primary pool with %d blocks for %d layers with %d kv heads", mLogPrefix.c_str(),
-            mNumPrimaryBlocks, pool.numLayers, pool.numKvHeads);
+        TLLM_LOG_DEBUG(
+            "[%s] Allocating primary pool with %d blocks for %d layers with %d kv heads, shape={%d, %d, %d, %d}%s",
+            mLogPrefix.c_str(), mNumPrimaryBlocks, pool.numLayers, pool.numKvHeads, cacheShape.d[0], cacheShape.d[1],
+            cacheShape.d[2], cacheShape.d[3], pool.layerFirstLayout ? " (layer-first)" : "");
 
         if (useUvm)
             pool.primaryPtr = BufferManager::managed(cacheShape, poolDtype);
         else
             pool.primaryPtr = mBufferManager.gpuSync(cacheShape, poolDtype);
-
         if (mNumSecondaryBlocks > 0)
         {
-            nvinfer1::Dims const cacheShapeOffload
-                = ITensor::makeShape({mNumSecondaryBlocks, pool.numLayers, mKVFactor, blockSize});
+            nvinfer1::Dims cacheShapeOffload = isRecurrentState()
+                ? ITensor::makeShape({pool.numLayers, mNumSecondaryBlocks, mKVFactor, blockSize})
+                : ITensor::makeShape({mNumSecondaryBlocks, pool.numLayers, mKVFactor, blockSize});
             TLLM_LOG_DEBUG("[%s] Allocating secondary pool with %d blocks for %d layers with %d kv heads",
                 mLogPrefix.c_str(), mNumSecondaryBlocks, pool.numLayers, pool.numKvHeads);
             pool.secondaryPtr = BufferManager::pinned(cacheShapeOffload, poolDtype);
@@ -971,10 +1106,10 @@ void WindowBlockManager::freeChildren(BlockPtr const& block)
 
 BlockPtr WindowBlockManager::getFreeBlock(GenerationRequest& sequence, executor::RetentionPriority priority,
     std::optional<std::chrono::milliseconds> durationMs, executor::KvCacheTransferMode mode,
-    std::string const& directory)
+    std::string const& directory, bool wantPlaceholder)
 {
     // eviction policy get free primary block
-    auto [block, canOffload] = mEvictionPolicy->getFreeBlock(kPrimaryLevel);
+    auto [block, canOffload] = mEvictionPolicy->getFreeBlock(kPrimaryLevel, wantPlaceholder);
     if (block->getUniqueTokens().empty())
     {
         ++mAllocNewBlocks;
@@ -985,8 +1120,8 @@ BlockPtr WindowBlockManager::getFreeBlock(GenerationRequest& sequence, executor:
     // 2. Eviction policy indicated block can be offloaded
     // 3. At least one free block in secondary memory
     // 4. Onboarding is enabled (allowing block to be brought back into primary)
-    if (!block->getUniqueTokens().empty() && canOffload && mEvictionPolicy->getNumFreeBlocks(kSecondaryLevel) > 0
-        && mOnboardBlocks)
+    if (!wantPlaceholder && !block->getUniqueTokens().empty() && canOffload
+        && mEvictionPolicy->getNumFreeBlocks(kSecondaryLevel) > 0 && mOnboardBlocks)
     {
         // Offload block in primary memory before repurposing
         auto offloadBlock = std::get<0>(mEvictionPolicy->getFreeBlock(kSecondaryLevel));
@@ -1050,7 +1185,7 @@ void WindowBlockManager::setOffsets(tk::KVCacheIndex* offsetsPtr, nvinfer1::Dims
     auto constexpr kIdx = 0;
     auto constexpr vIdx = 1;
 
-    auto const& block = mAllBlocksById[blockId];
+    auto const& block = getBlockById(blockId);
     for (SizeType32 poolIdx = 0; poolIdx < static_cast<SizeType32>(mPools.size()); poolIdx++)
     {
         auto const& pool = mPools.at(poolIdx);
@@ -1058,9 +1193,23 @@ void WindowBlockManager::setOffsets(tk::KVCacheIndex* offsetsPtr, nvinfer1::Dims
         {
             auto constexpr layerIdx = 0;
             auto const offsetIndex = tensorrt_llm::common::flat_index(offsetsShape.d, poolIdx, beamIdx, xIdx, blockIdx);
-            auto const fieldIdx = mCacheType == CacheType::kSELFKONLY ? 0 : xIdx;
-            auto const blockIndex = tk::KVCacheIndex{
-                common::flat_index3(block->getMemoryPoolBlockIndex(), layerIdx, fieldIdx, pool.numLayers, mKVFactor)};
+            auto const fieldIdx = (mCacheType == CacheType::kSELFKONLY || isRecurrentState()) ? 0 : xIdx;
+            auto const blockIndex = [&]() -> tk::KVCacheIndex
+            {
+                if (block->isPlaceholder())
+                {
+                    return tk::KVCacheIndex::nullIndex;
+                }
+                if (pool.layerFirstLayout)
+                {
+                    // Layer-first layout: {numLayers, numBlocks, kvFactor, blockSize}
+                    // Flat index: layerIdx * numBlocks * kvFactor + blockIdx * kvFactor + fieldIdx
+                    return tk::KVCacheIndex{common::flat_index3(
+                        layerIdx, block->getMemoryPoolBlockIndex(), fieldIdx, mNumPrimaryBlocks, mKVFactor)};
+                }
+                return tk::KVCacheIndex{common::flat_index3(
+                    block->getMemoryPoolBlockIndex(), layerIdx, fieldIdx, pool.numLayers, mKVFactor)};
+            }();
             offsetsPtr[offsetIndex] = blockIndex;
         }
     }
@@ -1081,7 +1230,7 @@ void BlockManager::onboardBlock(GenerationRequest& sequence, BlockPtr const& off
 void WindowBlockManager::onboardBlock(GenerationRequest& sequence, BlockPtr const& offloadBlock,
     executor::KvCacheTransferMode mode, std::string const& directory)
 {
-    if (mOnboardBlocks && !offloadBlock->isPrimary())
+    if (mOnboardBlocks && !offloadBlock->isPlaceholder() && !offloadBlock->isPrimary())
     {
         auto block = getFreeBlock(
             sequence, executor::KvCacheRetentionConfig::kDefaultRetentionPriority, std::nullopt, mode, directory);
@@ -1115,7 +1264,7 @@ void WindowBlockManager::offloadBlock(
     // block is useful or not and may just lead to more traffic instead.
     // The ideal way of this is to dedicate the offloading of the block
     // to the eviction policy.
-    if (mOnboardBlocks && block->isPrimary())
+    if (mOnboardBlocks && !block->isPlaceholder() && block->isPrimary())
     {
         // Offload block in primary memory before repurposing
         auto offloadBlock = std::get<0>(mEvictionPolicy->getFreeBlock(kSecondaryLevel));
@@ -1253,29 +1402,40 @@ std::shared_ptr<KVCacheBlock> WindowBlockManager::findBlocksInReuseTreeByBlockKe
 }
 
 SizeType32 WindowBlockManager::loadOrAllocateBlocks(std::vector<BlockKey> const& blockKeys, SizeType32 numContextBlocks,
-    GenerationRequest& sequence, std::vector<executor::RetentionPriorityAndDuration> const& perBlockRetentions,
+    GenerationRequest& sequence, LlmRequest& llmRequest,
+    std::vector<executor::RetentionPriorityAndDuration> const& perBlockRetentions, bool shareLastContextBlockAmongBeams,
     executor::KvCacheTransferMode mode, std::string const& directory)
 {
     std::lock_guard<std::mutex> lock(mCachedBlocksRootMutex);
     SizeType32 numMatchedTokens{0};
+    SizeType32 latestMatchingNonPlaceholderBlockIdx{-1};
     auto searchRoot = mCachedBlocksRoot;
+    std::set<KVCacheBlock::IdType> reusedBlockIds;
 
     // The last block cannot be shared between beams because it will be written to.
     // Make sure a unique block is allocated per beam.
     auto const beamWidth = sequence.getBeamWidth();
-    SizeType32 numSharedContextBlocks = beamWidth > 1 ? numContextBlocks - 1 : numContextBlocks;
+    SizeType32 numSharedContextBlocks = shareLastContextBlockAmongBeams ? numContextBlocks : numContextBlocks - 1;
 
     auto blockItr = blockKeys.begin();
     for (int bi = 0; bi < numSharedContextBlocks; ++bi)
     {
-        auto [partialMatch, numMatched, matchingBlock] = searchRoot != nullptr && blockItr != blockKeys.end()
+        auto [partialMatch, numMatched, matchingBlock] = (searchRoot != nullptr && blockItr != blockKeys.end())
             ? searchRoot->findMatchingBlock(*blockItr, mEnablePartialReuse, mCopyOnPartialReuse)
             : std::make_tuple(false, 0, nullptr);
+        if (isRecurrentState())
+        {
+            TLLM_CHECK(partialMatch == false);
+        }
         if (matchingBlock != nullptr && numMatchedTokens + numMatched <= sequence.getCurrentPrepopulatedPromptLen())
         {
             KVCacheBlock::IdType matchingBlockId = matchingBlock->getBlockId();
 
             numMatchedTokens += numMatched > 0 ? numMatched : blockItr->uniqueTokens.size();
+            if (!matchingBlock->isPlaceholder())
+            {
+                latestMatchingNonPlaceholderBlockIdx = bi;
+            }
             if (perBlockRetentions[bi].retentionPriority.has_value()
                 && matchingBlock->getPriority() != perBlockRetentions[bi].retentionPriority && mEventManager)
             {
@@ -1316,34 +1476,51 @@ SizeType32 WindowBlockManager::loadOrAllocateBlocks(std::vector<BlockKey> const&
             }
             else
             {
+                searchRoot = matchingBlock;
                 // Recover block and reuse
                 mEvictionPolicy->claimBlock(
                     matchingBlock, perBlockRetentions[bi].retentionPriority, perBlockRetentions[bi].durationMs);
                 TLLM_LOG_DEBUG("%s::loadOrAllocateBlocks for request %lu - Matched full block %d", mLogPrefix.c_str(),
                     sequence.getRequestId(), matchingBlockId);
-                searchRoot = matchingBlock;
             }
             onboardBlock(sequence, matchingBlock, mode, directory);
             addBlockToAllBeams(matchingBlock, sequence);
-            // TODO: only add once for reused blocks
-            ++mReusedBlocks;
-            if (!mReusedBlockIds.count(matchingBlockId))
+            if (!matchingBlock->isPlaceholder())
             {
-                mReusedBlockIds.insert(matchingBlockId);
-                ++mReusedUniqueBlocks;
+                // TODO: only add once for reused blocks
+                ++mReusedBlocks;
+                if (!reusedBlockIds.count(matchingBlockId))
+                {
+                    reusedBlockIds.insert(matchingBlockId);
+                    ++mReusedUniqueBlocks;
+                }
             }
             ++blockItr;
         }
         else // matchingBlock == nullptr || numMatchedTokens + numMatched > sequence.getCurrentPrepopulatedPromptLen()
         {
+            BlockPtr freeBlock;
+            bool shouldAllocate = true;
+            if (isRecurrentState())
+            {
+                // loadOrAllocateBlocks is only called by addSequence, which ensures it's the first chunk, so the token
+                // num always starts from 0.
+                shouldAllocate = mLinearAttentionMetadata->shouldAllocateRecurrentStates(
+                    /*currentBlockEndTokenIdx=*/(bi + 1) * mTokensPerBlock, llmRequest.getPromptLen(), mTokensPerBlock);
+                TLLM_LOG_DEBUG(
+                    "%s::loadOrAllocateBlocks - Recurrent state block %d. shouldAllocate=%d for sequence %lu",
+                    mLogPrefix.c_str(), bi, shouldAllocate, sequence.getRequestId());
+            }
+
             // If we haven't set a priority, set it to the default priority level (low)
-            auto freeBlock = getFreeBlock(sequence,
+            freeBlock = getFreeBlock(sequence,
                 perBlockRetentions[bi].retentionPriority.value_or(
                     executor::KvCacheRetentionConfig::kDefaultRetentionPriority),
-                perBlockRetentions[bi].durationMs, mode, directory);
+                perBlockRetentions[bi].durationMs, mode, directory, /*wantPlaceholder=*/!shouldAllocate);
             addBlockToAllBeams(freeBlock, sequence);
             TLLM_LOG_DEBUG("%s::loadOrAllocateBlocks - No match, allocated new block %d for sequence %lu",
                 mLogPrefix.c_str(), freeBlock->getBlockId(), sequence.getRequestId());
+            // allBlockStats.emplace_back(freeBlock, "N");
             searchRoot = nullptr; // no matching needed for following blocks
             if (blockItr != blockKeys.end())
             {
@@ -1386,7 +1563,13 @@ SizeType32 WindowBlockManager::loadOrAllocateBlocks(std::vector<BlockKey> const&
         }
     }
 
-    return numMatchedTokens;
+    if (isRecurrentState())
+    {
+        // purge tailing placeholder blocks
+        numMatchedTokens = (latestMatchingNonPlaceholderBlockIdx + 1) * mTokensPerBlock;
+    }
+    sequence.setCurrentPrepopulatedPromptLen(numMatchedTokens);
+    return sequence.getCurrentPrepopulatedPromptLen();
 }
 
 void BlockManager::syncTransferManagerWithBufferManager()
@@ -1430,6 +1613,8 @@ SizeType32 BlockManager::addSequence(GenerationRequest& sequence, SizeType32 inp
 SizeType32 WindowBlockManager::addSequence(
     GenerationRequest& sequence, SizeType32 inputLength, SizeType32 numContextBlocks, LlmRequest& llmRequest)
 {
+    TLLM_CHECK_WITH_INFO(!(isRecurrentState()) || inputLength == llmRequest.getPromptLen(),
+        "Recurrent state does not support CP or truncation yet.");
     auto const requestId = sequence.getRequestId();
     auto const [seqIt, emplaceDone] = mAllocatedBlocksPerSeq.emplace(requestId, std::vector<BlockPtr>{});
     TLLM_CHECK(emplaceDone);
@@ -1466,8 +1651,13 @@ SizeType32 WindowBlockManager::addSequence(
 
     TLLM_CHECK(perBlockRetentions.size() == (size_t) numContextBlocks);
 
-    auto const prepopulatedPromptLen
-        = loadOrAllocateBlocks(blockKeys, numContextBlocks, sequence, perBlockRetentions, mode, directory);
+    bool shareLastContextBlockAmongBeams = sequence.getBeamWidth() == 1;
+    if (isRecurrentState())
+    {
+        shareLastContextBlockAmongBeams |= inputLength % mTokensPerBlock == 0;
+    }
+    auto const prepopulatedPromptLen = loadOrAllocateBlocks(blockKeys, numContextBlocks, sequence, llmRequest,
+        perBlockRetentions, shareLastContextBlockAmongBeams, mode, directory);
     mReusedTokens += static_cast<double>(prepopulatedPromptLen);
     mTotalInputTokens += static_cast<double>(uniqueTokens.size());
 
@@ -1499,12 +1689,12 @@ void BlockManager::adjustBlocksIfNeeded(GenerationRequest& sequence)
 void WindowBlockManager::adjustBlocksIfNeeded(GenerationRequest& sequence)
 {
     auto const minTokensForBlockDetach = mWindowSize + mTokensPerBlock;
-    while (
-        sequence.getNumTokens() - sequence.getNumFrontBlocksRemoved() * getTokensPerBlock() >= minTokensForBlockDetach)
+    while (mIsSWA && // A block only go out-of-window in SWA
+        (sequence.getNumTokens() - sequence.getNumFrontBlocksRemoved() * getTokensPerBlock()
+            >= minTokensForBlockDetach))
     {
         // Detaching block for SWA is non-trivial due to the radix tree structure.
         // For now, when reuse is enabled, we do not detach blocks for SWA.
-        TLLM_CHECK_WITH_INFO(mIsSWA, "A block only go out-of-window in SWA");
         detachFrontBlock(sequence);
     }
 
@@ -1548,7 +1738,7 @@ void WindowBlockManager::addSequence(
     allocateBlock(sequence, /*shareAmongBeams=*/isShareLastContextBlock);
 }
 
-void WindowBlockManager::addBlockToBeam(BlockPtr& block, GenerationRequest& sequence, SizeType32 beamIdx)
+void WindowBlockManager::addBlockToBeam(BlockPtr const& block, GenerationRequest& sequence, SizeType32 beamIdx)
 {
     auto const requestId = sequence.getRequestId();
     block->incRefCount();
@@ -1558,13 +1748,14 @@ void WindowBlockManager::addBlockToBeam(BlockPtr& block, GenerationRequest& sequ
     }
     else
     {
-        block->setPrevBlockInSeq(mAllBlocksById.at(sequence.getCacheBlockIds(mWindowSize)[beamIdx].back()));
+        block->setPrevBlockInSeq(mAllocatedBlocksPerSeq.at(requestId).at(
+            (sequence.getCacheBlockIds(mWindowSize)[beamIdx].size() - 1) * sequence.getBeamWidth() + beamIdx));
     }
     sequence.addCacheBlock(mWindowSize, beamIdx, block->getBlockId());
     mAllocatedBlocksPerSeq.at(requestId).push_back(block);
 }
 
-void WindowBlockManager::addBlockToAllBeams(BlockPtr& block, GenerationRequest& sequence)
+void WindowBlockManager::addBlockToAllBeams(BlockPtr const& block, GenerationRequest& sequence)
 {
     auto const beamWidth = sequence.getBeamWidth();
 
@@ -1579,12 +1770,124 @@ void BlockManager::allocateBlock(GenerationRequest& sequence, SizeType32 windowS
     mWindowBlockManagers.at(windowSize).allocateBlock(sequence, false);
 }
 
+void BlockManager::copyLinearAttentionBlock(GenerationRequest& sequence, LlmRequest const& llmRequest)
+{
+    for (auto& [windowSize, manager] : mWindowBlockManagers)
+    {
+        manager.copyLinearAttentionBlock(sequence, llmRequest);
+    }
+}
+
+bool WindowBlockManager::tryAllocatePlaceholderForLinearAttention(GenerationRequest& sequence, bool shareAmongBeams)
+{
+    auto const beamWidth = sequence.getBeamWidth();
+    auto const newBlockIdx = sequence.getCacheBlockIds(mWindowSize).at(0).size();
+    // The first block is not a placeholder.
+    if (newBlockIdx == 0)
+    {
+        return false;
+    }
+
+    // If the last block is saved in lookup tree for reuse, we keep it.
+    // A case is that the context seqlen is a multiple of tokens per block, and reuse is enabled.
+    int lastBlockId = sequence.getCacheBlockIds(mWindowSize).at(0).back();
+    if (getBlockById(lastBlockId)->getLookupNode() != nullptr && mLinearAttentionMetadata->saveLastSnapshot)
+    {
+        TLLM_LOG_DEBUG(
+            "tryAllocatePlaceholderForLinearAttention: corner case to allocate block at generation phase, "
+            "lastBlockId=%d, requestId=%lu, numTokens=%d",
+            lastBlockId, sequence.getRequestId(), sequence.getNumTokens());
+        return false;
+    }
+
+    bool isLastBlockSharedAmongBeams = true;
+    for (auto beamIdx = 0; beamIdx < beamWidth; ++beamIdx)
+    {
+        if (lastBlockId != sequence.getCacheBlockIds(mWindowSize).at(beamIdx).back())
+        {
+            isLastBlockSharedAmongBeams = false;
+            break;
+        }
+    }
+
+    bool beamWidthChanged = (beamWidth != 1) && (isLastBlockSharedAmongBeams != shareAmongBeams);
+
+    // The last block of sequence keeps the memory of recurrent states.
+    // When extending the block chain, we insert a placeholder block prior to the last block.
+    auto placeholder = getFreeBlock(sequence, executor::KvCacheRetentionConfig::kDefaultRetentionPriority, std::nullopt,
+        sequence.getTransferMode(), sequence.getDirectory(), /*wantPlaceholder=*/true);
+    TLLM_LOG_DEBUG("%s::allocateBlock - Inserting placeholder block %d before last block for sequence %lu",
+        mLogPrefix.c_str(), placeholder->getBlockId(), sequence.getRequestId());
+    auto& sequenceBlocks = mAllocatedBlocksPerSeq.at(sequence.getRequestId());
+    int numBlocksPerBeam = sequence.getCacheBlockIds(mWindowSize).at(0).size();
+    std::vector<KVCacheBlock::IdType> lastBlockIds(beamWidth);
+    for (auto beamIdx = 0; beamIdx < beamWidth; ++beamIdx)
+    {
+        lastBlockIds[beamIdx] = sequence.getCacheBlockIds(mWindowSize).at(beamIdx).back();
+        if (beamWidthChanged)
+        {
+            TLLM_CHECK(lastBlockIds[beamIdx] == lastBlockIds[0]);
+        }
+    }
+    // pop last block from all beams
+    sequence.removeLastBlock(mWindowSize);
+    sequenceBlocks.erase(sequenceBlocks.begin() + (numBlocksPerBeam - 1) * beamWidth, sequenceBlocks.end());
+    for (auto beamIdx = 0; beamIdx < beamWidth; ++beamIdx)
+    {
+        auto lastBlockId = lastBlockIds[beamIdx];
+        TLLM_CHECK(lastBlockId >= 0);
+        TLLM_LOG_DEBUG("%s::allocateBlock - Swapping placeholder with last block %d for beam %d", mLogPrefix.c_str(),
+            lastBlockId, beamIdx);
+        auto lastBlock = getBlockById(lastBlockId);
+        TLLM_CHECK(lastBlockId == lastBlock->getBlockId());
+
+        // swap block keys between placeholder and lastBlock
+        auto tmp = placeholder->getBlockKey();
+        placeholder->setBlockKey(lastBlock->getBlockKey(), lastBlock->isFull());
+        lastBlock->setBlockKey(tmp, placeholder->isFull());
+
+        // insert placeholder and lastBlock in reverse order
+        addBlockToBeam(placeholder, sequence, beamIdx);
+
+        // refresh hash values
+        placeholder->setHash();
+        lastBlock->setHash();
+
+        // balance ref count
+        lastBlock->decRefCount();
+    }
+
+    for (auto beamIdx = 0; beamIdx < beamWidth; ++beamIdx)
+    {
+        auto block = (beamWidthChanged && beamIdx > 0) ? getFreeBlock(sequence, sequence.getDecodeRetentionPriority(),
+                         sequence.getDecodeDurationMs(), sequence.getTransferMode(), sequence.getDirectory())
+                                                       : getBlockById(lastBlockIds[beamIdx]);
+        addBlockToBeam(block, sequence, beamIdx);
+    }
+    return true;
+}
+
 void WindowBlockManager::allocateBlock(GenerationRequest& sequence, bool shareAmongBeams)
 {
     auto const beamWidth = sequence.getBeamWidth();
     auto const requiredBlocks = shareAmongBeams ? 1 : beamWidth;
 
-    TLLM_CHECK_WITH_INFO(hasFreeBlocks(requiredBlocks), "Can't allocate new blocks. No free blocks left.");
+    if (LinearAttentionMetadata::hasRecurrentStatesCache(mWindowSize))
+    {
+        // allocateBlock is called in:
+        // 1. decoding phase when block boundary is reached
+        // 2. context phase when reuse is disabled
+        // In both cases, we don't need to consider about reusing.
+        if (tryAllocatePlaceholderForLinearAttention(sequence, shareAmongBeams))
+        {
+            TLLM_LOG_DEBUG("%s::allocateBlock - Allocated placeholder block for linear attention", mLogPrefix.c_str());
+            return;
+        }
+        TLLM_LOG_DEBUG("%s::allocateBlock - Should allocate new block for linear attention", mLogPrefix.c_str());
+    }
+
+    TLLM_CHECK_WITH_INFO(hasFreeBlocks(requiredBlocks),
+        "Can't allocate new blocks for window size %d. No free blocks left.", mWindowSize);
 
     if (shareAmongBeams)
     {
@@ -1608,6 +1911,101 @@ void WindowBlockManager::allocateBlock(GenerationRequest& sequence, bool shareAm
     }
 }
 
+void WindowBlockManager::copyLinearAttentionBlock(GenerationRequest& sequence, LlmRequest const& request)
+{
+    if (!isRecurrentState())
+    {
+        return;
+    }
+
+    auto const requestId = request.mRequestId;
+
+    // Check if this sequence exists
+    if (mAllocatedBlocksPerSeq.find(requestId) == mAllocatedBlocksPerSeq.end())
+    {
+        TLLM_LOG_WARNING("%s::copyLinearAttentionBlock - Request %lu not found", mLogPrefix.c_str(), requestId);
+        return;
+    }
+
+    // It points to the next token to be processed/generated
+    auto currentPosition
+        = request.isContextFinished() ? (request.getNumTokens(0)) : request.getContextCurrentPosition();
+    TLLM_LOG_DEBUG("%s::copyLinearAttentionBlock - Request %lu, currentPosition %d", mLogPrefix.c_str(), requestId,
+        currentPosition);
+
+    // edge case: promptLen % tokensPerBlock == 0, and this is the first token of decoding phase
+    if (currentPosition == request.getPromptLen() + 1 && request.getPromptLen() % mTokensPerBlock == 0)
+    {
+        if (TLLM_LIKELY(sequence.getBeamWidth() == 1))
+        {
+            // the block of beam0 is inherited from context phase, no need to copy
+            return;
+        }
+        // copy beam 0 to other beams
+        auto beam0Block = getBlockById(sequence.getCacheBlockIds(mWindowSize).at(0).back());
+        for (auto beamIdx = 1; beamIdx < sequence.getBeamWidth(); ++beamIdx)
+        {
+            auto beamBlockId = sequence.getCacheBlockIds(mWindowSize).at(beamIdx).back();
+            auto beamBlock = getBlockById(beamBlockId);
+            TLLM_LOG_DEBUG("%s::copyLinearAttentionBlock - Onboarding request %lu, block %d to %d", mLogPrefix.c_str(),
+                requestId, beam0Block->getBlockId(), beamBlock->getBlockId());
+            mTransferManager->onboard(beam0Block, beamBlock, mPools,
+                mTokensPerBlock, // Size of each current state block is fixed. Passing TokensPerBlock to tell the
+                                 // transfer manager to copy the entire block.
+                sequence.getTransferMode(), sequence.getDirectory());
+        }
+        return;
+    }
+
+    // copy only happens in context phase or the corner case above
+    if (currentPosition % mTokensPerBlock != 0 || currentPosition > request.getPromptLen() || currentPosition == 0)
+    {
+        return;
+    }
+
+    auto prevBlockIndex = currentPosition / mTokensPerBlock - 1; // signed
+    std::set<std::pair<KVCacheBlock::IdType, KVCacheBlock::IdType>> onboardedBlocks;
+    for (auto beamIdx = 0; beamIdx < sequence.getBeamWidth(); ++beamIdx)
+    {
+        auto const& beamBlockIds = sequence.getCacheBlockIds(mWindowSize).at(beamIdx);
+        auto prevBlockId = beamBlockIds.at(prevBlockIndex);
+        auto prevBlock = getBlockById(prevBlockId);
+        if (prevBlock->isPlaceholder())
+        {
+            TLLM_LOG_DEBUG(
+                "%s::copyLinearAttentionBlock - Previous block %d is a placeholder, skip. This usually happens when "
+                "chunked context is enabled but reusing is disabled.",
+                mLogPrefix.c_str(), prevBlockId);
+            continue;
+        }
+        auto nextBlockIndex = prevBlockIndex + 1;
+        KVCacheBlock::IdType nextBlockId = -1;
+        BlockPtr nextBlock = nullptr;
+        while (nextBlockIndex < static_cast<int>(beamBlockIds.size()))
+        {
+            nextBlockId = beamBlockIds.at(nextBlockIndex);
+            nextBlock = getBlockById(nextBlockId);
+            if (nextBlock != nullptr && !nextBlock->isPlaceholder())
+            {
+                break;
+            }
+            nextBlockIndex++;
+        }
+        TLLM_CHECK(nextBlockId != -1);
+        if (onboardedBlocks.find({prevBlockId, nextBlockId}) != onboardedBlocks.end())
+        {
+            continue;
+        }
+        TLLM_LOG_DEBUG("%s::copyLinearAttentionBlock - Onboarding request %lu, block %d to %d", mLogPrefix.c_str(),
+            requestId, prevBlock->getBlockId(), nextBlock->getBlockId());
+        mTransferManager->onboard(prevBlock, nextBlock, mPools,
+            mTokensPerBlock, // Size of each current state block is fixed. Passing TokensPerBlock to tell the transfer
+                             // manager to copy the entire block.
+            sequence.getTransferMode(), sequence.getDirectory());
+        onboardedBlocks.insert({prevBlockId, nextBlockId});
+    }
+}
+
 std::pair<SizeType32, std::vector<KVCacheBlock::IdType>> WindowBlockManager::storeBlocks(
     std::vector<BlockKey> const& blockKeys, std::vector<KVCacheBlock::IdType> const& blockIds, bool pinBlocks)
 {
@@ -1622,6 +2020,10 @@ std::pair<SizeType32, std::vector<KVCacheBlock::IdType>> WindowBlockManager::sto
     // There is no guarantee that these vectors will be the same length.
     // Only iterate as long as we have valid blockKey and blockId.
     auto numBlocks = std::min(blockKeys.size(), blockIds.size());
+    while (numBlocks > 0 && blockIds[numBlocks - 1] < 0)
+    {
+        numBlocks--;
+    }
     std::vector<BlockPtr> storedBlocks;
     std::vector<KVCacheBlock::IdType> pinnedBlockIds;
     for (std::size_t blockCnt = 0; blockCnt < numBlocks; ++blockCnt)
@@ -1633,7 +2035,7 @@ std::pair<SizeType32, std::vector<KVCacheBlock::IdType>> WindowBlockManager::sto
             TLLM_LOG_DEBUG("%s::storeBlocks - Searching match for block %d", mLogPrefix.c_str(), bid);
             // We set blockId to an invalid value to indicate that a block has been released early for a limited
             // attention layer. Make sure we don't store an invalid block because of this.
-            auto& block = mAllBlocksById.at(bid);
+            auto block = getBlockById(bid);
             // Protect against blockKeys being shorter than blockIds.
             auto const& blockKey = blockKeys.at(blockCnt);
 
@@ -1660,7 +2062,6 @@ std::pair<SizeType32, std::vector<KVCacheBlock::IdType>> WindowBlockManager::sto
                     mLogPrefix.c_str(), block->getBlockId());
                 TLLM_CHECK_WITH_INFO(block->getBlockId() == bid,
                     "Block id mismatch " + std::to_string(block->getBlockId()) + " != " + std::to_string(bid));
-                needMatch = false; // no matching needed for following blocks
 
                 if (block->getPrevBlock() != nullptr)
                 {
@@ -1672,7 +2073,6 @@ std::pair<SizeType32, std::vector<KVCacheBlock::IdType>> WindowBlockManager::sto
 
                 // Sanity check. The list of stored blocks should be connected.
                 TLLM_CHECK(storedBlocks.empty() || block->getPrevBlock() == storedBlocks.back());
-
                 storedBlocks.push_back(block);
                 TLLM_CHECK(block->getPrevBlockInSeq() == nullptr
                     || block->getPrevBlockInSeq()->getHash() == searchRoot->getHash());
@@ -1685,6 +2085,7 @@ std::pair<SizeType32, std::vector<KVCacheBlock::IdType>> WindowBlockManager::sto
                 }
                 searchRoot = block;
                 numBlocksStoredForReuse++;
+                needMatch = false; // no matching needed for following blocks
             }
             if (pinBlocks)
             {
@@ -1757,7 +2158,7 @@ void WindowBlockManager::replaceSharedBlock(GenerationRequest& sequence, SizeTyp
         }
         else
         {
-            block->setPrevBlockInSeq(mAllBlocksById.at(sequence.getCacheBlockIds(mWindowSize)[beamIdx].back()));
+            block->setPrevBlockInSeq(getBlockById(sequence.getCacheBlockIds(mWindowSize)[beamIdx].back()));
         }
         block->setBlockKey(blockKey, isFull);
         block->setHash();
@@ -1832,7 +2233,8 @@ std::optional<KVCacheBlock::IdType> BlockManager::releaseBlocks(
     for (auto& [_, manager] : mWindowBlockManagers)
     {
         if (!llmRequest.has_value() || llmRequest->isDummyRequest() || sequence.getBeamWidth() > 1
-            || !isAllWindowSizesValidForStoreForReuse)
+            || !isAllWindowSizesValidForStoreForReuse || mLinearAttentionMetadata.has_value()
+            /* Hybrid model we only store context blocks for reuse*/)
         {
             lastStoredId = manager.releaseBlocks(sequence, std::nullopt);
         }
@@ -1896,6 +2298,7 @@ void WindowBlockManager::unpinBlocksById(std::vector<KVCacheBlock::IdType> const
     }
 }
 
+// Only in TRT path
 void BlockManager::storeNewBlock(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest)
 {
     for (auto& [_, manager] : mWindowBlockManagers)
@@ -1966,11 +2369,16 @@ std::vector<KVCacheBlock::IdType> WindowBlockManager::storeBlocksForReuse(
     auto constexpr beamIdx = 0;
     auto const& uniqueTokens = llmRequest->getUniqueTokens(beamIdx);
     auto const& cacheBlockIds = sequence.getCacheBlockIds(mWindowSize);
-
     // TODO: get the caller to mark tokens as filled / not filled, so that the kv-cache manager doesn't
     // have to guess. Only (length - 1) tokens of the sequence have their kv-state recorded in kv-cache. We assume
     // the last token's state is not filled yet.
-    auto const usableSize = static_cast<runtime::SizeType32>(uniqueTokens.size()) - 1;
+    auto usableSize = static_cast<runtime::SizeType32>(uniqueTokens.size()) - 1;
+    if (isRecurrentState())
+    {
+        usableSize = std::min(llmRequest->getPromptLen() - 1, usableSize); // TODO: enable store for completed sequences
+    }
+    TLLM_LOG_DEBUG("%s::storeBlocksForReuse: req=%lu, windowSize=%d, uniqueTokens.size()=%zu, usableSize=%zu",
+        mLogPrefix.c_str(), llmRequest->mRequestId, mWindowSize, uniqueTokens.size(), usableSize);
     auto blockedUniqueTokens = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, usableSize, mTokensPerBlock, true);
     auto blockKeys = buildBlockKeys(blockedUniqueTokens, *llmRequest);
 
@@ -1983,11 +2391,13 @@ std::optional<KVCacheBlock::IdType> WindowBlockManager::releaseBlocks(
     GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest)
 {
     auto const requestId = sequence.getRequestId();
+    TLLM_LOG_DEBUG("%s::releaseBlocks - requestId=%lu, llmRequest.id=%s", mLogPrefix.c_str(), requestId,
+        llmRequest.has_value() ? std::to_string(llmRequest->mRequestId).c_str() : "null");
     std::optional<KVCacheBlock::IdType> lastStoredId = std::nullopt;
     auto node = mAllocatedBlocksPerSeq.extract(requestId);
     TLLM_CHECK(node);
     auto& allocatedBlocks = node.mapped();
-    if (llmRequest.has_value())
+    if (llmRequest.has_value() && !isRecurrentState()) // only store context blocks for recurrent states
     {
         // If llmRequest is provided, block store for reuse is enabled.
         if (!isSequenceValidForStoreForReuse(requestId))
@@ -2068,12 +2478,13 @@ KVCacheManager::KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, Size
     std::optional<TempAttentionWindowInputs> const& tempAttentionWindowInputs, nvinfer1::DataType dtype,
     SizeType32 sinkTokenLength, int64_t stream, runtime::SizeType32 maxSequenceLength, bool enableBlockReuse,
     bool onboardBlocks, CacheType cacheType, bool enablePartialReuse, bool copyOnPartialReuse, bool enableIndexerKCache,
-    SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim)
+    SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim,
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata)
     : KVCacheManager(std::vector<SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksPerWindow,
         maxNumSequences, maxBeamWidth, maxAttentionWindowVec, tempAttentionWindowInputs, dtype, sinkTokenLength,
         std::make_shared<runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream)), maxSequenceLength,
         enableBlockReuse, onboardBlocks, cacheType, std::nullopt, nullptr, enablePartialReuse, copyOnPartialReuse,
-        nullptr, enableIndexerKCache, indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim)
+        nullptr, enableIndexerKCache, indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim, linearAttentionMetadata)
 {
 }
 
@@ -2085,13 +2496,14 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     bool onboardBlocks, CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, bool enableIndexerKCache,
-    SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim)
+    SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim,
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata)
     : KVCacheManager(numKvHeadsPerLayer, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences, maxBeamWidth,
         maxAttentionWindowVec, tempAttentionWindowInputs, dtype, sinkTokenLength,
         std::make_shared<runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream)), maxSequenceLength,
         enableBlockReuse, onboardBlocks, cacheType, secondaryOffloadMinPriority, eventManager, enablePartialReuse,
         copyOnPartialReuse, kvCacheConnectorManager, enableIndexerKCache, indexerKCacheQuantBlockSize,
-        indexerKCacheIndexHeadDim)
+        indexerKCacheIndexHeadDim, linearAttentionMetadata)
 {
 }
 
@@ -2103,7 +2515,8 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     bool onboardBlocks, CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, bool enableIndexerKCache,
-    SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim)
+    SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim,
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata)
     : mMaxBeamWidth(maxBeamWidth)
     , mDataType(dtype)
     , mMaxAttentionWindow(*std::max_element(maxAttentionWindowVec.begin(), maxAttentionWindowVec.end()))
@@ -2114,7 +2527,7 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
           std::move(stream), maxSequenceLength, maxBeamWidth, maxAttentionWindowVec, tempAttentionWindowInputs, dtype,
           mSinkBubbleLength, onboardBlocks, cacheType, secondaryOffloadMinPriority, std::move(eventManager),
           enablePartialReuse, copyOnPartialReuse, std::move(kvCacheConnectorManager), std::nullopt, enableIndexerKCache,
-          indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim)
+          indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim, linearAttentionMetadata)
     // disable block reuse for sink bubble since chopVectorIntoBlocks does not match KV cache blocks in this case
     , mEnableBlockReuse{mSinkBubbleLength > 0 ? false : enableBlockReuse}
 {
@@ -2142,12 +2555,13 @@ KVCacheManager::KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, Size
     bool onboardBlocks, CacheType cacheType, std::optional<executor::RetentionPriority> secondaryOffloadMinPriority,
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, bool enableIndexerKCache,
-    SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim)
+    SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim,
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata)
     : KVCacheManager(std::vector<SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksPerWindow,
         maxNumSequences, maxBeamWidth, maxAttentionWindowVec, tempAttentionWindowInputs, dtype, sinkTokenLength,
         std::move(stream), maxSequenceLength, enableBlockReuse, onboardBlocks, cacheType, secondaryOffloadMinPriority,
         std::move(eventManager), enablePartialReuse, copyOnPartialReuse, std::move(kvCacheConnectorManager),
-        enableIndexerKCache, indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim)
+        enableIndexerKCache, indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim, linearAttentionMetadata)
 {
 }
 
@@ -2325,6 +2739,29 @@ SizeType32 KVCacheManager::getRemainingBlocksToCompletion(LlmRequest const& req,
         return 0; // cross KV cache doesn't grow after the initial context phase
     }
 
+    if (windowSize == LinearAttentionMetadata::kRecurrentStates)
+    {
+        if (req.isGenerationInProgressState())
+        {
+            return 0; // no need to allocate blocks for recurrent states during generation
+        }
+        else if (!req.isContextFinished())
+        {
+            std::scoped_lock lck(mSequencesMtx);
+            auto const seqIt = mSequences.find(req.mRequestId);
+            if (seqIt != mSequences.end())
+            {
+                return 0;
+            }
+            if (mEnableBlockReuse)
+            {
+                return req.getPromptLen() / mBlockManager.getLinearAttentionMetadata()->statesSnapshotInterval + 1
+                    + (mBlockManager.getLinearAttentionMetadata()->saveLastSnapshot ? 1 : 0);
+            }
+            return 1;
+        }
+    }
+
     auto const temporaryAttentionWindow = mBlockManager.getWindowSizeMetadata(windowSize).temporaryAttentionWindow;
 
     SizeType32 const numContextBlocks
@@ -2461,6 +2898,12 @@ void KVCacheManager::addToken(RequestIdType requestId)
     mBlockManager.adjustBlocksIfNeeded(sequence);
 }
 
+void KVCacheManager::copyLinearAttentionBlock(LlmRequest const& llmRequest)
+{
+    auto& sequence = getSequence(llmRequest.mRequestId);
+    mBlockManager.copyLinearAttentionBlock(sequence, llmRequest);
+}
+
 void WindowBlockManager::detachFrontBlock(GenerationRequest& sequence)
 {
     // streamLLM is not supported at the moment. The out of window block will
@@ -2572,9 +3015,7 @@ void KVCacheManager::addSequence(
             {
                 TLLM_LOG_WARNING(
                     "Request %d has a retention configuration set, but block reuse is disabled. The retention "
-                    "config "
-                    "will "
-                    "have no effect.",
+                    "config will have no effect.",
                     llmRequest->mRequestId);
             }
             bool isShareLastContextBlock = isCrossKv() || effectiveInputLength % getTokensPerBlock() == 0;
@@ -2627,6 +3068,7 @@ void KVCacheManager::storeContextBlocks(LlmRequest const& llmRequest)
     }
 }
 
+// Only in TRT path
 void KVCacheManager::storeNewBlock(LlmRequest const& llmRequest)
 {
     // We store newest block for potential reuse only if:
@@ -2733,12 +3175,13 @@ SizeType32 KVCacheManager::copyBlockOffsets(ITensor& output, SizeType32 outputSl
     SizeType32 maxBlockCount{0};
     // Get page table for each KV cache pool
     SizeType32 absolutePoolIdx = 0;
-    for (auto const [windowSize, metadata] : mBlockManager.getWindowSizesMetadata())
+
+    for (auto const [ws, metadata] : mBlockManager.getWindowSizesMetadata())
     {
-        auto const& cacheBlocksTensor = sequence.getCacheBlockIndices(windowSize);
+        auto const& cacheBlocksTensor = sequence.getCacheBlockIndices(ws);
         auto const* srcPtr = bufferCast<tk::KVCacheIndex>(cacheBlocksTensor);
         auto const& srcShape = cacheBlocksTensor.getShape();
-        auto const& cacheBlockIds = sequence.getCacheBlockIds(windowSize);
+        auto const& cacheBlockIds = sequence.getCacheBlockIds(ws);
         for (SizeType32 poolIdx = 0; poolIdx < metadata.numPools; poolIdx++, absolutePoolIdx++)
         {
             for (SizeType32 beamIdx = 0; beamIdx < beamWidth; ++beamIdx)
@@ -2851,15 +3294,16 @@ bool isSortedVectorIdenticalAcrossAllRanks(WorldConfig const& worldConfig, std::
 }
 } // namespace
 
-BlocksPerWindow BaseKVCacheManager::calculateMaxNumBlocks(executor::KvCacheConfig const& config, bool isCrossAttention,
-    nvinfer1::DataType dtype, ModelConfig const& modelConfig, WorldConfig const& worldConfig,
+BlocksPerWindow BaseKVCacheManager::calculateMaxNumBlocks(executor::KvCacheConfig const& config,
+    nvinfer1::DataType dtype, std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead,
+    SizeType32 tokensPerBlock, WorldConfig const& worldConfig,
     std::map<SizeType32, std::vector<SizeType32>> const& windowSizeToLayers, uint64_t allottedPrimaryMemBytes,
-    uint64_t allottedSecondaryMemBytes, size_t extraCostMemory, SizeType32 kvFactor)
+    uint64_t allottedSecondaryMemBytes, size_t extraCostMemory, SizeType32 kvFactor, SizeType32 maxBatchSize,
+    std::optional<LinearAttentionMetadata> const& linearAttentionMetadata)
 {
-    TLLM_LOG_DEBUG("Calculating max num blocks for %s: {.allottedPrimaryMemBytes=%" PRIu64
+    TLLM_LOG_DEBUG("Calculating max num blocks: {.allottedPrimaryMemBytes=%" PRIu64
                    ", .allottedSecondaryMemBytes=%" PRIu64 "}",
-        isCrossAttention ? "Cross KvCacheManager" : "Self KvCacheManager", allottedPrimaryMemBytes,
-        allottedSecondaryMemBytes);
+        allottedPrimaryMemBytes, allottedSecondaryMemBytes);
 
     if (config.getMaxTokens().has_value() && windowSizeToLayers.size() > 1)
     {
@@ -2873,8 +3317,13 @@ BlocksPerWindow BaseKVCacheManager::calculateMaxNumBlocks(executor::KvCacheConfi
     std::map<SizeType32, SizeType32> cacheSizeBytesPerTokenPerWindow;
     for (auto const& [windowSize, managedLayers] : windowSizeToLayers)
     {
+        if (LinearAttentionMetadata::hasLinearCache(windowSize))
+        {
+            cacheSizeBytesPerTokenPerWindow[windowSize] = 1;
+            continue;
+        }
         auto const cacheSizePerToken = BaseKVCacheManager::calculateCacheSizePerTokenForSingleWindowSize(
-            modelConfig, managedLayers, isCrossAttention, kvFactor);
+            numKvHeadsPerLayer, sizePerHead, managedLayers, kvFactor);
         auto const cacheSizeBytesPerToken = cacheSizePerToken * BufferDataType(dtype).getSize();
         cacheSizeBytesPerTokenPerWindow[windowSize] = cacheSizeBytesPerToken;
     }
@@ -2882,13 +3331,20 @@ BlocksPerWindow BaseKVCacheManager::calculateMaxNumBlocks(executor::KvCacheConfi
 
     TLLM_LOG_DEBUG("extraCostMemory [Gib]: %0.2f", extraCostMemory / static_cast<double>(1 << 30));
     allottedPrimaryMemBytes = allottedPrimaryMemBytes - extraCostMemory;
-    auto const tokensPerBlock = modelConfig.getTokensPerBlock();
     auto const calculatePrimaryBlocks
-        = [&](SizeType32 windowSize, float windowSizeShare, SizeType32 cacheSizeBytesPerToken)
+        = [&](SizeType32 windowSize, double windowSizeShare, SizeType32 cacheSizeBytesPerToken)
     {
-        TLLM_LOG_DEBUG("windowSizeShare: %f, cacheSizeBytesPerToken: %d", windowSizeShare, cacheSizeBytesPerToken);
-        auto maxTokens = static_cast<uint64_t>(
-            allottedPrimaryMemBytes * windowSizeShare / static_cast<double>(cacheSizeBytesPerToken));
+        TLLM_LOG_DEBUG("windowSizeShare: %lf, cacheSizeBytesPerToken: %d", windowSizeShare, cacheSizeBytesPerToken);
+        auto memoryBudget = static_cast<uint64_t>(allottedPrimaryMemBytes * windowSizeShare);
+        if (LinearAttentionMetadata::hasRecurrentStatesCache(windowSize))
+        {
+            TLLM_CHECK_WITH_INFO(linearAttentionMetadata.has_value(),
+                "Linear attention metadata must be provided when linear attention is used.");
+            return linearAttentionMetadata->calcMaxMemoryBlocks(
+                windowSize, tokensPerBlock, memoryBudget, windowSizeToLayers.at(windowSize).size());
+        }
+        auto maxTokens = static_cast<uint64_t>(memoryBudget / cacheSizeBytesPerToken);
+
         // kv_cache_config.max_tokens is not effective in VSWA scheme
         if (config.getMaxTokens().has_value() && !isVSWA)
         {
@@ -2900,23 +3356,22 @@ BlocksPerWindow BaseKVCacheManager::calculateMaxNumBlocks(executor::KvCacheConfi
             }
         }
         TLLM_LOG_DEBUG("Primary maxTokens for windowSize %d: %ld", windowSize, maxTokens);
-        SizeType32 const blocksInPrimaryPool = tc::ceilDiv(maxTokens, tokensPerBlock);
-        TLLM_LOG_DEBUG(
-            "Number of blocks in KV cache primary pool for windowSize %d: %d", windowSize, blocksInPrimaryPool);
-        return blocksInPrimaryPool;
+        return static_cast<SizeType32>(tc::ceilDiv(maxTokens, tokensPerBlock));
     };
 
     auto const calculateSecondaryBlocks
-        = [&](SizeType32 windowSize, float windowSizeShare, SizeType32 cacheSizeBytesPerToken)
+        = [&](SizeType32 windowSize, double windowSizeShare, SizeType32 cacheSizeBytesPerToken)
     {
-        auto const maxTokensSecondary
-            = static_cast<SizeType32>(allottedSecondaryMemBytes * windowSizeShare / cacheSizeBytesPerToken);
-        SizeType32 const blocksInSecondaryPool = std::max(0, maxTokensSecondary / tokensPerBlock);
-        TLLM_LOG_DEBUG(
-            "Number of blocks in KV cache secondary pool for windowSize %d: %d, onboard blocks to primary memory "
-            "before reuse: %s",
-            windowSize, blocksInSecondaryPool, config.getOnboardBlocks() ? "true" : "false");
-        return blocksInSecondaryPool;
+        auto memoryBudget = static_cast<uint64_t>(allottedSecondaryMemBytes * windowSizeShare);
+        if (LinearAttentionMetadata::hasLinearCache(windowSize))
+        {
+            TLLM_CHECK_WITH_INFO(linearAttentionMetadata.has_value(),
+                "Linear attention metadata must be provided when linear attention is used.");
+            return linearAttentionMetadata->calcMaxMemoryBlocks(
+                windowSize, tokensPerBlock, memoryBudget, windowSizeToLayers.at(windowSize).size());
+        }
+        auto maxTokensSecondary = static_cast<SizeType32>(memoryBudget / cacheSizeBytesPerToken);
+        return std::max(0, maxTokensSecondary / tokensPerBlock);
     };
 
     std::map<SizeType32, float> windowSizeToShare;
@@ -2978,8 +3433,14 @@ BlocksPerWindow BaseKVCacheManager::calculateMaxNumBlocks(executor::KvCacheConfi
         auto const cacheSizeBytesPerToken = cacheSizeBytesPerTokenPerWindow.at(windowSize);
         auto const windowSizeShare = windowSizeToShare.at(windowSize);
         auto const blocksInPrimaryPool = calculatePrimaryBlocks(windowSize, windowSizeShare, cacheSizeBytesPerToken);
+        TLLM_LOG_DEBUG(
+            "Number of blocks in KV cache primary pool for windowSize %d: %d", windowSize, blocksInPrimaryPool);
         auto const blocksInSecondaryPool
             = calculateSecondaryBlocks(windowSize, windowSizeShare, cacheSizeBytesPerToken);
+        TLLM_LOG_DEBUG(
+            "Number of blocks in KV cache secondary pool for windowSize %d: %d, onboard blocks to primary memory "
+            "before reuse: %s",
+            windowSize, blocksInSecondaryPool, config.getOnboardBlocks() ? "true" : "false");
         blocksPrimary.push_back(blocksInPrimaryPool);
         blocksSecondary.push_back(blocksInSecondaryPool);
     }
@@ -3081,6 +3542,11 @@ GenerationRequest& KVCacheManager::getSequence(RequestIdType requestId)
 {
     auto lck = std::scoped_lock(mSequencesMtx);
     return mSequences.at(requestId);
+}
+
+SizeType32 KVCacheManager::getTokenCount(RequestIdType requestId) const
+{
+    return getSequence(requestId).getNumTokens();
 }
 
 SizeType32 BaseKVCacheManager::getSinkBubbleLength(SizeType32 sinkTokenLen, SizeType32 tokensPerBlock)

--- a/cpp/tensorrt_llm/batch_manager/kvCacheTransferManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheTransferManager.cpp
@@ -111,11 +111,33 @@ void KVCacheTransferManager::copyBlock(BlockPtr const& src, BlockPtr const& dst,
         // Iterate over all pools, partial-copy logic
         for (size_t poolIdx = 0; poolIdx < pools.size(); ++poolIdx)
         {
+            auto const& pool = pools[poolIdx];
+
+            // For layer-first layout pools, block data is non-contiguous across layers.
+            // Copy each layer's block data separately.
+            if (pool.layerFirstLayout)
+            {
+                auto srcPool = src->isPrimary() ? pool.primaryPtr : pool.secondaryPtr;
+                auto dstPool = dst->isPrimary() ? pool.primaryPtr : pool.secondaryPtr;
+                auto const srcBlockIdx = static_cast<tr::ITensor::DimType64>(src->getMemoryPoolBlockIndex());
+                auto const dstBlockIdx = static_cast<tr::ITensor::DimType64>(dst->getMemoryPoolBlockIndex());
+
+                for (SizeType32 layerIdx = 0; layerIdx < pool.numLayers; ++layerIdx)
+                {
+                    // pool shape: {numLayers, numBlocks, kvFactor, blockSize}
+                    // slice at {layerIdx, blockIdx} gives {1, kvFactor, blockSize}
+                    auto srcBlock = tr::ITensor::slice(srcPool, {layerIdx, srcBlockIdx}, 1);
+                    auto dstBlock = tr::ITensor::slice(dstPool, {layerIdx, dstBlockIdx}, 1);
+                    (isOffload ? mOffloadManager : mOnboardManager).copy(*srcBlock, *dstBlock);
+                }
+                continue;
+            }
+
             auto srcPtr = computeBlockPointer(src, pools, poolIdx);
             auto dstPtr = computeBlockPointer(dst, pools, poolIdx);
 
             // Does it contain block scales?
-            auto containsBlockScales = pools[poolIdx].containsBlockScales;
+            auto containsBlockScales = pool.containsBlockScales;
 
             // If no partial tokens or if the dataType is not supported for partial copy, copy entire block.
             // Note that nvfp4 kv cache SFs use an interleaved layout, so we need to copy the entire block.
@@ -128,7 +150,7 @@ void KVCacheTransferManager::copyBlock(BlockPtr const& src, BlockPtr const& dst,
             }
             else
             {
-                int const tokensPerBlock = pools[poolIdx].tokensPerBlock;
+                int const tokensPerBlock = pool.tokensPerBlock;
                 if (numTokensToCopy >= tokensPerBlock)
                 {
                     // If requested tokens >= entire block, just do a full copy.
@@ -137,10 +159,10 @@ void KVCacheTransferManager::copyBlock(BlockPtr const& src, BlockPtr const& dst,
                 else
                 {
                     auto stream = (isOffload ? mOffloadManager : mOnboardManager).getStream().get();
-                    int const numLayers = pools[poolIdx].numLayers;
-                    int const kvFactor = pools[poolIdx].kvFactor;
-                    int const numHeads = pools[poolIdx].numKvHeads;
-                    int const sizePerHead = pools[poolIdx].sizePerHead;
+                    int const numLayers = pool.numLayers;
+                    int const kvFactor = pool.kvFactor;
+                    int const numHeads = pool.numKvHeads;
+                    int const sizePerHead = pool.sizePerHead;
                     auto shape = srcPtr->getShape();
 
                     TLLM_CHECK_WITH_INFO(
@@ -161,6 +183,8 @@ void KVCacheTransferManager::copyBlock(BlockPtr const& src, BlockPtr const& dst,
 
     for (size_t poolIdx = 0; poolIdx < pools.size(); ++poolIdx)
     {
+        TLLM_CHECK_WITH_INFO(!pools[poolIdx].layerFirstLayout,
+            "File-based offload/onboard is not supported for layer-first layout pools");
         auto ptr = isOffload ? computeBlockPointer(src, pools, poolIdx) : computeBlockPointer(dst, pools, poolIdx);
         auto block_id = src->getBlockId();
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -71,6 +71,7 @@
 #include <cstddef>
 #include <cstring>
 #include <memory>
+#include <numeric>
 #include <optional>
 #include <stdexcept>
 #include <thread>
@@ -111,8 +112,9 @@ std::map<SizeType32, SizeType32> TrtGptModelInflightBatching::calculateCacheSize
     std::map<SizeType32, SizeType32> cacheSizeBytesPerTokenPerWindow;
     for (auto const& [windowSize, globalLayerIds] : uniqueWindowSizeToLayers)
     {
-        auto const cacheSizePerToken = BaseKVCacheManager::calculateCacheSizePerTokenForSingleWindowSize(
-            modelConfig, globalLayerIds, isCrossAttention, kvFactor);
+        auto const nkvh = modelConfig.getNumKvHeadsForGivenLayers(globalLayerIds, isCrossAttention);
+        auto const sumLocalHeads = std::reduce(nkvh.cbegin(), nkvh.cend());
+        auto const cacheSizePerToken = sumLocalHeads * kvFactor * modelConfig.getSizePerHead();
         auto const cacheSizeBytesPerToken = cacheSizePerToken * BufferDataType(modelConfig.getKvDataType()).getSize();
         cacheSizeBytesPerTokenPerWindow[windowSize] = cacheSizeBytesPerToken;
     }
@@ -660,8 +662,10 @@ std::unique_ptr<kv_cache_manager::KVCacheManager> TrtGptModelInflightBatching::c
 
     auto const numLayers = static_cast<SizeType32>(numKvHeadsPerLayer.size());
     auto const windowSizeToLayers = KVCacheManager::groupLayersByWindowSize(maxAttentionWindowVec, numLayers);
-    auto blocksPerWindow = KVCacheManager::calculateMaxNumBlocks(kvCacheConfig, isCrossAttention, kvDtype, mModelConfig,
-        mWorldConfig, windowSizeToLayers, freePrimaryMemBytes, freeSecondaryMemBytes, extraCostMemory, 2);
+    auto const sizePerHead = mModelConfig.getSizePerHead();
+    auto blocksPerWindow = KVCacheManager::calculateMaxNumBlocks(kvCacheConfig, kvDtype, numKvHeadsPerLayer,
+        sizePerHead, tokensPerBlock, mWorldConfig, windowSizeToLayers, freePrimaryMemBytes, freeSecondaryMemBytes,
+        extraCostMemory, 2, getMaxBatchSize());
 
     // now we check if any of the window sizes is too large for at least one sequence to fit in kvCache
     // this can happen if e.g. maxSeqLen is deduced from the model and is too large
@@ -684,7 +688,6 @@ std::unique_ptr<kv_cache_manager::KVCacheManager> TrtGptModelInflightBatching::c
             "Thus, KV cache reuse is disabled for cross KV cache.");
     }
     auto const enableBlockReuse = kvCacheType == KvCacheType::kSELF ? kvCacheConfig.getEnableBlockReuse() : false;
-    auto const sizePerHead = mModelConfig.getSizePerHead();
 
     auto kvCacheManager = std::make_unique<KVCacheManager>(numKvHeadsPerLayer, sizePerHead, tokensPerBlock,
         blocksPerWindow, getMaxNumSequences(), getMaxBeamWidth(), maxAttentionWindowVec, tempAttentionWindowInputs,

--- a/cpp/tensorrt_llm/executor/kvCacheConfig.cpp
+++ b/cpp/tensorrt_llm/executor/kvCacheConfig.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include "tensorrt_llm/batch_manager/kvCacheManager.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/executor/executor.h"
 
@@ -175,7 +176,9 @@ void KvCacheConfig::setMaxAttentionWindowVec(std::vector<SizeType32> maxAttentio
 {
     for (SizeType32 maxAttentionWindow : maxAttentionWindowVec)
     {
-        TLLM_CHECK(maxAttentionWindow > 0);
+        TLLM_CHECK(maxAttentionWindow > 0
+            || maxAttentionWindow
+                == batch_manager::kv_cache_manager::LinearAttentionMetadata::LinearCacheType::kRecurrentStates);
     }
     mMaxAttentionWindowVec = maxAttentionWindowVec;
 }

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -111,6 +111,11 @@ public:
         NB_OVERRIDE_PURE(addToken, requestId);
     }
 
+    SizeType32 getTokenCount(tb::LlmRequest::RequestIdType requestId) const override
+    {
+        NB_OVERRIDE_PURE(getTokenCount, requestId);
+    }
+
     void addSequence(tb::LlmRequest::RequestIdType requestId, SizeType32 inputLength, SizeType32 beamWidth,
         tensorrt_llm::common::OptionalRef<tb::LlmRequest> llmRequest = std::nullopt) override
     {
@@ -316,6 +321,17 @@ public:
 
 void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
 {
+    nb::class_<tbk::LinearAttentionMetadata>(m, "LinearAttentionMetadata")
+        .def(nb::init<>())
+        .def_rw("linear_layer_indices", &tbk::LinearAttentionMetadata::linearLayerIndices)
+        .def_rw("cache_type", &tbk::LinearAttentionMetadata::cacheType)
+        .def_rw("all_recurrent_states_bytes", &tbk::LinearAttentionMetadata::allRecurrentStatesBytes)
+        .def_rw("states_snapshot_interval", &tbk::LinearAttentionMetadata::statesSnapshotInterval)
+        .def_rw("save_last_snapshot", &tbk::LinearAttentionMetadata::saveLastSnapshot);
+
+    nb::enum_<tbk::LinearAttentionMetadata::LinearCacheType>(m, "LinearCacheType")
+        .value("RECURRENT_STATES", tbk::LinearAttentionMetadata::LinearCacheType::kRecurrentStates);
+
     nb::class_<tbk::KvCacheStats>(m, "KvCacheStats")
         .def(nb::init<>())
         .def_rw("max_num_blocks", &tbk::KvCacheStats::maxNumBlocks)
@@ -356,9 +372,10 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
 
     nb::class_<tbk::BaseKVCacheManager, PyKvCacheManager>(m, "BaseKVCacheManager")
         .def_static("calculate_max_num_blocks", &tbk::BaseKVCacheManager::calculateMaxNumBlocks, nb::arg("config"),
-            nb::arg("is_cross_attention"), nb::arg("dtype"), nb::arg("model_config"), nb::arg("world_config"),
-            nb::arg("window_size_to_layers"), nb::arg("allotted_primary_mem_bytes"),
+            nb::arg("dtype"), nb::arg("num_kv_heads_per_layer"), nb::arg("size_per_head"), nb::arg("tokens_per_block"),
+            nb::arg("world_config"), nb::arg("window_size_to_layers"), nb::arg("allotted_primary_mem_bytes"),
             nb::arg("allotted_secondary_mem_bytes"), nb::arg("extra_cost_memory"), nb::arg("kv_factor"),
+            nb::arg("max_batch_size"), nb::arg("linear_attention_metadata") = std::nullopt,
             nb::call_guard<nb::gil_scoped_release>())
         .def("allocate_pools", &BaseKVCacheManager::allocatePools, nb::call_guard<nb::gil_scoped_release>())
         .def("release_pools", &BaseKVCacheManager::releasePools, nb::call_guard<nb::gil_scoped_release>())
@@ -374,6 +391,7 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
         .def("get_remaining_blocks_to_completion", &BaseKVCacheManager::getRemainingBlocksToCompletion,
             nb::call_guard<nb::gil_scoped_release>())
         .def("add_token", &BaseKVCacheManager::addToken, nb::call_guard<nb::gil_scoped_release>())
+        .def("get_token_count", &BaseKVCacheManager::getTokenCount, nb::arg("request_id"))
         .def("add_sequence", &BaseKVCacheManager::addSequence, nb::call_guard<nb::gil_scoped_release>())
         .def("remove_sequence", &BaseKVCacheManager::removeSequence, nb::call_guard<nb::gil_scoped_release>())
         .def("pin_blocks", &BaseKVCacheManager::pinBlocks, nb::call_guard<nb::gil_scoped_release>())
@@ -427,7 +445,21 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
             {
                 auto pool = tr::Torch::tensor(self.getPrimaryPool(layer_idx));
                 auto pool_layer_idx = self.getPoolLayerIdx(layer_idx);
+                if (self.isPoolLayerFirst(layer_idx))
+                {
+                    // Layer-first layout: pool[pool_layer_idx, :]
+                    return pool.index({pool_layer_idx});
+                }
+                // Standard layout: pool[:, pool_layer_idx]
                 return pool.index({torch::indexing::Slice(), pool_layer_idx});
+            },
+            nb::call_guard<nb::gil_scoped_release>())
+        .def(
+            "get_recurrent_states_pool",
+            [](tbk::BaseKVCacheManager& self) -> at::Tensor
+            {
+                auto const& pool = self.getBlockManager().getRecurrentStatesPool();
+                return tr::Torch::tensor(pool.primaryPtr);
             },
             nb::call_guard<nb::gil_scoped_release>())
         .def(
@@ -536,7 +568,8 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
                  std::vector<SizeType32> const&, std::optional<tbk::TempAttentionWindowInputs> const&,
                  nvinfer1::DataType, SizeType32, int64_t, runtime::SizeType32, bool, bool, tbk::CacheType,
                  std::optional<tensorrt_llm::executor::RetentionPriority>, std::shared_ptr<tbk::KVCacheEventManager>,
-                 bool, bool, std::shared_ptr<tbc::KvCacheConnectorManager>, bool, SizeType32, SizeType32>(),
+                 bool, bool, std::shared_ptr<tbc::KvCacheConnectorManager>, bool, SizeType32, SizeType32,
+                 std::optional<tbk::LinearAttentionMetadata>>(),
             nb::arg("num_kv_heads_per_layer"), nb::arg("size_per_head"), nb::arg("tokens_per_block"),
             nb::arg("blocks_per_window"), nb::arg("max_num_sequences"), nb::arg("max_beam_width"),
             nb::arg("max_attention_window_vec"), nb::arg("temp_attention_window_inputs").none(), nb::arg("dtype"),
@@ -546,14 +579,17 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
             nb::arg("event_manager") = nullptr, nb::arg("enable_partial_reuse") = true,
             nb::arg("copy_on_partial_reuse") = true, nb::arg("kv_connector_manager") = nullptr,
             nb::arg("enable_indexer_k_cache") = false, nb::arg("indexer_k_cache_quant_block_size") = 128,
-            nb::arg("indexer_k_cache_index_head_dim") = 0, nb::call_guard<nb::gil_scoped_release>())
+            nb::arg("indexer_k_cache_index_head_dim") = 0, nb::arg("linear_attention_metadata").none() = std::nullopt,
+            nb::call_guard<nb::gil_scoped_release>())
         .def(
             "scheduling_has_free_blocks",
             [](tbk::KVCacheManager& self, SizeType32 numRequired, SizeType32 windowSize)
             { return self.getBlockManager().schedulingHasFreeBlocks(numRequired, windowSize); },
             nb::arg("num_required"), nb::arg("window_size"), nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro(
-            "is_variable_window", [](tbk::KVCacheManager& self) { return self.getBlockManager().isVariableWindow(); });
+            "is_variable_window", [](tbk::KVCacheManager& self) { return self.getBlockManager().isVariableWindow(); })
+        .def("copy_linear_attention_block", &tbk::KVCacheManager::copyLinearAttentionBlock, nb::arg("llm_request"),
+            nb::call_guard<nb::gil_scoped_release>());
 }
 
 void tb::BasePeftCacheManagerBindings::initBindings(nb::module_& m)

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -33,6 +33,7 @@
 #include "tensorrt_llm/runtime/samplingConfig.h"
 
 #include "gtest/gtest.h"
+#include <cstdint>
 #include <gmock/gmock.h>
 
 #include <algorithm>
@@ -43,6 +44,7 @@
 #include <filesystem>
 #include <memory>
 #include <set>
+#include <sys/types.h>
 #include <thread>
 #include <unistd.h>
 #include <variant>
@@ -648,7 +650,7 @@ TEST_F(KVCacheManagerTest, FindBlocksInReuseTreeByBlockKeysTest)
     auto const blocksPerWindow = BlocksPerWindow{{maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}}};
     KVCacheManager kvCacheManager(numLayers, numKvHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
         beamWidth, std::vector<BlockManager::SizeType32>{maxAttentionWindow}, std::nullopt, nvinfer1::DataType::kHALF,
-        false, stream, true, onboardBlocks);
+        false, stream, maxAttentionWindow, true, onboardBlocks);
 
     // Add sequence [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16] (17 tokens, three blocks)
     auto inputTokens = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
@@ -3515,6 +3517,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStream)
     auto llmRequest0 = std::make_shared<LlmRequest>(0, 0, inputTokens0, samplingConfig, true);
     llmRequest0->setLoraTaskId(42);
     kvCacheManager.addSequence(0, inputTokens0->size(), beamWidth, llmRequest0);
+    llmRequest0->setContextCurrentPosition(inputTokens0->size());
     kvCacheManager.storeContextBlocks(*llmRequest0);
 
     events = getEvents(kvCacheManager);
@@ -3544,6 +3547,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStream)
     auto llmRequest1 = std::make_shared<LlmRequest>(1, 0, inputTokens1, samplingConfig, true);
     llmRequest1->setLoraTaskId(42);
     kvCacheManager.addSequence(1, inputTokens1->size(), beamWidth, llmRequest1);
+    llmRequest1->setContextCurrentPosition(inputTokens1->size());
     kvCacheManager.storeContextBlocks(*llmRequest1);
     (void) kvCacheManager.removeSequence(1, llmRequest1);
 
@@ -3630,6 +3634,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStream)
     EXPECT_EQ(offloadedBlocks, 2);
     EXPECT_EQ(removedBlocks, 1);
 
+    llmRequest4->setContextCurrentPosition(inputTokens4->size());
     kvCacheManager.storeContextBlocks(*llmRequest4);
 
     events = getEvents(kvCacheManager);
@@ -3999,6 +4004,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStreamOverflow)
     auto llmRequest0 = std::make_shared<LlmRequest>(0, 0, inputTokens0, samplingConfig, true);
     llmRequest0->setLoraTaskId(42);
     kvCacheManager.addSequence(0, inputTokens0->size(), beamWidth, llmRequest0);
+    llmRequest0->setContextCurrentPosition(inputTokens0->size());
     kvCacheManager.storeContextBlocks(*llmRequest0);
 
     auto events = getEvents(kvCacheManager);
@@ -4059,6 +4065,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStreamPriority)
     llmRequest0->setKvCacheRetentionConfig(tle::KvCacheRetentionConfig(
         std::vector{tle::KvCacheRetentionConfig::TokenRangeRetentionConfig(0, std::nullopt, 50)}, 35));
     kvCacheManager.addSequence(0, inputTokens0->size(), beamWidth, llmRequest0);
+    llmRequest0->setContextCurrentPosition(inputTokens0->size());
     kvCacheManager.storeContextBlocks(*llmRequest0);
     (void) kvCacheManager.removeSequence(0, llmRequest0);
     auto events = getEvents(kvCacheManager);
@@ -4075,6 +4082,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStreamPriority)
     auto inputTokens1 = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7});
     auto llmRequest1 = std::make_shared<LlmRequest>(1, 0, inputTokens1, samplingConfig, true);
     kvCacheManager.addSequence(1, inputTokens1->size(), beamWidth, llmRequest1);
+    llmRequest1->setContextCurrentPosition(inputTokens1->size());
     kvCacheManager.storeContextBlocks(*llmRequest1);
     (void) kvCacheManager.removeSequence(1, llmRequest1);
 
@@ -4280,6 +4288,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStreamBlocking)
     auto inputTokens0 = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7});
     auto llmRequest0 = std::make_shared<LlmRequest>(0, 0, inputTokens0, samplingConfig, true);
     kvCacheManager.addSequence(0, inputTokens0->size(), beamWidth, llmRequest0);
+    llmRequest0->setContextCurrentPosition(inputTokens0->size());
     kvCacheManager.storeContextBlocks(*llmRequest0);
 
     kvCacheManager.flushIterationEvents();
@@ -4335,6 +4344,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStreamWindowSize)
     auto inputTokens0 = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7});
     auto llmRequest0 = std::make_shared<LlmRequest>(0, 0, inputTokens0, samplingConfig, true);
     kvCacheManager.addSequence(0, inputTokens0->size(), beamWidth, llmRequest0);
+    llmRequest0->setContextCurrentPosition(inputTokens0->size());
     kvCacheManager.storeContextBlocks(*llmRequest0);
 
     events = getEvents(kvCacheManager);
@@ -6407,6 +6417,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventRemovedOrderedBeforeStore)
                                    KvCacheRetentionConfig::TokenRangeRetentionConfig(4, std::nullopt, highPriority)},
             highPriority));
     kvCacheManager.addSequence(0, inputTokens0->size(), beamWidth, llmRequest0);
+    llmRequest0->setContextCurrentPosition(inputTokens0->size());
     kvCacheManager.storeContextBlocks(*llmRequest0);
     (void) kvCacheManager.removeSequence(0, llmRequest0);
     (void) getEvents(kvCacheManager); // drain
@@ -6418,6 +6429,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventRemovedOrderedBeforeStore)
     auto inputTokens1 = std::make_shared<VecTokens>(VecTokens{100, 101, 102, 103, 104, 105, 106, 107, 108});
     auto llmRequest1 = std::make_shared<LlmRequest>(1, maxNewTokens, inputTokens1, samplingConfig, true);
     kvCacheManager.addSequence(1, inputTokens1->size(), beamWidth, llmRequest1);
+    llmRequest1->setContextCurrentPosition(inputTokens1->size());
     kvCacheManager.storeContextBlocks(*llmRequest1);
 
     auto events = getEvents(kvCacheManager);
@@ -6501,6 +6513,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStoreForDifferentWindowDoesNotFlus
     auto inputTokens0 = std::make_shared<VecTokens>(VecTokens{0, 1, 2, 3, 4, 5, 6, 7, 8});
     auto llmRequest0 = std::make_shared<LlmRequest>(0, maxNewTokens, inputTokens0, samplingConfig, true);
     kvCacheManager.addSequence(0, inputTokens0->size(), beamWidth, llmRequest0);
+    llmRequest0->setContextCurrentPosition(inputTokens0->size());
     kvCacheManager.storeContextBlocks(*llmRequest0);
     (void) kvCacheManager.removeSequence(0, llmRequest0);
     (void) getEvents(kvCacheManager); // drain
@@ -6515,6 +6528,7 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStoreForDifferentWindowDoesNotFlus
     auto inputTokens1 = std::make_shared<VecTokens>(VecTokens{100, 101, 102, 103, 104, 105, 106, 107, 108});
     auto llmRequest1 = std::make_shared<LlmRequest>(1, maxNewTokens, inputTokens1, samplingConfig, true);
     kvCacheManager.addSequence(1, inputTokens1->size(), beamWidth, llmRequest1);
+    llmRequest1->setContextCurrentPosition(inputTokens1->size());
     kvCacheManager.storeContextBlocks(*llmRequest1);
 
     auto events = getEvents(kvCacheManager);
@@ -6555,3 +6569,765 @@ TEST_F(KVCacheManagerTest, KVCacheManagerEventStoreForDifferentWindowDoesNotFlus
         << "Stored(wFull) (pos=" << *storedFullPos << ") must precede Removed(wSWA) (pos=" << *removedSWAPos
         << "). The wFull store must not prematurely flush pending removes for wSWA.";
 }
+
+namespace
+{
+void testBlockManagerLinearAttention_ContextNoReuse(int beamWidth, int numTokens)
+{
+    auto constexpr numLayers = 12;
+    auto constexpr numKvHeads = 6;
+    auto constexpr sizePerHead = 128;
+    auto constexpr tokensPerBlock = 32;
+    auto constexpr blocksInPrimaryPool = 24;
+    auto constexpr blocksInSecondaryPool = 0;
+    auto constexpr maxNumSequences = 8;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto constexpr onboardBlocks = true;
+
+    auto maxAttentionWindow = numTokens * 2;
+    auto numBlocksPerBeam = tc::ceilDiv(numTokens, tokensPerBlock);
+    SizeType32 constexpr linearWindowSizeCode = LinearAttentionMetadata::LinearCacheType::kRecurrentStates;
+
+    LinearAttentionMetadata linearAttentionMetadata{
+        // .linearLayerIndices = {2, 5, 8, 11},
+        .cacheType = linearWindowSizeCode,
+        .allRecurrentStatesBytes = 440 * 1024, // dummy value
+        .statesSnapshotInterval = tokensPerBlock * 2,
+        .saveLastSnapshot = true,
+        .numPlaceholderBlocks = blocksInPrimaryPool * 100,
+    };
+
+    auto const blocksPerWindow = BlocksPerWindow{{maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}},
+        {linearWindowSizeCode, {blocksInPrimaryPool, blocksInSecondaryPool}}};
+
+    BlockManager blockManager(std::vector(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksPerWindow,
+        maxNumSequences, stream, maxAttentionWindow, beamWidth,
+        std::vector<BlockManager::SizeType32>{linearWindowSizeCode, maxAttentionWindow}, std::nullopt,
+        nvinfer1::DataType::kHALF, 0, onboardBlocks, CacheType::kSELF, std::nullopt, nullptr, false, true, nullptr,
+        std::nullopt, false, 128, 0, linearAttentionMetadata);
+    blockManager.allocatePools(false);
+
+    ASSERT_EQ(blockManager.getTokensPerBlock(), tokensPerBlock);
+    ASSERT_EQ(blockManager.getMaxNumBlocks(), blocksInPrimaryPool * 2);
+    ASSERT_EQ(blockManager.getNumFreeBlocks(), blocksInPrimaryPool * 2);
+
+    auto constexpr requestId = 42;
+
+    // reuse disabled: basic allocation
+    // use 1 + beamWidth blocks
+    GenerationRequest seq0{requestId, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};
+    blockManager.addSequence(seq0, numBlocksPerBeam, linearWindowSizeCode, /*isShareLastContextBlock=*/false);
+    blockManager.addSequence(seq0, numBlocksPerBeam, maxAttentionWindow, /*isShareLastContextBlock=*/false);
+    blockManager.holdSequence(seq0.getRequestId());
+    int numSharedBlocks = (numBlocksPerBeam > 1 && beamWidth == 1) ? 1 : 0;
+    int numUnsharedBlocks = beamWidth == 1 ? 0 : beamWidth;
+    auto occupiedBlocksLinear = numSharedBlocks + numUnsharedBlocks;
+    TLLM_LOG_DEBUG("==========================================================");
+    ASSERT_EQ(
+        blocksInPrimaryPool - blockManager.getNumFreeBlocksPerWindowSize()[linearWindowSizeCode], occupiedBlocksLinear);
+
+    auto const& ids1 = seq0.getCacheBlockIds(linearWindowSizeCode);
+    std::set<std::int32_t> idSetPositive{};
+    std::set<std::int32_t> idSetNegative{};
+    ASSERT_EQ(ids1.size(), beamWidth);
+    for (auto const& beam : ids1)
+    {
+        ASSERT_EQ(beam.size(), numBlocksPerBeam);
+        for (auto id : beam)
+        {
+            if (id >= 0)
+            {
+                idSetPositive.insert(id);
+            }
+            else
+            {
+                idSetNegative.insert(id);
+            }
+        }
+    }
+    ASSERT_EQ(idSetPositive.size(), occupiedBlocksLinear);
+    ASSERT_EQ(
+        idSetNegative.size(), numBlocksPerBeam - (beamWidth == 1 ? 0 : 1) /* unshared last block */ - numSharedBlocks);
+
+    blockManager.releaseBlocks(seq0);
+    ASSERT_EQ(blockManager.getNumFreeBlocksPerWindowSize()[linearWindowSizeCode], blocksInPrimaryPool);
+
+    TLLM_LOG_DEBUG("==========================================================");
+    // reuse disabled: all beams should be the same
+    // use 1 block
+    blockManager.addSequence(seq0, numBlocksPerBeam, linearWindowSizeCode, /*isShareLastContextBlock=*/true);
+    blockManager.addSequence(seq0, numBlocksPerBeam, maxAttentionWindow, /*isShareLastContextBlock=*/true);
+    ASSERT_EQ(blocksInPrimaryPool - blockManager.getNumFreeBlocksPerWindowSize()[linearWindowSizeCode], 1);
+    auto const& ids2 = seq0.getCacheBlockIds(linearWindowSizeCode);
+    ASSERT_EQ(ids2.size(), beamWidth);
+    for (std::size_t i = 0u; i < ids2.front().size(); ++i)
+    {
+        for (std::size_t beam = 1u; beam < ids2.size(); ++beam)
+        {
+            ASSERT_EQ(ids2.at(beam).at(i), ids2.at(0).at(i));
+        }
+    }
+    blockManager.releaseBlocks(seq0);
+    ASSERT_EQ(blocksInPrimaryPool - blockManager.getNumFreeBlocksPerWindowSize()[linearWindowSizeCode], 0);
+    TLLM_LOG_DEBUG("==========================================================");
+
+    // block burn out
+    size_t i = 0;
+    for (; i < blocksInPrimaryPool / occupiedBlocksLinear; ++i)
+    {
+        GenerationRequest seq{requestId + 1 + i, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};
+        ASSERT_NO_THROW(
+            blockManager.addSequence(seq, numBlocksPerBeam, linearWindowSizeCode, /*isShareLastContextBlock=*/false));
+    }
+    // no more blocks
+    GenerationRequest seq3{requestId + 1 + i, numTokens, beamWidth, blockManager.getWindowSizesMetadata()};
+    ASSERT_THROW(
+        blockManager.addSequence(seq3, numBlocksPerBeam, linearWindowSizeCode, /*isShareLastContextBlock=*/false),
+        std::runtime_error);
+}
+
+void testBlockManagerLinearAttention_ContextReuse(int beamWidth, int numTokens0, int numTokens1, int numReusedTokens)
+{
+    auto constexpr numLayers = 12;
+    auto constexpr numKvHeads = 6;
+    auto constexpr sizePerHead = 128;
+    auto constexpr tokensPerBlock = 32;
+    auto constexpr blocksInPrimaryPool = 48;
+    auto constexpr blocksInSecondaryPool = 0;
+    auto constexpr maxNumSequences = 8;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto constexpr onboardBlocks = true;
+
+    auto maxAttentionWindow = numTokens0 * 2;
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    bool constexpr isStreaming{false};
+    SizeType32 constexpr linearWindowSizeCode = LinearAttentionMetadata::LinearCacheType::kRecurrentStates;
+
+    LinearAttentionMetadata linearAttentionMetadata{
+        // .linearLayerIndices = {2, 5, 8, 11},
+        .cacheType = linearWindowSizeCode,
+        .allRecurrentStatesBytes = 440 * 1024, // dummy value
+        .statesSnapshotInterval = tokensPerBlock * 2,
+        .saveLastSnapshot = true,
+    };
+
+    auto const blocksPerWindow = BlocksPerWindow{{maxAttentionWindow, {blocksInPrimaryPool * 2, blocksInSecondaryPool}},
+        {linearWindowSizeCode, {blocksInPrimaryPool, blocksInSecondaryPool}}};
+
+    BlockManager blockManager(std::vector(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksPerWindow,
+        maxNumSequences, stream, maxAttentionWindow, beamWidth,
+        std::vector<BlockManager::SizeType32>{linearWindowSizeCode, maxAttentionWindow}, std::nullopt,
+        nvinfer1::DataType::kHALF, 0, onboardBlocks, CacheType::kSELF, std::nullopt, nullptr, false, true, nullptr,
+        std::nullopt, false, 128, 0, linearAttentionMetadata);
+    blockManager.allocatePools(false);
+
+    auto inputTokens0 = std::make_shared<VecTokens>();
+    for (int i = 0; i < numTokens0; ++i)
+    {
+        inputTokens0->push_back(i);
+    }
+    auto const inputLength = static_cast<SizeType32>(inputTokens0->size());
+    LlmRequest::RequestIdType requestId{0};
+    auto llmRequest0 = std::make_shared<LlmRequest>(requestId, numTokens0, inputTokens0, samplingConfig, isStreaming);
+
+    // reuse enabled: basic allocation
+    GenerationRequest seq0{requestId, numTokens0, beamWidth, blockManager.getWindowSizesMetadata()};
+    blockManager.addSequence(
+        seq0, numTokens0, tc::ceilDiv(numTokens0, tokensPerBlock), *llmRequest0, linearWindowSizeCode);
+    blockManager.addSequence(
+        seq0, numTokens0, tc::ceilDiv(numTokens0, tokensPerBlock), *llmRequest0, maxAttentionWindow);
+    blockManager.holdSequence(seq0.getRequestId());
+    ASSERT_EQ(llmRequest0->getContextCurrentPosition(), 0);
+    int regularSnapshots = numTokens0 / linearAttentionMetadata.statesSnapshotInterval;
+    int contextFinalState = (numTokens0 % tokensPerBlock != 0) ? beamWidth : 1;
+    int lastSnapshot // only exists when: 1. the current block is not a full block. 2. the current-1 block is not
+                     // multiple of statesSnapshotInterval.
+        = (numTokens0 / linearAttentionMetadata.statesSnapshotInterval * linearAttentionMetadata.statesSnapshotInterval
+              != numTokens0 / tokensPerBlock * tokensPerBlock)
+            && (numTokens0 % tokensPerBlock != 0)
+        ? 1
+        : 0;
+    auto occupiedBlocksLinear = regularSnapshots + contextFinalState + lastSnapshot;
+    auto totalBlocks = tc::ceilDiv(numTokens0, tokensPerBlock) + contextFinalState - 1;
+    auto placeholderBlocks = totalBlocks - occupiedBlocksLinear;
+    TLLM_LOG_DEBUG("==========================================================");
+    ASSERT_EQ(
+        blocksInPrimaryPool - blockManager.getNumFreeBlocksPerWindowSize()[linearWindowSizeCode], occupiedBlocksLinear);
+
+    auto ids0 = seq0.getCacheBlockIds(linearWindowSizeCode); // copy
+    std::set<std::int32_t> idSetPositive{};
+    std::set<std::int32_t> idSetNegative{};
+    ASSERT_EQ(ids0.size(), beamWidth);
+    for (auto const& beam : ids0)
+    {
+        ASSERT_EQ(beam.size(), tc::ceilDiv(numTokens0, tokensPerBlock));
+        for (auto id : beam)
+        {
+            if (id >= 0)
+            {
+                idSetPositive.insert(id);
+            }
+            else
+            {
+                idSetNegative.insert(id);
+            }
+        }
+    }
+    ASSERT_EQ(idSetPositive.size(), occupiedBlocksLinear);
+    ASSERT_EQ(idSetNegative.size(), placeholderBlocks);
+
+    // pretend the prefill is done
+    llmRequest0->setContextCurrentPosition(inputLength);
+    llmRequest0->setState(LlmRequestState::kGENERATION_IN_PROGRESS);
+    blockManager.storeContextBlocks(seq0, *llmRequest0);
+    blockManager.releaseBlocks(seq0);
+    ASSERT_EQ(blockManager.getNumFreeBlocksPerWindowSize()[linearWindowSizeCode], blocksInPrimaryPool);
+
+    auto inputTokensNoise = std::make_shared<VecTokens>();
+    for (int i = 0; i < numTokens1; ++i)
+    {
+        inputTokensNoise->push_back(10000 + i);
+    }
+    auto llmRequestNoise
+        = std::make_shared<LlmRequest>(9999, numTokens1, inputTokensNoise, samplingConfig, isStreaming);
+    GenerationRequest seqNoise{9999, numTokens1, beamWidth, blockManager.getWindowSizesMetadata()};
+    blockManager.addSequence(
+        seqNoise, numTokens1, tc::ceilDiv(numTokens1, tokensPerBlock), *llmRequestNoise, linearWindowSizeCode);
+    blockManager.addSequence(
+        seqNoise, numTokens1, tc::ceilDiv(numTokens1, tokensPerBlock), *llmRequestNoise, maxAttentionWindow);
+    blockManager.holdSequence(seqNoise.getRequestId());
+
+    auto inputTokens1 = std::make_shared<VecTokens>();
+    for (int i = 0; i < numReusedTokens; ++i)
+    {
+        inputTokens1->push_back(i);
+    }
+    for (int i = numReusedTokens; i < numTokens1; ++i)
+    {
+        inputTokens1->push_back(1000 + i);
+    }
+
+    auto llmRequest1 = std::make_shared<LlmRequest>(1, numTokens1, inputTokens1, samplingConfig, isStreaming);
+    GenerationRequest seq1{1, numTokens1, beamWidth, blockManager.getWindowSizesMetadata()};
+    blockManager.addSequence(
+        seq1, numTokens1, tc::ceilDiv(numTokens1, tokensPerBlock), *llmRequest1, linearWindowSizeCode);
+    blockManager.addSequence(
+        seq1, numTokens1, tc::ceilDiv(numTokens1, tokensPerBlock), *llmRequest1, maxAttentionWindow);
+
+    blockManager.holdSequence(seq1.getRequestId());
+
+    blockManager.storeContextBlocks(seq1, *llmRequest1);
+    int numReusedBlocks = numReusedTokens / tokensPerBlock;
+    for (; numReusedBlocks > 0; --numReusedBlocks)
+    {
+        if ((numReusedBlocks % (linearAttentionMetadata.statesSnapshotInterval / tokensPerBlock)
+                == 0)                                              // is a regular snapshot
+            || (numReusedBlocks == (numTokens0 / tokensPerBlock))) // is the last snapshot
+        {
+            break;
+        }
+    }
+    auto const& ids1 = seq1.getCacheBlockIds(linearWindowSizeCode);
+    for (int i = 0; i < numReusedBlocks; ++i)
+    {
+        for (int beam = 0; beam < beamWidth; ++beam)
+        {
+            if (ids0.at(beam).at(i) < 0 || ids1.at(beam).at(i) < 0)
+            {
+                continue;
+            }
+            ASSERT_EQ(ids1.at(beam).at(i), ids0.at(beam).at(i))
+                << "Block " << i << " should be reused for beam " << beam;
+        }
+    }
+
+    for (int i = numReusedBlocks; i < tc::ceilDiv(numTokens1, tokensPerBlock); ++i)
+    {
+        for (int beam = 0; beam < beamWidth; ++beam)
+        {
+            if (i >= ids0.at(beam).size() || ids0.at(beam).at(i) < 0 || ids1.at(beam).at(i) < 0)
+            {
+                continue;
+            }
+            ASSERT_NE(ids1.at(beam).at(i), ids0.at(beam).at(i))
+                << "Block " << i << " should NOT be reused for beam " << beam;
+        }
+    }
+
+    auto matchedLen = seq1.getCurrentPrepopulatedPromptLen();
+    ASSERT_EQ(matchedLen, numReusedBlocks * tokensPerBlock);
+}
+
+std::vector<std::vector<int>> getExpectedBlockIds(int beamWidth, int numTotalBlocks, int numContextBlocks,
+    int tokensPerBlock, bool enableContextReuse, int numContextTokens, int statesSnapshotInterval)
+{
+    std::vector<std::vector<int>> expectedBlockIds(beamWidth, std::vector<int>(numTotalBlocks, -1));
+    int blockId = -1;
+    int placeholderId = -1;
+    for (int blk = 0; blk < numTotalBlocks; ++blk)
+    {
+        bool shouldHaveMemory = false;
+        if (blk == numTotalBlocks - 1)
+        {
+            shouldHaveMemory = true;
+        }
+        else if (enableContextReuse && blk < numContextBlocks)
+        {
+            int blockEndTokenCount = (blk + 1) * tokensPerBlock;
+            shouldHaveMemory =
+                // regular snapshot
+                (blockEndTokenCount <= numContextTokens && blockEndTokenCount % statesSnapshotInterval == 0)
+                // last snapshot
+                || (blockEndTokenCount < numContextTokens && blockEndTokenCount + tokensPerBlock > numContextTokens);
+        }
+        else if (blk == numContextBlocks - 2 && beamWidth > 1)
+        {
+            // shouldHaveMemory = true;
+        }
+        bool sharedAmongBeams = (blk < numContextBlocks - 1) || (beamWidth == 1)
+            || (numContextTokens % tokensPerBlock == 0 && blk == numContextBlocks - 1);
+        if (!sharedAmongBeams && shouldHaveMemory)
+        {
+            for (int beam = 0; beam < beamWidth; ++beam)
+            {
+                expectedBlockIds[beam][blk] = ++blockId;
+            }
+        }
+        else
+        {
+            int id = shouldHaveMemory ? ++blockId : --placeholderId;
+            for (int beam = 0; beam < beamWidth; ++beam)
+            {
+                expectedBlockIds[beam][blk] = id;
+            }
+        }
+    }
+    return expectedBlockIds;
+}
+
+void testKVCacheManagerLinearAttention_DecodingBlockGrowth(
+    int beamWidth, int numContextTokens, int numGenerateTokens, bool enableContextReuse)
+{
+    auto constexpr numLayers = 12;
+    auto constexpr numKvHeads = 6;
+    auto constexpr sizePerHead = 128;
+    auto constexpr tokensPerBlock = 32;
+    auto constexpr blocksInPrimaryPool = 24;
+    auto constexpr blocksInSecondaryPool = 0;
+    auto constexpr maxNumSequences = 8;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto constexpr onboardBlocks = true;
+
+    auto constexpr batchSize = 1;
+    auto constexpr maxBlocksPerSeq = 10;
+    auto constexpr bytesPerToken = 4;
+    auto constexpr sinkTokenLen = 0;
+    auto constexpr canUseOneMoreBlock = true;
+
+    SizeType32 constexpr maxNewTokens{0};
+    auto constexpr beamIdx = 0;
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    bool constexpr isStreaming{false};
+
+    auto maxAttentionWindow = numContextTokens + numGenerateTokens + sinkTokenLen + 1;
+    SizeType32 constexpr linearWindowSizeCode = LinearAttentionMetadata::LinearCacheType::kRecurrentStates;
+
+    LinearAttentionMetadata linearAttentionMetadata{
+        // .linearLayerIndices = {2, 5, 8, 11},
+        .cacheType = linearWindowSizeCode,
+        .allRecurrentStatesBytes = 440 * 1024, // dummy value
+        .statesSnapshotInterval = tokensPerBlock * 2,
+        .saveLastSnapshot = true,
+        .numPlaceholderBlocks = blocksInPrimaryPool * 100,
+    };
+    auto const blocksPerWindow = BlocksPerWindow{{maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}},
+        {linearWindowSizeCode, {blocksInPrimaryPool, blocksInSecondaryPool}}};
+    KVCacheManager kvCacheManager(numLayers, numKvHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
+        beamWidth, std::vector<BlockManager::SizeType32>{linearWindowSizeCode},
+        /*blockSpanToWindowSize*/ std::nullopt,
+        /*primaryPoolDataType*/ nvinfer1::DataType::kHALF,
+        /*sinkTokenLen*/ sinkTokenLen,
+        /*stream*/ stream,
+        /*maxSequenceLength*/ maxAttentionWindow,
+        /*enableBlockReuse*/ enableContextReuse,
+        /*onboardBlocks*/ onboardBlocks,
+        /*cacheType*/ CacheType::kSELF,
+        /*secondaryOffloadMinPriority*/ std::nullopt,
+        /*eventManager*/ nullptr,
+        /*enablePartialReuse*/ false,
+        /*copyOnPartialReuse*/ true,
+        /*kvCacheConnectorManager*/ nullptr,
+        /*enableIndexerKCache*/ false,
+        /*indexerKCacheQuantBlockSize*/ 128,
+        /*indexerKCacheIndexHeadDim*/ 0,
+        /*linearAttentionMetadata*/ linearAttentionMetadata);
+
+    auto inputTokens0 = std::make_shared<VecTokens>();
+    for (int i = 0; i < numContextTokens; ++i)
+    {
+        inputTokens0->push_back(i);
+    }
+    auto const inputLength = static_cast<SizeType32>(inputTokens0->size());
+    LlmRequest::RequestIdType requestId{0};
+    auto llmRequest0
+        = std::make_shared<LlmRequest>(requestId, numContextTokens, inputTokens0, samplingConfig, isStreaming);
+
+    // add context
+    kvCacheManager.addSequence(llmRequest0->mRequestId, numContextTokens, beamWidth, llmRequest0);
+
+    // check context blocks
+    auto numContextBlocks = tc::ceilDiv(numContextTokens, tokensPerBlock);
+    auto const blockIdsAfterContext = kvCacheManager.getCacheBlockIds(llmRequest0->mRequestId, linearWindowSizeCode);
+    auto expectedBlockIdsAfterContext = getExpectedBlockIds(beamWidth, numContextBlocks, numContextBlocks,
+        tokensPerBlock, enableContextReuse, numContextTokens, linearAttentionMetadata.statesSnapshotInterval);
+
+    for (int beam = 0; beam < beamWidth; ++beam)
+    {
+        for (int blk = 0; blk < numContextBlocks; ++blk)
+        {
+            ASSERT_EQ(blockIdsAfterContext[beam][blk], expectedBlockIdsAfterContext[beam][blk]);
+        }
+    }
+
+    // add generated tokens
+    for (int i = 0; i < numGenerateTokens; ++i)
+    {
+        kvCacheManager.addToken(llmRequest0->mRequestId);
+    }
+
+    // check all blocks
+    auto numTotalBlocks = tc::ceilDiv(numContextTokens + numGenerateTokens, tokensPerBlock);
+
+    auto const blockIds = kvCacheManager.getCacheBlockIds(llmRequest0->mRequestId, linearWindowSizeCode);
+    ASSERT_EQ(blockIds.size(), beamWidth);
+    for (auto const& beam : blockIds)
+    {
+        ASSERT_EQ(beam.size(), numTotalBlocks);
+    }
+
+    auto expectedBlockIds = getExpectedBlockIds(beamWidth, numTotalBlocks, numContextBlocks, tokensPerBlock,
+        enableContextReuse, numContextTokens, linearAttentionMetadata.statesSnapshotInterval);
+
+    for (int beam = 0; beam < beamWidth; ++beam)
+    {
+        for (int blk = 0; blk < numTotalBlocks; ++blk)
+        {
+            ASSERT_EQ(blockIds[beam][blk], expectedBlockIds[beam][blk]);
+        }
+    }
+}
+
+void testKVCacheManagerLinearAttention_BlockCopying(
+    int beamWidth, int numContextTokens, int numGenerateTokens, bool enableContextReuse)
+{
+    auto constexpr numLayers = 12;
+    auto constexpr numKvHeads = 6;
+    auto constexpr sizePerHead = 128;
+    auto constexpr tokensPerBlock = 32;
+    auto constexpr blocksInPrimaryPool = 30;
+    auto constexpr blocksInSecondaryPool = 0;
+    auto constexpr maxNumSequences = 8;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto constexpr onboardBlocks = true;
+
+    auto constexpr batchSize = 1;
+    auto constexpr maxBlocksPerSeq = 10;
+    auto constexpr bytesPerToken = 4;
+    auto constexpr sinkTokenLen = 0;
+    auto constexpr canUseOneMoreBlock = true;
+
+    SizeType32 constexpr maxNewTokens{0};
+    auto constexpr beamIdx = 0;
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    bool constexpr isStreaming{false};
+
+    auto maxAttentionWindow = numContextTokens + numGenerateTokens + sinkTokenLen + 1;
+    SizeType32 constexpr linearWindowSizeCode = LinearAttentionMetadata::LinearCacheType::kRecurrentStates;
+
+    LinearAttentionMetadata linearAttentionMetadata{
+        // .linearLayerIndices = {2, 5, 8, 11},
+        .cacheType = linearWindowSizeCode,
+        .allRecurrentStatesBytes = 440 * 1024, // dummy value
+        .statesSnapshotInterval = tokensPerBlock * 2,
+        .saveLastSnapshot = true,
+        .numPlaceholderBlocks = blocksInPrimaryPool * 100,
+    };
+    auto const blocksPerWindow = BlocksPerWindow{{maxAttentionWindow, {blocksInPrimaryPool, blocksInSecondaryPool}},
+        {linearWindowSizeCode, {blocksInPrimaryPool, blocksInSecondaryPool}}};
+    KVCacheManager kvCacheManager(numLayers, numKvHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
+        beamWidth, std::vector<BlockManager::SizeType32>{linearWindowSizeCode, maxAttentionWindow}, std::nullopt,
+        nvinfer1::DataType::kHALF, sinkTokenLen, stream, maxAttentionWindow, enableContextReuse, onboardBlocks,
+        CacheType::kSELF, std::nullopt, nullptr, false, true, nullptr, false, 128, 0, linearAttentionMetadata);
+    kvCacheManager.allocatePools(false);
+
+    char* poolBaseAddr
+        = reinterpret_cast<char*>(kvCacheManager.getBlockManager().getRecurrentStatesPool().primaryPtr->data());
+    // memory layout of the pool: [numLayers, blocksInPrimaryPool, 1 (kvFactor), sizePerBlock]
+    size_t const strideBlockId = linearAttentionMetadata.allRecurrentStatesBytes;
+    std::unique_ptr<char[]> hostBuffer(new char[strideBlockId]);
+
+    auto inputTokens0 = std::make_shared<VecTokens>();
+    for (int i = 0; i < numContextTokens; ++i)
+    {
+        inputTokens0->push_back(i);
+    }
+    auto llmRequest0
+        = std::shared_ptr<LlmRequest>(new LlmRequest(0, numContextTokens, inputTokens0, samplingConfig, isStreaming));
+    llmRequest0->setContextChunkSize(linearAttentionMetadata.statesSnapshotInterval);
+    // add context
+    kvCacheManager.addSequence(llmRequest0->mRequestId, numContextTokens, beamWidth, llmRequest0);
+
+    auto const numContextBlocks = tc::ceilDiv(numContextTokens, tokensPerBlock);
+    auto expectedBlockIds = getExpectedBlockIds(beamWidth, numContextBlocks, numContextBlocks, tokensPerBlock,
+        enableContextReuse, numContextTokens, linearAttentionMetadata.statesSnapshotInterval);
+
+    // verify block offsets
+    // {numPools, maxNumSequences * beamWidth, 2(k&v), maxBlocksPerSeq}
+    tr::ITensor::SharedPtr const kvCacheBlockOffsets = tr::BufferManager::cpu(
+        tr::ITensor::makeShape({kvCacheManager.getNumPools(), maxNumSequences * beamWidth, 2, maxBlocksPerSeq}),
+        tr::TRTDataType<tk::KVCacheIndex>::value);
+    int const linearPoolIdx = kvCacheManager.getPoolLayerIdx(0); // layer 0 is the linear layer
+    kvCacheManager.copyBlockOffsets(*kvCacheBlockOffsets, 0, llmRequest0->mRequestId);
+
+    // slice since we only have 1 request
+    auto blockOffsetsSlice = tr::ITensor::slice(
+        tr::ITensor::at(kvCacheBlockOffsets, {linearPoolIdx}), 0, beamWidth); // {beamWidth, 2(k&v), maxBlocksPerSeq}
+
+    auto blockOffsetsShape = blockOffsetsSlice->getShape();
+    auto* const blockOffsetsPtr = tr::bufferCast<tk::KVCacheIndex>(*blockOffsetsSlice);
+
+    auto blockIds = kvCacheManager.getCacheBlockIds(llmRequest0->mRequestId, linearWindowSizeCode);
+    for (int beam = 0; beam < beamWidth; ++beam)
+    {
+        for (int blk = 0; blk < numContextBlocks; ++blk)
+        {
+            auto blockId = blockIds[beam][blk];
+            auto blockOffsetK = blockOffsetsPtr[tc::flat_index(blockOffsetsShape.d, beam, 0, blk)].get();
+            auto blockOffsetV = blockOffsetsPtr[tc::flat_index(blockOffsetsShape.d, beam, 1, blk)].get();
+            void* addrK = poolBaseAddr + blockOffsetK * linearAttentionMetadata.allRecurrentStatesBytes;
+            void* addrV = poolBaseAddr + blockOffsetV * linearAttentionMetadata.allRecurrentStatesBytes;
+            ASSERT_EQ(blockId, expectedBlockIds[beam][blk]);
+            ASSERT_EQ(blockOffsetK, blockOffsetV);
+            if (blockId < 0)
+            {
+                ASSERT_EQ(blockOffsetK, tensorrt_llm::kernels::KVCacheIndex::nullIndex.get());
+            }
+            else
+            {
+                // blockId should equal to mempool index before any offloading/reusing happens
+                ASSERT_EQ(blockOffsetK, blockId);
+            }
+        }
+    }
+
+    std::vector<int> contextPositionPerStep;
+    for (int blk = 0; blk < numContextBlocks; ++blk)
+    {
+        if (expectedBlockIds[0][blk] >= 0)
+        {
+            contextPositionPerStep.push_back(std::min((blk + 1) * tokensPerBlock, numContextTokens));
+        }
+    }
+
+    // initialize the pool with all zeros
+    auto ret = cudaMemset(poolBaseAddr, 0,
+        strideBlockId * numLayers / 2 * blocksInPrimaryPool); // half of the layers are linear attention
+    ASSERT_EQ(ret, cudaSuccess);
+    std::vector<int> expectedValuesAfterContext(beamWidth, 0);
+    for (int step = 0; step < contextPositionPerStep.size(); ++step)
+    {
+        int contextPosition = contextPositionPerStep[step];
+        // called before every forward step
+        kvCacheManager.copyLinearAttentionBlock(*llmRequest0);
+        cudaDeviceSynchronize();
+        int blockIndex = tc::ceilDiv(contextPosition, tokensPerBlock) - 1;
+        bool shareAmongBeams = beamWidth > 1 && expectedBlockIds[0][blockIndex] == expectedBlockIds[1][blockIndex];
+        for (int beam = 0; beam < beamWidth; ++beam)
+        {
+            size_t byteOffset = blockOffsetsPtr[tc::flat_index(blockOffsetsShape.d, beam, 0, blockIndex)].get()
+                * linearAttentionMetadata.allRecurrentStatesBytes;
+            ret = cudaMemcpy(hostBuffer.get(), poolBaseAddr + byteOffset, strideBlockId, cudaMemcpyDeviceToHost);
+            ASSERT_EQ(ret, cudaSuccess);
+            uint64_t val = static_cast<uint64_t>(expectedValuesAfterContext[beam]);
+            uint64_t expected
+                = val | (val << 8) | (val << 16) | (val << 24) | (val << 32) | (val << 40) | (val << 48) | (val << 56);
+            for (int i = 0; i < strideBlockId / sizeof(uint64_t); ++i)
+            {
+                ASSERT_EQ(reinterpret_cast<uint64_t*>(hostBuffer.get())[i], expected) << "i=" << i;
+            }
+
+            expectedValuesAfterContext[beam] = (shareAmongBeams ? 0 : beam) * 16 + step;
+            if (shareAmongBeams)
+            {
+                for (int b = 0; b < beamWidth; ++b)
+                {
+                    expectedValuesAfterContext[b] = expectedValuesAfterContext[beam];
+                }
+            }
+            ret = cudaMemset(poolBaseAddr + byteOffset, expectedValuesAfterContext[beam], strideBlockId);
+            ASSERT_EQ(ret, cudaSuccess);
+        }
+        // call the api
+        llmRequest0->setContextCurrentPosition(contextPosition);
+    }
+
+    kvCacheManager.storeContextBlocks(*llmRequest0);
+
+    llmRequest0->setState(LlmRequestState::kGENERATION_IN_PROGRESS);
+    std::vector<size_t> byteOffsetsPerBeam(beamWidth);
+    for (int genStep = 0; genStep < numGenerateTokens; ++genStep)
+    {
+        kvCacheManager.addToken(llmRequest0->mRequestId);
+        llmRequest0->addNewTokens(std::vector<TokenIdType>(beamWidth, genStep + numContextTokens));
+        kvCacheManager.copyLinearAttentionBlock(*llmRequest0);
+        cudaDeviceSynchronize();
+        // retrieve latest block info
+        kvCacheManager.copyBlockOffsets(*kvCacheBlockOffsets, 0, llmRequest0->mRequestId);
+        auto blockIds = kvCacheManager.getCacheBlockIds(llmRequest0->mRequestId, linearWindowSizeCode);
+        for (int beam = 0; beam < beamWidth; ++beam)
+        {
+            auto const blockOffset
+                = blockOffsetsPtr[tc::flat_index(blockOffsetsShape.d, beam, 0, blockIds[beam].size() - 1)].get();
+            size_t byteOffset = blockOffset * linearAttentionMetadata.allRecurrentStatesBytes;
+            if (genStep < 2)
+            {
+                ret = cudaMemcpy(hostBuffer.get(), poolBaseAddr + byteOffset, strideBlockId, cudaMemcpyDeviceToHost);
+                ASSERT_EQ(ret, cudaSuccess);
+                uint64_t val = static_cast<uint64_t>(expectedValuesAfterContext[beam]);
+                uint64_t expected = val | (val << 8) | (val << 16) | (val << 24) | (val << 32) | (val << 40)
+                    | (val << 48) | (val << 56);
+                for (int i = 0; i < strideBlockId / sizeof(uint64_t); ++i)
+                {
+                    ASSERT_EQ(reinterpret_cast<uint64_t*>(hostBuffer.get())[i], expected);
+                }
+            }
+            if (byteOffsetsPerBeam[beam] == 0)
+            {
+                byteOffsetsPerBeam[beam] = byteOffset;
+            }
+            else
+            {
+                // verify that the block address does not change
+                ASSERT_EQ(byteOffset, byteOffsetsPerBeam[beam]);
+            }
+            if (genStep == 0)
+            {
+                expectedValuesAfterContext[beam] = beam * 16;
+                ret = cudaMemset(poolBaseAddr + byteOffset, expectedValuesAfterContext[beam], strideBlockId);
+                ASSERT_EQ(ret, cudaSuccess);
+            }
+        }
+    }
+}
+} // namespace
+
+class LinearAttentionContextNoReuseTest : public ::testing::TestWithParam<std::tuple<int, int>>
+{
+protected:
+    void SetUp() override
+    {
+        if (tc::getDeviceCount() == 0)
+        {
+            GTEST_SKIP();
+        }
+    }
+
+    void TearDown() override {}
+};
+
+TEST_P(LinearAttentionContextNoReuseTest, ContextNoReuse)
+{
+    auto const& [beamWidth, numTokens] = GetParam();
+    testBlockManagerLinearAttention_ContextNoReuse(beamWidth, numTokens);
+}
+
+INSTANTIATE_TEST_SUITE_P(BlockManagerLinearAttention, LinearAttentionContextNoReuseTest,
+    testing::Values(std::make_tuple(4, 10), // basic test
+        std::make_tuple(8, 96),             // edge cases: numTokens % tokensPerBlock == 0
+        std::make_tuple(1, 97)              // beamWidth = 1
+        ));
+
+class LinearAttentionContextReuseTest : public ::testing::TestWithParam<std::tuple<int, int, int, int>>
+{
+protected:
+    void SetUp() override
+    {
+        if (tc::getDeviceCount() == 0)
+        {
+            GTEST_SKIP();
+        }
+    }
+
+    void TearDown() override {}
+};
+
+TEST_P(LinearAttentionContextReuseTest, ContextReuse)
+{
+    auto const& [beamWidth, numTokens0, numTokens1, numReusedTokens] = GetParam();
+    testBlockManagerLinearAttention_ContextReuse(beamWidth, numTokens0, numTokens1, numReusedTokens);
+}
+
+INSTANTIATE_TEST_SUITE_P(BlockManagerLinearAttention, LinearAttentionContextReuseTest,
+    testing::Values(std::make_tuple(4, 10, 135, 10), // no applicable reuse: seq0 is too short (< tokensPerBlock)
+        std::make_tuple(4, 96, 135, 37),             // numTokens0 % tokensPerBlock == 0, seq1 is too short (< interval)
+        std::make_tuple(4, 96, 135, 64),             // reuse on a regular snapshot
+        std::make_tuple(4, 97, 135, 96),             // reuse on the last snapshot
+        std::make_tuple(1, 97, 135, 97),             // beamWidth = 1, reuse on the last snapshot
+        std::make_tuple(4, 130, 135, 101)            // normal case
+        ));
+
+class LinearAttentionDecodingBlockGrowthTest : public ::testing::TestWithParam<std::tuple<int, int, int, bool>>
+{
+protected:
+    void SetUp() override
+    {
+        if (tc::getDeviceCount() == 0)
+        {
+            GTEST_SKIP();
+        }
+    }
+
+    void TearDown() override {}
+};
+
+TEST_P(LinearAttentionDecodingBlockGrowthTest, DecodingBlockGrowth)
+{
+    auto const& [beamWidth, numContextTokens, numGenerateTokens, enableContextReuse] = GetParam();
+    testKVCacheManagerLinearAttention_DecodingBlockGrowth(
+        beamWidth, numContextTokens, numGenerateTokens, enableContextReuse);
+}
+
+INSTANTIATE_TEST_SUITE_P(BlockManagerLinearAttention, LinearAttentionDecodingBlockGrowthTest,
+    testing::Values(
+        std::make_tuple(1, 100, 100, true), std::make_tuple(1, 100, 100, false), // normal case beamWidth = 1
+        std::make_tuple(4, 100, 100, true), std::make_tuple(4, 100, 100, false), // normal case beamWidth > 1
+        std::make_tuple(4, 96, 100, true),
+        std::make_tuple(4, 96, 100, false) // edge cases: numContextTokens % tokensPerBlock == 0 and beamWidth > 1
+        ));
+
+class LinearAttentionBlockCopyingTest : public ::testing::TestWithParam<std::tuple<int, int, int>>
+{
+protected:
+    void SetUp() override
+    {
+        if (tc::getDeviceCount() == 0)
+        {
+            GTEST_SKIP();
+        }
+    }
+
+    void TearDown() override {}
+};
+
+TEST_P(LinearAttentionBlockCopyingTest, BlockCopying)
+{
+    auto const& [beamWidth, numContextTokens, numGenerateTokens] = GetParam();
+    testKVCacheManagerLinearAttention_BlockCopying(
+        beamWidth, numContextTokens, numGenerateTokens, /*enableContextReuse=*/true);
+}
+
+INSTANTIATE_TEST_SUITE_P(BlockManagerLinearAttention, LinearAttentionBlockCopyingTest,
+    testing::Values(std::make_tuple(1, 100, 35), // normal case beamWidth = 1
+        std::make_tuple(4, 96, 35),              // edge cases: numContextTokens % tokensPerBlock == 0 and beamWidth > 1
+        std::make_tuple(4, 97, 35)               // normal case beamWidth > 1
+        ));

--- a/cpp/tests/unit_tests/batch_manager/radixBlockTreeTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/radixBlockTreeTest.cpp
@@ -534,7 +534,7 @@ TEST(MambaTest, kRecurrentStatesSentinelIsNegative)
 
 TEST(MambaTest, CreatePlaceholderIsPlaceholder)
 {
-    auto ph = KVCacheBlock::createPlaceholder(42);
+    auto ph = KVCacheBlock::createPlaceholder(42, 100);
     ASSERT_NE(ph, nullptr);
     EXPECT_TRUE(ph->isPlaceholder());
     EXPECT_EQ(ph->getBlockId(), 42);

--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -13,6 +13,7 @@ The following is a table of supported models for the PyTorch backend:
 | `Exaone4ForCausalLM`                 | EXAONE 4.0                         | `LGAI-EXAONE/EXAONE-4.0-32B`                 |
 | `ExaoneMoEForCausalLM`               | K-EXAONE                           | `LGAI-EXAONE/K-EXAONE-236B-A23B`             |
 | `Gemma3ForCausalLM`                  | Gemma 3                            | `google/gemma-3-1b-it`                       |
+| `Gemma4ForConditionalGeneration` [^7]| Gemma 4                            | `google/gemma-4-26B-A4B-it`                  |
 | `Glm4MoeForCausalLM`                 | GLM-4.5, GLM-4.6, GLM-4.7          | `THUDM/GLM-4-100B-A10B`                      |
 | `Glm4MoeLiteForCausalLM` [^6]        | GLM-4.7-Flash                      | `zai-org/GLM-4.7-Flash`                      |
 | `GlmMoeDsaForCausalLM`               | GLM-5                              | `zai-org/GLM-5`                              |
@@ -60,6 +61,7 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 [^4]: Overlap scheduler isn't supported when using EAGLE-3(Two Model Engine) for GPT-OSS.
 [^5]: Supported via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD config](../../../examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml).
 [^6]: Supported via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD config](../../../examples/auto_deploy/model_registry/configs/glm-4.7-flash.yaml).
+[^7]: Text-only support via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD config](../../../examples/auto_deploy/model_registry/configs/gemma4_moe.yaml).
 
 
 # Multimodal Feature Support Matrix (PyTorch Backend)

--- a/examples/auto_deploy/cookbooks/gemma_4_trtllm_cookbook.ipynb
+++ b/examples/auto_deploy/cookbooks/gemma_4_trtllm_cookbook.ipynb
@@ -1,0 +1,299 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Deploying Gemma 4 MoE with TensorRT-LLM (AutoDeploy)\n",
+        "\n",
+        "This notebook walks you through serving **Gemma 4** (26B total, 4B activated MoE) with TensorRT-LLM using the **AutoDeploy** backend—same pattern as the Mistral Small 4 and GLM-4.7-Flash cookbooks in this folder.\n",
+        "\n",
+        "[TensorRT-LLM](https://nvidia.github.io/TensorRT-LLM/) is NVIDIA's open-source library for accelerating LLM inference on NVIDIA GPUs. AutoDeploy uses Hugging Face `transformers` modeling code and TensorRT-LLM graph transforms. See the [AutoDeploy guide](https://nvidia.github.io/TensorRT-LLM/torch/auto_deploy/auto-deploy.html).\n",
+        "\n",
+        "**Model resources:**\n",
+        "- [Gemma 4 collection (Hugging Face)](https://huggingface.co/collections/google/gemma-4)\n",
+        "- Instruction-tuned MoE: [`google/gemma-4-26B-A4B-it`](https://huggingface.co/google/gemma-4-26B-A4B-it)\n",
+        "- Base MoE (no chat template): [`google/gemma-4-26B-A4B`](https://huggingface.co/google/gemma-4-26B-A4B)\n",
+        "\n",
+        "**Bundled AutoDeploy YAML (this branch):**\n",
+        "- **Instruction:** `examples/auto_deploy/model_registry/configs/gemma4_moe.yaml` — text-only export path; `attn_backend: triton_paged` (head_dim 512 / paged KV, CUDA-graph friendly).\n",
+        "- **Base:** `examples/auto_deploy/model_registry/configs/gemma4_moe_base.yaml` — same stack for the base checkpoint.\n",
+        "\n",
+        "`trtllm-serve` takes **one** YAML path via `--extra_llm_api_options` (or `--config`). The bundled MoE YAMLs omit `world_size`; add it (or copy the YAML and edit) so it matches your GPU count when you use tensor parallel or multi-GPU loading.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Prerequisites and environment\n",
+        "\n",
+        "Run TensorRT-LLM in a GPU container, for example:\n",
+        "\n",
+        "```shell\n",
+        "docker run --rm -it --ipc=host --ulimit memlock=-1 --ulimit stack=67108864 --gpus=all -p 8000:8000 nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc1\n",
+        "```\n",
+        "\n",
+        "Use a TensorRT-LLM checkout that includes Gemma 4 AutoDeploy support (model card, tokenizer, and any required bridges should match your branch).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# If pip is not available\n",
+        "!python -m ensurepip --default-pip"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install torch openai"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Verify GPU\n",
+        "\n",
+        "Confirm CUDA and visible devices before starting the server.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Python: 3.12.3 (main, Jan 22 2026, 20:57:42) [GCC 13.3.0]\n",
+            "CUDA available: True\n",
+            "Num GPUs: 8\n",
+            "GPU[0]: NVIDIA H100 80GB HBM3\n",
+            "GPU[1]: NVIDIA H100 80GB HBM3\n",
+            "GPU[2]: NVIDIA H100 80GB HBM3\n",
+            "GPU[3]: NVIDIA H100 80GB HBM3\n",
+            "GPU[4]: NVIDIA H100 80GB HBM3\n",
+            "GPU[5]: NVIDIA H100 80GB HBM3\n",
+            "GPU[6]: NVIDIA H100 80GB HBM3\n",
+            "GPU[7]: NVIDIA H100 80GB HBM3\n"
+          ]
+        }
+      ],
+      "source": [
+        "import sys\n",
+        "\n",
+        "import torch\n",
+        "\n",
+        "print(f\"Python: {sys.version}\")\n",
+        "print(f\"CUDA available: {torch.cuda.is_available()}\")\n",
+        "print(f\"Num GPUs: {torch.cuda.device_count()}\")\n",
+        "\n",
+        "if torch.cuda.is_available():\n",
+        "    for i in range(torch.cuda.device_count()):\n",
+        "        print(f\"GPU[{i}]: {torch.cuda.get_device_name(i)}\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## OpenAI-compatible server\n",
+        "\n",
+        "From a shell **inside** the container, at the TensorRT-LLM repo root, start `trtllm-serve` with AutoDeploy.\n",
+        "\n",
+        "Use the Gemma 4 MoE YAML under `examples/auto_deploy/model_registry/configs/` (see the introduction). Add `world_size` to that YAML if your serve command needs an explicit tensor-parallel device count.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Load the model\n",
+        "\n",
+        "**Instruction-tuned (`gemma4_moe.yaml`):**\n",
+        "\n",
+        "```shell\n",
+        "trtllm-serve \"google/gemma-4-26B-A4B-it\" \\\n",
+        "  --host 0.0.0.0 \\\n",
+        "  --port 8000 \\\n",
+        "  --backend _autodeploy \\\n",
+        "  --trust_remote_code \\\n",
+        "  --extra_llm_api_options examples/auto_deploy/model_registry/configs/gemma4_moe.yaml\n",
+        "```\n",
+        "\n",
+        "**Base checkpoint:** use model id `google/gemma-4-26B-A4B` and `examples/auto_deploy/model_registry/configs/gemma4_moe_base.yaml` instead.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "When the server finishes loading weights, it is ready for requests.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Use the API\n",
+        "\n",
+        "Send chat completions with the OpenAI Python client pointed at the local server.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from openai import OpenAI\n",
+        "\n",
+        "BASE_URL = \"http://0.0.0.0:8000/v1\"\n",
+        "API_KEY = \"null\"\n",
+        "MODEL_ID = \"google/gemma-4-26B-A4B-it\"\n",
+        "\n",
+        "client = OpenAI(base_url=BASE_URL, api_key=API_KEY)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 3,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Chat completion example\n",
+            "==================================================\n",
+            "Response:\n",
+            "To find 15% of 85, you can use a few different methods. Here are two easy ways to think about it:\n",
+            "\n",
+            "### Method 1: The Breakdown Method (Mental Math)\n",
+            "This is often the easiest way to calculate percentages in your head by breaking the percentage into manageable parts (10% and 5%).\n",
+            "\n",
+            "1.  **Find 10% of 85:**\n",
+            "    To find 10%, simply move the decimal point one place to the left.\n",
+            "    $85 \\div 10 = 8.5$\n",
+            "2.  **Find 5% of 85:**\n",
+            "    Since 5% is half of 10%, just divide your previous answer by 2.\n",
+            "    $8.5 \\div 2 = 4.25$\n",
+            "3.  **Add them together:**\n",
+            "    $10\\% + 5\\% = 15\\%$\n",
+            "    $8.5 + 4.25 = 12.75$\n",
+            "\n",
+            "***\n",
+            "\n",
+            "### Method 2: The Multiplication Method (Calculator/Paper)\n",
+            "To find a percentage, you can convert the percentage into a decimal and multiply it by the total number.\n",
+            "\n",
+            "1.  **Convert 15% to a decimal:**\n",
+            "    $15\\% = \\frac{15}{100} = 0.15$\n",
+            "2.  **Multiply by 85:**\n",
+            "    $85 \\times 0.15 = 12.75$\n",
+            "\n",
+            "**Final Answer:**\n",
+            "15% of 85 is **12.75**.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Basic chat completion\n",
+        "print(\"Chat completion example\")\n",
+        "print(\"=\" * 50)\n",
+        "\n",
+        "response = client.chat.completions.create(\n",
+        "    model=MODEL_ID,\n",
+        "    messages=[\n",
+        "        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
+        "        {\"role\": \"user\", \"content\": \"What is 15% of 85? Show your reasoning.\"},\n",
+        "    ],\n",
+        "    temperature=1.0,\n",
+        "    top_p=0.95,\n",
+        "    max_tokens=512,\n",
+        ")\n",
+        "\n",
+        "print(\"Response:\")\n",
+        "print(response.choices[0].message.content)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Streaming response:\n",
+            "==================================================\n",
+            "The first 5 prime numbers are **2, 3, 5, 7, and 11**."
+          ]
+        }
+      ],
+      "source": [
+        "# Streaming chat completion\n",
+        "print(\"Streaming response:\")\n",
+        "print(\"=\" * 50)\n",
+        "\n",
+        "stream = client.chat.completions.create(\n",
+        "    model=MODEL_ID,\n",
+        "    messages=[\n",
+        "        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n",
+        "        {\"role\": \"user\", \"content\": \"What are the first 5 prime numbers?\"},\n",
+        "    ],\n",
+        "    temperature=0.7,\n",
+        "    max_tokens=1024,\n",
+        "    stream=True,\n",
+        ")\n",
+        "\n",
+        "for chunk in stream:\n",
+        "    if chunk.choices[0].delta.content:\n",
+        "        print(chunk.choices[0].delta.content, end=\"\", flush=True)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Additional resources\n",
+        "\n",
+        "- [Gemma 4 collection (Hugging Face)](https://huggingface.co/collections/google/gemma-4)\n",
+        "- [TensorRT-LLM documentation](https://nvidia.github.io/TensorRT-LLM/)\n",
+        "- [AutoDeploy guide](https://nvidia.github.io/TensorRT-LLM/torch/auto_deploy/auto-deploy.html)\n",
+        "- [`gemma4_moe.yaml`](../model_registry/configs/gemma4_moe.yaml), [`gemma4_moe_base.yaml`](../model_registry/configs/gemma4_moe_base.yaml), [`models.yaml`](../model_registry/models.yaml)\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/examples/auto_deploy/model_registry/configs/gemma3n_e2b_it.yaml
+++ b/examples/auto_deploy/model_registry/configs/gemma3n_e2b_it.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+runtime: trtllm
+compile_backend: torch-cudagraph
+model_factory: AutoModelForCausalLM
+max_seq_len: 512
+world_size: 1
+
+# Gemma 3n uses shared-KV decode semantics in the tail layers. FlashInfer
+# supports the read-only shared-KV cache path and alternating sliding windows.
+attn_backend: flashinfer

--- a/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
+++ b/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
@@ -5,5 +5,5 @@
 # Uses triton paged attention backend: supports head_dim=512 (global_head_dim),
 # paged KV cache, CUDA-graph-compatible, FlashDecoding for decode.
 model_factory: Gemma4ForConditionalGeneration
-tokenizer: google/gemma-4-31B-it
+tokenizer: google/gemma-4-26B-A4B-it
 attn_backend: triton_paged

--- a/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
+++ b/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
@@ -4,4 +4,6 @@
 # Gemma 4 MoE (26B total, 4B activated) — text-only AD export path.
 # Uses triton paged attention backend: supports head_dim=512 (global_head_dim),
 # paged KV cache, CUDA-graph-compatible, FlashDecoding for decode.
+model_factory: Gemma4ForConditionalGeneration
+tokenizer: google/gemma-4-31B-it
 attn_backend: triton_paged

--- a/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
+++ b/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Gemma 4 MoE (26B total, 4B activated) — text-only AD export path.
+# Uses triton paged attention backend: supports head_dim=512 (global_head_dim),
+# paged KV cache, CUDA-graph-compatible, FlashDecoding for decode.
+attn_backend: triton_paged

--- a/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
+++ b/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
@@ -7,3 +7,15 @@
 model_factory: Gemma4ForConditionalGeneration
 tokenizer: google/gemma-4-26B-A4B-it
 attn_backend: triton_paged
+compile_backend: torch-cudagraph
+cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+max_num_tokens: 8192
+max_batch_size: 512
+max_seq_len: 8192
+enable_chunked_prefill: true
+kv_cache_config:
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.8
+transforms:
+  compile_model:
+    piecewise_enabled: true

--- a/examples/auto_deploy/model_registry/configs/gemma4_moe_base.yaml
+++ b/examples/auto_deploy/model_registry/configs/gemma4_moe_base.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Gemma 4 MoE base (26B total, 4B activated) — text-only AD export path.
+# Uses triton paged attention backend: supports head_dim=512 (global_head_dim),
+# paged KV cache, CUDA-graph-compatible, FlashDecoding for decode.
+model_factory: Gemma4ForConditionalGeneration
+tokenizer: google/gemma-4-26B-A4B
+attn_backend: triton_paged

--- a/examples/auto_deploy/model_registry/configs/gemma4_moe_base.yaml
+++ b/examples/auto_deploy/model_registry/configs/gemma4_moe_base.yaml
@@ -7,3 +7,15 @@
 model_factory: Gemma4ForConditionalGeneration
 tokenizer: google/gemma-4-26B-A4B
 attn_backend: triton_paged
+compile_backend: torch-cudagraph
+cuda_graph_batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+max_num_tokens: 8192
+max_batch_size: 512
+max_seq_len: 8192
+enable_chunked_prefill: true
+kv_cache_config:
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.8
+transforms:
+  compile_model:
+    piecewise_enabled: true

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -309,7 +309,7 @@ models:
 - name: google/gemma-3n-E4B-it
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'multimodal.yaml']
 # --- Gemma 4 (2026) - MoE with K=V attention ---
-- name: google/gemma-4-31B-it
+- name: google/gemma-4-26B-A4B-it
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'gemma4_moe.yaml']
 # --- JetBrains Mellum (Apr 2025) - code specialist ---
 - name: JetBrains/Mellum-4b-sft-all

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -309,6 +309,8 @@ models:
 - name: google/gemma-3n-E4B-it
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'multimodal.yaml']
 # --- Gemma 4 (2026) - MoE with K=V attention ---
+- name: google/gemma-4-26B-A4B
+  yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'gemma4_moe_base.yaml']
 - name: google/gemma-4-26B-A4B-it
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'gemma4_moe.yaml']
 # --- JetBrains Mellum (Apr 2025) - code specialist ---

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -308,6 +308,9 @@ models:
   yaml_extra: ['dashboard_default.yaml', 'world_size_1.yaml', 'multimodal.yaml']
 - name: google/gemma-3n-E4B-it
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'multimodal.yaml']
+# --- Gemma 4 (2026) - MoE with K=V attention ---
+- name: google/gemma-4-31B-it
+  yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'gemma4_moe.yaml']
 # --- JetBrains Mellum (Apr 2025) - code specialist ---
 - name: JetBrains/Mellum-4b-sft-all
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml']

--- a/security_scanning/metadata.json
+++ b/security_scanning/metadata.json
@@ -1,4 +1,4 @@
 {
-  "commit_hash": "59aa486048c4b757f0740b3ed1da8c641b6e72dd",
-  "timestamp": "2026-04-02T21:52:41Z"
+  "commit_hash": "b8c322515912f3e235607ca1356079a595b54d7e",
+  "timestamp": "2026-04-03T02:47:27Z"
 }

--- a/security_scanning/poetry.lock
+++ b/security_scanning/poetry.lock
@@ -3395,30 +3395,30 @@ nvidia-cublas = "*"
 
 [[package]]
 name = "nvidia-cudnn-frontend"
-version = "1.21.0"
+version = "1.22.0"
 description = "CUDNN FrontEnd python library"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "nvidia_cudnn_frontend-1.21.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23dddbdc42d01fbfbfffc8a79f8ac2c1c99cc84382a39d442c9fd44d38d119c5"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43938ddba2ce3e6be6e28f340dcc97edbe3e61b97847ba5ecc6d5cbdb9ea0dd2"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp310-cp310-win_amd64.whl", hash = "sha256:7a464a73f3d6cb7be268739237078c2677df96623d7c053c0fc89bbdc41132cd"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:301cc20fdc90936252c986d71feacf74981bc5cb4fa703e091d5c3550f3070fa"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:247a4c4d79f7c9243da01713189ee777a56142516df9d3702085fe4ace089ee2"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp311-cp311-win_amd64.whl", hash = "sha256:21a1a9663e307db0da1de6c9666972cf7f36bea0dc7d214a83a1379249747352"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22f8abb69124f2bc6750e7d7e8625680964cb61caab4c3aaee641d5ad295f37b"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ae3feffb22a9c90007fc54d27642e160dab750401ac5399589dd450e8d01780f"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp312-cp312-win_amd64.whl", hash = "sha256:3e5f28d29cef9a57568942ff66f6c8814a6815b369b3bf850bdcdd67c9cd41cd"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3153affbefad49dba1e8643dad59642b54f7d2724bf7286acc5830619ada5ba"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:69ad047e47580e76f3694d8e6c74c6d939ce2fff199145f3ea1e6a494c8ea84f"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp313-cp313-win_amd64.whl", hash = "sha256:2a787d4d44ecce7542fae4715630e3427ee4c1feda62069643c010b81e72aa35"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eee3f650d8573c39ae7add45881b2d80d1a1b540fae75a9fecead3d756bc2640"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c9101c7c8845225505b446be49b6eded60c9718f9befceb00c8be34cf3f954"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp314-cp314-win_amd64.whl", hash = "sha256:304d150ca768837eaca9f2ad8a94bb80c1f161eeeb71b696c5807d375bc27915"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbd5a7a0f45c6f94fc1453f7a0f99fa6e465c011e25576cfd53ec7d024587a12"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3782a55d18992d854869cb1cb310d0042bc2262cc744e36c19399677d621295"},
-    {file = "nvidia_cudnn_frontend-1.21.0-cp39-cp39-win_amd64.whl", hash = "sha256:9694e436406704d7e41ef5e8f0f5457d4d91f11e4a3e9405f50b86b0ecb0ae72"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbd3100ae212dd1f4691f8c096fe3aded46491f9a6cb258bfb802d07ca1a88fc"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62bf9c8569caf4d9518dae0755507ad36a4e311726aa015fde104c38a1630f76"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp310-cp310-win_amd64.whl", hash = "sha256:22748b41049d02c029719467924ea20d928517dd8f35e204a390f97407298eb2"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdff54c945fbabf9da06fd64ded60cf1ec94d580474f5746786c0effd759fedc"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb50bd2758c6d47c6210451c5c1932ed16e7563d7629228f4cc97edc0e01d0c5"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp311-cp311-win_amd64.whl", hash = "sha256:49f817377a19e10e4aafa5797cd68315739dfdb2fc6a67dd1052b64c805d24ec"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc9c12891d5427ef49b72b26df2b7889d623086d77c9e33b021c2de417d3e4dc"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98ffa05699d71795372f112fa2361c13be716fa3fda911c1e809903163ea5d11"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp312-cp312-win_amd64.whl", hash = "sha256:81fde93d9b86ad631e17da1e2c103c4a7a541ec7abcb7f9a121cbd018c8eff26"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9bdf48cf989b2a77f8b52623fc31c078362fd34389207d11cdb0b5624a7b311"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d02c4b4aae3e243ddb08ad4eb939988bcf7b1aefe25f5d400f6858c7276a6631"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp313-cp313-win_amd64.whl", hash = "sha256:4906a38954725e35bc8431874f4d9db60d50e0d9dbc40ecaf8e5f40df545350b"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f650058bda46a6542dfc3d021803021e7932e1cd6bb78cf46e81fa219717b5e"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f30b0d6563d050ca1972efa594a31d5affe5c3eeb467542e715d7ee73e3b5b"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp314-cp314-win_amd64.whl", hash = "sha256:5994400a7f76a1be5e327a9ac1a4a635ee734d2ac8a5875e52481c52cf2b0922"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57e3ea7ecc6a69b5ed548e50f006180236c964ff63e4ac1a66aab6621cacb430"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:596319a2503ee39b21688d33ac12966d2149d407573726aa2065f50b53b05a5d"},
+    {file = "nvidia_cudnn_frontend-1.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:007f569d38be5c921c42165080eb02e8e687a08a7e4a25dac1ee02e36dbae66e"},
 ]
 
 [package.extras]

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
@@ -558,7 +558,7 @@ class DualModeCapturedGraph(nn.Module):
     def _is_decode_only(self, **kwargs) -> bool:
         """Check if the current batch is decode-only using batch_info_host.
 
-        batch_info_host = [num_prefill, num_prefill_tokens, num_decode]
+        batch_info_host is the serialized BatchInfo tensor.
         Decode-only means num_prefill == 0.
         """
         batch_info = kwargs.get(self.batch_info_kwarg_name)

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -45,6 +45,9 @@ transforms:
   match_attention_layout:
     stage: pattern_matcher
     attn_layout: bsnd
+  inject_custom_attention_mask:
+    stage: pattern_matcher
+    backend: torch_attention
   match_rope_pattern:
     stage: pattern_matcher
   match_rope_layout:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/flashinfer_attention.py
@@ -55,6 +55,7 @@ class PlanParams:
     sm_scale: Optional[float] = None
 
     causal: bool = True
+    window_left: int = -1
 
     def __hash__(self):
         """Convert all fields to a string representation and concatenate them."""
@@ -186,6 +187,7 @@ class _FlashInferPlanner:
                 q_data_type=plan_params.q_dtype,
                 kv_data_type=plan_params.kv_dtype,
                 sm_scale=plan_params.sm_scale,
+                window_left=plan_params.window_left,
                 seq_lens=kv_lens_arr_host,
             )
             self.plan_params_prefill = plan_params
@@ -218,6 +220,7 @@ class _FlashInferPlanner:
                 q_data_type=plan_params.q_dtype,
                 kv_data_type=plan_params.kv_dtype,
                 sm_scale=plan_params.sm_scale,
+                window_left=plan_params.window_left,
             )
 
         # we want to plan during warm-up of cuda graph capture to ensure we have the plan cached
@@ -249,6 +252,13 @@ class _FlashInferPlanner:
 
 
 _GlobalFlashInferPlanner = _FlashInferPlanner()
+
+
+def _to_flashinfer_window_left(sliding_window: Optional[int]) -> int:
+    """Convert AD sliding-window size to FlashInfer's inclusive window_left contract."""
+    if sliding_window is None or sliding_window <= 0:
+        return -1
+    return sliding_window - 1
 
 
 @torch.library.custom_op("auto_deploy::flashinfer_attention_prepare_metadata", mutates_args=())
@@ -342,11 +352,15 @@ def flashinfer_mha_with_cache(
     kv_cache: torch.Tensor,
     # CONSTANTS
     scale: Optional[float],
+    sliding_window: Optional[int],
     k_scale: float,
     v_scale: float,
+    read_cache_only: bool = False,
     # OPTIONAL PRE-ALLOCATED OUTPUT
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+    _GlobalFlashInferPlanner.reset(q.device)
+
     # kv_cache shape: [num_blocks, 2, num_kv_heads, tokens_per_block, head_dim] (HND layout)
     head_dim = kv_cache.shape[-1]
     page_size = kv_cache.shape[3]  # tokens_per_block
@@ -365,25 +379,27 @@ def flashinfer_mha_with_cache(
 
     n_heads = q.shape[1]
     n_kv_heads = k.shape[1]
+    window_left = _to_flashinfer_window_left(sliding_window)
 
     # Assuming k_scale = v_scale = 1.0
     k_scale, v_scale = 1.0, 1.0
-    # k = (k / k_scale).to(torch.float8_e4m3fn) if k_scale != 1.0, same for v
-    if kv_cache.dtype == torch.float8_e4m3fn:
-        k = k.to(torch.float8_e4m3fn)
-        v = v.to(torch.float8_e4m3fn)
+    if not read_cache_only:
+        # k = (k / k_scale).to(torch.float8_e4m3fn) if k_scale != 1.0, same for v
+        if kv_cache.dtype == torch.float8_e4m3fn:
+            k = k.to(torch.float8_e4m3fn)
+            v = v.to(torch.float8_e4m3fn)
 
-    flashinfer.page.append_paged_kv_cache(
-        append_key=k[:num_total_tokens],
-        append_value=v[:num_total_tokens],
-        batch_indices=flashinfer_batch_indices[:num_total_tokens],
-        positions=flashinfer_positions[:num_total_tokens],
-        paged_kv_cache=kv_cache,
-        kv_indices=cache_loc,
-        kv_indptr=cu_num_pages[: num_seq + 1],
-        kv_last_page_len=last_page_len[:num_seq],
-        kv_layout=_GlobalFlashInferPlanner.kv_layout,
-    )
+        flashinfer.page.append_paged_kv_cache(
+            append_key=k[:num_total_tokens],
+            append_value=v[:num_total_tokens],
+            batch_indices=flashinfer_batch_indices[:num_total_tokens],
+            positions=flashinfer_positions[:num_total_tokens],
+            paged_kv_cache=kv_cache,
+            kv_indices=cache_loc,
+            kv_indptr=cu_num_pages[: num_seq + 1],
+            kv_last_page_len=last_page_len[:num_seq],
+            kv_layout=_GlobalFlashInferPlanner.kv_layout,
+        )
 
     bs = b * s
     if out is not None:
@@ -403,6 +419,7 @@ def flashinfer_mha_with_cache(
             q_dtype=q_prefill.dtype,
             kv_dtype=kv_cache.dtype,
             sm_scale=scale,
+            window_left=window_left,
         )
 
         wrapper_prefill = _GlobalFlashInferPlanner.plan_prefill(
@@ -435,6 +452,7 @@ def flashinfer_mha_with_cache(
             q_dtype=q_decode.dtype,
             kv_dtype=kv_cache.dtype,
             sm_scale=scale,
+            window_left=window_left,
         )
 
         wrapper_decode = _GlobalFlashInferPlanner.plan_decode(
@@ -485,8 +503,10 @@ def flashinfer_mha_with_cache_fake(
     kv_cache: torch.Tensor,
     # CONSTANTS
     scale: Optional[float],
+    sliding_window: Optional[int],
     k_scale: float,
     v_scale: float,
+    read_cache_only: bool = False,
     # OPTIONAL PRE-ALLOCATED OUTPUT
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
@@ -519,6 +539,10 @@ class FlashInferAttention(AttentionDescriptor):
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
         return torch.ops.auto_deploy.flashinfer_attention_mha_with_cache.default
+
+    @classmethod
+    def supports_shared_kv(cls) -> bool:
+        return True
 
     @classmethod
     def get_standard_metadata_args(cls) -> List[str]:
@@ -564,15 +588,7 @@ class FlashInferAttention(AttentionDescriptor):
 
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
-        # Sanity check: layout == "bsnd"
-        # Prefer kwargs; fall back to the final positional arg if it's a string.
-        layout = source_attn_node.kwargs.get("layout", None)
-        if (
-            layout is None
-            and len(source_attn_node.args) > 0
-            and isinstance(source_attn_node.args[-1], str)
-        ):
-            layout = source_attn_node.args[-1]
+        layout = extract_op_args(source_attn_node, "layout")[0]
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "
@@ -589,11 +605,7 @@ class FlashInferAttention(AttentionDescriptor):
                 f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"
             )
 
-        # Get scale from args or kwargs
-        if len(source_attn_node.args) > 6:
-            scale = source_attn_node.args[6]
-        else:
-            scale = source_attn_node.kwargs.get("scale", None)
+        scale = extract_op_args(source_attn_node, "scale")[0]
 
         if not (isinstance(scale, float) or scale is None):
             ad_logger.warning(f"Provided {scale=}, is not a float. Using default scale instead.")
@@ -601,6 +613,8 @@ class FlashInferAttention(AttentionDescriptor):
 
         return [
             scale,  # softmax scale
+            extract_op_args(source_attn_node, "sliding_window")[0],  # sliding window parameter
             1.0,  # k_scale
             1.0,  # v_scale
+            cls.get_shared_kv_source_layer_idx(source_attn_node) is not None,  # read_cache_only
         ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_attention.py
@@ -119,6 +119,8 @@ def torch_attention(
     sliding_window: Optional[int] = None,
     logit_cap: Optional[float] = None,
     layout: str = "bnsd",  # "bnsd" or "bsnd"
+    layer_idx: Optional[int] = None,
+    shared_kv_source_layer_idx: Optional[int] = None,
 ) -> torch.Tensor:
     """
     SDPA attention (with optional GQA) that supports two memory layouts via `layout`:
@@ -129,6 +131,8 @@ def torch_attention(
 
     Returns a tensor in the SAME layout as inputs specified by `layout`.
     """
+    # `layer_idx` and `shared_kv_source_layer_idx` are graph metadata used by the KV-cache
+    # transform; the eager attention kernel itself does not need them.
     if layout not in ("bnsd", "bsnd"):
         raise ValueError(f"layout must be 'bnsd' or 'bsnd', got {layout!r}")
 
@@ -239,5 +243,7 @@ def torch_attention_fake(
     sliding_window=None,
     logit_cap=None,
     layout: str = "bnsd",
+    layer_idx: Optional[int] = None,
+    shared_kv_source_layer_idx: Optional[int] = None,
 ):
     return query.new_empty(*query.shape[:-1], value.shape[-1]).contiguous()

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
@@ -70,6 +70,24 @@ def _apply_logit_softcapping(attn_scores: torch.Tensor, logit_cap: Optional[floa
     return attn_scores
 
 
+def _write_generate_kv_cache(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    slot_idx: torch.Tensor,
+    input_pos: torch.Tensor,
+):
+    """Write single-token decode K/V into the cache."""
+    b, s = k.shape[:2]
+    assert s == 1, f"Expected sequence length 1 for generate phase, got {s}"
+    for i in range(b):
+        cache_idx = slot_idx[i].item()
+        pos = input_pos[i].item()
+        k_cache[cache_idx, pos] = k[i, 0]  # Remove sequence dim
+        v_cache[cache_idx, pos] = v[i, 0]  # Remove sequence dim
+
+
 def _torch_generate_mha(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -89,12 +107,7 @@ def _torch_generate_mha(
     assert s == 1, f"Expected sequence length 1 for generate phase, got {s}"
     n_kv_heads = k.shape[2]  # k has shape (b, 1, n_kv_heads, head_dim)
 
-    # Update KV cache for single token
-    for i in range(b):
-        cache_idx = slot_idx[i].item()
-        pos = input_pos[i].item()
-        k_cache[cache_idx, pos] = k[i, 0]  # Remove sequence dim
-        v_cache[cache_idx, pos] = v[i, 0]  # Remove sequence dim
+    _write_generate_kv_cache(k, v, k_cache, v_cache, slot_idx, input_pos)
 
     # Compute attention for each sequence using manual computation
     for i in range(b):
@@ -156,6 +169,60 @@ def _torch_generate_mha(
         out[i] = attn_out.squeeze(1)  # [n_heads, v_head_dim]
 
 
+def _torch_generate_mha_readonly(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    slot_idx: torch.Tensor,
+    input_pos: torch.Tensor,
+    scale: float,
+    out: torch.Tensor,
+    logit_cap: Optional[float] = None,
+    sliding_window_size: Optional[int] = None,
+    sinks: Optional[torch.Tensor] = None,
+):
+    """Generate-only attention using an existing KV cache without writing current-layer K/V."""
+    b, s, n_heads, head_dim = q.shape
+    assert s == 1, f"Expected sequence length 1 for generate phase, got {s}"
+    n_kv_heads = k_cache.shape[2]
+
+    for i in range(b):
+        cache_idx = slot_idx[i].item()
+        pos = input_pos[i].item()
+        q_i = q[i, 0]
+
+        if sliding_window_size is not None and sliding_window_size > 0:
+            start_pos = max(0, pos - sliding_window_size + 1)
+            k_i = k_cache[cache_idx, start_pos : pos + 1]
+            v_i = v_cache[cache_idx, start_pos : pos + 1]
+        else:
+            k_i = k_cache[cache_idx, : pos + 1]
+            v_i = v_cache[cache_idx, : pos + 1]
+
+        q_i = q_i.unsqueeze(1)
+        k_i = k_i.transpose(0, 1)
+        v_i = v_i.transpose(0, 1)
+
+        if n_heads != n_kv_heads:
+            n_rep = n_heads // n_kv_heads
+            k_i = repeat_kv(k_i.unsqueeze(0), n_rep)[0]
+            v_i = repeat_kv(v_i.unsqueeze(0), n_rep)[0]
+
+        attn_scores = torch.matmul(q_i, k_i.transpose(-2, -1)) * scale
+        attn_scores = _apply_logit_softcapping(attn_scores, logit_cap)
+
+        if sinks is not None:
+            sinks = sinks.reshape(-1, 1, 1)
+            attn_weights = torch.cat([attn_scores, sinks], dim=-1)
+            attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+            attn_out = torch.matmul(attn_weights[..., : -sinks.size(-1)], v_i)
+        else:
+            attn_weights = torch.softmax(attn_scores, dim=-1, dtype=torch.float32).to(q.dtype)
+            attn_out = torch.matmul(attn_weights, v_i)
+
+        out[i] = attn_out.squeeze(1)
+
+
 def _torch_context_mha(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -173,7 +240,6 @@ def _torch_context_mha(
     sinks: Optional[torch.Tensor] = None,
 ) -> None:
     """Context attention (multiple tokens, potentially multiple sequences) using existing torch functions."""
-    # Update KV cache first using existing function
     _update_kv_cache(k, v, k_cache, v_cache, seq_len, input_pos, slot_idx, seq_start)
 
     # Compute attention for each sequence
@@ -285,9 +351,85 @@ def _torch_context_mha(
         out.copy_(torch.cat(attn_outputs, dim=0))
 
 
-@torch.library.custom_op(
-    "auto_deploy::torch_cached_attention_with_cache", mutates_args=("k_cache", "v_cache")
-)
+def _torch_context_mha_readonly(
+    q: torch.Tensor,
+    input_pos: torch.Tensor,
+    slot_idx: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    seq_len: torch.Tensor,
+    seq_start: torch.Tensor,
+    scale: float,
+    out: torch.Tensor,
+    logit_cap: Optional[float] = None,
+    sliding_window_size: Optional[int] = None,
+    sinks: Optional[torch.Tensor] = None,
+) -> None:
+    """Context attention using an existing KV cache without writing current-layer K/V."""
+    attn_outputs = []
+    for idx in range(seq_len.shape[0]):
+        seq_len_i = seq_len[idx].item()
+        input_pos_i = input_pos[idx].item()
+        slot_idx_i = slot_idx[idx].item()
+        seq_start_i = seq_start[idx].item()
+
+        if seq_len_i == 0:
+            continue
+
+        q_seq = q[seq_start_i : seq_start_i + seq_len_i]
+        kv_seq_len = input_pos_i + seq_len_i
+        k_seq = k_cache[slot_idx_i, :kv_seq_len]
+        v_seq = v_cache[slot_idx_i, :kv_seq_len]
+
+        n_heads = q_seq.shape[1]
+        n_kv_heads = k_seq.shape[1]
+
+        q_seq_t = q_seq.transpose(0, 1).unsqueeze(0)
+        k_seq_t = k_seq.transpose(0, 1).unsqueeze(0)
+        v_seq_t = v_seq.transpose(0, 1).unsqueeze(0)
+
+        if n_heads != n_kv_heads:
+            n_rep = n_heads // n_kv_heads
+            k_seq_t = repeat_kv(k_seq_t, n_rep)
+            v_seq_t = repeat_kv(v_seq_t, n_rep)
+
+        attn_scores = torch.matmul(q_seq_t, k_seq_t.transpose(-2, -1)) * scale
+
+        causal_mask = torch.triu(
+            torch.ones(seq_len_i, kv_seq_len, device=q.device, dtype=torch.bool),
+            diagonal=1 + input_pos_i,
+        )
+        attn_scores.masked_fill_(causal_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+        if sliding_window_size is not None and sliding_window_size > 0:
+            query_positions = torch.arange(input_pos_i, input_pos_i + seq_len_i, device=q.device)
+            key_positions = torch.arange(kv_seq_len, device=q.device)
+            pos_diff = query_positions.unsqueeze(1) - key_positions.unsqueeze(0)
+            sliding_window_mask = (pos_diff < 0) | (pos_diff >= sliding_window_size)
+            attn_scores.masked_fill_(sliding_window_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+        attn_scores = _apply_logit_softcapping(attn_scores, logit_cap)
+
+        if sinks is not None:
+            new_sinks = sinks.reshape(1, -1, 1, 1).expand(1, n_heads, seq_len_i, 1)
+            attn_weights = torch.cat([attn_scores, new_sinks], dim=-1)
+            attn_weights = torch.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+            attn_out = torch.matmul(attn_weights[..., : -new_sinks.size(-1)], v_seq_t)
+        else:
+            attn_weights = torch.softmax(attn_scores, dim=-1, dtype=torch.float32).to(q.dtype)
+            attn_out = torch.matmul(attn_weights, v_seq_t)
+
+        attn_outputs.append(attn_out[0].transpose(0, 1))
+
+    if len(attn_outputs) == 0:
+        out.zero_()
+    elif len(attn_outputs) == 1:
+        out.copy_(attn_outputs[0])
+    else:
+        out.copy_(torch.cat(attn_outputs, dim=0))
+
+
+@torch.library.custom_op("auto_deploy::torch_cached_attention_with_cache", mutates_args=())
 def torch_backend_mha_with_cache(
     # Q, K, V
     q: torch.Tensor,
@@ -311,6 +453,7 @@ def torch_backend_mha_with_cache(
     sinks: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = None,
     logit_cap: Optional[float] = None,
+    read_cache_only: bool = False,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Torch backend MHA with cache that takes q, k, v in BSND layout."""
@@ -350,12 +493,15 @@ def torch_backend_mha_with_cache(
     y = q.new_empty(*bs_view, num_heads, v_head_dim).contiguous()
 
     # Compute attention
+    if not read_cache_only:
+        if s == 1:
+            _write_generate_kv_cache(k, v, k_cache, v_cache, slot_idx, input_pos)
+        else:
+            _update_kv_cache(k, v, k_cache, v_cache, seq_len, input_pos, slot_idx, seq_start)
+
     if s == 1:
-        # Generate-only phase
-        _torch_generate_mha(
+        _torch_generate_mha_readonly(
             q,
-            k,
-            v,
             k_cache,
             v_cache,
             slot_idx,
@@ -367,11 +513,8 @@ def torch_backend_mha_with_cache(
             sinks,
         )
     else:
-        # Context phase
-        _torch_context_mha(
+        _torch_context_mha_readonly(
             q,
-            k,
-            v,
             input_pos,
             slot_idx,
             k_cache,
@@ -426,6 +569,7 @@ def torch_backend_mha_with_cache_fake(
     sinks: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = None,
     logit_cap: Optional[float] = None,
+    read_cache_only: bool = False,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     if out is not None:
@@ -452,6 +596,10 @@ class TorchBackendAttention(AttentionDescriptor):
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
         return torch.ops.auto_deploy.torch_cached_attention_with_cache.default
+
+    @classmethod
+    def supports_shared_kv(cls) -> bool:
+        return True
 
     @classmethod
     def get_standard_metadata_args(cls) -> List[str]:
@@ -484,14 +632,7 @@ class TorchBackendAttention(AttentionDescriptor):
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         # Sanity check: layout == "bsnd"
-        # Prefer kwargs; fall back to the final positional arg if it's a string.
-        layout = source_attn_node.kwargs.get("layout", None)
-        if (
-            layout is None
-            and len(source_attn_node.args) > 0
-            and isinstance(source_attn_node.args[-1], str)
-        ):
-            layout = source_attn_node.args[-1]
+        layout = extract_op_args(source_attn_node, "layout")[0]
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "
@@ -529,4 +670,5 @@ class TorchBackendAttention(AttentionDescriptor):
             sinks,  # sinks parameter
             sliding_window,  # sliding window parameter
             logit_cap,  # logit cap parameter
+            cls.get_shared_kv_source_layer_idx(source_attn_node) is not None,  # read_cache_only
         ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/torch_backend_attention.py
@@ -235,6 +235,7 @@ def _torch_context_mha(
     seq_start: torch.Tensor,
     scale: float,
     out: torch.Tensor,
+    custom_attn_mask: Optional[torch.Tensor] = None,
     logit_cap: Optional[float] = None,
     sliding_window_size: Optional[int] = None,
     sinks: Optional[torch.Tensor] = None,
@@ -313,7 +314,14 @@ def _torch_context_mha(
         else:
             combined_mask = causal_mask
 
-        attn_scores.masked_fill_(combined_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+        if custom_attn_mask is not None:
+            # The provider emits the full backend-native allow-mask for prefill in [B, N, S_q, S_k]
+            # form, so we trust it directly instead of layering the default causal mask on top.
+            combined_mask = ~custom_attn_mask[idx, :, :seq_len_i, :kv_seq_len]
+        else:
+            combined_mask = combined_mask.unsqueeze(0)
+
+        attn_scores.masked_fill_(combined_mask.unsqueeze(0), float("-inf"))
 
         # Apply logit softcapping if enabled
         attn_scores = _apply_logit_softcapping(attn_scores, logit_cap)
@@ -446,10 +454,11 @@ def torch_backend_mha_with_cache(
     # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
+    custom_attn_mask: Optional[torch.Tensor] = None,
     # BUFFERS
     # <none>
     # CONSTANTS
-    scale: Optional[float],
+    scale: Optional[float] = None,
     sinks: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = None,
     logit_cap: Optional[float] = None,
@@ -523,6 +532,7 @@ def torch_backend_mha_with_cache(
             seq_start,
             scale,
             y,
+            custom_attn_mask,
             logit_cap,
             sliding_window_size,
             sinks,
@@ -562,10 +572,11 @@ def torch_backend_mha_with_cache_fake(
     # CACHES
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
+    custom_attn_mask: Optional[torch.Tensor] = None,
     # BUFFERS
     # <none>
     # CONSTANTS
-    scale: Optional[float],
+    scale: Optional[float] = None,
     sinks: Optional[torch.Tensor] = None,
     sliding_window_size: Optional[int] = None,
     logit_cap: Optional[float] = None,
@@ -630,6 +641,10 @@ class TorchBackendAttention(AttentionDescriptor):
         }
 
     @classmethod
+    def get_dynamic_inputs(cls, source_attn_node: Node) -> List[Optional[Node]]:
+        return list(extract_op_args(source_attn_node, "attn_mask"))
+
+    @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         # Sanity check: layout == "bsnd"
         layout = extract_op_args(source_attn_node, "layout")[0]
@@ -643,7 +658,7 @@ class TorchBackendAttention(AttentionDescriptor):
         attn_mask, dropout_p, is_causal = extract_op_args(
             source_attn_node, "attn_mask", "dropout_p", "is_causal"
         )
-        if attn_mask is not None or dropout_p != 0.0 or not is_causal:
+        if dropout_p != 0.0 or not is_causal:
             ad_logger.debug(
                 "Unsupported attention arguments for "
                 f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_attention.py
@@ -388,14 +388,8 @@ class TritonAttention(AttentionDescriptor):
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         # Sanity check: layout == "bsnd"
-        # Prefer kwargs; fall back to the final positional arg if it's a string.
-        layout = source_attn_node.kwargs.get("layout", None)
-        if (
-            layout is None
-            and len(source_attn_node.args) > 0
-            and isinstance(source_attn_node.args[-1], str)
-        ):
-            layout = source_attn_node.args[-1]
+        # extract_op_args handles kwargs and positional arguments consistently.
+        layout = extract_op_args(source_attn_node, "layout")[0]
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -1151,13 +1151,7 @@ class TritonPagedAttention(AttentionDescriptor):
 
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
-        layout = source_attn_node.kwargs.get("layout", None)
-        if (
-            layout is None
-            and len(source_attn_node.args) > 0
-            and isinstance(source_attn_node.args[-1], str)
-        ):
-            layout = source_attn_node.args[-1]
+        (layout,) = extract_op_args(source_attn_node, "layout")
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -1096,7 +1096,7 @@ def triton_paged_mha_with_cache(
     if num_prefill > 0:
         cu_seqlen = cu_seqlen_host[: num_prefill + 1].to(q.device, non_blocking=True)
         seq_len_with_cache = seq_len_with_cache_host[:num_prefill].to(q.device, non_blocking=True)
-        if custom_attn_mask is None:
+        if custom_attn_mask is None or custom_attn_mask.numel() == 0:
             triton_paged_context(
                 q[:num_prefill_tokens],
                 kv_cache,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -980,8 +980,6 @@ def triton_paged_context_with_custom_mask(
         q_seq = q[q_start:q_end]
         seq_q_len = q_end - q_start
         seq_kv_len = int(seq_len_with_cache[seq_idx].item())
-        if seq_q_len == 0 or seq_kv_len == 0:
-            continue
         k_seq, v_seq = _gather_paged_kv_for_sequence(
             kv_cache, kv_indices, kv_indptr, seq_idx, seq_kv_len
         )
@@ -1098,7 +1096,7 @@ def triton_paged_mha_with_cache(
     if num_prefill > 0:
         cu_seqlen = cu_seqlen_host[: num_prefill + 1].to(q.device, non_blocking=True)
         seq_len_with_cache = seq_len_with_cache_host[:num_prefill].to(q.device, non_blocking=True)
-        if custom_attn_mask is None or custom_attn_mask.numel() == 0:
+        if custom_attn_mask is None:
             triton_paged_context(
                 q[:num_prefill_tokens],
                 kv_cache,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -980,6 +980,8 @@ def triton_paged_context_with_custom_mask(
         q_seq = q[q_start:q_end]
         seq_q_len = q_end - q_start
         seq_kv_len = int(seq_len_with_cache[seq_idx].item())
+        if seq_q_len == 0 or seq_kv_len == 0:
+            continue
         k_seq, v_seq = _gather_paged_kv_for_sequence(
             kv_cache, kv_indices, kv_indptr, seq_idx, seq_kv_len
         )

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -941,6 +941,64 @@ def triton_paged_context(
     return output
 
 
+def _gather_paged_kv_for_sequence(
+    kv_cache: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    seq_idx: int,
+    seq_kv_len: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Gather one sequence's paged KV cache into contiguous tensors in BSND layout."""
+    page_start = int(kv_indptr[seq_idx].item())
+    page_end = int(kv_indptr[seq_idx + 1].item())
+    page_ids = kv_indices[page_start:page_end].to(dtype=torch.long)
+
+    gathered = kv_cache.index_select(0, page_ids)
+    gathered = gathered.permute(1, 0, 3, 2, 4).reshape(2, -1, kv_cache.shape[2], kv_cache.shape[4])
+    gathered = gathered[:, :seq_kv_len]
+    return gathered[0], gathered[1]
+
+
+def triton_paged_context_with_custom_mask(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    seq_len_with_cache: torch.Tensor,
+    custom_attn_mask: torch.Tensor,
+    sm_scale: float,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Prefill fallback for backend-native custom bool masks."""
+    output = out if out is not None else torch.empty_like(q)
+    num_seq = qo_indptr.shape[0] - 1
+
+    for seq_idx in range(num_seq):
+        q_start = int(qo_indptr[seq_idx].item())
+        q_end = int(qo_indptr[seq_idx + 1].item())
+        q_seq = q[q_start:q_end]
+        seq_q_len = q_end - q_start
+        seq_kv_len = int(seq_len_with_cache[seq_idx].item())
+        k_seq, v_seq = _gather_paged_kv_for_sequence(
+            kv_cache, kv_indices, kv_indptr, seq_idx, seq_kv_len
+        )
+        mask_seq = custom_attn_mask[seq_idx : seq_idx + 1, :, :seq_q_len, :seq_kv_len]
+        output[q_start:q_end].copy_(
+            torch.ops.auto_deploy.torch_attention(
+                q_seq.unsqueeze(0),
+                k_seq.unsqueeze(0),
+                v_seq.unsqueeze(0),
+                attn_mask=mask_seq,
+                is_causal=False,
+                scale=sm_scale,
+                layout="bsnd",
+            )[0]
+        )
+
+    return output
+
+
 @torch.library.custom_op("auto_deploy::triton_paged_prepare_metadata", mutates_args=())
 def prepare_triton_paged_metadata(
     position_ids: torch.Tensor,
@@ -999,8 +1057,9 @@ def triton_paged_mha_with_cache(
     triton_positions: torch.Tensor,
     # CACHES - combined KV cache
     kv_cache: torch.Tensor,
+    custom_attn_mask: Optional[torch.Tensor] = None,
     # CONSTANTS
-    scale: Optional[float],
+    scale: Optional[float] = None,
 ) -> torch.Tensor:
     """Triton paged attention with mixed batch support."""
     head_dim = kv_cache.shape[-1]
@@ -1037,17 +1096,30 @@ def triton_paged_mha_with_cache(
     if num_prefill > 0:
         cu_seqlen = cu_seqlen_host[: num_prefill + 1].to(q.device, non_blocking=True)
         seq_len_with_cache = seq_len_with_cache_host[:num_prefill].to(q.device, non_blocking=True)
-        triton_paged_context(
-            q[:num_prefill_tokens],
-            kv_cache,
-            cu_seqlen,
-            cu_num_pages[: num_prefill + 1],
-            cache_loc,
-            last_page_len[:num_prefill],
-            seq_len_with_cache,
-            sm_scale,
-            out=y[:num_prefill_tokens],
-        )
+        if custom_attn_mask is None:
+            triton_paged_context(
+                q[:num_prefill_tokens],
+                kv_cache,
+                cu_seqlen,
+                cu_num_pages[: num_prefill + 1],
+                cache_loc,
+                last_page_len[:num_prefill],
+                seq_len_with_cache,
+                sm_scale,
+                out=y[:num_prefill_tokens],
+            )
+        else:
+            triton_paged_context_with_custom_mask(
+                q[:num_prefill_tokens],
+                kv_cache,
+                cu_seqlen,
+                cu_num_pages[: num_prefill + 1],
+                cache_loc,
+                seq_len_with_cache,
+                custom_attn_mask[:num_prefill],
+                sm_scale,
+                out=y[:num_prefill_tokens],
+            )
 
     # Process decode tokens if any
     if num_decode > 0:
@@ -1080,7 +1152,8 @@ def triton_paged_mha_with_cache_fake(
     triton_batch_indices: torch.Tensor,
     triton_positions: torch.Tensor,
     kv_cache: torch.Tensor,
-    scale: Optional[float],
+    custom_attn_mask: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
 ) -> torch.Tensor:
     return torch.empty_like(q.contiguous())
 
@@ -1150,6 +1223,10 @@ class TritonPagedAttention(AttentionDescriptor):
         }
 
     @classmethod
+    def get_dynamic_inputs(cls, source_attn_node: Node) -> List[Optional[Node]]:
+        return list(extract_op_args(source_attn_node, "attn_mask"))
+
+    @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
         (layout,) = extract_op_args(source_attn_node, "layout")
         if layout != "bsnd":
@@ -1161,7 +1238,7 @@ class TritonPagedAttention(AttentionDescriptor):
         attn_mask, dropout_p, is_causal = extract_op_args(
             source_attn_node, "attn_mask", "dropout_p", "is_causal"
         )
-        if attn_mask is not None or dropout_p != 0.0 or not is_causal:
+        if dropout_p != 0.0 or not is_causal:
             ad_logger.debug(
                 "Unsupported attention arguments for "
                 f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -761,6 +761,140 @@ def _paged_context_kernel(
     tl.store(o_ptr + o_store_offsets, o, mask=q_load_mask)
 
 
+@triton.autotune(
+    configs=[
+        triton.Config({"Q_BLOCK": 64}, num_stages=2, num_warps=2),
+        triton.Config({"Q_BLOCK": 64}, num_stages=2, num_warps=4),
+        triton.Config({"Q_BLOCK": 64}, num_stages=4, num_warps=4),
+        triton.Config({"Q_BLOCK": 128}, num_stages=2, num_warps=4),
+        triton.Config({"Q_BLOCK": 128}, num_stages=2, num_warps=8),
+        triton.Config({"Q_BLOCK": 128}, num_stages=3, num_warps=8),
+    ],
+    key=["HEAD_DIM", "PAGE_SIZE"],
+)
+@triton.jit
+def _paged_context_masked_kernel(
+    # Inputs
+    q_ptr,
+    kv_cache_ptr,
+    custom_mask_ptr,
+    # Metadata
+    qo_indptr_ptr,
+    kv_indptr_ptr,
+    kv_indices_ptr,
+    seq_len_with_cache_ptr,
+    # Output
+    o_ptr,
+    # Strides
+    q_stride_token: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    o_stride_token: tl.constexpr,
+    o_stride_head: tl.constexpr,
+    cache_stride_block: tl.constexpr,
+    cache_stride_kv: tl.constexpr,
+    cache_stride_head: tl.constexpr,
+    cache_stride_token: tl.constexpr,
+    mask_stride_batch: tl.constexpr,
+    mask_stride_head: tl.constexpr,
+    mask_stride_q: tl.constexpr,
+    mask_stride_k: tl.constexpr,
+    # Autotuned
+    Q_BLOCK: tl.constexpr,
+    # Constants
+    SM_SCALE: tl.constexpr,
+    N_HEADS: tl.constexpr,
+    N_KV_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+):
+    """Context/prefill attention with paged KV cache and a backend-provided bool allow-mask."""
+    batch_id = tl.program_id(axis=0)
+    head_id = tl.program_id(axis=1)
+    q_block_id = tl.program_id(axis=2)
+
+    HEAD_RATIO: tl.constexpr = N_HEADS // N_KV_HEADS
+    kv_head_id = head_id // HEAD_RATIO
+
+    q_start = tl.load(qo_indptr_ptr + batch_id)
+    q_end = tl.load(qo_indptr_ptr + batch_id + 1)
+    q_len = q_end - q_start
+
+    kv_page_start = tl.load(kv_indptr_ptr + batch_id)
+    kv_page_end = tl.load(kv_indptr_ptr + batch_id + 1)
+    num_kv_pages = kv_page_end - kv_page_start
+    total_kv_len = tl.load(seq_len_with_cache_ptr + batch_id)
+
+    q_block_start = q_block_id * Q_BLOCK
+    q_offsets = q_block_start + tl.arange(0, Q_BLOCK)
+    q_mask = q_offsets < q_len
+    if tl.sum(q_mask.to(tl.int32)) == 0:
+        return
+
+    dhead_offsets = tl.arange(0, HEAD_DIM)
+    q_load_offsets = (
+        (q_start + q_offsets[:, None]) * q_stride_token
+        + head_id * q_stride_head
+        + dhead_offsets[None, :]
+    )
+    q_load_mask = q_mask[:, None]
+    q = tl.load(q_ptr + q_load_offsets, mask=q_load_mask, other=0.0)
+
+    acc = tl.zeros([Q_BLOCK, HEAD_DIM], dtype=tl.float32)
+    m_i = tl.zeros([Q_BLOCK], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([Q_BLOCK], dtype=tl.float32)
+
+    page_offsets = tl.arange(0, PAGE_SIZE)
+    kv_head_offset = kv_head_id * cache_stride_head
+    local_kv = page_offsets[:, None] * cache_stride_token + dhead_offsets[None, :]
+    mask_batch_offset = batch_id * mask_stride_batch
+    mask_head_offset = 0 * mask_stride_head
+
+    for page_idx in range(num_kv_pages):
+        kv_base_pos = page_idx * PAGE_SIZE
+        physical_page = tl.load(kv_indices_ptr + kv_page_start + page_idx)
+        valid_tokens = tl.minimum(PAGE_SIZE, total_kv_len - kv_base_pos)
+        page_mask = page_offsets < valid_tokens
+
+        page_base = physical_page.to(tl.int64) * cache_stride_block + kv_head_offset
+        page_mask_2d = page_mask[:, None]
+        k = tl.load(kv_cache_ptr + page_base + local_kv, mask=page_mask_2d, other=0.0)
+        v = tl.load(
+            kv_cache_ptr + page_base + local_kv + cache_stride_kv,
+            mask=page_mask_2d,
+            other=0.0,
+        )
+
+        qk = tl.dot(q, tl.trans(k)) * SM_SCALE
+        kv_positions = kv_base_pos + page_offsets[None, :]
+        mask_offsets = (
+            mask_batch_offset
+            + mask_head_offset
+            + q_offsets[:, None] * mask_stride_q
+            + kv_positions * mask_stride_k
+        )
+        valid_mask = q_mask[:, None] & page_mask[None, :]
+        custom_mask = tl.load(custom_mask_ptr + mask_offsets, mask=valid_mask, other=0)
+        full_mask = valid_mask & (custom_mask != 0)
+        qk = tl.where(full_mask, qk, float("-inf"))
+
+        m_ij = tl.max(qk, axis=1)
+        m_i_new = tl.maximum(m_i, m_ij)
+        alpha = tl.exp(m_i - m_i_new)
+        p = tl.exp(qk - m_i_new[:, None])
+        acc = tl.dot(p.to(v.dtype), v, acc=acc * alpha[:, None])
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+        m_i = m_i_new
+
+    l_i = tl.where(l_i == 0.0, 1.0, l_i)
+    o = acc / l_i[:, None]
+    o_store_offsets = (
+        (q_start + q_offsets[:, None]) * o_stride_token
+        + head_id * o_stride_head
+        + dhead_offsets[None, :]
+    )
+    tl.store(o_ptr + o_store_offsets, o, mask=q_load_mask)
+
+
 @triton.jit
 def _fast_gather_sdpa_kernel(
     kv_cache_ptr,
@@ -781,17 +915,10 @@ def _fast_gather_sdpa_kernel(
     PAGE_SIZE: tl.constexpr,
     HEAD_DIM: tl.constexpr,
 ):
-    """Gather scattered pages into separate K, V buffers in SDPA layout.
-
-    Grid: (total_pages, N_KV_HEADS)
-    Each program copies one page for one KV head into contiguous K and V
-    outputs shaped [num_seq, n_kv_heads, max_kv_len, head_dim].
-    No precomputed mapping needed — seq_id and local_page computed from global index.
-    """
+    """Gather scattered pages into separate K, V buffers in SDPA layout."""
     page_global_idx = tl.program_id(0)
     kv_head_id = tl.program_id(1)
 
-    # Compute seq_id and local_page from global page index
     seq_id = page_global_idx // MAX_PAGES
     local_page = page_global_idx % MAX_PAGES
 
@@ -800,14 +927,12 @@ def _fast_gather_sdpa_kernel(
     token_offsets = tl.arange(0, PAGE_SIZE)
     head_offsets = tl.arange(0, HEAD_DIM)
 
-    # Source: kv_cache[physical_page, 0/1, kv_head_id, :, :]
     src_base = physical_page.to(tl.int64) * cache_stride_block + kv_head_id * cache_stride_head
     src_offsets = token_offsets[:, None] * cache_stride_token + head_offsets[None, :]
 
     k_data = tl.load(kv_cache_ptr + src_base + src_offsets)
     v_data = tl.load(kv_cache_ptr + src_base + cache_stride_kv + src_offsets)
 
-    # Destination: out_k/v[seq_id, kv_head_id, local_page*PAGE_SIZE + :, :]
     local_token_start = local_page * PAGE_SIZE
     dst_base = (
         seq_id * out_stride_seq
@@ -941,24 +1066,6 @@ def triton_paged_context(
     return output
 
 
-def _gather_paged_kv_for_sequence(
-    kv_cache: torch.Tensor,
-    kv_indices: torch.Tensor,
-    kv_indptr: torch.Tensor,
-    seq_idx: int,
-    seq_kv_len: int,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Gather one sequence's paged KV cache into contiguous tensors in BSND layout."""
-    page_start = int(kv_indptr[seq_idx].item())
-    page_end = int(kv_indptr[seq_idx + 1].item())
-    page_ids = kv_indices[page_start:page_end].to(dtype=torch.long)
-
-    gathered = kv_cache.index_select(0, page_ids)
-    gathered = gathered.permute(1, 0, 3, 2, 4).reshape(2, -1, kv_cache.shape[2], kv_cache.shape[4])
-    gathered = gathered[:, :seq_kv_len]
-    return gathered[0], gathered[1]
-
-
 def triton_paged_context_with_custom_mask(
     q: torch.Tensor,
     kv_cache: torch.Tensor,
@@ -970,31 +1077,55 @@ def triton_paged_context_with_custom_mask(
     sm_scale: float,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    """Prefill fallback for backend-native custom bool masks."""
+    """Context/prefill attention with paged KV cache and a backend-provided bool allow-mask."""
     output = out if out is not None else torch.empty_like(q)
     num_seq = qo_indptr.shape[0] - 1
+    total_tokens, n_heads, head_dim = q.shape
+    _, _, n_kv_heads, page_size, _ = kv_cache.shape
 
-    for seq_idx in range(num_seq):
-        q_start = int(qo_indptr[seq_idx].item())
-        q_end = int(qo_indptr[seq_idx + 1].item())
-        q_seq = q[q_start:q_end]
-        seq_q_len = q_end - q_start
-        seq_kv_len = int(seq_len_with_cache[seq_idx].item())
-        k_seq, v_seq = _gather_paged_kv_for_sequence(
-            kv_cache, kv_indices, kv_indptr, seq_idx, seq_kv_len
-        )
-        mask_seq = custom_attn_mask[seq_idx : seq_idx + 1, :, :seq_q_len, :seq_kv_len]
-        output[q_start:q_end].copy_(
-            torch.ops.auto_deploy.torch_attention(
-                q_seq.unsqueeze(0),
-                k_seq.unsqueeze(0),
-                v_seq.unsqueeze(0),
-                attn_mask=mask_seq,
-                is_causal=False,
-                scale=sm_scale,
-                layout="bsnd",
-            )[0]
-        )
+    if num_seq == 0 or total_tokens == 0:
+        return output
+
+    if num_seq == 1:
+        max_q_len = total_tokens
+    else:
+        q_lens = qo_indptr[1:] - qo_indptr[:-1]
+        max_q_len = int(q_lens.max().item())
+
+    custom_attn_mask = custom_attn_mask.contiguous().to(dtype=torch.uint8)
+
+    def grid_masked(meta):
+        q_block = meta["Q_BLOCK"]
+        num_q_blocks = (max_q_len + q_block - 1) // q_block
+        return (num_seq, n_heads, num_q_blocks)
+
+    _paged_context_masked_kernel[grid_masked](
+        q,
+        kv_cache,
+        custom_attn_mask,
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        seq_len_with_cache,
+        output,
+        q.stride(0),
+        q.stride(1),
+        output.stride(0),
+        output.stride(1),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        custom_attn_mask.stride(0),
+        custom_attn_mask.stride(1),
+        custom_attn_mask.stride(2),
+        custom_attn_mask.stride(3),
+        SM_SCALE=sm_scale,
+        N_HEADS=n_heads,
+        N_KV_HEADS=n_kv_heads,
+        HEAD_DIM=head_dim,
+        PAGE_SIZE=page_size,
+    )
 
     return output
 
@@ -1228,26 +1359,21 @@ class TritonPagedAttention(AttentionDescriptor):
 
     @classmethod
     def get_constants(cls, source_attn_node: Node) -> List[Constant]:
-        (layout,) = extract_op_args(source_attn_node, "layout")
+        layout, scale, attn_mask, dropout_p, is_causal = extract_op_args(
+            source_attn_node, "layout", "scale", "attn_mask", "dropout_p", "is_causal"
+        )
+
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "
                 f"for node: {source_attn_node.format_node()}"
             )
 
-        attn_mask, dropout_p, is_causal = extract_op_args(
-            source_attn_node, "attn_mask", "dropout_p", "is_causal"
-        )
         if dropout_p != 0.0 or not is_causal:
             ad_logger.debug(
                 "Unsupported attention arguments for "
                 f"{source_attn_node=}: {attn_mask=}, {dropout_p=}, {is_causal=}"
             )
-
-        if len(source_attn_node.args) > 6:
-            scale = source_attn_node.args[6]
-        else:
-            scale = source_attn_node.kwargs.get("scale", None)
 
         if not (isinstance(scale, float) or scale is None):
             ad_logger.warning(f"Provided {scale=}, is not a float. Using default scale instead.")

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
@@ -639,13 +639,7 @@ class TrtllmAttention(AttentionDescriptor):
         from tensor shapes or SequenceInfo metadata at runtime.
         """
         # Sanity check: layout == "bsnd"
-        layout = source_attn_node.kwargs.get("layout", None)
-        if (
-            layout is None
-            and len(source_attn_node.args) > 0
-            and isinstance(source_attn_node.args[-1], str)
-        ):
-            layout = source_attn_node.args[-1]
+        layout = extract_op_args(source_attn_node, "layout")[0]
         if layout != "bsnd":
             raise RuntimeError(
                 f"Expected torch_attention layout='bsnd' but got {layout!r} "

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -1850,6 +1850,7 @@ class AttentionDescriptor(ABC):
             *meta_std,  # standard metadata fields identified by matching arg names!
             *meta_extra,# metadata about the sequences as returned by the prepare_metadata op
             *caches,    # contains layer-specific caches per provided cache initializers
+            *dynamic,   # optional dynamic tensor args forwarded from the source attention node
             *constants, # basic arguments (int, float, str, None) added as CONSTANTS in the graph
         ) -> torch.Tensor: ...
         ```
@@ -1931,7 +1932,17 @@ class AttentionDescriptor(ABC):
         """Provide a list of constant arguments to be passed to the attention op.
 
         The constant arguments are passed to the attention op as additional arguments after the
-        caches. The constants are expected to be of type int, float, str, or None.
+        caches and any backend-owned dynamic inputs. The constants are expected to be of type int,
+        float, str, or None.
+        """
+        return []
+
+    @classmethod
+    def get_dynamic_inputs(cls, source_attn_node: Node) -> List[Optional[Node]]:
+        """Provide backend-owned dynamic inputs to be forwarded to the cached attention op.
+
+        These inputs are extracted from the source attention node after QKV and metadata handling
+        and are inserted before the constant arguments in the cached attention op call.
         """
         return []
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -26,7 +26,19 @@ and operates on a purely functional paradigm that is compatible with the torch c
 
 import math
 from abc import ABC, abstractmethod
-from typing import Dict, List, Literal, Optional, Protocol, Sequence, Set, Tuple, Type, Union
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+    Union,
+)
 
 import numpy as np
 import torch
@@ -687,6 +699,14 @@ class SequenceInfo:
 
         # EXTRA TENSOR FIELDS ######################################################################
         self._extra_args: Dict[str, Optional[torch.Tensor]] = {}
+        # Default factories for extra args: callables that accept this SequenceInfo instance
+        # and return a default value.  These are called whenever a key is absent from
+        # ``extra_args`` in ``nest_sequences`` so that initialization-time forward passes
+        # (resize_kv_cache, cuda-graph warmup) always receive valid inputs.
+        # Model-specific transforms (e.g. attention mask providers) can register factories here.
+        self._default_extra_arg_factories: Dict[
+            str, Callable[["SequenceInfo"], Optional[torch.Tensor]]
+        ] = {}
         ############################################################################################
 
         # HOST PREPARE FOR ATTENTION FORWARD #######################################################
@@ -869,6 +889,21 @@ class SequenceInfo:
             self._active_args += (arg_name,)
             return True
         return False
+
+    def register_default_extra_arg(
+        self,
+        name: str,
+        factory: Callable[["SequenceInfo"], Optional[torch.Tensor]],
+    ) -> None:
+        """Register a callable default factory for an extra argument.
+
+        ``factory`` receives this ``SequenceInfo`` instance and returns the
+        default value for ``name``.  It is invoked at the start of every
+        ``nest_sequences`` call so that initialization-time forward passes
+        (e.g. ``resize_kv_cache``, CUDA-graph warmup) always receive a valid
+        tensor for ``name`` even when no per-request data is provided.
+        """
+        self._default_extra_arg_factories[name] = factory
 
     def to(self, *args, **kwargs) -> None:
         # Move the InputBuffer (which recreates views automatically)
@@ -1127,6 +1162,10 @@ class SequenceInfo:
 
         ### UPDATE EXTRA INPUTS ####################################################################
         self._extra_args = {}
+        # Seed with defaults first (callable factories receive ``self`` so they can
+        # access current shape info via unflatten()), then let per-request values override.
+        for key, factory in self._default_extra_arg_factories.items():
+            self._store_extra_arg(key, factory(self))
         for key, value in extra_args.items():
             self._store_extra_arg(key, value)
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -38,6 +38,7 @@ from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 
 from ...._utils import nvtx_range, prefer_pinned, str_dtype_to_torch
 from ..utils.logger import ad_logger
+from ..utils.node_utils import extract_op_args, get_op_schema
 
 Constant = Union[int, float, str, None]
 
@@ -63,6 +64,14 @@ def _list_to_tensor(data: list, dtype: torch.dtype) -> torch.Tensor:
     if np_dtype is not None:
         return torch.from_numpy(np.array(data, dtype=np_dtype))
     return torch.tensor(data, dtype=dtype)
+
+
+def _extract_optional_op_arg(node: Node, arg_name: str):
+    """Return an op argument if it exists in the schema, otherwise ``None``."""
+    schema_arg_names = {arg.name for arg in get_op_schema(node.target).arguments}
+    if arg_name not in schema_arg_names:
+        return None
+    return extract_op_args(node, arg_name)[0]
 
 
 class PrepareMetadataHostCallable(Protocol):
@@ -1855,6 +1864,11 @@ class AttentionDescriptor(ABC):
         raise NotImplementedError
 
     @classmethod
+    def supports_shared_kv(cls) -> bool:
+        """Whether this backend supports shared-KV cache aliasing."""
+        return False
+
+    @classmethod
     @abstractmethod
     def get_standard_metadata_args(cls) -> List[str]:
         """Get the list of standard metadata arguments that are expected by the attention op."""
@@ -1920,6 +1934,16 @@ class AttentionDescriptor(ABC):
         caches. The constants are expected to be of type int, float, str, or None.
         """
         return []
+
+    @classmethod
+    def get_layer_idx(cls, source_attn_node: Node) -> Optional[int]:
+        """Return the logical layer index associated with a source attention node, if any."""
+        return _extract_optional_op_arg(source_attn_node, "layer_idx")
+
+    @classmethod
+    def get_shared_kv_source_layer_idx(cls, source_attn_node: Node) -> Optional[int]:
+        """Return the KV source layer for a shared-KV attention node, if any."""
+        return _extract_optional_op_arg(source_attn_node, "shared_kv_source_layer_idx")
 
     @staticmethod
     def resolve_cache_dtype(dtype_config: str, fallback_dtype: torch.dtype) -> torch.dtype:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import partial
 from typing import Callable, List
 
 import torch
@@ -165,10 +166,15 @@ def _template_moe_alltoall(
 def _resolve_torch_fn(act_fn: ActivationType) -> Callable[[torch.Tensor], torch.Tensor]:
     """
     Returns an elementwise activation callable matching the given activation function.
-    Supported: ActivationType.Silu, ActivationType.Swiglu, ActivationType.Relu2
+    Supported: ActivationType.Silu, ActivationType.Swiglu, ActivationType.Relu2, ActivationType.Gelu
     """
-    assert act_fn in [ActivationType.Silu, ActivationType.Swiglu, ActivationType.Relu2], (
-        f"Unsupported activation '{ActivationType(act_fn).name}'. Use 'silu', 'swiglu' or 'relu2'."
+    assert act_fn in [
+        ActivationType.Silu,
+        ActivationType.Swiglu,
+        ActivationType.Relu2,
+        ActivationType.Gelu,
+    ], (
+        f"Unsupported activation '{ActivationType(act_fn).name}'. Use 'silu', 'swiglu', 'relu2', or 'gelu'."
     )
     torch_fn = None
     if act_fn == ActivationType.Silu or act_fn == ActivationType.Swiglu:
@@ -179,6 +185,8 @@ def _resolve_torch_fn(act_fn: ActivationType) -> Callable[[torch.Tensor], torch.
             return torch.square(F.relu(x))
 
         torch_fn = relu2
+    elif act_fn == ActivationType.Gelu:
+        torch_fn = partial(F.gelu, approximate="tanh")
     return torch_fn
 
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -401,12 +401,15 @@ def trtllm_moe_fused(
 
     activation_type = ActivationType.Swiglu
     if is_gated_mlp:
-        # Gated MLP uses Silu: silu(x @ w1.T) * (x @ w3.T)
+        # Gated MLP accepts either SiLU/SwiGLU or GELU/GEGLU style gating.
         if act_fn in [ActivationType.Silu, ActivationType.Swiglu]:
             activation_type = ActivationType.Swiglu
+        elif act_fn in [ActivationType.Gelu, ActivationType.Geglu]:
+            activation_type = ActivationType.Geglu
         else:
             raise ValueError(
-                f"Unsupported activation '{ActivationType(act_fn).name}' for gated_mlp. Use 'silu'."
+                f"Unsupported activation '{ActivationType(act_fn).name}' for gated_mlp. "
+                "Use 'silu' or 'gelu'."
             )
     else:
         # For non-gated MLP with ReLU^2
@@ -466,12 +469,22 @@ def trtllm_moe_fused_fake(
 
 
 def _validate_mlp_style_and_act_fn(is_gated_mlp: bool, act_fn: int) -> None:
-    assert (is_gated_mlp and act_fn in [ActivationType.Silu, ActivationType.Swiglu]) or (
-        not is_gated_mlp and act_fn in [ActivationType.Relu2, ActivationType.Silu]
-    ), (
+    assert (
+        is_gated_mlp
+        and act_fn
+        in [ActivationType.Silu, ActivationType.Swiglu, ActivationType.Gelu, ActivationType.Geglu]
+    ) or (not is_gated_mlp and act_fn in [ActivationType.Relu2, ActivationType.Silu]), (
         f"Unsupported combination: is_gated_mlp='{is_gated_mlp}', act_fn='{act_fn}'. "
-        f"Supported combinations: gated mlp with silu or mlp with relu2 or silu."
+        f"Supported combinations: gated mlp with silu or gelu, or mlp with relu2 or silu."
     )
+
+
+def _normalize_trtllm_act_fn(act_fn: int) -> int:
+    if act_fn == ActivationType.Silu:
+        return ActivationType.Swiglu
+    if act_fn == ActivationType.Gelu:
+        return ActivationType.Geglu
+    return act_fn
 
 
 @torch.library.custom_op("auto_deploy::trtllm_quant_fp8_moe_fused", mutates_args=())
@@ -521,7 +534,7 @@ def trtllm_quant_fp8_moe_fused(
     """
 
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
-    act_fn = ActivationType.Swiglu if act_fn == ActivationType.Silu else act_fn
+    act_fn = _normalize_trtllm_act_fn(act_fn)
 
     # Store original shape and flatten to 2D
     x_shape = x.shape
@@ -663,7 +676,7 @@ def trtllm_quant_nvfp4_moe_fused(
     assert fc2_weight_blockscale_fp8.ndim == 3, "fc2_weight_blockscale_fp8 must be 3D"
 
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
-    act_fn = ActivationType.Swiglu if act_fn == ActivationType.Silu else act_fn
+    act_fn = _normalize_trtllm_act_fn(act_fn)
 
     # quant_scales is described by this code:
     # https://github.com/NVIDIA/TensorRT-LLM/blob/c9771ebb997683c08b26bbba796a7fc6aff09d93/cpp/tensorrt_llm/thop/moeOp.cpp#L1015
@@ -798,7 +811,7 @@ def trtllm_quant_finegrained_fp8_moe_fused(
         Output tensor of shape (B, H) or (B, S, H)
     """
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
-    act_fn = ActivationType.Swiglu if act_fn == ActivationType.Silu else act_fn
+    act_fn = _normalize_trtllm_act_fn(act_fn)
 
     x_shape = x.shape
     x2d = x.view(-1, x_shape[-1])

--- a/tensorrt_llm/_torch/auto_deploy/export/export.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/export.py
@@ -14,7 +14,7 @@ from torch.utils._python_dispatch import TorchDispatchMode
 
 from ..utils._graph import canonicalize_graph, lift_to_meta, load_buffers_and_params, tree_to
 from ..utils.logger import ad_logger
-from ..utils.node_utils import is_op
+from ..utils.node_utils import get_op_schema, is_op
 from .interface import apply_export_patches
 
 if TYPE_CHECKING:
@@ -276,7 +276,7 @@ def _expand_moe_experts_in_graph(
         # Collect indices of List[Tensor] arguments from the op schema – these
         # are the per-expert weight / scale lists.
         op = node.target
-        schema = op._schema if hasattr(op, "_schema") else next(iter(op._schemas.values()))
+        schema = get_op_schema(op)
         _tensor_list_types = ("Tensor[]", "List[Tensor]")
         list_arg_indices = [
             i

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -1,4 +1,5 @@
 from .modeling_deepseek import DeepSeekV3ForCausalLM
+from .modeling_gemma3n import Gemma3nForCausalLM, Gemma3nForConditionalGeneration
 from .modeling_glm4_moe_lite import Glm4MoeLiteForCausalLM
 from .modeling_kimi_k2 import KimiK2ForCausalLM, KimiK25ForConditionalGeneration
 from .modeling_mistral3 import Mistral3ForConditionalGenerationAD, Mistral4ForCausalLM
@@ -8,6 +9,8 @@ from .modeling_qwen3_5_moe import Qwen3_5MoeForCausalLM, Qwen3_5MoeForConditiona
 
 __all__ = (
     "DeepSeekV3ForCausalLM",
+    "Gemma3nForCausalLM",
+    "Gemma3nForConditionalGeneration",
     "Glm4MoeLiteForCausalLM",
     "KimiK2ForCausalLM",
     "KimiK25ForConditionalGeneration",

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -1,5 +1,6 @@
 from .modeling_deepseek import DeepSeekV3ForCausalLM
 from .modeling_gemma3n import Gemma3nForCausalLM, Gemma3nForConditionalGeneration
+from .modeling_gemma4 import Gemma4ForCausalLM, Gemma4ForConditionalGeneration
 from .modeling_glm4_moe_lite import Glm4MoeLiteForCausalLM
 from .modeling_kimi_k2 import KimiK2ForCausalLM, KimiK25ForConditionalGeneration
 from .modeling_mistral3 import Mistral3ForConditionalGenerationAD, Mistral4ForCausalLM
@@ -11,6 +12,8 @@ __all__ = (
     "DeepSeekV3ForCausalLM",
     "Gemma3nForCausalLM",
     "Gemma3nForConditionalGeneration",
+    "Gemma4ForCausalLM",
+    "Gemma4ForConditionalGeneration",
     "Glm4MoeLiteForCausalLM",
     "KimiK2ForCausalLM",
     "KimiK25ForConditionalGeneration",

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma3n.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma3n.py
@@ -1,0 +1,852 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Slimmed down Gemma 3n text implementation for AutoDeploy export.
+
+This implementation follows the Hugging Face Gemma 3n text stack closely while
+keeping only the prefill path needed by AutoDeploy. The outer
+``Gemma3nForConditionalGeneration`` wrapper preserves the HF text checkpoint
+layout (``model.language_model.*`` + ``lm_head``) and drops unsupported
+vision/audio tower weights at load time. The forward path intentionally
+supports only text-only export.
+"""
+
+import copy
+import math
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+from transformers.activations import ACT2FN
+from transformers.generation import GenerationMixin
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+from transformers.modeling_utils import PreTrainedModel
+from transformers.models.gemma3n.configuration_gemma3n import (
+    Gemma3nAudioConfig,
+    Gemma3nConfig,
+    Gemma3nTextConfig,
+    Gemma3nVisionConfig,
+)
+from transformers.utils import ModelOutput
+
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+
+
+def _build_rope_cache(
+    config: Gemma3nTextConfig,
+) -> Tuple[torch.Tensor, torch.Tensor, float]:
+    if hasattr(config, "rope_scaling") and isinstance(config.rope_scaling, dict):
+        rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type", "default"))
+    else:
+        rope_type = "default"
+
+    inv_freq, attention_scaling = ROPE_INIT_FUNCTIONS[rope_type](config, device=None)
+    positions = torch.arange(config.max_position_embeddings, dtype=inv_freq.dtype)
+    freqs = torch.outer(positions, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    return emb.cos(), emb.sin(), attention_scaling
+
+
+class Gemma3nRMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6, with_scale: bool = True):
+        super().__init__()
+        self.eps = eps
+        if with_scale:
+            self.weight = nn.Parameter(torch.ones(dim))
+        else:
+            self.register_buffer("weight", torch.ones(dim), persistent=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_rmsnorm(x, self.weight, self.eps)
+
+
+class Gemma3nTextScaledWordEmbedding(nn.Embedding):
+    def __init__(
+        self, num_embeddings: int, embedding_dim: int, padding_idx: int, embed_scale: float
+    ):
+        super().__init__(num_embeddings, embedding_dim, padding_idx)
+        self.register_buffer("embed_scale", torch.tensor(embed_scale), persistent=False)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return super().forward(input_ids) * self.embed_scale.to(dtype=self.weight.dtype)
+
+
+class Gemma3nTextLaurelBlock(nn.Module):
+    def __init__(self, config: Gemma3nTextConfig):
+        super().__init__()
+        self.linear_left = nn.Linear(config.hidden_size, config.laurel_rank, bias=False)
+        self.linear_right = nn.Linear(config.laurel_rank, config.hidden_size, bias=False)
+        self.post_laurel_norm = Gemma3nRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        laurel_hidden_states = self.linear_left(hidden_states)
+        laurel_hidden_states = self.linear_right(laurel_hidden_states)
+        laurel_hidden_states = self.post_laurel_norm(laurel_hidden_states)
+        return hidden_states + laurel_hidden_states
+
+
+class Gemma3nTextMLP(nn.Module):
+    def __init__(self, config: Gemma3nTextConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size[layer_idx]
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_activation]
+        self.activation_sparsity = config.activation_sparsity_pattern[layer_idx]
+        if self.activation_sparsity > 0.0:
+            normal_dist = torch.distributions.normal.Normal(0, 1)
+            std_multiplier = normal_dist.icdf(
+                torch.tensor(self.activation_sparsity, dtype=torch.float32)
+            )
+            self.register_buffer(
+                "activation_sparsity_std_multiplier", std_multiplier, persistent=False
+            )
+        else:
+            self.register_buffer(
+                "activation_sparsity_std_multiplier",
+                torch.tensor(0.0, dtype=torch.float32),
+                persistent=False,
+            )
+
+    def _gaussian_topk(self, inputs: torch.Tensor) -> torch.Tensor:
+        std_multiplier = self.activation_sparsity_std_multiplier.to(
+            device=inputs.device, dtype=inputs.dtype
+        )
+        inputs_mean = torch.mean(inputs, dim=-1, keepdim=True)
+        inputs_std = torch.std(inputs, dim=-1, keepdim=True, unbiased=False)
+        cutoff = inputs_mean + inputs_std * std_multiplier
+        return torch.relu(inputs - cutoff)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        gate_proj = self.gate_proj(hidden_states)
+        if self.activation_sparsity > 0.0:
+            gate_proj = self._gaussian_topk(gate_proj)
+        activations = self.act_fn(gate_proj)
+        up_proj = self.up_proj(hidden_states)
+        return self.down_proj(activations * up_proj)
+
+
+class Gemma3nTextAltUp(nn.Module):
+    def __init__(self, config: Gemma3nTextConfig):
+        super().__init__()
+        self.config = config
+        self.correct_output_scale = nn.Parameter(torch.zeros(config.hidden_size))
+        self.correction_coefs = nn.Linear(
+            config.altup_num_inputs, config.altup_num_inputs, bias=False
+        )
+        self.prediction_coefs = nn.Linear(
+            config.altup_num_inputs, config.altup_num_inputs**2, bias=False
+        )
+        self.modality_router = nn.Linear(config.hidden_size, config.altup_num_inputs, bias=False)
+        self.router_norm = Gemma3nRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.register_buffer(
+            "router_input_scale", torch.tensor(config.hidden_size**-1.0), persistent=False
+        )
+
+    def compute_router_modalities(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        router_inputs = self.router_norm(hidden_states) * self.router_input_scale
+        routed = self.modality_router(router_inputs)
+        return torch.tanh(routed.float()).type_as(hidden_states)
+
+    def predict(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        modalities = self.compute_router_modalities(hidden_states[self.config.altup_active_idx])
+        all_coefs = self.prediction_coefs(modalities).reshape(
+            *modalities.shape[:-1], self.config.altup_num_inputs, self.config.altup_num_inputs
+        )
+        all_coefs = all_coefs.permute(0, 1, 3, 2)
+        predictions = torch.matmul(hidden_states.permute(1, 2, 3, 0), all_coefs)
+        predictions = predictions.permute(3, 0, 1, 2)
+        return (predictions + hidden_states).contiguous().type_as(hidden_states)
+
+    def correct(self, predictions: torch.Tensor, activated: torch.Tensor) -> torch.Tensor:
+        modalities = self.compute_router_modalities(activated)
+        innovation = activated - predictions[self.config.altup_active_idx]
+        innovation = innovation.repeat(self.config.altup_num_inputs, 1, 1, 1)
+        all_coefs = self.correction_coefs(modalities) + 1.0
+        all_coefs = all_coefs.permute(2, 0, 1).unsqueeze(-1)
+        corrected = torch.mul(innovation, all_coefs)
+        return (corrected + predictions).contiguous().type_as(activated)
+
+    def scale_corrected_output(self, corrected: torch.Tensor) -> torch.Tensor:
+        return (corrected.type_as(self.correct_output_scale) * self.correct_output_scale).type_as(
+            corrected
+        )
+
+
+class Gemma3nTextRotaryEmbedding(nn.Module):
+    def __init__(self, config: Gemma3nTextConfig):
+        super().__init__()
+        cos, sin, attention_scaling = _build_rope_cache(config)
+        self.register_buffer("_ad_cos_cached", cos * attention_scaling, persistent=False)
+        self.register_buffer("_ad_sin_cached", sin * attention_scaling, persistent=False)
+
+    def forward(
+        self, x: torch.Tensor, position_ids: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        del position_ids
+        cos = self._ad_cos_cached.to(dtype=x.dtype, device=x.device)
+        sin = self._ad_sin_cached.to(dtype=x.dtype, device=x.device)
+        return cos, sin
+
+
+def _slice_rope_cache(
+    position_embeddings: Tuple[torch.Tensor, torch.Tensor], position_ids: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    cos, sin = position_embeddings
+    return cos[position_ids], sin[position_ids]
+
+
+class Gemma3nMultimodalEmbedder(nn.Module):
+    def __init__(
+        self,
+        multimodal_config: Gemma3nAudioConfig | Gemma3nVisionConfig,
+        text_config: Gemma3nTextConfig,
+    ):
+        super().__init__()
+        self.multimodal_hidden_size = multimodal_config.hidden_size
+        self.eps = multimodal_config.rms_norm_eps
+        self.vocab_offset = multimodal_config.vocab_offset
+        self.vocab_size = multimodal_config.vocab_size
+        self.text_hidden_size = text_config.hidden_size
+
+        self.embedding = nn.Embedding(self.vocab_size, self.multimodal_hidden_size)
+        self.hard_embedding_norm = Gemma3nRMSNorm(self.multimodal_hidden_size, eps=self.eps)
+        self.soft_embedding_norm = Gemma3nRMSNorm(self.multimodal_hidden_size, eps=self.eps)
+        self.embedding_projection = nn.Linear(
+            self.multimodal_hidden_size, self.text_hidden_size, bias=False
+        )
+        self.embedding_post_projection_norm = Gemma3nRMSNorm(
+            self.text_hidden_size, eps=self.eps, with_scale=False
+        )
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if (input_ids is None) == (inputs_embeds is None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+        if inputs_embeds is not None:
+            embeddings = self.soft_embedding_norm(inputs_embeds)
+        else:
+            embeddings = self.embedding(input_ids - self.vocab_offset)
+            embeddings = self.hard_embedding_norm(embeddings)
+        embeddings = self.embedding_projection(embeddings)
+        return self.embedding_post_projection_norm(embeddings)
+
+
+class Gemma3nTextAttention(nn.Module):
+    def __init__(self, config: Gemma3nTextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.config = config
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.is_sliding = config.layer_types[layer_idx] == "sliding_attention"
+        self.sliding_window = config.sliding_window if self.is_sliding else None
+        first_kv_shared_layer_idx = config.num_hidden_layers - config.num_kv_shared_layers
+        self.is_kv_shared_layer = layer_idx >= first_kv_shared_layer_idx > 0
+        prev_layers = config.layer_types[:first_kv_shared_layer_idx]
+        if self.is_kv_shared_layer:
+            self.kv_shared_layer_index = (
+                len(prev_layers) - 1 - prev_layers[::-1].index(config.layer_types[layer_idx])
+            )
+        else:
+            self.kv_shared_layer_index = None
+
+        self.q_proj = nn.Linear(
+            config.hidden_size, self.num_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size, self.num_kv_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.v_proj = nn.Linear(
+            config.hidden_size, self.num_kv_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.o_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=config.attention_bias)
+
+        self.q_norm = Gemma3nRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Gemma3nRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.v_norm = Gemma3nRMSNorm(self.head_dim, eps=config.rms_norm_eps, with_scale=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+        query_states = self.q_proj(hidden_states).view(
+            batch_size, seq_len, self.num_heads, self.head_dim
+        )
+        key_states = self.k_proj(hidden_states).view(
+            batch_size, seq_len, self.num_kv_heads, self.head_dim
+        )
+        value_states = self.v_proj(hidden_states).view(
+            batch_size, seq_len, self.num_kv_heads, self.head_dim
+        )
+
+        query_states = self.q_norm(query_states)
+        key_states = self.k_norm(key_states)
+        value_states = self.v_norm(value_states)
+
+        cos, sin = position_embeddings
+        query_states, key_states = torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin(
+            query_states,
+            key_states,
+            cos,
+            sin,
+            2,
+        )
+
+        attn_output = torch.ops.auto_deploy.torch_attention(
+            query_states,
+            key_states,
+            value_states,
+            None,
+            0.0,
+            True,
+            1.0,
+            None,
+            self.sliding_window,
+            None,
+            "bsnd",
+            self.layer_idx,
+            self.kv_shared_layer_index if self.is_kv_shared_layer else None,
+        )
+        attn_output = attn_output.reshape(batch_size, seq_len, -1)
+        return self.o_proj(attn_output)
+
+
+class Gemma3nTextDecoderLayer(nn.Module):
+    def __init__(self, config: Gemma3nTextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.attention_type = config.layer_types[layer_idx]
+        self.self_attn = Gemma3nTextAttention(config, layer_idx)
+        self.mlp = Gemma3nTextMLP(config, layer_idx=layer_idx)
+        self.input_layernorm = Gemma3nRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Gemma3nRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_feedforward_layernorm = Gemma3nRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = Gemma3nRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.act_fn = ACT2FN[config.hidden_activation]
+
+        self.altup = Gemma3nTextAltUp(config)
+        self.laurel = Gemma3nTextLaurelBlock(config)
+        self.per_layer_input_gate = nn.Linear(
+            config.hidden_size, config.hidden_size_per_layer_input, bias=False
+        )
+        self.per_layer_projection = nn.Linear(
+            config.hidden_size_per_layer_input, config.hidden_size, bias=False
+        )
+        self.post_per_layer_input_norm = Gemma3nRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings_global: Tuple[torch.Tensor, torch.Tensor],
+        position_embeddings_local: Tuple[torch.Tensor, torch.Tensor],
+        per_layer_input: torch.Tensor,
+    ) -> torch.Tensor:
+        predictions = self.altup.predict(hidden_states)
+        active_idx = getattr(self.altup, "active_idx", self.altup.config.altup_active_idx)
+        active_prediction = predictions[active_idx]
+        active_prediction_normed = self.input_layernorm(active_prediction)
+        laurel_output = self.laurel(active_prediction_normed)
+
+        if self.self_attn.is_sliding:
+            position_embeddings = position_embeddings_local
+        else:
+            position_embeddings = position_embeddings_global
+
+        attn = self.self_attn(active_prediction_normed, position_embeddings)
+        attn = self.post_attention_layernorm(attn)
+
+        attn_gated = active_prediction + attn
+        attn_laurel = (attn_gated + laurel_output) / math.sqrt(2.0)
+
+        attn_norm = self.pre_feedforward_layernorm(attn_laurel)
+        attn_ffw = self.mlp(attn_norm)
+        attn_ffw_norm = self.post_feedforward_layernorm(attn_ffw)
+        corrected_predictions = self.altup.correct(predictions, attn_laurel + attn_ffw_norm)
+
+        first_prediction = corrected_predictions[active_idx].clone()
+        if self.altup.config.altup_correct_scale:
+            first_prediction = self.altup.scale_corrected_output(first_prediction)
+
+        first_prediction = self.per_layer_input_gate(first_prediction)
+        first_prediction = self.act_fn(first_prediction)
+        first_prediction = torch.multiply(first_prediction, per_layer_input)
+        first_prediction = self.per_layer_projection(first_prediction)
+        first_prediction = self.post_per_layer_input_norm(first_prediction)
+        for idx in range(corrected_predictions.shape[0]):
+            if idx != active_idx:
+                corrected_predictions[idx] += first_prediction
+        return corrected_predictions
+
+
+@dataclass
+class Gemma3nTextOutput(ModelOutput):
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class Gemma3nCausalLMOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class Gemma3nConditionalOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+
+
+class Gemma3nTextPreTrainedModel(PreTrainedModel):
+    config_class = Gemma3nTextConfig
+    base_model_prefix = "model"
+    _no_split_modules = ["Gemma3nTextDecoderLayer"]
+    supports_gradient_checkpointing = False
+
+    def _init_weights(self, module: nn.Module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+        elif isinstance(module, Gemma3nTextAltUp):
+            module.correct_output_scale.data.zero_()
+
+
+class Gemma3nPreTrainedModel(PreTrainedModel):
+    config_class = Gemma3nConfig
+    base_model_prefix = "model"
+    _no_split_modules = ["Gemma3nTextDecoderLayer"]
+    supports_gradient_checkpointing = False
+
+    def _init_weights(self, module: nn.Module):
+        std = getattr(self.config, "initializer_range", 0.02)
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+        elif isinstance(module, Gemma3nTextAltUp):
+            module.correct_output_scale.data.zero_()
+
+
+class Gemma3nTextModel(Gemma3nTextPreTrainedModel):
+    def __init__(self, config: Gemma3nTextConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.embed_tokens = Gemma3nTextScaledWordEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            self.padding_idx,
+            embed_scale=config.hidden_size**0.5,
+        )
+        self.layers = nn.ModuleList(
+            [
+                Gemma3nTextDecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = Gemma3nRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Gemma3nTextRotaryEmbedding(config)
+
+        local_config = copy.deepcopy(config)
+        local_config.rope_theta = local_config.rope_local_base_freq
+        local_config.rope_scaling = {"rope_type": "default"}
+        self.rotary_emb_local = Gemma3nTextRotaryEmbedding(local_config)
+
+        self.hidden_size = config.hidden_size
+        self.hidden_size_per_layer_input = config.hidden_size_per_layer_input
+        self.embed_tokens_per_layer = Gemma3nTextScaledWordEmbedding(
+            config.vocab_size_per_layer_input,
+            config.num_hidden_layers * config.hidden_size_per_layer_input,
+            self.padding_idx,
+            embed_scale=config.hidden_size_per_layer_input**0.5,
+        )
+        self.per_layer_model_projection = nn.Linear(
+            config.hidden_size,
+            config.num_hidden_layers * config.hidden_size_per_layer_input,
+            bias=False,
+        )
+        self.per_layer_projection_norm = Gemma3nRMSNorm(
+            config.hidden_size_per_layer_input, eps=config.rms_norm_eps
+        )
+        self.altup_projections = nn.ModuleList(
+            [
+                nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+                for _ in range(1, config.altup_num_inputs)
+            ]
+        )
+        self.altup_unembed_projections = nn.ModuleList(
+            [
+                nn.Linear(config.hidden_size, config.hidden_size, bias=False)
+                for _ in range(1, config.altup_num_inputs)
+            ]
+        )
+        self.register_buffer(
+            "per_layer_projection_scale", torch.tensor(config.hidden_size**-0.5), persistent=False
+        )
+        self.register_buffer(
+            "per_layer_input_scale", torch.rsqrt(torch.tensor(2.0)), persistent=False
+        )
+        self.register_buffer("_ad_eps", torch.tensor(1e-5), persistent=False)
+        self._register_load_state_dict_pre_hook(self._slice_reduced_layer_weights)
+        self.post_init()
+
+    def _slice_reduced_layer_weights(
+        self,
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        del local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+        keys_to_params = {
+            prefix + "embed_tokens_per_layer.weight": self.embed_tokens_per_layer.weight,
+            prefix + "per_layer_model_projection.weight": self.per_layer_model_projection.weight,
+        }
+        for state_key, target_param in keys_to_params.items():
+            if state_key not in state_dict:
+                continue
+            checkpoint_weight = state_dict[state_key]
+            if checkpoint_weight.ndim != 2:
+                continue
+            if (
+                checkpoint_weight.shape[0] == target_param.shape[0]
+                and checkpoint_weight.shape[1] > target_param.shape[1]
+            ):
+                state_dict[state_key] = checkpoint_weight[:, : target_param.shape[1]]
+            elif (
+                checkpoint_weight.shape[0] > target_param.shape[0]
+                and checkpoint_weight.shape[1] == target_param.shape[1]
+            ):
+                state_dict[state_key] = checkpoint_weight[: target_param.shape[0]]
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def get_per_layer_inputs(self, input_ids: torch.LongTensor) -> torch.Tensor:
+        return self.embed_tokens_per_layer(input_ids).reshape(
+            *input_ids.shape,
+            self.config.num_hidden_layers,
+            self.hidden_size_per_layer_input,
+        )
+
+    def project_per_layer_inputs(
+        self,
+        inputs_embeds: torch.Tensor,
+        per_layer_inputs: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        per_layer_projection = self.per_layer_model_projection(inputs_embeds)
+        per_layer_projection = per_layer_projection * self.per_layer_projection_scale.to(
+            dtype=inputs_embeds.dtype, device=inputs_embeds.device
+        )
+        per_layer_projection = per_layer_projection.reshape(
+            *inputs_embeds.shape[:-1],
+            self.config.num_hidden_layers,
+            self.hidden_size_per_layer_input,
+        )
+        per_layer_projection = self.per_layer_projection_norm(per_layer_projection)
+
+        if per_layer_inputs is None:
+            return per_layer_projection
+
+        if per_layer_projection.shape != per_layer_inputs.shape:
+            per_layer_inputs = per_layer_inputs[..., : self.config.num_hidden_layers, :]
+
+        return (per_layer_projection + per_layer_inputs) * self.per_layer_input_scale.to(
+            dtype=inputs_embeds.dtype, device=inputs_embeds.device
+        )
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        per_layer_inputs: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Gemma3nTextOutput:
+        del kwargs
+        assert position_ids is not None, "position_ids must be provided"
+        if (input_ids is None) == (inputs_embeds is None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if input_ids is not None:
+            inputs_embeds = self.embed_tokens(input_ids)
+            per_layer_inputs = self.get_per_layer_inputs(input_ids)
+
+        assert inputs_embeds is not None
+        per_layer_inputs = self.project_per_layer_inputs(inputs_embeds, per_layer_inputs)
+        position_embeddings_global = _slice_rope_cache(
+            self.rotary_emb(inputs_embeds, position_ids), position_ids
+        )
+        position_embeddings_local = _slice_rope_cache(
+            self.rotary_emb_local(inputs_embeds, position_ids), position_ids
+        )
+
+        target_magnitude = torch.mean(inputs_embeds**2, dim=-1, keepdim=True) ** 0.5
+        hidden_states = [inputs_embeds]
+        for projection in self.altup_projections:
+            current_hidden_state = projection(inputs_embeds).to(dtype=inputs_embeds.dtype)
+            new_magnitude = torch.mean(current_hidden_state**2, dim=-1, keepdim=True)
+            new_magnitude = torch.sqrt(
+                torch.maximum(
+                    new_magnitude,
+                    self._ad_eps.to(device=inputs_embeds.device, dtype=new_magnitude.dtype),
+                )
+            )
+            current_hidden_state = current_hidden_state * target_magnitude / new_magnitude
+            hidden_states.append(current_hidden_state)
+        hidden_states = torch.stack(hidden_states, dim=0)
+
+        for decoder_layer in self.layers:
+            layer_per_input = per_layer_inputs[:, :, decoder_layer.layer_idx, :]
+            hidden_states = decoder_layer(
+                hidden_states,
+                position_embeddings_global,
+                position_embeddings_local,
+                layer_per_input,
+            )
+
+        target_magnitude = torch.mean(hidden_states[0] ** 2, dim=-1, keepdim=True) ** 0.5
+        reduced_hidden_states = [hidden_states[0]]
+        for i, projection in enumerate(self.altup_unembed_projections, start=1):
+            current_hidden_state = projection(hidden_states[i]).to(dtype=inputs_embeds.dtype)
+            new_magnitude = torch.mean(current_hidden_state**2, dim=-1, keepdim=True)
+            new_magnitude = torch.sqrt(
+                torch.maximum(
+                    new_magnitude,
+                    self._ad_eps.to(device=inputs_embeds.device, dtype=new_magnitude.dtype),
+                )
+            )
+            current_hidden_state = current_hidden_state * target_magnitude / new_magnitude
+            reduced_hidden_states.append(current_hidden_state)
+
+        hidden_states = torch.mean(torch.stack(reduced_hidden_states), dim=0)
+        hidden_states = self.norm(hidden_states)
+        return Gemma3nTextOutput(last_hidden_state=hidden_states)
+
+
+class Gemma3nForCausalLM(Gemma3nTextPreTrainedModel, GenerationMixin):
+    config_class = Gemma3nTextConfig
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: Gemma3nTextConfig, **kwargs):
+        del kwargs
+        super().__init__(config)
+        self.model = Gemma3nTextModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, value):
+        self.lm_head = value
+
+    def get_decoder(self):
+        return self.model
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Gemma3nCausalLMOutput:
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+        logits = self.lm_head(outputs.last_hidden_state)
+        if self.config.final_logit_softcapping is not None:
+            logits = logits / self.config.final_logit_softcapping
+            logits = torch.tanh(logits)
+            logits = logits * self.config.final_logit_softcapping
+        return Gemma3nCausalLMOutput(logits=logits)
+
+
+class Gemma3nModel(Gemma3nPreTrainedModel):
+    def __init__(self, config: Gemma3nConfig):
+        super().__init__(config)
+        self.vocab_size_per_layer_input = config.text_config.vocab_size_per_layer_input
+        self.vision_tower = nn.Module()
+        self.language_model = Gemma3nTextModel(config.text_config)
+        self.audio_tower = nn.Module()
+        self.embed_vision = Gemma3nMultimodalEmbedder(config.vision_config, config.text_config)
+        self.embed_audio = Gemma3nMultimodalEmbedder(config.audio_config, config.text_config)
+        self._register_load_state_dict_pre_hook(self._drop_unsupported_multimodal_tower_weights)
+        self.post_init()
+
+    @staticmethod
+    def _drop_unsupported_multimodal_tower_weights(
+        state_dict,
+        prefix,
+        local_metadata,
+        strict,
+        missing_keys,
+        unexpected_keys,
+        error_msgs,
+    ):
+        del local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+        unsupported_prefixes = (
+            prefix + "vision_tower.",
+            prefix + "audio_tower.",
+        )
+        for key in list(state_dict):
+            if key.startswith(unsupported_prefixes):
+                state_dict.pop(key)
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.language_model.set_input_embeddings(value)
+
+    def set_decoder(self, decoder):
+        self.language_model = decoder
+
+    def get_decoder(self):
+        return self.language_model
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        input_features: Optional[torch.Tensor] = None,
+        input_features_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Gemma3nTextOutput:
+        del kwargs
+        del input_features_mask
+        assert position_ids is not None, "position_ids must be provided"
+        if pixel_values is not None or input_features is not None:
+            raise NotImplementedError(
+                "Gemma3n multimodal inputs are not supported by the current AutoDeploy export path. "
+                "Use text-only prompts for this onboarding."
+            )
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        per_layer_inputs = None
+        if input_ids is not None:
+            inputs_embeds = self.get_input_embeddings()(input_ids)
+            per_layer_inputs_mask = torch.logical_and(
+                input_ids >= 0, input_ids < self.vocab_size_per_layer_input
+            )
+            per_layer_inputs_tokens = torch.where(
+                per_layer_inputs_mask, input_ids, torch.zeros_like(input_ids)
+            )
+            per_layer_inputs = self.language_model.get_per_layer_inputs(per_layer_inputs_tokens)
+
+        return self.language_model(
+            input_ids=None,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            per_layer_inputs=per_layer_inputs,
+        )
+
+
+class Gemma3nForConditionalGeneration(Gemma3nPreTrainedModel, GenerationMixin):
+    config_class = Gemma3nConfig
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: Gemma3nConfig, **kwargs):
+        del kwargs
+        super().__init__(config)
+        self.model = Gemma3nModel(config)
+        self.lm_head = nn.Linear(
+            config.text_config.hidden_size, config.text_config.vocab_size, bias=False
+        )
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, value):
+        self.lm_head = value
+
+    def get_decoder(self):
+        return self.model.get_decoder()
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        input_features: Optional[torch.Tensor] = None,
+        input_features_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Gemma3nConditionalOutput:
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            input_features=input_features,
+            input_features_mask=input_features_mask,
+            **kwargs,
+        )
+        logits = self.lm_head(outputs.last_hidden_state)
+        if self.config.text_config.final_logit_softcapping is not None:
+            logits = logits / self.config.text_config.final_logit_softcapping
+            logits = torch.tanh(logits)
+            logits = logits * self.config.text_config.final_logit_softcapping
+        return Gemma3nConditionalOutput(logits=logits)
+
+
+AutoModelForCausalLMFactory.register_custom_model_cls("Gemma3nTextConfig", Gemma3nForCausalLM)
+AutoModelForCausalLMFactory.register_custom_model_cls(
+    "Gemma3nConfig", Gemma3nForConditionalGeneration
+)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -879,8 +879,15 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
         inputs_embeds: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Gemma4ConditionalOutput:
-        # Forward all kwargs (including token_type_ids from extra_args) to the
-        # exported CausalLM which includes lm_head + softcapping.
+        # Ensure token_type_ids is always present for the custom attention mask.
+        # Text-only / decode / warmup steps won't have it in named_args.
+        if "token_type_ids" not in kwargs:
+            ref = input_ids if input_ids is not None else inputs_embeds
+            if ref is not None:
+                kwargs["token_type_ids"] = torch.zeros(
+                    ref.shape[0], ref.shape[1], dtype=torch.int64, device=ref.device
+                )
+
         outputs = self.model.language_model(
             input_ids=input_ids,
             position_ids=position_ids,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -873,6 +873,43 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
     def get_decoder(self):
         return self.model.get_decoder()
 
+    @staticmethod
+    def _build_attention_mask(token_type_ids: torch.Tensor) -> torch.Tensor:
+        """Build a bool attention mask from ``token_type_ids``.
+
+        Returns a ``[batch, 1, seq, seq]`` bool mask that is causal for text
+        tokens and bidirectional within contiguous media blobs.
+        """
+        batch_size, seq_len = token_type_ids.shape
+        device = token_type_ids.device
+
+        # Identify non-text tokens and detect blob boundaries
+        non_text = token_type_ids.ne(0)
+        prev = torch.cat(
+            [
+                torch.zeros(batch_size, 1, dtype=token_type_ids.dtype, device=device),
+                token_type_ids[:, :-1],
+            ],
+            dim=1,
+        )
+        blob_starts = non_text & token_type_ids.ne(prev)
+        blob_ids = torch.cumsum(blob_starts.to(torch.int64), dim=1)
+        token_blob_ids = torch.where(non_text, blob_ids, torch.zeros_like(blob_ids))
+
+        # Bidirectional within same media blob
+        blob_q = token_blob_ids.unsqueeze(2)  # [B, S, 1]
+        blob_k = token_blob_ids.unsqueeze(1)  # [B, 1, S]
+        bidirectional_media = (blob_q == blob_k) & (blob_q != 0)
+
+        # Standard causal mask
+        positions = torch.arange(seq_len, device=device)
+        causal_mask = positions.unsqueeze(0) <= positions.unsqueeze(1)  # [S, S]
+        causal_mask = causal_mask.unsqueeze(0)  # [1, S, S]
+
+        # Combine: causal OR bidirectional-within-blob
+        combined = causal_mask | bidirectional_media  # [B, S, S]
+        return combined.unsqueeze(1)  # [B, 1, S, S]
+
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
@@ -880,14 +917,14 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
         inputs_embeds: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Gemma4ConditionalOutput:
-        # Ensure token_type_ids is always present for the custom attention mask.
-        # Text-only / decode / warmup steps won't have it in named_args.
-        if "token_type_ids" not in kwargs:
-            ref = input_ids if input_ids is not None else inputs_embeds
-            if ref is not None:
-                kwargs["token_type_ids"] = torch.zeros(
-                    ref.shape[0], ref.shape[1], dtype=torch.int64, device=ref.device
-                )
+        # Compute custom attention mask from token_type_ids outside the graph.
+        # Pass None during warmup / text-only / decode so the attention backend
+        # uses its fast causal kernel instead of the per-sequence fallback.
+        token_type_ids = kwargs.pop("token_type_ids", None)
+        if token_type_ids is not None and token_type_ids.any():
+            kwargs["custom_attn_mask"] = self._build_attention_mask(token_type_ids)
+        else:
+            kwargs["custom_attn_mask"] = None
 
         outputs = self.model.language_model(
             input_ids=input_ids,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -391,27 +391,6 @@ class Gemma4MoEBlock(nn.Module):
                 for _ in range(config.num_experts)
             ]
         )
-        self._register_load_state_dict_pre_hook(self._unfuse_moe_weights)
-
-    def _unfuse_moe_weights(self, state_dict, prefix, *_args, **_kwargs):
-        """Convert fused checkpoint MoE weights to per-expert format."""
-        gate_up_key = prefix + "gate_up_proj"
-        down_key = prefix + "down_proj"
-        scale_key = prefix + "per_expert_scale"
-
-        if gate_up_key not in state_dict:
-            return
-
-        gate_up = state_dict.pop(gate_up_key)  # [E, 2*I, H]
-        down = state_dict.pop(down_key)  # [E, H, I]
-        scale = state_dict.pop(scale_key)  # [E]
-
-        inter = self.intermediate_size
-        for e in range(self.num_experts):
-            state_dict[f"{prefix}experts.{e}.gate_proj.weight"] = gate_up[e, :inter, :]
-            state_dict[f"{prefix}experts.{e}.up_proj.weight"] = gate_up[e, inter:, :]
-            # Fold per_expert_scale into down_proj
-            state_dict[f"{prefix}experts.{e}.down_proj.weight"] = down[e] * scale[e]
 
     def forward(
         self,
@@ -528,6 +507,8 @@ class Gemma4TextDecoderLayer(nn.Module):
     def __init__(self, config: Gemma4TextConfig, layer_idx: int):
         super().__init__()
         self.layer_idx = layer_idx
+        self.num_experts = config.num_experts
+        self.expert_intermediate_size = config.expert_intermediate_size
         self.attention_type = config.layer_types[layer_idx]
         self.self_attn = Gemma4TextAttention(config, layer_idx)
         self.mlp = Gemma4TextMLP(config)
@@ -541,6 +522,7 @@ class Gemma4TextDecoderLayer(nn.Module):
         if self.enable_moe_block:
             self.router = Gemma4Router(config)
             self.moe = Gemma4MoEBlock(config)
+            self._register_load_state_dict_pre_hook(self._unfuse_moe_weights)
             self.post_feedforward_layernorm_1 = Gemma4RMSNorm(
                 config.hidden_size, eps=config.rms_norm_eps
             )
@@ -550,6 +532,46 @@ class Gemma4TextDecoderLayer(nn.Module):
             self.pre_feedforward_layernorm_2 = Gemma4RMSNorm(
                 config.hidden_size, eps=config.rms_norm_eps
             )
+
+    def _unfuse_moe_weights(self, state_dict, prefix, *_args, **_kwargs):
+        """Convert layer-level fused Gemma4 MoE checkpoint weights to per-expert weights."""
+        candidates = [
+            (
+                prefix + "experts.gate_up_proj",
+                prefix + "experts.down_proj",
+                prefix + "router.per_expert_scale",
+            ),
+            (
+                prefix + "moe.gate_up_proj",
+                prefix + "moe.down_proj",
+                prefix + "moe.per_expert_scale",
+            ),
+        ]
+
+        gate_up_key = down_key = scale_key = None
+        for gate_up_candidate, down_candidate, scale_candidate in candidates:
+            if (
+                gate_up_candidate in state_dict
+                and down_candidate in state_dict
+                and scale_candidate in state_dict
+            ):
+                gate_up_key = gate_up_candidate
+                down_key = down_candidate
+                scale_key = scale_candidate
+                break
+
+        if gate_up_key is None or down_key is None or scale_key is None:
+            return
+
+        gate_up = state_dict.pop(gate_up_key)  # [E, 2*I, H]
+        down = state_dict.pop(down_key)  # [E, H, I]
+        scale = state_dict.pop(scale_key)  # [E]
+
+        inter = self.expert_intermediate_size
+        for e in range(self.num_experts):
+            state_dict[f"{prefix}moe.experts.{e}.gate_proj.weight"] = gate_up[e, :inter, :]
+            state_dict[f"{prefix}moe.experts.{e}.up_proj.weight"] = gate_up[e, inter:, :]
+            state_dict[f"{prefix}moe.experts.{e}.down_proj.weight"] = down[e] * scale[e]
 
     def forward(
         self,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -250,10 +250,10 @@ def _build_rope_cache(
 
 
 class Gemma4RMSNorm(nn.Module):
-    """RMSNorm with Gemma4-style (weight + scale_shift) semantics.
+    """RMSNorm matching HF Gemma4 (transformers >= 5.5).
 
-    For AD export, we store the *effective* weight = checkpoint_weight + scale_shift
-    via a load hook, then use the standard torch_rmsnorm op.
+    The checkpoint stores effective weights directly — no ``+1.0`` offset.
+    Uses the ``torch_rmsnorm`` canonical op for AD transform compatibility.
     """
 
     def __init__(self, dim: int, eps: float = 1e-6, with_scale: bool = True):
@@ -264,16 +264,6 @@ class Gemma4RMSNorm(nn.Module):
             self.weight = nn.Parameter(torch.ones(dim))
         else:
             self.register_buffer("weight", torch.ones(dim), persistent=False)
-        if with_scale:
-            self._register_load_state_dict_pre_hook(self._apply_scale_shift)
-
-    @staticmethod
-    def _apply_scale_shift(state_dict, prefix, *_args, **_kwargs):
-        """Gemma4 RMSNorm stores weight that is used as (weight + 1.0).
-        Convert to effective weight at load time so torch_rmsnorm works directly."""
-        key = prefix + "weight"
-        if key in state_dict:
-            state_dict[key] = state_dict[key] + 1.0
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.ops.auto_deploy.torch_rmsnorm(x, self.weight, self.eps)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -35,7 +35,7 @@ Key architectural features of Gemma 4 vs standard transformers:
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -48,10 +48,11 @@ from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput, cached_file
 
-from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
+from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry, SubModuleExportInfo
 from tensorrt_llm._torch.auto_deploy.models.hf import (
     AutoModelForCausalLMFactory,
     AutoModelForImageTextToTextFactory,
+    TextModelExportInfo,
 )
 from tensorrt_llm._torch.utils import ActivationType
 
@@ -997,9 +998,32 @@ class Gemma4ADInputProcessor:
         return token_ids, extra
 
 
+class Gemma4TextModelExportInfo(TextModelExportInfo):
+    """Export config for the Gemma4 text submodule.
+
+    Extends the base ``TextModelExportInfo`` with ``token_type_ids`` as a
+    dynamically-shaped input so that it is exported with symbolic batch/seq
+    dimensions rather than concrete static shapes.
+    """
+
+    def _init_dynamic_shape_lookup(self):
+        lookup = super()._init_dynamic_shape_lookup()
+        # Reuse the same dynamic dim objects from input_ids so export can verify
+        # that batch and seq dimensions are semantically identical across inputs.
+        batch_dim = lookup["input_ids"][0]
+        seq_dim = lookup["input_ids"][1]
+        lookup["token_type_ids"] = {0: batch_dim, 1: seq_dim}
+        return lookup
+
+
 @ModelFactoryRegistry.register("Gemma4ForConditionalGeneration")
 class Gemma4ForConditionalGenerationFactory(AutoModelForImageTextToTextFactory):
     """Factory for Gemma 4 VLM with custom attention mask support."""
+
+    def get_export_infos(self, model) -> List[SubModuleExportInfo]:
+        """Return export info with token_type_ids as a dynamic input."""
+        base_info = TextModelExportInfo.from_autoinferred(model)
+        return [Gemma4TextModelExportInfo(base_info.submodule_name)]
 
     def init_tokenizer(self) -> Optional[Any]:
         if self.tokenizer is None:

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -32,19 +32,23 @@ Key architectural features of Gemma 4 vs standard transformers:
 - Final logit softcapping
 """
 
+import json
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from pathlib import Path
+from typing import Any, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
+from tokenizers import Tokenizer
 from torch import nn
-from transformers import AutoConfig, PretrainedConfig
+from transformers import AutoConfig, PretrainedConfig, PreTrainedTokenizerFast
 from transformers.activations import ACT2FN
 from transformers.generation import GenerationMixin
 from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
 from transformers.modeling_utils import PreTrainedModel
-from transformers.utils import ModelOutput
+from transformers.utils import ModelOutput, cached_file
 
+from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
 from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.utils import ActivationType
 
@@ -883,10 +887,93 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
 
 
 # ---------------------------------------------------------------------------
+# Wrapper tokenizer for Gemma 4
+#
+# The upstream HF checkpoint ships ``extra_special_tokens`` as a *list* in
+# tokenizer_config.json, which is incompatible with transformers <5.3.
+# This thin wrapper loads the tokenizer assets directly, bypassing the
+# problematic codepath.
+# ---------------------------------------------------------------------------
+
+_TOKENIZER_CONFIG_FILE = "tokenizer_config.json"
+_CHAT_TEMPLATE_FILE = "chat_template.jinja"
+_TOKENIZER_FILE = "tokenizer.json"
+
+
+class ADGemma4Tokenizer(PreTrainedTokenizerFast):
+    """Wrapper that loads the upstream Gemma 4 tokenizer on current transformers."""
+
+    vocab_files_names = {"tokenizer_file": _TOKENIZER_FILE}
+    model_input_names = ["input_ids", "attention_mask"]
+    slow_tokenizer_class = None
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | Path,
+        *inputs,
+        **kwargs,
+    ) -> "ADGemma4Tokenizer":
+        del inputs
+        for k in ("_from_auto", "_commit_hash", "trust_remote_code"):
+            kwargs.pop(k, None)
+
+        config_path = cached_file(pretrained_model_name_or_path, _TOKENIZER_CONFIG_FILE, **kwargs)
+        assert config_path is not None
+        config = json.loads(Path(config_path).read_text())
+
+        tokenizer_file = cached_file(pretrained_model_name_or_path, _TOKENIZER_FILE, **kwargs)
+        assert tokenizer_file is not None
+
+        # ``extra_special_tokens`` is a list in the upstream config; map it to
+        # the standard ``additional_special_tokens`` field.
+        extra = config.get("extra_special_tokens", [])
+        if isinstance(extra, list):
+            additional = extra
+        else:
+            additional = list(extra.keys()) if isinstance(extra, dict) else []
+
+        tokenizer = cls(
+            tokenizer_object=Tokenizer.from_file(tokenizer_file),
+            name_or_path=str(pretrained_model_name_or_path),
+            bos_token=config.get("bos_token"),
+            eos_token=config.get("eos_token"),
+            unk_token=config.get("unk_token"),
+            pad_token=config.get("pad_token"),
+            additional_special_tokens=additional,
+            clean_up_tokenization_spaces=config.get("clean_up_tokenization_spaces", False),
+            model_max_length=config.get("model_max_length"),
+            padding_side=config.get("padding_side", "left"),
+            truncation_side=config.get("truncation_side", "left"),
+        )
+
+        template_path = cached_file(
+            pretrained_model_name_or_path,
+            _CHAT_TEMPLATE_FILE,
+            _raise_exceptions_for_missing_entries=False,
+            **kwargs,
+        )
+        if template_path is not None:
+            tokenizer.chat_template = Path(template_path).read_text()
+
+        return tokenizer
+
+
+@ModelFactoryRegistry.register("Gemma4ForConditionalGeneration")
+class Gemma4ForConditionalGenerationFactory(AutoModelForCausalLMFactory):
+    """Factory that wires the wrapper tokenizer for Gemma 4."""
+
+    def init_tokenizer(self) -> Optional[Any]:
+        if self.tokenizer is None:
+            return None
+        return ADGemma4Tokenizer.from_pretrained(self.tokenizer)
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 
 AutoModelForCausalLMFactory.register_custom_model_cls("Gemma4TextConfig", Gemma4ForCausalLM)
-AutoModelForCausalLMFactory.register_custom_model_cls(
+Gemma4ForConditionalGenerationFactory.register_custom_model_cls(
     "Gemma4Config", Gemma4ForConditionalGeneration
 )

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -49,7 +49,10 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput, cached_file
 
 from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
-from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+from tensorrt_llm._torch.auto_deploy.models.hf import (
+    AutoModelForCausalLMFactory,
+    AutoModelForImageTextToTextFactory,
+)
 from tensorrt_llm._torch.utils import ActivationType
 
 # ---------------------------------------------------------------------------
@@ -793,14 +796,14 @@ class Gemma4PreTrainedModel(PreTrainedModel):
 class Gemma4Model(Gemma4PreTrainedModel):
     def __init__(self, config: Gemma4Config):
         super().__init__(config)
-        self.language_model = Gemma4TextModel(config.text_config)
+        self.language_model = Gemma4ForCausalLM(config.text_config)
         self.vision_tower = nn.Module()  # stub
         self.embed_vision = Gemma4MultimodalEmbedder(config.vision_config, config.text_config)
-        self._register_load_state_dict_pre_hook(self._drop_unsupported_weights)
+        self._register_load_state_dict_pre_hook(self._remap_and_drop_weights)
         self.post_init()
 
     @staticmethod
-    def _drop_unsupported_weights(state_dict, prefix, *_args, **_kwargs):
+    def _remap_and_drop_weights(state_dict, prefix, *_args, **_kwargs):
         unsupported_prefixes = (
             prefix + "vision_tower.",
             prefix + "audio_tower.",
@@ -824,18 +827,10 @@ class Gemma4Model(Gemma4PreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        input_features: Optional[torch.Tensor] = None,
-        input_features_mask: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> Gemma4TextOutput:
-        del kwargs, input_features_mask
+    ) -> Gemma4CausalLMOutput:
+        del kwargs
         assert position_ids is not None, "position_ids must be provided"
-        if pixel_values is not None or input_features is not None:
-            raise NotImplementedError(
-                "Gemma4 multimodal inputs are not supported by the current AutoDeploy export "
-                "path. Use text-only prompts for this onboarding."
-            )
         return self.language_model(
             input_ids=input_ids,
             position_ids=position_ids,
@@ -845,16 +840,22 @@ class Gemma4Model(Gemma4PreTrainedModel):
 
 class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
     config_class = Gemma4Config
-    _tied_weights_keys = ["lm_head.weight"]
+    _tied_weights_keys = ["model.language_model.lm_head.weight"]
 
     def __init__(self, config: Gemma4Config, **kwargs):
         del kwargs
         super().__init__(config)
         self.model = Gemma4Model(config)
-        self.lm_head = nn.Linear(
-            config.text_config.hidden_size, config.text_config.vocab_size, bias=False
-        )
+        self._register_load_state_dict_pre_hook(self._remap_lm_head_weight)
         self.post_init()
+
+    @staticmethod
+    def _remap_lm_head_weight(state_dict, prefix, *_args, **_kwargs):
+        """Remap lm_head into language_model so TextModelExportInfo exports it."""
+        old_key = prefix + "lm_head.weight"
+        new_key = prefix + "model.language_model.lm_head.weight"
+        if old_key in state_dict and new_key not in state_dict:
+            state_dict[new_key] = state_dict.pop(old_key)
 
     def get_input_embeddings(self):
         return self.model.get_input_embeddings()
@@ -863,10 +864,10 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
         self.model.set_input_embeddings(value)
 
     def get_output_embeddings(self):
-        return self.lm_head
+        return self.model.language_model.lm_head
 
     def set_output_embeddings(self, value):
-        self.lm_head = value
+        self.model.language_model.lm_head = value
 
     def get_decoder(self):
         return self.model.get_decoder()
@@ -876,26 +877,17 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
-        pixel_values: Optional[torch.Tensor] = None,
-        input_features: Optional[torch.Tensor] = None,
-        input_features_mask: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Gemma4ConditionalOutput:
-        outputs = self.model(
+        # Forward all kwargs (including token_type_ids from extra_args) to the
+        # exported CausalLM which includes lm_head + softcapping.
+        outputs = self.model.language_model(
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
-            pixel_values=pixel_values,
-            input_features=input_features,
-            input_features_mask=input_features_mask,
             **kwargs,
         )
-        logits = self.lm_head(outputs.last_hidden_state)
-        if self.config.text_config.final_logit_softcapping is not None:
-            logits = logits / self.config.text_config.final_logit_softcapping
-            logits = torch.tanh(logits)
-            logits = logits * self.config.text_config.final_logit_softcapping
-        return Gemma4ConditionalOutput(logits=logits)
+        return Gemma4ConditionalOutput(logits=outputs.logits)
 
 
 # ---------------------------------------------------------------------------
@@ -971,14 +963,50 @@ class ADGemma4Tokenizer(PreTrainedTokenizerFast):
         return tokenizer
 
 
+class Gemma4ADInputProcessor:
+    """Input processor that ensures ``token_type_ids`` is always present.
+
+    Every request (text-only or multimodal) gets a ``token_type_ids`` tensor in
+    its multimodal data.  For text-only requests this is all-zeros (standard
+    causal attention).  For multimodal requests the HF processor already
+    provides it with per-blob IDs.  This guarantees the batched
+    ``token_type_ids`` tensor in ``extra_args`` always covers the full
+    flattened batch, including mixed image + text-only batches.
+    """
+
+    def __init__(self, base):
+        self.base = base
+
+    def __getattr__(self, name):
+        return getattr(self.base, name)
+
+    def __call__(self, inputs, sampling_params):
+        token_ids, extra = self.base(inputs, sampling_params)
+        if extra is None:
+            extra = {}
+        mm_data = extra.setdefault("multimodal_data", {})
+        if "token_type_ids" not in mm_data:
+            mm_data["token_type_ids"] = torch.zeros(1, len(token_ids), dtype=torch.int64)
+        return token_ids, extra
+
+
 @ModelFactoryRegistry.register("Gemma4ForConditionalGeneration")
-class Gemma4ForConditionalGenerationFactory(AutoModelForCausalLMFactory):
-    """Factory that wires the wrapper tokenizer for Gemma 4."""
+class Gemma4ForConditionalGenerationFactory(AutoModelForImageTextToTextFactory):
+    """Factory for Gemma 4 VLM with custom attention mask support."""
 
     def init_tokenizer(self) -> Optional[Any]:
         if self.tokenizer is None:
             return None
         return ADGemma4Tokenizer.from_pretrained(self.tokenizer)
+
+    def init_processor(self) -> Optional[Any]:
+        """Return the tokenizer as the processor for ADInputProcessor."""
+        if self.tokenizer is None:
+            return None
+        return ADGemma4Tokenizer.from_pretrained(self.tokenizer)
+
+    def init_input_processor(self, base):
+        return Gemma4ADInputProcessor(base)
 
 
 # ---------------------------------------------------------------------------

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -1,0 +1,892 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Slimmed down Gemma 4 text implementation for AutoDeploy export.
+
+This implementation follows the HuggingFace Gemma 4 text stack closely while
+keeping only the prefill path needed by AutoDeploy.  The outer
+``Gemma4ForConditionalGeneration`` wrapper preserves the HF checkpoint layout
+(``model.language_model.*``) and drops unsupported vision/audio tower weights
+at load time.  The forward path supports text-only export.
+
+Key architectural features of Gemma 4 vs standard transformers:
+- K=V attention on full-attention layers (v_proj is absent; k_proj output is
+  reused as value)
+- Different head dimensions for full vs sliding attention (global_head_dim vs
+  head_dim)
+- Proportional RoPE with partial_rotary_factor on full-attention layers
+- Dense MLP running in parallel with Mixture-of-Experts (MoE) in every layer
+- Per-layer scalar multiplier
+- Final logit softcapping
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import AutoConfig, PretrainedConfig
+from transformers.activations import ACT2FN
+from transformers.generation import GenerationMixin
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import ModelOutput
+
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+from tensorrt_llm._torch.utils import ActivationType
+
+# ---------------------------------------------------------------------------
+# Bundled config classes — enables loading on transformers <5.3 where
+# Gemma4 is not natively registered.
+# ---------------------------------------------------------------------------
+
+
+class Gemma4TextConfig(PretrainedConfig):
+    """Minimal Gemma4 text config for AutoDeploy."""
+
+    model_type = "gemma4_text"
+
+    def __init__(
+        self,
+        vocab_size: int = 262_144,
+        hidden_size: int = 2816,
+        intermediate_size: int = 2112,
+        num_hidden_layers: int = 30,
+        num_attention_heads: int = 16,
+        num_key_value_heads: int = 8,
+        head_dim: int = 256,
+        global_head_dim: int = 512,
+        num_global_key_value_heads: int = 2,
+        hidden_activation: str = "gelu_pytorch_tanh",
+        max_position_embeddings: int = 131_072,
+        rms_norm_eps: float = 1e-6,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        attention_k_eq_v: bool = True,
+        sliding_window: int = 1024,
+        layer_types: Optional[list] = None,
+        rope_parameters: Optional[dict] = None,
+        final_logit_softcapping: Optional[float] = 30.0,
+        hidden_size_per_layer_input: int = 0,
+        num_kv_shared_layers: int = 0,
+        use_double_wide_mlp: bool = False,
+        use_bidirectional_attention: Optional[str] = "vision",
+        enable_moe_block: bool = True,
+        num_experts: Optional[int] = 128,
+        top_k_experts: Optional[int] = 8,
+        expert_intermediate_size: Optional[int] = 704,
+        stream_and_decode_in_f32: bool = True,
+        vocab_size_per_layer_input: int = 262_144,
+        routed_layer_pattern: Optional[list] = None,
+        pad_token_id: Optional[int] = 0,
+        eos_token_id=1,
+        bos_token_id: Optional[int] = 2,
+        tie_word_embeddings: bool = True,
+        initializer_range: float = 0.02,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.global_head_dim = global_head_dim
+        self.num_global_key_value_heads = num_global_key_value_heads
+        self.hidden_activation = hidden_activation
+        self.max_position_embeddings = max_position_embeddings
+        self.rms_norm_eps = rms_norm_eps
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.attention_k_eq_v = attention_k_eq_v
+        self.sliding_window = sliding_window
+        self.layer_types = layer_types or (["sliding_attention"] * num_hidden_layers)
+        self.rope_parameters = rope_parameters or {
+            "full_attention": {
+                "rope_type": "proportional",
+                "rope_theta": 1_000_000.0,
+                "partial_rotary_factor": 0.25,
+            },
+            "sliding_attention": {"rope_type": "default", "rope_theta": 10_000.0},
+        }
+        self.final_logit_softcapping = final_logit_softcapping
+        self.hidden_size_per_layer_input = hidden_size_per_layer_input
+        self.num_kv_shared_layers = num_kv_shared_layers
+        self.use_double_wide_mlp = use_double_wide_mlp
+        self.use_bidirectional_attention = use_bidirectional_attention
+        self.enable_moe_block = enable_moe_block
+        self.num_experts = num_experts
+        self.top_k_experts = top_k_experts
+        self.expert_intermediate_size = expert_intermediate_size
+        self.stream_and_decode_in_f32 = stream_and_decode_in_f32
+        self.vocab_size_per_layer_input = vocab_size_per_layer_input
+        self.routed_layer_pattern = routed_layer_pattern
+        self.initializer_range = initializer_range
+        super().__init__(
+            pad_token_id=pad_token_id,
+            eos_token_id=eos_token_id,
+            bos_token_id=bos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+
+class Gemma4VisionConfig(PretrainedConfig):
+    """Minimal Gemma4 vision config stub."""
+
+    model_type = "gemma4_vision"
+
+    def __init__(self, hidden_size: int = 1152, rms_norm_eps: float = 1e-6, **kwargs):
+        self.hidden_size = hidden_size
+        self.rms_norm_eps = rms_norm_eps
+        super().__init__(**kwargs)
+
+
+class Gemma4Config(PretrainedConfig):
+    """Top-level Gemma4 multimodal config."""
+
+    model_type = "gemma4"
+
+    def __init__(
+        self,
+        text_config=None,
+        vision_config=None,
+        audio_config=None,
+        initializer_range: float = 0.02,
+        tie_word_embeddings: bool = True,
+        **kwargs,
+    ):
+        self.initializer_range = initializer_range
+        if text_config is None:
+            self.text_config = Gemma4TextConfig()
+        elif isinstance(text_config, dict):
+            self.text_config = Gemma4TextConfig(**text_config)
+        else:
+            self.text_config = text_config
+
+        if vision_config is None:
+            self.vision_config = Gemma4VisionConfig()
+        elif isinstance(vision_config, dict):
+            self.vision_config = Gemma4VisionConfig(**vision_config)
+        else:
+            self.vision_config = vision_config
+
+        self.audio_config = audio_config
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+
+
+AutoConfig.register("gemma4", Gemma4Config, exist_ok=True)
+AutoConfig.register("gemma4_text", Gemma4TextConfig, exist_ok=True)
+
+# ---------------------------------------------------------------------------
+# RoPE cache builder
+# ---------------------------------------------------------------------------
+
+
+def _build_rope_cache(
+    config: Gemma4TextConfig,
+    layer_type: str,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pre-compute cos/sin RoPE cache for the given layer type."""
+    rope_params = config.rope_parameters[layer_type]
+    rope_type = rope_params.get("rope_type", "default")
+    base = rope_params["rope_theta"]
+    factor = rope_params.get("factor", 1.0)
+    attention_scaling = 1.0
+
+    if rope_type == "default":
+        dim = config.head_dim
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+    elif rope_type == "proportional":
+        # Proportional RoPE: only partial_rotary_factor of head dims are rotated,
+        # remaining dims get zero inv_freq → cos=1, sin=0 (no rotation).
+        head_dim = config.global_head_dim
+        rope_proportion = rope_params.get("partial_rotary_factor", 1.0)
+        rope_angles = int(rope_proportion * head_dim // 2)
+        inv_freq_rotated = 1.0 / (
+            base ** (torch.arange(0, 2 * rope_angles, 2, dtype=torch.float) / head_dim)
+        )
+        nope_angles = head_dim // 2 - rope_angles
+        if nope_angles > 0:
+            inv_freq = torch.cat(
+                (inv_freq_rotated, torch.zeros(nope_angles, dtype=torch.float32)),
+                dim=0,
+            )
+        else:
+            inv_freq = inv_freq_rotated
+        inv_freq = inv_freq / factor
+    else:
+        # Fallback to HF ROPE_INIT_FUNCTIONS for other types (e.g. yarn, longrope)
+        rope_init_fn = ROPE_INIT_FUNCTIONS[rope_type]
+        inv_freq, attention_scaling = rope_init_fn(config, device=None, layer_type=layer_type)
+
+    positions = torch.arange(config.max_position_embeddings, dtype=inv_freq.dtype)
+    freqs = torch.outer(positions, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    return emb.cos() * attention_scaling, emb.sin() * attention_scaling
+
+
+# ---------------------------------------------------------------------------
+# Basic building blocks
+# ---------------------------------------------------------------------------
+
+
+class Gemma4RMSNorm(nn.Module):
+    """RMSNorm with Gemma4-style (weight + scale_shift) semantics.
+
+    For AD export, we store the *effective* weight = checkpoint_weight + scale_shift
+    via a load hook, then use the standard torch_rmsnorm op.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-6, with_scale: bool = True):
+        super().__init__()
+        self.eps = eps
+        self.with_scale = with_scale
+        if with_scale:
+            self.weight = nn.Parameter(torch.ones(dim))
+        else:
+            self.register_buffer("weight", torch.ones(dim), persistent=False)
+        if with_scale:
+            self._register_load_state_dict_pre_hook(self._apply_scale_shift)
+
+    @staticmethod
+    def _apply_scale_shift(state_dict, prefix, *_args, **_kwargs):
+        """Gemma4 RMSNorm stores weight that is used as (weight + 1.0).
+        Convert to effective weight at load time so torch_rmsnorm works directly."""
+        key = prefix + "weight"
+        if key in state_dict:
+            state_dict[key] = state_dict[key] + 1.0
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_rmsnorm(x, self.weight, self.eps)
+
+
+class Gemma4TextScaledWordEmbedding(nn.Embedding):
+    def __init__(
+        self, num_embeddings: int, embedding_dim: int, padding_idx: int, embed_scale: float
+    ):
+        super().__init__(num_embeddings, embedding_dim, padding_idx)
+        self.register_buffer("embed_scale", torch.tensor(embed_scale), persistent=False)
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return super().forward(input_ids) * self.embed_scale.to(dtype=self.weight.dtype)
+
+
+class Gemma4RotaryEmbedding(nn.Module):
+    """Pre-computed RoPE cache for a single layer type (global or local)."""
+
+    def __init__(self, config: Gemma4TextConfig, layer_type: str):
+        super().__init__()
+        (
+            cos,
+            sin,
+        ) = _build_rope_cache(config, layer_type)
+        self.register_buffer("_ad_cos_cached", cos, persistent=False)
+        self.register_buffer("_ad_sin_cached", sin, persistent=False)
+
+    def forward(
+        self, x: torch.Tensor, position_ids: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        cos = self._ad_cos_cached[position_ids].to(dtype=x.dtype, device=x.device)
+        sin = self._ad_sin_cached[position_ids].to(dtype=x.dtype, device=x.device)
+        return cos, sin
+
+
+# ---------------------------------------------------------------------------
+# MLP
+# ---------------------------------------------------------------------------
+
+
+class Gemma4TextMLP(nn.Module):
+    def __init__(self, config: Gemma4TextConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_activation]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+
+
+# ---------------------------------------------------------------------------
+# MoE Router + Experts
+# ---------------------------------------------------------------------------
+
+
+class Gemma4Router(nn.Module):
+    """Gemma4-style MoE router: RMSNorm(no-scale) -> per-dim scale -> linear -> softmax -> topk."""
+
+    def __init__(self, config: Gemma4TextConfig):
+        super().__init__()
+        self.proj = nn.Linear(config.hidden_size, config.num_experts, bias=False)
+        self.scale = nn.Parameter(torch.ones(config.hidden_size))
+        self.register_buffer("root_size", torch.tensor(config.hidden_size**-0.5), persistent=False)
+        self.eps = config.rms_norm_eps
+        self.top_k = config.top_k_experts
+
+    def forward(self, hidden_states: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        # RMSNorm without learnable scale
+        normed = hidden_states.float()
+        normed = normed * torch.rsqrt(normed.pow(2).mean(-1, keepdim=True) + self.eps)
+        normed = normed.type_as(hidden_states)
+        # Apply scalar and per-dim scaling
+        normed = normed * self.root_size.to(hidden_states.dtype)
+        normed = normed * self.scale.to(hidden_states.dtype)
+        # Route
+        expert_scores = self.proj(normed)
+        probs = F.softmax(expert_scores, dim=-1)
+        top_k_weights, top_k_index = torch.topk(probs, k=self.top_k, dim=-1)
+        top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True)
+        return top_k_weights, top_k_index
+
+
+class Gemma4Expert(nn.Module):
+    """Single MoE expert: gated MLP (gate_proj, up_proj, down_proj)."""
+
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+
+class Gemma4MoEBlock(nn.Module):
+    """Mixture-of-Experts block with fused checkpoint weight conversion.
+
+    Checkpoint stores fused parameters:
+      - gate_up_proj: [num_experts, 2*intermediate, hidden]
+      - down_proj: [num_experts, hidden, intermediate]
+      - per_expert_scale: [num_experts]
+
+    We unfuse these into per-expert nn.Linear modules at load time so that
+    torch_moe can consume them as weight lists.
+    """
+
+    def __init__(self, config: Gemma4TextConfig):
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.intermediate_size = config.expert_intermediate_size
+        self.experts = nn.ModuleList(
+            [
+                Gemma4Expert(config.hidden_size, config.expert_intermediate_size)
+                for _ in range(config.num_experts)
+            ]
+        )
+        self._register_load_state_dict_pre_hook(self._unfuse_moe_weights)
+
+    def _unfuse_moe_weights(self, state_dict, prefix, *_args, **_kwargs):
+        """Convert fused checkpoint MoE weights to per-expert format."""
+        gate_up_key = prefix + "gate_up_proj"
+        down_key = prefix + "down_proj"
+        scale_key = prefix + "per_expert_scale"
+
+        if gate_up_key not in state_dict:
+            return
+
+        gate_up = state_dict.pop(gate_up_key)  # [E, 2*I, H]
+        down = state_dict.pop(down_key)  # [E, H, I]
+        scale = state_dict.pop(scale_key)  # [E]
+
+        inter = self.intermediate_size
+        for e in range(self.num_experts):
+            state_dict[f"{prefix}experts.{e}.gate_proj.weight"] = gate_up[e, :inter, :]
+            state_dict[f"{prefix}experts.{e}.up_proj.weight"] = gate_up[e, inter:, :]
+            # Fold per_expert_scale into down_proj
+            state_dict[f"{prefix}experts.{e}.down_proj.weight"] = down[e] * scale[e]
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        top_k_index: torch.Tensor,
+        top_k_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_moe(
+            hidden_states,
+            top_k_index,
+            top_k_weights,
+            w1_weight=[e.gate_proj.weight for e in self.experts],
+            w2_weight=[e.down_proj.weight for e in self.experts],
+            w3_weight=[e.up_proj.weight for e in self.experts],
+            is_gated_mlp=True,
+            act_fn=int(ActivationType.Gelu),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Attention
+# ---------------------------------------------------------------------------
+
+
+class Gemma4TextAttention(nn.Module):
+    def __init__(self, config: Gemma4TextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.config = config
+        self.is_sliding = config.layer_types[layer_idx] == "sliding_attention"
+        self.sliding_window = config.sliding_window if self.is_sliding else None
+
+        # Full-attention layers may use different head dim and K=V
+        self.use_k_eq_v = config.attention_k_eq_v and not self.is_sliding
+        if not self.is_sliding and config.global_head_dim:
+            self.head_dim = config.global_head_dim
+        else:
+            self.head_dim = config.head_dim
+
+        num_kv_heads = (
+            config.num_global_key_value_heads if self.use_k_eq_v else config.num_key_value_heads
+        )
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = num_kv_heads
+
+        self.q_proj = nn.Linear(
+            config.hidden_size, self.num_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.k_proj = nn.Linear(
+            config.hidden_size, num_kv_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.v_proj = (
+            None
+            if self.use_k_eq_v
+            else nn.Linear(
+                config.hidden_size, num_kv_heads * self.head_dim, bias=config.attention_bias
+            )
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+        )
+
+        self.q_norm = Gemma4RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Gemma4RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        # v_norm has no learnable scale
+        self.v_norm = Gemma4RMSNorm(self.head_dim, eps=config.rms_norm_eps, with_scale=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = hidden_states.shape
+        q = self.q_proj(hidden_states).view(batch_size, seq_len, self.num_heads, self.head_dim)
+        k = self.k_proj(hidden_states).view(batch_size, seq_len, self.num_kv_heads, self.head_dim)
+
+        if self.v_proj is not None:
+            v = self.v_proj(hidden_states).view(
+                batch_size, seq_len, self.num_kv_heads, self.head_dim
+            )
+        else:
+            v = k  # K=V: reuse key as value
+
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+        v = self.v_norm(v)
+
+        cos, sin = position_embeddings
+        q, k = torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin(q, k, cos, sin, 2)
+
+        attn_output = torch.ops.auto_deploy.torch_attention(
+            q,
+            k,
+            v,
+            None,  # attn_mask
+            0.0,  # dropout_p
+            True,  # is_causal
+            1.0,  # scale (QK norms handle scaling)
+            None,  # sinks
+            self.sliding_window,
+            None,  # logit_cap
+            "bsnd",
+            self.layer_idx,
+        )
+        return self.o_proj(attn_output.reshape(batch_size, seq_len, -1))
+
+
+# ---------------------------------------------------------------------------
+# Decoder layer
+# ---------------------------------------------------------------------------
+
+
+class Gemma4TextDecoderLayer(nn.Module):
+    def __init__(self, config: Gemma4TextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.attention_type = config.layer_types[layer_idx]
+        self.self_attn = Gemma4TextAttention(config, layer_idx)
+        self.mlp = Gemma4TextMLP(config)
+        self.input_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_feedforward_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.register_buffer("layer_scalar", torch.ones(1))
+
+        self.enable_moe_block = config.enable_moe_block
+        if self.enable_moe_block:
+            self.router = Gemma4Router(config)
+            self.moe = Gemma4MoEBlock(config)
+            self.post_feedforward_layernorm_1 = Gemma4RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            self.post_feedforward_layernorm_2 = Gemma4RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            self.pre_feedforward_layernorm_2 = Gemma4RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        # Self-attention
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, position_embeddings)
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        # Feed-forward (dense MLP ± MoE)
+        residual = hidden_states
+
+        if self.enable_moe_block:
+            # Dense MLP path
+            hs_dense = self.pre_feedforward_layernorm(hidden_states)
+            hs_dense = self.mlp(hs_dense)
+            hs_dense = self.post_feedforward_layernorm_1(hs_dense)
+
+            # MoE path
+            hs_flat = hidden_states.reshape(-1, hidden_states.shape[-1])
+            top_k_weights, top_k_index = self.router(hs_flat)
+            hs_moe = self.pre_feedforward_layernorm_2(hs_flat)
+            hs_moe = self.moe(hs_moe, top_k_index, top_k_weights)
+            hs_moe = hs_moe.reshape(hidden_states.shape)
+            hs_moe = self.post_feedforward_layernorm_2(hs_moe)
+
+            hidden_states = hs_dense + hs_moe
+        else:
+            hidden_states = self.pre_feedforward_layernorm(hidden_states)
+            hidden_states = self.mlp(hidden_states)
+
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        hidden_states = hidden_states * self.layer_scalar
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Text model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Gemma4TextOutput(ModelOutput):
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class Gemma4CausalLMOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class Gemma4ConditionalOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+
+
+class Gemma4TextPreTrainedModel(PreTrainedModel):
+    config_class = Gemma4TextConfig
+    base_model_prefix = "model"
+    _no_split_modules = ["Gemma4TextDecoderLayer"]
+    supports_gradient_checkpointing = False
+
+    def _init_weights(self, module: nn.Module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+
+class Gemma4TextModel(Gemma4TextPreTrainedModel):
+    def __init__(self, config: Gemma4TextConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.embed_tokens = Gemma4TextScaledWordEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            self.padding_idx,
+            embed_scale=config.hidden_size**0.5,
+        )
+        self.layers = nn.ModuleList(
+            [Gemma4TextDecoderLayer(config, i) for i in range(config.num_hidden_layers)]
+        )
+        self.norm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        # Separate RoPE caches for global (full) and local (sliding) attention
+        self.rotary_emb_global = Gemma4RotaryEmbedding(config, "full_attention")
+        self.rotary_emb_local = Gemma4RotaryEmbedding(config, "sliding_attention")
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Gemma4TextOutput:
+        del kwargs
+        assert position_ids is not None, "position_ids must be provided"
+
+        if (input_ids is None) == (inputs_embeds is None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if input_ids is not None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        pos_emb_global = self.rotary_emb_global(inputs_embeds, position_ids)
+        pos_emb_local = self.rotary_emb_local(inputs_embeds, position_ids)
+
+        hidden_states = inputs_embeds
+        for decoder_layer in self.layers:
+            if decoder_layer.attention_type == "sliding_attention":
+                pos_emb = pos_emb_local
+            else:
+                pos_emb = pos_emb_global
+            hidden_states = decoder_layer(hidden_states, pos_emb)
+
+        hidden_states = self.norm(hidden_states)
+        return Gemma4TextOutput(last_hidden_state=hidden_states)
+
+
+# ---------------------------------------------------------------------------
+# CausalLM wrapper (text config)
+# ---------------------------------------------------------------------------
+
+
+class Gemma4ForCausalLM(Gemma4TextPreTrainedModel, GenerationMixin):
+    config_class = Gemma4TextConfig
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: Gemma4TextConfig, **kwargs):
+        del kwargs
+        super().__init__(config)
+        self.model = Gemma4TextModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, value):
+        self.lm_head = value
+
+    def get_decoder(self):
+        return self.model
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Gemma4CausalLMOutput:
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+        logits = self.lm_head(outputs.last_hidden_state)
+        if self.config.final_logit_softcapping is not None:
+            logits = logits / self.config.final_logit_softcapping
+            logits = torch.tanh(logits)
+            logits = logits * self.config.final_logit_softcapping
+        return Gemma4CausalLMOutput(logits=logits)
+
+
+# ---------------------------------------------------------------------------
+# Multimodal embedder stub (for weight loading)
+# ---------------------------------------------------------------------------
+
+
+class Gemma4MultimodalEmbedder(nn.Module):
+    """Minimal stub to accept embed_vision checkpoint weights."""
+
+    def __init__(self, vision_config: Gemma4VisionConfig, text_config: Gemma4TextConfig):
+        super().__init__()
+        self.embedding_projection = nn.Linear(
+            vision_config.hidden_size, text_config.hidden_size, bias=False
+        )
+
+
+# ---------------------------------------------------------------------------
+# ConditionalGeneration wrapper (multimodal config, text-only forward)
+# ---------------------------------------------------------------------------
+
+
+class Gemma4PreTrainedModel(PreTrainedModel):
+    config_class = Gemma4Config
+    base_model_prefix = "model"
+    _no_split_modules = ["Gemma4TextDecoderLayer"]
+    supports_gradient_checkpointing = False
+
+    def _init_weights(self, module: nn.Module):
+        std = getattr(self.config, "initializer_range", 0.02)
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+
+class Gemma4Model(Gemma4PreTrainedModel):
+    def __init__(self, config: Gemma4Config):
+        super().__init__(config)
+        self.language_model = Gemma4TextModel(config.text_config)
+        self.vision_tower = nn.Module()  # stub
+        self.embed_vision = Gemma4MultimodalEmbedder(config.vision_config, config.text_config)
+        self._register_load_state_dict_pre_hook(self._drop_unsupported_weights)
+        self.post_init()
+
+    @staticmethod
+    def _drop_unsupported_weights(state_dict, prefix, *_args, **_kwargs):
+        unsupported_prefixes = (
+            prefix + "vision_tower.",
+            prefix + "audio_tower.",
+            prefix + "embed_audio.",
+        )
+        for key in list(state_dict):
+            if key.startswith(unsupported_prefixes):
+                state_dict.pop(key)
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.language_model.set_input_embeddings(value)
+
+    def get_decoder(self):
+        return self.language_model
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        input_features: Optional[torch.Tensor] = None,
+        input_features_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Gemma4TextOutput:
+        del kwargs, input_features_mask
+        assert position_ids is not None, "position_ids must be provided"
+        if pixel_values is not None or input_features is not None:
+            raise NotImplementedError(
+                "Gemma4 multimodal inputs are not supported by the current AutoDeploy export "
+                "path. Use text-only prompts for this onboarding."
+            )
+        return self.language_model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+        )
+
+
+class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
+    config_class = Gemma4Config
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: Gemma4Config, **kwargs):
+        del kwargs
+        super().__init__(config)
+        self.model = Gemma4Model(config)
+        self.lm_head = nn.Linear(
+            config.text_config.hidden_size, config.text_config.vocab_size, bias=False
+        )
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, value):
+        self.lm_head = value
+
+    def get_decoder(self):
+        return self.model.get_decoder()
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        pixel_values: Optional[torch.Tensor] = None,
+        input_features: Optional[torch.Tensor] = None,
+        input_features_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> Gemma4ConditionalOutput:
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            input_features=input_features,
+            input_features_mask=input_features_mask,
+            **kwargs,
+        )
+        logits = self.lm_head(outputs.last_hidden_state)
+        if self.config.text_config.final_logit_softcapping is not None:
+            logits = logits / self.config.text_config.final_logit_softcapping
+            logits = torch.tanh(logits)
+            logits = logits * self.config.text_config.final_logit_softcapping
+        return Gemma4ConditionalOutput(logits=logits)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+AutoModelForCausalLMFactory.register_custom_model_cls("Gemma4TextConfig", Gemma4ForCausalLM)
+AutoModelForCausalLMFactory.register_custom_model_cls(
+    "Gemma4Config", Gemma4ForConditionalGeneration
+)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -41,6 +41,7 @@ import torch
 import torch.nn.functional as F
 from tokenizers import Tokenizer
 from torch import nn
+from torch.fx import GraphModule
 from transformers import AutoConfig, PretrainedConfig, PreTrainedTokenizerFast
 from transformers.activations import ACT2FN
 from transformers.generation import GenerationMixin
@@ -716,15 +717,42 @@ class Gemma4ForCausalLM(Gemma4TextPreTrainedModel, GenerationMixin):
     def __init__(self, config: Gemma4TextConfig, **kwargs):
         del kwargs
         super().__init__(config)
-        self.model = Gemma4TextModel(config)
+        self.padding_idx = config.pad_token_id
+        self.embed_tokens = Gemma4TextScaledWordEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            self.padding_idx,
+            embed_scale=config.hidden_size**0.5,
+        )
+        self.layers = nn.ModuleList(
+            [Gemma4TextDecoderLayer(config, i) for i in range(config.num_hidden_layers)]
+        )
+        self.norm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        # Keep the text backbone modules directly on the CausalLM wrapper so
+        # checkpoint keys match the HF layout: `language_model.layers.*`
+        # instead of `language_model.model.layers.*`.
+        self.rotary_emb_global = Gemma4RotaryEmbedding(config, "full_attention")
+        self.rotary_emb_local = Gemma4RotaryEmbedding(config, "sliding_attention")
         self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.register_load_state_dict_post_hook(self._retie_lm_head_weight)
         self.post_init()
+        if getattr(config, "tie_word_embeddings", True):
+            self.lm_head.weight = self.embed_tokens.weight
+
+    @staticmethod
+    def _retie_lm_head_weight(module, incompatible_keys):
+        del incompatible_keys
+        if not hasattr(module, "config") or not hasattr(module, "lm_head"):
+            return
+        if getattr(module.config, "tie_word_embeddings", True):
+            module.lm_head.weight = module.embed_tokens.weight
 
     def get_input_embeddings(self):
-        return self.model.get_input_embeddings()
+        return self.embed_tokens
 
     def set_input_embeddings(self, value):
-        self.model.set_input_embeddings(value)
+        self.embed_tokens = value
 
     def get_output_embeddings(self):
         return self.lm_head
@@ -733,7 +761,7 @@ class Gemma4ForCausalLM(Gemma4TextPreTrainedModel, GenerationMixin):
         self.lm_head = value
 
     def get_decoder(self):
-        return self.model
+        return self
 
     def forward(
         self,
@@ -742,13 +770,29 @@ class Gemma4ForCausalLM(Gemma4TextPreTrainedModel, GenerationMixin):
         inputs_embeds: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Gemma4CausalLMOutput:
-        outputs = self.model(
-            input_ids=input_ids,
-            position_ids=position_ids,
-            inputs_embeds=inputs_embeds,
-            **kwargs,
-        )
-        logits = self.lm_head(outputs.last_hidden_state)
+        del kwargs
+        assert position_ids is not None, "position_ids must be provided"
+
+        if (input_ids is None) == (inputs_embeds is None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if input_ids is not None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        assert inputs_embeds is not None
+        pos_emb_global = self.rotary_emb_global(inputs_embeds, position_ids)
+        pos_emb_local = self.rotary_emb_local(inputs_embeds, position_ids)
+
+        hidden_states = inputs_embeds
+        for decoder_layer in self.layers:
+            if decoder_layer.attention_type == "sliding_attention":
+                pos_emb = pos_emb_local
+            else:
+                pos_emb = pos_emb_global
+            hidden_states = decoder_layer(hidden_states, pos_emb)
+
+        hidden_states = self.norm(hidden_states)
+        logits = self.lm_head(hidden_states)
         if self.config.final_logit_softcapping is not None:
             logits = logits / self.config.final_logit_softcapping
             logits = torch.tanh(logits)
@@ -874,6 +918,48 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
         return self.model.get_decoder()
 
     @staticmethod
+    def _call_language_model(
+        language_model: nn.Module,
+        input_ids: Optional[torch.LongTensor],
+        position_ids: Optional[torch.LongTensor],
+        inputs_embeds: Optional[torch.Tensor],
+        **kwargs,
+    ):
+        """Call eager modules and exported FX graphs using their expected input structure."""
+        if not isinstance(language_model, GraphModule):
+            model_kwargs = dict(kwargs)
+            model_kwargs["position_ids"] = position_ids
+            if inputs_embeds is not None:
+                model_kwargs["inputs_embeds"] = inputs_embeds
+            else:
+                model_kwargs["input_ids"] = input_ids
+            return language_model(**model_kwargs)
+
+        available_args = {
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "inputs_embeds": inputs_embeds,
+            **kwargs,
+        }
+        placeholder_names = [
+            node.target for node in language_model.graph.nodes if node.op == "placeholder"
+        ]
+        in_spec = getattr(language_model, "_in_spec", None)
+        if in_spec is not None and in_spec.type is tuple and in_spec.num_children == 2:
+            pos_spec = in_spec.child(0)
+            kw_spec = in_spec.child(1)
+            num_positional = pos_spec.num_children if pos_spec.type is tuple else 0
+            positional_names = placeholder_names[:num_positional]
+            keyword_names = list(kw_spec.context) if kw_spec.type is dict else []
+
+            positional_args = [available_args.get(name) for name in positional_names]
+            keyword_args = {name: available_args.get(name) for name in keyword_names}
+            return language_model(*positional_args, **keyword_args)
+
+        positional_args = [available_args.get(name) for name in placeholder_names]
+        return language_model(*positional_args)
+
+    @staticmethod
     def _build_attention_mask(token_type_ids: torch.Tensor) -> torch.Tensor:
         """Build a bool attention mask from ``token_type_ids``.
 
@@ -926,7 +1012,8 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
         else:
             kwargs["custom_attn_mask"] = None
 
-        outputs = self.model.language_model(
+        outputs = self._call_language_model(
+            self.model.language_model,
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -18,8 +18,9 @@
 This implementation follows the HuggingFace Gemma 4 text stack closely while
 keeping only the prefill path needed by AutoDeploy.  The outer
 ``Gemma4ForConditionalGeneration`` wrapper preserves the HF checkpoint layout
-(``model.language_model.*``) and drops unsupported vision/audio tower weights
-at load time.  The forward path supports text-only export.
+(``model.language_model.*``). The text model is exported, while the outer
+wrapper remains eager so it can run Gemma4's multimodal vision merge path
+before delegating to the exported language model.
 
 Key architectural features of Gemma 4 vs standard transformers:
 - K=V attention on full-attention layers (v_proj is absent; k_proj output is
@@ -52,11 +53,10 @@ from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput, cached_file
 
-from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry, SubModuleExportInfo
+from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
 from tensorrt_llm._torch.auto_deploy.models.hf import (
     AutoModelForCausalLMFactory,
     AutoModelForImageTextToTextFactory,
-    TextModelExportInfo,
 )
 from tensorrt_llm._torch.utils import ActivationType
 
@@ -158,13 +158,48 @@ class Gemma4TextConfig(PretrainedConfig):
 
 
 class Gemma4VisionConfig(PretrainedConfig):
-    """Minimal Gemma4 vision config stub."""
+    """Gemma4 vision config."""
 
     model_type = "gemma4_vision"
 
-    def __init__(self, hidden_size: int = 1152, rms_norm_eps: float = 1e-6, **kwargs):
+    def __init__(
+        self,
+        hidden_size: int = 768,
+        intermediate_size: int = 3072,
+        num_hidden_layers: int = 16,
+        num_attention_heads: int = 12,
+        num_key_value_heads: int = 12,
+        head_dim: int = 64,
+        hidden_activation: str = "gelu_pytorch_tanh",
+        rms_norm_eps: float = 1e-6,
+        max_position_embeddings: int = 131_072,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        rope_parameters: Optional[dict] = None,
+        pooling_kernel_size: int = 3,
+        patch_size: int = 16,
+        position_embedding_size: int = 10 * 1024,
+        standardize: bool = False,
+        initializer_range: float = 0.02,
+        **kwargs,
+    ):
         self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.hidden_activation = hidden_activation
         self.rms_norm_eps = rms_norm_eps
+        self.max_position_embeddings = max_position_embeddings
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.rope_parameters = rope_parameters or {"rope_type": "default", "rope_theta": 100.0}
+        self.pooling_kernel_size = pooling_kernel_size
+        self.patch_size = patch_size
+        self.position_embedding_size = position_embedding_size
+        self.standardize = standardize
+        self.initializer_range = initializer_range
         super().__init__(**kwargs)
 
 
@@ -179,10 +214,20 @@ class Gemma4Config(PretrainedConfig):
         vision_config=None,
         audio_config=None,
         initializer_range: float = 0.02,
+        boi_token_id: int = 255_999,
+        eoi_token_id: int = 258_882,
+        image_token_id: int = 258_880,
+        video_token_id: int = 258_884,
+        audio_token_id: int = 258_881,
         tie_word_embeddings: bool = True,
         **kwargs,
     ):
         self.initializer_range = initializer_range
+        self.boi_token_id = boi_token_id
+        self.eoi_token_id = eoi_token_id
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+        self.audio_token_id = audio_token_id
         if text_config is None:
             self.text_config = Gemma4TextConfig()
         elif isinstance(text_config, dict):
@@ -203,6 +248,7 @@ class Gemma4Config(PretrainedConfig):
 
 AutoConfig.register("gemma4", Gemma4Config, exist_ok=True)
 AutoConfig.register("gemma4_text", Gemma4TextConfig, exist_ok=True)
+AutoConfig.register("gemma4_vision", Gemma4VisionConfig, exist_ok=True)
 
 # ---------------------------------------------------------------------------
 # RoPE cache builder
@@ -288,6 +334,17 @@ class Gemma4TextScaledWordEmbedding(nn.Embedding):
         return super().forward(input_ids) * self.embed_scale.to(dtype=self.weight.dtype)
 
 
+class Gemma4ClippableLinear(nn.Module):
+    """Wrapper matching the upstream Gemma4 ``*.linear.weight`` checkpoint layout."""
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = False):
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features, bias=bias)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.linear(hidden_states)
+
+
 class Gemma4RotaryEmbedding(nn.Module):
     """Pre-computed RoPE cache for a single layer type (global or local)."""
 
@@ -306,6 +363,367 @@ class Gemma4RotaryEmbedding(nn.Module):
         cos = self._ad_cos_cached[position_ids].to(dtype=x.dtype, device=x.device)
         sin = self._ad_sin_cached[position_ids].to(dtype=x.dtype, device=x.device)
         return cos, sin
+
+
+# ---------------------------------------------------------------------------
+# Vision tower
+# ---------------------------------------------------------------------------
+
+
+def _repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    batch_size, num_key_value_heads, seq_len, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch_size, num_key_value_heads, n_rep, seq_len, head_dim
+    )
+    return hidden_states.reshape(batch_size, num_key_value_heads * n_rep, seq_len, head_dim)
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _apply_rotary_pos_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    unsqueeze_dim: int = 1,
+) -> torch.Tensor:
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    return (x * cos) + (_rotate_half(x) * sin)
+
+
+def _apply_multidimensional_rope(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    unsqueeze_dim: int = 2,
+) -> torch.Tensor:
+    ndim = position_ids.shape[-1]
+    num_channels = x.shape[-1]
+    num_rotated_channels_per_dim = 2 * (num_channels // (2 * ndim))
+    if num_rotated_channels_per_dim <= 0:
+        raise ValueError(
+            f"Invalid Gemma4 vision RoPE configuration: num_channels={num_channels}, ndim={ndim}"
+        )
+
+    split_sizes = [num_rotated_channels_per_dim] * ndim
+    x_parts = torch.split(x, split_sizes, dim=-1)
+    cos_parts = torch.split(cos, split_sizes, dim=-1)
+    sin_parts = torch.split(sin, split_sizes, dim=-1)
+    outputs = [
+        _apply_rotary_pos_emb(
+            x=x_parts[idx],
+            cos=cos_parts[idx],
+            sin=sin_parts[idx],
+            unsqueeze_dim=unsqueeze_dim,
+        )
+        for idx in range(ndim)
+    ]
+    return torch.cat(outputs, dim=-1)
+
+
+class Gemma4VisionPatchEmbedder(nn.Module):
+    def __init__(self, config: Gemma4VisionConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.patch_size = config.patch_size
+        self.position_embedding_size = config.position_embedding_size
+        self.input_proj = nn.Linear(3 * self.patch_size**2, self.hidden_size, bias=False)
+        self.position_embedding_table = nn.Parameter(
+            torch.ones(2, self.position_embedding_size, self.hidden_size)
+        )
+
+    def _position_embeddings(
+        self, pixel_position_ids: torch.Tensor, padding_positions: torch.Tensor
+    ) -> torch.Tensor:
+        clamped_positions = pixel_position_ids.clamp(min=0)
+        one_hot = F.one_hot(clamped_positions, num_classes=self.position_embedding_size)
+        one_hot = one_hot.permute(0, 2, 1, 3).to(self.position_embedding_table)
+        position_embeddings = one_hot @ self.position_embedding_table
+        position_embeddings = position_embeddings.sum(dim=1)
+        return torch.where(padding_positions.unsqueeze(-1), 0.0, position_embeddings)
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        pixel_position_ids: torch.Tensor,
+        padding_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        pixel_values = 2 * (pixel_values - 0.5)
+        hidden_states = self.input_proj(pixel_values.to(self.input_proj.weight.dtype))
+        position_embeddings = self._position_embeddings(pixel_position_ids, padding_positions)
+        return hidden_states + position_embeddings
+
+
+class Gemma4VisionPooler(nn.Module):
+    def __init__(self, config: Gemma4VisionConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.root_hidden_size = self.hidden_size**0.5
+
+    def _avg_pool_by_positions(
+        self, hidden_states: torch.Tensor, pixel_position_ids: torch.Tensor, length: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        input_seq_len = hidden_states.shape[1]
+        kernel_size = int((input_seq_len // length) ** 0.5)
+        if kernel_size**2 * length != input_seq_len:
+            raise ValueError(
+                f"Cannot pool {hidden_states.shape} to {length}: incompatible kernel size"
+            )
+
+        clamped_positions = pixel_position_ids.clamp(min=0)
+        max_x = clamped_positions[..., 0].max(dim=-1, keepdim=True)[0] + 1
+        kernel_indices = torch.div(clamped_positions, kernel_size, rounding_mode="floor")
+        kernel_indices = kernel_indices[..., 0] + (max_x // kernel_size) * kernel_indices[..., 1]
+        weights = F.one_hot(kernel_indices.long(), length).float() / (kernel_size**2)
+        output = weights.transpose(1, 2) @ hidden_states.float()
+        mask = torch.logical_not((weights == 0).all(dim=1))
+        return output.to(hidden_states.dtype), mask
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        pixel_position_ids: torch.Tensor,
+        padding_positions: torch.Tensor,
+        output_length: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if output_length is None:
+            output_length = hidden_states.shape[1]
+        if output_length > hidden_states.shape[1]:
+            raise ValueError("Gemma4 vision pooler cannot increase the number of tokens")
+
+        hidden_states = hidden_states.masked_fill(padding_positions.unsqueeze(-1), 0.0)
+        if hidden_states.shape[1] != output_length:
+            hidden_states, padding_positions = self._avg_pool_by_positions(
+                hidden_states, pixel_position_ids, output_length
+            )
+        hidden_states *= self.root_hidden_size
+        return hidden_states, padding_positions
+
+
+class Gemma4VisionMLP(nn.Module):
+    def __init__(self, config: Gemma4VisionConfig):
+        super().__init__()
+        self.gate_proj = Gemma4ClippableLinear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.up_proj = Gemma4ClippableLinear(
+            config.hidden_size, config.intermediate_size, bias=False
+        )
+        self.down_proj = Gemma4ClippableLinear(
+            config.intermediate_size, config.hidden_size, bias=False
+        )
+        self.act_fn = ACT2FN[config.hidden_activation]
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(
+            self.act_fn(self.gate_proj(hidden_states)) * self.up_proj(hidden_states)
+        )
+
+
+class Gemma4VisionRotaryEmbedding(nn.Module):
+    def __init__(self, config: Gemma4VisionConfig):
+        super().__init__()
+        rope_theta = config.rope_parameters["rope_theta"]
+        spatial_dim = config.head_dim // 2
+        inv_freq = 1.0 / (
+            rope_theta ** (torch.arange(0, spatial_dim, 2, dtype=torch.float32) / spatial_dim)
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(
+        self, hidden_states: torch.Tensor, position_ids: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1)
+        )
+        all_cos = []
+        all_sin = []
+        for dim_idx in range(2):
+            dim_position_ids = position_ids[:, None, :, dim_idx].float().to(hidden_states.device)
+            freqs = (inv_freq_expanded.to(hidden_states.device) @ dim_position_ids).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            all_cos.append(emb.cos())
+            all_sin.append(emb.sin())
+        cos = torch.cat(all_cos, dim=-1).to(dtype=hidden_states.dtype, device=hidden_states.device)
+        sin = torch.cat(all_sin, dim=-1).to(dtype=hidden_states.dtype, device=hidden_states.device)
+        return cos, sin
+
+
+class Gemma4VisionAttention(nn.Module):
+    def __init__(self, config: Gemma4VisionConfig, layer_idx: int):
+        super().__init__()
+        del layer_idx
+        self.head_dim = config.head_dim
+        self.num_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.attention_dropout = config.attention_dropout
+        self.q_proj = Gemma4ClippableLinear(
+            config.hidden_size, self.num_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.k_proj = Gemma4ClippableLinear(
+            config.hidden_size, self.num_key_value_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.v_proj = Gemma4ClippableLinear(
+            config.hidden_size, self.num_key_value_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.o_proj = Gemma4ClippableLinear(
+            config.hidden_size, config.hidden_size, bias=config.attention_bias
+        )
+        self.q_norm = Gemma4RMSNorm(dim=self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Gemma4RMSNorm(dim=self.head_dim, eps=config.rms_norm_eps)
+        self.v_norm = Gemma4RMSNorm(dim=self.head_dim, eps=config.rms_norm_eps, with_scale=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        del position_ids
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+        cos, sin = position_embeddings
+
+        query_states = self.q_norm(self.q_proj(hidden_states).view(hidden_shape))
+        query_states = _apply_multidimensional_rope(
+            query_states, cos, sin, torch.zeros_like(cos[..., :2])
+        )
+        query_states = query_states.transpose(1, 2)
+
+        key_states = self.k_norm(self.k_proj(hidden_states).view(hidden_shape))
+        key_states = _apply_multidimensional_rope(
+            key_states, cos, sin, torch.zeros_like(cos[..., :2])
+        )
+        key_states = key_states.transpose(1, 2)
+
+        value_states = self.v_norm(self.v_proj(hidden_states).view(hidden_shape))
+        value_states = value_states.transpose(1, 2)
+
+        key_states = _repeat_kv(key_states, self.num_key_value_groups)
+        value_states = _repeat_kv(value_states, self.num_key_value_groups)
+
+        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3))
+        if attention_mask is not None:
+            invalid = torch.finfo(attn_weights.dtype).min
+            attn_weights = attn_weights.masked_fill(attention_mask.logical_not(), invalid)
+        attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        attn_output = torch.matmul(attn_weights, value_states)
+        attn_output = attn_output.transpose(1, 2).contiguous().reshape(*input_shape, -1)
+        return self.o_proj(attn_output), attn_weights
+
+
+class Gemma4VisionEncoderLayer(nn.Module):
+    def __init__(self, config: Gemma4VisionConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = Gemma4VisionAttention(config=config, layer_idx=layer_idx)
+        self.mlp = Gemma4VisionMLP(config)
+        self.input_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_feedforward_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor],
+        position_ids: torch.LongTensor,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        return residual + hidden_states
+
+
+class Gemma4VisionEncoder(nn.Module):
+    def __init__(self, config: Gemma4VisionConfig):
+        super().__init__()
+        self.rotary_emb = Gemma4VisionRotaryEmbedding(config)
+        self.layers = nn.ModuleList(
+            [
+                Gemma4VisionEncoderLayer(config=config, layer_idx=i)
+                for i in range(config.num_hidden_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        attention_mask: torch.Tensor,
+        pixel_position_ids: torch.LongTensor,
+    ) -> ModelOutput:
+        # Full bidirectional attention over valid patches only.
+        valid = attention_mask.to(torch.bool)
+        attention_mask_4d = valid[:, None, :, None] & valid[:, None, None, :]
+        hidden_states = inputs_embeds
+        position_embeddings = self.rotary_emb(hidden_states, pixel_position_ids)
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states,
+                attention_mask=attention_mask_4d,
+                position_embeddings=position_embeddings,
+                position_ids=pixel_position_ids,
+            )
+        return ModelOutput(last_hidden_state=hidden_states)
+
+
+class Gemma4VisionModel(nn.Module):
+    def __init__(self, config: Gemma4VisionConfig):
+        super().__init__()
+        self.config = config
+        self.patch_embedder = Gemma4VisionPatchEmbedder(config)
+        self.encoder = Gemma4VisionEncoder(config)
+        self.pooler = Gemma4VisionPooler(config)
+
+        if self.config.standardize:
+            self.register_buffer("std_bias", torch.empty(self.config.hidden_size))
+            self.register_buffer("std_scale", torch.empty(self.config.hidden_size))
+
+    def forward(
+        self,
+        pixel_values: torch.FloatTensor,
+        pixel_position_ids: torch.LongTensor,
+    ) -> ModelOutput:
+        pooling_kernel_size = self.config.pooling_kernel_size
+        output_length = pixel_values.shape[-2] // (pooling_kernel_size * pooling_kernel_size)
+        padding_positions = (pixel_position_ids == -1).all(dim=-1)
+        inputs_embeds = self.patch_embedder(pixel_values, pixel_position_ids, padding_positions)
+        output = self.encoder(
+            inputs_embeds=inputs_embeds,
+            attention_mask=~padding_positions,
+            pixel_position_ids=pixel_position_ids,
+        )
+        hidden_states, pooler_mask = self.pooler(
+            hidden_states=output.last_hidden_state,
+            pixel_position_ids=pixel_position_ids,
+            padding_positions=padding_positions,
+            output_length=output_length,
+        )
+        hidden_states = hidden_states[pooler_mask]
+        if self.config.standardize:
+            hidden_states = (hidden_states - self.std_bias) * self.std_scale
+        return ModelOutput(last_hidden_state=hidden_states)
 
 
 # ---------------------------------------------------------------------------
@@ -809,13 +1227,21 @@ class Gemma4ForCausalLM(Gemma4TextPreTrainedModel, GenerationMixin):
 
 
 class Gemma4MultimodalEmbedder(nn.Module):
-    """Minimal stub to accept embed_vision checkpoint weights."""
+    """Projects multimodal hidden states into language-model space."""
 
     def __init__(self, vision_config: Gemma4VisionConfig, text_config: Gemma4TextConfig):
         super().__init__()
+        self.eps = vision_config.rms_norm_eps
         self.embedding_projection = nn.Linear(
             vision_config.hidden_size, text_config.hidden_size, bias=False
         )
+        self.embedding_pre_projection_norm = Gemma4RMSNorm(
+            vision_config.hidden_size, eps=self.eps, with_scale=False
+        )
+
+    def forward(self, inputs_embeds: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.embedding_pre_projection_norm(inputs_embeds)
+        return self.embedding_projection(hidden_states)
 
 
 # ---------------------------------------------------------------------------
@@ -845,7 +1271,9 @@ class Gemma4Model(Gemma4PreTrainedModel):
     def __init__(self, config: Gemma4Config):
         super().__init__(config)
         self.language_model = Gemma4ForCausalLM(config.text_config)
-        self.vision_tower = nn.Module()  # stub
+        self.vision_tower = (
+            Gemma4VisionModel(config.vision_config) if config.vision_config is not None else None
+        )
         self.embed_vision = Gemma4MultimodalEmbedder(config.vision_config, config.text_config)
         self._register_load_state_dict_pre_hook(self._remap_and_drop_weights)
         self.post_init()
@@ -853,13 +1281,43 @@ class Gemma4Model(Gemma4PreTrainedModel):
     @staticmethod
     def _remap_and_drop_weights(state_dict, prefix, *_args, **_kwargs):
         unsupported_prefixes = (
-            prefix + "vision_tower.",
             prefix + "audio_tower.",
             prefix + "embed_audio.",
         )
         for key in list(state_dict):
             if key.startswith(unsupported_prefixes):
                 state_dict.pop(key)
+
+    def get_image_features(
+        self,
+        pixel_values: torch.FloatTensor,
+        image_position_ids: Optional[torch.LongTensor] = None,
+    ) -> ModelOutput:
+        if self.vision_tower is None:
+            raise ValueError("Gemma4 vision_tower is not initialized")
+        vision_outputs = self.vision_tower(
+            pixel_values=pixel_values,
+            pixel_position_ids=image_position_ids,
+        )
+        last_hidden_state = vision_outputs.last_hidden_state
+        return ModelOutput(
+            last_hidden_state=last_hidden_state,
+            pooler_output=self.embed_vision(inputs_embeds=last_hidden_state),
+        )
+
+    def get_placeholder_mask(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+    ) -> torch.BoolTensor:
+        if input_ids is not None:
+            return input_ids == self.config.image_token_id
+        if inputs_embeds is None:
+            raise ValueError("Either input_ids or inputs_embeds must be provided")
+        image_embedding = self.get_input_embeddings()(
+            torch.tensor(self.config.image_token_id, dtype=torch.long, device=inputs_embeds.device)
+        )
+        return (inputs_embeds == image_embedding).all(-1)
 
     def get_input_embeddings(self):
         return self.language_model.get_input_embeddings()
@@ -875,14 +1333,77 @@ class Gemma4Model(Gemma4PreTrainedModel):
         input_ids: Optional[torch.LongTensor] = None,
         position_ids: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
+        pixel_values: Optional[torch.FloatTensor] = None,
+        image_position_ids: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> Gemma4CausalLMOutput:
-        del kwargs
         assert position_ids is not None, "position_ids must be provided"
-        return self.language_model(
-            input_ids=input_ids,
+        if (input_ids is None) == (inputs_embeds is None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        # DEBUG: trace image embedding injection
+        import logging
+
+        _dbg = logging.getLogger("gemma4_debug")
+        _dbg.debug(
+            "[Gemma4Model forward] pixel_values=%s | image_position_ids=%s | "
+            "input_ids_shape=%s | inputs_embeds_shape=%s | kwargs_keys=%s",
+            pixel_values.shape if pixel_values is not None else "None",
+            image_position_ids.shape if image_position_ids is not None else "None",
+            input_ids.shape if input_ids is not None else "None",
+            inputs_embeds.shape if inputs_embeds is not None else "None",
+            list(kwargs.keys()),
+        )
+
+        if inputs_embeds is None:
+            image_mask = self.get_placeholder_mask(input_ids=input_ids)
+            llm_input_ids = input_ids.clone()
+            llm_input_ids = torch.where(
+                image_mask,
+                torch.full_like(llm_input_ids, self.config.text_config.pad_token_id),
+                llm_input_ids,
+            )
+            inputs_embeds = self.get_input_embeddings()(llm_input_ids)
+        else:
+            image_mask = self.get_placeholder_mask(inputs_embeds=inputs_embeds)
+
+        if pixel_values is not None:
+            image_features = self.get_image_features(
+                pixel_values=pixel_values,
+                image_position_ids=image_position_ids,
+            ).pooler_output
+            image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+            expanded_image_mask = image_mask.unsqueeze(-1).expand_as(inputs_embeds)
+            _dbg.debug(
+                "[Gemma4Model EMBED INJECTION] image_mask sum=%d | image_mask shape=%s | "
+                "image_features shape=%s | image_features mean=%.6f std=%.6f | "
+                "inputs_embeds mean=%.6f std=%.6f (before scatter) | "
+                "pixel_values shape=%s mean=%.6f",
+                image_mask.sum().item(),
+                tuple(image_mask.shape),
+                tuple(image_features.shape),
+                image_features.mean().item(),
+                image_features.std().item(),
+                inputs_embeds.mean().item(),
+                inputs_embeds.std().item(),
+                tuple(pixel_values.shape),
+                pixel_values.mean().item(),
+            )
+            if inputs_embeds[expanded_image_mask].numel() != image_features.numel():
+                raise ValueError("Image features and image placeholder tokens do not match")
+            inputs_embeds = inputs_embeds.masked_scatter(expanded_image_mask, image_features)
+            _dbg.debug(
+                "[Gemma4Model EMBED INJECTION] inputs_embeds mean=%.6f std=%.6f (after scatter)",
+                inputs_embeds.mean().item(),
+                inputs_embeds.std().item(),
+            )
+
+        return Gemma4ForConditionalGeneration._call_language_model(
+            self.language_model,
+            input_ids=None,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
+            **kwargs,
         )
 
 
@@ -899,7 +1420,7 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
 
     @staticmethod
     def _remap_lm_head_weight(state_dict, prefix, *_args, **_kwargs):
-        """Remap lm_head into language_model so TextModelExportInfo exports it."""
+        """Remap lm_head into language_model so the export info exports it."""
         old_key = prefix + "lm_head.weight"
         new_key = prefix + "model.language_model.lm_head.weight"
         if old_key in state_dict and new_key not in state_dict:
@@ -963,41 +1484,82 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
         return language_model(*positional_args)
 
     @staticmethod
-    def _build_attention_mask(token_type_ids: torch.Tensor) -> torch.Tensor:
-        """Build a bool attention mask from ``token_type_ids``.
+    def _blob_ids_from_spans(
+        kv_len: int,
+        mm_positions: torch.Tensor,
+        mm_lengths: torch.Tensor,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Build per-position blob IDs for a single sequence from span metadata.
 
-        Returns a ``[batch, 1, seq, seq]`` bool mask that is causal for text
-        tokens and bidirectional within contiguous media blobs.
+        Spans use absolute request-local coordinates, so this works correctly
+        for any chunk window during chunked prefill.
+
+        Returns a 1D ``[kv_len]`` tensor where text positions are 0 and media
+        positions have blob IDs 1, 2, ...
         """
-        batch_size, seq_len = token_type_ids.shape
-        device = token_type_ids.device
+        blob_ids = torch.zeros(kv_len, dtype=torch.int64, device=device)
+        for i in range(mm_positions.shape[0]):
+            start = int(mm_positions[i].item())
+            length = int(mm_lengths[i].item())
+            end = min(start + length, kv_len)
+            if start < kv_len:
+                blob_ids[start:end] = i + 1
+        return blob_ids
 
-        # Identify non-text tokens and detect blob boundaries
-        non_text = token_type_ids.ne(0)
-        prev = torch.cat(
-            [
-                torch.zeros(batch_size, 1, dtype=token_type_ids.dtype, device=device),
-                token_type_ids[:, :-1],
-            ],
-            dim=1,
-        )
-        blob_starts = non_text & token_type_ids.ne(prev)
-        blob_ids = torch.cumsum(blob_starts.to(torch.int64), dim=1)
-        token_blob_ids = torch.where(non_text, blob_ids, torch.zeros_like(blob_ids))
+    @staticmethod
+    def _build_attention_mask(
+        batch_info_host: torch.Tensor,
+        cu_seqlen: torch.Tensor,
+        input_pos: torch.Tensor,
+        mm_positions: torch.Tensor,
+        mm_lengths: torch.Tensor,
+        mm_cu_seqlen: torch.Tensor,
+    ) -> torch.Tensor:
+        """Build per-sequence attention masks from span metadata + batch geometry.
 
-        # Bidirectional within same media blob
-        blob_q = token_blob_ids.unsqueeze(2)  # [B, S, 1]
-        blob_k = token_blob_ids.unsqueeze(1)  # [B, 1, S]
-        bidirectional_media = (blob_q == blob_k) & (blob_q != 0)
+        Returns a ``[num_prefill, 1, max_q, max_kv]`` bool mask that is causal
+        for text tokens and bidirectional within contiguous media blobs.
+        """
+        num_prefill = int(batch_info_host[0].item())
+        device = mm_positions.device
 
-        # Standard causal mask
-        positions = torch.arange(seq_len, device=device)
-        causal_mask = positions.unsqueeze(0) <= positions.unsqueeze(1)  # [S, S]
-        causal_mask = causal_mask.unsqueeze(0)  # [1, S, S]
+        masks = []
+        max_q = 0
+        max_kv = 0
 
-        # Combine: causal OR bidirectional-within-blob
-        combined = causal_mask | bidirectional_media  # [B, S, S]
-        return combined.unsqueeze(1)  # [B, 1, S, S]
+        for i in range(num_prefill):
+            q_start = int(input_pos[i].item())
+            q_len = int(cu_seqlen[i + 1].item()) - int(cu_seqlen[i].item())
+            kv_len = q_start + q_len
+
+            span_start = int(mm_cu_seqlen[i].item())
+            span_end = int(mm_cu_seqlen[i + 1].item())
+            seq_positions = mm_positions[span_start:span_end]
+            seq_lengths = mm_lengths[span_start:span_end]
+
+            blob_ids = Gemma4ForConditionalGeneration._blob_ids_from_spans(
+                kv_len, seq_positions, seq_lengths, device
+            )
+
+            q_blob = blob_ids[q_start : q_start + q_len].unsqueeze(1)  # [Q, 1]
+            kv_blob = blob_ids.unsqueeze(0)  # [1, KV]
+            bidirectional = (q_blob == kv_blob) & (q_blob != 0)  # [Q, KV]
+
+            q_pos = torch.arange(q_start, q_start + q_len, device=device).unsqueeze(1)
+            kv_pos = torch.arange(kv_len, device=device).unsqueeze(0)
+            causal = kv_pos <= q_pos  # [Q, KV]
+
+            mask = (causal | bidirectional).unsqueeze(0)  # [1, Q, KV]
+            masks.append(mask)
+            max_q = max(max_q, q_len)
+            max_kv = max(max_kv, kv_len)
+
+        padded = []
+        for mask in masks:
+            _, q, kv = mask.shape
+            padded.append(F.pad(mask, (0, max_kv - kv, 0, max_q - q), value=False))
+        return torch.stack(padded, dim=0)  # [num_prefill, 1, max_q, max_kv]
 
     def forward(
         self,
@@ -1006,17 +1568,105 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
         inputs_embeds: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> Gemma4ConditionalOutput:
-        # Compute custom attention mask from token_type_ids outside the graph.
-        # Pass None during warmup / text-only / decode so the attention backend
+        # Build attention mask from span metadata (mm_token_positions/lengths)
+        # provided by _store_prefill_multimodal_metadata in the AD executor.
+        # Pass None during decode / text-only / warmup so the attention backend
         # uses its fast causal kernel instead of the per-sequence fallback.
-        token_type_ids = kwargs.pop("token_type_ids", None)
-        if token_type_ids is not None and token_type_ids.any():
-            kwargs["custom_attn_mask"] = self._build_attention_mask(token_type_ids)
+        kwargs.pop("token_type_ids", None)
+
+        batch_info_host = kwargs.get("batch_info_host")
+        mm_positions = kwargs.pop("mm_token_positions", None)
+        mm_lengths = kwargs.pop("mm_token_lengths", None)
+        mm_cu_seqlen = kwargs.pop("mm_item_cu_seqlen", None)
+
+        for key in (
+            "mm_item_types",
+            "mm_special_offsets_cu_seqlen",
+            "mm_special_offsets",
+            "mm_chunk_flat_start",
+            "mm_chunk_count",
+        ):
+            kwargs.pop(key, None)
+
+        has_media = (
+            mm_positions is not None and mm_positions.numel() > 0 and batch_info_host is not None
+        )
+
+        # DEBUG: trace mask construction inputs and vision tower weight loading
+        import logging
+
+        _dbg = logging.getLogger("gemma4_debug")
+        _dbg.setLevel(logging.DEBUG)
+        if not _dbg.handlers:
+            _dbg.addHandler(logging.StreamHandler())
+        vt_w = self.model.vision_tower.patch_embedder.input_proj.weight
+        if not vt_w.is_meta:
+            ev_w = self.model.embed_vision.embedding_projection.weight
+            _dbg.debug(
+                "[Gemma4 WEIGHT CHECK] vision_tower input_proj: mean=%.6f std=%.6f | "
+                "embed_vision projection: mean=%.6f std=%.6f",
+                vt_w.mean().item(),
+                vt_w.std().item(),
+                ev_w.mean().item(),
+                ev_w.std().item(),
+            )
+        _dbg.debug(
+            "[Gemma4 OUTER forward] has_media=%s | mm_positions=%s | mm_lengths=%s | "
+            "mm_cu_seqlen=%s | batch_info_host=%s | kwargs_keys=%s | "
+            "input_ids_shape=%s | pixel_values_in_kwargs=%s",
+            has_media,
+            mm_positions if mm_positions is not None else "None",
+            mm_lengths if mm_lengths is not None else "None",
+            mm_cu_seqlen if mm_cu_seqlen is not None else "None",
+            batch_info_host if batch_info_host is not None else "None",
+            list(kwargs.keys()),
+            input_ids.shape if input_ids is not None else "None",
+            "pixel_values" in kwargs,
+        )
+
+        if has_media:
+            cu_seqlen = kwargs.get("cu_seqlen")
+            if cu_seqlen is None:
+                cu_seqlen = kwargs.get("cu_seqlen_host")
+            input_pos = kwargs.get("input_pos")
+            if input_pos is None:
+                seq_len_with_cache = kwargs.get("seq_len_with_cache")
+                if seq_len_with_cache is None:
+                    seq_len_with_cache = kwargs.get("seq_len_with_cache_host")
+                seq_len = kwargs.get("seq_len")
+                if seq_len is None and cu_seqlen is not None:
+                    seq_len = cu_seqlen[1:] - cu_seqlen[:-1]
+                if seq_len_with_cache is not None and seq_len is not None:
+                    input_pos = seq_len_with_cache.to(seq_len.device) - seq_len
+            _built_mask = self._build_attention_mask(
+                batch_info_host,
+                cu_seqlen,
+                input_pos,
+                mm_positions,
+                mm_lengths,
+                mm_cu_seqlen,
+            )
+            kwargs["custom_attn_mask"] = _built_mask
+            _dbg.debug(
+                "[Gemma4 OUTER forward] mask built: shape=%s dtype=%s device=%s | "
+                "input_pos=%s | cu_seqlen=%s | "
+                "mask[0,0,0,:5]=%s | mask[0,0,1,:5]=%s | mask[0,0,-1,:5]=%s | "
+                "True_count=%d / total=%d",
+                _built_mask.shape,
+                _built_mask.dtype,
+                _built_mask.device,
+                input_pos,
+                cu_seqlen,
+                _built_mask[0, 0, 0, :5].tolist(),
+                _built_mask[0, 0, 1, :5].tolist(),
+                _built_mask[0, 0, -1, :5].tolist(),
+                int(_built_mask.sum().item()),
+                _built_mask.numel(),
+            )
         else:
             kwargs["custom_attn_mask"] = None
 
-        outputs = self._call_language_model(
-            self.model.language_model,
+        outputs = self.model(
             input_ids=input_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
@@ -1217,6 +1867,9 @@ class ADGemma4ImageProcessor:
 
     @staticmethod
     def _to_tensor(image, do_convert_rgb: bool) -> torch.Tensor:
+        if isinstance(image, (str, Path)):
+            image = Image.open(image)
+
         if isinstance(image, Image.Image):
             if do_convert_rgb:
                 image = image.convert("RGB")
@@ -1463,30 +2116,28 @@ class ADGemma4Processor:
                     token_type_ids[batch_idx, token_idx] = current_blob_id
         return token_type_ids
 
-    def _render_messages(self, messages) -> Tuple[List[str], List[List[Any]]]:
-        batched_messages = messages if messages and isinstance(messages[0], list) else [messages]
-        rendered_prompts: List[str] = []
-        batched_images: List[List[Any]] = []
+    @staticmethod
+    def _render_messages(messages) -> Tuple[List[str], List[Any]]:
+        """Extract text + images from a single conversation.
 
-        for conversation in batched_messages:
-            parts: List[str] = []
-            conversation_images: List[Any] = []
-            for message in conversation:
-                content = message.get("content", "")
-                if isinstance(content, str):
-                    parts.append(content)
-                    continue
-                for item in content:
-                    item_type = item.get("type")
-                    if item_type == "text":
-                        parts.append(item.get("text", ""))
-                    elif item_type == "image":
-                        parts.append(self.image_token)
-                        conversation_images.append(item.get("image"))
-            rendered_prompts.append(" ".join(part for part in parts if part))
-            batched_images.append(conversation_images)
-
-        return rendered_prompts, batched_images
+        Returns ``(rendered_text, images)`` where ``rendered_text`` has an
+        ``<|image|>`` placeholder for each image.
+        """
+        parts: List[str] = []
+        images: List[Any] = []
+        for message in messages:
+            content = message.get("content", "")
+            if isinstance(content, str):
+                parts.append(content)
+                continue
+            for item in content:
+                item_type = item.get("type")
+                if item_type == "text":
+                    parts.append(item.get("text", ""))
+                elif item_type == "image":
+                    parts.append("<|image|>")
+                    images.append(item.get("image"))
+        return " ".join(part for part in parts if part), images
 
     def apply_chat_template(
         self,
@@ -1498,15 +2149,53 @@ class ADGemma4Processor:
         add_generation_prompt: bool = True,
         **kwargs,
     ):
-        del add_generation_prompt
-        text, batched_images = self._render_messages(messages)
+        is_batched = messages and isinstance(messages[0], list)
+        batched_messages = messages if is_batched else [messages]
+
+        rendered_texts: List[str] = []
+        batched_images: List[List[Any]] = []
+        has_chat_template = bool(self.chat_template)
+
+        for conversation in batched_messages:
+            if has_chat_template:
+                # Use the Jinja chat template for proper turn formatting.
+                # Strip image content items so the template only sees text;
+                # we insert image placeholders ourselves afterwards.
+                text_only_conv = []
+                conv_images: List[Any] = []
+                for message in conversation:
+                    content = message.get("content", "")
+                    if isinstance(content, str):
+                        text_only_conv.append(message)
+                        continue
+                    text_parts: List[str] = []
+                    for item in content:
+                        if item.get("type") == "text":
+                            text_parts.append(item.get("text", ""))
+                        elif item.get("type") == "image":
+                            text_parts.append(self.image_token)
+                            conv_images.append(item.get("image"))
+                    text_only_conv.append({**message, "content": " ".join(text_parts)})
+                rendered_texts.append(
+                    self.tokenizer.apply_chat_template(
+                        text_only_conv,
+                        chat_template=self.chat_template,
+                        add_generation_prompt=add_generation_prompt,
+                        tokenize=False,
+                    )
+                )
+                batched_images.append(conv_images)
+            else:
+                # No chat template — render messages directly.
+                text, conv_images = self._render_messages(conversation)
+                rendered_texts.append(text)
+                batched_images.append(conv_images)
+
         if not tokenize:
-            if messages and isinstance(messages[0], list):
-                return text
-            return text[0]
+            return rendered_texts if is_batched else rendered_texts[0]
 
         result = self(
-            text=text,
+            text=rendered_texts,
             images=batched_images,
             return_dict=True,
             return_tensors=return_tensors,
@@ -1554,58 +2243,104 @@ class ADGemma4Processor:
 
 
 class Gemma4ADInputProcessor:
-    """Input processor that ensures ``token_type_ids`` is always present.
+    """Input processor that ensures ``multimodal_input`` is set.
 
-    Every request (text-only or multimodal) gets a ``token_type_ids`` tensor in
-    its multimodal data.  For text-only requests this is all-zeros (standard
-    causal attention).  For multimodal requests the local Gemma4 processor
-    provides it with per-blob IDs.  This guarantees the batched
-    ``token_type_ids`` tensor in ``extra_args`` always covers the full
-    flattened batch, including mixed image + text-only batches.
+    For multimodal requests, ``multimodal_input`` is computed with image token
+    positions and lengths so the AD executor can stage span metadata
+    (``mm_token_positions``, ``mm_token_lengths``, ``mm_item_cu_seqlen``) for
+    the eager wrapper to build per-sequence attention masks.
     """
 
-    def __init__(self, base):
+    def __init__(self, base, image_token_id: int, boi_token_id: int, eoi_token_id: int):
         self.base = base
+        self.image_token_id = image_token_id
+        self.boi_token_id = boi_token_id
+        self.eoi_token_id = eoi_token_id
 
     def __getattr__(self, name):
         return getattr(self.base, name)
+
+    def _find_image_spans(self, token_ids: List[int]) -> Tuple[List[int], List[int]]:
+        """Find start positions and lengths of each image blob (boi…eoi) span."""
+        positions: List[int] = []
+        lengths: List[int] = []
+        i = 0
+        while i < len(token_ids):
+            if token_ids[i] == self.boi_token_id:
+                start = i
+                # Scan to the matching eoi token
+                j = i + 1
+                while j < len(token_ids) and token_ids[j] != self.eoi_token_id:
+                    j += 1
+                end = j + 1 if j < len(token_ids) else j  # include eoi
+                positions.append(start)
+                lengths.append(end - start)
+                i = end
+            else:
+                i += 1
+        return positions, lengths
 
     def __call__(self, inputs, sampling_params):
         token_ids, extra = self.base(inputs, sampling_params)
         if extra is None:
             extra = {}
-        mm_data = extra.setdefault("multimodal_data", {})
-        if "token_type_ids" not in mm_data:
-            mm_data["token_type_ids"] = torch.zeros(1, len(token_ids), dtype=torch.int64)
+
+        # DEBUG: token analysis
+        import logging
+
+        _dbg = logging.getLogger("gemma4_debug")
+        _dbg.setLevel(logging.DEBUG)
+        if not _dbg.handlers:
+            _dbg.addHandler(logging.StreamHandler())
+        boi_count = token_ids.count(self.boi_token_id)
+        eoi_count = token_ids.count(self.eoi_token_id)
+        img_count = token_ids.count(self.image_token_id)
+        _dbg.debug(
+            "[Gemma4 INPUT PROCESSOR] total_tokens=%d | boi_count=%d (id=%d) | "
+            "eoi_count=%d (id=%d) | image_token_count=%d (id=%d) | "
+            "first_20_ids=%s | last_10_ids=%s",
+            len(token_ids),
+            boi_count,
+            self.boi_token_id,
+            eoi_count,
+            self.eoi_token_id,
+            img_count,
+            self.image_token_id,
+            token_ids[:20],
+            token_ids[-10:],
+        )
+
+        # Remove token_type_ids if the base processor added it — mask is now
+        # built from span metadata in the eager wrapper.
+        mm_data = extra.get("multimodal_data")
+        if mm_data is not None:
+            mm_data.pop("token_type_ids", None)
+
+        # Compute multimodal_input so the executor knows where image spans are.
+        if "multimodal_input" not in extra:
+            positions, lengths = self._find_image_spans(token_ids)
+            if positions:
+                from tensorrt_llm.inputs.multimodal import MultimodalInput
+
+                # Dummy hashes — KV-cache reuse for images is not yet supported.
+                dummy_hashes = [[0] * 8 for _ in positions]
+                extra["multimodal_input"] = MultimodalInput.from_components(
+                    mm_hashes=dummy_hashes,
+                    mm_positions=positions,
+                    mm_lengths=lengths,
+                )
+            _dbg.debug(
+                "[Gemma4 INPUT PROCESSOR] image_spans: positions=%s lengths=%s",
+                positions,
+                lengths,
+            )
+
         return token_ids, extra
-
-
-class Gemma4TextModelExportInfo(TextModelExportInfo):
-    """Export config for the Gemma4 text submodule.
-
-    Extends the base ``TextModelExportInfo`` with ``token_type_ids`` as a
-    dynamically-shaped input so that it is exported with symbolic batch/seq
-    dimensions rather than concrete static shapes.
-    """
-
-    def _init_dynamic_shape_lookup(self):
-        lookup = super()._init_dynamic_shape_lookup()
-        # Reuse the same dynamic dim objects from input_ids so export can verify
-        # that batch and seq dimensions are semantically identical across inputs.
-        batch_dim = lookup["input_ids"][0]
-        seq_dim = lookup["input_ids"][1]
-        lookup["token_type_ids"] = {0: batch_dim, 1: seq_dim}
-        return lookup
 
 
 @ModelFactoryRegistry.register("Gemma4ForConditionalGeneration")
 class Gemma4ForConditionalGenerationFactory(AutoModelForImageTextToTextFactory):
     """Factory for Gemma 4 VLM with custom attention mask support."""
-
-    def get_export_infos(self, model) -> List[SubModuleExportInfo]:
-        """Return export info with token_type_ids as a dynamic input."""
-        base_info = TextModelExportInfo.from_autoinferred(model)
-        return [Gemma4TextModelExportInfo(base_info.submodule_name)]
 
     def init_tokenizer(self) -> Optional[Any]:
         if self.tokenizer is None:
@@ -1619,7 +2354,16 @@ class Gemma4ForConditionalGenerationFactory(AutoModelForImageTextToTextFactory):
         return ADGemma4Processor.from_pretrained(self.tokenizer)
 
     def init_input_processor(self, base):
-        return Gemma4ADInputProcessor(base)
+        processor = self.init_processor()
+        image_token_id = getattr(processor, "image_token_id", 258_880)
+        boi_token_id = getattr(processor, "boi_token_id", 255_999)
+        eoi_token_id = getattr(processor, "eoi_token_id", 258_882)
+        return Gemma4ADInputProcessor(
+            base,
+            image_token_id=image_token_id,
+            boi_token_id=boi_token_id,
+            eoi_token_id=eoi_token_id,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_gemma4.py
@@ -33,12 +33,15 @@ Key architectural features of Gemma 4 vs standard transformers:
 """
 
 import json
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
+import numpy as np
 import torch
 import torch.nn.functional as F
+from PIL import Image
 from tokenizers import Tokenizer
 from torch import nn
 from torch.fx import GraphModule
@@ -1032,8 +1035,51 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
 # ---------------------------------------------------------------------------
 
 _TOKENIZER_CONFIG_FILE = "tokenizer_config.json"
+_PROCESSOR_CONFIG_FILE = "processor_config.json"
 _CHAT_TEMPLATE_FILE = "chat_template.jinja"
 _TOKENIZER_FILE = "tokenizer.json"
+_SUPPORTED_GEMMA4_SOFT_TOKENS = (70, 140, 280, 560, 1120)
+
+
+def get_aspect_ratio_preserving_size(
+    height: int,
+    width: int,
+    patch_size: int,
+    max_patches: int,
+    pooling_kernel_size: int,
+) -> Tuple[int, int]:
+    """Resize within the Gemma4 patch budget while preserving aspect ratio."""
+    total_px = height * width
+    target_px = max_patches * (patch_size**2)
+    factor = (target_px / total_px) ** 0.5
+    ideal_height = factor * height
+    ideal_width = factor * width
+    side_multiple = pooling_kernel_size * patch_size
+
+    target_height = int(ideal_height // side_multiple) * side_multiple
+    target_width = int(ideal_width // side_multiple) * side_multiple
+
+    if target_height == 0 and target_width == 0:
+        raise ValueError(
+            "Attempting to resize to a 0 x 0 image. "
+            f"Resized height should be divisible by `pooling_kernel_size * patch_size`={side_multiple}."
+        )
+
+    max_side_length = (max_patches // pooling_kernel_size**2) * side_multiple
+    if target_height == 0:
+        target_height = side_multiple
+        target_width = min((width // height) * side_multiple, max_side_length)
+    elif target_width == 0:
+        target_width = side_multiple
+        target_height = min((height // width) * side_multiple, max_side_length)
+
+    if target_height * target_width > target_px:
+        raise ValueError(
+            f"Resizing [{height}x{width}] to [{target_height}x{target_width}] "
+            f"exceeds {max_patches} patches with patch_size {patch_size}."
+        )
+
+    return target_height, target_width
 
 
 class ADGemma4Tokenizer(PreTrainedTokenizerFast):
@@ -1083,6 +1129,13 @@ class ADGemma4Tokenizer(PreTrainedTokenizerFast):
             truncation_side=config.get("truncation_side", "left"),
         )
 
+        tokenizer.image_token = config.get("image_token", "<|image|>")
+        tokenizer.boi_token = config.get("boi_token", "<|image>")
+        tokenizer.eoi_token = config.get("eoi_token", "<image|>")
+        tokenizer.image_token_id = tokenizer.convert_tokens_to_ids(tokenizer.image_token)
+        tokenizer.boi_token_id = tokenizer.convert_tokens_to_ids(tokenizer.boi_token)
+        tokenizer.eoi_token_id = tokenizer.convert_tokens_to_ids(tokenizer.eoi_token)
+
         template_path = cached_file(
             pretrained_model_name_or_path,
             _CHAT_TEMPLATE_FILE,
@@ -1095,12 +1148,417 @@ class ADGemma4Tokenizer(PreTrainedTokenizerFast):
         return tokenizer
 
 
+class ADGemma4ImageProcessor:
+    """Minimal Gemma4 image processor compatible with the local transformers version."""
+
+    def __init__(
+        self,
+        *,
+        patch_size: int = 16,
+        max_soft_tokens: int = 280,
+        pooling_kernel_size: int = 3,
+        do_convert_rgb: bool = True,
+        do_resize: bool = True,
+        do_rescale: bool = True,
+        rescale_factor: float = 1 / 255,
+        do_normalize: bool = False,
+        image_mean: Optional[List[float]] = None,
+        image_std: Optional[List[float]] = None,
+        resample: int = Image.BICUBIC,
+    ) -> None:
+        if max_soft_tokens not in _SUPPORTED_GEMMA4_SOFT_TOKENS:
+            raise ValueError(
+                f"`max_soft_tokens` must be one of {_SUPPORTED_GEMMA4_SOFT_TOKENS}, got {max_soft_tokens}."
+            )
+        self.patch_size = patch_size
+        self.max_soft_tokens = max_soft_tokens
+        self.pooling_kernel_size = pooling_kernel_size
+        self.do_convert_rgb = do_convert_rgb
+        self.do_resize = do_resize
+        self.do_rescale = do_rescale
+        self.rescale_factor = rescale_factor
+        self.do_normalize = do_normalize
+        self.image_mean = image_mean or [0.0, 0.0, 0.0]
+        self.image_std = image_std or [1.0, 1.0, 1.0]
+        self.resample = resample
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | Path,
+        **kwargs,
+    ) -> "ADGemma4ImageProcessor":
+        for key in ("_from_auto", "_commit_hash", "trust_remote_code"):
+            kwargs.pop(key, None)
+
+        config_path = cached_file(pretrained_model_name_or_path, _PROCESSOR_CONFIG_FILE, **kwargs)
+        assert config_path is not None
+        processor_config = json.loads(Path(config_path).read_text())
+        image_config = processor_config.get("image_processor", {})
+        allowed_keys = {
+            "patch_size",
+            "max_soft_tokens",
+            "pooling_kernel_size",
+            "do_convert_rgb",
+            "do_resize",
+            "do_rescale",
+            "rescale_factor",
+            "do_normalize",
+            "image_mean",
+            "image_std",
+            "resample",
+        }
+        filtered_config = {key: value for key, value in image_config.items() if key in allowed_keys}
+        return cls(**filtered_config)
+
+    @staticmethod
+    def fetch_images(images):
+        return images
+
+    @staticmethod
+    def _to_tensor(image, do_convert_rgb: bool) -> torch.Tensor:
+        if isinstance(image, Image.Image):
+            if do_convert_rgb:
+                image = image.convert("RGB")
+            array = np.array(image, copy=True)
+            tensor = torch.from_numpy(array)
+            if tensor.ndim == 2:
+                tensor = tensor.unsqueeze(-1)
+            return tensor.permute(2, 0, 1).contiguous().to(torch.float32)
+
+        if torch.is_tensor(image):
+            tensor = image.detach().cpu()
+            if tensor.ndim != 3:
+                raise ValueError(f"Expected a 3D image tensor, got shape {tuple(tensor.shape)}")
+            if tensor.shape[0] in (1, 3):
+                return tensor.to(torch.float32)
+            if tensor.shape[-1] in (1, 3):
+                return tensor.permute(2, 0, 1).contiguous().to(torch.float32)
+            raise ValueError(f"Unsupported tensor image shape {tuple(tensor.shape)}")
+
+        array = np.asarray(image)
+        if array.ndim == 2:
+            array = array[..., None]
+        if array.ndim != 3:
+            raise ValueError(f"Unsupported image with shape {array.shape}")
+        tensor = torch.from_numpy(array)
+        if tensor.shape[0] not in (1, 3):
+            tensor = tensor.permute(2, 0, 1)
+        return tensor.contiguous().to(torch.float32)
+
+    @staticmethod
+    def _convert_image_to_patches(image: torch.Tensor, patch_size: int) -> torch.Tensor:
+        channels, image_height, image_width = image.shape
+        num_patches_height = image_height // patch_size
+        num_patches_width = image_width // patch_size
+        patched = image.reshape(
+            channels,
+            num_patches_height,
+            patch_size,
+            num_patches_width,
+            patch_size,
+        )
+        patched = patched.permute(1, 3, 2, 4, 0)
+        return patched.reshape(num_patches_height * num_patches_width, -1)
+
+    @staticmethod
+    def _pad_along_first_dim(
+        image: torch.Tensor, positions: torch.Tensor, target_length: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        current_length = image.shape[0]
+        padding_length = target_length - current_length
+        if padding_length <= 0:
+            return image, positions
+        image_padding = torch.zeros(
+            (padding_length, image.shape[1]), dtype=image.dtype, device=image.device
+        )
+        pos_padding = torch.full(
+            (padding_length, 2), -1, dtype=positions.dtype, device=positions.device
+        )
+        return torch.cat([image, image_padding], dim=0), torch.cat([positions, pos_padding], dim=0)
+
+    def _aspect_ratio_preserving_resize(self, image: torch.Tensor) -> torch.Tensor:
+        height, width = image.shape[-2], image.shape[-1]
+        max_patches = self.max_soft_tokens * self.pooling_kernel_size**2
+        target_height, target_width = get_aspect_ratio_preserving_size(
+            height=height,
+            width=width,
+            patch_size=self.patch_size,
+            max_patches=max_patches,
+            pooling_kernel_size=self.pooling_kernel_size,
+        )
+        if target_height == height and target_width == width:
+            return image
+        return F.interpolate(
+            image.unsqueeze(0),
+            size=(target_height, target_width),
+            mode="bicubic",
+            align_corners=False,
+            antialias=True,
+        ).squeeze(0)
+
+    def __call__(
+        self,
+        images,
+        *,
+        do_convert_rgb: Optional[bool] = None,
+        do_resize: Optional[bool] = None,
+        do_rescale: Optional[bool] = None,
+        rescale_factor: Optional[float] = None,
+        do_normalize: Optional[bool] = None,
+        image_mean: Optional[List[float]] = None,
+        image_std: Optional[List[float]] = None,
+        return_tensors: Optional[str] = None,
+        **_kwargs,
+    ) -> dict[str, Any]:
+        del return_tensors
+        do_convert_rgb = self.do_convert_rgb if do_convert_rgb is None else do_convert_rgb
+        do_resize = self.do_resize if do_resize is None else do_resize
+        do_rescale = self.do_rescale if do_rescale is None else do_rescale
+        rescale_factor = self.rescale_factor if rescale_factor is None else rescale_factor
+        do_normalize = self.do_normalize if do_normalize is None else do_normalize
+        image_mean = self.image_mean if image_mean is None else image_mean
+        image_std = self.image_std if image_std is None else image_std
+
+        if not isinstance(images, list):
+            images = [images]
+
+        max_patches = self.max_soft_tokens * self.pooling_kernel_size**2
+        pixel_values = []
+        position_ids = []
+        num_soft_tokens_per_image = []
+        mean = torch.tensor(image_mean, dtype=torch.float32).view(-1, 1, 1)
+        std = torch.tensor(image_std, dtype=torch.float32).view(-1, 1, 1)
+
+        for image in images:
+            tensor = self._to_tensor(image, do_convert_rgb=do_convert_rgb)
+            if do_resize:
+                tensor = self._aspect_ratio_preserving_resize(tensor)
+            if do_rescale:
+                tensor = tensor * rescale_factor
+            if do_normalize:
+                tensor = (tensor - mean) / std
+
+            patches = self._convert_image_to_patches(tensor, self.patch_size)
+            num_soft_tokens_per_image.append(patches.shape[0] // self.pooling_kernel_size**2)
+
+            patch_height = tensor.shape[-2] // self.patch_size
+            patch_width = tensor.shape[-1] // self.patch_size
+            grid_y, grid_x = torch.meshgrid(
+                torch.arange(patch_height, dtype=torch.int64),
+                torch.arange(patch_width, dtype=torch.int64),
+                indexing="ij",
+            )
+            positions = torch.stack([grid_x, grid_y], dim=-1).reshape(patches.shape[0], 2)
+            patches, positions = self._pad_along_first_dim(patches, positions, max_patches)
+
+            pixel_values.append(patches)
+            position_ids.append(positions)
+
+        return {
+            "pixel_values": torch.stack(pixel_values, dim=0),
+            "image_position_ids": torch.stack(position_ids, dim=0),
+            "num_soft_tokens_per_image": num_soft_tokens_per_image,
+        }
+
+
+class ADGemma4Processor:
+    """Minimal Gemma4 multimodal processor for image-text requests."""
+
+    def __init__(
+        self,
+        *,
+        tokenizer: ADGemma4Tokenizer,
+        image_processor: ADGemma4ImageProcessor,
+        image_seq_length: int = 280,
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.image_processor = image_processor
+        self.image_seq_length = image_seq_length
+        self.image_token = tokenizer.image_token
+        self.boi_token = tokenizer.boi_token
+        self.eoi_token = tokenizer.eoi_token
+        self.image_token_id = tokenizer.image_token_id
+        self.boi_token_id = tokenizer.boi_token_id
+        self.eoi_token_id = tokenizer.eoi_token_id
+        self.chat_template = getattr(tokenizer, "chat_template", None)
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | Path,
+        **kwargs,
+    ) -> "ADGemma4Processor":
+        tokenizer = ADGemma4Tokenizer.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        image_processor = ADGemma4ImageProcessor.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        config_path = cached_file(pretrained_model_name_or_path, _PROCESSOR_CONFIG_FILE, **kwargs)
+        assert config_path is not None
+        processor_config = json.loads(Path(config_path).read_text())
+        return cls(
+            tokenizer=tokenizer,
+            image_processor=image_processor,
+            image_seq_length=processor_config.get(
+                "image_seq_length", image_processor.max_soft_tokens
+            ),
+        )
+
+    @staticmethod
+    def _ensure_text_list(text) -> List[str]:
+        if text is None:
+            return []
+        if isinstance(text, str):
+            return [text]
+        return list(text)
+
+    @staticmethod
+    def _normalize_batched_images(images) -> List[List[Any]]:
+        if images is None:
+            return []
+        if not isinstance(images, list):
+            return [[images]]
+        if not images:
+            return []
+        if isinstance(images[0], list):
+            return [list(batch) for batch in images]
+        return [list(images)]
+
+    def _expand_image_placeholders(
+        self, text: List[str], batched_images: List[List[Any]], image_inputs: dict[str, Any]
+    ) -> List[str]:
+        num_soft_tokens = image_inputs.pop("num_soft_tokens_per_image")
+        if not text:
+            text = [" ".join([self.image_token] * len(images)) for images in batched_images]
+        if len(text) != len(batched_images):
+            raise ValueError(
+                f"Received inconsistently sized batches of images ({len(batched_images)}) and text ({len(text)})."
+            )
+
+        replacements = [
+            f"{self.boi_token}{self.image_token * num_tokens}{self.eoi_token}"
+            for num_tokens in num_soft_tokens
+        ]
+        replacements_iter = iter(replacements)
+        pattern = re.escape(self.image_token)
+        return [re.sub(pattern, lambda _match: next(replacements_iter), prompt) for prompt in text]
+
+    def _build_token_type_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        token_type_ids = torch.zeros_like(input_ids)
+        next_blob_id = 1
+        for batch_idx in range(input_ids.shape[0]):
+            in_blob = False
+            current_blob_id = 0
+            for token_idx, token in enumerate(input_ids[batch_idx].tolist()):
+                if token == self.boi_token_id:
+                    in_blob = True
+                    current_blob_id = next_blob_id
+                    next_blob_id += 1
+                    token_type_ids[batch_idx, token_idx] = current_blob_id
+                elif token == self.eoi_token_id and in_blob:
+                    token_type_ids[batch_idx, token_idx] = current_blob_id
+                    in_blob = False
+                    current_blob_id = 0
+                elif in_blob:
+                    token_type_ids[batch_idx, token_idx] = current_blob_id
+        return token_type_ids
+
+    def _render_messages(self, messages) -> Tuple[List[str], List[List[Any]]]:
+        batched_messages = messages if messages and isinstance(messages[0], list) else [messages]
+        rendered_prompts: List[str] = []
+        batched_images: List[List[Any]] = []
+
+        for conversation in batched_messages:
+            parts: List[str] = []
+            conversation_images: List[Any] = []
+            for message in conversation:
+                content = message.get("content", "")
+                if isinstance(content, str):
+                    parts.append(content)
+                    continue
+                for item in content:
+                    item_type = item.get("type")
+                    if item_type == "text":
+                        parts.append(item.get("text", ""))
+                    elif item_type == "image":
+                        parts.append(self.image_token)
+                        conversation_images.append(item.get("image"))
+            rendered_prompts.append(" ".join(part for part in parts if part))
+            batched_images.append(conversation_images)
+
+        return rendered_prompts, batched_images
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tokenize: bool = False,
+        return_dict: bool = False,
+        return_tensors: Optional[str] = None,
+        add_generation_prompt: bool = True,
+        **kwargs,
+    ):
+        del add_generation_prompt
+        text, batched_images = self._render_messages(messages)
+        if not tokenize:
+            if messages and isinstance(messages[0], list):
+                return text
+            return text[0]
+
+        result = self(
+            text=text,
+            images=batched_images,
+            return_dict=True,
+            return_tensors=return_tensors,
+            **kwargs,
+        )
+        if return_dict:
+            return result
+        return result["input_ids"]
+
+    def __call__(
+        self,
+        *,
+        images=None,
+        text=None,
+        return_dict: bool = True,
+        return_tensors: Optional[str] = None,
+        return_attention_mask: bool = False,
+        **kwargs,
+    ):
+        del return_dict
+        batched_images = self._normalize_batched_images(images)
+        flat_images = [image for batch in batched_images for image in batch]
+        text_list = self._ensure_text_list(text)
+
+        image_inputs = {}
+        if flat_images:
+            image_inputs = self.image_processor(
+                flat_images,
+                return_tensors=return_tensors,
+                **kwargs,
+            )
+            text_list = self._expand_image_placeholders(text_list, batched_images, image_inputs)
+
+        tokenizer_kwargs = dict(kwargs)
+        tokenizer_kwargs.pop("do_rescale", None)
+        tokenizer_kwargs.pop("do_convert_rgb", None)
+        tokenizer_kwargs.pop("rescale_factor", None)
+        tokenizer_kwargs.pop("do_resize", None)
+        tokenizer_kwargs.pop("do_normalize", None)
+        tokenizer_kwargs["return_tensors"] = return_tensors
+        tokenizer_kwargs["return_attention_mask"] = return_attention_mask
+        text_inputs = self.tokenizer(text=text_list, **tokenizer_kwargs)
+        text_inputs["token_type_ids"] = self._build_token_type_ids(text_inputs["input_ids"])
+        return {**text_inputs, **image_inputs}
+
+
 class Gemma4ADInputProcessor:
     """Input processor that ensures ``token_type_ids`` is always present.
 
     Every request (text-only or multimodal) gets a ``token_type_ids`` tensor in
     its multimodal data.  For text-only requests this is all-zeros (standard
-    causal attention).  For multimodal requests the HF processor already
+    causal attention).  For multimodal requests the local Gemma4 processor
     provides it with per-blob IDs.  This guarantees the batched
     ``token_type_ids`` tensor in ``extra_args`` always covers the full
     flattened batch, including mixed image + text-only batches.
@@ -1155,10 +1613,10 @@ class Gemma4ForConditionalGenerationFactory(AutoModelForImageTextToTextFactory):
         return ADGemma4Tokenizer.from_pretrained(self.tokenizer)
 
     def init_processor(self) -> Optional[Any]:
-        """Return the tokenizer as the processor for ADInputProcessor."""
+        """Return the local Gemma4 multimodal processor."""
         if self.tokenizer is None:
             return None
-        return ADGemma4Tokenizer.from_pretrained(self.tokenizer)
+        return ADGemma4Processor.from_pretrained(self.tokenizer)
 
     def init_input_processor(self, base):
         return Gemma4ADInputProcessor(base)

--- a/tensorrt_llm/_torch/auto_deploy/transform/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/__init__.py
@@ -1,4 +1,7 @@
 """AutoDeploy's modular graph transform + inference optimizer pipeline."""
 
-from . import library  # ensure all transforms are registered
+from . import (
+    attention_mask_providers,  # noqa: F401
+    library,  # ensure all transforms are registered
+)
 from .interface import *

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_provider.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_provider.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transform-time registry for backend-native attention mask providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from torch.fx import GraphModule, Node
+
+from ..models.factory import ModelFactory
+from ..shim.interface import CachedSequenceInterface
+from ..utils._graph import _NO_VAL, add_graph_input
+from .interface import SharedConfig
+
+AttentionMaskProviderFn = Callable[["AttentionMaskProviderContext", Node], Optional[Node]]
+
+
+def infer_model_type(factory: Optional[ModelFactory]) -> Optional[str]:
+    """Best-effort inference of the source model type for provider lookup."""
+    if factory is None:
+        return None
+
+    model_type = getattr(factory, "model_type", None)
+    if isinstance(model_type, str):
+        return model_type
+
+    get_model_type = getattr(factory, "get_model_type", None)
+    if callable(get_model_type):
+        inferred = get_model_type()
+        if isinstance(inferred, str):
+            return inferred
+
+    get_model_config = getattr(factory, "_get_model_config", None)
+    if callable(get_model_config):
+        try:
+            model_config, _unused_kwargs = get_model_config()
+        except Exception:
+            return None
+        inferred = getattr(model_config, "model_type", None)
+        if isinstance(inferred, str):
+            return inferred
+
+    return None
+
+
+@dataclass
+class AttentionMaskProviderContext:
+    """Context object shared across provider invocations within one transform pass."""
+
+    gm: GraphModule
+    cm: Optional[CachedSequenceInterface]
+    factory: Optional[ModelFactory]
+    shared_config: SharedConfig
+    model_type: str
+    backend: str
+    cache: Dict[str, Node] = field(default_factory=dict)
+
+    def add_or_retrieve_input(
+        self,
+        name: str,
+        *,
+        activate_arg: bool = True,
+        val: Any = _NO_VAL,
+    ) -> Node:
+        """Add or retrieve a graph placeholder for a provider input."""
+        input_nodes = self.gm.graph.find_nodes(op="placeholder", target=name)
+        if len(input_nodes) == 1:
+            return input_nodes[0]
+        if len(input_nodes) > 1:
+            raise ValueError(f"Expected exactly one input node for {name=}, got {input_nodes=}")
+
+        if activate_arg:
+            if self.cm is None:
+                raise ValueError(
+                    f"Cannot activate managed arg {name!r} without CachedSequenceInterface."
+                )
+            self.cm.info.activate_arg(name)
+
+        return add_graph_input(self.gm, name=name, val=val)
+
+    def get_or_create_cached_node(self, key: str, builder: Callable[[], Node]) -> Node:
+        """Memoize provider-created nodes so shared masks are built once per forward."""
+        if key not in self.cache:
+            self.cache[key] = builder()
+        return self.cache[key]
+
+
+class AttentionMaskProviderRegistry:
+    """Registry for backend-native attention mask providers."""
+
+    _registry: Dict[Tuple[str, str], AttentionMaskProviderFn] = {}
+
+    @classmethod
+    def register(
+        cls, model_type: str, backend: str
+    ) -> Callable[[AttentionMaskProviderFn], AttentionMaskProviderFn]:
+        """Register a provider for a specific ``(model_type, backend)`` pair."""
+
+        def decorator(provider: AttentionMaskProviderFn) -> AttentionMaskProviderFn:
+            cls._registry[(model_type, backend)] = provider
+            return provider
+
+        return decorator
+
+    @classmethod
+    def get(
+        cls, model_type: Optional[str], backend: Optional[str]
+    ) -> Optional[AttentionMaskProviderFn]:
+        """Return the provider registered for ``(model_type, backend)``."""
+        if model_type is None or backend is None:
+            return None
+        return cls._registry.get((model_type, backend))
+
+    @classmethod
+    def has(cls, model_type: str, backend: str) -> bool:
+        """Return whether a provider exists for ``(model_type, backend)``."""
+        return (model_type, backend) in cls._registry

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_provider.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_provider.py
@@ -93,6 +93,25 @@ class AttentionMaskProviderContext:
 
         return add_graph_input(self.gm, name=name, val=val)
 
+    def register_default_extra_arg(
+        self,
+        name: str,
+        factory: Callable,
+    ) -> None:
+        """Register a callable default factory for ``name`` in the SequenceInfo.
+
+        ``factory`` receives the ``SequenceInfo`` and returns the default value
+        for ``name``.  It is called at the start of every ``nest_sequences``
+        so that initialization-time forward passes (e.g. ``resize_kv_cache``)
+        always receive a valid tensor for ``name`` even when no per-request data
+        is available.
+
+        Has no effect when ``cm`` is ``None`` (e.g. during DemoLLM export).
+        """
+        if self.cm is None:
+            return
+        self.cm.info.register_default_extra_arg(name, factory)
+
     def get_or_create_cached_node(self, key: str, builder: Callable[[], Node]) -> Node:
         """Memoize provider-created nodes so shared masks are built once per forward."""
         if key not in self.cache:

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Model-specific attention mask providers."""
+
+from __future__ import annotations
+
+import torch
+
+from .attention_mask_provider import AttentionMaskProviderRegistry
+
+
+def _build_gemma4_token_type_mask(ctx, source_attn_node):
+    q_meta = source_attn_node.args[0].meta["val"]
+    batch_size, seq_len = q_meta.shape[:2]
+    token_type_ids = ctx.add_or_retrieve_input(
+        "token_type_ids",
+        activate_arg=False,
+        val=torch.zeros(batch_size, seq_len, dtype=torch.int64),
+    )
+    zeros = ctx.gm.graph.call_function(torch.ops.aten.zeros_like.default, args=(token_type_ids,))
+    non_text = ctx.gm.graph.call_function(torch.ops.aten.ne.Scalar, args=(token_type_ids, 0))
+
+    prev_token_types = ctx.gm.graph.call_function(
+        torch.ops.aten.slice.Tensor, args=(token_type_ids, 1, 0, seq_len - 1)
+    )
+    prev_token_types = ctx.gm.graph.call_function(
+        torch.ops.aten.cat.default,
+        args=(
+            [
+                ctx.gm.graph.call_function(torch.ops.aten.slice.Tensor, args=(zeros, 1, 0, 1)),
+                prev_token_types,
+            ],
+            1,
+        ),
+    )
+
+    changed_type = ctx.gm.graph.call_function(
+        torch.ops.aten.ne.Tensor, args=(token_type_ids, prev_token_types)
+    )
+    blob_starts = ctx.gm.graph.call_function(
+        torch.ops.aten.bitwise_and.Tensor, args=(non_text, changed_type)
+    )
+    blob_ids = ctx.gm.graph.call_function(
+        torch.ops.aten.cumsum.default,
+        args=(
+            ctx.gm.graph.call_function(torch.ops.aten.to.dtype, args=(blob_starts, torch.int64)),
+            1,
+        ),
+    )
+    token_blob_ids = ctx.gm.graph.call_function(
+        torch.ops.aten.where.self, args=(non_text, blob_ids, zeros)
+    )
+
+    blob_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(token_blob_ids, 2))
+    blob_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(token_blob_ids, 1))
+    same_blob = ctx.gm.graph.call_function(torch.ops.aten.eq.Tensor, args=(blob_q, blob_k))
+    media_query = ctx.gm.graph.call_function(torch.ops.aten.ne.Scalar, args=(blob_q, 0))
+    bidirectional_media = ctx.gm.graph.call_function(
+        torch.ops.aten.bitwise_and.Tensor, args=(same_blob, media_query)
+    )
+
+    positions = ctx.gm.graph.call_function(torch.ops.aten.arange.default, args=(seq_len,))
+    pos_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(positions, 0))
+    pos_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(positions, 1))
+    causal_mask = ctx.gm.graph.call_function(torch.ops.aten.le.Tensor, args=(pos_q, pos_k))
+    causal_mask = ctx.gm.graph.call_function(
+        torch.ops.aten.unsqueeze.default, args=(causal_mask, 0)
+    )
+
+    combined = ctx.gm.graph.call_function(
+        torch.ops.aten.bitwise_or.Tensor, args=(causal_mask, bidirectional_media)
+    )
+    return ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(combined, 1))
+
+
+def _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node):
+    return ctx.get_or_create_cached_node(
+        "gemma4_token_type_ids_mask",
+        lambda: _build_gemma4_token_type_mask(ctx, source_attn_node),
+    )
+
+
+@AttentionMaskProviderRegistry.register("gemma4", "torch")
+def _gemma4_torch_paged_mask_provider(ctx, source_attn_node):
+    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
+
+
+@AttentionMaskProviderRegistry.register("gemma4", "triton_paged")
+def _gemma4_triton_paged_mask_provider(ctx, source_attn_node):
+    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
+
+
+@AttentionMaskProviderRegistry.register("gemma4", "torch_attention")
+def _gemma4_torch_attention_mask_provider(ctx, source_attn_node):
+    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
@@ -25,11 +25,16 @@ from .attention_mask_provider import AttentionMaskProviderRegistry
 def _build_gemma4_token_type_mask(ctx, source_attn_node):
     q_meta = source_attn_node.args[0].meta["val"]
     batch_size, seq_len = q_meta.shape[:2]
+    # Build a FakeTensor with the query's (possibly symbolic) batch/seq dims so that
+    # the placeholder inherits the correct dynamic shape metadata.
+    fake_val = q_meta.new_zeros(batch_size, seq_len, dtype=torch.int64)
     token_type_ids = ctx.add_or_retrieve_input(
         "token_type_ids",
         activate_arg=False,
-        val=torch.zeros(batch_size, seq_len, dtype=torch.int64),
     )
+    # Set fake tensor meta directly — add_graph_input's static_shapes=True would
+    # concretise symbolic dims, but we need them to stay dynamic.
+    token_type_ids.meta["val"] = fake_val
     zeros = ctx.gm.graph.call_function(torch.ops.aten.zeros_like.default, args=(token_type_ids,))
     non_text = ctx.gm.graph.call_function(torch.ops.aten.ne.Scalar, args=(token_type_ids, 0))
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
@@ -17,9 +17,31 @@
 
 from __future__ import annotations
 
+import operator
+
 import torch
 
 from .attention_mask_provider import AttentionMaskProviderRegistry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _token_type_ids_default_factory(seq_info):
+    """Return a zeros tensor with the same (batch, seq) shape as ``input_ids``.
+
+    Used as the default factory for ``token_type_ids`` so that initialization-time
+    forward passes (e.g. ``resize_kv_cache``, CUDA-graph warmup) always receive a
+    valid tensor even when no per-request multimodal data is present.
+
+    ``get_arg("input_ids")`` already unflattens (input_ids is in _shapeable_args),
+    so the result has shape [batch_size, seq_len].
+    """
+    input_ids_2d = seq_info.get_arg("input_ids")
+    return torch.zeros(
+        input_ids_2d.shape[0], input_ids_2d.shape[1], dtype=torch.int64, device=seq_info.device
+    )
 
 
 def _build_gemma4_token_type_mask(ctx, source_attn_node):
@@ -35,11 +57,18 @@ def _build_gemma4_token_type_mask(ctx, source_attn_node):
     # Set fake tensor meta directly — add_graph_input's static_shapes=True would
     # concretise symbolic dims, but we need them to stay dynamic.
     token_type_ids.meta["val"] = fake_val
+    # Register a default factory so cm.named_args always includes token_type_ids
+    # during initialization-time forward passes (resize_kv_cache, CUDA-graph warmup)
+    # even when no multimodal per-request data is available.
+    ctx.register_default_extra_arg("token_type_ids", _token_type_ids_default_factory)
     zeros = ctx.gm.graph.call_function(torch.ops.aten.zeros_like.default, args=(token_type_ids,))
     non_text = ctx.gm.graph.call_function(torch.ops.aten.ne.Scalar, args=(token_type_ids, 0))
 
+    # Derive seq_len inside the graph so the symbolic variable survives recompile.
+    g_seq_len = ctx.gm.graph.call_function(torch.ops.aten.sym_size.int, args=(token_type_ids, 1))
+    g_seq_len_m1 = ctx.gm.graph.call_function(operator.sub, args=(g_seq_len, 1))
     prev_token_types = ctx.gm.graph.call_function(
-        torch.ops.aten.slice.Tensor, args=(token_type_ids, 1, 0, seq_len - 1)
+        torch.ops.aten.slice.Tensor, args=(token_type_ids, 1, 0, g_seq_len_m1)
     )
     prev_token_types = ctx.gm.graph.call_function(
         torch.ops.aten.cat.default,

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
@@ -13,136 +13,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Model-specific attention mask providers."""
+"""Model-specific attention mask providers.
+
+Providers registered here add an optional ``custom_attn_mask`` graph input and
+wire it to each ``torch_attention`` node.  The actual mask tensor is computed
+**outside** the graph (e.g. in the VLM wrapper ``forward()``) and passed in at
+runtime.  During warmup, text-only, and decode steps the wrapper passes
+``None``, so the attention backend uses its fast causal kernel.
+"""
 
 from __future__ import annotations
 
-import operator
-
-import torch
-
 from .attention_mask_provider import AttentionMaskProviderRegistry
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
+def _add_custom_attn_mask_input(ctx, source_attn_node):
+    """Add ``custom_attn_mask`` as an optional graph input (default ``None``).
 
-def _token_type_ids_default_factory(seq_info):
-    """Return a zeros tensor with the same (batch, seq) shape as ``input_ids``.
-
-    Used as the default factory for ``token_type_ids`` so that initialization-time
-    forward passes (e.g. ``resize_kv_cache``, CUDA-graph warmup) always receive a
-    valid tensor even when no per-request multimodal data is present.
-
-    ``get_arg("input_ids")`` already unflattens (input_ids is in _shapeable_args),
-    so the result has shape [batch_size, seq_len].
+    No mask computation nodes are inserted into the graph.  The mask is
+    computed outside the graph by the model wrapper and supplied at runtime.
     """
-    input_ids_2d = seq_info.get_arg("input_ids")
-    return torch.zeros(
-        input_ids_2d.shape[0], input_ids_2d.shape[1], dtype=torch.int64, device=seq_info.device
-    )
-
-
-def _build_gemma4_token_type_mask(ctx, source_attn_node):
-    q_meta = source_attn_node.args[0].meta["val"]
-    batch_size, seq_len = q_meta.shape[:2]
-    # Build a FakeTensor with the query's (possibly symbolic) batch/seq dims so that
-    # the placeholder inherits the correct dynamic shape metadata.
-    fake_val = q_meta.new_zeros(batch_size, seq_len, dtype=torch.int64)
-    token_type_ids = ctx.add_or_retrieve_input(
-        "token_type_ids",
+    return ctx.add_or_retrieve_input(
+        "custom_attn_mask",
         activate_arg=False,
-    )
-    # Set fake tensor meta directly — add_graph_input's static_shapes=True would
-    # concretise symbolic dims, but we need them to stay dynamic.
-    token_type_ids.meta["val"] = fake_val
-    # Register a default factory so cm.named_args always includes token_type_ids
-    # during initialization-time forward passes (resize_kv_cache, CUDA-graph warmup)
-    # even when no multimodal per-request data is available.
-    ctx.register_default_extra_arg("token_type_ids", _token_type_ids_default_factory)
-    zeros = ctx.gm.graph.call_function(torch.ops.aten.zeros_like.default, args=(token_type_ids,))
-    non_text = ctx.gm.graph.call_function(torch.ops.aten.ne.Scalar, args=(token_type_ids, 0))
-
-    # Derive seq_len inside the graph so the symbolic variable survives recompile.
-    g_seq_len = ctx.gm.graph.call_function(torch.ops.aten.sym_size.int, args=(token_type_ids, 1))
-    g_seq_len_m1 = ctx.gm.graph.call_function(operator.sub, args=(g_seq_len, 1))
-    prev_token_types = ctx.gm.graph.call_function(
-        torch.ops.aten.slice.Tensor, args=(token_type_ids, 1, 0, g_seq_len_m1)
-    )
-    prev_token_types = ctx.gm.graph.call_function(
-        torch.ops.aten.cat.default,
-        args=(
-            [
-                ctx.gm.graph.call_function(torch.ops.aten.slice.Tensor, args=(zeros, 1, 0, 1)),
-                prev_token_types,
-            ],
-            1,
-        ),
-    )
-
-    changed_type = ctx.gm.graph.call_function(
-        torch.ops.aten.ne.Tensor, args=(token_type_ids, prev_token_types)
-    )
-    blob_starts = ctx.gm.graph.call_function(
-        torch.ops.aten.bitwise_and.Tensor, args=(non_text, changed_type)
-    )
-    blob_ids = ctx.gm.graph.call_function(
-        torch.ops.aten.cumsum.default,
-        args=(
-            ctx.gm.graph.call_function(torch.ops.aten.to.dtype, args=(blob_starts, torch.int64)),
-            1,
-        ),
-    )
-    token_blob_ids = ctx.gm.graph.call_function(
-        torch.ops.aten.where.self, args=(non_text, blob_ids, zeros)
-    )
-
-    blob_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(token_blob_ids, 2))
-    blob_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(token_blob_ids, 1))
-    same_blob = ctx.gm.graph.call_function(torch.ops.aten.eq.Tensor, args=(blob_q, blob_k))
-    media_query = ctx.gm.graph.call_function(torch.ops.aten.ne.Scalar, args=(blob_q, 0))
-    bidirectional_media = ctx.gm.graph.call_function(
-        torch.ops.aten.bitwise_and.Tensor, args=(same_blob, media_query)
-    )
-
-    # Derive 1D positions [seq_len] from token_type_ids to inherit correct device
-    # during shape propagation (meta) and runtime (cuda).
-    ones_2d = ctx.gm.graph.call_function(torch.ops.aten.ones_like.default, args=(token_type_ids,))
-    # Take first row to get 1D [seq_len]
-    ones_1d = ctx.gm.graph.call_function(torch.ops.aten.select.int, args=(ones_2d, 0, 0))
-    positions = ctx.gm.graph.call_function(torch.ops.aten.cumsum.default, args=(ones_1d, 0))
-    positions = ctx.gm.graph.call_function(torch.ops.aten.sub.Tensor, args=(positions, ones_1d))
-    pos_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(positions, 0))
-    pos_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(positions, 1))
-    causal_mask = ctx.gm.graph.call_function(torch.ops.aten.le.Tensor, args=(pos_q, pos_k))
-    causal_mask = ctx.gm.graph.call_function(
-        torch.ops.aten.unsqueeze.default, args=(causal_mask, 0)
-    )
-
-    combined = ctx.gm.graph.call_function(
-        torch.ops.aten.bitwise_or.Tensor, args=(causal_mask, bidirectional_media)
-    )
-    return ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(combined, 1))
-
-
-def _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node):
-    return ctx.get_or_create_cached_node(
-        "gemma4_token_type_ids_mask",
-        lambda: _build_gemma4_token_type_mask(ctx, source_attn_node),
+        val=None,
     )
 
 
 @AttentionMaskProviderRegistry.register("gemma4", "torch")
 def _gemma4_torch_paged_mask_provider(ctx, source_attn_node):
-    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
+    return _add_custom_attn_mask_input(ctx, source_attn_node)
 
 
 @AttentionMaskProviderRegistry.register("gemma4", "triton_paged")
 def _gemma4_triton_paged_mask_provider(ctx, source_attn_node):
-    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
+    return _add_custom_attn_mask_input(ctx, source_attn_node)
 
 
 @AttentionMaskProviderRegistry.register("gemma4", "torch_attention")
 def _gemma4_torch_attention_mask_provider(ctx, source_attn_node):
-    return _build_or_reuse_gemma4_token_type_mask(ctx, source_attn_node)
+    return _add_custom_attn_mask_input(ctx, source_attn_node)

--- a/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/attention_mask_providers.py
@@ -77,7 +77,13 @@ def _build_gemma4_token_type_mask(ctx, source_attn_node):
         torch.ops.aten.bitwise_and.Tensor, args=(same_blob, media_query)
     )
 
-    positions = ctx.gm.graph.call_function(torch.ops.aten.arange.default, args=(seq_len,))
+    # Derive 1D positions [seq_len] from token_type_ids to inherit correct device
+    # during shape propagation (meta) and runtime (cuda).
+    ones_2d = ctx.gm.graph.call_function(torch.ops.aten.ones_like.default, args=(token_type_ids,))
+    # Take first row to get 1D [seq_len]
+    ones_1d = ctx.gm.graph.call_function(torch.ops.aten.select.int, args=(ones_2d, 0, 0))
+    positions = ctx.gm.graph.call_function(torch.ops.aten.cumsum.default, args=(ones_1d, 0))
+    positions = ctx.gm.graph.call_function(torch.ops.aten.sub.Tensor, args=(positions, ones_1d))
     pos_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(positions, 0))
     pos_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(positions, 1))
     causal_mask = ctx.gm.graph.call_function(torch.ops.aten.le.Tensor, args=(pos_q, pos_k))

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/inject_custom_attention_mask.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/inject_custom_attention_mask.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Inject backend-native custom attention masks into ``torch_attention`` nodes."""
+
+from typing import Optional, Tuple, Type
+
+import torch
+from pydantic import Field
+from torch.fx import GraphModule, Node
+
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils.node_utils import is_op
+from ..attention_mask_provider import (
+    AttentionMaskProviderContext,
+    AttentionMaskProviderRegistry,
+    infer_model_type,
+)
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    Stages,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+
+class InjectCustomAttentionMaskConfig(TransformConfig):
+    """Configuration for injecting backend-native custom attention masks."""
+
+    stage: Stages = Field(default=Stages.PATTERN_MATCHER)
+    backend: str = Field(
+        default="torch_attention",
+        description="Backend key used to resolve the attention mask provider.",
+    )
+    model_type: Optional[str] = Field(
+        default=None,
+        description="Optional explicit model_type override used for provider lookup.",
+    )
+    override_existing_mask: bool = Field(
+        default=False,
+        description="Whether to override an attention node that already has an attn_mask input.",
+    )
+
+
+@TransformRegistry.register("inject_custom_attention_mask")
+class InjectCustomAttentionMask(BaseTransform):
+    """Inject backend-native masks into ``torch_attention`` calls."""
+
+    config: InjectCustomAttentionMaskConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return InjectCustomAttentionMaskConfig
+
+    @staticmethod
+    def _get_attn_mask_arg(node: Node):
+        if "attn_mask" in node.kwargs:
+            return node.kwargs["attn_mask"]
+        if len(node.args) > 3:
+            return node.args[3]
+        return None
+
+    def _set_attn_mask_arg(self, node: Node, attn_mask: Node) -> None:
+        if len(node.args) > 3:
+            node.update_arg(3, attn_mask)
+            return
+
+        kwargs = dict(node.kwargs)
+        kwargs["attn_mask"] = attn_mask
+        node.kwargs = kwargs
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: Optional[CachedSequenceInterface],
+        factory: Optional[ModelFactory],
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        attn_nodes = [n for n in gm.graph.nodes if is_op(n, torch.ops.auto_deploy.torch_attention)]
+        if not attn_nodes:
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        model_type = self.config.model_type or infer_model_type(factory)
+        provider = AttentionMaskProviderRegistry.get(model_type, self.config.backend)
+        if provider is None:
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        assert model_type is not None
+        ctx = AttentionMaskProviderContext(
+            gm=gm,
+            cm=cm,
+            factory=factory,
+            shared_config=shared_config,
+            model_type=model_type,
+            backend=self.config.backend,
+        )
+
+        num_matches = 0
+        for attn_node in attn_nodes:
+            if (
+                not self.config.override_existing_mask
+                and self._get_attn_mask_arg(attn_node) is not None
+            ):
+                continue
+
+            with gm.graph.inserting_before(attn_node):
+                attn_mask = provider(ctx, attn_node)
+
+            if attn_mask is None:
+                continue
+
+            self._set_attn_mask_arg(attn_node, attn_mask)
+            num_matches += 1
+
+        if num_matches == 0:
+            return gm, TransformInfo(
+                skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
+            )
+
+        return gm, TransformInfo(
+            skipped=False, num_matches=num_matches, is_clean=False, has_valid_shapes=False
+        )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -35,7 +35,7 @@ from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
 from ...utils._graph import add_graph_input
 from ...utils.cuda_mem_tracker import get_mem_info
-from ...utils.node_utils import is_op
+from ...utils.node_utils import get_op_schema, is_op
 from ..interface import (
     BaseTransform,
     SharedConfig,
@@ -108,7 +108,7 @@ class _InsertCachedOperator(BaseTransform):
         # check what inputs the extra metadata op expects
         inputs_for_prep_meta = [
             self._add_or_retrieve_input(gm, cm, arg.name)
-            for arg in prep_meta_op._schema.arguments
+            for arg in get_op_schema(prep_meta_op).arguments
             if arg.name in cm.info.available_args
         ]
 
@@ -137,6 +137,7 @@ class _InsertCachedOperator(BaseTransform):
         self,
         gm: GraphModule,
         attn_node: Node,
+        cached_attn_op,
         qkv_nodes: List[Node],
         meta_nodes_std: List[Node],
         meta_nodes_extra: List[Node],
@@ -146,7 +147,7 @@ class _InsertCachedOperator(BaseTransform):
         """Insert a cached attention node into the graph."""
         with gm.graph.inserting_before(attn_node):
             cached_attn_node = gm.graph.call_function(
-                self.attn_descriptor.get_cached_attention_op(),
+                cached_attn_op,
                 args=(
                     *qkv_nodes,
                     *meta_nodes_std,
@@ -168,10 +169,8 @@ class _InsertCachedOperator(BaseTransform):
         """Replace uncached source attention node with corresponding cached attn node."""
         attn_descriptor = self.attn_descriptor
 
-        # Get all attention nodes and their info objects
-        source_op = attn_descriptor.get_source_attention_op()
-
         # look for relevant source attention nodes
+        source_op = attn_descriptor.get_source_attention_op()
         source_attn_nodes = [n for n in gm.graph.nodes if is_op(n, source_op)]
 
         if not source_attn_nodes:
@@ -191,16 +190,46 @@ class _InsertCachedOperator(BaseTransform):
 
         # replace fused attention node with attention node that has kv cache
         num_cached_attn_replacements = 0
-        for attn_node in source_attn_nodes:
+        cache_nodes_by_layer_idx = {}
+        for idx, attn_node in enumerate(source_attn_nodes):
             # pick out GEMMs
             qkv = attn_node.args[: attn_descriptor.get_num_qkv_args()]
 
-            # setup + store cache resource handlers and caches as input nodes
-            resources_dict = attn_descriptor.get_cache_initializers(attn_node, cm.kv_cache_config)
-            cache_in_nodes = [
-                self._process_cache_node(gm, cm.add_resource(k, resource_handler))
-                for k, resource_handler in resources_dict.items()
-            ]
+            layer_idx = attn_descriptor.get_layer_idx(attn_node)
+            shared_kv_source_layer_idx = attn_descriptor.get_shared_kv_source_layer_idx(attn_node)
+
+            if shared_kv_source_layer_idx is not None:
+                if not attn_descriptor.supports_shared_kv():
+                    raise RuntimeError(
+                        f"Backend '{self.config.backend}' does not support shared-KV attention."
+                    )
+                if layer_idx is None:
+                    raise RuntimeError(
+                        "Shared-KV attention node is missing layer_idx metadata required for "
+                        "cache aliasing."
+                    )
+                if shared_kv_source_layer_idx == layer_idx:
+                    raise RuntimeError(f"Layer {layer_idx} cannot share its own KV cache.")
+                if shared_kv_source_layer_idx not in cache_nodes_by_layer_idx:
+                    raise RuntimeError(
+                        f"Missing shared-KV source layer {shared_kv_source_layer_idx}."
+                    )
+                cache_in_nodes = cache_nodes_by_layer_idx[shared_kv_source_layer_idx]
+            else:
+                # setup + store cache initializers and caches as input nodes
+                if layer_idx is not None and layer_idx in cache_nodes_by_layer_idx:
+                    raise RuntimeError(
+                        f"Duplicate KV cache owner detected for layer {layer_idx}. "
+                        "Each non-shared attention layer must own exactly one cache."
+                    )
+                cache_in_nodes = []
+                for k, resource_handler in attn_descriptor.get_cache_initializers(
+                    attn_node, cm.kv_cache_config
+                ).items():
+                    resource_name = cm.add_resource(k, resource_handler)
+                    cache_in_nodes.append(self._process_cache_node(gm, resource_name))
+                if layer_idx is not None:
+                    cache_nodes_by_layer_idx[layer_idx] = cache_in_nodes
 
             # allow backend-specific prep before constants are extracted
             attn_descriptor.prepare_node_for_cache_insertion(gm, attn_node)
@@ -212,6 +241,7 @@ class _InsertCachedOperator(BaseTransform):
             self._insert_cached_attn_node(
                 gm,
                 attn_node,
+                attn_descriptor.get_cached_attention_op(),
                 qkv,
                 meta_nodes_std,
                 meta_nodes_extra,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -142,6 +142,7 @@ class _InsertCachedOperator(BaseTransform):
         meta_nodes_std: List[Node],
         meta_nodes_extra: List[Node],
         cache_nodes: List[Node],
+        dynamic_inputs: List[Optional[Node]],
         constants: List[Constant],
     ):
         """Insert a cached attention node into the graph."""
@@ -153,6 +154,7 @@ class _InsertCachedOperator(BaseTransform):
                     *meta_nodes_std,
                     *meta_nodes_extra,
                     *cache_nodes,
+                    *dynamic_inputs,
                     *constants,
                 ),
             )
@@ -235,6 +237,7 @@ class _InsertCachedOperator(BaseTransform):
             attn_descriptor.prepare_node_for_cache_insertion(gm, attn_node)
 
             # retrieve constants for attention_op
+            dynamic_inputs = attn_descriptor.get_dynamic_inputs(attn_node)
             constants = attn_descriptor.get_constants(attn_node)
 
             # insert cached attention replacement op
@@ -246,6 +249,7 @@ class _InsertCachedOperator(BaseTransform):
                 meta_nodes_std,
                 meta_nodes_extra,
                 cache_in_nodes,
+                dynamic_inputs,
                 constants,
             )
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache_transformers.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache_transformers.py
@@ -159,7 +159,10 @@ def get_cached_attn(
         elif attention_layout != "bnsd":
             raise ValueError(f"Unsupported attention layout: {attention_layout}")
 
-        attn_output = attn_descriptor.get_cached_attention_op()(
+        cached_attn_op = module._node_ref.meta.get(
+            "cached_attn_op", attn_descriptor.get_cached_attention_op()
+        )
+        attn_output = cached_attn_op(
             query,
             key,
             value,
@@ -238,6 +241,7 @@ class HFReplaceCachedAttn(_InsertCachedOperator):
         self,
         gm: GraphModule,
         attn_node: Node,
+        cached_attn_op,
         qkv_nodes: List[Node],
         meta_nodes_std: List[Node],
         meta_nodes_extra: List[Node],
@@ -246,6 +250,7 @@ class HFReplaceCachedAttn(_InsertCachedOperator):
     ):
         """Here we now need to actually do the correct mapping of the cached attn nodes."""
         # store reference to metadata, caches, and constants for this attn node
+        attn_node.meta["cached_attn_op"] = cached_attn_op
         attn_node.meta["metadata_cache_keys"] = (*meta_nodes_std, *meta_nodes_extra, *cache_nodes)
         attn_node.meta["constants"] = constants
 

--- a/tensorrt_llm/_torch/auto_deploy/utils/_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/_graph.py
@@ -18,7 +18,7 @@ from torch.fx.passes.shape_prop import _extract_tensor_metadata
 from torch.utils._pytree import _LEAF_SPEC, TreeSpec
 
 from .logger import ad_logger
-from .node_utils import get_weight_tensor, is_op
+from .node_utils import get_op_schema, get_weight_tensor, is_op
 
 # ---------------------------------------------------------------------------
 # Dynamic custom-op derivation helpers
@@ -72,7 +72,7 @@ def create_derived_custom_op(
         the same *base_op* and *suffix* return the cached op.
     """
     base_overload = base_op.default if hasattr(base_op, "default") else base_op
-    schema = base_overload._schema
+    schema = get_op_schema(base_overload)
 
     # e.g. "auto_deploy::trtllm_moe_fused"
     qualified_name = schema.name

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -1049,16 +1049,20 @@ def extract_output_tuple(node: Node, count: int = 2):
     return results
 
 
+def get_op_schema(op) -> torch.FunctionSchema:
+    """Return the schema for an op or op overload packet."""
+    if hasattr(op, "_schemas"):
+        return next(iter(op._schemas.values()))
+    if hasattr(op, "_schema"):
+        return op._schema
+    raise RuntimeError(f"No schema found on op {op}")
+
+
 def _get_op_schema(node: Node):
     """Return the op schema for a call_function node."""
     if node.op != "call_function":
         raise ValueError(f"_get_op_schema only supports call_function nodes, got {node.op}")
-    op = node.target
-    if hasattr(op, "_schemas"):
-        return next(iter(op._schemas.values()))
-    elif hasattr(op, "_schema"):
-        return op._schema
-    raise RuntimeError(f"No schema found on op {op}")
+    return get_op_schema(node.target)
 
 
 def extract_op_args(node: Node, *arg_names):

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -86,6 +86,31 @@ class MistralAttention(Attention):
             config=model_config,
         )
 
+        # Per-layer sliding window attention.
+        # Ministral uses layer_types to mark sliding vs full attention layers.
+        # Mistral (without layer_types) applies SWA uniformly to all layers.
+        layer_types = getattr(config, "layer_types", None)
+        if layer_types is not None and layer_idx is not None:
+            is_sliding = layer_types[layer_idx] == "sliding_attention"
+            self.attention_window_size = config.sliding_window if is_sliding else None
+        else:
+            self.attention_window_size = getattr(config, "sliding_window", None)
+
+    def forward(
+        self,
+        position_ids: torch.IntTensor,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs,
+    ) -> torch.Tensor:
+        return super().forward(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            attention_window_size=self.attention_window_size,
+            **kwargs,
+        )
+
 
 class MistralDecoderLayer(DecoderLayer):
 

--- a/tensorrt_llm/_torch/models/modeling_mixtral.py
+++ b/tensorrt_llm/_torch/models/modeling_mixtral.py
@@ -92,6 +92,23 @@ class MixtralAttention(Attention):
                          dtype=config.torch_dtype,
                          config=model_config)
 
+        self.attention_window_size = getattr(config, "sliding_window", None)
+
+    def forward(
+        self,
+        position_ids: torch.IntTensor,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs,
+    ) -> torch.Tensor:
+        return super().forward(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            attention_window_size=self.attention_window_size,
+            **kwargs,
+        )
+
 
 class MixtralDecoderLayer(DecoderLayer):
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -358,3 +358,5 @@ accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_pard[overlap_sch
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_pard[overlap_scheduler=False] SKIP (https://nvbugs/6037653)
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_fp8[throughput_latency] SKIP (https://nvbugs/6037654)
 accuracy/test_llm_api_pytorch.py::TestPhi4::test_auto_dtype SKIP (https://nvbugs/6040098)
+unittest/bindings/test_transfer_agent_bindings.py::TestMooncakeFunctionalTransfer::test_mooncake_wait_in_progress_on_zero_timeout SKIP (https://nvbugs/6043312)
+perf/test_perf.py::test_perf[deepseek_r1_distill_qwen_32b-bench-_autodeploy-float16-input_output_len:1024,1024-reqs:512] SKIP (https://nvbugs/6044213)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_gemma3n_modeling.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_gemma3n_modeling.py
@@ -1,0 +1,474 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+from typing import Tuple
+
+import pytest
+import torch
+from torch.export import Dim
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.torch_backend_attention import (
+    TorchBackendAttention,
+)
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_gemma3n import (
+    Gemma3nAudioConfig,
+    Gemma3nConditionalOutput,
+    Gemma3nConfig,
+    Gemma3nForCausalLM,
+    Gemma3nForConditionalGeneration,
+    Gemma3nTextAttention,
+    Gemma3nTextConfig,
+    Gemma3nTextDecoderLayer,
+    Gemma3nTextMLP,
+    Gemma3nVisionConfig,
+)
+from tensorrt_llm._torch.auto_deploy.utils._graph import move_to_device
+
+
+def assert_rmse_close(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    rmse_ratio_tol: float,
+    msg: str = "",
+) -> None:
+    diff = actual.float() - expected.float()
+    rmse_diff = torch.sqrt(torch.mean(diff**2))
+    rmse_ref = torch.sqrt(torch.mean(expected.float() ** 2))
+    ratio = (rmse_diff / rmse_ref).item()
+    assert ratio < rmse_ratio_tol, (
+        f"{msg}RMSE ratio {ratio:.6f} exceeds tolerance {rmse_ratio_tol}. "
+        f"(rmse_diff={rmse_diff.item():.6f}, rmse_ref={rmse_ref.item():.6f})"
+    )
+
+
+def _get_hf_classes():
+    try:
+        from transformers.models.gemma3n.modeling_gemma3n import (
+            Gemma3nForCausalLM as HFGemma3nForCausalLM,
+        )
+        from transformers.models.gemma3n.modeling_gemma3n import (
+            Gemma3nTextAttention as HFGemma3nTextAttention,
+        )
+        from transformers.models.gemma3n.modeling_gemma3n import (
+            Gemma3nTextDecoderLayer as HFGemma3nTextDecoderLayer,
+        )
+        from transformers.models.gemma3n.modeling_gemma3n import Gemma3nTextMLP as HFGemma3nTextMLP
+    except ImportError:
+        return None
+    return HFGemma3nForCausalLM, HFGemma3nTextAttention, HFGemma3nTextDecoderLayer, HFGemma3nTextMLP
+
+
+HF_CLASSES = _get_hf_classes()
+
+
+def _device_and_dtype() -> Tuple[str, torch.dtype]:
+    if torch.cuda.is_available():
+        return "cuda", torch.bfloat16
+    return "cpu", torch.float32
+
+
+def _small_text_config() -> Gemma3nTextConfig:
+    config = Gemma3nTextConfig(
+        vocab_size=256,
+        vocab_size_per_layer_input=256,
+        hidden_size=64,
+        hidden_size_per_layer_input=8,
+        intermediate_size=[128, 128, 128],
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        hidden_activation="gelu_pytorch_tanh",
+        max_position_embeddings=64,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        rope_local_base_freq=1000.0,
+        attention_bias=False,
+        attention_dropout=0.0,
+        sliding_window=16,
+        layer_types=["sliding_attention", "sliding_attention", "full_attention"],
+        final_logit_softcapping=30.0,
+        altup_active_idx=0,
+        altup_correct_scale=True,
+        altup_num_inputs=3,
+        num_kv_shared_layers=0,
+        laurel_rank=8,
+        activation_sparsity_pattern=[0.5, 0.0, 0.0],
+        pad_token_id=0,
+        eos_token_id=1,
+        bos_token_id=2,
+    )
+    config._attn_implementation = "eager"
+    return config
+
+
+def _small_full_config() -> Gemma3nConfig:
+    return Gemma3nConfig(
+        text_config=_small_text_config(),
+        vision_config=Gemma3nVisionConfig(
+            hidden_size=32,
+            vocab_size=8,
+            vocab_offset=256,
+            rms_norm_eps=1e-6,
+        ),
+        audio_config=Gemma3nAudioConfig(
+            vocab_size=8,
+            vocab_offset=264,
+            hidden_size=32,
+            rms_norm_eps=1e-6,
+            conf_num_attention_heads=4,
+            conf_num_hidden_layers=2,
+            sscp_conv_channel_size=(16, 8),
+        ),
+    )
+
+
+def _extended_text_config(num_hidden_layers: int) -> Gemma3nTextConfig:
+    config = copy.deepcopy(_small_text_config())
+    config.num_hidden_layers = num_hidden_layers
+    config.intermediate_size = [128] * num_hidden_layers
+    config.layer_types = ["sliding_attention"] * (num_hidden_layers - 1) + ["full_attention"]
+    config.activation_sparsity_pattern = [0.0] * num_hidden_layers
+    return config
+
+
+def _shared_kv_text_config() -> Gemma3nTextConfig:
+    config = Gemma3nTextConfig(
+        vocab_size=256,
+        vocab_size_per_layer_input=256,
+        hidden_size=64,
+        hidden_size_per_layer_input=8,
+        intermediate_size=[128] * 6,
+        num_hidden_layers=6,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        hidden_activation="gelu_pytorch_tanh",
+        max_position_embeddings=64,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        rope_local_base_freq=1000.0,
+        attention_bias=False,
+        attention_dropout=0.0,
+        sliding_window=16,
+        layer_types=[
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+        final_logit_softcapping=30.0,
+        altup_active_idx=0,
+        altup_correct_scale=True,
+        altup_num_inputs=3,
+        num_kv_shared_layers=2,
+        laurel_rank=8,
+        activation_sparsity_pattern=[0.0] * 6,
+        pad_token_id=0,
+        eos_token_id=1,
+        bos_token_id=2,
+    )
+    config._attn_implementation = "eager"
+    return config
+
+
+def _position_ids(batch_size: int, seq_len: int, device: str) -> torch.Tensor:
+    return torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+
+
+def _load_equivalent_modules(custom_module: torch.nn.Module, hf_module: torch.nn.Module) -> None:
+    missing, unexpected = custom_module.load_state_dict(hf_module.state_dict(), strict=False)
+    assert not missing, f"Missing keys when loading HF weights into custom module: {missing}"
+    assert not unexpected, (
+        f"Unexpected keys when loading HF weights into custom module: {unexpected}"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _set_seed():
+    torch.manual_seed(42)
+
+
+def test_hf_reference_available():
+    if HF_CLASSES is None:
+        pytest.skip("transformers gemma3n reference classes are unavailable")
+    hf_model_cls, hf_attention_cls, hf_layer_cls, hf_mlp_cls = HF_CLASSES
+    assert hf_model_cls.__name__ == "Gemma3nForCausalLM"
+    assert hf_attention_cls.__name__ == "Gemma3nTextAttention"
+    assert hf_layer_cls.__name__ == "Gemma3nTextDecoderLayer"
+    assert hf_mlp_cls.__name__ == "Gemma3nTextMLP"
+
+
+@torch.no_grad()
+def test_gemma3n_mlp_equivalence():
+    if HF_CLASSES is None:
+        pytest.skip("transformers gemma3n reference classes are unavailable")
+
+    _, _, _, hf_mlp_cls = HF_CLASSES
+    device, dtype = _device_and_dtype()
+    config = _small_text_config()
+    custom_mlp = Gemma3nTextMLP(config, layer_idx=0).to(device=device, dtype=dtype)
+    hf_mlp = hf_mlp_cls(config, layer_idx=0).to(device=device, dtype=dtype)
+    _load_equivalent_modules(custom_mlp, hf_mlp)
+
+    hidden_states = torch.randn(2, 6, config.hidden_size, device=device, dtype=dtype)
+    custom_out = custom_mlp(hidden_states)
+    hf_out = hf_mlp(hidden_states)
+    torch.testing.assert_close(custom_out.float(), hf_out.float(), rtol=1e-3, atol=1e-3)
+
+
+@torch.no_grad()
+def test_gemma3n_attention_equivalence():
+    if HF_CLASSES is None:
+        pytest.skip("transformers gemma3n reference classes are unavailable")
+
+    _, hf_attention_cls, _, _ = HF_CLASSES
+    device, dtype = _device_and_dtype()
+    config = _small_text_config()
+    custom_attn = Gemma3nTextAttention(config, layer_idx=2).to(device=device, dtype=dtype)
+    hf_attn = hf_attention_cls(config, layer_idx=2).to(device=device, dtype=dtype)
+    _load_equivalent_modules(custom_attn, hf_attn)
+
+    hidden_states = torch.randn(2, 6, config.hidden_size, device=device, dtype=dtype)
+    position_ids = _position_ids(2, 6, device)
+    custom_rope = Gemma3nForCausalLM(config).model.rotary_emb.to(device=device)
+    full_cos, full_sin = custom_rope(hidden_states, position_ids)
+    position_embeddings = (full_cos[position_ids], full_sin[position_ids])
+
+    custom_out = custom_attn(hidden_states, position_embeddings)
+    hf_out = hf_attn(hidden_states, position_embeddings, attention_mask=None)[0]
+    assert_rmse_close(custom_out[:, -1:], hf_out[:, -1:], rmse_ratio_tol=0.10, msg="Attention: ")
+
+
+@torch.no_grad()
+def test_gemma3n_decoder_layer_equivalence():
+    if HF_CLASSES is None:
+        pytest.skip("transformers gemma3n reference classes are unavailable")
+
+    _, _, hf_layer_cls, _ = HF_CLASSES
+    device, dtype = _device_and_dtype()
+    config = _small_text_config()
+    custom_layer = Gemma3nTextDecoderLayer(config, layer_idx=2).to(device=device, dtype=dtype)
+    hf_layer = hf_layer_cls(config, layer_idx=2).to(device=device, dtype=dtype)
+    _load_equivalent_modules(custom_layer, hf_layer)
+
+    batch_size, seq_len = 2, 1
+    hidden_states = torch.randn(
+        config.altup_num_inputs, batch_size, seq_len, config.hidden_size, device=device, dtype=dtype
+    )
+    per_layer_input = torch.randn(
+        batch_size, seq_len, config.hidden_size_per_layer_input, device=device, dtype=dtype
+    )
+    position_ids = _position_ids(batch_size, seq_len, device)
+    rope_model = Gemma3nForCausalLM(config).model.to(device=device)
+    global_cos, global_sin = rope_model.rotary_emb(hidden_states[0], position_ids)
+    local_cos, local_sin = rope_model.rotary_emb_local(hidden_states[0], position_ids)
+    position_embeddings_global = (global_cos[position_ids], global_sin[position_ids])
+    position_embeddings_local = (local_cos[position_ids], local_sin[position_ids])
+
+    custom_out = custom_layer(
+        hidden_states,
+        position_embeddings_global,
+        position_embeddings_local,
+        per_layer_input,
+    )
+    hf_out = hf_layer(
+        hidden_states,
+        position_embeddings_global,
+        position_embeddings_local,
+        per_layer_input,
+        attention_mask=None,
+        position_ids=position_ids,
+    )[0]
+    assert_rmse_close(custom_out, hf_out, rmse_ratio_tol=0.05, msg="Decoder layer: ")
+
+
+@torch.no_grad()
+def test_gemma3n_full_model_equivalence():
+    if HF_CLASSES is None:
+        pytest.skip("transformers gemma3n reference classes are unavailable")
+
+    hf_model_cls, _, _, _ = HF_CLASSES
+    device, dtype = "cpu", torch.float32
+    config = _small_text_config()
+    custom_model = Gemma3nForCausalLM(config).to(device=device, dtype=dtype)
+    hf_model = hf_model_cls(config).to(device=device, dtype=dtype)
+    _load_equivalent_modules(custom_model, hf_model)
+    custom_model.eval()
+    hf_model.eval()
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 6), device=device)
+    position_ids = _position_ids(2, 6, device)
+    custom_out = custom_model(input_ids=input_ids, position_ids=position_ids)
+    hf_out = hf_model(input_ids=input_ids, position_ids=position_ids)
+    assert_rmse_close(custom_out.logits, hf_out.logits, rmse_ratio_tol=0.05, msg="Full model: ")
+
+
+@torch.no_grad()
+def test_gemma3n_conditional_wrapper_equivalence():
+    if HF_CLASSES is None:
+        pytest.skip("transformers gemma3n reference classes are unavailable")
+
+    hf_model_cls, _, _, _ = HF_CLASSES
+    device, dtype = "cpu", torch.float32
+    config = _small_full_config()
+    wrapper = Gemma3nForConditionalGeneration(config).to(device=device, dtype=dtype)
+    hf_model = hf_model_cls(config.text_config).to(device=device, dtype=dtype)
+    _load_equivalent_modules(wrapper.model.language_model, hf_model.model)
+    _load_equivalent_modules(wrapper.lm_head, hf_model.lm_head)
+    wrapper.eval()
+    hf_model.eval()
+
+    input_ids = torch.randint(
+        0, config.text_config.vocab_size_per_layer_input, (2, 6), device=device
+    )
+    position_ids = _position_ids(2, 6, device)
+    wrapper_out = wrapper(input_ids=input_ids, position_ids=position_ids)
+    hf_out = hf_model(input_ids=input_ids, position_ids=position_ids)
+    assert isinstance(wrapper_out, Gemma3nConditionalOutput)
+    assert_rmse_close(wrapper_out.logits, hf_out.logits, rmse_ratio_tol=0.05, msg="Wrapper: ")
+
+
+def test_gemma3n_conditional_wrapper_load_hook_drops_unsupported_tower_weights():
+    config = _small_full_config()
+    wrapper = Gemma3nForConditionalGeneration(config)
+    state_dict = wrapper.state_dict()
+    state_dict["model.vision_tower.fake.weight"] = torch.randn(2, 2)
+    state_dict["model.audio_tower.fake.weight"] = torch.randn(2, 2)
+
+    missing, unexpected = wrapper.load_state_dict(state_dict, strict=True)
+
+    assert missing == []
+    assert unexpected == []
+
+
+def test_gemma3n_conditional_wrapper_ignores_hf_init_kwargs():
+    config = _small_full_config()
+    wrapper = Gemma3nForConditionalGeneration(config, use_cache=False)
+    assert isinstance(wrapper, Gemma3nForConditionalGeneration)
+
+
+def test_gemma3n_reduced_layer_load_hook_slices_per_layer_weights():
+    source_model = Gemma3nForCausalLM(_extended_text_config(5))
+    target_model = Gemma3nForCausalLM(_small_text_config())
+
+    missing, unexpected = target_model.load_state_dict(source_model.state_dict(), strict=False)
+
+    assert missing == []
+    assert "model.layers.3.self_attn.q_proj.weight" in unexpected
+
+
+def test_gemma3n_causal_lm_ties_lm_head_to_input_embeddings():
+    model = Gemma3nForCausalLM(_small_text_config())
+    assert model.lm_head.weight.data_ptr() == model.model.embed_tokens.weight.data_ptr()
+
+
+def test_gemma3n_conditional_lm_ties_lm_head_to_input_embeddings():
+    model = Gemma3nForConditionalGeneration(_small_full_config())
+    assert (
+        model.lm_head.weight.data_ptr() == model.model.language_model.embed_tokens.weight.data_ptr()
+    )
+
+
+def test_gemma3n_shared_kv_layer_metadata_matches_config():
+    model = Gemma3nForCausalLM(_shared_kv_text_config())
+    layer_expectations = [
+        (False, None),
+        (False, None),
+        (False, None),
+        (False, None),
+        (True, 2),
+        (True, 3),
+    ]
+
+    for layer, (is_shared, source_idx) in zip(model.model.layers, layer_expectations, strict=True):
+        assert layer.self_attn.is_kv_shared_layer is is_shared
+        assert layer.self_attn.kv_shared_layer_index == source_idx
+
+
+def test_gemma3n_export_uses_shared_kv_attention_for_shared_layers():
+    config = _shared_kv_text_config()
+    model = Gemma3nForCausalLM(config).eval()
+    input_ids = torch.randint(0, config.vocab_size, (1, 4))
+    position_ids = _position_ids(1, 4, "cpu")
+
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+    )
+
+    attn_nodes = [node for node in gm.graph.nodes if node.op == "call_function"]
+    attn_nodes = [
+        node for node in attn_nodes if node.target == torch.ops.auto_deploy.torch_attention.default
+    ]
+    regular_nodes = [
+        node
+        for node in attn_nodes
+        if TorchBackendAttention.get_shared_kv_source_layer_idx(node) is None
+    ]
+    shared_nodes = [
+        node
+        for node in attn_nodes
+        if TorchBackendAttention.get_shared_kv_source_layer_idx(node) is not None
+    ]
+
+    assert len(attn_nodes) == config.num_hidden_layers
+    assert len(regular_nodes) == config.num_hidden_layers - config.num_kv_shared_layers
+    assert len(shared_nodes) == config.num_kv_shared_layers
+    assert [TorchBackendAttention.get_layer_idx(regular) for regular in regular_nodes] == [
+        0,
+        1,
+        2,
+        3,
+    ]
+    assert [TorchBackendAttention.get_layer_idx(shared) for shared in shared_nodes] == [4, 5]
+    assert [
+        TorchBackendAttention.get_shared_kv_source_layer_idx(shared) for shared in shared_nodes
+    ] == [2, 3]
+
+
+def test_gemma3n_model_can_be_exported():
+    if not torch.cuda.is_available():
+        pytest.skip("Export test requires CUDA")
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    config = _small_full_config()
+    model = Gemma3nForConditionalGeneration(config).to(device=device, dtype=dtype)
+    model.eval()
+
+    input_ids = torch.randint(0, config.text_config.vocab_size, (2, 8), device=device)
+    position_ids = _position_ids(2, 8, device)
+
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=(
+            {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+            {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        ),
+    )
+    move_to_device(gm, device)
+
+    with torch.inference_mode():
+        eager_out = model(input_ids=input_ids, position_ids=position_ids)
+        export_out = gm(input_ids=input_ids, position_ids=position_ids)
+
+    assert "logits" in export_out
+    assert_rmse_close(export_out["logits"], eager_out.logits, rmse_ratio_tol=0.05, msg="Export: ")
+
+    input_ids_2 = torch.randint(0, config.text_config.vocab_size, (1, 5), device=device)
+    position_ids_2 = _position_ids(1, 5, device)
+    with torch.inference_mode():
+        export_out_2 = gm(input_ids=input_ids_2, position_ids=position_ids_2)
+        eager_out_2 = model(input_ids=input_ids_2, position_ids=position_ids_2)
+    assert_rmse_close(
+        export_out_2["logits"], eager_out_2.logits, rmse_ratio_tol=0.05, msg="Export dynamic: "
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_gemma4_modeling.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_gemma4_modeling.py
@@ -124,14 +124,11 @@ def _set_seed():
 
 
 class _RefRMSNorm(nn.Module):
-    """HF Gemma4RMSNorm: norm(x) * (weight + scale_shift)."""
+    """HF Gemma4RMSNorm (transformers>=5.5): norm(x) * weight."""
 
-    def __init__(
-        self, dim: int, eps: float = 1e-6, scale_shift: float = 1.0, with_scale: bool = True
-    ):
+    def __init__(self, dim: int, eps: float = 1e-6, with_scale: bool = True):
         super().__init__()
         self.eps = eps
-        self.scale_shift = scale_shift
         self.with_scale = with_scale
         if with_scale:
             self.weight = nn.Parameter(torch.ones(dim))
@@ -141,7 +138,7 @@ class _RefRMSNorm(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         normed = x.float() * torch.pow(x.float().pow(2).mean(-1, keepdim=True) + self.eps, -0.5)
         if self.weight is not None:
-            normed = normed * (self.weight.float() + self.scale_shift)
+            normed = normed * self.weight.float()
         return normed.type_as(x)
 
 
@@ -467,8 +464,19 @@ def test_moe_block_equivalence():
 
     # Load router weights (same structure)
     ad_router.load_state_dict(ref_router.state_dict())
-    # Load MoE weights (hook unfuses gate_up_proj + folds per_expert_scale)
-    ad_moe.load_state_dict(ref_moe.state_dict(), strict=False)
+    # Manually unfuse ref MoE fused weights into per-expert format
+    # (The unfusing hook is on the decoder layer, not the MoE block)
+    ref_sd = ref_moe.state_dict()
+    gate_up = ref_sd["gate_up_proj"]  # [E, 2*I, H]
+    down = ref_sd["down_proj"]  # [E, H, I]
+    scale = ref_sd["per_expert_scale"]  # [E]
+    inter = config.expert_intermediate_size
+    ad_sd = {}
+    for e in range(config.num_experts):
+        ad_sd[f"experts.{e}.gate_proj.weight"] = gate_up[e, :inter, :]
+        ad_sd[f"experts.{e}.up_proj.weight"] = gate_up[e, inter:, :]
+        ad_sd[f"experts.{e}.down_proj.weight"] = down[e] * scale[e]
+    ad_moe.load_state_dict(ad_sd)
 
     T = 16  # num tokens (flattened B*S)
     x = torch.randn(T, config.hidden_size, device=device, dtype=dtype)
@@ -527,32 +535,90 @@ def test_decoder_layer_equivalence():
 # ---------------------------------------------------------------------------
 
 
-def test_full_model_equivalence():
-    """Full CausalLM logits match layer-by-layer reference with shared weights.
+class _RefForCausalLM(nn.Module):
+    """Standalone reference CausalLM for full-model equivalence testing."""
 
-    We verify this by comparing two AD ForCausalLM models with identical weights.
-    One is run normally; the other's output is verified through layer-by-layer
-    reference comparison (already tested above). Here we confirm that the
-    end-to-end model produces finite, deterministic logits with correct shape,
-    and that two forward passes with the same input produce identical output.
-    """
+    def __init__(self, config: Gemma4TextConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)
+        self.embed_scale = config.hidden_size**0.5
+        self.layers = nn.ModuleList(
+            [_RefDecoderLayer(config, i) for i in range(config.num_hidden_layers)]
+        )
+        self.norm = _RefRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        # Tie weights like AD model (tie_word_embeddings=True)
+        if config.tie_word_embeddings:
+            self.lm_head.weight = self.embed_tokens.weight
+
+    def forward(self, input_ids, position_ids):
+        hidden_states = self.embed_tokens(input_ids) * self.embed_scale
+        for i, layer in enumerate(self.layers):
+            layer_type = self.config.layer_types[i]
+            rope = _build_ref_rope(
+                self.config, layer_type, hidden_states.device, hidden_states.dtype
+            )
+            cos, sin = rope(hidden_states, position_ids)
+            causal_mask = (
+                torch.triu(
+                    torch.full(
+                        (hidden_states.shape[1], hidden_states.shape[1]),
+                        float("-inf"),
+                        device=hidden_states.device,
+                        dtype=hidden_states.dtype,
+                    ),
+                    diagonal=1,
+                )
+                .unsqueeze(0)
+                .unsqueeze(0)
+            )
+            hidden_states = layer(hidden_states, (cos, sin), attention_mask=causal_mask)
+        hidden_states = self.norm(hidden_states)
+        logits = self.lm_head(hidden_states)
+        if self.config.final_logit_softcapping is not None:
+            logits = logits / self.config.final_logit_softcapping
+            logits = torch.tanh(logits)
+            logits = logits * self.config.final_logit_softcapping
+        return logits
+
+
+def _transfer_ref_to_ad_full_model(ad_model: Gemma4ForCausalLM, ref_model: _RefForCausalLM) -> None:
+    """Transfer weights from reference full model into AD ForCausalLM."""
+    ref_sd = ref_model.state_dict()
+    ad_sd = {}
+    for k, v in ref_sd.items():
+        if k.startswith("lm_head."):
+            ad_sd[k] = v
+        else:
+            ad_sd[f"model.{k}"] = v
+    missing, unexpected = ad_model.load_state_dict(ad_sd, strict=False)
+    # v_norm buffers are non-persistent, expected missing
+    real_missing = {m for m in missing if "v_norm" not in m}
+    assert not real_missing, f"Missing keys: {real_missing}"
+    assert not unexpected, f"Unexpected keys: {unexpected}"
+
+
+def test_full_model_equivalence():
+    """Full CausalLM logits match standalone reference with shared weights."""
     device, dtype = _device_and_dtype()
     config = _small_text_config()
 
+    ref = _RefForCausalLM(config).to(device=device, dtype=dtype).eval()
     ad = Gemma4ForCausalLM(config).to(device=device, dtype=dtype).eval()
+    _transfer_ref_to_ad_full_model(ad, ref)
 
     B, S = 2, 8
     input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
     pos_ids = _position_ids(B, S, device)
 
     with torch.no_grad():
-        out1 = ad(input_ids=input_ids, position_ids=pos_ids)
-        out2 = ad(input_ids=input_ids, position_ids=pos_ids)
+        ref_logits = ref(input_ids, pos_ids)
+        ad_out = ad(input_ids=input_ids, position_ids=pos_ids)
 
-    assert out1.logits.shape == (B, S, config.vocab_size)
-    assert torch.isfinite(out1.logits).all()
-    # Determinism: two identical passes must produce identical logits
-    torch.testing.assert_close(out1.logits, out2.logits)
+    assert ad_out.logits.shape == (B, S, config.vocab_size)
+    assert torch.isfinite(ad_out.logits).all()
+    assert_rmse_close(ad_out.logits, ref_logits, rmse_ratio_tol=0.05, msg="Full model: ")
 
 
 def test_conditional_generation_wrapper():
@@ -608,6 +674,7 @@ def test_export():
     )
 
     with torch.no_grad():
+        pre_export_out = model(input_ids=input_ids, position_ids=pos_ids)
         exported_out = gm(input_ids, position_ids=pos_ids)
 
     logits = (
@@ -616,6 +683,8 @@ def test_export():
         else getattr(exported_out, "logits", exported_out)
     )
     assert torch.isfinite(logits).all(), "Export produced non-finite values"
+    # Exported graph should produce identical output to the original model
+    torch.testing.assert_close(logits, pre_export_out.logits, rtol=1e-3, atol=1e-3)
 
     # Test different shape
     B2, S2 = 1, 4

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_gemma4_modeling.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_gemma4_modeling.py
@@ -1,0 +1,628 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hierarchical equivalence tests for Gemma4 AutoDeploy custom model.
+
+Reference classes (_Ref*) are standalone PyTorch reimplementations of the
+HuggingFace Gemma4 math — no transformers>=5.3 dependency required.
+"""
+
+from typing import Optional, Tuple
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.export import Dim
+from transformers.activations import ACT2FN
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_gemma4 import (
+    Gemma4Config,
+    Gemma4ForCausalLM,
+    Gemma4ForConditionalGeneration,
+    Gemma4MoEBlock,
+    Gemma4RotaryEmbedding,
+    Gemma4Router,
+    Gemma4TextAttention,
+    Gemma4TextConfig,
+    Gemma4TextDecoderLayer,
+    Gemma4TextMLP,
+    Gemma4VisionConfig,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def assert_rmse_close(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    rmse_ratio_tol: float,
+    msg: str = "",
+) -> None:
+    diff = actual.float() - expected.float()
+    rmse_diff = torch.sqrt(torch.mean(diff**2))
+    rmse_ref = torch.sqrt(torch.mean(expected.float() ** 2))
+    ratio = (rmse_diff / rmse_ref).item()
+    assert ratio < rmse_ratio_tol, (
+        f"{msg}RMSE ratio {ratio:.6f} exceeds tolerance {rmse_ratio_tol}. "
+        f"(rmse_diff={rmse_diff.item():.6f}, rmse_ref={rmse_ref.item():.6f})"
+    )
+
+
+def _device_and_dtype() -> Tuple[str, torch.dtype]:
+    if torch.cuda.is_available():
+        return "cuda", torch.bfloat16
+    return "cpu", torch.float32
+
+
+def _small_text_config() -> Gemma4TextConfig:
+    config = Gemma4TextConfig(
+        vocab_size=256,
+        hidden_size=64,
+        intermediate_size=32,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_global_key_value_heads=1,
+        head_dim=16,
+        global_head_dim=32,
+        hidden_activation="gelu_pytorch_tanh",
+        max_position_embeddings=64,
+        rms_norm_eps=1e-6,
+        attention_bias=False,
+        attention_dropout=0.0,
+        attention_k_eq_v=True,
+        sliding_window=16,
+        layer_types=["sliding_attention", "sliding_attention", "full_attention"],
+        enable_moe_block=True,
+        num_experts=4,
+        top_k_experts=2,
+        expert_intermediate_size=16,
+        final_logit_softcapping=30.0,
+        hidden_size_per_layer_input=0,
+        num_kv_shared_layers=0,
+        use_double_wide_mlp=False,
+        use_bidirectional_attention="vision",
+        rope_parameters={
+            "full_attention": {
+                "rope_type": "proportional",
+                "rope_theta": 1000000.0,
+                "partial_rotary_factor": 0.25,
+            },
+            "sliding_attention": {
+                "rope_type": "default",
+                "rope_theta": 10000.0,
+            },
+        },
+        pad_token_id=0,
+        eos_token_id=1,
+        bos_token_id=2,
+        tie_word_embeddings=True,
+    )
+    config._attn_implementation = "eager"
+    return config
+
+
+def _position_ids(batch_size: int, seq_len: int, device: str) -> torch.Tensor:
+    return torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1)
+
+
+@pytest.fixture(autouse=True)
+def _set_seed():
+    torch.manual_seed(42)
+
+
+# ---------------------------------------------------------------------------
+# Standalone HF-faithful reference implementations (pure PyTorch)
+# These mirror the HuggingFace Gemma4 math exactly, using the same
+# state_dict key names, so weights can be shared between AD and reference.
+# ---------------------------------------------------------------------------
+
+
+class _RefRMSNorm(nn.Module):
+    """HF Gemma4RMSNorm: norm(x) * (weight + scale_shift)."""
+
+    def __init__(
+        self, dim: int, eps: float = 1e-6, scale_shift: float = 1.0, with_scale: bool = True
+    ):
+        super().__init__()
+        self.eps = eps
+        self.scale_shift = scale_shift
+        self.with_scale = with_scale
+        if with_scale:
+            self.weight = nn.Parameter(torch.ones(dim))
+        else:
+            self.weight = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        normed = x.float() * torch.pow(x.float().pow(2).mean(-1, keepdim=True) + self.eps, -0.5)
+        if self.weight is not None:
+            normed = normed * (self.weight.float() + self.scale_shift)
+        return normed.type_as(x)
+
+
+def _ref_rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _ref_apply_rotary(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, udim: int = 2):
+    cos = cos.unsqueeze(udim)
+    sin = sin.unsqueeze(udim)
+    return (x * cos) + (_ref_rotate_half(x) * sin)
+
+
+def _ref_repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
+    if n_rep == 1:
+        return x
+    b, n, s, d = x.shape
+    return x[:, :, None, :, :].expand(b, n, n_rep, s, d).reshape(b, n * n_rep, s, d)
+
+
+class _RefMLP(nn.Module):
+    def __init__(self, config: Gemma4TextConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_activation]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+
+
+class _RefAttention(nn.Module):
+    """HF Gemma4TextAttention reference (eager, no cache, no shared-kv)."""
+
+    def __init__(self, config: Gemma4TextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.is_sliding = config.layer_types[layer_idx] == "sliding_attention"
+        self.use_k_eq_v = config.attention_k_eq_v and not self.is_sliding
+
+        self.head_dim = (
+            config.global_head_dim
+            if (not self.is_sliding and config.global_head_dim)
+            else config.head_dim
+        )
+        self.num_heads = config.num_attention_heads
+        num_kv_heads = (
+            config.num_global_key_value_heads if self.use_k_eq_v else config.num_key_value_heads
+        )
+        self.num_kv_heads = num_kv_heads
+        self.num_kv_groups = self.num_heads // num_kv_heads
+        self.scaling = 1.0
+
+        self.q_proj = nn.Linear(config.hidden_size, self.num_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(config.hidden_size, num_kv_heads * self.head_dim, bias=False)
+        self.v_proj = (
+            None
+            if self.use_k_eq_v
+            else nn.Linear(config.hidden_size, num_kv_heads * self.head_dim, bias=False)
+        )
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, config.hidden_size, bias=False)
+        self.q_norm = _RefRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = _RefRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.v_norm = _RefRMSNorm(self.head_dim, eps=config.rms_norm_eps, with_scale=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        B, S, _ = hidden_states.shape
+        shape = (B, S, -1, self.head_dim)
+        cos, sin = position_embeddings
+
+        q = self.q_proj(hidden_states).view(shape)
+        q = self.q_norm(q)
+        q = _ref_apply_rotary(q, cos, sin, udim=2)
+        q = q.transpose(1, 2)  # -> [B, num_heads, S, head_dim]
+
+        k = self.k_proj(hidden_states).view(shape)
+        v = self.v_proj(hidden_states).view(shape) if self.v_proj is not None else k
+        k = self.k_norm(k)
+        k = _ref_apply_rotary(k, cos, sin, udim=2)
+        k = k.transpose(1, 2)
+        v = self.v_norm(v)
+        v = v.transpose(1, 2)
+
+        # Eager attention with GQA repeat
+        k = _ref_repeat_kv(k, self.num_kv_groups)
+        v = _ref_repeat_kv(v, self.num_kv_groups)
+        attn_w = torch.matmul(q, k.transpose(2, 3)) * self.scaling
+        if attention_mask is not None:
+            attn_w = attn_w + attention_mask
+        attn_w = F.softmax(attn_w, dim=-1, dtype=torch.float32).to(q.dtype)
+        out = torch.matmul(attn_w, v)
+        out = out.transpose(1, 2).contiguous().reshape(B, S, -1)
+        return self.o_proj(out)
+
+
+class _RefRouter(nn.Module):
+    """HF Gemma4Router reference."""
+
+    def __init__(self, config: Gemma4TextConfig):
+        super().__init__()
+        self.proj = nn.Linear(config.hidden_size, config.num_experts, bias=False)
+        self.scale = nn.Parameter(torch.ones(config.hidden_size))
+        self.register_buffer("root_size", torch.tensor(config.hidden_size**-0.5), persistent=False)
+        self.eps = config.rms_norm_eps
+        self.top_k = config.top_k_experts
+
+    def forward(self, hidden_states: torch.Tensor):
+        normed = hidden_states.float()
+        normed = normed * torch.rsqrt(normed.pow(2).mean(-1, keepdim=True) + self.eps)
+        normed = normed.type_as(hidden_states)
+        normed = (
+            normed * self.root_size.to(hidden_states.dtype) * self.scale.to(hidden_states.dtype)
+        )
+        probs = F.softmax(self.proj(normed), dim=-1)
+        topk_w, topk_i = torch.topk(probs, k=self.top_k, dim=-1)
+        topk_w = topk_w / topk_w.sum(dim=-1, keepdim=True)
+        return topk_w, topk_i
+
+
+class _RefMoEBlock(nn.Module):
+    """HF Gemma4MoEBlock reference with fused parameter layout."""
+
+    def __init__(self, config: Gemma4TextConfig):
+        super().__init__()
+        self.num_experts = config.num_experts
+        inter = config.expert_intermediate_size
+        hidden = config.hidden_size
+        self.gate_up_proj = nn.Parameter(torch.zeros(self.num_experts, 2 * inter, hidden))
+        self.down_proj = nn.Parameter(torch.zeros(self.num_experts, hidden, inter))
+        self.per_expert_scale = nn.Parameter(torch.ones(self.num_experts))
+        self.act_fn = ACT2FN[config.hidden_activation]
+
+    def forward(self, hidden_states, top_k_index, top_k_weights):
+        final = torch.zeros_like(hidden_states)
+        with torch.no_grad():
+            expert_mask = F.one_hot(top_k_index, num_classes=self.num_experts).permute(2, 1, 0)
+            expert_hit = expert_mask.sum(dim=(-1, -2)).nonzero()
+        for eidx in expert_hit:
+            eidx = eidx[0]
+            top_k_pos, token_idx = torch.where(expert_mask[eidx])
+            cur = hidden_states[token_idx]
+            gate, up = F.linear(cur, self.gate_up_proj[eidx]).chunk(2, dim=-1)
+            cur = self.act_fn(gate) * up
+            cur = F.linear(cur, self.down_proj[eidx])
+            cur = cur * self.per_expert_scale[eidx]
+            cur = cur * top_k_weights[token_idx, top_k_pos, None]
+            final.index_add_(0, token_idx, cur.to(final.dtype))
+        return final
+
+
+class _RefDecoderLayer(nn.Module):
+    """HF Gemma4TextDecoderLayer reference (no cache/grad-ckpt)."""
+
+    def __init__(self, config: Gemma4TextConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = _RefAttention(config, layer_idx)
+        self.mlp = _RefMLP(config)
+        self.input_layernorm = _RefRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = _RefRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_feedforward_layernorm = _RefRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = _RefRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.register_buffer("layer_scalar", torch.ones(1))
+        self.enable_moe_block = config.enable_moe_block
+        if self.enable_moe_block:
+            self.router = _RefRouter(config)
+            self.moe = _RefMoEBlock(config)
+            self.post_feedforward_layernorm_1 = _RefRMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            self.post_feedforward_layernorm_2 = _RefRMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            self.pre_feedforward_layernorm_2 = _RefRMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+
+    def forward(self, hidden_states, position_embeddings, attention_mask=None):
+        residual = hidden_states
+        h = self.input_layernorm(hidden_states)
+        h = self.self_attn(h, position_embeddings, attention_mask=attention_mask)
+        h = self.post_attention_layernorm(h)
+        hidden_states = residual + h
+
+        residual = hidden_states
+        if self.enable_moe_block:
+            h1 = self.pre_feedforward_layernorm(hidden_states)
+            h1 = self.mlp(h1)
+            h1 = self.post_feedforward_layernorm_1(h1)
+            h_flat = hidden_states.reshape(-1, hidden_states.shape[-1])
+            topk_w, topk_i = self.router(h_flat)
+            h2 = self.pre_feedforward_layernorm_2(h_flat)
+            h2 = self.moe(h2, topk_i, topk_w)
+            h2 = h2.reshape(hidden_states.shape)
+            h2 = self.post_feedforward_layernorm_2(h2)
+            hidden_states = h1 + h2
+        else:
+            hidden_states = self.pre_feedforward_layernorm(hidden_states)
+            hidden_states = self.mlp(hidden_states)
+
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+        hidden_states = hidden_states * self.layer_scalar
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Weight-transfer helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_ref_rope(config: Gemma4TextConfig, layer_type: str, device, dtype):
+    """Build reference cos/sin matching AD's Gemma4RotaryEmbedding."""
+    rope = Gemma4RotaryEmbedding(config, layer_type).to(device)
+    return rope
+
+
+def _load_ref_into_ad(ad_module: nn.Module, ref_module: nn.Module):
+    """Load reference state_dict into AD module (hooks handle weight conversion)."""
+    missing, unexpected = ad_module.load_state_dict(ref_module.state_dict(), strict=False)
+    # v_norm buffer (non-persistent) won't be in state_dict, that's expected
+    allowed_missing = {"v_norm.weight"}
+    real_missing = {k for k in missing if not any(k.endswith(s) for s in allowed_missing)}
+    assert not real_missing, f"Unexpected missing keys: {real_missing}"
+    assert not unexpected, f"Unexpected keys: {unexpected}"
+
+
+# ---------------------------------------------------------------------------
+# Tests — Block equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_mlp_equivalence():
+    """MLP block: identical math, should match exactly."""
+    device, dtype = _device_and_dtype()
+    config = _small_text_config()
+
+    ref = _RefMLP(config).to(device=device, dtype=dtype).eval()
+    ad = Gemma4TextMLP(config).to(device=device, dtype=dtype).eval()
+    ad.load_state_dict(ref.state_dict())
+
+    x = torch.randn(2, 8, config.hidden_size, device=device, dtype=dtype)
+    with torch.no_grad():
+        torch.testing.assert_close(ad(x), ref(x), rtol=1e-3, atol=1e-3)
+
+
+def test_attention_sliding_equivalence():
+    """Sliding attention (standard GQA) matches reference."""
+    device, dtype = _device_and_dtype()
+    config = _small_text_config()
+    layer_idx = 0  # sliding
+
+    ref = _RefAttention(config, layer_idx).to(device=device, dtype=dtype).eval()
+    ad = Gemma4TextAttention(config, layer_idx).to(device=device, dtype=dtype).eval()
+    _load_ref_into_ad(ad, ref)
+
+    B, S = 2, 8
+    x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
+    pos_ids = _position_ids(B, S, device)
+    rope = _build_ref_rope(config, "sliding_attention", device, dtype)
+    cos, sin = rope(x, pos_ids)
+
+    # Build causal mask for reference (AD uses is_causal=True internally)
+    causal_mask = torch.triu(
+        torch.full((S, S), float("-inf"), device=device, dtype=dtype), diagonal=1
+    )
+    causal_mask = causal_mask.unsqueeze(0).unsqueeze(0)
+
+    with torch.no_grad():
+        ad_out = ad(x, (cos, sin))
+        ref_out = ref(x, (cos, sin), attention_mask=causal_mask)
+    assert_rmse_close(ad_out, ref_out, rmse_ratio_tol=0.10, msg="Sliding attention: ")
+
+
+def test_attention_full_k_eq_v_equivalence():
+    """Full attention with K=V and different head_dim matches reference."""
+    device, dtype = _device_and_dtype()
+    config = _small_text_config()
+    layer_idx = 2  # full_attention
+
+    ref = _RefAttention(config, layer_idx).to(device=device, dtype=dtype).eval()
+    ad = Gemma4TextAttention(config, layer_idx).to(device=device, dtype=dtype).eval()
+    _load_ref_into_ad(ad, ref)
+
+    B, S = 2, 8
+    x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
+    pos_ids = _position_ids(B, S, device)
+    rope = _build_ref_rope(config, "full_attention", device, dtype)
+    cos, sin = rope(x, pos_ids)
+
+    causal_mask = torch.triu(
+        torch.full((S, S), float("-inf"), device=device, dtype=dtype), diagonal=1
+    )
+    causal_mask = causal_mask.unsqueeze(0).unsqueeze(0)
+
+    with torch.no_grad():
+        ad_out = ad(x, (cos, sin))
+        ref_out = ref(x, (cos, sin), attention_mask=causal_mask)
+    assert_rmse_close(ad_out, ref_out, rmse_ratio_tol=0.10, msg="Full K=V attention: ")
+
+
+def test_moe_block_equivalence():
+    """MoE block (router + experts) matches reference with fused weight conversion."""
+    device, dtype = _device_and_dtype()
+    config = _small_text_config()
+
+    ref_router = _RefRouter(config).to(device=device, dtype=dtype).eval()
+    ref_moe = _RefMoEBlock(config).to(device=device, dtype=dtype).eval()
+    # Initialize MoE fused params with random values (default is zeros → all-zero output)
+    nn.init.normal_(ref_moe.gate_up_proj, std=0.02)
+    nn.init.normal_(ref_moe.down_proj, std=0.02)
+    nn.init.uniform_(ref_moe.per_expert_scale, 0.5, 1.5)
+
+    ad_router = Gemma4Router(config).to(device=device, dtype=dtype).eval()
+    ad_moe = Gemma4MoEBlock(config).to(device=device, dtype=dtype).eval()
+
+    # Load router weights (same structure)
+    ad_router.load_state_dict(ref_router.state_dict())
+    # Load MoE weights (hook unfuses gate_up_proj + folds per_expert_scale)
+    ad_moe.load_state_dict(ref_moe.state_dict(), strict=False)
+
+    T = 16  # num tokens (flattened B*S)
+    x = torch.randn(T, config.hidden_size, device=device, dtype=dtype)
+
+    with torch.no_grad():
+        ref_w, ref_i = ref_router(x)
+        ad_w, ad_i = ad_router(x)
+        # Router outputs should match exactly (same math, no custom ops)
+        torch.testing.assert_close(ad_w, ref_w, rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(ad_i, ref_i)
+
+        ref_out = ref_moe(x, ref_i, ref_w)
+        ad_out = ad_moe(x, ad_i, ad_w)
+
+    assert_rmse_close(ad_out, ref_out, rmse_ratio_tol=0.02, msg="MoE block: ")
+
+
+# ---------------------------------------------------------------------------
+# Tests — Layer equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_decoder_layer_equivalence():
+    """Decoder layer (sliding + full) matches reference."""
+    device, dtype = _device_and_dtype()
+    config = _small_text_config()
+
+    for layer_idx in [0, 2]:
+        layer_type = config.layer_types[layer_idx]
+        ref = _RefDecoderLayer(config, layer_idx).to(device=device, dtype=dtype).eval()
+        ad = Gemma4TextDecoderLayer(config, layer_idx).to(device=device, dtype=dtype).eval()
+        _load_ref_into_ad(ad, ref)
+
+        B, S = 2, 8
+        x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
+        pos_ids = _position_ids(B, S, device)
+        rope = _build_ref_rope(config, layer_type, device, dtype)
+        cos, sin = rope(x, pos_ids)
+
+        causal_mask = (
+            torch.triu(torch.full((S, S), float("-inf"), device=device, dtype=dtype), diagonal=1)
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
+
+        with torch.no_grad():
+            ad_out = ad(x, (cos, sin))
+            ref_out = ref(x, (cos, sin), attention_mask=causal_mask)
+        assert_rmse_close(
+            ad_out, ref_out, rmse_ratio_tol=0.05, msg=f"Layer {layer_idx} ({layer_type}): "
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests — Full model equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_full_model_equivalence():
+    """Full CausalLM logits match layer-by-layer reference with shared weights.
+
+    We verify this by comparing two AD ForCausalLM models with identical weights.
+    One is run normally; the other's output is verified through layer-by-layer
+    reference comparison (already tested above). Here we confirm that the
+    end-to-end model produces finite, deterministic logits with correct shape,
+    and that two forward passes with the same input produce identical output.
+    """
+    device, dtype = _device_and_dtype()
+    config = _small_text_config()
+
+    ad = Gemma4ForCausalLM(config).to(device=device, dtype=dtype).eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
+    pos_ids = _position_ids(B, S, device)
+
+    with torch.no_grad():
+        out1 = ad(input_ids=input_ids, position_ids=pos_ids)
+        out2 = ad(input_ids=input_ids, position_ids=pos_ids)
+
+    assert out1.logits.shape == (B, S, config.vocab_size)
+    assert torch.isfinite(out1.logits).all()
+    # Determinism: two identical passes must produce identical logits
+    torch.testing.assert_close(out1.logits, out2.logits)
+
+
+def test_conditional_generation_wrapper():
+    """ConditionalGeneration wrapper loads and forwards correctly."""
+    device, dtype = _device_and_dtype()
+    config = Gemma4Config(
+        text_config=_small_text_config(),
+        vision_config=Gemma4VisionConfig(hidden_size=32),
+    )
+    model = Gemma4ForConditionalGeneration(config).to(device=device, dtype=dtype).eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, config.text_config.vocab_size, (B, S), device=device)
+    pos_ids = _position_ids(B, S, device)
+
+    with torch.no_grad():
+        out = model(input_ids=input_ids, position_ids=pos_ids)
+    assert out.logits is not None
+    assert out.logits.shape == (B, S, config.text_config.vocab_size)
+    assert torch.isfinite(out.logits).all()
+
+
+# ---------------------------------------------------------------------------
+# Tests — Export
+# ---------------------------------------------------------------------------
+
+
+def test_export():
+    """Model can be exported with torch.export and produces correct output."""
+    device = "cpu"
+    dtype = torch.float32
+    config = _small_text_config()
+    config.enable_moe_block = False  # MoE expert dispatch uses data-dependent ops
+
+    model = Gemma4ForCausalLM(config).to(device=device, dtype=dtype).eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
+    pos_ids = _position_ids(B, S, device)
+
+    batch_dim = Dim("batch", min=1, max=4)
+    seq_dim = Dim("seq", min=1, max=64)
+    dynamic_shapes = {
+        "input_ids": {0: batch_dim, 1: seq_dim},
+        "position_ids": {0: batch_dim, 1: seq_dim},
+    }
+
+    gm = torch_export_to_gm(
+        model,
+        args=(input_ids,),
+        kwargs={"position_ids": pos_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+
+    with torch.no_grad():
+        exported_out = gm(input_ids, position_ids=pos_ids)
+
+    logits = (
+        exported_out[0]
+        if isinstance(exported_out, tuple)
+        else getattr(exported_out, "logits", exported_out)
+    )
+    assert torch.isfinite(logits).all(), "Export produced non-finite values"
+
+    # Test different shape
+    B2, S2 = 1, 4
+    ids2 = torch.randint(0, config.vocab_size, (B2, S2), device=device)
+    pos2 = _position_ids(B2, S2, device)
+    with torch.no_grad():
+        out2 = gm(ids2, position_ids=pos2)
+    logits2 = out2[0] if isinstance(out2, tuple) else getattr(out2, "logits", out2)
+    assert logits2.shape == (B2, S2, config.vocab_size)
+    assert torch.isfinite(logits2).all()

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_shared_kv_attention.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_shared_kv_attention.py
@@ -1,0 +1,660 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.compile.piecewise_utils import is_dynamic_cached_op
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.flashinfer_attention import (
+    FlashInferAttention,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.torch_backend_attention import (
+    TorchBackendAttention,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
+from tensorrt_llm._torch.auto_deploy.transform.library.kvcache import (
+    InsertCachedAttentionConfig,
+    _InsertCachedOperator,
+)
+
+
+class _TinySharedKVModule(torch.nn.Module):
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        qkv = hidden_states.view(hidden_states.shape[0], hidden_states.shape[1], 2, 4)
+        regular = torch.ops.auto_deploy.torch_attention(
+            qkv,
+            qkv,
+            qkv,
+            None,
+            0.0,
+            True,
+            1.0,
+            None,
+            None,
+            None,
+            "bsnd",
+            0,
+        )
+        shared = torch.ops.auto_deploy.torch_attention(
+            qkv,
+            qkv,
+            qkv,
+            None,
+            0.0,
+            True,
+            1.0,
+            None,
+            None,
+            None,
+            "bsnd",
+            1,
+            0,
+        )
+        return regular + shared
+
+
+class _DuplicateLayerOwnerSharedKVModule(torch.nn.Module):
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        qkv = hidden_states.view(hidden_states.shape[0], hidden_states.shape[1], 2, 4)
+        first = torch.ops.auto_deploy.torch_attention(
+            qkv, qkv, qkv, None, 0.0, True, 1.0, None, None, None, "bsnd", 0
+        )
+        second = torch.ops.auto_deploy.torch_attention(
+            qkv, qkv, qkv, None, 0.0, True, 1.0, None, None, None, "bsnd", 0
+        )
+        return first + second
+
+
+def _context_meta(seq_len: int):
+    batch_info_host = BatchInfo()
+    batch_info_host.update([1, seq_len, 0, 0, 0, 0])
+    return (
+        batch_info_host.serialize(),
+        torch.tensor([seq_len], dtype=torch.int32),
+        torch.tensor([0], dtype=torch.int32),
+        torch.tensor([0], dtype=torch.int64),
+        torch.tensor([0], dtype=torch.int32),
+    )
+
+
+def _decode_meta(input_pos: int):
+    batch_info_host = BatchInfo()
+    batch_info_host.update([0, 0, 0, 0, 1, 1])
+    return (
+        batch_info_host.serialize(),
+        torch.tensor([1], dtype=torch.int32),
+        torch.tensor([input_pos], dtype=torch.int32),
+        torch.tensor([0], dtype=torch.int64),
+        torch.tensor([0], dtype=torch.int32),
+    )
+
+
+def _manual_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sliding_window: int | None = None,
+) -> torch.Tensor:
+    batch, seq_len_q, num_heads, _ = q.shape
+    _, seq_len_k, num_kv_heads, _ = k.shape
+    if num_heads != num_kv_heads:
+        repeat_factor = num_heads // num_kv_heads
+        k = k.repeat_interleave(repeat_factor, dim=2)
+        v = v.repeat_interleave(repeat_factor, dim=2)
+
+    q_t = q.transpose(1, 2)
+    k_t = k.transpose(1, 2)
+    v_t = v.transpose(1, 2)
+    scores = torch.matmul(q_t, k_t.transpose(-2, -1))
+    causal_mask = torch.triu(
+        torch.ones(seq_len_q, seq_len_k, dtype=torch.bool, device=scores.device),
+        diagonal=seq_len_k - seq_len_q + 1,
+    )
+    scores = scores.masked_fill(causal_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    if sliding_window is not None:
+        query_positions = torch.arange(seq_len_k - seq_len_q, seq_len_k, device=scores.device)
+        key_positions = torch.arange(seq_len_k, device=scores.device)
+        pos_diff = query_positions.unsqueeze(1) - key_positions.unsqueeze(0)
+        sliding_window_mask = (pos_diff < 0) | (pos_diff >= sliding_window)
+        scores = scores.masked_fill(sliding_window_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    weights = torch.softmax(scores, dim=-1)
+    return torch.matmul(weights, v_t).transpose(1, 2)
+
+
+def _make_layer_inputs(offset: float, seq_len: int, decode: bool = False):
+    base_q = torch.tensor(
+        [[[1.0, 0.0], [0.0, 1.0]]]
+        if decode
+        else [
+            [[1.0, 0.0], [0.0, 1.0]],
+            [[0.5, 0.5], [0.5, -0.5]],
+            [[0.25, 0.75], [0.75, 0.25]],
+        ],
+        dtype=torch.float32,
+    )
+    base_k = torch.tensor(
+        [[[1.0, 0.0]]] if decode else [[[1.0, 0.0]], [[0.0, 1.0]], [[1.0, 1.0]]],
+        dtype=torch.float32,
+    )
+    base_v = torch.tensor(
+        [[[10.0, 1.0]]] if decode else [[[10.0, 1.0]], [[2.0, 20.0]], [[30.0, 3.0]]],
+        dtype=torch.float32,
+    )
+    q = (base_q + offset).unsqueeze(0)
+    k = (base_k + offset).unsqueeze(0)
+    v = (base_v + offset * 10.0).unsqueeze(0)
+    assert q.shape[1] == seq_len
+    return q, k, v
+
+
+def test_shared_kv_transform_aliases_source_cache_placeholders():
+    module = _TinySharedKVModule().eval()
+    gm = torch_export_to_gm(module, (torch.randn(1, 4, 8),))
+
+    cm = CachedSequenceInterface(
+        max_seq_len=16,
+        max_batch_size=2,
+        max_num_tokens=16,
+        device="cpu",
+    )
+    transform = _InsertCachedOperator(
+        InsertCachedAttentionConfig(stage=Stages.CACHE_INIT, backend="torch")
+    )
+    gm, info = transform._apply(gm, cm, factory=None, shared_config=SharedConfig())
+
+    assert info.num_matches == 2
+
+    placeholder_names = [node.target for node in gm.graph.nodes if node.op == "placeholder"]
+    assert placeholder_names.count("r0_k_cache") == 1
+    assert placeholder_names.count("r1_v_cache") == 1
+    assert "r2_k_cache" not in placeholder_names
+    assert "r3_v_cache" not in placeholder_names
+    assert set(cm._resource_lookup).issubset(set(placeholder_names))
+
+    cached_nodes = [node for node in gm.graph.nodes if node.op == "call_function"]
+    regular_node = next(
+        node
+        for node in cached_nodes
+        if node.target == torch.ops.auto_deploy.torch_cached_attention_with_cache.default
+        and node.args[-1] is False
+    )
+    shared_node = next(
+        node
+        for node in cached_nodes
+        if node.target == torch.ops.auto_deploy.torch_cached_attention_with_cache.default
+        and node.args[-1] is True
+    )
+
+    assert regular_node.args[8] is shared_node.args[8]
+    assert regular_node.args[9] is shared_node.args[9]
+    assert regular_node.target == torch.ops.auto_deploy.torch_cached_attention_with_cache.default
+    assert shared_node.target == torch.ops.auto_deploy.torch_cached_attention_with_cache.default
+    assert regular_node.args[-1] is False
+    assert shared_node.args[-1] is True
+
+
+def test_shared_kv_cached_attention_reads_without_writing():
+    q = torch.tensor([[[[1.0, 0.0], [0.0, 1.0]]]], dtype=torch.float32)
+    dummy_k = torch.full((1, 1, 2, 2), 123.0, dtype=torch.float32)
+    dummy_v = torch.full((1, 1, 2, 2), -456.0, dtype=torch.float32)
+
+    k_cache = torch.tensor(
+        [[[[1.0, 0.0], [0.0, 1.0]], [[0.5, 0.0], [0.0, 0.5]], [[0.25, 0.0], [0.0, 0.25]]]],
+        dtype=torch.float32,
+    )
+    v_cache = torch.tensor(
+        [[[[10.0, 1.0], [2.0, 20.0]], [[30.0, 3.0], [4.0, 40.0]], [[50.0, 5.0], [6.0, 60.0]]]],
+        dtype=torch.float32,
+    )
+    k_cache_before = k_cache.clone()
+    v_cache_before = v_cache.clone()
+
+    batch_info_host = BatchInfo()
+    batch_info_host.update([0, 0, 0, 0, 1, 1])
+    output = torch.ops.auto_deploy.torch_cached_attention_with_cache(
+        q,
+        dummy_k,
+        dummy_v,
+        batch_info_host.serialize(),
+        torch.tensor([1], dtype=torch.int32),
+        torch.tensor([2], dtype=torch.int32),
+        torch.tensor([0], dtype=torch.int64),
+        torch.tensor([0], dtype=torch.int32),
+        k_cache,
+        v_cache,
+        1.0,
+        None,
+        None,
+        None,
+        True,
+    )
+
+    assert torch.equal(k_cache, k_cache_before)
+    assert torch.equal(v_cache, v_cache_before)
+
+    k_for_attn = k_cache_before[0, :3].transpose(0, 1)
+    v_for_attn = v_cache_before[0, :3].transpose(0, 1)
+    logits = torch.matmul(q[0, 0].unsqueeze(1), k_for_attn.transpose(-2, -1))
+    weights = torch.softmax(logits, dim=-1)
+    expected = torch.matmul(weights, v_for_attn).squeeze(1).unsqueeze(0).unsqueeze(0)
+    torch.testing.assert_close(output, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_torch_backend_attention_metadata_for_shared_kv_node():
+    module = _TinySharedKVModule().eval()
+    gm = torch_export_to_gm(module, (torch.randn(1, 4, 8),))
+    source_nodes = [
+        node
+        for node in gm.graph.nodes
+        if node.op == "call_function"
+        and node.target == torch.ops.auto_deploy.torch_attention.default
+    ]
+    regular = next(
+        node
+        for node in source_nodes
+        if node.target == torch.ops.auto_deploy.torch_attention.default
+    )
+    shared = next(node for node in source_nodes if TorchBackendAttention.get_layer_idx(node) == 1)
+
+    assert TorchBackendAttention.get_layer_idx(regular) == 0
+    assert TorchBackendAttention.get_layer_idx(shared) == 1
+    assert TorchBackendAttention.get_shared_kv_source_layer_idx(regular) is None
+    assert TorchBackendAttention.get_shared_kv_source_layer_idx(shared) == 0
+
+
+def test_flashinfer_backend_attention_metadata_for_shared_kv_node():
+    module = _TinySharedKVModule().eval()
+    gm = torch_export_to_gm(module, (torch.randn(1, 4, 8),))
+    source_nodes = [
+        node
+        for node in gm.graph.nodes
+        if node.op == "call_function"
+        and node.target == torch.ops.auto_deploy.torch_attention.default
+    ]
+    regular = next(
+        node
+        for node in source_nodes
+        if node.target == torch.ops.auto_deploy.torch_attention.default
+    )
+    shared = next(node for node in source_nodes if FlashInferAttention.get_layer_idx(node) == 1)
+
+    assert FlashInferAttention.get_layer_idx(regular) == 0
+    assert FlashInferAttention.get_layer_idx(shared) == 1
+    assert FlashInferAttention.get_shared_kv_source_layer_idx(regular) is None
+    assert FlashInferAttention.get_shared_kv_source_layer_idx(shared) == 0
+    assert FlashInferAttention.get_cached_attention_op() == (
+        torch.ops.auto_deploy.flashinfer_attention_mha_with_cache.default
+    )
+
+
+def test_shared_kv_transform_aliases_source_cache_placeholders_for_flashinfer():
+    module = _TinySharedKVModule().eval()
+    gm = torch_export_to_gm(module, (torch.randn(1, 4, 8),))
+
+    cm = CachedSequenceInterface(
+        max_seq_len=16,
+        max_batch_size=2,
+        max_num_tokens=16,
+        device="cpu",
+    )
+    transform = _InsertCachedOperator(
+        InsertCachedAttentionConfig(stage=Stages.CACHE_INIT, backend="flashinfer")
+    )
+    gm, info = transform._apply(gm, cm, factory=None, shared_config=SharedConfig())
+
+    assert info.num_matches == 2
+
+    placeholder_names = [node.target for node in gm.graph.nodes if node.op == "placeholder"]
+    assert placeholder_names.count("r0_kv_cache") == 1
+    assert "r1_kv_cache" not in placeholder_names
+    assert set(cm._resource_lookup).issubset(set(placeholder_names))
+
+    cached_nodes = [node for node in gm.graph.nodes if node.op == "call_function"]
+    regular_node = next(
+        node
+        for node in cached_nodes
+        if node.target == torch.ops.auto_deploy.flashinfer_attention_mha_with_cache.default
+        and node.args[-1] is False
+    )
+    shared_node = next(
+        node
+        for node in cached_nodes
+        if node.target == torch.ops.auto_deploy.flashinfer_attention_mha_with_cache.default
+        and node.args[-1] is True
+    )
+
+    assert regular_node.args[11] is shared_node.args[11]
+    assert regular_node.target == torch.ops.auto_deploy.flashinfer_attention_mha_with_cache.default
+    assert shared_node.target == torch.ops.auto_deploy.flashinfer_attention_mha_with_cache.default
+    assert regular_node.args[-1] is False
+    assert shared_node.args[-1] is True
+
+
+def test_flashinfer_cached_attention_is_dynamic_for_piecewise():
+    shared_op_name = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache.default.name()
+
+    class _FakeNode:
+        op = "call_function"
+
+        def __init__(self, target):
+            self.target = target
+
+    assert "flashinfer_attention_mha_with_cache" in shared_op_name
+    assert is_dynamic_cached_op(
+        _FakeNode(torch.ops.auto_deploy.flashinfer_attention_mha_with_cache.default)
+    )
+
+
+@torch.no_grad()
+def test_torch_shared_kv_cached_attention_supports_out_buffer():
+    q = torch.randn(1, 3, 2, 4)
+    k = torch.randn(1, 3, 1, 4)
+    v = torch.randn(1, 3, 1, 4)
+    batch_info_host = BatchInfo()
+    batch_info_host.update([1, 3, 0, 0, 1, 1])
+    seq_len = torch.tensor([3], dtype=torch.int32)
+    input_pos = torch.tensor([0, 1, 2], dtype=torch.int32)
+    slot_idx = torch.tensor([0, 1, 2], dtype=torch.int32)
+    cu_seqlen = torch.tensor([0], dtype=torch.int32)
+    k_cache = torch.randn(1, 4, 1, 4)
+    v_cache = torch.randn(1, 4, 1, 4)
+
+    expected = torch.ops.auto_deploy.torch_cached_attention_with_cache.default(
+        q,
+        k,
+        v,
+        batch_info_host.serialize(),
+        seq_len,
+        input_pos,
+        slot_idx,
+        cu_seqlen,
+        k_cache,
+        v_cache,
+        None,
+        read_cache_only=True,
+    )
+
+    out = torch.full_like(expected, float("nan"))
+    ret = torch.ops.auto_deploy.torch_cached_attention_with_cache.default(
+        q,
+        k,
+        v,
+        batch_info_host.serialize(),
+        seq_len,
+        input_pos,
+        slot_idx,
+        cu_seqlen,
+        k_cache,
+        v_cache,
+        None,
+        read_cache_only=True,
+        out=out,
+    )
+
+    assert ret.numel() == 0
+    torch.testing.assert_close(out, expected)
+
+
+def test_shared_kv_self_alias_raises():
+    class _SelfAliasingSharedKVModule(torch.nn.Module):
+        def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+            qkv = hidden_states.view(hidden_states.shape[0], hidden_states.shape[1], 2, 4)
+            return torch.ops.auto_deploy.torch_attention(
+                qkv, qkv, qkv, None, 0.0, True, 1.0, None, None, None, "bsnd", 1, 1
+            )
+
+    module = _SelfAliasingSharedKVModule().eval()
+    gm = torch_export_to_gm(module, (torch.randn(1, 4, 8),))
+
+    cm = CachedSequenceInterface(
+        max_seq_len=16,
+        max_batch_size=2,
+        max_num_tokens=16,
+        device="cpu",
+    )
+    transform = _InsertCachedOperator(
+        InsertCachedAttentionConfig(stage=Stages.CACHE_INIT, backend="torch")
+    )
+
+    with pytest.raises(RuntimeError, match="cannot share its own KV cache"):
+        transform._apply(gm, cm, factory=None, shared_config=SharedConfig())
+
+
+def test_duplicate_cache_owner_layer_idx_raises():
+    module = _DuplicateLayerOwnerSharedKVModule().eval()
+    gm = torch_export_to_gm(module, (torch.randn(1, 4, 8),))
+
+    cm = CachedSequenceInterface(
+        max_seq_len=16,
+        max_batch_size=2,
+        max_num_tokens=16,
+        device="cpu",
+    )
+    transform = _InsertCachedOperator(
+        InsertCachedAttentionConfig(stage=Stages.CACHE_INIT, backend="torch")
+    )
+
+    with pytest.raises(RuntimeError, match="Duplicate KV cache owner"):
+        transform._apply(gm, cm, factory=None, shared_config=SharedConfig())
+
+
+@torch.no_grad()
+def test_flashinfer_shared_kv_cached_attention_reads_aliased_cache_without_writing():
+    if not torch.cuda.is_available():
+        return
+
+    device = torch.device("cuda")
+    head_dim = 64
+    q = torch.zeros((1, 1, 1, head_dim), dtype=torch.float16, device=device)
+    q[0, 0, 0, 0] = 1.0
+    dummy_k = torch.full((1, 1, 1, head_dim), 9.0, dtype=torch.float16, device=device)
+    dummy_v = torch.full((1, 1, 1, head_dim), 7.0, dtype=torch.float16, device=device)
+
+    owner_k = torch.zeros((1, 3, 1, head_dim), dtype=torch.float16, device=device)
+    owner_k[0, 0, 0, 0] = 1.0
+    owner_k[0, 1, 0, 1] = 1.0
+    owner_k[0, 2, 0, 0] = 1.0
+    owner_k[0, 2, 0, 1] = 1.0
+    owner_v = torch.zeros((1, 3, 1, head_dim), dtype=torch.float16, device=device)
+    owner_v[0, 0, 0, 0] = 10.0
+    owner_v[0, 1, 0, 1] = 20.0
+    owner_v[0, 2, 0, 0] = 30.0
+    owner_v[0, 2, 0, 1] = 3.0
+    kv_cache = torch.zeros((1, 2, 1, 32, head_dim), dtype=torch.float16, device=device)
+    kv_cache[0, 0, 0, :3, :] = owner_k[0, :, 0, :]
+    kv_cache[0, 1, 0, :3, :] = owner_v[0, :, 0, :]
+    kv_cache_before = kv_cache.clone()
+
+    batch_info_host = BatchInfo()
+    batch_info_host.update([0, 0, 0, 0, 1, 1])
+    cu_seqlen_host = torch.tensor([0, 1], dtype=torch.int32, device="cpu")
+    cu_num_pages = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    cu_num_pages_host = torch.tensor([0, 1], dtype=torch.int32, device="cpu")
+    cache_loc = torch.tensor([0], dtype=torch.int32, device=device)
+    last_page_len = torch.tensor([3], dtype=torch.int32, device=device)
+    last_page_len_host = torch.tensor([3], dtype=torch.int32, device="cpu")
+    seq_len_with_cache_host = torch.tensor([3], dtype=torch.int32, device="cpu")
+    batch_indices = torch.zeros(1, dtype=torch.int32, device=device)
+    positions = torch.zeros(1, dtype=torch.int32, device=device)
+
+    output = torch.ops.auto_deploy.flashinfer_attention_mha_with_cache(
+        q,
+        dummy_k,
+        dummy_v,
+        batch_info_host.serialize(),
+        cu_seqlen_host,
+        cu_num_pages,
+        cu_num_pages_host,
+        cache_loc,
+        last_page_len,
+        last_page_len_host,
+        seq_len_with_cache_host,
+        batch_indices,
+        positions,
+        kv_cache,
+        1.0,
+        None,
+        1.0,
+        1.0,
+        True,
+    )
+
+    torch.testing.assert_close(kv_cache, kv_cache_before, rtol=0.0, atol=0.0)
+
+    expected = _manual_attention(q.float(), owner_k.float(), owner_v.float()).to(output.dtype)
+    torch.testing.assert_close(output.float(), expected.float(), rtol=2e-2, atol=2e-2)
+
+
+def test_shared_kv_six_layer_stack_matches_reference_for_prefill_and_decode():
+    layer_sources = {4: 2, 5: 3}
+    sliding_layers = {2, 4}
+    prefill_len = 3
+    decode_pos = prefill_len
+    owner_caches = {
+        layer_idx: (
+            torch.zeros(1, 8, 1, 2, dtype=torch.float32),
+            torch.zeros(1, 8, 1, 2, dtype=torch.float32),
+        )
+        for layer_idx in range(4)
+    }
+    owner_history = {}
+
+    for layer_idx in range(6):
+        q_prefill, k_prefill, v_prefill = _make_layer_inputs(
+            offset=float(layer_idx), seq_len=prefill_len
+        )
+        batch_info_host, seq_len, input_pos, slot_idx, cu_seqlen = _context_meta(prefill_len)
+        sliding_window = 2 if layer_idx in sliding_layers else None
+
+        if layer_idx in layer_sources:
+            source_idx = layer_sources[layer_idx]
+            k_cache, v_cache = owner_caches[source_idx]
+            output_prefill = torch.ops.auto_deploy.torch_cached_attention_with_cache(
+                q_prefill,
+                k_prefill,
+                v_prefill,
+                batch_info_host,
+                seq_len,
+                input_pos,
+                slot_idx,
+                cu_seqlen,
+                k_cache,
+                v_cache,
+                1.0,
+                None,
+                sliding_window,
+                None,
+                True,
+            )
+            expected_prefill = _manual_attention(
+                q_prefill,
+                owner_history[source_idx]["k_prefill"],
+                owner_history[source_idx]["v_prefill"],
+                sliding_window=sliding_window,
+            )
+        else:
+            k_cache, v_cache = owner_caches[layer_idx]
+            output_prefill = torch.ops.auto_deploy.torch_cached_attention_with_cache(
+                q_prefill,
+                k_prefill,
+                v_prefill,
+                batch_info_host,
+                seq_len,
+                input_pos,
+                slot_idx,
+                cu_seqlen,
+                k_cache,
+                v_cache,
+                1.0,
+                None,
+                sliding_window,
+                None,
+            )
+            expected_prefill = _manual_attention(
+                q_prefill,
+                k_prefill,
+                v_prefill,
+                sliding_window=sliding_window,
+            )
+            owner_history[layer_idx] = {
+                "k_prefill": k_prefill.clone(),
+                "v_prefill": v_prefill.clone(),
+            }
+            torch.testing.assert_close(k_cache[0, :prefill_len], k_prefill[0], rtol=0.0, atol=0.0)
+            torch.testing.assert_close(v_cache[0, :prefill_len], v_prefill[0], rtol=0.0, atol=0.0)
+
+        torch.testing.assert_close(output_prefill, expected_prefill, rtol=1e-5, atol=1e-5)
+
+    for layer_idx in range(6):
+        q_decode, k_decode, v_decode = _make_layer_inputs(
+            offset=100.0 + float(layer_idx), seq_len=1, decode=True
+        )
+        batch_info_host, seq_len, input_pos, slot_idx, cu_seqlen = _decode_meta(decode_pos)
+        sliding_window = 2 if layer_idx in sliding_layers else None
+
+        if layer_idx in layer_sources:
+            source_idx = layer_sources[layer_idx]
+            k_cache, v_cache = owner_caches[source_idx]
+            k_cache_before = k_cache.clone()
+            v_cache_before = v_cache.clone()
+            output_decode = torch.ops.auto_deploy.torch_cached_attention_with_cache(
+                q_decode,
+                k_decode,
+                v_decode,
+                batch_info_host,
+                seq_len,
+                input_pos,
+                slot_idx,
+                cu_seqlen,
+                k_cache,
+                v_cache,
+                1.0,
+                None,
+                sliding_window,
+                None,
+                True,
+            )
+            torch.testing.assert_close(k_cache, k_cache_before, rtol=0.0, atol=0.0)
+            torch.testing.assert_close(v_cache, v_cache_before, rtol=0.0, atol=0.0)
+            expected_k = owner_history[source_idx]["k_full"]
+            expected_v = owner_history[source_idx]["v_full"]
+        else:
+            k_cache, v_cache = owner_caches[layer_idx]
+            output_decode = torch.ops.auto_deploy.torch_cached_attention_with_cache(
+                q_decode,
+                k_decode,
+                v_decode,
+                batch_info_host,
+                seq_len,
+                input_pos,
+                slot_idx,
+                cu_seqlen,
+                k_cache,
+                v_cache,
+                1.0,
+                None,
+                sliding_window,
+                None,
+            )
+            expected_k = torch.cat([owner_history[layer_idx]["k_prefill"], k_decode], dim=1)
+            expected_v = torch.cat([owner_history[layer_idx]["v_prefill"], v_decode], dim=1)
+            owner_history[layer_idx]["k_full"] = expected_k
+            owner_history[layer_idx]["v_full"] = expected_v
+            torch.testing.assert_close(
+                k_cache[0, : decode_pos + 1], expected_k[0], rtol=0.0, atol=0.0
+            )
+            torch.testing.assert_close(
+                v_cache[0, : decode_pos + 1], expected_v[0], rtol=0.0, atol=0.0
+            )
+
+        expected_decode = _manual_attention(
+            q_decode,
+            expected_k,
+            expected_v,
+            sliding_window=sliding_window,
+        )
+        torch.testing.assert_close(output_decode, expected_decode, rtol=1e-5, atol=1e-5)

--- a/tests/unittest/_torch/modeling/test_modeling_mistral.py
+++ b/tests/unittest/_torch/modeling/test_modeling_mistral.py
@@ -536,3 +536,81 @@ def test_processor_get_num_tokens_per_image(
     mocked_auto_processor.from_pretrained.return_value._get_num_multimodal_tokens.assert_called_once_with(
         [(height, width)]
     )
+
+
+def test_mistral_attention_swa_wiring():
+    """Verify MistralAttention.forward passes sliding_window to Attention.forward."""
+    config = transformers.MistralConfig(
+        hidden_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        sliding_window=4096,
+    )
+    mc = model_config_lib.ModelConfig(
+        pretrained_config=config,
+        mapping=mapping_lib.Mapping(world_size=1, tp_size=1, rank=0),
+    )
+    attn = modeling_mistral.MistralAttention(mc, layer_idx=0)
+
+    with mock.patch(
+        "tensorrt_llm._torch.models.modeling_mistral.Attention.forward"
+    ) as mocked_forward:
+        attn.forward(position_ids=None, hidden_states=None, attn_metadata=None)
+
+    mocked_forward.assert_called_once()
+    _, call_kwargs = mocked_forward.call_args
+    assert call_kwargs["attention_window_size"] == config.sliding_window
+
+
+def test_mistral_attention_swa_none_when_unset():
+    """Verify MistralAttention.forward passes None when sliding_window is unset."""
+    config = transformers.MistralConfig(
+        hidden_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        sliding_window=None,
+    )
+    mc = model_config_lib.ModelConfig(
+        pretrained_config=config,
+        mapping=mapping_lib.Mapping(world_size=1, tp_size=1, rank=0),
+    )
+    attn = modeling_mistral.MistralAttention(mc, layer_idx=0)
+
+    with mock.patch(
+        "tensorrt_llm._torch.models.modeling_mistral.Attention.forward"
+    ) as mocked_forward:
+        attn.forward(position_ids=None, hidden_states=None, attn_metadata=None)
+
+    mocked_forward.assert_called_once()
+    _, call_kwargs = mocked_forward.call_args
+    assert call_kwargs["attention_window_size"] is None
+
+
+def test_mistral_attention_swa_layer_types():
+    """Ministral-style layer_types: sliding layers get SWA, full layers get None."""
+    config = transformers.MistralConfig(
+        hidden_size=128,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        sliding_window=32768,
+    )
+    # Ministral pattern: alternating sliding/full attention
+    config.layer_types = [
+        "sliding_attention",
+        "full_attention",
+        "sliding_attention",
+        "full_attention",
+    ]
+
+    mc = model_config_lib.ModelConfig(
+        pretrained_config=config,
+        mapping=mapping_lib.Mapping(world_size=1, tp_size=1, rank=0),
+    )
+
+    # Layer 0: sliding_attention → should use SWA
+    attn_sliding = modeling_mistral.MistralAttention(mc, layer_idx=0)
+    assert attn_sliding.attention_window_size == 32768
+
+    # Layer 1: full_attention → should be None
+    attn_full = modeling_mistral.MistralAttention(mc, layer_idx=1)
+    assert attn_full.attention_window_size is None

--- a/tests/unittest/_torch/modeling/test_modeling_mixtral.py
+++ b/tests/unittest/_torch/modeling/test_modeling_mixtral.py
@@ -15,7 +15,8 @@ from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.checkpoints.hf.mixtral_weight_mapper import \
     MixtralHfWeightMapper
-from tensorrt_llm._torch.models.modeling_mixtral import MixtralForCausalLM
+from tensorrt_llm._torch.models.modeling_mixtral import (MixtralAttention,
+                                                         MixtralForCausalLM)
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm.bindings.executor import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
@@ -355,3 +356,33 @@ class TestMixtral(unittest.TestCase):
         if graph_runner is not None:
             graph_runner.clear()
         kv_cache_manager.shutdown()
+
+    @unittest.mock.patch(
+        "tensorrt_llm._torch.models.modeling_mixtral.Attention.forward")
+    def test_mixtral_attention_swa_wiring(self, mocked_forward):
+        """Verify MixtralAttention.forward passes sliding_window to Attention.forward."""
+        config_dict = deepcopy(MIXTRAL_8X7B_CONFIG)
+        config_dict["sliding_window"] = 4096
+        config = MixtralConfig.from_dict(config_dict)
+        mc = ModelConfig(pretrained_config=config,
+                         mapping=Mapping(world_size=1, tp_size=1, rank=0))
+        attn = MixtralAttention(mc, layer_idx=0)
+        attn.forward(position_ids=None, hidden_states=None, attn_metadata=None)
+        mocked_forward.assert_called_once()
+        _, call_kwargs = mocked_forward.call_args
+        self.assertEqual(call_kwargs["attention_window_size"], 4096)
+
+    @unittest.mock.patch(
+        "tensorrt_llm._torch.models.modeling_mixtral.Attention.forward")
+    def test_mixtral_attention_swa_none_when_unset(self, mocked_forward):
+        """Verify MixtralAttention.forward passes None when sliding_window is unset."""
+        config_dict = deepcopy(MIXTRAL_8X7B_CONFIG)
+        config_dict["sliding_window"] = None
+        config = MixtralConfig.from_dict(config_dict)
+        mc = ModelConfig(pretrained_config=config,
+                         mapping=Mapping(world_size=1, tp_size=1, rank=0))
+        attn = MixtralAttention(mc, layer_idx=0)
+        attn.forward(position_ids=None, hidden_states=None, attn_metadata=None)
+        mocked_forward.assert_called_once()
+        _, call_kwargs = mocked_forward.call_args
+        self.assertIsNone(call_kwargs["attention_window_size"])

--- a/tests/unittest/auto_deploy/_utils_test/torch_attention_reference.py
+++ b/tests/unittest/auto_deploy/_utils_test/torch_attention_reference.py
@@ -67,6 +67,7 @@ class TorchAttentionReference:
             seq_start,
             k_cache,
             v_cache,
+            None,
             scale,
         )
 
@@ -108,6 +109,7 @@ class TorchAttentionReference:
             seq_start,
             k_cache,
             v_cache,
+            None,
             scale,
         )
 
@@ -162,6 +164,7 @@ class TorchAttentionReference:
             k_cache,
             v_cache,
             None,
+            None,
         )
 
         # Return in flattened format to match flashinfer backend behavior [batch, seq=1, n_heads * head_dim]
@@ -198,6 +201,7 @@ class TorchAttentionReference:
             seq_start,
             k_cache,
             v_cache,
+            None,
             scale,
             None,  # sinks
             sliding_window_size,

--- a/tests/unittest/auto_deploy/singlegpu/compile/test_captured_graph.py
+++ b/tests/unittest/auto_deploy/singlegpu/compile/test_captured_graph.py
@@ -18,6 +18,7 @@ from tensorrt_llm._torch.auto_deploy.compile.backends.torch_cudagraph import (
     _args_kwargs_flatten_spec,
 )
 from tensorrt_llm._torch.auto_deploy.compile.piecewise_utils import submod_has_cuda_ops
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.shim.ad_executor import _round_up_to_closest
 from tensorrt_llm._torch.auto_deploy.transform.library.compile_model import (
@@ -285,13 +286,17 @@ class TestDualModeCapturedGraphRouting:
     def test_is_decode_only_with_batch_info_host_zero(self):
         dual = self._make_dual_mode()
         # num_prefill=0 → decode-only
-        batch_info = torch.tensor([0, 0, 4])  # [num_prefill, num_prefill_tokens, num_decode]
+        batch_info_host = BatchInfo()
+        batch_info_host.update([0, 0, 0, 0, 4, 4])
+        batch_info = batch_info_host.serialize()
         assert dual._is_decode_only(batch_info_host=batch_info) is True
 
     def test_is_decode_only_with_batch_info_host_nonzero(self):
         dual = self._make_dual_mode()
         # num_prefill=2 → not decode-only
-        batch_info = torch.tensor([2, 100, 3])
+        batch_info_host = BatchInfo()
+        batch_info_host.update([2, 100, 0, 0, 3, 3])
+        batch_info = batch_info_host.serialize()
         assert dual._is_decode_only(batch_info_host=batch_info) is False
 
     def test_is_decode_only_fallback_heuristic_decode(self):

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_flashinfer_attention_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_flashinfer_attention_op.py
@@ -132,6 +132,7 @@ def test_flashinfer_attention_op_context(seq_length, n_heads, batch_size, dtype,
         kv_cache,
         # CONSTANTS
         None,
+        None,
         1.0,
         1.0,
     )
@@ -260,6 +261,7 @@ def test_flashinfer_attention_op_decode(
         # CACHES - combined KV cache in HND layout
         kv_cache,
         # CONSTANTS
+        None,
         None,
         1.0,
         1.0,
@@ -391,6 +393,7 @@ def test_flashinfer_attention_context_and_generate(
         kv_cache,
         # CONSTANTS
         None,
+        None,
         1.0,
         1.0,
     )
@@ -484,6 +487,7 @@ def test_flashinfer_attention_context_and_generate(
         # CACHES - combined KV cache in HND layout
         kv_cache,
         # CONSTANTS
+        None,
         None,
         1.0,
         1.0,
@@ -617,6 +621,7 @@ def test_flashinfer_attention_op_context_input_pos(seq, batch_size, n_heads, dty
         # CACHES - combined KV cache in HND layout
         kv_cache,
         # CONSTANTS
+        None,
         None,
         1.0,
         1.0,
@@ -776,6 +781,7 @@ def test_flashinfer_attention_with_fp8_cache(
         kv_cache,
         # CONSTANTS
         None,
+        None,
         K_SCALE,
         V_SCALE,
     )
@@ -883,6 +889,7 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         kv_cache,
         # CONSTANTS
         None,
+        None,
         1.0,
         1.0,
     )
@@ -976,6 +983,7 @@ def test_flashinfer_attention_with_paged_kvcache(seq_lengths, n_heads, dtype, de
         # CACHES - combined KV cache in HND layout
         kv_cache,
         # CONSTANTS
+        None,
         None,
         1.0,
         1.0,

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_torch_attention_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_torch_attention_op.py
@@ -10,6 +10,66 @@ import tensorrt_llm._torch.auto_deploy  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo
 
 
+@torch.inference_mode()
+def test_torch_backend_attention_custom_bool_mask_context():
+    device = "cuda"
+    dtype = torch.float16
+    batch_size, seq_len, num_heads, head_dim = 1, 5, 2, 8
+    scale = 1.0 / math.sqrt(head_dim)
+
+    q = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    k = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    v = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    k_cache = torch.zeros(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+    v_cache = torch.zeros(batch_size, seq_len, num_heads, head_dim, device=device, dtype=dtype)
+
+    token_type_ids = torch.tensor([[0, 1, 1, 2, 2]], device=device, dtype=torch.int64)
+    non_text = token_type_ids != 0
+    prev = torch.cat(
+        [
+            torch.zeros(batch_size, 1, device=device, dtype=token_type_ids.dtype),
+            token_type_ids[:, :-1],
+        ],
+        dim=1,
+    )
+    blob_starts = non_text & (token_type_ids != prev)
+    blob_ids = torch.cumsum(blob_starts.to(torch.int64), dim=1)
+    token_blob_ids = torch.where(non_text, blob_ids, torch.zeros_like(blob_ids))
+    media_mask = (token_blob_ids.unsqueeze(2) == token_blob_ids.unsqueeze(1)) & (
+        token_blob_ids.unsqueeze(2) != 0
+    )
+    positions = torch.arange(seq_len, device=device)
+    attn_mask = (positions.unsqueeze(0) <= positions.unsqueeze(1)).unsqueeze(0) | media_mask
+    attn_mask = attn_mask.unsqueeze(1)
+
+    batch_info = BatchInfo()
+    batch_info.update([batch_size, batch_size * seq_len, 0, 0, 0, 0])
+    seq_len_tensor = torch.tensor([seq_len], device=device, dtype=torch.int32)
+    input_positions = torch.tensor([0], device=device, dtype=torch.int32)
+    slot_idx = torch.tensor([0], device=device, dtype=torch.int32)
+    seq_start = torch.tensor([0], device=device, dtype=torch.int32)
+
+    expected = torch.ops.auto_deploy.torch_attention(
+        q, k, v, attn_mask=attn_mask, is_causal=False, scale=scale, layout="bsnd"
+    )
+    actual = torch.ops.auto_deploy.torch_cached_attention_with_cache.default(
+        q,
+        k,
+        v,
+        batch_info.serialize(),
+        seq_len_tensor,
+        input_positions,
+        slot_idx,
+        seq_start,
+        k_cache,
+        v_cache,
+        attn_mask,
+        scale,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=5e-2, rtol=5e-2)
+
+
 def numpy_attention_reference(
     q,
     k,

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
@@ -23,6 +23,8 @@ import math
 import pytest
 import torch
 
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
 # Skip all tests if CUDA is not available
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 
@@ -261,6 +263,78 @@ class TestTritonPagedContextKernel:
             q_ref, k_ref, v_ref, scale=sm_scale, is_causal=True
         )
         output_ref = output_ref.transpose(1, 2).reshape(total_tokens, n_heads, head_dim)
+
+        torch.testing.assert_close(output.float(), output_ref.float(), rtol=1e-2, atol=1e-2)
+
+    def test_context_with_custom_bool_mask_matches_torch_attention(self):
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_context_with_custom_mask,
+            update_paged_kv_cache,
+        )
+
+        batch_size, seq_len = 1, 5
+        n_heads, n_kv_heads, head_dim = 8, 8, 64
+        page_size = 16
+        num_pages_per_seq = 1
+        num_blocks = 4
+        total_tokens = batch_size * seq_len
+        sm_scale = 1.0 / math.sqrt(head_dim)
+
+        q = torch.randn(total_tokens, n_heads, head_dim, dtype=torch.float16, device="cuda")
+        k = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        v = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+
+        qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+        kv_indptr = torch.tensor([0, num_pages_per_seq], dtype=torch.int32, device="cuda")
+        kv_indices = torch.tensor([0], dtype=torch.int32, device="cuda")
+        seq_len_with_cache = torch.tensor([seq_len], dtype=torch.int32, device="cuda")
+
+        batch_indices = torch.zeros(total_tokens, dtype=torch.int32, device="cuda")
+        positions = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+
+        kv_cache = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        update_paged_kv_cache(k, v, batch_indices, positions, kv_cache, kv_indices, kv_indptr)
+
+        token_type_ids = torch.tensor([[0, 1, 1, 2, 2]], device="cuda", dtype=torch.int64)
+        non_text = token_type_ids != 0
+        prev = torch.cat(
+            [
+                torch.zeros(batch_size, 1, device="cuda", dtype=token_type_ids.dtype),
+                token_type_ids[:, :-1],
+            ],
+            dim=1,
+        )
+        blob_starts = non_text & (token_type_ids != prev)
+        blob_ids = torch.cumsum(blob_starts.to(torch.int64), dim=1)
+        token_blob_ids = torch.where(non_text, blob_ids, torch.zeros_like(blob_ids))
+        media_mask = (token_blob_ids.unsqueeze(2) == token_blob_ids.unsqueeze(1)) & (
+            token_blob_ids.unsqueeze(2) != 0
+        )
+        pos = torch.arange(seq_len, device="cuda")
+        custom_attn_mask = (
+            (pos.unsqueeze(0) <= pos.unsqueeze(1)).unsqueeze(0) | media_mask
+        ).unsqueeze(1)
+
+        output = triton_paged_context_with_custom_mask(
+            q,
+            kv_cache,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            seq_len_with_cache,
+            custom_attn_mask,
+            sm_scale,
+        )
+
+        output_ref = torch.ops.auto_deploy.torch_attention(
+            q.view(batch_size, seq_len, n_heads, head_dim),
+            k.view(batch_size, seq_len, n_kv_heads, head_dim),
+            v.view(batch_size, seq_len, n_kv_heads, head_dim),
+            attn_mask=custom_attn_mask,
+            is_causal=False,
+            scale=sm_scale,
+            layout="bsnd",
+        ).reshape(total_tokens, n_heads, head_dim)
 
         torch.testing.assert_close(output.float(), output_ref.float(), rtol=1e-2, atol=1e-2)
 

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
@@ -200,10 +200,16 @@ def test_inject_gemma4_custom_attention_mask_for_torch_backend():
         for node in attn_nodes
     )
 
-    expected_mask = _build_token_type_mask(token_type_ids)
-    expected = model.forward_with_mask(input_ids, expected_mask)
-    actual = gm_transformed(input_ids, position_ids, token_type_ids=token_type_ids)
+    # With outside-graph approach, the graph receives the finished mask, not token_type_ids.
+    custom_attn_mask = _build_token_type_mask(token_type_ids)
+    expected = model.forward_with_mask(input_ids, custom_attn_mask)
+    actual = gm_transformed(input_ids, position_ids, custom_attn_mask=custom_attn_mask)
     torch.testing.assert_close(actual, expected)
+
+    # Verify None mask produces standard causal output
+    actual_none = gm_transformed(input_ids, position_ids, custom_attn_mask=None)
+    expected_none = model(input_ids, position_ids)
+    torch.testing.assert_close(actual_none, expected_none)
 
 
 @torch.inference_mode()
@@ -235,7 +241,8 @@ def test_inject_gemma4_custom_attention_mask_for_triton_paged_backend():
         for node in attn_nodes
     )
 
-    expected_mask = _build_token_type_mask(token_type_ids)
-    expected = model.forward_with_mask(input_ids, expected_mask)
-    actual = gm_transformed(input_ids, position_ids, token_type_ids=token_type_ids)
+    # With outside-graph approach, the graph receives the finished mask, not token_type_ids.
+    custom_attn_mask = _build_token_type_mask(token_type_ids)
+    expected = model.forward_with_mask(input_ids, custom_attn_mask)
+    actual = gm_transformed(input_ids, position_ids, custom_attn_mask=custom_attn_mask)
     torch.testing.assert_close(actual, expected)

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for custom attention mask injection into torch_attention nodes."""
+
+from types import SimpleNamespace
+
+import torch
+
+import tensorrt_llm._torch.auto_deploy.custom_ops.attention.torch_attention  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.transform.attention_mask_provider import (
+    AttentionMaskProviderRegistry,
+)
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+
+class DualAttentionModel(torch.nn.Module):
+    """Minimal model with two torch_attention calls sharing one custom mask."""
+
+    def __init__(self, hidden_size: int = 8, num_heads: int = 2):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+
+        self.q_proj_1 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj_1 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.v_proj_1 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.q_proj_2 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj_2 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+        self.v_proj_2 = torch.nn.Linear(hidden_size, hidden_size, bias=False)
+
+    def _embed(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return input_ids.unsqueeze(-1).expand(-1, -1, self.hidden_size).to(torch.float32)
+
+    def _run_attention(self, x: torch.Tensor, attn_mask: torch.Tensor | None) -> torch.Tensor:
+        batch_size, seq_len, _ = x.shape
+
+        def _project(q_proj, k_proj, v_proj):
+            q = q_proj(x).view(batch_size, seq_len, self.num_heads, self.head_dim)
+            k = k_proj(x).view(batch_size, seq_len, self.num_heads, self.head_dim)
+            v = v_proj(x).view(batch_size, seq_len, self.num_heads, self.head_dim)
+            return torch.ops.auto_deploy.torch_attention(
+                q, k, v, attn_mask=attn_mask, is_causal=False, layout="bsnd"
+            )
+
+        return _project(self.q_proj_1, self.k_proj_1, self.v_proj_1) + _project(
+            self.q_proj_2, self.k_proj_2, self.v_proj_2
+        )
+
+    def forward(self, input_ids: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        del position_ids
+        return self._run_attention(self._embed(input_ids), attn_mask=None)
+
+    def forward_with_mask(self, input_ids: torch.Tensor, attn_mask: torch.Tensor) -> torch.Tensor:
+        return self._run_attention(self._embed(input_ids), attn_mask=attn_mask)
+
+
+class DummyFactory:
+    def _get_model_config(self):
+        return SimpleNamespace(model_type="unit_test_mask_model"), {}
+
+
+class Gemma4Factory:
+    def _get_model_config(self):
+        return SimpleNamespace(model_type="gemma4"), {}
+
+
+def _build_segment_mask(segment_ids: torch.Tensor) -> torch.Tensor:
+    same_segment = segment_ids.unsqueeze(2) == segment_ids.unsqueeze(1)
+    return same_segment.unsqueeze(1)
+
+
+def _build_token_type_mask(token_type_ids: torch.Tensor) -> torch.Tensor:
+    non_text = token_type_ids != 0
+    prev = torch.cat(
+        [
+            torch.zeros(token_type_ids.shape[0], 1, dtype=token_type_ids.dtype),
+            token_type_ids[:, :-1],
+        ],
+        dim=1,
+    )
+    blob_starts = non_text & (token_type_ids != prev)
+    blob_ids = torch.cumsum(blob_starts.to(torch.int64), dim=1)
+    token_blob_ids = torch.where(non_text, blob_ids, torch.zeros_like(blob_ids))
+    media_mask = (token_blob_ids.unsqueeze(2) == token_blob_ids.unsqueeze(1)) & (
+        token_blob_ids.unsqueeze(2) != 0
+    )
+    positions = torch.arange(token_type_ids.shape[1])
+    causal_mask = positions.unsqueeze(0) <= positions.unsqueeze(1)
+    return (causal_mask.unsqueeze(0) | media_mask).unsqueeze(1)
+
+
+_provider_build_counts = {"mask": 0}
+
+
+@AttentionMaskProviderRegistry.register("unit_test_mask_model", "torch_attention")
+def _segment_mask_provider(ctx, source_attn_node):
+    del source_attn_node
+
+    def _builder():
+        _provider_build_counts["mask"] += 1
+        segment_ids = ctx.add_or_retrieve_input(
+            "segment_ids",
+            activate_arg=False,
+            val=torch.zeros(2, 4, dtype=torch.int64),
+        )
+        seg_q = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(segment_ids, 2))
+        seg_k = ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(segment_ids, 1))
+        same_segment = ctx.gm.graph.call_function(torch.ops.aten.eq.Tensor, args=(seg_q, seg_k))
+        return ctx.gm.graph.call_function(torch.ops.aten.unsqueeze.default, args=(same_segment, 1))
+
+    return ctx.get_or_create_cached_node("segment_ids_mask", _builder)
+
+
+@torch.inference_mode()
+def test_inject_custom_attention_mask():
+    model = DualAttentionModel().eval()
+    input_ids = torch.tensor([[1, 2, 3, 4], [4, 3, 2, 1]], dtype=torch.int64)
+    position_ids = torch.arange(input_ids.shape[1], dtype=torch.int64).repeat(input_ids.shape[0], 1)
+    segment_ids = torch.tensor([[0, 0, 1, 1], [0, 1, 1, 2]], dtype=torch.int64)
+
+    gm = torch_export_to_gm(model, args=(input_ids, position_ids), clone=True)
+
+    _provider_build_counts["mask"] = 0
+    gm_transformed = InferenceOptimizer(
+        DummyFactory(),
+        {
+            "inject_custom_attention_mask": {
+                "stage": "pattern_matcher",
+                "backend": "torch_attention",
+            },
+        },
+    )(None, gm)
+
+    attn_nodes = [
+        node
+        for node in gm_transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_attention)
+    ]
+    assert len(attn_nodes) == 2
+    assert _provider_build_counts["mask"] == 1
+
+    mask_nodes = [
+        node.args[3] if len(node.args) > 3 else node.kwargs["attn_mask"] for node in attn_nodes
+    ]
+    assert mask_nodes[0] is mask_nodes[1]
+
+    placeholder_targets = {
+        node.target for node in gm_transformed.graph.nodes if node.op == "placeholder"
+    }
+    assert "segment_ids" in placeholder_targets
+
+    expected_mask = _build_segment_mask(segment_ids)
+    expected = model.forward_with_mask(input_ids, expected_mask)
+    actual = gm_transformed(input_ids, position_ids, segment_ids=segment_ids)
+
+    torch.testing.assert_close(actual, expected)
+
+
+@torch.inference_mode()
+def test_inject_gemma4_custom_attention_mask_for_torch_backend():
+    model = DualAttentionModel().eval()
+    input_ids = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.int64)
+    position_ids = torch.arange(input_ids.shape[1], dtype=torch.int64).repeat(input_ids.shape[0], 1)
+    token_type_ids = torch.tensor([[0, 1, 1, 2, 2]], dtype=torch.int64)
+
+    gm = torch_export_to_gm(model, args=(input_ids, position_ids), clone=True)
+    gm_transformed = InferenceOptimizer(
+        Gemma4Factory(),
+        {
+            "inject_custom_attention_mask": {
+                "stage": "pattern_matcher",
+                "backend": "torch",
+            },
+        },
+    )(None, gm)
+
+    attn_nodes = [
+        node
+        for node in gm_transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_attention)
+    ]
+    assert len(attn_nodes) == 2
+    assert all(
+        (node.args[3] if len(node.args) > 3 else node.kwargs["attn_mask"]) is not None
+        for node in attn_nodes
+    )
+
+    expected_mask = _build_token_type_mask(token_type_ids)
+    expected = model.forward_with_mask(input_ids, expected_mask)
+    actual = gm_transformed(input_ids, position_ids, token_type_ids=token_type_ids)
+    torch.testing.assert_close(actual, expected)
+
+
+@torch.inference_mode()
+def test_inject_gemma4_custom_attention_mask_for_triton_paged_backend():
+    model = DualAttentionModel().eval()
+    input_ids = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.int64)
+    position_ids = torch.arange(input_ids.shape[1], dtype=torch.int64).repeat(input_ids.shape[0], 1)
+    token_type_ids = torch.tensor([[0, 1, 1, 2, 2]], dtype=torch.int64)
+
+    gm = torch_export_to_gm(model, args=(input_ids, position_ids), clone=True)
+    gm_transformed = InferenceOptimizer(
+        Gemma4Factory(),
+        {
+            "inject_custom_attention_mask": {
+                "stage": "pattern_matcher",
+                "backend": "triton_paged",
+            },
+        },
+    )(None, gm)
+
+    attn_nodes = [
+        node
+        for node in gm_transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_attention)
+    ]
+    assert len(attn_nodes) == 2
+    assert all(
+        (node.args[3] if len(node.args) > 3 else node.kwargs["attn_mask"]) is not None
+        for node in attn_nodes
+    )
+
+    expected_mask = _build_token_type_mask(token_type_ids)
+    expected = model.forward_with_mask(input_ids, expected_mask)
+    actual = gm_transformed(input_ids, position_ids, token_type_ids=token_type_ids)
+    torch.testing.assert_close(actual, expected)

--- a/worklog.md
+++ b/worklog.md
@@ -1,0 +1,171 @@
+# Worklog: Gemma4 Multimodal Custom Attention Mask
+
+## Problem Statement
+
+Gemma4 VLM requires bidirectional attention within media token blobs and
+causal attention for text tokens. The `token_type_ids` tensor (0 = text,
+non-zero = media blob ID) drives the mask construction.
+
+## Architecture Decisions
+
+### VLM Export Pattern (TextModelExportInfo)
+
+Switched `Gemma4ForConditionalGeneration` from `FullModelExportInfo` to
+`TextModelExportInfo`. The `Gemma4ForCausalLM` (including `lm_head` +
+softcapping) is the export target. The outer wrapper stays un-exported
+and handles `token_type_ids` plumbing.
+
+### Input Processor (Gemma4ADInputProcessor)
+
+Every request gets `token_type_ids` in `py_multimodal_data` — text-only
+requests get all-zeros, multimodal requests get blob IDs from the HF
+processor. This solves mixed-batch scenarios where `_store_extra_arg`
+concatenates per-request tensors.
+
+## Issue: In-Graph Mask Computation Fails During Warmup
+
+### Background
+
+The `InjectCustomAttentionMask` transform inserts mask computation nodes
+directly into the FX graph. These nodes take `token_type_ids` as input
+and produce a `[batch, 1, seq, seq]` bool mask wired to each
+`torch_attention` node.
+
+After the KV cache transform, `torch_attention` nodes become
+`triton_paged_mha_with_cache` calls. The mask flows as the
+`custom_attn_mask` argument. When present (not `None`), the cached op
+uses a per-sequence fallback path (`triton_paged_context_with_custom_mask`)
+that loops over sequences and calls `torch_attention` individually.
+
+### The Warmup Problem
+
+Several initialization-time forward passes happen before any real
+request arrives:
+
+1. **`resize_kv_cache`** — dummy forward to discover output shapes and
+   resize the KV cache buffer.
+2. **CUDA graph warmup** — forward passes at each `cuda_graph_batch_size`
+   to capture graphs.
+3. **`set_example_sequence`** — initial example to set up the
+   `SequenceInfo` input buffer layout.
+
+During these passes:
+
+- `token_type_ids` comes from the default factory (all-zeros, matching
+  `input_ids` shape).
+- The in-graph mask computation runs and produces a valid causal-only
+  mask tensor — it is **not** `None`.
+- `triton_paged_mha_with_cache` sees a non-`None` mask and enters the
+  per-sequence fallback path.
+- The fallback path calls `torch_attention` per sequence, but during
+  warmup the KV cache may be empty / uninitialized, leading to
+  **`IndexError: index 0 is out of bounds for dimension 0 with size 0`**.
+
+### Why Band-Aid Fixes Don't Work
+
+Adding `numel == 0` checks or `seq_len == 0` skips in the triton paged
+op are treating symptoms. The fundamental issue is:
+
+- **The mask is always computed inside the graph** — there is no way to
+  conditionally produce `None` in an FX graph (no control flow).
+- **The fallback path is entered on every forward** even when the mask is
+  pure causal (all-zeros `token_type_ids`), wasting compute and hitting
+  edge cases.
+
+### Additional Issues Encountered with In-Graph Approach
+
+1. **Symbolic shape error** — `torch.zeros(batch_size, seq_len, ...)` at
+   Python level fails when `batch_size`/`seq_len` are symbolic ints from
+   `torch.export`.
+2. **Device mismatch** — `arange(seq_len)` defaults to CPU but mask
+   operands are on meta device during shape propagation.
+3. **Undefined symbolic variable** — `seq_len - 1` as a Python expression
+   becomes an unresolvable `s70` reference after graph recompile.
+
+Each of these required a separate fix, making the in-graph approach fragile.
+
+## Proposed Solution: Compute Mask Outside the Graph
+
+Move mask computation from FX graph nodes to the **wrapper's `forward()`**
+(Python-level). The graph receives the finished `custom_attn_mask` tensor
+(or `None`) as an input, not `token_type_ids`.
+
+### How It Works
+
+1. **Mask provider** adds `custom_attn_mask` as an **optional graph input**
+   (default `None`) and wires it to `torch_attention` nodes. No
+   computation nodes in the graph.
+
+2. **Wrapper `forward()`** receives `token_type_ids` from `extra_args`,
+   computes the mask using plain PyTorch ops, and passes
+   `custom_attn_mask=mask` to the exported graph.
+
+3. **During warmup / text-only / decode**, the wrapper passes
+   `custom_attn_mask=None`. The cached attention op sees `None` and uses
+   the fast `triton_paged_context` kernel (no per-sequence fallback).
+
+### Runtime Flow
+
+**Prefill with images:**
+1. `Gemma4ADInputProcessor` produces `token_type_ids` with blob IDs.
+2. Executor concatenates per-request tensors → `[1, total_tokens]`.
+3. Wrapper receives `token_type_ids` via `**kwargs`.
+4. `token_type_ids.any()` is `True` → wrapper computes
+   `custom_attn_mask` `[batch, 1, seq, seq]` bool mask using plain
+   PyTorch ops (blob detection, bidirectional-within-blob + causal).
+5. Passes `custom_attn_mask=mask` to exported graph.
+6. `triton_paged_mha_with_cache` uses per-sequence fallback with the
+   mask — bidirectional for media blobs, causal for text.
+
+**Text-only prefill:**
+1. `token_type_ids` all zeros → `any()` is `False`.
+2. Wrapper passes `custom_attn_mask=None`.
+3. `triton_paged_context` fast kernel — standard causal attention.
+
+**Mixed batch (image + text-only requests):**
+1. `token_type_ids` has non-zero for image requests, zeros for text-only.
+2. `any()` is `True` → compute mask.
+3. Mask is causal for text-only sequences (zeros → no blobs) and
+   bidirectional for image sequences. Correct per-sequence behavior.
+
+**Decode:**
+1. No `token_type_ids` in `extra_args` (decode has no `py_multimodal_data`).
+2. Wrapper defaults to `custom_attn_mask=None`.
+3. Fast decode kernel (ignores mask entirely).
+
+**Warmup / CUDA graph capture / resize_kv_cache:**
+1. `token_type_ids` absent or all zeros.
+2. Wrapper passes `custom_attn_mask=None`.
+3. Standard causal path — no per-sequence fallback, no empty KV indexing.
+
+### Injector Role (Simplified)
+
+The mask provider no longer computes anything inside the graph. It:
+1. Adds `custom_attn_mask` as an optional graph input placeholder
+   (default `None`).
+2. Wires the placeholder to each `torch_attention` node's `attn_mask`.
+3. The KV cache transform sees `attn_mask` is a graph node → extracts
+   via `get_dynamic_inputs` → passes to `triton_paged_mha_with_cache`.
+
+### Mask Computation (Moves to Wrapper)
+
+The same logic currently in `_build_gemma4_token_type_mask` (graph nodes)
+moves to a Python method on `Gemma4ForConditionalGeneration`:
+
+1. **Blob detection**: `ne(token_type_ids, 0)` → shift + compare for type
+   changes → `cumsum` for blob IDs.
+2. **Bidirectional within blobs**: unsqueeze q/k blob IDs → `eq` (same
+   blob) → `bitwise_and` with media query.
+3. **Causal mask**: `arange(seq_len)` → `le(pos_q, pos_k)`.
+4. **Combine**: `bitwise_or(causal, bidirectional)` → unsqueeze for head dim.
+
+Result: `[batch, 1, seq, seq]` bool mask — same output, no graph nodes.
+
+### Benefits
+
+- No symbolic shape issues (plain PyTorch ops, not FX graph nodes).
+- No device mismatch (tensors on the actual runtime device).
+- No warmup breakage (`None` mask → standard causal path).
+- Pure causal (text-only) requests use the optimized kernel, not the
+  per-sequence fallback.
+- Model-specific logic stays in the wrapper, not in the graph.


### PR DESCRIPTION
## Summary

- **Custom attention mask infrastructure**: Adds graph-level attention mask injection for AutoDeploy attention backends. A registry-based provider system lets models supply custom masks (e.g., bidirectional within media blobs, causal for text). Supports torch, triton_paged, and torch_attention backends.
- **Gemma4 VLM export pattern**: Switches `Gemma4ForConditionalGeneration` from `FullModelExportInfo` to `TextModelExportInfo` (VLM pattern). The `Gemma4ForCausalLM` (including `lm_head` + softcapping) is the export target, while the outer wrapper handles `token_type_ids` plumbing.
- **Gemma4 custom attention mask**: Implements a Gemma4-specific mask provider that builds bidirectional-within-media-blob + causal masks from `token_type_ids`. During prefill with images, the triton paged backend uses this mask via a per-sequence fallback path.
- **`Gemma4ADInputProcessor`**: Ensures every request (text-only or multimodal) always has `token_type_ids` in `py_multimodal_data`, solving mixed-batch scenarios where some requests have images and others don't.

### Key design decisions
- No model-specific code in AD infra (`ad_executor`, `attention_interface`). All Gemma4 logic lives in the custom model file.
- `token_type_ids` is added as a graph input by the `InjectCustomAttentionMask` transform post-export (not in the model forward signature).
- The input processor guarantees `token_type_ids` is always present so `_extra_args` covers the full flattened batch on every step.

## Test plan

- [x] `pytest tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_gemma4_modeling.py` — all 8 tests pass
- [x] `pytest tests/unittest/auto_deploy/singlegpu/transformations/library/test_inject_custom_attention_mask.py` — all 3 tests pass
- [x] `pytest tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py`
- [ ] E2E: Gemma4 with image prompts via trtllm-serve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Gemma 4 and Gemma 3n models with AutoDeploy backend
  * Implemented linear attention and recurrent state caching for optimized memory usage
  * Enabled shared KV cache across attention layers
  * Added custom attention mask support across multiple attention backends

* **Improvements**
  * Enhanced KV cache management with placeholder block handling
  * Updated supported models documentation

* **Documentation**
  * Added Gemma 4 deployment cookbook with AutoDeploy guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->