### PR TITLE
[None][feat] support multiple model names in --served_model_name

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -286,9 +286,8 @@ def _split_served_model_names(ctx, param, value):
     return tuple(out)
 
 
-def _resolve_served_model_names(
-        served_model_name: Optional[Sequence[str]],
-        llm_args: dict) -> list[str]:
+def _resolve_served_model_names(served_model_name: Optional[Sequence[str]],
+                                llm_args: dict) -> list[str]:
     """Normalize click's ``--served_model_name`` into a non-empty list.
 
     Drops empty strings (click passes ``""`` through for unset flags) and
@@ -344,15 +343,14 @@ def launch_server(
                 f"{backend} is not a known backend, check help for available options.",
                 param_hint="backend")
 
-        server = OpenAIServer(
-            generator=llm,
-            model=served_model_names,
-            tool_parser=tool_parser,
-            server_role=server_role,
-            metadata_server_cfg=metadata_server_cfg,
-            disagg_cluster_config=disagg_cluster_config,
-            multimodal_server_config=multimodal_server_config,
-            chat_template=chat_template)
+        server = OpenAIServer(generator=llm,
+                              model=served_model_names,
+                              tool_parser=tool_parser,
+                              server_role=server_role,
+                              metadata_server_cfg=metadata_server_cfg,
+                              disagg_cluster_config=disagg_cluster_config,
+                              multimodal_server_config=multimodal_server_config,
+                              chat_template=chat_template)
 
         # Optionally disable GC (default: not disabled)
         if os.getenv("TRTLLM_SERVER_DISABLE_GC", "0") == "1":
@@ -827,8 +825,7 @@ class ChoiceWithAlias(click.Choice):
         "values (`--served_model_name a,b,c`); the server accepts requests "
         "addressed to any of them. The first name is primary and is returned "
         "in the `model` field of responses. If not specified, the model path "
-        "is used.",
-        "prototype"))
+        "is used.", "prototype"))
 @click.option("--extra_visual_gen_options",
               type=str,
               default=None,

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -267,6 +267,25 @@ def get_llm_args(
     return llm_args, llm_args_extra_dict
 
 
+def _split_served_model_names(ctx, param, value):
+    """Flatten comma-separated --served_model_name values.
+
+    Click options can't use argparse-style ``nargs="+"``, so this callback
+    lets users pass comma-separated names in a single flag or repeat the flag.
+    All of these produce the same tuple ("a", "b", "c"):
+
+      --served_model_name a --served_model_name b --served_model_name c
+      --served_model_name a,b,c
+      --served_model_name a,b --served_model_name c
+    """
+    if not value:
+        return value
+    out: list[str] = []
+    for v in value:
+        out.extend(p.strip() for p in v.split(",") if p.strip())
+    return tuple(out)
+
+
 def _resolve_served_model_names(
         served_model_name: Optional[Sequence[str]],
         llm_args: dict) -> list[str]:
@@ -801,12 +820,15 @@ class ChoiceWithAlias(click.Choice):
     "--served_model_name",
     type=str,
     multiple=True,
+    callback=_split_served_model_names,
     default=None,
     help=help_info_with_stability_tag(
-        "The model name(s) used in the API. Can be specified multiple times for aliases; "
-        "the server accepts requests addressed to any of them. The first name is primary "
-        "and is returned in the `model` field of responses. If not specified, the model "
-        "path is used.",
+        "The model name(s) used in the API. Accepts repeated flags "
+        "(`--served_model_name a --served_model_name b`) or comma-separated "
+        "values (`--served_model_name a,b,c`); the server accepts requests "
+        "addressed to any of them. The first name is primary and is returned "
+        "in the `model` field of responses. If not specified, the model path "
+        "is used.",
         "prototype"))
 @click.option("--extra_visual_gen_options",
               type=str,

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -313,7 +313,6 @@ def launch_server(
     backend = llm_args["backend"]
     served_model_names = _resolve_served_model_names(served_model_name,
                                                      llm_args)
-    model = served_model_names[0]
     addr_info = socket.getaddrinfo(host, port, socket.AF_UNSPEC,
                                    socket.SOCK_STREAM)
     address_family = socket.AF_INET6 if all(

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -290,10 +290,16 @@ def _resolve_served_model_names(served_model_name: Optional[Sequence[str]],
                                 llm_args: dict) -> list[str]:
     """Normalize click's ``--served_model_name`` into a non-empty list.
 
-    Drops empty strings (click passes ``""`` through for unset flags) and
-    falls back to ``llm_args["model"]`` when no explicit name is provided.
+    Drops empty strings (click passes ``""`` through for unset flags),
+    deduplicates while preserving order, and falls back to
+    ``llm_args["model"]`` when no explicit name is provided.
     """
-    names = [n for n in (served_model_name or []) if n]
+    seen: set[str] = set()
+    names: list[str] = []
+    for n in (served_model_name or []):
+        if n and n not in seen:
+            seen.add(n)
+            names.append(n)
     return names or [llm_args["model"]]
 
 

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -267,6 +267,18 @@ def get_llm_args(
     return llm_args, llm_args_extra_dict
 
 
+def _resolve_served_model_names(
+        served_model_name: Optional[Sequence[str]],
+        llm_args: dict) -> list[str]:
+    """Normalize click's ``--served_model_name`` into a non-empty list.
+
+    Drops empty strings (click passes ``""`` through for unset flags) and
+    falls back to ``llm_args["model"]`` when no explicit name is provided.
+    """
+    names = [n for n in (served_model_name or []) if n]
+    return names or [llm_args["model"]]
+
+
 def launch_server(
         host: str,
         port: int,
@@ -280,10 +292,9 @@ def launch_server(
         served_model_name: Optional[Sequence[str]] = None):
 
     backend = llm_args["backend"]
-    # served_model_name may be a sequence (tuple from click's multiple=True, or list).
-    # Drop empty strings (click passes "" through) so downstream sees only real names.
-    served_model_names: list[str] = [n for n in (served_model_name or []) if n]
-    model = served_model_names[0] if served_model_names else llm_args["model"]
+    served_model_names = _resolve_served_model_names(served_model_name,
+                                                     llm_args)
+    model = served_model_names[0]
     addr_info = socket.getaddrinfo(host, port, socket.AF_UNSPEC,
                                    socket.SOCK_STREAM)
     address_family = socket.AF_INET6 if all(
@@ -317,7 +328,7 @@ def launch_server(
 
         server = OpenAIServer(
             generator=llm,
-            model=served_model_names if served_model_names else model,
+            model=served_model_names,
             tool_parser=tool_parser,
             server_role=server_role,
             metadata_server_cfg=metadata_server_cfg,
@@ -366,8 +377,8 @@ def launch_grpc_server(host: str,
         logger.info("Initializing TensorRT-LLM gRPC server...")
 
         backend = llm_args.get("backend")
-        _names = [n for n in (served_model_name or []) if n]
-        model_path = _names[0] if _names else llm_args.get("model", "")
+        names = [n for n in (served_model_name or []) if n]
+        model_path = names[0] if names else llm_args.get("model", "")
 
         if backend == "pytorch":
             llm_args.pop("build_config", None)
@@ -470,7 +481,7 @@ def launch_mm_encoder_server(
     mm_encoder = MultimodalEncoder(**encoder_args)
 
     server = OpenAIServer(generator=mm_encoder,
-                          model=model,
+                          model=[model],
                           server_role=ServerRole.MM_ENCODER,
                           metadata_server_cfg=metadata_server_cfg,
                           tool_parser=None)
@@ -504,7 +515,7 @@ def launch_visual_gen_server(
         f"Ulysses size: {visual_gen_model.args.parallel.dit_ulysses_size}")
 
     server = OpenAIServer(generator=visual_gen_model,
-                          model=model,
+                          model=[model],
                           server_role=ServerRole.VISUAL_GEN,
                           metadata_server_cfg=metadata_server_cfg,
                           tool_parser=None)

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -277,10 +277,13 @@ def launch_server(
         server_role: Optional[ServerRole] = None,
         disagg_cluster_config: Optional[DisaggClusterConfig] = None,
         multimodal_server_config: Optional[MultimodalServerConfig] = None,
-        served_model_name: Optional[str] = None):
+        served_model_name: Optional[Sequence[str]] = None):
 
     backend = llm_args["backend"]
-    model = served_model_name or llm_args["model"]
+    # served_model_name may be a sequence (tuple from click's multiple=True, or list).
+    # Drop empty strings (click passes "" through) so downstream sees only real names.
+    served_model_names: list[str] = [n for n in (served_model_name or []) if n]
+    model = served_model_names[0] if served_model_names else llm_args["model"]
     addr_info = socket.getaddrinfo(host, port, socket.AF_UNSPEC,
                                    socket.SOCK_STREAM)
     address_family = socket.AF_INET6 if all(
@@ -312,14 +315,15 @@ def launch_server(
                 f"{backend} is not a known backend, check help for available options.",
                 param_hint="backend")
 
-        server = OpenAIServer(generator=llm,
-                              model=model,
-                              tool_parser=tool_parser,
-                              server_role=server_role,
-                              metadata_server_cfg=metadata_server_cfg,
-                              disagg_cluster_config=disagg_cluster_config,
-                              multimodal_server_config=multimodal_server_config,
-                              chat_template=chat_template)
+        server = OpenAIServer(
+            generator=llm,
+            model=served_model_names if served_model_names else model,
+            tool_parser=tool_parser,
+            server_role=server_role,
+            metadata_server_cfg=metadata_server_cfg,
+            disagg_cluster_config=disagg_cluster_config,
+            multimodal_server_config=multimodal_server_config,
+            chat_template=chat_template)
 
         # Optionally disable GC (default: not disabled)
         if os.getenv("TRTLLM_SERVER_DISABLE_GC", "0") == "1":
@@ -331,7 +335,7 @@ def launch_server(
 def launch_grpc_server(host: str,
                        port: int,
                        llm_args: dict,
-                       served_model_name: Optional[str] = None):
+                       served_model_name: Optional[Sequence[str]] = None):
     """
     Launch a gRPC server for TensorRT-LLM.
 
@@ -342,7 +346,9 @@ def launch_grpc_server(host: str,
         host: Host to bind to
         port: Port to bind to
         llm_args: Arguments for LLM initialization (from get_llm_args)
-        served_model_name: Custom model name for API responses (defaults to model path)
+        served_model_name: Model name(s) for API responses (defaults to model path).
+            Note: the gRPC server only uses the first (primary) name. Multiple
+            aliases are supported by the HTTP/OpenAI server only.
     """
     import grpc
 
@@ -360,7 +366,8 @@ def launch_grpc_server(host: str,
         logger.info("Initializing TensorRT-LLM gRPC server...")
 
         backend = llm_args.get("backend")
-        model_path = served_model_name or llm_args.get("model", "")
+        _names = [n for n in (served_model_name or []) if n]
+        model_path = _names[0] if _names else llm_args.get("model", "")
 
         if backend == "pytorch":
             llm_args.pop("build_config", None)
@@ -782,11 +789,13 @@ class ChoiceWithAlias(click.Choice):
 @click.option(
     "--served_model_name",
     type=str,
+    multiple=True,
     default=None,
     help=help_info_with_stability_tag(
-        "The model name used in the API. If not specified, the model path is "
-        "used as the model name. This is useful when the model path is long or "
-        "when you want to expose a custom name to clients.", "prototype"))
+        "The model name(s) used in the API. Can be specified multiple times for aliases. "
+        "The first name is primary; additional names are aliases that the server also accepts. "
+        "If not specified, the model path is used as the model name.",
+        "prototype"))
 @click.option("--extra_visual_gen_options",
               type=str,
               default=None,
@@ -810,8 +819,8 @@ def serve(
         enable_attention_dp: bool, disagg_cluster_uri: Optional[str],
         media_io_kwargs: Optional[str], video_pruning_rate: Optional[float],
         telemetry: bool, custom_module_dirs: list[Path],
-        chat_template: Optional[str], grpc: bool,
-        served_model_name: Optional[str],
+        chat_template: Optional[str], grpc: bool, served_model_name: tuple[str,
+                                                                           ...],
         extra_visual_gen_options: Optional[str]):
     """Running an OpenAI API compatible server
 

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -803,9 +803,10 @@ class ChoiceWithAlias(click.Choice):
     multiple=True,
     default=None,
     help=help_info_with_stability_tag(
-        "The model name(s) used in the API. Can be specified multiple times for aliases. "
-        "The first name is primary; additional names are aliases that the server also accepts. "
-        "If not specified, the model path is used as the model name.",
+        "The model name(s) used in the API. Can be specified multiple times for aliases; "
+        "the server accepts requests addressed to any of them. The first name is primary "
+        "and is returned in the `model` field of responses. If not specified, the model "
+        "path is used.",
         "prototype"))
 @click.option("--extra_visual_gen_options",
               type=str,

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -765,20 +765,24 @@ class OpenAIServer:
             names: Sequence[str]) -> tuple[str, list[str]]:
         """Return (primary, aliases) from a sequence of names.
 
-        If the primary name points to an existing directory, its basename is used.
-        Duplicate aliases are removed while preserving order.
+        If the first name points to an existing directory, its basename
+        becomes the primary and the original path is kept as an alias so
+        clients that launched the server by path can still address it.
+        Duplicates are removed while preserving order.
         """
-        primary = names[0]
-        model_dir = Path(primary)
+        first = names[0]
+        model_dir = Path(first)
         if model_dir.exists() and model_dir.is_dir():
-            primary = model_dir.name
-        seen = {primary}
-        aliases = [primary]
-        for n in names[1:]:
-            if n not in seen:
+            candidates = [model_dir.name, first, *names[1:]]
+        else:
+            candidates = list(names)
+        seen: set[str] = set()
+        aliases: list[str] = []
+        for n in candidates:
+            if n and n not in seen:
                 seen.add(n)
                 aliases.append(n)
-        return primary, aliases
+        return aliases[0], aliases
 
     def _is_model_supported(self, model_name: Optional[str]) -> bool:
         """Return True if ``model_name`` is unset or matches a registered name."""
@@ -1823,6 +1827,9 @@ class OpenAIServer:
 
         Follows the OpenAI Images API specification for image generation.
         """
+        error_check_ret = self._check_model(request)
+        if error_check_ret is not None:
+            return error_check_ret
         try:
             image_id = f"image_{uuid.uuid4().hex}"
             params = parse_visual_gen_params(request, image_id)
@@ -1888,6 +1895,9 @@ class OpenAIServer:
         Follows the OpenAI Images API specification for image editing.
         Creates an edited or extended image given an original image and a prompt.
         """
+        error_check_ret = self._check_model(request)
+        if error_check_ret is not None:
+            return error_check_ret
         try:
             image_id = f"image_{uuid.uuid4().hex}"
             params = parse_visual_gen_params(request, image_id)
@@ -1951,6 +1961,9 @@ class OpenAIServer:
         try:
             # Parse request based on content-type
             request = await self._parse_video_generation_request(raw_request)
+            error_check_ret = self._check_model(request)
+            if error_check_ret is not None:
+                return error_check_ret
 
             # Resolve the video encode format (mp4/avi/auto)
             resolved_fmt, resolved_ext = resolve_video_format(
@@ -2089,6 +2102,9 @@ class OpenAIServer:
         try:
             # Parse request based on content-type
             request = await self._parse_video_generation_request(raw_request)
+            error_check_ret = self._check_model(request)
+            if error_check_ret is not None:
+                return error_check_ret
 
             video_id = f"video_{uuid.uuid4().hex}"
             params = parse_visual_gen_params(request,

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -187,7 +187,7 @@ class OpenAIServer:
     def __init__(
             self,
             generator: Union[LLM, MultimodalEncoder, VisualGen],
-            model: Sequence[str],
+            model: Union[str, Sequence[str]],
             tool_parser: Optional[str],
             server_role: Optional[ServerRole],
             metadata_server_cfg: MetadataServerConfig,

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -762,17 +762,22 @@ class OpenAIServer:
 
     @staticmethod
     def _normalize_model_names(
-            names: Sequence[str]) -> tuple[str, list[str]]:
+            names: Union[str, Sequence[str]]) -> tuple[str, list[str]]:
         """Return (primary, aliases) from a sequence of names.
 
         If the first name points to an existing directory, its basename
         becomes the primary and the original path is kept as an alias so
         clients that launched the server by path can still address it.
         Duplicates are removed while preserving order.
+
+        A bare ``str`` is accepted as a convenience for callers that still
+        pass a single name; it is treated as ``[name]``.
         """
-        first = names[0]
-        model_dir = Path(first)
-        if model_dir.exists() and model_dir.is_dir():
+        if isinstance(names, str):
+            names = [names]
+        first = names[0] if names else ""
+        model_dir = Path(first) if first else None
+        if model_dir is not None and model_dir.exists() and model_dir.is_dir():
             candidates = [model_dir.name, first, *names[1:]]
         else:
             candidates = list(names)
@@ -782,10 +787,18 @@ class OpenAIServer:
             if n and n not in seen:
                 seen.add(n)
                 aliases.append(n)
+        if not aliases:
+            raise ValueError(
+                "served model names must contain at least one non-empty name")
         return aliases[0], aliases
 
     def _is_model_supported(self, model_name: Optional[str]) -> bool:
-        """Return True if ``model_name`` is unset or matches a registered name."""
+        """Return True if ``model_name`` is unset or matches a registered name.
+
+        Falsy values (``None`` and ``""``) are treated as "unspecified" and
+        accepted — clients that omit the field still get a response. Only
+        explicit unknown names are rejected by :meth:`_check_model`.
+        """
         if not model_name:
             return True
         return model_name in self.served_model_names

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -780,11 +780,22 @@ class OpenAIServer:
                 aliases.append(n)
         return primary, aliases
 
-    def _resolve_model_name(self, requested: Optional[str]) -> str:
-        """Return the requested model name if it is a known alias, else the primary name."""
-        if requested and requested in self.served_model_names:
-            return requested
-        return self.model
+    def _is_model_supported(self, model_name: Optional[str]) -> bool:
+        """Return True if ``model_name`` is unset or matches a registered name."""
+        if not model_name:
+            return True
+        return model_name in self.served_model_names
+
+    def _check_model(self, request: Any) -> Optional[Response]:
+        """Return a 404 Response if ``request.model`` is not a registered name, else None."""
+        model_name = getattr(request, "model", None)
+        if self._is_model_supported(model_name):
+            return None
+        return self.create_error_response(
+            message=f"The model `{model_name}` does not exist.",
+            err_type="NotFoundError",
+            status_code=HTTPStatus.NOT_FOUND,
+        )
 
     async def get_model(self) -> JSONResponse:
         model_list = ModelList(
@@ -1021,6 +1032,9 @@ class OpenAIServer:
 
     async def openai_chat(self, request: ChatCompletionRequest,
                           raw_request: Request) -> Response:
+        error_check_ret = self._check_model(request)
+        if error_check_ret is not None:
+            return error_check_ret
 
         def get_role() -> str:
             if request.add_generation_prompt:
@@ -1086,9 +1100,9 @@ class OpenAIServer:
                     if strict_guided is not None:
                         sampling_params.guided_decoding = strict_guided
             postproc_args = ChatPostprocArgs.from_request(request)
-            # Echo the resolved alias (or fall back to primary) so streaming
-            # and non-streaming responses return the same model name.
-            postproc_args.model = self._resolve_model_name(request.model)
+            # Always report the primary name in responses; streaming inherits
+            # this via postproc_args.
+            postproc_args.model = self.model
             disaggregated_params = to_llm_disaggregated_params(
                 request.disaggregated_params)
 
@@ -1188,6 +1202,9 @@ class OpenAIServer:
 
     async def openai_mm_encoder(self, request: ChatCompletionRequest,
                                 raw_request: Request) -> Response:
+        error_check_ret = self._check_model(request)
+        if error_check_ret is not None:
+            return error_check_ret
 
         async def create_mm_embedding_response(promise: RequestOutput):
             await promise.aresult()
@@ -1212,7 +1229,7 @@ class OpenAIServer:
                 int(h["tensor_size"][0]) for h in mm_embedding_handles)
             return ChatCompletionResponse(
                 id=str(promise.request_id),
-                model=self._resolve_model_name(request.model),
+                model=self.model,
                 choices=[
                     ChatCompletionResponseChoice(
                         index=0,
@@ -1285,6 +1302,9 @@ class OpenAIServer:
 
     async def openai_completion(self, request: CompletionRequest,
                                 raw_request: Request) -> Response:
+        error_check_ret = self._check_model(request)
+        if error_check_ret is not None:
+            return error_check_ret
 
         async def completion_response(
                 promise: RequestOutput,
@@ -1325,7 +1345,7 @@ class OpenAIServer:
                     cached_tokens=num_cached_tokens, ),
             )
             merged_rsp = CompletionResponse(
-                model=self._resolve_model_name(request.model),
+                model=self.model,
                 choices=all_choices,
                 usage=usage_info,
                 prompt_token_ids=all_prompt_token_ids,
@@ -1410,10 +1430,9 @@ class OpenAIServer:
                 sampling_params.return_perf_metrics = True
             disaggregated_params = to_llm_disaggregated_params(
                 request.disaggregated_params)
-            resolved_model_name = self._resolve_model_name(request.model)
             for idx, prompt in enumerate(prompts):
                 postproc_args = CompletionPostprocArgs.from_request(request)
-                postproc_args.model = resolved_model_name
+                postproc_args.model = self.model
                 postproc_args.prompt_idx = idx
                 if request.echo:
                     postproc_args.prompt = prompt
@@ -1488,6 +1507,9 @@ class OpenAIServer:
         Chat Completion API with harmony format support.
         Supports both streaming and non-streaming modes.
         """
+        error_check_ret = self._check_model(request)
+        if error_check_ret is not None:
+            return error_check_ret
 
         async def create_streaming_generator(promise: RequestOutput,
                                              postproc_params: PostprocParams):
@@ -1547,7 +1569,7 @@ class OpenAIServer:
                              tracing.extract_trace_headers(raw_request.headers))
 
             postproc_args = ChatCompletionPostprocArgs.from_request(request)
-            postproc_args.model = self._resolve_model_name(request.model)
+            postproc_args.model = self.model
             postproc_params = PostprocParams(
                 post_processor=chat_harmony_streaming_post_processor
                 if request.stream else chat_harmony_post_processor,
@@ -1589,6 +1611,9 @@ class OpenAIServer:
 
     async def openai_responses(self, request: ResponsesRequest,
                                raw_request: Request) -> Response:
+        error_check_ret = self._check_model(request)
+        if error_check_ret is not None:
+            return error_check_ret
 
         async def create_response(
                 promise: RequestOutput,
@@ -1602,7 +1627,7 @@ class OpenAIServer:
                     generator=promise,
                     request=request,
                     sampling_params=args.sampling_params,
-                    model_name=self._resolve_model_name(request.model),
+                    model_name=self.model,
                     conversation_store=self.conversation_store,
                     generation_result=None,
                     enable_store=self.enable_store and request.store,
@@ -1671,7 +1696,7 @@ class OpenAIServer:
                 streaming_processor = ResponsesStreamingProcessor(
                     request=request,
                     sampling_params=sampling_params,
-                    model_name=self._resolve_model_name(request.model),
+                    model_name=self.model,
                     conversation_store=self.conversation_store,
                     enable_store=self.enable_store and request.store,
                     use_harmony=self.use_harmony,
@@ -1680,7 +1705,7 @@ class OpenAIServer:
                 )
 
             postproc_args = ResponsesAPIPostprocArgs(
-                model=self._resolve_model_name(request.model),
+                model=self.model,
                 request=request,
                 sampling_params=sampling_params,
                 use_harmony=self.use_harmony,
@@ -2086,7 +2111,7 @@ class OpenAIServer:
             video_job = VideoJob(
                 created_at=int(time.time()),
                 id=video_id,
-                model=self._resolve_model_name(request.model),
+                model=self.model,
                 prompt=request.prompt,
                 status="queued",
                 duration=request.seconds,

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from http import HTTPStatus
 from pathlib import Path
 from typing import (Annotated, Any, AsyncGenerator, AsyncIterator, List,
-                    Optional, Union)
+                    Optional, Sequence, Union)
 
 import uvicorn
 from fastapi import Body, FastAPI, Request
@@ -187,7 +187,7 @@ class OpenAIServer:
     def __init__(
             self,
             generator: Union[LLM, MultimodalEncoder, VisualGen],
-            model: str,
+            model: Union[str, Sequence[str]],
             tool_parser: Optional[str],
             server_role: Optional[ServerRole],
             metadata_server_cfg: MetadataServerConfig,
@@ -206,11 +206,7 @@ class OpenAIServer:
         self.host = None
         self.port = None
 
-        model_dir = Path(model)
-        if model_dir.exists() and model_dir.is_dir():
-            self.model = model_dir.name
-        else:
-            self.model = model
+        self.model, self.served_model_names = self._normalize_model_names(model)
         self.metrics_collector = None
         self.perf_metrics = None
         self.perf_metrics_lock = None
@@ -727,7 +723,7 @@ class OpenAIServer:
                     "role": "user",
                     "content": "hi"
                 }],  # Minimal prompt (often > 1 token after tokenization)
-                model=self.model,
+                model=self.model,  # Use primary model name for health checks
                 max_completion_tokens=1,  # Request only 1 token out
                 stream=False,
                 temperature=0.0,  # Deterministic output
@@ -764,8 +760,36 @@ class OpenAIServer:
         ver = {"version": VERSION}
         return JSONResponse(content=ver)
 
+    @staticmethod
+    def _normalize_model_names(
+            model: Union[str, Sequence[str]]) -> tuple[str, list[str]]:
+        """Return (primary, aliases) from a single name or a sequence of names.
+
+        If the primary name points to an existing directory, its basename is used.
+        Duplicate aliases are removed while preserving order.
+        """
+        names = list(model) if isinstance(model, (list, tuple)) else [model]
+        primary = names[0]
+        model_dir = Path(primary)
+        if model_dir.exists() and model_dir.is_dir():
+            primary = model_dir.name
+        seen = {primary}
+        aliases = [primary]
+        for n in names[1:]:
+            if n not in seen:
+                seen.add(n)
+                aliases.append(n)
+        return primary, aliases
+
+    def _resolve_model_name(self, requested: Optional[str]) -> str:
+        """Return the requested model name if it is a known alias, else the primary name."""
+        if requested and requested in self.served_model_names:
+            return requested
+        return self.model
+
     async def get_model(self) -> JSONResponse:
-        model_list = ModelList(data=[ModelCard(id=self.model)])
+        model_list = ModelList(
+            data=[ModelCard(id=name) for name in self.served_model_names])
         return JSONResponse(content=model_list.model_dump())
 
     async def get_iteration_stats(self) -> JSONResponse:
@@ -1186,7 +1210,7 @@ class OpenAIServer:
                 int(h["tensor_size"][0]) for h in mm_embedding_handles)
             return ChatCompletionResponse(
                 id=str(promise.request_id),
-                model=self.model,
+                model=self._resolve_model_name(request.model),
                 choices=[
                     ChatCompletionResponseChoice(
                         index=0,
@@ -1299,7 +1323,7 @@ class OpenAIServer:
                     cached_tokens=num_cached_tokens, ),
             )
             merged_rsp = CompletionResponse(
-                model=self.model,
+                model=self._resolve_model_name(request.model),
                 choices=all_choices,
                 usage=usage_info,
                 prompt_token_ids=all_prompt_token_ids,
@@ -1573,7 +1597,7 @@ class OpenAIServer:
                     generator=promise,
                     request=request,
                     sampling_params=args.sampling_params,
-                    model_name=self.model,
+                    model_name=self._resolve_model_name(request.model),
                     conversation_store=self.conversation_store,
                     generation_result=None,
                     enable_store=self.enable_store and request.store,
@@ -1642,7 +1666,7 @@ class OpenAIServer:
                 streaming_processor = ResponsesStreamingProcessor(
                     request=request,
                     sampling_params=sampling_params,
-                    model_name=self.model,
+                    model_name=self._resolve_model_name(request.model),
                     conversation_store=self.conversation_store,
                     enable_store=self.enable_store and request.store,
                     use_harmony=self.use_harmony,
@@ -1651,7 +1675,7 @@ class OpenAIServer:
                 )
 
             postproc_args = ResponsesAPIPostprocArgs(
-                model=self.model,
+                model=self._resolve_model_name(request.model),
                 request=request,
                 sampling_params=sampling_params,
                 use_harmony=self.use_harmony,
@@ -2057,7 +2081,7 @@ class OpenAIServer:
             video_job = VideoJob(
                 created_at=int(time.time()),
                 id=video_id,
-                model=request.model or self.model,
+                model=self._resolve_model_name(request.model),
                 prompt=request.prompt,
                 status="queued",
                 duration=request.seconds,

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -187,7 +187,7 @@ class OpenAIServer:
     def __init__(
             self,
             generator: Union[LLM, MultimodalEncoder, VisualGen],
-            model: Union[str, Sequence[str]],
+            model: Sequence[str],
             tool_parser: Optional[str],
             server_role: Optional[ServerRole],
             metadata_server_cfg: MetadataServerConfig,
@@ -762,13 +762,12 @@ class OpenAIServer:
 
     @staticmethod
     def _normalize_model_names(
-            model: Union[str, Sequence[str]]) -> tuple[str, list[str]]:
-        """Return (primary, aliases) from a single name or a sequence of names.
+            names: Sequence[str]) -> tuple[str, list[str]]:
+        """Return (primary, aliases) from a sequence of names.
 
         If the primary name points to an existing directory, its basename is used.
         Duplicate aliases are removed while preserving order.
         """
-        names = list(model) if isinstance(model, (list, tuple)) else [model]
         primary = names[0]
         model_dir = Path(primary)
         if model_dir.exists() and model_dir.is_dir():
@@ -1087,6 +1086,9 @@ class OpenAIServer:
                     if strict_guided is not None:
                         sampling_params.guided_decoding = strict_guided
             postproc_args = ChatPostprocArgs.from_request(request)
+            # Echo the resolved alias (or fall back to primary) so streaming
+            # and non-streaming responses return the same model name.
+            postproc_args.model = self._resolve_model_name(request.model)
             disaggregated_params = to_llm_disaggregated_params(
                 request.disaggregated_params)
 
@@ -1408,8 +1410,10 @@ class OpenAIServer:
                 sampling_params.return_perf_metrics = True
             disaggregated_params = to_llm_disaggregated_params(
                 request.disaggregated_params)
+            resolved_model_name = self._resolve_model_name(request.model)
             for idx, prompt in enumerate(prompts):
                 postproc_args = CompletionPostprocArgs.from_request(request)
+                postproc_args.model = resolved_model_name
                 postproc_args.prompt_idx = idx
                 if request.echo:
                     postproc_args.prompt = prompt
@@ -1543,6 +1547,7 @@ class OpenAIServer:
                              tracing.extract_trace_headers(raw_request.headers))
 
             postproc_args = ChatCompletionPostprocArgs.from_request(request)
+            postproc_args.model = self._resolve_model_name(request.model)
             postproc_params = PostprocParams(
                 post_processor=chat_harmony_streaming_post_processor
                 if request.stream else chat_harmony_post_processor,

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -109,6 +109,7 @@ l0_a10:
   - unittest/llmapi/test_llm_args.py
   - unittest/llmapi/test_kv_cache_dtype_override.py
   - unittest/llmapi/test_additional_model_outputs.py -m "gpu1"
+  - unittest/llmapi/apps/test_served_model_name.py
   - unittest/llmapi/test_request_priority.py
   # executor
   - unittest/executor/test_rpc.py

--- a/tests/unittest/_torch/visual_gen/test_trtllm_serve_endpoints.py
+++ b/tests/unittest/_torch/visual_gen/test_trtllm_serve_endpoints.py
@@ -161,7 +161,7 @@ def _create_server(generator: MockVisualGen, model_name: str = "test-model") -> 
     with patch("tensorrt_llm.serve.openai_server.VisualGen", MockVisualGen):
         server = OpenAIServer(
             generator=generator,
-            model=model_name,
+            model=[model_name],
             tool_parser=None,
             server_role=ServerRole.VISUAL_GEN,
             metadata_server_cfg=None,

--- a/tests/unittest/llmapi/apps/_test_openai_metrics.py
+++ b/tests/unittest/llmapi/apps/_test_openai_metrics.py
@@ -26,7 +26,7 @@ def llm():
 @pytest.fixture(scope="module")
 def client(llm):
     app_instance = OpenAIServer(llm,
-                                model=llama_model_path,
+                                model=[llama_model_path],
                                 tool_parser=None,
                                 server_role=None,
                                 metadata_server_cfg=None)

--- a/tests/unittest/llmapi/apps/test_served_model_name.py
+++ b/tests/unittest/llmapi/apps/test_served_model_name.py
@@ -65,6 +65,15 @@ def test_normalize_accepts_bare_str():
     assert OpenAIServer._normalize_model_names("m") == ("m", ["m"])
 
 
+def test_normalize_empty_raises():
+    """Passing an empty sequence (or all-empty-string sequence) must raise."""
+    with pytest.raises(ValueError, match="at least one non-empty"):
+        OpenAIServer._normalize_model_names([])
+
+    with pytest.raises(ValueError, match="at least one non-empty"):
+        OpenAIServer._normalize_model_names(["", ""])
+
+
 def test_is_model_supported_accepts_original_directory_path(tmp_path):
     """A client that knows the path the server was launched with still gets through."""
     model_dir = tmp_path / "ckpt"
@@ -125,7 +134,7 @@ def test_check_model_rejects_unknown_with_404():
         (("foo",), ["foo"]),
         (("foo", "bar"), ["foo", "bar"]),
         (("foo", "", "bar"), ["foo", "bar"]),
-        (("foo", "bar", "foo"), ["foo", "bar", "foo"]),
+        (("foo", "bar", "foo"), ["foo", "bar"]),
     ],
 )
 def test_resolve_served_model_names_cli(flag, expected):

--- a/tests/unittest/llmapi/apps/test_served_model_name.py
+++ b/tests/unittest/llmapi/apps/test_served_model_name.py
@@ -55,6 +55,20 @@ def test_normalize_directory_path_dedups_basename_and_path(tmp_path):
     assert aliases == ["ckpt", str(model_dir), "alias"]
 
 
+def test_normalize_file_path_not_treated_as_dir(tmp_path):
+    """A primary that exists as a FILE keeps its full path (no basename rewrite)."""
+    model_file = tmp_path / "ckpt.bin"
+    model_file.write_text("")
+    primary, aliases = OpenAIServer._normalize_model_names([str(model_file)])
+    assert primary == str(model_file)
+    assert aliases == [str(model_file)]
+
+
+def test_normalize_accepts_bare_str():
+    """Defensive: a plain str caller is treated as a single-name list."""
+    assert OpenAIServer._normalize_model_names("m") == ("m", ["m"])
+
+
 def test_is_model_supported_accepts_original_directory_path(tmp_path):
     """A client that knows the path the server was launched with still gets through."""
     model_dir = tmp_path / "ckpt"

--- a/tests/unittest/llmapi/apps/test_served_model_name.py
+++ b/tests/unittest/llmapi/apps/test_served_model_name.py
@@ -37,12 +37,32 @@ def test_normalize_dedup_preserves_order():
 
 
 def test_normalize_directory_path_uses_basename(tmp_path):
+    """Primary resolves to basename, but the original path stays a valid alias."""
     model_dir = tmp_path / "ckpt"
     model_dir.mkdir()
     primary, aliases = OpenAIServer._normalize_model_names(
         [str(model_dir), "alias"])
     assert primary == "ckpt"
-    assert aliases == ["ckpt", "alias"]
+    assert aliases == ["ckpt", str(model_dir), "alias"]
+
+
+def test_normalize_directory_path_dedups_basename_and_path(tmp_path):
+    """User-provided 'ckpt' alias after a dir path dedups to a single basename."""
+    model_dir = tmp_path / "ckpt"
+    model_dir.mkdir()
+    _, aliases = OpenAIServer._normalize_model_names(
+        [str(model_dir), "ckpt", "alias"])
+    assert aliases == ["ckpt", str(model_dir), "alias"]
+
+
+def test_is_model_supported_accepts_original_directory_path(tmp_path):
+    """A client that knows the path the server was launched with still gets through."""
+    model_dir = tmp_path / "ckpt"
+    model_dir.mkdir()
+    primary, aliases = OpenAIServer._normalize_model_names([str(model_dir)])
+    server = _make_server(primary, aliases)
+    assert server._is_model_supported(str(model_dir)) is True
+    assert server._is_model_supported("ckpt") is True
 
 
 def _make_server(primary, aliases):

--- a/tests/unittest/llmapi/apps/test_served_model_name.py
+++ b/tests/unittest/llmapi/apps/test_served_model_name.py
@@ -20,8 +20,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from tensorrt_llm.commands.serve import (_resolve_served_model_names,
-                                          _split_served_model_names)
+from tensorrt_llm.commands.serve import _resolve_served_model_names, _split_served_model_names
 from tensorrt_llm.serve.openai_server import OpenAIServer
 
 
@@ -30,8 +29,7 @@ def test_normalize_single_name():
 
 
 def test_normalize_dedup_preserves_order():
-    primary, aliases = OpenAIServer._normalize_model_names(
-        ("primary", "a1", "primary", "a2", "a1"))
+    primary, aliases = OpenAIServer._normalize_model_names(("primary", "a1", "primary", "a2", "a1"))
     assert primary == "primary"
     assert aliases == ["primary", "a1", "a2"]
 
@@ -40,8 +38,7 @@ def test_normalize_directory_path_uses_basename(tmp_path):
     """Primary resolves to basename, but the original path stays a valid alias."""
     model_dir = tmp_path / "ckpt"
     model_dir.mkdir()
-    primary, aliases = OpenAIServer._normalize_model_names(
-        [str(model_dir), "alias"])
+    primary, aliases = OpenAIServer._normalize_model_names([str(model_dir), "alias"])
     assert primary == "ckpt"
     assert aliases == ["ckpt", str(model_dir), "alias"]
 
@@ -50,8 +47,7 @@ def test_normalize_directory_path_dedups_basename_and_path(tmp_path):
     """User-provided 'ckpt' alias after a dir path dedups to a single basename."""
     model_dir = tmp_path / "ckpt"
     model_dir.mkdir()
-    _, aliases = OpenAIServer._normalize_model_names(
-        [str(model_dir), "ckpt", "alias"])
+    _, aliases = OpenAIServer._normalize_model_names([str(model_dir), "ckpt", "alias"])
     assert aliases == ["ckpt", str(model_dir), "alias"]
 
 
@@ -121,28 +117,34 @@ def test_check_model_rejects_unknown_with_404():
     assert "not-an-alias" in body["message"]
 
 
-@pytest.mark.parametrize("flag,expected", [
-    (None, ["/p/m"]),
-    ((), ["/p/m"]),
-    (("foo", ), ["foo"]),
-    (("foo", "bar"), ["foo", "bar"]),
-    (("foo", "", "bar"), ["foo", "bar"]),
-    (("foo", "bar", "foo"), ["foo", "bar", "foo"]),
-])
+@pytest.mark.parametrize(
+    "flag,expected",
+    [
+        (None, ["/p/m"]),
+        ((), ["/p/m"]),
+        (("foo",), ["foo"]),
+        (("foo", "bar"), ["foo", "bar"]),
+        (("foo", "", "bar"), ["foo", "bar"]),
+        (("foo", "bar", "foo"), ["foo", "bar", "foo"]),
+    ],
+)
 def test_resolve_served_model_names_cli(flag, expected):
     assert _resolve_served_model_names(flag, {"model": "/p/m"}) == expected
 
 
-@pytest.mark.parametrize("raw,expected", [
-    (None, None),
-    ((), ()),
-    (("a", ), ("a", )),
-    (("a", "b", "c"), ("a", "b", "c")),  # repeated flags stay as-is
-    (("a,b,c", ), ("a", "b", "c")),  # comma-separated single flag
-    (("a,b", "c"), ("a", "b", "c")),  # mixed
-    (("a , b , c", ), ("a", "b", "c")),  # whitespace around commas
-    (("a,,b", ), ("a", "b")),  # empty pieces dropped
-    (("", "a"), ("a", )),  # empty flag dropped
-])
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, None),
+        ((), ()),
+        (("a",), ("a",)),
+        (("a", "b", "c"), ("a", "b", "c")),  # repeated flags stay as-is
+        (("a,b,c",), ("a", "b", "c")),  # comma-separated single flag
+        (("a,b", "c"), ("a", "b", "c")),  # mixed
+        (("a , b , c",), ("a", "b", "c")),  # whitespace around commas
+        (("a,,b",), ("a", "b")),  # empty pieces dropped
+        (("", "a"), ("a",)),  # empty flag dropped
+    ],
+)
 def test_split_served_model_names(raw, expected):
     assert _split_served_model_names(None, None, raw) == expected

--- a/tests/unittest/llmapi/apps/test_served_model_name.py
+++ b/tests/unittest/llmapi/apps/test_served_model_name.py
@@ -16,11 +16,12 @@
 
 import pytest
 
+from tensorrt_llm.commands.serve import _resolve_served_model_names
 from tensorrt_llm.serve.openai_server import OpenAIServer
 
 
-def test_normalize_single_string():
-    assert OpenAIServer._normalize_model_names("m") == ("m", ["m"])
+def test_normalize_single_name():
+    assert OpenAIServer._normalize_model_names(["m"]) == ("m", ["m"])
 
 
 def test_normalize_dedup_preserves_order():
@@ -54,3 +55,15 @@ def test_resolve_known_alias_is_echoed_back():
 def test_resolve_unknown_falls_back_to_primary(requested):
     server = _make_server("primary", ["primary", "alias1"])
     assert server._resolve_model_name(requested) == "primary"
+
+
+@pytest.mark.parametrize("flag,expected", [
+    (None, ["/p/m"]),
+    ((), ["/p/m"]),
+    (("foo", ), ["foo"]),
+    (("foo", "bar"), ["foo", "bar"]),
+    (("foo", "", "bar"), ["foo", "bar"]),
+    (("foo", "bar", "foo"), ["foo", "bar", "foo"]),
+])
+def test_resolve_served_model_names_cli(flag, expected):
+    assert _resolve_served_model_names(flag, {"model": "/p/m"}) == expected

--- a/tests/unittest/llmapi/apps/test_served_model_name.py
+++ b/tests/unittest/llmapi/apps/test_served_model_name.py
@@ -14,6 +14,10 @@
 # limitations under the License.
 """Unit tests for multi-name / alias handling in OpenAIServer."""
 
+import json
+from http import HTTPStatus
+from types import SimpleNamespace
+
 import pytest
 
 from tensorrt_llm.commands.serve import _resolve_served_model_names
@@ -25,7 +29,8 @@ def test_normalize_single_name():
 
 
 def test_normalize_dedup_preserves_order():
-    primary, aliases = OpenAIServer._normalize_model_names(("primary", "a1", "primary", "a2", "a1"))
+    primary, aliases = OpenAIServer._normalize_model_names(
+        ("primary", "a1", "primary", "a2", "a1"))
     assert primary == "primary"
     assert aliases == ["primary", "a1", "a2"]
 
@@ -33,7 +38,8 @@ def test_normalize_dedup_preserves_order():
 def test_normalize_directory_path_uses_basename(tmp_path):
     model_dir = tmp_path / "ckpt"
     model_dir.mkdir()
-    primary, aliases = OpenAIServer._normalize_model_names([str(model_dir), "alias"])
+    primary, aliases = OpenAIServer._normalize_model_names(
+        [str(model_dir), "alias"])
     assert primary == "ckpt"
     assert aliases == ["ckpt", "alias"]
 
@@ -45,16 +51,39 @@ def _make_server(primary, aliases):
     return server
 
 
-def test_resolve_known_alias_is_echoed_back():
+@pytest.mark.parametrize("name", ["primary", "alias1", "alias2"])
+def test_is_model_supported_known(name):
     server = _make_server("primary", ["primary", "alias1", "alias2"])
-    assert server._resolve_model_name("alias1") == "alias1"
-    assert server._resolve_model_name("primary") == "primary"
+    assert server._is_model_supported(name) is True
 
 
-@pytest.mark.parametrize("requested", [None, "", "not-an-alias"])
-def test_resolve_unknown_falls_back_to_primary(requested):
+@pytest.mark.parametrize("name", [None, ""])
+def test_is_model_supported_empty_is_ok(name):
+    """vLLM-parity: empty/None client-supplied model is treated as valid."""
     server = _make_server("primary", ["primary", "alias1"])
-    assert server._resolve_model_name(requested) == "primary"
+    assert server._is_model_supported(name) is True
+
+
+def test_is_model_supported_unknown():
+    server = _make_server("primary", ["primary", "alias1"])
+    assert server._is_model_supported("not-an-alias") is False
+
+
+def test_check_model_accepts_known_alias():
+    server = _make_server("primary", ["primary", "alias1"])
+    request = SimpleNamespace(model="alias1")
+    assert server._check_model(request) is None
+
+
+def test_check_model_rejects_unknown_with_404():
+    server = _make_server("primary", ["primary", "alias1"])
+    request = SimpleNamespace(model="not-an-alias")
+    response = server._check_model(request)
+    assert response is not None
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    body = json.loads(response.body)
+    assert body["type"] == "NotFoundError"
+    assert "not-an-alias" in body["message"]
 
 
 @pytest.mark.parametrize("flag,expected", [

--- a/tests/unittest/llmapi/apps/test_served_model_name.py
+++ b/tests/unittest/llmapi/apps/test_served_model_name.py
@@ -20,7 +20,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from tensorrt_llm.commands.serve import _resolve_served_model_names
+from tensorrt_llm.commands.serve import (_resolve_served_model_names,
+                                          _split_served_model_names)
 from tensorrt_llm.serve.openai_server import OpenAIServer
 
 
@@ -96,3 +97,18 @@ def test_check_model_rejects_unknown_with_404():
 ])
 def test_resolve_served_model_names_cli(flag, expected):
     assert _resolve_served_model_names(flag, {"model": "/p/m"}) == expected
+
+
+@pytest.mark.parametrize("raw,expected", [
+    (None, None),
+    ((), ()),
+    (("a", ), ("a", )),
+    (("a", "b", "c"), ("a", "b", "c")),  # repeated flags stay as-is
+    (("a,b,c", ), ("a", "b", "c")),  # comma-separated single flag
+    (("a,b", "c"), ("a", "b", "c")),  # mixed
+    (("a , b , c", ), ("a", "b", "c")),  # whitespace around commas
+    (("a,,b", ), ("a", "b")),  # empty pieces dropped
+    (("", "a"), ("a", )),  # empty flag dropped
+])
+def test_split_served_model_names(raw, expected):
+    assert _split_served_model_names(None, None, raw) == expected

--- a/tests/unittest/llmapi/apps/test_served_model_name.py
+++ b/tests/unittest/llmapi/apps/test_served_model_name.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for multi-name / alias handling in OpenAIServer."""
+
+import pytest
+
+from tensorrt_llm.serve.openai_server import OpenAIServer
+
+
+def test_normalize_single_string():
+    assert OpenAIServer._normalize_model_names("m") == ("m", ["m"])
+
+
+def test_normalize_dedup_preserves_order():
+    primary, aliases = OpenAIServer._normalize_model_names(("primary", "a1", "primary", "a2", "a1"))
+    assert primary == "primary"
+    assert aliases == ["primary", "a1", "a2"]
+
+
+def test_normalize_directory_path_uses_basename(tmp_path):
+    model_dir = tmp_path / "ckpt"
+    model_dir.mkdir()
+    primary, aliases = OpenAIServer._normalize_model_names([str(model_dir), "alias"])
+    assert primary == "ckpt"
+    assert aliases == ["ckpt", "alias"]
+
+
+def _make_server(primary, aliases):
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.model = primary
+    server.served_model_names = aliases
+    return server
+
+
+def test_resolve_known_alias_is_echoed_back():
+    server = _make_server("primary", ["primary", "alias1", "alias2"])
+    assert server._resolve_model_name("alias1") == "alias1"
+    assert server._resolve_model_name("primary") == "primary"
+
+
+@pytest.mark.parametrize("requested", [None, "", "not-an-alias"])
+def test_resolve_unknown_falls_back_to_primary(requested):
+    server = _make_server("primary", ["primary", "alias1"])
+    assert server._resolve_model_name(requested) == "primary"


### PR DESCRIPTION
## Summary
- Allow `--served_model_name` to be specified multiple times, matching vLLM-style explicit served-name override semantics
- The first name is the primary served model name; additional names are accepted request aliases
- `/v1/models` returns all registered names; response `model` fields use the primary served model name

### Served model name semantics
`--served_model_name` follows vLLM-style override semantics:

- If `--served_model_name` is not specified, the launch model path is used as the served model name fallback. For local model directories, HTTP serving normalizes the basename as the primary name while preserving the original path as an accepted alias.
- If `--served_model_name` is specified, only the provided name(s) are valid request model names. The original model path is not implicitly added as an alias.
- When multiple names are provided, the first name is primary and is used in response metadata. Additional names are accepted request aliases, but responses still report the primary name.

### Changes
- **`serve.py`**: `--served_model_name` gains `multiple=True` (click); `launch_server`/`launch_grpc_server` accept `Sequence[str]`; normalizes to list internally
- **`openai_server.py`**: `__init__` accepts `Union[str, Sequence[str]]`; stores `self.model` (primary) and `self.served_model_names` (all); `get_model()` returns all names; `_check_model()` accepts requests addressed to any registered alias and rejects unknown explicit model names

### Usage
```bash
# Default fallback: served model name comes from the launch model path.
trtllm-serve /models/foo

# Explicit override with repeated flags.
trtllm-serve /models/foo \
  --served_model_name my-model \
  --served_model_name alias1

# Explicit override with comma-separated names.
trtllm-serve /models/foo --served_model_name my-model,alias1,alias2

# Quote comma-separated values if spaces are included after commas.
trtllm-serve /models/foo --served_model_name "my-model, alias1, alias2"
```

## Test plan
- [x] Unit tests: `pytest tests/unittest/llmapi/apps/test_served_model_name.py -v` passes 30 tests
- [x] Unit coverage includes:
  - Dedup and order preservation across multiple `--served_model_name` values
  - Alias request validation for known aliases, unknown aliases, `None`, and empty string
  - Directory-path → basename primary normalization while preserving original path as an alias
  - Single-string / empty input fallback for backward compatibility
  - Comma-separated and repeated-flag CLI parsing
- [x] Smoke test: `trtllm-serve <model> --served_model_name foo --served_model_name bar`
  - `GET /v1/models` lists both `foo` and `bar`
  - `POST /v1/chat/completions` with `model: "bar"` returns HTTP 200 and generates content; response `model` is `foo` because the first served name is primary
  - `POST /v1/chat/completions` with `model: "unknown"` returns HTTP 404 with `NotFoundError`
