### PR TITLE
feat: add standard gRPC health service for Kubernetes native probes

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -318,6 +318,38 @@ def launch_server(
         asyncio.run(server(host, port, sockets=[s]))
 
 
+class _TrtllmHealthServicer:
+    """Standard grpc.health.v1.Health servicer wrapping the existing health check."""
+
+    _KNOWN_SERVICES = {"", "trtllm.TrtllmService"}
+
+    def __init__(self, request_manager) -> None:
+        self._request_manager = request_manager
+
+    async def Check(self, request, context):
+        from grpc_health.v1 import health_pb2
+
+        service = request.service
+        if service not in self._KNOWN_SERVICES:
+            import grpc
+            context.set_code(grpc.StatusCode.NOT_FOUND)
+            context.set_details(f"Unknown service: {service}")
+            return health_pb2.HealthCheckResponse(
+                status=health_pb2.HealthCheckResponse.SERVICE_UNKNOWN)
+
+        try:
+            is_healthy, _ = await self._request_manager.health_check()
+            status = (health_pb2.HealthCheckResponse.SERVING if is_healthy else
+                      health_pb2.HealthCheckResponse.NOT_SERVING)
+        except Exception:
+            status = health_pb2.HealthCheckResponse.NOT_SERVING
+        return health_pb2.HealthCheckResponse(status=status)
+
+    async def Watch(self, request, context):
+        response = await self.Check(request, context)
+        yield response
+
+
 def launch_grpc_server(host: str,
                        port: int,
                        llm_args: dict,
@@ -335,6 +367,12 @@ def launch_grpc_server(host: str,
         served_model_name: Custom model name for API responses (defaults to model path)
     """
     import grpc
+
+    try:
+        from grpc_health.v1 import health_pb2_grpc
+        HEALTH_SERVICE_AVAILABLE = True
+    except ImportError:
+        HEALTH_SERVICE_AVAILABLE = False
 
     try:
         from grpc_reflection.v1alpha import reflection
@@ -390,14 +428,23 @@ def launch_grpc_server(host: str,
         trtllm_service_pb2_grpc.add_TrtllmServiceServicer_to_server(
             servicer, server)
 
+        # Register standard grpc.health.v1.Health service
+        if HEALTH_SERVICE_AVAILABLE:
+            health_servicer = _TrtllmHealthServicer(request_manager)
+            health_pb2_grpc.add_HealthServicer_to_server(
+                health_servicer, server)
+            logger.info("Standard gRPC health service registered")
+
         # Enable reflection for grpcurl and other tools
         if REFLECTION_AVAILABLE:
-            service_names = (
+            service_names = [
                 trtllm_service_pb2.DESCRIPTOR.services_by_name["TrtllmService"].
                 full_name,
                 reflection.SERVICE_NAME,
-            )
-            reflection.enable_server_reflection(service_names, server)
+            ]
+            if HEALTH_SERVICE_AVAILABLE:
+                service_names.append("grpc.health.v1.Health")
+            reflection.enable_server_reflection(tuple(service_names), server)
             logger.info("gRPC reflection enabled")
 
         # Bind to address


### PR DESCRIPTION
The gRPC server registers `trtllm.TrtllmService/HealthCheck` but not the
standard `grpc.health.v1.Health/Check` service defined by the gRPC health
checking protocol (https://github.com/grpc/grpc/blob/master/doc/health-checking.md).

Infrastructure that speaks the standard protocol (e.g. Kubernetes native gRPC
probes, grpc-health-probe, load balancers) gets UNIMPLEMENTED for every probe,
which is treated as unhealthy.

This PR adds a lightweight `grpc.health.v1.Health` servicer that delegates to
the existing `GrpcRequestManager.health_check()`. No new dependencies —
`grpcio-health-checking` is already installed; if absent the service is
silently skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added gRPC health check endpoint for server status monitoring and discovery through gRPC reflection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage
- Existing `tests/unittest/llmapi/test_grpc.py` covers the custom HealthCheck RPC
  and is unaffected.
- The new servicer delegates to the same `GrpcRequestManager.health_check()` —
  no new code paths in the health check logic itself.
- Manual verification: `grpcurl -plaintext localhost:<port> grpc.health.v1.Health/Check`
  returns SERVING when the engine is healthy.
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
