### PR TITLE
fix: Use CompletionStreamResponse for streaming completions usage chunk

### DIFF
--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -509,9 +509,9 @@ def completion_stream_post_processor(rsp: DetokenizedGenerationResultBase,
                 cached_tokens=rsp.cached_tokens),
         )
 
-        final_usage_chunk = ChatCompletionStreamResponse(choices=[],
-                                                         model=args.model,
-                                                         usage=final_usage)
+        final_usage_chunk = CompletionStreamResponse(choices=[],
+                                                     model=args.model,
+                                                     usage=final_usage)
         final_usage_data = final_usage_chunk.model_dump_json()
         res.append(f"data: {final_usage_data}\n\n")
     args.first_iteration = False

--- a/tests/unittest/llmapi/apps/_test_openai_completions.py
+++ b/tests/unittest/llmapi/apps/_test_openai_completions.py
@@ -279,11 +279,13 @@ async def test_completion_stream_options(async_client: openai.AsyncOpenAI,
                                                        False,
                                                    })
     async for chunk in stream:
+        assert chunk.object == "text_completion"
         if chunk.choices[0].finish_reason is None:
             assert chunk.usage is None
         else:
             assert chunk.usage is None
             final_chunk = await stream.__anext__()
+            assert final_chunk.object == "text_completion"
             assert final_chunk.usage is not None
             assert final_chunk.usage.prompt_tokens > 0
             assert final_chunk.usage.completion_tokens > 0
@@ -306,6 +308,7 @@ async def test_completion_stream_options(async_client: openai.AsyncOpenAI,
                                                        True,
                                                    })
     async for chunk in stream:
+        assert chunk.object == "text_completion"
         assert chunk.usage is not None
         assert chunk.usage.prompt_tokens > 0
         assert chunk.usage.completion_tokens > 0
@@ -313,6 +316,7 @@ async def test_completion_stream_options(async_client: openai.AsyncOpenAI,
                                             chunk.usage.completion_tokens)
         if chunk.choices[0].finish_reason is not None:
             final_chunk = await stream.__anext__()
+            assert final_chunk.object == "text_completion"
             assert final_chunk.usage is not None
             assert final_chunk.usage.prompt_tokens > 0
             assert final_chunk.usage.completion_tokens > 0


### PR DESCRIPTION
The completion_stream_post_processor incorrectly used ChatCompletionStreamResponse for the final usage-only chunk, causing streaming /v1/completions responses to include "object": "chat.completion.chunk" instead of the expected "object": "text_completion". This breaks OpenAI-compatible clients (e.g., aiperf) that validate the object type field per endpoint.

Replace ChatCompletionStreamResponse with CompletionStreamResponse at line 512 to match the type already used for regular streaming chunks (line 492).

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
  The completion_stream_post_processor incorrectly uses ChatCompletionStreamResponse for the final usage-only chunk in streaming /v1/completions responses. This causes the
  last SSE chunk to include "object": "chat.completion.chunk" instead of the expected "object": "text_completion", breaking OpenAI-compatible clients (e.g., aiperf) that
  validate the object type field per endpoint.

  Only the final usage-only chunk is affected — all regular token-streaming chunks already correctly use CompletionStreamResponse (line 492). The bug is only in the usage
  chunk at line 512, and only triggers when stream_options.include_usage is true.

  Repro

  Start trtllm-serve with any model using the PyTorch backend, then send:

  curl -s http://localhost:8001/v1/completions \
    -H "Content-Type: application/json" \
    -d '{"model": "...", "prompt": "Hello", "max_tokens": 3,
         "stream": true, "stream_options": {"include_usage": true}}'

  Before (bug)

  Regular token chunks have the correct type, but the final usage-only chunk has the wrong type:

  data: {"id":"cmpl-...","object":"text_completion",...,"choices":[{"text":" Kitty"}],"usage":null}
  data: {"id":"cmpl-...","object":"text_completion",...,"choices":[{"text":" Cafe"}],"usage":null}
  data: {"id":"cmpl-...","object":"text_completion",...,"choices":[{"text":" opens","finish_reason":"length"}],"usage":null}
  data: {"id":"chatcmpl-...","object":"chat.completion.chunk",...,"choices":[],"usage":{...}}  <- BUG
  data: [DONE]

  After (fix)

  data: {"id":"cmpl-...","object":"text_completion",...,"choices":[{"text":" Kitty"}],"usage":null}
  data: {"id":"cmpl-...","object":"text_completion",...,"choices":[{"text":" Cafe"}],"usage":null}
  data: {"id":"cmpl-...","object":"text_completion",...,"choices":[{"text":" opens","finish_reason":"length"}],"usage":null}
  data: {"id":"cmpl-...","object":"text_completion",...,"choices":[],"usage":{...}}  <- FIXED
  data: [DONE]

  Fix

  One-line change in tensorrt_llm/serve/postprocess_handlers.py:512: replace ChatCompletionStreamResponse with CompletionStreamResponse.

  Test plan

  - Llama-3.1-8B-Instruct: streaming /v1/completions with include_usage returns correct text_completion for all chunks
  - Chat completions endpoint unaffected (uses ChatCompletionStreamResponse correctly at line 319)
  - Pre-commit hooks pass

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
