### PR TITLE
[None][fix] Add missing allow_partial_loading param to CuteDSL and ConfigurableMoE load_weights

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -1237,9 +1237,7 @@ class ConfigurableMoE(MoE):
         )
         return self.backend.create_weights()
 
-    def load_weights(self,
-                     weights: List[Dict],
-                     allow_partial_loading: bool = False):
+    def load_weights(self, weights: List[Dict], allow_partial_loading: bool = False):
         """
         Load weights - delegated to backend
 

--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -1237,7 +1237,9 @@ class ConfigurableMoE(MoE):
         )
         return self.backend.create_weights()
 
-    def load_weights(self, weights: List[Dict]):
+    def load_weights(self,
+                     weights: List[Dict],
+                     allow_partial_loading: bool = False):
         """
         Load weights - delegated to backend
 
@@ -1245,7 +1247,7 @@ class ConfigurableMoE(MoE):
         assert hasattr(self.backend, "load_weights"), (
             f"Backend {self.backend.__class__.__name__} must implement load_weights()"
         )
-        return self.backend.load_weights(weights)
+        return self.backend.load_weights(weights, allow_partial_loading)
 
     def post_load_weights(self):
         """

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
@@ -979,8 +979,10 @@ class CuteDslFusedMoE(CutlassFusedMoE):
                          enable_alltoall=False)
         return x
 
-    def load_weights(self, weights: Dict[str, torch.Tensor]):
-        super().load_weights(weights)
+    def load_weights(self,
+                     weights: List[Dict],
+                     allow_partial_loading: bool = False):
+        super().load_weights(weights, allow_partial_loading)
         dwdp_handle_collector = getattr(self, "dwdp_handle_collector", None)
         if dwdp_handle_collector is not None:
             dwdp_handle_collector.register_weights(self)


### PR DESCRIPTION
## Summary
- PR #12136 (DWDP) added a `load_weights` override in `CuteDslFusedMoE` that dropped the `allow_partial_loading` parameter from the base class signature.
- `ConfigurableMoE.load_weights` also lacked this parameter.
- This causes `TypeError: CuteDslFusedMoE.load_weights() got an unexpected keyword argument 'allow_partial_loading'` when `qwen2_moe_weight_mapper` calls `module.load_weights(weights=..., allow_partial_loading=...)` on models using the CuteDSL or ConfigurableMoE backend (e.g., Qwen3 MoE).
- Fix: match the base class signature `load_weights(self, weights, allow_partial_loading=False)` in both overrides and pass through to `super()` / backend.

## Test plan
- [x] Verify Qwen3 MoE model loads without TypeError with CuteDSL backend
- [x] Verify existing MoE backends (Cutlass, Triton, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `allow_partial_loading` parameter to weight loading in Mixture of Experts modules, enabling flexible control over partial weight loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->