### PR TITLE
[#12617][fix] fix LoRA for Qwen2 and Mistral decoder layers

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import copy
 import dataclasses
 from typing import Any, Dict, List, Tuple
@@ -134,6 +148,7 @@ class MistralDecoderLayer(DecoderLayer):
             bias=False,
             dtype=config.torch_dtype,
             config=model_config,
+            layer_idx=layer_idx,
         )
         self.input_layernorm = RMSNorm(
             hidden_size=config.hidden_size,

--- a/tensorrt_llm/_torch/models/modeling_qwen.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from typing import Optional, Tuple
 
 import torch
@@ -134,6 +148,7 @@ class QwenDecoderLayer(DecoderLayer):
             bias=config.mlp_bias if hasattr(config, 'mlp_bias') else False,
             dtype=config.torch_dtype,
             config=model_config,
+            layer_idx=layer_idx,
         )
         self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,
                                        eps=config.rms_norm_eps,

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import copy
 from typing import Optional
 
@@ -121,6 +135,7 @@ class Qwen3DecoderLayer(DecoderLayer):
             dtype=config.torch_dtype,
             overridden_tp_size=1 if self.enable_attention_dp else None,
             config=model_config,
+            layer_idx=layer_idx,
         )
 
         self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,


### PR DESCRIPTION
## What

Two PyTorch-backend decoder layers never forward `layer_idx` to their `GatedMLP`,
and one of them also drops `lora_params` before calling the MLP:

| Model | `GatedMLP(layer_idx=...)` | `lora_params` reaches MLP | Symptom with LoRA |
|---|---|---|---|
| Qwen2 (`QwenDecoderLayer`) | missing | yes | crashes |
| Mistral (`MistralDecoderLayer`) | missing | **no** | silently wrong |

`GatedMLP.forward_lora()` guards on the index it needs to look up per-layer adapter
weights:

```python
assert self.layer_idx is not None, "layer_idx is required for lora"
```

**Qwen2** reaches that assert and dies:

```
tensorrt_llm.executor.utils.RequestError: layer_idx is required for lora
```

**Mistral** never gets there. `MistralModel.forward()` passes `lora_params` down to
the decoder layer, which forwards it to `self_attn`, but the MLP call dropped it:

```python
hidden_states = self.mlp(hidden_states)      # **kwargs missing
```

So `GatedMLP.forward()` sees `lora_params=None`, `bool(lora_params)` is false,
`forward_lora()` is never entered, and the assert never fires. Attention LoRA still
applies, so generation looks fine — **the MLP adapter weights are silently ignored**.
That failure mode produces no error at all, which is why it went unnoticed.

## Why

Reported by @AlessioNetti in #12617 as a secondary issue. Qwen3 had the same
`layer_idx` bug and was fixed independently in #12785; that PR also added
`test_qwen3_sanity.py`. Qwen2 and Mistral were left behind. `LlamaDecoderLayer`,
`Phi3DecoderLayer`, and `Gemma3DecoderLayer` already pass `layer_idx`.

## How

- `modeling_qwen.py` — `QwenDecoderLayer`: pass `layer_idx=layer_idx` to `GatedMLP`
- `modeling_mistral.py` — `MistralDecoderLayer`: pass `layer_idx=layer_idx` to `GatedMLP`
- `modeling_mistral.py` — `MistralDecoderLayer.forward()`: `self.mlp(hidden_states, **kwargs)`

The `**kwargs` change matters: without it the `layer_idx` fix is dead code on Mistral,
because `lora_params` still never reaches the MLP. This mirrors the `**kwargs` half of
#12785 (which applied it to `modeling_qwen3_moe.py`).

## Test

New `tests/unittest/_torch/modules/tests_lora_modules/test_qwen2_mistral_sanity.py`,
covering Qwen2-0.5B-Instruct and mistral-7b-v0.1. The architecture-agnostic helpers
from `test_qwen3_sanity.py` are extracted into `lora_sanity_utils.py` and shared by
both files rather than duplicated; `test_qwen3_sanity.py` is otherwise unchanged in
behaviour.

**The adapters deliberately target only the MLP modules.** Attention LoRA works on
both models either way, so an adapter that also covered attention would still change
the output and the tests would pass with the MLP path broken — which is exactly the
Mistral bug. With MLP-only adapters, `lora_params` that never reaches the MLP means no
LoRA is applied at all, and the output comparison catches it.

The directory is already listed in `l0_b200.yml`, `l0_b300.yml`, `l0_h100.yml` and
`l0_gb300_multi_gpus.yml`, so the new file is picked up automatically.

Local red/green verification (RTX 5070, TensorRT-LLM 1.2.1) is attached in a separate
comment, along with an explicit statement of what that run does and does not cover.

## Scope

Seven other `GatedMLP` call sites also omit `layer_idx`, but none of them are affected:
HunYuan (dense and MoE) explicitly rejects LoRA (`assert lora_params is None, "LORA is
not supported for HunYuanAttention"`); GLM, Mllama and Eagle3 have no PEFT LoRA path at
all; DeepSeekV3's `lora` references are `kv_lora_rank`, i.e. MLA's low-rank projection,
unrelated to adapters; and Laguna only carries `lora_params` in an attention `forward`
signature that the model never feeds. Qwen2 and Mistral were the only two models where
LoRA is wired up but the MLP does not receive it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- `QwenDecoderLayer` and `MistralDecoderLayer` now pass `layer_idx` to `GatedMLP`.
- Mistral now forwards MLP call keyword arguments, including `lora_params`.
- These changes address Qwen2 LoRA initialization errors and Mistral MLP adapter omission.
- The current diff contains only two source files. No public API declarations or configuration files changed.
- Test execution status is not independently available.

## QA Engineer Review

No test changes.

## Per-File QA Perspective

- `tensorrt_llm/_torch/models/modeling_mistral.py`: Verify Mistral decoder-layer construction and MLP LoRA parameter forwarding. Also verify that the broader 64-line change does not alter unrelated decoder behavior.
- `tensorrt_llm/_torch/models/modeling_qwen.py`: Verify that each Qwen2 decoder MLP receives its layer index and that LoRA inference no longer raises the missing-`layer_idx` error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->