### PR TITLE
[TRTLLM-11608][feat] pipelined prefill transfer

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -757,6 +757,13 @@ public:
     std::optional<KVCacheBlock::IdType> releaseBlocks(
         GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest);
 
+    //! \brief Release the first numBlocks prefix blocks of a sequence.
+    //! \details Used by disaggregated serving to free sender-side KV memory
+    //! for blocks whose data has already been transferred.  Reuses the
+    //! detachFrontBlock mechanism (decRefCount + eviction policy release).
+    //! Cumulative: calling with 3 then 5 releases blocks 0-4 total.
+    void releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks);
+
     //! \brief Simulate freeing all blocks for that sequence to check impact on number of free blocks
     void schedulingReleaseBlocks(LlmRequest::RequestIdType requestId);
 
@@ -1252,6 +1259,13 @@ public:
 
     std::optional<KVCacheBlock::IdType> releaseBlocks(
         GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest = std::nullopt, bool pinBlocks = false);
+
+    //! \brief Release the first numBlocks prefix blocks of a sequence.
+    //! \details Mirrors detachFrontBlock logic: decRefCount + eviction policy
+    //! release for each prefix block.  The mNumFrontBlocksRemoved counter on
+    //! GenerationRequest ensures releaseBlocks (called during removeSequence)
+    //! skips already-freed prefix blocks.
+    void releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks);
 
     [[nodiscard]] std::vector<KVCacheBlock::IdType> storeBlocksForReuse(
         GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest = std::nullopt, bool pinBlocks = false);
@@ -2104,6 +2118,11 @@ public:
 
     [[nodiscard]] std::optional<KVCacheBlock::IdType> removeSequence(LlmRequest::RequestIdType requestId,
         OptionalRef<LlmRequest const> llmRequest = std::nullopt, bool pinOnRelease = false) override;
+
+    //! \brief Release prefix blocks for a sequence without removing it.
+    //! \details Used by disaggregated serving for early block release during
+    //! chunked KV cache transfer.  No-op if the sequence does not exist.
+    void releasePrefixBlocks(LlmRequest::RequestIdType requestId, SizeType32 numBlocks);
 
     void schedulingRemoveSequence(LlmRequest::RequestIdType requestId) override;
 

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -2270,6 +2270,14 @@ std::optional<KVCacheBlock::IdType> BlockManager::releaseBlocks(
     return lastStoredId;
 }
 
+void BlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks)
+{
+    for (auto& [_, manager] : mWindowBlockManagers)
+    {
+        manager.releasePrefixBlocks(sequence, numBlocks);
+    }
+}
+
 void BlockManager::pinBlocks(GenerationRequest& sequence)
 {
     for (auto& [_, manager] : mWindowBlockManagers)
@@ -2962,6 +2970,36 @@ void WindowBlockManager::detachFrontBlock(GenerationRequest& sequence)
     sequence.removeFrontBlock(mWindowSize);
 }
 
+void WindowBlockManager::releasePrefixBlocks(GenerationRequest& sequence, SizeType32 numBlocks)
+{
+    TLLM_CHECK_WITH_INFO(
+        sequence.getBeamWidth() == 1, "[kv cache manager] releasePrefixBlocks does not support beamWidth > 1");
+
+    auto const requestId = sequence.getRequestId();
+    auto& allocatedBlocks = mAllocatedBlocksPerSeq.at(requestId);
+    SizeType32 const target = std::min(numBlocks, static_cast<SizeType32>(allocatedBlocks.size()));
+
+    while (sequence.getNumFrontBlocksRemoved() < target)
+    {
+        SizeType32 const blockIdx = sequence.getNumFrontBlocksRemoved();
+        auto& block = allocatedBlocks.at(blockIdx);
+
+        TLLM_LOG_DEBUG("%s::releasePrefixBlocks - Releasing block %d from sequence %lu", mLogPrefix.c_str(),
+            block->getBlockId(), requestId);
+
+        if (block->hasRefs())
+        {
+            block->decRefCount();
+        }
+        if (!block->hasRefs())
+        {
+            mEvictionPolicy->releaseBlock(block);
+        }
+
+        sequence.removeFrontBlock(mWindowSize);
+    }
+}
+
 std::optional<BlockKey> KVCacheManager::findNewContextBlock(
     VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const
 {
@@ -3134,6 +3172,21 @@ std::optional<KVCacheBlock::IdType> KVCacheManager::removeSequence(
     TLLM_CHECK(!mBlockManager.isSequenceHeld(requestId));
     TLLM_LOG_TRACE("[%s]::%s stop", isCrossKv() ? "CROSS" : "SELF", __PRETTY_FUNCTION__);
     return lastStoredId;
+}
+
+void KVCacheManager::releasePrefixBlocks(RequestIdType requestId, SizeType32 numBlocks)
+{
+    if (numBlocks <= 0)
+    {
+        return;
+    }
+    std::scoped_lock lock(mSequencesMtx);
+    auto it = mSequences.find(requestId);
+    if (it == mSequences.end())
+    {
+        return;
+    }
+    mBlockManager.releasePrefixBlocks(it->second, numBlocks);
 }
 
 std::vector<KVCacheBlock::IdType> KVCacheManager::storeBlocksForReuse(

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -589,7 +589,9 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
         .def_prop_ro(
             "is_variable_window", [](tbk::KVCacheManager& self) { return self.getBlockManager().isVariableWindow(); })
         .def("copy_linear_attention_block", &tbk::KVCacheManager::copyLinearAttentionBlock, nb::arg("llm_request"),
-            nb::call_guard<nb::gil_scoped_release>());
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("release_prefix_blocks", &tbk::KVCacheManager::releasePrefixBlocks, nb::arg("request_id"),
+            nb::arg("num_blocks"), nb::call_guard<nb::gil_scoped_release>());
 }
 
 void tb::BasePeftCacheManagerBindings::initBindings(nb::module_& m)

--- a/tensorrt_llm/_torch/disaggregation/base/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/base/transfer.py
@@ -141,7 +141,21 @@ class TxSessionBase(_SessionBase):
         self._sender = sender
 
     @abstractmethod
-    def send(self, slice: KVSlice) -> concurrent.futures.Future: ...
+    def send(self, slice: KVSlice, chunk_block_offset: int = 0) -> concurrent.futures.Future:
+        """Send a KV slice and return a Future for the transfer.
+
+        Args:
+            slice: The KV slice describing which source blocks to send.
+            chunk_block_offset: Block offset into the receiver's full
+                destination block list for this chunk.  Used by
+                sender-side chunking to slice the receiver's
+                destination blocks correctly.  Defaults to 0
+                (monolithic transfer).
+
+        Returns:
+            A ``Future`` that resolves when the transfer completes.
+        """
+        ...
 
 
 class RxSessionBase(_SessionBase):

--- a/tensorrt_llm/_torch/disaggregation/base/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/base/transfer.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import List, Optional, cast
 
 import numpy as np
+import torch
 
 from tensorrt_llm import DisaggregatedParams
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
@@ -141,7 +142,12 @@ class TxSessionBase(_SessionBase):
         self._sender = sender
 
     @abstractmethod
-    def send(self, slice: KVSlice, chunk_block_offset: int = 0) -> concurrent.futures.Future:
+    def send(
+        self,
+        slice: KVSlice,
+        chunk_block_offset: int = 0,
+        cuda_event: Optional[torch.cuda.Event] = None,
+    ) -> concurrent.futures.Future:
         """Send a KV slice and return a Future for the transfer.
 
         Args:
@@ -151,6 +157,10 @@ class TxSessionBase(_SessionBase):
                 sender-side chunking to slice the receiver's
                 destination blocks correctly.  Defaults to 0
                 (monolithic transfer).
+            cuda_event: Optional CUDA event to synchronize before
+                initiating the RDMA transfer.  Used by pipelined
+                prefill-transfer to ensure GPU KV writes are
+                visible before GPUDirect RDMA reads.
 
         Returns:
             A ``Future`` that resolves when the transfer completes.

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -189,6 +189,10 @@ class KVSendTask(SendTaskBase):
         chunk_block_offset: Block offset into the receiver's full
             destination block list.  Used by sender-side chunking to
             slice the receiver's destination blocks correctly.
+        cuda_event: Optional CUDA event that must be synchronized
+            before the RDMA transfer begins.  Used by pipelined
+            prefill-transfer to ensure GPU writes are visible to
+            the NIC before GPUDirect RDMA reads them.
     """
 
     def __init__(
@@ -197,12 +201,14 @@ class KVSendTask(SendTaskBase):
         params: DisaggregatedParams,
         slice_id: int,
         chunk_block_offset: int = 0,
+        cuda_event: Optional[torch.cuda.Event] = None,
     ) -> None:
         super().__init__(params)
         self.slice_id = slice_id
         self.transferred_count = 0
         self._slice = kv_slice
         self.chunk_block_offset = chunk_block_offset
+        self.cuda_event = cuda_event
 
 
 class Sender(SenderBase):
@@ -395,6 +401,12 @@ class Sender(SenderBase):
             )
             return
         task.status = TaskStatus.TRANSFERRING
+
+        # For pipelined prefill-transfer: wait for the GPU forward
+        # to finish writing KV data before starting RDMA.  This
+        # blocks only this worker thread, not the GPU or main thread.
+        if task.cuda_event is not None:
+            task.cuda_event.synchronize()
 
         agent_result = AgentResult.SUCCESS
         if write_meta.src_ptrs.size > 0:
@@ -889,11 +901,22 @@ class TxSession(TxSessionBase):
             return SessionStatus.TRANSFERRING
         return SessionStatus.READY if self.receiver_ready else SessionStatus.INIT
 
-    def send(self, slice: KVSlice, chunk_block_offset: int = 0) -> concurrent.futures.Future:
+    def send(
+        self,
+        slice: KVSlice,
+        chunk_block_offset: int = 0,
+        cuda_event: Optional[torch.cuda.Event] = None,
+    ) -> concurrent.futures.Future:
         with self.lock:
             params = self._base_args.params
             slice_id = len(self.kv_tasks)
-            task = KVSendTask(slice, params, slice_id, chunk_block_offset=chunk_block_offset)
+            task = KVSendTask(
+                slice,
+                params,
+                slice_id,
+                chunk_block_offset=chunk_block_offset,
+                cuda_event=cuda_event,
+            )
             self.kv_tasks.append(task)
             req_info_snapshot = dict(self._sender._get_req_info(task._unique_rid) or {})
         self._sender.dispatch_task(task, req_info_snapshot)

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -8,7 +8,7 @@ import time
 import weakref
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import msgpack
 import numpy as np
@@ -180,16 +180,29 @@ class AuxSendTask(SendTaskBase):
 
 
 class KVSendTask(SendTaskBase):
+    """A per-slice send task within a TxSession.
+
+    Args:
+        kv_slice: The KV slice describing which blocks to transfer.
+        params: Disaggregated serving parameters for this request.
+        slice_id: Index of this slice within the session's task list.
+        chunk_block_offset: Block offset into the receiver's full
+            destination block list.  Used by sender-side chunking to
+            slice the receiver's destination blocks correctly.
+    """
+
     def __init__(
         self,
         kv_slice: KVSlice,
         params: DisaggregatedParams,
         slice_id: int,
-    ):
+        chunk_block_offset: int = 0,
+    ) -> None:
         super().__init__(params)
         self.slice_id = slice_id
         self.transferred_count = 0
         self._slice = kv_slice
+        self.chunk_block_offset = chunk_block_offset
 
 
 class Sender(SenderBase):
@@ -398,13 +411,19 @@ class Sender(SenderBase):
         if timer:
             timer.record_transfer_end(write_meta.peer_rank)
 
-        ## TODO: just last slice need to send task state?
+        # The receiver always has a single monolithic task (slice_id=0).
+        # Sender-side chunking is transparent to the receiver: only the
+        # last chunk carries is_last_slice=True so the receiver knows
+        # when all data has arrived.  Intermediate chunk results are
+        # sent (not suppressed) so that RDMA failures propagate to the
+        # receiver immediately rather than requiring a timeout.
+        receiver_slice_id = 0
         self._get_or_connect_dealer(write_meta.peer_endpoint).send(
             [
                 MessageType.KV_AGENT_RESULT,
                 str(self._instance_rank).encode("ascii"),
                 str(write_meta.unique_rid).encode("ascii"),
-                str(write_meta.slice_id).encode("ascii"),
+                str(receiver_slice_id).encode("ascii"),
                 str(write_meta.is_last_slice).encode("ascii"),
                 agent_result.value.encode("ascii"),
             ]
@@ -428,6 +447,29 @@ class Sender(SenderBase):
             else:
                 write_meta.task_future.set_result(AgentResult.SUCCESS)
                 task.status = TaskStatus.TRANSFERRED
+                if session._on_chunk_transferred is not None:
+                    try:
+                        # Use the max across layer groups as the
+                        # cumulative release count.  For asymmetric
+                        # layer groups (e.g., sliding window), shorter
+                        # groups may have fewer blocks per chunk, but
+                        # each WindowBlockManager independently clamps
+                        # to its own allocated block count via
+                        # min(numBlocks, allocatedBlocks.size()).
+                        num_blocks = max(
+                            (len(ids) for ids in task._slice.block_ids_per_layer_groups),
+                            default=0,
+                        )
+                        session._on_chunk_transferred(
+                            request_id=session.request_id,
+                            chunk_block_offset=task.chunk_block_offset,
+                            num_blocks=num_blocks,
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"on_chunk_transferred callback failed for "
+                            f"request {session.request_id} slice {write_meta.slice_id}: {e}"
+                        )
 
         logger.debug(
             f"deliver_kv_to_agent completed: unique_rid={write_meta.unique_rid}, "
@@ -522,10 +564,20 @@ class Sender(SenderBase):
             dst_block_ids_per_groups = req_info.block_ids_per_layer_groups
             src_block_ids_per_groups = task._slice.block_ids_per_layer_groups
 
-            # Aggregate fragments from all matching pools using numpy concatenation
+            chunk_offset = task.chunk_block_offset
             for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
                 src_block_ids = src_block_ids_per_groups[self_lg]
-                dst_block_ids = dst_block_ids_per_groups[peer_lg]
+                full_dst_block_ids = dst_block_ids_per_groups[peer_lg]
+
+                # When sender uses chunking, the receiver sends all dst
+                # blocks in a single RecvReqInfo.  Slice dst to match
+                # this task's src chunk position.
+                if chunk_offset > 0 or len(src_block_ids) < len(full_dst_block_ids):
+                    dst_block_ids = full_dst_block_ids[
+                        chunk_offset : chunk_offset + len(src_block_ids)
+                    ]
+                else:
+                    dst_block_ids = full_dst_block_ids
 
                 if src_block_ids.size + 1 == dst_block_ids.size:
                     # FIXME: this is a temporary solution, need to be fixed for the draft tokens
@@ -801,6 +853,7 @@ class TxSession(TxSessionBase):
         sender: Sender,
         aux_buffer: Optional[AuxBuffer] = None,
         timeout_s: Optional[float] = None,
+        on_chunk_transferred: Optional[Callable] = None,
     ):
         super().__init__(sender, SessionArgsBase(params))
         self._timeout_s = timeout_s
@@ -813,6 +866,7 @@ class TxSession(TxSessionBase):
         self.kv_tasks = []
         self.aux_task = None
         self.lock = threading.Lock()
+        self._on_chunk_transferred = on_chunk_transferred
 
         self._exception: Optional[Exception] = None
         self._closed = False
@@ -835,11 +889,11 @@ class TxSession(TxSessionBase):
             return SessionStatus.TRANSFERRING
         return SessionStatus.READY if self.receiver_ready else SessionStatus.INIT
 
-    def send(self, slice: KVSlice) -> concurrent.futures.Future:
+    def send(self, slice: KVSlice, chunk_block_offset: int = 0) -> concurrent.futures.Future:
         with self.lock:
             params = self._base_args.params
             slice_id = len(self.kv_tasks)
-            task = KVSendTask(slice, params, slice_id)
+            task = KVSendTask(slice, params, slice_id, chunk_block_offset=chunk_block_offset)
             self.kv_tasks.append(task)
             req_info_snapshot = dict(self._sender._get_req_info(task._unique_rid) or {})
         self._sender.dispatch_task(task, req_info_snapshot)
@@ -1493,7 +1547,23 @@ class TransferWorker:
         self._rank_info.sender_endpoints = endpoints
         self._rank_info.layer_num_per_pp = layer_num_per_pp
 
-    def create_tx_session(self, request: LlmRequest) -> TxSession:
+    def create_tx_session(
+        self,
+        request: LlmRequest,
+        on_chunk_transferred: Optional[Callable] = None,
+    ) -> TxSession:
+        """Create a TxSession for the given request.
+
+        Args:
+            request: The LLM request to create a send session for.
+            on_chunk_transferred: Optional callback invoked on the
+                sender worker thread after each chunk's RDMA completes.
+                Signature: ``(request_id: int, chunk_block_offset: int,
+                num_blocks: int) -> None``.
+
+        Returns:
+            A new ``TxSession`` ready to accept ``send()`` calls.
+        """
         params = request.py_disaggregated_params
         assert params is not None
         return TxSession(
@@ -1502,6 +1572,7 @@ class TransferWorker:
             sender=self._sender,
             aux_buffer=self._aux_buffer,
             timeout_s=self._config.tx_timeout_s,
+            on_chunk_transferred=on_chunk_transferred,
         )
 
     def create_rx_session(self, request: LlmRequest) -> RxSession:

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -94,8 +94,11 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self._page_table = self._transfer_worker.page_table
         self._is_v2_manager = isinstance(kv_cache_manager, KVCacheManagerV2)
         self._chunk_size_blocks = cache_transceiver_config.chunk_size_blocks
+        self._enable_pipelined_transfer = cache_transceiver_config.enable_pipelined_transfer
         self._pending_prefix_releases: queue.Queue[Tuple[int, int]] = queue.Queue()
         self._chunk_callback: Optional[Callable] = self._make_chunk_callback()
+        # Track per-request pipelined chunk state: maps rid -> chunk_block_offset
+        self._pipelined_chunk_offsets: Dict[int, int] = {}
 
     def _broadcast_instance_name(self) -> str:
         if self._dist.rank == 0:
@@ -403,6 +406,81 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             req.context_phase_params.first_gen_tokens = first_gen_tokens
             req.context_phase_params.draft_tokens = draft_tokens
 
+    @property
+    def enable_pipelined_transfer(self) -> bool:
+        """Whether pipelined prefill-transfer is enabled."""
+        return self._enable_pipelined_transfer and self._chunk_size_blocks is not None
+
+    def send_prefill_chunk(
+        self,
+        req: LlmRequest,
+        chunk_start_block: int,
+        chunk_end_block: int,
+        is_last_chunk: bool,
+    ) -> None:
+        """Send one prefill chunk's KV data during ongoing prefill.
+
+        Called after each prefill chunk completes (before the next
+        chunk's forward begins).  Creates the TxSession on the first
+        call for a request and adds slices incrementally.  A CUDA
+        event is recorded on the current stream to ensure GPU writes
+        are visible before RDMA.
+
+        Args:
+            req: The context-only request being prefilled.
+            chunk_start_block: First block index for this chunk
+                (across layer groups).
+            chunk_end_block: One-past-last block index for this chunk.
+            is_last_chunk: Whether this is the final prefill chunk.
+                When True, aux data is sent and context_phase_params
+                is populated.
+        """
+        rid = get_unique_rid(req)
+        assert rid is not None
+
+        cuda_event = torch.cuda.Event()
+        cuda_event.record()
+
+        if rid not in self._send_sessions:
+            callback = self._chunk_callback if req.sampling_config.beam_width <= 1 else None
+            self._send_sessions[rid] = self._transfer_worker.create_tx_session(
+                req, on_chunk_transferred=callback
+            )
+            self._pipelined_chunk_offsets[rid] = 0
+
+        session = self._send_sessions[rid]
+        chunk_block_offset = self._pipelined_chunk_offsets[rid]
+
+        chunk_block_ids = []
+        assert self._page_table is not None
+        for idx, lg in enumerate(self._page_table.layer_groups):
+            block_ids = self._get_block_ids(req, idx, lg)
+            chunk_block_ids.append(block_ids[chunk_start_block:chunk_end_block])
+
+        kv_slice = KVSlice(
+            is_last_slice=is_last_chunk,
+            block_ids_per_layer_groups=chunk_block_ids,
+        )
+        session.send(kv_slice, chunk_block_offset=chunk_block_offset, cuda_event=cuda_event)
+
+        num_blocks_this_chunk = max((len(ids) for ids in chunk_block_ids), default=0)
+        self._pipelined_chunk_offsets[rid] = chunk_block_offset + num_blocks_this_chunk
+
+        if is_last_chunk:
+            if self._need_aux_transfer(req):
+                session.pack_aux(req)
+                session.send_aux()
+            req.context_phase_params = ContextPhaseParams(
+                first_gen_tokens=[],
+                req_id=rid,
+                opaque_state=None,
+                draft_tokens=None,
+                ctx_dp_rank=self._dp_rank,
+                disagg_info_endpoint=self._context_info_endpoint,
+            )
+            self._send_reqs[rid] = req
+            self._pipelined_chunk_offsets.pop(rid, None)
+
     @nvtx_range("KvCacheTransceiverV2.respond_and_send_async")
     def respond_and_send_async(self, req: LlmRequest) -> None:
         """Start background KV cache transfer to the generation server.
@@ -412,29 +490,39 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         that supports ``release_prefix_blocks``, a per-chunk callback is
         attached for early prefix block release.
 
+        When pipelined transfer is enabled and chunks were already sent
+        via ``send_prefill_chunk``, this method skips re-sending the
+        KV data (it was already sent incrementally during prefill).
+
         Args:
             req: The completed context request whose KV cache to transfer.
         """
         rid = get_unique_rid(req)
         assert rid is not None
-        if rid not in self._send_sessions:
-            # Skip early release for beam_width > 1: the C++ releasePrefixBlocks
-            # asserts beamWidth == 1.  Chunking still works (reduced descriptor
-            # pressure) but blocks are freed at session teardown instead.
-            callback = self._chunk_callback if req.sampling_config.beam_width <= 1 else None
-            self._send_sessions[rid] = self._transfer_worker.create_tx_session(
-                req, on_chunk_transferred=callback
-            )
-        session = self._send_sessions[rid]
-        req.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
 
-        kv_slices = self._create_kv_slices(req)
-        chunk_block_offset = 0
-        for kv_slice in kv_slices:
-            session.send(kv_slice, chunk_block_offset=chunk_block_offset)
-            chunk_block_offset += max(
-                (len(ids) for ids in kv_slice.block_ids_per_layer_groups), default=0
-            )
+        # If pipelined transfer already sent all chunks, skip re-sending.
+        pipelined_complete = rid in self._send_sessions and rid not in self._pipelined_chunk_offsets
+
+        if not pipelined_complete:
+            if rid not in self._send_sessions:
+                callback = self._chunk_callback if req.sampling_config.beam_width <= 1 else None
+                self._send_sessions[rid] = self._transfer_worker.create_tx_session(
+                    req, on_chunk_transferred=callback
+                )
+            session = self._send_sessions[rid]
+            req.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
+
+            kv_slices = self._create_kv_slices(req)
+            chunk_block_offset = 0
+            for kv_slice in kv_slices:
+                session.send(kv_slice, chunk_block_offset=chunk_block_offset)
+                chunk_block_offset += max(
+                    (len(ids) for ids in kv_slice.block_ids_per_layer_groups), default=0
+                )
+        else:
+            req.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
+
+        session = self._send_sessions[rid]
         if self._need_aux_transfer(req):
             session.pack_aux(req)
             session.send_aux()

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -1,7 +1,9 @@
+import math
+import queue
 import uuid
 from collections import defaultdict
 from itertools import chain
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 
 import numpy as np
 import torch
@@ -91,6 +93,9 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self._wait_reqs = {}
         self._page_table = self._transfer_worker.page_table
         self._is_v2_manager = isinstance(kv_cache_manager, KVCacheManagerV2)
+        self._chunk_size_blocks = cache_transceiver_config.chunk_size_blocks
+        self._pending_prefix_releases: queue.Queue[Tuple[int, int]] = queue.Queue()
+        self._chunk_callback: Optional[Callable] = self._make_chunk_callback()
 
     def _broadcast_instance_name(self) -> str:
         if self._dist.rank == 0:
@@ -206,6 +211,116 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             mamba_state_index=mamba_state_index,
         )
 
+    def _collect_block_ids(self, req: LlmRequest) -> List[List[int]]:
+        """Collect all valid block IDs per layer group for a request.
+
+        Args:
+            req: The LLM request whose KV cache block IDs to collect.
+
+        Returns:
+            A list of block ID lists, one per layer group.  Each inner
+            list contains the physical block IDs for that layer group,
+            filtered for sliding-window relevance.
+        """
+        return self._create_kv_slice(req).block_ids_per_layer_groups
+
+    def _create_kv_slices(self, req: LlmRequest) -> List[KVSlice]:
+        """Create one or more KVSlice objects for a request.
+
+        When ``chunk_size_blocks`` is ``None``, returns a single slice
+        covering all blocks.  Otherwise, each layer group's block ID
+        list is partitioned into slices of at most ``chunk_size_blocks``
+        blocks.
+
+        Args:
+            req: The LLM request to create slices for.
+
+        Returns:
+            A list of ``KVSlice`` objects.  Only the last slice has
+            ``is_last_slice=True``.
+
+        Raises:
+            AssertionError: If the reassembled block IDs from all slices
+                do not match the original block IDs.
+        """
+        all_block_ids = self._collect_block_ids(req)
+
+        if self._chunk_size_blocks is None:
+            return [KVSlice(is_last_slice=True, block_ids_per_layer_groups=all_block_ids)]
+
+        max_blocks = max((len(ids) for ids in all_block_ids), default=0)
+        if max_blocks == 0:
+            return [KVSlice(is_last_slice=True, block_ids_per_layer_groups=all_block_ids)]
+
+        num_chunks = math.ceil(max_blocks / self._chunk_size_blocks)
+        slices: List[KVSlice] = []
+        for chunk_idx in range(num_chunks):
+            start = chunk_idx * self._chunk_size_blocks
+            end = start + self._chunk_size_blocks
+            is_last = chunk_idx == num_chunks - 1
+
+            chunk_block_ids = [ids[start:end] for ids in all_block_ids]
+            slices.append(
+                KVSlice(is_last_slice=is_last, block_ids_per_layer_groups=chunk_block_ids)
+            )
+
+        for lg_idx, original_ids in enumerate(all_block_ids):
+            reassembled = []
+            for s in slices:
+                reassembled.extend(s.block_ids_per_layer_groups[lg_idx])
+            assert reassembled == original_ids, (
+                f"Chunking integrity check failed for layer group {lg_idx}: "
+                f"expected {len(original_ids)} blocks, got {len(reassembled)}"
+            )
+
+        return slices
+
+    def _make_chunk_callback(self) -> Optional[Callable]:
+        """Return a callback for early prefix block release.
+
+        The callback is invoked on the sender worker thread after each
+        chunk's RDMA finishes.  It enqueues a release request that the
+        main thread drains via ``_drain_pending_releases``.
+
+        Early release is disabled when:
+        - ``chunk_size_blocks`` is not set (no chunking)
+        - The KV cache manager does not support ``release_prefix_blocks``
+
+        The callback is created once at init time and shared across all
+        sessions (all sessions use the same release queue).
+
+        Returns:
+            A callback ``(request_id, chunk_block_offset, num_blocks) -> None``
+            if chunking is enabled and the KV cache manager supports
+            ``release_prefix_blocks``, otherwise ``None``.
+        """
+        if self._chunk_size_blocks is None:
+            return None
+        if not hasattr(self._kv_cache_manager, "release_prefix_blocks"):
+            return None
+
+        release_queue = self._pending_prefix_releases
+
+        def _on_chunk_transferred(request_id: int, chunk_block_offset: int, num_blocks: int):
+            cumulative_blocks = chunk_block_offset + num_blocks
+            release_queue.put((request_id, cumulative_blocks))
+
+        return _on_chunk_transferred
+
+    def _drain_pending_releases(self) -> None:
+        """Process all queued prefix block releases on the main thread.
+
+        Drains the ``_pending_prefix_releases`` queue and calls
+        ``release_prefix_blocks`` on the KV cache manager for each
+        entry.  Must be called from the main executor thread only.
+        """
+        while True:
+            try:
+                request_id, num_blocks = self._pending_prefix_releases.get_nowait()
+            except queue.Empty:
+                break
+            self._kv_cache_manager.release_prefix_blocks(request_id, num_blocks)
+
     @staticmethod
     def _need_aux_transfer(req: LlmRequest) -> bool:
         params = req.py_disaggregated_params
@@ -289,14 +404,37 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             req.context_phase_params.draft_tokens = draft_tokens
 
     @nvtx_range("KvCacheTransceiverV2.respond_and_send_async")
-    def respond_and_send_async(self, req: LlmRequest):
+    def respond_and_send_async(self, req: LlmRequest) -> None:
+        """Start background KV cache transfer to the generation server.
+
+        Creates (or reuses) a ``TxSession`` and sends each KV slice with
+        its chunk block offset.  When chunking is enabled with a manager
+        that supports ``release_prefix_blocks``, a per-chunk callback is
+        attached for early prefix block release.
+
+        Args:
+            req: The completed context request whose KV cache to transfer.
+        """
         rid = get_unique_rid(req)
         assert rid is not None
         if rid not in self._send_sessions:
-            self._send_sessions[rid] = self._transfer_worker.create_tx_session(req)
+            # Skip early release for beam_width > 1: the C++ releasePrefixBlocks
+            # asserts beamWidth == 1.  Chunking still works (reduced descriptor
+            # pressure) but blocks are freed at session teardown instead.
+            callback = self._chunk_callback if req.sampling_config.beam_width <= 1 else None
+            self._send_sessions[rid] = self._transfer_worker.create_tx_session(
+                req, on_chunk_transferred=callback
+            )
         session = self._send_sessions[rid]
         req.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
-        session.send(self._create_kv_slice(req))
+
+        kv_slices = self._create_kv_slices(req)
+        chunk_block_offset = 0
+        for kv_slice in kv_slices:
+            session.send(kv_slice, chunk_block_offset=chunk_block_offset)
+            chunk_block_offset += max(
+                (len(ids) for ids in kv_slice.block_ids_per_layer_groups), default=0
+            )
         if self._need_aux_transfer(req):
             session.pack_aux(req)
             session.send_aux()
@@ -314,7 +452,17 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         raise NotImplementedError("request_and_receive_sync is not implemented")
 
     @nvtx_range("KvCacheTransceiverV2.request_and_receive_async")
-    def request_and_receive_async(self, req: LlmRequest):
+    def request_and_receive_async(self, req: LlmRequest) -> None:
+        """Start background KV cache receive from the context server.
+
+        The receiver always uses a single monolithic slice.  Chunking is
+        sender-only: the sender splits its source blocks into chunks and
+        slices the receiver's destination blocks to match each chunk.
+
+        Args:
+            req: The generation request whose KV cache blocks to receive
+                into.
+        """
         rid = get_unique_rid(req)
         if rid in self._recv_sessions:
             logger.warning(
@@ -324,12 +472,16 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         req.state = LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS
         session = self._transfer_worker.create_rx_session(req)
         self._recv_sessions[rid] = session
-        session.receive(self._create_kv_slice(req))
+        all_block_ids = self._collect_block_ids(req)
+        full_slice = KVSlice(is_last_slice=True, block_ids_per_layer_groups=all_block_ids)
+        session.receive(full_slice)
         self._recv_reqs[rid] = req
 
     def check_context_transfer_status(
         self, at_least_request_num: Optional[int], mark_complete: bool = False
     ):
+        self._drain_pending_releases()
+
         block_all = at_least_request_num is None
         wait_num = at_least_request_num if not block_all else 0
 

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -94,6 +94,11 @@ def create_kv_cache_transceiver(
 
 class KvCacheTransceiver(ABC):
 
+    @property
+    def enable_pipelined_transfer(self) -> bool:
+        """Whether pipelined prefill-transfer is enabled."""
+        return False
+
     @abstractmethod
     def respond_and_send_async(self, req: LlmRequest):
         raise NotImplementedError

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3092,6 +3092,39 @@ class PyExecutor:
 
         return
 
+    def _maybe_send_prefill_chunk(self, request: LlmRequest) -> None:
+        """Send the just-completed prefill chunk's KV data if pipelined transfer is enabled.
+
+        Called from ``_update_request_states_tp`` after each context chunk's
+        ``move_to_next_context_chunk()``.  Converts token positions to block
+        indices and dispatches the chunk to the transceiver.
+
+        Args:
+            request: The context-only request whose chunk just completed.
+        """
+        if not self.kv_cache_transceiver:
+            return
+        if not request.is_context_only_request:
+            return
+        if not self.kv_cache_transceiver.enable_pipelined_transfer:
+            return
+        if request.is_finished_due_to_cancellation:
+            return
+
+        chunk_start_pos, chunk_end_pos = request.py_last_context_chunk
+        tpb = self.kv_cache_manager.tokens_per_block
+
+        chunk_start_block = chunk_start_pos // tpb
+        chunk_end_block = (chunk_end_pos + tpb - 1) // tpb
+        is_last_chunk = request.context_remaining_length == 0
+
+        self.kv_cache_transceiver.send_prefill_chunk(
+            request,
+            chunk_start_block=chunk_start_block,
+            chunk_end_block=chunk_end_block,
+            is_last_chunk=is_last_chunk,
+        )
+
     @nvtx_range("_send_kv_async")
     def _send_kv_async(self, scheduled_requests: List[LlmRequest]):
 
@@ -3272,6 +3305,9 @@ class PyExecutor:
                     request.context_current_position +
                     request.context_chunk_size)
                 request.move_to_next_context_chunk()
+
+                self._maybe_send_prefill_chunk(request)
+
             if request.context_remaining_length == 0:
                 if not self.disable_overlap_scheduler and request.will_complete_next_iteration(
                 ):

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -830,6 +830,24 @@ class KVCacheManager(BaseResourceManager):
         return self.impl.remove_sequence(request.py_request_id, request,
                                          pin_on_release)
 
+    def release_prefix_blocks(self, request_id: int, num_blocks: int) -> None:
+        """Release leading blocks from a request's V1 KV cache.
+
+        Used by disaggregated serving to free sender-side KV memory
+        for blocks whose data has already been transferred.  The
+        underlying C++ ``KVCacheManager::releasePrefixBlocks`` frees
+        blocks via the eviction policy so they can be reused.
+
+        Args:
+            request_id: The request whose KV cache to partially free.
+            num_blocks: Number of leading blocks to release
+                (cumulative from the start of the sequence).
+
+        Note:
+            No-op if the sequence does not exist (already removed).
+        """
+        self.impl.release_prefix_blocks(request_id, num_blocks)
+
     def store_blocks_for_reuse(self,
                                request: LlmRequest,
                                pin_blocks: bool = False):

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2374,6 +2374,28 @@ class KVCacheManagerV2(BaseResourceManager):
         kv_cache.close()
         self.index_mapper.remove_sequence(request.py_request_id)
 
+    def release_prefix_blocks(self, request_id: int, num_blocks: int) -> None:
+        """Release leading blocks from a request's V2 KV cache.
+
+        Used by disaggregated serving to free sender-side KV memory
+        for blocks whose data has already been transferred.  The
+        underlying ``_KVCache.release_prefix`` returns the physical
+        slots to the pool so they can be reused by other requests.
+
+        Args:
+            request_id: The request whose KV cache to partially free.
+            num_blocks: Number of leading blocks to release
+                (cumulative from the start of the sequence).
+
+        Note:
+            No-op if the request is not found in ``kv_cache_map``
+            (e.g. V1 path or already freed).
+        """
+        kv_cache = self.kv_cache_map.get(request_id)
+        if kv_cache is None:
+            return
+        kv_cache.release_prefix(num_blocks)
+
     def get_batch_cache_indices(self,
                                 request_ids: List[int],
                                 layer_id: int = 0) -> List[List[int]]:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2439,7 +2439,22 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         "Timeout in milliseconds to wait for the sender future to be ready when scheduled batch size is 0. This allows the request to be eventually cancelled by the user or because of kv_transfer_timeout_ms"
     )
 
+    chunk_size_blocks: Optional[PositiveInt] = Field(
+        default=None,
+        description=
+        "Maximum number of KV cache blocks per layer group per chunk for "
+        "chunked KV cache transfer. When set, each layer group's block list "
+        "is partitioned into slices of at most this many blocks, and each "
+        "slice is transferred independently. The total data per chunk is "
+        "approximately chunk_size_blocks * num_layer_groups * slot_bytes. "
+        "This reduces per-transfer NIXL descriptor pressure for long "
+        "sequences. When None (default), the entire KV cache is transferred "
+        "in a single slice. Only effective with the Python transceiver "
+        "(transceiver_runtime='PYTHON').")
+
     def _to_pybind(self):
+        # chunk_size_blocks is consumed by the Python transceiver only
+        # and has no C++ counterpart, so it is intentionally omitted.
         return _CacheTransceiverConfig(
             backend=_CacheTransceiverBackendType.from_string(self.backend),
             max_tokens_in_buffer=self.max_tokens_in_buffer,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2452,9 +2452,18 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         "in a single slice. Only effective with the Python transceiver "
         "(transceiver_runtime='PYTHON').")
 
+    enable_pipelined_transfer: bool = Field(
+        default=False,
+        description="When True, start transferring each prefill chunk's KV cache "
+        "as soon as its prefill completes, overlapping GPU compute "
+        "with RDMA transfer. Requires chunk_size_blocks to be set. "
+        "Only effective with the Python transceiver and chunked "
+        "prefill (enable_chunked_context=True). When False (default), "
+        "all prefill chunks complete before any transfer begins.")
+
     def _to_pybind(self):
-        # chunk_size_blocks is consumed by the Python transceiver only
-        # and has no C++ counterpart, so it is intentionally omitted.
+        # chunk_size_blocks and enable_pipelined_transfer are consumed
+        # by the Python transceiver only and have no C++ counterpart.
         return _CacheTransceiverConfig(
             backend=_CacheTransceiverBackendType.from_string(self.backend),
             max_tokens_in_buffer=self.max_tokens_in_buffer,

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
@@ -181,6 +181,9 @@ class _KVCache:
     def get_base_page_indices(
         self, layer_group_id: LayerGroupId, beam_id: BeamIndex = DEFAULT_BEAM_INDEX
     ) -> IndexSeq: ...
+    def get_ssm_block_base_index(
+        self, layer_group_id: LayerGroupId, beam_id: BeamIndex = DEFAULT_BEAM_INDEX
+    ) -> int: ...
     def get_aggregated_page_indices(
         self,
         layer_group_id: LayerGroupId,

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -179,6 +179,7 @@ class _KVCache:
         "_avg_capacity",
         "_ssm_blocks",
         "_never_resumed",
+        "_num_released_prefix_blocks",
         "__rawref__",
     )
 
@@ -250,6 +251,7 @@ class _KVCache:
             self.beam_width,
         )
         self._never_resumed = True
+        self._num_released_prefix_blocks = 0
         self.__rawref__ = rawref.NULL
         if input_tokens is not None:
             self._setup_for_reuse(input_tokens)
@@ -1062,12 +1064,16 @@ class _KVCache:
         for ordinal, block in typed_enumerate(self._blocks):
             is_committed = ordinal < self._num_committed_blocks
             assert is_committed == block.is_committed
+            prefix_released = ordinal < self._num_released_prefix_blocks
             for beam_block in block.pages:
                 assert typed_len(beam_block) == num_life_cycles
                 for lc in typed_range(num_life_cycles):
                     holder = beam_block[lc]
                     if lc == ssm_lc_id:
                         # SSM pages live in _ssm_blocks, not in _blocks
+                        assert holder is None
+                        continue
+                    if prefix_released:
                         assert holder is None
                         continue
                     start, end = stale_ranges[lc]
@@ -1246,6 +1252,42 @@ class _KVCache:
         if ssm_lc_id is not None:
             for beam_block in self._ssm_blocks:
                 beam_block[ssm_lc_id] = None
+
+    def release_prefix(self, num_blocks: int) -> None:
+        """Release page holders for the first ``num_blocks`` blocks.
+
+        Used by disaggregated serving to free sender-side KV memory
+        for blocks whose data has already been transferred.  The page
+        holders within each ``SeqBlock`` are set to ``None``, which
+        drops the ``_PageHolder`` references and triggers
+        ``schedule_for_eviction`` on committed pages.  The ``_blocks``
+        list itself is **not** shortened so that block ordinals and
+        ``close()`` / ``stop_committing()`` invariants are preserved.
+
+        Args:
+            num_blocks: Number of leading blocks to release.  Clamped
+                to ``len(self._blocks)`` if larger.
+
+        Note:
+            Callers must ensure that no in-flight RDMA reads reference
+            the released blocks.
+        """
+        if num_blocks <= 0:
+            return
+        num_blocks = min(num_blocks, len(self._blocks))
+
+        with self._record_event():
+            for i in range(num_blocks):
+                block = self._blocks[i]
+                for beam_pages in block.pages:
+                    for lc_idx in range(len(beam_pages)):
+                        beam_pages[lc_idx] = None
+
+        for beam_indices in self._base_page_indices:
+            for indices in beam_indices:
+                for i in range(min(num_blocks, len(indices))):
+                    indices[i] = BAD_PAGE_INDEX
+        self._num_released_prefix_blocks = max(self._num_released_prefix_blocks, num_blocks)
 
     @contextmanager
     def _record_event(self) -> Iterator[None]:

--- a/tests/unittest/disaggregated/test_chunked_transfer.py
+++ b/tests/unittest/disaggregated/test_chunked_transfer.py
@@ -1,0 +1,373 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for chunked KV cache transfer (sender-only chunking).
+
+These tests validate the session state machine, callback plumbing, and
+release queue mechanics using the real TxSession/RxSession classes with
+lightweight stub sender/receiver objects.
+"""
+
+import queue
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensorrt_llm import DisaggregatedParams
+from tensorrt_llm._torch.disaggregation.base.transfer import KVSlice, SessionStatus, WaitResult
+from tensorrt_llm._torch.disaggregation.native.transfer import (
+    AgentResult,
+    KVSendTask,
+    RxSession,
+    TaskStatus,
+    TxSession,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_params(rid: int = 42) -> DisaggregatedParams:
+    return DisaggregatedParams(disagg_request_id=rid)
+
+
+def _stub_sender():
+    """Create a stub sender with no-op methods needed by TxSession."""
+    sender = MagicMock()
+    sender.setup_session = MagicMock()
+    sender._get_req_info = MagicMock(return_value=None)
+    sender.dispatch_task = MagicMock()
+    return sender
+
+
+def _stub_receiver():
+    """Create a stub receiver with no-op methods needed by RxSession."""
+    receiver = MagicMock()
+    receiver.setup_session = MagicMock()
+    receiver.dispatch_task = MagicMock()
+    return receiver
+
+
+def _make_tx_session(num_slices: int, rid: int = 42, **kwargs) -> TxSession:
+    """Create a real TxSession and send num_slices slices into it."""
+    params = _make_params(rid)
+    session = TxSession(
+        request_id=rid,
+        params=params,
+        sender=_stub_sender(),
+        aux_slot=None,
+        **kwargs,
+    )
+    for i in range(num_slices):
+        s = KVSlice(
+            is_last_slice=(i == num_slices - 1),
+            block_ids_per_layer_groups=[[i]],
+        )
+        session.send(s, chunk_block_offset=i)
+    return session
+
+
+def _make_rx_session(num_slices: int, rid: int = 42) -> RxSession:
+    """Create a real RxSession and receive num_slices slices into it."""
+    params = _make_params(rid)
+    session = RxSession(
+        request_id=rid,
+        params=params,
+        receiver=_stub_receiver(),
+        aux_slot=None,
+    )
+    for i in range(num_slices):
+        s = KVSlice(
+            is_last_slice=(i == num_slices - 1),
+            block_ids_per_layer_groups=[[i]],
+        )
+        session.receive(s)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# KVSendTask tests
+# ---------------------------------------------------------------------------
+
+
+def test_kv_send_task_chunk_block_offset():
+    """KVSendTask stores chunk_block_offset correctly."""
+    s = KVSlice(is_last_slice=False, block_ids_per_layer_groups=[[0, 1]])
+    task = KVSendTask(s, _make_params(), slice_id=1, chunk_block_offset=512)
+    assert task.chunk_block_offset == 512
+    assert task.slice_id == 1
+    assert task._slice is s
+
+
+def test_kv_send_task_default_offset():
+    """Default chunk_block_offset is 0."""
+    s = KVSlice(is_last_slice=True, block_ids_per_layer_groups=[[0]])
+    task = KVSendTask(s, _make_params(), slice_id=0)
+    assert task.chunk_block_offset == 0
+
+
+# ---------------------------------------------------------------------------
+# TxSession multi-slice status tests (real class)
+# ---------------------------------------------------------------------------
+
+
+def test_tx_session_status_init_until_all_transferred():
+    """TxSession status is not KV_TRANSFERRED until ALL tasks complete."""
+    session = _make_tx_session(3)
+    session.receiver_ready = True
+    assert session.status == SessionStatus.TRANSFERRING or session.status == SessionStatus.READY
+
+    session.kv_tasks[0].status = TaskStatus.TRANSFERRED
+    assert session.status != SessionStatus.KV_TRANSFERRED
+
+    session.kv_tasks[1].status = TaskStatus.TRANSFERRED
+    assert session.status != SessionStatus.KV_TRANSFERRED
+
+    session.kv_tasks[2].status = TaskStatus.TRANSFERRED
+    assert session.status == SessionStatus.KV_TRANSFERRED
+
+
+def test_tx_session_status_error_on_any_failure():
+    """TxSession status is ERROR if any task fails."""
+    session = _make_tx_session(3)
+    session.kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session.kv_tasks[1].status = TaskStatus.ERROR
+    assert session.status == SessionStatus.ERROR
+
+
+def test_tx_session_wait_complete_all_tasks():
+    """TxSession.wait_complete blocks on all task futures."""
+    session = _make_tx_session(3)
+    for task in session.kv_tasks:
+        task.future.set_result(AgentResult.SUCCESS)
+        task.status = TaskStatus.TRANSFERRED
+
+    result = session.wait_complete(need_aux=False, timeout=1.0)
+    assert result == WaitResult.COMPLETED
+
+
+def test_tx_session_wait_complete_fails_on_partial_failure():
+    """TxSession.wait_complete returns FAILED if any task fails."""
+    session = _make_tx_session(3)
+    session.kv_tasks[0].future.set_result(AgentResult.SUCCESS)
+    session.kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session.kv_tasks[1].future.set_result(AgentResult.FAILED)
+    session.kv_tasks[1].status = TaskStatus.ERROR
+    session.kv_tasks[2].future.set_result(AgentResult.SUCCESS)
+    session.kv_tasks[2].status = TaskStatus.TRANSFERRED
+
+    result = session.wait_complete(need_aux=False, timeout=1.0)
+    assert result == WaitResult.FAILED
+
+
+# ---------------------------------------------------------------------------
+# RxSession multi-slice status tests (real class)
+# ---------------------------------------------------------------------------
+
+
+def test_rx_session_status_checks_all_tasks():
+    """RxSession status is KV_TRANSFERRED only when ALL tasks complete."""
+    session = _make_rx_session(3)
+    assert session.status == SessionStatus.INIT
+
+    session._kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[1].status = TaskStatus.TRANSFERRING
+    assert session.status == SessionStatus.TRANSFERRING
+
+    session._kv_tasks[1].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[2].status = TaskStatus.TRANSFERRED
+    assert session.status == SessionStatus.KV_TRANSFERRED
+
+
+def test_rx_session_status_error_on_any_failure():
+    """RxSession status is ERROR if any task fails."""
+    session = _make_rx_session(2)
+    session._kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[1].status = TaskStatus.ERROR
+    assert session.status == SessionStatus.ERROR
+
+
+def test_rx_session_process_aux_uses_last_task():
+    """process_aux_agent_result uses the last task's expected_transfers."""
+    session = _make_rx_session(3)
+    session._kv_tasks[0].expected_transfers = 99
+    session._kv_tasks[1].expected_transfers = 99
+    session._kv_tasks[2].expected_transfers = 1
+
+    session.process_aux_agent_result(0, AgentResult.SUCCESS)
+    assert session._aux_status == TaskStatus.TRANSFERRED
+
+
+def test_rx_session_wait_complete_all_tasks():
+    """RxSession.wait_complete blocks on all task futures."""
+    session = _make_rx_session(3)
+    for task in session._kv_tasks:
+        task.future.set_result(AgentResult.SUCCESS)
+        task.status = TaskStatus.TRANSFERRED
+
+    result = session.wait_complete(need_aux=False)
+    assert result == WaitResult.COMPLETED
+
+
+def test_rx_session_wait_complete_fails_on_partial_failure():
+    """RxSession.wait_complete returns FAILED if any task fails."""
+    session = _make_rx_session(2)
+    session._kv_tasks[0].future.set_result(AgentResult.SUCCESS)
+    session._kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[1].future.set_exception(RuntimeError("transfer failed"))
+    session._kv_tasks[1].status = TaskStatus.ERROR
+
+    result = session.wait_complete(need_aux=False)
+    assert result == WaitResult.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Chunk completion callback tests
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_callback_enqueues_release():
+    """Callback from _make_chunk_callback enqueues the correct release entries."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._chunk_size_blocks = 64
+    transceiver._pending_prefix_releases = queue.Queue()
+    transceiver._kv_cache_manager.release_prefix_blocks = MagicMock()
+
+    callback = KvCacheTransceiverV2._make_chunk_callback(transceiver)
+    assert callback is not None
+
+    callback(request_id=7, chunk_block_offset=0, num_blocks=64)
+    callback(request_id=7, chunk_block_offset=64, num_blocks=64)
+    callback(request_id=7, chunk_block_offset=128, num_blocks=64)
+
+    results = []
+    while not transceiver._pending_prefix_releases.empty():
+        results.append(transceiver._pending_prefix_releases.get_nowait())
+
+    assert results == [(7, 64), (7, 128), (7, 192)]
+
+
+def test_drain_pending_releases():
+    """_drain_pending_releases calls release_prefix_blocks for each entry."""
+    transceiver = MagicMock()
+    transceiver._pending_prefix_releases = queue.Queue()
+    transceiver._kv_cache_manager = MagicMock()
+    transceiver._pending_prefix_releases.put((10, 64))
+    transceiver._pending_prefix_releases.put((10, 128))
+    transceiver._pending_prefix_releases.put((20, 32))
+
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    KvCacheTransceiverV2._drain_pending_releases(transceiver)
+
+    calls = transceiver._kv_cache_manager.release_prefix_blocks.call_args_list
+    assert len(calls) == 3
+    assert calls[0].args == (10, 64)
+    assert calls[1].args == (10, 128)
+    assert calls[2].args == (20, 32)
+
+
+@pytest.mark.parametrize(
+    "has_release,chunk_size,expected_none",
+    [
+        (False, 64, True),
+        (True, None, True),
+        (False, None, True),
+        (True, 64, False),
+    ],
+    ids=["no_release_api", "no_chunking", "neither", "with_release_and_chunking"],
+)
+def test_make_chunk_callback_conditions(has_release, chunk_size, expected_none):
+    """_make_chunk_callback returns None unless both release API and chunking enabled."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._chunk_size_blocks = chunk_size
+    transceiver._pending_prefix_releases = queue.Queue()
+    if has_release:
+        transceiver._kv_cache_manager.release_prefix_blocks = MagicMock()
+    else:
+        del transceiver._kv_cache_manager.release_prefix_blocks
+
+    result = KvCacheTransceiverV2._make_chunk_callback(transceiver)
+    assert (result is None) == expected_none
+
+
+def test_chunk_callback_then_drain():
+    """End-to-end: callback enqueues, drain calls release_prefix_blocks."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._chunk_size_blocks = 4
+    transceiver._pending_prefix_releases = queue.Queue()
+    transceiver._kv_cache_manager.release_prefix_blocks = MagicMock()
+
+    callback = KvCacheTransceiverV2._make_chunk_callback(transceiver)
+    assert callback is not None
+
+    callback(request_id=1, chunk_block_offset=0, num_blocks=4)
+    callback(request_id=1, chunk_block_offset=4, num_blocks=4)
+    callback(request_id=1, chunk_block_offset=8, num_blocks=2)
+
+    KvCacheTransceiverV2._drain_pending_releases(transceiver)
+
+    calls = transceiver._kv_cache_manager.release_prefix_blocks.call_args_list
+    assert len(calls) == 3
+    assert calls[0].args == (1, 4)
+    assert calls[1].args == (1, 8)
+    assert calls[2].args == (1, 10)
+
+
+# ---------------------------------------------------------------------------
+# Mid-transfer chunk failure tests
+# ---------------------------------------------------------------------------
+
+
+def test_tx_session_mid_chunk_failure():
+    """If one chunk fails mid-transfer, the session reports ERROR."""
+    session = _make_tx_session(4)
+
+    session.kv_tasks[0].future.set_result(AgentResult.SUCCESS)
+    session.kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session.kv_tasks[1].future.set_result(AgentResult.SUCCESS)
+    session.kv_tasks[1].status = TaskStatus.TRANSFERRED
+    session.kv_tasks[2].future.set_exception(RuntimeError("RDMA failed"))
+    session.kv_tasks[2].status = TaskStatus.ERROR
+    session.kv_tasks[3].future.set_result(AgentResult.SUCCESS)
+    session.kv_tasks[3].status = TaskStatus.TRANSFERRED
+
+    assert session.status == SessionStatus.ERROR
+    result = session.wait_complete(need_aux=False, timeout=1.0)
+    assert result == WaitResult.FAILED
+
+
+def test_rx_session_mid_chunk_failure():
+    """If one chunk fails mid-transfer on receiver, the session reports ERROR."""
+    session = _make_rx_session(4)
+
+    session._kv_tasks[0].future.set_result(AgentResult.SUCCESS)
+    session._kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[1].future.set_exception(RuntimeError("RDMA failed"))
+    session._kv_tasks[1].status = TaskStatus.ERROR
+    session._kv_tasks[2].future.set_result(AgentResult.SUCCESS)
+    session._kv_tasks[2].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[3].future.set_result(AgentResult.SUCCESS)
+    session._kv_tasks[3].status = TaskStatus.TRANSFERRED
+
+    assert session.status == SessionStatus.ERROR
+    result = session.wait_complete(need_aux=False)
+    assert result == WaitResult.FAILED

--- a/tests/unittest/disaggregated/test_chunked_transfer.py
+++ b/tests/unittest/disaggregated/test_chunked_transfer.py
@@ -371,3 +371,90 @@ def test_rx_session_mid_chunk_failure():
     assert session.status == SessionStatus.ERROR
     result = session.wait_complete(need_aux=False)
     assert result == WaitResult.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Pipelined transfer tests
+# ---------------------------------------------------------------------------
+
+
+def test_pipelined_transfer_disabled_by_default():
+    """enable_pipelined_transfer defaults to False."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._enable_pipelined_transfer = False
+    transceiver._chunk_size_blocks = 64
+
+    result = KvCacheTransceiverV2.enable_pipelined_transfer.fget(transceiver)
+    assert result is False
+
+
+def test_pipelined_transfer_requires_chunk_size():
+    """enable_pipelined_transfer is False when chunk_size_blocks is None."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._enable_pipelined_transfer = True
+    transceiver._chunk_size_blocks = None
+
+    result = KvCacheTransceiverV2.enable_pipelined_transfer.fget(transceiver)
+    assert result is False
+
+
+def test_pipelined_transfer_enabled():
+    """enable_pipelined_transfer is True when both flags are set."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._enable_pipelined_transfer = True
+    transceiver._chunk_size_blocks = 64
+
+    result = KvCacheTransceiverV2.enable_pipelined_transfer.fget(transceiver)
+    assert result is True
+
+
+def test_respond_and_send_skips_resend_for_pipelined():
+    """respond_and_send_async skips re-sending when pipelined chunks are complete."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    rid = 42
+    transceiver._send_sessions = {rid: MagicMock()}
+    transceiver._pipelined_chunk_offsets = {}
+    transceiver._send_reqs = {}
+
+    req = MagicMock()
+    req.sampling_config.beam_width = 1
+
+    transceiver._create_kv_slices = MagicMock()
+    transceiver._need_aux_transfer = MagicMock(return_value=False)
+    transceiver._dp_rank = 0
+    transceiver._context_info_endpoint = "test"
+
+    import tensorrt_llm._torch.disaggregation.transceiver as transceiver_mod
+
+    original_get_rid = transceiver_mod.get_unique_rid
+    transceiver_mod.get_unique_rid = lambda req: rid
+    try:
+        KvCacheTransceiverV2.respond_and_send_async(transceiver, req)
+    finally:
+        transceiver_mod.get_unique_rid = original_get_rid
+
+    # _create_kv_slices should NOT have been called (skipped re-send)
+    transceiver._create_kv_slices.assert_not_called()
+
+
+def test_cuda_event_stored_on_task():
+    """KVSendTask stores cuda_event correctly."""
+    s = KVSlice(is_last_slice=False, block_ids_per_layer_groups=[[0, 1]])
+    event = MagicMock()
+    task = KVSendTask(s, MagicMock(disagg_request_id=1), slice_id=0, cuda_event=event)
+    assert task.cuda_event is event
+
+
+def test_cuda_event_none_by_default():
+    """KVSendTask.cuda_event defaults to None."""
+    s = KVSlice(is_last_slice=True, block_ids_per_layer_groups=[[0]])
+    task = KVSendTask(s, MagicMock(disagg_request_id=1), slice_id=0)
+    assert task.cuda_event is None

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -1328,5 +1328,112 @@ def test_transfer_worker_chunked(
             worker.shutdown()
 
 
+def add_and_verify_pipelined_request(
+    setup,
+    ctx_request_id,
+    gen_request_id,
+    request_len,
+    chunk_size_blocks,
+):
+    """Pipelined transfer: sender sends chunks with CUDA events, receiver sends 1."""
+    import math
+
+    ctx_transfer_workers = setup["ctx_transfer_workers"]
+    gen_transfer_workers = setup["gen_transfer_workers"]
+
+    ctx_info = _setup_chunked_request(setup, ctx_request_id, gen_request_id, request_len)
+    ctx_block_ids = ctx_info["ctx_block_ids"]
+    gen_block_ids = ctx_info["gen_block_ids"]
+
+    sender_sessions = [tw.create_tx_session(ctx_info["ctx_request"]) for tw in ctx_transfer_workers]
+    send_futures = []
+    for sender_session, block_ids_per_groups in zip(sender_sessions, ctx_block_ids):
+        max_blocks = max(len(ids) for ids in block_ids_per_groups)
+        num_chunks = math.ceil(max_blocks / chunk_size_blocks)
+        chunk_offset = 0
+        for chunk_idx in range(num_chunks):
+            start = chunk_idx * chunk_size_blocks
+            end = start + chunk_size_blocks
+            is_last = chunk_idx == num_chunks - 1
+            chunk_block_ids = [ids[start:end] for ids in block_ids_per_groups]
+            kv_slice = KVSlice(
+                is_last_slice=is_last,
+                block_ids_per_layer_groups=chunk_block_ids,
+            )
+            cuda_event = torch.cuda.Event()
+            cuda_event.record()
+            send_futures.append(
+                sender_session.send(
+                    kv_slice, chunk_block_offset=chunk_offset, cuda_event=cuda_event
+                )
+            )
+            chunk_offset += max(len(ids) for ids in chunk_block_ids)
+
+    receiver_sessions = [
+        tw.create_rx_session(ctx_info["gen_request"]) for tw in gen_transfer_workers
+    ]
+    recv_futures = []
+    for recv_session, block_ids_per_groups in zip(receiver_sessions, gen_block_ids):
+        full_slice = KVSlice(
+            is_last_slice=True,
+            block_ids_per_layer_groups=block_ids_per_groups,
+        )
+        recv_futures.append(recv_session.receive(full_slice))
+
+    for f in send_futures:
+        f.result()
+    for f in recv_futures:
+        f.result()
+
+    _verify_and_cleanup_chunked(setup, ctx_info, sender_sessions, receiver_sessions)
+
+
+PIPELINED_TEST_CONFIGS = [
+    (1, 1, False, 1, 1, False, False, True, "v2_tp1_pp1_pipelined"),
+    (1, 1, False, 1, 1, False, False, False, "v1_tp1_pp1_pipelined"),
+]
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,ctx_enable_dp,gen_tp,gen_pp,gen_enable_dp,is_mla,use_v2",
+    [(c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]) for c in PIPELINED_TEST_CONFIGS],
+    ids=[c[8] for c in PIPELINED_TEST_CONFIGS],
+)
+def test_transfer_worker_pipelined(
+    ctx_tp, ctx_pp, ctx_enable_dp, gen_tp, gen_pp, gen_enable_dp, is_mla, use_v2
+):
+    """Test pipelined transfer: chunks sent with CUDA events for V1 and V2."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    tensorrt_llm.logger.set_level("info")
+    logger.info(f"Test transfer worker {'V2' if use_v2 else 'V1'} with pipelined transfer")
+
+    setup = create_transfer_worker_setup(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        gen_enable_dp=gen_enable_dp,
+        is_mla=is_mla,
+        use_v2=use_v2,
+    )
+
+    request_len = setup["request_len"]
+    tokens_per_block = setup["tokens_per_block"]
+    total_blocks = (request_len + tokens_per_block - 1) // tokens_per_block
+    chunk_size = max(1, total_blocks // 2)
+
+    try:
+        add_and_verify_pipelined_request(setup, 0, 1, request_len, chunk_size_blocks=chunk_size)
+        add_and_verify_pipelined_request(setup, 2, 3, request_len * 2, chunk_size_blocks=chunk_size)
+    finally:
+        for worker in setup["ctx_transfer_workers"]:
+            worker.shutdown()
+        for worker in setup["gen_transfer_workers"]:
+            worker.shutdown()
+
+
 if __name__ == "__main__":
     test_transfer_worker_v1(1, 1, False, 1, 1, False, False)

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -133,6 +133,69 @@ def test_session_status_enum():
     assert len(SessionStatus) == 6
 
 
+# ---------------------------------------------------------------------------
+# Chunked KV slice creation tests
+# ---------------------------------------------------------------------------
+
+
+def _chunk_block_ids(all_block_ids, chunk_size_blocks):
+    """Call the real _create_kv_slices via a mock transceiver."""
+    from unittest.mock import MagicMock
+
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._chunk_size_blocks = chunk_size_blocks
+    transceiver._collect_block_ids = MagicMock(return_value=all_block_ids)
+    transceiver._create_kv_slices = KvCacheTransceiverV2._create_kv_slices.__get__(transceiver)
+
+    req = MagicMock()
+    return transceiver._create_kv_slices(req)
+
+
+@pytest.mark.parametrize(
+    "all_block_ids,chunk_size,expected_num_slices",
+    [
+        ([[0, 1, 2, 3, 4, 5, 6, 7]], None, 1),
+        ([[0, 1, 2, 3, 4, 5, 6, 7]], 4, 2),
+        ([list(range(10))], 4, 3),
+        ([[], []], 4, 1),
+        ([[0, 1, 2]], 64, 1),
+    ],
+    ids=["no_chunking", "even_split", "uneven_split", "empty_blocks", "chunk_larger_than_total"],
+)
+def test_create_kv_slices_basic(all_block_ids, chunk_size, expected_num_slices):
+    """Chunking produces the expected number of slices."""
+    slices = _chunk_block_ids(all_block_ids, chunk_size_blocks=chunk_size)
+    assert len(slices) == expected_num_slices
+    assert slices[-1].is_last_slice is True
+    if expected_num_slices > 1:
+        for s in slices[:-1]:
+            assert s.is_last_slice is False
+
+
+def test_create_kv_slices_integrity_check():
+    """Reassembled block IDs from all slices must match the original."""
+    all_block_ids = [list(range(17)), list(range(5))]
+    slices = _chunk_block_ids(all_block_ids, chunk_size_blocks=4)
+    for lg_idx, original in enumerate(all_block_ids):
+        reassembled = []
+        for s in slices:
+            reassembled.extend(s.block_ids_per_layer_groups[lg_idx])
+        assert reassembled == original
+
+
+def test_create_kv_slices_multiple_layer_groups():
+    """Different layer groups with different block counts produce correct chunking."""
+    all_block_ids = [list(range(8)), list(range(3))]
+    slices = _chunk_block_ids(all_block_ids, chunk_size_blocks=4)
+    assert len(slices) == 2
+    assert slices[0].block_ids_per_layer_groups[0] == [0, 1, 2, 3]
+    assert slices[1].block_ids_per_layer_groups[0] == [4, 5, 6, 7]
+    assert slices[0].block_ids_per_layer_groups[1] == [0, 1, 2]
+    assert slices[1].block_ids_per_layer_groups[1] == []
+
+
 def create_transfer_worker_setup(
     ctx_tp: int,
     ctx_pp: int,
@@ -1040,6 +1103,224 @@ def test_transfer_worker_v2_with_window(
         add_and_verify_request(setup, 0, 1, request_len=16, send_first=True)
         add_and_verify_request(setup, 2, 3, request_len=32, send_first=True)
         add_and_verify_request(setup, 4, 5, request_len=64, send_first=False)
+    finally:
+        for worker in setup["ctx_transfer_workers"]:
+            worker.shutdown()
+        for worker in setup["gen_transfer_workers"]:
+            worker.shutdown()
+
+
+def _setup_chunked_request(setup, ctx_request_id, gen_request_id, request_len):
+    """Shared setup for chunked transfer tests: create requests, allocate KV, get block IDs."""
+    ctx_transfer_workers = setup["ctx_transfer_workers"]
+    ctx_kv_cache_managers = setup["ctx_kv_cache_managers"]
+    gen_transfer_workers = setup["gen_transfer_workers"]
+    gen_kv_cache_managers = setup["gen_kv_cache_managers"]
+    ctx_info_endpoint = setup["ctx_info_endpoint"]
+    use_v2 = setup["use_v2"]
+    tokens_per_block = setup["tokens_per_block"]
+
+    sampling_params = SamplingParams()
+    unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
+
+    ctx_request = LlmRequest(
+        request_id=ctx_request_id,
+        max_new_tokens=1,
+        input_tokens=list(range(request_len)),
+        sampling_config=tensorrt_llm.bindings.SamplingConfig(
+            sampling_params._get_sampling_config()
+        ),
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
+    )
+    ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
+
+    gen_request = LlmRequest(
+        request_id=gen_request_id,
+        max_new_tokens=1,
+        input_tokens=list(range(request_len)),
+        sampling_config=tensorrt_llm.bindings.SamplingConfig(
+            sampling_params._get_sampling_config()
+        ),
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+    )
+    gen_request.py_disaggregated_params = DisaggregatedParams(
+        ctx_request_id=ctx_request.py_request_id,
+        ctx_dp_rank=0,
+        ctx_info_endpoint=ctx_info_endpoint,
+        disagg_request_id=unique_rid,
+    )
+
+    ctx_kv_caches, gen_kv_caches = [], []
+    for mgr in ctx_kv_cache_managers:
+        if use_v2:
+            kv = mgr._create_kv_cache(ctx_request.py_request_id, None, None)
+            assert kv.resume(torch.cuda.current_stream().cuda_stream)
+            assert kv.resize(request_len)
+            ctx_kv_caches.append(kv)
+        else:
+            mgr.impl.add_sequence(ctx_request.py_request_id, request_len, 1, ctx_request)
+
+    for mgr in gen_kv_cache_managers:
+        if use_v2:
+            kv = mgr._create_kv_cache(gen_request.py_request_id, None, None)
+            assert kv.resume(torch.cuda.current_stream().cuda_stream)
+            assert kv.resize(request_len)
+            gen_kv_caches.append(kv)
+        else:
+            mgr.impl.add_sequence(gen_request.py_request_id, request_len, 1, gen_request)
+
+    ctx_block_ids = [
+        get_block_ids_per_layer_groups(mgr, tw, ctx_request.py_request_id, use_v2, tokens_per_block)
+        for mgr, tw in zip(ctx_kv_cache_managers, ctx_transfer_workers)
+    ]
+    gen_block_ids = [
+        get_block_ids_per_layer_groups(mgr, tw, gen_request.py_request_id, use_v2, tokens_per_block)
+        for mgr, tw in zip(gen_kv_cache_managers, gen_transfer_workers)
+    ]
+
+    return {
+        "ctx_request": ctx_request,
+        "gen_request": gen_request,
+        "ctx_kv_caches": ctx_kv_caches,
+        "gen_kv_caches": gen_kv_caches,
+        "ctx_block_ids": ctx_block_ids,
+        "gen_block_ids": gen_block_ids,
+    }
+
+
+def _verify_and_cleanup_chunked(setup, ctx_info, sender_sessions, receiver_sessions):
+    """Shared verification and cleanup for chunked transfer tests."""
+    ctx_kv_cache_managers = setup["ctx_kv_cache_managers"]
+    gen_kv_cache_managers = setup["gen_kv_cache_managers"]
+    use_v2 = setup["use_v2"]
+
+    ctx_block_ids = ctx_info["ctx_block_ids"]
+    gen_block_ids = ctx_info["gen_block_ids"]
+
+    for session in sender_sessions:
+        assert session.status == SessionStatus.KV_TRANSFERRED
+    for session in receiver_sessions:
+        assert session.status == SessionStatus.KV_TRANSFERRED
+
+    num_layer_groups = len(ctx_block_ids[0])
+    for lg_id in range(num_layer_groups):
+        ctx_data = [
+            get_block_data(mgr, bids[lg_id], lg_id, use_v2, ctx_info["ctx_request"].py_request_id)
+            for mgr, bids in zip(ctx_kv_cache_managers, ctx_block_ids)
+        ]
+        gen_data = [
+            get_block_data(mgr, bids[lg_id], lg_id, use_v2, ctx_info["gen_request"].py_request_id)
+            for mgr, bids in zip(gen_kv_cache_managers, gen_block_ids)
+        ]
+        for c, g in zip(ctx_data, gen_data):
+            assert c.equal(g), f"Layer group {lg_id}: data mismatch with chunked transfer"
+
+    for s in receiver_sessions:
+        s.close()
+    for s in sender_sessions:
+        s.close()
+    if use_v2:
+        torch.cuda.current_stream().synchronize()
+        for kv in ctx_info["ctx_kv_caches"]:
+            kv.close()
+        for kv in ctx_info["gen_kv_caches"]:
+            kv.close()
+
+
+def add_and_verify_chunked_request(
+    setup,
+    ctx_request_id,
+    gen_request_id,
+    request_len,
+    chunk_size_blocks,
+):
+    """Chunked transfer variant: sender sends N slices, receiver sends 1."""
+    import math
+
+    ctx_transfer_workers = setup["ctx_transfer_workers"]
+    gen_transfer_workers = setup["gen_transfer_workers"]
+
+    ctx_info = _setup_chunked_request(setup, ctx_request_id, gen_request_id, request_len)
+    ctx_block_ids = ctx_info["ctx_block_ids"]
+    gen_block_ids = ctx_info["gen_block_ids"]
+
+    sender_sessions = [tw.create_tx_session(ctx_info["ctx_request"]) for tw in ctx_transfer_workers]
+    send_futures = []
+    for sender_session, block_ids_per_groups in zip(sender_sessions, ctx_block_ids):
+        max_blocks = max(len(ids) for ids in block_ids_per_groups)
+        num_chunks = math.ceil(max_blocks / chunk_size_blocks)
+        chunk_offset = 0
+        for chunk_idx in range(num_chunks):
+            start = chunk_idx * chunk_size_blocks
+            end = start + chunk_size_blocks
+            is_last = chunk_idx == num_chunks - 1
+            chunk_block_ids = [ids[start:end] for ids in block_ids_per_groups]
+            kv_slice = KVSlice(
+                is_last_slice=is_last,
+                block_ids_per_layer_groups=chunk_block_ids,
+            )
+            send_futures.append(sender_session.send(kv_slice, chunk_block_offset=chunk_offset))
+            chunk_offset += max(len(ids) for ids in chunk_block_ids)
+
+    receiver_sessions = [
+        tw.create_rx_session(ctx_info["gen_request"]) for tw in gen_transfer_workers
+    ]
+    recv_futures = []
+    for recv_session, block_ids_per_groups in zip(receiver_sessions, gen_block_ids):
+        full_slice = KVSlice(
+            is_last_slice=True,
+            block_ids_per_layer_groups=block_ids_per_groups,
+        )
+        recv_futures.append(recv_session.receive(full_slice))
+
+    for f in send_futures:
+        f.result()
+    for f in recv_futures:
+        f.result()
+
+    _verify_and_cleanup_chunked(setup, ctx_info, sender_sessions, receiver_sessions)
+
+
+CHUNKED_TEST_CONFIGS = [
+    (1, 1, False, 1, 1, False, False, True, "v2_tp1_pp1_chunked"),
+    (1, 1, False, 1, 1, False, False, False, "v1_tp1_pp1_chunked"),
+]
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,ctx_enable_dp,gen_tp,gen_pp,gen_enable_dp,is_mla,use_v2",
+    [(c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]) for c in CHUNKED_TEST_CONFIGS],
+    ids=[c[8] for c in CHUNKED_TEST_CONFIGS],
+)
+def test_transfer_worker_chunked(
+    ctx_tp, ctx_pp, ctx_enable_dp, gen_tp, gen_pp, gen_enable_dp, is_mla, use_v2
+):
+    """Test transfer worker with sender-side chunking for V1 and V2."""
+    tensorrt_llm.logger.set_level("info")
+    logger.info(f"Test transfer worker {'V2' if use_v2 else 'V1'} with chunked transfer")
+
+    setup = create_transfer_worker_setup(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        gen_enable_dp=gen_enable_dp,
+        is_mla=is_mla,
+        use_v2=use_v2,
+    )
+
+    request_len = setup["request_len"]
+    tokens_per_block = setup["tokens_per_block"]
+    total_blocks = (request_len + tokens_per_block - 1) // tokens_per_block
+    chunk_size = max(1, total_blocks // 2)
+
+    try:
+        add_and_verify_chunked_request(setup, 0, 1, request_len, chunk_size_blocks=chunk_size)
+        add_and_verify_chunked_request(setup, 2, 3, request_len * 2, chunk_size_blocks=chunk_size)
     finally:
         for worker in setup["ctx_transfer_workers"]:
             worker.shutdown()

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -756,6 +756,119 @@ class TestDisagg(TestKVCacheManagerV2):
         stream.take_finish_event().synchronize()
 
 
+class TestReleasePrefixBlocks(TestKVCacheManagerV2):
+    """Tests for _KVCache.release_prefix (chunked transfer early release).
+
+    release_prefix nullifies page holders in prefix blocks (setting
+    them to None) and marks their base_page_indices as BAD_PAGE_INDEX.
+    The _blocks list length is preserved to maintain ordinal invariants
+    for close() / stop_committing().
+    """
+
+    def _create_and_fill(self, prompt_len: int) -> "_KVCache":
+        """Helper: create a KV cache, resume, resize to prompt_len."""
+        prompt = [self.next_token() for _ in range(prompt_len)]
+        kv_cache = self.manager.create_kv_cache(None, prompt)
+        with TemporaryCudaStream([]) as stream:
+            success = kv_cache.resume(cast(CudaStream, stream.handle))
+            assert success
+            success = kv_cache.resize(prompt_len, prompt_len)
+            assert success
+        return kv_cache
+
+    def _count_valid_indices(self, kv_cache: "_KVCache", layer_group_id: int = 0) -> int:
+        """Count non-BAD_PAGE_INDEX entries in base_page_indices."""
+        indices = kv_cache.get_base_page_indices(LayerGroupId(layer_group_id))
+        return sum(1 for idx in indices if idx != BAD_PAGE_INDEX)
+
+    @parameterized.expand([256])
+    def test_release_prefix_basic(self, prompt_len: int) -> None:
+        """Releasing N prefix blocks invalidates their page indices."""
+        self.prepare(128 << 20, 128 << 20, 1 << 30, 4, None, 0, tokens_per_block=64)
+        kv_cache = self._create_and_fill(prompt_len)
+
+        original_num_blocks = kv_cache.num_blocks
+        release_count = 2
+        assert original_num_blocks > release_count
+
+        original_valid = self._count_valid_indices(kv_cache)
+        kv_cache.release_prefix(release_count)
+
+        assert kv_cache.num_blocks == original_num_blocks
+        valid_after = self._count_valid_indices(kv_cache)
+        assert valid_after == original_valid - release_count
+
+        kv_cache.close()
+
+    @parameterized.expand([128])
+    def test_release_prefix_zero(self, prompt_len: int) -> None:
+        """release_prefix(0) is a no-op."""
+        self.prepare(128 << 20, 128 << 20, 1 << 30, 4, None, 0, tokens_per_block=64)
+        kv_cache = self._create_and_fill(prompt_len)
+
+        original_num_blocks = kv_cache.num_blocks
+        original_valid = self._count_valid_indices(kv_cache)
+        kv_cache.release_prefix(0)
+
+        assert kv_cache.num_blocks == original_num_blocks
+        assert self._count_valid_indices(kv_cache) == original_valid
+        kv_cache.close()
+
+    @parameterized.expand([128])
+    def test_release_prefix_exceeds_blocks(self, prompt_len: int) -> None:
+        """release_prefix(N+5) invalidates all N blocks (clamped)."""
+        self.prepare(128 << 20, 128 << 20, 1 << 30, 4, None, 0, tokens_per_block=64)
+        kv_cache = self._create_and_fill(prompt_len)
+
+        original_num_blocks = kv_cache.num_blocks
+        kv_cache.release_prefix(original_num_blocks + 5)
+
+        assert kv_cache.num_blocks == original_num_blocks
+        assert self._count_valid_indices(kv_cache) == 0
+        kv_cache.close()
+
+    @parameterized.expand([256])
+    def test_release_prefix_cumulative(self, prompt_len: int) -> None:
+        """Two successive calls invalidate prefix blocks cumulatively."""
+        self.prepare(128 << 20, 128 << 20, 1 << 30, 4, None, 0, tokens_per_block=64)
+        kv_cache = self._create_and_fill(prompt_len)
+
+        original_valid = self._count_valid_indices(kv_cache)
+        kv_cache.release_prefix(2)
+        assert self._count_valid_indices(kv_cache) == original_valid - 2
+        # release_prefix(3) releases blocks 0-2; block 0-1 already released,
+        # so only block 2 is newly invalidated.
+        kv_cache.release_prefix(3)
+        assert self._count_valid_indices(kv_cache) == original_valid - 3
+        kv_cache.close()
+
+    @parameterized.expand([256])
+    def test_release_prefix_close_succeeds(self, prompt_len: int) -> None:
+        """close() succeeds after release_prefix without assertion errors."""
+        self.prepare(128 << 20, 128 << 20, 1 << 30, 4, None, 0, tokens_per_block=64)
+        kv_cache = self._create_and_fill(prompt_len)
+
+        kv_cache.release_prefix(kv_cache.num_blocks // 2)
+        kv_cache.close()
+
+
+class TestReleasePrefixEdgeCases(TestKVCacheManagerV2):
+    """Edge-case tests for _KVCache.release_prefix."""
+
+    def test_release_prefix_negative(self) -> None:
+        """release_prefix with negative count is a no-op."""
+        self.prepare(128 << 20, 128 << 20, 1 << 30, 4, None, 0, tokens_per_block=64)
+        prompt = [self.next_token() for _ in range(128)]
+        kv_cache = self.manager.create_kv_cache(None, prompt)
+        with TemporaryCudaStream([]) as stream:
+            assert kv_cache.resume(cast(CudaStream, stream.handle))
+            assert kv_cache.resize(128, 128)
+        original_blocks = kv_cache.num_blocks
+        kv_cache.release_prefix(-1)
+        assert kv_cache.num_blocks == original_blocks
+        kv_cache.close()
+
+
 class TestDisaggregatedServing(unittest.TestCase):
     @dataclass(slots=True)
     class NodeGroup:

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -897,6 +897,23 @@ class TestStrictBaseModelArbitraryArgs:
             CacheTransceiverConfig(backend="UCX", invalid_config="should_fail")
         assert "invalid_config" in str(exc_info.value)
 
+    def test_cache_transceiver_config_chunk_size_blocks(self):
+        """Test chunk_size_blocks field validation."""
+        config = CacheTransceiverConfig(chunk_size_blocks=64)
+        assert config.chunk_size_blocks == 64
+
+        config_none = CacheTransceiverConfig(chunk_size_blocks=None)
+        assert config_none.chunk_size_blocks is None
+
+        config_default = CacheTransceiverConfig()
+        assert config_default.chunk_size_blocks is None
+
+        with pytest.raises(pydantic_core._pydantic_core.ValidationError):
+            CacheTransceiverConfig(chunk_size_blocks=0)
+
+        with pytest.raises(pydantic_core._pydantic_core.ValidationError):
+            CacheTransceiverConfig(chunk_size_blocks=-1)
+
     def test_torch_compile_config_arbitrary_args(self):
         """Test that TorchCompileConfig rejects arbitrary arguments."""
         # Valid arguments should work


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

### Summary

Implements pipelined prefill-transfer for disaggregated serving. Instead of waiting for all prefill chunks to complete before starting KV cache transfer, each chunk's KV data is transferred to the generation server immediately after its prefill completes. This overlaps GPU compute with RDMA transfer, hiding transfer latency behind prefill computation. When transfer time per chunk is less than prefill time per chunk (typical for 100+ Gbps NIC with long-context workloads), transfer latency is nearly fully hidden.

This is Phase 2 of the chunked KV transfer work. It builds on PR #12602 (shared chunking infrastructure + V1 early block release) and PR #12469 (V2 early block release).

### Background

Phase 1 (PRs #12602 and #12469) splits monolithic RDMA transfers into chunks and frees GPU blocks as each chunk completes. However, all prefill computation still finishes before any transfer begins — the two operations are fully serialized. For a 4-chunk prefill, the GPU is idle during transfer and the NIC is idle during prefill.

This PR eliminates that serialization by starting the RDMA for each chunk during the next chunk's prefill. The result is that transfer time overlaps with prefill time, reducing both TTFT and peak GPU memory.

### Performance Impact

| Metric | Phase 1 (before) | Phase 2 (this PR) |
|--------|-------------------|-------------------|
| Single-request TTFT | Neutral (transfer additive) | Improved (transfer overlapped) |
| System-level TTFT | Improved (freed blocks) | Further improved (lower peak memory) |
| TPOT | Neutral | Neutral |
| Peak GPU memory | Reduced during transfer | ~2 chunks at steady state |
| Total wall time | C * T_prefill + C * T_transfer | C * T_prefill + T_transfer (last chunk only) |

### Design

The implementation adds three capabilities:

**1. CUDA event synchronization.** The GPU writes KV data on the default CUDA stream, while GPUDirect RDMA reads from the same memory. A CUDA event is recorded after each chunk's forward pass. The sender worker thread calls `event.synchronize()` before RDMA, ensuring GPU writes are visible. This blocks only the worker thread — the GPU and main executor thread run the next chunk's forward concurrently.

**2. Incremental session lifecycle.** `send_prefill_chunk()` on `KvCacheTransceiverV2` creates the `TxSession` on the first call for a request, then adds one KVSlice per subsequent call. On the final chunk, aux data and `context_phase_params` are populated. `respond_and_send_async()` detects that pipelined chunks were already sent and skips re-sending.

**3. Executor hook.** `_maybe_send_prefill_chunk()` runs in `_update_request_states_tp` after each `move_to_next_context_chunk()`. It converts token positions to block indices and dispatches the chunk to the transceiver.

### Timeline Comparison

Phase 1 (all prefill, then all transfer):

    Step | GPU (Prefill) | RDMA (Transfer) | Blocks Held
    -----|---------------|-----------------|------------
      1  | Chunk 0       |                 | 256
      2  | Chunk 1       |                 | 256
      3  | Chunk 2       |                 | 256
      4  | Chunk 3       |                 | 256
      5  |               | Chunk 0 xfer    | 256 -> 192
      6  |               | Chunk 1 xfer    | 192 -> 128
      7  |               | Chunk 2 xfer    | 128 -> 64
      8  |               | Chunk 3 xfer    | 64 -> 0

Phase 2 (pipelined, this PR):

    Step | GPU (Prefill) | RDMA (Transfer) | Blocks Held
    -----|---------------|-----------------|------------
      1  | Chunk 0       |                 | 64
      2  | Chunk 1       | Chunk 0 xfer    | 128 -> 64
      3  | Chunk 2       | Chunk 1 xfer    | 128 -> 64
      4  | Chunk 3       | Chunk 2 xfer    | 128 -> 64
      5  |               | Chunk 3 xfer    | 64 -> 0

### Changes

| File | Change |
|------|--------|
| `base/transfer.py` | Add `cuda_event` param to `TxSessionBase.send()` |
| `native/transfer.py` | Add `cuda_event` to `KVSendTask` and `TxSession.send()`; add `event.synchronize()` in `_deliver_kv_to_agent` before RDMA |
| `transceiver.py` | Add `send_prefill_chunk()`, `enable_pipelined_transfer` property, `_pipelined_chunk_offsets` tracking; update `respond_and_send_async` to skip re-sending |
| `kv_cache_transceiver.py` | Add `enable_pipelined_transfer` property to base class |
| `py_executor.py` | Add `_maybe_send_prefill_chunk()` hook in `_update_request_states_tp` |
| `llm_args.py` | Add `enable_pipelined_transfer` config field |

### Backward Compatibility

Setting `enable_pipelined_transfer=False` (default) preserves Phase 1 behavior exactly. No protocol changes — the receiver side is completely unchanged. CUDA event plumbing is a no-op when `cuda_event=None`.

### Known Limitations

- Best paired with generation-first scheduling (context-first requires orchestrator changes to route the gen request earlier)
- No benefit for single-chunk prefill (nothing to pipeline)

## Test Coverage

### E2E GPU Tests (`test_kv_transfer.py`)

| Test | Description |
|------|-------------|
| `test_transfer_worker_pipelined[v1_tp1_pp1_pipelined]` | V1 pipelined transfer with CUDA events + actual NIXL RDMA, verifies data correctness |
| `test_transfer_worker_pipelined[v2_tp1_pp1_pipelined]` | V2 pipelined transfer with CUDA events + actual NIXL RDMA |

GPU tests are skipped with `pytest.skip("CUDA not available")` when no GPU is present.

### Mock-Based Unit Tests (`test_chunked_transfer.py`)

| Test | Description |
|------|-------------|
| `test_pipelined_transfer_disabled_by_default` | `enable_pipelined_transfer` is False by default |
| `test_pipelined_transfer_requires_chunk_size` | Returns False when `chunk_size_blocks` is None |
| `test_pipelined_transfer_enabled` | Returns True when both flags set |
| `test_respond_and_send_skips_resend_for_pipelined` | `respond_and_send_async` skips `_create_kv_slices` when pipelined chunks already sent |
| `test_cuda_event_stored_on_task` | `KVSendTask.cuda_event` stores event correctly |
| `test_cuda_event_none_by_default` | `KVSendTask.cuda_event` defaults to None |

### Existing Tests (backward compatibility, from Phase 1)

| Test | Description |
|------|-------------|
| `test_transfer_worker_chunked[v1/v2]` | Chunked transfer without pipelining (default path) |
| `test_chunked_transfer.py` (19 tests) | Session state machine with `cuda_event=None` no-op path |

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
