### PR TITLE
[None][fix] Fix Nano chunked prefill

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -683,8 +683,10 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             budget = self.dynamic_tiler._max_num_patches
             params, _ = self.dynamic_tiler.process_media(image, budget)
             num_image_tokens = params.num_embeddings
-            # Add special tokens.
-            num_image_tokens += len(self.get_mm_special_token_ids())
+            # Add only image-specific special tokens (img_start, img_end),
+            # not all multimodal special tokens (which also includes
+            # sound_start, sound_end when audio is supported).
+            num_image_tokens += 2  # <img> and </img>
             return num_image_tokens
 
         # The logic is copied and modified from HuggingFace ImageProcessor.
@@ -750,8 +752,10 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         if self.processor.use_thumbnail and blocks != 1:
             blocks += 1
         num_image_tokens = self.num_image_token * blocks
-        # Add special tokens.
-        num_image_tokens += len(self.get_mm_special_token_ids())
+        # Add only image-specific special tokens (img_start, img_end),
+        # not all multimodal special tokens (which also includes
+        # sound_start, sound_end when audio is supported).
+        num_image_tokens += 2  # <img> and </img>
         return num_image_tokens
 
     def get_num_tokens_per_video(
@@ -772,7 +776,8 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                 max_num_tiles=VIDEO_MAX_NUM_TILES,
                 **kwargs,
             )
-            num_image_tokens_per_frame = num_tokens_per_frame - len(self.get_mm_special_token_ids())
+            num_special_tokens_per_frame = 2  # <img> and </img>
+            num_image_tokens_per_frame = num_tokens_per_frame - num_special_tokens_per_frame
             blocks = num_image_tokens_per_frame // self.num_image_token
             video_size = (num_frames, blocks * self.image_size, self.image_size)
             num_total_tokens = compute_retained_tokens_count(
@@ -781,7 +786,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                 pruning_ratio=video_pruning_rate,
             )
             # Add special tokens for each frame.
-            num_total_tokens += num_frames * len(self.get_mm_special_token_ids())
+            num_total_tokens += num_frames * num_special_tokens_per_frame
         else:
             # No pruning - sum tokens for all frames
             num_total_tokens = sum(

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -257,6 +257,26 @@ class TestNanoV2VLInputProcessor:
         img = Image.new("RGB", img_size)
         assert proc.get_num_tokens_per_image(image=img) == expected_tokens
 
+    @pytest.mark.parametrize(
+        "img_size, expected_tokens",
+        [
+            pytest.param((320, 320), 66),
+            pytest.param((160, 160), 27),
+            pytest.param((480, 160), 58),
+        ],
+    )
+    def test_get_num_tokens_per_image_with_audio_config(self, img_size, expected_tokens):
+        """Audio config must not inflate image token counts.
+
+        Regression test: get_mm_special_token_ids() returns 4 tokens when
+        audio is enabled (img_start, img_end, sound_start, sound_end), but
+        only the 2 image-specific tokens (<img>, </img>) are inserted per
+        image.  The token count must be identical with or without audio.
+        """
+        proc = _make_audio_processor(max_num_patches=256, min_num_patches=4)
+        img = Image.new("RGB", img_size)
+        assert proc.get_num_tokens_per_image(image=img) == expected_tokens
+
     @pytest.mark.parametrize("num_images", [1, 2, 3])
     def test_process_images_dynamic_token_count(self, num_images):
         """Total image tokens in input_ids should match sum of per-image num_embeddings."""


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined token counting for images and videos in multimodal models to use fixed token allocations.

* **Tests**
  * Added test coverage for audio-enabled model configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

* Why?

The number of multimodal tokens was calculated incorrectly for
newer models that support both audio and vision modalities,
leading to errors at runtime when chunked prefill is enabled.

* What?

This commit fixes this issue, and adds a test for it (verified to
fail without the fix).

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
