### PR TITLE
[None][feat] Add llm.encode() fast path for encoder-only models

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -181,6 +181,15 @@ class DemoLLM(LLM):
     def __init__(self, **kwargs):
         self.args: LlmArgs = LlmArgs(**kwargs)
 
+        if self.args.encode_only:
+            raise NotImplementedError(
+                "encode_only=True is not supported by DemoLLM (AutoDeploy debug path). "
+                "Use the standard LLM class with backend='pytorch' for encoder-only mode."
+            )
+        # set encode_only and encoder_executor to BaseLLM's default values
+        self._encode_only = False
+        self._encoder_executor = None
+
         self.mpi_session = None
         self.runtime_context = None
 

--- a/tensorrt_llm/_torch/pyexecutor/encoder_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/encoder_executor.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict
+
+import torch
+
+from tensorrt_llm.logger import logger
+
+
+class EncoderExecutor:
+    """Executor for encoder-only models.
+
+    Primary path: batch_forward(inputs) — synchronous batch execution.
+    Delegates to model_engine.encoder_forward() for all heavy lifting
+    (pre-allocated buffers, attention metadata, torch.compile).
+
+    This executor has no background thread, no scheduler, no sampler,
+    and no request queue. It runs entirely on the calling thread.
+    """
+
+    def __init__(self, model_engine, dist):
+        self.model_engine = model_engine
+        self.dist = dist
+
+        logger.info(
+            "encoder_only mode enabled: using EncoderExecutor. "
+            "Scheduler, sampler, KV cache, and generation-related parameters "
+            "(disable_overlap_scheduler, max_tokens, temperature, etc.) "
+            "are bypassed. Use llm.encode() for inference.")
+
+    def batch_forward(self,
+                      inputs: Dict[str, Any]) -> Dict[str, torch.Tensor]:
+        """Execute a pre-formed batch in one forward pass.
+
+        Args:
+            inputs: Dict with 'input_ids' ([total_tokens]) and 'seq_lens'
+                ([batch_size]) required. Optional model-specific kwargs
+                (token_type_ids, inputs_embeds, etc.) are passed through.
+
+        Returns:
+            Dict with 'logits' tensor and any other model outputs.
+        """
+        return self.model_engine.encoder_forward(inputs)
+
+    def shutdown(self):
+        """No background thread to stop — just release model engine resources."""
+        del self.model_engine

--- a/tensorrt_llm/_torch/pyexecutor/encoder_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/encoder_executor.py
@@ -38,10 +38,10 @@ class EncoderExecutor:
             "encoder_only mode enabled: using EncoderExecutor. "
             "Scheduler, sampler, KV cache, and generation-related parameters "
             "(disable_overlap_scheduler, max_tokens, temperature, etc.) "
-            "are bypassed. Use llm.encode() for inference.")
+            "are bypassed. Use llm.encode() for inference."
+        )
 
-    def batch_forward(self,
-                      inputs: Dict[str, Any]) -> Dict[str, torch.Tensor]:
+    def batch_forward(self, inputs: Dict[str, Any]) -> Dict[str, torch.Tensor]:
         """Execute a pre-formed batch in one forward pass.
 
         Args:

--- a/tensorrt_llm/_torch/pyexecutor/encoder_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/encoder_executor.py
@@ -20,7 +20,7 @@ from tensorrt_llm.logger import logger
 
 
 class EncoderExecutor:
-    """Executor for encoder-only models.
+    """Executor for models using the encode-only path.
 
     Primary path: batch_forward(inputs) — synchronous batch execution.
     Delegates to model_engine.encoder_forward() for all heavy lifting
@@ -35,7 +35,7 @@ class EncoderExecutor:
         self.dist = dist
 
         logger.info(
-            "encoder_only mode enabled: using EncoderExecutor. "
+            "encode_only path enabled: using EncoderExecutor. "
             "Scheduler, sampler, KV cache, and generation-related parameters "
             "(disable_overlap_scheduler, max_tokens, temperature, etc.) "
             "are bypassed. Use llm.encode() for inference."

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3705,8 +3705,7 @@ class PyTorchModelEngine(ModelEngine):
             num_accepted_tokens_device, req_id_to_old_request, resource_manager,
             maybe_graph)
 
-    def _prepare_encoder_inputs(self,
-                               inputs: Dict[str, Any]) -> Dict[str, Any]:
+    def _prepare_encoder_inputs(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Prepare model-ready inputs dict for encoder-only models.
 
         Encoder equivalent of _prepare_tp_inputs + _preprocess_inputs.
@@ -3749,15 +3748,13 @@ class PyTorchModelEngine(ModelEngine):
 
         # 3. Build model-ready dict.
         #    **inputs goes FIRST so that the explicit buffer keys override the
-        #    raw tensors. Extra keys (seq_lens, token_type_ids, etc.) pass
-        #    through to the model's **kwargs and are silently ignored if not
-        #    in the model's forward() signature.
+        #    raw tensors. Extra keys pass through to the model's **kwargs
+        #    are silently ignored if not in the model's forward() signature.
         model_inputs = {
             **inputs,
             'attn_metadata': attn_metadata,
             'input_ids': self.input_ids_cuda[:num_tokens],
             'position_ids': self.position_ids_cuda[:num_tokens].unsqueeze(0),
-            'inputs_embeds': None,
         }
 
         return model_inputs
@@ -3765,8 +3762,7 @@ class PyTorchModelEngine(ModelEngine):
     @torch.inference_mode()
     @with_model_extra_attrs(lambda self: self.model.extra_attrs)
     @nvtx_range("encoder_forward")
-    def encoder_forward(self,
-                        inputs: Dict[str, Any]) -> Dict[str, Any]:
+    def encoder_forward(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Direct tensor-level forward for encoder-only models.
 
         Bypasses ScheduledRequests/LlmRequest entirely. Takes a raw inputs
@@ -3781,7 +3777,9 @@ class PyTorchModelEngine(ModelEngine):
             Dict with 'logits' tensor and any other model outputs.
         """
         model_inputs = self._prepare_encoder_inputs(inputs)
-        return self._forward_step(model_inputs, None, False)
+        return self._forward_step(model_inputs,
+                                  gather_ids=None,
+                                  gather_context_logits=False)
 
     @torch.inference_mode()
     @with_model_extra_attrs(lambda self: self.model.extra_attrs)
@@ -3868,8 +3866,10 @@ class PyTorchModelEngine(ModelEngine):
                     return self._forward_step_mm_encoder_only(
                         inputs, scheduled_requests)
                 else:
-                    return self._forward_step(inputs, gather_ids,
-                                              gather_context_logits)
+                    return self._forward_step(
+                        inputs,
+                        gather_ids=gather_ids,
+                        gather_context_logits=gather_context_logits)
         with self.cuda_graph_runner.pad_batch(
                 scheduled_requests, resource_manager,
                 self.runtime_draft_len) as padded_requests:
@@ -3924,8 +3924,10 @@ class PyTorchModelEngine(ModelEngine):
                 if not can_run_graph:
                     # Fallback to eager execution if graph was not used
                     with MoeLoadBalancerIterContext(moe_load_balancer):
-                        outputs = self._forward_step(inputs, gather_ids,
-                                                     gather_context_logits)
+                        outputs = self._forward_step(
+                            inputs,
+                            gather_ids=gather_ids,
+                            gather_context_logits=gather_context_logits)
                 else:
                     if self.cuda_graph_runner.needs_capture(key):
 
@@ -3997,6 +3999,7 @@ class PyTorchModelEngine(ModelEngine):
     @nvtx_range("_forward_step")
     def _forward_step(self,
                       inputs: Dict[str, Any],
+                      *,
                       gather_ids: Optional[torch.Tensor],
                       gather_context_logits: bool = False) -> Dict[str, Any]:
         inputs = self._preprocess_inputs(inputs)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -4000,7 +4000,7 @@ class PyTorchModelEngine(ModelEngine):
     def _forward_step(self,
                       inputs: Dict[str, Any],
                       *,
-                      gather_ids: Optional[torch.Tensor],
+                      gather_ids: Optional[torch.Tensor] = None,
                       gather_context_logits: bool = False) -> Dict[str, Any]:
         inputs = self._preprocess_inputs(inputs)
         if inputs.get('spec_metadata', None):

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3706,7 +3706,7 @@ class PyTorchModelEngine(ModelEngine):
             maybe_graph)
 
     def _prepare_encoder_inputs(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        """Prepare model-ready inputs dict for encoder-only models.
+        """Prepare model-ready inputs dict for encode-only path.
 
         Encoder equivalent of _prepare_tp_inputs + _preprocess_inputs.
         Consumes raw inputs dict, copies to pre-allocated CUDA buffers,
@@ -3763,7 +3763,7 @@ class PyTorchModelEngine(ModelEngine):
     @with_model_extra_attrs(lambda self: self.model.extra_attrs)
     @nvtx_range("encoder_forward")
     def encoder_forward(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
-        """Direct tensor-level forward for encoder-only models.
+        """Direct tensor-level forward for encode-only path.
 
         Bypasses ScheduledRequests/LlmRequest entirely. Takes a raw inputs
         dict, prepares model-ready inputs via _prepare_encoder_inputs, and

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3705,6 +3705,84 @@ class PyTorchModelEngine(ModelEngine):
             num_accepted_tokens_device, req_id_to_old_request, resource_manager,
             maybe_graph)
 
+    def _prepare_encoder_inputs(self,
+                               inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Prepare model-ready inputs dict for encoder-only models.
+
+        Encoder equivalent of _prepare_tp_inputs + _preprocess_inputs.
+        Consumes raw inputs dict, copies to pre-allocated CUDA buffers,
+        sets up attention metadata, and returns model-ready dict.
+
+        Args:
+            inputs: Dict with required keys 'input_ids' ([total_tokens]) and
+                'seq_lens' ([batch_size]). Optional 'position_ids'
+                ([total_tokens]). Any additional keys (token_type_ids,
+                inputs_embeds, etc.) are passed through to the model's
+                forward() via **kwargs.
+        """
+        token_ids = inputs['input_ids']
+        seq_lens = inputs['seq_lens']
+        position_ids = inputs.get('position_ids')
+        num_tokens = token_ids.shape[0]
+        batch_size = seq_lens.shape[0]
+
+        assert num_tokens <= self.max_num_tokens, (
+            f"num_tokens ({num_tokens}) exceeds max_num_tokens "
+            f"({self.max_num_tokens}). Reduce batch size or sequence lengths.")
+
+        # 1. Copy to pre-allocated CUDA buffers
+        self.input_ids_cuda[:num_tokens].copy_(token_ids, non_blocking=True)
+        if position_ids is None:
+            # Auto-generate packed position IDs: [0..n1-1, 0..n2-1, ...]
+            position_ids = torch.cat(
+                [torch.arange(s, dtype=torch.int32) for s in seq_lens.tolist()])
+        self.position_ids_cuda[:num_tokens].copy_(position_ids,
+                                                  non_blocking=True)
+
+        # 2. Set up attention metadata
+        attn_metadata = self._set_up_attn_metadata(kv_cache_manager=None)
+        attn_metadata.seq_lens = seq_lens
+        attn_metadata.num_contexts = batch_size
+        attn_metadata.max_seq_len = self.max_seq_len
+        attn_metadata.request_ids = list(range(batch_size))
+        attn_metadata.prepare()
+
+        # 3. Build model-ready dict.
+        #    **inputs goes FIRST so that the explicit buffer keys override the
+        #    raw tensors. Extra keys (seq_lens, token_type_ids, etc.) pass
+        #    through to the model's **kwargs and are silently ignored if not
+        #    in the model's forward() signature.
+        model_inputs = {
+            **inputs,
+            'attn_metadata': attn_metadata,
+            'input_ids': self.input_ids_cuda[:num_tokens],
+            'position_ids': self.position_ids_cuda[:num_tokens].unsqueeze(0),
+            'inputs_embeds': None,
+        }
+
+        return model_inputs
+
+    @torch.inference_mode()
+    @with_model_extra_attrs(lambda self: self.model.extra_attrs)
+    @nvtx_range("encoder_forward")
+    def encoder_forward(self,
+                        inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Direct tensor-level forward for encoder-only models.
+
+        Bypasses ScheduledRequests/LlmRequest entirely. Takes a raw inputs
+        dict, prepares model-ready inputs via _prepare_encoder_inputs, and
+        calls _forward_step (which preserves torch.compile).
+
+        Args:
+            inputs: Dict with 'input_ids' and 'seq_lens' (required), plus
+                any model-specific kwargs (token_type_ids, inputs_embeds, etc.).
+
+        Returns:
+            Dict with 'logits' tensor and any other model outputs.
+        """
+        model_inputs = self._prepare_encoder_inputs(inputs)
+        return self._forward_step(model_inputs, None, False)
+
     @torch.inference_mode()
     @with_model_extra_attrs(lambda self: self.model.extra_attrs)
     def forward(self,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -225,6 +225,50 @@ def get_guided_decoding_config(guided_decoding_backend: str,
     return guided_decoding_config
 
 
+def create_encoder_executor(
+    llm_args: TorchLlmArgs,
+    checkpoint_dir: Optional[str] = None,
+):
+    """Create an EncoderExecutor for encoder-only models.
+
+    Handles model loading and model_engine creation, then wraps in a
+    lightweight EncoderExecutor. Skips all decoder infrastructure
+    (KV cache, scheduler, sampler, drafter, speculative decoding).
+
+    Args:
+        llm_args: Configuration arguments.
+        checkpoint_dir: Path to model checkpoint.
+
+    Returns:
+        An EncoderExecutor instance ready for batch_forward() calls.
+    """
+    from .encoder_executor import EncoderExecutor
+
+    torch.cuda.set_per_process_memory_fraction(1.0)
+    checkpoint_loader = _construct_checkpoint_loader(llm_args.backend,
+                                                     llm_args.checkpoint_loader,
+                                                     llm_args.checkpoint_format)
+    llm_args = ModelLoader.load_config_and_apply_defaults(
+        checkpoint_dir, llm_args, checkpoint_loader)
+
+    mapping = _get_mapping(llm_args.parallel_config.to_mapping())
+    dist = Distributed.get(mapping)
+
+    model_engine = PyTorchModelEngine(
+        model_path=checkpoint_dir,
+        llm_args=llm_args,
+        mapping=mapping,
+        dist=dist,
+        spec_config=None,
+        checkpoint_loader=checkpoint_loader,
+    )
+
+    return EncoderExecutor(
+        model_engine=model_engine,
+        dist=dist,
+    )
+
+
 def create_py_executor(
     llm_args: TorchLlmArgs,
     checkpoint_dir: Optional[str] = None,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -225,6 +225,17 @@ def get_guided_decoding_config(guided_decoding_backend: str,
     return guided_decoding_config
 
 
+def _load_config_and_create_checkpoint_loader(
+        llm_args: TorchLlmArgs, checkpoint_dir: Optional[str] = None):
+    torch.cuda.set_per_process_memory_fraction(1.0)
+    checkpoint_loader = _construct_checkpoint_loader(llm_args.backend,
+                                                     llm_args.checkpoint_loader,
+                                                     llm_args.checkpoint_format)
+    llm_args = ModelLoader.load_config_and_apply_defaults(
+        checkpoint_dir, llm_args, checkpoint_loader)
+    return llm_args, checkpoint_loader
+
+
 def create_encoder_executor(
     llm_args: TorchLlmArgs,
     checkpoint_dir: Optional[str] = None,
@@ -244,12 +255,8 @@ def create_encoder_executor(
     """
     from .encoder_executor import EncoderExecutor
 
-    torch.cuda.set_per_process_memory_fraction(1.0)
-    checkpoint_loader = _construct_checkpoint_loader(llm_args.backend,
-                                                     llm_args.checkpoint_loader,
-                                                     llm_args.checkpoint_format)
-    llm_args = ModelLoader.load_config_and_apply_defaults(
-        checkpoint_dir, llm_args, checkpoint_loader)
+    llm_args, checkpoint_loader = _load_config_and_create_checkpoint_loader(
+        llm_args, checkpoint_dir)
 
     mapping = _get_mapping(llm_args.parallel_config.to_mapping())
     dist = Distributed.get(mapping)
@@ -294,13 +301,8 @@ def create_py_executor(
     """
 
     skip_est = os.environ.get("TRTLLM_SKIP_KV_CACHE_ESTIMATION", '0') == '1'
-    torch.cuda.set_per_process_memory_fraction(1.0)
-    # Apply model-specific defaults early, before destructuring llm_args fields
-    checkpoint_loader = _construct_checkpoint_loader(llm_args.backend,
-                                                     llm_args.checkpoint_loader,
-                                                     llm_args.checkpoint_format)
-    llm_args = ModelLoader.load_config_and_apply_defaults(
-        checkpoint_dir, llm_args, checkpoint_loader)
+    llm_args, checkpoint_loader = _load_config_and_create_checkpoint_loader(
+        llm_args, checkpoint_dir)
 
     garbage_collection_gen0_threshold = llm_args.garbage_collection_gen0_threshold
     lora_config = llm_args.lora_config

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -240,7 +240,7 @@ def create_encoder_executor(
     llm_args: TorchLlmArgs,
     checkpoint_dir: Optional[str] = None,
 ):
-    """Create an EncoderExecutor for encoder-only models.
+    """Create an EncoderExecutor for models using the encode-only path.
 
     Handles model loading and model_engine creation, then wraps in a
     lightweight EncoderExecutor. Skips all decoder infrastructure

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -107,12 +107,12 @@ class EncoderOutput:
     """Output from an encoder-only model.
 
     Attributes:
-        logits: Model output tensor. Shape depends on model:
+        logits (torch.Tensor): Model output tensor. Shape depends on model:
             - Classification: [num_classes]
             - Per-token scoring: [seq_len, num_labels]
             - Embeddings: [hidden_size]
-        prompt_token_ids: The tokenized input IDs.
-        prompt: The original text prompt, if provided as string.
+        prompt_token_ids (List[int]): The tokenized input IDs.
+        prompt (Optional[str]): The original text prompt, if provided as string.
     """
     logits: torch.Tensor
     prompt_token_ids: List[int]
@@ -367,6 +367,7 @@ class BaseLLM:
                 Scheduling parameters. Defaults to None.
             cache_salt (str, Sequence[str], optional): If specified, KV cache will be salted with the provided string to limit the kv cache reuse to the requests with the same string. Defaults to None.
             priority (float, List[float]): The scheduling priority for the request(s), in the range [0, 1]. Higher values indicate higher priority. Defaults to 0.5.
+
         Returns:
             Union[tensorrt_llm.llmapi.RequestOutput, List[tensorrt_llm.llmapi.RequestOutput]]: The output data of the completion request to the LLM.
         """
@@ -460,6 +461,7 @@ class BaseLLM:
             scheduling_params (tensorrt_llm.scheduling_params.SchedulingParams, optional): Scheduling parameters. Defaults to None.
             cache_salt (str, optional): If specified, KV cache will be salted with the provided string to limit the kv cache reuse to the requests with the same string. Defaults to None.
             priority (float): The scheduling priority for the request, in the range [0, 1]. Higher values indicate higher priority. Defaults to 0.5.
+
         Returns:
             tensorrt_llm.llmapi.RequestOutput: The output data of the completion request to the LLM.
         """
@@ -745,22 +747,21 @@ class BaseLLM:
         self,
         inputs: Union[PromptInputs, Sequence[PromptInputs]],
         add_special_tokens: bool = True,
-        **model_kwargs,
+        **model_kwargs: Any,
     ) -> Union[EncoderOutput, List[EncoderOutput]]:
         """Encode inputs using an encoder-only model (PyTorch backend only).
 
         Only available when encode_only=True is set in the LLM constructor.
 
         Args:
-            inputs: Text string(s), token ID list(s), or TextPrompt/TokensPrompt dict(s).
-            add_special_tokens: Whether to add special tokens (e.g., [CLS]/[SEP])
-                during tokenization. Defaults to True.
-            **model_kwargs: Model-specific inputs passed through to the model's
-                forward(). Examples: token_type_ids (BERT), inputs_embeds
-                (reward models).
+            inputs (tensorrt_llm.inputs.data.PromptInputs, Sequence[tensorrt_llm.inputs.data.PromptInputs]): The prompt text or token ids.
+                It can be a single prompt or batched prompts.
+            add_special_tokens (bool): Whether to add special tokens (e.g., [CLS]/[SEP]) during tokenization. Defaults to True.
+            model_kwargs (Any): Model-specific inputs passed through to the model's forward(). Examples: token_type_ids (BERT),
+                inputs_embeds (reward models).
 
         Returns:
-            EncoderOutput or List[EncoderOutput] with logits/embeddings.
+            Union[tensorrt_llm.llmapi.llm.EncoderOutput, List[tensorrt_llm.llmapi.llm.EncoderOutput]]: The encoder output(s) containing logits or embeddings.
 
         Raises:
             RuntimeError: If encode_only mode is not enabled.

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -769,6 +769,10 @@ class BaseLLM:
             raise RuntimeError(
                 "encode() requires encoder_only=True. "
                 "Set encoder_only=True in the LLM() constructor.")
+        if self._encoder_executor is None:
+            raise RuntimeError(
+                "LLM is shut down or not initialized. Please recreate the LLM object."
+            )
 
         unbatched = not isinstance(inputs, list)
         if not unbatched:
@@ -790,8 +794,7 @@ class BaseLLM:
         # Tokenize each input (reuses existing input_processor)
         token_ids_list = []
         prompts = []
-        sampling_params = SamplingParams(
-            add_special_tokens=add_special_tokens)
+        sampling_params = SamplingParams(add_special_tokens=add_special_tokens)
 
         total_tokens = 0
         max_seq_len_batch = 0
@@ -830,15 +833,16 @@ class BaseLLM:
         seq_lens = torch.tensor([len(t) for t in token_ids_list],
                                 dtype=torch.int32)
         flat_token_ids = torch.tensor(
-            [tid for tids in token_ids_list for tid in tids],
-            dtype=torch.int32)
+            [tid for tids in token_ids_list for tid in tids], dtype=torch.int32)
 
         # Build inputs dict — common + model-specific kwargs.
         # Filter keys that are set internally by _prepare_encoder_inputs or
         # _forward_step to avoid "multiple values for keyword argument" errors.
         _RESERVED_KEYS = {
-            'input_ids', 'position_ids', 'seq_lens', 'attn_metadata',
-            'inputs_embeds', 'return_context_logits',
+            'input_ids',
+            'seq_lens',
+            'attn_metadata',
+            'return_context_logits',
         }
         filtered_kwargs = {
             k: v
@@ -926,9 +930,8 @@ class BaseLLM:
             List[dict]: A list of runtime events as dict.
         '''
         if self._encoder_only:
-            raise RuntimeError(
-                "get_kv_cache_events() is not available when "
-                "encoder_only=True.")
+            raise RuntimeError("get_kv_cache_events() is not available when "
+                               "encoder_only=True.")
         return self._executor.get_kv_events(timeout=timeout)
 
     @set_api_status("beta")
@@ -1153,7 +1156,8 @@ class BaseLLM:
             self._executor.shutdown()
             self._executor = None
 
-        if hasattr(self, "_encoder_executor") and self._encoder_executor is not None:
+        if hasattr(self,
+                   "_encoder_executor") and self._encoder_executor is not None:
             self._encoder_executor.shutdown()
             self._encoder_executor = None
 
@@ -1505,9 +1509,8 @@ class _TorchLLM(BaseLLM):
         # Hint: if this looks like an encoder model, suggest encode()
         if self.args.encoder_only is None and not self.args.mm_encoder_only:
             from tensorrt_llm._torch.model_config import ModelConfig
-            architectures = getattr(
-                self._hf_model_config, 'architectures',
-                None) if self._hf_model_config else None
+            architectures = getattr(self._hf_model_config, 'architectures',
+                                    None) if self._hf_model_config else None
             if architectures and not ModelConfig.is_generation_model(
                     architectures):
                 logger.info(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Sequence, Tuple, Union, cast
 
+import torch
 import transformers
 from tqdm import tqdm
 from transformers import PreTrainedTokenizerBase
@@ -99,6 +100,23 @@ class RequestOutput(DetokenizedGenerationResultBase, GenerationResult):
             "finished",
             "disaggregated_params",
         ]
+
+
+@dataclass
+class EncoderOutput:
+    """Output from an encoder-only model.
+
+    Attributes:
+        logits: Model output tensor. Shape depends on model:
+            - Classification: [num_classes]
+            - Per-token scoring: [seq_len, num_labels]
+            - Embeddings: [hidden_size]
+        prompt_token_ids: The tokenized input IDs.
+        prompt: The original text prompt, if provided as string.
+    """
+    logits: torch.Tensor
+    prompt_token_ids: List[int]
+    prompt: Optional[str] = None
 
 
 TRT_LLM_DOCSTRING = TRT_LLMARGS_EXPLICIT_DOCSTRING + """
@@ -238,6 +256,8 @@ class BaseLLM:
             # Due to the Executor can only accept a engine path, we need to save the engine to a directory
             self._engine_dir: Optional[Path] = None
             self._executor: Optional[GenerationExecutor] = None
+            self._encoder_only: bool = False
+            self._encoder_executor = None
             if self._on_trt_backend:
                 self._workspace = tempfile.TemporaryDirectory(
                     suffix="-llm-workspace", dir=self.args.workspace)
@@ -443,6 +463,11 @@ class BaseLLM:
         Returns:
             tensorrt_llm.llmapi.RequestOutput: The output data of the completion request to the LLM.
         """
+
+        if self._encoder_only:
+            raise RuntimeError(
+                "generate_async() is not available when encoder_only=True. "
+                "Use llm.encode() for encoder-only models.")
 
         # Check if the worker is shutting down
         if self._executor is None or self._executor.is_shutdown():
@@ -715,6 +740,135 @@ class BaseLLM:
             multimodal_params=multimodal_params,
         )
 
+    @set_api_status("prototype")
+    def encode(
+        self,
+        inputs: Union[PromptInputs, Sequence[PromptInputs]],
+        add_special_tokens: bool = True,
+        **model_kwargs,
+    ) -> Union[EncoderOutput, List[EncoderOutput]]:
+        """Encode inputs using an encoder-only model (PyTorch backend only).
+
+        Only available when encoder_only=True is set in the LLM constructor.
+
+        Args:
+            inputs: Text string(s), token ID list(s), or TextPrompt/TokensPrompt dict(s).
+            add_special_tokens: Whether to add special tokens (e.g., [CLS]/[SEP])
+                during tokenization. Defaults to True.
+            **model_kwargs: Model-specific inputs passed through to the model's
+                forward(). Examples: token_type_ids (BERT), inputs_embeds
+                (reward models).
+
+        Returns:
+            EncoderOutput or List[EncoderOutput] with logits/embeddings.
+
+        Raises:
+            RuntimeError: If encoder_only mode is not enabled.
+        """
+        if not self._encoder_only:
+            raise RuntimeError(
+                "encode() requires encoder_only=True. "
+                "Set encoder_only=True in the LLM() constructor.")
+
+        unbatched = not isinstance(inputs, list)
+        if not unbatched:
+            if isinstance(inputs[0], int):
+                unbatched = True
+        if unbatched:
+            inputs = [inputs]
+
+        engine = self._encoder_executor.model_engine
+        max_seq_len = engine.max_seq_len
+        max_num_tokens = engine.max_num_tokens
+        max_batch_size = engine.batch_size
+
+        if len(inputs) > max_batch_size:
+            raise ValueError(
+                f"Batch size ({len(inputs)}) exceeds max_batch_size "
+                f"({max_batch_size}). Split inputs into smaller batches.")
+
+        # Tokenize each input (reuses existing input_processor)
+        token_ids_list = []
+        prompts = []
+        sampling_params = SamplingParams(
+            add_special_tokens=add_special_tokens)
+
+        total_tokens = 0
+        max_seq_len_batch = 0
+        for inp in inputs:
+            inp = prompt_inputs(inp)
+            if "prompt_token_ids" in inp:
+                token_ids_list.append(inp["prompt_token_ids"])
+                seq_len = len(inp["prompt_token_ids"])
+                total_tokens += seq_len
+                max_seq_len_batch = max(max_seq_len_batch, seq_len)
+                prompts.append(None)
+            elif "prompt" in inp:
+                token_ids, _ = self.input_processor(inp, sampling_params)
+                token_ids_list.append(token_ids)
+                seq_len = len(token_ids)
+                total_tokens += seq_len
+                max_seq_len_batch = max(max_seq_len_batch, seq_len)
+                prompts.append(inp["prompt"])
+            else:
+                raise TypeError(f"Unsupported input type: {type(inp)}")
+
+        # Validate inputs against model capacity
+        if total_tokens > max_num_tokens:
+            raise ValueError(
+                f"Total tokens ({total_tokens}) across the batch exceeds "
+                f"max_num_tokens ({max_num_tokens}). Reduce batch size or "
+                f"sequence lengths.")
+
+        if max_seq_len_batch > max_seq_len:
+            raise ValueError(
+                f"Max sequence length ({max_seq_len_batch}) exceeds "
+                f"max_seq_len ({max_seq_len}). Truncate the input or increase "
+                f"max_seq_len.")
+
+        # Pack into flat tensors
+        seq_lens = torch.tensor([len(t) for t in token_ids_list],
+                                dtype=torch.int32)
+        flat_token_ids = torch.tensor(
+            [tid for tids in token_ids_list for tid in tids],
+            dtype=torch.int32)
+
+        # Build inputs dict — common + model-specific kwargs.
+        # Filter keys that are set internally by _prepare_encoder_inputs or
+        # _forward_step to avoid "multiple values for keyword argument" errors.
+        _RESERVED_KEYS = {
+            'input_ids', 'position_ids', 'seq_lens', 'attn_metadata',
+            'inputs_embeds', 'return_context_logits',
+        }
+        filtered_kwargs = {
+            k: v
+            for k, v in model_kwargs.items() if k not in _RESERVED_KEYS
+        }
+        forward_inputs = {
+            'input_ids': flat_token_ids,
+            'seq_lens': seq_lens,
+            **filtered_kwargs,
+        }
+
+        # Single forward pass
+        outputs = self._encoder_executor.batch_forward(forward_inputs)
+
+        # Package as EncoderOutput.
+        # NOTE: logits[i] assumes batch-indexed output (e.g., BERT classification
+        # returns [batch_size, num_classes]). Per-token models that return packed
+        # [total_tokens, hidden_size] would need cumulative-sum slicing instead.
+        logits = outputs['logits']
+        results = []
+        for i in range(len(token_ids_list)):
+            results.append(
+                EncoderOutput(
+                    logits=logits[i] if logits.dim() > 1 else logits,
+                    prompt_token_ids=token_ids_list[i],
+                    prompt=prompts[i],
+                ))
+
+        return results[0] if unbatched else results
+
     @set_api_status("beta")
     def get_stats(self, timeout: Optional[float] = 2) -> List[dict]:
         '''Get iteration statistics from the runtime.
@@ -727,6 +881,10 @@ class BaseLLM:
             List[dict]: A list of runtime stats as dicts.
                 e.g., [{"cpuMemUsage": ..., "iter": 0, ...}, {"cpuMemUsage": ..., "iter": 1, ...}]
         '''
+        if self._encoder_only:
+            raise RuntimeError(
+                "get_stats() is not available when encoder_only=True. "
+                "Use llm.encode() for encoder-only models.")
         return self._executor.get_stats(timeout=timeout)
 
     @set_api_status("beta")
@@ -741,6 +899,10 @@ class BaseLLM:
         Returns:
             tensorrt_llm.executor.result.IterationResult: An async iterable object containing runtime stats.
         '''
+        if self._encoder_only:
+            raise RuntimeError(
+                "get_stats_async() is not available when encoder_only=True. "
+                "Use llm.encode() for encoder-only models.")
         return self._executor.aget_stats(timeout=timeout)
 
     @set_api_status("beta")
@@ -763,6 +925,10 @@ class BaseLLM:
         Returns:
             List[dict]: A list of runtime events as dict.
         '''
+        if self._encoder_only:
+            raise RuntimeError(
+                "get_kv_cache_events() is not available when "
+                "encoder_only=True.")
         return self._executor.get_kv_events(timeout=timeout)
 
     @set_api_status("beta")
@@ -787,6 +953,10 @@ class BaseLLM:
         Returns:
             tensorrt_llm.executor.result.IterationResult: An async iterable object containing runtime events.
         '''
+        if self._encoder_only:
+            raise RuntimeError(
+                "get_kv_cache_events_async() is not available when "
+                "encoder_only=True.")
         return self._executor.aget_kv_events(timeout=timeout)
 
     def _process_env_overrides(self,
@@ -983,6 +1153,10 @@ class BaseLLM:
             self._executor.shutdown()
             self._executor = None
 
+        if hasattr(self, "_encoder_executor") and self._encoder_executor is not None:
+            self._encoder_executor.shutdown()
+            self._encoder_executor = None
+
         if hasattr(self, 'mpi_session') and self.mpi_session is not None:
             self.mpi_session.shutdown()
             self.mpi_session = None
@@ -993,6 +1167,9 @@ class BaseLLM:
         Returns:
             bool: True if the executor is running and not shutdown, False otherwise.
         """
+        if self._encoder_only:
+            return (hasattr(self, "_encoder_executor")
+                    and self._encoder_executor is not None)
         if hasattr(self, "_executor") and self._executor is not None:
             return not self._executor.is_shutdown()
 
@@ -1272,6 +1449,9 @@ class _TorchLLM(BaseLLM):
         Returns:
             list[Any]: A list of results from each worker.
         """
+        if self._encoder_only:
+            raise RuntimeError(
+                "_collective_rpc() is not available when encoder_only=True.")
         if hasattr(self._executor, 'collective_rpc'):
             return self._executor.collective_rpc(method, args, kwargs,
                                                  non_block, unique_reply_rank,
@@ -1305,6 +1485,38 @@ class _TorchLLM(BaseLLM):
                                                       **input_processor_kwargs)
         self._tokenizer = self.input_processor.tokenizer
 
+        # Resolve encoder_only mode (opt-in only)
+        self._encoder_only = (self.args.encoder_only is True)
+
+        if self._encoder_only:
+            # Create ONLY the EncoderExecutor — skip decoder infrastructure.
+            from tensorrt_llm._torch.pyexecutor.py_executor_creator import \
+                create_encoder_executor
+            self._encoder_executor = create_encoder_executor(
+                llm_args=self.args,
+                checkpoint_dir=str(self._hf_model_dir)
+                if self._hf_model_dir else None,
+            )
+            logger.info(
+                "encoder_only=True: using EncoderExecutor. Only llm.encode() "
+                "is available. generate()/generate_async() are not supported.")
+            return  # Skip _executor creation
+
+        # Hint: if this looks like an encoder model, suggest encode()
+        if self.args.encoder_only is None and not self.args.mm_encoder_only:
+            from tensorrt_llm._torch.model_config import ModelConfig
+            architectures = getattr(
+                self._hf_model_config, 'architectures',
+                None) if self._hf_model_config else None
+            if architectures and not ModelConfig.is_generation_model(
+                    architectures):
+                logger.info(
+                    "Detected encoder-only model architecture (%s). Consider "
+                    "using LLM(model=..., encoder_only=True) with "
+                    "llm.encode() for optimized batch-forward inference that "
+                    "bypasses the decoder scheduler.", architectures[0])
+
+        # Create the standard executor for generate()/generate_async()
         # TODO: revisit gather_context_logits
         return_logits = self.args.gather_generation_logits
         self._executor = self._executor_cls.create(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -256,7 +256,7 @@ class BaseLLM:
             # Due to the Executor can only accept a engine path, we need to save the engine to a directory
             self._engine_dir: Optional[Path] = None
             self._executor: Optional[GenerationExecutor] = None
-            self._encoder_only: bool = False
+            self._encode_only: bool = False
             self._encoder_executor = None
             if self._on_trt_backend:
                 self._workspace = tempfile.TemporaryDirectory(
@@ -464,9 +464,9 @@ class BaseLLM:
             tensorrt_llm.llmapi.RequestOutput: The output data of the completion request to the LLM.
         """
 
-        if self._encoder_only:
+        if self._encode_only:
             raise RuntimeError(
-                "generate_async() is not available when encoder_only=True. "
+                "generate_async() is not available when encode_only=True. "
                 "Use llm.encode() for encoder-only models.")
 
         # Check if the worker is shutting down
@@ -749,7 +749,7 @@ class BaseLLM:
     ) -> Union[EncoderOutput, List[EncoderOutput]]:
         """Encode inputs using an encoder-only model (PyTorch backend only).
 
-        Only available when encoder_only=True is set in the LLM constructor.
+        Only available when encode_only=True is set in the LLM constructor.
 
         Args:
             inputs: Text string(s), token ID list(s), or TextPrompt/TokensPrompt dict(s).
@@ -763,12 +763,11 @@ class BaseLLM:
             EncoderOutput or List[EncoderOutput] with logits/embeddings.
 
         Raises:
-            RuntimeError: If encoder_only mode is not enabled.
+            RuntimeError: If encode_only mode is not enabled.
         """
-        if not self._encoder_only:
-            raise RuntimeError(
-                "encode() requires encoder_only=True. "
-                "Set encoder_only=True in the LLM() constructor.")
+        if not self._encode_only:
+            raise RuntimeError("encode() requires encode_only=True. "
+                               "Set encode_only=True in the LLM() constructor.")
         if self._encoder_executor is None:
             raise RuntimeError(
                 "LLM is shut down or not initialized. Please recreate the LLM object."
@@ -861,7 +860,7 @@ class BaseLLM:
         # NOTE: logits[i] assumes batch-indexed output (e.g., BERT classification
         # returns [batch_size, num_classes]). Per-token models that return packed
         # [total_tokens, hidden_size] would need cumulative-sum slicing instead.
-        logits = outputs['logits']
+        logits = outputs['logits'].cpu()
         results = []
         for i in range(len(token_ids_list)):
             results.append(
@@ -885,9 +884,9 @@ class BaseLLM:
             List[dict]: A list of runtime stats as dicts.
                 e.g., [{"cpuMemUsage": ..., "iter": 0, ...}, {"cpuMemUsage": ..., "iter": 1, ...}]
         '''
-        if self._encoder_only:
+        if self._encode_only:
             raise RuntimeError(
-                "get_stats() is not available when encoder_only=True. "
+                "get_stats() is not available when encode_only=True. "
                 "Use llm.encode() for encoder-only models.")
         return self._executor.get_stats(timeout=timeout)
 
@@ -903,9 +902,9 @@ class BaseLLM:
         Returns:
             tensorrt_llm.executor.result.IterationResult: An async iterable object containing runtime stats.
         '''
-        if self._encoder_only:
+        if self._encode_only:
             raise RuntimeError(
-                "get_stats_async() is not available when encoder_only=True. "
+                "get_stats_async() is not available when encode_only=True. "
                 "Use llm.encode() for encoder-only models.")
         return self._executor.aget_stats(timeout=timeout)
 
@@ -929,9 +928,9 @@ class BaseLLM:
         Returns:
             List[dict]: A list of runtime events as dict.
         '''
-        if self._encoder_only:
+        if self._encode_only:
             raise RuntimeError("get_kv_cache_events() is not available when "
-                               "encoder_only=True.")
+                               "encode_only=True.")
         return self._executor.get_kv_events(timeout=timeout)
 
     @set_api_status("beta")
@@ -956,10 +955,10 @@ class BaseLLM:
         Returns:
             tensorrt_llm.executor.result.IterationResult: An async iterable object containing runtime events.
         '''
-        if self._encoder_only:
+        if self._encode_only:
             raise RuntimeError(
                 "get_kv_cache_events_async() is not available when "
-                "encoder_only=True.")
+                "encode_only=True.")
         return self._executor.aget_kv_events(timeout=timeout)
 
     def _process_env_overrides(self,
@@ -1171,7 +1170,7 @@ class BaseLLM:
         Returns:
             bool: True if the executor is running and not shutdown, False otherwise.
         """
-        if self._encoder_only:
+        if self._encode_only:
             return (hasattr(self, "_encoder_executor")
                     and self._encoder_executor is not None)
         if hasattr(self, "_executor") and self._executor is not None:
@@ -1453,9 +1452,9 @@ class _TorchLLM(BaseLLM):
         Returns:
             list[Any]: A list of results from each worker.
         """
-        if self._encoder_only:
+        if self._encode_only:
             raise RuntimeError(
-                "_collective_rpc() is not available when encoder_only=True.")
+                "_collective_rpc() is not available when encode_only=True.")
         if hasattr(self._executor, 'collective_rpc'):
             return self._executor.collective_rpc(method, args, kwargs,
                                                  non_block, unique_reply_rank,
@@ -1489,10 +1488,10 @@ class _TorchLLM(BaseLLM):
                                                       **input_processor_kwargs)
         self._tokenizer = self.input_processor.tokenizer
 
-        # Resolve encoder_only mode (opt-in only)
-        self._encoder_only = (self.args.encoder_only is True)
+        # Resolve encode_only mode (opt-in only)
+        self._encode_only = (self.args.encode_only is True)
 
-        if self._encoder_only:
+        if self._encode_only:
             # Create ONLY the EncoderExecutor — skip decoder infrastructure.
             from tensorrt_llm._torch.pyexecutor.py_executor_creator import \
                 create_encoder_executor
@@ -1502,12 +1501,12 @@ class _TorchLLM(BaseLLM):
                 if self._hf_model_dir else None,
             )
             logger.info(
-                "encoder_only=True: using EncoderExecutor. Only llm.encode() "
+                "encode_only=True: using EncoderExecutor. Only llm.encode() "
                 "is available. generate()/generate_async() are not supported.")
             return  # Skip _executor creation
 
         # Hint: if this looks like an encoder model, suggest encode()
-        if self.args.encoder_only is None and not self.args.mm_encoder_only:
+        if self.args.encode_only is None and not self.args.mm_encoder_only:
             from tensorrt_llm._torch.model_config import ModelConfig
             architectures = getattr(self._hf_model_config, 'architectures',
                                     None) if self._hf_model_config else None
@@ -1515,7 +1514,7 @@ class _TorchLLM(BaseLLM):
                     architectures):
                 logger.info(
                     "Detected encoder-only model architecture (%s). Consider "
-                    "using LLM(model=..., encoder_only=True) with "
+                    "using LLM(model=..., encode_only=True) with "
                     "llm.encode() for optimized batch-forward inference that "
                     "bypasses the decoder scheduler.", architectures[0])
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3710,7 +3710,7 @@ class TorchLlmArgs(BaseLlmArgs):
         status="prototype",
     )
 
-    encoder_only: Optional[bool] = Field(
+    encode_only: Optional[bool] = Field(
         default=False,
         description=
         "Set to True to use the batch-forward encode() path, which runs a "

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3710,6 +3710,16 @@ class TorchLlmArgs(BaseLlmArgs):
         status="prototype",
     )
 
+    encoder_only: Optional[bool] = Field(
+        default=None,
+        description=
+        "Set to True for encoder-only models (BERT, RoBERTa, reward models, "
+        "etc.) to enable the optimized batch-forward encode() path that "
+        "bypasses the decoder scheduler and autoregressive loop. When None, "
+        "proceed with the old generate() path.",
+        status="prototype",
+    )
+
     ray_worker_extension_cls: Optional[str] = Field(
         default=None,
         description="The full worker extension class name including module path. "

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3710,7 +3710,7 @@ class TorchLlmArgs(BaseLlmArgs):
         status="prototype",
     )
 
-    encode_only: Optional[bool] = Field(
+    encode_only: bool = Field(
         default=False,
         description=
         "Set to True to use the batch-forward encode() path, which runs a "

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3711,12 +3711,14 @@ class TorchLlmArgs(BaseLlmArgs):
     )
 
     encoder_only: Optional[bool] = Field(
-        default=None,
+        default=False,
         description=
-        "Set to True for encoder-only models (BERT, RoBERTa, reward models, "
-        "etc.) to enable the optimized batch-forward encode() path that "
-        "bypasses the decoder scheduler and autoregressive loop. When None, "
-        "proceed with the old generate() path.",
+        "Set to True to use the batch-forward encode() path, which runs a "
+        "single forward pass and returns the model output directly, bypassing "
+        "the scheduler and autoregressive loop. Works for encoder-only "
+        "models (BERT, RoBERTa, reward models) and decoder models used in "
+        "single-prefill mode (e.g., extracting embeddings). When False "
+        "(default), uses the standard generate() path.",
         status="prototype",
     )
 

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch_encode.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch_encode.py
@@ -16,14 +16,10 @@
 
 These tests exercise the LLM(encode_only=True) / llm.encode() single-forward
 prefill path and verify output correctness by direct logits comparison against
-HuggingFace reference models. Unlike the dataset-driven AccuracyTask flow, we
-compare tensors in-process — encode() doesn't generate, so there's no
-SamplingParams / EVALUATOR_CLS to plug into.
+HuggingFace reference models.
 
 Each decoder model is chosen as the *sole representative* of a distinct TRT-LLM
 model architecture class (e.g. LlamaForCausalLM, Gemma3ForCausalLM).
-Memory-gated models use pytest.param(marks=skip_less_device_memory(...)) so
-too-small GPUs auto-skip.
 
 Note: encode() is single-GPU only (no TP/PP). Every listed model is
 architecturally required to fit on one GPU for these tests.
@@ -44,28 +40,41 @@ PROMPTS = [
     "The future of AI is",
 ]
 
+_TORCH_TO_LLM_DTYPE = {
+    torch.bfloat16: "bfloat16",
+    torch.float16: "float16",
+    torch.float32: "float32",
+}
+
+
+def _resolve_checkpoint_dtype(model_path: str, trust_remote_code: bool = False):
+    """Derive the checkpoint's native precision from its HF config."""
+    from transformers import AutoConfig
+
+    cfg = AutoConfig.from_pretrained(model_path, trust_remote_code=trust_remote_code)
+    torch_dtype = getattr(cfg, "torch_dtype", None)
+    if not isinstance(torch_dtype, torch.dtype):
+        torch_dtype = torch.float32
+    llm_dtype = _TORCH_TO_LLM_DTYPE.get(torch_dtype, "auto")
+    return torch_dtype, llm_dtype
+
 
 # --------------------------------------------------------------------------- #
 # Encoder-only models (non-multimodal)
 # --------------------------------------------------------------------------- #
-#
-# Only architectures registered in tensorrt_llm/_torch/models/ via
-# @register_auto_model are resolvable. Plain BertModel / RobertaModel / DeBERTa
-# are NOT currently registered in the PyTorch backend.
-#
-# The third tuple element is an output-type tag that selects the HF reference
-# class and comparison strategy.
-ENCODER_MODELS = [
+
+CLASSIFICATION_MODELS = [
     pytest.param(
         "textattack/bert-base-uncased-yelp-polarity",
         f"{llm_models_root()}/bert/bert-base-uncased-yelp-polarity",
-        "classification",
         id="bert-yelp",
     ),
+]
+
+PER_TOKEN_REWARD_MODELS = [
     pytest.param(
         "Qwen/Qwen2.5-Math-PRM-7B",
         f"{llm_models_root()}/Qwen2.5-Math-PRM-7B",
-        "per_token_reward",
         marks=pytest.mark.skip_less_device_memory(32000),
         id="qwen2.5-prm-7b",
     ),
@@ -80,49 +89,72 @@ class TestEncoderEncode(LlmapiAccuracyTestHarness):
     here because the model differs per parametrize invocation.
     """
 
-    @pytest.mark.parametrize("model_name,model_path,output_type", ENCODER_MODELS)
-    def test_encode_matches_huggingface(self, model_name, model_path, output_type):
-        """encode() logits match HF reference within tolerance / argmax."""
-        if output_type == "classification":
-            from transformers import AutoModelForSequenceClassification, AutoTokenizer
+    @pytest.mark.parametrize("model_name,model_path", CLASSIFICATION_MODELS)
+    def test_encode_matches_huggingface_classification(self, model_name, model_path):
+        """Encoder classification heads: direct tensor compare on pooled logits.
 
-            hf_cls = AutoModelForSequenceClassification
-        else:
-            # Reward models share the causal-LM backbone + a scoring head.
-            # Loading via AutoModelForCausalLM gives us the raw token logits;
-            # trust_remote_code handles models whose heads are defined in
-            # their own modeling file (e.g., Qwen2ForProcessRewardModel).
-            from transformers import AutoModelForCausalLM, AutoTokenizer
+        A classification head pools over the sequence (BERT: [CLS] token) and
+        emits a single [num_classes] vector per prompt.
+        """
+        from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-            hf_cls = AutoModelForCausalLM
+        # Resolve the checkpoint's native precision.
+        torch_dtype, llm_dtype = _resolve_checkpoint_dtype(model_path)
 
-        with LLM(model_path, encode_only=True) as llm:
+        with LLM(model_path, encode_only=True, dtype=llm_dtype) as llm:
             outs = llm.encode(PROMPTS)
 
-        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
-        hf_model = hf_cls.from_pretrained(model_path, trust_remote_code=True).half().cuda().eval()
+        tokenizer = AutoTokenizer.from_pretrained(model_path)
+        hf_model = (
+            AutoModelForSequenceClassification.from_pretrained(model_path, torch_dtype=torch_dtype)
+            .cuda()
+            .eval()
+        )
         with torch.inference_mode():
             inputs = tokenizer(PROMPTS, return_tensors="pt", padding="longest").to(hf_model.device)
             hf_logits = hf_model(**inputs).logits.float().cpu()
+        tllm_logits = torch.stack([o.logits.cpu() for o in outs])
 
-        if output_type == "classification":
-            # Classification heads produce identically-shaped outputs;
-            # direct tensor comparison with the same FP16 tolerance as the
-            # unit test (rtol=atol=1.5e-2).
-            tllm_logits = torch.stack([o.logits.cpu() for o in outs])
-            torch.testing.assert_close(tllm_logits, hf_logits, rtol=1.5e-2, atol=1.5e-2)
-        else:
-            # Per-token reward output may be nested / per-sequence in TRT-LLM
-            # (see Qwen2ForProcessRewardModel). Compare last-token argmax
-            # per prompt — robust to shape differences.
-            for i in range(len(PROMPTS)):
-                t = outs[i].logits.cpu().float()
-                t_last = t[-1] if t.dim() > 1 else t
-                hf_last = hf_logits[i, -1]
-                assert t_last.argmax(dim=-1) == hf_last.argmax(dim=-1), (
-                    f"[{model_name}] prompt#{i} argmax mismatch: "
-                    f"TLLM={t_last.argmax(dim=-1)} vs HF={hf_last.argmax(dim=-1)}"
-                )
+        torch.testing.assert_close(tllm_logits, hf_logits, rtol=1.5e-2, atol=1.5e-2)
+
+    @pytest.mark.parametrize("model_name,model_path", PER_TOKEN_REWARD_MODELS)
+    def test_encode_matches_huggingface_per_token_reward(self, model_name, model_path):
+        """Per-token reward models: last-content-token argmax per prompt."""
+        from transformers import AutoModel, AutoTokenizer
+
+        # Resolve the checkpoint's native precision.
+        torch_dtype, llm_dtype = _resolve_checkpoint_dtype(model_path, trust_remote_code=True)
+
+        with LLM(model_path, encode_only=True, dtype=llm_dtype) as llm:
+            outs = llm.encode(PROMPTS)
+
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        hf_model = (
+            AutoModel.from_pretrained(model_path, trust_remote_code=True, torch_dtype=torch_dtype)
+            .cuda()
+            .eval()
+        )
+        # Force use_cache=False: Qwen2.5-Math-PRM-7B's vendored
+        # modeling_qwen2_rm.py was authored against an older transformers Cache
+        # API and calls DynamicCache.get_usable_length(), which no longer
+        # exists. A single-prefill logits comparison needs no KV cache anyway;
+        # disabling it sidesteps the vendored-code incompatibility.
+        hf_model.config.use_cache = False
+
+        # Tokenize and run HF one prompt at a time, matching TRT-LLM's per-prompt semantics.
+        for i, prompt in enumerate(PROMPTS):
+            with torch.inference_mode():
+                ids = tokenizer(prompt, return_tensors="pt").to(hf_model.device)
+                hf_prompt_logits = hf_model(**ids, use_cache=False).logits.float().cpu()
+            hf_last = hf_prompt_logits[0, -1]
+
+            t = outs[i].logits.cpu().float()
+            t_last = t[-1] if t.dim() > 1 else t
+            assert t_last.argmax(dim=-1) == hf_last.argmax(dim=-1), (
+                f"[{model_name}] prompt#{i} argmax mismatch: "
+                f"TLLM={t_last.argmax(dim=-1)} (logits={t_last.tolist()}) vs "
+                f"HF={hf_last.argmax(dim=-1)} (logits={hf_last.tolist()})"
+            )
 
 
 # --------------------------------------------------------------------------- #
@@ -183,35 +215,96 @@ DECODER_MODELS = [
 
 
 class TestDecoderEncode(LlmapiAccuracyTestHarness):
-    """Validates encode() on decoder models used in single-prefill mode.
+    """Validates encode() on decoder models used in single-prefill mode."""
 
-    The encode_only flag claims support for decoder models running a single
-    prefill (e.g., for embedding extraction). This class exercises one
-    representative per distinct TRT-LLM architecture class.
-    """
+    PROMPTS = [
+        "The quick brown fox",
+        "Hello, world! How are you today?",
+        (
+            "In a distant galaxy, an advanced civilization discovered "
+            "that time is not linear, and they"
+        ),
+    ]
+
+    # Top-K size used for the argmax-in-top-K containment / overlap checks.
+    # Chosen to be robust to near-tie argmax flips under FP16/BF16 rounding
+    # on very large vocabularies (Gemma-3 has 262K tokens).
+    TOPK = 5
+    TOPK_MIN_OVERLAP = 2
 
     @pytest.mark.threadleak(enabled=False)
     @pytest.mark.parametrize("model_name,model_path", DECODER_MODELS)
     def test_encode_matches_huggingface(self, model_name, model_path):
-        """encode() last-token argmax matches HF causal-LM prefill."""
+        """encode() last-token logits match HF causal-LM prefill.
+
+        Two checks are performed:
+
+        1. **Top-K semantic check** — top-1 on each side must appear in the
+           other side's top-K, and the top-K sets must overlap by at least
+           ``TOPK_MIN_OVERLAP``.
+
+        2. **Focused numerical check** — ``torch.testing.assert_close`` is
+           restricted to the union of both sides' top-K indices.
+        """
         from transformers import AutoModelForCausalLM, AutoTokenizer
 
-        prompts = ["The quick brown fox"]
-        with LLM(model_path, encode_only=True) as llm:
-            tllm_logits = llm.encode(prompts)[0].logits.cpu().float()
+        # Resolve the checkpoint's native precision.
+        torch_dtype, llm_dtype = _resolve_checkpoint_dtype(model_path)
+
+        with LLM(model_path, encode_only=True, dtype=llm_dtype) as llm:
+            outs = llm.encode(self.PROMPTS)
 
         tokenizer = AutoTokenizer.from_pretrained(model_path)
-        hf_model = AutoModelForCausalLM.from_pretrained(model_path).half().cuda().eval()
-        with torch.inference_mode():
-            inputs = tokenizer(prompts, return_tensors="pt").to(hf_model.device)
-            hf_logits = hf_model(**inputs).logits.float().cpu()
+        hf_model = (
+            AutoModelForCausalLM.from_pretrained(model_path, torch_dtype=torch_dtype).cuda().eval()
+        )
 
-        hf_last_pred = hf_logits[0, -1].argmax(dim=-1)
-        # TRT-LLM may return [vocab_size] (last-token only) or
-        # [seq_len, vocab_size] depending on the path. Handle both.
-        tllm_last_pred = (
-            tllm_logits[-1].argmax(dim=-1) if tllm_logits.dim() > 1 else tllm_logits.argmax(dim=-1)
-        )
-        assert tllm_last_pred == hf_last_pred, (
-            f"[{model_name}] TLLM predicted {tllm_last_pred} vs HF predicted {hf_last_pred}"
-        )
+        # encode() routes decoder causal LMs through LogitsProcessor with
+        # gather_context_logits=False, which returns last-token logits only
+        # (shape [vocab_size] per prompt). Per-token logits would require a
+        # separate encode() flag — tracked as follow-up work. See
+        # tensorrt_llm/_torch/modules/logits_processor.py.
+        for i, prompt in enumerate(self.PROMPTS):
+            with torch.inference_mode():
+                inputs = tokenizer(prompt, return_tensors="pt").to(hf_model.device)
+                hf_last = hf_model(**inputs).logits[0, -1].float().cpu()
+
+            tllm_last = outs[i].logits.cpu().float()
+
+            tllm_topk = tllm_last.topk(self.TOPK).indices
+            hf_topk = hf_last.topk(self.TOPK).indices
+            tllm_top1 = tllm_topk[0].item()
+            hf_top1 = hf_topk[0].item()
+            tllm_topk_set = set(tllm_topk.tolist())
+            hf_topk_set = set(hf_topk.tolist())
+            overlap = len(tllm_topk_set & hf_topk_set)
+
+            # (1) Semantic check — top-1 must be in the other side's top-K,
+            # and the top-K sets must substantially overlap.
+            assert tllm_top1 in hf_topk_set and hf_top1 in tllm_topk_set, (
+                f"[{model_name}] prompt#{i} ({prompt!r}) top-1 not in the "
+                f"other side's top-{self.TOPK}: "
+                f"TLLM top-1={tllm_top1}, HF top-1={hf_top1}, "
+                f"TLLM top-{self.TOPK}={sorted(tllm_topk_set)}, "
+                f"HF top-{self.TOPK}={sorted(hf_topk_set)}"
+            )
+            assert overlap >= self.TOPK_MIN_OVERLAP, (
+                f"[{model_name}] prompt#{i} ({prompt!r}) top-{self.TOPK} "
+                f"overlap {overlap} < {self.TOPK_MIN_OVERLAP}: "
+                f"TLLM={sorted(tllm_topk_set)}, HF={sorted(hf_topk_set)}"
+            )
+
+            # (2) Focused numerical check — compare logits only at the
+            # union of both sides' top-K indices.
+            important_idx = torch.unique(torch.cat([tllm_topk, hf_topk]))
+            torch.testing.assert_close(
+                tllm_last[important_idx],
+                hf_last[important_idx],
+                atol=0.4,
+                rtol=0.4,
+                msg=lambda m: (
+                    f"[{model_name}] prompt#{i} ({prompt!r}) top-K logits "
+                    f"differ beyond tolerance.\nTLLM={tllm_last[important_idx].tolist()}\n"
+                    f"HF={hf_last[important_idx].tolist()}\n{m}"
+                ),
+            )

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch_encode.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch_encode.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Accuracy tests for the llm.encode() path across encoder and decoder models.
+
+These tests exercise the LLM(encode_only=True) / llm.encode() single-forward
+prefill path and verify output correctness by direct logits comparison against
+HuggingFace reference models. Unlike the dataset-driven AccuracyTask flow, we
+compare tensors in-process — encode() doesn't generate, so there's no
+SamplingParams / EVALUATOR_CLS to plug into.
+
+Each decoder model is chosen as the *sole representative* of a distinct TRT-LLM
+model architecture class (e.g. LlamaForCausalLM, Gemma3ForCausalLM).
+Memory-gated models use pytest.param(marks=skip_less_device_memory(...)) so
+too-small GPUs auto-skip.
+
+Note: encode() is single-GPU only (no TP/PP). Every listed model is
+architecturally required to fit on one GPU for these tests.
+"""
+
+import pytest
+import torch
+
+from tensorrt_llm import LLM
+
+from ..conftest import llm_models_root
+from .accuracy_core import LlmapiAccuracyTestHarness
+
+PROMPTS = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Encoder-only models (non-multimodal)
+# --------------------------------------------------------------------------- #
+#
+# Only architectures registered in tensorrt_llm/_torch/models/ via
+# @register_auto_model are resolvable. Plain BertModel / RobertaModel / DeBERTa
+# are NOT currently registered in the PyTorch backend.
+#
+# The third tuple element is an output-type tag that selects the HF reference
+# class and comparison strategy.
+ENCODER_MODELS = [
+    pytest.param(
+        "textattack/bert-base-uncased-yelp-polarity",
+        f"{llm_models_root()}/bert/bert-base-uncased-yelp-polarity",
+        "classification",
+        id="bert-yelp",
+    ),
+    pytest.param(
+        "Qwen/Qwen2.5-Math-PRM-7B",
+        f"{llm_models_root()}/Qwen2.5-Math-PRM-7B",
+        "per_token_reward",
+        marks=pytest.mark.skip_less_device_memory(32000),
+        id="qwen2.5-prm-7b",
+    ),
+]
+
+
+class TestEncoderEncode(LlmapiAccuracyTestHarness):
+    """HF logits-level accuracy for encoder-only (non-MM) architectures.
+
+    Inherits LlmapiAccuracyTestHarness only for its class-scoped logger-level
+    fixture. The harness' MODEL_NAME / MODEL_PATH attributes are not used
+    here because the model differs per parametrize invocation.
+    """
+
+    @pytest.mark.parametrize("model_name,model_path,output_type", ENCODER_MODELS)
+    def test_encode_matches_huggingface(self, model_name, model_path, output_type):
+        """encode() logits match HF reference within tolerance / argmax."""
+        if output_type == "classification":
+            from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+            hf_cls = AutoModelForSequenceClassification
+        else:
+            # Reward models share the causal-LM backbone + a scoring head.
+            # Loading via AutoModelForCausalLM gives us the raw token logits;
+            # trust_remote_code handles models whose heads are defined in
+            # their own modeling file (e.g., Qwen2ForProcessRewardModel).
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+
+            hf_cls = AutoModelForCausalLM
+
+        with LLM(model_path, encode_only=True) as llm:
+            outs = llm.encode(PROMPTS)
+
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        hf_model = hf_cls.from_pretrained(model_path, trust_remote_code=True).half().cuda().eval()
+        with torch.inference_mode():
+            inputs = tokenizer(PROMPTS, return_tensors="pt", padding="longest").to(hf_model.device)
+            hf_logits = hf_model(**inputs).logits.float().cpu()
+
+        if output_type == "classification":
+            # Classification heads produce identically-shaped outputs;
+            # direct tensor comparison with the same FP16 tolerance as the
+            # unit test (rtol=atol=1.5e-2).
+            tllm_logits = torch.stack([o.logits.cpu() for o in outs])
+            torch.testing.assert_close(tllm_logits, hf_logits, rtol=1.5e-2, atol=1.5e-2)
+        else:
+            # Per-token reward output may be nested / per-sequence in TRT-LLM
+            # (see Qwen2ForProcessRewardModel). Compare last-token argmax
+            # per prompt — robust to shape differences.
+            for i in range(len(PROMPTS)):
+                t = outs[i].logits.cpu().float()
+                t_last = t[-1] if t.dim() > 1 else t
+                hf_last = hf_logits[i, -1]
+                assert t_last.argmax(dim=-1) == hf_last.argmax(dim=-1), (
+                    f"[{model_name}] prompt#{i} argmax mismatch: "
+                    f"TLLM={t_last.argmax(dim=-1)} vs HF={hf_last.argmax(dim=-1)}"
+                )
+
+
+# --------------------------------------------------------------------------- #
+# Decoder models used in single-prefill mode
+# --------------------------------------------------------------------------- #
+#
+# encode() on a decoder model runs a single prefill and returns logits without
+# running the autoregressive loop. Use case: embedding extraction, reward /
+# classification scoring on a causal LM backbone.
+#
+# One representative per distinct TRT-LLM architecture class:
+#   LlamaForCausalLM   — TinyLlama (also covers Mistral, which aliases LlamaModel)
+#   Gemma3ForCausalLM  — Gemma-3-1B (sliding window + global alternation)
+#   Phi3ForCausalLM    — Phi-4-mini (SuRoPE, merged QKV)
+#   Qwen2ForCausalLM   — Qwen2-7B (distinct GQA head config, SwiGLU variant)
+#   Qwen3ForCausalLM   — Qwen3-0.6B (QKNorm, architecturally distinct from Qwen2)
+#   Starcoder2ForCausalLM — StarCoder2-3B (MQA, sliding window, code model)
+DECODER_MODELS = [
+    # -- LlamaForCausalLM (covers Llama + Mistral family) --
+    pytest.param(
+        "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+        f"{llm_models_root()}/llama-models-v2/TinyLlama-1.1B-Chat-v1.0",
+        id="tinyllama-1.1b",
+    ),
+    # -- Gemma3ForCausalLM --
+    pytest.param(
+        "google/gemma-3-1b-it",
+        f"{llm_models_root()}/gemma/gemma-3-1b-it/",
+        id="gemma-3-1b",
+    ),
+    # -- Phi3ForCausalLM --
+    pytest.param(
+        "microsoft/Phi-4-mini-instruct",
+        f"{llm_models_root()}/Phi-4-mini-instruct",
+        marks=pytest.mark.skip_less_device_memory(24000),
+        id="phi-4-mini",
+    ),
+    # -- Qwen2ForCausalLM --
+    pytest.param(
+        "Qwen/Qwen2-7B-Instruct",
+        f"{llm_models_root()}/Qwen2-7B-Instruct",
+        marks=pytest.mark.skip_less_device_memory(32000),
+        id="qwen2-7b",
+    ),
+    # -- Qwen3ForCausalLM --
+    pytest.param(
+        "Qwen/Qwen3-0.6B",
+        f"{llm_models_root()}/Qwen3/Qwen3-0.6B",
+        id="qwen3-0.6b",
+    ),
+    # -- Starcoder2ForCausalLM --
+    pytest.param(
+        "bigcode/starcoder2-3b",
+        f"{llm_models_root()}/starcoder2-3b/",
+        id="starcoder2-3b",
+    ),
+]
+
+
+class TestDecoderEncode(LlmapiAccuracyTestHarness):
+    """Validates encode() on decoder models used in single-prefill mode.
+
+    The encode_only flag claims support for decoder models running a single
+    prefill (e.g., for embedding extraction). This class exercises one
+    representative per distinct TRT-LLM architecture class.
+    """
+
+    @pytest.mark.threadleak(enabled=False)
+    @pytest.mark.parametrize("model_name,model_path", DECODER_MODELS)
+    def test_encode_matches_huggingface(self, model_name, model_path):
+        """encode() last-token argmax matches HF causal-LM prefill."""
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        prompts = ["The quick brown fox"]
+        with LLM(model_path, encode_only=True) as llm:
+            tllm_logits = llm.encode(prompts)[0].logits.cpu().float()
+
+        tokenizer = AutoTokenizer.from_pretrained(model_path)
+        hf_model = AutoModelForCausalLM.from_pretrained(model_path).half().cuda().eval()
+        with torch.inference_mode():
+            inputs = tokenizer(prompts, return_tensors="pt").to(hf_model.device)
+            hf_logits = hf_model(**inputs).logits.float().cpu()
+
+        hf_last_pred = hf_logits[0, -1].argmax(dim=-1)
+        # TRT-LLM may return [vocab_size] (last-token only) or
+        # [seq_len, vocab_size] depending on the path. Handle both.
+        tllm_last_pred = (
+            tllm_logits[-1].argmax(dim=-1) if tllm_logits.dim() > 1 else tllm_logits.argmax(dim=-1)
+        )
+        assert tllm_last_pred == hf_last_pred, (
+            f"[{model_name}] TLLM predicted {tllm_last_pred} vs HF predicted {hf_last_pred}"
+        )

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -752,6 +752,14 @@ accuracy/test_llm_api_pytorch.py::TestQwen3NextInstruct::test_nvfp4[tp4ep4_adp_o
 accuracy/test_llm_api_pytorch.py::TestQwen3NextInstruct::test_nvfp4[tp4ep4_adp_on-trtllm]
 accuracy/test_llm_api_pytorch.py::TestQwen3NextThinking::test_auto_dtype[tp4ep4]
 accuracy/test_llm_api_pytorch.py::TestSeedOss_36B::test_auto_dtype
+accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface_classification[bert-yelp]
+accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface_per_token_reward[qwen2.5-prm-7b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[tinyllama-1.1b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[gemma-3-1b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[phi-4-mini]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[qwen2-7b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[qwen3-0.6b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[starcoder2-3b]
 accuracy/test_llm_api_pytorch_multimodal.py::TestGemma3_27BInstruct::test_fp8_prequantized
 accuracy/test_llm_api_pytorch_multimodal.py::TestMistralLarge3_675B::test_nvfp4_4gpus[latency_moe_trtllm]
 accuracy/test_llm_api_pytorch_multimodal.py::TestNemotron_Nano_12B_V2_VL::test_auto_dtype

--- a/tests/integration/test_lists/qa/llm_function_l20.txt
+++ b/tests/integration/test_lists/qa/llm_function_l20.txt
@@ -46,6 +46,15 @@ accuracy/test_llm_api_pytorch.py::TestMinistral8BInstruct::test_fp8
 accuracy/test_llm_api_pytorch.py::TestPhi4MiniInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestMistralNemo12B::test_auto_dtype
 
+accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface_classification[bert-yelp]
+accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface_per_token_reward[qwen2.5-prm-7b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[tinyllama-1.1b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[gemma-3-1b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[phi-4-mini]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[qwen2-7b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[qwen3-0.6b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[starcoder2-3b]
+
 accuracy/test_llm_api_pytorch_multimodal.py::TestQwen2_VL_7B::test_auto_dtype
 accuracy/test_llm_api_pytorch_multimodal.py::TestQwen2_5_VL_7B::test_auto_dtype
 accuracy/test_llm_api_pytorch_multimodal.py::TestNVILA_8B::test_auto_dtype

--- a/tests/integration/test_lists/qa/llm_function_rtx6k.txt
+++ b/tests/integration/test_lists/qa/llm_function_rtx6k.txt
@@ -180,6 +180,15 @@ accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_4gpus[v2_kv_cache-cutl
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_4gpus[v1_kv_cache-cutlass-two_model-no_overlap_scheduler]
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_4gpus[v2_kv_cache-cutlass-two_model-no_overlap_scheduler]
 
+accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface_classification[bert-yelp]
+accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface_per_token_reward[qwen2.5-prm-7b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[tinyllama-1.1b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[gemma-3-1b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[phi-4-mini]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[qwen2-7b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[qwen3-0.6b]
+accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[starcoder2-3b]
+
 accuracy/test_llm_api_pytorch_multimodal.py::TestQwen2_VL_7B::test_auto_dtype
 accuracy/test_llm_api_pytorch_multimodal.py::TestQwen2_5_VL_7B::test_auto_dtype
 accuracy/test_llm_api_pytorch_multimodal.py::TestNVILA_8B::test_auto_dtype

--- a/tests/integration/test_lists/test-db/l0_a100.yml
+++ b/tests/integration/test_lists/test-db/l0_a100.yml
@@ -17,6 +17,7 @@ l0_a100:
     - unittest/llmapi/test_llm_pytorch.py -m "part1"
     - unittest/llmapi/test_llm_pytorch.py -m "part2"
     - unittest/llmapi/test_llm_pytorch.py -m "part3"
+    - unittest/llmapi/test_llm_encode.py
     - unittest/llmapi/test_mpi_session.py ISOLATION
     - unittest/llmapi/test_memory_profiling.py::test_profile_kvcache # profile kvcache for vision encoder
     - unittest/llmapi/test_memory_profiling.py::test_pyexecutor_and_kvcache_share_execution_stream # test that PyExecutor and KVCacheManager share the same execution_stream
@@ -25,6 +26,15 @@ l0_a100:
     - unittest/executor/test_base_worker.py ISOLATION
     - unittest/executor/test_rpc_proxy.py
     - unittest/executor/test_rpc_worker.py
+    # llm.encode() accuracy
+    - accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface[bert-yelp]
+    - accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface[qwen2.5-prm-7b]
+    - accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[tinyllama-1.1b]
+    - accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[gemma-3-1b]
+    - accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[phi-4-mini]
+    - accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[qwen2-7b]
+    - accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[qwen3-0.6b]
+    - accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[starcoder2-3b]
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/integration/test_lists/test-db/l0_a100.yml
+++ b/tests/integration/test_lists/test-db/l0_a100.yml
@@ -27,8 +27,8 @@ l0_a100:
     - unittest/executor/test_rpc_proxy.py
     - unittest/executor/test_rpc_worker.py
     # llm.encode() accuracy
-    - accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface[bert-yelp]
-    - accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface[qwen2.5-prm-7b]
+    - accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface_classification[bert-yelp]
+    - accuracy/test_llm_api_pytorch_encode.py::TestEncoderEncode::test_encode_matches_huggingface_per_token_reward[qwen2.5-prm-7b]
     - accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[tinyllama-1.1b]
     - accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[gemma-3-1b]
     - accuracy/test_llm_api_pytorch_encode.py::TestDecoderEncode::test_encode_matches_huggingface[phi-4-mini]

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -103,6 +103,10 @@ methods:
         annotation: bool
         default: False
         status: prototype
+      encode_only:
+        annotation: bool
+        default: False
+        status: prototype
       disable_overlap_scheduler:
         annotation: bool
         default: False
@@ -307,6 +311,20 @@ methods:
         default: 0.5
         status: prototype
     return_annotation: tensorrt_llm.llmapi.llm.RequestOutput
+  encode:
+    parameters:
+      inputs:
+        annotation: Union[str, List[int], tensorrt_llm.inputs.data.TextPrompt, tensorrt_llm.inputs.data.TokensPrompt,
+          Sequence[Union[str, List[int], tensorrt_llm.inputs.data.TextPrompt, tensorrt_llm.inputs.data.TokensPrompt]]]
+        default: inspect._empty
+      add_special_tokens:
+        annotation: bool
+        default: True
+      model_kwargs:
+        annotation: Any
+        default: inspect._empty
+    return_annotation: Union[tensorrt_llm.llmapi.llm.EncoderOutput, List[tensorrt_llm.llmapi.llm.EncoderOutput]]
+    status: prototype
   preprocess:
     parameters:
       inputs:

--- a/tests/unittest/llmapi/test_llm_encode.py
+++ b/tests/unittest/llmapi/test_llm_encode.py
@@ -35,9 +35,9 @@ PROMPTS = [
 
 @pytest.fixture(scope="module")
 def bert_encode_llm():
-    """Create an LLM with encoder_only=True for BERT, shared across tests."""
+    """Create an LLM with encode_only=True for BERT, shared across tests."""
     model_dir = get_model_path(BERT_MODEL_PATH)
-    llm = LLM(model=model_dir, encoder_only=True)
+    llm = LLM(model=model_dir, encode_only=True)
     yield llm
     llm.shutdown()
 
@@ -134,28 +134,28 @@ def test_encode_matches_huggingface(bert_encode_llm):
 
 
 def test_generate_raises_on_encoder_only(bert_encode_llm):
-    """generate() raises RuntimeError when encoder_only=True."""
-    with pytest.raises(RuntimeError, match="encoder_only=True"):
+    """generate() raises RuntimeError when encode_only=True."""
+    with pytest.raises(RuntimeError, match="encode_only=True"):
         bert_encode_llm.generate(PROMPTS)
 
 
 def test_generate_async_raises_on_encoder_only(bert_encode_llm):
-    """generate_async() raises RuntimeError when encoder_only=True."""
-    with pytest.raises(RuntimeError, match="encoder_only=True"):
+    """generate_async() raises RuntimeError when encode_only=True."""
+    with pytest.raises(RuntimeError, match="encode_only=True"):
         bert_encode_llm.generate_async("Hello")
 
 
 def test_encode_raises_without_encoder_only():
-    """encode() raises RuntimeError on a decoder model (encoder_only=False)."""
+    """encode() raises RuntimeError on a decoder model (encode_only=False)."""
     model_dir = get_model_path(BERT_MODEL_PATH)
-    with LLM(model=model_dir, encoder_only=False, disable_overlap_scheduler=True) as llm:
-        with pytest.raises(RuntimeError, match="encoder_only=True"):
+    with LLM(model=model_dir, encode_only=False, disable_overlap_scheduler=True) as llm:
+        with pytest.raises(RuntimeError, match="encode_only=True"):
             llm.encode("Hello")
 
 
 def test_get_stats_raises_on_encoder_only(bert_encode_llm):
-    """get_stats() raises RuntimeError when encoder_only=True."""
-    with pytest.raises(RuntimeError, match="encoder_only=True"):
+    """get_stats() raises RuntimeError when encode_only=True."""
+    with pytest.raises(RuntimeError, match="encode_only=True"):
         bert_encode_llm.get_stats()
 
 

--- a/tests/unittest/llmapi/test_llm_encode.py
+++ b/tests/unittest/llmapi/test_llm_encode.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from tensorrt_llm import LLM
+from tensorrt_llm.llmapi.llm import EncoderOutput
+
+# isort: off
+from .test_llm import get_model_path
+
+# isort: on
+
+BERT_MODEL_PATH = "bert/bert-base-uncased-yelp-polarity"
+
+PROMPTS = [
+    "Hello, my name is",
+    "The president of the United States is",
+    "The capital of France is",
+    "The future of AI is",
+]
+
+
+@pytest.fixture(scope="module")
+def bert_encode_llm():
+    """Create an LLM with encoder_only=True for BERT, shared across tests."""
+    model_dir = get_model_path(BERT_MODEL_PATH)
+    llm = LLM(model=model_dir, encoder_only=True)
+    yield llm
+    llm.shutdown()
+
+
+# --------------------------------------------------------------------------- #
+# Basic encode() functionality
+# --------------------------------------------------------------------------- #
+
+
+def test_encode_single_string(bert_encode_llm):
+    """encode() with a single string returns a single EncoderOutput."""
+    result = bert_encode_llm.encode("Hello, my name is")
+
+    assert isinstance(result, EncoderOutput)
+    assert isinstance(result.logits, torch.Tensor)
+    assert result.logits.dim() == 1  # [num_classes] for classification
+    assert result.logits.shape[0] == 2  # yelp-polarity has 2 classes
+    assert result.prompt == "Hello, my name is"
+    assert isinstance(result.prompt_token_ids, list)
+    assert len(result.prompt_token_ids) > 0
+
+
+def test_encode_batch(bert_encode_llm):
+    """encode() with a list of strings returns a list of EncoderOutput."""
+    results = bert_encode_llm.encode(PROMPTS)
+
+    assert isinstance(results, list)
+    assert len(results) == len(PROMPTS)
+    for i, result in enumerate(results):
+        assert isinstance(result, EncoderOutput)
+        assert result.logits.shape == (2,)  # 2 classes
+        assert result.prompt == PROMPTS[i]
+
+
+def test_encode_token_ids(bert_encode_llm):
+    """encode() accepts pre-tokenized token ID lists."""
+    token_ids = [101, 7592, 1010, 2026, 2171, 2003, 102]  # "[CLS] hello, my name is [SEP]"
+    result = bert_encode_llm.encode(token_ids)
+
+    assert isinstance(result, EncoderOutput)
+    assert result.logits.shape == (2,)
+    assert result.prompt is None  # no text prompt when passing token IDs
+    assert result.prompt_token_ids == token_ids
+
+
+def test_encode_mixed_batch(bert_encode_llm):
+    """encode() handles mixed input types in a batch."""
+    from tensorrt_llm.inputs import TextPrompt, TokensPrompt
+
+    inputs = [
+        "Hello world",
+        TextPrompt(prompt="Test sentence"),
+        TokensPrompt(prompt_token_ids=[101, 7592, 2088, 102]),
+    ]
+    results = bert_encode_llm.encode(inputs)
+
+    assert len(results) == 3
+    assert results[0].prompt == "Hello world"
+    assert results[1].prompt == "Test sentence"
+    assert results[2].prompt is None
+
+
+# --------------------------------------------------------------------------- #
+# Output correctness — compare with HuggingFace
+# --------------------------------------------------------------------------- #
+
+
+def test_encode_matches_huggingface(bert_encode_llm):
+    """encode() logits match HuggingFace BertForSequenceClassification."""
+    from transformers import (AutoModelForSequenceClassification,
+                              AutoTokenizer)
+
+    model_dir = get_model_path(BERT_MODEL_PATH)
+
+    # Get TRT-LLM results
+    results = bert_encode_llm.encode(PROMPTS)
+    tllm_logits = torch.stack([r.logits.cpu() for r in results])
+
+    # Get HuggingFace results
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    hf_model = AutoModelForSequenceClassification.from_pretrained(model_dir)
+    hf_model = hf_model.half().to(tllm_logits.device)
+
+    with torch.inference_mode():
+        inputs = tokenizer(PROMPTS, return_tensors="pt",
+                           padding="longest").to(hf_model.device)
+        hf_outputs = hf_model(**inputs)
+        hf_logits = hf_outputs.logits.float()
+
+    torch.testing.assert_close(tllm_logits, hf_logits, rtol=1.5e-2,
+                               atol=1.5e-2)
+
+
+# --------------------------------------------------------------------------- #
+# Cross-API guards
+# --------------------------------------------------------------------------- #
+
+
+def test_generate_raises_on_encoder_only(bert_encode_llm):
+    """generate() raises RuntimeError when encoder_only=True."""
+    with pytest.raises(RuntimeError, match="encoder_only=True"):
+        bert_encode_llm.generate(PROMPTS)
+
+
+def test_generate_async_raises_on_encoder_only(bert_encode_llm):
+    """generate_async() raises RuntimeError when encoder_only=True."""
+    with pytest.raises(RuntimeError, match="encoder_only=True"):
+        bert_encode_llm.generate_async("Hello")
+
+
+def test_encode_raises_without_encoder_only():
+    """encode() raises RuntimeError on a decoder model (encoder_only=False)."""
+    model_dir = get_model_path(BERT_MODEL_PATH)
+    with LLM(model=model_dir, encoder_only=False,
+             disable_overlap_scheduler=True) as llm:
+        with pytest.raises(RuntimeError, match="encoder_only=True"):
+            llm.encode("Hello")
+
+
+def test_get_stats_raises_on_encoder_only(bert_encode_llm):
+    """get_stats() raises RuntimeError when encoder_only=True."""
+    with pytest.raises(RuntimeError, match="encoder_only=True"):
+        bert_encode_llm.get_stats()
+
+
+# --------------------------------------------------------------------------- #
+# Input validation
+# --------------------------------------------------------------------------- #
+
+
+def test_encode_empty_string(bert_encode_llm):
+    """encode("") should either raise or produce a valid (empty-ish) result.
+
+    Tokenizing "" with add_special_tokens=True produces [CLS][SEP] (2 tokens),
+    so this is actually a valid input for BERT.
+    """
+    result = bert_encode_llm.encode("")
+    assert isinstance(result, EncoderOutput)
+    assert result.logits.shape == (2,)
+
+
+# --------------------------------------------------------------------------- #
+# Health check
+# --------------------------------------------------------------------------- #
+
+
+def test_check_health_encoder_only(bert_encode_llm):
+    """_check_health() returns True for a live encoder-only LLM."""
+    assert bert_encode_llm._check_health() is True

--- a/tests/unittest/llmapi/test_llm_encode.py
+++ b/tests/unittest/llmapi/test_llm_encode.py
@@ -107,8 +107,7 @@ def test_encode_mixed_batch(bert_encode_llm):
 
 def test_encode_matches_huggingface(bert_encode_llm):
     """encode() logits match HuggingFace BertForSequenceClassification."""
-    from transformers import (AutoModelForSequenceClassification,
-                              AutoTokenizer)
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
     model_dir = get_model_path(BERT_MODEL_PATH)
 
@@ -119,16 +118,14 @@ def test_encode_matches_huggingface(bert_encode_llm):
     # Get HuggingFace results
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
     hf_model = AutoModelForSequenceClassification.from_pretrained(model_dir)
-    hf_model = hf_model.half().to(tllm_logits.device)
+    hf_model = hf_model.half().cuda()
 
     with torch.inference_mode():
-        inputs = tokenizer(PROMPTS, return_tensors="pt",
-                           padding="longest").to(hf_model.device)
+        inputs = tokenizer(PROMPTS, return_tensors="pt", padding="longest").to(hf_model.device)
         hf_outputs = hf_model(**inputs)
-        hf_logits = hf_outputs.logits.float()
+        hf_logits = hf_outputs.logits.float().cpu()
 
-    torch.testing.assert_close(tllm_logits, hf_logits, rtol=1.5e-2,
-                               atol=1.5e-2)
+    torch.testing.assert_close(tllm_logits, hf_logits, rtol=1.5e-2, atol=1.5e-2)
 
 
 # --------------------------------------------------------------------------- #
@@ -151,8 +148,7 @@ def test_generate_async_raises_on_encoder_only(bert_encode_llm):
 def test_encode_raises_without_encoder_only():
     """encode() raises RuntimeError on a decoder model (encoder_only=False)."""
     model_dir = get_model_path(BERT_MODEL_PATH)
-    with LLM(model=model_dir, encoder_only=False,
-             disable_overlap_scheduler=True) as llm:
+    with LLM(model=model_dir, encoder_only=False, disable_overlap_scheduler=True) as llm:
         with pytest.raises(RuntimeError, match="encoder_only=True"):
             llm.encode("Hello")
 

--- a/tests/unittest/llmapi/test_llm_encode.py
+++ b/tests/unittest/llmapi/test_llm_encode.py
@@ -101,34 +101,6 @@ def test_encode_mixed_batch(bert_encode_llm):
 
 
 # --------------------------------------------------------------------------- #
-# Output correctness — compare with HuggingFace
-# --------------------------------------------------------------------------- #
-
-
-def test_encode_matches_huggingface(bert_encode_llm):
-    """encode() logits match HuggingFace BertForSequenceClassification."""
-    from transformers import AutoModelForSequenceClassification, AutoTokenizer
-
-    model_dir = get_model_path(BERT_MODEL_PATH)
-
-    # Get TRT-LLM results
-    results = bert_encode_llm.encode(PROMPTS)
-    tllm_logits = torch.stack([r.logits.cpu() for r in results])
-
-    # Get HuggingFace results
-    tokenizer = AutoTokenizer.from_pretrained(model_dir)
-    hf_model = AutoModelForSequenceClassification.from_pretrained(model_dir)
-    hf_model = hf_model.half().cuda()
-
-    with torch.inference_mode():
-        inputs = tokenizer(PROMPTS, return_tensors="pt", padding="longest").to(hf_model.device)
-        hf_outputs = hf_model(**inputs)
-        hf_logits = hf_outputs.logits.float().cpu()
-
-    torch.testing.assert_close(tllm_logits, hf_logits, rtol=1.5e-2, atol=1.5e-2)
-
-
-# --------------------------------------------------------------------------- #
 # Cross-API guards
 # --------------------------------------------------------------------------- #
 
@@ -160,6 +132,42 @@ def test_get_stats_raises_on_encoder_only(bert_encode_llm):
 
 
 # --------------------------------------------------------------------------- #
+# Batch tokenization (Triton pattern)
+# --------------------------------------------------------------------------- #
+
+
+def test_encode_batch_token_ids(bert_encode_llm):
+    """encode() with a batch of pre-tokenized token IDs (Triton serving pattern).
+
+    This validates the batch tokenization pattern used in the Triton backend
+    example, where the tokenizer is called once for the entire batch and
+    the resulting token IDs are passed to encode().
+    """
+    from transformers import AutoTokenizer
+
+    model_dir = get_model_path(BERT_MODEL_PATH)
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+
+    # Batch tokenize — one tokenizer call for all prompts
+    encoded = tokenizer(PROMPTS, padding=False, truncation=True, max_length=512)
+    token_ids_list = encoded["input_ids"]
+
+    # Pass pre-tokenized IDs to encode()
+    results_from_ids = bert_encode_llm.encode(token_ids_list)
+
+    # Compare with string-based tokenization
+    results_from_strings = bert_encode_llm.encode(PROMPTS)
+
+    assert len(results_from_ids) == len(results_from_strings)
+    for r_ids, r_str in zip(results_from_ids, results_from_strings):
+        # Logits should be identical — same model, same tokens
+        torch.testing.assert_close(r_ids.logits, r_str.logits)
+        # Token IDs passed directly don't get re-tokenized
+        assert r_ids.prompt is None
+        assert r_str.prompt is not None
+
+
+# --------------------------------------------------------------------------- #
 # Input validation
 # --------------------------------------------------------------------------- #
 
@@ -173,6 +181,30 @@ def test_encode_empty_string(bert_encode_llm):
     result = bert_encode_llm.encode("")
     assert isinstance(result, EncoderOutput)
     assert result.logits.shape == (2,)
+
+
+def test_encode_oversized_batch(bert_encode_llm):
+    """encode() raises ValueError when batch exceeds max_batch_size."""
+    engine = bert_encode_llm._encoder_executor.model_engine
+    max_batch = engine.batch_size
+
+    # Create a batch that exceeds max_batch_size
+    oversized = ["Hello"] * (max_batch + 1)
+    with pytest.raises(ValueError, match="max_batch_size"):
+        bert_encode_llm.encode(oversized)
+
+
+def test_encode_add_special_tokens_false(bert_encode_llm):
+    """add_special_tokens=False skips [CLS]/[SEP] tokens."""
+    result_with = bert_encode_llm.encode("Hello world", add_special_tokens=True)
+    result_without = bert_encode_llm.encode("Hello world", add_special_tokens=False)
+
+    # With special tokens: [CLS] hello world [SEP] = more tokens
+    # Without: hello world = fewer tokens
+    assert len(result_with.prompt_token_ids) > len(result_without.prompt_token_ids)
+    # Both should still produce valid classification output
+    assert result_with.logits.shape == (2,)
+    assert result_without.logits.shape == (2,)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added encoder-only execution mode via new `encode_only` parameter for models like BERT
* Introduced `encode()` API method for efficient encode-only inference
* Added `EncoderOutput` dataclass containing logits and tokenized prompts
* Generation APIs now raise errors when encode-only mode is active

## Tests
* Added test coverage for encode-only inference, batch processing, and API validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

 ## Summary                                                                                                                                                             
   
  Adds a dedicated `llm.encode()` API for encode-only paths that bypasses the decoder-oriented PyExecutor loop entirely. Works for encoder models and decoder models running a "single-prefill" path.
                                                         
 ### Problem

  The current LLM API routes encoder models through the same `PyExecutor` designed for autoregressive decoders, introducing significant CPU overhead per batch from scheduler, KV cache management, sampling, and request state machine — none of which apply to encoders. **Encoder models need a simple, direct path to the model’s forward call with batch inference executed in a single pass.**
                                                                                                                                                                         
  ### Solution
  A new execution path (`encode_only=True`) that creates a lightweight `EncoderExecutor` instead of the full `PyExecutor`. The `encode()` method tokenizes, packs, and runs a single forward pass directly through `ModelEngine.encoder_forward()`, returning `EncoderOutput` with logits. **This new API demonstrates a 3.92× speedup for the BERT 110M model (`textattack/bert-base-uncased-yelp-polarity`) in eager mode with batch size 10.**
  ```
  encode()   mean: 5.17ms  (p50=5.16ms)
  generate() mean: 20.25ms (p50=20.02ms)
  Speedup: 3.92x
  ```

## Usage                                              
  ```python
  # New dedicated path
  llm = LLM(model="bert-base-uncased-yelp-polarity", encode_only=True)
  outputs = llm.encode(["Hello world", "Test sentence"])                                                                                                                 
  print(outputs[0].logits)  # [num_classes] tensor
                                                                                                                                                                         
  # Old path still works unchanged (no encode_only flag)
  llm = LLM(model="bert-base-uncased-yelp-polarity", disable_overlap_scheduler=True)
  outputs = llm.generate(prompts, SamplingParams(return_context_logits=True))    
```                                                                                                                                                                                                                                     
                                                         
  - `encode_only=True` must be explicitly set. Default (None) uses the old `generate()` path.
  - `encode_only=True` creates only `EncoderExecutor`; False/None creates only `PyExecutor`. Mutually exclusive.
  - `generate()/generate_async()` raise `RuntimeError` when `encode_only=True`. `encode()` is the only API.
  - Since `llm.encode()` reuses `PyTorchModelEngine` and its `_forward_step()` path, features like `TorchCompileConfig` are compatible.

## Future Works
                                                                                                                                                                         
  - Encoder CUDA graph integration — capture the encoder model to one single CUDA graph
  - Triton backend update — add an encoder model example
  - Parallelism supports (e.g. TP > 1) — expand the `EncoderExecutor`
  - Other minor optimizations (e.g. batch tokenization, cache `AttentionMetadata`, etc)

## Test Coverage

 - `tests/unittest/llmapi/test_llm_encode.py` — 11 new tests:
    - Basic: single string, batch, token IDs, mixed input types
    - Correctness: logits compared against HuggingFace `BertForSequenceClassification`
    - Health check: _check_health() returns True for encoder-only LLM                                                                   
- Existing tests unaffected (no `encode_only=True` → old path):
    - `tests/integration/defs/test_e2e.py::test_ptp_quickstart_bert`
    - `tests/unittest/llmapi/test_llm_pytorch.py::test_llm_reward_model`

CC: @symphonylyh @amukkara @nvrohanv @schetlur-nv @juney-nvidia 

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [X] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
