### PR TITLE
[TRTLLM-10938][feat] Enable block reuse with overlap scheduler

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -231,7 +231,7 @@ class AsyncTransferManager:
             logger.warning(
                 f"Request {request.py_request_id} not found in transfer manager"
             )
-            return
+            return False
 
         if transfer_metadata.end_transfer():
             self._requests_in_transfer.pop(request.py_request_id)
@@ -610,7 +610,12 @@ class PyExecutor:
                 self._terminate_request(request)
             return
         if self.async_transfer_manager.end_transfer(request):
-            self._terminate_request(request)
+            # When should_store_blocks is True, _handle_responses already
+            # terminated this request via the early-termination path
+            # (enable_partial_reuse_for_disagg branch). Skip the redundant
+            # termination to avoid double free_resources calls.
+            if not self.async_transfer_manager.should_store_blocks:
+                self._terminate_request(request)
 
     # Performance metrics methods are in PerfMetricsManager (self.perf_manager)
 

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -453,14 +453,6 @@ class BaseWorker(GenerationExecutor):
                 context_phase_params = request.disaggregated_params.get_context_phase_params(
                 )
 
-        if self._is_pytorch_backend and not self.llm_args.disable_overlap_scheduler \
-                and self.llm_args.kv_cache_config.enable_block_reuse \
-                and self.engine.kv_cache_transceiver is not None \
-                and request_type == tllm.RequestType.REQUEST_TYPE_CONTEXT_ONLY:
-            raise ValueError(
-                "Context only requests are not supported in pytorch backend when overlap is enabled with block reuse."
-            )
-
         assert request.id is not None
 
         def _deduce_max_tokens(request: GenerationRequest,

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -598,10 +598,6 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
     def test_auto_dtype(self, ctx_disable_overlap_scheduler,
                         gen_disable_overlap_scheduler, ctx_enable_block_reuse,
                         gen_enable_block_reuse):
-        if ctx_enable_block_reuse and not ctx_disable_overlap_scheduler:
-            pytest.skip(
-                "Skip this test because overlap scheduler is not supported with block reuse for context server"
-            )
         ctx_server_config = {
             "disable_overlap_scheduler": ctx_disable_overlap_scheduler,
             "kv_cache_config": {
@@ -1514,7 +1510,7 @@ class TestQwen3_8B(LlmapiAccuracyTestHarness):
         max_batch_size = 32
 
         kv_cache_config = {
-            "enable_block_reuse": True if ctx_pp == 1 else False,
+            "enable_block_reuse": True,
         }
 
         ctx_server_config = {

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap.yaml
@@ -11,9 +11,9 @@ context_servers:
   tensor_parallel_size: 1
   pipeline_parallel_size: 1
   kv_cache_config:
-    enable_block_reuse: false
+    enable_block_reuse: true
+    enable_partial_reuse: true
     free_gpu_memory_fraction: 0.2
-    enable_partial_reuse: false
   cache_transceiver_config:
     backend: DEFAULT
 generation_servers:
@@ -24,8 +24,8 @@ generation_servers:
   max_num_tokens: 4096
   max_seq_len: 4096
   kv_cache_config:
-    enable_block_reuse: false
+    enable_block_reuse: true
+    enable_partial_reuse: true
     free_gpu_memory_fraction: 0.2
-    enable_partial_reuse: false
   cache_transceiver_config:
     backend: DEFAULT

--- a/tests/unittest/_torch/executor/test_overlap_scheduler.py
+++ b/tests/unittest/_torch/executor/test_overlap_scheduler.py
@@ -25,14 +25,16 @@ def model_path():
 def create_llm(model_dir,
                disable_overlap_scheduler,
                sampler_type,
-               scheduler_config=None):
+               scheduler_config=None,
+               enable_block_reuse=False):
     """Create LLM with specific overlap scheduler setting"""
     if scheduler_config is None:
         scheduler_config = SchedulerConfig()
     pytorch_config = dict(disable_overlap_scheduler=disable_overlap_scheduler,
                           sampler_type=sampler_type)
 
-    trt_kv_cache_config = TRT_KvCacheConfig(enable_block_reuse=False)
+    trt_kv_cache_config = TRT_KvCacheConfig(
+        enable_block_reuse=enable_block_reuse)
 
     return LLM(
         model=str(model_dir),
@@ -51,10 +53,13 @@ def create_llm(model_dir,
 @pytest.mark.parametrize("sampler_type", ["TorchSampler", "TRTLLMSampler"])
 @pytest.mark.parametrize("use_python_scheduler", [False, True],
                          ids=["cpp_scheduler", "python_scheduler"])
+@pytest.mark.parametrize("enable_block_reuse", [False, True],
+                         ids=["no_reuse", "block_reuse"])
 @pytest.mark.high_cuda_memory
 @pytest.mark.mpi_ray_parity
 def test_overlap_scheduler_consistency(model_path, test_case, sampler_type,
-                                       use_python_scheduler):
+                                       use_python_scheduler,
+                                       enable_block_reuse):
     scheduler_config = SchedulerConfig(
         use_python_scheduler=use_python_scheduler)
 
@@ -76,7 +81,8 @@ def test_overlap_scheduler_consistency(model_path, test_case, sampler_type,
     with create_llm(model_path,
                     disable_overlap_scheduler=False,
                     sampler_type=sampler_type,
-                    scheduler_config=scheduler_config) as llm:
+                    scheduler_config=scheduler_config,
+                    enable_block_reuse=enable_block_reuse) as llm:
         outputs_with_overlap = llm.generate(prompts,
                                             sampling_params=sampling_config,
                                             use_tqdm=True)
@@ -88,7 +94,8 @@ def test_overlap_scheduler_consistency(model_path, test_case, sampler_type,
     with create_llm(model_path,
                     disable_overlap_scheduler=True,
                     sampler_type=sampler_type,
-                    scheduler_config=scheduler_config) as llm:
+                    scheduler_config=scheduler_config,
+                    enable_block_reuse=enable_block_reuse) as llm:
         outputs_without_overlap = llm.generate(prompts,
                                                sampling_params=sampling_config,
                                                use_tqdm=True)
@@ -98,8 +105,47 @@ def test_overlap_scheduler_consistency(model_path, test_case, sampler_type,
 
     # Verify outputs are consistent
     for with_overlap, without_overlap in zip(texts_with_overlap,
-                                             texts_without_overlap):
+                                             texts_without_overlap,
+                                             strict=True):
         assert with_overlap == without_overlap
+
+
+@pytest.mark.parametrize("sampler_type", ["TorchSampler", "TRTLLMSampler"])
+@pytest.mark.high_cuda_memory
+@pytest.mark.mpi_ray_parity
+def test_overlap_scheduler_block_reuse_cache_hit(model_path, test_case,
+                                                 sampler_type):
+    """Verify that blocks are actually reused when sending the same prompt
+    twice with the overlap scheduler enabled. Uses a single prompt to avoid
+    batch-internal cache hits that could make the cold-cache check flaky."""
+    prompt = test_case["prompts"][0]
+    max_new_tokens = test_case["max_new_tokens"]
+    temperature = test_case["temperature"]
+    top_p = test_case["top_p"]
+    stop_words = test_case["stop_words"]
+
+    sampling_config = SamplingParams(max_tokens=max_new_tokens,
+                                     stop=stop_words,
+                                     temperature=temperature,
+                                     top_p=top_p,
+                                     n=1,
+                                     use_beam_search=True)
+
+    with create_llm(model_path,
+                    disable_overlap_scheduler=False,
+                    sampler_type=sampler_type,
+                    enable_block_reuse=True) as llm:
+        output_first = llm.generate([prompt],
+                                    sampling_params=sampling_config,
+                                    use_tqdm=True)[0]
+        assert output_first.cached_tokens == 0, (
+            "First pass should have no cached tokens (cold cache)")
+
+        output_second = llm.generate([prompt],
+                                     sampling_params=sampling_config,
+                                     use_tqdm=True)[0]
+        assert output_second.cached_tokens > 0, (
+            "Second pass should reuse cached blocks")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * KV cache block reuse is now supported with the overlap scheduler in PyTorch, expanding efficient memory reuse scenarios.

* **Bug Fixes**
  * Deterministic request termination behavior improved to avoid redundant cleanup paths and ensure boolean-based termination outcomes.

* **Tests**
  * Test coverage expanded and test configs updated to exercise block-reuse scenarios and validate scheduler consistency and cache-hit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Re-enable KV cache block reuse (prefix caching) when the overlap scheduler is active. Block reuse and the overlap scheduler were previously mutually exclusive due to an explicit guard in `base_worker.py` that rejected context-only requests in disaggregated serving when both features were enabled.

### Problem

Block reuse (`enable_block_reuse`, default `True`) and the overlap scheduler (`disable_overlap_scheduler=False`, default) are both enabled by default, but their combination was explicitly blocked for disaggregated context-only requests.

### Root cause

Removing the guard exposed a latent issue: both `_handle_responses` (early termination with pinned blocks) and `_end_transfer_and_maybe_terminate` (after KV transfer completes) call `_terminate_request` → `free_resources` on the same request. Under the non-overlap scheduler this was benign because the transfer typically completed before `_handle_responses` ran, so only one path fired. Under the overlap scheduler, the deferred processing creates a window where the transfer is still in-flight when `_handle_responses` terminates the request, causing `end_transfer` to terminate it again.

### Fix

In `_end_transfer_and_maybe_terminate`, skip the redundant `_terminate_request` call when `should_store_blocks` is True, since the early-termination path in `_handle_responses` already handled it. This preserves the existing early-termination + pin/unpin mechanism while preventing the double-termination crash.

### Changes

**`tensorrt_llm/_torch/pyexecutor/py_executor.py`**
- In `_end_transfer_and_maybe_terminate`, guard the non-fast-transfer `_terminate_request` call with `if not should_store_blocks`. When `should_store_blocks` is True, `_handle_responses` already terminated the request via the `enable_partial_reuse_for_disagg` early-termination branch.
- Fix `end_transfer` to return `False` (instead of bare `return`) on `KeyError`, preventing unintended termination by the caller.

**`tensorrt_llm/executor/base_worker.py`**
- Remove the `ValueError` guard that rejected context-only requests when overlap scheduler, block reuse, and KV cache transceiver were all active.

**`tests/unittest/_torch/executor/test_overlap_scheduler.py`**
- Add `enable_block_reuse` parameter to `create_llm` helper and to `test_overlap_scheduler_consistency` as a parametrized axis (`[False, True]`), so the existing consistency test now covers both block reuse configurations.
- Add `test_overlap_scheduler_block_reuse_cache_hit` — sends the same prompt twice and verifies blocks are actually reused (`cached_tokens > 0` on second pass).
- Add `strict=True` to `zip()` call for length-mismatch safety.

**`tests/integration/defs/accuracy/test_disaggregated_serving.py`**
- Remove `pytest.skip` for the overlap + block reuse combination on context servers.
- Enable `enable_block_reuse` unconditionally in `_test_chunked_prefill_helper` (was gated on `ctx_pp == 1`; regular block reuse has no PP restriction).

**`tests/integration/defs/disaggregated/test_configs/disagg_config_overlap.yaml`**
- Enable `enable_block_reuse: true` and `enable_partial_reuse: true` on both context and generation servers to exercise the full block reuse path in the disaggregated overlap test.

## Test Coverage

| Test | What it covers |
|------|---------------|
| `test_overlap_scheduler_consistency[no_reuse-*]` | Existing: overlap vs. non-overlap consistency (block reuse OFF) |
| `test_overlap_scheduler_consistency[block_reuse-*]` | **New parameter**: overlap vs. non-overlap consistency (block reuse ON) |
| `test_overlap_scheduler_block_reuse_cache_hit` | **New**: verifies blocks are actually reused (`cached_tokens > 0`) |
| `test_auto_dtype` (disaggregated) | **Unblocked**: overlap + block reuse + context-only + disaggregated serving |
| `disagg_config_overlap.yaml` test | **Updated**: now exercises block reuse in disaggregated overlap config |

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
