### PR TITLE
[https://nvbugs/5448464][fix] Partially fix LoRA overallocation for Nemotron NAS

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1263,8 +1263,10 @@ def create_py_executor_instance(
         model_binding_config.max_lora_rank = lora_config.max_lora_rank
 
         max_lora_rank = lora_config.max_lora_rank
-        num_lora_modules = model_engine.model.model_config.pretrained_config.num_hidden_layers * \
-            len(target_modules + lora_config.missing_qkv_modules)
+        num_lora_modules = _compute_num_lora_modules(
+            pretrained_config,
+            target_modules + lora_config.missing_qkv_modules,
+        )
 
         peft_cache_config_model = PeftCacheConfig(
         ) if peft_cache_config is None else peft_cache_config
@@ -1513,6 +1515,69 @@ def get_decoding_mode(
         decoding_mode = DecodingMode.TopKTopP()
 
     return decoding_mode
+
+
+_ATTN_MODULES = frozenset({
+    "attn_q",
+    "attn_k",
+    "attn_v",
+    "attn_qkv",
+    "attn_dense",
+    "cross_attn_q",
+    "cross_attn_k",
+    "cross_attn_v",
+})
+_MLP_MODULES = frozenset({
+    "mlp_h_to_4h",
+    "mlp_4h_to_h",
+    "mlp_gate",
+    "mlp_gate_up",
+})
+
+
+def _compute_num_lora_modules(pretrained_config,
+                              all_target_modules: list[str]) -> int:
+    """Compute the total number of LoRA module-layer slots for cache sizing.
+
+    For models with per-layer block_configs (e.g. Nemotron-NAS / DeciLM),
+    layers with no_op or replace_with_linear attention/FFN cannot host LoRA
+    adapters, so they are excluded from the count.  For all other models,
+    falls back to the uniform num_hidden_layers x len(target_modules).
+    """
+    num_layers = pretrained_config.num_hidden_layers
+    block_configs = getattr(pretrained_config, "block_configs", None)
+
+    if block_configs is None:
+        return num_layers * len(all_target_modules)
+
+    attn_modules = [m for m in all_target_modules if m in _ATTN_MODULES]
+    mlp_modules = [m for m in all_target_modules if m in _MLP_MODULES]
+    other_modules = [
+        m for m in all_target_modules
+        if m not in _ATTN_MODULES and m not in _MLP_MODULES
+    ]
+
+    def _has_lora_capable_attn(bc):
+        return not bc.attention.no_op and not bc.attention.replace_with_linear
+
+    def _has_lora_capable_ffn(bc):
+        return not bc.ffn.no_op and not bc.ffn.replace_with_linear
+
+    layers_with_attn = sum(1 for bc in block_configs
+                           if _has_lora_capable_attn(bc))
+    layers_with_mlp = sum(1 for bc in block_configs
+                          if _has_lora_capable_ffn(bc))
+
+    total = (layers_with_attn * len(attn_modules) +
+             layers_with_mlp * len(mlp_modules) +
+             num_layers * len(other_modules))
+
+    logger.info(f"LoRA module-layer count: {total} "
+                f"(attn: {layers_with_attn}x{len(attn_modules)}, "
+                f"mlp: {layers_with_mlp}x{len(mlp_modules)}, "
+                f"other: {num_layers}x{len(other_modules)}, "
+                f"uniform would be {num_layers * len(all_target_modules)})")
+    return total
 
 
 def _infer_shared_expert_size_from_adapter(adapter_dir: str) -> int:

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -35,6 +35,7 @@ l0_a10:
   - unittest/inputs/test_content_format.py
   - unittest/others/test_convert_utils.py
   - unittest/others/test_lora_manager.py
+  - unittest/others/test_lora_module_count.py
   - unittest/others/test_time_breakdown.py
   - unittest/others/test_tracing.py
   - unittest/disaggregated/test_disagg_openai_client.py

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -586,9 +586,6 @@ def test_llama_7b_lora_config_overrides_peft_cache_config(cuda_graph_config):
         cuda_graph_config=cuda_graph_config)
 
 
-# TODO smor: currently Nemotron-Super-49B-v1 with LoRA memory consumption is overly high
-# https://jirasw.nvidia.com/browse/TRTLLM-5045
-@pytest.mark.skip(reason="https://nvbugs/5448464")
 @skip_gpu_memory_less_than_138gb
 @pytest.mark.part1
 @test_lora_with_and_without_cuda_graph

--- a/tests/unittest/others/test_lora_module_count.py
+++ b/tests/unittest/others/test_lora_module_count.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for _compute_num_lora_modules (per-layer LoRA cache sizing).
+
+Verifies that models with variable per-layer structure (e.g. Nemotron-NAS)
+get accurate LoRA module-layer counts instead of the uniform over-estimate.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from tensorrt_llm._torch.pyexecutor._util import _compute_num_lora_modules
+
+
+def _make_block_config(
+    attn_no_op=False, attn_linear=False, ffn_no_op=False, ffn_linear=False, ffn_mult=2.0
+):
+    return SimpleNamespace(
+        attention=SimpleNamespace(
+            no_op=attn_no_op, replace_with_linear=attn_linear, n_heads_in_group=8
+        ),
+        ffn=SimpleNamespace(no_op=ffn_no_op, replace_with_linear=ffn_linear, ffn_mult=ffn_mult),
+    )
+
+
+def _make_pretrained_config(num_hidden_layers, block_configs=None):
+    cfg = SimpleNamespace(num_hidden_layers=num_hidden_layers)
+    if block_configs is not None:
+        cfg.block_configs = block_configs
+    return cfg
+
+
+class TestComputeNumLoraModules(unittest.TestCase):
+    def test_uniform_model_no_block_configs(self):
+        """Standard model without block_configs uses num_layers x num_modules."""
+        config = _make_pretrained_config(32)
+        modules = ["attn_q", "attn_k", "attn_v", "mlp_h_to_4h", "mlp_4h_to_h"]
+        self.assertEqual(_compute_num_lora_modules(config, modules), 32 * 5)
+
+    def test_all_layers_active(self):
+        """block_configs present but all layers fully active gives same as uniform."""
+        blocks = [_make_block_config() for _ in range(10)]
+        config = _make_pretrained_config(10, blocks)
+        modules = ["attn_q", "attn_k", "attn_v", "mlp_h_to_4h", "mlp_4h_to_h"]
+        self.assertEqual(_compute_num_lora_modules(config, modules), 10 * 5)
+
+    def test_no_op_ffn_layers_excluded(self):
+        """Layers with no_op FFN are excluded from MLP module count."""
+        blocks = [
+            _make_block_config(),
+            _make_block_config(),
+            _make_block_config(ffn_no_op=True),
+            _make_block_config(ffn_no_op=True),
+        ]
+        config = _make_pretrained_config(4, blocks)
+        modules = ["attn_q", "attn_v", "mlp_h_to_4h", "mlp_4h_to_h"]
+        # attn: 4 layers x 2 modules = 8, mlp: 2 layers x 2 modules = 4
+        self.assertEqual(_compute_num_lora_modules(config, modules), 12)
+
+    def test_no_op_attn_layers_excluded(self):
+        """Layers with no_op attention are excluded from attention module count."""
+        blocks = [
+            _make_block_config(),
+            _make_block_config(attn_no_op=True),
+            _make_block_config(attn_no_op=True),
+            _make_block_config(),
+        ]
+        config = _make_pretrained_config(4, blocks)
+        modules = ["attn_q", "attn_k", "attn_v", "mlp_gate"]
+        # attn: 2 layers x 3 modules = 6, mlp: 4 layers x 1 module = 4
+        self.assertEqual(_compute_num_lora_modules(config, modules), 10)
+
+    def test_linear_stub_layers_excluded(self):
+        """Layers with replace_with_linear are excluded (LoRA not supported)."""
+        blocks = [
+            _make_block_config(),
+            _make_block_config(attn_linear=True),
+            _make_block_config(ffn_linear=True),
+            _make_block_config(attn_linear=True, ffn_linear=True),
+        ]
+        config = _make_pretrained_config(4, blocks)
+        modules = ["attn_q", "attn_k", "mlp_h_to_4h"]
+        # attn: layers 0,2 active = 2x2 = 4
+        # mlp: layers 0,1 active = 2x1 = 2
+        self.assertEqual(_compute_num_lora_modules(config, modules), 6)
+
+    def test_nemotron_nas_mini_pattern(self):
+        """Reproduces the 14-layer Nemotron-NAS mini config pattern."""
+        blocks = [
+            _make_block_config(),  # 0: full/full
+            _make_block_config(),  # 1: full/full
+            _make_block_config(attn_linear=True),  # 2: linear/full
+            _make_block_config(attn_no_op=True),  # 3: no_op/full
+            _make_block_config(ffn_linear=True),  # 4: full/linear
+            _make_block_config(ffn_no_op=True),  # 5: full/no_op
+            _make_block_config(),  # 6: full/full
+            _make_block_config(),  # 7: full/full
+            _make_block_config(),  # 8: full/full
+            _make_block_config(attn_linear=True),  # 9: linear/full
+            _make_block_config(attn_no_op=True),  # 10: no_op/full
+            _make_block_config(ffn_linear=True),  # 11: full/linear
+            _make_block_config(ffn_no_op=True),  # 12: full/no_op
+            _make_block_config(),  # 13: full/full
+        ]
+        config = _make_pretrained_config(14, blocks)
+        modules = ["attn_q", "attn_k", "attn_v", "mlp_h_to_4h", "mlp_4h_to_h", "mlp_gate"]
+
+        # Layers with LoRA-capable attention (not no_op, not linear):
+        #   0,1,4,5,6,7,8,11,12,13 = 10 layers
+        # Layers with LoRA-capable MLP (not no_op, not linear):
+        #   0,1,2,3,6,7,8,9,10,13 = 10 layers
+        expected = 10 * 3 + 10 * 3  # 60
+        uniform = 14 * 6  # 84
+        result = _compute_num_lora_modules(config, modules)
+        self.assertEqual(result, expected)
+        self.assertLess(result, uniform)
+
+    def test_attn_only_modules_ignore_ffn(self):
+        """When only targeting attention modules, FFN structure is irrelevant."""
+        blocks = [
+            _make_block_config(),
+            _make_block_config(ffn_no_op=True),
+            _make_block_config(ffn_linear=True),
+        ]
+        config = _make_pretrained_config(3, blocks)
+        modules = ["attn_q", "attn_k", "attn_v"]
+        self.assertEqual(_compute_num_lora_modules(config, modules), 3 * 3)
+
+    def test_other_modules_use_all_layers(self):
+        """Unrecognized module names fall back to counting all layers."""
+        blocks = [
+            _make_block_config(attn_no_op=True, ffn_no_op=True),
+            _make_block_config(attn_no_op=True, ffn_no_op=True),
+        ]
+        config = _make_pretrained_config(2, blocks)
+        modules = ["moe_router", "mamba_in_proj"]
+        # Neither attn nor mlp, so all layers are counted
+        self.assertEqual(_compute_num_lora_modules(config, modules), 2 * 2)
+
+    def test_empty_modules(self):
+        """No target modules gives zero."""
+        config = _make_pretrained_config(10)
+        self.assertEqual(_compute_num_lora_modules(config, []), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This is to fix https://nvbugspro.nvidia.com/bug/5448464.

**_Background_**:
- Nemotron-NAS (DeciLM) architecture uses neural architecture search to produce models with variable per-layer structure — some layers have full attention and MLP, others use cheap linear stubs (replace_with_linear), and some skip modules entirely (no_op).
- When LoRA is enabled, the C++ PeftCacheManager allocates a GPU cache sized by `num_device_module_layer`, which is computed in Python as `max_lora_rank` × `num_lora_modules` × `max_loras`. On Nemotron-Super-49B with LoRA rank 64, this cache requests ~2.46 GiB but only ~2.44 GiB remains after model + KV cache allocation, causing `cudaMallocAsync` OOM during executor creation.

**_Root cause_**

There are two forms of LoRA cache over-allocation:

- Inflated page size: `_infer_nemotron_ffn_mult` uses `max(ffn_mult)` across all layers as a single uniform `mlp_hidden_size`. This inflates LoraModule dimensions and therefore cache page size, since the C++ API requires uniform module dimensions across layers. Fixing this requires C++ changes to support per-layer LoraModule dimensions (tracked by [TRTLLM-5045](https://jirasw.nvidia.com/browse/TRTLLM-5045)).

- Inflated module count: `num_lora_modules` is computed as `num_hidden_layers` × `len(target_modules)`, assuming every layer has every module type. For Nemotron-NAS, this allocates cache slots for MLP LoRA on layers with no MLP (`no_op` or `replace_with_linear`), and attention LoRA on layers with no attention. These layers don't create those submodules in the PyTorch model, and LoRA adapters can't have weights for them — the slots are pure waste.

**_Fix_**:
- Address inflated module count only.
- Introduce `_compute_num_lora_modules()` which, for models with block_configs, inspects each layer to determine whether it has LoRA-capable attention and/or MLP. Target modules are classified as attention, MLP, or other, and only counted for layers that actually have that module type.
- For models without block_configs, behavior is unchanged.
- This change suffices to bring back the waived LoRA test for Nemotron NAS on H200.

## Test Coverage
```
$ pytest tests/unittest/others/test_lora_module_count.py -s -v
$ pytest tests/unittest/llmapi/test_llm_pytorch.py::test_nemotron_nas_lora -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoRA PEFT cache sizing accuracy for configurations with variable layer structures
  * Re-enabled Nemotron LoRA test case that was previously skipped

* **Tests**
  * New unit test validates LoRA module counting across diverse configuration scenarios, including cases with disabled attention/FFN modules and linear replacements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->