### PR TITLE
[#11879][fix] Fix free-block counter corruption in getFreeBlock offload path

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1125,6 +1125,16 @@ BlockPtr WindowBlockManager::getFreeBlock(GenerationRequest& sequence, executor:
     {
         // Offload block in primary memory before repurposing
         auto offloadBlock = std::get<0>(mEvictionPolicy->getFreeBlock(kSecondaryLevel));
+
+        // Claim both blocks BEFORE the swap so that getCacheLevel() returns the
+        // correct pre-swap level.  Previously the claims happened after the swap,
+        // causing claimBlock to erase from the wrong per-level free queue (UB) and
+        // to modify the wrong level's free-block counter — the root cause of
+        // getNumFreeBlocks() exceeding getMaxNumBlocks() in disagg/prefill mode
+        // (GitHub #11879).
+        mEvictionPolicy->claimBlock(block);        // primary block → claimed from primary queue
+        mEvictionPolicy->claimBlock(offloadBlock); // secondary block → claimed from secondary queue
+
         mTransferManager->offload(block, offloadBlock, mPools, 0, mode, directory);
         // swap linear block offsets (i.e. make block the offload block)
         block->swapMemoryPoolBlockOffset(offloadBlock);
@@ -1135,11 +1145,12 @@ BlockPtr WindowBlockManager::getFreeBlock(GenerationRequest& sequence, executor:
                 tle::KVCacheUpdatedData(block->getHash()).cacheLevelUpdated(kPrimaryLevel, kSecondaryLevel),
                 mWindowSize);
         }
-        // Update the block as a secondary block (maintaining its priority)
-        mEvictionPolicy->claimBlock(block);
-        // Release the block into secondary block queue
+        // Release block (now secondary after swap) into secondary block queue,
+        // preserving its existing priority.
         mEvictionPolicy->releaseBlock(block);
-        // We have the offloaded block as the block to use now.
+        // offloadBlock (now primary after swap) is already claimed above.
+        // The final claimBlock() below will be a no-op for the queue but still
+        // applies the caller's priority/durationMs.
         block = offloadBlock;
     }
 


### PR DESCRIPTION
Fundamentally fixes #11879

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory block management in KV cache offload operations. Memory blocks are now properly claimed before swapping memory offsets, ensuring correct queue accounting and preventing memory management inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

##  Description

  Root cause of #11879: In WindowBlockManager::getFreeBlock(), when the offload-during-allocation path is taken (primary block evicted to secondary pool to make room), claimBlock()/releaseBlock() were called after `swapMemoryPoolBlockOffset()`. This caused `getCacheLevel()` — which infers the cache level from `block->isPrimary()` — to return the post-swap level instead of the pre-swap level, resulting in:

  1. Undefined behavior: std::list::erase() called with an iterator belonging to a different std::list instance (erasing
  from the secondary free queue using an iterator into the primary free queue, and vice versa).
  2. Free-block counter corruption: mNumFreeBlocksPerLevel decremented/incremented on the wrong cache level, eventually
  causing getNumFreeBlocks(kPrimaryLevel) to exceed getMaxNumBlocks() and usedNumBlocks to go negative.

Fix: Move both claimBlock() calls to happen before the swap, so getCacheLevel() returns the correct pre-swap level. This matches the pattern already used by the standalone WindowBlockManager::offloadBlock() function (line 1307), which correctly claims before swapping.

  Before (buggy):
  getFreeBlock(primary) → getFreeBlock(secondary) → transfer → swap → claimBlock(wrong level!) → releaseBlock →
  claimBlock(wrong level!)

  After (fixed):
  getFreeBlock(primary) → getFreeBlock(secondary) → claimBlock(primary ✓) → claimBlock(secondary ✓) → transfer → swap →
  releaseBlock(secondary ✓)

  The final claimBlock(block, priority, durationMs) that follows the offload block becomes a no-op for the queue (the
  block's free-iterator is already nullopt) but still correctly applies the caller's retention priority and duration.

##  Test Coverage

  - Existing KV cache manager unit tests in tests/unittest/kv_cache_manager_v2_tests/ cover block allocation, offload,
  and onboard flows.
  - The bug requires disaggregated serving with secondary pool configured to trigger the offload-within-getFreeBlock
  path. The linked issue #11879 was observed in production disagg/prefill deployments. CI run with --disable-fail-fast is
   recommended to validate no regressions across disagg test suites.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
