### PR TITLE
[None][chore] Set the use_one_model flag to True by default on llm ap…

### DIFF
--- a/examples/llm-api/quickstart_advanced.py
+++ b/examples/llm-api/quickstart_advanced.py
@@ -181,7 +181,9 @@ def add_llm_args(parser):
     parser.add_argument('--spec_decode_max_draft_len', type=int, default=1)
     parser.add_argument('--draft_model_dir', type=str, default=None)
     parser.add_argument('--max_matching_ngram_size', type=int, default=5)
-    parser.add_argument('--use_one_model', default=False, action='store_true')
+    parser.add_argument('--use_one_model',
+                        default=True,
+                        action=argparse.BooleanOptionalAction)
     parser.add_argument('--eagle_choices', type=str, default=None)
     parser.add_argument('--use_dynamic_tree',
                         default=False,


### PR DESCRIPTION
With such changes, we'll set the `use_one_model` to true by default for Quickstart_advanced.py
No parameter → True
--use_one_model → True
--no-use_one_model → False

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default behavior for model selection in example utilities and enhanced CLI argument handling to support explicit enable/disable options for user control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->