### PR TITLE
[None][feat] Support loading FP8 LoRA weight files

### DIFF
--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -1156,11 +1156,15 @@ class LoraManager(object):
                         scale = float(hf_config["lora_alpha"]) / np.sqrt(effective_rank)
                     else:
                         scale = float(hf_config["lora_alpha"]) / effective_rank
+
+                    # Cast to model dtype before scaling
+                    # fp8 tensors don't support scalar multiply in PyTorch
+                    model_dtype = str_dtype_to_torch(model_config.dtype)
+                    t_in = t_in.to(model_dtype)
+                    t_out = t_out.to(model_dtype)
                     t_out = t_out * scale
-                    t_in = t_in.to(str_dtype_to_torch(model_config.dtype))
-                    t_out = t_out.to(str_dtype_to_torch(model_config.dtype))
                     if is_dora and t_mag is not None:
-                        t_mag = t_mag.to(str_dtype_to_torch(model_config.dtype))
+                        t_mag = t_mag.to(model_dtype)
 
                     self._lora_uid_to_low_ranks[uid][layer_idx][lora_module] = effective_rank
                     if self._retain_device_tensors:

--- a/tests/unittest/_torch/modules/tests_lora_modules/test_qwen3_sanity.py
+++ b/tests/unittest/_torch/modules/tests_lora_modules/test_qwen3_sanity.py
@@ -184,6 +184,14 @@ class TestQwen3LoRA:
             _ATTN_TRTLLM_MODULES + _MLP_TRTLLM_MODULES,
         )
 
+    def test_qwen3_fp8_lora(self):
+        _run_lora_test(
+            self.model_path,
+            {**_ATTN_LORA_MODULES, **_MLP_LORA_MODULES},
+            _ATTN_TRTLLM_MODULES + _MLP_TRTLLM_MODULES,
+            dtype=torch.float8_e4m3fn,
+        )
+
 
 @skip_gpu_memory_less_than_80gb
 class TestQwen3MoELoRA:
@@ -198,4 +206,12 @@ class TestQwen3MoELoRA:
             self.model_path,
             _ATTN_LORA_MODULES,
             _ATTN_TRTLLM_MODULES,
+        )
+
+    def test_qwen3_moe_fp8_lora(self):
+        _run_lora_test(
+            self.model_path,
+            _ATTN_LORA_MODULES,
+            _ATTN_TRTLLM_MODULES,
+            dtype=torch.float8_e4m3fn,
         )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LoRA tensor dtype casting to properly handle model precision before scaling operations.

* **Tests**
  * Expanded test coverage for FP8 precision support with LoRA weights on Qwen3 models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

When LoRA adapter weights are stored in fp8 format, `lora_manager.py` fails at `t_out = t_out * scale` as `mul_cuda` is  not implemented for fp8. This change cast weights to model dtype before the scale multiply.

Note: keeping weights in fp8 end-to-end is blocked by other issues and will be handled later.

## Test Coverage

New tests in tests/unittest/_torch/modules/tests_lora_modules/test_qwen3_sanity.py

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
