### PR TITLE
[#10481] [feat] Add Fuzzy Speculative Decoding (FSD) support

### DIFF
--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -252,12 +252,16 @@ class ExternalDraftTokensConfig
 public:
     explicit ExternalDraftTokensConfig(VecTokens tokens, std::optional<Tensor> logits = std::nullopt,
         std::optional<FloatType> const& acceptanceThreshold = std::nullopt,
-        std::optional<bool> const& fastLogits = std::nullopt);
+        std::optional<bool> const& fastLogits = std::nullopt,
+        std::optional<FloatType> const& fsdThreshold = std::nullopt,
+        std::optional<SizeType32> const& fsdDivergenceType = std::nullopt);
 
     [[nodiscard]] VecTokens getTokens() const;
     [[nodiscard]] std::optional<Tensor> getLogits() const;
     [[nodiscard]] std::optional<FloatType> getAcceptanceThreshold() const;
     [[nodiscard]] std::optional<bool> getFastLogits() const;
+    [[nodiscard]] std::optional<FloatType> getFsdThreshold() const;
+    [[nodiscard]] std::optional<SizeType32> getFsdDivergenceType() const;
 
 private:
     friend class Serialization;
@@ -269,6 +273,11 @@ private:
     std::optional<FloatType> mAcceptanceThreshold;
     /// @brief Use direct transfer for draft logits
     std::optional<bool> mFastLogits;
+    /// @brief Fuzzy Speculative Decoding divergence threshold. When set and > 0, tokens rejected by SD are accepted
+    /// if the divergence between target and draft distributions is below this threshold. Disabled by default.
+    std::optional<FloatType> mFsdThreshold;
+    /// @brief Fuzzy Speculative Decoding divergence type. 0=JS, 1=KL, 2=TV, 3=ReverseKL. Defaults to 0 (JS).
+    std::optional<SizeType32> mFsdDivergenceType;
 };
 
 /// @brief Configuration for prompt tuning

--- a/cpp/include/tensorrt_llm/runtime/decodingInput.h
+++ b/cpp/include/tensorrt_llm/runtime/decodingInput.h
@@ -115,6 +115,11 @@ public:
         SizeType32 step;
         float constantThreshold;
         bool useRandomAcceptanceThreshold;
+
+        //! FSD divergence threshold (0 = disabled, no extra computation)
+        float fsdThreshold{0.F};
+        //! FSD divergence type (0=JS, 1=KL, 2=TV, 3=ReverseKL)
+        SizeType32 fsdDivergenceType{0};
     };
 
     class ExplicitDraftTokensInputs

--- a/cpp/include/tensorrt_llm/runtime/samplingConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/samplingConfig.h
@@ -295,6 +295,8 @@ public:
         // valid &= validateVec("lengthPenalty", lengthPenalty, 0.f);
         valid &= validateVec("noRepeatNgramSize", noRepeatNgramSize, 0);
         valid &= validateVec("minP", minP, -fltEpsilon, {1.f});
+        valid &= validateVec("fsdThreshold", fsdThreshold, 0.f);
+        valid &= validateVec("fsdDivergenceType", fsdDivergenceType, 0, {3});
         // TODO: check `beamWidthArray`
 
         // Detect greedy sampling and overwrite params.

--- a/cpp/include/tensorrt_llm/runtime/samplingConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/samplingConfig.h
@@ -193,6 +193,10 @@ public:
             configs, [&configs](size_t ci) { return configs[ci].draftAcceptanceThreshold; }, 0);
         minP = fuseValues<FloatType>(
             configs, [&configs](size_t ci) { return configs[ci].minP; }, layers::DefaultDecodingParams::getMinP());
+        fsdThreshold = fuseValues<FloatType>(
+            configs, [&configs](size_t ci) { return configs[ci].fsdThreshold; }, 0);
+        fsdDivergenceType = fuseValues<SizeType32>(
+            configs, [&configs](size_t ci) { return configs[ci].fsdDivergenceType; }, 0);
     }
 
     explicit SamplingConfig(executor::SamplingConfig const& samplingConfig,
@@ -205,6 +209,15 @@ public:
         {
             draftAcceptanceThreshold
                 = std::vector<FloatType>{externalDraftTokensConfig.value().getAcceptanceThreshold().value()};
+        }
+        if (externalDraftTokensConfig && externalDraftTokensConfig.value().getFsdThreshold())
+        {
+            fsdThreshold = std::vector<FloatType>{externalDraftTokensConfig.value().getFsdThreshold().value()};
+        }
+        if (externalDraftTokensConfig && externalDraftTokensConfig.value().getFsdDivergenceType())
+        {
+            fsdDivergenceType
+                = std::vector<SizeType32>{externalDraftTokensConfig.value().getFsdDivergenceType().value()};
         }
 
 #define SET_FROM_OPTIONAL(varName, VarName, VarType)                                                                   \
@@ -371,6 +384,10 @@ public:
     // speculative decoding, only the first value is used (in gptDecoderBatched.cpp)
     OptVec<FloatType> draftAcceptanceThreshold; // [1] or [batchSize]
 
+    // Fuzzy Speculative Decoding (FSD) parameters
+    OptVec<FloatType> fsdThreshold;       // [1] or [batchSize], FSD divergence threshold (0 = disabled)
+    OptVec<SizeType32> fsdDivergenceType; // [1] or [batchSize], FSD divergence type (0=JS, 1=KL, 2=TV, 3=ReverseKL)
+
     // medusa params
     OptVec<std::vector<SizeType32>> topKMedusaHeads; // [batchSize, maxMedusaHeads]
 
@@ -387,6 +404,7 @@ public:
             && topPDecay == other.topPDecay && topPMin == other.topPMin && topPResetIds == other.topPResetIds
             && beamSearchDiversityRate == other.beamSearchDiversityRate && lengthPenalty == other.lengthPenalty
             && earlyStopping == other.earlyStopping && draftAcceptanceThreshold == other.draftAcceptanceThreshold
+            && fsdThreshold == other.fsdThreshold && fsdDivergenceType == other.fsdDivergenceType
             && topKMedusaHeads == other.topKMedusaHeads && normalizeLogProbs == other.normalizeLogProbs
             && outputLogProbs == other.outputLogProbs && cumLogProbs == other.cumLogProbs && minP == other.minP
             && beamWidthArray == other.beamWidthArray;

--- a/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
+++ b/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
@@ -434,9 +434,13 @@ void newRequestDraftTokensExternal(DecodingInput& jointDecodingInput, SizeType32
     externalDraftTokensInputs->useRandomAcceptanceThreshold = useRandomAcceptanceThreshold;
     externalDraftTokensInputs->constantThreshold = constantThreshold;
 
-    float const fsdThreshold = samplingConfig.fsdThreshold.has_value() ? samplingConfig.fsdThreshold.value()[0] : 0.F;
+    float const fsdThreshold = (samplingConfig.fsdThreshold.has_value() && !samplingConfig.fsdThreshold.value().empty())
+        ? samplingConfig.fsdThreshold.value()[0]
+        : 0.F;
     SizeType32 const fsdDivergenceType
-        = samplingConfig.fsdDivergenceType.has_value() ? samplingConfig.fsdDivergenceType.value()[0] : 0;
+        = (samplingConfig.fsdDivergenceType.has_value() && !samplingConfig.fsdDivergenceType.value().empty())
+        ? samplingConfig.fsdDivergenceType.value()[0]
+        : 0;
     externalDraftTokensInputs->fsdThreshold = fsdThreshold;
     externalDraftTokensInputs->fsdDivergenceType = fsdDivergenceType;
 

--- a/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
+++ b/cpp/tensorrt_llm/batch_manager/createNewDecoderRequests.cpp
@@ -434,6 +434,12 @@ void newRequestDraftTokensExternal(DecodingInput& jointDecodingInput, SizeType32
     externalDraftTokensInputs->useRandomAcceptanceThreshold = useRandomAcceptanceThreshold;
     externalDraftTokensInputs->constantThreshold = constantThreshold;
 
+    float const fsdThreshold = samplingConfig.fsdThreshold.has_value() ? samplingConfig.fsdThreshold.value()[0] : 0.F;
+    SizeType32 const fsdDivergenceType
+        = samplingConfig.fsdDivergenceType.has_value() ? samplingConfig.fsdDivergenceType.value()[0] : 0;
+    externalDraftTokensInputs->fsdThreshold = fsdThreshold;
+    externalDraftTokensInputs->fsdDivergenceType = fsdDivergenceType;
+
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
 }
 

--- a/cpp/tensorrt_llm/executor/decodingConfig.cpp
+++ b/cpp/tensorrt_llm/executor/decodingConfig.cpp
@@ -60,6 +60,12 @@ ExternalDraftTokensConfig::ExternalDraftTokensConfig(VecTokens tokens, std::opti
     if (mFsdThreshold)
     {
         TLLM_CHECK(mFsdThreshold.value() >= 0.F);
+        // Materialize the documented default (JS=0) so callers never see nullopt
+        // when a threshold is active.
+        if (!mFsdDivergenceType)
+        {
+            mFsdDivergenceType = 0;
+        }
     }
     if (mFsdDivergenceType)
     {

--- a/cpp/tensorrt_llm/executor/decodingConfig.cpp
+++ b/cpp/tensorrt_llm/executor/decodingConfig.cpp
@@ -27,11 +27,14 @@ namespace tensorrt_llm::executor
 
 // Constructor for ExternalDraftTokensConfig
 ExternalDraftTokensConfig::ExternalDraftTokensConfig(VecTokens tokens, std::optional<Tensor> logits,
-    std::optional<FloatType> const& acceptanceThreshold, std::optional<bool> const& fastLogits)
+    std::optional<FloatType> const& acceptanceThreshold, std::optional<bool> const& fastLogits,
+    std::optional<FloatType> const& fsdThreshold, std::optional<SizeType32> const& fsdDivergenceType)
     : mTokens(std::move(tokens))
     , mLogits(std::move(logits))
     , mAcceptanceThreshold(acceptanceThreshold)
     , mFastLogits(fastLogits)
+    , mFsdThreshold(fsdThreshold)
+    , mFsdDivergenceType(fsdDivergenceType)
 {
     TLLM_CHECK(!mTokens.empty());
     if (mLogits)
@@ -54,6 +57,16 @@ ExternalDraftTokensConfig::ExternalDraftTokensConfig(VecTokens tokens, std::opti
         TLLM_CHECK(mAcceptanceThreshold.value() > 0.f);
         TLLM_CHECK(mAcceptanceThreshold.value() <= 1.f);
     }
+    if (mFsdThreshold)
+    {
+        TLLM_CHECK(mFsdThreshold.value() >= 0.F);
+    }
+    if (mFsdDivergenceType)
+    {
+        constexpr SizeType32 kMAX_FSD_DIVERGENCE_TYPE = 3;
+        TLLM_CHECK(mFsdDivergenceType.value() >= 0);
+        TLLM_CHECK(mFsdDivergenceType.value() <= kMAX_FSD_DIVERGENCE_TYPE);
+    }
 }
 
 VecTokens ExternalDraftTokensConfig::getTokens() const
@@ -74,6 +87,16 @@ std::optional<FloatType> ExternalDraftTokensConfig::getAcceptanceThreshold() con
 std::optional<bool> ExternalDraftTokensConfig::getFastLogits() const
 {
     return mFastLogits;
+}
+
+std::optional<FloatType> ExternalDraftTokensConfig::getFsdThreshold() const
+{
+    return mFsdThreshold;
+}
+
+std::optional<SizeType32> ExternalDraftTokensConfig::getFsdDivergenceType() const
+{
+    return mFsdDivergenceType;
 }
 
 LookaheadDecodingConfig::LookaheadDecodingConfig(

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -289,8 +289,11 @@ ExternalDraftTokensConfig Serialization::deserializeExternalDraftTokensConfig(st
     auto logits = su::deserialize<std::optional<Tensor>>(is);
     auto acceptanceThreshold = su::deserialize<std::optional<FloatType>>(is);
     auto fastLogits = su::deserialize<std::optional<bool>>(is);
+    auto fsdThreshold = su::deserialize<std::optional<FloatType>>(is);
+    auto fsdDivergenceType = su::deserialize<std::optional<SizeType32>>(is);
 
-    return ExternalDraftTokensConfig{std::move(tokens), std::move(logits), acceptanceThreshold, fastLogits};
+    return ExternalDraftTokensConfig{
+        std::move(tokens), std::move(logits), acceptanceThreshold, fastLogits, fsdThreshold, fsdDivergenceType};
 }
 
 void Serialization::serialize(ExternalDraftTokensConfig const& config, std::ostream& os)
@@ -299,6 +302,8 @@ void Serialization::serialize(ExternalDraftTokensConfig const& config, std::ostr
     su::serialize(config.mLogits, os);
     su::serialize(config.mAcceptanceThreshold, os);
     su::serialize(config.mFastLogits, os);
+    su::serialize(config.mFsdThreshold, os);
+    su::serialize(config.mFsdDivergenceType, os);
 }
 
 size_t Serialization::serializedSize(ExternalDraftTokensConfig const& config)
@@ -308,6 +313,8 @@ size_t Serialization::serializedSize(ExternalDraftTokensConfig const& config)
     totalSize += su::serializedSize(config.mLogits);
     totalSize += su::serializedSize(config.mAcceptanceThreshold);
     totalSize += su::serializedSize(config.mFastLogits);
+    totalSize += su::serializedSize(config.mFsdThreshold);
+    totalSize += su::serializedSize(config.mFsdDivergenceType);
     return totalSize;
 }
 

--- a/cpp/tensorrt_llm/kernels/speculativeDecoding/externalDraftTokensKernels.cu
+++ b/cpp/tensorrt_llm/kernels/speculativeDecoding/externalDraftTokensKernels.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tensorrt_llm/kernels/speculativeDecoding/externalDraftTokensKernels.cu
+++ b/cpp/tensorrt_llm/kernels/speculativeDecoding/externalDraftTokensKernels.cu
@@ -117,7 +117,7 @@ __global__ void acceptDraftTokensKernel(T const* draftProbs, T* targetProbs, Siz
     bool const* batchUseDraftLogits, TokenIdType const* draftIds, FinishedState const* finishedInput,
     FinishedState* finishedOutput, curandState_t* curandState, SizeType32 const* batchSlots, SizeType32 maxDraftTokens,
     SizeType32 beamWidth, SizeType32 vocabSize, bool randomThreshold, float constantThreshold, SizeType32 step,
-    bool* batchIsAccepted, SizeType32* targetOutputIds)
+    bool* batchIsAccepted, SizeType32* targetOutputIds, float fsdThreshold, SizeType32 fsdDivergenceType)
 {
     auto const bid = blockIdx.x;
     auto const draftTokenIdx = step;
@@ -164,10 +164,18 @@ __global__ void acceptDraftTokensKernel(T const* draftProbs, T* targetProbs, Siz
     auto const draftProbsBatch = draftProbs + logitsOffset;
     auto const targetProbsBatch = targetProbs + (batchIdx * beamWidth * vocabSize);
 
+    // FSD: save original finishedInput state as raw bytes before any writes to finishedOutput.
+    // finishedInput and finishedOutput may alias the SAME buffer; saving the raw uint8 now
+    // lets the FSD acceptance path restore the pre-rejection state correctly.
+    __shared__ FinishedState::UnderlyingType savedFinishedInputRaw;
     __shared__ bool isAccepted;
+    __shared__ bool fsdTriggered;
     __shared__ T sSumVal;
     if (tid == 0)
     {
+        savedFinishedInputRaw = reinterpret_cast<FinishedState::UnderlyingType const*>(finishedInput)[batchSlot];
+
+        fsdTriggered = false;
         auto const draftOutputTokenId = draftIds[batchSlot * maxDraftTokens + draftTokenIdx];
         if (useDraftLogits)
         {
@@ -175,6 +183,12 @@ __global__ void acceptDraftTokensKernel(T const* draftProbs, T* targetProbs, Siz
             auto const targetProb = static_cast<float>(targetProbsBatch[draftOutputTokenId]);
             auto const draftProb = static_cast<float>(draftProbsBatch[draftOutputTokenId]);
             isAccepted = targetProb > threshold * draftProb;
+
+            // FSD: only trigger divergence check if SD rejected and FSD is enabled
+            if (!isAccepted && fsdThreshold > 0.0F)
+            {
+                fsdTriggered = true;
+            }
         }
         else
         {
@@ -190,6 +204,89 @@ __global__ void acceptDraftTokensKernel(T const* draftProbs, T* targetProbs, Siz
 
     __syncthreads();
 
+    // FSD divergence computation: only entered when SD rejected and fsdThreshold > 0
+    if (useDraftLogits && fsdTriggered)
+    {
+        constexpr float kEPSILON = 1e-10F;
+        constexpr SizeType32 kJS_DIVERGENCE = 0;
+        constexpr SizeType32 kKL_DIVERGENCE = 1;
+        constexpr SizeType32 kTV_DISTANCE = 2;
+        constexpr SizeType32 kREVERSE_KL_DIVERGENCE = 3;
+
+        float localDiv = 0.0F;
+        for (SizeType32 vIdx = tid; vIdx < vocabSize; vIdx += static_cast<SizeType32>(blockDim.x))
+        {
+            float const pTarget = static_cast<float>(targetProbsBatch[vIdx]) + kEPSILON;
+            float const pDraft = static_cast<float>(draftProbsBatch[vIdx]) + kEPSILON;
+
+            switch (fsdDivergenceType)
+            {
+            case kJS_DIVERGENCE:
+            {
+                float const m = 0.5F * (pTarget + pDraft);
+                localDiv += 0.5F * (pTarget * logf(pTarget / m) + pDraft * logf(pDraft / m));
+                break;
+            }
+            case kKL_DIVERGENCE:
+            {
+                // KL(draft‖target): measures draft overconfidence in tokens target discounts.
+                // This is the natural direction for FSD — large when draft assigned high probability
+                // to a token the target disagrees with, which is exactly the SD rejection scenario.
+                localDiv += pDraft * logf(pDraft / pTarget);
+                break;
+            }
+            case kTV_DISTANCE:
+            {
+                localDiv += fabsf(pTarget - pDraft);
+                break;
+            }
+            case kREVERSE_KL_DIVERGENCE:
+            {
+                // KL(target‖draft): large when target has modes the draft missed entirely.
+                localDiv += pTarget * logf(pTarget / pDraft);
+                break;
+            }
+            default:
+            {
+                // Default to JS divergence for unknown types
+                float const m = 0.5F * (pTarget + pDraft);
+                localDiv += 0.5F * (pTarget * logf(pTarget / m) + pDraft * logf(pDraft / m));
+                break;
+            }
+            }
+        }
+
+        // JS divergence is bounded by ln(2) with natural log; normalise to [0, 1].
+        // TV distance has a 0.5 factor applied to the sum.
+        if (fsdDivergenceType == kJS_DIVERGENCE)
+        {
+            localDiv /= logf(2.0F);
+        }
+        else if (fsdDivergenceType == kTV_DISTANCE)
+        {
+            localDiv *= 0.5F;
+        }
+
+        // Block-level reduction to get total divergence
+        float const totalDiv = blockReduceSum<float>(localDiv);
+
+        if (tid == 0)
+        {
+            if (totalDiv < fsdThreshold)
+            {
+                // FSD accepts: override SD rejection
+                isAccepted = true;
+                batchIsAccepted[batchSlot] = true;
+                // Undo the skip-decoding flag set during SD rejection.
+                // Use savedFinishedInputRaw (captured before setSkipDecoding) because
+                // finishedInput and finishedOutput may alias the same buffer.
+                reinterpret_cast<FinishedState::UnderlyingType*>(finishedOutput)[batchSlot] = savedFinishedInputRaw;
+            }
+        }
+        __syncthreads();
+    }
+
+    // Standard SD correction: only runs when both SD and FSD rejected (or FSD was not triggered)
     if (useDraftLogits && !isAccepted)
     {
         // correct target distribution
@@ -271,7 +368,8 @@ void invokeAcceptDraftTokens(SizeType32 batchSize, T* draftProbs, T* targetProbs
     bool const* batchUseDraftLogits, TokenIdType const* draftIds, FinishedState const* finishedInput,
     FinishedState* finishedOutput, curandState_t* curandState, SizeType32 const* batchSlots, SizeType32 maxDraftTokens,
     SizeType32 beamWidth, SizeType32 vocabSizePadded, bool randomThreshold, float constantThreshold, SizeType32 step,
-    bool* batchIsAccepted, SizeType32* targetOutputIds, cudaStream_t stream)
+    bool* batchIsAccepted, SizeType32* targetOutputIds, float fsdThreshold, SizeType32 fsdDivergenceType,
+    cudaStream_t stream)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
     TLLM_CHECK(beamWidth == 1);
@@ -280,7 +378,8 @@ void invokeAcceptDraftTokens(SizeType32 batchSize, T* draftProbs, T* targetProbs
         dim3 grid(batchSize * beamWidth);
         acceptDraftTokensKernel<<<grid, block, 0, stream>>>(draftProbs, targetProbs, numsDraftTokens,
             batchUseDraftLogits, draftIds, finishedInput, finishedOutput, curandState, batchSlots, maxDraftTokens,
-            beamWidth, vocabSizePadded, randomThreshold, constantThreshold, step, batchIsAccepted, targetOutputIds);
+            beamWidth, vocabSizePadded, randomThreshold, constantThreshold, step, batchIsAccepted, targetOutputIds,
+            fsdThreshold, fsdDivergenceType);
     }
     sync_check_cuda_error(stream);
     TLLM_LOG_TRACE("%s stop", __PRETTY_FUNCTION__);
@@ -298,13 +397,13 @@ template void invokeAcceptDraftTokens(SizeType32 batchSize, float* draftProbs, f
     FinishedState const* finishedInput, FinishedState* finishedOutput, curandState_t* curandState,
     SizeType32 const* batchSlots, SizeType32 maxDraftTokens, SizeType32 beamWidth, SizeType32 vocabSizePadded,
     bool randomThreshold, float constantThreshold, SizeType32 step, bool* batchIsAccepted, SizeType32* targetOutputIds,
-    cudaStream_t stream);
+    float fsdThreshold, SizeType32 fsdDivergenceType, cudaStream_t stream);
 template void invokeAcceptDraftTokens(SizeType32 batchSize, half* draftProbs, half* targetProbs,
     SizeType32 const* numsDraftTokens, bool const* batchUseDraftLogits, TokenIdType const* draftIds,
     FinishedState const* finishedInput, FinishedState* finishedOutput, curandState_t* curandState,
     SizeType32 const* batchSlots, SizeType32 maxDraftTokens, SizeType32 beamWidth, SizeType32 vocabSizePadded,
     bool randomThreshold, float constantThreshold, SizeType32 step, bool* batchIsAccepted, SizeType32* targetOutputIds,
-    cudaStream_t stream);
+    float fsdThreshold, SizeType32 fsdDivergenceType, cudaStream_t stream);
 
 void invokeForwardAcceptedTokens(SizeType32 batchSize, SizeType32 const* batchSlots, bool* batchIsAccepted,
     SizeType32* outputSequenceLengths, TokenIdType const* draftIds, TokenIdType** idsPtrs, SizeType32 step,

--- a/cpp/tensorrt_llm/kernels/speculativeDecoding/externalDraftTokensKernels.h
+++ b/cpp/tensorrt_llm/kernels/speculativeDecoding/externalDraftTokensKernels.h
@@ -29,9 +29,23 @@ TRTLLM_NAMESPACE_BEGIN
 namespace kernels::speculative_decoding
 {
 
+//! \brief Divergence types for Fuzzy Speculative Decoding (FSD).
+//! Used to select which divergence measure to compute when FSD is enabled.
+enum class FsdDivergenceType : runtime::SizeType32
+{
+    kJS_DIVERGENCE = 0,         //!< Jensen-Shannon divergence
+    kKL_DIVERGENCE = 1,         //!< Kullback-Leibler divergence (forward: PMT || PMD)
+    kTV_DISTANCE = 2,           //!< Total Variation distance
+    kREVERSE_KL_DIVERGENCE = 3, //!< Reverse KL divergence (PMD || PMT)
+};
+
 //! \brief Accepts or rejects draft tokens based on their probability distributions or the equality of draft and target
 //! tokens. Corrects targetLogits for the last accepted token
 //! according to https://openreview.net/pdf?id=C9NEblP8vS
+//!
+//! Optionally supports Fuzzy Speculative Decoding (FSD): when a token is rejected by standard SD and fsdThreshold > 0,
+//! the divergence between target and draft distributions is computed. If the divergence is below fsdThreshold, the
+//! rejection is overridden and the token is accepted. If still rejected, standard SD correction is applied.
 //!
 //! \param batchSize current batch size
 //! \param draftProbs output buffer [maxDraftTokens, batchSize, beamWidth, vocabSize].
@@ -58,6 +72,9 @@ namespace kernels::speculative_decoding
 //! forwarding next step.
 //! \param targetOutputIds input/output buffer [batchSize]. Stores target sampling output ids for acceptById
 //! logics.
+//! \param fsdThreshold FSD divergence threshold. When > 0 and SD rejects a token, the divergence between target
+//! and draft distributions is computed. If below this threshold, the token is accepted. 0 disables FSD.
+//! \param fsdDivergenceType FSD divergence type (0=JS, 1=KL, 2=TV, 3=ReverseKL). Only used when fsdThreshold > 0.
 //! \param stream stream
 template <typename T>
 void invokeAcceptDraftTokens(runtime::SizeType32 batchSize, T* draftProbs, T* targetProbs,
@@ -65,7 +82,8 @@ void invokeAcceptDraftTokens(runtime::SizeType32 batchSize, T* draftProbs, T* ta
     FinishedState const* finishedInput, FinishedState* finishedOutput, curandState_t* curandState,
     runtime::SizeType32 const* batchSlots, runtime::SizeType32 maxDraftTokens, runtime::SizeType32 beamWidth,
     runtime::SizeType32 vocabSizePadded, bool randomThreshold, float constantThreshold, runtime::SizeType32 step,
-    bool* batchIsAccepted, runtime::SizeType32* targetOutputIds, cudaStream_t stream);
+    bool* batchIsAccepted, runtime::SizeType32* targetOutputIds, float fsdThreshold,
+    runtime::SizeType32 fsdDivergenceType, cudaStream_t stream);
 
 //! \brief Mask the target logits with -inf for unselected topK/topP token ids.
 //! according to

--- a/cpp/tensorrt_llm/layers/decodingLayer.cpp
+++ b/cpp/tensorrt_llm/layers/decodingLayer.cpp
@@ -241,6 +241,8 @@ std::tuple<std::shared_ptr<BaseDecodingOutputs>, std::shared_ptr<BaseDecodingInp
         decodeInputs->step = externalDraftTokenParams->step;
         decodeInputs->useDraftLogits = externalDraftTokenParams->useDraftLogits;
         decodeInputs->useDraftLogitsHost = externalDraftTokenParams->useDraftLogitsHost;
+        decodeInputs->fsdThreshold = externalDraftTokenParams->fsdThreshold;
+        decodeInputs->fsdDivergenceType = externalDraftTokenParams->fsdDivergenceType;
 
         preparedInputs = decodeInputs;
         preparedOutputs = baseOutputs;

--- a/cpp/tensorrt_llm/layers/decodingParams.h
+++ b/cpp/tensorrt_llm/layers/decodingParams.h
@@ -360,6 +360,11 @@ public:
     float constantThreshold{};
     bool useRandomAcceptanceThreshold{};
 
+    //! FSD divergence threshold (0 = disabled, no extra computation)
+    float fsdThreshold{};
+    //! FSD divergence type (0=JS, 1=KL, 2=TV, 3=ReverseKL)
+    runtime::SizeType32 fsdDivergenceType{};
+
     //! optional parameters
     curandState_t* curandStates{}; // [localBatchSize]
 

--- a/cpp/tensorrt_llm/layers/externalDraftTokensLayer.cpp
+++ b/cpp/tensorrt_llm/layers/externalDraftTokensLayer.cpp
@@ -403,7 +403,8 @@ void ExternalDraftTokensLayer<T>::acceptDraftTokens(std::shared_ptr<BaseDecoding
         bufferCast<TokenIdType>(*inputs->draftTokenIds), finishedInput, finishedOutput, inputs->curandStates,
         workspace->getDeviceBatchSlotsPtr(), maxTokensPerStep, beamWidth, mDecoderDomain.getVocabSizePadded(),
         inputs->useRandomAcceptanceThreshold, inputs->constantThreshold, inputs->step,
-        bufferCast<bool>(*mBatchIsAccepted), bufferCast<SizeType32>(*mTargetOutputIds), getStream());
+        bufferCast<bool>(*mBatchIsAccepted), bufferCast<SizeType32>(*mTargetOutputIds), inputs->fsdThreshold,
+        inputs->fsdDivergenceType, getStream());
 
     sync_check_cuda_error(getStream());
 

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -243,24 +243,33 @@ void initRequestBindings(nb::module_& m)
         .def("__setstate__", outputConfigSetstate);
 
     auto externalDraftTokensConfigGetstate = [](tle::ExternalDraftTokensConfig const& self)
-    { return nb::make_tuple(self.getTokens(), self.getLogits(), self.getAcceptanceThreshold()); };
+    {
+        return nb::make_tuple(self.getTokens(), self.getLogits(), self.getAcceptanceThreshold(), self.getFastLogits(),
+            self.getFsdThreshold(), self.getFsdDivergenceType());
+    };
     auto externalDraftTokensConfigSetstate
         = [](tle::ExternalDraftTokensConfig& externalDraftTokensConfig, nb::tuple const& state)
     {
-        if (state.size() != 3)
+        if (state.size() != 6)
         {
             throw std::runtime_error("Invalid ExternalDraftTokensConfig state!");
         }
-        new (&externalDraftTokensConfig) tle::ExternalDraftTokensConfig(nb::cast<VecTokens>(state[0]),
-            nb::cast<std::optional<Tensor>>(state[1]), nb::cast<std::optional<FloatType>>(state[2]));
+        new (&externalDraftTokensConfig)
+            tle::ExternalDraftTokensConfig(nb::cast<VecTokens>(state[0]), nb::cast<std::optional<Tensor>>(state[1]),
+                nb::cast<std::optional<FloatType>>(state[2]), nb::cast<std::optional<bool>>(state[3]),
+                nb::cast<std::optional<FloatType>>(state[4]), nb::cast<std::optional<SizeType32>>(state[5]));
     };
     nb::class_<tle::ExternalDraftTokensConfig>(m, "ExternalDraftTokensConfig")
-        .def(nb::init<VecTokens, std::optional<Tensor>, std::optional<FloatType> const&, std::optional<bool>>(),
+        .def(nb::init<VecTokens, std::optional<Tensor>, std::optional<FloatType> const&, std::optional<bool>,
+                 std::optional<FloatType> const&, std::optional<SizeType32> const&>(),
             nb::arg("tokens"), nb::arg("logits") = nb::none(), nb::arg("acceptance_threshold") = nb::none(),
-            nb::arg("fast_logits") = nb::none())
+            nb::arg("fast_logits") = nb::none(), nb::arg("fsd_threshold") = nb::none(),
+            nb::arg("fsd_divergence_type") = nb::none())
         .def_prop_ro("tokens", &tle::ExternalDraftTokensConfig::getTokens)
         .def_prop_ro("logits", &tle::ExternalDraftTokensConfig::getLogits)
         .def_prop_ro("acceptance_threshold", &tle::ExternalDraftTokensConfig::getAcceptanceThreshold)
+        .def_prop_ro("fsd_threshold", &tle::ExternalDraftTokensConfig::getFsdThreshold)
+        .def_prop_ro("fsd_divergence_type", &tle::ExternalDraftTokensConfig::getFsdDivergenceType)
         .def("__getstate__", externalDraftTokensConfigGetstate)
         .def("__setstate__", externalDraftTokensConfigSetstate)
         .def_prop_ro("fast_logits", &tle::ExternalDraftTokensConfig::getFastLogits);

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -250,14 +250,22 @@ void initRequestBindings(nb::module_& m)
     auto externalDraftTokensConfigSetstate
         = [](tle::ExternalDraftTokensConfig& externalDraftTokensConfig, nb::tuple const& state)
     {
-        if (state.size() != 6)
+        // Support legacy 3-field (tokens, logits, acceptanceThreshold) and
+        // 4-field (+ fastLogits) formats for backward compatibility with
+        // pickled objects created before fsdThreshold/fsdDivergenceType were added.
+        if (state.size() < 3 || state.size() > 6)
         {
             throw std::runtime_error("Invalid ExternalDraftTokensConfig state!");
         }
-        new (&externalDraftTokensConfig)
-            tle::ExternalDraftTokensConfig(nb::cast<VecTokens>(state[0]), nb::cast<std::optional<Tensor>>(state[1]),
-                nb::cast<std::optional<FloatType>>(state[2]), nb::cast<std::optional<bool>>(state[3]),
-                nb::cast<std::optional<FloatType>>(state[4]), nb::cast<std::optional<SizeType32>>(state[5]));
+        auto const logits = nb::cast<std::optional<Tensor>>(state[1]);
+        auto const acceptanceThreshold = nb::cast<std::optional<FloatType>>(state[2]);
+        auto const fastLogits = state.size() >= 4 ? nb::cast<std::optional<bool>>(state[3]) : std::optional<bool>{};
+        auto const fsdThreshold
+            = state.size() >= 5 ? nb::cast<std::optional<FloatType>>(state[4]) : std::optional<FloatType>{};
+        auto const fsdDivergenceType
+            = state.size() >= 6 ? nb::cast<std::optional<SizeType32>>(state[5]) : std::optional<SizeType32>{};
+        new (&externalDraftTokensConfig) tle::ExternalDraftTokensConfig(
+            nb::cast<VecTokens>(state[0]), logits, acceptanceThreshold, fastLogits, fsdThreshold, fsdDivergenceType);
     };
     nb::class_<tle::ExternalDraftTokensConfig>(m, "ExternalDraftTokensConfig")
         .def(nb::init<VecTokens, std::optional<Tensor>, std::optional<FloatType> const&, std::optional<bool>,

--- a/cpp/tensorrt_llm/runtime/gptDecoder.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoder.cpp
@@ -340,6 +340,8 @@ void prepareExternalDraftTokensInputs(DecodingInput const& inputs, std::shared_p
     inputParams->draftTokenIds = externalDraftTokensInputs.draftTokenIds;
     inputParams->constantThreshold = externalDraftTokensInputs.constantThreshold;
     inputParams->useRandomAcceptanceThreshold = externalDraftTokensInputs.useRandomAcceptanceThreshold;
+    inputParams->fsdThreshold = externalDraftTokensInputs.fsdThreshold;
+    inputParams->fsdDivergenceType = externalDraftTokensInputs.fsdDivergenceType;
     inputParams->step = externalDraftTokensInputs.step;
     inputParams->useDraftLogits = externalDraftTokensInputs.useDraftLogits;
     inputParams->useDraftLogitsHost = externalDraftTokensInputs.useDraftLogitsHost;

--- a/cpp/tests/unit_tests/layers/externalDraftTokensLayerTest.cpp
+++ b/cpp/tests/unit_tests/layers/externalDraftTokensLayerTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tests/unit_tests/layers/externalDraftTokensLayerTest.cpp
+++ b/cpp/tests/unit_tests/layers/externalDraftTokensLayerTest.cpp
@@ -47,6 +47,8 @@ protected:
     TensorPtr mUseDraftLogitsHost;
     float mConstantThreshold = 1.0f;
     bool mUseRandomAcceptanceThreshold = true;
+    float mFsdThreshold = 0.0f;
+    runtime::SizeType32 mFsdDivergenceType = 0; // JS
 
     std::vector<T>* mTestDraftLogitsInit;
     std::vector<T> mTestDraftLogitsAccept = {
@@ -133,6 +135,8 @@ protected:
         decodeInputTensors->draftTokenIds = mDraftTokenIds;
         decodeInputTensors->constantThreshold = mConstantThreshold;
         decodeInputTensors->useRandomAcceptanceThreshold = mUseRandomAcceptanceThreshold;
+        decodeInputTensors->fsdThreshold = mFsdThreshold;
+        decodeInputTensors->fsdDivergenceType = mFsdDivergenceType;
         decodeInputTensors->step = step;
         decodeInputTensors->useDraftLogits = mUseDraftLogits;
         decodeInputTensors->useDraftLogitsHost = mUseDraftLogitsHost;
@@ -1400,6 +1404,135 @@ TYPED_TEST(ExternalDraftTokensLayerTest, BatchTopKBatchTopP)
         {0}, {0, 1}, {0}, {0}, {0}, {0},       // step 1
         {0}, {0, 1}, {0}, {0}, {0}, {0},       // step 2
         {0}, {0, 1}, {0}, {0}, {0}, {0},       // step 3
+    };
+    this->runTest(expectedOutputIds, params);
+}
+
+// ── Fuzzy Speculative Decoding (FSD) tests ───────────────────────────────────
+//
+// All three tests use topK=1, useDraftLogits=true, and mTestDraftLogitsReject.
+//
+// The "reject" draft distribution shifts its mass one step compared to the
+// target, producing two distinct divergence regimes when measured against the
+// post-topK=1 target distribution:
+//
+//   step 0 / step 2:  draft ≈ target (full dist)  →  JS_normalised ≈ 0.40
+//   step 1:           draft entirely disjoint from topK-1 target  →  JS ≈ 1.0
+//
+// FSD test 1 — T=0 recovers exact standard SD
+// FSD test 2 — T=100 (>>any JS) fuzzy-accepts every SD rejection
+// FSD test 3 — T=0.5 fuzzy-accepts only the low-divergence rejections
+//              (step-0 and step-2) while leaving the high-divergence
+//              step-1 rejection unchanged.
+
+TYPED_TEST(ExternalDraftTokensLayerTest, FsdDisabledMatchesStandardSD)
+{
+    // T=0 disables FSD entirely; results must be identical to standard SD.
+    SizeType32 topK = 1;
+    float topP = 0.0f;
+    TestSamplingParams params;
+    params.topKs = {topK};
+    params.topPs = {topP};
+    params.isExternalDraftTokensLayerTest = true;
+    params.useDraftLogits = true;
+    this->mFsdThreshold = 0.0f;
+    this->mFsdDivergenceType = 0; // JS (irrelevant when threshold == 0)
+
+    this->mTestDraftLogitsInit = &this->mTestDraftLogitsReject;
+    this->mTestDraftTokenIdsInit = {
+        {4, 0, 2}, // accept, accept, accept
+        {4, 0, 3}, // accept, accept, reject
+        {4, 1, 2}, // accept, reject, –
+        {4, 1, 2}, // accept, reject, –
+        {5, 0, 2}, // reject, –, –
+        {},        // no draft tokens — sampled from target
+    };
+
+    // Expected: identical to AcceptByLogitsTopK1TopP0Reject
+    std::vector<std::set<int32_t>> expectedOutputIds{
+        {4}, {4}, {4}, {4}, {4}, {4}, // step 0
+        {0}, {0}, {0}, {0}, {0}, {0}, // step 1
+        {2}, {2}, {0}, {0}, {0}, {0}, // step 2
+        {0}, {0}, {0}, {0}, {0}, {0}, // step 3
+    };
+    this->runTest(expectedOutputIds, params);
+}
+
+TYPED_TEST(ExternalDraftTokensLayerTest, FsdHighThresholdAcceptsAllRejections)
+{
+    // T=100 >> any JS value, so every SD-rejected token is fuzzy-accepted.
+    // Every draft token in the sequence is therefore accepted, giving the same
+    // token sequence as if the draft and target distributions agreed exactly.
+    SizeType32 topK = 1;
+    float topP = 0.0f;
+    TestSamplingParams params;
+    params.topKs = {topK};
+    params.topPs = {topP};
+    params.isExternalDraftTokensLayerTest = true;
+    params.useDraftLogits = true;
+    this->mFsdThreshold = 100.0f;
+    this->mFsdDivergenceType = 0; // JS
+
+    this->mTestDraftLogitsInit = &this->mTestDraftLogitsReject;
+    this->mTestDraftTokenIdsInit = {
+        {4, 0, 2}, // all accepted
+        {4, 0, 3}, // token 3 at step 2: fuzzy-accepted
+        {4, 1, 2}, // token 1 at step 1: fuzzy-accepted; step 2 continues
+        {4, 1, 2}, // same
+        {5, 0, 2}, // token 5 at step 0: fuzzy-accepted; steps 1–2 continue
+        {},        // no draft tokens — sampled from target
+    };
+
+    // All three draft positions are now accepted (or fuzzy-accepted), so the
+    // outputs follow the draft token ids exactly, with a bonus step at step 3
+    // sampling from the topK-1 target (always token 0 at that position).
+    std::vector<std::set<int32_t>> expectedOutputIds{
+        {4}, {4}, {4}, {4}, {5}, {4}, // step 0: batch 4 fuzzy-accepts token 5
+        {0}, {0}, {1}, {1}, {0}, {0}, // step 1: batches 2–3 fuzzy-accept token 1
+        {2}, {3}, {2}, {2}, {2}, {0}, // step 2: batch 1 fuzzy-accepts token 3
+        {0}, {0}, {0}, {0}, {0}, {0}, // step 3: bonus step, topK-1 samples token 0
+    };
+    this->runTest(expectedOutputIds, params);
+}
+
+TYPED_TEST(ExternalDraftTokensLayerTest, FsdPartialThresholdSelectiveAcceptance)
+{
+    // T=0.5 sits between the two JS regimes:
+    //   JS(step-0 / step-2 rejections) ≈ 0.40  <  0.5  →  fuzzy-accepted
+    //   JS(step-1 rejections)           ≈ 1.00  >  0.5  →  not fuzzy-accepted
+    //
+    // Step-0 and step-2 rejections are overridden by FSD; the step-1
+    // rejection is left to standard SD correction.
+    SizeType32 topK = 1;
+    float topP = 0.0f;
+    TestSamplingParams params;
+    params.topKs = {topK};
+    params.topPs = {topP};
+    params.isExternalDraftTokensLayerTest = true;
+    params.useDraftLogits = true;
+    this->mFsdThreshold = 0.5f;
+    this->mFsdDivergenceType = 0; // JS
+
+    this->mTestDraftLogitsInit = &this->mTestDraftLogitsReject;
+    this->mTestDraftTokenIdsInit = {
+        {4, 0, 2}, // all accepted normally
+        {4, 0, 3}, // token 3 at step 2: JS≈0.40 < 0.5 → fuzzy-accepted
+        {4, 1, 2}, // token 1 at step 1: JS≈1.00 > 0.5 → not fuzzy-accepted
+        {4, 1, 2}, // same
+        {5, 0, 2}, // token 5 at step 0: JS≈0.40 < 0.5 → fuzzy-accepted; steps 1–2 continue
+        {},        // no draft tokens — sampled from target
+    };
+
+    // Batch 1 (draft={4,0,3}): step 2 rejection fuzzy-accepted → outputs token 3
+    // Batches 2–3 (draft={4,1,2}): step 1 rejection NOT fuzzy-accepted → SD
+    //     correction applies; processing stops; steps 2–3 output default {0}
+    // Batch 4 (draft={5,0,2}): step 0 rejection fuzzy-accepted → outputs token 5,
+    //     then draft tokens 0 and 2 at steps 1–2 are accepted normally
+    std::vector<std::set<int32_t>> expectedOutputIds{
+        {4}, {4}, {4}, {4}, {5}, {4}, // step 0: batch 4 fuzzy-accepts token 5
+        {0}, {0}, {0}, {0}, {0}, {0}, // step 1: batches 2–3 rejected by SD (not fuzzy-accepted)
+        {2}, {3}, {0}, {0}, {2}, {0}, // step 2: batch 1 fuzzy-accepts token 3; batches 2–3 stopped
+        {0}, {0}, {0}, {0}, {0}, {0}, // step 3: bonus/stopped → all {0}
     };
     this->runTest(expectedOutputIds, params);
 }

--- a/examples/draft_target_model/run_dtm_fsd_example.py
+++ b/examples/draft_target_model/run_dtm_fsd_example.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal example showing Soft-FSD params with string divergence names.
+# This script is illustrative; adapt runners and inputs to your environment.
+
+import torch
+
+from tensorrt_llm.runtime.model_runner_cpp import ModelRunnerCpp
+
+
+def example_usage(target_runner: ModelRunnerCpp, draft_tokens_list, draft_logits_list=None):
+    # Example prompt (batch size 1)
+    batch_input_ids = [torch.tensor([1, 2, 3], dtype=torch.int32)]
+
+    kwargs = {
+        "batch_input_ids": batch_input_ids,
+        "draft_tokens_list": draft_tokens_list,
+        "draft_logits_list": draft_logits_list,
+        "max_new_tokens": 16,
+        # Soft-FSD controls:
+        "fsd_threshold": 0.05,
+        "fsd_divergence_type": "js",  # also supports "kl", "tv", "reverse_kl"
+    }
+
+    return target_runner.generate(**kwargs)

--- a/examples/draft_target_model/run_dtm_fsd_test.py
+++ b/examples/draft_target_model/run_dtm_fsd_test.py
@@ -1,0 +1,409 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal script to test FSD (Fuzzy Speculative Decoding) via the TensorRT-LLM
+# Python API. Run from the TensorRT-LLM repo root (or set PYTHONPATH).
+#
+# Models:
+#   Without --draft_engine_dir: only TARGET (--engine_dir) is loaded; draft tokens
+#   are placeholders (pad_id repeated).
+#   With --draft_engine_dir: DRAFT (1B) and TARGET (3B) are both loaded; draft model
+#   generates candidate tokens each step, target verifies with FSD.
+#
+# Prerequisites:
+#   1. Target engine (and if using --draft_engine_dir, draft engine too) built with:
+#        --speculative_decoding_mode=draft_tokens_external --max_draft_len=<N>
+#   2. C++ session; KV cache block reuse: --kv_cache_enable_block_reuse
+#   For draft+target: build both engines with the same max_draft_len (e.g. 5).
+#
+# Usage (target only; placeholder draft tokens):
+#   python examples/draft_target_model/run_dtm_fsd_test.py \
+#       --engine_dir /path/to/target_engine \
+#       --fsd_threshold 0.05 --fsd_divergence_type kl
+#
+# Usage (draft 1B + target 3B; real speculative decoding):
+#   python examples/draft_target_model/run_dtm_fsd_test.py \
+#       --draft_engine_dir /path/to/llama32_1b_engine \
+#       --engine_dir /path/to/llama32_3b_engine \
+#       --fsd_threshold 0.05 --fsd_divergence_type kl
+#
+# Benchmark (KL thresholds 0,0.1,...,1, report tokens/sec):
+#   python ... --engine_dir /path/to/target_engine [--draft_engine_dir /path/to/draft_engine] \
+#       --benchmark --benchmark_num_tokens 64
+#
+# Bindings-only test (no engine):
+#   python -c "
+#   import tensorrt_llm.bindings as trtllm
+#   c = trtllm.ExternalDraftTokensConfig([1,2,3], fsd_threshold=0.5, fsd_divergence_type=1)
+#   print('FSD config:', c.fsd_threshold, c.fsd_divergence_type)
+#   "
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from utils import add_common_args, load_tokenizer, read_model_name
+
+import tensorrt_llm
+from tensorrt_llm.logger import logger
+from tensorrt_llm.runtime import PYTHON_BINDINGS
+
+if PYTHON_BINDINGS:
+    from tensorrt_llm.runtime import ModelRunnerCpp
+else:
+    ModelRunnerCpp = None
+
+# FSD thresholds to sweep when --benchmark is used (KL divergence)
+BENCHMARK_FSD_THRESHOLDS = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Test FSD via TensorRT-LLM Python API")
+    parser = add_common_args(parser)
+    parser.add_argument("--input_text", type=str, nargs="+", default=["Hello, world"])
+    parser.add_argument("--max_output_len", type=int, default=64)
+    parser.add_argument(
+        "--max_draft_len", type=int, default=5, help="Must match engine --max_draft_len"
+    )
+    parser.add_argument("--max_input_length", type=int, default=512, help="Max input token length")
+    parser.add_argument(
+        "--fsd_threshold",
+        type=float,
+        default=0.05,
+        help="FSD divergence threshold (>=0). 0 = strict SD.",
+    )
+    parser.add_argument(
+        "--fsd_divergence_type", type=str, default="kl", choices=["js", "kl", "tv", "reverse_kl"]
+    )
+    parser.add_argument(
+        "--use_logits",
+        action="store_true",
+        help="Use draft logits (need gather_generation_logits when building)",
+    )
+    parser.add_argument(
+        "--hf_tokenizer_model",
+        type=str,
+        default=None,
+        help="HuggingFace model ID for tokenizer when engine_dir has no HF config "
+        "(e.g. meta-llama/Llama-3.2-1B-Instruct)",
+    )
+    parser.add_argument(
+        "--benchmark",
+        action="store_true",
+        help="Run FSD with thresholds 0,0.1,...,1 and report tokens/sec for each",
+    )
+    parser.add_argument(
+        "--benchmark_num_tokens",
+        type=int,
+        default=64,
+        help="Number of new tokens to generate per run when --benchmark (fixed target for tokens/sec)",
+    )
+    parser.add_argument(
+        "--draft_engine_dir",
+        type=str,
+        default=None,
+        help="Path to draft model engine (e.g. Llama 3.2 1B). "
+        "If set, use real draft+target; else use placeholder draft tokens.",
+    )
+    return parser.parse_args()
+
+
+def _get_tokenizer_dir(args, engine_dir):
+    """Resolve tokenizer source.
+
+    Prefers explicit tokenizer_dir or hf_tokenizer_model; fallback to engine_dir or HF default.
+    """
+    if args.tokenizer_dir:
+        return args.tokenizer_dir
+    if getattr(args, "hf_tokenizer_model", None):
+        return args.hf_tokenizer_model
+    config_path = os.path.join(engine_dir, "config.json")
+    if os.path.isfile(config_path):
+        with open(config_path) as f:
+            cfg = json.load(f)
+        if "model_type" in cfg:
+            return engine_dir
+        if "pretrained_config" in cfg:
+            arch = cfg["pretrained_config"].get("architecture", "")
+            if "Llama" in arch:
+                return "meta-llama/Llama-3.2-1B-Instruct"
+    return engine_dir
+
+
+def run_fsd_test(args):
+    if not PYTHON_BINDINGS:
+        logger.error("C++ Python bindings required for FSD. Rebuild with Python bindings.")
+        return 1
+
+    runtime_rank = tensorrt_llm.mpi_rank()
+    engine_dir = args.engine_dir
+    model_name, model_version = read_model_name(engine_dir)
+    tokenizer_dir = _get_tokenizer_dir(args, engine_dir)
+    tokenizer, pad_id, end_id = load_tokenizer(
+        tokenizer_dir=tokenizer_dir,
+        vocab_file=args.vocab_file,
+        model_name=model_name,
+        model_version=model_version,
+        tokenizer_type=args.tokenizer_type,
+    )
+
+    batch_input_ids = []
+    for text in args.input_text:
+        ids = tokenizer.encode(
+            text, add_special_tokens=True, truncation=True, max_length=args.max_input_length
+        )
+        batch_input_ids.append(torch.tensor(ids, dtype=torch.int32))
+    input_lengths = [x.size(0) for x in batch_input_ids]
+    batch_size = len(batch_input_ids)
+
+    max_output_tokens_for_runner = (
+        args.benchmark_num_tokens if args.benchmark else args.max_output_len
+    )
+    max_output_tokens = max_output_tokens_for_runner
+    max_draft = min(args.max_draft_len, max_output_tokens - 1)
+    common_runner_kwargs = dict(
+        rank=runtime_rank,
+        debug_mode=args.debug_mode,
+        max_output_len=max_output_tokens_for_runner,
+        is_enc_dec=False,
+        max_batch_size=batch_size,
+        max_input_len=max(input_lengths) + max_output_tokens_for_runner,
+        max_beam_width=1,
+        max_attention_window_size=args.max_attention_window_size,
+        sink_token_length=args.sink_token_length,
+        max_tokens_in_paged_kv_cache=args.max_tokens_in_paged_kv_cache,
+        kv_cache_enable_block_reuse=True,
+        kv_cache_free_gpu_memory_fraction=args.kv_cache_free_gpu_memory_fraction,
+        gather_generation_logits=args.use_logits,
+    )
+
+    use_draft_model = args.draft_engine_dir is not None
+    if use_draft_model:
+        draft_runner = ModelRunnerCpp.from_dir(
+            engine_dir=args.draft_engine_dir, **common_runner_kwargs
+        )
+        target_runner = ModelRunnerCpp.from_dir(engine_dir=engine_dir, **common_runner_kwargs)
+        if args.use_logits:
+            assert getattr(draft_runner, "gather_generation_logits", False) and getattr(
+                target_runner, "gather_generation_logits", False
+            ), "Build draft and target with --gather_generation_logits for --use_logits"
+        runner = target_runner  # for any single-run path that still expects runner
+    else:
+        runner_kwargs = dict(engine_dir=engine_dir, **common_runner_kwargs)
+        runner = ModelRunnerCpp.from_dir(**runner_kwargs)
+
+    draft_tokens_list = [[pad_id] * max_draft for _ in range(batch_size)]
+    draft_logits_list = None
+    if (
+        not use_draft_model
+        and args.use_logits
+        and getattr(runner, "gather_generation_logits", False)
+    ):
+        vocab_size = runner.model_config.vocab_size_padded
+        draft_logits_list = [
+            torch.zeros(max_draft, vocab_size, dtype=torch.float16) for _ in range(batch_size)
+        ]
+
+    def _run_draft_target_loop(fsd_threshold):
+        """Iterative draft->target FSD generation. Returns (outputs, num_generated, elapsed_sec)."""
+        max_seq_len = [input_lengths[i] + max_output_tokens for i in range(batch_size)]
+        prefix = [batch_input_ids[i].clone() for i in range(batch_size)]
+        batch_slot = list(range(batch_size))
+        output_ids = torch.full(
+            (batch_size, 1, max(input_lengths) + max_output_tokens),
+            end_id,
+            dtype=torch.int32,
+        )
+        for bi in range(batch_size):
+            output_ids[bi, 0, : input_lengths[bi]] = batch_input_ids[bi]
+        sequence_lengths = torch.zeros(batch_size, 1, dtype=torch.int32)
+
+        t0 = time.perf_counter()
+        n_steps = 0
+        while True:
+            n_steps += 1
+            batch_size_cur = len(prefix)
+            prefix_len = [prefix[i].size(0) for i in range(batch_size_cur)]
+
+            # Draft model: generate up to max_draft new tokens
+            draft_kwargs = dict(
+                batch_input_ids=prefix,
+                max_new_tokens=max_draft,
+                end_id=end_id,
+                pad_id=pad_id,
+                temperature=args.temperature,
+                top_k=args.top_k,
+                top_p=args.top_p,
+                return_dict=True,
+                output_sequence_lengths=True,
+            )
+            with torch.no_grad():
+                draft_out = draft_runner.generate(**draft_kwargs)
+            d_seq_len = draft_out["sequence_lengths"][:, 0].tolist()
+            d_ids = []
+            d_logits = [None] * batch_size_cur
+            for bi in range(batch_size_cur):
+                lo, r = prefix_len[bi], d_seq_len[bi]
+                if lo >= r:
+                    d_ids.append([end_id])
+                    continue
+                d_ids.append(draft_out["output_ids"][bi, 0, lo:r].tolist())
+                if args.use_logits and draft_out.get("generation_logits") is not None:
+                    d_logits[bi] = draft_out["generation_logits"][bi, 0, -len(d_ids[bi]) :, :]
+
+            # Target model: verify with FSD
+            target_kwargs = dict(
+                batch_input_ids=prefix,
+                max_new_tokens=max_draft + 1,
+                end_id=end_id,
+                pad_id=pad_id,
+                temperature=args.temperature,
+                top_k=args.top_k,
+                top_p=args.top_p,
+                return_dict=True,
+                output_sequence_lengths=True,
+                draft_tokens_list=d_ids,
+                fsd_threshold=fsd_threshold,
+                fsd_divergence_type=args.fsd_divergence_type,
+            )
+            if args.use_logits and d_logits[0] is not None:
+                target_kwargs["draft_logits_list"] = d_logits
+            with torch.no_grad():
+                target_out = target_runner.generate(**target_kwargs)
+            t_seq_len = target_out["sequence_lengths"][:, 0].tolist()
+
+            # Update outputs and prefix for next iteration
+            prefix_next = []
+            batch_slot_next = []
+            for bi in range(batch_size_cur):
+                gbi = batch_slot[bi]
+                lo = prefix_len[bi]
+                r = min(t_seq_len[bi], max_seq_len[gbi])
+                t_seq = target_out["output_ids"][bi, 0, :r]
+                output_ids[gbi, 0, lo:r] = t_seq[lo:r]
+                sequence_lengths[gbi, 0] = r
+                if r >= max_seq_len[gbi]:
+                    continue
+                if end_id in t_seq[lo:].tolist():
+                    continue
+                if r == lo:
+                    continue
+                prefix_next.append(t_seq)
+                batch_slot_next.append(gbi)
+            prefix = prefix_next
+            batch_slot = batch_slot_next
+            if len(prefix) == 0:
+                break
+        elapsed_sec = time.perf_counter() - t0
+        num_generated = sum(
+            int(sequence_lengths[i, 0].item()) - input_lengths[i] for i in range(batch_size)
+        )
+        outputs = {"output_ids": output_ids, "sequence_lengths": sequence_lengths}
+        return outputs, num_generated, elapsed_sec
+
+    def run_one_generate(fsd_threshold):
+        if use_draft_model:
+            return _run_draft_target_loop(fsd_threshold)
+        generate_kwargs = dict(
+            batch_input_ids=batch_input_ids,
+            max_new_tokens=max_output_tokens,
+            end_id=end_id,
+            pad_id=pad_id,
+            temperature=args.temperature,
+            top_k=args.top_k,
+            top_p=args.top_p,
+            return_dict=True,
+            output_sequence_lengths=True,
+            draft_tokens_list=draft_tokens_list,
+            fsd_threshold=fsd_threshold,
+            fsd_divergence_type=args.fsd_divergence_type,
+        )
+        if draft_logits_list is not None:
+            generate_kwargs["draft_logits_list"] = draft_logits_list
+        with torch.no_grad():
+            t0 = time.perf_counter()
+            outputs = runner.generate(**generate_kwargs)
+            elapsed_sec = time.perf_counter() - t0
+        seq_lengths = outputs["sequence_lengths"]
+        num_generated = sum(
+            int(seq_lengths[i, 0].item()) - input_lengths[i] for i in range(batch_size)
+        )
+        return outputs, num_generated, elapsed_sec
+
+    if args.benchmark:
+        if runtime_rank == 0:
+            print(
+                f"Benchmark: FSD divergence type={args.fsd_divergence_type}, "
+                f"generating up to {max_output_tokens} tokens per run"
+            )
+            print("Thresholds:", BENCHMARK_FSD_THRESHOLDS)
+            if use_draft_model:
+                print(f"Draft model:  {args.draft_engine_dir}")
+                print(f"Target model: {engine_dir} (from config: {model_name})")
+            else:
+                print(f"Target model: {engine_dir} (from config: {model_name})")
+                print("Draft tokens: placeholder only (no draft model)")
+            print(f"Input prompt: {args.input_text!r}")
+            print("")
+        results = []
+        for thresh in BENCHMARK_FSD_THRESHOLDS:
+            if runtime_rank == 0:
+                logger.info("Running FSD threshold=%.1f", thresh)
+            outputs, num_generated, elapsed_sec = run_one_generate(thresh)
+            tokens_per_sec = num_generated / elapsed_sec if elapsed_sec > 0 else 0.0
+            results.append((thresh, num_generated, elapsed_sec, tokens_per_sec))
+            if runtime_rank == 0:
+                output_ids = outputs["output_ids"]
+                seq_lengths = outputs["sequence_lengths"]
+                for i in range(batch_size):
+                    out_len = seq_lengths[i, 0].item()
+                    gen_ids = output_ids[i, 0, input_lengths[i] : out_len].tolist()
+                    text = tokenizer.decode(gen_ids, skip_special_tokens=True)
+                    print(
+                        f"  threshold={thresh:.1f} Output [{i}]: {text!r} "
+                        f"(tokens={len(gen_ids)}, time={elapsed_sec:.3f}s, "
+                        f"{tokens_per_sec:.2f} tok/s)"
+                    )
+        if runtime_rank == 0:
+            print("\n--- Summary: FSD threshold -> tokens/second ---")
+            for thresh, num_gen, elapsed, tps in results:
+                print(f"  {thresh:.1f} -> {tps:.2f}")
+            print("---")
+        return 0
+
+    if runtime_rank == 0:
+        logger.info(
+            "Running generate with FSD: fsd_threshold=%s, fsd_divergence_type=%s",
+            args.fsd_threshold,
+            args.fsd_divergence_type,
+        )
+    outputs, num_generated, elapsed_sec = run_one_generate(args.fsd_threshold)
+
+    if runtime_rank == 0:
+        output_ids = outputs["output_ids"]
+        seq_lengths = outputs["sequence_lengths"]
+        for i in range(batch_size):
+            out_len = seq_lengths[i, 0].item()
+            gen_ids = output_ids[i, 0, input_lengths[i] : out_len].tolist()
+            text = tokenizer.decode(gen_ids, skip_special_tokens=True)
+            print(f"Output [{i}]: {text!r} (len={len(gen_ids)})")
+        print("FSD test finished successfully.")
+    return 0
+
+
+def main():
+    args = parse_args()
+    tensorrt_llm.logger.set_level(args.log_level)
+    # Default prompt for benchmark often stops after 1 token; use a prompt that tends to generate more
+    if args.benchmark and args.input_text == ["Hello, world"]:
+        args.input_text = ["Once upon a time there was a little model that loved to generate text."]
+    return run_fsd_test(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/draft_target_model/run_dtm_fsd_test.py
+++ b/examples/draft_target_model/run_dtm_fsd_test.py
@@ -241,6 +241,7 @@ def run_fsd_test(args):
                 top_p=args.top_p,
                 return_dict=True,
                 output_sequence_lengths=True,
+                output_generation_logits=args.use_logits,
             )
             with torch.no_grad():
                 draft_out = draft_runner.generate(**draft_kwargs)
@@ -271,7 +272,7 @@ def run_fsd_test(args):
                 fsd_threshold=fsd_threshold,
                 fsd_divergence_type=args.fsd_divergence_type,
             )
-            if args.use_logits and d_logits[0] is not None:
+            if args.use_logits and all(lg is not None for lg in d_logits):
                 target_kwargs["draft_logits_list"] = d_logits
             with torch.no_grad():
                 target_out = target_runner.generate(**target_kwargs)

--- a/tensorrt_llm/runtime/model_runner_cpp.py
+++ b/tensorrt_llm/runtime/model_runner_cpp.py
@@ -51,6 +51,67 @@ _bindings_dtype_to_torch_dtype_dict = {
 
 SamplingConfigType = Union[SamplingConfig, trtllm.SamplingConfig]
 
+_FSD_DIVERGENCE_NAME_MAP = {
+    "js": 0,
+    "jensen_shannon": 0,
+    "jsd": 0,
+    "kl": 1,
+    "kld": 1,
+    "tv": 2,
+    "total_variation": 2,
+    "reverse_kl": 3,
+    "rkl": 3,
+    "kl_reverse": 3,
+}
+
+
+def _map_fsd_divergence_type(value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        key = value.strip().lower()
+        if key not in _FSD_DIVERGENCE_NAME_MAP:
+            raise ValueError(
+                f"Invalid fsd_divergence_type '{value}'. "
+                f"Allowed: {sorted(_FSD_DIVERGENCE_NAME_MAP.keys())} or 0-3.")
+        value = _FSD_DIVERGENCE_NAME_MAP[key]
+    elif not isinstance(value, int):
+        raise TypeError(
+            "fsd_divergence_type must be an int or a supported string name.")
+    if value < 0 or value > 3:
+        raise ValueError("fsd_divergence_type must be in range [0, 3].")
+    return int(value)
+
+
+def _validate_fsd_threshold(value):
+    if value is None:
+        return None
+    value = float(value)
+    if value < 0.0:
+        raise ValueError("fsd_threshold must be >= 0.")
+    return value
+
+
+def _validate_acceptance_threshold(value):
+    if value is None:
+        return None
+    value = float(value)
+    if value <= 0.0 or value > 1.0:
+        raise ValueError("acceptance_threshold must be in (0, 1].")
+    return value
+
+
+def _normalize_fsd_param(value, batch_size, name, mapper=None):
+    if value is None:
+        return [None] * batch_size
+    if isinstance(value, (list, tuple)):
+        if len(value) != batch_size:
+            raise ValueError(
+                f"{name} must have length {batch_size} for per-request values.")
+        return [mapper(v) if mapper else v for v in value]
+    mapped = mapper(value) if mapper else value
+    return [mapped] * batch_size
+
 
 def _world_config_to_mapping(world_config: WorldConfig):
     return Mapping(world_size=world_config.size,
@@ -608,6 +669,13 @@ class ModelRunnerCpp(ModelRunnerMixin):
                 Custom logits processor names.
             return_all_generated_tokens (bool):
                 Whether the full output is returned at each streaming step
+            fsd_threshold (float | List[float] | None):
+                Optional Fuzzy Speculative Decoding (FSD) threshold. When > 0, draft tokens rejected by SD can be
+                accepted if the divergence between target and draft distributions is below this threshold.
+                Accepts a scalar (applied to all requests) or per-request list.
+            fsd_divergence_type (int | str | List[int | str] | None):
+                FSD divergence type. Supports numeric values (0=JS, 1=KL, 2=TV, 3=Reverse KL) or string names
+                ("js", "kl", "tv", "reverse_kl"). Accepts a scalar (applied to all requests) or per-request list.
             kwargs (Dict[str, Any]:
                 Ad hoc parametrization of sampling_config.
                 The passed **kwargs matching the sampling_config's attributes will override them.
@@ -623,6 +691,15 @@ class ModelRunnerCpp(ModelRunnerMixin):
         if stopping_criteria is not None:
             raise RuntimeError(
                 "Stopping criteria is not supported in C++ session.")
+
+        fsd_threshold = kwargs.pop("fsd_threshold", None)
+        fsd_divergence_type = kwargs.pop("fsd_divergence_type", None)
+        acceptance_threshold = kwargs.pop("acceptance_threshold", None)
+        draft_tokens_list = kwargs.get("draft_tokens_list", None)
+        if (fsd_threshold is not None or fsd_divergence_type
+                is not None) and draft_tokens_list is None:
+            raise ValueError(
+                "fsd_threshold/fsd_divergence_type require draft_tokens_list.")
 
         if not self.use_kv_cache and max_new_tokens > 1:
             raise RuntimeError(
@@ -733,23 +810,50 @@ class ModelRunnerCpp(ModelRunnerMixin):
             request_lookahead_config = trtllm.LookaheadDecodingConfig(w, n, g)
         skip_cross_attn_blocks = kwargs.get('skip_cross_attn_blocks', None)
 
+        batch_size = len(batch_input_ids_list)
+        fsd_thresholds = _normalize_fsd_param(fsd_threshold, batch_size,
+                                              "fsd_threshold",
+                                              _validate_fsd_threshold)
+        fsd_divergence_types = _normalize_fsd_param(fsd_divergence_type,
+                                                    batch_size,
+                                                    "fsd_divergence_type",
+                                                    _map_fsd_divergence_type)
+        acceptance_thresholds = _normalize_fsd_param(
+            acceptance_threshold, batch_size, "acceptance_threshold",
+            _validate_acceptance_threshold)
+
         # Draft-Target-Model speculative decoding
         if "draft_tokens_list" in kwargs.keys() and kwargs[
                 "draft_tokens_list"] is not None and "draft_logits_list" in kwargs.keys(
                 ) and kwargs["draft_logits_list"] is not None:
             # Use logits to accept
-            external_draft_tokens_configs = [
-                ExternalDraftTokensConfig(draft_tokens, draft_logits)
-                for draft_tokens, draft_logits in zip(
-                    kwargs["draft_tokens_list"], kwargs["draft_logits_list"])
-            ]
+            external_draft_tokens_configs = []
+            for i, (draft_tokens, draft_logits) in enumerate(
+                    zip(kwargs["draft_tokens_list"],
+                        kwargs["draft_logits_list"])):
+                cfg_kwargs = dict(fsd_threshold=fsd_thresholds[i],
+                                  fsd_divergence_type=fsd_divergence_types[i])
+                if acceptance_thresholds[i] is not None:
+                    cfg_kwargs["acceptance_threshold"] = acceptance_thresholds[
+                        i]
+                external_draft_tokens_configs.append(
+                    ExternalDraftTokensConfig(draft_tokens, draft_logits,
+                                              **cfg_kwargs))
             is_draft_target_model = True
         elif "draft_tokens_list" in kwargs.keys(
         ) and kwargs["draft_tokens_list"] is not None:
             # Use tokens to accept
+            def _make_token_cfg(i, draft_tokens):
+                cfg_kwargs = dict(fsd_threshold=fsd_thresholds[i],
+                                  fsd_divergence_type=fsd_divergence_types[i])
+                if acceptance_thresholds[i] is not None:
+                    cfg_kwargs["acceptance_threshold"] = acceptance_thresholds[
+                        i]
+                return ExternalDraftTokensConfig(draft_tokens, **cfg_kwargs)
+
             external_draft_tokens_configs = [
-                ExternalDraftTokensConfig(draft_tokens)
-                for draft_tokens in kwargs["draft_tokens_list"]
+                _make_token_cfg(i, draft_tokens)
+                for i, draft_tokens in enumerate(kwargs["draft_tokens_list"])
             ]
             is_draft_target_model = True
         else:

--- a/tensorrt_llm/runtime/model_runner_cpp.py
+++ b/tensorrt_llm/runtime/model_runner_cpp.py
@@ -830,7 +830,8 @@ class ModelRunnerCpp(ModelRunnerMixin):
             external_draft_tokens_configs = []
             for i, (draft_tokens, draft_logits) in enumerate(
                     zip(kwargs["draft_tokens_list"],
-                        kwargs["draft_logits_list"])):
+                        kwargs["draft_logits_list"],
+                        strict=True)):
                 cfg_kwargs = dict(fsd_threshold=fsd_thresholds[i],
                                   fsd_divergence_type=fsd_divergence_types[i])
                 if acceptance_thresholds[i] is not None:

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -933,12 +933,18 @@ def test_external_draft_tokens_config():
     logits = torch.ones(3, 1)
     acceptance_threshold = 1.0
     fast_logits = False
+    fsd_threshold = 0.25
+    fsd_divergence_type = 3
     config = trtllm.ExternalDraftTokensConfig(tokens, logits,
-                                              acceptance_threshold, fast_logits)
+                                              acceptance_threshold, fast_logits,
+                                              fsd_threshold,
+                                              fsd_divergence_type)
     assert config.tokens == tokens
     assert (config.logits == logits).all()
     assert config.acceptance_threshold == acceptance_threshold
     assert config.fast_logits == fast_logits
+    assert config.fsd_threshold == fsd_threshold
+    assert config.fsd_divergence_type == fsd_divergence_type
 
 
 def test_prompt_tuning_config():

--- a/tests/unittest/test_model_runner_cpp_fsd_utils.py
+++ b/tests/unittest/test_model_runner_cpp_fsd_utils.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
 from tensorrt_llm.runtime import model_runner_cpp as mrc

--- a/tests/unittest/test_model_runner_cpp_fsd_utils.py
+++ b/tests/unittest/test_model_runner_cpp_fsd_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from tensorrt_llm.runtime import model_runner_cpp as mrc
+
+
+def test_map_fsd_divergence_type_strings():
+    assert mrc._map_fsd_divergence_type("js") == 0
+    assert mrc._map_fsd_divergence_type("JSD") == 0
+    assert mrc._map_fsd_divergence_type("kl") == 1
+    assert mrc._map_fsd_divergence_type("tv") == 2
+    assert mrc._map_fsd_divergence_type("reverse_kl") == 3
+
+
+def test_map_fsd_divergence_type_invalid():
+    with pytest.raises(ValueError):
+        mrc._map_fsd_divergence_type("unknown")
+    with pytest.raises(ValueError):
+        mrc._map_fsd_divergence_type(4)
+    with pytest.raises(TypeError):
+        mrc._map_fsd_divergence_type(0.5)
+
+
+def test_normalize_fsd_param():
+    values = mrc._normalize_fsd_param(0.1, 3, "fsd_threshold", mrc._validate_fsd_threshold)
+    assert values == [0.1, 0.1, 0.1]
+
+    values = mrc._normalize_fsd_param([0.1, 0.2], 2, "fsd_threshold", mrc._validate_fsd_threshold)
+    assert values == [0.1, 0.2]
+
+    with pytest.raises(ValueError):
+        mrc._normalize_fsd_param([0.1], 2, "fsd_threshold", mrc._validate_fsd_threshold)
+
+    with pytest.raises(ValueError):
+        mrc._validate_fsd_threshold(-0.1)


### PR DESCRIPTION
## Description

Closes #10481.

Implements **Fuzzy Speculative Decoding (FSD)** as described in [our ACL 2025 Findings paper](https://github.com/user-attachments/files/24465007/2025.findings-acl.1346.pdf). The implementation is minimal, fully opt-in, and leaves standard speculative decoding completely untouched unless explicitly enabled.

**Note:** The original paper reports using JS divergence as the FSD divergence used to collect the main results. We've since discovered a minor bug in the calculation of JS divergence in our experiment code. The empirical results in the paper therefore correspond to `reverse_kl`, as implemented below.

### What this PR does

Standard speculative decoding (SD) accepts draft tokens only when they preserve the target model's distribution exactly (via a rejection-sampling test). This is statistically correct, but gives users no way to trade a small, controlled amount of quality for meaningfully higher throughput.

FSD adds a single tunable threshold `T` to the rejection path. When SD rejects a draft token, FSD checks whether the divergence between the target and draft next-token distributions is below `T`. If so, the token is accepted anyway ("fuzzy acceptance"); if not, standard resampling proceeds as usual. Setting `T = 0` recovers exact SD. Increasing `T` smoothly raises the acceptance rate and throughput in exchange for a small, tunable quality reduction.

**The acceptance path is completely unchanged.** FSD only adds a lightweight divergence check on tokens that SD has already rejected, so it introduces zero overhead on accepted tokens and minimal overhead overall.

### Implementation

All changes are contained to the external-draft-tokens speculative decoding path:

**C++ kernel** (`cpp/tensorrt_llm/kernels/speculativeDecoding/externalDraftTokensKernels.cu`)
- When SD rejects a token and `fsdThreshold > 0`, the kernel computes a divergence between `targetProbs` and `draftProbs` across the full vocabulary using a block-level parallel reduction.
- If `divergence < fsdThreshold`, the rejection is overridden and the token is accepted.
- Four divergence metrics are supported (selectable via `fsdDivergenceType`):
  - `js` / `0` — Jensen-Shannon divergence, normalized by ln(2) to [0, 1]. **Recommended:** bounded and interpretable; `T = 1.0` accepts everything, `T = 0.5` is a natural midpoint.
  - `kl` / `1` — KL(draft ‖ target): large when the draft is overconfident on tokens the target discounts.
  - `reverse_kl` / `3` — KL(target ‖ draft): large when the target has high-probability modes the draft missed entirely.
  - `tv` / `2` — Total variation distance, in [0, 1].

**C++ executor API** (`cpp/include/tensorrt_llm/executor/executor.h`)
- `ExternalDraftTokensConfig` gains two new optional fields:
  - `fsdThreshold` (`std::optional<float>`) — the acceptance threshold `T`. Disabled when absent or 0.
  - `fsdDivergenceType` (`std::optional<int32_t>`) — selects the divergence metric (0–3).

**Python API** (`tensorrt_llm/runtime/model_runner_cpp.py`)
- `ModelRunnerCpp.generate()` accepts two new per-request keyword arguments:
  - `fsd_threshold` — scalar or per-request list of floats.
  - `fsd_divergence_type` — scalar or per-request list; accepts integers 0–3 or string names (`"js"`, `"kl"`, `"tv"`, `"reverse_kl"`).

**Python bindings** (`cpp/tensorrt_llm/nanobind/executor/request.cpp`)
- Exposes `fsd_threshold` and `fsd_divergence_type` as read-only properties on `ExternalDraftTokensConfig`.

**Bug fix: `skipDecoding` aliasing** — fixed a pre-existing bug in `acceptDraftTokensKernel` where `finishedInput` and `finishedOutput` could alias the same buffer. The old code wrote the skip-decoding flag and then read it back via the aliased pointer, causing the FSD override to read a stale value. Fixed by capturing `finishedInput[batchSlot]` into a local variable before any writes.

### Usage

```python
from tensorrt_llm.runtime import ModelRunnerCpp

runner = ModelRunnerCpp.from_dir(engine_dir="...", ...)

outputs = runner.generate(
    batch_input_ids=input_ids,
    draft_tokens_list=draft_tokens,
    draft_logits_list=draft_logits,   # raw (pre-softmax) logits from the draft model
    max_new_tokens=200,
    fsd_threshold=1.0,                # T=1.0 accepts all tokens with JS < 1.0 (i.e., everything)
    fsd_divergence_type="js",         # or "kl", "reverse_kl", "tv", or an integer 0–3
)
```

`fsd_threshold` and `fsd_divergence_type` can also be passed as per-request lists when batching requests with different settings.

**Recommended starting point:** `fsd_divergence_type="js"` with `fsd_threshold` swept over `[0.2, 0.4, 0.6, 0.8, 1.0]`. Since JS is normalized to [0, 1], the threshold has a stable, model-independent interpretation across draft-target pairs.

### Results

Benchmarked on Llama 3.2 1B (draft) + Llama 3.2 3B (target), `draft_len=5`, A5000 GPU:

| Divergence | Threshold | Tok/s | Accept% | Tok/round | vs SD |
|---|---|---|---|---|---|
| SD baseline | — | 269 | 77% | 14.1 | — |
| JS | 0.6 | 335 | 83% | 15.2 | +25% |
| JS | 0.8 | 385 | 92% | 17.7 | +43% |
| JS | **1.0** | **438** | **100%** | **20.0** | **+63%** |

JS saturates exactly at `T = 1.0` as expected from the [0, 1] normalization. At `T = 0.8` (~92% acceptance), throughput is already +43% vs SD with only ~2% quality reduction on standard benchmarks (see paper for full accuracy results).

Benchmarked on Llama 3.1 8B (draft) + Llama 3.1 70B (target), `draft_len=5`, 4×A6000 (`tp=4`):

| Divergence | Threshold | Tok/s | Accept% | Tok/round | vs SD |
|---|---|---|---|---|---|
| SD baseline | — | 15.4 | 80% | 3.98 | — |
| reverse_kl | 1.0 | 16.6 | 83% | 4.15 | +8% |
| reverse_kl | 2.0 | 19.2 | 92% | 4.62 | +25% |
| reverse_kl | 3.0 | 20.1 | 97% | 4.87 | +31% |
| reverse_kl | **4.0** | **20.3** | **100%** | **4.98** | **+32%** |

reverse_kl saturates at T ≈ 4 for open-ended generation (vs T ≈ 0.5–1.1 in the paper's structured benchmarks — see note above). The relative speedup at saturation is consistent: +31–34% across both settings.

## Test Coverage

- **`cpp/tests/unit_tests/layers/externalDraftTokensLayerTest.cpp`** — three new `TYPED_TEST` cases exercising the FSD CUDA kernel directly through the `ExternalDraftTokensLayer`:
  - `FsdDisabledMatchesStandardSD`: verifies T=0 produces identical output to standard SD.
  - `FsdHighThresholdAcceptsAllRejections`: verifies T=100 fuzzy-accepts every SD-rejected token, with correct output token ids at each step.
  - `FsdPartialThresholdSelectiveAcceptance`: verifies T=0.5 (JS) selectively fuzzy-accepts only low-divergence rejections (JS≈0.40) while leaving high-divergence rejections (JS≈1.0) to standard SD correction.
- **`tests/unittest/bindings/test_executor_bindings.py`** — verifies `fsd_threshold` and `fsd_divergence_type` round-trip correctly through the `ExternalDraftTokensConfig` nanobind bindings.
- **`tests/unittest/test_model_runner_cpp_fsd_utils.py`** — unit tests for `_map_fsd_divergence_type` (string/int normalization, error cases) and `_normalize_fsd_param` (scalar/list broadcasting).
- **`examples/draft_target_model/run_dtm_fsd_test.py`** — end-to-end integration script validating FSD acceptance rates and throughput against a real draft+target model pair.

## PR Checklist

Please review the following before submitting your PR:
- [x] PR description clearly explains what and why.
- [x] PR follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of our knowledge.
- [x] Test cases are provided for new code paths (kernel-level C++ tests, Python binding tests, Python utility tests).
- [x] No new dependencies have been introduced.
- [x] [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) — no ownership changes; no update required.
- [x] Documentation updated: usage example added to PR description; example scripts in `examples/draft_target_model/`.
- [x] tava architecture diagram — no significant design change; no update required.
- [x] Reviewers assigned automatically are appropriate for this PR.

- [ ] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Fuzzy Speculative Decoding (FSD) with configurable thresholds and divergence metrics (JS, KL, TV, Reverse KL)
  * Extended external draft tokens configuration with FSD parameters
  * Added Python API support for FSD parameters in speculative decoding

* **Documentation**
  * Added example scripts demonstrating FSD usage and configuration

* **Tests**
  * Added unit tests for FSD functionality and parameter validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->