### PR TITLE
[https://nvbugs/5996776][fix] Fix test OOM

### DIFF
--- a/tests/unittest/_torch/modules/test_fused_moe.py
+++ b/tests/unittest/_torch/modules/test_fused_moe.py
@@ -2590,14 +2590,14 @@ def test_fused_moe_triton_mxfp4(experts, hidden_size, intermediate_size,
         w3_bias = torch.randn((NUM_EXPERTS, INTERMEDIATE_SIZE),
                               dtype=dtype).cuda()
 
-        from triton_kernels.numerics_details.mxfp import (
-            downcast_to_mxfp_torch, upcast_from_mxfp_torch)
+        from triton_kernels.numerics_details.mxfp import (downcast_to_mxfp,
+                                                          upcast_from_mxfp)
 
         def fp32_to_mxfp4(tensor):
             tensor = tensor.transpose(1, 2).contiguous()
-            tensor_fp4, tensor_scales = downcast_to_mxfp_torch(tensor,
-                                                               torch.uint8,
-                                                               axis=1)
+            tensor_fp4, tensor_scales = downcast_to_mxfp(tensor,
+                                                         torch.uint8,
+                                                         axis=1)
             tensor_fp4 = tensor_fp4.transpose(1, 2).contiguous()
             tensor_scales = tensor_scales.transpose(1, 2).contiguous()
             return tensor_fp4, tensor_scales
@@ -2605,10 +2605,7 @@ def test_fused_moe_triton_mxfp4(experts, hidden_size, intermediate_size,
         def mxfp4_to_fp32(tensor, scales):
             tensor = tensor.transpose(1, 2).contiguous()
             scales = scales.transpose(1, 2).contiguous()
-            tensor = upcast_from_mxfp_torch(tensor,
-                                            scales,
-                                            torch.float32,
-                                            axis=1)
+            tensor = upcast_from_mxfp(tensor, scales, torch.float32, axis=1)
             return tensor.transpose(1, 2).contiguous()
 
         w1_weight_fp4, w1_weight_scale = fp32_to_mxfp4(w1_weight)


### PR DESCRIPTION
**This is a test setup fix. Use fused kernels instead pytorch kernels to avoid OOM. The pytorch implementation creates a lot of intermediate tensors.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated quantization helper function references in test suite to use updated Triton kernel APIs. Test logic and assertions remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
