### PR TITLE
[TRTLLM-11861][infra] Support wildcard in bot stage-list/extra-stage commands

### DIFF
--- a/.github/workflows/bot-command.yml
+++ b/.github/workflows/bot-command.yml
@@ -52,14 +52,14 @@ jobs:
             "`--disable-reuse-test ` *(OPTIONAL)* : Explicitly prevent the pipeline from reusing build artifacts and skipping successful test stages from a previous pipeline. Ensure that all builds and tests are run regardless of previous successes.\n\n" +
             "`--disable-fail-fast ` *(OPTIONAL)* : Disable fail fast on build/tests/infra failures.\n\n" +
             "`--skip-test ` *(OPTIONAL)* : Skip all test stages, but still run build stages, package stages and sanity check stages. Note: Does **NOT** update GitHub check status.\n\n" +
-            "`--stage-list \"A10-PyTorch-1, xxx\"` *(OPTIONAL)* : Only run the specified test stages. Examples: \"A10-PyTorch-1, xxx\". Note: Does **NOT** update GitHub check status.\n\n" +
+            "`--stage-list \"A10-PyTorch-1, xxx\"` *(OPTIONAL)* : Only run the specified test stages. Supports wildcard `*` for pattern matching (e.g., `\"*PerfSanity*\"` matches all stages containing PerfSanity). Examples: \"A10-PyTorch-1, xxx\", \"*PerfSanity*\". Note: Does **NOT** update GitHub check status.\n\n" +
             "`--gpu-type \"A30, H100_PCIe\"` *(OPTIONAL)* : Only run the test stages on the specified GPU types. Examples: \"A30, H100_PCIe\". Note: Does **NOT** update GitHub check status.\n\n" +
             "`--test-backend \"pytorch, cpp\"` *(OPTIONAL)* : Skip test stages which don't match the specified backends. Only support [pytorch, cpp, tensorrt, triton]. Examples: \"pytorch, cpp\" (does not run test stages with tensorrt or triton backend). Note: Does **NOT** update GitHub pipeline status.\n\n" +
             "`--only-multi-gpu-test ` *(OPTIONAL)* : Only run the multi-GPU tests. Note: Does **NOT** update GitHub check status.\n\n" +
             "`--disable-multi-gpu-test ` *(OPTIONAL)* : Disable the multi-GPU tests. Note: Does **NOT** update GitHub check status.\n\n" +
             "`--add-multi-gpu-test ` *(OPTIONAL)* : Force run the multi-GPU tests in addition to running L0 pre-merge pipeline.\n\n" +
             "`--post-merge ` *(OPTIONAL)* : Run the L0 post-merge pipeline instead of the ordinary L0 pre-merge pipeline.\n\n" +
-            "`--extra-stage \"H100_PCIe-TensorRT-Post-Merge-1, xxx\"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Examples: --extra-stage \"H100_PCIe-TensorRT-Post-Merge-1, xxx\".\n\n" +
+            "`--extra-stage \"H100_PCIe-TensorRT-Post-Merge-1, xxx\"` *(OPTIONAL)* : Run the ordinary L0 pre-merge pipeline and specified test stages. Supports wildcard `*` for pattern matching. Examples: --extra-stage \"H100_PCIe-TensorRT-Post-Merge-1, xxx\", --extra-stage \"*Post-Merge*\".\n\n" +
             "`--detailed-log ` *(OPTIONAL)* : Enable flushing out all logs to the Jenkins console. This will significantly increase the log volume and may slow down the job.\n\n" +
             "`--debug ` *(OPTIONAL)* : **Experimental feature**. Enable access to the CI container for debugging purpose. Note: Specify exactly one stage in the `stage-list` parameter to access the appropriate container environment. Note: Does **NOT** update GitHub check status.\n\n" +
             "`--high-priority ` *(OPTIONAL)* : Run the pipeline with high priority. This option is restricted to authorized users only and will route the job to a high-priority queue.\n\n" +

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1379,23 +1379,15 @@ def trimForStageList(stageNameList)
 }
 
 // Check if a stage key matches a pattern.
-// Supports exact match and wildcard '*' for substring matching.
+// Supports exact match and wildcard '*' for glob-style matching.
+// Uses Pattern.quote() to safely handle special characters in stage names.
 // Examples: "A10-PyTorch-1" (exact), "*PerfSanity*" (contains), "A10-*" (prefix).
 def stageMatchesPattern(String key, String pattern) {
     if (!pattern.contains('*')) {
         return key == pattern
     }
-    def parts = pattern.split('\\*', -1)
-    if (parts[0] && !key.startsWith(parts[0])) return false
-    if (parts[-1] && !key.endsWith(parts[-1])) return false
-    int idx = 0
-    for (part in parts) {
-        if (!part) continue
-        int found = key.indexOf(part, idx)
-        if (found < 0) return false
-        idx = found + part.length()
-    }
-    return true
+    def regex = '^' + pattern.split('\\*', -1).collect { java.util.regex.Pattern.quote(it) }.join('.*') + '$'
+    return key ==~ regex
 }
 
 // Check if a stage key matches any pattern in the list.

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1378,6 +1378,31 @@ def trimForStageList(stageNameList)
     return trimedList
 }
 
+// Check if a stage key matches a pattern.
+// Supports exact match and wildcard '*' for substring matching.
+// Examples: "A10-PyTorch-1" (exact), "*PerfSanity*" (contains), "A10-*" (prefix).
+def stageMatchesPattern(String key, String pattern) {
+    if (!pattern.contains('*')) {
+        return key == pattern
+    }
+    def parts = pattern.split('\\*', -1)
+    if (parts[0] && !key.startsWith(parts[0])) return false
+    if (parts[-1] && !key.endsWith(parts[-1])) return false
+    int idx = 0
+    for (part in parts) {
+        if (!part) continue
+        int found = key.indexOf(part, idx)
+        if (found < 0) return false
+        idx = found + part.length()
+    }
+    return true
+}
+
+// Check if a stage key matches any pattern in the list.
+def stageMatchesAnyPattern(String key, List patterns) {
+    return patterns.any { pattern -> stageMatchesPattern(key, pattern) }
+}
+
 // Test filter flags
 @Field
 def REUSE_TEST = "reuse_test"
@@ -3022,10 +3047,18 @@ def runPackageSanityCheck(pipeline, wheel_path, reinstall_dependencies=false, cp
 
 def checkStageNameSet(stageNames, jobKeys, paramName) {
     echo "Validate stage names for the passed GitLab bot params [${paramName}]."
-    invalidStageName = stageNames.findAll { !(it in jobKeys) }
-    if (invalidStageName) {
+    def unmatchedNames = stageNames.findAll { pattern ->
+        if (pattern.contains('*')) {
+            // Wildcard pattern: check that it matches at least one stage
+            !jobKeys.any { key -> stageMatchesPattern(key, pattern) }
+        } else {
+            // Exact name: check that it exists
+            !(pattern in jobKeys)
+        }
+    }
+    if (unmatchedNames) {
         def sortedJobKeys = jobKeys.sort()
-        throw new Exception("Cannot find the stage names [${invalidStageName}] from the passed params [${paramName}]. Available stage names (${sortedJobKeys.size()} total):\n${sortedJobKeys.collect { "    ${it}" }.join('\n')}")
+        throw new Exception("Cannot find the stage names [${unmatchedNames}] from the passed params [${paramName}]. Available stage names (${sortedJobKeys.size()} total):\n${sortedJobKeys.collect { "    ${it}" }.join('\n')}")
     }
 }
 
@@ -3790,17 +3823,17 @@ def launchTestJobs(pipeline, testFilter)
         }
     }
 
-    // Check --stage-list, only run the stages in stage-list.
+    // Check --stage-list, only run the stages in stage-list. Supports wildcard '*'.
     if (testFilter[TEST_STAGE_LIST] != null) {
         echo "Use TEST_STAGE_LIST for filtering. Stages: ${testFilter[(TEST_STAGE_LIST)]}."
-        parallelJobsFiltered = parallelJobs.findAll {it.key in testFilter[(TEST_STAGE_LIST)]}
+        parallelJobsFiltered = parallelJobs.findAll { stageMatchesAnyPattern(it.key, testFilter[(TEST_STAGE_LIST)]) }
         println parallelJobsFiltered.keySet()
     }
 
-    // Check --extra-stage, add the stages in extra-stage.
+    // Check --extra-stage, add the stages in extra-stage. Supports wildcard '*'.
     if (testFilter[EXTRA_STAGE_LIST] != null) {
         echo "Use EXTRA_STAGE_LIST for filtering. Stages: ${testFilter[(EXTRA_STAGE_LIST)]}."
-        parallelJobsFiltered += parallelJobs.findAll {it.key in testFilter[(EXTRA_STAGE_LIST)]}
+        parallelJobsFiltered += parallelJobs.findAll { stageMatchesAnyPattern(it.key, testFilter[(EXTRA_STAGE_LIST)]) }
         println parallelJobsFiltered.keySet()
     }
 


### PR DESCRIPTION
## Summary
- Add wildcard `*` support for `--stage-list` and `--extra-stage` bot commands
- Users can now specify patterns like `"*PerfSanity*"` to match all stages containing "PerfSanity" instead of listing each stage individually
- Supports exact names (backward compatible), prefix (`A10-*`), suffix (`*-1`), contains (`*PerfSanity*`), and multi-segment (`H100*Post-Merge*1`) patterns
- Implementation uses pure string operations (no regex), so special characters like `[]` in stage names are handled correctly

## Test plan
- [x] `/bot run --stage-list "*PerfSanity*"` — verify wildcard substring matching
- [x] `/bot run --stage-list "A10-PyTorch-1, *PerfSanity*"` — verify mixed exact + wildcard
- [x] `/bot run --stage-list "A10-PyTorch-1"` — verify backward compatibility
- [x] `/bot run --stage-list "*Nonexistent*"` — verify error on unmatched pattern
- [x] Check Jenkins console log for correct stage filtering output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Stage list filtering now supports wildcard `*` pattern matching (e.g., `"*PerfSanity*"`) for more flexible stage selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->