### PR TITLE
[None][feat] Add benchmark for all allreduce backend

### DIFF
--- a/tests/microbenchmarks/all_reduce.py
+++ b/tests/microbenchmarks/all_reduce.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from argparse import ArgumentParser
 from itertools import product
 
@@ -26,10 +27,14 @@ except ImportError:
     from cuda import cudart
 
 import tensorrt_llm as tllm
+import tensorrt_llm.bindings.internal.userbuffers as ub
 from tensorrt_llm import Mapping
 from tensorrt_llm._torch.autotuner import AutoTuner, autotune
+from tensorrt_llm._torch.custom_ops.userbuffers_custom_ops import \
+    copy_to_userbuffers
 from tensorrt_llm._torch.distributed import (AllReduce, AllReduceFusionOp,
-                                             Distributed)
+                                             Distributed,
+                                             userbuffers_allreduce_finalize)
 from tensorrt_llm._torch.modules.rms_norm import RMSNorm
 from tensorrt_llm._utils import (get_sm_version, local_mpi_rank, local_mpi_size,
                                  nvtx_range)
@@ -52,6 +57,8 @@ def profile_allreduce(
     norm=None,
     scale=None,
     bias=None,
+    allreduce_instance=None,
+    dtype=None,
 ):
 
     allreduce_params = AllReduceParams(
@@ -63,7 +70,8 @@ def profile_allreduce(
         bias=bias,
     )
 
-    allreduce = AllReduce(mapping=mapping, strategy=strategy)
+    allreduce = allreduce_instance or AllReduce(
+        mapping=mapping, strategy=strategy, dtype=dtype)
 
     def func(x, loop_num=inner_loop):
         for _ in range(loop_num):
@@ -273,6 +281,365 @@ def allreduce_benchmark(
     return df
 
 
+# ── nccl-tests style comprehensive benchmark (--benchmark mode) ──────────────
+
+_STRATEGY_MAP = {
+    "NCCL": AllReduceStrategy.NCCL,
+    "NCCL_SYMMETRIC": AllReduceStrategy.NCCL_SYMMETRIC,
+    "UB": AllReduceStrategy.UB,
+    "ONESHOT": AllReduceStrategy.ONESHOT,
+    "TWOSHOT": AllReduceStrategy.TWOSHOT,
+    "AUTO": AllReduceStrategy.AUTO,
+    "MNNVL": AllReduceStrategy.MNNVL,
+}
+_UB_STRATEGIES = {AllReduceStrategy.NCCL_SYMMETRIC, AllReduceStrategy.UB}
+_FUSION_MAP = {
+    "NONE":
+    AllReduceFusionOp.NONE,
+    "RESIDUAL_RMS_NORM":
+    AllReduceFusionOp.RESIDUAL_RMS_NORM,
+    "RESIDUAL_RMS_NORM_QUANT_FP8":
+    AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8,
+    "RESIDUAL_RMS_NORM_QUANT_NVFP4":
+    AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4,
+}
+
+
+def _fmt_size(nbytes):
+    """Format byte count as human-readable string (e.g. 256B, 4K, 1M, 2G)."""
+    if nbytes < 1024:
+        return f"{nbytes}B"
+    elif nbytes < 1024**2:
+        v = nbytes / 1024
+        return f"{v:.0f}K" if nbytes % 1024 == 0 else f"{v:.1f}K"
+    elif nbytes < 1024**3:
+        v = nbytes / 1024**2
+        return f"{v:.0f}M" if nbytes % (1024**2) == 0 else f"{v:.2f}M"
+    else:
+        v = nbytes / 1024**3
+        return f"{v:.0f}G" if nbytes % (1024**3) == 0 else f"{v:.2f}G"
+
+
+def _profile_ub(mapping,
+                dist,
+                allreduce,
+                fusion,
+                input,
+                residual,
+                norm,
+                scale,
+                enable_cudagraph=False,
+                inner_loop=200,
+                outer_loop=10):
+    """Profile UB allreduce kernel only (copy_to_ub and finalize are one-shot)."""
+    allreduce_params = AllReduceParams(fusion_op=fusion,
+                                       residual=residual,
+                                       norm_weight=norm.weight,
+                                       eps=norm.variance_epsilon,
+                                       scale=scale,
+                                       bias=None)
+
+    # Copy input into user-buffer memory once (simulates matmul_to_ub in real flow)
+    ub_input = copy_to_userbuffers(input)
+
+    def func(loop_num=inner_loop):
+        for _ in range(loop_num):
+            output = allreduce(ub_input, all_reduce_params=allreduce_params)
+        return output
+
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(outer_loop)]
+    stops = [torch.cuda.Event(enable_timing=True) for _ in range(outer_loop)]
+    graph = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        # warmup
+        for _ in range(4):
+            func(loop_num=1)
+        if enable_cudagraph:
+            with torch.cuda.graph(graph, stream=stream):
+                func()
+        dist.barrier()
+        delay_kernel(20000, stream)
+        torch.cuda.synchronize()
+        for i in range(outer_loop):
+            starts[i].record(stream)
+            if enable_cudagraph:
+                graph.replay()
+            else:
+                func()
+            stops[i].record(stream)
+    torch.cuda.synchronize()
+    # Finalize once to sync (simulates userbuffers_allreduce_finalize in real flow)
+    output = func(loop_num=1)
+    userbuffers_allreduce_finalize(output[-1])
+    runtimes = [starts[i].elapsed_time(stops[i]) for i in range(outer_loop)]
+    return sorted(runtimes)[len(runtimes) // 2] / inner_loop * 1000.0
+
+
+def _print_table(fusion_name, strategy_names, rows, world_size):
+    W_S, W_T, W_H, W_V, W_B = 10, 6, 6, 10, 16
+    n = len(strategy_names)
+    print(flush=True)
+    print(
+        f"# Fusion: {fusion_name}    world_size={world_size}    "
+        f"algbw = size / time (GB/s)",
+        flush=True)
+    print("#", flush=True)
+    fixed = f"{'size':>{W_S}}  {'ntok':>{W_T}}  {'hdim':>{W_H}}"
+    sh = "  ".join(f"{s:^{W_V * 2 + 2}}" for s in strategy_names)
+    print(f"# {fixed}  {sh}  {'BEST':>{W_B}}", flush=True)
+    pad = " " * (W_S + 2 + W_T + 2 + W_H)
+    mh = "  ".join(f"{'time(us)':>{W_V}}  {'algbw':>{W_V}}"
+                   for _ in strategy_names)
+    print(f"# {pad}  {mh}  {' ':>{W_B}}", flush=True)
+    tw = 2 + W_S + 2 + W_T + 2 + W_H + 2 + n * (W_V * 2 + 2) + (n -
+                                                                1) * 2 + 2 + W_B
+    print("#" + "-" * (tw - 1), flush=True)
+    for row in rows:
+        prefix = (f"  {row['size_human']:>{W_S}}  "
+                  f"{row['num_tokens']:>{W_T}}  "
+                  f"{row['hidden_size']:>{W_H}}")
+        vals, best_name, best_time = [], "N/A", float("inf")
+        for s in strategy_names:
+            t, bw = row.get(f"{s}_time"), row.get(f"{s}_algbw")
+            if t is not None:
+                vals.append(f"{t:>{W_V}.2f}  {bw:>{W_V}.2f}")
+                if t < best_time:
+                    best_time, best_name = t, s
+            else:
+                vals.append(f"{'N/A':>{W_V}}  {'N/A':>{W_V}}")
+        print(f"{prefix}  {'  '.join(vals)}  {best_name:>{W_B}}", flush=True)
+
+
+def allreduce_benchmark_all(
+    dtype='bfloat16',
+    test_range="256,268435456,2",
+    explore_2d=False,
+    enable_cudagraph=False,
+    strategy_names=None,
+    fusion_names=None,
+    inner_loop=200,
+    outer_loop=10,
+    save_csv=None,
+):
+    """Comprehensive benchmark: one table per fusion, all strategies side by side."""
+    import csv as csv_mod
+
+    world_size = tllm.mpi_world_size()
+    rank = tllm.mpi_rank()
+    local_rank = local_mpi_rank()
+    gpus_per_node = local_mpi_size()
+
+    torch.cuda.set_device(local_rank)
+    cudart.cudaSetDevice(local_rank)
+
+    mapping = Mapping(world_size, rank, gpus_per_node, tp_size=world_size)
+    logger.set_rank(mapping.rank)
+    AutoTuner.get().setup_distributed_state(mapping)
+    dist = Distributed.get(mapping)
+    sm_version = get_sm_version()
+
+    if world_size == 1:
+        raise RuntimeError("Benchmark requires mpi_world_size > 1")
+
+    torch_dtype = tllm._utils.str_dtype_to_torch(dtype)
+    elem_size = torch.finfo(torch_dtype).bits // 8
+
+    # Enable MNNVL testing on single-node (bypasses multi-node NVLink check)
+    os.environ["TLLM_TEST_MNNVL"] = "1"
+
+    # strategies
+    if strategy_names is None:
+        strategy_names = [
+            "NCCL", "NCCL_SYMMETRIC", "UB", "ONESHOT", "TWOSHOT", "AUTO",
+            "MNNVL"
+        ]
+    strategies = [_STRATEGY_MAP[s] for s in strategy_names]
+
+    # fusions
+    if fusion_names is None:
+        fusion_names = list(_FUSION_MAP.keys())
+    fusions = []
+    for f in fusion_names:
+        fop = _FUSION_MAP[f]
+        if fop == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4 and sm_version < 100:
+            if rank == 0:
+                print(f"[WARN] {f} requires SM100+, skipping.", flush=True)
+            continue
+        fusions.append((f, fop))
+
+    # shapes
+    if explore_2d:
+        num_tokens_list = [
+            1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384
+        ]
+        hidden_size_list = [128, 256, 512, 1024, 2048, 4096, 8192]
+        shape_list = list(product(num_tokens_list, hidden_size_list))
+    else:
+        min_bytes, max_bytes, ratio = [int(i) for i in test_range.split(",")]
+        shape_list = []
+        nbytes = min_bytes
+        while nbytes <= max_bytes:
+            total_elems = nbytes // elem_size
+            if total_elems <= 4096:
+                shape_list.append((1, max(total_elems, 1)))
+            else:
+                shape_list.append((total_elems // 4096, 4096))
+            nbytes *= ratio
+
+    # init user-buffers
+    need_ub = bool(_UB_STRATEGIES & set(strategies))
+    if need_ub:
+        if ub.ub_supported():
+            max_elems = max(s[0] * s[1] for s in shape_list)
+            ub.initialize_userbuffers_manager(world_size, 1, 1, rank,
+                                              torch.cuda.device_count(),
+                                              max_elems * elem_size)
+        else:
+            if rank == 0:
+                print("[WARN] ub not supported, skipping UB-based strategies.",
+                      flush=True)
+            strategies = [s for s in strategies if s not in _UB_STRATEGIES]
+            strategy_names = [s.name for s in strategies]
+
+    # create AllReduce instances
+    ar_instances = {}
+    for strat in strategies:
+        try:
+            ar_instances[strat] = AllReduce(mapping=mapping,
+                                            strategy=strat,
+                                            dtype=torch_dtype)
+        except Exception as e:
+            if rank == 0:
+                print(f"[WARN] Cannot init {strat.name}: {e}", flush=True)
+    strategies = [s for s in strategies if s in ar_instances]
+    strategy_names = [s.name for s in strategies]
+
+    max_workspace = CustomAllReduceHelper.max_workspace_size_auto(
+        mapping.tp_size)
+
+    if rank == 0:
+        print(f"\n{'=' * 80}", flush=True)
+        print("  TRT-LLM AllReduce Benchmark", flush=True)
+        print(
+            f"  world_size={world_size}  dtype={dtype}  SM={sm_version}"
+            f"  cudagraph={enable_cudagraph}"
+            f"  inner={inner_loop}  outer={outer_loop}",
+            flush=True)
+        print(f"  Strategies : {', '.join(strategy_names)}", flush=True)
+        print(f"  Fusions    : {', '.join(f for f, _ in fusions)}", flush=True)
+        print(f"{'=' * 80}", flush=True)
+
+    csv_rows = []
+
+    for fusion_name, fusion_op in fusions:
+        table_rows = []
+        for num_tokens, hidden_size in shape_list:
+            msg_bytes = num_tokens * hidden_size * elem_size
+            inp = torch.ones((num_tokens, hidden_size),
+                             dtype=torch_dtype,
+                             device="cuda")
+            res = torch.randn_like(inp)
+            norm = RMSNorm(hidden_size=hidden_size, dtype=torch_dtype,
+                           eps=1e-5).cuda()
+            norm.weight.data.copy_(
+                torch.randn((hidden_size, ), dtype=torch_dtype, device="cuda"))
+            scale = torch.tensor(1.0, dtype=torch.float32).cuda()
+
+            row = dict(size_human=_fmt_size(msg_bytes),
+                       num_tokens=num_tokens,
+                       hidden_size=hidden_size,
+                       size_bytes=msg_bytes)
+
+            for strat in strategies:
+                sn = strat.name
+                # skip invalid combos
+                skip = False
+                if strat == AllReduceStrategy.TWOSHOT and num_tokens < world_size:
+                    skip = True
+                elif strat in (AllReduceStrategy.ONESHOT, AllReduceStrategy.TWOSHOT) \
+                        and msg_bytes > max_workspace:
+                    skip = True
+                elif strat == AllReduceStrategy.UB and fusion_op == AllReduceFusionOp.NONE:
+                    skip = True
+
+                if skip:
+                    row[f"{sn}_time"] = row[f"{sn}_algbw"] = None
+                else:
+                    try:
+                        if strat == AllReduceStrategy.UB:
+                            t_us = _profile_ub(mapping, dist,
+                                               ar_instances[strat], fusion_op,
+                                               inp, res, norm, scale,
+                                               enable_cudagraph, inner_loop,
+                                               outer_loop)
+                        else:
+                            t_us = profile_allreduce(
+                                mapping=mapping,
+                                dist=dist,
+                                enable_cudagraph=enable_cudagraph,
+                                inner_loop=inner_loop,
+                                outer_loop=outer_loop,
+                                fusion=fusion_op,
+                                input=inp,
+                                residual=res,
+                                norm=norm,
+                                scale=scale,
+                                allreduce_instance=ar_instances[strat]) * 1000.0
+                        row[f"{sn}_time"] = t_us
+                        row[f"{sn}_algbw"] = msg_bytes / (t_us / 1e6) / 1e9
+                    except Exception as e:
+                        if rank == 0:
+                            print(
+                                f"  [SKIP] {sn} @ {_fmt_size(msg_bytes)}: {e}",
+                                flush=True)
+                        row[f"{sn}_time"] = row[f"{sn}_algbw"] = None
+
+                csv_rows.append({
+                    "world_size": world_size,
+                    "dtype": dtype,
+                    "fusion": fusion_name,
+                    "num_tokens": num_tokens,
+                    "hidden_size": hidden_size,
+                    "size_bytes": msg_bytes,
+                    "strategy": sn,
+                    "time_us": row[f"{sn}_time"] or 0.0,
+                    "algbw_GBps": row[f"{sn}_algbw"] or 0.0,
+                })
+            table_rows.append(row)
+
+        if rank == 0:
+            _print_table(fusion_name, strategy_names, table_rows, world_size)
+
+    # summary
+    if rank == 0:
+        print(f"\n{'=' * 80}", flush=True)
+        print("  Summary: peak algbw (GB/s) per strategy per fusion",
+              flush=True)
+        print(f"{'=' * 80}", flush=True)
+        hdr = f"  {'fusion':<35s}" + "".join(f"  {s:>14s}"
+                                             for s in strategy_names)
+        print(hdr, flush=True)
+        print("  " + "-" * (len(hdr) - 2), flush=True)
+        for fn, _ in fusions:
+            line = f"  {fn:<35s}"
+            for sn in strategy_names:
+                bws = [
+                    r["algbw_GBps"] for r in csv_rows if r["fusion"] == fn
+                    and r["strategy"] == sn and r["algbw_GBps"] > 0
+                ]
+                line += f"  {max(bws) if bws else 0.0:>14.2f}"
+            print(line, flush=True)
+        print(flush=True)
+
+    if rank == 0 and save_csv and csv_rows:
+        with open(save_csv, "w", newline="") as f:
+            writer = csv_mod.DictWriter(f, fieldnames=csv_rows[0].keys())
+            writer.writeheader()
+            writer.writerows(csv_rows)
+        print(f"Results saved to {save_csv}", flush=True)
+
+
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("--dtype", "-t", default="bfloat16")
@@ -285,14 +652,28 @@ if __name__ == "__main__":
     parser.add_argument("--enable_cudagraph", action="store_true")
     parser.add_argument("--save_csv", type=str, default=None)
     parser.add_argument("--enable_auto", action="store_true", default=False)
+    parser.add_argument("--benchmark",
+                        action="store_true",
+                        default=False,
+                        help="Run comprehensive benchmark across all backends "
+                        "with nccl-tests style output")
 
     args = parser.parse_args()
 
-    allreduce_benchmark(
-        args.dtype,
-        args.range,
-        args.enable_cudagraph,
-        args.explore_2d,
-        args.save_csv,
-        args.enable_auto,
-    )
+    if args.benchmark:
+        allreduce_benchmark_all(
+            dtype=args.dtype,
+            test_range=args.range,
+            explore_2d=args.explore_2d,
+            enable_cudagraph=args.enable_cudagraph,
+            save_csv=args.save_csv,
+        )
+    else:
+        allreduce_benchmark(
+            args.dtype,
+            args.range,
+            args.enable_cudagraph,
+            args.explore_2d,
+            args.save_csv,
+            args.enable_auto,
+        )


### PR DESCRIPTION
Add benchmark for all allreduce backend.

usage example:
```
mpirun -n 8 --oversubscribe --allow-run-as-root     python TensorRT-LLM/tests/microbenchmarks/all_reduce.py --benchmark --enable_cudagraph
```
results on H200x8:
```
================================================================================
  TRT-LLM AllReduce Benchmark
  world_size=8  dtype=bfloat16  SM=90  cudagraph=True  inner=200  outer=10
  Strategies : NCCL, NCCL_SYMMETRIC, UB, ONESHOT, TWOSHOT, AUTO, MNNVL
  Fusions    : NONE, RESIDUAL_RMS_NORM, RESIDUAL_RMS_NORM_QUANT_FP8
================================================================================
# Fusion: NONE    world_size=8    algbw = size / time (GB/s)
#
#       size    ntok    hdim           NCCL               NCCL_SYMMETRIC                UB                   ONESHOT                 TWOSHOT                   AUTO                   MNNVL                       BEST
#                               time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw                  
#---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
        256B       1     128       14.27        0.02        9.05        0.03         N/A         N/A        2.54        0.10         N/A         N/A        2.62        0.10        2.62        0.10           ONESHOT
        2.5K       1    1280       14.99        0.17        9.52        0.27         N/A         N/A        3.28        0.78         N/A         N/A        2.98        0.86        2.98        0.86              AUTO
         24K       3    4096       19.77        1.24       12.35        1.99         N/A         N/A        3.20        7.68         N/A         N/A        2.83        8.67        2.84        8.67              AUTO
        248K      31    4096       23.17       10.96       17.66       14.38         N/A         N/A        9.47       26.81       49.56        5.12        4.33       58.64        4.33       58.72             MNNVL
       2.44M     312    4096       41.27       61.93       31.60       80.89         N/A         N/A       73.40       34.82       35.81       71.37       16.68      153.27       16.68      153.24              AUTO
      24.41M    3125    4096      164.72      155.42      144.53      177.13         N/A         N/A      627.73       40.78      199.20      128.51      133.94      191.13      133.94      191.13              AUTO
     244.14M   31250    4096     1007.47      254.10     1094.76      233.84         N/A         N/A         N/A         N/A         N/A         N/A     1298.58      197.14     1298.62      197.13              NCCL

# Fusion: RESIDUAL_RMS_NORM    world_size=8    algbw = size / time (GB/s)
#
#       size    ntok    hdim           NCCL               NCCL_SYMMETRIC                UB                   ONESHOT                 TWOSHOT                   AUTO                   MNNVL                       BEST
#                               time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw                  
#---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
        256B       1     128       15.67        0.02        5.12        0.05        3.36        0.08        3.20        0.08         N/A         N/A        3.80        0.07        3.80        0.07           ONESHOT
        2.5K       1    1280       16.35        0.16        5.28        0.48        3.41        0.75        3.99        0.64         N/A         N/A        4.02        0.64        4.02        0.64                UB
         24K       3    4096       21.35        1.15        6.71        3.66        4.44        5.54        5.56        4.42         N/A         N/A        4.60        5.35        4.60        5.34                UB
        248K      31    4096       24.95       10.18       10.83       23.45        6.41       39.63       11.41       22.25       60.13        4.22        5.59       45.47        5.58       45.53             MNNVL
       2.44M     312    4096       44.03       58.05       21.47      119.05       16.18      157.99       68.61       37.25       45.91       55.67       17.78      143.78       17.77      143.81                UB
      24.41M    3125    4096      189.68      134.96      140.80      181.82      101.46      252.33      636.68       40.21      224.27      114.15      166.11      154.11      166.13      154.10                UB
     244.14M   31250    4096     1258.81      203.37     1345.77      190.23      946.82      270.38         N/A         N/A         N/A         N/A     1601.68      159.83     1601.73      159.83                UB

# Fusion: RESIDUAL_RMS_NORM_QUANT_FP8    world_size=8    algbw = size / time (GB/s)
#
#       size    ntok    hdim           NCCL               NCCL_SYMMETRIC                UB                   ONESHOT                 TWOSHOT                   AUTO                   MNNVL                       BEST
#                               time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw    time(us)       algbw                  
#---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
        256B       1     128       18.08        0.01        7.50        0.03        3.63        0.07        3.26        0.08         N/A         N/A        3.26        0.08        3.27        0.08              AUTO
        2.5K       1    1280       18.80        0.14        7.69        0.33        3.61        0.71        4.04        0.63         N/A         N/A        4.05        0.63        4.04        0.63                UB
         24K       3    4096       23.86        1.03        9.17        2.68        4.59        5.35        5.62        4.37         N/A         N/A        5.64        4.36        5.64        4.36                UB
        248K      31    4096       27.71        9.16       13.46       18.87        6.34       40.08       11.42       22.23       60.88        4.17       11.41       22.26       11.42       22.24                UB
       2.44M     312    4096       47.40       53.92       24.62      103.81       14.83      172.40       68.14       37.51       46.62       54.83       24.59      103.94       24.62      103.81                UB
      24.41M    3125    4096      201.48      127.06      152.62      167.74       88.24      290.13      636.27       40.23      224.00      114.29      152.60      167.76      152.60      167.76                UB
     244.14M   31250    4096     1354.52      189.00     1439.43      177.85      821.09      311.78         N/A         N/A         N/A         N/A     1353.94      189.08     1354.66      188.98                UB

================================================================================
  Summary: peak algbw (GB/s) per strategy per fusion
================================================================================
  fusion                                         NCCL  NCCL_SYMMETRIC              UB         ONESHOT         TWOSHOT            AUTO           MNNVL
  ---------------------------------------------------------------------------------------------------------------------------------------------------
  NONE                                         254.10          233.84            0.00           40.78          128.51          197.14          197.13
  RESIDUAL_RMS_NORM                            203.37          190.23          270.38           40.21          114.15          159.83          159.83
  RESIDUAL_RMS_NORM_QUANT_FP8                  189.00          177.85          311.78           40.23          114.29          189.08          188.98

```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new benchmarking mode with formatted table output and multi-strategy comparison
  * Introduced `--benchmark` CLI flag to activate enhanced benchmarking capabilities
  * Added 2D exploration for input shape benchmarking
  * Enabled CSV export functionality for benchmark results
  * Expanded user buffer profiling support across multiple backends
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
