### PR TITLE
[None][fix] Fix missing disagg_request_id fallback in context responses

### DIFF
--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -372,10 +372,14 @@ class OpenAIDisaggregatedService(OpenAIService):
                             f" disagg_request_id={choice.disaggregated_params.disagg_request_id!r}"
                         )
                     if choice.disaggregated_params.disagg_request_id is None:
-                        raise ValueError(
-                            f"Invalid disaggregated params: disagg_request_id is None for choice {idx}."
-                            f" finish_reason={choice.finish_reason!r},"
-                            f" ctx_request_id={choice.disaggregated_params.ctx_request_id!r}"
+                        logger.warning(
+                            "Context server choice %d is missing disagg_request_id; "
+                            "falling back to ctx_request_id=%s.",
+                            idx,
+                            choice.disaggregated_params.ctx_request_id,
+                        )
+                        choice.disaggregated_params.disagg_request_id = (
+                            choice.disaggregated_params.ctx_request_id
                         )
             return ctx_response
 

--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -146,7 +146,9 @@ class OpenAIDisaggregatedService(OpenAIService):
                 ctx_response = await self._ctx_client.send_request(
                     ctx_req, server=ctx_server, hooks=hooks, req_id=disagg_request_id
                 )
-                await self._verify_ctx_response(ctx_response)
+                await self._verify_ctx_response(
+                    ctx_response, ctx_req.disaggregated_params.disagg_request_id
+                )
                 ctx_response_disagg_params = ctx_response.choices[0].disaggregated_params
                 if ctx_response_disagg_params.disagg_request_id is not None:
                     disagg_request_id = ctx_response_disagg_params.disagg_request_id
@@ -352,7 +354,11 @@ class OpenAIDisaggregatedService(OpenAIService):
         await self._gen_client.shutdown()
         await self._coordinator.stop()
 
-    async def _verify_ctx_response(self, ctx_response: UCompletionResponse) -> None:
+    async def _verify_ctx_response(
+        self,
+        ctx_response: UCompletionResponse,
+        expected_disagg_request_id: Optional[int],
+    ) -> None:
         if ctx_response:
             for idx, choice in enumerate(ctx_response.choices):
                 if choice.disaggregated_params is None:
@@ -372,11 +378,18 @@ class OpenAIDisaggregatedService(OpenAIService):
                             f" disagg_request_id={choice.disaggregated_params.disagg_request_id!r}"
                         )
                     if choice.disaggregated_params.disagg_request_id is None:
-                        logger.warning(
-                            "Context server choice %d is missing disagg_request_id; "
-                            "falling back to ctx_request_id=%s.",
-                            idx,
-                            choice.disaggregated_params.ctx_request_id,
+                        if choice.disaggregated_params.ctx_request_id != expected_disagg_request_id:
+                            raise ValueError(
+                                f"Invalid disaggregated params: ctx_request_id="
+                                f"{choice.disaggregated_params.ctx_request_id!r} for choice {idx}"
+                                " does not match the successful context attempt's"
+                                f" disagg_request_id={expected_disagg_request_id!r}."
+                            )
+                        logger.warning_once(
+                            f"Context server choice {idx} is missing disagg_request_id; "
+                            f"falling back to verified ctx_request_id="
+                            f"{choice.disaggregated_params.ctx_request_id}.",
+                            key="missing_disagg_request_id_fallback",
                         )
                         choice.disaggregated_params.disagg_request_id = (
                             choice.disaggregated_params.ctx_request_id

--- a/tests/unittest/disaggregated/test_openai_disagg_service.py
+++ b/tests/unittest/disaggregated/test_openai_disagg_service.py
@@ -588,13 +588,22 @@ class TestVerifyCtxResponseDiagnostics:
             await svc._verify_ctx_response(resp)
 
     @pytest.mark.asyncio
-    async def test_missing_disagg_request_id_includes_ctx_id(self):
+    async def test_missing_disagg_request_id_falls_back_to_ctx_request_id(self):
         svc = _make_service("context_first")
         resp = _make_completion_response("", finish_reason="length", disagg_request_id=555)
         resp.choices[0].disaggregated_params.disagg_request_id = None
         resp.choices[0].disaggregated_params.ctx_request_id = 555
-        with pytest.raises(ValueError, match=r"disagg_request_id is None.*555"):
-            await svc._verify_ctx_response(resp)
+        with mock.patch("tensorrt_llm.serve.openai_disagg_service.logger.warning") as warning:
+            result = await svc._verify_ctx_response(resp)
+
+        assert result is resp
+        assert resp.choices[0].disaggregated_params.disagg_request_id == 555
+        warning.assert_called_once_with(
+            "Context server choice %d is missing disagg_request_id; "
+            "falling back to ctx_request_id=%s.",
+            0,
+            555,
+        )
 
     @pytest.mark.asyncio
     async def test_valid_response_passes(self):

--- a/tests/unittest/disaggregated/test_openai_disagg_service.py
+++ b/tests/unittest/disaggregated/test_openai_disagg_service.py
@@ -433,7 +433,7 @@ async def test_send_disagg_request_leaves_streaming_usage_to_gen_server(schedule
 
 
 @pytest.mark.asyncio
-async def test_context_retry_preserves_generation_reservation_id():
+async def test_context_retry_backfills_matching_id_and_preserves_generation_reservation():
     service = _make_service("context_first")
     service._ctx_client = AsyncMock()
     service._gen_client = AsyncMock()
@@ -445,7 +445,9 @@ async def test_context_retry_preserves_generation_reservation_id():
     async def _ctx_response(request, *_args, **_kwargs):
         # OpenAIHttpClient regenerates this field before a successful retry.
         request.disaggregated_params.disagg_request_id = 202
-        return _make_completion_response("", finish_reason="length", disagg_request_id=202)
+        response = _make_completion_response("", finish_reason="length", disagg_request_id=202)
+        response.choices[0].disaggregated_params.disagg_request_id = None
+        return response
 
     service._ctx_client.send_request = AsyncMock(side_effect=_ctx_response)
     service._gen_client.send_request = AsyncMock(
@@ -461,6 +463,7 @@ async def test_context_retry_preserves_generation_reservation_id():
     gen_call = service._gen_client.send_request.call_args
     assert gen_call.kwargs["req_id"] == 101
     assert gen_call.args[0].disaggregated_params.ctx_request_id == 202
+    assert gen_call.args[0].disaggregated_params.disagg_request_id == 202
 
 
 def test_generation_postprocessor_rewrites_usage_from_disaggregated_params():
@@ -577,7 +580,7 @@ class TestVerifyCtxResponseDiagnostics:
         resp = _make_completion_response("", finish_reason="error", disagg_request_id=1)
         resp.choices[0].disaggregated_params = None
         with pytest.raises(ValueError, match="finish_reason='error'"):
-            await svc._verify_ctx_response(resp)
+            await svc._verify_ctx_response(resp, expected_disagg_request_id=1)
 
     @pytest.mark.asyncio
     async def test_missing_ctx_request_id_includes_disagg_id(self):
@@ -585,7 +588,7 @@ class TestVerifyCtxResponseDiagnostics:
         resp = _make_completion_response("", finish_reason="length", disagg_request_id=999)
         resp.choices[0].disaggregated_params.ctx_request_id = None
         with pytest.raises(ValueError, match=r"ctx_request_id is None.*999"):
-            await svc._verify_ctx_response(resp)
+            await svc._verify_ctx_response(resp, expected_disagg_request_id=999)
 
     @pytest.mark.asyncio
     async def test_missing_disagg_request_id_falls_back_to_ctx_request_id(self):
@@ -593,23 +596,38 @@ class TestVerifyCtxResponseDiagnostics:
         resp = _make_completion_response("", finish_reason="length", disagg_request_id=555)
         resp.choices[0].disaggregated_params.disagg_request_id = None
         resp.choices[0].disaggregated_params.ctx_request_id = 555
-        with mock.patch("tensorrt_llm.serve.openai_disagg_service.logger.warning") as warning:
-            result = await svc._verify_ctx_response(resp)
+        with mock.patch(
+            "tensorrt_llm.serve.openai_disagg_service.logger.warning_once"
+        ) as warning_once:
+            result = await svc._verify_ctx_response(resp, expected_disagg_request_id=555)
 
         assert result is resp
         assert resp.choices[0].disaggregated_params.disagg_request_id == 555
-        warning.assert_called_once_with(
-            "Context server choice %d is missing disagg_request_id; "
-            "falling back to ctx_request_id=%s.",
-            0,
-            555,
+        warning_once.assert_called_once_with(
+            "Context server choice 0 is missing disagg_request_id; "
+            "falling back to verified ctx_request_id=555.",
+            key="missing_disagg_request_id_fallback",
         )
+
+    @pytest.mark.asyncio
+    async def test_missing_disagg_request_id_rejects_mismatched_ctx_request_id(self):
+        svc = _make_service("context_first")
+        resp = _make_completion_response("", finish_reason="length", disagg_request_id=777)
+        resp.choices[0].disaggregated_params.disagg_request_id = None
+
+        with pytest.raises(
+            ValueError,
+            match=r"ctx_request_id=777.*does not match.*disagg_request_id=555",
+        ):
+            await svc._verify_ctx_response(resp, expected_disagg_request_id=555)
+
+        assert resp.choices[0].disaggregated_params.disagg_request_id is None
 
     @pytest.mark.asyncio
     async def test_valid_response_passes(self):
         svc = _make_service("context_first")
         resp = _make_completion_response("ok", finish_reason="stop", disagg_request_id=42)
-        result = await svc._verify_ctx_response(resp)
+        result = await svc._verify_ctx_response(resp, expected_disagg_request_id=42)
         assert result is resp
 
     @pytest.mark.asyncio
@@ -619,7 +637,7 @@ class TestVerifyCtxResponseDiagnostics:
         svc = _make_service("context_first")
         resp = _make_completion_response("", finish_reason="stop", disagg_request_id=42)
         resp.choices[0].disaggregated_params.ctx_request_id = None
-        result = await svc._verify_ctx_response(resp)
+        result = await svc._verify_ctx_response(resp, expected_disagg_request_id=42)
         assert result is resp
 
     @pytest.mark.asyncio
@@ -627,7 +645,7 @@ class TestVerifyCtxResponseDiagnostics:
         svc = _make_service("context_first")
         resp = _make_completion_response("", finish_reason="stop", disagg_request_id=42)
         resp.choices[0].disaggregated_params.disagg_request_id = None
-        result = await svc._verify_ctx_response(resp)
+        result = await svc._verify_ctx_response(resp, expected_disagg_request_id=42)
         assert result is resp
 
 


### PR DESCRIPTION
## Summary

This change makes the disaggregated proxy tolerant of context-phase responses that include `ctx_request_id` but omit `disagg_request_id`.

Instead of failing hard in `_verify_ctx_response`, the proxy now falls back to `ctx_request_id` and logs a warning.

## Why

On a live 2-node DGX Spark disaggregated setup (`gpt-oss-120b`, UCX KV-cache transfer over RoCE/RDMA), the context server returned:
- `disaggregated_params.ctx_request_id != None`
- `disaggregated_params.disagg_request_id == None`

The proxy then raised:

```text
Invalid disaggregated params in context phase response. disagg_request_id is None
```

That prevented an otherwise healthy context/generation/proxy stack from serving requests.

## Rationale for the fallback

For context-first disaggregated flow, `ctx_request_id` is already the request identifier that the generation side uses to continue the request. When `disagg_request_id` is absent but `ctx_request_id` is present, using `ctx_request_id` preserves the existing request identity instead of aborting the request.

This is intentionally conservative:
- still errors if `disaggregated_params` is missing
- still errors if `ctx_request_id` is missing
- only fills `disagg_request_id` when it is the sole missing field
- emits a warning so the underlying worker-side omission remains visible

## Test

Added a regression test to verify `_verify_ctx_response` accepts a context-phase response with:
- `ctx_request_id` set
- `disagg_request_id` unset

and backfills `disagg_request_id` from `ctx_request_id`.

## Validation performed

Local validation:
- `python3 -m py_compile tensorrt_llm/serve/openai_disagg_service.py tests/unittest/disaggregated/test_openai_disagg_service.py`

I could not run the full pytest target in this lightweight clone because the local environment does not include TensorRT-LLM's Python test dependencies (for example `transformers`).

## Reproduction environment

Observed on:
- 2-node DGX Spark setup
- TensorRT-LLM `1.3.0rc10`
- disaggregated serving
- context server on node 1
- generation server on node 2
- proxy on node 1
- UCX KV-cache transfer over RoCE/RDMA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added a fallback for missing `disagg_request_id` in context responses.
- Applies the fallback only when `ctx_request_id` matches the expected request ID.
- Rejects missing or mismatched context IDs.
- Emits the warning once with a stable key.
- Preserves retry-updated request IDs.
- No configuration or public API changes were introduced.

## QA Engineer Review

- Updated the context retry test for missing `disagg_request_id`.
- Added coverage for matching fallback, mismatched IDs, response mutation, null IDs, and bounded warning calls.
- No corresponding `tests/integration/test_lists/`, `test-db/`, or `qa/` entries were changed.
- Verdict: needs follow-up for CI test-list coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->