### PR TITLE
[None][perf] Use +64 batch sizes for padding-enabled CUDA graphs

### DIFF
--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -179,12 +179,13 @@ class CudaGraphConfig(StrictBaseModel):
             batch_sizes += [
                 2**i for i in range(8, math.ceil(math.log(max_batch_size, 2)))
             ]
-            # Filter and sort batch sizes
-            batch_sizes = sorted(
-                [size for size in batch_sizes if size <= max_batch_size])
+
+        # Filter and sort batch sizes for both branches
+        batch_sizes = sorted(
+            [size for size in batch_sizes if size <= max_batch_size])
 
         # Add max_batch_size if not already included
-        if max_batch_size != batch_sizes[-1]:
+        if not batch_sizes or max_batch_size != batch_sizes[-1]:
             batch_sizes.append(max_batch_size)
 
         return batch_sizes

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -168,18 +168,20 @@ class CudaGraphConfig(StrictBaseModel):
             List of batch sizes to create CUDA graphs for
         """
         if enable_padding:
+            # Start with [1, 2, 4, 8, 16, 24, ..., 128] (multiples of 8)
             batch_sizes = [1, 2, 4] + [i * 8 for i in range(1, 17)]
+            # Sliding 64: extend by increments of 64 up to max_batch_size
+            while batch_sizes[-1] + 64 <= max_batch_size:
+                batch_sizes.append(batch_sizes[-1] + 64)
         else:
             batch_sizes = list(range(1, 32)) + [32, 64, 128]
-
-        # Add powers of 2 up to max_batch_size
-        batch_sizes += [
-            2**i for i in range(8, math.ceil(math.log(max_batch_size, 2)))
-        ]
-
-        # Filter and sort batch sizes
-        batch_sizes = sorted(
-            [size for size in batch_sizes if size <= max_batch_size])
+            # Add powers of 2 up to max_batch_size
+            batch_sizes += [
+                2**i for i in range(8, math.ceil(math.log(max_batch_size, 2)))
+            ]
+            # Filter and sort batch sizes
+            batch_sizes = sorted(
+                [size for size in batch_sizes if size <= max_batch_size])
 
         # Add max_batch_size if not already included
         if max_batch_size != batch_sizes[-1]:

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -712,6 +712,16 @@ class TestTorchLlmArgsCudaGraphSettings:
             128, True)
         assert args.cuda_graph_config.max_batch_size == 128
 
+    @pytest.mark.parametrize("max_batch_size", [64, 129, 320])
+    def test_generate_cuda_graph_batch_sizes_padding_edge_cases(
+            self, max_batch_size):
+        # All sizes must be <= max_batch_size, sorted, and include max_batch_size
+        batch_sizes = CudaGraphConfig._generate_cuda_graph_batch_sizes(
+            max_batch_size, enable_padding=True)
+        assert all(s <= max_batch_size for s in batch_sizes)
+        assert batch_sizes == sorted(batch_sizes)
+        assert max_batch_size in batch_sizes
+
 
 class TestTrtLlmArgs:
 


### PR DESCRIPTION
## Description

When enable_padding=True, replace the sparse powers-of-2 schedule (256, 512, 1024, 2048) with uniform +64 increments after the initial [1,2,4,8,...,128] base, giving denser coverage (192, 256, 320, …, max_batch_size) and reducing padding waste at intermediate batch sizes.

To test how denser batch sizes improve output throughput, we’ve tested on four major models, DeepSeek R1 and V3.2, Kimi K2 and Qwen 3, and in both aggregate and disagg modes. 

A denser set of batch sizes comes with the cost of more GPU memory. Each CUDA graph metadata takes about 10 MiB for DeepSeek R1. For +64 batch sizes, it increases from 220MiB to 490 MiB per GPU. For +8 batch sizes, it goes further to 2.6 GiB.

From the experiments, we found that denser batch sizes led to smaller drop on output throughput. Both +64 and +8 batch sizes improve the metrics. +64 batch sizes improve by up to 1.3x for agg and 1.5x for disagg for some large concurrencies.

+8 batch sizes improves a bit more than +64 on most models. However. We did notice a regression of +8 batch sizes on DeepSeek V3.2. We suspect DeepSeek V3.2 uses DSA which accelerates the attention computation but makes the CUDA graph more complex to store, thereby costing more than 2x GPU memory to save. This squeezes out available space for KV cache, reducing server capacity. Each GPU in the +8 experiment has 5 GiB fewer KV cache memory than the +64.

On the downside, +64 batch sizes increase server startup time.  TRTLLM repeats the graph capture twice. 1st as a dry run to measure how much GPU memory is used at runtime to estimate how much KV cache we can safely allocate. 2nd as the actual startup with the full KV cache allocated. Tested on GB200, DeepSeek R1 TP=4, IFB, max batch size 2048, it increases CUDA graph capture time by 1.4x and total LLM init time (measured as the time of `get_llm()`) by 1.17x. Future remedy can be to reduce the number of CUDA graph captures in the dry run phase and use an estimate based on the memory usage of the remaining CUDA graphs captured.

We concluded by suggesting landing the change to use +64 batch sizes for the next release. We are also writing a blog post with the data and guidance on how to set CUDA graph batch sizes for improving performance. Future work would include testing more options like +16, and designing a way of automatically setting the batch sizes to reach the best balance of memory cost and performance gains.



## Test Coverage

CI

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated CUDA graph batch size generation with adjusted scheduling patterns for different padding configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->