### PR TITLE
[#12715][fix] disable NCCL_SYMMETRIC tactic on GB10 (DGX Spark)

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -55,6 +55,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
 from tensorrt_llm.bindings.internal.thop import BufferKind
 
 
+@lru_cache(maxsize=None)
+def _is_gb10() -> bool:
+    """Return True on GB10 (DGX Spark). NCCL_SYMMETRIC is unsupported on this platform."""
+    return "GB10" in torch.cuda.get_device_name()
+
+
 # Used to WAR an issue in torch.bmm that it would break the graph when the out is not contiguous.
 @torch.library.custom_op("trtllm::bmm_out", mutates_args=("out", ))
 def bmm_out(a: torch.Tensor, b: torch.Tensor, out: torch.Tensor) -> None:
@@ -1995,10 +2001,14 @@ class AllReduceRunner(TunableRunner):
         profile: OptimizationProfile,
         **kwargs,
     ) -> List[int]:
-        valid_strategies = [
-            AllReduceStrategy.NCCL_SYMMETRIC.value,
-            AllReduceStrategy.NCCL.value,
-        ]
+        # NCCL_SYMMETRIC is unsupported on GB10 (DGX Spark); use plain NCCL only.
+        if _is_gb10():
+            valid_strategies = [AllReduceStrategy.NCCL.value]
+        else:
+            valid_strategies = [
+                AllReduceStrategy.NCCL_SYMMETRIC.value,
+                AllReduceStrategy.NCCL.value,
+            ]
         # Fallback in allreduceOp is set to NCCL_SYMMETRIC as default
         # So we need to check if the workspace size is too large to avoid hanging.
         workspace_size = inputs[0].numel() * inputs[0].element_size()
@@ -2040,11 +2050,13 @@ class AllReduceRunner(TunableRunner):
                 )
             return input
         if tactic == -1:
-            # tactic == -1 means the autotuner cache missed for this shape;
-            # fall back to NCCL_SYMMETRIC. Asymmetric ncclMemAlloc failures are
-            # handled by a cross-rank barrier in NCCLWindowAllocator, which
-            # falls back to plain NCCL if allocation fails on any rank.
-            tactic = AllReduceStrategy.NCCL_SYMMETRIC.value
+            # tactic == -1 means the autotuner cache missed for this shape.
+            # On GB10 (DGX Spark) NCCL_SYMMETRIC is unsupported, so fall back
+            # to plain NCCL. On other platforms fall back to NCCL_SYMMETRIC;
+            # asymmetric ncclMemAlloc failures are handled by a cross-rank
+            # barrier in NCCLWindowAllocator which falls back to plain NCCL.
+            tactic = (AllReduceStrategy.NCCL.value
+                      if _is_gb10() else AllReduceStrategy.NCCL_SYMMETRIC.value)
 
         return torch.ops.trtllm.allreduce(
             input,

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ctypes
 import enum
+import os
 import threading
+from ctypes.util import find_library
 from dataclasses import replace
 from functools import lru_cache
 from typing import ClassVar, List, Mapping, Optional, Tuple, Union
@@ -40,6 +43,7 @@ from .fast_custom_op import fast_custom_op
 
 if IS_FLASHINFER_AVAILABLE:
     from flashinfer.fp4_quantization import nvfp4_quantize as _flashinfer_nvfp4_quantize
+
 from ..modules.multi_stream_utils import do_multi_stream
 from ..modules.swiglu import silu_and_mul_kernel
 from ..utils import (ActivationType, deep_gemm_gen_tuning_buckets,
@@ -54,11 +58,55 @@ if IS_CUTLASS_DSL_AVAILABLE:
 # BufferKind is bound from C++; see cpp/tensorrt_llm/thop/outputTensor.h (torch_ext::BufferKind).
 from tensorrt_llm.bindings.internal.thop import BufferKind
 
+_NCCL_GB10_SYMMETRIC_FIXED_VERSION = 23004  # NCCL 2.30.4
+_NCCL_MNNVL_ENABLE = "NCCL_MNNVL_ENABLE"
+
 
 @lru_cache(maxsize=None)
 def _is_gb10() -> bool:
-    """Return True on GB10 (DGX Spark). NCCL_SYMMETRIC is unsupported on this platform."""
+    """Return True on GB10 (DGX Spark)."""
     return "GB10" in torch.cuda.get_device_name()
+
+
+@lru_cache(maxsize=None)
+def _get_nccl_runtime_version_code() -> Optional[int]:
+    lib_names = ["libnccl.so.2", "libnccl.so"]
+    nccl_lib = find_library("nccl")
+    if nccl_lib is not None and nccl_lib not in lib_names:
+        lib_names.append(nccl_lib)
+
+    for lib_name in lib_names:
+        try:
+            nccl = ctypes.CDLL(lib_name)
+            nccl.ncclGetVersion.argtypes = [ctypes.POINTER(ctypes.c_int)]
+            nccl.ncclGetVersion.restype = ctypes.c_int
+        except (AttributeError, OSError):
+            continue
+
+        version = ctypes.c_int()
+        if nccl.ncclGetVersion(ctypes.byref(version)) == 0:
+            return version.value
+
+    return None
+
+
+@lru_cache(maxsize=None)
+def _needs_gb10_nccl_symmetric_workaround() -> bool:
+    if not _is_gb10():
+        return False
+
+    runtime_version = _get_nccl_runtime_version_code()
+    return (runtime_version is None
+            or runtime_version < _NCCL_GB10_SYMMETRIC_FIXED_VERSION)
+
+
+@lru_cache(maxsize=None)
+def _init_gb10_nccl_symmetric_workaround() -> bool:
+    if not _needs_gb10_nccl_symmetric_workaround():
+        return False
+
+    os.environ.setdefault(_NCCL_MNNVL_ENABLE, "0")
+    return True
 
 
 # Used to WAR an issue in torch.bmm that it would break the graph when the out is not contiguous.
@@ -2001,8 +2049,8 @@ class AllReduceRunner(TunableRunner):
         profile: OptimizationProfile,
         **kwargs,
     ) -> List[int]:
-        # NCCL_SYMMETRIC is unsupported on GB10 (DGX Spark); use plain NCCL only.
-        if _is_gb10():
+        # NCCL_SYMMETRIC is unsupported on GB10 (DGX Spark) before NCCL 2.30.4.
+        if _needs_gb10_nccl_symmetric_workaround():
             valid_strategies = [AllReduceStrategy.NCCL.value]
         else:
             valid_strategies = [
@@ -2035,6 +2083,7 @@ class AllReduceRunner(TunableRunner):
         **kwargs,
     ) -> torch.Tensor:
         input, residual, norm_weight, scale, bias, workspace = inputs
+        gb10_nccl_workaround = _needs_gb10_nccl_symmetric_workaround()
         if do_preparation:
             valid_tactics = self.get_valid_tactics(inputs,
                                                    OptimizationProfile(),
@@ -2051,12 +2100,15 @@ class AllReduceRunner(TunableRunner):
             return input
         if tactic == -1:
             # tactic == -1 means the autotuner cache missed for this shape.
-            # On GB10 (DGX Spark) NCCL_SYMMETRIC is unsupported, so fall back
-            # to plain NCCL. On other platforms fall back to NCCL_SYMMETRIC;
-            # asymmetric ncclMemAlloc failures are handled by a cross-rank
-            # barrier in NCCLWindowAllocator which falls back to plain NCCL.
-            tactic = (AllReduceStrategy.NCCL.value
-                      if _is_gb10() else AllReduceStrategy.NCCL_SYMMETRIC.value)
+            # On GB10 (DGX Spark), NCCL_SYMMETRIC is unsupported before NCCL
+            # 2.30.4, so fall back to plain NCCL. On other platforms fall back
+            # to NCCL_SYMMETRIC; asymmetric ncclMemAlloc failures are handled
+            # by a cross-rank barrier in NCCLWindowAllocator which falls back
+            # to plain NCCL.
+            if gb10_nccl_workaround:
+                tactic = AllReduceStrategy.NCCL.value
+            else:
+                tactic = AllReduceStrategy.NCCL_SYMMETRIC.value
 
         return torch.ops.trtllm.allreduce(
             input,

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -707,6 +707,10 @@ class AllReduce(nn.Module):
         # read it here and stash the values as class-level attributes that
         # AllReduceRunner.forward can use during the autotuner warm-up phase.
         extra_attrs = get_model_extra_attrs()
+        from tensorrt_llm._torch.custom_ops.torch_custom_ops import \
+            _init_gb10_nccl_symmetric_workaround
+        _init_gb10_nccl_symmetric_workaround()
+
         if extra_attrs:
             from tensorrt_llm._torch.custom_ops.torch_custom_ops import \
                 AllReduceRunner


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility issues with GB10 CUDA devices in distributed reduction operations.
  * Improved fallback behavior when optimization cache is unavailable.

* **Performance**
  * Optimized distributed reduction tactics for specific hardware platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR disables NCCL symmetric on spark compute notes.
#12715 reports that there is a failure on that platform.
Until the issue can be resolved from within NCCL this work around should enable the platform again without impacting other platforms.
We are investigating actively this failure in NCCL and will resolve it, when that happens we can remove this WAR again.

## Test Coverage

I do not have access to a dual spark machine setup, so I need help with testing and verifying this fix.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
