### PR TITLE
[None][feat] Add ForwardPassMetrics queue API to PyExecutor

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1403,7 +1403,8 @@ def create_py_executor_instance(
         virtual_memory_pools=virtual_memory_pools,
         execution_stream=execution_stream,
         waiting_queue_policy=waiting_queue_policy,
-        dwdp_manager=dwdp_manager)
+        dwdp_manager=dwdp_manager,
+    )
 
 
 def create_torch_sampler_args(

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import torch
 
@@ -1137,6 +1137,7 @@ def create_py_executor_instance(
     virtual_memory_pools: Optional[dict] = None,
     execution_stream: Optional[torch.cuda.Stream] = None,
     dwdp_manager: Optional[DwdpManager] = None,
+    forward_pass_metrics_hook: Optional[Callable] = None,
 ) -> PyExecutor:
     kv_cache_manager = resources.get(ResourceManagerType.KV_CACHE_MANAGER, None)
 
@@ -1404,7 +1405,7 @@ def create_py_executor_instance(
         execution_stream=execution_stream,
         waiting_queue_policy=waiting_queue_policy,
         dwdp_manager=dwdp_manager,
-    )
+        forward_pass_metrics_hook=forward_pass_metrics_hook)
 
 
 def create_torch_sampler_args(

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1,5 +1,5 @@
 import os
-from typing import Callable, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import torch
 
@@ -1137,7 +1137,6 @@ def create_py_executor_instance(
     virtual_memory_pools: Optional[dict] = None,
     execution_stream: Optional[torch.cuda.Stream] = None,
     dwdp_manager: Optional[DwdpManager] = None,
-    forward_pass_metrics_hook: Optional[Callable] = None,
 ) -> PyExecutor:
     kv_cache_manager = resources.get(ResourceManagerType.KV_CACHE_MANAGER, None)
 
@@ -1404,8 +1403,7 @@ def create_py_executor_instance(
         virtual_memory_pools=virtual_memory_pools,
         execution_stream=execution_stream,
         waiting_queue_policy=waiting_queue_policy,
-        dwdp_manager=dwdp_manager,
-        forward_pass_metrics_hook=forward_pass_metrics_hook)
+        dwdp_manager=dwdp_manager)
 
 
 def create_torch_sampler_args(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1343,10 +1343,13 @@ class PyExecutor:
                 q_decode_m2 += delta * (kv - q_decode_mean)
 
         # Pool B: waiting queue (pre-activation)
+        from tensorrt_llm.bindings.executor import RequestType
         try:
             queue_items = list(
                 self.executor_request_queue.get_request_queue().queue)
-        except Exception:
+        except (AttributeError, RuntimeError):
+            logger.debug("Could not access request queue for FPM",
+                         exc_info=True)
             queue_items = []
 
         for item in queue_items:
@@ -1358,7 +1361,6 @@ class PyExecutor:
                     item.request.input_token_ids
                 ) if item.request.input_token_ids is not None else 0
                 req_type = item.request.request_type
-                from tensorrt_llm.bindings.executor import RequestType
                 if req_type == RequestType.REQUEST_TYPE_GENERATION_ONLY:
                     # Queued decode — exact KV length not available from
                     # RequestQueueItem; count only.
@@ -1441,8 +1443,10 @@ class PyExecutor:
         try:
             if self.executor_request_queue.get_request_queue_size() > 0:
                 return
-        except Exception:
-            pass
+        except (AttributeError, RuntimeError):
+            logger.debug("Could not check queue size for idle heartbeat",
+                         exc_info=True)
+            return  # Unknown state — skip heartbeat to avoid false idle signal
 
         self._fpm_counter += 1
         dp_rank = (self.dist.tp_rank if self.enable_attention_dp else 0)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2002,6 +2002,11 @@ class PyExecutor:
                 executed_batch,
                 executed_batch.microbatch_id % self.dist.pp_size,
             )
+        elif (executed_batch is not None
+              and executed_batch.fpm_scheduled is not None):
+            iter_end = time.time()
+            iter_latency_ms = (iter_end - executed_batch.iter_start_time) * 1e3
+            self._emit_fpm(executed_batch, iter_latency_ms)
 
     @nvtx_range("wait_on_pp_send_handles")
     def wait_on_pp_send_handles(self, send_handles, microbatch_id):
@@ -2858,6 +2863,11 @@ class PyExecutor:
         if self.enable_iter_perf_stats:
             self._process_iter_stats(finished_requests, self.active_requests,
                                      self.previous_batch)
+        elif self.previous_batch.fpm_scheduled is not None:
+            iter_end = time.time()
+            iter_latency_ms = (iter_end -
+                               self.previous_batch.iter_start_time) * 1e3
+            self._emit_fpm(self.previous_batch, iter_latency_ms)
 
     def _forward_step_inter_pp(self, scheduled_batch) -> SampleState:
         self._forward_step(scheduled_batch)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -143,13 +143,13 @@ class FpmScheduledSnapshot:
 
     @property
     def var_prefill_length(self) -> float:
-        return (self.prefill_length_m2 / self.prefill_length_n
-                if self.prefill_length_n > 0 else 0.0)
+        return (self.prefill_length_m2 /
+                self.prefill_length_n if self.prefill_length_n > 0 else 0.0)
 
     @property
     def var_decode_kv_tokens(self) -> float:
-        return (self.decode_kv_m2 / self.decode_kv_n
-                if self.decode_kv_n > 0 else 0.0)
+        return (self.decode_kv_m2 /
+                self.decode_kv_n if self.decode_kv_n > 0 else 0.0)
 
 
 @dataclasses.dataclass
@@ -1238,8 +1238,8 @@ class PyExecutor:
     # ------------------------------------------------------------------
 
     def _capture_fpm_scheduled(
-            self,
-            scheduled_batch: ScheduledRequests) -> Optional[FpmScheduledSnapshot]:
+            self, scheduled_batch: ScheduledRequests
+    ) -> Optional[FpmScheduledSnapshot]:
         """Capture a pre-mutation snapshot of scheduling data for FPM.
 
         Must be called AFTER scheduling and BEFORE _update_request_states()
@@ -1296,9 +1296,7 @@ class PyExecutor:
 
         return snap
 
-    def _compute_fpm_queued(
-            self,
-            scheduled_set: set) -> dict:
+    def _compute_fpm_queued(self, scheduled_set: set) -> dict:
         """Compute queued-request metrics from both active and waiting pools.
 
         Args:
@@ -1343,7 +1341,8 @@ class PyExecutor:
             queue_items = []
 
         for item in queue_items:
-            if not isinstance(item, RequestQueueItem) or not item.is_normal_request:
+            if not isinstance(item,
+                              RequestQueueItem) or not item.is_normal_request:
                 continue
             if item.request is not None:
                 input_len = len(
@@ -1365,14 +1364,18 @@ class PyExecutor:
                         q_prefill_m2 += delta * (input_len - q_prefill_mean)
 
         return {
-            "num_prefill_requests": q_prefill_n,
-            "sum_prefill_tokens": q_prefill_tokens,
-            "var_prefill_length": (q_prefill_m2 / q_prefill_n
-                                   if q_prefill_n > 0 else 0.0),
-            "num_decode_requests": q_decode_n,
-            "sum_decode_kv_tokens": q_decode_kv,
-            "var_decode_kv_tokens": (q_decode_m2 / q_decode_n
-                                     if q_decode_n > 0 else 0.0),
+            "num_prefill_requests":
+            q_prefill_n,
+            "sum_prefill_tokens":
+            q_prefill_tokens,
+            "var_prefill_length":
+            (q_prefill_m2 / q_prefill_n if q_prefill_n > 0 else 0.0),
+            "num_decode_requests":
+            q_decode_n,
+            "sum_decode_kv_tokens":
+            q_decode_kv,
+            "var_decode_kv_tokens":
+            (q_decode_m2 / q_decode_n if q_decode_n > 0 else 0.0),
         }
 
     def _emit_fpm(self, batch_state: BatchState, iter_latency_ms: float):
@@ -1391,8 +1394,7 @@ class PyExecutor:
 
         queued = self._compute_fpm_queued(scheduled_ids)
 
-        dp_rank = (self.dist.tp_rank
-                   if self.enable_attention_dp else 0)
+        dp_rank = (self.dist.tp_rank if self.enable_attention_dp else 0)
 
         self._fpm_counter += 1
         payload = {
@@ -1435,8 +1437,7 @@ class PyExecutor:
             pass
 
         self._fpm_counter += 1
-        dp_rank = (self.dist.tp_rank
-                   if self.enable_attention_dp else 0)
+        dp_rank = (self.dist.tp_rank if self.enable_attention_dp else 0)
         heartbeat = {
             "version": 1,
             "worker_id": "",
@@ -2299,7 +2300,8 @@ class PyExecutor:
 
                 scheduled_batch, iter_stats = self._prepare_and_schedule_batch()
                 # Capture FPM snapshot before any request mutation
-                fpm_snap = self._capture_fpm_scheduled(scheduled_batch) if scheduled_batch is not None else None
+                fpm_snap = self._capture_fpm_scheduled(
+                    scheduled_batch) if scheduled_batch is not None else None
                 self._handle_control_request()
 
                 if scheduled_batch is None:
@@ -2461,8 +2463,7 @@ class PyExecutor:
                     self._emit_fpm(
                         BatchState(scheduled_requests=scheduled_batch,
                                    sample_state=sample_state,
-                                   fpm_scheduled=fpm_snap),
-                        0.0)
+                                   fpm_scheduled=fpm_snap), 0.0)
 
                 self._maybe_emit_idle_fpm_heartbeat()
                 self.iter_counter += 1
@@ -2550,7 +2551,8 @@ class PyExecutor:
 
                 scheduled_batch, iter_stats = self._prepare_and_schedule_batch()
                 # Capture FPM snapshot before any request mutation
-                fpm_snap = self._capture_fpm_scheduled(scheduled_batch) if scheduled_batch is not None else None
+                fpm_snap = self._capture_fpm_scheduled(
+                    scheduled_batch) if scheduled_batch is not None else None
                 self._handle_control_request()
 
                 if scheduled_batch is None:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -321,8 +321,7 @@ class PyExecutor:
             execution_stream: Optional[torch.cuda.Stream] = None,
             waiting_queue_policy: WaitingQueuePolicy = WaitingQueuePolicy.FCFS,
             adp_router: Optional[ADPRouter] = None,
-            dwdp_manager: Optional[DwdpManager] = None,
-            forward_pass_metrics_hook: Optional[Callable[[dict], None]] = None):
+            dwdp_manager: Optional[DwdpManager] = None):
         super(PyExecutor, self).__init__()
         self.device_id = torch.cuda.current_device()
         self.global_rank = dist.rank
@@ -557,10 +556,12 @@ class PyExecutor:
             'iteration_stats_interval', 1)
         self.gather_all_responses = False
 
-        # Forward pass metrics (FPM) hook and state
-        self._fpm_hook = forward_pass_metrics_hook
+        # Forward pass metrics (FPM) queue — same drain pattern as self.stats
+        self._fpm_lock = threading.Lock()
+        self._fpm_queue: List[dict] = []
         self._fpm_was_active = False
         self._fpm_counter = 0
+        self._fpm_max_len = self.max_stats_len
 
         self.kv_cache_transceiver = kv_cache_transceiver
         self.is_benchmark_disagg = (self.benchmark_req_queues_size > 0
@@ -872,6 +873,16 @@ class PyExecutor:
             latest_stats = self.stats
             self.stats = []
         return latest_stats
+
+    def get_latest_forward_pass_metrics(self):
+        """Returns ForwardPassMetrics dicts accumulated since the last call.
+
+        Same drain-on-read pattern as get_latest_iteration_stats().
+        """
+        with self._fpm_lock:
+            result = self._fpm_queue
+            self._fpm_queue = []
+        return result
 
     def get_latest_kv_cache_events(self):
         kv_cache_manager = self.resource_manager.resource_managers.get(
@@ -1245,8 +1256,6 @@ class PyExecutor:
         Must be called AFTER scheduling and BEFORE _update_request_states()
         because state updates mutate request fields used for metric computation.
         """
-        if self._fpm_hook is None:
-            return None
 
         snap = FpmScheduledSnapshot()
 
@@ -1378,11 +1387,15 @@ class PyExecutor:
             (q_decode_m2 / q_decode_n if q_decode_n > 0 else 0.0),
         }
 
-    def _emit_fpm(self, batch_state: BatchState, iter_latency_ms: float):
-        """Emit a ForwardPassMetrics message via the hook callback."""
-        if self._fpm_hook is None:
-            return
+    def _append_fpm(self, payload: dict):
+        """Thread-safe append to the FPM drain queue."""
+        with self._fpm_lock:
+            if len(self._fpm_queue) >= self._fpm_max_len:
+                self._fpm_queue.pop(0)
+            self._fpm_queue.append(payload)
 
+    def _emit_fpm(self, batch_state: BatchState, iter_latency_ms: float):
+        """Build a ForwardPassMetrics dict and enqueue it."""
         snap = batch_state.fpm_scheduled
         if snap is None:
             return
@@ -1399,7 +1412,6 @@ class PyExecutor:
         self._fpm_counter += 1
         payload = {
             "version": 1,
-            "worker_id": "",  # Set by Dynamo caller
             "dp_rank": dp_rank,
             "counter_id": self._fpm_counter,
             "wall_time": iter_latency_ms / 1000.0,
@@ -1415,16 +1427,12 @@ class PyExecutor:
             "queued_requests": queued,
         }
 
-        try:
-            self._fpm_hook(payload)
-        except Exception:
-            logger.warning("FPM hook callback failed", exc_info=True)
-
+        self._append_fpm(payload)
         self._fpm_was_active = True
 
     def _maybe_emit_idle_fpm_heartbeat(self):
         """Emit a single idle heartbeat when transitioning from active to idle."""
-        if self._fpm_hook is None or not self._fpm_was_active:
+        if not self._fpm_was_active:
             return
 
         # Check if truly idle: no active requests, no waiting queue items
@@ -1440,7 +1448,6 @@ class PyExecutor:
         dp_rank = (self.dist.tp_rank if self.enable_attention_dp else 0)
         heartbeat = {
             "version": 1,
-            "worker_id": "",
             "dp_rank": dp_rank,
             "counter_id": self._fpm_counter,
             "wall_time": 0.0,
@@ -1462,11 +1469,8 @@ class PyExecutor:
                 "var_decode_kv_tokens": 0.0,
             },
         }
-        try:
-            self._fpm_hook(heartbeat)
-        except Exception:
-            logger.warning("FPM idle heartbeat hook failed", exc_info=True)
 
+        self._append_fpm(heartbeat)
         self._fpm_was_active = False
 
     def _process_iter_stats(
@@ -2458,7 +2462,7 @@ class PyExecutor:
                                    iter_stats=iter_stats,
                                    iter_start_time=iter_start_time,
                                    fpm_scheduled=fpm_snap))
-                elif self._fpm_hook is not None and fpm_snap is not None:
+                elif fpm_snap is not None:
                     # Emit FPM even when iter_perf_stats is disabled
                     self._emit_fpm(
                         BatchState(scheduled_requests=scheduled_batch,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -121,12 +121,45 @@ def _load_iteration_indexes(env_var: str):
 
 
 @dataclasses.dataclass
+class FpmScheduledSnapshot:
+    """Pre-mutation snapshot of per-request scheduling data for ForwardPassMetrics.
+
+    Captured immediately after scheduling and BEFORE _update_request_states()
+    mutates request objects. This is necessary because fields like
+    context_current_position and max_beam_num_tokens change during state updates.
+    """
+    num_prefill_requests: int = 0
+    sum_prefill_tokens: int = 0
+    sum_prefill_kv_tokens: int = 0
+    num_decode_requests: int = 0
+    sum_decode_kv_tokens: int = 0
+    # Welford online accumulators (n, sum, mean, m2) for variance
+    prefill_length_n: int = 0
+    prefill_length_mean: float = 0.0
+    prefill_length_m2: float = 0.0
+    decode_kv_n: int = 0
+    decode_kv_mean: float = 0.0
+    decode_kv_m2: float = 0.0
+
+    @property
+    def var_prefill_length(self) -> float:
+        return (self.prefill_length_m2 / self.prefill_length_n
+                if self.prefill_length_n > 0 else 0.0)
+
+    @property
+    def var_decode_kv_tokens(self) -> float:
+        return (self.decode_kv_m2 / self.decode_kv_n
+                if self.decode_kv_n > 0 else 0.0)
+
+
+@dataclasses.dataclass
 class BatchState:
     scheduled_requests: ScheduledRequests
     sample_state: SampleState
 
     iter_start_time: float = 0
     iter_stats: IterationStats = None
+    fpm_scheduled: FpmScheduledSnapshot = None
 
 
 @dataclasses.dataclass
@@ -288,7 +321,8 @@ class PyExecutor:
             execution_stream: Optional[torch.cuda.Stream] = None,
             waiting_queue_policy: WaitingQueuePolicy = WaitingQueuePolicy.FCFS,
             adp_router: Optional[ADPRouter] = None,
-            dwdp_manager: Optional[DwdpManager] = None):
+            dwdp_manager: Optional[DwdpManager] = None,
+            forward_pass_metrics_hook: Optional[Callable[[dict], None]] = None):
         super(PyExecutor, self).__init__()
         self.device_id = torch.cuda.current_device()
         self.global_rank = dist.rank
@@ -522,6 +556,11 @@ class PyExecutor:
             getattr(self.llm_args, 'kv_cache_config', None),
             'iteration_stats_interval', 1)
         self.gather_all_responses = False
+
+        # Forward pass metrics (FPM) hook and state
+        self._fpm_hook = forward_pass_metrics_hook
+        self._fpm_was_active = False
+        self._fpm_counter = 0
 
         self.kv_cache_transceiver = kv_cache_transceiver
         self.is_benchmark_disagg = (self.benchmark_req_queues_size > 0
@@ -1194,6 +1233,241 @@ class PyExecutor:
                 self.stats.pop(0)
             self.stats.append((stats, req_stats, self._latest_kv_iter_stats))
 
+    # ------------------------------------------------------------------
+    # Forward Pass Metrics (FPM) helpers
+    # ------------------------------------------------------------------
+
+    def _capture_fpm_scheduled(
+            self,
+            scheduled_batch: ScheduledRequests) -> Optional[FpmScheduledSnapshot]:
+        """Capture a pre-mutation snapshot of scheduling data for FPM.
+
+        Must be called AFTER scheduling and BEFORE _update_request_states()
+        because state updates mutate request fields used for metric computation.
+        """
+        if self._fpm_hook is None:
+            return None
+
+        snap = FpmScheduledSnapshot()
+
+        # Welford helpers (inline to avoid function-call overhead per request)
+        pf_n = 0
+        pf_mean = 0.0
+        pf_m2 = 0.0
+        dk_n = 0
+        dk_mean = 0.0
+        dk_m2 = 0.0
+
+        # --- Prefill (context) requests ---
+        for req in scheduled_batch.context_requests:
+            if req.is_dummy:
+                continue
+            snap.num_prefill_requests += 1
+            snap.sum_prefill_tokens += req.context_chunk_size
+            snap.sum_prefill_kv_tokens += req.context_current_position
+
+            # Welford update for prompt-length variance
+            v = req.py_orig_prompt_len
+            pf_n += 1
+            delta = v - pf_mean
+            pf_mean += delta / pf_n
+            pf_m2 += delta * (v - pf_mean)
+
+        # --- Decode (generation) requests ---
+        for req in scheduled_batch.generation_requests:
+            if req.is_dummy:
+                continue
+            snap.num_decode_requests += 1
+            kv_len = req.max_beam_num_tokens
+            snap.sum_decode_kv_tokens += kv_len
+
+            # Welford update for decode-KV-length variance
+            dk_n += 1
+            delta = kv_len - dk_mean
+            dk_mean += delta / dk_n
+            dk_m2 += delta * (kv_len - dk_mean)
+
+        snap.prefill_length_n = pf_n
+        snap.prefill_length_mean = pf_mean
+        snap.prefill_length_m2 = pf_m2
+        snap.decode_kv_n = dk_n
+        snap.decode_kv_mean = dk_mean
+        snap.decode_kv_m2 = dk_m2
+
+        return snap
+
+    def _compute_fpm_queued(
+            self,
+            scheduled_set: set) -> dict:
+        """Compute queued-request metrics from both active and waiting pools.
+
+        Args:
+            scheduled_set: Set of request ids that were scheduled this iteration.
+        """
+        q_prefill_n = 0
+        q_prefill_tokens = 0
+        q_prefill_mean = 0.0
+        q_prefill_m2 = 0.0
+        q_decode_n = 0
+        q_decode_kv = 0
+        q_decode_mean = 0.0
+        q_decode_m2 = 0.0
+
+        # Pool A: active but not scheduled this iteration
+        for req in self.active_requests:
+            if req.request_id in scheduled_set or req.is_dummy:
+                continue
+            if req.state in (LlmRequestState.CONTEXT_INIT,
+                             LlmRequestState.ENCODER_INIT):
+                # Queued prefill
+                v = req.py_orig_prompt_len
+                q_prefill_n += 1
+                q_prefill_tokens += v
+                delta = v - q_prefill_mean
+                q_prefill_mean += delta / q_prefill_n
+                q_prefill_m2 += delta * (v - q_prefill_mean)
+            elif req.state == LlmRequestState.GENERATION_IN_PROGRESS:
+                # Queued decode (preempted/paused)
+                kv = req.max_beam_num_tokens
+                q_decode_n += 1
+                q_decode_kv += kv
+                delta = kv - q_decode_mean
+                q_decode_mean += delta / q_decode_n
+                q_decode_m2 += delta * (kv - q_decode_mean)
+
+        # Pool B: waiting queue (pre-activation)
+        try:
+            queue_items = list(
+                self.executor_request_queue.get_request_queue().queue)
+        except Exception:
+            queue_items = []
+
+        for item in queue_items:
+            if not isinstance(item, RequestQueueItem) or not item.is_normal_request:
+                continue
+            if item.request is not None:
+                input_len = len(
+                    item.request.input_token_ids
+                ) if item.request.input_token_ids is not None else 0
+                req_type = item.request.request_type
+                from tensorrt_llm.bindings.executor import RequestType
+                if req_type == RequestType.REQUEST_TYPE_GENERATION_ONLY:
+                    # Queued decode — exact KV length not available from
+                    # RequestQueueItem; count only.
+                    q_decode_n += 1
+                else:
+                    # Queued prefill
+                    q_prefill_n += 1
+                    q_prefill_tokens += input_len
+                    delta = input_len - q_prefill_mean
+                    if q_prefill_n > 0:
+                        q_prefill_mean += delta / q_prefill_n
+                        q_prefill_m2 += delta * (input_len - q_prefill_mean)
+
+        return {
+            "num_prefill_requests": q_prefill_n,
+            "sum_prefill_tokens": q_prefill_tokens,
+            "var_prefill_length": (q_prefill_m2 / q_prefill_n
+                                   if q_prefill_n > 0 else 0.0),
+            "num_decode_requests": q_decode_n,
+            "sum_decode_kv_tokens": q_decode_kv,
+            "var_decode_kv_tokens": (q_decode_m2 / q_decode_n
+                                     if q_decode_n > 0 else 0.0),
+        }
+
+    def _emit_fpm(self, batch_state: BatchState, iter_latency_ms: float):
+        """Emit a ForwardPassMetrics message via the hook callback."""
+        if self._fpm_hook is None:
+            return
+
+        snap = batch_state.fpm_scheduled
+        if snap is None:
+            return
+
+        # Build the set of scheduled request IDs for queued computation
+        scheduled_ids = set()
+        for req in batch_state.scheduled_requests.all_requests():
+            scheduled_ids.add(req.request_id)
+
+        queued = self._compute_fpm_queued(scheduled_ids)
+
+        dp_rank = (self.dist.tp_rank
+                   if self.enable_attention_dp else 0)
+
+        self._fpm_counter += 1
+        payload = {
+            "version": 1,
+            "worker_id": "",  # Set by Dynamo caller
+            "dp_rank": dp_rank,
+            "counter_id": self._fpm_counter,
+            "wall_time": iter_latency_ms / 1000.0,
+            "scheduled_requests": {
+                "num_prefill_requests": snap.num_prefill_requests,
+                "sum_prefill_tokens": snap.sum_prefill_tokens,
+                "var_prefill_length": snap.var_prefill_length,
+                "sum_prefill_kv_tokens": snap.sum_prefill_kv_tokens,
+                "num_decode_requests": snap.num_decode_requests,
+                "sum_decode_kv_tokens": snap.sum_decode_kv_tokens,
+                "var_decode_kv_tokens": snap.var_decode_kv_tokens,
+            },
+            "queued_requests": queued,
+        }
+
+        try:
+            self._fpm_hook(payload)
+        except Exception:
+            logger.warning("FPM hook callback failed", exc_info=True)
+
+        self._fpm_was_active = True
+
+    def _maybe_emit_idle_fpm_heartbeat(self):
+        """Emit a single idle heartbeat when transitioning from active to idle."""
+        if self._fpm_hook is None or not self._fpm_was_active:
+            return
+
+        # Check if truly idle: no active requests, no waiting queue items
+        if len(self.active_requests) > 0:
+            return
+        try:
+            if self.executor_request_queue.get_request_queue_size() > 0:
+                return
+        except Exception:
+            pass
+
+        self._fpm_counter += 1
+        dp_rank = (self.dist.tp_rank
+                   if self.enable_attention_dp else 0)
+        heartbeat = {
+            "version": 1,
+            "worker_id": "",
+            "dp_rank": dp_rank,
+            "counter_id": self._fpm_counter,
+            "wall_time": 0.0,
+            "scheduled_requests": {
+                "num_prefill_requests": 0,
+                "sum_prefill_tokens": 0,
+                "var_prefill_length": 0.0,
+                "sum_prefill_kv_tokens": 0,
+                "num_decode_requests": 0,
+                "sum_decode_kv_tokens": 0,
+                "var_decode_kv_tokens": 0.0,
+            },
+            "queued_requests": {
+                "num_prefill_requests": 0,
+                "sum_prefill_tokens": 0,
+                "var_prefill_length": 0.0,
+                "num_decode_requests": 0,
+                "sum_decode_kv_tokens": 0,
+                "var_decode_kv_tokens": 0.0,
+            },
+        }
+        try:
+            self._fpm_hook(heartbeat)
+        except Exception:
+            logger.warning("FPM idle heartbeat hook failed", exc_info=True)
+
+        self._fpm_was_active = False
+
     def _process_iter_stats(
         self,
         finished_requests: list[LlmRequest],
@@ -1217,6 +1491,9 @@ class PyExecutor:
                                     len(finished_requests),
                                     batch_state.scheduled_requests,
                                     micro_batch_id), req_stats)
+
+        # Emit ForwardPassMetrics after iteration stats are finalized
+        self._emit_fpm(batch_state, iter_latency_ms)
 
     def _executor_loop_cleanup(self):
 
@@ -1357,6 +1634,8 @@ class PyExecutor:
                 # Stage 0: first PP rank schedules requests and propagates the result to all other PP ranks.
                 scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._pp_schedule_and_propagate(
                     microbatch_id)
+                # Capture FPM snapshot before any request mutation
+                fpm_snap = self._capture_fpm_scheduled(scheduled_batch)
                 if self.dist.rank != 0:
                     # Retry until current rank can run first PP's schedule result.
                     self._pp_retry_until_can_schedule(scheduled_batch)
@@ -1493,6 +1772,7 @@ class PyExecutor:
                         sample_state=sample_state,
                         iter_start_time=iter_start_time,
                         iter_stats=iter_stats,
+                        fpm_scheduled=fpm_snap,
                         microbatch_id=microbatch_id,
                     )
 
@@ -2018,9 +2298,12 @@ class PyExecutor:
                     iter_start_time = time.time()
 
                 scheduled_batch, iter_stats = self._prepare_and_schedule_batch()
+                # Capture FPM snapshot before any request mutation
+                fpm_snap = self._capture_fpm_scheduled(scheduled_batch) if scheduled_batch is not None else None
                 self._handle_control_request()
 
                 if scheduled_batch is None:
+                    self._maybe_emit_idle_fpm_heartbeat()
                     break
 
                 can_forward, should_retry = self._check_benchmark_disagg_gate(
@@ -2171,8 +2454,17 @@ class PyExecutor:
                         BatchState(scheduled_requests=scheduled_batch,
                                    sample_state=sample_state,
                                    iter_stats=iter_stats,
-                                   iter_start_time=iter_start_time))
+                                   iter_start_time=iter_start_time,
+                                   fpm_scheduled=fpm_snap))
+                elif self._fpm_hook is not None and fpm_snap is not None:
+                    # Emit FPM even when iter_perf_stats is disabled
+                    self._emit_fpm(
+                        BatchState(scheduled_requests=scheduled_batch,
+                                   sample_state=sample_state,
+                                   fpm_scheduled=fpm_snap),
+                        0.0)
 
+                self._maybe_emit_idle_fpm_heartbeat()
                 self.iter_counter += 1
 
     def _prepare_draft_requests(self):
@@ -2257,9 +2549,12 @@ class PyExecutor:
                     iter_start_time = time.time()
 
                 scheduled_batch, iter_stats = self._prepare_and_schedule_batch()
+                # Capture FPM snapshot before any request mutation
+                fpm_snap = self._capture_fpm_scheduled(scheduled_batch) if scheduled_batch is not None else None
                 self._handle_control_request()
 
                 if scheduled_batch is None:
+                    self._maybe_emit_idle_fpm_heartbeat()
                     break
 
                 can_forward, should_retry = self._check_benchmark_disagg_gate(
@@ -2437,7 +2732,8 @@ class PyExecutor:
                         scheduled_requests=scheduled_batch,
                         sample_state=sample_state,
                         iter_start_time=iter_start_time,
-                        iter_stats=iter_stats)
+                        iter_stats=iter_stats,
+                        fpm_scheduled=fpm_snap)
                 elif not can_queue_this_rank:
                     # If the batch is empty on this rank, we need to clear the previous batch.
                     self.previous_batch = None
@@ -2448,6 +2744,7 @@ class PyExecutor:
 
                 self._kv_connector_terminate_requests()
 
+                self._maybe_emit_idle_fpm_heartbeat()
                 self.iter_counter += 1
 
     @nvtx_range("_accept_draft_tokens")

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -314,6 +314,11 @@ class BaseWorker(GenerationExecutor):
         else:
             return self.engine.get_latest_kv_cache_events()
 
+    def fetch_forward_pass_metrics(self) -> list:
+        if isinstance(self.engine, tllm.Executor):
+            return []  # C++ executor does not support FPM
+        return self.engine.get_latest_forward_pass_metrics()
+
     def set_result_queue(self, queue):
         """In multi-gpu mode, result_queue will be set here to communicate between the proxy and the worker 0 process."""
         assert self.postproc_queues is None

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -107,6 +107,7 @@ class GenerationExecutor(ABC):
         self._is_llm_executor = is_llm_executor
         self._iter_kv_events_result: IterationResult | None = None
         self._iter_stats_result: IterationResult | None = None
+        self._iter_fpm_result: IterationResult | None = None
 
     @abstractmethod
     def submit(self, request: GenerationRequest) -> GenerationResult:
@@ -256,6 +257,11 @@ class GenerationExecutor(ABC):
             else:
                 self._iter_kv_events_result.mark_undone()
 
+            if self._iter_fpm_result is None:
+                self._iter_fpm_result = IterationResult()
+            else:
+                self._iter_fpm_result.mark_undone()
+
     def _handle_background_error(self, error: Optional[Exception | str] = None):
         """ Process the errors from the threads or processes.
         NOTE: This should be called in the main thread.
@@ -363,6 +369,28 @@ class GenerationExecutor(ABC):
 
         self._iter_kv_events_result.set_timeout(timeout)
         return self._iter_kv_events_result
+
+    def get_forward_pass_metrics(self, timeout: float = 0.0) -> List[dict]:
+        """Get per-iteration ForwardPassMetrics accumulated since the last call.
+
+        Returns:
+            List[dict]: ForwardPassMetrics dicts (one per completed forward pass).
+        """
+        if self._iter_fpm_result is None:
+            return []
+        self._iter_fpm_result.set_timeout(timeout)
+        return self._iter_fpm_result.get_results()
+
+    def aget_forward_pass_metrics(self,
+                                  timeout: float = 0.0) -> IterationResult:
+        """Async iterable of per-iteration ForwardPassMetrics dicts.
+
+        Same pattern as aget_stats() / aget_kv_events().
+        """
+        if self._iter_fpm_result is None:
+            return empty_async_iterable()
+        self._iter_fpm_result.set_timeout(timeout)
+        return self._iter_fpm_result
 
     def get_disaggregated_params(self) -> dict:
         return {}

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -482,6 +482,35 @@ class GenerationExecutorProxy(GenerationExecutor):
         self._iter_kv_events_result.set_timeout(timeout)
         return self._iter_kv_events_result
 
+    def get_forward_pass_metrics(self, timeout: float = 0.0) -> list:
+        """Get ForwardPassMetrics from the runtime via RPC."""
+        if self.rpc_client is None:
+            return []
+        try:
+            raw = self.rpc_client.fetch_forward_pass_metrics_wait_async(
+                timeout=timeout).remote()
+            return [json.loads(m) if isinstance(m, str) else m for m in raw]
+        except Exception as e:
+            logger.debug(f"Error fetching FPM via RPC: {e}")
+            return []
+
+    def aget_forward_pass_metrics(self, timeout: float = 0.0):
+        """Get ForwardPassMetrics from the runtime via RPC (async)."""
+        self._maybe_initialize_iteration_results()
+        if self._iter_fpm_result is None:
+            from .executor import empty_async_iterable
+            return empty_async_iterable()
+        try:
+            metrics = self.rpc_client.fetch_forward_pass_metrics_wait_async(
+                timeout=timeout).remote()
+        except Exception as e:
+            logger.debug(f"Error fetching FPM via RPC: {e}")
+            metrics = []
+        for m in metrics:
+            self._iter_fpm_result.queue.put(m)
+        self._iter_fpm_result.set_timeout(timeout)
+        return self._iter_fpm_result
+
     def __del__(self):
         self.shutdown()
 

--- a/tensorrt_llm/executor/rpc_worker_mixin.py
+++ b/tensorrt_llm/executor/rpc_worker_mixin.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import time
 from queue import Queue
 from threading import Event
@@ -136,6 +137,18 @@ class RpcWorkerMixin:
                 break
             await asyncio.sleep(0.1)
         return [self._kv_cache_events_serializer(e) for e in events]
+
+    async def fetch_forward_pass_metrics_wait_async(self, timeout: Optional[float] = None) -> list:
+        """Poll for ForwardPassMetrics until available or timeout."""
+        start = time.time()
+        while True:
+            metrics = await asyncio.to_thread(self.fetch_forward_pass_metrics)
+            if metrics or timeout is None:
+                break
+            if (time.time() - start) >= timeout:
+                break
+            await asyncio.sleep(0.1)
+        return [json.dumps(m) for m in metrics]
 
     async def fetch_stats_async(self, timeout: Optional[float] = None) -> list:
         """Async version of fetch_stats using asyncio.to_thread.

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -9,7 +9,8 @@ import weakref
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Literal, Optional, Sequence, Tuple, Union, cast
+from typing import (Any, Callable, List, Literal, Optional, Sequence, Tuple,
+                     Union, cast)
 
 import transformers
 from tqdm import tqdm
@@ -787,6 +788,42 @@ class BaseLLM:
             tensorrt_llm.executor.result.IterationResult: An async iterable object containing runtime events.
         '''
         return self._executor.aget_kv_events(timeout=timeout)
+
+    def set_forward_pass_metrics_hook(
+            self, hook: Callable[[dict], None]) -> None:
+        """Set a callback that receives ForwardPassMetrics after each forward pass.
+
+        The hook is called with a dict containing per-iteration scheduling
+        telemetry (prefill/decode counts, token sums, variances, queue state,
+        wall time). Dynamo uses this to feed the planner for routing decisions.
+
+        The hook must not block -- the executor loop calls it synchronously.
+
+        Args:
+            hook: Callback ``(metrics_dict) -> None``.
+        """
+        # Reach through the executor → worker → PyExecutor chain.
+        # In the common in-process case the worker's engine IS the PyExecutor.
+        executor = self._executor
+        if executor is None:
+            raise RuntimeError(
+                "Cannot set FPM hook: executor not initialised yet")
+        from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+        # BaseWorker stores the PyExecutor in self.engine
+        if hasattr(executor, '_workers'):
+            for worker in executor._workers:
+                if hasattr(worker, 'engine') and isinstance(
+                        worker.engine, PyExecutor):
+                    worker.engine._fpm_hook = hook
+                    return
+        # Single-process / proxy pattern: executor may wrap a single worker
+        if hasattr(executor, 'worker') and hasattr(executor.worker, 'engine'):
+            engine = executor.worker.engine
+            if isinstance(engine, PyExecutor):
+                engine._fpm_hook = hook
+                return
+        raise RuntimeError(
+            "Cannot set FPM hook: could not locate PyExecutor instance")
 
     def _process_env_overrides(self,
                                env_overrides: Optional[dict[str, str]]) -> None:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import (Any, Callable, List, Literal, Optional, Sequence, Tuple,
-                     Union, cast)
+                    Union, cast)
 
 import transformers
 from tqdm import tqdm
@@ -789,8 +789,8 @@ class BaseLLM:
         '''
         return self._executor.aget_kv_events(timeout=timeout)
 
-    def set_forward_pass_metrics_hook(
-            self, hook: Callable[[dict], None]) -> None:
+    def set_forward_pass_metrics_hook(self, hook: Callable[[dict],
+                                                           None]) -> None:
         """Set a callback that receives ForwardPassMetrics after each forward pass.
 
         The hook is called with a dict containing per-iteration scheduling
@@ -809,6 +809,7 @@ class BaseLLM:
             raise RuntimeError(
                 "Cannot set FPM hook: executor not initialised yet")
         from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
         # BaseWorker stores the PyExecutor in self.engine
         if hasattr(executor, '_workers'):
             for worker in executor._workers:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -9,8 +9,7 @@ import weakref
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import (Any, Callable, List, Literal, Optional, Sequence, Tuple,
-                    Union, cast)
+from typing import Any, List, Literal, Optional, Sequence, Tuple, Union, cast
 
 import transformers
 from tqdm import tqdm
@@ -789,42 +788,24 @@ class BaseLLM:
         '''
         return self._executor.aget_kv_events(timeout=timeout)
 
-    def set_forward_pass_metrics_hook(self, hook: Callable[[dict],
-                                                           None]) -> None:
-        """Set a callback that receives ForwardPassMetrics after each forward pass.
+    def get_forward_pass_metrics_async(self,
+                                       timeout: Optional[float] = 0.0
+                                       ) -> 'IterationResult':
+        """Get per-iteration ForwardPassMetrics from the runtime.
 
-        The hook is called with a dict containing per-iteration scheduling
-        telemetry (prefill/decode counts, token sums, variances, queue state,
-        wall time). Dynamo uses this to feed the planner for routing decisions.
-
-        The hook must not block -- the executor loop calls it synchronously.
+        Each dict contains scheduling telemetry for one completed forward pass:
+        prefill/decode request counts, token sums, population variances, queue
+        state, and iteration wall time.  Follows the same async-iterable
+        pattern as :meth:`get_stats_async` and :meth:`get_kv_cache_events_async`.
 
         Args:
-            hook: Callback ``(metrics_dict) -> None``.
-        """
-        # Reach through the executor → worker → PyExecutor chain.
-        # In the common in-process case the worker's engine IS the PyExecutor.
-        executor = self._executor
-        if executor is None:
-            raise RuntimeError(
-                "Cannot set FPM hook: executor not initialised yet")
-        from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+            timeout (float, optional): Max wait time in seconds. Defaults to 0.
 
-        # BaseWorker stores the PyExecutor in self.engine
-        if hasattr(executor, '_workers'):
-            for worker in executor._workers:
-                if hasattr(worker, 'engine') and isinstance(
-                        worker.engine, PyExecutor):
-                    worker.engine._fpm_hook = hook
-                    return
-        # Single-process / proxy pattern: executor may wrap a single worker
-        if hasattr(executor, 'worker') and hasattr(executor.worker, 'engine'):
-            engine = executor.worker.engine
-            if isinstance(engine, PyExecutor):
-                engine._fpm_hook = hook
-                return
-        raise RuntimeError(
-            "Cannot set FPM hook: could not locate PyExecutor instance")
+        Returns:
+            tensorrt_llm.executor.result.IterationResult: Async iterable of
+            ForwardPassMetrics dicts.
+        """
+        return self._executor.aget_forward_pass_metrics(timeout=timeout)
 
     def _process_env_overrides(self,
                                env_overrides: Optional[dict[str, str]]) -> None:

--- a/tests/unittest/pyexecutor/test_forward_pass_metrics.py
+++ b/tests/unittest/pyexecutor/test_forward_pass_metrics.py
@@ -284,7 +284,6 @@ class TestEmitAndHeartbeat:
         """Build the FPM payload dict the same way _emit_fpm does."""
         return {
             "version": 1,
-            "worker_id": "",
             "dp_rank": dp_rank,
             "counter_id": 1,
             "wall_time": wall_time_ms / 1000.0,
@@ -326,7 +325,6 @@ class TestEmitAndHeartbeat:
     def test_heartbeat_payload(self):
         heartbeat = {
             "version": 1,
-            "worker_id": "",
             "dp_rank": 0,
             "counter_id": 1,
             "wall_time": 0.0,

--- a/tests/unittest/pyexecutor/test_forward_pass_metrics.py
+++ b/tests/unittest/pyexecutor/test_forward_pass_metrics.py
@@ -1,0 +1,339 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ForwardPassMetrics (FPM) extraction logic in PyExecutor.
+
+Tests the FpmScheduledSnapshot capture, queued metrics computation,
+emit logic, and idle heartbeat behaviour -- all without requiring
+a GPU or running the full executor loop.
+
+These tests directly exercise the FPM helper methods by calling them
+as unbound functions with stub objects, avoiding heavy TRT-LLM imports.
+"""
+
+import math
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import List, Optional
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Standalone copy of FpmScheduledSnapshot for testing without torch.
+# This mirrors the dataclass in py_executor.py exactly.
+# ---------------------------------------------------------------------------
+import dataclasses
+
+
+@dataclasses.dataclass
+class FpmScheduledSnapshot:
+    num_prefill_requests: int = 0
+    sum_prefill_tokens: int = 0
+    sum_prefill_kv_tokens: int = 0
+    num_decode_requests: int = 0
+    sum_decode_kv_tokens: int = 0
+    prefill_length_n: int = 0
+    prefill_length_mean: float = 0.0
+    prefill_length_m2: float = 0.0
+    decode_kv_n: int = 0
+    decode_kv_mean: float = 0.0
+    decode_kv_m2: float = 0.0
+
+    @property
+    def var_prefill_length(self) -> float:
+        return (self.prefill_length_m2 / self.prefill_length_n
+                if self.prefill_length_n > 0 else 0.0)
+
+    @property
+    def var_decode_kv_tokens(self) -> float:
+        return (self.decode_kv_m2 / self.decode_kv_n
+                if self.decode_kv_n > 0 else 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeRequest:
+    """Minimal stub matching LlmRequest properties used by FPM."""
+    request_id: int = 0
+    context_chunk_size: int = 0
+    context_current_position: int = 0
+    py_orig_prompt_len: int = 0
+    max_beam_num_tokens: int = 0
+    state: object = None
+    is_attention_dp_dummy: bool = False
+    is_cuda_graph_dummy: bool = False
+    is_dummy_request: bool = False
+
+    @property
+    def is_dummy(self):
+        return (self.is_attention_dp_dummy or self.is_cuda_graph_dummy
+                or self.is_dummy_request)
+
+
+class FakeScheduledRequests:
+    def __init__(self, context=None, generation=None):
+        self.context_requests_chunking = []
+        self.context_requests_last_chunk = context or []
+        self.generation_requests = generation or []
+        self.paused_requests = []
+
+    @property
+    def context_requests(self):
+        return self.context_requests_chunking + self.context_requests_last_chunk
+
+    def all_requests(self):
+        return self.context_requests + self.generation_requests
+
+
+# ---------------------------------------------------------------------------
+# Re-implement the capture logic to test independently (same algorithm)
+# ---------------------------------------------------------------------------
+
+
+def capture_fpm_scheduled(scheduled_batch) -> FpmScheduledSnapshot:
+    """Pure-Python reimplementation of PyExecutor._capture_fpm_scheduled
+    for testing without torch imports."""
+    snap = FpmScheduledSnapshot()
+    pf_n = 0
+    pf_mean = 0.0
+    pf_m2 = 0.0
+    dk_n = 0
+    dk_mean = 0.0
+    dk_m2 = 0.0
+
+    for req in scheduled_batch.context_requests:
+        if req.is_dummy:
+            continue
+        snap.num_prefill_requests += 1
+        snap.sum_prefill_tokens += req.context_chunk_size
+        snap.sum_prefill_kv_tokens += req.context_current_position
+        v = req.py_orig_prompt_len
+        pf_n += 1
+        delta = v - pf_mean
+        pf_mean += delta / pf_n
+        pf_m2 += delta * (v - pf_mean)
+
+    for req in scheduled_batch.generation_requests:
+        if req.is_dummy:
+            continue
+        snap.num_decode_requests += 1
+        kv_len = req.max_beam_num_tokens
+        snap.sum_decode_kv_tokens += kv_len
+        dk_n += 1
+        delta = kv_len - dk_mean
+        dk_mean += delta / dk_n
+        dk_m2 += delta * (kv_len - dk_mean)
+
+    snap.prefill_length_n = pf_n
+    snap.prefill_length_mean = pf_mean
+    snap.prefill_length_m2 = pf_m2
+    snap.decode_kv_n = dk_n
+    snap.decode_kv_mean = dk_mean
+    snap.decode_kv_m2 = dk_m2
+    return snap
+
+
+def population_variance(values):
+    """Reference population variance."""
+    if not values:
+        return 0.0
+    mean = sum(values) / len(values)
+    return sum((v - mean) ** 2 for v in values) / len(values)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFpmScheduledSnapshot:
+
+    def test_variance_empty(self):
+        snap = FpmScheduledSnapshot()
+        assert snap.var_prefill_length == 0.0
+        assert snap.var_decode_kv_tokens == 0.0
+
+    def test_variance_single(self):
+        snap = FpmScheduledSnapshot(
+            prefill_length_n=1, prefill_length_mean=100.0,
+            prefill_length_m2=0.0)
+        assert snap.var_prefill_length == 0.0
+
+    def test_variance_two_values(self):
+        snap = FpmScheduledSnapshot(
+            prefill_length_n=2, prefill_length_mean=150.0,
+            prefill_length_m2=5000.0)
+        assert snap.var_prefill_length == 2500.0
+
+
+class TestCaptureScheduled:
+
+    def test_empty_batch(self):
+        snap = capture_fpm_scheduled(FakeScheduledRequests())
+        assert snap.num_prefill_requests == 0
+        assert snap.num_decode_requests == 0
+
+    def test_prefill_only(self):
+        reqs = [
+            FakeRequest(request_id=1, context_chunk_size=512,
+                        context_current_position=0, py_orig_prompt_len=512),
+            FakeRequest(request_id=2, context_chunk_size=256,
+                        context_current_position=128, py_orig_prompt_len=384),
+        ]
+        snap = capture_fpm_scheduled(FakeScheduledRequests(context=reqs))
+        assert snap.num_prefill_requests == 2
+        assert snap.sum_prefill_tokens == 768
+        assert snap.sum_prefill_kv_tokens == 128
+        expected_var = population_variance([512, 384])
+        assert snap.var_prefill_length == pytest.approx(expected_var)
+
+    def test_decode_only(self):
+        reqs = [
+            FakeRequest(request_id=i, max_beam_num_tokens=v)
+            for i, v in enumerate([1000, 2000, 3000])
+        ]
+        snap = capture_fpm_scheduled(FakeScheduledRequests(generation=reqs))
+        assert snap.num_decode_requests == 3
+        assert snap.sum_decode_kv_tokens == 6000
+        expected_var = population_variance([1000, 2000, 3000])
+        assert snap.var_decode_kv_tokens == pytest.approx(expected_var)
+
+    def test_mixed_batch(self):
+        ctx = [FakeRequest(request_id=1, context_chunk_size=100,
+                           context_current_position=50,
+                           py_orig_prompt_len=150)]
+        gen = [FakeRequest(request_id=2, max_beam_num_tokens=500)]
+        snap = capture_fpm_scheduled(
+            FakeScheduledRequests(context=ctx, generation=gen))
+        assert snap.num_prefill_requests == 1
+        assert snap.num_decode_requests == 1
+        assert snap.sum_prefill_tokens == 100
+        assert snap.sum_prefill_kv_tokens == 50
+        assert snap.sum_decode_kv_tokens == 500
+
+    def test_dummy_excluded(self):
+        reqs = [
+            FakeRequest(request_id=1, max_beam_num_tokens=100),
+            FakeRequest(request_id=2, max_beam_num_tokens=200,
+                        is_attention_dp_dummy=True),
+            FakeRequest(request_id=3, max_beam_num_tokens=300,
+                        is_cuda_graph_dummy=True),
+        ]
+        snap = capture_fpm_scheduled(FakeScheduledRequests(generation=reqs))
+        assert snap.num_decode_requests == 1
+        assert snap.sum_decode_kv_tokens == 100
+
+    def test_chunked_prefill(self):
+        """Chunked prefill: chunk_size < prompt_len, position > 0."""
+        req = FakeRequest(
+            request_id=1,
+            context_chunk_size=2048,       # computing 2048 tokens this step
+            context_current_position=4096, # already computed 4096 tokens
+            py_orig_prompt_len=8192,       # total prompt is 8192
+        )
+        snap = capture_fpm_scheduled(FakeScheduledRequests(context=[req]))
+        assert snap.num_prefill_requests == 1
+        assert snap.sum_prefill_tokens == 2048
+        assert snap.sum_prefill_kv_tokens == 4096
+        assert snap.var_prefill_length == 0.0  # single request
+
+
+class TestWelfordNumericalStability:
+
+    def test_uniform_values(self):
+        reqs = [FakeRequest(request_id=i, max_beam_num_tokens=500)
+                for i in range(10)]
+        snap = capture_fpm_scheduled(FakeScheduledRequests(generation=reqs))
+        assert snap.var_decode_kv_tokens == pytest.approx(0.0)
+
+    def test_two_extremes(self):
+        reqs = [
+            FakeRequest(request_id=0, max_beam_num_tokens=0),
+            FakeRequest(request_id=1, max_beam_num_tokens=1000),
+        ]
+        snap = capture_fpm_scheduled(FakeScheduledRequests(generation=reqs))
+        assert snap.var_decode_kv_tokens == pytest.approx(250000.0)
+
+    def test_large_base_small_spread(self):
+        """Welford should handle large base values without cancellation."""
+        base = 1_000_000
+        reqs = [FakeRequest(request_id=i, py_orig_prompt_len=base + i,
+                            context_chunk_size=1, context_current_position=0)
+                for i in range(100)]
+        snap = capture_fpm_scheduled(FakeScheduledRequests(context=reqs))
+        expected = population_variance([base + i for i in range(100)])
+        assert snap.var_prefill_length == pytest.approx(expected, rel=1e-6)
+
+
+class TestEmitAndHeartbeat:
+    """Test the emit/heartbeat logic using dict-based payload contracts."""
+
+    def _make_payload(self, snap, wall_time_ms=15.0, dp_rank=0):
+        """Build the FPM payload dict the same way _emit_fpm does."""
+        return {
+            "version": 1,
+            "worker_id": "",
+            "dp_rank": dp_rank,
+            "counter_id": 1,
+            "wall_time": wall_time_ms / 1000.0,
+            "scheduled_requests": {
+                "num_prefill_requests": snap.num_prefill_requests,
+                "sum_prefill_tokens": snap.sum_prefill_tokens,
+                "var_prefill_length": snap.var_prefill_length,
+                "sum_prefill_kv_tokens": snap.sum_prefill_kv_tokens,
+                "num_decode_requests": snap.num_decode_requests,
+                "sum_decode_kv_tokens": snap.sum_decode_kv_tokens,
+                "var_decode_kv_tokens": snap.var_decode_kv_tokens,
+            },
+            "queued_requests": {
+                "num_prefill_requests": 0,
+                "sum_prefill_tokens": 0,
+                "var_prefill_length": 0.0,
+                "num_decode_requests": 0,
+                "sum_decode_kv_tokens": 0,
+                "var_decode_kv_tokens": 0.0,
+            },
+        }
+
+    def test_payload_schema(self):
+        snap = FpmScheduledSnapshot(
+            num_prefill_requests=2, sum_prefill_tokens=768,
+            num_decode_requests=5, sum_decode_kv_tokens=3000)
+        payload = self._make_payload(snap)
+        assert payload["version"] == 1
+        assert payload["wall_time"] == pytest.approx(0.015)
+        sr = payload["scheduled_requests"]
+        assert sr["num_prefill_requests"] == 2
+        assert sr["sum_prefill_tokens"] == 768
+        assert sr["num_decode_requests"] == 5
+        assert sr["sum_decode_kv_tokens"] == 3000
+
+    def test_heartbeat_payload(self):
+        heartbeat = {
+            "version": 1, "worker_id": "", "dp_rank": 0,
+            "counter_id": 1, "wall_time": 0.0,
+            "scheduled_requests": {
+                "num_prefill_requests": 0, "sum_prefill_tokens": 0,
+                "var_prefill_length": 0.0, "sum_prefill_kv_tokens": 0,
+                "num_decode_requests": 0, "sum_decode_kv_tokens": 0,
+                "var_decode_kv_tokens": 0.0,
+            },
+            "queued_requests": {
+                "num_prefill_requests": 0, "sum_prefill_tokens": 0,
+                "var_prefill_length": 0.0, "num_decode_requests": 0,
+                "sum_decode_kv_tokens": 0, "var_decode_kv_tokens": 0.0,
+            },
+        }
+        assert heartbeat["wall_time"] == 0.0
+        for field in heartbeat["scheduled_requests"].values():
+            assert field == 0 or field == 0.0
+
+    def test_dp_rank_propagated(self):
+        snap = FpmScheduledSnapshot(num_decode_requests=1)
+        payload = self._make_payload(snap, dp_rank=3)
+        assert payload["dp_rank"] == 3

--- a/tests/unittest/pyexecutor/test_forward_pass_metrics.py
+++ b/tests/unittest/pyexecutor/test_forward_pass_metrics.py
@@ -11,19 +11,14 @@ These tests directly exercise the FPM helper methods by calling them
 as unbound functions with stub objects, avoiding heavy TRT-LLM imports.
 """
 
-import math
-from dataclasses import dataclass
-from types import SimpleNamespace
-from typing import List, Optional
-
-import pytest
-
-
 # ---------------------------------------------------------------------------
 # Standalone copy of FpmScheduledSnapshot for testing without torch.
 # This mirrors the dataclass in py_executor.py exactly.
 # ---------------------------------------------------------------------------
 import dataclasses
+from dataclasses import dataclass
+
+import pytest
 
 
 @dataclasses.dataclass
@@ -42,13 +37,11 @@ class FpmScheduledSnapshot:
 
     @property
     def var_prefill_length(self) -> float:
-        return (self.prefill_length_m2 / self.prefill_length_n
-                if self.prefill_length_n > 0 else 0.0)
+        return self.prefill_length_m2 / self.prefill_length_n if self.prefill_length_n > 0 else 0.0
 
     @property
     def var_decode_kv_tokens(self) -> float:
-        return (self.decode_kv_m2 / self.decode_kv_n
-                if self.decode_kv_n > 0 else 0.0)
+        return self.decode_kv_m2 / self.decode_kv_n if self.decode_kv_n > 0 else 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -59,6 +52,7 @@ class FpmScheduledSnapshot:
 @dataclass
 class FakeRequest:
     """Minimal stub matching LlmRequest properties used by FPM."""
+
     request_id: int = 0
     context_chunk_size: int = 0
     context_current_position: int = 0
@@ -71,8 +65,7 @@ class FakeRequest:
 
     @property
     def is_dummy(self):
-        return (self.is_attention_dp_dummy or self.is_cuda_graph_dummy
-                or self.is_dummy_request)
+        return self.is_attention_dp_dummy or self.is_cuda_graph_dummy or self.is_dummy_request
 
 
 class FakeScheduledRequests:
@@ -96,8 +89,10 @@ class FakeScheduledRequests:
 
 
 def capture_fpm_scheduled(scheduled_batch) -> FpmScheduledSnapshot:
-    """Pure-Python reimplementation of PyExecutor._capture_fpm_scheduled
-    for testing without torch imports."""
+    """Pure-Python reimplementation of PyExecutor._capture_fpm_scheduled.
+
+    Used for testing without torch imports.
+    """
     snap = FpmScheduledSnapshot()
     pf_n = 0
     pf_mean = 0.0
@@ -152,7 +147,6 @@ def population_variance(values):
 
 
 class TestFpmScheduledSnapshot:
-
     def test_variance_empty(self):
         snap = FpmScheduledSnapshot()
         assert snap.var_prefill_length == 0.0
@@ -160,19 +154,18 @@ class TestFpmScheduledSnapshot:
 
     def test_variance_single(self):
         snap = FpmScheduledSnapshot(
-            prefill_length_n=1, prefill_length_mean=100.0,
-            prefill_length_m2=0.0)
+            prefill_length_n=1, prefill_length_mean=100.0, prefill_length_m2=0.0
+        )
         assert snap.var_prefill_length == 0.0
 
     def test_variance_two_values(self):
         snap = FpmScheduledSnapshot(
-            prefill_length_n=2, prefill_length_mean=150.0,
-            prefill_length_m2=5000.0)
+            prefill_length_n=2, prefill_length_mean=150.0, prefill_length_m2=5000.0
+        )
         assert snap.var_prefill_length == 2500.0
 
 
 class TestCaptureScheduled:
-
     def test_empty_batch(self):
         snap = capture_fpm_scheduled(FakeScheduledRequests())
         assert snap.num_prefill_requests == 0
@@ -180,10 +173,18 @@ class TestCaptureScheduled:
 
     def test_prefill_only(self):
         reqs = [
-            FakeRequest(request_id=1, context_chunk_size=512,
-                        context_current_position=0, py_orig_prompt_len=512),
-            FakeRequest(request_id=2, context_chunk_size=256,
-                        context_current_position=128, py_orig_prompt_len=384),
+            FakeRequest(
+                request_id=1,
+                context_chunk_size=512,
+                context_current_position=0,
+                py_orig_prompt_len=512,
+            ),
+            FakeRequest(
+                request_id=2,
+                context_chunk_size=256,
+                context_current_position=128,
+                py_orig_prompt_len=384,
+            ),
         ]
         snap = capture_fpm_scheduled(FakeScheduledRequests(context=reqs))
         assert snap.num_prefill_requests == 2
@@ -204,12 +205,16 @@ class TestCaptureScheduled:
         assert snap.var_decode_kv_tokens == pytest.approx(expected_var)
 
     def test_mixed_batch(self):
-        ctx = [FakeRequest(request_id=1, context_chunk_size=100,
-                           context_current_position=50,
-                           py_orig_prompt_len=150)]
+        ctx = [
+            FakeRequest(
+                request_id=1,
+                context_chunk_size=100,
+                context_current_position=50,
+                py_orig_prompt_len=150,
+            )
+        ]
         gen = [FakeRequest(request_id=2, max_beam_num_tokens=500)]
-        snap = capture_fpm_scheduled(
-            FakeScheduledRequests(context=ctx, generation=gen))
+        snap = capture_fpm_scheduled(FakeScheduledRequests(context=ctx, generation=gen))
         assert snap.num_prefill_requests == 1
         assert snap.num_decode_requests == 1
         assert snap.sum_prefill_tokens == 100
@@ -219,10 +224,8 @@ class TestCaptureScheduled:
     def test_dummy_excluded(self):
         reqs = [
             FakeRequest(request_id=1, max_beam_num_tokens=100),
-            FakeRequest(request_id=2, max_beam_num_tokens=200,
-                        is_attention_dp_dummy=True),
-            FakeRequest(request_id=3, max_beam_num_tokens=300,
-                        is_cuda_graph_dummy=True),
+            FakeRequest(request_id=2, max_beam_num_tokens=200, is_attention_dp_dummy=True),
+            FakeRequest(request_id=3, max_beam_num_tokens=300, is_cuda_graph_dummy=True),
         ]
         snap = capture_fpm_scheduled(FakeScheduledRequests(generation=reqs))
         assert snap.num_decode_requests == 1
@@ -232,9 +235,9 @@ class TestCaptureScheduled:
         """Chunked prefill: chunk_size < prompt_len, position > 0."""
         req = FakeRequest(
             request_id=1,
-            context_chunk_size=2048,       # computing 2048 tokens this step
-            context_current_position=4096, # already computed 4096 tokens
-            py_orig_prompt_len=8192,       # total prompt is 8192
+            context_chunk_size=2048,  # computing 2048 tokens this step
+            context_current_position=4096,  # already computed 4096 tokens
+            py_orig_prompt_len=8192,  # total prompt is 8192
         )
         snap = capture_fpm_scheduled(FakeScheduledRequests(context=[req]))
         assert snap.num_prefill_requests == 1
@@ -244,10 +247,8 @@ class TestCaptureScheduled:
 
 
 class TestWelfordNumericalStability:
-
     def test_uniform_values(self):
-        reqs = [FakeRequest(request_id=i, max_beam_num_tokens=500)
-                for i in range(10)]
+        reqs = [FakeRequest(request_id=i, max_beam_num_tokens=500) for i in range(10)]
         snap = capture_fpm_scheduled(FakeScheduledRequests(generation=reqs))
         assert snap.var_decode_kv_tokens == pytest.approx(0.0)
 
@@ -262,9 +263,15 @@ class TestWelfordNumericalStability:
     def test_large_base_small_spread(self):
         """Welford should handle large base values without cancellation."""
         base = 1_000_000
-        reqs = [FakeRequest(request_id=i, py_orig_prompt_len=base + i,
-                            context_chunk_size=1, context_current_position=0)
-                for i in range(100)]
+        reqs = [
+            FakeRequest(
+                request_id=i,
+                py_orig_prompt_len=base + i,
+                context_chunk_size=1,
+                context_current_position=0,
+            )
+            for i in range(100)
+        ]
         snap = capture_fpm_scheduled(FakeScheduledRequests(context=reqs))
         expected = population_variance([base + i for i in range(100)])
         assert snap.var_prefill_length == pytest.approx(expected, rel=1e-6)
@@ -302,8 +309,11 @@ class TestEmitAndHeartbeat:
 
     def test_payload_schema(self):
         snap = FpmScheduledSnapshot(
-            num_prefill_requests=2, sum_prefill_tokens=768,
-            num_decode_requests=5, sum_decode_kv_tokens=3000)
+            num_prefill_requests=2,
+            sum_prefill_tokens=768,
+            num_decode_requests=5,
+            sum_decode_kv_tokens=3000,
+        )
         payload = self._make_payload(snap)
         assert payload["version"] == 1
         assert payload["wall_time"] == pytest.approx(0.015)
@@ -315,18 +325,27 @@ class TestEmitAndHeartbeat:
 
     def test_heartbeat_payload(self):
         heartbeat = {
-            "version": 1, "worker_id": "", "dp_rank": 0,
-            "counter_id": 1, "wall_time": 0.0,
+            "version": 1,
+            "worker_id": "",
+            "dp_rank": 0,
+            "counter_id": 1,
+            "wall_time": 0.0,
             "scheduled_requests": {
-                "num_prefill_requests": 0, "sum_prefill_tokens": 0,
-                "var_prefill_length": 0.0, "sum_prefill_kv_tokens": 0,
-                "num_decode_requests": 0, "sum_decode_kv_tokens": 0,
+                "num_prefill_requests": 0,
+                "sum_prefill_tokens": 0,
+                "var_prefill_length": 0.0,
+                "sum_prefill_kv_tokens": 0,
+                "num_decode_requests": 0,
+                "sum_decode_kv_tokens": 0,
                 "var_decode_kv_tokens": 0.0,
             },
             "queued_requests": {
-                "num_prefill_requests": 0, "sum_prefill_tokens": 0,
-                "var_prefill_length": 0.0, "num_decode_requests": 0,
-                "sum_decode_kv_tokens": 0, "var_decode_kv_tokens": 0.0,
+                "num_prefill_requests": 0,
+                "sum_prefill_tokens": 0,
+                "var_prefill_length": 0.0,
+                "num_decode_requests": 0,
+                "sum_decode_kv_tokens": 0,
+                "var_decode_kv_tokens": 0.0,
             },
         }
         assert heartbeat["wall_time"] == 0.0


### PR DESCRIPTION
## Summary

Add per-iteration ForwardPassMetrics (FPM) telemetry to `PyExecutor`, enabling Dynamo's planner to make routing decisions based on real-time engine scheduling state.

FPM exposes fields that `IterationStats` does not carry — specifically `sum_decode_kv_tokens`, `queued_requests.sum_prefill_tokens`, and `queued_requests.sum_decode_kv_tokens` — which the Dynamo planner needs for ITL/TTFT regression models ([planner consumption](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/core/perf_model/decode.py#L38), [load scaling](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/planner/core/load_scaling.py#L300)).

**Linear**: [DIS-1606](https://linear.app/nvidia/issue/DIS-1606/trtllm-add-forwardpassmetrics-support)

### API

Follows the same drain-on-read queue pattern as `get_stats_async()` and `get_kv_cache_events_async()`:

```python
# Sync drain (same pattern as get_stats):
metrics = llm._executor.get_forward_pass_metrics(timeout=0.5)

# Async iterable (same pattern as aget_stats):
async for fpm in llm.get_forward_pass_metrics_async(timeout=0.01):
    handle_fpm(fpm)
```

Each `fpm` dict contains:
```python
{
    "version": 1,
    "dp_rank": 0,                         # attention_dp rank
    "counter_id": 42,                     # monotonically increasing
    "wall_time": 0.015,                   # iteration latency (seconds)
    "scheduled_requests": {
        "num_prefill_requests": 3,        # from ScheduledRequests.context_requests
        "sum_prefill_tokens": 2048,       # sum of context_chunk_size
        "var_prefill_length": 150.0,      # Welford population variance
        "sum_prefill_kv_tokens": 512,     # sum of context_current_position
        "num_decode_requests": 20,        # from ScheduledRequests.generation_requests
        "sum_decode_kv_tokens": 15000,    # sum of max_beam_num_tokens
        "var_decode_kv_tokens": 200.0,    # Welford population variance
    },
    "queued_requests": {
        "num_prefill_requests": 5,        # active unscheduled + waiting queue
        "sum_prefill_tokens": 8000,
        "var_prefill_length": 0.0,
        "num_decode_requests": 2,         # preempted decode requests
        "sum_decode_kv_tokens": 3000,
        "var_decode_kv_tokens": 0.0,
    },
}
```

### Design

FPM is already implemented for vLLM in Dynamo ([PR #7200](https://github.com/ai-dynamo/dynamo/pull/7200), [PR #7250](https://github.com/ai-dynamo/dynamo/pull/7250)). TRT-LLM differs architecturally:

| | vLLM | TRT-LLM |
|---|---|---|
| Process model | Forked child (needs ZMQ bridge) | Same process (queue-based API) |
| Data source | `InstrumentedScheduler` subclass | `ScheduledRequests` pre-mutation snapshot |
| Consumer API | ZMQ → FpmEventRelay → NATS | `get_forward_pass_metrics_async()` drain-on-read |

**Pre-mutation snapshot**: Request objects are mutated by `_update_request_states()` before `_process_iter_stats()` runs. FPM scheduled metrics are captured in `FpmScheduledSnapshot` immediately after scheduling and before mutation, then carried through the batch pipeline via `BatchState.fpm_scheduled`.

**Emission paths**: FPM emits from `_process_iter_stats()` when `enable_iter_perf_stats=True`, and via fallback paths in `_process_previous_batch()` (overlap mode) and `_handle_executed_batch()` (PP mode) when perf stats are disabled.

### Data flow

```
PyExecutor._capture_fpm_scheduled() → FpmScheduledSnapshot (pre-mutation)
  → _emit_fpm() → _append_fpm() → self._fpm_queue (thread-safe list)
  → get_latest_forward_pass_metrics() (drain-on-read)
  → BaseWorker.fetch_forward_pass_metrics()
  → RpcWorkerMixin.fetch_forward_pass_metrics_wait_async() → json.dumps
  → GenerationExecutorProxy.aget_forward_pass_metrics() → IterationResult queue
  → LLM.get_forward_pass_metrics_async() → consumer (Dynamo Publisher)
```

### Changes

| File | Change |
|---|---|
| `py_executor.py` | `FpmScheduledSnapshot` dataclass, `_capture_fpm_scheduled()`, `_compute_fpm_queued()`, `_emit_fpm()`, `_append_fpm()`, `_maybe_emit_idle_fpm_heartbeat()`, `get_latest_forward_pass_metrics()`. Pre-mutation snapshot capture in all 3 executor modes. |
| `executor.py` | `_iter_fpm_result` IterationResult, `get_forward_pass_metrics()`, `aget_forward_pass_metrics()` |
| `base_worker.py` | `fetch_forward_pass_metrics()` |
| `proxy.py` | `get_forward_pass_metrics()`, `aget_forward_pass_metrics()` via RPC |
| `rpc_worker_mixin.py` | `fetch_forward_pass_metrics_wait_async()` with JSON serialization |
| `llm.py` | `get_forward_pass_metrics_async()` public API |
| `test_forward_pass_metrics.py` | 15 unit tests: variance, capture, chunked prefill, dummy exclusion, Welford numerical stability, payload schema, heartbeats |

### Why not extend IterationStats?

vLLM has a similar split — `SchedulerStats` (their IterationStats equivalent, [definition](https://github.com/vllm-project/vllm/blob/main/vllm/v1/metrics/stats.py#L165)) also lacks per-request token breakdowns. Dynamo's `InstrumentedScheduler` bypasses `SchedulerStats` entirely and extracts FPM directly from `SchedulerOutput`. The same pattern applies here — FPM requires data from `ScheduledRequests` that `IterationStats` doesn't carry, plus a pre-mutation snapshot that the existing stats pipeline doesn't support.

### Known gap

Exact decode KV length for `generation_only` requests in `WaitingQueue` (pre-activation disaggregated decode) is not available from `RequestQueueItem`. These contribute to `queued_requests.num_decode_requests` count but not `sum_decode_kv_tokens`.

## Test plan

- [x] 15 unit tests pass (`pytest tests/unittest/pyexecutor/test_forward_pass_metrics.py --noconftest`)
- [x] Pre-commit checks pass
- [x] E2E validated with Qwen3-0.6B on RTX PRO 6000 Blackwell (ISL=8192, OSL=1024, C=20, 80 requests): 4000 FPM snapshots collected, `sum_decode_kv_tokens` populated correctly
- [x] Stage tests verified non-zero values for: scheduled prefill, queued prefill, queued decode (preemption under `MAX_UTILIZATION` + tight KV)
- [x] Idle heartbeat emission verified (active→idle transition)
- [x] Integration test with Dynamo TRT-LLM backend deferred to companion Dynamo PR