### PR TITLE
[https://nvbugs/6060281][fix] Treat whitespace-only content in nano-v3 reasoning swap

### DIFF
--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -305,8 +305,13 @@ class NemotronV3ReasoningParser(DeepSeekR1Parser):
     def _maybe_swap_content(
             self, result: ReasoningParserResult) -> ReasoningParserResult:
         """When force_nonempty_content is set and content is empty, move
-        reasoning_content into content so the response always has content."""
-        if self._force_nonempty_content and not result.content and result.reasoning_content:
+        reasoning_content into content so the response always has content.
+
+        Whitespace-only content (e.g. a newline after the closing think tag) is
+        treated as empty so the swap still runs (NVBug 6060281)."""
+        content = result.content or ""
+        if self._force_nonempty_content and not content.strip(
+        ) and result.reasoning_content:
             return ReasoningParserResult(content=result.reasoning_content,
                                          reasoning_content="")
         return result

--- a/tests/unittest/llmapi/test_reasoning_parser.py
+++ b/tests/unittest/llmapi/test_reasoning_parser.py
@@ -265,6 +265,14 @@ def test_qwen3_reasoning_parser_stream(delta_texts: list, content: list,
         (f"a b {R1_END}", "a b ", "", {
             "force_nonempty_content": True
         }),
+        # NVBug 6060281: whitespace-only content after </redacted_thinking> must
+        # still trigger the reasoning-to-content swap when force_nonempty_content.
+        (f"a {R1_END}\n", "a ", "", {
+            "force_nonempty_content": True
+        }),
+        (f"a {R1_END} \t ", "a ", "", {
+            "force_nonempty_content": True
+        }),
     ])
 def test_nano_v3_reasoning_parser(text: str, content: str,
                                   reasoning_context: str,


### PR DESCRIPTION
…(6060281)

When chat_template_kwargs enables force_nonempty_content, NemotronV3ReasoningParser promotes reasoning into content if the parsed content string is empty. Apply the same fallback when content is only whitespace (e.g. a lone newline after the closing think tag), matching the non-whitespace empty case.

Add unit coverage for newline- and space-only trailing content.


Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved reasoning content parsing to properly handle cases where content contains only whitespace or newlines.
* Enhanced content validation logic to ensure consistent behavior when processing empty or whitespace-only text segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
