### PR TITLE
[None][docs] Add README for custom Claude Code skills and agents

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -53,3 +53,48 @@ skill or agent names. Manual invoke is there for when you want precise control.
 References:
 * [Extend Claude with skills](https://code.claude.com/docs/en/skills)
 * [Work with subagents](https://code.claude.com/docs/en/sub-agents#work-with-subagents)
+
+## Naming convention: domain prefixes
+
+Every skill and agent name starts with a **domain prefix** so that related
+entries group together when listed. The prefix identifies the skill's primary
+work area.
+
+| Prefix | Domain | Definition |
+|---|---|---|
+| `exec-` | Execution infra | Environment setup and job execution (compile, run, container) |
+| `perf-` | Performance work | Profiling, analysis, and performance tuning above the kernel layer |
+| `kernel-` | Kernel development | Kernel writing, generation, and kernel-specific transforms |
+| `trtllm-` | TRT-LLM development workflows | Workflows for reading, modifying, and contributing to the TRT-LLM codebase |
+| `modeling-` | Modeling workflow | Model onboarding, translation, validation, smoke tests, and evaluation |
+| `knowledge-` | Knowledge retrieval | Retrieval workflows for docs and enterprise knowledge |
+
+Boundary notes:
+
+* `kernel-` is for kernel code and kernel-specific transforms. Performance work
+  that does not modify kernels stays under `perf-`.
+* `trtllm-` is for development workflows in the TRT-LLM codebase (e.g.
+  codebase exploration, contribution guidelines). Static subsystem knowledge
+  belongs in repo docs, not as a skill.
+* `knowledge-` is only for retrieval workflows. Static domain knowledge docs
+  belong in the repo alongside the code they describe.
+
+### Naming rules for new skills and agents
+
+When adding a new skill or agent, follow these rules:
+
+1. **Pick the domain prefix** from the table above. If the skill doesn't fit
+   any existing prefix, propose a new prefix and get agreement on the domain
+   boundary before using it.
+2. **Name format**: `<prefix>-<descriptive-name>`. Keep it short — the prefix
+   already carries domain context, so the descriptive part should not repeat it.
+   * Good: `exec-local-compile`, `kernel-cuda-writing`, `perf-host-analysis`
+   * Bad: `exec-trtllm-compile`, `kernel-cuda-kernel-writing`,
+     `perf-trtllm-host-analysis`
+3. **Prefix reflects primary domain**. Some skills are focused on one thing
+   (e.g. `exec-local-compile`). Others orchestrate across domains (e.g. a
+   modeling skill that calls analysis, attention, compilation, and smoke-test
+   skills). Both are fine — use the prefix of the skill's primary domain, not
+   the domains it calls into.
+4. **Agents follow the same rule** — prefix reflects the agent's primary
+   domain, not every domain it touches.

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -54,47 +54,28 @@ References:
 * [Extend Claude with skills](https://code.claude.com/docs/en/skills)
 * [Work with subagents](https://code.claude.com/docs/en/sub-agents#work-with-subagents)
 
-## Naming convention: domain prefixes
+## Naming convention
 
-Every skill and agent name starts with a **domain prefix** so that related
-entries group together when listed. The prefix identifies the skill's primary
-work area.
+Every skill and agent name uses the format `<prefix>-<descriptive-name>`.
+The prefix identifies the primary work area; the descriptive part should be
+short and not repeat it.
 
 | Prefix | Domain | Definition |
 |---|---|---|
 | `exec-` | Execution infra | Environment setup and job execution (compile, run, container) |
-| `perf-` | Performance work | Profiling, analysis, and performance tuning above the kernel layer |
+| `perf-` | Performance work | Profiling, analysis, and tuning above the kernel layer (kernel modifications belong under `kernel-`) |
 | `kernel-` | Kernel development | Kernel writing, generation, and kernel-specific transforms |
-| `trtllm-` | TRT-LLM development workflows | Workflows for reading, modifying, and contributing to the TRT-LLM codebase |
+| `trtllm-` | TRT-LLM dev workflows | Workflows for reading, modifying, and contributing to the codebase (static subsystem knowledge belongs in repo docs) |
 | `modeling-` | Modeling workflow | Model onboarding, translation, validation, smoke tests, and evaluation |
-| `knowledge-` | Knowledge retrieval | Retrieval workflows for docs and enterprise knowledge |
+| `knowledge-` | Knowledge retrieval | Retrieval workflows for docs and enterprise knowledge (static domain knowledge belongs in repo docs) |
 
-Boundary notes:
+Guidelines:
 
-* `kernel-` is for kernel code and kernel-specific transforms. Performance work
-  that does not modify kernels stays under `perf-`.
-* `trtllm-` is for development workflows in the TRT-LLM codebase (e.g.
-  codebase exploration, contribution guidelines). Static subsystem knowledge
-  belongs in repo docs, not as a skill.
-* `knowledge-` is only for retrieval workflows. Static domain knowledge docs
-  belong in the repo alongside the code they describe.
-
-### Naming rules for new skills and agents
-
-When adding a new skill or agent, follow these rules:
-
-1. **Pick the domain prefix** from the table above. If the skill doesn't fit
-   any existing prefix, propose a new prefix and get agreement on the domain
-   boundary before using it.
-2. **Name format**: `<prefix>-<descriptive-name>`. Keep it short — the prefix
-   already carries domain context, so the descriptive part should not repeat it.
-   * Good: `exec-local-compile`, `kernel-cuda-writing`, `perf-host-analysis`
-   * Bad: `exec-trtllm-compile`, `kernel-cuda-kernel-writing`,
-     `perf-trtllm-host-analysis`
-3. **Prefix reflects primary domain**. Some skills are focused on one thing
-   (e.g. `exec-local-compile`). Others orchestrate across domains (e.g. a
-   modeling skill that calls analysis, attention, compilation, and smoke-test
-   skills). Both are fine — use the prefix of the skill's primary domain, not
-   the domains it calls into.
-4. **Agents follow the same rule** — prefix reflects the agent's primary
-   domain, not every domain it touches.
+* If a skill doesn't fit any prefix, propose a new one and agree on its
+  boundary before using it.
+* Use the prefix of the skill's **primary** domain, even if it orchestrates
+  across multiple domains.
+* Agents follow the same convention.
+* Good: `exec-local-compile`, `kernel-cuda-writing`, `perf-host-analysis`
+* Bad: `exec-trtllm-compile`, `kernel-cuda-kernel-writing`,
+  `perf-trtllm-host-analysis`

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -62,12 +62,13 @@ short and not repeat it.
 
 | Prefix | Domain | Definition |
 |---|---|---|
+| `ad-` | AutoDeploy | Model onboarding, pipeline debugging, and execution for the AutoDeploy backend |
+| `ci-` | CI/CD | CI failure retrieval, test diagnostics, and pipeline workflows |
 | `exec-` | Execution infra | Environment setup and job execution (compile, run, container) |
-| `perf-` | Performance work | Profiling, analysis, and tuning above the kernel layer (kernel modifications belong under `kernel-`) |
 | `kernel-` | Kernel development | Kernel writing, generation, and kernel-specific transforms |
+| `perf-` | Performance work | Profiling, analysis, and tuning above the kernel layer (kernel modifications belong under `kernel-`) |
+| `serve-` | Serving | Serving configuration, deployment, and runtime workflows |
 | `trtllm-` | TRT-LLM dev workflows | Workflows for reading, modifying, and contributing to the codebase (static subsystem knowledge belongs in repo docs) |
-| `modeling-` | Modeling workflow | Model onboarding, translation, validation, smoke tests, and evaluation |
-| `knowledge-` | Knowledge retrieval | Retrieval workflows for docs and enterprise knowledge (static domain knowledge belongs in repo docs) |
 
 Guidelines:
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,55 @@
+# Custom Claude Code Skills & Agents for TensorRT-LLM
+
+## Background: Skills & agents in Claude Code
+
+Claude Code supports two extensibility mechanisms — **skills** and **agents** —
+that let teams encode domain expertise into reusable, version-controlled
+components.
+
+**Skills** are markdown playbooks that Claude follows step-by-step when
+triggered. They are invoked via `/slash-commands` (e.g. `/perf-analysis`) or
+matched automatically from natural-language requests. Each skill lives in its
+own directory under `.claude/skills/` and can bundle reference materials that
+Claude reads during execution. See
+[Custom slash commands](https://code.claude.com/docs/en/skills)
+for details.
+
+**Agents** (sub-agents) are specialist workers that Claude spawns in a separate
+context to handle focused tasks. Each agent has its own system prompt, tool
+access, and domain knowledge. Claude delegates to them when it determines a task
+fits a specialist's scope, while you can also invoke agents directly. Agent
+definitions live under `.claude/agents/`. See
+[Custom sub-agents](https://code.claude.com/docs/en/sub-agents)
+for details.
+
+## How skills and agents are loaded
+
+For users who are working with Claude Code under TensorRT-LLM project directory,
+skills and agents are automatically discovered by Claude Code at startup — no
+manual registration needed. Files placed in `.claude/skills/` and
+`.claude/agents/` are picked up by convention.
+
+To verify what's loaded, launch Claude Code under TensorRT-LLM project directory
+and type `/skills` or `/agents` in the Claude Code prompt to see available
+skills and sub-agents.
+
+## How to use skills and agents
+
+There are two ways to trigger skills and agents:
+
+1. **Automatic dispatch** — just describe what you need in plain language
+   (e.g. "profile this workload", "compile TensorRT-LLM"). Claude Code will
+   match your request to the appropriate skill or delegate to the right
+   sub-agent automatically.
+
+2. **Manual invoke** — type `/<skill-name>` (e.g. `/perf-analysis`,
+   `/serve-config-guide`) to explicitly run a skill. For sub-agents, type
+   `@"<agent-name>" (agent)` (e.g. `@"exec-compile-specialist (agent)"`) to
+   delegate a task directly. This is useful when you know exactly which workflow you want.
+
+In most cases, automatic dispatch is sufficient — you don't need to memorize
+skill or agent names. Manual invoke is there for when you want precise control.
+
+References:
+* [Extend Claude with skills](https://code.claude.com/docs/en/skills)
+* [Work with subagents](https://code.claude.com/docs/en/sub-agents#work-with-subagents)


### PR DESCRIPTION
## Summary
- Add `.claude/README.md` documenting the custom Claude Code skills and sub-agents configured for the TensorRT-LLM repo
- Covers background on skills/agents, how they are discovered and loaded, and usage via manual invoke or automatic dispatch

## Test plan
- [x] Verify the README renders correctly on GitHub
- [x] Confirm skills/agents are discoverable as described (`/skills`, `/agents` in Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation detailing available AI-powered code skills and sub-agents, including their invocation methods, verification procedures, and usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->