### PR TITLE
[TRTLLM-11871][feat] Add support for audio + chunked prefill for nemotron

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -1575,6 +1575,42 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                 audio_idx += 1
         return "".join(parts)
 
+    def get_num_tokens_per_audio(
+        self,
+        *,
+        audio: Union[np.ndarray, Tuple[np.ndarray, int]],
+        **kwargs,
+    ) -> int:
+        """Return the total number of tokens for a single audio input.
+
+        This includes the `<so_start>` / `<so_end>` special tokens that
+        wrap the context tokens, matching the expansion performed by
+        `_expand_audio_placeholders`.
+        """
+        if self._audio_extractor is None:
+            raise ValueError(
+                "Audio inputs were passed in, but no audio preprocessing was configured "
+                "due to the absence of a `sound_config` in the model config."
+            )
+
+        extractor = self._audio_extractor
+        target_sr = extractor.sampling_rate
+
+        # Unpack (audio_data, sample_rate) tuples and resample if needed.
+        if isinstance(audio, tuple):
+            audio_data, orig_sr = audio
+        else:
+            audio_data = audio
+            orig_sr = target_sr
+
+        audio_length = len(audio_data)
+        if orig_sr != target_sr:
+            audio_length = math.ceil(audio_length * (target_sr / orig_sr))
+
+        num_context_tokens = extractor.audio_token_count(audio_length)
+        # +2 for <so_start> and <so_end>
+        return num_context_tokens + 2
+
     @staticmethod
     def _resample_audios(
         audios: List[Union[np.ndarray, Tuple[np.ndarray, int]]],
@@ -1591,7 +1627,11 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             if orig_sr != target_sr:
                 import librosa
 
-                audio_data = librosa.resample(audio_data, orig_sr=orig_sr, target_sr=target_sr)
+                # We use `fix=True` (even though it's currently the default) to guarantee that the
+                # output length matches what we calculate in `get_num_tokens_per_audio`.
+                audio_data = librosa.resample(
+                    audio_data, orig_sr=orig_sr, target_sr=target_sr, fix=True
+                )
             resampled_audios.append(audio_data)
 
         return resampled_audios

--- a/tensorrt_llm/inputs/__init__.py
+++ b/tensorrt_llm/inputs/__init__.py
@@ -9,6 +9,8 @@ from .registry import (BaseMultimodalDummyInputsBuilder,
                        create_input_processor_with_hash,
                        register_input_processor,
                        support_multimodal_disaggregated)
+# yapf and isort conflict on this import block
+# yapf: disable
 from .utils import (ALL_SUPPORTED_AUDIO_MODELS, ALL_SUPPORTED_IMAGE_MODELS,
                     ALL_SUPPORTED_MULTIMODAL_MODELS, ALL_SUPPORTED_VIDEO_MODELS,
                     BaseModalityData, ConversationMessage, MultimodalData,
@@ -19,6 +21,8 @@ from .utils import (ALL_SUPPORTED_AUDIO_MODELS, ALL_SUPPORTED_IMAGE_MODELS,
                     encode_base64_content_from_url, encode_base64_image,
                     get_cache_salt_id, load_base64_image_embeds, load_image,
                     load_video)
+
+# yapf: enable
 
 __all__ = [
     "ContentFormat",

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -578,6 +578,9 @@ def serialize_item(obj: object) -> bytes:
         return obj.numpy().tobytes()
     if isinstance(obj, np.ndarray):
         return obj.tobytes()
+    if isinstance(obj, (tuple, list)):
+        # Support compound types like audio (np.ndarray, sample_rate).
+        return b"".join(serialize_item(x) for x in obj)
 
     raise ValueError(f"Unsupported object type: {type(obj)}")
 
@@ -773,8 +776,11 @@ def find_mm_token_lengths(mm_data: Dict[str, Any],
                 num_tokens = input_processor.get_num_tokens_per_video(
                     video=item, )
                 modality_token_lengths.append(num_tokens)
+            elif modality == "audio":
+                num_tokens = input_processor.get_num_tokens_per_audio(
+                    audio=item)
+                modality_token_lengths.append(num_tokens)
             else:
-                # TODO: add audio support if needed
                 raise ValueError(f"Unsupported modality: {modality}")
 
         num_mm_tokens[modality] = modality_token_lengths

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -892,10 +892,11 @@ def create_input_processor_with_hash(
         modalities = list(set(inputs['multi_modal_data'].keys())
                           ) if 'multi_modal_data' in inputs else []
         if len(modalities) > 0:
-            # TODO: support multimodal hashing for multiple modalities within the same request
-            # TODO: add audio support
-            if len(modalities) == 1 and modalities[0] in ['image', 'video']:
-                # only try multimodal hashing if the inputs only contain image data
+            # TODO: support multimodal hashing for multiple modalities within the same request.
+            if len(modalities) == 1 and modalities[0] in [
+                    'image', 'video', 'audio'
+            ]:
+                # only try multimodal hashing if the inputs only contain a single modality.
                 if input_processor.multimodal_hashing_supported is not None:
                     use_multimodal_hashing = input_processor.multimodal_hashing_supported
                 else:

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -350,7 +350,12 @@ async def async_load_audio(
     audio: str,
     format: str = "pt",
     device: str = "cuda",
+    is_base64: bool = False,
 ) -> Tuple[np.ndarray, int]:
+    if is_base64:
+        raw_bytes = base64.b64decode(audio)
+        return soundfile.read(BytesIO(raw_bytes))
+
     parsed_url = urlparse(audio)
     if parsed_url.scheme in ["http", "https"]:
         async with aiohttp.ClientSession() as session:

--- a/tensorrt_llm/serve/chat_utils.py
+++ b/tensorrt_llm/serve/chat_utils.py
@@ -57,14 +57,14 @@ ChatCompletionContentPartParam: TypeAlias = Union[
     str,
 ]
 
-# TODO: Add "input_audio" to support byte_encoded audio input.
-VALID_MESSAGE_CONTENT_MM_PART_TYPES = [
+VALID_MESSAGE_CONTENT_MM_PART_TYPES = frozenset([
     "text",
     "image_url",
     "video_url",
     "audio_url",
+    "input_audio",
     "image_embeds",
-]
+])
 
 # Parser Functions
 _TextParser = partial(cast, ChatCompletionContentPartTextParam)
@@ -83,6 +83,8 @@ MM_PARSER_MAP: dict[str, Callable[[ChatCompletionContentPartParam], Union[
         lambda part: _VideoParser(part).get("video_url", {}).get("url", None),
         "audio_url":
         lambda part: _AudioParser(part).get("audio_url", {}).get("url", None),
+        "input_audio":
+        lambda part: cast(dict, part).get("input_audio", None),
         "image_embeds":
         lambda part: _ImageEmbedsParser(part).get("image_embeds", {}).get(
             "data", None),
@@ -162,6 +164,13 @@ def parse_chat_message_content_part(
         return MultimodalData(modality="audio",
                               data=async_load_audio(str_content,
                                                     **audio_kwargs),
+                              is_embedding=False)
+
+    if part_type == "input_audio":
+        dict_content = cast(dict, content)
+        audio_data = dict_content.get("data", "")
+        return MultimodalData(modality="audio",
+                              data=async_load_audio(audio_data, is_base64=True),
                               is_embedding=False)
 
     raise NotImplementedError(f"Unknown part type: {part_type}")

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -1,6 +1,7 @@
 """Preprocessing unit tests for modeling_nemotron_nano.py."""
 
 import functools
+import importlib
 import math
 import random
 from types import SimpleNamespace
@@ -410,9 +411,12 @@ def _make_extractor_config(**overrides):
     return SimpleNamespace(**defaults)
 
 
-def _make_audio_processor(**overrides):
+def _make_audio_processor(*, extractor_overrides=None, **overrides):
     """Create a NanoV2VLInputProcessor with audio support and mocked deps."""
-    return _make_nano_processor(sound_config=_make_extractor_config(), **overrides)
+    return _make_nano_processor(
+        sound_config=_make_extractor_config(**(extractor_overrides or {})),
+        **overrides,
+    )
 
 
 class TestAudioInputProcessor:
@@ -918,3 +922,79 @@ class TestProcessVideoPromptsEvs:
 
         placeholder_count = (evs_ids == proc.video_context_token_id).sum().item()
         assert placeholder_count == num_seps
+
+
+# --- Parameters for TestAudioTokenCountPrediction ---
+_ORIG_SAMPLE_RATES = [8000, 22050, 44100, 48000]
+# Make them odd numbers so we don't always have perfect dividers of the original sampling rate.
+_TARGET_SAMPLE_RATES = [8003, 16007]
+
+# Hop-length boundary values specific to each sample rate.
+_SR_SPECIFIC_LENGTHS = {
+    # hop ~= 80 orig samples at 8 kHz
+    8000: [*range(79, 83), *range(239, 243)],
+    # hop ~= 220.5 orig samples at 22.05 kHz
+    22050: [*range(219, 224), *range(440, 444)],
+    # hop ~= 441 orig samples at 44.1 kHz
+    44100: [*range(439, 444), *range(880, 885)],
+    # hop ~= 480 orig samples at 48 kHz
+    48000: [*range(478, 483), *range(959, 963)],
+}
+
+# Each (orig_sr, target_sr, audio_length) triple combines:
+# - common small/medium/large lengths + SR-specific hop-length boundaries
+# - scaled by `multiplier * orig_sr` to exercise multi-second durations
+_PREDICTION_PARAMS = sorted(
+    set(
+        (orig_sr, target_sr, mult * orig_sr + base_len)
+        for orig_sr in _ORIG_SAMPLE_RATES
+        for target_sr in _TARGET_SAMPLE_RATES
+        for base_len in sorted(
+            set(
+                [
+                    # Small values
+                    3,
+                    17,
+                    89,
+                    # Medium / large
+                    511,
+                    1023,
+                    2113,
+                    8017,
+                    16023,
+                    47923,
+                ]
+                + _SR_SPECIFIC_LENGTHS[orig_sr]
+            )
+        )
+        for mult in (0, 3)
+    )
+)
+
+
+@pytest.mark.skipif(not importlib.util.find_spec("librosa"), reason="librosa not installed")
+class TestAudioTokenCountPrediction:
+    """Verify that estimated audio token count matches that after actual processing."""
+
+    @pytest.mark.parametrize("orig_sr, target_sr, audio_length", _PREDICTION_PARAMS)
+    def test_prediction_matches_actual(self, orig_sr, target_sr, audio_length):
+        proc = _make_audio_processor(
+            extractor_overrides={"sampling_rate": target_sr},
+        )
+        extractor = proc._audio_extractor
+
+        audio_data = np.random.randn(audio_length).astype(np.float32)
+
+        # Path 1: prediction (get_num_tokens_per_audio — uses math.ceil).
+        predicted = proc.get_num_tokens_per_audio(audio=(audio_data, orig_sr))
+
+        # Path 2: actual resampling then token count.
+        [resampled] = proc._resample_audios([(audio_data, orig_sr)], target_sr)
+        actual = extractor.audio_token_count(len(resampled)) + 2  # +2 for wrapping tokens
+
+        assert predicted == actual, (
+            f"orig_sr={orig_sr}, target_sr={target_sr}, audio_length={audio_length}: "
+            f"predicted={predicted} != actual={actual}. "
+            f"ceil_length={math.ceil(audio_length * target_sr / orig_sr)}, "
+            f"resampled_length={len(resampled)}"
+        )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audio input support for multimodal models and chat applications
  * Base64-encoded audio content processing (compatible with standard audio formats)
  * Audio serialization and token counting for multimodal data structures
  * Chat messages can now include audio inputs alongside existing content types
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This commit:

* extends the current chunked prefill interfaces to allow models to
  implement the necessary code to opt-in for audio.
* implements it for nemotron nano.
* 
## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
