### PR TITLE
[https://nvbugs/6066969][fix] Store context blocks before request termination

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1681,6 +1681,18 @@ class PyExecutor:
                 self._update_requests(executed_batch.sample_state)
 
                 scheduled_requests = executed_batch.scheduled_requests
+                sample_state_scheduled_requests = executed_batch.scheduled_requests
+                attn_metadata = getattr(self.model_engine, 'attn_metadata',
+                                        None)
+                kv_cache_dtype_byte_size = getattr(self.model_engine,
+                                                   'kv_cache_dtype_byte_size',
+                                                   None)
+                # Store context blocks before _handle_responses
+                # because handle_responses can terminate requests and
+                # remove sequences from the KV cache manager.
+                self.resource_manager.update_resources(
+                    sample_state_scheduled_requests, attn_metadata,
+                    kv_cache_dtype_byte_size)
                 if self.kv_cache_transceiver:
                     finished_ctx_reqs = scheduled_requests.context_requests_last_chunk
                     self._send_kv_async(finished_ctx_reqs)
@@ -1691,15 +1703,6 @@ class PyExecutor:
                 # _handle_responses sees the request before it is terminated.
                 if self.kv_cache_transceiver:
                     self._check_disagg_ctx_cache_transfer_status(0)
-                sample_state_scheduled_requests = executed_batch.scheduled_requests
-                attn_metadata = getattr(self.model_engine, 'attn_metadata',
-                                        None)
-                kv_cache_dtype_byte_size = getattr(self.model_engine,
-                                                   'kv_cache_dtype_byte_size',
-                                                   None)
-                self.resource_manager.update_resources(
-                    sample_state_scheduled_requests, attn_metadata,
-                    kv_cache_dtype_byte_size)
 
                 self._remove_inflight_ids(scheduled_requests)
 
@@ -2135,6 +2138,17 @@ class PyExecutor:
                     self._update_request_states(scheduled_batch)
                     self._update_requests(sample_state, self.resource_manager)
 
+                    attn_metadata = getattr(self.model_engine, 'attn_metadata',
+                                            None)
+                    kv_cache_dtype_byte_size = getattr(
+                        self.model_engine, 'kv_cache_dtype_byte_size', None)
+                    # Store context blocks before _handle_responses and
+                    # because handle_responses can terminate requests and
+                    # remove sequences from the KV cache manager.
+                    self.resource_manager.update_resources(
+                        scheduled_batch, attn_metadata,
+                        kv_cache_dtype_byte_size)
+
                     self._send_kv_async(scheduled_batch.all_requests())
 
                     self._handle_canceled_requests()
@@ -2147,13 +2161,6 @@ class PyExecutor:
                     # (safe in non-overlap mode: no next iteration to overwrite events)
                     self.perf_manager.compute_batch_gpu_times(
                         scheduled_batch.all_requests())
-                    attn_metadata = getattr(self.model_engine, 'attn_metadata',
-                                            None)
-                    kv_cache_dtype_byte_size = getattr(
-                        self.model_engine, 'kv_cache_dtype_byte_size', None)
-                    self.resource_manager.update_resources(
-                        scheduled_batch, attn_metadata,
-                        kv_cache_dtype_byte_size)
                     if self.enable_kv_cache_events:
                         self._add_kv_cache_events()
 
@@ -2540,15 +2547,17 @@ class PyExecutor:
         return result_tensors, num_accepted_tokens
 
     def _process_previous_batch(self):
-        self._handle_canceled_requests()
-        finished_requests = self._handle_responses()
         scheduled_requests = self.previous_batch.scheduled_requests
         attn_metadata = getattr(self.model_engine, 'attn_metadata', None)
         kv_cache_dtype_byte_size = getattr(self.model_engine,
                                            'kv_cache_dtype_byte_size', None)
+        # Store context blocks before _handle_responses, because handle_responses can
+        # terminate requests and remove sequences from the KV cache manager.
         self.resource_manager.update_resources(scheduled_requests,
                                                attn_metadata,
                                                kv_cache_dtype_byte_size)
+        self._handle_canceled_requests()
+        finished_requests = self._handle_responses()
         if self.enable_kv_cache_events:
             self._add_kv_cache_events()
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -610,27 +610,13 @@ class PyExecutor:
 
             self.kv_connector_manager.wait_for_initialization()
 
-    def _end_transfer_and_maybe_terminate(self, request: LlmRequest):
-        if self.kv_cache_transceiver and request in self.active_requests:
-            # Fast-transfer: KV transfer completed in the same iteration
-            # before _handle_responses could run. Create the response now
-            # while state is still TRANS_IN_PROGRESS (required by C++
-            # createResult). Then proceed with end_transfer + termination.
-            response = request.create_response(False, self.dist.rank)
-            if response:
-                response.result.cached_tokens = request.cached_tokens
-                self._enqueue_responses([(request.py_request_id, response)])
-            if self.async_transfer_manager.end_transfer(request):
-                self.active_requests.remove(request)
-                self._terminate_request(request)
-            return
-        if self.async_transfer_manager.end_transfer(request):
-            # When should_store_blocks is True, _handle_responses already
-            # terminated this request via the early-termination path
-            # (enable_partial_reuse_for_disagg branch). Skip the redundant
-            # termination to avoid double free_resources calls.
-            if not self.async_transfer_manager.should_store_blocks:
-                self._terminate_request(request)
+    def _update_resources(self, scheduled_requests) -> None:
+        attn_metadata = getattr(self.model_engine, 'attn_metadata', None)
+        kv_cache_dtype_byte_size = getattr(self.model_engine,
+                                           'kv_cache_dtype_byte_size', None)
+        self.resource_manager.update_resources(scheduled_requests,
+                                               attn_metadata,
+                                               kv_cache_dtype_byte_size)
 
     # Performance metrics methods are in PerfMetricsManager (self.perf_manager)
 
@@ -1681,18 +1667,7 @@ class PyExecutor:
                 self._update_requests(executed_batch.sample_state)
 
                 scheduled_requests = executed_batch.scheduled_requests
-                sample_state_scheduled_requests = executed_batch.scheduled_requests
-                attn_metadata = getattr(self.model_engine, 'attn_metadata',
-                                        None)
-                kv_cache_dtype_byte_size = getattr(self.model_engine,
-                                                   'kv_cache_dtype_byte_size',
-                                                   None)
-                # Store context blocks before _handle_responses
-                # because handle_responses can terminate requests and
-                # remove sequences from the KV cache manager.
-                self.resource_manager.update_resources(
-                    sample_state_scheduled_requests, attn_metadata,
-                    kv_cache_dtype_byte_size)
+                self._update_resources(executed_batch.scheduled_requests)
                 if self.kv_cache_transceiver:
                     finished_ctx_reqs = scheduled_requests.context_requests_last_chunk
                     self._send_kv_async(finished_ctx_reqs)
@@ -1928,7 +1903,7 @@ class PyExecutor:
         if self.kv_connector_manager:
             reqs_to_terminate = self.kv_connector_manager.get_finished()
             for req in reqs_to_terminate:
-                self._end_transfer_and_maybe_terminate(req)
+                self.async_transfer_manager.end_transfer(req)
 
     def _kv_connector_wait_for_save(self):
         if self.kv_connector_manager is not None:
@@ -2138,16 +2113,7 @@ class PyExecutor:
                     self._update_request_states(scheduled_batch)
                     self._update_requests(sample_state, self.resource_manager)
 
-                    attn_metadata = getattr(self.model_engine, 'attn_metadata',
-                                            None)
-                    kv_cache_dtype_byte_size = getattr(
-                        self.model_engine, 'kv_cache_dtype_byte_size', None)
-                    # Store context blocks before _handle_responses and
-                    # because handle_responses can terminate requests and
-                    # remove sequences from the KV cache manager.
-                    self.resource_manager.update_resources(
-                        scheduled_batch, attn_metadata,
-                        kv_cache_dtype_byte_size)
+                    self._update_resources(scheduled_batch)
 
                     self._send_kv_async(scheduled_batch.all_requests())
 
@@ -2547,15 +2513,7 @@ class PyExecutor:
         return result_tensors, num_accepted_tokens
 
     def _process_previous_batch(self):
-        scheduled_requests = self.previous_batch.scheduled_requests
-        attn_metadata = getattr(self.model_engine, 'attn_metadata', None)
-        kv_cache_dtype_byte_size = getattr(self.model_engine,
-                                           'kv_cache_dtype_byte_size', None)
-        # Store context blocks before _handle_responses, because handle_responses can
-        # terminate requests and remove sequences from the KV cache manager.
-        self.resource_manager.update_resources(scheduled_requests,
-                                               attn_metadata,
-                                               kv_cache_dtype_byte_size)
+        self._update_resources(self.previous_batch.scheduled_requests)
         self._handle_canceled_requests()
         finished_requests = self._handle_responses()
         if self.enable_kv_cache_events:
@@ -3267,7 +3225,7 @@ class PyExecutor:
 
             request = requests_in_transfer[request_id]
 
-            self._end_transfer_and_maybe_terminate(request)
+            self.async_transfer_manager.end_transfer(request)
 
         # The set of requests in transfer may have changed since we terminated some requests.
         requests_in_transfer = self.async_transfer_manager.requests_in_transfer(
@@ -3283,7 +3241,7 @@ class PyExecutor:
                     request.py_kv_transfer_start_time = None
                     request.state = LlmRequestState.DISAGG_CONTEXT_COMPLETE
 
-                    self._end_transfer_and_maybe_terminate(request)
+                    self.async_transfer_manager.end_transfer(request)
 
         self._check_cache_transfer_errors("context requests")
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized resource-update logic and moved resource-tracking earlier across execution paths so resources are updated before request cancellation and response handling.
  * Simplified transfer completion/termination handling to call termination paths directly, improving KV-cache/context transfer reliability and preventing lost or inconsistent request state during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Move `update_resources` (which calls `store_context_blocks`) before `_handle_responses` in all three PyExecutor paths.

`_handle_responses` can terminate requests and remove sequences from the KV cache manager, causing `store_context_blocks` to fail with a `[kv cache manager] storeContextBlocks: Can not find sequence for request` warning.

**Fix:** Reorder `update_resources` to run before any code path that can terminate requests:
- `_handle_executed_batch` (overlap/PP path)
- Non-overlap executor loop
- `_process_previous_batch`

## Test Coverage

- Verified with disaggregated serving (Qwen3-0.6B, context + generation servers on single node)
- Ran 200 concurrent requests via aiperf (concurrency 10) — zero `storeContextBlocks` warnings
- No crashes or errors in context/generation server logs
- Existing disagg CI tests should cover regression

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.