### PR TITLE
[#12954][fix] AutoDeploy: Fix Gemma4 MoE config (disable multi_stream_moe, lower free_gpu_memory_fraction)

### DIFF
--- a/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
+++ b/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
@@ -16,7 +16,7 @@ max_seq_len: 8192
 enable_chunked_prefill: true
 kv_cache_config:
   enable_block_reuse: false
-  free_gpu_memory_fraction: 0.8
+  free_gpu_memory_fraction: 0.4
 transforms:
   compile_model:
     piecewise_enabled: true
@@ -26,5 +26,6 @@ transforms:
     enabled: true
   fuse_gemms:
     enabled: true
+  #TODO(suyogg): Enable when https://github.com/NVIDIA/TensorRT-LLM/issues/12954 is resolved
   multi_stream_moe:
-    enabled: true
+    enabled: false


### PR DESCRIPTION
## Summary

- **Disable `multi_stream_moe`** to fix accuracy regression when combined with MLIR elementwise fusion and monolithic CUDA graphs (GSM8K 80% → 90%). Root cause tracked in #12954.
- **Lower `free_gpu_memory_fraction`** from 0.8 to 0.4 to prevent OOM during piecewise CUDA graph capture on 80GB GPUs.

Config-only change — no code modifications.

## Verified scores

Model: `google/gemma-4-26B-A4B-it` (bf16, single H100 80GB)

| Benchmark | Score |
|-----------|-------|
| MMLU | 75% |
| GSM8K | 90% |

## Test plan

- [x] `TRTLLM_ACCURACY_NO_REFERENCE=1 pytest tests/integration/defs/accuracy/test_llm_api_autodeploy.py::TestGemma4MoE::test_bf16 -s -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model registry example configuration with adjusted GPU memory allocation parameters for KV cache operations.
  * Disabled a transform feature in the example configuration, pending resolution of an upstream dependency issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->