### PR TITLE
[https://nvbugs/6070421][fix] Prefer pre-compiled cubin over NVRTC in trtllm-gen FMHA run()

### DIFF
--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
@@ -291,6 +291,18 @@ public:
         bool shouldUseNvrtc = options.mFmhaKernelType == FmhaKernelType::SwapsMmaAbForGeneration && !options.mIsMlaGen
             && options.mDtypeKv != tg::Dtype::E2m1 && options.mHeadDimQk != 64 && !isLlama70bFp4Tp4;
 
+        // Prefer a pre-compiled cubin over NVRTC when one is available (e.g. sm_100f cubins on sm_100 GPUs).
+        if (shouldUseNvrtc)
+        {
+            FmhaOptions cubinCheckOptions = options;
+            algoFilterForCubinPath(cubinCheckOptions);
+            auto [checkHashId, checkInfo] = hashFromFmhaOptions(cubinCheckOptions);
+            if (mFunctions.find(checkHashId) != mFunctions.end())
+            {
+                shouldUseNvrtc = false;
+            }
+        }
+
         if (shouldUseNvrtc)
         {
             // nvrtc path - uses mFmhaInterface member for kernel caching

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -645,8 +645,6 @@ class TestNemotronSuperV3(LlmapiAccuracyTestHarness):
                            yaml_extra=[self.CONFIG_YAML],
                            trust_remote_code=True,
                            **kwargs) as llm:
-            if dtype == "fp8":
-                _set_quant_config(llm, "fp8")
             outputs = llm.generate(
                 ["Hello, how are you?"],
                 sampling_params=SamplingParams(max_tokens=10))

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -623,7 +623,7 @@ class TestNemotronSuperV3(LlmapiAccuracyTestHarness):
 
         print_memory_usage("after evaluation")
 
-    @skip_pre_blackwell
+    @skip_pre_hopper
     @pytest.mark.skip_less_device_memory(40000)
     @pytest.mark.parametrize("dtype", ["bf16", "fp8"])
     def test_functional_small(self, dtype):

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -163,7 +163,7 @@ def low_memory_overrides(config,
 
 
 def reduced_model_kwargs(num_hidden_layers: int,
-                         model_path: str = None) -> dict:
+                         model_path: str | None = None) -> dict:
     """Return model_kwargs to cap a model at ``num_hidden_layers`` layers.
 
     Reduces peak memory so large models fit on a single GPU for pre-merge

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -162,6 +162,31 @@ def low_memory_overrides(config,
     return config
 
 
+def reduced_model_kwargs(num_hidden_layers: int,
+                         model_path: str = None) -> dict:
+    """Return model_kwargs to cap a model at ``num_hidden_layers`` layers.
+
+    Reduces peak memory so large models fit on a single GPU for pre-merge
+    smoke testing. The rest of the architecture (attention, MoE, SSM) is
+    preserved; only the layer count is truncated.
+
+    For models whose config derives layer count from a list attribute (e.g.
+    ``layers_block_type`` in NemotronH), pass ``model_path`` so the list
+    is also truncated — otherwise the ``num_hidden_layers`` override has
+    no effect.
+    """
+    overrides = {"num_hidden_layers": num_hidden_layers}
+    if model_path is not None:
+        from transformers import AutoConfig
+        hf_config = AutoConfig.from_pretrained(model_path,
+                                               trust_remote_code=True)
+        for attr in ("layers_block_type", ):
+            val = getattr(hf_config, attr, None)
+            if val is not None:
+                overrides[attr] = val[:num_hidden_layers]
+    return {"model_kwargs": overrides}
+
+
 class TestLlama3_1_8B(LlmapiAccuracyTestHarness):
     MODEL_NAME = "meta-llama/Llama-3.1-8B"
     MODEL_PATH = hf_id_to_local_model_dir(MODEL_NAME)
@@ -597,6 +622,35 @@ class TestNemotronSuperV3(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
 
         print_memory_usage("after evaluation")
+
+    @skip_pre_blackwell
+    @pytest.mark.skip_less_device_memory(40000)
+    @pytest.mark.parametrize("dtype", ["bf16", "fp8"])
+    def test_functional_small(self, dtype):
+        """Single-GPU smoke test using a layer-reduced model.
+
+        Overrides num_hidden_layers so the 120B model fits on one GPU,
+        enabling pre-merge coverage of the full kernel dispatch path
+        (attention, MoE, SSM) without requiring a multi-GPU machine.
+        No accuracy threshold is checked — the truncated model is not
+        expected to produce meaningful text.
+        """
+        model_path = self.MODEL_PATHS[dtype]
+        kwargs = {}
+        kwargs.update(
+            reduced_model_kwargs(num_hidden_layers=16, model_path=model_path))
+        with AutoDeployLLM(model=model_path,
+                           tokenizer=model_path,
+                           world_size=1,
+                           yaml_extra=[self.CONFIG_YAML],
+                           trust_remote_code=True,
+                           **kwargs) as llm:
+            if dtype == "fp8":
+                _set_quant_config(llm, "fp8")
+            outputs = llm.generate(
+                ["Hello, how are you?"],
+                sampling_params=SamplingParams(max_tokens=10))
+            assert len(outputs) == 1
 
     @pytest.mark.skip_less_device_memory(180000)
     @pytest.mark.parametrize("world_size", [4, 8])

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -298,6 +298,8 @@ l0_b200:
   - accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[fp8-1-trtllm]
   - accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[nvfp4-1-trtllm]
   - accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_accuracy[nvfp4-1-attn_dp_off-trtllm]
+  - accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_functional_small[bf16]
+  - accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_functional_small[fp8]
   - unittest/auto_deploy/singlegpu/compile
   - unittest/auto_deploy/singlegpu/custom_ops
   - unittest/auto_deploy/singlegpu/models


### PR DESCRIPTION
## Description

PR #12612 introduced a `shouldUseNvrtc` path in `TllmGenFmhaKernel::run()` that unconditionally bypasses cubin lookup for `SwapsMmaAbForGeneration` kernels. On sm_100 (B200) GPUs, this triggers NVRTC compilation for kernels that already have compatible sm_100f pre-compiled cubins - causing a crash when cuda.h is not on the include path.                                                                                                                                                                
                                                                                                                                                                                                                                                        Fix: Before entering the NVRTC path, check whether a matching cubin exists in mFunctions. If one is found, skip NVRTC and use the cubin directly. 
                                                                                                                                                                                                                                                        
Failing tests fixed:                                                                                                                                                                                                                                  
tests/integration/defs/accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_accuracy[fp8-*
tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_fp8_4gpus
  
Added TestNemotronSuperV3::test_functional_small[fp8] - a single-GPU smoke test that loads a layer-reduced (16-layer) Super V3 FP8 model using reduced_model_kwargs(), a reusable helper that truncates both num_hidden_layers and layers_block_type to fit large hybrid models on one device. Added to l0_b200.yml for pre-merge coverage.

## Test Coverage

N/A - fixing existing tests

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * FMHA kernel now detects and prefers available precompiled binaries over on-the-fly compilation, reducing runtime compilation and improving efficiency.

* **Tests**
  * Added a small single-GPU AutoDeploy smoke test for Nemotron variants (bf16 and fp8) and a helper to create reduced model configs, expanding coverage and CI test listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->