### PR TITLE
[None][chore] Update flashinfer-python from 0.6.6 to 0.6.7.post3

### DIFF
--- a/ATTRIBUTIONS-Python.md
+++ b/ATTRIBUTIONS-Python.md
@@ -5261,7 +5261,7 @@ For more information, please refer to <http://unlicense.org>
   - `Tracker`: https://github.com/tox-dev/py-filelock/issues
 
 
-## flashinfer-python (0.6.6)
+## flashinfer-python (0.6.7.post3)
 
 ### Licenses
 License: `Apache-2.0`

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ ordered-set
 peft
 patchelf
 einops
-flashinfer-python==0.6.6
+flashinfer-python==0.6.7.post3
 opencv-python-headless
 xgrammar==0.1.32
 llguidance==0.7.29

--- a/security_scanning/poetry.lock
+++ b/security_scanning/poetry.lock
@@ -1433,19 +1433,20 @@ files = [
 
 [[package]]
 name = "flashinfer-python"
-version = "0.6.6"
+version = "0.6.7.post3"
 description = "FlashInfer: Kernel Library for LLM Serving"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "flashinfer_python-0.6.6-py3-none-any.whl", hash = "sha256:078f158636969eec1a0d3dea19c3ca90b426b66df89bbf7b7b8276ce2ec08148"},
-    {file = "flashinfer_python-0.6.6.tar.gz", hash = "sha256:0730ba7c7aad332961933bcebc5119762797161ede57d955f6fd199818ed1d92"},
+    {file = "flashinfer_python-0.6.7.post3-py3-none-any.whl", hash = "sha256:9d3f1aa0313cf9e5cf99f7560b8e003c57876088c8abfe7a3d330cccd4873052"},
+    {file = "flashinfer_python-0.6.7.post3.tar.gz", hash = "sha256:defad86864e087f754ed0a632c2d15aa389a1dc8e3198fb6b7d7af4b36e3eaa5"},
 ]
 
 [package.dependencies]
 apache-tvm-ffi = ">=0.1.6,<0.1.8 || >0.1.8,<0.1.8.post0 || >0.1.8.post0,<0.2"
 click = "*"
+cuda-tile = "*"
 einops = "*"
 ninja = "*"
 numpy = "*"

--- a/security_scanning/pyproject.toml
+++ b/security_scanning/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "peft (>=0.18.1,<0.19.0)",
     "patchelf (>=0.17.2.4,<0.18.0.0)",
     "einops (>=0.8.2,<0.9.0)",
-    "flashinfer-python (==0.6.6)",
+    "flashinfer-python (==0.6.7.post3)",
     "opencv-python-headless (>=4.13.0.92,<5.0.0.0)",
     "xgrammar (==0.1.32)",
     "llguidance (==0.7.29)",


### PR DESCRIPTION
## Summary
- Bump `flashinfer-python` from `0.6.6` to `0.6.7.post3` (latest stable)
- Updated version pins in `requirements.txt`, `security_scanning/pyproject.toml`, `security_scanning/poetry.lock`, and `ATTRIBUTIONS-Python.md`
- New upstream dependency `cuda-tile` added to `poetry.lock`

## Test plan
- [ ] `pip install -r requirements.txt` installs successfully
- [ ] `pytest tests/unittest/_torch/flashinfer/ -v`
- [ ] `pytest tests/unittest/_torch/attention/test_flashinfer_attention.py -v`
- [ ] CI pre-merge passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated flashinfer-python dependency from version 0.6.6 to 0.6.7.post3 across project configurations and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->