### PR TITLE
[None][fix] Support custom_tokenizer in KvCacheAwareRouter for disagg serving

### DIFF
--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -515,6 +515,15 @@ class MoeConfig(StrictBaseModel):
 
 Nvfp4Backend = Literal['cutlass', 'cublaslt', 'cutedsl', 'cuda_core']
 
+# Short aliases for built-in custom tokenizers.
+# Maps alias → full import path (module.ClassName).
+TOKENIZER_ALIASES = {
+    'deepseek_v32':
+    'tensorrt_llm.tokenizer.deepseek_v32.DeepseekV32Tokenizer',
+    'glm_moe_dsa':
+    'tensorrt_llm.tokenizer.glm_moe_dsa.GlmMoeDsaTokenizer',
+}
+
 
 class Nvfp4GemmConfig(StrictBaseModel):
     """
@@ -2762,26 +2771,11 @@ class BaseLlmArgs(StrictBaseModel):
                     "Please specify a tokenizer path or leave it as None to load from model path."
                 )
 
-            # Support short aliases for built-in tokenizers
-            TOKENIZER_ALIASES = {
-                'deepseek_v32':
-                'tensorrt_llm.tokenizer.deepseek_v32.DeepseekV32Tokenizer',
-                'glm_moe_dsa':
-                'tensorrt_llm.tokenizer.glm_moe_dsa.GlmMoeDsaTokenizer',
-            }
-
-            tokenizer_path = TOKENIZER_ALIASES.get(self.custom_tokenizer,
-                                                   self.custom_tokenizer)
-
-            # Dynamically import and use custom tokenizer
-            from importlib import import_module
+            from tensorrt_llm.tokenizer import load_custom_tokenizer
             try:
-                module_path, class_name = tokenizer_path.rsplit('.', 1)
-                module = import_module(module_path)
-                tokenizer_class = getattr(module, class_name)
-                # Use tokenizer path if specified, otherwise use model path
                 load_path = self.tokenizer if self.tokenizer else self.model
-                self.tokenizer = tokenizer_class.from_pretrained(
+                self.tokenizer = load_custom_tokenizer(
+                    self.custom_tokenizer,
                     load_path,
                     trust_remote_code=self.trust_remote_code,
                     use_fast=self.tokenizer_mode != 'slow')

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -609,6 +609,7 @@ class KvCacheAwareRouter(Router):
                  use_tokens: bool = False,
                  max_batch_size: int = 64,
                  tokens_per_block: int = 32,
+                 custom_tokenizer: Optional[str] = None,
                  **kwargs):
         super().__init__(server_role, servers, metadata_server_cfg,
                          metadata_server, **kwargs)
@@ -625,6 +626,7 @@ class KvCacheAwareRouter(Router):
         self._req_routing_table: dict[int, OpenAIRequest] = {}
 
         self._tokenizers = {}
+        self._custom_tokenizer = custom_tokenizer
         # TODO: use max_num_tokens? per server?
         self._max_batch_size = max_batch_size
         env_tokens_per_block = os.environ.get(
@@ -633,11 +635,17 @@ class KvCacheAwareRouter(Router):
             tokens_per_block = int(env_tokens_per_block)
         self._tokens_per_block = tokens_per_block
         logger.info(
-            f"KvCacheAwareRouter: tokens_per_block={self._tokens_per_block}")
+            f"KvCacheAwareRouter: tokens_per_block={self._tokens_per_block}"
+            f", custom_tokenizer={self._custom_tokenizer}")
 
     def _get_tokenizer(self, model: str):
         if model not in self._tokenizers:
-            self._tokenizers[model] = AutoTokenizer.from_pretrained(model)
+            if self._custom_tokenizer:
+                from tensorrt_llm.tokenizer import load_custom_tokenizer
+                self._tokenizers[model] = load_custom_tokenizer(
+                    self._custom_tokenizer, model)
+            else:
+                self._tokenizers[model] = AutoTokenizer.from_pretrained(model)
         return self._tokenizers[model]
 
     def _tokenize(self, request: OpenAIRequest) -> list[list[int]]:
@@ -646,7 +654,7 @@ class KvCacheAwareRouter(Router):
             if request.prompt_token_ids is not None:
                 return [request.prompt_token_ids]
             tokenizer = self._get_tokenizer(request.model)
-            token_ids = tokenizer.apply_chat_template(
+            result = tokenizer.apply_chat_template(
                 [
                     msg if isinstance(msg, dict) else dict(msg)
                     for msg in request.messages
@@ -654,9 +662,14 @@ class KvCacheAwareRouter(Router):
                 add_generation_prompt=request.add_generation_prompt,
                 tokenize=True,
             )
+            # Some custom tokenizers (e.g. DeepseekV32Tokenizer) return a
+            # string from apply_chat_template even with tokenize=True.
+            # Encode to token IDs if needed.
+            if isinstance(result, str):
+                result = tokenizer.encode(result, add_special_tokens=False)
             # Set prompt_token_ids so the worker server skips re-tokenization
-            request.prompt_token_ids = token_ids
-            return [token_ids]
+            request.prompt_token_ids = result
+            return [result]
 
         # Handle CompletionRequest (has prompt)
         prompts = request.prompt

--- a/tensorrt_llm/tokenizer/__init__.py
+++ b/tensorrt_llm/tokenizer/__init__.py
@@ -5,6 +5,7 @@ from .tokenizer import (
     TransformersTokenizer,
     _llguidance_tokenizer_info,
     _xgrammar_tokenizer_info,
+    load_custom_tokenizer,
     load_hf_tokenizer,
     tokenizer_factory,
 )
@@ -17,5 +18,6 @@ __all__ = [
     "tokenizer_factory",
     "_xgrammar_tokenizer_info",
     "_llguidance_tokenizer_info",
+    "load_custom_tokenizer",
     "load_hf_tokenizer",
 ]

--- a/tensorrt_llm/tokenizer/tokenizer.py
+++ b/tensorrt_llm/tokenizer/tokenizer.py
@@ -413,6 +413,39 @@ def maybe_register_transformers_modules_by_value():
             f"serialization: {e}")
 
 
+def load_custom_tokenizer(
+    custom_tokenizer: str,
+    model_path: str,
+    trust_remote_code: bool = False,
+    use_fast: bool = True,
+) -> TokenizerBase:
+    '''Load a custom tokenizer by alias or full import path.
+
+    Resolves short aliases (e.g. 'deepseek_v32') via TOKENIZER_ALIASES,
+    or accepts a full import path (e.g. 'tensorrt_llm.tokenizer.deepseek_v32.DeepseekV32Tokenizer').
+
+    Args:
+        custom_tokenizer: Alias or full import path of the tokenizer class.
+        model_path: Path to the model directory (passed to from_pretrained).
+        trust_remote_code: Whether to trust remote code.
+        use_fast: Whether to use the fast tokenizer.
+
+    Returns:
+        An instance of the custom tokenizer.
+    '''
+    from importlib import import_module
+    from tensorrt_llm.llmapi.llm_args import TOKENIZER_ALIASES
+
+    tokenizer_path = TOKENIZER_ALIASES.get(custom_tokenizer, custom_tokenizer)
+    module_path, class_name = tokenizer_path.rsplit('.', 1)
+    tokenizer_class = getattr(import_module(module_path), class_name)
+    return tokenizer_class.from_pretrained(
+        model_path,
+        trust_remote_code=trust_remote_code,
+        use_fast=use_fast,
+    )
+
+
 def load_hf_tokenizer(model_dir: str,
                       trust_remote_code: bool = True,
                       use_fast: bool = True,


### PR DESCRIPTION
## Summary

The KvCacheAwareRouter needs to tokenize incoming ChatCompletionRequests to compute block hashes for cache-aware routing. Models like DeepSeek-V3.2 use a custom tokenizer whose HF tokenizer lacks `chat_template`, causing `apply_chat_template` to fail.

### Changes

- **`router.py`**: Add `custom_tokenizer` parameter to `KvCacheAwareRouter` (passed via `router_args` in disagg server config). Resolve aliases using `TOKENIZER_ALIASES` from `llm_args.py`. Load custom tokenizer via `from_pretrained`. Handle `apply_chat_template` returning string instead of token IDs (some custom tokenizers ignore `tokenize=True`).
- **`llm_args.py`**: Move `TOKENIZER_ALIASES` to module level so both `_setup_tokenizer` and router can share it (remove local duplicate).

### Usage

In disagg server config:
```yaml
context_servers:
  router:
    type: kv_cache_aware
    args:
      custom_tokenizer: deepseek_v32
```

## Test plan

- Tested on GB200 and GB300 with DeepSeek-V3.2-FP4-v2, disagg 1P1D (DEP4+TEP8)
- Without fix: `ValueError: chat_template is not set` → 100% request failures
- With fix: 100% success, kv_cache_aware router works correctly with custom tokenizer

🤖 Generated with [Claude Code](https://claude.com/claude-code)