### PR TITLE
[DO NOT MERGE][None][infra] Enable CUDA coredump collection for L0 CI

### DIFF
--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
@@ -192,51 +192,61 @@ public:
 
     std::pair<bool, std::string> checkIfKernelExist(RunnerParams const& params) const
     {
-        // Some conditions to check if the kernel is supported.
-        // This is meant to avoid occupying unnecessary hashId bits.
-        if (params.mHeadDimQk % 8 != 0 || params.mHeadDimV % 8 != 0)
+        try
         {
-            return std::make_pair(false, "HeadDimQk and HeadDimV must be divisible by 8");
-        }
 
-        if (params.mMaxSeqLenQ == 0 || params.mBatchSize == 0
-            || (!isContextKernel(params.mKernelType) && params.mMaxSeqLenKv == 0))
+            // Some conditions to check if the kernel is supported.
+            // This is meant to avoid occupying unnecessary hashId bits.
+            if (params.mHeadDimQk % 8 != 0 || params.mHeadDimV % 8 != 0)
+            {
+                return std::make_pair(false, "HeadDimQk and HeadDimV must be divisible by 8");
+            }
+
+            if (params.mMaxSeqLenQ == 0 || params.mBatchSize == 0
+                || (!isContextKernel(params.mKernelType) && params.mMaxSeqLenKv == 0))
+            {
+                return std::make_pair(false, "Empty batch or zero sequence length");
+            }
+
+            // The selectKernelParams that might be updated.
+            SelectKernelParams selectKernelParams{params};
+
+            int32_t ctaDim = 512;
+            FmhaOptions options;
+            FmhaOptionsFromArgs optionsFromArgs;
+            parseOptionsFromRunnerParams(params, options);
+            options.mCudaArch = intToCudaArch(mSM);
+
+            FmhaAutoTuner autoTuner(options, optionsFromArgs, params.mMultiProcessorCount);
+            std::tie(options, optionsFromArgs, ctaDim) = autoTuner.selectKernel();
+            // Check if the options are valid or not.
+            checkFmhaOptions(options, optionsFromArgs);
+            // Update the options if needed.
+            updateFmhaOptions(options, optionsFromArgs);
+            // The number of CtasQ and CtasKv per sequence, Ctas in the Y dimension, and Ctas in the Z
+            // dimension.
+            computeNumCtas(options, params.mMultiProcessorCount);
+
+            // Check if a precompiled cubin exists for this configuration (same lookup as run()).
+            // If not, return (false, info) so the dispatcher can fall back to unfused MHA like on main.
+            algoFilterForCubinPath(options);
+            auto [hashId, info] = hashFromFmhaOptions(options);
+
+            if (mFunctions.find(hashId) == mFunctions.end())
+            {
+                TLLM_LOG_WARNING("Trtllm-gen kernels not found: " + info);
+                return std::make_pair(false, info);
+            }
+            TLLM_LOG_DEBUG("TRTLLM-Gen kernel traits: %s", info.c_str());
+
+            return std::make_pair(true, info);
+        }
+        catch (std::exception const& e)
         {
-            return std::make_pair(false, "Empty batch or zero sequence length");
+            std::string const errorInfo = std::string("Exception during kernel existence check: ") + e.what();
+            TLLM_LOG_WARNING(errorInfo);
+            return std::make_pair(false, errorInfo);
         }
-
-        // The selectKernelParams that might be updated.
-        SelectKernelParams selectKernelParams{params};
-
-        int32_t ctaDim = 512;
-        FmhaOptions options;
-        FmhaOptionsFromArgs optionsFromArgs;
-        parseOptionsFromRunnerParams(params, options);
-        options.mCudaArch = intToCudaArch(mSM);
-
-        FmhaAutoTuner autoTuner(options, optionsFromArgs, params.mMultiProcessorCount);
-        std::tie(options, optionsFromArgs, ctaDim) = autoTuner.selectKernel();
-        // Check if the options are valid or not.
-        checkFmhaOptions(options, optionsFromArgs);
-        // Update the options if needed.
-        updateFmhaOptions(options, optionsFromArgs);
-        // The number of CtasQ and CtasKv per sequence, Ctas in the Y dimension, and Ctas in the Z
-        // dimension.
-        computeNumCtas(options, params.mMultiProcessorCount);
-
-        // Check if a precompiled cubin exists for this configuration (same lookup as run()).
-        // If not, return (false, info) so the dispatcher can fall back to unfused MHA like on main.
-        algoFilterForCubinPath(options);
-        auto [hashId, info] = hashFromFmhaOptions(options);
-
-        if (mFunctions.find(hashId) == mFunctions.end())
-        {
-            TLLM_LOG_WARNING("Trtllm-gen kernels not found: " + info);
-            return std::make_pair(false, info);
-        }
-        TLLM_LOG_DEBUG("TRTLLM-Gen kernel traits: %s", info.c_str());
-
-        return std::make_pair(true, info);
     }
 
     void algoFilterForCubinPath(FmhaOptions& options) const

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1087,6 +1087,7 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 envVarsToExport['CUDA_ENABLE_COREDUMP_ON_EXCEPTION'] = '1'
                 envVarsToExport['CUDA_ENABLE_CPU_COREDUMP_ON_EXCEPTION'] = '0'
                 envVarsToExport['CUDA_ENABLE_LIGHTWEIGHT_COREDUMP'] = '1'
+                envVarsToExport['CUDA_COREDUMP_GENERATION_FLAGS'] = 'skip_nonrelocated_elf_images,skip_global_memory,skip_shared_memory,skip_local_memory,skip_constbank_memory'
                 envVarsToExport['CUDA_COREDUMP_FILE'] = "${jobWorkspace}/cuda_coredump_%h_%p.nvcudmp"
 
                 def srunArgs = [

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -118,6 +118,7 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
         def hasTimeoutTest = false
         def downloadResultSucceed = false
         def downloadPerfResultSucceed = false
+        def downloadCudaCoredumpSucceed = false
 
         pipeline.stage('Submit Test Result') {
             sh "mkdir -p ${stageName}"
@@ -157,8 +158,17 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
                 downloadPerfResultSucceed = Utils.exec(pipeline, script: scpFromRemoteCmd(remote, scpSources, "${stageName}/"), returnStatus: true, numRetries: 3) == 0
             }
 
-            echo "hasTimeoutTest: ${hasTimeoutTest}, downloadResultSucceed: ${downloadResultSucceed}, downloadPerfResultSucceed: ${downloadPerfResultSucceed}"
-            if (hasTimeoutTest || downloadResultSucceed || downloadPerfResultSucceed) {
+            // Download CUDA coredumps captured for GPU exceptions.
+            def coredumpFilePath = "/home/svc_tensorrt/bloom/scripts/${nodeName}/cuda_coredump_*.nvcudmp"
+            downloadCudaCoredumpSucceed = Utils.exec(
+                pipeline,
+                script: scpFromRemoteCmd(remote, coredumpFilePath, "${stageName}/"),
+                returnStatus: true,
+                numRetries: 3
+            ) == 0
+
+            echo "hasTimeoutTest: ${hasTimeoutTest}, downloadResultSucceed: ${downloadResultSucceed}, downloadPerfResultSucceed: ${downloadPerfResultSucceed}, downloadCudaCoredumpSucceed: ${downloadCudaCoredumpSucceed}"
+            if (hasTimeoutTest || downloadResultSucceed || downloadPerfResultSucceed || downloadCudaCoredumpSucceed) {
                 sh "ls -al ${stageName}/"
                 echo "Upload test results."
                 sh "tar -czvf results-${stageName}.tar.gz ${stageName}/"
@@ -168,7 +178,7 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
                     "${UPLOAD_PATH}/test-results/"
                 )
             } else {
-                println("No results xml to submit")
+                println("No results or debug artifacts to submit")
             }
         }
 
@@ -1073,6 +1083,11 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 envVarNames.each { varName ->
                     envVarsToExport[varName] = env."${varName}"
                 }
+                // Keep the coredump small enough to archive while preserving the failing kernel location.
+                envVarsToExport['CUDA_ENABLE_COREDUMP_ON_EXCEPTION'] = '1'
+                envVarsToExport['CUDA_ENABLE_CPU_COREDUMP_ON_EXCEPTION'] = '0'
+                envVarsToExport['CUDA_ENABLE_LIGHTWEIGHT_COREDUMP'] = '1'
+                envVarsToExport['CUDA_COREDUMP_FILE'] = "${jobWorkspace}/cuda_coredump_%h_%p.nvcudmp"
 
                 def srunArgs = [
                     "--container-name=multi_node_test-\${SLURM_JOB_ID}",

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -303,7 +303,6 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_bf16[latency] SKIP (https:/
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_tp4] SKIP (https://nvbugs/6018043)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_pp4_mtp] SKIP (https://nvbugs/6018046)
 test_fmha.py::test_fmha SKIP (https://nvbugs/6018058)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp] SKIP (https://nvbugs/6029882)
 accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_accuracy[bf16-4-attn_dp_off-trtllm] SKIP (https://nvbugs/5919796)
 accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_accuracy[fp8-4-attn_dp_off-trtllm] SKIP (https://nvbugs/6058066)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp4_v2_2_nodes_grace_blackwell-r1_fp4_v2_tep8_mtp3] SKIP (https://nvbugs/5997092)


### PR DESCRIPTION
## Summary
- enable lightweight CUDA coredumps for Slurm-based L0 test jobs
- write coredumps into the per-stage job workspace and pull them into the existing stage artifact tarball
- disable CPU coredumps so CI keeps the GPU dump needed to identify the failing kernel without archiving a much larger host dump

## Test plan
- pre-commit run --files jenkins/L0_Test.groovy
- /bot run --stage-list "GB200-8_GPUs-2_Nodes-PyTorch-2"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and download of CUDA coredump artifacts to improve GPU exception debugging and troubleshooting.
  * Enabled lightweight CUDA coredumps in job environment configuration for enhanced diagnostic data collection.

* **Improvements**
  * Extended logging messages when debug artifacts are unavailable, providing clearer visibility into missing diagnostic data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->