### PR TITLE
[TRTLLM-11695][feat] Add per-model VisualGen example scripts, shared configs, and per-model defaults

### DIFF
--- a/examples/visual_gen/README.md
+++ b/examples/visual_gen/README.md
@@ -4,6 +4,32 @@ Quick reference for running visual generation models.
 Please refer to [the VisualGen doc](https://nvidia.github.io/TensorRT-LLM/models/visual-generation.html)
 about the details of the feature.
 
+## Directory Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| [`models/`](models/) | Per-model example scripts — slim API examples (~40 lines) that focus on model-specific request construction and output processing |
+| [`configs/`](configs/) | YAML configs shared by offline examples (`--extra_visual_gen_options`) and `trtllm-serve` |
+| [`serve/`](serve/) | `trtllm-serve` usage, benchmarking, and client examples |
+
+## Quick Start
+
+[`quickstart_example.py`](quickstart_example.py) — generate a video in ~30 lines (Wan T2V, 1 GPU).
+
+## Per-Model Examples
+
+Each script under `models/` demonstrates a single model with the VisualGen API.
+Engine config (quantization, parallelism, TeaCache, etc.) is an optional YAML
+file passed via `--extra_visual_gen_options` — the same flag that `trtllm-serve` uses.
+
+```bash
+# Default: 1 GPU, model defaults
+python models/wan_t2v.py
+
+# With a shared config for NVFP4 quantization
+python models/wan_t2v.py --extra_visual_gen_options configs/wan2.2-t2v-fp4-1gpu.yaml
+```
+
 ## Prerequisites
 
 ```bash

--- a/examples/visual_gen/README.md
+++ b/examples/visual_gen/README.md
@@ -35,7 +35,7 @@ python models/wan_t2v.py --extra_visual_gen_options configs/wan2.2-t2v-fp4-1gpu.
 ```bash
 # Install dependencies (from repository root)
 pip install -r requirements-dev.txt
-pip install git+https://github.com/huggingface/diffusers.git
+pip install "diffusers>=0.37.0"
 ```
 
 

--- a/examples/visual_gen/configs/wan2.2-t2v-fp4-1gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp4-1gpu.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1-GPU Wan 2.2 T2V with NVFP4 dynamic quantization.
+# Shared by offline examples (--extra_visual_gen_options) and trtllm-serve.
+quant_config:
+  quant_algo: NVFP4
+  dynamic: true
+attention:
+  backend: VANILLA
+parallel:
+  dit_cfg_size: 1
+  dit_ulysses_size: 1
+  enable_parallel_vae: true
+teacache:
+  enable_teacache: false
+cuda_graph:
+  enable_cuda_graph: false

--- a/examples/visual_gen/configs/wan2.2-t2v-fp4-4gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp4-4gpu.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 4-GPU Wan 2.2 T2V with NVFP4 dynamic quantization.
+# Shared by offline examples (--extra_visual_gen_options) and trtllm-serve.
+quant_config:
+  quant_algo: NVFP4
+  dynamic: true
+attention:
+  backend: VANILLA
+parallel:
+  dit_cfg_size: 2
+  dit_ulysses_size: 2
+  enable_parallel_vae: true
+teacache:
+  enable_teacache: false
+cuda_graph:
+  enable_cuda_graph: false

--- a/examples/visual_gen/configs/wan2.2-t2v-fp8-8gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp8-8gpu.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 8-GPU Wan 2.2 T2V with FP8 blockwise dynamic quantization.
+# Shared by offline examples (--extra_visual_gen_options) and trtllm-serve.
+quant_config:
+  quant_algo: FP8_BLOCK_SCALES
+  dynamic: true
+attention:
+  backend: VANILLA
+parallel:
+  dit_cfg_size: 2
+  dit_ulysses_size: 4
+  enable_parallel_vae: true
+teacache:
+  enable_teacache: false
+cuda_graph:
+  enable_cuda_graph: false

--- a/examples/visual_gen/models/wan_t2v.py
+++ b/examples/visual_gen/models/wan_t2v.py
@@ -43,7 +43,7 @@ def main():
     parser.add_argument(
         "--output_path",
         type=str,
-        default="wan_t2v_output.mp4",
+        default="wan_t2v_output.avi",
         help="Path to save the output video",
     )
     args = parser.parse_args()

--- a/examples/visual_gen/models/wan_t2v.py
+++ b/examples/visual_gen/models/wan_t2v.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wan Text-to-Video generation.
+
+Usage:
+    python wan_t2v.py
+    python wan_t2v.py --extra_visual_gen_options ../configs/wan2.2-t2v-fp4-1gpu.yaml
+"""
+
+import argparse
+
+from tensorrt_llm import VisualGen, VisualGenArgs
+from tensorrt_llm.serve.media_storage import MediaStorage
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Wan Text-to-Video example")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+        help="Model path or HuggingFace Hub ID",
+    )
+    parser.add_argument(
+        "--extra_visual_gen_options",
+        type=str,
+        default=None,
+        help="Path to YAML config (same as trtllm-serve --extra_visual_gen_options)",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        default="wan_t2v_output.mp4",
+        help="Path to save the output video",
+    )
+    args = parser.parse_args()
+
+    # Engine config from shared YAML (optional); model-specific defaults apply otherwise.
+    extra_args = (
+        VisualGenArgs.from_yaml(args.extra_visual_gen_options)
+        if args.extra_visual_gen_options
+        else None
+    )
+    visual_gen = VisualGen(model=args.model, args=extra_args)
+
+    # --- Model-specific: T2V request construction ---
+    # Query per-model defaults (resolution, steps, guidance, seed, etc.).
+    params = visual_gen.default_params
+
+    output = visual_gen.generate(
+        inputs="A cat playing piano in a sunny room",
+        params=params,
+    )
+
+    # --- Model-specific: video output ---
+    MediaStorage.save_video(output.video, args.output_path, frame_rate=params.frame_rate)
+    print(f"Saved: {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/visual_gen/serve/README.md
+++ b/examples/visual_gen/serve/README.md
@@ -21,7 +21,7 @@ Before running these examples, ensure you have:
 1. **Install modules**: Install required dependencies before running examples:
 
    ```bash
-   pip install git+https://github.com/huggingface/diffusers.git
+   pip install "diffusers>=0.37.0"
    ```
 
    **Optional**: For better video compression (H.264/MP4), install [ffmpeg](https://ffmpeg.org/):

--- a/examples/visual_gen/serve/benchmark_visual_gen.sh
+++ b/examples/visual_gen/serve/benchmark_visual_gen.sh
@@ -16,7 +16,7 @@
 #   ./benchmark_visual_gen.sh
 #
 # Requirements:
-#   pip install git+https://github.com/huggingface/diffusers.git
+#   pip install "diffusers>=0.37.0"
 #
 # Optional (for MP4/H.264 video output):
 #   apt-get install ffmpeg   # or: conda install ffmpeg

--- a/tensorrt_llm/_torch/visual_gen/executor.py
+++ b/tensorrt_llm/_torch/visual_gen/executor.py
@@ -79,7 +79,7 @@ _TYPE_MAP = {
 
 # Generation config fields that pipelines declare defaults for.
 # If a user sets one of these but the pipeline doesn't declare it in
-# DEFAULT_GENERATION_PARAMS, the value will be silently ignored.
+# default_generation_params, the value will be silently ignored.
 # Conditioning inputs (image, negative_prompt, mask, image_cond_strength)
 # are excluded — they are validated at runtime by the pipeline's infer().
 _GENERATION_CONFIG_FIELDS = frozenset(
@@ -186,8 +186,8 @@ class DiffusionExecutor:
                     request_id=-1,
                     output={
                         "status": "READY",
-                        "default_generation_params": self.pipeline.DEFAULT_GENERATION_PARAMS,
-                        "extra_param_specs": self.pipeline.EXTRA_PARAM_SPECS,
+                        "default_generation_params": self.pipeline.default_generation_params,
+                        "extra_param_specs": self.pipeline.extra_param_specs,
                     },
                 )
             )
@@ -222,12 +222,12 @@ class DiffusionExecutor:
         and extra_param defaults (from ``extra_param_specs``).
         """
         # Universal field defaults
-        for field_name, default_value in self.pipeline.DEFAULT_GENERATION_PARAMS.items():
+        for field_name, default_value in self.pipeline.default_generation_params.items():
             if hasattr(req, field_name) and getattr(req, field_name) is None:
                 setattr(req, field_name, default_value)
 
         # Extra param defaults — fill all declared keys so infer() can use direct access
-        specs = self.pipeline.EXTRA_PARAM_SPECS
+        specs = self.pipeline.extra_param_specs
         if specs:
             if req.extra_params is None:
                 req.extra_params = {}
@@ -243,7 +243,7 @@ class DiffusionExecutor:
         Raises ``VisualGenParamsError`` on:
         - Unknown ``extra_params`` keys
         - Universal fields (e.g. ``num_frames``) set by the user but not
-          declared in the pipeline's ``DEFAULT_GENERATION_PARAMS``
+          declared in the pipeline's ``default_generation_params``
         - Type mismatches for ``extra_params`` values
         - Out-of-range ``extra_params`` values
         """
@@ -253,8 +253,8 @@ class DiffusionExecutor:
 
         errors: list[str] = []
         pipeline_name = self.pipeline.__class__.__name__
-        declared_defaults = self.pipeline.DEFAULT_GENERATION_PARAMS
-        specs = self.pipeline.EXTRA_PARAM_SPECS
+        declared_defaults = self.pipeline.default_generation_params
+        specs = self.pipeline.extra_param_specs
 
         # --- unknown extra_params keys ---
         if req.extra_params:
@@ -267,7 +267,7 @@ class DiffusionExecutor:
 
         # --- unsupported universal fields ---
         # Check generation config fields the user explicitly set (not None)
-        # that the pipeline never declared in DEFAULT_GENERATION_PARAMS.
+        # that the pipeline never declared in default_generation_params.
         # Conditioning inputs (image, negative_prompt, mask) are excluded —
         # they are validated at runtime by the pipeline's infer().
         for field_name in _GENERATION_CONFIG_FIELDS:
@@ -275,7 +275,7 @@ class DiffusionExecutor:
             if value is not None and field_name not in declared_defaults:
                 errors.append(
                     f"Parameter '{field_name}' is set but {pipeline_name} does "
-                    f"not use it (not in DEFAULT_GENERATION_PARAMS). "
+                    f"not use it (not in default_generation_params). "
                     f"It will be silently ignored."
                 )
 

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -229,13 +229,15 @@ class FluxPipeline(BasePipeline):
             # Enable TeaCache with FLUX.1-specific polynomial coefficients
             self._setup_teacache(self.transformer, FLUX_TEACACHE_COEFFICIENTS)
 
-    DEFAULT_GENERATION_PARAMS = {
-        "height": 1024,
-        "width": 1024,
-        "num_inference_steps": 50,
-        "guidance_scale": 3.5,
-        "max_sequence_length": 512,
-    }
+    @property
+    def default_generation_params(self):
+        return {
+            "height": 1024,
+            "width": 1024,
+            "num_inference_steps": 50,
+            "guidance_scale": 3.5,
+            "max_sequence_length": 512,
+        }
 
     def infer(self, req):
         """Run inference from DiffusionRequest."""

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -322,13 +322,15 @@ class Flux2Pipeline(BasePipeline):
             # Enable TeaCache with FLUX.2-specific polynomial coefficients
             self._setup_teacache(self.transformer, FLUX2_TEACACHE_COEFFICIENTS)
 
-    DEFAULT_GENERATION_PARAMS = {
-        "height": 1024,
-        "width": 1024,
-        "num_inference_steps": 50,
-        "guidance_scale": 3.5,
-        "max_sequence_length": 512,
-    }
+    @property
+    def default_generation_params(self):
+        return {
+            "height": 1024,
+            "width": 1024,
+            "num_inference_steps": 50,
+            "guidance_scale": 3.5,
+            "max_sequence_length": 512,
+        }
 
     def infer(self, req):
         """Run inference from DiffusionRequest."""

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -1040,59 +1040,63 @@ class LTX2Pipeline(BasePipeline):
     # Inference
     # ------------------------------------------------------------------
 
-    DEFAULT_GENERATION_PARAMS = {
-        "height": 512,
-        "width": 768,
-        "num_inference_steps": 40,
-        "guidance_scale": 4.0,
-        "max_sequence_length": 1024,
-        "num_frames": 121,
-        "frame_rate": 24.0,
-        "image_cond_strength": 1.0,
-    }
+    @property
+    def default_generation_params(self):
+        return {
+            "height": 512,
+            "width": 768,
+            "num_inference_steps": 40,
+            "guidance_scale": 4.0,
+            "max_sequence_length": 1024,
+            "num_frames": 121,
+            "frame_rate": 24.0,
+            "image_cond_strength": 1.0,
+        }
 
-    EXTRA_PARAM_SPECS = {
-        "output_type": ExtraParamSchema(
-            type="str",
-            default="pt",
-            description="Output type: 'pt' for PyTorch tensors, 'pil' for PIL images.",
-        ),
-        "guidance_rescale": ExtraParamSchema(
-            type="float",
-            default=0.0,
-            description="Guidance rescale factor to prevent overexposure.",
-        ),
-        "stg_scale": ExtraParamSchema(
-            type="float",
-            default=0.0,
-            description="Spatiotemporal guidance scale for multi-modal guidance.",
-        ),
-        "stg_blocks": ExtraParamSchema(
-            type="list",
-            description="Transformer block indices for STG perturbation.",
-        ),
-        "modality_scale": ExtraParamSchema(
-            type="float",
-            default=1.0,
-            description="Modality guidance scale for multi-modal generation.",
-        ),
-        "rescale_scale": ExtraParamSchema(
-            type="float",
-            default=0.0,
-            range=(0.0, 1.0),
-            description="CFG rescale factor for multi-modal guidance.",
-        ),
-        "guidance_skip_step": ExtraParamSchema(
-            type="int",
-            default=0,
-            description="Number of initial denoising steps to skip guidance.",
-        ),
-        "enhance_prompt": ExtraParamSchema(
-            type="bool",
-            default=False,
-            description="Use Gemma3 LLM to enhance the prompt before generation.",
-        ),
-    }
+    @property
+    def extra_param_specs(self):
+        return {
+            "output_type": ExtraParamSchema(
+                type="str",
+                default="pt",
+                description="Output type: 'pt' for PyTorch tensors, 'pil' for PIL images.",
+            ),
+            "guidance_rescale": ExtraParamSchema(
+                type="float",
+                default=0.0,
+                description="Guidance rescale factor to prevent overexposure.",
+            ),
+            "stg_scale": ExtraParamSchema(
+                type="float",
+                default=0.0,
+                description="Spatiotemporal guidance scale for multi-modal guidance.",
+            ),
+            "stg_blocks": ExtraParamSchema(
+                type="list",
+                description="Transformer block indices for STG perturbation.",
+            ),
+            "modality_scale": ExtraParamSchema(
+                type="float",
+                default=1.0,
+                description="Modality guidance scale for multi-modal generation.",
+            ),
+            "rescale_scale": ExtraParamSchema(
+                type="float",
+                default=0.0,
+                range=(0.0, 1.0),
+                description="CFG rescale factor for multi-modal guidance.",
+            ),
+            "guidance_skip_step": ExtraParamSchema(
+                type="int",
+                default=0,
+                description="Number of initial denoising steps to skip guidance.",
+            ),
+            "enhance_prompt": ExtraParamSchema(
+                type="bool",
+                default=False,
+                description="Use Gemma3 LLM to enhance the prompt before generation.",
+            ),
+        }
 
     def infer(self, req):
         """Run inference with request parameters."""

--- a/tensorrt_llm/_torch/visual_gen/models/wan/defaults.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/defaults.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-model default generation parameters for Wan pipelines.
+
+Deduction cascade: model version (2.1/2.2) → model size → model name.
+Shared by WanPipeline (T2V) and WanImageToVideoPipeline (I2V).
+"""
+
+from typing import Dict
+
+from tensorrt_llm._torch.visual_gen.pipeline import ExtraParamSchema
+
+# ---------------------------------------------------------------------------
+# Constant tables
+# ---------------------------------------------------------------------------
+
+_WAN21_480P_PARAMS = {
+    "height": 480,
+    "width": 832,
+    "num_inference_steps": 50,
+    "guidance_scale": 5.0,
+    "max_sequence_length": 512,
+    "num_frames": 81,
+    "frame_rate": 16.0,
+}
+
+_WAN21_720P_PARAMS = {
+    "height": 720,
+    "width": 1280,
+    "num_inference_steps": 50,
+    "guidance_scale": 5.0,
+    "max_sequence_length": 512,
+    "num_frames": 81,
+    "frame_rate": 16.0,
+}
+
+_WAN22_PARAMS = {
+    "height": 720,
+    "width": 1280,
+    "num_inference_steps": 40,
+    "guidance_scale": 4.0,
+    "max_sequence_length": 512,
+    "num_frames": 81,
+    "frame_rate": 16.0,
+}
+
+_WAN22_EXTRA_SPECS: Dict[str, ExtraParamSchema] = {
+    "guidance_scale_2": ExtraParamSchema(
+        type="float",
+        default=None,
+        description="Second guidance scale for Wan 2.2 two-stage denoising.",
+    ),
+    "boundary_ratio": ExtraParamSchema(
+        type="float",
+        default=None,
+        range=(0.0, 1.0),
+        description="Timestep boundary ratio for switching guidance scales (Wan 2.2).",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Deduction helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_480p_model(name_or_path: str, num_heads: int, is_wan22: bool) -> bool:
+    """Deduce whether the model's native resolution is 480p.
+
+    Cascade:
+    1. Wan 2.2 models are always 720p.
+    2. Small models (≤12 heads, e.g. 1.3B) are 480p.
+    3. Check model name for explicit "480p" (e.g. Wan2.1-I2V-14B-480P).
+    4. Default to 720p (14B T2V, 14B-720P I2V).
+    """
+    if is_wan22:
+        return False
+    if num_heads <= 12:
+        return True
+    if "480p" in name_or_path.lower():
+        return True
+    return False
+
+
+def get_wan_default_params(
+    is_wan22: bool,
+    name_or_path: str,
+    num_heads: int,
+    *,
+    include_i2v: bool = False,
+) -> dict:
+    """Return the default generation params dict for a Wan model.
+
+    Args:
+        is_wan22: Whether this is a Wan 2.2 model (has boundary_ratio).
+        name_or_path: Checkpoint path or HF model ID (_name_or_path).
+        num_heads: Number of attention heads from transformer config.
+        include_i2v: If True, add I2V-specific defaults (image_cond_strength).
+    """
+    if is_wan22:
+        params = dict(_WAN22_PARAMS)
+    elif _is_480p_model(name_or_path, num_heads, is_wan22):
+        params = dict(_WAN21_480P_PARAMS)
+    else:
+        params = dict(_WAN21_720P_PARAMS)
+
+    if include_i2v:
+        params["image_cond_strength"] = 1.0
+
+    return params
+
+
+def get_wan_extra_param_specs(is_wan22: bool) -> Dict[str, ExtraParamSchema]:
+    """Return extra_param_specs for a Wan model.
+
+    Wan 2.2 exposes guidance_scale_2 and boundary_ratio.
+    Wan 2.1 has no model-specific extra params.
+    """
+    if is_wan22:
+        return dict(_WAN22_EXTRA_SPECS)
+    return {}

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -9,8 +9,12 @@ from diffusers.video_processor import VideoProcessor
 from transformers import AutoTokenizer, UMT5EncoderModel
 
 from tensorrt_llm._torch.visual_gen.config import PipelineComponent
+from tensorrt_llm._torch.visual_gen.models.wan.defaults import (
+    get_wan_default_params,
+    get_wan_extra_param_specs,
+)
 from tensorrt_llm._torch.visual_gen.output import MediaOutput
-from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline, ExtraParamSchema
+from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
 from tensorrt_llm._torch.visual_gen.pipeline_registry import register_pipeline
 from tensorrt_llm._torch.visual_gen.teacache import ExtractorConfig, register_extractor_from_config
 from tensorrt_llm._torch.visual_gen.utils import postprocess_video_tensor
@@ -301,29 +305,17 @@ class WanPipeline(BasePipeline):
                 max_sequence_length=512,
             )
 
-    DEFAULT_GENERATION_PARAMS = {
-        "height": 480,
-        "width": 832,
-        "num_inference_steps": 50,
-        "guidance_scale": 5.0,
-        "max_sequence_length": 512,
-        "num_frames": 81,
-        "frame_rate": 24.0,
-    }
+    @property
+    def default_generation_params(self):
+        return get_wan_default_params(
+            is_wan22=self.is_wan22,
+            name_or_path=getattr(self.config, "_name_or_path", ""),
+            num_heads=getattr(self.config, "num_attention_heads", 40),
+        )
 
-    EXTRA_PARAM_SPECS = {
-        "guidance_scale_2": ExtraParamSchema(
-            type="float",
-            default=None,
-            description="Second guidance scale for Wan 2.2 two-stage denoising.",
-        ),
-        "boundary_ratio": ExtraParamSchema(
-            type="float",
-            default=None,
-            range=(0.0, 1.0),
-            description="Timestep boundary ratio for switching guidance scales (Wan 2.2).",
-        ),
-    }
+    @property
+    def extra_param_specs(self):
+        return get_wan_extra_param_specs(self.is_wan22)
 
     def infer(self, req):
         """Run inference with request parameters."""
@@ -336,8 +328,8 @@ class WanPipeline(BasePipeline):
             num_frames=req.num_frames,
             num_inference_steps=req.num_inference_steps,
             guidance_scale=req.guidance_scale,
-            guidance_scale_2=extra["guidance_scale_2"],
-            boundary_ratio=extra["boundary_ratio"],
+            guidance_scale_2=extra.get("guidance_scale_2"),
+            boundary_ratio=extra.get("boundary_ratio"),
             seed=req.seed,
             max_sequence_length=req.max_sequence_length,
         )

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -12,6 +12,10 @@ from diffusers.video_processor import VideoProcessor
 from transformers import AutoTokenizer, CLIPImageProcessor, CLIPVisionModel, UMT5EncoderModel
 
 from tensorrt_llm._torch.visual_gen.config import PipelineComponent
+from tensorrt_llm._torch.visual_gen.models.wan.defaults import (
+    get_wan_default_params,
+    get_wan_extra_param_specs,
+)
 from tensorrt_llm._torch.visual_gen.output import MediaOutput
 from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline, ExtraParamSchema
 from tensorrt_llm._torch.visual_gen.pipeline_registry import register_pipeline
@@ -363,35 +367,24 @@ class WanImageToVideoPipeline(BasePipeline):
                 max_sequence_length=512,
             )
 
-    DEFAULT_GENERATION_PARAMS = {
-        "height": 480,
-        "width": 832,
-        "num_inference_steps": 50,
-        "guidance_scale": 5.0,
-        "max_sequence_length": 512,
-        "num_frames": 81,
-        "frame_rate": 24.0,
-        "image_cond_strength": 1.0,
-    }
+    @property
+    def default_generation_params(self):
+        return get_wan_default_params(
+            is_wan22=self.is_wan22,
+            name_or_path=getattr(self.config, "_name_or_path", ""),
+            num_heads=getattr(self.config, "num_attention_heads", 40),
+            include_i2v=True,
+        )
 
-    EXTRA_PARAM_SPECS = {
-        "guidance_scale_2": ExtraParamSchema(
-            type="float",
-            default=None,
-            description="Second guidance scale for Wan 2.2 two-stage denoising.",
-        ),
-        "boundary_ratio": ExtraParamSchema(
-            type="float",
-            default=None,
-            range=(0.0, 1.0),
-            description="Timestep boundary ratio for switching guidance scales (Wan 2.2).",
-        ),
-        "last_image": ExtraParamSchema(
+    @property
+    def extra_param_specs(self):
+        specs = get_wan_extra_param_specs(self.is_wan22)
+        specs["last_image"] = ExtraParamSchema(
             type="str",
             default=None,
             description="Last frame path for video interpolation (Wan I2V).",
-        ),
-    }
+        )
+        return specs
 
     def infer(self, req):
         """Run inference with request parameters."""
@@ -401,7 +394,7 @@ class WanImageToVideoPipeline(BasePipeline):
 
         image = req.image[0] if isinstance(req.image, list) else req.image
         extra = req.extra_params or {}
-        last_image = extra["last_image"]
+        last_image = extra.get("last_image")
 
         if last_image is not None and isinstance(last_image, list):
             last_image = last_image[0] if last_image else None
@@ -415,8 +408,8 @@ class WanImageToVideoPipeline(BasePipeline):
             num_frames=req.num_frames,
             num_inference_steps=req.num_inference_steps,
             guidance_scale=req.guidance_scale,
-            guidance_scale_2=extra["guidance_scale_2"],
-            boundary_ratio=extra["boundary_ratio"],
+            guidance_scale_2=extra.get("guidance_scale_2"),
+            boundary_ratio=extra.get("boundary_ratio"),
             seed=req.seed,
             max_sequence_length=req.max_sequence_length,
             last_image=last_image,

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -237,15 +237,24 @@ class BasePipeline(nn.Module):
         """Return the VAE adapter class for the pipeline."""
         return None
 
-    #: Model-specific extra parameter specs. Subclasses override to declare
-    #: which ``extra_params`` keys they accept and their metadata.
-    #: Maps parameter names to ``ExtraParamSchema`` instances.
-    EXTRA_PARAM_SPECS: Dict[str, ExtraParamSchema] = {}
+    @property
+    def extra_param_specs(self) -> Dict[str, ExtraParamSchema]:
+        """Model-specific extra parameter specs.
 
-    #: Model-specific defaults for ``None`` fields in ``VisualGenParams``.
-    #: Keys should match ``DiffusionRequest`` field names. The executor
-    #: merges these into the request before calling ``infer()``.
-    DEFAULT_GENERATION_PARAMS: dict = {}
+        Subclasses override to declare which ``extra_params`` keys they
+        accept and their metadata.  Maps parameter names to
+        ``ExtraParamSchema`` instances.
+        """
+        return {}
+
+    @property
+    def default_generation_params(self) -> dict:
+        """Model-specific defaults for ``None`` fields in ``VisualGenParams``.
+
+        Keys should match ``DiffusionRequest`` field names.  The executor
+        merges these into the request before calling ``infer()``.
+        """
+        return {}
 
     def infer(self, req: Any):
         raise NotImplementedError

--- a/tests/integration/defs/examples/test_visual_gen.py
+++ b/tests/integration/defs/examples/test_visual_gen.py
@@ -763,3 +763,57 @@ def test_visual_gen_quickstart(_visual_gen_deps, llm_root, llm_venv):
 
     output_path = os.path.join(llm_venv.get_working_directory(), "output.avi")
     assert os.path.isfile(output_path), f"Quickstart did not produce output.avi at {output_path}"
+
+
+# =============================================================================
+# Core example tests — run per-model scripts from examples/visual_gen/models/
+# with shared YAML configs from examples/visual_gen/configs/.
+# =============================================================================
+
+
+def test_wan_t2v_example(_visual_gen_deps, llm_root, llm_venv):
+    """Run examples/visual_gen/models/wan_t2v.py with NVFP4 config end-to-end.
+
+    This is a core example test: it validates that the per-model example script
+    and the shared YAML config work together as documented in the README.
+    Uses the pre-quantized Wan 2.2 T2V A14B NVFP4 checkpoint.
+
+    NOTE: If a strict-duplicate test exists elsewhere (same model, same quant,
+    same resolution, same prompt, same script invocation), consider removing
+    it in favour of this one.  As of this writing, the closest test is
+    test_vbench_dimension_score_wan22_a14b_nvfp4 which uses the same checkpoint
+    but invokes the *old* visual_gen_wan_t2v.py script (not models/wan_t2v.py)
+    with different resolution/prompt and additionally runs VBench scoring.
+    Not a strict duplicate.
+    """
+    scratch_space = conftest.llm_models_root()
+    model_path = os.path.join(scratch_space, WAN22_A14B_NVFP4_MODEL_SUBPATH)
+    assert os.path.isdir(model_path), (
+        f"Model not found: {model_path} "
+        f"(set LLM_MODELS_ROOT or place {WAN22_A14B_NVFP4_MODEL_SUBPATH} under models root)"
+    )
+
+    out_dir = os.path.join(llm_venv.get_working_directory(), "visual_gen_output", "wan_t2v_example")
+    os.makedirs(out_dir, exist_ok=True)
+    output_path = os.path.join(out_dir, "wan_t2v_output.mp4")
+
+    script_path = os.path.join(llm_root, "examples", "visual_gen", "models", "wan_t2v.py")
+    config_path = os.path.join(
+        llm_root, "examples", "visual_gen", "configs", "wan2.2-t2v-fp4-1gpu.yaml"
+    )
+    assert os.path.isfile(script_path), f"Example script not found: {script_path}"
+    assert os.path.isfile(config_path), f"Config not found: {config_path}"
+
+    venv_check_call(
+        llm_venv,
+        [
+            script_path,
+            "--model",
+            model_path,
+            "--extra_visual_gen_options",
+            config_path,
+            "--output_path",
+            output_path,
+        ],
+    )
+    assert os.path.isfile(output_path), f"Example did not produce output at {output_path}"

--- a/tests/integration/defs/examples/test_visual_gen.py
+++ b/tests/integration/defs/examples/test_visual_gen.py
@@ -159,7 +159,7 @@ AESTHETIC_PREDICTOR_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", 
 def _visual_gen_deps(llm_venv):
     """Install av + diffusers + ffmpeg once per session (shared by all video-gen fixtures)."""
     llm_venv.run_cmd(["-m", "pip", "install", "av"])
-    llm_venv.run_cmd(["-m", "pip", "install", "git+https://github.com/huggingface/diffusers.git"])
+    llm_venv.run_cmd(["-m", "pip", "install", "diffusers>=0.37.0"])
     # Install ffmpeg system package required by MediaStorage.save_video for MP4 encoding
     check_call(["apt-get", "update", "-y"], shell=False)
     check_call(["apt-get", "install", "-y", "ffmpeg"], shell=False)

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -186,6 +186,7 @@ l0_b200:
   - unittest/_torch/visual_gen/test_ltx2_transformer.py
   - unittest/_torch/visual_gen/test_ltx2_attention.py
   - unittest/_torch/visual_gen/test_ltx2_pipeline.py
+  - examples/test_visual_gen.py::test_wan_t2v_example
   # - examples/test_visual_gen.py
   # ------------- Host perf module regression tests (6 representative scenarios) ---------------
   - perf/host_perf/test_module_scheduler.py::test_scheduler_production[production_gen_only_bs8]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -297,6 +297,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTEDSL-mtp_nextn=2-ep4-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-low_precision_combine=True-torch_compile=False]
   - accuracy/test_llm_api_pytorch.py::TestLlama3_3_70BInstruct::test_fp4_tp2pp2[torch_compile=False-enable_gemm_allreduce_fusion=False]
   - examples/test_visual_gen.py::test_visual_gen_quickstart
+  - examples/test_visual_gen.py::test_wan_t2v_example
   - examples/test_visual_gen.py::test_vbench_dimension_score_wan
   - examples/test_visual_gen.py::test_vbench_dimension_score_wan22_a14b_fp8
   - examples/test_visual_gen.py::test_vbench_dimension_score_wan22_a14b_nvfp4

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -271,7 +271,6 @@ accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=2-
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_no_kv_cache_reuse[quant_dtype=none-mtp_nextn=2-fp8kv=False-attention_dp=True-cuda_graph=True-overlap_scheduler=True] SKIP (https://nvbugs/5955773)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[baseline_mtp1] SKIP (https://nvbugs/5955792)
 full:RTXPro6000D/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=0-ep4-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-low_precision_combine=False-torch_compile=True] SKIP (https://nvbugs/5961814)
-examples/test_visual_gen.py::test_visual_gen_quickstart SKIP (https://nvbugs/5963896)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_2_model_mtp SKIP (https://nvbugs/5966585)
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_vswa_reuse_4gpus[one_model] SKIP (https://nvbugs/5927636)
 full:RTXPro6000D/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=2-ep4-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-low_precision_combine=False-torch_compile=False] SKIP (https://nvbugs/5961814)

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_params.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_params.py
@@ -18,6 +18,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+
+def _wan_mock(is_wan22=False, name_or_path="", num_heads=12):
+    """Create a mock with attributes needed by WanPipeline/WanI2V properties."""
+    mock = MagicMock()
+    mock.is_wan22 = is_wan22
+    config = MagicMock()
+    config._name_or_path = name_or_path
+    config.num_attention_heads = num_heads
+    mock.config = config
+    return mock
+
+
 # =============================================================================
 # VisualGenParams — Pydantic validation
 # =============================================================================
@@ -150,27 +162,39 @@ class TestExtraParamSchema:
 
 
 # =============================================================================
-# Pipeline DEFAULT_GENERATION_PARAMS and EXTRA_PARAM_SPECS
+# Pipeline default_generation_params and extra_param_specs
 # =============================================================================
 
 
 class TestPipelineDefaults:
     """Each pipeline declares correct default generation params."""
 
-    def test_wan_defaults(self):
+    def test_wan21_480p_defaults(self):
+        """Wan 2.1 small-model (≤12 heads) returns 480p defaults."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        d = WanPipeline.DEFAULT_GENERATION_PARAMS
+        d = WanPipeline.default_generation_params.fget(_wan_mock(is_wan22=False, num_heads=12))
         assert d["height"] == 480
         assert d["width"] == 832
         assert d["num_inference_steps"] == 50
         assert d["guidance_scale"] == 5.0
         assert d["num_frames"] == 81
 
+    def test_wan22_defaults(self):
+        """Wan 2.2 returns 720p defaults."""
+        from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
+
+        d = WanPipeline.default_generation_params.fget(_wan_mock(is_wan22=True, num_heads=40))
+        assert d["height"] == 720
+        assert d["width"] == 1280
+        assert d["num_inference_steps"] == 40
+        assert d["guidance_scale"] == 4.0
+        assert d["num_frames"] == 81
+
     def test_flux_defaults(self):
         from tensorrt_llm._torch.visual_gen.models.flux.pipeline_flux import FluxPipeline
 
-        d = FluxPipeline.DEFAULT_GENERATION_PARAMS
+        d = FluxPipeline.default_generation_params.fget(None)
         assert d["height"] == 1024
         assert d["width"] == 1024
         assert d["guidance_scale"] == 3.5
@@ -178,7 +202,7 @@ class TestPipelineDefaults:
     def test_ltx2_defaults(self):
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
 
-        d = LTX2Pipeline.DEFAULT_GENERATION_PARAMS
+        d = LTX2Pipeline.default_generation_params.fget(None)
         assert d["height"] == 512
         assert d["width"] == 768
         assert d["num_inference_steps"] == 40
@@ -189,28 +213,36 @@ class TestPipelineDefaults:
     def test_base_pipeline_empty_defaults(self):
         from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
 
-        assert BasePipeline.DEFAULT_GENERATION_PARAMS == {}
-        assert BasePipeline.EXTRA_PARAM_SPECS == {}
+        assert BasePipeline.default_generation_params.fget(None) == {}
+        assert BasePipeline.extra_param_specs.fget(None) == {}
 
 
 class TestPipelineExtraParamSpecs:
     """Each pipeline declares correct extra param specs."""
 
-    def test_wan_extra_specs(self):
+    def test_wan22_extra_specs(self):
+        """Wan 2.2 exposes guidance_scale_2 and boundary_ratio."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        specs = WanPipeline.EXTRA_PARAM_SPECS
+        specs = WanPipeline.extra_param_specs.fget(_wan_mock(is_wan22=True))
         assert "guidance_scale_2" in specs
         assert "boundary_ratio" in specs
         assert specs["guidance_scale_2"].type == "float"
         assert specs["boundary_ratio"].range == (0.0, 1.0)
+
+    def test_wan21_no_extra_specs(self):
+        """Wan 2.1 has no model-specific extra params."""
+        from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
+
+        specs = WanPipeline.extra_param_specs.fget(_wan_mock(is_wan22=False))
+        assert specs == {}
 
     def test_wan_i2v_extra_specs(self):
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan_i2v import (
             WanImageToVideoPipeline,
         )
 
-        specs = WanImageToVideoPipeline.EXTRA_PARAM_SPECS
+        specs = WanImageToVideoPipeline.extra_param_specs.fget(_wan_mock(is_wan22=True))
         assert "last_image" in specs
         assert "guidance_scale_2" in specs
         assert specs["last_image"].type == "str"
@@ -218,12 +250,12 @@ class TestPipelineExtraParamSpecs:
     def test_flux_no_extra_specs(self):
         from tensorrt_llm._torch.visual_gen.models.flux.pipeline_flux import FluxPipeline
 
-        assert FluxPipeline.EXTRA_PARAM_SPECS == {}
+        assert FluxPipeline.extra_param_specs.fget(None) == {}
 
     def test_ltx2_extra_specs(self):
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
 
-        specs = LTX2Pipeline.EXTRA_PARAM_SPECS
+        specs = LTX2Pipeline.extra_param_specs.fget(None)
         expected_keys = {
             "output_type",
             "guidance_rescale",
@@ -240,11 +272,12 @@ class TestPipelineExtraParamSpecs:
         assert specs["stg_blocks"].default is None
 
     def test_ltx2_extra_specs_attribute_access(self):
-        """Direct attribute-style access works: Pipeline.EXTRA_PARAM_SPECS['key']."""
+        """Direct attribute-style access works on the returned dict."""
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
 
-        assert LTX2Pipeline.EXTRA_PARAM_SPECS["modality_scale"].type == "float"
-        assert LTX2Pipeline.EXTRA_PARAM_SPECS["modality_scale"].default == 1.0
+        specs = LTX2Pipeline.extra_param_specs.fget(None)
+        assert specs["modality_scale"].type == "float"
+        assert specs["modality_scale"].default == 1.0
 
 
 # =============================================================================
@@ -255,12 +288,14 @@ class TestPipelineExtraParamSpecs:
 class TestDefaultMerging:
     """DiffusionExecutor._merge_defaults fills None fields correctly."""
 
-    def _make_mock_executor(self, pipeline_cls):
+    def _make_mock_executor(self, pipeline_cls, mock_self=None):
         """Create a mock DiffusionExecutor with the given pipeline class's specs."""
         executor = MagicMock()
         executor.pipeline = MagicMock()
-        executor.pipeline.DEFAULT_GENERATION_PARAMS = pipeline_cls.DEFAULT_GENERATION_PARAMS
-        executor.pipeline.EXTRA_PARAM_SPECS = pipeline_cls.EXTRA_PARAM_SPECS
+        executor.pipeline.default_generation_params = pipeline_cls.default_generation_params.fget(
+            mock_self
+        )
+        executor.pipeline.extra_param_specs = pipeline_cls.extra_param_specs.fget(mock_self)
         return executor
 
     def _make_request(self, **kwargs):
@@ -276,7 +311,7 @@ class TestDefaultMerging:
     def test_universal_defaults_merged(self):
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline)
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=False, num_heads=12))
         req = self._make_request()
         assert req.height is None
 
@@ -288,7 +323,7 @@ class TestDefaultMerging:
     def test_user_values_not_overwritten(self):
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline)
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=False, num_heads=12))
         req = self._make_request(height=1080, width=1920)
 
         self._merge(executor, req)
@@ -330,14 +365,15 @@ class TestDefaultMerging:
         assert req.extra_params is None  # Flux has no extra specs
 
     def test_all_declared_keys_present_after_merge(self):
-        """After merge, all EXTRA_PARAM_SPECS keys are in extra_params."""
+        """After merge, all extra_param_specs keys are in extra_params."""
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
 
         executor = self._make_mock_executor(LTX2Pipeline)
         req = self._make_request(extra_params={"stg_scale": 0.5})
 
         self._merge(executor, req)
-        for key in LTX2Pipeline.EXTRA_PARAM_SPECS:
+        ltx2_specs = LTX2Pipeline.extra_param_specs.fget(None)
+        for key in ltx2_specs:
             assert key in req.extra_params, f"Missing key: {key}"
 
 
@@ -353,7 +389,7 @@ class TestVisualGenDefaultParams:
     executor.extra_param_specs (populated from the READY signal).
     """
 
-    def _make_visual_gen(self, pipeline_cls):
+    def _make_visual_gen(self, pipeline_cls, mock_self=None):
         """Create VisualGen with mocked init and executor carrying pipeline metadata."""
         from tensorrt_llm.visual_gen import VisualGen
 
@@ -361,8 +397,10 @@ class TestVisualGenDefaultParams:
             vg = VisualGen.__new__(VisualGen)
             vg.executor = MagicMock()
             if pipeline_cls is not None:
-                vg.executor.default_generation_params = pipeline_cls.DEFAULT_GENERATION_PARAMS
-                vg.executor.extra_param_specs = pipeline_cls.EXTRA_PARAM_SPECS
+                vg.executor.default_generation_params = pipeline_cls.default_generation_params.fget(
+                    mock_self
+                )
+                vg.executor.extra_param_specs = pipeline_cls.extra_param_specs.fget(mock_self)
             else:
                 vg.executor.default_generation_params = {}
                 vg.executor.extra_param_specs = {}
@@ -383,16 +421,27 @@ class TestVisualGenDefaultParams:
         # None-default keys are present
         assert "stg_blocks" in params.extra_params
 
-    def test_wan_default_params(self):
+    def test_wan22_default_params(self):
+        """Wan 2.2 returns 720p defaults with guidance_scale_2/boundary_ratio."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        vg = self._make_visual_gen(WanPipeline)
+        vg = self._make_visual_gen(WanPipeline, _wan_mock(is_wan22=True))
         params = vg.default_params
-        assert params.height == 480
-        assert params.width == 832
+        assert params.height == 720
+        assert params.width == 1280
         assert params.extra_params is not None
         assert "guidance_scale_2" in params.extra_params
         assert "boundary_ratio" in params.extra_params
+
+    def test_wan21_default_params(self):
+        """Wan 2.1 small-model returns 480p defaults with no extra params."""
+        from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
+
+        vg = self._make_visual_gen(WanPipeline, _wan_mock(is_wan22=False, num_heads=12))
+        params = vg.default_params
+        assert params.height == 480
+        assert params.width == 832
+        assert params.extra_params is None
 
     def test_flux_default_params_no_extra(self):
         from tensorrt_llm._torch.visual_gen.models.flux.pipeline_flux import FluxPipeline
@@ -430,10 +479,10 @@ class TestVisualGenDefaultParams:
 
 
 class TestPipelineMetadataBridging:
-    """Verify DEFAULT_GENERATION_PARAMS and EXTRA_PARAM_SPECS survive
+    """Verify default_generation_params and extra_param_specs survive
     the pickle round-trip from DiffusionExecutor READY signal to the client."""
 
-    def _build_ready_response(self, pipeline_cls):
+    def _build_ready_response(self, pipeline_cls, mock_self=None):
         """Build a DiffusionResponse matching what DiffusionExecutor sends."""
         from tensorrt_llm._torch.visual_gen.executor import DiffusionResponse
 
@@ -441,8 +490,8 @@ class TestPipelineMetadataBridging:
             request_id=-1,
             output={
                 "status": "READY",
-                "default_generation_params": pipeline_cls.DEFAULT_GENERATION_PARAMS,
-                "extra_param_specs": pipeline_cls.EXTRA_PARAM_SPECS,
+                "default_generation_params": pipeline_cls.default_generation_params.fget(mock_self),
+                "extra_param_specs": pipeline_cls.extra_param_specs.fget(mock_self),
             },
         )
 
@@ -460,15 +509,16 @@ class TestPipelineMetadataBridging:
         resp = self._build_ready_response(LTX2Pipeline)
         restored = self._roundtrip(resp)
 
+        ltx2_defaults = LTX2Pipeline.default_generation_params.fget(None)
+        ltx2_specs = LTX2Pipeline.extra_param_specs.fget(None)
+
         assert isinstance(restored, DiffusionResponse)
         assert restored.request_id == -1
         payload = restored.output
         assert isinstance(payload, dict)
         assert payload["status"] == "READY"
-        assert payload["default_generation_params"] == LTX2Pipeline.DEFAULT_GENERATION_PARAMS
-        assert set(payload["extra_param_specs"].keys()) == set(
-            LTX2Pipeline.EXTRA_PARAM_SPECS.keys()
-        )
+        assert payload["default_generation_params"] == ltx2_defaults
+        assert set(payload["extra_param_specs"].keys()) == set(ltx2_specs.keys())
 
     def test_extra_param_schema_type_preserved(self):
         """ExtraParamSchema instances keep their type through pickle."""
@@ -492,7 +542,7 @@ class TestPipelineMetadataBridging:
         restored = self._roundtrip(resp)
 
         specs = restored.output["extra_param_specs"]
-        original = LTX2Pipeline.EXTRA_PARAM_SPECS
+        original = LTX2Pipeline.extra_param_specs.fget(None)
         for key in original:
             assert specs[key].type == original[key].type
             assert specs[key].default == original[key].default
@@ -500,20 +550,21 @@ class TestPipelineMetadataBridging:
             assert specs[key].description == original[key].description
 
     def test_wan_pipeline_roundtrip(self):
-        """Wan pipeline metadata survives the round-trip."""
+        """Wan 2.2 pipeline metadata survives the round-trip."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        resp = self._build_ready_response(WanPipeline)
+        mock_self = _wan_mock(is_wan22=True)
+        resp = self._build_ready_response(WanPipeline, mock_self)
         restored = self._roundtrip(resp)
 
         payload = restored.output
-        assert payload["default_generation_params"]["height"] == 480
+        assert payload["default_generation_params"]["height"] == 720
         assert payload["default_generation_params"]["num_frames"] == 81
         assert "guidance_scale_2" in payload["extra_param_specs"]
         assert "boundary_ratio" in payload["extra_param_specs"]
 
     def test_flux_empty_specs_roundtrip(self):
-        """Pipeline with no EXTRA_PARAM_SPECS round-trips as empty dict."""
+        """Pipeline with no extra_param_specs round-trips as empty dict."""
         from tensorrt_llm._torch.visual_gen.models.flux.pipeline_flux import FluxPipeline
 
         resp = self._build_ready_response(FluxPipeline)
@@ -531,6 +582,9 @@ class TestPipelineMetadataBridging:
         resp = self._build_ready_response(LTX2Pipeline)
         restored = self._roundtrip(resp)
 
+        ltx2_defaults = LTX2Pipeline.default_generation_params.fget(None)
+        ltx2_specs = LTX2Pipeline.extra_param_specs.fget(None)
+
         # Simulate what _wait_ready_async does: extract from the response payload
         client = MagicMock(spec=DiffusionRemoteClient)
         client.default_generation_params = {}
@@ -541,8 +595,8 @@ class TestPipelineMetadataBridging:
             client.default_generation_params = payload.get("default_generation_params", {})
             client.extra_param_specs = payload.get("extra_param_specs", {})
 
-        assert client.default_generation_params == LTX2Pipeline.DEFAULT_GENERATION_PARAMS
-        assert set(client.extra_param_specs.keys()) == set(LTX2Pipeline.EXTRA_PARAM_SPECS.keys())
+        assert client.default_generation_params == ltx2_defaults
+        assert set(client.extra_param_specs.keys()) == set(ltx2_specs.keys())
         for spec in client.extra_param_specs.values():
             assert isinstance(spec, ExtraParamSchema)
 
@@ -592,12 +646,14 @@ class TestVisualGenParamsError:
 class TestRequestValidation:
     """DiffusionExecutor._validate_request raises VisualGenParamsError on bad params."""
 
-    def _make_mock_executor(self, pipeline_cls):
+    def _make_mock_executor(self, pipeline_cls, mock_self=None):
         executor = MagicMock()
         executor.pipeline = MagicMock()
         executor.pipeline.__class__ = pipeline_cls
-        executor.pipeline.DEFAULT_GENERATION_PARAMS = pipeline_cls.DEFAULT_GENERATION_PARAMS
-        executor.pipeline.EXTRA_PARAM_SPECS = pipeline_cls.EXTRA_PARAM_SPECS
+        executor.pipeline.default_generation_params = pipeline_cls.default_generation_params.fget(
+            mock_self
+        )
+        executor.pipeline.extra_param_specs = pipeline_cls.extra_param_specs.fget(mock_self)
         return executor
 
     def _make_request(self, **kwargs):
@@ -668,7 +724,7 @@ class TestRequestValidation:
         """image is a conditioning input — validated at runtime by infer(), not here."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline)
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=False, num_heads=12))
         req = self._make_request(image="/path/to/img.png")
         # Should not raise — image validation is the pipeline's responsibility
         self._merge_and_validate(executor, req)
@@ -677,7 +733,7 @@ class TestRequestValidation:
         """num_frames is declared by WanPipeline, should not raise."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline)
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=False, num_heads=12))
         req = self._make_request(num_frames=81)
         self._merge_and_validate(executor, req)
 
@@ -687,7 +743,9 @@ class TestRequestValidation:
             WanImageToVideoPipeline,
         )
 
-        executor = self._make_mock_executor(WanImageToVideoPipeline)
+        executor = self._make_mock_executor(
+            WanImageToVideoPipeline, _wan_mock(is_wan22=False, num_heads=12)
+        )
         req = self._make_request(image="/path/to/img.png")
         self._merge_and_validate(executor, req)
 
@@ -735,7 +793,9 @@ class TestRequestValidation:
         )
         from tensorrt_llm.visual_gen import VisualGenParamsError
 
-        executor = self._make_mock_executor(WanImageToVideoPipeline)
+        executor = self._make_mock_executor(
+            WanImageToVideoPipeline, _wan_mock(is_wan22=False, num_heads=12)
+        )
         req = self._make_request(
             image="/img.png",
             extra_params={"last_image": 123},
@@ -749,7 +809,7 @@ class TestRequestValidation:
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
         from tensorrt_llm.visual_gen import VisualGenParamsError
 
-        executor = self._make_mock_executor(WanPipeline)
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=True))
         # boundary_ratio has range (0.0, 1.0)
         req = self._make_request(extra_params={"boundary_ratio": 2.0})
         with pytest.raises(VisualGenParamsError, match="out of range"):
@@ -759,7 +819,7 @@ class TestRequestValidation:
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
         from tensorrt_llm.visual_gen import VisualGenParamsError
 
-        executor = self._make_mock_executor(WanPipeline)
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=True))
         req = self._make_request(extra_params={"boundary_ratio": -0.5})
         with pytest.raises(VisualGenParamsError, match="out of range"):
             self._merge_and_validate(executor, req)
@@ -767,14 +827,14 @@ class TestRequestValidation:
     def test_boundary_value_at_range_edge_ok(self):
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline)
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=True))
         req = self._make_request(extra_params={"boundary_ratio": 0.0})
         self._merge_and_validate(executor, req)
 
     def test_boundary_value_at_range_max_ok(self):
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline)
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=True))
         req = self._make_request(extra_params={"boundary_ratio": 1.0})
         self._merge_and_validate(executor, req)
 
@@ -804,7 +864,7 @@ class TestRequestValidation:
         """None values for extra_params with range specs should not fail validation."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline)
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=True))
         req = self._make_request(extra_params={"boundary_ratio": None})
         self._merge_and_validate(executor, req)
 
@@ -819,8 +879,8 @@ class TestRequestValidation:
         executor = MagicMock()
         executor.pipeline = MagicMock()
         executor.pipeline.__class__.__name__ = "FluxPipeline"
-        executor.pipeline.DEFAULT_GENERATION_PARAMS = {"height": 1024, "width": 1024}
-        executor.pipeline.EXTRA_PARAM_SPECS = {}
+        executor.pipeline.default_generation_params = {"height": 1024, "width": 1024}
+        executor.pipeline.extra_param_specs = {}
         executor.pipeline._warmed_up_shapes = set()
         executor.pipeline.warmup_cache_key = MagicMock(return_value=(1024, 1024, None))
         executor.rank = 0


### PR DESCRIPTION

Examples:
- Add models/wan_t2v.py: slim API example using default_params workflow with --model and --extra_visual_gen_options flags
- Add configs/ with shared YAML configs for Wan 2.2 T2V (1/4/8 GPU) usable by both offline examples and trtllm-serve
- Update README with directory structure index and per-model usage

Per-model default generation params:
- Convert DEFAULT_GENERATION_PARAMS and EXTRA_PARAM_SPECS from class-level dicts to @property instance methods (lowercase) across all pipelines
- Add tensorrt_llm/_torch/visual_gen/models/wan/defaults.py with shared deduction logic: model version (2.1/2.2) -> model size -> model name
- Wan 2.1 1.3B defaults to 480p/50steps/5.0gs, Wan 2.1 14B to 720p, Wan 2.2 A14B to 720p/40steps/4.0gs, I2V 480P/720P by name
- Wan 2.2 extra_param_specs include guidance_scale_2 and boundary_ratio; Wan 2.1 has none

Testing:
- Add test_wan_t2v_example core example test using pre-quantized NVFP4 checkpoint, registered in l0_b200 and l0_dgx_b200 CI lists

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive documentation for visual generation examples, including directory structure, quick start guide, and per-model examples with configuration options.
  * Added three Wan 2.2 text-to-video configuration files supporting 1-GPU, 4-GPU, and 8-GPU setups with NVFP4 and FP8 quantization.
  * Added example script for Wan text-to-video generation with configurable model parameters and output options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->