### PR TITLE
[#13021][infra] Add concurrency control and permissions to PR check workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,6 +19,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+  contents: read
+
 jobs:
   check-pr-title:
     name: Check PR Title Format
@@ -64,7 +72,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Validate PR Checklist
         env:


### PR DESCRIPTION
## Summary
- Add `concurrency` group to cancel stale in-progress runs on rapid PR updates
- Declare least-privilege `permissions` (read-only for pull-requests and contents)
- Bump Python from 3.10 to 3.12 for consistency with `precommit-check.yml`

## Test plan
- [x] Verify PR check workflow triggers on a new PR
- [ ] Verify stale runs are cancelled when a new push arrives on the same PR
- [ ] Verify the checklist validation script runs correctly with Python 3.12

Closes #13021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize build efficiency and security permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->