### PR TITLE
[#13023][infra] Add Docker BuildKit registry cache to speed up image …

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -57,6 +57,21 @@ NGC_REPO           ?= nvcr.io/nvidia/tensorrt-llm
 NGC_USE_STAGING    ?= 0
 NGC_AUTO_REPO      ?= $(if $(filter 1,$(NGC_USE_STAGING)),$(NGC_STAGING_REPO),$(NGC_REPO))
 
+# Helper: literal comma for use inside $(if ...) expansions
+comma := ,
+
+# BuildKit cache configuration for registry-based layer caching.
+# Set DOCKER_CACHE_REPO to enable; leave empty to disable (default).
+# DOCKER_CACHE_FROM accepts additional --cache-from flags (space-separated)
+# to pull cached layers from multiple sources (e.g., branch-specific + main).
+DOCKER_CACHE_REPO  ?=
+DOCKER_CACHE_TAG   ?= $(if $(STAGE),$(STAGE)-)$(IMAGE_TAG)
+DOCKER_CACHE_FROM  ?=
+DOCKER_CACHE_OPTS  ?= $(if $(DOCKER_CACHE_REPO),\
+  --cache-to type=registry$(comma)ref=$(DOCKER_CACHE_REPO):$(DOCKER_CACHE_TAG)$(comma)mode=max \
+  --cache-from type=registry$(comma)ref=$(DOCKER_CACHE_REPO):$(DOCKER_CACHE_TAG) \
+  $(DOCKER_CACHE_FROM))
+
 define add_local_user
 	docker build \
 		--progress $(DOCKER_PROGRESS) \
@@ -86,7 +101,7 @@ base_pull:
     				   | grep '^BASH_ENV=' | sed 's/^[^=]*=//' 2>/dev/null)
 %_build: base_pull
 	@echo "Building docker image: $(IMAGE_WITH_TAG)"
-	docker buildx build $(DOCKER_BUILD_OPTS) $(DOCKER_BUILD_ARGS) \
+	docker buildx build $(DOCKER_BUILD_OPTS) $(DOCKER_BUILD_ARGS) $(DOCKER_CACHE_OPTS) \
 		--progress $(DOCKER_PROGRESS) \
 		$(if $(BASE_IMAGE), --build-arg BASE_IMAGE=$(BASE_IMAGE)) \
 		$(if $(BASE_TAG), --build-arg BASE_TAG=$(BASE_TAG)) \

--- a/jenkins/BuildDockerImage.groovy
+++ b/jenkins/BuildDockerImage.groovy
@@ -39,6 +39,10 @@ BUILD_JOBS_RELEASE_SBSA = "32"
 
 CCACHE_DIR="/mnt/sw-tensorrt-pvc/scratch.trt_ccache/llm_ccache"
 
+// Registry for Docker BuildKit layer cache (--cache-to / --cache-from).
+// Set to empty string to disable caching.
+DOCKER_CACHE_REGISTRY = env.dockerCacheRegistry ?: "urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm-cache"
+
 @Field
 def GITHUB_PR_API_URL = "github_pr_api_url"
 @Field
@@ -239,6 +243,35 @@ def prepareWheelFromBuildStage(dockerfileStage, arch) {
     return " BUILD_WHEEL_SCRIPT=${wheelScript} BUILD_WHEEL_ARGS='${wheelArgs}'"
 }
 
+/**
+ * Generate Makefile variables for Docker BuildKit registry cache.
+ *
+ * Produces up to 3 cache-from sources tried in order by BuildKit:
+ *   1. Branch+stage-specific  (exact match for rebuild on the same branch)
+ *   2. main branch+stage      (good fallback for new feature branches)
+ *   3. latest stable+stage    (updated after each successful post-merge)
+ *
+ * @param stage  Dockerfile target stage (e.g. "tritondevel", "release", "devel")
+ * @param arch   Architecture label       (e.g. "x86_64", "sbsa")
+ * @return       String with Makefile variable overrides, empty when caching is disabled
+ */
+def buildCacheArgs(stage, arch) {
+    if (!DOCKER_CACHE_REGISTRY) {
+        return ""
+    }
+
+    def cacheRepo = DOCKER_CACHE_REGISTRY
+    def branchTag = "${stage}-${arch}-${LLM_BRANCH_TAG}"
+
+    // Build the list of --cache-from flags for the Makefile DOCKER_CACHE_FROM variable.
+    // The Makefile already adds one --cache-from for DOCKER_CACHE_TAG (the branch-specific tag).
+    // Here we supply the additional fallback sources.
+    def cacheFromFlags = "--cache-from type=registry,ref=${cacheRepo}:${stage}-${arch}-main"
+    cacheFromFlags += " --cache-from type=registry,ref=${cacheRepo}:${stage}-${arch}-latest"
+
+    return " DOCKER_CACHE_REPO=${cacheRepo} DOCKER_CACHE_TAG=${branchTag} DOCKER_CACHE_FROM='${cacheFromFlags}'"
+}
+
 def buildImage(config, imageKeyToTag)
 {
     def target = config.target
@@ -267,6 +300,9 @@ def buildImage(config, imageKeyToTag)
     }
 
     args += " GITHUB_MIRROR=https://urm.nvidia.com/artifactory/github-go-remote"
+
+    // Compute BuildKit cache flags for this build's stage and architecture.
+    def cacheArgs = buildCacheArgs(dockerfileStage, arch)
 
     stage (config.stageName) {
         // Step 1: Clone TRT-LLM source codes
@@ -315,6 +351,7 @@ def buildImage(config, imageKeyToTag)
         TRITON_IMAGE = TRITON_IMAGE.replace("nvcr.io/", "urm.nvidia.com/docker/")
 
         if (dependent) {
+            def dependentCacheArgs = buildCacheArgs(dependent.dockerfileStage, arch)
             stage ("make ${dependent.target}_${action} (${arch})") {
                 def randomSleep = (Math.random() * 600 + 600).toInteger()
                 trtllm_utils.llmExecStepWithRetry(this, script: "docker pull ${TRITON_IMAGE}:${TRITON_BASE_TAG}", sleepInSecs: randomSleep, numRetries: 6, shortCommondRunTimeMax: 7200)
@@ -325,7 +362,7 @@ def buildImage(config, imageKeyToTag)
                 TORCH_INSTALL_TYPE=${torchInstallType} \
                 IMAGE_WITH_TAG=${dependentImageWithTag} \
                 STAGE=${dependent.dockerfileStage} \
-                BUILD_WHEEL_OPTS='-j ${build_jobs}' ${args}
+                BUILD_WHEEL_OPTS='-j ${build_jobs}' ${args}${dependentCacheArgs}
                 """, sleepInSecs: randomSleep, numRetries: 6, shortCommondRunTimeMax: 7200)
                 args += " DEVEL_IMAGE=${dependentImageWithTag}"
                 if (target == "ngc-release") {
@@ -355,7 +392,7 @@ def buildImage(config, imageKeyToTag)
                 TORCH_INSTALL_TYPE=${torchInstallType} \
                 IMAGE_WITH_TAG=${imageWithTag} \
                 STAGE=${dockerfileStage} \
-                BUILD_WHEEL_OPTS='-j ${build_jobs}' ${args} ${buildWheelArgs}
+                BUILD_WHEEL_OPTS='-j ${build_jobs}' ${args} ${buildWheelArgs}${cacheArgs}
                 """, sleepInSecs: randomSleep, numRetries: 6, shortCommondRunTimeMax: 7200)
             } catch (InterruptedException ex) {
                 throw ex
@@ -372,7 +409,7 @@ def buildImage(config, imageKeyToTag)
                 TORCH_INSTALL_TYPE=${torchInstallType} \
                 IMAGE_WITH_TAG=${imageWithTag} \
                 STAGE=${dockerfileStage} \
-                BUILD_WHEEL_OPTS='-j ${build_jobs}' ${args} ${buildWheelArgs}
+                BUILD_WHEEL_OPTS='-j ${build_jobs}' ${args} ${buildWheelArgs}${cacheArgs}
                 """, sleepInSecs: randomSleep, numRetries: 6, shortCommondRunTimeMax: 7200)
             }
             if (target == "ngc-release") {
@@ -389,7 +426,7 @@ def buildImage(config, imageKeyToTag)
                 TORCH_INSTALL_TYPE=${torchInstallType} \
                 IMAGE_WITH_TAG=${customImageWithTag} \
                 STAGE=${dockerfileStage} \
-                BUILD_WHEEL_OPTS='-j ${build_jobs}' ${args} ${buildWheelArgs}
+                BUILD_WHEEL_OPTS='-j ${build_jobs}' ${args} ${buildWheelArgs}${cacheArgs}
                 """
             }
         }


### PR DESCRIPTION
## Summary

   - Add `--cache-to` / `--cache-from` support to `docker/Makefile` and `jenkins/BuildDockerImage.groovy` so Docker image builds on ephemeral Kubernetes pods can reuse cached layers from a registry
   - Implement a 3-level cache strategy: branch-specific cache, main-branch fallback, and latest-stable fallback
   - Fully opt-in: when `DOCKER_CACHE_REPO` is empty (default), no cache flags are added and existing behavior is unchanged

   ## Context

   Every Docker image build currently runs on a fresh Kubernetes pod with Docker-in-Docker, meaning **zero Docker layer cache** is available at build start. The `devel` stage alone (TensorRT, CUDA toolkit, UCX, NIXL, etcd, Mooncake, etc.) is expensive and rarely changes between commits but is rebuilt
   from scratch every time.

   BuildKit's registry-based cache (`type=registry`) works with DinD since it uses the Docker daemon's registry access rather than the local filesystem.

   ## Changes

   ### `docker/Makefile`
   - Add `DOCKER_CACHE_REPO`, `DOCKER_CACHE_TAG`, `DOCKER_CACHE_FROM`, `DOCKER_CACHE_OPTS` variables
   - Inject `$(DOCKER_CACHE_OPTS)` into the `%_build` target's `docker buildx build` command
   - When `DOCKER_CACHE_REPO` is set, the build will:
     - Export all layers to the registry (`--cache-to ... mode=max`)
     - Import cached layers from the registry (`--cache-from`)
     - Accept additional `--cache-from` sources via `DOCKER_CACHE_FROM`

   ### `jenkins/BuildDockerImage.groovy`
   - Add `DOCKER_CACHE_REGISTRY` constant (configurable via `env.dockerCacheRegistry`)
   - Add `buildCacheArgs(stage, arch)` helper that generates Makefile variable overrides with 3 cache sources:
     1. `{stage}-{arch}-{branch}` — exact match for rebuilds on the same branch
     2. `{stage}-{arch}-main` — fallback for new feature branches
     3. `{stage}-{arch}-latest` — updated after each successful post-merge
   - Wire cache args into all 4 `make -C docker` invocations in `buildImage()`: dependent build, main build, retry build, and custom tag build

   ## Cache tag examples

   For a build of the `tritondevel` stage on `x86_64` from branch `feature/foo`:
   ```
   --cache-to   type=registry,ref=<cache-repo>:tritondevel-x86_64-feature_foo,mode=max
   --cache-from type=registry,ref=<cache-repo>:tritondevel-x86_64-feature_foo
   --cache-from type=registry,ref=<cache-repo>:tritondevel-x86_64-main
   --cache-from type=registry,ref=<cache-repo>:tritondevel-x86_64-latest
   ```

   ## Test plan

   - [ ] Verify local builds are unaffected (run `make -C docker tritondevel_build` without setting `DOCKER_CACHE_REPO`)
   - [ ] Test with cache enabled: `make -C docker tritondevel_build DOCKER_CACHE_REPO=<test-registry>`
   - [ ] Verify cache is exported to registry after first build
   - [ ] Verify second build on same branch pulls cached layers
   - [ ] Verify build on new branch falls back to main-branch cache
   - [ ] Run Jenkins pipeline with `dockerCacheRegistry` env var set and validate all 9 image builds use caching
   - [ ] Verify cache miss is graceful (no failure when cache tag doesn't exist yet)

   Closes #13023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build configuration to support optional registry-based layer caching for faster build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->