### PR TITLE
[None][fix] fix Wan unit tests

### DIFF
--- a/tests/unittest/_torch/visual_gen/test_wan.py
+++ b/tests/unittest/_torch/visual_gen/test_wan.py
@@ -185,21 +185,21 @@ def _run_cfg_worker(rank, world_size, checkpoint_path, inputs_list, return_dict)
         assert cfg_config["cfg_size"] == world_size, f"Rank {rank}: Wrong cfg_size"
 
         expected_cfg_group = rank // cfg_config["ulysses_size"]
-        assert cfg_config["cfg_group"] == expected_cfg_group, (
-            f"Rank {rank}: Wrong cfg_group. Expected {expected_cfg_group}, got {cfg_config['cfg_group']}"
+        assert cfg_config["cfg_rank"] == expected_cfg_group, (
+            f"Rank {rank}: Wrong cfg_rank. Expected {expected_cfg_group}, got {cfg_config['cfg_rank']}"
         )
 
         if rank == 0:
             print(f"[CFG Rank {rank}] Loaded with cfg_size={world_size}")
-            print(f"  cfg_group: {cfg_config['cfg_group']}")
+            print(f"  cfg_rank: {cfg_config['cfg_rank']}")
             print(f"  local_embeds shape: {cfg_config['local_embeds'].shape}")
-            print(f"  Using {'positive' if cfg_config['cfg_group'] == 0 else 'negative'} prompts")
+            print(f"  Using {'positive' if cfg_config['cfg_rank'] == 0 else 'negative'} prompts")
 
         # Verify prompt splitting - rank 0 gets positive, rank 1 gets negative
-        expected_embeds = prompt_embeds if cfg_config["cfg_group"] == 0 else neg_prompt_embeds
+        expected_embeds = prompt_embeds if cfg_config["cfg_rank"] == 0 else neg_prompt_embeds
         assert torch.allclose(cfg_config["local_embeds"], expected_embeds), (
             f"Rank {rank}: local_embeds doesn't match expected"
-            f"{'positive' if cfg_config['cfg_group'] == 0 else 'negative'} embeds"
+            f"{'positive' if cfg_config['cfg_rank'] == 0 else 'negative'} embeds"
         )
 
         # Run single denoising step with CFG parallel

--- a/tests/unittest/_torch/visual_gen/test_wan_i2v.py
+++ b/tests/unittest/_torch/visual_gen/test_wan_i2v.py
@@ -308,19 +308,19 @@ def _run_cfg_worker_i2v(rank, world_size, checkpoint_path, inputs_list, return_d
         assert cfg_config["cfg_size"] == world_size, f"Rank {rank}: Wrong cfg_size"
 
         expected_cfg_group = rank // cfg_config["ulysses_size"]
-        assert cfg_config["cfg_group"] == expected_cfg_group, (
-            f"Rank {rank}: Wrong cfg_group. Expected {expected_cfg_group}, got {cfg_config['cfg_group']}"
+        assert cfg_config["cfg_rank"] == expected_cfg_group, (
+            f"Rank {rank}: Wrong cfg_rank. Expected {expected_cfg_group}, got {cfg_config['cfg_rank']}"
         )
 
         if rank == 0:
             print(f"[CFG I2V Rank {rank}] Loaded with cfg_size={world_size}")
-            print(f"  cfg_group: {cfg_config['cfg_group']}")
+            print(f"  cfg_rank: {cfg_config['cfg_rank']}")
             print(f"  local_embeds shape: {cfg_config['local_embeds'].shape}")
-            print(f"  Using {'positive' if cfg_config['cfg_group'] == 0 else 'negative'} prompts")
+            print(f"  Using {'positive' if cfg_config['cfg_rank'] == 0 else 'negative'} prompts")
             print(f"  Image embeds: {'present' if image_embeds is not None else 'None'}")
 
         # Verify prompt splitting
-        expected_embeds = prompt_embeds if cfg_config["cfg_group"] == 0 else neg_prompt_embeds
+        expected_embeds = prompt_embeds if cfg_config["cfg_rank"] == 0 else neg_prompt_embeds
         assert torch.allclose(cfg_config["local_embeds"], expected_embeds), (
             f"Rank {rank}: local_embeds doesn't match expected embeds"
         )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated CFG parallel validation tests to use correct field references, ensuring proper rank mapping verification and prompt selection logic in visual generation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
