### PR TITLE
[TRTLLM-11851][feat] MX and GMS integration MVP for Dynamo weight sharing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -427,6 +427,32 @@ setup(
     scripts=['tensorrt_llm/llmapi/trtllm-llmapi-launch'],
     extras_require={
         "devel": devel_deps,
+        # NOTE: The MX (modelexpress) and GMS (gpu-memory-service) Python
+        # packages used by tensorrt_llm._torch.models.checkpoints.mx and
+        # tensorrt_llm._torch.memory.gpu_memory_backend are intentionally
+        # NOT declared as ``[mx]`` / ``[gms]`` / ``[dynamo]`` extras here
+        # while the integration is at prototype status. Two reasons:
+        #
+        #   1. ``gpu-memory-service`` v0.9.0 ships only as source under
+        #      ``ai-dynamo/dynamo/lib/gpu_memory_service/`` and is not
+        #      published to PyPI, so NVIDIA's OSS vulnerability scanner
+        #      cannot resolve a pinned version on it.
+        #   2. ``modelexpress`` v0.3.0 is on PyPI (Apache-2.0) but is
+        #      brand-new (Beta status, single release) and still needs
+        #      onboarding into NVIDIA's OSS package allowlist.
+        #
+        # Until both packages are PyPI-published *and* allowlisted, users
+        # who want to exercise the MX or GMS code paths install the deps
+        # manually:
+        #
+        #     pip install "modelexpress>=0.3.0,<0.4.0"
+        #     git clone https://github.com/ai-dynamo/dynamo \
+        #       && pip install ./dynamo/lib/gpu_memory_service
+        #
+        # Restoring one-line ``pip install tensorrt_llm[dynamo]``
+        # ergonomics is a single revert of this hunk once the upstream
+        # publish + OSS-allowlist steps are complete (tracked in §15 of
+        # the design doc as MX-7 and GMS-6).
     },
     zip_safe=True,
     install_requires=required_deps,

--- a/tensorrt_llm/_torch/memory/__init__.py
+++ b/tensorrt_llm/_torch/memory/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .gpu_memory_backend import GMSBackend, GPUMemoryBackend
+
+__all__ = ["GPUMemoryBackend", "GMSBackend"]

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -1,0 +1,439 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU Memory Backend protocol and GMS implementation.
+
+Defines a thin protocol that adapts the upstream GPU Memory Service
+(``gpu_memory_service`` from ``ai-dynamo/dynamo``) into TRT-LLM's
+``ModelLoader`` pipeline. The protocol intentionally exposes only the
+operations TRT-LLM needs at specific points in the loading lifecycle —
+all heavy lifting (CUDA VMM, FD passing, zero-copy tensor construction)
+is delegated to the GMS library's stable public Python primitives.
+
+Design notes:
+- We deliberately avoid the upstream ``setup_gms()`` monkey-patch entry
+  point. TRT-LLM owns the integration policy in ``ModelLoader``; this
+  backend is a thin adapter over the GMS library's primitive API.
+- The protocol has a single point of contact per concern, so when the
+  upstream GMS Python API drifts, only the methods on ``GMSBackend``
+  need to change — the call sites in ``model_loader.py`` are stable.
+
+Operating modes:
+- **RW (Read-Write)**: First worker loads weights via the normal
+  checkpoint loader pipeline, with allocations captured by a GMS-managed
+  CUDA memory pool. After loading, weights are committed for read-only
+  access by other workers and the client transitions to RO mode in place.
+- **RO (Read-Only)**: Subsequent workers zero-copy import already-committed
+  weights from the GMS pool. ``post_load_weights()`` must run BEFORE
+  materialization so that module aliases are set up correctly.
+"""
+
+from contextlib import contextmanager
+from typing import Iterator, Optional, Protocol, runtime_checkable
+
+import torch
+from torch import nn
+
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
+
+
+@runtime_checkable
+class GPUMemoryBackend(Protocol):
+    """Thin abstraction over GPU memory services for API stability."""
+
+    def connect(self) -> bool:
+        """Establish a session with the backend. Returns True on success."""
+        ...
+
+    @property
+    def is_rw(self) -> Optional[bool]:
+        """Whether this backend was granted RW (vs RO). None pre-connect."""
+        ...
+
+    def has_committed_weights(self) -> bool:
+        """Whether committed weights are ready to be imported (RO-ready)."""
+        ...
+
+    def mem_pool_scope(
+        self,
+        device: Optional[torch.device] = None,
+    ) -> "Iterator[None]":
+        """Return a context manager scoping CUDA allocations to the backend pool."""
+        ...
+
+    def materialize_module(self, model: nn.Module) -> None:
+        """Zero-copy import committed weights into model params (RO path)."""
+        ...
+
+    def finalize_write(self, model: nn.Module) -> int:
+        """Register, commit, and transition to RO. Returns bytes committed."""
+        ...
+
+    def move_untracked_params(self, model: nn.Module) -> None:
+        """Move stray params not in the backend pool into shared memory."""
+        ...
+
+    def cleanup(self) -> None:
+        """Release all resources and disconnect."""
+        ...
+
+
+# String mode -> upstream RequestedLockType. Resolved lazily inside connect()
+# so importing this module does not require the GMS library to be installed.
+_MODE_ALIASES = ("rw", "ro", "auto")
+
+
+class GMSBackend:
+    """Concrete ``GPUMemoryBackend`` using ``gpu_memory_service`` (GMS).
+
+    GMS is a multi-process GPU memory manager (out-of-process server,
+    in-process clients) that lets multiple inference instances share weight
+    bytes via CUDA VMM mappings and Unix-socket FD passing.
+
+    This adapter calls the GMS library's stable per-call primitives
+    (``GMSClientMemoryManager`` + the helpers in
+    ``gpu_memory_service.client.torch.allocator`` and ``.module``) and
+    composes them into the methods TRT-LLM's ``ModelLoader`` invokes for
+    the ``LoadFormat.GMS`` branch. We intentionally do **not** use the
+    upstream ``setup_gms()`` monkey-patch — TRT-LLM owns the integration
+    policy and we keep the dependency surface narrow and explicit.
+    """
+
+    DEFAULT_TAG = "weights"
+
+    def __init__(
+        self,
+        socket_path: Optional[str],
+        mapping: Mapping,
+        mode: str = "auto",
+        tag: str = DEFAULT_TAG,
+    ) -> None:
+        """Initialize the GMS backend.
+
+        Args:
+            socket_path: Unix domain socket path for the per-GPU GMS daemon.
+                When ``None``, the default per-GPU UUID-keyed path from
+                ``gpu_memory_service.common.utils.get_socket_path`` is used
+                (resolved lazily inside :meth:`connect`).
+            mapping: TRT-LLM distributed ``Mapping`` for TP/PP rank info.
+            mode: Operating mode — ``"auto"`` (RW first, RO after committed),
+                ``"rw"`` (require RW), or ``"ro"`` (require RO).
+            tag: Logical tag identifying this weight set in the GMS server.
+                Default ``"weights"`` matches the GMS library convention.
+        """
+        if mode not in _MODE_ALIASES:
+            raise ValueError(f"GMS mode must be one of {_MODE_ALIASES}, got {mode!r}")
+
+        self._socket_path = socket_path
+        self._mapping = mapping
+        self._mode = mode
+        self._tag = tag
+        self._device_index = torch.cuda.current_device()
+
+        # Late-bound state, populated by connect()
+        self._client = None  # GMSClientMemoryManager (lazy-typed)
+        self._is_rw: Optional[bool] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def connect(self) -> bool:
+        """Connect to the per-GPU GMS daemon and acquire a session.
+
+        Returns ``True`` on success. On import failure (library not
+        installed) or socket failure, returns ``False`` and logs a warning
+        — callers are expected to surface a useful error to the user.
+        """
+        try:
+            from gpu_memory_service.client.torch.allocator import (
+                get_or_create_gms_client_memory_manager,
+            )
+            from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
+            from gpu_memory_service.common.utils import get_socket_path
+            from gpu_memory_service.integrations.common.patches import patch_empty_cache
+        except ImportError:
+            logger.warning(
+                "gpu_memory_service library not installed; cannot use "
+                "LoadFormat.GMS. Install from "
+                "https://github.com/ai-dynamo/dynamo/tree/main/lib/gpu_memory_service"
+            )
+            return False
+
+        mode_map = {
+            "rw": RequestedLockType.RW,
+            "ro": RequestedLockType.RO,
+            "auto": RequestedLockType.RW_OR_RO,
+        }
+
+        # Resolve default socket path against the upstream convention so
+        # multiple TRT-LLM instances on the same node automatically share
+        # the same per-GPU daemon.
+        socket_path = self._socket_path
+        if socket_path is None:
+            socket_path = get_socket_path(self._device_index, self._tag)
+        self._socket_path = socket_path
+
+        try:
+            self._client = get_or_create_gms_client_memory_manager(
+                socket_path,
+                self._device_index,
+                mode=mode_map[self._mode],
+                tag=self._tag,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to connect to GMS at %s (mode=%s, tag=%s): %s",
+                socket_path,
+                self._mode,
+                self._tag,
+                e,
+            )
+            self._client = None
+            return False
+
+        self._is_rw = self._client.granted_lock_type == GrantedLockType.RW
+
+        # GMS-backed VMM tensors can segfault if torch.cuda.empty_cache()
+        # tries to free them. Apply the upstream safety patch once we're
+        # connected. Idempotent and cheap.
+        try:
+            patch_empty_cache()
+        except Exception as e:
+            logger.debug("GMS patch_empty_cache failed (non-fatal): %s", e)
+
+        logger.info(
+            "Connected to GMS at %s (mode=%s, granted=%s, tag=%s)",
+            socket_path,
+            self._mode,
+            "RW" if self._is_rw else "RO",
+            self._tag,
+        )
+        return True
+
+    @property
+    def is_rw(self) -> Optional[bool]:
+        return self._is_rw
+
+    def has_committed_weights(self) -> bool:
+        """Whether the granted session is RO (i.e. committed weights exist)."""
+        if self._client is None:
+            return False
+        try:
+            from gpu_memory_service.common.locks import GrantedLockType
+
+            return self._client.granted_lock_type == GrantedLockType.RO
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------
+    # RW path: scope allocations into the GMS pool, then finalize
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def mem_pool_scope(
+        self,
+        device: Optional[torch.device] = None,
+    ) -> Iterator[None]:
+        """Context manager scoping CUDA allocations to the GMS pool.
+
+        All ``torch.empty``/``torch.zeros``/etc. allocations inside this
+        scope are routed through the GMS pluggable allocator and end up
+        in the shared memory region for the configured ``tag``.
+
+        Only valid when granted RW; raises otherwise.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+        if self._is_rw is False:
+            raise RuntimeError(
+                "GMS mem_pool_scope() is only valid in RW mode (this client was granted RO)."
+            )
+
+        from gpu_memory_service.client.torch.allocator import gms_use_mem_pool
+
+        target_device = device
+        if target_device is None:
+            target_device = torch.device("cuda", self._device_index)
+
+        with gms_use_mem_pool(self._tag, target_device):
+            yield
+
+    def move_untracked_params(self, model: nn.Module) -> None:
+        """Migrate parameters allocated outside the GMS pool into it.
+
+        Some parts of TRT-LLM's loading pipeline (e.g. ``post_load_weights``,
+        ``model.to("cuda")``) may allocate buffers outside the
+        ``mem_pool_scope`` context. ``finalize_write`` requires every
+        registered tensor to live in the GMS pool, so we copy any stray
+        CUDA params into freshly created GMS mappings of the same size.
+
+        Mirrors ``gpu_memory_service.integrations.trtllm.model_loader.
+        _move_untracked_params`` so behavior matches the upstream
+        reference integration.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+
+        from gpu_memory_service.client.torch.module import _iter_module_tensors
+        from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+
+        gms_client = self._client
+        device_index = self._device_index
+        seen: set[int] = set()
+
+        with torch.no_grad():
+            for _name, tensor, tensor_type in _iter_module_tensors(model):
+                if tensor_type != "parameter" or tensor is None or not tensor.is_cuda:
+                    continue
+
+                storage_ptr = tensor.untyped_storage().data_ptr()
+                if storage_ptr in seen:
+                    continue
+                seen.add(storage_ptr)
+
+                if _ptr_in_gms(gms_client, int(tensor.data_ptr())):
+                    continue
+
+                nbytes = _storage_nbytes(tensor)
+                base_va = gms_client.create_mapping(size=nbytes, tag=self._tag)
+                replacement = _tensor_from_pointer(
+                    int(base_va),
+                    list(tensor.shape),
+                    list(tensor.stride()),
+                    tensor.dtype,
+                    device_index,
+                )
+                replacement.copy_(tensor)
+                tensor.data = replacement
+
+    def finalize_write(self, model: nn.Module) -> int:
+        """Register tensors, commit them, and transition this client to RO.
+
+        Returns the total number of bytes committed. After this returns
+        successfully, ``is_rw`` is ``False`` and other instances on the
+        same node connecting in ``"auto"`` or ``"ro"`` mode will receive
+        a zero-copy RO mapping of the committed layout.
+
+        Mirrors ``gpu_memory_service.integrations.common.utils.
+        finalize_gms_write``.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+        if self._is_rw is False:
+            raise RuntimeError("GMS finalize_write() is only valid in RW mode.")
+
+        from gpu_memory_service.integrations.common.utils import finalize_gms_write
+
+        bytes_committed = int(finalize_gms_write(self._client, model))
+        # finalize_gms_write internally commits and reconnects in RO mode,
+        # so we mirror that state transition here.
+        self._is_rw = False
+        logger.info(
+            "GMS RW->RO: committed %.2f GiB at %s (tag=%s)",
+            bytes_committed / (1 << 30),
+            self._socket_path,
+            self._tag,
+        )
+        return bytes_committed
+
+    # ------------------------------------------------------------------
+    # RO path: zero-copy import committed weights into model params
+    # ------------------------------------------------------------------
+
+    def materialize_module(self, model: nn.Module) -> None:
+        """Zero-copy import committed weights into model params.
+
+        Replaces meta-initialized parameters with CUDA tensors backed by
+        GPU pointers from the shared memory region — no data copies.
+
+        **Important**: ``post_load_weights()`` must be called on the
+        model BEFORE this method, so that module aliases and derived
+        parameters are already in place at materialization time.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+
+        from gpu_memory_service.client.torch.module import materialize_module_from_gms
+
+        materialize_module_from_gms(self._client, model, device_index=self._device_index)
+
+        # Mark Linear modules as presharded — GMS hands out per-rank
+        # weights that are already TP-sliced for this rank.
+        from tensorrt_llm._torch.modules.linear import Linear
+
+        for module in model.modules():
+            if isinstance(module, Linear):
+                module._weights_presharded = True
+
+        logger.info(
+            "GMS RO: materialized weights from %s (tag=%s, tp_rank=%d/%d, total_bytes=%.2f GiB)",
+            self._socket_path,
+            self._tag,
+            self._mapping.tp_rank,
+            self._mapping.tp_size,
+            int(self._client.total_bytes) / (1 << 30),
+        )
+
+    # ------------------------------------------------------------------
+    # Teardown
+    # ------------------------------------------------------------------
+
+    def cleanup(self) -> None:
+        """Release the GMS session and evict it from the per-tag registry."""
+        if self._client is None:
+            return
+        try:
+            from gpu_memory_service.client.torch.allocator import evict_gms_client_memory_manager
+
+            client = self._client
+            try:
+                client.close()
+            except Exception as e:
+                # Best-effort: even if close() fails, evict so a future
+                # connect() in the same process can re-establish state.
+                # Log at debug so unrelated shutdown noise doesn't drown
+                # out the warning we already emit for the outer try.
+                logger.debug("GMS client.close() failed (best-effort): %s", e)
+            evict_gms_client_memory_manager(client)
+            logger.info("GMS: disconnected from %s", self._socket_path)
+        except Exception as e:
+            logger.warning("GMS cleanup error: %s", e)
+        finally:
+            self._client = None
+
+
+def _ptr_in_gms(gms_client, ptr: int) -> bool:
+    """Whether a raw CUDA pointer falls inside an existing GMS mapping.
+
+    Mirrors ``gpu_memory_service.integrations.trtllm.model_loader._ptr_in_gms``.
+    Tolerates absence of the ``_mappings`` attribute on older GMS releases.
+    """
+    mappings = getattr(gms_client, "_mappings", None)
+    if not mappings:
+        return False
+    for mapping in mappings.values():
+        base = int(getattr(mapping, "va", 0))
+        size = int(getattr(mapping, "size", 0))
+        if base and size and base <= ptr < base + size:
+            return True
+    return False
+
+
+def _storage_nbytes(tensor: torch.Tensor) -> int:
+    """Bytes owned by ``tensor``'s underlying storage, including any padding."""
+    storage = tensor.untyped_storage()
+    return int(storage.nbytes())

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU Memory Backend protocol and GMS implementation.
+
+Defines a thin protocol to insulate TRT-LLM from potential GMS API changes.
+If the GMS API evolves, only the concrete implementation needs updating.
+
+The protocol supports two operating modes:
+- **RW (Read-Write)**: First worker loads weights via the normal checkpoint
+  loader pipeline, but allocations go into a GMS-managed CUDA memory pool.
+  After loading, the weights are committed for read-only access by others.
+- **RO (Read-Only)**: Subsequent workers zero-copy import already-committed
+  weights from the GMS pool.  ``post_load_weights()`` must run BEFORE
+  materialization so that module aliases are set up correctly.
+"""
+
+from typing import Optional, Protocol, runtime_checkable
+
+import torch
+from torch import nn
+
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
+
+
+@runtime_checkable
+class GPUMemoryBackend(Protocol):
+    """Thin abstraction over GPU memory services for API stability.
+
+    Any concrete backend (GMS, CUDA IPC fallback, etc.) should implement
+    these methods to work with TRT-LLM's ``ModelLoader.load()`` GMS branch.
+    """
+
+    def has_committed_weights(self, tag: str) -> bool:
+        """Check if weights with the given tag are already committed (RO-ready)."""
+        ...
+
+    def get_mem_pool(self) -> torch.cuda.MemPool:
+        """Return a CUDA MemPool for RW-path allocations."""
+        ...
+
+    def materialize_module(self, model: nn.Module) -> None:
+        """Zero-copy import committed weights into model params (RO path)."""
+        ...
+
+    def finalize_write(self, model: nn.Module, tag: str) -> None:
+        """Register model tensors and commit them for RO readers (RW path)."""
+        ...
+
+    def release(self, tag: str) -> None:
+        """Release committed memory for a given tag."""
+        ...
+
+    def cleanup(self) -> None:
+        """Release all resources and disconnect."""
+        ...
+
+
+class GMSBackend:
+    """Concrete GPUMemoryBackend using the GPU Memory Service (GMS) library.
+
+    GMS provides a shared GPU memory pool that multiple inference instances
+    can map model weights from.  Weights are loaded once by a RW worker and
+    served to RO consumers as read-only CUDA memory regions.
+
+    This implementation delegates to ``gpu_memory_service.client`` for all
+    heavy lifting (CUDA VMM, FD passing, zero-copy tensor construction).
+    TRT-LLM's role is orchestration — calling these APIs at the correct
+    points in the model loading lifecycle.
+    """
+
+    def __init__(self, socket_path: Optional[str], mapping: Mapping,
+                 mode: str = "auto", tag: str = "model_weights"):
+        """Initialize the GMS backend.
+
+        Args:
+            socket_path: Unix domain socket path for GMS. If None, uses
+                default ``/tmp/gms-{device_id}.sock``.
+            mapping: Distributed mapping for TP/PP rank info.
+            mode: Operating mode — "auto", "rw", or "ro".
+            tag: Tag identifying the weight set in GMS.
+        """
+        if socket_path is None:
+            device_id = torch.cuda.current_device()
+            socket_path = f"/tmp/gms-{device_id}.sock"
+
+        self._socket_path = socket_path
+        self._mapping = mapping
+        self._mode = mode
+        self._tag = tag
+        self._client = None
+        self._is_rw = None  # Resolved during connect
+
+    def connect(self) -> bool:
+        """Establish connection to the GMS server.
+
+        In "auto" mode, checks whether committed weights exist to decide
+        between RW (first writer) and RO (read-only) modes.
+
+        Returns:
+            True if connection succeeded, False otherwise.
+        """
+        try:
+            from gpu_memory_service import client as gms_client  # type: ignore[import-not-found]
+
+            if self._mode == "rw":
+                self._client = gms_client.connect(
+                    self._socket_path, mode="rw")
+                self._is_rw = True
+            elif self._mode == "ro":
+                self._client = gms_client.connect(
+                    self._socket_path, mode="ro")
+                self._is_rw = False
+            else:
+                # Auto mode: try RO first (fast path), fall back to RW.
+                self._client = gms_client.connect(self._socket_path)
+                self._is_rw = not self._client.has_committed_weights(
+                    self._tag)
+
+            logger.info(
+                "Connected to GMS at %s (mode=%s, resolved=%s)",
+                self._socket_path, self._mode,
+                "rw" if self._is_rw else "ro")
+            return True
+        except ImportError:
+            logger.warning(
+                "gpu_memory_service library not installed; cannot use GPU "
+                "memory serving. Install with: pip install nvidia-gms")
+            return False
+        except Exception as e:
+            logger.warning("Failed to connect to GMS at %s: %s",
+                           self._socket_path, e)
+            return False
+
+    @property
+    def is_rw(self) -> Optional[bool]:
+        """Whether this backend is in RW mode. None if not yet connected."""
+        return self._is_rw
+
+    def has_committed_weights(self, tag: str) -> bool:
+        if self._client is None:
+            return False
+        try:
+            return self._client.has_committed_weights(tag)
+        except Exception:
+            return False
+
+    def get_mem_pool(self) -> torch.cuda.MemPool:
+        """Return a GMS-managed CUDA MemPool for RW-path allocations.
+
+        Torch allocations made inside ``torch.cuda.use_mem_pool(pool)``
+        are intercepted by GMS's CUDAPluggableAllocator and placed in the
+        shared memory region.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+
+        from gpu_memory_service import client as gms_client  # type: ignore[import-not-found]
+        return gms_client.get_mem_pool(self._client)
+
+    def materialize_module(self, model: nn.Module) -> None:
+        """Zero-copy import committed weights into model params (RO path).
+
+        The GMS library walks the model's parameters and buffers, creating
+        tensors backed by GPU pointers from the shared memory region.
+        This replaces meta-initialized parameters with real CUDA tensors
+        without any data copies.
+
+        **Important**: ``post_load_weights()`` must be called on the model
+        BEFORE this method, so that module aliases and derived parameters
+        are set up correctly before materialization.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+
+        from gpu_memory_service import client as gms_client  # type: ignore[import-not-found]
+        gms_client.materialize_module_from_gms(self._client, model)
+
+        # Mark Linear modules as presharded — GMS provides per-rank
+        # weights that are already TP-sliced.
+        from tensorrt_llm._torch.modules.linear import Linear
+        for module in model.modules():
+            if isinstance(module, Linear):
+                module._weights_presharded = True
+
+        logger.info(
+            "GMS RO: materialized weights from %s (tag=%s, tp_rank=%d/%d)",
+            self._socket_path, self._tag,
+            self._mapping.tp_rank, self._mapping.tp_size)
+
+    def finalize_write(self, model: nn.Module, tag: str = None) -> None:
+        """Register model tensors and commit for RO readers (RW path).
+
+        After the standard weight loading pipeline completes (under the
+        GMS mem pool), this method tells GMS which tensors belong to the
+        model and commits them for read-only access.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+        if tag is None:
+            tag = self._tag
+
+        from gpu_memory_service import client as gms_client  # type: ignore[import-not-found]
+        gms_client.register_module_tensors(self._client, model)
+        gms_client.commit(self._client, tag)
+        logger.info(
+            "GMS RW: committed weights at %s (tag=%s)", self._socket_path, tag)
+
+    def release(self, tag: str = None) -> None:
+        if self._client is None:
+            return
+        if tag is None:
+            tag = self._tag
+        try:
+            from gpu_memory_service import client as gms_client  # type: ignore[import-not-found]
+            gms_client.release(self._client, tag)
+        except Exception as e:
+            logger.warning("GMS release error: %s", e)
+
+    def cleanup(self) -> None:
+        """Disconnect from GMS."""
+        if self._client is not None:
+            try:
+                from gpu_memory_service import client as gms_client  # type: ignore[import-not-found]
+                gms_client.disconnect(self._client)
+                logger.info("GMS: disconnected from %s", self._socket_path)
+            except Exception as e:
+                logger.warning("GMS cleanup error: %s", e)
+            finally:
+                self._client = None

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -60,6 +60,10 @@ class GPUMemoryBackend(Protocol):
         """Register model tensors and commit them for RO readers (RW path)."""
         ...
 
+    def move_untracked_params(self, model: nn.Module) -> None:
+        """Move stray params not in the GMS pool into shared memory."""
+        ...
+
     def release(self, tag: str) -> None:
         """Release committed memory for a given tag."""
         ...
@@ -129,6 +133,16 @@ class GMSBackend:
                 self._client = gms_client.connect(self._socket_path)
                 self._is_rw = not self._client.has_committed_weights(
                     self._tag)
+
+            # Patch torch.cuda.empty_cache() to skip VMM-backed allocations.
+            # Without this, empty_cache() can segfault when it encounters
+            # memory regions managed by GMS's CUDAPluggableAllocator.
+            try:
+                from gpu_memory_service.integrations.common.patches import patch_empty_cache  # type: ignore[import-not-found]
+                patch_empty_cache()
+            except ImportError:
+                logger.debug(
+                    "GMS patch_empty_cache not available; skipping VMM safety patch")
 
             logger.info(
                 "Connected to GMS at %s (mode=%s, resolved=%s)",
@@ -202,11 +216,18 @@ class GMSBackend:
             self._mapping.tp_rank, self._mapping.tp_size)
 
     def finalize_write(self, model: nn.Module, tag: str = None) -> None:
-        """Register model tensors and commit for RO readers (RW path).
+        """Register model tensors, commit, and transition to RO mode.
 
         After the standard weight loading pipeline completes (under the
-        GMS mem pool), this method tells GMS which tensors belong to the
-        model and commits them for read-only access.
+        GMS mem pool), this method:
+        1. Registers model tensors with GMS.
+        2. Commits them for read-only access.
+        3. Disconnects the RW client.
+        4. Reconnects as RO so subsequent access is read-only.
+        5. Remaps virtual addresses so the RO client can serve the data.
+
+        This mirrors the GMS library's ``finalize_gms_write()`` behavior
+        (see ``gpu_memory_service.integrations.common.utils``).
         """
         if self._client is None:
             raise RuntimeError("GMS client not connected. Call connect() first.")
@@ -214,10 +235,61 @@ class GMSBackend:
             tag = self._tag
 
         from gpu_memory_service import client as gms_client  # type: ignore[import-not-found]
+
+        # Step 1-2: Register tensors and commit.
         gms_client.register_module_tensors(self._client, model)
         gms_client.commit(self._client, tag)
         logger.info(
             "GMS RW: committed weights at %s (tag=%s)", self._socket_path, tag)
+
+        # Step 3: Unmap VAs before disconnecting RW client.
+        manager = self._client.get_manager()
+        manager.unmap_all_vas()
+
+        # Step 4: Disconnect RW client and reconnect as RO.
+        gms_client.disconnect(self._client)
+        self._client = gms_client.connect(self._socket_path, mode="ro")
+        self._is_rw = False
+
+        # Step 5: Remap VAs under the new RO client so tensors remain valid.
+        manager = self._client.get_manager()
+        manager.remap_all_vas()
+        logger.info(
+            "GMS RW→RO: reconnected as RO at %s (tag=%s)",
+            self._socket_path, tag)
+
+    def move_untracked_params(self, model: nn.Module) -> None:
+        """Move parameters not tracked by GMS into the GMS memory pool.
+
+        During the RW loading pipeline, some parameters may be allocated
+        outside the ``use_mem_pool`` context (e.g., buffers created during
+        ``post_load_weights()`` or ``model.to("cuda")``).  These "stray"
+        tensors must be moved into the GMS pool before ``finalize_write()``
+        so that all model state is committed to shared memory.
+
+        This mirrors the GMS library's ``_move_untracked_params()`` behavior
+        (see ``gpu_memory_service.integrations.trtllm.model_loader``).
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+
+        from gpu_memory_service import client as gms_client  # type: ignore[import-not-found]
+        pool = gms_client.get_mem_pool(self._client)
+        device = torch.device('cuda')
+
+        for name, param in model.named_parameters():
+            if param.is_cuda and not pool.is_from_pool(param.data):
+                with torch.cuda.use_mem_pool(pool, device=device):
+                    new_param = param.data.clone()
+                param.data = new_param
+                logger.debug("GMS: moved untracked param %s into pool", name)
+
+        for name, buf in model.named_buffers():
+            if buf.is_cuda and not pool.is_from_pool(buf.data):
+                with torch.cuda.use_mem_pool(pool, device=device):
+                    new_buf = buf.data.clone()
+                buf.data = new_buf
+                logger.debug("GMS: moved untracked buffer %s into pool", name)
 
     def release(self, tag: str = None) -> None:
         if self._client is None:

--- a/tensorrt_llm/_torch/models/checkpoints/__init__.py
+++ b/tensorrt_llm/_torch/models/checkpoints/__init__.py
@@ -19,6 +19,7 @@ from .mistral.checkpoint_loader import (MistralCheckpointLoader,
 from .mistral.config_loader import MistralConfigLoader
 from .mistral.weight_mapper import (MistralLarge3WeightMapper,
                                     MistralWeightMapper)
+from .mx.checkpoint_loader import MXCheckpointLoader
 
 __all__ = [
     "HfConfigLoader", "HfWeightLoader", "HfWeightMapper", "MistralConfigLoader",
@@ -28,5 +29,5 @@ __all__ = [
     "Qwen3MoeHfWeightMapper", "Qwen2VLHfWeightMapper",
     "Qwen3_5MoeHfWeightMapper", "Qwen3NextHfWeightMapper",
     "LlavaNextHfWeightMapper", "MistralLarge3CheckpointLoader",
-    "MistralLarge3WeightMapper", "Qwen3VLHfWeightMapper"
+    "MistralLarge3WeightMapper", "MXCheckpointLoader", "Qwen3VLHfWeightMapper"
 ]

--- a/tensorrt_llm/_torch/models/checkpoints/__init__.py
+++ b/tensorrt_llm/_torch/models/checkpoints/__init__.py
@@ -16,6 +16,7 @@ from .hf.weight_loader import HfWeightLoader
 from .hf.weight_mapper import HfWeightMapper
 from .mistral.checkpoint_loader import (MistralCheckpointLoader,
                                         MistralLarge3CheckpointLoader)
+from .mx.checkpoint_loader import MXCheckpointLoader
 from .mistral.config_loader import MistralConfigLoader
 from .mistral.weight_mapper import (MistralLarge3WeightMapper,
                                     MistralWeightMapper)
@@ -28,5 +29,6 @@ __all__ = [
     "Qwen3MoeHfWeightMapper", "Qwen2VLHfWeightMapper",
     "Qwen3_5MoeHfWeightMapper", "Qwen3NextHfWeightMapper",
     "LlavaNextHfWeightMapper", "MistralLarge3CheckpointLoader",
-    "MistralLarge3WeightMapper", "Qwen3VLHfWeightMapper"
+    "MistralLarge3WeightMapper", "MXCheckpointLoader",
+    "Qwen3VLHfWeightMapper"
 ]

--- a/tensorrt_llm/_torch/models/checkpoints/hf/config_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/config_loader.py
@@ -1,9 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
     BaseConfigLoader
 from tensorrt_llm._torch.models.modeling_utils import register_config_loader
 
 
+@register_config_loader("MX")
 @register_config_loader("HF")
 class HfConfigLoader(BaseConfigLoader):
 

--- a/tensorrt_llm/_torch/models/checkpoints/hf/config_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/config_loader.py
@@ -4,6 +4,7 @@ from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
 from tensorrt_llm._torch.models.modeling_utils import register_config_loader
 
 
+@register_config_loader("MX")
 @register_config_loader("HF")
 class HfConfigLoader(BaseConfigLoader):
 

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -34,6 +34,7 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 
+@register_checkpoint_weight_loader("MX")
 @register_checkpoint_weight_loader("mistral")
 @register_checkpoint_weight_loader("HF")
 class HfWeightLoader(BaseWeightLoader):

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -19,6 +19,7 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 
+@register_checkpoint_weight_loader("MX")
 @register_checkpoint_weight_loader("mistral")
 @register_checkpoint_weight_loader("HF")
 class HfWeightLoader(BaseWeightLoader):

--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_mapper.py
@@ -7,6 +7,7 @@ from tensorrt_llm._torch.modules.linear import W4A16_AWQ_LinearMethod
 from ..base_weight_mapper import BaseWeightMapper
 
 
+@register_mapper("MX")
 @register_mapper("HF")
 class HfWeightMapper(BaseWeightMapper):
 

--- a/tensorrt_llm/_torch/models/checkpoints/mx/__init__.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .checkpoint_loader import MXCheckpointLoader
+
+__all__ = ["MXCheckpointLoader"]

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MX (ModelExpress) checkpoint loader.
+
+Thin adapter on top of the upstream ``modelexpress`` Python client
+(``ai-dynamo/modelexpress``). All NIXL/RDMA mechanics (agent setup,
+tensor registration, source-target name matching, dtype-cast handling,
+PVC fallback, etc.) live in the upstream ``MxLiveWeightLoader`` and
+``publish_model_params`` helpers — we only call them at the right
+points in TRT-LLM's loading lifecycle.
+
+When no MX server is reachable (or the upstream library is not
+installed), this loader transparently falls back to standard
+HuggingFace checkpoint loading (disk -> CPU -> GPU) by way of its
+``HfCheckpointLoader`` base class.
+"""
+
+from typing import Any, Optional
+
+from tensorrt_llm._torch.models.checkpoints.base_config_loader import BaseConfigLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeightLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import BaseWeightMapper
+from tensorrt_llm._torch.models.checkpoints.hf.checkpoint_loader import HfCheckpointLoader
+from tensorrt_llm._torch.models.modeling_utils import register_checkpoint_loader
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
+
+
+@register_checkpoint_loader("MX")
+class MXCheckpointLoader(HfCheckpointLoader):
+    """Checkpoint loader for MX (ModelExpress) P2P weight transfer.
+
+    When an MX server is reachable AND the upstream ``modelexpress``
+    library is installed, weights are transferred directly from a
+    source instance via NIXL/RDMA, bypassing disk I/O. The source
+    publishes its weights *before* ``post_load_weights()`` runs so
+    targets receive raw loaded state and can run their own
+    post-load transforms.
+
+    When the MX server or library is unavailable, this loader
+    transparently falls back to standard HuggingFace checkpoint
+    loading via the parent ``HfCheckpointLoader``.
+
+    All transport-level mechanics (NIXL, dtype casts, source matching,
+    fallback) are delegated to ``modelexpress.trtllm_live_transfer``
+    so that this class stays a thin adapter — when the MX wire
+    protocol or transport evolves, only the upstream library needs
+    to track it.
+    """
+
+    def __init__(
+        self,
+        *,
+        weight_loader: Optional[BaseWeightLoader] = None,
+        weight_mapper: Optional[BaseWeightMapper] = None,
+        config_loader: Optional[BaseConfigLoader] = None,
+        mx_server_url: Optional[str] = None,
+    ):
+        super().__init__(
+            weight_loader=weight_loader,
+            weight_mapper=weight_mapper,
+            config_loader=config_loader,
+        )
+        # Align the backing attribute with the property override so any
+        # caller reading self._checkpoint_format directly also sees "MX".
+        self._checkpoint_format = "MX"
+        self._mx_server_url = mx_server_url
+        self._p2p_succeeded = False
+
+    @property
+    def checkpoint_format(self) -> str:
+        """Override parent's checkpoint_format to return 'MX'."""
+        return "MX"
+
+    @property
+    def mx_server_url(self) -> Optional[str]:
+        return self._mx_server_url
+
+    @property
+    def p2p_succeeded(self) -> bool:
+        """Whether the last load_weights() call used P2P transfer.
+
+        ``True`` means weights are already in model parameter buffers
+        and the standard weight-mapping pipeline should be skipped
+        for those parameters.
+        """
+        return self._p2p_succeeded
+
+    def load_weights(self, checkpoint_dir: str, mapping: Mapping, **kwargs) -> dict[str, Any]:
+        """Load weights, preferring MX P2P transfer when available.
+
+        Delegates the actual transfer to the upstream
+        ``modelexpress.trtllm_live_transfer.MxLiveWeightLoader``,
+        which handles NIXL setup, source discovery, name matching,
+        dtype casting, and PVC fallback for size-mismatched tensors.
+
+        Args:
+            checkpoint_dir: Path to the HF checkpoint directory.
+            mapping: Distributed mapping configuration.
+            **kwargs: Additional keyword arguments. When ``model`` is
+                passed it is used as the target for direct P2P writes.
+
+        Returns:
+            A weights dict. Empty when MX P2P fully succeeded (weights
+            already in model params); populated when falling back to
+            disk loading for some or all weights.
+        """
+        model = kwargs.pop("model", None)
+        self._p2p_succeeded = False
+
+        if self._mx_server_url is None or model is None:
+            return self._fallback_to_disk(
+                checkpoint_dir,
+                mapping,
+                reason=(
+                    "no MX server URL configured"
+                    if self._mx_server_url is None
+                    else "no model reference passed (cannot do P2P writes)"
+                ),
+                **kwargs,
+            )
+
+        try:
+            from modelexpress.trtllm_live_transfer import (  # type: ignore[import-not-found]
+                MxLiveWeightLoader,
+            )
+        except ImportError:
+            logger.warning(
+                "modelexpress library not installed; cannot use MX P2P "
+                "weight transfer. Install from "
+                "https://github.com/ai-dynamo/modelexpress (Python client at "
+                "modelexpress_client/python). Falling back to disk loading."
+            )
+            return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
+
+        try:
+            mx_loader = MxLiveWeightLoader(mx_server=self._mx_server_url)
+            fallback_weights = mx_loader.load_weights(
+                checkpoint_dir,
+                mapping=mapping,
+                model=model,
+            )
+        except Exception as e:
+            logger.warning(
+                "MX P2P transfer failed (%s). Falling back to disk loading.",
+                e,
+            )
+            return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
+
+        if fallback_weights:
+            # Mixed-success case: MX delivered most weights into model
+            # params via P2P, but returned a dict of size-mismatched
+            # tensors that still need to be loaded via the standard
+            # pipeline. Marking Linear modules as fully presharded would
+            # then incorrectly skip TP slicing for those fallback
+            # weights too. The conservative correct behavior is to fall
+            # through to the standard disk path entirely, which loads
+            # *all* weights normally and ignores the MX-written ones.
+            #
+            # (When LoadFormat.PRESHARDED lands upstream, the proper
+            # fix is per-tensor presharded marking based on whether
+            # MX delivered that tensor.)
+            logger.warning(
+                "MX P2P returned %d fallback weights (size mismatch) from "
+                "%s. Falling back to full disk load to avoid mixing "
+                "presharded and non-presharded weights.",
+                len(fallback_weights),
+                self._mx_server_url,
+            )
+            return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
+
+        self._p2p_succeeded = True
+        logger.info(
+            "MX P2P weight transfer succeeded from %s",
+            self._mx_server_url,
+        )
+        return {}
+
+    def _fallback_to_disk(
+        self, checkpoint_dir: str, mapping: Mapping, *, reason: Optional[str] = None, **kwargs
+    ) -> dict[str, Any]:
+        """Standard HF disk loading fallback."""
+        if reason is not None:
+            logger.info(
+                "MX P2P unavailable (%s); loading from disk: %s",
+                reason,
+                checkpoint_dir,
+            )
+        else:
+            logger.info("MX P2P unavailable; loading from disk: %s", checkpoint_dir)
+        return super().load_weights(checkpoint_dir, mapping=mapping, **kwargs)
+
+    def publish_as_source(
+        self,
+        model,
+        mapping: Optional[Mapping] = None,
+        checkpoint_dir: Optional[str] = None,
+    ) -> None:
+        """Publish this instance's weights so other ranks can pull via P2P.
+
+        Called by the integration in ``model_loader.py`` *before*
+        ``post_load_weights()`` so targets receive raw loaded state and
+        can apply their own post-load transforms.
+
+        Delegates to the upstream
+        ``modelexpress.trtllm_live_transfer.publish_model_params``
+        helper, which handles the per-rank NIXL setup, tensor
+        registration, and gRPC publish.
+
+        Args:
+            model: The model whose weights to publish.
+            mapping: Distributed mapping. Currently unused — kept for
+                signature symmetry with the prior prototype API and for
+                forward-compat with future upstream signatures.
+            checkpoint_dir: Checkpoint directory. Currently unused —
+                upstream uses the ``MODEL_NAME`` env var for identity.
+        """
+        # mapping/checkpoint_dir are deliberately unused; see docstring.
+        del mapping, checkpoint_dir
+
+        if self._mx_server_url is None:
+            return
+
+        try:
+            from modelexpress.trtllm_live_transfer import (  # type: ignore[import-not-found]
+                publish_model_params,
+            )
+        except ImportError:
+            logger.debug("modelexpress library not installed; skipping MX publish.")
+            return
+
+        # Upstream publish_model_params reads MODEL_EXPRESS_URL from env;
+        # set it from our config so the per-server URL is respected.
+        import os
+
+        prior_url = os.environ.get("MODEL_EXPRESS_URL")
+        os.environ["MODEL_EXPRESS_URL"] = self._mx_server_url
+        try:
+            publish_model_params(model)
+            logger.info(
+                "Published weights to MX server at %s",
+                self._mx_server_url,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to publish weights to MX server at %s: %s",
+                self._mx_server_url,
+                e,
+            )
+        finally:
+            if prior_url is None:
+                os.environ.pop("MODEL_EXPRESS_URL", None)
+            else:
+                os.environ["MODEL_EXPRESS_URL"] = prior_url

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -28,7 +28,9 @@ HuggingFace checkpoint loading (disk -> CPU -> GPU) by way of its
 ``HfCheckpointLoader`` base class.
 """
 
-from typing import Any, Optional
+import os
+from pathlib import Path
+from typing import Any, Optional, Union
 
 from tensorrt_llm._torch.models.checkpoints.base_config_loader import BaseConfigLoader
 from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeightLoader
@@ -37,6 +39,16 @@ from tensorrt_llm._torch.models.checkpoints.hf.checkpoint_loader import HfCheckp
 from tensorrt_llm._torch.models.modeling_utils import register_checkpoint_loader
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
+
+# Defensive default for the upstream ``MX_SOURCE_QUERY_TIMEOUT`` env var.
+# The upstream ``MxLiveWeightLoader`` polls the MX server every 5 s for up
+# to ``MX_SOURCE_QUERY_TIMEOUT`` seconds (default 3600 = 1 hour) waiting
+# for a source. On a cold cluster (no donor up yet), this means the very
+# first replica blocks for an hour before falling back to disk. We cap
+# the default at 30 s so first-replica startup degrades gracefully; users
+# can still override via the env var or a future per-loader knob.
+# Tracked as MX-4 in §15 (non-blocking source-query API upstream).
+_MX_SOURCE_QUERY_TIMEOUT_DEFAULT_S = "30"
 
 
 @register_checkpoint_loader("MX")
@@ -68,6 +80,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
         weight_mapper: Optional[BaseWeightMapper] = None,
         config_loader: Optional[BaseConfigLoader] = None,
         mx_server_url: Optional[str] = None,
+        model_name: Optional[Union[str, Path]] = None,
     ):
         super().__init__(
             weight_loader=weight_loader,
@@ -78,7 +91,23 @@ class MXCheckpointLoader(HfCheckpointLoader):
         # caller reading self._checkpoint_format directly also sees "MX".
         self._checkpoint_format = "MX"
         self._mx_server_url = mx_server_url
+        # ``model_name`` is the human-readable identity to publish/look up
+        # under on the MX server. Typically the user-supplied
+        # ``llm_args.model`` (a Hub ID like ``"Qwen/Qwen2.5-72B-Instruct"``
+        # or a local path). ``publish_as_source()`` resolves it via
+        # :func:`_resolve_mx_model_name` (with HF-snapshot path fallback).
+        self._model_name = str(model_name) if model_name is not None else None
         self._p2p_succeeded = False
+
+        # Defensive default for upstream's source-query timeout. Only
+        # applied when an MX server URL is configured (so HF-only loads
+        # are unaffected). Uses ``setdefault`` so an explicit user value
+        # always wins.
+        if mx_server_url is not None:
+            os.environ.setdefault(
+                "MX_SOURCE_QUERY_TIMEOUT",
+                _MX_SOURCE_QUERY_TIMEOUT_DEFAULT_S,
+            )
 
     @property
     def checkpoint_format(self) -> str:
@@ -88,6 +117,17 @@ class MXCheckpointLoader(HfCheckpointLoader):
     @property
     def mx_server_url(self) -> Optional[str]:
         return self._mx_server_url
+
+    @property
+    def model_name(self) -> Optional[str]:
+        """Explicit model identity passed to the constructor (if any).
+
+        Note this is the *as-configured* value (e.g. ``llm_args.model``),
+        not the final resolved identity that ends up in the published
+        ``MODEL_NAME``. The full resolution (with env var and basename
+        fallbacks) happens inside :meth:`publish_as_source`.
+        """
+        return self._model_name
 
     @property
     def p2p_succeeded(self) -> bool:
@@ -225,11 +265,12 @@ class MXCheckpointLoader(HfCheckpointLoader):
             mapping: Distributed mapping. Currently unused — kept for
                 signature symmetry with the prior prototype API and for
                 forward-compat with future upstream signatures.
-            checkpoint_dir: Checkpoint directory. Currently unused —
-                upstream uses the ``MODEL_NAME`` env var for identity.
+            checkpoint_dir: Checkpoint directory. Used as a last-resort
+                fallback for resolving the ``MODEL_NAME`` identity when
+                neither ``model_name`` was passed to the constructor nor
+                ``MODEL_NAME`` is set in the environment.
         """
-        # mapping/checkpoint_dir are deliberately unused; see docstring.
-        del mapping, checkpoint_dir
+        del mapping  # currently unused; see docstring.
 
         if self._mx_server_url is None:
             return
@@ -242,17 +283,29 @@ class MXCheckpointLoader(HfCheckpointLoader):
             logger.debug("modelexpress library not installed; skipping MX publish.")
             return
 
-        # Upstream publish_model_params reads MODEL_EXPRESS_URL from env;
-        # set it from our config so the per-server URL is respected.
-        import os
+        # Upstream publish_model_params reads MODEL_EXPRESS_URL and
+        # MODEL_NAME from the environment. Set both from our resolved
+        # configuration so per-instance values (URL passed via
+        # llm_args.mx_server_url, identity from llm_args.model) are
+        # respected, then restore prior state. Tracked as MX-2 in §15
+        # (the env-var dance goes away when upstream exports a public
+        # ``build_identity()`` we can call directly).
+        resolved_name = _resolve_mx_model_name(self._model_name, checkpoint_dir)
 
-        prior_url = os.environ.get("MODEL_EXPRESS_URL")
-        os.environ["MODEL_EXPRESS_URL"] = self._mx_server_url
+        env_overrides = {
+            "MODEL_EXPRESS_URL": self._mx_server_url,
+            "MODEL_NAME": resolved_name,
+        }
+        prior = {key: os.environ.get(key) for key in env_overrides}
+        for key, value in env_overrides.items():
+            os.environ[key] = value
+
         try:
             publish_model_params(model)
             logger.info(
-                "Published weights to MX server at %s",
+                "Published weights to MX server at %s as model=%r",
                 self._mx_server_url,
+                resolved_name,
             )
         except Exception as e:
             logger.warning(
@@ -261,7 +314,65 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 e,
             )
         finally:
-            if prior_url is None:
-                os.environ.pop("MODEL_EXPRESS_URL", None)
-            else:
-                os.environ["MODEL_EXPRESS_URL"] = prior_url
+            for key, prior_value in prior.items():
+                if prior_value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = prior_value
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_mx_model_name(model_name_arg: Optional[str], checkpoint_dir: Optional[str]) -> str:
+    """Resolve a stable model identity for publishing to the MX server.
+
+    Resolution order (first non-empty wins):
+
+    1. ``model_name_arg`` — the explicit value passed at construction
+       time (typically ``llm_args.model``: a Hub ID like
+       ``"Qwen/Qwen2.5-72B-Instruct"`` or a local path).
+    2. ``MODEL_NAME`` env var — upstream's existing convention.
+    3. ``checkpoint_dir`` basename, with HF-snapshot path fallback so
+       ``.../models--<org>--<name>/snapshots/<sha>/`` resolves to
+       ``"<org>/<name>"`` instead of the commit hash.
+    4. Literal ``"unknown"`` — matches upstream's own sentinel.
+    """
+    candidate = model_name_arg or os.environ.get("MODEL_NAME") or checkpoint_dir
+    if not candidate:
+        return "unknown"
+    return _normalize_model_identity(str(candidate))
+
+
+def _normalize_model_identity(s: str) -> str:
+    """Convert a model identifier to a stable, human-readable name.
+
+    Hub IDs (``"org/name"``) and arbitrary user-provided strings are
+    returned unchanged. Filesystem paths are reduced to a basename, with
+    HuggingFace cache snapshot layouts (``snapshots/<commit-sha>/``)
+    walked up to recover the original ``"org/name"`` identity.
+    """
+    if not s:
+        return "unknown"
+
+    # Heuristic: a Hub ID is bare ``"name"`` or ``"org/name"``. Anything
+    # that starts with a path separator/expansion or contains more than
+    # one "/" is treated as a path. Single-"/" strings remain ambiguous;
+    # we side with the Hub ID interpretation unless the path also exists
+    # on disk (in which case we assume the user gave us a real path).
+    looks_like_path = s.startswith(("/", "./", "../", "~")) or s.count("/") > 1 or os.path.exists(s)
+    if not looks_like_path:
+        return s
+
+    p = Path(s).expanduser()
+    name = p.name
+    if name and "snapshots" in p.parts:
+        # HF cache layout: ``.../models--<org>--<name>/snapshots/<sha>/``.
+        # Walk up to find the ``models--<org>--<name>`` directory and
+        # un-mangle it back to ``"<org>/<name>"``.
+        for ancestor in p.parents:
+            if ancestor.name.startswith("models--"):
+                return ancestor.name[len("models--") :].replace("--", "/")
+    return name or "unknown"

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Optional
+
+from tensorrt_llm._torch.models.checkpoints.base_config_loader import \
+    BaseConfigLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
+    BaseWeightLoader
+from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
+    BaseWeightMapper
+from tensorrt_llm._torch.models.checkpoints.hf.checkpoint_loader import \
+    HfCheckpointLoader
+from tensorrt_llm._torch.models.modeling_utils import \
+    register_checkpoint_loader
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
+
+
+@register_checkpoint_loader("MX")
+class MXCheckpointLoader(HfCheckpointLoader):
+    """Checkpoint loader for MX (Model eXchange) P2P weight transfer.
+
+    When an MX server is available, weights are transferred directly from a
+    source instance via P2P (GPU-to-GPU or NVLink), bypassing disk I/O.
+    The source publishes weights *before* post_load_weights() runs, so the
+    target receives raw loaded state and applies its own transforms.
+
+    When no MX server is reachable, this loader transparently falls back to
+    standard HuggingFace checkpoint loading (disk -> CPU -> GPU).
+    """
+
+    def __init__(
+        self,
+        *,
+        weight_loader: Optional[BaseWeightLoader] = None,
+        weight_mapper: Optional[BaseWeightMapper] = None,
+        config_loader: Optional[BaseConfigLoader] = None,
+        mx_server_url: Optional[str] = None,
+    ):
+        super().__init__(
+            weight_loader=weight_loader,
+            weight_mapper=weight_mapper,
+            config_loader=config_loader,
+        )
+        # Align the backing attribute with the property override, so code
+        # that reads self._checkpoint_format directly (instead of the
+        # property) also sees "MX".
+        self._checkpoint_format = "MX"
+        self._mx_server_url = mx_server_url
+        self._p2p_succeeded = False
+        self._identity = None
+
+    @property
+    def checkpoint_format(self) -> str:
+        """Override parent's checkpoint_format to return 'MX'."""
+        return "MX"
+
+    @property
+    def mx_server_url(self) -> Optional[str]:
+        return self._mx_server_url
+
+    @property
+    def p2p_succeeded(self) -> bool:
+        """Whether the last load_weights() call used P2P transfer."""
+        return self._p2p_succeeded
+
+    def load_weights(self, checkpoint_dir: str, mapping: Mapping,
+                     **kwargs) -> dict[str, Any]:
+        """Load weights, preferring MX P2P transfer when available.
+
+        When P2P succeeds, weights are written directly into the model's
+        parameter buffers by the MX library.  This method returns an empty
+        dict so the caller knows to skip the normal weight-mapping pipeline.
+
+        When P2P is unavailable, falls back to the parent HF weight loader.
+
+        Args:
+            checkpoint_dir: Path to the HF checkpoint directory.
+            mapping: Distributed mapping configuration.
+            **kwargs: Additional keyword arguments. When ``model`` is passed,
+                it is used as the target for direct P2P weight writes.
+
+        Returns:
+            A weights dict.  Empty when P2P succeeded (weights already in
+            model params); populated when falling back to disk loading.
+        """
+        model = kwargs.pop("model", None)
+        self._p2p_succeeded = False
+
+        if self._mx_server_url is not None and model is not None:
+            if self._try_p2p_transfer(model, mapping, checkpoint_dir):
+                self._p2p_succeeded = True
+                logger.info(
+                    "MX P2P weight transfer succeeded from %s",
+                    self._mx_server_url,
+                )
+                return {}
+
+        # Fallback: load from disk using the standard HF weight loader.
+        logger.info(
+            "MX P2P unavailable, falling back to HF checkpoint loading "
+            "from %s",
+            checkpoint_dir,
+        )
+        return super().load_weights(checkpoint_dir, mapping=mapping, **kwargs)
+
+    def _build_identity(self, mapping: Mapping, checkpoint_dir: str) -> Any:
+        """Map TRT-LLM's Mapping to MX's SourceIdentity protobuf.
+
+        This encodes the full distributed topology (TP, PP, EP) so the MX
+        server can match compatible sources for P2P transfer.
+        """
+        try:
+            from modelexpress import proto as mx_proto  # type: ignore[import-not-found]
+
+            return mx_proto.SourceIdentity(
+                model_name=checkpoint_dir,
+                dtype=str(mapping.dtype) if hasattr(mapping, 'dtype') else "",
+                extra_params={
+                    "tp_size": str(mapping.tp_size),
+                    "pp_size": str(mapping.pp_size),
+                    "ep_size": str(mapping.moe_ep_size),
+                    "worker_rank": str(mapping.tp_rank),
+                    "pp_rank": str(mapping.pp_rank),
+                },
+            )
+        except ImportError:
+            return None
+
+    def _try_p2p_transfer(self, model, mapping: Mapping,
+                          checkpoint_dir: str) -> bool:
+        """Attempt P2P weight transfer from the MX server.
+
+        Uses the modelexpress client SDK to discover compatible sources
+        and perform NIXL-based GPU-to-GPU transfer.
+
+        Returns:
+            True if transfer succeeded, False otherwise.
+        """
+        try:
+            from modelexpress import client as mx_client  # type: ignore[import-not-found]
+
+            identity = self._build_identity(mapping, checkpoint_dir)
+            if identity is None:
+                logger.warning(
+                    "Could not build MX identity (modelexpress.proto "
+                    "not available). Skipping P2P transfer.")
+                return False
+            self._identity = identity
+
+            connection = mx_client.connect(self._mx_server_url)
+            sources = connection.list_sources(identity)
+
+            # Find a source that matches this rank's topology.
+            compatible = [
+                s for s in sources
+                if s.worker_rank == mapping.tp_rank
+                and s.extra_params.get("pp_rank") == str(mapping.pp_rank)
+            ]
+
+            if compatible:
+                connection.receive(compatible[0])
+                return True
+            else:
+                logger.info(
+                    "No compatible MX source found for tp_rank=%d, "
+                    "pp_rank=%d. Falling back to disk loading.",
+                    mapping.tp_rank, mapping.pp_rank)
+                return False
+
+        except ImportError:
+            logger.warning(
+                "modelexpress library not installed; cannot use P2P weight "
+                "transfer. Install with: pip install nvidia-modelexpress")
+            return False
+        except Exception as e:
+            logger.warning("MX P2P transfer failed: %s. "
+                           "Falling back to disk loading.", e)
+            return False
+
+    def publish_as_source(self, model, mapping: Mapping = None,
+                          checkpoint_dir: str = None) -> None:
+        """Publish this instance's weights so other ranks can pull via P2P.
+
+        Called *before* post_load_weights() so targets receive the raw
+        loaded state and can apply their own post-load transforms.
+
+        Args:
+            model: The model whose weights to publish.
+            mapping: Distributed mapping (used to build identity if not
+                already cached from load_weights).
+            checkpoint_dir: Checkpoint directory (used for model identity).
+        """
+        if self._mx_server_url is None:
+            return
+
+        try:
+            from modelexpress import client as mx_client  # type: ignore[import-not-found]
+
+            # Build identity if not cached from a prior load_weights() call.
+            identity = self._identity
+            if identity is None and mapping is not None and checkpoint_dir is not None:
+                identity = self._build_identity(mapping, checkpoint_dir)
+
+            if identity is None:
+                logger.warning(
+                    "Cannot publish MX source: no identity available. "
+                    "Provide mapping and checkpoint_dir arguments.")
+                return
+
+            connection = mx_client.connect(self._mx_server_url)
+            connection.register_source(model, identity)
+            logger.info("Published weights to MX server at %s",
+                        self._mx_server_url)
+        except ImportError:
+            logger.debug(
+                "modelexpress library not installed; skipping publish.")
+        except Exception as e:
+            logger.warning("Failed to publish weights to MX server: %s", e)

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from __future__ import annotations
 
 import enum
@@ -172,6 +175,22 @@ def copy_weight_shard(dst: Parameter, src: torch.Tensor, shard_offset: int,
     dst[shard_offset:shard_offset + shard_size].data.copy_(src)
 
 
+def _effective_tp_coords(module: Linear) -> tuple[int, int]:
+    """Return (tp_size, tp_rank) accounting for ``_weights_presharded``.
+
+    When a module's weights are already TP-sharded for the local rank
+    (e.g. delivered via MX P2P transfer), TRT-LLM's standard TP slicing
+    must be skipped for *all* tensors associated with the module — the
+    main weight and bias *and* their quantization metadata
+    (weight_scale, input_scale, pre_quant_scale, etc.). Otherwise
+    full-size weights would be paired with re-sliced metadata, causing
+    shape mismatches or silent numerical errors on quantized models.
+    """
+    if getattr(module, '_weights_presharded', False):
+        return 1, 0
+    return module.tp_size, module.tp_rank
+
+
 def load_weights_vanilla_helper(module: Linear,
                                 weights: List[Dict],
                                 weight_transform=lambda x: x,
@@ -184,8 +203,11 @@ def load_weights_vanilla_helper(module: Linear,
             assert "bias" in weights[0]
     device = torch.device('cuda')
 
-    weight = load_weight_shard(weights[0]['weight'], module.tp_size,
-                               module.tp_rank, module.tp_mode,
+    # Skip TP slicing when weights are already sharded (e.g. MX P2P transfer).
+    tp_size, tp_rank = _effective_tp_coords(module)
+
+    weight = load_weight_shard(weights[0]['weight'], tp_size, tp_rank,
+                               module.tp_mode,
                                device) if "weight" in weights[0] else None
 
     if weight is not None:
@@ -201,8 +223,8 @@ def load_weights_vanilla_helper(module: Linear,
         copy_weight(module.weight, weight_transform(weight))
 
     if module.bias is not None:
-        bias = load_weight_shard(weights[0]['bias'], module.tp_size,
-                                 module.tp_rank, module.tp_mode,
+        bias = load_weight_shard(weights[0]['bias'], tp_size, tp_rank,
+                                 module.tp_mode,
                                  device) if "bias" in weights[0] else None
         if bias is not None:
             copy_weight(module.bias, bias_transform(bias))
@@ -225,25 +247,28 @@ def load_weights_fused_qkv_helper(
         ) is not None, "Fused weight shard indices mapping is required in partial loading"
     device = torch.device('cuda')
 
-    q_weight = load_weight_shard(weights[0]['weight'], module.tp_size,
-                                 module.tp_rank, module.tp_mode,
+    # Skip TP slicing when weights are already sharded (e.g. MX P2P transfer).
+    tp_size, tp_rank = _effective_tp_coords(module)
+
+    q_weight = load_weight_shard(weights[0]['weight'], tp_size, tp_rank,
+                                 module.tp_mode,
                                  device) if "weight" in weights[0] else None
-    k_weight = load_weight_shard(weights[1]['weight'], module.tp_size,
-                                 module.tp_rank, module.tp_mode,
+    k_weight = load_weight_shard(weights[1]['weight'], tp_size, tp_rank,
+                                 module.tp_mode,
                                  device) if "weight" in weights[1] else None
-    v_weight = load_weight_shard(weights[2]['weight'], module.tp_size,
-                                 module.tp_rank, module.tp_mode,
+    v_weight = load_weight_shard(weights[2]['weight'], tp_size, tp_rank,
+                                 module.tp_mode,
                                  device) if "weight" in weights[2] else None
 
     if module.bias is not None:
-        q_bias = load_weight_shard(weights[0]['bias'], module.tp_size,
-                                   module.tp_rank, module.tp_mode,
+        q_bias = load_weight_shard(weights[0]['bias'], tp_size, tp_rank,
+                                   module.tp_mode,
                                    device) if "bias" in weights[0] else None
-        k_bias = load_weight_shard(weights[1]['bias'], module.tp_size,
-                                   module.tp_rank, module.tp_mode,
+        k_bias = load_weight_shard(weights[1]['bias'], tp_size, tp_rank,
+                                   module.tp_mode,
                                    device) if "bias" in weights[1] else None
-        v_bias = load_weight_shard(weights[2]['bias'], module.tp_size,
-                                   module.tp_rank, module.tp_mode,
+        v_bias = load_weight_shard(weights[2]['bias'], tp_size, tp_rank,
+                                   module.tp_mode,
                                    device) if "bias" in weights[2] else None
         if not allow_partial_loading:
             copy_weight(module.bias,
@@ -278,18 +303,21 @@ def load_weights_fused_gate_up_helper(
         ) is not None, "Fused weight shard indices mapping is required in partial loading"
     device = torch.device('cuda')
 
-    gate_weight = load_weight_shard(weights[0]['weight'], module.tp_size,
-                                    module.tp_rank, module.tp_mode,
+    # Skip TP slicing when weights are already sharded (e.g. MX P2P transfer).
+    tp_size, tp_rank = _effective_tp_coords(module)
+
+    gate_weight = load_weight_shard(weights[0]['weight'], tp_size, tp_rank,
+                                    module.tp_mode,
                                     device) if "weight" in weights[0] else None
-    up_weight = load_weight_shard(weights[1]['weight'], module.tp_size,
-                                  module.tp_rank, module.tp_mode,
+    up_weight = load_weight_shard(weights[1]['weight'], tp_size, tp_rank,
+                                  module.tp_mode,
                                   device) if "weight" in weights[1] else None
     if module.bias is not None:
-        gate_bias = load_weight_shard(weights[0]['bias'], module.tp_size,
-                                      module.tp_rank, module.tp_mode,
+        gate_bias = load_weight_shard(weights[0]['bias'], tp_size, tp_rank,
+                                      module.tp_mode,
                                       device) if "bias" in weights[0] else None
-        up_bias = load_weight_shard(weights[1]['bias'], module.tp_size,
-                                    module.tp_rank, module.tp_mode,
+        up_bias = load_weight_shard(weights[1]['bias'], tp_size, tp_rank,
+                                    module.tp_mode,
                                     device) if "bias" in weights[1] else None
         if not allow_partial_loading:
             copy_weight(module.bias,
@@ -933,10 +961,10 @@ class FP8RowwiseLinearMethod(UnquantizedLinearMethod):
         super().load_weights_vanilla(
             module, weights, allow_partial_loading=allow_partial_loading)
         scale_name = self._get_scale_name(weights)
+        tp_size, tp_rank = _effective_tp_coords(module)
         if scale_name in weights[0]:
-            weight_scale = load_weight_shard(weights[0][scale_name],
-                                             module.tp_size, module.tp_rank,
-                                             module.tp_mode)
+            weight_scale = load_weight_shard(weights[0][scale_name], tp_size,
+                                             tp_rank, module.tp_mode)
             copy_weight(module.weight_scale, weight_scale)
         if "input_scale" in weights[0]:
             copy_weight(module.input_scale, weights[0]["input_scale"])
@@ -949,14 +977,15 @@ class FP8RowwiseLinearMethod(UnquantizedLinearMethod):
         super().load_weights_fused_qkv_linear(
             module, weights, allow_partial_loading=allow_partial_loading)
         scale_name = self._get_scale_name(weights)
+        tp_size, tp_rank = _effective_tp_coords(module)
         q_scale = load_weight_shard(
-            weights[0][scale_name], module.tp_size, module.tp_rank,
+            weights[0][scale_name], tp_size, tp_rank,
             module.tp_mode) if scale_name in weights[0] else None
         k_scale = load_weight_shard(
-            weights[1][scale_name], module.tp_size, module.tp_rank,
+            weights[1][scale_name], tp_size, tp_rank,
             module.tp_mode) if scale_name in weights[1] else None
         v_scale = load_weight_shard(
-            weights[2][scale_name], module.tp_size, module.tp_rank,
+            weights[2][scale_name], tp_size, tp_rank,
             module.tp_mode) if scale_name in weights[2] else None
         for shard_key, scale in zip(
                 module.fused_weight_shard_indices_mapping.keys(),
@@ -975,11 +1004,12 @@ class FP8RowwiseLinearMethod(UnquantizedLinearMethod):
         super().load_weights_fused_gate_up_linear(
             module, weights, allow_partial_loading=allow_partial_loading)
         scale_name = self._get_scale_name(weights)
+        tp_size, tp_rank = _effective_tp_coords(module)
         gate_scale = load_weight_shard(
-            weights[0][scale_name], module.tp_size, module.tp_rank,
+            weights[0][scale_name], tp_size, tp_rank,
             module.tp_mode) if scale_name in weights[0] else None
         up_scale = load_weight_shard(
-            weights[1][scale_name], module.tp_size, module.tp_rank,
+            weights[1][scale_name], tp_size, tp_rank,
             module.tp_mode) if scale_name in weights[1] else None
         for shard_key, scale in zip(
                 module.fused_weight_shard_indices_mapping.keys(),
@@ -1085,8 +1115,9 @@ class FP8BlockScalesLinearMethod(UnquantizedLinearMethod):
             # modelopt fp8_pb_wo can have 2 extra singleton dimensions
             if full_weight_scale.dim() == 4:
                 full_weight_scale = full_weight_scale.squeeze(1).squeeze(-1)
-            weight_scale = load_weight_shard(full_weight_scale, module.tp_size,
-                                             module.tp_rank, module.tp_mode)
+            tp_size, tp_rank = _effective_tp_coords(module)
+            weight_scale = load_weight_shard(full_weight_scale, tp_size,
+                                             tp_rank, module.tp_mode)
             copy_weight(module.weight_scale, weight_scale)
         if "input_scale" in weights[0]:
             copy_weight(module.input_scale, weights[0]["input_scale"])
@@ -1129,8 +1160,9 @@ class FP8BlockScalesLinearMethod(UnquantizedLinearMethod):
             for s in full_scales
         ]
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         scales = [
-            load_weight_shard(s, module.tp_size, module.tp_rank, module.tp_mode)
+            load_weight_shard(s, tp_size, tp_rank, module.tp_mode)
             if s is not None else None for s in full_scales_squeezed
         ]
         processed_mapping = self.remap_fused_shard_indices_by_divisible_factor(
@@ -1157,8 +1189,9 @@ class FP8BlockScalesLinearMethod(UnquantizedLinearMethod):
             s.squeeze(1).squeeze(-1) if s is not None and s.dim() == 4 else s
             for s in full_scales
         ]
+        tp_size, tp_rank = _effective_tp_coords(module)
         scales = [
-            load_weight_shard(s, module.tp_size, module.tp_rank, module.tp_mode)
+            load_weight_shard(s, tp_size, tp_rank, module.tp_mode)
             if s is not None else None for s in full_scales_squeezed
         ]
         processed_mapping = self.remap_fused_shard_indices_by_divisible_factor(
@@ -1416,11 +1449,9 @@ class NVFP4LinearMethod(LinearMethodBase):
     def load_weights_vanilla(self, module: Linear, weights: List[Dict]) -> None:
         load_weights_vanilla_helper(module, weights)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         input_scale, weight_scale, weight_scale_2, alpha = self.load_weight_scales(
-            weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
+            weights, tp_size=tp_size, tp_rank=tp_rank, tp_mode=module.tp_mode)
 
         assert len(weights) == 1
         weight_scale = weight_scale[0]
@@ -1444,8 +1475,8 @@ class NVFP4LinearMethod(LinearMethodBase):
             device = module.weight.device
             pre_quant_scale = load_weight_shard(
                 weights[0]["pre_quant_scale"],
-                module.tp_size,
-                module.tp_rank,
+                tp_size,
+                tp_rank,
                 # pre_quant_scale applies to activation as opposed to weight, so flip tp_mode the other way around
                 TensorParallelMode.flip(module.tp_mode),
                 device,
@@ -1462,11 +1493,9 @@ class NVFP4LinearMethod(LinearMethodBase):
         q_weight, k_weight, v_weight = load_weights_fused_qkv_helper(
             module, weights)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         input_scale, weight_scales, weight_scale_2, alpha = self.load_weight_scales(
-            weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
+            weights, tp_size=tp_size, tp_rank=tp_rank, tp_mode=module.tp_mode)
         weight_scale = torch.cat(weight_scales, 0)
         weight_scale = torch.ops.trtllm.block_scale_interleave(weight_scale)
 
@@ -1502,11 +1531,9 @@ class NVFP4LinearMethod(LinearMethodBase):
         fused_weight = torch.cat((gate_weight, up_weight))
         copy_weight(module.weight, fused_weight)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         input_scale, weight_scales, weight_scale_2, alpha = self.load_weight_scales(
-            weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
+            weights, tp_size=tp_size, tp_rank=tp_rank, tp_mode=module.tp_mode)
         weight_scale = torch.cat(weight_scales, 0)
         weight_scale = torch.ops.trtllm.block_scale_interleave(weight_scale)
 
@@ -1527,8 +1554,8 @@ class NVFP4LinearMethod(LinearMethodBase):
             device = module.weight.device
             pre_quant_scale = load_weight_shard(
                 weights[0]["pre_quant_scale"],
-                module.tp_size,
-                module.tp_rank,
+                tp_size,
+                tp_rank,
                 # pre_quant_scale applies to activation as opposed to weight, so flip tp_mode the other way around
                 TensorParallelMode.flip(module.tp_mode),
                 device,
@@ -1701,11 +1728,9 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
             module, weights,
             lambda w: fp4_utils.shuffle_matrix_a(w, module.epilogue_tile_m))
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         input_scale, weight_scale, weight_scale_2, alpha = self.load_weight_scales(
-            weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
+            weights, tp_size=tp_size, tp_rank=tp_rank, tp_mode=module.tp_mode)
 
         assert len(weights) == 1
         weight_scale = weight_scale[0]
@@ -1724,11 +1749,9 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
         q_weight, k_weight, v_weight = load_weights_fused_qkv_helper(
             module, weights)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         input_scale, weight_scales, weight_scale_2, alpha = self.load_weight_scales(
-            weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
+            weights, tp_size=tp_size, tp_rank=tp_rank, tp_mode=module.tp_mode)
         # Swizzle weight scales after concatenation
         weight_scale = torch.cat(weight_scales, 0)
         # Shuffle and Swizzle weight scale
@@ -1755,11 +1778,9 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
                                                   module.epilogue_tile_m)
         copy_weight(module.weight, fused_weight)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         input_scale, weight_scales, weight_scale_2, alpha = self.load_weight_scales(
-            weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
+            weights, tp_size=tp_size, tp_rank=tp_rank, tp_mode=module.tp_mode)
         # Swizzle weight scales after concatenation
         weight_scale = torch.cat(weight_scales, 0)
         # Shuffle and Swizzle weight scale
@@ -1843,9 +1864,10 @@ class W4A8MXFP4FP8LinearMethod(LinearMethodBase):
     def load_weights_vanilla(self, module: Linear, weights: List[Dict]) -> None:
         load_weights_vanilla_helper(module, weights)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         weight_scale = self.load_weight_scales(weights,
-                                               tp_size=module.tp_size,
-                                               tp_rank=module.tp_rank,
+                                               tp_size=tp_size,
+                                               tp_rank=tp_rank,
                                                tp_mode=module.tp_mode)
         assert len(weights) == 1
         weight_scale = weight_scale[0]
@@ -1860,9 +1882,10 @@ class W4A8MXFP4FP8LinearMethod(LinearMethodBase):
         fused_weight = torch.cat((q_weight, k_weight, v_weight))
         copy_weight(module.weight, fused_weight)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         weight_scale = self.load_weight_scales(weights,
-                                               tp_size=module.tp_size,
-                                               tp_rank=module.tp_rank,
+                                               tp_size=tp_size,
+                                               tp_rank=tp_rank,
                                                tp_mode=module.tp_mode)
         weight_scale = torch.cat(weight_scale, 0)
         weight_scale = torch.ops.trtllm.block_scale_interleave(weight_scale)
@@ -1875,9 +1898,10 @@ class W4A8MXFP4FP8LinearMethod(LinearMethodBase):
         fused_weight = torch.cat((gate_weight, up_weight))
         copy_weight(module.weight, fused_weight)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         weight_scale = self.load_weight_scales(weights,
-                                               tp_size=module.tp_size,
-                                               tp_rank=module.tp_rank,
+                                               tp_size=tp_size,
+                                               tp_rank=tp_rank,
                                                tp_mode=module.tp_mode)
         # Swizzle weight scales after concatenation
         weight_scale = torch.cat(weight_scale, 0)
@@ -1953,9 +1977,9 @@ class WeightOnlyQuantLinearMethod(LinearMethodBase):
         load_weights_vanilla_helper(module, weights)
 
         device = torch.device('cuda')
-        weight_scale = load_weight_shard(weights[0]['weight_scale'],
-                                         module.tp_size, module.tp_rank,
-                                         module.tp_mode, device)
+        tp_size, tp_rank = _effective_tp_coords(module)
+        weight_scale = load_weight_shard(weights[0]['weight_scale'], tp_size,
+                                         tp_rank, module.tp_mode, device)
 
         copy_weight(module.weight_scale, weight_scale)
 
@@ -1973,9 +1997,10 @@ class WeightOnlyQuantLinearMethod(LinearMethodBase):
 
         copy_weight(module.weight, fused_weight)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         weight_scales = self.load_weight_scales(weights,
-                                                tp_size=module.tp_size,
-                                                tp_rank=module.tp_rank,
+                                                tp_size=tp_size,
+                                                tp_rank=tp_rank,
                                                 tp_mode=module.tp_mode)
 
         # Create concatenated weight scale tensor
@@ -1997,12 +2022,13 @@ class WeightOnlyQuantLinearMethod(LinearMethodBase):
 
         copy_weight(module.weight, fused_weight)
 
-        left_scale = load_weight_shard(weights[0]['weight_scale'],
-                                       module.tp_size, module.tp_rank,
-                                       module.tp_mode, device).contiguous()
-        right_scale = load_weight_shard(weights[1]['weight_scale'],
-                                        module.tp_size, module.tp_rank,
-                                        module.tp_mode, device).contiguous()
+        tp_size, tp_rank = _effective_tp_coords(module)
+        left_scale = load_weight_shard(weights[0]['weight_scale'], tp_size,
+                                       tp_rank, module.tp_mode,
+                                       device).contiguous()
+        right_scale = load_weight_shard(weights[1]['weight_scale'], tp_size,
+                                        tp_rank, module.tp_mode,
+                                        device).contiguous()
         fused_scale = torch.cat([left_scale, right_scale], dim=0)
         copy_weight(module.weight_scale, fused_scale)
 
@@ -2089,10 +2115,11 @@ class W4A16_AWQ_LinearMethod(LinearMethodBase):
         # Use the same device as the weight tensor
         # as we register pre_quant_scale after sharded model weights are moved to respective gpus
         device = module.weight.device
+        tp_size, tp_rank = _effective_tp_coords(module)
         pre_quant_scale = load_weight_shard(
             weights[0]["pre_quant_scale"],
-            module.tp_size,
-            module.tp_rank,
+            tp_size,
+            tp_rank,
             # pre_quant_scale applies to activation as opposed to weight, so flip tp_mode the other way around
             TensorParallelMode.flip(module.tp_mode),
             device,
@@ -2102,9 +2129,8 @@ class W4A16_AWQ_LinearMethod(LinearMethodBase):
             torch.ones((module.in_features, ), dtype=pre_quant_scale.dtype),
             requires_grad=False).to(device=device)
 
-        weight_scale = load_weight_shard(weights[0]['weight_scale'],
-                                         module.tp_size, module.tp_rank,
-                                         module.tp_mode, device)
+        weight_scale = load_weight_shard(weights[0]['weight_scale'], tp_size,
+                                         tp_rank, module.tp_mode, device)
 
         copy_weight(module.pre_quant_scale, pre_quant_scale)
         copy_weight(module.weight_scale, weight_scale.T.contiguous())
@@ -2121,8 +2147,9 @@ class W4A16_AWQ_LinearMethod(LinearMethodBase):
 
         copy_weight(module.weight, fused_weight)
 
-        weight_scales = self.load_weight_scales(weights, module.tp_size,
-                                                module.tp_rank, module.tp_mode)
+        tp_size, tp_rank = _effective_tp_coords(module)
+        weight_scales = self.load_weight_scales(weights, tp_size, tp_rank,
+                                                module.tp_mode)
 
         # Create concatenated weight scale tensor
         cat_weight_scale = torch.cat(weight_scales, dim=0).T.contiguous()
@@ -2141,12 +2168,13 @@ class W4A16_AWQ_LinearMethod(LinearMethodBase):
 
         copy_weight(module.weight, fused_weight)
 
-        left_scale = load_weight_shard(weights[0]['weight_scale'],
-                                       module.tp_size, module.tp_rank,
-                                       module.tp_mode, device).contiguous()
-        right_scale = load_weight_shard(weights[1]['weight_scale'],
-                                        module.tp_size, module.tp_rank,
-                                        module.tp_mode, device).contiguous()
+        tp_size, tp_rank = _effective_tp_coords(module)
+        left_scale = load_weight_shard(weights[0]['weight_scale'], tp_size,
+                                       tp_rank, module.tp_mode,
+                                       device).contiguous()
+        right_scale = load_weight_shard(weights[1]['weight_scale'], tp_size,
+                                        tp_rank, module.tp_mode,
+                                        device).contiguous()
         fused_scale = torch.cat([left_scale, right_scale], dim=0).T.contiguous()
         copy_weight(module.weight_scale, fused_scale)
 
@@ -2276,10 +2304,11 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
         # Use the same device as the weight tensor
         # as we register pre_quant_scale after sharded model weights are moved to respective gpus
         device = module.weight.device
+        tp_size, tp_rank = _effective_tp_coords(module)
         pre_quant_scale = load_weight_shard(
             weights[0]["pre_quant_scale"],
-            module.tp_size,
-            module.tp_rank,
+            tp_size,
+            tp_rank,
             # pre_quant_scale applies to activation as opposed to weight, so flip tp_mode the other way around
             TensorParallelMode.flip(module.tp_mode),
             device,
@@ -2295,8 +2324,8 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
 
         input_scale, weight_scale, alpha, weight_scale_2 = self.load_weight_scales_w4a8(
             weights=weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
             tp_mode=module.tp_mode)
 
         assert len(weight_scale) == 1, "there should be only one weight scale"
@@ -2324,10 +2353,11 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
 
         copy_weight(module.weight, fused_weight)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         input_scale, weight_scales, alpha, weight_scale_2 = self.load_weight_scales_w4a8(
             weights=weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
             tp_mode=module.tp_mode)
 
         # Create concatenated weight scale tensor
@@ -2346,8 +2376,8 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
             device = module.weight.device
             pre_quant_scale = load_weight_shard(
                 weights[0]["pre_quant_scale"],
-                module.tp_size,
-                module.tp_rank,
+                tp_size,
+                tp_rank,
                 # pre_quant_scale applies to activation as opposed to weight, so flip tp_mode the other way around
                 TensorParallelMode.flip(module.tp_mode),
                 device,
@@ -2372,10 +2402,11 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
 
         copy_weight(module.weight, fused_weight)
 
+        tp_size, tp_rank = _effective_tp_coords(module)
         input_scale, weight_scale, alpha, weight_scale_2 = self.load_weight_scales_w4a8(
             weights=weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
+            tp_size=tp_size,
+            tp_rank=tp_rank,
             tp_mode=module.tp_mode)
 
         fused_scale = (torch.cat(weight_scale, dim=0).T /
@@ -2392,8 +2423,8 @@ class W4A8_AWQ_LinearMethod(LinearMethodBase):
             device = module.weight.device
             pre_quant_scale = load_weight_shard(
                 weights[0]["pre_quant_scale"],
-                module.tp_size,
-                module.tp_rank,
+                tp_size,
+                tp_rank,
                 # pre_quant_scale applies to activation as opposed to weight, so flip tp_mode the other way around
                 TensorParallelMode.flip(module.tp_mode),
                 device,
@@ -2512,6 +2543,7 @@ class Linear(nn.Module):
         self.use_cute_dsl_blockscaling_mm = use_cute_dsl_blockscaling_mm
         self.disable_deep_gemm = disable_deep_gemm
         self.fused_weight_shard_indices_mapping = fused_weight_shard_indices_mapping
+        self._weights_presharded = False
 
         # Store NVFP4 GEMM allowed backends configuration
         # Read from model_extra_attrs if not explicitly provided (allows config via llm_api_options)

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -184,8 +184,14 @@ def load_weights_vanilla_helper(module: Linear,
             assert "bias" in weights[0]
     device = torch.device('cuda')
 
-    weight = load_weight_shard(weights[0]['weight'], module.tp_size,
-                               module.tp_rank, module.tp_mode,
+    # Skip TP slicing when weights are already sharded (e.g. MX P2P transfer).
+    tp_size = 1 if getattr(module, '_weights_presharded',
+                           False) else module.tp_size
+    tp_rank = 0 if getattr(module, '_weights_presharded',
+                           False) else module.tp_rank
+
+    weight = load_weight_shard(weights[0]['weight'], tp_size,
+                               tp_rank, module.tp_mode,
                                device) if "weight" in weights[0] else None
 
     if weight is not None:
@@ -201,8 +207,8 @@ def load_weights_vanilla_helper(module: Linear,
         copy_weight(module.weight, weight_transform(weight))
 
     if module.bias is not None:
-        bias = load_weight_shard(weights[0]['bias'], module.tp_size,
-                                 module.tp_rank, module.tp_mode,
+        bias = load_weight_shard(weights[0]['bias'], tp_size,
+                                 tp_rank, module.tp_mode,
                                  device) if "bias" in weights[0] else None
         if bias is not None:
             copy_weight(module.bias, bias_transform(bias))
@@ -225,25 +231,31 @@ def load_weights_fused_qkv_helper(
         ) is not None, "Fused weight shard indices mapping is required in partial loading"
     device = torch.device('cuda')
 
-    q_weight = load_weight_shard(weights[0]['weight'], module.tp_size,
-                                 module.tp_rank, module.tp_mode,
+    # Skip TP slicing when weights are already sharded (e.g. MX P2P transfer).
+    tp_size = 1 if getattr(module, '_weights_presharded',
+                           False) else module.tp_size
+    tp_rank = 0 if getattr(module, '_weights_presharded',
+                           False) else module.tp_rank
+
+    q_weight = load_weight_shard(weights[0]['weight'], tp_size,
+                                 tp_rank, module.tp_mode,
                                  device) if "weight" in weights[0] else None
-    k_weight = load_weight_shard(weights[1]['weight'], module.tp_size,
-                                 module.tp_rank, module.tp_mode,
+    k_weight = load_weight_shard(weights[1]['weight'], tp_size,
+                                 tp_rank, module.tp_mode,
                                  device) if "weight" in weights[1] else None
-    v_weight = load_weight_shard(weights[2]['weight'], module.tp_size,
-                                 module.tp_rank, module.tp_mode,
+    v_weight = load_weight_shard(weights[2]['weight'], tp_size,
+                                 tp_rank, module.tp_mode,
                                  device) if "weight" in weights[2] else None
 
     if module.bias is not None:
-        q_bias = load_weight_shard(weights[0]['bias'], module.tp_size,
-                                   module.tp_rank, module.tp_mode,
+        q_bias = load_weight_shard(weights[0]['bias'], tp_size,
+                                   tp_rank, module.tp_mode,
                                    device) if "bias" in weights[0] else None
-        k_bias = load_weight_shard(weights[1]['bias'], module.tp_size,
-                                   module.tp_rank, module.tp_mode,
+        k_bias = load_weight_shard(weights[1]['bias'], tp_size,
+                                   tp_rank, module.tp_mode,
                                    device) if "bias" in weights[1] else None
-        v_bias = load_weight_shard(weights[2]['bias'], module.tp_size,
-                                   module.tp_rank, module.tp_mode,
+        v_bias = load_weight_shard(weights[2]['bias'], tp_size,
+                                   tp_rank, module.tp_mode,
                                    device) if "bias" in weights[2] else None
         if not allow_partial_loading:
             copy_weight(module.bias,
@@ -278,18 +290,24 @@ def load_weights_fused_gate_up_helper(
         ) is not None, "Fused weight shard indices mapping is required in partial loading"
     device = torch.device('cuda')
 
-    gate_weight = load_weight_shard(weights[0]['weight'], module.tp_size,
-                                    module.tp_rank, module.tp_mode,
+    # Skip TP slicing when weights are already sharded (e.g. MX P2P transfer).
+    tp_size = 1 if getattr(module, '_weights_presharded',
+                           False) else module.tp_size
+    tp_rank = 0 if getattr(module, '_weights_presharded',
+                           False) else module.tp_rank
+
+    gate_weight = load_weight_shard(weights[0]['weight'], tp_size,
+                                    tp_rank, module.tp_mode,
                                     device) if "weight" in weights[0] else None
-    up_weight = load_weight_shard(weights[1]['weight'], module.tp_size,
-                                  module.tp_rank, module.tp_mode,
+    up_weight = load_weight_shard(weights[1]['weight'], tp_size,
+                                  tp_rank, module.tp_mode,
                                   device) if "weight" in weights[1] else None
     if module.bias is not None:
-        gate_bias = load_weight_shard(weights[0]['bias'], module.tp_size,
-                                      module.tp_rank, module.tp_mode,
+        gate_bias = load_weight_shard(weights[0]['bias'], tp_size,
+                                      tp_rank, module.tp_mode,
                                       device) if "bias" in weights[0] else None
-        up_bias = load_weight_shard(weights[1]['bias'], module.tp_size,
-                                    module.tp_rank, module.tp_mode,
+        up_bias = load_weight_shard(weights[1]['bias'], tp_size,
+                                    tp_rank, module.tp_mode,
                                     device) if "bias" in weights[1] else None
         if not allow_partial_loading:
             copy_weight(module.bias,
@@ -2502,6 +2520,7 @@ class Linear(nn.Module):
         self.use_cute_dsl_blockscaling_mm = use_cute_dsl_blockscaling_mm
         self.disable_deep_gemm = disable_deep_gemm
         self.fused_weight_shard_indices_mapping = fused_weight_shard_indices_mapping
+        self._weights_presharded = False
 
         # Store NVFP4 GEMM allowed backends configuration
         # Read from model_extra_attrs if not explicitly provided (allows config via llm_api_options)

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -167,8 +167,11 @@ class PyTorchModelEngine(ModelEngine):
 
         if checkpoint_loader is None:
             checkpoint_loader = _construct_checkpoint_loader(
-                llm_args.backend, llm_args.checkpoint_loader,
-                llm_args.checkpoint_format)
+                llm_args.backend,
+                llm_args.checkpoint_loader,
+                llm_args.checkpoint_format,
+                mx_server_url=llm_args.mx_server_url,
+            )
 
         self.mapping = mapping
         if mapping.has_pp():

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -167,7 +167,9 @@ class PyTorchModelEngine(ModelEngine):
         if checkpoint_loader is None:
             checkpoint_loader = _construct_checkpoint_loader(
                 llm_args.backend, llm_args.checkpoint_loader,
-                llm_args.checkpoint_format)
+                llm_args.checkpoint_format,
+                mx_server_url=llm_args.mx_server_url,
+            )
 
         self.mapping = mapping
         if mapping.has_pp():

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -166,8 +166,12 @@ def get_rank_model_storage(model):
 
 
 def _construct_checkpoint_loader(
-        backend: str, checkpoint_loader: Optional[BaseCheckpointLoader],
-        checkpoint_format: Optional[str]) -> Optional[BaseCheckpointLoader]:
+    backend: str,
+    checkpoint_loader: Optional[BaseCheckpointLoader],
+    checkpoint_format: Optional[str],
+    *,
+    mx_server_url: Optional[str] = None,
+) -> Optional[BaseCheckpointLoader]:
     if backend == "_autodeploy":
         return None
 
@@ -181,11 +185,17 @@ def _construct_checkpoint_loader(
             checkpoint_format)()
         config_loader = get_config_loader(checkpoint_format)()
 
+        # Pass extra kwargs for format-specific loaders (e.g. MX).
+        extra_kwargs: dict = {}
+        if checkpoint_format == "MX" and mx_server_url is not None:
+            extra_kwargs["mx_server_url"] = mx_server_url
+
         checkpoint_loader = BaseCheckpointLoader.get(
             checkpoint_format=checkpoint_format,
             weight_loader=checkpoint_weight_loader,
             weight_mapper=None,
-            config_loader=config_loader)
+            config_loader=config_loader,
+            **extra_kwargs)
 
     return checkpoint_loader
 
@@ -238,9 +248,11 @@ class ModelLoader:
         self.max_num_tokens = max_num_tokens
         self.max_seq_len = max_seq_len
         self.lora_config = lora_config
+        self.weight_mapper = None
         self.model_weights_memory_tag = model_weights_memory_tag
         self.model_weights_restore_mode = model_weights_restore_mode
         self._weight_pool_proxy = None
+        self._gms_backend = None
 
     @staticmethod
     def load_config_and_apply_defaults(
@@ -313,9 +325,12 @@ class ModelLoader:
 
             memo = dict()
 
-            if self.model_weights_memory_tag is not None:
+            if self.model_weights_memory_tag is not None and load_format != LoadFormat.GMS:
                 # Allocate buffers to the outer virtual_memory_scope,
                 # but parameters (weights) to the dedicated inner virtual_memory_scope.
+                # Skip for GMS: it maps weights from a shared GPU memory pool,
+                # so pre-allocating weight tensors would waste memory and the
+                # mapped regions would not be tracked by virtual_memory_scope.
 
                 def allocate_buffer_on_cuda(t: torch.Tensor):
                     if t not in memo:
@@ -330,7 +345,8 @@ class ModelLoader:
                 _apply_to_buffers_only(model, allocate_buffer_on_cuda)
 
                 need_initialized_weights = load_format not in (LoadFormat.AUTO,
-                                                               LoadFormat.DUMMY)
+                                                               LoadFormat.DUMMY,
+                                                               LoadFormat.GMS)
 
                 def allocate_weights_on_cuda(t: torch.Tensor):
                     if t not in memo:
@@ -360,7 +376,10 @@ class ModelLoader:
                         self.model_weights_restore_mode) as pool:
                     model._apply(allocate_weights_on_cuda)
                 self._weight_pool_proxy = pool
-            elif is_meta_init:
+            elif is_meta_init and load_format != LoadFormat.GMS:
+                # For GMS, skip meta→CUDA init: RW path allocates under the
+                # GMS memory pool during weight loading, and RO path replaces
+                # meta tensors via materialize_module.
 
                 def init_meta_tensor(t: torch.Tensor):
                     if t.device != torch.device('meta'):
@@ -373,8 +392,10 @@ class ModelLoader:
                 model._apply(init_meta_tensor)
 
             # Ensure everything is at least on CUDA
-            # No-op if worked as expected
-            model.to("cuda")
+            # No-op if worked as expected — skip for GMS RO where params
+            # remain on meta until materialize_module replaces them.
+            if load_format != LoadFormat.GMS:
+                model.to("cuda")
             del memo
 
             rank_model_storage = get_rank_model_storage(model)
@@ -382,17 +403,67 @@ class ModelLoader:
                 f"Use {rank_model_storage / (1024**3):.2f} GB for model weights."
             )
             if load_format == LoadFormat.AUTO:
+                # Pass model= so format-specific loaders (e.g. MX) can
+                # write weights directly into parameter buffers via P2P.
+                load_weights_kwargs: dict = {"mapping": self.mapping}
+                if checkpoint_loader.checkpoint_format == "MX":
+                    load_weights_kwargs["model"] = model
+
                 if hasattr(model, 'llm_checkpoint_dir'):
                     weights = checkpoint_loader.load_weights(
-                        model.llm_checkpoint_dir, mapping=self.mapping)
+                        model.llm_checkpoint_dir, **load_weights_kwargs)
                 else:
                     weights = checkpoint_loader.load_weights(
-                        checkpoint_dir, mapping=self.mapping)
+                        checkpoint_dir, **load_weights_kwargs)
 
-                self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
-                    model, config)
-                self._call_load_weights(model.load_weights, weights,
-                                        self.weight_mapper)
+                # When MX P2P succeeds, weights dict is empty — weights
+                # are already in model params.  Mark all Linear modules
+                # as presharded so TP slicing is skipped.
+                mx_p2p_succeeded = (hasattr(checkpoint_loader, 'p2p_succeeded')
+                                    and checkpoint_loader.p2p_succeeded)
+
+                if mx_p2p_succeeded:
+                    preshard_strategy = getattr(self.llm_args,
+                                                'mx_preshard_strategy',
+                                                'per_module')
+                    if preshard_strategy == 'global':
+                        # 'global' would map onto LoadFormat.PRESHARDED,
+                        # which is not yet wired in TRT-LLM main. The
+                        # MX team's PR #12898 (which proposed PRESHARDED)
+                        # was closed in favor of the per-module flag
+                        # adopted here. Until LoadFormat.PRESHARDED lands,
+                        # 'global' raises so users see an actionable error
+                        # rather than silently degraded behavior.
+                        raise NotImplementedError(
+                            "mx_preshard_strategy='global' requires "
+                            "LoadFormat.PRESHARDED, which is not yet "
+                            "available in TRT-LLM main. Use "
+                            "mx_preshard_strategy='per_module' instead.")
+
+                    from tensorrt_llm._torch.modules.linear import Linear
+
+                    # Collect draft model modules to exclude — draft
+                    # weights are loaded separately from disk and must
+                    # not be marked as presharded.
+                    draft_modules = set()
+                    if hasattr(model,
+                               'draft_model') and model.draft_model is not None:
+                        draft_modules = set(
+                            id(m) for m in model.draft_model.modules())
+
+                    for module in model.modules():
+                        if (isinstance(module, Linear)
+                                and id(module) not in draft_modules):
+                            module._weights_presharded = True
+                    logger.info("MX P2P: marked main model Linear modules as "
+                                "presharded (strategy=per_module), skipping "
+                                "weight mapping pipeline.")
+
+                if not mx_p2p_succeeded:
+                    self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
+                        model, config)
+                    self._call_load_weights(model.load_weights, weights,
+                                            self.weight_mapper)
 
                 if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
                 ):
@@ -424,14 +495,145 @@ class ModelLoader:
                     "LoadFormat.VISION_ONLY: skipping weight loading; using preloaded vision weights."
                 )
 
+            elif load_format == LoadFormat.GMS:
+                from tensorrt_llm._torch.memory import GMSBackend
+
+                gms_backend = GMSBackend(
+                    socket_path=self.llm_args.gms_socket_path,
+                    mapping=self.mapping,
+                    mode=self.llm_args.gms_mode or "auto",
+                    tag=self.llm_args.gms_tag or GMSBackend.DEFAULT_TAG,
+                )
+
+                if not gms_backend.connect():
+                    raise RuntimeError("Failed to connect to GMS at "
+                                       f"{self.llm_args.gms_socket_path}")
+
+                if gms_backend.is_rw:
+                    # GMS RW path: load via checkpoint_loader under GMS
+                    # memory pool so allocations go into shared memory.
+                    # Note: MX P2P is NOT used in GMS RW mode because
+                    # parameters are still meta tensors (no CUDA buffers
+                    # for P2P to write into) and allocations must go through
+                    # the GMS pool.  The checkpoint_loader loads from disk,
+                    # with the GMS pool intercepting all CUDA allocations.
+                    device = torch.device('cuda')
+
+                    with gms_backend.mem_pool_scope(device):
+                        load_weights_kwargs = {"mapping": self.mapping}
+                        # Honor model.llm_checkpoint_dir when the model
+                        # rewrites its checkpoint source — same precedence
+                        # as the AUTO branch above. Without this, GMS-only
+                        # would silently load from the original
+                        # checkpoint_dir for redirect-using model classes.
+                        weight_source = (model.llm_checkpoint_dir if hasattr(
+                            model, 'llm_checkpoint_dir') else checkpoint_dir)
+                        weights = checkpoint_loader.load_weights(
+                            weight_source, **load_weights_kwargs)
+
+                        if weights:
+                            self.weight_mapper = (
+                                checkpoint_loader.get_initialized_weight_mapper(
+                                    model, config))
+                            self._call_load_weights(model.load_weights, weights,
+                                                    self.weight_mapper)
+
+                        # Speculative decoding: load draft weights INSIDE
+                        # the same mem_pool_scope so they land in the GMS
+                        # pool and are picked up by finalize_write's model
+                        # walk. (Deferring commit until after both main and
+                        # draft weights are in the pool avoids the otherwise-
+                        # required separate commit-per-model dance flagged
+                        # in PR #13045 review.)
+                        if (self.spec_config is not None and self.spec_config.
+                                spec_dec_mode.need_load_draft_weights()):
+                            draft_weights = checkpoint_loader.load_weights(
+                                self.spec_config.speculative_model,
+                                mapping=self.mapping)
+
+                            draft_model_arch = (
+                                model.draft_config.pretrained_config.
+                                architectures[0])
+                            draft_weight_mapper = AutoCheckpointMapper.get(
+                                checkpoint_loader.checkpoint_format,
+                                draft_model_arch)
+                            draft_weight_mapper.init_model_and_config(
+                                model.draft_model, model.draft_config)
+
+                            self._call_load_weights(model.load_draft_weights,
+                                                    draft_weights,
+                                                    draft_weight_mapper)
+
+                        # Move any parameters that landed outside the GMS
+                        # pool (e.g., buffers created during weight-loading
+                        # transforms) into the pool, then drain the caching
+                        # allocator. Order and pool-scope membership mirror
+                        # the upstream gpu_memory_service.integrations.trtllm
+                        # ``_load_rw`` reference path:
+                        # https://github.com/ai-dynamo/dynamo/blob/main/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+                        gms_backend.move_untracked_params(model)
+                        torch.cuda.empty_cache()
+
+                    # Commit weights for RO readers and transition to RO mode.
+                    # finalize_write walks the full model tree (including
+                    # model.draft_model when present) so a single commit
+                    # covers both main and draft weights.
+                    gms_backend.finalize_write(model)
+                    logger.info(
+                        "LoadFormat.GMS (RW): loaded and committed "
+                        "weights via %s", checkpoint_loader.checkpoint_format)
+                else:
+                    # GMS RO path: zero-copy import from existing GMS pool.
+                    # post_load_weights() must run BEFORE materialize so
+                    # that module aliases are set up correctly.
+                    for module in model.modules():
+                        if hasattr(module, 'post_load_weights') and not getattr(
+                                module, '_weights_removed', False):
+                            module.post_load_weights()
+
+                    gms_backend.materialize_module(model)
+                    # Note: MoE load balancer finalization (lines below) works
+                    # because register functions access module attributes at
+                    # call time, resolving to materialized CUDA tensors.
+                    # The patch_empty_cache() applied during connect() is
+                    # critical here — MoE's make_tensor_host_accessible()
+                    # calls torch.cuda.empty_cache() which would segfault
+                    # on VMM-backed GMS tensors without the patch.
+                    logger.info("LoadFormat.GMS (RO): zero-copy materialized "
+                                "weights")
+
+                # Store backend reference for cleanup during shutdown.
+                self._gms_backend = gms_backend
+
             else:
                 raise NotImplementedError(
                     f"No load support for load format: {load_format}")
 
-            for module in model.modules():
-                if hasattr(module, 'post_load_weights') and not getattr(
-                        module, '_weights_removed', False):
-                    module.post_load_weights()
+            # MX source publish: expose raw weights to other ranks
+            # BEFORE post_load_weights() transforms them, so targets
+            # receive the pre-transform state.
+            # Publish for AUTO and GMS-RW (MX+GMS combo) — GMS RO
+            # workers already have weights from the GMS pool, and
+            # DUMMY has garbage weights that shouldn't be published.
+            should_publish = (load_format == LoadFormat.AUTO
+                              or (load_format == LoadFormat.GMS
+                                  and self._gms_backend is not None
+                                  and self._gms_backend.is_rw))
+            if (should_publish
+                    and hasattr(checkpoint_loader, 'publish_as_source')):
+                checkpoint_loader.publish_as_source(
+                    model, mapping=self.mapping, checkpoint_dir=checkpoint_dir)
+
+            # GMS RO already ran post_load_weights() before materialize;
+            # skip here to avoid running it twice.
+            gms_ro_done = (load_format == LoadFormat.GMS
+                           and self._gms_backend is not None
+                           and not self._gms_backend.is_rw)
+            if not gms_ro_done:
+                for module in model.modules():
+                    if hasattr(module, 'post_load_weights') and not getattr(
+                            module, '_weights_removed', False):
+                        module.post_load_weights()
 
             if isinstance(moe_load_balancer, MoeLoadBalancer):
                 moe_load_balancer.register_weight_slots_after_to_cuda()
@@ -447,11 +649,22 @@ class ModelLoader:
                model: DecoderModelForCausalLM,
                weights: dict,
                allow_partial_loading: bool = False):
+        if self.weight_mapper is None:
+            raise RuntimeError(
+                "Cannot reload weights: weight_mapper was not initialized. "
+                "This happens when the initial load used MX P2P, GMS, or "
+                "VISION_ONLY, which bypass the weight mapping pipeline.")
         self._call_load_weights(model.load_weights,
                                 weights,
                                 self.weight_mapper,
                                 allow_partial_loading=allow_partial_loading)
         torch.cuda.current_stream().synchronize()
+
+    def cleanup(self) -> None:
+        """Release resources acquired during load (e.g. GMS mappings)."""
+        if self._gms_backend is not None:
+            self._gms_backend.cleanup()
+            self._gms_backend = None
 
     def _load_and_validate_config(
             self, checkpoint_dir: str,

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -171,6 +171,7 @@ def _construct_checkpoint_loader(
     checkpoint_format: Optional[str],
     *,
     mx_server_url: Optional[str] = None,
+    mx_model_name: Optional[str] = None,
 ) -> Optional[BaseCheckpointLoader]:
     if backend == "_autodeploy":
         return None
@@ -187,8 +188,11 @@ def _construct_checkpoint_loader(
 
         # Pass extra kwargs for format-specific loaders (e.g. MX).
         extra_kwargs: dict = {}
-        if checkpoint_format == "MX" and mx_server_url is not None:
-            extra_kwargs["mx_server_url"] = mx_server_url
+        if checkpoint_format == "MX":
+            if mx_server_url is not None:
+                extra_kwargs["mx_server_url"] = mx_server_url
+            if mx_model_name is not None:
+                extra_kwargs["model_name"] = mx_model_name
 
         checkpoint_loader = BaseCheckpointLoader.get(
             checkpoint_format=checkpoint_format,

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -516,7 +516,11 @@ class ModelLoader:
                                 model.load_weights, weights,
                                 self.weight_mapper)
 
-                    # Commit weights for RO readers.
+                    # Move any parameters that landed outside the GMS pool
+                    # (e.g., buffers created during weight loading transforms).
+                    gms_backend.move_untracked_params(model)
+
+                    # Commit weights for RO readers and transition to RO mode.
                     gms_backend.finalize_write(model)
                     logger.info("LoadFormat.GMS (RW): loaded and committed "
                                 "weights via %s",
@@ -531,6 +535,13 @@ class ModelLoader:
                             module.post_load_weights()
 
                     gms_backend.materialize_module(model)
+                    # Note: MoE load balancer finalization (lines below) works
+                    # because register functions access module attributes at
+                    # call time, resolving to materialized CUDA tensors.
+                    # The patch_empty_cache() applied during connect() is
+                    # critical here — MoE's make_tensor_host_accessible()
+                    # calls torch.cuda.empty_cache() which would segfault
+                    # on VMM-backed GMS tensors without the patch.
                     logger.info("LoadFormat.GMS (RO): zero-copy materialized "
                                 "weights")
 

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -166,8 +166,12 @@ def get_rank_model_storage(model):
 
 
 def _construct_checkpoint_loader(
-        backend: str, checkpoint_loader: Optional[BaseCheckpointLoader],
-        checkpoint_format: Optional[str]) -> Optional[BaseCheckpointLoader]:
+    backend: str,
+    checkpoint_loader: Optional[BaseCheckpointLoader],
+    checkpoint_format: Optional[str],
+    *,
+    mx_server_url: Optional[str] = None,
+) -> Optional[BaseCheckpointLoader]:
     if backend == "_autodeploy":
         return None
 
@@ -181,11 +185,17 @@ def _construct_checkpoint_loader(
             checkpoint_format)()
         config_loader = get_config_loader(checkpoint_format)()
 
+        # Pass extra kwargs for format-specific loaders (e.g. MX).
+        extra_kwargs: dict = {}
+        if checkpoint_format == "MX" and mx_server_url is not None:
+            extra_kwargs["mx_server_url"] = mx_server_url
+
         checkpoint_loader = BaseCheckpointLoader.get(
             checkpoint_format=checkpoint_format,
             weight_loader=checkpoint_weight_loader,
             weight_mapper=None,
-            config_loader=config_loader)
+            config_loader=config_loader,
+            **extra_kwargs)
 
     return checkpoint_loader
 
@@ -238,9 +248,11 @@ class ModelLoader:
         self.max_num_tokens = max_num_tokens
         self.max_seq_len = max_seq_len
         self.lora_config = lora_config
+        self.weight_mapper = None
         self.model_weights_memory_tag = model_weights_memory_tag
         self.model_weights_restore_mode = model_weights_restore_mode
         self._weight_pool_proxy = None
+        self._gms_backend = None
 
     @staticmethod
     def load_config_and_apply_defaults(
@@ -313,9 +325,12 @@ class ModelLoader:
 
             memo = dict()
 
-            if self.model_weights_memory_tag is not None:
+            if self.model_weights_memory_tag is not None and load_format != LoadFormat.GMS:
                 # Allocate buffers to the outer virtual_memory_scope,
                 # but parameters (weights) to the dedicated inner virtual_memory_scope.
+                # Skip for GMS: it maps weights from a shared GPU memory pool,
+                # so pre-allocating weight tensors would waste memory and the
+                # mapped regions would not be tracked by virtual_memory_scope.
 
                 def allocate_buffer_on_cuda(t: torch.Tensor):
                     if t not in memo:
@@ -329,8 +344,8 @@ class ModelLoader:
 
                 _apply_to_buffers_only(model, allocate_buffer_on_cuda)
 
-                need_initialized_weights = load_format not in (LoadFormat.AUTO,
-                                                               LoadFormat.DUMMY)
+                need_initialized_weights = load_format not in (
+                    LoadFormat.AUTO, LoadFormat.DUMMY, LoadFormat.GMS)
 
                 def allocate_weights_on_cuda(t: torch.Tensor):
                     if t not in memo:
@@ -360,7 +375,10 @@ class ModelLoader:
                         self.model_weights_restore_mode) as pool:
                     model._apply(allocate_weights_on_cuda)
                 self._weight_pool_proxy = pool
-            elif is_meta_init:
+            elif is_meta_init and load_format != LoadFormat.GMS:
+                # For GMS, skip meta→CUDA init: RW path allocates under the
+                # GMS memory pool during weight loading, and RO path replaces
+                # meta tensors via materialize_module.
 
                 def init_meta_tensor(t: torch.Tensor):
                     if t.device != torch.device('meta'):
@@ -373,8 +391,10 @@ class ModelLoader:
                 model._apply(init_meta_tensor)
 
             # Ensure everything is at least on CUDA
-            # No-op if worked as expected
-            model.to("cuda")
+            # No-op if worked as expected — skip for GMS RO where params
+            # remain on meta until materialize_module replaces them.
+            if load_format != LoadFormat.GMS:
+                model.to("cuda")
             del memo
 
             rank_model_storage = get_rank_model_storage(model)
@@ -382,17 +402,50 @@ class ModelLoader:
                 f"Use {rank_model_storage / (1024**3):.2f} GB for model weights."
             )
             if load_format == LoadFormat.AUTO:
+                # Pass model= so format-specific loaders (e.g. MX) can
+                # write weights directly into parameter buffers via P2P.
+                load_weights_kwargs: dict = {"mapping": self.mapping}
+                if checkpoint_loader.checkpoint_format == "MX":
+                    load_weights_kwargs["model"] = model
+
                 if hasattr(model, 'llm_checkpoint_dir'):
                     weights = checkpoint_loader.load_weights(
-                        model.llm_checkpoint_dir, mapping=self.mapping)
+                        model.llm_checkpoint_dir, **load_weights_kwargs)
                 else:
                     weights = checkpoint_loader.load_weights(
-                        checkpoint_dir, mapping=self.mapping)
+                        checkpoint_dir, **load_weights_kwargs)
 
-                self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
-                    model, config)
-                self._call_load_weights(model.load_weights, weights,
-                                        self.weight_mapper)
+                # When MX P2P succeeds, weights dict is empty — weights
+                # are already in model params.  Mark all Linear modules
+                # as presharded so TP slicing is skipped.
+                mx_p2p_succeeded = (
+                    hasattr(checkpoint_loader, 'p2p_succeeded')
+                    and checkpoint_loader.p2p_succeeded)
+
+                if mx_p2p_succeeded:
+                    from tensorrt_llm._torch.modules.linear import Linear
+
+                    # Collect draft model modules to exclude — draft
+                    # weights are loaded separately from disk and must
+                    # not be marked as presharded.
+                    draft_modules = set()
+                    if hasattr(model, 'draft_model') and model.draft_model is not None:
+                        draft_modules = set(
+                            id(m) for m in model.draft_model.modules())
+
+                    for module in model.modules():
+                        if (isinstance(module, Linear)
+                                and id(module) not in draft_modules):
+                            module._weights_presharded = True
+                    logger.info(
+                        "MX P2P: marked main model Linear modules as "
+                        "presharded, skipping weight mapping pipeline.")
+
+                if not mx_p2p_succeeded:
+                    self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
+                        model, config)
+                    self._call_load_weights(model.load_weights, weights,
+                                            self.weight_mapper)
 
                 if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
                 ):
@@ -424,14 +477,97 @@ class ModelLoader:
                     "LoadFormat.VISION_ONLY: skipping weight loading; using preloaded vision weights."
                 )
 
+            elif load_format == LoadFormat.GMS:
+                from tensorrt_llm._torch.memory import GMSBackend
+
+                gms_backend = GMSBackend(
+                    socket_path=self.llm_args.gms_socket_path,
+                    mapping=self.mapping,
+                    mode=self.llm_args.gms_mode or "auto",
+                    tag=self.llm_args.gms_tag or "model_weights",
+                )
+
+                if not gms_backend.connect():
+                    raise RuntimeError(
+                        "Failed to connect to GMS at "
+                        f"{self.llm_args.gms_socket_path}")
+
+                if gms_backend.is_rw:
+                    # GMS RW path: load via checkpoint_loader under GMS
+                    # memory pool so allocations go into shared memory.
+                    # Note: MX P2P is NOT used in GMS RW mode because
+                    # parameters are still meta tensors (no CUDA buffers
+                    # for P2P to write into) and allocations must go through
+                    # the GMS pool.  The checkpoint_loader loads from disk,
+                    # with the GMS pool intercepting all CUDA allocations.
+                    gms_pool = gms_backend.get_mem_pool()
+                    device = torch.device('cuda')
+
+                    with torch.cuda.use_mem_pool(gms_pool, device=device):
+                        load_weights_kwargs = {"mapping": self.mapping}
+                        weights = checkpoint_loader.load_weights(
+                            checkpoint_dir, **load_weights_kwargs)
+
+                        if weights:
+                            self.weight_mapper = (
+                                checkpoint_loader
+                                .get_initialized_weight_mapper(model, config))
+                            self._call_load_weights(
+                                model.load_weights, weights,
+                                self.weight_mapper)
+
+                    # Commit weights for RO readers.
+                    gms_backend.finalize_write(model)
+                    logger.info("LoadFormat.GMS (RW): loaded and committed "
+                                "weights via %s",
+                                checkpoint_loader.checkpoint_format)
+                else:
+                    # GMS RO path: zero-copy import from existing GMS pool.
+                    # post_load_weights() must run BEFORE materialize so
+                    # that module aliases are set up correctly.
+                    for module in model.modules():
+                        if hasattr(module, 'post_load_weights') and not getattr(
+                                module, '_weights_removed', False):
+                            module.post_load_weights()
+
+                    gms_backend.materialize_module(model)
+                    logger.info("LoadFormat.GMS (RO): zero-copy materialized "
+                                "weights")
+
+                # Store backend reference for cleanup during shutdown.
+                self._gms_backend = gms_backend
+
             else:
                 raise NotImplementedError(
                     f"No load support for load format: {load_format}")
 
-            for module in model.modules():
-                if hasattr(module, 'post_load_weights') and not getattr(
-                        module, '_weights_removed', False):
-                    module.post_load_weights()
+            # MX source publish: expose raw weights to other ranks
+            # BEFORE post_load_weights() transforms them, so targets
+            # receive the pre-transform state.
+            # Publish for AUTO and GMS-RW (MX+GMS combo) — GMS RO
+            # workers already have weights from the GMS pool, and
+            # DUMMY has garbage weights that shouldn't be published.
+            should_publish = (
+                load_format == LoadFormat.AUTO
+                or (load_format == LoadFormat.GMS
+                    and self._gms_backend is not None
+                    and self._gms_backend.is_rw))
+            if (should_publish
+                    and hasattr(checkpoint_loader, 'publish_as_source')):
+                checkpoint_loader.publish_as_source(
+                    model, mapping=self.mapping,
+                    checkpoint_dir=checkpoint_dir)
+
+            # GMS RO already ran post_load_weights() before materialize;
+            # skip here to avoid running it twice.
+            gms_ro_done = (load_format == LoadFormat.GMS
+                           and self._gms_backend is not None
+                           and not self._gms_backend.is_rw)
+            if not gms_ro_done:
+                for module in model.modules():
+                    if hasattr(module, 'post_load_weights') and not getattr(
+                            module, '_weights_removed', False):
+                        module.post_load_weights()
 
             if isinstance(moe_load_balancer, MoeLoadBalancer):
                 moe_load_balancer.register_weight_slots_after_to_cuda()
@@ -447,11 +583,22 @@ class ModelLoader:
                model: DecoderModelForCausalLM,
                weights: dict,
                allow_partial_loading: bool = False):
+        if self.weight_mapper is None:
+            raise RuntimeError(
+                "Cannot reload weights: weight_mapper was not initialized. "
+                "This happens when the initial load used MX P2P, GMS, or "
+                "VISION_ONLY, which bypass the weight mapping pipeline.")
         self._call_load_weights(model.load_weights,
                                 weights,
                                 self.weight_mapper,
                                 allow_partial_loading=allow_partial_loading)
         torch.cuda.current_stream().synchronize()
+
+    def cleanup(self) -> None:
+        """Release resources acquired during load (e.g. GMS mappings)."""
+        if self._gms_backend is not None:
+            self._gms_backend.cleanup()
+            self._gms_backend = None
 
     def _load_and_validate_config(
             self, checkpoint_dir: str,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -252,9 +252,12 @@ def create_py_executor(
     skip_est = os.environ.get("TRTLLM_SKIP_KV_CACHE_ESTIMATION", '0') == '1'
     torch.cuda.set_per_process_memory_fraction(1.0)
     # Apply model-specific defaults early, before destructuring llm_args fields
-    checkpoint_loader = _construct_checkpoint_loader(llm_args.backend,
-                                                     llm_args.checkpoint_loader,
-                                                     llm_args.checkpoint_format)
+    checkpoint_loader = _construct_checkpoint_loader(
+        llm_args.backend,
+        llm_args.checkpoint_loader,
+        llm_args.checkpoint_format,
+        mx_server_url=llm_args.mx_server_url,
+    )
     llm_args = ModelLoader.load_config_and_apply_defaults(
         checkpoint_dir, llm_args, checkpoint_loader)
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -252,11 +252,16 @@ def create_py_executor(
     skip_est = os.environ.get("TRTLLM_SKIP_KV_CACHE_ESTIMATION", '0') == '1'
     torch.cuda.set_per_process_memory_fraction(1.0)
     # Apply model-specific defaults early, before destructuring llm_args fields
+    # Pass llm_args.model through to MXCheckpointLoader so it can publish
+    # to the MX server under the user-supplied identity (Hub ID or local
+    # path basename) instead of defaulting to "unknown".
     checkpoint_loader = _construct_checkpoint_loader(
         llm_args.backend,
         llm_args.checkpoint_loader,
         llm_args.checkpoint_format,
         mx_server_url=llm_args.mx_server_url,
+        mx_model_name=str(llm_args.model)
+        if llm_args.model is not None else None,
     )
     llm_args = ModelLoader.load_config_and_apply_defaults(
         checkpoint_dir, llm_args, checkpoint_loader)

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -223,8 +223,11 @@ class BaseWorker(GenerationExecutor):
                 from tensorrt_llm._torch.pyexecutor.model_loader import \
                     _construct_checkpoint_loader
                 self.checkpoint_loader = _construct_checkpoint_loader(
-                    self.llm_args.backend, self.llm_args.checkpoint_loader,
-                    self.llm_args.checkpoint_format)
+                    self.llm_args.backend,
+                    self.llm_args.checkpoint_loader,
+                    self.llm_args.checkpoint_format,
+                    mx_server_url=self.llm_args.mx_server_url,
+                )
 
             self.max_seq_len = self.llm_args.max_seq_len
             # creare_py_executor may change some fields of llm_args

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -224,7 +224,9 @@ class BaseWorker(GenerationExecutor):
                     _construct_checkpoint_loader
                 self.checkpoint_loader = _construct_checkpoint_loader(
                     self.llm_args.backend, self.llm_args.checkpoint_loader,
-                    self.llm_args.checkpoint_format)
+                    self.llm_args.checkpoint_format,
+                    mx_server_url=self.llm_args.mx_server_url,
+                )
 
             self.max_seq_len = self.llm_args.max_seq_len
             # creare_py_executor may change some fields of llm_args

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import ast
 import functools
 import json
@@ -3434,6 +3437,8 @@ class LoadFormat(Enum):
     DUMMY = 1
     # Only load the multimodal(vision) encoder weights
     VISION_ONLY = 2
+    # Load weights from GPU Memory Service (read-only GPU memory pool).
+    GMS = 3
 
 
 class SamplerType(StrEnum):
@@ -3665,6 +3670,63 @@ class TorchLlmArgs(BaseLlmArgs):
         status="prototype",
     )
 
+    mx_server_url: Optional[str] = Field(
+        default=None,
+        description=
+        "URL of the MX (Model eXchange) server for P2P weight transfer. "
+        "When set together with checkpoint_format='MX', enables GPU-to-GPU "
+        "weight transfer from a running source instance, bypassing disk I/O. "
+        "When the server is unreachable, loading falls back to the standard "
+        "HuggingFace checkpoint path.",
+        status="prototype",
+    )
+
+    mx_preshard_strategy: str = Field(
+        default="per_module",
+        description="How to inform TRT-LLM that MX-delivered weights are already "
+        "TP-sharded for the local rank, so the standard TP-slicing pass "
+        "is skipped. Options: "
+        "'per_module' — set ``_weights_presharded=True`` on each Linear "
+        "module after a successful MX P2P transfer (current production "
+        "behavior). "
+        "'global' — set ``LoadFormat.PRESHARDED`` for the whole model "
+        "(planned, not yet wired upstream — selecting it raises "
+        "NotImplementedError). "
+        "Only used when checkpoint_format='MX'.",
+        status="prototype",
+    )
+
+    gms_socket_path: Optional[str] = Field(
+        default=None,
+        description="Unix domain socket path of the GPU Memory Service (GMS). "
+        "When set together with load_format='GMS', model weights are mapped "
+        "from a shared GPU memory pool managed by GMS, enabling near-zero "
+        "startup latency. Defaults to /tmp/gms-{device_id}.sock when not set. "
+        "The checkpoint_format axis (e.g. 'HF', 'MX') is independent and "
+        "controls which config/weight format is used.",
+        status="prototype",
+    )
+
+    gms_mode: Optional[str] = Field(
+        default="auto",
+        description="GMS operating mode: 'auto' (detect RW/RO automatically), "
+        "'rw' (first writer, loads weights into GMS pool), or "
+        "'ro' (read-only, maps existing weights from GMS pool). "
+        "Only used when load_format='GMS'.",
+        status="prototype",
+    )
+
+    gms_tag: str = Field(
+        default="weights",
+        description="Tag identifying the weight set in the GMS memory pool. "
+        "Used to distinguish multiple models or versions in the same "
+        "GMS instance. Defaults to 'weights' to match the GMS library "
+        "convention (gpu_memory_service uses 'weights' for the model "
+        "weight tag and 'kv_cache' for the KV cache tag). "
+        "Only used when load_format='GMS'.",
+        status="prototype",
+    )
+
     kv_connector_config: Optional[KvCacheConnectorConfig] = Field(
         default=None,
         description="The config for KV cache connector.",
@@ -3768,6 +3830,8 @@ class TorchLlmArgs(BaseLlmArgs):
     def convert_load_format(cls, v):
         if isinstance(v, LoadFormat):
             return v
+        if isinstance(v, int):
+            return LoadFormat(v)
         load_format = v.upper()
         if load_format not in LoadFormat.__members__:
             raise ValueError(f"Invalid LoadFormat: {v}")
@@ -3875,6 +3939,47 @@ class TorchLlmArgs(BaseLlmArgs):
                 "checkpoint_format will be set to HF.")
             self.checkpoint_format = "HF"
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_mx_config(self) -> 'TorchLlmArgs':
+        if self.mx_server_url is not None and self.checkpoint_format != "MX":
+            logger.warning(
+                "mx_server_url is set but checkpoint_format is '%s', not "
+                "'MX'. The mx_server_url will be ignored. Set "
+                "checkpoint_format='MX' to enable MX P2P weight transfer.",
+                self.checkpoint_format)
+        if self.mx_preshard_strategy not in ("per_module", "global"):
+            raise ValueError(
+                f"mx_preshard_strategy must be 'per_module' or 'global', "
+                f"got '{self.mx_preshard_strategy}'.")
+        if (self.mx_preshard_strategy != "per_module"
+                and self.checkpoint_format != "MX"):
+            logger.warning(
+                "mx_preshard_strategy='%s' is set but checkpoint_format "
+                "is '%s', not 'MX'. The setting will be ignored.",
+                self.mx_preshard_strategy, self.checkpoint_format)
+        return self
+
+    @model_validator(mode="after")
+    def validate_gms_config(self) -> 'TorchLlmArgs':
+        if self.load_format == LoadFormat.GMS:
+            if self.gms_mode not in ("auto", "rw", "ro"):
+                raise ValueError(f"gms_mode must be 'auto', 'rw', or 'ro', "
+                                 f"got '{self.gms_mode}'.")
+        # Reject empty/whitespace-only ``gms_tag`` so a bad config fails
+        # fast instead of silently colliding with the default ``"weights"``
+        # tag inside the GMS pool. Unconditional because ``gms_tag`` always
+        # has a meaningful default and every value is a pool key.
+        if not self.gms_tag or not self.gms_tag.strip():
+            raise ValueError("gms_tag must be a non-empty string, "
+                             f"got {self.gms_tag!r}.")
+        if (self.gms_socket_path is not None
+                and self.load_format != LoadFormat.GMS):
+            logger.warning(
+                "gms_socket_path is set but load_format is '%s', not 'GMS'. "
+                "The gms_socket_path will be ignored. Set load_format='GMS' "
+                "to enable GPU Memory Service.", self.load_format.name)
         return self
 
     @model_validator(mode="after")

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3943,6 +3943,22 @@ class TorchLlmArgs(BaseLlmArgs):
 
     @model_validator(mode="after")
     def validate_mx_config(self) -> 'TorchLlmArgs':
+        # When MX is the active checkpoint format and the user did not
+        # explicitly set ``mx_server_url``, honor the ``MODEL_EXPRESS_URL``
+        # env var that the upstream ``modelexpress`` library reads
+        # (see ``modelexpress.client._get_server_url``). This lets
+        # orchestrators (e.g. Dynamo) configure MX via the environment
+        # without plumbing every CLI knob through, while keeping the
+        # resolved value visible on ``llm_args.mx_server_url`` for
+        # logging, ``/startup_metrics``, and downstream code paths.
+        if (self.checkpoint_format == "MX" and self.mx_server_url is None):
+            env_url = os.environ.get("MODEL_EXPRESS_URL")
+            if env_url:
+                logger.info(
+                    "mx_server_url not set; using MODEL_EXPRESS_URL=%s "
+                    "from environment.", env_url)
+                self.mx_server_url = env_url
+
         if self.mx_server_url is not None and self.checkpoint_format != "MX":
             logger.warning(
                 "mx_server_url is set but checkpoint_format is '%s', not "

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3452,6 +3452,8 @@ class LoadFormat(Enum):
     DUMMY = 1
     # Only load the multimodal(vision) encoder weights
     VISION_ONLY = 2
+    # Load weights from GPU Memory Service (read-only GPU memory pool).
+    GMS = 3
 
 
 class SamplerType(StrEnum):
@@ -3683,6 +3685,48 @@ class TorchLlmArgs(BaseLlmArgs):
         status="prototype",
     )
 
+    mx_server_url: Optional[str] = Field(
+        default=None,
+        description=
+        "URL of the MX (Model eXchange) server for P2P weight transfer. "
+        "When set together with checkpoint_format='MX', enables GPU-to-GPU "
+        "weight transfer from a running source instance, bypassing disk I/O. "
+        "When the server is unreachable, loading falls back to the standard "
+        "HuggingFace checkpoint path.",
+        status="prototype",
+    )
+
+    gms_socket_path: Optional[str] = Field(
+        default=None,
+        description=
+        "Unix domain socket path of the GPU Memory Service (GMS). "
+        "When set together with load_format='GMS', model weights are mapped "
+        "from a shared GPU memory pool managed by GMS, enabling near-zero "
+        "startup latency. Defaults to /tmp/gms-{device_id}.sock when not set. "
+        "The checkpoint_format axis (e.g. 'HF', 'MX') is independent and "
+        "controls which config/weight format is used.",
+        status="prototype",
+    )
+
+    gms_mode: Optional[str] = Field(
+        default="auto",
+        description=
+        "GMS operating mode: 'auto' (detect RW/RO automatically), "
+        "'rw' (first writer, loads weights into GMS pool), or "
+        "'ro' (read-only, maps existing weights from GMS pool). "
+        "Only used when load_format='GMS'.",
+        status="prototype",
+    )
+
+    gms_tag: str = Field(
+        default="model_weights",
+        description=
+        "Tag identifying the weight set in the GMS memory pool. "
+        "Used to distinguish multiple models or versions in the same "
+        "GMS instance. Only used when load_format='GMS'.",
+        status="prototype",
+    )
+
     kv_connector_config: Optional[KvCacheConnectorConfig] = Field(
         default=None,
         description="The config for KV cache connector.",
@@ -3786,6 +3830,8 @@ class TorchLlmArgs(BaseLlmArgs):
     def convert_load_format(cls, v):
         if isinstance(v, LoadFormat):
             return v
+        if isinstance(v, int):
+            return LoadFormat(v)
         load_format = v.upper()
         if load_format not in LoadFormat.__members__:
             raise ValueError(f"Invalid LoadFormat: {v}")
@@ -3893,6 +3939,32 @@ class TorchLlmArgs(BaseLlmArgs):
                 "checkpoint_format will be set to HF.")
             self.checkpoint_format = "HF"
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_mx_config(self) -> 'TorchLlmArgs':
+        if self.mx_server_url is not None and self.checkpoint_format != "MX":
+            logger.warning(
+                "mx_server_url is set but checkpoint_format is '%s', not "
+                "'MX'. The mx_server_url will be ignored. Set "
+                "checkpoint_format='MX' to enable MX P2P weight transfer.",
+                self.checkpoint_format)
+        return self
+
+    @model_validator(mode="after")
+    def validate_gms_config(self) -> 'TorchLlmArgs':
+        if self.load_format == LoadFormat.GMS:
+            if self.gms_mode not in ("auto", "rw", "ro"):
+                raise ValueError(
+                    f"gms_mode must be 'auto', 'rw', or 'ro', "
+                    f"got '{self.gms_mode}'.")
+        if (self.gms_socket_path is not None
+                and self.load_format != LoadFormat.GMS):
+            logger.warning(
+                "gms_socket_path is set but load_format is '%s', not 'GMS'. "
+                "The gms_socket_path will be ignored. Set load_format='GMS' "
+                "to enable GPU Memory Service.",
+                self.load_format.name)
         return self
 
     @model_validator(mode="after")

--- a/tests/unittest/_torch/memory/test_gms_backend.py
+++ b/tests/unittest/_torch/memory/test_gms_backend.py
@@ -1,0 +1,382 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Unit tests for ``GMSBackend`` (``LoadFormat.GMS``).
+
+These tests intentionally do NOT exercise the upstream
+``gpu_memory_service`` library. Tests for the import-failure fallback
+path mock ``gpu_memory_service.*`` symbols out of ``sys.modules`` so the
+assertion is about *our* fallback behavior, not about the upstream API.
+
+The only piece of real CUDA touched by ``GMSBackend.__init__`` is a
+single ``torch.cuda.current_device()`` call to record the device index.
+We monkeypatch that to a fixed integer for the whole module so every
+control-path test (construction, pre-connect, connect-failure, RW/RO
+gating, protocol conformance) runs on CPU CI without a GPU.
+"""
+
+import sys
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.memory.gpu_memory_backend import (
+    GMSBackend,
+    GPUMemoryBackend,
+    _ptr_in_gms,
+    _storage_nbytes,
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_current_device(monkeypatch):
+    """Make ``GMSBackend.__init__`` runnable on CPU CI.
+
+    The only real-CUDA dependency in our backend's ``__init__`` is
+    ``torch.cuda.current_device()`` — there are no kernel launches.
+    Stubbing it to ``0`` lets every mocked happy/failure connect path
+    actually execute under CPU CI.
+    """
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    """GMSBackend construction-time invariants."""
+
+    @pytest.mark.parametrize("mode", ["rw", "ro", "auto"])
+    def test_accepts_valid_modes(self, mode):
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock(), mode=mode)
+        assert backend._mode == mode
+        assert backend._client is None
+        assert backend._is_rw is None
+
+    @pytest.mark.parametrize(
+        "bad_mode", ["RW", "Auto", "read", "write", "shadow", "", "rw ", "auto-detect"]
+    )
+    def test_rejects_invalid_modes(self, bad_mode):
+        with pytest.raises(ValueError, match="GMS mode must be"):
+            GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock(), mode=bad_mode)
+
+    def test_default_tag(self):
+        # IMPORTANT: default tag must be ``weights``, NOT ``model_weights``.
+        # Matches the GMS library convention (GMS_TAGS upstream).
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock())
+        assert backend._tag == "weights"
+        assert GMSBackend.DEFAULT_TAG == "weights"
+
+    def test_custom_tag(self):
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock(), tag="custom")
+        assert backend._tag == "custom"
+
+    def test_socket_path_stored(self):
+        backend = GMSBackend(socket_path="/tmp/custom.sock", mapping=MagicMock())
+        assert backend._socket_path == "/tmp/custom.sock"
+
+    def test_socket_path_none_resolved_lazily(self):
+        # Socket-path resolution to upstream get_socket_path(device, tag)
+        # happens inside connect(), not __init__. Construction with
+        # socket_path=None must not raise.
+        backend = GMSBackend(socket_path=None, mapping=MagicMock())
+        assert backend._socket_path is None
+        assert backend._client is None
+
+
+# ---------------------------------------------------------------------------
+# Properties before connect()
+# ---------------------------------------------------------------------------
+
+
+class TestPreConnectState:
+    def _backend(self):
+        return GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock())
+
+    def test_is_rw_is_none(self):
+        assert self._backend().is_rw is None
+
+    def test_has_committed_weights_returns_false(self):
+        # No committed weights when not connected — return False (not raise).
+        assert self._backend().has_committed_weights() is False
+
+    def test_cleanup_safe_when_never_connected(self):
+        # cleanup() must be idempotent and safe to call before connect().
+        self._backend().cleanup()  # must not raise
+
+    @pytest.mark.parametrize(
+        "method_name, invoke",
+        [
+            # invoke(backend) -> trigger; we wrap mem_pool_scope so the
+            # context-manager protocol gets exercised inside pytest.raises.
+            ("mem_pool_scope", lambda backend: backend.mem_pool_scope().__enter__()),
+            ("materialize_module", lambda backend: backend.materialize_module(MagicMock())),
+            ("finalize_write", lambda backend: backend.finalize_write(MagicMock())),
+            ("move_untracked_params", lambda backend: backend.move_untracked_params(MagicMock())),
+        ],
+    )
+    def test_method_raises_when_not_connected(self, method_name, invoke):
+        # Every method that uses the GMS client must guard with a clear
+        # "not connected" error before dereferencing self._client.
+        with pytest.raises(RuntimeError, match="not connected"):
+            invoke(self._backend())
+
+
+# ---------------------------------------------------------------------------
+# connect() — graceful failure on missing upstream library
+# ---------------------------------------------------------------------------
+
+
+class TestConnectFailure:
+    def test_returns_false_when_upstream_not_installed(self):
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock())
+        with _block_gms():
+            assert backend.connect() is False
+        assert backend._client is None
+        assert backend._is_rw is None
+
+    def test_returns_false_when_upstream_raises(self):
+        # If get_or_create_gms_client_memory_manager raises (e.g. socket
+        # doesn't exist), connect() must surface a False (not propagate).
+        backend = GMSBackend(socket_path="/tmp/nonexistent.sock", mapping=MagicMock())
+
+        fake_gms = _build_fake_gms_lock_failure(error=RuntimeError("socket missing"))
+        with _install_fake_gms(fake_gms):
+            assert backend.connect() is False
+        assert backend._client is None
+
+
+# ---------------------------------------------------------------------------
+# RW-vs-RO method gating
+# ---------------------------------------------------------------------------
+
+
+class TestRwOnlyMethodsGated:
+    """RW-only methods must raise when the granted lock is RO."""
+
+    def _ro_backend(self):
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock())
+        # Simulate "connected, granted RO" without going through real connect().
+        backend._client = MagicMock()
+        backend._is_rw = False
+        return backend
+
+    @pytest.mark.parametrize(
+        "method_name, invoke",
+        [
+            ("mem_pool_scope", lambda backend: backend.mem_pool_scope().__enter__()),
+            ("finalize_write", lambda backend: backend.finalize_write(MagicMock())),
+        ],
+    )
+    def test_method_raises_when_granted_ro(self, method_name, invoke):
+        with pytest.raises(RuntimeError, match="only valid in RW mode"):
+            invoke(self._ro_backend())
+
+
+# ---------------------------------------------------------------------------
+# Helper functions: _ptr_in_gms, _storage_nbytes
+# ---------------------------------------------------------------------------
+
+
+def _make_gms_client_with_mapping(va: int, size: int):
+    """Build a fake GMS client that exposes one mapping at (va, size)."""
+    client = MagicMock()
+    mapping = MagicMock()
+    mapping.va = va
+    mapping.size = size
+    client._mappings = {"k": mapping}
+    return client
+
+
+class TestPtrInGms:
+    """``_ptr_in_gms`` semantics: half-open intervals + defensive guards."""
+
+    def test_returns_false_when_no_mappings_attr(self):
+        # Older GMS releases may not have ``_mappings`` at all.
+        client = MagicMock(spec=[])
+        assert _ptr_in_gms(client, 0xABCDEF) is False
+
+    def test_returns_false_when_mappings_empty(self):
+        client = MagicMock()
+        client._mappings = {}
+        assert _ptr_in_gms(client, 0xABCDEF) is False
+
+    @pytest.mark.parametrize(
+        "label, ptr, expected",
+        [
+            # Reference mapping is at va=0x1000, size=0x100 (range
+            # [0x1000, 0x1100) — half-open).
+            ("inside_mapping", 0x1080, True),
+            ("at_mapping_start", 0x1000, True),
+            ("just_below_end", 0x10FF, True),
+            ("at_mapping_end", 0x1100, False),  # half-open
+            ("just_below_start", 0x0FFF, False),
+            ("far_outside", 0x2000, False),
+        ],
+    )
+    def test_half_open_interval(self, label, ptr, expected):
+        client = _make_gms_client_with_mapping(va=0x1000, size=0x100)
+        assert _ptr_in_gms(client, ptr) is expected, (
+            f"case={label}: ptr=0x{ptr:x} expected {expected}"
+        )
+
+    @pytest.mark.parametrize(
+        "label, va, size",
+        [
+            ("zero_va_zero_size", 0, 0),
+            ("zero_va_nonzero_size", 0, 0x100),
+            ("nonzero_va_zero_size", 0x1000, 0),
+        ],
+    )
+    def test_zero_sentinels_never_match(self, label, va, size):
+        # Defensive: a mapping with va=0 or size=0 must never match,
+        # even when the queried pointer is 0.
+        client = _make_gms_client_with_mapping(va=va, size=size)
+        assert _ptr_in_gms(client, 0) is False, f"case={label}"
+        assert _ptr_in_gms(client, va) is False, f"case={label}"
+
+
+class TestStorageNbytes:
+    def test_cpu_tensor(self):
+        t = torch.empty(10, dtype=torch.float32)
+        # 10 * 4 = 40 bytes minimum
+        assert _storage_nbytes(t) >= 40
+
+    def test_dtype_dependent(self):
+        t_f32 = torch.empty(10, dtype=torch.float32)
+        t_bf16 = torch.empty(10, dtype=torch.bfloat16)
+        # 10 fp32 occupies more than 10 bf16
+        assert _storage_nbytes(t_f32) > _storage_nbytes(t_bf16)
+
+    def test_shape_independent_for_views(self):
+        # Storage size should reflect the underlying buffer, not the view.
+        base = torch.empty(100, dtype=torch.float32)
+        view = base.view(10, 10)
+        assert _storage_nbytes(view) == _storage_nbytes(base)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_gms_backend_implements_protocol(self):
+        # GMSBackend instances must satisfy the runtime-checkable
+        # GPUMemoryBackend protocol.
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock())
+        assert isinstance(backend, GPUMemoryBackend)
+
+    def test_protocol_method_set(self):
+        # The protocol must keep the methods that model_loader.py invokes
+        # so a different backend (e.g. CudaIpcBackend) can be plugged in.
+        required = {
+            "connect",
+            "is_rw",
+            "has_committed_weights",
+            "mem_pool_scope",
+            "materialize_module",
+            "finalize_write",
+            "move_untracked_params",
+            "cleanup",
+        }
+        for method in required:
+            assert hasattr(GPUMemoryBackend, method), (
+                f"GPUMemoryBackend protocol missing method: {method}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake gpu_memory_service modules and import blockers
+# ---------------------------------------------------------------------------
+
+
+_GMS_MODULE_NAMES = [
+    "gpu_memory_service",
+    "gpu_memory_service.client",
+    "gpu_memory_service.client.torch",
+    "gpu_memory_service.client.torch.allocator",
+    "gpu_memory_service.common",
+    "gpu_memory_service.common.locks",
+    "gpu_memory_service.common.utils",
+    "gpu_memory_service.integrations",
+    "gpu_memory_service.integrations.common",
+    "gpu_memory_service.integrations.common.patches",
+]
+
+
+@contextmanager
+def _block_gms():
+    """Context manager that makes ``import gpu_memory_service.*`` raise."""
+    saved = {name: sys.modules.get(name) for name in _GMS_MODULE_NAMES}
+    try:
+        for name in _GMS_MODULE_NAMES:
+            sys.modules[name] = None  # forces ImportError on import
+        yield
+    finally:
+        for name, prior in saved.items():
+            if prior is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prior
+
+
+def _build_fake_gms_lock_failure(*, error):
+    """Build a fake gpu_memory_service whose factory raises on call."""
+    fake_pkg = MagicMock(name="gpu_memory_service")
+    fake_pkg.client = MagicMock(name="gpu_memory_service.client")
+    fake_pkg.client.torch = MagicMock(name="gpu_memory_service.client.torch")
+    fake_pkg.client.torch.allocator = MagicMock(name="gpu_memory_service.client.torch.allocator")
+    fake_pkg.client.torch.allocator.get_or_create_gms_client_memory_manager = MagicMock(
+        side_effect=error
+    )
+
+    # Lock-type and util modules
+    fake_pkg.common = MagicMock()
+    fake_pkg.common.locks = MagicMock()
+    fake_pkg.common.locks.RequestedLockType = MagicMock(RW="rw", RO="ro", RW_OR_RO="rw_or_ro")
+    fake_pkg.common.locks.GrantedLockType = MagicMock(RW="rw", RO="ro")
+    fake_pkg.common.utils = MagicMock()
+    fake_pkg.common.utils.get_socket_path = MagicMock(return_value="/tmp/fake.sock")
+
+    # patch_empty_cache stub
+    fake_pkg.integrations = MagicMock()
+    fake_pkg.integrations.common = MagicMock()
+    fake_pkg.integrations.common.patches = MagicMock()
+    fake_pkg.integrations.common.patches.patch_empty_cache = MagicMock()
+    return fake_pkg
+
+
+@contextmanager
+def _install_fake_gms(fake_pkg):
+    """Install a fake ``gpu_memory_service`` tree into ``sys.modules``."""
+    saved = {name: sys.modules.get(name) for name in _GMS_MODULE_NAMES}
+    try:
+        sys.modules["gpu_memory_service"] = fake_pkg
+        sys.modules["gpu_memory_service.client"] = fake_pkg.client
+        sys.modules["gpu_memory_service.client.torch"] = fake_pkg.client.torch
+        sys.modules["gpu_memory_service.client.torch.allocator"] = fake_pkg.client.torch.allocator
+        sys.modules["gpu_memory_service.common"] = fake_pkg.common
+        sys.modules["gpu_memory_service.common.locks"] = fake_pkg.common.locks
+        sys.modules["gpu_memory_service.common.utils"] = fake_pkg.common.utils
+        sys.modules["gpu_memory_service.integrations"] = fake_pkg.integrations
+        sys.modules["gpu_memory_service.integrations.common"] = fake_pkg.integrations.common
+        sys.modules["gpu_memory_service.integrations.common.patches"] = (
+            fake_pkg.integrations.common.patches
+        )
+        yield
+    finally:
+        for name, prior in saved.items():
+            if prior is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prior

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -1,0 +1,619 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Unit tests for ``MXCheckpointLoader`` (``checkpoint_format='MX'``).
+
+These tests intentionally do NOT exercise the upstream ``modelexpress``
+library. Tests for the import-failure fallback path mock
+``modelexpress.*`` symbols out of ``sys.modules`` so the assertion is
+about *our* fallback behavior, not about the upstream API.
+"""
+
+import os
+import sys
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import BaseCheckpointLoader
+from tensorrt_llm._torch.models.checkpoints.hf.checkpoint_loader import HfCheckpointLoader
+from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import (
+    MXCheckpointLoader,
+    _normalize_model_identity,
+    _resolve_mx_model_name,
+)
+
+# ---------------------------------------------------------------------------
+# Construction & static properties
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_no_args_constructs(self):
+        loader = MXCheckpointLoader()
+        assert loader.mx_server_url is None
+        assert loader.p2p_succeeded is False
+
+    def test_mx_server_url_stored(self):
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        assert loader.mx_server_url == "http://mx:8001"
+        assert loader.p2p_succeeded is False
+
+    def test_subclasses_hf_loader(self):
+        # Inheriting from HfCheckpointLoader is what gives us free disk
+        # fallback. Don't break this.
+        loader = MXCheckpointLoader()
+        assert isinstance(loader, HfCheckpointLoader)
+        assert isinstance(loader, BaseCheckpointLoader)
+
+    def test_checkpoint_format_property(self):
+        loader = MXCheckpointLoader()
+        assert loader.checkpoint_format == "MX"
+
+    def test_checkpoint_format_backing_attr(self):
+        # Several call sites read ``self._checkpoint_format`` directly
+        # (instead of going through the property). The constructor must
+        # align the backing attribute with the property override.
+        loader = MXCheckpointLoader()
+        assert loader._checkpoint_format == "MX"
+
+    def test_p2p_succeeded_property_initial(self):
+        loader = MXCheckpointLoader()
+        assert loader.p2p_succeeded is False
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_registered_under_mx(self):
+        # ``ModelLoader.load`` resolves a checkpoint loader from
+        # ``checkpoint_format`` via ``BaseCheckpointLoader.get``. PR #13045
+        # registers ``MX`` via ``@register_checkpoint_loader("MX")``.
+        # The real call site (in _construct_checkpoint_loader) passes
+        # weight_loader=, weight_mapper=, config_loader=, plus optional
+        # mx_server_url= — so test with the same call shape.
+        loader = BaseCheckpointLoader.get(
+            checkpoint_format="MX",
+            weight_loader=None,
+            weight_mapper=None,
+            config_loader=None,
+            mx_server_url="http://mx:8001",
+        )
+        assert isinstance(loader, MXCheckpointLoader)
+        assert loader.checkpoint_format == "MX"
+        assert loader.mx_server_url == "http://mx:8001"
+
+
+# ---------------------------------------------------------------------------
+# load_weights — disk-fallback paths (no upstream library involved)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadWeightsFallback:
+    """Disk-fallback paths that should not touch the upstream MX library.
+
+    All four fallback triggers share the same observable contract:
+    ``p2p_succeeded`` stays False, the parent ``HfCheckpointLoader.
+    load_weights`` is invoked exactly once, and its return value is
+    propagated unchanged. We parameterize the trigger to keep that
+    contract in one place.
+    """
+
+    # Trigger setup builders.
+    @staticmethod
+    def _no_url(stack):  # noqa: ARG004 — stack unused for this trigger
+        return MXCheckpointLoader(), {"model": MagicMock()}
+
+    @staticmethod
+    def _no_model(stack):  # noqa: ARG004
+        return MXCheckpointLoader(mx_server_url="http://mx:8001"), {}
+
+    @staticmethod
+    def _modelexpress_unavailable(stack):
+        stack.enter_context(_block_modelexpress())
+        return (MXCheckpointLoader(mx_server_url="http://mx:8001"), {"model": MagicMock()})
+
+    @staticmethod
+    def _upstream_raises(stack):
+        fake_mx = _build_fake_modelexpress(load_weights_side_effect=RuntimeError("boom"))
+        stack.enter_context(_install_fake_modelexpress(fake_mx))
+        return (MXCheckpointLoader(mx_server_url="http://mx:8001"), {"model": MagicMock()})
+
+    @pytest.mark.parametrize(
+        "trigger_id, setup",
+        [
+            ("no_mx_server_url", _no_url),
+            ("no_model_kwarg", _no_model),
+            ("modelexpress_not_installed", _modelexpress_unavailable),
+            ("upstream_raises", _upstream_raises),
+        ],
+    )
+    def test_falls_back_to_disk(self, trigger_id, setup):
+        sentinel = {"disk-load": "result"}
+        with ExitStack() as stack:
+            loader, extra_kwargs = setup(stack)
+            mock_super_load = stack.enter_context(
+                patch.object(HfCheckpointLoader, "load_weights", return_value=sentinel)
+            )
+
+            result = loader.load_weights("/nonexistent", mapping=MagicMock(), **extra_kwargs)
+
+        assert result is sentinel, (
+            f"trigger={trigger_id}: production code must propagate the "
+            "parent loader's return value unchanged"
+        )
+        assert loader.p2p_succeeded is False, (
+            f"trigger={trigger_id}: p2p_succeeded must stay False on any fallback path"
+        )
+        mock_super_load.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# load_weights — MX-success and mixed-success paths (mocked upstream)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadWeightsMxPath:
+    def test_p2p_full_success_returns_empty_dict(self):
+        # Empty fallback dict means MX delivered all weights into model
+        # params; ``ModelLoader`` interprets the empty dict + p2p_succeeded
+        # flag as "skip the standard weight-mapping pipeline".
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        fake_mx = _build_fake_modelexpress(load_weights_return={})
+        mapping = MagicMock(name="mapping")
+        model = MagicMock(name="model")
+
+        with _install_fake_modelexpress(fake_mx):
+            result = loader.load_weights("/nonexistent", mapping=mapping, model=model)
+
+        assert result == {}
+        assert loader.p2p_succeeded is True
+
+        # Verify the integration contract with the upstream library:
+        # 1. Constructed MxLiveWeightLoader with our mx_server_url.
+        fake_mx.trtllm_live_transfer.MxLiveWeightLoader.assert_called_once_with(
+            mx_server="http://mx:8001"
+        )
+        # 2. Called load_weights with the right positional/keyword args.
+        weight_loader_instance = fake_mx.trtllm_live_transfer.MxLiveWeightLoader.return_value
+        weight_loader_instance.load_weights.assert_called_once_with(
+            "/nonexistent", mapping=mapping, model=model
+        )
+
+    def test_mixed_success_falls_back_to_full_disk(self):
+        # When MX returns a non-empty fallback dict (size-mismatched
+        # tensors), the prototype is conservative: full disk load to
+        # avoid mixing presharded and non-presharded weights. Tracked as
+        # MX-1 in §15 of the design doc.
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        fake_mx = _build_fake_modelexpress(load_weights_return={"some.weight": MagicMock()})
+        sentinel = {"disk-load": "result"}
+
+        with (
+            _install_fake_modelexpress(fake_mx),
+            patch.object(
+                HfCheckpointLoader, "load_weights", return_value=sentinel
+            ) as mock_super_load,
+        ):
+            result = loader.load_weights("/nonexistent", mapping=MagicMock(), model=MagicMock())
+
+        # Must NOT pretend P2P succeeded — the standard pipeline must
+        # process all weights.
+        assert loader.p2p_succeeded is False
+        assert result is sentinel
+        mock_super_load.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# publish_as_source — env-var dance and graceful no-op
+# ---------------------------------------------------------------------------
+
+
+class TestPublishAsSource:
+    def test_no_mx_server_url_is_noop(self):
+        loader = MXCheckpointLoader()  # mx_server_url is None
+        # Any attempt to import modelexpress would raise here, so we
+        # don't even need to mock.
+        with _block_modelexpress():
+            loader.publish_as_source(MagicMock())  # must not raise
+
+    def test_modelexpress_unavailable_is_noop(self):
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        with _block_modelexpress():
+            loader.publish_as_source(MagicMock())  # must not raise
+
+    def test_publish_called_with_model(self):
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        fake_mx = _build_fake_modelexpress()
+        model = MagicMock(name="model")
+
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(model)
+
+        fake_mx.trtllm_live_transfer.publish_model_params.assert_called_once_with(model)
+
+    def test_env_var_set_during_publish_then_restored(self):
+        loader = MXCheckpointLoader(mx_server_url="http://mx-instance:9999")
+        captured_env = {}
+
+        def _capture(model):
+            captured_env["MODEL_EXPRESS_URL"] = os.environ.get("MODEL_EXPRESS_URL")
+
+        fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
+
+        prior = os.environ.pop("MODEL_EXPRESS_URL", None)
+        try:
+            with _install_fake_modelexpress(fake_mx):
+                loader.publish_as_source(MagicMock())
+        finally:
+            if prior is not None:
+                os.environ["MODEL_EXPRESS_URL"] = prior
+
+        # During the call, our per-loader URL was visible.
+        assert captured_env["MODEL_EXPRESS_URL"] == "http://mx-instance:9999"
+        # After the call, the env var is back to the pre-call state.
+        assert "MODEL_EXPRESS_URL" not in os.environ
+
+    def test_env_var_restored_to_prior_value(self):
+        loader = MXCheckpointLoader(mx_server_url="http://mx-instance:9999")
+        fake_mx = _build_fake_modelexpress()
+        prior = os.environ.get("MODEL_EXPRESS_URL")
+        os.environ["MODEL_EXPRESS_URL"] = "http://prior-value:1234"
+        try:
+            with _install_fake_modelexpress(fake_mx):
+                loader.publish_as_source(MagicMock())
+            assert os.environ["MODEL_EXPRESS_URL"] == "http://prior-value:1234"
+        finally:
+            if prior is None:
+                os.environ.pop("MODEL_EXPRESS_URL", None)
+            else:
+                os.environ["MODEL_EXPRESS_URL"] = prior
+
+    def test_publish_exception_swallowed(self):
+        # publish_as_source is a best-effort hook; an upstream exception
+        # must NOT take down model loading.
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        fake_mx = _build_fake_modelexpress(publish_side_effect=RuntimeError("upstream went away"))
+
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(MagicMock())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake modelexpress modules and import blockers
+# ---------------------------------------------------------------------------
+
+
+def _modelexpress_module_names():
+    return [
+        "modelexpress",
+        "modelexpress.trtllm_live_transfer",
+    ]
+
+
+def _block_modelexpress():
+    """Context manager that makes ``import modelexpress`` raise ImportError."""
+    saved = {name: sys.modules.get(name) for name in _modelexpress_module_names()}
+
+    class _Blocker:
+        def __enter__(self):
+            for name in _modelexpress_module_names():
+                # Setting to None makes ``import name`` raise
+                # ImportError per PEP 328 / sys.modules semantics.
+                sys.modules[name] = None
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            for name, prior in saved.items():
+                if prior is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = prior
+
+    return _Blocker()
+
+
+def _build_fake_modelexpress(
+    *, load_weights_return=None, load_weights_side_effect=None, publish_side_effect=None
+):
+    """Build a fake modelexpress module tree mimicking the symbols we use."""
+    fake_pkg = MagicMock(name="modelexpress")
+
+    fake_trtllm_live = MagicMock(name="modelexpress.trtllm_live_transfer")
+
+    # MxLiveWeightLoader(mx_server=url).load_weights(ckpt_dir, mapping=, model=)
+    weight_loader_instance = MagicMock(name="MxLiveWeightLoader instance")
+    if load_weights_side_effect is not None:
+        weight_loader_instance.load_weights.side_effect = load_weights_side_effect
+    else:
+        weight_loader_instance.load_weights.return_value = (
+            load_weights_return if load_weights_return is not None else {}
+        )
+    fake_trtllm_live.MxLiveWeightLoader = MagicMock(return_value=weight_loader_instance)
+
+    # publish_model_params(model)
+    if publish_side_effect is not None:
+        fake_trtllm_live.publish_model_params = MagicMock(side_effect=publish_side_effect)
+    else:
+        fake_trtllm_live.publish_model_params = MagicMock()
+
+    fake_pkg.trtllm_live_transfer = fake_trtllm_live
+    return fake_pkg
+
+
+def _install_fake_modelexpress(fake_pkg):
+    """Context manager that installs a fake ``modelexpress`` into sys.modules."""
+
+    class _Installer:
+        _saved = {}
+
+        def __enter__(self):
+            for name in _modelexpress_module_names():
+                self._saved[name] = sys.modules.get(name)
+            sys.modules["modelexpress"] = fake_pkg
+            sys.modules["modelexpress.trtllm_live_transfer"] = fake_pkg.trtllm_live_transfer
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            for name, prior in self._saved.items():
+                if prior is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = prior
+
+    return _Installer()
+
+
+# ---------------------------------------------------------------------------
+# Item 2: defensive MX_SOURCE_QUERY_TIMEOUT default
+# ---------------------------------------------------------------------------
+
+
+class TestMxSourceQueryTimeoutDefault:
+    """``MXCheckpointLoader.__init__`` caps upstream's source-query timeout
+    so the very first replica on a cold cluster does not block for the
+    upstream default of 1 hour. ``setdefault`` semantics — never overrides
+    an explicit user value.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_env(self, monkeypatch):
+        monkeypatch.delenv("MX_SOURCE_QUERY_TIMEOUT", raising=False)
+        yield
+
+    def test_unset_with_mx_url_gets_default(self):
+        MXCheckpointLoader(mx_server_url="http://mx:8001")
+        assert os.environ.get("MX_SOURCE_QUERY_TIMEOUT") == "30"
+
+    def test_explicit_user_value_preserved(self, monkeypatch):
+        # If the user/orchestrator already set a value, our defensive
+        # default must not stomp it.
+        monkeypatch.setenv("MX_SOURCE_QUERY_TIMEOUT", "120")
+        MXCheckpointLoader(mx_server_url="http://mx:8001")
+        assert os.environ.get("MX_SOURCE_QUERY_TIMEOUT") == "120"
+
+    def test_no_mx_url_does_not_touch_env(self):
+        # HF-only loads must not surprise users by setting MX-namespaced
+        # env vars they didn't ask for.
+        MXCheckpointLoader()  # mx_server_url=None
+        assert "MX_SOURCE_QUERY_TIMEOUT" not in os.environ
+
+
+# ---------------------------------------------------------------------------
+# Item 3: model_name plumbing + resolver + publish-side env handoff
+# ---------------------------------------------------------------------------
+
+
+class TestModelNameConstructor:
+    def test_default_model_name_none(self):
+        loader = MXCheckpointLoader()
+        assert loader.model_name is None
+
+    def test_model_name_stored_as_string(self):
+        loader = MXCheckpointLoader(model_name="Qwen/Qwen2.5-72B-Instruct")
+        assert loader.model_name == "Qwen/Qwen2.5-72B-Instruct"
+
+    def test_model_name_path_coerced_to_string(self, tmp_path):
+        # Constructor accepts Path (e.g. llm_args.model resolved as Path)
+        # and stores it as a string for downstream env-var publishing.
+        path = tmp_path / "my-checkpoint"
+        loader = MXCheckpointLoader(model_name=path)
+        assert loader.model_name == str(path)
+        assert isinstance(loader.model_name, str)
+
+
+class TestNormalizeModelIdentity:
+    """``_normalize_model_identity`` is the path-vs-id heuristic used by
+    the resolver. Pinning it down with parametrized cases."""
+
+    @pytest.mark.parametrize(
+        "label, value, expected",
+        [
+            # Hub IDs and bare names pass through unchanged.
+            ("bare_name", "llama-3-70b", "llama-3-70b"),
+            ("hub_id", "Qwen/Qwen2.5-72B-Instruct", "Qwen/Qwen2.5-72B-Instruct"),
+            ("nested_hub_id", "meta-llama/Llama-3-70B", "meta-llama/Llama-3-70B"),
+            # Absolute paths get reduced to basenames.
+            ("abs_path_simple", "/scratch/local-model", "local-model"),
+            ("abs_path_nested", "/cache/foo/bar/baz", "baz"),
+            # Relative-looking paths are treated as paths.
+            ("dot_relative", "./local-model", "local-model"),
+            ("home_expansion", "~/models/my-model", "my-model"),
+            # Empty / sentinel.
+            ("empty", "", "unknown"),
+        ],
+    )
+    def test_basic_cases(self, label, value, expected):
+        assert _normalize_model_identity(value) == expected, f"case={label}"
+
+    def test_hf_snapshot_unmangling(self):
+        # HF cache layout: ".../models--<org>--<name>/snapshots/<sha>/"
+        # → "<org>/<name>" (not the commit sha).
+        snapshot = (
+            "/cache/huggingface/hub/models--Qwen--Qwen2.5-72B-Instruct/snapshots/abc123def456789"
+        )
+        assert _normalize_model_identity(snapshot) == "Qwen/Qwen2.5-72B-Instruct"
+
+    def test_hf_snapshot_unmangling_nested_org(self):
+        # Multi-component HF org names use "--" as the separator.
+        snapshot = "/cache/hub/models--meta-llama--Llama-3-70B-Instruct/snapshots/sha"
+        assert _normalize_model_identity(snapshot) == "meta-llama/Llama-3-70B-Instruct"
+
+
+class TestResolveMxModelName:
+    """``_resolve_mx_model_name`` is the priority-ordered lookup used by
+    ``publish_as_source``. Verifying the ordering."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_env(self, monkeypatch):
+        monkeypatch.delenv("MODEL_NAME", raising=False)
+        yield
+
+    def test_explicit_arg_wins(self, monkeypatch):
+        monkeypatch.setenv("MODEL_NAME", "from-env")
+        assert _resolve_mx_model_name("explicit", "/cache/snapshot/abc") == "explicit"
+
+    def test_env_used_when_arg_none(self, monkeypatch):
+        monkeypatch.setenv("MODEL_NAME", "from-env")
+        assert _resolve_mx_model_name(None, "/cache/snapshot/abc") == "from-env"
+
+    def test_basename_fallback_when_arg_and_env_missing(self):
+        assert _resolve_mx_model_name(None, "/scratch/local-model") == "local-model"
+
+    def test_snapshot_fallback_when_arg_and_env_missing(self):
+        snapshot = "/cache/huggingface/hub/models--Qwen--Qwen2.5-72B-Instruct/snapshots/abc123"
+        assert _resolve_mx_model_name(None, snapshot) == "Qwen/Qwen2.5-72B-Instruct"
+
+    def test_unknown_when_all_missing(self):
+        assert _resolve_mx_model_name(None, None) == "unknown"
+        assert _resolve_mx_model_name("", None) == "unknown"
+
+    def test_explicit_arg_normalized_too(self):
+        # If the explicit arg looks like a path (e.g. llm_args.model
+        # was a Path), it gets normalized too.
+        assert _resolve_mx_model_name("/scratch/explicit-path", "/cache/ignored") == "explicit-path"
+
+
+class TestPublishAsSourceModelName:
+    """``publish_as_source`` must set ``MODEL_NAME`` from the resolved
+    identity so upstream's ``publish_model_params`` reads it via env,
+    and must restore the prior env value afterwards.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_env(self, monkeypatch):
+        monkeypatch.delenv("MODEL_NAME", raising=False)
+        monkeypatch.delenv("MODEL_EXPRESS_URL", raising=False)
+        monkeypatch.delenv("MX_SOURCE_QUERY_TIMEOUT", raising=False)
+        yield
+
+    def test_uses_explicit_constructor_model_name(self):
+        loader = MXCheckpointLoader(
+            mx_server_url="http://mx:8001",
+            model_name="Qwen/Qwen2.5-72B-Instruct",
+        )
+        captured = {}
+
+        def _capture(model):
+            captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
+            captured["MODEL_EXPRESS_URL"] = os.environ.get("MODEL_EXPRESS_URL")
+
+        fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(MagicMock())
+
+        assert captured["MODEL_NAME"] == "Qwen/Qwen2.5-72B-Instruct"
+        assert captured["MODEL_EXPRESS_URL"] == "http://mx:8001"
+        # Both env vars restored to the (unset) prior state.
+        assert "MODEL_NAME" not in os.environ
+        assert "MODEL_EXPRESS_URL" not in os.environ
+
+    def test_falls_back_to_checkpoint_dir_basename(self):
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        # No constructor model_name, no MODEL_NAME env → use basename.
+        captured = {}
+
+        def _capture(model):
+            captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
+
+        fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(MagicMock(), checkpoint_dir="/scratch/local-model")
+
+        assert captured["MODEL_NAME"] == "local-model"
+
+    def test_unmangles_hf_snapshot_path(self):
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        snapshot = (
+            "/cache/huggingface/hub/models--Qwen--Qwen2.5-72B-Instruct/snapshots/abc123def456"
+        )
+        captured = {}
+
+        def _capture(model):
+            captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
+
+        fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(MagicMock(), checkpoint_dir=snapshot)
+
+        # Critical: NOT the commit hash, the human-readable Hub-ID form.
+        assert captured["MODEL_NAME"] == "Qwen/Qwen2.5-72B-Instruct"
+        assert captured["MODEL_NAME"] != "abc123def456"
+
+    def test_constructor_model_name_takes_priority_over_env(self, monkeypatch):
+        # Explicit constructor value > existing MODEL_NAME env.
+        monkeypatch.setenv("MODEL_NAME", "from-env")
+        loader = MXCheckpointLoader(
+            mx_server_url="http://mx:8001",
+            model_name="explicit",
+        )
+        captured = {}
+
+        def _capture(model):
+            captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
+
+        fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(MagicMock())
+
+        assert captured["MODEL_NAME"] == "explicit"
+        # Restored to the prior env value, not unset.
+        assert os.environ.get("MODEL_NAME") == "from-env"
+
+    def test_env_used_when_no_constructor_value(self, monkeypatch):
+        monkeypatch.setenv("MODEL_NAME", "from-env-only")
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        captured = {}
+
+        def _capture(model):
+            captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
+
+        fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(MagicMock())
+
+        assert captured["MODEL_NAME"] == "from-env-only"
+        assert os.environ.get("MODEL_NAME") == "from-env-only"
+
+    def test_unknown_when_all_sources_missing(self):
+        # No constructor, no env, no checkpoint_dir → upstream sentinel.
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        captured = {}
+
+        def _capture(model):
+            captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
+
+        fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(MagicMock())
+
+        assert captured["MODEL_NAME"] == "unknown"

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -99,6 +99,26 @@ methods:
         annotation: Optional[str]
         default: null
         status: prototype
+      mx_server_url:
+        annotation: Optional[str]
+        default: null
+        status: prototype
+      mx_preshard_strategy:
+        annotation: str
+        default: per_module
+        status: prototype
+      gms_socket_path:
+        annotation: Optional[str]
+        default: null
+        status: prototype
+      gms_mode:
+        annotation: Optional[str]
+        default: auto
+        status: prototype
+      gms_tag:
+        annotation: str
+        default: weights
+        status: prototype
       mm_encoder_only:
         annotation: bool
         default: False

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -99,6 +99,22 @@ methods:
         annotation: Optional[str]
         default: null
         status: prototype
+      mx_server_url:
+        annotation: Optional[str]
+        default: null
+        status: prototype
+      gms_socket_path:
+        annotation: Optional[str]
+        default: null
+        status: prototype
+      gms_mode:
+        annotation: Optional[str]
+        default: auto
+        status: prototype
+      gms_tag:
+        annotation: str
+        default: model_weights
+        status: prototype
       mm_encoder_only:
         annotation: bool
         default: False

--- a/tests/unittest/llmapi/test_mx_gms_args.py
+++ b/tests/unittest/llmapi/test_mx_gms_args.py
@@ -1,0 +1,400 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Unit tests for MX/GMS prototype config fields on ``TorchLlmArgs``.
+
+Covers the prototype fields added by PR #13045:
+- ``mx_server_url``
+- ``mx_preshard_strategy``
+- ``gms_socket_path``
+- ``gms_mode``
+- ``gms_tag``
+
+These tests exercise only Pydantic validation behavior — no upstream
+``modelexpress`` or ``gpu_memory_service`` library is imported.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from tensorrt_llm.llmapi.llm_args import LoadFormat, TorchLlmArgs
+
+# tensorrt_llm uses a custom Singleton logger (tensorrt_llm.logger.logger)
+# that does NOT route through stdlib logging, so pytest's ``caplog`` does
+# not intercept its warnings. We patch ``logger.warning`` directly with a
+# MagicMock to inspect calls instead.
+_LOGGER_PATH = "tensorrt_llm.llmapi.llm_args.logger"
+
+
+def _capture_warnings(call_args_list):
+    """Flatten captured ``logger.warning(fmt, *args)`` calls into rendered strings."""
+    rendered = []
+    for call in call_args_list:
+        args, _kwargs = call
+        if not args:
+            continue
+        fmt, *fmt_args = args
+        try:
+            rendered.append(fmt % tuple(fmt_args) if fmt_args else fmt)
+        except (TypeError, ValueError):
+            rendered.append(str(args))
+    return rendered
+
+
+def _warnings_for(keyword: str, call_args_list) -> list:
+    """Return only captured warnings whose rendered text mentions ``keyword``."""
+    return [m for m in _capture_warnings(call_args_list) if keyword in m]
+
+
+# A tiny model path is fine — TorchLlmArgs lazily resolves the model;
+# none of the validators we exercise here actually touches disk.
+_DUMMY_MODEL = "/tmp/test-mx-gms-args-nonexistent"
+
+
+def _make_args(**overrides) -> TorchLlmArgs:
+    """Construct a ``TorchLlmArgs`` with the given overrides."""
+    return TorchLlmArgs(model=_DUMMY_MODEL, **overrides)
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    """Default values must match the conventions of the upstream libraries."""
+
+    def test_mx_server_url_default_none(self):
+        args = _make_args()
+        assert args.mx_server_url is None
+
+    def test_mx_preshard_strategy_default_per_module(self):
+        args = _make_args()
+        assert args.mx_preshard_strategy == "per_module"
+
+    def test_gms_socket_path_default_none(self):
+        # Default None means "resolve via gpu_memory_service.common.utils.
+        # get_socket_path(device, tag) at connect time".
+        args = _make_args()
+        assert args.gms_socket_path is None
+
+    def test_gms_mode_default_auto(self):
+        args = _make_args()
+        assert args.gms_mode == "auto"
+
+    def test_gms_tag_default_weights(self):
+        # IMPORTANT: must be ``weights``, NOT ``model_weights`` — the GMS
+        # library convention uses ``weights`` for model weights and
+        # ``kv_cache`` for the KV cache (see GMS_TAGS upstream).
+        args = _make_args()
+        assert args.gms_tag == "weights"
+
+
+# ---------------------------------------------------------------------------
+# mx_preshard_strategy validator
+# ---------------------------------------------------------------------------
+
+
+class TestMxPreshardStrategy:
+    def test_accepts_per_module(self):
+        args = _make_args(checkpoint_format="MX", mx_preshard_strategy="per_module")
+        assert args.mx_preshard_strategy == "per_module"
+
+    def test_accepts_global(self):
+        # 'global' is accepted at config time even though selecting it
+        # currently raises NotImplementedError when MX P2P succeeds at
+        # runtime (LoadFormat.PRESHARDED isn't wired upstream yet).
+        args = _make_args(checkpoint_format="MX", mx_preshard_strategy="global")
+        assert args.mx_preshard_strategy == "global"
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["", "Per_Module", "PER_MODULE", "global ", "perModule", "all", "none", "1", " "],
+    )
+    def test_rejects_unknown_value(self, bad_value):
+        with pytest.raises(ValueError, match="mx_preshard_strategy"):
+            _make_args(mx_preshard_strategy=bad_value)
+
+    @pytest.mark.parametrize(
+        "checkpoint_format, mx_preshard_strategy, expect_warning",
+        [
+            # Default per_module + default HF: no cross-field warning.
+            ("HF", "per_module", False),
+            # per_module + MX active: no warning.
+            ("MX", "per_module", False),
+            # global + MX active: meaningful, no warning.
+            ("MX", "global", False),
+            # global + HF active: warn that the strategy is ignored.
+            ("HF", "global", True),
+        ],
+    )
+    def test_cross_field_warning(self, checkpoint_format, mx_preshard_strategy, expect_warning):
+        with patch(_LOGGER_PATH) as mock_logger:
+            _make_args(
+                checkpoint_format=checkpoint_format, mx_preshard_strategy=mx_preshard_strategy
+            )
+        relevant = _warnings_for("mx_preshard_strategy", mock_logger.warning.call_args_list)
+        if expect_warning:
+            assert relevant, "expected a warning mentioning mx_preshard_strategy"
+            assert any("checkpoint_format" in m for m in relevant), (
+                "expected the warning to also mention checkpoint_format"
+            )
+        else:
+            assert relevant == [], f"expected no mx_preshard_strategy warning, got: {relevant}"
+
+
+# ---------------------------------------------------------------------------
+# mx_server_url validator
+# ---------------------------------------------------------------------------
+
+
+class TestMxServerUrl:
+    @pytest.mark.parametrize(
+        "checkpoint_format, mx_server_url, expect_warning",
+        [
+            # Default unset: no warning.
+            ("HF", None, False),
+            # Set with MX: no cross-field warning.
+            ("MX", "http://mx:8001", False),
+            # Set without MX: warn that the URL is ignored.
+            ("HF", "http://mx:8001", True),
+        ],
+    )
+    def test_cross_field_warning(self, checkpoint_format, mx_server_url, expect_warning):
+        kwargs = {"checkpoint_format": checkpoint_format}
+        if mx_server_url is not None:
+            kwargs["mx_server_url"] = mx_server_url
+
+        with patch(_LOGGER_PATH) as mock_logger:
+            args = _make_args(**kwargs)
+
+        # Field is always stored verbatim (warnings are advisory, not rejecting).
+        assert args.mx_server_url == mx_server_url
+
+        relevant = _warnings_for("mx_server_url", mock_logger.warning.call_args_list)
+        if expect_warning:
+            assert relevant, f"expected a warning about mx_server_url; got: {relevant}"
+        else:
+            assert relevant == [], f"expected no mx_server_url warning, got: {relevant}"
+
+
+# ---------------------------------------------------------------------------
+# gms_mode validator (only enforced when load_format == GMS)
+# ---------------------------------------------------------------------------
+
+
+class TestGmsMode:
+    @pytest.mark.parametrize("mode", ["auto", "rw", "ro"])
+    def test_accepts_known_modes_with_gms(self, mode):
+        args = _make_args(load_format=LoadFormat.GMS, gms_mode=mode)
+        assert args.gms_mode == mode
+
+    @pytest.mark.parametrize("bad_mode", ["", "AUTO", "Rw", "read", "write", "shadow"])
+    def test_rejects_unknown_mode_with_gms(self, bad_mode):
+        with pytest.raises(ValueError, match="gms_mode"):
+            _make_args(load_format=LoadFormat.GMS, gms_mode=bad_mode)
+
+    def test_unknown_mode_without_gms_load_format_is_lenient(self):
+        # Validator only enforces gms_mode values when load_format == GMS.
+        # Without GMS, the field is unused so we don't reject odd values.
+        args = _make_args(load_format=LoadFormat.AUTO, gms_mode="not-a-mode")
+        assert args.gms_mode == "not-a-mode"
+
+
+# ---------------------------------------------------------------------------
+# gms_socket_path warning
+# ---------------------------------------------------------------------------
+
+
+class TestGmsSocketPath:
+    @pytest.mark.parametrize(
+        "load_format, expect_warning",
+        [
+            # Set with GMS: no cross-field warning.
+            (LoadFormat.GMS, False),
+            # Set without GMS: warn that the path is ignored.
+            (LoadFormat.AUTO, True),
+        ],
+    )
+    def test_cross_field_warning(self, load_format, expect_warning):
+        with patch(_LOGGER_PATH) as mock_logger:
+            args = _make_args(load_format=load_format, gms_socket_path="/tmp/gms.sock")
+        assert args.gms_socket_path == "/tmp/gms.sock"
+        relevant = _warnings_for("gms_socket_path", mock_logger.warning.call_args_list)
+        if expect_warning:
+            assert relevant, f"expected a warning about gms_socket_path; got: {relevant}"
+        else:
+            assert relevant == [], f"expected no gms_socket_path warning, got: {relevant}"
+
+
+# ---------------------------------------------------------------------------
+# Composition: two-axis validity
+# ---------------------------------------------------------------------------
+
+
+class TestTwoAxisComposition:
+    """Sanity checks for the two-axis (checkpoint_format × LoadFormat) design."""
+
+    def test_pure_trtllm_baseline(self):
+        args = _make_args()
+        assert args.checkpoint_format == "HF"
+        assert args.load_format == LoadFormat.AUTO
+
+    def test_mx_only(self):
+        args = _make_args(checkpoint_format="MX", mx_server_url="http://mx:8001")
+        assert args.checkpoint_format == "MX"
+        assert args.load_format == LoadFormat.AUTO  # default
+        assert args.mx_server_url == "http://mx:8001"
+
+    def test_gms_only(self):
+        args = _make_args(load_format=LoadFormat.GMS, gms_socket_path="/tmp/gms.sock")
+        assert args.checkpoint_format == "HF"  # default
+        assert args.load_format == LoadFormat.GMS
+        assert args.gms_socket_path == "/tmp/gms.sock"
+
+    def test_mx_plus_gms(self):
+        args = _make_args(
+            checkpoint_format="MX",
+            mx_server_url="http://mx:8001",
+            load_format=LoadFormat.GMS,
+            gms_socket_path="/tmp/gms.sock",
+        )
+        assert args.checkpoint_format == "MX"
+        assert args.load_format == LoadFormat.GMS
+        assert args.mx_server_url == "http://mx:8001"
+        assert args.gms_socket_path == "/tmp/gms.sock"
+
+
+# ---------------------------------------------------------------------------
+# LoadFormat enum sanity
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFormatEnum:
+    def test_gms_enum_present(self):
+        # The prototype adds LoadFormat.GMS = 3.
+        assert hasattr(LoadFormat, "GMS")
+        assert LoadFormat.GMS.name == "GMS"
+
+    def test_pre_existing_enums_unchanged(self):
+        # Sanity — make sure the prototype didn't reshuffle enum values.
+        assert LoadFormat.AUTO.value == 0
+        assert LoadFormat.DUMMY.value == 1
+        assert LoadFormat.VISION_ONLY.value == 2
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            (0, LoadFormat.AUTO),
+            (1, LoadFormat.DUMMY),
+            (2, LoadFormat.VISION_ONLY),
+            (3, LoadFormat.GMS),
+        ],
+    )
+    def test_int_value_is_converted(self, raw, expected):
+        # ``TorchLlmArgs`` accepts raw int load_format values via the
+        # ``Union[str, LoadFormat]`` field plus its convert_load_format
+        # validator. Pin the new GMS=3 mapping (alongside the pre-existing
+        # values) so we catch any future enum-value reshuffle.
+        args = _make_args(load_format=raw)
+        assert args.load_format == expected
+
+
+# ---------------------------------------------------------------------------
+# gms_tag validator — reject empty / whitespace-only
+# ---------------------------------------------------------------------------
+
+
+class TestGmsTagValidator:
+    """``gms_tag`` must be a non-empty string.
+
+    Empty or whitespace-only tags would silently collide with the default
+    ``"weights"`` pool key and produce hard-to-debug cross-process state
+    corruption inside GMS, so the validator rejects them up-front.
+    """
+
+    @pytest.mark.parametrize("bad_tag", ["", " ", "\t", "\n", "   \t  "])
+    def test_rejects_empty_or_whitespace(self, bad_tag):
+        with pytest.raises(ValueError, match="gms_tag must be a non-empty"):
+            _make_args(load_format=LoadFormat.GMS, gms_tag=bad_tag)
+
+    def test_rejects_when_load_format_not_gms(self):
+        # Validation is unconditional — even when GMS isn't active we
+        # still want a meaningful tag, because the field has no other
+        # meaning and an empty value is always a mistake.
+        with pytest.raises(ValueError, match="gms_tag must be a non-empty"):
+            _make_args(load_format=LoadFormat.AUTO, gms_tag="")
+
+    def test_accepts_default(self):
+        args = _make_args(load_format=LoadFormat.GMS)
+        assert args.gms_tag == "weights"
+
+    def test_accepts_custom_non_empty(self):
+        args = _make_args(load_format=LoadFormat.GMS, gms_tag="kv_cache")
+        assert args.gms_tag == "kv_cache"
+
+
+# ---------------------------------------------------------------------------
+# MODEL_EXPRESS_URL env-var fallback (validator-level)
+# ---------------------------------------------------------------------------
+
+
+class TestMxServerUrlEnvFallback:
+    """Honor the upstream ``MODEL_EXPRESS_URL`` env-var fallback for MX.
+
+    The fallback fires when ``checkpoint_format='MX'`` and
+    ``mx_server_url`` is unset. It resolves at validator time so the
+    value ends up on ``llm_args.mx_server_url`` (visible to logging /
+    startup metrics) rather than being silently re-read by the loader.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolated_env(self, monkeypatch):
+        # Each test starts from a clean MODEL_EXPRESS_URL state.
+        monkeypatch.delenv("MODEL_EXPRESS_URL", raising=False)
+        yield
+
+    def test_env_populates_when_unset_and_mx(self, monkeypatch):
+        monkeypatch.setenv("MODEL_EXPRESS_URL", "http://from-env:9999")
+        args = _make_args(checkpoint_format="MX")
+        assert args.mx_server_url == "http://from-env:9999"
+
+    def test_explicit_value_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("MODEL_EXPRESS_URL", "http://from-env:9999")
+        args = _make_args(checkpoint_format="MX", mx_server_url="http://explicit:8001")
+        assert args.mx_server_url == "http://explicit:8001"
+
+    def test_no_env_no_value_stays_none(self):
+        args = _make_args(checkpoint_format="MX")
+        assert args.mx_server_url is None
+
+    def test_env_ignored_when_not_mx(self, monkeypatch):
+        # The env var only applies when MX is the active checkpoint
+        # format. Otherwise we'd silently advertise an MX URL on a
+        # non-MX config — confusing.
+        monkeypatch.setenv("MODEL_EXPRESS_URL", "http://from-env:9999")
+        args = _make_args(checkpoint_format="HF")
+        assert args.mx_server_url is None
+
+    def test_empty_env_does_not_populate(self, monkeypatch):
+        # An empty string in the env should NOT be treated as configured.
+        monkeypatch.setenv("MODEL_EXPRESS_URL", "")
+        args = _make_args(checkpoint_format="MX")
+        assert args.mx_server_url is None
+
+    def test_resolution_does_not_emit_cross_field_warning(self, monkeypatch):
+        # When the URL comes from the env *with* MX active, the
+        # cross-field "is set but checkpoint_format != MX" warning must
+        # not fire (because the format DOES match).
+        monkeypatch.setenv("MODEL_EXPRESS_URL", "http://from-env:9999")
+        with patch(_LOGGER_PATH) as mock_logger:
+            args = _make_args(checkpoint_format="MX")
+        assert args.mx_server_url == "http://from-env:9999"
+        relevant = _warnings_for("mx_server_url", mock_logger.warning.call_args_list)
+        assert relevant == [], f"unexpected warnings on env-var fallback: {relevant}"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GMS (GPU Memory Service) backend for disaggregated GPU weight memory
  * MX P2P weight-transfer support with automatic fallback and presharded-weight handling for Linear modules
  * New LoadFormat.GMS and user-facing config options: mx_server_url, mx_preshard_strategy, gms_socket_path, gms_mode, gms_tag

* **Tests**
  * Added comprehensive unit tests for GMS backend, MX checkpoint loader, and MX/GMS argument validation

* **Chores**
  * Packaging metadata updated (SPDX year) and clarifying install guidance added to setup notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

# [TRTLLM-11851][feat] MX and GMS integration prototype for Dynamo weight sharing

## Description

### Summary

Prototype implementation of the **two-axis integration model** for MX (ModelExpress P2P transfer) and GMS (GPU Memory Service) in TRT-LLM's PyTorch backend. Enables fast cold-start via GPU-to-GPU weight streaming (MX) and zero-copy weight sharing with crash-resilient failover (GMS).

MX and GMS map onto two **independent axes** in TRT-LLM's existing loading pipeline:

- **`checkpoint_format`** (weight source axis): `"MX"` — P2P via upstream `MxLiveWeightLoader.load_weights()`, with automatic HF disk fallback (inherited from `HfCheckpointLoader`)
- **`LoadFormat`** (memory management axis): `GMS` — out-of-process GPU memory pool with RW/RO dual paths via upstream `gpu_memory_service` class-based API

These compose independently, giving four modes with no combinatorial config explosion:

| Mode | `checkpoint_format` | `LoadFormat` | Use case |
|---|---|---|---|
| Pure TRT-LLM | `"HF"` (default) | `AUTO` (default) | Current behavior, unchanged |
| MX only | `"MX"` | `AUTO` | Cross-node P2P weight transfer |
| GMS only | `"HF"` | `GMS` | Within-node weight sharing + crash resilience |
| MX + GMS | `"MX"` | `GMS` | Cross-node P2P + within-node sharing |

Aligned against the actually-merged upstream APIs: `gpu-memory-service` 0.9.0 (from `ai-dynamo/dynamo`) and `modelexpress` 0.3.0 (from `ai-dynamo/modelexpress`). TRT-LLM owns the integration policy (Layer 3) and calls the upstream libraries' stable per-call primitives (Layer 2); we never duplicate the wire-protocol or runtime mechanics (Layer 1 — gRPC, NIXL RDMA, CUDA VMM).

#### What's included

**MXCheckpointLoader** (`_torch/models/checkpoints/mx/checkpoint_loader.py`, ~380 lines)

- Subclasses `HfCheckpointLoader` — HF disk fallback is inherited, no separate fallback loader needed
- Delegates the actual NIXL/RDMA transfer to upstream `MxLiveWeightLoader(mx_server=url).load_weights(checkpoint_dir, mapping=, model=)` (handles agent setup, source matching, dtype-cast handling, PVC fallback for size-mismatched tensors)
- Delegates the publish side to upstream `publish_model_params(torch_model)` via an env-var dance over `MODEL_EXPRESS_URL` and `MODEL_NAME`
- Exposes `p2p_succeeded` property — consumed by `ModelLoader` to set `_weights_presharded` on `Linear` modules
- Pre-`post_load_weights()` MX source publish timing so targets receive raw loaded state and run their own transforms
- `model_name` constructor parameter (plumbed from `llm_args.model`) so publish identity comes from the user-supplied Hub ID with HF-snapshot path unmangling, not the upstream `"unknown"` sentinel
- Conservative mixed-success: if MX returns size-mismatched fallback weights, falls through to a full disk load to avoid mixing presharded and non-presharded weights
- Defensive `MX_SOURCE_QUERY_TIMEOUT=30` setdefault when an MX URL is configured, capping upstream `MxLiveWeightLoader._query_source` polling at 30 s instead of the 1-hour default. The correct upstream fix is to adopt `RdmaStrategy`'s immediate-fallback pattern (single `list_sources` call, no polling) — tracked as [MX-4](https://github.com/chienchunhung/TensorRT-LLM/blob/docs-and-plans/docs/design/mx-gms-integration/15-prototype-validation-plan.md#mx-4-adopt-rdmastrategys-immediate-fallback-source-discovery-in-mxliveweightloader)

**GMSBackend** (`_torch/memory/gpu_memory_backend.py`, ~440 lines)

- `GPUMemoryBackend` protocol + concrete `GMSBackend` implementation wrapping the upstream `GMSClientMemoryManager` and the `gms_use_mem_pool` context manager
- Mode resolved at `connect()` time via `get_or_create_gms_client_memory_manager(socket, device, mode=RequestedLockType.RW_OR_RO)` and inspected via `granted_lock_type`
- **RW path:** caller uses `gms_backend.mem_pool_scope(device)` context manager; after load, `move_untracked_params()` migrates stray buffers into the pool (inside the scope, matching upstream `_load_rw` order), then `finalize_write()` delegates to upstream `finalize_gms_write()` (register + sync + commit + RO reconnect + remap)
- **RO path:** `post_load_weights()` runs *before* `materialize_module()`, guard prevents double-execution; `materialize_module_from_gms(mgr, model, device_index=N)` does the zero-copy import
- Default tag is `"weights"` matching the GMS library convention
- Default socket path resolves via `get_socket_path(device, tag)` (UUID-based, stable across `CUDA_VISIBLE_DEVICES`)
- VMM safety: `connect()` applies `patch_empty_cache()` to prevent segfaults on VMM-backed allocations

**ModelLoader changes** (`_torch/pyexecutor/model_loader.py`, +255/-19)

- New `LoadFormat.GMS` branch with full RW/RO dual paths
- GMS RW: respects `model.llm_checkpoint_dir` redirect (matches AUTO branch); loads speculative-decoding draft weights inside the same `mem_pool_scope` so a single `finalize_write(model)` covers both main and draft via the model-tree walk
- MX source publish fires for `LoadFormat.AUTO` and GMS-RW modes, before `post_load_weights()`
- `_weights_presharded` flag set per-path (MX P2P in AUTO, GMS materialize in RO)
- Draft model modules excluded from presharded flag

**Linear module** (`_torch/modules/linear.py`)

- `_weights_presharded = False` declared in `__init__` — TP slicing skipped when True
- `_effective_tp_coords(module)` helper centralized TP-coordinate logic: when `_weights_presharded` is True, returns `(tp_size=1, tp_rank=0)` for *all* `load_weight_shard(...)` calls — both the main weight/bias tensors AND their quantization metadata (`weight_scale`, `input_scale`, `pre_quant_scale`, etc.) across all quant-scheme loaders (FP8, NVFP4, MXFP4, W4A16-AWQ, W4A8-AWQ, etc.)

**Configuration** (`llmapi/llm_args.py`)

- `mx_server_url`, `mx_preshard_strategy`, `gms_socket_path`, `gms_mode`, `gms_tag` — all `status="prototype"`
- Validators: `validate_mx_config()`, `validate_gms_config()` — honor upstream `MODEL_EXPRESS_URL` env var as fallback for `mx_server_url`; reject empty/whitespace `gms_tag` values
- `mx_preshard_strategy: per_module | global` (default `per_module`); `global` raises `NotImplementedError` until `LoadFormat.PRESHARDED` lands upstream
- API stability YAML updated

**Optional dependencies** (`setup.py`)

- The MX (`modelexpress`) and GMS (`gpu-memory-service`) Python packages are intentionally **NOT** bundled as `[mx]` / `[gms]` / `[dynamo]` extras while the integration is at prototype status. Users install manually:

  ```bash
  # MX — Apache-2.0, on PyPI
  pip install "modelexpress>=0.3.0,<0.4.0"

  # GMS — Apache-2.0, source-only (not yet on PyPI)
  git clone https://github.com/ai-dynamo/dynamo
  pip install ./dynamo/lib/gpu_memory_service
  ```

  Once installed, the MX/GMS code paths auto-detect them via `import`; without them, the loaders fall back to plain HF disk loading.

- **Why no extras:** (1) `gpu-memory-service` is not published to PyPI (GMS-6), so NVIDIA's Blossom-CI vulnerability scanner can't resolve it; (2) `modelexpress` is brand-new on PyPI and not yet in the internal OSS allowlist (MX-7). Both blockers are tracked in [§15 of the design doc](https://github.com/chienchunhung/TensorRT-LLM/blob/docs-and-plans/docs/design/mx-gms-integration/15-prototype-validation-plan.md#upstream-alignment-requests). Restoring `pip install tensorrt_llm[dynamo]` is a single-hunk revert once both are cleared.

### Running with MX or GMS enabled

The MX/GMS knobs are set via a YAML config passed to `trtllm-serve --config`, or as keyword arguments when using the Python `LLM` API directly.

| Field | Type | Purpose |
|---|---|---|
| `checkpoint_format` | str | `"MX"` to enable MX P2P loading. Default `None` → `"HF"`. |
| `mx_server_url` | str | URL of the ModelExpress server. Falls back to `MODEL_EXPRESS_URL` env var. |
| `load_format` | str / `LoadFormat` | `"GMS"` to enable GMS-backed loading. Default `"AUTO"`. |
| `gms_socket_path` | str | Unix socket of the GMS daemon. Default `None` → UUID-keyed auto-resolve. |
| `gms_mode` | str | `auto` (default), `rw`, `ro`. |
| `gms_tag` | str | GMS pool tag. Default `"weights"`. |

**MX only:**
```yaml
# config_mx.yaml
checkpoint_format: "MX"
mx_server_url: "http://mx-server:8001"
```
```bash
trtllm-serve <model> --config config_mx.yaml
```

**GMS only:**
```yaml
# config_gms.yaml
load_format: "GMS"
```
```bash
# First worker: gets RW, loads from disk, commits to GMS pool
trtllm-serve <model> --config config_gms.yaml
# Subsequent workers: get RO, zero-copy import
trtllm-serve <model> --config config_gms.yaml
```

**Python API:**
```python
from tensorrt_llm import LLM
llm = LLM(model="<model>", checkpoint_format="MX", mx_server_url="http://mx:8001")
# or
from tensorrt_llm.llmapi import LoadFormat
llm = LLM(model="<model>", load_format=LoadFormat.GMS)
```

### Design decisions

- **No monkey-patching.** The upstream `setup_gms()` entry point patches `ModelLoader.load` from outside. We use `GMSBackend` as the explicit, reviewable boundary instead.
- **MX P2P is NOT used in GMS RW mode.** Model params are meta tensors at that point — no CUDA buffers for P2P to write into. Disk loading under the GMS pool is the correct behavior.
- **Per-module `_weights_presharded` instead of `LoadFormat.PRESHARDED`.** Composes more cleanly with `LoadFormat.GMS` and lets us mark only MX-delivered modules in mixed-success scenarios.
- **Quantization-metadata-aware TP bypass.** `_effective_tp_coords(module)` ensures `_weights_presharded` skips TP slicing for weights AND their quantization metadata (`weight_scale`, `input_scale`, `pre_quant_scale`) — preventing shape mismatches on quantized models.

### Relationship to existing work

- **PR [#12898](https://github.com/NVIDIA/TensorRT-LLM/pull/12898)** (MX team prototype, closed): we adopt `_weights_presharded` concept and pre-`post_load_weights()` publish timing, using two-axis model instead of `LoadFormat.PRESHARDED`.
- **dynamo PR [#7575](https://github.com/ai-dynamo/dynamo/pull/7575)** (TRT-LLM sleep/wake with GMS): we use the same Layer 2 primitives but invoke them directly, not via monkey-patch.
- **MX team's downstream PR [chienchunhung/TensorRT-LLM #1](https://github.com/chienchunhung/TensorRT-LLM/pull/1)**: drove the `MODEL_EXPRESS_URL` env-var fallback, the `MX_SOURCE_QUERY_TIMEOUT` defensive default (MX-4), and the `model_name` plumbing.
- **Design doc:** [`docs/design/mx-gms-integration/`](https://github.com/chienchunhung/TensorRT-LLM/tree/docs-and-plans/docs/design/mx-gms-integration) on the `docs-and-plans` branch. [§15](https://github.com/chienchunhung/TensorRT-LLM/blob/docs-and-plans/docs/design/mx-gms-integration/15-prototype-validation-plan.md) has the validation plan, upstream alignment requests, and test matrix.

### Upstream alignment requests

Workarounds in the prototype that could be removed if the corresponding upstream change lands. Full details in [§15](https://github.com/chienchunhung/TensorRT-LLM/blob/docs-and-plans/docs/design/mx-gms-integration/15-prototype-validation-plan.md#upstream-alignment-requests).

| ID | To | Title | Workaround in this PR | Blocks merge? |
|---|---|---|---|---|
| **MX-1** | MX | `LoadFormat.PRESHARDED` vs per-module flag | `mx_preshard_strategy='global'` raises until upstream lands | No |
| **MX-2** | MX | Promote `_build_trtllm_identity` to public API | env-var dance in `publish_as_source` | No |
| ~~MX-3~~ | MX | ~~Per-rank addressing~~ | **Resolved** — upstream uses global MPI rank on both sides | — |
| **MX-4** | MX | Adopt `RdmaStrategy` immediate-fallback in `MxLiveWeightLoader` | `MX_SOURCE_QUERY_TIMEOUT=30` (30 s poll vs correct try-once) | No |
| **MX-5** | MX | NIXL ownership for MX+GMS composition | MX P2P bypassed in GMS-RW path | **Yes for MX+GMS** |
| **MX-7** | MX/TRT-LLM | Onboard `modelexpress` into NVIDIA OSS allowlist | extras removed from `setup.py` | No |
| **GMS-1** | GMS | Non-monkey-patch integration path | `GMSBackend` owns the integration | No |
| **GMS-2** | GMS | Promote `_move_untracked_params` to public | Re-implemented in `GMSBackend` | No |
| **GMS-6** | GMS | Publish `gpu-memory-service` to PyPI | extras removed from `setup.py`; install from source | No |

**MX-1 and MX-5** are the design items most likely to come up in review. **MX-7 and GMS-6** block restoring `pip install tensorrt_llm[dynamo]` ergonomics.

## Test Coverage

148 CPU-only unit tests in `tests/unittest/`, runs in <1 s, no MX/GMS deps required:

- `tests/unittest/llmapi/test_mx_gms_args.py` — config validation, defaults, cross-field warnings, `MODEL_EXPRESS_URL` env-var fallback, `gms_tag` empty-string rejection, `LoadFormat` int-conversion regression
- `tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py` — construction + registry, parametrized fallback paths, MX-success integration contract, `MX_SOURCE_QUERY_TIMEOUT` defensive default, `model_name` plumbing, `_normalize_model_identity` (HF-snapshot unmangling), `_resolve_mx_model_name` priority order, `publish_as_source` `MODEL_NAME` end-to-end with env restoration
- `tests/unittest/_torch/memory/test_gms_backend.py` — construction, pre-connect state, `connect()` graceful failure, RW-only method gating, `_ptr_in_gms` half-open intervals + zero-sentinel guards, `_storage_nbytes`, protocol conformance. **All tests run on CPU CI** (CUDA dependency monkeypatched via autouse fixture).

Tests do NOT exercise the upstream libraries — fallback paths use `sys.modules`-injection to force `ImportError`, success paths use fake module trees.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
