### PR TITLE
[TRTLLM-11421][fix] fix data races in speculative decoding fast-logits handoff

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -487,7 +487,7 @@ TrtGptModelInflightBatching::TrtGptModelInflightBatching(std::shared_ptr<nvinfer
     {
         mDraftModelSendLogitsThread
             = std::make_unique<std::thread>(&utils::draftModelSendLogitsThread, mDevice, &mDraftModelThreadShouldExit,
-                &mDraftRequestsWaitingToSendLogits, &mDraftRequestsDoneSendingLogits, &mDraftRequestsDoneMtx);
+                &mDraftRequestsWaitingToSendLogits, &mDraftRequestsDoneSendingLogits, &mDraftRequestsMtx);
     }
 
     mCreateNewDecoderRequests = std::make_unique<CreateNewDecoderRequests>(
@@ -908,7 +908,7 @@ void TrtGptModelInflightBatching::forwardSync()
         {
             RequestVector doneSending;
             {
-                std::lock_guard<std::mutex> lk(mDraftRequestsDoneMtx);
+                std::lock_guard<std::mutex> lk(mDraftRequestsMtx);
                 doneSending.swap(mDraftRequestsDoneSendingLogits);
             }
             for (auto const& llmReq : doneSending)
@@ -2537,6 +2537,7 @@ void TrtGptModelInflightBatching::updateRequests(ScheduledRequests const& schedu
             {
                 if (llmReq->getReturnGenerationLogits() && mSpeculativeDecodingFastLogits && mIsLeaderInOrchMode)
                 {
+                    std::lock_guard<std::mutex> lk(mDraftRequestsMtx);
                     mDraftRequestsWaitingToSendLogits.push_back(llmReq);
                 }
                 else

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -485,9 +485,9 @@ TrtGptModelInflightBatching::TrtGptModelInflightBatching(std::shared_ptr<nvinfer
         = executorConfig.getSpecDecConfig().has_value() && executorConfig.getSpecDecConfig()->fastLogits;
     if (mSpeculativeDecodingFastLogits && modelConfig.getSpeculativeDecodingMode().isNone() && mIsLeaderInOrchMode)
     {
-        mDraftModelSendLogitsThread = std::make_unique<std::thread>(&utils::draftModelSendLogitsThread, mDevice,
-            &mDraftModelThreadShouldExit, &mDraftRequestsWaitingToSendLogits, mSeqSlotManager, getMaxInputLen(),
-            mKvCacheManager, mCrossKvCacheManager, mPeftCacheManager);
+        mDraftModelSendLogitsThread
+            = std::make_unique<std::thread>(&utils::draftModelSendLogitsThread, mDevice, &mDraftModelThreadShouldExit,
+                &mDraftRequestsWaitingToSendLogits, &mDraftRequestsDoneSendingLogits, &mDraftRequestsDoneMtx);
     }
 
     mCreateNewDecoderRequests = std::make_unique<CreateNewDecoderRequests>(
@@ -901,6 +901,19 @@ void TrtGptModelInflightBatching::forwardSync()
                         mReqIdsToTerminate.erase(llmReq->mRequestId);
                     }
                 }
+            }
+        }
+
+        // Terminate draft requests whose logits have been sent by the background thread.
+        {
+            RequestVector doneSending;
+            {
+                std::lock_guard<std::mutex> lk(mDraftRequestsDoneMtx);
+                doneSending.swap(mDraftRequestsDoneSendingLogits);
+            }
+            for (auto const& llmReq : doneSending)
+            {
+                terminateRequest(llmReq);
             }
         }
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -608,6 +608,9 @@ private:
     bool mIsLeaderInOrchMode{false};
     // List of completed draft requests which logits will need to be sent to the target model.
     RequestVector mDraftRequestsWaitingToSendLogits;
+    // Draft requests whose logits have been sent — pending termination by main thread.
+    RequestVector mDraftRequestsDoneSendingLogits; // guarded by mDraftRequestsDoneMtx
+    std::mutex mDraftRequestsDoneMtx;
     SizeType32 mSeamlessLADMaxDraftLen{0};
     bool mUseSeamlessLookahead{false};
     RewindInputs mRewindInputs;

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -607,10 +607,12 @@ private:
     std::atomic<bool> mDraftModelThreadShouldExit{false};
     bool mIsLeaderInOrchMode{false};
     // List of completed draft requests which logits will need to be sent to the target model.
+    // Guarded by mDraftRequestsMtx (shared with the background logits sender thread).
     RequestVector mDraftRequestsWaitingToSendLogits;
     // Draft requests whose logits have been sent — pending termination by main thread.
-    RequestVector mDraftRequestsDoneSendingLogits; // guarded by mDraftRequestsDoneMtx
-    std::mutex mDraftRequestsDoneMtx;
+    // Guarded by mDraftRequestsMtx.
+    RequestVector mDraftRequestsDoneSendingLogits;
+    std::mutex mDraftRequestsMtx;
     SizeType32 mSeamlessLADMaxDraftLen{0};
     bool mUseSeamlessLookahead{false};
     RewindInputs mRewindInputs;

--- a/cpp/tensorrt_llm/batch_manager/utils/logitsThread.cpp
+++ b/cpp/tensorrt_llm/batch_manager/utils/logitsThread.cpp
@@ -18,9 +18,6 @@
 #include "logitsThread.h"
 
 #include "tensorrt_llm/batch_manager/llmRequest.h"
-#include "tensorrt_llm/batch_manager/peftCacheManager.h"
-#include "tensorrt_llm/batch_manager/sequenceSlotManager.h"
-#include "tensorrt_llm/batch_manager/utils/inflightBatchingUtils.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/executor/executor.h"
 #include "tensorrt_llm/runtime/utils/mpiTags.h"
@@ -38,10 +35,8 @@ enum class FastLogitsMpiId : uint64_t
 };
 
 void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadShouldExit,
-    RequestVector* draftRequestsWaitingToSendLogits, std::shared_ptr<SequenceSlotManager> const& seqSlotManager,
-    SizeType32 maxInputLen, std::shared_ptr<kv_cache_manager::BaseKVCacheManager> const& kvCacheManager,
-    std::shared_ptr<kv_cache_manager::BaseKVCacheManager> const& crossKvCacheManager,
-    std::shared_ptr<BasePeftCacheManager> const& peftCacheManager)
+    RequestVector* draftRequestsWaitingToSendLogits, RequestVector* draftRequestsDoneSendingLogits,
+    std::mutex* draftRequestsDoneMtx)
 {
 #if ENABLE_MULTI_DEVICE
     TLLM_CUDA_CHECK(cudaSetDevice(device));
@@ -115,8 +110,11 @@ void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadS
         worldComm.send(draftLogits->data(), draftLogits->getSizeInBytes(), mpi::MpiType::kUINT8, source_rank,
             mpi::MpiTag::kSpecDecLogitsData);
 
-        terminateRequest(
-            *seqSlotManager, *draftRequest, maxInputLen, kvCacheManager, crossKvCacheManager, peftCacheManager);
+        // Defer termination to the main thread to avoid racing on mSequences.
+        {
+            std::lock_guard<std::mutex> lk(*draftRequestsDoneMtx);
+            draftRequestsDoneSendingLogits->push_back(draftRequest);
+        }
     }
 #endif // ENABLE_MULTI_DEVICE
 }

--- a/cpp/tensorrt_llm/batch_manager/utils/logitsThread.cpp
+++ b/cpp/tensorrt_llm/batch_manager/utils/logitsThread.cpp
@@ -36,7 +36,7 @@ enum class FastLogitsMpiId : uint64_t
 
 void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadShouldExit,
     RequestVector* draftRequestsWaitingToSendLogits, RequestVector* draftRequestsDoneSendingLogits,
-    std::mutex* draftRequestsDoneMtx)
+    std::mutex* draftRequestsMtx)
 {
 #if ENABLE_MULTI_DEVICE
     TLLM_CUDA_CHECK(cudaSetDevice(device));
@@ -95,7 +95,11 @@ void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadS
             return nullptr;
         };
 
-        std::shared_ptr<LlmRequest> draftRequest = findDraftRequest();
+        std::shared_ptr<LlmRequest> draftRequest;
+        {
+            std::lock_guard<std::mutex> lk(*draftRequestsMtx);
+            draftRequest = findDraftRequest();
+        }
         TLLM_CHECK(draftRequest != nullptr);
 
         auto draftLogits = runtime::ITensor::slice(draftRequest->getGenerationLogitsHost(), {0, 0});
@@ -112,7 +116,7 @@ void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadS
 
         // Defer termination to the main thread to avoid racing on mSequences.
         {
-            std::lock_guard<std::mutex> lk(*draftRequestsDoneMtx);
+            std::lock_guard<std::mutex> lk(*draftRequestsMtx);
             draftRequestsDoneSendingLogits->push_back(draftRequest);
         }
     }

--- a/cpp/tensorrt_llm/batch_manager/utils/logitsThread.h
+++ b/cpp/tensorrt_llm/batch_manager/utils/logitsThread.h
@@ -23,16 +23,10 @@
 #include "tensorrt_llm/runtime/iTensor.h"
 
 #include <memory>
+#include <mutex>
 
 namespace tensorrt_llm::batch_manager
 {
-namespace kv_cache_manager
-{
-class BaseKVCacheManager;
-} // namespace kv_cache_manager
-
-class SequenceSlotManager;
-class BasePeftCacheManager;
 class GenerateRequestOptions;
 } // namespace tensorrt_llm::batch_manager
 
@@ -44,11 +38,12 @@ struct SpeculativeDecodingFastLogitsInfo;
 namespace tensorrt_llm::batch_manager::utils
 {
 
+/// Background thread that sends draft model logits to the target model via MPI.
+/// After sending, completed requests are pushed to \p draftRequestsDoneSendingLogits
+/// (guarded by \p draftRequestsDoneMtx) so the main thread can terminate them.
 void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadShouldExit,
-    RequestVector* draftRequestsWaitingToSendLogits, std::shared_ptr<SequenceSlotManager> const& seqSlotManager,
-    runtime::SizeType32 maxInputLen, std::shared_ptr<kv_cache_manager::BaseKVCacheManager> const& kvCacheManager,
-    std::shared_ptr<kv_cache_manager::BaseKVCacheManager> const& crossKvCacheManager,
-    std::shared_ptr<BasePeftCacheManager> const& peftCacheManager);
+    RequestVector* draftRequestsWaitingToSendLogits, RequestVector* draftRequestsDoneSendingLogits,
+    std::mutex* draftRequestsDoneMtx);
 
 void targetModelReceiveLogits(runtime::ITensor::SharedPtr& draftLogitsHost,
     executor::SpeculativeDecodingFastLogitsInfo const& fastLogitsInfo, nvinfer1::DataType logitsDtype);

--- a/cpp/tensorrt_llm/batch_manager/utils/logitsThread.h
+++ b/cpp/tensorrt_llm/batch_manager/utils/logitsThread.h
@@ -39,11 +39,11 @@ namespace tensorrt_llm::batch_manager::utils
 {
 
 /// Background thread that sends draft model logits to the target model via MPI.
-/// After sending, completed requests are pushed to \p draftRequestsDoneSendingLogits
-/// (guarded by \p draftRequestsDoneMtx) so the main thread can terminate them.
+/// Both \p draftRequestsWaitingToSendLogits (consumed here) and \p draftRequestsDoneSendingLogits
+/// (produced here for the main thread to drain) are guarded by \p draftRequestsMtx.
 void draftModelSendLogitsThread(int device, std::atomic<bool>* draftModelThreadShouldExit,
     RequestVector* draftRequestsWaitingToSendLogits, RequestVector* draftRequestsDoneSendingLogits,
-    std::mutex* draftRequestsDoneMtx);
+    std::mutex* draftRequestsMtx);
 
 void targetModelReceiveLogits(runtime::ITensor::SharedPtr& draftLogitsHost,
     executor::SpeculativeDecodingFastLogitsInfo const& fastLogitsInfo, nvinfer1::DataType logitsDtype);


### PR DESCRIPTION
## Summary

- `draftModelSendLogitsThread` called `terminateRequest()` directly from a background thread, racing with the main thread on `KVCacheManager::removeSequence()` and other shared batch manager state (sequence slot manager, PEFT cache manager).
- Fix: after sending logits via MPI, the background thread now pushes completed requests into a handoff queue (`mDraftRequestsDoneSendingLogits`) drained by the main thread in `forwardSync()`, where `terminateRequest()` is called.
- The same two threads also shared `mDraftRequestsWaitingToSendLogits` (main thread push_back, background thread iterate+erase) without synchronization. Fix: extend the existing mutex (renamed `mDraftRequestsDoneMtx` → `mDraftRequestsMtx`) to guard both queues. MPI sends remain outside the lock to avoid serializing network I/O.
- This also removes the logits thread dependency on `SequenceSlotManager`, `BaseKVCacheManager`, and `BasePeftCacheManager`, simplifying its interface.

## Related

- Complements #12251 (KVCacheManager TOCTOU race fixes) -- that PR fixes races within the KV cache manager itself; this PR fixes the upstream race where `terminateRequest` was called from the wrong thread entirely.

## Test plan

- [x] Existing speculative decoding fast-logits orchestration tests pass
- [x] Stress test with overlap scheduling / MTP mode to exercise the concurrent send-logits + terminate path
- [x] CI: `/bot run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored speculative decoding thread coordination: request termination is now deferred from the background logits thread to the main thread via a shared synchronization queue, improving inter-thread synchronization and simplifying background thread dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->