### PR TITLE
[TRTLLM-11974][feat] Handle multimodal placeholder expansion in token space for Nemotron Nano

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -155,6 +155,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         prompt_token_ids: List[int],
         num_mm_tokens_per_placeholder: List[int],
         hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
+        mm_data: Optional[Dict[str, Any]] = None,
     ) -> Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
         """
         Expands MM placeholder tokens in `prompt_token_ids` so that each single placeholder
@@ -172,6 +173,10 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 specifies the number of MM feature tokens to expand/repeat for that placeholder.
             hf_processor_mm_kwargs (Optional[Dict[str, Any]]): Optional dictionary of arguments
                 to pass to the HuggingFace processor, if needed for token expansion.
+            mm_data (Optional[Dict[str, Any]]): The original `multi_modal_data` dict
+                (e.g. `{"image": [...], "video": [...]}`). Subclasses whose expansion
+                depends on the raw MM content (e.g. per-video frame metadata) use this;
+                LLaVA-Next ignores it because its expansion is a pure token-ID rewrite.
 
         Returns:
             Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
@@ -180,6 +185,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 `extra_processed_inputs["multimodal_data"]`. Always `None` for LLaVA-Next
                 (no auxiliary streams needed).
         """
+        del mm_data  # LLaVA-Next's image-only expansion doesn't need raw MM data
         expanded, _, _ = self._expand_image_placeholders_in_token_ids(
             prompt_token_ids, num_mm_tokens_per_placeholder)
         return expanded, None

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -155,6 +155,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         prompt_token_ids: List[int],
         num_mm_tokens_per_placeholder: List[int],
         hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
         """
         Expands MM placeholder tokens in `prompt_token_ids` so that each single placeholder

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -155,7 +155,6 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         prompt_token_ids: List[int],
         num_mm_tokens_per_placeholder: List[int],
         hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
-        mm_data: Optional[Dict[str, Any]] = None,
     ) -> Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
         """
         Expands MM placeholder tokens in `prompt_token_ids` so that each single placeholder
@@ -173,10 +172,6 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 specifies the number of MM feature tokens to expand/repeat for that placeholder.
             hf_processor_mm_kwargs (Optional[Dict[str, Any]]): Optional dictionary of arguments
                 to pass to the HuggingFace processor, if needed for token expansion.
-            mm_data (Optional[Dict[str, Any]]): The original `multi_modal_data` dict
-                (e.g. `{"image": [...], "video": [...]}`). Subclasses whose expansion
-                depends on the raw MM content (e.g. per-video frame metadata) use this;
-                LLaVA-Next ignores it because its expansion is a pure token-ID rewrite.
 
         Returns:
             Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
@@ -185,7 +180,6 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 `extra_processed_inputs["multimodal_data"]`. Always `None` for LLaVA-Next
                 (no auxiliary streams needed).
         """
-        del mm_data  # LLaVA-Next's image-only expansion doesn't need raw MM data
         expanded, _, _ = self._expand_image_placeholders_in_token_ids(
             prompt_token_ids, num_mm_tokens_per_placeholder)
         return expanded, None

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -155,7 +155,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         prompt_token_ids: List[int],
         num_mm_tokens_per_placeholder: List[int],
         hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
-    ) -> List[int]:
+    ) -> Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
         """
         Expands MM placeholder tokens in `prompt_token_ids` so that each single placeholder
         is replaced by the corresponding number of multimodal feature tokens.
@@ -174,12 +174,15 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                 to pass to the HuggingFace processor, if needed for token expansion.
 
         Returns:
-            List[int]: The prompt token IDs where each MM placeholder token has been
-                replaced/expanded with the appropriate number of MM feature tokens.
+            Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
+                `expanded_ids` (List[int]) — prompt token IDs with each MM placeholder expanded.
+                `mm_data_updates` (Optional[Dict]) — extra fields to merge into
+                `extra_processed_inputs["multimodal_data"]`. Always `None` for LLaVA-Next
+                (no auxiliary streams needed).
         """
         expanded, _, _ = self._expand_image_placeholders_in_token_ids(
             prompt_token_ids, num_mm_tokens_per_placeholder)
-        return expanded
+        return expanded, None
 
     def _postprocess(
         self, input_ids: torch.Tensor, mm_features: Union[torch.Tensor,

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -994,10 +994,10 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
 
     def get_mm_special_token_ids(self) -> torch.Tensor:
         "Return multimodal special token ids for NanoV2VL."
-        ids = [self.image_start_token_id, self.image_end_token_id]
+        ids = list(self._img_start_token_ids) + list(self._img_end_token_ids)
         if self._sound_start_token_id is not None:
             ids.extend([self._sound_start_token_id, self._sound_end_token_id])
-        return torch.tensor(ids)
+        return torch.tensor(sorted(set(ids)))
 
     def get_mm_token_ids(self):
         ids = [self.img_context_token_id]

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -44,6 +44,16 @@ from .modeling_utils import register_auto_model
 
 # Set max_num_tiles to 1 for video modality, to match the training behavior.
 VIDEO_MAX_NUM_TILES = 1
+# Several video code paths (`_process_videos_frames`'s HF-processor fallback,
+# `_get_video_tokens_per_frame`'s fallback, `_compute_video_size_lightweight`,
+# and `get_num_tokens_per_video`'s EVS branch) all assume a single tile per
+# frame. Increasing this constant would require updating those paths
+# accordingly — multi-tile video expansion isn't currently supported and the
+# prompt-side MM counts would diverge from the vision encoder's output.
+# Guard against accidental change.
+assert VIDEO_MAX_NUM_TILES == 1, (
+    "NanoV2VL video paths assume a single tile per frame; see comment above."
+)
 IMAGE_PLACEHOLDER = "<image>"
 VIDEO_PLACEHOLDER = "<video>"
 AUDIO_PLACEHOLDER = "<so_embedding>"

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -997,7 +997,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         ids = list(self._img_start_token_ids) + list(self._img_end_token_ids)
         if self._sound_start_token_id is not None:
             ids.extend([self._sound_start_token_id, self._sound_end_token_id])
-        return torch.tensor(sorted(set(ids)))
+        return torch.tensor(ids)
 
     def get_mm_token_ids(self):
         ids = [self.img_context_token_id]
@@ -1009,9 +1009,6 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         """Return minimal placeholder text for the given multimodal item counts,
         so that the HF processor can be called with (dummy_text, mm_data)
         without error. Used when processing tokenized prompt + MM data.
-
-        NanoV2VL currently accepts only one modality per request, so at most
-        one of `image`, `video`, or `audio` will be non-zero in `mm_counts`.
 
         Args:
             mm_counts (Dict[str, int]): A mapping of each multimodal modality

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -1038,9 +1038,9 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         num_videos = mm_counts.get("video", 0)
         num_audios = mm_counts.get("audio", 0)
         parts: List[str] = []
-        parts.extend([IMAGE_PLACEHOLDER] * num_images)
-        parts.extend([VIDEO_PLACEHOLDER] * num_videos)
-        parts.extend([AUDIO_PLACEHOLDER] * num_audios)
+        parts.extend([self.img_context_token] * num_images)
+        parts.extend([self.video_context_token] * num_videos)
+        parts.extend([self._sound_context_token] * num_audios)
         return "".join(parts)
 
     def get_num_tokens_per_image(
@@ -1057,10 +1057,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             budget = self.dynamic_tiler._max_num_patches
             params, _ = self.dynamic_tiler.process_media(image, budget)
             num_image_tokens = params.num_embeddings
-            # Add only image-specific special tokens (img_start, img_end),
-            # not all multimodal special tokens (which also includes
-            # sound_start, sound_end when audio is supported).
-            num_image_tokens += 2  # <img> and </img>
+            num_image_tokens += len(self._img_start_token_ids) + len(self._img_end_token_ids)
             return num_image_tokens
 
         # The logic is copied and modified from HuggingFace ImageProcessor.
@@ -1125,10 +1122,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         if self.processor.use_thumbnail and blocks != 1:
             blocks += 1
         num_image_tokens = self.num_image_token * blocks
-        # Add only image-specific special tokens (img_start, img_end),
-        # not all multimodal special tokens (which also includes
-        # sound_start, sound_end when audio is supported).
-        num_image_tokens += 2  # <img> and </img>
+        num_image_tokens += len(self._img_start_token_ids) + len(self._img_end_token_ids)
         return num_image_tokens
 
     def _get_video_tokens_per_frame(
@@ -1567,7 +1561,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                 expansion.extend(prefix_ids)
                 if evs_expansion is not None:
                     evs_expansion.extend(prefix_ids)
-            for frame_sep, num_tokens in zip(frame_seps, tokens_per_frame):
+            for frame_sep, num_tokens in zip(frame_seps, tokens_per_frame, strict=True):
                 sep_ids = self.tokenizer.encode(frame_sep, add_special_tokens=False)
                 expansion.extend(sep_ids)
                 expansion.extend(self._img_start_token_ids)

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -24,6 +24,7 @@ from ...inputs import (
     MultimodalPlaceholderPlacement,
     TextPrompt,
     compute_retained_tokens_count,
+    compute_retained_tokens_from_tubelet_budget,
     compute_retention_mask,
     register_input_processor,
 )
@@ -870,6 +871,18 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         self._img_context_token_ids = self.tokenizer.encode(
             self.img_context_token, add_special_tokens=False
         )
+        # Pre-tokenize the user-facing "<video>" placeholder string. NOTE this may
+        # be a multi-token BPE sequence (e.g. [1060, 24073, 1062]) rather than
+        # `video_context_token_id`, because `<video>` is typically NOT registered
+        # as an added special token in the HF tokenizer (unlike `<image>` /
+        # `<so_embedding>`). `video_context_token_id` is instead a reserved
+        # extended-vocab ID that the model uses internally as the per-tubelet EVS
+        # placeholder; the tokenizer cannot produce it from user text. The fast
+        # path (token IDs & MM data) searches for this subsequence in the
+        # caller's `prompt_token_ids`.
+        self._video_placeholder_token_ids = self.tokenizer.encode(
+            self.video_context_token, add_special_tokens=False
+        )
         # Keep single-ID aliases for backward compat.
         self.image_start_token_id = self._img_start_token_ids[0]
         self.image_end_token_id = self._img_end_token_ids[0]
@@ -991,6 +1004,34 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         if self._sound_context_token_id is not None:
             ids.append(self._sound_context_token_id)
         return torch.tensor(ids, dtype=torch.int32)
+
+    def get_text_with_mm_placeholders(self, mm_counts: Dict[str, int]) -> str:
+        """Return minimal placeholder text for the given multimodal item counts,
+        so that the HF processor can be called with (dummy_text, mm_data)
+        without error. Used when processing tokenized prompt + MM data.
+
+        NanoV2VL currently accepts only one modality per request, so at most
+        one of `image`, `video`, or `audio` will be non-zero in `mm_counts`.
+
+        Args:
+            mm_counts (Dict[str, int]): A mapping of each multimodal modality
+                name (`'image'`, `'video'`, `'audio'`) to the count of items
+                for that modality that need corresponding placeholders in the
+                dummy text.
+
+        Returns:
+            str: A minimal placeholder string containing the correct number
+                and type of multimodal placeholders, suitable for passing
+                along with mm_data to the Hugging Face processor.
+        """
+        num_images = mm_counts.get("image", 0)
+        num_videos = mm_counts.get("video", 0)
+        num_audios = mm_counts.get("audio", 0)
+        parts: List[str] = []
+        parts.extend([IMAGE_PLACEHOLDER] * num_images)
+        parts.extend([VIDEO_PLACEHOLDER] * num_videos)
+        parts.extend([AUDIO_PLACEHOLDER] * num_audios)
+        return "".join(parts)
 
     def get_num_tokens_per_image(
         self,
@@ -1130,25 +1171,528 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
 
         num_special_tokens_per_frame = 2  # <img> and </img>
         if video_pruning_rate > 0:
-            num_tokens_per_frame = self.get_num_tokens_per_image(
-                image=video[0],
-                max_num_tiles=VIDEO_MAX_NUM_TILES,
-                **kwargs,
-            )
-            num_image_tokens_per_frame = num_tokens_per_frame - num_special_tokens_per_frame
-            blocks = num_image_tokens_per_frame // self.num_image_token
-            video_size = (num_tubelets, blocks * self.image_size, self.image_size)
-            num_total_tokens = compute_retained_tokens_count(
-                video_size=video_size,
-                spatial_merge_size=self.spatial_merge_size,
+            # `tokens_per_unit` already reflects the actual per-tubelet
+            # post-pixel-shuffle spatial grid the vision encoder sees — it
+            # comes from `_get_video_tokens_per_frame`, which is
+            # video_target_num_patches / aspect-preserving / image_size
+            # fallback aware. That's the same grid
+            # `_process_videos_frames` feeds to the encoder, so retention
+            # computed from it matches the encoder's actual EVS output.
+            # `compute_retained_tokens_from_tubelet_budget` is the shared
+            # helper `compute_retained_tokens_count` delegates to, so the
+            # two paths stay in sync by construction.
+            evs_tokens = compute_retained_tokens_from_tubelet_budget(
+                num_tubelets=num_tubelets,
+                tokens_per_tubelet=tokens_per_unit,
                 pruning_ratio=video_pruning_rate,
             )
-            # Add special tokens for each tubelet.
-            num_total_tokens += num_tubelets * num_special_tokens_per_frame
+            num_total_tokens = evs_tokens + num_tubelets * num_special_tokens_per_frame
         else:
             # No pruning: tokens_per_unit * num_tubelets + special tokens.
             num_total_tokens = num_tubelets * (tokens_per_unit + num_special_tokens_per_frame)
         return num_total_tokens
+
+    # ------------------------------------------------------------------
+    # Tokenized+MM fast path: expand placeholder tokens in token IDs
+    # ------------------------------------------------------------------
+
+    def expand_prompt_token_ids_for_mm(
+        self,
+        prompt_token_ids: List[int],
+        num_mm_tokens_per_placeholder: List[int],
+        hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
+        """Expand MM placeholder tokens in `prompt_token_ids` so that each
+        single placeholder is replaced by the corresponding number of
+        multimodal feature tokens.
+
+        This is used when processing a tokenized prompt plus multimodal data,
+        without calling the full HuggingFace processor. Detects which modality
+        is present by scanning for placeholder token IDs and dispatches to the
+        matching per-modality expansion helper. NanoV2VL allows only one
+        modality per request, so this raises `ValueError` if placeholders for
+        more than one modality are found.
+
+        Args:
+            prompt_token_ids (List[int]): The input prompt token IDs with
+                image / video / audio placeholder tokens.
+            num_mm_tokens_per_placeholder (List[int]): For each MM placeholder
+                in `prompt_token_ids`, specifies the total number of MM tokens
+                (including modality-specific start/end special tokens) that
+                the placeholder should expand to. Produced by
+                `find_mm_token_lengths`.
+            hf_processor_mm_kwargs (Optional[Dict[str, Any]]): Optional
+                dictionary of HF processor kwargs. For the video path, the
+                fast-path pipeline additionally injects the original
+                `multi_modal_data` under the internal key `_multi_modal_data`
+                so that frame separator text (derived from video metadata)
+                can be reconstructed.
+
+        Returns:
+            Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
+                `expanded_ids` (List[int]) — prompt token IDs where each MM
+                placeholder has been replaced/expanded with the appropriate
+                number of MM feature tokens (plus frame separator tokens for
+                video).
+                `mm_data_updates` (Optional[Dict]) — additional fields to
+                merge into `extra_processed_inputs["multimodal_data"]`.
+                Currently only non-None for EVS-enabled video, in which case
+                it is `{"video": {"evs_ids": evs_ids_tensor}}`.
+        """
+        # Detect modality primarily from `mm_data`, which is authoritative and
+        # independent of tokenizer quirks. The token-scanning fallback is only
+        # used when `mm_data` is absent (shouldn't happen in the fast path, but
+        # kept as a safety net). Token scanning is fragile for video because
+        # `<video>` is typically not registered as an added special token and
+        # thus BPE-decomposes differently depending on trailing context — see
+        # the two-tier matching strategy in `_expand_video_placeholders_in_token_ids`.
+        mm_data = (hf_processor_mm_kwargs or {}).get("_multi_modal_data") or {}
+        if mm_data:
+            has_image = "image" in mm_data and bool(mm_data["image"])
+            has_video = "video" in mm_data and bool(mm_data["video"])
+            has_audio = "audio" in mm_data and bool(mm_data["audio"])
+        else:
+            has_image = self.img_context_token_id in prompt_token_ids
+            has_video = self._contains_video_placeholder(prompt_token_ids)
+            has_audio = (
+                self._sound_context_token_id is not None
+                and self._sound_context_token_id in prompt_token_ids
+            )
+
+        active_count = sum([has_image, has_video, has_audio])
+        if active_count > 1:
+            raise ValueError(
+                "NanoV2VL does not support multiple modalities in the same prompt yet."
+            )
+        if active_count == 0:
+            return prompt_token_ids, None
+
+        if has_image:
+            expanded = self._expand_image_placeholders_in_token_ids(
+                prompt_token_ids, num_mm_tokens_per_placeholder
+            )
+            return expanded, None
+        if has_audio:
+            expanded = self._expand_audio_placeholders_in_token_ids(
+                prompt_token_ids, num_mm_tokens_per_placeholder
+            )
+            return expanded, None
+        # has_video -- reuse `mm_data` already extracted above for detection.
+        expanded_ids, evs_ids_tensor = self._expand_video_placeholders_in_token_ids(
+            prompt_token_ids, num_mm_tokens_per_placeholder, mm_data or None
+        )
+        mm_data_updates: Optional[Dict[str, Dict[str, Any]]] = None
+        if evs_ids_tensor is not None:
+            mm_data_updates = {"video": {"evs_ids": evs_ids_tensor}}
+        return expanded_ids, mm_data_updates
+
+    def _contains_video_placeholder(self, prompt_token_ids: List[int]) -> bool:
+        """Return True if `_video_placeholder_token_ids` appears as a
+        contiguous subsequence of `prompt_token_ids`."""
+        pattern = self._video_placeholder_token_ids
+        if not pattern:
+            return False
+        pattern_len = len(pattern)
+        for i in range(len(prompt_token_ids) - pattern_len + 1):
+            if prompt_token_ids[i : i + pattern_len] == pattern:
+                return True
+        return False
+
+    def _expand_image_placeholders_in_token_ids(
+        self,
+        prompt_token_ids: List[int],
+        num_mm_tokens_per_placeholder: List[int],
+    ) -> List[int]:
+        """Replace each `img_context_token_id` in the prompt with
+        `<img>` + `<image>` repeated N times + `</img>` at the token-ID level.
+
+        The per-placeholder count `N` comes from `get_num_tokens_per_image`
+        and already includes the two special start/end tokens, so the number
+        of repeated context tokens written is
+        `N - len(_img_start_token_ids) - len(_img_end_token_ids)`.
+
+        Args:
+            prompt_token_ids (List[int]): The input prompt token IDs with
+                `img_context_token_id` placeholders.
+            num_mm_tokens_per_placeholder (List[int]): For each image
+                placeholder in `prompt_token_ids`, the total number of MM
+                tokens (including start/end) to expand to.
+
+        Returns:
+            List[int]: The prompt token IDs with each image placeholder
+                replaced by the full `<img><image>*N</img>` token sequence.
+        """
+        num_start = len(self._img_start_token_ids)
+        num_end = len(self._img_end_token_ids)
+
+        expanded: List[int] = []
+        image_idx = 0
+        for tok in prompt_token_ids:
+            if tok == self.img_context_token_id:
+                if image_idx >= len(num_mm_tokens_per_placeholder):
+                    raise ValueError(
+                        f"More image placeholder tokens in prompt than "
+                        f"num_mm_tokens_per_placeholder entries: found "
+                        f"{image_idx + 1} placeholders, "
+                        f"num_mm_tokens_per_placeholder has "
+                        f"{len(num_mm_tokens_per_placeholder)} entries."
+                    )
+                n = num_mm_tokens_per_placeholder[image_idx]
+                num_context = n - num_start - num_end
+                expanded.extend(self._img_start_token_ids)
+                expanded.extend([self.img_context_token_id] * num_context)
+                expanded.extend(self._img_end_token_ids)
+                image_idx += 1
+            else:
+                expanded.append(tok)
+
+        if image_idx != len(num_mm_tokens_per_placeholder):
+            raise ValueError(
+                f"Expected {len(num_mm_tokens_per_placeholder)} image "
+                f"placeholders, found {image_idx}."
+            )
+        return expanded
+
+    def _expand_audio_placeholders_in_token_ids(
+        self,
+        prompt_token_ids: List[int],
+        num_mm_tokens_per_placeholder: List[int],
+    ) -> List[int]:
+        """Replace each `_sound_context_token_id` in the prompt with
+        `<so_start>` + `<so_embedding>` repeated N times + `<so_end>` at the
+        token-ID level.
+
+        The per-placeholder count `N` comes from `get_num_tokens_per_audio`
+        and already includes the two special start/end tokens, so the number
+        of repeated context tokens written is `N - 2`.
+
+        Args:
+            prompt_token_ids (List[int]): The input prompt token IDs with
+                `_sound_context_token_id` placeholders.
+            num_mm_tokens_per_placeholder (List[int]): For each audio
+                placeholder in `prompt_token_ids`, the total number of MM
+                tokens (including start/end) to expand to.
+
+        Returns:
+            List[int]: The prompt token IDs with each audio placeholder
+                replaced by the full `<so_start><so_embedding>*N<so_end>`
+                token sequence.
+        """
+        expanded: List[int] = []
+        audio_idx = 0
+        for tok in prompt_token_ids:
+            if tok == self._sound_context_token_id:
+                if audio_idx >= len(num_mm_tokens_per_placeholder):
+                    raise ValueError(
+                        f"More audio placeholder tokens in prompt than "
+                        f"num_mm_tokens_per_placeholder entries: found "
+                        f"{audio_idx + 1} placeholders, "
+                        f"num_mm_tokens_per_placeholder has "
+                        f"{len(num_mm_tokens_per_placeholder)} entries."
+                    )
+                n = num_mm_tokens_per_placeholder[audio_idx]
+                # n includes 2 special tokens (start + end).
+                expanded.append(self._sound_start_token_id)
+                expanded.extend([self._sound_context_token_id] * (n - 2))
+                expanded.append(self._sound_end_token_id)
+                audio_idx += 1
+            else:
+                expanded.append(tok)
+
+        if audio_idx != len(num_mm_tokens_per_placeholder):
+            raise ValueError(
+                f"Expected {len(num_mm_tokens_per_placeholder)} audio "
+                f"placeholders, found {audio_idx}."
+            )
+        return expanded
+
+    def _compute_video_size_lightweight(
+        self,
+        video_frames: List[Image.Image],
+    ) -> List[int]:
+        """Compute the `video_size` descriptor `[num_frames, num_tiles, h, w]`
+        from frame dimensions only, without running the pixel-processing
+        pipeline.
+
+        This mirrors the shape returned by `_process_videos_frames` but skips
+        the expensive tensor construction, so the token-ID expansion path can
+        cheaply derive per-frame token counts and frame separator strings.
+
+        With `video_target_num_patches` set, target dimensions are computed via
+        `get_video_target_size_and_feature_size`. Otherwise (HF-processor
+        fallback), frames are assumed to be resized to `self.image_size` with
+        a single tile per frame (`VIDEO_MAX_NUM_TILES == 1`).
+
+        Args:
+            video_frames (List[Image.Image]): The list of frames for a single
+                video. Only the first frame's dimensions are inspected when
+                `video_target_num_patches` is set.
+
+        Returns:
+            List[int]: `[num_frames, num_tiles_per_frame, h, w]`, where
+                `num_tiles_per_frame` is always 1 for NanoV2VL video paths.
+        """
+        num_frames = len(video_frames)
+        if self.video_target_num_patches is not None:
+            frame = video_frames[0]
+            if isinstance(frame, Image.Image):
+                orig_w, orig_h = frame.width, frame.height
+            else:
+                orig_h, orig_w = frame.shape[-2], frame.shape[-1]
+            target_w, target_h, _ = get_video_target_size_and_feature_size(
+                orig_w=orig_w,
+                orig_h=orig_h,
+                target_patches=self.video_target_num_patches,
+                maintain_aspect_ratio=self.video_maintain_aspect_ratio,
+                patch_size=self.patch_size,
+                downsample_ratio=self.downsample_ratio,
+            )
+            return [num_frames, 1, target_h, target_w]
+        return [num_frames, 1, self.image_size, self.image_size]
+
+    def _expand_video_placeholders_in_token_ids(
+        self,
+        prompt_token_ids: List[int],
+        num_mm_tokens_per_placeholder: List[int],
+        mm_data: Optional[Dict[str, Any]],
+    ) -> Tuple[List[int], Optional[torch.Tensor]]:
+        """Replace each `<video>` placeholder in `prompt_token_ids` with the
+        full per-frame expansion (optional "This is a video:\\n" prefix,
+        then for each frame/tubelet: frame separator text tokens, `<img>`,
+        `<image>` repeated per-frame-N times, `</img>`).
+
+        The `<video>` placeholder is located by a **two-tier** strategy that
+        mirrors vLLM's `_apply_prompt_updates`:
+
+          1. Token-level subsequence match against
+             `self._video_placeholder_token_ids` (the result of tokenizing
+             `"<video>"` in isolation at init time).
+
+          2. If token-level matching fails to find all `len(videos)`
+             occurrences (typically because BPE merged the trailing `>` of
+             `<video>` with the following character into a different token
+             ID), decode the prompt back to text, split on the literal
+             `"<video>"` string, and re-encode each segment.
+
+        When EVS is enabled (`self.video_pruning_rate > 0`), a **parallel
+        `evs_ids` stream** is also produced — same surrounding context (text
+        segments, frame separators, `<img>`/`</img>` wrappers), but with a
+        single `video_context_token_id` per tubelet instead of
+        `img_context_token_id*num_tokens`. This matches the evs_ids built by
+        `_process_video_prompts` in the non-fast-path and is consumed by
+        `merge_evs_mm_embeds` at LLM forward time.
+
+        Args:
+            prompt_token_ids (List[int]): The input prompt token IDs with
+                `<video>` placeholders.
+            num_mm_tokens_per_placeholder (List[int]): For each video
+                placeholder, the total number of MM tokens produced by
+                `get_num_tokens_per_video`. Currently used only for sanity /
+                iteration; per-frame counts are recomputed from `mm_data`.
+            mm_data (Optional[Dict[str, Any]]): The original
+                `multi_modal_data` dict, injected by the fast-path pipeline
+                under `hf_processor_mm_kwargs["_multi_modal_data"]`. Must
+                contain a `"video"` entry with `VideoData`-like items
+                (`.frames`, `.metadata`). Required; cannot be reconstructed
+                from `prompt_token_ids` alone because frame separators depend
+                on per-video metadata.
+
+        Returns:
+            Tuple[List[int], Optional[torch.Tensor]]:
+                `expanded_ids` (List[int]) — prompt token IDs with each
+                `<video>` placeholder replaced by its full per-frame token
+                sequence.
+                `evs_ids` (Optional[torch.Tensor]) — parallel stream with one
+                `video_context_token_id` placeholder per tubelet when EVS is
+                enabled; `None` otherwise.
+
+        Raises:
+            ValueError: If `mm_data` is `None`, or if the number of
+                `<video>` placeholders does not match the number of videos
+                in `mm_data`.
+        """
+        if mm_data is None:
+            raise ValueError(
+                "Video expansion requires multi_modal_data (passed via "
+                "hf_processor_mm_kwargs['_multi_modal_data'])."
+            )
+
+        videos = mm_data.get("video", [])
+        if not isinstance(videos, list):
+            videos = [videos]
+
+        evs_enabled = self.video_pruning_rate > 0
+
+        # Pre-compute per-video expansion token sequences for BOTH streams.
+        # Surrounding context (prefix, frame separators, <img>/</img>) is
+        # byte-for-byte identical; only the per-tubelet MM content differs.
+        #
+        # Per-tubelet img_context counts come from
+        # `_compute_token_numbers_per_video`, which matches what the
+        # vision encoder actually produces post-EVS (single-tile
+        # per-tubelet spatial grid). `get_num_tokens_per_video` — used by
+        # `find_mm_token_lengths` — must agree with this.
+        video_expansions: List[List[int]] = []
+        video_evs_expansions: Optional[List[List[int]]] = [] if evs_enabled else None
+        for video_data in videos:
+            if hasattr(video_data, "frames"):
+                frames = video_data.frames
+                metadata = video_data.metadata
+            else:
+                frames = video_data
+                metadata = None
+
+            video_size = self._compute_video_size_lightweight(frames)
+            # When EVS is enabled, `_compute_token_numbers_per_video`
+            # returns the dummy pattern [K_pre_evs, 0, 0, ...] — same shape
+            # the non-fast-path uses to size `input_ids` pre-EVS-merge;
+            # `merge_evs_mm_embeds` rewrites it at forward time.
+            tokens_per_frame = self._compute_token_numbers_per_video([video_size])[0]
+            frame_seps = self._get_frame_separators([video_size], [metadata])[0]
+
+            expansion: List[int] = []
+            evs_expansion: Optional[List[int]] = [] if evs_enabled else None
+            if self._add_video_prefix:
+                prefix_ids = self.tokenizer.encode("This is a video:\n", add_special_tokens=False)
+                expansion.extend(prefix_ids)
+                if evs_expansion is not None:
+                    evs_expansion.extend(prefix_ids)
+            for frame_sep, num_tokens in zip(frame_seps, tokens_per_frame):
+                sep_ids = self.tokenizer.encode(frame_sep, add_special_tokens=False)
+                expansion.extend(sep_ids)
+                expansion.extend(self._img_start_token_ids)
+                expansion.extend([self.img_context_token_id] * num_tokens)
+                expansion.extend(self._img_end_token_ids)
+                if evs_expansion is not None:
+                    evs_expansion.extend(sep_ids)
+                    evs_expansion.extend(self._img_start_token_ids)
+                    evs_expansion.append(self.video_context_token_id)
+                    evs_expansion.extend(self._img_end_token_ids)
+
+            video_expansions.append(expansion)
+            if video_evs_expansions is not None and evs_expansion is not None:
+                video_evs_expansions.append(evs_expansion)
+
+        # Two-tier matching strategy (mirroring vLLM's `_apply_prompt_updates`):
+        #
+        #   1. **Token-level fast path**: scan for the pre-tokenized
+        #      `<video>` subsequence in `prompt_token_ids`. Works when the
+        #      tokenizer round-trips `<video>` as a stable BPE sequence
+        #      (e.g. when `<video>` sits at a token boundary).
+        #
+        #   2. **Text-level fallback**: when token-level matching doesn't
+        #      locate all expected occurrences (because BPE merged the
+        #      placeholder's last token with the following character — e.g.
+        #      `>` + `\n` fuses into a single different token ID), decode
+        #      `prompt_token_ids` back to text, split on the `<video>`
+        #      string, and re-encode each segment. This is the same "search
+        #      across token boundaries" escape hatch vLLM uses.
+        tier1 = self._try_token_level_video_replace(
+            prompt_token_ids, video_expansions, video_evs_expansions
+        )
+        if tier1 is not None:
+            expanded_ids, evs_ids_list = tier1
+        else:
+            expanded_ids, evs_ids_list = self._text_level_video_replace(
+                prompt_token_ids, video_expansions, video_evs_expansions
+            )
+
+        evs_ids_tensor = (
+            torch.tensor(evs_ids_list, dtype=torch.long) if evs_ids_list is not None else None
+        )
+        return expanded_ids, evs_ids_tensor
+
+    def _try_token_level_video_replace(
+        self,
+        prompt_token_ids: List[int],
+        video_expansions: List[List[int]],
+        video_evs_expansions: Optional[List[List[int]]] = None,
+    ) -> Optional[Tuple[List[int], Optional[List[int]]]]:
+        """Return `(expanded_ids, evs_ids_or_None)` if every `<video>`
+        occurrence is locatable as a contiguous token-ID subsequence; else
+        return `None` to signal that the text-level fallback is required.
+
+        When `video_evs_expansions` is provided (EVS), both streams are
+        produced in parallel: outside MM chunks each token is copied into
+        both streams; at each matched boundary, `video_expansions[i]` goes
+        into `expanded`, `video_evs_expansions[i]` goes into `evs`.
+        """
+        pattern = self._video_placeholder_token_ids
+        if not pattern:
+            return None
+
+        pattern_len = len(pattern)
+        expanded: List[int] = []
+        evs: Optional[List[int]] = [] if video_evs_expansions is not None else None
+        video_idx = 0
+        i = 0
+        while i < len(prompt_token_ids):
+            if (
+                i + pattern_len <= len(prompt_token_ids)
+                and prompt_token_ids[i : i + pattern_len] == pattern
+            ):
+                if video_idx >= len(video_expansions):
+                    # More token-level matches than videos — ambiguous; bail.
+                    return None
+                expanded.extend(video_expansions[video_idx])
+                if evs is not None and video_evs_expansions is not None:
+                    evs.extend(video_evs_expansions[video_idx])
+                video_idx += 1
+                i += pattern_len
+            else:
+                tok = prompt_token_ids[i]
+                expanded.append(tok)
+                if evs is not None:
+                    evs.append(tok)
+                i += 1
+
+        if video_idx != len(video_expansions):
+            return None  # At least one <video> not found as a subsequence.
+        return expanded, evs
+
+    def _text_level_video_replace(
+        self,
+        prompt_token_ids: List[int],
+        video_expansions: List[List[int]],
+        video_evs_expansions: Optional[List[List[int]]] = None,
+    ) -> Tuple[List[int], Optional[List[int]]]:
+        """Fallback used when token-level subsequence matching fails because
+        BPE merged the `<video>` placeholder with its trailing context.
+
+        Decode `prompt_token_ids` back to text, split on the literal
+        `<video>` string, re-tokenize each segment, and interleave with the
+        per-video expansions. Correctness-preserving but does incur a
+        decode/encode round-trip on CPU.
+
+        When `video_evs_expansions` is provided (EVS), both streams are
+        produced: each non-MM segment is tokenized once and emitted into
+        both streams; at each placeholder boundary, `video_expansions[i]` is
+        appended to `expanded` and `video_evs_expansions[i]` to `evs`.
+        """
+        text = self.tokenizer.decode(prompt_token_ids, skip_special_tokens=False)
+        placeholder = self.video_context_token  # "<video>"
+        segments = text.split(placeholder)
+        num_placeholders = len(segments) - 1
+        if num_placeholders != len(video_expansions):
+            raise ValueError(
+                f"Video expansion: decoded prompt text contains "
+                f"{num_placeholders} '{placeholder}' placeholders, but "
+                f"mm_data has {len(video_expansions)} videos."
+            )
+
+        expanded: List[int] = []
+        evs: Optional[List[int]] = [] if video_evs_expansions is not None else None
+        for i, segment in enumerate(segments):
+            if segment:
+                seg_ids = self.tokenizer.encode(segment, add_special_tokens=False)
+                expanded.extend(seg_ids)
+                if evs is not None:
+                    evs.extend(seg_ids)
+            if i < num_placeholders:
+                expanded.extend(video_expansions[i])
+                if evs is not None and video_evs_expansions is not None:
+                    evs.extend(video_evs_expansions[i])
+        return expanded, evs
 
     def _process_images(
         self, images: List[Image.Image | torch.Tensor], text_prompt: str
@@ -1684,11 +2228,27 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         audio: Union[np.ndarray, Tuple[np.ndarray, int]],
         **kwargs,
     ) -> int:
-        """Return the total number of tokens for a single audio input.
+        """Return the total number of MM tokens for a single audio item.
 
-        This includes the `<so_start>` / `<so_end>` special tokens that
-        wrap the context tokens, matching the expansion performed by
-        `_expand_audio_placeholders`.
+        The count includes the `<so_start>` and `<so_end>` special tokens.
+        The audio is resampled to the extractor's sampling rate when
+        provided as a `(np.ndarray, int)` tuple, so the returned count matches
+        what `extractor.audio_token_count` would produce in the full path
+        (`_process_audio` -> `_resample_audios` -> `_expand_audio_placeholders`).
+
+        Args:
+            audio (Union[np.ndarray, Tuple[np.ndarray, int]]): Either raw audio
+                samples (assumed to already be at the extractor's sampling
+                rate), or a `(samples, sample_rate)` tuple. If the provided
+                sample rate differs from the extractor's, the audio is
+                resampled before counting tokens.
+            **kwargs: Ignored; accepted for interface compatibility with
+                other `get_num_tokens_per_*` methods.
+
+        Returns:
+            int: The total number of MM tokens (feature tokens + 2 for
+                `<so_start>` and `<so_end>`) that a single audio item expands
+                to in the prompt.
         """
         if self._audio_extractor is None:
             raise ValueError(

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -44,16 +44,6 @@ from .modeling_utils import register_auto_model
 
 # Set max_num_tiles to 1 for video modality, to match the training behavior.
 VIDEO_MAX_NUM_TILES = 1
-# Several video code paths (`_process_videos_frames`'s HF-processor fallback,
-# `_get_video_tokens_per_frame`'s fallback, `_compute_video_size_lightweight`,
-# and `get_num_tokens_per_video`'s EVS branch) all assume a single tile per
-# frame. Increasing this constant would require updating those paths
-# accordingly — multi-tile video expansion isn't currently supported and the
-# prompt-side MM counts would diverge from the vision encoder's output.
-# Guard against accidental change.
-assert VIDEO_MAX_NUM_TILES == 1, (
-    "NanoV2VL video paths assume a single tile per frame; see comment above."
-)
 IMAGE_PLACEHOLDER = "<image>"
 VIDEO_PLACEHOLDER = "<video>"
 AUDIO_PLACEHOLDER = "<so_embedding>"
@@ -1306,115 +1296,108 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                 return True
         return False
 
+    def _expand_single_token_placeholders(
+        self,
+        prompt_token_ids: List[int],
+        num_mm_tokens_per_placeholder: List[int],
+        *,
+        context_token_id: int,
+        start_token_ids: List[int],
+        end_token_ids: List[int],
+        modality_name: str,
+    ) -> List[int]:
+        """Shared per-placeholder expansion for modalities whose in-prompt
+        marker is a single token ID (i.e. the tokenizer maps the placeholder
+        string to exactly one token).
+
+        Replaces each occurrence of `context_token_id` in `prompt_token_ids`
+        with `start_token_ids + [context_token_id] * (N - num_start - num_end) + end_token_ids`,
+        where `N = num_mm_tokens_per_placeholder[i]` is the total expanded
+        length (including start / end special tokens) reported by the
+        corresponding `get_num_tokens_per_<modality>`.
+
+        Args:
+            prompt_token_ids: Input prompt token IDs with single-token
+                placeholders of `context_token_id`.
+            num_mm_tokens_per_placeholder: One entry per placeholder;
+                total expanded length (including start / end).
+            context_token_id: Single token ID that marks each placeholder
+                in the prompt (e.g. `img_context_token_id == 18`).
+            start_token_ids: Tokens to emit before the repeated
+                `context_token_id` run (e.g. `_img_start_token_ids == [19]`).
+            end_token_ids: Tokens to emit after the repeated run
+                (e.g. `_img_end_token_ids == [20]`).
+            modality_name: Human-readable name (`"image"` / `"audio"`) used
+                in error messages.
+
+        Returns:
+            The prompt token IDs with each placeholder replaced by
+            `start + context*K + end`, where `K = N - len(start) - len(end)`.
+        """
+        num_start = len(start_token_ids)
+        num_end = len(end_token_ids)
+
+        expanded: List[int] = []
+        idx = 0
+        for tok in prompt_token_ids:
+            if tok == context_token_id:
+                if idx >= len(num_mm_tokens_per_placeholder):
+                    raise ValueError(
+                        f"More {modality_name} placeholder tokens in prompt "
+                        f"than num_mm_tokens_per_placeholder entries: found "
+                        f"{idx + 1} placeholders, "
+                        f"num_mm_tokens_per_placeholder has "
+                        f"{len(num_mm_tokens_per_placeholder)} entries."
+                    )
+                n = num_mm_tokens_per_placeholder[idx]
+                num_context = n - num_start - num_end
+                expanded.extend(start_token_ids)
+                expanded.extend([context_token_id] * num_context)
+                expanded.extend(end_token_ids)
+                idx += 1
+            else:
+                expanded.append(tok)
+
+        if idx != len(num_mm_tokens_per_placeholder):
+            raise ValueError(
+                f"Expected {len(num_mm_tokens_per_placeholder)} "
+                f"{modality_name} placeholders, found {idx}."
+            )
+        return expanded
+
     def _expand_image_placeholders_in_token_ids(
         self,
         prompt_token_ids: List[int],
         num_mm_tokens_per_placeholder: List[int],
     ) -> List[int]:
-        """Replace each `img_context_token_id` in the prompt with
-        `<img>` + `<image>` repeated N times + `</img>` at the token-ID level.
-
-        The per-placeholder count `N` comes from `get_num_tokens_per_image`
-        and already includes the two special start/end tokens, so the number
-        of repeated context tokens written is
-        `N - len(_img_start_token_ids) - len(_img_end_token_ids)`.
-
-        Args:
-            prompt_token_ids (List[int]): The input prompt token IDs with
-                `img_context_token_id` placeholders.
-            num_mm_tokens_per_placeholder (List[int]): For each image
-                placeholder in `prompt_token_ids`, the total number of MM
-                tokens (including start/end) to expand to.
-
-        Returns:
-            List[int]: The prompt token IDs with each image placeholder
-                replaced by the full `<img><image>*N</img>` token sequence.
-        """
-        num_start = len(self._img_start_token_ids)
-        num_end = len(self._img_end_token_ids)
-
-        expanded: List[int] = []
-        image_idx = 0
-        for tok in prompt_token_ids:
-            if tok == self.img_context_token_id:
-                if image_idx >= len(num_mm_tokens_per_placeholder):
-                    raise ValueError(
-                        f"More image placeholder tokens in prompt than "
-                        f"num_mm_tokens_per_placeholder entries: found "
-                        f"{image_idx + 1} placeholders, "
-                        f"num_mm_tokens_per_placeholder has "
-                        f"{len(num_mm_tokens_per_placeholder)} entries."
-                    )
-                n = num_mm_tokens_per_placeholder[image_idx]
-                num_context = n - num_start - num_end
-                expanded.extend(self._img_start_token_ids)
-                expanded.extend([self.img_context_token_id] * num_context)
-                expanded.extend(self._img_end_token_ids)
-                image_idx += 1
-            else:
-                expanded.append(tok)
-
-        if image_idx != len(num_mm_tokens_per_placeholder):
-            raise ValueError(
-                f"Expected {len(num_mm_tokens_per_placeholder)} image "
-                f"placeholders, found {image_idx}."
-            )
-        return expanded
+        """Image expansion — thin wrapper around
+        `_expand_single_token_placeholders` with image-specific tokens."""
+        return self._expand_single_token_placeholders(
+            prompt_token_ids,
+            num_mm_tokens_per_placeholder,
+            context_token_id=self.img_context_token_id,
+            start_token_ids=self._img_start_token_ids,
+            end_token_ids=self._img_end_token_ids,
+            modality_name="image",
+        )
 
     def _expand_audio_placeholders_in_token_ids(
         self,
         prompt_token_ids: List[int],
         num_mm_tokens_per_placeholder: List[int],
     ) -> List[int]:
-        """Replace each `_sound_context_token_id` in the prompt with
-        `<so_start>` + `<so_embedding>` repeated N times + `<so_end>` at the
-        token-ID level.
+        """Audio expansion — thin wrapper around
+        `_expand_single_token_placeholders` with audio-specific tokens."""
+        return self._expand_single_token_placeholders(
+            prompt_token_ids,
+            num_mm_tokens_per_placeholder,
+            context_token_id=self._sound_context_token_id,
+            start_token_ids=[self._sound_start_token_id],
+            end_token_ids=[self._sound_end_token_id],
+            modality_name="audio",
+        )
 
-        The per-placeholder count `N` comes from `get_num_tokens_per_audio`
-        and already includes the two special start/end tokens, so the number
-        of repeated context tokens written is `N - 2`.
-
-        Args:
-            prompt_token_ids (List[int]): The input prompt token IDs with
-                `_sound_context_token_id` placeholders.
-            num_mm_tokens_per_placeholder (List[int]): For each audio
-                placeholder in `prompt_token_ids`, the total number of MM
-                tokens (including start/end) to expand to.
-
-        Returns:
-            List[int]: The prompt token IDs with each audio placeholder
-                replaced by the full `<so_start><so_embedding>*N<so_end>`
-                token sequence.
-        """
-        expanded: List[int] = []
-        audio_idx = 0
-        for tok in prompt_token_ids:
-            if tok == self._sound_context_token_id:
-                if audio_idx >= len(num_mm_tokens_per_placeholder):
-                    raise ValueError(
-                        f"More audio placeholder tokens in prompt than "
-                        f"num_mm_tokens_per_placeholder entries: found "
-                        f"{audio_idx + 1} placeholders, "
-                        f"num_mm_tokens_per_placeholder has "
-                        f"{len(num_mm_tokens_per_placeholder)} entries."
-                    )
-                n = num_mm_tokens_per_placeholder[audio_idx]
-                # n includes 2 special tokens (start + end).
-                expanded.append(self._sound_start_token_id)
-                expanded.extend([self._sound_context_token_id] * (n - 2))
-                expanded.append(self._sound_end_token_id)
-                audio_idx += 1
-            else:
-                expanded.append(tok)
-
-        if audio_idx != len(num_mm_tokens_per_placeholder):
-            raise ValueError(
-                f"Expected {len(num_mm_tokens_per_placeholder)} audio "
-                f"placeholders, found {audio_idx}."
-            )
-        return expanded
-
-    def _compute_video_size_lightweight(
+    def _compute_video_shape_descriptor(
         self,
         video_frames: List[Image.Image],
     ) -> List[int]:
@@ -1543,17 +1526,22 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         video_expansions: List[List[int]] = []
         video_evs_expansions: Optional[List[List[int]]] = [] if evs_enabled else None
         for video_data in videos:
-            if hasattr(video_data, "frames"):
-                frames = video_data.frames
-                metadata = video_data.metadata
-            else:
-                frames = video_data
-                metadata = None
+            # `video_data` comes in two shapes:
+            #   - A `VideoData`-like object (with `.frames` / `.metadata`
+            #     attributes) — the production case (openai_server wraps
+            #     video inputs this way) and the unit-test case (tests use
+            #     `SimpleNamespace(frames=..., metadata=...)`).
+            #   - A plain list of frames (no metadata) — the defensive
+            #     fallback when callers pass raw frames directly, matching
+            #     the pattern in `find_mm_token_lengths` in multimodal.py.
+            # `getattr` with a default handles both uniformly.
+            frames = getattr(video_data, "frames", video_data)
+            metadata = getattr(video_data, "metadata", None)
 
-            video_size = self._compute_video_size_lightweight(frames)
+            video_size = self._compute_video_shape_descriptor(frames)
             # When EVS is enabled, `_compute_token_numbers_per_video`
             # returns the dummy pattern [K_pre_evs, 0, 0, ...] — same shape
-            # the non-fast-path uses to size `input_ids` pre-EVS-merge;
+            # the str-replacement-path uses to size `input_ids` pre-EVS-merge;
             # `merge_evs_mm_embeds` rewrites it at forward time.
             tokens_per_frame = self._compute_token_numbers_per_video([video_size])[0]
             frame_seps = self._get_frame_separators([video_size], [metadata])[0]
@@ -1581,25 +1569,21 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             if video_evs_expansions is not None and evs_expansion is not None:
                 video_evs_expansions.append(evs_expansion)
 
-        # Two-tier matching strategy (mirroring vLLM's `_apply_prompt_updates`):
+        # Dispatch by placeholder token length:
         #
-        #   1. **Token-level fast path**: scan for the pre-tokenized
-        #      `<video>` subsequence in `prompt_token_ids`. Works when the
-        #      tokenizer round-trips `<video>` as a stable BPE sequence
-        #      (e.g. when `<video>` sits at a token boundary).
+        #   - len == 1: `<video>` is a single added special token, stable
+        #     across BPE boundaries — token-level subsequence matching is
+        #     always correct, no fallback needed.
         #
-        #   2. **Text-level fallback**: when token-level matching doesn't
-        #      locate all expected occurrences (because BPE merged the
-        #      placeholder's last token with the following character — e.g.
-        #      `>` + `\n` fuses into a single different token ID), decode
-        #      `prompt_token_ids` back to text, split on the `<video>`
-        #      string, and re-encode each segment. This is the same "search
-        #      across token boundaries" escape hatch vLLM uses.
-        tier1 = self._try_token_level_video_replace(
-            prompt_token_ids, video_expansions, video_evs_expansions
-        )
-        if tier1 is not None:
-            expanded_ids, evs_ids_list = tier1
+        #   - len > 1: `<video>` decomposes into multiple BPE tokens whose
+        #     last token can merge with the following character (e.g. `>` +
+        #     `\n` fuses into a different token ID), so token-level search
+        #     is unreliable. Go straight to the text-level path: decode,
+        #     split on the literal `<video>` string, re-encode each segment.
+        if len(self._video_placeholder_token_ids) == 1:
+            expanded_ids, evs_ids_list = self._token_level_video_replace(
+                prompt_token_ids, video_expansions, video_evs_expansions
+            )
         else:
             expanded_ids, evs_ids_list = self._text_level_video_replace(
                 prompt_token_ids, video_expansions, video_evs_expansions
@@ -1610,52 +1594,54 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         )
         return expanded_ids, evs_ids_tensor
 
-    def _try_token_level_video_replace(
+    def _token_level_video_replace(
         self,
         prompt_token_ids: List[int],
         video_expansions: List[List[int]],
         video_evs_expansions: Optional[List[List[int]]] = None,
-    ) -> Optional[Tuple[List[int], Optional[List[int]]]]:
-        """Return `(expanded_ids, evs_ids_or_None)` if every `<video>`
-        occurrence is locatable as a contiguous token-ID subsequence; else
-        return `None` to signal that the text-level fallback is required.
+    ) -> Tuple[List[int], Optional[List[int]]]:
+        """Scan `prompt_token_ids` for each `<video>` placeholder as a
+        single-token match and splice in the per-video expansion(s).
+
+        Only called when `len(self._video_placeholder_token_ids) == 1`, so
+        the placeholder is a stable added special token and a plain ID
+        scan is reliable — no BPE boundary merging to worry about.
+
+        Raises `ValueError` if the number of matches doesn't equal the
+        number of videos (indicates malformed input, not a fallback case).
 
         When `video_evs_expansions` is provided (EVS), both streams are
         produced in parallel: outside MM chunks each token is copied into
-        both streams; at each matched boundary, `video_expansions[i]` goes
-        into `expanded`, `video_evs_expansions[i]` goes into `evs`.
+        both streams; at each match, `video_expansions[i]` goes into
+        `expanded` and `video_evs_expansions[i]` goes into `evs`.
         """
-        pattern = self._video_placeholder_token_ids
-        if not pattern:
-            return None
-
-        pattern_len = len(pattern)
+        placeholder_id = self._video_placeholder_token_ids[0]
         expanded: List[int] = []
         evs: Optional[List[int]] = [] if video_evs_expansions is not None else None
         video_idx = 0
-        i = 0
-        while i < len(prompt_token_ids):
-            if (
-                i + pattern_len <= len(prompt_token_ids)
-                and prompt_token_ids[i : i + pattern_len] == pattern
-            ):
+        for tok in prompt_token_ids:
+            if tok == placeholder_id:
                 if video_idx >= len(video_expansions):
-                    # More token-level matches than videos — ambiguous; bail.
-                    return None
+                    raise ValueError(
+                        f"Video expansion: prompt_token_ids contains more "
+                        f"'<video>' placeholders than videos "
+                        f"({len(video_expansions)})."
+                    )
                 expanded.extend(video_expansions[video_idx])
-                if evs is not None and video_evs_expansions is not None:
+                if evs is not None:
                     evs.extend(video_evs_expansions[video_idx])
                 video_idx += 1
-                i += pattern_len
             else:
-                tok = prompt_token_ids[i]
                 expanded.append(tok)
                 if evs is not None:
                     evs.append(tok)
-                i += 1
 
         if video_idx != len(video_expansions):
-            return None  # At least one <video> not found as a subsequence.
+            raise ValueError(
+                f"Video expansion: prompt_token_ids contains {video_idx} "
+                f"'<video>' placeholder(s), but mm_data has "
+                f"{len(video_expansions)} video(s)."
+            )
         return expanded, evs
 
     def _text_level_video_replace(
@@ -1818,6 +1804,14 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             else:
                 # Fallback: use HF image processor with VIDEO_MAX_NUM_TILES.
                 orig_max_num_tiles = self.processor.max_num_tiles
+                # Several video code paths all assume a single tile per frame.
+                # Increasing this constant would require updating those paths
+                # accordingly — multi-tile video expansion isn't currently supported and the
+                # prompt-side MM counts would diverge from the vision encoder's output.
+                # Guard against accidental change.
+                assert VIDEO_MAX_NUM_TILES == 1, (
+                    "NanoV2VL video paths assume a single tile per frame; see comment above."
+                )
                 self.processor.max_num_tiles = VIDEO_MAX_NUM_TILES
                 try:
                     processed_images = self.processor(images=video, return_tensors="pt").to(

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -1205,6 +1205,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         prompt_token_ids: List[int],
         num_mm_tokens_per_placeholder: List[int],
         hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
+        mm_data: Optional[Dict[str, Any]] = None,
     ) -> Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
         """Expand MM placeholder tokens in `prompt_token_ids` so that each
         single placeholder is replaced by the corresponding number of
@@ -1226,11 +1227,14 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                 the placeholder should expand to. Produced by
                 `find_mm_token_lengths`.
             hf_processor_mm_kwargs (Optional[Dict[str, Any]]): Optional
-                dictionary of HF processor kwargs. For the video path, the
-                fast-path pipeline additionally injects the original
-                `multi_modal_data` under the internal key `_multi_modal_data`
-                so that frame separator text (derived from video metadata)
-                can be reconstructed.
+                dictionary of HF processor kwargs. Not currently consulted by
+                NanoV2VL's expansion (kept for interface compatibility with
+                other implementations of `expand_prompt_token_ids_for_mm`).
+            mm_data (Optional[Dict[str, Any]]): The original
+                `multi_modal_data` dict (`{"image": [...], "video": [...],
+                "audio": [...]}`). Required by the video path for frame
+                separator text reconstruction from per-video metadata; the
+                image and audio paths don't use it.
 
         Returns:
             Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]:
@@ -1250,7 +1254,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         # `<video>` is typically not registered as an added special token and
         # thus BPE-decomposes differently depending on trailing context — see
         # the two-tier matching strategy in `_expand_video_placeholders_in_token_ids`.
-        mm_data = (hf_processor_mm_kwargs or {}).get("_multi_modal_data") or {}
+        mm_data = mm_data or {}
         if mm_data:
             has_image = "image" in mm_data and bool(mm_data["image"])
             has_video = "video" in mm_data and bool(mm_data["video"])
@@ -1494,12 +1498,12 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                 `get_num_tokens_per_video`. Currently used only for sanity /
                 iteration; per-frame counts are recomputed from `mm_data`.
             mm_data (Optional[Dict[str, Any]]): The original
-                `multi_modal_data` dict, injected by the fast-path pipeline
-                under `hf_processor_mm_kwargs["_multi_modal_data"]`. Must
-                contain a `"video"` entry with `VideoData`-like items
-                (`.frames`, `.metadata`). Required; cannot be reconstructed
-                from `prompt_token_ids` alone because frame separators depend
-                on per-video metadata.
+                `multi_modal_data` dict, threaded through by the fast-path
+                pipeline as a dedicated argument on
+                `expand_prompt_token_ids_for_mm`. Must contain a `"video"`
+                entry with `VideoData`-like items (`.frames`, `.metadata`).
+                Required; cannot be reconstructed from `prompt_token_ids`
+                alone because frame separators depend on per-video metadata.
 
         Returns:
             Tuple[List[int], Optional[torch.Tensor]]:
@@ -1517,8 +1521,8 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         """
         if mm_data is None:
             raise ValueError(
-                "Video expansion requires multi_modal_data (passed via "
-                "hf_processor_mm_kwargs['_multi_modal_data'])."
+                "Video expansion requires multi_modal_data (passed as the "
+                "`mm_data` argument of expand_prompt_token_ids_for_mm)."
             )
 
         videos = mm_data.get("video", [])

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -1148,6 +1148,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         *,
         video: List[Union[Image.Image, torch.Tensor]],
         video_pruning_rate: Optional[float] = None,
+        video_metadata: Optional[dict] = None,
         **kwargs,
     ):
         # Use VIDEO_PRUNING_RATIO if not explicitly provided
@@ -1184,6 +1185,25 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         else:
             # No pruning: tokens_per_unit * num_tubelets + special tokens.
             num_total_tokens = num_tubelets * (tokens_per_unit + num_special_tokens_per_frame)
+
+        # If audio was extracted from this video, the prompt carries
+        # <so_start><so_embedding>*M<so_end> appended after the video frames
+        # (see _expand_video_placeholders_in_token_ids and the slow-path
+        # _extract_audio_from_video). Account for those tokens so
+        # total_mm_tokens_in_request matches the actual mm-token count in the
+        # tokenized prompt and len(mm_embed) at forward time.
+        if (
+            isinstance(video_metadata, dict)
+            and "audio_samples" in video_metadata
+            and self._audio_extractor is not None
+        ):
+            num_total_tokens += self.get_num_tokens_per_audio(
+                audio=(
+                    video_metadata["audio_samples"],
+                    video_metadata["audio_sample_rate"],
+                )
+            )
+
         return num_total_tokens
 
     # ------------------------------------------------------------------
@@ -1564,6 +1584,37 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                     evs_expansion.extend(self._img_start_token_ids)
                     evs_expansion.append(self.video_context_token_id)
                     evs_expansion.extend(self._img_end_token_ids)
+
+            # If audio was extracted from this video, append <so_start><so_embedding>*M<so_end>
+            # so the prompt has placeholder slots for audio embeddings produced by
+            # _interleave_video_audio_embeddings at forward time. Reuse
+            # get_num_tokens_per_audio (which returns M + 2) and derive M; this keeps
+            # the count consistent with get_num_tokens_per_video's accounting and avoids
+            # an unnecessary librosa.resample (we only need the resampled length, not
+            # the resampled samples themselves).
+            # Audio is NOT pruned by EVS, so both streams need identical audio slots.
+            if (
+                isinstance(metadata, dict)
+                and "audio_samples" in metadata
+                and self._audio_extractor is not None
+            ):
+                num_audio_context = (
+                    self.get_num_tokens_per_audio(
+                        audio=(
+                            metadata["audio_samples"],
+                            metadata["audio_sample_rate"],
+                        )
+                    )
+                    - 2
+                )
+                audio_ids = (
+                    [self._sound_start_token_id]
+                    + [self._sound_context_token_id] * num_audio_context
+                    + [self._sound_end_token_id]
+                )
+                expansion.extend(audio_ids)
+                if evs_expansion is not None:
+                    evs_expansion.extend(audio_ids)
 
             video_expansions.append(expansion)
             if video_evs_expansions is not None and evs_expansion is not None:

--- a/tensorrt_llm/inputs/__init__.py
+++ b/tensorrt_llm/inputs/__init__.py
@@ -1,6 +1,8 @@
 from .content_format import ContentFormat, detect_content_format
 from .data import PromptInputs, TextPrompt, TokensPrompt, prompt_inputs
-from .evs import compute_retained_tokens_count, compute_retention_mask
+from .evs import (compute_retained_tokens_count,
+                  compute_retained_tokens_from_tubelet_budget,
+                  compute_retention_mask)
 from .multimodal import MultimodalInput
 # yapf and isort conflict on the following import blocks
 # yapf: disable
@@ -65,6 +67,7 @@ __all__ = [
     "load_video",
     "get_cache_salt_id",
     "compute_retained_tokens_count",
+    "compute_retained_tokens_from_tubelet_budget",
     "compute_retention_mask",
     "load_base64_image_embeds",
 ]

--- a/tensorrt_llm/inputs/evs.py
+++ b/tensorrt_llm/inputs/evs.py
@@ -4,11 +4,35 @@
 import torch
 
 
+def compute_retained_tokens_from_tubelet_budget(num_tubelets: int,
+                                                tokens_per_tubelet: int,
+                                                pruning_ratio: float) -> int:
+    """Compute the number of retained tokens for a video given a precomputed per-tubelet token count.
+
+    Ensures that at least one tubelet's worth of tokens is always retained —
+    i.e. pruning never drops the whole video.
+
+    Args:
+        num_tubelets: Number of temporal units (tubelets) in the video.
+        tokens_per_tubelet: Post-spatial-merge token count per tubelet. For a
+            video with spatial grid (H, W) after patchification and
+            pixel-shuffle, this equals
+            ``(H // spatial_merge_size) * (W // spatial_merge_size)``.
+        pruning_ratio: The pruning ratio in [0, 1).
+
+    Returns:
+        The number of retained tokens across all tubelets.
+    """
+    evs_num_tokens = int(num_tubelets * tokens_per_tubelet *
+                         (1 - pruning_ratio))
+    return max(tokens_per_tubelet, evs_num_tokens)
+
+
 def compute_retained_tokens_count(video_size: torch.LongTensor,
                                   spatial_merge_size: int,
                                   pruning_ratio: float) -> int:
-    """
-    Compute the number of retained tokens for a given video.
+    """Compute the number of retained tokens for a given video.
+
     Method ensures that we retain all the tokens from the first frame
     regardless of the pruning rate.
 
@@ -25,9 +49,9 @@ def compute_retained_tokens_count(video_size: torch.LongTensor,
     # Tuple of ints input came from Preprocessing stage, while in actual forward() it was a Tensor.
     # To make sure number of output tokens stays the case - an explicit cast was added.
     T, H, W = map(int, video_size)
-    min_num_tokens = (H // spatial_merge_size) * (W // spatial_merge_size)
-    evs_num_tokens = int(T * min_num_tokens * (1 - pruning_ratio))
-    return max(min_num_tokens, evs_num_tokens)
+    tokens_per_tubelet = (H // spatial_merge_size) * (W // spatial_merge_size)
+    return compute_retained_tokens_from_tubelet_budget(T, tokens_per_tubelet,
+                                                       pruning_ratio)
 
 
 def compute_retention_mask(
@@ -37,8 +61,7 @@ def compute_retention_mask(
     pruning_ratio: float,
     flatten_output: bool = True,
 ) -> torch.Tensor:
-    """
-    Computes the retention mask for input video embeddings.
+    """Computes the retention mask for input video embeddings.
 
     Args:
         video_embeds (`torch.Tensor`): The input video embeddings

--- a/tensorrt_llm/inputs/evs.py
+++ b/tensorrt_llm/inputs/evs.py
@@ -7,7 +7,9 @@ import torch
 def compute_retained_tokens_from_tubelet_budget(num_tubelets: int,
                                                 tokens_per_tubelet: int,
                                                 pruning_ratio: float) -> int:
-    """Compute the number of retained tokens for a video given a precomputed per-tubelet token count.
+    """This is Nemotron Nano V3 OMNI-specific at the moment.
+
+    Compute the number of retained tokens for a video given a precomputed per-tubelet token count.
 
     Ensures that at least one tubelet's worth of tokens is always retained —
     i.e. pruning never drops the whole video.

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -783,7 +783,9 @@ def find_mm_token_lengths(
                     image=item, )
                 modality_token_lengths.append(num_tokens)
             elif modality == "video":
+                video_metadata = None
                 if isinstance(item, tensorrt_llm.inputs.utils.VideoData):
+                    video_metadata = item.metadata
                     item = item.frames
                 assert isinstance(item, list), "Video must be a list of frames"
                 call_kwargs = {"video": item}
@@ -796,7 +798,13 @@ def find_mm_token_lengths(
                     call_kwargs["video_grid_thw"] = video_grid_thw_for_items[
                         idx]
                 num_tokens = input_processor.get_num_tokens_per_video(
+<<<<<<< HEAD
                     **call_kwargs)
+=======
+                    video=item,
+                    video_metadata=video_metadata,
+                )
+>>>>>>> cfc5f09533 (Support extracting audio from video)
                 modality_token_lengths.append(num_tokens)
             elif modality == "audio":
                 num_tokens = input_processor.get_num_tokens_per_audio(

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -797,6 +797,12 @@ def find_mm_token_lengths(
                     item = item.frames
                 assert isinstance(item, list), "Video must be a list of frames"
                 call_kwargs = {"video": item}
+                if video_metadata is not None:
+                    # Used by per-model overrides that need to account for
+                    # video-derived auxiliary modalities (e.g. Nemotron Nano
+                    # adds <so_*> token slots when metadata carries
+                    # `audio_samples` from extract_audio=true).
+                    call_kwargs["video_metadata"] = video_metadata
                 if video_grid_thw_for_items is not None:
                     # TODO(TRTLLM-11951): Replace this Qwen-VL-specific
                     # metadata wiring with a generic per-item processed
@@ -806,13 +812,7 @@ def find_mm_token_lengths(
                     call_kwargs["video_grid_thw"] = video_grid_thw_for_items[
                         idx]
                 num_tokens = input_processor.get_num_tokens_per_video(
-<<<<<<< HEAD
                     **call_kwargs)
-=======
-                    video=item,
-                    video_metadata=video_metadata,
-                )
->>>>>>> cfc5f09533 (Support extracting audio from video)
                 modality_token_lengths.append(num_tokens)
             elif modality == "audio":
                 num_tokens = input_processor.get_num_tokens_per_audio(

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -629,6 +629,14 @@ def apply_mm_hashes(
                 if isinstance(frame, torch.Tensor):
                     frame = frame.detach().cpu().contiguous()
                 hasher.update(serialize_item(frame))
+            # TODO(TRTLLM-12297): also fold metadata["audio_samples"] /
+            # metadata["audio_sample_rate"] into the hash when present.
+            # extract_audio=true makes audio affect token counts and
+            # embeddings (see modeling_nemotron_nano.py
+            # _expand_video_placeholders_in_token_ids and
+            # get_num_tokens_per_video), but two videos with identical
+            # frames and different audio currently share the same MM hash —
+            # KV-cache reuse can return stale audio-conditioned states.
         else:
             hasher.update(serialize_item(item))
 

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -868,7 +868,10 @@ def create_input_processor_with_hash(
 
         # Merge any model-specific auxiliary streams (e.g. video evs_ids for
         # EVS-enabled runs) into extra_processed_inputs["multimodal_data"].
-        # `merge_evs_mm_embeds` will pick them up at LLM forward time.
+        # The dummy-placeholder pass above produced these against the synthetic
+        # placeholder text, so they're stale w.r.t. the real prompt; overwrite
+        # them with the values rebuilt from `prompt_token_ids` here so
+        # `merge_evs_mm_embeds` picks up the correct stream at LLM forward time.
         if mm_data_updates:
             mm_container = extra_processed_inputs.setdefault(
                 "multimodal_data", {})

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -310,6 +310,7 @@ class BaseMultimodalInputProcessor(ABC):
         self,
         *,
         video: List[Union[Image.Image, torch.Tensor]],
+        video_metadata: Optional[dict] = None,
         **kwargs,
     ):
         """
@@ -321,6 +322,11 @@ class BaseMultimodalInputProcessor(ABC):
         Returns the token count for the given video.
         Example: for a video item, return the prompt-side token count for that
         one video unit, not the number of video frames.
+
+        `video_metadata` is consumed here (not forwarded into
+        `get_num_multimodal_tokens`) so subclasses that don't need are unaffected.
+        Subclasses that need `video_metadata` (e.g. Nemotron Nano
+        accounting for audio extracted from video) override this method.
 
         Subclasses can override this method to provide custom logic to calculate the number of tokens.
         """

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -859,14 +859,12 @@ def create_input_processor_with_hash(
                 "tokenized_multimodal_process: find_mm_token_lengths returned "
                 "no token lengths for the provided multi_modal_data.")
 
-        # Build kwargs for expand, injecting mm_data so model-specific
-        # expansion (e.g. video frame separators) can access it.
-        expand_kwargs = dict(inputs.get("mm_processor_kwargs") or {})
-        expand_kwargs["_multi_modal_data"] = mm_data
         expanded_ids, mm_data_updates = input_processor.expand_prompt_token_ids_for_mm(
             prompt_token_ids,
             num_mm_tokens,
-            hf_processor_mm_kwargs=expand_kwargs)
+            hf_processor_mm_kwargs=inputs.get("mm_processor_kwargs"),
+            mm_data=mm_data,
+        )
 
         # Merge any model-specific auxiliary streams (e.g. video evs_ids for
         # EVS-enabled runs) into extra_processed_inputs["multimodal_data"].

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -859,10 +859,24 @@ def create_input_processor_with_hash(
                 "tokenized_multimodal_process: find_mm_token_lengths returned "
                 "no token lengths for the provided multi_modal_data.")
 
-        expanded_ids = input_processor.expand_prompt_token_ids_for_mm(
+        # Build kwargs for expand, injecting mm_data so model-specific
+        # expansion (e.g. video frame separators) can access it.
+        expand_kwargs = dict(inputs.get("mm_processor_kwargs") or {})
+        expand_kwargs["_multi_modal_data"] = mm_data
+        expanded_ids, mm_data_updates = input_processor.expand_prompt_token_ids_for_mm(
             prompt_token_ids,
             num_mm_tokens,
-            hf_processor_mm_kwargs=inputs.get("mm_processor_kwargs"))
+            hf_processor_mm_kwargs=expand_kwargs)
+
+        # Merge any model-specific auxiliary streams (e.g. video evs_ids for
+        # EVS-enabled runs) into extra_processed_inputs["multimodal_data"].
+        # `merge_evs_mm_embeds` will pick them up at LLM forward time.
+        if mm_data_updates:
+            mm_container = extra_processed_inputs.setdefault(
+                "multimodal_data", {})
+            for modality, field_updates in mm_data_updates.items():
+                mm_container.setdefault(modality, {}).update(field_updates)
+
         return multimodal_hashing_process(
             inputs,
             sampling_params,

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -448,7 +448,7 @@ async def async_load_video(video: str,
         return await asyncio.to_thread(_load_from_bytes, decoded_video)
     else:
         return await asyncio.to_thread(_load_video_by_cv2, video, num_frames,
-                                       fps, format, device)
+                                       fps, format, device, extract_audio)
 
 
 def _normalize_file_uri(uri: str) -> str:

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -18,6 +18,7 @@ l0_l40s:
   - unittest/_torch/modeling -k "modeling_siglip"
   - unittest/_torch/modeling -k "modeling_vila"
   - unittest/_torch/modeling -k "modeling_nemotron_nano_v2_vl"
+  - unittest/_torch/modeling/test_nemotron_nano_preprocessing.py -k "TestGetTextWithMMPlaceholders or TestExpandImagePlaceholders or TestExpandAudioPlaceholders or TestExpandVideoPlaceholders or TestExpandVideoPlaceholdersMultiToken or TestExpandVideoPlaceholdersEVS or TestExpandPromptTokenIdsForMM or TestGetNumTokensPerAudio"
   - unittest/_torch/modeling/test_modeling_llava_next.py::TestLlavaNext::test_all
   - unittest/_torch/modeling/test_modeling_llava_next.py::test_llava_next_expand_prompt_token_ids_for_mm
   - unittest/_torch/modeling/test_modeling_qwen2_5vl.py::TestQwen2_5_VL::test_all

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -18,7 +18,6 @@ l0_l40s:
   - unittest/_torch/modeling -k "modeling_siglip"
   - unittest/_torch/modeling -k "modeling_vila"
   - unittest/_torch/modeling -k "modeling_nemotron_nano_v2_vl"
-  - unittest/_torch/modeling/test_nemotron_nano_preprocessing.py -k "TestGetTextWithMMPlaceholders or TestExpandImagePlaceholders or TestExpandAudioPlaceholders or TestExpandVideoPlaceholders or TestExpandVideoPlaceholdersMultiToken or TestExpandVideoPlaceholdersEVS or TestExpandPromptTokenIdsForMM or TestGetNumTokensPerAudio or TestGetNumTokensPerVideoInvariants"
   - unittest/_torch/modeling/test_modeling_llava_next.py::TestLlavaNext::test_all
   - unittest/_torch/modeling/test_modeling_llava_next.py::test_llava_next_expand_prompt_token_ids_for_mm
   - unittest/_torch/modeling/test_modeling_qwen2_5vl.py::TestQwen2_5_VL::test_all

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -18,7 +18,7 @@ l0_l40s:
   - unittest/_torch/modeling -k "modeling_siglip"
   - unittest/_torch/modeling -k "modeling_vila"
   - unittest/_torch/modeling -k "modeling_nemotron_nano_v2_vl"
-  - unittest/_torch/modeling/test_nemotron_nano_preprocessing.py -k "TestGetTextWithMMPlaceholders or TestExpandImagePlaceholders or TestExpandAudioPlaceholders or TestExpandVideoPlaceholders or TestExpandVideoPlaceholdersMultiToken or TestExpandVideoPlaceholdersEVS or TestExpandPromptTokenIdsForMM or TestGetNumTokensPerAudio"
+  - unittest/_torch/modeling/test_nemotron_nano_preprocessing.py -k "TestGetTextWithMMPlaceholders or TestExpandImagePlaceholders or TestExpandAudioPlaceholders or TestExpandVideoPlaceholders or TestExpandVideoPlaceholdersMultiToken or TestExpandVideoPlaceholdersEVS or TestExpandPromptTokenIdsForMM or TestGetNumTokensPerAudio or TestGetNumTokensPerVideoInvariants"
   - unittest/_torch/modeling/test_modeling_llava_next.py::TestLlavaNext::test_all
   - unittest/_torch/modeling/test_modeling_llava_next.py::test_llava_next_expand_prompt_token_ids_for_mm
   - unittest/_torch/modeling/test_modeling_qwen2_5vl.py::TestQwen2_5_VL::test_all

--- a/tests/unittest/_torch/modeling/test_modeling_llava_next.py
+++ b/tests/unittest/_torch/modeling/test_modeling_llava_next.py
@@ -118,9 +118,12 @@ def test_llava_next_expand_prompt_token_ids_for_mm():
     prompt_token_ids = [1, 2, image_token_id, 3, image_token_id, 4]
     num_mm_tokens_per_placeholder = [10, 20]
 
-    expanded = input_processor.expand_prompt_token_ids_for_mm(
+    expanded, mm_data_updates = input_processor.expand_prompt_token_ids_for_mm(
         prompt_token_ids, num_mm_tokens_per_placeholder
     )
+
+    # LLaVA-Next has no auxiliary streams; mm_data_updates must be None.
+    assert mm_data_updates is None
 
     # Expected: [1, 2] + 10 * placeholder_id + [3] + 20 * placeholder_id + [4]
     expected_len = 2 + 10 + 1 + 20 + 1

--- a/tests/unittest/_torch/modeling/test_modeling_llava_next.py
+++ b/tests/unittest/_torch/modeling/test_modeling_llava_next.py
@@ -122,7 +122,7 @@ def test_llava_next_expand_prompt_token_ids_for_mm():
         prompt_token_ids, num_mm_tokens_per_placeholder
     )
 
-    # LLaVA-Next has no auxiliary streams; mm_data_updates must be None.
+    # LLaVA-Next has no auxiliary data structures like EVS IDs; mm_data_updates must be None.
     assert mm_data_updates is None
 
     # Expected: [1, 2] + 10 * placeholder_id + [3] + 20 * placeholder_id + [4]

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -999,3 +999,526 @@ class TestAudioTokenCountPrediction:
             f"ceil_length={math.ceil(audio_length * target_sr / orig_sr)}, "
             f"resampled_length={len(resampled)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tokenized+MM fast path tests
+# ---------------------------------------------------------------------------
+
+
+def _make_fast_path_processor(**overrides):
+    """Create a processor with predictable single-token special token IDs.
+
+    The default mock tokenizer returns list(range(len(text))), which makes
+    multi-char tokens map to multi-element lists.  For expansion tests we
+    override the pre-tokenized ID lists so that <img>, </img>, etc. are each
+    represented by a single, distinct integer.
+
+    We pick IDs outside the printable-ASCII `ord(c)` range (0-127) so that
+    tests which override `tokenizer.encode` with ord-based mocks (e.g. the
+    text-level fallback tests) don't produce spurious img_start/img_end IDs
+    from letters in frame separators like "Frame" (`ord('e') == 101`).
+    """
+    proc = _make_processor(**overrides)
+    # Override pre-tokenized special token ID lists to single-element lists.
+    proc._img_start_token_ids = [500]
+    proc._img_end_token_ids = [501]
+    proc._img_context_token_ids = [proc.img_context_token_id]  # 20
+    # Collapse the `<video>` placeholder to a single-ID pattern for tests so
+    # the existing single-token prompts (e.g. [1, 2, vid_ctx, 3]) still match.
+    # Real tokenizers may produce multi-token BPE for `<video>`; the
+    # TestExpandVideoPlaceholdersMultiToken suite exercises that case.
+    proc._video_placeholder_token_ids = [proc.video_context_token_id]  # 21
+    proc.image_start_token_id = 500
+    proc.image_end_token_id = 501
+    return proc
+
+
+def _make_fast_path_audio_processor(**overrides):
+    """Audio-enabled processor with predictable special token IDs."""
+    proc = _make_audio_processor(**overrides)
+    proc._img_start_token_ids = [500]
+    proc._img_end_token_ids = [501]
+    proc._video_placeholder_token_ids = [proc.video_context_token_id]
+    proc.image_start_token_id = 500
+    proc.image_end_token_id = 501
+    # Audio special token IDs.
+    proc._sound_context_token_id = 30
+    proc._sound_start_token_id = 200
+    proc._sound_end_token_id = 201
+    return proc
+
+
+class TestGetTextWithMMPlaceholders:
+    def test_single_image(self):
+        proc = _make_fast_path_processor()
+        assert proc.get_text_with_mm_placeholders({"image": 1}) == "<image>"
+
+    def test_multiple_images(self):
+        proc = _make_fast_path_processor()
+        assert proc.get_text_with_mm_placeholders({"image": 3}) == "<image><image><image>"
+
+    def test_single_video(self):
+        proc = _make_fast_path_processor()
+        assert proc.get_text_with_mm_placeholders({"video": 1}) == "<video>"
+
+    def test_single_audio(self):
+        proc = _make_fast_path_audio_processor()
+        text = proc.get_text_with_mm_placeholders({"audio": 1})
+        assert text == AUDIO_PLACEHOLDER
+
+    def test_empty(self):
+        proc = _make_fast_path_processor()
+        assert proc.get_text_with_mm_placeholders({}) == ""
+
+
+class TestExpandImagePlaceholders:
+    def test_single_image(self):
+        proc = _make_fast_path_processor()
+        img_ctx = proc.img_context_token_id  # 20
+        prompt = [1, 2, img_ctx, 3, 4]
+        # N = 12 total MM tokens: 1 (start) + 10 (context) + 1 (end)
+        expanded = proc._expand_image_placeholders_in_token_ids(prompt, [12])
+        assert expanded == [1, 2, 500] + [img_ctx] * 10 + [501, 3, 4]
+
+    def test_multiple_images(self):
+        proc = _make_fast_path_processor()
+        img_ctx = proc.img_context_token_id
+        prompt = [1, img_ctx, 2, img_ctx, 3]
+        # Two images: 7 tokens each (1 start + 5 context + 1 end)
+        expanded = proc._expand_image_placeholders_in_token_ids(prompt, [7, 7])
+        assert expanded == ([1, 500] + [img_ctx] * 5 + [501, 2, 500] + [img_ctx] * 5 + [501, 3])
+
+    def test_mismatch_more_placeholders_than_entries(self):
+        proc = _make_fast_path_processor()
+        img_ctx = proc.img_context_token_id
+        prompt = [img_ctx, img_ctx]
+        with pytest.raises(ValueError, match="More image placeholder"):
+            proc._expand_image_placeholders_in_token_ids(prompt, [5])
+
+    def test_mismatch_fewer_placeholders_than_entries(self):
+        proc = _make_fast_path_processor()
+        img_ctx = proc.img_context_token_id
+        prompt = [img_ctx]
+        with pytest.raises(ValueError, match="Expected 2 image placeholders"):
+            proc._expand_image_placeholders_in_token_ids(prompt, [5, 5])
+
+
+class TestExpandAudioPlaceholders:
+    def test_single_audio(self):
+        proc = _make_fast_path_audio_processor()
+        snd_ctx = proc._sound_context_token_id  # 30
+        prompt = [1, 2, snd_ctx, 3]
+        # N = 10 total: 1 start + 8 context + 1 end
+        expanded = proc._expand_audio_placeholders_in_token_ids(prompt, [10])
+        assert expanded == [1, 2, 200] + [snd_ctx] * 8 + [201, 3]
+
+    def test_multiple_audios(self):
+        proc = _make_fast_path_audio_processor()
+        snd_ctx = proc._sound_context_token_id
+        prompt = [snd_ctx, 5, snd_ctx]
+        expanded = proc._expand_audio_placeholders_in_token_ids(prompt, [6, 8])
+        assert expanded == ([200] + [snd_ctx] * 4 + [201, 5, 200] + [snd_ctx] * 6 + [201])
+
+    def test_mismatch_raises(self):
+        proc = _make_fast_path_audio_processor()
+        snd_ctx = proc._sound_context_token_id
+        prompt = [snd_ctx, snd_ctx]
+        with pytest.raises(ValueError, match="More audio placeholder"):
+            proc._expand_audio_placeholders_in_token_ids(prompt, [5])
+
+
+class TestExpandVideoPlaceholders:
+    @staticmethod
+    def _make_video_processor():
+        """Non-dynamic processor with video_target_num_patches for simple math."""
+        proc = _make_fast_path_processor(
+            video_target_num_patches=None,
+        )
+        # With video_target_num_patches=None, image_size=512, patch_size=16,
+        # downsample_ratio=0.5: tokens_per_frame = (512/16)^2 * 0.5^2 = 256.
+        # video_size = [num_frames, 1, 512, 512]
+        # _add_video_prefix should be True for fallback path.
+        proc._add_video_prefix = False  # disable to simplify test
+        proc.video_pruning_rate = 0
+        proc.video_temporal_patch_size = 1
+        return proc
+
+    def test_single_video_no_metadata(self):
+        proc = self._make_video_processor()
+        vid_ctx = proc.video_context_token_id  # 21
+        img_ctx = proc.img_context_token_id  # 20
+        prompt = [1, 2, vid_ctx, 3]
+        num_frames = 2
+
+        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
+        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=None)]}
+
+        # tokens_per_frame = 256, so total MM tokens per video =
+        # num_frames * (256 + 2) = 2 * 258 = 516
+        total_mm = num_frames * (256 + 2)
+
+        expanded, evs_ids = proc._expand_video_placeholders_in_token_ids(
+            prompt, [total_mm], mm_data
+        )
+
+        # No EVS -> evs_ids must be None.
+        assert evs_ids is None
+
+        # Should start with [1, 2], end with [3].
+        assert expanded[:2] == [1, 2]
+        assert expanded[-1] == 3
+
+        # Count img_context tokens: should be 2 * 256 = 512.
+        ctx_count = expanded.count(img_ctx)
+        assert ctx_count == num_frames * 256
+
+        # Count img_start tokens: should be 2 (one per frame).
+        start_count = expanded.count(500)
+        assert start_count == num_frames
+
+        # Count img_end tokens: should be 2.
+        end_count = expanded.count(501)
+        assert end_count == num_frames
+
+    def test_missing_mm_data_raises(self):
+        proc = self._make_video_processor()
+        vid_ctx = proc.video_context_token_id
+        with pytest.raises(ValueError, match="requires multi_modal_data"):
+            proc._expand_video_placeholders_in_token_ids([vid_ctx], [100], None)
+
+
+class TestExpandVideoPlaceholdersMultiToken:
+    """Exercise the realistic case where `<video>` BPE-decomposes into multiple
+    tokens (e.g. [1060, 24073, 1062] for the Nemotron Nano tokenizer). This is
+    what production hits — `<video>` is typically NOT registered as an added
+    special token, so `video_context_token_id` is never what the tokenizer
+    produces from the user's prompt text."""
+
+    @staticmethod
+    def _make_video_processor_multi_token():
+        proc = _make_fast_path_processor(video_target_num_patches=None)
+        proc._add_video_prefix = False
+        proc.video_pruning_rate = 0
+        proc.video_temporal_patch_size = 1
+        # Simulate realistic BPE decomposition: "<video>" -> three tokens.
+        proc._video_placeholder_token_ids = [1060, 24073, 1062]
+        return proc
+
+    def test_single_video_multi_token_pattern(self):
+        proc = self._make_video_processor_multi_token()
+        pattern = proc._video_placeholder_token_ids  # [1060, 24073, 1062]
+        img_ctx = proc.img_context_token_id
+
+        # prompt: [text..., <video>, text...] where <video> is a 3-token subseq
+        prompt = [1, 2, *pattern, 3]
+        num_frames = 2
+        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
+        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=None)]}
+        total_mm = num_frames * (256 + 2)
+
+        expanded, evs_ids = proc._expand_video_placeholders_in_token_ids(
+            prompt, [total_mm], mm_data
+        )
+        # No EVS -> no evs_ids.
+        assert evs_ids is None
+
+        # Leading / trailing text survives; the 3-token pattern is consumed.
+        assert expanded[:2] == [1, 2]
+        assert expanded[-1] == 3
+        # Pattern tokens must no longer appear as a contiguous subsequence.
+        found_pattern = any(
+            expanded[i : i + len(pattern)] == pattern
+            for i in range(len(expanded) - len(pattern) + 1)
+        )
+        assert not found_pattern, "Pattern should have been replaced; found leftover <video> subseq"
+        # Same MM token counts as the single-ID case.
+        assert expanded.count(img_ctx) == num_frames * 256
+        assert expanded.count(500) == num_frames  # img_start
+        assert expanded.count(501) == num_frames  # img_end
+
+    def test_text_level_fallback_when_bpe_merges_trailing_context(self):
+        """Simulate the production scenario: `<video>` tokenizes to one pattern
+        in isolation (e.g. [1060, 24073, 1062]) but the tokens in the actual
+        prompt end with a DIFFERENT ID (e.g. [1060, 24073, 3318]) because BPE
+        merged `>` with the following newline/whitespace. Token-level match
+        fails; the text-level fallback must still succeed."""
+        proc = self._make_video_processor_multi_token()
+        img_ctx = proc.img_context_token_id
+
+        # Patch the mock tokenizer to (a) decode back to a text that contains
+        # `<video>` and (b) re-encode that text stably. We simulate a tokenizer
+        # that produces [1060, 24073, 3318] in context but splits <video> into
+        # [1060, 24073, 1062] in isolation.
+        def mock_decode(ids, **kw):
+            # Deterministic: represent any ID as its string form, and emit the
+            # literal string "<video>" whenever we see the "in-context" trio.
+            text_parts = []
+            i = 0
+            while i < len(ids):
+                if ids[i : i + 3] == [1060, 24073, 3318]:
+                    text_parts.append("<video>\n")
+                    i += 3
+                else:
+                    text_parts.append(f"T{ids[i]} ")
+                    i += 1
+            return "".join(text_parts)
+
+        def mock_encode(text, **kw):
+            # Our test prompt decodes to "T1 T2 <video>\nT3 "; we re-encode by
+            # splitting on `<video>` and emitting a marker per token.
+            if kw.get("return_tensors") == "pt":
+                return torch.tensor(list(range(len(text)))).unsqueeze(0)
+            return [ord(c) % 1000 for c in text]
+
+        proc.tokenizer.decode = mock_decode
+        proc.tokenizer.encode = mock_encode
+
+        # Prompt contains the "in-context" BPE tokenization [1060, 24073, 3318],
+        # NOT the "isolation" pattern [1060, 24073, 1062]. Token-level match
+        # fails; text-level fallback must kick in.
+        prompt = [1, 2, 1060, 24073, 3318, 3]
+        num_frames = 2
+        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
+        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=None)]}
+        total_mm = num_frames * (256 + 2)
+
+        expanded, evs_ids = proc._expand_video_placeholders_in_token_ids(
+            prompt, [total_mm], mm_data
+        )
+        # Still no EVS -> evs_ids must be None.
+        assert evs_ids is None
+
+        # MM token counts should match, regardless of which tier matched.
+        assert expanded.count(img_ctx) == num_frames * 256
+        assert expanded.count(500) == num_frames  # img_start
+        assert expanded.count(501) == num_frames  # img_end
+
+    def test_fallback_count_mismatch_raises(self):
+        """If the decoded text has a different number of `<video>` occurrences
+        than `mm_data["video"]`, the fallback must raise a clear error."""
+        proc = self._make_video_processor_multi_token()
+        # Decoded text has zero `<video>` substrings.
+        proc.tokenizer.decode = lambda ids, **kw: "no placeholder here"
+        prompt = [1, 2, 3, 4]
+        frames = [Image.new("RGB", (512, 512)) for _ in range(2)]
+        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=None)]}
+        with pytest.raises(ValueError, match="contains 0 '<video>' placeholders"):
+            proc._expand_video_placeholders_in_token_ids(prompt, [516], mm_data)
+
+
+class TestExpandVideoPlaceholdersEVS:
+    """Tests for the EVS (video pruning) path in the tokenized+MM fast path.
+
+    Mirrors the non-fast-path behavior in `_process_video_prompts`: when
+    `video_pruning_rate > 0`, `_expand_video_placeholders_in_token_ids`
+    returns a tuple `(expanded_ids, evs_ids_tensor)` where `evs_ids_tensor`
+    has one `video_context_token_id` per tubelet (wrapped with
+    `<img>`/`</img>`), to be consumed by `merge_evs_mm_embeds` at forward
+    time.
+    """
+
+    @staticmethod
+    def _make_evs_video_processor():
+        """Video processor with EVS enabled and a mocked
+        `_compute_token_numbers_per_video` so tests don't depend on the
+        full EVS retention-count math."""
+        proc = _make_fast_path_processor(video_target_num_patches=None)
+        proc._add_video_prefix = False
+        proc.video_pruning_rate = 0.5
+        proc.video_temporal_patch_size = 1
+        # Pretend EVS will pre-budget 100 tokens to the first tubelet and 0
+        # to the rest (this is the dummy shape the non-fast-path also uses).
+        proc._compute_token_numbers_per_video = mock.Mock(return_value=[[100, 0, 0]])
+        return proc
+
+    def test_evs_token_level_returns_evs_ids_tensor(self):
+        """Token-level match path: the `<video>` subsequence is present in
+        `prompt_token_ids`, both `expanded_ids` and `evs_ids` tensors are
+        produced in parallel."""
+        proc = self._make_evs_video_processor()
+        vid_ctx = proc.video_context_token_id  # 21 (single-ID in tests)
+        img_ctx = proc.img_context_token_id  # 20
+        num_frames = 3
+        total_mm = 100 + 2 * num_frames  # 100 feature tokens + start/end per tubelet
+
+        prompt = [1, 2, vid_ctx, 3]
+        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
+        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=None)]}
+
+        expanded, evs_ids = proc._expand_video_placeholders_in_token_ids(
+            prompt, [total_mm], mm_data
+        )
+
+        assert evs_ids is not None
+        assert isinstance(evs_ids, torch.Tensor)
+        assert evs_ids.dtype == torch.long
+
+        # expanded: 100 img_context tokens in tubelet 1, 0 in tubelets 2/3,
+        # plus img_start/end per tubelet.
+        assert expanded.count(img_ctx) == 100
+        assert expanded.count(500) == num_frames  # img_start per tubelet
+        assert expanded.count(501) == num_frames  # img_end per tubelet
+        # Surrounding non-MM tokens preserved at head/tail.
+        assert expanded[:2] == [1, 2]
+        assert expanded[-1] == 3
+
+        # evs_ids: one video_context_token_id per tubelet (3 total),
+        # each still wrapped with img_start/end; surrounding text identical.
+        evs_list = evs_ids.tolist()
+        assert evs_list.count(vid_ctx) == num_frames
+        assert evs_list.count(500) == num_frames  # img_start
+        assert evs_list.count(501) == num_frames  # img_end
+        # evs_ids must have NO img_context_token_id (by design — merge_evs
+        # substitutes retained counts at forward time).
+        assert img_ctx not in evs_list
+        # Surrounding prompt tokens preserved in evs_ids too.
+        assert evs_list[:2] == [1, 2]
+        assert evs_list[-1] == 3
+
+    def test_evs_text_level_fallback(self):
+        """Text-level fallback path under EVS: `<video>` is absent from the
+        token stream (BPE boundary merged), decode/split/re-encode kicks in
+        and must still produce both streams."""
+        proc = self._make_evs_video_processor()
+        # Force a multi-token pattern that is NOT present in the real prompt,
+        # so Tier 1 fails and we fall through to Tier 2.
+        proc._video_placeholder_token_ids = [1060, 24073, 1062]
+
+        # Mock decode/encode to simulate the BPE-merged reality.
+        def mock_decode(ids, **kw):
+            parts = []
+            i = 0
+            while i < len(ids):
+                if ids[i : i + 3] == [1060, 24073, 3318]:
+                    parts.append("<video>\n")
+                    i += 3
+                else:
+                    parts.append(f"T{ids[i]} ")
+                    i += 1
+            return "".join(parts)
+
+        def mock_encode(text, **kw):
+            if kw.get("return_tensors") == "pt":
+                return torch.tensor(list(range(len(text)))).unsqueeze(0)
+            return [ord(c) % 1000 for c in text]
+
+        proc.tokenizer.decode = mock_decode
+        proc.tokenizer.encode = mock_encode
+
+        vid_ctx = proc.video_context_token_id  # 21
+        img_ctx = proc.img_context_token_id  # 20
+        num_frames = 3
+
+        # Prompt uses the "in-context" pattern (3318), not the "isolation"
+        # pattern (1062) -> Tier 1 bails, Tier 2 handles it.
+        prompt = [1, 2, 1060, 24073, 3318, 3]
+        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
+        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=None)]}
+        total_mm = 100 + 2 * num_frames
+
+        expanded, evs_ids = proc._expand_video_placeholders_in_token_ids(
+            prompt, [total_mm], mm_data
+        )
+
+        assert evs_ids is not None
+        assert isinstance(evs_ids, torch.Tensor)
+
+        # MM counts in both streams must match the EVS-dummy shape.
+        assert expanded.count(img_ctx) == 100
+        assert expanded.count(500) == num_frames  # img_start
+        assert expanded.count(501) == num_frames  # img_end
+
+        evs_list = evs_ids.tolist()
+        assert evs_list.count(vid_ctx) == num_frames
+        assert evs_list.count(500) == num_frames  # img_start
+        assert evs_list.count(501) == num_frames  # img_end
+        assert img_ctx not in evs_list
+
+    def test_dispatch_returns_evs_ids_in_mm_data_updates(self):
+        """Integration test: with EVS on, the dispatch-level
+        `expand_prompt_token_ids_for_mm` packages the evs_ids tensor into
+        `{"video": {"evs_ids": tensor}}` in the second slot of the tuple."""
+        proc = self._make_evs_video_processor()
+        vid_ctx = proc.video_context_token_id
+        num_frames = 2
+        prompt = [1, vid_ctx, 2]
+        # Override mock for 2-frame video.
+        proc._compute_token_numbers_per_video = mock.Mock(return_value=[[50, 0]])
+        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
+        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=None)]}
+        total_mm = 50 + 2 * num_frames
+
+        expanded, mm_data_updates = proc.expand_prompt_token_ids_for_mm(
+            prompt,
+            [total_mm],
+            hf_processor_mm_kwargs={"_multi_modal_data": mm_data},
+        )
+
+        assert mm_data_updates is not None
+        assert "video" in mm_data_updates
+        assert "evs_ids" in mm_data_updates["video"]
+        evs_tensor = mm_data_updates["video"]["evs_ids"]
+        assert isinstance(evs_tensor, torch.Tensor)
+        assert evs_tensor.dtype == torch.long
+        # Expect `num_frames` video_context placeholders in evs_ids.
+        assert (evs_tensor == vid_ctx).sum().item() == num_frames
+
+
+class TestExpandPromptTokenIdsForMM:
+    """Integration tests for the top-level dispatch method."""
+
+    def test_dispatches_to_image(self):
+        proc = _make_fast_path_processor()
+        img_ctx = proc.img_context_token_id
+        prompt = [1, img_ctx, 2]
+        result, mm_data_updates = proc.expand_prompt_token_ids_for_mm(prompt, [5])
+        assert mm_data_updates is None
+        assert 500 in result  # img_start_token_id
+        assert 501 in result  # img_end_token_id
+
+    def test_dispatches_to_audio(self):
+        proc = _make_fast_path_audio_processor()
+        snd_ctx = proc._sound_context_token_id
+        prompt = [1, snd_ctx, 2]
+        result, mm_data_updates = proc.expand_prompt_token_ids_for_mm(prompt, [5])
+        assert mm_data_updates is None
+        assert 200 in result  # sound_start_token_id
+        assert 201 in result  # sound_end_token_id
+
+    def test_no_placeholders_returns_unchanged(self):
+        proc = _make_fast_path_processor()
+        prompt = [1, 2, 3, 4]
+        result, mm_data_updates = proc.expand_prompt_token_ids_for_mm(prompt, [])
+        assert mm_data_updates is None
+        assert result == prompt
+
+    def test_multiple_modalities_raises(self):
+        proc = _make_fast_path_audio_processor()
+        img_ctx = proc.img_context_token_id
+        snd_ctx = proc._sound_context_token_id
+        prompt = [img_ctx, snd_ctx]
+        with pytest.raises(ValueError, match="multiple modalities"):
+            proc.expand_prompt_token_ids_for_mm(prompt, [5, 5])
+
+
+class TestGetNumTokensPerAudio:
+    def test_bare_array(self):
+        proc = _make_audio_processor()
+        audio = np.random.randn(16000).astype(np.float32)
+        n = proc.get_num_tokens_per_audio(audio=audio)
+        expected = proc._audio_extractor.audio_token_count(16000) + 2
+        assert n == expected
+
+    def test_tuple_with_matching_sample_rate(self):
+        proc = _make_audio_processor()
+        sr = proc._audio_extractor.sampling_rate
+        audio = np.random.randn(16000).astype(np.float32)
+        n = proc.get_num_tokens_per_audio(audio=(audio, sr))
+        expected = proc._audio_extractor.audio_token_count(16000) + 2
+        assert n == expected
+
+    def test_no_audio_config_raises(self):
+        proc = _make_processor()  # No sound_config
+        with pytest.raises(ValueError, match="sound_config"):
+            proc.get_num_tokens_per_audio(audio=np.zeros(100))

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -1016,7 +1016,7 @@ def _make_fast_path_processor(**overrides):
 
     We pick IDs outside the printable-ASCII `ord(c)` range (0-127) so that
     tests which override `tokenizer.encode` with ord-based mocks (e.g. the
-    text-level fallback tests) don't produce spurious img_start/img_end IDs
+    text-level path tests) don't produce spurious img_start/img_end IDs
     from letters in frame separators like "Frame" (`ord('e') == 101`).
     """
     proc = _make_processor(**overrides)
@@ -1050,82 +1050,91 @@ def _make_fast_path_audio_processor(**overrides):
 
 
 class TestGetTextWithMMPlaceholders:
-    def test_single_image(self):
+    @pytest.mark.parametrize(
+        "mm_counts, expected",
+        [
+            pytest.param({"image": 1}, "<image>", id="single_image"),
+            pytest.param({"image": 3}, "<image><image><image>", id="multiple_images"),
+            pytest.param({"video": 1}, "<video>", id="single_video"),
+            pytest.param({}, "", id="empty"),
+        ],
+    )
+    def test_image_video_and_empty(self, mm_counts, expected):
         proc = _make_fast_path_processor()
-        assert proc.get_text_with_mm_placeholders({"image": 1}) == "<image>"
-
-    def test_multiple_images(self):
-        proc = _make_fast_path_processor()
-        assert proc.get_text_with_mm_placeholders({"image": 3}) == "<image><image><image>"
-
-    def test_single_video(self):
-        proc = _make_fast_path_processor()
-        assert proc.get_text_with_mm_placeholders({"video": 1}) == "<video>"
+        assert proc.get_text_with_mm_placeholders(mm_counts) == expected
 
     def test_single_audio(self):
+        # Kept separate: audio requires `_make_fast_path_audio_processor` (a
+        # different factory that wires up `sound_config`).
         proc = _make_fast_path_audio_processor()
-        text = proc.get_text_with_mm_placeholders({"audio": 1})
-        assert text == AUDIO_PLACEHOLDER
-
-    def test_empty(self):
-        proc = _make_fast_path_processor()
-        assert proc.get_text_with_mm_placeholders({}) == ""
+        assert proc.get_text_with_mm_placeholders({"audio": 1}) == AUDIO_PLACEHOLDER
 
 
 class TestExpandImagePlaceholders:
-    def test_single_image(self):
+    # Placeholder IDs are referenced as literals (20=img_ctx, 500/501=start/end)
+    # to keep the parametrize tables readable. See `_make_fast_path_processor`.
+    @pytest.mark.parametrize(
+        "prompt, num_mm_tokens, expected",
+        [
+            pytest.param(
+                [1, 2, 20, 3, 4],
+                [12],  # 1 (start) + 10 (context) + 1 (end)
+                [1, 2, 500] + [20] * 10 + [501, 3, 4],
+                id="single_image",
+            ),
+            pytest.param(
+                [1, 20, 2, 20, 3],
+                [7, 7],  # each: 1 start + 5 context + 1 end
+                [1, 500] + [20] * 5 + [501, 2, 500] + [20] * 5 + [501, 3],
+                id="multiple_images",
+            ),
+        ],
+    )
+    def test_happy_path(self, prompt, num_mm_tokens, expected):
         proc = _make_fast_path_processor()
-        img_ctx = proc.img_context_token_id  # 20
-        prompt = [1, 2, img_ctx, 3, 4]
-        # N = 12 total MM tokens: 1 (start) + 10 (context) + 1 (end)
-        expanded = proc._expand_image_placeholders_in_token_ids(prompt, [12])
-        assert expanded == [1, 2, 500] + [img_ctx] * 10 + [501, 3, 4]
+        assert proc._expand_image_placeholders_in_token_ids(prompt, num_mm_tokens) == expected
 
-    def test_multiple_images(self):
+    @pytest.mark.parametrize(
+        "prompt, num_mm_tokens, match",
+        [
+            pytest.param([20, 20], [5], "More image placeholder", id="more_placeholders"),
+            pytest.param([20], [5, 5], "Expected 2 image placeholders", id="fewer_placeholders"),
+        ],
+    )
+    def test_mismatch_raises(self, prompt, num_mm_tokens, match):
         proc = _make_fast_path_processor()
-        img_ctx = proc.img_context_token_id
-        prompt = [1, img_ctx, 2, img_ctx, 3]
-        # Two images: 7 tokens each (1 start + 5 context + 1 end)
-        expanded = proc._expand_image_placeholders_in_token_ids(prompt, [7, 7])
-        assert expanded == ([1, 500] + [img_ctx] * 5 + [501, 2, 500] + [img_ctx] * 5 + [501, 3])
-
-    def test_mismatch_more_placeholders_than_entries(self):
-        proc = _make_fast_path_processor()
-        img_ctx = proc.img_context_token_id
-        prompt = [img_ctx, img_ctx]
-        with pytest.raises(ValueError, match="More image placeholder"):
-            proc._expand_image_placeholders_in_token_ids(prompt, [5])
-
-    def test_mismatch_fewer_placeholders_than_entries(self):
-        proc = _make_fast_path_processor()
-        img_ctx = proc.img_context_token_id
-        prompt = [img_ctx]
-        with pytest.raises(ValueError, match="Expected 2 image placeholders"):
-            proc._expand_image_placeholders_in_token_ids(prompt, [5, 5])
+        with pytest.raises(ValueError, match=match):
+            proc._expand_image_placeholders_in_token_ids(prompt, num_mm_tokens)
 
 
 class TestExpandAudioPlaceholders:
-    def test_single_audio(self):
+    # Literals: 30=snd_ctx, 200/201=sound_start/end. See `_make_fast_path_audio_processor`.
+    @pytest.mark.parametrize(
+        "prompt, num_mm_tokens, expected",
+        [
+            pytest.param(
+                [1, 2, 30, 3],
+                [10],  # 1 start + 8 context + 1 end
+                [1, 2, 200] + [30] * 8 + [201, 3],
+                id="single_audio",
+            ),
+            pytest.param(
+                [30, 5, 30],
+                [6, 8],
+                [200] + [30] * 4 + [201, 5, 200] + [30] * 6 + [201],
+                id="multiple_audios",
+            ),
+        ],
+    )
+    def test_happy_path(self, prompt, num_mm_tokens, expected):
         proc = _make_fast_path_audio_processor()
-        snd_ctx = proc._sound_context_token_id  # 30
-        prompt = [1, 2, snd_ctx, 3]
-        # N = 10 total: 1 start + 8 context + 1 end
-        expanded = proc._expand_audio_placeholders_in_token_ids(prompt, [10])
-        assert expanded == [1, 2, 200] + [snd_ctx] * 8 + [201, 3]
-
-    def test_multiple_audios(self):
-        proc = _make_fast_path_audio_processor()
-        snd_ctx = proc._sound_context_token_id
-        prompt = [snd_ctx, 5, snd_ctx]
-        expanded = proc._expand_audio_placeholders_in_token_ids(prompt, [6, 8])
-        assert expanded == ([200] + [snd_ctx] * 4 + [201, 5, 200] + [snd_ctx] * 6 + [201])
+        assert proc._expand_audio_placeholders_in_token_ids(prompt, num_mm_tokens) == expected
 
     def test_mismatch_raises(self):
         proc = _make_fast_path_audio_processor()
         snd_ctx = proc._sound_context_token_id
-        prompt = [snd_ctx, snd_ctx]
         with pytest.raises(ValueError, match="More audio placeholder"):
-            proc._expand_audio_placeholders_in_token_ids(prompt, [5])
+            proc._expand_audio_placeholders_in_token_ids([snd_ctx, snd_ctx], [5])
 
 
 class TestExpandVideoPlaceholders:
@@ -1193,7 +1202,12 @@ class TestExpandVideoPlaceholdersMultiToken:
     tokens (e.g. [1060, 24073, 1062] for the Nemotron Nano tokenizer). This is
     what production hits — `<video>` is typically NOT registered as an added
     special token, so `video_context_token_id` is never what the tokenizer
-    produces from the user's prompt text."""
+    produces from the user's prompt text.
+
+    With length-based dispatch, `len(_video_placeholder_token_ids) > 1` always
+    goes through the text-level (decode/split/re-encode) path — token-level
+    matching is unreliable here because BPE can merge the placeholder's last
+    token with the following character."""
 
     @staticmethod
     def _make_video_processor_multi_token():
@@ -1205,44 +1219,13 @@ class TestExpandVideoPlaceholdersMultiToken:
         proc._video_placeholder_token_ids = [1060, 24073, 1062]
         return proc
 
-    def test_single_video_multi_token_pattern(self):
-        proc = self._make_video_processor_multi_token()
-        pattern = proc._video_placeholder_token_ids  # [1060, 24073, 1062]
-        img_ctx = proc.img_context_token_id
-
-        # prompt: [text..., <video>, text...] where <video> is a 3-token subseq
-        prompt = [1, 2, *pattern, 3]
-        num_frames = 2
-        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
-        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=None)]}
-        total_mm = num_frames * (256 + 2)
-
-        expanded, evs_ids = proc._expand_video_placeholders_in_token_ids(
-            prompt, [total_mm], mm_data
-        )
-        # No EVS -> no evs_ids.
-        assert evs_ids is None
-
-        # Leading / trailing text survives; the 3-token pattern is consumed.
-        assert expanded[:2] == [1, 2]
-        assert expanded[-1] == 3
-        # Pattern tokens must no longer appear as a contiguous subsequence.
-        found_pattern = any(
-            expanded[i : i + len(pattern)] == pattern
-            for i in range(len(expanded) - len(pattern) + 1)
-        )
-        assert not found_pattern, "Pattern should have been replaced; found leftover <video> subseq"
-        # Same MM token counts as the single-ID case.
-        assert expanded.count(img_ctx) == num_frames * 256
-        assert expanded.count(500) == num_frames  # img_start
-        assert expanded.count(501) == num_frames  # img_end
-
-    def test_text_level_fallback_when_bpe_merges_trailing_context(self):
+    def test_text_level_path_when_bpe_merges_trailing_context(self):
         """Simulate the production scenario: `<video>` tokenizes to one pattern
         in isolation (e.g. [1060, 24073, 1062]) but the tokens in the actual
         prompt end with a DIFFERENT ID (e.g. [1060, 24073, 3318]) because BPE
-        merged `>` with the following newline/whitespace. Token-level match
-        fails; the text-level fallback must still succeed."""
+        merged `>` with the following newline/whitespace. The text-level path
+        must handle this correctly (length-based dispatch routes all multi-
+        token placeholders here)."""
         proc = self._make_video_processor_multi_token()
         img_ctx = proc.img_context_token_id
 
@@ -1275,8 +1258,8 @@ class TestExpandVideoPlaceholdersMultiToken:
         proc.tokenizer.encode = mock_encode
 
         # Prompt contains the "in-context" BPE tokenization [1060, 24073, 3318],
-        # NOT the "isolation" pattern [1060, 24073, 1062]. Token-level match
-        # fails; text-level fallback must kick in.
+        # NOT the "isolation" pattern [1060, 24073, 1062]. Length-based
+        # dispatch (len > 1) routes through the text-level path regardless.
         prompt = [1, 2, 1060, 24073, 3318, 3]
         num_frames = 2
         frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
@@ -1289,14 +1272,14 @@ class TestExpandVideoPlaceholdersMultiToken:
         # Still no EVS -> evs_ids must be None.
         assert evs_ids is None
 
-        # MM token counts should match, regardless of which tier matched.
+        # MM token counts should match.
         assert expanded.count(img_ctx) == num_frames * 256
         assert expanded.count(500) == num_frames  # img_start
         assert expanded.count(501) == num_frames  # img_end
 
-    def test_fallback_count_mismatch_raises(self):
+    def test_text_level_count_mismatch_raises(self):
         """If the decoded text has a different number of `<video>` occurrences
-        than `mm_data["video"]`, the fallback must raise a clear error."""
+        than `mm_data["video"]`, the text-level path must raise a clear error."""
         proc = self._make_video_processor_multi_token()
         # Decoded text has zero `<video>` substrings.
         proc.tokenizer.decode = lambda ids, **kw: "no placeholder here"
@@ -1376,13 +1359,12 @@ class TestExpandVideoPlaceholdersEVS:
         assert evs_list[:2] == [1, 2]
         assert evs_list[-1] == 3
 
-    def test_evs_text_level_fallback(self):
-        """Text-level fallback path under EVS: `<video>` is absent from the
-        token stream (BPE boundary merged), decode/split/re-encode kicks in
-        and must still produce both streams."""
+    def test_evs_text_level_path(self):
+        """Text-level path under EVS: multi-token `<video>` placeholder
+        dispatches to decode/split/re-encode, which must still produce both
+        streams in parallel."""
         proc = self._make_evs_video_processor()
-        # Force a multi-token pattern that is NOT present in the real prompt,
-        # so Tier 1 fails and we fall through to Tier 2.
+        # Multi-token pattern -> dispatch routes through the text-level path.
         proc._video_placeholder_token_ids = [1060, 24073, 1062]
 
         # Mock decode/encode to simulate the BPE-merged reality.
@@ -1411,7 +1393,8 @@ class TestExpandVideoPlaceholdersEVS:
         num_frames = 3
 
         # Prompt uses the "in-context" pattern (3318), not the "isolation"
-        # pattern (1062) -> Tier 1 bails, Tier 2 handles it.
+        # pattern (1062). Length-based dispatch (len > 1) routes through
+        # the text-level path unconditionally.
         prompt = [1, 2, 1060, 24073, 3318, 3]
         frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
         mm_data = {"video": [SimpleNamespace(frames=frames, metadata=None)]}
@@ -1503,23 +1486,26 @@ class TestExpandPromptTokenIdsForMM:
 
 
 class TestGetNumTokensPerAudio:
-    def test_bare_array(self):
+    @pytest.mark.parametrize(
+        "wrap_with_sample_rate",
+        [
+            pytest.param(False, id="bare_array"),
+            pytest.param(True, id="tuple_with_matching_sample_rate"),
+        ],
+    )
+    def test_bare_array_and_sample_rate_tuple(self, wrap_with_sample_rate):
         proc = _make_audio_processor()
         audio = np.random.randn(16000).astype(np.float32)
-        n = proc.get_num_tokens_per_audio(audio=audio)
+        audio_input = (
+            (audio, proc._audio_extractor.sampling_rate) if wrap_with_sample_rate else audio
+        )
         expected = proc._audio_extractor.audio_token_count(16000) + 2
-        assert n == expected
-
-    def test_tuple_with_matching_sample_rate(self):
-        proc = _make_audio_processor()
-        sr = proc._audio_extractor.sampling_rate
-        audio = np.random.randn(16000).astype(np.float32)
-        n = proc.get_num_tokens_per_audio(audio=(audio, sr))
-        expected = proc._audio_extractor.audio_token_count(16000) + 2
-        assert n == expected
+        assert proc.get_num_tokens_per_audio(audio=audio_input) == expected
 
     def test_no_audio_config_raises(self):
-        proc = _make_processor()  # No sound_config
+        # Kept separate: uses `_make_processor` (no sound_config) — fundamentally
+        # different setup from the happy-path cases above.
+        proc = _make_processor()
         with pytest.raises(ValueError, match="sound_config"):
             proc.get_num_tokens_per_audio(audio=np.zeros(100))
 
@@ -1571,7 +1557,7 @@ class TestGetNumTokensPerVideoInvariants:
         w, h = frame_dims
         frames = [Image.new("RGB", (w, h)) for _ in range(num_frames)]
 
-        video_size = proc._compute_video_size_lightweight(frames)
+        video_size = proc._compute_video_shape_descriptor(frames)
         per_tubelet = proc._compute_token_numbers_per_video([video_size])[0]
         num_tubelets = len(per_tubelet)
         # `get_num_tokens_per_video` hardcodes

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -23,7 +23,7 @@ from tensorrt_llm._torch.models.modeling_nemotron_nano import (
     get_video_target_size_and_feature_size,
     video_to_pixel_values,
 )
-from tensorrt_llm.inputs.multimodal import MultimodalParams
+from tensorrt_llm.inputs.multimodal import MultimodalParams, find_mm_token_positions
 
 
 def make_tiler(**overrides):
@@ -249,6 +249,19 @@ def _make_nano_processor(*, sound_config, **overrides):
     proc._img_end_token_ids = [501]
     proc.image_start_token_id = 500
     proc.image_end_token_id = 501
+
+    # When sound_config is None, the constructor still runs
+    # `self._sound_context_token_id = getattr(config, "sound_context_token_id", None)`
+    # against the Mock config, which returns a Mock instead of None. That
+    # would later sneak into get_mm_token_ids / get_mm_special_token_ids and
+    # raise "Mock object cannot be interpreted as an integer" inside
+    # torch.tensor. Force the audio attributes to None to match the real
+    # no-audio case. (When sound_config is provided, __init__ overwrites
+    # these from the tokenizer, so the audio path is unaffected.)
+    if sound_config is None:
+        proc._sound_context_token_id = None
+        proc._sound_start_token_id = None
+        proc._sound_end_token_id = None
 
     return proc
 
@@ -1588,6 +1601,85 @@ class TestGetNumTokensPerVideoInvariants:
             f"maintain_aspect_ratio={maintain_aspect_ratio}, "
             f"frame_dims={frame_dims})"
         )
+
+
+class TestMultiTokenWrappersConsistency:
+    """End-to-end regression for multi-token BPE wrappers (`<img>`, `</img>`).
+
+    `get_num_tokens_per_image` adds `len(_img_start_token_ids) +
+    len(_img_end_token_ids)` so multi-token BPE wrappers are correctly counted.
+    For that count to line up at the assertion in `find_mm_token_positions`
+    (`len(mm_positions) == sum(num_mm_tokens)`), `get_mm_special_token_ids`
+    must include **every** ID in those wrapper lists — not just the [0]
+    aliases. Otherwise trailing wrapper tokens are seen as plain text and the
+    counts diverge.
+    """
+
+    @staticmethod
+    def _make_multi_token_wrapper_processor():
+        """Processor whose <img>/</img> tokenize to multi-element BPE lists.
+
+        Real production tokenizers usually register these as single added
+        special tokens, but this exercises the BPE-fallback case the class
+        explicitly accounts for in __init__ ("These may be multi-token under
+        BPE, so we store the full ID list.").
+        """
+        proc = _make_processor()
+        # Multi-token BPE encodings — chosen to be distinct from
+        # img_context_token_id (20), video_context_token_id (21), and any
+        # plausible mock-tokenizer text-encoding range.
+        proc._img_start_token_ids = [9100, 9101, 9102]
+        proc._img_end_token_ids = [9200, 9201]
+        proc.image_start_token_id = proc._img_start_token_ids[0]
+        proc.image_end_token_id = proc._img_end_token_ids[0]
+        return proc
+
+    def test_get_mm_special_token_ids_includes_all_wrapper_tokens(self):
+        proc = self._make_multi_token_wrapper_processor()
+        special_ids = set(proc.get_mm_special_token_ids().tolist())
+        # Every BPE token in the wrapper lists must be present.
+        for tok in proc._img_start_token_ids + proc._img_end_token_ids:
+            assert tok in special_ids, (
+                f"get_mm_special_token_ids missing wrapper token {tok}; "
+                f"returned={sorted(special_ids)}"
+            )
+        # The single-ID alias is no longer authoritative on its own, but it
+        # must remain present (it's a member of the full list anyway).
+        assert proc.image_start_token_id in special_ids
+        assert proc.image_end_token_id in special_ids
+
+    def test_find_mm_token_positions_matches_get_num_tokens_per_image(self):
+        """End-to-end invariant: with multi-token wrappers, the count
+        reported by get_num_tokens_per_image must equal the number of mm
+        positions find_mm_token_positions extracts from the expanded prompt.
+        Before the get_mm_special_token_ids fix, only the first BPE token of
+        each wrapper was masked as special and this assertion was off by
+        `(len(start) - 1) + (len(end) - 1)` per image."""
+        proc = self._make_multi_token_wrapper_processor()
+        img_ctx = proc.img_context_token_id  # 20
+
+        # Build a single-image prompt: [text..., <image>, text...]
+        prompt = [1, 2, img_ctx, 3]
+
+        # Use the real per-image count (includes feature tokens + wrappers).
+        num_per_image = proc.get_num_tokens_per_image(image=Image.new("RGB", (320, 320)))
+        expanded = proc._expand_image_placeholders_in_token_ids(prompt, [num_per_image])
+
+        # Mirror the fast path's call to find_mm_token_positions.
+        start_positions, _ = find_mm_token_positions(
+            input_ids=expanded,
+            num_mm_tokens=[num_per_image],
+            mm_token_ids=proc.get_mm_token_ids(),
+            mm_special_token_ids=proc.get_mm_special_token_ids(),
+        )
+
+        # find_mm_token_positions internally asserts
+        #   len(mm_positions) == sum(num_mm_tokens)
+        # so reaching here without an exception is the regression check. Also
+        # sanity-check the start position lands at the expected offset.
+        assert len(start_positions) == 1
+        # The image expansion starts after the two leading prompt tokens.
+        assert start_positions[0] == 2
 
 
 @pytest.mark.skipif(not importlib.util.find_spec("librosa"), reason="librosa not installed")

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -236,6 +236,20 @@ def _make_nano_processor(*, sound_config, **overrides):
             tokenizer=tokenizer,
         )
 
+    # Default the start/end wrapper ID lists to single-element lists.
+    # Real production tokenizers register <img>/</img> as added special tokens
+    # with single IDs, so this matches reality. Without the override, the
+    # mock tokenizer's `list(range(len(text)))` encoding yields multi-token
+    # IDs (5 for "<img>", 6 for "</img>") which leak into
+    # `get_num_tokens_per_image`'s `+= len(start) + len(end)` accounting and
+    # break tests that pre-date the multi-token wrapper fix. Test classes that
+    # specifically exercise multi-token wrappers can still override these
+    # attributes after construction.
+    proc._img_start_token_ids = [500]
+    proc._img_end_token_ids = [501]
+    proc.image_start_token_id = 500
+    proc.image_end_token_id = 501
+
     return proc
 
 
@@ -1574,3 +1588,205 @@ class TestGetNumTokensPerVideoInvariants:
             f"maintain_aspect_ratio={maintain_aspect_ratio}, "
             f"frame_dims={frame_dims})"
         )
+
+
+@pytest.mark.skipif(not importlib.util.find_spec("librosa"), reason="librosa not installed")
+class TestFastPathVideoWithExtractedAudio:
+    """Fast-path-only tests for handling audio extracted from video.
+
+    These exercise the tokenized+MM fast path
+    (`_expand_video_placeholders_in_token_ids` and the `video_metadata` kwarg of
+    `get_num_tokens_per_video`). The slow text path (`_extract_audio_from_video`
+    -> `_prepare_audio_features` -> `_expand_audio_placeholders`) is covered by
+    `TestAudioInputProcessor`.
+
+    When `--media_io_kwargs '{"video": {"extract_audio": true}}'` is set, the
+    video loader stashes audio samples under `VideoData.metadata["audio_samples"]`.
+    The fast-path video branch must append `<so_start><so_embedding>*M<so_end>`
+    after the per-video frame tokens so the prompt has placeholder slots for the
+    audio embeddings produced by `_interleave_video_audio_embeddings` at forward
+    time. `get_num_tokens_per_video` must include those tokens in its count so
+    `find_mm_token_lengths` reports a total that matches the actual mm-token
+    count in the tokenized prompt (otherwise `find_mm_token_positions` asserts
+    `sum(num_mm_tokens) == len(mm_positions)` and the request fails).
+    """
+
+    @staticmethod
+    def _make_video_audio_processor():
+        """Audio-enabled fast-path processor with EVS off and predictable counts.
+
+        With metadata-driven frame separators ("Frame 1 sampled at 0.00 seconds: "
+        ~ 33 chars), the default mock encoder `list(range(len(text)))` produces
+        token IDs that collide with mm-token IDs like img_context_token_id=20 and
+        _sound_context_token_id=30 — leading to spurious mm-token matches in the
+        expansion. Shift the encoded range to 1000+ so text tokens never overlap
+        with any mm-token id used in this suite (20, 21, 30, 200, 201, 500, 501).
+        """
+        proc = _make_fast_path_audio_processor(video_target_num_patches=None)
+        proc._add_video_prefix = False
+        proc.video_pruning_rate = 0
+        proc.video_temporal_patch_size = 1
+
+        def shifted_encode(text, **kw):
+            ids = [1000 + i for i in range(len(text))]
+            if kw.get("return_tensors") == "pt":
+                return torch.tensor(ids).unsqueeze(0)
+            return ids
+
+        proc.tokenizer.encode = mock.Mock(side_effect=shifted_encode)
+        return proc
+
+    @staticmethod
+    def _audio_metadata(num_frames=2, num_samples=16000, sample_rate=16000):
+        """Build a metadata dict matching what the cv2/PyAV video loader emits
+        when extract_audio=True (see inputs/utils.py:_load_video_by_cv2).
+        `frames_indices` length must equal the actual number of frames passed
+        to the processor — otherwise `_get_frame_separators` produces a
+        separator list that mismatches `_compute_token_numbers_per_video`'s
+        output and the strict zip in the per-tubelet loop fails."""
+        return {
+            "total_num_frames": num_frames,
+            "fps": 30.0,
+            "duration": num_frames / 30.0,
+            "frames_indices": list(range(num_frames)),
+            "audio_samples": np.random.randn(num_samples).astype(np.float32),
+            "audio_sample_rate": sample_rate,
+        }
+
+    def test_fast_path_appends_audio_tokens_after_video(self):
+        """When metadata carries audio_samples, the per-video expansion must end
+        with `<so_start>` + `<so_embedding>` * M + `<so_end>`, where M is the
+        Parakeet-extractor's audio_token_count for the resampled audio length."""
+        proc = self._make_video_audio_processor()
+        vid_ctx = proc.video_context_token_id
+        img_ctx = proc.img_context_token_id
+        num_frames = 2
+
+        prompt = [1, 2, vid_ctx, 3]
+        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
+        metadata = self._audio_metadata(num_frames=num_frames)
+        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=metadata)]}
+
+        # Match accounting in get_num_tokens_per_video: per-frame video tokens
+        # (256 + <img>/</img>) plus audio M+2 (start/end).
+        per_frame = 256 + 2
+        audio_total = proc.get_num_tokens_per_audio(
+            audio=(metadata["audio_samples"], metadata["audio_sample_rate"])
+        )  # = M + 2
+        total_mm = num_frames * per_frame + audio_total
+
+        expanded, evs_ids = proc._expand_video_placeholders_in_token_ids(
+            prompt, [total_mm], mm_data
+        )
+
+        assert evs_ids is None  # EVS disabled
+        # Surrounding text preserved.
+        assert expanded[:2] == [1, 2]
+        assert expanded[-1] == 3
+
+        # The audio block is appended AFTER the video frames, so the last 4
+        # tokens of the MM region are: <so_start>, ..., <so_context>, <so_end>, 3.
+        # Find audio block boundaries.
+        sound_start_id = proc._sound_start_token_id
+        sound_end_id = proc._sound_end_token_id
+        sound_ctx_id = proc._sound_context_token_id
+
+        assert expanded.count(sound_start_id) == 1
+        assert expanded.count(sound_end_id) == 1
+        # Audio block must form a single contiguous run between start and end.
+        start_idx = expanded.index(sound_start_id)
+        end_idx = expanded.index(sound_end_id)
+        assert end_idx > start_idx
+        audio_context_run = expanded[start_idx + 1 : end_idx]
+        assert all(t == sound_ctx_id for t in audio_context_run)
+        assert len(audio_context_run) == audio_total - 2  # M context tokens
+        # Audio block must come AFTER all video frame tokens (verify the last
+        # img_end appears before <so_start>).
+        last_img_end = max(i for i, t in enumerate(expanded) if t == 501)
+        assert last_img_end < start_idx
+        # And no audio tokens before the video region.
+        assert expanded.index(img_ctx) < start_idx
+
+    def test_fast_path_no_audio_tokens_when_metadata_has_no_audio(self):
+        """Regression check: video without `audio_samples` in metadata must not
+        emit any audio token IDs (otherwise we'd inject phantom slots that the
+        encoder produces no embeddings for)."""
+        proc = self._make_video_audio_processor()
+        vid_ctx = proc.video_context_token_id
+        num_frames = 2
+
+        prompt = [1, vid_ctx, 2]
+        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
+        # Metadata present but missing audio_samples (the common
+        # extract_audio=False case). `frames_indices` length must match
+        # num_frames so `_get_frame_separators` produces a separator list of
+        # the right length.
+        metadata_no_audio = {
+            "total_num_frames": num_frames,
+            "fps": 30.0,
+            "duration": num_frames / 30.0,
+            "frames_indices": list(range(num_frames)),
+        }
+        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=metadata_no_audio)]}
+        total_mm = num_frames * (256 + 2)
+
+        expanded, _ = proc._expand_video_placeholders_in_token_ids(prompt, [total_mm], mm_data)
+
+        assert proc._sound_start_token_id not in expanded
+        assert proc._sound_end_token_id not in expanded
+        assert proc._sound_context_token_id not in expanded
+
+    def test_get_num_tokens_per_video_includes_audio_when_metadata_has_audio(self):
+        """`get_num_tokens_per_video` must add `M + 2` to its return value when
+        the video metadata carries extracted audio. Without this,
+        `find_mm_token_lengths` under-reports total mm-tokens and the fast path's
+        `find_mm_token_positions` assertion fires."""
+        proc = self._make_video_audio_processor()
+        num_frames = 2
+        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
+        metadata = self._audio_metadata(num_frames=num_frames)
+
+        video_only = proc.get_num_tokens_per_video(video=frames)
+        with_audio = proc.get_num_tokens_per_video(video=frames, video_metadata=metadata)
+        audio_alone = proc.get_num_tokens_per_audio(
+            audio=(metadata["audio_samples"], metadata["audio_sample_rate"])
+        )
+
+        assert with_audio == video_only + audio_alone
+        # Without metadata or with metadata missing audio_samples, the count must
+        # match the video-only path exactly (no implicit audio accounting).
+        assert proc.get_num_tokens_per_video(video=frames, video_metadata=None) == video_only
+        assert (
+            proc.get_num_tokens_per_video(video=frames, video_metadata={"fps": 30.0}) == video_only
+        )
+
+    def test_expansion_length_matches_get_num_tokens_per_video(self):
+        """End-to-end invariant: the number of mm-tokens the fast-path expansion
+        emits for a single video must equal what `get_num_tokens_per_video` /
+        `find_mm_token_lengths` reports for that video — both with and without
+        extracted audio. If these drift, `find_mm_token_positions`'s
+        `sum(num_mm_tokens) == len(mm_positions)` assertion fails."""
+        proc = self._make_video_audio_processor()
+        vid_ctx = proc.video_context_token_id
+        num_frames = 2
+        frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
+        metadata = self._audio_metadata(num_frames=num_frames)
+        mm_data = {"video": [SimpleNamespace(frames=frames, metadata=metadata)]}
+
+        declared = proc.get_num_tokens_per_video(video=frames, video_metadata=metadata)
+        prompt = [1, vid_ctx, 2]
+        expanded, _ = proc._expand_video_placeholders_in_token_ids(prompt, [declared], mm_data)
+
+        # Count mm-token IDs present in the expansion (mirrors
+        # find_mm_token_positions's mask, which catches both context tokens and
+        # special wrappers via mm_token_ids / mm_special_token_ids).
+        mm_token_ids = {
+            proc.img_context_token_id,
+            proc._sound_context_token_id,
+            500,  # <img> from _make_fast_path_audio_processor
+            501,  # </img>
+            proc._sound_start_token_id,
+            proc._sound_end_token_id,
+        }
+        actual_mm = sum(1 for t in expanded if t in mm_token_ids)
+        assert actual_mm == declared

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -1522,3 +1522,69 @@ class TestGetNumTokensPerAudio:
         proc = _make_processor()  # No sound_config
         with pytest.raises(ValueError, match="sound_config"):
             proc.get_num_tokens_per_audio(audio=np.zeros(100))
+
+
+class TestGetNumTokensPerVideoInvariants:
+    """A regression test for the exact invariant that was broken before the
+    `get_num_tokens_per_video` fix: `find_mm_token_lengths` (via
+    `get_num_tokens_per_video`) and `_compute_token_numbers_per_video` must
+    report counts that agree on per-video totals, because
+    `find_mm_token_positions` later asserts
+    `len(mm_positions) == sum(num_mm_tokens)`, where `len(mm_positions)` is
+    driven by the expansion (built from `_compute_token_numbers_per_video`)
+    and `sum(num_mm_tokens)` comes from `find_mm_token_lengths` /
+    `get_num_tokens_per_video`.
+
+    Before the fix, `get_num_tokens_per_video`'s EVS branch routed the
+    frame through `get_num_tokens_per_image`'s dynamic-tiler logic, which
+    returned a multi-block count that the vision encoder never actually
+    produces — so `find_mm_token_lengths` over-reported the total and the
+    fast path's `find_mm_token_positions` assertion failed.
+
+    This test parametrizes over the knobs that gate branching in both
+    functions (`video_target_num_patches`, `video_maintain_aspect_ratio`)
+    plus the EVS pruning rate and a couple of frame aspect ratios. If
+    anyone ever re-introduces a divergence between the two computation
+    paths, this test catches it.
+    """
+
+    @pytest.mark.parametrize("video_pruning_rate", [0.0, 0.3, 0.5, 0.7])
+    @pytest.mark.parametrize("video_target_num_patches", [None, 256, 1024])
+    @pytest.mark.parametrize("maintain_aspect_ratio", [False, True])
+    @pytest.mark.parametrize("frame_dims", [(512, 512), (1920, 1080), (640, 360)])
+    def test_get_num_tokens_per_video_agrees_with_compute_token_numbers_per_video(
+        self,
+        video_pruning_rate,
+        video_target_num_patches,
+        maintain_aspect_ratio,
+        frame_dims,
+    ):
+        proc = _make_nano_processor(
+            sound_config=None,
+            video_target_num_patches=video_target_num_patches,
+            video_maintain_aspect_ratio=maintain_aspect_ratio,
+            video_temporal_patch_size=2,
+        )
+        proc.video_pruning_rate = video_pruning_rate
+
+        num_frames = 10  # with T=2 -> 5 tubelets
+        w, h = frame_dims
+        frames = [Image.new("RGB", (w, h)) for _ in range(num_frames)]
+
+        video_size = proc._compute_video_size_lightweight(frames)
+        per_tubelet = proc._compute_token_numbers_per_video([video_size])[0]
+        num_tubelets = len(per_tubelet)
+        # `get_num_tokens_per_video` hardcodes
+        # `num_special_tokens_per_frame = 2` (<img> and </img>) and adds it
+        # per tubelet on top of the retained feature tokens.
+        expected_total = sum(per_tubelet) + num_tubelets * 2
+        actual_total = proc.get_num_tokens_per_video(video=frames)
+        assert actual_total == expected_total, (
+            f"Drift between get_num_tokens_per_video={actual_total} and "
+            f"sum(_compute_token_numbers_per_video) + 2*num_tubelets="
+            f"{expected_total} "
+            f"(pruning={video_pruning_rate}, "
+            f"target_patches={video_target_num_patches}, "
+            f"maintain_aspect_ratio={maintain_aspect_ratio}, "
+            f"frame_dims={frame_dims})"
+        )

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -1452,7 +1452,7 @@ class TestExpandVideoPlaceholdersEVS:
         _, mm_data_updates = proc.expand_prompt_token_ids_for_mm(
             prompt,
             [total_mm],
-            hf_processor_mm_kwargs={"_multi_modal_data": mm_data},
+            mm_data=mm_data,
         )
 
         assert mm_data_updates is not None

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -1449,7 +1449,7 @@ class TestExpandVideoPlaceholdersEVS:
         mm_data = {"video": [SimpleNamespace(frames=frames, metadata=None)]}
         total_mm = 50 + 2 * num_frames
 
-        expanded, mm_data_updates = proc.expand_prompt_token_ids_for_mm(
+        _, mm_data_updates = proc.expand_prompt_token_ids_for_mm(
             prompt,
             [total_mm],
             hf_processor_mm_kwargs={"_multi_modal_data": mm_data},

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -23,7 +23,11 @@ from tensorrt_llm._torch.models.modeling_nemotron_nano import (
     get_video_target_size_and_feature_size,
     video_to_pixel_values,
 )
-from tensorrt_llm.inputs.multimodal import MultimodalParams, find_mm_token_positions
+from tensorrt_llm.inputs.multimodal import (
+    MultimodalParams,
+    _compute_mm_masks,
+    _find_mm_token_start_pos_from_masks,
+)
 
 
 def make_tiler(**overrides):
@@ -1542,7 +1546,7 @@ class TestGetNumTokensPerVideoInvariants:
     `get_num_tokens_per_video` fix: `find_mm_token_lengths` (via
     `get_num_tokens_per_video`) and `_compute_token_numbers_per_video` must
     report counts that agree on per-video totals, because
-    `find_mm_token_positions` later asserts
+    `_find_mm_token_start_pos_from_masks` later asserts
     `len(mm_positions) == sum(num_mm_tokens)`, where `len(mm_positions)` is
     driven by the expansion (built from `_compute_token_numbers_per_video`)
     and `sum(num_mm_tokens)` comes from `find_mm_token_lengths` /
@@ -1552,7 +1556,7 @@ class TestGetNumTokensPerVideoInvariants:
     frame through `get_num_tokens_per_image`'s dynamic-tiler logic, which
     returned a multi-block count that the vision encoder never actually
     produces — so `find_mm_token_lengths` over-reported the total and the
-    fast path's `find_mm_token_positions` assertion failed.
+    fast path's `_find_mm_token_start_pos_from_masks` assertion failed.
 
     This test parametrizes over the knobs that gate branching in both
     functions (`video_target_num_patches`, `video_maintain_aspect_ratio`)
@@ -1608,7 +1612,7 @@ class TestMultiTokenWrappersConsistency:
 
     `get_num_tokens_per_image` adds `len(_img_start_token_ids) +
     len(_img_end_token_ids)` so multi-token BPE wrappers are correctly counted.
-    For that count to line up at the assertion in `find_mm_token_positions`
+    For that count to line up at the assertion in `_find_mm_token_start_pos_from_masks`
     (`len(mm_positions) == sum(num_mm_tokens)`), `get_mm_special_token_ids`
     must include **every** ID in those wrapper lists — not just the [0]
     aliases. Otherwise trailing wrapper tokens are seen as plain text and the
@@ -1648,10 +1652,10 @@ class TestMultiTokenWrappersConsistency:
         assert proc.image_start_token_id in special_ids
         assert proc.image_end_token_id in special_ids
 
-    def test_find_mm_token_positions_matches_get_num_tokens_per_image(self):
+    def test_mm_token_start_pos_matches_get_num_tokens_per_image(self):
         """End-to-end invariant: with multi-token wrappers, the count
         reported by get_num_tokens_per_image must equal the number of mm
-        positions find_mm_token_positions extracts from the expanded prompt.
+        positions _find_mm_token_start_pos_from_masks extracts from the expanded prompt.
         Before the get_mm_special_token_ids fix, only the first BPE token of
         each wrapper was masked as special and this assertion was off by
         `(len(start) - 1) + (len(end) - 1)` per image."""
@@ -1665,16 +1669,27 @@ class TestMultiTokenWrappersConsistency:
         num_per_image = proc.get_num_tokens_per_image(image=Image.new("RGB", (320, 320)))
         expanded = proc._expand_image_placeholders_in_token_ids(prompt, [num_per_image])
 
-        # Mirror the fast path's call to find_mm_token_positions.
-        start_positions, _ = find_mm_token_positions(
-            input_ids=expanded,
-            num_mm_tokens=[num_per_image],
+        # Mirror the fast path's mask + start-position computation. The
+        # legacy public `find_mm_token_positions` was split into private
+        # helpers `_compute_mm_masks` + `_find_mm_token_start_pos_from_masks`;
+        # the latter still owns the `mm_positions.numel() == sum(num_mm_tokens)`
+        # assertion that triggers when wrappers BPE-split and only the [0]
+        # alias is in `mm_special_token_ids`.
+        input_ids_tensor = torch.tensor(expanded)
+        mm_mask, _embed_mask, special_mask = _compute_mm_masks(
+            input_ids=input_ids_tensor,
+            vocab_size=None,
             mm_token_ids=proc.get_mm_token_ids(),
             mm_special_token_ids=proc.get_mm_special_token_ids(),
         )
+        start_positions, _ = _find_mm_token_start_pos_from_masks(
+            mm_mask=mm_mask,
+            special_mask=special_mask,
+            num_mm_tokens=[num_per_image],
+        )
 
-        # find_mm_token_positions internally asserts
-        #   len(mm_positions) == sum(num_mm_tokens)
+        # _find_mm_token_start_pos_from_masks internally asserts
+        #   mm_positions.numel() == sum(num_mm_tokens)
         # so reaching here without an exception is the regression check. Also
         # sanity-check the start position lands at the expected offset.
         assert len(start_positions) == 1
@@ -1699,7 +1714,7 @@ class TestFastPathVideoWithExtractedAudio:
     audio embeddings produced by `_interleave_video_audio_embeddings` at forward
     time. `get_num_tokens_per_video` must include those tokens in its count so
     `find_mm_token_lengths` reports a total that matches the actual mm-token
-    count in the tokenized prompt (otherwise `find_mm_token_positions` asserts
+    count in the tokenized prompt (otherwise `_find_mm_token_start_pos_from_masks` asserts
     `sum(num_mm_tokens) == len(mm_positions)` and the request fails).
     """
 
@@ -1832,7 +1847,7 @@ class TestFastPathVideoWithExtractedAudio:
         """`get_num_tokens_per_video` must add `M + 2` to its return value when
         the video metadata carries extracted audio. Without this,
         `find_mm_token_lengths` under-reports total mm-tokens and the fast path's
-        `find_mm_token_positions` assertion fires."""
+        `_find_mm_token_start_pos_from_masks` assertion fires."""
         proc = self._make_video_audio_processor()
         num_frames = 2
         frames = [Image.new("RGB", (512, 512)) for _ in range(num_frames)]
@@ -1856,7 +1871,7 @@ class TestFastPathVideoWithExtractedAudio:
         """End-to-end invariant: the number of mm-tokens the fast-path expansion
         emits for a single video must equal what `get_num_tokens_per_video` /
         `find_mm_token_lengths` reports for that video — both with and without
-        extracted audio. If these drift, `find_mm_token_positions`'s
+        extracted audio. If these drift, `_find_mm_token_start_pos_from_masks`'s
         `sum(num_mm_tokens) == len(mm_positions)` assertion fails."""
         proc = self._make_video_audio_processor()
         vid_ctx = proc.video_context_token_id
@@ -1870,7 +1885,7 @@ class TestFastPathVideoWithExtractedAudio:
         expanded, _ = proc._expand_video_placeholders_in_token_ids(prompt, [declared], mm_data)
 
         # Count mm-token IDs present in the expansion (mirrors
-        # find_mm_token_positions's mask, which catches both context tokens and
+        # _find_mm_token_start_pos_from_masks's mask, which catches both context tokens and
         # special wrappers via mm_token_ids / mm_special_token_ids).
         mm_token_ids = {
             proc.img_context_token_id,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster tokenized multimodal path with improved placeholder expansion for images, video, and audio.
  * More efficient video token pruning and EVS-aware retained-token computation.

* **Bug Fixes**
  * More consistent placeholder expansion results and clearer error cases for mismatched multimodal input.

* **Tests**
  * Extensive new unit and integration tests covering multimodal preprocessing, placeholder variants, and EVS behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Adds the tokenized-prompt + multimodal-data fast path (the same pattern PR #11708 introduced for LLaVA-Next) to Nemotron Nano V3 OMNI, covering all three modalities — image, video, audio — including EVS-enabled video. Also fixes a pre-existing bug in `NanoV2VLInputProcessor.get_num_tokens_per_video`'s EVS branch where the per-tubelet retained token count was inflated by routing through `get_num_tokens_per_image`'s dynamic-tiler logic, causing `find_mm_token_positions` to disagree with the vision encoder's real post-EVS output.

- `tensorrt_llm/_torch/models/modeling_nemotron_nano.py` — Adds `get_text_with_mm_placeholders`, `get_num_tokens_per_audio`, `expand_prompt_token_ids_for_mm` (+ per-modality helpers) to `NanoV2VLInputProcessor`. Video expansion uses a two-tier strategy mirroring vLLM's `_apply_prompt_updates` (token-level subsequence match with a text-level decode/split/re-encode fallback). EVS support included via a parallel `evs_ids` stream consumed by `merge_evs_mm_embeds`. Fixes `get_num_tokens_per_video`'s EVS branch to derive `video_size` the same way `_process_videos_frames` does.

- `tensorrt_llm/inputs/evs.py` - Extracts `compute_retained_tokens_from_tubelet_budget` as the shared retention-count helper; `compute_retained_tokens_count` now delegates to it.

- `tensorrt_llm/inputs/multimodal.py` — Adds audio branch to `find_mm_token_lengths`; fixes `find_mm_token_positions` no-match early return from `[]` to `([], [])` to match its declared 2-tuple signature.

- `tensorrt_llm/inputs/registry.py` - `tokenized_multimodal_process` threads `multi_modal_data` through to the input processor (needed by video expansion) and merges any returned `mm_data_updates` (e.g. `evs_ids`) into `extra_processed_inputs["multimodal_data"]`. Adds "audio" to the multimodal-hashing modality whitelist.

- `tensorrt_llm/_torch/models/modeling_llava_next.py` - `expand_prompt_token_ids_for_mm` signature updated to return `Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]`; always returns `(expanded, None)`.

## Test Coverage

`tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py` - 8 new test classes covering each fast-path method, multi-token BPE patterns, EVS token-level + text-level tiers, dispatch integration, and audio.

Tested with VLMEvalKitMcore for the following datasets InfoVQA_VAL, OCRBench, VoxPopuli_ASR_test, TedLium_ASR_Test, Video-MME (EVS off), Video-MME (EVS of 0.5) by temporarily tokenizing the text prompt to trigger the fast path. The scores match the default, non-fast path where the text prompt and MM data is handled directly by the HF processor.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
