### PR TITLE
[None][feat] use multi thread for kv transfer

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -154,6 +154,7 @@ class SendTaskBase:
     def __init__(self, params: DisaggregatedParams):
         self.status = TaskStatus.INIT
         self.future = concurrent.futures.Future()
+        self.lock = threading.Lock()
         self._params = params
         assert params.disagg_request_id is not None
         self._unique_rid: int = params.disagg_request_id
@@ -286,9 +287,10 @@ class Sender(SenderBase):
         return session
 
     def _enqueue(self, write_meta: WriteMeta):
-        # Distribute tasks to threads by unique_rid to ensure same session's tasks
-        # are processed by the same thread in order
-        thread_idx = write_meta.unique_rid % self._num_threads
+        # Route by (unique_rid, peer_rank) so that:
+        # - Same peer's slices stay ordered on one thread (is_last_slice correctness)
+        # - Different peers can run on different threads (better load balancing)
+        thread_idx = hash((write_meta.unique_rid, write_meta.peer_rank)) % self._num_threads
         self._send_task_queues[thread_idx].put(write_meta)
 
     def _process_task_queue(self, thread_idx: int):
@@ -410,16 +412,20 @@ class Sender(SenderBase):
             ]
         )
 
-        task.transferred_count += 1
         if timer:
             timer.record_task_end(write_meta.peer_rank)
         ri = self._registrar.self_rank_info
         task.print_perf_info(write_meta.peer_rank, ri.instance_name, ri.instance_rank)
-        if task.transferred_count > write_meta.expected_transfers:
+
+        with task.lock:
+            task.transferred_count += 1
+            count = task.transferred_count
+
+        if count > write_meta.expected_transfers:
             session.set_exception(
                 f"KV slice {write_meta.slice_id} received more than {write_meta.expected_transfers} transfers"
             )
-        elif task.transferred_count == write_meta.expected_transfers:
+        elif count == write_meta.expected_transfers:
             if write_meta.task_future.done():
                 task.status = TaskStatus.ERROR
                 session.set_exception(
@@ -469,19 +475,23 @@ class Sender(SenderBase):
             ]
         )
 
-        aux_task._transfer_count += 1
         if timer:
             timer.record_task_end(write_meta.peer_rank)
         ri = self._registrar.self_rank_info
         aux_task.print_perf_info(write_meta.peer_rank, ri.instance_name, ri.instance_rank)
-        if aux_task._transfer_count == write_meta.expected_transfers:
+
+        with aux_task.lock:
+            aux_task._transfer_count += 1
+            count = aux_task._transfer_count
+
+        if count == write_meta.expected_transfers:
             if aux_task.future.done():
                 aux_task.status = TaskStatus.ERROR
                 session.set_exception("aux future already resolved on completion")
             else:
                 aux_task.future.set_result(AgentResult.SUCCESS)
                 aux_task.status = TaskStatus.TRANSFERRED
-        elif aux_task._transfer_count > write_meta.expected_transfers:
+        elif count > write_meta.expected_transfers:
             session.set_exception(
                 f"aux task received more than {write_meta.expected_transfers} transfers"
             )

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -235,7 +235,8 @@ class Sender(SenderBase):
         self._peer_requests_timestamps: dict[int, float] = {}  # unique_rid -> insert time
         self._peer_requests_lock = threading.Lock()
         self._messenger = ZMQMessenger(mode="ROUTER")
-        self._dealers = {}
+        self._dealers = {}  # used by listener thread only (single-threaded path)
+        self._thread_local = threading.local()  # per-thread DEALER cache for worker threads
         self._sessions = {}  # unique_rid -> TxSession
         self._sessions_lock = threading.Lock()  # Protects _sessions and _pre_cancelled_rids
         self._pre_cancelled_rids: set[int] = set()
@@ -357,30 +358,60 @@ class Sender(SenderBase):
         thread_idx = hash((write_meta.unique_rid, write_meta.peer_rank)) % self._num_threads
         self._send_task_queues[thread_idx].put(write_meta)
 
+    def _get_or_connect_thread_dealer(self, endpoint: Optional[str]) -> ZMQMessenger:
+        """Get or create a per-thread DEALER socket via threading.local().
+        Each worker thread gets its own cache so there is no cross-thread
+        access to the same ZMQ socket."""
+        if endpoint is None:
+            raise ValueError("Sender: peer endpoint is None; peer may not have registered yet")
+        dealers = getattr(self._thread_local, "dealers", None)
+        if dealers is None:
+            dealers = {}
+            self._thread_local.dealers = dealers
+        if endpoint not in dealers:
+            dealers[endpoint] = ZMQMessenger(mode="DEALER", endpoint=endpoint)
+        return dealers[endpoint]
+
     def _process_task_queue(self, thread_idx: int):
         device_id = self._device_id
         torch.cuda.set_device(device_id)
         CUASSERT(cudart.cudaSetDevice(device_id))
 
         task_queue = self._send_task_queues[thread_idx]
-        while True:
-            write_meta = task_queue.get()
-            if write_meta is None:
-                break
-            try:
-                if write_meta.meta_type == WriteMetaType.AUX:
-                    logger.debug(
-                        f"_process_task_queue[{thread_idx}]: delivering aux task to agent: {write_meta}"
+        try:
+            while True:
+                write_meta = task_queue.get()
+                if write_meta is None:
+                    break
+                try:
+                    if write_meta.meta_type == WriteMetaType.AUX:
+                        logger.debug(
+                            f"_process_task_queue[{thread_idx}]: delivering aux task to agent: {write_meta}"
+                        )
+                        self._deliver_aux_to_agent(write_meta)
+                    else:
+                        self._deliver_kv_to_agent(write_meta)
+                except Exception as e:
+                    logger.error(
+                        f"_process_task_queue[{thread_idx}]: unhandled exception for "
+                        f"unique_rid={write_meta.unique_rid}: {e}"
                     )
-                    self._deliver_aux_to_agent(write_meta)
-                else:
-                    self._deliver_kv_to_agent(write_meta)
-            except Exception as e:
-                logger.error(
-                    f"_process_task_queue[{thread_idx}]: unhandled exception for "
-                    f"unique_rid={write_meta.unique_rid}: {e}"
-                )
-                write_meta.task.fail(e)
+                    write_meta.task.fail(e)
+        finally:
+            # Clean up this thread's DEALER sockets. threading.local storage
+            # is only accessible from the owning thread, so shutdown must
+            # happen here rather than in Sender.shutdown().
+            dealers = getattr(self._thread_local, "dealers", None)
+            if dealers:
+                for endpoint, dealer in dealers.items():
+                    try:
+                        dealer.stop()
+                    except Exception as e:
+                        logger.warning(
+                            f"_process_task_queue[{thread_idx}]: failed to stop dealer "
+                            f"for endpoint {endpoint}: {e}"
+                        )
+                dealers.clear()
 
     @staticmethod
     @nvtx_range("_make_agent_request")
@@ -486,7 +517,7 @@ class Sender(SenderBase):
             timer.record_transfer_end(write_meta.peer_rank)
 
         ## TODO: just last slice need to send task state?
-        self._get_or_connect_dealer(write_meta.peer_endpoint).send(
+        self._get_or_connect_thread_dealer(write_meta.peer_endpoint).send(
             [
                 MessageType.KV_AGENT_RESULT,
                 str(self._instance_rank).encode("ascii"),
@@ -549,7 +580,7 @@ class Sender(SenderBase):
             if timer:
                 timer.record_transfer_end(write_meta.peer_rank)
 
-        self._get_or_connect_dealer(write_meta.peer_endpoint).send(
+        self._get_or_connect_thread_dealer(write_meta.peer_endpoint).send(
             [
                 MessageType.AUX_AGENT_RESULT,
                 str(self._instance_rank).encode("ascii"),

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -159,6 +159,7 @@ class SendTaskBase:
         self.status = TaskStatus.INIT
         self._event = threading.Event()
         self._exception: Optional[Exception] = None
+        self.lock = threading.Lock()
         self._params = params
         self._unique_rid: Optional[int] = params.disagg_request_id
         self._perf_timer = PerfTimer() if perf_log_manager.enabled else None
@@ -350,9 +351,10 @@ class Sender(SenderBase):
         return session
 
     def _enqueue(self, write_meta: WriteMeta):
-        # Distribute tasks to threads by unique_rid to ensure same session's tasks
-        # are processed by the same thread in order
-        thread_idx = write_meta.unique_rid % self._num_threads
+        # Route by (unique_rid, peer_rank) so that:
+        # - Same peer's slices stay ordered on one thread (is_last_slice correctness)
+        # - Different peers can run on different threads (better load balancing)
+        thread_idx = hash((write_meta.unique_rid, write_meta.peer_rank)) % self._num_threads
         self._send_task_queues[thread_idx].put(write_meta)
 
     def _process_task_queue(self, thread_idx: int):
@@ -495,16 +497,20 @@ class Sender(SenderBase):
             ]
         )
 
-        task.transferred_count += 1
         if timer:
             timer.record_task_end(write_meta.peer_rank)
         ri = self._registrar.self_rank_info
         task.print_perf_info(write_meta.peer_rank, ri.instance_name, ri.instance_rank)
-        if task.transferred_count > write_meta.expected_transfers:
+
+        with task.lock:
+            task.transferred_count += 1
+            count = task.transferred_count
+
+        if count > write_meta.expected_transfers:
             session.set_exception(
                 f"KV slice {write_meta.slice_id} received more than {write_meta.expected_transfers} transfers"
             )
-        elif task.transferred_count == write_meta.expected_transfers:
+        elif count == write_meta.expected_transfers:
             if task.is_done:
                 task.status = TaskStatus.ERROR
                 session.set_exception(
@@ -552,18 +558,22 @@ class Sender(SenderBase):
             ]
         )
 
-        aux_task._transfer_count += 1
         if timer:
             timer.record_task_end(write_meta.peer_rank)
         ri = self._registrar.self_rank_info
         aux_task.print_perf_info(write_meta.peer_rank, ri.instance_name, ri.instance_rank)
-        if aux_task._transfer_count == write_meta.expected_transfers:
+
+        with aux_task.lock:
+            aux_task._transfer_count += 1
+            count = aux_task._transfer_count
+
+        if count == write_meta.expected_transfers:
             if aux_task.is_done:
                 aux_task.status = TaskStatus.ERROR
                 session.set_exception("aux task already resolved on completion")
             else:
                 aux_task.complete()
-        elif aux_task._transfer_count > write_meta.expected_transfers:
+        elif count > write_meta.expected_transfers:
             session.set_exception(
                 f"aux task received more than {write_meta.expected_transfers} transfers"
             )

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -205,7 +205,8 @@ class Sender(SenderBase):
         self._peer_requests: dict = {}
         self._peer_requests_lock = threading.Lock()
         self._messenger = ZMQMessenger(mode="ROUTER")
-        self._dealers = {}
+        self._dealers = {}  # used by listener thread only (single-threaded path)
+        self._thread_local = threading.local()  # per-thread DEALER cache for worker threads
         self._sessions = {}  # unique_rid -> TxSession
         self._sessions_lock = threading.Lock()  # Protects _sessions access
         self._shutdown = False
@@ -293,31 +294,61 @@ class Sender(SenderBase):
         thread_idx = hash((write_meta.unique_rid, write_meta.peer_rank)) % self._num_threads
         self._send_task_queues[thread_idx].put(write_meta)
 
+    def _get_or_connect_thread_dealer(self, endpoint: Optional[str]) -> ZMQMessenger:
+        """Get or create a per-thread DEALER socket via threading.local().
+        Each worker thread gets its own cache so there is no cross-thread
+        access to the same ZMQ socket."""
+        if endpoint is None:
+            raise ValueError("Sender: peer endpoint is None; peer may not have registered yet")
+        dealers = getattr(self._thread_local, "dealers", None)
+        if dealers is None:
+            dealers = {}
+            self._thread_local.dealers = dealers
+        if endpoint not in dealers:
+            dealers[endpoint] = ZMQMessenger(mode="DEALER", endpoint=endpoint)
+        return dealers[endpoint]
+
     def _process_task_queue(self, thread_idx: int):
         device_id = self._device_id
         torch.cuda.set_device(device_id)
         CUASSERT(cudart.cudaSetDevice(device_id))
 
         task_queue = self._send_task_queues[thread_idx]
-        while True:
-            write_meta = task_queue.get()
-            if write_meta is None:
-                break
-            try:
-                if write_meta.meta_type == WriteMetaType.AUX:
-                    logger.debug(
-                        f"_process_task_queue[{thread_idx}]: delivering aux task to agent: {write_meta}"
+        try:
+            while True:
+                write_meta = task_queue.get()
+                if write_meta is None:
+                    break
+                try:
+                    if write_meta.meta_type == WriteMetaType.AUX:
+                        logger.debug(
+                            f"_process_task_queue[{thread_idx}]: delivering aux task to agent: {write_meta}"
+                        )
+                        self._deliver_aux_to_agent(write_meta)
+                    else:
+                        self._deliver_kv_to_agent(write_meta)
+                except Exception as e:
+                    logger.error(
+                        f"_process_task_queue[{thread_idx}]: unhandled exception for "
+                        f"unique_rid={write_meta.unique_rid}: {e}"
                     )
-                    self._deliver_aux_to_agent(write_meta)
-                else:
-                    self._deliver_kv_to_agent(write_meta)
-            except Exception as e:
-                logger.error(
-                    f"_process_task_queue[{thread_idx}]: unhandled exception for "
-                    f"unique_rid={write_meta.unique_rid}: {e}"
-                )
-                if not write_meta.task_future.done():
-                    write_meta.task_future.set_exception(e)
+                    if not write_meta.task_future.done():
+                        write_meta.task_future.set_exception(e)
+        finally:
+            # Clean up this thread's DEALER sockets. threading.local storage
+            # is only accessible from the owning thread, so shutdown must
+            # happen here rather than in Sender.shutdown().
+            dealers = getattr(self._thread_local, "dealers", None)
+            if dealers:
+                for endpoint, dealer in dealers.items():
+                    try:
+                        dealer.stop()
+                    except Exception as e:
+                        logger.warning(
+                            f"_process_task_queue[{thread_idx}]: failed to stop dealer "
+                            f"for endpoint {endpoint}: {e}"
+                        )
+                dealers.clear()
 
     @staticmethod
     @nvtx_range("_make_agent_request")
@@ -401,7 +432,7 @@ class Sender(SenderBase):
             timer.record_transfer_end(write_meta.peer_rank)
 
         ## TODO: just last slice need to send task state?
-        self._get_or_connect_dealer(write_meta.peer_endpoint).send(
+        self._get_or_connect_thread_dealer(write_meta.peer_endpoint).send(
             [
                 MessageType.KV_AGENT_RESULT,
                 str(self._instance_rank).encode("ascii"),
@@ -466,7 +497,7 @@ class Sender(SenderBase):
             if timer:
                 timer.record_transfer_end(write_meta.peer_rank)
 
-        self._get_or_connect_dealer(write_meta.peer_endpoint).send(
+        self._get_or_connect_thread_dealer(write_meta.peer_endpoint).send(
             [
                 MessageType.AUX_AGENT_RESULT,
                 str(self._instance_rank).encode("ascii"),

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 import tensorrt_llm
+import tensorrt_llm._torch.disaggregation.native.transfer as transfer_mod
 import tensorrt_llm.bindings
 import tensorrt_llm.bindings.executor as trtllm
 import tensorrt_llm.tensorrt_llm_transfer_agent_binding  # TODO: remove it.  # noqa: F401
@@ -31,6 +32,14 @@ from tensorrt_llm.bindings import LayerType as LayerTypeCpp
 from tensorrt_llm.bindings import ModelConfig as ModelConfigCpp
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 from tensorrt_llm.logger import logger
+
+# Default to 4 worker threads for all KV transfer tests in this module.
+KV_TRANSFER_TEST_NUM_THREADS = 4
+
+
+@pytest.fixture(autouse=True)
+def _set_kv_transfer_num_threads(monkeypatch):
+    monkeypatch.setattr(transfer_mod, "KV_TRANSFER_NUM_THREADS", KV_TRANSFER_TEST_NUM_THREADS)
 
 
 @dataclass

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 
 import tensorrt_llm
+import tensorrt_llm._torch.disaggregation.native.transfer as transfer_mod
 import tensorrt_llm.bindings
 import tensorrt_llm.bindings.executor as trtllm
 import tensorrt_llm.tensorrt_llm_transfer_agent_binding  # TODO: remove it.  # noqa: F401
@@ -32,6 +33,14 @@ from tensorrt_llm.bindings import LayerType as LayerTypeCpp
 from tensorrt_llm.bindings import ModelConfig as ModelConfigCpp
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 from tensorrt_llm.logger import logger
+
+# Default to 4 worker threads for all KV transfer tests in this module.
+KV_TRANSFER_TEST_NUM_THREADS = 4
+
+
+@pytest.fixture(autouse=True)
+def _set_kv_transfer_num_threads(monkeypatch):
+    monkeypatch.setattr(transfer_mod, "KV_TRANSFER_NUM_THREADS", KV_TRANSFER_TEST_NUM_THREADS)
 
 
 @dataclass

--- a/tests/unittest/disaggregated/test_kv_transfer_mp.py
+++ b/tests/unittest/disaggregated/test_kv_transfer_mp.py
@@ -114,6 +114,8 @@ def worker_fn(
     os.environ["MASTER_PORT"] = str(master_port)
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
+    # Use 4 worker threads for KV transfer to exercise multi-thread code paths
+    os.environ["TRTLLM_KV_TRANSFER_NUM_THREADS"] = "4"
 
     # Initialize distributed (use gloo for single GPU compatibility)
     dist.init_process_group(backend="gloo", rank=rank, world_size=world_size)


### PR DESCRIPTION
…one thread

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced thread-safe protection for completion counter updates in concurrent KV cache transfer delivery paths.

* **Performance & Stability**
  * Optimized task routing strategy to better utilize multi-threaded execution while maintaining per-peer transaction ordering in distributed inference scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->
ctx1dep4_gen4_tep8_deepseek r1 

gen side kv transfer time (ms)
  ┌────────┬────────┬────────┬────────┬─────────┐                                                                                            
  │ Metric │  thread 4  │  thread 1  │  │  perf imporment│                                                                                            
  ├────────┼────────┼────────┼─────────┼─────────┤                                                                                           
  │ mean   │ 12.772 │ 15.229 │ +2.457  │ +19.24% │                                                                                           
  ├────────┼────────┼────────┼─────────┼─────────┤                                                                                           
  │ median │ 12.055 │ 14.631 │ +2.576  │ +21.37% │                                                                                           
  ├────────┼────────┼────────┼─────────┼─────────┤
  │ p90    │ 14.200 │ 17.535 │ +3.335  │ +23.49% │                                                                                           
  ├────────┼────────┼────────┼─────────┼─────────┤                                                                                           
  │ p95    │ 18.809 │ 20.630 │ +1.821  │ +9.68%  │
  ├────────┼────────┼────────┼─────────┼─────────┤                                                                                           
  │ p99    │ 23.312 │ 29.193 │ +5.881  │ +25.23% │
  ├────────┼────────┼────────┼─────────┼─────────┤                                                                                           
  │ max    │ 30.318 │ 47.499 │ +17.181 │ +56.67% │
  └────────┴────────┴────────┴─────────┴─────────┘ 
## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
