### PR TITLE
[TRTLLM-11471][fix] Eliminate redundant serialization and MPI collectives in safe_allgather/safe_gather

### DIFF
--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -330,73 +330,61 @@ def safe_broadcast(comm, obj, root=0, chunk_size: int = 4 * 1024 * 1024):
             raise RuntimeError(f"Deserialization failed: {str(e)}") from e
 
 
-def _prepare_chunked_transfer(
+def _serialize_and_exchange_lengths(
     comm: Any,
     obj: Any,
-    chunk_size: int,
-) -> Tuple[int, int, np.ndarray, np.ndarray, np.ndarray, int, int]:
-    """Common preparation for safe_gather and safe_allgather.
+) -> Tuple[int, int, np.ndarray, np.ndarray, np.ndarray]:
+    """Serialize *obj* and exchange payload lengths across all ranks.
 
-    Validates chunk_size, serializes the object, exchanges payload lengths
-    across all ranks, and computes displacements and round counts for a
-    chunked MPI transfer.
+    Uses buffer-based ``MPI_Allgather`` (uppercase) for the length
+    exchange — a single MPI collective with no pickle overhead, which
+    is the same work that mpi4py does internally inside
+    ``comm.allgather(obj)``.
 
     Args:
         comm: MPI communicator (``MPI.Comm`` instance).
         obj: Python object to transfer (must be picklable).
-        chunk_size: Per-round max bytes each rank contributes.
 
     Returns:
-        Tuple of ``(rank, size, lengths, displs, sendbuf, num_rounds,
-        chunk_size)`` where:
+        Tuple of ``(rank, size, lengths, displs, sendbuf)`` where:
 
         - **rank** (*int*) — this process's rank in *comm*.
         - **size** (*int*) — total number of ranks in *comm*.
         - **lengths** (*np.ndarray[int64]*) — per-rank serialized payload
-          sizes.
+          sizes.  A value of ``-1`` signals a serialization failure.
         - **displs** (*np.ndarray[int64]*) — per-rank byte offsets into a
           concatenated receive buffer.
         - **sendbuf** (*np.ndarray[uint8]*) — this rank's serialized
-          payload as a contiguous byte array.
-        - **num_rounds** (*int*) — number of chunked transfer rounds
-          needed.
-        - **chunk_size** (*int*) — possibly reduced from the input to keep
-          per-round displacements within int32.
+          payload as a contiguous byte array (empty when serialization
+          failed).
     """
-    if chunk_size <= 0:
-        raise ValueError("chunk_size must be > 0")
-
     rank = comm.Get_rank()
     size = comm.Get_size()
 
-    # Ensure chunk_size * size fits in int32 for per-round displacements.
-    max_safe_chunk = np.iinfo(np.int32).max // size if size > 0 else chunk_size
-    if chunk_size > max_safe_chunk:
-        logger.info(
-            "_prepare_chunked_transfer: reducing chunk_size from %d to %d "
-            "to keep per-round displacements within int32 (size=%d)",
-            chunk_size, max_safe_chunk, size)
-        chunk_size = max_safe_chunk
-
+    local_ser_error = None
     try:
         payload = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
-    except Exception as e:
-        _ = comm.allgather(-1)
-        raise RuntimeError(f"Rank {rank} serialization failed: {e}") from e
+        local_len = np.array([len(payload)], dtype=np.int64)
+    except Exception as exc:
+        payload = b""
+        local_len = np.array([-1], dtype=np.int64)
+        local_ser_error = exc
 
-    lengths = np.array(comm.allgather(len(payload)), dtype=np.int64)
+    # Buffer-based Allgather: 1 MPI collective, no pickle overhead.
+    lengths = np.empty(size, dtype=np.int64)
+    comm.Allgather([local_len, MPI.INT64_T], [lengths, MPI.INT64_T])
+
     if (lengths < 0).any():
-        raise RuntimeError("Serialization failed on at least one rank")
+        raise RuntimeError(
+            f"Rank {rank}: serialization failed on at least one rank "
+            f"(lengths={lengths})") from local_ser_error
 
     displs = np.zeros(size, dtype=np.int64)
     if size > 1:
         displs[1:] = np.cumsum(lengths[:-1])
 
     sendbuf = np.frombuffer(payload, dtype=np.uint8)
-    max_len = int(lengths.max()) if size > 0 else 0
-    num_rounds = math.ceil(max_len / chunk_size) if max_len > 0 else 0
-
-    return rank, size, lengths, displs, sendbuf, num_rounds, chunk_size
+    return rank, size, lengths, displs, sendbuf
 
 
 def _chunked_transfer_loop(
@@ -488,6 +476,8 @@ def _deserialize_recvbuf(
         List of deserialized Python objects (``len == size``). Ranks whose
         payload length is zero are represented as ``None``.
     """
+    # Zero-length payloads (e.g. from pickling None) are returned as None
+    # without calling pickle.loads, which would fail on empty bytes.
     return [
         pickle.loads(recvbuf[displs[i]:displs[i] + lengths[i]])  # nosec B301
         if lengths[i] > 0 else None for i in range(size)
@@ -503,6 +493,14 @@ def safe_gather(
     """Safely gather potentially large objects by splitting into fixed-size
     chunks, using raw-byte MPI.Gatherv with a per-round temp buffer to
     keep counts and displacements within int32.
+
+    The function serializes *obj* once with ``pickle.dumps``, exchanges
+    payload lengths via buffer-based ``MPI_Allgather`` (1 MPI collective),
+    then transfers the raw bytes with ``MPI_Gatherv`` (1 MPI collective).
+    This matches the number of MPI collectives that mpi4py's
+    ``comm.gather(obj)`` performs internally, while adding chunking
+    safety for payloads whose total exceeds the int32 displacement
+    limit (~2 GB).
 
     Args:
         comm: MPI communicator (``MPI.Comm`` instance) to gather over.
@@ -520,16 +518,40 @@ def safe_gather(
     if MPI is None:
         raise RuntimeError(
             "mpi4py is required when ENABLE_MULTI_DEVICE is True")
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be > 0")
 
-    rank, size, lengths, displs, sendbuf, num_rounds, chunk_size = \
-        _prepare_chunked_transfer(comm, obj, chunk_size)
+    # Step 1: serialize once and exchange lengths (1 MPI collective).
+    rank, size, lengths, displs, sendbuf = \
+        _serialize_and_exchange_lengths(comm, obj)
 
-    # Fast path: when all payloads fit in a single round, the simple
-    # comm.gather avoids the chunked-loop overhead.
-    if num_rounds <= 1:
-        return comm.gather(obj, root=root)
+    total = int(lengths.sum())
+    int32_max = np.iinfo(np.int32).max
 
-    recvbuf = np.empty(lengths.sum(), dtype=np.uint8) if rank == root else None
+    # Step 2a: total fits in int32 — single Gatherv (1 MPI collective).
+    if total < int32_max:
+        counts = lengths.astype(np.int32)
+        displs32 = displs.astype(np.int32)
+        if rank == root:
+            recvbuf = np.empty(total, dtype=np.uint8)
+            comm.Gatherv([sendbuf, MPI.BYTE],
+                         [recvbuf, counts, displs32, MPI.BYTE],
+                         root=root)
+            return _deserialize_recvbuf(recvbuf, lengths, displs, size)
+        else:
+            comm.Gatherv([sendbuf, MPI.BYTE], None, root=root)
+            return None
+
+    # Step 2b: total exceeds int32 — chunked Gatherv.
+    logger.info(
+        "safe_gather: total payload %d bytes exceeds int32 limit, "
+        "using chunked Gatherv (size=%d)", total, size)
+    max_safe_chunk = int32_max // size
+    chunk_size = min(chunk_size, max_safe_chunk)
+    max_len = int(lengths.max())
+    num_rounds = math.ceil(max_len / chunk_size) if max_len > 0 else 0
+
+    recvbuf = np.empty(total, dtype=np.uint8) if rank == root else None
 
     def _gatherv(send_part, round_recvbuf, counts, round_displs):
         if rank == root:
@@ -553,25 +575,16 @@ def safe_allgather(
     chunk_size: int = 4 * 1024 * 1024,
 ) -> List[Any]:
     """Safely allgather potentially large objects by splitting into
-    fixed-size chunks, using raw-byte MPI.Allgatherv. Every rank ends
-    up with the complete list of deserialized objects.
+    fixed-size chunks, using raw-byte MPI.Allgatherv.
 
-    Why "safe": mpi4py's ``comm.allgather(obj)`` internally calls
-    ``MPI_Allgatherv`` with 32-bit ``int`` counts and displacements.
-    When any rank's serialized payload or the cumulative displacement
-    exceeds ~2 GB, this causes silent data corruption or segfaults.
-    Additionally, mpi4py's pickle5-based protocol may allocate extra
-    out-of-band buffers for large objects, causing unexpected memory
-    spikes. This function avoids both issues by:
-
-    1. Serializing once with ``pickle.dumps`` (no out-of-band buffers).
-    2. Transferring raw bytes in rounds of at most ``chunk_size`` per
-       rank, keeping each ``MPI_Allgatherv`` call's counts and
-       displacements within 32-bit limits.
-
-    For small objects the overhead is negligible (one extra allgather of
-    int64 lengths, single-round transfer), so this can be used as a
-    drop-in replacement for ``comm.allgather``.
+    The function serializes *obj* once with ``pickle.dumps``, exchanges
+    payload lengths via buffer-based ``MPI_Allgather`` (1 MPI collective),
+    then transfers the raw bytes with ``MPI_Allgatherv`` (1 MPI
+    collective).  This matches the number of MPI collectives that
+    mpi4py's ``comm.allgather(obj)`` performs internally, while adding
+    chunking safety for payloads whose total exceeds the int32
+    displacement limit (~2 GB) and avoiding mpi4py's pickle5
+    out-of-band buffers that can cause unexpected memory spikes.
 
     Args:
         comm: MPI communicator (``MPI.Comm`` instance) to allgather over.
@@ -588,16 +601,35 @@ def safe_allgather(
     if MPI is None:
         raise RuntimeError(
             "mpi4py is required when ENABLE_MULTI_DEVICE is True")
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be > 0")
 
-    rank, size, lengths, displs, sendbuf, num_rounds, chunk_size = \
-        _prepare_chunked_transfer(comm, obj, chunk_size)
+    # Step 1: serialize once and exchange lengths (1 MPI collective).
+    rank, size, lengths, displs, sendbuf = \
+        _serialize_and_exchange_lengths(comm, obj)
 
-    # Fast path: when all payloads fit in a single round, the simple
-    # comm.allgather avoids the chunked-loop overhead.
-    if num_rounds <= 1:
-        return comm.allgather(obj)
+    total = int(lengths.sum())
+    int32_max = np.iinfo(np.int32).max
 
-    recvbuf = np.empty(lengths.sum(), dtype=np.uint8)
+    # Step 2a: total fits in int32 — single Allgatherv (1 MPI collective).
+    if total < int32_max:
+        counts = lengths.astype(np.int32)
+        displs32 = displs.astype(np.int32)
+        recvbuf = np.empty(total, dtype=np.uint8)
+        comm.Allgatherv([sendbuf, MPI.BYTE],
+                        [recvbuf, counts, displs32, MPI.BYTE])
+        return _deserialize_recvbuf(recvbuf, lengths, displs, size)
+
+    # Step 2b: total exceeds int32 — chunked Allgatherv.
+    logger.info(
+        "safe_allgather: total payload %d bytes exceeds int32 limit, "
+        "using chunked Allgatherv (size=%d)", total, size)
+    max_safe_chunk = int32_max // size
+    chunk_size = min(chunk_size, max_safe_chunk)
+    max_len = int(lengths.max())
+    num_rounds = math.ceil(max_len / chunk_size) if max_len > 0 else 0
+
+    recvbuf = np.empty(total, dtype=np.uint8)
 
     def _allgatherv(send_part, round_recvbuf, counts, round_displs):
         comm.Allgatherv([send_part, MPI.BYTE],

--- a/tests/unittest/_torch/distributed/test_safe_mpi_comm.py
+++ b/tests/unittest/_torch/distributed/test_safe_mpi_comm.py
@@ -339,15 +339,18 @@ class TestSafeAllgather:
             assert result[i]["rank"] == i
 
         # Exactly 2 buffer-based collectives.
-        assert spy.Allgather_count == 1, \
+        assert spy.Allgather_count == 1, (
             f"Expected 1 Allgather (lengths), got {spy.Allgather_count}"
-        assert spy.Allgatherv_count == 1, \
+        )
+        assert spy.Allgatherv_count == 1, (
             f"Expected 1 Allgatherv (data), got {spy.Allgatherv_count}"
+        )
 
         # No Python-level (lowercase) collectives — these would mean
         # redundant serialization and extra MPI ops.
-        assert spy.allgather_count == 0, \
+        assert spy.allgather_count == 0, (
             f"Python-level allgather should not be called, got {spy.allgather_count}"
+        )
 
     def test_allgather_serializes_once(self):
         """Verify that safe_allgather calls pickle.dumps exactly once
@@ -362,8 +365,9 @@ class TestSafeAllgather:
             result = communicator.safe_allgather(spy, obj)
 
         assert len(result) == self.world_size
-        assert mock_dumps.call_count == 1, \
+        assert mock_dumps.call_count == 1, (
             f"Expected 1 pickle.dumps call, got {mock_dumps.call_count}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -520,16 +524,20 @@ class TestSafeGather:
             assert result is None
 
         # Exactly 2 buffer-based collectives.
-        assert spy.Allgather_count == 1, \
+        assert spy.Allgather_count == 1, (
             f"Expected 1 Allgather (lengths), got {spy.Allgather_count}"
-        assert spy.Gatherv_count == 1, \
+        )
+        assert spy.Gatherv_count == 1, (
             f"Expected 1 Gatherv (data), got {spy.Gatherv_count}"
+        )
 
         # No Python-level (lowercase) collectives.
-        assert spy.allgather_count == 0, \
+        assert spy.allgather_count == 0, (
             f"Python-level allgather should not be called, got {spy.allgather_count}"
-        assert spy.gather_count == 0, \
+        )
+        assert spy.gather_count == 0, (
             f"Python-level gather should not be called, got {spy.gather_count}"
+        )
 
     def test_gather_serializes_once(self):
         """Verify that safe_gather calls pickle.dumps exactly once
@@ -547,8 +555,9 @@ class TestSafeGather:
             assert len(result) == self.world_size
         else:
             assert result is None
-        assert mock_dumps.call_count == 1, \
+        assert mock_dumps.call_count == 1, (
             f"Expected 1 pickle.dumps call, got {mock_dumps.call_count}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/_torch/distributed/test_safe_mpi_comm.py
+++ b/tests/unittest/_torch/distributed/test_safe_mpi_comm.py
@@ -527,9 +527,7 @@ class TestSafeGather:
         assert spy.Allgather_count == 1, (
             f"Expected 1 Allgather (lengths), got {spy.Allgather_count}"
         )
-        assert spy.Gatherv_count == 1, (
-            f"Expected 1 Gatherv (data), got {spy.Gatherv_count}"
-        )
+        assert spy.Gatherv_count == 1, f"Expected 1 Gatherv (data), got {spy.Gatherv_count}"
 
         # No Python-level (lowercase) collectives.
         assert spy.allgather_count == 0, (

--- a/tests/unittest/_torch/distributed/test_safe_mpi_comm.py
+++ b/tests/unittest/_torch/distributed/test_safe_mpi_comm.py
@@ -20,10 +20,11 @@ that safely handle large serialized objects by avoiding MPI's 32-bit
 count/displacement limits.
 
 Run with mpirun:
-    mpirun -n 2 python -m pytest tests/unittest/_torch/distributed/test_safe_allgather.py -v
+    mpirun -n 2 python -m pytest tests/unittest/_torch/distributed/test_safe_mpi_comm.py -v
 """
 
 import pickle
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -50,6 +51,56 @@ def get_mpi_comm():
     from mpi4py import MPI
 
     return MPI.COMM_WORLD
+
+
+# ---------------------------------------------------------------------------
+# CommSpy: transparent wrapper that counts MPI entry points while
+# forwarding all calls to the real communicator.
+# ---------------------------------------------------------------------------
+
+
+class CommSpy:
+    """Transparent MPI communicator wrapper that counts collective calls.
+
+    Every call is forwarded to the real communicator — this is
+    instrumentation, not mocking.  After calling safe_allgather /
+    safe_gather with a CommSpy, inspect the counters to verify the
+    exact number of MPI collectives used.
+    """
+
+    def __init__(self, comm):
+        self._comm = comm
+        # Buffer-based (uppercase) — expected entry points.
+        self.Allgather_count = 0
+        self.Allgatherv_count = 0
+        self.Gatherv_count = 0
+        # Python-level (lowercase) — should never be called by the
+        # new implementation.
+        self.allgather_count = 0
+        self.gather_count = 0
+
+    def Allgather(self, sendbuf, recvbuf):
+        self.Allgather_count += 1
+        return self._comm.Allgather(sendbuf, recvbuf)
+
+    def Allgatherv(self, sendbuf, recvbuf):
+        self.Allgatherv_count += 1
+        return self._comm.Allgatherv(sendbuf, recvbuf)
+
+    def Gatherv(self, sendbuf, recvbuf, root=0):
+        self.Gatherv_count += 1
+        return self._comm.Gatherv(sendbuf, recvbuf, root=root)
+
+    def allgather(self, obj):
+        self.allgather_count += 1
+        return self._comm.allgather(obj)
+
+    def gather(self, obj, root=0):
+        self.gather_count += 1
+        return self._comm.gather(obj, root=root)
+
+    def __getattr__(self, name):
+        return getattr(self._comm, name)
 
 
 # ---------------------------------------------------------------------------
@@ -272,6 +323,48 @@ class TestSafeAllgather:
             assert result[i]["rank"] == i
             assert result[i]["values"] == list(range(100))
 
+    def test_allgather_uses_exactly_two_collectives(self):
+        """Verify that safe_allgather uses exactly 2 MPI collectives for
+        small objects: 1 buffer-based Allgather (length exchange) +
+        1 Allgatherv (data transfer).  No Python-level (lowercase)
+        allgather should be called."""
+        spy = CommSpy(self.comm)
+        obj = {"rank": self.rank, "value": self.rank * 100}
+
+        result = communicator.safe_allgather(spy, obj)
+
+        # Correctness.
+        assert len(result) == self.world_size
+        for i in range(self.world_size):
+            assert result[i]["rank"] == i
+
+        # Exactly 2 buffer-based collectives.
+        assert spy.Allgather_count == 1, \
+            f"Expected 1 Allgather (lengths), got {spy.Allgather_count}"
+        assert spy.Allgatherv_count == 1, \
+            f"Expected 1 Allgatherv (data), got {spy.Allgatherv_count}"
+
+        # No Python-level (lowercase) collectives — these would mean
+        # redundant serialization and extra MPI ops.
+        assert spy.allgather_count == 0, \
+            f"Python-level allgather should not be called, got {spy.allgather_count}"
+
+    def test_allgather_serializes_once(self):
+        """Verify that safe_allgather calls pickle.dumps exactly once
+        (inside _serialize_and_exchange_lengths), not twice."""
+        spy = CommSpy(self.comm)
+        obj = {"rank": self.rank, "data": list(range(100))}
+
+        with patch(
+            "tensorrt_llm._torch.distributed.communicator.pickle.dumps",
+            wraps=pickle.dumps,
+        ) as mock_dumps:
+            result = communicator.safe_allgather(spy, obj)
+
+        assert len(result) == self.world_size
+        assert mock_dumps.call_count == 1, \
+            f"Expected 1 pickle.dumps call, got {mock_dumps.call_count}"
+
 
 # ---------------------------------------------------------------------------
 # Tests for the safe_gather free function
@@ -407,6 +500,55 @@ class TestSafeGather:
                 assert result[i] == expected
         else:
             assert result is None
+
+    def test_gather_uses_exactly_two_collectives(self):
+        """Verify that safe_gather uses exactly 2 MPI collectives for
+        small objects: 1 buffer-based Allgather (length exchange) +
+        1 Gatherv (data transfer).  No Python-level (lowercase)
+        gather/allgather should be called."""
+        spy = CommSpy(self.comm)
+        obj = {"rank": self.rank, "value": self.rank * 100}
+
+        result = communicator.safe_gather(spy, obj, root=0)
+
+        # Correctness.
+        if self.rank == 0:
+            assert len(result) == self.world_size
+            for i in range(self.world_size):
+                assert result[i]["rank"] == i
+        else:
+            assert result is None
+
+        # Exactly 2 buffer-based collectives.
+        assert spy.Allgather_count == 1, \
+            f"Expected 1 Allgather (lengths), got {spy.Allgather_count}"
+        assert spy.Gatherv_count == 1, \
+            f"Expected 1 Gatherv (data), got {spy.Gatherv_count}"
+
+        # No Python-level (lowercase) collectives.
+        assert spy.allgather_count == 0, \
+            f"Python-level allgather should not be called, got {spy.allgather_count}"
+        assert spy.gather_count == 0, \
+            f"Python-level gather should not be called, got {spy.gather_count}"
+
+    def test_gather_serializes_once(self):
+        """Verify that safe_gather calls pickle.dumps exactly once
+        (inside _serialize_and_exchange_lengths), not twice."""
+        spy = CommSpy(self.comm)
+        obj = {"rank": self.rank, "data": list(range(100))}
+
+        with patch(
+            "tensorrt_llm._torch.distributed.communicator.pickle.dumps",
+            wraps=pickle.dumps,
+        ) as mock_dumps:
+            result = communicator.safe_gather(spy, obj, root=0)
+
+        if self.rank == 0:
+            assert len(result) == self.world_size
+        else:
+            assert result is None
+        assert mock_dumps.call_count == 1, \
+            f"Expected 1 pickle.dumps call, got {mock_dumps.call_count}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized distributed communication operations with efficient data serialization, intelligent payload size handling, and a fast path for smaller data transfers to reduce overhead in multi-GPU scenarios.

* **Bug Fixes**
  * Enhanced error handling in distributed operations with improved exception reporting and failure detection during collective communications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

### Summary

   - **Fixes performance regression** in `safe_allgather`/`safe_gather` introduced by PR #12174: every call was doing 4 MPI collectives + 3 serializations instead of
   the original 2 + 1.
   - Rewrites both functions to serialize once, exchange lengths via buffer-based `MPI_Allgather` (1 collective), then transfer raw bytes via
   `MPI_Allgatherv`/`MPI_Gatherv` (1 collective) — matching what mpi4py's `comm.allgather(obj)` does internally.
   - Preserves the >2GB chunking safety for payloads exceeding the int32 displacement limit.

### Before PR #12174 (original mpi4py)                                                                                                                                
   ```                                                                                                                                                                   
   comm.allgather(obj):                                                                                                                                                  
     pickle.dumps(obj)                     # serialization #1                                                                                                            
     MPI_Allgather(sizes)                  # internal MPI op #1                                                                                                          
     MPI_Allgatherv(pickled_bytes)         # internal MPI op #2                                                                                                          
     pickle.loads(...)                     # deserialization                                                                                                             
   Total: 2 MPI collectives, 1 serialization                                                                                                                             
   No protection against >2GB payloads (int32 overflow → silent corruption)                                                                                              
   ```                                                                                                                                                                   
                                                                                                                                                                         
   ### PR #12174 (introduced regression)                                                                                                                                 
   ```                                                                                                                                                                   
   _prepare_chunked_transfer:
     pickle.dumps(obj)                     # serialization #1                                                                                                            
     comm.allgather(len(payload))          # 2 internal MPI ops (Allgather + Allgatherv)                                                                                 
   fast path (num_rounds <= 1):                                                                                                                                          
     comm.allgather(obj)                   # serialization #2 + #3, 2 more internal MPI ops                                                                              
   Total: 4 MPI collectives, 3 serializations                                                                                                                            
   Added >2GB chunking safety, but 2x collective overhead on the hot path                                                                                                
   ```                                                                                                                                                                   
                                                                                                                                                                         
   ### This PR (fix)                                                                                                                                                     
   ```                                                                                                                                                                   
   _serialize_and_exchange_lengths:                                                                                                                                      
     pickle.dumps(obj)                     # serialization #1                                                                                                            
     comm.Allgather([local_len, INT64])    # 1 buffer-based MPI op (no pickle)                                                                                           
   safe_allgather / safe_gather:                                                                                                                                         
     comm.Allgatherv([sendbuf, BYTE], ...) # 1 buffer-based MPI op (pre-serialized bytes)                                                                                
   Total: 2 MPI collectives, 1 serialization
   Preserves >2GB chunking safety, matches original mpi4py performance
   ```

   ### Additional improvements
   - Preserve exception chain on serialization failures (`from local_ser_error`)
   - Log when entering the chunked transfer path (>2GB aggregate payloads)
   - Remove dead `size > 0` guards (MPI guarantees `size >= 1`)
   - Fix test docstring referencing wrong filename
   - Add `CommSpy`-based tests verifying exact collective and serialization counts

## Test coverage                                                                                                                                                      
                                                                                                                                                                         
   | Scenario | Test | Status |                                                                                                                                          
   |----------|------|--------|                                                                                                                                          
   | Small object fast path (2a) | Most `TestSafeAllgather`/`TestSafeGather` tests + CommSpy tests | Covered |                                                           
   | Large object chunked path (2b) | `test_*_large_object`, `test_*_multi_round_chunking` | Covered |                                                                   
   | Asymmetric payload sizes | `test_*_displacement_correctness_asymmetric` | Covered |                                                                                 
   | `chunk_size` validation | `test_*_invalid_chunk_size` | Covered |                                                                                                   
   | `chunk_size` auto-capping | `test_allgather_chunk_size_auto_capped` | Covered |                                                                                     
   | Exact collective count (2 buffer-based, 0 Python-level) | `test_*_uses_exactly_two_collectives` | **New** |                                                         
   | Exact serialization count (1 `pickle.dumps`) | `test_*_serializes_once` | **New** |                                                                                 
   | None/empty payloads | `test_allgather_none`, `test_allgather_empty_collections` | Covered |                                                                         
   | Non-zero root for gather | `test_gather_non_zero_root` | Covered |                                                                                                  
   | Cross-rank consistency | `test_allgather_cross_rank_consistency` | Covered |                                                                                        
   | MPIDist TP/PP/CP wiring | `TestMPIDistAllgather`, `TestMPIDistGather` | Covered |                                                                                   
   | Total > int32 (real >2GB payloads) | N/A — requires multi-GB allocations per rank | Not covered (by design) |

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
