### PR TITLE
[None][fix] Fix scheduler off-by-one in FLUX pipelines at high resolutions

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -311,6 +311,7 @@ class FluxPipeline(BasePipeline):
             self.scheduler.set_timesteps(sigmas=sigmas, device=self.device, mu=mu)
 
         timesteps = self.scheduler.timesteps
+        self.scheduler.set_begin_index(0)
 
         # Prepare guidance (embedded guidance for FLUX)
         guidance = None

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -403,6 +403,7 @@ class Flux2Pipeline(BasePipeline):
         else:
             self.scheduler.set_timesteps(sigmas=sigmas.tolist(), device=self.device, mu=mu)
         timesteps = self.scheduler.timesteps
+        self.scheduler.set_begin_index(0)
 
         # Prepare guidance (only for variants with guidance_embeds=True)
         guidance = None


### PR DESCRIPTION
## Summary
- Add `set_begin_index(0)` after `set_timesteps` in FLUX.1 and FLUX.2 pipelines to match upstream diffusers behavior
- Fixes `IndexError` when running FLUX at high resolutions (e.g. 6400×6400 / 160K+ tokens) with few inference steps

## Root Cause
FLUX uses dynamic timestep shifting (`mu`) that scales linearly with sequence length. At high resolutions (160K+ tokens), `mu` becomes large enough (~27.5) that all scheduler sigmas collapse to the same value (1.0) and all timesteps become identical (1000.0).

Without `set_begin_index(0)`, the scheduler's `_init_step_index` calls `index_for_timestep(1000.0)`, finds all timesteps matching, and picks index 1 (not 0). After N steps, `step_index` reaches `N+1`, causing an out-of-bounds access on `self.sigmas[step_index + 1]`.

The upstream diffusers `FluxPipeline` avoids this by calling `self.scheduler.set_begin_index(0)` before the denoise loop (diffusers `pipeline_flux.py:936`), which forces `_init_step_index` to use index 0.

## Test Plan
- [x] Verified FLUX.1-dev at 6400×6400 (160K tokens, 4 steps) completes successfully with this fix (previously crashed with IndexError)
- [x] Verified no regression at standard resolutions (3072×3072, 4352×4352)
- [x] Sage attention unit tests pass (864/864) on PR #12937 branch with this fix applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed scheduler initialization in Flux visual generation models to ensure consistent pipeline behavior across generation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->