### PR TITLE
[None][pref] Consolidate prefix reuse queries into single analyzePrefixReuse radix tree walk

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -698,6 +698,28 @@ public:
     }
 };
 
+/// \brief Result of a single radix tree walk that collects all prefix reuse information.
+/// \details Replaces separate findNewContextBlock() + countReusableBlocks(true) +
+///          countReusableBlocks(false) calls with a single walk, reducing 2-3 walks to 1.
+struct PrefixReuseSummary
+{
+    using SizeType32 = tensorrt_llm::runtime::SizeType32;
+
+    /// Number of prefix blocks already allocated (refCount > 0).
+    /// Used by the block budget to avoid double-counting with the eviction free count.
+    SizeType32 reusableBlocksAllocated{0};
+
+    /// Total number of prefix blocks cached (allocated or free-cached).
+    /// Used by the token budget (NoEvict) since all cached tokens avoid recompute.
+    SizeType32 reusableBlocksAll{0};
+
+    /// First block key NOT found in the radix tree. std::nullopt means either all full
+    /// prefix blocks matched (full prefix hit) or the request has no full block key to
+    /// probe yet; a concrete BlockKey identifies the first missing full block.
+    /// Used by the capacity scheduler's skip-check logic to decide whether to defer a request.
+    std::optional<BlockKey> firstNewBlock{std::nullopt};
+};
+
 // The WindowBlockManager manages the metadata of KVCacheBlocks.
 // It manages multiple arrays of cache blocks called pools.
 // Layers with the same number of kv heads are grouped under the same pool.
@@ -1030,22 +1052,9 @@ public:
     void offloadBlock(BlockPtr const& block, executor::KvCacheTransferMode mode = executor::KvCacheTransferMode::DRAM,
         std::string const& directory = "");
 
-    //! \brief Find first new block that must be allocated for context phase and return it's concatenated token vectors.
-    //! \details Only full blocks are considered.
-    [[nodiscard]] std::optional<BlockKey> findNewContextBlock(
+    //! \brief Combined prefix reuse analysis — single radix tree walk.
+    [[nodiscard]] PrefixReuseSummary analyzePrefixReuse(
         VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const;
-
-    //! \brief Count the number of full blocks that can be reused from the KV cache for a given request.
-    //! \details Traverses the radix tree to count how many consecutive blocks from the beginning
-    //!          of the request's context are already cached.
-    //! \param uniqueTokens The unique tokens representing the request's context.
-    //! \param llmRequest The request to check for reusable blocks.
-    //! \param onlyAllocated If true, only count blocks that have active references (already allocated
-    //!        to another sequence). Free cached blocks are excluded because they are already counted
-    //!        in the eviction policy's free count.
-    //! \return The number of full blocks that can be reused.
-    [[nodiscard]] SizeType32 countReusableBlocks(
-        VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest, bool onlyAllocated = false) const;
 
     [[nodiscard]] runtime::BufferManager const& getBufferManager() const
     {
@@ -1405,14 +1414,10 @@ public:
     void setOffsets(kernels::KVCacheIndex* offsetsPtr, nvinfer1::Dims const& offsetsShape, SizeType32 beamIdx,
         SizeType32 blockIdx, KVCacheBlock::IdType blockId, SizeType32 windowSize) const;
 
-    // WILL NOT WORK FOR VARIABLE WINDOW ATTENTION
-    [[nodiscard]] std::optional<BlockKey> findNewContextBlock(
-        VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const;
-
-    //! \brief Count the number of full blocks that can be reused from the KV cache for a given request.
+    //! \brief Combined prefix reuse analysis — single radix tree walk.
     //! \details WILL NOT WORK FOR VARIABLE WINDOW ATTENTION.
-    [[nodiscard]] SizeType32 countReusableBlocks(
-        VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest, bool onlyAllocated = false) const;
+    [[nodiscard]] PrefixReuseSummary analyzePrefixReuse(
+        VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const;
 
     //! \brief Bring block from primary to secondary memory for window size.
     //! \details Does nothing if block is already in primary memory.
@@ -1850,18 +1855,21 @@ public:
     [[nodiscard]] virtual BlockManager const& getBlockManager() const = 0;
 
     /// @brief  Function that computes the number of KV cache blocks needed to advance a request by one or two
-    /// iterations
+    /// iterations.
     /// @param req The request for which we need to calculate the number of needed KV cache blocks
+    /// @param cachedSummary Optional pre-computed PrefixReuseSummary to avoid redundant radix tree walks.
     /// @return  The number of blocks
-    [[nodiscard]] virtual SizeType32 getNeededBlocksOneStep(
-        LlmRequest const& req, bool twoStepsLookAhead, SizeType32 windowSize) const
+    [[nodiscard]] virtual SizeType32 getNeededBlocksOneStep(LlmRequest const& req, bool twoStepsLookAhead,
+        SizeType32 windowSize, std::optional<PrefixReuseSummary> const& cachedSummary = std::nullopt) const
         = 0;
 
     /// @brief  Function that computes the number of KV cache blocks needed to advance a request to completion (i.e. for
-    /// maxNewTokens)
+    /// maxNewTokens).
     /// @param req The request for which we need to calculate the number of needed KV cache blocks
+    /// @param cachedSummary Optional pre-computed PrefixReuseSummary to avoid redundant radix tree walks.
     /// @return  The number of blocks
-    [[nodiscard]] virtual SizeType32 getRemainingBlocksToCompletion(LlmRequest const& req, SizeType32 windowSize) const
+    [[nodiscard]] virtual SizeType32 getRemainingBlocksToCompletion(LlmRequest const& req, SizeType32 windowSize,
+        std::optional<PrefixReuseSummary> const& cachedSummary = std::nullopt) const
         = 0;
 
     /// @brief Pin blocks associated with a request to prevent eviction.
@@ -1934,21 +1942,10 @@ public:
 
     [[nodiscard]] virtual bool isCrossKv() const = 0;
 
-    //! \brief Find first new block that must be allocated for context phase and return it's concatenated token vector.
-    //! \details Only full blocks are considered.
-    [[nodiscard]] virtual std::optional<BlockKey> findNewContextBlock(
+    //! \brief Combined prefix reuse analysis — single radix tree walk.
+    //! \details Collects firstNewBlock + reusableBlocksAllocated + reusableBlocksAll in one pass.
+    [[nodiscard]] virtual PrefixReuseSummary analyzePrefixReuse(
         VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const
-        = 0;
-
-    //! \brief Count the number of full blocks that can be reused from the KV cache for a given request.
-    //! \details Traverses the radix tree to count how many consecutive blocks from the beginning
-    //!          of the request's context are already cached.
-    //! \param uniqueTokens The unique tokens representing the request's context.
-    //! \param llmRequest The request to check for reusable blocks.
-    //! \param onlyAllocated If true, only count blocks that have active references.
-    //! \return The number of full blocks that can be reused.
-    [[nodiscard]] virtual SizeType32 countReusableBlocks(
-        VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest, bool onlyAllocated = false) const
         = 0;
 
     //! \brief Store full context blocks contributed by llmRequest.
@@ -2242,15 +2239,15 @@ public:
     /// iterations
     /// @param req The request for which we need to calculate the number of needed KV cache blocks
     /// @return  The number of blocks
-    [[nodiscard]] SizeType32 getNeededBlocksOneStep(
-        LlmRequest const& req, bool twoStepsLookAhead, SizeType32 windowSize) const override;
+    [[nodiscard]] SizeType32 getNeededBlocksOneStep(LlmRequest const& req, bool twoStepsLookAhead,
+        SizeType32 windowSize, std::optional<PrefixReuseSummary> const& cachedSummary = std::nullopt) const override;
 
     /// @brief  Function that computes the number of KV cache blocks remaining to advance a request to completion (i.e.
     /// for maxNewTokens); the allocated blocks are excluded
     /// @param req The request for which we need to calculate the number of needed KV cache blocks
     /// @return  The number of blocks
-    [[nodiscard]] SizeType32 getRemainingBlocksToCompletion(
-        LlmRequest const& req, SizeType32 windowSize) const override;
+    [[nodiscard]] SizeType32 getRemainingBlocksToCompletion(LlmRequest const& req, SizeType32 windowSize,
+        std::optional<PrefixReuseSummary> const& cachedSummary = std::nullopt) const override;
 
     /// @brief Increase size for request with requestId. Allocate new KV cache block(s) if needed.
     void addToken(LlmRequest::RequestIdType requestId) override;
@@ -2345,14 +2342,9 @@ public:
         return mBlockManager.getCacheType();
     }
 
-    //! \brief Find first new block that must be allocated for context phase and return it's concatenated token vector.
-    //! \details Only full blocks are considered.
-    [[nodiscard]] std::optional<BlockKey> findNewContextBlock(
+    //! \brief Combined prefix reuse analysis — single radix tree walk.
+    [[nodiscard]] PrefixReuseSummary analyzePrefixReuse(
         VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const override;
-
-    //! \brief Count the number of full blocks that can be reused from the KV cache for a given request.
-    [[nodiscard]] SizeType32 countReusableBlocks(
-        VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest, bool onlyAllocated = false) const override;
 
     //! \brief Store full context blocks contributed by llmRequest.
     //! \details These blocks become reusable from next step.

--- a/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
+++ b/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,19 +47,19 @@ prefillWithChunkedContextsAlreadyExecuting(RequestList const& activeRequests,
             if (kvCacheManager.isEnableBlockReuse())
             {
                 auto uniqueTokens = req->getUniqueTokens(0);
-                auto newContextBlockOpt = kvCacheManager.findNewContextBlock(uniqueTokens, *req);
-                if (newContextBlockOpt.has_value())
+                auto summary = kvCacheManager.analyzePrefixReuse(uniqueTokens, *req);
+                if (summary.firstNewBlock.has_value())
                 {
-                    newlyContributedContextBlocks.insert(newContextBlockOpt.value());
+                    newlyContributedContextBlocks.insert(summary.firstNewBlock.value());
                 }
             }
             if (crossKvCacheManager && crossKvCacheManager->isEnableBlockReuse())
             {
                 auto uniqueTokens = *(req->getEncoderUniqueTokens().value());
-                auto newContextBlockOpt = crossKvCacheManager->findNewContextBlock(uniqueTokens, *req);
-                if (newContextBlockOpt.has_value())
+                auto summary = crossKvCacheManager->analyzePrefixReuse(uniqueTokens, *req);
+                if (summary.firstNewBlock.has_value())
                 {
-                    newlyContributedCrossContextBlocks.insert(newContextBlockOpt.value());
+                    newlyContributedCrossContextBlocks.insert(summary.firstNewBlock.value());
                 }
             }
         }
@@ -67,60 +67,48 @@ prefillWithChunkedContextsAlreadyExecuting(RequestList const& activeRequests,
     return {std::move(newlyContributedContextBlocks), std::move(newlyContributedCrossContextBlocks)};
 }
 
-bool oneManagerBeneficialToSkip(tensorrt_llm::batch_manager::kv_cache_manager::BaseKVCacheManager const& kvCacheManager,
-    VecUniqueTokens const& uniqueTokens, std::shared_ptr<LlmRequest> const& llmRequest,
-    std::unordered_set<BlockKey, BlockKeyHasher>& newlyContributedContextBlocks)
+/// @brief Check if a single manager's summary indicates we should skip this request.
+/// @details Returns true if the request's first new context block was already contributed
+/// by an earlier scheduled request (so waiting would let us reuse it). Does NOT mutate
+/// the set — registration is deferred to beneficialToSkip after both KV checks pass.
+bool oneManagerBeneficialToSkip(std::optional<kv_cache_manager::PrefixReuseSummary> const& summary,
+    std::unordered_set<BlockKey, BlockKeyHasher> const& newlyContributedContextBlocks)
 {
-    // Find first context block that isn't already in KV cache
-    auto newContextBlockOpt = kvCacheManager.findNewContextBlock(uniqueTokens, *llmRequest);
-    if (newContextBlockOpt.has_value())
-    {
-        auto const& newContextBlock = newContextBlockOpt.value();
-        if (newlyContributedContextBlocks.count(newContextBlock) > 0)
-        {
-            // newContextBlock was contributed by earlier scheduled request.
-            // Better to skip this step so we can reuse.
-            return true;
-        }
-
-        // This request is contributing newContextBlock.
-        newlyContributedContextBlocks.insert(newContextBlock);
-    }
-    // Either all context blocks are already in KV cache,
-    // or no previously scheduled request has contributed newContextBlock.
-    return false;
+    return summary.has_value() && summary->firstNewBlock.has_value()
+        && newlyContributedContextBlocks.count(summary->firstNewBlock.value()) > 0;
 }
 
-//! \brief Check if it is beneficial to skip this request rather than schedule it.
-//! \details One condition that makes it beneficial is if this request can reuse kv cache block(s) contributed by
-//! already scheduled context requests.
-bool beneficialToSkip(std::shared_ptr<tensorrt_llm::batch_manager::LlmRequest> const& req,
-    kv_cache_manager::BaseKVCacheManager const& kvCacheManager,
-    OptionalRef<kv_cache_manager::BaseKVCacheManager const> crossKvCacheManager,
+/// @brief Check if it is beneficial to skip this request rather than schedule it.
+/// @details Returns true if this request can reuse KV cache block(s) that will be contributed
+/// by already-scheduled context requests. Uses pre-computed PrefixReuseSummary values.
+/// When the request is NOT skipped, registers its firstNewBlock contributions so that
+/// subsequent duplicate requests can be deferred.
+bool beneficialToSkip(std::optional<kv_cache_manager::PrefixReuseSummary> const& summary,
+    std::optional<kv_cache_manager::PrefixReuseSummary> const& crossSummary,
     std::unordered_set<BlockKey, BlockKeyHasher>& newlyContributedContextBlocks,
     std::unordered_set<BlockKey, BlockKeyHasher>& newlyContributedCrossContextBlocks)
 {
-    if (req->isContextInitState() && req->isFirstContextChunk())
+    if (oneManagerBeneficialToSkip(summary, newlyContributedContextBlocks))
     {
-        if (kvCacheManager.isEnableBlockReuse())
-        {
-            auto uniqueTokens = req->getUniqueTokens(0);
-            if (oneManagerBeneficialToSkip(kvCacheManager, uniqueTokens, req, newlyContributedContextBlocks))
-            {
-                return true;
-            }
-        }
-        if (crossKvCacheManager && crossKvCacheManager->isEnableBlockReuse())
-        {
-            auto uniqueTokens = *(req->getEncoderUniqueTokens().value());
-            if (oneManagerBeneficialToSkip(*crossKvCacheManager, uniqueTokens, req, newlyContributedCrossContextBlocks))
-            {
-                return true;
-            }
-        }
+        return true;
+    }
+    if (oneManagerBeneficialToSkip(crossSummary, newlyContributedCrossContextBlocks))
+    {
+        return true;
+    }
+    // Request is NOT skipped — register its contributions so subsequent duplicate
+    // requests can be deferred correctly.
+    if (summary.has_value() && summary->firstNewBlock.has_value())
+    {
+        newlyContributedContextBlocks.insert(summary->firstNewBlock.value());
+    }
+    if (crossSummary.has_value() && crossSummary->firstNewBlock.has_value())
+    {
+        newlyContributedCrossContextBlocks.insert(crossSummary->firstNewBlock.value());
     }
     return false;
 }
+
 } // namespace
 
 MaxRequestsScheduler::MaxRequestsScheduler(
@@ -251,9 +239,13 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
         if (req->isGenerationInProgressState())
         {
             scheduledRequests.emplace_back(req);
-            reservedBlocks.decrementReservedBlocks(*req);
+            reservedBlocks.enoughAvailableBlocks(*req);
+            reservedBlocks.commitBlocks();
             if (reservedCrossBlocks)
-                reservedCrossBlocks->decrementReservedBlocks(*req);
+            {
+                reservedCrossBlocks->enoughAvailableBlocks(*req);
+                reservedCrossBlocks->commitBlocks();
+            }
             bool const reqHasLora = req->getLoraTaskId().has_value();
             bool const isNewTask = reqHasLora && !uniqTaskIds.count(req->getLoraTaskId().value());
             if (isNewTask)
@@ -285,10 +277,35 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
         {
             for (auto const& req : requests)
             {
-                // if context request can reuse blocks contributed by another context request, skip
-                if (!StaticBatchScheduling && skippingIsRelevant && !req->isDisaggGenerationInitState()
-                    && beneficialToSkip(req, kvCacheManager, crossKvCacheManager, newlyContributedContextBlocks,
-                        newlyContributedCrossContextBlocks))
+                // For first-chunk context requests with block reuse, compute the prefix reuse
+                // summary once. This single radix tree walk serves both the beneficial-to-skip
+                // check and the block budget estimation in getRemainingBlocksToCompletion,
+                // eliminating 2 redundant walks per request.
+                bool const isFirstChunkContext
+                    = req->isContextInitState() && req->isFirstContextChunk() && !req->isDisaggGenerationInitState();
+                std::optional<kv_cache_manager::PrefixReuseSummary> summary;
+                std::optional<kv_cache_manager::PrefixReuseSummary> crossSummary;
+                if (isFirstChunkContext)
+                {
+                    // analyzePrefixReuse asserts on variable-window managers; skip the walk there
+                    // and let downstream callers fall back to their fresh tree-walk path.
+                    if (kvCacheManager.isEnableBlockReuse() && !kvCacheManager.getBlockManager().isVariableWindow())
+                    {
+                        auto uniqueTokens = req->getUniqueTokens(0);
+                        summary = kvCacheManager.analyzePrefixReuse(uniqueTokens, *req);
+                    }
+                    if (crossKvCacheManager && crossKvCacheManager->isEnableBlockReuse()
+                        && !crossKvCacheManager->getBlockManager().isVariableWindow())
+                    {
+                        auto uniqueTokens = *(req->getEncoderUniqueTokens().value());
+                        crossSummary = crossKvCacheManager->analyzePrefixReuse(uniqueTokens, *req);
+                    }
+                }
+
+                // Beneficial-to-skip check using the cached summary
+                if (!StaticBatchScheduling && skippingIsRelevant && isFirstChunkContext
+                    && beneficialToSkip(
+                        summary, crossSummary, newlyContributedContextBlocks, newlyContributedCrossContextBlocks))
                 {
                     continue;
                 }
@@ -300,9 +317,14 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
 
                 if (req->isContextInitState() || req->isDisaggGenerationInitState())
                 {
-                    bool enoughBlocks = reservedBlocks.enoughAvailableBlocks(*req);
-                    bool enoughCrossBlocks
-                        = reservedCrossBlocks ? reservedCrossBlocks->enoughAvailableBlocks(*req) : true;
+                    // Check block availability using the cached summary when available.
+                    // enoughAvailableBlocks is check-only (no decrement) — safe if cross check fails.
+                    bool enoughBlocks = reservedBlocks.enoughAvailableBlocks(*req, summary);
+                    bool enoughCrossBlocks = true;
+                    if (reservedCrossBlocks)
+                    {
+                        enoughCrossBlocks = reservedCrossBlocks->enoughAvailableBlocks(*req, crossSummary);
+                    }
                     bool reqHasLora = req->getLoraTaskId().has_value();
                     bool isNewTask = reqHasLora && !uniqTaskIds.count(req->getLoraTaskId().value());
                     auto neededPeftPages = isNewTask && peftCacheManager ? peftCacheManager->determineNumPages(req) : 0;
@@ -310,9 +332,12 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
                     if (enoughBlocks && enoughCrossBlocks && neededPeftPages <= availablePeftPages)
                     {
                         scheduledRequests.emplace_back(req);
-                        reservedBlocks.decrementReservedBlocks(*req);
+                        // Decrement using the cached values computed by enoughAvailableBlocks.
+                        reservedBlocks.commitBlocks();
                         if (reservedCrossBlocks)
-                            reservedCrossBlocks->decrementReservedBlocks(*req);
+                        {
+                            reservedCrossBlocks->commitBlocks();
+                        }
                         availablePeftPages -= neededPeftPages;
                         if (isNewTask)
                         {
@@ -336,7 +361,8 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
 bool trySchedulingRequestMaxUtilization(std::shared_ptr<LlmRequest> const& req, SizeType32 maxNumRequests,
     RequestVector& scheduledRequests, kv_cache_manager::MaxUtilizationScheduledBlocksManager& blocksManager,
     OptionalRef<BasePeftCacheManager const> peftCacheManager, SizeType32& numScheduledPeftPages,
-    std::unordered_set<uint64_t>& seenTaskIds);
+    std::unordered_set<uint64_t>& seenTaskIds,
+    std::optional<kv_cache_manager::PrefixReuseSummary> const& cachedSummary);
 
 std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
     kv_cache_manager::BaseKVCacheManager& kvCacheManager, OptionalRef<BasePeftCacheManager const> peftCacheManager,
@@ -383,17 +409,32 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
             continue;
         }
 
-        // if context request can reuse blocks contributed by another context request, skip
-        if (skippingIsRelevant
+        // For first-chunk context requests with block reuse, compute the prefix reuse
+        // summary once. This single radix tree walk serves both the beneficial-to-skip
+        // check and the block budget estimation in getNeededBlocksOneStep.
+        bool const isFirstChunkContext
+            = req->isContextInitState() && req->isFirstContextChunk() && !req->isDisaggGenerationInitState();
+        std::optional<kv_cache_manager::PrefixReuseSummary> summary;
+        // analyzePrefixReuse asserts on variable-window managers; skip the walk there
+        // and let downstream callers fall back to their fresh tree-walk path.
+        if (isFirstChunkContext && kvCacheManager.isEnableBlockReuse()
+            && !kvCacheManager.getBlockManager().isVariableWindow())
+        {
+            auto uniqueTokens = req->getUniqueTokens(0);
+            summary = kvCacheManager.analyzePrefixReuse(uniqueTokens, *req);
+        }
+
+        // Beneficial-to-skip check using the cached summary (no cross KV cache for MaxUtil)
+        if (skippingIsRelevant && isFirstChunkContext
             && beneficialToSkip(
-                req, kvCacheManager, std::nullopt, newlyContributedContextBlocks, newlyContributedCrossContextBlocks))
+                summary, std::nullopt, newlyContributedContextBlocks, newlyContributedCrossContextBlocks))
         {
             reqIt++;
             continue;
         }
 
         bool const wasScheduled = trySchedulingRequestMaxUtilization(req, mMaxNumRequests, scheduledRequests,
-            scheduledBlocksManager, peftCacheManager, numScheduledPeftPages, seenTaskIds);
+            scheduledBlocksManager, peftCacheManager, numScheduledPeftPages, seenTaskIds, summary);
         if (wasScheduled)
         {
             TLLM_LOG_DEBUG("MaxUtilizationScheduler: request ID %lu -> start", req->mRequestId);
@@ -427,7 +468,7 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
 bool trySchedulingRequestMaxUtilization(std::shared_ptr<LlmRequest> const& req, SizeType32 maxNumRequests,
     RequestVector& scheduledRequests, kv_cache_manager::MaxUtilizationScheduledBlocksManager& blocksManager,
     OptionalRef<BasePeftCacheManager const> peftCacheManager, SizeType32& numScheduledPeftPages,
-    std::unordered_set<uint64_t>& seenTaskIds)
+    std::unordered_set<uint64_t>& seenTaskIds, std::optional<kv_cache_manager::PrefixReuseSummary> const& cachedSummary)
 {
     if (scheduledRequests.size() < static_cast<std::size_t>(maxNumRequests))
     {
@@ -437,7 +478,9 @@ bool trySchedulingRequestMaxUtilization(std::shared_ptr<LlmRequest> const& req, 
             = (isNewTask && peftCacheManager) ? peftCacheManager->determineNumPages(req) : 0;
         TLLM_LOG_DEBUG(
             "MaxUtilizationScheduler: request ID %lu required peft pages: %i", req->mRequestId, numRequiredPeftPages);
-        auto const scheduledBlocksIfFitsKvCache = blocksManager.prepareNewNumberOfBlocksIfWeEndUpScheduling(*req);
+        // Use the cached summary when available to avoid a redundant tree walk
+        auto const scheduledBlocksIfFitsKvCache
+            = blocksManager.prepareNewNumberOfBlocksIfWeEndUpScheduling(*req, cachedSummary);
         bool fitsPeft
             = (peftCacheManager ? numRequiredPeftPages + numScheduledPeftPages <= peftCacheManager->getMaxDevicePages()
                                 : true);

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1310,57 +1310,23 @@ void WindowBlockManager::offloadBlock(
     }
 }
 
-[[nodiscard]] std::optional<BlockKey> BlockManager::findNewContextBlock(
+PrefixReuseSummary BlockManager::analyzePrefixReuse(
     VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const
 {
-    TLLM_CHECK_WITH_INFO(
-        !isVariableWindow(), "The optimization of delaying requests won't work for variable window attention");
+    TLLM_CHECK_WITH_INFO(!isVariableWindow(), "analyzePrefixReuse does not work for variable window attention");
     auto const& onlyManager = mWindowBlockManagers.cbegin()->second;
-    return onlyManager.findNewContextBlock(uniqueTokens, llmRequest);
+    return onlyManager.analyzePrefixReuse(uniqueTokens, llmRequest);
 }
 
-SizeType32 BlockManager::countReusableBlocks(
-    VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest, bool onlyAllocated) const
-{
-    TLLM_CHECK_WITH_INFO(!isVariableWindow(), "countReusableBlocks does not work for variable window attention");
-    auto const& onlyManager = mWindowBlockManagers.cbegin()->second;
-    return onlyManager.countReusableBlocks(uniqueTokens, llmRequest, onlyAllocated);
-}
-
-std::optional<BlockKey> WindowBlockManager::findNewContextBlock(
+PrefixReuseSummary WindowBlockManager::analyzePrefixReuse(
     VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const
 {
     auto blockedUniqueTokens
         = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, uniqueTokens.size(), mTokensPerBlock, false);
     auto blockKeys = buildBlockKeys(blockedUniqueTokens, llmRequest);
-    BlockKey ret;
-    ret.loraTaskId = llmRequest.getLoraTaskId();
-    std::lock_guard<std::mutex> lock(mCachedBlocksRootMutex);
-    auto searchRoot = mCachedBlocksRoot;
-    for (auto const& blockKey : blockKeys)
-    {
-        ret.uniqueTokens.insert(ret.uniqueTokens.end(), blockKey.uniqueTokens.begin(), blockKey.uniqueTokens.end());
-        auto [partialMatch, numMatched, matchingBlock] = searchRoot != nullptr
-            ? searchRoot->findMatchingBlock(blockKey, false, false)
-            : std::make_tuple(false, 0, nullptr);
-        if (matchingBlock == nullptr)
-        {
-            return ret;
-        }
-        searchRoot = std::move(matchingBlock);
-    }
-    return std::nullopt;
-}
 
-SizeType32 WindowBlockManager::countReusableBlocks(
-    VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest, bool onlyAllocated) const
-{
-    // Chop tokens into full blocks only (allowPartial=false)
-    auto blockedUniqueTokens
-        = chopVectorIntoBlocks<UniqueToken>(uniqueTokens, uniqueTokens.size(), mTokensPerBlock, false);
-    auto blockKeys = buildBlockKeys(blockedUniqueTokens, llmRequest);
+    PrefixReuseSummary summary;
 
-    SizeType32 reusableBlocks = 0;
     std::lock_guard<std::mutex> lock(mCachedBlocksRootMutex);
     auto searchRoot = mCachedBlocksRoot;
 
@@ -1372,24 +1338,22 @@ SizeType32 WindowBlockManager::countReusableBlocks(
 
         if (matchingBlock == nullptr)
         {
-            // No more matching blocks found
+            summary.firstNewBlock = blockKey;
             break;
         }
 
-        // When onlyAllocated is true, only count blocks that are already allocated
-        // to an active sequence (have refs). Sharing these blocks doesn't consume
-        // from the free pool. Free cached blocks (no refs) are already counted in
-        // the eviction policy's free count and must not be double-counted.
-        if (!onlyAllocated || matchingBlock->hasRefs())
+        ++summary.reusableBlocksAll;
+        if (matchingBlock->hasRefs())
         {
-            ++reusableBlocks;
+            ++summary.reusableBlocksAllocated;
         }
+
         searchRoot = std::move(matchingBlock);
     }
 
-    TLLM_LOG_DEBUG("%s::countReusableBlocks - Found %d reusable blocks (onlyAllocated=%d)", mLogPrefix.c_str(),
-        reusableBlocks, onlyAllocated);
-    return reusableBlocks;
+    TLLM_LOG_DEBUG("%s::analyzePrefixReuse - reusableAllocated=%d, reusableAll=%d, hasNewBlock=%d", mLogPrefix.c_str(),
+        summary.reusableBlocksAllocated, summary.reusableBlocksAll, summary.firstNewBlock.has_value());
+    return summary;
 }
 
 WindowBlockManager::ClaimResult WindowBlockManager::claimMatchingBlocks(GenerationRequest& sequence,
@@ -3273,8 +3237,8 @@ void KVCacheManager::startScheduling()
     mBlockManager.startScheduling();
 }
 
-SizeType32 KVCacheManager::getNeededBlocksOneStep(
-    LlmRequest const& req, bool twoStepsLookAhead, SizeType32 windowSize) const
+SizeType32 KVCacheManager::getNeededBlocksOneStep(LlmRequest const& req, bool twoStepsLookAhead, SizeType32 windowSize,
+    std::optional<PrefixReuseSummary> const& cachedSummary) const
 {
     // Default to zero; overwritten below when block reuse is active for a first-chunk context request.
     req.setEstimatedReusableTokens(0);
@@ -3297,8 +3261,10 @@ SizeType32 KVCacheManager::getNeededBlocksOneStep(
         if (mEnableBlockReuse && !mBlockManager.isVariableWindow() && !isCrossKv()
             && !req.isDisaggGenerationInitState())
         {
-            auto const& uniqueTokens = req.getUniqueTokens(0);
-            auto const numReusableBlocks = countReusableBlocks(uniqueTokens, req, /*onlyAllocated=*/true);
+            // Use the cached summary if provided; otherwise perform a fresh tree walk.
+            auto const summary
+                = cachedSummary.has_value() ? cachedSummary.value() : analyzePrefixReuse(req.getUniqueTokens(0), req);
+            auto const numReusableBlocks = summary.reusableBlocksAllocated;
             auto const promptInputLen = std::min(req.mPromptLen, windowSize + chunkSize);
             // `addSequence()` ignores the last prompt token because its KV cannot be recovered.
             // When the prompt lands exactly on a block boundary, counting reusable full blocks from
@@ -3343,7 +3309,8 @@ SizeType32 KVCacheManager::getNeededBlocksOneStep(
     return 0;
 }
 
-SizeType32 KVCacheManager::getRemainingBlocksToCompletion(LlmRequest const& req, SizeType32 windowSize) const
+SizeType32 KVCacheManager::getRemainingBlocksToCompletion(
+    LlmRequest const& req, SizeType32 windowSize, std::optional<PrefixReuseSummary> const& cachedSummary) const
 {
     // Default to zero; overwritten below when block reuse is active for a first-chunk context request.
     req.setEstimatedReusableTokens(0);
@@ -3410,21 +3377,25 @@ SizeType32 KVCacheManager::getRemainingBlocksToCompletion(LlmRequest const& req,
     if (mEnableBlockReuse && !mBlockManager.isVariableWindow() && req.isContextInitState() && req.isFirstContextChunk()
         && numAllocBlocksPerBeam == 0)
     {
-        auto const uniqueTokens = req.getUniqueTokens(0);
+        // Use the cached summary if provided; otherwise perform a fresh tree walk.
+        auto const summary
+            = cachedSummary.has_value() ? cachedSummary.value() : analyzePrefixReuse(req.getUniqueTokens(0), req);
         // Block budget: only subtract blocks that are already allocated (have active refs).
         // Free cached blocks are already counted in the eviction policy's free pool and
         // must not be double-counted against the capacity estimate.
-        auto const numReusableBlocksAllocated = countReusableBlocks(uniqueTokens, req, /*onlyAllocated=*/true);
-        numReusableContextBlocks = std::min(numReusableBlocksAllocated, numContextBlocks);
+        // Cap at (promptLen-1)/tpb to avoid over-counting when the prompt is exactly
+        // block-aligned (last full block has not been committed to the tree yet).
+        SizeType32 const maxRecoverableBlocks = (req.mPromptLen - 1) / getTokensPerBlock();
+        numReusableContextBlocks = std::min({summary.reusableBlocksAllocated, numContextBlocks, maxRecoverableBlocks});
         // Token budget: count all reusable blocks (free or allocated). Cached tokens need
         // not be recomputed regardless of whether their blocks currently have active refs.
-        auto const numReusableBlocksAll = countReusableBlocks(uniqueTokens, req, /*onlyAllocated=*/false);
-        req.setEstimatedReusableTokens(std::min(numReusableBlocksAll, numContextBlocks) * getTokensPerBlock());
+        req.setEstimatedReusableTokens(
+            std::min({summary.reusableBlocksAll, numContextBlocks, maxRecoverableBlocks}) * getTokensPerBlock());
         TLLM_LOG_DEBUG(
             "getRemainingBlocksToCompletion: request ID %lu, numContextBlocks=%d, "
             "numReusableBlocksAllocated=%d, numReusableBlocksAll=%d, "
             "numReusableContextBlocks=%d, numGenBlocksPerBeam=%d",
-            req.mRequestId, numContextBlocks, numReusableBlocksAllocated, numReusableBlocksAll,
+            req.mRequestId, numContextBlocks, summary.reusableBlocksAllocated, summary.reusableBlocksAll,
             numReusableContextBlocks, numGenBlocksPerBeam);
     }
 
@@ -3559,17 +3530,10 @@ void WindowBlockManager::detachFrontBlock(GenerationRequest& sequence)
     sequence.removeFrontBlock(mWindowSize);
 }
 
-std::optional<BlockKey> KVCacheManager::findNewContextBlock(
+PrefixReuseSummary KVCacheManager::analyzePrefixReuse(
     VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest) const
 {
-    auto newContextBlockOpt = mBlockManager.findNewContextBlock(uniqueTokens, llmRequest);
-    return newContextBlockOpt;
-}
-
-SizeType32 KVCacheManager::countReusableBlocks(
-    VecUniqueTokens const& uniqueTokens, LlmRequest const& llmRequest, bool onlyAllocated) const
-{
-    return mBlockManager.countReusableBlocks(uniqueTokens, llmRequest, onlyAllocated);
+    return mBlockManager.analyzePrefixReuse(uniqueTokens, llmRequest);
 }
 
 void KVCacheManager::addSequence(

--- a/cpp/tensorrt_llm/batch_manager/scheduledBlocksManager.h
+++ b/cpp/tensorrt_llm/batch_manager/scheduledBlocksManager.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <map>
 #include <optional>
+#include <vector>
 
 namespace tensorrt_llm::batch_manager::kv_cache_manager
 {
@@ -37,28 +38,40 @@ public:
     {
     }
 
-    void decrementReservedBlocks(LlmRequest const& req)
+    /// @brief  Check whether enough blocks are available for the request.
+    /// Caches the per-window block counts for a subsequent commitBlocks() call.
+    bool enoughAvailableBlocks(
+        LlmRequest const& req, std::optional<PrefixReuseSummary> const& cachedSummary = std::nullopt)
     {
-        for (auto& [windowSize, availableBlocks] : mAvailableBlocks)
+        mCachedNeededBlocks.clear();
+        bool enough = true;
+        for (auto const& [windowSize, availableBlocks] : mAvailableBlocks)
         {
-            availableBlocks -= mKvCacheManager.getRemainingBlocksToCompletion(req, windowSize);
+            auto const needed = mKvCacheManager.getRemainingBlocksToCompletion(req, windowSize, cachedSummary);
+            mCachedNeededBlocks.emplace_back(windowSize, needed);
+            if (needed > availableBlocks)
+            {
+                enough = false;
+            }
         }
+        return enough;
     }
 
-    bool enoughAvailableBlocks(LlmRequest const& req)
+    /// @brief  Subtract the block counts cached by the last enoughAvailableBlocks() call.
+    void commitBlocks()
     {
-        return std::all_of(mAvailableBlocks.cbegin(), mAvailableBlocks.cend(),
-            [this, &req](auto const& pair)
-            {
-                auto const& [windowSize, availableBlocks] = pair;
-                auto const neededBlocks = mKvCacheManager.getRemainingBlocksToCompletion(req, windowSize);
-                return neededBlocks <= availableBlocks;
-            });
+        for (auto const& [windowSize, needed] : mCachedNeededBlocks)
+        {
+            mAvailableBlocks[windowSize] -= needed;
+        }
+        mCachedNeededBlocks.clear();
     }
 
 private:
     BaseKVCacheManager const& mKvCacheManager;
     std::map<SizeType32, SizeType32> mAvailableBlocks;
+    // Cache from last enoughAvailableBlocks call, consumed by commitBlocks
+    std::vector<std::pair<SizeType32, SizeType32>> mCachedNeededBlocks;
 };
 
 class MaxUtilizationScheduledBlocksManager
@@ -77,12 +90,14 @@ public:
         }
     }
 
-    std::optional<std::map<SizeType32, SizeType32>> prepareNewNumberOfBlocksIfWeEndUpScheduling(LlmRequest const& req)
+    std::optional<std::map<SizeType32, SizeType32>> prepareNewNumberOfBlocksIfWeEndUpScheduling(
+        LlmRequest const& req, std::optional<PrefixReuseSummary> const& cachedSummary = std::nullopt)
     {
         std::map<SizeType32, SizeType32> blocksIfScheduled;
         for (auto const& [windowSize, numScheduled] : mNumScheduledBlocks)
         {
-            auto const required = mKvCacheManager.getNeededBlocksOneStep(req, mTwoStepsLookAhead, windowSize);
+            auto const required
+                = mKvCacheManager.getNeededBlocksOneStep(req, mTwoStepsLookAhead, windowSize, cachedSummary);
 
             TLLM_LOG_DEBUG("MaxUtilizationScheduler: request ID %lu required blocks %i for %i window size",
                 req.mRequestId, required, windowSize);

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -184,6 +184,12 @@ public:
         NB_OVERRIDE_PURE(isEnableBlockReuse);
     }
 
+    tbk::PrefixReuseSummary analyzePrefixReuse(
+        tbk::VecUniqueTokens const& uniqueTokens, tb::LlmRequest const& llmRequest) const override
+    {
+        NB_OVERRIDE_PURE(analyzePrefixReuse, uniqueTokens, llmRequest);
+    }
+
     bool isEnablePartialReuse() const override
     {
         NB_OVERRIDE_PURE(isEnablePartialReuse);
@@ -197,12 +203,6 @@ public:
     bool isCrossKv() const override
     {
         NB_OVERRIDE_PURE(isCrossKv);
-    }
-
-    std::optional<BlockKey> findNewContextBlock(
-        VecUniqueTokens const& uniqueTokens, tb::LlmRequest const& llmRequest) const override
-    {
-        NB_OVERRIDE_PURE(findNewContextBlock, uniqueTokens, llmRequest);
     }
 
     void storeContextBlocks(tb::LlmRequest const& llmRequest) override
@@ -272,12 +272,6 @@ public:
     {
         NB_OVERRIDE_PURE(flushIterationEvents);
     }
-
-    SizeType32 countReusableBlocks(VecUniqueTokens const& uniqueTokens, tb::LlmRequest const& llmRequest,
-        bool onlyAllocated = false) const override
-    {
-        NB_OVERRIDE_PURE(countReusableBlocks, uniqueTokens, llmRequest, onlyAllocated);
-    }
 };
 
 // TODO: Deduplicate executor bindings KvCacheStats
@@ -344,6 +338,12 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
     nb::enum_<tbk::LinearAttentionMetadata::LinearCacheType>(m, "LinearCacheType")
         .value("RECURRENT_STATES", tbk::LinearAttentionMetadata::LinearCacheType::kRecurrentStates);
 
+    nb::class_<tbk::PrefixReuseSummary>(m, "PrefixReuseSummary")
+        .def(nb::init<>())
+        .def_ro("reusable_blocks_allocated", &tbk::PrefixReuseSummary::reusableBlocksAllocated)
+        .def_ro("reusable_blocks_all", &tbk::PrefixReuseSummary::reusableBlocksAll)
+        .def_ro("first_new_block", &tbk::PrefixReuseSummary::firstNewBlock);
+
     nb::class_<tbk::KvCacheStats>(m, "KvCacheStats")
         .def(nb::init<>())
         .def_rw("max_num_blocks", &tbk::KvCacheStats::maxNumBlocks)
@@ -395,7 +395,9 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
             nb::arg("lora_task_id"), nb::arg("unique_tokens"))
         .def_ro("uses_extra_ids", &tbk::BlockKey::usesExtraIds)
         .def_ro("lora_task_id", &tbk::BlockKey::loraTaskId)
-        .def_ro("unique_tokens", &tbk::BlockKey::uniqueTokens);
+        .def_ro("unique_tokens", &tbk::BlockKey::uniqueTokens)
+        .def("__eq__", &tbk::BlockKey::operator==)
+        .def("__hash__", [](tbk::BlockKey const& key) -> size_t { return tbk::BlockKeyHasher{}(key); });
 
     nb::class_<tbk::BlockKeyHasher>(m, "BlockKeyHasher")
         .def_static("hash", &tbk::BlockKeyHasher::hash, nb::arg("block_key"), nb::arg("parent_hash") = 0);
@@ -422,10 +424,14 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
         .def("get_iteration_stats", &BaseKVCacheManager::getIterationStats, nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro("max_blocks_per_seq",
             [](tbk::BaseKVCacheManager& self) { return self.getOffsetTableDimensions().maxBlocksPerSeq; })
-        .def("get_needed_blocks_one_step", &BaseKVCacheManager::getNeededBlocksOneStep,
+        // nanobind does not inherit C++ default arguments from member-function pointers, so the
+        // cached_summary default must be spelled out here or Python callers that omit it raise
+        // TypeError. See kvCacheManager.h for the C++ signatures.
+        .def("get_needed_blocks_one_step", &BaseKVCacheManager::getNeededBlocksOneStep, nb::arg("req"),
+            nb::arg("two_steps_look_ahead"), nb::arg("window_size"), nb::arg("cached_summary") = std::nullopt,
             nb::call_guard<nb::gil_scoped_release>())
-        .def("get_remaining_blocks_to_completion", &BaseKVCacheManager::getRemainingBlocksToCompletion,
-            nb::call_guard<nb::gil_scoped_release>())
+        .def("get_remaining_blocks_to_completion", &BaseKVCacheManager::getRemainingBlocksToCompletion, nb::arg("req"),
+            nb::arg("window_size"), nb::arg("cached_summary") = std::nullopt, nb::call_guard<nb::gil_scoped_release>())
         .def("add_token", &BaseKVCacheManager::addToken, nb::call_guard<nb::gil_scoped_release>())
         .def("get_token_count", &BaseKVCacheManager::getTokenCount, nb::arg("request_id"))
         .def("add_sequence", &BaseKVCacheManager::addSequence, nb::call_guard<nb::gil_scoped_release>())
@@ -586,10 +592,8 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
         .def("store_context_blocks", &BaseKVCacheManager::storeContextBlocks, nb::call_guard<nb::gil_scoped_release>())
         .def("store_blocks_for_reuse", &BaseKVCacheManager::storeBlocksForReuse,
             nb::call_guard<nb::gil_scoped_release>())
-        .def("find_new_context_block", &BaseKVCacheManager::findNewContextBlock, nb::arg("unique_tokens"),
+        .def("analyze_prefix_reuse", &BaseKVCacheManager::analyzePrefixReuse, nb::arg("unique_tokens"),
             nb::arg("llm_request"), nb::call_guard<nb::gil_scoped_release>())
-        .def("count_reusable_blocks", &BaseKVCacheManager::countReusableBlocks, nb::arg("unique_tokens"),
-            nb::arg("llm_request"), nb::arg("only_allocated") = false, nb::call_guard<nb::gil_scoped_release>())
         .def("get_cache_block_ids", &BaseKVCacheManager::getCacheBlockIds, nb::call_guard<nb::gil_scoped_release>())
         .def("get_batch_cache_block_ids", &BaseKVCacheManager::getBatchCacheBlockIds,
             nb::call_guard<nb::gil_scoped_release>())

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -6228,9 +6228,9 @@ TEST(KVCacheManagerReuseAccountingTest, ReuseAwareBlockEstimatesStayConsistentAf
 
     // Note: storeContextBlocks only stores (length - 1) tokens worth of blocks
     // For 64 tokens with 16 tokens/block, only 63/16 = 3 full blocks are stored
-    auto const reusableBlocks = kvCacheManager->countReusableBlocks(req1.getUniqueTokens(0), req1);
+    auto const summary = kvCacheManager->analyzePrefixReuse(req1.getUniqueTokens(0), req1);
     auto const expectedReusableBlocks = (promptLength - 1) / tokensPerBlock; // 3 blocks
-    EXPECT_EQ(reusableBlocks, expectedReusableBlocks);
+    EXPECT_EQ(summary.reusableBlocksAll, expectedReusableBlocks);
 
     // After removeSequence, reusable blocks have no active refs and are free in the eviction queue.
     // The scheduling functions must NOT subtract free reusable blocks to avoid double-counting
@@ -6321,9 +6321,8 @@ TEST(KVCacheManagerReuseAccountingTest, NeededBlocksOneStepCapsAllocatedReuseAtE
     // boundary, but one generated token already exists in the token history.
     req1.addNewToken(promptLength, 0);
 
-    auto const reusableAllocatedBlocks
-        = kvCacheManager->countReusableBlocks(req1.getUniqueTokens(0), req1, /*onlyAllocated=*/true);
-    EXPECT_EQ(reusableAllocatedBlocks, promptLength / tokensPerBlock);
+    auto const summaryAlloc = kvCacheManager->analyzePrefixReuse(req1.getUniqueTokens(0), req1);
+    EXPECT_EQ(summaryAlloc.reusableBlocksAllocated, promptLength / tokensPerBlock);
 
     auto const neededOneStep
         = kvCacheManager->getNeededBlocksOneStep(req1, /*twoStepsLookAhead=*/false, onlyWindowSize);
@@ -6372,8 +6371,8 @@ TEST(KVCacheManagerReuseAccountingTest, CountReusableBlocksNoMatchReturnsZero)
     };
 
     // No blocks should be reusable since nothing has been cached
-    auto const reusableBlocks = kvCacheManager->countReusableBlocks(req.getUniqueTokens(0), req);
-    EXPECT_EQ(reusableBlocks, 0);
+    auto const summaryEmpty = kvCacheManager->analyzePrefixReuse(req.getUniqueTokens(0), req);
+    EXPECT_EQ(summaryEmpty.reusableBlocksAll, 0);
 }
 
 TEST(KVCacheManagerReuseAccountingTest, CountReusableBlocksPartialMatch)
@@ -6437,8 +6436,8 @@ TEST(KVCacheManagerReuseAccountingTest, CountReusableBlocksPartialMatch)
     };
 
     // Should find 2 reusable blocks (first 32 tokens match)
-    auto const reusableBlocks = kvCacheManager->countReusableBlocks(req1.getUniqueTokens(0), req1);
-    EXPECT_EQ(reusableBlocks, 2);
+    auto const summaryShared = kvCacheManager->analyzePrefixReuse(req1.getUniqueTokens(0), req1);
+    EXPECT_EQ(summaryShared.reusableBlocksAll, 2);
 
     // After removeSequence, reusable blocks are free (no active refs).
     // getNeededBlocksOneStep must NOT subtract free reusable blocks to avoid double-counting.
@@ -6709,9 +6708,9 @@ TEST(KVCacheManagerReuseAccountingTest, MultipleRequestsWithSharedPrefix)
         true,
     };
 
-    // Should reuse 2 blocks (shared prefix) — public API counts all reusable regardless of ref state
-    auto const reusableBlocks = kvCacheManager->countReusableBlocks(req1.getUniqueTokens(0), req1);
-    EXPECT_EQ(reusableBlocks, sharedPrefixLength / tokensPerBlock);
+    // Should reuse 2 blocks (shared prefix) — analyzePrefixReuse counts all reusable regardless of ref state
+    auto const summaryPrefix = kvCacheManager->analyzePrefixReuse(req1.getUniqueTokens(0), req1);
+    EXPECT_EQ(summaryPrefix.reusableBlocksAll, sharedPrefixLength / tokensPerBlock);
 
     // After removeSequence, reusable blocks are free (no active refs).
     // getNeededBlocksOneStep must NOT subtract free reusable blocks.

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -588,9 +588,8 @@ class KVCacheManager(BaseResourceManager):
                                   sampling_config=SamplingConfig(),
                                   is_streaming=False,
                                   lora_task_id=lora_task_id)
-        num_blocks = self.impl.count_reusable_blocks(unique_tokens, dummy_req,
-                                                     False)
-        return num_blocks * self.tokens_per_block
+        summary = self.impl.analyze_prefix_reuse(unique_tokens, dummy_req)
+        return summary.reusable_blocks_all * self.tokens_per_block
 
     def shutdown(self):
         self.impl.release_pools()

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
@@ -1315,34 +1315,20 @@ class PyCapacityScheduler:
                 # Chunked context request already executing
                 if enable_block_reuse:
                     unique_tokens = req.get_unique_tokens(0)
-                    block_key = self.kv_cache_manager.find_new_context_block(unique_tokens, req)
-                    if block_key is not None:
-                        newly_contributed_context_blocks.add(block_key)
+                    summary = self.kv_cache_manager.analyze_prefix_reuse(unique_tokens, req)
+                    if summary.first_new_block is not None:
+                        newly_contributed_context_blocks.add(summary.first_new_block)
 
                 if cross_enable_reuse:
                     encoder_unique_tokens = req.get_encoder_unique_tokens()
                     if encoder_unique_tokens is not None:
-                        block_key = self.cross_kv_cache_manager.find_new_context_block(
+                        summary = self.cross_kv_cache_manager.analyze_prefix_reuse(
                             encoder_unique_tokens, req
                         )
-                        if block_key is not None:
-                            newly_contributed_cross_context_blocks.add(block_key)
+                        if summary.first_new_block is not None:
+                            newly_contributed_cross_context_blocks.add(summary.first_new_block)
 
         return newly_contributed_context_blocks, newly_contributed_cross_context_blocks
-
-    def _one_manager_beneficial_to_skip(
-        self, kv_cache_manager, unique_tokens, req: LlmRequest, newly_contributed_blocks: set
-    ) -> bool:
-        """
-        Check if skipping is beneficial for one KV cache manager.
-        C++ reference: capacityScheduler.cpp:70-92 (oneManagerBeneficialToSkip)
-        """
-        new_context_block = kv_cache_manager.find_new_context_block(unique_tokens, req)
-        if new_context_block is not None:
-            if new_context_block in newly_contributed_blocks:
-                return True
-            newly_contributed_blocks.add(new_context_block)
-        return False
 
     def _beneficial_to_skip(
         self,
@@ -1355,17 +1341,24 @@ class PyCapacityScheduler:
         A request should be skipped if it can reuse blocks contributed by
         already scheduled context requests.
 
-        C++ reference: capacityScheduler.cpp:97-123 (beneficialToSkip)
+        When the request is NOT skipped, its firstNewBlock contributions are
+        registered so that subsequent duplicate requests can be deferred.
+
+        C++ reference: capacityScheduler.cpp (beneficialToSkip / oneManagerBeneficialToSkip)
         """
         if not (req.is_context_init_state and req.is_first_context_chunk):
             return False
 
+        ctx_new_block = None
+        cross_new_block = None
+
         if self.kv_cache_manager is not None and self.kv_cache_manager.enable_block_reuse:
             unique_tokens = req.get_unique_tokens(0)
-            if self._one_manager_beneficial_to_skip(
-                self.kv_cache_manager, unique_tokens, req, newly_contributed_context_blocks
-            ):
-                return True
+            summary = self.kv_cache_manager.analyze_prefix_reuse(unique_tokens, req)
+            if summary.first_new_block is not None:
+                if summary.first_new_block in newly_contributed_context_blocks:
+                    return True
+                ctx_new_block = summary.first_new_block
 
         if (
             self.cross_kv_cache_manager is not None
@@ -1373,13 +1366,20 @@ class PyCapacityScheduler:
         ):
             encoder_unique_tokens = req.get_encoder_unique_tokens()
             if encoder_unique_tokens is not None:
-                if self._one_manager_beneficial_to_skip(
-                    self.cross_kv_cache_manager,
-                    encoder_unique_tokens,
-                    req,
-                    newly_contributed_cross_context_blocks,
-                ):
-                    return True
+                summary = self.cross_kv_cache_manager.analyze_prefix_reuse(
+                    encoder_unique_tokens, req
+                )
+                if summary.first_new_block is not None:
+                    if summary.first_new_block in newly_contributed_cross_context_blocks:
+                        return True
+                    cross_new_block = summary.first_new_block
+
+        # Request is NOT skipped — register contributions so subsequent duplicate
+        # requests can be deferred correctly.
+        if ctx_new_block is not None:
+            newly_contributed_context_blocks.add(ctx_new_block)
+        if cross_new_block is not None:
+            newly_contributed_cross_context_blocks.add(cross_new_block)
 
         return False
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2431,7 +2431,7 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
     )
 
     def _to_pybind(self):
-        return _KvCacheConfig(
+        config = _KvCacheConfig(
             enable_block_reuse=self.enable_block_reuse,
             max_tokens=self.max_tokens,
             max_attention_window=self.max_attention_window,
@@ -2447,6 +2447,7 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
             attention_dp_events_gather_period_ms=self.
             attention_dp_events_gather_period_ms,
             max_gpu_total_bytes=self.max_gpu_total_bytes)
+        return config
 
     @field_validator('free_gpu_memory_fraction')
     @classmethod

--- a/tests/unittest/_torch/executor/test_kvcache_aware_router.py
+++ b/tests/unittest/_torch/executor/test_kvcache_aware_router.py
@@ -410,8 +410,8 @@ class TestProbeOnV1KVCacheManager:
 
         result = KVCacheManager.probe_prefix_match_length(mgr, input_tokens=[1, 2, 3])
         assert result == 0
-        # count_reusable_blocks should NOT be called (would crash)
-        mgr.impl.count_reusable_blocks.assert_not_called()
+        # analyze_prefix_reuse should NOT be called (would crash)
+        mgr.impl.analyze_prefix_reuse.assert_not_called()
 
     def test_empty_tokens_returns_zero(self):
         from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
@@ -432,7 +432,9 @@ class TestProbeOnV1KVCacheManager:
         mgr.enable_block_reuse = True
         mgr.impl = Mock()
         mgr.impl.is_variable_window = False
-        mgr.impl.count_reusable_blocks = Mock(return_value=3)
+        mock_summary = Mock()
+        mock_summary.reusable_blocks_all = 3
+        mgr.impl.analyze_prefix_reuse = Mock(return_value=mock_summary)
         mgr.tokens_per_block = 64
 
         result = KVCacheManager.probe_prefix_match_length(mgr, input_tokens=list(range(200)))

--- a/tests/unittest/_torch/executor/test_py_scheduler.py
+++ b/tests/unittest/_torch/executor/test_py_scheduler.py
@@ -37,6 +37,15 @@ from tensorrt_llm._torch.pyexecutor.scheduler.scheduler import (
 from tensorrt_llm.llmapi.llm_args import CapacitySchedulerPolicy
 
 
+@dataclass
+class MockPrefixReuseSummary:
+    """Mock for C++ PrefixReuseSummary returned by analyze_prefix_reuse."""
+
+    reusable_blocks_allocated: int = 0
+    reusable_blocks_all: int = 0
+    first_new_block: Optional[object] = None
+
+
 def _make_request(
     request_id: int,
     prompt_len: int = 10,
@@ -165,8 +174,17 @@ class MockKVCacheManager:
     def scheduling_remove_sequence(self, req_id: int):
         pass
 
-    def find_new_context_block(self, unique_tokens, req):
-        return None
+    def analyze_prefix_reuse(self, unique_tokens, req):
+        if self.enable_block_reuse and unique_tokens:
+            # Derive a deterministic, hashable block key from the tokens so that
+            # duplicate requests produce equal first_new_block values and trigger
+            # the beneficial-to-skip logic.  UniqueToken objects (nanobind-wrapped
+            # C++ structs) have no __hash__/__eq__, so extract the primitive fields.
+            block_key = tuple(
+                t if isinstance(t, int) else (t.token_id, t.token_extra_id) for t in unique_tokens
+            )
+            return MockPrefixReuseSummary(first_new_block=block_key)
+        return MockPrefixReuseSummary()
 
     def get_max_resource_count(self) -> int:
         return self._num_free_blocks
@@ -2446,8 +2464,11 @@ class TestPyCapacitySchedulerKVCacheReuse:
         r1 = _make_request(1, prompt_len=21, input_tokens=tokens)
         r2 = _make_request(2, prompt_len=21, input_tokens=tokens)
         fitting, disagg, paused = scheduler.schedule_request([r0, r1, r2])
-        # With reuse enabled, beneficial_to_skip may delay r1 and r2
-        assert len(fitting) >= 1
+        # With reuse enabled, r1 and r2 share the same prefix as r0 and are delayed.
+        # GUARANTEED_NO_EVICT skips them via continue — they are not in paused.
+        assert len(fitting) == 1
+        assert fitting[0].request_id == 0
+        assert len(paused) == 0
 
     def test_delay_duplicate_request_chunked(self):
         """C++ ref: DelayDuplicateRequestChunked"""
@@ -2463,7 +2484,11 @@ class TestPyCapacitySchedulerKVCacheReuse:
         r1 = _make_request(1, prompt_len=50, input_tokens=tokens)
         r1.context_chunk_size = 20
         fitting, disagg, paused = scheduler.schedule_request([r0, r1])
-        assert len(fitting) >= 1
+        # r1 shares the same prefix as r0 and is delayed.
+        # GUARANTEED_NO_EVICT skips it via continue — it is not in paused.
+        assert len(fitting) == 1
+        assert fitting[0].request_id == 0
+        assert len(paused) == 0
 
     def test_delay_five_requests_complicated(self):
         """C++ ref: DelayFiveRequestsComplicated"""
@@ -2493,7 +2518,11 @@ class TestPyCapacitySchedulerKVCacheReuse:
         r0 = _make_request(0, prompt_len=20, input_tokens=tokens)
         r1 = _make_request(1, prompt_len=20, input_tokens=tokens)
         fitting, disagg, paused = scheduler.schedule_request([r0, r1])
-        assert len(fitting) >= 1
+        # r1 shares the same prefix as r0 and is delayed.
+        # GUARANTEED_NO_EVICT skips it via continue — it is not in paused.
+        assert len(fitting) == 1
+        assert fitting[0].request_id == 0
+        assert len(paused) == 0
 
     def test_reuse_aware_partial_prefix_match(self):
         """C++ ref: ReuseAwareSchedulingWithPartialPrefixMatch"""
@@ -2508,7 +2537,8 @@ class TestPyCapacitySchedulerKVCacheReuse:
         r0 = _make_request(0, prompt_len=30, input_tokens=tokens0)
         r1 = _make_request(1, prompt_len=30, input_tokens=tokens1)
         fitting, disagg, paused = scheduler.schedule_request([r0, r1])
-        assert len(fitting) >= 1
+        # Different token sequences produce different block keys — no skipping
+        assert len(fitting) == 2
 
     def test_no_reuse_with_different_prompts(self):
         """C++ ref: NoReuseWithDifferentPrompts"""


### PR DESCRIPTION
Replace separate findNewContextBlock() + countReusableBlocks(onlyAllocated=true/false) with a single analyzePrefixReuse() returning PrefixReuseSummary, reducing 2-3 redundant radix tree walks per request to 1. Cache the summary in the capacityscheduler loop and thread it through getNeededBlocksOneStep/getRemainingBlocksToCompletion. Refactor GuaranteedNoEvict block tracking to enoughAvailableBlocks()+commitBlocks() pattern to avoid recomputing block counts. Update nanobind bindings, Python callers, and all tests. Fix MockKVCacheManager to return a deterministic first_new_block so beneficial-to-skip logic is actually exercised in scheduler tests.

# Prefix-Aware Scheduling: Overhead Analysis & Optimization Report

## Summary

Prefix-aware scheduling inspects the KV cache radix tree during capacity scheduling to estimate how many blocks can be reused for each incoming request. This enables smarter admission decisions (admitting more requests per iteration) and token budget optimization (reducing compute for cached prefixes).

Patrice raised the concern that these radix tree inspections add non-negligible overhead at high concurrency. We investigated, confirmed the redundancy, optimized it, and measured the result. **After optimization, prefix-aware scheduling adds zero extra radix tree walks compared to the baseline with block reuse enabled.** There is no need for a configuration flag to disable it.

---

## The Original Problem: Redundant Radix Tree Walks

Before this change, the capacity scheduler performed **multiple redundant radix tree walks per pending context request**. Each walk acquires `mCachedBlocksRootMutex`, calls `chopVectorIntoBlocks` + `buildBlockKeys`, then iterates over block keys calling `findMatchingBlock`. All walks operate on the same tokens for the same request — pure redundancy.

### GuaranteedNoEvict scheduler (default) — before optimization

For each pending context request in the scheduling loop:

| Call | What it does | Walks |
|------|-------------|-------|
| `beneficialToSkip()` → `findNewContextBlock()` | Finds first uncached block key | 1 |
| `enoughAvailableBlocks()` → `getRemainingBlocksToCompletion()` → `countReusableBlocks(true)` + `countReusableBlocks(false)` | Counts reusable blocks (allocated and total) for budget estimation | 2 |
| `decrementReservedBlocks()` → `getRemainingBlocksToCompletion()` → same as above | Same computation again for decrementing available blocks | 2 |
| **Total per request** | | **5 walks** |

(In the original code before `analyzePrefixReuse` consolidation, `getRemainingBlocksToCompletion` called `countReusableBlocks` twice — once with `onlyAllocated=true` and once with `onlyAllocated=false`.)

### MaxUtilization scheduler — before optimization

| Call | Walks |
|------|-------|
| `beneficialToSkip()` → `findNewContextBlock()` | 1 |
| `prepareNewNumberOfBlocksIfWeEndUpScheduling()` → `getNeededBlocksOneStep()` → `countReusableBlocks(true)` | 1 |
| **Total per request** | **2 walks** |

---

## The Optimization: Single Walk with Cached Summary

### Step 1: `analyzePrefixReuse()` — merge 3 functions into 1

We replaced three separate functions (`findNewContextBlock`, `countReusableBlocks(true)`, `countReusableBlocks(false)`) with a single `analyzePrefixReuse()` that returns a `PrefixReuseSummary`:

```cpp
struct PrefixReuseSummary {
    SizeType32 reusableBlocksAllocated;  // blocks with active refs (for block budget)
    SizeType32 reusableBlocksAll;        // all cached blocks (for token budget)
    std::optional<BlockKey> firstNewBlock; // first uncached block (for skip-check)
};
```

One lock acquisition, one tree traversal, all three results.

### Step 2: Cache the summary across callers

Both capacity schedulers now compute `analyzePrefixReuse()` **once** at the top of the pending-request loop and pass the cached `PrefixReuseSummary` through to all downstream callers:

- The **skip-check** reads `summary.firstNewBlock` directly (no function call)
- `enoughAvailableBlocks(req, summary)` passes the cached summary to `getRemainingBlocksToCompletion`, which uses it instead of re-walking the tree
- `decrementCachedBlocks()` uses the block counts already computed by `enoughAvailableBlocks`, eliminating the second call to `getRemainingBlocksToCompletion` entirely

### After optimization

| Scheduler | Walks per pending context request |
|-----------|----------------------------------|
| GuaranteedNoEvict | **1** (down from 5) |
| MaxUtilization | **1** (down from 2) |

Critically, this single walk is gated by `isEnableBlockReuse()` — it happens whether prefix-aware scheduling is "on" or "off." **There is no additional work that could be gated by a separate flag.** The radix tree walk is required for the `beneficialToSkip` optimization (a block reuse feature), and its results are now reused for budget estimation at zero extra cost.

---

## Benchmark Setup

### Environment

| Platform | GPUs | Model | TP |
|----------|------|-------|----|
| B200 node | 8 × NVIDIA B200 | DeepSeek-V3.2-NVFP4 (671B MoE) | 8 |
| H100 node | 8 × NVIDIA H100 PCIe | Llama-3.3-70B-Instruct-FP8 | 8 |

### Workload

Each concurrency level N sends N requests simultaneously via `LLM.generate()` with `max_tokens=1` (minimize execution time, isolate scheduling overhead). All requests share a ~400-token system prompt prefix with unique 50-word suffixes, creating the prefix-sharing pattern that exercises the radix tree.

### Timing Method

We instrumented `SimpleScheduler.schedule_request()` (the production Python wrapper around the C++ `BindCapacityScheduler` + `BindMicroBatchScheduler`) with timing code gated by the `TLLM_SCHED_TIMING_FILE` environment variable. The `TLLM_` prefix ensures propagation to MPI worker processes via `mpi_session.py`. Each scheduler invocation writes a JSON line with `{elapsed_us, n_ctx, n_gen, n_active, pid}` to the timing file. The main process reads these after `generate()` completes.

**Per-iteration time** = `total_scheduler_us / num_iterations`. This is the average wall-clock time of each `schedule_request()` call. Since the scheduler is called multiple times per `generate()` (processing requests in batches until all complete), this metric isolates the per-call overhead.

**Why per-iteration, not total?** With prefix-aware scheduling, the scheduler admits more requests per pass (thanks to reuse credit), needing fewer total iterations. Without it, budgets are pessimistic, fewer requests fit per pass, and many more iterations are needed. Total scheduler time conflates per-call cost with iteration count — per-iteration time isolates the actual scheduling work.

### Runs

- **v1 (before optimization):** The original code with redundant tree walks
- **v2 (after optimization):** The cached-summary optimization (1 walk per request)

Each configuration was run with 3 repeats per concurrency level.

---

## Results

### B200 — DeepSeek-V3.2-NVFP4

#### Per-Iteration Scheduler Time (the key metric)

"v1 ON" = before optimization with prefix-aware enabled (redundant tree walks).
"v2 ON" = after optimization with prefix-aware enabled (cached single walk).
"OFF" = prefix-aware scheduling disabled (`enable_block_reuse=true` but no reuse estimation). This represents the theoretical minimum — no budget estimation work at all. Measured alongside v2 using the same binary.

| Concurrency | v1 ON (us) | v2 ON (us) | OFF (us) | v1 ON vs OFF | v2 ON vs OFF |
|:-----------:|-----------:|-----------:|---------:|-------------:|-------------:|
| 1 | 39 | 25 | 25 | +56% | **+0%** |
| 4 | 57 | 34 | 34 | +68% | **+0%** |
| 16 | 166 | 78 | 66 | +152% | **+18%** |
| 64 | 629 | 273 | 245 | +157% | **+11%** |
| 256 | 1,800 | 832 | 1,022 | +80% | **-19%** |
| 1024 | 4,454 | 2,432 | 4,239 | +5% | **-43%** |

At low concurrency (1-4), v2 ON is indistinguishable from OFF — the cached summary adds zero measurable overhead. At mid concurrency (16-64), v2 ON is only 11-18% above OFF, down from 150%+ in v1. At high concurrency (256-1024), v2 ON is actually **cheaper** than OFF per iteration because the reuse-aware budget admits more requests per pass, reducing the number of pending requests the scheduler must evaluate in subsequent iterations.

#### Total Scheduler Time

| Concurrency | v1 ON (us) | v2 ON (us) | OFF (us) | v1 ON vs OFF | v2 ON vs OFF |
|:-----------:|-----------:|-----------:|---------:|-------------:|-------------:|
| 1 | 311 | 198 | 203 | +53% | **-2%** |
| 4 | 910 | 548 | 542 | +68% | **+1%** |
| 16 | 2,650 | 1,249 | 1,593 | +66% | **-22%** |
| 64 | 10,060 | 4,372 | 13,699 | -27% | **-68%** |
| 256 | 43,211 | 19,977 | 188,074 | -77% | **-89%** |
| 1024 | 217,836 | 145,847 | 2,950,478 | -93% | **-95%** |

At concurrency >= 64, prefix-aware scheduling has **lower total scheduler time** than OFF in both v1 and v2, because it admits more requests per pass and requires far fewer iterations.

#### Scheduler Iterations

| Concurrency | ON iters | OFF iters | Ratio |
|:-----------:|---------:|----------:|------:|
| 1 | 8 | 8 | 1.0x |
| 16 | 16 | 24 | 1.5x |
| 64 | 16 | 56 | 3.5x |
| 256 | 24 | 184 | 7.7x |
| 1024 | 48 | 696 | **14.5x** |

Without reuse credit, the scheduler needs **14.5x more iterations** at concurrency=1024 because each pass admits far fewer requests.

#### E2E Performance

| Concurrency | With prefix-aware (s) | Without (s) | Speedup |
|:-----------:|---------------------:|------------:|--------:|
| 16 | 0.26 | 0.37 | 1.4x |
| 64 | 0.30 | 0.91 | 3.0x |
| 256 | 0.65 | 3.01 | 4.6x |
| 1024 | 1.79 | 11.83 | **6.6x** |

#### Scheduler as % of E2E

| Concurrency | v2 ON sched% | OFF sched% |
|:-----------:|-------------:|-----------:|
| 64 | 1.44% | 1.51% |
| 256 | 3.08% | 6.24% |
| 1024 | 8.14% | 24.94% |

### H100 — Llama-3.3-70B-Instruct-FP8

#### Per-Iteration Scheduler Time

| Concurrency | v1 ON (us) | v2 ON (us) | OFF (us) | v1 ON vs OFF | v2 ON vs OFF |
|:-----------:|-----------:|-----------:|---------:|-------------:|-------------:|
| 1 | 70 | 48 | 48 | +52% | **+0%** |
| 16 | 2,149 | 1,030 | 860 | +150% | **+20%** |
| 64 | 5,958 | 2,436 | 1,274 | +368% | **+91%** |
| 256 | 11,208 | 4,876 | 12,460 | -10% | **-61%** |
| 1024 | 22,032 | 13,977 | 44,837 | -51% | **-69%** |

The H100 shows a wider gap at mid-concurrency (64) because Llama-70B has longer per-request scheduling work. At high concurrency, the pattern matches B200: v2 ON is cheaper than OFF per iteration.

#### Total Scheduler Time

| Concurrency | v1 ON (us) | v2 ON (us) | OFF (us) | v1 ON vs OFF | v2 ON vs OFF |
|:-----------:|-----------:|-----------:|---------:|-------------:|-------------:|
| 1 | 563 | 384 | 384 | +47% | **+0%** |
| 16 | 34,378 | 16,480 | 20,640 | +67% | **-20%** |
| 64 | 142,980 | 46,284 | 71,344 | +100% | **-35%** |
| 256 | 264,740 | 141,404 | 2,292,640 | -88% | **-94%** |
| 1024 | 2,312,679 | 1,341,792 | 31,206,552 | -93% | **-96%** |

#### E2E Performance

| Concurrency | With prefix-aware (s) | Without (s) | Speedup |
|:-----------:|---------------------:|------------:|--------:|
| 16 | 1.89 | 2.45 | 1.3x |
| 64 | 6.59 | 8.64 | 1.3x |
| 256 | 16.08 | 24.27 | 1.5x |
| 1024 | 47.39 | 100.81 | **2.1x** |

#### Scheduler as % of E2E

| Concurrency | v2 ON sched% | OFF sched% |
|:-----------:|-------------:|-----------:|
| 64 | 0.76% | 0.83% |
| 256 | 0.95% | 9.44% |
| 1024 | 2.66% | 30.96% |

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->
## Test Coverage
Existing tests have good coverage.
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Consolidated KV-cache reuse analysis and added optional cached results so schedulers avoid redundant work, improving throughput and reducing scheduling overhead.
* **New Features**
  * Exposed a reusable-prefix summary to higher-level bindings so callers can inspect reuse estimates.
* **Tests**
  * Updated unit tests and scheduler tests to reflect the new reuse-summary-driven behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->