### PR TITLE
[None][fix] Fix errors in KV cache manager V2 and scheduler V2

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1398,13 +1398,8 @@ class PyExecutor:
                 can_queue, can_queue_this_rank = self._can_queue(
                     scheduled_batch)
                 if not can_queue:
-                    # Revert spurious KV cache capacity growth (see
-                    # _executor_loop for the full comment).
-                    if can_queue_this_rank \
-                            and self._scheduler_manages_kv_suspend:
-                        for req in scheduled_batch.generation_requests:
-                            self.kv_cache_manager.revert_allocate_generation(
-                                req)
+                    self._maybe_revert_kv_growth(scheduled_batch, can_queue,
+                                                 can_queue_this_rank)
                     logger.debug(
                         f"microbatch {microbatch_id} cannot be queued, skipping"
                     )
@@ -1795,6 +1790,21 @@ class PyExecutor:
 
         return can_queue, can_queue_this_rank
 
+    def _maybe_revert_kv_growth(self, scheduled_batch, can_queue: bool,
+                                can_queue_this_rank: bool):
+        """Revert KV cache capacity growth when the batch is skipped.
+
+        With attention DP, can_queue=False means another rank has an empty
+        batch so no forward pass will run.  The V2 scheduler already grew
+        each generation request's KV cache capacity during scheduling;
+        revert that growth so it does not accumulate across skipped
+        iterations and overflow the host page-index buffer.
+        """
+        if not can_queue and can_queue_this_rank \
+                and self._scheduler_manages_kv_suspend:
+            for req in scheduled_batch.generation_requests:
+                self.kv_cache_manager.revert_allocate_generation(req)
+
     def _prepare_and_schedule_batch(self):
         new_requests = self._fetch_and_activate_new_requests()
         if self.should_stop_processing:
@@ -2069,12 +2079,8 @@ class PyExecutor:
                     can_queue, can_queue_this_rank = self._can_queue(
                         scheduled_batch)
 
-                # Revert spurious KV cache capacity growth (see overlap
-                # loop for the full comment).
-                if not can_queue and can_queue_this_rank \
-                        and self._scheduler_manages_kv_suspend:
-                    for req in scheduled_batch.generation_requests:
-                        self.kv_cache_manager.revert_allocate_generation(req)
+                self._maybe_revert_kv_growth(scheduled_batch, can_queue,
+                                             can_queue_this_rank)
 
                 if can_queue:
                     # init_disagg_gen_requests must be before drafter loop, otherwise draft requests do not have initialized matchers.
@@ -2327,16 +2333,8 @@ class PyExecutor:
                     can_queue, can_queue_this_rank = self._can_queue(
                         scheduled_batch)
 
-                # With attention DP, can_queue=False means another rank has
-                # an empty batch so no forward pass will run.  The V2
-                # scheduler already grew each generation request's KV cache
-                # capacity during scheduling; revert that growth so it does
-                # not accumulate across skipped iterations and overflow the
-                # host page-index buffer.
-                if not can_queue and can_queue_this_rank \
-                        and self._scheduler_manages_kv_suspend:
-                    for req in scheduled_batch.generation_requests:
-                        self.kv_cache_manager.revert_allocate_generation(req)
+                self._maybe_revert_kv_growth(scheduled_batch, can_queue,
+                                             can_queue_this_rank)
 
                 # If the batch is not empty on this rank, but empty on other ranks,
                 # we need to delay the update of the previous batch's sample state,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1395,8 +1395,16 @@ class PyExecutor:
                     f'{scheduled_batch.num_generation_requests} generation requests'
                 )
 
-                can_queue, _ = self._can_queue(scheduled_batch)
+                can_queue, can_queue_this_rank = self._can_queue(
+                    scheduled_batch)
                 if not can_queue:
+                    # Revert spurious KV cache capacity growth (see
+                    # _executor_loop for the full comment).
+                    if can_queue_this_rank \
+                            and self._scheduler_manages_kv_suspend:
+                        for req in scheduled_batch.generation_requests:
+                            self.kv_cache_manager.revert_allocate_generation(
+                                req)
                     logger.debug(
                         f"microbatch {microbatch_id} cannot be queued, skipping"
                     )

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2034,7 +2034,8 @@ class PyExecutor:
 
                 finished_requests = []
 
-                can_queue, _ = self._can_queue(scheduled_batch)
+                can_queue, can_queue_this_rank = self._can_queue(
+                    scheduled_batch)
 
                 if can_queue:
                     if self.kv_cache_transceiver:
@@ -2057,7 +2058,15 @@ class PyExecutor:
 
                 # if using a kv connector, we need to call can_queue again since scheduled_batch might have changed
                 if self.kv_connector_manager:
-                    can_queue, _ = self._can_queue(scheduled_batch)
+                    can_queue, can_queue_this_rank = self._can_queue(
+                        scheduled_batch)
+
+                # Revert spurious KV cache capacity growth (see overlap
+                # loop for the full comment).
+                if not can_queue and can_queue_this_rank \
+                        and self._scheduler_manages_kv_suspend:
+                    for req in scheduled_batch.generation_requests:
+                        self.kv_cache_manager.revert_allocate_generation(req)
 
                 if can_queue:
                     # init_disagg_gen_requests must be before drafter loop, otherwise draft requests do not have initialized matchers.
@@ -2309,6 +2318,17 @@ class PyExecutor:
                 if self.kv_connector_manager:
                     can_queue, can_queue_this_rank = self._can_queue(
                         scheduled_batch)
+
+                # With attention DP, can_queue=False means another rank has
+                # an empty batch so no forward pass will run.  The V2
+                # scheduler already grew each generation request's KV cache
+                # capacity during scheduling; revert that growth so it does
+                # not accumulate across skipped iterations and overflow the
+                # host page-index buffer.
+                if not can_queue and can_queue_this_rank \
+                        and self._scheduler_manages_kv_suspend:
+                    for req in scheduled_batch.generation_requests:
+                        self.kv_cache_manager.revert_allocate_generation(req)
 
                 # If the batch is not empty on this rank, but empty on other ranks,
                 # we need to delay the update of the previous batch's sample state,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1398,8 +1398,7 @@ class PyExecutor:
                 can_queue, can_queue_this_rank = self._can_queue(
                     scheduled_batch)
                 if not can_queue:
-                    self._maybe_revert_kv_growth(scheduled_batch, can_queue,
-                                                 can_queue_this_rank)
+                    self._maybe_revert_gen_alloc(scheduled_batch, can_queue)
                     logger.debug(
                         f"microbatch {microbatch_id} cannot be queued, skipping"
                     )
@@ -1790,8 +1789,7 @@ class PyExecutor:
 
         return can_queue, can_queue_this_rank
 
-    def _maybe_revert_kv_growth(self, scheduled_batch, can_queue: bool,
-                                can_queue_this_rank: bool):
+    def _maybe_revert_gen_alloc(self, scheduled_batch, can_queue: bool):
         """Revert KV cache capacity growth when the batch is skipped.
 
         With attention DP, can_queue=False means another rank has an empty
@@ -1799,9 +1797,13 @@ class PyExecutor:
         each generation request's KV cache capacity during scheduling;
         revert that growth so it does not accumulate across skipped
         iterations and overflow the host page-index buffer.
+
+        Only applies to KV cache manager V2 + scheduler V2, because the V2
+        scheduler allocates KV cache capacity during scheduling, before the
+        can_queue check.  V1 allocates in prepare_resources() after the
+        can_queue check, so no revert is needed.
         """
-        if not can_queue and can_queue_this_rank \
-                and self._scheduler_manages_kv_suspend:
+        if not can_queue and self._scheduler_manages_kv_suspend:
             for req in scheduled_batch.generation_requests:
                 self.kv_cache_manager.revert_allocate_generation(req)
 
@@ -2079,8 +2081,7 @@ class PyExecutor:
                     can_queue, can_queue_this_rank = self._can_queue(
                         scheduled_batch)
 
-                self._maybe_revert_kv_growth(scheduled_batch, can_queue,
-                                             can_queue_this_rank)
+                self._maybe_revert_gen_alloc(scheduled_batch, can_queue)
 
                 if can_queue:
                     # init_disagg_gen_requests must be before drafter loop, otherwise draft requests do not have initialized matchers.
@@ -2333,8 +2334,7 @@ class PyExecutor:
                     can_queue, can_queue_this_rank = self._can_queue(
                         scheduled_batch)
 
-                self._maybe_revert_kv_growth(scheduled_batch, can_queue,
-                                             can_queue_this_rank)
+                self._maybe_revert_gen_alloc(scheduled_batch, can_queue)
 
                 # If the batch is not empty on this rank, but empty on other ranks,
                 # we need to delay the update of the previous batch's sample state,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1395,10 +1395,9 @@ class PyExecutor:
                     f'{scheduled_batch.num_generation_requests} generation requests'
                 )
 
-                can_queue, can_queue_this_rank = self._can_queue(
-                    scheduled_batch)
+                can_queue, _ = self._can_queue(scheduled_batch)
                 if not can_queue:
-                    self._maybe_revert_gen_alloc(scheduled_batch, can_queue)
+                    self._revert_gen_alloc(scheduled_batch)
                     logger.debug(
                         f"microbatch {microbatch_id} cannot be queued, skipping"
                     )
@@ -1789,7 +1788,7 @@ class PyExecutor:
 
         return can_queue, can_queue_this_rank
 
-    def _maybe_revert_gen_alloc(self, scheduled_batch, can_queue: bool):
+    def _revert_gen_alloc(self, scheduled_batch):
         """Revert KV cache capacity growth when the batch is skipped.
 
         With attention DP, can_queue=False means another rank has an empty
@@ -1803,7 +1802,7 @@ class PyExecutor:
         can_queue check.  V1 allocates in prepare_resources() after the
         can_queue check, so no revert is needed.
         """
-        if not can_queue and self._scheduler_manages_kv_suspend:
+        if self._scheduler_manages_kv_suspend:
             for req in scheduled_batch.generation_requests:
                 self.kv_cache_manager.revert_allocate_generation(req)
 
@@ -2054,8 +2053,7 @@ class PyExecutor:
 
                 finished_requests = []
 
-                can_queue, can_queue_this_rank = self._can_queue(
-                    scheduled_batch)
+                can_queue, _ = self._can_queue(scheduled_batch)
 
                 if can_queue:
                     if self.kv_cache_transceiver:
@@ -2078,10 +2076,10 @@ class PyExecutor:
 
                 # if using a kv connector, we need to call can_queue again since scheduled_batch might have changed
                 if self.kv_connector_manager:
-                    can_queue, can_queue_this_rank = self._can_queue(
-                        scheduled_batch)
+                    can_queue, _ = self._can_queue(scheduled_batch)
 
-                self._maybe_revert_gen_alloc(scheduled_batch, can_queue)
+                if not can_queue:
+                    self._revert_gen_alloc(scheduled_batch)
 
                 if can_queue:
                     # init_disagg_gen_requests must be before drafter loop, otherwise draft requests do not have initialized matchers.
@@ -2334,7 +2332,8 @@ class PyExecutor:
                     can_queue, can_queue_this_rank = self._can_queue(
                         scheduled_batch)
 
-                self._maybe_revert_gen_alloc(scheduled_batch, can_queue)
+                if not can_queue:
+                    self._revert_gen_alloc(scheduled_batch)
 
                 # If the batch is not empty on this rank, but empty on other ranks,
                 # we need to delay the update of the previous batch's sample state,

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1735,6 +1735,13 @@ class KVCacheManagerV2(BaseResourceManager):
         assert quota != float(
             'inf'
         ), "Quota not set. Check kv_cache_config.max_tokens or kv_cache_config.max_gpu_total_bytes"
+
+        # Sync KV cache quota across TP ranks so all ranks allocate the same
+        # amount and the scheduler produces identical batches.
+        if mapping.world_size > 1:
+            dist = Distributed.get(mapping)
+            quota = dist.allreduce(quota, op=ReduceOp.MIN)
+
         logger.info(
             f"KV cache manager v2 device quota set to {quota / (1 << 30)}GiB")
 

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2058,6 +2058,25 @@ class KVCacheManagerV2(BaseResourceManager):
         return kv_cache.resize(
             self._required_gen_capacity(req, kv_cache.capacity))
 
+    def revert_allocate_generation(self, req: LlmRequest) -> None:
+        """Undo the capacity growth from try_allocate_generation.
+
+        When attention DP causes can_queue=False after scheduling, the
+        forward pass is skipped but the scheduler already grew each
+        generation request's KV cache capacity by 1 (+draft tokens).
+        This method shrinks capacity back to undo that spurious growth
+        so it does not accumulate across iterations and overflow the
+        host page-index buffer.
+        """
+        kv_cache = self.kv_cache_map.get(req.py_request_id)
+        if kv_cache is None or not kv_cache.is_active:
+            return
+        draft_len = get_draft_token_length(req)
+        reverted_cap = kv_cache.capacity - 1 - draft_len
+        if reverted_cap < 0:
+            return
+        kv_cache.resize(reverted_cap)
+
     def _restore_page_index_bufs(self, request_id: int, kv_cache) -> None:
         """Re-connect host page-index buffers after resume().
 

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2075,7 +2075,11 @@ class KVCacheManagerV2(BaseResourceManager):
         reverted_cap = kv_cache.capacity - 1 - draft_len
         if reverted_cap < 0:
             return
-        kv_cache.resize(reverted_cap)
+        if not kv_cache.resize(reverted_cap):
+            raise RuntimeError(
+                f"Failed to revert KV cache capacity for request "
+                f"{req.py_request_id} from {kv_cache.capacity} to "
+                f"{reverted_cap}")
 
     def _restore_page_index_bufs(self, request_id: int, kv_cache) -> None:
         """Re-connect host page-index buffers after resume().

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1736,11 +1736,16 @@ class KVCacheManagerV2(BaseResourceManager):
             'inf'
         ), "Quota not set. Check kv_cache_config.max_tokens or kv_cache_config.max_gpu_total_bytes"
 
-        # Sync KV cache quota across TP ranks so all ranks allocate the same
-        # amount and the scheduler produces identical batches.
+        # Sync KV cache token capacity across ranks so all ranks allocate
+        # the same number of tokens and the scheduler produces identical
+        # batches.  Normalize to token count before the allreduce because
+        # bytes_per_token varies across PP ranks (different local layers).
         if mapping.world_size > 1:
             dist = Distributed.get(mapping)
-            quota = dist.allreduce(quota, op=ReduceOp.MIN)
+            bytes_per_token = self.get_cache_bytes_per_token()
+            max_tokens = quota / bytes_per_token
+            max_tokens = dist.allreduce(max_tokens, op=ReduceOp.MIN)
+            quota = max_tokens * bytes_per_token
 
         logger.info(
             f"KV cache manager v2 device quota set to {quota / (1 << 30)}GiB")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed KV cache memory allocation issue in distributed inference scenarios where memory would accumulate across skipped iterations, improving overall memory efficiency during multi-rank inference operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Two fixes for KV cache manager V2 in multi-rank scenarios:

1. **Sync KV cache quota across TP ranks**: When `mapping.world_size > 1`, use `allreduce(MIN)` to ensure all TP ranks allocate the same KV cache quota. Without this, ranks with different available memory would get different quotas, causing the scheduler to produce different batches across ranks.

2. **Revert spurious KV cache capacity growth**: When attention DP causes `can_queue=False` after scheduling (another rank has an empty batch), the forward pass is skipped but the V2 scheduler already grew each generation request's KV cache capacity. Add `revert_allocate_generation()` to undo that growth so it does not accumulate across skipped iterations and overflow the host page-index buffer. Applied in both the non-overlap and overlap executor loops.

## Test Coverage

- Multi-GPU TP tests with KV cache manager V2
- Attention DP scenarios with mismatched batch sizes across ranks

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.