### PR TITLE
[None][fix] Remove leftover onboardBlocks param in kvCacheManagerTest

### DIFF
--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -4519,7 +4519,6 @@ TEST_F(KVCacheManagerTest, StoreBlocksForReuseWithPinDoesNotCreateGhostFreeBlock
     auto constexpr blocksInSecondaryPool = 0;
     auto constexpr maxNumSequences = 8;
     auto const stream = std::make_shared<tr::CudaStream>();
-    auto constexpr onboardBlocks = true;
     auto constexpr beamWidth = 1;
     auto const maxAttentionWindow = tokensPerBlock * blocksInPrimaryPool;
 
@@ -4527,7 +4526,7 @@ TEST_F(KVCacheManagerTest, StoreBlocksForReuseWithPinDoesNotCreateGhostFreeBlock
 
     KVCacheManager kvCacheManager(numLayers, numKvHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
         beamWidth, std::vector<BlockManager::SizeType32>{maxAttentionWindow}, std::nullopt, nvinfer1::DataType::kHALF,
-        0, stream, maxAttentionWindow, true /* enableBlockReuse */, onboardBlocks);
+        0, stream, maxAttentionWindow, true /* enableBlockReuse */);
     kvCacheManager.allocatePools(false);
 
     auto const totalBlocks = kvCacheManager.getMaxNumBlocks();


### PR DESCRIPTION
## Description

Commit ec3464418 ("[None][chore] Remove onboard block switch for KV cache manager (#12449)") removed the `onboardBlocks` parameter from the `KVCacheManager` constructor but missed the `StoreBlocksForReuseWithPinDoesNotCreateGhostFreeBlocks` test case in `kvCacheManagerTest.cpp`, causing a compilation error.

This PR removes the leftover `onboardBlocks` variable and its usage from the constructor call.

## Test Coverage

- The fix is removing a stale argument from an existing test. No new tests needed.
- The affected test (`StoreBlocksForReuseWithPinDoesNotCreateGhostFreeBlocks`) will now compile and run correctly.

## PR Checklist

- [x] I have read and followed the [TensorRT-LLM Contribution Guidelines](CONTRIBUTING.md)

## GitHub Bot Help

| Command | Description |
|---------|-------------|
| `/bot run` | Run default CI pipeline |
| `/bot help` | List all bot commands |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified a regression test for the KV cache manager by removing an unused constructor parameter, streamlining test configuration while maintaining test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->