### PR TITLE
fix: guard enable_partial_reuse_for_disagg against in-flight KV transfers

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3721,9 +3721,17 @@ class PyExecutor:
                     # Already terminated by _check_disagg_ctx_cache_transfer_status;
                     # track for stats only to avoid double-free (nvbug/5961736).
                     requests_finished_by_transfer.append(request)
+                elif request.is_disagg_context_transmission_state:
+                    # Request is still transferring KV cache to the decode worker.
+                    # Do NOT terminate — the C++ CacheTransceiver holds a raw
+                    # pointer in mSenderFutures. Terminating now would create a
+                    # dangling pointer causing heap corruption (free(): invalid
+                    # next size). Let the transfer complete or time out via
+                    # kv_transfer_timeout_ms in checkContextTransferStatus.
+                    pass
                 elif force_terminate_for_partial_reuse:
                     requests_to_terminate.append(request)
-                elif not request.is_disagg_context_transmission_state:
+                else:
                     requests_to_terminate.append(request)
             else:
                 new_active_requests.append(request)


### PR DESCRIPTION
## Summary

- Add `is_disagg_context_transmission_state` guard before the `force_terminate_for_partial_reuse` branch in `_check_request_responses()`
- Prevents heap corruption (`free(): invalid next size`) caused by terminating requests during active KV cache transfer in disaggregated mode

## Problem

The `force_terminate_for_partial_reuse` branch (line 3724) terminates requests unconditionally when `enable_partial_reuse_for_disagg` is `True`, including requests in `DISAGG_CONTEXT_TRANS_IN_PROGRESS` state. This creates dangling pointers in the C++ `CacheTransceiver::mSenderFutures` map, causing heap corruption when the freed memory is later accessed.

### Before (buggy)
```python
if request.is_disagg_context_complete_state:
    requests_finished_by_transfer.append(request)
elif force_terminate_for_partial_reuse:
    requests_to_terminate.append(request)  # ← terminates during active KV transfer!
elif not request.is_disagg_context_transmission_state:
    requests_to_terminate.append(request)
```

### After (fixed)
```python
if request.is_disagg_context_complete_state:
    requests_finished_by_transfer.append(request)
elif request.is_disagg_context_transmission_state:
    pass  # ← skip termination during KV transfer
elif force_terminate_for_partial_reuse:
    requests_to_terminate.append(request)
else:
    requests_to_terminate.append(request)
```

## Crash stack trace

```
free(): invalid next size (fast)
→ LRUEvictionPolicy::claimBlock
→ WindowBlockManager::getFreeBlock
→ WindowBlockManager::addSequence
→ KVCacheManager::addSequence
```

## Reproduction

- Model: Qwen3-0.6B, 1P1D disaggregated, `free_gpu_memory_fraction=0.3`, NIXL backend
- Load: concurrency 48, ISL 8000, 120s
- Crashes in ~65s without the fix
- With fix applied (in-place patch), same test runs to completion without crash

## Test plan

- [x] In-place patched rc11 image, ran overload test (conc 48, ISL 8000, 120s) — no crash
- [x] Unpatched rc11 baseline crashed at ~65s — confirms fix is needed
- [x] `enable_partial_reuse: false` workaround also prevents crash (code takes else branch which has guard)
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request handling to prevent premature termination of disaggregated context transmission requests, allowing them to complete properly through existing timeout mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->