### PR TITLE
[TRTLLM-12015][feat] Introduce KV reuse in transceiver v2

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/base/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/base/transfer.py
@@ -44,8 +44,12 @@ class KVSlice:
     """
     Specifies which portion of KV cache to transfer.
 
-    token_range is the half-open token interval [start, end) of the tokens
-    covered by the blocks in block_ids_per_layer_groups.
+    token_range is the half-open token interval [start, end) representing
+    the logical portion of the prompt being transferred.  For non-windowed
+    layers every block in block_ids_per_layer_groups covers exactly this
+    range.  For sliding-window layers the actual blocks may cover only a
+    suffix of the interval; the sender derives the exact per-group token
+    offset from its own page-table metadata when building write metadata.
     """
 
     token_range: Optional[TokenRange] = None

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -648,8 +648,22 @@ class Sender(SenderBase):
                         f"{dst_block_ids.size} (expected diff <= 1)"
                     )
                 tpb = extractor.page_table.tokens_per_block
-                src_start = task._slice.token_range.start if task._slice.token_range else 0
-                dst_start = req_info.start_token_idx or 0
+                token_range = task._slice.token_range
+                lg_info = extractor.page_table.layer_groups[self_lg]
+                window_size = getattr(lg_info, "sliding_window_size", None)
+                if window_size is not None and token_range is not None:
+                    # For sliding-window layers the window-trimmed block list
+                    # starts at stale_end*tpb, not 0.  Compute correct per-group
+                    # src_start and dst_start so _align_kv_blocks can pair blocks
+                    # by their actual token coverage rather than the global offset.
+                    prompt_len = token_range.end
+                    stale_end = max(0, (prompt_len + 1 - window_size) // tpb)
+                    cached_tokens = token_range.start
+                    src_start = max(stale_end * tpb, cached_tokens)
+                    dst_start = max(stale_end * tpb, req_info.start_token_idx or 0)
+                else:
+                    src_start = token_range.start if token_range else 0
+                    dst_start = req_info.start_token_idx or 0
                 src_block_ids, dst_block_ids = Sender._align_kv_blocks(
                     src_block_ids,
                     dst_block_ids,
@@ -1535,6 +1549,8 @@ class RxSession(RxSessionBase):
     def status(self) -> SessionStatus:
         if self._terminal_status is not None:
             return self._terminal_status
+        if self._exception is not None or any(t.status == TaskStatus.ERROR for t in self._kv_tasks):
+            return SessionStatus.ERROR
         if self._kv_tasks:
             kv_all_transferred = all(t.status == TaskStatus.TRANSFERRED for t in self._kv_tasks)
             if kv_all_transferred and self._aux_status == TaskStatus.TRANSFERRED:

--- a/tensorrt_llm/_torch/disaggregation/resource/cache_reuse.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/cache_reuse.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Union
+
+import numpy as np
+
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
+from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager, KVCacheManagerV2
+
+from .page import AttentionLayerGroup
+from .utils import get_global_layer_ids
+
+
+class CacheReuseAdapter(ABC):
+    """Uniform prefix-reuse API over KVCacheManager V1/V2."""
+
+    @property
+    @abstractmethod
+    def enable_block_reuse(self) -> bool: ...
+
+    @property
+    @abstractmethod
+    def tokens_per_block(self) -> int: ...
+
+    @abstractmethod
+    def get_cached_token_count(self, req: LlmRequest) -> int:
+        """Block-aligned count of prefix tokens already cached for *req*."""
+
+    @abstractmethod
+    def get_block_ids(
+        self,
+        req: LlmRequest,
+        group_idx: int,
+        lg: AttentionLayerGroup,
+    ) -> np.ndarray:
+        """All block IDs for *req* in layer group *lg* (dtype ``int64``)."""
+
+    @abstractmethod
+    def commit_blocks_for_reuse(self, req: LlmRequest) -> None:
+        """Commit KV blocks to radix tree for future prefix reuse.
+
+        Must be called after ``req.context_current_position = req.prompt_len``.
+        """
+
+
+class _CacheReuseAdapterV1(CacheReuseAdapter):
+    """C++-backed KVCacheManager."""
+
+    def __init__(self, mgr: KVCacheManager) -> None:
+        self._mgr = mgr
+
+    @property
+    def enable_block_reuse(self) -> bool:
+        return self._mgr.enable_block_reuse
+
+    @property
+    def tokens_per_block(self) -> int:
+        return self._mgr.tokens_per_block
+
+    def get_cached_token_count(self, req: LlmRequest) -> int:
+        if not self.enable_block_reuse:
+            return 0
+        cached = req.prepopulated_prompt_len
+        tpb = self.tokens_per_block
+        return (cached // tpb) * tpb
+
+    def get_block_ids(self, req, group_idx, lg):  # noqa: ARG002
+        first_layer = get_global_layer_ids(lg)[0]
+        return np.asarray(
+            self._mgr.get_batch_cache_indices([req.py_request_id], layer_idx=first_layer)[0],
+            dtype=np.int64,
+        )
+
+    def commit_blocks_for_reuse(self, req: LlmRequest) -> None:
+        if not self.enable_block_reuse:
+            return
+        self._mgr.store_blocks_for_reuse(req, pin_blocks=False)
+
+
+class _CacheReuseAdapterV2(CacheReuseAdapter):
+    """Python-based KVCacheManagerV2."""
+
+    def __init__(self, mgr: KVCacheManagerV2) -> None:
+        self._mgr = mgr
+
+    @property
+    def enable_block_reuse(self) -> bool:
+        return self._mgr.enable_block_reuse
+
+    @property
+    def tokens_per_block(self) -> int:
+        return self._mgr.tokens_per_block
+
+    def get_cached_token_count(self, req: LlmRequest) -> int:
+        if not self.enable_block_reuse:
+            return 0
+        kv_cache = self._mgr.kv_cache_map.get(req.py_request_id)
+        if kv_cache is None:
+            return 0
+        cached = kv_cache.num_committed_tokens
+        tpb = self.tokens_per_block
+        return (cached // tpb) * tpb
+
+    def get_block_ids(self, req, group_idx, lg):  # noqa: ARG002
+        return np.fromiter(
+            self._mgr.kv_cache_map[req.py_request_id].get_aggregated_page_indices(
+                group_idx, valid_only=True
+            ),
+            dtype=np.int64,
+        )
+
+    def commit_blocks_for_reuse(self, req: LlmRequest) -> None:
+        if not self.enable_block_reuse:
+            return
+        kv_cache = self._mgr.kv_cache_map.get(req.py_request_id)
+        if kv_cache is None:
+            return
+        if req.context_current_position > kv_cache.num_committed_tokens:
+            kv_cache.commit(
+                req.get_tokens(0)[kv_cache.num_committed_tokens : req.context_current_position]
+            )
+            kv_cache.stop_committing()
+
+
+def create_cache_reuse_adapter(
+    mgr: Union[KVCacheManager, KVCacheManagerV2],
+) -> CacheReuseAdapter:
+    """Factory — pick the right adapter for the concrete manager type."""
+    if isinstance(mgr, KVCacheManagerV2):
+        return _CacheReuseAdapterV2(mgr)
+    return _CacheReuseAdapterV1(mgr)

--- a/tensorrt_llm/_torch/disaggregation/resource/cache_reuse.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/cache_reuse.py
@@ -130,11 +130,7 @@ class _CacheReuseAdapterV2(CacheReuseAdapter):
         kv_cache = self._mgr.kv_cache_map.get(req.py_request_id)
         if kv_cache is None:
             return
-        if req.context_current_position > kv_cache.num_committed_tokens:
-            kv_cache.commit(
-                req.get_tokens(0)[kv_cache.num_committed_tokens : req.context_current_position]
-            )
-            kv_cache.stop_committing()
+        self._mgr.try_commit_blocks_for_reuse(req, kv_cache)
 
 
 def create_cache_reuse_adapter(

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -160,7 +160,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         adapter = self._reuse_adapter
         tpb = adapter.tokens_per_block
 
-        is_gen_only = req.is_generation_only_request
+        is_gen_only = req.is_generation_only_request()
         cached_tokens = adapter.get_cached_token_count(req) if is_gen_only else 0
         num_cached_blocks = cached_tokens // tpb
 
@@ -639,9 +639,8 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 f"cp_size: {self._mapping.cp_size}"
             )
 
-    @property
-    def reuse_adapter(self) -> CacheReuseAdapter:
-        return self._reuse_adapter
+    def commit_blocks_for_reuse(self, req) -> None:
+        self._reuse_adapter.commit_blocks_for_reuse(req)
 
     def get_context_state(self):
         raise NotImplementedError("get_context_state is not implemented")

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -17,8 +17,11 @@ from tensorrt_llm._torch.disaggregation.base.transfer import (
     get_unique_rid,
 )
 from tensorrt_llm._torch.disaggregation.native.transfer import TransferWorker, TransferWorkerConfig
+from tensorrt_llm._torch.disaggregation.resource.cache_reuse import (
+    CacheReuseAdapter,
+    create_cache_reuse_adapter,
+)
 from tensorrt_llm._torch.disaggregation.resource.page import MambaLayerGroup
-from tensorrt_llm._torch.disaggregation.resource.utils import get_global_layer_ids
 from tensorrt_llm._torch.distributed.communicator import Distributed
 from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import KvCacheTransceiver
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
@@ -26,7 +29,7 @@ from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import (
     MambaHybridCacheManager,
     PythonMambaCacheManager,
 )
-from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager, KVCacheManagerV2
+from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._utils import nvtx_range
 from tensorrt_llm.bindings import LlmRequestState
 from tensorrt_llm.bindings.executor import ContextPhaseParams
@@ -64,6 +67,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             cache_transceiver_config.kv_transfer_sender_future_timeout_ms
         )
         self._check_compatible()
+        self._reuse_adapter: CacheReuseAdapter = create_cache_reuse_adapter(kv_cache_manager)
 
         self._device_id = torch.cuda.current_device()
         logger.info(f"device_id: {self._device_id} in KvCacheTransceiverV2")
@@ -92,7 +96,6 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self._recv_reqs = {}
         self._wait_reqs = {}
         self._page_table = self._transfer_worker.page_table
-        self._is_v2_manager = isinstance(kv_cache_manager, KVCacheManagerV2)
 
     def _broadcast_instance_name(self) -> str:
         if self._dist.rank == 0:
@@ -148,35 +151,21 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self._recv_reqs.clear()
         self._transfer_worker.shutdown()
 
-    def _get_block_ids(self, req: LlmRequest, group_idx: int, lg) -> np.ndarray:
-        if self._is_v2_manager:
-            kv_cache_map = getattr(self._kv_cache_manager, "kv_cache_map")
-            # Returns Iterator[int], consume directly into ndarray
-            return np.fromiter(
-                kv_cache_map[req.py_request_id].get_aggregated_page_indices(
-                    group_idx, valid_only=True
-                ),
-                dtype=np.int64,
-            )
-        else:
-            first_layer = get_global_layer_ids(lg)[0]
-            return np.asarray(
-                self._kv_cache_manager.get_batch_cache_indices(
-                    [req.py_request_id], layer_idx=first_layer
-                )[0],
-                dtype=np.int64,
-            )
-
     def _create_kv_slice(
         self,
         req: LlmRequest,
         token_range: Optional[TokenRange] = None,
         is_last_slice: bool = True,
     ) -> KVSlice:
-        tpb = self._kv_cache_manager.tokens_per_block
+        adapter = self._reuse_adapter
+        tpb = adapter.tokens_per_block
 
-        if token_range is None and req.prompt_len > 0:
-            token_range = TokenRange(start=0, end=req.prompt_len)
+        is_gen_only = req.is_generation_only_request
+        cached_tokens = adapter.get_cached_token_count(req) if is_gen_only else 0
+        num_cached_blocks = cached_tokens // tpb
+
+        if token_range is None and req.prompt_len > 0 and cached_tokens < req.prompt_len:
+            token_range = TokenRange(start=cached_tokens, end=req.prompt_len)
 
         groups = []
         assert self._page_table is not None
@@ -185,18 +174,18 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 # Mamba layer groups have no KV cache blocks; skip.
                 groups.append(np.array([], dtype=np.int64))
                 continue
-            block_ids = self._get_block_ids(req, idx, lg)
+            block_ids = adapter.get_block_ids(req, idx, lg)
 
-            # Filter to only window-relevant blocks for sliding window layer groups.
-            # Computes the expected number of non-stale blocks (using the same
-            # eviction formula as update_resources) and keeps only the tail.
-            # This works correctly regardless of whether update_resources has
-            # been called:
-            #   - Pre-eviction: all blocks present → trim to last N.
-            #   - Post-eviction (V2 valid_only=True): stale blocks already
-            #     removed → len == expected_valid, so the condition is false.
             window_size = lg.sliding_window_size
             if window_size is not None:
+                # Filter to only window-relevant blocks.
+                # Computes the expected number of non-stale blocks (using the same
+                # eviction formula as update_resources) and keeps only the tail.
+                # This works correctly regardless of whether update_resources has
+                # been called:
+                #   - Pre-eviction: all blocks present → trim to last N.
+                #   - Post-eviction (V2 valid_only=True): stale blocks already
+                #     removed → len == expected_valid, so the condition is false.
                 total_blocks = (req.prompt_len + tpb - 1) // tpb
                 stale_end = max(0, (req.prompt_len + 1 - window_size) // tpb)
                 expected_valid = total_blocks - stale_end
@@ -204,6 +193,20 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                     block_ids = np.array([], dtype=np.int64)
                 elif block_ids.size > expected_valid:
                     block_ids = block_ids[-expected_valid:]
+
+                # For window layers, only skip blocks that fall within BOTH the
+                # cached prefix [0, num_cached_blocks) AND the valid window
+                # [stale_end, total_blocks).  Plain block_ids[num_cached_blocks:]
+                # is wrong here because the window-trimmed list starts at
+                # stale_end, not 0.
+                cached_in_window = max(0, num_cached_blocks - stale_end)
+                if cached_in_window >= block_ids.size:
+                    block_ids = np.array([], dtype=np.int64)
+                elif cached_in_window > 0:
+                    block_ids = block_ids[cached_in_window:]
+            else:
+                if num_cached_blocks > 0 and block_ids.size > num_cached_blocks:
+                    block_ids = block_ids[num_cached_blocks:]
 
             groups.append(block_ids)
 
@@ -635,6 +638,10 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 f"KvCacheTransceiverV2: _check_compatible: only support context parallelism is 1: "
                 f"cp_size: {self._mapping.cp_size}"
             )
+
+    @property
+    def reuse_adapter(self) -> CacheReuseAdapter:
+        return self._reuse_adapter
 
     def get_context_state(self):
         raise NotImplementedError("get_context_state is not implemented")

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -140,6 +140,9 @@ class KvCacheTransceiver(ABC):
         """
         ...
 
+    def commit_blocks_for_reuse(self, req: LlmRequest) -> None:
+        """Commit received KV blocks to the radix tree for prefix reuse. No-op by default."""
+
     def shutdown(self):
         """Shut down the transceiver and release registered resources."""
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3340,10 +3340,8 @@ class PyExecutor:
             if req.is_disagg_generation_transmission_complete:
                 req.state = LlmRequestState.GENERATION_IN_PROGRESS
                 req.context_current_position = req.prompt_len
-                if self.kv_cache_transceiver is not None and hasattr(
-                        self.kv_cache_transceiver, 'reuse_adapter'):
-                    self.kv_cache_transceiver.reuse_adapter.commit_blocks_for_reuse(
-                        req)
+                if self.kv_cache_transceiver is not None:
+                    self.kv_cache_transceiver.commit_blocks_for_reuse(req)
                 req.decoding_iter = 1
                 req.py_decoding_iter = 1
                 req.py_kv_transfer_start_time = None

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -410,8 +410,7 @@ class PyExecutor:
         self.max_num_active_requests = model_engine.get_max_num_sequences()
         self.active_requests: List[LlmRequest] = []
         self.expected_num_active_requests = 0
-        # TODO: Remove the condition on the PP size once disagg support from KVCache reuse
-        # path is fixed.
+        # TODO: Remove PP size == 1 gate for disagg + block reuse with PP > 1.
         # Buffer for responses generated inside _end_transfer_and_maybe_terminate.
         # With ADP, _enqueue_responses does a tp_gather collective.  When called
         # from _send_kv_async the owning DP rank has a response but the other
@@ -3341,6 +3340,10 @@ class PyExecutor:
             if req.is_disagg_generation_transmission_complete:
                 req.state = LlmRequestState.GENERATION_IN_PROGRESS
                 req.context_current_position = req.prompt_len
+                if self.kv_cache_transceiver is not None and hasattr(
+                        self.kv_cache_transceiver, 'reuse_adapter'):
+                    self.kv_cache_transceiver.reuse_adapter.commit_blocks_for_reuse(
+                        req)
                 req.decoding_iter = 1
                 req.py_decoding_iter = 1
                 req.py_kv_transfer_start_time = None
@@ -4061,9 +4064,7 @@ class PyExecutor:
                                     f"Request {request.py_request_id} has no avg_decoded_tokens_per_iter"
                                 )
 
-                # If partial reuse is enabled, and the KV cache manager is not VSWA, and the PP size is 1,
-                # then we need to terminate the request. TODO: Remove this once disagg support from KVCache reuse
-                # path is fixed.
+                # TODO: Remove PP size == 1 gate for disagg + block reuse with PP > 1.
                 force_terminate_for_partial_reuse = (
                     self.enable_partial_reuse_for_disagg
                     and not self.kv_cache_manager.is_vswa

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2622,16 +2622,12 @@ class KVCacheManagerV2(BaseResourceManager):
 
         return requests
 
-    def free_resources(self, request: LlmRequest, pin_on_release: bool = False):
-        self._allocated_draft_lens.pop(request.py_request_id, None)
-        kv_cache = self.kv_cache_map.pop(request.py_request_id, None)
-        if kv_cache is None:
-            return
+    def try_commit_blocks_for_reuse(self, request: LlmRequest,
+                                    kv_cache) -> None:
         if (self.enable_block_reuse and not self.is_draft
                 and not request.is_dummy_request
                 and request.context_current_position
                 > kv_cache.num_committed_tokens):
-            # When block reuse is enabled, before freeing the resources, we need to commit the tokens to prepare for reuse if it is not committed yet.
             tokens = self._augment_tokens_for_block_reuse(
                 request.get_tokens(DEFAULT_BEAM_INDEX),
                 request,
@@ -2639,6 +2635,13 @@ class KVCacheManagerV2(BaseResourceManager):
                 end=request.context_current_position)
             kv_cache.commit(tokens)
             kv_cache.stop_committing()
+
+    def free_resources(self, request: LlmRequest, pin_on_release: bool = False):
+        self._allocated_draft_lens.pop(request.py_request_id, None)
+        kv_cache = self.kv_cache_map.pop(request.py_request_id, None)
+        if kv_cache is None:
+            return
+        self.try_commit_blocks_for_reuse(request, kv_cache)
         kv_cache.close()
         self.index_mapper.remove_sequence(request.py_request_id)
 

--- a/tests/unittest/disaggregated/test_cache_reuse_adapter.py
+++ b/tests/unittest/disaggregated/test_cache_reuse_adapter.py
@@ -1,0 +1,358 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for CacheReuseAdapter and _align_kv_blocks prefix-offset logic."""
+
+import numpy as np
+import pytest
+
+from tensorrt_llm._torch.disaggregation.native.transfer import Sender
+
+# ---------------------------------------------------------------------------
+# _align_kv_blocks tests (the core block-alignment helper)
+# ---------------------------------------------------------------------------
+
+
+class TestAlignKvBlocks:
+    """Verify Sender._align_kv_blocks handles prefix-cache offsets correctly."""
+
+    TPB = 64  # tokens_per_block
+
+    def _align(self, src, dst, src_start=0, dst_start=0):
+        return Sender._align_kv_blocks(
+            np.array(src, dtype=np.int64),
+            np.array(dst, dtype=np.int64),
+            src_token_start=src_start,
+            dst_token_start=dst_start,
+            tokens_per_block=self.TPB,
+        )
+
+    def test_no_prefix_cache(self):
+        """Neither side has prefix cache — identity."""
+        src, dst = self._align([10, 11, 12], [20, 21, 22])
+        np.testing.assert_array_equal(src, [10, 11, 12])
+        np.testing.assert_array_equal(dst, [20, 21, 22])
+
+    def test_gen_has_prefix_cache(self):
+        """Gen cached 2 blocks — only transfer suffix."""
+        # ctx sends blocks for tokens [0, 320), gen needs only [128, 320)
+        src, dst = self._align(
+            [10, 11, 12, 13, 14],  # 5 blocks, full prompt
+            [20, 21, 22],  # 3 blocks, suffix only
+            src_start=0,
+            dst_start=2 * self.TPB,  # gen cached 2 blocks
+        )
+        # src should skip first 2 blocks, transfer 3
+        np.testing.assert_array_equal(src, [12, 13, 14])
+        np.testing.assert_array_equal(dst, [20, 21, 22])
+
+    def test_ctx_has_prefix_cache(self):
+        """Ctx cached 1 block — ctx starts from block 1."""
+        src, dst = self._align(
+            [10, 11, 12],  # ctx: 3 blocks starting from token 64
+            [20, 21, 22, 23],  # gen: 4 blocks, full prompt
+            src_start=1 * self.TPB,
+            dst_start=0,
+        )
+        # dst should skip first block, transfer 3
+        np.testing.assert_array_equal(src, [10, 11, 12])
+        np.testing.assert_array_equal(dst, [21, 22, 23])
+
+    def test_both_have_prefix_cache(self):
+        """Both sides cached — transfer only the overlap."""
+        src, dst = self._align(
+            [10, 11, 12],  # ctx: 3 blocks from token 64
+            [20, 21],  # gen: 2 blocks from token 128
+            src_start=1 * self.TPB,
+            dst_start=2 * self.TPB,
+        )
+        # overlap starts at token 128 → src_skip=1, dst_skip=0, n=2
+        np.testing.assert_array_equal(src, [11, 12])
+        np.testing.assert_array_equal(dst, [20, 21])
+
+    def test_gen_full_cache_hit(self):
+        """Gen has entire prompt cached — nothing to transfer."""
+        src, dst = self._align(
+            [10, 11, 12],  # ctx: full prompt
+            [20, 21, 22],  # gen: full prompt (all cached)
+            src_start=0,
+            dst_start=3 * self.TPB,  # gen cached all 3 blocks
+        )
+        assert src.size == 0
+        assert dst.size == 0
+
+    def test_gen_prefix_with_draft_block(self):
+        """Gen has prefix cache + 1 extra draft block — transfer suffix only."""
+        src, dst = self._align(
+            [10, 11, 12, 13],  # ctx: 4 blocks
+            [20, 21, 22],  # gen: 2 suffix + 1 draft
+            src_start=0,
+            dst_start=2 * self.TPB,
+        )
+        # transfer min(4-2, 3-0) = 2 blocks
+        np.testing.assert_array_equal(src, [12, 13])
+        np.testing.assert_array_equal(dst, [20, 21])
+
+
+# ---------------------------------------------------------------------------
+# KVSlice token_range with prefix offset
+# ---------------------------------------------------------------------------
+
+
+class TestTokenRangeWithPrefix:
+    """Verify TokenRange is correctly set with prefix offsets."""
+
+    def test_no_cache(self):
+        from tensorrt_llm._torch.disaggregation.base.transfer import TokenRange
+
+        tr = TokenRange(start=0, end=256)
+        assert tr.start == 0
+        assert tr.end == 256
+
+    def test_partial_cache(self):
+        from tensorrt_llm._torch.disaggregation.base.transfer import TokenRange
+
+        tr = TokenRange(start=128, end=256)
+        assert tr.start == 128
+        assert tr.end == 256
+
+    def test_full_cache_hit_raises(self):
+        """When cached_tokens == prompt_len, start == end should raise."""
+        from tensorrt_llm._torch.disaggregation.base.transfer import TokenRange
+
+        with pytest.raises(ValueError):
+            TokenRange(start=256, end=256)
+
+
+# ---------------------------------------------------------------------------
+# Sliding window + cache reuse: block-ID filter
+# ---------------------------------------------------------------------------
+
+
+def _apply_window_cache_filter(block_ids, prompt_len, tpb, window_size, num_cached_blocks):
+    """Replicate the block-ID filtering from KvCacheTransceiverV2._create_kv_slice.
+
+    In V2 with valid_only=True the adapter already strips stale blocks, so
+    ``block_ids`` starts at stale_end.  ``cached_in_window`` counts only the
+    blocks that are both cached and inside the valid window, avoiding
+    over-skipping when num_cached_blocks includes stale entries.
+    """
+    block_ids = np.array(block_ids, dtype=np.int64)
+    total_blocks = (prompt_len + tpb - 1) // tpb
+    stale_end = max(0, (prompt_len + 1 - window_size) // tpb)
+    expected_valid = total_blocks - stale_end
+    if expected_valid <= 0:
+        return np.array([], dtype=np.int64)
+    elif block_ids.size > expected_valid:
+        block_ids = block_ids[-expected_valid:]
+    cached_in_window = max(0, num_cached_blocks - stale_end)
+    if cached_in_window >= block_ids.size:
+        return np.array([], dtype=np.int64)
+    elif cached_in_window > 0:
+        block_ids = block_ids[cached_in_window:]
+    return block_ids
+
+
+class TestWindowCacheBlockFilter:
+    """Verify cached_in_window filtering for sliding window + cache reuse.
+
+    Setup: tpb=8, prompt_len=32 (4 blocks), window_size=16.
+      stale_end = max(0, (33-16)//8) = 2.
+      valid_only returns blocks starting at stale_end → [G2, G3].
+    """
+
+    TPB = 8
+    PROMPT_LEN = 32
+    WINDOW = 16
+    BLOCKS = [20, 21]  # physical IDs for the 2 valid window blocks
+
+    def _filter(self, num_cached_blocks):
+        return _apply_window_cache_filter(
+            self.BLOCKS, self.PROMPT_LEN, self.TPB, self.WINDOW, num_cached_blocks
+        )
+
+    def test_no_cache(self):
+        """Gen has no cached tokens → all valid window blocks needed."""
+        result = self._filter(num_cached_blocks=0)
+        np.testing.assert_array_equal(result, [20, 21])
+
+    def test_cache_entirely_in_stale_zone(self):
+        """Gen cached 2 blocks, both stale (cached_in_window=0).
+
+        num_cached_blocks=2 == stale_end=2 → cached_in_window=0.
+        All valid window blocks still needed.
+        """
+        result = self._filter(num_cached_blocks=2)
+        np.testing.assert_array_equal(result, [20, 21])
+
+    def test_cache_partially_in_window(self):
+        """Gen cached 3 blocks (2 stale + 1 window): cached_in_window=1.
+
+        stale_end=2, num_cached_blocks=3 → cached_in_window=1.
+        Skip 1 block from the valid window list → only [G3] needed.
+        """
+        result = _apply_window_cache_filter(
+            [20, 21], self.PROMPT_LEN, self.TPB, self.WINDOW, num_cached_blocks=3
+        )
+        np.testing.assert_array_equal(result, [21])
+
+    def test_cache_covers_all_window_blocks(self):
+        """Gen cached all 4 blocks: cached_in_window ≥ expected_valid → empty."""
+        result = self._filter(num_cached_blocks=4)
+        assert result.size == 0
+
+    def test_cached_in_window_vs_naive_skip(self):
+        """cached_in_window skips correctly when stale_end > 0.
+
+        window_size=24, tpb=8, prompt_len=32 → stale_end=1.
+        valid window blocks after stale removal: [G1, G2, G3].
+        Gen cached 2 blocks → cached_in_window=max(0, 2-1)=1 → skip 1 → [G2, G3].
+
+        A naive block_ids[num_cached_blocks:] skips 2 from [G1,G2,G3] and gives [G3] only.
+        """
+        blocks = [10, 11, 12]  # [G1, G2, G3] after stale removal (stale_end=1)
+        prompt_len, tpb, window_size = 32, 8, 24
+        num_cached_blocks = 2
+
+        result = _apply_window_cache_filter(blocks, prompt_len, tpb, window_size, num_cached_blocks)
+        np.testing.assert_array_equal(result, [11, 12])
+
+        stale_end = max(0, (prompt_len + 1 - window_size) // tpb)  # = 1
+        naive_result = np.array(blocks, dtype=np.int64)[num_cached_blocks:]
+        assert naive_result.tolist() == [12]
+        assert result.tolist() != naive_result.tolist()
+        assert stale_end == 1
+
+    def test_large_window_no_stale_blocks(self):
+        """Window covers entire prompt: stale_end=0, cached_in_window=num_cached_blocks.
+
+        prompt_len=32, window_size=32, tpb=8 → stale_end=0.
+        Gen cached 1 block → cached_in_window=1.
+        """
+        result = _apply_window_cache_filter(
+            [10, 11, 12, 13], prompt_len=32, tpb=8, window_size=32, num_cached_blocks=1
+        )
+        np.testing.assert_array_equal(result, [11, 12, 13])
+
+
+# ---------------------------------------------------------------------------
+# Sliding window + cache reuse: sender src_start / dst_start
+# ---------------------------------------------------------------------------
+
+
+class TestWindowSenderAlignment:
+    """Verify src_start / dst_start for sliding window layers in Sender._do_send.
+
+    After valid_only removal, both the src and dst block lists start at
+    stale_end*tpb (not at 0).  src_start=max(stale_end*tpb, ctx_cached_tokens)
+    and dst_start=stale_end*tpb tell _align_kv_blocks where each list begins
+    so that it computes the correct block-skip counts.
+    """
+
+    TPB = 8
+
+    @staticmethod
+    def _compute_starts(prompt_len, tpb, window_size, ctx_cached_tokens):
+        """Compute src_start/dst_start for a window layer group."""
+        stale_end = max(0, (prompt_len + 1 - window_size) // tpb)
+        src_start = max(stale_end * tpb, ctx_cached_tokens)
+        dst_start = stale_end * tpb
+        return src_start, dst_start
+
+    def _align(self, src, dst, src_start, dst_start):
+        return Sender._align_kv_blocks(
+            np.array(src, dtype=np.int64),
+            np.array(dst, dtype=np.int64),
+            src_token_start=src_start,
+            dst_token_start=dst_start,
+            tokens_per_block=self.TPB,
+        )
+
+    def test_window_no_cache_stale_blocks_present(self):
+        """Pure window transfer: no cache, stale blocks removed by valid_only.
+
+        tpb=8, window_size=16, prompt_len=32 → stale_end=2.
+        After valid_only: src=[C2,C3], dst=[G2,G3], both starting at token 16.
+        src_start=dst_start=16 → identity alignment.
+        """
+        prompt_len, window_size = 32, 16
+        src = [10, 11]  # C2, C3 (valid window blocks)
+        dst = [20, 21]  # G2, G3
+        src_start, dst_start = self._compute_starts(prompt_len, self.TPB, window_size, 0)
+        assert src_start == 16
+        assert dst_start == 16
+        result_src, result_dst = self._align(src, dst, src_start, dst_start)
+        np.testing.assert_array_equal(result_src, [10, 11])
+        np.testing.assert_array_equal(result_dst, [20, 21])
+
+    def test_stale_cache_alignment(self):
+        """Window + stale-only cache: src_start=stale_end*tpb avoids over-skipping.
+
+        tpb=8, window_size=16, prompt_len=32 → stale_end=2.
+        Gen cached 2 blocks (all stale) → req_info.start_token_idx=16.
+        valid_only src=[C2,C3] starts at token 16, not 0.
+
+        Using src_start=0 and dst_start=16 treats src as starting at 0,
+        causing _align to compute src_skip=2 and return empty arrays.
+        Setting src_start=dst_start=16 gives the correct full transfer.
+        """
+        prompt_len, window_size = 32, 16
+        src = [10, 11]  # C2, C3 (valid window blocks, stale removed)
+        dst = [20, 21]  # G2, G3
+
+        wrong_src, _ = self._align(src, dst, src_start=0, dst_start=16)
+        assert wrong_src.size == 0
+
+        src_start, dst_start = self._compute_starts(prompt_len, self.TPB, window_size, 0)
+        result_src, result_dst = self._align(src, dst, src_start, dst_start)
+        np.testing.assert_array_equal(result_src, [10, 11])
+        np.testing.assert_array_equal(result_dst, [20, 21])
+
+    def test_ctx_cache_in_window(self):
+        """Ctx has cached tokens within the valid window.
+
+        tpb=8, window_size=24, prompt_len=32 → stale_end=1, stale_end*tpb=8.
+        Ctx cached 2 blocks (16 tokens): src_start=max(8,16)=16, dst_start=8.
+        After valid_only: src=[C1,C2,C3], dst=[G1,G2,G3].
+        overlap_start=max(16,8)=16 → src_skip=0, dst_skip=1, n=2.
+        """
+        prompt_len, window_size = 32, 24
+        ctx_cached_tokens = 16
+        src = [10, 11, 12]  # C1, C2, C3 after valid_only (stale_end=1)
+        dst = [20, 21, 22]  # G1, G2, G3 after valid_only
+
+        src_start, dst_start = self._compute_starts(
+            prompt_len, self.TPB, window_size, ctx_cached_tokens
+        )
+        assert src_start == 16
+        assert dst_start == 8
+
+        result_src, result_dst = self._align(src, dst, src_start, dst_start)
+        np.testing.assert_array_equal(result_src, [10, 11])
+        np.testing.assert_array_equal(result_dst, [21, 22])
+
+    def test_no_stale_no_cache(self):
+        """Window covers entire prompt, no cache: src_start=dst_start=0, identity alignment.
+
+        tpb=8, window_size=32, prompt_len=32 → stale_end=0.
+        """
+        prompt_len, window_size = 32, 32
+        src = [10, 11, 12, 13]
+        dst = [20, 21, 22, 23]
+        src_start, dst_start = self._compute_starts(prompt_len, self.TPB, window_size, 0)
+        assert src_start == 0
+        assert dst_start == 0
+        result_src, result_dst = self._align(src, dst, src_start, dst_start)
+        np.testing.assert_array_equal(result_src, [10, 11, 12, 13])
+        np.testing.assert_array_equal(result_dst, [20, 21, 22, 23])

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -1057,6 +1057,139 @@ def test_transfer_worker_v2_with_window(
             worker.shutdown()
 
 
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("use_v2", [False, True], ids=["v1", "v2"])
+def test_transfer_with_gen_prefix_offset(use_v2):
+    """Verify that only suffix blocks are transferred when gen has a prefix offset.
+
+    Simulates gen-side prefix cache: ctx sends all blocks for [0, request_len),
+    gen only provides suffix block IDs with start_token_idx > 0.
+    _align_kv_blocks should align correctly so only the suffix data is written.
+    """
+    tensorrt_llm.logger.set_level("info")
+    tokens_per_block = 8
+    request_len = 32  # 4 blocks
+    prefix_blocks = 2  # gen has 2 blocks already cached
+    prefix_tokens = prefix_blocks * tokens_per_block
+
+    setup = create_transfer_worker_setup(
+        ctx_tp=1,
+        ctx_pp=1,
+        ctx_enable_dp=False,
+        gen_tp=1,
+        gen_pp=1,
+        gen_enable_dp=False,
+        use_v2=use_v2,
+    )
+
+    ctx_tw = setup["ctx_transfer_workers"][0]
+    ctx_mgr = setup["ctx_kv_cache_managers"][0]
+    gen_tw = setup["gen_transfer_workers"][0]
+    gen_mgr = setup["gen_kv_cache_managers"][0]
+    ctx_info_endpoint = setup["ctx_info_endpoint"]
+
+    unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
+    sampling_params = SamplingParams()
+    sc = tensorrt_llm.bindings.SamplingConfig(sampling_params._get_sampling_config())
+
+    # Create ctx request (full prompt)
+    ctx_request = LlmRequest(
+        request_id=0,
+        max_new_tokens=1,
+        input_tokens=list(range(request_len)),
+        sampling_config=sc,
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
+    )
+    ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
+
+    # Create gen request (same prompt)
+    gen_request = LlmRequest(
+        request_id=1,
+        max_new_tokens=1,
+        input_tokens=list(range(request_len)),
+        sampling_config=sc,
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+    )
+    gen_request.py_disaggregated_params = DisaggregatedParams(
+        ctx_request_id=0,
+        ctx_dp_rank=0,
+        ctx_info_endpoint=ctx_info_endpoint,
+        disagg_request_id=unique_rid,
+    )
+
+    # Allocate KV on both sides
+    ctx_kv_caches, gen_kv_caches = [], []
+    if use_v2:
+        kv = ctx_mgr._create_kv_cache(0, None, None)
+        kv.resume(torch.cuda.current_stream().cuda_stream)
+        kv.resize(request_len)
+        ctx_kv_caches.append(kv)
+
+        kv = gen_mgr._create_kv_cache(1, None, None)
+        kv.resume(torch.cuda.current_stream().cuda_stream)
+        kv.resize(request_len)
+        gen_kv_caches.append(kv)
+    else:
+        ctx_mgr.impl.add_sequence(0, request_len, 1, ctx_request)
+        gen_mgr.impl.add_sequence(1, request_len, 1, gen_request)
+
+    # Get block IDs
+    ctx_block_ids = get_block_ids_per_layer_groups(ctx_mgr, ctx_tw, 0, use_v2, tokens_per_block)
+    gen_block_ids = get_block_ids_per_layer_groups(gen_mgr, gen_tw, 1, use_v2, tokens_per_block)
+
+    # Gen: only provide suffix block IDs (skip prefix_blocks)
+    gen_suffix_block_ids = [
+        np.asarray(bids[prefix_blocks:], dtype=np.int64) for bids in gen_block_ids
+    ]
+
+    try:
+        # Ctx sends all blocks
+        tx = ctx_tw.create_tx_session(ctx_request)
+        send_slice = KVSlice(
+            is_last_slice=True,
+            block_ids_per_layer_groups=ctx_block_ids,
+            token_range=TokenRange(start=0, end=request_len),
+        )
+        send_future = tx.send(send_slice)
+
+        # Gen receives only suffix blocks with start_token_idx offset
+        rx = gen_tw.create_rx_session(gen_request)
+        recv_slice = KVSlice(
+            is_last_slice=True,
+            block_ids_per_layer_groups=gen_suffix_block_ids,
+            token_range=TokenRange(start=prefix_tokens, end=request_len),
+        )
+        recv_future = rx.receive(recv_slice)
+
+        send_future.result()
+        recv_future.result()
+
+        # Verify: suffix blocks on gen should match corresponding ctx blocks
+        num_layer_groups = len(ctx_block_ids)
+        for lg_id in range(num_layer_groups):
+            ctx_all_bids = ctx_block_ids[lg_id]
+            ctx_suffix_bids = ctx_all_bids[prefix_blocks:]
+            gen_suffix_bids = gen_suffix_block_ids[lg_id]
+
+            ctx_data = get_block_data(ctx_mgr, ctx_suffix_bids, lg_id, use_v2, 0)
+            gen_data = get_block_data(gen_mgr, gen_suffix_bids, lg_id, use_v2, 1)
+            assert ctx_data.equal(gen_data), (
+                f"Layer group {lg_id}: suffix block data mismatch after prefix-offset transfer"
+            )
+
+        rx.close()
+        tx.close()
+    finally:
+        if use_v2:
+            torch.cuda.current_stream().synchronize()
+            for kv in ctx_kv_caches + gen_kv_caches:
+                kv.close()
+        ctx_tw.shutdown()
+        gen_tw.shutdown()
+
+
 @pytest.mark.timeout(60)
 def test_session_cancel_before_send():
     """TxSession/RxSession cancelled before any transfer starts."""

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -20,6 +20,7 @@ from tensorrt_llm._torch.disaggregation.base.transfer import (
     LayerRange,
     SessionStatus,
     TokenRange,
+    WaitResult,
 )
 from tensorrt_llm._torch.disaggregation.native.transfer import TransferWorker, TransferWorkerConfig
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
@@ -1132,8 +1133,12 @@ def test_transfer_with_gen_prefix_offset(use_v2):
         kv.resize(request_len)
         gen_kv_caches.append(kv)
     else:
-        ctx_mgr.impl.add_sequence(0, request_len, 1, ctx_request)
-        gen_mgr.impl.add_sequence(1, request_len, 1, gen_request)
+        ctx_mgr.impl.add_sequence_batch(
+            [(ctx_request.py_request_id, request_len, 1)], [ctx_request]
+        )
+        gen_mgr.impl.add_sequence_batch(
+            [(gen_request.py_request_id, request_len, 1)], [gen_request]
+        )
 
     # Get block IDs
     ctx_block_ids = get_block_ids_per_layer_groups(ctx_mgr, ctx_tw, 0, use_v2, tokens_per_block)
@@ -1152,7 +1157,6 @@ def test_transfer_with_gen_prefix_offset(use_v2):
             block_ids_per_layer_groups=ctx_block_ids,
             token_range=TokenRange(start=0, end=request_len),
         )
-        send_future = tx.send(send_slice)
 
         # Gen receives only suffix blocks with start_token_idx offset
         rx = gen_tw.create_rx_session(gen_request)
@@ -1161,10 +1165,13 @@ def test_transfer_with_gen_prefix_offset(use_v2):
             block_ids_per_layer_groups=gen_suffix_block_ids,
             token_range=TokenRange(start=prefix_tokens, end=request_len),
         )
-        recv_future = rx.receive(recv_slice)
+        rx.receive(recv_slice)
+        tx.send(send_slice)
 
-        send_future.result()
-        recv_future.result()
+        result = tx.wait_complete()
+        assert result == WaitResult.COMPLETED, f"tx wait_complete returned {result}"
+        result = rx.wait_complete(blocking=True)
+        assert result == WaitResult.COMPLETED, f"rx wait_complete returned {result}"
 
         # Verify: suffix blocks on gen should match corresponding ctx blocks
         num_layer_groups = len(ctx_block_ids)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache reuse adapter abstraction for improved KV block management across cache manager versions.
  * Enhanced KV slice token range tracking to support cached token accounting in disaggregated execution.

* **Bug Fixes**
  * Improved block alignment logic for speculative decoding in distributed KV cache scenarios.

* **Tests**
  * Added comprehensive tests for KV cache block alignment and token range handling in disaggregated transfer workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Limitation

In V2, `_KVCache.num_committed_tokens` is a single per-sequence scalar, so `_setup_for_reuse` intersects all layer-group constraints into one global cutoff. For hybrid models with a short SWA window, the SWA check often truncates the match to 0, dragging full-attention layers down with it, even though their pages are still in the prefix tree.

The transceiver inherits this: `cached_tokens` and `KVSlice.token_range` are also single values, so every layer group shares one reuse boundary. Lifting this requires per-group commit lengths in the manager and per-group token ranges in the transfer protocol.

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
