### PR TITLE
[TRTLLM-10288][perf] Reduce AutoTuner host overhead in inference hot path

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -253,6 +253,21 @@ class TunableRunner(ABC):
         """
         return tuple(self.__dict__.values())
 
+    @property
+    def _cache_key_prefix(self) -> Tuple[str, str]:
+        """Cached (class_name, unique_id_str) tuple — computed once per runner instance.
+
+        This avoids re-computing runner.__class__.__name__ and str(runner.unique_id())
+        on every get_cache_key() call during inference. These values are constant for a
+        given runner instance.
+        """
+        try:
+            return self.__cache_key_prefix
+        except AttributeError:
+            self.__cache_key_prefix = (self.__class__.__name__,
+                                       str(self.unique_id()))
+            return self.__cache_key_prefix
+
 
 @contextlib.contextmanager
 def autotune(tune_mode: bool = True,
@@ -298,6 +313,9 @@ def autotune(tune_mode: bool = True,
         autotuner.skip_dynamic_tuning_buckets = old_skip
         if autotune_enabled:
             logger.info("[Autotuner] Autotuning process ends")
+            # Invalidate the choose_one cache since the profiling cache
+            # has been updated with new entries.
+            autotuner._choose_one_cache.clear()
 
         # save cache
         if cache_path is not None:
@@ -447,11 +465,15 @@ class AutoTunerProfilingCache:
         tuning_config: TuningConfig,
         apply_map_to_tuning_buckets: bool = True,
     ) -> Tuple:
+        # Use cached (class_name, unique_id_str) prefix to avoid
+        # recomputing str(runner.unique_id()) on every call (~1-2us saving).
+        prefix = runner._cache_key_prefix
         return (
             custom_op,
-            runner.__class__.__name__,
-            str(runner.unique_id()),
-            AutoTuner.get()._find_nearest_profile(
+            prefix[0],
+            prefix[1],
+            # Call classmethod directly — avoids AutoTuner.get() singleton lookup.
+            AutoTuner._find_nearest_profile(
                 input_shapes,
                 tuning_config.dynamic_tensor_specs,
                 tuning_config.constraint_specs,
@@ -760,6 +782,12 @@ class AutoTuner:
         # Last captured choose_one() contexts
         self._last_capture: Optional['AutoTuner.TacticsCapture'] = None
 
+        # Fast-path cache for choose_one() during inference.
+        # Maps (custom_op, *bucketed_dynamic_dim_values) -> (runner_id, tactic).
+        # Avoids the full search_cache → get_cache_key → _find_nearest_profile
+        # chain on repeated calls with the same bucketed input shapes.
+        self._choose_one_cache: dict = {}
+
         # Dsitributed tuning state
         self._dist: Optional[Distributed] = None
         self._has_received_cache: bool = False
@@ -887,6 +915,32 @@ class AutoTuner:
             Although runners[0] with tactic=-1 is always treated as the fallback runner.
             Runner authors are suggested to provide a fallback implementation for each runner to avoid potential issues.
         """
+
+        # ---- NON-TUNING PATH: fast-key cache ----
+        if not self.is_tuning_mode and self._active_capture is None:
+            fast_key = self._make_fast_key(custom_op, tuning_config, inputs)
+            cached = self._choose_one_cache.get(fast_key)
+            if cached is not None:
+                best_runner_id, best_tactic = cached
+                return (runners[best_runner_id], best_tactic)
+
+            # Cache miss — full resolution via search_cache
+            input_shapes = tuple(
+                t.size() if isinstance(t, torch.Tensor) else torch.Size((0, ))
+                for t in inputs)
+            is_cache_hit, best_runner_id, best_tactic, min_time = \
+                self.profiling_cache.search_cache(
+                    custom_op, runners, input_shapes, tuning_config,
+                    apply_map_to_tuning_buckets=True)
+            if not is_cache_hit:
+                logger.warning_once(
+                    f"[AutoTuner] {custom_op} using the fallback tactic, "
+                    f"due to cache miss on input shapes={input_shapes}",
+                    key=(custom_op, "warning_autotuning_cache_miss_fallback"))
+            self._choose_one_cache[fast_key] = (best_runner_id, best_tactic)
+            return (runners[best_runner_id], best_tactic)
+
+        # ---- TUNING / CAPTURE / REPLAY ----
 
         # Check if we're in replay mode via active TacticsCapture
         if self._active_capture is not None and self._active_capture.is_replaying(
@@ -1024,6 +1078,37 @@ class AutoTuner:
             custom_op] = self.stats.tuned_op_time_cost.get(
                 custom_op, 0) + tuning_end_time - tuning_start_time
         return (runners[runner_id], tactic)
+
+    # ------------------------------------------------------------------
+    # _make_fast_key — bucketed cache key for choose_one fast path
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_fast_key(custom_op, tuning_config, inputs):
+        """Build a minimal cache key from bucketed dynamic dimensions only.
+
+        Instead of constructing the full ``input_shapes`` tuple (one
+        ``t.size()`` per input, O(N)) and running ``_find_nearest_profile``
+        (list↔tuple conversion), we extract only the 1–2 integer values
+        that actually vary at inference time (e.g. batch size) and bucket
+        them.  This gives an O(K) key where K = len(dynamic_tensor_specs),
+        typically 1.
+        """
+        dynamic_specs = tuning_config.dynamic_tensor_specs
+        if not dynamic_specs:
+            return (custom_op, )
+        max_tokens = tuning_config.tune_max_num_tokens
+        dyn_vals = []
+        for spec in dynamic_specs:
+            inp = inputs[spec.input_idx]
+            if isinstance(inp, torch.Tensor):
+                v = spec.map_to_tuning_buckets(inp.size(spec.dim_idx))
+            else:
+                v = 0
+            if max_tokens is not None:
+                v = min(v, max_tokens)
+            dyn_vals.append(v)
+        return (custom_op, *dyn_vals)
 
     def _profile_runners(
         self,

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -782,10 +782,12 @@ class AutoTuner:
         # Last captured choose_one() contexts
         self._last_capture: Optional['AutoTuner.TacticsCapture'] = None
 
-        # Fast-path cache for choose_one() during inference.
-        # Maps (custom_op, *bucketed_dynamic_dim_values) -> (runner_id, tactic).
-        # Avoids the full search_cache → get_cache_key → _find_nearest_profile
-        # chain on repeated calls with the same bucketed input shapes.
+        # Inference fast-path cache for choose_one().
+        # Maps (custom_op, runner_ids, *bucketed_dims) -> (runner_id, tactic).
+        # On cache hit, resolves the runner via runners[runner_id] from the
+        # caller's list — never caches runner instances directly.
+        # Skips the full search_cache → _find_nearest_profile chain on
+        # repeated calls.
         self._choose_one_cache: dict = {}
 
         # Dsitributed tuning state
@@ -918,16 +920,15 @@ class AutoTuner:
 
         # ---- NON-TUNING PATH: fast-key cache ----
         if not self.is_tuning_mode and self._active_capture is None:
-            fast_key = self._make_fast_key(custom_op, tuning_config, inputs)
+            fast_key = self._make_fast_key(custom_op, runners, tuning_config,
+                                           inputs)
             cached = self._choose_one_cache.get(fast_key)
             if cached is not None:
                 best_runner_id, best_tactic = cached
                 return (runners[best_runner_id], best_tactic)
 
             # Cache miss — full resolution via search_cache
-            input_shapes = tuple(
-                t.size() if isinstance(t, torch.Tensor) else torch.Size((0, ))
-                for t in inputs)
+            input_shapes = tuple(self._get_input_sizes(inputs))
             is_cache_hit, best_runner_id, best_tactic, min_time = \
                 self.profiling_cache.search_cache(
                     custom_op, runners, input_shapes, tuning_config,
@@ -989,27 +990,13 @@ class AutoTuner:
             })
 
         input_shapes = tuple(self._get_input_sizes(inputs))
-        is_cache_hit, best_runner_id, best_tactic, min_time = self.profiling_cache.search_cache(
-            custom_op,
-            runners,
-            input_shapes,
-            tuning_config,
-            apply_map_to_tuning_buckets=True)
+        is_cache_hit, best_runner_id, best_tactic, min_time = \
+            self.profiling_cache.search_cache(
+                custom_op, runners, input_shapes, tuning_config,
+                apply_map_to_tuning_buckets=True)
 
-        # Early return if it's not tuning, use cache found one or fallback one
-        if not self.is_tuning_mode:
-            best_runner = runners[best_runner_id]
-            # TODO: check the stored runner and tactic can implement this shape here
-            # Log the cache miss. Expect no cache miss in inference.
-            if not is_cache_hit:
-                logger.warning_once(
-                    f"[AutoTuner] {custom_op} using the fallback tactic, due to cache miss on input shapes={input_shapes}",
-                    key=(custom_op, "warning_autotuning_cache_miss_fallback"))
-
-            return (best_runner, best_tactic)
-
-        # If it's tuning mode and cache hit, return the best runner and tactic to avoid redundant profiling.
-        if self.is_tuning_mode and is_cache_hit:
+        # Cache hit — skip profiling (avoids redundant work during tuning/capture).
+        if is_cache_hit:
             return (runners[best_runner_id], best_tactic)
 
         # PP rank does not have cache hit, so we try to receive the cache from the previous rank
@@ -1084,19 +1071,20 @@ class AutoTuner:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _make_fast_key(custom_op, tuning_config, inputs):
-        """Build a minimal cache key from bucketed dynamic dimensions only.
+    def _make_fast_key(custom_op, runners, tuning_config, inputs):
+        """Build a minimal cache key from runner identity + bucketed dynamic dims.
 
-        Instead of constructing the full ``input_shapes`` tuple (one
-        ``t.size()`` per input, O(N)) and running ``_find_nearest_profile``
-        (list↔tuple conversion), we extract only the 1–2 integer values
-        that actually vary at inference time (e.g. batch size) and bucket
-        them.  This gives an O(K) key where K = len(dynamic_tensor_specs),
-        typically 1.
+        Includes each runner's ``_cache_key_prefix`` (class name + unique_id)
+        so that different runner configurations for the same ``custom_op``
+        do not collide.  For the dynamic dimensions we extract only the 1–2
+        integer values that actually vary at inference time (e.g. batch size)
+        and bucket them.  This gives an O(R + K) key where R = len(runners)
+        (typically 1–3) and K = len(dynamic_tensor_specs) (typically 1).
         """
+        runner_ids = tuple(r._cache_key_prefix for r in runners)
         dynamic_specs = tuning_config.dynamic_tensor_specs
         if not dynamic_specs:
-            return (custom_op, )
+            return (custom_op, runner_ids)
         max_tokens = tuning_config.tune_max_num_tokens
         dyn_vals = []
         for spec in dynamic_specs:
@@ -1108,7 +1096,7 @@ class AutoTuner:
             if max_tokens is not None:
                 v = min(v, max_tokens)
             dyn_vals.append(v)
-        return (custom_op, *dyn_vals)
+        return (custom_op, runner_ids, *dyn_vals)
 
     def _profile_runners(
         self,

--- a/tests/unittest/_torch/misc/test_autotuner.py
+++ b/tests/unittest/_torch/misc/test_autotuner.py
@@ -846,6 +846,111 @@ def _distributed_worker_function(world_size, strategy):
     return True
 
 
+def test_choose_one_cache_hit():
+    """choose_one() should cache (runner_id, tactic) and reuse on subsequent calls."""
+    x, w = torch.randn(16, 64), torch.randn(64, 128)
+    runner = GemmRunner()
+    tuning_config = TuningConfig(dynamic_tensor_specs=(DynamicTensorSpec(
+        input_idx=0,
+        dim_idx=0,
+        gen_tuning_buckets=get_power_of_2_num_tokens_buckets,
+        map_to_tuning_buckets=next_positive_power_of_2), ), )
+
+    tuner = AutoTuner.get()
+    tuner.clear_cache()
+    tuner._choose_one_cache.clear()
+
+    # Tune first
+    with autotune():
+        tuner.choose_one("test_choose_one_cache", [runner], tuning_config,
+                         [x, w])
+
+    # First choose_one — cache miss, populates _choose_one_cache
+    runner1, tactic1 = tuner.choose_one("test_choose_one_cache", [runner],
+                                        tuning_config, [x, w])
+    assert runner1 is runner
+    assert isinstance(tactic1, int)
+
+    fast_key = AutoTuner._make_fast_key("test_choose_one_cache", [runner],
+                                        tuning_config, [x, w])
+    assert fast_key in tuner._choose_one_cache, \
+        "_choose_one_cache should have entry after first call"
+
+    # Second choose_one — cache hit, same values
+    runner2, tactic2 = tuner.choose_one("test_choose_one_cache", [runner],
+                                        tuning_config, [x, w])
+    assert runner1 is runner2, "Cached choose_one should return same runner"
+    assert tactic1 == tactic2, "Cached choose_one should return same tactic"
+
+    # Re-tuning should clear _choose_one_cache
+    with autotune():
+        tuner.choose_one("test_choose_one_cache", [runner], tuning_config,
+                         [x, w])
+    assert len(tuner._choose_one_cache) == 0, \
+        "_choose_one_cache should be cleared after re-tuning"
+
+
+def test_choose_one_cache_different_runners_same_op():
+    """choose_one() cache must not collide when different runners share the same custom_op.
+
+    Reproduces the bug where _choose_one_cache key was (custom_op, *bucketed_dims)
+    without runner identity, causing a runner configured for one dtype to be
+    returned for a call with a different dtype (e.g. int8 runner used for int4 data).
+    """
+
+    class TypedRunner(TunableRunner):
+        """Runner whose output depends on a config parameter (simulates weight_dtype)."""
+
+        def __init__(self, scale: float):
+            super().__init__()
+            self.scale = scale
+
+        def unique_id(self):
+            return (self.scale, )
+
+        def get_valid_tactics(self, inputs, profile, **kwargs):
+            return [0]
+
+        def forward(self, /, inputs, *, tactic=0, **kwargs):
+            return inputs[0] @ inputs[1] * self.scale
+
+    x, w = torch.randn(16, 64), torch.randn(64, 128)
+    runner_a = TypedRunner(scale=1.0)
+    runner_b = TypedRunner(scale=2.0)
+    tuning_config = TuningConfig(dynamic_tensor_specs=(DynamicTensorSpec(
+        input_idx=0,
+        dim_idx=0,
+        gen_tuning_buckets=get_power_of_2_num_tokens_buckets,
+        map_to_tuning_buckets=next_positive_power_of_2), ), )
+
+    tuner = AutoTuner.get()
+    tuner.clear_cache()
+    tuner._choose_one_cache.clear()
+
+    # Tune both runners under the SAME custom_op name
+    op_name = "test_cache_collision"
+    with autotune():
+        tuner.choose_one(op_name, [runner_a], tuning_config, [x, w])
+    with autotune():
+        tuner.choose_one(op_name, [runner_b], tuning_config, [x, w])
+
+    # First call — runner_a
+    r1, t1 = tuner.choose_one(op_name, [runner_a], tuning_config, [x, w])
+    result_a = r1(inputs=[x, w], tactic=t1)
+
+    # Second call — runner_b (MUST NOT return runner_a's cached result)
+    r2, t2 = tuner.choose_one(op_name, [runner_b], tuning_config, [x, w])
+    result_b = r2(inputs=[x, w], tactic=t2)
+
+    expected_a = x @ w * 1.0
+    expected_b = x @ w * 2.0
+    assert torch.allclose(result_a, expected_a, atol=1e-5), \
+        f"Runner A should produce scale=1.0 result"
+    assert torch.allclose(result_b, expected_b, atol=1e-5), \
+        f"Runner B should produce scale=2.0 result, got scale={result_b[0,0]/expected_a[0,0]:.1f}x (cache collision!)"
+    assert r1 is not r2, "Different runners must not be aliased by cache"
+
+
 @pytest.mark.skipif(torch.cuda.device_count() < 2,
                     reason="Requires at least 2 GPUs for this test")
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Reduces AutoTuner host overhead in the inference hot path. Profiling on B200 showed the `choose_one()` → `search_cache()` → `get_cache_key()` path adds significant Python overhead on every custom op call. This PR eliminates the bulk of it.

### Changes

**Phase 1: WAR Optimizations**
- Cached key prefix in `get_cache_key()` (avoids recomputing `__class__.__name__` + `str(unique_id())` per call)
- Singleton runner caches for `nvfp4_gemm` and `quantize_e4m3_per_tensor`

**Phase 2: `_choose_one_cache` fast path in `choose_one()`**
- `_choose_one_cache`: maps `(custom_op, runner_ids, *bucketed_dims)` → `(runner_id, tactic)`. On cache hit: one `_make_fast_key()` + one `dict.get()`, then resolve runner from caller's list.
- `_make_fast_key()`: lightweight key using only dynamic dimensions + runner identity (`_cache_key_prefix`).
- `dispatch()`: simplified to thin wrapper over `choose_one()` — delegates all caching to `_choose_one_cache`.
- `TunableRunner.bind_tactic()`: returns callable pre-bound to a specific tactic. Subclasses pre-resolve sub-runners.
- Converted 21 callsites to `dispatch()` across `torch_custom_ops.py` (12) and `cute_dsl_custom_ops.py` (9).

**Cache collision fix (runner identity in key)**
- Cache key includes `runner_ids` (tuple of each runner's `_cache_key_prefix`) so that different runner configurations for the same `custom_op` + dimensions don't collide (e.g. int8 vs int4 `weight_only_quant_gemm` runners).
- Cache stores `(runner_id, tactic)` instead of runner instances — resolution always uses caller's `runners` list.

## Profiling Results

Clean wall-clock measurements on B200, nvfp4_gemm (M=128, K=4096, N=4096, CUTLASS, 500 iters, no nsys/NVTX overhead):

| Path | Total/call | Overhead | vs Original |
|---|---|---|---|
| **Original** (choose_one + runner ctor) | ~30.1us | +12.7us | baseline |
| **This PR** (choose_one cache hit, via @custom_op) | 25.2us | +7.8us | **saves 4.9us (1.20x)** |
| Raw kernel floor (dispatch_fn direct) | 17.4us | — | — |

### Overhead breakdown

| Component | Original | This PR |
|---|---|---|
| Python dispatch logic | 6.2us | **1.3us** (79% reduction) |
| torch.ops @custom_op framework tax | 6.5us | 6.5us (unchanged) |
| **Total overhead** | **12.7us** | **7.8us** |

The \`_choose_one_cache\` reduces Python overhead from 6.2us to 1.3us by replacing per-call runner construction + \`choose_one()\` tactic search with \`_make_fast_key()\` + \`dict.get()\`.

The remaining 6.5us is the \`@torch.library.custom_op\` framework dispatch cost (DispatchKeySet traversal, auto-functionalization, schema validation). This is addressable separately via \`fast_custom_op\` (PR #13149), which reduces it to 2.3us.

### Per-step impact (40 tunable ops)

| Config | Overhead/step |
|---|---|
| Original | 1.21ms |
| This PR | 1.01ms (**-16%**) |
| This PR + fast_custom_op (#13149) | 0.84ms (**-30%**) |

## Correctness Verification

### Cache collision fix
Single-GPU collision repro (B200, \`weight_only_quant_gemm\`, same dims 4096x7168x2112):
- **Before fix**: int8 runner cached, int4 call returns wrong runner → \`RuntimeError: size of tensor a (1056) must match size of tensor b (2112)\`
- **After fix**: Both int8 and int4 pass — runner identity in cache key prevents collision

### Unit tests
| Test Suite | Result |
|---|---|
| Core AutoTuner (test_autotuner.py) | All passed |
| FP4 Linear (test_fp4_linear.py) | 8 passed |
| Fused MoE (test_fused_moe.py) | Passed |

## Files Modified

| File | Change |
|---|---|
| \`tensorrt_llm/_torch/autotuner.py\` | \`_choose_one_cache\` in choose_one(), simplified dispatch(), \`_make_fast_key()\` with runner identity, \`bind_tactic()\` |
| \`tensorrt_llm/_torch/custom_ops/torch_custom_ops.py\` | Runner caches, 12 callsites → dispatch() |
| \`tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py\` | 9 callsites → dispatch() |
| \`tests/unittest/_torch/misc/test_autotuner.py\` | +2 tests: cache hit/invalidation, collision prevention |

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.