### PR TITLE
[https://nvbugs/6076767][fix] Add barrier before warmup to prevent PP hang with guided decoding

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -473,6 +473,13 @@ class PyExecutor:
         # The scheduler will avoid scheduling requests that are already in flight.
         self.inflight_req_ids = ReqIdsSet()
 
+        # Synchronize all ranks before warmup. This prevents a PP
+        # communication deadlock when ranks on the last PP stage are delayed
+        # by heavy initialisation (e.g. guided-decoder / llguidance tokenizer
+        # creation) while earlier PP stages already start warmup forward
+        # passes that require matching pp_recv on the later stages.
+        self.dist.barrier()
+
         # During warmup, we don't enable the profiler
         # Run warmup on the execution_stream for proper synchronization with
         # KVCacheTransferManager's onboard/offload operations.


### PR DESCRIPTION
## Summary
- Fix for NVBugs 6076767: [TensorRT-LLM][release/1.2.1]: accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_guided_decoding_4gpus[llguidance] stably hang
- **Root cause**: Add barrier before warmup to prevent PP hang with guided decoding
- **Fix**: (auto-detected from git commit)
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6076767


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added global synchronization during initialization for pipeline-parallel execution stages to ensure coordinated startup behavior across all ranks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->