### PR TITLE
[None][fix] Fix Mamba cache correctness under MTP + CUDA-graph padding

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/rnnStateManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/rnnStateManager.cpp
@@ -20,8 +20,6 @@
 #include "tensorrt_llm/runtime/cudaStream.h"
 #include "tensorrt_llm/runtime/utils/runtimeUtils.h"
 
-#include <unordered_set>
-
 using namespace tensorrt_llm::runtime;
 
 namespace tensorrt_llm::batch_manager::rnn_state_manager
@@ -258,40 +256,16 @@ std::vector<RnnStateManager::SizeType32> RnnStateManager::getStateIndices(
     std::vector<RequestIdType> const& requestIds, std::vector<bool> const& isPadding)
 {
     TLLM_CHECK_WITH_INFO(requestIds.size() == isPadding.size(), "requestIds and isPadding must have the same size");
-
-    std::unordered_set<SizeType32> availableSlots;
-    availableSlots.reserve(mMaxNumSequences);
-    for (SizeType32 i = 0; i < mMaxNumSequences; ++i)
-    {
-        availableSlots.insert(i);
-    }
-
-    for (size_t i = 0; i < requestIds.size(); ++i)
-    {
-        if (!isPadding[i])
-        {
-            availableSlots.erase(getCacheIndex(requestIds[i]));
-        }
-    }
-
+    // Every id (real or CUDA-graph padding sentinel) has a permanent slot
+    // allocated by allocateCacheBlocks; padding entries all share their
+    // sentinel's slot, so they never alias a live request and never
+    // consume free-pool slots.
     std::vector<SizeType32> result;
     result.reserve(requestIds.size());
-    auto availableIt = availableSlots.begin();
-
-    for (size_t i = 0; i < requestIds.size(); ++i)
+    for (auto const& rid : requestIds)
     {
-        if (isPadding[i])
-        {
-            TLLM_CHECK_WITH_INFO(availableIt != availableSlots.end(), "Run out of available slots for padding");
-            result.push_back(*availableIt);
-            ++availableIt;
-        }
-        else
-        {
-            result.push_back(getCacheIndex(requestIds[i]));
-        }
+        result.push_back(getCacheIndex(rid));
     }
-
     return result;
 }
 

--- a/cpp/tensorrt_llm/thop/mamba2MTPSSMCacheOp.cpp
+++ b/cpp/tensorrt_llm/thop/mamba2MTPSSMCacheOp.cpp
@@ -55,7 +55,11 @@ void mamba2_mtp_ssm_cache_update(th::Tensor ssm, th::Tensor x, th::Tensor dt, th
     int const head_dim = ssm.size(2);
     int const ssm_dim = ssm.size(3);
 
-    TORCH_CHECK(intermediate_states.dim() == 5 && intermediate_states.size(0) == ssm.size(0)
+    // intermediate_states is indexed by intermediate_states_indices (batch
+    // position 0..bs-1), independent of ssm's slot pool; it only needs to
+    // fit the forward batch, which may be smaller than ssm.size(0) when
+    // the cache pool reserves extra slots (e.g. CUDA-graph padding dummies).
+    TORCH_CHECK(intermediate_states.dim() == 5 && intermediate_states.size(0) >= bs
             && intermediate_states.size(1) == cache_steps && intermediate_states.size(2) == nheads
             && intermediate_states.size(3) == head_dim && intermediate_states.size(4) == ssm_dim,
         "intermediate_states shape check failed");

--- a/cpp/tensorrt_llm/thop/mamba2MTPSSMCacheOp.cpp
+++ b/cpp/tensorrt_llm/thop/mamba2MTPSSMCacheOp.cpp
@@ -55,10 +55,11 @@ void mamba2_mtp_ssm_cache_update(th::Tensor ssm, th::Tensor x, th::Tensor dt, th
     int const head_dim = ssm.size(2);
     int const ssm_dim = ssm.size(3);
 
-    // intermediate_states is indexed by intermediate_states_indices (batch
-    // position 0..bs-1), independent of ssm's slot pool; it only needs to
-    // fit the forward batch, which may be smaller than ssm.size(0) when
-    // the cache pool reserves extra slots (e.g. CUDA-graph padding dummies).
+    // ssm.size(0) is the Mamba cache capacity — independent of the
+    // current batch (may include parked requests or reserved dummy
+    // slots). intermediate_states is per-step scratch indexed by
+    // intermediate_states_indices in [0, bs), so it only needs to
+    // fit the forward batch.
     TORCH_CHECK(intermediate_states.dim() == 5 && intermediate_states.size(0) >= bs
             && intermediate_states.size(1) == cache_steps && intermediate_states.size(2) == nheads
             && intermediate_states.size(3) == head_dim && intermediate_states.size(4) == ssm_dim,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_eagle.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_eagle.py
@@ -1025,10 +1025,12 @@ class EagleWrapper(nn.Module):
         kv_cache_manager = csi.kv_cache_manager
         if num_extend > 0 and isinstance(kv_cache_manager, MambaHybridCacheManager):
             if kv_cache_manager.is_speculative():
+                state_indices = csi.get_arg("slot_idx", truncate=True)
                 _ctx = SimpleNamespace(num_seqs=num_sequences, num_contexts=num_prefill)
                 kv_cache_manager.update_mamba_states(
                     attn_metadata=_ctx,
                     num_accepted_tokens=new_tokens_lens,
+                    state_indices=state_indices,
                 )
 
         # compute the cache and position offset based on the number of new tokens compared to the

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -305,15 +305,6 @@ def _generate_dummy_request(
     dummy_request = kv_cache_manager.add_dummy_requests([request_id], **request_kwargs)[0]
     dummy_request.is_cuda_graph_dummy = True
 
-    # generate a dummy scheduled requests object
-    dummy_scheduled_requests = ScheduledRequests()
-    dummy_scheduled_requests.generation_requests.append(dummy_request)
-
-    # if it's a hybrid kv-cache manager, we need to manually call prepare_resources again (not done
-    # in add_dummy_requests)
-    if is_hybrid_cache:
-        kv_cache_manager.prepare_resources(dummy_scheduled_requests)
-
     # add to spec resource manager
     if spec_res_mgr:
         spec_res_mgr.add_dummy_requests([request_id])

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -32,8 +32,7 @@ from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 from tensorrt_llm._torch.pyexecutor.resource_manager import (
     BaseResourceManager, CacheTypeCpp, DataType, KVCacheManager, get_pp_layers)
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
-from tensorrt_llm._utils import (nvtx_range, prefer_pinned,
-                                 torch_dtype_to_binding)
+from tensorrt_llm._utils import nvtx_range, torch_dtype_to_binding
 from tensorrt_llm.bindings.internal.batch_manager import (
     KvCacheConnectorManager, LinearAttentionMetadata, LinearCacheType)
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig
@@ -373,12 +372,6 @@ class PythonMambaCacheManager(BaseResourceManager):
         # mamba cache index, maps request_id -> state indices
         self.mamba_cache_index: Dict[int, int] = {}
 
-        # mamba cache state indices
-        self.state_indices: torch.Tensor = torch.arange(max_batch_size,
-                                                        device=device,
-                                                        dtype=torch.int32)
-        # save mamba state indices for requests
-        self.state_indices_list: List[int] = []
         # save intermediate state indices for requests
         self.intermediate_state_indices = torch.arange(max_batch_size,
                                                        dtype=torch.int32,
@@ -397,23 +390,13 @@ class PythonMambaCacheManager(BaseResourceManager):
 
     @torch.inference_mode()
     def _prepare_mamba_cache_blocks(self, request_ids: List[int]):
-        self.state_indices_list.clear()
         for r in request_ids:
-            # cache hit
             if r in self.mamba_cache_index:
-                self.state_indices_list.append(self.mamba_cache_index[r])
-            # cache miss
-            else:
-                if len(self.mamba_cache_free_blocks) == 0:
-                    raise RuntimeError("run out of mamba cache blocks")
-                block = self.mamba_cache_free_blocks.pop()
-                self.mamba_cache_index[r] = block
-                self.state_indices_list.append(block)
-        self.state_indices[:len(self.state_indices_list)].copy_(
-            torch.tensor(self.state_indices_list,
-                         dtype=torch.int32,
-                         pin_memory=prefer_pinned()),
-            non_blocking=True)
+                continue
+            if len(self.mamba_cache_free_blocks) == 0:
+                raise RuntimeError("run out of mamba cache blocks")
+            block = self.mamba_cache_free_blocks.pop()
+            self.mamba_cache_index[r] = block
 
     def prepare_resources(self, scheduled_batch: ScheduledRequests):
         context_ids = [
@@ -494,9 +477,6 @@ class PythonMambaCacheManager(BaseResourceManager):
 
     def shutdown(self):
         """Release tensor memory."""
-        # Clear state indices
-        self.state_indices = torch.tensor([])
-
         # Clear mamba cache states
         if isinstance(self.mamba_cache, self.SpeculativeState):
             self.mamba_cache = self.SpeculativeState(
@@ -668,15 +648,17 @@ class MambaCacheManager(BaseResourceManager, BaseMambaCacheManager):
     def shutdown(self):
         self._impl.shutdown()
 
-    def update_mamba_states(self,
-                            attn_metadata: "AttentionMetadata",
+    def update_mamba_states(self, attn_metadata: "AttentionMetadata",
                             num_accepted_tokens: torch.Tensor,
-                            state_indices: Optional[torch.Tensor] = None):
+                            state_indices: torch.Tensor):
+        # Non-speculative configs don't allocate intermediate state; the
+        # promotion is a clean no-op.
+        if not self._impl.is_speculative():
+            return
+        # Belt-and-suspenders: C++ is non-speculative today so this is
+        # unreachable. Fires if C++ ever grows speculative support
+        # without also implementing the scatter there.
         assert not self._use_cpp, "update_mamba_states is not supported in CppMambaCacheManager"
-        # Resolve the forward-path fallback outside the @torch.compile body
-        # so Dynamo only specializes on a concrete Tensor.
-        if state_indices is None:
-            state_indices = self._impl.state_indices
         self._impl.update_mamba_states(attn_metadata, num_accepted_tokens,
                                        state_indices)
 
@@ -793,14 +775,6 @@ class MixedMambaHybridCacheManager(KVCacheManager, MambaCacheManager):
                          kv_cache_dtype_byte_size: float = None):
         KVCacheManager.update_resources(self, scheduled_batch, attn_metadata,
                                         kv_cache_dtype_byte_size)
-
-    def update_mamba_states(self,
-                            attn_metadata: "AttentionMetadata",
-                            num_accepted_tokens: torch.Tensor,
-                            state_indices: Optional[torch.Tensor] = None):
-        MambaCacheManager.update_mamba_states(self, attn_metadata,
-                                              num_accepted_tokens,
-                                              state_indices)
 
 
 def calc_context_stop_positions(prompt_len: int,

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -191,12 +191,10 @@ class CppMambaCacheManager(BaseResourceManager):
         self.mamba_impl.free_cache_block(request.py_request_id)
 
     def add_dummy_requests(self, request_ids: List[int], **kwargs):
-        # For CUDA graph dummy requests, the blocks will be allocated
-        # when get_state_indices is called.
-        from .cuda_graph_runner import CUDA_GRAPH_DUMMY_REQUEST_ID
-        request_ids = [
-            rid for rid in request_ids if rid != CUDA_GRAPH_DUMMY_REQUEST_ID
-        ]
+        # Allocate a permanent slot for every id, including CUDA-graph
+        # padding sentinels (matches PythonMambaCacheManager). Padding
+        # entries in get_state_indices then resolve via mCacheIndex to
+        # the sentinel's reserved slot and never alias a live request.
         if request_ids:
             self.mamba_impl.allocate_cache_blocks(request_ids)
 
@@ -428,10 +426,16 @@ class PythonMambaCacheManager(BaseResourceManager):
         self._prepare_mamba_cache_blocks(request_ids)
 
     def add_dummy_requests(self, request_ids: List[int], **kwargs):
-        from .cuda_graph_runner import CUDA_GRAPH_DUMMY_REQUEST_ID
-        request_ids = [
-            rid for rid in request_ids if rid != CUDA_GRAPH_DUMMY_REQUEST_ID
-        ]
+        # Allocate a permanent slot for every dummy request ID, including
+        # the CUDA-graph padding sentinel. Padding entries in a batch all
+        # reference the same dummy request ID, so they share one slot via
+        # mamba_cache_index lookup in get_state_indices. This mirrors how
+        # MTP's per-draft-len padding dummies already behave (they use
+        # CUDA_GRAPH_DUMMY_REQUEST_ID - draft_len, which was never
+        # filtered here) and keeps padding writes off every live
+        # request's slot, even under the overlap scheduler where a prior
+        # batch's completed requests linger in mamba_cache_index until
+        # _process_previous_batch runs.
         if request_ids:
             for r in request_ids:
                 if r not in self.mamba_cache_index:
@@ -448,29 +452,10 @@ class PythonMambaCacheManager(BaseResourceManager):
 
     def get_state_indices(self, request_ids: List[int],
                           is_padding: List[bool]) -> List[int]:
-        assert len(request_ids) == len(is_padding), (
-            "request_ids and is_padding must have the same size")
-
-        used_slots = {
-            self.mamba_cache_index[req_id]
-            for req_id, pad in zip(request_ids, is_padding) if not pad
-        }
-        available_slots = iter(
-            sorted(set(range(self.state_indices.numel())) - used_slots))
-
-        def slot_for(req_id: int, pad: bool):
-            if pad:
-                try:
-                    return next(available_slots)
-                except StopIteration:
-                    raise RuntimeError(
-                        "Run out of available slots for padding") from None
-            return self.mamba_cache_index[req_id]
-
-        result = [
-            slot_for(rid, pad) for rid, pad in zip(request_ids, is_padding)
-        ]
-        return result
+        # Padding entries reuse the slot pre-allocated by their dummy
+        # request in add_dummy_requests; see that method for the
+        # overlap-scheduler rationale.
+        return [self.mamba_cache_index[rid] for rid in request_ids]
 
     def get_conv_states(self, layer_idx: int) -> torch.Tensor:
         layer_offset = self.mamba_layer_offsets[layer_idx]
@@ -530,14 +515,14 @@ class PythonMambaCacheManager(BaseResourceManager):
 
     @torch.compile(options={"max-autotune": True})
     def update_mamba_states(self, attn_metadata: "AttentionMetadata",
-                            num_accepted_tokens: torch.Tensor):
+                            num_accepted_tokens: torch.Tensor,
+                            state_indices: torch.Tensor):
         batch_size = attn_metadata.num_seqs
         num_contexts = attn_metadata.num_contexts
         num_gens = batch_size - num_contexts
         num_accepted_draft_tokens = num_accepted_tokens[
             num_contexts:num_contexts + num_gens] - 1
-        state_indices_d = self.state_indices[num_contexts:num_contexts +
-                                             num_gens]
+        state_indices_d = state_indices[num_contexts:num_contexts + num_gens]
 
         conv_states = self.mamba_cache.conv
         ssm_states = self.mamba_cache.temporal
@@ -683,10 +668,17 @@ class MambaCacheManager(BaseResourceManager, BaseMambaCacheManager):
     def shutdown(self):
         self._impl.shutdown()
 
-    def update_mamba_states(self, attn_metadata: "AttentionMetadata",
-                            num_accepted_tokens: torch.Tensor):
+    def update_mamba_states(self,
+                            attn_metadata: "AttentionMetadata",
+                            num_accepted_tokens: torch.Tensor,
+                            state_indices: Optional[torch.Tensor] = None):
         assert not self._use_cpp, "update_mamba_states is not supported in CppMambaCacheManager"
-        self._impl.update_mamba_states(attn_metadata, num_accepted_tokens)
+        # Resolve the forward-path fallback outside the @torch.compile body
+        # so Dynamo only specializes on a concrete Tensor.
+        if state_indices is None:
+            state_indices = self._impl.state_indices
+        self._impl.update_mamba_states(attn_metadata, num_accepted_tokens,
+                                       state_indices)
 
 
 class MixedMambaHybridCacheManager(KVCacheManager, MambaCacheManager):
@@ -733,7 +725,13 @@ class MixedMambaHybridCacheManager(KVCacheManager, MambaCacheManager):
         # mamba hybrid cache requires block reuse to be disabled in KV cache config
         assert not kv_cache_config.enable_block_reuse, "mamba hybrid cache requires block reuse to be disabled in KV cache config"
 
-        # initialize mamba cache manager
+        # Reserve one Mamba slot per possible CUDA-graph padding dummy
+        # (one per runtime_draft_len in 0..max_draft_len) so a full
+        # max_batch_size of real requests still leaves room for padding.
+        max_draft_len = (spec_config.max_draft_len
+                         if spec_config is not None else 0)
+        pool_size = max_batch_size + max_draft_len + 1
+
         MambaCacheManager.__init__(
             self,
             mamba_d_state,
@@ -742,7 +740,7 @@ class MixedMambaHybridCacheManager(KVCacheManager, MambaCacheManager):
             mamba_n_groups,
             mamba_head_dim,
             mamba_num_layers,
-            max_batch_size,
+            pool_size,
             max_batch_size,
             mapping,
             mamba_cache_dtype,
@@ -796,10 +794,13 @@ class MixedMambaHybridCacheManager(KVCacheManager, MambaCacheManager):
         KVCacheManager.update_resources(self, scheduled_batch, attn_metadata,
                                         kv_cache_dtype_byte_size)
 
-    def update_mamba_states(self, attn_metadata: "AttentionMetadata",
-                            num_accepted_tokens: torch.Tensor):
+    def update_mamba_states(self,
+                            attn_metadata: "AttentionMetadata",
+                            num_accepted_tokens: torch.Tensor,
+                            state_indices: Optional[torch.Tensor] = None):
         MambaCacheManager.update_mamba_states(self, attn_metadata,
-                                              num_accepted_tokens)
+                                              num_accepted_tokens,
+                                              state_indices)
 
 
 def calc_context_stop_positions(prompt_len: int,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -858,6 +858,16 @@ def create_py_executor(
                 py_executor.kv_cache_transceiver.shutdown()
         finally:
             kv_cache_creator.teardown_managers(resources)
+
+        # Release Phase-1 CUDA graph pools before final KV allocation to avoid overshoot.
+        for eng in [model_engine, draft_model_engine]:
+            if eng is None:
+                continue
+            if eng.attn_metadata is not None:
+                if llm_args.cuda_graph_config is not None:
+                    eng._release_cuda_graphs()
+                eng.attn_metadata = None
+
         del py_executor  # free before constructing new
         gc.collect()
 
@@ -872,13 +882,6 @@ def create_py_executor(
             max_seq_len = kv_cache_creator._max_seq_len
             update_sampler_max_seq_len(max_seq_len, sampler)
 
-            for eng in [model_engine, draft_model_engine]:
-                if eng is None:
-                    continue
-                if eng.attn_metadata is not None:
-                    if llm_args.cuda_graph_config is not None:
-                        eng._release_cuda_graphs()
-                    eng.attn_metadata = None
         with allocation_scope(ExecutorMemoryType.EXTRA_RESOURCES):
 
             # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -1167,9 +1167,15 @@ class MTPEagleWorker(MTPWorker):
             self._is_mamba_hybrid_cache = isinstance(
                 attn_metadata.kv_cache_manager, MambaHybridCacheManager)
         if num_gens > 0 and self._is_mamba_hybrid_cache:
+            # Use the forward-path state_indices so the scatter lines up
+            # with the mixer's reads (covers the full padded batch).
+            mamba_metadata = getattr(attn_metadata, 'mamba_metadata', None)
+            mamba_state_indices = (mamba_metadata.state_indices
+                                   if mamba_metadata is not None else None)
             attn_metadata.kv_cache_manager.update_mamba_states(
                 attn_metadata=attn_metadata,
-                num_accepted_tokens=num_accepted_tokens)
+                num_accepted_tokens=num_accepted_tokens,
+                state_indices=mamba_state_indices)
 
         # Save the old attn_metadata and spec_metadata
         self._prepare_attn_metadata_for_spec_dec(attn_metadata)

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -1167,15 +1167,10 @@ class MTPEagleWorker(MTPWorker):
             self._is_mamba_hybrid_cache = isinstance(
                 attn_metadata.kv_cache_manager, MambaHybridCacheManager)
         if num_gens > 0 and self._is_mamba_hybrid_cache:
-            # Use the forward-path state_indices so the scatter lines up
-            # with the mixer's reads (covers the full padded batch).
-            mamba_metadata = getattr(attn_metadata, 'mamba_metadata', None)
-            mamba_state_indices = (mamba_metadata.state_indices
-                                   if mamba_metadata is not None else None)
             attn_metadata.kv_cache_manager.update_mamba_states(
                 attn_metadata=attn_metadata,
                 num_accepted_tokens=num_accepted_tokens,
-                state_indices=mamba_state_indices)
+                state_indices=attn_metadata.mamba_metadata.state_indices)
 
         # Save the old attn_metadata and spec_metadata
         self._prepare_attn_metadata_for_spec_dec(attn_metadata)

--- a/tests/unittest/_torch/executor/test_mamba_cache_manager.py
+++ b/tests/unittest/_torch/executor/test_mamba_cache_manager.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for MambaCacheManager padding-slot behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import CUDA_GRAPH_DUMMY_REQUEST_ID
+from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import (
+    CppMambaCacheManager,
+    PythonMambaCacheManager,
+)
+from tensorrt_llm.mapping import Mapping
+
+skip_no_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def _make_mgr(max_batch_size=4, max_draft_len=2):
+    # Pool size mirrors MambaHybridCacheManager's +max_draft_len+1 headroom.
+    pool = max_batch_size + max_draft_len + 1
+    return PythonMambaCacheManager(
+        d_state=8,
+        d_conv=4,
+        num_heads=4,
+        n_groups=1,
+        head_dim=8,
+        num_layers=2,
+        max_batch_size=pool,
+        spec_state_size=max_batch_size,
+        mapping=Mapping(world_size=1, tp_size=1, pp_size=1),
+        dtype=torch.float16,
+        ssm_cache_dtype=torch.float16,
+        speculative_num_draft_tokens=max_draft_len,
+    )
+
+
+@skip_no_cuda
+def test_padding_slot_not_held_by_parked_real():
+    """get_state_indices must not hand the padding position a slot
+    owned by a live request outside the current batch. Padding entries
+    all reuse the pre-allocated slot of their dummy request (added via
+    add_dummy_requests), which is distinct from every real request's
+    slot."""
+    mgr = _make_mgr(max_batch_size=4, max_draft_len=2)
+    # Four real requests claim slots; pool has max_batch_size+max_draft_len+1 = 7 slots.
+    mgr._prepare_mamba_cache_blocks([100, 101, 102, 103])
+    # Pre-allocate the padding dummy's slot (what _get_padded_batch does
+    # via kv_cache_manager.add_dummy_requests before get_state_indices).
+    mgr.add_dummy_requests([CUDA_GRAPH_DUMMY_REQUEST_ID])
+    # Current batch has only two reals; 102 and 103 are "parked".
+    request_ids = [100, 101, CUDA_GRAPH_DUMMY_REQUEST_ID]
+    indices = mgr.get_state_indices(request_ids, [False, False, True])
+    real_slots = {mgr.mamba_cache_index[r] for r in [100, 101, 102, 103]}
+    assert indices[2] not in real_slots, (
+        f"padding slot {indices[2]} overlaps a real request's slot (real slots: {real_slots})"
+    )
+    # Padding should reuse the dummy's reserved slot, not allocate a new one.
+    assert indices[2] == mgr.mamba_cache_index[CUDA_GRAPH_DUMMY_REQUEST_ID]
+
+
+@skip_no_cuda
+def test_padding_survives_overlap_scheduler_pressure():
+    """Regression for the overlap-scheduler + attention-dp + CUDA-graph
+    padding combo: prior-iter completions linger in mamba_cache_index
+    until _process_previous_batch runs, so get_state_indices must not
+    require N unused pool slots to serve N padding entries."""
+    mgr = _make_mgr(max_batch_size=4, max_draft_len=0)
+    # Fill the pool with "live" real requests (simulates completed
+    # requests from prior iter that haven't been freed yet).
+    mgr._prepare_mamba_cache_blocks([100, 101, 102, 103])
+    # Pre-allocate the padding dummy's slot.
+    mgr.add_dummy_requests([CUDA_GRAPH_DUMMY_REQUEST_ID])
+    # Current batch: 1 real request + 3 padding entries (attention-dp
+    # pushed padded_batch_size to 4 on this rank even though only 1 real
+    # gen request is scheduled here).
+    request_ids = [100] + [CUDA_GRAPH_DUMMY_REQUEST_ID] * 3
+    is_padding = [False] + [True] * 3
+    indices = mgr.get_state_indices(request_ids, is_padding)
+    # All padding entries share the dummy's slot.
+    dummy_slot = mgr.mamba_cache_index[CUDA_GRAPH_DUMMY_REQUEST_ID]
+    assert indices[0] == mgr.mamba_cache_index[100]
+    assert indices[1:] == [dummy_slot] * 3
+
+
+@skip_no_cuda
+def test_update_mamba_states_uses_passed_state_indices():
+    """update_mamba_states must scatter using the caller-supplied
+    state_indices tensor (e.g. mamba_metadata.state_indices)."""
+    mgr = _make_mgr()
+    mgr._prepare_mamba_cache_blocks([100, 101, 102])
+
+    ssm, conv = mgr.mamba_cache.temporal, mgr.mamba_cache.conv
+    ssm.zero_()
+    conv.zero_()
+    mgr.mamba_cache.intermediate_ssm.fill_(7.0)
+    mgr.mamba_cache.intermediate_conv_window.fill_(7.0)
+
+    # Caller passes slots [slot_R1, slot_R2, slot_R3, 0] for a padded
+    # batch. Slot 0 belongs to the padding dummy.
+    state_indices = torch.tensor(
+        [mgr.mamba_cache_index[100], mgr.mamba_cache_index[101], mgr.mamba_cache_index[102], 0],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    attn = SimpleNamespace(num_seqs=4, num_contexts=0)
+    mgr.update_mamba_states(
+        attn,
+        torch.tensor([1, 1, 1, 1], dtype=torch.int32, device="cuda"),
+        state_indices=state_indices,
+    )
+
+    for rid in [100, 101, 102]:
+        slot = mgr.mamba_cache_index[rid]
+        assert torch.all(ssm[:, slot] == 7.0)
+        assert torch.all(conv[:, slot] == 7.0)
+
+
+@skip_no_cuda
+def test_update_mamba_states_uses_self_state_indices_when_passed():
+    """Regression for the pre-patch behavior where update_mamba_states
+    implicitly read self.state_indices: passing it explicitly as the
+    caller-supplied tensor must produce the same writes."""
+    mgr = _make_mgr()
+    mgr._prepare_mamba_cache_blocks([100, 101, 102])
+
+    ssm, conv = mgr.mamba_cache.temporal, mgr.mamba_cache.conv
+    ssm.zero_()
+    conv.zero_()
+    mgr.mamba_cache.intermediate_ssm.fill_(5.0)
+    mgr.mamba_cache.intermediate_conv_window.fill_(5.0)
+
+    attn = SimpleNamespace(num_seqs=3, num_contexts=0)
+    mgr.update_mamba_states(
+        attn,
+        torch.tensor([1, 1, 1], dtype=torch.int32, device="cuda"),
+        state_indices=mgr.state_indices,
+    )
+
+    for rid in [100, 101, 102]:
+        slot = mgr.mamba_cache_index[rid]
+        assert torch.all(ssm[:, slot] == 5.0)
+        assert torch.all(conv[:, slot] == 5.0)
+
+
+def test_cpp_add_dummy_requests_allocates_sentinel():
+    """CppMambaCacheManager.add_dummy_requests must allocate a permanent
+    slot for every id — including the raw CUDA-graph sentinel — so
+    get_state_indices can return it without racing parked live requests
+    for a free slot."""
+    stub = SimpleNamespace(mamba_impl=MagicMock())
+    CppMambaCacheManager.add_dummy_requests(stub, [100, CUDA_GRAPH_DUMMY_REQUEST_ID, 101])
+    stub.mamba_impl.allocate_cache_blocks.assert_called_once_with(
+        [100, CUDA_GRAPH_DUMMY_REQUEST_ID, 101]
+    )
+
+
+def test_cpp_add_dummy_requests_noop_on_empty_list():
+    stub = SimpleNamespace(mamba_impl=MagicMock())
+    CppMambaCacheManager.add_dummy_requests(stub, [])
+    stub.mamba_impl.allocate_cache_blocks.assert_not_called()

--- a/tests/unittest/_torch/executor/test_mamba_cache_manager.py
+++ b/tests/unittest/_torch/executor/test_mamba_cache_manager.py
@@ -86,9 +86,10 @@ def test_padding_survives_overlap_scheduler_pressure():
 
 
 @skip_no_cuda
-def test_update_mamba_states_uses_passed_state_indices():
-    """update_mamba_states must scatter using the caller-supplied
-    state_indices tensor (e.g. mamba_metadata.state_indices)."""
+def test_update_mamba_states_mtp_path():
+    """MTP forward path: update_mamba_states must scatter using the
+    caller-supplied Mamba2Metadata-style state_indices tensor (partition
+    order, padded to the captured batch size)."""
     mgr = _make_mgr()
     mgr._prepare_mamba_cache_blocks([100, 101, 102])
 
@@ -98,10 +99,15 @@ def test_update_mamba_states_uses_passed_state_indices():
     mgr.mamba_cache.intermediate_ssm.fill_(7.0)
     mgr.mamba_cache.intermediate_conv_window.fill_(7.0)
 
-    # Caller passes slots [slot_R1, slot_R2, slot_R3, 0] for a padded
-    # batch. Slot 0 belongs to the padding dummy.
+    # Simulate mamba_metadata.state_indices — full captured batch of 4
+    # (3 reals + 1 padding dummy on slot 0).
     state_indices = torch.tensor(
-        [mgr.mamba_cache_index[100], mgr.mamba_cache_index[101], mgr.mamba_cache_index[102], 0],
+        [
+            mgr.mamba_cache_index[100],
+            mgr.mamba_cache_index[101],
+            mgr.mamba_cache_index[102],
+            0,
+        ],
         dtype=torch.int32,
         device="cuda",
     )
@@ -119,45 +125,108 @@ def test_update_mamba_states_uses_passed_state_indices():
 
 
 @skip_no_cuda
-def test_update_mamba_states_uses_self_state_indices_when_passed():
-    """Regression for the pre-patch behavior where update_mamba_states
-    implicitly read self.state_indices: passing it explicitly as the
-    caller-supplied tensor must produce the same writes."""
+def test_update_mamba_states_autodeploy_path():
+    """Test update_mamba_states in AutoDeploy path."""
     mgr = _make_mgr()
-    mgr._prepare_mamba_cache_blocks([100, 101, 102])
+    mgr._prepare_mamba_cache_blocks([200, 201, 202])
 
     ssm, conv = mgr.mamba_cache.temporal, mgr.mamba_cache.conv
     ssm.zero_()
     conv.zero_()
-    mgr.mamba_cache.intermediate_ssm.fill_(5.0)
-    mgr.mamba_cache.intermediate_conv_window.fill_(5.0)
+    mgr.mamba_cache.intermediate_ssm.fill_(3.0)
+    mgr.mamba_cache.intermediate_conv_window.fill_(3.0)
 
-    attn = SimpleNamespace(num_seqs=3, num_contexts=0)
+    # Mimic csi.get_arg("slot_idx", truncate=True): int64, truncated
+    # to current_length. One prefill (200), two generation (201, 202).
+    state_indices = torch.tensor(
+        [
+            mgr.mamba_cache_index[200],
+            mgr.mamba_cache_index[201],
+            mgr.mamba_cache_index[202],
+        ],
+        dtype=torch.int64,
+        device="cuda",
+    )
+    # num_contexts=1 means only indices [1:] are scattered (the gen slice).
+    attn = SimpleNamespace(num_seqs=3, num_contexts=1)
     mgr.update_mamba_states(
         attn,
         torch.tensor([1, 1, 1], dtype=torch.int32, device="cuda"),
-        state_indices=mgr.state_indices,
+        state_indices=state_indices,
     )
 
-    for rid in [100, 101, 102]:
+    # Only 201 and 202 (the generation slice) should have been written.
+    assert torch.all(ssm[:, mgr.mamba_cache_index[200]] == 0.0)
+    for rid in [201, 202]:
         slot = mgr.mamba_cache_index[rid]
-        assert torch.all(ssm[:, slot] == 5.0)
-        assert torch.all(conv[:, slot] == 5.0)
+        assert torch.all(ssm[:, slot] == 3.0)
+        assert torch.all(conv[:, slot] == 3.0)
 
 
-def test_cpp_add_dummy_requests_allocates_sentinel():
-    """CppMambaCacheManager.add_dummy_requests must allocate a permanent
-    slot for every id — including the raw CUDA-graph sentinel — so
-    get_state_indices can return it without racing parked live requests
-    for a free slot."""
-    stub = SimpleNamespace(mamba_impl=MagicMock())
-    CppMambaCacheManager.add_dummy_requests(stub, [100, CUDA_GRAPH_DUMMY_REQUEST_ID, 101])
-    stub.mamba_impl.allocate_cache_blocks.assert_called_once_with(
-        [100, CUDA_GRAPH_DUMMY_REQUEST_ID, 101]
-    )
+@skip_no_cuda
+def test_non_mtp_pytorch_prepare_and_get_state_indices_flow():
+    """Test non-MTP PyTorch backend prepare and get_state_indices flow."""
+    mgr = _make_mgr(max_batch_size=4, max_draft_len=0)
+    # Simulate a non-MTP step: mix of context + generation requests,
+    # plus a CUDA-graph padding dummy.
+    context_ids = [400]
+    gen_ids = [401, 402]
+    mgr._prepare_mamba_cache_blocks(context_ids + gen_ids)
+    mgr.add_dummy_requests([CUDA_GRAPH_DUMMY_REQUEST_ID])
+
+    # All reals have distinct slots.
+    reals = set(mgr.mamba_cache_index[r] for r in context_ids + gen_ids)
+    assert len(reals) == 3
+    # Dummy's slot is distinct from every real.
+    assert mgr.mamba_cache_index[CUDA_GRAPH_DUMMY_REQUEST_ID] not in reals
+
+    # What Mamba2Metadata.prepare would do: resolve indices for the
+    # current padded batch (3 reals + 1 padding).
+    request_ids = context_ids + gen_ids + [CUDA_GRAPH_DUMMY_REQUEST_ID]
+    is_padding = [False, False, False, True]
+    indices = mgr.get_state_indices(request_ids, is_padding)
+    assert indices == [
+        mgr.mamba_cache_index[400],
+        mgr.mamba_cache_index[401],
+        mgr.mamba_cache_index[402],
+        mgr.mamba_cache_index[CUDA_GRAPH_DUMMY_REQUEST_ID],
+    ]
 
 
 def test_cpp_add_dummy_requests_noop_on_empty_list():
     stub = SimpleNamespace(mamba_impl=MagicMock())
     CppMambaCacheManager.add_dummy_requests(stub, [])
     stub.mamba_impl.allocate_cache_blocks.assert_not_called()
+
+
+@skip_no_cuda
+def test_cpp_get_state_indices_resolves_sentinel_to_reserved_slot():
+    """End-to-end C++ path: add_dummy_requests + getStateIndices must
+    resolve the CUDA-graph sentinel to its reserved slot, distinct from
+    every live request's slot — guards the C++ mCacheIndex lookup, not
+    just the Python forwarder."""
+    mgr = CppMambaCacheManager(
+        d_state=8,
+        d_conv=4,
+        num_heads=4,
+        n_groups=1,
+        head_dim=8,
+        num_layers=2,
+        max_num_sequences=8,
+        mapping=Mapping(world_size=1, tp_size=1, pp_size=1),
+        dtype=torch.float16,
+        ssm_cache_dtype=torch.float16,
+    )
+    mgr.add_dummy_requests([100, 101, CUDA_GRAPH_DUMMY_REQUEST_ID])
+
+    request_ids = [100, 101, CUDA_GRAPH_DUMMY_REQUEST_ID]
+    is_padding = [False, False, True]
+    indices = mgr.get_state_indices(request_ids, is_padding)
+
+    sentinel_slot = indices[2]
+    real_slots = {indices[0], indices[1]}
+    assert sentinel_slot not in real_slots, (
+        f"sentinel slot {sentinel_slot} aliases a real request's slot {real_slots}"
+    )
+    # Resolve again — reserved slot must be stable across calls.
+    assert mgr.get_state_indices(request_ids, is_padding) == indices

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -440,13 +440,23 @@ def test_hybrid_cache_transceiver_single_process(backend, hybrid_dtypes,
         hybrid_cache_manager_gen.get_buffers(0),
         hybrid_cache_manager_ctx.get_buffers(0)), "different kv-cache values"
 
-    assert torch.equal(hybrid_cache_manager_gen.get_conv_states(1),
-                       hybrid_cache_manager_ctx.get_conv_states(
-                           1)), "different mamba conv states"
+    # The transceiver copies a single request's state between
+    # independently-allocated slots on each side, so we check the
+    # request's own slot instead of the full state buffer (which has
+    # extra padding-dummy slots that only the ctx side touched).
+    slot_ctx = hybrid_cache_manager_ctx._impl.mamba_impl.get_cache_index(
+        ctx_request.py_request_id)
+    slot_gen = hybrid_cache_manager_gen._impl.mamba_impl.get_cache_index(
+        gen_request.py_request_id)
+    assert torch.equal(
+        hybrid_cache_manager_gen.get_conv_states(1)[slot_gen],
+        hybrid_cache_manager_ctx.get_conv_states(1)[slot_ctx]), (
+            "different mamba conv states")
 
-    assert torch.equal(hybrid_cache_manager_gen.get_ssm_states(1),
-                       hybrid_cache_manager_ctx.get_ssm_states(
-                           1)), "different mamba ssm states"
+    assert torch.equal(
+        hybrid_cache_manager_gen.get_ssm_states(1)[slot_gen],
+        hybrid_cache_manager_ctx.get_ssm_states(1)[slot_ctx]), (
+            "different mamba ssm states")
 
 
 @pytest.mark.timeout(120)


### PR DESCRIPTION
# Features

- Reserve max_draft_len + 1 extra Mamba slots in
  MambaHybridCacheManager so real requests and CUDA-graph padding
  dummies both fit.
- Allocate a permanent slot for the CUDA-graph sentinel; padding
  reuses it via direct mamba_cache_index lookup and no longer aliases
  live requests parked under the overlap scheduler.
- update_mamba_states scatters into the caller's state_indices
  (mamba_metadata.state_indices under MTP), removing the stale-tail
  read.
- Relax mamba2_mtp_ssm_cache_update's intermediate_states.size(0)
  check to ">= bs"; it's indexed by batch position, not slot.
- Release Phase-1 CUDA-graph pools before final KV allocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified Mamba state index allocation logic, removing redundant slot management.
  * Relaxed validation for Mamba2 intermediate states to permit larger cache pools.
  * Improved padding slot handling in Mamba cache manager by reusing pre-allocated sentinel slots.
  * Adjusted CUDA graph pool release timing in memory estimation path.

* **Tests**
  * Added comprehensive Mamba cache manager regression tests covering padding and state update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
