### PR TITLE
[https://nvbugs/6086538][fix] suppress misleading skip-softmax FMHA warning in generation

### DIFF
--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/trtllmGen_fmha_export/KernelTraits.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/trtllmGen_fmha_export/KernelTraits.h
@@ -129,12 +129,11 @@ struct KernelConfig : public KernelConfigBase {
     // Set numStagesQ for headDim > 128 kernels.
     bool const isGenerationSkipSoftmax =
       options.mSkipsSoftmaxWhenPossible && !isContextKernel(options.mFmhaKernelType);
-    bool const usesSingleInst = mNumInstsQ * mNumInstsKv == 1;
-    if (usesSingleInst && !isGenerationSkipSoftmax) {
+    if (mNumInstsQ * mNumInstsKv == 1 && !isGenerationSkipSoftmax) {
       TLLM_CHECK_INFO(mTileSizeQ == 64 || (mHeadDimQk > 128 && mHeadDimV > 128),
                       "Consider using numInstsQ = 2 for better performance.");
     }
-    if (usesSingleInst) {
+    if (mNumInstsQ * mNumInstsKv == 1) {
       // There is no enough shared memory for 2 stages when the headDim is not split into multiple
       // stages.
       if (mHeadDimPerStageKv == 0 && keepsMmaAbForDsMlaGen) {

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/trtllmGen_fmha_export/KernelTraits.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/trtllmGen_fmha_export/KernelTraits.h
@@ -129,11 +129,12 @@ struct KernelConfig : public KernelConfigBase {
     // Set numStagesQ for headDim > 128 kernels.
     bool const isGenerationSkipSoftmax =
       options.mSkipsSoftmaxWhenPossible && !isContextKernel(options.mFmhaKernelType);
-    if (mNumInstsQ * mNumInstsKv == 1) {
-      if (!isGenerationSkipSoftmax) {
-        TLLM_CHECK_INFO(mTileSizeQ == 64 || (mHeadDimQk > 128 && mHeadDimV > 128),
-                        "Consider using numInstsQ = 2 for better performance.");
-      }
+    bool const usesSingleInst = mNumInstsQ * mNumInstsKv == 1;
+    if (usesSingleInst && !isGenerationSkipSoftmax) {
+      TLLM_CHECK_INFO(mTileSizeQ == 64 || (mHeadDimQk > 128 && mHeadDimV > 128),
+                      "Consider using numInstsQ = 2 for better performance.");
+    }
+    if (usesSingleInst) {
       // There is no enough shared memory for 2 stages when the headDim is not split into multiple
       // stages.
       if (mHeadDimPerStageKv == 0 && keepsMmaAbForDsMlaGen) {

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/trtllmGen_fmha_export/KernelTraits.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/trtllmGen_fmha_export/KernelTraits.h
@@ -127,9 +127,13 @@ struct KernelConfig : public KernelConfigBase {
     }
 
     // Set numStagesQ for headDim > 128 kernels.
+    bool const isGenerationSkipSoftmax =
+      options.mSkipsSoftmaxWhenPossible && !isContextKernel(options.mFmhaKernelType);
     if (mNumInstsQ * mNumInstsKv == 1) {
-      TLLM_CHECK_INFO(mTileSizeQ == 64 || (mHeadDimQk > 128 && mHeadDimV > 128),
-                      "Consider using numInstsQ = 2 for better performance.");
+      if (!isGenerationSkipSoftmax) {
+        TLLM_CHECK_INFO(mTileSizeQ == 64 || (mHeadDimQk > 128 && mHeadDimV > 128),
+                        "Consider using numInstsQ = 2 for better performance.");
+      }
       // There is no enough shared memory for 2 stages when the headDim is not split into multiple
       // stages.
       if (mHeadDimPerStageKv == 0 && keepsMmaAbForDsMlaGen) {


### PR DESCRIPTION
## Summary
Suppress the FMHA "Consider using numInstsQ = 2" INFO log for skip-softmax generation kernels.

The warning is misleading for this path because skip-softmax generation intentionally uses a 1x1 numInsts configuration, while the existing INFO suggests 2x1 would be preferable.

## Validation
- Rebuilt `build_wheel_targets` successfully
- Verified from local MiniMax-M2 repro logs that the warning spam is aligned with generation warmup, not context/prefill warmup
- Kept the change scoped to generation skip-softmax so context warnings remain intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Performance optimization for generation kernels enabling conditional softmax computation skipping to improve efficiency in specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->