### PR TITLE
[None][feat] AutoDeploy Minimax Perf Updates

### DIFF
--- a/cpp/tensorrt_llm/kernels/shardedQKNormKernel.cu
+++ b/cpp/tensorrt_llm/kernels/shardedQKNormKernel.cu
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * The SyncComm and Barrier structs below are adapted from:
+ *   tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.cu
+ * Copyright (c) 2022-2025, NVIDIA CORPORATION. Apache-2.0 License.
+ */
+
+#include "tensorrt_llm/kernels/shardedQKNormKernel.h"
+
+#include <cassert>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <stdexcept>
+#include <string>
+
+namespace tensorrt_llm::kernels
+{
+
+// ---------------------------------------------------------------------------
+// Barrier flag count — must match kBarrierFlagCount in allReduceFusionKernels.h
+// ---------------------------------------------------------------------------
+static constexpr int kBarrierFlagCount = 256;
+
+// ---------------------------------------------------------------------------
+// SyncComm: manages per-block counter and flag, and pointers to peer buffers.
+// Adapted from allReduceFusionKernels.cu (tensorrt_llm::kernels::ar_fusion).
+// ---------------------------------------------------------------------------
+template <int NRanks>
+struct SyncComm
+{
+    __device__ __forceinline__ SyncComm(void** workspace)
+    {
+        counter_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[0];
+        flag_ptr = &reinterpret_cast<int*>(workspace[NRanks * 3])[1];
+        flag_value = *flag_ptr;
+        for (int r = 0; r < NRanks; ++r)
+        {
+            comm_bufs[r] = workspace[r];
+            barrier_flags[r] = workspace[NRanks + r];
+        }
+        __syncthreads();
+        if (threadIdx.x == 0)
+        {
+            atomicAdd(counter_ptr, 1);
+        }
+    }
+
+    __device__ __forceinline__ void update(int new_flag_value)
+    {
+        if (blockIdx.x == 0 && threadIdx.x == 0)
+        {
+            while (*reinterpret_cast<int volatile*>(counter_ptr) != gridDim.x)
+            {
+            }
+            *flag_ptr = new_flag_value;
+            *counter_ptr = 0;
+        }
+    }
+
+    int* counter_ptr;
+    int* flag_ptr;
+    void* comm_bufs[NRanks];
+    void* barrier_flags[NRanks];
+    int flag_value;
+};
+
+// ---------------------------------------------------------------------------
+// Barrier: per-rank cross-GPU synchronization using NVLink store/load.
+// Adapted from allReduceFusionKernels.cu (tensorrt_llm::kernels::ar_fusion).
+// ---------------------------------------------------------------------------
+template <int NRanks>
+class Barrier
+{
+public:
+    __device__ __forceinline__ Barrier(int rank, SyncComm<NRanks> const& comm)
+    {
+        if (threadIdx.x < NRanks)
+        {
+            m_flag_value = comm.flag_value;
+            int current_rank = rank;
+            int target_rank = threadIdx.x;
+            m_target_flag = reinterpret_cast<int*>(comm.barrier_flags[target_rank]) + current_rank;
+            m_current_flag
+                = reinterpret_cast<int*>(comm.barrier_flags[current_rank]) + blockIdx.x * NRanks + target_rank;
+        }
+    }
+
+    __device__ __forceinline__ void sync()
+    {
+        __syncthreads();
+        if (threadIdx.x < NRanks)
+        {
+            m_flag_value = next_flag(m_flag_value);
+            // Signal all blocks up to kBarrierFlagCount to avoid ABA problems.
+            for (int flag_idx = blockIdx.x; flag_idx < kBarrierFlagCount; flag_idx += gridDim.x)
+            {
+                st_flag(m_target_flag + flag_idx * NRanks, m_flag_value);
+            }
+            while (ld_flag(m_current_flag) == prev_flag(m_flag_value))
+            {
+            }
+        }
+        __syncthreads();
+    }
+
+protected:
+    __device__ __forceinline__ void st_flag(int* addr, int flag)
+    {
+        asm volatile("st.global.release.sys.b32 [%1], %0;" ::"r"(flag), "l"(addr));
+    }
+
+    __device__ __forceinline__ int ld_flag(int* addr)
+    {
+        int flag;
+        asm volatile("ld.global.acquire.sys.b32 %0, [%1];" : "=r"(flag) : "l"(addr));
+        return flag;
+    }
+
+    __device__ __forceinline__ int next_flag(int flag)
+    {
+        return flag == 2 ? 0 : flag + 1;
+    }
+
+    __device__ __forceinline__ int prev_flag(int flag)
+    {
+        return flag == 0 ? 2 : flag - 1;
+    }
+
+public:
+    int m_flag_value;
+
+private:
+    int* m_target_flag;
+    int* m_current_flag;
+};
+
+// ---------------------------------------------------------------------------
+// Warp-level sum reduction (used in block reduction below).
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ float warpReduceSum(float val)
+{
+#pragma unroll
+    for (int mask = 16; mask > 0; mask >>= 1)
+    {
+        val += __shfl_xor_sync(0xffffffff, val, mask, 32);
+    }
+    return val;
+}
+
+// ---------------------------------------------------------------------------
+// Block-level sum reduction for two float values simultaneously.
+// Returns the block-wide sum in thread 0; all threads should call this.
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ void blockReduceSum2(float& val0, float& val1)
+{
+    __shared__ float shared0[33];
+    __shared__ float shared1[33];
+
+    int lane = threadIdx.x & 0x1f;
+    int wid = threadIdx.x >> 5;
+
+    val0 = warpReduceSum(val0);
+    val1 = warpReduceSum(val1);
+
+    if (lane == 0)
+    {
+        shared0[wid] = val0;
+        shared1[wid] = val1;
+    }
+    __syncthreads();
+
+    int nwarps = (blockDim.x + 31) / 32;
+    val0 = (threadIdx.x < nwarps) ? shared0[lane] : 0.f;
+    val1 = (threadIdx.x < nwarps) ? shared1[lane] : 0.f;
+
+    val0 = warpReduceSum(val0);
+    val1 = warpReduceSum(val1);
+}
+
+// ---------------------------------------------------------------------------
+// Main fused kernel: one block per token.
+// ---------------------------------------------------------------------------
+template <int NRanks, typename DType>
+__global__ void shardedQKNormKernel(DType const* __restrict__ q_in, DType const* __restrict__ k_in,
+    DType* __restrict__ q_out, DType* __restrict__ k_out, float const* __restrict__ weight_q,
+    float const* __restrict__ weight_k, void** workspace, int n_tokens, int local_q_dim, int local_k_dim, int q_stride,
+    int k_stride, int world_size, int rank, float eps)
+{
+    int token_idx = blockIdx.x;
+    if (token_idx >= n_tokens)
+        return;
+
+    // -----------------------------------------------------------------------
+    // Phase 1: compute local sum-of-squares for this token's Q and K rows.
+    // Input uses q_stride / k_stride (>= local dim) to allow a view into a
+    // fused [N, total_dim] tensor (e.g. Q+K+V output of a fused GEMM).
+    // -----------------------------------------------------------------------
+    float q_sumsq = 0.f;
+    float k_sumsq = 0.f;
+
+    for (int i = threadIdx.x; i < local_q_dim; i += blockDim.x)
+    {
+        float v = static_cast<float>(q_in[token_idx * q_stride + i]);
+        q_sumsq += v * v;
+    }
+    for (int i = threadIdx.x; i < local_k_dim; i += blockDim.x)
+    {
+        float v = static_cast<float>(k_in[token_idx * k_stride + i]);
+        k_sumsq += v * v;
+    }
+
+    blockReduceSum2(q_sumsq, k_sumsq);
+
+    // Thread 0 writes the packed [q_sumsq, k_sumsq] into this rank's comm buffer.
+    if (threadIdx.x == 0)
+    {
+        float2* comm_slot = reinterpret_cast<float2*>(workspace[rank]) + token_idx;
+        *comm_slot = make_float2(q_sumsq, k_sumsq);
+    }
+    __syncthreads();
+
+    // -----------------------------------------------------------------------
+    // Phase 2: cross-GPU barrier — wait for all NRanks to write their variances.
+    // -----------------------------------------------------------------------
+    SyncComm<NRanks> comm(workspace);
+    Barrier<NRanks> barrier(rank, comm);
+    barrier.sync();
+    comm.update(comm.flag_value + 1);
+    // After update, all blocks on all ranks have arrived.
+
+    // -----------------------------------------------------------------------
+    // Phase 3: each rank independently reads all peers' packed variances and
+    //          sums them to get global_q_sumsq, global_k_sumsq.
+    // -----------------------------------------------------------------------
+    __shared__ float2 s_global_stats;
+    if (threadIdx.x == 0)
+    {
+        float global_q = 0.f, global_k = 0.f;
+        for (int r = 0; r < NRanks; ++r)
+        {
+            float2 peer = reinterpret_cast<float2 const*>(workspace[r])[token_idx];
+            global_q += peer.x;
+            global_k += peer.y;
+        }
+        s_global_stats = make_float2(global_q, global_k);
+    }
+    __syncthreads();
+
+    float global_q_sumsq = s_global_stats.x;
+    float global_k_sumsq = s_global_stats.y;
+
+    // -----------------------------------------------------------------------
+    // Phase 4: normalize Q and K using global stats.
+    // -----------------------------------------------------------------------
+    float global_q_count = static_cast<float>(local_q_dim * world_size);
+    float global_k_count = static_cast<float>(local_k_dim * world_size);
+    float rstd_q = rsqrtf(global_q_sumsq / global_q_count + eps);
+    float rstd_k = rsqrtf(global_k_sumsq / global_k_count + eps);
+
+    // Output rows are packed (stride = local_dim); input rows may be strided.
+    for (int i = threadIdx.x; i < local_q_dim; i += blockDim.x)
+    {
+        float v = static_cast<float>(q_in[token_idx * q_stride + i]);
+        q_out[token_idx * local_q_dim + i] = static_cast<DType>(v * rstd_q * weight_q[i]);
+    }
+    for (int i = threadIdx.x; i < local_k_dim; i += blockDim.x)
+    {
+        float v = static_cast<float>(k_in[token_idx * k_stride + i]);
+        k_out[token_idx * local_k_dim + i] = static_cast<DType>(v * rstd_k * weight_k[i]);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Launcher
+// ---------------------------------------------------------------------------
+
+template <int NRanks, typename DType>
+static void launchTyped(void* q_in, void* k_in, void* q_out, void* k_out, void* weight_q, void* weight_k,
+    void** workspace, int n_tokens, int local_q_dim, int local_k_dim, int q_stride, int k_stride, int world_size,
+    int rank, float eps, cudaStream_t stream)
+{
+    // Block size: cover max(local_q_dim, local_k_dim), rounded to warp, capped at 512.
+    int max_dim = (local_q_dim > local_k_dim) ? local_q_dim : local_k_dim;
+    int block_size = ((max_dim + 31) / 32) * 32;
+    if (block_size > 512)
+        block_size = 512;
+    if (block_size < 32)
+        block_size = 32;
+
+    // Grid: one block per token.
+    shardedQKNormKernel<NRanks, DType><<<n_tokens, block_size, 0, stream>>>(reinterpret_cast<DType const*>(q_in),
+        reinterpret_cast<DType const*>(k_in), reinterpret_cast<DType*>(q_out), reinterpret_cast<DType*>(k_out),
+        reinterpret_cast<float const*>(weight_q), reinterpret_cast<float const*>(weight_k), workspace, n_tokens,
+        local_q_dim, local_k_dim, q_stride, k_stride, world_size, rank, eps);
+}
+
+void launchShardedQKNormKernel(void* q_in, void* k_in, void* q_out, void* k_out, void* weight_q, void* weight_k,
+    void** workspace, int n_tokens, int local_q_dim, int local_k_dim, int q_stride, int k_stride, int world_size,
+    int rank, float eps, bool is_bf16, cudaStream_t stream)
+{
+    if (n_tokens > kBarrierFlagCount)
+    {
+        throw std::runtime_error("shardedQKNormKernel: n_tokens (" + std::to_string(n_tokens)
+            + ") exceeds kBarrierFlagCount (" + std::to_string(kBarrierFlagCount)
+            + "). Use NCCL-based sharded_rmsnorm for large batch sizes.");
+    }
+
+#define DISPATCH_RANKS_DTYPE(NRANKS, DTYPE)                                                                            \
+    launchTyped<NRANKS, DTYPE>(q_in, k_in, q_out, k_out, weight_q, weight_k, workspace, n_tokens, local_q_dim,         \
+        local_k_dim, q_stride, k_stride, world_size, rank, eps, stream)
+
+    if (is_bf16)
+    {
+        switch (world_size)
+        {
+        case 2: DISPATCH_RANKS_DTYPE(2, __nv_bfloat16); break;
+        case 4: DISPATCH_RANKS_DTYPE(4, __nv_bfloat16); break;
+        case 8: DISPATCH_RANKS_DTYPE(8, __nv_bfloat16); break;
+        default:
+            throw std::runtime_error(
+                "shardedQKNormKernel: unsupported world_size=" + std::to_string(world_size) + " for bf16");
+        }
+    }
+    else
+    {
+        switch (world_size)
+        {
+        case 2: DISPATCH_RANKS_DTYPE(2, half); break;
+        case 4: DISPATCH_RANKS_DTYPE(4, half); break;
+        case 8: DISPATCH_RANKS_DTYPE(8, half); break;
+        default:
+            throw std::runtime_error(
+                "shardedQKNormKernel: unsupported world_size=" + std::to_string(world_size) + " for fp16");
+        }
+    }
+
+#undef DISPATCH_RANKS_DTYPE
+}
+
+} // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/kernels/shardedQKNormKernel.h
+++ b/cpp/tensorrt_llm/kernels/shardedQKNormKernel.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace tensorrt_llm::kernels
+{
+
+/**
+ * Fused sharded QK RMSNorm using NVLink-based cross-GPU barrier.
+ *
+ * Normalizes Q and K (both column-sharded across tensor-parallel ranks) using a
+ * single NVLink barrier on packed [N_tokens, 2] variance scalars rather than two
+ * NCCL all-reduces. The barrier uses the SyncComm/Barrier infrastructure from
+ * allReduceFusionKernels.cu (st.global.release.sys / ld.global.acquire.sys).
+ *
+ * Workspace layout (from get_allreduce_workspace):
+ *   workspace[0..tp-1]      : comm buffers — we reuse the first tp entries to
+ *                             store packed float2 [q_sumsq, k_sumsq] per token
+ *   workspace[tp..2*tp-1]   : barrier_flags (one int per rank per block)
+ *   workspace[3*tp]         : flag buffer [counter, sync_flag, lamport_flag]
+ *
+ * @param q_in         Input Q tensor pointer (fp16 or bf16); row stride = q_stride elements
+ * @param k_in         Input K tensor pointer; row stride = k_stride elements
+ * @param q_out        Output Q tensor (packed, row stride = local_q_dim)
+ * @param k_out        Output K tensor (packed, row stride = local_k_dim)
+ * @param weight_q     RMSNorm weight for Q [local_q_dim] (float32)
+ * @param weight_k     RMSNorm weight for K [local_k_dim] (float32)
+ * @param workspace    Void** workspace pointer array from get_allreduce_workspace
+ * @param n_tokens     Number of tokens (rows) to process
+ * @param local_q_dim  Local head dimension for Q (= full_q_dim / world_size)
+ * @param local_k_dim  Local head dimension for K (= full_k_dim / world_size)
+ * @param q_stride     Row stride of q_in in elements (>= local_q_dim; e.g. = local_q_dim
+ *                     for packed Q, = fused_qkv_dim for a view into fused Q+K+V output).
+ *                     Must have last-dim-contiguous (element stride of 1).
+ * @param k_stride     Row stride of k_in in elements.
+ * @param world_size   Tensor parallel size (number of ranks)
+ * @param rank         This rank's index [0, world_size)
+ * @param eps          RMSNorm epsilon for numerical stability
+ * @param is_bf16      true for bfloat16, false for float16
+ * @param stream       CUDA stream
+ */
+void launchShardedQKNormKernel(void* q_in, void* k_in, void* q_out, void* k_out, void* weight_q, void* weight_k,
+    void** workspace, int n_tokens, int local_q_dim, int local_k_dim, int q_stride, int k_stride, int world_size,
+    int rank, float eps, bool is_bf16, cudaStream_t stream);
+
+} // namespace tensorrt_llm::kernels

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -116,7 +116,8 @@ add_library(
   dsv3RopeOp.cpp
   fusedGemmAllreduceOp.cpp
   convertReqIndexToGlobalOp.cpp
-  trtllmGenQKVProcessOp.cpp)
+  trtllmGenQKVProcessOp.cpp
+  shardedQKNormOp.cpp)
 set_property(TARGET th_common PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(
   th_common PRIVATE ${TORCH_LIBRARIES} th_utils ${Python3_LIBRARIES}

--- a/cpp/tensorrt_llm/thop/shardedQKNormOp.cpp
+++ b/cpp/tensorrt_llm/thop/shardedQKNormOp.cpp
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/kernels/shardedQKNormKernel.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+
+namespace tensorrt_llm::torch_ext
+{
+
+/**
+ * Fused sharded QK RMSNorm using NVLink-based cross-GPU barrier.
+ *
+ * @param q         Q tensor [..., local_q_dim] (fp16 or bf16)
+ * @param k         K tensor [..., local_k_dim] (fp16 or bf16)
+ * @param weight_q  RMSNorm weight for Q [local_q_dim] (must be float32)
+ * @param weight_k  RMSNorm weight for K [local_k_dim] (must be float32)
+ * @param q_out     Pre-allocated output for Q (same shape/dtype as q)
+ * @param k_out     Pre-allocated output for K (same shape/dtype as k)
+ * @param workspace LongTensor encoding void** workspace (from get_allreduce_workspace)
+ * @param eps       RMSNorm epsilon
+ * @param world_size Tensor parallel size
+ * @param rank      This rank's index
+ */
+void lamport_sharded_qk_rmsnorm(at::Tensor const& q, at::Tensor const& k, at::Tensor const& weight_q,
+    at::Tensor const& weight_k, at::Tensor& q_out, at::Tensor& k_out, at::Tensor const& workspace, double eps,
+    int64_t world_size, int64_t rank)
+{
+    TORCH_CHECK(q.is_cuda(), "q must be a CUDA tensor");
+    TORCH_CHECK(k.is_cuda(), "k must be a CUDA tensor");
+    TORCH_CHECK(q.scalar_type() == k.scalar_type(), "q and k must have the same dtype");
+    TORCH_CHECK(q.scalar_type() == at::ScalarType::Half || q.scalar_type() == at::ScalarType::BFloat16,
+        "q must be fp16 or bf16");
+    TORCH_CHECK(weight_q.scalar_type() == at::ScalarType::Float, "weight_q must be float32");
+    TORCH_CHECK(weight_k.scalar_type() == at::ScalarType::Float, "weight_k must be float32");
+    TORCH_CHECK(workspace.scalar_type() == at::ScalarType::Long, "workspace must be a LongTensor");
+
+    // Inputs may be strided views (e.g. slices of a fused Q+K+V GEMM output).
+    // Require the last dim to be contiguous (element stride 1); use row stride for the kernel.
+    TORCH_CHECK(q.dim() >= 2 && k.dim() >= 2, "q and k must be at least 2D");
+    TORCH_CHECK(q.stride(-1) == 1, "q must be contiguous along its last dim");
+    TORCH_CHECK(k.stride(-1) == 1, "k must be contiguous along its last dim");
+    TORCH_CHECK(q_out.is_contiguous(), "q_out must be contiguous");
+    TORCH_CHECK(k_out.is_contiguous(), "k_out must be contiguous");
+
+    // Flatten to [n_tokens, local_dim]
+    int64_t n_tokens = q.numel() / q.size(-1);
+    int64_t local_q_dim = q.size(-1);
+    int64_t local_k_dim = k.size(-1);
+    // Row stride in elements (handles both packed Q/K and fused-GEMM-slice inputs).
+    // For a 2D tensor with stride(-1) == 1, stride(-2) is the row stride in elements.
+    int64_t q_stride = (q.dim() >= 2) ? q.stride(-2) : local_q_dim;
+    int64_t k_stride = (k.dim() >= 2) ? k.stride(-2) : local_k_dim;
+
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    bool is_bf16 = (q.scalar_type() == at::ScalarType::BFloat16);
+
+    // The workspace tensor is a LongTensor whose data pointer IS the void** array
+    void** ws_ptr = reinterpret_cast<void**>(workspace.data_ptr());
+
+    tensorrt_llm::kernels::launchShardedQKNormKernel(q.data_ptr(), k.data_ptr(), q_out.data_ptr(), k_out.data_ptr(),
+        weight_q.data_ptr(), weight_k.data_ptr(), ws_ptr, static_cast<int>(n_tokens), static_cast<int>(local_q_dim),
+        static_cast<int>(local_k_dim), static_cast<int>(q_stride), static_cast<int>(k_stride),
+        static_cast<int>(world_size), static_cast<int>(rank), static_cast<float>(eps), is_bf16, stream);
+}
+
+} // namespace tensorrt_llm::torch_ext
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def(
+        "lamport_sharded_qk_rmsnorm("
+        "Tensor q,"
+        "Tensor k,"
+        "Tensor weight_q,"
+        "Tensor weight_k,"
+        "Tensor(a!) q_out,"
+        "Tensor(a!) k_out,"
+        "Tensor workspace,"
+        "float eps,"
+        "int world_size,"
+        "int rank) -> ()");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("lamport_sharded_qk_rmsnorm", &tensorrt_llm::torch_ext::lamport_sharded_qk_rmsnorm);
+}

--- a/examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml
+++ b/examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml
@@ -7,13 +7,13 @@ model_factory: AutoModelForCausalLM
 tokenizer: MiniMaxAI/MiniMax-M2.7
 attn_backend: trtllm
 compile_backend: torch-cudagraph
-world_size: 2
-max_seq_len: 2048
-max_num_tokens: 1024
-max_batch_size: 64
+world_size: 8
+max_seq_len: 17408
+max_num_tokens: 8192
+max_batch_size: 32
 enable_chunked_prefill: true
 cuda_graph_config:
-  max_batch_size: 64
+  batch_sizes: [1, 2, 4, 8, 16, 32]
 kv_cache_config:
   enable_block_reuse: false
   free_gpu_memory_fraction: 0.8

--- a/examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml
+++ b/examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml
@@ -19,7 +19,7 @@ cuda_graph_config:
 
 kv_cache_config:
   enable_block_reuse: true
-  free_gpu_memory_fraction: 0.90
+  free_gpu_memory_fraction: 0.80
   tokens_per_block: 32
 
 transforms:

--- a/examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml
+++ b/examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml
@@ -7,9 +7,9 @@ model_factory: AutoModelForCausalLM
 tokenizer: MiniMaxAI/MiniMax-M2.7
 attn_backend: trtllm
 compile_backend: torch-cudagraph
-world_size: 8
-max_seq_len: 17408
-max_num_tokens: 8192
+world_size: 2
+max_seq_len: 2304
+max_num_tokens: 2304
 max_batch_size: 32
 enable_chunked_prefill: true
 cuda_graph_config:
@@ -18,9 +18,14 @@ kv_cache_config:
   enable_block_reuse: false
   free_gpu_memory_fraction: 0.8
 transforms:
+  detect_sharding:
+    use_allgather_qk_norm: true
   fuse_trtllm_attn_quant_fp8:
     enabled: true
   fuse_rmsnorm_quant_fp8:
+    stage: post_load_fusion
+    enabled: true
+  fuse_rmsnorm_fp8_finegrained:
     stage: post_load_fusion
     enabled: true
   gather_logits_before_lm_head:
@@ -28,6 +33,6 @@ transforms:
   fuse_gemms:
     enabled: true
   multi_stream_moe:
-    enabled: true
+    enabled: false
   compile_model:
     piecewise_enabled: true

--- a/examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml
+++ b/examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml
@@ -7,13 +7,13 @@ model_factory: AutoModelForCausalLM
 tokenizer: MiniMaxAI/MiniMax-M2.7
 attn_backend: trtllm
 compile_backend: torch-cudagraph
-world_size: 8
-max_seq_len: 8192
-max_num_tokens: 8192
-max_batch_size: 8
+world_size: 2
+max_seq_len: 2048
+max_num_tokens: 1024
+max_batch_size: 64
 enable_chunked_prefill: true
 cuda_graph_config:
-  max_batch_size: 8
+  max_batch_size: 64
 kv_cache_config:
   enable_block_reuse: false
   free_gpu_memory_fraction: 0.8

--- a/examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml
+++ b/examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml
@@ -54,3 +54,7 @@ transforms:
     # use_allgather_qk_norm: true
     use_fused_qk_norm: true
     allreduce_strategy: SYMM_MEM
+    # TP-shard lm_head (column split + all_gather) — weight is BF16 and unsharded
+    # by default; dominates decode memory bandwidth. ~2x speedup on lm_head step.
+    shard_all_unprocessed: true
+    simple_shard_filter: "lm_head"

--- a/examples/auto_deploy/model_registry/configs/minimax_m2.7_tp2_fused_qknorm.yaml
+++ b/examples/auto_deploy/model_registry/configs/minimax_m2.7_tp2_fused_qknorm.yaml
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# MiniMax-M2.7 (256 experts, top-8, FP8 quantized) — standalone AD serving config.
-# 62 layers, GQA (48 Q / 8 KV heads), head_dim=128, partial RoPE.
+# MiniMax-M2.7 (256 experts, top-8, FP8 quantized) — TP=2 with fused Lamport QK-norm.
+# Uses lamport_sharded_qk_rmsnorm: one NVLink barrier on packed [N,2] variance scalars
+# instead of two separate NCCL allreduces (one for Q, one for K).
 model_factory: AutoModelForCausalLM
 tokenizer: MiniMaxAI/MiniMax-M2.7
 attn_backend: trtllm
@@ -11,16 +12,19 @@ world_size: 4
 
 max_seq_len: 2048
 max_num_tokens: 16384
-max_batch_size: 512
+max_batch_size: 32
 enable_chunked_prefill: true
 
 cuda_graph_config:
-  batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+  batch_sizes: [1, 2, 4, 8, 16, 32]
 
 kv_cache_config:
   enable_block_reuse: true
   free_gpu_memory_fraction: 0.90
   tokens_per_block: 32
+
+model_kwargs:
+  num_hidden_layers: 5
 
 transforms:
   fuse_trtllm_attn_quant_fp8:
@@ -35,6 +39,11 @@ transforms:
     stage: post_load_fusion
     enabled: true
   bypass_qk_split_for_lamport:
+    # Feeds narrow views of the fused Q+K+V GEMM output directly into the
+    # lamport_sharded_qk_rmsnorm op (whose body now runs the packed NCCL pre/post
+    # Triton path). The lamport CUDA kernel that used to cause a rank barrier
+    # imbalance here is disabled, so no rank-sync concern. Eliminates the Q and
+    # K .contiguous() copies from split_output (~5us/layer saved).
     stage: post_load_fusion
     enabled: true
   gather_logits_before_lm_head:
@@ -51,6 +60,5 @@ transforms:
   compile_model:
     piecewise_enabled: true
   detect_sharding:
-    # use_allgather_qk_norm: true
     use_fused_qk_norm: true
     allreduce_strategy: SYMM_MEM

--- a/examples/auto_deploy/model_registry/configs/minimax_m2.7_tp2_fused_qknorm.yaml
+++ b/examples/auto_deploy/model_registry/configs/minimax_m2.7_tp2_fused_qknorm.yaml
@@ -62,3 +62,8 @@ transforms:
   detect_sharding:
     use_fused_qk_norm: true
     allreduce_strategy: SYMM_MEM
+    # lm_head weight is BF16 and 1.23GB unsharded — dominates decode memory
+    # bandwidth. Column-shard by vocab dim + AllGather outputs → ~2x speedup
+    # (187us -> ~94us per decode step).
+    shard_all_unprocessed: true
+    simple_shard_filter: "lm_head"

--- a/examples/auto_deploy/model_registry/configs/minimax_m2.7_tp2_reduced.yaml
+++ b/examples/auto_deploy/model_registry/configs/minimax_m2.7_tp2_reduced.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# MiniMax-M2.7 reduced-layer config for AutoDeploy perf analysis.
+# Keeps TP/world_size at 2 while shrinking the model to a small layer count
+# so we can get faster baseline sweeps and profiling iterations.
+model_factory: AutoModelForCausalLM
+tokenizer: MiniMaxAI/MiniMax-M2.7
+attn_backend: trtllm
+compile_backend: torch-cudagraph
+world_size: 2
+max_seq_len: 4096
+max_num_tokens: 4096
+max_batch_size: 32
+enable_chunked_prefill: true
+cuda_graph_config:
+  batch_sizes: [1, 2, 4, 8, 16, 32]
+kv_cache_config:
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.8
+model_kwargs:
+  num_hidden_layers: 5
+transforms:
+  fuse_trtllm_attn_quant_fp8:
+    enabled: true
+  fuse_rmsnorm_quant_fp8:
+    stage: post_load_fusion
+    enabled: true
+  gather_logits_before_lm_head:
+    enabled: true
+  fuse_gemms:
+    enabled: true
+  multi_stream_moe:
+    enabled: false
+  compile_model:
+    piecewise_enabled: true

--- a/examples/auto_deploy/model_registry/configs/minimax_m2.7_tp2_reduced_allgather_qknorm.yaml
+++ b/examples/auto_deploy/model_registry/configs/minimax_m2.7_tp2_reduced_allgather_qknorm.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# MiniMax-M2.7 reduced-layer config: AllGather QK-norm experiment.
+# Derived from minimax_m2.7_tp2_reduced.yaml; adds use_allgather_qk_norm: true.
+#
+# Effect vs baseline (sharded_rmsnorm):
+#   - sharded_rmsnorm (AllReduce of scalar variance + unfused pow/sum/rsqrt) is DISABLED
+#   - QK norms instead use: AllGather(Q/K shard) → fused RMSNorm → Slice
+#   - Weight is NOT sharded; full norm weight remains on each rank
+#   - Eliminates: 10 pow + 10 reduce + 10 rsqrt kernel launches per decode iter
+#   - Replaces: 10 F32 AllReduces (128B each, ~13µs) with 10 AllGathers (~192KB Q, ~32KB K)
+model_factory: AutoModelForCausalLM
+tokenizer: MiniMaxAI/MiniMax-M2.7
+attn_backend: trtllm
+compile_backend: torch-cudagraph
+world_size: 2
+max_seq_len: 4096
+max_num_tokens: 4096
+max_batch_size: 32
+enable_chunked_prefill: true
+cuda_graph_config:
+  batch_sizes: [1, 2, 4, 8, 16, 32]
+kv_cache_config:
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.8
+model_kwargs:
+  num_hidden_layers: 5
+transforms:
+  detect_sharding:
+    use_allgather_qk_norm: true
+  fuse_trtllm_attn_quant_fp8:
+    enabled: true
+  fuse_rmsnorm_quant_fp8:
+    stage: post_load_fusion
+    enabled: true
+  gather_logits_before_lm_head:
+    enabled: true
+  fuse_gemms:
+    enabled: true
+  multi_stream_moe:
+    enabled: false
+  compile_model:
+    piecewise_enabled: true

--- a/examples/auto_deploy/model_registry/configs/minimax_m2.7_tp2_reduced_allgather_qknorm.yaml
+++ b/examples/auto_deploy/model_registry/configs/minimax_m2.7_tp2_reduced_allgather_qknorm.yaml
@@ -1,44 +1,52 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# MiniMax-M2.7 reduced-layer config: AllGather QK-norm experiment.
-# Derived from minimax_m2.7_tp2_reduced.yaml; adds use_allgather_qk_norm: true.
-#
-# Effect vs baseline (sharded_rmsnorm):
-#   - sharded_rmsnorm (AllReduce of scalar variance + unfused pow/sum/rsqrt) is DISABLED
-#   - QK norms instead use: AllGather(Q/K shard) → fused RMSNorm → Slice
-#   - Weight is NOT sharded; full norm weight remains on each rank
-#   - Eliminates: 10 pow + 10 reduce + 10 rsqrt kernel launches per decode iter
-#   - Replaces: 10 F32 AllReduces (128B each, ~13µs) with 10 AllGathers (~192KB Q, ~32KB K)
+# MiniMax-M2.7 (256 experts, top-8, FP8 quantized) — standalone AD serving config.
+# 62 layers, GQA (48 Q / 8 KV heads), head_dim=128, partial RoPE.
 model_factory: AutoModelForCausalLM
 tokenizer: MiniMaxAI/MiniMax-M2.7
 attn_backend: trtllm
 compile_backend: torch-cudagraph
-world_size: 2
-max_seq_len: 4096
-max_num_tokens: 4096
+world_size: 4
+
+max_seq_len: 2048
+max_num_tokens: 16384
 max_batch_size: 32
 enable_chunked_prefill: true
+
 cuda_graph_config:
   batch_sizes: [1, 2, 4, 8, 16, 32]
+
 kv_cache_config:
-  enable_block_reuse: false
-  free_gpu_memory_fraction: 0.8
+  enable_block_reuse: true
+  free_gpu_memory_fraction: 0.90
+  tokens_per_block: 32
+
 model_kwargs:
   num_hidden_layers: 5
+
 transforms:
-  detect_sharding:
-    use_allgather_qk_norm: true
   fuse_trtllm_attn_quant_fp8:
     enabled: true
   fuse_rmsnorm_quant_fp8:
+    stage: post_load_fusion
+    enabled: true
+  fuse_rmsnorm_fp8_finegrained:
     stage: post_load_fusion
     enabled: true
   gather_logits_before_lm_head:
     enabled: true
   fuse_gemms:
     enabled: true
+  fuse_gemms_mixed_children:
+    enabled: true
   multi_stream_moe:
     enabled: false
+  multi_stream_gemm:
+    stage: compile
+    enabled: true
   compile_model:
     piecewise_enabled: true
+  detect_sharding:
+    use_allgather_qk_norm: true
+    allreduce_strategy: SYMM_MEM

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -238,6 +238,12 @@ transforms:
     enabled: false
   optimize_rope:
     stage: post_load_fusion
+  bypass_qk_split_for_lamport:
+    stage: post_load_fusion
+    enabled: false
+  fuse_fp8_prequant_shared:
+    stage: post_load_fusion
+    enabled: false
   ############################################################################################
   # VISUALIZE GRAPH
   ############################################################################################

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/moe_ep_mask.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/moe_ep_mask.py
@@ -94,8 +94,22 @@ def _moe_ep_mask_impl(
     top_k = shape[-1]
     M = selected_experts.numel() // top_k
 
-    local_indices = torch.empty_like(selected_experts)
-    masked_weights = torch.empty_like(top_k_weights)
+    # Always allocate contiguous outputs (memory_format=contiguous_format explicitly)
+    # so downstream consumers (e.g. fp8_block_scale_moe_runner which requires int32
+    # contiguous selected_experts and contiguous weights) can skip defensive
+    # .contiguous() calls. This is a load-bearing guarantee — do not relax it.
+    local_indices = torch.empty(
+        shape,
+        dtype=selected_experts.dtype,
+        device=selected_experts.device,
+        memory_format=torch.contiguous_format,
+    )
+    masked_weights = torch.empty(
+        shape,
+        dtype=top_k_weights.dtype,
+        device=top_k_weights.device,
+        memory_format=torch.contiguous_format,
+    )
 
     BLOCK_M = 128 if M >= 128 else triton.next_power_of_2(max(1, M))
     grid = (triton.cdiv(M, BLOCK_M),)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/moe_ep_mask.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/moe_ep_mask.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""Fused EP-sharding mask for MoE top-k routing output.
+
+Replaces the 5 elementwise aten ops the sharding transform inserts between
+`noaux_tc_op` (or topk fallback) and the fused MoE op:
+
+    sub       = selected_experts - (ep_rank * experts_per_rank)
+    floordiv  = selected_experts // experts_per_rank
+    rank_mask = floordiv == ep_rank      # or `>=` for the last rank
+    bool_cast = rank_mask.to(weights.dtype)
+    masked    = top_k_weights * bool_cast
+
+with a single Triton kernel that writes both `local_indices` and
+`masked_weights` in one pass. All inputs/outputs are small `[M, top_k]`
+tensors, so the win is eliminating per-op launch / host-dispatch cost, not
+arithmetic work.
+"""
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+from torch import Tensor
+
+
+@triton.jit
+def _moe_ep_mask_kernel(
+    indices_ptr,  # [M, TOP_K] int
+    weights_ptr,  # [M, TOP_K] bf16 or fp16 or fp32
+    local_indices_ptr,  # [M, TOP_K] int
+    masked_weights_ptr,  # [M, TOP_K] bf16 or fp16 or fp32
+    M,
+    ep_rank,
+    experts_per_rank,
+    lower_bound,  # ep_rank * experts_per_rank (precomputed)
+    TOP_K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    IS_LAST_RANK: tl.constexpr,
+):
+    """One program covers BLOCK_M rows; each row has TOP_K entries.
+
+    For each (row, k):
+        local_idx = idx - lower_bound
+        group = idx // experts_per_rank
+        owned = (group >= ep_rank) if IS_LAST_RANK else (group == ep_rank)
+        masked = weight if owned else 0
+    """
+    pid = tl.program_id(0)
+    offs_m = pid * BLOCK_M + tl.arange(0, BLOCK_M)
+    m_mask = offs_m < M
+
+    offs_k = tl.arange(0, TOP_K)
+    # 2D indexing: [BLOCK_M, TOP_K]
+    ptrs = offs_m[:, None] * TOP_K + offs_k[None, :]
+    load_mask = m_mask[:, None]
+
+    idx = tl.load(indices_ptr + ptrs, mask=load_mask, other=0)
+    w = tl.load(weights_ptr + ptrs, mask=load_mask, other=0.0)
+
+    local_idx = idx - lower_bound
+    group = idx // experts_per_rank
+    if IS_LAST_RANK:
+        owned = group >= ep_rank
+    else:
+        owned = group == ep_rank
+
+    # Mask weights by multiplying with the bool (promoted through where to keep dtype).
+    masked = tl.where(owned, w, tl.zeros_like(w))
+
+    tl.store(local_indices_ptr + ptrs, local_idx, mask=load_mask)
+    tl.store(masked_weights_ptr + ptrs, masked, mask=load_mask)
+
+
+def _moe_ep_mask_impl(
+    selected_experts: Tensor,
+    top_k_weights: Tensor,
+    ep_rank: int,
+    ep_size: int,
+    experts_per_rank: int,
+) -> Tuple[Tensor, Tensor]:
+    assert selected_experts.shape == top_k_weights.shape
+    assert selected_experts.is_contiguous() and top_k_weights.is_contiguous()
+
+    shape = selected_experts.shape
+    top_k = shape[-1]
+    M = selected_experts.numel() // top_k
+
+    local_indices = torch.empty_like(selected_experts)
+    masked_weights = torch.empty_like(top_k_weights)
+
+    BLOCK_M = 128 if M >= 128 else triton.next_power_of_2(max(1, M))
+    grid = (triton.cdiv(M, BLOCK_M),)
+    _moe_ep_mask_kernel[grid](
+        selected_experts,
+        top_k_weights,
+        local_indices,
+        masked_weights,
+        M,
+        ep_rank,
+        experts_per_rank,
+        ep_rank * experts_per_rank,
+        TOP_K=top_k,
+        BLOCK_M=BLOCK_M,
+        IS_LAST_RANK=(ep_rank == ep_size - 1),
+    )
+    return local_indices, masked_weights
+
+
+@torch.library.custom_op("auto_deploy::moe_ep_mask", mutates_args=())
+def moe_ep_mask(
+    selected_experts: Tensor,
+    top_k_weights: Tensor,
+    ep_rank: int,
+    ep_size: int,
+    experts_per_rank: int,
+) -> Tuple[Tensor, Tensor]:
+    """Fused EP-sharding mask for top-k routing outputs.
+
+    Args:
+        selected_experts: [..., top_k] integer expert indices in GLOBAL coords.
+        top_k_weights:    [..., top_k] per-token routing weights.
+        ep_rank:          Expert-parallel rank (0..ep_size-1).
+        ep_size:          Expert-parallel size.
+        experts_per_rank: Number of experts owned by each rank.
+
+    Returns:
+        local_indices:   [..., top_k] indices in LOCAL coords (global - lower_bound).
+        masked_weights:  [..., top_k] weights with remote-rank entries zeroed.
+    """
+    return _moe_ep_mask_impl(selected_experts, top_k_weights, ep_rank, ep_size, experts_per_rank)
+
+
+@moe_ep_mask.register_fake
+def _moe_ep_mask_fake(
+    selected_experts: Tensor,
+    top_k_weights: Tensor,
+    ep_rank: int,
+    ep_size: int,
+    experts_per_rank: int,
+) -> Tuple[Tensor, Tensor]:
+    return torch.empty_like(selected_experts), torch.empty_like(top_k_weights)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -926,6 +926,111 @@ def trtllm_quant_finegrained_fp8_moe_fused_fake(
     return torch.empty_like(x)
 
 
+@torch.library.custom_op(
+    "auto_deploy::trtllm_quant_finegrained_fp8_moe_fused_prequant", mutates_args=()
+)
+def trtllm_quant_finegrained_fp8_moe_fused_prequant(
+    x_fp8: torch.Tensor,  # [..., H] float8_e4m3fn — pre-quantized
+    x_sf: torch.Tensor,  # [H//128, M] float32 — per-1x128-block activation scales
+    x_shape_hint: torch.Tensor,  # [..., H] BF16 — only used for output shape + dtype
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    fc1_expert_weights: torch.Tensor,
+    fc2_expert_weights: torch.Tensor,
+    fc1_weight_scale: torch.Tensor,
+    fc2_weight_scale: torch.Tensor,
+    is_gated_mlp: bool = True,
+    act_fn: int = int(ActivationType.Silu),
+    mapping_config: str = "",
+    max_num_tokens: int = 0,
+    apply_routing_on_input: bool = False,
+) -> torch.Tensor:
+    """Pre-quantized variant of trtllm_quant_finegrained_fp8_moe_fused.
+
+    Skips the internal fp8_quantize_1x128(x) call — caller passes pre-computed
+    (x_fp8, x_sf). Only valid on the Blackwell EP all-reduce path where the
+    underlying fp8_block_scale_moe_runner accepts FP8+scale inputs natively.
+
+    x_shape_hint carries the target output shape + dtype (typically the original
+    BF16 tensor before quantization).
+    """
+    _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
+    act_fn = _normalize_trtllm_act_fn(act_fn)
+    mapping, enable_alltoall = _check_moe_alltoall(mapping_config, max_num_tokens)
+
+    assert not enable_alltoall, (
+        "prequant variant is Blackwell EP-all-reduce path only; all-to-all "
+        "path still owns its own quantization."
+    )
+    assert is_sm_100f(), "prequant variant requires SM100+ (Blackwell)."
+    assert is_gated_mlp, (
+        "fp8_block_scale_moe_runner supports gated MLP (SwiGlu) only on the EP all-reduce path."
+    )
+
+    x_shape = x_shape_hint.shape
+    hidden = x_shape[-1]
+
+    selected_experts = selected_experts.int().contiguous()
+    routing_weights = routing_weights.to(torch.float32).contiguous()
+    routing_weights_bf16 = routing_weights.to(torch.bfloat16).contiguous()
+
+    num_experts = fc1_expert_weights.shape[0]
+    top_k = selected_experts.shape[-1]
+    intermediate_size = (
+        fc1_expert_weights.shape[1] // 2 if is_gated_mlp else fc1_expert_weights.shape[1]
+    )
+    fc1_weight_scale_f32 = fc1_weight_scale.to(torch.float32).contiguous()
+    fc2_weight_scale_f32 = fc2_weight_scale.to(torch.float32).contiguous()
+
+    # Ensure FP8 input is reshaped to [M, H] for the C++ runner
+    x_fp8_2d = x_fp8.reshape(-1, hidden)
+
+    output = torch.ops.trtllm.fp8_block_scale_moe_runner(
+        None,  # routing_logits
+        None,  # routing_bias
+        x_fp8_2d,
+        x_sf,
+        fc1_expert_weights.contiguous(),
+        fc1_weight_scale_f32,
+        fc2_expert_weights.contiguous(),
+        fc2_weight_scale_f32,
+        num_experts,
+        top_k,
+        None,  # n_group
+        None,  # topk_group
+        intermediate_size,
+        0,  # local_expert_offset
+        num_experts,  # local_num_experts
+        None,  # routed_scaling_factor
+        RoutingMethodType.Renormalize,
+        topk_weights=routing_weights_bf16,
+        topk_ids=selected_experts,
+    )
+
+    return output.view(x_shape).to(x_shape_hint.dtype)
+
+
+@trtllm_quant_finegrained_fp8_moe_fused_prequant.register_fake
+def _trtllm_quant_finegrained_fp8_moe_fused_prequant_fake(
+    x_fp8: torch.Tensor,
+    x_sf: torch.Tensor,
+    x_shape_hint: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    fc1_expert_weights: torch.Tensor,
+    fc2_expert_weights: torch.Tensor,
+    fc1_weight_scale: torch.Tensor,
+    fc2_weight_scale: torch.Tensor,
+    is_gated_mlp: bool = True,
+    act_fn: int = int(ActivationType.Silu),
+    mapping_config: str = "",
+    max_num_tokens: int = 0,
+    apply_routing_on_input: bool = False,
+) -> torch.Tensor:
+    _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
+    return torch.empty_like(x_shape_hint)
+
+
 @torch.library.custom_op("auto_deploy::trtllm_nvfp4_trtllm_gen_moe_fused", mutates_args=())
 def trtllm_nvfp4_trtllm_gen_moe_fused(
     x: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -970,17 +970,32 @@ def trtllm_quant_finegrained_fp8_moe_fused_prequant(
     x_shape = x_shape_hint.shape
     hidden = x_shape[-1]
 
-    selected_experts = selected_experts.int().contiguous()
-    routing_weights = routing_weights.to(torch.float32).contiguous()
-    routing_weights_bf16 = routing_weights.to(torch.bfloat16).contiguous()
+    # Avoid per-call kernel launches when dtypes/layout already match expectations.
+    # The Blackwell runner needs int32 selected_experts, bf16 topk_weights, and
+    # fp32 weight scales. Our graph already produces int32 selected_experts and
+    # bf16 routing_weights (from moe_ep_mask + noaux_tc_op); the fp32 weight-scale
+    # cast is a wasted per-call kernel on static weights — pre-cast them at model
+    # load time (see FuseFineGrainedFP8Moe) so it's a no-op here.
+    if selected_experts.dtype != torch.int32 or not selected_experts.is_contiguous():
+        selected_experts = selected_experts.int().contiguous()
+    if routing_weights.dtype != torch.bfloat16 or not routing_weights.is_contiguous():
+        routing_weights_bf16 = routing_weights.to(torch.bfloat16).contiguous()
+    else:
+        routing_weights_bf16 = routing_weights
 
     num_experts = fc1_expert_weights.shape[0]
     top_k = selected_experts.shape[-1]
     intermediate_size = (
         fc1_expert_weights.shape[1] // 2 if is_gated_mlp else fc1_expert_weights.shape[1]
     )
-    fc1_weight_scale_f32 = fc1_weight_scale.to(torch.float32).contiguous()
-    fc2_weight_scale_f32 = fc2_weight_scale.to(torch.float32).contiguous()
+    if fc1_weight_scale.dtype != torch.float32 or not fc1_weight_scale.is_contiguous():
+        fc1_weight_scale_f32 = fc1_weight_scale.to(torch.float32).contiguous()
+    else:
+        fc1_weight_scale_f32 = fc1_weight_scale
+    if fc2_weight_scale.dtype != torch.float32 or not fc2_weight_scale.is_contiguous():
+        fc2_weight_scale_f32 = fc2_weight_scale.to(torch.float32).contiguous()
+    else:
+        fc2_weight_scale_f32 = fc2_weight_scale
 
     # Ensure FP8 input is reshaped to [M, H] for the C++ runner
     x_fp8_2d = x_fp8.reshape(-1, hidden)
@@ -990,9 +1005,9 @@ def trtllm_quant_finegrained_fp8_moe_fused_prequant(
         None,  # routing_bias
         x_fp8_2d,
         x_sf,
-        fc1_expert_weights.contiguous(),
+        fc1_expert_weights,
         fc1_weight_scale_f32,
-        fc2_expert_weights.contiguous(),
+        fc2_expert_weights,
         fc2_weight_scale_f32,
         num_experts,
         top_k,
@@ -1007,6 +1022,8 @@ def trtllm_quant_finegrained_fp8_moe_fused_prequant(
         topk_ids=selected_experts,
     )
 
+    if output.dtype == x_shape_hint.dtype:
+        return output.view(x_shape)
     return output.view(x_shape).to(x_shape_hint.dtype)
 
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "rms_norm",
     "triton_rms_norm",
     "triton_fused_add_rms_norm_quant_fp8",
+    "rms_norm_fp8_1x128",
     "l2norm",
     "flashinfer_fused_add_rms_norm",
 ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "triton_rms_norm",
     "triton_fused_add_rms_norm_quant_fp8",
     "rms_norm_fp8_1x128",
+    "qk_norm_packed",
     "l2norm",
     "flashinfer_fused_add_rms_norm",
 ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/qk_norm_packed.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/qk_norm_packed.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""Packed QK RMSNorm pre/post AllReduce Triton kernels.
+
+Used as the prefill fallback for lamport_sharded_qk_rmsnorm when n_tokens exceeds
+the lamport barrier-flag capacity (256). Algorithm mirrors the lamport kernel's
+internal structure but replaces the NVLink barrier with a small NCCL AllReduce:
+
+    packed = qk_rms_sum_sq_pack(q, k)            # 1 Triton kernel: pre-reduce
+    dist.all_reduce(packed, op=SUM)              # 1 NCCL kernel:  small F32 payload
+    q_out, k_out = qk_rms_norm_from_packed(
+        q, k, packed, w_q, w_k, eps, ws_q, ws_k) # 1 Triton kernel: post-reduce
+
+Total 3 kernels per Q/K-norm call regardless of batch size, vs ~18 if
+sharded_rmsnorm is invoked twice.
+"""
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+from torch import Tensor
+
+
+# ---------------------------------------------------------------------------
+# Pre-reduce: compute per-token packed (sum(Q^2), sum(K^2)) in fp32.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _qk_rms_sum_sq_pack_kernel(
+    q_ptr,
+    k_ptr,
+    packed_ptr,
+    d_q,
+    d_k,
+    q_row_stride,
+    k_row_stride,
+    BLOCK_Q: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """One program per token; accumulates sum-of-squares for Q row and K row."""
+    row = tl.program_id(0)
+
+    # Q sum of squares.
+    offs_q = tl.arange(0, BLOCK_Q)
+    mask_q = offs_q < d_q
+    q = tl.load(q_ptr + row * q_row_stride + offs_q, mask=mask_q, other=0.0).to(tl.float32)
+    q_sumsq = tl.sum(q * q, axis=0)
+
+    # K sum of squares.
+    offs_k = tl.arange(0, BLOCK_K)
+    mask_k = offs_k < d_k
+    k = tl.load(k_ptr + row * k_row_stride + offs_k, mask=mask_k, other=0.0).to(tl.float32)
+    k_sumsq = tl.sum(k * k, axis=0)
+
+    # Write packed [row, 0] = q_sumsq, [row, 1] = k_sumsq (stride 2 along row dim).
+    tl.store(packed_ptr + row * 2 + 0, q_sumsq)
+    tl.store(packed_ptr + row * 2 + 1, k_sumsq)
+
+
+def _next_pow2(x: int) -> int:
+    # Triton BLOCK_SIZE must be a power of two.
+    return 1 << (x - 1).bit_length()
+
+
+def _qk_rms_sum_sq_pack_impl(q: Tensor, k: Tensor) -> Tensor:
+    assert q.shape[:-1] == k.shape[:-1], "q and k must share leading dims"
+    assert q.stride(-1) == 1 and k.stride(-1) == 1, "q/k must be last-dim-contiguous"
+
+    d_q = q.shape[-1]
+    d_k = k.shape[-1]
+    n_tokens = q.numel() // d_q
+    q_row_stride = q.stride(-2) if q.dim() >= 2 else d_q
+    k_row_stride = k.stride(-2) if k.dim() >= 2 else d_k
+
+    packed = torch.empty(n_tokens, 2, dtype=torch.float32, device=q.device)
+    BLOCK_Q = _next_pow2(d_q)
+    BLOCK_K = _next_pow2(d_k)
+    _qk_rms_sum_sq_pack_kernel[(n_tokens,)](
+        q,
+        k,
+        packed,
+        d_q,
+        d_k,
+        q_row_stride,
+        k_row_stride,
+        BLOCK_Q=BLOCK_Q,
+        BLOCK_K=BLOCK_K,
+    )
+    return packed
+
+
+@torch.library.custom_op("auto_deploy::qk_rms_sum_sq_pack", mutates_args=())
+def qk_rms_sum_sq_pack(q: Tensor, k: Tensor) -> Tensor:
+    """Per-token packed sum-of-squares for Q and K.
+
+    Returns packed[n_tokens, 2] float32 where:
+        packed[i, 0] = sum(q[i, :] ** 2)
+        packed[i, 1] = sum(k[i, :] ** 2)
+
+    Call dist.all_reduce(packed) before feeding to qk_rms_norm_from_packed.
+    """
+    return _qk_rms_sum_sq_pack_impl(q, k)
+
+
+@qk_rms_sum_sq_pack.register_fake
+def _qk_rms_sum_sq_pack_fake(q: Tensor, k: Tensor) -> Tensor:
+    n_tokens = q.numel() // q.shape[-1]
+    return torch.empty(n_tokens, 2, dtype=torch.float32, device=q.device)
+
+
+# ---------------------------------------------------------------------------
+# Post-reduce: normalize Q and K using the AllReduced packed variance.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _qk_rms_norm_from_packed_kernel(
+    q_ptr,
+    k_ptr,
+    packed_ptr,
+    w_q_ptr,
+    w_k_ptr,
+    q_out_ptr,
+    k_out_ptr,
+    d_q,
+    d_k,
+    q_row_stride,
+    k_row_stride,
+    q_out_row_stride,
+    k_out_row_stride,
+    eps,
+    inv_global_count_q,  # 1 / (d_q * world_size)
+    inv_global_count_k,  # 1 / (d_k * world_size)
+    BLOCK_Q: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    row = tl.program_id(0)
+
+    q_sumsq = tl.load(packed_ptr + row * 2 + 0)
+    k_sumsq = tl.load(packed_ptr + row * 2 + 1)
+    rstd_q = tl.rsqrt(q_sumsq * inv_global_count_q + eps)
+    rstd_k = tl.rsqrt(k_sumsq * inv_global_count_k + eps)
+
+    # Normalize and scale Q.
+    offs_q = tl.arange(0, BLOCK_Q)
+    mask_q = offs_q < d_q
+    q = tl.load(q_ptr + row * q_row_stride + offs_q, mask=mask_q, other=0.0).to(tl.float32)
+    w_q = tl.load(w_q_ptr + offs_q, mask=mask_q, other=0.0).to(tl.float32)
+    q_out = q * rstd_q * w_q
+    tl.store(
+        q_out_ptr + row * q_out_row_stride + offs_q,
+        q_out.to(q_out_ptr.dtype.element_ty),
+        mask=mask_q,
+    )
+
+    # Normalize and scale K.
+    offs_k = tl.arange(0, BLOCK_K)
+    mask_k = offs_k < d_k
+    k = tl.load(k_ptr + row * k_row_stride + offs_k, mask=mask_k, other=0.0).to(tl.float32)
+    w_k = tl.load(w_k_ptr + offs_k, mask=mask_k, other=0.0).to(tl.float32)
+    k_out = k * rstd_k * w_k
+    tl.store(
+        k_out_ptr + row * k_out_row_stride + offs_k,
+        k_out.to(k_out_ptr.dtype.element_ty),
+        mask=mask_k,
+    )
+
+
+def _qk_rms_norm_from_packed_impl(
+    q: Tensor,
+    k: Tensor,
+    packed: Tensor,
+    w_q: Tensor,
+    w_k: Tensor,
+    eps: float,
+    world_size: int,
+) -> Tuple[Tensor, Tensor]:
+    assert q.stride(-1) == 1 and k.stride(-1) == 1, "q/k must be last-dim-contiguous"
+    assert packed.dtype == torch.float32, "packed must be float32"
+    assert w_q.dtype == torch.float32 and w_k.dtype == torch.float32, "weights must be fp32"
+
+    d_q = q.shape[-1]
+    d_k = k.shape[-1]
+    n_tokens = q.numel() // d_q
+    q_row_stride = q.stride(-2) if q.dim() >= 2 else d_q
+    k_row_stride = k.stride(-2) if k.dim() >= 2 else d_k
+
+    q_out = torch.empty(q.shape, dtype=q.dtype, device=q.device)
+    k_out = torch.empty(k.shape, dtype=k.dtype, device=k.device)
+    q_out_row_stride = q_out.stride(-2) if q_out.dim() >= 2 else d_q
+    k_out_row_stride = k_out.stride(-2) if k_out.dim() >= 2 else d_k
+
+    BLOCK_Q = _next_pow2(d_q)
+    BLOCK_K = _next_pow2(d_k)
+    inv_count_q = 1.0 / (d_q * world_size)
+    inv_count_k = 1.0 / (d_k * world_size)
+    _qk_rms_norm_from_packed_kernel[(n_tokens,)](
+        q,
+        k,
+        packed,
+        w_q,
+        w_k,
+        q_out,
+        k_out,
+        d_q,
+        d_k,
+        q_row_stride,
+        k_row_stride,
+        q_out_row_stride,
+        k_out_row_stride,
+        float(eps),
+        float(inv_count_q),
+        float(inv_count_k),
+        BLOCK_Q=BLOCK_Q,
+        BLOCK_K=BLOCK_K,
+    )
+    return q_out, k_out
+
+
+@torch.library.custom_op("auto_deploy::qk_rms_norm_from_packed", mutates_args=())
+def qk_rms_norm_from_packed(
+    q: Tensor,
+    k: Tensor,
+    packed: Tensor,
+    w_q: Tensor,
+    w_k: Tensor,
+    eps: float,
+    world_size: int,
+) -> Tuple[Tensor, Tensor]:
+    """Normalize Q and K using AllReduced packed variance.
+
+    Args:
+        q, k: local shards, last-dim-contiguous (bf16 or fp16).
+        packed: [n_tokens, 2] fp32 AllReduced sum-of-squares.
+        w_q, w_k: RMSNorm weights, fp32, local shard.
+        eps: RMSNorm epsilon.
+        world_size: tensor-parallel world size (for global element count).
+
+    Returns (q_out, k_out) packed contiguous tensors, same dtype as inputs.
+    """
+    return _qk_rms_norm_from_packed_impl(q, k, packed, w_q, w_k, eps, world_size)
+
+
+@qk_rms_norm_from_packed.register_fake
+def _qk_rms_norm_from_packed_fake(
+    q: Tensor,
+    k: Tensor,
+    packed: Tensor,
+    w_q: Tensor,
+    w_k: Tensor,
+    eps: float,
+    world_size: int,
+) -> Tuple[Tensor, Tensor]:
+    return torch.empty_like(q), torch.empty_like(k)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/rms_norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/rms_norm.py
@@ -15,6 +15,8 @@
 
 """Custom operator for FlashInfer and Triton RMSNorm implementation."""
 
+from typing import Tuple
+
 import flashinfer
 import torch
 import torch.distributed as dist
@@ -35,6 +37,7 @@ try:
 except (ModuleNotFoundError, ImportError):
     _layer_norm_fwd = None
 from .triton_rms_norm import rms_norm
+from .triton_sharded_qk_norm import triton_fused_sharded_qk_norm
 
 
 @torch.library.custom_op("auto_deploy::flashinfer_rms_norm", mutates_args=())
@@ -351,3 +354,114 @@ def sharded_rmsnorm(
 def _(input: torch.Tensor, weight: torch.Tensor, eps: float, world_size: int) -> torch.Tensor:
     """Fake implementation for tracing."""
     return torch.empty_like(input)
+
+
+@torch.library.custom_op("auto_deploy::fused_sharded_qk_rmsnorm", mutates_args=())
+def fused_sharded_qk_rmsnorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    world_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fused sharded QK RMSNorm with packed variance allreduce.
+
+    Normalizes Q and K (both sharded along head dim) using a single allreduce
+    on packed variance scalars instead of two separate allreduces.
+    """
+    return triton_fused_sharded_qk_norm(q, k, weight_q, weight_k, eps, world_size)
+
+
+@fused_sharded_qk_rmsnorm.register_fake
+def _(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    world_size: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fake implementation for tracing."""
+    return torch.empty_like(q), torch.empty_like(k)
+
+
+@torch.library.custom_op("auto_deploy::lamport_sharded_qk_rmsnorm", mutates_args=())
+def lamport_sharded_qk_rmsnorm(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    world_size: int,
+    rank: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fused QK RMSNorm using NVLink cross-GPU barrier on packed variance scalars.
+
+    Normalizes Q and K (both column-sharded across tensor-parallel ranks) using a
+    single NVLink barrier on packed [N_tokens, 2] float32 variance scalars via
+    the SyncComm/Barrier infrastructure (st.global.release.sys / ld.global.acquire.sys).
+    This avoids NCCL entirely and reduces collective overhead to a single barrier
+    round-trip over NVLink.
+
+    Args:
+        q: Local Q shard [..., local_q_dim] (fp16 or bf16).
+        k: Local K shard [..., local_k_dim] (fp16 or bf16).
+        weight_q: RMSNorm weight for Q [local_q_dim] (float32).
+        weight_k: RMSNorm weight for K [local_k_dim] (float32).
+        eps: Small constant for numerical stability.
+        world_size: Tensor parallel size.
+        rank: This rank's index.
+
+    Returns:
+        Tuple of (q_norm, k_norm) with same shapes and dtypes as q and k.
+    """
+    # Preconditions (enforced by the sharding transform):
+    #   - Weights are fp32 (pre-cast at weight-load time in FusedQKNormShardingInfo).
+    #
+    # Always uses the packed pre + NCCL AR + post flow (3 Triton + 1 NCCL kernel
+    # per call, captured per piecewise bucket — no runtime Python branch). Works
+    # at any n_tokens and has no rank-barrier dependency.
+    #
+    # NOTE: the lamport CUDA path (trtllm.lamport_sharded_qk_rmsnorm) exists but is
+    # commented out below — it shows a severe e2e regression (80 → 25 tok/s on
+    # MiniMax M2.7 TP=2) that is not yet root-caused. Re-enable only after the
+    # regression is understood (likely a rank-barrier scheduling issue, not the
+    # kernel itself).
+    #
+    # Lamport CUDA path (disabled):
+    # _LAMPORT_MAX_TOKENS = 256
+    # n_tokens = q.numel() // q.shape[-1]
+    # if n_tokens <= _LAMPORT_MAX_TOKENS:
+    #     from tensorrt_llm._torch.distributed.ops import get_allreduce_workspace
+    #     from tensorrt_llm.mapping import Mapping
+    #
+    #     mapping = Mapping(world_size=world_size, rank=rank, tp_size=world_size)
+    #     workspace = get_allreduce_workspace(mapping)
+    #     q_out = torch.empty(q.shape, dtype=q.dtype, device=q.device)
+    #     k_out = torch.empty(k.shape, dtype=k.dtype, device=k.device)
+    #     torch.ops.trtllm.lamport_sharded_qk_rmsnorm(
+    #         q, k, weight_q, weight_k, q_out, k_out, workspace,
+    #         float(eps), world_size, rank,
+    #     )
+    #     return q_out, k_out
+
+    packed = torch.ops.auto_deploy.qk_rms_sum_sq_pack(q, k)
+    dist.all_reduce(packed, op=dist.ReduceOp.SUM)
+    return torch.ops.auto_deploy.qk_rms_norm_from_packed(
+        q, k, packed, weight_q, weight_k, float(eps), world_size
+    )
+
+
+@lamport_sharded_qk_rmsnorm.register_fake
+def _(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    weight_q: torch.Tensor,
+    weight_k: torch.Tensor,
+    eps: float,
+    world_size: int,
+    rank: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Fake implementation for tracing."""
+    return torch.empty_like(q), torch.empty_like(k)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/rms_norm_fp8_1x128.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/rms_norm_fp8_1x128.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fused RMSNorm + per-1x128-block FP8 quantization Triton kernel.
+
+Designed to feed trtllm_finegrained_fp8_linear_prequant, eliminating the
+direct_copy + scale_1x128_kernel overhead that trtllm_finegrained_fp8_linear
+pays internally when it quantizes its BF16 input on-the-fly.
+"""
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+from torch import Tensor
+
+_FP8_MAX = float(torch.finfo(torch.float8_e4m3fn).max)  # 448.0
+
+
+@triton.jit
+def _rms_norm_fp8_1x128_kernel(
+    x_ptr,
+    w_ptr,
+    bf16_out_ptr,
+    fp8_out_ptr,
+    sf_out_ptr,
+    M,
+    K,
+    eps: tl.constexpr,
+    N_QUANT: tl.constexpr,  # K // 128 (K must be divisible by 128)
+):
+    """Fused RMSNorm + per-128-element FP8 block quantization.
+
+    Grid: (M,) — one program per token row.
+
+    Two-pass over N_QUANT blocks of 128 elements per row:
+      Pass 1: accumulate sum-of-squares for RMSNorm variance.
+      Pass 2: apply norm, store BF16, compute per-block scale, quantize to FP8.
+
+    Scale output layout matches fp8_quantize_1x128: [N_QUANT, M] float32,
+    where sf[blk, row] = max(|norm[row, blk*128:(blk+1)*128]|) / FP8_MAX.
+    """
+    row = tl.program_id(0)
+    blk_offsets = tl.arange(0, 128)
+
+    # Pass 1: accumulate sum of squares across all blocks
+    _var = tl.zeros([128], dtype=tl.float32)
+    for blk in range(N_QUANT):
+        off = blk * 128 + blk_offsets
+        mask = off < K
+        x = tl.load(x_ptr + row * K + off, mask=mask, other=0.0).to(tl.float32)
+        _var += x * x  # masked loads give 0.0 for out-of-bounds, so x*x=0 there
+    sum_sq = tl.sum(_var)
+    rstd = tl.rsqrt(sum_sq / K + eps)
+
+    # Pass 2: normalize, store BF16, per-block FP8 quant
+    FP8_MAX: tl.constexpr = 448.0
+
+    for blk in range(N_QUANT):
+        off = blk * 128 + blk_offsets
+        mask = off < K
+
+        x = tl.load(x_ptr + row * K + off, mask=mask, other=0.0).to(tl.float32)
+        w = tl.load(w_ptr + off, mask=mask, other=0.0).to(tl.float32)
+        x_norm = x * rstd * w
+
+        # BF16 norm output
+        tl.store(bf16_out_ptr + row * K + off, x_norm.to(tl.bfloat16), mask=mask)
+
+        # Per-block scale: max(|x_norm|) / FP8_MAX
+        x_abs = tl.abs(x_norm)
+        max_val = tl.max(tl.where(mask, x_abs, 0.0), axis=0)
+        scale = tl.maximum(max_val / FP8_MAX, 1e-12)
+
+        # Quantize: clamp then cast to FP8
+        x_fp8 = tl.minimum(tl.maximum(x_norm / scale, -FP8_MAX), FP8_MAX).to(tl.float8e4nv)
+        tl.store(fp8_out_ptr + row * K + off, x_fp8, mask=mask)
+
+        # Scale at [blk, row] in [N_QUANT, M] layout (matches fp8_quantize_1x128 output)
+        tl.store(sf_out_ptr + blk * M + row, scale)
+
+
+def _rms_norm_fp8_1x128_impl(
+    input: Tensor, weight: Tensor, eps: float
+) -> Tuple[Tensor, Tensor, Tensor]:
+    """Fused RMSNorm + per-1x128-block FP8 quantization.
+
+    Args:
+        input:  [..., K] bfloat16, K must be divisible by 128.
+        weight: [K] bfloat16 norm scale weights.
+        eps:    small constant for numerical stability.
+
+    Returns:
+        bf16_out: same shape as input, bfloat16 — RMSNorm output.
+        fp8_out:  same shape as input, float8_e4m3fn — quantized output.
+        sf_out:   [K//128, M] float32 — per-block activation scale factors,
+                  in the same layout as torch.ops.trtllm.fp8_quantize_1x128.
+                  M = product of all dimensions of input except the last.
+    """
+    orig_shape = input.shape
+    K = input.shape[-1]
+    M = input.numel() // K
+
+    assert K % 128 == 0, f"K={K} must be divisible by 128 for rms_norm_fp8_1x128"
+    N_QUANT = K // 128
+
+    x2 = input.reshape(M, K)
+    if not x2.is_contiguous():
+        x2 = x2.contiguous()
+    if not weight.is_contiguous():
+        weight = weight.contiguous()
+
+    bf16_out = torch.empty_like(x2)
+    fp8_out = torch.empty(M, K, dtype=torch.float8_e4m3fn, device=x2.device)
+    sf_out = torch.empty(N_QUANT, M, dtype=torch.float32, device=x2.device)
+
+    grid = (M,)
+    _rms_norm_fp8_1x128_kernel[grid](
+        x2,
+        weight,
+        bf16_out,
+        fp8_out,
+        sf_out,
+        M,
+        K,
+        eps=eps,
+        N_QUANT=N_QUANT,
+    )
+
+    return bf16_out.reshape(orig_shape), fp8_out.reshape(orig_shape), sf_out
+
+
+@torch.library.custom_op("auto_deploy::rms_norm_fp8_1x128", mutates_args=())
+def rms_norm_fp8_1x128(input: Tensor, weight: Tensor, eps: float) -> Tuple[Tensor, Tensor, Tensor]:
+    """Custom op: fused RMSNorm + per-1x128-block FP8 quantization.
+
+    Intended to replace flashinfer_rms_norm when its output feeds only
+    trtllm_finegrained_fp8_linear nodes, eliminating the per-linear
+    direct_copy + scale_1x128_kernel overhead.
+
+    Returns (bf16_norm, fp8_quant, act_scale_factors) where act_scale_factors
+    can be passed directly to trtllm_finegrained_fp8_linear_prequant.
+    """
+    return _rms_norm_fp8_1x128_impl(input, weight, eps)
+
+
+@rms_norm_fp8_1x128.register_fake
+def _rms_norm_fp8_1x128_fake(
+    input: Tensor, weight: Tensor, eps: float
+) -> Tuple[Tensor, Tensor, Tensor]:
+    K = input.shape[-1]
+    M = input.numel() // K
+    N_QUANT = (K + 127) // 128
+    bf16_out = torch.empty_like(input)
+    fp8_out = torch.empty(input.shape, dtype=torch.float8_e4m3fn, device=input.device)
+    sf_out = torch.empty(N_QUANT, M, dtype=torch.float32, device=input.device)
+    return bf16_out, fp8_out, sf_out

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/triton_sharded_qk_norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/triton_sharded_qk_norm.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton kernels for fused sharded QK RMSNorm with packed variance allreduce."""
+
+from typing import Tuple
+
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+from torch import Tensor
+
+
+@triton.jit
+def triton_row_sumsq_kernel(
+    input_ptr,
+    output_ptr,
+    input_row_stride: tl.constexpr,
+    N_COLS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Compute sum(x^2) over each row, returning one float32 scalar per row.
+
+    One program per row — prog_id selects the row.
+    """
+    prog_id = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_N)
+
+    x_ptr = input_ptr + prog_id * input_row_stride
+    x = tl.load(x_ptr + offsets, mask=offsets < N_COLS)
+    xf = x.to(tl.float32)
+
+    row_sumsq = tl.sum(xf * xf, 0)
+    tl.store(output_ptr + prog_id, row_sumsq)
+
+
+@triton.jit
+def triton_normalize_scale_kernel(
+    input_ptr,
+    global_sumsq_ptr,
+    weight_ptr,
+    output_ptr,
+    input_row_stride: tl.constexpr,
+    global_count: tl.constexpr,
+    eps: tl.constexpr,
+    N_COLS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Normalize a row using a precomputed global sum-of-squares scalar.
+
+    One program per row. Reads the global sum-of-squares for this row from
+    global_sumsq_ptr[prog_id], computes rstd, then normalizes and scales.
+    """
+    prog_id = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK_N)
+
+    # Load precomputed global sum-of-squares for this row
+    global_sumsq = tl.load(global_sumsq_ptr + prog_id).to(tl.float32)
+
+    # Compute reciprocal standard deviation from global stats
+    rstd = 1.0 / tl.sqrt(global_sumsq / global_count + eps)
+
+    # Load input row
+    x_ptr = input_ptr + prog_id * input_row_stride
+    x = tl.load(x_ptr + offsets, mask=offsets < N_COLS)
+    xf = x.to(tl.float32)
+
+    # Load weight
+    w = tl.load(weight_ptr + offsets, mask=offsets < N_COLS)
+    wf = w.to(tl.float32)
+
+    # Normalize and scale
+    out = (xf * rstd * wf).to(x.dtype)
+
+    out_ptr = output_ptr + prog_id * input_row_stride
+    tl.store(out_ptr + offsets, out, mask=offsets < N_COLS)
+
+
+def triton_fused_sharded_qk_norm(
+    q: Tensor,
+    k: Tensor,
+    weight_q: Tensor,
+    weight_k: Tensor,
+    eps: float,
+    world_size: int,
+) -> Tuple[Tensor, Tensor]:
+    """Fused sharded QK RMSNorm with a single packed allreduce.
+
+    Computes RMSNorm for both Q and K (sharded along head dim) using ONE
+    allreduce on packed [N_tokens, 2] variance stats instead of two separate
+    allreduces.
+
+    Algorithm:
+        1. Compute local sum-of-squares for each row of Q and K separately.
+        2. Pack into [seq_len, 2] float32 and do ONE dist.all_reduce(SUM).
+        3. Normalize Q using global stats col 0, normalize K using global stats col 1.
+
+    Args:
+        q: Local Q shard, shape [..., local_q_dim].
+        k: Local K shard, shape [..., local_k_dim].
+        weight_q: Local Q norm weight, shape [local_q_dim].
+        weight_k: Local K norm weight, shape [local_k_dim].
+        eps: Small constant for numerical stability.
+        world_size: Number of devices across which Q and K are sharded.
+
+    Returns:
+        Tuple of (q_norm, k_norm), each with the same shape as the respective input.
+    """
+    if not q.is_contiguous():
+        q = q.contiguous()
+    if not k.is_contiguous():
+        k = k.contiguous()
+
+    seq_len = q.numel() // q.shape[-1]
+    local_q_dim = q.shape[-1]
+    local_k_dim = k.shape[-1]
+
+    BLOCK_Q = triton.next_power_of_2(local_q_dim)
+    BLOCK_K = triton.next_power_of_2(local_k_dim)
+
+    q_sumsq = torch.empty(seq_len, device=q.device, dtype=torch.float32)
+    k_sumsq = torch.empty(seq_len, device=q.device, dtype=torch.float32)
+
+    # Kernel 1a: compute local sum-of-squares for each row of Q
+    triton_row_sumsq_kernel[(seq_len,)](
+        q,
+        q_sumsq,
+        input_row_stride=q.stride(-2),
+        N_COLS=local_q_dim,
+        BLOCK_N=BLOCK_Q,
+        num_warps=4,
+    )
+
+    # Kernel 1b: compute local sum-of-squares for each row of K
+    triton_row_sumsq_kernel[(seq_len,)](
+        k,
+        k_sumsq,
+        input_row_stride=k.stride(-2),
+        N_COLS=local_k_dim,
+        BLOCK_N=BLOCK_K,
+        num_warps=4,
+    )
+
+    # Step 2: Pack into [seq_len, 2] and do ONE allreduce
+    packed = torch.stack([q_sumsq, k_sumsq], dim=-1)  # [seq_len, 2] float32
+    dist.all_reduce(packed, op=dist.ReduceOp.SUM)
+
+    # Step 3: Normalize Q and K using their respective global stats
+    q_out = torch.empty_like(q)
+    k_out = torch.empty_like(k)
+
+    triton_normalize_scale_kernel[(seq_len,)](
+        q,
+        packed[:, 0].contiguous(),
+        weight_q,
+        q_out,
+        input_row_stride=q.stride(-2),
+        global_count=local_q_dim * world_size,
+        eps=eps,
+        N_COLS=local_q_dim,
+        BLOCK_N=BLOCK_Q,
+        num_warps=4,
+    )
+
+    triton_normalize_scale_kernel[(seq_len,)](
+        k,
+        packed[:, 1].contiguous(),
+        weight_k,
+        k_out,
+        input_row_stride=k.stride(-2),
+        global_count=local_k_dim * world_size,
+        eps=eps,
+        N_COLS=local_k_dim,
+        BLOCK_N=BLOCK_K,
+        num_warps=4,
+    )
+
+    return q_out, k_out

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -677,3 +677,57 @@ def _trtllm_finegrained_fp8_linear_fake(
     """Fake implementation for torch.export tracing."""
     out_features = weight.shape[0]
     return torch.empty((*input.shape[:-1], out_features), dtype=input.dtype, device=input.device)
+
+
+@torch.library.custom_op("auto_deploy::trtllm_finegrained_fp8_linear_prequant", mutates_args=())
+def trtllm_finegrained_fp8_linear_prequant(
+    input_fp8: torch.Tensor,  # [..., K] float8_e4m3fn (pre-quantized)
+    act_sf: torch.Tensor,  # [K//128, M] float32 per-block activation scales
+    weight: torch.Tensor,  # [N, K] float8_e4m3fn
+    bias: Optional[torch.Tensor],  # [N] or None
+    weight_scale: torch.Tensor,  # [ceil(N/128), ceil(K/128)] per-block weight scale
+) -> torch.Tensor:
+    """FineGrainedFP8 linear with pre-quantized input.
+
+    Skips the dynamic fp8_quantize_1x128 step and calls fp8_block_scaling_gemm
+    directly with the provided activation scale factors. Intended to be used
+    after rms_norm_fp8_1x128 which already computed (fp8_input, act_sf).
+
+    Args:
+        input_fp8:   [..., K] float8_e4m3fn — pre-quantized activations.
+        act_sf:      [K//128, M] float32 — per-block scales, M = prod(...).
+        weight:      [N, K] float8_e4m3fn — pre-quantized weight.
+        bias:        [N] or None.
+        weight_scale:[ceil(N/128), ceil(K/128)] float32 or bfloat16.
+
+    Returns:
+        [..., N] bfloat16 output, same batch dims as input_fp8.
+    """
+    if weight_scale.dtype != torch.float32:
+        weight_scale = weight_scale.float()
+
+    input_shape = input_fp8.shape
+    K = input_shape[-1]
+    M = input_fp8.numel() // K
+    N = weight.shape[0]
+
+    input_2d = input_fp8.reshape(M, K)
+    output = torch.ops.trtllm.fp8_block_scaling_gemm(input_2d, weight, act_sf, weight_scale)
+
+    if bias is not None:
+        output = output + bias
+
+    return output.reshape(*input_shape[:-1], N)
+
+
+@trtllm_finegrained_fp8_linear_prequant.register_fake
+def _trtllm_finegrained_fp8_linear_prequant_fake(
+    input_fp8: torch.Tensor,
+    act_sf: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Fake implementation for torch.export tracing."""
+    N = weight.shape[0]
+    return torch.empty((*input_fp8.shape[:-1], N), dtype=torch.bfloat16, device=input_fp8.device)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/__init__.py
@@ -27,4 +27,5 @@ __all__ = [
     "flashinfer_rope",
     "triton_rope",
     "triton_rope_kernel",
+    "partial_rope_fused",
 ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/partial_rope_fused.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/partial_rope_fused.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""Fused partial RoPE (NeoX format) — rotate first ``rotary_dim`` channels and
+pass the remaining ``head_dim - rotary_dim`` channels through in one kernel.
+
+Replaces the 4-kernel graph pattern that MiniMax-M2 / DeepSeek-V3 style models
+emit after ``apply_rotary_pos_emb``:
+
+    slice(q, -1, 0, Dr)   \\
+    slice(q, -1, Dr, ...)  >-- flashinfer_rope(q_rot, k_rot, ...) + 2x cat
+    slice(k, -1, 0, Dr)   /
+
+    (4 glue kernels ~7 µs/layer: flashinfer_rope + 3 CatArrayBatchedCopy + elemwise)
+
+The fused Triton kernel does the full thing in one launch per tensor (Q and K).
+For NeoX-format caches (``emb = cat(freqs, freqs, -1)``) the second half of
+``cos`` / ``sin`` duplicates the first half, so we only read the first half.
+"""
+
+from typing import Tuple
+
+import torch
+import triton
+import triton.language as tl
+from torch import Tensor
+
+
+@triton.jit
+def _partial_rope_one_kernel(
+    x_ptr,
+    cos_ptr,
+    sin_ptr,
+    x_out_ptr,
+    x_stride_m,
+    x_stride_h,
+    x_out_stride_m,
+    x_out_stride_h,
+    cos_stride_m,
+    DH: tl.constexpr,  # head_dim
+    DR: tl.constexpr,  # rotary_dim, must be even and <= DH
+    HALF: tl.constexpr,  # DR // 2
+    DH_PASS: tl.constexpr,  # DH - DR (pow-of-2 or 0)
+):
+    """One program per (token, head). Rotates x[:DR] NeoX-style, copies x[DR:DH].
+
+    NOTE: merging Q and K into a single kernel (grid sized to max(H_Q, H_KV)
+    with runtime predication on H_KV) was tested and produced a net
+    regression — active GPU time increased by ~150 µs/iter on the MiniMax-M2.7
+    tp2 reduced config. Likely cause: runtime-branched work per program hurts
+    occupancy and per-program latency more than it saves in launch overhead.
+    Keeping two launches (one for Q, one for K) for now.
+    """
+    m = tl.program_id(0)
+    h = tl.program_id(1)
+
+    x_base = x_ptr + m * x_stride_m + h * x_stride_h
+    out_base = x_out_ptr + m * x_out_stride_m + h * x_out_stride_h
+
+    # Rotary lanes
+    offs_half = tl.arange(0, HALF)
+    x_lo = tl.load(x_base + offs_half).to(tl.float32)
+    x_hi = tl.load(x_base + HALF + offs_half).to(tl.float32)
+    cos = tl.load(cos_ptr + m * cos_stride_m + offs_half).to(tl.float32)
+    sin = tl.load(sin_ptr + m * cos_stride_m + offs_half).to(tl.float32)
+
+    # NeoX rotate_half: cat(-x_hi, x_lo); rotation = x*cos + rot_half(x)*sin
+    out_lo = x_lo * cos - x_hi * sin
+    out_hi = x_hi * cos + x_lo * sin
+
+    dtype = x_out_ptr.dtype.element_ty
+    tl.store(out_base + offs_half, out_lo.to(dtype))
+    tl.store(out_base + HALF + offs_half, out_hi.to(dtype))
+
+    # Pass-through lanes: [DR:DH]. When DH == DR, skipped at compile time.
+    if DH_PASS > 0:
+        offs_pass = tl.arange(0, DH_PASS)
+        x_pass = tl.load(x_base + DR + offs_pass)
+        tl.store(out_base + DR + offs_pass, x_pass)
+
+
+def _next_pow2(x: int) -> int:
+    return 1 << (x - 1).bit_length()
+
+
+def _partial_rope_fused_impl(
+    q: Tensor, k: Tensor, cos: Tensor, sin: Tensor
+) -> Tuple[Tensor, Tensor]:
+    """Partial RoPE over leading-dim-flattened q, k.
+
+    Args:
+        q:   [..., H_q, Dh]    — bf16 or fp16.
+        k:   [..., H_kv, Dh]   — bf16 or fp16.
+        cos: [..., Dr]         — same dtype as q (typically bf16).
+        sin: [..., Dr]         — same dtype as q.
+
+    Returns (q_out, k_out) with the same shapes and dtypes as the inputs.
+
+    Assumptions:
+        - Dh and Dr are even; Dr <= Dh; (Dh - Dr) is a power of 2 or 0.
+        - cos/sin are in NeoX duplicated format (second half == first half);
+          only the first Dr/2 lanes are read.
+    """
+    assert q.shape[-1] == k.shape[-1], "Q and K must share head_dim"
+    assert q.dtype == k.dtype, "Q and K must share dtype"
+    q_shape, k_shape = q.shape, k.shape
+    Dh = q_shape[-1]
+    Dr = cos.shape[-1]
+    Hq = q_shape[-2]
+    Hkv = k_shape[-2]
+
+    assert Dr % 2 == 0 and Dr <= Dh, f"Dr={Dr} must be even and <= Dh={Dh}"
+    assert q.stride(-1) == 1 and k.stride(-1) == 1, "last dim must be contiguous"
+    assert cos.stride(-1) == 1 and sin.stride(-1) == 1, "last dim must be contiguous"
+
+    # Flatten leading dims into a single M dim.
+    M = q.numel() // (Hq * Dh)
+    q_flat = q.reshape(M, Hq, Dh)
+    k_flat = k.reshape(M, Hkv, Dh)
+    cos_flat = cos.reshape(M, Dr)
+    sin_flat = sin.reshape(M, Dr)
+
+    q_out = torch.empty_like(q_flat)
+    k_out = torch.empty_like(k_flat)
+
+    DH_PASS = Dh - Dr
+    # DH_PASS must be a power of 2 (or 0) for tl.arange.
+    assert DH_PASS == 0 or DH_PASS == _next_pow2(DH_PASS), (
+        f"(Dh - Dr)={DH_PASS} must be a power of two"
+    )
+    HALF = Dr // 2
+
+    grid_q = (M, Hq)
+    _partial_rope_one_kernel[grid_q](
+        q_flat,
+        cos_flat,
+        sin_flat,
+        q_out,
+        q_flat.stride(0),
+        q_flat.stride(1),
+        q_out.stride(0),
+        q_out.stride(1),
+        cos_flat.stride(0),
+        DH=Dh,
+        DR=Dr,
+        HALF=HALF,
+        DH_PASS=DH_PASS,
+    )
+    grid_k = (M, Hkv)
+    _partial_rope_one_kernel[grid_k](
+        k_flat,
+        cos_flat,
+        sin_flat,
+        k_out,
+        k_flat.stride(0),
+        k_flat.stride(1),
+        k_out.stride(0),
+        k_out.stride(1),
+        cos_flat.stride(0),
+        DH=Dh,
+        DR=Dr,
+        HALF=HALF,
+        DH_PASS=DH_PASS,
+    )
+
+    return q_out.reshape(q_shape), k_out.reshape(k_shape)
+
+
+@torch.library.custom_op("auto_deploy::partial_rope_fused", mutates_args=())
+def partial_rope_fused(q: Tensor, k: Tensor, cos: Tensor, sin: Tensor) -> Tuple[Tensor, Tensor]:
+    """Fused partial RoPE (NeoX format) on the last head_dim of q/k.
+
+    Rotates the first ``cos.shape[-1]`` (== rotary_dim) channels and copies
+    the remaining ``head_dim - rotary_dim`` channels unchanged. Two Triton
+    kernel launches total (one for Q, one for K), replacing the
+    slice+flashinfer_rope+cat pattern.
+    """
+    return _partial_rope_fused_impl(q, k, cos, sin)
+
+
+@partial_rope_fused.register_fake
+def _partial_rope_fused_fake(
+    q: Tensor, k: Tensor, cos: Tensor, sin: Tensor
+) -> Tuple[Tensor, Tensor]:
+    return torch.empty_like(q), torch.empty_like(k)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_minimax_m2.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_minimax_m2.py
@@ -73,18 +73,14 @@ def apply_rotary_pos_emb(
 
     Only the first ``rotary_dim`` dimensions are rotated; the rest pass through.
     ``unsqueeze_dim=2`` broadcasts over the head dimension (N) in bsnd.
+
+    Uses the fused Triton kernel (``auto_deploy.partial_rope_fused``) which
+    replaces the slice + flashinfer_rope + cat pattern with a single kernel
+    launch per tensor. The expected cos/sin layout is bsnd with Dr == cos.shape[-1]
+    and unsqueeze_dim == 2 (broadcast over the head dimension).
     """
-    cos = cos.unsqueeze(unsqueeze_dim)
-    sin = sin.unsqueeze(unsqueeze_dim)
-
-    rotary_dim = cos.shape[-1]
-    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
-    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
-
-    q_embed = (q_rot * cos) + (rotate_half(q_rot) * sin)
-    k_embed = (k_rot * cos) + (rotate_half(k_rot) * sin)
-
-    return torch.cat([q_embed, q_pass], dim=-1), torch.cat([k_embed, k_pass], dim=-1)
+    assert unsqueeze_dim == 2, "partial_rope_fused expects bsnd layout with unsqueeze_dim=2"
+    return torch.ops.auto_deploy.partial_rope_fused(q, k, cos, sin)
 
 
 # ---------------------------------------------------------------------------

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_minimax_m2.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_minimax_m2.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -28,6 +28,7 @@ from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from transformers.activations import ACT2FN
 from transformers.generation import GenerationMixin
 from transformers.modeling_utils import PreTrainedModel
@@ -171,14 +172,21 @@ class MiniMaxM2SparseMoeBlock(nn.Module):
         bsz, seq_len, hidden_dim = hidden_states.shape
         hidden_flat = hidden_states.view(-1, hidden_dim)
 
-        # Sigmoid routing with bias correction and top-k selection
-        router_logits = self.gate(hidden_flat)
-        routing_weights = torch.sigmoid(router_logits.float())
-        scores = routing_weights + self.e_score_correction_bias
-        _, top_k_indices = torch.topk(scores, self.top_k, dim=-1, sorted=False)
-        top_k_weights = routing_weights.gather(1, top_k_indices)
-        top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True)
-        top_k_weights = top_k_weights.to(hidden_flat.dtype)
+        if self.gate.weight.dtype == torch.float32:
+            router_logits = F.linear(hidden_flat.float(), self.gate.weight)
+        else:
+            router_logits = torch.ops.trtllm.dsv3_router_gemm_op(
+                hidden_flat, self.gate.weight.t(), bias=None, out_dtype=torch.float32
+            )
+
+        top_k_weights, top_k_indices = torch.ops.trtllm.noaux_tc_op(
+            router_logits,
+            self.e_score_correction_bias,
+            1,
+            1,
+            self.top_k,
+            1.0,
+        )
 
         # Dispatch via AD canonical MoE op
         output = torch.ops.auto_deploy.torch_moe(

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_minimax_m2.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_minimax_m2.py
@@ -179,22 +179,31 @@ class MiniMaxM2SparseMoeBlock(nn.Module):
         else:
             router_logits = self.gate(hidden_flat)
 
-        if can_use_fused_router:
-            top_k_weights, top_k_indices = torch.ops.trtllm.noaux_tc_op(
-                router_logits,
-                self.e_score_correction_bias,
-                1,
-                1,
-                self.top_k,
-                1.0,
-            )
-        else:
-            routing_weights = torch.sigmoid(router_logits)
-            scores = routing_weights + self.e_score_correction_bias
-            _, top_k_indices = torch.topk(scores, self.top_k, dim=-1, sorted=False)
-            top_k_weights = routing_weights.gather(1, top_k_indices)
-            top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True)
-            top_k_weights = top_k_weights.to(hidden_flat.dtype)
+        top_k_weights, top_k_indices = torch.ops.trtllm.noaux_tc_op(
+            router_logits,
+            self.e_score_correction_bias,
+            1,
+            1,
+            self.top_k,
+            1.0,
+        )
+
+        # if can_use_fused_router:
+        #     top_k_weights, top_k_indices = torch.ops.trtllm.noaux_tc_op(
+        #         router_logits,
+        #         self.e_score_correction_bias,
+        #         1,
+        #         1,
+        #         self.top_k,
+        #         1.0,
+        #     )
+        # else:
+        #     routing_weights = torch.sigmoid(router_logits)
+        #     scores = routing_weights + self.e_score_correction_bias
+        #     _, top_k_indices = torch.topk(scores, self.top_k, dim=-1, sorted=False)
+        #     top_k_weights = routing_weights.gather(1, top_k_indices)
+        #     top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True)
+        #     top_k_weights = top_k_weights.to(hidden_flat.dtype)
 
         # Dispatch via AD canonical MoE op
         output = torch.ops.auto_deploy.torch_moe(

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_minimax_m2.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_minimax_m2.py
@@ -28,7 +28,6 @@ from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from transformers.activations import ACT2FN
 from transformers.generation import GenerationMixin
 from transformers.modeling_utils import PreTrainedModel
@@ -172,21 +171,30 @@ class MiniMaxM2SparseMoeBlock(nn.Module):
         bsz, seq_len, hidden_dim = hidden_states.shape
         hidden_flat = hidden_states.view(-1, hidden_dim)
 
-        if self.gate.weight.dtype == torch.float32:
-            router_logits = F.linear(hidden_flat.float(), self.gate.weight)
-        else:
+        can_use_fused_router = hidden_flat.is_cuda
+        if can_use_fused_router and self.gate.weight.dtype != torch.float32:
             router_logits = torch.ops.trtllm.dsv3_router_gemm_op(
                 hidden_flat, self.gate.weight.t(), bias=None, out_dtype=torch.float32
             )
+        else:
+            router_logits = self.gate(hidden_flat)
 
-        top_k_weights, top_k_indices = torch.ops.trtllm.noaux_tc_op(
-            router_logits,
-            self.e_score_correction_bias,
-            1,
-            1,
-            self.top_k,
-            1.0,
-        )
+        if can_use_fused_router:
+            top_k_weights, top_k_indices = torch.ops.trtllm.noaux_tc_op(
+                router_logits,
+                self.e_score_correction_bias,
+                1,
+                1,
+                self.top_k,
+                1.0,
+            )
+        else:
+            routing_weights = torch.sigmoid(router_logits)
+            scores = routing_weights + self.e_score_correction_bias
+            _, top_k_indices = torch.topk(scores, self.top_k, dim=-1, sorted=False)
+            top_k_weights = routing_weights.gather(1, top_k_indices)
+            top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True)
+            top_k_weights = top_k_weights.to(hidden_flat.dtype)
 
         # Dispatch via AD canonical MoE op
         output = torch.ops.auto_deploy.torch_moe(

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/minimax_m2.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/minimax_m2.py
@@ -13,7 +13,6 @@ import types
 from typing import Dict
 
 import torch
-import torch.nn.functional as F
 from transformers import AutoModelForCausalLM
 
 
@@ -32,20 +31,29 @@ def minimax_m2_moe(self, hidden_states: torch.Tensor):
         )
     hidden_states = hidden_states.view(-1, hidden_dim)
     # router_logits: (batch * sequence_length, n_experts)
-    if self.gate.weight.dtype == torch.float32:
-        router_logits = F.linear(hidden_states.float(), self.gate.weight)
-    else:
+    can_use_fused_router = hidden_states.is_cuda
+    if can_use_fused_router and self.gate.weight.dtype != torch.float32:
         router_logits = torch.ops.trtllm.dsv3_router_gemm_op(
             hidden_states, self.gate.weight.t(), bias=None, out_dtype=torch.float32
         )
-    top_k_weights, selected_experts = torch.ops.trtllm.noaux_tc_op(
-        router_logits,
-        self.e_score_correction_bias,
-        1,
-        1,
-        self.top_k,
-        1.0,
-    )
+    else:
+        router_logits = self.gate(hidden_states)
+    if can_use_fused_router:
+        top_k_weights, selected_experts = torch.ops.trtllm.noaux_tc_op(
+            router_logits,
+            self.e_score_correction_bias,
+            1,
+            1,
+            self.top_k,
+            1.0,
+        )
+    else:
+        routing_weights = torch.sigmoid(router_logits)
+        scores_for_choice = routing_weights + self.e_score_correction_bias
+        _, selected_experts = torch.topk(scores_for_choice, self.top_k, dim=-1, sorted=False)
+        top_k_weights = routing_weights.gather(1, selected_experts)
+        top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True)
+        top_k_weights = top_k_weights.to(hidden_states.dtype)
 
     final_hidden_states = torch.ops.auto_deploy.torch_moe(
         hidden_states,

--- a/tensorrt_llm/_torch/auto_deploy/models/patches/minimax_m2.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/patches/minimax_m2.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """A patch for MiniMax-M2 MoE to make it compatible with torch.export.
 
 MiniMax-M2 is loaded from HuggingFace hub (trust_remote_code), so we cannot
@@ -10,6 +13,7 @@ import types
 from typing import Dict
 
 import torch
+import torch.nn.functional as F
 from transformers import AutoModelForCausalLM
 
 
@@ -28,24 +32,20 @@ def minimax_m2_moe(self, hidden_states: torch.Tensor):
         )
     hidden_states = hidden_states.view(-1, hidden_dim)
     # router_logits: (batch * sequence_length, n_experts)
-    router_logits = self.gate(hidden_states)
-
-    # MiniMax-M2 specific routing:
-    # Step 1: Sigmoid activation (not softmax like Mixtral)
-    routing_weights = torch.sigmoid(router_logits.float())
-
-    # Step 2: Add bias for expert selection only
-    scores_for_choice = routing_weights + self.e_score_correction_bias
-
-    # Step 3: Select top-k experts based on biased scores
-    _, selected_experts = torch.topk(scores_for_choice, self.top_k, dim=-1, sorted=False)
-
-    # Step 4: Gather ORIGINAL sigmoid weights (not biased scores)
-    top_k_weights = routing_weights.gather(1, selected_experts)
-
-    # Step 5: Normalize so weights sum to 1
-    top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True)
-    top_k_weights = top_k_weights.to(hidden_states.dtype)
+    if self.gate.weight.dtype == torch.float32:
+        router_logits = F.linear(hidden_states.float(), self.gate.weight)
+    else:
+        router_logits = torch.ops.trtllm.dsv3_router_gemm_op(
+            hidden_states, self.gate.weight.t(), bias=None, out_dtype=torch.float32
+        )
+    top_k_weights, selected_experts = torch.ops.trtllm.noaux_tc_op(
+        router_logits,
+        self.e_score_correction_bias,
+        1,
+        1,
+        self.top_k,
+        1.0,
+    )
 
     final_hidden_states = torch.ops.auto_deploy.torch_moe(
         hidden_states,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/bypass_qk_split_for_lamport.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/bypass_qk_split_for_lamport.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""Transform: bypass split_output for Q/K inputs to lamport_sharded_qk_rmsnorm.
+
+After fuse_gemms runs, the fused Q+K+V output [M, q_dim+k_dim+v_dim] is routed
+through a Python `split_output` helper that calls `.contiguous()` on each of
+Q, K, V. Q and K feed lamport_sharded_qk_rmsnorm (which now supports strided
+inputs), so their contiguous copies are wasted work (2 kernels per layer).
+
+This transform rewrites:
+
+    fused = trtllm_finegrained_fp8_linear_prequant(...)  # [M, 4096]
+    (Q_c, K_c, V_c) = split_output(fused)                # 3 contiguous copies
+    q_norm, k_norm = lamport_sharded_qk_rmsnorm(Q_c, K_c, ...)
+    ... = view(V_c, ...)                                 # needs contiguous
+
+to:
+
+    fused = trtllm_finegrained_fp8_linear_prequant(...)  # [M, 4096]
+    Q_view = aten.narrow(fused, -1, 0, q_dim)            # strided view, no kernel
+    K_view = aten.narrow(fused, -1, q_dim, k_dim)        # strided view, no kernel
+    V_c    = aten.clone(aten.narrow(fused, -1, q_dim+k_dim, v_dim))  # 1 contig kernel
+    q_norm, k_norm = lamport_sharded_qk_rmsnorm(Q_view, K_view, ...)
+
+Net: -2 kernels per fused QK-norm call.
+"""
+
+import operator
+from typing import Tuple, Type
+
+import torch
+from torch.fx import GraphModule, Node
+
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils._graph import eliminate_dead_code
+from ...utils.node_utils import is_op
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+
+def _split_output_info(node: Node):
+    """If node is getitem(split_output, idx), return (split_node, idx, fused_input).
+
+    Returns None otherwise.
+    """
+    if node.op != "call_function" or node.target is not operator.getitem:
+        return None
+    split_node, idx = node.args[0], node.args[1]
+    if not isinstance(split_node, Node):
+        return None
+    if split_node.op != "call_function":
+        return None
+    # The split helper is an inline closure; match by name heuristic.
+    target_repr = getattr(split_node.target, "__qualname__", "") or str(split_node.target)
+    if "split_output" not in target_repr:
+        return None
+    fused_input = split_node.args[0]
+    if not isinstance(fused_input, Node):
+        return None
+    return split_node, int(idx), fused_input
+
+
+@TransformRegistry.register("bypass_qk_split_for_lamport")
+class BypassQKSplitForLamport(BaseTransform):
+    """Replace split_output copies with narrow views when inputs feed lamport QK norm.
+
+    Works together with the strided-read path in lamport_sharded_qk_rmsnorm:
+    Q and K become strided views of the fused GEMM output; V gets a clone
+    (still required by the downstream aten.view).
+    """
+
+    config: TransformConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return TransformConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        graph = gm.graph
+        cnt = 0
+
+        for node in list(graph.nodes):
+            if not is_op(node, torch.ops.auto_deploy.lamport_sharded_qk_rmsnorm):
+                continue
+
+            q_node, k_node = node.args[0], node.args[1]
+            q_info = _split_output_info(q_node)
+            k_info = _split_output_info(k_node)
+            if q_info is None or k_info is None:
+                continue
+            q_split, q_idx, q_fused = q_info
+            k_split, k_idx, k_fused = k_info
+            # Q and K must come from the same split_output node (same fused GEMM)
+            if q_split is not k_split or q_fused is not k_fused:
+                continue
+            # Expect Q at index 0 and K at index 1 (matches split_output layout)
+            if q_idx != 0 or k_idx != 1:
+                continue
+
+            # Compute Q and K sizes from their current meta shapes
+            q_meta = q_node.meta.get("val")
+            k_meta = k_node.meta.get("val")
+            if q_meta is None or k_meta is None:
+                continue
+            try:
+                q_dim = int(q_meta.shape[-1])
+                k_dim = int(k_meta.shape[-1])
+            except Exception:
+                continue
+
+            # Insert narrow views for Q and K before the lamport op
+            with graph.inserting_before(node):
+                q_view = graph.call_function(
+                    torch.ops.aten.narrow.default,
+                    args=(q_fused, -1, 0, q_dim),
+                )
+                k_view = graph.call_function(
+                    torch.ops.aten.narrow.default,
+                    args=(q_fused, -1, q_dim, k_dim),
+                )
+            # Propagate meta (tensor shape) so downstream shape_prop is happy
+            q_view.meta["val"] = q_meta
+            k_view.meta["val"] = k_meta
+
+            # Swap the lamport op inputs
+            node.replace_input_with(q_node, q_view)
+            node.replace_input_with(k_node, k_view)
+
+            # Q and K getitems may now be dead. If split_output's only remaining
+            # consumer is the V getitem (idx == 2), replace that with a narrow
+            # + clone to keep V contiguous for the downstream aten.view.
+            remaining_getitems = [
+                u for u in list(q_split.users) if u is not q_node and u is not k_node
+            ]
+            v_getitem = None
+            only_v = True
+            for u in remaining_getitems:
+                info = _split_output_info(u)
+                if info is None or info[1] != 2:
+                    only_v = False
+                    break
+                v_getitem = u
+
+            if only_v and v_getitem is not None:
+                v_meta = v_getitem.meta.get("val")
+                if v_meta is not None:
+                    try:
+                        v_dim = int(v_meta.shape[-1])
+                    except Exception:
+                        v_dim = None
+                    if v_dim is not None:
+                        with graph.inserting_before(v_getitem):
+                            v_narrow = graph.call_function(
+                                torch.ops.aten.narrow.default,
+                                args=(q_fused, -1, q_dim + k_dim, v_dim),
+                            )
+                            v_contig = graph.call_function(
+                                torch.ops.aten.clone.default,
+                                args=(v_narrow,),
+                                kwargs={"memory_format": torch.contiguous_format},
+                            )
+                        v_narrow.meta["val"] = v_meta
+                        v_contig.meta["val"] = v_meta
+                        v_getitem.replace_all_uses_with(v_contig)
+                        graph.erase_node(v_getitem)
+
+            cnt += 1
+
+        if cnt > 0:
+            eliminate_dead_code(gm)
+        gm.recompile()
+        info = TransformInfo(
+            skipped=(cnt == 0),
+            num_matches=cnt,
+            is_clean=(cnt == 0),
+            has_valid_shapes=(cnt == 0),
+        )
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
@@ -130,10 +130,16 @@ class FuseAllreduceResidualRMSNorm(BaseTransform):
         # Instantiate Pattern Functions
         # ============================================================================
 
-        if shared_config.dist_config is not None:
-            strategy = shared_config.dist_config.allreduce_strategy
-        elif hasattr(gm, "_sharding_transform_container"):
+        # Prefer the per-transform allreduce_strategy from the sharding container —
+        # that's where the YAML `detect_sharding.allreduce_strategy` value lives.
+        # `shared_config.dist_config.allreduce_strategy` is the global default ("NCCL")
+        # and is not updated from the YAML, so reading it first would cause this
+        # transform to compile patterns for the wrong allreduce op and silently match
+        # nothing when the YAML selects a non-default strategy (e.g. SYMM_MEM).
+        if hasattr(gm, "_sharding_transform_container"):
             strategy = gm._sharding_transform_container.config.allreduce_strategy.name
+        elif shared_config.dist_config is not None:
+            strategy = shared_config.dist_config.allreduce_strategy
         else:
             ad_logger.warning("No dist config found, skipping allreduce-residual-rmsnorm fusion")
             return gm, TransformInfo(

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_fp8_prequant_shared.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_fp8_prequant_shared.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""Transform: fuse FP8 1x128 activation quantization across shared consumers.
+
+For any BF16 (or FP16) node whose users include at least one
+`trtllm_finegrained_fp8_linear` and at least one
+`trtllm_quant_finegrained_fp8_moe_fused`, insert a single
+`fp8_quantize_1x128` on that shared input and rewire both consumers to
+pre-quantized variants:
+
+    shared_bf16                                shared_bf16
+      ├─ fp8_linear   (router)                   ├─ fp8_quantize_1x128 ──┐
+      └─ fp8_moe_fused                           │                      │
+                                                 ├─ fp8_linear_prequant (router)
+                                                 └─ fp8_moe_fused_prequant
+
+Net per-layer savings: one fp8_quantize_1x128 executes instead of being
+re-run internally by each consumer (each internal call is
+`direct_copy + scale_1x128_kernel` ≈ 5–6 µs).
+
+This transform complements `fuse_rmsnorm_fp8_finegrained`, which handles the
+analogous pattern where the shared source is a `flashinfer_rms_norm`. Here
+the source is arbitrary (e.g., a view of `trtllm_fused_allreduce_residual_rmsnorm`'s
+output), so we emit an explicit `fp8_quantize_1x128` instead of replacing the
+parent op.
+"""
+
+import operator
+from typing import List, Tuple, Type
+
+import torch
+from torch.fx import GraphModule, Node
+
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils._graph import eliminate_dead_code
+from ...utils.node_utils import extract_op_args, is_op
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+
+def _is_fp8_linear(node: Node) -> bool:
+    return is_op(node, torch.ops.auto_deploy.trtllm_finegrained_fp8_linear)
+
+
+def _is_fp8_moe(node: Node) -> bool:
+    return is_op(node, torch.ops.auto_deploy.trtllm_quant_finegrained_fp8_moe_fused)
+
+
+def _src_last_dim(src: Node) -> int:
+    meta = src.meta.get("tensor_meta") or src.meta.get("val")
+    if meta is None:
+        return -1
+    try:
+        return int(meta.shape[-1])
+    except Exception:
+        return -1
+
+
+@TransformRegistry.register("fuse_fp8_prequant_shared")
+class FuseFP8PrequantShared(BaseTransform):
+    """Share a single fp8_quantize_1x128 across FP8 linear + MoE users.
+
+    Targets the post-attention residual path in DeepSeek-V3 / MiniMax-V3
+    style MoE blocks: the same BF16 tensor (view of
+    `trtllm_fused_allreduce_residual_rmsnorm`) feeds both the router FP8
+    linear and the fused FP8 MoE op.
+    """
+
+    config: TransformConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return TransformConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        graph = gm.graph
+        cnt = 0
+
+        # Collect candidate source nodes (any node with ≥2 FP8 users where at
+        # least one is MoE — that's the savings target; pure linear-only is
+        # already handled by fuse_rmsnorm_fp8_finegrained where applicable).
+        seen_src: set = set()
+        for node in list(graph.nodes):
+            for user in node.users:
+                if _is_fp8_moe(user) and user.args[0] is node:
+                    seen_src.add(node)
+                    break
+
+        # When True, also fuses the FP8 linear (router) users into the shared
+        # pre-quant — this is the "all-fused" path that saves ~10 kernels/iter.
+        # See the module docstring for the rank-timing trade-off observed in
+        # synthetic nsys traces; the real-workload effect is what end-to-end
+        # benchmarking measures.
+        _FUSE_LINEAR_USERS = True
+
+        for src in seen_src:
+            # Split users by op type; ignore non-consuming users (e.g., views
+            # to other paths) to stay conservative.
+            linear_users: List[Node] = []
+            moe_users: List[Node] = []
+            for u in list(src.users):
+                if _is_fp8_linear(u) and u.args[0] is src:
+                    linear_users.append(u)
+                elif _is_fp8_moe(u) and u.args[0] is src:
+                    moe_users.append(u)
+
+            if not _FUSE_LINEAR_USERS:
+                linear_users = []
+
+            # Need at least one linear + one MoE user to see savings; or
+            # a MoE user alone (still saves the MoE's internal quant).
+            if not moe_users:
+                continue
+
+            k_dim = _src_last_dim(src)
+            if k_dim <= 0 or k_dim % 128 != 0:
+                continue
+
+            # Insert the explicit fp8_quantize_1x128 before the earliest consumer.
+            earliest = min(linear_users + moe_users, key=lambda n: list(graph.nodes).index(n))
+            with graph.inserting_before(earliest):
+                # fp8_quantize_1x128 returns (fp8, sf)
+                quant_node = graph.call_function(
+                    torch.ops.trtllm.fp8_quantize_1x128.default,
+                    args=(src,),
+                )
+                fp8_node = graph.call_function(operator.getitem, args=(quant_node, 0))
+                sf_node = graph.call_function(operator.getitem, args=(quant_node, 1))
+
+            # Rewrite linear users → prequant variant.
+            for lin in linear_users:
+                _, weight_arg, bias_arg, ws_arg = extract_op_args(
+                    lin, "input", "weight", "bias", "weight_scale"
+                )
+                with graph.inserting_before(lin):
+                    prequant = graph.call_function(
+                        torch.ops.auto_deploy.trtllm_finegrained_fp8_linear_prequant.default,
+                        args=(fp8_node, sf_node, weight_arg, bias_arg, ws_arg),
+                    )
+                lin.replace_all_uses_with(prequant)
+                graph.erase_node(lin)
+                cnt += 1
+
+            # Rewrite MoE users → prequant variant (pass src as shape/dtype hint).
+            for moe in moe_users:
+                args = list(moe.args)
+                kwargs = dict(moe.kwargs)
+                # Build prequant call: replace positional arg 0 (x) with (fp8, sf, hint)
+                # and keep the rest.
+                new_args = (fp8_node, sf_node, src) + tuple(args[1:])
+                with graph.inserting_before(moe):
+                    prequant = graph.call_function(
+                        torch.ops.auto_deploy.trtllm_quant_finegrained_fp8_moe_fused_prequant.default,
+                        args=new_args,
+                        kwargs=kwargs,
+                    )
+                moe.replace_all_uses_with(prequant)
+                graph.erase_node(moe)
+                cnt += 1
+
+        if cnt > 0:
+            eliminate_dead_code(gm)
+        gm.recompile()
+        info = TransformInfo(
+            skipped=(cnt == 0),
+            num_matches=cnt,
+            is_clean=(cnt == 0),
+            has_valid_shapes=(cnt == 0),
+        )
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rmsnorm_fp8_finegrained.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rmsnorm_fp8_finegrained.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transform: fuse flashinfer_rms_norm + trtllm_finegrained_fp8_linear.
+
+Replaces the pattern:
+
+    %norm = flashinfer_rms_norm(%x, %weight, eps)
+    %q    = trtllm_finegrained_fp8_linear(%norm, %wq, None, %wsq)
+    %k    = trtllm_finegrained_fp8_linear(%norm, %wk, None, %wsk)
+    ...   (any number of finegrained FP8 linears sharing %norm as input)
+
+with:
+
+    %fused = rms_norm_fp8_1x128(%x, %weight, eps)
+    %bf16  = getitem(%fused, 0)   # BF16 norm, replaces %norm for non-linear users
+    %fp8   = getitem(%fused, 1)   # FP8 pre-quantized activations
+    %sf    = getitem(%fused, 2)   # [K//128, M] activation scale factors
+    %q     = trtllm_finegrained_fp8_linear_prequant(%fp8, %sf, %wq, None, %wsq)
+    %k     = trtllm_finegrained_fp8_linear_prequant(%fp8, %sf, %wk, None, %wsk)
+    ...
+
+This eliminates the direct_copy + scale_1x128_kernel overhead that
+trtllm_finegrained_fp8_linear pays internally for each call to quantize its
+BF16 input on the fly. With N FP8 linears sharing one norm output, we save
+2*(N-1) kernel launches and replace 1 BF16 quant with the Triton fused op.
+
+Conditions for fusion:
+  1. The norm op is flashinfer_rms_norm.
+  2. ALL direct users of the norm output are trtllm_finegrained_fp8_linear.
+     (If any non-linear user exists, fusion is skipped to avoid BF16/FP8 split.)
+  3. K (the last dimension of the norm output) is divisible by 128.
+"""
+
+import operator
+from typing import List, Tuple, Type
+
+import torch
+from torch.fx import GraphModule, Node
+
+from ...models.factory import ModelFactory
+from ...shim.interface import CachedSequenceInterface
+from ...utils._graph import eliminate_dead_code
+from ...utils.node_utils import extract_op_args, is_op
+from ..interface import (
+    BaseTransform,
+    SharedConfig,
+    TransformConfig,
+    TransformInfo,
+    TransformRegistry,
+)
+
+
+def _is_finegrained_fp8_linear(node: Node) -> bool:
+    return is_op(node, torch.ops.auto_deploy.trtllm_finegrained_fp8_linear)
+
+
+def _extract_finegrained_linear_args(node: Node):
+    """Return (input, weight, bias, weight_scale) for trtllm_finegrained_fp8_linear."""
+    return extract_op_args(node, "input", "weight", "bias", "weight_scale")
+
+
+def _norm_k_dim(norm_node: Node) -> int:
+    """Return the K (last) dimension of a norm node's output, or -1 if unknown."""
+    meta = norm_node.meta.get("tensor_meta") or norm_node.meta.get("val")
+    if meta is None:
+        return -1
+    try:
+        shape = meta.shape
+        if len(shape) == 0:
+            return -1
+        k = int(shape[-1])
+        return k
+    except Exception:
+        return -1
+
+
+def _collect_fp8_linear_users(norm_node: Node) -> Tuple[List[Node], bool]:
+    """Collect all direct trtllm_finegrained_fp8_linear users of norm_node.
+
+    Returns:
+        (users, all_fp8): list of matching FP8 linear nodes, and whether ALL
+        direct users are FP8 linears (fusion safety check).
+    """
+    users = list(norm_node.users.keys())
+    fp8_users = [u for u in users if _is_finegrained_fp8_linear(u)]
+    all_fp8 = len(fp8_users) == len(users) and len(fp8_users) > 0
+    return fp8_users, all_fp8
+
+
+@TransformRegistry.register("fuse_rmsnorm_fp8_finegrained")
+class FuseRMSNormFP8Finegrained(BaseTransform):
+    """Fuse flashinfer_rms_norm + N×trtllm_finegrained_fp8_linear.
+
+    This transform runs in the post_load_fusion stage and eliminates the
+    repeated dynamic FP8 quantization (direct_copy + scale_1x128_kernel)
+    that trtllm_finegrained_fp8_linear performs per call. When multiple FP8
+    linears share one norm output (e.g. Q/K/V projections), a single Triton
+    kernel now produces both the BF16 norm and pre-quantized FP8+scales.
+    """
+
+    config: TransformConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return TransformConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        graph = gm.graph
+        cnt = 0
+        original_nodes = list(graph.nodes)
+        node_order = {n: i for i, n in enumerate(original_nodes)}
+
+        for norm_node in original_nodes:
+            if not is_op(norm_node, torch.ops.auto_deploy.flashinfer_rms_norm):
+                continue
+
+            fp8_users, all_fp8 = _collect_fp8_linear_users(norm_node)
+            if not all_fp8:
+                # Non-linear users exist — skip to avoid BF16/FP8 split issues.
+                continue
+
+            # Check K is divisible by 128
+            k_dim = _norm_k_dim(norm_node)
+            if k_dim <= 0 or k_dim % 128 != 0:
+                continue
+
+            # Extract norm inputs: (input, weight, eps)
+            norm_input, norm_weight, norm_eps = extract_op_args(norm_node, "input", "weight", "eps")
+
+            # Find insertion point: before the earliest FP8 linear
+            earliest = min(fp8_users, key=lambda n: node_order.get(n, float("inf")))
+
+            # Insert fused op + getitems
+            with graph.inserting_before(earliest):
+                fused_node = graph.call_function(
+                    torch.ops.auto_deploy.rms_norm_fp8_1x128.default,
+                    args=(norm_input, norm_weight, norm_eps),
+                )
+                bf16_node = graph.call_function(operator.getitem, args=(fused_node, 0))
+                fp8_node = graph.call_function(operator.getitem, args=(fused_node, 1))
+                sf_node = graph.call_function(operator.getitem, args=(fused_node, 2))
+
+            # Replace each finegrained FP8 linear with the prequant variant
+            for fp8_linear in fp8_users:
+                _, weight_arg, bias_arg, ws_arg = _extract_finegrained_linear_args(fp8_linear)
+                with graph.inserting_before(fp8_linear):
+                    prequant_node = graph.call_function(
+                        torch.ops.auto_deploy.trtllm_finegrained_fp8_linear_prequant.default,
+                        args=(fp8_node, sf_node, weight_arg, bias_arg, ws_arg),
+                    )
+                fp8_linear.replace_all_uses_with(prequant_node)
+                graph.erase_node(fp8_linear)
+                cnt += 1
+
+            # Replace all remaining uses of norm_node with bf16_node
+            norm_node.replace_all_uses_with(bf16_node)
+            if len(norm_node.users) == 0:
+                graph.erase_node(norm_node)
+
+        if cnt > 0:
+            eliminate_dead_code(gm)
+        gm.recompile()
+        info = TransformInfo(
+            skipped=(cnt == 0),
+            num_matches=cnt,
+            is_clean=(cnt == 0),
+            has_valid_shapes=(cnt == 0),
+        )
+        return gm, info

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -2832,6 +2832,14 @@ def _stack_finegrained_fp8_moe_weights(gm: GraphModule) -> int:
         fc2_expert_weights = w2_stacked
         fc2_weight_scale = w2_scale_stacked
 
+        # Pre-cast to float32 at load time — the fused FP8 MoE C++ runner requires
+        # fp32 scales. Doing it once here eliminates a wasted per-forward-pass
+        # weight-scale cast kernel inside trtllm_quant_finegrained_fp8_moe_fused{,_prequant}.
+        if fc1_weight_scale.dtype != torch.float32:
+            fc1_weight_scale = fc1_weight_scale.to(torch.float32).contiguous()
+        if fc2_weight_scale.dtype != torch.float32:
+            fc2_weight_scale = fc2_weight_scale.to(torch.float32).contiguous()
+
         del w1_stacked, w2_stacked, w3_stacked
         del w1_scale_stacked, w2_scale_stacked, w3_scale_stacked
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -276,6 +276,15 @@ class ShardingTransformConfig(TransformConfig):
         ),
     )
 
+    use_fused_qk_norm: bool = Field(
+        default=False,
+        description=(
+            "When True, replace paired Q/K sharded_rmsnorm ops with a single "
+            "fused_sharded_qk_rmsnorm op. Uses one allreduce on packed [N,2] variance "
+            "stats instead of two separate allreduces — halves collective overhead."
+        ),
+    )
+
     dist_mapping: dict[str, int] = Field(default_factory=dict)
 
     mapping: Any = Field(default=None)  # Legacy: tensorrt_llm.mapping.Mapping (kept for compat)
@@ -1189,6 +1198,107 @@ class RMSNormShardingInfo(ShardingTransformInfo):
         )
 
 
+class FusedQKNormShardingInfo(ShardingTransformInfo):
+    """Replace a Q/K norm pair with a single lamport_sharded_qk_rmsnorm op.
+
+    Uses one NVLink barrier on packed [N_tokens, 2] variance scalars instead of
+    two separate NCCL all-reduces. target_node is the Q norm node; k_node_name is
+    the K norm node.
+    """
+
+    world_size: int
+    k_node_name: str
+
+    def validate(self, gm: GraphModule = None, node: Node = None) -> bool:
+        if not is_op(node, torch.ops.auto_deploy.torch_rmsnorm):
+            ad_logger.debug(
+                f"FusedQKNormShardingInfo only applies to torch_rmsnorm ops. "
+                f"Got {node.target}. Skipping."
+            )
+            return False
+        return True
+
+    def apply(self, gm: GraphModule, node: Node) -> None:
+        """Replace Q and K torch_rmsnorm nodes with a single lamport_sharded_qk_rmsnorm op.
+
+        Both norm weights are column-sharded. The fused op uses ONE NVLink barrier
+        on packed [N_tokens, 2] variance scalars instead of two separate NCCL all-reduces.
+        """
+        q_node = node
+        node_dict = {n.name: n for n in gm.graph.nodes}
+        if self.k_node_name not in node_dict:
+            ad_logger.warning(
+                f"FusedQKNormShardingInfo: k_node {self.k_node_name} not found, skipping"
+            )
+            return
+
+        k_node = node_dict[self.k_node_name]
+
+        q_input = q_node.args[0]
+        k_input = k_node.args[0]
+        q_weight_node = q_node.args[1]
+        k_weight_node = k_node.args[1]
+        eps = q_node.args[2]
+
+        # Shard both weights along dim 0 (column-shard) AND pre-cast to float32
+        # (the lamport_sharded_qk_rmsnorm CUDA kernel requires fp32 weights).
+        # Pre-casting at load time eliminates a per-call bf16->fp32 kernel launch
+        # (~3-4us each) that would otherwise run every layer every forward step.
+        rank = self.config.rank
+        world_size = self.world_size
+
+        def _shard_and_cast_to_fp32(
+            t: torch.Tensor, rank=rank, world_size=world_size
+        ) -> torch.Tensor:
+            sharded = _split_tensor_for_tp(t, dim=0, rank=rank, world_size=world_size)
+            return sharded.to(torch.float32)
+
+        for weight_node in (q_weight_node, k_weight_node):
+            weight_key = weight_node.target
+            weight_tensor = gm.get_parameter(weight_key)
+            shard_weight_tensor(
+                gm=gm,
+                weight_tensor=weight_tensor,
+                param_key=weight_key,
+                dim=0,
+                rank=rank,
+                world_size=world_size,
+                custom_shard_fn=_shard_and_cast_to_fp32,
+            )
+            ad_logger.debug(f"Sharded QK norm weight (fp32 pre-cast): {weight_key}")
+
+        # Insert fused op after k_node (topologically later of the two).
+        # lamport_sharded_qk_rmsnorm signature: (q, k, weight_q, weight_k, eps, world_size, rank)
+        with gm.graph.inserting_after(k_node):
+            fused_node = gm.graph.call_function(
+                torch.ops.auto_deploy.lamport_sharded_qk_rmsnorm.default,
+                args=(q_input, k_input, q_weight_node, k_weight_node, eps, world_size, rank),
+            )
+
+        # Extract tuple outputs
+        with gm.graph.inserting_after(fused_node):
+            q_out = gm.graph.call_function(operator.getitem, args=(fused_node, 0))
+        with gm.graph.inserting_after(q_out):
+            k_out = gm.graph.call_function(operator.getitem, args=(fused_node, 1))
+
+        # Rewire all downstream uses
+        q_node.replace_all_uses_with(q_out)
+        k_node.replace_all_uses_with(k_out)
+
+        # Fix back the fused_node inputs (replace_all_uses_with may have affected them)
+        fused_node.replace_input_with(q_out, q_input)
+        fused_node.replace_input_with(k_out, k_input)
+
+        # Remove original norm nodes (they now have no users)
+        gm.graph.erase_node(q_node)
+        gm.graph.erase_node(k_node)
+
+        ad_logger.debug(
+            f"Replaced Q/K norm pair ({q_node.name}, {k_node.name}) with "
+            f"lamport_sharded_qk_rmsnorm (world_size={world_size}, rank={rank})"
+        )
+
+
 ########################################################
 #  Transform API classes
 ########################################################
@@ -1376,7 +1486,8 @@ class ShardingTransformExecutor(BaseTransform):
             f"TP={len(transforms.weight_sharding_transforms)}, "
             f"EP={len(transforms.ep_transforms)}, "
             f"BMM={len(transforms.bmm_transforms)}, "
-            f"RMSNorm={len(transforms.rmsnorm_transforms)}"
+            f"RMSNorm={len(transforms.rmsnorm_transforms)}, "
+            f"FusedQKNorm={len(transforms.fused_qk_norm_transforms)}"
         )
         with WeightBiasInfoCache():
             for tp_transform in transforms.weight_sharding_transforms:
@@ -1393,6 +1504,9 @@ class ShardingTransformExecutor(BaseTransform):
                     num_matches += 1
             for rmsnorm_transform in transforms.allgather_rmsnorm_transforms:
                 if check_and_apply(rmsnorm_transform):
+                    num_matches += 1
+            for fused_qk_norm_transform in transforms.fused_qk_norm_transforms:
+                if check_and_apply(fused_qk_norm_transform):
                     num_matches += 1
 
         # post-sharding cleanup transformations
@@ -1419,6 +1533,7 @@ class ShardingTransformContainer(BaseModel):
     ep_transforms: List[EPShardingInfo] = Field(default_factory=list)
     rmsnorm_transforms: List[RMSNormShardingInfo] = Field(default_factory=list)
     allgather_rmsnorm_transforms: List[AllGatherRMSNormShardingInfo] = Field(default_factory=list)
+    fused_qk_norm_transforms: List[FusedQKNormShardingInfo] = Field(default_factory=list)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -1429,6 +1544,7 @@ class ShardingTransformContainer(BaseModel):
             ParameterUpdateInfo: self.parameter_update_transforms,
             RMSNormShardingInfo: self.rmsnorm_transforms,
             AllGatherRMSNormShardingInfo: self.allgather_rmsnorm_transforms,
+            FusedQKNormShardingInfo: self.fused_qk_norm_transforms,
         }
 
     def add(self, transform: ShardingTransformInfo) -> bool:
@@ -1731,7 +1847,9 @@ def shard_weight_tensor(
     """
 
     # Handle fused weights
-    if fused_weight_dims is not None:
+    if custom_shard_fn is not None:
+        f_split = custom_shard_fn
+    elif fused_weight_dims is not None:
 
         def f_split(
             t: torch.Tensor,
@@ -2163,27 +2281,26 @@ def _insert_sharded_moe(
         # - all_reduce sums partial results across GPUs
         # ---------------------------------------------------------------------------
         with gm.graph.inserting_before(node):
-            # Localize expert IDs: selected_experts_local = selected_experts - (ep_rank * experts_per_rank)
-            lower = experts_per_rank * ep_rank
-            selected_experts_local = gm.graph.create_node(
-                "call_function", operator.sub, args=(selected_experts, lower), kwargs={}
-            )
-
-            # Create rank mask: True only for tokens routed to this rank's experts
-            div_node = gm.graph.create_node(
+            # Fused EP mask: produces both (local_indices, masked_weights) in a
+            # single Triton kernel, replacing the 5-kernel aten chain
+            # (sub, floordiv, eq/ge, bool->dtype cast, mul).
+            ep_mask_node = gm.graph.create_node(
                 "call_function",
-                operator.floordiv,
-                args=(selected_experts, experts_per_rank),
+                torch.ops.auto_deploy.moe_ep_mask.default,
+                args=(
+                    selected_experts,
+                    final_scales,
+                    ep_rank,
+                    ep_size,
+                    experts_per_rank,
+                ),
                 kwargs={},
             )
-            comp_op = torch.ge if ep_rank == ep_size - 1 else torch.eq
-            rank_mask = gm.graph.create_node(
-                "call_function", comp_op, args=(div_node, ep_rank), kwargs={}
+            selected_experts_local = gm.graph.create_node(
+                "call_function", operator.getitem, args=(ep_mask_node, 0), kwargs={}
             )
-
-            # Zero out routing weights for remote experts
             final_scales_local = gm.graph.create_node(
-                "call_function", operator.mul, args=(final_scales, rank_mask), kwargs={}
+                "call_function", operator.getitem, args=(ep_mask_node, 1), kwargs={}
             )
 
         args[1] = selected_experts_local
@@ -3047,6 +3164,10 @@ def _shard_qk_norm(
         include=lambda n: n.op == "get_attr",
     )
 
+    # When use_fused_qk_norm is True, collect (user_node, upstream_proj) pairs so
+    # we can match Q and K norm nodes into FusedQKNormShardingInfo instances.
+    qk_norm_candidates: List[Tuple[Node, str]] = []
+
     for weight_node in intermediate_weight_nodes:
         weight_key = weight_node.target
 
@@ -3102,7 +3223,12 @@ def _shard_qk_norm(
             )
             continue
 
-        # Choose between AllGather→norm→slice or AllReduce-of-variance (sharded_rmsnorm)
+        # Choose strategy: fused lamport barrier, AllGather, or NCCL-based sharded_rmsnorm.
+        if config.use_fused_qk_norm:
+            # Collect candidates; pairs are registered after the loop.
+            qk_norm_candidates.append((user_node, upstream_proj))
+            continue
+
         if config.use_allgather_qk_norm:
             info_cls = AllGatherRMSNormShardingInfo
             strategy_label = "allgather->norm->slice"
@@ -3121,6 +3247,25 @@ def _shard_qk_norm(
                 f"Added {info_cls.__name__} for {user_node.name} (strategy: {strategy_label})"
             )
             added_nodes += 1
+
+    # Register paired Q+K fused transforms when use_fused_qk_norm is active.
+    if config.use_fused_qk_norm and qk_norm_candidates:
+        q_norms = [(n, w) for n, w in qk_norm_candidates if "q_proj" in w]
+        k_norms = [(n, w) for n, w in qk_norm_candidates if "k_proj" in w]
+        for (q_node, _), (k_node, _) in zip(q_norms, k_norms):
+            if transform_container.add(
+                FusedQKNormShardingInfo(
+                    target_node=q_node.name,
+                    k_node_name=k_node.name,
+                    config=config,
+                    world_size=world_size,
+                )
+            ):
+                ad_logger.debug(
+                    f"Added FusedQKNormShardingInfo for Q={q_node.name}, K={k_node.name} "
+                    f"(strategy: lamport_sharded_qk_rmsnorm)"
+                )
+                added_nodes += 1
 
     return added_nodes
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -265,6 +265,17 @@ class ShardingTransformConfig(TransformConfig):
         "When None (default), all enable_sharding nodes are processed regardless of layer_type.",
     )
 
+    use_allgather_qk_norm: bool = Field(
+        default=False,
+        description=(
+            "When True, replace sharded_rmsnorm (AllReduce of scalar variance) with an "
+            "AllGather → RMSNorm → Slice pattern for QK norms. "
+            "This avoids the unfused pow+sum+rsqrt kernel sequence. "
+            "Faster than sharded_rmsnorm when NCCL latency dominates over bandwidth cost "
+            "(e.g. small TP=2 with NVLink)."
+        ),
+    )
+
     dist_mapping: dict[str, int] = Field(default_factory=dict)
 
     mapping: Any = Field(default=None)  # Legacy: tensorrt_llm.mapping.Mapping (kept for compat)
@@ -1027,6 +1038,86 @@ def _resolve_ep_cls_from_node(node: Node) -> type[EPShardingInfo]:
     return EPShardingInfo
 
 
+class AllGatherRMSNormShardingInfo(ShardingTransformInfo):
+    """Replace QK-norm with AllGather → RMSNorm → Slice instead of sharded_rmsnorm.
+
+    Alternative to RMSNormShardingInfo: instead of AllReducing a scalar variance,
+    AllGather the full Q/K tensor, run a standard fused RMSNorm, then slice back
+    to the local shard. This avoids the unfused pow+sum+rsqrt kernel sequence at
+    the cost of communicating the full tensor (not just a scalar).
+
+    For small TP (e.g. TP=2) with NCCL latency dominating, AllGather of the
+    full tensor can be faster than AllReduce of the scalar variance because the
+    scalar AR still pays the NCCL latency floor (~13µs) while AllGather of a
+    larger tensor amortises that cost with NVLink bandwidth.
+
+    The weight is NOT sharded; the full norm weight stays on each rank so that
+    the norm can operate on the full gathered tensor.
+    """
+
+    world_size: int
+
+    @classmethod
+    def from_node(cls, node: Node, **kwargs) -> "AllGatherRMSNormShardingInfo":
+        return cls(target_node=node.name, **kwargs)
+
+    def validate(self, gm: GraphModule = None, node: Node = None) -> bool:
+        if not is_op(node, torch.ops.auto_deploy.torch_rmsnorm):
+            ad_logger.debug(
+                f"AllGatherRMSNormShardingInfo only applies to torch_rmsnorm ops. "
+                f"Got {node.target}. Skipping."
+            )
+            return False
+        return True
+
+    def apply(self, gm: GraphModule, node: Node) -> None:
+        """Insert AllGather → torch_rmsnorm → Slice in place of the original norm.
+
+        The weight is left unsharded (full weight on each rank).
+        Graph rewrite:
+          input_node (sharded) → [torch_rmsnorm] → downstream
+        becomes:
+          input_node → [AllGather dim=-1] → [torch_rmsnorm] → [chunk+getitem] → downstream
+        """
+        input_node = node.args[0]
+
+        rank = self.config.rank
+        world_size = self.world_size
+        all_gather_op, _ = _get_dist_ops(self.config.dist_backend)
+
+        # 1. Insert AllGather before the norm: gather shards along last dim → full tensor
+        with gm.graph.inserting_before(node):
+            gathered_node = gm.graph.call_function(
+                all_gather_op,
+                args=(input_node, -1),
+            )
+
+        # 2. Redirect the norm's first arg from the sharded input to the gathered tensor
+        node.replace_input_with(input_node, gathered_node)
+
+        # 3. Chunk the norm output by world_size along the last dim, take this rank's shard
+        with gm.graph.inserting_after(node):
+            chunk_node = gm.graph.call_function(
+                torch.ops.aten.chunk.default,
+                args=(node, world_size, -1),
+            )
+        with gm.graph.inserting_after(chunk_node):
+            slice_node = gm.graph.call_function(
+                operator.getitem,
+                args=(chunk_node, rank),
+            )
+
+        # 4. Redirect all downstream uses of the norm output to the sliced shard,
+        #    then fix chunk_node's input back to the norm node (not the slice_node).
+        node.replace_all_uses_with(slice_node)
+        chunk_node.replace_input_with(slice_node, node)
+
+        ad_logger.debug(
+            f"Replaced torch_rmsnorm with allgather->norm->slice "
+            f"(rank={rank}, world_size={world_size})"
+        )
+
+
 class RMSNormShardingInfo(ShardingTransformInfo):
     """Configuration for replacing RMSNorm with sharded version.
 
@@ -1300,6 +1391,9 @@ class ShardingTransformExecutor(BaseTransform):
             for rmsnorm_transform in transforms.rmsnorm_transforms:
                 if check_and_apply(rmsnorm_transform):
                     num_matches += 1
+            for rmsnorm_transform in transforms.allgather_rmsnorm_transforms:
+                if check_and_apply(rmsnorm_transform):
+                    num_matches += 1
 
         # post-sharding cleanup transformations
         for update_transform in transforms.parameter_update_transforms:
@@ -1324,6 +1418,7 @@ class ShardingTransformContainer(BaseModel):
     bmm_transforms: List[BMMShardingInfo] = Field(default_factory=list)
     ep_transforms: List[EPShardingInfo] = Field(default_factory=list)
     rmsnorm_transforms: List[RMSNormShardingInfo] = Field(default_factory=list)
+    allgather_rmsnorm_transforms: List[AllGatherRMSNormShardingInfo] = Field(default_factory=list)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -1333,6 +1428,7 @@ class ShardingTransformContainer(BaseModel):
             EPShardingInfo: self.ep_transforms,
             ParameterUpdateInfo: self.parameter_update_transforms,
             RMSNormShardingInfo: self.rmsnorm_transforms,
+            AllGatherRMSNormShardingInfo: self.allgather_rmsnorm_transforms,
         }
 
     def add(self, transform: ShardingTransformInfo) -> bool:
@@ -3006,18 +3102,23 @@ def _shard_qk_norm(
             )
             continue
 
-        # Add RMSNormShardingInfo to replace with sharded_rmsnorm
-        # This handles both weight sharding and op replacement in one transform
+        # Choose between AllGather→norm→slice or AllReduce-of-variance (sharded_rmsnorm)
+        if config.use_allgather_qk_norm:
+            info_cls = AllGatherRMSNormShardingInfo
+            strategy_label = "allgather->norm->slice"
+        else:
+            info_cls = RMSNormShardingInfo
+            strategy_label = "sharded_rmsnorm (allreduce of variance)"
+
         if transform_container.add(
-            RMSNormShardingInfo.from_node(
+            info_cls.from_node(
                 user_node,
                 config=config,
                 world_size=world_size,
             )
         ):
             ad_logger.debug(
-                f"Added RMSNormShardingInfo for {user_node.name} "
-                f"(will replace with sharded_rmsnorm for global mean)"
+                f"Added {info_cls.__name__} for {user_node.name} (strategy: {strategy_label})"
             )
             added_nodes += 1
 

--- a/tests/unittest/auto_deploy/multigpu/custom_ops/test_lamport_sharded_qk_rmsnorm.py
+++ b/tests/unittest/auto_deploy/multigpu/custom_ops/test_lamport_sharded_qk_rmsnorm.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functional tests for lamport_sharded_qk_rmsnorm custom op.
+
+This module tests that the lamport_sharded_qk_rmsnorm op produces correct
+numerical results when run across multiple GPUs with column-sharded Q and K inputs.
+
+The op computes RMSNorm on column-sharded Q and K activations using a single
+NVLink barrier (or NCCL fallback) on packed [N_tokens, 2] variance scalars,
+which is mathematically equivalent to running non-sharded global RMSNorm on
+the full Q and K tensors.
+"""
+
+import pickle
+import sys
+import traceback
+
+import cloudpickle
+import pytest
+import torch
+import torch.distributed as dist
+from mpi4py import MPI
+
+from tensorrt_llm._torch.auto_deploy.distributed.common import initialize, is_initialized
+
+# Register this module for cloudpickle serialization for MPI workers
+cloudpickle.register_pickle_by_value(sys.modules[__name__])
+MPI.pickle.__init__(
+    cloudpickle.dumps,
+    cloudpickle.loads,
+    pickle.HIGHEST_PROTOCOL,
+)
+
+# Reuse the MPI executor pool across tests (first test running will leak a thread)
+pytestmark = pytest.mark.threadleak(enabled=False)
+
+
+def _reference_rmsnorm(input: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """Reference (non-sharded) RMSNorm implementation."""
+    input_fp32 = input.to(torch.float32)
+    variance = input_fp32.pow(2).mean(-1, keepdim=True)
+    input_normalized = input_fp32 * torch.rsqrt(variance + eps)
+    return weight * input_normalized.to(input.dtype)
+
+
+def _run_lamport_sharded_qk_rmsnorm_test(
+    tensor_parallel_size: int,
+    batch_size: int = 2,
+    seq_len: int = 8,
+    q_hidden: int = 64,
+    k_hidden: int = 64,
+    eps: float = 1e-6,
+    dtype_str: str = "float16",
+):
+    """Test that lamport_sharded_qk_rmsnorm matches non-sharded global RMSNorm.
+
+    Each rank:
+    1. Creates identical full Q, K, weight_q, weight_k tensors (same seed)
+    2. Computes reference results using non-sharded RMSNorm on the full tensors
+    3. Column-shards Q, K, weight_q, weight_k for this rank
+    4. Calls lamport_sharded_qk_rmsnorm on local shards
+    5. All-gathers outputs and compares with reference
+    """
+    # Import inside worker to avoid cloudpickle serialization issues with torch.ops
+    import tensorrt_llm
+    import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+
+    rank = tensorrt_llm.mpi_rank()
+    world_size = tensor_parallel_size
+    torch.cuda.set_device(rank)
+
+    if not is_initialized():
+        initialize(rank, port=29500)
+
+    dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16}
+    dtype = dtype_map[dtype_str]
+
+    try:
+        torch.manual_seed(42)  # Same seed for reproducibility across ranks
+
+        # Full tensors (same on all ranks due to fixed seed).
+        # Weights are created in the activation dtype so that the reference
+        # _reference_rmsnorm and the op produce results in the same dtype.
+        full_q = torch.randn(batch_size, seq_len, q_hidden, device="cuda", dtype=dtype)
+        full_k = torch.randn(batch_size, seq_len, k_hidden, device="cuda", dtype=dtype)
+        full_weight_q = torch.randn(q_hidden, device="cuda", dtype=dtype)
+        full_weight_k = torch.randn(k_hidden, device="cuda", dtype=dtype)
+
+        # Reference: non-sharded global RMSNorm on full tensors
+        ref_q_out = _reference_rmsnorm(full_q, full_weight_q, eps)
+        ref_k_out = _reference_rmsnorm(full_k, full_weight_k, eps)
+
+        # Column shard: split last dim across ranks
+        local_q_dim = q_hidden // world_size
+        local_k_dim = k_hidden // world_size
+        q_start = rank * local_q_dim
+        k_start = rank * local_k_dim
+
+        local_q = full_q[..., q_start : q_start + local_q_dim].contiguous()
+        local_k = full_k[..., k_start : k_start + local_k_dim].contiguous()
+        # The op accepts float32 weights internally but the test passes the activation dtype;
+        # the Python fallback and CUDA kernel both cast to float32 as needed.
+        local_weight_q = full_weight_q[q_start : q_start + local_q_dim].contiguous()
+        local_weight_k = full_weight_k[k_start : k_start + local_k_dim].contiguous()
+
+        # Call lamport_sharded_qk_rmsnorm via dynamic getattr to avoid cloudpickle capturing torch.ops
+        op = getattr(getattr(torch, "ops"), "auto_deploy").lamport_sharded_qk_rmsnorm
+        local_q_out, local_k_out = op(
+            local_q, local_k, local_weight_q, local_weight_k, eps, world_size, rank
+        )
+
+        # All-gather Q outputs across ranks and compare
+        gathered_q = [torch.zeros_like(local_q_out) for _ in range(world_size)]
+        dist.all_gather(gathered_q, local_q_out)
+        reconstructed_q = torch.cat(gathered_q, dim=-1)
+
+        torch.testing.assert_close(
+            reconstructed_q,
+            ref_q_out,
+            atol=1e-2,
+            rtol=1e-2,
+            msg=f"lamport_sharded_qk_rmsnorm Q output doesn't match reference (rank={rank})",
+        )
+
+        # All-gather K outputs across ranks and compare
+        gathered_k = [torch.zeros_like(local_k_out) for _ in range(world_size)]
+        dist.all_gather(gathered_k, local_k_out)
+        reconstructed_k = torch.cat(gathered_k, dim=-1)
+
+        torch.testing.assert_close(
+            reconstructed_k,
+            ref_k_out,
+            atol=1e-2,
+            rtol=1e-2,
+            msg=f"lamport_sharded_qk_rmsnorm K output doesn't match reference (rank={rank})",
+        )
+
+    except Exception:
+        traceback.print_exc()
+        raise
+
+    return True
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for this test")
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_lamport_sharded_qk_rmsnorm_functional(mpi_pool_executor):
+    """Functional test: verify lamport_sharded_qk_rmsnorm produces correct numerical results."""
+    torch.manual_seed(0)
+    tensor_parallel_size = mpi_pool_executor.num_workers
+
+    results = mpi_pool_executor.map(
+        _run_lamport_sharded_qk_rmsnorm_test,
+        *zip(*[(tensor_parallel_size,)] * tensor_parallel_size),
+    )
+    for r in results:
+        assert r is True
+
+
+def _run_lamport_sharded_qk_rmsnorm_dtype_test(tensor_parallel_size: int, dtype_str: str):
+    """Worker function for dtype parametrized test."""
+    return _run_lamport_sharded_qk_rmsnorm_test(tensor_parallel_size, dtype_str=dtype_str)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for this test")
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+@pytest.mark.parametrize("dtype_str", ["float16", "bfloat16"])
+def test_lamport_sharded_qk_rmsnorm_dtypes(mpi_pool_executor, dtype_str):
+    """Test lamport_sharded_qk_rmsnorm with float16 and bfloat16."""
+    torch.manual_seed(0)
+    tensor_parallel_size = mpi_pool_executor.num_workers
+
+    results = mpi_pool_executor.map(
+        _run_lamport_sharded_qk_rmsnorm_dtype_test,
+        *zip(*[(tensor_parallel_size, dtype_str)] * tensor_parallel_size),
+    )
+    for r in results:
+        assert r is True
+
+
+def _run_lamport_sharded_qk_rmsnorm_dim_test(
+    tensor_parallel_size: int, q_hidden: int, k_hidden: int
+):
+    """Worker function for asymmetric Q/K dim test."""
+    return _run_lamport_sharded_qk_rmsnorm_test(
+        tensor_parallel_size, q_hidden=q_hidden, k_hidden=k_hidden
+    )
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for this test")
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+@pytest.mark.parametrize("q_hidden,k_hidden", [(64, 64), (128, 64)])
+def test_lamport_sharded_qk_rmsnorm_dims(mpi_pool_executor, q_hidden, k_hidden):
+    """Test lamport_sharded_qk_rmsnorm with symmetric and asymmetric Q/K dimensions."""
+    torch.manual_seed(0)
+    tensor_parallel_size = mpi_pool_executor.num_workers
+
+    results = mpi_pool_executor.map(
+        _run_lamport_sharded_qk_rmsnorm_dim_test,
+        *zip(*[(tensor_parallel_size, q_hidden, k_hidden)] * tensor_parallel_size),
+    )
+    for r in results:
+        assert r is True

--- a/tests/unittest/auto_deploy/multigpu/custom_ops/test_sharded_rmsnorm.py
+++ b/tests/unittest/auto_deploy/multigpu/custom_ops/test_sharded_rmsnorm.py
@@ -169,3 +169,99 @@ def test_sharded_rmsnorm_different_dtypes(mpi_pool_executor, dtype_str):
     )
     for r in results:
         assert r is True
+
+
+def _run_allgather_rmsnorm_test(
+    tensor_parallel_size: int,
+    batch_size: int = 2,
+    seq_len: int = 8,
+    hidden_size: int = 64,
+    eps: float = 1e-6,
+    dtype_str: str = "float16",
+):
+    """Test AllGather QK RMSNorm against a full-tensor reference.
+
+    Each rank:
+    1. Creates identical full input and weight tensors
+    2. Column-shards the activation for this rank
+    3. All-gathers the local shard to reconstruct the full activation
+    4. Applies the selected RMSNorm op to the full activation
+    5. Slices the local shard back out and compares the reconstructed output
+       against the corresponding full-tensor reference
+    """
+    import tensorrt_llm
+    import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+
+    rank = tensorrt_llm.mpi_rank()
+    world_size = tensor_parallel_size
+    torch.cuda.set_device(rank)
+
+    if not is_initialized():
+        initialize(rank, port=29500)
+
+    dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16}
+    dtype = dtype_map[dtype_str]
+
+    try:
+        torch.manual_seed(42)
+
+        full_input = torch.randn(batch_size, seq_len, hidden_size, device="cuda", dtype=dtype)
+        full_weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+
+        reference_output = _reference_rmsnorm(full_input, full_weight, eps)
+
+        local_hidden_size = hidden_size // world_size
+        start_idx = rank * local_hidden_size
+        end_idx = start_idx + local_hidden_size
+        local_input = full_input[..., start_idx:end_idx].contiguous()
+
+        gathered_inputs = [torch.zeros_like(local_input) for _ in range(world_size)]
+        dist.all_gather(gathered_inputs, local_input)
+        gathered_input = torch.cat(gathered_inputs, dim=-1)
+
+        rmsnorm_op = getattr(getattr(torch, "ops"), "auto_deploy")
+        full_output = rmsnorm_op.torch_rmsnorm(gathered_input, full_weight, eps)
+        assert full_output.dtype == dtype
+
+        local_output = torch.chunk(full_output, world_size, dim=-1)[rank].contiguous()
+
+        gathered_outputs = [torch.zeros_like(local_output) for _ in range(world_size)]
+        dist.all_gather(gathered_outputs, local_output)
+        reconstructed_output = torch.cat(gathered_outputs, dim=-1)
+
+        torch.testing.assert_close(
+            reconstructed_output,
+            reference_output,
+            atol=1e-2,
+            rtol=1e-2,
+            msg=f"AllGather RMSNorm result doesn't match reference (rank={rank})",
+        )
+    except Exception:
+        traceback.print_exc()
+        raise
+
+    return True
+
+
+def _run_allgather_rmsnorm_hidden_size_test(tensor_parallel_size: int, hidden_size: int):
+    """Worker function for hidden-size-parametrized AllGather RMSNorm tests."""
+    return _run_allgather_rmsnorm_test(
+        tensor_parallel_size,
+        hidden_size=hidden_size,
+    )
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for this test")
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+@pytest.mark.parametrize("hidden_size", [64, 128, 256])
+def test_allgather_rmsnorm_different_hidden_sizes(mpi_pool_executor, hidden_size):
+    """Test the AllGather QK RMSNorm path across hidden sizes."""
+    torch.manual_seed(0)
+    tensor_parallel_size = mpi_pool_executor.num_workers
+
+    results = mpi_pool_executor.map(
+        _run_allgather_rmsnorm_hidden_size_test,
+        *zip(*[(tensor_parallel_size, hidden_size)] * tensor_parallel_size),
+    )
+    for r in results:
+        assert r is True

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_rmsnorm_sharding.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_rmsnorm_sharding.py
@@ -18,6 +18,8 @@ torch_rmsnorm ops based on weight shape and position in the graph:
 These are graph-level unit tests that verify the transform logic.
 """
 
+import operator
+
 import torch
 import torch.nn as nn
 
@@ -146,6 +148,45 @@ def count_ops(gm, op) -> int:
     return count
 
 
+def count_targets(gm, target) -> int:
+    """Count the number of call_function nodes with an exact target."""
+    count = 0
+    for node in gm.graph.nodes:
+        if node.op == "call_function" and node.target == target:
+            count += 1
+    return count
+
+
+def make_sharding_optimizer(
+    *,
+    use_allgather_qk_norm: bool = False,
+    run_shape_prop: bool = True,
+    dist_backend: str = "auto",
+) -> InferenceOptimizer:
+    """Create a sharding optimizer configured for RMSNorm transform tests."""
+    return InferenceOptimizer(
+        None,
+        {
+            "detect_sharding": {
+                "stage": "sharding",
+                "simple_shard_only": False,
+                "sharding_source": ["manual", "factory", "heuristic"],
+                "support_partial_config": True,
+                "sharding_scope": ["tp", "ep", "bmm"],
+                "shard_all_unprocessed": True,
+                "allreduce_strategy": "NCCL",
+                "dist_backend": dist_backend,
+                "requires_shape_prop": True,
+                "use_allgather_qk_norm": use_allgather_qk_norm,
+            },
+            "sharding_transform_executor": {
+                "stage": "sharding",
+                "run_shape_prop": run_shape_prop,
+            },
+        },
+    )
+
+
 # =============================================================================
 # Tests
 # =============================================================================
@@ -174,26 +215,7 @@ class TestRMSNormShardingTransform:
         assert before_sharded == 0, f"Expected 0 sharded_rmsnorm before, got {before_sharded}"
 
         # Apply sharding transform with world_size=2
-        optimizer = InferenceOptimizer(
-            None,
-            {
-                "detect_sharding": {
-                    "stage": "sharding",
-                    "simple_shard_only": False,
-                    "sharding_source": ["manual", "factory", "heuristic"],
-                    "support_partial_config": True,
-                    "sharding_scope": ["tp", "ep", "bmm"],
-                    "shard_all_unprocessed": True,
-                    "allreduce_strategy": "NCCL",
-                    "dist_backend": "auto",
-                    "requires_shape_prop": True,
-                },
-                "sharding_transform_executor": {
-                    "stage": "sharding",
-                    "run_shape_prop": True,
-                },
-            },
-        )
+        optimizer = make_sharding_optimizer()
         optimizer.shared_config.local_rank = 0
         optimizer.shared_config.world_size = 2
         gm_transformed = optimizer(None, gm)
@@ -207,6 +229,38 @@ class TestRMSNormShardingTransform:
             f"Expected 2 sharded_rmsnorm after transform, got {after_sharded}. "
             f"Remaining torch_rmsnorm: {after_rmsnorm}"
         )
+        assert gm_transformed.get_parameter("q_norm_weight").shape == torch.Size([32])
+        assert gm_transformed.get_parameter("k_norm_weight").shape == torch.Size([32])
+
+    def test_full_hidden_norm_transformed_to_allgather_norm(self):
+        """Test that the AllGather QK norm path rewrites to gather->norm->slice.
+
+        When use_allgather_qk_norm is enabled:
+        - Q/K norms should use all-gather + torch_rmsnorm + local slice
+        - The original torch_rmsnorm nodes should remain in place with gathered inputs
+        - Q/K norm weights should remain unsharded
+        """
+        model = SimpleAttentionWithQKNorm(use_full_hidden_norm=True).to("cuda", dtype=torch.float16)
+        x = torch.randn(1, 8, 64, device="cuda", dtype=torch.float16)
+
+        gm = torch_export_to_gm(model, args=(x,), clone=True)
+
+        optimizer = make_sharding_optimizer(
+            use_allgather_qk_norm=True,
+            run_shape_prop=False,
+            dist_backend="torch",
+        )
+        optimizer.shared_config.local_rank = 0
+        optimizer.shared_config.world_size = 2
+        gm_transformed = optimizer(None, gm)
+
+        assert count_ops(gm_transformed, torch.ops.auto_deploy.torch_dist_all_gather.default) == 2
+        assert count_ops(gm_transformed, torch.ops.auto_deploy.torch_rmsnorm.default) == 2
+        assert count_ops(gm_transformed, torch.ops.auto_deploy.sharded_rmsnorm.default) == 0
+        assert count_ops(gm_transformed, torch.ops.aten.chunk.default) == 2
+        assert count_targets(gm_transformed, operator.getitem) == 2
+        assert gm_transformed.get_parameter("q_norm_weight").shape == torch.Size([64])
+        assert gm_transformed.get_parameter("k_norm_weight").shape == torch.Size([64])
 
     def test_per_head_norm_not_transformed(self):
         """Test that per-head norm RMSNorm ops are NOT replaced.
@@ -229,26 +283,7 @@ class TestRMSNormShardingTransform:
 
         # Apply sharding transform with world_size=2
         # Using the same config as default.yaml for detect_sharding and sharding_transform_executor
-        optimizer = InferenceOptimizer(
-            None,
-            {
-                "detect_sharding": {
-                    "stage": "sharding",
-                    "simple_shard_only": False,
-                    "sharding_source": ["manual", "factory", "heuristic"],
-                    "support_partial_config": True,
-                    "sharding_scope": ["tp", "ep", "bmm"],
-                    "shard_all_unprocessed": True,
-                    "allreduce_strategy": "NCCL",
-                    "dist_backend": "auto",
-                    "requires_shape_prop": True,
-                },
-                "sharding_transform_executor": {
-                    "stage": "sharding",
-                    "run_shape_prop": True,
-                },
-            },
-        )
+        optimizer = make_sharding_optimizer()
         # Set world_size and rank on shared_config
         optimizer.shared_config.local_rank = 0
         optimizer.shared_config.world_size = 2
@@ -288,26 +323,7 @@ class TestRMSNormShardingTransform:
         assert before_rmsnorm == 1, f"Expected 1 torch_rmsnorm before, got {before_rmsnorm}"
 
         # Apply sharding transform with world_size=4 (like the failing Llama test)
-        optimizer = InferenceOptimizer(
-            None,
-            {
-                "detect_sharding": {
-                    "stage": "sharding",
-                    "simple_shard_only": False,
-                    "sharding_source": ["manual", "factory", "heuristic"],
-                    "support_partial_config": True,
-                    "sharding_scope": ["tp", "ep", "bmm"],
-                    "shard_all_unprocessed": True,
-                    "allreduce_strategy": "NCCL",
-                    "dist_backend": "auto",
-                    "requires_shape_prop": True,
-                },
-                "sharding_transform_executor": {
-                    "stage": "sharding",
-                    "run_shape_prop": True,
-                },
-            },
-        )
+        optimizer = make_sharding_optimizer()
         optimizer.shared_config.local_rank = 0
         optimizer.shared_config.world_size = 4
         gm_transformed = optimizer(None, gm)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_moe_ep_mask.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_moe_ep_mask.py
@@ -65,6 +65,13 @@ def test_moe_ep_mask_matches_reference(
     assert out_idx.shape == indices.shape
     assert out_w.shape == weights.shape
 
+    # moe_ep_mask is a load-bearing contiguity guarantee — downstream consumers
+    # (e.g. fp8_block_scale_moe_runner) require int32 + contiguous selected_experts
+    # and contiguous routing_weights. If this breaks, the prequant MoE op in
+    # trtllm_moe.py can quietly feed strided tensors into the C++ runner.
+    assert out_idx.is_contiguous()
+    assert out_w.is_contiguous()
+
     torch.testing.assert_close(out_idx, ref_idx)
     torch.testing.assert_close(out_w, ref_w)
 
@@ -83,5 +90,7 @@ def test_moe_ep_mask_3d_shape():
         indices, weights, ep_rank, ep_size, experts_per_rank
     )
 
+    assert out_idx.is_contiguous()
+    assert out_w.is_contiguous()
     torch.testing.assert_close(out_idx, ref_idx)
     torch.testing.assert_close(out_w, ref_w)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_moe_ep_mask.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_moe_ep_mask.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit test for auto_deploy::moe_ep_mask.
+
+The Triton kernel replaces the aten chain (sub, floordiv, eq/ge, cast, mul) used
+by the MoE EP-sharding transform. Correctness is verified against that chain.
+"""
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+
+
+def _reference_moe_ep_mask(
+    selected_experts: torch.Tensor,
+    top_k_weights: torch.Tensor,
+    ep_rank: int,
+    ep_size: int,
+    experts_per_rank: int,
+):
+    """Matches the aten-op chain in sharding.py (AllReduce paradigm)."""
+    lower = ep_rank * experts_per_rank
+    local_indices = selected_experts - lower
+    group = selected_experts // experts_per_rank
+    if ep_rank == ep_size - 1:
+        rank_mask = group >= ep_rank
+    else:
+        rank_mask = group == ep_rank
+    masked_weights = top_k_weights * rank_mask.to(top_k_weights.dtype)
+    return local_indices, masked_weights
+
+
+@pytest.mark.parametrize("weights_dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("indices_dtype", [torch.int32, torch.int64])
+@pytest.mark.parametrize(
+    "ep_rank,ep_size,num_experts",
+    [
+        (0, 2, 256),  # even split, first rank (uses ==)
+        (1, 2, 256),  # even split, last rank (uses >=)
+        (0, 4, 256),  # 4-way split, first rank
+        (3, 4, 256),  # 4-way split, last rank
+        (1, 4, 256),  # 4-way split, middle rank
+    ],
+)
+@pytest.mark.parametrize("M,top_k", [(1, 8), (20, 8), (256, 8), (1024, 8)])
+def test_moe_ep_mask_matches_reference(
+    M, top_k, ep_rank, ep_size, num_experts, indices_dtype, weights_dtype
+):
+    device = "cuda"
+    experts_per_rank = num_experts // ep_size
+    torch.manual_seed(42 + ep_rank * 100 + M)
+
+    indices = torch.randint(0, num_experts, (M, top_k), dtype=indices_dtype, device=device)
+    weights = torch.randn(M, top_k, dtype=weights_dtype, device=device)
+
+    ref_idx, ref_w = _reference_moe_ep_mask(indices, weights, ep_rank, ep_size, experts_per_rank)
+    out_idx, out_w = torch.ops.auto_deploy.moe_ep_mask(
+        indices, weights, ep_rank, ep_size, experts_per_rank
+    )
+
+    assert out_idx.dtype == indices.dtype
+    assert out_w.dtype == weights.dtype
+    assert out_idx.shape == indices.shape
+    assert out_w.shape == weights.shape
+
+    torch.testing.assert_close(out_idx, ref_idx)
+    torch.testing.assert_close(out_w, ref_w)
+
+
+def test_moe_ep_mask_3d_shape():
+    """Confirm leading-dim flatten works for [B, S, top_k] inputs."""
+    device = "cuda"
+    ep_rank, ep_size, experts_per_rank = 0, 2, 128
+    num_experts = ep_size * experts_per_rank
+
+    indices = torch.randint(0, num_experts, (4, 32, 8), dtype=torch.int32, device=device)
+    weights = torch.randn(4, 32, 8, dtype=torch.bfloat16, device=device)
+
+    ref_idx, ref_w = _reference_moe_ep_mask(indices, weights, ep_rank, ep_size, experts_per_rank)
+    out_idx, out_w = torch.ops.auto_deploy.moe_ep_mask(
+        indices, weights, ep_rank, ep_size, experts_per_rank
+    )
+
+    torch.testing.assert_close(out_idx, ref_idx)
+    torch.testing.assert_close(out_w, ref_w)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/rope/test_partial_rope_fused.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/rope/test_partial_rope_fused.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit test for auto_deploy::partial_rope_fused.
+
+Verifies the fused Triton kernel against the reference `apply_rotary_pos_emb`
+implementation in tensorrt_llm._torch.auto_deploy.models.custom.modeling_minimax_m2
+across typical MiniMax-M2.7 shapes and dtypes.
+"""
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+
+
+def _ref_rotate_half(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _ref_partial_rope(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    unsqueeze_dim: int = 2,
+):
+    """Reference partial RoPE — matches modeling_minimax_m2.apply_rotary_pos_emb."""
+    cos_u = cos.unsqueeze(unsqueeze_dim)
+    sin_u = sin.unsqueeze(unsqueeze_dim)
+    rotary_dim = cos.shape[-1]
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+    q_embed = (q_rot * cos_u) + (_ref_rotate_half(q_rot) * sin_u)
+    k_embed = (k_rot * cos_u) + (_ref_rotate_half(k_rot) * sin_u)
+    return (
+        torch.cat([q_embed, q_pass], dim=-1),
+        torch.cat([k_embed, k_pass], dim=-1),
+    )
+
+
+def _make_neox_cos_sin(n_tokens: int, rotary_dim: int, dtype, device):
+    """Produce cos/sin in NeoX duplicated format (emb = cat(freqs, freqs, -1))."""
+    base = 10000.0
+    inv_freq = 1.0 / (base ** (torch.arange(0, rotary_dim, 2, dtype=torch.float32) / rotary_dim))
+    t = torch.arange(n_tokens, dtype=torch.float32)
+    freqs = torch.outer(t, inv_freq)
+    emb = torch.cat((freqs, freqs), dim=-1)
+    cos = emb.cos().to(dtype).to(device)
+    sin = emb.sin().to(dtype).to(device)
+    return cos, sin
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "B,S,H_q,H_kv,Dh,Dr",
+    [
+        (1, 1, 24, 4, 128, 64),  # MiniMax-M2.7 TP=2 decode batch=1
+        (1, 32, 24, 4, 128, 64),  # decode batch=32
+        (1, 1024, 24, 4, 128, 64),  # prefill
+        (2, 64, 48, 8, 128, 64),  # untensor-sharded M2.7
+        (1, 16, 8, 8, 64, 64),  # full RoPE (Dr == Dh, no pass-through)
+    ],
+)
+def test_partial_rope_fused_matches_reference(B, S, H_q, H_kv, Dh, Dr, dtype):
+    device = "cuda"
+    torch.manual_seed(42 + B * 7 + S)
+
+    q = torch.randn(B, S, H_q, Dh, dtype=dtype, device=device)
+    k = torch.randn(B, S, H_kv, Dh, dtype=dtype, device=device)
+    cos_all, sin_all = _make_neox_cos_sin(B * S, Dr, dtype, device)
+    cos = cos_all.view(B, S, Dr)
+    sin = sin_all.view(B, S, Dr)
+
+    ref_q, ref_k = _ref_partial_rope(q, k, cos, sin, unsqueeze_dim=2)
+    out_q, out_k = torch.ops.auto_deploy.partial_rope_fused(q, k, cos, sin)
+
+    assert out_q.shape == ref_q.shape
+    assert out_k.shape == ref_k.shape
+    assert out_q.dtype == dtype
+    assert out_k.dtype == dtype
+
+    # Tolerances: bf16 has ~3e-3 unit in the last place for products + sums
+    atol = 1e-2 if dtype == torch.bfloat16 else 5e-3
+    rtol = 1e-2 if dtype == torch.bfloat16 else 5e-3
+    torch.testing.assert_close(out_q, ref_q, atol=atol, rtol=rtol)
+    torch.testing.assert_close(out_k, ref_k, atol=atol, rtol=rtol)
+
+
+def test_partial_rope_fused_3d_flat():
+    """Leading dims may be already flattened [M, H, Dh] instead of [B, S, H, Dh]."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    M, H_q, H_kv, Dh, Dr = 64, 24, 4, 128, 64
+    q = torch.randn(M, H_q, Dh, dtype=dtype, device=device)
+    k = torch.randn(M, H_kv, Dh, dtype=dtype, device=device)
+    cos, sin = _make_neox_cos_sin(M, Dr, dtype, device)
+
+    ref_q, ref_k = _ref_partial_rope(q, k, cos, sin, unsqueeze_dim=1)
+    out_q, out_k = torch.ops.auto_deploy.partial_rope_fused(q, k, cos, sin)
+
+    torch.testing.assert_close(out_q, ref_q, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(out_k, ref_k, atol=1e-2, rtol=1e-2)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sharded QK RMS normalization with cross-GPU synchronization for distributed inference
  * Added packed QK norm with AllReduce for flexible normalization strategies
  * Added fine-grained FP8 quantization for MoE and linear operations with pre-quantization support
  * Added fused partial rotary position embedding and expert-parallel masking operations

* **Improvements**
  * Enhanced model optimization with new graph transforms for quantization fusion
  * Updated model configurations with improved performance parameters and new normalization options

* **Tests**
  * Added multi-GPU and single-GPU functional tests for new operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This branch adds AutoDeploy perf optimizations for MiniMax-M2 / MiniMax-M2.7 decode. The wins come from new fused custom ops, AD graph transforms that wire those ops in, an alternate sharding strategy for QK-norm, and a fix to the sharding-config plumbing that was silently disabling existing AllReduce+RMSNorm fusion.

## Changes

### Fused custom ops (Triton)
- **`partial_rope_fused`** — fused partial-RoPE (NeoX) for MiniMax-M2 style models. Replaces `slice + flashinfer_rope + 3× CatArrayBatchedCopy` with 2 launches (Q and K).
- **`rms_norm_fp8_1x128`** — fused RMSNorm + per-1×128-block FP8 quant; feeds `trtllm_finegrained_fp8_linear_prequant` so Q/K/V projections skip an internal `direct_copy + scale_1x128`.
- **`qk_norm_packed`** — packed pre/post QK RMSNorm around a small NCCL AllReduce on `[N,2]` fp32 variance; 3 Triton + 1 NCCL kernel per call, default QK-norm path.
- **`moe_ep_mask`** — fused EP sharding mask (sub/floordiv/eq/cast/mul → 1 kernel).
- **`triton_sharded_qk_norm`** — fallback for AllGather-based QK norm.
- **`trtllm_quant_finegrained_fp8_moe_fused_prequant`** — MoE variant accepting pre-quantized FP8 + scale inputs.

### AD transforms
- `fuse_rmsnorm_fp8_finegrained`: RMSNorm + N× finegrained_fp8_linear → `rms_norm_fp8_1x128` + N× linear_prequant.
- `bypass_qk_split_for_lamport`: feed strided views of fused QKV GEMM into lamport sharded QK rmsnorm without `.contiguous()`.
- `fuse_fp8_prequant_shared`: single `fp8_quantize_1x128` shared across router + MoE op.
- MoE EP sharding now emits one `moe_ep_mask` node instead of 4 ATen ops.
- New `AllGatherRMSNormShardingInfo`: `AllGather(Q/K, dim=-1) → fused RMSNorm → Slice` instead of per-norm scalar AllReduce — trades 10× latency-bound 128B AllReduces for bandwidth-bound AllGathers on NVLink.
- lm_head TP sharding (column-shard along vocab + AllGather) via `detect_sharding` + `simple_shard_filter="lm_head"`.

### MiniMax-M2 model / patch
- Routing rewritten to use `trtllm.dsv3_router_gemm_op` (or fp32 `F.linear` fallback) + `trtllm.noaux_tc_op`, replacing the sigmoid/topk/gather Python sequence.
- `apply_rotary_pos_emb` routes directly into `partial_rope_fused`.

### Cleanups
- `trtllm_quant_finegrained_fp8_moe_fused{,_prequant}`: skip per-call `.int().contiguous()` / dtype casts when inputs already match; skip output cast when dtypes match.
- `fuse_finegrained_fp8_moe`: pre-cast fc1/fc2 weight scales to fp32 at load time (eliminates 2 per-call launches per layer).

### Fix
- `FuseAllreduceResidualRMSNorm` previously read `shared_config.dist_config.allreduce_strategy` (hardcoded NCCL default) instead of the per-transform sharding container (which holds the YAML value, e.g. `SYMM_MEM`). Result: it compiled NCCL patterns against a SYMM_MEM graph, matched 0 sites, and left ~1 unfused AllReduce + RMSNorm per layer (~500µs/iter on 62-layer M2.7 TP=4 / B200). Now reads the container first, falling back to dist_config. Restores all 62 matches and halves AllReduce count in the compiled graph.
- Restore MiniMax-M2 router fallback semantics.

### Configs
- `minimax_m2.7.yaml` updated to TP=8, max_seq_len=17408, max_num_tokens=8192, max_batch_size=32, padded CUDA-graph batch sizes `[1,2,4,8,16,32]`; enables fusion transforms + lm_head sharding.
- New `minimax_m2.7_tp2_fused_qknorm.yaml` and `minimax_m2.7_tp2_reduced_allgather_qknorm.yaml` debug configs.
- New knob `detect_sharding.use_allgather_qk_norm`.

## Measured impact (MiniMax-M2.7, B200)

- AllGather QK-norm vs sharded_rmsnorm (TP=2, 5-layer reduced): **6935.7 → 7346.8 tok/s (+5.9%)**, P50 729 → 688 ms (-5.7%).
- Partial-RoPE + lm_head TP + MoE cleanup (TP=2, 5-layer reduced): kernels/iter 383 → 347 (-9.4%); ad_run_forward GPU active down ~250 µs/iter pre-lm_head, additional ~80 µs after; lm_head wall-clock 187 µs → ~104 µs (+ ~40 µs AllGather), roughly 2× on the largest unfused decode kernel.
- Sharding-strategy fix: ~500 µs/iter recovered on the 62-layer full TP=4 config; halves AllReduce count in the compiled graph.

## Tests

- `test_moe_ep_mask` (Triton vs ATen reference)
- `test_lamport_sharded_qk_rmsnorm` (multigpu)
- `partial_rope_fused`: 11 parametric cases (decode batches 1/32/1024 incl. `Dr==Dh` full-rope)

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
