### PR TITLE
[TRTINFRA-7677][build] Pin deps for CI using a constraints file

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,8 +1,99 @@
-# These vulnerabilities were inherited from the base image (pytorch:25.12-py3) and should be removed when the base image
-# is updated.
+# Pinned versions of pure-Python dependencies for reproducible CI/dev builds.
+#
+# This file is a pip *constraints* file -- only pins already-requested packages
+# to a specific version, never triggers installs on its own. It is applied via
+# `-c constraints.txt` from requirements.txt and requirements-dev.txt.
+#
+# Scope:
+#   - Pure-Python deps we install ourselves (pandas, click, fastapi, ...).
+#   - Container-provided packages (torch, triton, tensorrt, nixl, nccl,
+#     cuda-*, nvidia-*, flashinfer, modelopt, cutlass-dsl, ...) are
+#     DELIBERATELY OMITTED -- they are inherited via
+#     `virtualenv --system-site-packages` from the NGC base image.
+#   - Packages already pinned in requirements.txt / requirements-dev.txt are
+#     omitted to avoid duplication.
+#
+# Versions below correspond to the NGC container used by current CI. Regenerate
+# inside the target container via:  python scripts/generate_constraints.py
+#
+# ---------------------------------------------------------------------------
+# Security WARs inherited from the base image (pytorch:<base_tag>). Remove
+# these entries when the base image is updated past the advisory. These three
+# entries are also force-installed by docker/Dockerfile.multi to upgrade the
+# vulnerable versions shipped in the base image.
+# ---------------------------------------------------------------------------
 # WAR against https://github.com/advisories/GHSA-8rrh-rw8j-w5fx
 wheel>=0.46.2
 # WAR against https://github.com/advisories/GHSA-qjxf-f2mg-c6mc
 tornado>=6.5.5
 # WAR against https://github.com/advisories/GHSA-3936-cmfr-pm3m
 black>=26.3.1
+
+# ---------------------------------------------------------------------------
+# Pins from requirements.txt
+# ---------------------------------------------------------------------------
+build~=1.4
+colored~=2.3
+lark~=1.3
+mpi4py~=3.1
+graphviz~=0.21
+openai~=2.31
+polygraphy~=0.49
+psutil~=7.0
+pulp~=3.3
+pandas~=2.3
+pillow~=12.1
+optimum~=2.1
+evaluate~=0.4
+click~=8.3
+click_option_group~=0.5
+aenum~=3.1
+pyzmq~=26.4
+uvicorn~=0.44
+ordered-set~=4.1
+patchelf~=0.17
+einops~=0.8
+opencv-python-headless~=4.13
+jsonschema~=4.26
+backoff~=2.2
+nvtx~=0.2
+matplotlib~=3.10
+meson~=1.11
+ninja~=1.13
+blake3~=1.0
+soundfile~=0.13
+tiktoken~=0.12
+blobfile~=3.2
+plotly~=6.4
+numexpr~=2.14
+partial_json_parser~=0.2
+llist~=0.7
+python-multipart~=0.0.26
+
+# ---------------------------------------------------------------------------
+# Pins from requirements-dev.txt
+# ---------------------------------------------------------------------------
+mako~=1.3
+oyaml~=1.0
+parameterized~=0.9
+pre-commit~=4.5
+pybind11~=3.0
+pybind11-stubgen~=2.5
+pytest~=9.0
+pytest-asyncio~=1.3
+pytest-cov~=7.1
+pytest-csv~=3.0
+pytest-env~=1.6
+pytest-forked~=1.6
+pytest-xdist~=3.8
+pytest-timeout~=2.4
+pytest-split~=0.11
+pytest-mock~=3.15
+pytest-threadleak~=0.5
+pytest-unused-fixtures~=0.3
+rouge_score~=0.1
+cloudpickle~=3.1
+pytest-rerunfailures~=16.1
+docstring_parser~=0.17
+cxxfilt~=0.3
+line_profiler~=5.0

--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -49,12 +49,16 @@ RUN --mount=type=bind,source=docker/common,target=/opt/docker/common \
     bash /opt/docker/common/install.sh --base --cmake --ccache --cuda_toolkit \
          --tensorrt --polygraphy --mpi4py --pytorch --opencv
 
-# Install constraints after install.sh so cleanup() doesn't delete the file mid-RUN
+# Install constraints after install.sh so cleanup() doesn't delete the file mid-RUN.
+# Only the security-WAR packages are force-reinstalled here; constraints.txt as a
+# whole is a pip constraint file (applied via -c at other install sites) and is
+# not meant to trigger installs on its own.
 COPY constraints.txt /tmp/constraints.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
-    # WAR: uninstall dependencies that has vulnerability
+    # WAR: uninstall dependencies that have vulnerabilities in the base image
     pip3 uninstall -y tornado black nbconvert || true && \
-    pip3 install --ignore-installed --no-cache-dir -r /tmp/constraints.txt && \
+    pip3 install --ignore-installed --no-cache-dir \
+        wheel tornado black -c /tmp/constraints.txt && \
     rm /tmp/constraints.txt
 
 # Install UCX, NIXL, etcd

--- a/examples/ray_orchestrator/requirements.txt
+++ b/examples/ray_orchestrator/requirements.txt
@@ -1,3 +1,3 @@
 -c ../constraints.txt
-tensorrt_llm>=0.0.0.dev0
-ray[default]
+# Pulls tensorrt_llm plus the `ray` optional extra (pin lives in setup.py).
+tensorrt_llm[ray]>=0.0.0.dev0

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2562,11 +2562,12 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
             sh "cd ${llmSrc} && sed -i 's#tensorrt~=.*\$#tensorrt#g' requirements.txt && cat requirements.txt"
         }
         trtllm_utils.llmExecStepWithRetry(pipeline, script: "cd ${llmSrc} && pip3 install -r requirements-dev.txt")
-        if (stageName.contains("-Ray-")) {
-            trtllm_utils.llmExecStepWithRetry(pipeline, script: "pip3 install ray[default]==2.54.1")
-        }
         if (!skipInstallWheel) {
             trtllm_utils.llmExecStepWithRetry(pipeline, script: "cd ${llmPath} && pip3 install --force-reinstall --no-deps TensorRT-LLM/tensorrt_llm-*.whl")
+        }
+        if (stageName.contains("-Ray-")) {
+            // Ray is an optional extra defined in setup.py; pin lives there.
+            trtllm_utils.llmExecStepWithRetry(pipeline, script: "cd ${llmSrc} && pip3 install 'tensorrt_llm[ray]' -c constraints.txt")
         }
 
         trtllm_utils.llmExecStepWithRetry(pipeline, script: "mkdir -p /opt/tritonserver/backends/tensorrtllm")

--- a/jenkins/scripts/perf/local/slurm_install.sh
+++ b/jenkins/scripts/perf/local/slurm_install.sh
@@ -65,15 +65,15 @@ slurm_install_setup() {
 
             if [ -n "$WHEEL_FILE" ]; then
                 echo "Found wheel: $WHEEL_FILE"
-                retry_command pip install --retries 10 "$WHEEL_FILE"
+                retry_command pip install --retries 10 "$WHEEL_FILE" -c "$llmSrcNode/constraints.txt"
                 retry_command pip install --retries 10 -r "$llmSrcNode/requirements-dev.txt"
             else
                 echo "ERROR: No wheel file found in $llmSrcNode/build, falling back to source install"
-                retry_command bash -c "cd $llmSrcNode && pip install --retries 10 -e . && pip install --retries 10 -r requirements-dev.txt"
+                retry_command bash -c "cd $llmSrcNode && pip install --retries 10 -e . -c constraints.txt && pip install --retries 10 -r requirements-dev.txt"
             fi
         else
             # Source installation mode (default)
-            retry_command bash -c "cd $llmSrcNode && pip install --retries 10 -e . && pip install --retries 10 -r requirements-dev.txt"
+            retry_command bash -c "cd $llmSrcNode && pip install --retries 10 -e . -c constraints.txt && pip install --retries 10 -r requirements-dev.txt"
         fi
 
         cd /tmp

--- a/jenkins/scripts/slurm_install.sh
+++ b/jenkins/scripts/slurm_install.sh
@@ -25,11 +25,12 @@ slurm_install_setup() {
         python3 --version
         retry_command apt-get install -y libffi-dev
         nvidia-smi && nvidia-smi -q && nvidia-smi topo -m
-        if [[ $pytestCommand == *--run-ray* ]]; then
-            retry_command pip3 install --retries 10 "ray[default]==2.54.1"
-        fi
         retry_command bash -c "cd $llmSrcNode && pip3 install --retries 10 -r requirements-dev.txt"
         retry_command bash -c "cd $resourcePathNode && pip3 install --retries 10 --force-reinstall --no-deps TensorRT-LLM/tensorrt_llm-*.whl"
+        if [[ $pytestCommand == *--run-ray* ]]; then
+            # Ray is an optional extra defined in setup.py; pin lives there.
+            retry_command bash -c "cd $llmSrcNode && pip3 install --retries 10 'tensorrt_llm[ray]' -c constraints.txt"
+        fi
         gpuUuids=$(nvidia-smi -q | grep "GPU UUID" | awk '{print $4}' | tr '\n' ',' || true)
         hostNodeName="${HOST_NODE_NAME:-$(hostname -f || hostname)}"
         echo "HOST_NODE_NAME = $hostNodeName ; GPU_UUIDS = $gpuUuids ; STAGE_NAME = $stageName"

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -380,11 +380,17 @@ def check_missing_libs(lib_name: str) -> list[str]:
     return missing
 
 
-def generate_python_stubs_linux(venv_python: Path, deep_ep: bool,
-                                flash_mla: bool, transfer_agent_binding: bool,
-                                binding_lib_name: str):
-    build_run(f"\"{venv_python}\" -m pip install nanobind")
-    build_run(f"\"{venv_python}\" -m pip install pybind11-stubgen")
+def generate_python_stubs_linux(venv_python: Path,
+                                deep_ep: bool,
+                                flash_mla: bool,
+                                transfer_agent_binding: bool,
+                                binding_lib_name: str,
+                                constraint_file: Path = None):
+    constraint_arg = f' -c "{constraint_file}"' if constraint_file and constraint_file.exists(
+    ) else ""
+    build_run(f"\"{venv_python}\" -m pip install nanobind{constraint_arg}")
+    build_run(
+        f"\"{venv_python}\" -m pip install pybind11-stubgen{constraint_arg}")
 
     env_stub_gen = os.environ.copy()
     cuda_home_dir = env_stub_gen.get("CUDA_HOME") or env_stub_gen.get(
@@ -1033,10 +1039,12 @@ def main(*,
                     generate_python_stubs_windows(venv_python, pkg_dir, lib_dir)
                 else:  # on linux
                     generate_python_stubs_linux(
-                        venv_python, bool(deep_ep_cuda_architectures),
+                        venv_python,
+                        bool(deep_ep_cuda_architectures),
                         bool(flash_mla_cuda_architectures),
                         nixl_root is not None or mooncake_root is not None,
-                        binding_lib_file_name)
+                        binding_lib_file_name,
+                        constraint_file=project_dir / "constraints.txt")
 
     build_kv_cache_manager_v2(project_dir, venv_python, use_mypyc=mypyc)
 

--- a/scripts/generate_constraints.py
+++ b/scripts/generate_constraints.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regenerate constraints.txt from the currently-installed environment.
+
+constraints.txt pins the pure-Python dependencies of TensorRT-LLM to the
+versions verified in our NGC base container. It is a pip *constraint* file
+(applied via `-c`), not an install list.
+
+Intended workflow:
+    1. Enter a fresh NGC container that matches the desired CI baseline.
+    2. `pip install -r requirements-dev.txt` (or otherwise populate the env).
+    3. `python scripts/generate_constraints.py`  -> rewrites constraints.txt.
+    4. Review the diff and commit.
+
+Packages provided by the container (torch, triton, tensorrt, nixl, cuda-*,
+nvidia-*, flashinfer, modelopt, cutlass-dsl, ...) are deliberately omitted --
+they are inherited via `virtualenv --system-site-packages`.
+
+Packages already carrying an explicit version specifier in requirements.txt /
+requirements-dev.txt are skipped too (no point duplicating an existing pin).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from importlib import metadata
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Layout
+# ---------------------------------------------------------------------------
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+REQUIREMENTS = PROJECT_ROOT / "requirements.txt"
+REQUIREMENTS_DEV = PROJECT_ROOT / "requirements-dev.txt"
+CONSTRAINTS = PROJECT_ROOT / "constraints.txt"
+
+# ---------------------------------------------------------------------------
+# Exclusions -- container-provided packages. Normalized names (PEP 503:
+# lowercase, '-' and '_' and '.' collapsed to '-').
+# ---------------------------------------------------------------------------
+CONTAINER_PROVIDED = {
+    # PyTorch stack
+    "torch",
+    "torchvision",
+    "torchao",
+    # Triton
+    "triton",
+    "triton-kernels",
+    # TensorRT
+    "tensorrt",
+    "tensorrt-llm",
+    # NIXL / NCCL
+    "nixl",
+    "nccl-cu13",
+    # CUDA Python stack
+    "cuda-python",
+    "cuda-core",
+    "cuda-tile",
+    "cupti-python",
+    # FlashInfer / ModelOpt / CUTLASS DSL
+    "flashinfer-python",
+}
+# Packages whose normalized name starts with any of these prefixes are also
+# treated as container-provided.
+CONTAINER_PREFIXES = ("nvidia-",)
+
+# ---------------------------------------------------------------------------
+# File preamble and section headers (kept in sync with constraints.txt layout)
+# ---------------------------------------------------------------------------
+FILE_HEADER = """\
+# Pinned versions of pure-Python dependencies for reproducible CI/dev builds.
+#
+# This file is a pip *constraints* file -- only pins already-requested packages
+# to a specific version, never triggers installs on its own. It is applied via
+# `-c constraints.txt` from requirements.txt and requirements-dev.txt.
+#
+# Scope:
+#   - Pure-Python deps we install ourselves (pandas, click, fastapi, ...).
+#   - Container-provided packages (torch, triton, tensorrt, nixl, nccl,
+#     cuda-*, nvidia-*, flashinfer, modelopt, cutlass-dsl, ...) are
+#     DELIBERATELY OMITTED -- they are inherited via
+#     `virtualenv --system-site-packages` from the NGC base image.
+#   - Packages already pinned in requirements.txt / requirements-dev.txt are
+#     omitted to avoid duplication.
+#
+# Versions below correspond to the NGC container used by current CI. Regenerate
+# inside the target container via:  python scripts/generate_constraints.py
+#
+# ---------------------------------------------------------------------------
+# Security WARs inherited from the base image (pytorch:<base_tag>). Remove
+# these entries when the base image is updated past the advisory. These three
+# entries are also force-installed by docker/Dockerfile.multi to upgrade the
+# vulnerable versions shipped in the base image.
+# ---------------------------------------------------------------------------
+# WAR against https://github.com/advisories/GHSA-8rrh-rw8j-w5fx
+wheel>=0.46.2
+# WAR against https://github.com/advisories/GHSA-qjxf-f2mg-c6mc
+tornado>=6.5.5
+# WAR against https://github.com/advisories/GHSA-3936-cmfr-pm3m
+black>=26.3.1
+"""
+
+SECTION_HEADER = """\
+
+# ---------------------------------------------------------------------------
+# Pins from {filename}
+# ---------------------------------------------------------------------------
+"""
+
+
+def normalize(name: str) -> str:
+    """Normalize a distribution name per PEP 503."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def is_container_provided(name: str) -> bool:
+    n = normalize(name)
+    if n in CONTAINER_PROVIDED:
+        return True
+    return any(n.startswith(p) for p in CONTAINER_PREFIXES)
+
+
+# A requirement line is "unpinned" when it carries no version specifier at all
+# (no `==`, `~=`, `>=`, `<=`, `>`, `<`, `!=`, `===`). Environment markers and
+# extras are allowed but do not count as a version specifier.
+_SPECIFIER_CHARS = ("==", "~=", "===", "!=", ">=", "<=", ">", "<")
+
+
+def parse_unpinned(requirements_file: Path) -> list[str]:
+    """Return ordered list of unpinned package names from a requirements file.
+
+    Skips comments, blank lines, `-r`/`-c`/`--` directives, URL requirements,
+    and any requirement that already carries a version specifier.
+    """
+    names: list[str] = []
+    seen: set[str] = set()
+    for raw in requirements_file.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith(("-r", "-c", "--", "-i ")):
+            continue
+        if line.startswith(("git+", "http://", "https://")):
+            continue
+
+        # Strip environment marker, e.g. `pkg ; python_version>='3.10'`
+        spec = line.split(";", 1)[0].strip()
+        # Strip inline comment
+        spec = spec.split("#", 1)[0].strip()
+        if not spec:
+            continue
+        if any(s in spec for s in _SPECIFIER_CHARS):
+            continue
+
+        # Strip extras: `pkg[extra1,extra2]` -> `pkg`
+        name = re.split(r"[\[\s]", spec, maxsplit=1)[0].strip()
+        if not name:
+            continue
+        key = normalize(name)
+        if key in seen:
+            continue
+        seen.add(key)
+        names.append(name)
+    return names
+
+
+def compatible_release(version: str) -> str:
+    """Return a PEP 440 compatible-release specifier for `version`.
+
+    Policy:
+      - `0.0.X`  -> `~=0.0.X` (lock to patch, allow nothing beyond 0.1.0)
+      - otherwise -> `~=MAJOR.MINOR` (allow patch bumps within the same
+        MAJOR.MINOR series)
+    """
+    parts = version.split(".")
+    if len(parts) < 2:
+        return f"=={version}"
+    major, minor = parts[0], parts[1]
+    if major == "0" and minor == "0":
+        # e.g. python-multipart 0.0.26 -> ~=0.0.26
+        patch = parts[2] if len(parts) >= 3 else "0"
+        # Strip any pre/post/dev tag from patch (e.g. `0.17.2.4` -> `0`).
+        patch = re.match(r"\d+", patch).group(0) if re.match(r"\d+", patch) else "0"
+        return f"~=0.0.{patch}"
+    return f"~={major}.{minor}"
+
+
+def installed_version(name: str) -> str | None:
+    """Return the installed version of `name` or None if not installed."""
+    try:
+        return metadata.version(name)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def build_section(requirements_file: Path, already_emitted: set[str]) -> tuple[str, list[str]]:
+    """Build a section of constraint lines for one requirements file.
+
+    Returns (section_text, warnings_list). `already_emitted` is mutated with
+    newly emitted package keys so later sections don't duplicate them.
+    """
+    warnings: list[str] = []
+    lines: list[str] = []
+    for name in parse_unpinned(requirements_file):
+        key = normalize(name)
+        if key in already_emitted:
+            continue
+        if is_container_provided(name):
+            continue
+        version = installed_version(name)
+        if version is None:
+            warnings.append(f"  {name}: not installed in the current environment -- skipped")
+            continue
+        spec = compatible_release(version)
+        lines.append(f"{name}{spec}")
+        already_emitted.add(key)
+
+    if not lines:
+        return "", warnings
+    section = SECTION_HEADER.format(filename=requirements_file.name) + "\n".join(lines) + "\n"
+    return section, warnings
+
+
+def render_constraints() -> tuple[str, list[str]]:
+    """Render the full constraints.txt content from the current environment."""
+    already_emitted: set[str] = {"wheel", "tornado", "black"}
+    body = FILE_HEADER
+    all_warnings: list[str] = []
+    for req in (REQUIREMENTS, REQUIREMENTS_DEV):
+        section, warnings = build_section(req, already_emitted)
+        body += section
+        all_warnings.extend(warnings)
+    return body, all_warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--stdout",
+        action="store_true",
+        help="Print the generated file to stdout instead of writing it",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if constraints.txt would change. Useful in CI.",
+    )
+    args = parser.parse_args()
+
+    rendered, warnings = render_constraints()
+
+    for warning in warnings:
+        print(f"[warning] {warning}", file=sys.stderr)
+
+    if args.stdout:
+        sys.stdout.write(rendered)
+        return 0
+
+    if args.check:
+        current = CONSTRAINTS.read_text() if CONSTRAINTS.exists() else ""
+        if current != rendered:
+            print(
+                f"{CONSTRAINTS} is stale; run `python scripts/generate_constraints.py`"
+                " inside the target container to refresh it.",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    CONSTRAINTS.write_text(rendered)
+    print(f"Wrote {CONSTRAINTS}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -110,10 +110,9 @@ required_deps, extra_URLs = parse_requirements(
 devel_deps, _ = parse_requirements(
     Path("requirements-dev-windows.txt"
          if on_windows else "requirements-dev.txt"))
-constraints_file = Path("constraints.txt")
-if constraints_file.exists():
-    constraints, _ = parse_requirements(constraints_file)
-    required_deps.extend(constraints)
+# constraints.txt is intentionally NOT merged into install_requires: it is a
+# dev/CI-only pin list applied via `-c constraints.txt` (from requirements.txt
+# and requirements-dev.txt). Customer install contracts stay loose.
 
 if on_windows:
     package_data = [
@@ -427,6 +426,10 @@ setup(
     scripts=['tensorrt_llm/llmapi/trtllm-llmapi-launch'],
     extras_require={
         "devel": devel_deps,
+        # Optional: Ray orchestrator (tensorrt_llm/executor/ray_executor.py).
+        # Pinned here so CI and downstream users install the version we test
+        # against -- bump in this single place.
+        "ray": ["ray[default]==2.54.1"],
     },
     zip_safe=True,
     install_requires=required_deps,

--- a/tests/integration/defs/verl/verl_config.yml
+++ b/tests/integration/defs/verl/verl_config.yml
@@ -31,7 +31,8 @@ verl_config:
     - "pip install --no-cache-dir -U git+https://github.com/ISEEKYAN/mbridge.git"
     - "pip install --no-deps --no-cache-dir git+https://github.com/NVIDIA/Megatron-LM.git@core_v0.15.0"
     - "pip3 install pytest-asyncio"
-    - "pip3 install --no-cache-dir 'ray[default]==2.54.1'"
+    # Ray is an optional extra defined in setup.py; pin lives there.
+    - "pip3 install --no-cache-dir 'tensorrt_llm[ray]'"
 
 
   # The environment variables to expose in the container before setting up


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added script to regenerate dependency constraints automatically.

* **Chores**
  * Ray is now an optional feature rather than a default dependency.
  * Improved dependency constraint management in build and installation processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

* Why?

Previously, very few dependencies were pinned in `requirements.txt`. This meant that, if 3rd party dependencies were updated, we could be subject to incompatibilities, which would render all outstanding CI pipelines dead on arrival.

* What?

This commit adds a `constraints.txt` file that can be optionally used during installation. For the time being, it only pins with the compatible release operator.

Jenkins files, setup scripts (for stubbing), etc. are updated accordingly.

A script is also checked to help (re)generate this file if need be.
## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
