### PR TITLE
[https://nvbugs/5945047][fix] Fix cluster launch enablement for SM120 GPUs in allReduce fusion

### DIFF
--- a/cpp/tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.cu
@@ -651,8 +651,11 @@ void allreduce_fusion_kernel_launcher(AllReduceFusionParams const& params)
         }
     }
     int threads_per_token = params.hidden_dim / kElemsPerAccess<DType>;
+    // Cluster launch is supported on Hopper (SM90) and datacenter Blackwell (SM100/SM103),
+    // but NOT on workstation Blackwell (SM120/SM121) which lacks cluster launch hardware.
     int cluster_size;
-    if (SM >= 90)
+    bool const supports_cluster = (SM >= 90 && SM < 120);
+    if (supports_cluster)
     {
         cluster_size = 8;
     }
@@ -694,7 +697,7 @@ void allreduce_fusion_kernel_launcher(AllReduceFusionParams const& params)
     attribute[1].val.clusterDim.y = 1;
     attribute[1].val.clusterDim.z = 1;
     cfg.attrs = attribute;
-    cfg.numAttrs = SM >= 90 ? 2 : 0;
+    cfg.numAttrs = supports_cluster ? 2 : 0;
     if (oneshot)
     {
         bool trigger_completion_at_end = params.trigger_completion_at_end;

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -250,7 +250,6 @@ full:RTX/accuracy/test_llm_api_pytorch.py::TestGemma3_1BInstruct::test_auto_dtyp
 full:RTXPro6000D/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=0-ep4-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-low_precision_combine=False-torch_compile=False] SKIP (https://nvbugs/5948435)
 full:RTXPro6000D/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=0-ep4-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-low_precision_combine=False-torch_compile=True] SKIP (https://nvbugs/5961814)
 full:RTXPro6000D/accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=2-ep4-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-low_precision_combine=False-torch_compile=False] SKIP (https://nvbugs/5961814)
-full:RTXPro6000D/accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_4gpus[v2_kv_cache-cutlass-one_model-overlap_scheduler] SKIP (https://nvbugs/5945047)
 full:RTXPro6000D/accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_nvfp4[dep4_latency_moe_cutlass-torch_compile=True] SKIP (https://nvbugs/5929339)
 full:RTX_6000D/accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_4gpus[v2_kv_cache-cutlass-two_model-no_overlap_scheduler] SKIP (https://nvbugs/6128420)
 full:RTX_6000D/accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_nvfp4[latency_moe_cutlass] SKIP (https://nvbugs/6128419)


### PR DESCRIPTION
## Summary
- Fix for NVBugs 5945047: [TensorRT-LLM][L0][Post-Merge][main] Test failed: test_eagle3_4gpus[v2_kv_cache-cutlass-one_model-overlap_scheduler]
- **Root cause**: The allReduce fusion kernel unconditionally enabled cluster launch for all GPUs with SM >= 90. However, workstation Blackwell GPUs (SM120/SM121) do not have cluster launch hardware support, causing a CUDA illegal instruction error when the kernel attempted to use cluster launch on these architectures.
- **Fix**: Added an architecture range check (SM >= 90 && SM < 120) to gate cluster launch enablement, ensuring it is only used on Hopper (SM90) and datacenter Blackwell (SM100/SM103) GPUs that actually support the feature. The same condition is applied to both the cluster_size selection and the cudaLaunchAttribute configuration.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/5945047