### PR TITLE
[None][test] Remove triton_server test_opt

### DIFF
--- a/tests/integration/defs/triton_server/test_triton.py
+++ b/tests/integration/defs/triton_server/test_triton.py
@@ -123,16 +123,6 @@ def test_gpt(tritonserver_test_root, test_name, llm_root, model_path,
         llm_root)
 
 
-@pytest.mark.parametrize("test_name", ["opt"], indirect=True)
-def test_opt(tritonserver_test_root, test_name, llm_root, model_path,
-             engine_dir):
-    build_model(test_name, llm_root, tritonserver_test_root)
-    tokenizer_type = "auto"
-    run_shell_command(
-        f"cd {tritonserver_test_root} && ./test.sh {test_name} {engine_dir} {model_path} {tokenizer_type}",
-        llm_root)
-
-
 @pytest.mark.parametrize("test_name", ["llama"], indirect=True)
 def test_llama(tritonserver_test_root, test_name, llm_root, model_path,
                engine_dir):

--- a/tests/integration/test_lists/test-db/l0_a30.yml
+++ b/tests/integration/test_lists/test-db/l0_a30.yml
@@ -66,7 +66,6 @@ l0_a30:
       stage: pre_merge
       backend: triton
   tests:
-  - triton_server/test_triton.py::test_opt[opt]
   - triton_server/test_triton_llm.py::test_llmapi_backend[1-0-disableDecoupleMode-tensorrt_llm]
   - triton_server/test_triton_llm.py::test_llmapi_backend[1-0-enableDecoupleMode-tensorrt_llm]
 - condition:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed test cases for Triton server backend to streamline test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Removes the `triton_server/test_triton.py::test_opt[opt]` integration test and its corresponding listing in `tests/integration/test_lists/test-db/l0_a30.yml`. Continues the ongoing triton_server test cleanup.

## Test Coverage

N/A — this PR removes a test; no new code paths are introduced.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.