### PR TITLE
[https://nvbugs/6085022][fix] Synchronize warmup skip decisions across ranks

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -39,7 +39,7 @@ from ..autotuner import AutoTuner, autotune
 from ..compilation.backend import Backend
 from ..compilation.utils import capture_piecewise_cuda_graph
 from ..distributed import Distributed
-from ..distributed.communicator import init_pp_comm
+from ..distributed.communicator import ReduceOp, init_pp_comm
 from ..expert_statistic import ExpertStatistic
 from ..memory_buffer_utils import with_shared_pool
 from ..metadata import KVCacheParams
@@ -882,8 +882,12 @@ class PyTorchModelEngine(ModelEngine):
                         self._create_warmup_request(resource_manager,
                                                     num_tokens, num_gen_tokens),
                         resource_manager) as batch:
-                    if batch is None:
-                        continue  # Not enough KV cache space
+                    # Synchronize skip decisions across all ranks to prevent
+                    # hangs when one rank skips but others proceed into
+                    # collective ops inside the forward pass.
+                    if not self._all_ranks_warmup_ready(batch is not None,
+                                                        num_tokens):
+                        continue
                     logger.info(
                         f"Run warmup with {num_tokens} tokens, include {num_gen_tokens} generation tokens"
                     )
@@ -896,6 +900,53 @@ class PyTorchModelEngine(ModelEngine):
                     f"OOM during general warmup with {num_tokens} tokens, "
                     f"{num_gen_tokens} generation tokens. Skipping.")
                 torch.cuda.empty_cache()
+
+    def _all_ranks_warmup_ready(self, has_batch: bool,
+                                num_tokens: int) -> bool:
+        """Ensure all ranks agree on whether to proceed with warmup.
+
+        In multi-rank setups, warmup forward passes involve collective
+        operations (allreduce, allgather). If one rank skips warmup (e.g.,
+        due to insufficient KV cache or GPU memory) while others proceed,
+        the proceeding ranks will hang indefinitely at the next collective
+        op, eventually timing out and crashing.
+
+        This method synchronizes the decision across all ranks: warmup
+        proceeds only if every rank is ready.
+        """
+        if self.dist is None:
+            return has_batch
+
+        is_ready = has_batch
+
+        # Pre-check GPU memory to avoid OOM that would leave other ranks
+        # stuck in collective ops mid-forward.  The OOM catch in
+        # _general_warmup only helps the failing rank; other ranks remain
+        # blocked in the forward pass.
+        if is_ready:
+            free_mem, _ = torch.cuda.mem_get_info()
+            # Estimate memory needed for the warmup forward pass:
+            # attention workspace + activation tensors + temporary buffers.
+            # Use ~500 KiB per token as a conservative estimate, with a
+            # floor of 4 GiB.
+            min_free = max(num_tokens * 512 * 1024, 4 * 1024**3)
+            if free_mem < min_free:
+                is_ready = False
+                logger.info(
+                    f"Insufficient free GPU memory "
+                    f"({free_mem / 1024**3:.1f} GiB free, "
+                    f"need {min_free / 1024**3:.1f} GiB) for warmup with "
+                    f"{num_tokens} tokens on rank {self.dist.rank}")
+
+        all_ready = self.dist.allreduce(
+            1 if is_ready else 0, op=ReduceOp.MIN) > 0
+
+        if not all_ready and has_batch:
+            logger.warning(
+                f"Skipping warmup with {num_tokens} tokens: "
+                f"not all ranks have sufficient resources")
+
+        return all_ready
 
     def _run_autotuner_warmup(self, resource_manager: ResourceManager):
         """Runs a forward pass to populate the autotuner cache."""


### PR DESCRIPTION
…s ranks to prevent hang

When one rank hits OOM during warmup (e.g., rank 0 with extra orchestrator overhead on a disaggregated CTX server), it catches the exception and moves on. However, other ranks remain stuck in collective operations inside the forward pass, eventually timing out and crashing with CUDA launch failures.

This fix adds _all_ranks_warmup_ready() which uses allreduce to synchronize the warmup decision across all ranks:
1. Ensures all ranks have a valid warmup batch before proceeding
2. Pre-checks free GPU memory on all ranks before large warmups to prevent OOM that would leave other ranks hanging in collective ops

This specifically fixes the DSV3.2 CTX server crash (TP=4, max_num_tokens=32784) where rank 0 OOMs during the 32K-token warmup forward pass while ranks 1-3 hang at the next collective op for 5 minutes before crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced warmup process for distributed GPU execution with synchronized readiness checks across all ranks.
  * Added GPU memory availability validation before warmup to prevent out-of-memory errors in multi-GPU deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
