### PR TITLE
[None][feat] Switch CP cache transmission from contiguous to round-robin

### DIFF
--- a/cpp/tensorrt_llm/common/envUtils.cpp
+++ b/cpp/tensorrt_llm/common/envUtils.cpp
@@ -307,12 +307,6 @@ bool getEnvUseMooncakeKvCache()
     return useMooncakeKvCache;
 }
 
-bool getEnvUseRoundRobinBlockDistForCP()
-{
-    static bool const useRoundRobinBlockDistForCP = getBoolEnv("TRTLLM_USE_ROUND_ROBIN_BLOCK_DIST_FOR_CP");
-    return useRoundRobinBlockDistForCP;
-}
-
 std::string getEnvUCXInterface()
 {
     static std::once_flag flag;

--- a/cpp/tensorrt_llm/common/envUtils.h
+++ b/cpp/tensorrt_llm/common/envUtils.h
@@ -93,8 +93,6 @@ bool getEnvUseNixlKvCache();
 
 bool getEnvUseMooncakeKvCache();
 
-bool getEnvUseRoundRobinBlockDistForCP();
-
 std::string getEnvUCXInterface();
 
 std::string getEnvNixlInterface();

--- a/cpp/tensorrt_llm/executor/cache_transmission/cacheSplitConcat.cu
+++ b/cpp/tensorrt_llm/executor/cache_transmission/cacheSplitConcat.cu
@@ -19,7 +19,6 @@
 #include "tensorrt_llm/common/assert.h"
 #include "tensorrt_llm/common/cudaFp8Utils.h"
 #include "tensorrt_llm/common/cudaUtils.h"
-#include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/common/reduceKernelUtils.cuh"
 #include "tensorrt_llm/executor/dataTransceiverState.h"
 #include "tensorrt_llm/executor/tensor.h"
@@ -64,32 +63,14 @@ int getBlockNumAccountingForCP(int cpRank, int cpSize, int numTotalBlocks)
     {
         return numTotalBlocks;
     }
-    // Blocks are distributed among CP ranks as evenly as possible. When the number of blocks is not
-    // divisible by cpSize, the remainder shall be distributed evenly among lowest-indexed CP ranks
-    // (let's call them overflow ranks).
+    // Blocks are distributed among CP ranks in a round-robin fashion. When the number of blocks is not
+    // divisible by cpSize, the lowest-indexed CP ranks each receive one extra block.
     int numBlocksCurrRank = numTotalBlocks / cpSize;
     if (numTotalBlocks % cpSize > cpRank)
     {
         numBlocksCurrRank++;
     }
     return numBlocksCurrRank;
-}
-
-int getGlobalBlockIdAccountingForCP(int localBlockIdx, int cpSize, int cpRank, int numTotalBlocks)
-{
-    if (tensorrt_llm::common::getEnvUseRoundRobinBlockDistForCP())
-    {
-        return localBlockIdx * cpSize + cpRank;
-    }
-    else
-    {
-        int const minBlocksPerCPRank = numTotalBlocks / cpSize;
-        int const minBlocksOnPrevCPRanks = minBlocksPerCPRank * cpRank;
-        int const numOverflowRanks = numTotalBlocks % cpSize;
-        // Each previous overflow rank has one more block than minBlocksPerCPRank.
-        int const overflowBlocksOnPrevCPRanks = std::min(cpRank, numOverflowRanks);
-        return minBlocksOnPrevCPRanks + overflowBlocksOnPrevCPRanks + localBlockIdx;
-    }
 }
 
 // inputBlockNums: [outputBlockNum, inputRanks.size]
@@ -644,35 +625,12 @@ __device__ __forceinline__ void getLayerIdInDomainPPandRankInDomainPP(int layerI
     layerNumInSpecPP = sharedLayerNumInSpecPP;
 }
 
-__device__ __forceinline__ void getBlockIdInDomainCPandRankInDomainCP(
-    int blockId, int domainCPSize, uint64_t* prefixBlockNumDevPtr, int& blockIdInDomainCP, int& rankInDomainCP)
-{
-    __shared__ int sharedBlockIdInDomainCP;
-    __shared__ int sharedRankInDomainCP;
-
-#pragma unroll 1
-    for (int cpRank = threadIdx.x; cpRank < domainCPSize; cpRank += blockDim.x)
-    {
-        if (blockId >= prefixBlockNumDevPtr[cpRank] && blockId < prefixBlockNumDevPtr[cpRank + 1])
-        {
-            sharedBlockIdInDomainCP = blockId - prefixBlockNumDevPtr[cpRank];
-            sharedRankInDomainCP = cpRank;
-            break;
-        }
-    }
-
-    __syncthreads();
-    blockIdInDomainCP = sharedBlockIdInDomainCP;
-    rankInDomainCP = sharedRankInDomainCP;
-}
-
 // MLA Head 1: One thread block per [(2), tokens, dimsPerHead]
 
 template <typename T, int subWarpSize, int vecSizeByte>
 __global__ void splitKVCacheForMLAKernel(T const** __restrict__ inputBlocks, T** __restrict__ outputCaches,
     int tokensPerBlock, int numLayers, int headNum, int dimsPerHead, int inputBlockNum, int domainPPSize,
-    int domainTPSize, int domainCPSize, int kvFactor, uint64_t* prefixLayerNumDevPtr, bool isCPRoundRobin,
-    uint64_t* prefixBlockNumDevPtr)
+    int domainTPSize, int domainCPSize, int kvFactor, uint64_t* prefixLayerNumDevPtr)
 {
     int const subWarpId = threadIdx.x / subWarpSize;
     int const laneId = threadIdx.x % subWarpSize;
@@ -685,17 +643,9 @@ __global__ void splitKVCacheForMLAKernel(T const** __restrict__ inputBlocks, T**
 
     for (int64_t blockId = blockIdx.y; blockId < inputBlockNum; blockId += gridDim.y)
     {
-        // Default to CP round-robin.
-        int rankInDomainCP = blockId % domainCPSize;    // genCPRank to which this block belongs.
-        int blockIdInDomainCP = blockId / domainCPSize; // localBlockId on genCPRank.
-        if (domainCPSize > 1 && !isCPRoundRobin)
-        {
-            // NOTE: domainCPSize is the same as genCPSize as contextCP is always 1 currently. So,
-            // - rankInDomainCP is the same as genCPRank to which this block belongs.
-            // - blockIdInDomainCP is the localBlockId on this genCPRank.
-            getBlockIdInDomainCPandRankInDomainCP(
-                blockId, domainCPSize, prefixBlockNumDevPtr, blockIdInDomainCP, rankInDomainCP);
-        }
+        // Blocks are distributed among CP ranks in a round-robin fashion.
+        int const rankInDomainCP = blockId % domainCPSize;    // genCPRank to which this block belongs.
+        int const blockIdInDomainCP = blockId / domainCPSize; // localBlockId on genCPRank.
 #pragma unroll 1
         for (int layerId = blockIdx.x; layerId < numLayers; layerId += gridDim.x)
         {
@@ -762,8 +712,7 @@ __global__ void splitKVCacheForMLAKernel(T const** __restrict__ inputBlocks, T**
 template <typename T, int subWarpSize, int subWarpNumInGroup, int vecSizeByte>
 __global__ void splitKVCacheKernel(T const** __restrict__ inputBlocks, T** __restrict__ outputCaches,
     int tokensPerBlock, int numLayers, int headNum, int dimsPerHead, int inputBlockNum, int domainPPSize,
-    int domainTPSize, int headNumDomainTP, uint64_t* prefixLayerNumDevPtr, int domainCPSize, bool isCPRoundRobin,
-    uint64_t* prefixBlockNumDevPtr)
+    int domainTPSize, int headNumDomainTP, uint64_t* prefixLayerNumDevPtr, int domainCPSize)
 {
 
     // layerNumDomainPP =  numLayers/domainPPSize
@@ -785,16 +734,9 @@ __global__ void splitKVCacheKernel(T const** __restrict__ inputBlocks, T** __res
 
     for (int blockId = blockIdx.y; blockId < inputBlockNum; blockId += gridDim.y)
     {
-        // CP block distribution: determine which CP rank gets this block and the local block id.
-        // Default to CP round-robin.
-        int rankInDomainCP = blockId % domainCPSize;    // genCPRank to which this block belongs.
-        int blockIdInDomainCP = blockId / domainCPSize; // localBlockId on genCPRank.
-        if (domainCPSize > 1 && !isCPRoundRobin)
-        {
-            // Contiguous block distribution: use prefix sum to find the CP rank.
-            getBlockIdInDomainCPandRankInDomainCP(
-                blockId, domainCPSize, prefixBlockNumDevPtr, blockIdInDomainCP, rankInDomainCP);
-        }
+        // Blocks are distributed among CP ranks in a round-robin fashion.
+        int const rankInDomainCP = blockId % domainCPSize;    // genCPRank to which this block belongs.
+        int const blockIdInDomainCP = blockId / domainCPSize; // localBlockId on genCPRank.
 
 #pragma unroll 1
 
@@ -1222,15 +1164,6 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
     cachePtrs.insert(cachePtrs.end(), prefixLayerNum.begin(), prefixLayerNum.end());
     bool const isWindow = windowSizes.size() > 1;
 
-    std::vector<uint64_t> prefixBlockNum(targetRankInfo.mDomainCPSize + 1, 0);
-    prefixBlockNum[0] = 0;
-    for (int i = 0; i < targetRankInfo.mDomainCPSize; i++)
-    {
-        prefixBlockNum[i + 1]
-            = prefixBlockNum[i] + getBlockNumAccountingForCP(i, targetRankInfo.mDomainCPSize, inputBlockNumSum);
-    }
-    cachePtrs.insert(cachePtrs.end(), prefixBlockNum.begin(), prefixBlockNum.end());
-
     runtime::BufferManager::IBufferPtr PtrsDeviceBuffer
         = bufferManager.gpu(cachePtrs.size(), nvinfer1::DataType::kINT64);
     TLLM_CHECK(PtrsDeviceBuffer->getSizeInBytes() == cachePtrs.size() * sizeof(T*));
@@ -1290,8 +1223,6 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
     T** outputCachePtrsDev = static_cast<T**>(PtrsDeviceBuffer->data()) + inputBlockNumSum;
     uint64_t* prefixLayerNumDevPtr
         = static_cast<uint64_t*>(PtrsDeviceBuffer->data()) + inputBlockNumSum + outputSplitBlocks.size();
-    uint64_t* prefixBlockNumDevPtr = static_cast<uint64_t*>(PtrsDeviceBuffer->data()) + inputBlockNumSum
-        + outputSplitBlocks.size() + prefixLayerNum.size();
 
     int const tokensPerBlock = selfModelConfig.mTokensPerBlock;
     int const selfPPRank = selfIdx / (selfParallelConfig.mTensorParallelism * selfParallelConfig.mContextParallelism);
@@ -1305,7 +1236,6 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
     int const headNumDomainTP = headNum / (domainTPSize / targetRankInfo.mPeerDupHeadFactor);
     int const kvFactor = selfAttentionConfig.mKvFactor;
     bool const isMLA = selfAttentionConfig.mAttentionType == CacheState::AttentionType::kMLA;
-    bool const isCPRoundRobin = tensorrt_llm::common::getEnvUseRoundRobinBlockDistForCP();
     constexpr int mlaSubWarpSize = 16;
 
     TLLM_LOG_DEBUG(
@@ -1320,10 +1250,9 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
     {
         if (isMLA)
         {
-            splitKVCacheForMLAKernel<T, mlaSubWarpSize, 16>
-                <<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(inputBlockPtrsDev, outputCachePtrsDev,
-                    tokensPerBlock, numLayers, headNum, dimsPerHead, inputBlockNumSum, domainPPSize, domainTPSize,
-                    domainCPSize, kvFactor, prefixLayerNumDevPtr, isCPRoundRobin, prefixBlockNumDevPtr);
+            splitKVCacheForMLAKernel<T, mlaSubWarpSize, 16><<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(
+                inputBlockPtrsDev, outputCachePtrsDev, tokensPerBlock, numLayers, headNum, dimsPerHead,
+                inputBlockNumSum, domainPPSize, domainTPSize, domainCPSize, kvFactor, prefixLayerNumDevPtr);
         }
         else if (isWindow)
         {
@@ -1337,7 +1266,7 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
             splitKVCacheKernel<T, subWarpSize, subWarpNumInGroup, 16>
                 <<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(inputBlockPtrsDev, outputCachePtrsDev,
                     tokensPerBlock, numLayers, headNum, dimsPerHead, inputBlockNumSum, domainPPSize, domainTPSize,
-                    headNumDomainTP, prefixLayerNumDevPtr, domainCPSize, isCPRoundRobin, prefixBlockNumDevPtr);
+                    headNumDomainTP, prefixLayerNumDevPtr, domainCPSize);
         }
         break;
     }
@@ -1345,10 +1274,9 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
     {
         if (isMLA)
         {
-            splitKVCacheForMLAKernel<T, mlaSubWarpSize, 8>
-                <<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(inputBlockPtrsDev, outputCachePtrsDev,
-                    tokensPerBlock, numLayers, headNum, dimsPerHead, inputBlockNumSum, domainPPSize, domainTPSize,
-                    domainCPSize, kvFactor, prefixLayerNumDevPtr, isCPRoundRobin, prefixBlockNumDevPtr);
+            splitKVCacheForMLAKernel<T, mlaSubWarpSize, 8><<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(
+                inputBlockPtrsDev, outputCachePtrsDev, tokensPerBlock, numLayers, headNum, dimsPerHead,
+                inputBlockNumSum, domainPPSize, domainTPSize, domainCPSize, kvFactor, prefixLayerNumDevPtr);
         }
         else if (isWindow)
         {
@@ -1362,7 +1290,7 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
             splitKVCacheKernel<T, subWarpSize, subWarpNumInGroup, 8>
                 <<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(inputBlockPtrsDev, outputCachePtrsDev,
                     tokensPerBlock, numLayers, headNum, dimsPerHead, inputBlockNumSum, domainPPSize, domainTPSize,
-                    headNumDomainTP, prefixLayerNumDevPtr, domainCPSize, isCPRoundRobin, prefixBlockNumDevPtr);
+                    headNumDomainTP, prefixLayerNumDevPtr, domainCPSize);
         }
         break;
     }
@@ -1376,7 +1304,7 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
                 splitKVCacheForMLAKernel<T, mlaSubWarpSize, 4>
                     <<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(inputBlockPtrsDev, outputCachePtrsDev,
                         tokensPerBlock, numLayers, headNum, dimsPerHead, inputBlockNumSum, domainPPSize, domainTPSize,
-                        domainCPSize, kvFactor, prefixLayerNumDevPtr, isCPRoundRobin, prefixBlockNumDevPtr);
+                        domainCPSize, kvFactor, prefixLayerNumDevPtr);
             }
             else if (isWindow)
             {
@@ -1391,7 +1319,7 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
                 splitKVCacheKernel<T, subWarpSize, subWarpNumInGroup, 4>
                     <<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(inputBlockPtrsDev, outputCachePtrsDev,
                         tokensPerBlock, numLayers, headNum, dimsPerHead, inputBlockNumSum, domainPPSize, domainTPSize,
-                        headNumDomainTP, prefixLayerNumDevPtr, domainCPSize, isCPRoundRobin, prefixBlockNumDevPtr);
+                        headNumDomainTP, prefixLayerNumDevPtr, domainCPSize);
             }
             break;
         }
@@ -1409,7 +1337,7 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
                 splitKVCacheForMLAKernel<T, mlaSubWarpSize, 2>
                     <<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(inputBlockPtrsDev, outputCachePtrsDev,
                         tokensPerBlock, numLayers, headNum, dimsPerHead, inputBlockNumSum, domainPPSize, domainTPSize,
-                        domainCPSize, kvFactor, prefixLayerNumDevPtr, isCPRoundRobin, prefixBlockNumDevPtr);
+                        domainCPSize, kvFactor, prefixLayerNumDevPtr);
             }
             else if (isWindow)
             {
@@ -1424,7 +1352,7 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
                 splitKVCacheKernel<T, subWarpSize, subWarpNumInGroup, 2>
                     <<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(inputBlockPtrsDev, outputCachePtrsDev,
                         tokensPerBlock, numLayers, headNum, dimsPerHead, inputBlockNumSum, domainPPSize, domainTPSize,
-                        headNumDomainTP, prefixLayerNumDevPtr, domainCPSize, isCPRoundRobin, prefixBlockNumDevPtr);
+                        headNumDomainTP, prefixLayerNumDevPtr, domainCPSize);
             }
             break;
         }
@@ -1438,7 +1366,7 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
                 splitKVCacheForMLAKernel<T, mlaSubWarpSize, 1>
                     <<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(inputBlockPtrsDev, outputCachePtrsDev,
                         tokensPerBlock, numLayers, headNum, dimsPerHead, inputBlockNumSum, domainPPSize, domainTPSize,
-                        domainCPSize, kvFactor, prefixLayerNumDevPtr, isCPRoundRobin, prefixBlockNumDevPtr);
+                        domainCPSize, kvFactor, prefixLayerNumDevPtr);
             }
             else if (isWindow)
             {
@@ -1453,7 +1381,7 @@ void splitKVCache(std::map<SizeType32, std::vector<runtime::ITensor::SharedPtr>>
                 splitKVCacheKernel<T, subWarpSize, subWarpNumInGroup, 1>
                     <<<gridDim, blockDimx, 0, bufferManager.getStream().get()>>>(inputBlockPtrsDev, outputCachePtrsDev,
                         tokensPerBlock, numLayers, headNum, dimsPerHead, inputBlockNumSum, domainPPSize, domainTPSize,
-                        headNumDomainTP, prefixLayerNumDevPtr, domainCPSize, isCPRoundRobin, prefixBlockNumDevPtr);
+                        headNumDomainTP, prefixLayerNumDevPtr, domainCPSize);
             }
             break;
         }

--- a/cpp/tensorrt_llm/executor/cache_transmission/cacheSplitConcat.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/cacheSplitConcat.h
@@ -63,7 +63,7 @@ TargetRanksInfo targetIRanksForRnn(
  * @brief Calculate the number of blocks allocated to a specific Context Parallelism (CP) rank.
  *
  * This function determines how many blocks should be allocated to a given CP rank when
- * distributing a total number of blocks across multiple CP ranks.
+ * distributing a total number of blocks across multiple CP ranks in a round-robin fashion.
  *
  * @param cpRank The rank (index) of the current CP process. Must be in range [0, cpSize).
  * @param cpSize The total number of CP ranks/processes in the parallel group.
@@ -72,22 +72,6 @@ TargetRanksInfo targetIRanksForRnn(
  * @return The number of blocks allocated to the specified CP rank.
  */
 int getBlockNumAccountingForCP(int cpRank, int cpSize, int numTotalBlocks);
-
-/**
- * @brief Convert a local block index to a global block ID when Context Parallelism (CP) is enabled.
- *
- * This function maps a local block index (within a specific CP rank) to its corresponding
- * global block ID across all CP ranks. It supports two distribution strategies controlled
- * by the environment variable TRTLLM_USE_ROUND_ROBIN_BLOCK_DIST_FOR_CP.
- *
- * @param localBlockIdx The local block index within the current CP rank (0-based).
- * @param cpSize The total number of CP ranks in the parallel group.
- * @param cpRank The rank of the current CP process. Must be in range [0, cpSize).
- * @param numTotalBlocks The total number of blocks distributed across all CP ranks.
- *
- * @return The global block ID corresponding to the local block index.
- */
-int getGlobalBlockIdAccountingForCP(int localBlockIdx, int cpSize, int cpRank, int numTotalBlocks);
 
 void concatKVCacheDispatch(runtime::ITensor::SharedPtr* inputBlocks, int inputBlockNum,
     std::vector<int> const& inputRanks, kv_cache::CacheState const& peerCacheState,

--- a/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
@@ -447,13 +447,11 @@ struct CPMetaData
         mTotalNumBlocksAcrossCPRanks = (totalSeqLen + numTokensPerBlock - 1) / numTokensPerBlock;
         mNumBlocksThisCPRank = tensorrt_llm::executor::kv_cache::getBlockNumAccountingForCP(
             cpRank, cpSize, mTotalNumBlocksAcrossCPRanks);
-        mSeqLenOnThisCPRank = totalSeqLen;
+        // For round-robin distribution of blocks among CP ranks, the last block (which may have padded tokens)
+        // belongs to the CP rank with index (mTotalNumBlocksAcrossCPRanks - 1) % cpSize.
         int numPaddedTokensLastBlock = 0;
-        TLLM_CHECK_WITH_INFO(!tensorrt_llm::common::getEnvUseRoundRobinBlockDistForCP(),
-            "Round-robin block distribution for CP needs further adjustments.");
-        // If there are any padded tokens, they will be on the last block on last CP rank for contiguous distribution of
-        // blocks.
-        if (cpRank == cpSize - 1 && totalSeqLen % numTokensPerBlock != 0)
+        int const lastBlockOwnerCPRank = (mTotalNumBlocksAcrossCPRanks - 1) % cpSize;
+        if (cpRank == lastBlockOwnerCPRank && totalSeqLen % numTokensPerBlock != 0)
         {
             numPaddedTokensLastBlock = numTokensPerBlock - (totalSeqLen % numTokensPerBlock);
         }
@@ -461,8 +459,8 @@ struct CPMetaData
         mGlobalBlockIds = std::vector<int>(mNumBlocksThisCPRank);
         for (int i = 0; i < mNumBlocksThisCPRank; i++)
         {
-            mGlobalBlockIds[i] = tensorrt_llm::executor::kv_cache::getGlobalBlockIdAccountingForCP(
-                i, cpSize, cpRank, mTotalNumBlocksAcrossCPRanks);
+            // Round-robin distribution: localBlockIdx i on cpRank maps to global blockId (i * cpSize + cpRank).
+            mGlobalBlockIds[i] = i * cpSize + cpRank;
         }
     }
 };

--- a/tensorrt_llm/_torch/pyexecutor/request_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/request_utils.py
@@ -239,7 +239,7 @@ def partition_context_for_helix(
             f"Please use smaller tokens_per_block for KV cache or reduce the number of CP ranks."
         )
 
-    # Padding to ensure torch.stack used with torch.tensor_split works properly.
+    # Pad the last (partial) block so every block has exactly tokens_per_block tokens.
     padding_len = 0
     if input_len % tokens_per_block != 0:
         padding_len = tokens_per_block - (input_len % tokens_per_block)
@@ -247,20 +247,21 @@ def partition_context_for_helix(
         all_input_ids = torch.cat((all_input_ids, padding_ids), dim=-1)
     all_position_ids = torch.arange(0, input_len + padding_len, dtype=torch.int64).unsqueeze(0)
 
-    input_id_blocks_per_rank = torch.tensor_split(
-        torch.stack(all_input_ids.split(tokens_per_block, dim=-1)), cp_size
-    )
-    position_id_blocks_per_rank = torch.tensor_split(
-        torch.stack(all_position_ids.split(tokens_per_block, dim=-1)), cp_size
+    # Round-robin block assignment across CP ranks: rank r owns blocks {r, r+cp_size, r+2*cp_size, ...}.
+    # This must agree with the C++ KV cache split kernels (cacheSplitConcat.cu) so that the input
+    # tokens this rank processes correspond to the KV blocks it received from the context server.
+    input_id_blocks = list(all_input_ids.split(tokens_per_block, dim=-1))
+    position_id_blocks = list(all_position_ids.split(tokens_per_block, dim=-1))
+
+    input_ids_this_rank = torch.cat(input_id_blocks[cp_rank::cp_size], dim=-1).flatten().tolist()
+    position_ids_this_rank = (
+        torch.cat(position_id_blocks[cp_rank::cp_size], dim=-1).flatten().tolist()
     )
 
-    # Get the input_ids and position_ids for this rank.
-    input_ids_this_rank = input_id_blocks_per_rank[cp_rank].flatten().tolist()
-    position_ids_this_rank = position_id_blocks_per_rank[cp_rank].flatten().tolist()
-
-    # Undo the padding. Only last rank's last block will be padded right now
-    # given contiguous block assignment.
-    if cp_rank == cp_size - 1 and padding_len > 0:
+    # The (single) padded block is the global last block; under round-robin it is owned by rank
+    # (num_total_blocks - 1) % cp_size, and is the last local block on that rank. Strip its padding.
+    last_block_owner = (num_total_blocks - 1) % cp_size
+    if cp_rank == last_block_owner and padding_len > 0:
         input_ids_this_rank = input_ids_this_rank[:-padding_len]
         position_ids_this_rank = position_ids_this_rank[:-padding_len]
 

--- a/tests/unittest/_torch/executor/test_request_utils.py
+++ b/tests/unittest/_torch/executor/test_request_utils.py
@@ -93,14 +93,19 @@ def test_merge_helix_requests_with_padding():
 
         assert isinstance(llm_request, LlmRequest)
         assert llm_request.request_id == 1
+        # Round-robin block distribution across 4 CP ranks (7 blocks total, 2 tokens/block):
+        #   rank 0 owns blocks {0, 4} -> tokens [1,2, 9,10]
+        #   rank 1 owns blocks {1, 5} -> tokens [3,4, 11,12]
+        #   rank 2 owns blocks {2, 6} -> tokens [5,6, 13]  (block 6 is the last block; padding stripped)
+        #   rank 3 owns block  {3}    -> tokens [7,8]
         if rank == 0:
-            assert llm_request.get_tokens(0) == [1, 2, 3, 4]
+            assert llm_request.get_tokens(0) == [1, 2, 9, 10]
         elif rank == 1:
-            assert llm_request.get_tokens(0) == [5, 6, 7, 8]
+            assert llm_request.get_tokens(0) == [3, 4, 11, 12]
         elif rank == 2:
-            assert llm_request.get_tokens(0) == [9, 10, 11, 12]
+            assert llm_request.get_tokens(0) == [5, 6, 13]
         else:
-            assert llm_request.get_tokens(0) == [13]
+            assert llm_request.get_tokens(0) == [7, 8]
 
 
 def test_merge_helix_requests_without_padding():
@@ -139,10 +144,13 @@ def test_merge_helix_requests_without_padding():
 
         assert isinstance(llm_request, LlmRequest)
         assert llm_request.request_id == 1
+        # Round-robin block distribution across 2 CP ranks (3 blocks total, 4 tokens/block):
+        #   rank 0 owns blocks {0, 2} -> tokens [1,2,3,4, 9,10,11,12]
+        #   rank 1 owns block  {1}    -> tokens [5,6,7,8]
         if rank == 0:
-            assert llm_request.get_tokens(0) == [1, 2, 3, 4, 5, 6, 7, 8]
+            assert llm_request.get_tokens(0) == [1, 2, 3, 4, 9, 10, 11, 12]
         else:
-            assert llm_request.get_tokens(0) == [9, 10, 11, 12]
+            assert llm_request.get_tokens(0) == [5, 6, 7, 8]
 
 
 def test_merge_helix_requests_insufficient_blocks_error():
@@ -231,14 +239,19 @@ def test_merge_requests_with_helix_cp_config():
 
         assert isinstance(llm_request, LlmRequest)
         assert llm_request.request_id == 1
+        # Round-robin block distribution across 4 CP ranks (7 blocks total, 2 tokens/block):
+        #   rank 0 owns blocks {0, 4} -> tokens [1,2, 9,10]
+        #   rank 1 owns blocks {1, 5} -> tokens [3,4, 11,12]
+        #   rank 2 owns blocks {2, 6} -> tokens [5,6, 13]  (block 6 is the last block; padding stripped)
+        #   rank 3 owns block  {3}    -> tokens [7,8]
         if rank == 0:
-            assert llm_request.get_tokens(0) == [1, 2, 3, 4]
+            assert llm_request.get_tokens(0) == [1, 2, 9, 10]
         elif rank == 1:
-            assert llm_request.get_tokens(0) == [5, 6, 7, 8]
+            assert llm_request.get_tokens(0) == [3, 4, 11, 12]
         elif rank == 2:
-            assert llm_request.get_tokens(0) == [9, 10, 11, 12]
+            assert llm_request.get_tokens(0) == [5, 6, 13]
         else:
-            assert llm_request.get_tokens(0) == [13]
+            assert llm_request.get_tokens(0) == [7, 8]
 
 
 def test_get_from_waiting_queue():


### PR DESCRIPTION
## Description

This PR makes round-robin the only distribution scheme for Helix CP cache transmission.

For example, let's say `ctxTpSize`=1 and `genCpSize`=2 and there are 5 blocks to be transmitted with IDs 0, 1, 2, 3, 4 for a given sequence.
| Distribution               | genCpRank0 | genCpRank1 |
| -------------------------- | ---------- | ---------- |
| Round-robin | 0, 2, 4    | 1, 3       |
| Contiguous   | 0, 1, 2    | 3, 4       |

## Test Coverage

```
$ mpirun -n 1 ./tests/unit_tests/multi_gpu/cacheTransceiverTest --gtest_filter='targetTest.CacheState*'
$ TRTLLM_USE_UCX_KVCACHE=1 TLLM_LOG_LEVEL=INFO mpirun -n 8 ./$CPP_BUILD_DIR/tests/unit_tests/multi_gpu/cacheTransceiverTest --gtest_filter='*AsymmetricCaseTest*WithCP*ForMLA*:*AsymmetricCaseTestWithCPAndDPForMLA*'
$ TRTLLM_USE_UCX_KVCACHE=1 TLLM_LOG_LEVEL=INFO mpirun -n 8 ./$CPP_BUILD_DIR/tests/unit_tests/multi_gpu/cacheTransceiverTest --gtest_filter='*AsymmetricCaseTest*WithCP*ForGQA*:*AsymmetricCaseTestWithCPAndDPForGQA*'
$ pytest tests/integration/defs/accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype_with_helix -s -v
$ pytest tests/integration/defs/accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_auto_dtype_with_helix -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Context Parallel (CP) block distribution across multiple GPUs by removing environment-based configuration and standardizing to round-robin block allocation. This improves system predictability and reduces complexity in multi-device scenarios.

* **Tests**
  * Updated unit tests for multi-GPU token distribution and request merging to verify correct block ownership under the new standardized round-robin assignment scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->