### PR TITLE
[None][fix] Handle None tokenizer in OpenAI server

### DIFF
--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -43,11 +43,18 @@ from tensorrt_llm.llmapi import (DisaggScheduleStyle, GuidedDecodingParams,
 from tensorrt_llm.llmapi.reasoning_parser import ReasoningParserFactory
 
 
-def _logit_bias_to_embedding_bias(logit_bias: Optional[Dict[str, float]],
-                                  vocab_size: int) -> Optional[torch.Tensor]:
+def _logit_bias_to_embedding_bias(
+        logit_bias: Optional[Dict[str, float]],
+        vocab_size: Optional[int]) -> Optional[torch.Tensor]:
     """Convert OpenAI logit_bias dict to embedding_bias tensor for sampling."""
     if logit_bias is None:
         return None
+    if vocab_size is None:
+        raise ValueError(
+            "logit_bias requires a tokenizer, but the server was started "
+            "without one (e.g. num_postprocess_workers > 0). "
+            "Remove logit_bias from your request or set num_postprocess_workers=0."
+        )
 
     # Create 1D zeros tensor as expected by executor API (will be unsqueezed to [1, vocab_size] internally)
     embedding_bias = torch.zeros(vocab_size, dtype=torch.float32)
@@ -390,7 +397,7 @@ class CompletionRequest(OpenAIBaseModel):
     # doc: end-completion-extra-params
 
     def to_sampling_params(self,
-                           vocab_size: int = 32000,
+                           vocab_size: Optional[int] = None,
                            gather_generation_logits: bool = False,
                            backend: Optional[str] = None) -> SamplingParams:
         sampling_params = SamplingParams(
@@ -752,7 +759,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
     # doc: end-chat-completion-extra-params
 
     def to_sampling_params(self,
-                           vocab_size: int = 32000,
+                           vocab_size: Optional[int] = None,
                            gather_generation_logits: bool = False,
                            reasoning_parser: Optional[str] = None,
                            backend: Optional[str] = None) -> SamplingParams:

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -516,6 +516,12 @@ class OpenAIServer:
 
         return True if self.generator.args.num_postprocess_workers > 0 else False
 
+    @property
+    def _vocab_size(self) -> Optional[int]:
+        if self.tokenizer is not None and self.tokenizer.tokenizer is not None:
+            return self.tokenizer.tokenizer.vocab_size
+        return None
+
     @staticmethod
     def create_error_response(
             message: str,
@@ -1043,7 +1049,7 @@ class OpenAIServer:
             # Pass the tokenizer vocabulary size so ``logit_bias`` can be
             # expanded into an embedding bias tensor in the sampler.
             sampling_params = request.to_sampling_params(
-                vocab_size=self.tokenizer.tokenizer.vocab_size,
+                vocab_size=self._vocab_size,
                 gather_generation_logits=self.generator.args.
                 gather_generation_logits,
                 reasoning_parser=self.generator.args.reasoning_parser,
@@ -1375,7 +1381,7 @@ class OpenAIServer:
             # Pass the tokenizer vocabulary size so ``logit_bias`` can be
             # expanded into an embedding bias tensor in the sampler.
             sampling_params = request.to_sampling_params(
-                vocab_size=self.tokenizer.tokenizer.vocab_size,
+                vocab_size=self._vocab_size,
                 gather_generation_logits=self.generator.args.
                 gather_generation_logits,
                 backend=self.generator.args.backend)
@@ -1510,8 +1516,7 @@ class OpenAIServer:
                 request.stop_token_ids = harmony_stop_tokens
 
             sampling_params = request.to_sampling_params(
-                vocab_size=self.tokenizer.tokenizer.vocab_size,
-                reasoning_parser="gpt_oss")
+                vocab_size=self._vocab_size, reasoning_parser="gpt_oss")
             sampling_params.detokenize = False  # Harmony adapter handles detokenization
             disaggregated_params = to_llm_disaggregated_params(
                 request.disaggregated_params)

--- a/tests/unittest/llmapi/apps/test_harmony_parsing.py
+++ b/tests/unittest/llmapi/apps/test_harmony_parsing.py
@@ -36,7 +36,8 @@ try:
         get_harmony_adapter,
         handle_streaming_response,
     )
-    from tensorrt_llm.serve.openai_protocol import StreamOptions
+    from tensorrt_llm.serve.openai_protocol import StreamOptions, _logit_bias_to_embedding_bias
+    from tensorrt_llm.serve.openai_server import OpenAIServer
 
     _harmony_available = True
 except (ImportError, ModuleNotFoundError):
@@ -1190,6 +1191,14 @@ class TestStreamOptionsUsage:
         finally:
             if request_id in harmony_adapter._stream_states:
                 harmony_adapter.cleanup_stream_state(request_id)
+
+
+def test_none_tokenizer_num_postprocess_workers():
+    server = object.__new__(OpenAIServer)
+    server.tokenizer = None
+    assert server._vocab_size is None
+    with pytest.raises(ValueError, match="logit_bias requires a tokenizer"):
+        _logit_bias_to_embedding_bias({"0": 1.0}, vocab_size=None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

When num_postprocess_workers > 0, tokenization is delegated to worker processes and self.tokenizer is None on the main server process. Three request handler paths accessed self.tokenizer.tokenizer.vocab_size unconditionally, crashing all requests with AttributeError regardless of whether logit_bias was used.

vocab_size is only needed in _logit_bias_to_embedding_bias, and only when logit_bias is actually provided in the request. For the common case of logit_bias=None the function returns None immediately without touching vocab_size.

- Add OpenAIServer._vocab_size property returning tokenizer.tokenizer.vocab_size, or None if tokenizer is absent
- Replace the three direct accesses with self._vocab_size
- Update _logit_bias_to_embedding_bias and to_sampling_params to accept Optional[int] for vocab_size; the previous hardcoded default of 32000 was silently wrong for models with a different vocabulary size
- Raise a clear ValueError if logit_bias is provided but vocab_size is None, instead of crashing with a cryptic TypeError

## Test Coverage

tests/unittest/llmapi/apps/test_harmony_parsing.py::test_none_tokenizer_num_postprocess_workers

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for logit_bias parameter to prevent issues when the server is configured without tokenizer access (such as when postprocessing workers are enabled).
  * Enhanced error reporting to clearly communicate when logit_bias cannot be applied due to missing tokenizer configuration.
  * Improved vocabulary size handling to gracefully manage configurations with optional tokenizer availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->