### PR TITLE
[TRTLLM-10491][test] unwaive DeepSeekV3Lite nvfp4 4gpus test (flaky, self-healed)

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -196,7 +196,6 @@ examples/test_medusa.py::test_llm_medusa_with_qaunt_base_model_1gpu[fp8-use_cpp_
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_guided_decoding_4gpus[one_model] SKIP (https://nvbugs/5596343)
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_guided_decoding_4gpus[two_model] SKIP (https://nvbugs/5596343)
 examples/test_ray.py::test_llm_inference_distributed_ray[tp2pp2] SKIP (https://nvbugs/5781731)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_nvfp4_4gpus[moe_backend=CUTLASS-mtp_nextn=0-tp2pp2-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-low_precision_combine=False-torch_compile=True] SKIP (https://nvbugs/5819005)
 unittest/llmapi/test_mpi_session.py::test_llmapi_launch_multiple_tasks SKIP (https://nvbugs/5819014)
 unittest/_torch/thop/serial/test_moe.py::TestMoeFp4::test_gptoss_style_nvfp4[limit1-beta0-alpha1-RoutingGPTOSS-512-512-1] SKIP (https://nvbugs/5819042)
 llmapi/test_llm_examples.py::test_llmapi_tensorrt_engine SKIP (https://nvbugs/5820553)


### PR DESCRIPTION
## Background

NVBug 5819005 was filed on 2026-01-17 after a single CI failure on
`TestDeepSeekV3Lite::test_nvfp4_4gpus` with the configuration
`moe_backend=CUTLASS-mtp_nextn=0-tp2pp2-fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-low_precision_combine=False-torch_compile=True`
on DGX B300 (4 GPU). Accuracy fell to 60.235, 0.27% below the
statistical threshold of 60.507. The test was waived in
`tests/integration/test_lists/waives.txt` pending investigation.

## Evidence this is flaky / self-healed

**CI history (2025-12-01 ~ 2026-04-20):**
- ~349 runs total: **348 PASSED, 1 FAILED**
- The single failure was on 2026-01-18, all other runs PASSED

**Local verification (DGX B300, 4 GPU, 2026-04-16):**
Ran the exact waived configuration 10 times on current `main`:

| Run | Accuracy | Result |
|-----|----------|--------|
| 1 | 64.22 | PASSED |
| 2 | 64.63 | PASSED |
| 3 | 63.27 | PASSED |
| 4 | 63.38 | PASSED |
| 5 | 64.06 | PASSED |
| 6 | 63.27 | PASSED |
| 7 | 63.72 | PASSED |
| 8 | 63.68 | PASSED |
| 9 | 63.31 | PASSED |
| 10 | 63.72 | PASSED |

- **10/10 PASSED**
- Accuracy range: 63.27 ~ 64.63 (avg **63.726**, essentially equal
  to reference 63.710)
- Worst case is **+2.76% above threshold** (60.507), ~10x the
  original failure margin (−0.27%)
- The 2026-01-18 low-accuracy run (60.235) is not reproducible

## Conclusion

One isolated failure in ~349 CI runs, no local reproduction in 10
consecutive runs on current `main`, and accuracy distribution
centered on the reference value — this is flaky behavior under an
older software stack that has since self-healed. Safe to remove
the waive.

## Changes

- Remove the waive entry for this test from
  `tests/integration/test_lists/waives.txt`

## Test plan

- [x] Ran the waived configuration 10 times locally on DGX B300
      (4 GPU), 10/10 PASSED
- [x] CI run with the waive removed (triggered via `/bot run` on this PR)

## Linked

- JIRA: [TRTLLM-10491](https://jirasw.nvidia.com/browse/TRTLLM-10491)
- NVBug: https://nvbugs/5819005
