### PR TITLE
[None][feat] Add hit-rate gate and fair-share cap to KV-aware ADP router

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -388,12 +388,6 @@ class PyExecutor:
             self.enable_kv_cache_reuse
             and self.kv_cache_manager.enable_partial_reuse)
 
-        self.adp_router: ADPRouter = ADPRouter.create(
-            dist=self.dist,
-            kv_cache_manager=self.kv_cache_manager,
-            attention_dp_config=self.llm_args.attention_dp_config,
-        )
-
         self.max_input_len = max_input_len
         # _executor_loop private data
         self.max_num_active_requests = model_engine.get_max_num_sequences()
@@ -405,6 +399,16 @@ class PyExecutor:
             self.resource_manager,
             should_store_blocks=self.enable_partial_reuse_for_disagg
             and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1)
+
+        # Router is built after async_transfer_manager so KVCacheAwareADPRouter
+        # can receive the transfer-manager reference at construction time.
+        self.adp_router: ADPRouter = ADPRouter.create(
+            dist=self.dist,
+            kv_cache_manager=self.kv_cache_manager,
+            attention_dp_config=self.llm_args.attention_dp_config,
+            async_transfer_manager=self.async_transfer_manager,
+        )
+
         self.previous_batch: Optional[BatchState] = None
         self.has_previous_draft_tokens = False
         self.num_scheduled_requests: int = 0
@@ -2711,6 +2715,7 @@ class PyExecutor:
             # extra allgather. When introducing new router implementations
             # (e.g. KV-cache-aware) that need new_requests to gather additional
             # info, the allgather position may need to be revisited.
+
             all_rank_states = self.adp_router.gather_all_rank_states(
                 active_requests)
             all_ranks_num_active_requests = [

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -18,10 +18,14 @@ Includes:
 from __future__ import annotations
 
 import heapq
+import math
+import random
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from dataclasses import astuple, dataclass
 from typing import TYPE_CHECKING, Dict, List, Tuple
+
+from tensorrt_llm.logger import logger
 
 if TYPE_CHECKING:
     from tensorrt_llm._torch.distributed.communicator import Distributed
@@ -79,7 +83,11 @@ class ADPRouter(ABC):
 
     @classmethod
     def create(
-        cls, dist: "Distributed", kv_cache_manager=None, attention_dp_config=None
+        cls,
+        dist: "Distributed",
+        kv_cache_manager=None,
+        attention_dp_config=None,
+        async_transfer_manager=None,
     ) -> "ADPRouter":
         """Factory method to create the appropriate ADP router.
 
@@ -87,6 +95,9 @@ class ADPRouter(ABC):
             dist: Distributed communicator.
             kv_cache_manager: KV cache manager instance (may be None).
             attention_dp_config: AttentionDpConfig instance (may be None).
+            async_transfer_manager: PyExecutor's AsyncTransferManager, used by
+                KVCacheAwareADPRouter to account for KV-transfer-in-progress
+                requests in per-rank load.  Ignored by DefaultADPRouter.
 
         Returns:
             A KVCacheAwareADPRouter if config requests it and the
@@ -103,6 +114,9 @@ class ADPRouter(ABC):
                 dist=dist,
                 kv_cache_manager=kv_cache_manager,
                 load_balance_weight=attention_dp_config.kv_cache_routing_load_balance_weight,
+                match_rate_threshold=attention_dp_config.kv_cache_routing_match_rate_threshold,
+                fair_share_multiplier=attention_dp_config.kv_cache_routing_fair_share_multiplier,
+                async_transfer_manager=async_transfer_manager,
             )
 
         return DefaultADPRouter(dist=dist)
@@ -343,24 +357,51 @@ class KVCacheAwareADPRouter(ADPRouter):
 
     needs_prefix_matches: bool = True
 
-    def __init__(self, dist: "Distributed", kv_cache_manager, load_balance_weight: float = 1.0):
+    def __init__(
+        self,
+        dist: "Distributed",
+        kv_cache_manager,
+        load_balance_weight: float = 1.0,
+        match_rate_threshold: float = 0.1,
+        fair_share_multiplier: float = 2.0,
+        async_transfer_manager=None,
+    ):
         super().__init__(dist)
         self.kv_cache_manager = kv_cache_manager
         self.load_balance_weight = load_balance_weight
+        self.match_rate_threshold = match_rate_threshold
+        self.fair_share_multiplier = fair_share_multiplier
         self._all_ranks_prefix_matches: List[Dict[int, int]] = []
+        # Requests still sending KV to GEN are invisible in active_requests;
+        # fold them back in via the transfer manager (see create_rank_state).
+        self.async_transfer_manager = async_transfer_manager
 
     def create_rank_state(
         self,
         active_requests: list[LlmRequest],
         new_requests: list[RequestQueueItem],
     ) -> RankState:
-        if self.dist.has_cp_helix:
-            num_active_tokens = sum(req.total_input_len_cp for req in active_requests)
-        else:
-            num_active_tokens = sum(req.py_orig_prompt_len for req in active_requests)
+        # Remaining-to-compute tokens for a live request (net of KV cache
+        # hits), matching the (req_tokens - match_len) scale used by
+        # route_requests scoring.
+        def _active_tokens(req) -> int:
+            if self.dist.has_cp_helix:
+                return max(req.total_input_len_cp - req.cached_tokens, 0)
+            return max(req.py_orig_prompt_len - req.cached_tokens, 0)
+
+        num_active_tokens = sum(_active_tokens(req) for req in active_requests)
+        n_active_for_state = len(active_requests)
+
+        # Fold in requests mid KV-transfer to GEN; they are removed from
+        # active_requests but still counted as per-rank load.
+        if self.async_transfer_manager is not None:
+            in_transfer = self.async_transfer_manager.requests_in_transfer()
+            num_active_tokens += sum(_active_tokens(r) for r in in_transfer.values())
+            n_active_for_state += len(in_transfer)
+
         return RankState(
             rank=self.dist.tp_rank,
-            num_active_requests=len(active_requests),
+            num_active_requests=n_active_for_state,
             num_active_tokens=num_active_tokens,
         )
 
@@ -430,6 +471,16 @@ class KVCacheAwareADPRouter(ADPRouter):
             return ()
         return tuple(token_ids[:num_tokens])
 
+    @staticmethod
+    def _req_tokens(req_item) -> int:
+        if req_item.request is None:
+            return 0
+        return len(getattr(req_item.request, "input_token_ids", []))
+
+    def _match_len(self, rank: int, req_id: int) -> int:
+        matches = self._all_ranks_prefix_matches
+        return matches[rank].get(req_id, 0) if rank < len(matches) else 0
+
     def route_requests(
         self,
         all_rank_states: list[RankState],
@@ -462,82 +513,108 @@ class KVCacheAwareADPRouter(ADPRouter):
                     and all_ranks_num_active_requests[target_dp_rank] < max_num_active_requests
                 ):
                     all_ranks_num_active_requests[target_dp_rank] += 1
+                    # Keep token tally in sync with the soft-balancing phase.
+                    effective = max(
+                        self._req_tokens(req_item) - self._match_len(target_dp_rank, req_item.id),
+                        0,
+                    )
+                    all_ranks_num_active_tokens[target_dp_rank] += effective
                     scheduled = True
                     all_ranks_new_requests[target_dp_rank].append(req_item)
 
             if not scheduled:
                 remaining_unscheduled.append(req_item)
 
-        num_new_requests_all_ranks = len(remaining_unscheduled)
-        total_num_active_requests = sum(all_ranks_num_active_requests)
-        expected_num_active_requests = max(
-            (total_num_active_requests + num_new_requests_all_ranks + tp_size - 1) // tp_size,
-            max(all_ranks_num_active_requests),
-        )
-
-        # --- Prefix-affinity sorting ---
-        # Sort by prefix fingerprint first (group related requests together),
-        # then by ISL descending within each group.  This ensures that when
-        # request A (conv X, turn 5) is routed to rank R, request B (conv X,
-        # turn 3) is processed next and the load tracker still favours rank R.
+        # Group requests by prefix fingerprint so related turns of the same
+        # conversation see each other's load-tracker updates; longer ISL
+        # first within a group.
         def _sort_key(req_item):
             tokens = getattr(req_item.request, "input_token_ids", []) if req_item.request else []
-            fp = self._prefix_fingerprint(tokens)
-            # Negate length so longer requests come first within each group
-            return (fp, -len(tokens))
+            return (self._prefix_fingerprint(tokens), -len(tokens))
 
         remaining_unscheduled = sorted(remaining_unscheduled, key=_sort_key)
 
+        # Loose cap at fair_share_multiplier * ceil(total / tp_size): safety
+        # net against runaway concentration, still loose enough that cache
+        # affinity wins in the common case.
+        num_new_requests_all_ranks = len(remaining_unscheduled)
+        total_num_active_requests = sum(all_ranks_num_active_requests)
+        fair_share = (
+            total_num_active_requests + num_new_requests_all_ranks + tp_size - 1
+        ) // tp_size
+        expected_num_active_requests = max(
+            math.ceil(self.fair_share_multiplier * fair_share),
+            max(all_ranks_num_active_requests),
+        )
         eligible_ranks = [
             rank
             for rank in range(tp_size)
             if all_ranks_num_active_requests[rank] < expected_num_active_requests
         ]
 
-        prefix_matches = self._all_ranks_prefix_matches
-
         for req_item in remaining_unscheduled:
             if not eligible_ranks:
                 break
 
-            req_tokens = (
-                len(getattr(req_item.request, "input_token_ids", [])) if req_item.request else 0
-            )
+            req_tokens = self._req_tokens(req_item)
             req_id = req_item.id
 
-            best_rank = eligible_ranks[0]
+            # Shuffle eligible ranks per decision so score ties fall to a
+            # uniform random pick instead of "lowest index wins" (which
+            # starves high-index ranks during cold start).  Seed with
+            # req_id so every TP rank produces the same permutation --
+            # route_requests runs locally on every rank with no broadcast,
+            # so divergence would deadlock the distributed protocol.
+            iter_ranks = list(eligible_ranks)
+            random.Random(req_id).shuffle(iter_ranks)
+            best_rank = iter_ranks[0]
             best_score = float("inf")
 
-            # --- Normalize load term ---
-            # Normalize each rank's active_tokens by the total load across all
-            # eligible ranks (floored to req_tokens to avoid dividing by ~0).
-            # This makes the load term scale-invariant: a rank carrying 2x the
-            # average load gets a normalized penalty of ~req_tokens regardless
-            # of whether total load is 100 tokens or 100 000 tokens.
-            # Using load_range (max-min) instead caused the penalty to blow up
-            # when all ranks were near-idle (small range, large relative fraction).
+            # Normalize per-rank active_tokens by the total load across
+            # eligible ranks (floored to req_tokens to avoid ~0 division),
+            # so the load penalty is scale-invariant.
             total_load = sum(all_ranks_num_active_tokens[r] for r in eligible_ranks)
             load_denom = max(total_load, float(req_tokens))
 
-            for rank in eligible_ranks:
-                match_len = prefix_matches[rank].get(req_id, 0) if rank < len(prefix_matches) else 0
+            # Per-rank prefix match lengths, reused by gate + scoring +
+            # post-decision bookkeeping.
+            match_lens = {r: self._match_len(r, req_id) for r in eligible_ranks}
+
+            # Cache-affinity gate: below the threshold, zero out match_len
+            # so routing is driven purely by load.
+            max_match_for_req = max(match_lens.values(), default=0)
+            cache_affinity_active = (
+                max_match_for_req / max(req_tokens, 1)
+            ) > self.match_rate_threshold
+
+            for rank in iter_ranks:
+                match_len = match_lens[rank] if cache_affinity_active else 0
                 score = self._score_rank(
                     req_tokens, match_len, all_ranks_num_active_tokens[rank], load_denom
                 )
-                if score < best_score:
+                # Tie-break on active_tokens to spread traffic when scores
+                # collide; cache-affinity wins are unaffected (lower score).
+                if (score, all_ranks_num_active_tokens[rank]) < (
+                    best_score,
+                    all_ranks_num_active_tokens[best_rank],
+                ):
                     best_score = score
                     best_rank = rank
 
             all_ranks_new_requests[best_rank].append(req_item)
             all_ranks_num_active_requests[best_rank] += 1
 
-            match_len = (
-                prefix_matches[best_rank].get(req_id, 0) if best_rank < len(prefix_matches) else 0
-            )
-            effective_added = req_tokens - match_len
+            effective_added = max(req_tokens - match_lens[best_rank], 0)
             all_ranks_num_active_tokens[best_rank] += effective_added
 
+            # Progressive eviction: rank leaves eligibility once it hits
+            # the cap for the rest of this batch.
             if all_ranks_num_active_requests[best_rank] >= expected_num_active_requests:
                 eligible_ranks.remove(best_rank)
+
+        logger.debug(
+            f"[adp_router] new_reqs_per_rank="
+            f"{[len(all_ranks_new_requests[r]) for r in range(tp_size)]}"
+        )
 
         return all_ranks_new_requests, expected_num_active_requests

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -621,6 +621,29 @@ class AttentionDpConfig(StrictBaseModel):
         "Weight (beta) for the load-balance term in KV cache-aware routing. "
         "Higher values prioritize load balance over cache affinity. "
         "Only used when enable_kv_cache_aware_routing is True.")
+    kv_cache_routing_match_rate_threshold: float = Field(
+        default=0.1,
+        description=
+        "Cache-affinity gate in KV cache-aware routing. For each request, "
+        "match_len contributes to scoring only when max(match_len) / "
+        "request_tokens across eligible ranks is strictly above this "
+        "threshold; otherwise match_len is forced to 0 so routing is driven "
+        "purely by load. Default 0.1 requires at least a 10% hit rate before "
+        "cache affinity kicks in, which prevents a small universal prefix "
+        "(e.g. a shared system prompt) from pinning all traffic to the "
+        "first warm ranks. Set to 0.0 to honour any nonzero match. "
+        "Only used when enable_kv_cache_aware_routing is True.")
+    kv_cache_routing_fair_share_multiplier: float = Field(
+        default=2.0,
+        description=
+        "Loose per-rank active-request cap in KV cache-aware routing, "
+        "expressed as a multiplier of the ceil fair-share "
+        "(ceil((total_active + new) / tp_size)). Once a rank hits this cap "
+        "within a scheduling batch it is removed from the eligible set for "
+        "the remainder of the batch. Default 2.0 permits a 2x slack so "
+        "cache affinity can dominate while preventing runaway concentration "
+        "on a single rank. Set to 1.0 for strict fair share. "
+        "Only used when enable_kv_cache_aware_routing is True.")
 
     @model_validator(mode='after')
     def validate_attention_dp_config(self) -> 'AttentionDpConfig':

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -15,6 +15,7 @@ from tensorrt_llm._torch.pyexecutor.scheduler import FCFSWaitingQueue
 from tensorrt_llm._torch.pyexecutor.scheduler.adp_router import (
     ADPRouter,
     DefaultADPRouter,
+    KVCacheAwareADPRouter,
     RankState,
 )
 
@@ -822,3 +823,137 @@ def test_balance_requests_across_ranks_token_count_sorting():
     assert result[0][0] == req2
     assert result[1][0] == req3
     assert result[2][0] == req1
+
+
+class TestKVCacheAwareADPRouterRouting:
+    """Routing behavior of KVCacheAwareADPRouter."""
+
+    def _make_router(
+        self,
+        tp_size=2,
+        tp_rank=0,
+        lbw=1.0,
+        match_rate_threshold=0.1,
+        fair_share_multiplier=2.0,
+        prefix_matches=None,
+    ):
+        dist = _mock_dist(tp_rank=tp_rank, tp_size=tp_size)
+        dist.tp_allgather = lambda data: [list(data) for _ in range(tp_size)]
+        kv_cache_manager = MagicMock()
+        kv_cache_manager.enable_block_reuse = True
+        router = KVCacheAwareADPRouter(
+            dist=dist,
+            kv_cache_manager=kv_cache_manager,
+            load_balance_weight=lbw,
+            match_rate_threshold=match_rate_threshold,
+            fair_share_multiplier=fair_share_multiplier,
+        )
+        if prefix_matches is None:
+            # Default: rank 0 has 0 match, rank 1 has 50 match on req 1.
+            prefix_matches = [
+                {0: 0, 1: 0},
+                {0: 0, 1: 50},
+            ]
+        router._all_ranks_prefix_matches = prefix_matches
+        return router
+
+    def _rank_states(self, tp_size, active_reqs=None, active_tokens=None):
+        active_reqs = active_reqs or [0] * tp_size
+        active_tokens = active_tokens or [0] * tp_size
+        return [
+            RankState(
+                rank=r, num_active_requests=active_reqs[r], num_active_tokens=active_tokens[r]
+            )
+            for r in range(tp_size)
+        ]
+
+    def test_cache_affinity_wins(self):
+        """50/100 = 50% match is well above the 0.1 default gate, so the
+        request must land on the rank holding the cache (rank 1)."""
+        router = self._make_router(tp_size=2, lbw=0.5)
+        req = _make_request_item(req_id=1, num_tokens=100)
+        result, _ = router.route_requests(self._rank_states(2), [req], max_num_active_requests=10)
+        assert result[0] == []
+        assert result[1] == [req]
+
+    def test_match_rate_threshold_gates_cache_affinity(self):
+        """With rank 0 loaded but holding cache, and rank 1 idle with no
+        cache:
+        - threshold below the hit rate (0.5 < 0.6) keeps cache affinity
+          active and routes to rank 0.
+        - threshold above the hit rate (0.7 >= 0.6) suppresses affinity
+          and the idle rank 1 wins on load.
+        """
+        prefix_matches = [{1: 60}, {1: 0}]
+        states = [
+            RankState(rank=0, num_active_requests=1, num_active_tokens=100),
+            RankState(rank=1, num_active_requests=0, num_active_tokens=0),
+        ]
+
+        router_active = self._make_router(
+            tp_size=2,
+            lbw=0.1,
+            match_rate_threshold=0.5,
+            prefix_matches=prefix_matches,
+        )
+        req = _make_request_item(req_id=1, num_tokens=100)
+        result_active, _ = router_active.route_requests(states, [req], max_num_active_requests=10)
+        assert result_active[0] == [req]
+        assert result_active[1] == []
+
+        router_gated = self._make_router(
+            tp_size=2,
+            lbw=0.1,
+            match_rate_threshold=0.7,
+            prefix_matches=prefix_matches,
+        )
+        req = _make_request_item(req_id=1, num_tokens=100)
+        result_gated, _ = router_gated.route_requests(states, [req], max_num_active_requests=10)
+        assert result_gated[0] == []
+        assert result_gated[1] == [req]
+
+    def test_fair_share_multiplier_caps_per_rank(self):
+        """With 8 requests all preferring rank 0 (cache hit), a loose
+        multiplier lets rank 0 absorb them all; a strict multiplier=1.0
+        evicts rank 0 at the fair share and spreads the remainder across
+        the other ranks."""
+        tp_size = 4
+        # rank 0 has an 80-token match on every req; other ranks have none.
+        prefix_matches = [{i: 80 for i in range(8)}] + [
+            {i: 0 for i in range(8)} for _ in range(tp_size - 1)
+        ]
+        states = [
+            RankState(rank=r, num_active_requests=0, num_active_tokens=0) for r in range(tp_size)
+        ]
+
+        # Loose (multiplier=4.0 -> cap = 4 * ceil(8/4) = 8): rank 0 takes all.
+        router_loose = self._make_router(
+            tp_size=tp_size,
+            lbw=0.1,
+            match_rate_threshold=0.0,
+            fair_share_multiplier=4.0,
+            prefix_matches=prefix_matches,
+        )
+        reqs_loose = [_make_request_item(req_id=i, num_tokens=100) for i in range(8)]
+        result_loose, _ = router_loose.route_requests(
+            states, reqs_loose, max_num_active_requests=100
+        )
+        assert len(result_loose[0]) == 8
+        for r in range(1, tp_size):
+            assert result_loose[r] == []
+
+        # Strict (multiplier=1.0 -> cap = ceil(8/4) = 2): rank 0 evicted
+        # after 2; remaining 6 spread across ranks 1..3.
+        router_strict = self._make_router(
+            tp_size=tp_size,
+            lbw=0.1,
+            match_rate_threshold=0.0,
+            fair_share_multiplier=1.0,
+            prefix_matches=prefix_matches,
+        )
+        reqs_strict = [_make_request_item(req_id=i, num_tokens=100) for i in range(8)]
+        result_strict, _ = router_strict.route_requests(
+            states, reqs_strict, max_num_active_requests=100
+        )
+        assert len(result_strict[0]) == 2
+        assert sum(len(result_strict[r]) for r in range(1, tp_size)) == 6

--- a/tests/unittest/_torch/executor/test_kvcache_aware_router.py
+++ b/tests/unittest/_torch/executor/test_kvcache_aware_router.py
@@ -94,8 +94,8 @@ class TestKVCacheAwareADPRouter:
         mgr = _mock_kv_cache_manager()
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
 
-        req1 = Mock(py_orig_prompt_len=100)
-        req2 = Mock(py_orig_prompt_len=200)
+        req1 = Mock(py_orig_prompt_len=100, cached_tokens=0)
+        req2 = Mock(py_orig_prompt_len=200, cached_tokens=0)
         state = router.create_rank_state([req1, req2], [])
         assert state.rank == 0
         assert state.num_active_requests == 2
@@ -106,7 +106,7 @@ class TestKVCacheAwareADPRouter:
         mgr = _mock_kv_cache_manager()
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
 
-        req1 = Mock(total_input_len_cp=150)
+        req1 = Mock(total_input_len_cp=150, cached_tokens=0)
         state = router.create_rank_state([req1], [])
         assert state.rank == 1
         assert state.num_active_tokens == 150
@@ -269,7 +269,11 @@ class TestKVCacheAwareADPRouter:
         """
         dist = _mock_dist(tp_rank=0, tp_size=2)
         mgr = _mock_kv_cache_manager()
-        router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
+        # Pin fair_share_multiplier=1.0 so the cap equals fair_share (2).
+        # This test isolates the effective-token bookkeeping from the
+        # cap-relaxation behavior covered separately in
+        # test_fair_share_multiplier_caps_per_rank.
+        router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, fair_share_multiplier=1.0)
 
         # Requests 1,2 have cache on rank 0; requests 3,4 have no cache
         router._all_ranks_prefix_matches = [


### PR DESCRIPTION
## Description

Tunes `KVCacheAwareADPRouter` so cache affinity and load balance work together instead of fighting each other. Three behaviour changes, one config surface change, and a small amount of cleanup.

### 1. Hit-rate gate — `kv_cache_routing_match_rate_threshold` (default `0.1`)
For each request, `match_len` contributes to scoring only when `max(match_len) / request_tokens` across eligible ranks is strictly above the threshold; below it, `match_len` is forced to `0` and routing is driven purely by load. This prevents a small universal prefix (e.g. a shared system prompt) from pinning all traffic to the first warm ranks. Set to `0.0` to honour any nonzero match.

### 2. Fair-share cap — `kv_cache_routing_fair_share_multiplier` (default `2.0`)
Per-rank active-request cap expressed as a multiplier of the ceil fair-share, i.e. `fair_share_multiplier * ceil((total_active + new) / tp_size)`. Once a rank hits the cap within a scheduling batch it is dropped from the eligible set for the rest of that batch. `2.0` leaves enough slack for affinity to win in the common case while preventing runaway concentration; set to `1.0` for strict fair share.

### 3. Transfer-in-progress load accounting
Requests mid-KV-transfer to GEN are no longer visible in `active_requests`, so the router used to under-count load on the rank that is sending. The router now pulls `requests_in_transfer()` from the PyExecutor's `AsyncTransferManager` and folds those requests into both `num_active_requests` and `num_active_tokens` when building each rank's `RankState`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two configuration parameters to control KV cache-aware routing behavior: `kv_cache_routing_match_rate_threshold` and `kv_cache_routing_fair_share_multiplier`.

* **Improvements**
  * Optimized request routing algorithm to better utilize KV cache affinity while maintaining balanced load distribution across distributed ranks.
  * Improved handling of asynchronous request transfers during routing initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->