### PR TITLE
[https://nvbugs/5919796][fix] AutoDeploy: Fix TP deadlock in multistream MoE

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/utils/multi_stream_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/multi_stream_utils.py
@@ -156,24 +156,22 @@ def begin_aux_stream_passthrough(
     # which is NOT ``torch.cuda.default_stream()``.
     caller_stream = torch.cuda.current_stream(device)
     cuda_stream_manager._caller_streams[device] = caller_stream
-    # Synchronize the caller stream before switching to aux.  The GPU-side
-    # event wait (aux_stream.wait_event) alone is NOT sufficient when
-    # MLIR-generated Triton kernels precede this point: their interaction
-    # with PyTorch's CUDA caching allocator can cause the allocator to
-    # recycle memory that the aux stream still needs, leading to illegal
-    # memory accesses or silent data corruption.  A CPU-side synchronize
-    # ensures all caller-stream GPU work has retired before aux-stream
-    # allocations begin.
-    # NOTE: this cannot be called during CUDA graph capture.  The cudagraph
-    # path must rely on event-based sync only; a separate fix is needed
-    # there (see TRTLLM multi_stream_moe + MLIR tracking).
-    if not torch.cuda.is_current_stream_capturing():
-        caller_stream.synchronize()
     # Record where the caller's stream has reached so aux knows when data is ready.
     main_event = cuda_stream_manager.get_event(device, cuda_stream_manager.MAIN_STREAM_NAME)
     main_event.record(caller_stream)
     # Switch the thread-local current stream to aux.
     aux_stream = cuda_stream_manager.get_stream(device, cuda_stream_manager.AUX_STREAM_NAME)
+    # Tell the caching allocator that x is also live on aux_stream.  Without
+    # this, MLIR/Triton kernels that produced x on the main stream can cause
+    # the allocator to recycle x's backing storage before aux-stream work
+    # has consumed it, leading to silent data corruption or illegal accesses.
+    # record_stream is the idiomatic PyTorch solution for this cross-stream
+    # liveness problem: it is a CPU-only allocator hint, never a GPU sync,
+    # so it cannot deadlock with in-flight NCCL collectives.
+    # NOTE: skip during CUDA graph capture — passthrough partitions are
+    # reclassified as dynamic and won't be captured anyway.
+    if not torch.cuda.is_current_stream_capturing():
+        x.record_stream(aux_stream)
     torch.cuda.set_stream(aux_stream)
     # Make aux wait for the main-stream event before executing any work.
     aux_stream.wait_event(main_event)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -281,7 +281,6 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_bf16[latency] SKIP (https:/
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_pp4_mtp] SKIP (https://nvbugs/6018046)
 test_fmha.py::test_fmha SKIP (https://nvbugs/6018058)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp] SKIP (https://nvbugs/6029882)
-accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_accuracy[fp8-4-attn_dp_off-trtllm] SKIP (https://nvbugs/6058066)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=True-enable_chunked_prefill=False-v2_kv_cache=False] SKIP (https://nvbugs/6027594)
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_pard[overlap_scheduler=True] SKIP (https://nvbugs/6037653)
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_pard[overlap_scheduler=False] SKIP (https://nvbugs/6037653)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -281,7 +281,6 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_bf16[latency] SKIP (https:/
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_pp4_mtp] SKIP (https://nvbugs/6018046)
 test_fmha.py::test_fmha SKIP (https://nvbugs/6018058)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp] SKIP (https://nvbugs/6029882)
-accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_accuracy[bf16-4-attn_dp_off-trtllm] SKIP (https://nvbugs/5919796)
 accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_accuracy[fp8-4-attn_dp_off-trtllm] SKIP (https://nvbugs/6058066)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16[mtp_nextn=0-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=True-enable_chunked_prefill=False-v2_kv_cache=False] SKIP (https://nvbugs/6027594)
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_pard[overlap_scheduler=True] SKIP (https://nvbugs/6037653)


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

caller_stream.synchronize() deadlocks under multi-rank eager execution when a NCCL collective is in-flight on the main stream: all ranks block simultaneously on the CPU-side sync waiting for the collective to complete, but the collective cannot complete because all ranks are blocked — circular deadlock.

The synchronize() was added in PR #12847 to fix an accuracy regression caused by the PyTorch caching allocator recycling tensor memory too early across streams. This fix addresses the same underlying allocator liveness problem using `x.record_stream(aux_stream)` - a CPU-only allocator hint that prevents premature memory recycling without ever blocking the CPU thread. Since record_stream returns immediately regardless of NCCL state, the deadlock cannot occur.

**Important note**: the original bug (5919796) pre-dates PR #12847, and was consistently reproduced at the time. Currently, the test fails only rarely. The only deadlock reproduction we have is tied to the synchronize() code path introduced in #12847.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized GPU stream handling for improved synchronization efficiency.

* **Tests**
  * Re-enabled previously skipped accuracy tests for LLM API auto-deploy backend configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->