### PR TITLE
[None][feat] Add per-rank iteration stats to /metrics endpoint

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1351,7 +1351,88 @@ class PyExecutor:
     def _append_iter_stats(self,
                            stats: IterationStats,
                            req_stats: Optional[List[RequestStats]] = None):
+        """Append one iteration's stats to the export buffer.
 
+        Under attention-DP with ``tp_size > 1`` each rank has diverging
+        scheduler/KV-cache state. When the environment variable
+        ``TLLM_METRICS_ALL_RANKS=1`` is set, this method collectively
+        gathers every rank's :class:`IterationStats` (+ optional per-request
+        stats and KV iteration stats) via :meth:`tp_allgather` and rank 0
+        stores one pre-serialized JSON dict per rank (tagged with
+        ``"rank"``) in ``self.stats`` so ``/metrics`` can export stats from
+        every rank. Non-leader ranks drop the gathered result.
+
+        The env var defaults to off so upstream behavior (rank-0-only
+        export) is preserved unless users explicitly opt in. Under pure TP
+        (no attention-DP) every rank runs the same requests on the same
+        iteration, so the gather would be redundant and only adds a CPU-GPU
+        sync on the hot path — we fall through to the legacy rank-0-only
+        append in that case regardless of the env var.
+
+        Args:
+            stats: Iteration-level stats from the local rank.
+            req_stats: Optional per-request stats from the local rank.
+        """
+
+        tp_size = getattr(self.dist, "tp_size", 1)
+        gather_all_ranks = os.environ.get("TLLM_METRICS_ALL_RANKS", "0") == "1"
+        if (gather_all_ranks and self.enable_iter_perf_stats and tp_size > 1
+                and self.enable_attention_dp):
+            import json as _json
+            local_dict = _json.loads(stats.to_json_str())
+            if req_stats:
+                local_dict["requestStats"] = [
+                    _json.loads(r.to_json_str()) for r in req_stats
+                ]
+            if self._latest_kv_iter_stats is not None:
+                local_dict["kvCacheIterationStats"] = {
+                    str(window_size): {
+                        "primaryMaxNumBlocks": s.primary_max_num_blocks,
+                        "primaryFreeNumBlocks": s.primary_free_num_blocks,
+                        "primaryUsedNumBlocks": s.primary_used_num_blocks,
+                        "secondaryMaxNumBlocks": s.secondary_max_num_blocks,
+                        "secondaryFreeNumBlocks": s.secondary_free_num_blocks,
+                        "secondaryUsedNumBlocks": s.secondary_used_num_blocks,
+                        "iterAllocTotalBlocks": s.iter_alloc_total_blocks,
+                        "iterAllocNewBlocks": s.iter_alloc_new_blocks,
+                        "iterReusedBlocks": s.iter_reused_blocks,
+                        "iterFullReusedBlocks": s.iter_full_reused_blocks,
+                        "iterPartialReusedBlocks": s.iter_partial_reused_blocks,
+                        "iterMissedBlocks": s.iter_missed_blocks,
+                        "iterCacheHitRate": s.iter_cache_hit_rate,
+                        "iterGenAllocBlocks": s.iter_gen_alloc_blocks,
+                        "iterOnboardBlocks": s.iter_onboard_blocks,
+                        "iterOnboardBytes": s.iter_onboard_bytes,
+                        "iterOffloadBlocks": s.iter_offload_blocks,
+                        "iterOffloadBytes": s.iter_offload_bytes,
+                        "iterIntraDeviceCopyBlocks":
+                        s.iter_intra_device_copy_blocks,
+                        "iterIntraDeviceCopyBytes":
+                        s.iter_intra_device_copy_bytes,
+                    }
+                    for window_size, s in self._latest_kv_iter_stats.items()
+                }
+            local_dict["rank"] = self.dist.tp_rank
+
+            gathered = self.dist.tp_allgather(local_dict)
+
+            if self.dist.tp_rank == 0:
+                with self.stats_lock:
+                    # Wrap as ("per_rank_dict", dict) so the serializer can
+                    # distinguish from the legacy (stats, req_stats, kv) tuple.
+                    # Trim before appending so every rank's entry for the
+                    # same iteration lands in the buffer atomically; evicting
+                    # during the append loop would let partial iterations
+                    # survive at the head of self.stats.
+                    cap = self.max_stats_len * tp_size
+                    overflow = max(0, len(self.stats) + len(gathered) - cap)
+                    if overflow:
+                        del self.stats[:overflow]
+                    for d in gathered:
+                        self.stats.append(("per_rank_dict", d))
+            return
+
+        # Legacy path: rank-0-only (single-rank or iter stats disabled).
         with self.stats_lock:
             if len(self.stats) > self.max_stats_len:
                 self.stats.pop(0)

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -662,6 +662,12 @@ class BaseWorker(GenerationExecutor):
     # Define a Callable to join iteration and request stats
     @staticmethod
     def _stats_serializer(stats) -> str:
+        # Per-rank path: stats is ("per_rank_dict", {..., "rank": N}).
+        # Already serialized on the producing rank via allgather — just emit.
+        if (isinstance(stats, tuple) and len(stats) == 2
+                and stats[0] == "per_rank_dict"):
+            return json.dumps(stats[1])
+
         iteration_stats, req_stats = stats[0], stats[1]
         kv_iter_stats = stats[2] if len(stats) > 2 else None
 


### PR DESCRIPTION
Previously, /metrics and get_stats_async only returned rank-0's iteration stats. Under attention-DP or any multi-rank PyTorch-executor deployment, each rank has its own KV cache / scheduler / batch state and their utilization can diverge, but only rank 0 was observable.

This change makes PyExecutor._append_iter_stats collectively gather each rank's IterationStats (+ RequestStats, KV cache iter stats) via a tp_allgather. Rank 0 serializes the gathered results to JSON dicts tagged with "rank": N and stores them alongside its local stats so the same existing /metrics transport (RPC -> _iter_stats_result queue -> JSON list) returns one entry per (iteration, rank).

The gather is opt-in via the `TLLM_METRICS_ALL_RANKS=1` environment variable and only runs when `tp_size > 1` and `enable_attention_dp=True`. Default behavior (env unset or `!=1`) is byte-identical to upstream: only rank 0's stats are exported. Non-leader ranks drop the gathered result (they don't export).

base_worker._stats_serializer gains a fast-path: if the buffer entry is the new ("per_rank_dict", {...}) tuple, emit its JSON directly instead of calling to_json_str() on the already-serialized dict.

## Usage

Opt in on every worker process (e.g. via `trtllm-serve` env) in an attention-DP deployment:

```bash
TLLM_METRICS_ALL_RANKS=1 trtllm-serve <model> --tp_size 8 --ep_size 8 \
    --extra_llm_api_options extra_llm_api_options.yaml ...
```

with `enable_attention_dp: true` and `enable_iter_perf_stats: true` in the server config. Then each `/metrics` JSON entry carries a new `"rank": N` field; a single iteration produces N entries (one per rank). Group by `iter` for cross-rank snapshots, or filter by `rank` for per-rank time series.

Under pure TP (no attn-DP) the gather is skipped regardless of the env var — every rank runs the same requests on the same iteration, so per-rank stats would be redundant and the allgather would only add a CPU-GPU sync on the hot path.

## Overhead verification

<img width="1489" height="252" alt="image" src="https://github.com/user-attachments/assets/82ce1fea-db1a-4a62-92a1-2e0d6008f8da" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Monitoring**
  * Enhanced per-rank iteration performance statistics collection for distributed tensor parallel setups when multi-GPU deployment is enabled.
  * Updated statistics serialization format to support per-rank metrics collection and storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

