### PR TITLE
[None][feat] Support tool-calling in KvCacheAwareRouter for disagg serving

### DIFF
--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -711,6 +711,17 @@ class BlockHashMixin:
             if request.prompt_token_ids is not None:
                 return [request.prompt_token_ids]
             tokenizer = self._get_tokenizer(request.model)
+            # Forward tools and chat_template_kwargs so custom tokenizers
+            # (e.g. DeepseekV32Tokenizer) render tool schemas and respect
+            # template flags like `thinking=true` when computing the prompt
+            # token ids used for cache-aware routing AND passed downstream
+            # (prompt_token_ids makes the worker skip re-tokenization).
+            tool_dicts = (None if getattr(request, "tools", None) is None else [
+                tool.model_dump() if hasattr(tool, "model_dump") else tool
+                for tool in request.tools
+            ])
+            chat_template_kwargs = (request.chat_template_kwargs if getattr(
+                request, "chat_template_kwargs", None) else {})
             result = tokenizer.apply_chat_template(
                 [
                     msg if isinstance(msg, dict) else dict(msg)
@@ -719,6 +730,8 @@ class BlockHashMixin:
                 add_generation_prompt=request.add_generation_prompt,
                 tokenize=True,
                 return_dict=False,
+                tools=tool_dicts,
+                **chat_template_kwargs,
             )
             # Some custom tokenizers (e.g. DeepseekV32Tokenizer) return a
             # string from apply_chat_template even with tokenize=True.

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -8,8 +8,10 @@ import pytest
 
 from tensorrt_llm.llmapi.disagg_utils import RouterConfig
 from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
+                                                ChatCompletionToolsParam,
                                                 CompletionRequest,
-                                                DisaggregatedParams)
+                                                DisaggregatedParams,
+                                                FunctionDefinition)
 from tensorrt_llm.serve.router import (BlockHashMixin, ConversationRouter,
                                        KvCacheAwareRouter, LoadBalancingRouter,
                                        RoundRobinRouter, create_router)
@@ -889,3 +891,174 @@ def test_block_hash_mixin_routes_through_transformers_tokenizer():
     # not the TransformersTokenizer wrapper.
     assert out is inner
     assert probe._tokenizers["dummy/model"] is inner
+
+
+# ---------------------------------------------------------------------------
+# _tokenize: tools + chat_template_kwargs forwarding (PR #13232)
+# ---------------------------------------------------------------------------
+
+
+def _get_weather_tool() -> ChatCompletionToolsParam:
+    """Build a sample tool definition matching the OpenAI schema."""
+    return ChatCompletionToolsParam(function=FunctionDefinition(
+        name="get_current_weather",
+        description="Get the current weather for a city.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "city": {
+                    "type": "string",
+                    "description": "City name"
+                }
+            },
+            "required": ["city"],
+        },
+    ))
+
+
+def _mock_tokenizer(token_ids=None):
+    """Return a mock tokenizer with a recorded apply_chat_template.
+
+    ``apply_chat_template`` records its kwargs and returns the supplied
+    token id list.
+    """
+    tok = mock.MagicMock()
+    tok.apply_chat_template.return_value = token_ids or [1, 2, 3, 4, 5]
+    return tok
+
+
+@pytest.mark.parametrize("router_class",
+                         [KvCacheAwareRouter, ConversationRouter])
+def test_tokenize_forwards_tools_and_chat_template_kwargs(router_class):
+    """Regression test for PR #13232.
+
+    ``BlockHashMixin._tokenize`` must forward the request's ``tools`` (as a
+    list of dicts) and ``chat_template_kwargs`` to
+    ``tokenizer.apply_chat_template``. Without this, custom tokenizers that
+    render tool schemas into the prompt (e.g. DeepSeek-V3.2) produce
+    truncated token ids, breaking cache-aware routing decisions and the
+    ``prompt_token_ids`` handed to the worker downstream.
+    """
+    router = router_class(server_role=None,
+                          servers=["server1"],
+                          use_tokens=False,
+                          max_batch_size=32,
+                          tokens_per_block=32)
+
+    tok = _mock_tokenizer()
+    with mock.patch.object(router, "_get_tokenizer", return_value=tok):
+        req = ChatCompletionRequest(
+            model="TinyLlama",
+            messages=[{
+                "role": "user",
+                "content": "what's the weather in Paris?"
+            }],
+            tools=[_get_weather_tool()],
+            chat_template_kwargs={"thinking": True},
+        )
+        router._tokenize(req)
+
+    tok.apply_chat_template.assert_called_once()
+    kwargs = tok.apply_chat_template.call_args.kwargs
+    # tools must be forwarded as a list of dicts (model_dump), not the
+    # Pydantic objects themselves.
+    assert isinstance(kwargs["tools"], list) and len(kwargs["tools"]) == 1
+    tool_dict = kwargs["tools"][0]
+    assert isinstance(tool_dict, dict)
+    assert tool_dict["type"] == "function"
+    assert tool_dict["function"]["name"] == "get_current_weather"
+    assert "parameters" in tool_dict["function"]
+    # chat_template_kwargs must be forwarded as **kwargs (not nested).
+    assert kwargs.get("thinking") is True
+
+
+@pytest.mark.parametrize("router_class",
+                         [KvCacheAwareRouter, ConversationRouter])
+def test_tokenize_without_tools_passes_none(router_class):
+    """Bare chat request: no tools, no chat_template_kwargs.
+
+    ``apply_chat_template`` still runs but receives ``tools=None`` and no
+    extra keyword arguments.
+    """
+    router = router_class(server_role=None,
+                          servers=["server1"],
+                          use_tokens=False,
+                          max_batch_size=32,
+                          tokens_per_block=32)
+
+    tok = _mock_tokenizer()
+    with mock.patch.object(router, "_get_tokenizer", return_value=tok):
+        req = ChatCompletionRequest(model="TinyLlama",
+                                    messages=[{
+                                        "role": "user",
+                                        "content": "hello"
+                                    }])
+        router._tokenize(req)
+
+    tok.apply_chat_template.assert_called_once()
+    kwargs = tok.apply_chat_template.call_args.kwargs
+    assert kwargs["tools"] is None
+    assert "thinking" not in kwargs
+    # messages and add_generation_prompt must still flow through unchanged.
+    assert kwargs["tokenize"] is True
+
+
+def test_tokenize_preserves_empty_tools_list():
+    """Preserve empty tools list distinct from ``None``.
+
+    ``tools=[]`` is semantically distinct from ``tools=None``; preserve it
+    so the router's call matches what the worker's own
+    ``apply_chat_template`` would pass (see ``serve/openai_server.py``
+    tool_dicts assignment).
+    """
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server1"],
+                                use_tokens=False,
+                                max_batch_size=32,
+                                tokens_per_block=32)
+
+    tok = _mock_tokenizer()
+    with mock.patch.object(router, "_get_tokenizer", return_value=tok):
+        req = ChatCompletionRequest(model="TinyLlama",
+                                    messages=[{
+                                        "role": "user",
+                                        "content": "hi"
+                                    }],
+                                    tools=[])
+        router._tokenize(req)
+
+    kwargs = tok.apply_chat_template.call_args.kwargs
+    assert kwargs["tools"] == []
+
+
+def test_tokenize_skipped_when_prompt_token_ids_already_set():
+    """Skip tokenization when ``prompt_token_ids`` is already populated.
+
+    When the caller pre-tokenizes (``prompt_token_ids`` set), the router
+    must not invoke ``apply_chat_template`` at all — the cached token ids
+    are returned as-is.
+    """
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server1"],
+                                use_tokens=False,
+                                max_batch_size=32,
+                                tokens_per_block=32)
+
+    tok = _mock_tokenizer()
+    with mock.patch.object(router, "_get_tokenizer",
+                           return_value=tok) as get_tok:
+        req = ChatCompletionRequest(
+            model="TinyLlama",
+            messages=[{
+                "role": "user",
+                "content": "irrelevant"
+            }],
+            tools=[_get_weather_tool()],
+            chat_template_kwargs={"thinking": True},
+            prompt_token_ids=[10, 20, 30],
+        )
+        out = router._tokenize(req)
+
+    assert out == [[10, 20, 30]]
+    get_tok.assert_not_called()
+    tok.apply_chat_template.assert_not_called()


### PR DESCRIPTION
## Description

`KvCacheAwareRouter._tokenize` pre-tokenizes `ChatCompletionRequest`s to compute routing block-hashes, and sets `request.prompt_token_ids` so the worker server skips re-tokenization. Today it only forwards `request.messages` to `apply_chat_template`, ignoring `request.tools` and `request.chat_template_kwargs`.

For models whose chat templates materialize tools into the prompt (DeepSeek-V3.2 inlines a tool-schema system block via its custom template), this silently drops the entire tool block from the final prompt — even though the client provided `tools` in the API request. Tool-calling requests are then run against a prompt that never saw the tools, which both degrades tool-use behavior and produces incorrect cache-aware routing decisions (block hashes computed over a truncated prompt).

### Change

Forward `request.tools` (unwrapped via `model_dump()`) and `request.chat_template_kwargs` into `apply_chat_template`, so router-side pre-tokenization produces the same prompt token IDs the worker would have produced on its own — tools and template flags included. No behavior change for requests without `tools` or `chat_template_kwargs`.

## Test Coverage

Reproduced on DeepSeek-V3.2 1P1D (DEP8 CTX + TEP8 GEN) with an agentic coding benchmark (12 tools per request, `chat_template_kwargs={"thinking": true}`):

- cache hit rate: 95.2% → 95.9%


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.