### PR TITLE
[#13082][fix] Fix-multimodal embedding mismatch

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -412,6 +412,8 @@ def fuse_input_embeds(
         return input_ids, None
 
     mm_embed = torch.cat(mm_embeds, dim=0)
+    mm_embed_shapes = [tuple(embed.shape) for embed in mm_embeds]
+    multimodal_debug_info = kwargs.get("multimodal_debug_info")
 
     # TODO: support the case where only one index tensor is provided, the other is derived as the complement (try to avoid implicit host-device synchronization)
     if text_token_indices is None or mm_token_indices is None:
@@ -420,10 +422,22 @@ def fuse_input_embeds(
             input_ids,
             vocab_size=embedding_layer.num_embeddings,
             mm_token_ids=mm_token_ids)
+    logger.debug(
+        "Fusing multimodal embeddings: "
+        f"mm_token_count={mm_token_indices.shape[0]}, "
+        f"mm_embedding_shape={tuple(mm_embed.shape)}, "
+        f"mm_embed_shapes={mm_embed_shapes}, "
+        f"multimodal_debug_info={multimodal_debug_info}")
     if mm_token_indices.shape[0] != mm_embed.shape[0]:
+        debug_details = [
+            f"mm_embed_shapes={mm_embed_shapes}",
+            f"text_token_count={text_token_indices.shape[0]}",
+            f"multimodal_debug_info={multimodal_debug_info}",
+        ]
         raise ValueError(
             f"Multimodal token count mismatch: found {len(mm_token_indices)} image tokens in input_ids "
             f"but received {mm_embed.shape[0]} image embeddings. "
+            f"{' '.join(debug_details)} "
             "This is likely due to KV cache reuse, chunk prefill, or other optimizations that "
             "cause token count mismatches within the inference batch.")
 

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -180,9 +180,7 @@ def _cache_multimodal_embeddings(
     logger.debug(
         f"Caching {len(split_embeddings)} multimodal embedding chunks in {len(multimodal_params)} params"
     )
-    for param, embed_chunk in zip(valid_params,
-                                  split_embeddings,
-                                  strict=True):
+    for param, embed_chunk in zip(valid_params, split_embeddings, strict=True):
         param.multimodal_data["multimodal_embedding"] = embed_chunk
 
     logger.debug(
@@ -414,8 +412,6 @@ def fuse_input_embeds(
         return input_ids, None
 
     mm_embed = torch.cat(mm_embeds, dim=0)
-    mm_embed_shapes = [tuple(embed.shape) for embed in mm_embeds]
-    multimodal_debug_info = kwargs.get("multimodal_debug_info")
 
     # TODO: support the case where only one index tensor is provided, the other is derived as the complement (try to avoid implicit host-device synchronization)
     if text_token_indices is None or mm_token_indices is None:
@@ -425,17 +421,9 @@ def fuse_input_embeds(
             vocab_size=embedding_layer.num_embeddings,
             mm_token_ids=mm_token_ids)
     if mm_token_indices.shape[0] != mm_embed.shape[0]:
-        debug_details = [
-            f"{mm_embed_shapes=}",
-            f"text_token_count={text_token_indices.shape[0]}",
-            f"{multimodal_debug_info=}",
-        ]
         raise ValueError(
             f"Multimodal token count mismatch: found {len(mm_token_indices)} image tokens in input_ids "
-            f"but received {mm_embed.shape[0]} image embeddings. "
-            f"{' '.join(debug_details)} "
-            "This is likely due to KV cache reuse, chunk prefill, or other optimizations that "
-            "cause token count mismatches within the inference batch.")
+            f"but received {mm_embed.shape[0]} image embeddings.")
 
     text_embed = embedding_layer(input_ids[text_token_indices])
     input_embeds = torch.empty(input_ids.shape[0],

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -180,7 +180,9 @@ def _cache_multimodal_embeddings(
     logger.debug(
         f"Caching {len(split_embeddings)} multimodal embedding chunks in {len(multimodal_params)} params"
     )
-    for param, embed_chunk in zip(valid_params, split_embeddings):
+    for param, embed_chunk in zip(valid_params,
+                                  split_embeddings,
+                                  strict=True):
         param.multimodal_data["multimodal_embedding"] = embed_chunk
 
     logger.debug(
@@ -422,17 +424,11 @@ def fuse_input_embeds(
             input_ids,
             vocab_size=embedding_layer.num_embeddings,
             mm_token_ids=mm_token_ids)
-    logger.debug(
-        "Fusing multimodal embeddings: "
-        f"mm_token_count={mm_token_indices.shape[0]}, "
-        f"mm_embedding_shape={tuple(mm_embed.shape)}, "
-        f"mm_embed_shapes={mm_embed_shapes}, "
-        f"multimodal_debug_info={multimodal_debug_info}")
     if mm_token_indices.shape[0] != mm_embed.shape[0]:
         debug_details = [
-            f"mm_embed_shapes={mm_embed_shapes}",
+            f"{mm_embed_shapes=}",
             f"text_token_count={text_token_indices.shape[0]}",
-            f"multimodal_debug_info={multimodal_debug_info}",
+            f"{multimodal_debug_info=}",
         ]
         raise ValueError(
             f"Multimodal token count mismatch: found {len(mm_token_indices)} image tokens in input_ids "
@@ -923,7 +919,7 @@ def multiscale_forward(model,
     num_splits = [math.ceil(size / max_split_size)
                   for size in img_sizes]  # number of splits each scale
     input_multiscale = []
-    for size, num_split in zip(img_sizes, num_splits):
+    for size, num_split in zip(img_sizes, num_splits, strict=True):
         x = F.interpolate(input.to(torch.float32), size=size,
                           mode='bicubic').to(input.dtype)
         x = s2_split_chessboard(x, num_split=num_split)
@@ -950,7 +946,7 @@ def multiscale_forward(model,
     # merge outputs of different splits for each scale separately
     outs_multiscale = [
         s2_merge_chessboard(out, num_split=num_split)
-        for num_split, out in zip(num_splits, outs_multiscale)
+        for num_split, out in zip(num_splits, outs_multiscale, strict=True)
     ]
 
     # interpolate outputs from different scales and concat together

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -47,13 +47,15 @@ from ..modules.embedding import Embedding, LMHead
 from .modeling_auto import AutoModelForCausalLM
 from .modeling_multimodal_encoder import (VisionTower, VisionTowerDynamicS2,
                                           VisionTowerS2)
+# yapf: disable
 from .modeling_multimodal_utils import (dynamic_preprocess_dispatch,
                                         dynamic_s2_preprocess_dispatch,
-                                        find_input_mm_embeds,
                                         filter_mm_token_from_input_ids,
-                                        fuse_input_embeds, merge_chessboard,
+                                        find_input_mm_embeds, fuse_input_embeds,
+                                        merge_chessboard,
                                         merge_features_for_dynamic_s2,
                                         preprocess_dispatch, split_chessboard)
+# yapf: enable
 from .modeling_utils import ModelConfig, register_auto_model
 
 SENTINEL_TOKEN = "<vila/sentinel>"  # nosec B105
@@ -63,89 +65,10 @@ MEDIA_TOKENS = {
 }
 
 
-def _build_vila_request_grouping(multimodal_params):
-    request_grouping = []
-    for request_index, multimodal_param in enumerate(multimodal_params):
-        runtime = multimodal_param.multimodal_runtime
-        request_grouping.append({
-            "request_index":
-            request_index,
-            "embedding_shape":
-            tuple(multimodal_param.multimodal_data[
-                "multimodal_embedding"].shape),
-            "num_unseen_mm_tokens":
-            getattr(runtime, "num_unseen_mm_tokens", None),
-            "num_mm_tokens_in_chunk":
-            getattr(runtime, "num_mm_tokens_in_chunk", None),
-            "total_mm_tokens_in_request":
-            getattr(runtime, "total_mm_tokens_in_request", None),
-            "num_unseen_special_tokens":
-            getattr(runtime, "num_unseen_special_tokens", None),
-            "num_special_tokens_in_chunk":
-            getattr(runtime, "num_special_tokens_in_chunk", None),
-            "total_special_tokens_in_request":
-            getattr(runtime, "total_special_tokens_in_request", None),
-        })
-    return request_grouping
-
-
-def _build_multimodal_debug_info(
-    multimodal_params,
-    num_context_requests: int,
-    num_generation_requests: int,
-):
-    return {
-        "batch_size": len(multimodal_params),
-        "num_context_requests": num_context_requests,
-        "num_generation_requests": num_generation_requests,
-        "request_grouping":
-        _build_vila_request_grouping(multimodal_params[:num_context_requests]),
-    }
-
-
-def _update_vila_sliced_debug_info(
-    multimodal_debug_info: dict,
-    context_multimodal_params,
-    mm_embeds: List[torch.Tensor],
-) -> None:
-    multimodal_debug_info["sliced_mm_embed_shapes"] = [
-        tuple(embed.shape) for embed in mm_embeds
-    ]
-    if len(mm_embeds) != len(context_multimodal_params):
-        raise RuntimeError(
-            "[VILA] Post-slice request grouping mismatch: "
-            f"context_requests={len(context_multimodal_params)}, "
-            f"sliced_embedding_groups={len(mm_embeds)}, "
-            f"{multimodal_debug_info=}")
-
-    for request_group, multimodal_param, mm_embed in zip(
-            multimodal_debug_info["request_grouping"],
-            context_multimodal_params,
-            mm_embeds,
-            strict=True):
-        runtime = multimodal_param.multimodal_runtime
-        expected_active_tokens = None
-        if runtime is not None:
-            expected_active_tokens = (
-                runtime.num_mm_tokens_in_chunk -
-                runtime.num_special_tokens_in_chunk)
-        request_group["expected_active_tokens"] = expected_active_tokens
-        request_group["actual_sliced_tokens"] = mm_embed.shape[0]
-        if (expected_active_tokens is not None
-                and expected_active_tokens != mm_embed.shape[0]):
-            raise RuntimeError(
-                "[VILA] Post-slice request mismatch: "
-                f"request_index={request_group['request_index']}, "
-                f"{expected_active_tokens=}, "
-                f"actual_sliced_tokens={mm_embed.shape[0]}, "
-                f"{multimodal_debug_info=}")
-
-
 def _validate_vila_mm_alignment(
     input_ids: torch.IntTensor,
     embedding_layer: Embedding,
     mm_embeds: List[torch.Tensor],
-    multimodal_debug_info: dict,
 ) -> Tuple[torch.IntTensor, torch.IntTensor]:
     # VILA expands multimodal placeholders into out-of-vocab ids during
     # preprocessing, so counting OOV ids here gives the active multimodal span
@@ -156,13 +79,11 @@ def _validate_vila_mm_alignment(
     )
     expected_tokens = mm_token_indices.shape[0]
     actual_embeds = sum(embed.shape[0] for embed in mm_embeds)
-    multimodal_debug_info["expected_mm_tokens"] = expected_tokens
-    multimodal_debug_info["actual_mm_embeds"] = actual_embeds
     if expected_tokens != actual_embeds:
-        raise RuntimeError(
-            "[VILA] Post-slice mismatch: "
-            f"{expected_tokens=}, {actual_embeds=}, "
-            f"{multimodal_debug_info=}")
+        raise ValueError(
+            "[VILA] Multimodal token count mismatch after slicing: "
+            f"found {expected_tokens} image tokens in input_ids but received "
+            f"{actual_embeds} image embeddings.")
     return text_token_indices, mm_token_indices
 
 
@@ -1077,10 +998,8 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
                 self.vision_tower, visual_features, block_sizes)
 
             visual_features = [
-                split_chessboard(x, block_size[0], block_size[1])
-                for x, block_size in zip(visual_features,
-                                         new_block_sizes,
-                                         strict=True)
+                split_chessboard(x, block_size[0], block_size[1]) for x,
+                block_size in zip(visual_features, new_block_sizes, strict=True)
             ]  # list of B * C * H * W tensors
             visual_features = torch.cat(
                 [rearrange(x, "b c h w -> b (h w) c") for x in visual_features],
@@ -1093,10 +1012,8 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
                 ],
                                       dim=0))
             visual_features = [
-                merge_chessboard(x, block_size[0], block_size[1])
-                for x, block_size in zip(visual_features,
-                                         new_block_sizes,
-                                         strict=True)
+                merge_chessboard(x, block_size[0], block_size[1]) for x,
+                block_size in zip(visual_features, new_block_sizes, strict=True)
             ]  # list of 1 * C * H * W tensors
             visual_features = [
                 rearrange(x, "1 c h w -> (h w) c") for x in visual_features
@@ -1324,44 +1241,24 @@ class VilaModel(PreTrainedModel):
         mm_embeds = []
         text_token_indices = None
         mm_token_indices = None
-        multimodal_debug_info = _build_multimodal_debug_info(
-            multimodal_params=multimodal_params,
-            num_context_requests=num_context_requests,
-            num_generation_requests=num_generation_requests,
-        )
         if len(context_multimodal_params) > 0:
             mm_embeds = [
                 multimodal_param.multimodal_data["multimodal_embedding"]
                 for multimodal_param in context_multimodal_params
             ]
-            mm_embed_shapes = [tuple(embed.shape) for embed in mm_embeds]
-            logger.debug(
-                "VILA multimodal forward before slicing: "
-                f"{mm_embed_shapes=}, {multimodal_debug_info=}")
             # Other multimodal models already slice batched embeddings with
             # find_input_mm_embeds() before fusion. VILA previously skipped
             # that step and could feed the full cached embedding tensor into a
             # chunked context batch, which breaks token/embed alignment.
-            mm_embeds = find_input_mm_embeds(mm_embeds, context_multimodal_params)
-            _update_vila_sliced_debug_info(multimodal_debug_info,
-                                           context_multimodal_params,
-                                           mm_embeds)
-            mm_embed_shapes = [tuple(embed.shape) for embed in mm_embeds]
-            logger.debug(
-                "VILA multimodal forward after slicing: "
-                f"{mm_embed_shapes=}, {multimodal_debug_info=}")
+            mm_embeds = find_input_mm_embeds(mm_embeds,
+                                             context_multimodal_params)
             if input_ids is not None:
                 text_token_indices, mm_token_indices = _validate_vila_mm_alignment(
                     input_ids=input_ids,
                     embedding_layer=self.llm.model.embed_tokens,
                     mm_embeds=mm_embeds,
-                    multimodal_debug_info=multimodal_debug_info,
                 )
-                logger.debug(
-                    "VILA multimodal alignment validated: "
-                    f"{multimodal_debug_info=}")
 
-        kwargs["multimodal_debug_info"] = multimodal_debug_info
         if text_token_indices is not None and mm_token_indices is not None:
             kwargs["text_token_indices"] = text_token_indices
             kwargs["mm_token_indices"] = mm_token_indices

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -1,4 +1,4 @@
-# Copyright 2024 NVIDIA CORPORATION & AFFILIATES
+# Copyright 2024-2026 NVIDIA CORPORATION & AFFILIATES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ from .modeling_multimodal_encoder import (VisionTower, VisionTowerDynamicS2,
                                           VisionTowerS2)
 from .modeling_multimodal_utils import (dynamic_preprocess_dispatch,
                                         dynamic_s2_preprocess_dispatch,
+                                        find_input_mm_embeds,
+                                        filter_mm_token_from_input_ids,
                                         fuse_input_embeds, merge_chessboard,
                                         merge_features_for_dynamic_s2,
                                         preprocess_dispatch, split_chessboard)
@@ -59,6 +61,36 @@ MEDIA_TOKENS = {
     "image": "<image>",
     "video": "<vila/video>",
 }
+
+
+def _validate_vila_mm_alignment(
+    input_ids: torch.IntTensor,
+    embedding_layer: Embedding,
+    mm_embeds: List[torch.Tensor],
+    multimodal_debug_info: dict,
+) -> Tuple[torch.IntTensor, torch.IntTensor]:
+    # VILA expands multimodal placeholders into out-of-vocab ids during
+    # preprocessing, so counting OOV ids here gives the active multimodal span
+    # for the current chunk. Reuse the indices for fusion to avoid an extra sync.
+    text_token_indices, mm_token_indices = filter_mm_token_from_input_ids(
+        input_ids=input_ids,
+        vocab_size=embedding_layer.num_embeddings,
+    )
+    expected_tokens = mm_token_indices.shape[0]
+    actual_embeds = sum(embed.shape[0] for embed in mm_embeds)
+    multimodal_debug_info["expected_mm_tokens"] = expected_tokens
+    multimodal_debug_info["actual_mm_embeds"] = actual_embeds
+    logger.debug(
+        "VILA multimodal alignment after slicing: "
+        f"expected_mm_tokens={expected_tokens}, "
+        f"actual_mm_embeds={actual_embeds}, "
+        f"multimodal_debug_info={multimodal_debug_info}")
+    if expected_tokens != actual_embeds:
+        raise RuntimeError(
+            "[VILA] Post-slice mismatch: "
+            f"tokens={expected_tokens}, embeds={actual_embeds}, "
+            f"multimodal_debug_info={multimodal_debug_info}")
+    return text_token_indices, mm_token_indices
 
 
 def _convert_dtype(dtype):
@@ -1209,16 +1241,106 @@ class VilaModel(PreTrainedModel):
         """
 
         num_context_requests, num_generation_requests = attn_metadata.num_contexts, attn_metadata.num_generations
+        logger.debug(f"{num_context_requests=}, {num_generation_requests=}")
         multimodal_params = kwargs.get("multimodal_params", [])
+        context_multimodal_params = multimodal_params[:num_context_requests]
         mm_embeds = []
-        if len(multimodal_params) > 0:
+        text_token_indices = None
+        mm_token_indices = None
+        multimodal_debug_info = {
+            "batch_size": len(multimodal_params),
+            "num_context_requests": num_context_requests,
+            "num_generation_requests": num_generation_requests,
+            "request_grouping": [],
+        }
+        if len(context_multimodal_params) > 0:
             mm_embeds = [
                 multimodal_param.multimodal_data["multimodal_embedding"]
-                for multimodal_param in multimodal_params
+                for multimodal_param in context_multimodal_params
             ]
+            for request_index, multimodal_param in enumerate(
+                    context_multimodal_params):
+                runtime = multimodal_param.multimodal_runtime
+                multimodal_debug_info["request_grouping"].append({
+                    "request_index":
+                    request_index,
+                    "embedding_shape":
+                    tuple(multimodal_param.multimodal_data[
+                        "multimodal_embedding"].shape),
+                    "num_unseen_mm_tokens":
+                    getattr(runtime, "num_unseen_mm_tokens", None),
+                    "num_mm_tokens_in_chunk":
+                    getattr(runtime, "num_mm_tokens_in_chunk", None),
+                    "total_mm_tokens_in_request":
+                    getattr(runtime, "total_mm_tokens_in_request", None),
+                    "num_unseen_special_tokens":
+                    getattr(runtime, "num_unseen_special_tokens", None),
+                    "num_special_tokens_in_chunk":
+                    getattr(runtime, "num_special_tokens_in_chunk", None),
+                    "total_special_tokens_in_request":
+                    getattr(runtime, "total_special_tokens_in_request", None),
+                })
+            logger.debug(
+                "VILA multimodal forward before slicing: "
+                f"batch_size={len(multimodal_params)}, "
+                f"request_grouping={multimodal_debug_info['request_grouping']}")
+            # Other multimodal models already slice batched embeddings with
+            # find_input_mm_embeds() before fusion. VILA previously skipped
+            # that step and could feed the full cached embedding tensor into a
+            # chunked context batch, which breaks token/embed alignment.
+            mm_embeds = find_input_mm_embeds(mm_embeds, context_multimodal_params)
+            multimodal_debug_info["sliced_mm_embed_shapes"] = [
+                tuple(mm_embed.shape) for mm_embed in mm_embeds
+            ]
+            if len(mm_embeds) != len(context_multimodal_params):
+                raise RuntimeError(
+                    "[VILA] Post-slice request grouping mismatch: "
+                    f"context_requests={len(context_multimodal_params)}, "
+                    f"sliced_embedding_groups={len(mm_embeds)}, "
+                    f"multimodal_debug_info={multimodal_debug_info}")
+            for request_index, (multimodal_param, mm_embed) in enumerate(
+                    zip(context_multimodal_params, mm_embeds)):
+                runtime = multimodal_param.multimodal_runtime
+                expected_active_tokens = None
+                if runtime is not None:
+                    expected_active_tokens = (
+                        runtime.num_mm_tokens_in_chunk -
+                        runtime.num_special_tokens_in_chunk)
+                multimodal_debug_info["request_grouping"][request_index][
+                    "expected_active_tokens"] = expected_active_tokens
+                multimodal_debug_info["request_grouping"][request_index][
+                    "actual_sliced_tokens"] = mm_embed.shape[0]
+                if (expected_active_tokens is not None
+                        and expected_active_tokens != mm_embed.shape[0]):
+                    raise RuntimeError(
+                        "[VILA] Post-slice request mismatch: "
+                        f"request_index={request_index}, "
+                        f"expected_active_tokens={expected_active_tokens}, "
+                        f"actual_sliced_tokens={mm_embed.shape[0]}, "
+                        f"multimodal_debug_info={multimodal_debug_info}")
+            logger.debug(
+                "VILA multimodal forward after slicing: "
+                f"sliced_mm_embed_shapes={multimodal_debug_info['sliced_mm_embed_shapes']}"
+            )
+            if input_ids is not None:
+                text_token_indices, mm_token_indices = _validate_vila_mm_alignment(
+                    input_ids=input_ids,
+                    embedding_layer=self.llm.model.embed_tokens,
+                    mm_embeds=mm_embeds,
+                    multimodal_debug_info=multimodal_debug_info,
+                )
 
+        fuse_kwargs = dict(kwargs)
+        fuse_kwargs["multimodal_debug_info"] = multimodal_debug_info
+        if text_token_indices is not None and mm_token_indices is not None:
+            fuse_kwargs["text_token_indices"] = text_token_indices
+            fuse_kwargs["mm_token_indices"] = mm_token_indices
         input_ids, inputs_embeds = fuse_input_embeds(
-            self.llm.model.embed_tokens, input_ids, mm_embeds, **kwargs)
+            self.llm.model.embed_tokens,
+            input_ids,
+            mm_embeds,
+            **fuse_kwargs,
+        )
         logits = self.llm.forward(attn_metadata=attn_metadata,
                                   input_ids=input_ids,
                                   position_ids=position_ids,

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -63,6 +63,84 @@ MEDIA_TOKENS = {
 }
 
 
+def _build_vila_request_grouping(multimodal_params):
+    request_grouping = []
+    for request_index, multimodal_param in enumerate(multimodal_params):
+        runtime = multimodal_param.multimodal_runtime
+        request_grouping.append({
+            "request_index":
+            request_index,
+            "embedding_shape":
+            tuple(multimodal_param.multimodal_data[
+                "multimodal_embedding"].shape),
+            "num_unseen_mm_tokens":
+            getattr(runtime, "num_unseen_mm_tokens", None),
+            "num_mm_tokens_in_chunk":
+            getattr(runtime, "num_mm_tokens_in_chunk", None),
+            "total_mm_tokens_in_request":
+            getattr(runtime, "total_mm_tokens_in_request", None),
+            "num_unseen_special_tokens":
+            getattr(runtime, "num_unseen_special_tokens", None),
+            "num_special_tokens_in_chunk":
+            getattr(runtime, "num_special_tokens_in_chunk", None),
+            "total_special_tokens_in_request":
+            getattr(runtime, "total_special_tokens_in_request", None),
+        })
+    return request_grouping
+
+
+def _build_multimodal_debug_info(
+    multimodal_params,
+    num_context_requests: int,
+    num_generation_requests: int,
+):
+    return {
+        "batch_size": len(multimodal_params),
+        "num_context_requests": num_context_requests,
+        "num_generation_requests": num_generation_requests,
+        "request_grouping":
+        _build_vila_request_grouping(multimodal_params[:num_context_requests]),
+    }
+
+
+def _update_vila_sliced_debug_info(
+    multimodal_debug_info: dict,
+    context_multimodal_params,
+    mm_embeds: List[torch.Tensor],
+) -> None:
+    multimodal_debug_info["sliced_mm_embed_shapes"] = [
+        tuple(embed.shape) for embed in mm_embeds
+    ]
+    if len(mm_embeds) != len(context_multimodal_params):
+        raise RuntimeError(
+            "[VILA] Post-slice request grouping mismatch: "
+            f"context_requests={len(context_multimodal_params)}, "
+            f"sliced_embedding_groups={len(mm_embeds)}, "
+            f"{multimodal_debug_info=}")
+
+    for request_group, multimodal_param, mm_embed in zip(
+            multimodal_debug_info["request_grouping"],
+            context_multimodal_params,
+            mm_embeds,
+            strict=True):
+        runtime = multimodal_param.multimodal_runtime
+        expected_active_tokens = None
+        if runtime is not None:
+            expected_active_tokens = (
+                runtime.num_mm_tokens_in_chunk -
+                runtime.num_special_tokens_in_chunk)
+        request_group["expected_active_tokens"] = expected_active_tokens
+        request_group["actual_sliced_tokens"] = mm_embed.shape[0]
+        if (expected_active_tokens is not None
+                and expected_active_tokens != mm_embed.shape[0]):
+            raise RuntimeError(
+                "[VILA] Post-slice request mismatch: "
+                f"request_index={request_group['request_index']}, "
+                f"{expected_active_tokens=}, "
+                f"actual_sliced_tokens={mm_embed.shape[0]}, "
+                f"{multimodal_debug_info=}")
+
+
 def _validate_vila_mm_alignment(
     input_ids: torch.IntTensor,
     embedding_layer: Embedding,
@@ -80,16 +158,11 @@ def _validate_vila_mm_alignment(
     actual_embeds = sum(embed.shape[0] for embed in mm_embeds)
     multimodal_debug_info["expected_mm_tokens"] = expected_tokens
     multimodal_debug_info["actual_mm_embeds"] = actual_embeds
-    logger.debug(
-        "VILA multimodal alignment after slicing: "
-        f"expected_mm_tokens={expected_tokens}, "
-        f"actual_mm_embeds={actual_embeds}, "
-        f"multimodal_debug_info={multimodal_debug_info}")
     if expected_tokens != actual_embeds:
         raise RuntimeError(
             "[VILA] Post-slice mismatch: "
-            f"tokens={expected_tokens}, embeds={actual_embeds}, "
-            f"multimodal_debug_info={multimodal_debug_info}")
+            f"{expected_tokens=}, {actual_embeds=}, "
+            f"{multimodal_debug_info=}")
     return text_token_indices, mm_token_indices
 
 
@@ -251,7 +324,7 @@ def process_images(images: Union[List[Image.Image], List[torch.Tensor]],
     block_sizes = None
     if isinstance(images[0], tuple):
         # VILA 2.0 dynamic S2 has block_sizes parameter
-        images, block_sizes = zip(*images)
+        images, block_sizes = zip(*images, strict=True)
         block_sizes = list(block_sizes)
 
     if all(x.shape[1:] == images[0].shape[1:] for x in images):
@@ -1005,7 +1078,9 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
 
             visual_features = [
                 split_chessboard(x, block_size[0], block_size[1])
-                for x, block_size in zip(visual_features, new_block_sizes)
+                for x, block_size in zip(visual_features,
+                                         new_block_sizes,
+                                         strict=True)
             ]  # list of B * C * H * W tensors
             visual_features = torch.cat(
                 [rearrange(x, "b c h w -> b (h w) c") for x in visual_features],
@@ -1019,7 +1094,9 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
                                       dim=0))
             visual_features = [
                 merge_chessboard(x, block_size[0], block_size[1])
-                for x, block_size in zip(visual_features, new_block_sizes)
+                for x, block_size in zip(visual_features,
+                                         new_block_sizes,
+                                         strict=True)
             ]  # list of 1 * C * H * W tensors
             visual_features = [
                 rearrange(x, "1 c h w -> (h w) c") for x in visual_features
@@ -1247,81 +1324,32 @@ class VilaModel(PreTrainedModel):
         mm_embeds = []
         text_token_indices = None
         mm_token_indices = None
-        multimodal_debug_info = {
-            "batch_size": len(multimodal_params),
-            "num_context_requests": num_context_requests,
-            "num_generation_requests": num_generation_requests,
-            "request_grouping": [],
-        }
+        multimodal_debug_info = _build_multimodal_debug_info(
+            multimodal_params=multimodal_params,
+            num_context_requests=num_context_requests,
+            num_generation_requests=num_generation_requests,
+        )
         if len(context_multimodal_params) > 0:
             mm_embeds = [
                 multimodal_param.multimodal_data["multimodal_embedding"]
                 for multimodal_param in context_multimodal_params
             ]
-            for request_index, multimodal_param in enumerate(
-                    context_multimodal_params):
-                runtime = multimodal_param.multimodal_runtime
-                multimodal_debug_info["request_grouping"].append({
-                    "request_index":
-                    request_index,
-                    "embedding_shape":
-                    tuple(multimodal_param.multimodal_data[
-                        "multimodal_embedding"].shape),
-                    "num_unseen_mm_tokens":
-                    getattr(runtime, "num_unseen_mm_tokens", None),
-                    "num_mm_tokens_in_chunk":
-                    getattr(runtime, "num_mm_tokens_in_chunk", None),
-                    "total_mm_tokens_in_request":
-                    getattr(runtime, "total_mm_tokens_in_request", None),
-                    "num_unseen_special_tokens":
-                    getattr(runtime, "num_unseen_special_tokens", None),
-                    "num_special_tokens_in_chunk":
-                    getattr(runtime, "num_special_tokens_in_chunk", None),
-                    "total_special_tokens_in_request":
-                    getattr(runtime, "total_special_tokens_in_request", None),
-                })
+            mm_embed_shapes = [tuple(embed.shape) for embed in mm_embeds]
             logger.debug(
                 "VILA multimodal forward before slicing: "
-                f"batch_size={len(multimodal_params)}, "
-                f"request_grouping={multimodal_debug_info['request_grouping']}")
+                f"{mm_embed_shapes=}, {multimodal_debug_info=}")
             # Other multimodal models already slice batched embeddings with
             # find_input_mm_embeds() before fusion. VILA previously skipped
             # that step and could feed the full cached embedding tensor into a
             # chunked context batch, which breaks token/embed alignment.
             mm_embeds = find_input_mm_embeds(mm_embeds, context_multimodal_params)
-            multimodal_debug_info["sliced_mm_embed_shapes"] = [
-                tuple(mm_embed.shape) for mm_embed in mm_embeds
-            ]
-            if len(mm_embeds) != len(context_multimodal_params):
-                raise RuntimeError(
-                    "[VILA] Post-slice request grouping mismatch: "
-                    f"context_requests={len(context_multimodal_params)}, "
-                    f"sliced_embedding_groups={len(mm_embeds)}, "
-                    f"multimodal_debug_info={multimodal_debug_info}")
-            for request_index, (multimodal_param, mm_embed) in enumerate(
-                    zip(context_multimodal_params, mm_embeds)):
-                runtime = multimodal_param.multimodal_runtime
-                expected_active_tokens = None
-                if runtime is not None:
-                    expected_active_tokens = (
-                        runtime.num_mm_tokens_in_chunk -
-                        runtime.num_special_tokens_in_chunk)
-                multimodal_debug_info["request_grouping"][request_index][
-                    "expected_active_tokens"] = expected_active_tokens
-                multimodal_debug_info["request_grouping"][request_index][
-                    "actual_sliced_tokens"] = mm_embed.shape[0]
-                if (expected_active_tokens is not None
-                        and expected_active_tokens != mm_embed.shape[0]):
-                    raise RuntimeError(
-                        "[VILA] Post-slice request mismatch: "
-                        f"request_index={request_index}, "
-                        f"expected_active_tokens={expected_active_tokens}, "
-                        f"actual_sliced_tokens={mm_embed.shape[0]}, "
-                        f"multimodal_debug_info={multimodal_debug_info}")
+            _update_vila_sliced_debug_info(multimodal_debug_info,
+                                           context_multimodal_params,
+                                           mm_embeds)
+            mm_embed_shapes = [tuple(embed.shape) for embed in mm_embeds]
             logger.debug(
                 "VILA multimodal forward after slicing: "
-                f"sliced_mm_embed_shapes={multimodal_debug_info['sliced_mm_embed_shapes']}"
-            )
+                f"{mm_embed_shapes=}, {multimodal_debug_info=}")
             if input_ids is not None:
                 text_token_indices, mm_token_indices = _validate_vila_mm_alignment(
                     input_ids=input_ids,
@@ -1329,17 +1357,19 @@ class VilaModel(PreTrainedModel):
                     mm_embeds=mm_embeds,
                     multimodal_debug_info=multimodal_debug_info,
                 )
+                logger.debug(
+                    "VILA multimodal alignment validated: "
+                    f"{multimodal_debug_info=}")
 
-        fuse_kwargs = dict(kwargs)
-        fuse_kwargs["multimodal_debug_info"] = multimodal_debug_info
+        kwargs["multimodal_debug_info"] = multimodal_debug_info
         if text_token_indices is not None and mm_token_indices is not None:
-            fuse_kwargs["text_token_indices"] = text_token_indices
-            fuse_kwargs["mm_token_indices"] = mm_token_indices
+            kwargs["text_token_indices"] = text_token_indices
+            kwargs["mm_token_indices"] = mm_token_indices
         input_ids, inputs_embeds = fuse_input_embeds(
             self.llm.model.embed_tokens,
             input_ids,
             mm_embeds,
-            **fuse_kwargs,
+            **kwargs,
         )
         logits = self.llm.forward(attn_metadata=attn_metadata,
                                   input_ids=input_ids,

--- a/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
+++ b/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
@@ -107,6 +107,38 @@ def test_fuse_input_embeds_mismatch_raises(device):
 
 @pytest.mark.parametrize("device", ["cpu"] +
                          (["cuda"] if torch.cuda.is_available() else []))
+def test_fuse_input_embeds_mismatch_includes_debug_info(device):
+    emb = make_embedding(num_embeddings=50, hidden_size=8, device=device)
+    input_ids = torch.tensor([1, 51, 2, 52, 3], dtype=torch.long, device=device)
+    text_idx, mm_idx = filter_mm_token_from_input_ids(
+        input_ids, vocab_size=emb.num_embeddings)
+    wrong_mm = torch.randn(mm_idx.shape[0] + 1, 8, device=device)
+
+    with pytest.raises(ValueError, match="Multimodal token count mismatch"
+                       ) as exc_info:
+        fuse_input_embeds(
+            emb,
+            input_ids, [wrong_mm],
+            text_token_indices=text_idx,
+            mm_token_indices=mm_idx,
+            multimodal_debug_info={
+                "batch_size": 1,
+                "num_context_requests": 1,
+                "request_grouping": [{
+                    "request_index": 0,
+                    "num_mm_tokens_in_chunk": 2,
+                    "total_mm_tokens_in_request": 3,
+                }],
+            })
+
+    error_message = str(exc_info.value)
+    assert "mm_embed_shapes=[(3, 8)]" in error_message
+    assert "num_context_requests': 1" in error_message
+    assert "num_mm_tokens_in_chunk': 2" in error_message
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
 def test_fuse_input_embeds_success_oov_path(device):
     hidden = 8
     emb = make_embedding(num_embeddings=40, hidden_size=hidden, device=device)

--- a/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
+++ b/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
@@ -2,8 +2,10 @@ import pytest
 import torch
 
 from tensorrt_llm._torch.models.modeling_multimodal_utils import (
-    filter_mm_token_from_input_ids, fuse_input_embeds)
+    filter_mm_token_from_input_ids, find_input_mm_embeds, fuse_input_embeds)
 from tensorrt_llm._torch.modules.embedding import Embedding
+from tensorrt_llm.inputs.multimodal import (MultimodalParams,
+                                            MultimodalRuntimeData)
 
 
 def make_embedding(num_embeddings: int = 100,
@@ -107,34 +109,56 @@ def test_fuse_input_embeds_mismatch_raises(device):
 
 @pytest.mark.parametrize("device", ["cpu"] +
                          (["cuda"] if torch.cuda.is_available() else []))
-def test_fuse_input_embeds_mismatch_includes_debug_info(device):
+def test_fuse_input_embeds_mismatch_error_includes_counts(device):
     emb = make_embedding(num_embeddings=50, hidden_size=8, device=device)
     input_ids = torch.tensor([1, 51, 2, 52, 3], dtype=torch.long, device=device)
     text_idx, mm_idx = filter_mm_token_from_input_ids(
         input_ids, vocab_size=emb.num_embeddings)
     wrong_mm = torch.randn(mm_idx.shape[0] + 1, 8, device=device)
 
-    with pytest.raises(ValueError, match="Multimodal token count mismatch"
-                       ) as exc_info:
+    with pytest.raises(ValueError,
+                       match="Multimodal token count mismatch") as exc_info:
         fuse_input_embeds(
             emb,
-            input_ids, [wrong_mm],
+            input_ids,
+            [wrong_mm],
             text_token_indices=text_idx,
             mm_token_indices=mm_idx,
-            multimodal_debug_info={
-                "batch_size": 1,
-                "num_context_requests": 1,
-                "request_grouping": [{
-                    "request_index": 0,
-                    "num_mm_tokens_in_chunk": 2,
-                    "total_mm_tokens_in_request": 3,
-                }],
-            })
+        )
 
     error_message = str(exc_info.value)
-    assert "mm_embed_shapes=[(3, 8)]" in error_message
-    assert "num_context_requests': 1" in error_message
-    assert "num_mm_tokens_in_chunk': 2" in error_message
+    assert "found 2 image tokens in input_ids" in error_message
+    assert "received 3 image embeddings" in error_message
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
+def test_fuse_input_embeds_with_chunked_multimodal_slice(device):
+    hidden = 8
+    emb = make_embedding(num_embeddings=50, hidden_size=hidden, device=device)
+    input_ids = torch.tensor([1, 51, 2, 52, 3], dtype=torch.long, device=device)
+    full_mm_embed = torch.randn(5, hidden, device=device)
+    runtime = MultimodalRuntimeData(
+        past_seen_token_num=3,
+        chunk_end_pos=5,
+        embed_mask_cumsum=torch.arange(1, 6, dtype=torch.int64),
+    )
+    multimodal_params = [MultimodalParams(multimodal_runtime=runtime)]
+
+    mm_embeds = find_input_mm_embeds([full_mm_embed], multimodal_params)
+    out_ids, out_embeds = fuse_input_embeds(emb,
+                                            input_ids,
+                                            mm_embeds,
+                                            mm_token_ids=None)
+
+    assert out_ids is None
+    assert out_embeds is not None
+    _, mm_idx = filter_mm_token_from_input_ids(input_ids,
+                                               vocab_size=emb.num_embeddings)
+    torch.testing.assert_close(
+        out_embeds[mm_idx],
+        full_mm_embed[3:5].to(dtype=out_embeds.dtype, device=out_embeds.device),
+    )
 
 
 @pytest.mark.parametrize("device", ["cpu"] +

--- a/tests/unittest/_torch/multimodal/test_multimodal_runtime.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_runtime.py
@@ -256,8 +256,7 @@ class TestFindInputMmEmbed:
         mm_embeds = [torch.randn(total_mm_tokens, _EMBED_DIM)]
         multimodal_params = [
             _make_multimodal_params(num_unseen_mm_tokens,
-                                    num_mm_tokens_in_chunk,
-                                    [total_mm_tokens])
+                                    num_mm_tokens_in_chunk, [total_mm_tokens])
         ]
 
         result = find_input_mm_embeds(mm_embeds, multimodal_params)

--- a/tests/unittest/_torch/multimodal/test_multimodal_runtime.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_runtime.py
@@ -241,6 +241,34 @@ class TestFindInputMmEmbed:
         assert result[0].shape == (5, _EMBED_DIM)
         torch.testing.assert_close(result[0], mm_embeds[0][5:10])
 
+    def test_single_batch_chunked_prefill_regression(self):
+        """
+        Reproduce the NVILA-style case where a single request carries the full
+        image embedding cache, but only the current chunk should be fused.
+        The 3072 -> 781 split mirrors the reported failure mode:
+        3072 is the full image embedding length for the request, while 781 is
+        the active multimodal token span in the current chunk.
+        """
+        total_mm_tokens = 3072
+        num_mm_tokens_in_chunk = 781
+        num_unseen_mm_tokens = total_mm_tokens - num_mm_tokens_in_chunk
+
+        mm_embeds = [torch.randn(total_mm_tokens, _EMBED_DIM)]
+        multimodal_params = [
+            _make_multimodal_params(num_unseen_mm_tokens,
+                                    num_mm_tokens_in_chunk,
+                                    [total_mm_tokens])
+        ]
+
+        result = find_input_mm_embeds(mm_embeds, multimodal_params)
+
+        assert len(result) == 1
+        assert result[0].shape == (num_mm_tokens_in_chunk, _EMBED_DIM)
+        torch.testing.assert_close(
+            result[0],
+            mm_embeds[0][num_unseen_mm_tokens:total_mm_tokens],
+        )
+
     def test_noncontiguous_individual_batching_mixed_gaps(self):
         """
         Non-contiguous: individual batching mode, three requests with


### PR DESCRIPTION
Fixes #13082

Align multimodal image embeddings with active image tokens in VILA during chunked prefill / KV-cache reuse.
Previously, full image embeddings were passed while input_ids contained only a subset of image tokens, causing a mismatch error.

This patch applies find_input_mm_embeds() to slice embeddings correctly and adds basic validation + debug info.
No impact on text-only models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU compatibility validation for FP4/MXFP4 quantization with informative error messages
  * Enhanced multimodal model debugging with detailed alignment tracking

* **Bug Fixes**
  * Improved quantization metadata validation for linear layers
  * Fixed multimodal embedding slicing for correct chunked fusion

* **Tests**
  * Added validation coverage for quantization support and multimodal scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->