### PR TITLE
[None][fix] Use bf16 for LTX-2 FP4 stage 2

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Union
 import safetensors.torch
 import torch
 
+from tensorrt_llm._torch.modules.linear import Linear, NVFP4LinearMethod, UnquantizedLinearMethod
 from tensorrt_llm._torch.visual_gen.output import MediaOutput
 from tensorrt_llm._torch.visual_gen.pipeline_registry import register_pipeline
 from tensorrt_llm._torch.visual_gen.quantization.ops import quantize_fp8_blockwise, quantize_nvfp4
@@ -344,13 +345,20 @@ def _apply_lora_deltas(
     NVFP4-quantized weights (packed, half the last dim) we
     dequantize → apply → requantize.
 
+    For FP4-quantized models (both static-packed and dynamic), merged
+    weights are always kept in BF16 for stage 2 inference.  The parent
+    ``Linear`` module's ``quant_method`` is swapped to
+    ``UnquantizedLinearMethod`` so inference runs with plain ``F.linear``.
+    The original tensors and ``quant_method`` are saved so that
+    ``_restore_lora_state`` can fully restore the original state afterwards.
+
     Returns ``(applied_count, saved_quant_state)`` where
     *saved_quant_state* maps parameter names to their original
     quantized tensors so that un-merging can restore them exactly
     (avoiding double round-trip loss).
     """
     applied = 0
-    saved_state: Dict[str, torch.Tensor] = {}
+    saved_state: Dict[str, Any] = {}
     # Build a lookup that maps *clean* parameter names to the actual
     # Parameter objects.  torch.compile wraps each block in an
     # OptimizedModule, inserting ``._orig_mod.`` into the parameter
@@ -361,6 +369,13 @@ def _apply_lora_deltas(
     for raw_name, param in module.named_parameters():
         clean = raw_name.replace("._orig_mod.", ".")
         state[clean] = param
+
+    # Always build module path → module mapping for quant_method swapping.
+    module_dict: Dict[str, torch.nn.Module] = {}
+    for raw_name, mod in module.named_modules():
+        clean = raw_name.replace("._orig_mod.", ".")
+        module_dict[clean] = mod
+
     _FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
 
     for name, delta in deltas.items():
@@ -409,6 +424,15 @@ def _apply_lora_deltas(
                     delta.to(param.device, param.dtype),
                     alpha=sign,
                 )
+                # Dynamic FP4: weights are stored as BF16 but quantized
+                # on-the-fly at inference via NVFP4LinearMethod.  Swap to
+                # UnquantizedLinearMethod so stage 2 runs plain BF16 GEMMs.
+                linear_mod = module_dict.get(base)
+                if (linear_mod is not None
+                        and isinstance(linear_mod, Linear)
+                        and isinstance(linear_mod.quant_method, NVFP4LinearMethod)):
+                    saved_state[f"__quant_method__{base}"] = linear_mod.quant_method
+                    linear_mod.quant_method = UnquantizedLinearMethod()
             applied += 1
 
         # --- FP4 packed (half last dim) -----------------------------------
@@ -443,10 +467,19 @@ def _apply_lora_deltas(
             )
             bf16.add_(delta.to(bf16.device, bf16.dtype), alpha=sign)
 
-            qw, new_scale, new_s2 = _requantize_fp4_weight(bf16)
-            param.data.copy_(qw)
-            ws_param.data.copy_(new_scale)
-            ws2_param.data.fill_(new_s2.item())
+            # Static FP4: always keep in BF16 for stage 2 — replace the
+            # packed FP4 storage (shape changes from (out, in//2) → (out, in))
+            # and swap the parent Linear's quant_method to plain F.linear.
+            param.data = bf16
+            linear_mod = module_dict.get(base)
+            if linear_mod is not None and isinstance(linear_mod, Linear):
+                saved_state[f"__quant_method__{base}"] = linear_mod.quant_method
+                linear_mod.quant_method = UnquantizedLinearMethod()
+            else:
+                logger.warning(
+                    f"Static FP4 LoRA merge: could not find Linear module at '{base}'; "
+                    f"quant_method not swapped — FP4 kernel may crash."
+                )
             applied += 1
         else:
             logger.warning(
@@ -459,16 +492,40 @@ def _apply_lora_deltas(
 
 def _restore_lora_state(
     module: torch.nn.Module,
-    saved_state: Dict[str, torch.Tensor],
+    saved_state: Dict[str, Any],
 ) -> None:
-    """Restore quantized parameters saved by ``_apply_lora_deltas``."""
+    """Restore quantized parameters saved by ``_apply_lora_deltas``.
+
+    Handles three cases:
+    - Regular tensors (same shape/dtype): restored via ``.data.copy_()``.
+    - BF16-swapped FP4 weights (shape/dtype changed for stage 2):
+      restored via ``.data =`` assignment to replace the storage.
+    - Saved ``quant_method`` objects (keys starting with
+      ``__quant_method__``): re-assigned to the corresponding Linear module.
+    """
     state: Dict[str, torch.nn.Parameter] = {}
     for raw_name, param in module.named_parameters():
         clean = raw_name.replace("._orig_mod.", ".")
         state[clean] = param
+
+    module_dict: Dict[str, torch.nn.Module] = {}
+    for raw_name, mod in module.named_modules():
+        clean = raw_name.replace("._orig_mod.", ".")
+        module_dict[clean] = mod
+
     for name, data in saved_state.items():
-        if name in state:
-            state[name].data.copy_(data)
+        if name.startswith("__quant_method__"):
+            mod_path = name[len("__quant_method__"):]
+            mod = module_dict.get(mod_path)
+            if mod is not None:
+                mod.quant_method = data
+        elif name in state:
+            param = state[name]
+            if param.data.shape == data.shape and param.data.dtype == data.dtype:
+                param.data.copy_(data)
+            else:
+                # Shape or dtype changed (e.g. BF16 swap): replace storage.
+                param.data = data
 
 
 # ---------------------------------------------------------------------------
@@ -687,16 +744,20 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         # ================================================================
         # Stage 2: refinement denoising with distilled LoRA
         # ================================================================
+        # For FP4 models (static-packed or dynamic), stage 2 always runs in
+        # BF16: the quant_method is swapped to UnquantizedLinearMethod inside
+        # _apply_lora_deltas and restored afterwards.  BF16 models are unaffected.
         n, saved_quant_state = _apply_lora_deltas(
             self.transformer,
             self._distilled_lora_deltas,
             sign=1.0,
         )
-        logger.info(f"Merged distilled LoRA ({n} params) for stage 2")
+        logger.info(f"Merged distilled LoRA ({n} params) for stage 2 (BF16 weights)")
 
         # Disable Ulysses for Stage 2: only rank 0 is active, so
         # cross-rank collectives in the attention backend would hang.
         self.transformer.set_ulysses_enabled(False)
+        stage2_start = time.time()
         try:
             video_latents, audio_latents = self._refinement_denoise(
                 video_latents=video_latents,
@@ -712,6 +773,8 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
                 image_cond_strength=image_cond_strength,
             )
         finally:
+            stage2_denoise_time = time.time() - stage2_start
+            logger.info(f"Stage 2 denoising time: {stage2_denoise_time:.2f}s (BF16 weights)")
             self.transformer.set_ulysses_enabled(True)
             if saved_quant_state:
                 # for FP8 / FP4 stage 2, we restore the original quantized weights by copying them back

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Union
 import safetensors.torch
 import torch
 
-from tensorrt_llm._torch.modules.linear import Linear, NVFP4LinearMethod, UnquantizedLinearMethod
+from tensorrt_llm._torch.modules.linear import Linear, UnquantizedLinearMethod
 from tensorrt_llm._torch.visual_gen.output import MediaOutput
 from tensorrt_llm._torch.visual_gen.pipeline_registry import register_pipeline
 from tensorrt_llm._torch.visual_gen.quantization.ops import quantize_fp8_blockwise, quantize_nvfp4
@@ -341,21 +341,22 @@ def _apply_lora_deltas(
     """Add (sign=+1) or remove (sign=-1) pre-computed LoRA deltas.
 
     For standard (BF16/FP16) weights the delta is added directly.
-    For FP8-quantized weights (same shape, float8 dtype) and
-    NVFP4-quantized weights (packed, half the last dim) we
-    dequantize → apply → requantize.
+    For FP8-quantized weights (same shape, float8 dtype), we
+    dequantize → apply → requantize.  FP4 weights are handled through
+    the packed-FP4 branch because the current static and dynamic NVFP4
+    load paths both store packed FP4 weights by the time LoRA deltas are
+    applied.  For packed FP4, merged weights are kept in BF16 for stage 2
+    inference.  The parent ``Linear`` module's ``quant_method`` is swapped
+    to ``UnquantizedLinearMethod`` so inference runs with plain
+    ``F.linear``.  The original tensors and ``quant_method`` are saved so
+    that ``_restore_lora_state`` can fully restore the original state
+    afterwards.
 
-    For FP4-quantized models (both static-packed and dynamic), merged
-    weights are always kept in BF16 for stage 2 inference.  The parent
-    ``Linear`` module's ``quant_method`` is swapped to
-    ``UnquantizedLinearMethod`` so inference runs with plain ``F.linear``.
-    The original tensors and ``quant_method`` are saved so that
-    ``_restore_lora_state`` can fully restore the original state afterwards.
-
-    Returns ``(applied_count, saved_quant_state)`` where
-    *saved_quant_state* maps parameter names to their original
-    quantized tensors so that un-merging can restore them exactly
-    (avoiding double round-trip loss).
+    Returns ``(applied_count, saved_lora_state)`` where
+    *saved_lora_state* maps each touched parameter name to its original
+    tensor.  For packed FP4 it also stores the parent ``quant_method`` so
+    that stage 2 can run with BF16 weights and then restore the exact
+    original FP4 state without another quantization round trip.
     """
     applied = 0
     saved_state: Dict[str, Any] = {}
@@ -424,20 +425,9 @@ def _apply_lora_deltas(
                     delta.to(param.device, param.dtype),
                     alpha=sign,
                 )
-                # Dynamic FP4: weights are stored as BF16 but quantized
-                # on-the-fly at inference via NVFP4LinearMethod.  Swap to
-                # UnquantizedLinearMethod so stage 2 runs plain BF16 GEMMs.
-                linear_mod = module_dict.get(base)
-                if (
-                    linear_mod is not None
-                    and isinstance(linear_mod, Linear)
-                    and isinstance(linear_mod.quant_method, NVFP4LinearMethod)
-                ):
-                    saved_state[f"__quant_method__{base}"] = linear_mod.quant_method
-                    linear_mod.quant_method = UnquantizedLinearMethod()
             applied += 1
 
-        # --- FP4 packed (half last dim) -----------------------------------
+        # --- packed FP4 (half last dim) -----------------------------------
         elif (
             param.ndim == 2
             and delta.ndim == 2
@@ -469,19 +459,18 @@ def _apply_lora_deltas(
             )
             bf16.add_(delta.to(bf16.device, bf16.dtype), alpha=sign)
 
-            # Static FP4: always keep in BF16 for stage 2 — replace the
-            # packed FP4 storage (shape changes from (out, in//2) → (out, in))
-            # and swap the parent Linear's quant_method to plain F.linear.
-            param.data = bf16
             linear_mod = module_dict.get(base)
-            if linear_mod is not None and isinstance(linear_mod, Linear):
-                saved_state[f"__quant_method__{base}"] = linear_mod.quant_method
-                linear_mod.quant_method = UnquantizedLinearMethod()
-            else:
-                logger.warning(
-                    f"Static FP4 LoRA merge: could not find Linear module at '{base}'; "
-                    f"quant_method not swapped — FP4 kernel may crash."
+            if linear_mod is None or not isinstance(linear_mod, Linear):
+                raise RuntimeError(
+                    f"Packed FP4 LoRA merge: could not find Linear module at '{base}'."
                 )
+
+            # Packed FP4: keep the LoRA-merged weight in BF16 for stage 2.
+            # This replaces packed FP4 storage (out, in//2) with BF16 storage
+            # (out, in) and swaps the parent Linear to plain F.linear.
+            param.data = bf16
+            saved_state[f"__quant_method__{base}"] = linear_mod.quant_method
+            linear_mod.quant_method = UnquantizedLinearMethod()
             applied += 1
         else:
             logger.warning(
@@ -496,7 +485,7 @@ def _restore_lora_state(
     module: torch.nn.Module,
     saved_state: Dict[str, Any],
 ) -> None:
-    """Restore quantized parameters saved by ``_apply_lora_deltas``.
+    """Restore parameters and quantization state saved by ``_apply_lora_deltas``.
 
     Handles three cases:
     - Regular tensors (same shape/dtype): restored via ``.data.copy_()``.
@@ -519,8 +508,11 @@ def _restore_lora_state(
         if name.startswith("__quant_method__"):
             mod_path = name[len("__quant_method__") :]
             mod = module_dict.get(mod_path)
-            if mod is not None:
-                mod.quant_method = data
+            if mod is None or not isinstance(mod, Linear):
+                raise RuntimeError(
+                    f"Could not restore quant_method for Linear module '{mod_path}'."
+                )
+            mod.quant_method = data
         elif name in state:
             param = state[name]
             if param.data.shape == data.shape and param.data.dtype == data.dtype:
@@ -749,7 +741,7 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         # For FP4 models (static-packed or dynamic), stage 2 always runs in
         # BF16: the quant_method is swapped to UnquantizedLinearMethod inside
         # _apply_lora_deltas and restored afterwards.  BF16 models are unaffected.
-        n, saved_quant_state = _apply_lora_deltas(
+        n, saved_lora_state = _apply_lora_deltas(
             self.transformer,
             self._distilled_lora_deltas,
             sign=1.0,
@@ -778,11 +770,12 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             stage2_denoise_time = time.time() - stage2_start
             logger.info(f"Stage 2 denoising time: {stage2_denoise_time:.2f}s (BF16 weights)")
             self.transformer.set_ulysses_enabled(True)
-            if saved_quant_state:
-                # for FP8 / FP4 stage 2, we restore the original quantized weights by copying them back
-                _restore_lora_state(self.transformer, saved_quant_state)
+            if saved_lora_state:
+                # Restore every LoRA-touched parameter from its snapshot. Packed
+                # FP4 also restores the original quant_method.
+                _restore_lora_state(self.transformer, saved_lora_state)
             else:
-                # for BF16 stage 2, we restore the original weights by subtracting LoRA deltas
+                # Fallback for the unexpected case where no snapshot was recorded.
                 _apply_lora_deltas(
                     self.transformer,
                     self._distilled_lora_deltas,

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -38,6 +38,7 @@ from .ltx2_core.video_vae import TilingConfig
 from .pipeline_ltx2 import LTX2Pipeline, _assert_resolution, _find_safetensors_files
 
 STAGE_2_DISTILLED_SIGMA_VALUES = [0.909375, 0.725, 0.421875, 0.0]
+_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
 
 
 # ---------------------------------------------------------------------------
@@ -340,7 +341,8 @@ def _apply_lora_deltas(
 ) -> tuple:
     """Add (sign=+1) or remove (sign=-1) pre-computed LoRA deltas.
 
-    For standard (BF16/FP16) weights the delta is added directly.
+    For standard (BF16/FP16) weights the delta is added directly and
+    later removed by subtracting the same delta.
     For FP8-quantized weights (same shape, float8 dtype), we
     dequantize → apply → requantize.  FP4 weights are handled through
     the packed-FP4 branch because the current static and dynamic NVFP4
@@ -348,15 +350,17 @@ def _apply_lora_deltas(
     applied.  For packed FP4, merged weights are kept in BF16 for stage 2
     inference.  The parent ``Linear`` module's ``quant_method`` is swapped
     to ``UnquantizedLinearMethod`` so inference runs with plain
-    ``F.linear``.  The original tensors and ``quant_method`` are saved so
-    that ``_restore_lora_state`` can fully restore the original state
-    afterwards.
+    ``F.linear``.  The quantized original tensors and ``quant_method`` are
+    saved so that ``_restore_lora_state`` can fully restore the original
+    state afterwards.
 
     Returns ``(applied_count, saved_lora_state)`` where
-    *saved_lora_state* maps each touched parameter name to its original
-    tensor.  For packed FP4 it also stores the parent ``quant_method`` so
-    that stage 2 can run with BF16 weights and then restore the exact
-    original FP4 state without another quantization round trip.
+    *saved_lora_state* maps each touched quantized parameter name to its
+    original tensor.  For packed FP4 it also stores the parent
+    ``quant_method`` so that stage 2 can run with BF16 weights and then
+    restore the exact original FP4 state without another quantization round
+    trip.  Dense BF16/FP16/FP32 weights are not stored in
+    *saved_lora_state*.
     """
     applied = 0
     saved_state: Dict[str, Any] = {}
@@ -376,8 +380,6 @@ def _apply_lora_deltas(
     for raw_name, mod in module.named_modules():
         clean = raw_name.replace("._orig_mod.", ".")
         module_dict[clean] = mod
-
-    _FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
 
     for name, delta in deltas.items():
         param_name = name if name in state else f"{name}.weight"
@@ -419,8 +421,8 @@ def _apply_lora_deltas(
                 param.data.copy_(qw)
                 ws_param.data.copy_(new_scale)
             else:
-                # BF16/FP16/FP32 — direct in-place addition
-                saved_state[param_name] = param.data.clone()
+                # BF16/FP16/FP32: direct in-place addition. These are
+                # restored by subtracting the same delta after stage 2.
                 param.data.add_(
                     delta.to(param.device, param.dtype),
                     alpha=sign,
@@ -479,6 +481,43 @@ def _apply_lora_deltas(
                 f"Skipping."
             )
     return applied, saved_state
+
+
+def _subtract_dense_lora_deltas(
+    module: torch.nn.Module,
+    deltas: Dict[str, torch.Tensor],
+    saved_state: Dict[str, Any],
+) -> int:
+    """Remove LoRA deltas from dense floating-point weights.
+
+    Quantized weights are skipped here because FP8 and FP4 are restored from
+    exact snapshots in ``saved_state``.
+    """
+    restored = 0
+    state: Dict[str, torch.nn.Parameter] = {}
+    for raw_name, param in module.named_parameters():
+        clean = raw_name.replace("._orig_mod.", ".")
+        state[clean] = param
+
+    for name, delta in deltas.items():
+        param_name = name if name in state else f"{name}.weight"
+        if param_name not in state or param_name in saved_state:
+            continue
+
+        param = state[param_name]
+        if param.shape != delta.shape or param.dtype in _FP8_DTYPES:
+            continue
+
+        if not param.data.is_floating_point():
+            continue
+
+        param.data.add_(
+            delta.to(param.device, param.dtype),
+            alpha=-1.0,
+        )
+        restored += 1
+
+    return restored
 
 
 def _restore_lora_state(
@@ -774,13 +813,11 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
                 # Restore every LoRA-touched parameter from its snapshot. Packed
                 # FP4 also restores the original quant_method.
                 _restore_lora_state(self.transformer, saved_lora_state)
-            else:
-                # Fallback for the unexpected case where no snapshot was recorded.
-                _apply_lora_deltas(
-                    self.transformer,
-                    self._distilled_lora_deltas,
-                    sign=-1.0,
-                )
+            _subtract_dense_lora_deltas(
+                self.transformer,
+                self._distilled_lora_deltas,
+                saved_lora_state,
+            )
             logger.info("Un-merged distilled LoRA after stage 2")
 
         # ================================================================

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -354,15 +354,17 @@ def _apply_lora_deltas(
     saved so that ``_restore_lora_state`` can fully restore the original
     state afterwards.
 
-    Returns ``(applied_count, saved_lora_state)`` where
+    Returns ``(applied_count, saved_lora_state, snapshot_required_count)`` where
     *saved_lora_state* maps each touched quantized parameter name to its
     original tensor.  For packed FP4 it also stores the parent
     ``quant_method`` so that stage 2 can run with BF16 weights and then
     restore the exact original FP4 state without another quantization round
     trip.  Dense BF16/FP16/FP32 weights are not stored in
-    *saved_lora_state*.
+    *saved_lora_state*.  *snapshot_required_count* is the number of
+    quantized weights that must be restored from saved snapshots.
     """
     applied = 0
+    snapshot_required = 0
     saved_state: Dict[str, Any] = {}
     # Build a lookup that maps *clean* parameter names to the actual
     # Parameter objects.  torch.compile wraps each block in an
@@ -420,6 +422,7 @@ def _apply_lora_deltas(
                 )
                 param.data.copy_(qw)
                 ws_param.data.copy_(new_scale)
+                snapshot_required += 1
             else:
                 # BF16/FP16/FP32: direct in-place addition. These are
                 # restored by subtracting the same delta after stage 2.
@@ -473,6 +476,7 @@ def _apply_lora_deltas(
             param.data = bf16
             saved_state[f"__quant_method__{base}"] = linear_mod.quant_method
             linear_mod.quant_method = UnquantizedLinearMethod()
+            snapshot_required += 1
             applied += 1
         else:
             logger.warning(
@@ -480,7 +484,7 @@ def _apply_lora_deltas(
                 f"param={list(param.shape)}, delta={list(delta.shape)}. "
                 f"Skipping."
             )
-    return applied, saved_state
+    return applied, saved_state, snapshot_required
 
 
 def _subtract_dense_lora_deltas(
@@ -518,6 +522,16 @@ def _subtract_dense_lora_deltas(
         restored += 1
 
     return restored
+
+
+def _count_saved_lora_weight_tensors(saved_state: Dict[str, Any]) -> int:
+    """Count LoRA-touched base weights restored from snapshots."""
+    return sum(
+        1
+        for name in saved_state
+        if not name.startswith("__quant_method__")
+        and (name == "weight" or name.endswith(".weight"))
+    )
 
 
 def _restore_lora_state(
@@ -780,7 +794,7 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         # For FP4 models (static-packed or dynamic), stage 2 always runs in
         # BF16: the quant_method is swapped to UnquantizedLinearMethod inside
         # _apply_lora_deltas and restored afterwards.  BF16 models are unaffected.
-        n, saved_lora_state = _apply_lora_deltas(
+        n, saved_lora_state, snapshot_required = _apply_lora_deltas(
             self.transformer,
             self._distilled_lora_deltas,
             sign=1.0,
@@ -809,15 +823,32 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             stage2_denoise_time = time.time() - stage2_start
             logger.info(f"Stage 2 denoising time: {stage2_denoise_time:.2f}s (BF16 weights)")
             self.transformer.set_ulysses_enabled(True)
-            if saved_lora_state:
+            if snapshot_required and not saved_lora_state:
+                raise RuntimeError(
+                    "Quantized LoRA state was not saved; cannot safely restore "
+                    "FP8/FP4 stage 2 weights."
+                )
+
+            snapshot_restored = 0
+            if snapshot_required:
                 # Restore every LoRA-touched parameter from its snapshot. Packed
                 # FP4 also restores the original quant_method.
                 _restore_lora_state(self.transformer, saved_lora_state)
-            _subtract_dense_lora_deltas(
+                snapshot_restored = _count_saved_lora_weight_tensors(saved_lora_state)
+
+            # Dense BF16/FP16/FP32 weights are not snapshotted; restore them by
+            # subtracting the LoRA deltas directly.
+            dense_restored = _subtract_dense_lora_deltas(
                 self.transformer,
                 self._distilled_lora_deltas,
                 saved_lora_state,
             )
+            restored = snapshot_restored + dense_restored
+            if restored != n:
+                raise RuntimeError(
+                    f"Restored {restored} LoRA-touched weights after stage 2, "
+                    f"but {n} were applied."
+                )
             logger.info("Un-merged distilled LoRA after stage 2")
 
         # ================================================================

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -846,8 +846,7 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             restored = snapshot_restored + dense_restored
             if restored != n:
                 raise RuntimeError(
-                    f"Restored {restored} LoRA-touched weights after stage 2, "
-                    f"but {n} were applied."
+                    f"Restored {restored} LoRA-touched weights after stage 2, but {n} were applied."
                 )
             logger.info("Un-merged distilled LoRA after stage 2")
 

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -428,9 +428,11 @@ def _apply_lora_deltas(
                 # on-the-fly at inference via NVFP4LinearMethod.  Swap to
                 # UnquantizedLinearMethod so stage 2 runs plain BF16 GEMMs.
                 linear_mod = module_dict.get(base)
-                if (linear_mod is not None
-                        and isinstance(linear_mod, Linear)
-                        and isinstance(linear_mod.quant_method, NVFP4LinearMethod)):
+                if (
+                    linear_mod is not None
+                    and isinstance(linear_mod, Linear)
+                    and isinstance(linear_mod.quant_method, NVFP4LinearMethod)
+                ):
                     saved_state[f"__quant_method__{base}"] = linear_mod.quant_method
                     linear_mod.quant_method = UnquantizedLinearMethod()
             applied += 1
@@ -515,7 +517,7 @@ def _restore_lora_state(
 
     for name, data in saved_state.items():
         if name.startswith("__quant_method__"):
-            mod_path = name[len("__quant_method__"):]
+            mod_path = name[len("__quant_method__") :]
             mod = module_dict.get(mod_path)
             if mod is not None:
                 mod.quant_method = data

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -513,6 +513,7 @@ class TestTwoStageLoRAHelpers:
         """Merge then unmerge in BF16 should leave weights approximately unchanged."""
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2_two_stages import (
             _apply_lora_deltas,
+            _subtract_dense_lora_deltas,
         )
 
         device = "cuda"
@@ -522,13 +523,15 @@ class TestTwoStageLoRAHelpers:
         delta = torch.randn(64, 64, device=device) * 0.01
         deltas = {"weight": delta}
 
-        applied, _ = _apply_lora_deltas(linear, deltas, sign=1.0)
+        applied, saved_state = _apply_lora_deltas(linear, deltas, sign=1.0)
         assert applied == 1, "Expected one parameter to be modified"
+        assert saved_state == {}, "Dense BF16 weights should not be snapshotted"
         assert not torch.allclose(linear.weight.data, original_weight), (
             "Weights should have changed after applying delta"
         )
 
-        _apply_lora_deltas(linear, deltas, sign=-1.0)
+        removed = _subtract_dense_lora_deltas(linear, deltas, saved_state)
+        assert removed == 1, "Expected one dense parameter to be unmerged"
         drift = (linear.weight.data.float() - original_weight.float()).abs().max().item()
         assert drift < 0.05, f"bf16 merge/unmerge drift too large: {drift:.2e}"
 
@@ -552,6 +555,7 @@ class TestTwoStageLoRAHelpers:
         """After N merge+unmerge rounds the drift stays bounded."""
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2_two_stages import (
             _apply_lora_deltas,
+            _subtract_dense_lora_deltas,
         )
 
         device = "cuda"
@@ -561,18 +565,19 @@ class TestTwoStageLoRAHelpers:
         deltas = {"weight": torch.randn(64, 64, device=device) * 0.01}
         rounds = 10
         for _ in range(rounds):
-            _apply_lora_deltas(model, deltas, sign=1.0)
-            _apply_lora_deltas(model, deltas, sign=-1.0)
+            _, saved_state = _apply_lora_deltas(model, deltas, sign=1.0)
+            assert saved_state == {}, "Dense BF16 weights should not be snapshotted"
+            _subtract_dense_lora_deltas(model, deltas, saved_state)
 
         drift = (model.weight.data.float() - original.float()).abs().max().item()
         assert drift < 0.1, f"bf16 drift after {rounds} rounds too large: {drift:.2e}"
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    def test_restore_lora_state_exact(self):
-        """_restore_lora_state restores original quantized tensors exactly."""
+    def test_dense_lora_state_not_saved_and_subtract_restores(self):
+        """Dense weights are restored by subtraction without snapshot storage."""
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2_two_stages import (
             _apply_lora_deltas,
-            _restore_lora_state,
+            _subtract_dense_lora_deltas,
         )
 
         device = "cuda"
@@ -582,11 +587,13 @@ class TestTwoStageLoRAHelpers:
         deltas = {"weight": torch.randn(32, 32, device=device) * 0.1}
         _, saved_state = _apply_lora_deltas(linear, deltas, sign=1.0)
 
+        assert saved_state == {}, "Dense FP32 weights should not be snapshotted"
         assert not torch.allclose(linear.weight.data, original_weight)
 
-        _restore_lora_state(linear, saved_state)
+        removed = _subtract_dense_lora_deltas(linear, deltas, saved_state)
+        assert removed == 1
         assert torch.allclose(linear.weight.data, original_weight), (
-            "_restore_lora_state should restore weights exactly"
+            "Dense LoRA subtraction should restore weights"
         )
 
 
@@ -942,6 +949,7 @@ class TestLTX2TwoStagePipelineLoading:
         """Loaded LoRA deltas should match transformer parameter names."""
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2_two_stages import (
             _apply_lora_deltas,
+            _subtract_dense_lora_deltas,
         )
 
         args = VisualGenArgs(
@@ -966,11 +974,13 @@ class TestLTX2TwoStagePipelineLoading:
             print(f"\n[Two-Stage] LoRA apply rate: {match_rate:.1f}% ({applied}/{total})")
             assert match_rate > 99.0, f"Expected >99% LoRA match rate, got {match_rate:.1f}%"
 
-            # Verify unmerge
-            removed, _ = _apply_lora_deltas(
+            assert saved_state == {}, "BF16 checkpoint should not snapshot dense weights"
+
+            # Verify dense unmerge by subtraction
+            removed = _subtract_dense_lora_deltas(
                 pipeline.transformer,
                 pipeline._distilled_lora_deltas,
-                sign=-1.0,
+                saved_state,
             )
             assert removed == applied, (
                 f"Unmerge applied {removed} deltas, but merge applied {applied}"

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -523,9 +523,7 @@ class TestTwoStageLoRAHelpers:
         delta = torch.randn(64, 64, device=device) * 0.01
         deltas = {"weight": delta}
 
-        applied, saved_state, snapshot_required = _apply_lora_deltas(
-            linear, deltas, sign=1.0
-        )
+        applied, saved_state, snapshot_required = _apply_lora_deltas(linear, deltas, sign=1.0)
         assert applied == 1, "Expected one parameter to be modified"
         assert saved_state == {}, "Dense BF16 weights should not be snapshotted"
         assert snapshot_required == 0
@@ -569,9 +567,7 @@ class TestTwoStageLoRAHelpers:
         deltas = {"weight": torch.randn(64, 64, device=device) * 0.01}
         rounds = 10
         for _ in range(rounds):
-            _, saved_state, snapshot_required = _apply_lora_deltas(
-                model, deltas, sign=1.0
-            )
+            _, saved_state, snapshot_required = _apply_lora_deltas(model, deltas, sign=1.0)
             assert saved_state == {}, "Dense BF16 weights should not be snapshotted"
             assert snapshot_required == 0
             _subtract_dense_lora_deltas(model, deltas, saved_state)
@@ -592,9 +588,7 @@ class TestTwoStageLoRAHelpers:
         original_weight = linear.weight.data.clone()
 
         deltas = {"weight": torch.randn(32, 32, device=device) * 0.1}
-        _, saved_state, snapshot_required = _apply_lora_deltas(
-            linear, deltas, sign=1.0
-        )
+        _, saved_state, snapshot_required = _apply_lora_deltas(linear, deltas, sign=1.0)
 
         assert saved_state == {}, "Dense FP32 weights should not be snapshotted"
         assert snapshot_required == 0

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -523,9 +523,12 @@ class TestTwoStageLoRAHelpers:
         delta = torch.randn(64, 64, device=device) * 0.01
         deltas = {"weight": delta}
 
-        applied, saved_state = _apply_lora_deltas(linear, deltas, sign=1.0)
+        applied, saved_state, snapshot_required = _apply_lora_deltas(
+            linear, deltas, sign=1.0
+        )
         assert applied == 1, "Expected one parameter to be modified"
         assert saved_state == {}, "Dense BF16 weights should not be snapshotted"
+        assert snapshot_required == 0
         assert not torch.allclose(linear.weight.data, original_weight), (
             "Weights should have changed after applying delta"
         )
@@ -546,8 +549,9 @@ class TestTwoStageLoRAHelpers:
         original_weight = linear.weight.data.clone()
 
         deltas = {"nonexistent_param.weight": torch.randn(8, 8, device=device)}
-        applied, _ = _apply_lora_deltas(linear, deltas, sign=1.0)
+        applied, _, snapshot_required = _apply_lora_deltas(linear, deltas, sign=1.0)
         assert applied == 0
+        assert snapshot_required == 0
         assert torch.allclose(linear.weight.data, original_weight)
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -565,8 +569,11 @@ class TestTwoStageLoRAHelpers:
         deltas = {"weight": torch.randn(64, 64, device=device) * 0.01}
         rounds = 10
         for _ in range(rounds):
-            _, saved_state = _apply_lora_deltas(model, deltas, sign=1.0)
+            _, saved_state, snapshot_required = _apply_lora_deltas(
+                model, deltas, sign=1.0
+            )
             assert saved_state == {}, "Dense BF16 weights should not be snapshotted"
+            assert snapshot_required == 0
             _subtract_dense_lora_deltas(model, deltas, saved_state)
 
         drift = (model.weight.data.float() - original.float()).abs().max().item()
@@ -585,9 +592,12 @@ class TestTwoStageLoRAHelpers:
         original_weight = linear.weight.data.clone()
 
         deltas = {"weight": torch.randn(32, 32, device=device) * 0.1}
-        _, saved_state = _apply_lora_deltas(linear, deltas, sign=1.0)
+        _, saved_state, snapshot_required = _apply_lora_deltas(
+            linear, deltas, sign=1.0
+        )
 
         assert saved_state == {}, "Dense FP32 weights should not be snapshotted"
+        assert snapshot_required == 0
         assert not torch.allclose(linear.weight.data, original_weight)
 
         removed = _subtract_dense_lora_deltas(linear, deltas, saved_state)
@@ -963,7 +973,7 @@ class TestLTX2TwoStagePipelineLoading:
 
         pipeline = PipelineLoader(args).load(skip_warmup=True)
         try:
-            applied, saved_state = _apply_lora_deltas(
+            applied, saved_state, snapshot_required = _apply_lora_deltas(
                 pipeline.transformer,
                 pipeline._distilled_lora_deltas,
                 sign=1.0,
@@ -975,6 +985,7 @@ class TestLTX2TwoStagePipelineLoading:
             assert match_rate > 99.0, f"Expected >99% LoRA match rate, got {match_rate:.1f}%"
 
             assert saved_state == {}, "BF16 checkpoint should not snapshot dense weights"
+            assert snapshot_required == 0
 
             # Verify dense unmerge by subtraction
             removed = _subtract_dense_lora_deltas(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced FP4 quantization handling during LoRA (Low-Rank Adaptation) application in multi-stage visual generation pipelines, improving parameter management and state restoration.
  * Improved logging and timing information for multi-stage processing to provide better visibility into execution flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

### Image Quality

See videos for BF16 / FP4 stage 2 comparison on dynamic FP4 and static FP4. BF16 stage 2 is visually better.
https://drive.google.com/drive/folders/1aPXUjUXioV5UXOaUooDQj0NpdRNHDHDJ?usp=sharing

### Perf Summary

With 10s video of 1536x1024 resolution, here is the perf table comparision.

| Metric | FP4 | BF16 | Delta | Verdict |
|--------|-----|------|-------|---------|
| Stage 2 denoising (avg) | 15.32 s | 15.81 s | +0.49 s | **BF16 3.2% slower** |
| Two-stage total (avg)   | 82.99 s | 84.72 s | +1.73 s | **BF16 2.1% slower** |

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
