### PR TITLE
[None][fix] Fix GIL management for guided decoding host func

### DIFF
--- a/cpp/tensorrt_llm/nanobind/runtime/hostfunc.cpp
+++ b/cpp/tensorrt_llm/nanobind/runtime/hostfunc.cpp
@@ -78,12 +78,8 @@ std::optional<uintptr_t> launchHostFunc(
 {
     auto const stream = reinterpret_cast<cudaStream_t>(streamPtr);
 
-    nb::gil_scoped_acquire gil;
-
     auto hostFuncUserData
         = std::make_unique<HostFuncUserData>(freeUserData, pyHostFunc, nb::tuple(pyArgs), nb::dict(pyKwargs));
-
-    nb::gil_scoped_release release;
 
     cudaError_t err = cudaLaunchHostFunc(stream, cudaHostFuncTrampoline, hostFuncUserData.get());
     if (err != cudaSuccess)
@@ -100,9 +96,6 @@ std::optional<uintptr_t> launchHostFunc(
 
 void freeHostFuncUserData(uintptr_t userDataPtr)
 {
-    // Acquire the GIL to safely release the Python objects.
-    nb::gil_scoped_acquire gil;
-
     // Create a unique_ptr to take over the ownership of the user data;
     // the user data is released when the unique_ptr is destroyed.
     auto hostFuncUserData = std::unique_ptr<HostFuncUserData>(reinterpret_cast<HostFuncUserData*>(userDataPtr));
@@ -112,9 +105,7 @@ void freeHostFuncUserData(uintptr_t userDataPtr)
 
 void initHostFuncBindings(nb::module_& m)
 {
-    m.def("launch_hostfunc", &launchHostFunc, "Launch a Python host function to a CUDA stream",
-        nb::call_guard<nb::gil_scoped_release>());
-    m.def("free_hostfunc_user_data", &freeHostFuncUserData, "Free the user data for the Python host function",
-        nb::call_guard<nb::gil_scoped_release>());
+    m.def("launch_hostfunc", &launchHostFunc, "Launch a Python host function to a CUDA stream");
+    m.def("free_hostfunc_user_data", &freeHostFuncUserData, "Free the user data for the Python host function");
 }
 } // namespace tensorrt_llm::nanobind::runtime


### PR DESCRIPTION
## Description

When the nano bind function passes Python objects by value we need to hold GIL for the entire duration of the function body since the Python objects will be destructed after the function completes.

## Test Coverage

- `tests/integration/defs/accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_guided_decoding_with_eagle3` - exercises the guided decoding + eagle3 + disagg path that invokes `launch_hostfunc`.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized runtime performance by improving host function execution efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->