### PR TITLE
[#13099][feat] Support Wan 2.2 5B TI2V model

### DIFF
--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -107,6 +107,7 @@ For full documentation, see the [Visual Generation](./visual-generation.md) page
 | `Wan-AI/Wan2.1-I2V-14B-720P-Diffusers` | Image-to-Video |
 | `Wan-AI/Wan2.2-T2V-A14B-Diffusers` | Text-to-Video |
 | `Wan-AI/Wan2.2-I2V-A14B-Diffusers` | Image-to-Video |
+| `Wan-AI/Wan2.2-TI2V-5B-Diffusers` | Text-to-Video, Image-to-Video |
 | `Lightricks/LTX-2` | Text-to-Video (with Audio), Image-to-Video (with Audio) |
 
 ## Feature Matrix

--- a/docs/source/models/visual-generation.md
+++ b/docs/source/models/visual-generation.md
@@ -30,6 +30,7 @@ TensorRT-LLM **VisualGen** provides a unified inference stack for diffusion mode
 | `Wan-AI/Wan2.1-I2V-14B-720P-Diffusers` | Image-to-Video |
 | `Wan-AI/Wan2.2-T2V-A14B-Diffusers` | Text-to-Video |
 | `Wan-AI/Wan2.2-I2V-A14B-Diffusers` | Image-to-Video |
+| `Wan-AI/Wan2.2-TI2V-5B-Diffusers` | Text-to-Video, Image-to-Video |
 | `Lightricks/LTX-2` | Text-to-Video (with Audio), Image-to-Video (with Audio) |
 
 Models are auto-detected from the checkpoint directory. Diffusers-format models are detected via `model_index.json`; LTX-2 monolithic safetensors checkpoints are detected via embedded metadata. The `AutoPipeline` registry selects the appropriate pipeline class automatically.

--- a/examples/visual_gen/visual_gen_wan_i2v.py
+++ b/examples/visual_gen/visual_gen_wan_i2v.py
@@ -53,26 +53,32 @@ def parse_args():
     )
 
     # Generation Params
-    parser.add_argument("--height", type=int, default=720, help="Video height")
-    parser.add_argument("--width", type=int, default=1280, help="Video width")
-    parser.add_argument("--num_frames", type=int, default=81, help="Number of frames to generate")
+    parser.add_argument("--height", type=int, default=None, help="Video height (default: auto-detect)")
+    parser.add_argument("--width", type=int, default=None, help="Video width (default: auto-detect)")
+    parser.add_argument(
+        "--num_frames",
+        type=int,
+        default=None,
+        help="Number of frames to generate (default: auto-detect)",
+    )
+    parser.add_argument("--frame_rate", type=float, default=None, help="Output video frame rate (default: auto-detect)")
     parser.add_argument(
         "--steps",
         type=int,
         default=None,
-        help="Number of denoising steps (default: auto-detect, 50 for Wan2.1, 40 for Wan2.2)",
+        help="Number of denoising steps (default: auto-detect, 50 for Wan2.1 and Wan 2.2 5B, 40 for Wan2.2 A14B)",
     )
     parser.add_argument(
         "--guidance_scale",
         type=float,
         default=None,
-        help="Guidance scale (default: auto-detect, 5.0 for Wan2.1, 4.0 for Wan2.2)",
+        help="Guidance scale (default: auto-detect, 5.0 for Wan2.1 and Wan 2.2 5B, 4.0 for Wan2.2 A14B)",
     )
     parser.add_argument(
         "--guidance_scale_2",
         type=float,
         default=None,
-        help="Second-stage guidance scale for Wan2.2 two-stage denoising (default: 3.0)",
+        help="Second-stage guidance scale for Wan2.2 A14B two-stage denoising (default: 3.0)",
     )
     parser.add_argument(
         "--boundary_ratio",
@@ -352,14 +358,20 @@ def main():
     )
 
     try:
+        defaults = visual_gen.default_params
+        negative_prompt_log = (args.negative_prompt if args.negative_prompt is not None else "[model default]")
+        height = args.height if args.height is not None else defaults.height
+        width = args.width if args.width is not None else defaults.width
+        num_frames = args.num_frames if args.num_frames is not None else defaults.num_frames
+        steps = args.steps if args.steps is not None else defaults.num_inference_steps
+        frame_rate = args.frame_rate if args.frame_rate is not None else defaults.frame_rate
+
         logger.info(f"Generating video for prompt: '{args.prompt}'")
-        logger.info(f"Negative prompt: '{args.negative_prompt}'")
+        logger.info(f"Negative prompt: '{negative_prompt_log}'")
         logger.info(f"Input image: {args.image_path}")
         if args.last_image_path:
             logger.info(f"Last frame image: {args.last_image_path}")
-        logger.info(
-            f"Resolution: {args.height}x{args.width}, Frames: {args.num_frames}, Steps: {args.steps}"
-        )
+        logger.info(f"Resolution: {height}x{width}, Frames: {num_frames}, Steps: {steps}, FPS: {frame_rate}")
 
         start_time = time.time()
 
@@ -380,6 +392,7 @@ def main():
                 guidance_scale=args.guidance_scale,
                 seed=args.seed,
                 num_frames=args.num_frames,
+                frame_rate=args.frame_rate,
                 negative_prompt=args.negative_prompt,
                 image=args.image_path,
                 extra_params=extra_params if extra_params else None,
@@ -388,7 +401,7 @@ def main():
 
         logger.info(f"Generation completed in {time.time() - start_time:.2f}s")
 
-        MediaStorage.save_video(output.video, args.output_path, audio=output.audio, frame_rate=16.0)
+        MediaStorage.save_video(output.video, args.output_path, audio=output.audio, frame_rate=frame_rate)
 
     finally:
         visual_gen.shutdown()

--- a/examples/visual_gen/visual_gen_wan_i2v.py
+++ b/examples/visual_gen/visual_gen_wan_i2v.py
@@ -66,12 +66,6 @@ def parse_args():
         help="Number of frames to generate (default: auto-detect)",
     )
     parser.add_argument(
-        "--frame_rate",
-        type=float,
-        default=None,
-        help="Output video frame rate (default: auto-detect)",
-    )
-    parser.add_argument(
         "--steps",
         type=int,
         default=None,
@@ -375,16 +369,14 @@ def main():
         width = args.width if args.width is not None else defaults.width
         num_frames = args.num_frames if args.num_frames is not None else defaults.num_frames
         steps = args.steps if args.steps is not None else defaults.num_inference_steps
-        frame_rate = args.frame_rate if args.frame_rate is not None else defaults.frame_rate
+        frame_rate = defaults.frame_rate
 
         logger.info(f"Generating video for prompt: '{args.prompt}'")
         logger.info(f"Negative prompt: '{negative_prompt_log}'")
         logger.info(f"Input image: {args.image_path}")
         if args.last_image_path:
             logger.info(f"Last frame image: {args.last_image_path}")
-        logger.info(
-            f"Resolution: {height}x{width}, Frames: {num_frames}, Steps: {steps}, FPS: {frame_rate}"
-        )
+        logger.info(f"Resolution: {height}x{width}, Frames: {num_frames}, Steps: {steps}")
 
         start_time = time.time()
 
@@ -405,7 +397,7 @@ def main():
                 guidance_scale=args.guidance_scale,
                 seed=args.seed,
                 num_frames=args.num_frames,
-                frame_rate=args.frame_rate,
+                frame_rate=frame_rate,
                 negative_prompt=args.negative_prompt,
                 image=args.image_path,
                 extra_params=extra_params if extra_params else None,

--- a/examples/visual_gen/visual_gen_wan_i2v.py
+++ b/examples/visual_gen/visual_gen_wan_i2v.py
@@ -53,15 +53,24 @@ def parse_args():
     )
 
     # Generation Params
-    parser.add_argument("--height", type=int, default=None, help="Video height (default: auto-detect)")
-    parser.add_argument("--width", type=int, default=None, help="Video width (default: auto-detect)")
+    parser.add_argument(
+        "--height", type=int, default=None, help="Video height (default: auto-detect)"
+    )
+    parser.add_argument(
+        "--width", type=int, default=None, help="Video width (default: auto-detect)"
+    )
     parser.add_argument(
         "--num_frames",
         type=int,
         default=None,
         help="Number of frames to generate (default: auto-detect)",
     )
-    parser.add_argument("--frame_rate", type=float, default=None, help="Output video frame rate (default: auto-detect)")
+    parser.add_argument(
+        "--frame_rate",
+        type=float,
+        default=None,
+        help="Output video frame rate (default: auto-detect)",
+    )
     parser.add_argument(
         "--steps",
         type=int,
@@ -359,7 +368,9 @@ def main():
 
     try:
         defaults = visual_gen.default_params
-        negative_prompt_log = (args.negative_prompt if args.negative_prompt is not None else "[model default]")
+        negative_prompt_log = (
+            args.negative_prompt if args.negative_prompt is not None else "[model default]"
+        )
         height = args.height if args.height is not None else defaults.height
         width = args.width if args.width is not None else defaults.width
         num_frames = args.num_frames if args.num_frames is not None else defaults.num_frames
@@ -371,7 +382,9 @@ def main():
         logger.info(f"Input image: {args.image_path}")
         if args.last_image_path:
             logger.info(f"Last frame image: {args.last_image_path}")
-        logger.info(f"Resolution: {height}x{width}, Frames: {num_frames}, Steps: {steps}, FPS: {frame_rate}")
+        logger.info(
+            f"Resolution: {height}x{width}, Frames: {num_frames}, Steps: {steps}, FPS: {frame_rate}"
+        )
 
         start_time = time.time()
 
@@ -401,7 +414,9 @@ def main():
 
         logger.info(f"Generation completed in {time.time() - start_time:.2f}s")
 
-        MediaStorage.save_video(output.video, args.output_path, audio=output.audio, frame_rate=frame_rate)
+        MediaStorage.save_video(
+            output.video, args.output_path, audio=output.audio, frame_rate=frame_rate
+        )
 
     finally:
         visual_gen.shutdown()

--- a/examples/visual_gen/visual_gen_wan_t2v.py
+++ b/examples/visual_gen/visual_gen_wan_t2v.py
@@ -47,15 +47,24 @@ def parse_args():
     )
 
     # Generation Params
-    parser.add_argument("--height", type=int, default=None, help="Video height (default: auto-detect)")
-    parser.add_argument("--width", type=int, default=None, help="Video width (default: auto-detect)")
+    parser.add_argument(
+        "--height", type=int, default=None, help="Video height (default: auto-detect)"
+    )
+    parser.add_argument(
+        "--width", type=int, default=None, help="Video width (default: auto-detect)"
+    )
     parser.add_argument(
         "--num_frames",
         type=int,
         default=None,
         help="Number of frames to generate (default: auto-detect)",
     )
-    parser.add_argument("--frame_rate", type=float, default=None, help="Output video frame rate (default: auto-detect)")
+    parser.add_argument(
+        "--frame_rate",
+        type=float,
+        default=None,
+        help="Output video frame rate (default: auto-detect)",
+    )
     parser.add_argument(
         "--steps",
         type=int,
@@ -359,7 +368,9 @@ def main():
 
     try:
         defaults = visual_gen.default_params
-        negative_prompt_log = args.negative_prompt if args.negative_prompt is not None else "[model default]"
+        negative_prompt_log = (
+            args.negative_prompt if args.negative_prompt is not None else "[model default]"
+        )
         height = args.height if args.height is not None else defaults.height
         width = args.width if args.width is not None else defaults.width
         num_frames = args.num_frames if args.num_frames is not None else defaults.num_frames
@@ -368,7 +379,9 @@ def main():
 
         logger.info(f"Generating video for prompt: '{args.prompt}'")
         logger.info(f"Negative prompt: '{negative_prompt_log}'")
-        logger.info(f"Resolution: {height}x{width}, Frames: {num_frames}, Steps: {steps}, FPS: {frame_rate}")
+        logger.info(
+            f"Resolution: {height}x{width}, Frames: {num_frames}, Steps: {steps}, FPS: {frame_rate}"
+        )
 
         start_time = time.time()
 
@@ -395,7 +408,9 @@ def main():
 
         logger.info(f"Generation completed in {time.time() - start_time:.2f}s")
 
-        MediaStorage.save_video(output.video, args.output_path, audio=output.audio, frame_rate=frame_rate)
+        MediaStorage.save_video(
+            output.video, args.output_path, audio=output.audio, frame_rate=frame_rate
+        )
 
     finally:
         visual_gen.shutdown()

--- a/examples/visual_gen/visual_gen_wan_t2v.py
+++ b/examples/visual_gen/visual_gen_wan_t2v.py
@@ -47,26 +47,32 @@ def parse_args():
     )
 
     # Generation Params
-    parser.add_argument("--height", type=int, default=720, help="Video height")
-    parser.add_argument("--width", type=int, default=1280, help="Video width")
-    parser.add_argument("--num_frames", type=int, default=81, help="Number of frames to generate")
+    parser.add_argument("--height", type=int, default=None, help="Video height (default: auto-detect)")
+    parser.add_argument("--width", type=int, default=None, help="Video width (default: auto-detect)")
+    parser.add_argument(
+        "--num_frames",
+        type=int,
+        default=None,
+        help="Number of frames to generate (default: auto-detect)",
+    )
+    parser.add_argument("--frame_rate", type=float, default=None, help="Output video frame rate (default: auto-detect)")
     parser.add_argument(
         "--steps",
         type=int,
         default=None,
-        help="Number of denoising steps (default: auto-detect, 50 for Wan2.1, 40 for Wan2.2)",
+        help="Number of denoising steps (default: auto-detect, 50 for Wan2.1 and Wan 2.2 5B, 40 for Wan2.2 A14B)",
     )
     parser.add_argument(
         "--guidance_scale",
         type=float,
         default=None,
-        help="Guidance scale (default: auto-detect, 5.0 for Wan2.1, 4.0 for Wan2.2)",
+        help="Guidance scale (default: auto-detect, 5.0 for Wan2.1 and Wan 2.2 5B, 4.0 for Wan2.2 A14B)",
     )
     parser.add_argument(
         "--guidance_scale_2",
         type=float,
         default=None,
-        help="Second-stage guidance scale for Wan2.2 two-stage denoising (default: 3.0)",
+        help="Second-stage guidance scale for Wan2.2 A14B two-stage denoising (default: 3.0)",
     )
     parser.add_argument(
         "--boundary_ratio",
@@ -352,11 +358,17 @@ def main():
     )
 
     try:
+        defaults = visual_gen.default_params
+        negative_prompt_log = args.negative_prompt if args.negative_prompt is not None else "[model default]"
+        height = args.height if args.height is not None else defaults.height
+        width = args.width if args.width is not None else defaults.width
+        num_frames = args.num_frames if args.num_frames is not None else defaults.num_frames
+        steps = args.steps if args.steps is not None else defaults.num_inference_steps
+        frame_rate = args.frame_rate if args.frame_rate is not None else defaults.frame_rate
+
         logger.info(f"Generating video for prompt: '{args.prompt}'")
-        logger.info(f"Negative prompt: '{args.negative_prompt}'")
-        logger.info(
-            f"Resolution: {args.height}x{args.width}, Frames: {args.num_frames}, Steps: {args.steps}"
-        )
+        logger.info(f"Negative prompt: '{negative_prompt_log}'")
+        logger.info(f"Resolution: {height}x{width}, Frames: {num_frames}, Steps: {steps}, FPS: {frame_rate}")
 
         start_time = time.time()
 
@@ -375,6 +387,7 @@ def main():
                 guidance_scale=args.guidance_scale,
                 seed=args.seed,
                 num_frames=args.num_frames,
+                frame_rate=args.frame_rate,
                 negative_prompt=args.negative_prompt,
                 extra_params=extra_params if extra_params else None,
             ),
@@ -382,7 +395,7 @@ def main():
 
         logger.info(f"Generation completed in {time.time() - start_time:.2f}s")
 
-        MediaStorage.save_video(output.video, args.output_path, audio=output.audio, frame_rate=16.0)
+        MediaStorage.save_video(output.video, args.output_path, audio=output.audio, frame_rate=frame_rate)
 
     finally:
         visual_gen.shutdown()

--- a/examples/visual_gen/visual_gen_wan_t2v.py
+++ b/examples/visual_gen/visual_gen_wan_t2v.py
@@ -60,12 +60,6 @@ def parse_args():
         help="Number of frames to generate (default: auto-detect)",
     )
     parser.add_argument(
-        "--frame_rate",
-        type=float,
-        default=None,
-        help="Output video frame rate (default: auto-detect)",
-    )
-    parser.add_argument(
         "--steps",
         type=int,
         default=None,
@@ -375,13 +369,11 @@ def main():
         width = args.width if args.width is not None else defaults.width
         num_frames = args.num_frames if args.num_frames is not None else defaults.num_frames
         steps = args.steps if args.steps is not None else defaults.num_inference_steps
-        frame_rate = args.frame_rate if args.frame_rate is not None else defaults.frame_rate
+        frame_rate = defaults.frame_rate
 
         logger.info(f"Generating video for prompt: '{args.prompt}'")
         logger.info(f"Negative prompt: '{negative_prompt_log}'")
-        logger.info(
-            f"Resolution: {height}x{width}, Frames: {num_frames}, Steps: {steps}, FPS: {frame_rate}"
-        )
+        logger.info(f"Resolution: {height}x{width}, Frames: {num_frames}, Steps: {steps}")
 
         start_time = time.time()
 
@@ -400,7 +392,7 @@ def main():
                 guidance_scale=args.guidance_scale,
                 seed=args.seed,
                 num_frames=args.num_frames,
-                frame_rate=args.frame_rate,
+                frame_rate=frame_rate,
                 negative_prompt=args.negative_prompt,
                 extra_params=extra_params if extra_params else None,
             ),

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -895,6 +895,8 @@ class DiffusionModelConfig(BaseModel):
                     transformer_2_spec = model_index.get("transformer_2")
                     if transformer_2_spec and transformer_2_spec[0] is not None:
                         pretrained_config.boundary_ratio = model_index["boundary_ratio"]
+                if "expand_timesteps" in model_index:
+                    pretrained_config.expand_timesteps = bool(model_index["expand_timesteps"])
         else:
             # ---------- Single safetensors ----------
             native_config = cls._try_load_safetensors_config(checkpoint_path)

--- a/tensorrt_llm/_torch/visual_gen/models/wan/defaults.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/defaults.py
@@ -59,11 +59,11 @@ _WAN22_14B_PARAMS = {
 _WAN22_5B_PARAMS = {
     "height": 704,
     "width": 1280,
-    "num_inference_steps": 40,
+    "num_inference_steps": 50,
     "guidance_scale": 5.0,
     "max_sequence_length": 512,
-    "num_frames": 81,
-    "frame_rate": 16.0,
+    "num_frames": 121,
+    "frame_rate": 24.0,
 }
 
 _WAN22_EXTRA_SPECS: Dict[str, ExtraParamSchema] = {

--- a/tensorrt_llm/_torch/visual_gen/models/wan/defaults.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/defaults.py
@@ -46,11 +46,21 @@ _WAN21_720P_PARAMS = {
     "frame_rate": 16.0,
 }
 
-_WAN22_PARAMS = {
+_WAN22_14B_PARAMS = {
     "height": 720,
     "width": 1280,
     "num_inference_steps": 40,
     "guidance_scale": 4.0,
+    "max_sequence_length": 512,
+    "num_frames": 81,
+    "frame_rate": 16.0,
+}
+
+_WAN22_5B_PARAMS = {
+    "height": 704,
+    "width": 1280,
+    "num_inference_steps": 40,
+    "guidance_scale": 5.0,
     "max_sequence_length": 512,
     "num_frames": 81,
     "frame_rate": 16.0,
@@ -99,18 +109,22 @@ def get_wan_default_params(
     name_or_path: str,
     num_heads: int,
     *,
+    is_wan22_5b: bool = False,
     include_i2v: bool = False,
 ) -> dict:
     """Return the default generation params dict for a Wan model.
 
     Args:
-        is_wan22: Whether this is a Wan 2.2 model (has boundary_ratio).
+        is_wan22: Whether this is a Wan 2.2 A14B model (has boundary_ratio).
         name_or_path: Checkpoint path or HF model ID (_name_or_path).
         num_heads: Number of attention heads from transformer config.
+        is_wan22_5b: Whether this is a Wan 2.2 TI2V-5B model.
         include_i2v: If True, add I2V-specific defaults (image_cond_strength).
     """
-    if is_wan22:
-        params = dict(_WAN22_PARAMS)
+    if is_wan22_5b:
+        params = dict(_WAN22_5B_PARAMS)
+    elif is_wan22:
+        params = dict(_WAN22_14B_PARAMS)
     elif _is_480p_model(name_or_path, num_heads, is_wan22):
         params = dict(_WAN21_480P_PARAMS)
     else:

--- a/tensorrt_llm/_torch/visual_gen/models/wan/defaults.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/defaults.py
@@ -105,7 +105,7 @@ def _is_480p_model(name_or_path: str, num_heads: int, is_wan22: bool) -> bool:
 
 
 def get_wan_default_params(
-    is_wan22: bool,
+    is_wan22_14b: bool,
     name_or_path: str,
     num_heads: int,
     *,
@@ -115,7 +115,7 @@ def get_wan_default_params(
     """Return the default generation params dict for a Wan model.
 
     Args:
-        is_wan22: Whether this is a Wan 2.2 A14B model (has boundary_ratio).
+        is_wan22_14b: Whether this is a Wan 2.2 A14B model (has boundary_ratio).
         name_or_path: Checkpoint path or HF model ID (_name_or_path).
         num_heads: Number of attention heads from transformer config.
         is_wan22_5b: Whether this is a Wan 2.2 TI2V-5B model.
@@ -123,9 +123,9 @@ def get_wan_default_params(
     """
     if is_wan22_5b:
         params = dict(_WAN22_5B_PARAMS)
-    elif is_wan22:
+    elif is_wan22_14b:
         params = dict(_WAN22_14B_PARAMS)
-    elif _is_480p_model(name_or_path, num_heads, is_wan22):
+    elif _is_480p_model(name_or_path, num_heads, is_wan22_14b):
         params = dict(_WAN21_480P_PARAMS)
     else:
         params = dict(_WAN21_720P_PARAMS)
@@ -136,12 +136,12 @@ def get_wan_default_params(
     return params
 
 
-def get_wan_extra_param_specs(is_wan22: bool) -> Dict[str, ExtraParamSchema]:
+def get_wan_extra_param_specs(is_wan22_14b: bool) -> Dict[str, ExtraParamSchema]:
     """Return extra_param_specs for a Wan model.
 
-    Wan 2.2 exposes guidance_scale_2 and boundary_ratio.
-    Wan 2.1 has no model-specific extra params.
+    Wan 2.2 A14B exposes guidance_scale_2 and boundary_ratio.
+    Wan 2.1 and Wan 2.2 TI2V-5B have no model-specific extra params.
     """
-    if is_wan22:
+    if is_wan22_14b:
         return dict(_WAN22_EXTRA_SPECS)
     return {}

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -32,7 +32,7 @@ from .transformer_wan import WanTransformer3DModel
 # - Wan2.1-T2V-14B: Single-stage text-to-video (14B parameters)
 # - Wan2.1-T2V-1.3B: Single-stage text-to-video (1.3B parameters)
 # - Wan2.2-T2V-A14B: Two-stage text-to-video (14B, boundary_ratio for high/low-noise stages; supports 480P & 720P)
-# - Wan2.2-TI2V-5B: Single-stage, text-to-video and image-to-video (5B; supports 480P & 720P)
+# - Wan2.2-TI2V-5B: Single-stage, text-to-video and image-to-video (5B; supports 720P)
 
 WAN_TEACACHE_COEFFICIENTS = {
     "1.3B": {
@@ -91,9 +91,9 @@ class WanPipeline(BasePipeline):
         self.is_wan22_5b = self.expand_timesteps
 
         # Validate TeaCache compatibility before allocating GPU memory
-        if self.is_wan22_14b and model_config.cache_backend == "teacache":
+        if (self.is_wan22_14b or self.is_wan22_5b) and model_config.cache_backend == "teacache":
             raise ValueError(
-                "TeaCache is not supported for Wan 2.2 T2V models. "
+                "TeaCache is not supported for Wan 2.2 models. "
                 "Use cache_backend='none' or 'cache_dit' (not 'teacache')."
             )
 
@@ -141,11 +141,13 @@ class WanPipeline(BasePipeline):
     def default_warmup_resolutions(self):
         if self.is_wan22_5b:
             # The 720p resolution of Wan2.2 TI2V 5B model is 704x1280
-            return [(480, 832), (704, 1280)]
+            return [(704, 1280)]
         return [(480, 832), (720, 1280)]
 
     @property
     def default_warmup_num_frames(self):
+        if self.is_wan22_5b:
+            return [33, 121]
         return [33, 81]
 
     @property
@@ -197,8 +199,9 @@ class WanPipeline(BasePipeline):
             logger.info("Detected Wan 2.1 T2V (single-stage denoising)")
 
         # Set default VAE scale factors (will be overridden if VAE is loaded)
+        default_vae_scale_factor_spatial = 16 if self.is_wan22_5b else 8
         self.vae_scale_factor_temporal = 4
-        self.vae_scale_factor_spatial = 8
+        self.vae_scale_factor_spatial = default_vae_scale_factor_spatial
 
         if PipelineComponent.TOKENIZER not in skip_components:
             logger.info("Loading tokenizer...")
@@ -224,7 +227,11 @@ class WanPipeline(BasePipeline):
             ).to(device)
 
             self.vae_scale_factor_temporal = getattr(self.vae.config, "scale_factor_temporal", 4)
-            self.vae_scale_factor_spatial = getattr(self.vae.config, "scale_factor_spatial", 8)
+            self.vae_scale_factor_spatial = getattr(
+                self.vae.config,
+                "scale_factor_spatial",
+                default_vae_scale_factor_spatial,
+            )
 
         if PipelineComponent.SCHEDULER not in skip_components:
             logger.info("Loading scheduler...")
@@ -341,7 +348,11 @@ class WanPipeline(BasePipeline):
         # Wan 2.2 TI2V-5B takes one conditioning image if provided
         image = req.params.image
         if isinstance(image, list):
-            raise ValueError(f"WanPipeline I2V expects a single image, got list of {len(image)}.")
+            if len(image) != 1:
+                raise ValueError(
+                    f"WanPipeline I2V expects a single image, got list of {len(image)}."
+                )
+            image = image[0]
 
         return self.forward(
             prompt=req.prompt,
@@ -377,7 +388,7 @@ class WanPipeline(BasePipeline):
     ):
         pipeline_start = time.time()
 
-        # I2V is only supported on Wan 2.2 TI2V-5B here. Wan 2.1 I2V and Wan 2.2 A14B I2V use WanImageToVideoPipeline
+        # WanPipeline supports I2V for Wan 2.2 TI2V-5B. Use WanImageToVideoPipeline for Wan 2.1 I2V and Wan 2.2 A14B I2V
         is_i2v = image is not None
         if is_i2v and not self.is_wan22_5b:
             raise ValueError(
@@ -421,6 +432,13 @@ class WanPipeline(BasePipeline):
             f"Running {mode_str} inference "
             f"(boundary_ratio={boundary_ratio}, has_transformer_2={self.transformer_2 is not None})"
         )
+
+        # Set model-specific defaults if not provided
+        defaults = self.default_generation_params
+        if num_inference_steps is None:
+            num_inference_steps = defaults["num_inference_steps"]
+        if guidance_scale is None:
+            guidance_scale = defaults["guidance_scale"]
 
         if self.is_wan22_14b and guidance_scale_2 is None:
             guidance_scale_2 = guidance_scale  # Match HF: default to guidance_scale when unset
@@ -622,6 +640,8 @@ class WanPipeline(BasePipeline):
 
         return randn_tensor(shape, generator=generator, device=self.device, dtype=self.dtype)
 
+    # Adapted from diffusers.pipelines.wan.pipeline_wan_i2v
+    # https://github.com/huggingface/diffusers/blob/main/src/diffusers/pipelines/wan/pipeline_wan_i2v.py
     @nvtx_range("_prepare_latents_wan22_5B_i2v", color="blue")
     def _prepare_latents_wan22_5B_i2v(
         self,
@@ -642,7 +662,7 @@ class WanPipeline(BasePipeline):
         latent_height = height // self.vae_scale_factor_spatial
         latent_width = width // self.vae_scale_factor_spatial
 
-        num_channels_latents = getattr(self.transformer.config, "in_channels", 16)
+        num_channels_latents = getattr(self.transformer.config, "in_channels", 48)
         shape = (batch_size, num_channels_latents, num_latent_frames, latent_height, latent_width)
         latents = randn_tensor(shape, generator=generator, device=self.device, dtype=self.dtype)
 
@@ -659,6 +679,8 @@ class WanPipeline(BasePipeline):
         latent_condition = retrieve_latents(self.vae.encode(image), sample_mode="argmax").to(
             self.dtype
         )
+        if batch_size > 1:
+            latent_condition = latent_condition.repeat(batch_size, 1, 1, 1, 1)
 
         # Normalize latents to match diffusion model's latent space
         latents_mean = (

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -517,13 +517,12 @@ class WanPipeline(BasePipeline):
             )
 
         # Pin reference image to latent after each scheduler step (Wan 2.2 5B I2V only)
-        post_step_fn = None
-        if self.is_wan22_5b and is_i2v:
+        def _pin_i2v_first_frame(x):
+            return ((1 - i2v_first_frame_mask) * i2v_condition + i2v_first_frame_mask * x).to(
+                self.dtype
+            )
 
-            def post_step_fn(x):
-                return ((1 - i2v_first_frame_mask) * i2v_condition + i2v_first_frame_mask * x).to(
-                    self.dtype
-                )
+        post_step_fn = _pin_i2v_first_frame if (self.is_wan22_5b and is_i2v) else None
 
         # Two-stage denoising: model switching in forward_fn, guidance scale switching in denoise()
         latents = self.denoise(

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -2,6 +2,7 @@ import time
 from typing import List, Optional, Union
 
 import diffusers
+import PIL.Image
 import torch
 from diffusers import AutoencoderKLWan, FlowMatchEulerDiscreteScheduler
 from diffusers.utils.torch_utils import randn_tensor
@@ -17,6 +18,7 @@ from tensorrt_llm._torch.visual_gen.models.wan.defaults import (
     get_wan_default_params,
     get_wan_extra_param_specs,
 )
+from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan_utils import retrieve_latents
 from tensorrt_llm._torch.visual_gen.output import MediaOutput
 from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
 from tensorrt_llm._torch.visual_gen.pipeline_registry import register_pipeline
@@ -26,10 +28,11 @@ from tensorrt_llm.logger import logger
 
 from .transformer_wan import WanTransformer3DModel
 
-# Supported Wan T2V models:
+# Supported Wan models:
 # - Wan2.1-T2V-14B: Single-stage text-to-video (14B parameters)
 # - Wan2.1-T2V-1.3B: Single-stage text-to-video (1.3B parameters)
 # - Wan2.2-T2V-A14B: Two-stage text-to-video (14B, boundary_ratio for high/low-noise stages; supports 480P & 720P)
+# - Wan2.2-TI2V-5B: Single-stage, text-to-video and image-to-video (5B; supports 480P & 720P)
 
 WAN_TEACACHE_COEFFICIENTS = {
     "1.3B": {
@@ -79,13 +82,16 @@ WAN_DEFAULT_NEGATIVE_PROMPT = (
 @register_pipeline("WanPipeline")
 class WanPipeline(BasePipeline):
     def __init__(self, model_config):
-        # Wan2.2 two-stage denoising parameters
+        # Wan2.2 A14B two-stage denoising parameters
         self.transformer_2 = None
         self.boundary_ratio = getattr(model_config.pretrained_config, "boundary_ratio", None)
-        self.is_wan22 = self.boundary_ratio is not None
+        self.expand_timesteps = getattr(model_config.pretrained_config, "expand_timesteps", False)
+        # Derived model type flags
+        self.is_wan22_14b = self.boundary_ratio is not None
+        self.is_wan22_5b = self.expand_timesteps
 
         # Validate TeaCache compatibility before allocating GPU memory
-        if self.is_wan22 and model_config.cache_backend == "teacache":
+        if self.is_wan22_14b and model_config.cache_backend == "teacache":
             raise ValueError(
                 "TeaCache is not supported for Wan 2.2 T2V models. "
                 "Use cache_backend='none' or 'cache_dit' (not 'teacache')."
@@ -133,6 +139,9 @@ class WanPipeline(BasePipeline):
 
     @property
     def default_warmup_resolutions(self):
+        if self.is_wan22_5b:
+            # The 720p resolution of Wan2.2 TI2V 5B model is 704x1280
+            return [(480, 832), (704, 1280)]
         return [(480, 832), (720, 1280)]
 
     @property
@@ -141,7 +150,7 @@ class WanPipeline(BasePipeline):
 
     @property
     def default_warmup_steps(self):
-        return 4 if self.is_wan22 else 2
+        return 4 if self.is_wan22_14b else 2
 
     @property
     def resolution_multiple_of(self):
@@ -159,9 +168,9 @@ class WanPipeline(BasePipeline):
         logger.info("Creating WAN transformer with quantization support...")
         self.transformer = WanTransformer3DModel(model_config=self.model_config)
 
-        # Wan2.2: create second transformer for two-stage denoising
-        if self.boundary_ratio is not None:
-            logger.info("Creating second transformer for Wan2.2 two-stage denoising...")
+        # Wan2.2 A14B: create second transformer for two-stage denoising
+        if self.is_wan22_14b:
+            logger.info("Creating second transformer for Wan2.2 A14B two-stage denoising...")
             self.transformer_2 = WanTransformer3DModel(model_config=self.model_config)
 
     def load_standard_components(
@@ -180,8 +189,10 @@ class WanPipeline(BasePipeline):
             )
 
         # Detect model version
-        if self.is_wan22:
-            logger.info("Detected Wan 2.2 T2V (two-stage denoising)")
+        if self.is_wan22_14b:
+            logger.info("Detected Wan 2.2 A14B T2V (two-stage denoising)")
+        elif self.is_wan22_5b:
+            logger.info("Detected Wan 2.2 5B TI2V (single-stage denoising)")
         else:
             logger.info("Detected Wan 2.1 T2V (single-stage denoising)")
 
@@ -247,12 +258,12 @@ class WanPipeline(BasePipeline):
             self.transformer.load_weights(transformer_weights)
             logger.info("Transformer weights loaded successfully.")
 
-        # Wan2.2: Load weights for second transformer if it exists
+        # Wan2.2 A14B: Load weights for second transformer if it exists
         if self.transformer_2 is not None and hasattr(self.transformer_2, "load_weights"):
-            logger.info("Loading transformer_2 weights for Wan2.2...")
+            logger.info("Loading transformer_2 weights for Wan2.2 A14B...")
             if not has_separate_weights:
                 raise ValueError(
-                    "Wan2.2 model requires separate 'transformer' and 'transformer_2' weights in checkpoint, "
+                    "Wan2.2 A14B model requires separate 'transformer' and 'transformer_2' weights in checkpoint, "
                     f"but only found: {list(weights.keys())}. "
                     "Two-stage denoising requires distinct weights for high-noise and low-noise transformers."
                 )
@@ -282,7 +293,7 @@ class WanPipeline(BasePipeline):
                     )
                 )
 
-            if not self.is_wan22:
+            if not self.is_wan22_14b:
                 self._setup_cache_acceleration(
                     self.transformer, coefficients=WAN_TEACACHE_COEFFICIENTS
                 )
@@ -314,18 +325,24 @@ class WanPipeline(BasePipeline):
     @property
     def default_generation_params(self):
         return get_wan_default_params(
-            is_wan22=self.is_wan22,
+            is_wan22=self.is_wan22_14b,
             name_or_path=getattr(self.config, "_name_or_path", ""),
             num_heads=getattr(self.config, "num_attention_heads", 40),
+            is_wan22_5b=self.is_wan22_5b,
         )
 
     @property
     def extra_param_specs(self):
-        return get_wan_extra_param_specs(self.is_wan22)
+        return get_wan_extra_param_specs(self.is_wan22_14b)
 
     def infer(self, req):
         """Run inference with request parameters."""
         extra = req.params.extra_params or {}
+        # Wan 2.2 TI2V-5B takes one conditioning image if provided
+        image = req.params.image
+        if isinstance(image, list):
+            raise ValueError(f"WanPipeline I2V expects a single image, got list of {len(image)}.")
+
         return self.forward(
             prompt=req.prompt,
             negative_prompt=req.params.negative_prompt,
@@ -338,6 +355,7 @@ class WanPipeline(BasePipeline):
             boundary_ratio=extra.get("boundary_ratio"),
             seed=req.params.seed,
             max_sequence_length=req.params.max_sequence_length,
+            image=image,
         )
 
     @nvtx_range("WanPipeline.forward")
@@ -355,8 +373,17 @@ class WanPipeline(BasePipeline):
         boundary_ratio: Optional[float] = None,
         seed: int = 42,
         max_sequence_length: int = 512,
+        image: Optional[Union[PIL.Image.Image, torch.Tensor, str]] = None,
     ):
         pipeline_start = time.time()
+
+        # I2V is only supported on Wan 2.2 TI2V-5B here. Wan 2.1 I2V and Wan 2.2 A14B I2V use WanImageToVideoPipeline
+        is_i2v = image is not None
+        if is_i2v and not self.is_wan22_5b:
+            raise ValueError(
+                "WanPipeline only supports image conditioning for Wan 2.2 TI2V-5B. "
+                "For Wan 2.1 I2V or Wan 2.2 A14B I2V, use WanImageToVideoPipeline."
+            )
 
         # Determine batch size
         if isinstance(prompt, str):
@@ -370,10 +397,10 @@ class WanPipeline(BasePipeline):
         # Use user-provided boundary_ratio if given, otherwise fall back to model config
         boundary_ratio = boundary_ratio if boundary_ratio is not None else self.boundary_ratio
 
-        # Validate that Wan 2.2 models have boundary_ratio set
+        # Validate that Wan 2.2 A14B models have boundary_ratio set
         if self.transformer_2 is not None and boundary_ratio is None:
             raise ValueError(
-                "Wan 2.2 models require boundary_ratio to be set. "
+                "Wan 2.2 A14B models require boundary_ratio to be set. "
                 "boundary_ratio was not found in model config. "
                 "Please pass boundary_ratio as a parameter."
             )
@@ -383,18 +410,25 @@ class WanPipeline(BasePipeline):
             negative_prompt = WAN_DEFAULT_NEGATIVE_PROMPT
 
         # Set model-specific defaults based on Wan version
+        mode_str = "I2V" if is_i2v else "T2V"
+        if self.is_wan22_14b:
+            logger.info(f"Detected Wan 2.2 A14B {mode_str} (two-stage denoising)")
+        elif self.is_wan22_5b:
+            logger.info(f"Detected Wan 2.2 5B {mode_str} (single-stage denoising)")
+        else:
+            logger.info(f"Detected Wan 2.1 {mode_str} (single-stage denoising)")
         logger.info(
-            f"Running {'Wan 2.2' if self.is_wan22 else 'Wan 2.1'} T2V inference"
+            f"Running {mode_str} inference "
             f"(boundary_ratio={boundary_ratio}, has_transformer_2={self.transformer_2 is not None})"
         )
 
         if num_inference_steps is None:
-            num_inference_steps = 40 if self.is_wan22 else 50
+            num_inference_steps = 40 if self.is_wan22_14b or self.is_wan22_5b else 50
 
         if guidance_scale is None:
-            guidance_scale = 4.0 if self.is_wan22 else 5.0
+            guidance_scale = 4.0 if self.is_wan22_14b else 5.0  # 5B and Wan 2.1 both use 5.0
 
-        if self.is_wan22 and guidance_scale_2 is None:
+        if self.is_wan22_14b and guidance_scale_2 is None:
             guidance_scale_2 = guidance_scale  # Match HF: default to guidance_scale when unset
 
         # Validate two-stage denoising configuration
@@ -414,18 +448,26 @@ class WanPipeline(BasePipeline):
         )
         logger.info(f"Prompt encoding completed in {time.time() - encode_start:.2f}s")
 
-        # Prepare Latents
-        latents = self._prepare_latents(batch_size, height, width, num_frames, generator)
+        # Prepare Latents. T2V = pure noise. 5B I2V also produces an image-conditioned latent
+        # plus a first-frame mask used for blending + mask-aware timestep expansion.
+        i2v_condition = None
+        i2v_first_frame_mask = None
+        if is_i2v:
+            latents, i2v_condition, i2v_first_frame_mask = self._prepare_latents_wan22_5B_i2v(
+                batch_size, image, height, width, num_frames, generator
+            )
+        else:
+            latents = self._prepare_latents(batch_size, height, width, num_frames, generator)
         logger.debug(f"Latents shape: {latents.shape}")
 
         self.scheduler.set_timesteps(num_inference_steps, device=self.device)
 
-        # Wan2.2: Calculate boundary timestep for two-stage denoising
+        # Wan2.2 A14B: Calculate boundary timestep for two-stage denoising
         boundary_timestep = None
         if boundary_ratio is not None and self.transformer_2 is not None:
             boundary_timestep = boundary_ratio * self.scheduler.config.num_train_timesteps
             logger.info(
-                f"Wan2.2 two-stage denoising: boundary_timestep={boundary_timestep:.1f}, "
+                f"Wan2.2 A14B two-stage denoising: boundary_timestep={boundary_timestep:.1f}, "
                 f"guidance_scale={guidance_scale}, guidance_scale_2={guidance_scale_2}"
             )
 
@@ -440,18 +482,16 @@ class WanPipeline(BasePipeline):
 
             extra_stream_latents and extra_tensors are unused for WAN (single stream, no additional embeddings).
             """
-            # Select model based on timestep (if two-stage denoising is enabled)
+            current_t = timestep if timestep.dim() == 0 else timestep[0]
+
+            # Select model based on timestep (two-stage denoising for Wan 2.2 A14B)
             if boundary_timestep is not None and self.transformer_2 is not None:
-                # Extract scalar timestep for comparison
-                current_t = timestep if timestep.dim() == 0 else timestep[0]
                 if current_t >= boundary_timestep:
                     current_model = self.transformer
                     model_name = "transformer (high-noise)"
                 else:
                     current_model = self.transformer_2
                     model_name = "transformer_2 (low-noise)"
-
-                # Log when switching models
                 if last_model_used[0] != model_name:
                     if self.rank == 0:
                         logger.info(f"Switched to {model_name} at timestep {current_t:.1f}")
@@ -459,11 +499,40 @@ class WanPipeline(BasePipeline):
             else:
                 current_model = self.transformer
 
+            # Build per-patch 2D timestep for Wan 2.2 TI2V-5B
+            if self.is_wan22_5b:
+                _, ph, pw = self.transformer.config.patch_size
+                if is_i2v:
+                    # I2V: frame-0 patches get timestep 0, remaining patches get current_t
+                    patch_ts = i2v_first_frame_mask[0, 0, :, ::ph, ::pw] * current_t
+                else:
+                    # T2V: all patches get current_t
+                    patch_ts = (
+                        torch.ones(
+                            latents.shape[2],
+                            latents.shape[3] // ph,
+                            latents.shape[4] // pw,
+                            device=latents.device,
+                            dtype=torch.float32,
+                        )
+                        * current_t
+                    )
+                timestep = patch_ts.flatten().unsqueeze(0).expand(latents.shape[0], -1)
+
             return current_model(
                 hidden_states=latents,
                 timestep=timestep,
                 encoder_hidden_states=encoder_hidden_states,
             )
+
+        # Pin reference image to latent after each scheduler step (Wan 2.2 5B I2V only)
+        post_step_fn = None
+        if self.is_wan22_5b and is_i2v:
+
+            def post_step_fn(x):
+                return ((1 - i2v_first_frame_mask) * i2v_condition + i2v_first_frame_mask * x).to(
+                    self.dtype
+                )
 
         # Two-stage denoising: model switching in forward_fn, guidance scale switching in denoise()
         latents = self.denoise(
@@ -475,6 +544,7 @@ class WanPipeline(BasePipeline):
             forward_fn=forward_fn,
             guidance_scale_2=guidance_scale_2,
             boundary_timestep=boundary_timestep,
+            post_step_fn=post_step_fn,
         )
 
         # Decode
@@ -549,7 +619,7 @@ class WanPipeline(BasePipeline):
         generator: torch.Generator,
     ) -> torch.Tensor:
         """Prepare random latents for video generation."""
-        num_channels_latents = 16
+        num_channels_latents = getattr(self.transformer.config, "in_channels", 16)
         num_latent_frames = (num_frames - 1) // self.vae_scale_factor_temporal + 1
 
         shape = (
@@ -561,6 +631,72 @@ class WanPipeline(BasePipeline):
         )
 
         return randn_tensor(shape, generator=generator, device=self.device, dtype=self.dtype)
+
+    @nvtx_range("_prepare_latents_wan22_5B_i2v", color="blue")
+    def _prepare_latents_wan22_5B_i2v(
+        self,
+        batch_size: int,
+        image: Union[PIL.Image.Image, torch.Tensor, str],
+        height: int,
+        width: int,
+        num_frames: int,
+        generator: torch.Generator,
+    ):
+        """Prepare latents with first-frame image conditioning for Wan 2.2 TI2V-5B.
+
+        Returns (latents, latent_condition, first_frame_mask). The 5B model blends the
+        image into the first frame in-channel (no mask channel concat) and uses a
+        mask-aware timestep during denoising.
+        """
+        num_latent_frames = (num_frames - 1) // self.vae_scale_factor_temporal + 1
+        latent_height = height // self.vae_scale_factor_spatial
+        latent_width = width // self.vae_scale_factor_spatial
+
+        num_channels_latents = getattr(self.transformer.config, "in_channels", 16)
+        shape = (batch_size, num_channels_latents, num_latent_frames, latent_height, latent_width)
+        latents = randn_tensor(shape, generator=generator, device=self.device, dtype=self.dtype)
+
+        # Load and preprocess image
+        if isinstance(image, str):
+            image = PIL.Image.open(image).convert("RGB")
+        image = (
+            self.video_processor.preprocess(image, height=height, width=width)
+            .to(self.device, dtype=self.vae.dtype)
+            .unsqueeze(2)
+        )
+
+        # Encode video condition through VAE
+        latent_condition = retrieve_latents(self.vae.encode(image), sample_mode="argmax").to(
+            self.dtype
+        )
+
+        # Normalize latents to match diffusion model's latent space
+        latents_mean = (
+            torch.tensor(self.vae.config.latents_mean)
+            .view(1, self.vae.config.z_dim, 1, 1, 1)
+            .to(latents.device, latents.dtype)
+        )
+        latents_std = 1.0 / torch.tensor(self.vae.config.latents_std).view(
+            1, self.vae.config.z_dim, 1, 1, 1
+        ).to(latents.device, latents.dtype)
+        latent_condition = (latent_condition - latents_mean) * latents_std
+
+        # Create first-frame mask
+        first_frame_mask = torch.ones(
+            1,
+            1,
+            num_latent_frames,
+            latent_height,
+            latent_width,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        first_frame_mask[:, :, 0] = 0
+
+        # Blend latent condition into latents
+        latents = (1 - first_frame_mask) * latent_condition + first_frame_mask * latents
+
+        return latents, latent_condition, first_frame_mask
 
     @nvtx_range("_decode_latents", color="blue")
     def _decode_latents(self, latents: torch.Tensor) -> torch.Tensor:

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -325,10 +325,10 @@ class WanPipeline(BasePipeline):
     @property
     def default_generation_params(self):
         return get_wan_default_params(
-            is_wan22=self.is_wan22_14b,
+            is_wan22_14b=self.is_wan22_14b,
+            is_wan22_5b=self.is_wan22_5b,
             name_or_path=getattr(self.config, "_name_or_path", ""),
             num_heads=getattr(self.config, "num_attention_heads", 40),
-            is_wan22_5b=self.is_wan22_5b,
         )
 
     @property
@@ -422,12 +422,6 @@ class WanPipeline(BasePipeline):
             f"(boundary_ratio={boundary_ratio}, has_transformer_2={self.transformer_2 is not None})"
         )
 
-        if num_inference_steps is None:
-            num_inference_steps = 40 if self.is_wan22_14b or self.is_wan22_5b else 50
-
-        if guidance_scale is None:
-            guidance_scale = 4.0 if self.is_wan22_14b else 5.0  # 5B and Wan 2.1 both use 5.0
-
         if self.is_wan22_14b and guidance_scale_2 is None:
             guidance_scale_2 = guidance_scale  # Match HF: default to guidance_scale when unset
 
@@ -448,8 +442,7 @@ class WanPipeline(BasePipeline):
         )
         logger.info(f"Prompt encoding completed in {time.time() - encode_start:.2f}s")
 
-        # Prepare Latents. T2V = pure noise. 5B I2V also produces an image-conditioned latent
-        # plus a first-frame mask used for blending + mask-aware timestep expansion.
+        # Prepare Latents. Pure noise for T2V. Image-conditioned latent for Wan 2.25B I2V
         i2v_condition = None
         i2v_first_frame_mask = None
         if is_i2v:
@@ -482,9 +475,11 @@ class WanPipeline(BasePipeline):
 
             extra_stream_latents and extra_tensors are unused for WAN (single stream, no additional embeddings).
             """
+
+            # Extract scalar timestep
             current_t = timestep if timestep.dim() == 0 else timestep[0]
 
-            # Select model based on timestep (two-stage denoising for Wan 2.2 A14B)
+            # Select model based on timestep (if two-stage denoising is enabled)
             if boundary_timestep is not None and self.transformer_2 is not None:
                 if current_t >= boundary_timestep:
                     current_model = self.transformer
@@ -492,6 +487,8 @@ class WanPipeline(BasePipeline):
                 else:
                     current_model = self.transformer_2
                     model_name = "transformer_2 (low-noise)"
+
+                # Log when switching models
                 if last_model_used[0] != model_name:
                     if self.rank == 0:
                         logger.info(f"Switched to {model_name} at timestep {current_t:.1f}")
@@ -502,22 +499,16 @@ class WanPipeline(BasePipeline):
             # Build per-patch 2D timestep for Wan 2.2 TI2V-5B
             if self.is_wan22_5b:
                 _, ph, pw = self.transformer.config.patch_size
+                nf = latents.shape[2]
+                nh = latents.shape[3] // ph
+                nw = latents.shape[4] // pw
                 if is_i2v:
-                    # I2V: frame-0 patches get timestep 0, remaining patches get current_t
+                    # I2V: timestep 0 for reference image, current_t for noisy frames
                     patch_ts = i2v_first_frame_mask[0, 0, :, ::ph, ::pw] * current_t
+                    timestep = patch_ts.flatten().unsqueeze(0).expand(latents.shape[0], -1)
                 else:
-                    # T2V: all patches get current_t
-                    patch_ts = (
-                        torch.ones(
-                            latents.shape[2],
-                            latents.shape[3] // ph,
-                            latents.shape[4] // pw,
-                            device=latents.device,
-                            dtype=torch.float32,
-                        )
-                        * current_t
-                    )
-                timestep = patch_ts.flatten().unsqueeze(0).expand(latents.shape[0], -1)
+                    # T2V: current_t for all frames
+                    timestep = current_t.reshape(1, 1).expand(latents.shape[0], nf * nh * nw)
 
             return current_model(
                 hidden_states=latents,

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -20,6 +20,7 @@ from tensorrt_llm._torch.visual_gen.models.wan.defaults import (
     get_wan_default_params,
     get_wan_extra_param_specs,
 )
+from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan_utils import retrieve_latents
 from tensorrt_llm._torch.visual_gen.output import MediaOutput
 from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline, ExtraParamSchema
 from tensorrt_llm._torch.visual_gen.pipeline_registry import register_pipeline
@@ -76,25 +77,6 @@ WAN_DEFAULT_NEGATIVE_PROMPT = (
     "incomplete, extra fingers, poorly drawn hands, poorly drawn face, deformed, disfigured, malformed limbs, "
     "fused fingers, motionless image, cluttered background, three legs, many people in the background, walking backward"
 )
-
-
-def retrieve_latents(
-    encoder_output: torch.Tensor,
-    generator: Optional[torch.Generator] = None,
-    sample_mode: str = "argmax",
-):
-    """Extract latents from VAE encoder output.
-
-    For I2V, we use argmax mode to get deterministic encoding of the input image.
-    """
-    if hasattr(encoder_output, "latent_dist") and sample_mode == "sample":
-        return encoder_output.latent_dist.sample(generator)
-    elif hasattr(encoder_output, "latent_dist") and sample_mode == "argmax":
-        return encoder_output.latent_dist.mode()
-    elif hasattr(encoder_output, "latents"):
-        return encoder_output.latents
-    else:
-        raise AttributeError("Could not access latents of provided encoder_output")
 
 
 @register_pipeline("WanImageToVideoPipeline")

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -454,6 +454,13 @@ class WanImageToVideoPipeline(BasePipeline):
         if negative_prompt is None:
             negative_prompt = WAN_DEFAULT_NEGATIVE_PROMPT
 
+        # Set model-specific defaults if not provided
+        defaults = self.default_generation_params
+        if num_inference_steps is None:
+            num_inference_steps = defaults["num_inference_steps"]
+        if guidance_scale is None:
+            guidance_scale = defaults["guidance_scale"]
+
         if self.is_wan22_14b and guidance_scale_2 is None:
             guidance_scale_2 = guidance_scale  # Match HF: default to guidance_scale when unset
 

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_i2v.py
@@ -85,10 +85,10 @@ class WanImageToVideoPipeline(BasePipeline):
         # Wan2.2 14B two-stage denoising parameters
         self.transformer_2 = None
         self.boundary_ratio = getattr(model_config.pretrained_config, "boundary_ratio", None)
-        self.is_wan22 = self.boundary_ratio is not None
+        self.is_wan22_14b = self.boundary_ratio is not None
 
         # Validate TeaCache compatibility before allocating GPU memory
-        if self.is_wan22 and model_config.cache_backend == "teacache":
+        if self.is_wan22_14b and model_config.cache_backend == "teacache":
             raise ValueError(
                 "TeaCache is not supported for Wan 2.2 models. "
                 "Use cache_backend='none' or 'cache_dit' (not 'teacache')."
@@ -143,7 +143,7 @@ class WanImageToVideoPipeline(BasePipeline):
 
     @property
     def default_warmup_steps(self):
-        return 4 if self.is_wan22 else 2
+        return 4 if self.is_wan22_14b else 2
 
     @property
     def resolution_multiple_of(self):
@@ -250,12 +250,12 @@ class WanImageToVideoPipeline(BasePipeline):
 
         # Load image encoder and processor (only for Wan 2.1)
         # Wan 2.2: Has both transformer_2 and boundary_ratio (two-stage denoising)
-        if self.is_wan22:
+        if self.is_wan22_14b:
             logger.info("Detected Wan 2.2 I2V (two-stage, no CLIP)")
         else:
             logger.info("Detected Wan 2.1 I2V (single-stage, uses CLIP)")
 
-        if PipelineComponent.IMAGE_ENCODER not in skip_components and not self.is_wan22:
+        if PipelineComponent.IMAGE_ENCODER not in skip_components and not self.is_wan22_14b:
             logger.info("Loading CLIP image encoder for I2V conditioning (Wan 2.1 only)...")
             self.image_encoder = CLIPVisionModel.from_pretrained(
                 checkpoint_dir,
@@ -263,7 +263,7 @@ class WanImageToVideoPipeline(BasePipeline):
                 torch_dtype=torch.float32,  # Keep CLIP in FP32 for stability
             ).to(device)
 
-        if PipelineComponent.IMAGE_PROCESSOR not in skip_components and not self.is_wan22:
+        if PipelineComponent.IMAGE_PROCESSOR not in skip_components and not self.is_wan22_14b:
             logger.info("Loading CLIP image processor...")
             self.image_processor = CLIPImageProcessor.from_pretrained(
                 checkpoint_dir,
@@ -323,7 +323,7 @@ class WanImageToVideoPipeline(BasePipeline):
                     )
                 )
 
-            if not self.is_wan22:
+            if not self.is_wan22_14b:
                 self._setup_cache_acceleration(
                     self.transformer, coefficients=WAN_I2V_TEACACHE_COEFFICIENTS
                 )
@@ -356,7 +356,7 @@ class WanImageToVideoPipeline(BasePipeline):
     @property
     def default_generation_params(self):
         return get_wan_default_params(
-            is_wan22=self.is_wan22,
+            is_wan22_14b=self.is_wan22_14b,
             name_or_path=getattr(self.config, "_name_or_path", ""),
             num_heads=getattr(self.config, "num_attention_heads", 40),
             include_i2v=True,
@@ -364,7 +364,7 @@ class WanImageToVideoPipeline(BasePipeline):
 
     @property
     def extra_param_specs(self):
-        specs = get_wan_extra_param_specs(self.is_wan22)
+        specs = get_wan_extra_param_specs(self.is_wan22_14b)
         specs["last_image"] = ExtraParamSchema(
             type="str",
             default=None,
@@ -454,14 +454,7 @@ class WanImageToVideoPipeline(BasePipeline):
         if negative_prompt is None:
             negative_prompt = WAN_DEFAULT_NEGATIVE_PROMPT
 
-        # Set model-specific defaults based on Wan version
-        if num_inference_steps is None:
-            num_inference_steps = 40 if self.is_wan22 else 50
-
-        if guidance_scale is None:
-            guidance_scale = 4.0 if self.is_wan22 else 5.0
-
-        if self.is_wan22 and guidance_scale_2 is None:
+        if self.is_wan22_14b and guidance_scale_2 is None:
             guidance_scale_2 = guidance_scale  # Match HF: default to guidance_scale when unset
 
         # Validate two-stage denoising configuration
@@ -498,13 +491,13 @@ class WanImageToVideoPipeline(BasePipeline):
         image_encode_start = time.time()
 
         # Determine model version
-        model_version = "Wan 2.2" if self.is_wan22 else "Wan 2.1"
+        model_version = "Wan 2.2" if self.is_wan22_14b else "Wan 2.1"
         logger.info(
             f"Running {model_version} I2V inference "
             f"(boundary_ratio={boundary_ratio}, has_transformer_2={self.transformer_2 is not None})"
         )
 
-        if not self.is_wan22:
+        if not self.is_wan22_14b:
             # Wan 2.1 I2V: Compute CLIP image embeddings
             image_embeds = self._encode_image(image, last_image)
             image_embeds = image_embeds.to(self.dtype)

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_utils.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_utils.py
@@ -1,0 +1,17 @@
+from typing import Any, Optional
+
+import torch
+
+
+def retrieve_latents(
+    encoder_output: Any,
+    generator: Optional[torch.Generator] = None,
+    sample_mode: str = "argmax",
+):
+    if hasattr(encoder_output, "latent_dist") and sample_mode == "sample":
+        return encoder_output.latent_dist.sample(generator)
+    if hasattr(encoder_output, "latent_dist") and sample_mode == "argmax":
+        return encoder_output.latent_dist.mode()
+    if hasattr(encoder_output, "latents"):
+        return encoder_output.latents
+    raise AttributeError("Could not access latents of provided encoder_output")

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_utils.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_utils.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from typing import Any, Optional
 
 import torch

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_utils.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan_utils.py
@@ -7,7 +7,7 @@ def retrieve_latents(
     encoder_output: Any,
     generator: Optional[torch.Generator] = None,
     sample_mode: str = "argmax",
-):
+) -> torch.Tensor:
     if hasattr(encoder_output, "latent_dist") and sample_mode == "sample":
         return encoder_output.latent_dist.sample(generator)
     if hasattr(encoder_output, "latent_dist") and sample_mode == "argmax":

--- a/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
@@ -200,8 +200,18 @@ class WanTimeTextImageEmbedding(nn.Module):
                 image_embed_dim, dim, pos_embed_seq_len=pos_embed_seq_len, model_config=model_config
             )
 
-    def forward(self, timestep, encoder_hidden_states, encoder_hidden_states_image=None):
+    def forward(
+        self,
+        timestep,
+        encoder_hidden_states,
+        encoder_hidden_states_image=None,
+        timestep_seq_len=None,
+    ):
         timestep = self.timesteps_proj(timestep)
+
+        # Unflatten timestep if seq_len is provided
+        if timestep_seq_len is not None:
+            timestep = timestep.unflatten(0, (-1, timestep_seq_len))
 
         # Get time_embedder dtype
         time_embedder_dtype = next(iter(self.time_embedder.parameters())).dtype
@@ -352,9 +362,23 @@ class WanBlock(nn.Module):
         freqs_cos,
         freqs_sin,
     ):
-        shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
-            self.scale_shift_table.float() + temb.float()
-        ).chunk(6, dim=1)
+        if temb.ndim == 4:
+            # temb: batch_size, seq_len, 6, hidden_size
+            shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
+                self.scale_shift_table.unsqueeze(0).float() + temb.float()
+            ).chunk(6, dim=2)
+            # batch_size, seq_len, 1, hidden_size -> batch_size, seq_len, hidden_size
+            shift_msa = shift_msa.squeeze(2)
+            scale_msa = scale_msa.squeeze(2)
+            gate_msa = gate_msa.squeeze(2)
+            c_shift_msa = c_shift_msa.squeeze(2)
+            c_scale_msa = c_scale_msa.squeeze(2)
+            c_gate_msa = c_gate_msa.squeeze(2)
+        else:
+            # temb: batch_size, 6, hidden_size
+            shift_msa, scale_msa, gate_msa, c_shift_msa, c_scale_msa, c_gate_msa = (
+                self.scale_shift_table.float() + temb.float()
+            ).chunk(6, dim=1)
 
         normed = self.norm1(x.float()) * (1 + scale_msa) + shift_msa
         normed = normed.to(x.dtype)
@@ -666,10 +690,28 @@ class WanTransformer3DModel(nn.Module):
                 ]
 
         # Time and text/image embeddings
+        # Timestep shape: [batch_size] or [batch_size, seq_len]
+        if timestep.ndim == 2:
+            ts_seq_len = timestep.shape[1]
+            timestep = timestep.flatten()
+        else:
+            ts_seq_len = None
+
         temb, temb_proj, encoder_hidden_states, encoder_hidden_states_image = (
-            self.condition_embedder(timestep, encoder_hidden_states, encoder_hidden_states_image)
+            self.condition_embedder(
+                timestep,
+                encoder_hidden_states,
+                encoder_hidden_states_image,
+                timestep_seq_len=ts_seq_len,
+            )
         )
-        temb_proj = temb_proj.view(-1, 6, self.config.hidden_size)
+        # Reshape temb_proj based on whether timesteps were expanded
+        if ts_seq_len is not None:
+            # batch_size, seq_len, 6, hidden_size
+            temb_proj = temb_proj.unflatten(2, (6, self.config.hidden_size))
+        else:
+            # batch_size, 6, hidden_size
+            temb_proj = temb_proj.unflatten(1, (6, self.config.hidden_size))
 
         # I2V: Concatenate image and text embeddings if image embeddings are provided
         if encoder_hidden_states_image is not None:
@@ -704,7 +746,14 @@ class WanTransformer3DModel(nn.Module):
             x = torch.cat(x_list, dim=1)
 
         # Output projection and unpatchify
-        shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
+        if temb.ndim == 3:
+            # batch_size, seq_len, hidden_size
+            shift, scale = (self.scale_shift_table.unsqueeze(0) + temb.unsqueeze(2)).chunk(2, dim=2)
+            shift = shift.squeeze(2)
+            scale = scale.squeeze(2)
+        else:
+            # batch_size, hidden_size
+            shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
         x = self.norm_out(x) * (1 + scale) + shift
         x = x.to(hidden_states.dtype)
 

--- a/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
@@ -661,6 +661,7 @@ class WanTransformer3DModel(nn.Module):
         x = self.patch_embedding(hidden_states).flatten(2).transpose(1, 2)
 
         # Shard sequence across ranks: [B, S] -> [B, S/P]
+        chunk_size = None
         if self.use_seq_parallel:
             seq_len = x.shape[1]
             if seq_len % self.seq_parallel_size != 0:
@@ -671,23 +672,15 @@ class WanTransformer3DModel(nn.Module):
                 )
 
             chunk_size = seq_len // self.seq_parallel_size
-            x = x[
-                :,
-                self.seq_parallel_rank * chunk_size : (self.seq_parallel_rank + 1) * chunk_size,
-                :,
-            ]
+            chunk_start = self.seq_parallel_rank * chunk_size
+            chunk_end = chunk_start + chunk_size
+            x = x[:, chunk_start:chunk_end, :]
 
             # Shard RoPE frequencies to match sequence sharding
             # RoPE freqs shape: [B, S, ...], so shard along dim 1 (sequence dimension)
             if freqs_cos is not None and freqs_sin is not None:
-                freqs_cos = freqs_cos[
-                    :,
-                    self.seq_parallel_rank * chunk_size : (self.seq_parallel_rank + 1) * chunk_size,
-                ]
-                freqs_sin = freqs_sin[
-                    :,
-                    self.seq_parallel_rank * chunk_size : (self.seq_parallel_rank + 1) * chunk_size,
-                ]
+                freqs_cos = freqs_cos[:, chunk_start:chunk_end]
+                freqs_sin = freqs_sin[:, chunk_start:chunk_end]
 
         # Time and text/image embeddings
         # Timestep shape: [batch_size] or [batch_size, seq_len]
@@ -709,6 +702,9 @@ class WanTransformer3DModel(nn.Module):
         if ts_seq_len is not None:
             # batch_size, seq_len, 6, hidden_size
             temb_proj = temb_proj.unflatten(2, (6, self.config.hidden_size))
+            # Shard per-patch temb_proj to match the local sequence chunk
+            if chunk_size is not None:
+                temb_proj = temb_proj[:, chunk_start:chunk_end]
         else:
             # batch_size, 6, hidden_size
             temb_proj = temb_proj.unflatten(1, (6, self.config.hidden_size))

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -824,6 +824,7 @@ class BasePipeline(nn.Module):
         extra_streams: Optional[Dict[str, Tuple[torch.Tensor, Any]]] = None,
         guidance_scale_2: Optional[float] = None,
         boundary_timestep: Optional[float] = None,
+        post_step_fn: Optional[Callable] = None,
     ):
         """Execute denoising loop with optional CFG parallel and TeaCache support.
 
@@ -850,6 +851,9 @@ class BasePipeline(nn.Module):
                              to guidance_scale_2 when timestep < boundary_timestep.
             boundary_timestep: Optional timestep boundary for two-stage denoising.
                               Switches guidance scale when crossing this threshold.
+            post_step_fn: Optional callable applied to latents after each scheduler step.
+                         Signature: post_step_fn(latents) -> latents
+                         Use for constraints that must hold throughout denoising.
 
         Returns:
             Single latents if no extra_streams
@@ -938,6 +942,9 @@ class BasePipeline(nn.Module):
                 scheduler,
                 extra_stream_schedulers,
             )
+
+            if post_step_fn is not None:
+                latents = post_step_fn(latents)
 
             # Logging
             if self.rank == 0:

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_params.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_params.py
@@ -19,10 +19,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def _wan_mock(is_wan22=False, name_or_path="", num_heads=12):
+def _wan_mock(is_wan22_14b=False, is_wan22_5b=False, name_or_path="", num_heads=12):
     """Create a mock with attributes needed by WanPipeline/WanI2V properties."""
     mock = MagicMock()
-    mock.is_wan22 = is_wan22
+    mock.is_wan22_14b = is_wan22_14b
+    mock.is_wan22_5b = is_wan22_5b
     config = MagicMock()
     config._name_or_path = name_or_path
     config.num_attention_heads = num_heads
@@ -173,23 +174,39 @@ class TestPipelineDefaults:
         """Wan 2.1 small-model (≤12 heads) returns 480p defaults."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        d = WanPipeline.default_generation_params.fget(_wan_mock(is_wan22=False, num_heads=12))
+        d = WanPipeline.default_generation_params.fget(_wan_mock(num_heads=12))
         assert d["height"] == 480
         assert d["width"] == 832
         assert d["num_inference_steps"] == 50
         assert d["guidance_scale"] == 5.0
         assert d["num_frames"] == 81
 
-    def test_wan22_defaults(self):
-        """Wan 2.2 returns 720p defaults."""
+    def test_wan22_14b_defaults(self):
+        """Wan 2.2 A14B returns 720p defaults."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        d = WanPipeline.default_generation_params.fget(_wan_mock(is_wan22=True, num_heads=40))
+        d = WanPipeline.default_generation_params.fget(
+            _wan_mock(is_wan22_14b=True, is_wan22_5b=False, num_heads=40)
+        )
         assert d["height"] == 720
         assert d["width"] == 1280
         assert d["num_inference_steps"] == 40
         assert d["guidance_scale"] == 4.0
         assert d["num_frames"] == 81
+
+    def test_wan22_5b_defaults(self):
+        """Wan 2.2 TI2V-5B returns native 720p defaults."""
+        from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
+
+        d = WanPipeline.default_generation_params.fget(
+            _wan_mock(is_wan22_14b=False, is_wan22_5b=True, num_heads=24)
+        )
+        assert d["height"] == 704
+        assert d["width"] == 1280
+        assert d["num_inference_steps"] == 50
+        assert d["guidance_scale"] == 5.0
+        assert d["num_frames"] == 121
+        assert d["frame_rate"] == 24.0
 
     def test_flux_defaults(self):
         from tensorrt_llm._torch.visual_gen.models.flux.pipeline_flux import FluxPipeline
@@ -221,10 +238,12 @@ class TestPipelineExtraParamSpecs:
     """Each pipeline declares correct extra param specs."""
 
     def test_wan22_extra_specs(self):
-        """Wan 2.2 exposes guidance_scale_2 and boundary_ratio."""
+        """Wan 2.2 A14B exposes guidance_scale_2 and boundary_ratio."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        specs = WanPipeline.extra_param_specs.fget(_wan_mock(is_wan22=True))
+        specs = WanPipeline.extra_param_specs.fget(
+            _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
+        )
         assert "guidance_scale_2" in specs
         assert "boundary_ratio" in specs
         assert specs["guidance_scale_2"].type == "float"
@@ -234,7 +253,16 @@ class TestPipelineExtraParamSpecs:
         """Wan 2.1 has no model-specific extra params."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        specs = WanPipeline.extra_param_specs.fget(_wan_mock(is_wan22=False))
+        specs = WanPipeline.extra_param_specs.fget(_wan_mock())
+        assert specs == {}
+
+    def test_wan22_5b_no_extra_specs(self):
+        """Wan 2.2 TI2V-5B has no model-specific extra params."""
+        from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
+
+        specs = WanPipeline.extra_param_specs.fget(
+            _wan_mock(is_wan22_14b=False, is_wan22_5b=True)
+        )
         assert specs == {}
 
     def test_wan_i2v_extra_specs(self):
@@ -242,7 +270,9 @@ class TestPipelineExtraParamSpecs:
             WanImageToVideoPipeline,
         )
 
-        specs = WanImageToVideoPipeline.extra_param_specs.fget(_wan_mock(is_wan22=True))
+        specs = WanImageToVideoPipeline.extra_param_specs.fget(
+            _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
+        )
         assert "last_image" in specs
         assert "guidance_scale_2" in specs
         assert specs["last_image"].type == "str"
@@ -312,7 +342,7 @@ class TestDefaultMerging:
     def test_universal_defaults_merged(self):
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=False, num_heads=12))
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(num_heads=12))
         req = self._make_request()
         assert req.params.height is None
 
@@ -324,7 +354,7 @@ class TestDefaultMerging:
     def test_user_values_not_overwritten(self):
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=False, num_heads=12))
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(num_heads=12))
         req = self._make_request(height=1080, width=1920)
 
         self._merge(executor, req)
@@ -446,10 +476,12 @@ class TestVisualGenDefaultParams:
         assert "stg_blocks" in params.extra_params
 
     def test_wan22_default_params(self):
-        """Wan 2.2 returns 720p defaults with guidance_scale_2/boundary_ratio."""
+        """Wan 2.2 A14B returns 720p defaults with guidance_scale_2/boundary_ratio."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        vg = self._make_visual_gen(WanPipeline, _wan_mock(is_wan22=True))
+        vg = self._make_visual_gen(
+            WanPipeline, _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
+        )
         params = vg.default_params
         assert params.height == 720
         assert params.width == 1280
@@ -457,11 +489,27 @@ class TestVisualGenDefaultParams:
         assert "guidance_scale_2" in params.extra_params
         assert "boundary_ratio" in params.extra_params
 
+    def test_wan22_5b_default_params(self):
+        """Wan 2.2 TI2V-5B returns 704x1280 defaults with no extra params."""
+        from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
+
+        vg = self._make_visual_gen(
+            WanPipeline, _wan_mock(is_wan22_14b=False, is_wan22_5b=True, num_heads=24)
+        )
+        params = vg.default_params
+        assert params.height == 704
+        assert params.width == 1280
+        assert params.num_inference_steps == 50
+        assert params.guidance_scale == 5.0
+        assert params.num_frames == 121
+        assert params.frame_rate == 24.0
+        assert params.extra_params is None
+
     def test_wan21_default_params(self):
         """Wan 2.1 small-model returns 480p defaults with no extra params."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        vg = self._make_visual_gen(WanPipeline, _wan_mock(is_wan22=False, num_heads=12))
+        vg = self._make_visual_gen(WanPipeline, _wan_mock(num_heads=12))
         params = vg.default_params
         assert params.height == 480
         assert params.width == 832
@@ -574,10 +622,10 @@ class TestPipelineMetadataBridging:
             assert specs[key].description == original[key].description
 
     def test_wan_pipeline_roundtrip(self):
-        """Wan 2.2 pipeline metadata survives the round-trip."""
+        """Wan 2.2 A14B pipeline metadata survives the round-trip."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        mock_self = _wan_mock(is_wan22=True)
+        mock_self = _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
         resp = self._build_ready_response(WanPipeline, mock_self)
         restored = self._roundtrip(resp)
 
@@ -749,7 +797,7 @@ class TestRequestValidation:
         """image is a conditioning input — validated at runtime by infer(), not here."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=False, num_heads=12))
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(num_heads=12))
         req = self._make_request(image="/path/to/img.png")
         # Should not raise — image validation is the pipeline's responsibility
         self._merge_and_validate(executor, req)
@@ -758,7 +806,7 @@ class TestRequestValidation:
         """num_frames is declared by WanPipeline, should not raise."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=False, num_heads=12))
+        executor = self._make_mock_executor(WanPipeline, _wan_mock(num_heads=12))
         req = self._make_request(num_frames=81)
         self._merge_and_validate(executor, req)
 
@@ -769,7 +817,7 @@ class TestRequestValidation:
         )
 
         executor = self._make_mock_executor(
-            WanImageToVideoPipeline, _wan_mock(is_wan22=False, num_heads=12)
+            WanImageToVideoPipeline, _wan_mock(num_heads=12)
         )
         req = self._make_request(image="/path/to/img.png")
         self._merge_and_validate(executor, req)
@@ -835,7 +883,7 @@ class TestRequestValidation:
         from tensorrt_llm.visual_gen import VisualGenParamsError
 
         executor = self._make_mock_executor(
-            WanImageToVideoPipeline, _wan_mock(is_wan22=False, num_heads=12)
+            WanImageToVideoPipeline, _wan_mock(num_heads=12)
         )
         req = self._make_request(
             image="/img.png",
@@ -850,7 +898,9 @@ class TestRequestValidation:
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
         from tensorrt_llm.visual_gen import VisualGenParamsError
 
-        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=True))
+        executor = self._make_mock_executor(
+            WanPipeline, _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
+        )
         # boundary_ratio has range (0.0, 1.0)
         req = self._make_request(extra_params={"boundary_ratio": 2.0})
         with pytest.raises(VisualGenParamsError, match="out of range"):
@@ -860,7 +910,9 @@ class TestRequestValidation:
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
         from tensorrt_llm.visual_gen import VisualGenParamsError
 
-        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=True))
+        executor = self._make_mock_executor(
+            WanPipeline, _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
+        )
         req = self._make_request(extra_params={"boundary_ratio": -0.5})
         with pytest.raises(VisualGenParamsError, match="out of range"):
             self._merge_and_validate(executor, req)
@@ -868,14 +920,18 @@ class TestRequestValidation:
     def test_boundary_value_at_range_edge_ok(self):
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=True))
+        executor = self._make_mock_executor(
+            WanPipeline, _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
+        )
         req = self._make_request(extra_params={"boundary_ratio": 0.0})
         self._merge_and_validate(executor, req)
 
     def test_boundary_value_at_range_max_ok(self):
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=True))
+        executor = self._make_mock_executor(
+            WanPipeline, _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
+        )
         req = self._make_request(extra_params={"boundary_ratio": 1.0})
         self._merge_and_validate(executor, req)
 
@@ -905,7 +961,9 @@ class TestRequestValidation:
         """None values for extra_params with range specs should not fail validation."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        executor = self._make_mock_executor(WanPipeline, _wan_mock(is_wan22=True))
+        executor = self._make_mock_executor(
+            WanPipeline, _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
+        )
         req = self._make_request(extra_params={"boundary_ratio": None})
         self._merge_and_validate(executor, req)
 

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_params.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_params.py
@@ -241,9 +241,7 @@ class TestPipelineExtraParamSpecs:
         """Wan 2.2 A14B exposes guidance_scale_2 and boundary_ratio."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        specs = WanPipeline.extra_param_specs.fget(
-            _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
-        )
+        specs = WanPipeline.extra_param_specs.fget(_wan_mock(is_wan22_14b=True, is_wan22_5b=False))
         assert "guidance_scale_2" in specs
         assert "boundary_ratio" in specs
         assert specs["guidance_scale_2"].type == "float"
@@ -260,9 +258,7 @@ class TestPipelineExtraParamSpecs:
         """Wan 2.2 TI2V-5B has no model-specific extra params."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        specs = WanPipeline.extra_param_specs.fget(
-            _wan_mock(is_wan22_14b=False, is_wan22_5b=True)
-        )
+        specs = WanPipeline.extra_param_specs.fget(_wan_mock(is_wan22_14b=False, is_wan22_5b=True))
         assert specs == {}
 
     def test_wan_i2v_extra_specs(self):
@@ -479,9 +475,7 @@ class TestVisualGenDefaultParams:
         """Wan 2.2 A14B returns 720p defaults with guidance_scale_2/boundary_ratio."""
         from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
 
-        vg = self._make_visual_gen(
-            WanPipeline, _wan_mock(is_wan22_14b=True, is_wan22_5b=False)
-        )
+        vg = self._make_visual_gen(WanPipeline, _wan_mock(is_wan22_14b=True, is_wan22_5b=False))
         params = vg.default_params
         assert params.height == 720
         assert params.width == 1280
@@ -816,9 +810,7 @@ class TestRequestValidation:
             WanImageToVideoPipeline,
         )
 
-        executor = self._make_mock_executor(
-            WanImageToVideoPipeline, _wan_mock(num_heads=12)
-        )
+        executor = self._make_mock_executor(WanImageToVideoPipeline, _wan_mock(num_heads=12))
         req = self._make_request(image="/path/to/img.png")
         self._merge_and_validate(executor, req)
 
@@ -882,9 +874,7 @@ class TestRequestValidation:
         )
         from tensorrt_llm.visual_gen import VisualGenParamsError
 
-        executor = self._make_mock_executor(
-            WanImageToVideoPipeline, _wan_mock(num_heads=12)
-        )
+        executor = self._make_mock_executor(WanImageToVideoPipeline, _wan_mock(num_heads=12))
         req = self._make_request(
             image="/img.png",
             extra_params={"last_image": 123},

--- a/tests/unittest/_torch/visual_gen/test_wan22_ti2v_5b_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_wan22_ti2v_5b_pipeline.py
@@ -1,0 +1,481 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Correctness tests for Wan 2.2 TI2V-5B pipeline against HuggingFace reference.
+
+Tests verify that the TRTLLM WanPipeline produces decoded video with high cosine
+similarity to the HuggingFace diffusers baseline for both T2V and I2V. The threshold is 0.99 for T2V test and 0.98 (not 0.99) for I2V test because
+I2V image conditioning (VAE-encoded image + mask concatenated to the latent)
+accumulates additional bfloat16 error compared to T2V.
+
+Model tested:
+  - Wan2.2-TI2V-5B-Diffusers   (704x1280, 9 frames)
+
+Run:
+    pytest tests/unittest/_torch/visual_gen/test_wan22_ti2v_5b_pipeline.py -v -s
+
+Override checkpoint path:
+    DIFFUSION_MODEL_PATH_WAN22_TI2V_5B=/path/to/wan22_ti2v_5b \\
+        pytest tests/unittest/_torch/visual_gen/test_wan22_ti2v_5b_pipeline.py -v -s
+"""
+
+import importlib
+import os
+
+os.environ["TLLM_DISABLE_MPI"] = "1"
+
+import gc
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import torch.nn.functional as F
+from diffusers import WanImageToVideoPipeline as HFWanImageToVideoPipeline
+from diffusers import WanPipeline as HFWanPipeline
+from PIL import Image
+
+from tensorrt_llm._torch.visual_gen.config import (
+    AttentionConfig,
+    CacheDiTConfig,
+    TorchCompileConfig,
+    VisualGenArgs,
+)
+from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _cleanup_mpi_env():
+    yield
+    os.environ.pop("TLLM_DISABLE_MPI", None)
+
+
+# ============================================================================
+# Path helpers
+# ============================================================================
+
+
+def _llm_models_root() -> str:
+    """Return LLM_MODELS_ROOT path if set in env, assert when it's set but not a valid path."""
+    root = Path("/home/scratch.trt_llm_data_ci/llm-models/")
+    if "LLM_MODELS_ROOT" in os.environ:
+        root = Path(os.environ["LLM_MODELS_ROOT"])
+    if not root.exists():
+        root = Path("/scratch.trt_llm_data/llm-models/")
+    assert root.exists(), (
+        "Set LLM_MODELS_ROOT or ensure /home/scratch.trt_llm_data_ci/llm-models/ is accessible."
+    )
+    return str(root)
+
+
+def _checkpoint(env_var: str, default_name: str) -> str:
+    return os.environ.get(env_var) or os.path.join(_llm_models_root(), default_name)
+
+
+WAN22_TI2V_5B_PATH = _checkpoint(
+    "DIFFUSION_MODEL_PATH_WAN22_TI2V_5B",
+    "Wan2.2-TI2V-5B-Diffusers",
+)
+
+# ============================================================================
+# Test constants
+# ============================================================================
+
+
+PROMPT = "A cat sitting on a sunny windowsill watching birds outside."
+NEGATIVE_PROMPT = ""
+NUM_STEPS = 4
+SEED = 42
+T2V_COS_SIM_THRESHOLD = 0.99
+I2V_COS_SIM_THRESHOLD = 0.98
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_test_image(height: int, width: int) -> Image.Image:
+    """Create a deterministic gradient test image."""
+    img = np.zeros((height, width, 3), dtype=np.uint8)
+    img[:, :, 0] = np.linspace(0, 255, height, dtype=np.uint8)[:, np.newaxis]
+    img[:, :, 1] = np.linspace(0, 255, width, dtype=np.uint8)[np.newaxis, :]
+    img[:, :, 2] = 128
+    return Image.fromarray(img, mode="RGB")
+
+
+def _load_trtllm_pipeline(checkpoint_path: str):
+    """Load TRTLLM WanPipeline without torch.compile or warmup."""
+    if not os.path.exists(checkpoint_path):
+        pytest.skip(f"Checkpoint not found: {checkpoint_path}")
+    args = VisualGenArgs(
+        checkpoint_path=checkpoint_path,
+        device="cuda",
+        dtype="bfloat16",
+        torch_compile=TorchCompileConfig(enable_torch_compile=False),
+    )
+    return PipelineLoader(args).load(skip_warmup=True)
+
+
+def _load_hf_pipeline(checkpoint_path: str, mode: str):
+    """Load HuggingFace diffusers pipeline for Wan2.2 TI2V-5B."""
+    pipeline_cls = HFWanPipeline if mode == "t2v" else HFWanImageToVideoPipeline
+    hf_pipe = pipeline_cls.from_pretrained(
+        checkpoint_path,
+        torch_dtype=torch.bfloat16,
+    )
+    hf_pipe = hf_pipe.to("cuda")
+    hf_pipe.set_progress_bar_config(disable=True)
+    return hf_pipe
+
+
+def _capture_trtllm_video(
+    pipeline,
+    mode: str,
+    prompt: str,
+    negative_prompt: str,
+    height: int,
+    width: int,
+    num_frames: int,
+    num_inference_steps: int,
+    guidance_scale: float,
+    seed: int,
+) -> torch.Tensor:
+    """Run full TRTLLM pipeline including VAE decode; return (T, H, W, C) float in [0, 1]."""
+    call_kwargs = dict(
+        prompt=prompt,
+        negative_prompt=negative_prompt,
+        height=height,
+        width=width,
+        num_frames=num_frames,
+        num_inference_steps=num_inference_steps,
+        guidance_scale=guidance_scale,
+        seed=seed,
+    )
+    if mode == "i2v":
+        call_kwargs["image"] = _make_test_image(height, width)
+
+    with torch.no_grad():
+        result = pipeline.forward(**call_kwargs)
+    video = result.video.float() / 255.0
+    if video.dim() == 5:
+        video = video[0]
+    return video
+
+
+def _capture_hf_video(
+    hf_pipe,
+    mode: str,
+    prompt: str,
+    negative_prompt: str,
+    height: int,
+    width: int,
+    num_frames: int,
+    num_inference_steps: int,
+    guidance_scale: float,
+    seed: int,
+) -> torch.Tensor:
+    """Run HF pipeline with output_type='np'; return (T, H, W, C) float in [0, 1]."""
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    call_kwargs = dict(
+        prompt=prompt,
+        negative_prompt=negative_prompt,
+        height=height,
+        width=width,
+        num_frames=num_frames,
+        num_inference_steps=num_inference_steps,
+        guidance_scale=guidance_scale,
+        generator=generator,
+        output_type="np",
+    )
+    if mode == "i2v":
+        call_kwargs["image"] = _make_test_image(height, width)
+
+    output = hf_pipe(**call_kwargs)
+    frames = output.frames
+    if isinstance(frames, np.ndarray):
+        return torch.from_numpy(frames[0]).float()
+    return frames[0].float()
+
+
+def _cosine_similarity(a: torch.Tensor, b: torch.Tensor) -> float:
+    """Cosine similarity between two tensors (flattened to 1D, cast to float32 on CPU)."""
+    a_flat = a.float().cpu().reshape(-1)
+    b_flat = b.float().cpu().reshape(-1)
+    return F.cosine_similarity(a_flat.unsqueeze(0), b_flat.unsqueeze(0)).clamp(-1.0, 1.0).item()
+
+
+def _assert_pipeline_matches_hf(
+    checkpoint_path: str,
+    mode: str,
+    height: int,
+    width: int,
+    num_frames: int,
+    guidance_scale: float,
+    threshold: float,
+    model_label: str,
+) -> None:
+    """Run TRTLLM and HF pipelines sequentially, compare decoded video output."""
+    # --- TRTLLM ---
+    trtllm_pipe = _load_trtllm_pipeline(checkpoint_path)
+
+    # Confirm this is the single-stage Wan 2.2 TI2V-5B path.
+    assert trtllm_pipe.is_wan22_5b is True
+    assert trtllm_pipe.transformer_2 is None
+    assert trtllm_pipe.expand_timesteps is True
+
+    trtllm_video = _capture_trtllm_video(
+        trtllm_pipe,
+        mode=mode,
+        prompt=PROMPT,
+        negative_prompt=NEGATIVE_PROMPT,
+        height=height,
+        width=width,
+        num_frames=num_frames,
+        num_inference_steps=NUM_STEPS,
+        guidance_scale=guidance_scale,
+        seed=SEED,
+    )
+    del trtllm_pipe
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    # --- HF reference ---
+    hf_pipe = _load_hf_pipeline(checkpoint_path, mode)
+    hf_video = _capture_hf_video(
+        hf_pipe,
+        mode=mode,
+        prompt=PROMPT,
+        negative_prompt=NEGATIVE_PROMPT,
+        height=height,
+        width=width,
+        num_frames=num_frames,
+        num_inference_steps=NUM_STEPS,
+        guidance_scale=guidance_scale,
+        seed=SEED,
+    )
+    del hf_pipe
+    gc.collect()
+    torch.cuda.empty_cache()
+
+    # --- Compare ---
+    assert trtllm_video.numel() == hf_video.numel(), (
+        f"{model_label}: element count mismatch — "
+        f"TRTLLM {trtllm_video.shape} ({trtllm_video.numel()}) vs "
+        f"HF {hf_video.shape} ({hf_video.numel()})"
+    )
+
+    cos_sim = _cosine_similarity(trtllm_video, hf_video)
+    print(f"\n  {model_label} cosine similarity: {cos_sim:.6f}")
+    assert cos_sim >= threshold, (
+        f"{model_label}: cosine similarity {cos_sim:.6f} < {threshold}. "
+        f"TRTLLM pipeline output diverges from the HuggingFace reference. "
+        f"Video shapes — TRTLLM: {trtllm_video.shape}, HF: {hf_video.shape}."
+    )
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.wan_t2v
+class TestWan22TI2V5B_T2V_PipelineCorrectness:
+    """Wan2.2-TI2V-5B T2V correctness vs HuggingFace reference."""
+
+    def test_cosine_similarity(self):
+        _assert_pipeline_matches_hf(
+            checkpoint_path=WAN22_TI2V_5B_PATH,
+            mode="t2v",
+            height=704,
+            width=1280,
+            num_frames=9,
+            guidance_scale=5.0,
+            threshold=T2V_COS_SIM_THRESHOLD,
+            model_label="Wan2.2-TI2V-5B T2V",
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.wan_i2v
+class TestWan22TI2V5B_I2V_PipelineCorrectness:
+    """Wan2.2-TI2V-5B I2V correctness vs HuggingFace reference."""
+
+    def test_cosine_similarity(self):
+        _assert_pipeline_matches_hf(
+            checkpoint_path=WAN22_TI2V_5B_PATH,
+            mode="i2v",
+            height=704,
+            width=1280,
+            num_frames=9,
+            guidance_scale=5.0,
+            threshold=I2V_COS_SIM_THRESHOLD,
+            model_label="Wan2.2-TI2V-5B I2V",
+        )
+
+
+# =============================================================================
+# Batch Generation Tests
+# =============================================================================
+
+
+class TestWan22TI2V5BBatchGeneration:
+    """Batch generation tests for Wan 2.2 TI2V-5B (single-stage, T2V and I2V modes)."""
+
+    @pytest.fixture(scope="class")
+    def wan22_ti2v_5b_full_pipeline(self):
+        """Load full Wan 2.2 TI2V-5B pipeline (all components) for batch tests."""
+        if not WAN22_TI2V_5B_PATH or not os.path.exists(WAN22_TI2V_5B_PATH):
+            pytest.skip("Checkpoint not available. Set DIFFUSION_MODEL_PATH_WAN22_TI2V_5B.")
+
+        args = VisualGenArgs(
+            checkpoint_path=WAN22_TI2V_5B_PATH,
+            device="cuda",
+            dtype="bfloat16",
+            torch_compile=TorchCompileConfig(enable_torch_compile=False),
+        )
+        pipeline = PipelineLoader(args).load(skip_warmup=True)
+        yield pipeline
+        del pipeline
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_t2v_single_prompt_backward_compat(self, wan22_ti2v_5b_full_pipeline):
+        """T2V single prompt returns (B, T, H, W, C) for backward compatibility."""
+        result = wan22_ti2v_5b_full_pipeline.forward(
+            prompt="a cat walking",
+            height=704,
+            width=1280,
+            num_frames=9,
+            num_inference_steps=4,
+            guidance_scale=5.0,
+            seed=42,
+        )
+        assert result.video.dim() == 5, f"Expected 5D (B,T,H,W,C), got {result.video.dim()}D"
+        B, _T, H, W, C = result.video.shape
+        assert B == 1 and H == 704 and W == 1280 and C == 3
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_t2v_batch_prompt_shape(self, wan22_ti2v_5b_full_pipeline):
+        """T2V list of prompts returns (B, T, H, W, C)."""
+        prompts = ["a sunset over mountains", "a cat on a roof"]
+        result = wan22_ti2v_5b_full_pipeline.forward(
+            prompt=prompts,
+            height=704,
+            width=1280,
+            num_frames=9,
+            num_inference_steps=4,
+            guidance_scale=5.0,
+            seed=42,
+        )
+        assert result.video.dim() == 5, f"Expected 5D (B,T,H,W,C), got {result.video.dim()}D"
+        B, _T, H, W, C = result.video.shape
+        assert B == 2 and H == 704 and W == 1280 and C == 3
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_i2v_single_prompt_backward_compat(self, wan22_ti2v_5b_full_pipeline):
+        """I2V single prompt returns (B, T, H, W, C) for backward compatibility."""
+        test_image = _make_test_image(704, 1280)
+        result = wan22_ti2v_5b_full_pipeline.forward(
+            prompt="a cat walking",
+            image=test_image,
+            height=704,
+            width=1280,
+            num_frames=9,
+            num_inference_steps=4,
+            guidance_scale=5.0,
+            seed=42,
+        )
+        assert result.video.dim() == 5, f"Expected 5D (B,T,H,W,C), got {result.video.dim()}D"
+        B, _T, H, W, C = result.video.shape
+        assert B == 1 and H == 704 and W == 1280 and C == 3
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_i2v_batch_prompt_shape(self, wan22_ti2v_5b_full_pipeline):
+        """I2V list of prompts with a single broadcast image returns (B, T, H, W, C)."""
+        test_image = _make_test_image(704, 1280)
+        prompts = ["a sunset over mountains", "a cat on a roof"]
+        result = wan22_ti2v_5b_full_pipeline.forward(
+            prompt=prompts,
+            image=test_image,
+            height=704,
+            width=1280,
+            num_frames=9,
+            num_inference_steps=4,
+            guidance_scale=5.0,
+            seed=42,
+        )
+        assert result.video.dim() == 5, f"Expected 5D (B,T,H,W,C), got {result.video.dim()}D"
+        B, _T, H, W, C = result.video.shape
+        assert B == 2 and H == 704 and W == 1280 and C == 3
+
+
+# =============================================================================
+# Combined Optimization Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.wan_t2v
+@pytest.mark.wan_i2v
+@pytest.mark.skipif(importlib.util.find_spec("cache_dit") is None, reason="cache_dit not installed")
+class TestWan22TI2V5BCombinedOptimizations:
+    """FP8 + CacheDiT + TRTLLM attention combined on Wan 2.2 TI2V-5B (704x1280)."""
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_fp8_cache_dit_trtllm(self):
+        if not os.path.exists(WAN22_TI2V_5B_PATH):
+            pytest.skip(f"Checkpoint not found: {WAN22_TI2V_5B_PATH}")
+        args = VisualGenArgs(
+            checkpoint_path=WAN22_TI2V_5B_PATH,
+            device="cuda",
+            dtype="bfloat16",
+            torch_compile=TorchCompileConfig(enable_torch_compile=False),
+            quant_config={"quant_algo": "FP8", "dynamic": True},
+            attention=AttentionConfig(backend="TRTLLM"),
+            cache=CacheDiTConfig(),
+        )
+        pipeline = PipelineLoader(args).load(skip_warmup=True)
+        try:
+            with torch.no_grad():
+                t2v_result = pipeline.forward(
+                    prompt="a cat sitting on a windowsill",
+                    negative_prompt="",
+                    height=704,
+                    width=1280,
+                    num_frames=9,
+                    num_inference_steps=10,
+                    guidance_scale=5.0,
+                    seed=42,
+                )
+            assert t2v_result.video.dim() == 5
+            B, _T, H, W, C = t2v_result.video.shape
+            assert B == 1 and H == 704 and W == 1280 and C == 3
+
+            assert pipeline.cache_accelerator is not None
+            assert pipeline.cache_accelerator.is_enabled()
+
+            with torch.no_grad():
+                i2v_result = pipeline.forward(
+                    image=_make_test_image(704, 1280),
+                    prompt="a cat sitting on a windowsill",
+                    negative_prompt="",
+                    height=704,
+                    width=1280,
+                    num_frames=9,
+                    num_inference_steps=10,
+                    guidance_scale=5.0,
+                    seed=42,
+                )
+            assert i2v_result.video.dim() == 5
+            B, _T, H, W, C = i2v_result.video.shape
+            assert B == 1 and H == 704 and W == 1280 and C == 3
+
+            assert pipeline.cache_accelerator is not None
+            assert pipeline.cache_accelerator.is_enabled()
+        finally:
+            del pipeline
+            gc.collect()
+            torch.cuda.empty_cache()

--- a/tests/unittest/_torch/visual_gen/test_wan22_ti2v_5b_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_wan22_ti2v_5b_pipeline.py
@@ -4,9 +4,10 @@
 """Correctness tests for Wan 2.2 TI2V-5B pipeline against HuggingFace reference.
 
 Tests verify that the TRTLLM WanPipeline produces decoded video with high cosine
-similarity to the HuggingFace diffusers baseline for both T2V and I2V. The threshold is 0.99 for T2V test and 0.98 (not 0.99) for I2V test because
-I2V image conditioning (VAE-encoded image + mask concatenated to the latent)
-accumulates additional bfloat16 error compared to T2V.
+similarity to the HuggingFace diffusers baseline for both T2V and I2V.
+The threshold is 0.99 for T2V and 0.98 (not 0.99) for I2V because I2V image
+conditioning (VAE-encoded image + mask concatenated to the latent) accumulates
+additional bfloat16 error compared to T2V.
 
 Model tested:
   - Wan2.2-TI2V-5B-Diffusers   (704x1280, 9 frames)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Wan 2.2 TI2V-5B image-to-video generation
  * Image input support for visual generation pipeline
  * Enhanced Wan 2.2 model variants (14B and 5B sizes)

* **Improvements**
  * Improved latent processing and timestep handling for image-to-video workflows
  * Refined configuration for different Wan 2.2 model variants
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
The Wan 2.2 5B model is a unified text-image-to-video model that handles both T2V and I2V in a single pipeline. Supports #13099 

- Detect the Wan 2.2 5B model via `expand_timesteps` flag in `model_index.json`
- Build Wan 2.2 5B's per-patch 2D timestep during denoising: frame-0 patches get t=0 (I2V) or all patches get current_t (T2V)
- Extend `WanTransformer3DModel` to accept per-patch `timestep` tensors `([B, num_patches])` alongside the standard scalar/batch form
- Add `post_step_fn` callback to `denoise()` to pin frame 0 back to the VAE-encoded input image after each scheduler step. This is needed for Wan 2.2 5B's I2V
- Add `_WAN22_5B_PARAMS` with `704×1280` native resolution, `40` steps, guidance `5.0`
- Rename `is_wan22` to `is_wan22_14b` throughout for clarity; remove unnecessary  `num_inference_steps` & `guidance_scale` fallbacks from forward()

@o-stoner @chang-l

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
