### PR TITLE
[None][perf] Clear multimodal data upon prefill completion

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -31,6 +31,7 @@ from tensorrt_llm.bindings.executor import (DisServingRequestStats,
                                             StaticBatchingStats)
 from tensorrt_llm.bindings.internal.batch_manager import (LlmRequestType,
                                                           ReqIdsSet)
+from tensorrt_llm.inputs.multimodal import strip_mm_data_for_generation
 from tensorrt_llm.llmapi.llm_args import PeftCacheConfig, WaitingQueuePolicy
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import CpType
@@ -118,6 +119,20 @@ def _load_iteration_indexes(env_var: str):
                 ) from None
 
     return frozenset(starts), frozenset(stops)
+
+
+def _strip_py_multimodal_data_post_prefill(request: LlmRequest) -> None:
+    """Drop pinned encoder cache and raw pre-encoder tensors after prefill completes.
+
+    Wraps `strip_mm_data_for_generation` and mutates the shared `request.py_multimodal_data`
+    in-place so the `LlmRequest`'s multimodal tensors actually get freed (unlike
+    `MultimodalParams.strip_for_generation`, which rebinds a per-forward-call wrapper's attribute
+    and leaves the request's dict untouched).
+    """
+    mm_data = getattr(request, "py_multimodal_data", None)
+    if not mm_data:
+        return
+    strip_mm_data_for_generation(mm_data)
 
 
 @dataclasses.dataclass
@@ -3431,6 +3446,12 @@ class PyExecutor:
                     request.context_chunk_size)
                 request.move_to_next_context_chunk()
             if request.context_remaining_length == 0:
+                # Prefill is done for this request; drop pinned encoder outputs
+                # (multimodal_embedding) and raw pre-encoder tensors that multimodal models stashed
+                # on `py_multimodal_data`. Without this, encoder inputs and outputs for multi-modal
+                # requests stay pinned on GPU through the full decode lifetime and can lead to OOMs
+                # at high concurrency.
+                _strip_py_multimodal_data_post_prefill(request)
                 if not self.disable_overlap_scheduler and request.will_complete_next_iteration(
                 ):
                     request.set_exclude_last_generation_logits(False)

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -17,6 +17,25 @@ from tensorrt_llm.logger import logger
 default_hasher = blake3
 
 
+def strip_mm_data_for_generation(mm_data: Dict[str, Any]) -> None:
+    """Clear `mm_data` in place, retaining only `mrope_config.mrope_position_deltas`.
+
+    Shared primitive behind `MultimodalParams.strip_for_generation` (which applies
+    it to a detached copy, preserving its caller's dict) and the post-prefill
+    release path in `py_executor` (which applies it directly to the shared
+    `request.py_multimodal_data` to actually free pinned encoder outputs).
+    """
+    if not mm_data:
+        return
+    mrope_config = mm_data.get('mrope_config')
+    mrope_deltas = None
+    if isinstance(mrope_config, dict):
+        mrope_deltas = mrope_config.get('mrope_position_deltas')
+    mm_data.clear()
+    if mrope_deltas is not None:
+        mm_data['mrope_config'] = {'mrope_position_deltas': mrope_deltas}
+
+
 @dataclass
 class MultimodalInput:
     multimodal_hashes: List[List[int]]
@@ -536,21 +555,9 @@ class MultimodalParams:
         """
         if not self.multimodal_data:
             return
-
-        # Extract mrope_position_deltas before clearing
-        mrope_position_deltas = None
-        if 'mrope_config' in self.multimodal_data:
-            mrope_config = self.multimodal_data['mrope_config']
-            if isinstance(mrope_config,
-                          dict) and 'mrope_position_deltas' in mrope_config:
-                mrope_position_deltas = mrope_config['mrope_position_deltas']
-
-        # Clear all data and restore only position deltas if they exist
-        self.multimodal_data = {}
-        if mrope_position_deltas is not None:
-            self.multimodal_data['mrope_config'] = {
-                'mrope_position_deltas': mrope_position_deltas
-            }
+        # Detach from the caller's dict, then apply the in-place primitive.
+        self.multimodal_data = dict(self.multimodal_data)
+        strip_mm_data_for_generation(self.multimodal_data)
 
     def has_content(self) -> bool:
         """Check if this object contains any multimodal data."""


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Optimization**
  * Improved memory efficiency in multimodal AI models by automatically releasing encoder caches and raw tensors immediately after the prefill phase completes.

* **Refactor**
  * Extracted and centralized multimodal data cleanup logic into a shared helper function for improved code maintainability and consistency across the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

* Why?

The multimodal inputs (pixel values, audio tensor, etc.) as well as outputs (embeddings) get stored in a request's `py_multimodal_data` dictionary. This is only ever dereferenced once a request is completed.

This meant that, at high-concurrency, given that there is no queuing of requests based on multimodal considerations, GPU memory would keep increasing until the number of concurrent requests that have gotten out of the queue decreases. Coupled with large multimodal input (e.g. long audio sequences), this could very easily lead to OOM errors at runtime.

* What?

This commit frees a requests multimodal data once it has completed the prefill phase.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
