### PR TITLE
[https://nvbugs/6095953][fix] Fix cache memory estimation for Qwen3 hybrid models in trtllm-bench

### DIFF
--- a/tensorrt_llm/bench/benchmark/utils/general.py
+++ b/tensorrt_llm/bench/benchmark/utils/general.py
@@ -11,7 +11,7 @@ from tensorrt_llm._torch.pyexecutor.model_loader import \
     validate_and_set_kv_cache_quant
 from tensorrt_llm.bench.build.build import (get_benchmark_engine_settings,
                                             get_model_config)
-from tensorrt_llm.bench.build.dataclasses import NemotronHybridConfig
+from tensorrt_llm.bench.build.dataclasses import NemotronHybridConfig, Qwen3HybridConfig
 from tensorrt_llm.bench.dataclasses.general import (DatasetMetadata,
                                                     InferenceRequest)
 from tensorrt_llm.logger import logger
@@ -113,8 +113,9 @@ def get_settings(params: dict, dataset_metadata: DatasetMetadata, model: str,
 
         if isinstance(
                 model_config,
-                NemotronHybridConfig) and mamba_ssm_cache_dtype not in (None,
-                                                                        "auto"):
+                (NemotronHybridConfig,
+                 Qwen3HybridConfig)) and mamba_ssm_cache_dtype not in (None,
+                                                                       "auto"):
             model_config.set_mamba_ssm_cache_dtype(mamba_ssm_cache_dtype)
 
         from tensorrt_llm._torch.model_config import ModelConfig

--- a/tensorrt_llm/bench/benchmark/utils/general.py
+++ b/tensorrt_llm/bench/benchmark/utils/general.py
@@ -11,7 +11,8 @@ from tensorrt_llm._torch.pyexecutor.model_loader import \
     validate_and_set_kv_cache_quant
 from tensorrt_llm.bench.build.build import (get_benchmark_engine_settings,
                                             get_model_config)
-from tensorrt_llm.bench.build.dataclasses import NemotronHybridConfig, Qwen3HybridConfig
+from tensorrt_llm.bench.build.dataclasses import (NemotronHybridConfig,
+                                                  Qwen3HybridConfig)
 from tensorrt_llm.bench.dataclasses.general import (DatasetMetadata,
                                                     InferenceRequest)
 from tensorrt_llm.logger import logger
@@ -111,11 +112,9 @@ def get_settings(params: dict, dataset_metadata: DatasetMetadata, model: str,
     else:
         model_config = get_model_config(model, model_path)
 
-        if isinstance(
-                model_config,
-                (NemotronHybridConfig,
-                 Qwen3HybridConfig)) and mamba_ssm_cache_dtype not in (None,
-                                                                       "auto"):
+        if isinstance(model_config,
+                      (NemotronHybridConfig, Qwen3HybridConfig
+                       )) and mamba_ssm_cache_dtype not in (None, "auto"):
             model_config.set_mamba_ssm_cache_dtype(mamba_ssm_cache_dtype)
 
         from tensorrt_llm._torch.model_config import ModelConfig

--- a/tensorrt_llm/bench/build/build.py
+++ b/tensorrt_llm/bench/build/build.py
@@ -5,7 +5,7 @@ from typing import Tuple, get_args
 import click
 from click_option_group import AllOptionGroup, optgroup
 
-from tensorrt_llm._torch.pyexecutor.config_utils import is_nemotron_hybrid, load_pretrained_config
+from tensorrt_llm._torch.pyexecutor.config_utils import is_nemotron_hybrid, is_qwen3_hybrid, load_pretrained_config
 from tensorrt_llm.bench.dataclasses.general import BenchmarkEnvironment
 from tensorrt_llm.bench.utils.data import create_dataset_from_stream, initialize_tokenizer
 from tensorrt_llm.bench.utils import VALID_QUANT_ALGOS
@@ -14,7 +14,7 @@ from tensorrt_llm._tensorrt_engine import LLM
 from tensorrt_llm.llmapi.llm_utils import QuantConfig
 from tensorrt_llm.logger import logger
 from tensorrt_llm.quantization.mode import QuantAlgo
-from tensorrt_llm.bench.build.dataclasses import ModelConfig, NemotronHybridConfig
+from tensorrt_llm.bench.build.dataclasses import ModelConfig, NemotronHybridConfig, Qwen3HybridConfig
 from tensorrt_llm.bench.build.tuning import calc_engine_setting
 
 TUNED_QUANTS = {
@@ -89,6 +89,8 @@ def get_model_config(model_name: str, model_path: Path = None) -> ModelConfig:
                                                trust_remote_code=True)
     if is_nemotron_hybrid(pretrained_config):
         return NemotronHybridConfig.from_hf(model_name, model_path)
+    if is_qwen3_hybrid(pretrained_config):
+        return Qwen3HybridConfig.from_hf(model_name, model_path)
     return ModelConfig.from_hf(model_name, model_path)
 
 

--- a/tensorrt_llm/bench/build/dataclasses.py
+++ b/tensorrt_llm/bench/build/dataclasses.py
@@ -14,8 +14,7 @@ import json
 import struct
 
 from tensorrt_llm._torch.pyexecutor.config_utils import (
-    load_pretrained_config, get_qwen3_hybrid_layer_types, is_qwen3_hybrid)
-
+    load_pretrained_config, get_qwen3_hybrid_layer_types)
 
 
 def parse_safetensors_file_metadata(model_path, filename):
@@ -115,8 +114,9 @@ def get_safetensors_metadata(model_name_or_path):
 
 
 class ModelConfig(BaseModel):
-    """ Model specific configurations. The parameters are needed in engine
-        setting calculation.
+    """Model specific configurations.
+
+    The parameters are needed in engine setting calculation.
     """
     name: str
     model_type: str
@@ -274,15 +274,17 @@ class Qwen3HybridConfig(ModelConfig):
 
     @model_validator(mode="after")
     def set_values_if_none(self):
-        """Derive num_attention_layers and num_linear_attention_layers from
-        the HF config's layer_types / full_attention_interval."""
+        """Derive num_attention_layers and num_linear_attention_layers.
+
+        Uses the HF config's layer_types / full_attention_interval.
+        """
         if self.num_linear_attention_layers is None or self.num_attention_layers is None:
             pretrained_config = load_pretrained_config(self.name,
                                                        trust_remote_code=True)
             layer_types = get_qwen3_hybrid_layer_types(pretrained_config)
             if self.num_attention_layers is None:
-                self.num_attention_layers = sum(
-                    1 for lt in layer_types if lt == "full_attention")
+                self.num_attention_layers = sum(1 for lt in layer_types
+                                                if lt == "full_attention")
             if self.num_linear_attention_layers is None:
                 self.num_linear_attention_layers = sum(
                     1 for lt in layer_types if lt == "linear_attention")
@@ -294,9 +296,9 @@ class Qwen3HybridConfig(ModelConfig):
         d_inner = self.linear_value_head_dim * self.linear_num_value_heads
         conv_dim = d_inner + 2 * self.linear_num_key_heads * self.linear_key_head_dim
         conv_state_elems = conv_dim * (self.linear_conv_kernel_dim - 1)
-        ssm_state_elems = (self.linear_num_value_heads
-                           * self.linear_value_head_dim
-                           * self.linear_key_head_dim)
+        ssm_state_elems = (self.linear_num_value_heads *
+                           self.linear_value_head_dim *
+                           self.linear_key_head_dim)
         gb_per_cache = bytes_per_elem * self.num_linear_attention_layers * (
             conv_state_elems + ssm_state_elems) / (1024**3)
         return gb_per_cache

--- a/tensorrt_llm/bench/build/dataclasses.py
+++ b/tensorrt_llm/bench/build/dataclasses.py
@@ -13,7 +13,9 @@ import os
 import json
 import struct
 
-from tensorrt_llm._torch.pyexecutor.config_utils import load_pretrained_config
+from tensorrt_llm._torch.pyexecutor.config_utils import (
+    load_pretrained_config, get_qwen3_hybrid_layer_types, is_qwen3_hybrid)
+
 
 
 def parse_safetensors_file_metadata(model_path, filename):
@@ -250,6 +252,56 @@ class NemotronHybridConfig(ModelConfig):
 
     def cache_memory_fraction(self, cache_memory_fraction):
         # Each mamba cache entry is pretty large (~50MB for 8B model), so we are more conservative when estimating the max batch size
+        return cache_memory_fraction**2
+
+    def set_mamba_ssm_cache_dtype(self, mamba_ssm_cache_dtype: str):
+        self.mamba_ssm_cache_dtype = mamba_ssm_cache_dtype
+
+
+class Qwen3HybridConfig(ModelConfig):
+    """Config for Qwen3 hybrid models (full-attention + linear-attention layers).
+
+    Maps Qwen3.5 linear-attention parameters to the same cache estimation
+    formulas used by NemotronHybridConfig.
+    """
+    linear_key_head_dim: int  # d_state
+    linear_conv_kernel_dim: int  # d_conv
+    linear_num_value_heads: int  # num_heads (mamba_num_heads)
+    linear_num_key_heads: int  # n_groups
+    linear_value_head_dim: int  # head_dim (mamba_head_dim)
+    num_linear_attention_layers: Optional[int] = Field(default=None)
+    mamba_ssm_cache_dtype: Optional[str] = Field(default="auto")
+
+    @model_validator(mode="after")
+    def set_values_if_none(self):
+        """Derive num_attention_layers and num_linear_attention_layers from
+        the HF config's layer_types / full_attention_interval."""
+        if self.num_linear_attention_layers is None or self.num_attention_layers is None:
+            pretrained_config = load_pretrained_config(self.name,
+                                                       trust_remote_code=True)
+            layer_types = get_qwen3_hybrid_layer_types(pretrained_config)
+            if self.num_attention_layers is None:
+                self.num_attention_layers = sum(
+                    1 for lt in layer_types if lt == "full_attention")
+            if self.num_linear_attention_layers is None:
+                self.num_linear_attention_layers = sum(
+                    1 for lt in layer_types if lt == "linear_attention")
+
+        super().set_values_if_none()
+        return self
+
+    def extra_model_cache_in_gb(self, bytes_per_elem, target_seq_len=None):
+        d_inner = self.linear_value_head_dim * self.linear_num_value_heads
+        conv_dim = d_inner + 2 * self.linear_num_key_heads * self.linear_key_head_dim
+        conv_state_elems = conv_dim * (self.linear_conv_kernel_dim - 1)
+        ssm_state_elems = (self.linear_num_value_heads
+                           * self.linear_value_head_dim
+                           * self.linear_key_head_dim)
+        gb_per_cache = bytes_per_elem * self.num_linear_attention_layers * (
+            conv_state_elems + ssm_state_elems) / (1024**3)
+        return gb_per_cache
+
+    def cache_memory_fraction(self, cache_memory_fraction):
         return cache_memory_fraction**2
 
     def set_mamba_ssm_cache_dtype(self, mamba_ssm_cache_dtype: str):

--- a/tensorrt_llm/bench/build/tuning.py
+++ b/tensorrt_llm/bench/build/tuning.py
@@ -110,9 +110,8 @@ def calc_engine_setting(
         target_input_len,
         target_output_len,
         pp_size,
-        disable_optimistic_tuning=isinstance(model_config,
-                                             (NemotronHybridConfig,
-                                              Qwen3HybridConfig)))
+        disable_optimistic_tuning=isinstance(
+            model_config, (NemotronHybridConfig, Qwen3HybridConfig)))
 
     # Functional and performance
     if total_gpu_memory < engine_size:

--- a/tensorrt_llm/bench/build/tuning.py
+++ b/tensorrt_llm/bench/build/tuning.py
@@ -6,7 +6,7 @@ from tensorrt_llm._utils import str_dtype_to_torch
 from tensorrt_llm.llmapi.llm_utils import QuantConfig
 from tensorrt_llm.logger import logger
 from tensorrt_llm.quantization.mode import QuantAlgo
-from tensorrt_llm.bench.build.dataclasses import ModelConfig, NemotronHybridConfig
+from tensorrt_llm.bench.build.dataclasses import ModelConfig, NemotronHybridConfig, Qwen3HybridConfig
 from .utils import get_device_memory
 import math
 
@@ -82,7 +82,7 @@ def calc_engine_setting(
         kv_cache_gpu_mem_fraction)
 
     bytes_per_elem = BYTES_PER_ELEM.get(QuantAlgo.NO_QUANT)
-    if isinstance(model_config, NemotronHybridConfig):
+    if isinstance(model_config, (NemotronHybridConfig, Qwen3HybridConfig)):
         mamba_ssm_cache_dtype = model_config.mamba_ssm_cache_dtype
         if mamba_ssm_cache_dtype != "auto":
             if str_dtype_to_torch(mamba_ssm_cache_dtype) == torch.float32:
@@ -111,7 +111,8 @@ def calc_engine_setting(
         target_output_len,
         pp_size,
         disable_optimistic_tuning=isinstance(model_config,
-                                             NemotronHybridConfig))
+                                             (NemotronHybridConfig,
+                                              Qwen3HybridConfig)))
 
     # Functional and performance
     if total_gpu_memory < engine_size:


### PR DESCRIPTION
@coderabbitai summary

## Description

The autotuner in `trtllm-bench` did not account for SSM/linear-attention cache in Qwen3 hybrid models (e.g. `nvidia/Qwen3.5-397B-A17B-NVFP4`). `get_model_config()` only checked `is_nemotron_hybrid()` (requires `hybrid_override_pattern`), but Qwen3.5 uses `layer_types`/`full_attention_interval` instead, so it fell through to base `ModelConfig` with `extra_model_cache_in_gb()=0`. This allocated all free memory to KV cache (208 GB KV, 0 GB extra), inflating `max_batch_size` and causing OOM when the runtime allocated mamba cache for 45 linear-attention layers (~93 MB/request).

**Fix:**
- Add `Qwen3HybridConfig` in `dataclasses.py` that maps Qwen3.5 `linear_*` fields to cache estimation (same formula as `NemotronHybridConfig`)
- Add `is_qwen3_hybrid()` check in `build.py:get_model_config()` dispatch
- Extend `isinstance` checks in `tuning.py` and `benchmark/utils/general.py` to cover `Qwen3HybridConfig`

| Field | Before (buggy) | After (fixed) |
|-------|----------------|---------------|
| `num_attention_layers` | 60 (all layers) | 15 (full-attention only) |
| `extra_model_cache_in_gb()` | 0.0000 GB | 0.0910 GB/request |
| `cache_memory_fraction(0.95)` | 0.9500 | 0.9025 |

## Test Coverage

- Verified fix locally with repro script against `nvidia/Qwen3.5-397B-A17B-NVFP4` HF config
- Run trtllm-bench autotuning on Qwen3.5-397B-A17B-NVFP4 (GB200 TP8) — should no longer OOM
- Verify NemotronHybrid models are not affected (no regression)

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.