### PR TITLE
[None][fix] initialize sampler state for ADP dummy requests

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -2667,20 +2667,15 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         return num_accepted_draft_tokens - 1
 
     @classmethod
-    def _filter_new_requests(cls, scheduled_requests: ScheduledRequests) -> list[LlmRequest]:
-        # list is faster than generator
-        return [
-            request
-            for request in scheduled_requests.context_requests_last_chunk
-            if not request.is_finished and not request.py_is_draft
-        ]
-
-    @classmethod
     def _collect_new_requests_for_setup(cls, scheduled_requests: ScheduledRequests) -> list[LlmRequest]:
         # ADP can inject generation-phase dummy requests after request activation.
         # Those still need sampler-side slot initialization before grouping/sampling.
         # The two source lists are disjoint by construction.
-        context_new_requests = cls._filter_new_requests(scheduled_requests)
+        context_new_requests = [
+            request
+            for request in scheduled_requests.context_requests_last_chunk
+            if not request.is_finished and not request.py_is_draft
+        ]
         adp_dummy_generation_requests = [
             request
             for request in scheduled_requests.generation_requests

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -2676,22 +2676,17 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         ]
 
     @classmethod
-    def _filter_adp_dummy_generation_requests(
-        cls, scheduled_requests: ScheduledRequests
-    ) -> list[LlmRequest]:
+    def _collect_new_requests_for_setup(cls, scheduled_requests: ScheduledRequests) -> list[LlmRequest]:
         # ADP can inject generation-phase dummy requests after request activation.
         # Those still need sampler-side slot initialization before grouping/sampling.
-        return [
+        # The two source lists are disjoint by construction.
+        context_new_requests = cls._filter_new_requests(scheduled_requests)
+        adp_dummy_generation_requests = [
             request
             for request in scheduled_requests.generation_requests
-            if request.is_attention_dp_dummy and not request.is_finished and not request.py_is_draft
+            if request.is_attention_dp_dummy
         ]
-
-    @classmethod
-    def _collect_new_requests_for_setup(cls, scheduled_requests: ScheduledRequests) -> list[LlmRequest]:
-        return cls._filter_new_requests(scheduled_requests) + cls._filter_adp_dummy_generation_requests(
-            scheduled_requests
-        )
+        return context_new_requests + adp_dummy_generation_requests
 
     @override
     def validate_request(self, request: LlmRequest) -> None:

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -2675,6 +2675,24 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             if not request.is_finished and not request.py_is_draft
         ]
 
+    @classmethod
+    def _filter_adp_dummy_generation_requests(
+        cls, scheduled_requests: ScheduledRequests
+    ) -> list[LlmRequest]:
+        # ADP can inject generation-phase dummy requests after request activation.
+        # Those still need sampler-side slot initialization before grouping/sampling.
+        return [
+            request
+            for request in scheduled_requests.generation_requests
+            if request.is_attention_dp_dummy and not request.is_finished and not request.py_is_draft
+        ]
+
+    @classmethod
+    def _collect_new_requests_for_setup(cls, scheduled_requests: ScheduledRequests) -> list[LlmRequest]:
+        return cls._filter_new_requests(scheduled_requests) + cls._filter_adp_dummy_generation_requests(
+            scheduled_requests
+        )
+
     @override
     def validate_request(self, request: LlmRequest) -> None:
         if self._use_beam_search:
@@ -2696,7 +2714,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         Args:
             scheduled_requests: The scheduled requests to set up the sampler step for.
         """
-        new_requests = self._filter_new_requests(scheduled_requests)
+        new_requests = self._collect_new_requests_for_setup(scheduled_requests)
 
         if not new_requests:
             return

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -2667,7 +2667,9 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         return num_accepted_draft_tokens - 1
 
     @classmethod
-    def _collect_new_requests_for_setup(cls, scheduled_requests: ScheduledRequests) -> list[LlmRequest]:
+    def _collect_new_requests_for_setup(
+        cls, scheduled_requests: ScheduledRequests
+    ) -> list[LlmRequest]:
         # ADP can inject generation-phase dummy requests after request activation.
         # Those still need sampler-side slot initialization before grouping/sampling.
         # The two source lists are disjoint by construction.

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -76,11 +76,14 @@ class TestSetupSamplerStepRequestSelection:
         is_attention_dp_dummy: bool = False,
         is_finished: bool = False,
         py_is_draft: bool = False,
-    ) -> SimpleNamespace:
-        return SimpleNamespace(
-            is_attention_dp_dummy=is_attention_dp_dummy,
-            is_finished=is_finished,
-            py_is_draft=py_is_draft,
+    ) -> LlmRequest:
+        return cast(
+            LlmRequest,
+            SimpleNamespace(
+                is_attention_dp_dummy=is_attention_dp_dummy,
+                is_finished=is_finished,
+                py_is_draft=py_is_draft,
+            ),
         )
 
     def test_collect_new_requests_for_setup_includes_adp_dummy_generation_requests(self):

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from itertools import product
+from types import SimpleNamespace
 from typing import (
     Any,
     Callable,
@@ -66,6 +67,54 @@ from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm.bindings import SamplingConfig
 from tensorrt_llm.bindings.executor import FinishReason
 from tensorrt_llm.sampling_params import SamplingParams
+
+
+class TestSetupSamplerStepRequestSelection:
+
+    @staticmethod
+    def _make_request(
+        *,
+        is_attention_dp_dummy: bool = False,
+        is_finished: bool = False,
+        py_is_draft: bool = False,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            is_attention_dp_dummy=is_attention_dp_dummy,
+            is_finished=is_finished,
+            py_is_draft=py_is_draft,
+        )
+
+    def test_collect_new_requests_for_setup_includes_adp_dummy_generation_requests(self):
+        scheduled_requests = ScheduledRequests()
+
+        context_request = self._make_request()
+        finished_context_request = self._make_request(is_finished=True)
+        draft_context_request = self._make_request(py_is_draft=True)
+        adp_dummy_generation_request = self._make_request(is_attention_dp_dummy=True)
+        regular_generation_request = self._make_request()
+        finished_adp_dummy_generation_request = self._make_request(
+            is_attention_dp_dummy=True, is_finished=True
+        )
+        draft_adp_dummy_generation_request = self._make_request(
+            is_attention_dp_dummy=True, py_is_draft=True
+        )
+
+        scheduled_requests.context_requests_last_chunk = [
+            context_request,
+            finished_context_request,
+            draft_context_request,
+        ]
+        scheduled_requests.generation_requests = [
+            adp_dummy_generation_request,
+            regular_generation_request,
+            finished_adp_dummy_generation_request,
+            draft_adp_dummy_generation_request,
+        ]
+
+        assert TorchSampler._collect_new_requests_for_setup(scheduled_requests) == [
+            context_request,
+            adp_dummy_generation_request,
+        ]
 
 
 @force_ampere

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -111,10 +111,12 @@ class TestSetupSamplerStepRequestSelection:
             draft_adp_dummy_generation_request,
         ]
 
-        assert TorchSampler._collect_new_requests_for_setup(scheduled_requests) == [
-            context_request,
-            adp_dummy_generation_request,
-        ]
+        collected = TorchSampler._collect_new_requests_for_setup(scheduled_requests)
+        assert len(collected) == 4
+        assert collected[0] is context_request
+        assert collected[1] is adp_dummy_generation_request
+        assert collected[2] is finished_adp_dummy_generation_request
+        assert collected[3] is draft_adp_dummy_generation_request
 
 
 @force_ampere

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -70,7 +70,6 @@ from tensorrt_llm.sampling_params import SamplingParams
 
 
 class TestSetupSamplerStepRequestSelection:
-
     @staticmethod
     def _make_request(
         *,

--- a/tests/unittest/_torch/sampler/test_torch_sampler.py
+++ b/tests/unittest/_torch/sampler/test_torch_sampler.py
@@ -1471,7 +1471,7 @@ class TestBatchedSampling:
             def _mock_filter(self, requests: ScheduledRequests) -> list[LlmRequest]:
                 return requests.all_requests()
 
-            patcher.setattr(TorchSampler, "_filter_new_requests", _mock_filter)
+            patcher.setattr(TorchSampler, "_collect_new_requests_for_setup", _mock_filter)
 
             sample_states = [
                 maybe_check_no_sync(


### PR DESCRIPTION
## Summary
- initialize sampler state for ADP dummy generation requests
- include ADP dummy generation requests in sampler setup request collection
- add unit coverage for the ADP dummy sampler path

## Problem
When attention DP is enabled, the executor can inject generation-phase dummy requests so an otherwise idle rank can still participate in collective operations during the forward pass.

Before this change, `setup_sampler_step()` only initialized sampler-side state for requests returned by `_filter_new_requests()`, which only covers newly activated context-last-chunk requests. ADP dummy generation requests were therefore skipped during sampler setup, even though they could still participate in later request grouping and sampling logic.

That left these dummy requests without the expected sampler slot/state initialization and could lead to incorrect sampler bookkeeping on the ADP dummy path.

## Fix
Use a broader request collection step for sampler setup:
- keep including the normal newly activated context-last-chunk requests
- additionally include ADP dummy generation requests (`is_attention_dp_dummy`)

This preserves the normal sampler setup path while ensuring ADP dummy requests get the same required initialization before later sampler processing.

## Testing
- Not run (not requested)