### PR TITLE
[TRI-966] [fix] Fix L0_backend_trtllm

### DIFF
--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
@@ -553,9 +553,9 @@ def convert_request(request,
                 "A value is required for request_output_len")
         streaming = get_input_scalar_by_name(request, 'streaming', batch_size,
                                              batch_index)
-        # trtllm.Request requires `streaming` to be a bool (not None). The
-        # Triton input is optional, so coerce a missing value to False.
-        inputs['streaming'] = bool(streaming) if streaming is not None else False
+        # trtllm.Request requires `streaming` to be a bool.
+        inputs['streaming'] = bool(
+            streaming) if streaming is not None else False
         if inputs['streaming'] and not decoupled:
             raise pb_utils.TritonModelException(
                 "Streaming is only supported in decoupled mode.")

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
@@ -551,8 +551,11 @@ def convert_request(request,
         if inputs['max_tokens'] is None:
             raise pb_utils.TritonModelException(
                 "A value is required for request_output_len")
-        inputs['streaming'] = get_input_scalar_by_name(request, 'streaming',
-                                                       batch_size, batch_index)
+        streaming = get_input_scalar_by_name(request, 'streaming', batch_size,
+                                             batch_index)
+        # trtllm.Request requires `streaming` to be a bool (not None). The
+        # Triton input is optional, so coerce a missing value to False.
+        inputs['streaming'] = bool(streaming) if streaming is not None else False
         if inputs['streaming'] and not decoupled:
             raise pb_utils.TritonModelException(
                 "Streaming is only supported in decoupled mode.")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming input handling to ensure it's always properly coerced to a boolean value, with a default of `false` when omitted. This improves robustness in request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

NV bug: https://nvbugs/6089262

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**


Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
<!--
Please explain the issue and the solution in short.
-->
This PR updates the Triton `tensorrt_llm` model to pass the `streaming` argument as a boolean.
Previously, the model failed when building a `trtllm.Request(**inputs, ...)` because it passed `streaming=None` to the `pybind` constructor, which only accepts `streaming: bool` (not `Optional[bool]`).

Error:
`
File \"/opt/tritonserver/tensorrtllm_backend/ci/L0_backend_trtllm/triton_model_repo/tensorrt_llm_bls/1/lib/triton_decoder.py\", line 122, in _exec_triton_request_single\n    raise pb_utils.TritonModelException(responses.error().message())\nc_python_backend_utils.TritonModelException: An error occurred when processing the input values for request id d0b08d87-0515-4af6-aba8-adb07bf99666, the error was '__init__(): incompatible function arguments. The following argument types are supported:\n    1. __init__(self, input_token_ids: collections.abc.Sequence[int], max_tokens: int, *, streaming: bool = False, ...
`
## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
L0_backend_trtllm--base

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [X] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
