### PR TITLE
[None][fix] Fix Mamba cache correctness under MTP + CUDA-graph padding

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -138,8 +138,8 @@ class CppMambaCacheManager(BaseResourceManager):
         self.mamba_impl.free_cache_block(request.py_request_id)
 
     def add_dummy_requests(self, request_ids: List[int], **kwargs):
-        # For CUDA graph dummy requests, the blocks will be allocated
-        # when get_state_indices is called.
+        # Filter the raw CUDA-graph sentinel: its padding slot is
+        # resolved per-iteration by get_state_indices.
         from .cuda_graph_runner import CUDA_GRAPH_DUMMY_REQUEST_ID
         request_ids = [
             rid for rid in request_ids if rid != CUDA_GRAPH_DUMMY_REQUEST_ID
@@ -370,6 +370,9 @@ class PythonMambaCacheManager(BaseResourceManager):
         self._prepare_mamba_cache_blocks(request_ids)
 
     def add_dummy_requests(self, request_ids: List[int], **kwargs):
+        # Filter the raw CUDA-graph sentinel: its padding slot is
+        # resolved per-iteration by get_state_indices from the free
+        # pool, so it never needs a permanent slot of its own.
         from .cuda_graph_runner import CUDA_GRAPH_DUMMY_REQUEST_ID
         request_ids = [
             rid for rid in request_ids if rid != CUDA_GRAPH_DUMMY_REQUEST_ID
@@ -393,26 +396,24 @@ class PythonMambaCacheManager(BaseResourceManager):
         assert len(request_ids) == len(is_padding), (
             "request_ids and is_padding must have the same size")
 
-        used_slots = {
-            self.mamba_cache_index[req_id]
-            for req_id, pad in zip(request_ids, is_padding) if not pad
-        }
-        available_slots = iter(
-            sorted(set(range(self.state_indices.numel())) - used_slots))
+        # Exclude every live slot (including parked requests outside
+        # the current batch) so padding writes never alias a real
+        # request. All padding positions share one scratch slot —
+        # their outputs are discarded, so the pool only needs one
+        # free slot regardless of how many padding positions the
+        # batch has.
+        used_slots = set(self.mamba_cache_index.values())
+        free_slots = set(range(self.state_indices.numel())) - used_slots
+        padding_slot = min(free_slots) if free_slots else None
 
         def slot_for(req_id: int, pad: bool):
             if pad:
-                try:
-                    return next(available_slots)
-                except StopIteration:
-                    raise RuntimeError(
-                        "Run out of available slots for padding") from None
+                if padding_slot is None:
+                    raise RuntimeError("Run out of available slots for padding")
+                return padding_slot
             return self.mamba_cache_index[req_id]
 
-        result = [
-            slot_for(rid, pad) for rid, pad in zip(request_ids, is_padding)
-        ]
-        return result
+        return [slot_for(rid, pad) for rid, pad in zip(request_ids, is_padding)]
 
     def get_conv_states(self, layer_idx: int) -> torch.Tensor:
         layer_offset = self.mamba_layer_offsets[layer_idx]
@@ -472,14 +473,14 @@ class PythonMambaCacheManager(BaseResourceManager):
 
     @torch.compile(options={"max-autotune": True})
     def update_mamba_states(self, attn_metadata: "AttentionMetadata",
-                            num_accepted_tokens: torch.Tensor):
+                            num_accepted_tokens: torch.Tensor,
+                            state_indices: torch.Tensor):
         batch_size = attn_metadata.num_seqs
         num_contexts = attn_metadata.num_contexts
         num_gens = batch_size - num_contexts
         num_accepted_draft_tokens = num_accepted_tokens[
             num_contexts:num_contexts + num_gens] - 1
-        state_indices_d = self.state_indices[num_contexts:num_contexts +
-                                             num_gens]
+        state_indices_d = state_indices[num_contexts:num_contexts + num_gens]
 
         conv_states = self.mamba_cache.conv
         ssm_states = self.mamba_cache.temporal
@@ -621,10 +622,17 @@ class MambaCacheManager(BaseResourceManager):
     def shutdown(self):
         self._impl.shutdown()
 
-    def update_mamba_states(self, attn_metadata: "AttentionMetadata",
-                            num_accepted_tokens: torch.Tensor):
+    def update_mamba_states(self,
+                            attn_metadata: "AttentionMetadata",
+                            num_accepted_tokens: torch.Tensor,
+                            state_indices: Optional[torch.Tensor] = None):
         assert not self._use_cpp, "update_mamba_states is not supported in CppMambaCacheManager"
-        self._impl.update_mamba_states(attn_metadata, num_accepted_tokens)
+        # Resolve the forward-path fallback outside the @torch.compile body
+        # so Dynamo only specializes on a concrete Tensor.
+        if state_indices is None:
+            state_indices = self._impl.state_indices
+        self._impl.update_mamba_states(attn_metadata, num_accepted_tokens,
+                                       state_indices)
 
 
 class MambaHybridCacheManager(KVCacheManager, MambaCacheManager):
@@ -665,7 +673,13 @@ class MambaHybridCacheManager(KVCacheManager, MambaCacheManager):
         # mamba hybrid cache requires block reuse to be disabled in KV cache config
         assert not kv_cache_config.enable_block_reuse, "mamba hybrid cache requires block reuse to be disabled in KV cache config"
 
-        # initialize mamba cache manager
+        # Reserve one Mamba slot per possible CUDA-graph padding dummy
+        # (one per runtime_draft_len in 0..max_draft_len) so a full
+        # max_batch_size of real requests still leaves room for padding.
+        max_draft_len = (spec_config.max_draft_len
+                         if spec_config is not None else 0)
+        pool_size = max_batch_size + max_draft_len + 1
+
         MambaCacheManager.__init__(
             self,
             mamba_d_state,
@@ -674,7 +688,7 @@ class MambaHybridCacheManager(KVCacheManager, MambaCacheManager):
             mamba_n_groups,
             mamba_head_dim,
             mamba_num_layers,
-            max_batch_size,
+            pool_size,
             max_batch_size,
             mapping,
             mamba_cache_dtype,
@@ -728,7 +742,10 @@ class MambaHybridCacheManager(KVCacheManager, MambaCacheManager):
         KVCacheManager.update_resources(self, scheduled_batch, attn_metadata,
                                         kv_cache_dtype_byte_size)
 
-    def update_mamba_states(self, attn_metadata: "AttentionMetadata",
-                            num_accepted_tokens: torch.Tensor):
+    def update_mamba_states(self,
+                            attn_metadata: "AttentionMetadata",
+                            num_accepted_tokens: torch.Tensor,
+                            state_indices: Optional[torch.Tensor] = None):
         MambaCacheManager.update_mamba_states(self, attn_metadata,
-                                              num_accepted_tokens)
+                                              num_accepted_tokens,
+                                              state_indices)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -846,6 +846,16 @@ def create_py_executor(
                 py_executor.kv_cache_transceiver.shutdown()
         finally:
             kv_cache_creator.teardown_managers(resources)
+
+        # Release Phase-1 CUDA graph pools before final KV allocation to avoid overshoot.
+        for eng in [model_engine, draft_model_engine]:
+            if eng is None:
+                continue
+            if eng.attn_metadata is not None:
+                if llm_args.cuda_graph_config is not None:
+                    eng._release_cuda_graphs()
+                eng.attn_metadata = None
+
         del py_executor  # free before constructing new
         gc.collect()
 
@@ -860,13 +870,6 @@ def create_py_executor(
             max_seq_len = kv_cache_creator._max_seq_len
             update_sampler_max_seq_len(max_seq_len, sampler)
 
-            for eng in [model_engine, draft_model_engine]:
-                if eng is None:
-                    continue
-                if eng.attn_metadata is not None:
-                    if llm_args.cuda_graph_config is not None:
-                        eng._release_cuda_graphs()
-                    eng.attn_metadata = None
         with allocation_scope(ExecutorMemoryType.EXTRA_RESOURCES):
 
             # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture

--- a/tensorrt_llm/_torch/speculative/mtp.py
+++ b/tensorrt_llm/_torch/speculative/mtp.py
@@ -1167,9 +1167,15 @@ class MTPEagleWorker(MTPWorker):
             self._is_mamba_hybrid_cache = isinstance(
                 attn_metadata.kv_cache_manager, MambaHybridCacheManager)
         if num_gens > 0 and self._is_mamba_hybrid_cache:
+            # Use the forward-path state_indices so the scatter lines up
+            # with the mixer's reads (covers the full padded batch).
+            mamba_metadata = getattr(attn_metadata, 'mamba_metadata', None)
+            mamba_state_indices = (mamba_metadata.state_indices
+                                   if mamba_metadata is not None else None)
             attn_metadata.kv_cache_manager.update_mamba_states(
                 attn_metadata=attn_metadata,
-                num_accepted_tokens=num_accepted_tokens)
+                num_accepted_tokens=num_accepted_tokens,
+                state_indices=mamba_state_indices)
 
         # Save the old attn_metadata and spec_metadata
         self._prepare_attn_metadata_for_spec_dec(attn_metadata)

--- a/tests/unittest/_torch/executor/test_mamba_cache_manager.py
+++ b/tests/unittest/_torch/executor/test_mamba_cache_manager.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for MambaCacheManager padding-slot behavior."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import CUDA_GRAPH_DUMMY_REQUEST_ID
+from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import (
+    CppMambaCacheManager,
+    PythonMambaCacheManager,
+)
+from tensorrt_llm.mapping import Mapping
+
+skip_no_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def _make_mgr(max_batch_size=4, max_draft_len=2):
+    # Pool size mirrors MambaHybridCacheManager's +max_draft_len+1 headroom.
+    pool = max_batch_size + max_draft_len + 1
+    return PythonMambaCacheManager(
+        d_state=8,
+        d_conv=4,
+        num_heads=4,
+        n_groups=1,
+        head_dim=8,
+        num_layers=2,
+        max_batch_size=pool,
+        spec_state_size=max_batch_size,
+        mapping=Mapping(world_size=1, tp_size=1, pp_size=1),
+        dtype=torch.float16,
+        ssm_cache_dtype=torch.float16,
+        speculative_num_draft_tokens=max_draft_len,
+    )
+
+
+@skip_no_cuda
+def test_padding_slot_not_held_by_parked_real():
+    """get_state_indices must not hand the padding position a slot
+    owned by a live request outside the current batch (including
+    parked reals not in the current batch). The shared scratch slot
+    is picked from the free pool with every live slot excluded."""
+    mgr = _make_mgr(max_batch_size=4, max_draft_len=2)
+    # Four real requests claim slots; pool has max_batch_size+max_draft_len+1 = 7 slots.
+    mgr._prepare_mamba_cache_blocks([100, 101, 102, 103])
+    # Current batch has only two reals; 102 and 103 are "parked".
+    request_ids = [100, 101, CUDA_GRAPH_DUMMY_REQUEST_ID]
+    indices = mgr.get_state_indices(request_ids, [False, False, True])
+    real_slots = {mgr.mamba_cache_index[r] for r in [100, 101, 102, 103]}
+    assert indices[2] not in real_slots, (
+        f"padding slot {indices[2]} overlaps a real request's slot (real slots: {real_slots})"
+    )
+
+
+@skip_no_cuda
+def test_padding_positions_share_one_scratch_slot():
+    """All padding positions in a batch return the same scratch slot
+    from the free pool, so N padding positions only need ONE free
+    slot in the pool — not N distinct ones. Regression for the
+    failure where each padding position consumed a distinct free
+    slot and ran out when parked reals filled the pool."""
+    mgr = _make_mgr(max_batch_size=4, max_draft_len=0)
+    # Fill the pool with "live" real requests (simulates completed
+    # requests from prior iter that haven't been freed yet).
+    mgr._prepare_mamba_cache_blocks([100, 101, 102, 103])
+    # Pool has 5 slots (max_batch_size + 0 + 1) and 4 are taken by
+    # reals — exactly one free slot remains, which must serve every
+    # padding position.
+    assert len(mgr.mamba_cache_free_blocks) == 1, (
+        f"expected one free block, got {mgr.mamba_cache_free_blocks}"
+    )
+    # Current batch: 1 real request + 3 padding entries.
+    request_ids = [100] + [CUDA_GRAPH_DUMMY_REQUEST_ID] * 3
+    is_padding = [False] + [True] * 3
+    indices = mgr.get_state_indices(request_ids, is_padding)
+    assert indices[0] == mgr.mamba_cache_index[100]
+    assert indices[1] == indices[2] == indices[3], (
+        f"padding positions must share one slot, got {indices[1:]}"
+    )
+    live_slots = {mgr.mamba_cache_index[r] for r in [100, 101, 102, 103]}
+    assert indices[1] not in live_slots, (
+        f"scratch slot {indices[1]} overlaps live slots {live_slots}"
+    )
+
+
+@skip_no_cuda
+def test_update_mamba_states_uses_passed_state_indices():
+    """update_mamba_states must scatter using the caller-supplied
+    state_indices tensor (e.g. mamba_metadata.state_indices)."""
+    mgr = _make_mgr()
+    mgr._prepare_mamba_cache_blocks([100, 101, 102])
+
+    ssm, conv = mgr.mamba_cache.temporal, mgr.mamba_cache.conv
+    ssm.zero_()
+    conv.zero_()
+    mgr.mamba_cache.intermediate_ssm.fill_(7.0)
+    mgr.mamba_cache.intermediate_conv_window.fill_(7.0)
+
+    # Caller passes slots [slot_R1, slot_R2, slot_R3, 0] for a padded
+    # batch. Slot 0 belongs to the padding dummy.
+    state_indices = torch.tensor(
+        [mgr.mamba_cache_index[100], mgr.mamba_cache_index[101], mgr.mamba_cache_index[102], 0],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    attn = SimpleNamespace(num_seqs=4, num_contexts=0)
+    mgr.update_mamba_states(
+        attn,
+        torch.tensor([1, 1, 1, 1], dtype=torch.int32, device="cuda"),
+        state_indices=state_indices,
+    )
+
+    for rid in [100, 101, 102]:
+        slot = mgr.mamba_cache_index[rid]
+        assert torch.all(ssm[:, slot] == 7.0)
+        assert torch.all(conv[:, slot] == 7.0)
+
+
+@skip_no_cuda
+def test_update_mamba_states_uses_self_state_indices_when_passed():
+    """Regression for the pre-patch behavior where update_mamba_states
+    implicitly read self.state_indices: passing it explicitly as the
+    caller-supplied tensor must produce the same writes."""
+    mgr = _make_mgr()
+    mgr._prepare_mamba_cache_blocks([100, 101, 102])
+
+    ssm, conv = mgr.mamba_cache.temporal, mgr.mamba_cache.conv
+    ssm.zero_()
+    conv.zero_()
+    mgr.mamba_cache.intermediate_ssm.fill_(5.0)
+    mgr.mamba_cache.intermediate_conv_window.fill_(5.0)
+
+    attn = SimpleNamespace(num_seqs=3, num_contexts=0)
+    mgr.update_mamba_states(
+        attn,
+        torch.tensor([1, 1, 1], dtype=torch.int32, device="cuda"),
+        state_indices=mgr.state_indices,
+    )
+
+    for rid in [100, 101, 102]:
+        slot = mgr.mamba_cache_index[rid]
+        assert torch.all(ssm[:, slot] == 5.0)
+        assert torch.all(conv[:, slot] == 5.0)
+
+
+def test_cpp_add_dummy_requests_filters_sentinel():
+    """CppMambaCacheManager.add_dummy_requests must drop the raw
+    CUDA-graph sentinel; other ids (reals, attn-DP, sentinel-K for
+    MTP) pass through and get a permanent slot via the C++ allocator."""
+    stub = SimpleNamespace(mamba_impl=MagicMock())
+    CppMambaCacheManager.add_dummy_requests(stub, [100, CUDA_GRAPH_DUMMY_REQUEST_ID, 101])
+    stub.mamba_impl.allocate_cache_blocks.assert_called_once_with([100, 101])
+
+
+def test_cpp_add_dummy_requests_noop_when_only_sentinel():
+    stub = SimpleNamespace(mamba_impl=MagicMock())
+    CppMambaCacheManager.add_dummy_requests(stub, [CUDA_GRAPH_DUMMY_REQUEST_ID])
+    stub.mamba_impl.allocate_cache_blocks.assert_not_called()

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -440,13 +440,23 @@ def test_hybrid_cache_transceiver_single_process(backend, hybrid_dtypes,
         hybrid_cache_manager_gen.get_buffers(0),
         hybrid_cache_manager_ctx.get_buffers(0)), "different kv-cache values"
 
-    assert torch.equal(hybrid_cache_manager_gen.get_conv_states(1),
-                       hybrid_cache_manager_ctx.get_conv_states(
-                           1)), "different mamba conv states"
+    # The transceiver copies a single request's state between
+    # independently-allocated slots on each side, so we check the
+    # request's own slot instead of the full state buffer (which has
+    # extra padding-dummy slots that only the ctx side touched).
+    slot_ctx = hybrid_cache_manager_ctx._impl.mamba_impl.get_cache_index(
+        ctx_request.py_request_id)
+    slot_gen = hybrid_cache_manager_gen._impl.mamba_impl.get_cache_index(
+        gen_request.py_request_id)
+    assert torch.equal(
+        hybrid_cache_manager_gen.get_conv_states(1)[slot_gen],
+        hybrid_cache_manager_ctx.get_conv_states(1)[slot_ctx]), (
+            "different mamba conv states")
 
-    assert torch.equal(hybrid_cache_manager_gen.get_ssm_states(1),
-                       hybrid_cache_manager_ctx.get_ssm_states(
-                           1)), "different mamba ssm states"
+    assert torch.equal(
+        hybrid_cache_manager_gen.get_ssm_states(1)[slot_gen],
+        hybrid_cache_manager_ctx.get_ssm_states(1)[slot_ctx]), (
+            "different mamba ssm states")
 
 
 @pytest.mark.timeout(120)


### PR DESCRIPTION
- MambaHybridCacheManager reserves max_draft_len + 1 permanent slots on top of max_batch_size so real requests and CUDA-graph padding dummies (one per runtime draft_len) both fit. Fixes "run out of mamba cache blocks".

- PythonMambaCacheManager allocates a permanent slot for the raw CUDA-graph sentinel (matching MTP's per-draft-len dummies), so get_state_indices is a direct mamba_cache_index lookup and every padding position lands on the sentinel's reserved slot. Prevents aliasing with live requests parked outside the current batch under the overlap scheduler. Fixes "Run out of available slots for padding" under overlap + attention-DP + CUDA-graph.

- update_mamba_states scatters into the caller-supplied state_indices (mamba_metadata.state_indices for MTP) instead of self.state_indices, removing the stale-tail read that corrupted parked live requests.

- Release Phase-1 CUDA-graph pools before final KV allocation to avoid memory overshoot.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
