### PR TITLE
[TRTLLM-11759][fix] Reduce peak host memory during NemotronH_Nano_VL_V2 init

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -1772,21 +1772,25 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
 
         self.model_config = model_config
         llm_model_config = copy.deepcopy(model_config)
-        vision_model_config = copy.deepcopy(model_config)
         if hasattr(self, "llm"):
             return
 
-        if not _is_disagg():
-            self.vision_encoder = NanoV2VLVisionEncoder(vision_model_config).eval()
-
+        # Vision and sound encoders are constructed lazily in load_weights(),
+        # after MetaInitMode has exited, because their HuggingFace-based
+        # submodules (RADIO's nn.LayerNorm, HFParakeetEncoder, ...) use
+        # deterministic init ops (ones_, zeros_, fill_, .to(dtype=...),
+        # .detach()) that raise MetaInitException on meta tensors and would
+        # otherwise force the entire model onto the slow fallback path.
+        # Vision+sound weights are only ~2GB combined, so allocating them
+        # on CPU first is cheap, and the LLM's fast meta-init path is kept
+        # intact.
+        #
+        # Snapshot the multimodal ModelConfig now — self.post_config() below
+        # reassigns self.model_config.pretrained_config to the LLM-only
+        # NemotronHConfig, which loses vision_config / sound_config / etc.
+        self._mm_model_config = copy.deepcopy(model_config)
+        self.vision_encoder: Optional[NanoV2VLVisionEncoder] = None
         self.sound_encoder: ProjectedParakeet | None = None
-        sound_config = getattr(config, "sound_config", None)
-        if sound_config is not None:
-            self.sound_encoder = ProjectedParakeet(
-                sound_config,
-                llm_hidden_size=config.llm_config.hidden_size,
-                dtype=getattr(config, "torch_dtype", torch.bfloat16),
-            ).eval()
 
         llm_model_config.pretrained_config = llm_model_config.pretrained_config.llm_config
         self._update_config_for_quantization(llm_model_config)
@@ -1806,12 +1810,45 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         )
 
     def load_weights(self, weights):
+        # Construct vision/sound encoders here (outside MetaInitMode) so their
+        # HF-based submodules allocate regular CPU tensors. Then move them to
+        # CUDA since model.to("cuda") in model_loader already ran for the LLM.
+        # Use the snapshot of the multimodal ModelConfig taken in __init__ —
+        # self.model_config.pretrained_config was overwritten by post_config()
+        # to be the LLM-only config and no longer has vision_config /
+        # sound_config / force_image_size / etc.
+        mm_pretrained = self._mm_model_config.pretrained_config
+        if self.vision_encoder is None and not _is_disagg():
+            self.vision_encoder = NanoV2VLVisionEncoder(self._mm_model_config).eval().to("cuda")
+        sound_config = getattr(mm_pretrained, "sound_config", None)
+        if self.sound_encoder is None and sound_config is not None:
+            self.sound_encoder = (
+                ProjectedParakeet(
+                    sound_config,
+                    llm_hidden_size=mm_pretrained.llm_config.hidden_size,
+                    dtype=getattr(mm_pretrained, "torch_dtype", torch.bfloat16),
+                )
+                .eval()
+                .to("cuda")
+            )
+
         # Load vision encoder weights.
-        self.vision_encoder.load_weights(weights)
+        if self.vision_encoder is not None:
+            self.vision_encoder.load_weights(weights)
+
+        # Free vision encoder weights from the dict so the backing mmap pages can be released.
+        if hasattr(weights, "mark_consumed"):
+            weights.mark_consumed("vision_model")
+            weights.mark_consumed("mlp1")
 
         # Load sound encoder weights.
         if self.sound_encoder is not None:
             self.sound_encoder.load_weights(weights)
+
+        # Free sound encoder weights (whether loaded or not) to allow shard 1 mmap to be released.
+        if hasattr(weights, "mark_consumed"):
+            weights.mark_consumed("sound_encoder")
+            weights.mark_consumed("sound_projection")
 
         # Load language model weights.
         filtered_weights = {
@@ -1822,6 +1859,10 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         weight_mapper = NemotronHHfWeightMapper()
         weight_mapper.init_model_and_config(self.llm, self.model_config)
         self.llm.load_weights(filtered_weights, weight_mapper=weight_mapper)
+
+        # Free LLM weights from the dict to release the backing mmap pages for shards 2-17.
+        if hasattr(weights, "mark_consumed"):
+            weights.mark_consumed("language_model")
 
     @property
     def vocab_size_padded(self) -> int:


### PR DESCRIPTION
The multimodal NemotronH_Nano_VL_V2 model was hitting MetaInitException during MetaInitMode-guarded init because its HuggingFace-based submodules (nn.RMSNorm / nn.LayerNorm in the RADIO vision encoder, HFParakeetEncoder for the audio tower) use deterministic init ops (ones_, zeros_, fill_, .to(dtype=...), .detach()) that raise MetaInitException on meta tensors. The resulting fallback to regular init:
  * allocated ~33GB of real CPU tensors for the LLM,
  * took ~225s in model.to("cuda") copying CPU->CUDA, and
  * pushed process RSS to ~33GB during load (observed ~40GB extra host memory persisting after loading on unified-memory systems).

Fix:
  * Defer construction of self.vision_encoder and self.sound_encoder from NemotronH_Nano_VL_V2.__init__ to load_weights(). At load time, MetaInitMode has already exited, so the HF submodules allocate regular CPU tensors without triggering MetaInitException, and the LLM (created in __init__) keeps its fast meta-init path. Snapshot the multimodal ModelConfig (self._mm_model_config) before self.post_config() overwrites self.model_config.pretrained_config with the LLM-only NemotronHConfig, so load_weights can still access vision_config / sound_config / force_image_size / etc.
  * In NemotronH_Nano_VL_V2.load_weights, call mark_consumed on vision_model, mlp1, sound_encoder, sound_projection, and language_model prefixes so ConsumableWeightsDict can progressively release mmap-backed safetensors pages during loading.

Vision+sound weights are ~2GB combined versus ~33-62GB for the LLM, so allocating them on CPU first and moving to CUDA in load_weights is cheap. MetaInitMode itself is left unchanged, avoiding any risk of silent meta-tensor leaks into runtime buffers.

After the fix, model.to("cuda") becomes a no-op (0.01s vs 225s) since LLM tensors are allocated directly on CUDA from meta placeholders, peak proc_rss drops ~30GB, and "memory used outside torch" drops from ~77GiB to ~54GiB.

It also reduced model init time by avoiding the model init fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved memory efficiency for Nemotron Nano model by optimizing weight loading and resource management during initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
