### PR TITLE
[TRTLLM-11767][feat] LTX2 pipeline refactor part1 - auto upgrade to two stage pipeline

### DIFF
--- a/examples/visual_gen/visual_gen_ltx2.py
+++ b/examples/visual_gen/visual_gen_ltx2.py
@@ -3,6 +3,7 @@
 
 import argparse
 import time
+from pathlib import Path
 
 from tensorrt_llm import VisualGen, VisualGenArgs, VisualGenParams, logger
 from tensorrt_llm._torch.visual_gen.config import CacheDiTConfig
@@ -298,6 +299,32 @@ def parse_args():
     return parser.parse_args()
 
 
+def _discover_two_stage_paths(model_path: str) -> tuple[str, str]:
+    """Look up spatial upsampler and distilled LoRA in an LTX2 checkpoint directory.
+
+    Returns (upsampler_path, distilled_lora_path); empty strings if not a directory
+    or no unique match is found.
+    """
+    d = Path(model_path)
+    if not d.is_dir():
+        return "", ""
+
+    def _pick(pattern: str) -> str:
+        matches = sorted(d.glob(pattern))
+        if len(matches) == 1:
+            return str(matches[0])
+        if len(matches) > 1:
+            logger.warning(
+                f"Multiple files matching {pattern!r} under {model_path}: "
+                f"{[m.name for m in matches]}. Pass the path explicitly to disambiguate."
+            )
+        return ""
+
+    upsampler = _pick("*spatial-upscaler*.safetensors") or _pick("*upsampler*.safetensors")
+    distilled_lora = _pick("*distilled-lora*.safetensors") or _pick("*distilled*lora*.safetensors")
+    return upsampler, distilled_lora
+
+
 def _linear_type_to_quant_config(linear_type: str):
     """Map --linear_type CLI shortcut to quant_config dict for VisualGenArgs."""
     mapping = {
@@ -370,6 +397,15 @@ def _build_diffusion_args(args) -> VisualGenArgs:
 
 def main():
     args = parse_args()
+
+    if not args.spatial_upsampler_path or not args.distilled_lora_path:
+        discovered_upsampler, discovered_lora = _discover_two_stage_paths(args.model_path)
+        if not args.spatial_upsampler_path and discovered_upsampler:
+            args.spatial_upsampler_path = discovered_upsampler
+            logger.info(f"Discovered spatial upsampler: {discovered_upsampler}")
+        if not args.distilled_lora_path and discovered_lora:
+            args.distilled_lora_path = discovered_lora
+            logger.info(f"Discovered distilled LoRA: {discovered_lora}")
 
     if bool(args.spatial_upsampler_path) != bool(args.distilled_lora_path):
         missing = (

--- a/examples/visual_gen/visual_gen_ltx2.py
+++ b/examples/visual_gen/visual_gen_ltx2.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """LTX2 Text/Image-to-Video generation using TensorRT-LLM Visual Generation."""
 
 import argparse
+import os
 import time
 
 from tensorrt_llm import VisualGen, VisualGenArgs, VisualGenParams, logger
-from tensorrt_llm._torch.visual_gen.config import CacheDiTConfig
+from tensorrt_llm._torch.visual_gen.config import LTX2_FORCE_ONE_STAGE_ENV, CacheDiTConfig
+from tensorrt_llm.serve.media_storage import MediaStorage
 
 logger.set_level("info")
 
@@ -218,15 +223,6 @@ def parse_args():
             "transformer for stage 2 and un-merged afterwards."
         ),
     )
-    parser.add_argument(
-        "--one_stage_pipeline",
-        action="store_true",
-        help=(
-            "Force the LTX2 one-stage pipeline. This disables automatic "
-            "two-stage auxiliary checkpoint discovery and prevents promotion "
-            "to LTX2TwoStagesPipeline."
-        ),
-    )
 
     # Parallelism
     parser.add_argument(
@@ -345,6 +341,8 @@ def _cache_dit_config_from_args(args) -> CacheDiTConfig:
 def _build_diffusion_args(args) -> VisualGenArgs:
     """Build VisualGenArgs from parsed CLI args."""
     if args.enable_cache_dit:
+        os.environ[LTX2_FORCE_ONE_STAGE_ENV] = "1"
+        logger.info(f"{LTX2_FORCE_ONE_STAGE_ENV}=1 because Cache DiT requires one-stage LTX2.")
         cache_kwargs = {"cache": _cache_dit_config_from_args(args)}
     else:
         cache_kwargs = {}
@@ -368,7 +366,6 @@ def _build_diffusion_args(args) -> VisualGenArgs:
         pipeline={
             "enable_layerwise_nvtx_marker": args.enable_layerwise_nvtx_marker,
         },
-        one_stage_pipeline=args.one_stage_pipeline or args.enable_cache_dit,
     )
     if args.spatial_upsampler_path:
         kwargs["spatial_upsampler_path"] = args.spatial_upsampler_path

--- a/examples/visual_gen/visual_gen_ltx2.py
+++ b/examples/visual_gen/visual_gen_ltx2.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python3
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
 """LTX2 Text/Image-to-Video generation using TensorRT-LLM Visual Generation."""
 
 import argparse
@@ -371,7 +368,7 @@ def _build_diffusion_args(args) -> VisualGenArgs:
         pipeline={
             "enable_layerwise_nvtx_marker": args.enable_layerwise_nvtx_marker,
         },
-        one_stage_pipeline=args.one_stage_pipeline,
+        one_stage_pipeline=args.one_stage_pipeline or args.enable_cache_dit,
     )
     if args.spatial_upsampler_path:
         kwargs["spatial_upsampler_path"] = args.spatial_upsampler_path

--- a/examples/visual_gen/visual_gen_ltx2.py
+++ b/examples/visual_gen/visual_gen_ltx2.py
@@ -5,12 +5,10 @@
 """LTX2 Text/Image-to-Video generation using TensorRT-LLM Visual Generation."""
 
 import argparse
-import os
 import time
 
 from tensorrt_llm import VisualGen, VisualGenArgs, VisualGenParams, logger
-from tensorrt_llm._torch.visual_gen.config import LTX2_FORCE_ONE_STAGE_ENV, CacheDiTConfig
-from tensorrt_llm.serve.media_storage import MediaStorage
+from tensorrt_llm._torch.visual_gen.config import CacheDiTConfig
 
 logger.set_level("info")
 
@@ -341,8 +339,7 @@ def _cache_dit_config_from_args(args) -> CacheDiTConfig:
 def _build_diffusion_args(args) -> VisualGenArgs:
     """Build VisualGenArgs from parsed CLI args."""
     if args.enable_cache_dit:
-        os.environ[LTX2_FORCE_ONE_STAGE_ENV] = "1"
-        logger.info(f"{LTX2_FORCE_ONE_STAGE_ENV}=1 because Cache DiT requires one-stage LTX2.")
+        logger.info("Cache DiT enabled; LTX2 will run as a one-stage pipeline.")
         cache_kwargs = {"cache": _cache_dit_config_from_args(args)}
     else:
         cache_kwargs = {}

--- a/examples/visual_gen/visual_gen_ltx2.py
+++ b/examples/visual_gen/visual_gen_ltx2.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """LTX2 Text/Image-to-Video generation using TensorRT-LLM Visual Generation."""
 
 import argparse
 import time
-from pathlib import Path
 
 from tensorrt_llm import VisualGen, VisualGenArgs, VisualGenParams, logger
 from tensorrt_llm._torch.visual_gen.config import CacheDiTConfig
@@ -202,9 +204,10 @@ def parse_args():
         type=str,
         default="",
         help=(
-            "Path to the learned LatentUpsampler checkpoint (.safetensors). "
-            "When provided, the pipeline uses two-stage generation: stage 1 "
-            "at half resolution, learned 2x upsample, stage 2 refinement."
+            "Optional path to the learned LatentUpsampler checkpoint (.safetensors). "
+            "If omitted, VisualGen tries to discover it next to the model checkpoint. "
+            "When available, the pipeline uses two-stage generation: stage 1 at half "
+            "resolution, learned 2x upsample, stage 2 refinement."
         ),
     )
     parser.add_argument(
@@ -212,8 +215,9 @@ def parse_args():
         type=str,
         default="",
         help=(
-            "Path to the distilled LoRA checkpoint (.safetensors) for "
-            "stage 2 refinement. The LoRA weights are merged into the "
+            "Optional path to the distilled LoRA checkpoint (.safetensors) for "
+            "stage 2 refinement. If omitted, VisualGen tries to discover it next "
+            "to the model checkpoint. The LoRA weights are merged into the "
             "transformer for stage 2 and un-merged afterwards."
         ),
     )
@@ -299,32 +303,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def _discover_two_stage_paths(model_path: str) -> tuple[str, str]:
-    """Look up spatial upsampler and distilled LoRA in an LTX2 checkpoint directory.
-
-    Returns (upsampler_path, distilled_lora_path); empty strings if not a directory
-    or no unique match is found.
-    """
-    d = Path(model_path)
-    if not d.is_dir():
-        return "", ""
-
-    def _pick(pattern: str) -> str:
-        matches = sorted(d.glob(pattern))
-        if len(matches) == 1:
-            return str(matches[0])
-        if len(matches) > 1:
-            logger.warning(
-                f"Multiple files matching {pattern!r} under {model_path}: "
-                f"{[m.name for m in matches]}. Pass the path explicitly to disambiguate."
-            )
-        return ""
-
-    upsampler = _pick("*spatial-upscaler*.safetensors") or _pick("*upsampler*.safetensors")
-    distilled_lora = _pick("*distilled-lora*.safetensors") or _pick("*distilled*lora*.safetensors")
-    return upsampler, distilled_lora
-
-
 def _linear_type_to_quant_config(linear_type: str):
     """Map --linear_type CLI shortcut to quant_config dict for VisualGenArgs."""
     mapping = {
@@ -397,24 +375,6 @@ def _build_diffusion_args(args) -> VisualGenArgs:
 
 def main():
     args = parse_args()
-
-    if not args.spatial_upsampler_path or not args.distilled_lora_path:
-        discovered_upsampler, discovered_lora = _discover_two_stage_paths(args.model_path)
-        if not args.spatial_upsampler_path and discovered_upsampler:
-            args.spatial_upsampler_path = discovered_upsampler
-            logger.info(f"Discovered spatial upsampler: {discovered_upsampler}")
-        if not args.distilled_lora_path and discovered_lora:
-            args.distilled_lora_path = discovered_lora
-            logger.info(f"Discovered distilled LoRA: {discovered_lora}")
-
-    if bool(args.spatial_upsampler_path) != bool(args.distilled_lora_path):
-        missing = (
-            "--distilled_lora_path" if args.spatial_upsampler_path else "--spatial_upsampler_path"
-        )
-        raise ValueError(
-            f"Two-stage pipeline requires both --spatial_upsampler_path and "
-            f"--distilled_lora_path, but {missing} was not provided."
-        )
 
     attn2d_size = args.attn2d_row_size * args.attn2d_col_size
     if attn2d_size > 1 and args.ulysses_size > 1:

--- a/examples/visual_gen/visual_gen_ltx2.py
+++ b/examples/visual_gen/visual_gen_ltx2.py
@@ -221,6 +221,15 @@ def parse_args():
             "transformer for stage 2 and un-merged afterwards."
         ),
     )
+    parser.add_argument(
+        "--one_stage_pipeline",
+        action="store_true",
+        help=(
+            "Force the LTX2 one-stage pipeline. This disables automatic "
+            "two-stage auxiliary checkpoint discovery and prevents promotion "
+            "to LTX2TwoStagesPipeline."
+        ),
+    )
 
     # Parallelism
     parser.add_argument(
@@ -362,6 +371,7 @@ def _build_diffusion_args(args) -> VisualGenArgs:
         pipeline={
             "enable_layerwise_nvtx_marker": args.enable_layerwise_nvtx_marker,
         },
+        one_stage_pipeline=args.one_stage_pipeline,
     )
     if args.spatial_upsampler_path:
         kwargs["spatial_upsampler_path"] = args.spatial_upsampler_path

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -1,5 +1,4 @@
 import json
-import os
 from enum import Enum
 from pathlib import Path
 from types import SimpleNamespace
@@ -23,9 +22,6 @@ from tensorrt_llm.quantization.mode import QuantAlgo
 # =============================================================================
 
 CacheBackendName = Literal["teacache", "cache_dit"]
-
-LTX2_FORCE_ONE_STAGE_ENV = "TLLM_LTX2_FORCE_ONE_STAGE_PIPELINE"
-_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 
 # =============================================================================
 # Pipeline component identifiers
@@ -568,106 +564,6 @@ def create_attention_metadata_state() -> Dict[str, Any]:
     return {"metadata": None, "capacity": (0, 0)}
 
 
-def _get_ltx2_auxiliary_search_dir(checkpoint_path: Path) -> Optional[Path]:
-    if checkpoint_path.is_dir():
-        return checkpoint_path
-    if checkpoint_path.is_file():
-        return checkpoint_path.parent
-    return None
-
-
-def _pick_unique_file(search_dir: Path, pattern: str) -> str:
-    matches = sorted(search_dir.glob(pattern))
-    if len(matches) == 1:
-        return str(matches[0])
-    if len(matches) > 1:
-        logger.warning(
-            f"Multiple files matching {pattern!r} under {search_dir}: "
-            f"{[m.name for m in matches]}. Pass the path explicitly to disambiguate."
-        )
-    return ""
-
-
-def _env_flag_enabled(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in _TRUE_ENV_VALUES
-
-
-def discover_ltx2_two_stage_paths(
-    checkpoint_path: Path,
-    spatial_upsampler_path: str = "",
-    distilled_lora_path: str = "",
-) -> Tuple[str, str]:
-    """Resolve LTX2 two-stage auxiliary checkpoint paths.
-
-    Explicit paths take precedence. Missing paths are discovered from the
-    checkpoint directory only when a pattern has exactly one match.
-    """
-    search_dir = _get_ltx2_auxiliary_search_dir(checkpoint_path)
-    if search_dir is None:
-        return spatial_upsampler_path, distilled_lora_path
-
-    if not spatial_upsampler_path:
-        spatial_upsampler_path = _pick_unique_file(
-            search_dir, "*spatial-upscaler*.safetensors"
-        ) or _pick_unique_file(search_dir, "*upsampler*.safetensors")
-    if not distilled_lora_path:
-        distilled_lora_path = _pick_unique_file(
-            search_dir, "*distilled-lora*.safetensors"
-        ) or _pick_unique_file(search_dir, "*distilled*lora*.safetensors")
-
-    return spatial_upsampler_path, distilled_lora_path
-
-
-def resolve_ltx2_pipeline_extra_attrs(
-    checkpoint_path: Path,
-    spatial_upsampler_path: str = "",
-    distilled_lora_path: str = "",
-) -> Dict[str, Any]:
-    """Resolve LTX2 pipeline-selection attributes before variant selection."""
-    if _env_flag_enabled(LTX2_FORCE_ONE_STAGE_ENV):
-        logger.info(
-            f"{LTX2_FORCE_ONE_STAGE_ENV} is enabled; skipping two-stage auxiliary "
-            "checkpoint discovery and promotion."
-        )
-        if spatial_upsampler_path or distilled_lora_path:
-            logger.info(
-                "Ignoring spatial_upsampler_path/distilled_lora_path because "
-                f"{LTX2_FORCE_ONE_STAGE_ENV} is enabled."
-            )
-        return {"force_one_stage_pipeline": True}
-
-    resolved_upsampler_path, resolved_lora_path = discover_ltx2_two_stage_paths(
-        checkpoint_path,
-        spatial_upsampler_path,
-        distilled_lora_path,
-    )
-    if not resolved_upsampler_path and not resolved_lora_path:
-        return {}
-
-    if bool(resolved_upsampler_path) != bool(resolved_lora_path):
-        if spatial_upsampler_path or distilled_lora_path:
-            missing = "distilled_lora_path" if resolved_upsampler_path else "spatial_upsampler_path"
-            raise ValueError(
-                "LTX2 two-stage pipeline requires both spatial_upsampler_path "
-                f"and distilled_lora_path, but {missing} was not provided or discovered."
-            )
-        logger.warning(
-            "Found only one LTX2 two-stage auxiliary checkpoint in "
-            f"{checkpoint_path}; falling back to the one-stage pipeline. "
-            "Pass both paths explicitly to enable two-stage inference."
-        )
-        return {}
-
-    if not spatial_upsampler_path:
-        logger.info(f"Discovered LTX2 spatial upsampler: {resolved_upsampler_path}")
-    if not distilled_lora_path:
-        logger.info(f"Discovered LTX2 distilled LoRA: {resolved_lora_path}")
-    return {
-        "spatial_upsampler_path": resolved_upsampler_path,
-        "distilled_lora_path": resolved_lora_path,
-    }
-
-
 # =============================================================================
 # DiffusionModelConfig - Internal configuration (merged/parsed)
 # =============================================================================
@@ -966,13 +862,11 @@ class DiffusionModelConfig(BaseModel):
         checkpoint_path = Path(checkpoint_dir)
         extra_attrs: Dict[str, Any] = {}
 
-        extra_attrs.update(
-            resolve_ltx2_pipeline_extra_attrs(
-                checkpoint_path,
-                args.spatial_upsampler_path if args else "",
-                args.distilled_lora_path if args else "",
-            )
-        )
+        if args:
+            if args.spatial_upsampler_path:
+                extra_attrs["spatial_upsampler_path"] = args.spatial_upsampler_path
+            if args.distilled_lora_path:
+                extra_attrs["distilled_lora_path"] = args.distilled_lora_path
 
         # Discover pipeline components (diffusers layout)
         components = discover_pipeline_components(checkpoint_path)
@@ -1012,6 +906,8 @@ class DiffusionModelConfig(BaseModel):
             if native_config is not None:
                 transformer_dict = native_config.get("transformer", {})
                 pretrained_config = SimpleNamespace(**transformer_dict)
+                if not getattr(pretrained_config, "_name_or_path", None):
+                    pretrained_config._name_or_path = str(checkpoint_path)
                 extra_attrs["monolithic_safetensors_config"] = native_config
 
                 # quantization_config lives as a separate safetensors metadata

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -423,6 +423,17 @@ class VisualGenArgs(StrictBaseModel):
         ),
     )
 
+    # LTX-2 specific option: force base one-stage pipeline even when two-stage
+    # auxiliary checkpoints are passed explicitly or discoverable next to the model.
+    one_stage_pipeline: bool = PydanticField(
+        False,
+        description=(
+            "Force the LTX-2 one-stage pipeline. When enabled, TensorRT-LLM "
+            "does not discover or use spatial_upsampler_path/distilled_lora_path "
+            "for two-stage pipeline promotion."
+        ),
+    )
+
     # HuggingFace Hub options
     revision: Optional[str] = PydanticField(
         None,
@@ -914,34 +925,49 @@ class DiffusionModelConfig(BaseModel):
         # Resolve LTX2 two-stage auxiliary paths before pipeline variant selection.
         explicit_spatial_upsampler_path = args.spatial_upsampler_path if args else ""
         explicit_distilled_lora_path = args.distilled_lora_path if args else ""
-        spatial_upsampler_path, distilled_lora_path = discover_ltx2_two_stage_paths(
-            checkpoint_path,
-            explicit_spatial_upsampler_path,
-            explicit_distilled_lora_path,
-        )
-        if bool(spatial_upsampler_path) != bool(distilled_lora_path):
-            if explicit_spatial_upsampler_path or explicit_distilled_lora_path:
-                missing = (
-                    "distilled_lora_path" if spatial_upsampler_path else "spatial_upsampler_path"
-                )
-                raise ValueError(
-                    "LTX2 two-stage pipeline requires both spatial_upsampler_path "
-                    f"and distilled_lora_path, but {missing} was not provided or discovered."
-                )
-            logger.warning(
-                "Found only one LTX2 two-stage auxiliary checkpoint in "
-                f"{checkpoint_path}; falling back to the one-stage pipeline. "
-                "Pass both paths explicitly to enable two-stage inference."
+        one_stage_pipeline = bool(getattr(args, "one_stage_pipeline", False))
+        if one_stage_pipeline:
+            extra_attrs["one_stage_pipeline"] = True
+            logger.info(
+                "LTX2 one_stage_pipeline is enabled; skipping two-stage auxiliary "
+                "checkpoint discovery and promotion."
             )
-            spatial_upsampler_path = ""
-            distilled_lora_path = ""
-        if spatial_upsampler_path and distilled_lora_path:
-            extra_attrs["spatial_upsampler_path"] = spatial_upsampler_path
-            extra_attrs["distilled_lora_path"] = distilled_lora_path
-            if not explicit_spatial_upsampler_path:
-                logger.info(f"Discovered LTX2 spatial upsampler: {spatial_upsampler_path}")
-            if not explicit_distilled_lora_path:
-                logger.info(f"Discovered LTX2 distilled LoRA: {distilled_lora_path}")
+            if explicit_spatial_upsampler_path or explicit_distilled_lora_path:
+                logger.info(
+                    "Ignoring spatial_upsampler_path/distilled_lora_path because "
+                    "one_stage_pipeline is enabled."
+                )
+        else:
+            spatial_upsampler_path, distilled_lora_path = discover_ltx2_two_stage_paths(
+                checkpoint_path,
+                explicit_spatial_upsampler_path,
+                explicit_distilled_lora_path,
+            )
+            if bool(spatial_upsampler_path) != bool(distilled_lora_path):
+                if explicit_spatial_upsampler_path or explicit_distilled_lora_path:
+                    missing = (
+                        "distilled_lora_path"
+                        if spatial_upsampler_path
+                        else "spatial_upsampler_path"
+                    )
+                    raise ValueError(
+                        "LTX2 two-stage pipeline requires both spatial_upsampler_path "
+                        f"and distilled_lora_path, but {missing} was not provided or discovered."
+                    )
+                logger.warning(
+                    "Found only one LTX2 two-stage auxiliary checkpoint in "
+                    f"{checkpoint_path}; falling back to the one-stage pipeline. "
+                    "Pass both paths explicitly to enable two-stage inference."
+                )
+                spatial_upsampler_path = ""
+                distilled_lora_path = ""
+            if spatial_upsampler_path and distilled_lora_path:
+                extra_attrs["spatial_upsampler_path"] = spatial_upsampler_path
+                extra_attrs["distilled_lora_path"] = distilled_lora_path
+                if not explicit_spatial_upsampler_path:
+                    logger.info(f"Discovered LTX2 spatial upsampler: {spatial_upsampler_path}")
+                if not explicit_distilled_lora_path:
+                    logger.info(f"Discovered LTX2 distilled LoRA: {distilled_lora_path}")
 
         # Discover pipeline components (diffusers layout)
         components = discover_pipeline_components(checkpoint_path)

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -1,4 +1,5 @@
 import json
+import os
 from enum import Enum
 from pathlib import Path
 from types import SimpleNamespace
@@ -22,6 +23,9 @@ from tensorrt_llm.quantization.mode import QuantAlgo
 # =============================================================================
 
 CacheBackendName = Literal["teacache", "cache_dit"]
+
+LTX2_FORCE_ONE_STAGE_ENV = "TLLM_LTX2_FORCE_ONE_STAGE_PIPELINE"
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 
 # =============================================================================
 # Pipeline component identifiers
@@ -420,17 +424,6 @@ class VisualGenArgs(StrictBaseModel):
         ),
     )
 
-    # LTX-2 specific option: force base one-stage pipeline even when two-stage
-    # auxiliary checkpoints are passed explicitly or discoverable next to the model.
-    one_stage_pipeline: bool = PydanticField(
-        False,
-        description=(
-            "Force the LTX-2 one-stage pipeline. When enabled, TensorRT-LLM "
-            "does not discover or use spatial_upsampler_path/distilled_lora_path "
-            "for two-stage pipeline promotion."
-        ),
-    )
-
     # HuggingFace Hub options
     revision: Optional[str] = PydanticField(
         None,
@@ -595,6 +588,10 @@ def _pick_unique_file(search_dir: Path, pattern: str) -> str:
     return ""
 
 
+def _env_flag_enabled(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUE_ENV_VALUES
+
+
 def discover_ltx2_two_stage_paths(
     checkpoint_path: Path,
     spatial_upsampler_path: str = "",
@@ -625,20 +622,19 @@ def resolve_ltx2_pipeline_extra_attrs(
     checkpoint_path: Path,
     spatial_upsampler_path: str = "",
     distilled_lora_path: str = "",
-    one_stage_pipeline: bool = False,
 ) -> Dict[str, Any]:
     """Resolve LTX2 pipeline-selection attributes before variant selection."""
-    if one_stage_pipeline:
+    if _env_flag_enabled(LTX2_FORCE_ONE_STAGE_ENV):
         logger.info(
-            "LTX2 one_stage_pipeline is enabled; skipping two-stage auxiliary "
+            f"{LTX2_FORCE_ONE_STAGE_ENV} is enabled; skipping two-stage auxiliary "
             "checkpoint discovery and promotion."
         )
         if spatial_upsampler_path or distilled_lora_path:
             logger.info(
                 "Ignoring spatial_upsampler_path/distilled_lora_path because "
-                "one_stage_pipeline is enabled."
+                f"{LTX2_FORCE_ONE_STAGE_ENV} is enabled."
             )
-        return {"one_stage_pipeline": True}
+        return {"force_one_stage_pipeline": True}
 
     resolved_upsampler_path, resolved_lora_path = discover_ltx2_two_stage_paths(
         checkpoint_path,
@@ -975,7 +971,6 @@ class DiffusionModelConfig(BaseModel):
                 checkpoint_path,
                 args.spatial_upsampler_path if args else "",
                 args.distilled_lora_path if args else "",
-                args.one_stage_pipeline if args else False,
             )
         )
 

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
 import json
 from enum import Enum
 from pathlib import Path
@@ -624,6 +621,57 @@ def discover_ltx2_two_stage_paths(
     return spatial_upsampler_path, distilled_lora_path
 
 
+def resolve_ltx2_pipeline_extra_attrs(
+    checkpoint_path: Path,
+    spatial_upsampler_path: str = "",
+    distilled_lora_path: str = "",
+    one_stage_pipeline: bool = False,
+) -> Dict[str, Any]:
+    """Resolve LTX2 pipeline-selection attributes before variant selection."""
+    if one_stage_pipeline:
+        logger.info(
+            "LTX2 one_stage_pipeline is enabled; skipping two-stage auxiliary "
+            "checkpoint discovery and promotion."
+        )
+        if spatial_upsampler_path or distilled_lora_path:
+            logger.info(
+                "Ignoring spatial_upsampler_path/distilled_lora_path because "
+                "one_stage_pipeline is enabled."
+            )
+        return {"one_stage_pipeline": True}
+
+    resolved_upsampler_path, resolved_lora_path = discover_ltx2_two_stage_paths(
+        checkpoint_path,
+        spatial_upsampler_path,
+        distilled_lora_path,
+    )
+    if not resolved_upsampler_path and not resolved_lora_path:
+        return {}
+
+    if bool(resolved_upsampler_path) != bool(resolved_lora_path):
+        if spatial_upsampler_path or distilled_lora_path:
+            missing = "distilled_lora_path" if resolved_upsampler_path else "spatial_upsampler_path"
+            raise ValueError(
+                "LTX2 two-stage pipeline requires both spatial_upsampler_path "
+                f"and distilled_lora_path, but {missing} was not provided or discovered."
+            )
+        logger.warning(
+            "Found only one LTX2 two-stage auxiliary checkpoint in "
+            f"{checkpoint_path}; falling back to the one-stage pipeline. "
+            "Pass both paths explicitly to enable two-stage inference."
+        )
+        return {}
+
+    if not spatial_upsampler_path:
+        logger.info(f"Discovered LTX2 spatial upsampler: {resolved_upsampler_path}")
+    if not distilled_lora_path:
+        logger.info(f"Discovered LTX2 distilled LoRA: {resolved_lora_path}")
+    return {
+        "spatial_upsampler_path": resolved_upsampler_path,
+        "distilled_lora_path": resolved_lora_path,
+    }
+
+
 # =============================================================================
 # DiffusionModelConfig - Internal configuration (merged/parsed)
 # =============================================================================
@@ -922,60 +970,14 @@ class DiffusionModelConfig(BaseModel):
         checkpoint_path = Path(checkpoint_dir)
         extra_attrs: Dict[str, Any] = {}
 
-        # Resolve LTX2 two-stage auxiliary paths before pipeline variant selection.
-        explicit_spatial_upsampler_path = args.spatial_upsampler_path if args else ""
-        explicit_distilled_lora_path = args.distilled_lora_path if args else ""
-        explicit_one_stage_pipeline = bool(getattr(args, "one_stage_pipeline", False))
-        cache_dit_forces_one_stage = isinstance(cache_cfg, CacheDiTConfig)
-        one_stage_pipeline = explicit_one_stage_pipeline or cache_dit_forces_one_stage
-        if one_stage_pipeline:
-            extra_attrs["one_stage_pipeline"] = True
-            if cache_dit_forces_one_stage and not explicit_one_stage_pipeline:
-                logger.info(
-                    "LTX2 Cache-DiT is only supported with the one-stage pipeline; "
-                    "skipping two-stage auxiliary checkpoint discovery and promotion."
-                )
-            else:
-                logger.info(
-                    "LTX2 one_stage_pipeline is enabled; skipping two-stage auxiliary "
-                    "checkpoint discovery and promotion."
-                )
-            if explicit_spatial_upsampler_path or explicit_distilled_lora_path:
-                logger.info(
-                    "Ignoring spatial_upsampler_path/distilled_lora_path because "
-                    "one_stage_pipeline is enabled."
-                )
-        else:
-            spatial_upsampler_path, distilled_lora_path = discover_ltx2_two_stage_paths(
+        extra_attrs.update(
+            resolve_ltx2_pipeline_extra_attrs(
                 checkpoint_path,
-                explicit_spatial_upsampler_path,
-                explicit_distilled_lora_path,
+                args.spatial_upsampler_path if args else "",
+                args.distilled_lora_path if args else "",
+                args.one_stage_pipeline if args else False,
             )
-            if bool(spatial_upsampler_path) != bool(distilled_lora_path):
-                if explicit_spatial_upsampler_path or explicit_distilled_lora_path:
-                    missing = (
-                        "distilled_lora_path"
-                        if spatial_upsampler_path
-                        else "spatial_upsampler_path"
-                    )
-                    raise ValueError(
-                        "LTX2 two-stage pipeline requires both spatial_upsampler_path "
-                        f"and distilled_lora_path, but {missing} was not provided or discovered."
-                    )
-                logger.warning(
-                    "Found only one LTX2 two-stage auxiliary checkpoint in "
-                    f"{checkpoint_path}; falling back to the one-stage pipeline. "
-                    "Pass both paths explicitly to enable two-stage inference."
-                )
-                spatial_upsampler_path = ""
-                distilled_lora_path = ""
-            if spatial_upsampler_path and distilled_lora_path:
-                extra_attrs["spatial_upsampler_path"] = spatial_upsampler_path
-                extra_attrs["distilled_lora_path"] = distilled_lora_path
-                if not explicit_spatial_upsampler_path:
-                    logger.info(f"Discovered LTX2 spatial upsampler: {spatial_upsampler_path}")
-                if not explicit_distilled_lora_path:
-                    logger.info(f"Discovered LTX2 distilled LoRA: {distilled_lora_path}")
+        )
 
         # Discover pipeline components (diffusers layout)
         components = discover_pipeline_components(checkpoint_path)

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from enum import Enum
 from pathlib import Path
@@ -403,8 +406,9 @@ class VisualGenArgs(StrictBaseModel):
         "",
         description=(
             "Path to the learned LatentUpsampler checkpoint (.safetensors). "
-            "Required for LTX-2 two-stage pipelines. When provided, the "
-            "pipeline auto-selects LTX2TwoStagesPipeline."
+            "Optional for LTX-2 two-stage pipelines. When provided, the "
+            "pipeline auto-selects LTX2TwoStagesPipeline. If omitted, "
+            "TensorRT-LLM tries to discover it in the checkpoint directory."
         ),
     )
 
@@ -413,8 +417,9 @@ class VisualGenArgs(StrictBaseModel):
         "",
         description=(
             "Path to the distilled LoRA checkpoint (.safetensors) used in "
-            "the stage 2 refinement pass. The LoRA weights are merged into "
-            "the transformer for stage 2 denoising and un-merged afterwards."
+            "the stage 2 refinement pass. If omitted, TensorRT-LLM tries to "
+            "discover it in the checkpoint directory. The LoRA weights are "
+            "merged into the transformer for stage 2 denoising and un-merged afterwards."
         ),
     )
 
@@ -560,6 +565,52 @@ def discover_pipeline_components(checkpoint_path: Path) -> Dict[str, Path]:
 def create_attention_metadata_state() -> Dict[str, Any]:
     """Create model-scoped attention metadata state for TRTLLM visual-gen backend."""
     return {"metadata": None, "capacity": (0, 0)}
+
+
+def _get_ltx2_auxiliary_search_dir(checkpoint_path: Path) -> Optional[Path]:
+    if checkpoint_path.is_dir():
+        return checkpoint_path
+    if checkpoint_path.is_file():
+        return checkpoint_path.parent
+    return None
+
+
+def _pick_unique_file(search_dir: Path, pattern: str) -> str:
+    matches = sorted(search_dir.glob(pattern))
+    if len(matches) == 1:
+        return str(matches[0])
+    if len(matches) > 1:
+        logger.warning(
+            f"Multiple files matching {pattern!r} under {search_dir}: "
+            f"{[m.name for m in matches]}. Pass the path explicitly to disambiguate."
+        )
+    return ""
+
+
+def discover_ltx2_two_stage_paths(
+    checkpoint_path: Path,
+    spatial_upsampler_path: str = "",
+    distilled_lora_path: str = "",
+) -> Tuple[str, str]:
+    """Resolve LTX2 two-stage auxiliary checkpoint paths.
+
+    Explicit paths take precedence. Missing paths are discovered from the
+    checkpoint directory only when a pattern has exactly one match.
+    """
+    search_dir = _get_ltx2_auxiliary_search_dir(checkpoint_path)
+    if search_dir is None:
+        return spatial_upsampler_path, distilled_lora_path
+
+    if not spatial_upsampler_path:
+        spatial_upsampler_path = _pick_unique_file(
+            search_dir, "*spatial-upscaler*.safetensors"
+        ) or _pick_unique_file(search_dir, "*upsampler*.safetensors")
+    if not distilled_lora_path:
+        distilled_lora_path = _pick_unique_file(
+            search_dir, "*distilled-lora*.safetensors"
+        ) or _pick_unique_file(search_dir, "*distilled*lora*.safetensors")
+
+    return spatial_upsampler_path, distilled_lora_path
 
 
 # =============================================================================
@@ -860,11 +911,37 @@ class DiffusionModelConfig(BaseModel):
         checkpoint_path = Path(checkpoint_dir)
         extra_attrs: Dict[str, Any] = {}
 
-        # Propagate two-stage paths into extra_attrs for pipeline use
-        if args and args.spatial_upsampler_path:
-            extra_attrs["spatial_upsampler_path"] = args.spatial_upsampler_path
-        if args and args.distilled_lora_path:
-            extra_attrs["distilled_lora_path"] = args.distilled_lora_path
+        # Resolve LTX2 two-stage auxiliary paths before pipeline variant selection.
+        explicit_spatial_upsampler_path = args.spatial_upsampler_path if args else ""
+        explicit_distilled_lora_path = args.distilled_lora_path if args else ""
+        spatial_upsampler_path, distilled_lora_path = discover_ltx2_two_stage_paths(
+            checkpoint_path,
+            explicit_spatial_upsampler_path,
+            explicit_distilled_lora_path,
+        )
+        if bool(spatial_upsampler_path) != bool(distilled_lora_path):
+            if explicit_spatial_upsampler_path or explicit_distilled_lora_path:
+                missing = (
+                    "distilled_lora_path" if spatial_upsampler_path else "spatial_upsampler_path"
+                )
+                raise ValueError(
+                    "LTX2 two-stage pipeline requires both spatial_upsampler_path "
+                    f"and distilled_lora_path, but {missing} was not provided or discovered."
+                )
+            logger.warning(
+                "Found only one LTX2 two-stage auxiliary checkpoint in "
+                f"{checkpoint_path}; falling back to the one-stage pipeline. "
+                "Pass both paths explicitly to enable two-stage inference."
+            )
+            spatial_upsampler_path = ""
+            distilled_lora_path = ""
+        if spatial_upsampler_path and distilled_lora_path:
+            extra_attrs["spatial_upsampler_path"] = spatial_upsampler_path
+            extra_attrs["distilled_lora_path"] = distilled_lora_path
+            if not explicit_spatial_upsampler_path:
+                logger.info(f"Discovered LTX2 spatial upsampler: {spatial_upsampler_path}")
+            if not explicit_distilled_lora_path:
+                logger.info(f"Discovered LTX2 distilled LoRA: {distilled_lora_path}")
 
         # Discover pipeline components (diffusers layout)
         components = discover_pipeline_components(checkpoint_path)

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -925,13 +925,21 @@ class DiffusionModelConfig(BaseModel):
         # Resolve LTX2 two-stage auxiliary paths before pipeline variant selection.
         explicit_spatial_upsampler_path = args.spatial_upsampler_path if args else ""
         explicit_distilled_lora_path = args.distilled_lora_path if args else ""
-        one_stage_pipeline = bool(getattr(args, "one_stage_pipeline", False))
+        explicit_one_stage_pipeline = bool(getattr(args, "one_stage_pipeline", False))
+        cache_dit_forces_one_stage = isinstance(cache_cfg, CacheDiTConfig)
+        one_stage_pipeline = explicit_one_stage_pipeline or cache_dit_forces_one_stage
         if one_stage_pipeline:
             extra_attrs["one_stage_pipeline"] = True
-            logger.info(
-                "LTX2 one_stage_pipeline is enabled; skipping two-stage auxiliary "
-                "checkpoint discovery and promotion."
-            )
+            if cache_dit_forces_one_stage and not explicit_one_stage_pipeline:
+                logger.info(
+                    "LTX2 Cache-DiT is only supported with the one-stage pipeline; "
+                    "skipping two-stage auxiliary checkpoint discovery and promotion."
+                )
+            else:
+                logger.info(
+                    "LTX2 one_stage_pipeline is enabled; skipping two-stage auxiliary "
+                    "checkpoint discovery and promotion."
+                )
             if explicit_spatial_upsampler_path or explicit_distilled_lora_path:
                 logger.info(
                     "Ignoring spatial_upsampler_path/distilled_lora_path because "

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -5,9 +5,10 @@
 import copy
 import gc
 import json
+import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import safetensors.torch
 import torch
@@ -44,6 +45,95 @@ from .ltx2_core.types import (
 )
 from .ltx2_core.video_vae import TilingConfig, VideoDecoderConfigurator, VideoEncoderConfigurator
 from .transformer_ltx2 import LTXModel, LTXModelType
+
+LTX2_FORCE_ONE_STAGE_ENV = "TLLM_LTX2_FORCE_ONE_STAGE_PIPELINE"
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
+
+
+def ltx2_force_one_stage_enabled() -> bool:
+    return os.environ.get(LTX2_FORCE_ONE_STAGE_ENV, "").strip().lower() in _TRUE_ENV_VALUES
+
+
+def _get_ltx2_auxiliary_search_dir(checkpoint_path: Path) -> Optional[Path]:
+    if checkpoint_path.is_dir():
+        return checkpoint_path
+    if checkpoint_path.is_file():
+        return checkpoint_path.parent
+    return None
+
+
+def _pick_unique_file(search_dir: Path, pattern: str) -> str:
+    matches = sorted(search_dir.glob(pattern))
+    if len(matches) == 1:
+        return str(matches[0])
+    if len(matches) > 1:
+        logger.warning(
+            f"Multiple files matching {pattern!r} under {search_dir}: "
+            f"{[m.name for m in matches]}. Pass the path explicitly to disambiguate."
+        )
+    return ""
+
+
+def discover_ltx2_two_stage_paths(
+    checkpoint_path: Path,
+    spatial_upsampler_path: str = "",
+    distilled_lora_path: str = "",
+) -> Tuple[str, str]:
+    """Resolve LTX2 two-stage auxiliary checkpoint paths."""
+    search_dir = _get_ltx2_auxiliary_search_dir(checkpoint_path)
+    if search_dir is None:
+        return spatial_upsampler_path, distilled_lora_path
+
+    if not spatial_upsampler_path:
+        spatial_upsampler_path = _pick_unique_file(
+            search_dir, "*spatial-upscaler*.safetensors"
+        ) or _pick_unique_file(search_dir, "*upsampler*.safetensors")
+    if not distilled_lora_path:
+        distilled_lora_path = _pick_unique_file(
+            search_dir, "*distilled-lora*.safetensors"
+        ) or _pick_unique_file(search_dir, "*distilled*lora*.safetensors")
+
+    return spatial_upsampler_path, distilled_lora_path
+
+
+def resolve_ltx2_pipeline_extra_attrs(
+    checkpoint_path: Path,
+    extra_attrs: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Resolve LTX2 pipeline-selection attributes before variant selection."""
+    extra_attrs = dict(extra_attrs or {})
+    spatial_upsampler_path = extra_attrs.get("spatial_upsampler_path", "")
+    distilled_lora_path = extra_attrs.get("distilled_lora_path", "")
+    resolved_upsampler_path, resolved_lora_path = discover_ltx2_two_stage_paths(
+        checkpoint_path,
+        spatial_upsampler_path,
+        distilled_lora_path,
+    )
+    if not resolved_upsampler_path and not resolved_lora_path:
+        return {}
+
+    if bool(resolved_upsampler_path) != bool(resolved_lora_path):
+        if spatial_upsampler_path or distilled_lora_path:
+            missing = "distilled_lora_path" if resolved_upsampler_path else "spatial_upsampler_path"
+            raise ValueError(
+                "LTX2 two-stage pipeline requires both spatial_upsampler_path "
+                f"and distilled_lora_path, but {missing} was not provided or discovered."
+            )
+        logger.warning(
+            "Found only one LTX2 two-stage auxiliary checkpoint in "
+            f"{checkpoint_path}; falling back to the one-stage pipeline. "
+            "Pass both paths explicitly to enable two-stage inference."
+        )
+        return {}
+
+    if not spatial_upsampler_path:
+        logger.info(f"Discovered LTX2 spatial upsampler: {resolved_upsampler_path}")
+    if not distilled_lora_path:
+        logger.info(f"Discovered LTX2 distilled LoRA: {resolved_lora_path}")
+    return {
+        "spatial_upsampler_path": resolved_upsampler_path,
+        "distilled_lora_path": resolved_lora_path,
+    }
 
 
 def _assert_resolution(height: int, width: int, *, is_two_stage: bool = False) -> None:
@@ -487,8 +577,19 @@ class LTX2Pipeline(BasePipeline):
 
     @classmethod
     def resolve_variant(cls, config):
-        if config.extra_attrs.get("force_one_stage_pipeline"):
+        if getattr(config, "cache_backend", None) == "cache_dit":
+            logger.info("Cache-DiT is enabled; forcing one-stage LTX2 pipeline.")
             return cls
+
+        if ltx2_force_one_stage_enabled():
+            logger.info(f"{LTX2_FORCE_ONE_STAGE_ENV} is enabled; forcing one-stage LTX2 pipeline.")
+            return cls
+
+        checkpoint_path = getattr(config.pretrained_config, "_name_or_path", "")
+        if checkpoint_path:
+            config.extra_attrs.update(
+                resolve_ltx2_pipeline_extra_attrs(Path(checkpoint_path), config.extra_attrs)
+            )
         if config.extra_attrs.get("spatial_upsampler_path") and config.extra_attrs.get(
             "distilled_lora_path"
         ):

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -487,7 +487,7 @@ class LTX2Pipeline(BasePipeline):
 
     @classmethod
     def resolve_variant(cls, config):
-        if config.extra_attrs.get("one_stage_pipeline"):
+        if config.extra_attrs.get("force_one_stage_pipeline"):
             return cls
         if config.extra_attrs.get("spatial_upsampler_path") and config.extra_attrs.get(
             "distilled_lora_path"

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -487,6 +487,8 @@ class LTX2Pipeline(BasePipeline):
 
     @classmethod
     def resolve_variant(cls, config):
+        if config.extra_attrs.get("one_stage_pipeline"):
+            return cls
         if config.extra_attrs.get("spatial_upsampler_path") and config.extra_attrs.get(
             "distilled_lora_path"
         ):

--- a/tests/unittest/_torch/visual_gen/test_cache_dit.py
+++ b/tests/unittest/_torch/visual_gen/test_cache_dit.py
@@ -345,10 +345,7 @@ class TestCacheDiTRealPipelineForward:
                 if pipeline is not None:
                     self._teardown_cache_dit(pipeline)
 
-    def test_ltx2_cache_dit_skips_blocks_after_forward(self, monkeypatch):
-        from tensorrt_llm._torch.visual_gen.config import LTX2_FORCE_ONE_STAGE_ENV
-
-        monkeypatch.setenv(LTX2_FORCE_ONE_STAGE_ENV, "1")
+    def test_ltx2_cache_dit_skips_blocks_after_forward(self):
         ckpt = _resolve_ltx2_checkpoint()
         text_enc = _resolve_ltx2_text_encoder()
         if ckpt is None or text_enc is None:

--- a/tests/unittest/_torch/visual_gen/test_cache_dit.py
+++ b/tests/unittest/_torch/visual_gen/test_cache_dit.py
@@ -345,7 +345,10 @@ class TestCacheDiTRealPipelineForward:
                 if pipeline is not None:
                     self._teardown_cache_dit(pipeline)
 
-    def test_ltx2_cache_dit_skips_blocks_after_forward(self):
+    def test_ltx2_cache_dit_skips_blocks_after_forward(self, monkeypatch):
+        from tensorrt_llm._torch.visual_gen.config import LTX2_FORCE_ONE_STAGE_ENV
+
+        monkeypatch.setenv(LTX2_FORCE_ONE_STAGE_ENV, "1")
         ckpt = _resolve_ltx2_checkpoint()
         text_enc = _resolve_ltx2_text_encoder()
         if ckpt is None or text_enc is None:

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -22,7 +22,6 @@ from test_common.llm_data import llm_models_root
 from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm._torch.visual_gen.config import (
     AttentionConfig,
-    CacheDiTConfig,
     DiffusionModelConfig,
     PipelineComponent,
     VisualGenArgs,
@@ -827,33 +826,6 @@ class TestLTX2OneStagePipelineConfig:
             spatial_upsampler_path="/fake/upsampler.safetensors",
             distilled_lora_path="/fake/lora.safetensors",
             one_stage_pipeline=True,
-        )
-        config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
-
-        assert config.extra_attrs["one_stage_pipeline"] is True
-        assert "spatial_upsampler_path" not in config.extra_attrs
-        assert "distilled_lora_path" not in config.extra_attrs
-
-    def test_cache_dit_disables_auxiliary_discovery(self, tmp_path):
-        checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
-        (checkpoint_path / "ltx-2-spatial-upscaler-x2-1.0.safetensors").touch()
-        (checkpoint_path / "ltx-2-19b-distilled-lora-384.safetensors").touch()
-
-        args = VisualGenArgs(checkpoint_path=str(checkpoint_path), cache=CacheDiTConfig())
-        config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
-
-        assert config.extra_attrs["one_stage_pipeline"] is True
-        assert "spatial_upsampler_path" not in config.extra_attrs
-        assert "distilled_lora_path" not in config.extra_attrs
-
-    def test_cache_dit_ignores_explicit_auxiliary_paths(self, tmp_path):
-        checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
-
-        args = VisualGenArgs(
-            checkpoint_path=str(checkpoint_path),
-            spatial_upsampler_path="/fake/upsampler.safetensors",
-            distilled_lora_path="/fake/lora.safetensors",
-            cache=CacheDiTConfig(),
         )
         config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
 

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -21,12 +21,13 @@ from test_common.llm_data import llm_models_root
 
 from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm._torch.visual_gen.config import (
-    LTX2_FORCE_ONE_STAGE_ENV,
     AttentionConfig,
+    CacheDiTConfig,
     DiffusionModelConfig,
     PipelineComponent,
     VisualGenArgs,
 )
+from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2_FORCE_ONE_STAGE_ENV
 from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
 
 os.environ.setdefault("TLLM_DISABLE_MPI", "1")
@@ -732,8 +733,9 @@ class TestTwoStageLoRAFileLoading:
 class TestTwoStagePipelineVariantResolution:
     """Test that LTX2Pipeline.resolve_variant selects the correct class."""
 
-    def test_resolve_variant_returns_two_stage_when_configured(self):
+    def test_resolve_variant_returns_two_stage_when_configured(self, monkeypatch):
         """When both upsampler and LoRA paths are set, resolve_variant returns TwoStages."""
+        monkeypatch.delenv(LTX2_FORCE_ONE_STAGE_ENV, raising=False)
         from unittest.mock import MagicMock
 
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
@@ -742,6 +744,7 @@ class TestTwoStagePipelineVariantResolution:
         )
 
         config = MagicMock()
+        config.pretrained_config._name_or_path = ""
         config.extra_attrs = {
             "spatial_upsampler_path": "/fake/upsampler.safetensors",
             "distilled_lora_path": "/fake/lora.safetensors",
@@ -750,15 +753,16 @@ class TestTwoStagePipelineVariantResolution:
         result = LTX2Pipeline.resolve_variant(config)
         assert result is LTX2TwoStagesPipeline
 
-    def test_resolve_variant_honors_force_one_stage_pipeline(self):
-        """force_one_stage_pipeline should prevent promotion even when two-stage paths exist."""
+    def test_resolve_variant_honors_force_one_stage_env(self, monkeypatch):
+        """The env knob should prevent promotion even when two-stage paths exist."""
         from unittest.mock import MagicMock
 
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
 
+        monkeypatch.setenv(LTX2_FORCE_ONE_STAGE_ENV, "1")
         config = MagicMock()
+        config.pretrained_config._name_or_path = ""
         config.extra_attrs = {
-            "force_one_stage_pipeline": True,
             "spatial_upsampler_path": "/fake/upsampler.safetensors",
             "distilled_lora_path": "/fake/lora.safetensors",
         }
@@ -773,6 +777,7 @@ class TestTwoStagePipelineVariantResolution:
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
 
         config = MagicMock()
+        config.pretrained_config._name_or_path = ""
         config.extra_attrs = {}
 
         result = LTX2Pipeline.resolve_variant(config)
@@ -785,6 +790,7 @@ class TestTwoStagePipelineVariantResolution:
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
 
         config = MagicMock()
+        config.pretrained_config._name_or_path = ""
         config.extra_attrs = {"spatial_upsampler_path": "/fake/upsampler.safetensors"}
 
         result = LTX2Pipeline.resolve_variant(config)
@@ -792,9 +798,14 @@ class TestTwoStagePipelineVariantResolution:
 
 
 class TestLTX2ForceOneStageEnv:
-    """Test force-one-stage env-var behavior before pipeline construction."""
+    """Test force-one-stage env-var behavior during LTX2 variant selection."""
 
     def test_two_stage_auxiliary_paths_are_discovered_by_default(self, tmp_path, monkeypatch):
+        from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
+        from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2_two_stages import (
+            LTX2TwoStagesPipeline,
+        )
+
         monkeypatch.delenv(LTX2_FORCE_ONE_STAGE_ENV, raising=False)
         checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
         upsampler_path = checkpoint_path / "ltx-2-spatial-upscaler-x2-1.0.safetensors"
@@ -805,23 +816,32 @@ class TestLTX2ForceOneStageEnv:
         args = VisualGenArgs(checkpoint_path=str(checkpoint_path))
         config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
 
+        assert LTX2Pipeline.resolve_variant(config) is LTX2TwoStagesPipeline
         assert config.extra_attrs["spatial_upsampler_path"] == str(upsampler_path)
         assert config.extra_attrs["distilled_lora_path"] == str(lora_path)
 
-    def test_force_one_stage_env_disables_auxiliary_discovery(self, tmp_path, monkeypatch):
+    def test_force_one_stage_env_skips_auto_discovery(self, tmp_path, monkeypatch):
+        from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
+
         monkeypatch.setenv(LTX2_FORCE_ONE_STAGE_ENV, "1")
         checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
-        (checkpoint_path / "ltx-2-spatial-upscaler-x2-1.0.safetensors").touch()
-        (checkpoint_path / "ltx-2-19b-distilled-lora-384.safetensors").touch()
+        upsampler_path = checkpoint_path / "ltx-2-spatial-upscaler-x2-1.0.safetensors"
+        lora_path = checkpoint_path / "ltx-2-19b-distilled-lora-384.safetensors"
+        upsampler_path.touch()
+        lora_path.touch()
 
         args = VisualGenArgs(checkpoint_path=str(checkpoint_path))
         config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
 
-        assert config.extra_attrs["force_one_stage_pipeline"] is True
+        assert LTX2Pipeline.resolve_variant(config) is LTX2Pipeline
         assert "spatial_upsampler_path" not in config.extra_attrs
         assert "distilled_lora_path" not in config.extra_attrs
 
-    def test_force_one_stage_env_ignores_explicit_auxiliary_paths(self, tmp_path, monkeypatch):
+    def test_force_one_stage_env_prevents_promotion_with_explicit_auxiliary_paths(
+        self, tmp_path, monkeypatch
+    ):
+        from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
+
         monkeypatch.setenv(LTX2_FORCE_ONE_STAGE_ENV, "1")
         checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
 
@@ -832,9 +852,30 @@ class TestLTX2ForceOneStageEnv:
         )
         config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
 
-        assert config.extra_attrs["force_one_stage_pipeline"] is True
-        assert "spatial_upsampler_path" not in config.extra_attrs
-        assert "distilled_lora_path" not in config.extra_attrs
+        assert config.extra_attrs["spatial_upsampler_path"] == "/fake/upsampler.safetensors"
+        assert config.extra_attrs["distilled_lora_path"] == "/fake/lora.safetensors"
+        assert LTX2Pipeline.resolve_variant(config) is LTX2Pipeline
+
+    def test_cache_dit_config_prevents_promotion_with_explicit_auxiliary_paths(
+        self, tmp_path, monkeypatch
+    ):
+        from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
+
+        monkeypatch.delenv(LTX2_FORCE_ONE_STAGE_ENV, raising=False)
+        checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
+
+        args = VisualGenArgs(
+            checkpoint_path=str(checkpoint_path),
+            cache=CacheDiTConfig(),
+            spatial_upsampler_path="/fake/upsampler.safetensors",
+            distilled_lora_path="/fake/lora.safetensors",
+        )
+        config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
+
+        assert config.cache_backend == "cache_dit"
+        assert config.extra_attrs["spatial_upsampler_path"] == "/fake/upsampler.safetensors"
+        assert config.extra_attrs["distilled_lora_path"] == "/fake/lora.safetensors"
+        assert LTX2Pipeline.resolve_variant(config) is LTX2Pipeline
 
 
 class TestTwoStageUpsamplerBuildingBlocks:

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -11,6 +11,7 @@ Requires LTX-2 checkpoint. Does NOT require the LTX-2 reference code.
 """
 
 import gc
+import json
 import os
 
 import pytest
@@ -19,7 +20,12 @@ import torch.nn.functional as F
 from test_common.llm_data import llm_models_root
 
 from tensorrt_llm._torch.modules.linear import Linear
-from tensorrt_llm._torch.visual_gen.config import AttentionConfig, PipelineComponent, VisualGenArgs
+from tensorrt_llm._torch.visual_gen.config import (
+    AttentionConfig,
+    DiffusionModelConfig,
+    PipelineComponent,
+    VisualGenArgs,
+)
 from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
 
 os.environ.setdefault("TLLM_DISABLE_MPI", "1")
@@ -46,6 +52,17 @@ SKIP_COMPONENTS = [
     PipelineComponent.VAE,
     PipelineComponent.SCHEDULER,
 ]
+
+
+def _write_minimal_ltx2_diffusers_checkpoint(tmp_path):
+    checkpoint_path = tmp_path / "ltx2"
+    transformer_path = checkpoint_path / "transformer"
+    transformer_path.mkdir(parents=True)
+    (checkpoint_path / "model_index.json").write_text(
+        json.dumps({"transformer": ["tensorrt_llm", "LTX2Transformer"]})
+    )
+    (transformer_path / "config.json").write_text(json.dumps({"_class_name": "LTX2"}))
+    return checkpoint_path
 
 
 def _get_ltx2_transformer_inputs(transformer, device="cuda", dtype=torch.bfloat16):
@@ -732,6 +749,22 @@ class TestTwoStagePipelineVariantResolution:
         result = LTX2Pipeline.resolve_variant(config)
         assert result is LTX2TwoStagesPipeline
 
+    def test_resolve_variant_honors_one_stage_pipeline(self):
+        """one_stage_pipeline should prevent promotion even when two-stage paths exist."""
+        from unittest.mock import MagicMock
+
+        from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
+
+        config = MagicMock()
+        config.extra_attrs = {
+            "one_stage_pipeline": True,
+            "spatial_upsampler_path": "/fake/upsampler.safetensors",
+            "distilled_lora_path": "/fake/lora.safetensors",
+        }
+
+        result = LTX2Pipeline.resolve_variant(config)
+        assert result is LTX2Pipeline
+
     def test_resolve_variant_returns_base_without_two_stage_config(self):
         """Without upsampler/LoRA paths, resolve_variant returns base LTX2Pipeline."""
         from unittest.mock import MagicMock
@@ -755,6 +788,50 @@ class TestTwoStagePipelineVariantResolution:
 
         result = LTX2Pipeline.resolve_variant(config)
         assert result is LTX2Pipeline
+
+
+class TestLTX2OneStagePipelineConfig:
+    """Test one_stage_pipeline config behavior before pipeline construction."""
+
+    def test_two_stage_auxiliary_paths_are_discovered_by_default(self, tmp_path):
+        checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
+        upsampler_path = checkpoint_path / "ltx-2-spatial-upscaler-x2-1.0.safetensors"
+        lora_path = checkpoint_path / "ltx-2-19b-distilled-lora-384.safetensors"
+        upsampler_path.touch()
+        lora_path.touch()
+
+        args = VisualGenArgs(checkpoint_path=str(checkpoint_path))
+        config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
+
+        assert config.extra_attrs["spatial_upsampler_path"] == str(upsampler_path)
+        assert config.extra_attrs["distilled_lora_path"] == str(lora_path)
+
+    def test_one_stage_pipeline_disables_auxiliary_discovery(self, tmp_path):
+        checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
+        (checkpoint_path / "ltx-2-spatial-upscaler-x2-1.0.safetensors").touch()
+        (checkpoint_path / "ltx-2-19b-distilled-lora-384.safetensors").touch()
+
+        args = VisualGenArgs(checkpoint_path=str(checkpoint_path), one_stage_pipeline=True)
+        config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
+
+        assert config.extra_attrs["one_stage_pipeline"] is True
+        assert "spatial_upsampler_path" not in config.extra_attrs
+        assert "distilled_lora_path" not in config.extra_attrs
+
+    def test_one_stage_pipeline_ignores_explicit_auxiliary_paths(self, tmp_path):
+        checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
+
+        args = VisualGenArgs(
+            checkpoint_path=str(checkpoint_path),
+            spatial_upsampler_path="/fake/upsampler.safetensors",
+            distilled_lora_path="/fake/lora.safetensors",
+            one_stage_pipeline=True,
+        )
+        config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
+
+        assert config.extra_attrs["one_stage_pipeline"] is True
+        assert "spatial_upsampler_path" not in config.extra_attrs
+        assert "distilled_lora_path" not in config.extra_attrs
 
 
 class TestTwoStageUpsamplerBuildingBlocks:

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -21,6 +21,7 @@ from test_common.llm_data import llm_models_root
 
 from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm._torch.visual_gen.config import (
+    LTX2_FORCE_ONE_STAGE_ENV,
     AttentionConfig,
     DiffusionModelConfig,
     PipelineComponent,
@@ -749,15 +750,15 @@ class TestTwoStagePipelineVariantResolution:
         result = LTX2Pipeline.resolve_variant(config)
         assert result is LTX2TwoStagesPipeline
 
-    def test_resolve_variant_honors_one_stage_pipeline(self):
-        """one_stage_pipeline should prevent promotion even when two-stage paths exist."""
+    def test_resolve_variant_honors_force_one_stage_pipeline(self):
+        """force_one_stage_pipeline should prevent promotion even when two-stage paths exist."""
         from unittest.mock import MagicMock
 
         from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2Pipeline
 
         config = MagicMock()
         config.extra_attrs = {
-            "one_stage_pipeline": True,
+            "force_one_stage_pipeline": True,
             "spatial_upsampler_path": "/fake/upsampler.safetensors",
             "distilled_lora_path": "/fake/lora.safetensors",
         }
@@ -790,10 +791,11 @@ class TestTwoStagePipelineVariantResolution:
         assert result is LTX2Pipeline
 
 
-class TestLTX2OneStagePipelineConfig:
-    """Test one_stage_pipeline config behavior before pipeline construction."""
+class TestLTX2ForceOneStageEnv:
+    """Test force-one-stage env-var behavior before pipeline construction."""
 
-    def test_two_stage_auxiliary_paths_are_discovered_by_default(self, tmp_path):
+    def test_two_stage_auxiliary_paths_are_discovered_by_default(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(LTX2_FORCE_ONE_STAGE_ENV, raising=False)
         checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
         upsampler_path = checkpoint_path / "ltx-2-spatial-upscaler-x2-1.0.safetensors"
         lora_path = checkpoint_path / "ltx-2-19b-distilled-lora-384.safetensors"
@@ -806,30 +808,31 @@ class TestLTX2OneStagePipelineConfig:
         assert config.extra_attrs["spatial_upsampler_path"] == str(upsampler_path)
         assert config.extra_attrs["distilled_lora_path"] == str(lora_path)
 
-    def test_one_stage_pipeline_disables_auxiliary_discovery(self, tmp_path):
+    def test_force_one_stage_env_disables_auxiliary_discovery(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(LTX2_FORCE_ONE_STAGE_ENV, "1")
         checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
         (checkpoint_path / "ltx-2-spatial-upscaler-x2-1.0.safetensors").touch()
         (checkpoint_path / "ltx-2-19b-distilled-lora-384.safetensors").touch()
 
-        args = VisualGenArgs(checkpoint_path=str(checkpoint_path), one_stage_pipeline=True)
+        args = VisualGenArgs(checkpoint_path=str(checkpoint_path))
         config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
 
-        assert config.extra_attrs["one_stage_pipeline"] is True
+        assert config.extra_attrs["force_one_stage_pipeline"] is True
         assert "spatial_upsampler_path" not in config.extra_attrs
         assert "distilled_lora_path" not in config.extra_attrs
 
-    def test_one_stage_pipeline_ignores_explicit_auxiliary_paths(self, tmp_path):
+    def test_force_one_stage_env_ignores_explicit_auxiliary_paths(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(LTX2_FORCE_ONE_STAGE_ENV, "1")
         checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
 
         args = VisualGenArgs(
             checkpoint_path=str(checkpoint_path),
             spatial_upsampler_path="/fake/upsampler.safetensors",
             distilled_lora_path="/fake/lora.safetensors",
-            one_stage_pipeline=True,
         )
         config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
 
-        assert config.extra_attrs["one_stage_pipeline"] is True
+        assert config.extra_attrs["force_one_stage_pipeline"] is True
         assert "spatial_upsampler_path" not in config.extra_attrs
         assert "distilled_lora_path" not in config.extra_attrs
 

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -22,6 +22,7 @@ from test_common.llm_data import llm_models_root
 from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm._torch.visual_gen.config import (
     AttentionConfig,
+    CacheDiTConfig,
     DiffusionModelConfig,
     PipelineComponent,
     VisualGenArgs,
@@ -826,6 +827,33 @@ class TestLTX2OneStagePipelineConfig:
             spatial_upsampler_path="/fake/upsampler.safetensors",
             distilled_lora_path="/fake/lora.safetensors",
             one_stage_pipeline=True,
+        )
+        config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
+
+        assert config.extra_attrs["one_stage_pipeline"] is True
+        assert "spatial_upsampler_path" not in config.extra_attrs
+        assert "distilled_lora_path" not in config.extra_attrs
+
+    def test_cache_dit_disables_auxiliary_discovery(self, tmp_path):
+        checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
+        (checkpoint_path / "ltx-2-spatial-upscaler-x2-1.0.safetensors").touch()
+        (checkpoint_path / "ltx-2-19b-distilled-lora-384.safetensors").touch()
+
+        args = VisualGenArgs(checkpoint_path=str(checkpoint_path), cache=CacheDiTConfig())
+        config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
+
+        assert config.extra_attrs["one_stage_pipeline"] is True
+        assert "spatial_upsampler_path" not in config.extra_attrs
+        assert "distilled_lora_path" not in config.extra_attrs
+
+    def test_cache_dit_ignores_explicit_auxiliary_paths(self, tmp_path):
+        checkpoint_path = _write_minimal_ltx2_diffusers_checkpoint(tmp_path)
+
+        args = VisualGenArgs(
+            checkpoint_path=str(checkpoint_path),
+            spatial_upsampler_path="/fake/upsampler.safetensors",
+            distilled_lora_path="/fake/lora.safetensors",
+            cache=CacheDiTConfig(),
         )
         config = DiffusionModelConfig.from_pretrained(str(checkpoint_path), args=args)
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The LTX2 visual generation example now automatically discovers spatial upsampler and distilled LoRA paths from checkpoint directories when CLI arguments are not explicitly provided, with informative logging for successful discoveries and warnings when multiple candidates are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This PR refactors LTX2 two-stage pipeline selection so it is handled in the core VisualGen config flow. spatial_upsampler_path and distilled_lora_path can now be provided through VisualGenArgs, and when omitted, TensorRT-LLM attempts to discover matching auxiliary checkpoints next to the LTX2 model checkpoint. When both auxiliary checkpoints are available, the base LTX2Pipeline is automatically promoted to LTX2TwoStagesPipeline.

This PR also adds an explicit one_stage_pipeline override for debugging, feature testing, and cases where users need to force one-stage execution even when two-stage assets are present. When enabled, TensorRT-LLM skips two-stage auxiliary checkpoint discovery and prevents promotion to LTX2TwoStagesPipeline. Unit coverage was added for default two-stage discovery/promotion, incomplete auxiliary checkpoint fallback, and the forced one-stage override.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
