### PR TITLE
[None][feat] Add BaseLlmArgs.force_deterministic field

### DIFF
--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -53,13 +53,6 @@ from .tokenizer import TokenizerBase, _xgrammar_tokenizer_info
 from .utils import (append_docstring, exception_handler, get_device_count,
                     logger_debug, set_api_status)
 
-# Snapshot FORCE_DETERMINISTIC once at module import so we can distinguish
-# a user-set value (preserved) from a value set by a prior
-# LLM(force_deterministic=True) instance in the same process (safe to clear
-# when a later LLM specifies force_deterministic=False, see BaseLLM.__init__).
-_FORCE_DETERMINISTIC_ENV_AT_IMPORT: Optional[str] = os.environ.get(
-    "FORCE_DETERMINISTIC")
-
 
 class RequestOutput(DetokenizedGenerationResultBase, GenerationResult):
     """The output data of a completion request to the LLM.
@@ -243,23 +236,15 @@ class BaseLLM:
         # access. Scoped here (rather than in the BaseLlmArgs validator) to
         # avoid a process-global side effect from a pure validator.
         #
-        # When force_deterministic=False we also explicitly clear the env
-        # var to prevent leaks from a prior LLM(force_deterministic=True)
-        # instance in the same process -- but only if the env var was not
-        # set externally by the user (either via the shell, captured at
-        # module-import time, or via the env_overrides kwarg on this
-        # instance, applied by _process_env_overrides above). This
-        # preserves the existing env-var API.  The C++ getters in
-        # envUtils.cpp latch per-process and cannot be un-done; that leak
-        # is an accepted constraint of the C++ side.
-        force_det_externally_set = (
-            _FORCE_DETERMINISTIC_ENV_AT_IMPORT is not None
-            or (env_overrides is not None
-                and "FORCE_DETERMINISTIC" in env_overrides))
+        # Note: when force_deterministic=True, the env var persists for the
+        # lifetime of the process -- it is not cleared when this LLM is
+        # shut down, nor when a subsequent LLM(force_deterministic=False)
+        # is constructed. This mirrors the one-way nature of the C++ side,
+        # whose static-const getters in envUtils.cpp latch on first access
+        # and cannot be un-done per-process; attempting to restore Python
+        # side parity alone is both complex and misleading.
         if self.args.force_deterministic:
             os.environ["FORCE_DETERMINISTIC"] = "1"
-        elif not force_det_externally_set:
-            os.environ.pop("FORCE_DETERMINISTIC", None)
 
         if self.args.parallel_config.is_multi_gpu:
             if os.getenv("RAY_LOCAL_WORLD_SIZE") is None and get_device_count(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -53,6 +53,13 @@ from .tokenizer import TokenizerBase, _xgrammar_tokenizer_info
 from .utils import (append_docstring, exception_handler, get_device_count,
                     logger_debug, set_api_status)
 
+# Snapshot FORCE_DETERMINISTIC once at module import so we can distinguish
+# a user-set value (preserved) from a value set by a prior
+# LLM(force_deterministic=True) instance in the same process (safe to clear
+# when a later LLM specifies force_deterministic=False, see BaseLLM.__init__).
+_FORCE_DETERMINISTIC_ENV_AT_IMPORT: Optional[str] = os.environ.get(
+    "FORCE_DETERMINISTIC")
+
 
 class RequestOutput(DetokenizedGenerationResultBase, GenerationResult):
     """The output data of a completion request to the LLM.
@@ -235,8 +242,18 @@ class BaseLLM:
         # the C++ static-const getters in envUtils.cpp latch true on first
         # access. Scoped here (rather than in the BaseLlmArgs validator) to
         # avoid a process-global side effect from a pure validator.
+        #
+        # When force_deterministic=False we also explicitly clear the env
+        # var IF it wasn't set at module-import time, to prevent leaks from
+        # a prior LLM(force_deterministic=True) instance in the same
+        # process. A user-set value (shell env present at import) is
+        # preserved so the existing env-var API continues to work. The C++
+        # getters in envUtils.cpp latch per-process and cannot be un-done;
+        # that leak is an accepted constraint of the C++ side.
         if self.args.force_deterministic:
             os.environ["FORCE_DETERMINISTIC"] = "1"
+        elif _FORCE_DETERMINISTIC_ENV_AT_IMPORT is None:
+            os.environ.pop("FORCE_DETERMINISTIC", None)
 
         if self.args.parallel_config.is_multi_gpu:
             if os.getenv("RAY_LOCAL_WORLD_SIZE") is None and get_device_count(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -244,15 +244,21 @@ class BaseLLM:
         # avoid a process-global side effect from a pure validator.
         #
         # When force_deterministic=False we also explicitly clear the env
-        # var IF it wasn't set at module-import time, to prevent leaks from
-        # a prior LLM(force_deterministic=True) instance in the same
-        # process. A user-set value (shell env present at import) is
-        # preserved so the existing env-var API continues to work. The C++
-        # getters in envUtils.cpp latch per-process and cannot be un-done;
-        # that leak is an accepted constraint of the C++ side.
+        # var to prevent leaks from a prior LLM(force_deterministic=True)
+        # instance in the same process -- but only if the env var was not
+        # set externally by the user (either via the shell, captured at
+        # module-import time, or via the env_overrides kwarg on this
+        # instance, applied by _process_env_overrides above). This
+        # preserves the existing env-var API.  The C++ getters in
+        # envUtils.cpp latch per-process and cannot be un-done; that leak
+        # is an accepted constraint of the C++ side.
+        force_det_externally_set = (
+            _FORCE_DETERMINISTIC_ENV_AT_IMPORT is not None
+            or (env_overrides is not None
+                and "FORCE_DETERMINISTIC" in env_overrides))
         if self.args.force_deterministic:
             os.environ["FORCE_DETERMINISTIC"] = "1"
-        elif _FORCE_DETERMINISTIC_ENV_AT_IMPORT is None:
+        elif not force_det_externally_set:
             os.environ.pop("FORCE_DETERMINISTIC", None)
 
         if self.args.parallel_config.is_multi_gpu:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -230,6 +230,14 @@ class BaseLLM:
                      "yellow")
         self.mpi_session = self.args.mpi_session
 
+        # Apply force_deterministic to the process env before any MPI pool
+        # is spawned, so worker processes inherit FORCE_DETERMINISTIC and
+        # the C++ static-const getters in envUtils.cpp latch true on first
+        # access. Scoped here (rather than in the BaseLlmArgs validator) to
+        # avoid a process-global side effect from a pure validator.
+        if self.args.force_deterministic:
+            os.environ["FORCE_DETERMINISTIC"] = "1"
+
         if self.args.parallel_config.is_multi_gpu:
             if os.getenv("RAY_LOCAL_WORLD_SIZE") is None and get_device_count(
             ) < self.args.parallel_config.world_size_per_node:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2800,6 +2800,16 @@ class BaseLlmArgs(StrictBaseModel):
     trust_remote_code: bool = Field(
         default=False, description="Whether to trust the remote code.")
 
+    force_deterministic: bool = Field(
+        default=False,
+        description=(
+            "Force deterministic execution at the cost of some performance. "
+            "When enabled, disables KV cache block reuse (partial and full), "
+            "forces single-block attention, selects the first MoE tactic, and "
+            "forces one-shot allreduce on multi-GPU paths. Declarative "
+            "equivalent of setting FORCE_DETERMINISTIC=1 in the environment."),
+        status="prototype")
+
     tensor_parallel_size: int = Field(default=1,
                                       description="The tensor parallel size.")
 
@@ -3108,6 +3118,26 @@ class BaseLlmArgs(StrictBaseModel):
                 field_info = self.__class__.model_fields.get(field_name)
                 if field_info is not None and field_info.default is not None:
                     setattr(self, field_name, field_info.default)
+        return self
+
+    @model_validator(mode="after")
+    def _apply_force_deterministic(self):
+        """Propagate force_deterministic=True to env var and KV cache flags.
+
+        Sets os.environ['FORCE_DETERMINISTIC']=1 so the C++ getters in
+        cpp/tensorrt_llm/common/envUtils.cpp latch the master flag. They OR
+        their per-subsystem env var against this master, so setting only the
+        master cascades to attention / MoE / allreduce. Also flips
+        kv_cache_config.enable_block_reuse / enable_partial_reuse so the
+        resolved args object is self-consistent with the Python code paths
+        in llm.py and py_executor_creator.py that gate on the same env var.
+        """
+        if not self.force_deterministic:
+            return self
+
+        os.environ["FORCE_DETERMINISTIC"] = "1"
+        self.kv_cache_config.enable_block_reuse = False
+        self.kv_cache_config.enable_partial_reuse = False
         return self
 
     @model_validator(mode="after")

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3122,20 +3122,18 @@ class BaseLlmArgs(StrictBaseModel):
 
     @model_validator(mode="after")
     def _apply_force_deterministic(self):
-        """Propagate force_deterministic=True to env var and KV cache flags.
+        """Flip kv_cache_config reuse flags when force_deterministic is set.
 
-        Sets os.environ['FORCE_DETERMINISTIC']=1 so the C++ getters in
-        cpp/tensorrt_llm/common/envUtils.cpp latch the master flag. They OR
-        their per-subsystem env var against this master, so setting only the
-        master cascades to attention / MoE / allreduce. Also flips
-        kv_cache_config.enable_block_reuse / enable_partial_reuse so the
-        resolved args object is self-consistent with the Python code paths
-        in llm.py and py_executor_creator.py that gate on the same env var.
+        Kept validator-local (no process-global side effects): only mutates
+        the resolved args object so it remains self-consistent with the
+        Python code paths in llm.py and py_executor_creator.py that gate on
+        the same intent. The FORCE_DETERMINISTIC env var that the C++ layer
+        reads is applied at executor/session creation time (see llm.py),
+        scoped to the boundary where workers are about to be spawned.
         """
         if not self.force_deterministic:
             return self
 
-        os.environ["FORCE_DETERMINISTIC"] = "1"
         self.kv_cache_config.enable_block_reuse = False
         self.kv_cache_config.enable_partial_reuse = False
         return self

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -170,10 +170,21 @@ class MpiPoolSession(MpiSession):
     def _start_mpi_pool(self):
         assert not self.mpi_pool, 'MPI session already started'
 
+        # Env vars outside the TRTLLM*/TLLM* prefix that are also read by
+        # the C++ layer in the worker (via static-const std::getenv in
+        # cpp/tensorrt_llm/common/envUtils.cpp). These must be forwarded
+        # explicitly or the worker sees them as unset.
+        _extra_passthrough = {
+            "FORCE_DETERMINISTIC",
+            "FORCE_ATTENTION_KERNEL_DETERMINISTIC",
+            "FORCE_MOE_KERNEL_DETERMINISTIC",
+            "FORCE_ALL_REDUCE_DETERMINISTIC",
+        }
         env = {
             key: value
             for key, value in os.environ.items()
-            if key.startswith("TRTLLM") or key.startswith("TLLM")
+            if (key.startswith("TRTLLM") or key.startswith("TLLM")
+                or key in _extra_passthrough)
         }
         self.mpi_pool = MPIPoolExecutor(max_workers=self.n_workers,
                                         path=sys.path,

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -74,6 +74,10 @@ methods:
         annotation: int
         default: 20000
         status: beta
+      force_deterministic:
+        annotation: bool
+        default: False
+        status: prototype
       # Misc
       backend:
         annotation: Literal["pytorch"]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `force_deterministic` configuration option that disables KV cache reuse and enables deterministic execution behavior.

* **Tests**
  * Updated API stability tests to reflect the new configuration parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Adds a typed LLM API field equivalent to FORCE_DETERMINISTIC=1.

The existing env var is undocumented and discoverable only via source. It is also silently ineffective under MpiPoolSession (trtllm-serve and other non-mpirun entry points) because the worker env is filtered to TRTLLM*/TLLM*-prefixed keys, stripping the four FORCE_* determinism vars. Orchestrator-side KV-cache reuse flags still flip, but the C++ attention / MoE / allreduce getters never see the master flag.

Changes:
- tensorrt_llm/llmapi/llm_args.py: add force_deterministic field and a model validator that sets os.environ["FORCE_DETERMINISTIC"]=1 and flips kv_cache_config.enable_block_reuse / enable_partial_reuse.
- tensorrt_llm/llmapi/mpi_session.py: allow the four FORCE_* env vars through the MpiPoolSession worker-env filter. Also fixes the pre-existing env-var API under MpiPoolSession.

The C++ getters already OR per-subsystem env vars against the master, so setting only FORCE_DETERMINISTIC cascades; no C++ changes needed.

## Test Coverage

Local testing only

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
