### PR TITLE
[#7091][fix] remove INT8 from trtllm-bench --quantization choices

### DIFF
--- a/tensorrt_llm/bench/utils/__init__.py
+++ b/tensorrt_llm/bench/utils/__init__.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import functools
 import os
 import subprocess  # nosec B404
@@ -20,7 +34,7 @@ VALID_CACHE_DTYPES = Literal["float16", "float8", "int8"]
 VALID_QUANT_ALGOS = Literal[f"{QuantAlgo.W8A16}", f"{QuantAlgo.W4A16}",
                             f"{QuantAlgo.W4A16_AWQ}", f"{QuantAlgo.W4A8_AWQ}",
                             f"{QuantAlgo.W4A16_GPTQ}", f"{QuantAlgo.FP8}",
-                            f"{QuantAlgo.INT8}", f"{QuantAlgo.NVFP4}"]
+                            f"{QuantAlgo.NVFP4}"]
 VALID_SCHEDULING_POLICIES = \
     Literal["max_utilization", "guaranteed_no_evict", "static"]
 


### PR DESCRIPTION
**[NVIDIA/TensorRT-LLM#7091][fix] Summary**

- `trtllm-bench build --help` advertises `INT8` under `-q/--quantization`, but passing it crashes in `QuantConfig.from_quant_algo` because `QUANT_ALGO_LIST` at `tensorrt_llm/quantization/mode.py:52` deliberately excludes `QuantAlgo.INT8` for weight quantization. 
- Fixes NVIDIA/TensorRT-LLM#7091.

## Description

- Drop `INT8` from the `VALID_QUANT_ALGOS` `Literal` in `tensorrt_llm/bench/utils/__init__.py`.
- That `Literal` is the single source feeding both Click's quantization choices and the Pydantic field type, so removing it here makes both layers reject the value cleanly instead of letting it fall through to the AssertionError.

## Test Coverage

- There is no existing `tests/unittest/bench/` CLI harness, and the existing runtime assertion in `QuantConfig.from_quant_algo` continues to backstop the contract.
- `trtllm-bench --model meta-llama/Llama-3.1-8B build --help` no longer lists `INT8` under `--quantization` (now 7 choices)
-  `--quantization INT8` is rejected by Click before any model/engine code runs.
## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added license header comments to a utility module.
  * Tweaked an internal quantization list (no change to contents or runtime behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->