### PR TITLE
[NVBug 5969206][draft] Subset of PR 13056 cherry-picked onto 4e69c14f73 (rc11 base) — 15 C++/Python fixes

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -204,13 +204,22 @@ class BaseCacheTransceiver
 {
 public:
     virtual ~BaseCacheTransceiver() = default;
-    virtual void respondAndSendAsync(LlmRequest* llmRequest) = 0;
+    // These methods take std::shared_ptr<LlmRequest> (not a raw pointer) so the
+    // transceiver and its async workers can hold a strong reference for the
+    // duration of the transfer. Previously they took LlmRequest*, which left
+    // the worker (via RequestAndPromise::mRequest) dereferencing a pybind
+    // shared_ptr that Python could drop via _terminate_request — a
+    // forensically-confirmed UAF pattern (mRequestId read as
+    // 0x5555555555555555 under MALLOC_PERTURB_). Passing the shared_ptr through
+    // keeps the LlmRequest alive until every holder (Python active_requests,
+    // C++ futures map, async worker) has released its reference.
+    virtual void respondAndSendAsync(std::shared_ptr<LlmRequest> llmRequest) = 0;
     virtual void respondAndSendLayerWise(
         RequestVector const& requests, std::shared_ptr<ContextProgress> const& progress)
         = 0;
 
-    virtual void requestAndReceiveSync(LlmRequest* llmRequest) = 0;
-    virtual void requestAndReceiveAsync(LlmRequest* llmRequest) = 0;
+    virtual void requestAndReceiveSync(std::shared_ptr<LlmRequest> llmRequest) = 0;
+    virtual void requestAndReceiveAsync(std::shared_ptr<LlmRequest> llmRequest) = 0;
 
     /// Check all requests transferring context, and return the requests that have completed or encountered an error.
     virtual RequestStatuses checkContextTransferStatus(
@@ -221,7 +230,7 @@ public:
 
     [[nodiscard]] virtual bool checkGenTransferComplete() const = 0;
 
-    virtual bool cancelRequest(LlmRequest* llmRequest) = 0;
+    virtual bool cancelRequest(std::shared_ptr<LlmRequest> llmRequest) = 0;
 };
 
 class CacheTransceiver : public BaseCacheTransceiver
@@ -252,13 +261,13 @@ public:
 
     virtual ~CacheTransceiver();
 
-    void respondAndSendAsync(LlmRequest* llmRequest) override;
+    void respondAndSendAsync(std::shared_ptr<LlmRequest> llmRequest) override;
 
     void respondAndSendLayerWise(
         RequestVector const& requests, std::shared_ptr<ContextProgress> const& progress) override;
 
-    void requestAndReceiveSync(LlmRequest* llmRequest) override;
-    void requestAndReceiveAsync(LlmRequest* llmRequest) override;
+    void requestAndReceiveSync(std::shared_ptr<LlmRequest> llmRequest) override;
+    void requestAndReceiveAsync(std::shared_ptr<LlmRequest> llmRequest) override;
 
     RequestStatuses checkContextTransferStatus(
         std::optional<int> const& atLeastRequestNum = std::nullopt, bool markComplete = false) override;
@@ -267,7 +276,7 @@ public:
 
     [[nodiscard]] bool checkGenTransferComplete() const override;
 
-    virtual bool cancelRequest(LlmRequest* llmRequest) override;
+    virtual bool cancelRequest(std::shared_ptr<LlmRequest> llmRequest) override;
 
 private:
     void initializeCommState();
@@ -276,8 +285,17 @@ private:
 
     std::unique_ptr<CacheSender> mCacheSender;
     std::unique_ptr<CacheReceiver> mCacheReceiver;
-    std::vector<std::pair<LlmRequest*, std::future<void>>> mSenderFutures;
-    std::vector<std::pair<LlmRequest*, std::future<void>>> mRequesterFutures;
+    // Store shared_ptr rather than raw LlmRequest* so the futures map holds a
+    // strong reference for the duration of the transfer. Otherwise Python's
+    // _terminate_request can drop its pybind shared_ptr while the C++ side's
+    // raw pointer is still dereferenced by checkGenTransferStatus /
+    // checkContextTransferStatus (the UAF forensically confirmed via
+    // MALLOC_PERTURB_=85 producing mRequestId=0x5555555555555555). Entries are
+    // erased only in the normal eviction paths (completion, deadline,
+    // exception), ensuring the request outlives every C++ access but doesn't
+    // leak past the transfer lifecycle.
+    std::vector<std::pair<std::shared_ptr<LlmRequest>, std::future<void>>> mSenderFutures;
+    std::vector<std::pair<std::shared_ptr<LlmRequest>, std::future<void>>> mRequesterFutures;
     mpi::MpiComm const* mMpiWorldComm{nullptr};
 
     std::shared_ptr<CacheTransceiverComm> mGroupComm;

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
@@ -26,6 +26,48 @@
 namespace tensorrt_llm::batch_manager
 {
 
+void BufferIndexHolder::release() noexcept
+{
+    if (!mHeld || mMgr == nullptr)
+    {
+        return;
+    }
+    // freeBufferIndexFor{Recv,Send} is a no-op for nullopt index, so the
+    // only way this matters is when we actually hold a value. Log the
+    // auto-release so post-saturation runs can distinguish RAII releases
+    // from formatter-driven happy-path releases — a spike in [buf]
+    // AUTO_RELEASE events signals that an exit path other than the normal
+    // receiveSync finish is firing often (e.g. not-ready or cancel).
+    try
+    {
+        TLLM_LOG_WARNING("[buf] BufferIndexHolder AUTO_RELEASE index=%d isRecv=%d", mIndex.value_or(-1),
+            static_cast<int>(mIsRecv));
+        if (mIsRecv)
+        {
+            mMgr->freeBufferIndexForRecv(mIndex);
+        }
+        else
+        {
+            mMgr->freeBufferIndexForSend(mIndex);
+        }
+    }
+    catch (...)
+    {
+        // Destructors are noexcept; log and swallow to preserve the
+        // invariant that stack unwinding on a cancel/exception path
+        // cannot call std::terminate from here.
+        try
+        {
+            TLLM_LOG_WARNING(
+                "[buf] BufferIndexHolder::release suppressed exception (index=%d)", mIndex.value_or(-1));
+        }
+        catch (...)
+        {
+        }
+    }
+    mHeld = false;
+}
+
 BaseTransBufferManager::BaseTransBufferManager(
     size_t transferBufferSize, nvinfer1::DataType dataType, std::optional<size_t> maxNumTokens)
     : mDataType{dataType}

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
@@ -64,9 +64,11 @@ void BaseTransBufferManager::freeBufferIndexForSend(std::optional<int> bufferId)
     freeBufferIndex(mConcurrenceSendResource, bufferId, mSendBufferCount, mOnlyUseDynamicBuffer);
 }
 
-std::optional<int> BaseTransBufferManager::assignBufferIndexForRecv()
+std::optional<int> BaseTransBufferManager::assignBufferIndexForRecv(
+    std::atomic<bool> const* perRequestCancel, int64_t waitSliceMs, std::optional<uint64_t> requestIdForLog)
 {
-    return assignBufferIndex(mConcurrenceRecvResource, mRecvBufferCount, mOnlyUseDynamicBuffer);
+    return assignBufferIndex(
+        mConcurrenceRecvResource, mRecvBufferCount, mOnlyUseDynamicBuffer, perRequestCancel, waitSliceMs, requestIdForLog);
 }
 
 void BaseTransBufferManager::freeBufferIndexForRecv(std::optional<int> bufferId)
@@ -225,16 +227,76 @@ void BaseTransBufferManager::allocateBuffer()
     }
 }
 
-std::optional<int> BaseTransBufferManager::assignBufferIndex(
-    ConcurrenceResource& resource, size_t bufferCount, bool onlyUseDynamicBuffer)
+std::optional<int> BaseTransBufferManager::assignBufferIndex(ConcurrenceResource& resource, size_t bufferCount,
+    bool onlyUseDynamicBuffer, std::atomic<bool> const* perRequestCancel, int64_t waitSliceMs,
+    std::optional<uint64_t> requestIdForLog)
 {
     if (onlyUseDynamicBuffer)
     {
         return std::nullopt;
     }
+    // Hypothesized wedge site: under saturation with N stuck transfers all
+    // holding their receive-buffer slots, new incoming sendRequestInfo calls
+    // park here on an unbounded CV wait and never observe the per-request
+    // cancel flag. Replace the unbounded wait with a bounded wait_for-style
+    // loop that re-checks the predicate AND the perRequestCancel atomic every
+    // waitSliceMs, so:
+    //   - a cancel fired on THIS request while it is parked unblocks it by
+    //     throwing, and requestSync unwinds cleanly into the drain worker's
+    //     existing catch(std::exception) path;
+    //   - even without an explicit cancel, waking every waitSliceMs gives us
+    //     progress logs and keeps the drain worker responsive to shutdown
+    //     (mTerminate can flip between slices and the caller's outer loop
+    //     will observe it).
+    // Also emit [buf] log markers so the (reqId, pool, duration) profile of
+    // each wait can be cross-referenced with the drain worker's [reqSync]
+    // trail and the C++-side kv_transfer_timeout_ms evictions.
     std::unique_lock lk(resource.mBuffersMutex);
-    resource.mBuffersCV.wait(
-        lk, [&resource, bufferCount]() { return static_cast<size_t>(resource.mConcurrence) < bufferCount; });
+    auto const predicate
+        = [&resource, bufferCount]() { return static_cast<size_t>(resource.mConcurrence) < bufferCount; };
+    if (!predicate())
+    {
+        auto const reqIdStr = requestIdForLog.has_value() ? std::to_string(requestIdForLog.value()) : std::string{"?"};
+        TLLM_LOG_WARNING("[buf] assignBufferIndex WAIT reqId=%s concurrence=%d/%zu poolExhausted=1", reqIdStr.c_str(),
+            resource.mConcurrence.load(), bufferCount);
+        auto const waitStart = std::chrono::steady_clock::now();
+        int waitIterations = 0;
+        auto const slice = std::chrono::milliseconds{waitSliceMs};
+        while (!predicate())
+        {
+            resource.mBuffersCV.wait_for(lk, slice);
+            ++waitIterations;
+            if (perRequestCancel != nullptr && perRequestCancel->load(std::memory_order_relaxed))
+            {
+                auto const elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - waitStart)
+                                           .count();
+                TLLM_LOG_WARNING(
+                    "[buf] assignBufferIndex CANCEL reqId=%s waitedMs=%lld iterations=%d concurrence=%d/%zu",
+                    reqIdStr.c_str(), static_cast<long long>(elapsedMs), waitIterations,
+                    resource.mConcurrence.load(), bufferCount);
+                TLLM_THROW("assignBufferIndex cancelled via perRequestCancel (reqId=%s)", reqIdStr.c_str());
+            }
+            // Periodically surface progress when a wait drags on; helps
+            // attribute "no-recovery" windows to a specific stuck pool.
+            if ((waitIterations % 50) == 0)
+            {
+                auto const elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - waitStart)
+                                           .count();
+                TLLM_LOG_WARNING(
+                    "[buf] assignBufferIndex STILL_WAITING reqId=%s waitedMs=%lld iterations=%d concurrence=%d/%zu",
+                    reqIdStr.c_str(), static_cast<long long>(elapsedMs), waitIterations,
+                    resource.mConcurrence.load(), bufferCount);
+            }
+        }
+        auto const elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - waitStart)
+                                   .count();
+        TLLM_LOG_WARNING("[buf] assignBufferIndex ACQUIRED reqId=%s waitedMs=%lld iterations=%d concurrence=%d/%zu",
+            reqIdStr.c_str(), static_cast<long long>(elapsedMs), waitIterations, resource.mConcurrence.load(),
+            bufferCount);
+    }
     int bufferId = -1;
     for (size_t i = 0; i < bufferCount; i++)
     {

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
@@ -28,22 +28,20 @@ namespace tensorrt_llm::batch_manager
 
 void BufferIndexHolder::release() noexcept
 {
+    // Silent release — intended for happy-path callers that have confirmed
+    // the slot is no longer needed. Frees the slot, disarms the holder, and
+    // does NOT log AUTO_RELEASE. Used atomically in place of the older
+    // detach() + explicit freeBufferIndex*() pair: the sequence previously
+    // had a narrow window (between the two calls) where an exception would
+    // trip the destructor fallback and emit a misleading AUTO_RELEASE.
+    // Using a single noexcept call here makes the happy-path release atomic
+    // at the API level.
     if (!mHeld || mMgr == nullptr)
     {
         return;
     }
-    // freeBufferIndexFor{Recv,Send} is a no-op for nullopt index, so the
-    // only way this matters is when we actually hold a value. Log the
-    // auto-release so post-saturation runs can distinguish RAII releases
-    // from formatter-driven happy-path releases — a spike in [buf]
-    // AUTO_RELEASE events signals that an exit path other than the normal
-    // receiveSync finish is firing often (e.g. not-ready or cancel).
     try
     {
-        auto const reqIdStr
-            = mRequestIdForLog.has_value() ? std::to_string(mRequestIdForLog.value()) : std::string{"?"};
-        TLLM_LOG_WARNING("[buf] BufferIndexHolder AUTO_RELEASE reqId=%s index=%d isRecv=%d", reqIdStr.c_str(),
-            mIndex.value_or(-1), static_cast<int>(mIsRecv));
         if (mIsRecv)
         {
             mMgr->freeBufferIndexForRecv(mIndex);
@@ -55,9 +53,6 @@ void BufferIndexHolder::release() noexcept
     }
     catch (...)
     {
-        // Destructors are noexcept; log and swallow to preserve the
-        // invariant that stack unwinding on a cancel/exception path
-        // cannot call std::terminate from here.
         try
         {
             auto const reqIdStr
@@ -70,6 +65,30 @@ void BufferIndexHolder::release() noexcept
         }
     }
     mHeld = false;
+}
+
+void BufferIndexHolder::releaseWithLog() noexcept
+{
+    // Destructor-fallback path. If we reach here with mHeld=true, some exit
+    // path (exception, early return that forgot to call release()/detach())
+    // left the slot held. Log AUTO_RELEASE so the non-happy exit is visible
+    // in [buf] diagnostics, then delegate to release() for the actual free.
+    // A spike in AUTO_RELEASE events after this commit specifically signals
+    // non-happy-exit leaks — happy-path releases are silent.
+    if (mHeld && mMgr != nullptr)
+    {
+        try
+        {
+            auto const reqIdStr
+                = mRequestIdForLog.has_value() ? std::to_string(mRequestIdForLog.value()) : std::string{"?"};
+            TLLM_LOG_WARNING("[buf] BufferIndexHolder AUTO_RELEASE reqId=%s index=%d isRecv=%d", reqIdStr.c_str(),
+                mIndex.value_or(-1), static_cast<int>(mIsRecv));
+        }
+        catch (...)
+        {
+        }
+    }
+    release();
 }
 
 BaseTransBufferManager::BaseTransBufferManager(
@@ -100,10 +119,11 @@ BaseTransBufferManager::BaseTransBufferManager(
     allocateBuffer();
 }
 
-std::optional<int> BaseTransBufferManager::assignBufferIndexForSend(std::optional<uint64_t> requestIdForLog)
+std::optional<int> BaseTransBufferManager::assignBufferIndexForSend(
+    std::atomic<bool> const* perRequestCancel, int64_t waitSliceMs, std::optional<uint64_t> requestIdForLog)
 {
-    return assignBufferIndex(mConcurrenceSendResource, mSendBufferCount, mOnlyUseDynamicBuffer,
-        /*perRequestCancel=*/nullptr, /*waitSliceMs=*/100, requestIdForLog);
+    return assignBufferIndex(
+        mConcurrenceSendResource, mSendBufferCount, mOnlyUseDynamicBuffer, perRequestCancel, waitSliceMs, requestIdForLog);
 }
 
 void BaseTransBufferManager::freeBufferIndexForSend(std::optional<int> bufferId)

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
@@ -40,8 +40,10 @@ void BufferIndexHolder::release() noexcept
     // receiveSync finish is firing often (e.g. not-ready or cancel).
     try
     {
-        TLLM_LOG_WARNING("[buf] BufferIndexHolder AUTO_RELEASE index=%d isRecv=%d", mIndex.value_or(-1),
-            static_cast<int>(mIsRecv));
+        auto const reqIdStr
+            = mRequestIdForLog.has_value() ? std::to_string(mRequestIdForLog.value()) : std::string{"?"};
+        TLLM_LOG_WARNING("[buf] BufferIndexHolder AUTO_RELEASE reqId=%s index=%d isRecv=%d", reqIdStr.c_str(),
+            mIndex.value_or(-1), static_cast<int>(mIsRecv));
         if (mIsRecv)
         {
             mMgr->freeBufferIndexForRecv(mIndex);
@@ -58,8 +60,10 @@ void BufferIndexHolder::release() noexcept
         // cannot call std::terminate from here.
         try
         {
-            TLLM_LOG_WARNING(
-                "[buf] BufferIndexHolder::release suppressed exception (index=%d)", mIndex.value_or(-1));
+            auto const reqIdStr
+                = mRequestIdForLog.has_value() ? std::to_string(mRequestIdForLog.value()) : std::string{"?"};
+            TLLM_LOG_WARNING("[buf] BufferIndexHolder::release suppressed exception (reqId=%s index=%d)",
+                reqIdStr.c_str(), mIndex.value_or(-1));
         }
         catch (...)
         {
@@ -96,9 +100,10 @@ BaseTransBufferManager::BaseTransBufferManager(
     allocateBuffer();
 }
 
-std::optional<int> BaseTransBufferManager::assignBufferIndexForSend()
+std::optional<int> BaseTransBufferManager::assignBufferIndexForSend(std::optional<uint64_t> requestIdForLog)
 {
-    return assignBufferIndex(mConcurrenceSendResource, mSendBufferCount, mOnlyUseDynamicBuffer);
+    return assignBufferIndex(mConcurrenceSendResource, mSendBufferCount, mOnlyUseDynamicBuffer,
+        /*perRequestCancel=*/nullptr, /*waitSliceMs=*/100, requestIdForLog);
 }
 
 void BaseTransBufferManager::freeBufferIndexForSend(std::optional<int> bufferId)

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
@@ -46,6 +46,97 @@ enum class BufferKind : uint8_t
     kRNN = 2
 };
 
+class BaseTransBufferManager;
+
+/// @brief RAII scoped holder for a buffer index acquired from
+///        BaseTransBufferManager::assignBufferIndexForRecv /
+///        assignBufferIndexForSend. Releases the index on destruction,
+///        including stack unwind from exceptions.
+///
+/// Motivation: CacheReceiver::Impl::requestSync has at least six exit paths
+/// (normal, early-cancel, not-ready, cancel-after-ready, receiveReadySignal
+/// cancelled, exception from requestSync). Pre-fix, the buffer-index
+/// release lived inside receiveSync's formatter — so any exit path that
+/// skipped receiveSync leaked one index. v12 saturation test reproduced
+/// this: one `(not-ready)` early return permanently wedged the size-1
+/// pool and every subsequent request waited forever.
+///
+/// This holder closes that class of bug rather than patching the one
+/// observed branch. Move-only so ownership is unambiguous; `detach()`
+/// hands off ownership when the formatter inside receiveSync takes the
+/// buffer's release responsibility on the happy path.
+class BufferIndexHolder
+{
+public:
+    BufferIndexHolder() = default;
+
+    BufferIndexHolder(BaseTransBufferManager& mgr, std::optional<int> index, bool isRecv) noexcept
+        : mMgr(&mgr)
+        , mIndex(index)
+        , mHeld(index.has_value())
+        , mIsRecv(isRecv)
+    {
+    }
+
+    ~BufferIndexHolder()
+    {
+        release();
+    }
+
+    BufferIndexHolder(BufferIndexHolder const&) = delete;
+    BufferIndexHolder& operator=(BufferIndexHolder const&) = delete;
+
+    BufferIndexHolder(BufferIndexHolder&& other) noexcept
+        : mMgr(other.mMgr)
+        , mIndex(other.mIndex)
+        , mHeld(other.mHeld)
+        , mIsRecv(other.mIsRecv)
+    {
+        other.mHeld = false;
+    }
+
+    BufferIndexHolder& operator=(BufferIndexHolder&& other) noexcept
+    {
+        if (this != &other)
+        {
+            release();
+            mMgr = other.mMgr;
+            mIndex = other.mIndex;
+            mHeld = other.mHeld;
+            mIsRecv = other.mIsRecv;
+            other.mHeld = false;
+        }
+        return *this;
+    }
+
+    [[nodiscard]] std::optional<int> index() const noexcept
+    {
+        return mIndex;
+    }
+
+    [[nodiscard]] bool held() const noexcept
+    {
+        return mHeld;
+    }
+
+    /// @brief Relinquish ownership without releasing. Use when a downstream
+    ///        owner (e.g. the formatter inside receiveSync) takes over the
+    ///        release responsibility on the happy path.
+    std::optional<int> detach() noexcept
+    {
+        mHeld = false;
+        return mIndex;
+    }
+
+private:
+    void release() noexcept;
+
+    BaseTransBufferManager* mMgr{nullptr};
+    std::optional<int> mIndex{};
+    bool mHeld{false};
+    bool mIsRecv{true};
+};
+
 /// @brief Base class for cache transfer buffer management.
 /// Handles buffer pool allocation, index assignment, and slicing.
 /// Derived classes provide cache-specific size calculations.

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
@@ -65,8 +65,20 @@ public:
     void freeBufferIndexForSend(std::optional<int> bufferId);
 
     /// @brief Assign a buffer index for receiving.
+    /// @param perRequestCancel Optional per-request cancel flag. When non-null
+    ///        and flipped true while this call is parked on the pool-exhausted
+    ///        CV wait, the function throws so the caller (drain worker) can
+    ///        unwind instead of blocking indefinitely. Checked every
+    ///        `waitSliceMs` during the wait; also bounds the wait by polling
+    ///        for recovery even without an explicit cancel.
+    /// @param waitSliceMs Per-iteration timeout for the internal condition
+    ///        variable wait (ms). Defaults to 100 ms.
+    /// @param requestIdForLog Optional request id used to tag [buf] log lines
+    ///        so a pool-exhausted wedge can be attributed to a specific reqId
+    ///        when cross-referenced with the drain-worker's [reqSync] trail.
     /// @return Assigned buffer index, or nullopt if using dynamic buffers.
-    std::optional<int> assignBufferIndexForRecv();
+    std::optional<int> assignBufferIndexForRecv(std::atomic<bool> const* perRequestCancel = nullptr,
+        int64_t waitSliceMs = 100, std::optional<uint64_t> requestIdForLog = std::nullopt);
 
     /// @brief Free a buffer index used for receiving.
     /// @param bufferId The buffer index to free.
@@ -132,7 +144,9 @@ protected:
         runtime::BufferManager const& bufferManagerToUse, ConcurrenceResource& concurrenceResource);
 
     void allocateBuffer();
-    std::optional<int> assignBufferIndex(ConcurrenceResource& resource, size_t bufferCount, bool onlyUseDynamicBuffer);
+    std::optional<int> assignBufferIndex(ConcurrenceResource& resource, size_t bufferCount, bool onlyUseDynamicBuffer,
+        std::atomic<bool> const* perRequestCancel = nullptr, int64_t waitSliceMs = 100,
+        std::optional<uint64_t> requestIdForLog = std::nullopt);
     void freeBufferIndex(
         ConcurrenceResource& resource, std::optional<int> bufferId, size_t bufferCount, bool onlyUseDynamicBuffer);
 

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
@@ -82,7 +82,7 @@ public:
 
     ~BufferIndexHolder()
     {
-        release();
+        releaseWithLog();
     }
 
     BufferIndexHolder(BufferIndexHolder const&) = delete;
@@ -132,8 +132,23 @@ public:
         return mIndex;
     }
 
-private:
+    /// @brief Happy-path release. Frees the slot immediately and disarms the
+    ///        destructor so AUTO_RELEASE is NOT logged. Use this on any path
+    ///        where the caller has confirmed the slot is no longer needed and
+    ///        the release is the expected outcome (e.g. the sender formatter
+    ///        after sendAllBuffers returns). After this call, the holder owns
+    ///        nothing; subsequent destructor or move-assignment is a no-op.
+    ///
+    ///        Contrast with the destructor's fallback path: if the holder goes
+    ///        out of scope with mHeld still true (exception, early return that
+    ///        forgot to call release/detach), the destructor logs AUTO_RELEASE
+    ///        so the non-happy exit is visible in [buf] diagnostics.
     void release() noexcept;
+
+private:
+    /// @brief Destructor-fallback path. Emits AUTO_RELEASE log (tagged with
+    ///        reqId if known) and then performs the same work as release().
+    void releaseWithLog() noexcept;
 
     BaseTransBufferManager* mMgr{nullptr};
     std::optional<int> mIndex{};
@@ -153,11 +168,20 @@ public:
     [[nodiscard]] virtual BufferKind getBufferKind() const = 0;
 
     /// @brief Assign a buffer index for sending.
+    /// @param perRequestCancel Optional per-request cancel flag. When non-null
+    ///        and flipped true while this call is parked on the pool-exhausted
+    ///        CV wait, the function throws so the caller (sender worker) can
+    ///        unwind instead of blocking indefinitely. Checked every
+    ///        `waitSliceMs` during the wait. Parity with
+    ///        assignBufferIndexForRecv.
+    /// @param waitSliceMs Per-iteration timeout for the internal condition
+    ///        variable wait (ms). Defaults to 100 ms.
     /// @param requestIdForLog Optional request id used to tag [buf] log lines
     ///        so a pool-exhausted wedge on the send side can be attributed
-    ///        to a specific reqId (parity with assignBufferIndexForRecv).
+    ///        to a specific reqId.
     /// @return Assigned buffer index, or nullopt if using dynamic buffers.
-    std::optional<int> assignBufferIndexForSend(std::optional<uint64_t> requestIdForLog = std::nullopt);
+    std::optional<int> assignBufferIndexForSend(std::atomic<bool> const* perRequestCancel = nullptr,
+        int64_t waitSliceMs = 100, std::optional<uint64_t> requestIdForLog = std::nullopt);
 
     /// @brief Free a buffer index used for sending.
     /// @param bufferId The buffer index to free.

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
@@ -70,11 +70,13 @@ class BufferIndexHolder
 public:
     BufferIndexHolder() = default;
 
-    BufferIndexHolder(BaseTransBufferManager& mgr, std::optional<int> index, bool isRecv) noexcept
+    BufferIndexHolder(BaseTransBufferManager& mgr, std::optional<int> index, bool isRecv,
+        std::optional<uint64_t> requestIdForLog = std::nullopt) noexcept
         : mMgr(&mgr)
         , mIndex(index)
         , mHeld(index.has_value())
         , mIsRecv(isRecv)
+        , mRequestIdForLog(requestIdForLog)
     {
     }
 
@@ -91,6 +93,7 @@ public:
         , mIndex(other.mIndex)
         , mHeld(other.mHeld)
         , mIsRecv(other.mIsRecv)
+        , mRequestIdForLog(other.mRequestIdForLog)
     {
         other.mHeld = false;
     }
@@ -104,6 +107,7 @@ public:
             mIndex = other.mIndex;
             mHeld = other.mHeld;
             mIsRecv = other.mIsRecv;
+            mRequestIdForLog = other.mRequestIdForLog;
             other.mHeld = false;
         }
         return *this;
@@ -135,6 +139,7 @@ private:
     std::optional<int> mIndex{};
     bool mHeld{false};
     bool mIsRecv{true};
+    std::optional<uint64_t> mRequestIdForLog{};
 };
 
 /// @brief Base class for cache transfer buffer management.
@@ -148,8 +153,11 @@ public:
     [[nodiscard]] virtual BufferKind getBufferKind() const = 0;
 
     /// @brief Assign a buffer index for sending.
+    /// @param requestIdForLog Optional request id used to tag [buf] log lines
+    ///        so a pool-exhausted wedge on the send side can be attributed
+    ///        to a specific reqId (parity with assignBufferIndexForRecv).
     /// @return Assigned buffer index, or nullopt if using dynamic buffers.
-    std::optional<int> assignBufferIndexForSend();
+    std::optional<int> assignBufferIndexForSend(std::optional<uint64_t> requestIdForLog = std::nullopt);
 
     /// @brief Free a buffer index used for sending.
     /// @param bufferId The buffer index to free.

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -34,6 +34,7 @@
 #include "tensorrt_llm/runtime/iTensor.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <future>
@@ -63,7 +64,9 @@ void sendBuffer(TransferSession& session, int deviceId, size_t localIdx,
     executor::kv_cache::TargetRanksInfo const& targetInfo, std::vector<size_t> const& pickUpConnections)
 {
     size_t connIdx = pickUpConnections[localIdx];
-    TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), " send localIdx: %ld connIdx: %ld", localIdx, connIdx);
+    auto const sendReqId = static_cast<uint64_t>(session.getLlmRequest().mRequestId);
+    TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), "[send] START reqId=%zu localIdx=%ld connIdx=%ld", sendReqId,
+        localIdx, connIdx);
     NVTX3_SCOPED_RANGE(sendBuffer);
     TLLM_CUDA_CHECK(cudaSetDevice(deviceId));
     TLLM_CHECK(session.getConnections().size() > (connIdx / targetInfo.mPeerDupHeadFactor));
@@ -76,11 +79,11 @@ void sendBuffer(TransferSession& session, int deviceId, size_t localIdx,
 
     if (bufferIdx < bufferCoverTargetNum)
     {
-        TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), " send connIdx: %ld bufferIdx: %ld size:%ld", connIdx,
-            bufferIdx, outputBuffers[bufferIdx]->getSizeInBytes());
+        TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), "[send] PRE reqId=%zu connIdx=%ld bufferIdx=%ld size=%ld",
+            sendReqId, connIdx, bufferIdx, outputBuffers[bufferIdx]->getSizeInBytes());
         session.send(connIdx, outputBuffers[bufferIdx]->data(), outputBuffers[bufferIdx]->getSizeInBytes());
-        TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), " end send connIdx: %ld bufferIdx: %ld size:%ld", connIdx,
-            bufferIdx, outputBuffers[bufferIdx]->getSizeInBytes());
+        TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), "[send] DONE reqId=%zu connIdx=%ld bufferIdx=%ld size=%ld",
+            sendReqId, connIdx, bufferIdx, outputBuffers[bufferIdx]->getSizeInBytes());
     }
     else
     {
@@ -122,6 +125,11 @@ void sendAllBuffers(TransferSession& session, int deviceId,
     executor::kv_cache::TargetRanksInfo const& targetInfo, std::vector<size_t> const& pickUpConnections)
 {
     size_t targetNum = pickUpConnections.size();
+    // Diagnostic markers around future.get() waits — if the send-side wedges
+    // inside the transport layer rather than at the formatter-level short
+    // circuit, the FUTURE_WAIT / FUTURE_JOIN trail pins the stuck batch to a
+    // specific (reqId, connIdx-range, elapsedMs) for post-mortem.
+    auto const sendReqId = static_cast<uint64_t>(session.getLlmRequest().mRequestId);
 
     if (targetNum > 1)
     {
@@ -140,6 +148,7 @@ void sendAllBuffers(TransferSession& session, int deviceId,
             auto concurrencyNum = std::min(std::max(static_cast<size_t>(1), bufferCoverTargetNum), targetNum);
 
             auto remainSendNum = targetNum;
+            size_t batchIdx = 0;
             while (remainSendNum > 0)
             {
                 auto sendConcurrencyNum = std::min(remainSendNum, concurrencyNum);
@@ -157,11 +166,20 @@ void sendAllBuffers(TransferSession& session, int deviceId,
                                 bufferManager, targetInfo, pickUpConnections);
                         }));
                 }
+                TLLM_LOG_WARNING("[send] FUTURE_WAIT reqId=%zu batch=%zu concurrency=%zu remain=%zu", sendReqId,
+                    batchIdx, sendConcurrencyNum, remainSendNum);
+                auto const waitStart = std::chrono::steady_clock::now();
                 for (auto& future : futures)
                 {
                     future.get();
                 }
+                auto const elapsedMs
+                    = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - waitStart)
+                          .count();
+                TLLM_LOG_WARNING("[send] FUTURE_JOIN reqId=%zu batch=%zu elapsedMs=%lld", sendReqId, batchIdx,
+                    static_cast<long long>(elapsedMs));
                 remainSendNum -= sendConcurrencyNum;
+                ++batchIdx;
             }
         }
     }
@@ -481,16 +499,16 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         // cache blocks to the corresponding buffer.
         // 5. send the buffer to the corresponding target. Ideally, we send only once (one buffer) for each target.
 
-        // RAII wrapper mirrors the receiver-side pattern (see BufferIndexHolder
-        // comment in baseTransBuffer.h): any non-happy exit between acquire and
-        // the explicit free below auto-releases the slot, closing the class of
-        // "early return leaks a send-pool index permanently" bug that wedged
-        // the size-1 pool under saturation. The happy path detaches the holder
-        // right before the existing freeBufferIndexForSend so the invariant
-        // "sendAllBuffers returning = transport done, slot safe to free
-        // immediately" is unchanged.
+        // RAII wrapper mirrors the receiver-side pattern. Happy-path uses
+        // sendHolder.release() (silent atomic free+disarm) after sendAllBuffers
+        // returns; any other exit between acquire and release auto-releases via
+        // ~BufferIndexHolder with a diagnostic AUTO_RELEASE log. The send-pool
+        // CV wait inside assignBufferIndexForSend observes the session's
+        // per-request cancel flag and throws on cancel (parity with recv side).
         auto const sendReqIdForLog = std::make_optional(static_cast<uint64_t>(llmRequest.mRequestId));
-        auto cacheBufferId = mCacheTransBufferManager->assignBufferIndexForSend(sendReqIdForLog);
+        auto const* sendCancelFlag = &session.getDataContext().getTransferTerminate();
+        auto cacheBufferId
+            = mCacheTransBufferManager->assignBufferIndexForSend(sendCancelFlag, /*waitSliceMs=*/100, sendReqIdForLog);
         BufferIndexHolder sendHolder(*mCacheTransBufferManager, cacheBufferId, /*isRecv=*/false, sendReqIdForLog);
         TLLM_LOG_DEBUG("[buf] SEND_ACQUIRED reqId=%zu index=%d", llmRequest.mRequestId, cacheBufferId.value_or(-1));
         int peerDuplicateHeadFactor = targetInfo.mPeerDupHeadFactor;
@@ -574,14 +592,13 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         sendAllBuffers(session, deviceId, outputSplitCaches, bufferCoverTargetNum, preAllocSendBuffer, bufferManager,
             targetInfo, pickUpConnections);
 
-        session.setTime(TransferSession::kTimeTransmissions);
-
-        // Happy path: sendAllBuffers returned, slot is safe to free. Detach the
-        // holder so its destructor becomes a no-op, then free explicitly (keeps
-        // the timing semantics identical to pre-RAII code).
-        (void) sendHolder.detach();
+        // Atomic happy-path release — frees the slot and disarms the holder in
+        // one noexcept call. Placed immediately after sendAllBuffers so any
+        // subsequent throw (e.g. from setTime) cannot trip the destructor
+        // fallback and emit a misleading AUTO_RELEASE for a non-leak.
+        sendHolder.release();
         TLLM_LOG_DEBUG("[buf] SEND_RELEASE reqId=%zu index=%d", llmRequest.mRequestId, cacheBufferId.value_or(-1));
-        mCacheTransBufferManager->freeBufferIndexForSend(cacheBufferId);
+        session.setTime(TransferSession::kTimeTransmissions);
         session.setTime(TransferSession::kTimePostprocess);
     }
     TLLM_LOG_DEBUG(

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -481,7 +481,18 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         // cache blocks to the corresponding buffer.
         // 5. send the buffer to the corresponding target. Ideally, we send only once (one buffer) for each target.
 
-        auto cacheBufferId = mCacheTransBufferManager->assignBufferIndexForSend();
+        // RAII wrapper mirrors the receiver-side pattern (see BufferIndexHolder
+        // comment in baseTransBuffer.h): any non-happy exit between acquire and
+        // the explicit free below auto-releases the slot, closing the class of
+        // "early return leaks a send-pool index permanently" bug that wedged
+        // the size-1 pool under saturation. The happy path detaches the holder
+        // right before the existing freeBufferIndexForSend so the invariant
+        // "sendAllBuffers returning = transport done, slot safe to free
+        // immediately" is unchanged.
+        auto const sendReqIdForLog = std::make_optional(static_cast<uint64_t>(llmRequest.mRequestId));
+        auto cacheBufferId = mCacheTransBufferManager->assignBufferIndexForSend(sendReqIdForLog);
+        BufferIndexHolder sendHolder(*mCacheTransBufferManager, cacheBufferId, /*isRecv=*/false, sendReqIdForLog);
+        TLLM_LOG_DEBUG("[buf] SEND_ACQUIRED reqId=%zu index=%d", llmRequest.mRequestId, cacheBufferId.value_or(-1));
         int peerDuplicateHeadFactor = targetInfo.mPeerDupHeadFactor;
         auto bufferTargetNum = targetNum / peerDuplicateHeadFactor;
         auto ppRank = selfIdx
@@ -565,6 +576,11 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
 
         session.setTime(TransferSession::kTimeTransmissions);
 
+        // Happy path: sendAllBuffers returned, slot is safe to free. Detach the
+        // holder so its destructor becomes a no-op, then free explicitly (keeps
+        // the timing semantics identical to pre-RAII code).
+        (void) sendHolder.detach();
+        TLLM_LOG_DEBUG("[buf] SEND_RELEASE reqId=%zu index=%d", llmRequest.mRequestId, cacheBufferId.value_or(-1));
         mCacheTransBufferManager->freeBufferIndexForSend(cacheBufferId);
         session.setTime(TransferSession::kTimePostprocess);
     }

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -590,47 +590,27 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                     // Check if total elapsed time exceeds kv_transfer_timeout_ms.
                     // Without this, stuck transfers retry the per-iteration timeout forever,
                     // holding KV blocks indefinitely and exhausting the cache pool.
+                    // Check if total elapsed time exceeds kv_transfer_timeout_ms.
+                    // The Python-side is_disagg_context_transmission_state guard
+                    // ensures requests are NOT terminated during active transfer,
+                    // so the LlmRequest* pointer is guaranteed to be valid here.
+                    // Without this total timeout, stuck transfers retry the
+                    // per-iteration timeout forever, holding pinned KV blocks
+                    // indefinitely and exhausting the cache pool.
                     if (kvTransferTimeoutMs.has_value())
                     {
                         auto transferStart = request->getKvCacheTransferStart();
-                        // Guard: if transfer start was never set (TimePoint epoch),
-                        // the request pointer may be stale or the start time was not recorded.
-                        // Treat as timed out immediately to avoid infinite retry.
-                        bool startTimeValid = transferStart.time_since_epoch().count() > 0;
-                        bool shouldTimeout = !startTimeValid;
-                        long elapsedMs = 0;
-                        if (startTimeValid)
+                        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            LlmRequest::getSteadyClockNow() - transferStart);
+                        auto elapsedMs = static_cast<long>(elapsed.count());
+                        if (elapsedMs > kvTransferTimeoutMs.value())
                         {
-                            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                LlmRequest::getSteadyClockNow() - transferStart);
-                            elapsedMs = static_cast<long>(elapsed.count());
-                            shouldTimeout = elapsedMs > kvTransferTimeoutMs.value();
-                        }
-                        if (shouldTimeout)
-                        {
-                            // IMPORTANT: Do NOT dereference request->setState() or call
-                            // mCacheSender->cancelRequest(*request) here. The LlmRequest*
-                            // in mSenderFutures is a raw pointer with no ownership — the
-                            // Python layer may have already freed the request. Dereferencing
-                            // a dangling pointer causes heap corruption (free(): invalid
-                            // next size). Just erase the stale entry from mSenderFutures.
-                            // The Python layer handles state transitions via
-                            // _end_transfer_and_maybe_terminate when it processes the
-                            // error/completion from check_context_transfer_status.
-                            if (startTimeValid)
-                            {
-                                TLLM_LOG_WARNING(
-                                    "Context KV cache transfer timed out: elapsed %ld ms > limit %d ms. "
-                                    "Removing entry from mSenderFutures (ptr=%p).",
-                                    elapsedMs, kvTransferTimeoutMs.value(), static_cast<void const*>(request));
-                            }
-                            else
-                            {
-                                TLLM_LOG_WARNING(
-                                    "Removing stale entry from mSenderFutures: transfer start time is "
-                                    "uninitialized (request pointer %p may be dangling).",
-                                    static_cast<void const*>(request));
-                            }
+                            TLLM_LOG_WARNING(
+                                "Context KV cache transfer for request %ld exceeded total timeout: "
+                                "elapsed %ld ms > limit %d ms. Marking as error.",
+                                request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                            request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                            requestsStatus.errorRequestIds.insert(request->mRequestId);
                             it = mSenderFutures.erase(it);
                             continue;
                         }
@@ -651,14 +631,13 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
             }
             catch (std::exception const& e)
             {
-                // Do NOT dereference request here — the pointer may be dangling.
-                // The future threw an exception (e.g. Broken promise from sender
-                // thread crash), and the request may have been freed concurrently.
-                // Just log the error and erase the entry.
-                TLLM_LOG_WARNING(
-                    "Error during context transfer (ptr=%p): %s. "
-                    "Removing entry from mSenderFutures.",
-                    static_cast<void const*>(request), e.what());
+                // The Python-side is_disagg_context_transmission_state guard
+                // ensures the request is alive, so the pointer is valid.
+                // Report as error so Python can call end_transfer to unpin blocks.
+                TLLM_LOG_WARNING("Error during context transfer for request %ld: %s. Marking as error.",
+                    request->mRequestId, e.what());
+                request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                requestsStatus.errorRequestIds.insert(request->mRequestId);
                 it = mSenderFutures.erase(it);
             }
         }

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -489,11 +489,17 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     bool blockAll = !atLeastRequestNum.has_value();
     std::optional<int> senderFutureTimeoutMs = std::nullopt;
     std::optional<int> kvTransferTimeoutMs = std::nullopt;
-    // If blockAll is true, we want to block and not use a timeout
-    if (!blockAll && mCacheTransceiverConfig.has_value())
+    if (mCacheTransceiverConfig.has_value())
     {
-        senderFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
+        // The overall transfer deadline applies in both blockAll and polling modes; a
+        // stuck sender must not hang indefinitely regardless of how callers invoke this.
         kvTransferTimeoutMs = mCacheTransceiverConfig->getKvTransferTimeoutMs();
+        // The per-iteration poll timeout is only relevant when the caller wants to
+        // return after checking at least `atLeastRequestNum` entries.
+        if (!blockAll)
+        {
+            senderFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
+        }
     }
 
     // Log mSenderFutures state for diagnosing dangling pointer issues.
@@ -573,9 +579,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         {
             try
             {
-                // Wait for up to a specified timeout
+                // Wait for up to a specified timeout (0 means a single non-blocking poll in blockAll mode).
                 auto status = future.wait_for(std::chrono::milliseconds(senderFutureTimeoutMs.value_or(0)));
-                if (status == std::future_status::ready || !senderFutureTimeoutMs.has_value())
+                if (status == std::future_status::ready)
                 {
                     future.get();
                     requestsStatus.completedRequestIds.insert(request->mRequestId);
@@ -587,16 +593,12 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 }
                 else if (status == std::future_status::timeout)
                 {
-                    // Check if total elapsed time exceeds kv_transfer_timeout_ms.
-                    // Without this, stuck transfers retry the per-iteration timeout forever,
-                    // holding KV blocks indefinitely and exhausting the cache pool.
-                    // Check if total elapsed time exceeds kv_transfer_timeout_ms.
-                    // The Python-side is_disagg_context_transmission_state guard
-                    // ensures requests are NOT terminated during active transfer,
-                    // so the LlmRequest* pointer is guaranteed to be valid here.
-                    // Without this total timeout, stuck transfers retry the
-                    // per-iteration timeout forever, holding pinned KV blocks
-                    // indefinitely and exhausting the cache pool.
+                    // Future is not ready. Enforce the overall deadline first, regardless of
+                    // blockAll. The Python-side is_disagg_context_transmission_state guard
+                    // ensures the LlmRequest* is alive here. Without this, a stuck sender
+                    // would retry the per-iteration timeout forever (polling mode) or block
+                    // indefinitely on future.get() (blockAll mode), pinning KV blocks and
+                    // exhausting the cache pool.
                     if (kvTransferTimeoutMs.has_value())
                     {
                         auto transferStart = request->getKvCacheTransferStart();
@@ -615,9 +617,25 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                             continue;
                         }
                     }
-                    TLLM_LOG_WARNING("Timed out waiting for context KV cache transfer after %d milliseconds.",
-                        senderFutureTimeoutMs.value());
-                    ++it;
+                    if (senderFutureTimeoutMs.has_value())
+                    {
+                        TLLM_LOG_WARNING("Timed out waiting for context KV cache transfer after %d milliseconds.",
+                            senderFutureTimeoutMs.value());
+                        ++it;
+                    }
+                    else
+                    {
+                        // blockAll mode with no deadline exceeded: block on get() as the
+                        // caller intends, but the deadline will be re-checked on each entry
+                        // of subsequent outer invocations.
+                        future.get();
+                        requestsStatus.completedRequestIds.insert(request->mRequestId);
+                        if (markComplete)
+                        {
+                            request->setState(LlmRequestState::kDISAGG_CONTEXT_COMPLETE);
+                        }
+                        it = mSenderFutures.erase(it);
+                    }
                 }
                 else
                 {

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -323,7 +323,7 @@ void CacheTransceiver::setContextState(LlmRequest* llmRequest)
     }
 }
 
-void CacheTransceiver::respondAndSendAsync(LlmRequest* llmRequest)
+void CacheTransceiver::respondAndSendAsync(std::shared_ptr<LlmRequest> llmRequest)
 {
     TLLM_CHECK(llmRequest && llmRequest->isContextOnlyRequest());
     llmRequest->setState(LlmRequestState::kDISAGG_CONTEXT_TRANS_IN_PROGRESS);
@@ -337,12 +337,12 @@ void CacheTransceiver::respondAndSendAsync(LlmRequest* llmRequest)
         }
         return;
     }
-    setContextState(llmRequest);
-    auto future = mCacheSender->sendAsync(*llmRequest);
+    setContextState(llmRequest.get());
+    auto future = mCacheSender->sendAsync(llmRequest);
     TLLM_LOG_DEBUG("respondAndSendAsync: adding request %ld to mSenderFutures (ptr=%p, transferStart=%ld, size=%zu)",
-        llmRequest->mRequestId, static_cast<void*>(llmRequest),
+        llmRequest->mRequestId, static_cast<void*>(llmRequest.get()),
         static_cast<long>(llmRequest->getKvCacheTransferStart().time_since_epoch().count()), mSenderFutures.size() + 1);
-    mSenderFutures.emplace_back(llmRequest, std::move(future));
+    mSenderFutures.emplace_back(std::move(llmRequest), std::move(future));
 }
 
 void CacheTransceiver::respondAndSendLayerWise(
@@ -357,22 +357,22 @@ void CacheTransceiver::respondAndSendLayerWise(
 
         llmRequest->setState(LlmRequestState::kDISAGG_CONTEXT_INIT_AND_TRANS);
         setContextState(llmRequest.get());
-        auto future = mCacheSender->sendAsync(*llmRequest);
-        mSenderFutures.emplace_back(llmRequest.get(), std::move(future));
+        auto future = mCacheSender->sendAsync(llmRequest);
+        mSenderFutures.emplace_back(llmRequest, std::move(future));
     }
 }
 
-void CacheTransceiver::requestAndReceiveSync(LlmRequest* llmRequest)
+void CacheTransceiver::requestAndReceiveSync(std::shared_ptr<LlmRequest> llmRequest)
 {
     TLLM_CHECK(llmRequest && llmRequest->isGenerationOnlyRequest());
     {
-        auto future = mCacheReceiver->receiveAsync(*llmRequest);
+        auto future = mCacheReceiver->receiveAsync(llmRequest);
         future.get();
     }
     llmRequest->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE);
 }
 
-void CacheTransceiver::requestAndReceiveAsync(LlmRequest* llmRequest)
+void CacheTransceiver::requestAndReceiveAsync(std::shared_ptr<LlmRequest> llmRequest)
 {
     TLLM_CHECK(llmRequest && llmRequest->isGenerationOnlyRequest());
 
@@ -394,14 +394,15 @@ void CacheTransceiver::requestAndReceiveAsync(LlmRequest* llmRequest)
     // valid transfer start time" and is overwritten by requestSync() with a
     // slightly later time — harmless for the deadline check.
     llmRequest->setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
-    auto future = mCacheReceiver->receiveAsync(*llmRequest);
+    auto future = mCacheReceiver->receiveAsync(llmRequest);
     TLLM_LOG_DEBUG(
         "requestAndReceiveAsync: adding request %ld to mRequesterFutures (ptr=%p, transferStart=%ld, size=%zu)",
-        llmRequest->mRequestId, static_cast<void*>(llmRequest),
+        llmRequest->mRequestId, static_cast<void*>(llmRequest.get()),
         static_cast<long>(llmRequest->getKvCacheTransferStart().time_since_epoch().count()),
         mRequesterFutures.size() + 1);
-    mRequesterFutures.emplace_back(llmRequest, std::move(future));
     llmRequest->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+    TLLM_LOG_WARNING("[reqFut] INSERT reqId=%zu size_after=%zu", llmRequest->mRequestId, mRequesterFutures.size() + 1);
+    mRequesterFutures.emplace_back(std::move(llmRequest), std::move(future));
 }
 
 std::vector<LlmRequest::RequestIdType> gatherRequestIds(
@@ -530,8 +531,8 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         {
             auto& [req, fut] = mSenderFutures[i];
             auto startTs = req->getKvCacheTransferStart().time_since_epoch().count();
-            TLLM_LOG_DEBUG("  [%zu] ptr=%p reqId=%ld startTs=%ld", i, static_cast<void const*>(req), req->mRequestId,
-                static_cast<long>(startTs));
+            TLLM_LOG_DEBUG("  [%zu] ptr=%p reqId=%ld startTs=%ld", i, static_cast<void const*>(req.get()),
+                req->mRequestId, static_cast<long>(startTs));
         }
     }
 
@@ -735,8 +736,8 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
         {
             auto& [req, fut] = mRequesterFutures[i];
             auto startTs = req->getKvCacheTransferStart().time_since_epoch().count();
-            TLLM_LOG_DEBUG("  [%zu] ptr=%p reqId=%ld startTs=%ld", i, static_cast<void const*>(req), req->mRequestId,
-                static_cast<long>(startTs));
+            TLLM_LOG_DEBUG("  [%zu] ptr=%p reqId=%ld startTs=%ld", i, static_cast<void const*>(req.get()),
+                req->mRequestId, static_cast<long>(startTs));
         }
     }
 
@@ -853,14 +854,13 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
     // Helper: finalize a generation-side transfer on the happy path.
     // Called in two places: status == ready, and blockAll fall-through
     // from the timeout branch.
-    auto const completeEntry = [this](LlmRequest* request)
+    auto const completeEntry = [this](std::shared_ptr<LlmRequest> const& request)
     {
         request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE);
         if (!common::getEnvKVCacheTimeOutputPath().empty())
         {
-            auto transferSyncComm
-                = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupDataComm : mGroupComm;
-            updateKVCacheTransferBW(transferSyncComm, request);
+            auto transferSyncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupDataComm : mGroupComm;
+            updateKVCacheTransferBW(transferSyncComm, request.get());
         }
         if (useMPI())
         {
@@ -880,7 +880,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
     std::size_t numErrored = 0;
     for (auto it = mRequesterFutures.begin(); it != mRequesterFutures.end();)
     {
-        auto* request = it->first;
+        auto& request = it->first; // std::shared_ptr<LlmRequest> const& — our own strong ref
         auto& future = it->second;
         // Enforce the overall deadline for every entry on every invocation,
         // independent of the readiness gate below. In polling mode (blockAll ==
@@ -890,8 +890,16 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
         // (see checkContextTransferStatus above) never becomes ready, so
         // gating the deadline check behind `toCompleteIdSet` would let stuck
         // entries accumulate in `mRequesterFutures` and pin generation-side
-        // KV blocks forever. The Python-side guard against terminating
-        // in-transmission requests ensures the LlmRequest* is alive here.
+        // KV blocks forever.
+        //
+        // Lifetime: mRequesterFutures now holds shared_ptr<LlmRequest>, so
+        // the request is kept alive for the duration of every C++ access
+        // here regardless of whether Python has already dropped its
+        // active_requests reference. The previous raw-pointer design
+        // required the Python Path A guard to delay Python-side
+        // _terminate_request, which is what produced the orphan-induced
+        // KV-block leak: an orphan that never reached this iteration
+        // stayed IN_PROGRESS forever and Python kept skipping cleanup.
         if (kvTransferTimeoutMs.has_value())
         {
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1006,7 +1014,7 @@ bool CacheTransceiver::checkGenTransferComplete() const
     return mRequesterFutures.empty();
 }
 
-bool CacheTransceiver::cancelRequest(LlmRequest* llmRequest)
+bool CacheTransceiver::cancelRequest(std::shared_ptr<LlmRequest> llmRequest)
 {
     if (llmRequest->isContextOnlyRequest())
     {

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -590,6 +590,32 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     for (auto it = mSenderFutures.begin(); it != mSenderFutures.end();)
     {
         auto& [request, future] = *it;
+        // Enforce the overall deadline for every entry on every invocation,
+        // independent of the readiness gate below. `toCompleteIdSet` is
+        // populated from the consensus freqVec (entries that were ready on
+        // every rank) plus up to `atLeastRequestNum` insertion-order entries.
+        // A stuck sender whose future never becomes ready is not in the
+        // consensus set, so with `atLeastRequestNum=0` it would otherwise
+        // escape the deadline check entirely and pin KV blocks forever. The
+        // Python-side is_disagg_context_transmission_state guard ensures the
+        // LlmRequest* is alive here.
+        if (kvTransferTimeoutMs.has_value())
+        {
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                LlmRequest::getSteadyClockNow() - request->getKvCacheTransferStart());
+            auto elapsedMs = static_cast<long>(elapsed.count());
+            if (elapsedMs > kvTransferTimeoutMs.value())
+            {
+                TLLM_LOG_WARNING(
+                    "Context KV cache transfer for request %ld exceeded total timeout: "
+                    "elapsed %ld ms > limit %d ms. Marking as error.",
+                    request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                requestsStatus.errorRequestIds.insert(request->mRequestId);
+                it = mSenderFutures.erase(it);
+                continue;
+            }
+        }
         if (blockAll || (toCompleteIdSet.find(request->mRequestId) != toCompleteIdSet.end()))
         {
             try
@@ -608,30 +634,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 }
                 else if (status == std::future_status::timeout)
                 {
-                    // Future is not ready. Enforce the overall deadline first, regardless of
-                    // blockAll. The Python-side is_disagg_context_transmission_state guard
-                    // ensures the LlmRequest* is alive here. Without this, a stuck sender
-                    // would retry the per-iteration timeout forever (polling mode) or block
-                    // indefinitely on future.get() (blockAll mode), pinning KV blocks and
-                    // exhausting the cache pool.
-                    if (kvTransferTimeoutMs.has_value())
-                    {
-                        auto transferStart = request->getKvCacheTransferStart();
-                        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                            LlmRequest::getSteadyClockNow() - transferStart);
-                        auto elapsedMs = static_cast<long>(elapsed.count());
-                        if (elapsedMs > kvTransferTimeoutMs.value())
-                        {
-                            TLLM_LOG_WARNING(
-                                "Context KV cache transfer for request %ld exceeded total timeout: "
-                                "elapsed %ld ms > limit %d ms. Marking as error.",
-                                request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
-                            request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-                            requestsStatus.errorRequestIds.insert(request->mRequestId);
-                            it = mSenderFutures.erase(it);
-                            continue;
-                        }
-                    }
+                    // The overall deadline was already enforced unconditionally
+                    // at the top of this loop, so if we reach here the deadline
+                    // has not yet passed for this entry.
                     if (senderFutureTimeoutMs.has_value())
                     {
                         TLLM_LOG_WARNING("Timed out waiting for context KV cache transfer after %d milliseconds.",
@@ -871,6 +876,33 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
     {
         auto* request = it->first;
         auto& future = it->second;
+        // Enforce the overall deadline for every entry on every invocation,
+        // independent of the readiness gate below. In polling mode (blockAll ==
+        // false) `toCompleteIdSet` is populated from the initial
+        // `wait_for(0)` sweep and only contains receivers whose futures were
+        // already ready. A receiver whose peer sender evicted the transfer
+        // (see checkContextTransferStatus above) never becomes ready, so
+        // gating the deadline check behind `toCompleteIdSet` would let stuck
+        // entries accumulate in `mRequesterFutures` and pin generation-side
+        // KV blocks forever. The Python-side guard against terminating
+        // in-transmission requests ensures the LlmRequest* is alive here.
+        if (kvTransferTimeoutMs.has_value())
+        {
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                LlmRequest::getSteadyClockNow() - request->getKvCacheTransferStart());
+            auto elapsedMs = static_cast<long>(elapsed.count());
+            if (elapsedMs > kvTransferTimeoutMs.value())
+            {
+                TLLM_LOG_WARNING(
+                    "Generation KV cache transfer for request %ld exceeded total timeout: "
+                    "elapsed %ld ms > limit %d ms. Marking as error.",
+                    request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                it = mRequesterFutures.erase(it);
+                ++numErrored;
+                continue;
+            }
+        }
         if (blockAll || toCompleteIdSet.find(request->mRequestId) != toCompleteIdSet.end())
         {
             try
@@ -887,35 +919,9 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
                 }
                 else if (status == std::future_status::timeout)
                 {
-                    // Future is not ready. Enforce the overall deadline first,
-                    // regardless of blockAll. The Python-side guard against
-                    // terminating in-transmission requests ensures the LlmRequest*
-                    // is alive here. Without this, a stuck receiver would retry
-                    // the per-iteration timeout forever (polling mode) or block
-                    // indefinitely on future.get() (blockAll mode), pinning
-                    // generation-side KV blocks.
-                    if (kvTransferTimeoutMs.has_value())
-                    {
-                        auto transferStart = request->getKvCacheTransferStart();
-                        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                            LlmRequest::getSteadyClockNow() - transferStart);
-                        auto elapsedMs = static_cast<long>(elapsed.count());
-                        if (elapsedMs > kvTransferTimeoutMs.value())
-                        {
-                            TLLM_LOG_WARNING(
-                                "Generation KV cache transfer for request %ld exceeded total timeout: "
-                                "elapsed %ld ms > limit %d ms. Marking as error.",
-                                request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
-                            request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-                            it = mRequesterFutures.erase(it);
-                            ++numErrored;
-                            continue;
-                        }
-                        TLLM_LOG_DEBUG(
-                            "checkGenTransferStatus: request %ld not ready; elapsed %ld ms "
-                            "(deadline %d ms), continuing to poll.",
-                            request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
-                    }
+                    // The overall deadline was already enforced unconditionally at
+                    // the top of this loop, so if we reach here the deadline has
+                    // not yet passed for this entry.
                     if (senderFutureTimeoutMs.has_value())
                     {
                         TLLM_LOG_WARNING("Timed out waiting for generation KV cache transfer for request %ld "

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -610,6 +610,12 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                     "Context KV cache transfer for request %ld exceeded total timeout: "
                     "elapsed %ld ms > limit %d ms. Marking as error.",
                     request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                // Defense-in-depth sender-side cancel. Sender zombies empirically
+                // unwind on peer teardown (decode-pod restart), but in general
+                // CacheSender::cancelRequest clears mReadyResponses /
+                // mCancelledRequests bookkeeping so a subsequent re-enqueue
+                // or telemetry path doesn't see the stale request.
+                mCacheSender->cancelRequest(*request);
                 request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                 requestsStatus.errorRequestIds.insert(request->mRequestId);
                 it = mSenderFutures.erase(it);
@@ -897,6 +903,21 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
                     "Generation KV cache transfer for request %ld exceeded total timeout: "
                     "elapsed %ld ms > limit %d ms. Marking as error.",
                     request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                // Erasing the std::future<void> from mRequesterFutures only
+                // destroys the Python-facing handle; the std::async task
+                // spawned by CacheReceiver::receiveAsync is still running,
+                // blocked inside recvReadySignal waiting on a peer signal
+                // that will never arrive. Over a saturation window these
+                // zombies accumulate and pin NIXL/UCX per-request state, so
+                // subsequent receives queue behind a frozen pool and every
+                // new transfer deterministically waits kv_transfer_timeout_ms
+                // even after load stops (the "no-recovery" bug). Call
+                // cancelRequest to flip the per-request cancel flag in
+                // CacheReceiver::Impl, which the notification polling loop
+                // observes via the DataContext and returns early with
+                // isReady=false. requestSync then takes the
+                // kDISAGG_TRANS_ERROR branch and the task exits cleanly.
+                mCacheReceiver->cancelRequest(*request);
                 request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                 it = mRequesterFutures.erase(it);
                 ++numErrored;

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -384,7 +384,22 @@ void CacheTransceiver::requestAndReceiveAsync(LlmRequest* llmRequest)
         return;
     }
 
+    // Record the transfer start synchronously, before pushing the future.
+    // CacheReceiver::receiveAsync() spawns a background thread that does the
+    // same thing inside requestSync(), but until that thread runs,
+    // getKvCacheTransferStart() would return the default (epoch) time point.
+    // checkGenTransferStatus's elapsed-time deadline check would then see a
+    // huge elapsed value and falsely evict the entry. A pre-emptive set
+    // here keeps the invariant "every entry in mRequesterFutures has a
+    // valid transfer start time" and is overwritten by requestSync() with a
+    // slightly later time — harmless for the deadline check.
+    llmRequest->setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
     auto future = mCacheReceiver->receiveAsync(*llmRequest);
+    TLLM_LOG_DEBUG(
+        "requestAndReceiveAsync: adding request %ld to mRequesterFutures (ptr=%p, transferStart=%ld, size=%zu)",
+        llmRequest->mRequestId, static_cast<void*>(llmRequest),
+        static_cast<long>(llmRequest->getKvCacheTransferStart().time_since_epoch().count()),
+        mRequesterFutures.size() + 1);
     mRequesterFutures.emplace_back(llmRequest, std::move(future));
     llmRequest->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
 }
@@ -679,6 +694,41 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastRequestNum)
 {
     bool blockAll = !atLeastRequestNum.has_value();
+    std::optional<int> senderFutureTimeoutMs = std::nullopt;
+    std::optional<int> kvTransferTimeoutMs = std::nullopt;
+    if (mCacheTransceiverConfig.has_value())
+    {
+        // The overall transfer deadline applies in both blockAll and polling modes; a
+        // stuck receiver must not hang indefinitely regardless of how callers invoke
+        // this. Without this, mRequesterFutures would accumulate stuck entries,
+        // pinning generation-side KV blocks and eventually exhausting the pool.
+        kvTransferTimeoutMs = mCacheTransceiverConfig->getKvTransferTimeoutMs();
+        // The per-iteration poll timeout is only relevant when the caller wants to
+        // return after checking at least `atLeastRequestNum` entries.
+        if (!blockAll)
+        {
+            senderFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
+        }
+    }
+
+    // Log mRequesterFutures state for diagnosing dangling pointer / stuck
+    // receiver issues. Mirrors the diagnostic added to checkContextTransferStatus.
+    if (!mRequesterFutures.empty())
+    {
+        TLLM_LOG_DEBUG(
+            "checkGenTransferStatus: mRequesterFutures.size()=%zu, blockAll=%d, "
+            "kvTransferTimeoutMs=%d, senderFutureTimeoutMs=%d",
+            mRequesterFutures.size(), blockAll ? 1 : 0, kvTransferTimeoutMs.value_or(-1),
+            senderFutureTimeoutMs.value_or(-1));
+        for (size_t i = 0; i < mRequesterFutures.size(); ++i)
+        {
+            auto& [req, fut] = mRequesterFutures[i];
+            auto startTs = req->getKvCacheTransferStart().time_since_epoch().count();
+            TLLM_LOG_DEBUG("  [%zu] ptr=%p reqId=%ld startTs=%ld", i, static_cast<void const*>(req), req->mRequestId,
+                static_cast<long>(startTs));
+        }
+    }
+
     std::vector<LlmRequest::RequestIdType> genTransferReadyRequestIds;
     for (auto&& [request, future] : mRequesterFutures)
     {
@@ -789,46 +839,138 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             " checkGenTransferStatus toCompleteIdSet size: %zu, atLeastRequestNum: %d ", toCompleteIdSet.size(),
             atLeastRequestNum.value_or(0));
     }
+    // Helper: finalize a generation-side transfer on the happy path.
+    // Called in two places: status == ready, and blockAll fall-through
+    // from the timeout branch.
+    auto const completeEntry = [this](LlmRequest* request)
+    {
+        request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE);
+        if (!common::getEnvKVCacheTimeOutputPath().empty())
+        {
+            auto transferSyncComm
+                = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupDataComm : mGroupComm;
+            updateKVCacheTransferBW(transferSyncComm, request);
+        }
+        if (useMPI())
+        {
+            TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
+                "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
+                request->mRequestId, request->getContextPhaseParams().value().getReqId());
+        }
+        else
+        {
+            TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
+                "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
+                request->mRequestId, request->getContextPhaseParams().value().getReqId());
+        }
+    };
+
+    std::size_t numCompleted = 0;
+    std::size_t numErrored = 0;
     for (auto it = mRequesterFutures.begin(); it != mRequesterFutures.end();)
     {
-        if (blockAll || toCompleteIdSet.find(it->first->mRequestId) != toCompleteIdSet.end())
+        auto* request = it->first;
+        auto& future = it->second;
+        if (blockAll || toCompleteIdSet.find(request->mRequestId) != toCompleteIdSet.end())
         {
             try
             {
-                it->second.get();
-                it->first->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE);
-
-                // Gather the kv cache transfer time from all workers and update to leader rank
-                if (!common::getEnvKVCacheTimeOutputPath().empty())
+                // Wait for up to a specified timeout (0 means a single non-blocking
+                // poll in blockAll mode).
+                auto status = future.wait_for(std::chrono::milliseconds(senderFutureTimeoutMs.value_or(0)));
+                if (status == std::future_status::ready)
                 {
-                    auto syncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupDataComm : mGroupComm;
-                    updateKVCacheTransferBW(syncComm, it->first);
+                    future.get();
+                    completeEntry(request);
+                    it = mRequesterFutures.erase(it);
+                    ++numCompleted;
+                }
+                else if (status == std::future_status::timeout)
+                {
+                    // Future is not ready. Enforce the overall deadline first,
+                    // regardless of blockAll. The Python-side guard against
+                    // terminating in-transmission requests ensures the LlmRequest*
+                    // is alive here. Without this, a stuck receiver would retry
+                    // the per-iteration timeout forever (polling mode) or block
+                    // indefinitely on future.get() (blockAll mode), pinning
+                    // generation-side KV blocks.
+                    if (kvTransferTimeoutMs.has_value())
+                    {
+                        auto transferStart = request->getKvCacheTransferStart();
+                        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            LlmRequest::getSteadyClockNow() - transferStart);
+                        auto elapsedMs = static_cast<long>(elapsed.count());
+                        if (elapsedMs > kvTransferTimeoutMs.value())
+                        {
+                            TLLM_LOG_WARNING(
+                                "Generation KV cache transfer for request %ld exceeded total timeout: "
+                                "elapsed %ld ms > limit %d ms. Marking as error.",
+                                request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                            request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                            it = mRequesterFutures.erase(it);
+                            ++numErrored;
+                            continue;
+                        }
+                        TLLM_LOG_DEBUG(
+                            "checkGenTransferStatus: request %ld not ready; elapsed %ld ms "
+                            "(deadline %d ms), continuing to poll.",
+                            request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                    }
+                    if (senderFutureTimeoutMs.has_value())
+                    {
+                        TLLM_LOG_WARNING("Timed out waiting for generation KV cache transfer for request %ld "
+                                         "after %d milliseconds (per-iteration).",
+                            request->mRequestId, senderFutureTimeoutMs.value());
+                        ++it;
+                    }
+                    else
+                    {
+                        // blockAll mode with deadline not yet exceeded: block on get()
+                        // as the caller requested. A hard cap across a stuck receiver
+                        // only applies on subsequent outer invocations — callers that
+                        // need an unconditional hard cap should pass atLeastRequestNum
+                        // so the per-iteration poll timeout can drive the deadline
+                        // check each tick.
+                        future.get();
+                        completeEntry(request);
+                        it = mRequesterFutures.erase(it);
+                        ++numCompleted;
+                    }
+                }
+                else
+                {
+                    TLLM_LOG_ERROR(
+                        "Future returned unexpected status for generation request %ld. Marking as error.",
+                        request->mRequestId);
+                    request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                    it = mRequesterFutures.erase(it);
+                    ++numErrored;
                 }
             }
             catch (std::exception const& e)
             {
-                TLLM_LOG_ERROR(
-                    "Error occurred during generation transfer for request %ld: %s", it->first->mRequestId, e.what());
-                it->first->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                // The Python-side guard against terminating in-transmission requests
+                // ensures the LlmRequest* is still alive here. Report as error so
+                // Python's _check_cache_transfer_errors picks it up (via state ==
+                // kDISAGG_TRANS_ERROR) and cleanly unwinds the request.
+                TLLM_LOG_WARNING("Error during generation transfer for request %ld: %s. Marking as error.",
+                    request->mRequestId, e.what());
+                request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                it = mRequesterFutures.erase(it);
+                ++numErrored;
             }
-            if (useMPI())
-            {
-                TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
-                    it->first->mRequestId, it->first->getContextPhaseParams().value().getReqId());
-            }
-            else
-            {
-                TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
-                    it->first->mRequestId, it->first->getContextPhaseParams().value().getReqId());
-            }
-            it = mRequesterFutures.erase(it);
         }
         else
         {
             ++it;
         }
+    }
+
+    if (numCompleted > 0 || numErrored > 0)
+    {
+        TLLM_LOG_DEBUG(
+            "checkGenTransferStatus done: completed=%zu, errored=%zu, mRequesterFutures.size()=%zu",
+            numCompleted, numErrored, mRequesterFutures.size());
     }
 }
 

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -339,6 +339,9 @@ void CacheTransceiver::respondAndSendAsync(LlmRequest* llmRequest)
     }
     setContextState(llmRequest);
     auto future = mCacheSender->sendAsync(*llmRequest);
+    TLLM_LOG_DEBUG("respondAndSendAsync: adding request %ld to mSenderFutures (ptr=%p, transferStart=%ld, size=%zu)",
+        llmRequest->mRequestId, static_cast<void*>(llmRequest),
+        static_cast<long>(llmRequest->getKvCacheTransferStart().time_since_epoch().count()), mSenderFutures.size() + 1);
     mSenderFutures.emplace_back(llmRequest, std::move(future));
 }
 
@@ -485,10 +488,30 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 {
     bool blockAll = !atLeastRequestNum.has_value();
     std::optional<int> senderFutureTimeoutMs = std::nullopt;
+    std::optional<int> kvTransferTimeoutMs = std::nullopt;
     // If blockAll is true, we want to block and not use a timeout
     if (!blockAll && mCacheTransceiverConfig.has_value())
     {
         senderFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
+        kvTransferTimeoutMs = mCacheTransceiverConfig->getKvTransferTimeoutMs();
+    }
+
+    // Log mSenderFutures state for diagnosing dangling pointer issues.
+    // Each entry's pointer address and request ID are logged so we can detect
+    // when a pointer's underlying memory is freed (reqId changes to 0).
+    if (!mSenderFutures.empty())
+    {
+        TLLM_LOG_DEBUG(
+            "checkContextTransferStatus: mSenderFutures.size()=%zu, blockAll=%d, "
+            "kvTransferTimeoutMs=%d",
+            mSenderFutures.size(), blockAll ? 1 : 0, kvTransferTimeoutMs.value_or(-1));
+        for (size_t i = 0; i < mSenderFutures.size(); ++i)
+        {
+            auto& [req, fut] = mSenderFutures[i];
+            auto startTs = req->getKvCacheTransferStart().time_since_epoch().count();
+            TLLM_LOG_DEBUG("  [%zu] ptr=%p reqId=%ld startTs=%ld", i, static_cast<void const*>(req), req->mRequestId,
+                static_cast<long>(startTs));
+        }
     }
 
     auto syncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupTPInDPComm : mGroupTensorParaComm;
@@ -564,6 +587,54 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 }
                 else if (status == std::future_status::timeout)
                 {
+                    // Check if total elapsed time exceeds kv_transfer_timeout_ms.
+                    // Without this, stuck transfers retry the per-iteration timeout forever,
+                    // holding KV blocks indefinitely and exhausting the cache pool.
+                    if (kvTransferTimeoutMs.has_value())
+                    {
+                        auto transferStart = request->getKvCacheTransferStart();
+                        // Guard: if transfer start was never set (TimePoint epoch),
+                        // the request pointer may be stale or the start time was not recorded.
+                        // Treat as timed out immediately to avoid infinite retry.
+                        bool startTimeValid = transferStart.time_since_epoch().count() > 0;
+                        bool shouldTimeout = !startTimeValid;
+                        long elapsedMs = 0;
+                        if (startTimeValid)
+                        {
+                            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                LlmRequest::getSteadyClockNow() - transferStart);
+                            elapsedMs = static_cast<long>(elapsed.count());
+                            shouldTimeout = elapsedMs > kvTransferTimeoutMs.value();
+                        }
+                        if (shouldTimeout)
+                        {
+                            // IMPORTANT: Do NOT dereference request->setState() or call
+                            // mCacheSender->cancelRequest(*request) here. The LlmRequest*
+                            // in mSenderFutures is a raw pointer with no ownership — the
+                            // Python layer may have already freed the request. Dereferencing
+                            // a dangling pointer causes heap corruption (free(): invalid
+                            // next size). Just erase the stale entry from mSenderFutures.
+                            // The Python layer handles state transitions via
+                            // _end_transfer_and_maybe_terminate when it processes the
+                            // error/completion from check_context_transfer_status.
+                            if (startTimeValid)
+                            {
+                                TLLM_LOG_WARNING(
+                                    "Context KV cache transfer timed out: elapsed %ld ms > limit %d ms. "
+                                    "Removing entry from mSenderFutures (ptr=%p).",
+                                    elapsedMs, kvTransferTimeoutMs.value(), static_cast<void const*>(request));
+                            }
+                            else
+                            {
+                                TLLM_LOG_WARNING(
+                                    "Removing stale entry from mSenderFutures: transfer start time is "
+                                    "uninitialized (request pointer %p may be dangling).",
+                                    static_cast<void const*>(request));
+                            }
+                            it = mSenderFutures.erase(it);
+                            continue;
+                        }
+                    }
                     TLLM_LOG_WARNING("Timed out waiting for context KV cache transfer after %d milliseconds.",
                         senderFutureTimeoutMs.value());
                     ++it;
@@ -580,10 +651,14 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
             }
             catch (std::exception const& e)
             {
-                TLLM_LOG_ERROR(
-                    "Error occurred during context transfer for request %ld: %s", request->mRequestId, e.what());
-                request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-                requestsStatus.errorRequestIds.insert(request->mRequestId);
+                // Do NOT dereference request here — the pointer may be dangling.
+                // The future threw an exception (e.g. Broken promise from sender
+                // thread crash), and the request may have been freed concurrently.
+                // Just log the error and erase the entry.
+                TLLM_LOG_WARNING(
+                    "Error during context transfer (ptr=%p): %s. "
+                    "Removing entry from mSenderFutures.",
+                    static_cast<void const*>(request), e.what());
                 it = mSenderFutures.erase(it);
             }
         }
@@ -591,6 +666,14 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         {
             ++it;
         }
+    }
+
+    if (!requestsStatus.completedRequestIds.empty() || !requestsStatus.errorRequestIds.empty())
+    {
+        TLLM_LOG_DEBUG(
+            "checkContextTransferStatus done: completed=%zu, errors=%zu, "
+            "mSenderFutures.size()=%zu",
+            requestsStatus.completedRequestIds.size(), requestsStatus.errorRequestIds.size(), mSenderFutures.size());
     }
 
     return requestsStatus;

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -756,7 +756,10 @@ public:
     [[nodiscard]] std::future<void> receiveAsync(LlmRequest& llmRequest)
     {
         // TODO: Modify the implementation here to avoid frequent thread creation.
-        return std::async(std::launch::async, &CacheReceiver::Impl::requestSync, this, std::ref(llmRequest));
+        // Lambda disambiguates the overloaded requestSync; the single-arg
+        // overload delegates to the per-request-cancel version using
+        // mTerminate as the cancel source.
+        return std::async(std::launch::async, [this, &llmRequest]() { requestSync(llmRequest); });
     }
 
     [[nodiscard]] std::future<void> requestAndReceiveAsyncMultiThreads(LlmRequest& llmRequest)
@@ -780,9 +783,22 @@ public:
                 mRequestFutures.emplace_back(std::move(requestFuture));
             }
             auto& asyncResource = mInstanceToAsyncResource.at(processInfo);
+            // Register a per-request cancel flag so cancelRequest() can abort
+            // the receive even after it has been dequeued and is blocked inside
+            // requestSync (e.g. waiting on recvReadySignal for a peer that
+            // will never respond — the ghost-UCX scenario described in the
+            // gen-side no-recovery investigation). The shared_ptr keeps the
+            // atomic alive for the duration of both the RequestAndPromise
+            // (held on the queue / in the worker's local) and any downstream
+            // DataContext references.
+            auto cancelFlag = std::make_shared<std::atomic<bool>>(false);
+            {
+                std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+                mInFlightCancelFlags[llmRequest.mRequestId] = cancelFlag;
+            }
             {
                 std::unique_lock<std::mutex> lck(asyncResource->mMtxForQueue);
-                asyncResource->mRequestsQueue.emplace_back(std::addressof(llmRequest), std::move(promise));
+                asyncResource->mRequestsQueue.emplace_back(std::addressof(llmRequest), std::move(promise), cancelFlag);
             }
             asyncResource->mCVforQueue.notify_all();
             return future;
@@ -1001,6 +1017,26 @@ public:
                 asyncResource->mRequestsQueue.erase(it);
                 isCancelled = true;
             }
+        }
+        if (!isCancelled)
+        {
+            // Request already dequeued past mRequestsQueue (worker thread has
+            // picked it up; most likely blocked inside requestSync ->
+            // recvReadySignal waiting on a peer). Flip the per-request cancel
+            // flag so the notification polling loop in
+            // AgentConnectionManager::waitForNotification observes it and
+            // returns early with isReady=false. requestSync then falls into
+            // the kDISAGG_TRANS_ERROR branch and the future resolves, freeing
+            // the NIXL/UCX per-request state instead of leaking it.
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            auto flagIt = mInFlightCancelFlags.find(llmRequest.mRequestId);
+            if (flagIt != mInFlightCancelFlags.end())
+            {
+                flagIt->second->store(true);
+                isCancelled = true;
+                TLLM_LOG_DEBUG(
+                    "Flipped in-flight cancel flag for request %zu (not in queue).", llmRequest.mRequestId);
+            }
             else
             {
                 TLLM_LOG_WARNING("Cannot cancel request %zu", llmRequest.mRequestId);
@@ -1009,7 +1045,7 @@ public:
         return isCancelled;
     }
 
-    bool receiveReadySignal(TransferSession& session)
+    bool receiveReadySignal(TransferSession& session, std::atomic<bool> const& perRequestCancel)
     {
         bool isReadyFinal = true;
         bool isReady = false;
@@ -1022,8 +1058,14 @@ public:
             {
                 auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections.at(i));
                 TLLM_CHECK(agentConnection);
+                // Pass the per-request cancel flag as the DataContext's
+                // transferTerminate. The notification polling loop in
+                // AgentConnectionManager::waitForNotification checks this
+                // atomic and returns early when it flips — either on
+                // process shutdown (all per-request flags flipped in
+                // ~Impl()) or on per-request cancelRequest().
                 isReady = agentConnection->recvReadySignal(
-                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG, mTerminate});
+                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG, perRequestCancel});
             }
             else
             {
@@ -1036,9 +1078,28 @@ public:
         return isReadyFinal;
     }
 
+    // Overload preserved for the (currently unused) std::async-based receiveAsync
+    // path and for any callers that don't plumb a per-request cancel flag. Uses
+    // the process-level mTerminate only.
+    bool receiveReadySignal(TransferSession& session)
+    {
+        return receiveReadySignal(session, mTerminate);
+    }
+
     ~Impl()
     {
         mTerminate.store(true);
+        // Flip every per-request cancel flag so recvReadySignal's polling
+        // loop can observe shutdown via the same atomic it uses for
+        // per-request cancellation. The shared_ptr aliasing in DataContext
+        // keeps these alive for any still-in-flight recvReadySignal calls.
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            for (auto& [id, flag] : mInFlightCancelFlags)
+            {
+                flag->store(true);
+            }
+        }
         for (auto&& [processInfo, asyncResource] : mInstanceToAsyncResource)
         {
             asyncResource->mTerminate = true;
@@ -1051,19 +1112,34 @@ public:
     }
 
 private:
-    void requestSync(LlmRequest& llmRequest)
+    void requestSync(LlmRequest& llmRequest, std::atomic<bool> const& perRequestCancel)
     {
         TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
             "Start calling requestSync for request ID: %zu, context request ID: %zu.", llmRequest.mRequestId,
             llmRequest.getContextPhaseParams().value().getReqId());
         llmRequest.setKvCacheTransferStart(std::chrono::steady_clock::now());
+        // Early-out if cancel fired between queueing and dequeue.
+        if (perRequestCancel.load() || mTerminate.load())
+        {
+            llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+            llmRequest.setKvCacheTransferEnd(std::chrono::steady_clock::now());
+            return;
+        }
         TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
         auto session = sendRequestInfo(llmRequest);
         session.setTime(TransferSession::kTimeRequestInfo);
-        bool isReady = receiveReadySignal(session);
-        if (!isReady)
+        // receiveReadySignal blocks inside AgentConnectionManager::waitForNotification's
+        // polling loop until the peer sends the ready notification OR the
+        // perRequestCancel flag flips. That's the one path that can actually
+        // release a zombie receive when a timeout-eviction fires on the C++
+        // side; without it the std::async/worker task would stay blocked
+        // indefinitely and hold NIXL/UCX per-request state.
+        bool isReady = receiveReadySignal(session, perRequestCancel);
+        if (!isReady || perRequestCancel.load())
         {
-            // Reuse the error state for the cancelled request.
+            // Either the peer never sent the ready signal (timeout / cancel
+            // fired) or the cancel was observed after ready. Either way,
+            // reuse the error state — AsyncTransferManager cleanup will run.
             llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
             llmRequest.setKvCacheTransferEnd(std::chrono::steady_clock::now());
             return;
@@ -1076,20 +1152,37 @@ private:
             llmRequest.getContextPhaseParams().value().getReqId());
     }
 
+    // Overload used by the (currently unused) std::async-based
+    // Impl::receiveAsync path, where no per-request cancel flag is plumbed.
+    // Threads the process-wide mTerminate through the same polling path so
+    // shutdown still interrupts it.
+    void requestSync(LlmRequest& llmRequest)
+    {
+        requestSync(llmRequest, mTerminate);
+    }
+
     struct RequestAndPromise
     {
         LlmRequest* mRequest;
         std::unique_ptr<std::promise<void>> mPromise;
+        // Per-request cancel flag. Flipped by CacheReceiver::Impl::cancelRequest
+        // when a timeout-eviction (in checkGenTransferStatus) or similar
+        // wants to abort an in-flight receive that has already been dequeued
+        // past the mRequestsQueue stage.
+        std::shared_ptr<std::atomic<bool>> mCancelFlag;
 
         RequestAndPromise()
             : mRequest(nullptr)
             , mPromise(nullptr)
+            , mCancelFlag(nullptr)
         {
         }
 
-        RequestAndPromise(LlmRequest* request, std::unique_ptr<std::promise<void>>&& promise)
+        RequestAndPromise(LlmRequest* request, std::unique_ptr<std::promise<void>>&& promise,
+            std::shared_ptr<std::atomic<bool>> cancelFlag)
             : mRequest(request)
             , mPromise(std::move(promise))
+            , mCancelFlag(std::move(cancelFlag))
         {
         }
 
@@ -1098,6 +1191,7 @@ private:
         RequestAndPromise(RequestAndPromise&& other) noexcept
             : mRequest(other.mRequest)
             , mPromise(std::move(other.mPromise))
+            , mCancelFlag(std::move(other.mCancelFlag))
         {
             other.mRequest = nullptr;
         }
@@ -1111,9 +1205,11 @@ private:
                 {
                     mPromise.reset();
                 }
+                mCancelFlag.reset();
 
                 mRequest = other.mRequest;
                 mPromise = std::move(other.mPromise);
+                mCancelFlag = std::move(other.mCancelFlag);
 
                 other.mRequest = nullptr;
             }
@@ -1159,7 +1255,9 @@ private:
                 try
                 {
                     TLLM_CHECK_WITH_INFO(requestAndPromise.mRequest != nullptr, "requestAndPromise.mRequest is null");
-                    requestSync(*requestAndPromise.mRequest);
+                    TLLM_CHECK_WITH_INFO(
+                        requestAndPromise.mCancelFlag != nullptr, "requestAndPromise.mCancelFlag is null");
+                    requestSync(*requestAndPromise.mRequest, *requestAndPromise.mCancelFlag);
                     requestAndPromise.mPromise->set_value();
                 }
                 catch (tensorrt_llm::common::RequestSpecificException const& err)
@@ -1178,6 +1276,15 @@ private:
                         requestAndPromise.mRequest->getContextPhaseParams().value().getReqId(), err.what());
                     requestAndPromise.mPromise->set_exception(std::current_exception());
                 }
+                // Deregister the per-request cancel flag regardless of
+                // success / exception. The shared_ptr in requestAndPromise
+                // still keeps the atomic alive for any in-flight DataContext
+                // references that haven't unwound yet.
+                if (requestAndPromise.mRequest != nullptr)
+                {
+                    std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+                    mInFlightCancelFlags.erase(requestAndPromise.mRequest->mRequestId);
+                }
             }
         }
     }
@@ -1195,6 +1302,11 @@ private:
     std::ofstream mMeasuresFile;
     std::mutex mMeasuresFileMutex;
     std::atomic<bool> mTerminate{false};
+    // Per-request cancel flags for in-flight receives that have been dequeued
+    // past mRequestsQueue. Registered on enqueue, looked up by cancelRequest
+    // for in-flight cancellation, and unregistered after requestSync returns.
+    std::mutex mInFlightCancelMutex;
+    std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<std::atomic<bool>>> mInFlightCancelFlags;
 };
 
 void CacheSender::ImplDeleter::operator()(Impl* ptr)

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -967,6 +967,20 @@ public:
 
     TransferSession sendRequestInfo(LlmRequest const& llmRequest, std::atomic<bool> const& perRequestCancel)
     {
+        // Legacy / public-wrapper path: no pre-acquired ids; acquires
+        // internally with no RAII protection. Not on the drain-worker path.
+        return sendRequestInfo(llmRequest, perRequestCancel, /*preAcquiredCacheBufferIds=*/{});
+    }
+
+    // Overload that takes caller-acquired buffer indices (wrapped in
+    // BufferIndexHolders at the call site). requestSync uses this variant so
+    // RAII covers all non-happy-path exits (not-ready, cancel, throw). The
+    // preAcquiredCacheBufferIds vector must have one entry per cache
+    // transfer buffer manager (aligned with
+    // AgentConnectionManager::getCacheTransBufferManagers()).
+    TransferSession sendRequestInfo(LlmRequest const& llmRequest, std::atomic<bool> const& perRequestCancel,
+        std::vector<std::optional<size_t>> preAcquiredCacheBufferIds)
+    {
         uint64_t requestId = llmRequest.getContextPhaseParams().value().getReqId();
         auto const& contextState = llmRequest.getDataTransceiverState();
         auto const& commState = contextState.getCommState().value();
@@ -1008,29 +1022,28 @@ public:
         std::vector<std::optional<size_t>> cacheBufferIds;
         if (agentConnectionManager)
         {
-            // Thread perRequestCancel + reqId through assignBufferIndexForRecv's
-            // pool wait. Pre-fix this CV was unbounded and observed to wedge
-            // under saturation (v11b: [reqSync] pre-sendRequestInfo with no
-            // matching post-sendRequestInfo for 60 s+). With the bounded
-            // wait_for loop in baseTransBuffer.cpp, a cancel fired on this
-            // reqId — or on any peer's reqId whose completion frees a buffer
-            // slot — now unwedges the wait promptly. reqId is also tagged
-            // into the [buf] logs so pool-exhaustion wedges can be attributed
-            // cross-correlation with [reqSync] and [drain] trails.
-            auto const reqIdForLog
-                = std::make_optional(static_cast<uint64_t>(llmRequest.mRequestId));
-            TLLM_LOG_WARNING("[reqSync] pre-assignBufferIndexForRecv reqId=%zu managerCount=%zu",
-                llmRequest.mRequestId,
-                agentConnectionManager->getCacheTransBufferManagers().size());
-            for (auto& cacheTransBufferManager : agentConnectionManager->getCacheTransBufferManagers())
+            if (!preAcquiredCacheBufferIds.empty())
             {
-                cacheBufferIds.push_back(
-                    cacheTransBufferManager->assignBufferIndexForRecv(&perRequestCancel, /*waitSliceMs=*/100,
-                        reqIdForLog));
+                // requestSync already acquired these indices under RAII
+                // holders — use them as-is so receiveSync's formatter
+                // releases via the existing path while any non-happy-path
+                // exit from requestSync releases via ~BufferIndexHolder.
+                cacheBufferIds = std::move(preAcquiredCacheBufferIds);
+                TLLM_CHECK(!cacheBufferIds.empty());
             }
-            TLLM_LOG_WARNING("[reqSync] post-assignBufferIndexForRecv reqId=%zu assigned=%zu",
-                llmRequest.mRequestId, cacheBufferIds.size());
-            TLLM_CHECK(!cacheBufferIds.empty());
+            else
+            {
+                // Legacy path: no RAII protection. Acquire internally,
+                // matching pre-RAII behavior for callers that don't go
+                // through requestSync.
+                auto const reqIdForLog = std::make_optional(static_cast<uint64_t>(llmRequest.mRequestId));
+                for (auto& cacheTransBufferManager : agentConnectionManager->getCacheTransBufferManagers())
+                {
+                    cacheBufferIds.push_back(cacheTransBufferManager->assignBufferIndexForRecv(
+                        &perRequestCancel, /*waitSliceMs=*/100, reqIdForLog));
+                }
+                TLLM_CHECK(!cacheBufferIds.empty());
+            }
         }
 
         auto allCounterparts
@@ -1314,7 +1327,54 @@ private:
             return;
         }
         TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
-        auto session = sendRequestInfo(llmRequest, perRequestCancel);
+
+        // Pre-acquire receive-buffer indices under RAII holders BEFORE entering
+        // sendRequestInfo. This is the core of the RAII fix: the formatter
+        // inside receiveSync releases the indices on the happy path (hence
+        // the `detach()` after a successful receiveSync below), but every
+        // OTHER exit path from requestSync used to leak one index per exit.
+        // v12 evidence: one `(not-ready or cancel after ready)` early return
+        // permanently wedged the size-1 pool after prefill's ctx-timeout
+        // flipped isReady=0. With the holder, any return or throw between
+        // acquisition and the final detach releases the index via the
+        // holder's destructor, closing the class of bug rather than the
+        // specific branch observed.
+        std::vector<BufferIndexHolder> recvHolders;
+        std::vector<std::optional<size_t>> cacheBufferIds;
+        auto* agentConnectionManagerForAcq
+            = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
+        if (agentConnectionManagerForAcq)
+        {
+            auto const reqIdForLog = std::make_optional(static_cast<uint64_t>(llmRequest.mRequestId));
+            TLLM_LOG_WARNING("[reqSync] pre-assignBufferIndexForRecv reqId=%zu managerCount=%zu",
+                llmRequest.mRequestId,
+                agentConnectionManagerForAcq->getCacheTransBufferManagers().size());
+            auto const& managers = agentConnectionManagerForAcq->getCacheTransBufferManagers();
+            recvHolders.reserve(managers.size());
+            cacheBufferIds.reserve(managers.size());
+            for (auto* cacheTransBufferManager : managers)
+            {
+                auto rawIdx = cacheTransBufferManager->assignBufferIndexForRecv(
+                    &perRequestCancel, /*waitSliceMs=*/100, reqIdForLog);
+                recvHolders.emplace_back(*cacheTransBufferManager, rawIdx, /*isRecv=*/true);
+                if (rawIdx.has_value())
+                {
+                    cacheBufferIds.push_back(static_cast<size_t>(rawIdx.value()));
+                }
+                else
+                {
+                    cacheBufferIds.push_back(std::nullopt);
+                }
+            }
+            TLLM_LOG_WARNING("[reqSync] post-assignBufferIndexForRecv reqId=%zu assigned=%zu",
+                llmRequest.mRequestId, cacheBufferIds.size());
+        }
+
+        // [reqSync] pre-sendRequestInfo — if the next line prints but
+        // post-sendRequestInfo never does, sendRequestInfo wedges (NIXL agent
+        // state corruption is the leading hypothesis).
+        TLLM_LOG_WARNING("[reqSync] pre-sendRequestInfo reqId=%zu", llmRequest.mRequestId);
+        auto session = sendRequestInfo(llmRequest, perRequestCancel, std::move(cacheBufferIds));
         session.setTime(TransferSession::kTimeRequestInfo);
         // receiveReadySignal blocks inside AgentConnectionManager::waitForNotification's
         // polling loop until the peer sends the ready notification OR the
@@ -1334,6 +1394,18 @@ private:
         }
         receiveSync(session);
         llmRequest.setKvCacheTransferEnd(std::chrono::steady_clock::now());
+
+        // Happy path only: the formatter invoked inside receiveSync already
+        // released each buffer index via freeBufferIndexForRecv. Detach the
+        // holders so they don't double-release when this stack frame
+        // unwinds. If control is about to leave requestSync via any OTHER
+        // path below (none today, but safe against future edits), the
+        // holders would still release automatically — detaching is strictly
+        // a correctness requirement for the just-completed receiveSync path.
+        for (auto& h : recvHolders)
+        {
+            (void) h.detach();
+        }
 
         TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
             "End calling requestSync for request ID: %zu, context request ID: %zu.", llmRequest.mRequestId,

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -301,6 +301,15 @@ public:
         std::promise<void> promise;
         auto future = promise.get_future();
         llmRequest.setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
+        // Register a per-request cancel flag for this sender-side request,
+        // symmetric to CacheReceiver::Impl's flag registry. This allows
+        // CacheSender::cancelRequest to flip the flag when the request is
+        // already being processed (i.e. when it is the mCurrentRequest and
+        // therefore not cancellable via the queue-drain path). The flag is
+        // consumed by the session's DataContext (built in recvRequestInfo)
+        // and by AgentConnection::send's poll-wait loop, which breaks out
+        // on cancel.
+        (void) getOrCreateInFlightCancelFlag(llmRequest.mRequestId);
         {
             {
                 std::scoped_lock lkResp(mSenderMutex);
@@ -312,6 +321,19 @@ public:
         }
         mSenderCv.notify_all();
         return future;
+    }
+
+    std::shared_ptr<std::atomic<bool>> getOrCreateInFlightCancelFlag(RequestIdType requestId)
+    {
+        std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+        auto it = mInFlightCancelFlags.find(requestId);
+        if (it != mInFlightCancelFlags.end())
+        {
+            return it->second;
+        }
+        auto flag = std::make_shared<std::atomic<bool>>(false);
+        mInFlightCancelFlags.emplace(requestId, flag);
+        return flag;
     }
 
     [[nodiscard]] executor::kv_cache::CommState const& getCommState() const
@@ -391,13 +413,27 @@ public:
 
         TLLM_CHECK_WITH_INFO(peerIdx < static_cast<int>(allCounterparts.size()),
             "Peer rank %d not found in expected counterparts", peerSelfIdx);
+        // Get or create the per-request cancel flag for this requestId. If
+        // sendAsync already ran for this reqId the flag is registered; if
+        // recvRequestInfo races ahead, we create it here so the session
+        // DataContext below holds a live reference. The flag's shared_ptr
+        // lifetime is tied to the mInFlightCancelFlags map; it's erased
+        // only after sendSync finishes (in removeResponse / cancel
+        // cleanup), so the DataContext reference never dangles.
+        auto cancelFlag = getOrCreateInFlightCancelFlag(requestId);
         {
             std::unique_lock<std::mutex> lk(mMtxForMap);
             auto it = mRequestToSession.find(requestId);
             if (it == mRequestToSession.end())
             {
+                // Use the per-request cancel flag (not mTerminate) so a
+                // cancel fired by CacheSender::cancelRequest mid-send is
+                // observed by AgentConnection::send's poll-wait loop via
+                // ctx.getTransferTerminate(). Shutdown still works because
+                // ~Impl flips every registered per-request flag before
+                // joining the response worker.
                 auto session = TransferSession(std::vector<Connection const*>(allCounterparts.size(), nullptr),
-                    DataContext{tagFromRequestId(requestId), mTerminate}, allCounterparts, mSelfState,
+                    DataContext{tagFromRequestId(requestId), *cancelFlag}, allCounterparts, mSelfState,
                     info.getTransState(), mBufferManager, info.getIndexFromEnd(), info.getLastBlockKey(), nullptr,
                     !common::getEnvKVCacheTimeOutputPath().empty());
                 session.setTime(TransferSession::kTimeRequestInfo);
@@ -425,18 +461,39 @@ public:
     bool cancelRequest(LlmRequest const& llmRequest)
     {
         bool isCancelled = false;
-        std::scoped_lock lkResp(mSenderMutex);
-        auto it = mReadyResponses.find(llmRequest.mRequestId);
-        // If the request is not the current request and already in the ready queue, we can cancel it.
-        if (it != mReadyResponses.end()
-            && (!mCurrentRequest.has_value() || getCurrentRequestId() != llmRequest.mRequestId))
         {
-            mCancelledRequests.insert(llmRequest.mRequestId);
-            isCancelled = true;
+            std::scoped_lock lkResp(mSenderMutex);
+            auto it = mReadyResponses.find(llmRequest.mRequestId);
+            // If the request is not the current request and already in the ready queue, we can cancel it.
+            if (it != mReadyResponses.end()
+                && (!mCurrentRequest.has_value() || getCurrentRequestId() != llmRequest.mRequestId))
+            {
+                mCancelledRequests.insert(llmRequest.mRequestId);
+                isCancelled = true;
+            }
         }
-        else
+        if (!isCancelled)
         {
-            TLLM_LOG_WARNING("Cannot cancel request %zu", llmRequest.mRequestId);
+            // Request is the mCurrentRequest (or not even in mReadyResponses)
+            // — the queue-drain path can't abort it. Flip the per-request
+            // cancel flag registered at sendAsync time; AgentConnection::send
+            // observes ctx.getTransferTerminate() in its poll-wait loop and
+            // throws, which unwinds sendSync and lets the response worker
+            // resume. Symmetric to CacheReceiver::cancelRequest's Path B.
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            auto flagIt = mInFlightCancelFlags.find(llmRequest.mRequestId);
+            if (flagIt != mInFlightCancelFlags.end())
+            {
+                flagIt->second->store(true);
+                isCancelled = true;
+                TLLM_LOG_DEBUG(
+                    "Flipped in-flight sender cancel flag for request %zu (not in queue or is current).",
+                    llmRequest.mRequestId);
+            }
+            else
+            {
+                TLLM_LOG_WARNING("Cannot cancel request %zu", llmRequest.mRequestId);
+            }
         }
         return isCancelled;
     }
@@ -586,11 +643,18 @@ private:
                 // not be removed from mCancelledRequests. This should be handled by timeout.
                 auto it = mReadyResponses.find(mCurrentRequest.value());
                 TLLM_CHECK(it != mReadyResponses.end());
+                auto const cancelledReqId = mCurrentRequest.value();
                 {
                     std::scoped_lock lkResp(mSenderMutex);
                     mReadyResponses.erase(it);
-                    mCancelledRequests.erase(mCurrentRequest.value());
-                    mRemainSendCount.erase(mCurrentRequest.value());
+                    mCancelledRequests.erase(cancelledReqId);
+                    mRemainSendCount.erase(cancelledReqId);
+                }
+                // Symmetric to removeResponse's flag cleanup — drop the
+                // per-request cancel flag on the cancel path too.
+                {
+                    std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+                    mInFlightCancelFlags.erase(cancelledReqId);
                 }
                 mCurrentRequest = std::nullopt;
 
@@ -678,6 +742,19 @@ private:
             std::unique_lock lk(mCondMutex);
             mTerminate = true;
         }
+        // Flip every registered per-request cancel flag so any AgentConnection::send
+        // currently in its poll-wait observes shutdown via the same atomic it
+        // polls for per-request cancellation. Needed because recvRequestInfo's
+        // TransferSession DataContext references per-request flags (not
+        // mTerminate), so without this, shutdown would not interrupt an
+        // in-flight sender wedge.
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            for (auto& [id, flag] : mInFlightCancelFlags)
+            {
+                flag->store(true);
+            }
+        }
         // We don't have to wait for the future. If another thread is sending data, it won't pay attention
         // to the terminate flag.
         mSenderCv.notify_all();
@@ -695,9 +772,17 @@ private:
 
     void removeResponse(std::map<RequestIdType, Response>::iterator it)
     {
+        auto const reqId = it->first;
         {
             std::scoped_lock lkResp(mSenderMutex);
             mReadyResponses.erase(it);
+        }
+        // Drop the per-request cancel flag now that the send completed
+        // (the session destruction via release() will drop its DataContext
+        // reference to the atomic; the map entry is the last shared_ptr).
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            mInFlightCancelFlags.erase(reqId);
         }
         if (mReadyResponses.empty())
         {
@@ -737,6 +822,13 @@ private:
     std::mutex mMtxForMap;
     runtime::BufferManager mBufferManager;
     std::ofstream mMeasuresFile;
+    // Per-request cancel-flag registry (sender-side parity with
+    // CacheReceiver::Impl). Registered at sendAsync time, referenced by
+    // the TransferSession's DataContext in recvRequestInfo, flipped by
+    // cancelRequest on the non-queue-drainable case, and erased after
+    // removeResponse / cancel-cleanup. ~terminate flips all for shutdown.
+    std::mutex mInFlightCancelMutex;
+    std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<std::atomic<bool>>> mInFlightCancelFlags;
 };
 
 class CacheReceiver::Impl
@@ -972,7 +1064,7 @@ public:
                 TLLM_CHECK(agentConnection != nullptr);
 
                 const_cast<executor::kv_cache::AgentConnection*>(agentConnection)
-                    ->sendRequestAndBufferInfo(requestInfo, idsForRank, validConnectionIdx);
+                    ->sendRequestAndBufferInfo(requestInfo, idsForRank, validConnectionIdx, &perRequestCancel);
             }
             else
             {

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -33,6 +33,8 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <sys/syscall.h>
+#include <unistd.h>
 #include <unordered_map>
 
 namespace tensorrt_llm::batch_manager
@@ -1482,6 +1484,12 @@ private:
         tensorrt_llm::common::setThreadName("dataTransRequest");
         TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
 
+        // Entry-point marker. If this never prints, the std::async launch in
+        // requestAndReceiveAsyncMultiThreads never actually ran — suspect a
+        // mInstanceToAsyncResource.emplace race or missing thread creation.
+        TLLM_LOG_WARNING("[drain] ENTER tid=%ld resource=%p", static_cast<long>(syscall(SYS_gettid)),
+            static_cast<void const*>(&resource));
+
         while (!resource.mTerminate)
         {
             RequestAndPromise requestAndPromise;
@@ -1503,13 +1511,23 @@ private:
                 requestAndPromise = std::move(resource.mRequestsQueue.front());
                 resource.mRequestsQueue.pop_front();
             }
+            auto const reqId = requestAndPromise.mRequest != nullptr ? requestAndPromise.mRequest->mRequestId
+                                                                     : static_cast<LlmRequest::RequestIdType>(0);
             {
                 try
                 {
                     TLLM_CHECK_WITH_INFO(requestAndPromise.mRequest != nullptr, "requestAndPromise.mRequest is null");
                     TLLM_CHECK_WITH_INFO(
                         requestAndPromise.mCancelFlag != nullptr, "requestAndPromise.mCancelFlag is null");
+                    // Log before the blocking call so we can pair pre/post on the
+                    // same reqId; an unmatched pre-requestSync beyond kv_transfer_timeout_ms
+                    // without a corresponding post-requestSync indicates the worker is
+                    // alive but parked inside requestSync (likely NIXL/UCX progress
+                    // loop or a lock) rather than having exited.
+                    TLLM_LOG_WARNING("[drain] pre-requestSync reqId=%zu queueRemaining=%zu", reqId,
+                        resource.mRequestsQueue.size());
                     requestSync(*requestAndPromise.mRequest, *requestAndPromise.mCancelFlag);
+                    TLLM_LOG_WARNING("[drain] post-requestSync reqId=%zu", reqId);
                     requestAndPromise.mPromise->set_value();
                 }
                 catch (tensorrt_llm::common::RequestSpecificException const& err)
@@ -1528,6 +1546,36 @@ private:
                         requestAndPromise.mRequest->getContextPhaseParams().value().getReqId(), err.what());
                     requestAndPromise.mPromise->set_exception(std::current_exception());
                 }
+                catch (...)
+                {
+                    // Non-std::exception escapes (e.g. throws of integer / custom
+                    // types from NIXL / UCX backends, or the rare C++ ABI abort
+                    // path) would otherwise kill this worker thread and leave
+                    // the mRequestsQueue unserviced forever. When that happens,
+                    // the in-flight cancel flag registry in
+                    // requestAndReceiveAsyncMultiThreads keeps inserting
+                    // entries, cancelRequest keeps finding them in the queue
+                    // (Path A of cancelRequest), silently drops them, and the
+                    // per-request cancel flag path (Path B) is never reached
+                    // — producing the post-saturation "no recovery" state where
+                    // every new receive just waits kv_transfer_timeout_ms.
+                    // Swallow and continue so the drain loop remains alive;
+                    // set the promise so the caller's future resolves with an
+                    // error rather than hanging.
+                    TLLM_LOG_WARNING(
+                        "[drain] UNKNOWN (non-std::exception) escape reqId=%zu — continuing loop", reqId);
+                    if (requestAndPromise.mPromise)
+                    {
+                        try
+                        {
+                            requestAndPromise.mPromise->set_exception(std::current_exception());
+                        }
+                        catch (...)
+                        {
+                            // promise already satisfied; nothing else to do
+                        }
+                    }
+                }
                 // Deregister the per-request cancel flag regardless of
                 // success / exception. The shared_ptr in requestAndPromise
                 // still keeps the atomic alive for any in-flight DataContext
@@ -1539,6 +1587,12 @@ private:
                 }
             }
         }
+
+        // Exit marker. If mTerminate is 0 here, something bypassed the
+        // catch-all above (shouldn't happen) — the queueSize snapshot at exit
+        // tells us how many requests the worker abandoned when it died.
+        TLLM_LOG_WARNING("[drain] EXIT tid=%ld mTerminate=%d queueSize=%zu", static_cast<long>(syscall(SYS_gettid)),
+            static_cast<int>(resource.mTerminate.load()), resource.mRequestsQueue.size());
     }
 
     int mDeviceId{-1};

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -296,11 +296,11 @@ public:
         }
     }
 
-    [[nodiscard]] std::future<void> sendAsync(LlmRequest& llmRequest)
+    [[nodiscard]] std::future<void> sendAsync(std::shared_ptr<LlmRequest> const& llmRequest)
     {
         std::promise<void> promise;
         auto future = promise.get_future();
-        llmRequest.setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
+        llmRequest->setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
         // Register a per-request cancel flag for this sender-side request,
         // symmetric to CacheReceiver::Impl's flag registry. This allows
         // CacheSender::cancelRequest to flip the flag when the request is
@@ -309,12 +309,14 @@ public:
         // consumed by the session's DataContext (built in recvRequestInfo)
         // and by AgentConnection::send's poll-wait loop, which breaks out
         // on cancel.
-        (void) getOrCreateInFlightCancelFlag(llmRequest.mRequestId);
+        (void) getOrCreateInFlightCancelFlag(llmRequest->mRequestId);
         {
             {
                 std::scoped_lock lkResp(mSenderMutex);
-                mReadyResponses.emplace(
-                    llmRequest.mRequestId, Response{std::addressof(llmRequest), std::move(promise)});
+                // Worker holds shared_ptr so Python-side _terminate_request
+                // cannot drop the LlmRequest out from under the async-send
+                // worker's dereferences.
+                mReadyResponses.emplace(llmRequest->mRequestId, Response{llmRequest, std::move(promise)});
             }
             std::unique_lock lkCond(mCondMutex);
             mAnyReady = true;
@@ -550,7 +552,10 @@ public:
 private:
     struct Response
     {
-        LlmRequest* mRequest;
+        // Store shared_ptr rather than raw pointer so the async-send worker's
+        // dereferences stay safe past Python-side _terminate_request. Same
+        // UAF mitigation as RequestAndPromise on the receiver side.
+        std::shared_ptr<LlmRequest> mRequest;
         std::promise<void> mPromise;
     };
 
@@ -884,26 +889,28 @@ public:
         TLLM_CUDA_CHECK(cudaGetDevice(&mDeviceId));
     }
 
-    [[nodiscard]] std::future<void> receiveAsync(LlmRequest& llmRequest)
+    [[nodiscard]] std::future<void> receiveAsync(std::shared_ptr<LlmRequest> const& llmRequest)
     {
         // TODO: Modify the implementation here to avoid frequent thread creation.
-        // Lambda disambiguates the overloaded requestSync; the single-arg
-        // overload delegates to the per-request-cancel version using
-        // mTerminate as the cancel source.
-        return std::async(std::launch::async, [this, &llmRequest]() { requestSync(llmRequest); });
+        // Lambda captures the shared_ptr so the request is kept alive until the
+        // async task completes — closes the raw-pointer UAF that the old
+        // `[this, &llmRequest]` capture was vulnerable to.
+        auto llmRequestCopy = llmRequest;
+        return std::async(std::launch::async,
+            [this, llmRequestCopy]() { requestSync(*llmRequestCopy); });
     }
 
-    [[nodiscard]] std::future<void> requestAndReceiveAsyncMultiThreads(LlmRequest& llmRequest)
+    [[nodiscard]] std::future<void> requestAndReceiveAsyncMultiThreads(std::shared_ptr<LlmRequest> const& llmRequest)
     {
         try
         {
             auto promise = std::make_unique<std::promise<void>>();
             auto future = promise->get_future();
-            TLLM_CHECK(llmRequest.getDataTransceiverState().getCommState().has_value());
+            TLLM_CHECK(llmRequest->getDataTransceiverState().getCommState().has_value());
             std::string processInfo = kDefaultProcessInfo;
             if (common::getEnvRequestKVCacheConcurrent())
             {
-                processInfo = llmRequest.getDataTransceiverState().getCommState()->toString();
+                processInfo = llmRequest->getDataTransceiverState().getCommState()->toString();
             }
             if (mInstanceToAsyncResource.find(processInfo) == mInstanceToAsyncResource.end())
             {
@@ -925,11 +932,14 @@ public:
             auto cancelFlag = std::make_shared<std::atomic<bool>>(false);
             {
                 std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
-                mInFlightCancelFlags[llmRequest.mRequestId] = cancelFlag;
+                mInFlightCancelFlags[llmRequest->mRequestId] = cancelFlag;
             }
             {
                 std::unique_lock<std::mutex> lck(asyncResource->mMtxForQueue);
-                asyncResource->mRequestsQueue.emplace_back(std::addressof(llmRequest), std::move(promise), cancelFlag);
+                // Worker holds shared_ptr so Python-side _terminate_request
+                // cannot drop the LlmRequest out from under the worker's
+                // dereferences — closes the raw-pointer UAF.
+                asyncResource->mRequestsQueue.emplace_back(llmRequest, std::move(promise), cancelFlag);
             }
             asyncResource->mCVforQueue.notify_all();
             return future;
@@ -1423,7 +1433,14 @@ private:
 
     struct RequestAndPromise
     {
-        LlmRequest* mRequest;
+        // Store shared_ptr rather than a raw pointer so the async worker's
+        // dereferences (mRequest->mRequestId, mRequest->getDataTransceiverState,
+        // mRequest->setState, etc.) stay safe even after Python's
+        // _terminate_request drops its own pybind shared_ptr. The
+        // forensically-confirmed UAF (mRequestId read as 0x5555555555555555
+        // under MALLOC_PERTURB_=85) was exactly this: raw pointer dereferenced
+        // past Python-side free.
+        std::shared_ptr<LlmRequest> mRequest;
         std::unique_ptr<std::promise<void>> mPromise;
         // Per-request cancel flag. Flipped by CacheReceiver::Impl::cancelRequest
         // when a timeout-eviction (in checkGenTransferStatus) or similar
@@ -1438,9 +1455,9 @@ private:
         {
         }
 
-        RequestAndPromise(LlmRequest* request, std::unique_ptr<std::promise<void>>&& promise,
+        RequestAndPromise(std::shared_ptr<LlmRequest> request, std::unique_ptr<std::promise<void>>&& promise,
             std::shared_ptr<std::atomic<bool>> cancelFlag)
-            : mRequest(request)
+            : mRequest(std::move(request))
             , mPromise(std::move(promise))
             , mCancelFlag(std::move(cancelFlag))
         {
@@ -1448,33 +1465,8 @@ private:
 
         RequestAndPromise(RequestAndPromise const&) = delete;
 
-        RequestAndPromise(RequestAndPromise&& other) noexcept
-            : mRequest(other.mRequest)
-            , mPromise(std::move(other.mPromise))
-            , mCancelFlag(std::move(other.mCancelFlag))
-        {
-            other.mRequest = nullptr;
-        }
-
-        RequestAndPromise& operator=(RequestAndPromise&& other) noexcept
-        {
-            if (this != &other)
-            {
-                mRequest = nullptr;
-                if (mPromise)
-                {
-                    mPromise.reset();
-                }
-                mCancelFlag.reset();
-
-                mRequest = other.mRequest;
-                mPromise = std::move(other.mPromise);
-                mCancelFlag = std::move(other.mCancelFlag);
-
-                other.mRequest = nullptr;
-            }
-            return *this;
-        }
+        RequestAndPromise(RequestAndPromise&& other) noexcept = default;
+        RequestAndPromise& operator=(RequestAndPromise&& other) noexcept = default;
     };
 
     struct AsyncResource
@@ -1585,7 +1577,7 @@ CacheSender::CacheSender(
 {
 }
 
-std::future<void> CacheSender::sendAsync(LlmRequest& llmRequest) const
+std::future<void> CacheSender::sendAsync(std::shared_ptr<LlmRequest> const& llmRequest) const
 {
     return mImpl->sendAsync(llmRequest);
 }
@@ -1628,7 +1620,7 @@ CacheReceiver::CacheReceiver(
 {
 }
 
-std::future<void> CacheReceiver::receiveAsync(LlmRequest& llmRequest) const
+std::future<void> CacheReceiver::receiveAsync(std::shared_ptr<LlmRequest> const& llmRequest) const
 {
     return mImpl->requestAndReceiveAsyncMultiThreads(llmRequest);
 }

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -1356,7 +1356,7 @@ private:
             {
                 auto rawIdx = cacheTransBufferManager->assignBufferIndexForRecv(
                     &perRequestCancel, /*waitSliceMs=*/100, reqIdForLog);
-                recvHolders.emplace_back(*cacheTransBufferManager, rawIdx, /*isRecv=*/true);
+                recvHolders.emplace_back(*cacheTransBufferManager, rawIdx, /*isRecv=*/true, reqIdForLog);
                 if (rawIdx.has_value())
                 {
                     cacheBufferIds.push_back(static_cast<size_t>(rawIdx.value()));

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -826,7 +826,15 @@ public:
         }
     }
 
+    // Overload kept for the public CacheReceiver::sendRequestInfo wrapper
+    // and any direct caller without a per-request cancel flag. Threads
+    // mTerminate through so process shutdown still interrupts the poll loop.
     TransferSession sendRequestInfo(LlmRequest const& llmRequest)
+    {
+        return sendRequestInfo(llmRequest, mTerminate);
+    }
+
+    TransferSession sendRequestInfo(LlmRequest const& llmRequest, std::atomic<bool> const& perRequestCancel)
     {
         uint64_t requestId = llmRequest.getContextPhaseParams().value().getReqId();
         auto const& contextState = llmRequest.getDataTransceiverState();
@@ -902,6 +910,18 @@ public:
 
         for (size_t ci = 0; ci < allCounterparts.size(); ci++)
         {
+            // Honor perRequestCancel between per-peer notify iterations. If
+            // the drain worker's cancelRequest has fired (e.g. the gen-side
+            // kv_transfer_timeout_ms hit), bail out of this loop instead of
+            // continuing to notify peers that have already abandoned their
+            // side of the transfer. v11b instrumentation localized the
+            // post-saturation wedge to this function; without this check the
+            // for-body can block on notifySyncMessage to a stuck peer without
+            // any opportunity to observe the cancel flag.
+            if (perRequestCancel.load(std::memory_order_relaxed))
+            {
+                TLLM_THROW("sendRequestInfo cancelled via perRequestCancel for request %zu", llmRequest.mRequestId);
+            }
             auto rank = allCounterparts[ci];
             auto const* connection = connections.at(rank);
 
@@ -956,11 +976,16 @@ public:
             }
             else
             {
-                sendRequestInfo(connection, requestInfo);
+                sendRequestInfo(connection, requestInfo, perRequestCancel);
             }
         }
         auto const& resource = getReceiveCacheResource(llmRequest);
-        return TransferSession(std::move(allConnections), DataContext{tagFromRequestId(requestId), mTerminate},
+        // The TransferSession's DataContext is used by downstream data-phase
+        // operations (receiveSync -> unformat -> per-connection send/recv).
+        // Wire perRequestCancel through so those calls observe the same
+        // cancel flag the per-iteration loops here honor. AgentConnection::send
+        // reads ctx.getTransferTerminate() in its wait-poll loop.
+        return TransferSession(std::move(allConnections), DataContext{tagFromRequestId(requestId), perRequestCancel},
             std::move(allCounterparts), mSelfState, contextState, resource->mBufferManager,
             requestInfo.getIndexFromEnd(), requestInfo.getLastBlockKey(), &llmRequest,
             !common::getEnvKVCacheTimeOutputPath().empty());
@@ -984,16 +1009,21 @@ public:
         return mProcessToResources.at(processString);
     }
 
-    void sendRequestInfo(executor::kv_cache::Connection const* connection, RequestInfo const& info)
+    void sendRequestInfo(executor::kv_cache::Connection const* connection, RequestInfo const& info,
+        std::atomic<bool> const& perRequestCancel)
     {
         std::ostringstream oss;
         RequestInfo::serialize(info, oss);
         auto const& serializedInfo = oss.str();
         std::size_t const infoSize = serializedInfo.size();
         TransceiverTag::Id id{TransceiverTag::Id::REQUEST_SEND};
-        connection->send(DataContext{TransceiverTag::kID_TAG}, &id, sizeof(id));
-        connection->send(DataContext{TransceiverTag::kINFO_SIZE_TAG}, &infoSize, sizeof(infoSize));
-        connection->send(DataContext{TransceiverTag::kINFO_TAG}, serializedInfo.data(), infoSize);
+        // Propagate perRequestCancel via each DataContext so the underlying
+        // connection->send implementation (e.g. AgentConnection::send's
+        // poll-wait on submitted transfer) can observe a cancel fired
+        // asynchronously by CacheReceiver::cancelRequest.
+        connection->send(DataContext{TransceiverTag::kID_TAG, perRequestCancel}, &id, sizeof(id));
+        connection->send(DataContext{TransceiverTag::kINFO_SIZE_TAG, perRequestCancel}, &infoSize, sizeof(infoSize));
+        connection->send(DataContext{TransceiverTag::kINFO_TAG, perRequestCancel}, serializedInfo.data(), infoSize);
     }
 
     bool cancelRequest(LlmRequest const& llmRequest)
@@ -1053,6 +1083,15 @@ public:
 
         for (size_t i = 0; i < connections.size(); i++)
         {
+            // Honor perRequestCancel between per-peer ready-signal waits so
+            // a cancel fired during the multi-rank wait sequence bails out
+            // rather than continuing to wait on subsequent peers.
+            if (perRequestCancel.load(std::memory_order_relaxed))
+            {
+                TLLM_LOG_WARNING(
+                    "[reqSync] receiveReadySignal cancelled via perRequestCancel mid-loop");
+                return false;
+            }
             auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
             if (agentConnectionManager)
             {
@@ -1126,7 +1165,7 @@ private:
             return;
         }
         TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
-        auto session = sendRequestInfo(llmRequest);
+        auto session = sendRequestInfo(llmRequest, perRequestCancel);
         session.setTime(TransferSession::kTimeRequestInfo);
         // receiveReadySignal blocks inside AgentConnectionManager::waitForNotification's
         // polling loop until the peer sends the ready notification OR the

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -356,21 +356,37 @@ public:
 
     void release(LlmRequest::RequestIdType requestId)
     {
-        std::unique_lock<std::mutex> lk(mMtxForMap);
-        auto it = mRequestToSession.find(requestId);
-        TLLM_CHECK(it != mRequestToSession.end());
-        if (!common::getEnvKVCacheTimeOutputPath().empty())
         {
-            if (!mMeasuresFile.is_open())
+            std::unique_lock<std::mutex> lk(mMtxForMap);
+            auto it = mRequestToSession.find(requestId);
+            TLLM_CHECK(it != mRequestToSession.end());
+            if (!common::getEnvKVCacheTimeOutputPath().empty())
             {
-                auto outputPath = getTransferOutputPath("send");
-                mMeasuresFile.open(outputPath);
-                TLLM_CHECK_WITH_INFO(
-                    mMeasuresFile.is_open(), "Failed to open transfer output file: %s", outputPath.string().c_str());
+                if (!mMeasuresFile.is_open())
+                {
+                    auto outputPath = getTransferOutputPath("send");
+                    mMeasuresFile.open(outputPath);
+                    TLLM_CHECK_WITH_INFO(mMeasuresFile.is_open(), "Failed to open transfer output file: %s",
+                        outputPath.string().c_str());
+                }
+                it->second.exportMeasure(mMeasuresFile, true);
             }
-            it->second.exportMeasure(mMeasuresFile, true);
+            // Erase the session first so its DataContext (which references the
+            // per-request cancel atomic) is destroyed before we drop the
+            // flag's shared_ptr below. This ordering guarantees no dangling
+            // reference from DataContext into a freed atomic.
+            mRequestToSession.erase(it);
         }
-        mRequestToSession.erase(it);
+        // Drop the per-request cancel flag now that the session is gone.
+        // This is the single point where flags are reclaimed during normal
+        // operation; cancel paths that skip release() (sendSync threw or
+        // mCancelledRequests fired) intentionally leak the flag shared_ptr
+        // until ~Impl / terminate(), matching the existing session-leak
+        // behavior on those error paths.
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            mInFlightCancelFlags.erase(requestId);
+        }
     }
 
     [[nodiscard]] RequestInfo recvRequestInfo()
@@ -650,12 +666,11 @@ private:
                     mCancelledRequests.erase(cancelledReqId);
                     mRemainSendCount.erase(cancelledReqId);
                 }
-                // Symmetric to removeResponse's flag cleanup — drop the
-                // per-request cancel flag on the cancel path too.
-                {
-                    std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
-                    mInFlightCancelFlags.erase(cancelledReqId);
-                }
+                // Intentionally do NOT erase mInFlightCancelFlags[cancelledReqId]
+                // here — see removeResponse for rationale. The session for
+                // this reqId remains in mRequestToSession (release() is not
+                // called on this path), so its DataContext still references
+                // the atomic. The flag shared_ptr is reclaimed at ~Impl.
                 mCurrentRequest = std::nullopt;
 
                 if (mReadyResponses.empty())
@@ -734,6 +749,31 @@ private:
                 it.second.mPromise.set_exception(std::current_exception());
             }
         }
+        catch (...)
+        {
+            // Non-std::exception escape (integer throw, custom type throw
+            // from NIXL/UCX backends, C++ ABI edge cases). response() is
+            // noexcept, so an uncaught non-std throw would call
+            // std::terminate. Catch here to resolve pending promises with
+            // the exception so callers see a failure instead of the
+            // process aborting. Symmetric to the catch(...) added to
+            // CacheReceiver::Impl::request() in commit f63172f7e. The
+            // worker thread still exits after this catch — sender is then
+            // dead for this process, but fail-closed via the promises is
+            // strictly better than terminate().
+            TLLM_LOG_ERROR("[CacheSender] UNKNOWN (non-std::exception) escape in response() — worker exiting");
+            for (auto& it : mReadyResponses)
+            {
+                try
+                {
+                    it.second.mPromise.set_exception(std::current_exception());
+                }
+                catch (...)
+                {
+                    // promise already satisfied
+                }
+            }
+        }
     }
 
     void terminate()
@@ -772,18 +812,17 @@ private:
 
     void removeResponse(std::map<RequestIdType, Response>::iterator it)
     {
-        auto const reqId = it->first;
         {
             std::scoped_lock lkResp(mSenderMutex);
             mReadyResponses.erase(it);
         }
-        // Drop the per-request cancel flag now that the send completed
-        // (the session destruction via release() will drop its DataContext
-        // reference to the atomic; the map entry is the last shared_ptr).
-        {
-            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
-            mInFlightCancelFlags.erase(reqId);
-        }
+        // Flag erase is intentionally NOT here. The session's DataContext
+        // references the atomic held by mInFlightCancelFlags; dropping the
+        // map entry while the session still exists in mRequestToSession
+        // would dangle that reference. Flag lifetime is tied to session
+        // lifetime — reclaimed in release() (called by
+        // sendAndRemoveResponse's success path after sendSync completes)
+        // or at ~Impl for leaked sessions on error paths.
         if (mReadyResponses.empty())
         {
             std::unique_lock lkCond(mCondMutex);

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -1008,10 +1008,28 @@ public:
         std::vector<std::optional<size_t>> cacheBufferIds;
         if (agentConnectionManager)
         {
+            // Thread perRequestCancel + reqId through assignBufferIndexForRecv's
+            // pool wait. Pre-fix this CV was unbounded and observed to wedge
+            // under saturation (v11b: [reqSync] pre-sendRequestInfo with no
+            // matching post-sendRequestInfo for 60 s+). With the bounded
+            // wait_for loop in baseTransBuffer.cpp, a cancel fired on this
+            // reqId — or on any peer's reqId whose completion frees a buffer
+            // slot — now unwedges the wait promptly. reqId is also tagged
+            // into the [buf] logs so pool-exhaustion wedges can be attributed
+            // cross-correlation with [reqSync] and [drain] trails.
+            auto const reqIdForLog
+                = std::make_optional(static_cast<uint64_t>(llmRequest.mRequestId));
+            TLLM_LOG_WARNING("[reqSync] pre-assignBufferIndexForRecv reqId=%zu managerCount=%zu",
+                llmRequest.mRequestId,
+                agentConnectionManager->getCacheTransBufferManagers().size());
             for (auto& cacheTransBufferManager : agentConnectionManager->getCacheTransBufferManagers())
             {
-                cacheBufferIds.push_back(cacheTransBufferManager->assignBufferIndexForRecv());
+                cacheBufferIds.push_back(
+                    cacheTransBufferManager->assignBufferIndexForRecv(&perRequestCancel, /*waitSliceMs=*/100,
+                        reqIdForLog));
             }
+            TLLM_LOG_WARNING("[reqSync] post-assignBufferIndexForRecv reqId=%zu assigned=%zu",
+                llmRequest.mRequestId, cacheBufferIds.size());
             TLLM_CHECK(!cacheBufferIds.empty());
         }
 

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
@@ -257,9 +257,12 @@ public:
 
     /// @brief Asynchronously respond to the request and send data.
     /// @param llmRequest Request object. Its data should be ready when called, and the data for this request
-    /// should remain valid until future synchronization.
+    /// should remain valid until future synchronization. Passed as shared_ptr so
+    /// the async worker keeps the LlmRequest alive past any Python-side
+    /// _terminate_request — closes the raw-pointer UAF forensically confirmed
+    /// via MALLOC_PERTURB_=85 producing mRequestId=0x5555555555555555.
     /// @return Once the data is fully sent, the future object will become valid.
-    [[nodiscard]] virtual std::future<void> sendAsync(LlmRequest& llmRequest) const;
+    [[nodiscard]] virtual std::future<void> sendAsync(std::shared_ptr<LlmRequest> const& llmRequest) const;
 
     /// @brief Return the internal communicator status.
     /// @return The communicator status.
@@ -314,9 +317,12 @@ public:
 
     /// @brief Asynchronously send a request to receive data.
     /// @param llmRequest Request object. Its data should be in an allocated but unwritten state when called, and the
-    /// data for this request should remain intact only after future synchronization.
+    /// data for this request should remain intact only after future synchronization. Passed as shared_ptr so
+    /// the async worker keeps the LlmRequest alive past any Python-side
+    /// _terminate_request — closes the raw-pointer UAF forensically confirmed
+    /// via MALLOC_PERTURB_=85.
     /// @return Once the data is fully received, the future object will become valid.
-    [[nodiscard]] virtual std::future<void> receiveAsync(LlmRequest& llmRequest) const;
+    [[nodiscard]] virtual std::future<void> receiveAsync(std::shared_ptr<LlmRequest> const& llmRequest) const;
 
     virtual TransferSession sendRequestInfo(LlmRequest const& llmRequest);
 

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -30,6 +30,7 @@
 #include "tensorrt_llm/runtime/cudaEvent.h"
 #include "tensorrt_llm/runtime/iTensor.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <future>
@@ -253,12 +254,15 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             return bufferSizeForTarget;
         };
         auto bufferEleSizes = getBufferSizeForTarget();
-        // RAII wrapper mirrors the receiver-side pattern (see BufferIndexHolder
-        // comment in baseTransBuffer.h). Any non-happy exit between acquire and
-        // the explicit free below auto-releases the send-pool slot.
+        // RAII wrapper mirrors the receiver-side pattern. Happy-path uses
+        // sendHolder.release() (silent atomic free+disarm); other exits auto-
+        // release via ~BufferIndexHolder with an AUTO_RELEASE log. Send-pool CV
+        // wait observes the per-request cancel flag via the session's
+        // DataContext and throws on cancel (parity with recv side).
         auto const sendReqIdForLog = std::make_optional(static_cast<uint64_t>(llmRequest.mRequestId));
-        auto cacheBufferId
-            = mCacheTransBufferManagers[transferIndexerKCache]->assignBufferIndexForSend(sendReqIdForLog);
+        auto const* sendCancelFlag = &session.getDataContext().getTransferTerminate();
+        auto cacheBufferId = mCacheTransBufferManagers[transferIndexerKCache]->assignBufferIndexForSend(
+            sendCancelFlag, /*waitSliceMs=*/100, sendReqIdForLog);
         BufferIndexHolder sendHolder(
             *mCacheTransBufferManagers[transferIndexerKCache], cacheBufferId, /*isRecv=*/false, sendReqIdForLog);
         TLLM_LOG_DEBUG("[buf] SEND_ACQUIRED reqId=%zu index=%d", llmRequest.mRequestId, cacheBufferId.value_or(-1));
@@ -303,6 +307,7 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             NVTX3_SCOPED_RANGE(sendBufferFun);
 
             TLLM_CUDA_CHECK(cudaSetDevice(deviceId));
+            auto const sendReqId = static_cast<uint64_t>(llmRequest.mRequestId);
             auto startTime = LlmRequest::getSteadyClockNow();
             // Compute cacheIdx based on CP-major connection ordering:
             // - cpDomainIdx = which CP domain this connection belongs to.
@@ -313,7 +318,11 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             if (cacheIdx < bufferCoverTargetNum)
             {
                 size_t size = outputSplitCaches.at(cacheIdx)->getSizeInBytes();
+                TLLM_LOG_DEBUG(
+                    "[send] PRE reqId=%zu connIdx=%zu cacheIdx=%zu size=%zu", sendReqId, processIdx, cacheIdx, size);
                 session.send(processIdx, outputSplitCaches.at(cacheIdx)->data(), size);
+                TLLM_LOG_DEBUG(
+                    "[send] DONE reqId=%zu connIdx=%zu cacheIdx=%zu size=%zu", sendReqId, processIdx, cacheIdx, size);
             }
             else
             {
@@ -363,6 +372,8 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
 
                 auto remainSendNum = pickUpConnections.size();
 
+                auto const sendReqId = static_cast<uint64_t>(llmRequest.mRequestId);
+                size_t batchIdx = 0;
                 while (remainSendNum > 0)
                 {
                     auto sendConcurrencyNum = std::min(remainSendNum, concurrencyNum);
@@ -376,11 +387,20 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
                         TLLM_CHECK(connIdx < session.getConnections().size());
                         futures.push_back(std::async(std::launch::async, sendBufferFun, deviceId, connIdx));
                     }
+                    TLLM_LOG_WARNING("[send] FUTURE_WAIT reqId=%zu batch=%zu concurrency=%zu remain=%zu", sendReqId,
+                        batchIdx, sendConcurrencyNum, remainSendNum);
+                    auto const waitStart = std::chrono::steady_clock::now();
                     for (auto& future : futures)
                     {
                         future.get();
                     }
+                    auto const elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::steady_clock::now() - waitStart)
+                                               .count();
+                    TLLM_LOG_WARNING("[send] FUTURE_JOIN reqId=%zu batch=%zu elapsedMs=%lld", sendReqId, batchIdx,
+                        static_cast<long long>(elapsedMs));
                     remainSendNum -= sendConcurrencyNum;
+                    ++batchIdx;
                 }
             }
         }
@@ -388,12 +408,9 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
         {
             sendBufferFun(deviceId, pickUpConnections[0]);
         }
-        // Happy path: all send paths above have returned, slot is safe to free.
-        // Detach the holder so its destructor is a no-op, then free explicitly
-        // (timing is unchanged from pre-RAII code).
-        (void) sendHolder.detach();
+        // Atomic happy-path release — silent free + disarm in one noexcept call.
+        sendHolder.release();
         TLLM_LOG_DEBUG("[buf] SEND_RELEASE reqId=%zu index=%d", llmRequest.mRequestId, cacheBufferId.value_or(-1));
-        mCacheTransBufferManagers[transferIndexerKCache]->freeBufferIndexForSend(cacheBufferId);
     }
     session.setTime(TransferSession::kTimeTransmissions);
     session.setTime(TransferSession::kTimePostprocess);

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -253,7 +253,15 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             return bufferSizeForTarget;
         };
         auto bufferEleSizes = getBufferSizeForTarget();
-        auto cacheBufferId = mCacheTransBufferManagers[transferIndexerKCache]->assignBufferIndexForSend();
+        // RAII wrapper mirrors the receiver-side pattern (see BufferIndexHolder
+        // comment in baseTransBuffer.h). Any non-happy exit between acquire and
+        // the explicit free below auto-releases the send-pool slot.
+        auto const sendReqIdForLog = std::make_optional(static_cast<uint64_t>(llmRequest.mRequestId));
+        auto cacheBufferId
+            = mCacheTransBufferManagers[transferIndexerKCache]->assignBufferIndexForSend(sendReqIdForLog);
+        BufferIndexHolder sendHolder(
+            *mCacheTransBufferManagers[transferIndexerKCache], cacheBufferId, /*isRecv=*/false, sendReqIdForLog);
+        TLLM_LOG_DEBUG("[buf] SEND_ACQUIRED reqId=%zu index=%d", llmRequest.mRequestId, cacheBufferId.value_or(-1));
         auto result = mCacheTransBufferManagers[transferIndexerKCache]->getOrAllocateSendBuffers(
             cacheBufferId, static_cast<int>(pPDomainSize * cPDomainSize), bufferEleSizes, bufferManager);
         auto& outputSplitCaches = std::get<0>(result);
@@ -380,6 +388,11 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
         {
             sendBufferFun(deviceId, pickUpConnections[0]);
         }
+        // Happy path: all send paths above have returned, slot is safe to free.
+        // Detach the holder so its destructor is a no-op, then free explicitly
+        // (timing is unchanged from pre-RAII code).
+        (void) sendHolder.detach();
+        TLLM_LOG_DEBUG("[buf] SEND_RELEASE reqId=%zu index=%d", llmRequest.mRequestId, cacheBufferId.value_or(-1));
         mCacheTransBufferManagers[transferIndexerKCache]->freeBufferIndexForSend(cacheBufferId);
     }
     session.setTime(TransferSession::kTimeTransmissions);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -921,7 +921,7 @@ void TrtGptModelInflightBatching::forwardSync()
                     TLLM_CHECK_WITH_INFO(mCacheTransceiver,
                         "Disaggregated serving is not enabled, please check the configuration of "
                         "cacheTransceiverConfig.");
-                    mCacheTransceiver->respondAndSendAsync(llmReq.get());
+                    mCacheTransceiver->respondAndSendAsync(llmReq);
                 }
                 mSeqSlotManager->freeSequenceSlot(llmReq->mRequestId);
             }
@@ -1602,11 +1602,11 @@ void TrtGptModelInflightBatching::prepareDisaggGenInitRequests(
             mCacheTransceiver, "Disaggregated serving is not enabled, please check the configuration.");
         if (common::getEnvDisableKVCacheTransferOverlap())
         {
-            mCacheTransceiver->requestAndReceiveSync(newGenReq.get());
+            mCacheTransceiver->requestAndReceiveSync(newGenReq);
         }
         else
         {
-            mCacheTransceiver->requestAndReceiveAsync(newGenReq.get());
+            mCacheTransceiver->requestAndReceiveAsync(newGenReq);
         }
     }
     if (!common::getEnvDisableKVCacheTransferOverlap())

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
@@ -175,6 +175,17 @@ void AgentConnection::send(DataContext const& ctx, void const* data, size_t size
         }
     }
     TLLM_CHECK_WITH_INFO(transferState == TransferState::kSUCCESS, "AgentConnection::send failed");
+    // One more cancel check between the successful wait and the (potentially
+    // blocking) notifySyncMessage. notifySyncMessage goes through the NIXL
+    // backend and is not interruptible from this layer; if cancel fires in
+    // the gap between wait() returning and notify starting, bail out now.
+    if (ctx.getTransferTerminate().load(std::memory_order_relaxed))
+    {
+        TLLM_LOG_WARNING(
+            "AgentConnection::send cancelled after transfer completed but before notify (ctx tag=%d, remote=%s)",
+            ctx.getTag(), mRemoteAgentName.c_str());
+        TLLM_THROW("AgentConnection::send cancelled pre-notify");
+    }
     // TODO: there is a bug in request_with_notify https://github.com/ai-dynamo/nixl/pull/252
     mAgentConnectionManager->getAgent()->notifySyncMessage(mRemoteAgentName, ss.str());
 }
@@ -187,7 +198,8 @@ void AgentConnection::recv(DataContext const& ctx, void* data, size_t size) cons
 }
 
 void AgentConnection::sendRequestAndBufferInfo(batch_manager::RequestInfo& requestInfo,
-    std::vector<std::optional<size_t>> const& cacheBufferIds, int connectionIdx)
+    std::vector<std::optional<size_t>> const& cacheBufferIds, int connectionIdx,
+    std::atomic<bool> const* perRequestCancel)
 {
     TLLM_CHECK(!common::getEnvTryZCopyForKVCacheTransfer());
 
@@ -239,6 +251,18 @@ void AgentConnection::sendRequestAndBufferInfo(batch_manager::RequestInfo& reque
     std::stringstream ss;
     NotificationInfo notificationInfo{requestAndBufferInfo};
     NotificationInfo::serialize(notificationInfo, ss);
+    // Pre-notify cancel check: notifySyncMessage enters the NIXL backend and
+    // is not interruptible from this layer. The caller's for-loop in
+    // CacheReceiver::Impl::sendRequestInfo also checks perRequestCancel
+    // between iterations; this check narrows the window where a cancel
+    // fired right before this peer's notify is suppressed.
+    if (perRequestCancel != nullptr && perRequestCancel->load(std::memory_order_relaxed))
+    {
+        TLLM_LOG_WARNING(
+            "AgentConnection::sendRequestAndBufferInfo cancelled via perRequestCancel before notify (remote=%s)",
+            mRemoteAgentName.c_str());
+        TLLM_THROW("sendRequestAndBufferInfo cancelled pre-notify");
+    }
     mAgentConnectionManager->getAgent()->notifySyncMessage(mRemoteAgentName, ss.str());
 }
 

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
@@ -143,7 +143,37 @@ void AgentConnection::send(DataContext const& ctx, void const* data, size_t size
     NotificationInfo notificationInfo{syncInfo};
     std::stringstream ss;
     NotificationInfo::serialize(notificationInfo, ss);
-    TransferState transferState = status->wait();
+    // Poll in bounded chunks so we can observe ctx.getTransferTerminate()
+    // (which may be a per-request cancel flag plumbed in from the drain
+    // worker's requestSync) between polls. Without this, a stuck peer
+    // blocks submitTransferRequests's completion indefinitely — the
+    // post-saturation no-recovery signature diagnosed in
+    // docs/pr-13056-option-c.md and verified via v11b [reqSync]
+    // instrumentation, where pre-sendRequestInfo had no matching
+    // post-sendRequestInfo for 60 s+.
+    static constexpr int64_t kCancelPollTimeoutMs = 100;
+    TransferState transferState = TransferState::kIN_PROGRESS;
+    while (transferState == TransferState::kIN_PROGRESS)
+    {
+        transferState = status->wait(kCancelPollTimeoutMs);
+        if (transferState == TransferState::kIN_PROGRESS
+            && ctx.getTransferTerminate().load(std::memory_order_relaxed))
+        {
+            // Cancel observed mid-send. TransferStatus exposes no abort
+            // primitive, so we cannot force-release the underlying NIXL
+            // xfer from here — the xfer may complete asynchronously or
+            // leak one descriptor per cancel event. Throwing here lets
+            // the caller (requestSync) unwind via
+            // RequestSpecificException and the drain worker resume
+            // consuming mRequestsQueue, which is the acceptance criterion
+            // for recovery. Leaking a single xfer descriptor per cancel
+            // is preferable to an unrecoverable drain-worker wedge.
+            TLLM_LOG_WARNING(
+                "AgentConnection::send cancelled via transferTerminate (ctx tag=%d, remote=%s)",
+                ctx.getTag(), mRemoteAgentName.c_str());
+            TLLM_THROW("AgentConnection::send cancelled mid-transfer");
+        }
+    }
     TLLM_CHECK_WITH_INFO(transferState == TransferState::kSUCCESS, "AgentConnection::send failed");
     // TODO: there is a bug in request_with_notify https://github.com/ai-dynamo/nixl/pull/252
     mAgentConnectionManager->getAgent()->notifySyncMessage(mRemoteAgentName, ss.str());

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.h
@@ -259,8 +259,14 @@ public:
         std::string mAgentName, std::string mRemoteAgentName, AgentConnectionManager* mAgentConnectionManager);
     void send(DataContext const& ctx, void const* data, size_t size) const override;
     void recv(DataContext const& ctx, void* data, size_t size) const override;
+    // `perRequestCancel` is an optional pointer to a per-request cancel
+    // atomic (matches the flag registry in CacheReceiver::Impl). When
+    // non-null and flipped true before notifySyncMessage runs, the function
+    // throws so requestSync can unwind instead of blocking inside a NIXL
+    // backend notify call with no visibility into cancellation.
     void sendRequestAndBufferInfo(batch_manager::RequestInfo& requestInfo,
-        std::vector<std::optional<size_t>> const& cacheBufferIds, int validConnectionIdx);
+        std::vector<std::optional<size_t>> const& cacheBufferIds, int validConnectionIdx,
+        std::atomic<bool> const* perRequestCancel = nullptr);
     void setSenderState(std::vector<MemoryDesc> cacheReceiverBufferDescs, int valideSegmentIdx,
         std::vector<std::pair<size_t, size_t>> offsetRatios, std::vector<uint8_t> bufferKinds);
     void setHasLoadRemoteAgent(bool hasLoadRemoteAgent);

--- a/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
@@ -46,17 +46,17 @@ public:
     // using BaseCacheTransceiver::BaseCacheTransceiver; // Inherit constructors
     NB_TRAMPOLINE(tb::BaseCacheTransceiver, 6);
 
-    void respondAndSendAsync(tb::LlmRequest* llmRequest) override
+    void respondAndSendAsync(std::shared_ptr<tb::LlmRequest> llmRequest) override
     {
         NB_OVERRIDE_PURE(respondAndSendAsync, llmRequest);
     }
 
-    void requestAndReceiveSync(tb::LlmRequest* llmRequest) override
+    void requestAndReceiveSync(std::shared_ptr<tb::LlmRequest> llmRequest) override
     {
         NB_OVERRIDE_PURE(requestAndReceiveSync, llmRequest);
     }
 
-    void requestAndReceiveAsync(tb::LlmRequest* llmRequest) override
+    void requestAndReceiveAsync(std::shared_ptr<tb::LlmRequest> llmRequest) override
     {
         NB_OVERRIDE_PURE(requestAndReceiveAsync, llmRequest);
     }
@@ -77,7 +77,7 @@ public:
         NB_OVERRIDE_PURE(checkGenTransferComplete);
     }
 
-    bool cancelRequest(tb::LlmRequest* llmRequest) override
+    bool cancelRequest(std::shared_ptr<tb::LlmRequest> llmRequest) override
     {
         NB_OVERRIDE_PURE(cancelRequest, llmRequest);
     }

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3638,7 +3638,13 @@ class PyExecutor:
                 # If partial reuse is enabled, and the KV cache manager is not VSWA, and the PP size is 1,
                 # then we need to terminate the request. TODO: Remove this once disagg support from KVCache reuse
                 # path is fixed.
-                if request.is_disagg_context_transmission_state:
+                if request.is_disagg_context_complete_state:
+                    # Already terminated (or attempted) by
+                    # _check_disagg_ctx_cache_transfer_status; re-terminating
+                    # here would cause a double free in resource_manager
+                    # (nvbug/5961736).
+                    pass
+                elif request.is_disagg_context_transmission_state:
                     # Request is still transferring KV cache to the decode worker.
                     # Do NOT terminate — the C++ CacheTransceiver still holds a raw
                     # pointer to this request in mSenderFutures. Terminating now

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3618,11 +3618,19 @@ class PyExecutor:
                 # If partial reuse is enabled, and the KV cache manager is not VSWA, and the PP size is 1,
                 # then we need to terminate the request. TODO: Remove this once disagg support from KVCache reuse
                 # path is fixed.
-                if self.enable_partial_reuse_for_disagg and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1:
+                if request.is_disagg_context_transmission_state:
+                    # Request is still transferring KV cache to the decode worker.
+                    # Do NOT terminate — the C++ CacheTransceiver still holds a raw
+                    # pointer to this request in mSenderFutures. Terminating now
+                    # would free the LlmRequest and create a dangling pointer,
+                    # causing use-after-free (request ID reads as 0, transfer start
+                    # reads as epoch). Let the transfer complete or time out via
+                    # kv_transfer_timeout_ms in checkContextTransferStatus.
+                    pass
+                elif self.enable_partial_reuse_for_disagg and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1:
                     requests_to_terminate.append(request)
                 else:
-                    if not request.is_disagg_context_transmission_state:
-                        requests_to_terminate.append(request)
+                    requests_to_terminate.append(request)
             else:
                 new_active_requests.append(request)
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3175,21 +3175,16 @@ class PyExecutor:
         for request_id in list(requests_in_transfer.keys()):
             request = requests_in_transfer[request_id]
             if request.py_kv_transfer_timed_out and request_id not in completed_req_ids:
-                # Every entry in requests_in_transfer is by construction in
-                # DISAGG_CONTEXT_TRANS_IN_PROGRESS (set by
-                # AsyncTransferManager.start_transfer before the C++ sender
-                # gets the raw LlmRequest*). Python-side cancel_request()
-                # only drains CacheSender::mReadyResponses; it does NOT
-                # remove the raw pointer from CacheTransceiver::mSenderFutures.
-                # _end_transfer_and_maybe_terminate() would then free the
-                # LlmRequest, and the next checkContextTransferStatus call
-                # would dereference a dangling pointer (use-after-free that
-                # surfaces as `free(): invalid next size`).
-                # Defer to the C++ kv_transfer_timeout_ms path, which evicts
-                # the entry and reports it via errorRequestIds — at which
-                # point the request is safe to terminate.
-                if request.is_disagg_context_transmission_state:
-                    continue
+                # The Path B guard previously deferred cleanup while state was
+                # DISAGG_CONTEXT_TRANS_IN_PROGRESS to avoid a UAF on
+                # CacheTransceiver::mSenderFutures's raw LlmRequest* (confirmed
+                # via MALLOC_PERTURB_=85 producing mRequestId=0x5555555555555555).
+                # mSenderFutures now holds std::shared_ptr<LlmRequest>, so the
+                # LlmRequest outlives every C++ access regardless of when
+                # Python drops its pybind reference — the UAF class is gone
+                # and the guard is no longer needed. Running cancel_request +
+                # end_transfer here recovers the KV blocks promptly even when
+                # the C++ deadline check can't reach the entry (orphan class).
                 is_cancelled = self.kv_cache_transceiver.cancel_request(request)
                 # If cancel is successful, mark as complete so it can be cleaned up
                 # Otherwise, try at next iteration
@@ -3559,24 +3554,18 @@ class PyExecutor:
                 requests_to_terminate.append(request)
                 continue
 
-            # Check if generation request needs cleanup due to KV cache transfer timeout
+            # Check if generation request needs cleanup due to KV cache transfer timeout.
+            #
+            # The C++ transceiver's async workers and mSenderFutures /
+            # mRequesterFutures now hold std::shared_ptr<LlmRequest> (not raw
+            # pointers), so Python-side _terminate_request can safely run
+            # regardless of C++ state — the LlmRequest stays alive until all
+            # strong references (Python active_requests, C++ futures map,
+            # async workers) drop. The previous Path A guard existed to defer
+            # cleanup until C++ evicted first; that guard was what turned
+            # C++ tracker orphans into permanent KV-block leaks because the
+            # C++ deadline check couldn't reach orphaned entries.
             if request.py_kv_transfer_timed_out:
-                # If the request is still in transmission, the C++ cache
-                # sender/receiver holds a raw LlmRequest* in
-                # mSenderFutures / mRequesterFutures. A Python-side
-                # cancel_request() only drains mReadyResponses (on the
-                # sender) / mReceiverFutures map (on the receiver) and
-                # leaves the raw pointer in place. _handle_errors() would
-                # then free the LlmRequest, and the next
-                # checkContextTransferStatus / checkGenTransferStatus call
-                # would dereference a dangling pointer (use-after-free).
-                # Defer cleanup to the C++ kv_transfer_timeout_ms path,
-                # which evicts the entry and reports it via errorRequestIds
-                # (ctx) or DISAGG_TRANS_ERROR state (gen).
-                if (request.is_disagg_context_transmission_state
-                        or request.
-                        is_disagg_generation_transmission_in_progress):
-                    continue
                 is_cancelled = self.kv_cache_transceiver.cancel_request(request)
                 if is_cancelled:
                     self._handle_errors(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3175,6 +3175,21 @@ class PyExecutor:
         for request_id in list(requests_in_transfer.keys()):
             request = requests_in_transfer[request_id]
             if request.py_kv_transfer_timed_out and request_id not in completed_req_ids:
+                # Every entry in requests_in_transfer is by construction in
+                # DISAGG_CONTEXT_TRANS_IN_PROGRESS (set by
+                # AsyncTransferManager.start_transfer before the C++ sender
+                # gets the raw LlmRequest*). Python-side cancel_request()
+                # only drains CacheSender::mReadyResponses; it does NOT
+                # remove the raw pointer from CacheTransceiver::mSenderFutures.
+                # _end_transfer_and_maybe_terminate() would then free the
+                # LlmRequest, and the next checkContextTransferStatus call
+                # would dereference a dangling pointer (use-after-free that
+                # surfaces as `free(): invalid next size`).
+                # Defer to the C++ kv_transfer_timeout_ms path, which evicts
+                # the entry and reports it via errorRequestIds — at which
+                # point the request is safe to terminate.
+                if request.is_disagg_context_transmission_state:
+                    continue
                 is_cancelled = self.kv_cache_transceiver.cancel_request(request)
                 # If cancel is successful, mark as complete so it can be cleaned up
                 # Otherwise, try at next iteration
@@ -3546,6 +3561,22 @@ class PyExecutor:
 
             # Check if generation request needs cleanup due to KV cache transfer timeout
             if request.py_kv_transfer_timed_out:
+                # If the request is still in transmission, the C++ cache
+                # sender/receiver holds a raw LlmRequest* in
+                # mSenderFutures / mRequesterFutures. A Python-side
+                # cancel_request() only drains mReadyResponses (on the
+                # sender) / mReceiverFutures map (on the receiver) and
+                # leaves the raw pointer in place. _handle_errors() would
+                # then free the LlmRequest, and the next
+                # checkContextTransferStatus / checkGenTransferStatus call
+                # would dereference a dangling pointer (use-after-free).
+                # Defer cleanup to the C++ kv_transfer_timeout_ms path,
+                # which evicts the entry and reports it via errorRequestIds
+                # (ctx) or DISAGG_TRANS_ERROR state (gen).
+                if (request.is_disagg_context_transmission_state
+                        or request.
+                        is_disagg_generation_transmission_in_progress):
+                    continue
                 is_cancelled = self.kv_cache_transceiver.cancel_request(request)
                 if is_cancelled:
                     self._handle_errors(


### PR DESCRIPTION
## Intent

Draft PR. Subset of the commits in #13056, rebased/cherry-picked onto base commit `4e69c14f732a6e6afce4f71616db5b5cd2b10530` (the TRT-LLM commit the `tensorrt-llm==1.3.0rc11` wheel in NVIDIA NGC's `dynamo-trtllm:dynamo-main-pr12639-x86-b200` image is built on).

This branch is **not** meant to replace PR #13056 — it exists so we can build a rc11-based image with the shared_ptr / UAF fixes applied and test it against the d64 reproducer documented downstream. If the resulting image no longer crashes with `std::future_error: Broken promise`, that localises the remaining failure mode.

## What's included (15 commits from #13056, in cherry-pick order, + 1 follow-up fix for a resolution mistake)

All 15 fix commits come from PR #13056. One additional follow-up commit on this branch re-adds a guard that was accidentally dropped during conflict resolution (see "Conflict resolution audit" below).

1. `d7844fc6f` — Enforce `kv_transfer_timeout_ms` on prefill sender + guard against dangling pointers
2. `b2b0a820f` — Report timed-out transfers to Python for full cleanup
3. `9ad782231` — Apply `kv_transfer_timeout_ms` in blockAll mode
4. `daf70d403` — Close remaining UAF paths and enforce gen-side deadline
5. `b9450529b` — Hoist `kv_transfer_timeout_ms` check above readiness gate
6. `267e813c2` — Release receiver resources when gen-side deadline evicts
7. `738183086` — `sendRequestInfo` / `receiveReadySignal` / data-phase send honor `perRequestCancel`
8. `3736d1129` — Sender-side in-flight cancel parity + `notifySyncMessage` pre-notify check
9. `6cf21fd7c` — Tie sender cancel-flag lifetime to session + port `catch(...)` to sender worker
10. `149421e72` — Bound `assignBufferIndex` CV wait + plumb cancel + diagnostic `[buf]` logs
11. `30f9cb2ec` — RAII `BufferIndexHolder` for `requestSync` — stop leaking pool slots on non-happy exits
12. `28ef114db` — RAII `BufferIndexHolder` on sender formatters + reqId-tagged `[buf]` logs
13. `902fab728` — Send-side RAII: atomic `release()`, cancel parity, FUTURE_WAIT/JOIN diagnostics
14. `33262c5ba` — **Carry `std::shared_ptr<LlmRequest>` through transceiver** — close UAF, remove Path A/B guards, unwedge KV block leak
15. `f63172f7e` — Harden drain worker loop against non-`std::exception` escapes
16. _(follow-up on this branch, not from #13056)_ — Re-add `is_disagg_context_complete_state` guard to `_handle_responses` that was dropped during the `d7844fc6f` conflict resolution. See audit below.

## What's intentionally **not** here (vs PR #13056)

- Comment-only chores (`84499475b`, `568454fbd`, `b2dd08146`, `5779e5c53`, `4001ac5d7`)
- Regression test (`88987cc08`) — pulled out; test harness needs adaptation on the older base
- Diagnostic-only commits (`e61a5fa2b`, `5904b9e11`)
- Reverted pair (`80474ce30`, `d30767c69`)

## Conflict resolution audit

Four files needed manual resolution because the base at `4e69c14f73` predates refactors the PR assumed. Each resolution was re-audited after the initial pass — findings below.

### `py_executor.py` first hunk (`d7844fc6f`) — **had a bug, now fixed**

PR 13056 introduces three guard branches before the terminate paths:

```python
if request.is_disagg_context_complete_state:
    requests_finished_by_transfer.append(request)   # not in this subset's codepath
elif request.is_disagg_context_transmission_state:
    pass
elif force_terminate_for_partial_reuse:
    requests_to_terminate.append(request)
else:
    requests_to_terminate.append(request)
```

The `requests_finished_by_transfer` local variable is defined elsewhere in the PR 13056 base but **not** on `4e69c14f73`, so the first branch can't be ported verbatim. The initial resolution dropped the whole first branch.

Audit found this was unsafe: the `is_disagg_context_complete_state` attribute IS available on `4e69c14f73` (C++ `isDisaggContextCompleteState()` + nanobind binding). A COMPLETE-state request can remain in `active_requests` when `_end_transfer_and_maybe_terminate` has `end_transfer()` return False, and without the guard `_handle_responses` would append it to `requests_to_terminate` and call `_terminate_request` → `resource_manager.free_resources(request)` a second time (nvbug/5961736). This is a pre-existing latent issue on rc11 base that PR 13056 fixes; dropping the guard during cherry-pick left the subset failing to apply that fix.

The follow-up commit on this branch re-adds the guard as a `pass` branch — the subset doesn't need the `requests_finished_by_transfer` stats tracking, only the double-free avoidance.

### `tests/unittest/others/test_kv_cache_transceiver.py` (`b9450529b`) — test coverage loss, no runtime impact

The two new regression tests `test_context_transfer_times_out_on_stuck_sender` and `test_context_transfer_times_out_with_at_least_zero` depend on test helpers not available on `4e69c14f73`. Dropped entirely; the subset is C++-fixes-only and the tests should be ported separately.

### `dataTransceiver.cpp` (`738183086` / `30f9cb2ec`) — signature evolution, took the later form

The signature of `sendRequestInfo` evolves across commits 7 and 11:
- (7) `sendRequestInfo(llmRequest, perRequestCancel)`
- (11) `sendRequestInfo(llmRequest, perRequestCancel, std::move(cacheBufferIds))`

The cherry-pick for (7) conflicted because HEAD had the single-argument form; the cherry-pick for (11) then conflicted again on the same site. Both were resolved by taking the later commit's form (11), which is what the PR ultimately lands on. No divergence from PR 13056's final state.

### `cacheTransceiver.cpp` + `py_executor.py` (`33262c5ba`) — faithful to commit intent

This commit explicitly removes the Path A/B Python guards that earlier PR commits (notably `daf70d403`) added, because `mSenderFutures` / `mRequesterFutures` now hold `std::shared_ptr<LlmRequest>` and the UAF class the guards existed to prevent is gone. The conflict resolution accepts the removal — this is exactly what the commit message describes.

## Build / test instructions

This branch is for another agent to build into a Dynamo container image. The intended usage:

```bash
git clone https://github.com/yifjiang/TensorRT-LLM.git
cd TensorRT-LLM
git checkout pr13056-subset-on-4e69c14
# Build a tensorrt_llm wheel from this branch (replaces the 1.3.0rc11 wheel baked into the dynamo image)
# Layer the new wheel into a dynamo-trtllm image; see the downstream d64 reproducer doc for the expected harness.
```

Do not merge this draft PR into `main` — it is a cherry-pick against a known past base commit and will conflict with current `main`. It exists only to supply a clean patch series for an offline build.

## Verification plan (run downstream)

1. Build the patched `tensorrt_llm` wheel from this branch.
2. Overlay into the Dynamo container image currently used by the d64 reproducer.
3. Run the 1P1D loadgen at conc 16 / 48 / 128 with live worker-log tails.
4. Pass criteria: no `std::future_error: Broken promise`, no `bad optional access` in the event loop; all three recovery probes return `ok200`.