### PR TITLE
[TRTLLM-12199][feat] WideEP FT: add EPGroupHealth thread-safe rank mask (1a.1)

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/ep_group_health.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/ep_group_health.py
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""EP group health tracking for WideEP fault tolerance.
+
+This module provides :class:`EPGroupHealth`, a process-local, thread-safe data
+structure that records which ranks in an Expert Parallel (EP) group are currently
+alive vs. failed. It is the single source of truth for EP rank health within one
+process and is consumed by:
+
+  * AlltoAll communication backends (rank masking on dispatch / combine)
+  * The host-side AlltoAll watchdog (failure detection)
+  * The MoE load balancer (emergency-mask reconfiguration)
+  * The model engine and PyExecutor (degraded health reporting)
+
+Cross-process consensus on which ranks are dead (failure broadcast across the EP
+group) is the responsibility of higher-layer coordination components and is not
+performed here.
+"""
+
+import threading
+from typing import NamedTuple
+
+# Default number of uint64 words for EPGroupHealth.get_mask_words().
+# Matches the active_rank_mask ABI of the NVLink AlltoAll kernels
+# (uint64_t[2]). Two words cover 128 ranks, sufficient for NVL72 with
+# headroom.
+EP_MASK_NUM_WORDS: int = 2
+
+
+class EPGroupHealthSnapshot(NamedTuple):
+    """Atomic snapshot of :class:`EPGroupHealth` state.
+
+    Returned by :meth:`EPGroupHealth.snapshot`; all four fields reflect a
+    single point in time (a single internal lock acquisition). Use this when
+    the consumer needs a coherent view across multiple fields rather than
+    calling individual accessors back-to-back (which can observe torn state
+    if a mutator runs between calls).
+    """
+
+    # Active-rank bitmask (bit i set iff rank i is active).
+    mask: int
+    # Number of ranks currently marked active.
+    active_count: int
+    # Immutable snapshot of failed ranks.
+    failed_ranks: frozenset[int]
+    # Monotonic counter; bumps only on effective state changes.
+    generation: int
+
+
+class EPGroupHealth:
+    """Thread-safe health tracker for the ranks of an EP group.
+
+    Internally backed by an arbitrary-precision Python ``int`` bitmask
+    (bit ``i`` set iff rank ``i`` is currently active). The kernel-side
+    representation as a fixed-width array of ``uint64`` words is exposed via
+    :meth:`get_mask_words`; this matches the ``active_rank_mask`` parameter
+    expected by the NVLink AlltoAll kernels.
+
+    All read and write operations take an internal lock. Read operations that
+    return collection types return defensive snapshots so the caller cannot
+    mutate internal state.
+
+    .. note::
+       Observations across multiple individual accessors are **not** atomic
+       (a mutator can run between calls). Consumers that need a coherent
+       multi-field view should call :meth:`snapshot`, or compare a cached
+       :attr:`generation` to detect concurrent changes.
+
+    Args:
+        moe_world_size: Total number of ranks in the MoE world. Must be ``> 0``.
+
+    Raises:
+        ValueError: If ``moe_world_size <= 0``.
+    """
+
+    def __init__(self, moe_world_size: int) -> None:
+        """Initialize all MoE ranks as active."""
+        if moe_world_size <= 0:
+            raise ValueError(f"moe_world_size must be > 0, got {moe_world_size}")
+        # _moe_world_size and _all_active_mask are set once here and never mutated;
+        # they are therefore safe to read without holding _lock (e.g. in
+        # _validate_rank, moe_world_size property).
+        self._moe_world_size: int = moe_world_size
+        self._all_active_mask: int = (1 << moe_world_size) - 1
+        self._active_mask: int = self._all_active_mask
+        self._active_count: int = moe_world_size
+        self._failed_ranks: set[int] = set()
+        self._generation: int = 0
+        self._lock = threading.Lock()
+
+    @property
+    def moe_world_size(self) -> int:
+        """Total number of ranks in the MoE world (immutable)."""
+        return self._moe_world_size
+
+    @property
+    def generation(self) -> int:
+        """Monotonic counter incremented on every effective state change.
+
+        Idempotent calls (e.g. marking an already-failed rank as failed) do not
+        bump the counter. Consumers that need to react to mask changes can
+        cache the last-seen generation and compare on each iteration boundary
+        instead of diffing the full mask.
+        """
+        # The lock is taken to ensure visibility of writes by other threads
+        # without relying on GIL-based ordering (relevant for free-threaded
+        # CPython, PEP 703 / 3.13+). The read itself is atomic either way.
+        with self._lock:
+            return self._generation
+
+    def _validate_rank(self, rank: int) -> None:
+        """Raise if ``rank`` is outside the MoE world."""
+        if not 0 <= rank < self._moe_world_size:
+            raise ValueError(f"rank must be in [0, {self._moe_world_size}), got {rank}")
+
+    def mark_failed(self, rank: int) -> bool:
+        """Mark ``rank`` as failed. Idempotent.
+
+        Args:
+            rank: Index of the rank to mark, in ``[0, moe_world_size)``.
+
+        Returns:
+            ``True`` if this call changed state (rank was previously active),
+            ``False`` if the rank was already marked failed.
+
+        Raises:
+            ValueError: If ``rank`` is outside ``[0, moe_world_size)``.
+        """
+        self._validate_rank(rank)
+        bit = 1 << rank
+        with self._lock:
+            if not self._active_mask & bit:
+                return False
+            self._active_mask &= ~bit
+            self._active_count -= 1
+            self._failed_ranks.add(rank)
+            self._generation += 1
+            return True
+
+    def mark_active(self, rank: int) -> bool:
+        """Mark ``rank`` as active. Idempotent.
+
+        Used when a replacement rank rejoins the group after a failure.
+        Higher layers may impose a "monotonic failure" policy (do not
+        reactivate a failed rank until the process group has been
+        reconstructed); this primitive does not enforce that policy on its own.
+
+        Args:
+            rank: Index of the rank to mark, in ``[0, moe_world_size)``.
+
+        Returns:
+            ``True`` if this call changed state (rank was previously failed),
+            ``False`` if the rank was already marked active.
+
+        Raises:
+            ValueError: If ``rank`` is outside ``[0, moe_world_size)``.
+        """
+        self._validate_rank(rank)
+        bit = 1 << rank
+        with self._lock:
+            if self._active_mask & bit:
+                return False
+            self._active_mask |= bit
+            self._active_count += 1
+            self._failed_ranks.discard(rank)
+            self._generation += 1
+            return True
+
+    def is_active(self, rank: int) -> bool:
+        """Return ``True`` iff ``rank`` is currently marked active.
+
+        Raises:
+            ValueError: If ``rank`` is outside ``[0, moe_world_size)``.
+        """
+        self._validate_rank(rank)
+        with self._lock:
+            return bool(self._active_mask & (1 << rank))
+
+    def get_mask(self) -> int:
+        """Return the active-rank bitmask as a Python ``int``.
+
+        Bit ``i`` is set iff rank ``i`` is currently active.
+        """
+        with self._lock:
+            return self._active_mask
+
+    def get_mask_words(self, num_words: int = EP_MASK_NUM_WORDS) -> tuple[int, ...]:
+        """Return the active-rank bitmask split into little-endian uint64 words.
+
+        Suitable for passing to CUDA kernels that accept ``uint64_t[num_words]``.
+        Word ``0`` covers ranks ``0..63``, word ``1`` covers ranks ``64..127``,
+        etc. The default of two words covers the NVL72 case (72 ranks) with
+        headroom for future expansion.
+
+        Args:
+            num_words: Number of 64-bit words to produce. Must be large enough
+                to hold ``moe_world_size`` bits (``num_words * 64 >= moe_world_size``).
+
+        Returns:
+            A tuple of ``num_words`` non-negative ``int`` values, each in
+            ``[0, 2**64)``.
+
+        Raises:
+            ValueError: If ``num_words`` is non-positive or too small to hold
+                ``moe_world_size`` bits.
+        """
+        if num_words <= 0:
+            raise ValueError(f"num_words must be > 0, got {num_words}")
+        if num_words * 64 < self._moe_world_size:
+            raise ValueError(
+                f"num_words={num_words} cannot represent moe_world_size={self._moe_world_size}"
+            )
+        word_mask = (1 << 64) - 1
+        with self._lock:
+            mask = self._active_mask
+        return tuple((mask >> (i * 64)) & word_mask for i in range(num_words))
+
+    def get_active_count(self) -> int:
+        """Return the number of ranks currently marked active."""
+        with self._lock:
+            return self._active_count
+
+    def get_failed_ranks(self) -> frozenset[int]:
+        """Return an immutable snapshot of the set of failed ranks."""
+        with self._lock:
+            return frozenset(self._failed_ranks)
+
+    def all_active(self) -> bool:
+        """Return ``True`` iff every rank in the group is currently active."""
+        with self._lock:
+            return self._active_mask == self._all_active_mask
+
+    def snapshot(self) -> EPGroupHealthSnapshot:
+        """Return an atomic snapshot of mask, active_count, failed_ranks, generation.
+
+        All four fields reflect a single point in time (one lock acquisition).
+        Prefer this over calling individual accessors back-to-back when the
+        consumer needs a coherent multi-field view.
+        """
+        with self._lock:
+            return EPGroupHealthSnapshot(
+                mask=self._active_mask,
+                active_count=self._active_count,
+                failed_ranks=frozenset(self._failed_ranks),
+                generation=self._generation,
+            )
+
+    def __len__(self) -> int:
+        """Return the MoE world size (``moe_world_size``), not the active count.
+
+        Provided for compatibility with code that treats this object as a
+        sized container of ranks (alive or dead). Use :meth:`get_active_count`
+        when you specifically want the surviving-rank count.
+        """
+        return self._moe_world_size
+
+    def __repr__(self) -> str:
+        """Return a concise debug representation of the current health state."""
+        with self._lock:
+            return (
+                f"EPGroupHealth(moe_world_size={self._moe_world_size}, "
+                f"active_count={self._active_count}, "
+                f"failed_ranks={sorted(self._failed_ranks)}, "
+                f"generation={self._generation})"
+            )

--- a/tests/unittest/_torch/modules/test_ep_group_health.py
+++ b/tests/unittest/_torch/modules/test_ep_group_health.py
@@ -1,0 +1,479 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for EPGroupHealth (WideEP fault tolerance, PR 1a.1).
+
+Covers single-threaded correctness of the public API and concurrent update
+races as required by the WideEP FT implementation plan section 8.
+"""
+
+import threading
+
+import pytest
+
+from tensorrt_llm._torch.modules.fused_moe.ep_group_health import (
+    EP_MASK_NUM_WORDS,
+    EPGroupHealth,
+    EPGroupHealthSnapshot,
+)
+
+# ---------------------------------------------------------------------------
+# Construction and validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "moe_world_size",
+    [1, 2, 8, 64, 72, 128],
+    ids=["ep1", "ep2", "ep8", "ep64_one_word_full", "nvl72", "ep128_two_words_full"],
+)
+def test_initial_state_all_active(moe_world_size: int) -> None:
+    """Verify a new health object starts with every rank active."""
+    h = EPGroupHealth(moe_world_size)
+    assert h.moe_world_size == moe_world_size
+    assert len(h) == moe_world_size
+    assert h.get_active_count() == moe_world_size
+    assert h.get_failed_ranks() == frozenset()
+    assert h.all_active() is True
+    assert h.generation == 0
+    assert h.get_mask() == (1 << moe_world_size) - 1
+    for r in range(moe_world_size):
+        assert h.is_active(r) is True
+
+
+@pytest.mark.parametrize(
+    "bad_size",
+    [0, -1, -100],
+    ids=["zero", "neg_one", "large_neg"],
+)
+def test_init_rejects_non_positive_moe_world_size(bad_size: int) -> None:
+    """Reject zero and negative MoE world sizes."""
+    with pytest.raises(ValueError):
+        EPGroupHealth(bad_size)
+
+
+@pytest.mark.parametrize(
+    "bad_rank",
+    [-1, 8, 9, 100],
+    ids=["neg_one", "at_moe_world_size", "above_moe_world_size", "way_above"],
+)
+def test_methods_reject_out_of_range_rank(bad_rank: int) -> None:
+    """Reject invalid ranks across rank-indexed APIs."""
+    h = EPGroupHealth(8)
+    with pytest.raises(ValueError):
+        h.mark_failed(bad_rank)
+    with pytest.raises(ValueError):
+        h.mark_active(bad_rank)
+    with pytest.raises(ValueError):
+        h.is_active(bad_rank)
+
+
+# ---------------------------------------------------------------------------
+# Single-threaded correctness: mark_failed / mark_active
+# ---------------------------------------------------------------------------
+
+
+def test_mark_failed_basic() -> None:
+    """Marking an active rank failed updates mask, count, set, and generation."""
+    h = EPGroupHealth(8)
+    assert h.mark_failed(3) is True
+    assert h.is_active(3) is False
+    assert h.get_active_count() == 7
+    assert h.get_failed_ranks() == frozenset({3})
+    assert h.all_active() is False
+    assert h.generation == 1
+    # bit 3 cleared, all other bits set
+    assert h.get_mask() == ((1 << 8) - 1) & ~(1 << 3)
+
+
+def test_mark_failed_idempotent() -> None:
+    """Repeated failure marks for the same rank are no-ops."""
+    h = EPGroupHealth(8)
+    assert h.mark_failed(2) is True
+    gen_after_first = h.generation
+    # Second call is a no-op and reports it.
+    assert h.mark_failed(2) is False
+    assert h.generation == gen_after_first
+    assert h.get_active_count() == 7
+    assert h.get_failed_ranks() == frozenset({2})
+
+
+def test_mark_active_reverses_mark_failed() -> None:
+    """Reactivating a failed rank restores the all-active state."""
+    h = EPGroupHealth(8)
+    h.mark_failed(5)
+    assert h.is_active(5) is False
+    assert h.mark_active(5) is True
+    assert h.is_active(5) is True
+    assert h.get_active_count() == 8
+    assert h.get_failed_ranks() == frozenset()
+    assert h.all_active() is True
+    # Two state changes total: fail + reactivate.
+    assert h.generation == 2
+
+
+def test_mark_active_idempotent_on_already_active() -> None:
+    """Reactivating an already active rank is a no-op."""
+    h = EPGroupHealth(8)
+    # Brand-new health: all ranks active. Reactivating any rank is a no-op.
+    assert h.mark_active(0) is False
+    assert h.generation == 0
+    assert h.get_active_count() == 8
+
+
+def test_multiple_failures_accumulate() -> None:
+    """Independent rank failures accumulate in the mask and failed-rank set."""
+    h = EPGroupHealth(16)
+    for r in [1, 4, 7, 12]:
+        assert h.mark_failed(r) is True
+    assert h.get_active_count() == 12
+    assert h.get_failed_ranks() == frozenset({1, 4, 7, 12})
+    expected_mask = ((1 << 16) - 1) & ~((1 << 1) | (1 << 4) | (1 << 7) | (1 << 12))
+    assert h.get_mask() == expected_mask
+    assert h.generation == 4
+
+
+def test_get_failed_ranks_returns_snapshot() -> None:
+    """Failed-rank queries return immutable snapshots."""
+    h = EPGroupHealth(8)
+    h.mark_failed(2)
+    snap = h.get_failed_ranks()
+    assert isinstance(snap, frozenset)
+    # Snapshot is a frozenset; it cannot be mutated by the caller.
+    with pytest.raises(AttributeError):
+        snap.add(3)  # type: ignore[attr-defined]
+    # Subsequent state changes do not affect the prior snapshot.
+    h.mark_failed(3)
+    assert snap == frozenset({2})
+    assert h.get_failed_ranks() == frozenset({2, 3})
+
+
+# ---------------------------------------------------------------------------
+# get_mask_words (kernel-passing format)
+# ---------------------------------------------------------------------------
+
+
+def _expected_words(moe_world_size: int, num_words: int, fail_ranks: list[int]) -> tuple[int, ...]:
+    """Reference computation: bit i set iff i < moe_world_size and i not in fail_ranks,
+    then split into ``num_words`` little-endian uint64 words.
+    """
+    full = (1 << moe_world_size) - 1
+    for r in fail_ranks:
+        full &= ~(1 << r)
+    word_mask = (1 << 64) - 1
+    return tuple((full >> (i * 64)) & word_mask for i in range(num_words))
+
+
+@pytest.mark.parametrize(
+    "moe_world_size,num_words,fail_ranks",
+    [
+        # default 2 words, all active -> (0xFF, 0)
+        (8, 2, []),
+        # one word, fully populated -> ((1<<64)-1,)
+        (64, 1, []),
+        # NVL72, low-word failure (rank 37 in word 0)
+        (72, 2, [37]),
+        # NVL72, high-word failure (rank 70 in word 1, bit 6)
+        (72, 2, [70]),
+        # extra words past moe_world_size are zero
+        (8, 4, []),
+        # moe_world_size > 128 (beyond default kernel ABI), one failure per word
+        (256, 4, [10, 70, 130, 200]),
+    ],
+    ids=[
+        "ep8_default_all_active",
+        "ep64_one_word_full",
+        "nvl72_low_word_failure",
+        "nvl72_high_word_failure",
+        "ep8_extra_words_zero",
+        "ep256_one_failure_per_word",
+    ],
+)
+def test_get_mask_words_layout(moe_world_size: int, num_words: int, fail_ranks: list[int]) -> None:
+    """Single-word, multi-word, NVL72 boundary, and >128 cases all share the same
+    invariant: get_mask_words() splits the bitmask into the requested number of
+    little-endian uint64 words. Each word must fit in uint64 and the words must
+    reassemble to the underlying get_mask() Python int.
+    """
+    h = EPGroupHealth(moe_world_size)
+    for r in fail_ranks:
+        assert h.mark_failed(r) is True
+
+    words = h.get_mask_words(num_words=num_words)
+    assert words == _expected_words(moe_world_size, num_words, fail_ranks)
+    assert len(words) == num_words
+    for w in words:
+        assert 0 <= w < (1 << 64)
+    # Round-trip: words reassembled equal the underlying Python int.
+    assert h.get_mask() == sum(w << (i * 64) for i, w in enumerate(words))
+
+
+@pytest.mark.parametrize(
+    "bad_num_words",
+    [0, -1],
+    ids=["zero_words", "negative_words"],
+)
+def test_get_mask_words_rejects_non_positive(bad_num_words: int) -> None:
+    """Reject non-positive mask word counts."""
+    h = EPGroupHealth(8)
+    with pytest.raises(ValueError):
+        h.get_mask_words(num_words=bad_num_words)
+
+
+@pytest.mark.parametrize(
+    "moe_world_size,num_words",
+    [
+        (72, 1),  # NVL72: 72 bits do not fit in a single uint64
+        (256, 2),  # moe_world_size > 128 does not fit in the default 2 words
+        (256, 3),  # nor in 3 words
+    ],
+    ids=[
+        "nvl72_in_one_word",
+        "ep256_in_default_two_words",
+        "ep256_in_three_words",
+    ],
+)
+def test_get_mask_words_rejects_too_few_words(moe_world_size: int, num_words: int) -> None:
+    """Reject mask word counts that cannot cover the MoE world."""
+    h = EPGroupHealth(moe_world_size)
+    with pytest.raises(ValueError):
+        h.get_mask_words(num_words=num_words)
+
+
+# ---------------------------------------------------------------------------
+# Generation counter semantics
+# ---------------------------------------------------------------------------
+
+
+def test_generation_only_bumps_on_effective_change() -> None:
+    """Only effective active/failed transitions bump generation."""
+    h = EPGroupHealth(8)
+    assert h.generation == 0
+
+    assert h.mark_failed(3) is True
+    assert h.generation == 1
+    assert h.mark_failed(3) is False  # idempotent
+    assert h.generation == 1
+
+    assert h.mark_active(0) is False  # already active
+    assert h.generation == 1
+
+    assert h.mark_active(3) is True
+    assert h.generation == 2
+
+
+def test_repr_is_informative() -> None:
+    """repr includes the main state fields for debugging."""
+    h = EPGroupHealth(4)
+    h.mark_failed(1)
+    s = repr(h)
+    assert "moe_world_size=4" in s
+    assert "active_count=3" in s
+    assert "failed_ranks=[1]" in s
+    assert "generation=1" in s
+
+
+# ---------------------------------------------------------------------------
+# Concurrent update races
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_mark_failed_distinct_ranks() -> None:
+    """Many threads, each marking a distinct rank; all should land exactly once."""
+    moe_world_size = 128
+    h = EPGroupHealth(moe_world_size)
+
+    barrier = threading.Barrier(moe_world_size)
+
+    def worker(rank: int) -> None:
+        """Mark one distinct rank failed after the synchronized start."""
+        # Synchronize start so threads contend on the lock simultaneously.
+        barrier.wait()
+        h.mark_failed(rank)
+
+    threads = [threading.Thread(target=worker, args=(r,)) for r in range(moe_world_size)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert h.get_active_count() == 0
+    assert h.get_failed_ranks() == frozenset(range(moe_world_size))
+    assert h.get_mask() == 0
+    assert h.generation == moe_world_size
+
+
+def test_concurrent_mark_failed_same_rank_idempotent() -> None:
+    """Many threads racing on the same rank; exactly one effective change."""
+    h = EPGroupHealth(8)
+    n_threads = 64
+    barrier = threading.Barrier(n_threads)
+    effective_changes: list[bool] = []
+    changes_lock = threading.Lock()
+
+    def worker() -> None:
+        """Race with other workers to mark rank 3 failed."""
+        barrier.wait()
+        changed = h.mark_failed(3)
+        with changes_lock:
+            effective_changes.append(changed)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert sum(effective_changes) == 1
+    assert h.get_active_count() == 7
+    assert h.get_failed_ranks() == frozenset({3})
+    assert h.generation == 1
+
+
+def test_concurrent_mixed_fail_and_reactivate() -> None:
+    """Stress: alternating fail/active calls converge to a deterministic state.
+
+    Each rank is touched by one fail-then-active pair; the final state must be
+    all ranks active, with generation == 2 * moe_world_size. The reactivate thread
+    waits on a per-rank threading.Event signaled by the fail thread, so we
+    avoid any busy-wait that could spin under adversarial scheduling.
+    """
+    moe_world_size = 32
+    h = EPGroupHealth(moe_world_size)
+
+    barrier = threading.Barrier(moe_world_size * 2)
+    fail_done = [threading.Event() for _ in range(moe_world_size)]
+
+    def fail(rank: int) -> None:
+        """Mark one rank failed and signal its paired reactivation thread."""
+        barrier.wait()
+        h.mark_failed(rank)
+        fail_done[rank].set()
+
+    def reactivate(rank: int) -> None:
+        """Wait for the paired failure before marking the rank active again."""
+        barrier.wait()
+        # Wait for the corresponding fail to land, then reactivate. Bounded
+        # wait so a regression that prevented the fail signal cannot wedge CI.
+        assert fail_done[rank].wait(timeout=10.0), f"rank {rank} fail did not signal"
+        h.mark_active(rank)
+
+    fail_threads = [threading.Thread(target=fail, args=(r,)) for r in range(moe_world_size)]
+    react_threads = [threading.Thread(target=reactivate, args=(r,)) for r in range(moe_world_size)]
+
+    for t in fail_threads + react_threads:
+        t.start()
+    for t in fail_threads + react_threads:
+        t.join()
+
+    assert h.all_active() is True
+    assert h.get_active_count() == moe_world_size
+    assert h.get_failed_ranks() == frozenset()
+    # Each rank contributed exactly two effective state changes.
+    assert h.generation == 2 * moe_world_size
+
+
+# ---------------------------------------------------------------------------
+# Oscillation (fail -> active -> fail -> active)
+# ---------------------------------------------------------------------------
+
+
+def test_oscillation_preserves_generation_monotonicity() -> None:
+    """Fail -> active -> fail -> active on the same rank.
+
+    Verifies that generation increments by exactly one per effective
+    transition and that the final state is fully restored.
+    """
+    h = EPGroupHealth(8)
+    rank = 5
+    expected_gen = 0
+
+    for cycle in range(4):
+        if cycle % 2 == 0:
+            assert h.mark_failed(rank) is True
+            assert h.is_active(rank) is False
+        else:
+            assert h.mark_active(rank) is True
+            assert h.is_active(rank) is True
+        expected_gen += 1
+        assert h.generation == expected_gen
+
+    # Ended on an active transition; rank should be back.
+    assert h.is_active(rank) is True
+    assert h.all_active() is True
+    assert h.generation == 4
+
+
+# ---------------------------------------------------------------------------
+# snapshot() - atomic multi-field read
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_returns_all_fields_at_one_instant() -> None:
+    """snapshot returns one coherent immutable state view."""
+    h = EPGroupHealth(16)
+    h.mark_failed(3)
+    h.mark_failed(7)
+
+    snap = h.snapshot()
+    assert isinstance(snap, EPGroupHealthSnapshot)
+    assert snap.mask == ((1 << 16) - 1) & ~((1 << 3) | (1 << 7))
+    assert snap.active_count == 14
+    assert snap.failed_ranks == frozenset({3, 7})
+    assert snap.generation == 2
+
+    # Field aliases still work via attribute access.
+    assert snap[0] == snap.mask
+    assert snap[3] == snap.generation
+
+
+def test_snapshot_is_immutable() -> None:
+    """snapshot results cannot be mutated by callers."""
+    h = EPGroupHealth(8)
+    h.mark_failed(1)
+    snap = h.snapshot()
+
+    # NamedTuples are immutable; reassigning a field must fail.
+    with pytest.raises(AttributeError):
+        snap.generation = 99  # type: ignore[misc]
+    # The frozenset slot cannot be mutated either.
+    with pytest.raises(AttributeError):
+        snap.failed_ranks.add(2)  # type: ignore[attr-defined]
+
+    # And later state changes do not retroactively alter the snapshot.
+    h.mark_failed(2)
+    assert snap.failed_ranks == frozenset({1})
+    assert snap.generation == 1
+
+
+# ---------------------------------------------------------------------------
+# __len__ semantics
+# ---------------------------------------------------------------------------
+
+
+def test_len_returns_moe_world_size_not_active_count() -> None:
+    """__len__ is the MoE world size; failures must not change it."""
+    h = EPGroupHealth(8)
+    assert len(h) == 8
+    h.mark_failed(0)
+    h.mark_failed(1)
+    h.mark_failed(2)
+    assert h.get_active_count() == 5  # active count moves
+    assert len(h) == 8  # moe_world_size does not
+
+
+def test_ep_mask_num_words_constant_default_value() -> None:
+    """Lock in the kernel-ABI default. If this changes, kMaxRanks must too."""
+    assert EP_MASK_NUM_WORDS == 2


### PR DESCRIPTION
## Description

Adds `EPGroupHealth`, a process-local, thread-safe rank-health primitive for WideEP fault tolerance (PR 1a.1).

This PR has no runtime behavior change. It only adds the shared in-process state object that follow-up PRs will consume from the AlltoAll watchdog, NVLink rank-mask binding, EPLB reconfigure path, and PyExecutor health reporting.

`EPGroupHealth` provides:
- Idempotent `mark_failed(rank)` / `mark_active(rank)` mutators.
- `is_active`, `get_active_count`, `get_failed_ranks`, and `all_active` queries.
- Active-rank mask export as both a Python `int` and little-endian `uint64` words for the kernel ABI.
- A monotonic `generation` counter for cheap iteration-boundary change detection.
- Atomic immutable `snapshot()` reads for consumers that need coherent multi-field state.

## Background

Phase 1 of WideEP FT needs one shared in-process answer to "which EP ranks are alive?" before later PRs can safely wire detection, kernel masking, EPLB remap, and health reporting. This PR intentionally limits scope to that primitive; cross-rank consensus, watchdog detection, kernel changes, and EPLB integration remain in follow-up PRs.

## Test Coverage

Adds pure-Python unit coverage for:
- construction and validation
- idempotent fail/reactivate semantics
- generation-counter behavior
- mask-word layout, including NVL72 and multi-word cases
- immutable failed-rank and snapshot views
- concurrent update races

Run:
`pytest tests/unittest/_torch/modules/test_ep_group_health.py -v`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit summary, please make sure it makes sense.
- PR follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work)).
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health monitoring system for tracking Expert Parallel rank status, enabling automatic detection and management of node failures in distributed training scenarios.

* **Tests**
  * Added comprehensive unit test coverage validating rank health tracking, state transitions, concurrent safety, and failure recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->