### PR TITLE
[TRI-978][fix] Fix streaming=None crash and CI test failures in L0_backend_trtllm

### DIFF
--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
@@ -551,8 +551,10 @@ def convert_request(request,
         if inputs['max_tokens'] is None:
             raise pb_utils.TritonModelException(
                 "A value is required for request_output_len")
-        inputs['streaming'] = get_input_scalar_by_name(request, 'streaming',
-                                                       batch_size, batch_index)
+        streaming = get_input_scalar_by_name(request, 'streaming', batch_size,
+                                             batch_index)
+        inputs['streaming'] = bool(
+            streaming) if streaming is not None else False
         if inputs['streaming'] and not decoupled:
             raise pb_utils.TritonModelException(
                 "Streaming is only supported in decoupled mode.")

--- a/triton_backend/ci/L0_backend_trtllm/base_metrics_verification_tests.py
+++ b/triton_backend/ci/L0_backend_trtllm/base_metrics_verification_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -81,6 +81,8 @@ class TRTLLMBaseMetricsTest(unittest.TestCase):
                 utils.prepare_tensor("max_tokens", output0_len, "http"),
                 utils.prepare_tensor("bad_words", bad_words_list, "http"),
                 utils.prepare_tensor("stop_words", stop_words_list, "http"),
+                utils.prepare_tensor("stream", np.array([[False]], dtype=bool),
+                                     "http"),
             ]
             if beam_width_value > 1:
                 beam_width = np.ones_like(input0).astype(

--- a/triton_backend/ci/L0_backend_trtllm/custom_metrics_verification_tests.py
+++ b/triton_backend/ci/L0_backend_trtllm/custom_metrics_verification_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -128,13 +128,13 @@ class CustomMetricsTest(unittest.TestCase):
                                            '%m-%d-%Y %H:%M:%S.%f')
                 # Function only supports input in seconds so extract timestamp in seconds
                 # then add microseconds
-                dt_curl = datetime.utcfromtimestamp(
+                dt_curl = datetime.fromtimestamp(
                     int(metrics[metric_key]) // 1000000)
                 dt_curl += timedelta(microseconds=int(metrics[metric_key][-6:]))
                 difference = dt_log - dt_curl
                 self.assertTrue(
-                    timedelta(seconds=-1) <= difference, difference
-                    <= timedelta(seconds=1))
+                    timedelta(seconds=-1) <= difference <= timedelta(seconds=1),
+                    f"Timestamp difference out of range: {difference}")
 
     def test_1_gpu_IFB_no_stream(self):
         self._base_test("1gpu_IFB_no_streaming_server.log",

--- a/triton_backend/ci/L0_backend_trtllm/test.sh
+++ b/triton_backend/ci/L0_backend_trtllm/test.sh
@@ -177,7 +177,7 @@ for NUM_GPU in "${NUM_GPUS_TO_TEST[@]}"; do
         break
     fi
 
-    SERVER_ARGS="--world_size=${NUM_GPU} --model_repo=${MODEL_DIR}"
+    SERVER_ARGS="--world_size=${NUM_GPU} --model_repo=${MODEL_DIR} --oversubscribe"
 
     reset_model_repo
 
@@ -252,7 +252,6 @@ for NUM_GPU in "${NUM_GPUS_TO_TEST[@]}"; do
         exit 1
     fi
 
-    set -e
     python3 ${TOOLS_DIR}/inflight_batcher_llm/benchmark_core_model.py \
         --max-input-len=500 \
         --protocol grpc \
@@ -266,9 +265,7 @@ for NUM_GPU in "${NUM_GPUS_TO_TEST[@]}"; do
         wait_for_server_terminated ${SERVER_TIMEOUT} ${SERVER_PID[@]}
         RET=1
     fi
-    set +e
 
-    set -e
     python3 ${TOOLS_DIR}/inflight_batcher_llm/end_to_end_test.py \
         --max-input-len=500 \
         --dataset=${DATASET}
@@ -280,7 +277,6 @@ for NUM_GPU in "${NUM_GPUS_TO_TEST[@]}"; do
         wait_for_server_terminated ${SERVER_TIMEOUT} ${SERVER_PID[@]}
         RET=1
     fi
-    set +e
 
     # Make sure the metrics is retrieved after the server has updated the metrics internally
     sleep ${SLEEP_DURATION}

--- a/triton_backend/ci/L0_backend_trtllm/test.sh
+++ b/triton_backend/ci/L0_backend_trtllm/test.sh
@@ -255,6 +255,7 @@ for NUM_GPU in "${NUM_GPUS_TO_TEST[@]}"; do
     set -e
     python3 ${TOOLS_DIR}/inflight_batcher_llm/benchmark_core_model.py \
         --max-input-len=500 \
+        --protocol grpc \
         dataset --dataset=${DATASET} \
         --tokenizer-dir=${TOKENIZER_DIR}
 

--- a/triton_backend/inflight_batcher_llm/src/custom_metrics_reporter/custom_metrics_reporter.cc
+++ b/triton_backend/inflight_batcher_llm/src/custom_metrics_reporter/custom_metrics_reporter.cc
@@ -72,10 +72,12 @@ const std::vector<std::string> CustomMetricsReporter::input_metric_type_labels_{
 
 uint64_t convertTimestampToMicroseconds(std::string const& ts)
 {
+    // -1 tells mktime to determine DST automatically, matching localtime() used in getCurrentTimestamp
+    int const kMktimeDetermineDst = -1;
     std::tm tm = {};
     std::stringstream ss(ts);
     ss >> std::get_time(&tm, "%m-%d-%Y %H:%M:%S");
-    tm.tm_isdst = -1; // Let mktime determine DST to match localtime() used in getCurrentTimestamp
+    tm.tm_isdst = kMktimeDetermineDst;
     auto timestamp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
     auto epoch = std::chrono::time_point_cast<std::chrono::microseconds>(timestamp).time_since_epoch();
     uint64_t seconds_to_microseconds = std::chrono::duration_cast<std::chrono::microseconds>(epoch).count();

--- a/triton_backend/inflight_batcher_llm/src/custom_metrics_reporter/custom_metrics_reporter.cc
+++ b/triton_backend/inflight_batcher_llm/src/custom_metrics_reporter/custom_metrics_reporter.cc
@@ -75,6 +75,7 @@ uint64_t convertTimestampToMicroseconds(std::string const& ts)
     std::tm tm = {};
     std::stringstream ss(ts);
     ss >> std::get_time(&tm, "%m-%d-%Y %H:%M:%S");
+    tm.tm_isdst = -1; // Let mktime determine DST to match localtime() used in getCurrentTimestamp
     auto timestamp = std::chrono::system_clock::from_time_t(std::mktime(&tm));
     auto epoch = std::chrono::time_point_cast<std::chrono::microseconds>(timestamp).time_since_epoch();
     uint64_t seconds_to_microseconds = std::chrono::duration_cast<std::chrono::microseconds>(epoch).count();

--- a/triton_backend/tools/inflight_batcher_llm/benchmark_core_model.py
+++ b/triton_backend/tools/inflight_batcher_llm/benchmark_core_model.py
@@ -91,6 +91,9 @@ def test_performance(client,
                                      FLAGS.protocol),
                 utils.prepare_tensor("request_output_len", output0_len,
                                      FLAGS.protocol),
+                utils.prepare_tensor("streaming",
+                                     np.array([[FLAGS.decoupled]], dtype=bool),
+                                     FLAGS.protocol),
             ]
             append_pad_id_to_tensors(pad_id, inputs)
             append_end_id_to_tensors(end_id, inputs)
@@ -131,6 +134,9 @@ def test_performance(client,
                 utils.prepare_tensor("input_lengths", input_lens[i],
                                      FLAGS.protocol),
                 utils.prepare_tensor("request_output_len", output0_len,
+                                     FLAGS.protocol),
+                utils.prepare_tensor("streaming",
+                                     np.array([[FLAGS.decoupled]], dtype=bool),
                                      FLAGS.protocol),
             ]
 


### PR DESCRIPTION
## Summary

Fixes multiple CI failures in `L0_backend_trtllm` caused by the executor requiring an explicit `streaming` bool.

- **`model.py`**: coerce `streaming=None` → `False` when `get_input_scalar_by_name()` returns `None` (mirrors NVIDIA/TensorRT-LLM#13276)
- **`base_metrics_verification_tests.py`**: pass explicit `streaming=False` tensor; rename `"streaming"` → `"stream"` to match the ensemble model's declared external input
- **`custom_metrics_verification_tests.py`**: fix malformed `assertTrue` chained comparison; use `fromtimestamp` instead of `utcfromtimestamp` to avoid 8-hour offset on UTC-offset runners
- **`custom_metrics_reporter.cc`**: set `tm_isdst=-1` before `mktime()` so DST is auto-determined, matching `localtime()` used in `getCurrentTimestamp()`
- **`benchmark_core_model.py`**: pass explicit `streaming` tensor; switch to gRPC protocol to avoid gevent segfault on aarch64 during Python exit

Related: NVIDIA/TensorRT-LLM#13276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved streaming parameter handling with proper boolean normalization
  * Enhanced timestamp conversion accuracy for daylight saving time compatibility

* **Tests**
  * Updated test infrastructure to include streaming parameter support in inference requests
  * Added explicit protocol specification to benchmarking tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->