### PR TITLE
[None][perf] Eliminate ~6s FMHA JIT recompile in eager generation by aligning kernel selection with CUDA graph warmup

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -1113,7 +1113,11 @@ int AttentionOp::mlaGeneration(
         tllmRunnerParams.mMaxSeqLenCacheKv = generation_params.max_attention_window_size;
         // This should be set to numDraftTokens + 1.
         tllmRunnerParams.mMaxSeqLenQ = params.acc_q_len / batch_beam;
-        tllmRunnerParams.mMaxSeqLenKv = generation_params.max_past_kv_length;
+        // Override mMaxSeqLenKv with the max cache capacity so FMHA picks the same kernel as
+        // CUDA graph warmup and avoids the eager-mode JIT miss/recompile. This is safe for
+        // PagedKv on this path because the strides do not depend on mMaxSeqLenKv, and extra
+        // KV CTAs exit early through seqLensKvPtr.
+        tllmRunnerParams.mMaxSeqLenKv = generation_params.max_attention_window_size;
         tllmRunnerParams.mSumOfSeqLensQ = int(batch_beam * tllmRunnerParams.mMaxSeqLenQ);
         // Not used in the generation kernels as contiguous_kv or paged_kv layouts are used.
         tllmRunnerParams.mSumOfSeqLensKv = int(batch_beam * tllmRunnerParams.mMaxSeqLenKv);

--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -1117,6 +1117,8 @@ int AttentionOp::mlaGeneration(
         // CUDA graph warmup and avoids the eager-mode JIT miss/recompile. This is safe for
         // PagedKv on this path because the strides do not depend on mMaxSeqLenKv, and extra
         // KV CTAs exit early through seqLensKvPtr.
+        // TODO: mirror the is_swa + W+1 logic from xqaDispatcher.cpp when MLA gains SWA
+        // support (also requires adding Sliding cubins to the MLA gen kernel set).
         tllmRunnerParams.mMaxSeqLenKv = generation_params.max_attention_window_size;
         tllmRunnerParams.mSumOfSeqLensQ = int(batch_beam * tllmRunnerParams.mMaxSeqLenQ);
         // Not used in the generation kernels as contiguous_kv or paged_kv layouts are used.

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
@@ -269,10 +269,7 @@ public:
         if (shouldUseNvrtc(options))
         {
             // For the NVRTC path, we return supported as long as autotuner successfully selected a kernel config.
-            std::ostringstream sstream;
-            populateJsonConfig(options, sstream);
-            std::string info = sstream.str();
-            return std::make_pair(true, info);
+            return std::make_pair(true, "NVRTC path is supported");
         }
 
         // Check if a precompiled cubin exists for this configuration (same lookup as run()).

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
@@ -213,6 +213,12 @@ public:
         }
     }
 
+    static bool shouldUseNvrtc(FmhaOptions const& options)
+    {
+        return options.mFmhaKernelType == FmhaKernelType::SwapsMmaAbForGeneration
+            && options.mDtypeKv != tg::Dtype::E2m1;
+    }
+
     std::pair<bool, std::string> checkIfKernelExist(RunnerParams const& params) const
     {
         // Some conditions to check if the kernel is supported.
@@ -259,6 +265,15 @@ public:
         // The number of CtasQ and CtasKv per sequence, Ctas in the Y dimension, and Ctas in the Z
         // dimension.
         computeNumCtas(options, params.mMultiProcessorCount);
+
+        if (shouldUseNvrtc(options))
+        {
+            // For the NVRTC path, we return supported as long as autotuner successfully selected a kernel config.
+            std::ostringstream sstream;
+            populateJsonConfig(options, sstream);
+            std::string info = sstream.str();
+            return std::make_pair(true, info);
+        }
 
         // Check if a precompiled cubin exists for this configuration (same lookup as run()).
         // If not, return (false, info) so the dispatcher can fall back to unfused MHA like on main.
@@ -336,14 +351,8 @@ public:
 
         FmhaData fmhaData;
         setFmhaData(params, options, fmhaData);
-        bool isLlama70bFp4Tp4 = options.mHeadDimQk == 128 && options.mHeadDimV == 128
-            && options.mDtypeK == tg::Dtype::E4m3 && options.mNumHeadsQ == 16 && options.mNumHeadsQPerKv == 8;
 
-        bool shouldUseNvrtc = options.mFmhaKernelType == FmhaKernelType::SwapsMmaAbForGeneration && !options.mIsMlaGen
-            && options.mDtypeK != tg::Dtype::E2m1 && options.mHeadDimQk != 64 && !isLlama70bFp4Tp4
-            && !isTokenSparse(options.mSparseType);
-
-        if (shouldUseNvrtc)
+        if (shouldUseNvrtc(options))
         {
             // nvrtc path - uses mFmhaInterface member for kernel caching
             FmhaConfig fmhaConfig;

--- a/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
@@ -496,14 +496,15 @@ void XqaDispatcher::runImpl(
         // It is used to construct contiguous kv cache TMA descriptors.
         tllmRunnerParams.mMaxSeqLenCacheKv = params.max_attention_window_size;
         tllmRunnerParams.mMaxSeqLenQ = params.generation_input_length;
-        // Override mMaxSeqLenKv with the max cache capacity so FMHA picks the same kernel as
-        // CUDA graph warmup and avoids the eager-mode JIT miss/recompile. This is safe for
-        // PagedKv because its strides do not depend on mMaxSeqLenKv and extra KV CTAs exit
-        // early through seqLensKvPtr. ContiguousKv keeps the runtime value because its
-        // strides depend on it.
-        tllmRunnerParams.mMaxSeqLenKv = (tllmRunnerParams.mQkvLayout == QkvLayout::PagedKv)
-            ? params.max_attention_window_size
-            : params.max_past_kv_length;
+        // Pin mMaxSeqLenKv to a static per-layer value so warmup and runtime pick the same
+        // FMHA kernel (no JIT miss). Safe for PagedKv since strides are independent of it.
+        // SWA layers add +1 to trigger the SlidingOrChunkedCausal mask upgrade in the
+        // autotuner.
+        bool const is_swa = params.max_attention_window_size < params.rotary_embedding_max_positions;
+        int32_t const paged_kv_max_seq_len_kv
+            = is_swa ? params.max_attention_window_size + 1 : params.max_attention_window_size;
+        tllmRunnerParams.mMaxSeqLenKv
+            = (tllmRunnerParams.mQkvLayout == QkvLayout::PagedKv) ? paged_kv_max_seq_len_kv : params.max_past_kv_length;
         tllmRunnerParams.mSumOfSeqLensQ = int(params.batch_size * beam_width * tllmRunnerParams.mMaxSeqLenQ);
         // The sliding window attention size.
         tllmRunnerParams.mAttentionWindowSize = params.cyclic_attention_window_size;

--- a/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
@@ -496,7 +496,14 @@ void XqaDispatcher::runImpl(
         // It is used to construct contiguous kv cache TMA descriptors.
         tllmRunnerParams.mMaxSeqLenCacheKv = params.max_attention_window_size;
         tllmRunnerParams.mMaxSeqLenQ = params.generation_input_length;
-        tllmRunnerParams.mMaxSeqLenKv = params.max_past_kv_length;
+        // Override mMaxSeqLenKv with the max cache capacity so FMHA picks the same kernel as
+        // CUDA graph warmup and avoids the eager-mode JIT miss/recompile. This is safe for
+        // PagedKv because its strides do not depend on mMaxSeqLenKv and extra KV CTAs exit
+        // early through seqLensKvPtr. ContiguousKv keeps the runtime value because its
+        // strides depend on it.
+        tllmRunnerParams.mMaxSeqLenKv = (tllmRunnerParams.mQkvLayout == QkvLayout::PagedKv)
+            ? params.max_attention_window_size
+            : params.max_past_kv_length;
         tllmRunnerParams.mSumOfSeqLensQ = int(params.batch_size * beam_width * tllmRunnerParams.mMaxSeqLenQ);
         // The sliding window attention size.
         tllmRunnerParams.mAttentionWindowSize = params.cyclic_attention_window_size;


### PR DESCRIPTION
@coderabbitai summary



## Description

In eager (non-CUDA-graph) generation, MLA and XQA FMHA dispatches were picking a
different trtllm-gen kernel than the CUDA graph warmup path, producing a kernel
cache miss and triggering a ~6s NVRTC JIT recompile on the first generation step.
The mismatch had two root causes:

1. **Kernel selection key divergence.** Warmup constructs `tllmRunnerParams` with
   `mMaxSeqLenKv = max_attention_window_size` (max cache capacity), while the
   eager runtime path used `max_past_kv_length` (current sequence length).
   `mMaxSeqLenKv` participates in kernel-variant selection, so the two paths
   resolved to different cubins / NVRTC configs &rarr; cache miss.
2. **Narrow NVRTC gate.** `shouldUseNvrtc` excluded several generation configs
   (`mIsMlaGen`, `mHeadDimQk == 64`, Llama-70B-fp4-tp4, token-sparse), forcing
   them through a precompiled cubin lookup that was not guaranteed to hit.

### Fix

- `cpp/tensorrt_llm/common/attentionOp.cpp` (MLA gen): set
  `mMaxSeqLenKv = max_attention_window_size`.
- `cpp/tensorrt_llm/kernels/xqaDispatcher.cpp` (XQA gen): same, but **only for
  `PagedKv`** (its strides do not depend on `mMaxSeqLenKv`, and excess KV CTAs
  exit via `seqLensKvPtr`). `ContiguousKv` keeps `max_past_kv_length` because
  its strides are `mMaxSeqLenKv`-dependent.
- `cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h`: extract
  `shouldUseNvrtc` into a static predicate and simplify it to
  `FmhaKernelType::SwapsMmaAbForGeneration && mDtypeKv != E2m1`. In
  `checkIfKernelExist`, when the NVRTC path is selected, return `supported=true`
  without requiring a precompiled cubin (NVRTC will compile/cache on demand).

No correctness change &mdash; the paged-KV invariants above are documented inline in
each changed call site.

## Test Coverage

- Functional: exercised by existing MLA and XQA generation tests &mdash; no new
  numerical path is introduced.
- Perf regression check: covered by the `PerfSanity-Post-Merge` pipeline
  (GB200-4_GPUs / DGX_B200-8_GPUs / GB200-8_GPUs-2_Nodes), which runs eager
  generation and would catch re-introduction of the JIT stall.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit&#39;s summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
