### PR TITLE
[None][fix] AutoDeploy: pad piecewise inputs to bucket + stable addresses for multi-stream partitions

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
@@ -26,9 +26,16 @@ from tensorrt_llm._torch.autotuner import autotune
 from ...utils.cuda_graph import CudaGraphWarmUpPhase
 from ...utils.logger import ad_logger
 from ..compiler import CompileBackendRegistry, CompilerBackend, GetArgsKwargsForBatchSize
-from ..piecewise_runner import ADPiecewiseRunner, DynamicOpWrapper, MetadataWrapper, OutputInfo
+from ..piecewise_runner import (
+    ADPiecewiseRunner,
+    DynamicOpWrapper,
+    MetadataWrapper,
+    OutputInfo,
+    StablePassthroughWrapper,
+)
 from ..piecewise_utils import (
     SplitInfo,
+    _submod_has_stream_switch,
     is_dynamic_cached_op,
     is_metadata_prep,
     needs_out_buffer,
@@ -436,6 +443,7 @@ class PiecewiseCapturedGraph(nn.Module):
         if runner_by_idx:
             fallback_runner = runner_by_idx[min(runner_by_idx)]
         num_metadata_wrapped = 0
+        num_passthrough_wrapped = 0
         for idx in all_submod_indices:
             if idx in runner_by_idx:
                 current_static_runner = runner_by_idx[idx]
@@ -453,6 +461,18 @@ class PiecewiseCapturedGraph(nn.Module):
                         ad_logger.info(
                             "PiecewiseCapturedGraph: wrapped %s in "
                             "MetadataWrapper (stable output addresses)",
+                            submod_name,
+                        )
+                    elif isinstance(submod, GraphModule) and _submod_has_stream_switch(submod):
+                        # Multi-stream reclassified partitions run eagerly and
+                        # would otherwise return outputs at fresh addresses
+                        # every call, breaking captured graphs downstream.
+                        wrapper = StablePassthroughWrapper(submod)
+                        setattr(self.split_gm, submod_name, wrapper)
+                        num_passthrough_wrapped += 1
+                        ad_logger.info(
+                            "PiecewiseCapturedGraph: wrapped %s in "
+                            "StablePassthroughWrapper (multi-stream partition)",
                             submod_name,
                         )
                     continue
@@ -482,12 +502,16 @@ class PiecewiseCapturedGraph(nn.Module):
 
         self._is_prepared = True
         num_dynamic_eager = (
-            len(self.split_info.dynamic_submod_indices) - num_wrapped_dynamic - num_metadata_wrapped
+            len(self.split_info.dynamic_submod_indices)
+            - num_wrapped_dynamic
+            - num_metadata_wrapped
+            - num_passthrough_wrapped
         )
         ad_logger.info(
             f"PiecewiseCapturedGraph: prepared with {self.split_info.num_submodules} submodules "
             f"({num_wrapped_static} static runners, {num_skipped_static} trivial skipped, "
             f"{num_wrapped_dynamic} dynamic wrapped, {num_metadata_wrapped} metadata wrapped, "
+            f"{num_passthrough_wrapped} passthrough wrapped, "
             f"{num_dynamic_eager} dynamic eager), piecewise_num_tokens={self.piecewise_num_tokens}"
         )
 
@@ -592,8 +616,17 @@ class PiecewiseCapturedGraph(nn.Module):
                 {k: (v[0].shape, f"dyn_dim={v[1]}") for k, v in self._static_input_buffers.items()},
             )
 
-    def _copy_to_static_buffers(self, kwargs: Dict[str, Any]) -> None:
-        """Copy kwargs into pre-allocated static buffers for address stability."""
+    def _copy_to_static_buffers(
+        self, kwargs: Dict[str, Any], num_tokens: Optional[int] = None
+    ) -> None:
+        """Copy kwargs into pre-allocated static buffers for address stability.
+
+        When ``num_tokens`` is provided (runtime path), each dynamic-dim buffer
+        is narrowed to ``num_tokens`` (the bucket size) so replay sees the same
+        shape the graph was captured at.  Real data is written into the first
+        ``src.shape[dyn_dim]`` positions and the tail ``[src_len:num_tokens]``
+        is zero-padded so static layers (norms, linears, MoE) see clean values.
+        """
         for key, (buf, dyn_dim) in self._static_input_buffers.items():
             src = kwargs.get(key)
             if src is not None and isinstance(src, torch.Tensor):
@@ -601,8 +634,12 @@ class PiecewiseCapturedGraph(nn.Module):
                     buf.copy_(src)
                     kwargs[key] = buf
                 else:
-                    buf_view = buf.narrow(dyn_dim, 0, src.shape[dyn_dim])
-                    buf_view.copy_(src)
+                    src_len = src.shape[dyn_dim]
+                    view_len = num_tokens if num_tokens is not None else src_len
+                    buf_view = buf.narrow(dyn_dim, 0, view_len)
+                    if view_len > src_len:
+                        buf_view.narrow(dyn_dim, src_len, view_len - src_len).zero_()
+                    buf_view.narrow(dyn_dim, 0, src_len).copy_(src)
                     kwargs[key] = buf_view
 
     def warmup_and_capture(
@@ -638,7 +675,7 @@ class PiecewiseCapturedGraph(nn.Module):
         for nt in num_tokens_list:
             ad_logger.info(f"PiecewiseCapturedGraph: warming up for num_tokens={nt}")
             args, kwargs = get_args_kwargs(nt)
-            self._copy_to_static_buffers(kwargs)
+            self._copy_to_static_buffers(kwargs, num_tokens=nt)
 
             ADPiecewiseRunner.set_current_num_tokens(nt)
 
@@ -684,7 +721,7 @@ class PiecewiseCapturedGraph(nn.Module):
     def forward(self, *args, num_tokens: Optional[int] = None, **kwargs) -> Any:
         """Forward pass: static segments replay graphs, dynamic segments run eagerly."""
         if self.split_gm is not None:
-            self._copy_to_static_buffers(kwargs)
+            self._copy_to_static_buffers(kwargs, num_tokens=num_tokens)
             ADPiecewiseRunner.set_current_num_tokens(num_tokens)
             try:
                 result = self.split_gm(*args, **kwargs)

--- a/tensorrt_llm/_torch/auto_deploy/compile/piecewise_runner.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/piecewise_runner.py
@@ -254,6 +254,78 @@ class MetadataWrapper(nn.Module):
         return saved
 
 
+class StablePassthroughWrapper(nn.Module):
+    """Wraps an eagerly-executed partition to give its outputs stable addresses.
+
+    Multi-stream partitions (reclassified from static to dynamic because they
+    contain host-side stream-switching ops that cannot be captured) run eagerly
+    on every forward.  Eager execution allocates fresh output tensors each call,
+    but downstream static segments captured those outputs at specific pool
+    addresses — a fresh allocation breaks CUDA graph replay for everything that
+    follows.
+
+    On capture: allocate a persistent buffer matching each output tensor.  Copy
+      the eager result into it and return the persistent buffer.  The next
+      static runner captures its graph against this stable address.
+    On replay: run the partition eagerly, copy_ its result into the same
+      persistent buffer, and return the buffer.  Downstream captured graphs see
+      the expected address and valid data.
+    """
+
+    def __init__(self, submodule: nn.Module):
+        super().__init__()
+        self.submodule = submodule
+        # {num_tokens: tuple of persistent output tensors matching capture-time shapes}
+        self._stable_outputs: Dict[int, Tuple[Any, ...]] = {}
+
+    @staticmethod
+    def _alloc_like(result: Any) -> Tuple[Any, ...]:
+        if isinstance(result, torch.Tensor):
+            return (torch.empty_like(result),)
+        if isinstance(result, (tuple, list)):
+            return tuple(torch.empty_like(t) if isinstance(t, torch.Tensor) else t for t in result)
+        return ()
+
+    @staticmethod
+    def _copy_into_saved(result: Any, saved: Tuple[Any, ...]) -> None:
+        items = (result,) if isinstance(result, torch.Tensor) else result
+        for real, stable in zip(items, saved):
+            if isinstance(real, torch.Tensor) and isinstance(stable, torch.Tensor):
+                stable.copy_(real)
+
+    @staticmethod
+    def _rebuild_result(original: Any, saved: Tuple[Any, ...]) -> Any:
+        if isinstance(original, torch.Tensor):
+            return saved[0]
+        if isinstance(original, tuple):
+            return tuple(saved)
+        if isinstance(original, list):
+            return list(saved)
+        return saved
+
+    def forward(self, *args, **kwargs) -> Any:
+        nt = ADPiecewiseRunner._current_num_tokens
+        phase = ADPiecewiseRunner._current_phase
+
+        result = self.submodule(*args, **kwargs)
+
+        if nt is None or phase == "warmup":
+            return result
+
+        if phase == "capture":
+            stable = self._alloc_like(result)
+            self._stable_outputs[nt] = stable
+            self._copy_into_saved(result, stable)
+            return self._rebuild_result(result, stable)
+
+        # replay
+        saved = self._stable_outputs.get(nt)
+        if saved is None:
+            return result
+        self._copy_into_saved(result, saved)
+        return self._rebuild_result(result, saved)
+
+
 class ADPiecewiseRunner(nn.Module):
     """Wraps a static submodule and manages its CUDA graph capture/replay.
 


### PR DESCRIPTION
## Summary

Fixes two issues that caused Qwen3.5-35B-A3B (and other multi-stream + TP models) to fail with `tensor a (N) must match tensor b (bucket) at non-singleton dimension 1` and `ADPiecewiseRunner ADDRESS MISMATCH` warnings when piecewise CUDA graphs are enabled.

- **Pad piecewise inputs to bucket size.** `_copy_to_static_buffers` narrowed static input buffers (e.g. `inputs_embeds`, `position_ids`) to the runtime token count rather than the captured bucket size. At runtime, real token counts are smaller than the nearest bucket, so `split_gm` saw `inputs_embeds` at `[1, real_len, H]` while captured graphs expected `[1, bucket, H]`. `_copy_to_static_buffers` now accepts `num_tokens` and narrows to the bucket, zero-padding the tail beyond real data.
- **Stable output addresses for reclassified multi-stream partitions.** Partitions reclassified from static to dynamic because they contain host-side stream-switching ops (`begin_aux_stream_passthrough`, `record_event_passthrough`, etc.) were running eagerly and returning fresh-address outputs every call, breaking downstream static-runner captured graphs that expected stable pool addresses. New `StablePassthroughWrapper` allocates persistent output buffers per bucket at capture time and `copy_()`s eager results into them on replay, so downstream replays see the expected stable addresses.

## Test plan

- [x] `pytest tests/unittest/auto_deploy/singlegpu/compile/` — 136 passed, no regressions.
- [x] E2E repro: `python examples/auto_deploy/build_and_run_ad.py --model Qwen/Qwen3.5-35B-A3B --use-registry` (TP=2, 4 layers, piecewise on) now completes with coherent output, zero shape-mismatch errors, zero address-mismatch warnings. Before this PR: `RequestError: The size of tensor a (16) must match the size of tensor b (64) at non-singleton dimension 1`.
- [ ] Larger-scale accuracy runs on full 40-layer Qwen3.5-35B.
- [ ] Accuracy/regression on other models exercising multi-stream + piecewise (e.g. Nemotron Super, Gemma4 MoE).