### PR TITLE
[None][infra] enable CUDA line info by default for Debug/RelWithDebInfo

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -323,15 +323,16 @@ if(UNIX)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -O0 -fno-inline")
 endif()
 
-# Note: The following are desirable settings that should be enabled if we
-# decrease shared library size. See e.g.
-# https://github.com/rapidsai/cudf/pull/6134 for a similar issue in another
-# project.
-
-# set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "${CMAKE_CUDA_FLAGS_RELWITHDEBINFO}
-# --generate-line-info")
-
-# set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -G")
+# Emit CUDA line info for Debug and RelWithDebInfo so nsys/ncu can map samples
+# back to source, and emit full device debug info (-G) for Debug so cuda-gdb can
+# step through kernels. These flags inflate section sizes significantly, so
+# building these configurations for all CUDA architectures at once will fail to
+# link -- build_wheel.py enforces that a specific --cuda_architectures must be
+# passed in that case.
+# cmake-format: off
+set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "${CMAKE_CUDA_FLAGS_RELWITHDEBINFO} --generate-line-info")
+set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} --generate-line-info -G")
+# cmake-format: on
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_SYSTEM=cmake_oss ")
 

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -550,6 +550,18 @@ def main(*,
         if "70-real" in cuda_architectures:
             raise RuntimeError("Volta architecture is deprecated support.")
 
+    # Debug and RelWithDebInfo enable CUDA `--generate-line-info`, which
+    # inflates .text so much that linking against every supported arch
+    # overflows section limits. Require an explicit arch list so the build
+    # won't silently fail deep into compilation.
+    if build_type in ("Debug", "RelWithDebInfo") and cuda_architectures is None:
+        raise RuntimeError(
+            f"Building {build_type} requires --cuda_architectures to be set "
+            "explicitly (e.g. --cuda_architectures=90-real). Building for all "
+            "architectures with line info enabled exceeds linker section "
+            "limits. Pass a narrow arch list matching the GPU you intend to "
+            "debug/profile.")
+
     cuda_architectures = cuda_architectures or 'all'
     cmake_cuda_architectures = f'"-DCMAKE_CUDA_ARCHITECTURES={cuda_architectures}"'
 

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -554,7 +554,7 @@ def main(*,
     # inflates .text so much that linking against every supported arch
     # overflows section limits. Require an explicit arch list so the build
     # won't silently fail deep into compilation.
-    if build_type in ("Debug", "RelWithDebInfo") and cuda_architectures is None:
+    if build_type in ("Debug", "RelWithDebInfo") and not cuda_architectures:
         raise RuntimeError(
             f"Building {build_type} requires --cuda_architectures to be set "
             "explicitly (e.g. --cuda_architectures=90-real). Building for all "


### PR DESCRIPTION
## Summary
- Emit `--generate-line-info` by default for both `Debug` and `RelWithDebInfo` CUDA flags, so `nsys`/`ncu` can map samples back to source without needing to hand-tweak CMake.
- Emit `-G` by default for `Debug` so `cuda-gdb` can step through kernels.
- Because these flags inflate device-side section sizes enough that linking against every supported CUDA architecture overflows ELF section limits, `scripts/build_wheel.py` now rejects `Debug`/`RelWithDebInfo` builds that don't pass an explicit `--cuda_architectures`. `Release` builds are unaffected.

## Motivation
Previously the project shipped with `--generate-line-info` and `-G` commented out in `cpp/CMakeLists.txt` because enabling them caused link-time failures when building for all CUDA archs. In practice the only builds that compile `RelWithDebInfo`/`Debug` are developers working on specific GPUs — they don't need every arch, and they *do* need line info/device debug info. Trading a default-all-archs developer build (which almost no one actually uses with debug info) for usable debug/profile builds is a clear win.

## Test plan
- [ ] `python scripts/build_wheel.py -b Release` still succeeds with default `cuda_architectures=all`.
- [ ] `python scripts/build_wheel.py -b RelWithDebInfo` now fails fast with an informative error telling the developer to pass `--cuda_architectures`.
- [ ] `python scripts/build_wheel.py -b RelWithDebInfo --cuda_architectures 90-real` succeeds and produces a `libtensorrt_llm.so` with CUDA line info resolvable by `nsys`/`ncu`.
- [ ] `python scripts/build_wheel.py -b Debug --cuda_architectures 90-real` succeeds and produces a binary debuggable with `cuda-gdb`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CUDA compilation flags for Debug and RelWithDebInfo builds to include source line mappings and device debug information.
  * Build process now requires explicit CUDA architecture specification when using Debug or RelWithDebInfo configurations instead of using defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->