### PR TITLE
[https://nvbugs/6061812][fix] Tighten ruff-legacy baseline after D205 unblock

### DIFF
--- a/ruff-legacy-baseline.json
+++ b/ruff-legacy-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "generated_by": "scripts/legacy_utils.py lint-update-violations",
-    "total_violations": 5341,
+    "total_violations": 5323,
     "total_files": 493
   },
   ".github/scripts/label_community_user.py": {
@@ -928,7 +928,7 @@
     "D411": 2
   },
   "tensorrt_llm/llmapi/llm_args.py": {
-    "D200": 24,
+    "D200": 23,
     "D202": 1,
     "D205": 11,
     "D208": 2,
@@ -1575,8 +1575,7 @@
   },
   "tensorrt_llm/serve/openai_server.py": {
     "D205": 1,
-    "D212": 2,
-    "F821": 2
+    "D212": 2
   },
   "tensorrt_llm/serve/responses_utils.py": {
     "D200": 2,
@@ -1587,8 +1586,7 @@
     "D205": 1,
     "D212": 1,
     "D300": 1,
-    "D411": 1,
-    "D415": 8
+    "D415": 7
   },
   "tensorrt_llm/serve/scripts/benchmark_dataset.py": {
     "D200": 4,
@@ -1877,7 +1875,7 @@
     "D212": 3
   },
   "tests/integration/defs/perf/open_search_db_utils.py": {
-    "D200": 2,
+    "D200": 1,
     "D212": 4,
     "E402": 1
   },
@@ -2088,7 +2086,7 @@
   },
   "tests/unittest/bindings/test_executor_bindings.py": {
     "D202": 1,
-    "E712": 56,
+    "E712": 54,
     "F403": 2,
     "F405": 3,
     "F811": 1
@@ -2149,8 +2147,7 @@
     "F811": 1
   },
   "tests/unittest/llmapi/test_executor.py": {
-    "D205": 5,
-    "D209": 3
+    "D205": 1
   },
   "tests/unittest/llmapi/test_llm.py": {
     "D200": 1,
@@ -2166,7 +2163,7 @@
     "D200": 1,
     "D202": 2,
     "D212": 2,
-    "E712": 20,
+    "E712": 19,
     "F811": 1
   },
   "tests/unittest/llmapi/test_llm_multi_gpu.py": {
@@ -2483,7 +2480,7 @@
   },
   "triton_backend/all_models/tests/test_python_backend.py": {
     "E402": 2,
-    "E712": 40,
+    "E712": 38,
     "F403": 1,
     "F405": 72
   },


### PR DESCRIPTION
## Summary

- NVBug 6061812 — L0_PostMerge Pre-Commit Check on `main` broke (build #2644) because PR #12513 added D205/D209-violating docstrings that slipped past pre-merge (its CI ran before PR #11469's baseline landed in `main`).
- PR #12996 collapsed the offending docstrings to single-line form, unblocking post-merge, but left the committed baseline loose — a reintroduction of the same shapes would still pass.
- This PR regenerates `ruff-legacy-baseline.json` via `scripts/legacy_utils.py lint-update-violations` to lock the ratchet at the post-fix state.

Total violations: 5341 → 5323 (18 fewer) across 7 files. Most notable tightening:

| File | Rule | Before | After |
|------|------|--------|-------|
| `tests/unittest/llmapi/test_executor.py` | D205 | 5 | 1 |
| `tests/unittest/llmapi/test_executor.py` | D209 | 3 | 0 |
| `tensorrt_llm/serve/openai_server.py` | F821 | 2 | 0 |
| `tensorrt_llm/serve/router.py` | D411 | 1 | 0 |
| `tensorrt_llm/serve/router.py` | D415 | 8 | 7 |
| `tensorrt_llm/llmapi/llm_args.py` | D200 | 24 | 23 |
| `tests/unittest/llmapi/test_llm_args.py` | E712 | 20 | 19 |
| `tests/unittest/bindings/test_executor_bindings.py` | E712 | 56 | 54 |
| `triton_backend/all_models/tests/test_python_backend.py` | E712 | 40 | 38 |
| `tests/integration/defs/perf/open_search_db_utils.py` | D200 | 2 | 1 |

No source code changes — the baseline JSON is the only file touched.

## Test plan

- [x] `scripts/legacy_utils.py check-configs` passes (generated configs up to date)
- [x] `scripts/legacy_utils.py lint-precommit` passes on all 1350 legacy files with the new baseline (no regressions)
- [x] `pre-commit run --files ruff-legacy-baseline.json` all hooks pass
- [x] `pre-commit run ruff-legacy --files <tightened files>` passes
- [x] Commit is DCO-signed; title follows the `[JIRA/NVBUG][type]` format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated code quality baseline configuration reflecting incremental improvements across the codebase, with total violation count decreased from 5341 to 5323.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->