### PR TITLE
Support Mixed KV cache Precision for different layers

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -717,6 +717,10 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
             "blocks=%d, max sequence length=%d",
             maxBlocksPerSeq, windowSize, tokensPerBlock, allottedPrimaryBlocks, allottedSecondaryBlocks,
             maxSequenceLength);
+        TLLM_LOG_INFO(
+            "JINDA_DEBUG: KV cache buffer init: max tokens per sequence=%d (= max(windowSize,maxSeqLen) + sinkBubble)"
+            " [window size=%d, max sequence length=%d, max blocks per seq=%d]",
+            maxTokenNum, windowSize, maxSequenceLength, maxBlocksPerSeq);
         TLLM_LOG_DEBUG(
             "%s Metadata: %s", manager.getLogPrefix().c_str(), mWindowSizeToMetadata[windowSize].toString().c_str());
         absolutePoolsOffset += numPools;
@@ -3153,33 +3157,79 @@ void KVCacheManager::allocatePools(bool useUvm)
     mBlockManager.allocatePools(useUvm);
     auto const numPools = mBlockManager.getNumPools();
 
+    // Compute the total bytes occupied by all primary KV-cache pools.
+    //
+    // There are two categories of pools for NVFP4 KV cache:
+    //   1. KV element pools  — store the actual K/V data, packed as INT8
+    //                          (2 FP4 values per byte).
+    //   2. Block scale pools — store per-block FP8 quantization scales
+    //                          (1 scale per 16 FP4 elements).
+    //
+    // BUG FIX 1 (scale pool dtype):
+    //   The original code applied the FP4 byte formula `(volume * 4) / 8` to
+    //   every pool when mDataType == kFP4, including block scale pools whose
+    //   elements are FP8 (1 byte each).  This caused a 2× undercount of the
+    //   scale pool size.  Fix: detect containsBlockScales and use the FP8
+    //   element size unconditionally for those pools.
+    //
+    // BUG FIX 2 (FP4 element pool double-halving):
+    //   When a FP4 element pool is constructed, sizePerHead is already divided
+    //   by numEltsPerContainer=2 so that each "element" in the pool tensor
+    //   represents one packed INT8 byte (holding 2 FP4 values).  The original
+    //   formula `(cacheVolume * 4) / 8` = cacheVolume * 0.5 halved the volume
+    //   a second time, reporting half the actual GPU allocation.  Fix: treat
+    //   each element as 1 byte (kINT8), matching how allocatePools() allocates
+    //   the buffer (see WindowBlockManager::allocatePools where poolDtype is
+    //   set to kINT8 for FP4 pools before calling gpuSync).
     uint64_t cacheSizeBytes = 0;
+    uint64_t elemPoolBytes = 0;
+    uint64_t scalePoolBytes = 0;
     for (SizeType32 poolIdx = 0; poolIdx < numPools; poolIdx++)
     {
+        auto const& pool = mBlockManager.getPool(poolIdx);
         auto const cacheShape = mBlockManager.getPrimaryPool(poolIdx)->getShape();
         auto const cacheVolume = ITensor::volume(cacheShape);
-#ifdef ENABLE_FP4
-        auto const isFp4 = mDataType == nvinfer1::DataType::kFP4;
-#else
-        auto const isFp4 = false;
-#endif
-        if (!isFp4)
+        uint64_t poolBytes = 0;
+        if (pool.containsBlockScales)
         {
-            cacheSizeBytes += cacheVolume * BufferDataType(mDataType).getSize();
+            // BUG FIX 1: scale pools are FP8 regardless of mDataType.
+            poolBytes = cacheVolume * BufferDataType(nvinfer1::DataType::kFP8).getSize();
+            scalePoolBytes += poolBytes;
         }
         else
         {
-            cacheSizeBytes += (cacheVolume * 4) / 8;
+#ifdef ENABLE_FP4
+            auto const isFp4 = mDataType == nvinfer1::DataType::kFP4;
+#else
+            auto const isFp4 = false;
+#endif
+            if (isFp4)
+            {
+                // BUG FIX 2: sizePerHead was already halved at pool construction
+                // (sizePerHead / numEltsPerContainer), so cacheVolume is already
+                // in bytes (INT8 elements).  Use size 1, not 0.5.
+                poolBytes = cacheVolume * BufferDataType(nvinfer1::DataType::kINT8).getSize();
+            }
+            else
+            {
+                poolBytes = cacheVolume * BufferDataType(mDataType).getSize();
+            }
+            elemPoolBytes += poolBytes;
         }
+        cacheSizeBytes += poolBytes;
     }
     // Save the total number of bytes allocated for the KV-cache for KvCacheStats
     mAllocatedBytes = cacheSizeBytes;
     if (tc::Logger::getLogger()->getLevel() <= tc::Logger::INFO)
     {
-
         TLLM_LOG_INFO("Number of tokens per block: %d.", mBlockManager.getTokensPerBlock());
         auto const maxNumTokens = mBlockManager.getNumPrimaryBlocks() * mBlockManager.getTokensPerBlock();
         TLLM_LOG_INFO("[MemUsageChange] Allocated %0.2f GiB for max tokens in paged KV cache (%d).",
+            cacheSizeBytes / static_cast<double>(1 << 30), maxNumTokens);
+        TLLM_LOG_INFO(
+            "JINDA_DEBUG: KV cache pool breakdown: element pool=%.2f GiB, scale pool=%.2f GiB, total=%.2f GiB"
+            " [max tokens=%d]",
+            elemPoolBytes / static_cast<double>(1 << 30), scalePoolBytes / static_cast<double>(1 << 30),
             cacheSizeBytes / static_cast<double>(1 << 30), maxNumTokens);
     }
 

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -374,8 +374,10 @@ public:
         op.mRuntimeSparseAttentionParams.sparse_topk = num_sparse_topk;
         if (op.mUseSparseAttention && use_kv_cache)
         {
-            op.mRuntimeSparseAttentionParams.sparse_kv_cache_pool
-                = reinterpret_cast<char*>(host_kv_cache_pool_pointers.value().index({pool_index, 0}).item<int64_t>());
+            // In mixed-precision mode pool_pointers may be 3D; primary ptr is at [pool, 0, 0].
+            auto const& pptr = host_kv_cache_pool_pointers.value();
+            op.mRuntimeSparseAttentionParams.sparse_kv_cache_pool = reinterpret_cast<char*>(
+                (pptr.dim() == 3 ? pptr.index({pool_index, 0, 0}) : pptr.index({pool_index, 0})).item<int64_t>());
         }
 
         AttentionOp::EnqueueParams<T> common_enqueue_params;
@@ -995,11 +997,29 @@ KvCachePoolPointers buildKvCachePoolPointers(at::Tensor const& hostKvCachePoolPo
     }
     else
     {
-        TORCH_CHECK(hostKvCachePoolPointers.dim() == 2);
-        pointers.primaryPoolPtr = reinterpret_cast<void*>(
-            reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 0}).item<int64_t>()) + intraPoolOffset);
-        pointers.secondaryPoolPtr = reinterpret_cast<void*>(
-            reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 1}).item<int64_t>()) + intraPoolOffset);
+        // In mixed-precision mode the pool_pointers tensor may be 3D (num_pools, 2, 2) even for
+        // non-FP4 layers: FP8/BF16 pool pointers are stored in the first slot of the last dim
+        // ([poolIndex, primary/secondary, 0]) and the scale slot ([..., 1]) is left as zero.
+        // Accept both dim==2 (pure non-FP4) and dim==3 (mixed-precision).
+        if (hostKvCachePoolPointers.dim() == 3)
+        {
+            pointers.primaryPoolPtr = reinterpret_cast<void*>(
+                reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 0, 0}).item<int64_t>())
+                + intraPoolOffset);
+            pointers.secondaryPoolPtr = reinterpret_cast<void*>(
+                reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 1, 0}).item<int64_t>())
+                + intraPoolOffset);
+        }
+        else
+        {
+            TORCH_CHECK(hostKvCachePoolPointers.dim() == 2);
+            pointers.primaryPoolPtr = reinterpret_cast<void*>(
+                reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 0}).item<int64_t>())
+                + intraPoolOffset);
+            pointers.secondaryPoolPtr = reinterpret_cast<void*>(
+                reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 1}).item<int64_t>())
+                + intraPoolOffset);
+        }
     }
     return pointers;
 }

--- a/mixed_layer_imp_doc/kv_cache_precision_comparison.md
+++ b/mixed_layer_imp_doc/kv_cache_precision_comparison.md
@@ -1,0 +1,249 @@
+# TensorRT-LLM KV Cache: Uniform FP8/BF16 vs Uniform NVFP4 vs Mixed Precision
+
+This document compares the three KV cache precision modes in TensorRT-LLM, covering memory pool
+structure, Python-to-C++ construction flow, and the `kv_cache_pool_pointers` tensor format.
+All examples use **Qwen3-8B** as a reference: 36 transformer layers, 8 KV heads per layer,
+`head_dim=128`, `tokens_per_block=16`.
+
+---
+
+## 1. Memory Pool Structure
+
+### C++ Pool Layout
+
+The fundamental unit of KV cache storage is a **pool** — a contiguous GPU buffer shared across
+layers. Pools are allocated inside `WindowBlockManager::allocatePools()` in `kvCacheManager.cpp`.
+
+Within a single attention-window group, layers are **grouped into pools by their KV head count**.
+All layers sharing the same number of KV heads share one pool. For Qwen3-8B (uniform 8 KV heads),
+this means one pool holds all 36 layers:
+
+```
+Pool shape: [num_blocks, num_layers_in_pool, kvFactor, tokens_per_block × head_dim]
+          = [num_blocks, 36,                 2,         16 × 128               ]
+          = [num_blocks, 36, 2, 2048]
+```
+
+- `num_blocks`: total paged blocks allocated (e.g. 2000)
+- `num_layers_in_pool`: layers sharing this pool (36 for Qwen3-8B)
+- `kvFactor=2`: one slice for K, one for V (1 for K-only cache types)
+- `tokens_per_block × head_dim`: the data per head per block
+
+Each **block** is a page in the paged-attention scheme. Block metadata
+(`KVCacheBlock`) is separate — it only stores the block ID and index into the pool;
+the actual tensor lives in the pool buffer.
+
+`num_pools > 1` arises when:
+- Different layers have different KV head counts (variable GQA / MLA hybrids)
+- Different layers use different attention window sizes (sliding window attention)
+
+In those cases, `pool_mapping[layer] = [pool_idx, layer_within_pool]` routes each layer
+to the correct pool.
+
+---
+
+### Uniform FP8 / BF16
+
+One pool, element dtype = FP8 (1 byte) or BF16 (2 bytes).
+
+```
+C++ pool (FP8 example):
+  dtype  : kFP8
+  shape  : [num_blocks, 36, 2, 2048]
+  bytes  : num_blocks × 36 × 2 × 2048 × 1
+```
+
+No separate scale pool is needed — FP8 uses a global per-tensor scale (`kv_scale_orig_quant`
+passed as a scalar to the attention kernel), not per-block scales.
+
+### Uniform NVFP4
+
+NVFP4 stores data at 4 bits per element (packed as INT8, 2 values per byte) with
+**per-block FP8 scale factors** (1 scale per 16 NVFP4 elements). This requires two
+parallel pools per logical pool:
+
+```
+C++ data pool:
+  dtype  : kINT8  (2 NVFP4 elems packed per byte)
+  shape  : [num_blocks, 36, 2, 2048 / 2]       ← half the element count
+          = [num_blocks, 36, 2, 1024]
+
+C++ scale pool:
+  dtype  : kFP8   (1 scale per 16 NVFP4 elems)
+  shape  : [num_blocks, 36, 2, 2048 / 16]
+          = [num_blocks, 36, 2, 128]
+```
+
+The scale pool is created in `WindowBlockManager::createBlockScalePools()` with
+`containsBlockScales=true` and `sizePerHead /= 16`.
+
+### Mixed Precision
+
+Each dtype group gets its **own independent set of pools**. For example, FP8 for layers 0–1
+and NVFP4 for layers 2–35:
+
+```
+Group A — FP8 (layers 0–1):
+  data pool shape: [num_blocks_A, 2,  2, 2048]   dtype: kFP8
+
+Group B — NVFP4 (layers 2–35):
+  data pool shape: [num_blocks_B, 34, 2, 1024]   dtype: kINT8
+  scale pool shape:[num_blocks_B, 34, 2, 128]    dtype: kFP8
+```
+
+Memory budgets are split proportionally by `bytes_per_token × num_layers_in_group` across groups
+(see `_util.py:948-956`), so each group gets a fair share of GPU memory.
+
+---
+
+## 2. Python-to-C++ Construction Flow
+
+### Uniform Precision (`KVCacheManager`, `resource_manager.py:254`)
+
+A single `KVCacheManager` wraps one C++ `KVCacheManagerImpl`:
+
+```
+Python KVCacheManager.__init__()
+  │
+  ├─ get_pp_layers()              # filter layers for this pipeline-parallel stage
+  ├─ compute num_kv_heads_per_layer (with TP sharding)
+  ├─ build KvCacheConfigCpp + ModelConfigCpp
+  │
+  └─ KVCacheManagerCpp(**kwargs)  # C++ constructor (via nanobind)
+       │
+       ├─ BlockManager(numKvHeadsPerLayer, sizePerHead, tokensPerBlock, ...)
+       │    └─ WindowBlockManager per unique attention-window size
+       │         └─ KVCacheBlockPool per unique numKvHeads group
+       │              └─ allocatePools() → cudaMalloc GPU buffer
+       │
+       └─ returns impl
+
+  impl.allocate_pools(False)
+  self.kv_cache_pool_pointers = impl.get_block_pool_pointers()   # (num_pools, 2)
+
+  # NVFP4 only: attach scale pool pointers on dim=-1
+  scale_ptrs = impl.get_block_scale_pool_pointers()
+  if scale_ptrs.numel() > 0:
+      self.kv_cache_pool_pointers = torch.stack([data_ptrs, scale_ptrs], dim=-1)
+      # shape becomes: (num_pools, 2, 2)
+
+  self.kv_cache_pool_mapping = impl.get_layer_to_pool_mapping()  # (num_local_layers, 2)
+```
+
+### Mixed Precision (`MixedPrecisionKVCacheManager`, `resource_manager.py:1645`)
+
+A compositor that owns multiple `KVCacheManager` instances, one per dtype group:
+
+```
+_util.py: create_mixed_precision_kv_cache_manager()
+  │
+  ├─ group layers by dtype:  {FP8: [0,1], NVFP4: [2..35]}
+  ├─ split GPU budget proportionally by bytes_per_token × num_layers
+  │
+  └─ for each (dtype, layers) group:
+       ├─ build layer_mask = [i in group for i in range(num_hidden_layers)]
+       ├─ deep-copy kv_cache_config with proportional max_gpu_total_bytes
+       └─ KVCacheManager(dtype=dtype, layer_mask=layer_mask, ...)
+            └─ same C++ construction as uniform case above, but for subset of layers
+
+  MixedPrecisionKVCacheManager(sub_managers=[mgr_fp8, mgr_nvfp4], per_layer_dtype_map)
+       │
+       ├─ _build_merged_pool_pointers()   → (total_pools, 2, 2)
+       └─ _build_merged_pool_mapping()    → (num_local_layers, 2)  with offset pool indices
+```
+
+---
+
+## 3. `kv_cache_pool_pointers` Tensor
+
+This is a **CPU tensor of raw GPU (and host) memory addresses**. It stays on CPU because the
+attention kernel reads it as a host-side lookup table — for each layer it reads the base address
+of the pool and then uses `kv_cache_block_offsets` to find the right block at runtime.
+
+### Uniform FP8 / BF16
+
+```
+shape: (num_pools, 2)    dtype: int64
+
+[pool_idx, 0]  →  GPU primary pool base address
+[pool_idx, 1]  →  host secondary pool address  (0 if no CPU offloading)
+
+Qwen3-8B example (1 pool):
+  [[gpu_data_ptr, 0]]
+```
+
+### Uniform NVFP4
+
+```
+shape: (num_pools, 2, 2)    dtype: int64
+
+[pool_idx, 0, 0]  →  GPU  primary  data  ptr
+[pool_idx, 0, 1]  →  GPU  primary  scale ptr
+[pool_idx, 1, 0]  →  host secondary data  ptr   (0 if no offloading)
+[pool_idx, 1, 1]  →  host secondary scale ptr   (0 if no offloading)
+
+Qwen3-8B example (1 pool):
+  [[[data_gpu_ptr, scale_gpu_ptr],
+    [0,            0            ]]]
+```
+
+Built by stacking `get_block_pool_pointers()` and `get_block_scale_pool_pointers()` on `dim=-1`
+(`resource_manager.py:545-548`).
+
+### Mixed Precision
+
+```
+shape: (total_pools_across_all_managers, 2, 2)    dtype: int64
+
+Always 3D. Non-FP4 pools are zero-padded in dim 2:
+  [pool_idx, j, 0]  →  data  ptr  (primary/secondary)
+  [pool_idx, j, 1]  →  scale ptr  (0 for FP8/BF16 pools)
+
+Example: FP8 layers 0–1  +  NVFP4 layers 2–35  (3 pools total):
+  pool 0 (FP8 data):    [[fp8_gpu_ptr,   0              ], [0, 0]]
+  pool 1 (NVFP4 data):  [[fp4_gpu_ptr,   fp4_scale_ptr  ], [0, 0]]
+  pool 2 (NVFP4 scale): (absorbed into pool 1 dim 2 — not a separate entry)
+```
+
+`_build_merged_pool_pointers()` (`resource_manager.py:1746`) normalises all sub-manager tensors
+to 3D before `torch.cat(parts, dim=0)`. NVFP4 sub-managers pass through as-is; FP8/BF16
+sub-managers are zero-padded.
+
+### Comparison Table
+
+| | Uniform FP8/BF16 | Uniform NVFP4 | Mixed |
+|---|---|---|---|
+| Shape | `(num_pools, 2)` | `(num_pools, 2, 2)` | `(total_pools, 2, 2)` |
+| `[i, j, 0]` | data ptr | data ptr | data ptr |
+| `[i, j, 1]` | N/A | **scale ptr** | scale ptr (0 for non-FP4) |
+| `j=0` | primary (GPU) | primary (GPU) | primary (GPU) |
+| `j=1` | secondary (host) | secondary (host) | secondary (host) |
+| Who builds it | C++ `get_block_pool_pointers()` | C++ + `torch.stack(..., dim=-1)` | `_build_merged_pool_pointers()` |
+| `num_pools=1` when | uniform head count + single window | uniform head count + single window | N/A (sum across groups) |
+
+---
+
+## 4. `kv_cache_pool_mapping`
+
+Companion tensor that tells the attention kernel which pool each layer uses:
+
+```
+shape: (num_local_layers, 2)    dtype: int32
+
+[layer_local_idx, 0]  →  pool_idx           (indexes into pool_pointers dim 0)
+[layer_local_idx, 1]  →  layer_within_pool  (indexes into pool dim 1)
+```
+
+For uniform Qwen3-8B (all 36 layers → pool 0):
+```
+[[0, 0], [0, 1], [0, 2], ..., [0, 35]]
+```
+
+For mixed FP8 (layers 0–1, pool 0) + NVFP4 (layers 2–35, pool 1):
+```
+[[0, 0], [0, 1], [1, 0], [1, 1], ..., [1, 33]]
+  ^FP8^            ^--------- NVFP4 -----------^
+```
+Pool indices in the mixed case are offset by `_pool_offsets[id(mgr)]` in
+`_build_merged_pool_mapping()` (`resource_manager.py:1780`) so they correctly index
+into the concatenated `pool_pointers` tensor.

--- a/mixed_layer_imp_doc/scripts/config.yaml
+++ b/mixed_layer_imp_doc/scripts/config.yaml
@@ -1,0 +1,31 @@
+# TensorRT-LLM serve config for Qwen3-8B on a single GPU
+# Usage: passed to trtllm-serve via --config
+
+# Single GPU — no tensor parallelism needed
+tensor_parallel_size: 1
+
+# KV cache quantization.
+# - "fp8"   works with any model on Hopper/Blackwell (recommended for Qwen/Qwen3-8B BF16 weights)
+# - "nvfp4" requires FP8 context FMHA, which is only active when the model weights
+#           are themselves FP8-quantized (e.g. nvidia/Qwen3-8B-FP8). Do NOT use nvfp4
+#           with plain BF16 checkpoints — it will crash with "mFP8ContextFMHA must enable".
+# - Mixed-precision per-layer syntax (Qwen3-8B has 36 layers, 0-35):
+#   dtype: "0-1:fp8,2-35:nvfp4"
+#   This uses FP8 for layers 0-1 and NVFP4 for layers 2-35.
+#   Requires FP8-quantized weights for NVFP4 layers.
+kv_cache_config:
+  # dtype: "fp8"
+  # dtype: "nvfp4"
+  dtype: "0-3:fp8,4-35:nvfp4"
+  free_gpu_memory_fraction: 0.85
+
+# CUDA graphs: pre-capture common batch sizes for lower kernel launch overhead
+cuda_graph_config:
+  enable_padding: true
+  batch_sizes:
+    - 1
+    - 2
+    - 4
+    - 8
+    - 16
+    - 32

--- a/mixed_layer_imp_doc/scripts/start_server.sh
+++ b/mixed_layer_imp_doc/scripts/start_server.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Run INSIDE the container — activates venv and starts trtllm-serve.
+# Usage: bash /code/tensorrt_llm/scripts/serve/start_server.sh [port]
+
+set -euo pipefail
+
+
+VENV="/code/tensorrt_llm/.venv-3.12"
+export LD_LIBRARY_PATH="/usr/local/cuda-13.1/targets/x86_64-linux/lib:${VENV}/lib/python3.12/site-packages/torch/lib:${LD_LIBRARY_PATH:-}"
+source "${VENV}/bin/activate"
+export HF_HOME=/data/huggingface
+
+
+PORT="${1:-8010}"
+# MODEL="Qwen/Qwen3-8B"
+# MODEL="nvidia/Qwen3-8B-FP8"
+# MODEL="Qwen/Qwen3-VL-2B-Thinking-FP8"
+MODEL="Qwen/Qwen3-4B-Thinking-2507-FP8"
+
+SCRIPT_DIR=/scripts/serve
+CONFIG="${SCRIPT_DIR}/config.yaml"
+
+
+# Activate venv
+# shellcheck disable=SC1091
+
+
+# Prepend venv torch/lib so the correct libc10.so is found at runtime.
+# CUDA 13.1 lib must come before the venv's nvidia/cu13/lib — the venv ships
+# libnvJitLink.so.13 at version 13.0 but TensorRT-LLM requires >= 13.1.
+
+
+# Pin to GPU 3 (already enforced by --gpus device=3 in start_docker.sh,
+# but set here explicitly in case the container has multiple GPUs visible)
+export CUDA_VISIBLE_DEVICES=3
+
+echo "Starting TensorRT-LLM server"
+echo "  Model   : ${MODEL}"
+echo "  GPU     : CUDA device 3"
+echo "  Port    : ${PORT}"
+echo "  Config  : ${CONFIG}"
+echo "  HF cache: ${HF_HOME}"
+echo " CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}"
+
+# CUDA_LAUNCH_BLOCKING=1 
+# CUDA_LAUNCH_BLOCKING=1  
+trtllm-serve "${MODEL}" \
+    --max_batch_size 128 \
+    --max_num_tokens 8192 \
+    --max_seq_len 32768 \
+    --host 0.0.0.0 \
+    --port "${PORT}" \
+    --config "${CONFIG}"

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -211,7 +211,11 @@ class ModelConfig(Generic[TConfig]):
                     return True
         return False
 
-    def get_quant_config(self, name: Optional[str] = None) -> QuantConfig:
+    @property
+    def per_layer_quant_configs(self) -> Optional[Dict[str, "QuantConfig"]]:
+        return self.quant_config_dict
+
+    def get_quant_config(self, name: Optional[str] = None) -> "QuantConfig":
         if name is None or self.per_layer_quant_configs is None:
             return self.quant_config
 

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -885,6 +885,11 @@ class FP8RowwiseLinearMethod(UnquantizedLinearMethod):
         module.inv_input_scale = Parameter(torch.tensor(1.,
                                                         dtype=torch.float32),
                                            requires_grad=False)
+        # K, V scales for NVFP4 KV cache
+        module.kv_scales = Parameter(torch.ones(3, dtype=torch.float32),
+                                     requires_grad=False)
+        module.inv_kv_scales = Parameter(torch.ones(3, dtype=torch.float32),
+                                         requires_grad=False)
         if bias:
             module.bias = Parameter(torch.empty((out_features), dtype=dtype),
                                     requires_grad=False)
@@ -1012,6 +1017,11 @@ class FP8BlockScalesLinearMethod(UnquantizedLinearMethod):
         module.inv_input_scale = Parameter(torch.tensor(1.,
                                                         dtype=torch.float32),
                                            requires_grad=False)
+        # K, V scales for NVFP4 KV cache
+        module.kv_scales = Parameter(torch.ones(3, dtype=torch.float32),
+                                     requires_grad=False)
+        module.inv_kv_scales = Parameter(torch.ones(3, dtype=torch.float32),
+                                         requires_grad=False)
         if bias:
             module.bias = Parameter(torch.empty((out_features), dtype=dtype),
                                     requires_grad=False)

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -17,7 +17,7 @@ from tensorrt_llm.llmapi.llm_args import (
     CacheTransceiverConfig, CapacitySchedulerPolicy, EagleDecodingConfig,
     KvCacheConfig, MTPDecodingConfig, PeftCacheConfig, SamplerType,
     SchedulerConfig, SparseAttentionConfig, SpeculativeConfig, TorchLlmArgs,
-    WaitingQueuePolicy)
+    WaitingQueuePolicy, parse_kv_cache_dtype_spec)
 # isort: on
 from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_helper import (LoraConfig,
@@ -40,8 +40,8 @@ from .mamba_cache_manager import MambaHybridCacheManager
 from .model_engine import PyTorchModelEngine
 from .py_executor import PyExecutor
 from .resource_manager import (KVCacheManager, KVCacheManagerV2,
-                               PeftCacheManager, ResourceManager,
-                               ResourceManagerType)
+                               MixedPrecisionKVCacheManager, PeftCacheManager,
+                               ResourceManager, ResourceManagerType)
 from .sampler import (EarlyStopSampler, EarlyStopWithMMResult, TorchSampler,
                       TRTLLMSampler)
 from .scheduler import (BindCapacityScheduler, BindMicroBatchScheduler,
@@ -866,6 +866,291 @@ def _build_per_layer_num_kv_heads(
                                                         ] * num_spec_layers
 
 
+def _dtype_str_to_binding(dtype_str: str,
+                          fallback_dtype: "tensorrt_llm.bindings.DataType",
+                          quant_config) -> "tensorrt_llm.bindings.DataType":
+    """Map a per-layer KV cache dtype string to a binding DataType."""
+    s = dtype_str.lower()
+    if s == "auto":
+        return fallback_dtype
+    if s in ("fp8", "float8"):
+        return tensorrt_llm.bindings.DataType.FP8
+    if s in ("nvfp4", "fp4"):
+        return tensorrt_llm.bindings.DataType.NVFP4
+    if s in ("fp16", "float16"):
+        return tensorrt_llm.bindings.DataType.HALF
+    if s in ("bf16", "bfloat16"):
+        return tensorrt_llm.bindings.DataType.BF16
+    raise ValueError(f"Unsupported per-layer KV cache dtype: '{dtype_str}'")
+
+
+def _resolve_per_layer_dtype(
+    dtype_spec: Union[str, Dict[int, str]],
+    num_layers: int,
+    quant_config,
+    fallback_dtype: "tensorrt_llm.bindings.DataType",
+) -> Dict[int, "tensorrt_llm.bindings.DataType"]:
+    """Resolve KvCacheConfig.dtype into a full per-layer DataType mapping."""
+    raw_map = parse_kv_cache_dtype_spec(dtype_spec, num_layers)
+    return {
+        i: _dtype_str_to_binding(s, fallback_dtype, quant_config)
+        for i, s in raw_map.items()
+    }
+
+
+def _create_mixed_kv_cache_manager(
+    per_layer_dtype_map: Dict[int, "tensorrt_llm.bindings.DataType"],
+    kv_cache_manager_cls,
+    mapping: Mapping,
+    kv_cache_config: KvCacheConfig,
+    tokens_per_block: int,
+    max_seq_len: int,
+    max_batch_size: int,
+    spec_config,
+    sparse_attn_config,
+    max_num_tokens: int,
+    max_beam_width: int,
+    kv_connector_manager,
+    estimating_kv_cache: bool,
+    execution_stream,
+    model_engine,
+    _model_config,
+    quant_config,
+    per_layer_num_kv_heads: List[int],
+    head_dim: int,
+    num_hidden_layers: int,
+    is_draft: bool,
+    fallback_dtype: "tensorrt_llm.bindings.DataType",
+) -> "MixedPrecisionKVCacheManager":
+    """Create per-dtype-group KVCacheManagers and wrap in MixedPrecisionKVCacheManager."""
+    import copy
+
+    # Group layers by dtype preserving insertion order
+    groups: Dict["tensorrt_llm.bindings.DataType", List[int]] = {}
+    for layer_idx, dtype in per_layer_dtype_map.items():
+        groups.setdefault(dtype, []).append(layer_idx)
+
+    # Compute bytes-per-token for each dtype group to split total memory budget
+    from .resource_manager import KVCacheManager as _KVCacheManager
+    total_budget = kv_cache_config.max_gpu_total_bytes  # set by estimation pass
+
+    def _bytes_per_token(dtype, num_layers_in_group):
+        kv_factor = 2
+        tp_size = max(mapping.tp_size, 1)
+        # Use the first layer's kv head count for the group (simplified)
+        # In practice all layers in a group share the same model params
+        return _KVCacheManager.get_cache_size_per_token_for_dtype(
+            dtype, kv_factor, num_layers_in_group, per_layer_num_kv_heads,
+            head_dim, tp_size) if hasattr(
+                _KVCacheManager,
+                'get_cache_size_per_token_for_dtype') else head_dim
+
+    # Compute proportional weights for budget splitting
+    group_weights = {}
+    for dtype, layers in groups.items():
+        # Simple weight: num_layers × head_dim (same heads assumed for now)
+        # For full accuracy, use actual bytes-per-token for this dtype
+        bpt = _get_bytes_per_token(dtype, mapping, per_layer_num_kv_heads,
+                                   head_dim, layers)
+        group_weights[dtype] = bpt * len(layers)
+
+    total_weight = sum(group_weights.values())
+
+    sub_managers = []
+    pool_offset = 0
+    for dtype, layers in groups.items():
+        layer_mask = [i in set(layers) for i in range(num_hidden_layers)]
+        cfg_copy = copy.deepcopy(kv_cache_config)
+        if total_budget > 0 and total_weight > 0:
+            group_budget = int(total_budget * group_weights[dtype] /
+                               total_weight)
+            cfg_copy.max_gpu_total_bytes = group_budget
+            cfg_copy.free_gpu_memory_fraction = None  # prevent free-mem fallback
+            # Compute max_tokens from the budget using this group's total
+            # bytes-per-token (per-layer bpt × number of layers in group).
+            # _get_bytes_per_token returns per-layer bytes; multiply by
+            # len(layers) for total across all group layers.
+            bpt_per_layer = _get_bytes_per_token(dtype, mapping,
+                                                 per_layer_num_kv_heads,
+                                                 head_dim, layers)
+            total_bpt = bpt_per_layer * len(layers)
+            cfg_copy.max_tokens = int(
+                group_budget / total_bpt) if total_bpt > 0 else None
+
+        mgr = kv_cache_manager_cls(
+            cfg_copy,
+            tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+            # num_layers must equal sum(layer_mask) per get_pp_layers assertion.
+            num_layers=len(layers),
+            num_kv_heads=per_layer_num_kv_heads,
+            head_dim=head_dim,
+            tokens_per_block=tokens_per_block,
+            max_seq_len=max_seq_len,
+            max_batch_size=max_batch_size,
+            mapping=mapping,
+            dtype=dtype,
+            spec_config=spec_config,
+            max_num_tokens=max_num_tokens,
+            max_beam_width=max_beam_width,
+            is_draft=is_draft,
+            kv_connector_manager=kv_connector_manager
+            if not estimating_kv_cache else None,
+            sparse_attn_config=sparse_attn_config,
+            is_estimating_kv_cache=estimating_kv_cache,
+            execution_stream=execution_stream,
+            layer_mask=layer_mask,
+        )
+        sub_managers.append(mgr)
+
+    # Patch per-layer attention quant configs so each layer's attention kernel
+    # uses the right KV dtype (has_fp8_kv_cache / has_fp4_kv_cache flags).
+    if model_engine is not None and not estimating_kv_cache:
+        _apply_per_layer_kv_quant_config(model_engine.model,
+                                         per_layer_dtype_map, quant_config)
+
+    return MixedPrecisionKVCacheManager(sub_managers, per_layer_dtype_map)
+
+
+def _get_bytes_per_token(
+    dtype: "tensorrt_llm.bindings.DataType",
+    mapping: Mapping,
+    per_layer_num_kv_heads: List[int],
+    head_dim: int,
+    layers: List[int],
+) -> float:
+    """Approximate bytes per token for a dtype group (for memory budget splitting)."""
+    tp_size = max(mapping.tp_size, 1)
+    kv_factor = 2
+    # Use average kv heads across this group's layers.
+    # _build_per_layer_num_kv_heads may return a plain int (uniform case).
+    if isinstance(per_layer_num_kv_heads, int):
+        avg_heads = per_layer_num_kv_heads
+    else:
+        heads = [per_layer_num_kv_heads[i] for i in layers
+                 if i < len(per_layer_num_kv_heads)]
+        avg_heads = (sum(heads) / len(heads)) if heads else 1
+    elems_per_token = kv_factor * (avg_heads / tp_size) * head_dim
+    if dtype == tensorrt_llm.bindings.DataType.FP8:
+        return elems_per_token * 1.0
+    if dtype == tensorrt_llm.bindings.DataType.NVFP4:
+        return elems_per_token * (0.5 + 1.0 / 16)  # FP4 data + FP8 scales
+    return elems_per_token * 2.0  # BF16/FP16
+
+
+def _apply_per_layer_kv_quant_config(model, per_layer_dtype_map: Dict,
+                                     base_quant_config):
+    """Call update_quant_config on each attention layer with the right KV dtype.
+
+    Handles two cases:
+      1. The module found by _get_attention_module has ``update_quant_config``
+         directly (e.g. TrtllmAttention when it is the leaf attention).
+      2. The module is an ``Attention`` wrapper (e.g. Qwen3Attention) whose
+         inner ``TrtllmAttention`` is stored in ``.attn``.  In this case we
+         update ``wrapper.quant_config`` so that ``attention.py`` picks up the
+         new KV dtype when building ``kv_scales_sf``, and then call
+         ``wrapper.attn.update_quant_config`` so the C++ wrapper's quant_mode
+         is also updated.
+
+    For NVFP4 KV cache used with BF16 model weights the ``qkv_proj`` may not
+    have ``kv_scales`` / ``inv_kv_scales`` attributes because those are only
+    created when the module is instantiated with an FP4 quant config.  We add
+    identity-scale tensors (value 1.0) so the forward pass can pass them to
+    the kernel without raising AttributeError.
+    """
+    import copy
+    from torch.nn import Parameter
+    from tensorrt_llm.models.modeling_utils import QuantConfig
+    from tensorrt_llm.quantization import QuantMode
+
+    # Pre-compute the base mode (weight quant bits only, no KV cache bits).
+    base_mode = (base_quant_config.layer_quant_mode
+                 if base_quant_config is not None else QuantMode(0))
+    base_mode_no_kv = (base_mode & ~QuantMode.FP8_KV_CACHE
+                       & ~QuantMode.NVFP4_KV_CACHE & ~QuantMode.INT8_KV_CACHE)
+
+    for layer_idx, dtype in per_layer_dtype_map.items():
+        attn = _get_attention_module(model, layer_idx)
+        if attn is None:
+            continue
+        qcfg = copy.deepcopy(base_quant_config) if base_quant_config else None
+        if qcfg is None:
+            qcfg = QuantConfig()
+        # Compute the desired per-layer KV cache quant mode.
+        mode = base_mode_no_kv
+        if dtype == tensorrt_llm.bindings.DataType.FP8:
+            mode = mode.set_fp8_kv_cache()
+        elif dtype == tensorrt_llm.bindings.DataType.NVFP4:
+            mode = mode.set_fp4_kv_cache()
+        # layer_quant_mode is a @cached_property; inject the pre-computed value
+        # directly into the instance cache so update_quant_config sees it correctly.
+        qcfg.__dict__['layer_quant_mode'] = mode
+
+        if hasattr(attn, 'update_quant_config'):
+            # Case 1: leaf TrtllmAttention (or any module with the method).
+            attn.update_quant_config(qcfg)
+        else:
+            # Case 2: Attention wrapper (e.g. QKNormRoPEAttention / Qwen3Attention).
+            # Update the wrapper's quant_config so attention.py reads kv_scales_sf.
+            attn.quant_config = qcfg
+            # Update the inner TrtllmAttention so the C++ wrapper uses the right
+            # quantMode when computing intraPoolOffset / cacheElemBits.
+            inner = getattr(attn, 'attn', None)
+            if inner is not None and hasattr(inner, 'update_quant_config'):
+                inner.update_quant_config(qcfg)
+
+        # For NVFP4 KV cache with BF16 model weights: qkv_proj may lack
+        # kv_scales / inv_kv_scales because they are only added at Linear
+        # creation time when the quant config already has fp4_kv_cache set.
+        # Inject identity-scale tensors so the attention forward succeeds.
+        if mode.has_fp4_kv_cache():
+            qkv_proj = getattr(attn, 'qkv_proj', None)
+            if qkv_proj is not None and not hasattr(qkv_proj, 'kv_scales'):
+                # Determine device from an existing model parameter.
+                try:
+                    dev = next(attn.parameters()).device
+                except StopIteration:
+                    dev = torch.device('cuda')
+                qkv_proj.kv_scales = Parameter(
+                    torch.ones(3, dtype=torch.float32, device=dev),
+                    requires_grad=False)
+                qkv_proj.inv_kv_scales = Parameter(
+                    torch.ones(3, dtype=torch.float32, device=dev),
+                    requires_grad=False)
+
+
+def _get_attention_module(model, layer_idx: int):
+    """Walk model.layers[layer_idx] to find the self-attention module.
+
+    Handles flat models (model.layers), single-wrapped models
+    (model.{model,llm}.layers), and double-wrapped VL models
+    (model.llm.model.layers, e.g. Qwen3VLForConditionalGeneration wrapping
+    Qwen3ForCausalLM wrapping Qwen3Model).
+    """
+    layers = getattr(model, 'layers', None)
+    if layers is None:
+        for first_attr in ('model', 'llm'):
+            inner = getattr(model, first_attr, None)
+            if inner is None:
+                continue
+            layers = getattr(inner, 'layers', None)
+            if layers is not None:
+                break
+            # Two levels: VL wrapper -> ForCausalLM -> inner Model
+            inner2 = getattr(inner, 'model', None)
+            if inner2 is not None:
+                layers = getattr(inner2, 'layers', None)
+                if layers is not None:
+                    break
+    if layers is None or layer_idx >= len(layers):
+        return None
+    layer = layers[layer_idx]
+    for attr in ('self_attn', 'self_attention', 'attention', 'attn'):
+        attn = getattr(layer, attr, None)
+        if attn is not None:
+            return attn
+    return None
+
+
 def _create_kv_cache_manager(
         model_engine: Optional[PyTorchModelEngine],
         kv_cache_manager_cls,
@@ -925,6 +1210,53 @@ def _create_kv_cache_manager(
 
     # Use provided num_layers if available, otherwise use config
     num_hidden_layers = num_layers if num_layers is not None else config.num_hidden_layers
+
+    # --- Mixed-precision per-layer KV cache ---
+    # If dtype spec contains per-layer info with more than one distinct dtype,
+    # delegate to _create_mixed_kv_cache_manager instead.
+    if not is_mla(config) and not estimating_kv_cache:
+        raw_dtype_spec = kv_cache_config.dtype
+        if isinstance(raw_dtype_spec, (dict, str)) and (
+                isinstance(raw_dtype_spec, dict)
+                or ":" in str(raw_dtype_spec)):
+            per_layer_dtype_map = _resolve_per_layer_dtype(
+                raw_dtype_spec, num_hidden_layers, quant_config, kv_cache_dtype)
+            unique_dtypes = set(per_layer_dtype_map.values())
+            if len(unique_dtypes) > 1:
+                # Build per_layer_num_kv_heads before delegating
+                draft_config_for_kv_early = None
+                if layer_mask is None:
+                    draft_config_for_kv_early = (getattr(
+                        model_engine.model, 'draft_config', None)
+                                                 if model_engine is not None
+                                                 else None)
+                per_layer_num_kv_heads_early = _build_per_layer_num_kv_heads(
+                    num_key_value_heads, num_hidden_layers, spec_config,
+                    draft_config_for_kv_early)
+                return _create_mixed_kv_cache_manager(
+                    per_layer_dtype_map=per_layer_dtype_map,
+                    kv_cache_manager_cls=kv_cache_manager_cls,
+                    mapping=mapping,
+                    kv_cache_config=kv_cache_config,
+                    tokens_per_block=tokens_per_block,
+                    max_seq_len=max_seq_len,
+                    max_batch_size=max_batch_size,
+                    spec_config=spec_config,
+                    sparse_attn_config=sparse_attn_config,
+                    max_num_tokens=max_num_tokens,
+                    max_beam_width=max_beam_width,
+                    kv_connector_manager=kv_connector_manager,
+                    estimating_kv_cache=estimating_kv_cache,
+                    execution_stream=execution_stream,
+                    model_engine=model_engine,
+                    _model_config=_model_config,
+                    quant_config=quant_config,
+                    per_layer_num_kv_heads=per_layer_num_kv_heads_early,
+                    head_dim=head_dim,
+                    num_hidden_layers=num_hidden_layers,
+                    is_draft=is_draft,
+                    fallback_dtype=kv_cache_dtype,
+                )
     # Only include draft KV heads in the per-layer list when draft layers
     # are NOT handled by a separate draft KV cache manager.  When layer_mask
     # is provided from the caller, it means the main KV cache covers only

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -76,6 +76,16 @@ def validate_and_set_kv_cache_quant(model_config: ModelConfig,
             "checkpoint KV quantization.")
         return
 
+    # Per-layer mixed-precision spec (e.g. "0-1:fp8,2-35:nvfp4" or a dict).
+    # Per-layer quant config is applied later by _apply_per_layer_kv_quant_config;
+    # skip global override here.
+    if isinstance(pyt_kv_cache_dtype, dict) or (
+            isinstance(pyt_kv_cache_dtype, str) and ":" in pyt_kv_cache_dtype):
+        logger.info(
+            f'Per-layer mixed KV cache dtype spec "{pyt_kv_cache_dtype}" detected; '
+            "skipping global quant override.")
+        return
+
     # If we have an invalid quantization, simply raise an exception.
     if not valid_pyt_quant:
         raise ValueError(

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -552,6 +552,21 @@ class KVCacheManager(BaseResourceManager):
         self.max_blocks_per_seq = self.impl.max_blocks_per_seq
         self.enable_block_reuse = kv_cache_config.enable_block_reuse
         self.enable_partial_reuse = kv_cache_config.enable_partial_reuse
+
+        pool_bytes = (self.blocks_in_primary_pool * self.tokens_per_block *
+                      self.get_cache_bytes_per_token())
+        layer_list = self.pp_layers
+        if layer_list:
+            layer_str = (f"{layer_list[0]}-{layer_list[-1]}"
+                         if len(layer_list) > 1 else str(layer_list[0]))
+        else:
+            layer_str = "(none)"
+        logger.info(
+            f"KV cache pool: dtype={self.dtype}, layers=[{layer_str}], "
+            f"num_layers={len(layer_list)}, "
+            f"pool_size={pool_bytes / (1 << 30):.2f} GiB "
+            f"({self.blocks_in_primary_pool} blocks × {self.tokens_per_block} tokens/block)")
+
         self.host_kv_cache_block_offsets = torch.empty(
             self.num_pools,
             max_batch_size * max_beam_width,
@@ -1625,6 +1640,300 @@ class KVCacheManager(BaseResourceManager):
     def reset_reuse_state(self):
         """Reset the reuse state of the KV cache manager."""
         self.impl.reset_reuse_state()
+
+
+class MixedPrecisionKVCacheManager(BaseResourceManager):
+    """Wraps multiple KVCacheManager instances for per-layer mixed-precision KV cache.
+
+    Each sub-manager owns a contiguous group of layers sharing one KV dtype (e.g. FP8
+    for layers 0-1, NVFP4 for layers 2-35).  The class merges their pool-pointer and
+    pool-mapping tensors into unified views that the attention backend consumes.
+
+    Merged kv_cache_pool_pointers is always 3D (num_total_pools, 2, 2):
+      - NVFP4 pools: [primary_data, secondary_data] × [data_ptr, scale_ptr]
+      - FP8/BF16 pools: [primary_ptr, secondary_ptr] × [data_ptr, 0]
+
+    The C++ buildKvCachePoolPointers in attentionOp.cpp is patched to accept a 3D tensor
+    for non-FP4 layers, reading the primary/secondary pointer from slice [..., 0].
+    """
+
+    def __init__(self, sub_managers: List["KVCacheManager"],
+                 per_layer_dtype_map: Dict[int, "DataType"]):
+        self.sub_managers = sub_managers
+        self.per_layer_dtype_map = per_layer_dtype_map
+
+        # Use first sub-manager as the "primary" source for shared scalar properties.
+        primary = sub_managers[0]
+        self.mapping = primary.mapping
+        self.tokens_per_block = primary.tokens_per_block
+        self.max_seq_len = primary.max_seq_len
+        self.max_batch_size = primary.max_batch_size
+        self.max_blocks_per_seq = max(m.max_blocks_per_seq for m in sub_managers)
+        self.is_draft = primary.is_draft
+        self.kv_cache_type = primary.kv_cache_type
+        self.is_vswa = primary.is_vswa
+        self.num_extra_kv_tokens = primary.num_extra_kv_tokens
+        self.enable_block_reuse = primary.enable_block_reuse
+        self.enable_partial_reuse = primary.enable_partial_reuse
+        self.max_attention_window_vec = primary.max_attention_window_vec
+        self.kv_factor = primary.kv_factor
+        self.head_dim = primary.head_dim
+        self.num_kv_heads = primary.num_kv_heads
+        self.kv_connector_manager = primary.kv_connector_manager
+        self.max_draft_len = primary.max_draft_len
+        self.max_total_draft_tokens = primary.max_total_draft_tokens
+        self.event_buffer_max_size = primary.event_buffer_max_size
+        self.attention_dp_events_gather_period_ms = primary.attention_dp_events_gather_period_ms
+
+        # Build a sorted, deduplicated global pp_layers list.
+        global_set: Set[int] = set()
+        for mgr in sub_managers:
+            global_set.update(mgr.pp_layers)
+        self.pp_layers = sorted(global_set)
+        self.layer_offsets = {
+            global_idx: local_idx
+            for local_idx, global_idx in enumerate(self.pp_layers)
+        }
+        self.num_local_layers = len(self.pp_layers)
+        self.num_layers = max(m.num_layers for m in sub_managers)
+
+        # Reconstruct per-layer kv head counts in global layer order.
+        self.num_kv_heads_per_layer: List[int] = []
+        for global_idx in self.pp_layers:
+            for mgr in sub_managers:
+                if global_idx in mgr.layer_offsets:
+                    local_idx = mgr.layer_offsets[global_idx]
+                    self.num_kv_heads_per_layer.append(
+                        mgr.num_kv_heads_per_layer[local_idx])
+                    break
+        self.total_num_kv_heads_per_layer = primary.total_num_kv_heads_per_layer
+
+        # Total pool count across all sub-managers.
+        self.num_pools = sum(m.num_pools for m in sub_managers)
+
+        # Cumulative pool offset for each sub-manager (used when merging pool mapping).
+        self._pool_offsets: Dict[int, int] = {}
+        offset = 0
+        for mgr in sub_managers:
+            self._pool_offsets[id(mgr)] = offset
+            offset += mgr.num_pools
+
+        # Merged tensors (built once at init; pool pointers don't change after allocation).
+        self.kv_cache_pool_pointers = self._build_merged_pool_pointers()
+        self.kv_cache_pool_mapping = self._build_merged_pool_mapping()
+
+        # Allocate a combined CPU block-offset buffer used by copy_batch_block_offsets.
+        max_seqs = max(m.host_kv_cache_block_offsets.shape[1]
+                       for m in sub_managers)
+        self.host_kv_cache_block_offsets = torch.empty(
+            self.num_pools,
+            max_seqs,
+            2,
+            self.max_blocks_per_seq,
+            dtype=torch.int32,
+            pin_memory=prefer_pinned(),
+            device='cpu',
+        )
+
+        # Warmup-baseline counters (mirroring KVCacheManager).
+        self._warmup_reused_blocks = 0
+        self._warmup_missed_blocks = 0
+
+    # ------------------------------------------------------------------
+    # Pool tensor construction helpers
+    # ------------------------------------------------------------------
+
+    def _build_merged_pool_pointers(self) -> torch.Tensor:
+        """Merge sub-manager pool-pointer tensors into a single 3D tensor.
+
+        Both 2D (FP8/BF16) and 3D (NVFP4) inputs are normalised to shape
+        (n, 2, 2): data pointers go into slice [..., 0], scale pointers
+        (zero for non-FP4) go into slice [..., 1].
+        """
+        parts = []
+        for mgr in self.sub_managers:
+            pp = mgr.kv_cache_pool_pointers  # (n, 2) or (n, 2, 2)
+            if pp.dim() == 2:
+                n = pp.shape[0]
+                expanded = torch.zeros(n, 2, 2, dtype=torch.int64, device='cpu')
+                expanded[:, :, 0] = pp.to(torch.int64)
+                parts.append(expanded)
+            else:
+                parts.append(
+                    pp.to(torch.int64) if pp.dtype != torch.int64 else pp)
+        return torch.cat(parts, dim=0)
+
+    def _build_merged_pool_mapping(self) -> torch.Tensor:
+        """Build a (num_local_layers, 2) pool-mapping tensor in global layer order.
+
+        Pool indices from each sub-manager are offset by the cumulative pool count
+        of preceding managers so they index correctly into the merged pool_pointers.
+        """
+        merged = torch.zeros(self.num_local_layers, 2, dtype=torch.int32)
+        for mgr in self.sub_managers:
+            pool_offset = self._pool_offsets[id(mgr)]
+            for local_idx, global_idx in enumerate(mgr.pp_layers):
+                if global_idx not in self.layer_offsets:
+                    continue
+                merged_row = self.layer_offsets[global_idx]
+                src = mgr.kv_cache_pool_mapping[local_idx]  # (2,)
+                merged[merged_row, 0] = int(src[0]) + pool_offset  # offset pool index
+                merged[merged_row, 1] = int(src[1])                # layer-in-pool unchanged
+        return merged
+
+    # ------------------------------------------------------------------
+    # Scheduler / C++ compatibility
+    # ------------------------------------------------------------------
+
+    @property
+    def impl(self):
+        """Return first sub-manager's C++ impl for scheduler / transceiver compatibility."""
+        return self.sub_managers[0].impl
+
+    @property
+    def dtype(self) -> "DataType":
+        return self.sub_managers[0].dtype
+
+    # ------------------------------------------------------------------
+    # BaseResourceManager interface
+    # ------------------------------------------------------------------
+
+    def get_max_resource_count(self) -> int:
+        return min(m.get_max_resource_count() for m in self.sub_managers)
+
+    def get_needed_resource_to_completion(self, request: LlmRequest) -> int:
+        # Each sub-manager needs blocks for its own layer group; use the max.
+        return max(m.get_needed_resource_to_completion(request)
+                   for m in self.sub_managers)
+
+    def prepare_resources(self, scheduled_batch: ScheduledRequests):
+        for mgr in self.sub_managers:
+            mgr.prepare_resources(scheduled_batch)
+
+    def update_resources(self,
+                         scheduled_batch: ScheduledRequests,
+                         attn_metadata: "AttentionMetadata" = None,
+                         kv_cache_dtype_byte_size: float = None):
+        for mgr in self.sub_managers:
+            mgr.update_resources(scheduled_batch, attn_metadata,
+                                 kv_cache_dtype_byte_size)
+
+    def free_resources(self, request: LlmRequest, pin_on_release: bool = False):
+        for mgr in self.sub_managers:
+            mgr.free_resources(request, pin_on_release)
+
+    def shutdown(self):
+        for mgr in self.sub_managers:
+            mgr.shutdown()
+
+    def add_dummy_requests(self, *args, **kwargs):
+        """Add dummy requests to all sub-managers; return requests from the first."""
+        result = None
+        for mgr in self.sub_managers:
+            r = mgr.add_dummy_requests(*args, **kwargs)
+            if result is None:
+                result = r
+        return result
+
+    # ------------------------------------------------------------------
+    # Block offset copying (called every forward pass)
+    # ------------------------------------------------------------------
+
+    def copy_batch_block_offsets(self, dst_tensor: torch.Tensor,
+                                 request_ids: List[int], beam_width: int,
+                                 num_context: int, num_seqs: int):
+        """Populate each sub-manager's CPU block offsets then copy to GPU dst_tensor."""
+        for mgr in self.sub_managers:
+            mgr.impl.copy_batch_block_offsets(mgr.host_kv_cache_block_offsets,
+                                              request_ids[:num_context], 1, 0)
+            mgr.impl.copy_batch_block_offsets(mgr.host_kv_cache_block_offsets,
+                                              request_ids[num_context:],
+                                              beam_width, num_context)
+
+        # Copy each sub-manager's CPU slice to the correct pool rows of dst_tensor.
+        pool_start = 0
+        for mgr in self.sub_managers:
+            n = mgr.host_kv_cache_block_offsets.shape[0]
+            src = mgr.host_kv_cache_block_offsets
+            for pool_idx in range(n):
+                dst_tensor[pool_start + pool_idx, :num_seqs].copy_(
+                    src[pool_idx, :num_seqs], non_blocking=True)
+            pool_start += n
+
+    # ------------------------------------------------------------------
+    # Capacity / stats
+    # ------------------------------------------------------------------
+
+    def get_num_free_blocks(self) -> int:
+        return min(m.get_num_free_blocks() for m in self.sub_managers)
+
+    def get_num_kv_blocks(self, num_tokens: int) -> int:
+        return (num_tokens + self.tokens_per_block - 1) // self.tokens_per_block
+
+    def get_num_available_tokens(self,
+                                 token_num_upper_bound: int,
+                                 max_num_draft_tokens: int = 0,
+                                 **kwargs) -> int:
+        return min(
+            token_num_upper_bound,
+            self.get_num_free_blocks() * self.tokens_per_block -
+            self.num_extra_kv_tokens - max_num_draft_tokens)
+
+    def get_kv_cache_stats(self):
+        # Report stats from the first sub-manager as a representative summary.
+        return self.sub_managers[0].get_kv_cache_stats()
+
+    def get_iteration_stats(self):
+        return self.sub_managers[0].get_iteration_stats()
+
+    def snapshot_warmup_baseline(self):
+        for mgr in self.sub_managers:
+            mgr.snapshot_warmup_baseline()
+
+    # ------------------------------------------------------------------
+    # Misc pass-throughs
+    # ------------------------------------------------------------------
+
+    def get_cache_indices(self, request: LlmRequest, *args, **kwargs):
+        return self.sub_managers[0].get_cache_indices(request, *args, **kwargs)
+
+    def probe_prefix_match_length(self, *args, **kwargs) -> int:
+        return self.sub_managers[0].probe_prefix_match_length(*args, **kwargs)
+
+    def flush_iteration_events(self):
+        self.sub_managers[0].flush_iteration_events()
+
+    def get_latest_events(self, *args, **kwargs):
+        return self.sub_managers[0].get_latest_events(*args, **kwargs)
+
+    def rewind_kv_cache(self, request: LlmRequest, rewind_len: int):
+        for mgr in self.sub_managers:
+            mgr.rewind_kv_cache(request, rewind_len)
+
+    def reset_reuse_state(self):
+        for mgr in self.sub_managers:
+            mgr.reset_reuse_state()
+
+    def check_invalid_values_in_kv_cache(self, *args, **kwargs) -> bool:
+        return any(
+            m.check_invalid_values_in_kv_cache(*args, **kwargs)
+            for m in self.sub_managers)
+
+    def store_blocks_for_reuse(self, *args, **kwargs):
+        return self.sub_managers[0].store_blocks_for_reuse(*args, **kwargs)
+
+    def get_buffers(self, layer_idx: int, kv_layout: str = "NHD"):
+        for mgr in self.sub_managers:
+            if layer_idx in mgr.layer_offsets:
+                return mgr.get_buffers(layer_idx, kv_layout)
+        return None
+
+    def get_temp_attention_window_inputs(self, *args, **kwargs):
+        return self.sub_managers[0].get_temp_attention_window_inputs(
+            *args, **kwargs)
+
+    def get_priority_by_block_id(self, *args, **kwargs):
+        return self.sub_managers[0].get_priority_by_block_id(*args, **kwargs)
 
 
 class KVCacheManagerV2(BaseResourceManager):
@@ -2857,7 +3166,8 @@ class ResourceManager:
     ):
         for _, resource_manager in self.resource_managers.items():
             if hasattr(resource_manager, "update_resources"):
-                if isinstance(resource_manager, KVCacheManager):
+                if isinstance(resource_manager,
+                               (KVCacheManager, MixedPrecisionKVCacheManager)):
                     resource_manager.update_resources(scheduled_batch,
                                                       attn_metadata,
                                                       kv_cache_dtype_byte_size)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2300,6 +2300,57 @@ SparseAttentionConfig: TypeAlias = Annotated[
 ]
 
 
+def parse_kv_cache_dtype_spec(
+        spec: Union[str, Dict[int, str]],
+        num_layers: int) -> Dict[int, str]:
+    """Parse a KV cache dtype specification into a per-layer dict.
+
+    Supported formats:
+    - Plain string (no colon): uniform dtype for all layers, e.g. "fp8"
+    - Range-syntax string: "0-1:fp8,2-35:nvfp4"
+    - Dict: {0: "fp8", 2: "nvfp4"} — missing layers default to "auto"
+
+    Returns a full mapping {layer_idx: dtype_str} for all num_layers layers.
+    """
+    result: Dict[int, str] = {i: "auto" for i in range(num_layers)}
+
+    if isinstance(spec, dict):
+        for k, v in spec.items():
+            if not (0 <= k < num_layers):
+                raise ValueError(
+                    f"Layer index {k} out of range [0, {num_layers})")
+            result[k] = v
+        return result
+
+    # String spec
+    if ":" not in spec:
+        # Uniform dtype
+        return {i: spec for i in range(num_layers)}
+
+    # Range syntax: "0-1:fp8,2-35:nvfp4"
+    for segment in spec.split(","):
+        segment = segment.strip()
+        if ":" not in segment:
+            raise ValueError(
+                f"Invalid per-layer dtype segment '{segment}'. "
+                "Expected format 'start-end:dtype' or 'idx:dtype'.")
+        range_part, dtype_str = segment.rsplit(":", 1)
+        dtype_str = dtype_str.strip()
+        range_part = range_part.strip()
+        if "-" in range_part:
+            parts = range_part.split("-", 1)
+            start, end = int(parts[0]), int(parts[1])
+        else:
+            start = end = int(range_part)
+        for i in range(start, end + 1):
+            if not (0 <= i < num_layers):
+                raise ValueError(
+                    f"Layer index {i} out of range [0, {num_layers})")
+            result[i] = dtype_str
+
+    return result
+
+
 @PybindMirror.mirror_pybind_fields(_KvCacheConfig)
 class KvCacheConfig(StrictBaseModel, PybindMirror):
     """
@@ -2383,10 +2434,19 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
     )
 
     # This is a pure python field, not a pybind field. It is only for the Pytorch backend.
-    dtype: str = Field(
+    # Accepts a uniform dtype string ("auto", "fp8", "nvfp4", …) OR a per-layer
+    # range-syntax string ("0-1:fp8,2-35:nvfp4") OR a dict mapping layer index
+    # to dtype string ({0: "fp8", 2: "nvfp4"}).
+    dtype: Union[str, Dict[int, str]] = Field(
         default="auto",
-        description=
-        "The data type to use for the KV cache. Use 'auto' to follow checkpoint metadata, otherwise force the specified dtype."
+        description=(
+            "The data type to use for the KV cache. "
+            "Use 'auto' to follow checkpoint metadata. "
+            "For uniform precision use a dtype string (e.g. 'fp8', 'nvfp4'). "
+            "For per-layer mixed precision use a range-syntax string "
+            "(e.g. '0-1:fp8,2-35:nvfp4') or a dict mapping layer index to "
+            "dtype string (e.g. {0: 'fp8', 2: 'nvfp4'})."
+        )
     )
 
     # This is a pure python field, not a pybind field. It is only for the Pytorch backend.
@@ -2461,14 +2521,19 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
 
     @field_validator('dtype')
     @classmethod
-    def validate_dtype(cls, v: str):
+    def validate_dtype(cls, v):
+        if isinstance(v, dict):
+            return v
         v = v.lower()
-        if v in ("auto", "fp8",
-                 "nvfp4") or v in _str_to_torch_dtype_dict.keys():
+        if v in ("auto", "fp8", "nvfp4") or v in _str_to_torch_dtype_dict.keys():
+            return v
+        # Per-layer range syntax: "0-1:fp8,2-35:nvfp4"
+        if ":" in v:
             return v
 
         raise ValueError(
-            'kv_cache_config.dtype must be one of "auto", "fp8", "nvfp4", or valid torch.dtype string'
+            'kv_cache_config.dtype must be one of "auto", "fp8", "nvfp4", '
+            'a valid torch.dtype string, or a per-layer range spec like "0-1:fp8,2-35:nvfp4"'
         )
 
     @field_validator('max_gpu_total_bytes')


### PR DESCRIPTION

## Release Notes

Mixed-precision per-layer KV cache allows assigning different KV cache quantization formats to different transformer layers via a simple range-syntax string in KvCacheConfig.dtype.

```
  kv_cache_config:
    dtype: "0-3:fp8,4-35:nvfp4"  # FP8 for first 4 layers, NVFP4 for the remaining 32
    free_gpu_memory_fraction: 0.85
```
Example serve config and launch script for Qwen3-4B: https://github.com/jjia-droid/TensorRT-LLM/tree/jinda_dev/mixed_layer_imp_doc

  Implementation and pool structure details: https://github.com/jjia-droid/TensorRT-LLM/blob/jinda_dev/mixed_layer_imp_doc/kv_cache_precision_comparison.md

* **New Features**
  * Added mixed-precision KV cache support allowing different layers to use different precision levels (FP8, BF16, NVFP4) simultaneously within a single model.
  * Introduced per-layer KV cache dtype configuration with range-based syntax (e.g., `0-3:fp8,4-35:nvfp4`).

* **Documentation**
  * Added comprehensive documentation describing KV cache precision behaviors and mixed-precision setup workflows.

* **Improvements**
  * Enhanced logging for KV cache buffer initialization and pool size reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->