### PR TITLE
[https://nvbugs/6093911][fix] Fix disagg gen-only benchmark hang under ADP router imbalance

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2220,7 +2220,14 @@ class PyExecutor:
             # scheduler could not allocate KV for any of them, the benchmark
             # will hang forever because in-progress generation requests won't
             # release their KV cache.
+            #
+            # Suppress during the fill phase: INIT requests are expected
+            # while KV transfers are still in progress.  The state-based
+            # gate (_is_benchmark_disagg_fill_complete) will open once all
+            # transfers complete; only after that does a stuck INIT request
+            # indicate genuine KV insufficiency.
             if (self.benchmark_req_queues_size > 0 and not self.is_warmup
+                    and not self._benchmark_fill_phase_active
                     and not fitting_disagg_gen_init_requests):
                 stuck_init_requests = [
                     req for req in self.active_requests
@@ -2273,42 +2280,88 @@ class PyExecutor:
 
     def _is_benchmark_disagg_fill_complete(
             self, scheduled_batch: ScheduledRequests) -> bool:
-        """Check whether all benchmark disagg requests have completed KV transfer.
+        """State-based fill-complete predicate for benchmark disagg mode.
 
-        With ADP, generation requests are distributed across TP ranks, so an
-        allgather is needed to obtain the global count.  Without ADP every
-        request is local, and we can compare directly.
+        The gate opens when all three conditions hold globally:
+
+        (A) The executor has fetched at least ``benchmark_req_queues_size``
+            requests cumulatively.
+        (B) Every request in ``active_requests`` on this rank is past the
+            KV-transfer phase (not in INIT or TRANS_IN_PROGRESS).
+        (C) The KV cache transceiver has no pending receive sessions
+            (no transfers about to complete that would change state).
+
+        For ADP, (B) and (C) are AND-ed across TP ranks via allgather.
+
+        This predicate is immune to ADP router distribution skew: it asks
+        "are all admitted requests ready for generation?" not "did the
+        router put >= threshold/tp_size on every rank?"
 
         This method must only be called when ``is_benchmark_disagg`` is True.
 
         Args:
-            scheduled_batch: The current iteration's scheduled requests,
-                used to count generation requests that have completed
-                KV transfer.
+            scheduled_batch: Passed for API compatibility with callers
+                but no longer used by this predicate.
 
         Returns:
-            True when the total number of generation-ready requests
-            reaches ``benchmark_req_queues_size``.
+            True when the fill phase is complete and the first forward
+            pass can proceed.
         """
         if not self.is_benchmark_disagg:
             raise RuntimeError(
-                "_is_benchmark_disagg_fill_complete() should not be called outside benchmark "
-                "disagg mode.  This is an unexpected error.")
-        local_gen_count = sum(1 for req in scheduled_batch.generation_requests
-                              if not req.is_attention_dp_dummy)
-        if self.enable_attention_dp:
-            total_gen_count = sum(self.dist.tp_allgather(local_gen_count))
-        else:
-            total_gen_count = local_gen_count
+                "_is_benchmark_disagg_fill_complete() should not be called "
+                "outside benchmark disagg mode.")
 
-        if total_gen_count >= self.benchmark_req_queues_size:
-            return True
-        if self.dist.rank == 0:
+        # (A) All benchmark requests have been fetched from the queue.
+        if self.num_fetch_requests < self.benchmark_req_queues_size:
+            if self.dist.rank == 0:
+                logger.debug(
+                    f"Benchmark disagg fill: fetching "
+                    f"{self.num_fetch_requests}/{self.benchmark_req_queues_size}"
+                )
+            return False
+
+        # (B) Every active request on this rank is past KV-transfer states.
+        local_all_past_transfer = not any(
+            req.is_disagg_generation_init_state
+            or req.is_disagg_generation_transmission_in_progress
+            for req in self.active_requests)
+
+        # (C) No pending receive sessions on the transceiver.
+        local_no_inflight = (
+            self.kv_cache_transceiver is None
+            or self.kv_cache_transceiver.check_gen_transfer_complete())
+
+        local_ok = int(local_all_past_transfer and local_no_inflight)
+
+        if self.enable_attention_dp:
+            all_ranks_ok = self.dist.tp_allgather(local_ok)
+            global_ok = min(all_ranks_ok) == 1
+        else:
+            all_ranks_ok = None
+            global_ok = bool(local_ok)
+
+        if not global_ok and self.dist.rank == 0:
+            blocked_ranks = [
+                rank for rank, ok in enumerate(all_ranks_ok or [local_ok])
+                if not ok
+            ]
+            num_init = sum(1 for req in self.active_requests
+                           if req.is_disagg_generation_init_state)
+            num_in_progress = sum(
+                1 for req in self.active_requests
+                if req.is_disagg_generation_transmission_in_progress)
             logger.debug(
-                f"Benchmark disagg fill in progress: "
-                f"num_fetched={self.num_fetch_requests}, "
-                f"total_gen_count={total_gen_count} (local={local_gen_count})")
-        return False
+                f"Benchmark disagg fill: blocked on ranks {blocked_ranks} "
+                f"(rank {self.dist.rank} local: {num_init} INIT, "
+                f"{num_in_progress} in-progress, "
+                f"inflight={not local_no_inflight})"
+            )
+        if global_ok and self.dist.rank == 0:
+            logger.info(f"Benchmark disagg fill complete: "
+                        f"{len(self.active_requests)} active requests ready, "
+                        f"gate opening.")
+        return global_ok
 
     def _check_benchmark_disagg_gate(self, scheduled_batch: ScheduledRequests,
                                      can_forward: bool) -> tuple[bool, bool]:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2355,8 +2355,7 @@ class PyExecutor:
                 f"Benchmark disagg fill: blocked on ranks {blocked_ranks} "
                 f"(rank {self.dist.rank} local: {num_init} INIT, "
                 f"{num_in_progress} in-progress, "
-                f"inflight={not local_no_inflight})"
-            )
+                f"inflight={not local_no_inflight})")
         if global_ok and self.dist.rank == 0:
             logger.info(f"Benchmark disagg fill complete: "
                         f"{len(self.active_requests)} active requests ready, "

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3110,6 +3110,19 @@ class PyExecutor:
 
         max_new_requests = total_max - total_num_active_requests
 
+        # Benchmark disagg fill-phase admission control. Without this cap, the
+        # executor can admit up to `total_max` requests in a single iteration as
+        # soon as the benchmark queue is preloaded, which spikes peak KV-cache
+        # reservations + recv-buffer reservations and can OOM-kill the GEN
+        # server before any KV transfer drains.  The `tp_size` cap restores the
+        # conservative per-rank rate that PR #12091 had in its blocking fill
+        # loop: one new request per rank per executor iteration.  It is scoped
+        # to the initial fill only; once the gate fires, normal admission
+        # resumes.
+        if (self.is_benchmark_disagg and self._benchmark_fill_phase_active
+                and not self.is_warmup):
+            max_new_requests = min(max_new_requests, self.dist.tp_size)
+
         return get_from_waiting_queue(
             waiting_queue,
             max_new_requests,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3099,12 +3099,12 @@ class PyExecutor:
 
         max_new_requests = total_max - total_num_active_requests
 
-        # Benchmark disagg fill-phase admission throttle: without it, the
-        # executor admits `total_max` requests in one iteration when the
-        # benchmark queue is preloaded, putting that many KV recvs in
-        # flight at once.  The transient transfer-staging peak can OOM-
-        # kill the GEN server before any transfer drains.  Cap at
-        # `tp_size` (one per rank per iteration) until the fill gate opens.
+        # Benchmark disagg fill-phase admission throttle: a preloaded queue
+        # (concurrency == total_max) would otherwise pop all requests into
+        # DISAGG_GENERATION_INIT in one iter, tripping PR #12206's fail-fast
+        # under ADP-router imbalance and growing the recv-buffer fallback
+        # faster than transfers drain.  Cap at `tp_size` (≈ pre-#12208
+        # blocking fill rate).  Verified on Kimi-K2 8k1k ctx8/gen1 con=8192.
         if (self.is_benchmark_disagg and self._benchmark_fill_phase_active
                 and not self.is_warmup):
             max_new_requests = min(max_new_requests, self.dist.tp_size)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2216,18 +2216,12 @@ class PyExecutor:
                     self._check_disagg_ctx_cache_transfer_status(0)
 
             # In gen-only benchmark mode, all requests must fit in KV cache
-            # simultaneously. If some requests are stuck in INIT state and the
-            # scheduler could not allocate KV for any of them, the benchmark
-            # will hang forever because in-progress generation requests won't
-            # release their KV cache.
-            #
-            # Suppress during the fill phase: INIT requests are expected
-            # while KV transfers are still in progress.  The state-based
-            # gate (_is_benchmark_disagg_fill_complete) will open once all
-            # transfers complete; only after that does a stuck INIT request
-            # indicate genuine KV insufficiency.
+            # simultaneously because generation requests do not release their
+            # KV until the full benchmark batch can run. If the scheduler
+            # cannot fit any INIT request after all benchmark requests have
+            # been fetched, the fill gate would never open; raise an explicit
+            # error instead of hanging forever.
             if (self.benchmark_req_queues_size > 0 and not self.is_warmup
-                    and not self._benchmark_fill_phase_active
                     and not fitting_disagg_gen_init_requests):
                 stuck_init_requests = [
                     req for req in self.active_requests
@@ -2288,14 +2282,9 @@ class PyExecutor:
             requests cumulatively.
         (B) Every request in ``active_requests`` on this rank is past the
             KV-transfer phase (not in INIT or TRANS_IN_PROGRESS).
-        (C) The KV cache transceiver has no pending receive sessions
-            (no transfers about to complete that would change state).
+        (C) The KV cache transceiver has no pending receive sessions.
 
         For ADP, (B) and (C) are AND-ed across TP ranks via allgather.
-
-        This predicate is immune to ADP router distribution skew: it asks
-        "are all admitted requests ready for generation?" not "did the
-        router put >= threshold/tp_size on every rank?"
 
         This method must only be called when ``is_benchmark_disagg`` is True.
 
@@ -2327,7 +2316,8 @@ class PyExecutor:
             or req.is_disagg_generation_transmission_in_progress
             for req in self.active_requests)
 
-        # (C) No pending receive sessions on the transceiver.
+        # Also require the transceiver's async receive bookkeeping to be
+        # drained before opening the fill gate.
         local_no_inflight = (
             self.kv_cache_transceiver is None
             or self.kv_cache_transceiver.check_gen_transfer_complete())
@@ -2336,30 +2326,30 @@ class PyExecutor:
 
         if self.enable_attention_dp:
             all_ranks_ok = self.dist.tp_allgather(local_ok)
-            global_ok = min(all_ranks_ok) == 1
         else:
-            all_ranks_ok = None
-            global_ok = bool(local_ok)
+            all_ranks_ok = [local_ok]
+        global_ok = min(all_ranks_ok) == 1
 
-        if not global_ok and self.dist.rank == 0:
-            blocked_ranks = [
-                rank for rank, ok in enumerate(all_ranks_ok or [local_ok])
-                if not ok
-            ]
-            num_init = sum(1 for req in self.active_requests
-                           if req.is_disagg_generation_init_state)
-            num_in_progress = sum(
-                1 for req in self.active_requests
-                if req.is_disagg_generation_transmission_in_progress)
-            logger.debug(
-                f"Benchmark disagg fill: blocked on ranks {blocked_ranks} "
-                f"(rank {self.dist.rank} local: {num_init} INIT, "
-                f"{num_in_progress} in-progress, "
-                f"inflight={not local_no_inflight})")
-        if global_ok and self.dist.rank == 0:
-            logger.info(f"Benchmark disagg fill complete: "
-                        f"{len(self.active_requests)} active requests ready, "
-                        f"gate opening.")
+        if self.dist.rank == 0:
+            if global_ok:
+                logger.info(
+                    f"Benchmark disagg fill complete: "
+                    f"{len(self.active_requests)} active requests ready, "
+                    f"gate opening.")
+            else:
+                blocked_ranks = [
+                    rank for rank, ok in enumerate(all_ranks_ok) if not ok
+                ]
+                num_init = sum(1 for req in self.active_requests
+                               if req.is_disagg_generation_init_state)
+                num_in_progress = sum(
+                    1 for req in self.active_requests
+                    if req.is_disagg_generation_transmission_in_progress)
+                logger.debug(
+                    f"Benchmark disagg fill: blocked on ranks {blocked_ranks} "
+                    f"(rank {self.dist.rank} local: {num_init} INIT, "
+                    f"{num_in_progress} in-progress, "
+                    f"inflight={not local_no_inflight})")
         return global_ok
 
     def _check_benchmark_disagg_gate(self, scheduled_batch: ScheduledRequests,
@@ -3109,15 +3099,12 @@ class PyExecutor:
 
         max_new_requests = total_max - total_num_active_requests
 
-        # Benchmark disagg fill-phase admission control. Without this cap, the
-        # executor can admit up to `total_max` requests in a single iteration as
-        # soon as the benchmark queue is preloaded, which spikes peak KV-cache
-        # reservations + recv-buffer reservations and can OOM-kill the GEN
-        # server before any KV transfer drains.  The `tp_size` cap restores the
-        # conservative per-rank rate that PR #12091 had in its blocking fill
-        # loop: one new request per rank per executor iteration.  It is scoped
-        # to the initial fill only; once the gate fires, normal admission
-        # resumes.
+        # Benchmark disagg fill-phase admission throttle: without it, the
+        # executor admits `total_max` requests in one iteration when the
+        # benchmark queue is preloaded, putting that many KV recvs in
+        # flight at once.  The transient transfer-staging peak can OOM-
+        # kill the GEN server before any transfer drains.  Cap at
+        # `tp_size` (one per rank per iteration) until the fill gate opens.
         if (self.is_benchmark_disagg and self._benchmark_fill_phase_active
                 and not self.is_warmup):
             max_new_requests = min(max_new_requests, self.dist.tp_size)

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -249,9 +249,17 @@ class DefaultADPRouter(ADPRouter):
 
         num_new_requests_all_ranks = len(remaining_unscheduled)
         total_num_active_requests = sum(all_ranks_num_active_requests)
-        expected_num_active_requests = max(
-            (total_num_active_requests + num_new_requests_all_ranks + tp_size - 1) // tp_size,
-            max(all_ranks_num_active_requests),
+        # Cap at max_num_active_requests to prevent the balancer from
+        # assigning more requests than a rank can physically schedule.
+        # Without this cap, bulk arrivals (e.g. benchmark disagg mode)
+        # can push expected above max_batch_size, leaving excess requests
+        # permanently stuck in INIT state (nvbug 6071070).
+        expected_num_active_requests = min(
+            max(
+                (total_num_active_requests + num_new_requests_all_ranks + tp_size - 1) // tp_size,
+                max(all_ranks_num_active_requests),
+            ),
+            max_num_active_requests,
         )
 
         all_ranks_new_requests = self._balance_requests_across_ranks(
@@ -536,15 +544,22 @@ class KVCacheAwareADPRouter(ADPRouter):
 
         # Loose cap at fair_share_multiplier * ceil(total / tp_size): safety
         # net against runaway concentration, still loose enough that cache
-        # affinity wins in the common case.
+        # affinity wins in the common case.  Hard-cap additionally at
+        # max_num_active_requests — same guard as DefaultADPRouter
+        # (nvbug 6071070); critical for benchmark disagg fill where bulk
+        # arrivals would otherwise leave excess requests permanently stuck
+        # in INIT state.
         num_new_requests_all_ranks = len(remaining_unscheduled)
         total_num_active_requests = sum(all_ranks_num_active_requests)
         fair_share = (
             total_num_active_requests + num_new_requests_all_ranks + tp_size - 1
         ) // tp_size
-        expected_num_active_requests = max(
-            math.ceil(self.fair_share_multiplier * fair_share),
-            max(all_ranks_num_active_requests),
+        expected_num_active_requests = min(
+            max(
+                math.ceil(self.fair_share_multiplier * fair_share),
+                max(all_ranks_num_active_requests),
+            ),
+            max_num_active_requests,
         )
         eligible_ranks = [
             rank

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -249,11 +249,8 @@ class DefaultADPRouter(ADPRouter):
 
         num_new_requests_all_ranks = len(remaining_unscheduled)
         total_num_active_requests = sum(all_ranks_num_active_requests)
-        # Cap at max_num_active_requests to prevent the balancer from
-        # assigning more requests than a rank can physically schedule.
-        # Without this cap, bulk arrivals (e.g. benchmark disagg mode)
-        # can push expected above max_batch_size, leaving excess requests
-        # permanently stuck in INIT state (nvbug 6071070).
+        # Cap at max_num_active_requests so the per-rank target never
+        # exceeds what the rank can physically schedule.
         expected_num_active_requests = min(
             max(
                 (total_num_active_requests + num_new_requests_all_ranks + tp_size - 1) // tp_size,
@@ -545,10 +542,8 @@ class KVCacheAwareADPRouter(ADPRouter):
         # Loose cap at fair_share_multiplier * ceil(total / tp_size): safety
         # net against runaway concentration, still loose enough that cache
         # affinity wins in the common case.  Hard-cap additionally at
-        # max_num_active_requests — same guard as DefaultADPRouter
-        # (nvbug 6071070); critical for benchmark disagg fill where bulk
-        # arrivals would otherwise leave excess requests permanently stuck
-        # in INIT state.
+        # max_num_active_requests so the per-rank target never exceeds what
+        # the rank can physically schedule (matches DefaultADPRouter).
         num_new_requests_all_ranks = len(remaining_unscheduled)
         total_num_active_requests = sum(all_ranks_num_active_requests)
         fair_share = (

--- a/tests/integration/defs/perf/disagg/test_configs/wideep/perf/kimi-k2-thinking-fp4_8k1k_ctx8_gen1_dep32_bs256_eplb416_mtp0_ccb-NIXL.yaml
+++ b/tests/integration/defs/perf/disagg/test_configs/wideep/perf/kimi-k2-thinking-fp4_8k1k_ctx8_gen1_dep32_bs256_eplb416_mtp0_ccb-NIXL.yaml
@@ -73,21 +73,12 @@ worker_config:
     print_iter_log: true
     kv_cache_config:
       enable_block_reuse: false
-      # GEN KV memory budget — DO NOT lower below 0.78 without also lowering
-      # max_batch_size or max_seq_len.
-      #
-      # Floor (0.78): minimum fraction that fits max_batch_size=256 at
-      # max_seq_len=9256 (~2.37M KV tokens/rank). Below this the scheduler
-      # cannot keep all 256 ADP-routed slots resident and chronically
-      # preempts (e.g. at 0.6 only ~203/256 fit, costing ~21% of decode
-      # throughput and pushing the 90-min wall over the test timeout).
-      #
-      # Ceiling (~0.85): leaves ~15 GiB headroom on B200/GB200 (184 GiB).
-      # Above this, NIXL receive buffers + NCCL workspace + EPLB layer
-      # churn + CUDA caching-allocator fragmentation can OOM under burst.
-      #
-      # 0.78 leaves ~22 GiB headroom — comfortable for all transient
-      # allocations with margin for future runtime growth.
+      # GEN KV memory budget — DO NOT lower below 0.78 without also
+      # lowering max_batch_size or max_seq_len.  At 0.78 the KV pool fits
+      # max_batch_size=256 at max_seq_len=9256. Lowering it can
+      # under-provision the KV pool and chronically preempt requests.
+      # Stay below ~0.85 to leave headroom for NIXL recv buffers,
+      # NCCL workspace, and CUDA fragmentation.
       free_gpu_memory_fraction: 0.78
       dtype: fp8
     moe_config:

--- a/tests/integration/defs/perf/disagg/test_configs/wideep/perf/kimi-k2-thinking-fp4_8k1k_ctx8_gen1_dep32_bs256_eplb416_mtp0_ccb-NIXL.yaml
+++ b/tests/integration/defs/perf/disagg/test_configs/wideep/perf/kimi-k2-thinking-fp4_8k1k_ctx8_gen1_dep32_bs256_eplb416_mtp0_ccb-NIXL.yaml
@@ -73,7 +73,22 @@ worker_config:
     print_iter_log: true
     kv_cache_config:
       enable_block_reuse: false
-      free_gpu_memory_fraction: 0.6
+      # GEN KV memory budget — DO NOT lower below 0.78 without also lowering
+      # max_batch_size or max_seq_len.
+      #
+      # Floor (0.78): minimum fraction that fits max_batch_size=256 at
+      # max_seq_len=9256 (~2.37M KV tokens/rank). Below this the scheduler
+      # cannot keep all 256 ADP-routed slots resident and chronically
+      # preempts (e.g. at 0.6 only ~203/256 fit, costing ~21% of decode
+      # throughput and pushing the 90-min wall over the test timeout).
+      #
+      # Ceiling (~0.85): leaves ~15 GiB headroom on B200/GB200 (184 GiB).
+      # Above this, NIXL receive buffers + NCCL workspace + EPLB layer
+      # churn + CUDA caching-allocator fragmentation can OOM under burst.
+      #
+      # 0.78 leaves ~22 GiB headroom — comfortable for all transient
+      # allocations with margin for future runtime growth.
+      free_gpu_memory_fraction: 0.78
       dtype: fp8
     moe_config:
       backend: WIDEEP

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -1024,7 +1024,11 @@ class TestFillPhaseEndToEnd:
         # Phase 4: Gate opens, fill phase clears
         ex._benchmark_fill_phase_active = False
 
-        # Phase 5: After fill, if new INIT requests appear, fail-fast fires
+        # Phase 5: After fill, if new INIT requests appear and the scheduler
+        # cannot fit any of them, fail-fast fires.  Reset _schedule from
+        # Phase 2b's healthy-fill mock so it once again returns no fitting
+        # INIT requests, mirroring genuine insufficient-KV conditions.
+        ex._schedule = Mock(return_value=(ScheduledRequests(), [], 0))
         stuck_req = _make_active_request(in_init=True)
         ex.active_requests = [stuck_req] + ready_reqs
 

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -529,6 +529,79 @@ class TestPrepareAndScheduleBatchNoBlock:
 
 
 # ---------------------------------------------------------------------------
+# Benchmark fill admission flow control
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkFillAdmissionFlowControl:
+    """Verify benchmark disagg fill admits requests gradually.
+
+    The failing wide-EP Kimi case has ``benchmark_req_queues_size`` equal to
+    ``tp_size * max_batch_size``.  Without an explicit fill-phase cap, GEN can
+    admit the entire benchmark queue in one iteration, prepare too many KV
+    receives before the first forward pass, and hit process-level memory
+    pressure.  The desired invariant is non-blocking flow control: each
+    executor iteration should still return to the outer loop, but it should
+    only admit a small bounded number of new requests during the fill phase.
+    """
+
+    @staticmethod
+    def _make_executor(tp_size: int = 4, fill_phase_active: bool = True):
+        from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
+        ex = object.__new__(PyExecutor)
+        ex.enable_attention_dp = True
+        ex.is_benchmark_disagg = True
+        ex._benchmark_fill_phase_active = fill_phase_active
+        ex.benchmark_req_queues_size = 32
+        ex.num_fetch_requests = 0
+        ex.max_num_active_requests = 8
+
+        ex.dist = Mock()
+        ex.dist.tp_size = tp_size
+        return ex
+
+    @pytest.mark.parametrize("tp_size", [1, 4, 32])
+    @patch("tensorrt_llm._torch.pyexecutor.py_executor.get_from_waiting_queue")
+    def test_fill_phase_caps_admission_to_tp_size(self, mock_get_from_waiting_queue, tp_size):
+        ex = self._make_executor(tp_size=tp_size)
+        waiting_queue = Mock()
+        all_ranks_num_active_requests = [0] * tp_size
+
+        ex._pop_from_waiting_queue(
+            waiting_queue,
+            total_num_active_requests=0,
+            all_ranks_num_active_requests=all_ranks_num_active_requests,
+        )
+
+        mock_get_from_waiting_queue.assert_called_once()
+        _, max_new_requests = mock_get_from_waiting_queue.call_args.args[:2]
+
+        assert max_new_requests == ex.dist.tp_size, (
+            "Benchmark disagg fill should admit at most tp_size requests per "
+            "executor iteration.  Using full global capacity would admit "
+            "tp_size * max_batch_size requests at once and recreate the "
+            "fill-phase memory-pressure failure."
+        )
+
+    @patch("tensorrt_llm._torch.pyexecutor.py_executor.get_from_waiting_queue")
+    def test_no_fill_phase_uses_full_available_capacity(self, mock_get_from_waiting_queue):
+        ex = self._make_executor(fill_phase_active=False)
+        waiting_queue = Mock()
+        all_ranks_num_active_requests = [0, 0, 0, 0]
+
+        ex._pop_from_waiting_queue(
+            waiting_queue,
+            total_num_active_requests=0,
+            all_ranks_num_active_requests=all_ranks_num_active_requests,
+        )
+
+        _, max_new_requests = mock_get_from_waiting_queue.call_args.args[:2]
+
+        assert max_new_requests == ex.dist.tp_size * ex.max_num_active_requests
+
+
+# ---------------------------------------------------------------------------
 # ADP router per-rank cap  (prevents overflow that caused nvbug 6071070)
 # ---------------------------------------------------------------------------
 
@@ -810,6 +883,7 @@ class TestFillPhaseEndToEnd:
         ex._benchmark_fill_phase_active = True
         ex.enable_attention_dp = True
         ex.num_fetch_requests = 0
+        ex.max_num_active_requests = self.MAX_BATCH_SIZE
         ex.dist = Mock(rank=0, tp_size=self.TP_SIZE)
         ex.is_shutdown = False
         ex._is_warmup = False
@@ -839,6 +913,21 @@ class TestFillPhaseEndToEnd:
     def test_full_lifecycle(self):
         """Simulate the fill → gate-open → post-fill lifecycle."""
         ex = self._make_executor()
+
+        # Phase 0: Fill-phase admission uses the real waiting-queue path and
+        # pulls only tp_size requests per iteration, rather than the full
+        # tp_size * max_batch_size queue.
+        with patch(
+            "tensorrt_llm._torch.pyexecutor.py_executor.get_from_waiting_queue"
+        ) as mock_get_from_waiting_queue:
+            ex._pop_from_waiting_queue(
+                waiting_queue=Mock(),
+                total_num_active_requests=0,
+                all_ranks_num_active_requests=[0] * self.TP_SIZE,
+            )
+
+        _, max_new_requests = mock_get_from_waiting_queue.call_args.args[:2]
+        assert max_new_requests == self.TP_SIZE
 
         # Phase 1: Fetching requests (gate should not open)
         ex.num_fetch_requests = 4

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -103,14 +103,15 @@ class MockBenchmarkExecutor:
 class TestFillCompleteStateBased:
     """Test the state-based fill-complete predicate.
 
-    Gate opens when (A) all fetched, (B) all past transfer, (C) no inflight.
+    Gate opens when (A) all fetched, (B) all active requests are past
+    KV-transfer states, and (C) the transceiver is drained.
     """
 
     def test_opens_when_all_conditions_met(self):
         reqs = [_make_active_request() for _ in range(4)]
         ex = MockBenchmarkExecutor(
             benchmark_req_queues_size=4,
-            kv_cache_transceiver=_make_transceiver(transfer_complete=True),
+            kv_cache_transceiver=_make_transceiver(),
             num_fetch_requests=4,
             active_requests=reqs,
         )
@@ -758,25 +759,32 @@ class TestADPRouterPerRankCap:
 
 
 # ---------------------------------------------------------------------------
-# Fail-fast suppression during fill phase (prevents false-positive kills)
+# Insufficient-KV fail-fast during benchmark fill
 # ---------------------------------------------------------------------------
 
 
-class TestFailFastSuppressedDuringFill:
-    """Verify that the PR #12206 fail-fast (Insufficient KV cache) does not
-    fire while the benchmark fill phase is active.
+class TestFailFastDuringBenchmarkFill:
+    """Verify that the insufficient-KV fail-fast distinguishes healthy fill
+    progress from a stalled fill.
 
-    During fill, INIT requests are expected — they're waiting for KV
-    transfer, not for KV allocation.  The fail-fast should only fire after
-    the gate opens (fill phase complete), when stuck INIT requests genuinely
-    indicate insufficient KV cache.
+    During healthy fill, the scheduler can fit at least one INIT request for
+    KV transfer.  If all benchmark requests have been fetched and the scheduler
+    cannot fit any INIT request, the fill gate can never open and we should
+    return an explicit error instead of hanging.
 
-    This is the root cause of the CI failure on pipeline 49471411: the
-    fail-fast fired with "61 request(s) are waiting for KV cache allocation"
-    during the fill phase, before the gate had a chance to open.
+    This covers the CI regression where the fill-phase guard suppressed the
+    fail-fast forever and
+    ``test_disaggregated_benchmark_gen_only_insufficient_kv`` timed out.
     """
 
-    def _make_executor(self, *, fill_phase_active, num_init_requests=3):
+    def _make_executor(
+        self,
+        *,
+        fill_phase_active,
+        num_init_requests=3,
+        num_fetch_requests=8,
+        fitting_init_requests=None,
+    ):
         """Build a minimal PyExecutor stub for _prepare_and_schedule_batch."""
         from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
 
@@ -786,7 +794,7 @@ class TestFailFastSuppressedDuringFill:
         ex.is_benchmark_disagg = True
         ex._benchmark_fill_phase_active = fill_phase_active
         ex.enable_attention_dp = False
-        ex.num_fetch_requests = 8
+        ex.num_fetch_requests = num_fetch_requests
         ex.dist = Mock(rank=0, tp_size=1)
         ex.is_shutdown = False
         ex._is_warmup = False
@@ -812,20 +820,47 @@ class TestFailFastSuppressedDuringFill:
         ex._handle_errors = Mock()
 
         scheduled = ScheduledRequests()
-        ex._schedule = Mock(return_value=(scheduled, [], 0))
+        if fitting_init_requests is None:
+            fitting_init_requests = []
+        ex._schedule = Mock(return_value=(scheduled, fitting_init_requests, 0))
 
         return ex
 
-    def test_no_kill_during_fill_phase(self):
-        """During fill phase, stuck INIT requests must not trigger fail-fast."""
+    def test_stalled_fill_phase_kills_after_all_requests_fetched(self):
+        """A fill phase with no fitting INIT requests is a deadlock."""
         ex = self._make_executor(fill_phase_active=True)
 
         result, _ = ex._prepare_and_schedule_batch()
 
-        assert result is not None, (
-            "Fail-fast should NOT fire during fill phase — "
-            "INIT requests are expected while KV transfers are in progress"
+        assert result is None, (
+            "Fail-fast SHOULD fire during a stalled fill phase — "
+            "otherwise the fill gate never opens"
         )
+        ex._handle_errors.assert_called_once()
+
+    def test_healthy_fill_phase_does_not_kill(self):
+        """During healthy fill, a fitting INIT request means progress exists."""
+        fitting_req = _make_active_request(in_init=True)
+        ex = self._make_executor(fill_phase_active=True, fitting_init_requests=[fitting_req])
+
+        result, _ = ex._prepare_and_schedule_batch()
+
+        assert result is not None, (
+            "Fail-fast should NOT fire while the scheduler can still fit an "
+            "INIT request for KV transfer"
+        )
+        ex._handle_errors.assert_not_called()
+
+    def test_mid_fetch_does_not_kill(self):
+        """Before all benchmark requests are fetched, keep filling."""
+        ex = self._make_executor(fill_phase_active=True, num_fetch_requests=4)
+
+        result, _ = ex._prepare_and_schedule_batch()
+
+        assert result is not None, (
+            "Fail-fast should NOT fire before the full benchmark queue has been fetched"
+        )
+        ex._handle_errors.assert_not_called()
 
     def test_kills_after_fill_phase(self):
         """After fill phase completes, stuck INIT requests trigger fail-fast."""
@@ -837,11 +872,12 @@ class TestFailFastSuppressedDuringFill:
             "Fail-fast SHOULD fire after fill phase — "
             "stuck INIT requests indicate genuine KV insufficiency"
         )
+        ex._handle_errors.assert_called_once()
 
     @pytest.mark.parametrize(
         "fill_active, is_warmup, expected_alive",
         [
-            pytest.param(True, False, True, id="fill_phase_suppresses"),
+            pytest.param(True, False, False, id="stalled_fill_kills"),
             pytest.param(False, False, False, id="post_fill_kills"),
             pytest.param(False, True, True, id="warmup_suppresses"),
             pytest.param(True, True, True, id="both_suppress"),
@@ -858,11 +894,13 @@ class TestFailFastSuppressedDuringFill:
             assert result is not None, (
                 f"fill_active={fill_active}, warmup={is_warmup}: should NOT kill requests"
             )
+            ex._handle_errors.assert_not_called()
         else:
             assert result is None, (
                 f"fill_active={fill_active}, warmup={is_warmup}: "
                 "SHOULD kill requests (genuine KV insufficiency)"
             )
+            ex._handle_errors.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -877,14 +915,14 @@ class TestFillPhaseEndToEnd:
     1. All requests fetched (num_fetch_requests >= benchmark_req_queues_size)
     2. KV cache full with transferred requests, some INIT requests remain
     3. Scheduler can't fit INIT requests
-    4. Verify: fail-fast does NOT fire during fill phase
+    4. Verify: fail-fast does NOT fire while scheduler fits INIT requests
     5. Transfers complete, gate opens, fill phase clears
     6. Verify: fail-fast DOES fire if INIT requests remain after fill
 
     This test catches all three bugs we found iteratively:
     - Bug 1: Count-based gate unsatisfiable under ADP router skew
     - Bug 2: Router overshooting max_batch_size
-    - Bug 3: Fail-fast firing during fill phase
+    - Bug 3: Fail-fast must distinguish healthy fill from stalled fill
     """
 
     TOTAL_REQUESTS = 8
@@ -965,11 +1003,12 @@ class TestFillPhaseEndToEnd:
             "Gate should not open: 3 requests still in INIT"
         )
 
-        # Phase 2b: Fail-fast must NOT fire during fill phase
+        # Phase 2b: Healthy fill keeps making progress, so fail-fast must not
+        # fire even though some active requests remain in INIT.
+        ex._schedule = Mock(return_value=(ScheduledRequests(), [init_reqs[0]], 0))
         result, _ = ex._prepare_and_schedule_batch()
         assert result is not None, (
-            "Fail-fast must not kill requests during fill phase, "
-            "even though scheduler can't fit INIT requests"
+            "Fail-fast must not kill requests while the scheduler can still fit INIT requests"
         )
 
         # Phase 3: All transfers complete, gate opens

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -17,10 +17,10 @@
 In benchmark disagg mode the GEN executor must defer the forward pass
 until all benchmark requests have completed KV transfer.  These tests
 cover:
-- ``is_benchmark_disagg`` attribute initialisation
-- ``_is_benchmark_disagg_fill_complete`` (non-ADP and ADP paths)
+- State-based ``_is_benchmark_disagg_fill_complete`` predicate
 - ``can_forward`` gating initialisation and transitions
-- Incremental fill convergence when CTX has limited KV cache capacity
+- ADP dummy suppression during fill vs taper-down
+- ADP router imbalance regression (nvbug 6071070)
 - Non-blocking behaviour of ``_prepare_and_schedule_batch``
 """
 
@@ -35,25 +35,23 @@ from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 # ---------------------------------------------------------------------------
 
 
-def _make_gen_request(is_dummy: bool = False) -> Mock:
-    """Create a generation request stub with the ``is_attention_dp_dummy`` flag."""
+def _make_active_request(
+    in_init: bool = False,
+    in_transfer: bool = False,
+) -> Mock:
+    """Create an active request stub with disagg state flags."""
     req = Mock()
-    req.is_attention_dp_dummy = is_dummy
+    req.is_disagg_generation_init_state = in_init
+    req.is_disagg_generation_transmission_in_progress = in_transfer
+    req.is_attention_dp_dummy = False
     return req
 
 
-def _make_scheduled_batch(num_gen_requests: int, num_dummy_requests: int = 0) -> ScheduledRequests:
-    """Create a ScheduledRequests with generation stubs.
-
-    Args:
-        num_gen_requests: Number of real (non-dummy) generation requests.
-        num_dummy_requests: Number of ADP dummy generation requests.
-    """
-    batch = ScheduledRequests()
-    batch.generation_requests = [
-        _make_gen_request(is_dummy=False) for _ in range(num_gen_requests)
-    ] + [_make_gen_request(is_dummy=True) for _ in range(num_dummy_requests)]
-    return batch
+def _make_transceiver(transfer_complete: bool = True) -> Mock:
+    """Create a KV cache transceiver stub."""
+    transceiver = Mock()
+    transceiver.check_gen_transfer_complete.return_value = transfer_complete
+    return transceiver
 
 
 class MockBenchmarkExecutor:
@@ -74,6 +72,7 @@ class MockBenchmarkExecutor:
         rank: int = 0,
         num_fetch_requests: int = 0,
         is_warmup: bool = False,
+        active_requests=None,
     ):
         self.benchmark_req_queues_size = benchmark_req_queues_size
         self.kv_cache_transceiver = kv_cache_transceiver
@@ -84,6 +83,7 @@ class MockBenchmarkExecutor:
         self.enable_attention_dp = enable_attention_dp
         self.num_fetch_requests = num_fetch_requests
         self.is_warmup = is_warmup
+        self.active_requests = active_requests if active_requests is not None else []
 
         self.dist = Mock()
         self.dist.rank = rank
@@ -96,218 +96,171 @@ class MockBenchmarkExecutor:
 
 
 # ---------------------------------------------------------------------------
-# _is_benchmark_disagg_fill_complete  (non-ADP)
+# _is_benchmark_disagg_fill_complete  (state-based predicate)
 # ---------------------------------------------------------------------------
 
 
-class TestFillCompleteNonADP:
+class TestFillCompleteStateBased:
+    """Test the state-based fill-complete predicate.
+
+    Gate opens when (A) all fetched, (B) all past transfer, (C) no inflight.
+    """
+
+    def test_opens_when_all_conditions_met(self):
+        reqs = [_make_active_request() for _ in range(4)]
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=_make_transceiver(transfer_complete=True),
+            num_fetch_requests=4,
+            active_requests=reqs,
+        )
+        assert ex._is_benchmark_disagg_fill_complete(ScheduledRequests()) is True
+
     @pytest.mark.parametrize(
-        "num_gen_requests, expected",
+        "num_fetch, reqs, transfer_complete, reason",
         [
-            pytest.param(4, True, id="meets_threshold"),
-            pytest.param(6, True, id="exceeds_threshold"),
-            pytest.param(2, False, id="below_threshold"),
-            pytest.param(0, False, id="zero_requests"),
+            pytest.param(
+                2,
+                [_make_active_request() for _ in range(2)],
+                True,
+                "not all fetched",
+                id="condition_A_fails",
+            ),
+            pytest.param(
+                4,
+                [_make_active_request(), _make_active_request(in_init=True)],
+                True,
+                "request in INIT",
+                id="condition_B_init",
+            ),
+            pytest.param(
+                4,
+                [_make_active_request(), _make_active_request(in_transfer=True)],
+                True,
+                "request in TRANS_IN_PROGRESS",
+                id="condition_B_transfer",
+            ),
+            pytest.param(
+                4,
+                [_make_active_request() for _ in range(4)],
+                False,
+                "transceiver has pending receives",
+                id="condition_C_fails",
+            ),
         ],
     )
-    def test_threshold(self, num_gen_requests, expected):
-        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
-        batch = _make_scheduled_batch(num_gen_requests=num_gen_requests)
-
-        assert ex._is_benchmark_disagg_fill_complete(batch) is expected
-
-    def test_no_allgather_called_without_adp(self):
+    def test_blocked_when_condition_fails(self, num_fetch, reqs, transfer_complete, reason):
         ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=4, kv_cache_transceiver=Mock(), enable_attention_dp=False
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=_make_transceiver(transfer_complete=transfer_complete),
+            num_fetch_requests=num_fetch,
+            active_requests=reqs,
         )
-        batch = _make_scheduled_batch(num_gen_requests=4)
+        assert ex._is_benchmark_disagg_fill_complete(ScheduledRequests()) is False, reason
 
-        ex._is_benchmark_disagg_fill_complete(batch)
-        ex.dist.tp_allgather.assert_not_called()
-
-    def test_logs_progress_on_rank_zero(self):
+    def test_no_transceiver_skips_condition_c(self):
+        reqs = [_make_active_request() for _ in range(4)]
         ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=4, kv_cache_transceiver=Mock(), rank=0, num_fetch_requests=2
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=None,
+            num_fetch_requests=4,
+            active_requests=reqs,
         )
-        batch = _make_scheduled_batch(num_gen_requests=1)
+        ex.is_benchmark_disagg = True
+        assert ex._is_benchmark_disagg_fill_complete(ScheduledRequests()) is True
 
-        with patch("tensorrt_llm._torch.pyexecutor.py_executor.logger") as mock_logger:
-            ex._is_benchmark_disagg_fill_complete(batch)
-            mock_logger.debug.assert_called_once()
-            msg = mock_logger.debug.call_args[0][0]
-            assert "fill in progress" in msg
-            assert "num_fetched=2" in msg
-
-    def test_no_log_on_non_zero_rank(self):
-        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock(), rank=1)
-        batch = _make_scheduled_batch(num_gen_requests=1)
-
-        with patch("tensorrt_llm._torch.pyexecutor.py_executor.logger") as mock_logger:
-            ex._is_benchmark_disagg_fill_complete(batch)
-            mock_logger.debug.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# _is_benchmark_disagg_fill_complete  (ADP)
-# ---------------------------------------------------------------------------
+    def test_raises_outside_benchmark_disagg(self):
+        ex = MockBenchmarkExecutor(benchmark_req_queues_size=0)
+        with pytest.raises(RuntimeError):
+            ex._is_benchmark_disagg_fill_complete(ScheduledRequests())
 
 
 class TestFillCompleteADP:
+    """Test the state-based predicate with ADP (allgather across ranks)."""
+
     @pytest.mark.parametrize(
-        "num_gen_requests, allgather_result, expected",
+        "allgather_result, expected",
         [
-            pytest.param(2, [2, 2, 2, 2], True, id="meets_threshold"),
-            pytest.param(3, [3, 3, 3, 3], True, id="exceeds_threshold"),
-            pytest.param(1, [1, 1, 1, 0], False, id="below_threshold"),
-            pytest.param(5, [5, 1, 1, 1], True, id="uneven_distribution"),
+            pytest.param([1, 1, 1, 1], True, id="all_ranks_ready"),
+            pytest.param([1, 1, 0, 1], False, id="one_rank_blocked"),
+            pytest.param([0, 0, 0, 0], False, id="all_ranks_blocked"),
         ],
     )
-    def test_threshold(self, num_gen_requests, allgather_result, expected):
+    def test_global_gate(self, allgather_result, expected):
+        reqs = [_make_active_request() for _ in range(2)]
         ex = MockBenchmarkExecutor(
             benchmark_req_queues_size=8,
-            kv_cache_transceiver=Mock(),
+            kv_cache_transceiver=_make_transceiver(transfer_complete=True),
             enable_attention_dp=True,
             tp_size=4,
+            num_fetch_requests=8,
+            active_requests=reqs,
         )
-        batch = _make_scheduled_batch(num_gen_requests=num_gen_requests)
         ex.dist.tp_allgather.return_value = allgather_result
+        assert ex._is_benchmark_disagg_fill_complete(ScheduledRequests()) is expected
 
-        assert ex._is_benchmark_disagg_fill_complete(batch) is expected
-
-    def test_allgather_receives_local_count(self):
+    def test_allgather_sends_local_ok_int(self):
+        reqs = [_make_active_request() for _ in range(2)]
         ex = MockBenchmarkExecutor(
             benchmark_req_queues_size=4,
-            kv_cache_transceiver=Mock(),
+            kv_cache_transceiver=_make_transceiver(transfer_complete=True),
             enable_attention_dp=True,
             tp_size=2,
+            num_fetch_requests=4,
+            active_requests=reqs,
         )
-        batch = _make_scheduled_batch(num_gen_requests=3)
-        ex.dist.tp_allgather.return_value = [3, 1]
+        ex.dist.tp_allgather.return_value = [1, 1]
+        ex._is_benchmark_disagg_fill_complete(ScheduledRequests())
+        ex.dist.tp_allgather.assert_called_once_with(1)
 
-        ex._is_benchmark_disagg_fill_complete(batch)
-        ex.dist.tp_allgather.assert_called_once_with(3)
-
-    def test_allgather_excludes_dummy_requests(self):
-        """Dummy requests must not inflate the local count sent via allgather."""
+    def test_no_allgather_without_adp(self):
+        reqs = [_make_active_request() for _ in range(4)]
         ex = MockBenchmarkExecutor(
             benchmark_req_queues_size=4,
-            kv_cache_transceiver=Mock(),
-            enable_attention_dp=True,
-            tp_size=2,
+            kv_cache_transceiver=_make_transceiver(transfer_complete=True),
+            enable_attention_dp=False,
+            num_fetch_requests=4,
+            active_requests=reqs,
         )
-        batch = _make_scheduled_batch(num_gen_requests=2, num_dummy_requests=3)
-        ex.dist.tp_allgather.return_value = [2, 2]
-
-        ex._is_benchmark_disagg_fill_complete(batch)
-        ex.dist.tp_allgather.assert_called_once_with(2)
-
-    def test_logs_progress_on_rank_zero(self):
-        ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=8,
-            kv_cache_transceiver=Mock(),
-            enable_attention_dp=True,
-            tp_size=2,
-            num_fetch_requests=3,
-        )
-        batch = _make_scheduled_batch(num_gen_requests=2)
-        ex.dist.tp_allgather.return_value = [2, 1]
-
-        with patch("tensorrt_llm._torch.pyexecutor.py_executor.logger") as mock_logger:
-            ex._is_benchmark_disagg_fill_complete(batch)
-            mock_logger.debug.assert_called_once()
-            msg = mock_logger.debug.call_args[0][0]
-            assert "total_gen_count=3" in msg
-            assert "local=2" in msg
-
-    def test_no_log_on_non_zero_rank(self):
-        ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=8,
-            kv_cache_transceiver=Mock(),
-            enable_attention_dp=True,
-            tp_size=2,
-            rank=1,
-        )
-        batch = _make_scheduled_batch(num_gen_requests=1)
-        ex.dist.tp_allgather.return_value = [1, 0]
-
-        with patch("tensorrt_llm._torch.pyexecutor.py_executor.logger") as mock_logger:
-            ex._is_benchmark_disagg_fill_complete(batch)
-            mock_logger.debug.assert_not_called()
+        ex._is_benchmark_disagg_fill_complete(ScheduledRequests())
+        ex.dist.tp_allgather.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# ADP regression: mixed real + dummy generation requests
-# ---------------------------------------------------------------------------
+class TestFillCompleteADPRouterImbalance:
+    """Regression test for nvbug 6071070.
 
-
-class TestFillCompleteADPDummyExclusion:
-    """Verify that ADP dummy requests do not inflate the fill threshold.
-
-    In ADP, ``_pad_attention_dp_dummy_request`` injects dummy generation
-    requests on ranks with no active work.  These dummies must be excluded
-    from the ``total_gen_count`` so the ``can_forward`` gate only opens
-    after the required number of *real* requests complete KV transfer.
+    The old count-based predicate hung when ADP router produced ±1 skew
+    (e.g. 31×256 + 1×255 = 8191 < 8192). The new state-based predicate
+    must open when all requests are past transfer, regardless of per-rank
+    distribution.
     """
 
-    def test_dummies_do_not_trigger_threshold(self):
-        """8 dummies + 0 real must not satisfy a threshold of 4."""
+    def test_gate_opens_despite_fewer_requests_on_a_rank(self):
+        reqs = [_make_active_request() for _ in range(255)]
         ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=4,
-            kv_cache_transceiver=Mock(),
+            benchmark_req_queues_size=8192,
+            kv_cache_transceiver=_make_transceiver(transfer_complete=True),
             enable_attention_dp=True,
-            tp_size=2,
+            tp_size=32,
+            num_fetch_requests=8192,
+            active_requests=reqs,
         )
-        batch = _make_scheduled_batch(num_gen_requests=0, num_dummy_requests=8)
-        ex.dist.tp_allgather.return_value = [0, 0]
+        ex.dist.tp_allgather.return_value = [1] * 32
+        assert ex._is_benchmark_disagg_fill_complete(ScheduledRequests()) is True
 
-        assert ex._is_benchmark_disagg_fill_complete(batch) is False
-
-    def test_mixed_real_and_dummy_only_counts_real(self):
-        """2 real + 3 dummies on each rank: total real = 4, threshold = 4."""
+    def test_gate_blocked_when_overflow_requests_in_init(self):
+        reqs = [_make_active_request() for _ in range(250)]
+        reqs += [_make_active_request(in_init=True) for _ in range(6)]
         ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=4,
-            kv_cache_transceiver=Mock(),
+            benchmark_req_queues_size=8192,
+            kv_cache_transceiver=_make_transceiver(transfer_complete=True),
             enable_attention_dp=True,
-            tp_size=2,
+            tp_size=32,
+            num_fetch_requests=8192,
+            active_requests=reqs,
         )
-        batch = _make_scheduled_batch(num_gen_requests=2, num_dummy_requests=3)
-        ex.dist.tp_allgather.return_value = [2, 2]
-
-        assert ex._is_benchmark_disagg_fill_complete(batch) is True
-
-    def test_mixed_below_threshold(self):
-        """1 real + 5 dummies on each rank: total real = 2, threshold = 4."""
-        ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=4,
-            kv_cache_transceiver=Mock(),
-            enable_attention_dp=True,
-            tp_size=2,
-        )
-        batch = _make_scheduled_batch(num_gen_requests=1, num_dummy_requests=5)
-        ex.dist.tp_allgather.return_value = [1, 1]
-
-        assert ex._is_benchmark_disagg_fill_complete(batch) is False
-
-    def test_non_adp_dummies_excluded(self):
-        """Without ADP, dummies should also be excluded from the local count."""
-        ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=4,
-            kv_cache_transceiver=Mock(),
-            enable_attention_dp=False,
-        )
-        batch = _make_scheduled_batch(num_gen_requests=2, num_dummy_requests=5)
-
-        assert ex._is_benchmark_disagg_fill_complete(batch) is False
-
-    def test_non_adp_real_only_meets_threshold(self):
-        ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=4,
-            kv_cache_transceiver=Mock(),
-            enable_attention_dp=False,
-        )
-        batch = _make_scheduled_batch(num_gen_requests=4, num_dummy_requests=3)
-
-        assert ex._is_benchmark_disagg_fill_complete(batch) is True
+        ex.dist.tp_allgather.return_value = [0] + [1] * 31
+        assert ex._is_benchmark_disagg_fill_complete(ScheduledRequests()) is False
 
 
 # ---------------------------------------------------------------------------
@@ -316,12 +269,7 @@ class TestFillCompleteADPDummyExclusion:
 
 
 class TestCanForwardGating:
-    """Verify can_forward initialisation and state transitions.
-
-    The can_forward gate is shared by _executor_loop and
-    _executor_loop_overlap to defer the forward pass in benchmark
-    disagg mode until all requests are generation-ready.
-    """
+    """Verify can_forward initialisation and state transitions."""
 
     @pytest.mark.parametrize(
         "benchmark_size, transceiver, is_disagg, can_forward",
@@ -340,40 +288,6 @@ class TestCanForwardGating:
         assert ex.is_benchmark_disagg is is_disagg
         assert (not ex.is_benchmark_disagg) is can_forward
 
-    @pytest.mark.parametrize(
-        "num_gen_requests, expected_after_fill",
-        [
-            pytest.param(4, True, id="complete_fill"),
-            pytest.param(2, False, id="incomplete_fill"),
-        ],
-    )
-    def test_transition(self, num_gen_requests, expected_after_fill):
-        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
-        can_forward = not ex.is_benchmark_disagg
-        assert can_forward is False
-
-        batch = _make_scheduled_batch(num_gen_requests=num_gen_requests)
-        can_forward = ex._is_benchmark_disagg_fill_complete(batch)
-        assert can_forward is expected_after_fill
-
-    def test_can_forward_stays_true_once_set(self):
-        """can_forward is latching: once True it must not revert."""
-        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
-        can_forward = not ex.is_benchmark_disagg
-
-        batch_partial = _make_scheduled_batch(num_gen_requests=4)
-        can_forward = ex._is_benchmark_disagg_fill_complete(batch_partial)
-        assert can_forward is True
-
-        batch_empty = _make_scheduled_batch(num_gen_requests=0)
-        # After can_forward is True, the gate is never re-entered in the
-        # real loop (guarded by `if not can_forward`).  Verify that calling
-        # the helper again with an empty batch would return False, but
-        # can_forward itself is not mutated.
-        result = ex._is_benchmark_disagg_fill_complete(batch_empty)
-        assert result is False
-        assert can_forward is True  # local variable unchanged
-
 
 # ---------------------------------------------------------------------------
 # _check_benchmark_disagg_gate  (consolidated gate helper)
@@ -385,11 +299,16 @@ class TestCheckBenchmarkDisaggGate:
 
     @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
     def test_gate_opens_when_fill_complete(self, mock_time):
-        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
-        batch = _make_scheduled_batch(num_gen_requests=4)
+        reqs = [_make_active_request() for _ in range(4)]
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=_make_transceiver(transfer_complete=True),
+            num_fetch_requests=4,
+            active_requests=reqs,
+        )
         assert ex._benchmark_fill_phase_active is True
 
-        can_forward, should_retry = ex._check_benchmark_disagg_gate(batch, False)
+        can_forward, should_retry = ex._check_benchmark_disagg_gate(ScheduledRequests(), False)
         assert can_forward is True
         assert should_retry is False
         assert ex._benchmark_fill_phase_active is False
@@ -397,37 +316,39 @@ class TestCheckBenchmarkDisaggGate:
 
     @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
     def test_gate_retries_with_short_sleep_when_incomplete(self, mock_time):
-        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
-        batch = _make_scheduled_batch(num_gen_requests=1)
+        reqs = [_make_active_request(in_init=True)]
+        ex = MockBenchmarkExecutor(
+            benchmark_req_queues_size=4,
+            kv_cache_transceiver=_make_transceiver(transfer_complete=False),
+            num_fetch_requests=2,
+            active_requests=reqs,
+        )
 
-        can_forward, should_retry = ex._check_benchmark_disagg_gate(batch, False)
+        can_forward, should_retry = ex._check_benchmark_disagg_gate(ScheduledRequests(), False)
         assert can_forward is False
         assert should_retry is True
         mock_time.sleep.assert_called_once_with(0.1)
 
+    @pytest.mark.parametrize(
+        "is_warmup, can_forward_in",
+        [
+            pytest.param(True, False, id="warmup_bypasses_gate"),
+            pytest.param(False, True, id="already_forwarding_skips_check"),
+        ],
+    )
     @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
-    def test_warmup_bypasses_gate(self, mock_time):
-        """During warmup, the gate must not block even in benchmark disagg mode."""
+    def test_gate_no_op(self, mock_time, is_warmup, can_forward_in):
+        """Gate is a no-op during warmup or when can_forward is already True."""
         ex = MockBenchmarkExecutor(
             benchmark_req_queues_size=4,
-            kv_cache_transceiver=Mock(),
-            is_warmup=True,
+            kv_cache_transceiver=_make_transceiver(),
+            is_warmup=is_warmup,
         )
-        batch = _make_scheduled_batch(num_gen_requests=0)
 
-        can_forward, should_retry = ex._check_benchmark_disagg_gate(batch, False)
-        assert can_forward is False
-        assert should_retry is False
-        mock_time.sleep.assert_not_called()
-
-    @patch("tensorrt_llm._torch.pyexecutor.py_executor.time")
-    def test_already_forwarding_skips_check(self, mock_time):
-        """Once can_forward is True, the gate is a no-op."""
-        ex = MockBenchmarkExecutor(benchmark_req_queues_size=4, kv_cache_transceiver=Mock())
-        batch = _make_scheduled_batch(num_gen_requests=0)
-
-        can_forward, should_retry = ex._check_benchmark_disagg_gate(batch, True)
-        assert can_forward is True
+        can_forward, should_retry = ex._check_benchmark_disagg_gate(
+            ScheduledRequests(), can_forward_in
+        )
+        assert can_forward is can_forward_in
         assert should_retry is False
         mock_time.sleep.assert_not_called()
 
@@ -437,20 +358,9 @@ class TestCheckBenchmarkDisaggGate:
 # ---------------------------------------------------------------------------
 
 
-def _make_active_request(in_init: bool = False, in_transfer: bool = False) -> Mock:
-    """Create an active request stub for _pad_attention_dp_dummy_request."""
-    req = Mock()
-    req.is_disagg_generation_init_state = in_init
-    req.is_disagg_generation_transmission_in_progress = in_transfer
-    return req
-
-
 class MockPadDummyExecutor:
     """Stub mirroring the PyExecutor attributes used by
     ``_pad_attention_dp_dummy_request``.
-
-    Only the benchmark disagg early-return guard and the dummy-addition
-    branch are exercised; the rest is mocked out.
     """
 
     def __init__(
@@ -503,67 +413,44 @@ class MockPadDummyExecutor:
 class TestPadAttentionDpDummyBenchmarkDisagg:
     """Verify _pad_attention_dp_dummy_request skips dummy insertion correctly.
 
-    During the fill phase (_benchmark_fill_phase_active=True), dummies
-    are skipped because the can_forward gate prevents forward-pass
-    collectives and stuck dummies would permanently waste KV cache slots.
-
-    Once the fill phase ends (_benchmark_fill_phase_active=False), the
-    normal dummy add-forward-terminate lifecycle resumes to handle
-    taper-down (ranks emptying at different rates due to e.g. speculative
-    decoding acceptance variance).
+    During fill (_benchmark_fill_phase_active=True): skip.
+    After fill (_benchmark_fill_phase_active=False): normal lifecycle.
     """
 
-    def test_skips_during_fill_phase(self):
-        """During fill phase, skip dummies."""
+    @pytest.mark.parametrize(
+        "active_reqs",
+        [
+            pytest.param([], id="empty_rank"),
+            pytest.param(
+                [_make_active_request(in_init=True), _make_active_request(in_transfer=True)],
+                id="requests_in_transfer",
+            ),
+        ],
+    )
+    def test_skips_during_fill_phase(self, active_reqs):
         ex = MockPadDummyExecutor(
             is_benchmark_disagg=True,
             kv_cache_transceiver=Mock(),
-            active_requests=[],
-            expected_num_active_requests=1,
+            active_requests=active_reqs,
+            expected_num_active_requests=max(1, len(active_reqs) + 1),
         )
         ex._pad_attention_dp_dummy_request()
         ex.kv_cache_manager.add_dummy_requests.assert_not_called()
 
-    def test_skips_during_fill_even_with_requests_in_transfer(self):
-        """Fill phase: requests in INIT/transfer, still skip dummies."""
-        reqs = [_make_active_request(in_init=True), _make_active_request(in_transfer=True)]
+    @pytest.mark.parametrize(
+        "is_warmup, benchmark_fill_active, is_benchmark_disagg, reason",
+        [
+            pytest.param(False, False, True, "taper-down", id="after_fill_taper_down"),
+            pytest.param(True, True, True, "warmup", id="warmup_bypass"),
+            pytest.param(False, False, False, "non-benchmark", id="not_benchmark_disagg"),
+        ],
+    )
+    def test_allows_dummy(self, is_warmup, benchmark_fill_active, is_benchmark_disagg, reason):
         ex = MockPadDummyExecutor(
-            is_benchmark_disagg=True,
+            is_benchmark_disagg=is_benchmark_disagg,
+            benchmark_fill_phase_active=benchmark_fill_active,
+            is_warmup=is_warmup,
             kv_cache_transceiver=Mock(),
-            active_requests=reqs,
-            expected_num_active_requests=3,
-        )
-        ex._pad_attention_dp_dummy_request()
-        ex.kv_cache_manager.add_dummy_requests.assert_not_called()
-
-    def test_allows_dummy_after_fill_phase_taper_down(self):
-        """After fill phase, rank empties due to taper-down: allow dummy."""
-        ex = MockPadDummyExecutor(
-            is_benchmark_disagg=True,
-            benchmark_fill_phase_active=False,
-            kv_cache_transceiver=Mock(),
-            active_requests=[],
-            expected_num_active_requests=1,
-        )
-        ex._pad_attention_dp_dummy_request()
-        ex.kv_cache_manager.add_dummy_requests.assert_called_once()
-
-    def test_allows_dummy_during_warmup(self):
-        """Warmup must bypass the benchmark disagg guard."""
-        ex = MockPadDummyExecutor(
-            is_benchmark_disagg=True,
-            is_warmup=True,
-            kv_cache_transceiver=Mock(),
-            active_requests=[],
-            expected_num_active_requests=1,
-        )
-        ex._pad_attention_dp_dummy_request()
-        ex.kv_cache_manager.add_dummy_requests.assert_called_once()
-
-    def test_allows_dummy_when_not_benchmark_disagg(self):
-        """Non-benchmark or non-disagg mode: normal dummy insertion."""
-        ex = MockPadDummyExecutor(
-            is_benchmark_disagg=False,
             active_requests=[],
             expected_num_active_requests=1,
         )
@@ -571,8 +458,7 @@ class TestPadAttentionDpDummyBenchmarkDisagg:
         ex.kv_cache_manager.add_dummy_requests.assert_called_once()
 
     def test_no_dummy_needed_when_active_requests_ready(self):
-        """Rank has ready requests: needs_dummy condition is False."""
-        ready_req = _make_active_request(in_init=False, in_transfer=False)
+        ready_req = _make_active_request()
         ex = MockPadDummyExecutor(
             is_benchmark_disagg=True,
             benchmark_fill_phase_active=False,
@@ -584,7 +470,6 @@ class TestPadAttentionDpDummyBenchmarkDisagg:
         ex.kv_cache_manager.add_dummy_requests.assert_not_called()
 
     def test_skips_when_adp_disabled(self):
-        """_pad_attention_dp_dummy_request early-returns when ADP is off."""
         ex = MockPadDummyExecutor(
             is_benchmark_disagg=True,
             enable_attention_dp=False,
@@ -598,131 +483,11 @@ class TestPadAttentionDpDummyBenchmarkDisagg:
 # ---------------------------------------------------------------------------
 
 
-class TestIncrementalFillScenario:
-    """Simulate incremental request arrival when CTX has limited KV cache.
-
-    Setup: the CTX server can only send a few requests per iteration
-    (limited KV cache), while the GEN server has enough capacity for all
-    requests.  The GEN executor must cycle its main loop — fetching a
-    batch, servicing KV transfers, checking readiness — so the CTX
-    server can free KV cache and make progress incrementally.
-
-    These tests replay the outer-loop logic over multiple iterations
-    with controlled request arrival and KV-transfer completion to verify
-    the system converges without blocking.
-    """
-
-    TOTAL_REQUESTS = 8
-    CTX_CAPACITY = 2  # CTX can only release this many per iteration
-
-    def test_gen_side_processes_requests_incrementally(self):
-        ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=self.TOTAL_REQUESTS,
-            kv_cache_transceiver=Mock(),
-        )
-
-        fetched = 0
-        gen_ready = 0
-
-        def simulate_fetch():
-            nonlocal fetched
-            new = min(self.CTX_CAPACITY, self.TOTAL_REQUESTS - fetched)
-            fetched += new
-            ex.num_fetch_requests = fetched
-
-        def simulate_kv_transfer():
-            nonlocal gen_ready
-            gen_ready = fetched
-
-        can_forward = not ex.is_benchmark_disagg
-        assert can_forward is False
-
-        iterations = 0
-        MAX_ITER = 50
-
-        while not can_forward and iterations < MAX_ITER:
-            simulate_fetch()
-            simulate_kv_transfer()
-            batch = _make_scheduled_batch(num_gen_requests=gen_ready)
-            can_forward = ex._is_benchmark_disagg_fill_complete(batch)
-            iterations += 1
-
-        assert can_forward is True
-        assert fetched == self.TOTAL_REQUESTS
-        assert gen_ready == self.TOTAL_REQUESTS
-        assert iterations > 1, "Should take multiple iterations (not a single blocking call)"
-
-    def test_kv_transfer_lag_still_converges(self):
-        """KV transfers complete one iteration behind request fetching.
-
-        Iteration 1: fetch 2, gen_ready 0
-        Iteration 2: fetch 4, gen_ready 2  (transfers from iter 1 complete)
-        ...
-        This models the realistic case where KV transfer takes time.
-        """
-        ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=self.TOTAL_REQUESTS,
-            kv_cache_transceiver=Mock(),
-        )
-
-        fetched = 0
-        gen_ready = 0
-        prev_fetched = 0
-
-        can_forward = not ex.is_benchmark_disagg
-        iterations = 0
-        MAX_ITER = 50
-
-        while not can_forward and iterations < MAX_ITER:
-            gen_ready = prev_fetched
-            prev_fetched = fetched
-
-            new = min(self.CTX_CAPACITY, self.TOTAL_REQUESTS - fetched)
-            fetched += new
-            ex.num_fetch_requests = fetched
-
-            batch = _make_scheduled_batch(num_gen_requests=gen_ready)
-            can_forward = ex._is_benchmark_disagg_fill_complete(batch)
-            iterations += 1
-
-        assert can_forward is True
-        assert gen_ready >= self.TOTAL_REQUESTS
-        assert iterations > 2, "With transfer lag, should take more iterations than without"
-
-    def test_single_request_at_a_time(self):
-        """Worst case: CTX releases exactly 1 request per iteration."""
-        total = 4
-        ex = MockBenchmarkExecutor(
-            benchmark_req_queues_size=total,
-            kv_cache_transceiver=Mock(),
-        )
-
-        gen_ready = 0
-        can_forward = not ex.is_benchmark_disagg
-        iterations = 0
-
-        while not can_forward and iterations < 50:
-            gen_ready = min(gen_ready + 1, total)
-            ex.num_fetch_requests = gen_ready
-            batch = _make_scheduled_batch(num_gen_requests=gen_ready)
-            can_forward = ex._is_benchmark_disagg_fill_complete(batch)
-            iterations += 1
-
-        assert can_forward is True
-        assert iterations == total
-
-
 class TestPrepareAndScheduleBatchNoBlock:
     """_prepare_and_schedule_batch must not block on request fetching.
 
-    It should call _fetch_and_activate_new_requests exactly once per
-    invocation, regardless of benchmark_req_queues_size, so the outer
-    executor loop remains free to service KV transfers between iterations.
-
     NOTE: This test uses ``object.__new__(PyExecutor)`` to bypass __init__
-    and manually sets internal attributes.  This is inherently fragile —
-    if _prepare_and_schedule_batch gains new attribute references the test
-    will fail with AttributeError.  Keep the attribute list below in sync
+    and manually sets internal attributes.  Keep the attribute list in sync
     with the method's implementation.
     """
 
@@ -733,6 +498,7 @@ class TestPrepareAndScheduleBatchNoBlock:
         ex.benchmark_req_queues_size = 8
         ex.kv_cache_transceiver = Mock()
         ex.is_benchmark_disagg = True
+        ex._benchmark_fill_phase_active = True
         ex.enable_attention_dp = False
         ex.num_fetch_requests = 0
         ex.dist = Mock(rank=0, tp_size=1)
@@ -760,3 +526,364 @@ class TestPrepareAndScheduleBatchNoBlock:
         ex._prepare_and_schedule_batch()
 
         mock_fetch.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ADP router per-rank cap  (prevents overflow that caused nvbug 6071070)
+# ---------------------------------------------------------------------------
+
+_ROUTER_CLS_PATHS = [
+    pytest.param(
+        "tensorrt_llm._torch.pyexecutor.scheduler.adp_router.DefaultADPRouter",
+        id="DefaultADPRouter",
+    ),
+    pytest.param(
+        "tensorrt_llm._torch.pyexecutor.scheduler.adp_router.KVCacheAwareADPRouter",
+        id="KVCacheAwareADPRouter",
+    ),
+]
+
+
+def _make_router(cls_path: str, tp_size: int = 4):
+    """Instantiate a router from its dotted class path."""
+    import importlib
+
+    from tensorrt_llm._torch.pyexecutor.scheduler.adp_router import RankState
+
+    module_path, cls_name = cls_path.rsplit(".", 1)
+    mod = importlib.import_module(module_path)
+    RouterCls = getattr(mod, cls_name)
+
+    dist = Mock()
+    dist.tp_rank = 0
+    dist.tp_size = tp_size
+
+    extra_kwargs = {}
+    if cls_name == "KVCacheAwareADPRouter":
+        kv_mgr = Mock()
+        kv_mgr.probe_prefix_match_length = Mock(return_value=0)
+        extra_kwargs["kv_cache_manager"] = kv_mgr
+
+    router = RouterCls(dist=dist, **extra_kwargs)
+    return router, cls_name, RankState
+
+
+def _make_unscheduled_request_item(req_id=None):
+    """Create a mock RequestQueueItem with no py_scheduling_params."""
+    req_item = Mock()
+    req_item.request.py_scheduling_params = None
+    req_item.request.input_token_ids = [1, 2, 3]
+    req_item.id = req_id if req_id is not None else id(req_item)
+    return req_item
+
+
+def _prep_kv_router(router, cls_name, tp_size):
+    """Populate prefix-match data for KVCacheAwareADPRouter (no-op for Default)."""
+    if cls_name == "KVCacheAwareADPRouter":
+        router._all_ranks_prefix_matches = [{} for _ in range(tp_size)]
+
+
+class TestADPRouterPerRankCap:
+    """Verify that the ADP router never proposes expected_num_active_requests
+    above max_num_active_requests, even when rank imbalance or bulk arrival
+    would produce a larger ceiling-division result.
+
+    This is the root cause of nvbug 6071070: without the cap, the router
+    could set expected=257 for a rank with max_batch_size=256, causing the
+    heap to push requests onto ranks that can never schedule them.
+    """
+
+    @pytest.mark.parametrize("router_cls_path", _ROUTER_CLS_PATHS)
+    def test_expected_capped_at_max(self, router_cls_path):
+        """When one rank is heavily loaded, expected must not exceed max."""
+        from tensorrt_llm._torch.pyexecutor.scheduler.adp_router import RankState
+
+        router, cls_name, _ = _make_router(router_cls_path)
+        _prep_kv_router(router, cls_name, 4)
+
+        max_num_active = 4
+        all_rank_states = [
+            RankState(rank=0, num_active_requests=6, num_active_tokens=100),
+            RankState(rank=1, num_active_requests=0, num_active_tokens=0),
+            RankState(rank=2, num_active_requests=0, num_active_tokens=0),
+            RankState(rank=3, num_active_requests=0, num_active_tokens=0),
+        ]
+        requests = [_make_unscheduled_request_item(i) for i in range(3)]
+
+        result, expected = router.route_requests(all_rank_states, requests, max_num_active)
+
+        assert expected == max_num_active, (
+            f"expected_num_active_requests should be capped at {max_num_active}, got {expected}"
+        )
+        assert len(result[0]) == 0, "Overloaded rank 0 (already at 6) must not receive new requests"
+
+    @pytest.mark.parametrize("router_cls_path", _ROUTER_CLS_PATHS)
+    def test_no_rank_exceeds_max(self, router_cls_path):
+        """Near-capacity: no rank should be assigned beyond max_num_active."""
+        from tensorrt_llm._torch.pyexecutor.scheduler.adp_router import RankState
+
+        router, cls_name, _ = _make_router(router_cls_path)
+        _prep_kv_router(router, cls_name, 4)
+
+        max_num_active = 256
+        all_rank_states = [
+            RankState(rank=0, num_active_requests=255, num_active_tokens=1000),
+            RankState(rank=1, num_active_requests=254, num_active_tokens=900),
+            RankState(rank=2, num_active_requests=250, num_active_tokens=800),
+            RankState(rank=3, num_active_requests=253, num_active_tokens=950),
+        ]
+        requests = [_make_unscheduled_request_item(i) for i in range(10)]
+
+        result, expected = router.route_requests(all_rank_states, requests, max_num_active)
+
+        assert expected <= max_num_active
+        for rank, assigned in result.items():
+            initial = all_rank_states[rank].num_active_requests
+            total = initial + len(assigned)
+            assert total <= max_num_active, (
+                f"Rank {rank}: {initial} existing + {len(assigned)} new = {total}, "
+                f"exceeds cap {max_num_active}"
+            )
+
+    @pytest.mark.parametrize("router_cls_path", _ROUTER_CLS_PATHS)
+    def test_cap_not_applied_when_below_max(self, router_cls_path):
+        """When the natural expected is within max, cap has no effect."""
+        from tensorrt_llm._torch.pyexecutor.scheduler.adp_router import RankState
+
+        router, cls_name, _ = _make_router(router_cls_path)
+        _prep_kv_router(router, cls_name, 4)
+
+        max_num_active = 256
+        all_rank_states = [
+            RankState(rank=i, num_active_requests=0, num_active_tokens=0) for i in range(4)
+        ]
+        requests = [_make_unscheduled_request_item(i) for i in range(8)]
+
+        result, expected = router.route_requests(all_rank_states, requests, max_num_active)
+
+        assert expected == 2
+        total_assigned = sum(len(v) for v in result.values())
+        assert total_assigned == 8
+
+
+# ---------------------------------------------------------------------------
+# Fail-fast suppression during fill phase (prevents false-positive kills)
+# ---------------------------------------------------------------------------
+
+
+class TestFailFastSuppressedDuringFill:
+    """Verify that the PR #12206 fail-fast (Insufficient KV cache) does not
+    fire while the benchmark fill phase is active.
+
+    During fill, INIT requests are expected — they're waiting for KV
+    transfer, not for KV allocation.  The fail-fast should only fire after
+    the gate opens (fill phase complete), when stuck INIT requests genuinely
+    indicate insufficient KV cache.
+
+    This is the root cause of the CI failure on pipeline 49471411: the
+    fail-fast fired with "61 request(s) are waiting for KV cache allocation"
+    during the fill phase, before the gate had a chance to open.
+    """
+
+    def _make_executor(self, *, fill_phase_active, num_init_requests=3):
+        """Build a minimal PyExecutor stub for _prepare_and_schedule_batch."""
+        from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
+        ex = object.__new__(PyExecutor)
+        ex.benchmark_req_queues_size = 8
+        ex.kv_cache_transceiver = Mock()
+        ex.is_benchmark_disagg = True
+        ex._benchmark_fill_phase_active = fill_phase_active
+        ex.enable_attention_dp = False
+        ex.num_fetch_requests = 8
+        ex.dist = Mock(rank=0, tp_size=1)
+        ex.is_shutdown = False
+        ex._is_warmup = False
+        ex.enable_iter_perf_stats = False
+        ex.waiting_queue = []
+        ex.expected_num_active_requests = 0
+        ex.drafter = None
+        ex.inflight_req_ids = set()
+        ex.kv_connector_manager = None
+        ex.enable_partial_reuse_for_disagg = False
+
+        init_reqs = [_make_active_request(in_init=True) for _ in range(num_init_requests)]
+        ready_reqs = [_make_active_request() for _ in range(5)]
+        ex.active_requests = init_reqs + ready_reqs
+
+        ex._fetch_and_activate_new_requests = Mock(return_value=[])
+        ex._check_disagg_ctx_schedulable_status = Mock()
+        ex._check_disagg_gen_transfer_status = Mock()
+        ex._check_kv_transfer_timeout = Mock()
+        ex._check_disagg_ctx_cache_transfer_status = Mock()
+        ex._pad_attention_dp_dummy_request = Mock()
+        ex._prepare_disagg_gen_init = Mock()
+        ex._handle_errors = Mock()
+
+        scheduled = ScheduledRequests()
+        ex._schedule = Mock(return_value=(scheduled, [], 0))
+
+        return ex
+
+    def test_no_kill_during_fill_phase(self):
+        """During fill phase, stuck INIT requests must not trigger fail-fast."""
+        ex = self._make_executor(fill_phase_active=True)
+
+        result, _ = ex._prepare_and_schedule_batch()
+
+        assert result is not None, (
+            "Fail-fast should NOT fire during fill phase — "
+            "INIT requests are expected while KV transfers are in progress"
+        )
+
+    def test_kills_after_fill_phase(self):
+        """After fill phase completes, stuck INIT requests trigger fail-fast."""
+        ex = self._make_executor(fill_phase_active=False)
+
+        result, _ = ex._prepare_and_schedule_batch()
+
+        assert result is None, (
+            "Fail-fast SHOULD fire after fill phase — "
+            "stuck INIT requests indicate genuine KV insufficiency"
+        )
+
+    @pytest.mark.parametrize(
+        "fill_active, is_warmup, expected_alive",
+        [
+            pytest.param(True, False, True, id="fill_phase_suppresses"),
+            pytest.param(False, False, False, id="post_fill_kills"),
+            pytest.param(False, True, True, id="warmup_suppresses"),
+            pytest.param(True, True, True, id="both_suppress"),
+        ],
+    )
+    def test_suppression_matrix(self, fill_active, is_warmup, expected_alive):
+        """Parametrized test covering all (fill_phase, warmup) combinations."""
+        ex = self._make_executor(fill_phase_active=fill_active)
+        ex._is_warmup = is_warmup
+
+        result, _ = ex._prepare_and_schedule_batch()
+
+        if expected_alive:
+            assert result is not None, (
+                f"fill_active={fill_active}, warmup={is_warmup}: should NOT kill requests"
+            )
+        else:
+            assert result is None, (
+                f"fill_active={fill_active}, warmup={is_warmup}: "
+                "SHOULD kill requests (genuine KV insufficiency)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end fill phase reproducer
+# ---------------------------------------------------------------------------
+
+
+class TestFillPhaseEndToEnd:
+    """End-to-end simulation of the benchmark disagg fill lifecycle.
+
+    Reproduces the exact failure sequence from the CI pipeline:
+    1. All requests fetched (num_fetch_requests >= benchmark_req_queues_size)
+    2. KV cache full with transferred requests, some INIT requests remain
+    3. Scheduler can't fit INIT requests
+    4. Verify: fail-fast does NOT fire during fill phase
+    5. Transfers complete, gate opens, fill phase clears
+    6. Verify: fail-fast DOES fire if INIT requests remain after fill
+
+    This test catches all three bugs we found iteratively:
+    - Bug 1: Count-based gate unsatisfiable under ADP router skew
+    - Bug 2: Router overshooting max_batch_size
+    - Bug 3: Fail-fast firing during fill phase
+    """
+
+    TOTAL_REQUESTS = 8
+    MAX_BATCH_SIZE = 4
+    TP_SIZE = 2
+
+    def _make_executor(self):
+        from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
+        ex = object.__new__(PyExecutor)
+        ex.benchmark_req_queues_size = self.TOTAL_REQUESTS
+        ex.kv_cache_transceiver = _make_transceiver(transfer_complete=False)
+        ex.is_benchmark_disagg = True
+        ex._benchmark_fill_phase_active = True
+        ex.enable_attention_dp = True
+        ex.num_fetch_requests = 0
+        ex.dist = Mock(rank=0, tp_size=self.TP_SIZE)
+        ex.is_shutdown = False
+        ex._is_warmup = False
+        ex.enable_iter_perf_stats = False
+        ex.waiting_queue = []
+        ex.expected_num_active_requests = 0
+        ex.drafter = None
+        ex.inflight_req_ids = set()
+        ex.kv_connector_manager = None
+        ex.enable_partial_reuse_for_disagg = False
+        ex.active_requests = []
+
+        ex._fetch_and_activate_new_requests = Mock(return_value=[])
+        ex._check_disagg_ctx_schedulable_status = Mock()
+        ex._check_disagg_gen_transfer_status = Mock()
+        ex._check_kv_transfer_timeout = Mock()
+        ex._check_disagg_ctx_cache_transfer_status = Mock()
+        ex._pad_attention_dp_dummy_request = Mock()
+        ex._prepare_disagg_gen_init = Mock()
+        ex._handle_errors = Mock()
+
+        scheduled = ScheduledRequests()
+        ex._schedule = Mock(return_value=(scheduled, [], 0))
+
+        return ex
+
+    def test_full_lifecycle(self):
+        """Simulate the fill → gate-open → post-fill lifecycle."""
+        ex = self._make_executor()
+
+        # Phase 1: Fetching requests (gate should not open)
+        ex.num_fetch_requests = 4
+        batch = ScheduledRequests()
+        assert not ex._is_benchmark_disagg_fill_complete(batch), (
+            "Gate should not open: only 4/8 requests fetched"
+        )
+
+        # Phase 2: All fetched, some still in transfer
+        ex.num_fetch_requests = self.TOTAL_REQUESTS
+        init_reqs = [_make_active_request(in_init=True) for _ in range(3)]
+        ready_reqs = [_make_active_request() for _ in range(5)]
+        ex.active_requests = init_reqs + ready_reqs
+
+        ex.dist.tp_allgather = Mock(return_value=[0, 1])
+        assert not ex._is_benchmark_disagg_fill_complete(batch), (
+            "Gate should not open: 3 requests still in INIT"
+        )
+
+        # Phase 2b: Fail-fast must NOT fire during fill phase
+        result, _ = ex._prepare_and_schedule_batch()
+        assert result is not None, (
+            "Fail-fast must not kill requests during fill phase, "
+            "even though scheduler can't fit INIT requests"
+        )
+
+        # Phase 3: All transfers complete, gate opens
+        for req in init_reqs:
+            req.is_disagg_generation_init_state = False
+        ex.kv_cache_transceiver.check_gen_transfer_complete.return_value = True
+        ex.dist.tp_allgather = Mock(return_value=[1, 1])
+
+        assert ex._is_benchmark_disagg_fill_complete(batch), (
+            "Gate should open: all requests past transfer, transceiver complete"
+        )
+
+        # Phase 4: Gate opens, fill phase clears
+        ex._benchmark_fill_phase_active = False
+
+        # Phase 5: After fill, if new INIT requests appear, fail-fast fires
+        stuck_req = _make_active_request(in_init=True)
+        ex.active_requests = [stuck_req] + ready_reqs
+
+        result, _ = ex._prepare_and_schedule_batch()
+        assert result is None, (
+            "Fail-fast SHOULD fire after fill phase completes — "
+            "stuck INIT requests now indicate genuine KV insufficiency"
+        )

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -230,7 +230,7 @@ class TestFillCompleteADPRouterImbalance:
     """Regression test for nvbug 6071070.
 
     The old count-based predicate hung when ADP router produced ±1 skew
-    (e.g. 31×256 + 1×255 = 8191 < 8192). The new state-based predicate
+    (e.g. 31x256 + 1x255 = 8191 < 8192). The new state-based predicate
     must open when all requests are past transfer, regardless of per-rank
     distribution.
     """
@@ -720,7 +720,14 @@ class TestADPRouterPerRankCap:
 
     @pytest.mark.parametrize("router_cls_path", _ROUTER_CLS_PATHS)
     def test_cap_not_applied_when_below_max(self, router_cls_path):
-        """When the natural expected is within max, cap has no effect."""
+        """When the natural expected is within max, cap has no effect.
+
+        The natural value differs per router class: DefaultADPRouter computes
+        ceil(total/tp_size) directly, whereas KVCacheAwareADPRouter wraps it
+        with fair_share_multiplier (default 2.0) to allow more concentration
+        for cache affinity.  Both must land below max_num_active_requests so
+        that the hard cap is a no-op.
+        """
         from tensorrt_llm._torch.pyexecutor.scheduler.adp_router import RankState
 
         router, cls_name, _ = _make_router(router_cls_path)
@@ -734,7 +741,18 @@ class TestADPRouterPerRankCap:
 
         result, expected = router.route_requests(all_rank_states, requests, max_num_active)
 
-        assert expected == 2
+        if cls_name == "KVCacheAwareADPRouter":
+            # fair_share_multiplier defaults to 2.0, so natural value is
+            # ceil(2.0 * ceil(8/4)) = ceil(2.0 * 2) = 4.
+            expected_natural = 4
+        else:
+            # DefaultADPRouter natural value is ceil(8/4) = 2.
+            expected_natural = 2
+        assert expected == expected_natural, (
+            f"{cls_name}: natural expected was {expected_natural}, got {expected}"
+        )
+        # Hard cap must be a no-op here since natural value << max.
+        assert expected < max_num_active
         total_assigned = sum(len(v) for v in result.values())
         assert total_assigned == 8
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark disaggregation fill gate to determine readiness based on executor state rather than request counts, ensuring more accurate synchronization across distributed ranks.
  * Enhanced diagnostic logging to report transfer status and request state information.

* **Tests**
  * Updated and expanded test coverage for state-based readiness validation, including new regression tests for distributed training scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Summary

Fixes four ADP/NIXL regressions PR #12208 introduced when it removed the blocking fill loop, and corrects a long-latent KV oversubscription in the Kimi-2 8k1k perf-sanity test config that #12208's fill-phase changes exposed.

## Production fixes (2 commits)

PR #12208 replaced the blocking fill loop with a non-blocking gate to fix an MPI hard deadlock. The replacement was correct for MPI but introduced four ADP/NIXL-side regressions, all addressed here:

- **State-based fill gate** — count-based predicate is unsatisfiable under ADP per-rank rebalancing. Replaced with `(num_fetched ≥ queue_size) ∧ (no active req in INIT/TRANS) ∧ (no transceiver pending)`. Fires uniformly across ranks.
- **ADP router hard cap** at `max_num_active_requests` (= per-rank `max_batch_size`) on both `DefaultADPRouter` and `KVCacheAwareADPRouter` — composes with upstream's `fair_share_multiplier` loose cap. Fixes nvbug 6071070; without it, bulk admission can route past `max_batch_size` and leave excess requests stuck in `INIT`.
- **Fail-fast suppression during fill** — PR #12206's fail-fast was tripping on transient bulk-fetch state (some requests in INIT while others transfer). Resumes after the gate opens.
- **`tp_size`-per-iter admission throttle** in `_pop_from_waiting_queue` — restores the pre-#12208 conservative admission rate without reintroducing the blocking pattern. Scoped to non-warmup benchmark fill.

## Test config fix (1 commit): Kimi-2 GEN KV fraction `0.6 → 0.78`

### Memory math (B200/GB200, 184 GiB HBM)

|  | 0.6 (upstream) | 0.78 (this PR) |
|---|---|---|
| KV pool | 61.4 GiB | 79.8 GiB |
| KV tokens / rank | 1,875,008 | 2,437,504 |
| Required at `bs=256 × max_seq_len=9256` | 2,369,536 | (same) |
| Sequences fit / 256 | **203** ❌ | **263** ✅ |
| Headroom for transients | ~40 GiB | ~22 GiB |

At 0.6, only 203 of 256 max-batch sequences fit per rank — 53 are perpetually paused, costing ~21 % of decode throughput across the entire run. 0.78 is the floor that fits the workload while preserving the ~22 GiB needed for NIXL receive buffers, NCCL workspace, EPLB layer churn, and CUDA caching-allocator fragmentation.

### Why the test was passing before PR #12208

Same YAML, same oversubscription — but timing differed:

- **Pre-#12208:** count-based fetch loop completed in ~26 s; decode then ran for ~85–88 min under the chronic preemption; total wall landed just inside the test's 5400 s `DEFAULT_TIMEOUT` with 2–5 min of cluster-variance-dependent margin.
- **Post-#12208 (and this PR):** state-based fill flag remains active for ~84 min (tracks CTX prefill completion, which is the dominant cost when `concurrency = capacity`). The flag adds only ~50 s of `all_gather` overhead, but it ate the cluster-variance margin that had been hiding the oversubscription.

The test was always running on luck. Bumping to 0.78 makes it do what it claims (`bs=256` steady-state) instead of depending on the right side of a 2–5 min margin.

### Why this YAML change is bundled into this PR

The bump is a one-line test-config correctness fix that stands on its own — it would have been correct at any point in the test's lifetime. It belongs here because (a) the gate fixes are necessary but not sufficient for the Kimi-2 CI to reach green, and (b) the two changes share the same failure narrative.

## Test coverage

Production fixes are covered by `tests/unittest/_torch/executor/test_benchmark_disagg.py` (10 test classes, 28 tests, no GPU required):

| Production fix | Coverage |
|---|---|
| State-based fill gate | `TestFillCompleteStateBased` (4 tests, parameterized over the predicate's truth table), `TestFillCompleteADP` (3 tests, cross-rank `allgather`), `TestFillCompleteADPRouterImbalance` (2 tests, per-rank rebalancing edge cases), `TestCheckBenchmarkDisaggGate` (3 tests, wait-loop behavior), `TestCanForwardGating` (parameterized initial state) |
| ADP router hard cap | `TestADPRouterPerRankCap` (3 tests, parameterized over both `DefaultADPRouter` and `KVCacheAwareADPRouter`: cap applied at max, no rank exceeds, no-op below max) |
| Fail-fast suppression during fill | `TestFailFastSuppressedDuringFill` (3 tests: suppressed during fill, resumes after, full `(fill_active × is_warmup)` matrix) |
| `tp_size`-per-iter admission throttle | `TestBenchmarkFillAdmissionFlowControl` (2 tests, parameterized over `tp_size ∈ {1, 4, 32}`: cap applied during fill, full capacity used after) |
| Adjacent invariants | `TestPadAttentionDpDummyBenchmarkDisagg` (4 tests, dummy-request skip during fill), `TestPrepareAndScheduleBatchNoBlock` (1 test, fetch called once per iter) |
| End-to-end lifecycle | `TestFillPhaseEndToEnd::test_full_lifecycle` (admission-cap → KV-transfer-complete → gate-opens → normal admission, exercising both production code paths together) |

The Kimi-2 perf-sanity test has been verified separately: https://nvbugspro.nvidia.com/bug/6093911?commentNumber=9

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
