### PR TITLE
[Issue-13318][fix] Trim context chunks in _prepare_tp_inputs to prevent over-admission crash

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2237,6 +2237,74 @@ class PyTorchModelEngine(ModelEngine):
                 num_accepted_tokens_device, req_id_to_old_request,
                 resource_manager)
 
+        # Guard against scheduler over-admission (issue #13318).
+        #
+        # The MicroBatchScheduler admits a batch using a reuse-discounted
+        # token budget: for a last-chunk context request with `reusable > 0`
+        # it charges only `max(0, context_remaining - reusable)` tokens
+        # (see `_reuse_adjusted_compute` in scheduler/scheduler.py and the
+        # matching C++ logic). The forward pass below, however, extends
+        # `position_ids` by the full `context_chunk_size` per context request
+        # regardless of reuse (the reusable prefix still needs its position
+        # embeddings computed). When `max_num_tokens` is tight, this
+        # mismatch lets `len(position_ids)` overshoot `self.max_num_tokens`
+        # by up to `min(chunk_size, reusable)` per offending request, which
+        # trips the assertion a few lines below and kills the event loop
+        # thread (see issue #13318).
+        #
+        # Pre-compute the predicted `position_ids` growth using the same
+        # accounting the loops below will use, and shrink the trailing
+        # context chunk(s) to fit. `isLastContextChunk()` /
+        # `isFirstContextChunk()` are live-derived from
+        # `context_current_position`, `context_chunk_size`, and
+        # `prompt_len` — mutating `context_chunk_size` here automatically
+        # de-promotes a "last" chunk back to "middle" for this iteration,
+        # and the next scheduler tick picks up the remaining tokens via
+        # the normal chunked-prefill progression. KV cache allocated by
+        # `prepare_resources` for the original chunk size stays reserved
+        # and is reclaimed when the request eventually finishes.
+        if self.max_num_tokens is not None:
+            predicted_ctx_tokens = sum(
+                req.context_chunk_size
+                for req in scheduled_requests.context_requests)
+            # Each generation request extends `position_ids` by
+            # `1 + num_draft_tokens`. The gen loop below uses either
+            # `get_draft_token_length(req)` (extend path) or
+            # `self.runtime_draft_len` (plain gen / first-draft path), so
+            # take the larger of the two to stay conservative — a slight
+            # overestimate only causes us to trim a little earlier, never
+            # fails to catch a real overshoot.
+            predicted_gen_tokens = sum(
+                1 + max(get_draft_token_length(req), self.runtime_draft_len)
+                for req in scheduled_requests.generation_requests)
+            predicted_total = predicted_ctx_tokens + predicted_gen_tokens
+            if predicted_total > self.max_num_tokens:
+                overshoot = predicted_total - self.max_num_tokens
+                for req in reversed(scheduled_requests.context_requests):
+                    if overshoot <= 0:
+                        break
+                    if req.context_chunk_size <= 1:
+                        continue
+                    trim = min(overshoot, req.context_chunk_size - 1)
+                    new_size = req.context_chunk_size - trim
+                    logger.warning(
+                        "[issue-13318] Scheduler over-admitted by "
+                        "%d token(s); trimming context chunk for request "
+                        "%s: chunk_size %d -> %d",
+                        overshoot, req.py_request_id,
+                        req.context_chunk_size, new_size,
+                    )
+                    req.context_chunk_size = new_size
+                    overshoot -= trim
+                if overshoot > 0:
+                    # Could not trim enough (e.g. every chunk already at 1
+                    # and generation traffic alone exceeds max_num_tokens).
+                    # Let the assertion below fire so the condition stays
+                    # observable rather than silently corrupting state.
+                    logger.error(
+                        "[issue-13318] Residual overshoot of %d token(s) "
+                        "after trimming; assertion will fire.", overshoot)
+
         # if new_tensors_device exist, input_ids will only contain new context tokens
         input_ids = []  # per sequence
         sequence_lengths = []  # per sequence


### PR DESCRIPTION
## Summary

Fixes #13318. Adds a Python-side post-scheduler guard in `_prepare_tp_inputs` that pre-computes the predicted `position_ids` growth and trims the trailing context chunk(s) if the batch would overshoot `max_num_tokens`. Mitigates the event-loop-killing `assert total_num_tokens <= self.max_num_tokens` crash observed in production with `enable_chunked_prefill: true` + `enable_block_reuse: true`.

## Root cause (quoting the issue)

- `MicroBatchScheduler` (V1, C++) admits batches using a reuse-discounted token budget. For a last-chunk context request with `reusable > 0` it charges only `max(0, context_remaining - reusable)` tokens — see `_reuse_adjusted_compute` in `tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py:321` and its C++ counterpart.
- `_prepare_tp_inputs` (this file, around line 2276) extends `position_ids` by the **full** `context_chunk_size` per context request regardless of reuse: the reusable prefix's position embeddings still need to be computed in the forward pass.
- When `max_num_tokens` is tight, the admission-vs-forward mismatch lets `len(position_ids)` overshoot `max_num_tokens` by up to `min(chunk_size, reusable)` per offending request. The assertion at `model_engine.py:2678` fires, the event-loop thread dies, and the server hangs until `docker kill` + restart (issue #13318 has the full reproduction).

The admission math in `_reuse_adjusted_compute` (and its C++ twin) is still wrong after this fix — it subtracts reusable tokens that the forward pass has to process anyway. A proper root-cause fix should align the admission budget with the actual forward-pass cost. Until that lands, this guard keeps the event loop alive and lets the server degrade gracefully instead of crashing.

## What the fix does

At the top of `_prepare_tp_inputs` (before `input_ids = []`), after the `_apply_incremental_update` early-return:

1. Compute `predicted_ctx_tokens = sum(req.context_chunk_size for req in context_requests)` — exact match for what the context loop will extend onto `position_ids`.
2. Compute `predicted_gen_tokens = sum(1 + max(get_draft_token_length(req), self.runtime_draft_len) for req in generation_requests)` — conservative upper bound covering both extend-request and plain-gen / first-draft paths.
3. If `predicted_total > self.max_num_tokens`, iterate the context requests in reverse and shrink `req.context_chunk_size` until the overshoot is cleared (leaving each chunk at least 1 token).
4. If the overshoot cannot be fully cleared (pathological config), log an error and let the original assertion fire so the condition stays observable.

Why mutating `context_chunk_size` mid-pipeline is safe:

- `isLastContextChunk()` (`cpp/include/tensorrt_llm/batch_manager/llmRequest.h:1636`) is **live-derived** from `getContextCurrentPosition() + getContextChunkSize() == mPromptLen`, so shrinking the chunk automatically de-promotes a "last" chunk to a "middle" chunk for this iteration. The next scheduler tick picks up the remaining tokens through the normal chunked-prefill progression.
- `context_chunk_size` is a read/write property in the nanobind binding (`cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp:128`), mapped to `setContextChunkSize` which clamps to `getContextRemainingLength()` and rejects negatives.
- KV cache already reserved by `prepare_resources` for the original chunk size stays in place and is reclaimed when the request finishes.
- The cost is O(N_requests) per iteration and only fires when overshoot is detected.

## Relationship to PR #12806

PR #12806 fixes the analogous bug on `feat/bench_y`, which carries a Python-side `remaining_budget` re-check in `prepare_resources` that doesn't exist on `main`. The fix here applies the same intent ("pre-account committed forward-pass cost; shrink admissions to fit") but at the layer that exists on `main` — the pre-loop guard in `_prepare_tp_inputs`. Once the C++ admission math is aligned with forward-pass cost (or a Python-side pre-scheduler budget lands on `main`), this guard becomes a redundant backstop and can be removed.

## Test plan

- [ ] Run the reproduction from issue #13318 (Mistral-Nemo-12B replay at qps=7.0 with `max_num_tokens=4096`, `enable_chunked_prefill=true`, `enable_partial_reuse=true`, `enable_block_reuse=true`): verify no `AssertionError`, no event-loop hang, `[issue-13318] trimming context chunk` warnings appear in the server log, and traffic continues to be served.
- [ ] Verify `max_num_tokens=8192` baseline (clean across 10k+ requests per issue's matrix) is unchanged.
- [ ] Unit test: construct a `ScheduledRequests` batch whose summed `context_chunk_size + gen_tokens` exceeds a mocked `max_num_tokens`; assert the trailing `context_chunk_size` is reduced to fit and a warning is logged.
- [ ] No-regression check on non-reuse / non-chunked configs: the guard only activates when `predicted_total > max_num_tokens`, which should not happen under a correct scheduler, so steady-state behavior should be unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit



<!-- end of auto-generated comment: release notes by coderabbit.ai -->