### PR TITLE
[#13321][fix] AutoDeploy: stabilize piecewise CUDA graph outputs with multi_stream_moe

### DIFF
--- a/examples/auto_deploy/model_registry/configs/nano_v3.yaml
+++ b/examples/auto_deploy/model_registry/configs/nano_v3.yaml
@@ -52,3 +52,5 @@ transforms:
     enabled: true
   insert_cached_ssm_attention:
     backend: flashinfer_ssm
+  compile_model:
+    piecewise_enabled: true

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
@@ -26,7 +26,13 @@ from tensorrt_llm._torch.autotuner import autotune
 from ...utils.cuda_graph import CudaGraphWarmUpPhase
 from ...utils.logger import ad_logger
 from ..compiler import CompileBackendRegistry, CompilerBackend, GetArgsKwargsForBatchSize
-from ..piecewise_runner import ADPiecewiseRunner, DynamicOpWrapper, MetadataWrapper, OutputInfo
+from ..piecewise_runner import (
+    ADPiecewiseRunner,
+    DynamicOpWrapper,
+    MetadataWrapper,
+    MultiStreamWrapper,
+    OutputInfo,
+)
 from ..piecewise_utils import (
     SplitInfo,
     is_dynamic_cached_op,
@@ -34,6 +40,7 @@ from ..piecewise_utils import (
     needs_out_buffer,
     split_graph_at_dynamic_ops,
     submod_has_cuda_ops,
+    submod_has_stream_switch,
 )
 
 
@@ -436,6 +443,7 @@ class PiecewiseCapturedGraph(nn.Module):
         if runner_by_idx:
             fallback_runner = runner_by_idx[min(runner_by_idx)]
         num_metadata_wrapped = 0
+        num_multi_stream_wrapped = 0
         for idx in all_submod_indices:
             if idx in runner_by_idx:
                 current_static_runner = runner_by_idx[idx]
@@ -453,6 +461,16 @@ class PiecewiseCapturedGraph(nn.Module):
                         ad_logger.info(
                             "PiecewiseCapturedGraph: wrapped %s in "
                             "MetadataWrapper (stable output addresses)",
+                            submod_name,
+                        )
+                    elif submod_has_stream_switch(submod):
+                        wrapper = MultiStreamWrapper(submod)
+                        setattr(self.split_gm, submod_name, wrapper)
+                        num_multi_stream_wrapped += 1
+                        ad_logger.info(
+                            "PiecewiseCapturedGraph: wrapped %s in "
+                            "MultiStreamWrapper (self-allocated stable output "
+                            "buffer outside the graph pool)",
                             submod_name,
                         )
                     continue
@@ -482,12 +500,16 @@ class PiecewiseCapturedGraph(nn.Module):
 
         self._is_prepared = True
         num_dynamic_eager = (
-            len(self.split_info.dynamic_submod_indices) - num_wrapped_dynamic - num_metadata_wrapped
+            len(self.split_info.dynamic_submod_indices)
+            - num_wrapped_dynamic
+            - num_metadata_wrapped
+            - num_multi_stream_wrapped
         )
         ad_logger.info(
             f"PiecewiseCapturedGraph: prepared with {self.split_info.num_submodules} submodules "
             f"({num_wrapped_static} static runners, {num_skipped_static} trivial skipped, "
             f"{num_wrapped_dynamic} dynamic wrapped, {num_metadata_wrapped} metadata wrapped, "
+            f"{num_multi_stream_wrapped} multi-stream wrapped, "
             f"{num_dynamic_eager} dynamic eager), piecewise_num_tokens={self.piecewise_num_tokens}"
         )
 
@@ -592,18 +614,31 @@ class PiecewiseCapturedGraph(nn.Module):
                 {k: (v[0].shape, f"dyn_dim={v[1]}") for k, v in self._static_input_buffers.items()},
             )
 
-    def _copy_to_static_buffers(self, kwargs: Dict[str, Any]) -> None:
-        """Copy kwargs into pre-allocated static buffers for address stability."""
+    def _copy_to_static_buffers(self, kwargs: Dict[str, Any], bucket: Optional[int] = None) -> None:
+        """Copy kwargs into pre-allocated static buffers for address stability.
+
+        When ``bucket`` is provided (piecewise path), each buffer view is
+        narrowed to the bucket size — not the actual request size — so that
+        eager multi-stream submodules see tensors consistent in shape with
+        the outputs produced by captured graphs (which were captured at the
+        bucket size).  The tail beyond the actual request size is zeroed so
+        that padding positions contain predictable data.
+        """
         for key, (buf, dyn_dim) in self._static_input_buffers.items():
             src = kwargs.get(key)
-            if src is not None and isinstance(src, torch.Tensor):
-                if dyn_dim is None:
-                    buf.copy_(src)
-                    kwargs[key] = buf
-                else:
-                    buf_view = buf.narrow(dyn_dim, 0, src.shape[dyn_dim])
-                    buf_view.copy_(src)
-                    kwargs[key] = buf_view
+            if src is None or not isinstance(src, torch.Tensor):
+                continue
+            if dyn_dim is None:
+                buf.copy_(src)
+                kwargs[key] = buf
+                continue
+            actual_size = src.shape[dyn_dim]
+            view_size = bucket if bucket is not None and bucket >= actual_size else actual_size
+            buf_view = buf.narrow(dyn_dim, 0, view_size)
+            buf_view.narrow(dyn_dim, 0, actual_size).copy_(src)
+            if view_size > actual_size:
+                buf_view.narrow(dyn_dim, actual_size, view_size - actual_size).zero_()
+            kwargs[key] = buf_view
 
     def warmup_and_capture(
         self,
@@ -684,7 +719,10 @@ class PiecewiseCapturedGraph(nn.Module):
     def forward(self, *args, num_tokens: Optional[int] = None, **kwargs) -> Any:
         """Forward pass: static segments replay graphs, dynamic segments run eagerly."""
         if self.split_gm is not None:
-            self._copy_to_static_buffers(kwargs)
+            # Narrow static-input-buffer views to the bucket size (not the
+            # actual request size) so eager multi-stream submodules see
+            # shapes consistent with captured-graph outputs.
+            self._copy_to_static_buffers(kwargs, bucket=num_tokens)
             ADPiecewiseRunner.set_current_num_tokens(num_tokens)
             try:
                 result = self.split_gm(*args, **kwargs)

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Compile backend with cudagraph.
 
 1. Monolithic CUDA graph: captures entire model as one graph for decode-only.
@@ -633,7 +647,17 @@ class PiecewiseCapturedGraph(nn.Module):
                 kwargs[key] = buf
                 continue
             actual_size = src.shape[dyn_dim]
-            view_size = bucket if bucket is not None and bucket >= actual_size else actual_size
+            if bucket is not None:
+                assert bucket >= actual_size, (
+                    f"_copy_to_static_buffers: bucket ({bucket}) must be >= actual "
+                    f"dynamic-dim size ({actual_size}) for kwarg '{key}' — upstream "
+                    f"bucket selection is inconsistent with the request shape"
+                )
+                assert bucket <= buf.shape[dyn_dim], (
+                    f"_copy_to_static_buffers: bucket ({bucket}) exceeds static "
+                    f"buffer size ({buf.shape[dyn_dim]}) for kwarg '{key}'"
+                )
+            view_size = bucket if bucket is not None else actual_size
             buf_view = buf.narrow(dyn_dim, 0, view_size)
             buf_view.narrow(dyn_dim, 0, actual_size).copy_(src)
             if view_size > actual_size:

--- a/tensorrt_llm/_torch/auto_deploy/compile/piecewise_runner.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/piecewise_runner.py
@@ -467,3 +467,104 @@ class DynamicOpWrapper(nn.Module):
             )
             kwargs["out"] = out_buf
         return self.submodule(*args, **kwargs)
+
+
+class MultiStreamWrapper(nn.Module):
+    """Wraps a multi-stream partition to give its output(s) stable addresses.
+
+    Multi-stream partitions (those containing ``begin_aux_stream_passthrough``
+    and friends) are reclassified from static to dynamic because they rely
+    on a host-side ``caller_stream.synchronize()`` that cannot be called
+    during CUDA graph capture.  They therefore run eagerly between captured
+    static segments.
+
+    Their output tensors, however, feed directly into the *next* static
+    segment's captured graph.  The caching allocator hands out a fresh
+    address for each eager allocation, so the next segment replays against
+    a stale pointer and produces wrong outputs (observed as
+    ``ADPiecewiseRunner ADDRESS MISMATCH`` errors).
+
+    Fix: the wrapper holds its own per-bucket stable buffer allocated from
+    the default caching allocator (outside any graph pool).  The buffer is
+    strong-ref'd by the wrapper, so its address never moves.  On each call
+    the wrapper copies the freshly-computed eager output into this buffer
+    and returns the buffer; the following static segment's captured graph
+    therefore replays against a fixed address.
+
+    Why not the preceding runner's graph pool (as ``DynamicOpWrapper``
+    does)?  The graph pool aggressively recycles allocations whose Python
+    strong refs drop after the runner's ``forward`` returns.  With larger
+    partitions (e.g. Qwen3.5's MoE-plus-next-layer-RoPE MS regions), the
+    pool reuses those addresses for later captures, corrupting the MS
+    output and producing asynchronous ``illegal memory access`` errors.
+    Allocating outside the pool avoids the recycling race entirely.
+
+    Cost: one persistent buffer per (wrapper × bucket) in the caching
+    allocator.  Copy cost is one ``cudaMemcpyAsync`` per layer — negligible
+    next to the MoE compute — and runs on the main stream since
+    ``end_aux_stream_passthrough`` has already restored the caller stream.
+    """
+
+    def __init__(self, submodule: nn.Module):
+        super().__init__()
+        self.submodule = submodule
+        # Keyed by num_tokens bucket; value is a Tensor or a list of
+        # (Tensor-or-None) mirroring the submodule's output container.
+        self._stable_bufs: Dict[int, Any] = {}
+
+    def forward(self, *args, **kwargs) -> Any:
+        result = self.submodule(*args, **kwargs)
+
+        phase = ADPiecewiseRunner._current_phase
+        if phase == "warmup":
+            return result
+
+        nt = ADPiecewiseRunner._current_num_tokens
+        if nt is None:
+            return result
+
+        stable = self._stable_bufs.get(nt)
+        if stable is None:
+            stable = self._alloc_stable(result)
+            if stable is None:
+                return result
+            self._stable_bufs[nt] = stable
+
+        return _copy_into_stable(result, stable)
+
+    @staticmethod
+    def _alloc_stable(result: Any) -> Any:
+        if isinstance(result, torch.Tensor):
+            return torch.empty_like(result)
+        if isinstance(result, (tuple, list)):
+            return [torch.empty_like(r) if isinstance(r, torch.Tensor) else None for r in result]
+        return None
+
+
+def _copy_into_stable(result: Any, stable: Any) -> Any:
+    """Copy ``result`` into the stable buffer(s) and return the stable structure.
+
+    Mirrors ``result``'s container type (Tensor/tuple/list).  Non-tensor
+    items in a tuple/list are passed through unchanged.
+    """
+    if isinstance(result, torch.Tensor):
+        if not isinstance(stable, torch.Tensor):
+            return result
+        if result.data_ptr() != stable.data_ptr():
+            stable.copy_(result)
+        return stable
+
+    if isinstance(result, (tuple, list)):
+        if not isinstance(stable, list) or len(stable) != len(result):
+            return result
+        merged = []
+        for r, s in zip(result, stable):
+            if isinstance(r, torch.Tensor) and isinstance(s, torch.Tensor):
+                if r.data_ptr() != s.data_ptr():
+                    s.copy_(r)
+                merged.append(s)
+            else:
+                merged.append(r)
+        return type(result)(merged) if isinstance(result, tuple) else merged
+
+    return result

--- a/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
@@ -252,7 +252,7 @@ def is_metadata_prep(submod: nn.Module) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _submod_has_stream_switch(submod: GraphModule) -> bool:
+def submod_has_stream_switch(submod: GraphModule) -> bool:
     """Return True if *submod* contains a multi-stream passthrough function."""
     for node in submod.graph.nodes:
         if node.op == "call_function":
@@ -260,6 +260,10 @@ def _submod_has_stream_switch(submod: GraphModule) -> bool:
             if func_name in _STREAM_SWITCH_FUNCTION_NAMES:
                 return True
     return False
+
+
+# Backwards-compatible private alias (used within this module below).
+_submod_has_stream_switch = submod_has_stream_switch
 
 
 @dataclass

--- a/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Utilities for piecewise CUDA graph: dynamic op registry, classification, and graph splitting.
 
 This module provides the logic to:

--- a/tests/unittest/auto_deploy/singlegpu/compile/test_captured_graph.py
+++ b/tests/unittest/auto_deploy/singlegpu/compile/test_captured_graph.py
@@ -18,14 +18,22 @@ from tensorrt_llm._torch.auto_deploy.compile.backends.torch_cudagraph import (
     PiecewiseCapturedGraph,
     _args_kwargs_flatten_spec,
 )
-from tensorrt_llm._torch.auto_deploy.compile.piecewise_runner import ADPiecewiseRunner
-from tensorrt_llm._torch.auto_deploy.compile.piecewise_utils import submod_has_cuda_ops
+from tensorrt_llm._torch.auto_deploy.compile.piecewise_runner import (
+    ADPiecewiseRunner,
+    MultiStreamWrapper,
+)
+from tensorrt_llm._torch.auto_deploy.compile.piecewise_utils import SplitInfo, submod_has_cuda_ops
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.shim.ad_executor import _round_up_to_closest
 from tensorrt_llm._torch.auto_deploy.transform.library.compile_model import (
     CompileModel,
     _generate_default_piecewise_num_tokens,
+)
+from tensorrt_llm._torch.auto_deploy.utils.multi_stream_utils import (
+    begin_aux_stream_passthrough,
+    cuda_stream_manager,
+    end_aux_stream_passthrough,
 )
 
 
@@ -580,6 +588,59 @@ class TestPiecewiseCapturedGraphStaticInputBuffers:
         assert copied is static_buffer
         assert torch.equal(copied, src)
 
+    def test_copy_to_static_buffers_bucket_narrow_zeros_tail(self):
+        """Piecewise path: narrow to bucket size (not src size), tail zeroed."""
+        pcg = PiecewiseCapturedGraph(nn.Linear(4, 4), piecewise_num_tokens=[64])
+        buf = torch.full((1, 16, 4), fill_value=-1.0)
+        pcg._static_input_buffers["x"] = (buf, 1)
+
+        src = torch.ones(1, 5, 4)
+        kwargs = {"x": src}
+        pcg._copy_to_static_buffers(kwargs, bucket=8)
+
+        view = kwargs["x"]
+        assert view.shape == (1, 8, 4)
+        # First 5 positions == src data
+        assert torch.equal(view[:, :5, :], src)
+        # Tail [5:8] must be zeroed
+        assert torch.all(view[:, 5:8, :] == 0)
+        # Untouched region [8:16] keeps its initial sentinel
+        assert torch.all(buf[:, 8:16, :] == -1)
+
+    def test_copy_to_static_buffers_bucket_equals_actual(self):
+        """When bucket == actual, no tail-zero is needed."""
+        pcg = PiecewiseCapturedGraph(nn.Linear(4, 4), piecewise_num_tokens=[64])
+        buf = torch.full((1, 16, 4), fill_value=-1.0)
+        pcg._static_input_buffers["x"] = (buf, 1)
+
+        src = torch.ones(1, 8, 4)
+        kwargs = {"x": src}
+        pcg._copy_to_static_buffers(kwargs, bucket=8)
+
+        view = kwargs["x"]
+        assert view.shape == (1, 8, 4)
+        assert torch.equal(view, src)
+        # Nothing else touched
+        assert torch.all(buf[:, 8:16, :] == -1)
+
+    def test_copy_to_static_buffers_bucket_smaller_than_actual_asserts(self):
+        """Fail-fast: caller selected a bucket that can't fit the request."""
+        pcg = PiecewiseCapturedGraph(nn.Linear(4, 4), piecewise_num_tokens=[64])
+        pcg._static_input_buffers["x"] = (torch.zeros(1, 16, 4), 1)
+
+        src = torch.ones(1, 10, 4)
+        with pytest.raises(AssertionError, match="bucket .* must be >= actual"):
+            pcg._copy_to_static_buffers({"x": src}, bucket=4)
+
+    def test_copy_to_static_buffers_bucket_exceeds_buf_asserts(self):
+        """Fail-fast: caller picked a bucket larger than the allocated buffer."""
+        pcg = PiecewiseCapturedGraph(nn.Linear(4, 4), piecewise_num_tokens=[64])
+        pcg._static_input_buffers["x"] = (torch.zeros(1, 16, 4), 1)
+
+        src = torch.ones(1, 4, 4)
+        with pytest.raises(AssertionError, match="bucket .* exceeds static buffer size"):
+            pcg._copy_to_static_buffers({"x": src}, bucket=32)
+
 
 # ============================================================================
 # Tests for _generate_default_piecewise_num_tokens (compile_model.py)
@@ -808,3 +869,158 @@ class TestCompileModelGraphModuleTargetCollection:
                 backend=backend,
                 piecewise_enabled=True,
             )
+
+
+# ============================================================================
+# Smoke test: multi-stream passthrough nodes inside a piecewise split must be
+# wrapped by MultiStreamWrapper (and not by DynamicOpWrapper / left unwrapped).
+# ============================================================================
+
+
+def _build_ms_static_submod():
+    """Build a GraphModule whose body contains multi-stream passthrough calls.
+
+    Mirrors the shape of a static partition produced by the
+    ``multi_stream_moe`` transform: ``begin_aux -> compute -> end_aux``.
+    The passthrough nodes are added as ``call_function`` references so FX
+    recognises them without actually executing them at trace time (they
+    require a live CUDA stream manager which is unavailable on CPU hosts).
+    """
+    root = nn.Module()
+    root.add_module("lin", nn.Linear(4, 4))
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    y = g.call_function(begin_aux_stream_passthrough, args=(x,))
+    y = g.call_module("lin", args=(y,))
+    out = g.call_function(end_aux_stream_passthrough, args=(y,))
+    g.output(out)
+    return torch.fx.GraphModule(root, g)
+
+
+def _build_plain_static_submod():
+    """A fully static partition: just a linear."""
+    root = nn.Module()
+    root.add_module("lin", nn.Linear(4, 4))
+    g = torch.fx.Graph()
+    x = g.placeholder("x")
+    out = g.call_module("lin", args=(x,))
+    g.output(out)
+    return torch.fx.GraphModule(root, g)
+
+
+class TestPiecewiseCapturedGraphMultiStreamWiring:
+    """Smoke test for the prepare() wiring of multi-stream partitions."""
+
+    def _build_split_gm(self, ms_submod, plain_submod):
+        """Assemble a split_gm with a plain + stream-switch partition pair.
+
+        Layout is ``submod_0 (plain static) -> submod_1
+        (static-with-stream-switch)`` — matching what
+        ``split_graph_at_dynamic_ops`` returns for a graph whose first
+        partition is an ordinary static compute and whose second partition
+        contains multi-stream passthroughs.
+        """
+        parent = nn.Module()
+        parent.add_module("submod_0", plain_submod)
+        parent.add_module("submod_1", ms_submod)
+
+        # Parent FX graph just chains the two submods.
+        g = torch.fx.Graph()
+        x = g.placeholder("x")
+        call0 = g.call_module("submod_0", args=(x,))
+        call1 = g.call_module("submod_1", args=(call0,))
+        g.output(call1)
+        return torch.fx.GraphModule(parent, g)
+
+    def test_prepare_wraps_stream_switch_submod_in_multi_stream_wrapper(self, monkeypatch):
+        """Stream-switch partitions become MultiStreamWrapper after prepare().
+
+        The plain partition becomes an ADPiecewiseRunner.
+        """
+        ms_submod = _build_ms_static_submod()
+        plain_submod = _build_plain_static_submod()
+        split_gm = self._build_split_gm(ms_submod, plain_submod)
+
+        # Stand in for split_graph_at_dynamic_ops: declare submod_1 (the one
+        # containing the passthroughs) as reclassified-to-dynamic, and keep
+        # submod_0 static.
+        fake_info = SplitInfo(
+            split_gm=split_gm,
+            num_submodules=2,
+            static_submod_indices=[0],
+            dynamic_submod_indices=[1],
+        )
+        monkeypatch.setattr(
+            "tensorrt_llm._torch.auto_deploy.compile.backends.torch_cudagraph."
+            "split_graph_at_dynamic_ops",
+            lambda _gm: fake_info,
+        )
+
+        # Wrap the split_gm in a parent GraphModule so isinstance(GraphModule)
+        # check in prepare() passes.
+        pcg = PiecewiseCapturedGraph(split_gm, piecewise_num_tokens=[8, 16])
+        pcg.prepare()
+
+        assert isinstance(pcg.split_gm.submod_0, ADPiecewiseRunner)
+        assert isinstance(pcg.split_gm.submod_1, MultiStreamWrapper)
+        # The MS wrapper was counted in prepare's summary path and did not
+        # hijack the DynamicOpWrapper/metadata paths.
+        assert 1 not in pcg._wrapped_dynamic_indices  # MS wrappers don't need shape discovery
+
+    def test_multi_stream_wrapper_stable_address_in_prepare_flow(self, monkeypatch):
+        """MS wrapper output address stays fixed across replays.
+
+        Drives a prepare()-produced ``MultiStreamWrapper`` through the
+        three ``ADPiecewiseRunner`` phases (warmup/capture/replay) and
+        asserts every replay returns a tensor at the same ``data_ptr`` —
+        the invariant the piecewise captured graph relies on.
+        """
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA required for MultiStreamWrapper stable-address check")
+
+        # The wrapped submodule calls begin_aux / end_aux which consult the
+        # CUDA stream manager — register the current device so the singleton
+        # has a main/aux event pair for it.
+        cuda_stream_manager.add_device(torch.cuda.current_device())
+
+        ms_submod = _build_ms_static_submod().cuda()
+        plain_submod = _build_plain_static_submod().cuda()
+        split_gm = self._build_split_gm(ms_submod, plain_submod).cuda()
+
+        fake_info = SplitInfo(
+            split_gm=split_gm,
+            num_submodules=2,
+            static_submod_indices=[0],
+            dynamic_submod_indices=[1],
+        )
+        monkeypatch.setattr(
+            "tensorrt_llm._torch.auto_deploy.compile.backends.torch_cudagraph."
+            "split_graph_at_dynamic_ops",
+            lambda _gm: fake_info,
+        )
+
+        pcg = PiecewiseCapturedGraph(split_gm, piecewise_num_tokens=[8])
+        pcg.prepare()
+
+        ms_wrapper = pcg.split_gm.submod_1
+        assert isinstance(ms_wrapper, MultiStreamWrapper)
+
+        # Drive the wrapper directly, matching how split_gm would call it
+        # during warmup -> capture -> replay.
+        ADPiecewiseRunner.set_current_num_tokens(8)
+        try:
+            ADPiecewiseRunner.set_current_phase("warmup")
+            ms_wrapper(torch.randn(8, 4, device="cuda"))
+            # Warmup must not allocate a stable buffer yet.
+            assert ms_wrapper._stable_bufs == {}
+
+            ADPiecewiseRunner.set_current_phase("capture")
+            out_capture = ms_wrapper(torch.randn(8, 4, device="cuda"))
+            ptr = out_capture.data_ptr()
+
+            ADPiecewiseRunner.set_current_phase("replay")
+            for _ in range(5):
+                assert ms_wrapper(torch.randn(8, 4, device="cuda")).data_ptr() == ptr
+        finally:
+            ADPiecewiseRunner.set_current_num_tokens(None)
+            ADPiecewiseRunner.set_current_phase("replay")

--- a/tests/unittest/auto_deploy/singlegpu/compile/test_piecewise_runner.py
+++ b/tests/unittest/auto_deploy/singlegpu/compile/test_piecewise_runner.py
@@ -20,8 +20,10 @@ import torch.nn as nn
 
 from tensorrt_llm._torch.auto_deploy.compile.piecewise_runner import (
     ADPiecewiseRunner,
+    MultiStreamWrapper,
     OutputInfo,
     SegmentEntry,
+    _copy_into_stable,
 )
 
 # ============================================================================
@@ -308,3 +310,210 @@ class TestADPiecewiseRunnerFullCycle:
             ADPiecewiseRunner.set_current_phase("capture")
             runner(x)
             assert 8 in runner.entries
+
+
+# ============================================================================
+# _copy_into_stable helper tests (container-agnostic copy used by MultiStreamWrapper)
+# ============================================================================
+
+
+class TestCopyIntoStable:
+    def test_single_tensor_copy_returns_stable(self):
+        result = torch.randn(4, 8)
+        stable = torch.empty_like(result)
+        out = _copy_into_stable(result, stable)
+        assert out is stable
+        assert torch.equal(out, result)
+
+    def test_single_tensor_same_identity_is_noop(self):
+        """When result already IS the stable buffer, no self-copy is performed."""
+        buf = torch.randn(4, 8)
+        out = _copy_into_stable(buf, buf)
+        assert out is buf
+
+    def test_tuple_of_tensors(self):
+        r = (torch.randn(3), torch.randn(2, 2))
+        s = [torch.empty_like(t) for t in r]
+        out = _copy_into_stable(r, s)
+        assert isinstance(out, tuple)
+        assert out[0] is s[0] and out[1] is s[1]
+        assert torch.equal(out[0], r[0])
+        assert torch.equal(out[1], r[1])
+
+    def test_list_of_tensors(self):
+        r = [torch.randn(3), torch.randn(2, 2)]
+        s = [torch.empty_like(t) for t in r]
+        out = _copy_into_stable(r, s)
+        assert isinstance(out, list)
+        assert out[0] is s[0] and out[1] is s[1]
+
+    def test_tuple_with_none_passthrough(self):
+        """Non-tensor entries (e.g. None) round-trip unchanged."""
+        r = (torch.randn(3), None, torch.randn(4))
+        s = [torch.empty_like(r[0]), None, torch.empty_like(r[2])]
+        out = _copy_into_stable(r, s)
+        assert isinstance(out, tuple)
+        assert out[0] is s[0]
+        assert out[1] is None
+        assert out[2] is s[2]
+
+    def test_length_mismatch_returns_result(self):
+        """Defensive path: if the stable container doesn't match, fall back to result."""
+        r = (torch.randn(3), torch.randn(4))
+        s = [torch.empty_like(r[0])]  # wrong length
+        out = _copy_into_stable(r, s)
+        assert out is r
+
+
+# ============================================================================
+# MultiStreamWrapper tests
+# ============================================================================
+
+
+class _DummyMS(nn.Module):
+    """Toy submodule that mimics a multi-stream MoE region.
+
+    Returns a fresh tensor each call so callers can observe address drift.
+    """
+
+    def __init__(self, shape):
+        super().__init__()
+        self.shape = shape
+        self.device = torch.device("cuda")
+
+    def forward(self, x):
+        # Produce a fresh tensor whose content depends on x so repeated calls
+        # return different data. Allocation is via regular caching allocator,
+        # so its pointer is not address-stable across calls.
+        return torch.full(self.shape, float(x.sum().item()), device=self.device)
+
+
+class _DummyMSTuple(nn.Module):
+    """Tuple-output variant: returns (tensor, None, tensor)."""
+
+    def __init__(self, shape_a, shape_b):
+        super().__init__()
+        self.shape_a = shape_a
+        self.shape_b = shape_b
+        self.device = torch.device("cuda")
+
+    def forward(self, x):
+        s = float(x.sum().item())
+        return (
+            torch.full(self.shape_a, s, device=self.device),
+            None,
+            torch.full(self.shape_b, s + 1, device=self.device),
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="MultiStreamWrapper tests need CUDA")
+class TestMultiStreamWrapper:
+    def setup_method(self):
+        ADPiecewiseRunner._current_num_tokens = None
+        ADPiecewiseRunner._current_phase = "replay"
+
+    def test_warmup_returns_raw_result_without_allocating(self):
+        """During warmup, the wrapper forwards through the submod unchanged."""
+        wrapper = MultiStreamWrapper(_DummyMS((4, 8))).cuda()
+        ADPiecewiseRunner.set_current_phase("warmup")
+        ADPiecewiseRunner.set_current_num_tokens(4)
+
+        out = wrapper(torch.ones(4, device="cuda"))
+        assert out.shape == (4, 8)
+        assert wrapper._stable_bufs == {}
+
+    def test_none_num_tokens_returns_raw_result(self):
+        """When no bucket is active, the wrapper is a pass-through."""
+        wrapper = MultiStreamWrapper(_DummyMS((4, 8))).cuda()
+        ADPiecewiseRunner.set_current_phase("replay")
+        ADPiecewiseRunner.set_current_num_tokens(None)
+
+        out = wrapper(torch.ones(4, device="cuda"))
+        assert out.shape == (4, 8)
+        assert wrapper._stable_bufs == {}
+
+    def test_capture_allocates_stable_and_returns_it(self):
+        wrapper = MultiStreamWrapper(_DummyMS((4, 8))).cuda()
+        ADPiecewiseRunner.set_current_phase("capture")
+        ADPiecewiseRunner.set_current_num_tokens(4)
+
+        out = wrapper(torch.ones(4, device="cuda"))
+        assert 4 in wrapper._stable_bufs
+        stable = wrapper._stable_bufs[4]
+        assert out is stable
+        assert out.shape == (4, 8)
+
+    def test_replay_reuses_stable_and_address_is_fixed(self):
+        """Stable buffer address must not drift across replays for one bucket.
+
+        This is the core invariant the piecewise captured graph relies on.
+        """
+        wrapper = MultiStreamWrapper(_DummyMS((4, 8))).cuda()
+
+        ADPiecewiseRunner.set_current_num_tokens(4)
+        ADPiecewiseRunner.set_current_phase("capture")
+        out1 = wrapper(torch.ones(4, device="cuda"))
+        ptr_capture = out1.data_ptr()
+
+        ADPiecewiseRunner.set_current_phase("replay")
+        out2 = wrapper(torch.ones(4, device="cuda") * 2)
+        out3 = wrapper(torch.ones(4, device="cuda") * 3)
+
+        assert out2.data_ptr() == ptr_capture
+        assert out3.data_ptr() == ptr_capture
+        # Data reflects the most recent submodule call (copied in each time).
+        assert torch.all(out3 == 3.0 * 4)
+
+    def test_different_buckets_get_independent_buffers(self):
+        wrapper = MultiStreamWrapper(_DummyMS((4, 8))).cuda()
+
+        ADPiecewiseRunner.set_current_phase("capture")
+        ADPiecewiseRunner.set_current_num_tokens(4)
+        wrapper(torch.ones(4, device="cuda"))
+        ADPiecewiseRunner.set_current_num_tokens(16)
+        wrapper(torch.ones(4, device="cuda"))
+
+        assert 4 in wrapper._stable_bufs and 16 in wrapper._stable_bufs
+        assert wrapper._stable_bufs[4].data_ptr() != wrapper._stable_bufs[16].data_ptr()
+
+    def test_tuple_output_is_preserved_and_addresses_stable(self):
+        wrapper = MultiStreamWrapper(_DummyMSTuple((3,), (5,))).cuda()
+
+        ADPiecewiseRunner.set_current_num_tokens(3)
+        ADPiecewiseRunner.set_current_phase("capture")
+        out1 = wrapper(torch.ones(3, device="cuda"))
+        assert isinstance(out1, tuple) and len(out1) == 3
+        assert out1[1] is None
+        ptrs = (out1[0].data_ptr(), out1[2].data_ptr())
+
+        ADPiecewiseRunner.set_current_phase("replay")
+        out2 = wrapper(torch.ones(3, device="cuda") * 2)
+        assert out2[0].data_ptr() == ptrs[0]
+        assert out2[2].data_ptr() == ptrs[1]
+        assert out2[1] is None
+        assert torch.all(out2[0] == 2.0 * 3)
+        assert torch.all(out2[2] == 2.0 * 3 + 1)
+
+    def test_stable_buffer_outside_graph_pool_does_not_recycle(self):
+        """Regression test for the Qwen3.5 IMA.
+
+        Even when other large allocations happen between calls, the stable
+        buffer address must remain valid because it is outside any graph
+        pool and strong-ref'd by the wrapper.
+        """
+        wrapper = MultiStreamWrapper(_DummyMS((4, 8))).cuda()
+
+        ADPiecewiseRunner.set_current_phase("capture")
+        ADPiecewiseRunner.set_current_num_tokens(4)
+        wrapper(torch.ones(4, device="cuda"))
+        ptr = wrapper._stable_bufs[4].data_ptr()
+
+        # Churn the caching allocator.
+        for _ in range(64):
+            _ = torch.empty(1024 * 1024, device="cuda")
+
+        # Wrapper still holds its buffer at the same address.
+        assert wrapper._stable_bufs[4].data_ptr() == ptr
+        ADPiecewiseRunner.set_current_phase("replay")
+        out = wrapper(torch.ones(4, device="cuda"))
+        assert out.data_ptr() == ptr

--- a/tests/unittest/auto_deploy/singlegpu/smoke/test_ad_build_small_single.py
+++ b/tests/unittest/auto_deploy/singlegpu/smoke/test_ad_build_small_single.py
@@ -262,15 +262,13 @@ def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
         (
             "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8",
             {
+                "compile_backend": "torch-cudagraph",
                 "transforms": {
                     "mlir_elementwise_fusion": {"enabled": True},
                     "multi_stream_moe": {"stage": "compile", "enabled": True},
                     "insert_cached_attention": {"backend": "flashinfer"},
                     "insert_cached_ssm_attention": {"backend": "triton_ssm"},
-                    "compile_model": {
-                        "backend": "torch-cudagraph",
-                        "piecewise_enabled": True,
-                    },
+                    "compile_model": {"piecewise_enabled": True},
                 },
             },
         ),

--- a/tests/unittest/auto_deploy/singlegpu/smoke/test_ad_build_small_single.py
+++ b/tests/unittest/auto_deploy/singlegpu/smoke/test_ad_build_small_single.py
@@ -257,6 +257,23 @@ def _check_ad_config(experiment_config: ExperimentConfig, llm_args: LlmArgs):
                 },
             },
         ),
+        # Smoke test for NVIDIA/TensorRT-LLM#13321 — exercises the piecewise
+        # CUDA graph + multi_stream_moe path that MultiStreamWrapper unblocks.
+        (
+            "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8",
+            {
+                "transforms": {
+                    "mlir_elementwise_fusion": {"enabled": True},
+                    "multi_stream_moe": {"stage": "compile", "enabled": True},
+                    "insert_cached_attention": {"backend": "flashinfer"},
+                    "insert_cached_ssm_attention": {"backend": "triton_ssm"},
+                    "compile_model": {
+                        "backend": "torch-cudagraph",
+                        "piecewise_enabled": True,
+                    },
+                },
+            },
+        ),
     ],
 )
 def test_build_ad(model_hub_id: str, llm_extra_args: dict):


### PR DESCRIPTION
## Summary
Enables piecewise CUDA graph together with `multi_stream_moe` for the Nemotron-3-Nano-30B-A3B-FP8 and Qwen3.5-35B-A3B model families (closes #13321). Without this fix, piecewise + multi_stream_moe either produced gibberish tokens (nano_v3, `ADPiecewiseRunner ADDRESS MISMATCH`) or crashed during capture/inference (Qwen3.5, asynchronous IMA in `flashinfer_rope`, then a `size 16 vs 64` `aten.add` shape mismatch).

## Root causes
1. **Unstable output address of reclassified multi-stream partitions.** `piecewise_utils.split_graph_at_dynamic_ops` moves partitions containing `begin/end/wait/record_aux_stream_passthrough` to the dynamic set so they run eagerly (CPU-side `synchronize()` cannot be called during CUDA graph capture). `PiecewiseCapturedGraph.prepare()` left those partitions unwrapped. Their eager output got a fresh caching-allocator address each call, while the following static partition's captured graph had baked in the capture-time address — `ADPiecewiseRunner` logged `ADDRESS MISMATCH` on every layer following one of these partitions, and on Qwen3.5 the pool's address recycling surfaced as an asynchronous IMA in the next layer's RoPE kernel.
2. **Wrong narrow-size in `_copy_to_static_buffers` for the piecewise path.** Static input buffers (e.g. `inputs_embeds`) were narrowed to the real request size. Captured partitions tolerated this silently (padding zeros behind the view), but eager multi-stream submodules hit strict `aten.add` shape checks between narrowed inputs (size 16) and intermediates still at bucket size (size 64).

## Fix
- `MultiStreamWrapper` (`piecewise_runner.py`) wraps each reclassified partition and holds its own per-bucket stable buffer in the regular caching allocator. The submodule runs eagerly and the wrapper copies the result into that buffer before returning, so the next captured static partition always replays against a fixed address. Allocating outside the graph pool sidesteps the aggressive pool-recycling race that caused asynchronous IMAs on larger partitions.
- `_copy_to_static_buffers(kwargs, bucket=None)` (`backends/torch_cudagraph.py`) — when called from the piecewise path with `bucket=num_tokens`, narrows views to the bucket size and zeroes the padding tail. Monolithic path still narrows to actual size.
- `submod_has_stream_switch` (`piecewise_utils.py`) is promoted from private to public so the compile backend can call it.
- `nano_v3.yaml` now sets `compile_model.piecewise_enabled: true` (matches `qwen3.5_moe_35b.yaml`, which already had it on main).

## Test plan
- [x] `build_and_run_ad.py --model nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8 --use-registry` — 0 `ADDRESS MISMATCH`, 10/10 prompts coherent.
- [x] `build_and_run_ad.py --model Qwen/Qwen3.5-35B-A3B` (default config, piecewise on + multi_stream_moe on) — 0 errors, 10/10 prompts coherent.
- [x] `pre-commit run` clean on all modified files.

## Known follow-up
A small number of `CUDA Graph is empty … wrong device or stream` warnings appear on the largest piecewise bucket capture (1 per rank). They do not affect correctness — all outputs are verified coherent — but are worth investigating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Piecewise model compilation is now available and can be enabled via configuration settings.
  * Enhanced multi-stream execution handling for compiled models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->