### PR TITLE
[https://nvbugs/5839028][fix] Lower KV cache fraction for DeepSeek-R1 FP8 DEEPGEMM variants

### DIFF
--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -2973,7 +2973,15 @@ class TestDeepSeekR1(LlmapiAccuracyTestHarness):
         if is_sm_100f():
             moe_backend = "DEEPGEMM" if moe_backend == "_DEFAULT" else moe_backend
             moe_config = MoeConfig(backend=moe_backend, max_num_tokens=16384)
-            kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.6)
+            # The DEEPGEMM MoE backend has a higher peak-memory profile than
+            # the TRTLLM backend on B200 (shapes fused on the fly, per-tactic
+            # autotuner scratch). With throughput batch sizes, MTP speculation
+            # and CUDA Graph private pools, the 0.6 fraction leaves no headroom
+            # and OOMs intermittently during GSM8K generation (nvbugs/5839028
+            # and nvbugs/6084764). Use 0.5 only for DEEPGEMM; keep 0.6 for
+            # TRTLLM which is already exercised successfully at that budget.
+            fraction = 0.5 if moe_backend == "DEEPGEMM" else 0.6
+            kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=fraction)
         else:
             if moe_backend != "_DEFAULT":
                 pytest.skip("Not supported MoE backend!")

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -297,7 +297,6 @@ unittest/disaggregated/test_agent_multi_backends.py::test_run_with_different_env
 verl/test_verl_cases.py::test_adapter SKIP (https://nvbugs/5981833)
 verl/test_verl_cases.py::test_async_server SKIP (https://nvbugs/5981833)
 verl/test_verl_cases.py::test_rollout_utils SKIP (https://nvbugs/5981833)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp] SKIP (https://nvbugs/5839028)
 accuracy/test_llm_api_pytorch.py::TestGLM4_5Air::test_nvfp4_multi_gpus[throughput_trtllm] SKIP (https://nvbugs/5981293)
 accuracy/test_llm_api_pytorch.py::TestGLM4_5Air::test_nvfp4_2_model_mtp[2model] SKIP (https://nvbugs/5981293)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_bfloat16_python_scheduler[mtp_nextn=2-attention_dp=True-cuda_graph=True-overlap_scheduler=True-enable_chunked_prefill=False] SKIP (https://nvbugs/5981122)


### PR DESCRIPTION
## Summary
- Lower KV-cache `free_gpu_memory_fraction` from 0.6 to 0.5 for the DEEPGEMM MoE backend in `TestDeepSeekR1::test_fp8_blockscale` on Blackwell (SM100f).
- Unwaive `accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp]` (nvbugs/5839028).

## Motivation

Per the pipeline log attached to [nvbugs/5839028](https://nvbugs/5839028), rank 7 OOMs during GSM8K generation right after MMLU completes:
```
CUDA out of memory. Tried to allocate 3.47 GiB. GPU 7 has a total capacity of 178.35 GiB of which 3.28 GiB is free.
Including non-PyTorch memory, this process has 175.06 GiB memory in use.
139.09 GiB allowed; Of the allocated memory 132.21 GiB is allocated by PyTorch, with 113.88 MiB allocated in private pools (e.g., CUDA Graphs), and 3.57 GiB is reserved by PyTorch but unallocated.
```

The DEEPGEMM MoE backend has a higher peak-memory profile than TRTLLM (on-the-fly shape fusion, per-tactic autotuner scratch). Combined with throughput batch sizes, MTP speculation, and CUDA Graph private pools, `free_gpu_memory_fraction=0.6` leaves no headroom.

Evidence that memory pressure is backend-specific, not param-specific:
- `throughput_mtp_trtllm` (same params, TRTLLM backend) passes at 0.6.
- Sister bug [nvbugs/6084764](https://nvbugs/6084764) waives `throughput` (no MTP, still DEEPGEMM) with the same OOM.

So the fix is keyed on the MoE backend: 0.5 for DEEPGEMM, 0.6 for TRTLLM.

## Verification

On `umbriel-b200-082` (8x B200, release/1.3.0rc11 image), the worktree with this fix ran the unwaived test to completion:
```
accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp]
  MMLU weighted average accuracy: 87.43 (threshold 85.756, reference 87.573) PASS
  GSM8K evaluated accuracy:        95.15 (threshold 92.21,  reference 95.413) PASS
PASSED in 1147.15s (0:19:07)
```
No OOM, no hang.

## Test plan
- [x] Reproduce-then-verify on 8x B200 — passed (see above).
- [ ] Re-run the unwaived case in CI (DGX_B200-8_GPUs-PyTorch-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled previously skipped test case for FP8 blockscale functionality.
  * Updated memory configuration parameters to enhance test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->