### PR TITLE
[backport][issue-13318] feat/bench_y reuse-budget fixes (#12682, #12806, #12909) on v1.3.0rc11

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/microBatchScheduler.cpp
+++ b/cpp/tensorrt_llm/batch_manager/microBatchScheduler.cpp
@@ -24,6 +24,25 @@ namespace tensorrt_llm::batch_manager
 
 using SizeType32 = MicroBatchScheduler::SizeType32;
 
+/// Return the forward-pass token cost for a context chunk with KV cache reuse.
+///
+/// setPrepopulatedPromptLen shifts the chunk window right by the prepopulated
+/// amount rather than shrinking it.  For non-last chunks the model still
+/// processes approximately @p chunkSize tokens; only for the last chunk is the
+/// cost @p contextRemaining - @p reusable.
+static SizeType32 reuse_adjusted_compute(SizeType32 chunkSize, SizeType32 reusable, SizeType32 contextRemaining)
+{
+    if (reusable <= 0)
+    {
+        return chunkSize;
+    }
+    if (reusable + chunkSize < contextRemaining)
+    {
+        return chunkSize;
+    }
+    return std::max<SizeType32>(0, contextRemaining - reusable);
+}
+
 MicroBatchScheduler::MicroBatchScheduler(std::optional<batch_scheduler::ContextChunkingConfig> ctxChunkConfig,
     std::optional<SizeType32> maxContextLength, LlmRequestState noScheduleUntilState,
     LlmRequestState noScheduleAfterState)
@@ -38,16 +57,15 @@ void MicroBatchScheduler::fitDraftTokens(RequestVector& contextsToBeChunked,
     std::optional<SizeType32> ctxTokensCapacity, SizeType32 const chunkUnitSize,
     std::optional<SizeType32> const& maxContextLength)
 {
-    // How many compute tokens (chunk - reusable) are in this batch already?
+    // How many compute tokens are in this batch already?
     SizeType32 numCtxTokens{0};
     for (auto const& llmReq : contextsToBeChunked)
     {
         SizeType32 const chunkSize = llmReq->getContextChunkSize();
-        // contextRemaining = P for first chunk; used to compute actual model token count.
         SizeType32 const contextRemaining = llmReq->getContextRemainingLength();
         SizeType32 const reusable
             = llmReq->isFirstContextChunk() ? std::min(llmReq->getEstimatedReusableTokens(), contextRemaining) : 0;
-        numCtxTokens += std::min(chunkSize, std::max<SizeType32>(0, contextRemaining - reusable));
+        numCtxTokens += reuse_adjusted_compute(chunkSize, reusable, contextRemaining);
     }
 
     // Discard draft tokens that won't fit into the existing chunk unit, max
@@ -125,14 +143,13 @@ void MicroBatchScheduler::setCtxRequestsChunkSize<MicroBatchScheduler::ContextCh
             SizeType32 actualChunkSize = llmReq->getContextChunkSize();
             SizeType32 actualIncrement = actualChunkSize - pastChunkSize;
 
-            // Compute-aware budget: reusable tokens are served from cache and do not
-            // consume forward-pass capacity. Only the tokens beyond the reusable prefix count.
-            SizeType32 const reusable = llmReq->isFirstContextChunk()
-                ? std::min(llmReq->getEstimatedReusableTokens(), llmReq->getContextRemainingLength())
-                : 0;
-            SizeType32 const pastCompute = std::max<SizeType32>(0, pastChunkSize - std::min(reusable, pastChunkSize));
-            SizeType32 const actualCompute
-                = std::max<SizeType32>(0, actualChunkSize - std::min(reusable, actualChunkSize));
+            // Compute-aware budget accounting for setPrepopulatedPromptLen's
+            // chunk-shift behaviour (non-last chunks keep their full size).
+            SizeType32 const contextRemaining = llmReq->getContextRemainingLength();
+            SizeType32 const reusable
+                = llmReq->isFirstContextChunk() ? std::min(llmReq->getEstimatedReusableTokens(), contextRemaining) : 0;
+            SizeType32 const pastCompute = reuse_adjusted_compute(pastChunkSize, reusable, contextRemaining);
+            SizeType32 const actualCompute = reuse_adjusted_compute(actualChunkSize, reusable, contextRemaining);
             SizeType32 const computeIncrement = actualCompute - pastCompute;
 
             if ((ctxTokensCapacity && numCtxTokens + computeIncrement > ctxTokensCapacity.value())
@@ -181,24 +198,21 @@ void MicroBatchScheduler::setCtxRequestsChunkSize<MicroBatchScheduler::ContextCh
     for (auto& llmReq : contextsToBeChunked)
     {
         SizeType32 const suggestedChunkSize = llmReq->getContextRemainingLength();
-        // Reusable tokens are "free" — they don't consume forward-pass compute budget.
         SizeType32 const reusable
             = llmReq->isFirstContextChunk() ? std::min(llmReq->getEstimatedReusableTokens(), suggestedChunkSize) : 0;
-        SizeType32 const computeCost = suggestedChunkSize - reusable;
+        SizeType32 const computeCost = reuse_adjusted_compute(suggestedChunkSize, reusable, suggestedChunkSize);
         SizeType32 actualChunkSize = suggestedChunkSize;
         if (ctxTokensCapacity && computeCost > ctxTokensCapacity.value())
         {
-            // Model processes min(chunk_size, P - reusable) tokens starting from position reusable.
-            // To keep model tokens within budget: chunk_size <= capacity (not reusable + capacity).
             actualChunkSize = ctxTokensCapacity.value();
         }
         if (maxContextLength)
         {
-            // maxContextLength limits compute tokens, not total tokens.
-            SizeType32 const actualCompute = std::max<SizeType32>(0, actualChunkSize - reusable);
+            SizeType32 const actualCompute = reuse_adjusted_compute(actualChunkSize, reusable, suggestedChunkSize);
             if (actualCompute > maxContextLength.value())
             {
-                actualChunkSize = std::min<SizeType32>(reusable + maxContextLength.value(), suggestedChunkSize);
+                actualChunkSize = maxContextLength.value();
+                actualChunkSize = std::min(actualChunkSize, suggestedChunkSize);
             }
         }
         if (actualChunkSize != suggestedChunkSize)
@@ -208,10 +222,7 @@ void MicroBatchScheduler::setCtxRequestsChunkSize<MicroBatchScheduler::ContextCh
         llmReq->setContextChunkSize(actualChunkSize);
         if (ctxTokensCapacity)
         {
-            // Decrement by actual model token count: min(chunk_size, P - reusable).
-            // This equals min(actualChunkSize, computeCost) since computeCost = suggestedChunkSize - reusable.
-            SizeType32 const modelCost
-                = std::min(actualChunkSize, std::max<SizeType32>(0, suggestedChunkSize - reusable));
+            SizeType32 const modelCost = reuse_adjusted_compute(actualChunkSize, reusable, suggestedChunkSize);
             ctxTokensCapacity = ctxTokensCapacity.value() - modelCost;
         }
     }
@@ -349,10 +360,12 @@ std::tuple<RequestVector, RequestVector> MicroBatchScheduler::operator()(Request
             if (!mCtxChunkConfig) // skip chunking
             {
                 constexpr SizeType32 beam{0};
-                reqNumTokens
-                    = llmReq->getNumTokens(beam) + (llmReq->hasDraftTokens() ? llmReq->getNumDraftTokens() : 0);
-                // Compute tokens = total - reusable (at least 1 to make progress)
-                SizeType32 const computeTokens = std::max(1, reqNumTokens - reusable);
+                SizeType32 const contextTokens = llmReq->getNumTokens(beam);
+                SizeType32 const draftTokens = llmReq->hasDraftTokens() ? llmReq->getNumDraftTokens() : 0;
+                reqNumTokens = contextTokens + draftTokens;
+                SizeType32 const contextCompute
+                    = reuse_adjusted_compute(contextTokens, reusable, llmReq->getContextRemainingLength());
+                SizeType32 const computeTokens = std::max(1, contextCompute + draftTokens);
                 TLLM_CHECK_WITH_INFO(!mMaxContextLength || computeTokens <= mMaxContextLength.value(),
                     "Context compute tokens (%d) exceeds the limit value (%d)", computeTokens,
                     mMaxContextLength.value());
@@ -369,9 +382,8 @@ std::tuple<RequestVector, RequestVector> MicroBatchScheduler::operator()(Request
                 llmReq->setContextChunkSize(llmReq->getContextRemainingLength());
                 auto const draftTokens
                     = (llmReq->isLastContextChunk() && llmReq->hasDraftTokens()) ? llmReq->getNumDraftTokens() : 0;
-                // Compute cost: context compute + draft tokens
-                // (reusable tokens only offset context tokens, not draft tokens)
-                SizeType32 const contextCompute = std::max(0, llmReq->getContextChunkSize() - reusable);
+                SizeType32 const contextCompute = reuse_adjusted_compute(
+                    llmReq->getContextChunkSize(), reusable, llmReq->getContextRemainingLength());
                 SizeType32 computeTokens = contextCompute + draftTokens;
 
                 if (mMaxContextLength)
@@ -444,10 +456,9 @@ std::tuple<RequestVector, RequestVector> MicroBatchScheduler::operator()(Request
         if (llmReq->getContextChunkSize() > 0)
         {
             contextRequests.emplace_back(llmReq);
-            // Only count compute tokens (total - reusable).
-            // Reusable credit only applies to the first context chunk.
             SizeType32 const reusable = llmReq->isFirstContextChunk() ? llmReq->getEstimatedReusableTokens() : 0;
-            SizeType32 const computeTokens = std::max(0, llmReq->getContextChunkSize() - reusable);
+            SizeType32 const computeTokens
+                = reuse_adjusted_compute(llmReq->getContextChunkSize(), reusable, llmReq->getContextRemainingLength());
             batchNumTokens += computeTokens;
             TLLM_LOG_DEBUG("context request scheduled: ID %lu, chunk size %d%s", llmReq->mRequestId,
                 llmReq->getContextChunkSize(), reusable > 0 ? (", reusable " + std::to_string(reusable)).c_str() : "");

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2636,6 +2636,24 @@ class PyTorchModelEngine(ModelEngine):
         num_tokens = len(input_ids)
         num_draft_tokens = len(draft_tokens)
         total_num_tokens = len(position_ids)
+        if total_num_tokens > self.max_num_tokens:
+            ctx_details = []
+            for r in scheduled_requests.context_requests:
+                pos = r.context_current_position
+                csz = r.context_chunk_size
+                full = len(r.get_tokens(0))
+                tokens = min(csz, max(0, full - pos))
+                ctx_details.append(
+                    f"rid={r.py_request_id} pos={pos} chunk={csz} "
+                    f"full={full} tokens={tokens}")
+            gen_count = len(scheduled_requests.generation_requests)
+            from tensorrt_llm.logger import logger as _mnt_logger
+            _mnt_logger.error(
+                f"MNT overflow: total={total_num_tokens} "
+                f"max={self.max_num_tokens} "
+                f"ctx_reqs={len(scheduled_requests.context_requests)} "
+                f"gen_reqs={gen_count} "
+                f"ctx_breakdown=[{'; '.join(ctx_details)}]")
         assert total_num_tokens <= self.max_num_tokens, (
             f"total_num_tokens ({total_num_tokens}) should be less than or equal to max_num_tokens ({self.max_num_tokens})"
         )

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3100,8 +3100,16 @@ class PyExecutor:
                         resource_mgr_type].prepare_resources(
                             disagg_gen_init_to_prepare)
 
-            # Trigger KV cache exchange for new disagg_gen_init_requests
-            self._recv_disagg_gen_cache(fitting_disagg_gen_init_requests)
+            # Use the filtered batch after prepare_resources, not the original
+            # list.  prepare_resources may skip add_sequence for some requests
+            # (e.g. reuse budget exhaustion) and remove them from the batch via
+            # reset_context_requests.  Passing skipped requests to KV transfer
+            # causes unordered_map::at in getSequence because the sequence was
+            # never registered.  Skipped requests remain in active_requests
+            # with DISAGG_GENERATION_INIT state and will be rescheduled.
+            accepted_requests = list(
+                disagg_gen_init_to_prepare.context_requests)
+            self._recv_disagg_gen_cache(accepted_requests)
 
     @nvtx_range("_prepare_disagg_gen_transmission_complete")
     def _prepare_disagg_gen_transmission_complete(self, scheduled_batch):
@@ -3728,14 +3736,13 @@ class PyExecutor:
                                     f"Request {request.py_request_id} has no avg_decoded_tokens_per_iter"
                                 )
 
-                # If partial reuse is enabled, and the KV cache manager is not VSWA, and the PP size is 1,
-                # then we need to terminate the request. TODO: Remove this once disagg support from KVCache reuse
-                # path is fixed.
-                if self.enable_partial_reuse_for_disagg and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1:
+                # Never terminate a request while KV cache transfer is
+                # still in progress — the GEN worker may still be receiving
+                # data from the pinned blocks.  The request will be
+                # terminated by _end_transfer_and_maybe_terminate once the
+                # transfer completes (or times out).
+                if not request.is_disagg_context_transmission_state:
                     requests_to_terminate.append(request)
-                else:
-                    if not request.is_disagg_context_transmission_state:
-                        requests_to_terminate.append(request)
             else:
                 new_active_requests.append(request)
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2807,6 +2807,116 @@ class PyExecutor:
                     balanced_context_requests = context_requests
         return balanced_context_requests
 
+    @staticmethod
+    def _compute_scheduled_tokens(context_requests, generation_requests):
+        """Compute the total number of scheduled tokens for batch waiting decisions.
+
+        For context requests, we estimate the actual compute tokens for this
+        iteration (excluding tokens served from KV cache).
+
+        For generation requests, each contributes 1 + num_draft_tokens.
+
+        Note on reusable token handling:
+        estimated_reusable_tokens is an absolute count from position 0.
+        Depending on the scheduler, context_current_position may or may not
+        have been advanced past the reusable prefix by the time this method
+        is called:
+        - V1 scheduler: prepare_context runs after scheduling, so
+          context_current_position is still 0.
+        - V2 scheduler: prepare_context runs during scheduling, so
+          context_current_position is already advanced to the reused offset.
+        To handle both correctly, the reusable credit applied to the current
+        chunk is max(0, reusable - context_current_position), i.e. only the
+        portion of the reusable range that falls within this chunk's span.
+        """
+        num_scheduled_ctx_tokens = 0
+        for ctx_req in context_requests:
+            reusable = (ctx_req.estimated_reusable_tokens
+                        if ctx_req.is_first_context_chunk else 0)
+            # Credit only the reusable tokens that overlap with the current
+            # chunk: if context_current_position has already been advanced past
+            # the reusable prefix (V2), the credit is 0; if not (V1), the full
+            # reusable count is subtracted.
+            reusable_in_chunk = max(0,
+                                    reusable - ctx_req.context_current_position)
+            remaining = ctx_req.context_remaining_length
+            if (reusable_in_chunk > 0 and
+                    reusable_in_chunk + ctx_req.context_chunk_size < remaining):
+                compute = ctx_req.context_chunk_size
+            else:
+                compute = max(1, ctx_req.context_chunk_size - reusable_in_chunk)
+            num_scheduled_ctx_tokens += compute
+        num_scheduled_gen_tokens = sum(1 + gen_req.num_draft_tokens
+                                       for gen_req in generation_requests)
+        return num_scheduled_ctx_tokens + num_scheduled_gen_tokens
+
+    def _maybe_log_batch_wait_decision(
+        self,
+        context_requests: list[LlmRequest],
+        generation_requests: list[LlmRequest],
+        num_scheduled_tokens: int,
+        wait_threshold: float,
+        should_waiting: bool,
+    ) -> None:
+        """Diagnostics for batch_wait: set TLLM_LOG_BATCH_WAIT=1 (rank 0 only)."""
+        if self.dist.rank != 0:
+            return
+
+        num_scheduled_gen_tokens = sum(1 + gen_req.num_draft_tokens
+                                       for gen_req in generation_requests)
+        num_scheduled_ctx_formula = num_scheduled_tokens - num_scheduled_gen_tokens
+
+        chunk_ctx_sum = 0
+        ctx_summaries: List[str] = []
+        max_detail = 4
+        for i, ctx_req in enumerate(context_requests):
+            full_len = len(ctx_req.get_tokens(0))
+            begin = ctx_req.context_current_position
+            chunk_sz = ctx_req.context_chunk_size
+            this_chunk = min(chunk_sz, max(0, full_len - begin))
+            chunk_ctx_sum += this_chunk
+            reusable = (ctx_req.estimated_reusable_tokens
+                        if ctx_req.is_first_context_chunk else 0)
+            reusable_in_chunk = max(0, reusable - begin)
+            remaining = ctx_req.context_remaining_length
+            if (reusable_in_chunk > 0
+                    and reusable_in_chunk + chunk_sz < remaining):
+                formula_contrib = chunk_sz
+            else:
+                formula_contrib = max(1, chunk_sz - reusable_in_chunk)
+            if i < max_detail:
+                ctx_summaries.append(
+                    f"rid={ctx_req.py_request_id} full={full_len} pos={begin} "
+                    f"chunk_sz={chunk_sz} this_chunk={this_chunk} "
+                    f"reusable={reusable} formula_contrib={formula_contrib}")
+        n_ctx = len(context_requests)
+        if n_ctx > max_detail:
+            ctx_summaries.append(f"... +{n_ctx - max_detail} more ctx req(s)")
+
+        logger.info(
+            "batch_wait: formula_total=",
+            num_scheduled_tokens,
+            " formula_ctx=",
+            num_scheduled_ctx_formula,
+            " formula_gen=",
+            num_scheduled_gen_tokens,
+            " chunk_ctx_sum=",
+            chunk_ctx_sum,
+            " threshold=",
+            wait_threshold,
+            " wait_iter=",
+            self.batch_wait_iters_count,
+            "/",
+            self.batch_wait_timeout_iters,
+            " should_defer_ctx=",
+            should_waiting,
+            " num_gen=",
+            len(generation_requests),
+            " ctx_detail=[",
+            "; ".join(ctx_summaries),
+            "]",
+        )
+
     def _waiting_requests(self, context_requests: list[LlmRequest],
                           generation_requests: list[LlmRequest]):
         """
@@ -2816,13 +2926,16 @@ class PyExecutor:
         - The number of waiting iterations is smaller than `self.batch_wait_timeout_iters`.
         """
 
-        num_scheduled_ctx_tokens = sum(
-            len(ctx_req.get_tokens(0)) for ctx_req in context_requests)
-        num_scheduled_gen_tokens = sum(1 + gen_req.num_draft_tokens
-                                       for gen_req in generation_requests)
-        num_scheduled_tokens = num_scheduled_ctx_tokens + num_scheduled_gen_tokens
+        num_scheduled_tokens = self._compute_scheduled_tokens(
+            context_requests, generation_requests)
+        wait_threshold = (self.batch_wait_max_tokens_ratio *
+                          self.max_num_tokens)
 
-        should_waiting = self.batch_wait_iters_count < self.batch_wait_timeout_iters and num_scheduled_tokens < self.batch_wait_max_tokens_ratio * self.max_num_tokens
+        should_waiting = self.batch_wait_iters_count < self.batch_wait_timeout_iters and num_scheduled_tokens < wait_threshold
+        self._maybe_log_batch_wait_decision(context_requests,
+                                            generation_requests,
+                                            num_scheduled_tokens,
+                                            wait_threshold, should_waiting)
         if should_waiting:
             self.batch_wait_iters_count += 1
             return []

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -619,6 +619,22 @@ class KVCacheManager(BaseResourceManager):
             # wait for all pending work to finish before launching offload/onboarding/partial copy
             self.impl.sync_transfer_manager_with_buffer_manager()
 
+            # Pre-addSequence budget re-validation.  The C++ scheduler
+            # should already account for the chunk-shift cost, but under
+            # heavy KV-cache eviction the actual reuse may be lower than
+            # estimated.  We re-probe the radix tree and estimate the
+            # true forward cost; if it exceeds the remaining budget the
+            # request is skipped (re-scheduled next iteration).
+            remaining_budget = None
+            if self.enable_block_reuse and not self.is_draft:
+                gen_tokens = sum(
+                    req.get_beam_width_by_iter(for_next_iteration=False) +
+                    get_draft_token_length(req)
+                    for req in scheduled_batch.generation_requests)
+                remaining_budget = self.max_num_tokens - gen_tokens
+
+            accepted_ctx_requests = []
+
             # allocate KV Cache
             for req in scheduled_batch.context_requests:
                 req_beam_width = req.sampling_config.beam_width
@@ -635,9 +651,37 @@ class KVCacheManager(BaseResourceManager):
                 else:
                     if req.is_first_context_chunk and self._kv_connector_should_add_sequence(
                             req):
-                        self.impl.add_sequence(req.py_request_id,
-                                               req.prompt_len, req_beam_width,
-                                               req)
+                        if remaining_budget is not None:
+                            unique_tokens = req.get_unique_tokens(0)
+                            reusable_blocks = self.impl.count_reusable_blocks(
+                                unique_tokens, req, False)
+                            actual_reuse = (reusable_blocks *
+                                            self.tokens_per_block)
+                            req_compute = self._estimate_post_reuse_compute(
+                                actual_reuse, req.context_chunk_size,
+                                req.prompt_len)
+                            if req_compute > remaining_budget:
+                                logger.warning(
+                                    f"Reuse budget: skip req "
+                                    f"{req.py_request_id} "
+                                    f"(compute={req_compute}, "
+                                    f"chunk={req.context_chunk_size}, "
+                                    f"reuse={actual_reuse}, "
+                                    f"remaining={remaining_budget})")
+                                continue
+                            remaining_budget -= req_compute
+
+                        try:
+                            self.impl.add_sequence(req.py_request_id,
+                                                   req.prompt_len,
+                                                   req_beam_width, req)
+                        except RuntimeError:
+                            logger.warning(
+                                f"add_sequence: req "
+                                f"{req.py_request_id} already exists, "
+                                f"skipping")
+                            accepted_ctx_requests.append(req)
+                            continue
                         for _ in range(self.num_extra_kv_tokens):
                             self.impl.add_token(req.py_request_id)
                         for _ in range(get_draft_token_length(req)):
@@ -647,9 +691,16 @@ class KVCacheManager(BaseResourceManager):
                             block_ids = self.get_cache_indices(req)
                             self.kv_connector_manager.update_state_after_alloc(
                                 req, block_ids)
+                    elif remaining_budget is not None:
+                        reusable = (req.estimated_reusable_tokens
+                                    if req.is_first_context_chunk else 0)
+                        remaining_budget -= self._estimate_post_reuse_compute(
+                            reusable, req.context_chunk_size, req.prompt_len)
+
+                accepted_ctx_requests.append(req)
 
             # A request may change from `context_requests_chunking` to `context_requests_last_chunk` in `add_sequence` due to KV cache reuse, so we rebuild the context request lists here.
-            scheduled_batch.reset_context_requests()
+            scheduled_batch.reset_context_requests(accepted_ctx_requests)
 
             for req in scheduled_batch.generation_requests:
                 if self.mapping.has_cp_helix():
@@ -673,6 +724,23 @@ class KVCacheManager(BaseResourceManager):
         if self.kv_connector_manager is not None:
             self.kv_connector_manager.build_scheduler_output(
                 scheduled_batch, self)
+
+    def _estimate_post_reuse_compute(self, reuse_tokens: int, chunk_size: int,
+                                     prompt_len: int) -> int:
+        """Estimate forward compute tokens after setPrepopulatedPromptLen.
+
+        For non-last chunks the chunk window shifts right by the reused
+        amount and the forward cost is approximately chunk_size.  For
+        last chunks the cost is prompt_len - reuse (original formula).
+        """
+        P = reuse_tokens
+        if P > 0 and P < prompt_len:
+            if P + chunk_size < prompt_len:
+                aligned_end = ((P + chunk_size) // self.tokens_per_block *
+                               self.tokens_per_block)
+                return max(1, aligned_end - P)
+            return max(1, prompt_len - P)
+        return chunk_size
 
     def _kv_connector_should_add_sequence(self, request: LlmRequest) -> bool:
         return self.kv_connector_manager is None or self.kv_connector_manager.should_add_sequence(

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -633,6 +633,14 @@ class KVCacheManager(BaseResourceManager):
                     for req in scheduled_batch.generation_requests)
                 remaining_budget = self.max_num_tokens - gen_tokens
 
+                # Pre-subtract the fixed cost of non-first-chunk context
+                # requests.  These have no reuse to re-validate and their
+                # compute cost is committed, so first-chunk budget checks
+                # must see the budget with these costs already removed.
+                for req in scheduled_batch.context_requests:
+                    if not req.is_first_context_chunk:
+                        remaining_budget -= req.context_chunk_size
+
             accepted_ctx_requests = []
 
             # allocate KV Cache
@@ -691,9 +699,13 @@ class KVCacheManager(BaseResourceManager):
                             block_ids = self.get_cache_indices(req)
                             self.kv_connector_manager.update_state_after_alloc(
                                 req, block_ids)
-                    elif remaining_budget is not None:
-                        reusable = (req.estimated_reusable_tokens
-                                    if req.is_first_context_chunk else 0)
+                    elif remaining_budget is not None and req.is_first_context_chunk:
+                        # First-chunk request that skipped add_sequence
+                        # (e.g. kv_connector said not to).  Subtract its
+                        # estimated cost so later first-chunk checks see a
+                        # correct budget.  Non-first-chunk costs were
+                        # already pre-subtracted above.
+                        reusable = req.estimated_reusable_tokens
                         remaining_budget -= self._estimate_post_reuse_compute(
                             reusable, req.context_chunk_size, req.prompt_len)
 


### PR DESCRIPTION
**Draft PR for visibility, CI signal, and maintainer discussion — not for merge as-is.** Branch is intentionally based on the `v1.3.0rc11` tag commit (`4e69c14f732a6e6afce4f71616db5b5cd2b10530`), not on `main`. The diff vs main shows the rc11-based delta plus three cherry-picks. The proper merge path requires re-authoring the patches against current `main` (where #12976 + #13029 have changed the surrounding code).

## TL;DR

**Scope:** this is about the V1 code path (`use_python_scheduler=False`, `use_kv_cache_manager_v2=False`) — **the default configuration on `origin/main`** (`tensorrt_llm/llmapi/llm_args.py:2153` and `:2419` — V2 is `status="prototype"`). The #13318 reporter and our production deployment both run with these defaults. V2 (PyMicroBatchScheduler + KVCacheManagerV2) has its own `remaining_budget` mechanism in `scheduler/scheduler_v2.py:379` and is not the subject of this PR. The bug therefore affects users running stock TRT-LLM with default settings, not a legacy or opt-in path.

When PR #12865 ("Merge feat/bench_y to main") was broken up and closed (2026-04-21), only the **admission-side half** of the V1 reuse-budget fix made it to main:
- ✅ #12976 — landed the C++ `reuse_adjusted_compute()` helper + a partial `_compute_scheduled_tokens` rewrite in `py_executor.py`
- ✅ #13029 — landed the batched `add_sequence_batch` two-phase claim refactor

The **V1-path runtime backstop** that catches mid-pipeline over-admission is missing from `origin/main` (verified absent as of `36113bf6a` via direct grep on `resource_manager.py`, `py_executor.py`, `scheduler/scheduler.py`). `❌` below means *absent from main*, not *unneeded*:

**Required to prevent the assert (load-bearing fix):**
- ❌ `_estimate_post_reuse_compute()` helper in `resource_manager.py` — required infrastructure, the gate calls it
- ❌ `remaining_budget` gate in `prepare_resources` — runs before `_prepare_tp_inputs`, filters over-admitted requests via `reset_context_requests(accepted_ctx_requests)`. The actual mechanism that prevents the assert. (V1 analogue to V2's existing budget mechanism in `scheduler_v2.py:379`.)
- ❌ #12806's pre-subtract for non-first-chunk costs — closes a hole in the gate (without it, the gate undercounts and some over-admissions still leak through). PR base = `feat/bench_y`, never main.

**Required for disagg deployments:**
- ❌ #12909's filtered batch in `_recv_disagg_gen_cache` — without it, when the gate skips a request in disagg mode, `CacheReceiver::requestSync` throws `unordered_map::at` from `getSequence()`. Aggregated mode doesn't need it; disagg mode crashes differently without it. PR base = `feat/bench_y`, never main.

**Observability only (not load-bearing):**
- ❌ MNT overflow diagnostic logging in `model_engine.py` — adds a per-request breakdown log line before the assertion. If the gate works, the assertion never fires; if it doesn't, the diagnostic helps debug. The fix doesn't depend on this.

The bug pattern is recognized — main carries an integration test for it via #12913 (`[https://nvbugs/5991576][test] Add E2E test for PP+disagg+block_reuse+chunked_prefill hang`, merged 2026-04-13) — but the V1-path fix never landed alongside the test.

Issue #13318 confirms the bug **still reproduces on `main` + #12976 + #13029** with V1 settings. The reporter (Saddss) provides a deterministic 5-minute reproducer matrix. The C++/admission-side fix alone doesn't catch the case where actual reuse differs from the scheduler's estimate (e.g., due to host-cache eviction between admission and forward pass).

This PR is the missing V1-path pieces: three commits cherry-picked from `feat/bench_y`, applied cleanly onto `v1.3.0rc11`. Authors preserved (lancelly, liji-nv, reasonsolo).

## What's omitted from feat/bench_y (and why)

`feat/bench_y` has **16 commits unique to it vs `main`**. This PR includes 3 of them. The other 13 are deliberately omitted, in three categories:

### Already on main — would be redundant cherry-picks (2 commits)

- **`38599dc1d4` (#12919)** — "fix disagg kvcache router for chat API." This is itself a cherry-pick of #12337 *into* `feat/bench_y`. The original #12337 was merged to `main` 2026-04-05 (commit `e16317e451`) AND is already reachable from `v1.3.0rc11` (verified via `git merge-base --is-ancestor e16317e451 v1.3.0rc11`). So it's already in our branch base.
- **`74cb463408` (#13139)** — "Consolidate prefix reuse queries into single analyzePrefixReuse radix tree walk." The same fix landed on `main` independently as #13095 (commit `b4585998b`, merged 2026-04-21). Including #13139 would re-introduce changes already on main and add merge conflicts to no benefit.

### DSA / Sparse Attention work — DeepSeek V3.2-specific (8 commits)

These touch the DSA (DeepSeek Sparse Attention) code path used by DeepSeek V3.2 with sparse attention enabled. Our deployment serves Qwen3-Coder-480B, which doesn't use DSA. Including these would broaden the patch surface for code that doesn't run in our deployment and isn't related to #13318.

- `acefe293aa` — Split MLA DSA custom op for piecewise CUDA graph capture
- `c8466f084d` — Fix pre_indexer bogus parallel pattern + mla_dsa_proj docstring
- `f0dc05f20b` — Move `_update_k_cache` into `sparse_attn_indexer`
- `66627a1b85` — Clean up MLA DSA custom op dispatch
- `c21c41cb61` — Restore `quant_block_size` assertion in `sparse_attn_indexer`
- `7556e67ff7` (#12683) — Fix `DSACacheManager` and `RocketCacheManager` KV cache estimation ignoring `num_layers` for draft models
- `ae2139f7a4` (cherry-pick of #12581 / #12681) — Multiple host perf optimizations for DSA part
- `ca4ace1503` (#12691) — Reduce host overhead in DSA MLA attention path

### Unrelated to #13318 (3 commits)

- **`9c7984e7ac` (#12692)** — PyTorch 2.11 + `torch.compile` multi-stream bug workaround. Adds `disable_on_compile` flag to `maybe_execute_in_parallel` and threads it through model files (DeepSeek V3, ExaoneMoE, GLM, Llama, NemotronH, Qwen3-Next, Mamba2). This is a `dynamo`/`torch.compile` correctness fix for PyTorch 2.11's stream-capture bug, completely orthogonal to the V1 admission path that produces #13318.
- **`4140cccd45`** — "Add default values for num_contexts and num_ctx_tokens" — 3-line C++ change in `cpp/tensorrt_llm/thop/attentionOp.h` adding parameter defaults. Not load-bearing for our cherry-picks (they apply cleanly to rc11 source without it). Cosmetic / backwards-compat.
- **`a7ccae832e` (#13182)** — Add `TestServePrefixAwareScheduling` integration test based on LMBenchmark's synthetic-multi-round-qa generator. A useful regression test for the prefix-cache scheduling path, but a *test addition only* — not part of the runtime fix. Could be ported as a separate test PR if useful (in fact, our internal repro tooling for the production v4 image is loosely modeled on it).

### Summary

Of the 16 commits on `feat/bench_y`, the V1-bug-fix subset is precisely the 3 we cherry-pick. Everything else is either already on main, model-specific (DSA), unrelated (PT 2.11 dynamo workaround), cosmetic (attentionOp defaults), or test-only. We carry the smallest set that closes the gap.

## What this PR contains

| # | Commit (this branch) | Original | PR | Files | Why it's needed |
|---|---|---|---|---|---|
| 1 | `c0d22ad6c` | `d9038d3b90` | #12682 | 4 | The original (superset) of #12976. Contains C++ `reuse_adjusted_compute()` (already on main via #12976), `_compute_scheduled_tokens` rewrite (different shape than #12976's), AND the missing `_estimate_post_reuse_compute()` + `remaining_budget` gate in `prepare_resources` + MNT overflow diagnostic |
| 2 | `9faa1dd27` | `01c4947990` | #12806 | 1 | Pre-subtract non-first-chunk context costs from `remaining_budget` before first-chunk checks. Patches a bug introduced in #12682's gate |
| 3 | `e11cedca5` | `f24dcb33e1` | #12909 | 1 | Disagg-only: pass filtered (post-`prepare_resources`) batch to `_recv_disagg_gen_cache`, fixing `CacheReceiver::requestSync` `unordered_map::at` when the gate skips a request |

## Overlap with what's already on main

| Component | Already on main | Our cherry-picks | Result |
|---|---|---|---|
| C++ `reuse_adjusted_compute()` in `microBatchScheduler.cpp` | ✅ #12976 | ✅ #12682 (byte-identical) | clean dedup on merge |
| `_compute_scheduled_tokens` rewrite in `py_executor.py` | ✅ #12976 (one shape) | ✅ #12682 (different shape) | **conflict** — needs reconciliation |
| `add_sequence_batch` two-phase flow in `prepare_resources` | ✅ #13029 | ❌ | needs the `remaining_budget` gate re-threaded into the new flow |
| `_estimate_post_reuse_compute()` helper | ❌ | ✅ #12682 | new |
| `remaining_budget` gate in `prepare_resources` | ❌ | ✅ #12682 | new (key fix) |
| Pre-subtract non-first-chunk costs | ❌ | ✅ #12806 | new |
| Disagg `_recv_disagg_gen_cache` filtered batch | ❌ | ✅ #12909 | new |
| MNT overflow diagnostic in `model_engine.py` | ❌ | ✅ #12682 | new (observability) |

## Merge dry-run summary (vs current `main`)

I ran `git merge-tree --merge-base v1.3.0rc11 origin/main v1.3.0rc11-benchy-subset`:

- `cpp/tensorrt_llm/batch_manager/microBatchScheduler.cpp` — auto-merged, **verified clean** (1 definition, 9 call sites, no duplication — the same-author byte-identical additions de-duplicate correctly)
- `tensorrt_llm/_torch/pyexecutor/model_engine.py` — auto-merged cleanly (main's changes here are EAGLE3 / LoRA / warmup, different parts of the file)
- `tensorrt_llm/_torch/pyexecutor/py_executor.py` — **CONFLICT** with #12976 (both rewrote `_compute_scheduled_tokens`)
- `tensorrt_llm/_torch/pyexecutor/resource_manager.py` — **CONFLICT** with #13029 (both changed `prepare_resources`; #13029 added the batched flow, our gate needs to re-thread through it)

So this PR is **not directly mergeable as-is**. The conflicts are semantic (which version of `_compute_scheduled_tokens` wins; how the budget gate re-threads through #13029's two-phase claim), not mechanical.

## What we're asking from maintainers

1. **Acknowledge the gap.** Was dropping the V1-path runtime backstop intentional when #12865 was broken up? The bug from #13318 wouldn't fire if the backstop was on main. The existence of #12913 (NVBug 5991576 integration test for the same bug pattern, merged to main 2026-04-13) suggests the failure mode is recognized — but no V1 fix landed with the test.
2. **Port the missing pieces onto current main.** The clean path is: re-author #12682's `_estimate_post_reuse_compute` helper, the `prepare_resources` `remaining_budget` gate, plus #12806 and #12909, as a single follow-up PR onto `main`'s current shape (with #12976's `_compute_scheduled_tokens` rewrite and #13029's batched-claim flow). @lancelly is the natural author since #12682 and #12976 are both yours.
3. **Backport to a release line.** Even if a clean main port lands, downstream consumers on rc11/rc12 wheels need a backport path. We're already running this overlay in production for Qwen3-Coder-480B; happy to share the build steps if there's interest.

## Production context

This branch backs internal dynamo-trtllm production images used to serve Qwen3-Coder-480B, which experienced the #13318 crash three times on 2026-04-22. We are shipping **two image variants from this same branch** and A/B-validating them on a single allocation:

| Variant | Wheel | C++ admission fix in `libtensorrt_llm.so` | Crash prevented by |
|---|---|---|---|
| `head-health-cuda-v4-benchy-rc11` (overlay) | vanilla `tensorrt-llm==1.3.0rc11` from PyPI; 3 Python files from this branch overlaid on top | ❌ rc11 vanilla, no fix | Python `remaining_budget` gate alone (runs before `_prepare_tp_inputs`, filters over-admitted requests via `reset_context_requests(accepted_ctx_requests)`) |
| `head-health-cuda-v4-benchy-rc11-full` | custom-built from this branch with `has_trtllm_context: "1"` | ✅ `reuse_adjusted_compute()` symbol present in shipped binary | C++ admission fix + Python backstop (defense in depth) |

Both variants are independently sufficient to prevent the assertion. An in-flight 3-way E2E (v3 baseline → v4 overlay → v4 full) on a single GB200 allocation runs the issue #13318 reproducer (deterministic 800-session multi-turn chat replay, qps=5.2 warmup → qps=7.0 trigger). The run measures:

- **Correctness:** v3 must hang with `AssertionError: total_num_tokens > max_num_tokens`; both v4 variants must complete without the assert and without `SCHEDULER_HANG_DETECTED`.
- **Gate activity:** `Reuse budget: skip req` warning count in the overlay variant (proves the Python gate is firing — if zero, the workload is not exercising the over-admission path).
- **Throughput cost of skipping the C++ rebuild:** achieved QPS and P50 latency at the trigger phase, plus skip-warning count delta between overlay and full. Hypothesis: full has fewer skips and modestly better QPS because the C++ admission fix prevents over-admission upstream of the gate. If full and overlay are indistinguishable on QPS/latency, overlay is the correct operational choice (5-min build vs ~40-min build per arch). Results will be appended here when the run completes.

The overlay variant matters because it's a Python-only build that takes minutes; the right operational shape if the C++ admission fix turns out to be a marginal throughput optimization in practice. The full variant matters because it's the apples-to-apples comparison with what an upstream port (to current `main` shape with #12976 + #13029) would deliver.

## Disagg deployment (no additional cherry-picks needed)

Our production target (Qwen3-Coder-480B) is a multi-host disagg deployment, but the in-flight A/B is on aggregated single-host (Qwen3-4B on 1× GB200) — the bug is admission-side and largely model-/topology-independent, and the aggregated repro is what the #13318 reporter ships. The image, however, is shared between both deployment shapes. Specifically:

- **No additional source/cherry-pick changes are needed for disagg.** Of the 16 commits unique to `feat/bench_y` vs `main`, exactly two touch disagg code:
  - `f24dcb33e1` (#12909) — GEN-side filter for `_recv_disagg_gen_cache` when the budget gate skips a request. **Already in this PR.**
  - `38599dc1d4` (#12919) — `KvCacheAwareRouter` chat-API tokenization. This is itself a cherry-pick of #12337 into `feat/bench_y`; **#12337 is already on `main`** (merged 2026-04-05, commit `e16317e451`). No action needed on our side.
- **The image is identical between aggregated and disagg deployments.** Same wheel, same Python overlays, same C++ binary. The only differences are at deployment time: multi-host node allocation, KV transceiver configuration (NIXL or UCX), and routing of decode/prefill workers via `DECODE_NODES` / `PREFILL_NODES` env vars in our orchestration scripts.
- **Without #12909, disagg deployments would crash differently.** The Python budget gate (#12682) skips over-admitted requests; in disagg mode this means the request was registered for KV-transfer routing but `add_sequence` was never called for it. Without #12909's filtered-batch fix, `CacheReceiver::requestSync` then throws `unordered_map::at` from `getSequence()`. So #12909 is **mandatory for disagg-targeted backports** (rather than optional, as a naïve "minimal fix" view might suggest if you only consider the assert).
- **#12806 is also disagg-relevant indirectly:** without it, the gate undercounts and lets some over-admissions leak through. In disagg this means *more* runtime mismatches between scheduler estimate and actual reuse — not crashes (the gate still catches them), but extra re-validation skips and the disagg adjacency in #12909 firing more often. So `{#12682, #12806, #12909}` is the minimum coherent set for disagg.

If a reviewer wanted to backport just #12806's pre-subtract patch to a release line (because it's the smallest, only-1-file change), it wouldn't compile — it patches a function (`prepare_resources`'s `remaining_budget` block) that #12682 introduces. The three commits must be cherry-picked together.

Happy to chat in this PR or on #13318 about the right port shape. Not requesting merge of this PR — it's a marker for what got dropped, not a candidate for landing.


