### PR TITLE
[https://nvbugs/6084743][fix] Use free port for FLUX/WAN multi-GPU test distributed init

### DIFF
--- a/tests/unittest/_torch/visual_gen/test_flux_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_flux_pipeline.py
@@ -32,6 +32,7 @@ from tensorrt_llm._torch.visual_gen.config import (
     VisualGenArgs,
 )
 from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
+from tensorrt_llm._utils import get_free_port
 
 
 def _llm_models_root() -> str:
@@ -899,11 +900,11 @@ class TestFluxBatchGeneration:
 # =============================================================================
 
 
-def _setup_distributed(rank, world_size, backend="nccl"):
+def _setup_distributed(rank, world_size, master_port, backend="nccl"):
     """Initialize distributed process group for multi-GPU tests."""
     os.environ["TLLM_DISABLE_MPI"] = "1"
     os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = "12355"
+    os.environ["MASTER_PORT"] = str(master_port)
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
 
@@ -917,13 +918,13 @@ def _cleanup_distributed():
         dist.destroy_process_group()
 
 
-def _run_ulysses_worker(rank, world_size, checkpoint_path, inputs_cpu, return_dict):
+def _run_ulysses_worker(rank, world_size, master_port, checkpoint_path, inputs_cpu, return_dict):
     """Worker function for Ulysses multi-GPU test.
 
     Must be module-level for multiprocessing.spawn() pickling.
     """
     try:
-        _setup_distributed(rank, world_size)
+        _setup_distributed(rank, world_size, master_port)
 
         from tensorrt_llm._torch.visual_gen.config import ParallelConfig, VisualGenArgs
         from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
@@ -1024,9 +1025,10 @@ class TestFluxParallelism:
         manager = mp.Manager()
         return_dict = manager.dict()
 
+        master_port = get_free_port()
         mp.spawn(
             _run_ulysses_worker,
-            args=(2, FLUX1_CHECKPOINT_PATH, inputs_cpu, return_dict),
+            args=(2, master_port, FLUX1_CHECKPOINT_PATH, inputs_cpu, return_dict),
             nprocs=2,
             join=True,
         )
@@ -1061,13 +1063,15 @@ class TestFluxParallelism:
         torch.cuda.empty_cache()
 
 
-def _run_all_optimizations_worker(rank, world_size, checkpoint_path, inputs_cpu, return_dict):
+def _run_all_optimizations_worker(
+    rank, world_size, master_port, checkpoint_path, inputs_cpu, return_dict
+):
     """Worker for combined optimizations test (FP8 + TeaCache + TRTLLM + Ulysses).
 
     Must be module-level for multiprocessing.spawn() pickling.
     """
     try:
-        _setup_distributed(rank, world_size)
+        _setup_distributed(rank, world_size, master_port)
 
         from tensorrt_llm._torch.visual_gen.config import (
             AttentionConfig,
@@ -1205,9 +1209,10 @@ class TestFluxCombinedOptimizations:
         manager = mp.Manager()
         return_dict = manager.dict()
 
+        master_port = get_free_port()
         mp.spawn(
             _run_all_optimizations_worker,
-            args=(2, FLUX1_CHECKPOINT_PATH, inputs_cpu, return_dict),
+            args=(2, master_port, FLUX1_CHECKPOINT_PATH, inputs_cpu, return_dict),
             nprocs=2,
             join=True,
         )


### PR DESCRIPTION
## Summary
- Fixes the flaky post-merge failure `test_flux_pipeline.py::TestFluxCombinedOptimizations::test_all_optimizations_combined` tracked by [nvbug 6084743](https://nvbugspro.nvidia.com/bug/6084743) / [TRTLLM-12007](https://jirasw.nvidia.com/browse/TRTLLM-12007).
- `_setup_distributed` in `tests/unittest/_torch/visual_gen/test_flux_pipeline.py` hardcoded `MASTER_PORT=12355` for `torch.distributed` init. When two multi-GPU tests land on the same node back-to-back, or another process already holds 12355, `init_process_group` fails with *"The server socket has failed to listen on any local network address"*.
- Thread `master_port` through `_setup_distributed` and both worker functions, and allocate a fresh free port via `tensorrt_llm._utils.get_free_port()` at each `mp.spawn` call site.
- Same pattern is already used by the sibling tests under `tests/unittest/_torch/visual_gen/multi_gpu/` (e.g. `test_flux_ulysses.py`, `test_ulysses_attention.py`).

## Test plan
- [x] `python -m py_compile tests/unittest/_torch/visual_gen/test_flux_pipeline.py`
- [x] Local test pass on B200 x2 (pre-existing flake doesn't reproduce with fixed port collision path).
- [x] CI: `/bot run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Improved distributed multi-GPU test infrastructure with dynamic port allocation
- Tests can now run reliably in parallel without port conflicts
- Enhanced stability across diverse system environments and resource configurations
- Better support for containerized and shared testing infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->