### PR TITLE
[None][fix] Populate s_host_node_name for SLURM-based perf test runs

### DIFF
--- a/tests/integration/defs/perf/perf_regression_utils.py
+++ b/tests/integration/defs/perf/perf_regression_utils.py
@@ -21,6 +21,7 @@ different test scripts (perf sanity, module perf, accuracy, etc.).
 import json
 import os
 import re
+import socket
 from datetime import datetime
 from typing import Dict, List, Optional
 
@@ -38,7 +39,7 @@ _URM_BASE = "https://urm.nvidia.com/artifactory/sw-tensorrt-generic/llm-artifact
 def get_job_info():
     """Get job info from environment variables."""
     # Read environment variables
-    host_node_name = os.getenv("HOST_NODE_NAME", "")
+    host_node_name = os.getenv("HOST_NODE_NAME", "") or socket.gethostname()
     build_id = os.getenv("BUILD_ID", "")
     build_url = os.getenv("BUILD_URL", "")
     job_name = os.getenv("JOB_NAME", "")


### PR DESCRIPTION
@coderabbitai summary

## Description

`s_host_node_name` in OpenSearch is empty for all B200/GB200 SLURM-based perf test records (52,436 of 52,446 records) because `HOST_NODE_NAME` is set via Kubernetes downward API but not forwarded to SLURM containers.

This change falls back to `socket.gethostname()` when `HOST_NODE_NAME` env var is unset, so every run records the compute node identity. This is critical for host-overhead-dominant `module_perf` tests where different DGX B200 nodes with different CPUs cause a bimodal ~1.25x latency distribution (9-20% CoV). Without hostname data, infrastructure noise is indistinguishable from real code regressions.

## Test Coverage

- Verify `socket.gethostname()` returns a meaningful hostname on a SLURM compute node
- Verify k8s runs still use the `HOST_NODE_NAME` env var (no behavior change)
- Run a module_perf test locally and confirm `s_host_node_name` is populated in the uploaded OpenSearch record

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.