### PR TITLE
[None][perf] Offload KvCacheAwareRouter tokenize+block-hash to a thread

### DIFF
--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -738,6 +738,20 @@ class BlockHashMixin:
             block_hashes.append(hash_list)
         return block_hashes
 
+    def _tokenize_and_compute_block_hashes(
+            self,
+            request: OpenAIRequest) -> tuple[list[list[int]], list[list[int]]]:
+        """Synchronous tokenize + block-hash, combined for thread offload.
+
+        Factored into one method so ``get_next_server`` can offload the whole
+        CPU-bound step via ``asyncio.to_thread`` in a single call, keeping
+        the orchestrator's asyncio event loop free to dispatch other
+        requests in parallel.
+        """
+        token_lists = self._tokenize(request)
+        block_hashes = self._compute_block_hashes(token_lists)
+        return token_lists, block_hashes
+
     @staticmethod
     def _text_to_int_sequences(texts: list[str]) -> list[list[int]]:
         """Convert text strings to lists of unicode code points.
@@ -782,8 +796,15 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                 server for server in self._server_state.keys()
                 if server != exclude_server
             ]
-        token_lists = self._tokenize(request)
-        block_hashes = self._compute_block_hashes(token_lists)
+        # Tokenize + block-hash is CPU-bound (~50 ms p50 for a 40 k-token
+        # chat request with a Rust-backed tokenizer). Running it directly
+        # inside the async handler blocks the orchestrator's event loop and
+        # serializes all concurrent requests through it; with HuggingFace
+        # tokenizers releasing the GIL, offloading to a thread lets multiple
+        # tokenize calls run in parallel and frees the event loop to
+        # dispatch HTTP traffic to the CTX/GEN workers meanwhile.
+        token_lists, block_hashes = await asyncio.to_thread(
+            self._tokenize_and_compute_block_hashes, request)
         padded_tokens = sum(
             len(hash_list)
             for hash_list in block_hashes) * self._tokens_per_block


### PR DESCRIPTION
## Description

**Issue.** `KvCacheAwareRouter.get_next_server` calls `_tokenize` + `_compute_block_hashes` synchronously inside an `async def`. With ~50 ms CPU per call for a 40 k-token chat request, this blocks the orchestrator's single asyncio event loop and serializes all concurrent clients. At 128 concurrent clients we measured the orchestrator spending **78 % of wall time on synchronous tokenize**; both CTX and GEN workers sat idle despite loaded clients and free KV capacity.

**Solution.** Combine the synchronous tokenize + block-hash step into one helper on `BlockHashMixin` and dispatch it via `asyncio.to_thread` in `get_next_server`. The HuggingFace tokenizer releases the GIL, so tokenize can run in parallel on worker threads while the event loop continues dispatching HTTP to CTX/GEN.

**Result** at the same 1P2D DEP8+TEP8 MTP=1 c=64 lbw=0.5 config: GEN batch size goes from ~8 (wobbly) to **~15 saturated at `max_batch_size=16`**, TTFT p50 **15 s → 2.8 s**, throughput **~250 k → 453 k tok/s** (×1.8), cache hit preserved at 97 %.

## Test Coverage

- `tests/unittest/disaggregated/test_router.py` exercises `KvCacheAwareRouter.get_next_server` end-to-end; the return contract (`(server, info_dict)` with the same `token_lists` / `block_hashes` / `matches`) is preserved.
- No new public API, no config knobs added.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.