### PR TITLE
[None][fix] Enable MoE load balancer setup for Kimi-K2.5

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py
@@ -1078,6 +1078,7 @@ moe_model_arch_list = [
     'DeepseekV32ForCausalLM',
     'GlmMoeDsaForCausalLM',
     'GptOssForCausalLM',
+    'KimiK25ForConditionalGeneration',
     'MixtralForCausalLM',
     'Llama4ForConditionalGeneration',
     'NemotronHForCausalLM',


### PR DESCRIPTION
## Summary

- Add `KimiK25ForConditionalGeneration` to `moe_model_arch_list` in `tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py` so `maybe_create_moe_load_balancer` calls `moe_load_balancer.setup(ep_rank, ep_size)` for Kimi-K2.5.
- Without this entry, enabling EPLB (e.g. `moe_load_balancer.num_slots=288`) for Kimi-K2.5 crashes during executor init with `ValueError: Cannot calculate num_local_slots. num_slots must be set and setup() must be called.`.

## Root cause

Kimi-K2.5 registers as `KimiK25ForConditionalGeneration` (see `tensorrt_llm/_torch/models/modeling_deepseekv3.py`), deriving from `DeepseekV3ForCausalLM`. `maybe_create_moe_load_balancer` whitelists architectures by name before calling `MoeLoadBalancerConfig.setup(ep_rank, ep_size)`. Kimi-K2.5 was missing from the list, so `setup()` was never called and `_ep_size` stayed `None`. Later, during model init, `ConfigurableMoE._init_load_balancer` reads `moe_load_balancer_config.num_local_slots`, which then raises.

Traceback (abbreviated, from a 16-rank GB200 run with EPLB enabled):
```
File ".../fused_moe/create_moe.py", line 389, in create_moe
    return ConfigurableMoE(...)
File ".../fused_moe/configurable_moe.py", line 146, in __init__
    super().__init__(...)
File ".../fused_moe/interface.py", line 293, in __init__
    self._init_load_balancer(model_config, aux_stream_dict)
File ".../fused_moe/interface.py", line 357, in _init_load_balancer
    moe_load_balancer_config.num_local_slots
File ".../llmapi/llm_args.py", line 497, in num_local_slots
    raise ValueError(
ValueError: Cannot calculate `num_local_slots`. `num_slots` must be set and setup() must be called.
```

## Test plan

- [x] Rerun the Kimi-K2.5 disaggregated benchmark (ctx2_gen1_dep16, `moe_load_balancer.num_slots=288`) and confirm executor init succeeds without the `num_local_slots` error.
- [x] Confirm existing MoE models (DeepseekV3/V32, Qwen3MoE, etc.) still initialize correctly — the change only adds a new whitelist entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the KimiK25 model with optimized expert-parallel load balancing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->