### PR TITLE
DRAFT proof: Kimi K2.5 + Eagle3 shadow-failover stack (do not merge)

### DIFF
--- a/DYNAMO_FORK.md
+++ b/DYNAMO_FORK.md
@@ -1,0 +1,55 @@
+# Dynamo fork of TensorRT-LLM
+
+This repository is a fork of [NVIDIA/TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM)
+used by [ai-dynamo/dynamo](https://github.com/ai-dynamo/dynamo) to land TensorRT-LLM
+patches needed for Dynamo — most notably GPU Memory Service (GMS) integration,
+shadow-engine failover hooks, and MPI worker bootstrap.
+
+## Ownership
+
+Currently hosted under `galletas1712/TensorRT-LLM` (personal account). The original
+plan was to host this under the `ai-dynamo` GitHub org, but:
+1. `NVIDIA/TensorRT-LLM` is blocked by NVIDIA org policy from being forked directly
+   into `ai-dynamo`.
+2. Direct transfer into `ai-dynamo` requires repo-create permissions that the
+   current maintainer does not have in the org.
+
+Ownership may be re-homed to `ai-dynamo` later if/when the policy/permissions allow.
+Until then, treat this repository as the canonical Dynamo-side TensorRT-LLM fork.
+
+## Branch layout
+
+- `main` — tracks upstream `NVIDIA/TensorRT-LLM:main` unmodified. Sync with
+  `git fetch upstream && git push origin upstream/main:main`.
+- `dynamo/main` — the patched Dynamo branch. All Dynamo-specific PRs land here.
+  Branched from upstream tag `v1.3.0rc11` (commit `4e69c14f732`).
+- `dynamo/release/1.3` — release-series branch pinned to the 1.3 line. Consumer
+  images in `ai-dynamo/dynamo` pin a specific commit on this branch.
+
+## Opening a PR
+
+- Target `dynamo/main` on this repository (`galletas1712/TensorRT-LLM`).
+- Keep upstream-friendly patches small and reviewable — they should be easy to
+  port to a PR against `NVIDIA/TensorRT-LLM:main` when NVIDIA is ready to accept
+  them.
+
+## How Dynamo consumes this fork
+
+The Dynamo container build pins a specific TensorRT-LLM wheel/commit. The swap
+points are in `ai-dynamo/dynamo` at `container/context.yaml`:
+
+```yaml
+trtllm:
+  pip_wheel: tensorrt-llm==<version>            # PyPI pin (upstream)
+  trtllm_wheel_image: <wheel image>             # Release image (upstream)
+  github_trtllm_commit: <sha-or-tag>            # Used by install_tensorrt.sh
+```
+
+To consume this fork, one of those is swapped to either a fork-built wheel image
+or a `pip install git+https://github.com/galletas1712/TensorRT-LLM@<sha>`.
+Details and options live in `gms/trtllm-fork-infrastructure-plan.md` in the
+Dynamo repo.
+
+## License
+
+Apache-2.0, inherited from upstream NVIDIA/TensorRT-LLM. See `LICENSE`.

--- a/cpp/tensorrt_llm/runtime/virtualMemory.cpp
+++ b/cpp/tensorrt_llm/runtime/virtualMemory.cpp
@@ -295,11 +295,15 @@ size_t CudaVirtualMemoryManager::materializeWithTag(std::string const& tag)
     }
     catch (...)
     {
-        for (auto itRollback = begin; itRollback != it;)
+        auto rollbackMemory = [this](auto entryIt)
         {
-            auto const handle = itRollback->second->first;
-            auto& memory = itRollback->second->second.mMemory;
-            ++itRollback;
+            auto const handle = entryIt->second->first;
+            auto& memory = entryIt->second->second.mMemory;
+            if (memory.status() == CUDAVirtualMemoryChunk::RELEASED)
+            {
+                return;
+            }
+
             try
             {
                 memory.release();
@@ -310,10 +314,15 @@ size_t CudaVirtualMemoryManager::materializeWithTag(std::string const& tag)
                 unsafeRemove(handle);
                 TLLM_LOG_ERROR("Additional exception thrown during rollback of materializeWithTag: %s", e.what());
             }
+        };
+
+        for (auto itRollback = begin; itRollback != it;)
+        {
+            auto current = itRollback++;
+            rollbackMemory(current);
         }
 
-        addBadHandle(it->second->first);
-        unsafeRemove(it->second->first);
+        rollbackMemory(it);
 
         throw;
     }

--- a/cpp/tests/unit_tests/runtime/virtualMemoryTest.cpp
+++ b/cpp/tests/unit_tests/runtime/virtualMemoryTest.cpp
@@ -1214,13 +1214,14 @@ TEST_F(VirtualMemoryManagerTest, TestAddException)
 
 TEST_F(VirtualMemoryManagerTest, TestMaterializeException)
 {
-    // State structure to track create/release order and can throw on a specific call
+    // State structure to track create/setup order and rollback behavior.
     struct CreatorState
     {
-        int& createCounter;       // Reference to shared counter
-        int throwOnCreateIdx = 0; // 1-based index to throw on create
+        int& createCounter;
+        int throwOnSetupIdx = 0;
         int myCreateIdx = INT_MAX;
         bool createCalled = false;
+        bool setupCalled = false;
         bool releaseCalled = false;
         CUmemGenericAllocationHandle createdHandle = 0xbaadf00dbaadf00d;
 
@@ -1230,7 +1231,6 @@ TEST_F(VirtualMemoryManagerTest, TestMaterializeException)
         }
     };
 
-    // Dummy Creator that uses external state
     class TestMatEx_DummyCreator : public CUDAVirtualMemoryChunk::Creator
     {
     public:
@@ -1245,10 +1245,6 @@ TEST_F(VirtualMemoryManagerTest, TestMaterializeException)
         {
             state.createCalled = true;
             state.myCreateIdx = ++state.createCounter;
-            if (state.throwOnCreateIdx > 0 && state.myCreateIdx == state.throwOnCreateIdx)
-            {
-                throw DummyException();
-            }
             return state.createdHandle;
         }
 
@@ -1259,80 +1255,94 @@ TEST_F(VirtualMemoryManagerTest, TestMaterializeException)
         }
     };
 
-    // Create shared counter
+    class TestMatEx_DummyConfigurator : public CUDAVirtualMemoryChunk::Configurator
+    {
+    public:
+        CreatorState& state;
+
+        TestMatEx_DummyConfigurator(CreatorState& state)
+            : state(state)
+        {
+        }
+
+        void setup(CUmemGenericAllocationHandle) override
+        {
+            state.setupCalled = true;
+            if (state.throwOnSetupIdx > 0 && state.myCreateIdx == state.throwOnSetupIdx)
+            {
+                throw DummyException();
+            }
+        }
+
+        void teardown(CUmemGenericAllocationHandle, bool) override {}
+    };
+
     int sharedCreateCounter = 0;
 
-    // Create state objects for each creator
     CreatorState state1(sharedCreateCounter);
     CreatorState state2(sharedCreateCounter);
     CreatorState state3(sharedCreateCounter);
 
-    // We want the second memory (by create order) to throw
-    state1.throwOnCreateIdx = 2;
-    state2.throwOnCreateIdx = 2;
-    state3.throwOnCreateIdx = 2;
+    state1.throwOnSetupIdx = 2;
+    state2.throwOnSetupIdx = 2;
+    state3.throwOnSetupIdx = 2;
 
-    // Create creators and configurators
     auto creator1 = std::make_unique<TestMatEx_DummyCreator>(state1);
     auto creator2 = std::make_unique<TestMatEx_DummyCreator>(state2);
     auto creator3 = std::make_unique<TestMatEx_DummyCreator>(state3);
+    auto configurator1 = std::make_unique<TestMatEx_DummyConfigurator>(state1);
+    auto configurator2 = std::make_unique<TestMatEx_DummyConfigurator>(state2);
+    auto configurator3 = std::make_unique<TestMatEx_DummyConfigurator>(state3);
 
-    // Add memories to manager in RELEASED state (don't auto-materialize by constructing manually)
-    CUDAVirtualMemoryChunk vm1(std::move(creator1), {});
-    CUDAVirtualMemoryChunk vm2(std::move(creator2), {});
-    CUDAVirtualMemoryChunk vm3(std::move(creator3), {});
+    CUDAVirtualMemoryChunk::Configurators configurators1;
+    configurators1.push_back(std::move(configurator1));
+    CUDAVirtualMemoryChunk::Configurators configurators2;
+    configurators2.push_back(std::move(configurator2));
+    CUDAVirtualMemoryChunk::Configurators configurators3;
+    configurators3.push_back(std::move(configurator3));
+
+    CUDAVirtualMemoryChunk vm1(std::move(creator1), std::move(configurators1));
+    CUDAVirtualMemoryChunk vm2(std::move(creator2), std::move(configurators2));
+    CUDAVirtualMemoryChunk vm3(std::move(creator3), std::move(configurators3));
 
     mVMManager->add(0x1000, "test_tag", std::move(vm1));
     mVMManager->add(0x2000, "test_tag", std::move(vm2));
     mVMManager->add(0x3000, "test_tag", std::move(vm3));
 
-    // Verify initial state is clean
     EXPECT_TRUE(badHandles().empty());
 
-    // materializeWithTag should stop at the first exception (second memory by create order)
-    // and attempt to rollback the first memory that succeeded
     EXPECT_THROW(mVMManager->materializeWithTag("test_tag"), DummyException);
 
-    // Find which creators were called and in what order
     std::vector<std::pair<uintptr_t, CreatorState*>> creators
         = {{0x1000, &state1}, {0x2000, &state2}, {0x3000, &state3}};
-    // Sort by myCreateIdx (nonzero means create was called)
     std::sort(creators.begin(), creators.end(),
         [](auto const& a, auto const& b) { return a.second->myCreateIdx < b.second->myCreateIdx; });
 
-    // The first memory (by create order) should have been materialized then released during rollback
     auto* first = creators[0].second;
     EXPECT_TRUE(first->createCalled);
-    EXPECT_TRUE(first->releaseCalled); // Rolled back
-    // The second memory should have thrown during setup, so creator was called but setup failed
+    EXPECT_TRUE(first->setupCalled);
+    EXPECT_TRUE(first->releaseCalled);
+
     auto* second = creators[1].second;
     EXPECT_TRUE(second->createCalled);
-    EXPECT_FALSE(second->releaseCalled);
-    // The third memory should not have been touched (myCreateIdx == 0)
+    EXPECT_TRUE(second->setupCalled);
+    EXPECT_TRUE(second->releaseCalled);
+
     auto* third = creators[2].second;
     EXPECT_FALSE(third->createCalled);
+    EXPECT_FALSE(third->setupCalled);
     EXPECT_FALSE(third->releaseCalled);
 
-    // The handle of the memory that threw should be the second one's handle
-    uintptr_t thrownHandle = creators[1].first;
-
-    // Verify bad handles tracking - memories that threw exceptions should be removed
     auto badHandles = mVMManager->retrieveBadHandles();
-    EXPECT_EQ(badHandles.size(), 1);
-    EXPECT_EQ(badHandles[0], thrownHandle);
+    EXPECT_TRUE(badHandles.empty());
 
-    // Verify the memory that threw was removed from the manager
-    auto removedMem = mVMManager->remove(thrownHandle);
-    EXPECT_FALSE(removedMem); // Should have been removed due to exception
+    auto const materialized = mVMManager->materializeWithTag("test_tag");
+    EXPECT_EQ(materialized, 3);
 
-    // The other two memories should still be in manager
     for (int i = 0; i < 3; ++i)
     {
-        if (creators[i].first != thrownHandle)
-        {
-            auto removed = mVMManager->remove(creators[i].first);
-            EXPECT_TRUE(removed);
-        }
+        auto removed = mVMManager->remove(creators[i].first);
+        EXPECT_TRUE(removed);
     }
 }
 

--- a/tensorrt_llm/_mnnvl_utils.py
+++ b/tensorrt_llm/_mnnvl_utils.py
@@ -444,6 +444,72 @@ class MnnvlMoe:
     moe_mapping: Mapping = None
 
     @staticmethod
+    def _workspace_bytes(workspace: Optional[MnnvlMemory]) -> int:
+        if workspace is None or not hasattr(workspace, "ptr"):
+            return 0
+        allocation = type(workspace).allocated_map.get(workspace.ptr)
+        if allocation is not None:
+            return int(allocation[1])
+        return int(getattr(workspace, "segment_size", 0) or 0)
+
+    @staticmethod
+    def workspace_bytes() -> int:
+        return sum(
+            MnnvlMoe._workspace_bytes(workspace) for workspace in (
+                MnnvlMoe.moe_workspace,
+                MnnvlMoe.moe_prepare_workspace,
+            ))
+
+    @staticmethod
+    def release_workspaces() -> int:
+        released_bytes = MnnvlMoe.workspace_bytes()
+        if released_bytes == 0:
+            return 0
+
+        comm = None
+        for workspace in (MnnvlMoe.moe_workspace,
+                          MnnvlMoe.moe_prepare_workspace):
+            if workspace is not None:
+                comm = type(workspace).get_comm(workspace.mapping)
+                break
+
+        if comm is not None:
+            comm.barrier()
+        torch.cuda.synchronize()
+
+        for attr in ("moe_workspace", "moe_prepare_workspace"):
+            workspace = getattr(MnnvlMoe, attr)
+            if workspace is None:
+                continue
+            if hasattr(workspace, "ptr"):
+                type(workspace).close_mnnvl_memory(workspace.ptr)
+                delattr(workspace, "ptr")
+            setattr(MnnvlMoe, attr, None)
+
+        MnnvlMoe.moe_workspace_tensor = None
+        MnnvlMoe.moe_prepare_workspace_tensor = None
+
+        if comm is not None:
+            comm.barrier()
+        torch.cuda.synchronize()
+        return released_bytes
+
+    @staticmethod
+    def restore_workspaces(mapping: Optional[Mapping] = None) -> int:
+        mapping = mapping or MnnvlMoe.moe_mapping
+        if mapping is None:
+            return 0
+
+        before_bytes = MnnvlMoe.workspace_bytes()
+        if MnnvlMoe.moe_workspace is None:
+            MnnvlMoe.get_moe_workspaces(mapping)
+        if MnnvlMoe.moe_prepare_workspace is None:
+            MnnvlMoe.get_moe_prepare_workspace(mapping)
+
+        torch.cuda.synchronize()
+        return max(MnnvlMoe.workspace_bytes() - before_bytes, 0)
+
+    @staticmethod
     def get_moe_workspaces(mapping: Mapping):
         if MnnvlMoe.moe_workspace is not None:
             assert mapping == MnnvlMoe.moe_mapping, "only one moe mapping supported now"

--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -29,6 +29,13 @@ from tensorrt_llm.mapping import Mapping
 PP_COMM_TAG_AUTOTUNING = 30000
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
 class DistributedTuningStrategy(enum.Enum):
     """
     Strategy for distributed tuning.
@@ -1165,6 +1172,8 @@ class AutoTuner:
             to get an average execution time. Stream synchronization and delays
             are used to ensure accurate timing.
         """
+        use_cuda_graph = _env_bool("TLLM_AUTOTUNER_USE_CUDA_GRAPH",
+                                   use_cuda_graph)
         input_tensor_batches = self._prepare_input_tensors_with_batches(
             inputs, tuning_config)
 

--- a/tensorrt_llm/_torch/distributed/moe_alltoall.py
+++ b/tensorrt_llm/_torch/distributed/moe_alltoall.py
@@ -156,6 +156,7 @@ class MoeAlltoAll:
         # Initialize or reuse workspace
         MnnvlMemory.initialize()
 
+        self.mapping = mapping
         self.workspace_size_per_rank = workspace_size_per_rank
         self.max_num_tokens = max_num_tokens
         self.ep_size = mapping.moe_ep_size
@@ -177,17 +178,53 @@ class MoeAlltoAll:
         self.enable_eplb = num_experts is not None
         self.eplb_stats_num_experts = num_experts
 
+        self._state: _A2AState = _A2AState()
+        self.restore_workspace()
+
+    @classmethod
+    def release_workspace(cls) -> int:
+        workspace = cls._WORKSPACE
+        if workspace is None:
+            return 0
+
+        workspace_size = int(workspace.get("workspace_size_per_rank", 0))
+        mnnvl_mem = workspace.get("mnnvl_mem")
+        cls._WORKSPACE = None
+
+        torch.cuda.synchronize()
+        if mnnvl_mem is not None and hasattr(mnnvl_mem, "ptr"):
+            type(mnnvl_mem).close_mnnvl_memory(mnnvl_mem.ptr)
+            delattr(mnnvl_mem, "ptr")
+        workspace.clear()
+
+        if workspace_size:
+            tllm_logger.info(
+                "NVLinkOneSided AlltoAll: Released workspace with size %d bytes.",
+                workspace_size,
+            )
+        return workspace_size
+
+    def release(self) -> int:
+        released_size = self.release_workspace()
+        self.mnnvl_mem = None
+        self.workspace = None
+        self.metainfo = None
+        self._state = _A2AState()
+        return released_size
+
+    def restore_workspace(self) -> None:
         if self._WORKSPACE is None:
             tllm_logger.info(
-                f"NVLinkOneSided AlltoAll: Allocating workspace with size {workspace_size_per_rank} bytes. ep_rank: {self.ep_rank}, ep_size: {self.ep_size}, max_num_tokens: {self.max_num_tokens}"
+                f"NVLinkOneSided AlltoAll: Allocating workspace with size {self.workspace_size_per_rank} bytes. ep_rank: {self.ep_rank}, ep_size: {self.ep_size}, max_num_tokens: {self.max_num_tokens}"
             )
-            mnnvl_mem = MnnvlMemory(mapping, workspace_size_per_rank)
+            mnnvl_mem = MnnvlMemory(self.mapping,
+                                    self.workspace_size_per_rank)
             workspace = mnnvl_mem.as_torch_strided_tensor(torch.uint8)
             metainfo = torch.ops.trtllm.moe_a2a_initialize(
                 workspace, self.ep_rank, self.ep_size, self.max_num_tokens,
                 self.eplb_stats_num_experts)
             MoeAlltoAll._WORKSPACE = {
-                "workspace_size_per_rank": workspace_size_per_rank,
+                "workspace_size_per_rank": self.workspace_size_per_rank,
                 "max_num_tokens": self.max_num_tokens,
                 "ep_rank": self.ep_rank,
                 "ep_size": self.ep_size,
@@ -198,7 +235,7 @@ class MoeAlltoAll:
             }
         else:
             assert self._WORKSPACE[
-                "workspace_size_per_rank"] == workspace_size_per_rank, "mistakenly reusing workspace with different workspace_size_per_rank"
+                "workspace_size_per_rank"] == self.workspace_size_per_rank, "mistakenly reusing workspace with different workspace_size_per_rank"
             assert self._WORKSPACE[
                 "max_num_tokens"] == self.max_num_tokens, "mistakenly reusing workspace with different max_num_tokens"
             assert self._WORKSPACE[
@@ -212,7 +249,6 @@ class MoeAlltoAll:
         self.mnnvl_mem = self._WORKSPACE["mnnvl_mem"]
         self.workspace = self._WORKSPACE["workspace"]
         self.metainfo = self._WORKSPACE["metainfo"]
-        # Internal state
         self._state: _A2AState = _A2AState()
 
     def dispatch(self,

--- a/tensorrt_llm/_torch/memory/__init__.py
+++ b/tensorrt_llm/_torch/memory/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .gpu_memory_backend import GMSBackend, GPUMemoryBackend
+
+__all__ = ["GPUMemoryBackend", "GMSBackend"]

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import contextmanager
+from typing import Iterator, Optional, Protocol, runtime_checkable
+
+import torch
+from torch import nn
+
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
+
+_MODE_ALIASES = ("rw", "ro", "auto")
+
+
+@runtime_checkable
+class GPUMemoryBackend(Protocol):
+    def connect(self) -> bool:
+        ...
+
+    @property
+    def is_rw(self) -> Optional[bool]:
+        ...
+
+    def has_committed_weights(self) -> bool:
+        ...
+
+    def mem_pool_scope(self, device: Optional[torch.device] = None) -> Iterator[None]:
+        ...
+
+    def materialize_module(self, model: nn.Module) -> None:
+        ...
+
+    def finalize_write(self, model: nn.Module) -> int:
+        ...
+
+    def move_untracked_params(self, model: nn.Module) -> None:
+        ...
+
+    def cleanup(self) -> None:
+        ...
+
+
+class GMSBackend:
+    DEFAULT_TAG = "weights"
+
+    def __init__(
+        self,
+        socket_path: Optional[str],
+        mapping: Mapping,
+        mode: str = "auto",
+        tag: str = DEFAULT_TAG,
+    ) -> None:
+        if mode not in _MODE_ALIASES:
+            raise ValueError(
+                f"GMS mode must be one of {_MODE_ALIASES}, got {mode!r}")
+
+        self._socket_path = socket_path
+        self._mapping = mapping
+        self._mode = mode
+        self._tag = tag
+        self._device_index = torch.cuda.current_device()
+        self._client = None
+        self._is_rw: Optional[bool] = None
+
+    def connect(self) -> bool:
+        try:
+            from gpu_memory_service.client.torch.allocator import (
+                get_or_create_gms_client_memory_manager,
+            )
+            from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
+            from gpu_memory_service.common.utils import get_socket_path
+            from gpu_memory_service.integrations.common.patches import patch_empty_cache
+        except ImportError:
+            logger.warning(
+                "gpu_memory_service is not installed; LoadFormat.GMS is unavailable.")
+            return False
+
+        mode_map = {
+            "rw": RequestedLockType.RW,
+            "ro": RequestedLockType.RO,
+            "auto": RequestedLockType.RW_OR_RO,
+        }
+
+        socket_path = self._socket_path
+        if socket_path is None:
+            socket_path = get_socket_path(self._device_index, self._tag)
+        self._socket_path = socket_path
+
+        try:
+            self._client = get_or_create_gms_client_memory_manager(
+                socket_path,
+                self._device_index,
+                mode=mode_map[self._mode],
+                tag=self._tag,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to connect to GMS at %s (mode=%s, tag=%s): %s",
+                socket_path,
+                self._mode,
+                self._tag,
+                e,
+            )
+            self._client = None
+            return False
+
+        self._is_rw = self._client.granted_lock_type == GrantedLockType.RW
+        try:
+            patch_empty_cache()
+        except Exception as e:
+            logger.debug("GMS patch_empty_cache failed (non-fatal): %s", e)
+
+        logger.info(
+            "Connected to GMS at %s (mode=%s, granted=%s, tag=%s)",
+            socket_path,
+            self._mode,
+            "RW" if self._is_rw else "RO",
+            self._tag,
+        )
+        return True
+
+    @property
+    def is_rw(self) -> Optional[bool]:
+        return self._is_rw
+
+    def has_committed_weights(self) -> bool:
+        if self._client is None:
+            return False
+        try:
+            from gpu_memory_service.common.locks import GrantedLockType
+
+            return self._client.granted_lock_type == GrantedLockType.RO
+        except Exception:
+            return False
+
+    @contextmanager
+    def mem_pool_scope(
+        self,
+        device: Optional[torch.device] = None,
+    ) -> Iterator[None]:
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+        if self._is_rw is False:
+            raise RuntimeError(
+                "GMS mem_pool_scope() is only valid in RW mode (this client was granted RO)."
+            )
+
+        from gpu_memory_service.client.torch.allocator import gms_use_mem_pool
+
+        target_device = device
+        if target_device is None:
+            target_device = torch.device("cuda", self._device_index)
+
+        with gms_use_mem_pool(self._tag, target_device):
+            yield
+
+    def move_untracked_params(self, model: nn.Module) -> None:
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+
+        from gpu_memory_service.client.torch.module import _iter_module_tensors
+        from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+
+        gms_client = self._client
+        seen: set[int] = set()
+
+        with torch.no_grad():
+            for _name, tensor, tensor_type in _iter_module_tensors(model):
+                if tensor_type != "parameter" or tensor is None or not tensor.is_cuda:
+                    continue
+
+                storage_ptr = tensor.untyped_storage().data_ptr()
+                if storage_ptr in seen:
+                    continue
+                seen.add(storage_ptr)
+
+                if _ptr_in_gms(gms_client, int(tensor.data_ptr())):
+                    continue
+
+                nbytes = _storage_nbytes(tensor)
+                base_va = gms_client.create_mapping(size=nbytes, tag=self._tag)
+                replacement = _tensor_from_pointer(
+                    int(base_va),
+                    list(tensor.shape),
+                    list(tensor.stride()),
+                    tensor.dtype,
+                    self._device_index,
+                )
+                replacement.copy_(tensor)
+                tensor.data = replacement
+
+    def finalize_write(self, model: nn.Module) -> int:
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+        if self._is_rw is False:
+            raise RuntimeError("GMS finalize_write() is only valid in RW mode.")
+
+        from gpu_memory_service.client.torch.module import register_module_tensors
+        from gpu_memory_service.integrations.common.utils import finalize_gms_write
+
+        register_module_tensors(self._client, model)
+        bytes_committed = int(self._client.total_bytes)
+        torch.cuda.synchronize()
+        finalize_gms_write(self._client)
+        self._is_rw = False
+        logger.info(
+            "GMS RW->RO: committed %.2f GiB at %s (tag=%s)",
+            bytes_committed / (1 << 30),
+            self._socket_path,
+            self._tag,
+        )
+        return bytes_committed
+
+    def materialize_module(self, model: nn.Module) -> None:
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+
+        from gpu_memory_service.client.torch.module import materialize_module_from_gms
+        from tensorrt_llm._torch.modules.linear import Linear
+
+        materialize_module_from_gms(
+            self._client,
+            model,
+            device_index=self._device_index,
+        )
+
+        for module in model.modules():
+            if isinstance(module, Linear):
+                module._weights_presharded = True
+
+        logger.info(
+            "GMS RO: materialized weights from %s (tag=%s, tp_rank=%d/%d, total_bytes=%.2f GiB)",
+            self._socket_path,
+            self._tag,
+            self._mapping.tp_rank,
+            self._mapping.tp_size,
+            int(self._client.total_bytes) / (1 << 30),
+        )
+
+    def cleanup(self) -> None:
+        if self._client is None:
+            return
+
+        try:
+            from gpu_memory_service.client.torch.allocator import (
+                evict_gms_client_memory_manager,
+            )
+
+            client = self._client
+            try:
+                client.close()
+            except Exception:
+                pass
+            evict_gms_client_memory_manager(client)
+            logger.info("GMS: disconnected from %s", self._socket_path)
+        except Exception as e:
+            logger.warning("GMS cleanup error: %s", e)
+        finally:
+            self._client = None
+
+
+def _ptr_in_gms(gms_client, ptr: int) -> bool:
+    mappings = getattr(gms_client, "mappings", None)
+    if not mappings:
+        mappings = getattr(gms_client, "_mappings", None)
+    if not mappings:
+        return False
+
+    for mapping in mappings.values():
+        base = int(getattr(mapping, "va", 0))
+        size = int(getattr(mapping, "aligned_size", getattr(mapping, "size", 0)))
+        if base and size and base <= ptr < base + size:
+            return True
+    return False
+
+
+def _storage_nbytes(tensor: torch.Tensor) -> int:
+    return int(tensor.untyped_storage().nbytes())

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -150,6 +150,16 @@ class GMSBackend:
             return 0
         return int(self._client.total_bytes)
 
+    def mapped_bytes(self) -> int:
+        if self._client is None:
+            return 0
+
+        total = 0
+        for mapping in getattr(self._client, "mappings", {}).values():
+            if int(getattr(mapping, "handle", 0)) != 0:
+                total += int(getattr(mapping, "aligned_size", 0))
+        return total
+
     @contextmanager
     def mem_pool_scope(
         self,
@@ -270,6 +280,45 @@ class GMSBackend:
             self._mapping.tp_size,
             int(self._client.total_bytes) / (1 << 30),
         )
+
+    def park_weights(self) -> int:
+        if self._client is None:
+            return 0
+        if self._is_rw is True:
+            logger.warning("GMS: refusing to park RW weight mappings")
+            return 0
+        if getattr(self._client, "is_unmapped", False):
+            return 0
+
+        mapped_bytes = self.mapped_bytes()
+        self._client.unmap_all_vas()
+        self._client.abort()
+        self._is_rw = None
+        logger.info(
+            "GMS: parked %.2f GiB of RO weight mappings for tag=%s",
+            mapped_bytes / (1 << 30),
+            self._tag,
+        )
+        return mapped_bytes
+
+    def restore_weights(self) -> int:
+        if self._client is None:
+            return 0
+        if not getattr(self._client, "is_unmapped", False):
+            return 0
+
+        from gpu_memory_service.common.locks import RequestedLockType
+
+        self._client.connect(RequestedLockType.RO, timeout_ms=30_000)
+        self._client.remap_all_vas()
+        self._is_rw = False
+        mapped_bytes = self.mapped_bytes()
+        logger.info(
+            "GMS: restored %.2f GiB of RO weight mappings for tag=%s",
+            mapped_bytes / (1 << 30),
+            self._tag,
+        )
+        return mapped_bytes
 
     def cleanup(self) -> None:
         if self._client is None:

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Mapping as MappingABC
 from contextlib import contextmanager
 from typing import Iterator, Optional, Protocol, runtime_checkable
 
@@ -23,6 +24,9 @@ class GPUMemoryBackend(Protocol):
         ...
 
     def has_committed_weights(self) -> bool:
+        ...
+
+    def total_bytes(self) -> int:
         ...
 
     def mem_pool_scope(self, device: Optional[torch.device] = None) -> Iterator[None]:
@@ -140,6 +144,11 @@ class GMSBackend:
             return self._client.granted_lock_type == GrantedLockType.RO
         except Exception:
             return False
+
+    def total_bytes(self) -> int:
+        if self._client is None:
+            return 0
+        return int(self._client.total_bytes)
 
     @contextmanager
     def mem_pool_scope(
@@ -287,14 +296,17 @@ class GMSBackend:
 
 def _ptr_in_gms(gms_client, ptr: int) -> bool:
     mappings = getattr(gms_client, "mappings", None)
-    if not mappings:
+    if not isinstance(mappings, MappingABC):
         mappings = getattr(gms_client, "_mappings", None)
-    if not mappings:
+    if not isinstance(mappings, MappingABC) or not mappings:
         return False
 
     for mapping in mappings.values():
         base = int(getattr(mapping, "va", 0))
-        size = int(getattr(mapping, "aligned_size", getattr(mapping, "size", 0)))
+        size = getattr(mapping, "aligned_size", None)
+        if not isinstance(size, int):
+            size = getattr(mapping, "size", 0)
+        size = int(size)
         if base and size and base <= ptr < base + size:
             return True
     return False

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -34,6 +34,12 @@ class GPUMemoryBackend(Protocol):
     def finalize_write(self, model: nn.Module) -> int:
         ...
 
+    def defer_finalize_write(self, model: nn.Module) -> None:
+        ...
+
+    def finalize_pending_write(self) -> int:
+        ...
+
     def move_untracked_params(self, model: nn.Module) -> None:
         ...
 
@@ -62,6 +68,7 @@ class GMSBackend:
         self._device_index = torch.cuda.current_device()
         self._client = None
         self._is_rw: Optional[bool] = None
+        self._pending_model: Optional[nn.Module] = None
 
     def connect(self) -> bool:
         try:
@@ -196,6 +203,8 @@ class GMSBackend:
         if self._is_rw is False:
             raise RuntimeError("GMS finalize_write() is only valid in RW mode.")
 
+        self._pending_model = None
+
         from gpu_memory_service.client.torch.module import register_module_tensors
         from gpu_memory_service.integrations.common.utils import finalize_gms_write
 
@@ -211,6 +220,21 @@ class GMSBackend:
             self._tag,
         )
         return bytes_committed
+
+    def defer_finalize_write(self, model: nn.Module) -> None:
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+        if self._is_rw is False:
+            raise RuntimeError("GMS defer_finalize_write() is only valid in RW mode.")
+        self._pending_model = model
+
+    def finalize_pending_write(self) -> int:
+        if self._pending_model is None:
+            return 0
+
+        model = self._pending_model
+        self._pending_model = None
+        return self.finalize_write(model)
 
     def materialize_module(self, model: nn.Module) -> None:
         if self._client is None:
@@ -258,6 +282,7 @@ class GMSBackend:
             logger.warning("GMS cleanup error: %s", e)
         finally:
             self._client = None
+            self._pending_model = None
 
 
 def _ptr_in_gms(gms_client, ptr: int) -> bool:

--- a/tensorrt_llm/_torch/memory_buffer_utils.py
+++ b/tensorrt_llm/_torch/memory_buffer_utils.py
@@ -35,6 +35,33 @@ class Buffers:
     def __init__(self):
         self.buffers: dict[str, list[BufferBlock]] = {}
 
+    def bytes_by_name(self) -> dict[str, int]:
+        bytes_by_name = {}
+        for name, blocks in self.buffers.items():
+            total = 0
+            for block in blocks:
+                buffer = getattr(block, "buffer", None)
+                if buffer is not None:
+                    total += int(buffer.numel()) * int(buffer.element_size())
+            if total:
+                bytes_by_name[name] = total
+        return bytes_by_name
+
+    def clear(self) -> tuple[int, int]:
+        released_bytes = 0
+        released_buffers = 0
+        for blocks in self.buffers.values():
+            for block in blocks:
+                buffer = getattr(block, "buffer", None)
+                if buffer is None:
+                    continue
+                released_bytes += int(buffer.numel()) * int(
+                    buffer.element_size())
+                released_buffers += 1
+                del block.buffer
+        self.buffers.clear()
+        return released_buffers, released_bytes
+
     @staticmethod
     def _view_as(buffer: torch.Tensor, target_shape: list[int],
                  target_dtype: torch.dtype) -> torch.Tensor:

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -1,4 +1,5 @@
 import contextlib
+import errno
 import json
 import os
 import tempfile
@@ -28,6 +29,10 @@ from tensorrt_llm.quantization.mode import QuantAlgo
 TConfig = TypeVar("TConfig", bound=transformers.PretrainedConfig)
 
 
+def _is_shared_fs_lock_error(exc: BaseException) -> bool:
+    return isinstance(exc, OSError) and exc.errno in (errno.ESTALE, errno.ENOLCK)
+
+
 @contextlib.contextmanager
 def config_file_lock(timeout: int = 10):
     """
@@ -49,7 +54,9 @@ def config_file_lock(timeout: int = 10):
     try:
         with lock:
             yield
-    except (PermissionError, filelock.Timeout):
+    except (PermissionError, filelock.Timeout, OSError) as e:
+        if isinstance(e, OSError) and not _is_shared_fs_lock_error(e):
+            raise
         # Fallback to tempdir
         tmp_dir = Path(tempfile.gettempdir())
         tmp_dir.mkdir(parents=True, exist_ok=True)
@@ -58,15 +65,11 @@ def config_file_lock(timeout: int = 10):
         try:
             with tmp_lock:
                 yield
-        except filelock.Timeout:
+        except (filelock.Timeout, PermissionError, OSError) as e:
+            if isinstance(e, OSError) and not _is_shared_fs_lock_error(e):
+                raise
             logger.warning(
-                f"failed to acquire tempdir config lock within {timeout} seconds, proceeding without lock"
-            )
-            # proceed without lock
-            yield
-        except (PermissionError) as e:
-            logger.warning(
-                f"tempdir config lock unavailable due to OS/permission issue: {e}, proceeding without lock"
+                f"config lock unavailable ({e}); proceeding without config lock"
             )
             # proceed without lock
             yield

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
@@ -283,6 +283,36 @@ class NVLinkOneSided(Communication):
         """
         return MnnvlMemory.supports_mnnvl()
 
+    @classmethod
+    def release_workspace(cls) -> int:
+        workspace = cls._WORKSPACE
+        if workspace is None:
+            return 0
+
+        workspace_size = int(workspace.get("workspace_size_per_rank", 0))
+        mnnvl_mem = workspace.get("mnnvl_mem")
+        cls._WORKSPACE = None
+
+        torch.cuda.synchronize()
+        if mnnvl_mem is not None and hasattr(mnnvl_mem, "ptr"):
+            type(mnnvl_mem).close_mnnvl_memory(mnnvl_mem.ptr)
+            delattr(mnnvl_mem, "ptr")
+        workspace.clear()
+
+        if workspace_size:
+            tllm_logger.info(
+                "NVLinkOneSided: Released workspace with size %d bytes.",
+                workspace_size,
+            )
+        return workspace_size
+
+    def destroy(self):
+        self.release_workspace()
+        self.mnnvl_mem = None
+        self.workspace = None
+        self.moe_a2a_metainfo = None
+        self._dispatch_state = {"phase": "destroyed"}
+
     def supports_post_quant_dispatch(self) -> bool:
         """
         NVLINK one-sided comm supports post-quant dispatch.

--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -383,10 +383,13 @@ class ConfigurableMoE(MoE):
         Side effects:
             - May switch self.comm to AllGather if current strategy cannot be used
 
-        Note: This method does NOT create strategy if None (creation happens lazily elsewhere).
-              It only validates and potentially falls back existing AllToAll strategies.
+        Note: This method recreates the communication strategy if it was
+              destroyed while the engine was sleeping.
 
         """
+
+        if self.comm is None:
+            self.comm = self._create_comm_strategy_auto()
 
         # Early return if nothing to validate:
         # - None: Atten is TP or single rank, no communication needed
@@ -422,6 +425,7 @@ class ConfigurableMoE(MoE):
         """
         if self.comm is not None:
             self.comm.destroy()
+            self.comm = None
 
     def __enter__(self):
         return self

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -104,7 +104,16 @@ def load_weight_shard(
     tensor_parallel_mode: Optional[TensorParallelMode] = None,
     device: torch.device = torch.device('cpu'),
     return_slice_indices: bool = False,
+    *,
+    module: Optional[nn.Module] = None,
 ) -> torch.Tensor:
+    # If the caller's module already holds presharded weights (e.g. zero-copy
+    # imported from GMS RO), skip re-sharding. This preserves correctness for
+    # any later `module.load_weights(...)` or `ModelLoader.reload(...)` path
+    # that reaches this function after materialization.
+    if module is not None and getattr(module, '_weights_presharded', False):
+        tensor_parallel_size = 1
+        tensor_parallel_rank = 0
     # Skip device transfers on integrated GPUs to conserve shared memory
     if weight.device.type != device.type and is_device_integrated():
         # For integrated GPU systems (e.g., DGX Spark), CPU and GPU share limited physical memory.
@@ -186,7 +195,7 @@ def load_weights_vanilla_helper(module: Linear,
 
     weight = load_weight_shard(weights[0]['weight'], module.tp_size,
                                module.tp_rank, module.tp_mode,
-                               device) if "weight" in weights[0] else None
+                               device, module=module) if "weight" in weights[0] else None
 
     if weight is not None:
         if module.has_weight_only_quant:
@@ -203,7 +212,7 @@ def load_weights_vanilla_helper(module: Linear,
     if module.bias is not None:
         bias = load_weight_shard(weights[0]['bias'], module.tp_size,
                                  module.tp_rank, module.tp_mode,
-                                 device) if "bias" in weights[0] else None
+                                 device, module=module) if "bias" in weights[0] else None
         if bias is not None:
             copy_weight(module.bias, bias_transform(bias))
 
@@ -227,24 +236,24 @@ def load_weights_fused_qkv_helper(
 
     q_weight = load_weight_shard(weights[0]['weight'], module.tp_size,
                                  module.tp_rank, module.tp_mode,
-                                 device) if "weight" in weights[0] else None
+                                 device, module=module) if "weight" in weights[0] else None
     k_weight = load_weight_shard(weights[1]['weight'], module.tp_size,
                                  module.tp_rank, module.tp_mode,
-                                 device) if "weight" in weights[1] else None
+                                 device, module=module) if "weight" in weights[1] else None
     v_weight = load_weight_shard(weights[2]['weight'], module.tp_size,
                                  module.tp_rank, module.tp_mode,
-                                 device) if "weight" in weights[2] else None
+                                 device, module=module) if "weight" in weights[2] else None
 
     if module.bias is not None:
         q_bias = load_weight_shard(weights[0]['bias'], module.tp_size,
                                    module.tp_rank, module.tp_mode,
-                                   device) if "bias" in weights[0] else None
+                                   device, module=module) if "bias" in weights[0] else None
         k_bias = load_weight_shard(weights[1]['bias'], module.tp_size,
                                    module.tp_rank, module.tp_mode,
-                                   device) if "bias" in weights[1] else None
+                                   device, module=module) if "bias" in weights[1] else None
         v_bias = load_weight_shard(weights[2]['bias'], module.tp_size,
                                    module.tp_rank, module.tp_mode,
-                                   device) if "bias" in weights[2] else None
+                                   device, module=module) if "bias" in weights[2] else None
         if not allow_partial_loading:
             copy_weight(module.bias,
                         bias_transform(torch.cat((q_bias, k_bias, v_bias))))
@@ -280,17 +289,17 @@ def load_weights_fused_gate_up_helper(
 
     gate_weight = load_weight_shard(weights[0]['weight'], module.tp_size,
                                     module.tp_rank, module.tp_mode,
-                                    device) if "weight" in weights[0] else None
+                                    device, module=module) if "weight" in weights[0] else None
     up_weight = load_weight_shard(weights[1]['weight'], module.tp_size,
                                   module.tp_rank, module.tp_mode,
-                                  device) if "weight" in weights[1] else None
+                                  device, module=module) if "weight" in weights[1] else None
     if module.bias is not None:
         gate_bias = load_weight_shard(weights[0]['bias'], module.tp_size,
                                       module.tp_rank, module.tp_mode,
-                                      device) if "bias" in weights[0] else None
+                                      device, module=module) if "bias" in weights[0] else None
         up_bias = load_weight_shard(weights[1]['bias'], module.tp_size,
                                     module.tp_rank, module.tp_mode,
-                                    device) if "bias" in weights[1] else None
+                                    device, module=module) if "bias" in weights[1] else None
         if not allow_partial_loading:
             copy_weight(module.bias,
                         bias_transform(torch.cat((gate_bias, up_bias))))
@@ -2502,6 +2511,7 @@ class Linear(nn.Module):
         self.use_cute_dsl_blockscaling_mm = use_cute_dsl_blockscaling_mm
         self.disable_deep_gemm = disable_deep_gemm
         self.fused_weight_shard_indices_mapping = fused_weight_shard_indices_mapping
+        self._weights_presharded = False
 
         # Store NVFP4 GEMM allowed backends configuration
         # Read from model_extra_attrs if not explicitly provided (allows config via llm_api_options)

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -181,14 +181,17 @@ class KvCacheCreator:
         NOTE: `allocated_bytes` is the total KV-cache memory that must be pre-allocated during the estimation phase (for both the main and draft models) so the estimation run can complete successfully. When computing `available_kv_mem`, add this amount back in.
         """
         kv_size_per_token = self._get_kv_size_per_token()
+        peer_memory_reserve_bytes = self._gms_shadow_peer_memory_reserve_bytes()
 
-        available_kv_mem = (total_gpu_memory - peak_memory +
+        available_kv_mem = (total_gpu_memory - peak_memory -
+                            peer_memory_reserve_bytes +
                             allocated_bytes) * fraction
         logger.info(
             f"Peak memory during memory usage profiling (torch + non-torch): {peak_memory / (GB):.2f} GiB, "
             f"available KV cache memory when calculating max tokens: {available_kv_mem / (GB):.2f} GiB, "
             f"fraction is set {fraction}, kv size per token is {kv_size_per_token}. device total memory {total_gpu_memory / (GB):.2f} GiB, "
-            f"temporary kv cache memory during profiling {allocated_bytes / (GB):.2f} GiB"
+            f"temporary kv cache memory during profiling {allocated_bytes / (GB):.2f} GiB, "
+            f"GMS peer memory reserve {peer_memory_reserve_bytes / (GB):.2f} GiB"
         )
         return int(available_kv_mem)
 
@@ -254,6 +257,38 @@ class KvCacheCreator:
                 continue
             total += int(model_loader.gms_weight_bytes())
         return total
+
+    def _gms_shadow_peer_memory_reserve_bytes(self) -> int:
+        def _env_value(key: str) -> Optional[str]:
+            value = os.environ.get(key)
+            if value is not None:
+                return value
+
+            env_overrides = getattr(getattr(self, "_llm_args", None),
+                                    "env_overrides", None)
+            if isinstance(env_overrides, dict):
+                return env_overrides.get(key)
+            return None
+
+        raw_bytes = _env_value("TRTLLM_GMS_SHADOW_PEER_MEMORY_RESERVE_BYTES")
+        if raw_bytes is not None:
+            try:
+                return max(int(raw_bytes), 0)
+            except ValueError:
+                logger.warning(
+                    "Ignoring invalid TRTLLM_GMS_SHADOW_PEER_MEMORY_RESERVE_BYTES=%r",
+                    raw_bytes)
+                return 0
+
+        raw_gib = _env_value("TRTLLM_GMS_SHADOW_PEER_MEMORY_RESERVE_GIB")
+        if raw_gib is not None:
+            try:
+                return max(int(float(raw_gib) * GB), 0)
+            except ValueError:
+                logger.warning(
+                    "Ignoring invalid TRTLLM_GMS_SHADOW_PEER_MEMORY_RESERVE_GIB=%r",
+                    raw_gib)
+        return 0
 
     def _moe_workspace_bytes(self) -> int:
         total = 0
@@ -350,6 +385,7 @@ class KvCacheCreator:
     ) -> int:
         gms_weight_bytes = self._gms_weight_bytes()
         moe_workspace_bytes = self._moe_workspace_bytes()
+        peer_memory_reserve_bytes = self._gms_shadow_peer_memory_reserve_bytes()
         # non_torch_extra_bytes is process-local.  RO GMS weight mappings are
         # not charged to the process by NVML, so count them separately.
         local_extra_bytes = max(non_torch_extra_bytes - moe_workspace_bytes, 0)
@@ -357,7 +393,8 @@ class KvCacheCreator:
                                      min_torch_activation_bytes, 0)
         local_non_kv_memory = (
             model_bytes + torch_activation_bytes + gms_weight_bytes +
-            moe_workspace_bytes + local_extra_bytes)
+            moe_workspace_bytes + local_extra_bytes +
+            peer_memory_reserve_bytes)
         available_kv_mem = max(total_gpu_memory - local_non_kv_memory, 0) * fraction
         logger.info(
             "GMS shadow KV calibration: available KV cache memory "
@@ -372,6 +409,7 @@ class KvCacheCreator:
             f"temporary_kv={temporary_kv_bytes / GB:.2f} GiB, "
             f"non_torch_extra={non_torch_extra_bytes / GB:.2f} GiB, "
             f"local_non_torch_extra={local_extra_bytes / GB:.2f} GiB, "
+            f"peer_memory_reserve={peer_memory_reserve_bytes / GB:.2f} GiB, "
             f"fraction={fraction}). Other engines' active KV is intentionally ignored."
         )
         return int(available_kv_mem)

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -104,6 +104,8 @@ class KvCacheCreator:
         self._mapping = mapping
         self._kv_cache_config = kv_cache_config
         self._max_kv_tokens_in = self._kv_cache_config.max_tokens
+        self._max_gpu_total_bytes_in = self._kv_cache_config.max_gpu_total_bytes
+        self._gms_shadow_torch_activation_reserve_bytes = 0
         self._max_num_tokens = max_num_tokens
         self._max_beam_width = max_beam_width
         self._kv_connector_manager = kv_connector_manager
@@ -190,6 +192,58 @@ class KvCacheCreator:
         )
         return int(available_kv_mem)
 
+    def _same_gms_engine_process(self, pid: int) -> bool:
+        current_engine_id = self._llm_env("ENGINE_ID")
+        current_socket_dir = self._llm_env("GMS_SOCKET_DIR")
+        if current_engine_id is None:
+            return False
+
+        try:
+            with open(f"/proc/{pid}/environ", "rb") as env_file:
+                entries = env_file.read().split(b"\0")
+        except OSError:
+            return False
+
+        process_env = {}
+        for entry in entries:
+            if b"=" not in entry:
+                continue
+            key, value = entry.split(b"=", 1)
+            try:
+                process_env[key.decode()] = value.decode()
+            except UnicodeDecodeError:
+                continue
+
+        if process_env.get("ENGINE_ID") != current_engine_id:
+            return False
+        if current_socket_dir is not None:
+            return process_env.get("GMS_SOCKET_DIR") == current_socket_dir
+        return True
+
+    def _current_process_gpu_memory(self) -> Optional[int]:
+        try:
+            import pynvml
+        except ImportError:
+            logger.debug("pynvml is not available for process-local memory accounting")
+            return None
+
+        try:
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(
+                torch.cuda.current_device())
+            current_pid = os.getpid()
+            used_bytes = 0
+            for proc in pynvml.nvmlDeviceGetComputeRunningProcesses(handle):
+                proc_pid = int(proc.pid)
+                if (proc_pid == current_pid
+                        or self._same_gms_engine_process(proc_pid)):
+                    used_bytes += int(proc.usedGpuMemory or 0)
+            return used_bytes if used_bytes > 0 else None
+        except Exception as exc:
+            logger.debug(
+                f"Unable to query process-local GPU memory with NVML: {exc}")
+            return None
+
     def _gms_weight_bytes(self) -> int:
         total = 0
         for engine in (self._model_engine, self._draft_model_engine):
@@ -243,17 +297,45 @@ class KvCacheCreator:
                             or 0)
         return total
 
+    def _llm_env(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        value = os.environ.get(key)
+        if value is not None:
+            return value
+
+        env_overrides = getattr(self._llm_args, "env_overrides", None)
+        if isinstance(env_overrides, dict):
+            return env_overrides.get(key, default)
+        return default
+
     def _use_gms_shadow_kv_calibration(self) -> bool:
-        if self._llm_args.load_format != LoadFormat.GMS:
-            return False
-        raw_value = os.environ.get("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", "1")
+        raw_value = str(
+            self._llm_env("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", "1"))
         if raw_value.lower() in {"0", "false", "no", "off"}:
             return False
-        if self._llm_args.gms_mode == "ro":
-            return True
-        if self._llm_args.gms_mode == "rw":
+        gms_mode = str(getattr(self._llm_args, "gms_mode", "")).lower()
+        if gms_mode == "rw":
             return False
-        return os.environ.get("ENGINE_ID", "0") != "0"
+        engine_id = self._llm_env("ENGINE_ID", "0")
+        if (self._llm_env("GMS_SOCKET_DIR") and engine_id != "0"):
+            return True
+
+        load_format = self._llm_args.load_format
+        load_format_name = getattr(load_format, "name", str(load_format)).upper()
+        load_format_value = getattr(load_format, "value", str(load_format))
+        load_format_text = str(load_format)
+        is_gms_load = (
+            load_format == LoadFormat.GMS
+            or load_format_name == LoadFormat.GMS.name
+            or str(load_format_value).lower() == LoadFormat.GMS.name.lower()
+            or load_format_text.lower() == LoadFormat.GMS.name.lower()
+            or load_format_text.lower().endswith(
+                f".{LoadFormat.GMS.name.lower()}")
+            or str(load_format_value) == str(LoadFormat.GMS.value))
+        if not is_gms_load:
+            return False
+        if gms_mode == "ro":
+            return True
+        return engine_id != "0"
 
     def _cal_gms_shadow_max_memory(
         self,
@@ -264,13 +346,15 @@ class KvCacheCreator:
         fraction: float,
         temporary_kv_bytes: int,
         non_torch_extra_bytes: int = 0,
+        min_torch_activation_bytes: int = 0,
     ) -> int:
         gms_weight_bytes = self._gms_weight_bytes()
         moe_workspace_bytes = self._moe_workspace_bytes()
-        local_extra_bytes = max(
-            non_torch_extra_bytes - gms_weight_bytes - moe_workspace_bytes, 0)
-        torch_activation_bytes = max(
-            torch_peak_memory - model_bytes - temporary_kv_bytes, 0)
+        # non_torch_extra_bytes is process-local.  RO GMS weight mappings are
+        # not charged to the process by NVML, so count them separately.
+        local_extra_bytes = max(non_torch_extra_bytes - moe_workspace_bytes, 0)
+        torch_activation_bytes = max(torch_peak_memory - model_bytes,
+                                     min_torch_activation_bytes, 0)
         local_non_kv_memory = (
             model_bytes + torch_activation_bytes + gms_weight_bytes +
             moe_workspace_bytes + local_extra_bytes)
@@ -280,6 +364,8 @@ class KvCacheCreator:
             f"{available_kv_mem / GB:.2f} GiB (total={total_gpu_memory / GB:.2f} GiB, "
             f"local_non_kv={local_non_kv_memory / GB:.2f} GiB, "
             f"torch_peak={torch_peak_memory / GB:.2f} GiB, "
+            f"torch_activation={torch_activation_bytes / GB:.2f} GiB, "
+            f"torch_activation_reserve={min_torch_activation_bytes / GB:.2f} GiB, "
             f"model_bytes={model_bytes / GB:.2f} GiB, "
             f"gms_weights={gms_weight_bytes / GB:.2f} GiB, "
             f"moe_workspace={moe_workspace_bytes / GB:.2f} GiB, "
@@ -509,11 +595,21 @@ class KvCacheCreator:
         end, total_gpu_memory = torch.cuda.mem_get_info()
         total_used_bytes = total_gpu_memory - end
         model_bytes = torch.cuda.memory_stats()["allocated_bytes.all.current"]
+        global_non_torch_bytes_after_load = max(
+            total_used_bytes - model_bytes, 0)
+        process_gpu_memory = self._current_process_gpu_memory()
+        non_torch_bytes_after_load = (
+            max(process_gpu_memory - model_bytes, 0)
+            if process_gpu_memory is not None else
+            max(global_non_torch_bytes_after_load - self._gms_weight_bytes(), 0))
         logger.info(
             f"Memory used after loading model weights (inside torch) in memory usage profiling: {model_bytes / (GB):.2f} GiB"
         )
         logger.info(
-            f"Memory used after loading model weights (outside torch) in memory usage profiling: {((total_used_bytes - model_bytes) if total_used_bytes > model_bytes else 0) / (GB):.2f} GiB"
+            f"Memory used after loading model weights (outside torch, all processes) in memory usage profiling: {global_non_torch_bytes_after_load / (GB):.2f} GiB"
+        )
+        logger.info(
+            f"Memory used after loading model weights (outside torch, current process) in memory usage profiling: {non_torch_bytes_after_load / (GB):.2f} GiB"
         )
         kv_cache_max_memory = None
 
@@ -568,21 +664,34 @@ class KvCacheCreator:
             total_used_bytes = total_gpu_memory - end
             activation_bytes = torch_peak_memory - model_bytes
             extra_cost = max(total_used_bytes - torch_used_bytes, 0)
+            process_gpu_memory = self._current_process_gpu_memory()
+            local_extra_cost = (
+                max(process_gpu_memory - torch_used_bytes, 0)
+                if process_gpu_memory is not None else
+                max(extra_cost - self._gms_weight_bytes(), 0))
             peak_memory = torch_peak_memory + extra_cost
             logger.info(
                 f"Memory dynamically allocated during inference (inside torch) in memory usage profiling: {activation_bytes / (GB):.2f} GiB"
             )
             logger.info(
-                f"Memory used outside torch (e.g., NCCL and CUDA graphs) in memory usage profiling: {extra_cost / (GB):.2f} GiB"
+                f"Memory used outside torch (e.g., NCCL and CUDA graphs, all processes) in memory usage profiling: {extra_cost / (GB):.2f} GiB"
+            )
+            logger.info(
+                f"Memory used outside torch (e.g., NCCL and CUDA graphs, current process) in memory usage profiling: {local_extra_cost / (GB):.2f} GiB"
             )
             if self._use_gms_shadow_kv_calibration():
+                self._gms_shadow_torch_activation_reserve_bytes = max(
+                    getattr(self, "_gms_shadow_torch_activation_reserve_bytes",
+                            0), activation_bytes)
                 kv_cache_max_memory = self._cal_gms_shadow_max_memory(
                     torch_peak_memory=torch_peak_memory,
                     model_bytes=model_bytes,
                     total_gpu_memory=total_gpu_memory,
                     fraction=fraction,
                     temporary_kv_bytes=allocated_bytes,
-                    non_torch_extra_bytes=extra_cost,
+                    non_torch_extra_bytes=local_extra_cost,
+                    min_torch_activation_bytes=getattr(
+                        self, "_gms_shadow_torch_activation_reserve_bytes", 0),
                 )
 
         else:
@@ -596,6 +705,9 @@ class KvCacheCreator:
                     total_gpu_memory=total_gpu_memory,
                     fraction=fraction,
                     temporary_kv_bytes=allocated_bytes,
+                    non_torch_extra_bytes=non_torch_bytes_after_load,
+                    min_torch_activation_bytes=getattr(
+                        self, "_gms_shadow_torch_activation_reserve_bytes", 0),
                 )
 
         # calculate max memory from peak memory and free gpu memory fraction
@@ -643,11 +755,11 @@ class KvCacheCreator:
 
         # ---------------------------handle max_gpu_total_bytes---------------------------------
         # if user provided max_gpu_total_bytes, set max memory from max_gpu_total_bytes
-        if self._kv_cache_config.max_gpu_total_bytes > 0:
+        if self._max_gpu_total_bytes_in > 0:
             kv_cache_max_memory = min(kv_cache_max_memory,
-                                      self._kv_cache_config.max_gpu_total_bytes)
+                                      self._max_gpu_total_bytes_in)
             logger.info(
-                f"max_gpu_total_bytes={self._kv_cache_config.max_gpu_total_bytes / (GB):.2f} GiB is provided. New max memory is {kv_cache_max_memory / (GB):.2f} GiB"
+                f"max_gpu_total_bytes={self._max_gpu_total_bytes_in / (GB):.2f} GiB is provided. New max memory is {kv_cache_max_memory / (GB):.2f} GiB"
             )
 
         logger.info(
@@ -881,7 +993,22 @@ class KvCacheCreator:
                        resources: Dict,
                        estimating_kv_cache: bool = False) -> None:
         """Construct KV caches for model and draft model (if applicable)."""
-        if self._skip_est:
+        use_gms_shadow_kv_calibration = self._use_gms_shadow_kv_calibration()
+        use_gms_shadow_final_calibration = (
+            not estimating_kv_cache and use_gms_shadow_kv_calibration)
+        if use_gms_shadow_final_calibration:
+            logger.info(
+                f"Using GMS shadow final KV calibration (load_format={self._llm_args.load_format}, "
+                f"gms_mode={self._llm_args.gms_mode}, engine_id={self._llm_env('ENGINE_ID', '0')})."
+            )
+        if (use_gms_shadow_final_calibration
+                and self._max_gpu_total_bytes_in <= 0):
+            # The warmup estimate runs while previously parked engines still
+            # have local runtime state on the GPU.  Recompute the final shadow
+            # KV budget with GMS-aware accounting instead of preserving that
+            # lower estimate as if it were a user cap.
+            self._kv_cache_config.max_gpu_total_bytes = 0
+        if self._skip_est or use_gms_shadow_final_calibration:
             self.configure_kv_cache_capacity()
 
         # For V2 with separate one-model draft KV cache, split the total budget

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -15,7 +15,7 @@ from tensorrt_llm.bindings.executor import DecodingMode
 # isort: off
 from tensorrt_llm.llmapi.llm_args import (
     CacheTransceiverConfig, CapacitySchedulerPolicy, EagleDecodingConfig,
-    KvCacheConfig, MTPDecodingConfig, PeftCacheConfig, SamplerType,
+    KvCacheConfig, LoadFormat, MTPDecodingConfig, PeftCacheConfig, SamplerType,
     SchedulerConfig, SparseAttentionConfig, SpeculativeConfig, TorchLlmArgs,
     WaitingQueuePolicy)
 # isort: on
@@ -187,6 +187,106 @@ class KvCacheCreator:
             f"available KV cache memory when calculating max tokens: {available_kv_mem / (GB):.2f} GiB, "
             f"fraction is set {fraction}, kv size per token is {kv_size_per_token}. device total memory {total_gpu_memory / (GB):.2f} GiB, "
             f"temporary kv cache memory during profiling {allocated_bytes / (GB):.2f} GiB"
+        )
+        return int(available_kv_mem)
+
+    def _gms_weight_bytes(self) -> int:
+        total = 0
+        for engine in (self._model_engine, self._draft_model_engine):
+            if engine is None:
+                continue
+            model_loader = getattr(engine, "model_loader", None)
+            if model_loader is None:
+                continue
+            total += int(model_loader.gms_weight_bytes())
+        return total
+
+    def _moe_workspace_bytes(self) -> int:
+        total = 0
+        try:
+            from tensorrt_llm._mnnvl_utils import MnnvlMoe
+        except ImportError:
+            pass
+        else:
+            total += MnnvlMoe.workspace_bytes()
+
+        seen_workspace_owners: set[type] = set()
+        try:
+            from tensorrt_llm._torch.distributed.moe_alltoall import MoeAlltoAll
+            from tensorrt_llm._torch.modules.fused_moe.communication.nvlink_one_sided import \
+                NVLinkOneSided
+        except ImportError:
+            return 0
+
+        for engine in (self._model_engine, self._draft_model_engine):
+            model = getattr(engine, "model", None)
+            if model is None:
+                continue
+            for module in model.modules():
+                for candidate in (
+                        getattr(module, "moe_a2a", None),
+                        getattr(module, "comm", None),
+                ):
+                    if not isinstance(candidate, (MoeAlltoAll, NVLinkOneSided)):
+                        continue
+                    owner = type(candidate)
+                    if owner in seen_workspace_owners:
+                        continue
+                    seen_workspace_owners.add(owner)
+
+                    workspace = getattr(owner, "_WORKSPACE", None)
+                    if workspace is not None:
+                        total += int(workspace.get("workspace_size_per_rank", 0))
+                    else:
+                        total += int(
+                            getattr(candidate, "workspace_size_per_rank", 0)
+                            or 0)
+        return total
+
+    def _use_gms_shadow_kv_calibration(self) -> bool:
+        if self._llm_args.load_format != LoadFormat.GMS:
+            return False
+        raw_value = os.environ.get("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", "1")
+        if raw_value.lower() in {"0", "false", "no", "off"}:
+            return False
+        if self._llm_args.gms_mode == "ro":
+            return True
+        if self._llm_args.gms_mode == "rw":
+            return False
+        return os.environ.get("ENGINE_ID", "0") != "0"
+
+    def _cal_gms_shadow_max_memory(
+        self,
+        *,
+        torch_peak_memory: int,
+        model_bytes: int,
+        total_gpu_memory: int,
+        fraction: float,
+        temporary_kv_bytes: int,
+        non_torch_extra_bytes: int = 0,
+    ) -> int:
+        gms_weight_bytes = self._gms_weight_bytes()
+        moe_workspace_bytes = self._moe_workspace_bytes()
+        local_extra_bytes = max(
+            non_torch_extra_bytes - gms_weight_bytes - moe_workspace_bytes, 0)
+        torch_activation_bytes = max(
+            torch_peak_memory - model_bytes - temporary_kv_bytes, 0)
+        local_non_kv_memory = (
+            model_bytes + torch_activation_bytes + gms_weight_bytes +
+            moe_workspace_bytes + local_extra_bytes)
+        available_kv_mem = max(total_gpu_memory - local_non_kv_memory, 0) * fraction
+        logger.info(
+            "GMS shadow KV calibration: available KV cache memory "
+            f"{available_kv_mem / GB:.2f} GiB (total={total_gpu_memory / GB:.2f} GiB, "
+            f"local_non_kv={local_non_kv_memory / GB:.2f} GiB, "
+            f"torch_peak={torch_peak_memory / GB:.2f} GiB, "
+            f"model_bytes={model_bytes / GB:.2f} GiB, "
+            f"gms_weights={gms_weight_bytes / GB:.2f} GiB, "
+            f"moe_workspace={moe_workspace_bytes / GB:.2f} GiB, "
+            f"temporary_kv={temporary_kv_bytes / GB:.2f} GiB, "
+            f"non_torch_extra={non_torch_extra_bytes / GB:.2f} GiB, "
+            f"local_non_torch_extra={local_extra_bytes / GB:.2f} GiB, "
+            f"fraction={fraction}). Other engines' active KV is intentionally ignored."
         )
         return int(available_kv_mem)
 
@@ -415,6 +515,7 @@ class KvCacheCreator:
         logger.info(
             f"Memory used after loading model weights (outside torch) in memory usage profiling: {((total_used_bytes - model_bytes) if total_used_bytes > model_bytes else 0) / (GB):.2f} GiB"
         )
+        kv_cache_max_memory = None
 
         if py_executor is not None and not self._skip_est:
             py_executor.set_gather_responses(True)
@@ -474,16 +575,35 @@ class KvCacheCreator:
             logger.info(
                 f"Memory used outside torch (e.g., NCCL and CUDA graphs) in memory usage profiling: {extra_cost / (GB):.2f} GiB"
             )
+            if self._use_gms_shadow_kv_calibration():
+                kv_cache_max_memory = self._cal_gms_shadow_max_memory(
+                    torch_peak_memory=torch_peak_memory,
+                    model_bytes=model_bytes,
+                    total_gpu_memory=total_gpu_memory,
+                    fraction=fraction,
+                    temporary_kv_bytes=allocated_bytes,
+                    non_torch_extra_bytes=extra_cost,
+                )
 
         else:
             peak_memory = total_used_bytes
             allocated_bytes = 0
             activation_bytes = 0
+            if self._use_gms_shadow_kv_calibration():
+                kv_cache_max_memory = self._cal_gms_shadow_max_memory(
+                    torch_peak_memory=model_bytes,
+                    model_bytes=model_bytes,
+                    total_gpu_memory=total_gpu_memory,
+                    fraction=fraction,
+                    temporary_kv_bytes=allocated_bytes,
+                )
 
         # calculate max memory from peak memory and free gpu memory fraction
-        kv_cache_max_memory = self._cal_max_memory(peak_memory,
-                                                   total_gpu_memory, fraction,
-                                                   allocated_bytes)
+        if kv_cache_max_memory is None:
+            kv_cache_max_memory = self._cal_max_memory(peak_memory,
+                                                       total_gpu_memory,
+                                                       fraction,
+                                                       allocated_bytes)
 
         # NOTE:
         # For KVCacheManager, KvCacheCreator currently controls capacity using two parameters in KVCacheConfig:

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -1,10 +1,13 @@
 import bisect
 import contextlib
+import os
+import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional, Tuple, TypeAlias
 
 import torch
 
+from tensorrt_llm.logger import logger
 from tensorrt_llm.llmapi.llm_args import (BaseSparseAttentionConfig,
                                           DecodingBaseConfig)
 from tensorrt_llm.mapping import Mapping
@@ -27,6 +30,17 @@ from .scheduler import ScheduledRequests
 # A large prime number used for dummy request IDs to avoid collisions
 CUDA_GRAPH_DUMMY_REQUEST_ID = (1 << 64) - 1
 KeyType: TypeAlias = Tuple[int, int, bool, bool]
+GB = 1024**3
+
+
+def _truthy_env(name: str, default: str = "0") -> bool:
+    return os.environ.get(name, default).lower() in {"1", "true", "yes", "on"}
+
+
+def _fmt_gib(value: Optional[int]) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value / GB:.2f} GiB"
 
 
 @dataclass
@@ -297,6 +311,84 @@ class CUDAGraphRunner:
         """
         return self.memory_pool
 
+    def _cuda_graph_memory_snapshot(self) -> Optional[dict]:
+        if not _truthy_env("TRTLLM_CUDA_GRAPH_MEMORY_SNAPSHOTS"):
+            return None
+
+        if _truthy_env("TRTLLM_CUDA_GRAPH_MEMORY_SYNC", "1"):
+            try:
+                torch.cuda.synchronize()
+            except Exception as error:
+                logger.debug(
+                    "Unable to synchronize before CUDA graph memory snapshot: %s",
+                    error)
+
+        try:
+            free, total = torch.cuda.mem_get_info()
+            stats = torch.cuda.memory_stats()
+            return {
+                "allocated":
+                int(torch.cuda.memory_allocated()),
+                "reserved":
+                int(torch.cuda.memory_reserved()),
+                "active":
+                int(stats.get("active_bytes.all.current", 0)),
+                "inactive_split":
+                int(stats.get("inactive_split_bytes.all.current", 0)),
+                "private_pool_allocated":
+                int(stats.get("allocated_bytes.private_pool.current", 0)),
+                "private_pool_reserved":
+                int(stats.get("reserved_bytes.private_pool.current", 0)),
+                "segment_current":
+                int(stats.get("segment.all.current", 0)),
+                "driver_free":
+                int(free),
+                "driver_total":
+                int(total),
+            }
+        except Exception as error:
+            logger.debug("Unable to query CUDA graph memory snapshot: %s",
+                         error)
+            return None
+
+    def _log_cuda_graph_memory_snapshot(self,
+                                        label: str,
+                                        key: KeyType,
+                                        elapsed_s: Optional[float] = None,
+                                        previous: Optional[dict] = None
+                                        ) -> Optional[dict]:
+        snapshot = self._cuda_graph_memory_snapshot()
+        if snapshot is None:
+            return None
+
+        def delta(field: str) -> Optional[int]:
+            if previous is None:
+                return None
+            return snapshot.get(field, 0) - previous.get(field, 0)
+
+        logger.info(
+            "CUDA graph memory snapshot: "
+            f"label={label} key={key} graphs={len(self.graphs)} "
+            f"pool_set={self.memory_pool is not None} "
+            f"elapsed={elapsed_s if elapsed_s is not None else 0.0:.3f}s "
+            f"allocated={_fmt_gib(snapshot['allocated'])} "
+            f"reserved={_fmt_gib(snapshot['reserved'])} "
+            f"active={_fmt_gib(snapshot['active'])} "
+            f"inactive_split={_fmt_gib(snapshot['inactive_split'])} "
+            f"private_pool_allocated={_fmt_gib(snapshot['private_pool_allocated'])} "
+            f"private_pool_reserved={_fmt_gib(snapshot['private_pool_reserved'])} "
+            f"segments={snapshot['segment_current']} "
+            f"driver_free={_fmt_gib(snapshot['driver_free'])} "
+            f"driver_total={_fmt_gib(snapshot['driver_total'])} "
+            f"delta_allocated={_fmt_gib(delta('allocated'))} "
+            f"delta_reserved={_fmt_gib(delta('reserved'))} "
+            f"delta_active={_fmt_gib(delta('active'))} "
+            f"delta_inactive_split={_fmt_gib(delta('inactive_split'))} "
+            f"delta_private_pool_allocated={_fmt_gib(delta('private_pool_allocated'))} "
+            f"delta_private_pool_reserved={_fmt_gib(delta('private_pool_reserved'))} "
+            f"delta_driver_free={_fmt_gib(delta('driver_free'))}")
+        return snapshot
+
     def capture(self,
                 key: KeyType,
                 forward_fn: Callable,
@@ -348,23 +440,49 @@ class CUDAGraphRunner:
         # internal states according to the docs:
         # https://pytorch.org/docs/stable/notes/cuda.html#cuda-graph-semantics
         # This also lets us initialize states in the attn_metadata.
+        capture_started_at = time.monotonic()
+        last_snapshot = self._log_cuda_graph_memory_snapshot(
+            "capture/before", key)
         graph = torch.cuda.CUDAGraph()
         with with_multi_stream(True), piecewise_cuda_graph(False):
+            step_started_at = time.monotonic()
             for _ in range(self.WARMUP_STEPS):
                 _setup_spec_decoding_and_forward(key, forward_fn,
                                                  capture_inputs)
                 if postprocess_fn is not None:
                     postprocess_fn(capture_inputs)
+            last_snapshot = self._log_cuda_graph_memory_snapshot(
+                "capture/after_eager_warmup",
+                key,
+                elapsed_s=time.monotonic() - step_started_at,
+                previous=last_snapshot)
 
+            step_started_at = time.monotonic()
             with torch.cuda.graph(graph, pool=self.memory_pool):
                 output = _setup_spec_decoding_and_forward(
                     key, forward_fn, capture_inputs)
+            last_snapshot = self._log_cuda_graph_memory_snapshot(
+                "capture/after_cuda_graph",
+                key,
+                elapsed_s=time.monotonic() - step_started_at,
+                previous=last_snapshot)
             if postprocess_fn is not None:
+                step_started_at = time.monotonic()
                 postprocess_fn(capture_inputs)
+                last_snapshot = self._log_cuda_graph_memory_snapshot(
+                    "capture/after_postprocess",
+                    key,
+                    elapsed_s=time.monotonic() - step_started_at,
+                    previous=last_snapshot)
 
         self.graphs[key] = graph
         self.graph_outputs[key] = make_weak_ref(output)
         self.memory_pool = graph.pool()
+        self._log_cuda_graph_memory_snapshot(
+            "capture/after_store",
+            key,
+            elapsed_s=time.monotonic() - capture_started_at,
+            previous=last_snapshot)
 
     def replay(self, key: KeyType,
                current_inputs: Dict[str, Any]) -> Optional[torch.Tensor]:

--- a/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
@@ -4,7 +4,7 @@ import queue
 import threading
 import time
 from itertools import repeat
-from typing import Iterable, List, Optional, Tuple
+from typing import Any, Iterable, List, Optional, Tuple
 
 from tensorrt_llm.llmapi.disagg_utils import get_local_request_id
 
@@ -24,6 +24,7 @@ class RequestQueueItem:
     child_req_ids: Optional[list] = None
     is_canceled_request: bool = False
     query: Optional[list] = None  # only used in `StarAttention`
+    control_action: Optional[tuple[str, tuple[Any, ...], dict[str, Any]]] = None
 
     @property
     def is_shutdown_request(self):
@@ -126,9 +127,21 @@ class ExecutorRequestQueue:
             self.request_queue.put(
                 RequestQueueItem(req_id, is_canceled_request=True))
 
-    def enqueue_control_request(self):
+    def enqueue_control_request(
+        self,
+        action: Optional[str] = None,
+        args: tuple[Any, ...] = (),
+        kwargs: Optional[dict[str, Any]] = None,
+    ):
         with self.enqueue_lock:
-            self.request_queue.put(RequestQueueItem(id=CONTROL_REQUEST_ID))
+            self.request_queue.put(
+                RequestQueueItem(
+                    id=CONTROL_REQUEST_ID,
+                    control_action=(
+                        (action, args, kwargs or {}) if action is not None else None
+                    ),
+                )
+            )
 
     def enqueue_shutdown_request(self):
         with self.enqueue_lock:

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -638,6 +638,46 @@ class PyTorchModelEngine(ModelEngine):
         finally:
             self.cuda_graph_runner.enabled = _run_cuda_graphs
 
+    def _is_gms_runtime(self) -> bool:
+        gms_mode = str(getattr(self.llm_args, "gms_mode", "")).lower()
+        if gms_mode in {"ro", "rw"}:
+            return True
+
+        load_format = getattr(self.llm_args, "load_format", None)
+        load_format_values = {
+            str(load_format).lower(),
+            str(getattr(load_format, "name", "")).lower(),
+            str(getattr(load_format, "value", "")).lower(),
+        }
+        if "gms" in load_format_values or any(
+                value.endswith(".gms") for value in load_format_values):
+            return True
+
+        env_overrides = getattr(self.llm_args, "env_overrides", None)
+        if isinstance(env_overrides, dict) and env_overrides.get(
+                "GMS_SOCKET_DIR"):
+            return True
+        return bool(os.environ.get("GMS_SOCKET_DIR"))
+
+    def _can_capture_cuda_graph_now(self, key: Tuple[int, int, bool,
+                                                    bool]) -> bool:
+        if self.is_warmup or not self._is_gms_runtime():
+            return True
+
+        warned_keys = getattr(self, "_runtime_cuda_graph_capture_warned",
+                              set())
+        if key not in warned_keys:
+            warned_keys.add(key)
+            self._runtime_cuda_graph_capture_warned = warned_keys
+            logger.warning(
+                "Skipping runtime CUDA graph capture for missing key=%s in "
+                "GMS mode; falling back to eager execution. GMS shadow "
+                "failover requires CUDA graphs to be captured during startup "
+                "warmup, not during promotion or serving.",
+                key,
+            )
+        return False
+
     @staticmethod
     def warmup_with_kv_cache_cleanup(method):
         """
@@ -657,10 +697,6 @@ class PyTorchModelEngine(ModelEngine):
         @functools.wraps(method)
         def wrapper(self, resource_manager: ResourceManager, *args, **kwargs):
             result = method(self, resource_manager, *args, **kwargs)
-            if getattr(self, "_skip_warmup_kv_cache_cleanup_once", False):
-                self._skip_warmup_kv_cache_cleanup_once = False
-                return result
-
             kv_cache_manager = resource_manager.get_resource_manager(
                 self.kv_cache_manager_key)
             if kv_cache_manager is not None:
@@ -688,15 +724,6 @@ class PyTorchModelEngine(ModelEngine):
             logger.info("Skipping warm up as no KV Cache manager allocated.")
             return
 
-        if self._should_defer_warmup_once():
-            logger.info(
-                f"Deferring model engine warmup until wakeup: "
-                f"{getattr(self, '_defer_warmup_reason', '')}")
-            self._defer_warmup_once = False
-            self._deferred_warmup_pending = True
-            self._skip_warmup_kv_cache_cleanup_once = True
-            return
-
         # The lifetime of model engine and kv cache manager can be different.
         # Reset the global cuda graph dummy requests in warmup.
         self.cuda_graph_runner.padding_dummy_requests = {}
@@ -714,67 +741,12 @@ class PyTorchModelEngine(ModelEngine):
         # is decode-only and runs into issues with autotuner warmup.
         if not self.mapping.has_cp_helix():
             self._run_autotuner_warmup(resource_manager)
-        if self._should_defer_cuda_graph_warmup_once():
-            logger.info(
-                f"Deferring CUDA graph warmup for this engine until wakeup: "
-                f"{getattr(self, '_defer_cuda_graph_warmup_reason', '')}")
-            self._defer_cuda_graph_warmup_once = False
-            self._deferred_cuda_graph_warmup_pending = True
-        else:
-            self._run_cuda_graph_warmup(resource_manager)
+        self._run_cuda_graph_warmup(resource_manager)
         if not self.is_draft_model and not self.mapping.has_cp_helix(
         ) and self.guided_decoder is None and not isinstance(
                 kv_cache_manager, MambaHybridCacheManager):
             # Run extra general warmup to warmup memory pool before running real requests to reduce memory fragmentation.
             self._general_warmup(resource_manager, reverse=True)
-
-    def defer_warmup_once(self, reason: str = "") -> None:
-        self._defer_warmup_once = True
-        self._defer_warmup_reason = reason
-
-    def has_deferred_warmup(self) -> bool:
-        return bool(getattr(self, "_deferred_warmup_pending", False))
-
-    def _should_defer_warmup_once(self) -> bool:
-        return bool(getattr(self, "_defer_warmup_once", False))
-
-    def run_deferred_warmup(self, resource_manager: ResourceManager) -> int:
-        if not self.has_deferred_warmup():
-            return 0
-
-        before = len(self.cuda_graph_runner.graphs)
-        logger.info("Running deferred model engine warmup after wakeup.")
-        try:
-            self.warmup(resource_manager)
-        except Exception:
-            self._deferred_warmup_pending = True
-            raise
-        self._deferred_warmup_pending = False
-        return len(self.cuda_graph_runner.graphs) - before
-
-    def defer_cuda_graph_warmup_once(self, reason: str = "") -> None:
-        self._defer_cuda_graph_warmup_once = True
-        self._defer_cuda_graph_warmup_reason = reason
-
-    def has_deferred_cuda_graph_warmup(self) -> bool:
-        return bool(getattr(self, "_deferred_cuda_graph_warmup_pending", False))
-
-    def _should_defer_cuda_graph_warmup_once(self) -> bool:
-        return bool(getattr(self, "_defer_cuda_graph_warmup_once", False)
-                    and self.cuda_graph_runner.enabled)
-
-    @warmup_with_kv_cache_cleanup
-    def capture_deferred_cuda_graphs(self,
-                                     resource_manager: ResourceManager) -> int:
-        if not self.has_deferred_cuda_graph_warmup():
-            return 0
-
-        before = len(self.cuda_graph_runner.graphs)
-        logger.info("Capturing deferred CUDA graphs after wakeup.")
-        with self.set_warmup_flag():
-            self._run_cuda_graph_warmup(resource_manager)
-        self._deferred_cuda_graph_warmup_pending = False
-        return len(self.cuda_graph_runner.graphs) - before
 
     def _general_warmup(self,
                         resource_manager: ResourceManager,
@@ -3805,6 +3777,11 @@ class PyTorchModelEngine(ModelEngine):
             )
 
             can_run_graph = key is not None
+            if (can_run_graph and self.cuda_graph_runner.needs_capture(key)
+                    and not self._can_capture_cuda_graph_now(key)):
+                can_run_graph = False
+                key = None
+
             if can_run_graph:
                 attn_metadata = maybe_attn_metadata
                 spec_metadata = maybe_spec_metadata

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -657,6 +657,10 @@ class PyTorchModelEngine(ModelEngine):
         @functools.wraps(method)
         def wrapper(self, resource_manager: ResourceManager, *args, **kwargs):
             result = method(self, resource_manager, *args, **kwargs)
+            if getattr(self, "_skip_warmup_kv_cache_cleanup_once", False):
+                self._skip_warmup_kv_cache_cleanup_once = False
+                return result
+
             kv_cache_manager = resource_manager.get_resource_manager(
                 self.kv_cache_manager_key)
             if kv_cache_manager is not None:
@@ -684,6 +688,15 @@ class PyTorchModelEngine(ModelEngine):
             logger.info("Skipping warm up as no KV Cache manager allocated.")
             return
 
+        if self._should_defer_warmup_once():
+            logger.info(
+                f"Deferring model engine warmup until wakeup: "
+                f"{getattr(self, '_defer_warmup_reason', '')}")
+            self._defer_warmup_once = False
+            self._deferred_warmup_pending = True
+            self._skip_warmup_kv_cache_cleanup_once = True
+            return
+
         # The lifetime of model engine and kv cache manager can be different.
         # Reset the global cuda graph dummy requests in warmup.
         self.cuda_graph_runner.padding_dummy_requests = {}
@@ -701,12 +714,67 @@ class PyTorchModelEngine(ModelEngine):
         # is decode-only and runs into issues with autotuner warmup.
         if not self.mapping.has_cp_helix():
             self._run_autotuner_warmup(resource_manager)
-        self._run_cuda_graph_warmup(resource_manager)
+        if self._should_defer_cuda_graph_warmup_once():
+            logger.info(
+                f"Deferring CUDA graph warmup for this engine until wakeup: "
+                f"{getattr(self, '_defer_cuda_graph_warmup_reason', '')}")
+            self._defer_cuda_graph_warmup_once = False
+            self._deferred_cuda_graph_warmup_pending = True
+        else:
+            self._run_cuda_graph_warmup(resource_manager)
         if not self.is_draft_model and not self.mapping.has_cp_helix(
         ) and self.guided_decoder is None and not isinstance(
                 kv_cache_manager, MambaHybridCacheManager):
             # Run extra general warmup to warmup memory pool before running real requests to reduce memory fragmentation.
             self._general_warmup(resource_manager, reverse=True)
+
+    def defer_warmup_once(self, reason: str = "") -> None:
+        self._defer_warmup_once = True
+        self._defer_warmup_reason = reason
+
+    def has_deferred_warmup(self) -> bool:
+        return bool(getattr(self, "_deferred_warmup_pending", False))
+
+    def _should_defer_warmup_once(self) -> bool:
+        return bool(getattr(self, "_defer_warmup_once", False))
+
+    def run_deferred_warmup(self, resource_manager: ResourceManager) -> int:
+        if not self.has_deferred_warmup():
+            return 0
+
+        before = len(self.cuda_graph_runner.graphs)
+        logger.info("Running deferred model engine warmup after wakeup.")
+        try:
+            self.warmup(resource_manager)
+        except Exception:
+            self._deferred_warmup_pending = True
+            raise
+        self._deferred_warmup_pending = False
+        return len(self.cuda_graph_runner.graphs) - before
+
+    def defer_cuda_graph_warmup_once(self, reason: str = "") -> None:
+        self._defer_cuda_graph_warmup_once = True
+        self._defer_cuda_graph_warmup_reason = reason
+
+    def has_deferred_cuda_graph_warmup(self) -> bool:
+        return bool(getattr(self, "_deferred_cuda_graph_warmup_pending", False))
+
+    def _should_defer_cuda_graph_warmup_once(self) -> bool:
+        return bool(getattr(self, "_defer_cuda_graph_warmup_once", False)
+                    and self.cuda_graph_runner.enabled)
+
+    @warmup_with_kv_cache_cleanup
+    def capture_deferred_cuda_graphs(self,
+                                     resource_manager: ResourceManager) -> int:
+        if not self.has_deferred_cuda_graph_warmup():
+            return 0
+
+        before = len(self.cuda_graph_runner.graphs)
+        logger.info("Capturing deferred CUDA graphs after wakeup.")
+        with self.set_warmup_flag():
+            self._run_cuda_graph_warmup(resource_manager)
+        self._deferred_cuda_graph_warmup_pending = False
+        return len(self.cuda_graph_runner.graphs) - before
 
     def _general_warmup(self,
                         resource_manager: ResourceManager,

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -238,9 +238,11 @@ class ModelLoader:
         self.max_num_tokens = max_num_tokens
         self.max_seq_len = max_seq_len
         self.lora_config = lora_config
+        self.weight_mapper = None
         self.model_weights_memory_tag = model_weights_memory_tag
         self.model_weights_restore_mode = model_weights_restore_mode
         self._weight_pool_proxy = None
+        self._gms_backend = None
 
     @staticmethod
     def load_config_and_apply_defaults(
@@ -313,7 +315,7 @@ class ModelLoader:
 
             memo = dict()
 
-            if self.model_weights_memory_tag is not None:
+            if self.model_weights_memory_tag is not None and load_format != LoadFormat.GMS:
                 # Allocate buffers to the outer virtual_memory_scope,
                 # but parameters (weights) to the dedicated inner virtual_memory_scope.
 
@@ -329,8 +331,11 @@ class ModelLoader:
 
                 _apply_to_buffers_only(model, allocate_buffer_on_cuda)
 
-                need_initialized_weights = load_format not in (LoadFormat.AUTO,
-                                                               LoadFormat.DUMMY)
+                need_initialized_weights = load_format not in (
+                    LoadFormat.AUTO,
+                    LoadFormat.DUMMY,
+                    LoadFormat.GMS,
+                )
 
                 def allocate_weights_on_cuda(t: torch.Tensor):
                     if t not in memo:
@@ -360,7 +365,7 @@ class ModelLoader:
                         self.model_weights_restore_mode) as pool:
                     model._apply(allocate_weights_on_cuda)
                 self._weight_pool_proxy = pool
-            elif is_meta_init:
+            elif is_meta_init and load_format != LoadFormat.GMS:
 
                 def init_meta_tensor(t: torch.Tensor):
                     if t.device != torch.device('meta'):
@@ -374,7 +379,8 @@ class ModelLoader:
 
             # Ensure everything is at least on CUDA
             # No-op if worked as expected
-            model.to("cuda")
+            if load_format != LoadFormat.GMS:
+                model.to("cuda")
             del memo
 
             rank_model_storage = get_rank_model_storage(model)
@@ -418,6 +424,48 @@ class ModelLoader:
                 ):
                     model.draft_model.load_weights_from_target_model(model)
 
+            elif load_format == LoadFormat.GMS:
+                from tensorrt_llm._torch.memory import GMSBackend
+
+                gms_backend = GMSBackend(
+                    socket_path=self.llm_args.gms_socket_path,
+                    mapping=self.mapping,
+                    mode=self.llm_args.gms_mode or "auto",
+                    tag=self.llm_args.gms_tag or GMSBackend.DEFAULT_TAG,
+                )
+                if not gms_backend.connect():
+                    raise RuntimeError("Failed to connect to GMS")
+
+                if gms_backend.is_rw:
+                    with gms_backend.mem_pool_scope(torch.device("cuda")):
+                        if hasattr(model, 'llm_checkpoint_dir'):
+                            weights = checkpoint_loader.load_weights(
+                                model.llm_checkpoint_dir, mapping=self.mapping)
+                        else:
+                            weights = checkpoint_loader.load_weights(
+                                checkpoint_dir, mapping=self.mapping)
+
+                        self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
+                            model, config)
+                        self._call_load_weights(model.load_weights, weights,
+                                                self.weight_mapper)
+                        torch.cuda.empty_cache()
+
+                    gms_backend.move_untracked_params(model)
+                    gms_backend.finalize_write(model)
+                    logger.info("LoadFormat.GMS (RW): published weights")
+                else:
+                    for module in model.modules():
+                        if hasattr(module, 'post_load_weights') and not getattr(
+                                module, '_weights_removed', False):
+                            module.post_load_weights()
+
+                    gms_backend.materialize_module(model)
+                    logger.info(
+                        "LoadFormat.GMS (RO): zero-copy materialized weights")
+
+                self._gms_backend = gms_backend
+
             elif load_format == LoadFormat.VISION_ONLY:
                 # Vision weights are already loaded within the model.
                 logger.info(
@@ -428,10 +476,14 @@ class ModelLoader:
                 raise NotImplementedError(
                     f"No load support for load format: {load_format}")
 
-            for module in model.modules():
-                if hasattr(module, 'post_load_weights') and not getattr(
-                        module, '_weights_removed', False):
-                    module.post_load_weights()
+            gms_ro_done = (load_format == LoadFormat.GMS
+                           and self._gms_backend is not None
+                           and not self._gms_backend.is_rw)
+            if not gms_ro_done:
+                for module in model.modules():
+                    if hasattr(module, 'post_load_weights') and not getattr(
+                            module, '_weights_removed', False):
+                        module.post_load_weights()
 
             if isinstance(moe_load_balancer, MoeLoadBalancer):
                 moe_load_balancer.register_weight_slots_after_to_cuda()
@@ -447,11 +499,19 @@ class ModelLoader:
                model: DecoderModelForCausalLM,
                weights: dict,
                allow_partial_loading: bool = False):
+        if self.weight_mapper is None:
+            raise RuntimeError(
+                "Cannot reload weights: weight_mapper was not initialized.")
         self._call_load_weights(model.load_weights,
                                 weights,
                                 self.weight_mapper,
                                 allow_partial_loading=allow_partial_loading)
         torch.cuda.current_stream().synchronize()
+
+    def cleanup(self) -> None:
+        if self._gms_backend is not None:
+            self._gms_backend.cleanup()
+            self._gms_backend = None
 
     def _load_and_validate_config(
             self, checkpoint_dir: str,

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -616,6 +616,16 @@ class ModelLoader:
             return 0
         return self._gms_backend.total_bytes()
 
+    def park_gms_weights(self) -> int:
+        if self._gms_backend is None:
+            return 0
+        return self._gms_backend.park_weights()
+
+    def restore_gms_weights(self) -> int:
+        if self._gms_backend is None:
+            return 0
+        return self._gms_backend.restore_weights()
+
     def _load_and_validate_config(
             self, checkpoint_dir: str,
             checkpoint_loader: BaseCheckpointLoader) -> ModelConfig:

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -199,6 +199,31 @@ def _apply_to_buffers_only(model: torch.nn.Module, fn):
                 module._buffers[key] = fn(buf)
 
 
+def _prebind_shared_draft_submodules(model: torch.nn.Module) -> None:
+    """Bind draft shared submodules before GMS RO materialization.
+
+    One-model speculative configs can leave draft embed/lm_head pointers unset
+    until the normal disk-load path wires them to the target model. The GMS RO
+    path skips disk loading, so bind the shared module references first.
+    """
+    draft = getattr(model, 'draft_model', None)
+    if draft is None:
+        return
+
+    target_inner = getattr(model, 'model', None)
+    draft_inner = getattr(draft, 'model', draft)
+    if target_inner is None or draft_inner is None:
+        return
+
+    target_embed = getattr(target_inner, 'embed_tokens', None)
+    if target_embed is not None and getattr(draft_inner, 'embed_tokens', None) is None:
+        draft_inner.embed_tokens = target_embed
+
+    target_lm_head = getattr(model, 'lm_head', None)
+    if target_lm_head is not None and getattr(draft, 'lm_head', None) is None:
+        draft.lm_head = target_lm_head
+
+
 class ModelLoader:
     """
     Handles the loading, configuration, and weight initialization of a PyTorch model.
@@ -314,8 +339,56 @@ class ModelLoader:
                 is_meta_init = False
 
             memo = dict()
+            gms_backend = None
+            post_load_done = False
 
-            if self.model_weights_memory_tag is not None and load_format != LoadFormat.GMS:
+            if load_format == LoadFormat.GMS:
+                from tensorrt_llm._torch.memory import GMSBackend
+
+                gms_backend = GMSBackend(
+                    socket_path=self.llm_args.gms_socket_path,
+                    mapping=self.mapping,
+                    mode=self.llm_args.gms_mode or "auto",
+                    tag=self.llm_args.gms_tag or GMSBackend.DEFAULT_TAG,
+                )
+                if not gms_backend.connect():
+                    raise RuntimeError("Failed to connect to GMS")
+                self._gms_backend = gms_backend
+
+            if load_format == LoadFormat.GMS and gms_backend is not None and gms_backend.is_rw:
+
+                def allocate_buffer_on_cuda(t: torch.Tensor):
+                    if t not in memo:
+                        if t.device == torch.device('meta'):
+                            cuda_t = torch.empty_like(t, device='cuda')
+                        else:
+                            cuda_t = t.cuda()
+                        memo[t] = cuda_t
+                        memo[cuda_t] = cuda_t
+                    return memo[t]
+
+                _apply_to_buffers_only(model, allocate_buffer_on_cuda)
+
+                need_initialized_weights = load_format not in (
+                    LoadFormat.AUTO,
+                    LoadFormat.DUMMY,
+                )
+
+                def allocate_weights_on_cuda(t: torch.Tensor):
+                    if t not in memo:
+                        cuda_t = torch.empty_like(t, device='cuda')
+                        if t.device != torch.device('meta') and (
+                                need_initialized_weights or is_meta_init):
+                            cuda_t.copy_(t)
+                        memo[t] = cuda_t
+                        memo[cuda_t] = cuda_t
+                    return memo[t]
+
+                with gms_backend.mem_pool_scope(torch.device('cuda')):
+                    model._apply(allocate_weights_on_cuda)
+                model.to('cuda')
+
+            elif self.model_weights_memory_tag is not None and load_format != LoadFormat.GMS:
                 # Allocate buffers to the outer virtual_memory_scope,
                 # but parameters (weights) to the dedicated inner virtual_memory_scope.
 
@@ -425,46 +498,46 @@ class ModelLoader:
                     model.draft_model.load_weights_from_target_model(model)
 
             elif load_format == LoadFormat.GMS:
-                from tensorrt_llm._torch.memory import GMSBackend
-
-                gms_backend = GMSBackend(
-                    socket_path=self.llm_args.gms_socket_path,
-                    mapping=self.mapping,
-                    mode=self.llm_args.gms_mode or "auto",
-                    tag=self.llm_args.gms_tag or GMSBackend.DEFAULT_TAG,
-                )
-                if not gms_backend.connect():
-                    raise RuntimeError("Failed to connect to GMS")
+                assert gms_backend is not None
 
                 if gms_backend.is_rw:
-                    with gms_backend.mem_pool_scope(torch.device("cuda")):
-                        if hasattr(model, 'llm_checkpoint_dir'):
-                            weights = checkpoint_loader.load_weights(
-                                model.llm_checkpoint_dir, mapping=self.mapping)
-                        else:
-                            weights = checkpoint_loader.load_weights(
-                                checkpoint_dir, mapping=self.mapping)
+                    if hasattr(model, 'llm_checkpoint_dir'):
+                        weights = checkpoint_loader.load_weights(
+                            model.llm_checkpoint_dir, mapping=self.mapping)
+                    else:
+                        weights = checkpoint_loader.load_weights(
+                            checkpoint_dir, mapping=self.mapping)
 
-                        self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
-                            model, config)
-                        self._call_load_weights(model.load_weights, weights,
-                                                self.weight_mapper)
-                        torch.cuda.empty_cache()
+                    self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
+                        model, config)
+                    self._call_load_weights(model.load_weights, weights,
+                                            self.weight_mapper)
 
-                    gms_backend.move_untracked_params(model)
-                    gms_backend.finalize_write(model)
-                    logger.info("LoadFormat.GMS (RW): published weights")
-                else:
                     for module in model.modules():
                         if hasattr(module, 'post_load_weights') and not getattr(
                                 module, '_weights_removed', False):
                             module.post_load_weights()
+                    post_load_done = True
 
+                    gms_backend.move_untracked_params(model)
+                    torch.cuda.empty_cache()
+                    gms_backend.defer_finalize_write(model)
+                    logger.info(
+                        "LoadFormat.GMS (RW): delaying weight publish until final executor start_worker")
+                else:
+                    if hasattr(model, 'post_load_weights'):
+                        model.post_load_weights()
+                    _prebind_shared_draft_submodules(model)
                     gms_backend.materialize_module(model)
+
+                    for module in model.modules():
+                        if hasattr(module, 'post_load_weights') and not getattr(
+                                module, '_weights_removed', False):
+                            module.post_load_weights()
+                    post_load_done = True
+
                     logger.info(
                         "LoadFormat.GMS (RO): zero-copy materialized weights")
-
-                self._gms_backend = gms_backend
 
             elif load_format == LoadFormat.VISION_ONLY:
                 # Vision weights are already loaded within the model.
@@ -476,10 +549,7 @@ class ModelLoader:
                 raise NotImplementedError(
                     f"No load support for load format: {load_format}")
 
-            gms_ro_done = (load_format == LoadFormat.GMS
-                           and self._gms_backend is not None
-                           and not self._gms_backend.is_rw)
-            if not gms_ro_done:
+            if not post_load_done:
                 for module in model.modules():
                     if hasattr(module, 'post_load_weights') and not getattr(
                             module, '_weights_removed', False):
@@ -512,6 +582,11 @@ class ModelLoader:
         if self._gms_backend is not None:
             self._gms_backend.cleanup()
             self._gms_backend = None
+
+    def finalize_pending_gms_write(self) -> int:
+        if self._gms_backend is None:
+            return 0
+        return self._gms_backend.finalize_pending_write()
 
     def _load_and_validate_config(
             self, checkpoint_dir: str,

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -513,6 +513,29 @@ class ModelLoader:
                     self._call_load_weights(model.load_weights, weights,
                                             self.weight_mapper)
 
+                    # Mirror the AUTO path: one-model speculative configs (e.g.
+                    # Kimi K2.5 + Eagle3) keep draft weights in a separate
+                    # checkpoint dir. `model.load_weights` explicitly skips
+                    # `draft_model.*` tensors, so we must load them here, or
+                    # the published RW snapshot has uninitialized draft weights
+                    # and RO clients see garbage with no surfaced error.
+                    if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
+                    ):
+                        draft_weights = checkpoint_loader.load_weights(
+                            self.spec_config.speculative_model,
+                            mapping=self.mapping)
+
+                        draft_model_arch = model.draft_config.pretrained_config.architectures[
+                            0]
+                        draft_weight_mapper = AutoCheckpointMapper.get(
+                            checkpoint_loader.checkpoint_format, draft_model_arch)
+                        draft_weight_mapper.init_model_and_config(
+                            model.draft_model, model.draft_config)
+
+                        self._call_load_weights(model.load_draft_weights,
+                                                draft_weights,
+                                                draft_weight_mapper)
+
                     for module in model.modules():
                         if hasattr(module, 'post_load_weights') and not getattr(
                                 module, '_weights_removed', False):

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -611,6 +611,11 @@ class ModelLoader:
             return 0
         return self._gms_backend.finalize_pending_write()
 
+    def gms_weight_bytes(self) -> int:
+        if self._gms_backend is None:
+            return 0
+        return self._gms_backend.total_bytes()
+
     def _load_and_validate_config(
             self, checkpoint_dir: str,
             checkpoint_loader: BaseCheckpointLoader) -> ModelConfig:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1,6 +1,7 @@
 import dataclasses
 import datetime
 import functools
+import gc
 import os
 import threading
 import time
@@ -513,6 +514,8 @@ class PyExecutor:
 
         self.control_request_barrier = threading.Event()
         self.control_action_done = threading.Event()
+        self.control_action_error: Optional[BaseException] = None
+        self.control_action_result = None
 
         self.stats_lock = threading.Lock()
         self.stats = []
@@ -2127,7 +2130,38 @@ class PyExecutor:
                 f"but found {len(self.control_requests)} control requests. "
                 f"This may indicate a race condition or improper control request handling."
             )
-            self.control_requests.pop(0)
+            control_request = self.control_requests.pop(0)
+            if control_request.control_action is not None:
+                action, args, kwargs = control_request.control_action
+                error_summary = None
+                try:
+                    self.control_action_result = self._run_control_request_action(
+                        action, args, kwargs)
+                    self.control_action_error = None
+                except BaseException as error:
+                    self.control_action_result = None
+                    self.control_action_error = error
+                    error_summary = f"{type(error).__name__}: {error}"
+
+                rank_errors = self.dist.allgather(
+                    (self.dist.rank, error_summary))
+                if self.dist.rank == 0:
+                    failed_ranks = [
+                        f"rank {rank}: {message}"
+                        for rank, message in rank_errors if message is not None
+                    ]
+                    if failed_ranks:
+                        self.control_action_error = RuntimeError(
+                            f"Control action {action!r} failed on "
+                            f"{len(failed_ranks)} rank(s): "
+                            + "; ".join(failed_ranks))
+
+                self.dist.barrier()
+                self.control_request_barrier.set()
+                if self.dist.rank != 0:
+                    self.control_request_barrier.clear()
+                return
+
             self.control_request_barrier.set()
             self.control_action_done.wait()
             self.control_action_done.clear()
@@ -2158,6 +2192,296 @@ class PyExecutor:
             # Cleanup: signal worker to resume
             self.control_action_done.set()
             self.control_request_barrier.clear()
+
+    def _iter_configurable_moe_modules(self):
+        from tensorrt_llm._torch.modules.fused_moe.configurable_moe import \
+            ConfigurableMoE
+
+        for engine in (self.model_engine, self.draft_model_engine):
+            model = getattr(engine, "model", None)
+            if model is None:
+                continue
+            for module in model.modules():
+                if isinstance(module, ConfigurableMoE):
+                    yield module
+
+    def _iter_moe_alltoall_instances(self):
+        from tensorrt_llm._torch.distributed.moe_alltoall import MoeAlltoAll
+
+        seen: set[int] = set()
+        for engine in (self.model_engine, self.draft_model_engine):
+            model = getattr(engine, "model", None)
+            if model is None:
+                continue
+            for module in model.modules():
+                moe_a2a = getattr(module, "moe_a2a", None)
+                if not isinstance(moe_a2a, MoeAlltoAll):
+                    continue
+                instance_id = id(moe_a2a)
+                if instance_id in seen:
+                    continue
+                seen.add(instance_id)
+                yield moe_a2a
+
+    def _iter_legacy_mnnvl_moe_modules(self):
+        seen: set[int] = set()
+        for engine in (self.model_engine, self.draft_model_engine):
+            model = getattr(engine, "model", None)
+            if model is None:
+                continue
+            for module in model.modules():
+                module_id = id(module)
+                if module_id in seen:
+                    continue
+                has_workspace = (getattr(module, "alltoall_workspace", None)
+                                 is not None or getattr(
+                                     module, "alltoall_prepare_workspace", None)
+                                 is not None)
+                was_released = getattr(module,
+                                       "_trtllm_gms_released_mnnvl_moe",
+                                       False)
+                if not has_workspace and not was_released:
+                    continue
+                seen.add(module_id)
+                yield module
+
+    def _release_legacy_mnnvl_moe_workspaces(self) -> tuple[int, int]:
+        from tensorrt_llm._mnnvl_utils import MnnvlMoe
+
+        modules = list(self._iter_legacy_mnnvl_moe_modules())
+        if not modules and MnnvlMoe.workspace_bytes() == 0:
+            return 0, 0
+
+        for module in modules:
+            if (getattr(module, "alltoall_workspace", None) is None
+                    and getattr(module, "alltoall_prepare_workspace", None)
+                    is None):
+                continue
+            module._trtllm_gms_released_mnnvl_moe = True
+            if hasattr(module, "alltoall_workspace"):
+                module.alltoall_workspace = None
+            if hasattr(module, "alltoall_prepare_workspace"):
+                module.alltoall_prepare_workspace = None
+
+        released_bytes = MnnvlMoe.release_workspaces()
+        if released_bytes:
+            logger.info(
+                "Released %.2f GiB of legacy MNNVL MoE workspace for %d modules.",
+                released_bytes / (1024**3), len(modules))
+        return len(modules), released_bytes
+
+    def _restore_legacy_mnnvl_moe_workspaces(self) -> tuple[int, int]:
+        from tensorrt_llm._mnnvl_utils import MnnvlMoe
+
+        modules = list(self._iter_legacy_mnnvl_moe_modules())
+        if not modules:
+            return 0, 0
+
+        mapping = MnnvlMoe.moe_mapping
+        for module in modules:
+            module_mapping = getattr(module, "mapping", None)
+            if module_mapping is not None:
+                mapping = module_mapping
+                break
+
+        restored_bytes = MnnvlMoe.restore_workspaces(mapping)
+        for module in modules:
+            if not getattr(module, "_trtllm_gms_released_mnnvl_moe", False):
+                continue
+            if hasattr(module, "alltoall_workspace"):
+                module.alltoall_workspace = MnnvlMoe.moe_workspace_tensor
+            if hasattr(module, "alltoall_prepare_workspace"):
+                module.alltoall_prepare_workspace = (
+                    MnnvlMoe.moe_prepare_workspace_tensor)
+            delattr(module, "_trtllm_gms_released_mnnvl_moe")
+
+        if restored_bytes:
+            logger.info(
+                "Restored %.2f GiB of legacy MNNVL MoE workspace for %d modules.",
+                restored_bytes / (1024**3), len(modules))
+        return len(modules), restored_bytes
+
+    def _release_moe_communication(self) -> int:
+        released = 0
+        for module in self._iter_configurable_moe_modules():
+            if module.comm is None:
+                continue
+            module.destroy()
+            released += 1
+
+        legacy_released_bytes = 0
+        for moe_a2a in self._iter_moe_alltoall_instances():
+            legacy_released_bytes += moe_a2a.release()
+            released += 1
+
+        legacy_mnnvl_modules, legacy_mnnvl_bytes = (
+            self._release_legacy_mnnvl_moe_workspaces())
+        legacy_released_bytes += legacy_mnnvl_bytes
+        released += legacy_mnnvl_modules
+
+        if released:
+            torch.cuda.synchronize()
+            logger.info("Released MoE communication resources for %d modules.",
+                        released)
+        else:
+            logger.info("No MoE communication resources to release.")
+        if legacy_released_bytes:
+            logger.info("Released %.2f GiB of legacy MoE AllToAll workspace.",
+                        legacy_released_bytes / (1024**3))
+        return released
+
+    def _restore_moe_communication(self) -> int:
+        restored = 0
+        for module in self._iter_configurable_moe_modules():
+            if module.comm is not None:
+                continue
+            module.comm = module._create_comm_strategy_auto()
+            if module.comm is not None:
+                restored += 1
+
+        for moe_a2a in self._iter_moe_alltoall_instances():
+            if moe_a2a.workspace is not None:
+                continue
+            moe_a2a.restore_workspace()
+            restored += 1
+
+        legacy_mnnvl_modules, _ = self._restore_legacy_mnnvl_moe_workspaces()
+        restored += legacy_mnnvl_modules
+
+        if restored:
+            torch.cuda.synchronize()
+            logger.info("Restored MoE communication resources for %d modules.",
+                        restored)
+        else:
+            logger.info("No MoE communication resources to restore.")
+        return restored
+
+    def _flush_cuda_allocator_after_sleep(self, sleep_tags: List[str],
+                                          released_blobs: int,
+                                          released_pools: int) -> None:
+        try:
+            allocated_before = torch.cuda.memory_allocated()
+            reserved_before = torch.cuda.memory_reserved()
+            free_before, total = torch.cuda.mem_get_info()
+        except Exception as error:
+            logger.debug("Failed to sample CUDA memory before sleep cleanup: %s",
+                         error)
+            allocated_before = reserved_before = free_before = total = 0
+
+        for cleanup in (torch.cuda.synchronize, gc.collect,
+                        torch.cuda.empty_cache, torch.cuda.synchronize):
+            try:
+                cleanup()
+            except Exception as error:
+                logger.debug("Sleep cleanup step failed: %s", error)
+
+        try:
+            allocated_after = torch.cuda.memory_allocated()
+            reserved_after = torch.cuda.memory_reserved()
+            free_after, total_after = torch.cuda.mem_get_info()
+            logger.info(
+                f"Sleep cleanup for tags={sleep_tags} "
+                f"released_blobs={released_blobs} released_pools={released_pools}, "
+                f"allocated {allocated_before / (1024**3):.2f}->"
+                f"{allocated_after / (1024**3):.2f} GiB, reserved "
+                f"{reserved_before / (1024**3):.2f}->"
+                f"{reserved_after / (1024**3):.2f} GiB, driver free "
+                f"{free_before / (1024**3):.2f}->"
+                f"{free_after / (1024**3):.2f} GiB of "
+                f"{total_after / (1024**3):.2f} GiB.")
+        except Exception as error:
+            logger.debug("Failed to sample CUDA memory after sleep cleanup: %s",
+                         error)
+
+    def _release_virtual_memory_pool_caches(self, tags: List[str]) -> int:
+        if self.virtual_memory_pools is None:
+            return 0
+
+        released_pools = 0
+        for tag in tags:
+            pool_proxy = self.virtual_memory_pools.pop(tag, None)
+            if pool_proxy is None:
+                continue
+
+            release_cached_blocks = getattr(pool_proxy,
+                                            "release_cached_blocks", None)
+            if callable(release_cached_blocks):
+                released_pools += release_cached_blocks()
+                continue
+
+            pools = getattr(pool_proxy, "_pools", None)
+            if pools is None:
+                continue
+            released_pools += len(pools)
+            pools.clear()
+
+        return released_pools
+
+    def _run_control_request_action(self, action: str, args: tuple, kwargs: dict):
+        from tensorrt_llm.llmapi.llm_args import SleepConfig
+
+        if action == "sleep":
+            from tensorrt_llm._torch.virtual_memory import release_with_tag
+
+            sleep_tags = SleepConfig.expand_sleep_tags(
+                args[0] if args else kwargs.get("sleep_tags", []))
+            released_moe = 0
+            if "executor_extra" in sleep_tags or "moe_comm" in sleep_tags:
+                released_moe = self._release_moe_communication()
+            vmm_tags = [tag for tag in sleep_tags if tag != "moe_comm"]
+            if not vmm_tags:
+                if released_moe:
+                    self._flush_cuda_allocator_after_sleep(sleep_tags,
+                                                           released_moe, 0)
+                return 0
+            released_blobs = release_with_tag(*vmm_tags)
+            released_pools = self._release_virtual_memory_pool_caches(vmm_tags)
+            if released_blobs or released_moe:
+                self._flush_cuda_allocator_after_sleep(
+                    sleep_tags, released_blobs + released_moe, released_pools)
+            return released_blobs
+
+        if action == "wakeup":
+            from tensorrt_llm._torch.virtual_memory import materialize_with_tag
+
+            wakeup_tags = SleepConfig.expand_sleep_tags(
+                args[0] if args else kwargs.get("wakeup_tags", []))
+            reset_kv_cache = "kv_cache" in wakeup_tags
+            vmm_tags = [tag for tag in wakeup_tags if tag != "moe_comm"]
+            result = materialize_with_tag(*vmm_tags) if vmm_tags else 0
+            if reset_kv_cache:
+                self.reset_prefix_cache()
+            if "executor_extra" in wakeup_tags or "moe_comm" in wakeup_tags:
+                self._restore_moe_communication()
+            return result
+
+        raise ValueError(f"Unknown control action: {action}")
+
+    def _run_distributed_control_action(self, action: str, tags: List[str]):
+        if self.dist.rank != 0:
+            raise RuntimeError(
+                f"{action} control actions must be submitted from rank 0")
+
+        self.control_action_error = None
+        self.control_action_result = None
+        self.executor_request_queue.enqueue_control_request(action=action,
+                                                            args=(tags, ))
+        self.control_request_barrier.wait()
+        try:
+            if self.control_action_error is not None:
+                raise RuntimeError(
+                    f"Control action {action!r} failed") from self.control_action_error
+            return self.control_action_result
+        finally:
+            self.control_action_error = None
+            self.control_action_result = None
+            self.control_request_barrier.clear()
+
+    def sleep(self, sleep_tags: List[str]):
+        return self._run_distributed_control_action("sleep", sleep_tags)
+
+    def wakeup(self, wakeup_tags: List[str]):
+        return self._run_distributed_control_action("wakeup", wakeup_tags)
 
     def _executor_loop_overlap(self):
         torch.cuda.set_device(self.device_id)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2937,12 +2937,21 @@ class PyExecutor:
             if (SleepConfig.GMS_WEIGHTS_TAG in sleep_tags
                     and self._should_park_gms_weight_mappings()):
                 parked_gms = self._park_gms_weight_mappings()
+                log_sleep_phases = os.environ.get(
+                    "TRTLLM_GMS_LOG_SLEEP_PHASES", "0").lower()
+                if log_sleep_phases in {"1", "true", "yes", "on"}:
+                    self._log_gpu_memory_snapshot(
+                        "sleep/after_gms_park",
+                        sleep_tags,
+                        gms_mapping_bytes=parked_gms,
+                    )
             vmm_tags = [
                 tag for tag in sleep_tags
                 if tag not in ("moe_comm", SleepConfig.GMS_WEIGHTS_TAG)
             ]
             released_blobs = 0
             released_pools = 0
+            release_tag_stats = []
             if not vmm_tags:
                 cleared_buffers, cleared_buffer_bytes = (
                     self._clear_memory_buffers_for_sleep())
@@ -2961,6 +2970,7 @@ class PyExecutor:
                     "released_blobs": 0,
                     "released_moe_modules": released_moe,
                     "released_pools": 0,
+                    "release_tag_stats": release_tag_stats,
                     "released_cuda_graphs": released_graphs,
                     "cleared_memory_buffers": cleared_buffers,
                     "cleared_memory_buffer_bytes": cleared_buffer_bytes,
@@ -2968,8 +2978,56 @@ class PyExecutor:
                     "before": before_snapshot,
                     "after": after_snapshot,
                 }
-            released_blobs = release_with_tag(*vmm_tags)
-            released_pools = self._release_virtual_memory_pool_caches(vmm_tags)
+            per_tag_release = os.environ.get(
+                "TRTLLM_GMS_LOG_PER_TAG_SLEEP_RELEASE", "0").lower()
+            if per_tag_release in {"1", "true", "yes", "on"}:
+                for tag in vmm_tags:
+                    tag_started_at = time.monotonic()
+                    before_current, _ = self._nvml_gpu_memory_bytes()
+                    before_reserved = int(torch.cuda.memory_reserved())
+                    tag_blobs = release_with_tag(tag)
+                    tag_pools = self._release_virtual_memory_pool_caches([tag])
+                    self._flush_cuda_allocator_after_sleep([tag], tag_blobs,
+                                                           tag_pools)
+                    after_current, _ = self._nvml_gpu_memory_bytes()
+                    after_reserved = int(torch.cuda.memory_reserved())
+                    stat = {
+                        "tag": tag,
+                        "released_blobs": tag_blobs,
+                        "released_pools": tag_pools,
+                        "elapsed_s": time.monotonic() - tag_started_at,
+                        "before_current": before_current,
+                        "after_current": after_current,
+                        "delta_current": (
+                            after_current - before_current
+                            if after_current is not None
+                            and before_current is not None else None),
+                        "before_reserved": before_reserved,
+                        "after_reserved": after_reserved,
+                        "delta_reserved":
+                        after_reserved - before_reserved,
+                    }
+                    release_tag_stats.append(stat)
+                    logger.info(
+                        "GMS shadow sleep tag release: rank=%s tag=%s "
+                        "blobs=%s pools=%s elapsed=%.3fs current_delta=%s "
+                        "reserved_delta=%s before_current=%s after_current=%s",
+                        getattr(self.dist, "rank", None),
+                        tag,
+                        tag_blobs,
+                        tag_pools,
+                        stat["elapsed_s"],
+                        self._fmt_gib(stat["delta_current"]),
+                        self._fmt_gib(stat["delta_reserved"]),
+                        self._fmt_gib(before_current),
+                        self._fmt_gib(after_current),
+                    )
+                    released_blobs += tag_blobs
+                    released_pools += tag_pools
+            else:
+                released_blobs = release_with_tag(*vmm_tags)
+                released_pools = self._release_virtual_memory_pool_caches(
+                    vmm_tags)
             cleared_buffers, cleared_buffer_bytes = (
                 self._clear_memory_buffers_for_sleep())
             self._flush_cuda_allocator_after_sleep(
@@ -2989,6 +3047,7 @@ class PyExecutor:
                 "released_blobs": released_blobs,
                 "released_moe_modules": released_moe,
                 "released_pools": released_pools,
+                "release_tag_stats": release_tag_stats,
                 "released_cuda_graphs": released_graphs,
                 "cleared_memory_buffers": cleared_buffers,
                 "cleared_memory_buffer_bytes": cleared_buffer_bytes,
@@ -3000,30 +3059,64 @@ class PyExecutor:
         if action == "wakeup":
             from tensorrt_llm._torch.virtual_memory import materialize_with_tag
 
+            total_started_at = time.monotonic()
+            timings = {}
             wakeup_tags = SleepConfig.expand_sleep_tags(
                 args[0] if args else kwargs.get("wakeup_tags", []))
+            step_started_at = time.monotonic()
             before_snapshot = self._log_gpu_memory_snapshot(
                 "wakeup/before", wakeup_tags)
+            timings["before_snapshot_s"] = time.monotonic() - step_started_at
             reset_kv_cache = "kv_cache" in wakeup_tags
             restored_gms = 0
             if SleepConfig.GMS_WEIGHTS_TAG in wakeup_tags:
+                step_started_at = time.monotonic()
                 restored_gms = self._restore_gms_weight_mappings()
+                timings["restore_gms_weights_s"] = (
+                    time.monotonic() - step_started_at)
             vmm_tags = [
                 tag for tag in wakeup_tags
                 if tag not in ("moe_comm", SleepConfig.GMS_WEIGHTS_TAG)
             ]
+            step_started_at = time.monotonic()
             result = materialize_with_tag(*vmm_tags) if vmm_tags else 0
+            timings["materialize_vmm_s"] = time.monotonic() - step_started_at
             if reset_kv_cache:
+                step_started_at = time.monotonic()
                 self.reset_prefix_cache()
+                timings["reset_prefix_cache_s"] = (
+                    time.monotonic() - step_started_at)
             if "executor_extra" in wakeup_tags or "moe_comm" in wakeup_tags:
+                step_started_at = time.monotonic()
                 restored_moe = self._restore_moe_communication()
+                timings["restore_moe_s"] = time.monotonic() - step_started_at
             else:
                 restored_moe = 0
+                timings["restore_moe_s"] = 0.0
+            step_started_at = time.monotonic()
             after_snapshot = self._log_gpu_memory_snapshot(
                 "wakeup/after",
                 wakeup_tags,
                 blobs=result,
                 gms_mapping_bytes=restored_gms,
+            )
+            timings["after_snapshot_s"] = time.monotonic() - step_started_at
+            timings["total_rank_action_s"] = (
+                time.monotonic() - total_started_at)
+            logger.info(
+                "GMS shadow wakeup timings: rank=%s tags=%s "
+                "before_snapshot=%.3fs restore_gms_weights=%.3fs "
+                "materialize_vmm=%.3fs reset_prefix_cache=%.3fs "
+                "restore_moe=%.3fs after_snapshot=%.3fs total=%.3fs",
+                getattr(self.dist, "rank", None),
+                wakeup_tags,
+                timings.get("before_snapshot_s", 0.0),
+                timings.get("restore_gms_weights_s", 0.0),
+                timings.get("materialize_vmm_s", 0.0),
+                timings.get("reset_prefix_cache_s", 0.0),
+                timings.get("restore_moe_s", 0.0),
+                timings.get("after_snapshot_s", 0.0),
+                timings.get("total_rank_action_s", 0.0),
             )
             return {
                 "action": "wakeup",
@@ -3032,6 +3125,7 @@ class PyExecutor:
                 "materialized_blobs": result,
                 "restored_moe_modules": restored_moe,
                 "gms_mapping_bytes": restored_gms,
+                "timings": timings,
                 "before": before_snapshot,
                 "after": after_snapshot,
             }

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2926,48 +2926,6 @@ class PyExecutor:
         )
         return True
 
-    def _run_deferred_warmups_after_wakeup(self) -> tuple[int, int]:
-        pending_warmup_engines = []
-        pending_graph_engines = []
-        for engine in (self.model_engine, self.draft_model_engine):
-            if engine is None:
-                continue
-            has_deferred_warmup = getattr(engine, "has_deferred_warmup", None)
-            if callable(has_deferred_warmup) and has_deferred_warmup():
-                pending_warmup_engines.append(engine)
-                continue
-
-            has_deferred = getattr(engine, "has_deferred_cuda_graph_warmup",
-                                   None)
-            if callable(has_deferred) and has_deferred():
-                pending_graph_engines.append(engine)
-
-        if not pending_warmup_engines and not pending_graph_engines:
-            return 0, 0
-
-        captured_graphs = 0
-        warmed_engines = 0
-        was_warmup = self.is_warmup
-        self.is_warmup = True
-        self.execution_stream.wait_stream(torch.cuda.current_stream())
-        try:
-            with torch.cuda.stream(self.execution_stream):
-                for engine in pending_warmup_engines:
-                    captured_graphs += engine.run_deferred_warmup(
-                        self.resource_manager)
-                    warmed_engines += 1
-                for engine in pending_graph_engines:
-                    captured_graphs += engine.capture_deferred_cuda_graphs(
-                        self.resource_manager)
-        finally:
-            torch.cuda.current_stream().wait_stream(self.execution_stream)
-            self.is_warmup = was_warmup
-
-        logger.info(
-            f"Ran {warmed_engines} deferred warmups and captured "
-            f"{captured_graphs} deferred CUDA graphs after GMS shadow wakeup")
-        return warmed_engines, captured_graphs
-
     def _run_control_request_action(self, action: str, args: tuple, kwargs: dict):
         from tensorrt_llm.llmapi.llm_args import SleepConfig
 
@@ -3138,11 +3096,6 @@ class PyExecutor:
                 restored_moe = 0
                 timings["restore_moe_s"] = 0.0
             step_started_at = time.monotonic()
-            warmed_engines, captured_graphs = (
-                self._run_deferred_warmups_after_wakeup())
-            timings["run_deferred_warmups_s"] = (
-                time.monotonic() - step_started_at)
-            step_started_at = time.monotonic()
             after_snapshot = self._log_gpu_memory_snapshot(
                 "wakeup/after",
                 wakeup_tags,
@@ -3160,7 +3113,6 @@ class PyExecutor:
                 f"materialize_vmm={timings.get('materialize_vmm_s', 0.0):.3f}s "
                 f"reset_prefix_cache={timings.get('reset_prefix_cache_s', 0.0):.3f}s "
                 f"restore_moe={timings.get('restore_moe_s', 0.0):.3f}s "
-                f"deferred_warmups={timings.get('run_deferred_warmups_s', 0.0):.3f}s "
                 f"after_snapshot={timings.get('after_snapshot_s', 0.0):.3f}s "
                 f"total={timings.get('total_rank_action_s', 0.0):.3f}s")
             return {
@@ -3169,8 +3121,6 @@ class PyExecutor:
                 "result": result,
                 "materialized_blobs": result,
                 "restored_moe_modules": restored_moe,
-                "deferred_warmup_engines": warmed_engines,
-                "captured_cuda_graphs": captured_graphs,
                 "gms_mapping_bytes": restored_gms,
                 "timings": timings,
                 "before": before_snapshot,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2142,6 +2142,10 @@ class PyExecutor:
                     self.control_action_result = None
                     self.control_action_error = error
                     error_summary = f"{type(error).__name__}: {error}"
+                    logger.error(
+                        f"Control action {action!r} failed on rank {self.dist.rank}"
+                    )
+                    logger.error(traceback.format_exc())
 
                 rank_errors = self.dist.allgather(
                     (self.dist.rank, error_summary))
@@ -2151,6 +2155,11 @@ class PyExecutor:
                         for rank, message in rank_errors if message is not None
                     ]
                     if failed_ranks:
+                        logger.error(
+                            "Control action %r failed across ranks: %s",
+                            action,
+                            "; ".join(failed_ranks),
+                        )
                         self.control_action_error = RuntimeError(
                             f"Control action {action!r} failed on "
                             f"{len(failed_ranks)} rank(s): "
@@ -2417,6 +2426,50 @@ class PyExecutor:
 
         return released_pools
 
+    def _park_gms_weight_mappings(self) -> int:
+        parked_bytes = 0
+        for engine in (self.model_engine, self.draft_model_engine):
+            model_loader = getattr(engine, "model_loader", None)
+            if model_loader is None:
+                continue
+            park_gms_weights = getattr(model_loader, "park_gms_weights", None)
+            if callable(park_gms_weights):
+                parked_bytes += int(park_gms_weights())
+        return parked_bytes
+
+    def _restore_gms_weight_mappings(self) -> int:
+        restored_bytes = 0
+        for engine in (self.model_engine, self.draft_model_engine):
+            model_loader = getattr(engine, "model_loader", None)
+            if model_loader is None:
+                continue
+            restore_gms_weights = getattr(model_loader, "restore_gms_weights",
+                                          None)
+            if callable(restore_gms_weights):
+                restored_bytes += int(restore_gms_weights())
+        return restored_bytes
+
+    def _should_park_gms_weight_mappings(self) -> bool:
+        release_policy = os.environ.get("TRTLLM_GMS_RELEASE_WEIGHTS_ON_SLEEP",
+                                        "primary").lower()
+        if release_policy in {"0", "false", "no", "off", "none"}:
+            return False
+        if release_policy in {"1", "true", "yes", "on", "all", "always"}:
+            return True
+
+        gms_mode = str(getattr(self.llm_args, "gms_mode", "")).lower()
+        if release_policy in {"primary", "rw", "writer"}:
+            return gms_mode != "ro"
+        if release_policy in {"shadow", "ro", "standby"}:
+            return gms_mode == "ro"
+
+        logger.warning(
+            "Unknown TRTLLM_GMS_RELEASE_WEIGHTS_ON_SLEEP=%r; defaulting to "
+            "primary-only GMS weight parking",
+            release_policy,
+        )
+        return gms_mode != "ro"
+
     def _run_control_request_action(self, action: str, args: tuple, kwargs: dict):
         from tensorrt_llm.llmapi.llm_args import SleepConfig
 
@@ -2428,15 +2481,22 @@ class PyExecutor:
             released_moe = 0
             if "executor_extra" in sleep_tags or "moe_comm" in sleep_tags:
                 released_moe = self._release_moe_communication()
-            vmm_tags = [tag for tag in sleep_tags if tag != "moe_comm"]
+            parked_gms = 0
+            if (SleepConfig.GMS_WEIGHTS_TAG in sleep_tags
+                    and self._should_park_gms_weight_mappings()):
+                parked_gms = self._park_gms_weight_mappings()
+            vmm_tags = [
+                tag for tag in sleep_tags
+                if tag not in ("moe_comm", SleepConfig.GMS_WEIGHTS_TAG)
+            ]
             if not vmm_tags:
-                if released_moe:
+                if released_moe or parked_gms:
                     self._flush_cuda_allocator_after_sleep(sleep_tags,
                                                            released_moe, 0)
                 return 0
             released_blobs = release_with_tag(*vmm_tags)
             released_pools = self._release_virtual_memory_pool_caches(vmm_tags)
-            if released_blobs or released_moe:
+            if released_blobs or released_moe or parked_gms:
                 self._flush_cuda_allocator_after_sleep(
                     sleep_tags, released_blobs + released_moe, released_pools)
             return released_blobs
@@ -2447,7 +2507,12 @@ class PyExecutor:
             wakeup_tags = SleepConfig.expand_sleep_tags(
                 args[0] if args else kwargs.get("wakeup_tags", []))
             reset_kv_cache = "kv_cache" in wakeup_tags
-            vmm_tags = [tag for tag in wakeup_tags if tag != "moe_comm"]
+            if SleepConfig.GMS_WEIGHTS_TAG in wakeup_tags:
+                self._restore_gms_weight_mappings()
+            vmm_tags = [
+                tag for tag in wakeup_tags
+                if tag not in ("moe_comm", SleepConfig.GMS_WEIGHTS_TAG)
+            ]
             result = materialize_with_tag(*vmm_tags) if vmm_tags else 0
             if reset_kv_cache:
                 self.reset_prefix_cache()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2149,6 +2149,8 @@ class PyExecutor:
 
                 rank_errors = self.dist.allgather(
                     (self.dist.rank, error_summary))
+                rank_results = self.dist.allgather(
+                    (self.dist.rank, self.control_action_result))
                 if self.dist.rank == 0:
                     failed_ranks = [
                         f"rank {rank}: {message}"
@@ -2164,6 +2166,12 @@ class PyExecutor:
                             f"Control action {action!r} failed on "
                             f"{len(failed_ranks)} rank(s): "
                             + "; ".join(failed_ranks))
+                    else:
+                        self.control_action_result = [
+                            result
+                            for _, result in sorted(rank_results,
+                                                    key=lambda item: item[0])
+                        ]
 
                 self.dist.barrier()
                 self.control_request_barrier.set()
@@ -2365,6 +2373,447 @@ class PyExecutor:
             logger.info("No MoE communication resources to restore.")
         return restored
 
+    @staticmethod
+    def _fmt_gib(value: Optional[int]) -> str:
+        if value is None:
+            return "n/a"
+        return f"{value / (1024**3):.2f} GiB"
+
+    @staticmethod
+    def _tensor_storage_bytes(value: object, seen_storages: set[int]) -> int:
+        if not isinstance(value, torch.Tensor):
+            return 0
+        try:
+            storage = value.untyped_storage()
+            data_ptr = int(storage.data_ptr())
+            if data_ptr in seen_storages:
+                return 0
+            seen_storages.add(data_ptr)
+            return int(storage.nbytes())
+        except Exception:
+            return int(value.numel() * value.element_size())
+
+    def _nested_tensor_bytes(self, value: object, seen_storages: set[int]) -> int:
+        total = self._tensor_storage_bytes(value, seen_storages)
+        if total:
+            return total
+        if isinstance(value, dict):
+            return sum(
+                self._nested_tensor_bytes(entry, seen_storages)
+                for entry in value.values())
+        if isinstance(value, (list, tuple, set)):
+            return sum(
+                self._nested_tensor_bytes(entry, seen_storages)
+                for entry in value)
+        return 0
+
+    def _same_gms_engine_process(self, pid: int) -> bool:
+        current_engine_id = os.environ.get("ENGINE_ID")
+        current_socket_dir = os.environ.get("GMS_SOCKET_DIR")
+        if current_engine_id is None:
+            return False
+
+        try:
+            with open(f"/proc/{pid}/environ", "rb") as env_file:
+                entries = env_file.read().split(b"\0")
+        except OSError:
+            return False
+
+        process_env = {}
+        for entry in entries:
+            if b"=" not in entry:
+                continue
+            key, value = entry.split(b"=", 1)
+            try:
+                process_env[key.decode()] = value.decode()
+            except UnicodeDecodeError:
+                continue
+
+        if process_env.get("ENGINE_ID") != current_engine_id:
+            return False
+        if current_socket_dir is not None:
+            return process_env.get("GMS_SOCKET_DIR") == current_socket_dir
+        return True
+
+    def _nvml_gpu_memory_bytes(self) -> tuple[Optional[int], Optional[int]]:
+        try:
+            import pynvml
+        except ImportError:
+            return None, None
+
+        try:
+            pynvml.nvmlInit()
+            handle = pynvml.nvmlDeviceGetHandleByIndex(
+                torch.cuda.current_device())
+            current_pid = os.getpid()
+            current_process_bytes = 0
+            same_engine_gms_bytes = 0
+            for proc in pynvml.nvmlDeviceGetComputeRunningProcesses(handle):
+                proc_pid = int(proc.pid)
+                used_bytes = int(proc.usedGpuMemory or 0)
+                if proc_pid == current_pid:
+                    current_process_bytes += used_bytes
+                elif self._same_gms_engine_process(proc_pid):
+                    same_engine_gms_bytes += used_bytes
+            return (current_process_bytes
+                    or None), (same_engine_gms_bytes or None)
+        except Exception as error:
+            logger.debug("Unable to query GPU memory with NVML: %s", error)
+            return None, None
+
+    def _gms_weight_bytes(self) -> int:
+        total = 0
+        for engine in (self.model_engine, self.draft_model_engine):
+            model_loader = getattr(engine, "model_loader", None)
+            if model_loader is None:
+                continue
+            gms_weight_bytes = getattr(model_loader, "gms_weight_bytes", None)
+            if callable(gms_weight_bytes):
+                total += int(gms_weight_bytes())
+        return total
+
+    def _moe_workspace_bytes(self) -> int:
+        total = 0
+        try:
+            from tensorrt_llm._mnnvl_utils import MnnvlMoe
+        except ImportError:
+            pass
+        else:
+            total += int(MnnvlMoe.workspace_bytes())
+
+        try:
+            from tensorrt_llm._torch.distributed.moe_alltoall import MoeAlltoAll
+            from tensorrt_llm._torch.modules.fused_moe.communication.nvlink_one_sided import \
+                NVLinkOneSided
+        except ImportError:
+            return total
+
+        seen_workspace_owners: set[type] = set()
+        for engine in (self.model_engine, self.draft_model_engine):
+            model = getattr(engine, "model", None)
+            if model is None:
+                continue
+            for module in model.modules():
+                for candidate in (
+                        getattr(module, "moe_a2a", None),
+                        getattr(module, "comm", None),
+                ):
+                    if not isinstance(candidate, (MoeAlltoAll, NVLinkOneSided)):
+                        continue
+                    owner = type(candidate)
+                    if owner in seen_workspace_owners:
+                        continue
+                    seen_workspace_owners.add(owner)
+                    workspace = getattr(owner, "_WORKSPACE", None)
+                    if workspace is not None:
+                        total += int(workspace.get("workspace_size_per_rank", 0)
+                                     or 0)
+                    else:
+                        total += int(
+                            getattr(candidate, "workspace_size_per_rank", 0)
+                            or 0)
+        return total
+
+    def _allreduce_workspace_bytes(self) -> int:
+        try:
+            from tensorrt_llm._torch.distributed import ops as distributed_ops
+        except ImportError:
+            return 0
+
+        seen_storages: set[int] = set()
+        total = 0
+        thread_local_values = vars(distributed_ops._thread_local)
+        for name, value in thread_local_values.items():
+            if (name.startswith("allreduce_workspaces")
+                    or name == "lowprecision_allreduce_workspaces"):
+                total += self._nested_tensor_bytes(value, seen_storages)
+
+        for workspace in distributed_ops.MNNVLAllReduce.allreduce_mnnvl_workspaces.values(
+        ):
+            explicit_bytes = 0
+            if isinstance(workspace, dict):
+                explicit_bytes = int(workspace.get("buffer_size_bytes", 0)
+                                     or 0) * 3
+            tensor_bytes = self._nested_tensor_bytes(workspace, seen_storages)
+            total += max(explicit_bytes, tensor_bytes)
+        return total
+
+    def _virtual_memory_pool_summary(self) -> str:
+        if self.virtual_memory_pools is None:
+            return "none"
+
+        parts = []
+        for tag, pool_proxy in sorted(self.virtual_memory_pools.items()):
+            pools = getattr(pool_proxy, "_pools", None)
+            if pools is None:
+                parts.append(f"{tag}:unknown")
+            else:
+                parts.append(f"{tag}:{len(pools)}")
+        return ",".join(parts) if parts else "empty"
+
+    def _torch_memory_stats_snapshot(self) -> dict:
+        try:
+            stats = torch.cuda.memory_stats()
+        except Exception as error:
+            logger.debug("Unable to query torch CUDA memory stats: %s", error)
+            return {}
+
+        keys = (
+            "active_bytes.all.current",
+            "allocated_bytes.all.current",
+            "inactive_split_bytes.all.current",
+            "reserved_bytes.all.current",
+        )
+        return {key: int(stats.get(key, 0)) for key in keys}
+
+    def _memory_buffer_bytes_by_name(self) -> dict[str, int]:
+        try:
+            from tensorrt_llm._torch.memory_buffer_utils import get_memory_buffers
+
+            buffers = get_memory_buffers()
+            bytes_by_name = getattr(buffers, "bytes_by_name", None)
+            if callable(bytes_by_name):
+                return {
+                    str(name): int(size)
+                    for name, size in bytes_by_name().items()
+                    if int(size) > 0
+                }
+        except Exception as error:
+            logger.debug("Unable to query TRTLLM memory buffers: %s", error)
+        return {}
+
+    def _memory_buffer_summary(self, bytes_by_name: dict[str, int]) -> str:
+        if not bytes_by_name:
+            return "empty"
+        return ",".join(
+            f"{name}:{self._fmt_gib(size)}"
+            for name, size in sorted(bytes_by_name.items(),
+                                     key=lambda item: item[1],
+                                     reverse=True)[:8])
+
+    def _gms_clients(self) -> list:
+        clients = []
+        for engine in (self.model_engine, self.draft_model_engine):
+            model_loader = getattr(engine, "model_loader", None)
+            gms_backend = getattr(model_loader, "_gms_backend", None)
+            client = getattr(gms_backend, "_client", None)
+            if client is not None:
+                clients.append(client)
+        return clients
+
+    def _tensor_in_gms_mappings(self, tensor: torch.Tensor) -> bool:
+        try:
+            ptr = int(tensor.data_ptr())
+        except Exception:
+            return False
+
+        for client in self._gms_clients():
+            mappings = getattr(client, "mappings", None)
+            if not mappings:
+                mappings = getattr(client, "_mappings", None)
+            if not mappings:
+                continue
+            for mapping in mappings.values():
+                base = int(getattr(mapping, "va", 0))
+                size = int(
+                    getattr(mapping, "aligned_size",
+                            getattr(mapping, "size", 0)) or 0)
+                if base and size and base <= ptr < base + size:
+                    return True
+        return False
+
+    def _iter_model_cuda_tensors(self):
+        try:
+            from gpu_memory_service.client.torch.module import _iter_module_tensors
+        except ImportError:
+            return
+
+        for engine_name, engine in (
+            ("model", self.model_engine),
+            ("draft_model", self.draft_model_engine),
+        ):
+            model = getattr(engine, "model", None)
+            if model is None:
+                continue
+            for name, tensor, tensor_type in _iter_module_tensors(model):
+                if tensor is None or not tensor.is_cuda:
+                    continue
+                yield engine_name, model, name, tensor, tensor_type
+
+    def _model_cuda_tensor_summary(self) -> tuple[int, dict[str, int], str]:
+        totals: dict[str, int] = {}
+        top_local_tensors: list[tuple[int, str]] = []
+        seen_storages: set[int] = set()
+
+        for engine_name, _model, name, tensor, tensor_type in self._iter_model_cuda_tensors(
+        ):
+            try:
+                storage = tensor.untyped_storage()
+                storage_ptr = int(storage.data_ptr())
+                nbytes = int(storage.nbytes())
+            except Exception:
+                storage_ptr = int(tensor.data_ptr())
+                nbytes = int(tensor.numel() * tensor.element_size())
+
+            if storage_ptr in seen_storages:
+                continue
+            seen_storages.add(storage_ptr)
+
+            locality = "gms" if self._tensor_in_gms_mappings(
+                tensor) else "local"
+            key = f"{tensor_type}_{locality}"
+            totals[key] = totals.get(key, 0) + nbytes
+            if locality == "local":
+                top_local_tensors.append(
+                    (nbytes, f"{engine_name}.{tensor_type}.{name}"))
+
+        local_bytes = sum(size for key, size in totals.items()
+                          if key.endswith("_local"))
+        top_summary = ",".join(
+            f"{name}:{self._fmt_gib(size)}"
+            for size, name in sorted(top_local_tensors, reverse=True)[:8])
+        return local_bytes, totals, top_summary or "empty"
+
+    def _log_gpu_memory_snapshot(self,
+                                 label: str,
+                                 tags: Optional[List[str]] = None,
+                                 *,
+                                 blobs: int = 0,
+                                 moe_modules: int = 0,
+                                 pools: int = 0,
+                                 gms_mapping_bytes: int = 0) -> dict:
+        try:
+            torch.cuda.synchronize()
+        except Exception as error:
+            logger.debug("Unable to synchronize before memory snapshot: %s",
+                         error)
+
+        try:
+            torch_allocated = int(torch.cuda.memory_allocated())
+            torch_reserved = int(torch.cuda.memory_reserved())
+            driver_free, driver_total = torch.cuda.mem_get_info()
+            driver_used = int(driver_total - driver_free)
+        except Exception as error:
+            logger.debug("Unable to query torch CUDA memory snapshot: %s", error)
+            torch_allocated = torch_reserved = 0
+            driver_free = driver_total = driver_used = None
+
+        nvml_current, nvml_same_engine_gms = self._nvml_gpu_memory_bytes()
+        non_torch_vs_reserved = (
+            max(nvml_current - torch_reserved, 0)
+            if nvml_current is not None else None)
+        non_torch_vs_allocated = (
+            max(nvml_current - torch_allocated, 0)
+            if nvml_current is not None else None)
+        torch_cached = max(torch_reserved - torch_allocated, 0)
+        torch_stats = self._torch_memory_stats_snapshot()
+        buffer_bytes_by_name = self._memory_buffer_bytes_by_name()
+        buffer_bytes = sum(buffer_bytes_by_name.values())
+        model_local_tensor_bytes, model_tensor_bytes_by_type, model_local_tensors = (
+            self._model_cuda_tensor_summary())
+        snapshot = {
+            "label": label,
+            "rank": getattr(self.dist, "rank", None),
+            "pid": os.getpid(),
+            "device": torch.cuda.current_device(),
+            "gms_mode": getattr(self.llm_args, "gms_mode", None),
+            "tags": tags or [],
+            "action_blobs": blobs,
+            "action_moe_modules": moe_modules,
+            "action_pools": pools,
+            "action_gms_mapping_bytes": gms_mapping_bytes,
+            "torch_allocated": torch_allocated,
+            "torch_reserved": torch_reserved,
+            "torch_cached": torch_cached,
+            "torch_active_bytes": int(
+                torch_stats.get("active_bytes.all.current", 0)),
+            "torch_inactive_split_bytes": int(
+                torch_stats.get("inactive_split_bytes.all.current", 0)),
+            "nvml_current_process": nvml_current,
+            "nvml_same_engine_gms": nvml_same_engine_gms,
+            "non_torch_current_vs_reserved": non_torch_vs_reserved,
+            "non_torch_current_vs_allocated": non_torch_vs_allocated,
+            "driver_used": driver_used,
+            "driver_free": driver_free,
+            "driver_total": driver_total,
+            "gms_weight_bytes": self._gms_weight_bytes(),
+            "moe_workspace": self._moe_workspace_bytes(),
+            "allreduce_workspace": self._allreduce_workspace_bytes(),
+            "memory_buffer_bytes": buffer_bytes,
+            "memory_buffer_bytes_by_name": buffer_bytes_by_name,
+            "model_local_tensor_bytes": model_local_tensor_bytes,
+            "model_tensor_bytes_by_type": model_tensor_bytes_by_type,
+            "model_local_tensors": model_local_tensors,
+            "vmm_pools": self._virtual_memory_pool_summary(),
+        }
+
+        logger.info(
+            "GMS shadow memory snapshot: "
+            f"label={snapshot['label']} rank={snapshot['rank']} "
+            f"pid={snapshot['pid']} device={snapshot['device']} "
+            f"gms_mode={snapshot['gms_mode']} tags={snapshot['tags']} "
+            f"action_blobs={snapshot['action_blobs']} "
+            f"action_moe_modules={snapshot['action_moe_modules']} "
+            f"action_pools={snapshot['action_pools']} "
+            f"action_gms_mapping={self._fmt_gib(snapshot['action_gms_mapping_bytes'])} "
+            f"torch_allocated={self._fmt_gib(snapshot['torch_allocated'])} "
+            f"torch_reserved={self._fmt_gib(snapshot['torch_reserved'])} "
+            f"torch_cached={self._fmt_gib(snapshot['torch_cached'])} "
+            f"torch_active={self._fmt_gib(snapshot['torch_active_bytes'])} "
+            f"torch_inactive_split={self._fmt_gib(snapshot['torch_inactive_split_bytes'])} "
+            f"nvml_current_process={self._fmt_gib(snapshot['nvml_current_process'])} "
+            f"nvml_same_engine_gms={self._fmt_gib(snapshot['nvml_same_engine_gms'])} "
+            f"non_torch_current_vs_reserved={self._fmt_gib(snapshot['non_torch_current_vs_reserved'])} "
+            f"non_torch_current_vs_allocated={self._fmt_gib(snapshot['non_torch_current_vs_allocated'])} "
+            f"driver_used={self._fmt_gib(snapshot['driver_used'])} "
+            f"driver_free={self._fmt_gib(snapshot['driver_free'])} "
+            f"driver_total={self._fmt_gib(snapshot['driver_total'])} "
+            f"gms_weight_bytes={self._fmt_gib(snapshot['gms_weight_bytes'])} "
+            f"moe_workspace={self._fmt_gib(snapshot['moe_workspace'])} "
+            f"allreduce_workspace={self._fmt_gib(snapshot['allreduce_workspace'])} "
+            f"memory_buffers={self._fmt_gib(snapshot['memory_buffer_bytes'])} "
+            f"memory_buffers_by_name={self._memory_buffer_summary(buffer_bytes_by_name)} "
+            f"model_local_tensors={self._fmt_gib(snapshot['model_local_tensor_bytes'])} "
+            f"model_tensor_bytes_by_type={snapshot['model_tensor_bytes_by_type']} "
+            f"model_local_tensors_by_name={snapshot['model_local_tensors']} "
+            f"vmm_pools={snapshot['vmm_pools']}")
+        return snapshot
+
+    def _release_cuda_graphs_for_sleep(self) -> int:
+        release_graphs = os.environ.get(
+            "TRTLLM_RELEASE_CUDA_GRAPHS_ON_SLEEP", "1").lower()
+        if release_graphs in {"0", "false", "no", "off"}:
+            return 0
+
+        released = 0
+        for engine in (self.model_engine, self.draft_model_engine):
+            if engine is None or not hasattr(engine, "_release_cuda_graphs"):
+                continue
+            cuda_graph_runner = getattr(engine, "cuda_graph_runner", None)
+            graph_count = len(getattr(cuda_graph_runner, "graphs", {}) or {})
+            engine._release_cuda_graphs()
+            released += graph_count
+        if released and torch.cuda.is_available():
+            torch.cuda.synchronize()
+        return released
+
+    def _clear_memory_buffers_for_sleep(self) -> tuple[int, int]:
+        clear_buffers = os.environ.get("TRTLLM_CLEAR_MEMORY_BUFFERS_ON_SLEEP",
+                                       "1").lower()
+        if clear_buffers in {"0", "false", "no", "off"}:
+            return 0, 0
+
+        try:
+            from tensorrt_llm._torch.memory_buffer_utils import get_memory_buffers
+
+            buffers = get_memory_buffers()
+            clear = getattr(buffers, "clear", None)
+            if callable(clear):
+                return clear()
+        except Exception as error:
+            logger.debug("Unable to clear TRTLLM memory buffers: %s", error)
+        return 0, 0
+
     def _flush_cuda_allocator_after_sleep(self, sleep_tags: List[str],
                                           released_blobs: int,
                                           released_pools: int) -> None:
@@ -2451,7 +2900,7 @@ class PyExecutor:
 
     def _should_park_gms_weight_mappings(self) -> bool:
         release_policy = os.environ.get("TRTLLM_GMS_RELEASE_WEIGHTS_ON_SLEEP",
-                                        "primary").lower()
+                                        "all").lower()
         if release_policy in {"0", "false", "no", "off", "none"}:
             return False
         if release_policy in {"1", "true", "yes", "on", "all", "always"}:
@@ -2465,10 +2914,10 @@ class PyExecutor:
 
         logger.warning(
             "Unknown TRTLLM_GMS_RELEASE_WEIGHTS_ON_SLEEP=%r; defaulting to "
-            "primary-only GMS weight parking",
+            "all GMS weight parking",
             release_policy,
         )
-        return gms_mode != "ro"
+        return True
 
     def _run_control_request_action(self, action: str, args: tuple, kwargs: dict):
         from tensorrt_llm.llmapi.llm_args import SleepConfig
@@ -2478,6 +2927,9 @@ class PyExecutor:
 
             sleep_tags = SleepConfig.expand_sleep_tags(
                 args[0] if args else kwargs.get("sleep_tags", []))
+            before_snapshot = self._log_gpu_memory_snapshot(
+                "sleep/before", sleep_tags)
+            released_graphs = self._release_cuda_graphs_for_sleep()
             released_moe = 0
             if "executor_extra" in sleep_tags or "moe_comm" in sleep_tags:
                 released_moe = self._release_moe_communication()
@@ -2489,26 +2941,73 @@ class PyExecutor:
                 tag for tag in sleep_tags
                 if tag not in ("moe_comm", SleepConfig.GMS_WEIGHTS_TAG)
             ]
+            released_blobs = 0
+            released_pools = 0
             if not vmm_tags:
-                if released_moe or parked_gms:
-                    self._flush_cuda_allocator_after_sleep(sleep_tags,
-                                                           released_moe, 0)
-                return 0
+                cleared_buffers, cleared_buffer_bytes = (
+                    self._clear_memory_buffers_for_sleep())
+                self._flush_cuda_allocator_after_sleep(sleep_tags, released_moe,
+                                                       0)
+                after_snapshot = self._log_gpu_memory_snapshot(
+                    "sleep/after",
+                    sleep_tags,
+                    moe_modules=released_moe,
+                    gms_mapping_bytes=parked_gms,
+                )
+                return {
+                    "action": "sleep",
+                    "tags": sleep_tags,
+                    "result": 0,
+                    "released_blobs": 0,
+                    "released_moe_modules": released_moe,
+                    "released_pools": 0,
+                    "released_cuda_graphs": released_graphs,
+                    "cleared_memory_buffers": cleared_buffers,
+                    "cleared_memory_buffer_bytes": cleared_buffer_bytes,
+                    "gms_mapping_bytes": parked_gms,
+                    "before": before_snapshot,
+                    "after": after_snapshot,
+                }
             released_blobs = release_with_tag(*vmm_tags)
             released_pools = self._release_virtual_memory_pool_caches(vmm_tags)
-            if released_blobs or released_moe or parked_gms:
-                self._flush_cuda_allocator_after_sleep(
-                    sleep_tags, released_blobs + released_moe, released_pools)
-            return released_blobs
+            cleared_buffers, cleared_buffer_bytes = (
+                self._clear_memory_buffers_for_sleep())
+            self._flush_cuda_allocator_after_sleep(
+                sleep_tags, released_blobs + released_moe, released_pools)
+            after_snapshot = self._log_gpu_memory_snapshot(
+                "sleep/after",
+                sleep_tags,
+                blobs=released_blobs,
+                moe_modules=released_moe,
+                pools=released_pools,
+                gms_mapping_bytes=parked_gms,
+            )
+            return {
+                "action": "sleep",
+                "tags": sleep_tags,
+                "result": released_blobs,
+                "released_blobs": released_blobs,
+                "released_moe_modules": released_moe,
+                "released_pools": released_pools,
+                "released_cuda_graphs": released_graphs,
+                "cleared_memory_buffers": cleared_buffers,
+                "cleared_memory_buffer_bytes": cleared_buffer_bytes,
+                "gms_mapping_bytes": parked_gms,
+                "before": before_snapshot,
+                "after": after_snapshot,
+            }
 
         if action == "wakeup":
             from tensorrt_llm._torch.virtual_memory import materialize_with_tag
 
             wakeup_tags = SleepConfig.expand_sleep_tags(
                 args[0] if args else kwargs.get("wakeup_tags", []))
+            before_snapshot = self._log_gpu_memory_snapshot(
+                "wakeup/before", wakeup_tags)
             reset_kv_cache = "kv_cache" in wakeup_tags
+            restored_gms = 0
             if SleepConfig.GMS_WEIGHTS_TAG in wakeup_tags:
-                self._restore_gms_weight_mappings()
+                restored_gms = self._restore_gms_weight_mappings()
             vmm_tags = [
                 tag for tag in wakeup_tags
                 if tag not in ("moe_comm", SleepConfig.GMS_WEIGHTS_TAG)
@@ -2517,8 +3016,25 @@ class PyExecutor:
             if reset_kv_cache:
                 self.reset_prefix_cache()
             if "executor_extra" in wakeup_tags or "moe_comm" in wakeup_tags:
-                self._restore_moe_communication()
-            return result
+                restored_moe = self._restore_moe_communication()
+            else:
+                restored_moe = 0
+            after_snapshot = self._log_gpu_memory_snapshot(
+                "wakeup/after",
+                wakeup_tags,
+                blobs=result,
+                gms_mapping_bytes=restored_gms,
+            )
+            return {
+                "action": "wakeup",
+                "tags": wakeup_tags,
+                "result": result,
+                "materialized_blobs": result,
+                "restored_moe_modules": restored_moe,
+                "gms_mapping_bytes": restored_gms,
+                "before": before_snapshot,
+                "after": after_snapshot,
+            }
 
         raise ValueError(f"Unknown control action: {action}")
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2779,7 +2779,14 @@ class PyExecutor:
             f"vmm_pools={snapshot['vmm_pools']}")
         return snapshot
 
-    def _release_cuda_graphs_for_sleep(self) -> int:
+    def _release_cuda_graphs_for_sleep(
+        self, sleep_tags: Optional[List[str]] = None
+    ) -> int:
+        if sleep_tags is not None and "gms_weights" in sleep_tags:
+            # GMS failover sleep preserves VA ranges; dropping graphs here
+            # pushes graph recapture onto the promoted shadow's first request.
+            return 0
+
         release_graphs = os.environ.get(
             "TRTLLM_RELEASE_CUDA_GRAPHS_ON_SLEEP", "1").lower()
         if release_graphs in {"0", "false", "no", "off"}:
@@ -2929,7 +2936,7 @@ class PyExecutor:
                 args[0] if args else kwargs.get("sleep_tags", []))
             before_snapshot = self._log_gpu_memory_snapshot(
                 "sleep/before", sleep_tags)
-            released_graphs = self._release_cuda_graphs_for_sleep()
+            released_graphs = self._release_cuda_graphs_for_sleep(sleep_tags)
             released_moe = 0
             if "executor_extra" in sleep_tags or "moe_comm" in sleep_tags:
                 released_moe = self._release_moe_communication()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2926,6 +2926,48 @@ class PyExecutor:
         )
         return True
 
+    def _run_deferred_warmups_after_wakeup(self) -> tuple[int, int]:
+        pending_warmup_engines = []
+        pending_graph_engines = []
+        for engine in (self.model_engine, self.draft_model_engine):
+            if engine is None:
+                continue
+            has_deferred_warmup = getattr(engine, "has_deferred_warmup", None)
+            if callable(has_deferred_warmup) and has_deferred_warmup():
+                pending_warmup_engines.append(engine)
+                continue
+
+            has_deferred = getattr(engine, "has_deferred_cuda_graph_warmup",
+                                   None)
+            if callable(has_deferred) and has_deferred():
+                pending_graph_engines.append(engine)
+
+        if not pending_warmup_engines and not pending_graph_engines:
+            return 0, 0
+
+        captured_graphs = 0
+        warmed_engines = 0
+        was_warmup = self.is_warmup
+        self.is_warmup = True
+        self.execution_stream.wait_stream(torch.cuda.current_stream())
+        try:
+            with torch.cuda.stream(self.execution_stream):
+                for engine in pending_warmup_engines:
+                    captured_graphs += engine.run_deferred_warmup(
+                        self.resource_manager)
+                    warmed_engines += 1
+                for engine in pending_graph_engines:
+                    captured_graphs += engine.capture_deferred_cuda_graphs(
+                        self.resource_manager)
+        finally:
+            torch.cuda.current_stream().wait_stream(self.execution_stream)
+            self.is_warmup = was_warmup
+
+        logger.info(
+            f"Ran {warmed_engines} deferred warmups and captured "
+            f"{captured_graphs} deferred CUDA graphs after GMS shadow wakeup")
+        return warmed_engines, captured_graphs
+
     def _run_control_request_action(self, action: str, args: tuple, kwargs: dict):
         from tensorrt_llm.llmapi.llm_args import SleepConfig
 
@@ -3016,19 +3058,14 @@ class PyExecutor:
                     }
                     release_tag_stats.append(stat)
                     logger.info(
-                        "GMS shadow sleep tag release: rank=%s tag=%s "
-                        "blobs=%s pools=%s elapsed=%.3fs current_delta=%s "
-                        "reserved_delta=%s before_current=%s after_current=%s",
-                        getattr(self.dist, "rank", None),
-                        tag,
-                        tag_blobs,
-                        tag_pools,
-                        stat["elapsed_s"],
-                        self._fmt_gib(stat["delta_current"]),
-                        self._fmt_gib(stat["delta_reserved"]),
-                        self._fmt_gib(before_current),
-                        self._fmt_gib(after_current),
-                    )
+                        f"GMS shadow sleep tag release: "
+                        f"rank={getattr(self.dist, 'rank', None)} tag={tag} "
+                        f"blobs={tag_blobs} pools={tag_pools} "
+                        f"elapsed={stat['elapsed_s']:.3f}s "
+                        f"current_delta={self._fmt_gib(stat['delta_current'])} "
+                        f"reserved_delta={self._fmt_gib(stat['delta_reserved'])} "
+                        f"before_current={self._fmt_gib(before_current)} "
+                        f"after_current={self._fmt_gib(after_current)}")
                     released_blobs += tag_blobs
                     released_pools += tag_pools
             else:
@@ -3101,6 +3138,11 @@ class PyExecutor:
                 restored_moe = 0
                 timings["restore_moe_s"] = 0.0
             step_started_at = time.monotonic()
+            warmed_engines, captured_graphs = (
+                self._run_deferred_warmups_after_wakeup())
+            timings["run_deferred_warmups_s"] = (
+                time.monotonic() - step_started_at)
+            step_started_at = time.monotonic()
             after_snapshot = self._log_gpu_memory_snapshot(
                 "wakeup/after",
                 wakeup_tags,
@@ -3111,26 +3153,24 @@ class PyExecutor:
             timings["total_rank_action_s"] = (
                 time.monotonic() - total_started_at)
             logger.info(
-                "GMS shadow wakeup timings: rank=%s tags=%s "
-                "before_snapshot=%.3fs restore_gms_weights=%.3fs "
-                "materialize_vmm=%.3fs reset_prefix_cache=%.3fs "
-                "restore_moe=%.3fs after_snapshot=%.3fs total=%.3fs",
-                getattr(self.dist, "rank", None),
-                wakeup_tags,
-                timings.get("before_snapshot_s", 0.0),
-                timings.get("restore_gms_weights_s", 0.0),
-                timings.get("materialize_vmm_s", 0.0),
-                timings.get("reset_prefix_cache_s", 0.0),
-                timings.get("restore_moe_s", 0.0),
-                timings.get("after_snapshot_s", 0.0),
-                timings.get("total_rank_action_s", 0.0),
-            )
+                f"GMS shadow wakeup timings: "
+                f"rank={getattr(self.dist, 'rank', None)} tags={wakeup_tags} "
+                f"before_snapshot={timings.get('before_snapshot_s', 0.0):.3f}s "
+                f"restore_gms_weights={timings.get('restore_gms_weights_s', 0.0):.3f}s "
+                f"materialize_vmm={timings.get('materialize_vmm_s', 0.0):.3f}s "
+                f"reset_prefix_cache={timings.get('reset_prefix_cache_s', 0.0):.3f}s "
+                f"restore_moe={timings.get('restore_moe_s', 0.0):.3f}s "
+                f"deferred_warmups={timings.get('run_deferred_warmups_s', 0.0):.3f}s "
+                f"after_snapshot={timings.get('after_snapshot_s', 0.0):.3f}s "
+                f"total={timings.get('total_rank_action_s', 0.0):.3f}s")
             return {
                 "action": "wakeup",
                 "tags": wakeup_tags,
                 "result": result,
                 "materialized_blobs": result,
                 "restored_moe_modules": restored_moe,
+                "deferred_warmup_engines": warmed_engines,
+                "captured_cuda_graphs": captured_graphs,
                 "gms_mapping_bytes": restored_gms,
                 "timings": timings,
                 "before": before_snapshot,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -46,6 +46,31 @@ from .model_loader import ModelLoader, _construct_checkpoint_loader
 from .py_executor import PyExecutor
 
 
+def _flush_cuda_allocator_after_kv_estimation() -> None:
+    if not torch.cuda.is_available():
+        return
+
+    gc.collect()
+    try:
+        free_before, total = torch.cuda.mem_get_info()
+    except Exception:
+        free_before, total = None, None
+
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+
+    if free_before is None or total is None:
+        return
+
+    free_after, _ = torch.cuda.mem_get_info()
+    reclaimed = max(free_after - free_before, 0)
+    if reclaimed:
+        logger.info(
+            "Released %.2f GiB from the CUDA caching allocator after KV cache estimation teardown",
+            reclaimed / (1024**3),
+        )
+
+
 class _ExecutorMemoryMonitor:
     """Currently this focuses on tracking memory usage and related errors."""
 
@@ -862,7 +887,7 @@ def create_py_executor(
         finally:
             kv_cache_creator.teardown_managers(resources)
         del py_executor  # free before constructing new
-        gc.collect()
+        _flush_cuda_allocator_after_kv_estimation()
 
         with allocation_scope(ExecutorMemoryType.KV_CACHE):
             # Before estimating KV cache size, a minimal KV cache has been allocated using

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -923,6 +923,21 @@ def create_py_executor(
     if mapping.rank == 0:
         logger.info(f"LLM Args:\n{llm_args}")
 
+    for engine_name, engine in (("main", model_engine), ("draft", draft_model_engine)):
+        if engine is None:
+            continue
+        model_loader = getattr(engine, 'model_loader', None)
+        if model_loader is None:
+            continue
+
+        committed_bytes = model_loader.finalize_pending_gms_write()
+        if committed_bytes:
+            logger.info(
+                "Finalized delayed GMS publish for %s model before start_worker: %.2f GiB",
+                engine_name,
+                committed_bytes / (1 << 30),
+            )
+
     py_executor.start_worker()
 
     return py_executor

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -32,7 +32,8 @@ from ..attention_backend.trtllm import TrtllmAttention
 from ..distributed import Distributed
 from ..speculative import (get_num_extra_kv_tokens, get_spec_drafter,
                            get_spec_resource_manager)
-from ..virtual_memory import scope as virtual_memory_scope
+from ..virtual_memory import (run_with_oom_retry,
+                              scope as virtual_memory_scope)
 from ._util import (KvCacheCreator, _adjust_torch_mem_fraction,
                     create_py_executor_instance, instantiate_sampler, is_mla,
                     validate_feature_combination)
@@ -204,6 +205,22 @@ def update_sampler_max_seq_len(max_seq_len, sampler):
     if isinstance(sampler, TRTLLMSampler):
         assert hasattr(sampler, "max_seq_len")
         sampler.max_seq_len = max_seq_len
+
+
+def _build_kv_cache_managers(
+    kv_cache_creator: KvCacheCreator,
+    resources,
+    *,
+    estimating_kv_cache: bool,
+    enable_sleep: bool,
+) -> None:
+    if enable_sleep and not estimating_kv_cache:
+        run_with_oom_retry(
+            lambda: kv_cache_creator.build_managers(resources, False),
+            description="Building KV cache managers")
+        return
+
+    kv_cache_creator.build_managers(resources, estimating_kv_cache)
 
 
 def get_guided_decoding_config(guided_decoding_backend: str,
@@ -760,7 +777,12 @@ def create_py_executor(
         with allocation_scope(
                 ExecutorMemoryType.INIT_KV_CACHE
                 if estimating_kv_cache else ExecutorMemoryType.KV_CACHE):
-            kv_cache_creator.build_managers(resources, estimating_kv_cache)
+            _build_kv_cache_managers(
+                kv_cache_creator,
+                resources,
+                estimating_kv_cache=estimating_kv_cache,
+                enable_sleep=enable_sleep,
+            )
             # Originally, max_seq_len might be mutated inside build_managers as field of executor config.
             # Since now, we are changing kv_cache_creator._max_seq_len instead. Restore max_seq_len here.
             max_seq_len = kv_cache_creator._max_seq_len
@@ -847,7 +869,12 @@ def create_py_executor(
             # create_kv_cache_manager above, which caps kv_cache_creator.max_seq_len. Restoring
             # the original value before creating the final KV cache.
             kv_cache_creator._max_seq_len = model_engine_max_seq_len
-            kv_cache_creator.build_managers(resources, False)
+            _build_kv_cache_managers(
+                kv_cache_creator,
+                resources,
+                estimating_kv_cache=False,
+                enable_sleep=enable_sleep,
+            )
             # Originally, max_seq_len might be mutated inside build_managers as field of executor config.
             # Since now, we are changing kv_cache_creator._max_seq_len instead. Restore max_seq_len here.
             max_seq_len = kv_cache_creator._max_seq_len

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -32,8 +32,7 @@ from ..attention_backend.trtllm import TrtllmAttention
 from ..distributed import Distributed
 from ..speculative import (get_num_extra_kv_tokens, get_spec_drafter,
                            get_spec_resource_manager)
-from ..virtual_memory import (release_with_tag, run_with_oom_retry,
-                              scope as virtual_memory_scope)
+from ..virtual_memory import run_with_oom_retry, scope as virtual_memory_scope
 from ._util import (KvCacheCreator, _adjust_torch_mem_fraction,
                     create_py_executor_instance, instantiate_sampler, is_mla,
                     validate_feature_combination)
@@ -69,145 +68,6 @@ def _flush_cuda_allocator_after_kv_estimation() -> None:
             "Released %.2f GiB from the CUDA caching allocator after KV cache estimation teardown",
             reclaimed / (1024**3),
         )
-
-
-def _llm_env(llm_args: TorchLlmArgs,
-             key: str,
-             default: Optional[str] = None) -> Optional[str]:
-    value = os.environ.get(key)
-    if value is not None:
-        return value
-
-    env_overrides = getattr(llm_args, "env_overrides", None)
-    if isinstance(env_overrides, dict):
-        return env_overrides.get(key, default)
-    return default
-
-
-def _false_env(value: Optional[str]) -> bool:
-    return str(value).lower() in {"0", "false", "no", "off"}
-
-
-def _is_gms_load_format(llm_args: TorchLlmArgs) -> bool:
-    load_format = getattr(llm_args, "load_format", None)
-    load_format_name = getattr(load_format, "name", str(load_format)).upper()
-    load_format_value = getattr(load_format, "value", str(load_format))
-    load_format_text = str(load_format)
-    return (load_format == LoadFormat.GMS
-            or load_format_name == LoadFormat.GMS.name
-            or str(load_format_value).lower() == LoadFormat.GMS.name.lower()
-            or load_format_text.lower() == LoadFormat.GMS.name.lower()
-            or load_format_text.lower().endswith(
-                f".{LoadFormat.GMS.name.lower()}")
-            or str(load_format_value) == str(LoadFormat.GMS.value))
-
-
-def _should_defer_gms_shadow_cuda_graph_capture(
-        llm_args: TorchLlmArgs, *, estimating_kv_cache: bool) -> bool:
-    if not estimating_kv_cache:
-        return False
-    if getattr(llm_args, "cuda_graph_config", None) is None:
-        return False
-    if getattr(llm_args, "sleep_config", None) is None:
-        return False
-    if _false_env(
-            _llm_env(llm_args, "TRTLLM_GMS_DEFER_SHADOW_CUDA_GRAPH_CAPTURE",
-                     "1")):
-        return False
-
-    gms_mode = str(getattr(llm_args, "gms_mode", "")).lower()
-    if gms_mode == "rw":
-        return False
-    if gms_mode == "ro":
-        return True
-
-    engine_id = _llm_env(llm_args, "ENGINE_ID", "0")
-    if _llm_env(llm_args, "GMS_SOCKET_DIR") and engine_id != "0":
-        return True
-
-    return _is_gms_load_format(llm_args) and engine_id != "0"
-
-
-def _should_defer_gms_shadow_startup_warmup(
-        llm_args: TorchLlmArgs, *, estimating_kv_cache: bool) -> bool:
-    if _false_env(
-            _llm_env(llm_args, "TRTLLM_GMS_DEFER_SHADOW_STARTUP_WARMUP",
-                     "1")):
-        return False
-    return _should_defer_gms_shadow_cuda_graph_capture(
-        llm_args, estimating_kv_cache=estimating_kv_cache)
-
-
-def _release_virtual_memory_pool_caches(vm_pools: dict,
-                                        tags: tuple[str, ...]) -> int:
-    released_pools = 0
-    for tag in tags:
-        pool_proxy = vm_pools.pop(tag, None)
-        if pool_proxy is None:
-            continue
-
-        release_cached_blocks = getattr(pool_proxy, "release_cached_blocks",
-                                        None)
-        if callable(release_cached_blocks):
-            released_pools += release_cached_blocks()
-            continue
-
-        pools = getattr(pool_proxy, "_pools", None)
-        if pools is None:
-            continue
-        released_pools += len(pools)
-        pools.clear()
-    return released_pools
-
-
-def _prepare_gms_shadow_parked_startup(
-        model_engine: PyTorchModelEngine,
-        draft_model_engine: Optional[PyTorchModelEngine],
-        llm_args: TorchLlmArgs,
-        vm_pools: dict,
-        *,
-        estimating_kv_cache: bool,
-) -> bool:
-    if not _should_defer_gms_shadow_startup_warmup(
-            llm_args, estimating_kv_cache=estimating_kv_cache):
-        return False
-
-    reason = (
-        "GMS shadow final startup defers full warmup until wakeup and "
-        "parks full KV physical memory so active replicas keep maximum KV "
-        "capacity without startup-time peer memory pressure")
-    for engine in (model_engine, draft_model_engine):
-        if engine is not None:
-            engine.defer_warmup_once(reason)
-
-    released_blobs = release_with_tag(ExecutorMemoryType.KV_CACHE.value)
-    released_pools = _release_virtual_memory_pool_caches(
-        vm_pools, (ExecutorMemoryType.KV_CACHE.value, ))
-    _flush_cuda_allocator_after_kv_estimation()
-    logger.info(
-        f"{reason}: released_kv_blobs={released_blobs} "
-        f"released_kv_pools={released_pools}")
-    return True
-
-
-def _defer_gms_shadow_cuda_graph_capture(
-        model_engine: PyTorchModelEngine,
-        draft_model_engine: Optional[PyTorchModelEngine],
-        llm_args: TorchLlmArgs,
-        *,
-        estimating_kv_cache: bool,
-) -> None:
-    if not _should_defer_gms_shadow_cuda_graph_capture(
-            llm_args, estimating_kv_cache=estimating_kv_cache):
-        return
-
-    reason = (
-        "GMS shadow final startup defers full-KV CUDA graph capture until "
-        "wakeup so parked peers do not consume graph-capture headroom")
-    for engine in (model_engine, draft_model_engine):
-        if engine is not None:
-            engine.defer_cuda_graph_warmup_once(reason)
-    logger.info(reason)
 
 
 class _ExecutorMemoryMonitor:
@@ -1052,20 +912,6 @@ def create_py_executor(
                         eng._release_cuda_graphs()
                     eng.attn_metadata = None
 
-            prepared_parked_shadow = _prepare_gms_shadow_parked_startup(
-                model_engine,
-                draft_model_engine,
-                llm_args,
-                vm_pools,
-                estimating_kv_cache=estimating_kv_cache,
-            )
-            if not prepared_parked_shadow:
-                _defer_gms_shadow_cuda_graph_capture(
-                    model_engine,
-                    draft_model_engine,
-                    llm_args,
-                    estimating_kv_cache=estimating_kv_cache,
-                )
         with allocation_scope(ExecutorMemoryType.EXTRA_RESOURCES):
 
             # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -32,7 +32,7 @@ from ..attention_backend.trtllm import TrtllmAttention
 from ..distributed import Distributed
 from ..speculative import (get_num_extra_kv_tokens, get_spec_drafter,
                            get_spec_resource_manager)
-from ..virtual_memory import (run_with_oom_retry,
+from ..virtual_memory import (release_with_tag, run_with_oom_retry,
                               scope as virtual_memory_scope)
 from ._util import (KvCacheCreator, _adjust_torch_mem_fraction,
                     create_py_executor_instance, instantiate_sampler, is_mla,
@@ -69,6 +69,145 @@ def _flush_cuda_allocator_after_kv_estimation() -> None:
             "Released %.2f GiB from the CUDA caching allocator after KV cache estimation teardown",
             reclaimed / (1024**3),
         )
+
+
+def _llm_env(llm_args: TorchLlmArgs,
+             key: str,
+             default: Optional[str] = None) -> Optional[str]:
+    value = os.environ.get(key)
+    if value is not None:
+        return value
+
+    env_overrides = getattr(llm_args, "env_overrides", None)
+    if isinstance(env_overrides, dict):
+        return env_overrides.get(key, default)
+    return default
+
+
+def _false_env(value: Optional[str]) -> bool:
+    return str(value).lower() in {"0", "false", "no", "off"}
+
+
+def _is_gms_load_format(llm_args: TorchLlmArgs) -> bool:
+    load_format = getattr(llm_args, "load_format", None)
+    load_format_name = getattr(load_format, "name", str(load_format)).upper()
+    load_format_value = getattr(load_format, "value", str(load_format))
+    load_format_text = str(load_format)
+    return (load_format == LoadFormat.GMS
+            or load_format_name == LoadFormat.GMS.name
+            or str(load_format_value).lower() == LoadFormat.GMS.name.lower()
+            or load_format_text.lower() == LoadFormat.GMS.name.lower()
+            or load_format_text.lower().endswith(
+                f".{LoadFormat.GMS.name.lower()}")
+            or str(load_format_value) == str(LoadFormat.GMS.value))
+
+
+def _should_defer_gms_shadow_cuda_graph_capture(
+        llm_args: TorchLlmArgs, *, estimating_kv_cache: bool) -> bool:
+    if not estimating_kv_cache:
+        return False
+    if getattr(llm_args, "cuda_graph_config", None) is None:
+        return False
+    if getattr(llm_args, "sleep_config", None) is None:
+        return False
+    if _false_env(
+            _llm_env(llm_args, "TRTLLM_GMS_DEFER_SHADOW_CUDA_GRAPH_CAPTURE",
+                     "1")):
+        return False
+
+    gms_mode = str(getattr(llm_args, "gms_mode", "")).lower()
+    if gms_mode == "rw":
+        return False
+    if gms_mode == "ro":
+        return True
+
+    engine_id = _llm_env(llm_args, "ENGINE_ID", "0")
+    if _llm_env(llm_args, "GMS_SOCKET_DIR") and engine_id != "0":
+        return True
+
+    return _is_gms_load_format(llm_args) and engine_id != "0"
+
+
+def _should_defer_gms_shadow_startup_warmup(
+        llm_args: TorchLlmArgs, *, estimating_kv_cache: bool) -> bool:
+    if _false_env(
+            _llm_env(llm_args, "TRTLLM_GMS_DEFER_SHADOW_STARTUP_WARMUP",
+                     "1")):
+        return False
+    return _should_defer_gms_shadow_cuda_graph_capture(
+        llm_args, estimating_kv_cache=estimating_kv_cache)
+
+
+def _release_virtual_memory_pool_caches(vm_pools: dict,
+                                        tags: tuple[str, ...]) -> int:
+    released_pools = 0
+    for tag in tags:
+        pool_proxy = vm_pools.pop(tag, None)
+        if pool_proxy is None:
+            continue
+
+        release_cached_blocks = getattr(pool_proxy, "release_cached_blocks",
+                                        None)
+        if callable(release_cached_blocks):
+            released_pools += release_cached_blocks()
+            continue
+
+        pools = getattr(pool_proxy, "_pools", None)
+        if pools is None:
+            continue
+        released_pools += len(pools)
+        pools.clear()
+    return released_pools
+
+
+def _prepare_gms_shadow_parked_startup(
+        model_engine: PyTorchModelEngine,
+        draft_model_engine: Optional[PyTorchModelEngine],
+        llm_args: TorchLlmArgs,
+        vm_pools: dict,
+        *,
+        estimating_kv_cache: bool,
+) -> bool:
+    if not _should_defer_gms_shadow_startup_warmup(
+            llm_args, estimating_kv_cache=estimating_kv_cache):
+        return False
+
+    reason = (
+        "GMS shadow final startup defers full warmup until wakeup and "
+        "parks full KV physical memory so active replicas keep maximum KV "
+        "capacity without startup-time peer memory pressure")
+    for engine in (model_engine, draft_model_engine):
+        if engine is not None:
+            engine.defer_warmup_once(reason)
+
+    released_blobs = release_with_tag(ExecutorMemoryType.KV_CACHE.value)
+    released_pools = _release_virtual_memory_pool_caches(
+        vm_pools, (ExecutorMemoryType.KV_CACHE.value, ))
+    _flush_cuda_allocator_after_kv_estimation()
+    logger.info(
+        f"{reason}: released_kv_blobs={released_blobs} "
+        f"released_kv_pools={released_pools}")
+    return True
+
+
+def _defer_gms_shadow_cuda_graph_capture(
+        model_engine: PyTorchModelEngine,
+        draft_model_engine: Optional[PyTorchModelEngine],
+        llm_args: TorchLlmArgs,
+        *,
+        estimating_kv_cache: bool,
+) -> None:
+    if not _should_defer_gms_shadow_cuda_graph_capture(
+            llm_args, estimating_kv_cache=estimating_kv_cache):
+        return
+
+    reason = (
+        "GMS shadow final startup defers full-KV CUDA graph capture until "
+        "wakeup so parked peers do not consume graph-capture headroom")
+    for engine in (model_engine, draft_model_engine):
+        if engine is not None:
+            engine.defer_cuda_graph_warmup_once(reason)
+    logger.info(reason)
 
 
 class _ExecutorMemoryMonitor:
@@ -912,6 +1051,21 @@ def create_py_executor(
                     if llm_args.cuda_graph_config is not None:
                         eng._release_cuda_graphs()
                     eng.attn_metadata = None
+
+            prepared_parked_shadow = _prepare_gms_shadow_parked_startup(
+                model_engine,
+                draft_model_engine,
+                llm_args,
+                vm_pools,
+                estimating_kv_cache=estimating_kv_cache,
+            )
+            if not prepared_parked_shadow:
+                _defer_gms_shadow_cuda_graph_capture(
+                    model_engine,
+                    draft_model_engine,
+                    llm_args,
+                    estimating_kv_cache=estimating_kv_cache,
+                )
         with allocation_scope(ExecutorMemoryType.EXTRA_RESOURCES):
 
             # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -944,18 +944,32 @@ class KVCacheManager(BaseResourceManager):
 
         cache_size_bytes_per_token = self.get_cache_bytes_per_token()
 
-        free_mem, total_mem = torch.cuda.mem_get_info()
-
         assert free_mem_fraction < 1.0, f"Invalid freeMemFraction, freeMemFraction {free_mem_fraction} must be smaller than 1.0"
-        max_tokens = free_mem_fraction * free_mem / cache_size_bytes_per_token
+        if kv_cache_config.max_gpu_total_bytes > 0:
+            max_tokens = (kv_cache_config.max_gpu_total_bytes /
+                          cache_size_bytes_per_token)
+            logger.info(
+                "max_gpu_total_bytes is set by "
+                "kv_cache_config.max_gpu_total_bytes: "
+                f"{kv_cache_config.max_gpu_total_bytes / (1 << 30)}GiB"
+            )
+        else:
+            free_mem, total_mem = torch.cuda.mem_get_info()
+            max_tokens = free_mem_fraction * free_mem / cache_size_bytes_per_token
 
         # If user specified a number of tokens
         if kv_cache_config.max_tokens is not None:
             # If user also specified a free gpu memory fraction, take the min
-            if kv_cache_config.free_gpu_memory_fraction is not None:
+            if (kv_cache_config.free_gpu_memory_fraction is not None
+                    and kv_cache_config.max_gpu_total_bytes <= 0):
                 max_tokens = min(kv_cache_config.max_tokens, max_tokens)
                 logger.warning(
                     f'Both free_gpu_memory_fraction and max_tokens are set (to {free_mem_fraction} and {max_tokens} with free memory {free_mem / (1 << 30)}GiB of total memory {total_mem / (1<<30)}GiB, respectively). The smaller value will be used.'
+                )
+            elif kv_cache_config.max_gpu_total_bytes > 0:
+                max_tokens = min(kv_cache_config.max_tokens, max_tokens)
+                logger.info(
+                    f"max_tokens is set by kv_cache_config.max_tokens: {kv_cache_config.max_tokens}"
                 )
             else:
                 max_tokens = kv_cache_config.max_tokens

--- a/tensorrt_llm/_torch/virtual_memory.py
+++ b/tensorrt_llm/_torch/virtual_memory.py
@@ -1,6 +1,7 @@
 import contextlib
 import functools
 import gc
+import os
 import time
 from contextlib import contextmanager
 from typing import Callable, Generator, TypeVar
@@ -20,7 +21,7 @@ __all__ = [
 ]
 
 T = TypeVar("T")
-_OOM_RETRY_INTERVAL_SECONDS = 1.0
+_OOM_RETRY_INTERVAL_SECONDS = 0.05
 
 
 @functools.cache
@@ -48,6 +49,11 @@ class _MultiPoolProxy:
 
     def _add(self, pool: torch.cuda.MemPool):
         self._pools.append(pool)
+
+    def release_cached_blocks(self) -> int:
+        released_pools = len(self._pools)
+        self._pools.clear()
+        return released_pools
 
     def __del__(self):
         self._pools.clear()
@@ -149,12 +155,14 @@ def _cleanup_after_oom() -> None:
 
 def run_with_oom_retry(action: Callable[[], T], *, description: str) -> T:
     retries = 0
+    retry_interval = float(
+        os.environ.get("TLLM_VMM_OOM_RETRY_INTERVAL_SECONDS",
+                       str(_OOM_RETRY_INTERVAL_SECONDS)))
     while True:
         try:
             result = action()
             if retries:
-                logger.info("%s succeeded after %d retries", description,
-                            retries)
+                logger.info(f"{description} succeeded after {retries} retries")
             return result
         except Exception as error:
             if not _is_oom_error(error):
@@ -162,10 +170,10 @@ def run_with_oom_retry(action: Callable[[], T], *, description: str) -> T:
 
             retries += 1
             logger.warning(
-                "%s hit OOM, waiting for capacity before retry %d: %s",
-                description, retries, error)
+                f"{description} hit OOM, waiting for capacity before "
+                f"retry {retries}: {error}")
             _cleanup_after_oom()
-            time.sleep(_OOM_RETRY_INTERVAL_SECONDS)
+            time.sleep(retry_interval)
 
 
 def materialize_with_tag(*tags: str) -> int:

--- a/tensorrt_llm/_torch/virtual_memory.py
+++ b/tensorrt_llm/_torch/virtual_memory.py
@@ -1,7 +1,9 @@
 import contextlib
 import functools
+import gc
+import time
 from contextlib import contextmanager
-from typing import Generator
+from typing import Callable, Generator, TypeVar
 
 import torch
 
@@ -10,11 +12,15 @@ from tensorrt_llm.bindings.internal.runtime import \
 from tensorrt_llm.bindings.internal.runtime import (
     get_virtual_memory_manager, pop_virtual_memory_allocator,
     push_virtual_memory_allocator)
+from tensorrt_llm.logger import logger
 
 __all__ = [
     "RestoreMode", "maybe_scope", "scope", "release_with_tag",
-    "materialize_with_tag"
+    "materialize_with_tag", "run_with_oom_retry"
 ]
+
+T = TypeVar("T")
+_OOM_RETRY_INTERVAL_SECONDS = 1.0
 
 
 @functools.cache
@@ -128,6 +134,40 @@ def release_with_tag(*tags: str) -> int:
     return released_blobs
 
 
+def _is_oom_error(error: Exception) -> bool:
+    return isinstance(error, torch.OutOfMemoryError) or "out of memory" in str(
+        error).lower()
+
+
+def _cleanup_after_oom() -> None:
+    for cleanup in (torch.cuda.synchronize, gc.collect, torch.cuda.empty_cache):
+        try:
+            cleanup()
+        except Exception as cleanup_error:
+            logger.debug("OOM cleanup step failed: %s", cleanup_error)
+
+
+def run_with_oom_retry(action: Callable[[], T], *, description: str) -> T:
+    retries = 0
+    while True:
+        try:
+            result = action()
+            if retries:
+                logger.info("%s succeeded after %d retries", description,
+                            retries)
+            return result
+        except Exception as error:
+            if not _is_oom_error(error):
+                raise
+
+            retries += 1
+            logger.warning(
+                "%s hit OOM, waiting for capacity before retry %d: %s",
+                description, retries, error)
+            _cleanup_after_oom()
+            time.sleep(_OOM_RETRY_INTERVAL_SECONDS)
+
+
 def materialize_with_tag(*tags: str) -> int:
     """Materialize virtual memory allocated with given tags
 
@@ -135,5 +175,9 @@ def materialize_with_tag(*tags: str) -> int:
     :return: Number of memory blobs materialized
     """
     manager = get_virtual_memory_manager()
-    materialized_blobs = sum(manager.materialize_with_tag(tag) for tag in tags)
+    materialized_blobs = 0
+    for tag in tags:
+        materialized_blobs += run_with_oom_retry(
+            lambda tag=tag: manager.materialize_with_tag(tag),
+            description=f"Materializing virtual memory for tag {tag}")
     return materialized_blobs

--- a/tensorrt_llm/_torch/virtual_memory.py
+++ b/tensorrt_llm/_torch/virtual_memory.py
@@ -21,7 +21,7 @@ __all__ = [
 ]
 
 T = TypeVar("T")
-_OOM_RETRY_INTERVAL_SECONDS = 0.05
+_OOM_RETRY_INTERVAL_SECONDS = 0.2
 
 
 @functools.cache

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -648,6 +648,26 @@ class BaseWorker(GenerationExecutor):
 
         return result
 
+    def sleep(self, sleep_tags: List[str]):
+        if hasattr(self.engine, "sleep"):
+            return self.engine.sleep(sleep_tags)
+
+        from tensorrt_llm._torch.virtual_memory import release_with_tag
+
+        return release_with_tag(*sleep_tags)
+
+    def wakeup(self, wakeup_tags: List[str]):
+        if hasattr(self.engine, "wakeup"):
+            return self.engine.wakeup(wakeup_tags)
+
+        from tensorrt_llm._torch.virtual_memory import materialize_with_tag
+
+        wakeup_tags = list(wakeup_tags)
+        result = materialize_with_tag(*wakeup_tags)
+        if "kv_cache" in wakeup_tags and hasattr(self.engine, 'reset_prefix_cache'):
+            self.engine.reset_prefix_cache()
+        return result
+
     def shutdown(self):
         if self.doing_shutdown:
             return

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -157,6 +157,12 @@ class GenerationExecutorProxy(GenerationExecutor):
         # send back a finished result.
         self.request_queue.put(CancellingRequest(request_id))
 
+    def sleep(self, sleep_tags: List[str]):
+        return self.rpc_client.sleep(sleep_tags).remote(need_response=True)
+
+    def wakeup(self, wakeup_tags: List[str]):
+        return self.rpc_client.wakeup(wakeup_tags).remote(need_response=True)
+
     def dispatch_result_task(self) -> bool:
         # TODO[chunweiy]: convert the dispatch_result_task to async, that should
         # benefit from zmq.asyncio.Context

--- a/tensorrt_llm/executor/ray_gpu_worker.py
+++ b/tensorrt_llm/executor/ray_gpu_worker.py
@@ -295,6 +295,8 @@ class RayGPUWorker(RpcWorkerMixin, BaseWorker):
             logger.info(f"Wakeup: {tags}")
             torch.cuda.synchronize()
             materialize_with_tag(*tags)
+            if ExecutorMemoryType.KV_CACHE in tags:
+                self.engine.reset_prefix_cache()
             torch.cuda.synchronize()
         except Exception as e:
             logger.error(f"Encountered an error in wakeup")

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -186,6 +186,12 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
     def abort_request(self, request_id: int) -> None:
         return self.rpc_client.abort_request(request_id).remote()
 
+    def sleep(self, sleep_tags: List[str]):
+        return self.rpc_client.sleep(sleep_tags).remote(need_response=True)
+
+    def wakeup(self, wakeup_tags: List[str]):
+        return self.rpc_client.wakeup(wakeup_tags).remote(need_response=True)
+
     def shutdown(self):
         if self._shutdown_event.is_set():
             return

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -85,6 +85,18 @@ class GenerationExecutorWorker(RpcWorkerMixin, BaseWorker):
         # so we only need to start the response thread
         self.start_thread(self.await_response_thread)
 
+    def sleep(self, sleep_tags: List[str]):
+        from tensorrt_llm._torch.virtual_memory import release_with_tag
+
+        release_with_tag(*sleep_tags)
+
+    def wakeup(self, wakeup_tags: List[str]):
+        from tensorrt_llm._torch.virtual_memory import materialize_with_tag
+
+        materialize_with_tag(*wakeup_tags)
+        if "kv_cache" in wakeup_tags and hasattr(self.engine, 'reset_prefix_cache'):
+            self.engine.reset_prefix_cache()
+
     def shutdown(self):
 
         if self.doing_shutdown:

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -85,18 +85,6 @@ class GenerationExecutorWorker(RpcWorkerMixin, BaseWorker):
         # so we only need to start the response thread
         self.start_thread(self.await_response_thread)
 
-    def sleep(self, sleep_tags: List[str]):
-        from tensorrt_llm._torch.virtual_memory import release_with_tag
-
-        release_with_tag(*sleep_tags)
-
-    def wakeup(self, wakeup_tags: List[str]):
-        from tensorrt_llm._torch.virtual_memory import materialize_with_tag
-
-        materialize_with_tag(*wakeup_tags)
-        if "kv_cache" in wakeup_tags and hasattr(self.engine, 'reset_prefix_cache'):
-            self.engine.reset_prefix_cache()
-
     def shutdown(self):
 
         if self.doing_shutdown:

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -1249,10 +1249,14 @@ class _TorchLLM(BaseLLM):
             return self._executor.collective_rpc(method, args, kwargs,
                                                  non_block, unique_reply_rank,
                                                  target_ranks)
-        else:
-            raise ValueError(
-                f"Executor type {type(self._executor)} does not support collective RPC."
-            )
+
+        local_method = getattr(self._executor, method, None)
+        if callable(local_method):
+            return [local_method(*args, **(kwargs or {}))]
+
+        raise ValueError(
+            f"Executor type {type(self._executor)} does not support collective RPC."
+        )
 
     def _build_model(self):
         super()._build_model()

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1705,6 +1705,36 @@ class SleepConfig(StrictBaseModel):
     DEFAULT_RESTORE_MODES: ClassVar[dict[str, str]] = {
         ExecutorMemoryType.KV_CACHE: "NONE",
     }
+    SHADOW_FAILOVER_PRESET: ClassVar[str] = "shadow_failover"
+    SHADOW_FAILOVER_TAGS: ClassVar[tuple[str, ...]] = (
+        ExecutorMemoryType.KV_CACHE.value,
+        ExecutorMemoryType.MODEL_ENGINE_MAIN.value,
+        ExecutorMemoryType.MODEL_ENGINE_DRAFT.value,
+        ExecutorMemoryType.MODEL_EXTRA.value,
+        ExecutorMemoryType.EXTRA_RESOURCES.value,
+        "moe_comm",
+        ExecutorMemoryType.SPEC_RESOURCES.value,
+        ExecutorMemoryType.DRAFTER.value,
+        ExecutorMemoryType.SAMPLER.value,
+        ExecutorMemoryType.GUIDED_DECODER.value,
+    )
+
+    @classmethod
+    def shadow_failover_tags(cls) -> tuple[str, ...]:
+        return cls.SHADOW_FAILOVER_TAGS
+
+    @classmethod
+    def expand_sleep_tags(cls, tags: list[str] | tuple[str, ...] | None) -> list[str]:
+        expanded: list[str] = []
+        for tag in tags or ():
+            if tag == cls.SHADOW_FAILOVER_PRESET:
+                candidates = cls.SHADOW_FAILOVER_TAGS
+            else:
+                candidates = (tag,)
+            for candidate in candidates:
+                if candidate not in expanded:
+                    expanded.append(candidate)
+        return expanded
 
     @staticmethod
     def _normalize_restore_mode(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1706,12 +1706,14 @@ class SleepConfig(StrictBaseModel):
         ExecutorMemoryType.KV_CACHE: "NONE",
     }
     SHADOW_FAILOVER_PRESET: ClassVar[str] = "shadow_failover"
+    GMS_WEIGHTS_TAG: ClassVar[str] = "gms_weights"
     SHADOW_FAILOVER_TAGS: ClassVar[tuple[str, ...]] = (
         ExecutorMemoryType.KV_CACHE.value,
         ExecutorMemoryType.MODEL_ENGINE_MAIN.value,
         ExecutorMemoryType.MODEL_ENGINE_DRAFT.value,
         ExecutorMemoryType.MODEL_EXTRA.value,
         ExecutorMemoryType.EXTRA_RESOURCES.value,
+        GMS_WEIGHTS_TAG,
         "moe_comm",
         ExecutorMemoryType.SPEC_RESOURCES.value,
         ExecutorMemoryType.DRAFTER.value,
@@ -3696,6 +3698,10 @@ class TorchLlmArgs(BaseLlmArgs):
     def convert_load_format(cls, v):
         if isinstance(v, LoadFormat):
             return v
+        if isinstance(v, int):
+            return LoadFormat(v)
+        if isinstance(v, str) and v.startswith(f"{LoadFormat.__name__}."):
+            v = v.split(".", 1)[1]
         load_format = v.upper()
         if load_format not in LoadFormat.__members__:
             raise ValueError(f"Invalid LoadFormat: {v}")

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3306,6 +3306,8 @@ class LoadFormat(Enum):
     DUMMY = 1
     # Only load the multimodal(vision) encoder weights
     VISION_ONLY = 2
+    # Load weights from GPU Memory Service.
+    GMS = 3
 
 
 class SamplerType(StrEnum):
@@ -3537,6 +3539,27 @@ class TorchLlmArgs(BaseLlmArgs):
         status="prototype",
     )
 
+    gms_socket_path: Optional[str] = Field(
+        default=None,
+        description="Unix domain socket path of the GPU Memory Service. "
+        "Only used when load_format='GMS'.",
+        status="prototype",
+    )
+
+    gms_mode: Optional[str] = Field(
+        default="auto",
+        description="GMS operating mode: 'auto', 'rw', or 'ro'. "
+        "Only used when load_format='GMS'.",
+        status="prototype",
+    )
+
+    gms_tag: str = Field(
+        default="weights",
+        description="Logical tag for the GMS weight set. Defaults to 'weights'. "
+        "Only used when load_format='GMS'.",
+        status="prototype",
+    )
+
     kv_connector_config: Optional[KvCacheConnectorConfig] = Field(
         default=None,
         description="The config for KV cache connector.",
@@ -3746,6 +3769,22 @@ class TorchLlmArgs(BaseLlmArgs):
                 "neither checkpoint_format nor checkpoint_loader were provided, "
                 "checkpoint_format will be set to HF.")
             self.checkpoint_format = "HF"
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_gms_config(self) -> 'TorchLlmArgs':
+        if self.load_format == LoadFormat.GMS and self.gms_mode not in (
+                "auto", "rw", "ro"):
+            raise ValueError(
+                f"gms_mode must be 'auto', 'rw', or 'ro', got '{self.gms_mode}'."
+            )
+
+        if self.gms_socket_path is not None and self.load_format != LoadFormat.GMS:
+            logger.warning(
+                "gms_socket_path is set but load_format is '%s', not 'GMS'. "
+                "The gms_socket_path will be ignored. Set load_format='GMS' "
+                "to enable GPU Memory Service.", self.load_format.name)
 
         return self
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1747,7 +1747,7 @@ class SleepConfig(StrictBaseModel):
                              str | _VirtualMemoryRestoreMode]] = None,
         *,
         default_mode: Optional[_VirtualMemoryRestoreMode] = None
-    ) -> defaultdict[ExecutorMemoryType, _VirtualMemoryRestoreMode]:
+    ) -> dict[ExecutorMemoryType, _VirtualMemoryRestoreMode]:
         from tensorrt_llm._torch.virtual_memory import RestoreMode
         default_mode: _VirtualMemoryRestoreMode = default_mode or (
             RestoreMode.PINNED if prefer_pinned() else RestoreMode.CPU)
@@ -1759,7 +1759,10 @@ class SleepConfig(StrictBaseModel):
             cls._normalize_restore_mode(value)
             for key, value in cases.items()
         }
-        return defaultdict(lambda: default_mode, normalized_cases)
+        return {
+            memory_type: normalized_cases.get(memory_type, default_mode)
+            for memory_type in ExecutorMemoryType
+        }
 
     @field_validator('restore_modes', mode='plain')
     @classmethod

--- a/tensorrt_llm/llmapi/mpi_session.py
+++ b/tensorrt_llm/llmapi/mpi_session.py
@@ -27,6 +27,19 @@ if ENABLE_MULTI_DEVICE:
 T = TypeVar("T")
 
 
+def _is_mpi_pool_env_key(key: str) -> bool:
+    return (key.startswith("TRTLLM") or key.startswith("TLLM")
+            or key.startswith("GMS_")
+            or key in {"ENGINE_ID", "FAILOVER_LOCK_PATH"})
+
+
+def _get_mpi_pool_env() -> Dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items() if _is_mpi_pool_env_key(key)
+    }
+
+
 class MPINodeState:
     ''' MPINodeState acts as a central global state shares between tasks on MPI node.
 
@@ -170,11 +183,7 @@ class MpiPoolSession(MpiSession):
     def _start_mpi_pool(self):
         assert not self.mpi_pool, 'MPI session already started'
 
-        env = {
-            key: value
-            for key, value in os.environ.items()
-            if key.startswith("TRTLLM") or key.startswith("TLLM")
-        }
+        env = _get_mpi_pool_env()
         self.mpi_pool = MPIPoolExecutor(max_workers=self.n_workers,
                                         path=sys.path,
                                         env=env)

--- a/tests/unittest/_torch/executor/test_executor_request_queue.py
+++ b/tests/unittest/_torch/executor/test_executor_request_queue.py
@@ -161,6 +161,20 @@ def test_enqueue_shutdown_request(executor_queue):
     assert item.is_shutdown_request
 
 
+def test_enqueue_control_request_with_action(executor_queue):
+    executor_queue.enqueue_control_request(
+        action="sleep", args=(["kv_cache"],), kwargs={"reason": "standby"}
+    )
+
+    item = executor_queue.request_queue.get_nowait()
+    assert item.is_control_request
+    assert item.control_action == (
+        "sleep",
+        (["kv_cache"],),
+        {"reason": "standby"},
+    )
+
+
 def test_enqueue_request_after_shutdown(executor_queue):
     """Test that enqueuing fails after shutdown."""
     executor_queue.enqueue_shutdown_request()

--- a/tests/unittest/_torch/executor/test_kv_cache_estimation.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_estimation.py
@@ -12,11 +12,6 @@ from unittest.mock import Mock, patch
 import pytest
 
 from tensorrt_llm._torch.pyexecutor._util import KvCacheCreator
-from tensorrt_llm._torch.pyexecutor.model_engine import PyTorchModelEngine
-from tensorrt_llm._torch.pyexecutor.py_executor_creator import (
-    _should_defer_gms_shadow_cuda_graph_capture,
-    _should_defer_gms_shadow_startup_warmup,
-)
 from tensorrt_llm._torch.pyexecutor.resource_manager import (KVCacheManager,
                                                               ResourceManagerType)
 from tensorrt_llm.llmapi.llm_args import LoadFormat
@@ -213,6 +208,27 @@ def test_gms_shadow_calibration_counts_local_extra_smaller_than_gms_weights():
     )
 
     assert available == int((180 - 88) * gib * 0.85)
+
+
+def test_gms_shadow_calibration_reserves_parked_peer_memory(monkeypatch):
+    gib = 1 << 30
+    creator = object.__new__(KvCacheCreator)
+    creator._gms_weight_bytes = Mock(return_value=74 * gib)
+    creator._moe_workspace_bytes = Mock(return_value=0)
+    monkeypatch.setenv("TRTLLM_GMS_SHADOW_PEER_MEMORY_RESERVE_GIB", "10")
+
+    available = creator._cal_gms_shadow_max_memory(
+        torch_peak_memory=1 * gib,
+        model_bytes=1 * gib,
+        total_gpu_memory=180 * gib,
+        fraction=0.85,
+        temporary_kv_bytes=0,
+        non_torch_extra_bytes=13 * gib,
+    )
+
+    # The reserve represents already-parked peers whose pre-captured graphs and
+    # runtime state remain physically resident during the next engine startup.
+    assert available == int((180 - 98) * gib * 0.85)
 
 
 def test_gms_shadow_final_calibration_uses_process_local_non_torch_memory():
@@ -454,107 +470,3 @@ def test_gms_shadow_final_calibration_discards_warmup_derived_cap():
     assert creator._kv_cache_config.max_gpu_total_bytes == 96
     assert resources[ResourceManagerType.KV_CACHE_MANAGER] == "kv"
     assert resources[ResourceManagerType.DRAFT_KV_CACHE_MANAGER] is None
-
-
-def test_gms_shadow_deferred_cuda_graph_capture_enabled_for_ro_shadow(
-        monkeypatch):
-    llm_args = Mock(load_format=LoadFormat.GMS,
-                    gms_mode="ro",
-                    cuda_graph_config=Mock(),
-                    sleep_config=Mock())
-
-    monkeypatch.delenv("TRTLLM_GMS_DEFER_SHADOW_CUDA_GRAPH_CAPTURE",
-                       raising=False)
-
-    assert _should_defer_gms_shadow_cuda_graph_capture(
-        llm_args, estimating_kv_cache=True) is True
-
-
-def test_gms_shadow_deferred_cuda_graph_capture_requires_estimation():
-    llm_args = Mock(load_format=LoadFormat.GMS,
-                    gms_mode="ro",
-                    cuda_graph_config=Mock(),
-                    sleep_config=Mock())
-
-    assert _should_defer_gms_shadow_cuda_graph_capture(
-        llm_args, estimating_kv_cache=False) is False
-
-
-def test_gms_shadow_deferred_cuda_graph_capture_can_be_disabled(monkeypatch):
-    llm_args = Mock(load_format=LoadFormat.GMS,
-                    gms_mode="ro",
-                    cuda_graph_config=Mock(),
-                    sleep_config=Mock())
-
-    monkeypatch.setenv("TRTLLM_GMS_DEFER_SHADOW_CUDA_GRAPH_CAPTURE", "0")
-
-    assert _should_defer_gms_shadow_cuda_graph_capture(
-        llm_args, estimating_kv_cache=True) is False
-
-
-def test_gms_shadow_deferred_cuda_graph_capture_does_not_apply_to_rw():
-    llm_args = Mock(load_format=LoadFormat.GMS,
-                    gms_mode="rw",
-                    cuda_graph_config=Mock(),
-                    sleep_config=Mock(),
-                    env_overrides={
-                        "ENGINE_ID": "1",
-                        "GMS_SOCKET_DIR": "/tmp/gms",
-                    })
-
-    assert _should_defer_gms_shadow_cuda_graph_capture(
-        llm_args, estimating_kv_cache=True) is False
-
-
-def test_gms_shadow_deferred_startup_warmup_enabled_for_ro_shadow(
-        monkeypatch):
-    llm_args = Mock(load_format=LoadFormat.GMS,
-                    gms_mode="ro",
-                    cuda_graph_config=Mock(),
-                    sleep_config=Mock())
-
-    monkeypatch.delenv("TRTLLM_GMS_DEFER_SHADOW_STARTUP_WARMUP",
-                       raising=False)
-
-    assert _should_defer_gms_shadow_startup_warmup(
-        llm_args, estimating_kv_cache=True) is True
-
-
-def test_gms_shadow_deferred_startup_warmup_can_be_disabled(monkeypatch):
-    llm_args = Mock(load_format=LoadFormat.GMS,
-                    gms_mode="ro",
-                    cuda_graph_config=Mock(),
-                    sleep_config=Mock())
-
-    monkeypatch.setenv("TRTLLM_GMS_DEFER_SHADOW_STARTUP_WARMUP", "0")
-
-    assert _should_defer_gms_shadow_startup_warmup(
-        llm_args, estimating_kv_cache=True) is False
-
-
-def test_deferred_warmup_skips_invalid_kv_cleanup_once():
-    class DummyEngine:
-        kv_cache_manager_key = ResourceManagerType.KV_CACHE_MANAGER
-
-    engine = DummyEngine()
-    kv_cache_manager = Mock()
-    kv_cache_manager.check_invalid_values_in_kv_cache.return_value = False
-    resource_manager = Mock()
-    resource_manager.get_resource_manager.return_value = kv_cache_manager
-
-    @PyTorchModelEngine.warmup_with_kv_cache_cleanup
-    def deferred_warmup(self, resource_manager):
-        self._skip_warmup_kv_cache_cleanup_once = True
-
-    deferred_warmup(engine, resource_manager)
-
-    kv_cache_manager.check_invalid_values_in_kv_cache.assert_not_called()
-    assert not engine._skip_warmup_kv_cache_cleanup_once
-
-    @PyTorchModelEngine.warmup_with_kv_cache_cleanup
-    def real_warmup(self, resource_manager):
-        return "warmed"
-
-    assert real_warmup(engine, resource_manager) == "warmed"
-    kv_cache_manager.check_invalid_values_in_kv_cache.assert_called_once_with(
-        fill_with_zero=True)

--- a/tests/unittest/_torch/executor/test_kv_cache_estimation.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_estimation.py
@@ -12,6 +12,8 @@ from unittest.mock import Mock, patch
 import pytest
 
 from tensorrt_llm._torch.pyexecutor._util import KvCacheCreator
+from tensorrt_llm._torch.pyexecutor.resource_manager import (KVCacheManager,
+                                                              ResourceManagerType)
 from tensorrt_llm.llmapi.llm_args import LoadFormat
 
 # ---------------------------------------------------------------------------
@@ -163,20 +165,140 @@ def test_gms_shadow_calibration_accounts_resident_weights_and_local_overhead():
         non_torch_extra_bytes=20 * gib,
     )
 
-    # local_non_kv = model 10 + activation 2 + GMS weights 6
-    #              + MoE workspace 4 + non-GMS/native extra 10 = 32 GiB.
-    assert available == int((100 - 32) * gib * 0.85)
+    # non_torch_extra is process-local; RO GMS weight mappings are not part of
+    # that NVML number.  Only subtract MoE workspace to avoid double counting it.
+    # local_non_kv = model 10 + activation 4 + GMS weights 6
+    #              + MoE workspace 4 + other native extra 16 = 40 GiB.
+    assert available == int((100 - 40) * gib * 0.85)
+
+
+def test_gms_shadow_calibration_reserves_warmup_activation_with_vmm_kv():
+    gib = 1 << 30
+    creator = object.__new__(KvCacheCreator)
+    creator._gms_weight_bytes = Mock(return_value=74 * gib)
+    creator._moe_workspace_bytes = Mock(return_value=0)
+
+    available = creator._cal_gms_shadow_max_memory(
+        torch_peak_memory=3 * gib,
+        model_bytes=1 * gib,
+        total_gpu_memory=180 * gib,
+        fraction=0.85,
+        temporary_kv_bytes=9 * gib,
+        non_torch_extra_bytes=13 * gib,
+    )
+
+    # VMM KV allocation is not reflected in torch's peak allocator stats, so
+    # the 2 GiB torch activation peak must still be reserved for full-size KV.
+    assert available == int((180 - 90) * gib * 0.85)
+
+
+def test_gms_shadow_calibration_counts_local_extra_smaller_than_gms_weights():
+    gib = 1 << 30
+    creator = object.__new__(KvCacheCreator)
+    creator._gms_weight_bytes = Mock(return_value=74 * gib)
+    creator._moe_workspace_bytes = Mock(return_value=0)
+
+    available = creator._cal_gms_shadow_max_memory(
+        torch_peak_memory=1 * gib,
+        model_bytes=1 * gib,
+        total_gpu_memory=180 * gib,
+        fraction=0.85,
+        temporary_kv_bytes=0,
+        non_torch_extra_bytes=13 * gib,
+    )
+
+    assert available == int((180 - 88) * gib * 0.85)
+
+
+def test_gms_shadow_final_calibration_uses_process_local_non_torch_memory():
+    gib = 1 << 30
+    creator = object.__new__(KvCacheCreator)
+    creator._mapping = Mock(cp_config={})
+    creator._kv_cache_config = Mock(free_gpu_memory_fraction=0.85,
+                                    max_gpu_total_bytes=0)
+    creator._skip_est = False
+    creator._profiling_stage_data = None
+    creator._kv_cache_manager_cls = KVCacheManager
+    creator._max_kv_tokens_in = None
+    creator._max_gpu_total_bytes_in = 0
+    creator._gms_shadow_torch_activation_reserve_bytes = 0
+    creator._use_gms_shadow_kv_calibration = Mock(return_value=True)
+    creator._cal_gms_shadow_max_memory = Mock(return_value=64 * gib)
+    creator._get_kv_size_per_token = Mock(return_value=gib)
+    creator._current_process_gpu_memory = Mock(return_value=25 * gib)
+
+    with (
+            patch("torch.cuda.empty_cache"),
+            patch("torch.cuda.reset_peak_memory_stats"),
+            patch("torch.cuda.mem_get_info", return_value=(80 * gib, 100 * gib)),
+            patch("torch.cuda.memory_stats",
+                  return_value={"allocated_bytes.all.current": 8 * gib}),
+    ):
+        creator.configure_kv_cache_capacity(py_executor=None)
+
+    creator._cal_gms_shadow_max_memory.assert_called_once_with(
+        torch_peak_memory=8 * gib,
+        model_bytes=8 * gib,
+        total_gpu_memory=100 * gib,
+        fraction=0.85,
+        temporary_kv_bytes=0,
+        non_torch_extra_bytes=17 * gib,
+        min_torch_activation_bytes=0,
+    )
+    assert creator._kv_cache_config.max_gpu_total_bytes == 64 * gib
+    assert creator._kv_cache_config.max_tokens == 64
+
+
+def test_gms_shadow_final_calibration_reuses_warmup_activation_reserve():
+    gib = 1 << 30
+    creator = object.__new__(KvCacheCreator)
+    creator._mapping = Mock(cp_config={})
+    creator._kv_cache_config = Mock(free_gpu_memory_fraction=0.85,
+                                    max_gpu_total_bytes=0)
+    creator._skip_est = False
+    creator._profiling_stage_data = None
+    creator._kv_cache_manager_cls = KVCacheManager
+    creator._max_kv_tokens_in = None
+    creator._max_gpu_total_bytes_in = 0
+    creator._gms_shadow_torch_activation_reserve_bytes = 3 * gib
+    creator._use_gms_shadow_kv_calibration = Mock(return_value=True)
+    creator._cal_gms_shadow_max_memory = Mock(return_value=64 * gib)
+    creator._get_kv_size_per_token = Mock(return_value=gib)
+    creator._current_process_gpu_memory = Mock(return_value=25 * gib)
+
+    with (
+            patch("torch.cuda.empty_cache"),
+            patch("torch.cuda.reset_peak_memory_stats"),
+            patch("torch.cuda.mem_get_info", return_value=(80 * gib, 100 * gib)),
+            patch("torch.cuda.memory_stats",
+                  return_value={"allocated_bytes.all.current": 8 * gib}),
+    ):
+        creator.configure_kv_cache_capacity(py_executor=None)
+
+    creator._cal_gms_shadow_max_memory.assert_called_once_with(
+        torch_peak_memory=8 * gib,
+        model_bytes=8 * gib,
+        total_gpu_memory=100 * gib,
+        fraction=0.85,
+        temporary_kv_bytes=0,
+        non_torch_extra_bytes=17 * gib,
+        min_torch_activation_bytes=3 * gib,
+    )
+    assert creator._kv_cache_config.max_gpu_total_bytes == 64 * gib
+    assert creator._kv_cache_config.max_tokens == 64
 
 
 @pytest.mark.parametrize(
     ("gms_mode", "engine_id", "expected"),
     [("ro", "0", True), ("rw", "1", False), ("", "0", False), ("", "1", True)],
 )
+@pytest.mark.parametrize("load_format",
+                         [LoadFormat.GMS, "GMS", "gms", "LoadFormat.GMS", 3])
 def test_gms_shadow_calibration_only_applies_to_ro_or_non_primary_engine(
-    monkeypatch, gms_mode, engine_id, expected
+    monkeypatch, load_format, gms_mode, engine_id, expected
 ):
     creator = object.__new__(KvCacheCreator)
-    creator._llm_args = Mock(load_format=LoadFormat.GMS, gms_mode=gms_mode)
+    creator._llm_args = Mock(load_format=load_format, gms_mode=gms_mode)
 
     monkeypatch.setenv("ENGINE_ID", engine_id)
     monkeypatch.delenv("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", raising=False)
@@ -191,3 +313,139 @@ def test_gms_shadow_calibration_can_be_disabled(monkeypatch):
     monkeypatch.setenv("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", "0")
 
     assert creator._use_gms_shadow_kv_calibration() is False
+
+
+def test_gms_shadow_calibration_uses_mpi_worker_environment(monkeypatch):
+    creator = object.__new__(KvCacheCreator)
+    creator._llm_args = Mock(load_format="auto", gms_mode="auto")
+
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("GMS_SOCKET_DIR", "/tmp/gms")
+    monkeypatch.delenv("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", raising=False)
+
+    assert creator._use_gms_shadow_kv_calibration() is True
+
+
+def test_gms_shadow_calibration_uses_llm_env_overrides(monkeypatch):
+    creator = object.__new__(KvCacheCreator)
+    creator._llm_args = Mock(load_format="auto",
+                             gms_mode="auto",
+                             env_overrides={
+                                 "ENGINE_ID": "1",
+                                 "GMS_SOCKET_DIR": "/tmp/gms",
+                             })
+
+    monkeypatch.delenv("ENGINE_ID", raising=False)
+    monkeypatch.delenv("GMS_SOCKET_DIR", raising=False)
+    monkeypatch.delenv("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", raising=False)
+
+    assert creator._use_gms_shadow_kv_calibration() is True
+
+
+def test_gms_shadow_calibration_env_overrides_do_not_override_rw(monkeypatch):
+    creator = object.__new__(KvCacheCreator)
+    creator._llm_args = Mock(load_format=LoadFormat.GMS,
+                             gms_mode="rw",
+                             env_overrides={
+                                 "ENGINE_ID": "1",
+                                 "GMS_SOCKET_DIR": "/tmp/gms",
+                             })
+
+    monkeypatch.delenv("ENGINE_ID", raising=False)
+    monkeypatch.delenv("GMS_SOCKET_DIR", raising=False)
+    monkeypatch.delenv("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", raising=False)
+
+    assert creator._use_gms_shadow_kv_calibration() is False
+
+
+def test_gms_shadow_calibration_worker_environment_does_not_override_rw(
+        monkeypatch):
+    creator = object.__new__(KvCacheCreator)
+    creator._llm_args = Mock(load_format=LoadFormat.GMS, gms_mode="rw")
+
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("GMS_SOCKET_DIR", "/tmp/gms")
+    monkeypatch.delenv("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", raising=False)
+
+    assert creator._use_gms_shadow_kv_calibration() is False
+
+
+def test_legacy_kv_manager_trusts_calibrated_max_gpu_total_bytes(monkeypatch):
+    manager = object.__new__(KVCacheManager)
+    monkeypatch.setattr(KVCacheManager, "get_cache_bytes_per_token",
+                        lambda _: 1024)
+    kv_cache_config = Mock(
+        free_gpu_memory_fraction=0.85,
+        host_cache_size=0,
+        max_gpu_total_bytes=80 * 1024,
+        max_tokens=None,
+    )
+    mapping = Mock(world_size=1)
+
+    with patch("torch.cuda.mem_get_info",
+               return_value=(10 * 1024, 100 * 1024)) as mem_get_info:
+        blocks, secondary_blocks = manager.calculate_max_num_blocks(
+            kv_cache_config,
+            head_dim=0,
+            tokens_per_block=16,
+            mapping=mapping,
+            dtype=None,
+        )
+
+    mem_get_info.assert_not_called()
+    assert blocks == 5
+    assert secondary_blocks == 0
+
+
+def test_gms_shadow_calibration_runs_when_estimation_is_disabled():
+    creator = object.__new__(KvCacheCreator)
+    creator._skip_est = False
+    creator._max_gpu_total_bytes_in = 0
+    creator._kv_cache_config = Mock(max_gpu_total_bytes=0)
+    creator._llm_args = Mock(load_format=LoadFormat.GMS,
+                             gms_mode="ro",
+                             env_overrides={"ENGINE_ID": "1"})
+    creator._use_gms_shadow_kv_calibration = Mock(return_value=True)
+    creator.configure_kv_cache_capacity = Mock()
+    creator._should_create_separate_draft_kv_cache = Mock(return_value=False)
+    creator._create_kv_cache_manager = Mock(return_value="kv")
+    creator._model_engine = Mock()
+    creator._kv_connector_manager = None
+    creator._draft_model_engine = None
+    resources = {}
+
+    creator.build_managers(resources, estimating_kv_cache=False)
+
+    creator.configure_kv_cache_capacity.assert_called_once_with()
+    assert resources[ResourceManagerType.KV_CACHE_MANAGER] == "kv"
+    assert resources[ResourceManagerType.DRAFT_KV_CACHE_MANAGER] is None
+
+
+def test_gms_shadow_final_calibration_discards_warmup_derived_cap():
+    creator = object.__new__(KvCacheCreator)
+    creator._skip_est = False
+    creator._max_gpu_total_bytes_in = 0
+    creator._kv_cache_config = Mock(max_gpu_total_bytes=32)
+    creator._llm_args = Mock(load_format=LoadFormat.GMS,
+                             gms_mode="ro",
+                             env_overrides={"ENGINE_ID": "1"})
+    creator._use_gms_shadow_kv_calibration = Mock(return_value=True)
+
+    def configure_kv_cache_capacity():
+        assert creator._kv_cache_config.max_gpu_total_bytes == 0
+        creator._kv_cache_config.max_gpu_total_bytes = 96
+
+    creator.configure_kv_cache_capacity = Mock(side_effect=configure_kv_cache_capacity)
+    creator._should_create_separate_draft_kv_cache = Mock(return_value=False)
+    creator._create_kv_cache_manager = Mock(return_value="kv")
+    creator._model_engine = Mock()
+    creator._kv_connector_manager = None
+    creator._draft_model_engine = None
+    resources = {}
+
+    creator.build_managers(resources, estimating_kv_cache=False)
+
+    creator.configure_kv_cache_capacity.assert_called_once_with()
+    assert creator._kv_cache_config.max_gpu_total_bytes == 96
+    assert resources[ResourceManagerType.KV_CACHE_MANAGER] == "kv"
+    assert resources[ResourceManagerType.DRAFT_KV_CACHE_MANAGER] is None

--- a/tests/unittest/_torch/executor/test_kv_cache_estimation.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_estimation.py
@@ -12,6 +12,11 @@ from unittest.mock import Mock, patch
 import pytest
 
 from tensorrt_llm._torch.pyexecutor._util import KvCacheCreator
+from tensorrt_llm._torch.pyexecutor.model_engine import PyTorchModelEngine
+from tensorrt_llm._torch.pyexecutor.py_executor_creator import (
+    _should_defer_gms_shadow_cuda_graph_capture,
+    _should_defer_gms_shadow_startup_warmup,
+)
 from tensorrt_llm._torch.pyexecutor.resource_manager import (KVCacheManager,
                                                               ResourceManagerType)
 from tensorrt_llm.llmapi.llm_args import LoadFormat
@@ -449,3 +454,107 @@ def test_gms_shadow_final_calibration_discards_warmup_derived_cap():
     assert creator._kv_cache_config.max_gpu_total_bytes == 96
     assert resources[ResourceManagerType.KV_CACHE_MANAGER] == "kv"
     assert resources[ResourceManagerType.DRAFT_KV_CACHE_MANAGER] is None
+
+
+def test_gms_shadow_deferred_cuda_graph_capture_enabled_for_ro_shadow(
+        monkeypatch):
+    llm_args = Mock(load_format=LoadFormat.GMS,
+                    gms_mode="ro",
+                    cuda_graph_config=Mock(),
+                    sleep_config=Mock())
+
+    monkeypatch.delenv("TRTLLM_GMS_DEFER_SHADOW_CUDA_GRAPH_CAPTURE",
+                       raising=False)
+
+    assert _should_defer_gms_shadow_cuda_graph_capture(
+        llm_args, estimating_kv_cache=True) is True
+
+
+def test_gms_shadow_deferred_cuda_graph_capture_requires_estimation():
+    llm_args = Mock(load_format=LoadFormat.GMS,
+                    gms_mode="ro",
+                    cuda_graph_config=Mock(),
+                    sleep_config=Mock())
+
+    assert _should_defer_gms_shadow_cuda_graph_capture(
+        llm_args, estimating_kv_cache=False) is False
+
+
+def test_gms_shadow_deferred_cuda_graph_capture_can_be_disabled(monkeypatch):
+    llm_args = Mock(load_format=LoadFormat.GMS,
+                    gms_mode="ro",
+                    cuda_graph_config=Mock(),
+                    sleep_config=Mock())
+
+    monkeypatch.setenv("TRTLLM_GMS_DEFER_SHADOW_CUDA_GRAPH_CAPTURE", "0")
+
+    assert _should_defer_gms_shadow_cuda_graph_capture(
+        llm_args, estimating_kv_cache=True) is False
+
+
+def test_gms_shadow_deferred_cuda_graph_capture_does_not_apply_to_rw():
+    llm_args = Mock(load_format=LoadFormat.GMS,
+                    gms_mode="rw",
+                    cuda_graph_config=Mock(),
+                    sleep_config=Mock(),
+                    env_overrides={
+                        "ENGINE_ID": "1",
+                        "GMS_SOCKET_DIR": "/tmp/gms",
+                    })
+
+    assert _should_defer_gms_shadow_cuda_graph_capture(
+        llm_args, estimating_kv_cache=True) is False
+
+
+def test_gms_shadow_deferred_startup_warmup_enabled_for_ro_shadow(
+        monkeypatch):
+    llm_args = Mock(load_format=LoadFormat.GMS,
+                    gms_mode="ro",
+                    cuda_graph_config=Mock(),
+                    sleep_config=Mock())
+
+    monkeypatch.delenv("TRTLLM_GMS_DEFER_SHADOW_STARTUP_WARMUP",
+                       raising=False)
+
+    assert _should_defer_gms_shadow_startup_warmup(
+        llm_args, estimating_kv_cache=True) is True
+
+
+def test_gms_shadow_deferred_startup_warmup_can_be_disabled(monkeypatch):
+    llm_args = Mock(load_format=LoadFormat.GMS,
+                    gms_mode="ro",
+                    cuda_graph_config=Mock(),
+                    sleep_config=Mock())
+
+    monkeypatch.setenv("TRTLLM_GMS_DEFER_SHADOW_STARTUP_WARMUP", "0")
+
+    assert _should_defer_gms_shadow_startup_warmup(
+        llm_args, estimating_kv_cache=True) is False
+
+
+def test_deferred_warmup_skips_invalid_kv_cleanup_once():
+    class DummyEngine:
+        kv_cache_manager_key = ResourceManagerType.KV_CACHE_MANAGER
+
+    engine = DummyEngine()
+    kv_cache_manager = Mock()
+    kv_cache_manager.check_invalid_values_in_kv_cache.return_value = False
+    resource_manager = Mock()
+    resource_manager.get_resource_manager.return_value = kv_cache_manager
+
+    @PyTorchModelEngine.warmup_with_kv_cache_cleanup
+    def deferred_warmup(self, resource_manager):
+        self._skip_warmup_kv_cache_cleanup_once = True
+
+    deferred_warmup(engine, resource_manager)
+
+    kv_cache_manager.check_invalid_values_in_kv_cache.assert_not_called()
+    assert not engine._skip_warmup_kv_cache_cleanup_once
+
+    @PyTorchModelEngine.warmup_with_kv_cache_cleanup
+    def real_warmup(self, resource_manager):
+        return "warmed"
+
+    assert real_warmup(engine, resource_manager) == "warmed"
+    kv_cache_manager.check_invalid_values_in_kv_cache.assert_called_once_with(
+        fill_with_zero=True)

--- a/tests/unittest/_torch/executor/test_kv_cache_estimation.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_estimation.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from tensorrt_llm._torch.pyexecutor._util import KvCacheCreator
+from tensorrt_llm.llmapi.llm_args import LoadFormat
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -145,3 +146,48 @@ def test_regression_without_fix_would_overcount():
     wrong = tp * 3 * tpb  # 768  (all duplicates summed)
     assert result == correct
     assert result != wrong
+
+
+def test_gms_shadow_calibration_accounts_resident_weights_and_local_overhead():
+    gib = 1 << 30
+    creator = object.__new__(KvCacheCreator)
+    creator._gms_weight_bytes = Mock(return_value=6 * gib)
+    creator._moe_workspace_bytes = Mock(return_value=4 * gib)
+
+    available = creator._cal_gms_shadow_max_memory(
+        torch_peak_memory=14 * gib,
+        model_bytes=10 * gib,
+        total_gpu_memory=100 * gib,
+        fraction=0.85,
+        temporary_kv_bytes=2 * gib,
+        non_torch_extra_bytes=20 * gib,
+    )
+
+    # local_non_kv = model 10 + activation 2 + GMS weights 6
+    #              + MoE workspace 4 + non-GMS/native extra 10 = 32 GiB.
+    assert available == int((100 - 32) * gib * 0.85)
+
+
+@pytest.mark.parametrize(
+    ("gms_mode", "engine_id", "expected"),
+    [("ro", "0", True), ("rw", "1", False), ("", "0", False), ("", "1", True)],
+)
+def test_gms_shadow_calibration_only_applies_to_ro_or_non_primary_engine(
+    monkeypatch, gms_mode, engine_id, expected
+):
+    creator = object.__new__(KvCacheCreator)
+    creator._llm_args = Mock(load_format=LoadFormat.GMS, gms_mode=gms_mode)
+
+    monkeypatch.setenv("ENGINE_ID", engine_id)
+    monkeypatch.delenv("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", raising=False)
+
+    assert creator._use_gms_shadow_kv_calibration() is expected
+
+
+def test_gms_shadow_calibration_can_be_disabled(monkeypatch):
+    creator = object.__new__(KvCacheCreator)
+    creator._llm_args = Mock(load_format=LoadFormat.GMS, gms_mode="ro")
+
+    monkeypatch.setenv("TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION", "0")
+
+    assert creator._use_gms_shadow_kv_calibration() is False

--- a/tests/unittest/_torch/memory/test_gms_backend.py
+++ b/tests/unittest/_torch/memory/test_gms_backend.py
@@ -154,6 +154,48 @@ class TestTotalBytes:
         assert backend.total_bytes() == 5678
 
 
+class TestSleepWake:
+
+    def test_release_read_only_mappings_unmaps_and_drops_session(self):
+        backend = _make_backend()
+        backend._client = MagicMock(total_bytes=2 * (1 << 30),
+                                    is_unmapped=False)
+        backend._is_rw = False
+
+        assert backend.release_read_only_mappings() == 2 * (1 << 30)
+
+        backend._client.unmap_all_vas.assert_called_once()
+        backend._client.abort.assert_called_once()
+        assert backend._is_rw is None
+
+    def test_release_read_only_mappings_skips_rw_client(self):
+        backend = _make_backend()
+        backend._client = MagicMock(total_bytes=2 * (1 << 30),
+                                    is_unmapped=False)
+        backend._is_rw = True
+
+        assert backend.release_read_only_mappings() == 0
+
+        backend._client.unmap_all_vas.assert_not_called()
+        backend._client.abort.assert_not_called()
+        assert backend._is_rw is True
+
+    def test_restore_read_only_mappings_reconnects_ro_and_remaps(self):
+        backend = _make_backend()
+        backend._client = MagicMock(total_bytes=3 * (1 << 30),
+                                    is_unmapped=True)
+        backend._is_rw = None
+        fake_gms = _build_fake_gms_success()
+
+        with _install_fake_gms(fake_gms):
+            assert backend.restore_read_only_mappings() == 3 * (1 << 30)
+
+        backend._client.connect.assert_called_once_with(
+            fake_gms.common.locks.RequestedLockType.RO, timeout_ms=30000)
+        backend._client.remap_all_vas.assert_called_once()
+        assert backend._is_rw is False
+
+
 class TestPtrInGms:
 
     def test_returns_false_when_no_mappings_attr(self):

--- a/tests/unittest/_torch/memory/test_gms_backend.py
+++ b/tests/unittest/_torch/memory/test_gms_backend.py
@@ -67,6 +67,9 @@ class TestPreConnectState:
     def test_is_rw_is_none(self):
         assert _make_backend().is_rw is None
 
+    def test_total_bytes_is_zero(self):
+        assert _make_backend().total_bytes() == 0
+
     def test_has_committed_weights_returns_false(self):
         assert _make_backend().has_committed_weights() is False
 
@@ -143,6 +146,14 @@ class TestFinalizeWrite:
         assert backend._is_rw is False
 
 
+class TestTotalBytes:
+
+    def test_returns_client_total_bytes(self):
+        backend = _make_backend()
+        backend._client = MagicMock(total_bytes=5678)
+        assert backend.total_bytes() == 5678
+
+
 class TestPtrInGms:
 
     def test_returns_false_when_no_mappings_attr(self):
@@ -194,6 +205,7 @@ class TestProtocolConformance:
             "connect",
             "is_rw",
             "has_committed_weights",
+            "total_bytes",
             "mem_pool_scope",
             "materialize_module",
             "finalize_write",

--- a/tests/unittest/_torch/memory/test_gms_backend.py
+++ b/tests/unittest/_torch/memory/test_gms_backend.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.memory.gpu_memory_backend import (
+    GMSBackend,
+    GPUMemoryBackend,
+    _ptr_in_gms,
+    _storage_nbytes,
+)
+
+_GMS_MODULE_NAMES = [
+    "gpu_memory_service",
+    "gpu_memory_service.client",
+    "gpu_memory_service.client.torch",
+    "gpu_memory_service.client.torch.allocator",
+    "gpu_memory_service.client.torch.module",
+    "gpu_memory_service.common",
+    "gpu_memory_service.common.locks",
+    "gpu_memory_service.common.utils",
+    "gpu_memory_service.integrations",
+    "gpu_memory_service.integrations.common",
+    "gpu_memory_service.integrations.common.patches",
+    "gpu_memory_service.integrations.common.utils",
+]
+
+
+def _make_backend(**kwargs):
+    with patch("torch.cuda.current_device", return_value=0):
+        return GMSBackend(mapping=MagicMock(), socket_path="/tmp/gms.sock", **kwargs)
+
+
+class TestConstruction:
+
+    @pytest.mark.parametrize("mode", ["rw", "ro", "auto"])
+    def test_accepts_valid_modes(self, mode):
+        backend = _make_backend(mode=mode)
+        assert backend._mode == mode
+        assert backend._client is None
+        assert backend._is_rw is None
+
+    @pytest.mark.parametrize(
+        "bad_mode", ["RW", "Auto", "read", "write", "shadow", "", "rw "])
+    def test_rejects_invalid_modes(self, bad_mode):
+        with pytest.raises(ValueError, match="GMS mode must be"):
+            _make_backend(mode=bad_mode)
+
+    def test_default_tag(self):
+        backend = _make_backend()
+        assert backend._tag == "weights"
+        assert GMSBackend.DEFAULT_TAG == "weights"
+
+    def test_socket_path_none_resolved_lazily(self):
+        with patch("torch.cuda.current_device", return_value=0):
+            backend = GMSBackend(mapping=MagicMock(), socket_path=None)
+        assert backend._socket_path is None
+
+
+class TestPreConnectState:
+
+    def test_is_rw_is_none(self):
+        assert _make_backend().is_rw is None
+
+    def test_has_committed_weights_returns_false(self):
+        assert _make_backend().has_committed_weights() is False
+
+    def test_cleanup_safe_when_never_connected(self):
+        _make_backend().cleanup()
+
+    @pytest.mark.parametrize(
+        "invoke",
+        [
+            lambda backend: backend.mem_pool_scope().__enter__(),
+            lambda backend: backend.materialize_module(MagicMock()),
+            lambda backend: backend.finalize_write(MagicMock()),
+            lambda backend: backend.move_untracked_params(MagicMock()),
+        ],
+    )
+    def test_method_raises_when_not_connected(self, invoke):
+        with pytest.raises(RuntimeError, match="not connected"):
+            invoke(_make_backend())
+
+
+class TestConnectFailure:
+
+    def test_returns_false_when_upstream_not_installed(self):
+        backend = _make_backend()
+        with _block_gms():
+            assert backend.connect() is False
+        assert backend._client is None
+        assert backend._is_rw is None
+
+    def test_returns_false_when_upstream_raises(self):
+        backend = _make_backend()
+        fake_gms = _build_fake_gms_lock_failure(RuntimeError("socket missing"))
+        with _install_fake_gms(fake_gms):
+            assert backend.connect() is False
+        assert backend._client is None
+
+
+class TestRwOnlyMethodsGated:
+
+    def _ro_backend(self):
+        backend = _make_backend()
+        backend._client = MagicMock()
+        backend._is_rw = False
+        return backend
+
+    @pytest.mark.parametrize(
+        "invoke",
+        [
+            lambda backend: backend.mem_pool_scope().__enter__(),
+            lambda backend: backend.finalize_write(MagicMock()),
+        ],
+    )
+    def test_method_raises_when_granted_ro(self, invoke):
+        with pytest.raises(RuntimeError, match="only valid in RW mode"):
+            invoke(self._ro_backend())
+
+
+class TestFinalizeWrite:
+
+    def test_uses_two_step_gms_api(self):
+        backend = _make_backend()
+        backend._client = MagicMock(total_bytes=1234)
+        backend._is_rw = True
+        model = MagicMock()
+        fake_gms = _build_fake_gms_success()
+
+        with _install_fake_gms(fake_gms), patch("torch.cuda.synchronize"):
+            assert backend.finalize_write(model) == 1234
+
+        fake_gms.client.torch.module.register_module_tensors.assert_called_once_with(
+            backend._client, model)
+        fake_gms.integrations.common.utils.finalize_gms_write.assert_called_once_with(
+            backend._client)
+        assert backend._is_rw is False
+
+
+class TestPtrInGms:
+
+    def test_returns_false_when_no_mappings_attr(self):
+        client = MagicMock(spec=[])
+        assert _ptr_in_gms(client, 0xABCDEF) is False
+
+    def test_returns_false_when_mappings_empty(self):
+        client = MagicMock()
+        client._mappings = {}
+        assert _ptr_in_gms(client, 0xABCDEF) is False
+
+    @pytest.mark.parametrize(
+        "ptr, expected",
+        [
+            (0x1080, True),
+            (0x1000, True),
+            (0x10FF, True),
+            (0x1100, False),
+            (0x0FFF, False),
+        ],
+    )
+    def test_half_open_interval(self, ptr, expected):
+        client = _make_gms_client_with_mapping(va=0x1000, size=0x100)
+        assert _ptr_in_gms(client, ptr) is expected
+
+
+class TestStorageNbytes:
+
+    def test_cpu_tensor(self):
+        assert _storage_nbytes(torch.empty(10, dtype=torch.float32)) >= 40
+
+    def test_dtype_dependent(self):
+        assert _storage_nbytes(torch.empty(10, dtype=torch.float32)) > _storage_nbytes(
+            torch.empty(10, dtype=torch.bfloat16))
+
+    def test_shape_independent_for_views(self):
+        base = torch.empty(100, dtype=torch.float32)
+        view = base.view(10, 10)
+        assert _storage_nbytes(view) == _storage_nbytes(base)
+
+
+class TestProtocolConformance:
+
+    def test_gms_backend_implements_protocol(self):
+        assert isinstance(_make_backend(), GPUMemoryBackend)
+
+    def test_protocol_method_set(self):
+        required = {
+            "connect",
+            "is_rw",
+            "has_committed_weights",
+            "mem_pool_scope",
+            "materialize_module",
+            "finalize_write",
+            "move_untracked_params",
+            "cleanup",
+        }
+        for method in required:
+            assert hasattr(GPUMemoryBackend, method)
+
+
+def _make_gms_client_with_mapping(va: int, size: int):
+    client = MagicMock()
+    mapping = MagicMock()
+    mapping.va = va
+    mapping.size = size
+    client._mappings = {"k": mapping}
+    return client
+
+
+@contextmanager
+def _block_gms():
+    saved = {name: sys.modules.get(name) for name in _GMS_MODULE_NAMES}
+    try:
+        for name in _GMS_MODULE_NAMES:
+            sys.modules[name] = None
+        yield
+    finally:
+        for name, prior in saved.items():
+            if prior is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prior
+
+
+@contextmanager
+def _install_fake_gms(fake_pkg):
+    saved = {name: sys.modules.get(name) for name in _GMS_MODULE_NAMES}
+    try:
+        sys.modules["gpu_memory_service"] = fake_pkg
+        sys.modules["gpu_memory_service.client"] = fake_pkg.client
+        sys.modules["gpu_memory_service.client.torch"] = fake_pkg.client.torch
+        sys.modules["gpu_memory_service.client.torch.allocator"] = fake_pkg.client.torch.allocator
+        sys.modules["gpu_memory_service.client.torch.module"] = fake_pkg.client.torch.module
+        sys.modules["gpu_memory_service.common"] = fake_pkg.common
+        sys.modules["gpu_memory_service.common.locks"] = fake_pkg.common.locks
+        sys.modules["gpu_memory_service.common.utils"] = fake_pkg.common.utils
+        sys.modules["gpu_memory_service.integrations"] = fake_pkg.integrations
+        sys.modules["gpu_memory_service.integrations.common"] = fake_pkg.integrations.common
+        sys.modules["gpu_memory_service.integrations.common.patches"] = fake_pkg.integrations.common.patches
+        sys.modules["gpu_memory_service.integrations.common.utils"] = fake_pkg.integrations.common.utils
+        yield
+    finally:
+        for name, prior in saved.items():
+            if prior is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prior
+
+
+def _build_fake_gms_lock_failure(error):
+    fake_pkg = MagicMock(name="gpu_memory_service")
+    fake_pkg.client = MagicMock()
+    fake_pkg.client.torch = MagicMock()
+    fake_pkg.client.torch.allocator = MagicMock()
+    fake_pkg.client.torch.allocator.get_or_create_gms_client_memory_manager = MagicMock(
+        side_effect=error)
+    fake_pkg.client.torch.module = MagicMock()
+    fake_pkg.common = MagicMock()
+    fake_pkg.common.locks = MagicMock()
+    fake_pkg.common.locks.RequestedLockType = MagicMock(RW="rw", RO="ro", RW_OR_RO="rw_or_ro")
+    fake_pkg.common.locks.GrantedLockType = MagicMock(RW="rw", RO="ro")
+    fake_pkg.common.utils = MagicMock()
+    fake_pkg.common.utils.get_socket_path = MagicMock(return_value="/tmp/fake.sock")
+    fake_pkg.integrations = MagicMock()
+    fake_pkg.integrations.common = MagicMock()
+    fake_pkg.integrations.common.patches = MagicMock()
+    fake_pkg.integrations.common.patches.patch_empty_cache = MagicMock()
+    fake_pkg.integrations.common.utils = MagicMock()
+    return fake_pkg
+
+
+def _build_fake_gms_success():
+    fake_pkg = _build_fake_gms_lock_failure(None)
+    fake_pkg.client.torch.allocator.get_or_create_gms_client_memory_manager = MagicMock(
+        return_value=MagicMock(granted_lock_type="rw"))
+    fake_pkg.client.torch.module.register_module_tensors = MagicMock()
+    fake_pkg.integrations.common.utils.finalize_gms_write = MagicMock()
+    return fake_pkg

--- a/tests/unittest/_torch/memory/test_mnnvl_moe.py
+++ b/tests/unittest/_torch/memory/test_mnnvl_moe.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from tensorrt_llm._mnnvl_utils import MnnvlMoe
+
+
+class _FakeWorkspace:
+    allocated_map = {}
+    closed_ptrs = []
+
+    def __init__(self, mapping, ptr, segment_size):
+        self.mapping = mapping
+        self.ptr = ptr
+        self.segment_size = segment_size
+
+    @classmethod
+    def get_comm(cls, mapping):
+        return mapping.comm
+
+    @classmethod
+    def close_mnnvl_memory(cls, ptr):
+        cls.closed_ptrs.append(ptr)
+        cls.allocated_map.pop(ptr)
+
+
+@pytest.fixture(autouse=True)
+def reset_mnnvl_moe_state():
+    previous = {
+        "moe_workspace": MnnvlMoe.moe_workspace,
+        "moe_prepare_workspace": MnnvlMoe.moe_prepare_workspace,
+        "moe_workspace_tensor": MnnvlMoe.moe_workspace_tensor,
+        "moe_prepare_workspace_tensor": MnnvlMoe.moe_prepare_workspace_tensor,
+        "moe_mapping": MnnvlMoe.moe_mapping,
+    }
+    _FakeWorkspace.allocated_map = {}
+    _FakeWorkspace.closed_ptrs = []
+    MnnvlMoe.moe_workspace = None
+    MnnvlMoe.moe_prepare_workspace = None
+    MnnvlMoe.moe_workspace_tensor = None
+    MnnvlMoe.moe_prepare_workspace_tensor = None
+    MnnvlMoe.moe_mapping = None
+    yield
+    for attr, value in previous.items():
+        setattr(MnnvlMoe, attr, value)
+
+
+def test_mnnvl_moe_release_workspaces_closes_mappings_and_drops_tensors():
+    mapping = Mock()
+    mapping.comm = Mock()
+    workspace = _FakeWorkspace(mapping, ptr=11, segment_size=256)
+    prepare_workspace = _FakeWorkspace(mapping, ptr=22, segment_size=512)
+    _FakeWorkspace.allocated_map = {
+        11: (mapping, 1024, [], 0, 0, 0),
+        22: (mapping, 2048, [], 0, 0, 0),
+    }
+
+    MnnvlMoe.moe_workspace = workspace
+    MnnvlMoe.moe_prepare_workspace = prepare_workspace
+    MnnvlMoe.moe_workspace_tensor = object()
+    MnnvlMoe.moe_prepare_workspace_tensor = object()
+    MnnvlMoe.moe_mapping = mapping
+
+    with patch("torch.cuda.synchronize"):
+        released_bytes = MnnvlMoe.release_workspaces()
+
+    assert released_bytes == 3072
+    assert _FakeWorkspace.closed_ptrs == [11, 22]
+    assert not hasattr(workspace, "ptr")
+    assert not hasattr(prepare_workspace, "ptr")
+    assert MnnvlMoe.moe_workspace is None
+    assert MnnvlMoe.moe_prepare_workspace is None
+    assert MnnvlMoe.moe_workspace_tensor is None
+    assert MnnvlMoe.moe_prepare_workspace_tensor is None
+    assert MnnvlMoe.moe_mapping is mapping
+    assert mapping.comm.barrier.call_count == 2
+
+
+def test_mnnvl_moe_restore_workspaces_recreates_missing_workspaces():
+    mapping = Mock()
+    mapping.comm = Mock()
+
+    def restore_workspace(restored_mapping):
+        assert restored_mapping is mapping
+        MnnvlMoe.moe_workspace = _FakeWorkspace(mapping, ptr=33, segment_size=128)
+        MnnvlMoe.moe_workspace_tensor = object()
+        _FakeWorkspace.allocated_map[33] = (mapping, 1024, [], 0, 0, 0)
+
+    def restore_prepare_workspace(restored_mapping):
+        assert restored_mapping is mapping
+        MnnvlMoe.moe_prepare_workspace = _FakeWorkspace(
+            mapping, ptr=44, segment_size=256
+        )
+        MnnvlMoe.moe_prepare_workspace_tensor = object()
+        _FakeWorkspace.allocated_map[44] = (mapping, 2048, [], 0, 0, 0)
+
+    with (
+        patch.object(MnnvlMoe, "get_moe_workspaces", side_effect=restore_workspace),
+        patch.object(
+            MnnvlMoe,
+            "get_moe_prepare_workspace",
+            side_effect=restore_prepare_workspace,
+        ),
+        patch("torch.cuda.synchronize") as synchronize,
+    ):
+        restored_bytes = MnnvlMoe.restore_workspaces(mapping)
+
+    assert restored_bytes == 3072
+    assert MnnvlMoe.moe_workspace.ptr == 33
+    assert MnnvlMoe.moe_prepare_workspace.ptr == 44
+    synchronize.assert_called_once()
+
+
+def test_mnnvl_moe_workspace_bytes_falls_back_to_segment_size():
+    mapping = Mock()
+    mapping.comm = Mock()
+    MnnvlMoe.moe_workspace = _FakeWorkspace(mapping, ptr=55, segment_size=128)
+    MnnvlMoe.moe_prepare_workspace = _FakeWorkspace(
+        mapping, ptr=66, segment_size=256
+    )
+
+    assert MnnvlMoe.workspace_bytes() == 384

--- a/tests/unittest/_torch/misc/test_py_executor_creator_retry.py
+++ b/tests/unittest/_torch/misc/test_py_executor_creator_retry.py
@@ -1,0 +1,59 @@
+import pytest
+
+from tensorrt_llm._torch import virtual_memory
+from tensorrt_llm._torch.pyexecutor import py_executor_creator
+
+
+class _DummyKvCacheCreator:
+
+    def __init__(self, *, fail_once: bool):
+        self.fail_once = fail_once
+        self.calls: list[tuple[dict, bool]] = []
+
+    def build_managers(self, resources, estimating_kv_cache: bool):
+        self.calls.append((resources, estimating_kv_cache))
+        if self.fail_once and len(self.calls) == 1:
+            raise RuntimeError("out of memory")
+
+
+def test_build_kv_cache_managers_retries_final_sleep_path(monkeypatch):
+    creator = _DummyKvCacheCreator(fail_once=True)
+    resources = {"kv": "cache"}
+    sleeps: list[float] = []
+
+    monkeypatch.setattr(virtual_memory.torch.cuda, "synchronize",
+                        lambda: None)
+    monkeypatch.setattr(virtual_memory.torch.cuda, "empty_cache",
+                        lambda: None)
+    monkeypatch.setattr(virtual_memory.gc, "collect", lambda: 0)
+    monkeypatch.setattr(virtual_memory.time, "sleep", sleeps.append)
+
+    py_executor_creator._build_kv_cache_managers(
+        creator,
+        resources,
+        estimating_kv_cache=False,
+        enable_sleep=True,
+    )
+
+    assert creator.calls == [(resources, False), (resources, False)]
+    assert sleeps == [1.0]
+
+
+def test_build_kv_cache_managers_skips_retry_for_estimation(monkeypatch):
+    creator = _DummyKvCacheCreator(fail_once=True)
+    resources = {"kv": "cache"}
+    monkeypatch.setattr(
+        py_executor_creator,
+        "run_with_oom_retry",
+        lambda *args, **kwargs: pytest.fail("estimation path should not retry"),
+    )
+
+    with pytest.raises(RuntimeError, match="out of memory"):
+        py_executor_creator._build_kv_cache_managers(
+            creator,
+            resources,
+            estimating_kv_cache=True,
+            enable_sleep=True,
+        )
+
+    assert creator.calls == [(resources, True)]

--- a/tests/unittest/_torch/misc/test_virtual_memory_retry.py
+++ b/tests/unittest/_torch/misc/test_virtual_memory_retry.py
@@ -1,0 +1,57 @@
+import pytest
+
+from tensorrt_llm._torch import virtual_memory
+
+
+class _RetryingManager:
+
+    def __init__(self):
+        self.calls = 0
+
+    def materialize_with_tag(self, tag: str) -> int:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError(f"{tag} out of memory")
+        return 1
+
+
+def test_materialize_with_tag_retries_oom(monkeypatch):
+    manager = _RetryingManager()
+    sleeps: list[float] = []
+    sync_calls: list[None] = []
+    empty_cache_calls: list[None] = []
+    gc_calls: list[int] = []
+
+    monkeypatch.setattr(virtual_memory, "get_virtual_memory_manager",
+                        lambda: manager)
+    monkeypatch.setattr(virtual_memory.torch.cuda, "synchronize",
+                        lambda: sync_calls.append(None))
+    monkeypatch.setattr(virtual_memory.torch.cuda, "empty_cache",
+                        lambda: empty_cache_calls.append(None))
+    monkeypatch.setattr(virtual_memory.gc, "collect",
+                        lambda: gc_calls.append(1) or 0)
+    monkeypatch.setattr(virtual_memory.time, "sleep", sleeps.append)
+
+    assert virtual_memory.materialize_with_tag("kv_cache") == 1
+    assert manager.calls == 2
+    assert sleeps == [1.0]
+    assert len(sync_calls) == 1
+    assert len(empty_cache_calls) == 1
+    assert gc_calls == [1]
+
+
+def test_materialize_with_tag_does_not_retry_non_oom(monkeypatch):
+    class _FailingManager:
+
+        def materialize_with_tag(self, tag: str) -> int:
+            raise RuntimeError(f"{tag} permission denied")
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(virtual_memory, "get_virtual_memory_manager",
+                        lambda: _FailingManager())
+    monkeypatch.setattr(virtual_memory.time, "sleep", sleeps.append)
+
+    with pytest.raises(RuntimeError, match="permission denied"):
+        virtual_memory.materialize_with_tag("kv_cache")
+
+    assert not sleeps

--- a/tests/unittest/_torch/modules/test_load_weight_shard.py
+++ b/tests/unittest/_torch/modules/test_load_weight_shard.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for presharded-aware `load_weight_shard`.
+
+Covers the GMS RO failure mode: a module whose weights were zero-copy
+materialized (already this rank's slice) must not be re-sharded on later
+`load_weights` / `ModelLoader.reload` invocations.
+"""
+
+import torch
+
+from tensorrt_llm._torch.modules.linear import (
+    TensorParallelMode,
+    load_weight_shard,
+)
+
+
+class _FakeModule:
+    """Minimal stand-in for a TP-aware module without the full Linear import cost."""
+
+    def __init__(self, presharded: bool = False):
+        self._weights_presharded = presharded
+
+
+def _make_weight(shape):
+    return torch.arange(int(torch.tensor(shape).prod()),
+                        dtype=torch.float32).reshape(shape)
+
+
+class TestPreshardedGate:
+
+    def test_presharded_false_slices(self):
+        """Default path slices full checkpoint weight by rank."""
+        weight = _make_weight((8, 4))
+        shard = load_weight_shard(
+            weight,
+            tensor_parallel_size=2,
+            tensor_parallel_rank=1,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+        )
+        assert shard.shape == (4, 4)
+        torch.testing.assert_close(shard, weight[4:, :])
+
+    def test_presharded_true_passes_through(self):
+        """Presharded module skips re-sharding regardless of tp args."""
+        weight = _make_weight((4, 4))
+        module = _FakeModule(presharded=True)
+        shard = load_weight_shard(
+            weight,
+            tensor_parallel_size=2,
+            tensor_parallel_rank=1,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            module=module,
+        )
+        assert shard.shape == weight.shape
+        torch.testing.assert_close(shard, weight)
+
+    def test_module_without_flag_slices(self):
+        """`_weights_presharded` defaulting to False is respected via getattr."""
+
+        class _BareModule:
+            pass
+
+        weight = _make_weight((8, 4))
+        module = _BareModule()
+        shard = load_weight_shard(
+            weight,
+            tensor_parallel_size=2,
+            tensor_parallel_rank=0,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            module=module,
+        )
+        assert shard.shape == (4, 4)
+        torch.testing.assert_close(shard, weight[:4, :])
+
+    def test_presharded_true_row_mode(self):
+        weight = _make_weight((4, 4))
+        module = _FakeModule(presharded=True)
+        shard = load_weight_shard(
+            weight,
+            tensor_parallel_size=4,
+            tensor_parallel_rank=2,
+            tensor_parallel_mode=TensorParallelMode.ROW,
+            module=module,
+        )
+        torch.testing.assert_close(shard, weight)
+
+    def test_module_none_preserves_legacy_behavior(self):
+        """Callers that do not pass module=... continue to re-shard."""
+        weight = _make_weight((8, 4))
+        shard = load_weight_shard(
+            weight,
+            tensor_parallel_size=4,
+            tensor_parallel_rank=0,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+        )
+        assert shard.shape == (2, 4)
+        torch.testing.assert_close(shard, weight[:2, :])

--- a/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_sleep.py
+++ b/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_sleep.py
@@ -133,3 +133,41 @@ def test_llm_sleep_discard_weights(process_gpu_memory_info_available):
         # Can generate something without crashing
         outputs = llm.generate(prompts, sampling_params)
         assert all(output.outputs[0] is not None for output in outputs)
+
+
+def test_llm_sleep_kv_cache_wakeup_resets_prefix_cache():
+    llama_model_path = str(llm_models_root() / "llama-models-v2/TinyLlama-1.1B-Chat-v1.0")
+    kv_cache_config = KvCacheConfig(enable_block_reuse=True, max_tokens=16384)
+
+    llm = LLM(
+        model=llama_model_path,
+        sleep_config=SleepConfig(),
+        kv_cache_config=kv_cache_config,
+    )
+
+    prompt = "The capital of France is"
+    sampling_params = SamplingParams(temperature=0)
+
+    with llm:
+        before = llm.generate([prompt], sampling_params)[0].outputs[0].text
+
+        llm._collective_rpc(
+            "sleep",
+            (
+                [
+                    ExecutorMemoryType.KV_CACHE,
+                ],
+            ),
+        )
+        llm._collective_rpc(
+            "wakeup",
+            (
+                [
+                    ExecutorMemoryType.KV_CACHE,
+                ],
+            ),
+        )
+
+        after = llm.generate([prompt], sampling_params)[0].outputs[0].text
+
+    assert before == after

--- a/tests/unittest/_torch/test_model_config.py
+++ b/tests/unittest/_torch/test_model_config.py
@@ -1,9 +1,10 @@
+import errno
 import types
 
 import pytest
 import torch
 
-from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.model_config import ModelConfig, config_file_lock
 from tensorrt_llm._torch.pyexecutor.model_loader import validate_and_set_kv_cache_quant
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
@@ -116,3 +117,76 @@ def test_validate_and_set_kv_cache_quant_rejects_invalid_dtype():
     model_config = _make_model_config_with_kv_quant(QuantAlgo.FP8)
     with pytest.raises(ValueError, match="Accepted types are"):
         validate_and_set_kv_cache_quant(model_config, "invalid_dtype")
+
+
+def test_config_file_lock_falls_back_on_stale_file_handle(monkeypatch):
+    calls = []
+
+    class FakeLock:
+        def __init__(self, path, timeout):
+            self.path = path
+            calls.append(path)
+
+        def __enter__(self):
+            if len(calls) == 1:
+                raise OSError(errno.ESTALE, "Stale file handle")
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.model_config.filelock.FileLock",
+        FakeLock,
+    )
+
+    with config_file_lock():
+        pass
+
+    assert len(calls) == 2
+
+
+def test_config_file_lock_proceeds_without_lock_when_tempdir_lock_fails(monkeypatch):
+    calls = []
+
+    class FakeLock:
+        def __init__(self, path, timeout):
+            self.path = path
+            calls.append(path)
+
+        def __enter__(self):
+            raise OSError(errno.ENOLCK, "No locks available")
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.model_config.filelock.FileLock",
+        FakeLock,
+    )
+
+    with config_file_lock():
+        pass
+
+    assert len(calls) == 2
+
+
+def test_config_file_lock_reraises_unexpected_oserror(monkeypatch):
+    class FakeLock:
+        def __init__(self, path, timeout):
+            self.path = path
+
+        def __enter__(self):
+            raise OSError(errno.EIO, "I/O error")
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.model_config.filelock.FileLock",
+        FakeLock,
+    )
+
+    with pytest.raises(OSError, match="I/O error"):
+        with config_file_lock():
+            pass

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -99,6 +99,18 @@ methods:
         annotation: Optional[str]
         default: null
         status: prototype
+      gms_socket_path:
+        annotation: Optional[str]
+        default: null
+        status: prototype
+      gms_mode:
+        annotation: Optional[str]
+        default: auto
+        status: prototype
+      gms_tag:
+        annotation: str
+        default: weights
+        status: prototype
       mm_encoder_only:
         annotation: bool
         default: False

--- a/tests/unittest/executor/test_ray_gpu_worker_sleep.py
+++ b/tests/unittest/executor/test_ray_gpu_worker_sleep.py
@@ -1,0 +1,61 @@
+from contextlib import contextmanager
+
+import tensorrt_llm.executor.ray_gpu_worker as ray_gpu_worker
+from tensorrt_llm.llmapi.llm_args import ExecutorMemoryType
+
+
+class _DummyTorchLlmArgs:
+
+    def __init__(self):
+        self.sleep_config = object()
+
+
+class _DummyEngine:
+
+    def __init__(self):
+        self.reset_calls = 0
+
+    @contextmanager
+    def control_action(self):
+        yield
+
+    def reset_prefix_cache(self):
+        self.reset_calls += 1
+
+
+def _make_worker(monkeypatch):
+    monkeypatch.setattr(ray_gpu_worker, "TorchLlmArgs", _DummyTorchLlmArgs)
+    worker = object.__new__(ray_gpu_worker.RayGPUWorker)
+    worker.engine = _DummyEngine()
+    worker.llm_args = _DummyTorchLlmArgs()
+    return worker
+
+
+def test_wakeup_resets_prefix_cache_for_kv_cache(monkeypatch):
+    worker = _make_worker(monkeypatch)
+    materialized: list[tuple[ExecutorMemoryType, ...]] = []
+
+    monkeypatch.setattr(ray_gpu_worker.torch.cuda, "synchronize",
+                        lambda: None)
+    monkeypatch.setattr(ray_gpu_worker, "materialize_with_tag",
+                        lambda *tags: materialized.append(tags) or 1)
+
+    ray_gpu_worker.RayGPUWorker.wakeup(worker,
+                                       [ExecutorMemoryType.KV_CACHE.value])
+
+    assert materialized == [(ExecutorMemoryType.KV_CACHE,)]
+    assert worker.engine.reset_calls == 1
+
+
+def test_wakeup_skips_prefix_cache_reset_without_kv_cache(monkeypatch):
+    worker = _make_worker(monkeypatch)
+
+    monkeypatch.setattr(ray_gpu_worker.torch.cuda, "synchronize",
+                        lambda: None)
+    monkeypatch.setattr(ray_gpu_worker, "materialize_with_tag",
+                        lambda *tags: 1)
+
+    ray_gpu_worker.RayGPUWorker.wakeup(
+        worker, [ExecutorMemoryType.MODEL_WEIGHTS_MAIN.value])
+
+    assert worker.engine.reset_calls == 0

--- a/tests/unittest/llmapi/test_gms_args.py
+++ b/tests/unittest/llmapi/test_gms_args.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pytest
+
+from tensorrt_llm.llmapi.llm_args import LoadFormat, TorchLlmArgs
+
+_LOGGER_PATH = "tensorrt_llm.llmapi.llm_args.logger"
+_DUMMY_MODEL = "/tmp/test-gms-args-nonexistent"
+
+
+def _make_args(**overrides) -> TorchLlmArgs:
+    return TorchLlmArgs(model=_DUMMY_MODEL, **overrides)
+
+
+def _capture_warnings(call_args_list):
+    rendered = []
+    for call in call_args_list:
+        args, _kwargs = call
+        if not args:
+            continue
+        fmt, *fmt_args = args
+        try:
+            rendered.append(fmt % tuple(fmt_args) if fmt_args else fmt)
+        except (TypeError, ValueError):
+            rendered.append(str(args))
+    return rendered
+
+
+def _warnings_for(keyword: str, call_args_list) -> list[str]:
+    return [m for m in _capture_warnings(call_args_list) if keyword in m]
+
+
+class TestDefaults:
+
+    def test_gms_socket_path_default_none(self):
+        assert _make_args().gms_socket_path is None
+
+    def test_gms_mode_default_auto(self):
+        assert _make_args().gms_mode == "auto"
+
+    def test_gms_tag_default_weights(self):
+        assert _make_args().gms_tag == "weights"
+
+
+class TestGmsMode:
+
+    @pytest.mark.parametrize("mode", ["auto", "rw", "ro"])
+    def test_accepts_known_modes_with_gms(self, mode):
+        assert _make_args(load_format=LoadFormat.GMS, gms_mode=mode).gms_mode == mode
+
+    @pytest.mark.parametrize("bad_mode", ["", "AUTO", "Rw", "read", "write", "shadow"])
+    def test_rejects_unknown_mode_with_gms(self, bad_mode):
+        with pytest.raises(ValueError, match="gms_mode"):
+            _make_args(load_format=LoadFormat.GMS, gms_mode=bad_mode)
+
+    def test_unknown_mode_without_gms_is_lenient(self):
+        assert _make_args(load_format=LoadFormat.AUTO,
+                          gms_mode="not-a-mode").gms_mode == "not-a-mode"
+
+
+class TestGmsSocketPath:
+
+    @pytest.mark.parametrize(
+        "load_format, expect_warning",
+        [
+            (LoadFormat.GMS, False),
+            (LoadFormat.AUTO, True),
+        ],
+    )
+    def test_cross_field_warning(self, load_format, expect_warning):
+        with patch(_LOGGER_PATH) as mock_logger:
+            args = _make_args(load_format=load_format,
+                              gms_socket_path="/tmp/gms.sock")
+
+        assert args.gms_socket_path == "/tmp/gms.sock"
+        relevant = _warnings_for("gms_socket_path",
+                                 mock_logger.warning.call_args_list)
+        if expect_warning:
+            assert relevant
+        else:
+            assert relevant == []
+
+
+class TestLoadFormatEnum:
+
+    def test_gms_enum_present(self):
+        assert hasattr(LoadFormat, "GMS")
+        assert LoadFormat.GMS.name == "GMS"
+
+    def test_pre_existing_values_unchanged(self):
+        assert LoadFormat.AUTO.value == 0
+        assert LoadFormat.DUMMY.value == 1
+        assert LoadFormat.VISION_ONLY.value == 2
+
+
+class TestComposition:
+
+    def test_gms_only(self):
+        args = _make_args(load_format=LoadFormat.GMS,
+                          gms_socket_path="/tmp/gms.sock")
+        assert args.checkpoint_format == "HF"
+        assert args.load_format == LoadFormat.GMS
+        assert args.gms_socket_path == "/tmp/gms.sock"

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -1,3 +1,4 @@
+import pickle
 import tempfile
 from collections import defaultdict
 from dataclasses import is_dataclass
@@ -381,6 +382,26 @@ def test_SleepConfig_restore_modes_normalized_from_defaultdict():
         ExecutorMemoryType.MODEL_WEIGHTS_MAIN] == RestoreMode.PINNED
     assert sleep_config.restore_modes[
         ExecutorMemoryType.SAMPLER] == RestoreMode.CPU
+
+
+def test_SleepConfig_default_restore_modes_pickle_roundtrip():
+    sleep_config = SleepConfig()
+
+    restored = pickle.loads(pickle.dumps(sleep_config))
+
+    assert isinstance(restored.restore_modes, dict)
+    assert not isinstance(restored.restore_modes, defaultdict)
+    assert restored.restore_modes == sleep_config.restore_modes
+
+
+def test_TorchLlmArgs_with_sleep_config_pickle_roundtrip():
+    llm_args = TorchLlmArgs(model="/tmp/dummy_model",
+                            sleep_config=SleepConfig())
+
+    restored = pickle.loads(pickle.dumps(llm_args))
+
+    assert isinstance(restored.sleep_config, SleepConfig)
+    assert restored.sleep_config.restore_modes == llm_args.sleep_config.restore_modes
 
 
 def test_DynamicBatchConfig_declaration():

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -35,11 +35,12 @@ from tensorrt_llm.llmapi.llm_args import (BaseLlmArgs, CacheTransceiverConfig,
                                           ExecutorMemoryType,
                                           ExtendedRuntimePerfKnobConfig,
                                           KvCacheConfig,
-                                          LookaheadDecodingConfig, MoeConfig,
-                                          PeftCacheConfig, PybindMirror,
-                                          RayPlacementConfig, SleepConfig,
-                                          SpeculativeConfig, StrictBaseModel,
-                                          TorchCompileConfig, TorchLlmArgs,
+                                          LoadFormat, LookaheadDecodingConfig,
+                                          MoeConfig, PeftCacheConfig,
+                                          PybindMirror, RayPlacementConfig,
+                                          SleepConfig, SpeculativeConfig,
+                                          StrictBaseModel, TorchCompileConfig,
+                                          TorchLlmArgs,
                                           TrtLlmArgs,
                                           UserProvidedDecodingConfig,
                                           update_llm_args_with_extra_dict)
@@ -423,6 +424,17 @@ def test_TorchLlmArgs_with_sleep_config_pickle_roundtrip():
 
     assert isinstance(restored.sleep_config, SleepConfig)
     assert restored.sleep_config.restore_modes == llm_args.sleep_config.restore_modes
+
+
+@pytest.mark.parametrize("load_format",
+                         [LoadFormat.GMS, "GMS", "gms", "LoadFormat.GMS", 3])
+def test_TorchLlmArgs_gms_load_format_roundtrip(load_format):
+    llm_args = TorchLlmArgs(model="/tmp/dummy_model", load_format=load_format)
+
+    assert llm_args.load_format == LoadFormat.GMS
+    assert pickle.loads(pickle.dumps(llm_args)).load_format == LoadFormat.GMS
+    assert TorchLlmArgs.model_validate(
+        llm_args.model_dump()).load_format == LoadFormat.GMS
 
 
 def test_DynamicBatchConfig_declaration():

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -394,6 +394,27 @@ def test_SleepConfig_default_restore_modes_pickle_roundtrip():
     assert restored.restore_modes == sleep_config.restore_modes
 
 
+def test_SleepConfig_shadow_failover_preset_expands_to_runtime_tags():
+    tags = SleepConfig.expand_sleep_tags([SleepConfig.SHADOW_FAILOVER_PRESET])
+
+    assert tags == list(SleepConfig.shadow_failover_tags())
+    assert ExecutorMemoryType.KV_CACHE.value in tags
+    assert ExecutorMemoryType.MODEL_ENGINE_MAIN.value in tags
+    assert ExecutorMemoryType.EXTRA_RESOURCES.value in tags
+    assert "moe_comm" in tags
+    assert ExecutorMemoryType.MODEL_WEIGHTS_MAIN.value not in tags
+    assert ExecutorMemoryType.MODEL_WEIGHTS_DRAFT.value not in tags
+
+
+def test_SleepConfig_expand_sleep_tags_preserves_custom_overrides():
+    tags = SleepConfig.expand_sleep_tags(
+        [ExecutorMemoryType.KV_CACHE.value, SleepConfig.SHADOW_FAILOVER_PRESET])
+
+    assert tags[0] == ExecutorMemoryType.KV_CACHE.value
+    assert tags.count(ExecutorMemoryType.KV_CACHE.value) == 1
+    assert "moe_comm" in tags
+
+
 def test_TorchLlmArgs_with_sleep_config_pickle_roundtrip():
     llm_args = TorchLlmArgs(model="/tmp/dummy_model",
                             sleep_config=SleepConfig())

--- a/tests/unittest/llmapi/test_mpi_session.py
+++ b/tests/unittest/llmapi/test_mpi_session.py
@@ -12,6 +12,7 @@ import pytest
 from tensorrt_llm.bindings.BuildInfo import ENABLE_MULTI_DEVICE
 from tensorrt_llm.llmapi.mpi_session import (MPINodeState, MpiPoolSession,
                                              RemoteMpiCommSessionClient,
+                                             _get_mpi_pool_env,
                                              split_mpi_env)
 
 # isort: off
@@ -115,6 +116,24 @@ def task1():
 def test_split_mpi_env():
     session = MpiPoolSession(n_workers=4)
     session.submit_sync(task1)
+
+
+def test_mpi_pool_forwards_gms_failover_env(monkeypatch):
+    monkeypatch.setenv("TRTLLM_FOO", "trtllm")
+    monkeypatch.setenv("TLLM_BAR", "tllm")
+    monkeypatch.setenv("GMS_SOCKET_DIR", "/tmp/gms")
+    monkeypatch.setenv("ENGINE_ID", "1")
+    monkeypatch.setenv("FAILOVER_LOCK_PATH", "/tmp/gms/failover.lock")
+    monkeypatch.setenv("UNRELATED_ENV", "ignore-me")
+
+    env = _get_mpi_pool_env()
+
+    assert env["TRTLLM_FOO"] == "trtllm"
+    assert env["TLLM_BAR"] == "tllm"
+    assert env["GMS_SOCKET_DIR"] == "/tmp/gms"
+    assert env["ENGINE_ID"] == "1"
+    assert env["FAILOVER_LOCK_PATH"] == "/tmp/gms/failover.lock"
+    assert "UNRELATED_ENV" not in env
 
 
 @skip_single_gpu


### PR DESCRIPTION
## DO NOT MERGE - proof build only

This draft PR exists to trigger NVIDIA/TensorRT-LLM external-contributor CI and to host the TRT-LLM-side patches needed by the Dynamo TRT-LLM shadow-engine failover proof.

**Head**: `galletas1712/TensorRT-LLM:schwinns/gms-refactor-20260423` @ `9ba5ee40`
**Base**: `NVIDIA/TensorRT-LLM:main`

Dynamo-side orchestration and runtime pytest live in ai-dynamo/dynamo#8621.

## Patch Rationale

- **GMS backend prototype for TRT-LLM weights.** Primary workers need to publish model weights through GPU Memory Service, and standby workers need to restore them in RO mode without loading a second checkpoint copy. This is the core memory-sharing primitive for hot shadow failover.
- **GMS weight mapping park/restore for parked engines.** Parked RO shadows must drop local GMS weight VA mappings when configured with `TRTLLM_GMS_RELEASE_WEIGHTS_ON_SLEEP=all`. The backing store remains resident once in GMS, but the parked process releases its local mappings so duplicate shadow footprint is lower.
- **GMS load-format normalization.** `LoadFormat.GMS`, string forms like `gms`, and serialized enum forms must round-trip through `TorchLlmArgs` and MPI startup. Without this, TP workers can silently miss the GMS path.
- **MPI environment propagation.** `GMS_*`, `ENGINE_ID`, and `FAILOVER_LOCK_PATH` must reach MPI workers, not only the parent process. Otherwise GMS mode and failover-lock behavior diverge across TP ranks.
- **Expose GMS weight byte accounting.** Kimi K2.5 + EAGLE3 showed that TRT-LLM's KV sizing cannot treat GMS-resident weights as ordinary free memory. The calibration code needs to know how much weight memory is backed by GMS so primary and RO standby measurements are comparable.
- **Calibrate KV cache sizing for GMS RO shadows.** A standby sees weights already resident in GPU memory. The KV estimator corrects for GMS weights, process-local non-torch overhead, MoE workspace accounting, and temporary KV so the promoted engine can target nearly the same KV size as the original primary.
- **Add a GMS shadow peer-memory reserve.** Large CUDA graph ladders need startup/capture headroom while an already-prepared peer is still parked. `TRTLLM_GMS_SHADOW_PEER_MEMORY_RESERVE_GIB` / `_BYTES` subtracts explicit headroom before applying `free_gpu_memory_fraction`; this keeps pre-capture from OOMing without lowering the serving memory fraction below `0.85`.
- **Relax the VMM OOM retry polling interval.** The GMS failover path intentionally blocks and retries VMM materialization while peer KV memory is being released. The pod-validated setting uses a `0.2s` retry interval to avoid tight polling across TP ranks while preserving the staggered block-on-OOM behavior.
- **Respect explicit `max_gpu_total_bytes`.** Once calibration produces a byte budget, the resource manager must honor it directly; otherwise the later KV manager can remeasure a different free-memory state and resize inconsistently.
- **Remove deferred GMS shadow warmup/CUDA graph capture.** The earlier park-full-KV/deferred-warmup experiment worked mechanically but is not acceptable for shadow failover: warmup and CUDA graph capture must not run in promotion/wakeup. This PR now requires those steps to complete before the shadow parks.
- **Prevent lazy runtime CUDA graph capture in GMS serving mode.** If a promoted GMS engine sees a missing graph key, it falls back to eager execution instead of capturing the graph on the post-failover request. This prevents an uncaptured shape from silently moving graph capture into the failover hot path.
- **Preserve CUDA graphs on GMS shadow sleep.** Non-GMS sleep can keep its previous graph-release behavior, but `gms_weights` shadow-failover sleep preserves captured inference graphs. Releasing them made Qwen's first promoted-shadow response recapture graphs and jump from about `1s` to about `13s` after `SIGKILL`.
- **Add opt-in CUDA graph memory snapshots.** `TRTLLM_CUDA_GRAPH_MEMORY_SNAPSHOTS=1` logs per-key graph-capture memory/timing snapshots around eager warmup, graph capture, postprocess, and graph storage. This was needed to prove bs128's incremental graph reserve and distinguish graph memory from GMS weights/KV VMM.
- **Flush allocator state after profiling and sleep.** Some standby footprint is cached allocator state rather than live model state. Explicit cleanup after KV estimation and during sleep keeps cached blocks from blocking later VMM materialization.
- **Release held VMM MemPool proxy references.** Sleeping a shadow must actually drop cached virtual-memory pool references; otherwise the standby still holds memory even after tagged blobs are released.
- **Clear TRT-LLM reusable memory buffers on sleep.** `memory_buffer_utils.Buffers.bytes_by_name()` and `clear()` let sleep account for and release reusable buffers that are safe to rebuild after promotion.
- **Return distributed sleep/wakeup results from all MPI workers.** The executor request queue now gathers per-rank control action results, not only errors. Dynamo uses those results to log the memory ledger for each TP worker and to prove cleanup ran on MPI children.
- **Add opt-in GMS shadow failover diagnostics.** `TRTLLM_GMS_LOG_PER_TAG_SLEEP_RELEASE=1` breaks sleep cleanup down by VMM tag, `TRTLLM_GMS_LOG_SLEEP_PHASES=1` can snapshot memory immediately after GMS weight parking, and wakeup reports per-rank phase timings.
- **Add the `shadow_failover` SleepConfig preset.** Dynamo should not hardcode TRT-LLM's internal sleep tags. TRT-LLM owns the preset expansion for KV, model, draft model, executor extras, MoE comms, speculative resources, drafter, sampler, guided decoder state, and GMS weights.
- **Make `SleepConfig` pickleable.** Dynamo passes `LLMArgs` through MPI startup at TP=8. The previous `defaultdict(lambda: ...)` restore-mode default was not pickleable, so worker startup failed before GMS restore. Default restore modes are now a plain `dict`.
- **Add MoE/MNNVL release and restore hooks.** Large MoE runs can allocate private communication/workspace state outside shared GMS weights. These hooks allow sleep to release those resources and wake to restore them when the selected backend exposes releasable state.
- **Add `TLLM_AUTOTUNER_USE_CUDA_GRAPH` for autotuner profiling.** Kimi K2.5 + EAGLE3 showed that autotuner profiling can allocate about `37-38 GiB/rank` in CUDA graph private pools even when inference CUDA graphs are disabled. This env gate disables only the autotuner's internal `torch.cuda.CUDAGraph()` profiling wrapper; inference CUDA graphs remain controlled by `cuda_graph_config`.
- **Add focused unit coverage.** Tests pin SleepConfig pickle/preset behavior, GMS load-format serialization, MPI env propagation, GMS backend byte accounting, RO GMS mapping release/restore, GMS KV calibration including peer reserve, and MoE/MNNVL workspace release/restore behavior.

## Current Behavior

The accepted path now preserves the failover invariant: warmup and CUDA graph capture happen before the standby parks, and promotion/wakeup does not run deferred warmup or graph capture.

The latest Kimi K2.5 + EAGLE3 TP=8 bs128 run used one standby, `free_gpu_memory_fraction=0.85`, a pre-populated autotuner cache, `TLLM_AUTOTUNER_USE_CUDA_GRAPH=0`, explicit CUDA graph batch sizes `[1,2,4,8,16,32,64,128]`, `enable_padding=true`, and `TRTLLM_GMS_SHADOW_PEER_MEMORY_RESERVE_GIB=10`. It passed with the standby already pre-captured and parked before the primary served traffic.

```text
standby failover ready:        5.86s
post-restore response latency: 0.57s
SIGKILL -> response:           6.43s
primary KV blocks:             58510
promoted standby KV blocks:    60232
primary KV bytes:              61.27 GiB main + 3.01 GiB draft
standby KV bytes:              63.07 GiB main + 3.10 GiB draft
```

The promoted-standby wakeup hot path was dominated by GMS weight restore/import/access setup: `restore_gms_weights=4.91-5.03s`, while `materialize_vmm=0.01-0.04s`. No deferred warmup/CUDA graph bucket was present.

The no-reserve control run failed before failover: the standby sized to roughly `75 GiB/rank` KV, captured bs128, then OOMed starting bs64 with rank-0 driver free down to `0.01 GiB`. The 10 GiB peer reserve is therefore startup/capture headroom, not a serving-memory-fraction cheat.

```mermaid
sequenceDiagram
    participant P as Primary TRT-LLM
    participant G as GMS
    participant S as Shadow TRT-LLM
    participant V as TRT-LLM VMM/KV/Graphs
    participant D as Dynamo Locks/Router

    P->>G: publish weights RW
    P->>V: autotune/cache-hit warmup and CUDA graph capture
    P->>V: sleep(shadow_failover), preserve graphs, release KV/VMM/caches
    S->>G: map weights RO from shared GMS store
    S->>V: calibrate KV with GMS weights + peer reserve
    S->>V: allocate KV, run warmup, capture CUDA graphs before parking
    S->>V: sleep(shadow_failover), preserve graphs, release KV/VMM/caches
    S->>D: park and wait on failover lock
    P->>V: wake for serving path and allocate full KV
    P->>D: serve traffic, then SIGKILL releases lock
    S->>D: acquire failover lock
    S->>G: reconnect/remap GMS weights RO
    S->>V: wake and materialize KV VMM; no warmup or graph capture
    S->>D: publish model metadata
    D->>S: route post-failover inference for manual inspection
```

## Validation

TRT-LLM build/setup notes:

- Kernel/FATBIN artifacts are LFS-backed; this proof branch did not regenerate kernel blobs.
- The nscale pod used the TRT-LLM devcontainer plus this fork branch installed into the runtime. The final committed TRT-LLM Python files were copied into both `/workspace-dev/TensorRT-LLM` and `/usr/local/lib/python3.12/dist-packages/tensorrt_llm` before the final run.

Checks from this commit:

- `git diff --check` - clean.
- Local `python3 -m py_compile` for edited TRT-LLM runtime files - passed.
- Local grep for deferred-warmup/capture symbols (`TRTLLM_GMS_DEFER`, `run_deferred`, `capture_deferred`, `defer_warmup_once`, `defer_cuda_graph_warmup_once`, etc.) - no matches in the edited pyexecutor/test paths.
- Pod installed-runtime `python3 -m py_compile` for edited TRT-LLM runtime files - passed.
- Targeted local pytest could not run because local Python lacks `pytest`; the nscale pod ran the runtime failover pytest against the synced installed code.

Dynamo runtime validation with this TRT-LLM code synced into the pod:

- `Qwen/Qwen3-0.6B`, TP=1, two shadows, `free_gpu_memory_fraction=0.85` - `1 passed in 158.00s`; failover-ready `0.71s`, post-restore response `0.33s`, kill-to-response `1.04s`; primary/promoted KV blocks `[43485, 0]` / `[43589, 0]`.
- `Qwen/Qwen3-0.6B`, TP=8, two shadows, `free_gpu_memory_fraction=0.85` - `1 passed in 198.33s`; failover-ready `3.34s`, post-restore response `0.50s`, kill-to-response `3.84s`; primary/promoted KV blocks `[344905, 0]` / `[345103, 0]`.
- Kimi K2.5 + EAGLE3 TP=8, one standby, CUDA graphs disabled, autotuner disabled - `1 passed in 360.40s`; failover-ready `5.21s`, post-restore response `1.95s`, kill-to-response `7.15s`.
- Kimi K2.5 + EAGLE3 TP=8, one standby, no-deferral bs128 pre-capture, autotuner cache hit, `TLLM_AUTOTUNER_USE_CUDA_GRAPH=0`, peer reserve `10 GiB` - `1 passed in 320.54s`; failover-ready `5.86s`, post-restore response `0.57s`, kill-to-response `6.43s`; primary/promoted KV blocks `58510/60232`; manual response ended in `failover-ok`.
- No-reserve bs128 pre-capture control - failed during standby graph pre-capture before failover, proving the peer reserve is needed for startup/capture headroom at `free_gpu_memory_fraction=0.85`.
- Autotuner cache reuse, inference CUDA graphs disabled - both primary and standby loaded the pre-populated cache with `0` `Profiled runner=` lines; test passed in `299.07s`; kill-to-response `9.53s`; primary/promoted KV blocks `70660/72380`.
- Historical/rejected park-full-KV/deferred-warmup experiments passed through bs128/bs256 and greedy bs512, but they are no longer target behavior because they move warmup/CUDA graph capture into promotion.

Artifacts/worklog are archived locally under `/Users/schwinns/dynamo-worktrees/trtllm-failover-artifacts-20260427`, especially `new-runs-20260428-precapture-guard/INDEX.md` and `trtllm_failover_artifacts_with_precapture_guard_20260428.tar.gz`.

## Known Follow-Ups

- Reduce the `restore_gms_weights` hot-path bucket. Current evidence points at CUDA handle import/access setup, not weight data copy or KV VMM materialization.
- Evaluate the keep-RO-mapped tradeoff again with the no-deferral graph-preserving path. It may reduce promotion latency, but it increases parked duplicate footprint.
- Kimi has been validated with one standby for large-model runs. Multiple Kimi standbys and automatic shadow replenishment need additional capacity work.
- Add a true autotuner cache-builder/cache-only mode so serving replicas consume prebuilt artifacts without cache-producer residue.
- Continue CUDA graph memory work for very large batch sizes and advanced sampling. The bs128 explicit ladder passes with peer reserve; bs512 advanced-sampling graph capture still needs a lower-memory or sampling-mode-specific TRT-LLM fix.

This PR is **not** intended for merge as-is. It is a proof-build branch for the Dynamo shadow-failover stack and should be closed once the relevant pieces land through their intended upstream path.

Signed-off-by: Schwinn Saereesitthipitak <schwinns@nvidia.com>

## Reproducibility: nscale Devpod Setup

### Pod / container

- Kubernetes context: `nv-prd-dgxc.teleport.sh-dynamo-nscale-dev-cluster`
- Namespace / pod: `schwinns` / `trtllm-gms-failover-devpod`
- Node: `cluster-0967a26d-pool-14bee067-prctr-s2877`
- Container image: `nvcr.io/nvidia/tensorrt-llm/devel:1.3.0rc12`
- Pod resources: requests `cpu=48`, `memory=384Gi`; limits `cpu=96`, `memory=768Gi`
- Shared HF model cache PVC: volume `hf-cache`, PVC `shared-model-cache`, mounted at `/home/dynamo/.cache/huggingface`
- Workspace volume: `workspace-dev`, mounted at `/workspace-dev`
- Shared memory volume: `emptyDir.medium=Memory`, mounted at `/dev/shm`
- Hardware/runtime observed in the run logs: 8x NVIDIA B200, ~`182633 MiB` visible per GPU, CUDA `13.1.1.006`, driver `590.48.01`, Python `3.12.3`, PyTorch `2.11.0a0+eb65b36914.nv26.02`, NGC PyTorch `26.02`, TensorRT-LLM package `1.3.0rc11`, `gpu-memory-service==0.9.0`.

The source directories in the pod were synced into `/workspace-dev/dynamo` and `/workspace-dev/TensorRT-LLM` without `.git` metadata. The PR SHAs used for the synced source/build were:

- Dynamo: `ai-dynamo/dynamo:schwinns/gms-refactor-20260423` at `b1fb89cf2cc37be4a49c5cdad7d89a3b0058a6d6`
- TensorRT-LLM fork: `galletas1712/TensorRT-LLM:schwinns/gms-refactor-20260423` at `9ba5ee407b3e1fe4a48b427d6e6bcc10824e629b`

Installed packages in the accepted pod:

```text
ai-dynamo                         1.1.0   /workspace-dev/dynamo
ai-dynamo-runtime                 1.1.0   /workspace-dev/dynamo/lib/bindings/python
gpu-memory-service                0.9.0   /workspace-dev/dynamo/lib/gpu_memory_service
tensorrt_llm                      1.3.0rc11
tensorrt                          10.15.1.29
```

### Build / install steps

TRTLLM had C++ changes, so the wheel was rebuilt inside the pod with the native B200 arch and ccache:

```bash
cd /workspace-dev/TensorRT-LLM
./scripts/build_wheel.py --clean --use_ccache --cuda_architectures=native
# Install the generated TensorRT-LLM wheel into the dev container environment.
```

Dynamo and GMS were installed editable from the synced Dynamo branch:

```bash
cd /workspace-dev/dynamo
uv pip install -e '.[trtllm]'
uv pip install -e lib/gpu_memory_service
# At minimum, `uv pip install gpu-memory-service` is required if not using the editable in-tree GMS package.
```

Detached `kubectl exec` runs needed the Python wheel `.libs` directories on `LD_LIBRARY_PATH`; without this, the run could fail to load `libnixl-c7102487.so` / `libetcd-cpp-api-core-cac80504.so`:

```bash
PYLIB_DIRS=$(find /usr/local/lib/python3.12/dist-packages -maxdepth 1 \
  -type d \( -name '*.libs' -o -name '.*.libs' \) -printf '%p:' 2>/dev/null)
export LD_LIBRARY_PATH=/usr/local/lib:${PYLIB_DIRS}${LD_LIBRARY_PATH:-}
```

### Accepted TRTLLM shadow-failover pytest command

The main accepted Kimi K2.5 + EAGLE3 run used the shared HF cache offline and pre-captured CUDA graphs before parking the standby. Promotion does **not** defer warmup or CUDA graph capture into the failover hot path.

```bash
cd /workspace-dev/dynamo

export HF_HOME=/home/dynamo/.cache/huggingface
export HF_HUB_CACHE=/home/dynamo/.cache/huggingface/hub
export HF_HUB_OFFLINE=1
export DYN_TRTLLM_SHADOW_FAILOVER_MODEL=/home/dynamo/.cache/huggingface/hub/models--nvidia--Kimi-K2.5-NVFP4/snapshots/c0285e649c34d4386b01e38abca642c06cbe014e
export DYN_TRTLLM_SHADOW_FAILOVER_SERVED_MODEL_NAME=Kimi-K2.5-NVFP4-Eagle3
export DYN_TRTLLM_SHADOW_FAILOVER_ENGINE_YAML=/workspace-dev/dynamo/tests/gpu_memory_service/trtllm_kimi_k25_eagle3_engine.yaml
export DYN_TRTLLM_SHADOW_FAILOVER_TP=8
export DYN_TRTLLM_SHADOW_FAILOVER_SHADOW_COUNT=1
export DYN_TRTLLM_SHADOW_FAILOVER_FREE_GPU_MEMORY_FRACTION=0.85
export DYN_TRTLLM_SHADOW_FAILOVER_MAX_KV_BLOCK_DELTA_FRACTION=0.05
export DYN_TRTLLM_SHADOW_FAILOVER_MAX_READY_SECONDS=1200
export DYN_TRTLLM_SHADOW_FAILOVER_MAX_POST_KILL_RESPONSE_SECONDS=1200
export DYN_TRTLLM_SHADOW_FAILOVER_POST_RESTORE_RESPONSE_TIMEOUT_SECONDS=1200
export DYN_TRTLLM_SHADOW_FAILOVER_RESPONSE_MAX_TOKENS=128
export DYN_TRTLLM_SHADOW_FAILOVER_POST_RESTORE_MAX_TOKENS=128
export DYN_TRTLLM_SHADOW_FAILOVER_POST_RESTORE_PROMPT='Say exactly: failover-ok'
export DYN_TRTLLM_SHADOW_FAILOVER_EXTRA_ARGS='--disable-torch-compile --override-engine-args '\''{"enable_autotuner":true,"max_batch_size":128,"cuda_graph_config":{"batch_sizes":[1,2,4,8,16,32,64,128],"enable_padding":true}}'\'''
export TLLM_AUTOTUNER_CACHE_PATH=/tmp/kimi_autocache_reuse_nograph_1777335866/autotune-cache.json
export TLLM_AUTOTUNER_USE_CUDA_GRAPH=0
export TLLM_AUTOTUNER_LOG_LEVEL_DEBUG_TO_INFO=1
export TRTLLM_CLEAR_MEMORY_BUFFERS_ON_SLEEP=1
export TRTLLM_CUDA_GRAPH_MEMORY_SNAPSHOTS=1
export TRTLLM_CUDA_GRAPH_MEMORY_SYNC=1
export TRTLLM_GMS_LOG_PER_TAG_SLEEP_RELEASE=1
export TRTLLM_GMS_LOG_SLEEP_PHASES=1
export TRTLLM_GMS_RELEASE_WEIGHTS_ON_SLEEP=all
export TRTLLM_GMS_SHADOW_MEMORY_CALIBRATION=1
export TRTLLM_GMS_SHADOW_PEER_MEMORY_RESERVE_GIB=10
export PYTORCH_ALLOC_CONF=garbage_collection_threshold:0.99999
export DYN_LOG=debug

python -m pytest -s tests/gpu_memory_service/test_trtllm_shadow_failover.py::test_gms_shadow_engine_failover_trtllm --tb=short
```

Notes on that configuration:

- `TRTLLM_GMS_SHADOW_PEER_MEMORY_RESERVE_GIB=10` reserves headroom for the already parked peer while the promoted engine sizes KV and captures CUDA graphs. This is currently a conservative explicit reserve; a follow-up is to replace it with measured peer footprint where possible.
- `TLLM_AUTOTUNER_USE_CUDA_GRAPH=0` avoids the autotuner's CUDA-graph profiling pool, which was observed to create a private per-rank memory spike around 37-38 GiB in failed exploratory runs.
- The accepted graph-capture shape set is explicit powers of two up to `bs=128` with padding enabled. The default/expanded graph batch set put too much pressure on the parked-shadow setup.
- The pytest asserts failover mechanics and timing; response quality was manually inspected from `pytest.log` for the `failover-ok` response, rather than asserting semantic coherence in pytest.

### Timing / validation results

| Run | Artifact | Result | Failover timing | KV capacity |
| --- | --- | --- | --- | --- |
| Qwen3-0.6B TP=1 default | `/Users/schwinns/dynamo-worktrees/trtllm-failover-artifacts-20260427/qwen3_06b_tp1_final_1777080565/pytest.log` | `1 passed in 158.00s` | post-restore inference completed and response manually inspected | primary/promoted KV blocks `43485/43589` |
| Qwen3-0.6B TP=8 | `/Users/schwinns/dynamo-worktrees/trtllm-failover-artifacts-20260427/qwen3_06b_tp8_accept_1777078131/pytest.log` | `1 passed in 198.33s` | post-restore inference completed and response manually inspected | primary/promoted KV blocks `344905/345103` |
| Kimi K2.5 NVFP4 + EAGLE3 TP=8, autotune cache reuse, CUDA graphs bs128 | `/Users/schwinns/dynamo-worktrees/trtllm-failover-artifacts-20260427/new-runs-20260428-precapture-guard/logs/kimi_precapture_cgbs128_reserve10_guard_snap_1777360695/pytest.log` | `1 passed in 320.54s` | standby ready `5.86s`; post-restore response `0.57s`; SIGKILL-to-response `6.43s`; response manually inspected as `failover-ok` | primary/promoted KV blocks `58510/60232`; primary approx `61.27 GiB main + 3.01 GiB draft`; promoted standby approx `63.07 GiB main + 3.10 GiB draft` |
| Kimi K2.5 NVFP4 + EAGLE3 TP=8 tensor audit follow-up | `/Users/schwinns/dynamo-worktrees/trtllm-failover-artifacts-20260427/new-runs-20260428-tensor-audit/tensor_audit_1777364433/pytest.log` | `1 passed in 355.83s` | standby ready `5.91s`; post-restore response `0.55s`; SIGKILL-to-response `6.46s` | primary/promoted KV blocks `58510/60232`; parked footprint approx `9.5-9.7 GiB/rank`; local tensor storage approx `4.282 GiB/rank` (`3.437 GiB` CUDA graph runner + `0.845 GiB` shape-classified local tensors) |

The hot wake path in the accepted Kimi run was dominated by remapping/restoring GMS weights, not KV VMM materialization:

```text
restore_gms_weights: ~4.91-5.03s/rank
materialize_vmm:     ~0.01-0.04s/rank
restore_moe:         ~0.01s/rank
total rank wake:     ~5.63-5.67s/rank
```

### Artifact index

Local artifact/worklog roots:

- Worklog: `/Users/schwinns/dynamo-worktrees/trtllm-failover-artifacts-20260427/WORKLOG.md`
- CUDA graph investigation: `/Users/schwinns/dynamo-worktrees/trtllm-failover-artifacts-20260427/new-runs-20260427-cuda-graphs/CUDA_GRAPH_MEMORY_INVESTIGATION.md`
- Tensor audit summary: `/Users/schwinns/dynamo-worktrees/trtllm-failover-artifacts-20260427/new-runs-20260428-tensor-audit/TENSOR_AUDIT_SUMMARY.md`
- Accepted Kimi bs128 run: `/Users/schwinns/dynamo-worktrees/trtllm-failover-artifacts-20260427/new-runs-20260428-precapture-guard/logs/kimi_precapture_cgbs128_reserve10_guard_snap_1777360695/`
- Accepted tensor audit run: `/Users/schwinns/dynamo-worktrees/trtllm-failover-artifacts-20260427/new-runs-20260428-tensor-audit/tensor_audit_1777364433/`

Pod artifact root for the latest tensor-audit run:

- `/workspace-dev/trtllmfailover-artifacts/tensor_audit_1777364433/pytest.log`
- `/workspace-dev/trtllmfailover-artifacts/tensor_audit_1777364433/run.env`
- `/workspace-dev/trtllmfailover-artifacts/tensor_audit_1777364433/tensor_audit/*.json`

