### PR TITLE
[None][chore] Include layer_idx in MoE backend fallback warnings

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -111,7 +111,7 @@ class Qwen3MoE(nn.Module):
             dtype=config.torch_dtype,
             apply_routing=False,
             routing_method_type=RoutingMethodType.Renormalize,
-            moe_backend_cls=get_moe_cls(model_config),
+            moe_backend_cls=get_moe_cls(model_config, layer_idx=layer_idx),
         )
 
         self.weight_loading_mode = MoEWeightLoadingMode.FUSED_GATE_UP_PROJ if config.model_type == "qwen3_vl_moe_text" else MoEWeightLoadingMode.VANILLA

--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -26,12 +26,15 @@ from .routing import BaseMoeRoutingMethod
 
 
 def get_moe_cls(
-        model_config: ModelConfig,
-        override_quant_config: Optional[QuantConfig] = None) -> Type[MoE]:
+    model_config: ModelConfig,
+    override_quant_config: Optional[QuantConfig] = None,
+    layer_idx: Optional[int] = None,
+) -> Type[MoE]:
     moe_backend = model_config.moe_backend
     quant_config = model_config.quant_config
     if override_quant_config is not None:
         quant_config = override_quant_config
+    layer_prefix = f"[layer_idx={layer_idx}] " if layer_idx is not None else ""
     if moe_backend.upper() == "CUTLASS":
         return CutlassFusedMoE
     elif moe_backend.upper() == "VANILLA":
@@ -43,7 +46,7 @@ def get_moe_cls(
             return CuteDslFusedMoE
         else:
             logger.warning(
-                "CuteDslFusedMoE only supports fp8_block_scales and nvfp4. "
+                f"{layer_prefix}CuteDslFusedMoE only supports fp8_block_scales and nvfp4. "
                 f"Check out details in quant_config: {quant_config}. Using CutlassFusedMoE instead."
             )
             return CutlassFusedMoE
@@ -52,7 +55,7 @@ def get_moe_cls(
     elif moe_backend.upper() == "DENSEGEMM":
         if quant_config is None or not quant_config.quant_mode.has_nvfp4():
             logger.warning(
-                "DenseGEMMFusedMoE only supports nvfp4. "
+                f"{layer_prefix}DenseGEMMFusedMoE only supports nvfp4. "
                 f"Check out details in quant_config: {quant_config}. Using CutlassFusedMoE instead."
             )
             return CutlassFusedMoE
@@ -61,7 +64,7 @@ def get_moe_cls(
         sm_version = get_sm_version()
         if sm_version not in DenseGEMMFusedMoE._SUPPORTED_SM_VERSIONS:
             logger.warning(
-                f"DenseGEMMFusedMoE only supports SM {DenseGEMMFusedMoE._SUPPORTED_SM_VERSIONS} "
+                f"{layer_prefix}DenseGEMMFusedMoE only supports SM {DenseGEMMFusedMoE._SUPPORTED_SM_VERSIONS} "
                 f"(got SM {sm_version}). Using CutlassFusedMoE instead.")
             return CutlassFusedMoE
         return DenseGEMMFusedMoE
@@ -85,7 +88,7 @@ def get_moe_cls(
                 "trtllm_bf16_moe support, but it is not available.")
         else:
             logger.warning(
-                "TRTLLMGenFusedMoE only supports fp8_block_scales, nvfp4, w4a16_mxfp4, w4a8_nvfp4_fp8, w4a8_mxfp4_fp8, and w4a8_mxfp4_mxfp8. "
+                f"{layer_prefix}TRTLLMGenFusedMoE only supports fp8_block_scales, nvfp4, w4a16_mxfp4, w4a8_nvfp4_fp8, w4a8_mxfp4_fp8, and w4a8_mxfp4_mxfp8. "
                 f"Check out details in quant_config: {quant_config}. Using CutlassFusedMoE instead."
             )
             return CutlassFusedMoE
@@ -143,11 +146,13 @@ def get_moe_cls(
 
 
 def resolve_moe_cls(
-        model_config: ModelConfig,
-        routing_method: BaseMoeRoutingMethod,
-        dtype: Optional[torch.dtype],
-        override_quant_config: Optional[QuantConfig] = None) -> Type[MoE]:
-    moe_cls = get_moe_cls(model_config, override_quant_config)
+    model_config: ModelConfig,
+    routing_method: BaseMoeRoutingMethod,
+    dtype: Optional[torch.dtype],
+    override_quant_config: Optional[QuantConfig] = None,
+    layer_idx: Optional[int] = None,
+) -> Type[MoE]:
+    moe_cls = get_moe_cls(model_config, override_quant_config, layer_idx)
 
     effective_quant_config = override_quant_config or model_config.quant_config
     has_quant = (effective_quant_config is not None
@@ -488,7 +493,7 @@ def create_moe(
         dtype = pretrained_config.torch_dtype
 
     moe_cls = resolve_moe_cls(model_config, routing_method, dtype,
-                              override_quant_config)
+                              override_quant_config, layer_idx)
 
     enable_configurable_moe = os.environ.get("ENABLE_CONFIGURABLE_MOE",
                                              "1") == "1"


### PR DESCRIPTION
## Summary

- When the requested MoE backend (CuteDSL, DenseGEMM, TRTLLMGen) cannot be used for a given layer's `quant_config` and falls back to `CutlassFusedMoE`, the existing warning does not say which layer triggered it.
- In mixed-quant checkpoints (e.g. DeepSeek V3.2 FP4 where the MTP layer is excluded from quantization), this produces identical-looking warnings repeated once per rank, making it impossible to tell whether the fallback is an expected per-layer decision or a real regression.
- Threads `layer_idx` through `get_moe_cls` and prefixes the four fallback `logger.warning` calls with `[layer_idx=N] ` when known. No behavior change.

## Test plan

- [x] Run any MoE model where the CuteDSL/DenseGEMM/TRTLLMGen backend is requested but one or more layers fall back (e.g. DS-V3.2 FP4 with MTP + CUTEDSL backend) and confirm the warnings now include `[layer_idx=N]`.
- [x] Run a pure homogeneous-quant model and confirm output is unchanged apart from the `[layer_idx=N]` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced MoE (Mixture of Experts) backend initialization with per-layer context for more precise backend class selection.
  * Improved diagnostic and warning messages with layer-specific identifiers during backend resolution, providing clearer feedback in fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->