### PR TITLE
[None][perf] Skip request broadcast when world_size is 1

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/request_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/request_utils.py
@@ -520,6 +520,9 @@ class RequestBroadcaster:
         """Broadcast requests across pipeline stages."""
         payloads = (new_requests, py_request_objects)
 
+        if self.dist.world_size == 1:
+            return payloads
+
         if not self.dist.has_pp:
             return self.dist.broadcast(payloads, root=0)
 


### PR DESCRIPTION
Skip the MPI broadcast in RequestBroadcaster._broadcast_requests when world_size == 1. The broadcast call still incurs pickle serialization overhead even when there is only one rank, which is wasteful for single-GPU (especially for multimodal) runs.

The check is placed before the has_pp branch so it covers every parallelism configuration (TP / PP / CP / EP / DP).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized request distribution in single-process deployments to eliminate unnecessary communication overhead and improve performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->