### PR TITLE
[TRTLLM-12213][infra] Pre-init pyxis container to avoid rootfs lock race in dis…

### DIFF
--- a/jenkins/scripts/perf/disaggregated/slurm_launch_draft.sh
+++ b/jenkins/scripts/perf/disaggregated/slurm_launch_draft.sh
@@ -10,6 +10,18 @@ mkdir -p "$testOutputDir"
 chmod +x $runScript
 chmod +x $installScript
 
+# Pre-initialize the pyxis container rootfs serially on every node so that
+# the subsequent parallel `srun ... &` steps (gen/ctx/disagg/benchmark) that
+# share --container-name=multi_node_test-$SLURM_JOB_ID just attach to an
+# already-initialized rootfs. Without this, concurrent pyxis attaches race
+# for the rootfs flock and fail with "Could not acquire rootfs lock".
+echo "Pre-initializing pyxis container on all nodes..."
+if ! srun "${srunArgs[@]}" --ntasks-per-node=1 --kill-on-bad-exit=1 true \
+    &> $jobWorkspace/container_preinit.log; then
+    cleanup_on_failure "Failed to pre-initialize container. Check $jobWorkspace/container_preinit.log"
+fi
+echo "Pyxis container pre-initialized on all nodes"
+
 # Run installation on all nodes
 echo "Running installation on all nodes..."
 if ! srun "${srunArgs[@]}" $installScript &> $jobWorkspace/install.log; then

--- a/jenkins/scripts/perf/disaggregated/slurm_launch_draft.sh
+++ b/jenkins/scripts/perf/disaggregated/slurm_launch_draft.sh
@@ -17,7 +17,7 @@ chmod +x $installScript
 # for the rootfs flock and fail with "Could not acquire rootfs lock".
 echo "Pre-initializing pyxis container on all nodes..."
 if ! srun "${srunArgs[@]}" --ntasks-per-node=1 --kill-on-bad-exit=1 true \
-    &> $jobWorkspace/container_preinit.log; then
+    &> "$jobWorkspace/container_preinit.log"; then
     cleanup_on_failure "Failed to pre-initialize container. Check $jobWorkspace/container_preinit.log"
 fi
 echo "Pyxis container pre-initialized on all nodes"


### PR DESCRIPTION
The disagg perf sanity stages launch 4+ `srun ... &` steps that all share `--container-name=multi_node_test-$SLURM_JOB_ID`. Concurrent pyxis attaches race for the per-container rootfs flock and intermittently fail with:

  pyxis: [ERROR] Could not acquire rootfs lock
  pyxis: couldn't start container
  spank_pyxis.so: task_init() failed with rc=-1

Run one serialized `srun --ntasks-per-node=1 true` before the parallel steps so that every node's pyxis rootfs is fully initialized up front; subsequent concurrent steps then only attach to the existing rootfs and no longer race for the init flock. The existing `sleep 5` guards are kept as belt-and-suspenders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced container initialization process to prevent concurrent setup conflicts and improve deployment reliability.
  * Added error detection with improved failure notifications to guide troubleshooting when initialization issues occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
