### PR TITLE
[None][fix] fix disagg kv cache reuse token accounting

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -550,6 +550,7 @@ class LlmResult:
         self._py_result = py_result
         self.is_final = is_final
         self.cached_tokens = 0
+        self.kv_cache_reused_blocks = None
         # Time breakdown metrics for performance analysis
         # Contains: step_metrics (list), ctx_gpu_forward_time (float), ctx_gpu_sample_time (float)
         self.time_breakdown_metrics = time_breakdown_metrics

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -610,6 +610,21 @@ class PyExecutor:
 
             self.kv_connector_manager.wait_for_initialization()
 
+    @staticmethod
+    def _set_response_kv_cache_fields(response: LlmResponse,
+                                      request: LlmRequest) -> None:
+        response.result.cached_tokens = request.cached_tokens
+        kv_cache_reused_blocks = request.reused_blocks
+        if request.llm_request_type == LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY:
+            kv_cache_reused_blocks += request.missed_blocks
+        elif request.is_generation_only_request():
+            disaggregated_params = getattr(request, "py_disaggregated_params",
+                                           None)
+            if disaggregated_params is not None:
+                kv_cache_reused_blocks += (
+                    disaggregated_params.kv_cache_reused_blocks or 0)
+        response.result.kv_cache_reused_blocks = kv_cache_reused_blocks
+
     def _end_transfer_and_maybe_terminate(self, request: LlmRequest):
         if self.kv_cache_transceiver and request in self.active_requests:
             # Fast-transfer: KV transfer completed in the same iteration
@@ -618,7 +633,7 @@ class PyExecutor:
             # createResult). Then proceed with end_transfer + termination.
             response = request.create_response(False, self.dist.rank)
             if response:
-                response.result.cached_tokens = request.cached_tokens
+                self._set_response_kv_cache_fields(response, request)
                 self._enqueue_responses([(request.py_request_id, response)])
             if self.async_transfer_manager.end_transfer(request):
                 self.active_requests.remove(request)
@@ -3747,7 +3762,7 @@ class PyExecutor:
                 response = request.create_response(False, self.dist.rank)
                 if response:
                     request_done = request.is_finished
-                    response.result.cached_tokens = request.cached_tokens
+                    self._set_response_kv_cache_fields(response, request)
                     new_responses.append((req_id, response))
 
             if request_done:

--- a/tensorrt_llm/disaggregated_params.py
+++ b/tensorrt_llm/disaggregated_params.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from dataclasses import dataclass
 from enum import IntEnum
 from typing import Any, Dict, List, Optional
@@ -33,6 +36,9 @@ class DisaggregatedParams:
          Each entry is a list (one per beam) of TokenLogprobs (list of dict[int, Logprob]).
         first_gen_logits (List): The generation logits for first_gen_tokens, produced during prefill.
          Each entry is a torch.Tensor of shape [num_tokens, vocab_size] (one per beam/sequence).
+        kv_cache_reused_blocks (int): KV cache blocks counted as reused by disaggregated generation. Context
+         responses carry context KV blocks; generation responses carry context KV blocks plus generation-side reused
+         blocks.
 
         multimodal_embedding_handles (List[Dict[str, Any]]): The resulting multimodal embedding handles from ViT.
         multimodal_hashes (List[List[int]]): The multimodal hashes of each multimodal item in the request.
@@ -51,6 +57,7 @@ class DisaggregatedParams:
     ctx_dp_rank: Optional[int] = None
     ctx_info_endpoint: Optional[str] = None
     schedule_style: Optional[DisaggScheduleStyle] = None
+    kv_cache_reused_blocks: Optional[int] = None
 
     # E-P Disaggregated Params
     multimodal_embedding_handles: Optional[List[Dict[str, Any]]] = (

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import dataclasses
 import json
@@ -466,6 +469,8 @@ class GenerationResultBase:
             self.decoding_iter = response_result.decoding_iter
             self.cached_tokens = getattr(response_result, 'cached_tokens', 0)
             self.avg_decoded_tokens_per_iter = response_result.avg_decoded_tokens_per_iter
+            kv_cache_reused_blocks = getattr(response_result,
+                                             'kv_cache_reused_blocks', None)
             if context_phase_params is not None:
                 existing_disagg_params = self.disaggregated_params
                 # Use `replace` to preserve things like `mrope_position_ids_handle` and
@@ -480,7 +485,13 @@ class GenerationResultBase:
                     draft_tokens=context_phase_params.draft_tokens,
                     ctx_dp_rank=context_phase_params.ctx_dp_rank,
                     ctx_info_endpoint=context_phase_params.disagg_info_endpoint,
+                    kv_cache_reused_blocks=kv_cache_reused_blocks,
                     multimodal_embedding_handles=None,
+                )
+            elif kv_cache_reused_blocks is not None and self.disaggregated_params is not None:
+                self._disaggregated_params = dataclasses.replace(
+                    self.disaggregated_params,
+                    kv_cache_reused_blocks=kv_cache_reused_blocks,
                 )
 
             finish_reasons = response_result.finish_reasons

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Adapted from
 # https://github.com/vllm-project/vllm/blob/4db5176d9758b720b05460c50ace3c01026eb158/vllm/entrypoints/openai/protocol.py
 import base64
@@ -128,6 +131,7 @@ class DisaggregatedParams(OpenAIBaseModel):
     ctx_info_endpoint: Optional[str] = None
     schedule_style: Optional[DisaggScheduleStyle] = None
     conversation_id: Optional[str] = None
+    kv_cache_reused_blocks: Optional[int] = None
 
 
 class ErrorResponse(OpenAIBaseModel):
@@ -1204,6 +1208,7 @@ def to_disaggregated_params(
         ctx_dp_rank=tllm_disagg_params.ctx_dp_rank,
         ctx_info_endpoint=tllm_disagg_params.ctx_info_endpoint,
         schedule_style=tllm_disagg_params.schedule_style,
+        kv_cache_reused_blocks=tllm_disagg_params.kv_cache_reused_blocks,
     )
 
 
@@ -1226,6 +1231,7 @@ def to_llm_disaggregated_params(
         ctx_dp_rank=disaggregated_params.ctx_dp_rank,
         ctx_info_endpoint=disaggregated_params.ctx_info_endpoint,
         schedule_style=disaggregated_params.schedule_style,
+        kv_cache_reused_blocks=disaggregated_params.kv_cache_reused_blocks,
     )
 
 

--- a/tests/unittest/disaggregated/test_disaggregated_params.py
+++ b/tests/unittest/disaggregated/test_disaggregated_params.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -56,6 +59,7 @@ def test_to_disaggregated_params():
         first_gen_tokens=[1, 2],
         ctx_dp_rank=5,
         ctx_info_endpoint="tcp://10.0.0.1:5000",
+        kv_cache_reused_blocks=3,
     )
     openai_params = to_disaggregated_params(llm_params)
 
@@ -63,6 +67,7 @@ def test_to_disaggregated_params():
     assert openai_params.first_gen_tokens == [1, 2]
     assert openai_params.ctx_dp_rank == 5
     assert openai_params.ctx_info_endpoint == "tcp://10.0.0.1:5000"
+    assert openai_params.kv_cache_reused_blocks == 3
 
 
 def test_to_llm_disaggregated_params():
@@ -73,12 +78,14 @@ def test_to_llm_disaggregated_params():
         request_type="generation_only",
         ctx_dp_rank=2,
         ctx_info_endpoint="tcp://10.0.0.1:5000",
+        kv_cache_reused_blocks=4,
     )
     llm_params = to_llm_disaggregated_params(openai_params)
 
     assert llm_params.request_type == "generation_only"
     assert llm_params.ctx_dp_rank == 2
     assert llm_params.ctx_info_endpoint == "tcp://10.0.0.1:5000"
+    assert llm_params.kv_cache_reused_blocks == 4
 
 
 @patch("tensorrt_llm.disaggregated_params.tllme")

--- a/tests/unittest/disaggregated/test_openai_disagg_service.py
+++ b/tests/unittest/disaggregated/test_openai_disagg_service.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 from unittest.mock import AsyncMock
 
@@ -41,6 +44,7 @@ def _make_completion_response(
     disagg_request_id: int = 42,
     prompt_token_ids=None,
     context_only=True,
+    kv_cache_reused_blocks=None,
 ) -> CompletionResponse:
     if prompt_token_ids is None:
         prompt_token_ids = [1, 2, 3]
@@ -57,6 +61,7 @@ def _make_completion_response(
                     request_type="context_only" if context_only else "generation_only",
                     disagg_request_id=disagg_request_id,
                     ctx_request_id=disagg_request_id,
+                    kv_cache_reused_blocks=kv_cache_reused_blocks,
                 ),
             )
         ],
@@ -110,6 +115,7 @@ async def test_send_disagg_request(monkeypatch, stream, schedule_style):
                 finish_reason="length",
                 disagg_request_id=request.disaggregated_params.disagg_request_id,
                 context_only=True,
+                kv_cache_reused_blocks=7,
             )
 
         async def _delayed_gen_response(*_args, **_kwargs):
@@ -142,6 +148,8 @@ async def test_send_disagg_request(monkeypatch, stream, schedule_style):
             gen_req.disaggregated_params.ctx_request_id
             == ctx_req.disaggregated_params.disagg_request_id
         )
+        if schedule_style == "context_first":
+            assert gen_req.disaggregated_params.kv_cache_reused_blocks == 7
 
         if stream:
             assert hasattr(result, "__aiter__")

--- a/tests/unittest/llmapi/test_executor.py
+++ b/tests/unittest/llmapi/test_executor.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 import datetime
 import json
@@ -5,6 +8,7 @@ import tempfile
 import threading
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -292,6 +296,33 @@ def create_rsp(id, finished: bool = False):
     return tllm.Response(request_id=0, result=result, client_id=0)
 
 
+def create_rsp_with_cached_tokens(id,
+                                  cached_tokens: int,
+                                  finished: bool = True,
+                                  kv_cache_reused_blocks=None):
+    result = SimpleNamespace(
+        output_token_ids=[[id]],
+        context_logits=None,
+        generation_logits=None,
+        log_probs=None,
+        cum_log_probs=None,
+        finish_reasons=[tllm.FinishReason.END_ID],
+        is_final=finished,
+        sequence_index=0,
+        request_perf_metrics=None,
+        context_phase_params=None,
+        decoding_iter=1,
+        cached_tokens=cached_tokens,
+        kv_cache_reused_blocks=kv_cache_reused_blocks,
+        avg_decoded_tokens_per_iter=0,
+    )
+    return SimpleNamespace(
+        result=result,
+        client_id=0,
+        has_error=lambda: False,
+    )
+
+
 def test_GenerationResultBase():
     sampling_params = SamplingParams(max_tokens=4)
     result = GenerationResultBase(
@@ -316,6 +347,59 @@ def test_GenerationResult():
     result._handle_response(create_rsp(44, finished=True))
     assert len(result.outputs[0].token_ids) == 12
     assert result._done
+
+
+def test_generation_result_context_response_carries_kv_cache_reused_blocks():
+    sampling_params = SamplingParams(max_tokens=4)
+    result = GenerationResultBase(id=2, sampling_params=sampling_params)
+    response = create_rsp_with_cached_tokens(2,
+                                             cached_tokens=64,
+                                             kv_cache_reused_blocks=7)
+    response.result.context_phase_params = tllm.ContextPhaseParams([2], 123,
+                                                                   bytes([0,
+                                                                          1]),
+                                                                   [], 0, "")
+
+    result._handle_response(response)
+
+    assert result.cached_tokens == 64
+    assert result.outputs[0].disaggregated_params.kv_cache_reused_blocks == 7
+
+
+def test_generation_result_preserves_backend_generation_cached_tokens():
+    sampling_params = SamplingParams(max_tokens=4)
+    disagg_params = DisaggregatedParams(
+        request_type="generation_only",
+        first_gen_tokens=[7],
+        ctx_request_id=123,
+        kv_cache_reused_blocks=2,
+    )
+    result = GenerationResultBase(id=2, sampling_params=sampling_params)
+    result._disaggregated_params = disagg_params
+    response = create_rsp_with_cached_tokens(2, cached_tokens=2)
+
+    result._handle_response(response)
+
+    assert result.cached_tokens == 2
+
+
+def test_generation_result_updates_generation_kv_cache_reused_blocks():
+    sampling_params = SamplingParams(max_tokens=4)
+    disagg_params = DisaggregatedParams(
+        request_type="generation_only",
+        first_gen_tokens=[7],
+        ctx_request_id=123,
+        kv_cache_reused_blocks=2,
+    )
+    result = GenerationResultBase(id=2, sampling_params=sampling_params)
+    result._disaggregated_params = disagg_params
+    response = create_rsp_with_cached_tokens(2,
+                                             cached_tokens=2,
+                                             kv_cache_reused_blocks=5)
+
+    result._handle_response(response)
+
+    assert result.outputs[0].disaggregated_params.kv_cache_reused_blocks == 5
 
 
 def test_DetokenizedGenerationResultBase():


### PR DESCRIPTION
Summary:
- carry context-side KV cache reused tokens through disaggregated params
- use the carried reused-token count for generation response cached_tokens
- add unit coverage for param roundtrip, disagg forwarding, and response cached token handling

Testing:
- pre-commit hooks run by git commit
- python syntax compile check
- git diff --check