### PR TITLE
[None][perf] Extend customMoeRouting kernel to support Qwen3.5

### DIFF
--- a/cpp/tensorrt_llm/kernels/customMoeRoutingKernels.cu
+++ b/cpp/tensorrt_llm/kernels/customMoeRoutingKernels.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,9 +35,18 @@ TRTLLM_NAMESPACE_BEGIN
 namespace kernels
 {
 
-static constexpr int BLOCK_SIZE = 1024;
 static constexpr int WARP_SIZE = 32;
-static constexpr int WARPS_PER_BLOCK = BLOCK_SIZE / WARP_SIZE;
+// Default block size for kernels with small MaxNumExperts (<=128).
+// Large-expert variants (256/384/512) use a smaller block (see pickBlockSize)
+// to reduce register-file pressure and permit higher SM occupancy.
+static constexpr int DEFAULT_BLOCK_SIZE = 1024;
+static constexpr int LARGE_BLOCK_SIZE = 256;
+
+template <int MaxNumExperts>
+constexpr int pickBlockSize()
+{
+    return MaxNumExperts > 128 ? LARGE_BLOCK_SIZE : DEFAULT_BLOCK_SIZE;
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -110,15 +119,17 @@ __device__ void calcSoftmax(cg::thread_block_tile<WARP_SIZE> const& warp, DataTy
 
 template <typename InputT, typename OutputT, typename IdxT, int MaxNumExperts, int MaxNumTopExperts,
     bool DoSoftmaxBeforeTopK>
-__global__ void customMoeRoutingKernel(InputT* routerLogits, OutputT* topkValues, IdxT* topkIndices,
-    int32_t const numTokens, int32_t const numExperts, int32_t const topK)
+__global__ void __launch_bounds__(pickBlockSize<MaxNumExperts>(), 1) customMoeRoutingKernel(InputT* routerLogits,
+    OutputT* topkValues, IdxT* topkIndices, int32_t const numTokens, int32_t const numExperts, int32_t const topK)
 {
     using BaseType = std::conditional_t<DoSoftmaxBeforeTopK, float, InputT>;
+    constexpr int kBlockSize = pickBlockSize<MaxNumExperts>();
+    constexpr int kWarpsPerBlock = kBlockSize / WARP_SIZE;
     uint32_t const blockRank = blockIdx.x;
-    uint32_t const tIdx = BLOCK_SIZE * blockRank + threadIdx.x;
+    uint32_t const tIdx = kBlockSize * blockRank + threadIdx.x;
     uint32_t const warpIdx = tIdx / WARP_SIZE;
     uint32_t const laneIdx = tIdx % WARP_SIZE;
-    uint32_t const warpNum = gridDim.x * WARPS_PER_BLOCK;
+    uint32_t const warpNum = gridDim.x * kWarpsPerBlock;
     auto block = cg::this_thread_block();
     auto warp = cg::tiled_partition<WARP_SIZE>(block);
 
@@ -217,6 +228,9 @@ int nextPowerOfTwo(int num)
         case 8:                                                                                                        \
             kernelInstance = &customMoeRoutingKernel<InputT, OutputT, IdxT, MAX_NUM_EXPERTS, 8, DoSoftmaxBeforeTopK>;  \
             break;                                                                                                     \
+        case 16:                                                                                                       \
+            kernelInstance = &customMoeRoutingKernel<InputT, OutputT, IdxT, MAX_NUM_EXPERTS, 16, DoSoftmaxBeforeTopK>; \
+            break;                                                                                                     \
         default: kernelInstance = nullptr; break;                                                                      \
         }                                                                                                              \
         break;
@@ -227,10 +241,15 @@ void invokeCustomMoeRouting(InputT* routerLogits, OutputT* topkValues, IdxT* top
 {
 
     const uint32_t maxNumBlocks = 1024;
-    const uint32_t numBlocks = std::min(static_cast<uint32_t>((numTokens - 1) / WARPS_PER_BLOCK + 1), maxNumBlocks);
 
     uint32_t maxNumExperts = nextPowerOfTwo(numExperts) < 32 ? 32 : nextPowerOfTwo(numExperts);
     uint32_t maxNumTopExperts = nextPowerOfTwo(topK);
+
+    // Pick block size matching what pickBlockSize<> selects for this MaxNumExperts.
+    // Large-expert variants use LARGE_BLOCK_SIZE to reduce register pressure.
+    uint32_t blockSize = maxNumExperts > 128 ? LARGE_BLOCK_SIZE : DEFAULT_BLOCK_SIZE;
+    uint32_t warpsPerBlock = blockSize / WARP_SIZE;
+    const uint32_t numBlocks = std::min(static_cast<uint32_t>((numTokens - 1) / warpsPerBlock + 1), maxNumBlocks);
 
     auto* kernelInstance = &customMoeRoutingKernel<InputT, OutputT, IdxT, 128, 8, DoSoftmaxBeforeTopK>;
 
@@ -240,6 +259,9 @@ void invokeCustomMoeRouting(InputT* routerLogits, OutputT* topkValues, IdxT* top
         CASE(64)
         CASE(96)
         CASE(128)
+        CASE(256)
+        CASE(384)
+        CASE(512)
     default: kernelInstance = nullptr; break;
     }
 
@@ -249,7 +271,7 @@ void invokeCustomMoeRouting(InputT* routerLogits, OutputT* topkValues, IdxT* top
     }
 
     dim3 renormMoeRoutingGridDim(numBlocks);
-    dim3 renormMoeRoutingBlockDim(BLOCK_SIZE);
+    dim3 renormMoeRoutingBlockDim(blockSize);
     cudaLaunchConfig_t config;
     config.gridDim = renormMoeRoutingGridDim;
     config.blockDim = renormMoeRoutingBlockDim;

--- a/cpp/tensorrt_llm/kernels/moeTopKFuncs.cuh
+++ b/cpp/tensorrt_llm/kernels/moeTopKFuncs.cuh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -264,16 +264,14 @@ __forceinline__ __device__ void reduceTopK(cg::thread_block_tile<kWARP_SIZE> con
                 inIdx[i] = idx[start + i];
             }
             reduceTopKFunc<K, Type, 4>(warp, topKValue, topKIdx, inValue, inIdx, minValue, actualK);
-            int inOffset = laneIdx % K;
-            if (laneIdx >= loop * K && laneIdx < (loop + 1) * K)
+            for (int resultIdx = 0; resultIdx < numResults; ++resultIdx)
             {
-                topKBufferValue[0] = topKValue[inOffset];
-                topKBufferIdx[0] = topKIdx[inOffset];
-            }
-            if (loop == numLoops - 1 && (laneIdx < (numLoops * K - kWARP_SIZE)))
-            {
-                topKBufferValue[1] = topKValue[inOffset];
-                topKBufferIdx[1] = topKIdx[inOffset];
+                int const candidateIdx = resultIdx * kWARP_SIZE + laneIdx - loop * K;
+                if (candidateIdx >= 0 && candidateIdx < K)
+                {
+                    topKBufferValue[resultIdx] = topKValue[candidateIdx];
+                    topKBufferIdx[resultIdx] = topKIdx[candidateIdx];
+                }
             }
         }
 

--- a/cpp/tensorrt_llm/thop/customMoeRoutingOp.cpp
+++ b/cpp/tensorrt_llm/thop/customMoeRoutingOp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,9 @@ std::tuple<at::Tensor, at::Tensor> custom_moe_routing_op(
     int64_t num_tokens = input_size[0];
     int64_t num_experts = input_size[1];
     TORCH_CHECK(input_size.size() == 2, "router_logits must be a 2D Tensor");
-    TORCH_CHECK(topk <= 8, "topk should be smaller than or equal to 8 for now"); //@todo: remove this restriction later
-    TORCH_CHECK(num_experts <= 128, "expert number should be smaller than or equal to 128 for now");
+    TORCH_CHECK(
+        topk <= 16, "topk should be smaller than or equal to 16 for now"); //@todo: remove this restriction later
+    TORCH_CHECK(num_experts <= 512, "expert number should be smaller than or equal to 512 for now");
 
     // Determine output data type
     at::ScalarType topk_values_dtype = output_dtype.value_or(torch::kFloat32);

--- a/tensorrt_llm/_torch/modules/fused_moe/routing.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/routing.py
@@ -299,7 +299,7 @@ class DefaultMoeRoutingMethod(BaseMoeRoutingMethod):
     def apply(self,
               router_logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         num_experts = router_logits.shape[-1]
-        if self.force_enable_pytorch_op or num_experts > 128 or self.top_k > 8:
+        if self.force_enable_pytorch_op or num_experts > 512 or self.top_k > 16:
             return self.apply_pytorch(router_logits)
         else:
             return torch.ops.trtllm.default_moe_routing_op(
@@ -551,7 +551,7 @@ class RenormalizeMoeRoutingMethod(BaseMoeRoutingMethod):
     def apply(self,
               router_logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         num_experts = router_logits.shape[-1]
-        if self.force_enable_pytorch_op or num_experts > 128 or self.top_k > 8:
+        if self.force_enable_pytorch_op or num_experts > 512 or self.top_k > 16:
             return self.apply_pytorch(router_logits)
         else:
             return torch.ops.trtllm.renorm_moe_routing_op(

--- a/tests/unittest/_torch/modules/test_moe_routing.py
+++ b/tests/unittest/_torch/modules/test_moe_routing.py
@@ -189,7 +189,7 @@ def gen_unique_logits(num_tokens, num_experts, dtype):
 @pytest.mark.parametrize("top_k", [2, 8])
 @pytest.mark.parametrize("dtype",
                          [torch.bfloat16, torch.float32, torch.float16])
-@pytest.mark.parametrize("num_experts", [8, 67, 128])
+@pytest.mark.parametrize("num_experts", [8, 67, 128, 512])
 def test_customized_renormalize_moe_routing(num_tokens, top_k, num_experts,
                                             dtype):
 
@@ -204,8 +204,51 @@ def test_customized_renormalize_moe_routing(num_tokens, top_k, num_experts,
                                               force_enable_pytorch_op=True)
     reference_indices, reference_scales = ref_routing.apply(router_logits)
 
+    # Compare top-k as a set: when router_logits contain ties (e.g. bf16 +
+    # num_experts>256 collapses many randperm values to the same bf16 number),
+    # the kernel and the reference may legitimately break ties in different
+    # orders. Sort each row by indices before comparing, and align scales by
+    # the same permutation.
+    idx_sorted, perm = torch.sort(indices, dim=1)
+    ref_idx_sorted, ref_perm = torch.sort(reference_indices, dim=1)
+    assert torch.equal(idx_sorted, ref_idx_sorted)
+
+    scales_sorted = torch.gather(scales, 1, perm)
+    ref_scales_sorted = torch.gather(reference_scales, 1, ref_perm)
+    assert torch.allclose(scales_sorted, ref_scales_sorted)
+
+
+@pytest.mark.parametrize("routing_cls",
+                         [DefaultMoeRoutingMethod, RenormalizeMoeRoutingMethod])
+@pytest.mark.parametrize("dtype",
+                         [torch.bfloat16, torch.float32, torch.float16])
+def test_customized_moe_routing_512_experts_topk10_middle_block(
+        routing_cls, dtype):
+    num_tokens = 4
+    num_experts = 512
+    top_k = 10
+    router_logits = torch.full((num_tokens, num_experts),
+                               -20,
+                               dtype=torch.float32,
+                               device="cuda")
+    expected_topk_indices = torch.arange(256,
+                                         256 + top_k,
+                                         device="cuda",
+                                         dtype=torch.int32)
+
+    for token_idx in range(num_tokens):
+        router_logits[token_idx, expected_topk_indices.long()] = torch.arange(
+            top_k, 0, -1, dtype=torch.float32, device="cuda") + token_idx
+    router_logits = router_logits.to(dtype)
+
+    routing = routing_cls(top_k=top_k, force_enable_pytorch_op=False)
+    indices, scales = routing.apply(router_logits)
+
+    ref_routing = routing_cls(top_k=top_k, force_enable_pytorch_op=True)
+    reference_indices, reference_scales = ref_routing.apply(router_logits)
+
     assert torch.equal(indices, reference_indices)
-    assert torch.allclose(scales, reference_scales)
+    assert torch.allclose(scales, reference_scales, atol=1e-3, rtol=1e-3)
 
 
 def test_sparse_mixer_reference():


### PR DESCRIPTION
This PR enables gatherTopK+softmax → customMoeRoutingKernel opt for qwen3.5.

Qwen3.5-397B-A17B-NVFP4 and Qwen3-Next-80B have num_experts=512, top_k=10, which previously failed the fast-path guard (`num_experts > 128 || top_k > 8`) in RenormalizeMoeRoutingMethod.apply and fell back to a pytorch path (torch.topk + softmax_warp_forward), costing ~2.5% of GPU time per MoE layer on ADP4 1k/1k decode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended mixture-of-experts model support: now handles up to 512 experts (previously 128)
  * Increased top-k parameter limit to 16 (previously 8)

* **Performance**
  * Optimized CUDA kernel execution with adaptive block sizing for varying expert configurations

* **Tests**
  * Added comprehensive test coverage for large-scale expert configurations (512 experts with various top-k values)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
