### PR TITLE
[Draft] Harden disagg transceiver request lifetime

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -204,13 +204,15 @@ class BaseCacheTransceiver
 {
 public:
     virtual ~BaseCacheTransceiver() = default;
-    virtual void respondAndSendAsync(LlmRequest* llmRequest) = 0;
+    // Transfers are asynchronous. Pass shared_ptr so the transceiver and its
+    // workers keep the request alive until the corresponding future resolves.
+    virtual void respondAndSendAsync(std::shared_ptr<LlmRequest> llmRequest) = 0;
     virtual void respondAndSendLayerWise(
         RequestVector const& requests, std::shared_ptr<ContextProgress> const& progress)
         = 0;
 
-    virtual void requestAndReceiveSync(LlmRequest* llmRequest) = 0;
-    virtual void requestAndReceiveAsync(LlmRequest* llmRequest) = 0;
+    virtual void requestAndReceiveSync(std::shared_ptr<LlmRequest> llmRequest) = 0;
+    virtual void requestAndReceiveAsync(std::shared_ptr<LlmRequest> llmRequest) = 0;
 
     /// Check all requests transferring context, and return the requests that have completed or encountered an error.
     virtual RequestStatuses checkContextTransferStatus(
@@ -221,7 +223,7 @@ public:
 
     [[nodiscard]] virtual bool checkGenTransferComplete() const = 0;
 
-    virtual bool cancelRequest(LlmRequest* llmRequest) = 0;
+    virtual bool cancelRequest(std::shared_ptr<LlmRequest> llmRequest) = 0;
 };
 
 class CacheTransceiver : public BaseCacheTransceiver
@@ -252,13 +254,13 @@ public:
 
     virtual ~CacheTransceiver();
 
-    void respondAndSendAsync(LlmRequest* llmRequest) override;
+    void respondAndSendAsync(std::shared_ptr<LlmRequest> llmRequest) override;
 
     void respondAndSendLayerWise(
         RequestVector const& requests, std::shared_ptr<ContextProgress> const& progress) override;
 
-    void requestAndReceiveSync(LlmRequest* llmRequest) override;
-    void requestAndReceiveAsync(LlmRequest* llmRequest) override;
+    void requestAndReceiveSync(std::shared_ptr<LlmRequest> llmRequest) override;
+    void requestAndReceiveAsync(std::shared_ptr<LlmRequest> llmRequest) override;
 
     RequestStatuses checkContextTransferStatus(
         std::optional<int> const& atLeastRequestNum = std::nullopt, bool markComplete = false) override;
@@ -267,7 +269,7 @@ public:
 
     [[nodiscard]] bool checkGenTransferComplete() const override;
 
-    virtual bool cancelRequest(LlmRequest* llmRequest) override;
+    virtual bool cancelRequest(std::shared_ptr<LlmRequest> llmRequest) override;
 
 private:
     void initializeCommState();
@@ -276,8 +278,10 @@ private:
 
     std::unique_ptr<CacheSender> mCacheSender;
     std::unique_ptr<CacheReceiver> mCacheReceiver;
-    std::vector<std::pair<LlmRequest*, std::future<void>>> mSenderFutures;
-    std::vector<std::pair<LlmRequest*, std::future<void>>> mRequesterFutures;
+    // Hold strong references while futures are outstanding so Python-side
+    // cleanup cannot leave C++ with dangling LlmRequest pointers.
+    std::vector<std::pair<std::shared_ptr<LlmRequest>, std::future<void>>> mSenderFutures;
+    std::vector<std::pair<std::shared_ptr<LlmRequest>, std::future<void>>> mRequesterFutures;
     mpi::MpiComm const* mMpiWorldComm{nullptr};
 
     std::shared_ptr<CacheTransceiverComm> mGroupComm;

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
@@ -21,10 +21,111 @@
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/common/opUtils.h"
 
+#include <exception>
 #include <mutex>
 
 namespace tensorrt_llm::batch_manager
 {
+
+namespace
+{
+
+char const* bufferKindName(BufferKind kind)
+{
+    switch (kind)
+    {
+    case BufferKind::kKV: return "kv";
+    case BufferKind::kKV_INDEXER: return "kv_indexer";
+    case BufferKind::kRNN: return "rnn";
+    }
+    return "unknown";
+}
+
+} // namespace
+
+BufferIndexHolder::BufferIndexHolder(
+    BaseTransBufferManager* manager, Direction direction, std::optional<int> bufferId)
+    : mManager{manager}
+    , mDirection{direction}
+    , mBufferId{bufferId}
+    , mOwns{manager != nullptr}
+{
+}
+
+BufferIndexHolder::~BufferIndexHolder()
+{
+    reset();
+}
+
+BufferIndexHolder::BufferIndexHolder(BufferIndexHolder&& other) noexcept
+    : mManager{other.mManager}
+    , mDirection{other.mDirection}
+    , mBufferId{other.mBufferId}
+    , mOwns{other.mOwns}
+{
+    other.mManager = nullptr;
+    other.mBufferId = std::nullopt;
+    other.mOwns = false;
+}
+
+BufferIndexHolder& BufferIndexHolder::operator=(BufferIndexHolder&& other) noexcept
+{
+    if (this != &other)
+    {
+        reset();
+        mManager = other.mManager;
+        mDirection = other.mDirection;
+        mBufferId = other.mBufferId;
+        mOwns = other.mOwns;
+        other.mManager = nullptr;
+        other.mBufferId = std::nullopt;
+        other.mOwns = false;
+    }
+    return *this;
+}
+
+BufferIndexHolder BufferIndexHolder::acquireSend(BaseTransBufferManager& manager)
+{
+    return BufferIndexHolder{&manager, Direction::kSend, manager.assignBufferIndexForSend()};
+}
+
+BufferIndexHolder BufferIndexHolder::acquireRecv(BaseTransBufferManager& manager)
+{
+    return BufferIndexHolder{&manager, Direction::kRecv, manager.assignBufferIndexForRecv()};
+}
+
+void BufferIndexHolder::reset() noexcept
+{
+    if (!mOwns || mManager == nullptr)
+    {
+        return;
+    }
+
+    try
+    {
+        if (mDirection == Direction::kSend)
+        {
+            mManager->freeBufferIndexForSend(mBufferId);
+        }
+        else
+        {
+            mManager->freeBufferIndexForRecv(mBufferId);
+        }
+    }
+    catch (std::exception const& e)
+    {
+        TLLM_LOG_ERROR(
+            "Exception while releasing cache transfer buffer index %d: %s", mBufferId.value_or(-1), e.what());
+    }
+    catch (...)
+    {
+        TLLM_LOG_ERROR("Unknown exception while releasing cache transfer buffer index %d", mBufferId.value_or(-1));
+    }
+
+    mManager = nullptr;
+    mBufferId = std::nullopt;
+    mOwns = false;
+}
 
 BaseTransBufferManager::BaseTransBufferManager(
     size_t transferBufferSize, nvinfer1::DataType dataType, std::optional<size_t> maxNumTokens)
@@ -56,22 +157,48 @@ BaseTransBufferManager::BaseTransBufferManager(
 
 std::optional<int> BaseTransBufferManager::assignBufferIndexForSend()
 {
-    return assignBufferIndex(mConcurrenceSendResource, mSendBufferCount, mOnlyUseDynamicBuffer);
+    auto bufferId = assignBufferIndex(mConcurrenceSendResource, mSendBufferCount, mOnlyUseDynamicBuffer);
+    if (bufferId.has_value())
+    {
+        TLLM_LOG_DEBUG("Assigned send cache transfer buffer kind=%s index=%d outstanding=%d/%zu",
+            bufferKindName(getBufferKind()), bufferId.value(), mConcurrenceSendResource.mConcurrence.load(),
+            mSendBufferCount);
+    }
+    return bufferId;
 }
 
 void BaseTransBufferManager::freeBufferIndexForSend(std::optional<int> bufferId)
 {
     freeBufferIndex(mConcurrenceSendResource, bufferId, mSendBufferCount, mOnlyUseDynamicBuffer);
+    if (bufferId.has_value())
+    {
+        TLLM_LOG_DEBUG("Freed send cache transfer buffer kind=%s index=%d outstanding=%d/%zu",
+            bufferKindName(getBufferKind()), bufferId.value(), mConcurrenceSendResource.mConcurrence.load(),
+            mSendBufferCount);
+    }
 }
 
 std::optional<int> BaseTransBufferManager::assignBufferIndexForRecv()
 {
-    return assignBufferIndex(mConcurrenceRecvResource, mRecvBufferCount, mOnlyUseDynamicBuffer);
+    auto bufferId = assignBufferIndex(mConcurrenceRecvResource, mRecvBufferCount, mOnlyUseDynamicBuffer);
+    if (bufferId.has_value())
+    {
+        TLLM_LOG_DEBUG("Assigned recv cache transfer buffer kind=%s index=%d outstanding=%d/%zu",
+            bufferKindName(getBufferKind()), bufferId.value(), mConcurrenceRecvResource.mConcurrence.load(),
+            mRecvBufferCount);
+    }
+    return bufferId;
 }
 
 void BaseTransBufferManager::freeBufferIndexForRecv(std::optional<int> bufferId)
 {
     freeBufferIndex(mConcurrenceRecvResource, bufferId, mRecvBufferCount, mOnlyUseDynamicBuffer);
+    if (bufferId.has_value())
+    {
+        TLLM_LOG_DEBUG("Freed recv cache transfer buffer kind=%s index=%d outstanding=%d/%zu",
+            bufferKindName(getBufferKind()), bufferId.value(), mConcurrenceRecvResource.mConcurrence.load(),
+            mRecvBufferCount);
+    }
 }
 
 std::tuple<std::vector<runtime::ITensor::SharedPtr>, size_t, bool> BaseTransBufferManager::getOrAllocateSendBuffers(

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
@@ -39,11 +39,53 @@ class FabricMemory;
 namespace tensorrt_llm::batch_manager
 {
 
+class BaseTransBufferManager;
+
 enum class BufferKind : uint8_t
 {
     kKV = 0,
     kKV_INDEXER = 1,
     kRNN = 2
+};
+
+class BufferIndexHolder
+{
+public:
+    enum class Direction : uint8_t
+    {
+        kSend = 0,
+        kRecv = 1
+    };
+
+    BufferIndexHolder() = default;
+    BufferIndexHolder(BaseTransBufferManager* manager, Direction direction, std::optional<int> bufferId);
+    ~BufferIndexHolder();
+
+    BufferIndexHolder(BufferIndexHolder const&) = delete;
+    BufferIndexHolder& operator=(BufferIndexHolder const&) = delete;
+    BufferIndexHolder(BufferIndexHolder&& other) noexcept;
+    BufferIndexHolder& operator=(BufferIndexHolder&& other) noexcept;
+
+    [[nodiscard]] static BufferIndexHolder acquireSend(BaseTransBufferManager& manager);
+    [[nodiscard]] static BufferIndexHolder acquireRecv(BaseTransBufferManager& manager);
+
+    [[nodiscard]] std::optional<int> get() const noexcept
+    {
+        return mBufferId;
+    }
+
+    [[nodiscard]] bool owns() const noexcept
+    {
+        return mOwns;
+    }
+
+    void reset() noexcept;
+
+private:
+    BaseTransBufferManager* mManager{nullptr};
+    Direction mDirection{Direction::kSend};
+    std::optional<int> mBufferId{std::nullopt};
+    bool mOwns{false};
 };
 
 /// @brief Base class for cache transfer buffer management.

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -481,7 +481,8 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         // cache blocks to the corresponding buffer.
         // 5. send the buffer to the corresponding target. Ideally, we send only once (one buffer) for each target.
 
-        auto cacheBufferId = mCacheTransBufferManager->assignBufferIndexForSend();
+        auto cacheBufferHolder = BufferIndexHolder::acquireSend(*mCacheTransBufferManager);
+        auto cacheBufferId = cacheBufferHolder.get();
         int peerDuplicateHeadFactor = targetInfo.mPeerDupHeadFactor;
         auto bufferTargetNum = targetNum / peerDuplicateHeadFactor;
         auto ppRank = selfIdx
@@ -565,7 +566,6 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
 
         session.setTime(TransferSession::kTimeTransmissions);
 
-        mCacheTransBufferManager->freeBufferIndexForSend(cacheBufferId);
         session.setTime(TransferSession::kTimePostprocess);
     }
     TLLM_LOG_DEBUG(
@@ -787,6 +787,7 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
             size_t remainNoCoverTargetNum = 0;
             size_t bufferCoverTargetNum = 0;
             std::optional<int> cacheBufferId = std::nullopt;
+            BufferIndexHolder cacheBufferHolder;
             {
                 NVTX3_SCOPED_RANGE(formatInputAllocBuffer);
 
@@ -800,7 +801,8 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
                 }
                 else
                 {
-                    cacheBufferId = mCacheTransBufferManager->assignBufferIndexForRecv();
+                    cacheBufferHolder = BufferIndexHolder::acquireRecv(*mCacheTransBufferManager);
+                    cacheBufferId = cacheBufferHolder.get();
                 }
                 auto [recvSplitCachestmp, bufferCoverTargetNumtmp, onlyUseDynamicBuffer]
                     = mCacheTransBufferManager->getOrAllocateRecvBuffers(
@@ -935,10 +937,6 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
                     recvSplitCaches, outputBuffersPerWindow, destConfig, selfConfig, selfIdx, bufferManager);
 
                 bufferManager.getStream().synchronize();
-                if (cacheBufferId.has_value())
-                {
-                    mCacheTransBufferManager->freeBufferIndexForRecv(cacheBufferId);
-                }
             }
             session.setTime(TransferSession::kTimePostprocess);
         }

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -323,7 +323,7 @@ void CacheTransceiver::setContextState(LlmRequest* llmRequest)
     }
 }
 
-void CacheTransceiver::respondAndSendAsync(LlmRequest* llmRequest)
+void CacheTransceiver::respondAndSendAsync(std::shared_ptr<LlmRequest> llmRequest)
 {
     TLLM_CHECK(llmRequest && llmRequest->isContextOnlyRequest());
     llmRequest->setState(LlmRequestState::kDISAGG_CONTEXT_TRANS_IN_PROGRESS);
@@ -337,9 +337,9 @@ void CacheTransceiver::respondAndSendAsync(LlmRequest* llmRequest)
         }
         return;
     }
-    setContextState(llmRequest);
-    auto future = mCacheSender->sendAsync(*llmRequest);
-    mSenderFutures.emplace_back(llmRequest, std::move(future));
+    setContextState(llmRequest.get());
+    auto future = mCacheSender->sendAsync(llmRequest);
+    mSenderFutures.emplace_back(std::move(llmRequest), std::move(future));
 }
 
 void CacheTransceiver::respondAndSendLayerWise(
@@ -354,22 +354,22 @@ void CacheTransceiver::respondAndSendLayerWise(
 
         llmRequest->setState(LlmRequestState::kDISAGG_CONTEXT_INIT_AND_TRANS);
         setContextState(llmRequest.get());
-        auto future = mCacheSender->sendAsync(*llmRequest);
-        mSenderFutures.emplace_back(llmRequest.get(), std::move(future));
+        auto future = mCacheSender->sendAsync(llmRequest);
+        mSenderFutures.emplace_back(llmRequest, std::move(future));
     }
 }
 
-void CacheTransceiver::requestAndReceiveSync(LlmRequest* llmRequest)
+void CacheTransceiver::requestAndReceiveSync(std::shared_ptr<LlmRequest> llmRequest)
 {
     TLLM_CHECK(llmRequest && llmRequest->isGenerationOnlyRequest());
     {
-        auto future = mCacheReceiver->receiveAsync(*llmRequest);
+        auto future = mCacheReceiver->receiveAsync(llmRequest);
         future.get();
     }
     llmRequest->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE);
 }
 
-void CacheTransceiver::requestAndReceiveAsync(LlmRequest* llmRequest)
+void CacheTransceiver::requestAndReceiveAsync(std::shared_ptr<LlmRequest> llmRequest)
 {
     TLLM_CHECK(llmRequest && llmRequest->isGenerationOnlyRequest());
 
@@ -381,9 +381,9 @@ void CacheTransceiver::requestAndReceiveAsync(LlmRequest* llmRequest)
         return;
     }
 
-    auto future = mCacheReceiver->receiveAsync(*llmRequest);
-    mRequesterFutures.emplace_back(llmRequest, std::move(future));
+    auto future = mCacheReceiver->receiveAsync(llmRequest);
     llmRequest->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+    mRequesterFutures.emplace_back(std::move(llmRequest), std::move(future));
 }
 
 std::vector<LlmRequest::RequestIdType> gatherRequestIds(
@@ -722,7 +722,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
                 if (!common::getEnvKVCacheTimeOutputPath().empty())
                 {
                     auto syncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupDataComm : mGroupComm;
-                    updateKVCacheTransferBW(syncComm, it->first);
+                    updateKVCacheTransferBW(syncComm, it->first.get());
                 }
             }
             catch (std::exception const& e)
@@ -757,7 +757,7 @@ bool CacheTransceiver::checkGenTransferComplete() const
     return mRequesterFutures.empty();
 }
 
-bool CacheTransceiver::cancelRequest(LlmRequest* llmRequest)
+bool CacheTransceiver::cancelRequest(std::shared_ptr<LlmRequest> llmRequest)
 {
     if (llmRequest->isContextOnlyRequest())
     {

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -54,7 +54,9 @@
 #include "tensorrt_llm/runtime/utils/pgUtils.h"
 #include <algorithm>
 #include <cstddef>
+#include <exception>
 #include <numeric>
+#include <stdexcept>
 #include <unordered_set>
 
 namespace tensorrt_llm::batch_manager
@@ -484,6 +486,8 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     std::optional<int> const& atLeastRequestNum, bool markComplete)
 {
     bool blockAll = !atLeastRequestNum.has_value();
+    TLLM_LOG_DEBUG("Checking context KV transfer futures: pending=%zu atLeast=%d blockAll=%d markComplete=%d",
+        mSenderFutures.size(), atLeastRequestNum.value_or(0), blockAll, markComplete);
     std::optional<int> senderFutureTimeoutMs = std::nullopt;
     // If blockAll is true, we want to block and not use a timeout
     if (!blockAll && mCacheTransceiverConfig.has_value())
@@ -564,8 +568,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 }
                 else if (status == std::future_status::timeout)
                 {
-                    TLLM_LOG_WARNING("Timed out waiting for context KV cache transfer after %d milliseconds.",
-                        senderFutureTimeoutMs.value());
+                    TLLM_LOG_WARNING(
+                        "Timed out waiting for context KV cache transfer after %d milliseconds for request %ld.",
+                        senderFutureTimeoutMs.value(), request->mRequestId);
                     ++it;
                 }
                 else
@@ -586,6 +591,13 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 requestsStatus.errorRequestIds.insert(request->mRequestId);
                 it = mSenderFutures.erase(it);
             }
+            catch (...)
+            {
+                TLLM_LOG_ERROR("Unknown error occurred during context transfer for request %ld", request->mRequestId);
+                request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                requestsStatus.errorRequestIds.insert(request->mRequestId);
+                it = mSenderFutures.erase(it);
+            }
         }
         else
         {
@@ -599,6 +611,8 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastRequestNum)
 {
     bool blockAll = !atLeastRequestNum.has_value();
+    TLLM_LOG_DEBUG("Checking generation KV transfer futures: pending=%zu atLeast=%d blockAll=%d",
+        mRequesterFutures.size(), atLeastRequestNum.value_or(0), blockAll);
     std::vector<LlmRequest::RequestIdType> genTransferReadyRequestIds;
     for (auto&& [request, future] : mRequesterFutures)
     {
@@ -729,6 +743,12 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             {
                 TLLM_LOG_ERROR(
                     "Error occurred during generation transfer for request %ld: %s", it->first->mRequestId, e.what());
+                it->first->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+            }
+            catch (...)
+            {
+                TLLM_LOG_ERROR(
+                    "Unknown error occurred during generation transfer for request %ld", it->first->mRequestId);
                 it->first->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
             }
             if (useMPI())

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -30,9 +30,11 @@
 #include "tensorrt_llm/runtime/common.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include <chrono>
+#include <exception>
 #include <future>
 #include <map>
 #include <memory>
+#include <stdexcept>
 #include <unordered_map>
 
 namespace tensorrt_llm::batch_manager
@@ -78,8 +80,15 @@ void TransferSession::send(size_t idx, void const* data, size_t size)
     }
     catch (std::exception const& e)
     {
+        auto const requestId = mRequest != nullptr ? mRequest->mRequestId : 0;
         throw common::RequestSpecificException(
-            __FILE__, __LINE__, e.what(), mRequest->mRequestId, common::RequestErrorCode::kNETWORK_ERROR);
+            __FILE__, __LINE__, e.what(), requestId, common::RequestErrorCode::kNETWORK_ERROR);
+    }
+    catch (...)
+    {
+        auto const requestId = mRequest != nullptr ? mRequest->mRequestId : 0;
+        throw common::RequestSpecificException(__FILE__, __LINE__, "Unknown exception in cache transfer send",
+            requestId, common::RequestErrorCode::kNETWORK_ERROR);
     }
 }
 
@@ -91,8 +100,15 @@ void TransferSession::recv(size_t idx, void* data, size_t size)
     }
     catch (std::exception const& e)
     {
+        auto const requestId = mRequest != nullptr ? mRequest->mRequestId : 0;
         throw common::RequestSpecificException(
-            __FILE__, __LINE__, e.what(), mRequest->mRequestId, common::RequestErrorCode::kNETWORK_ERROR);
+            __FILE__, __LINE__, e.what(), requestId, common::RequestErrorCode::kNETWORK_ERROR);
+    }
+    catch (...)
+    {
+        auto const requestId = mRequest != nullptr ? mRequest->mRequestId : 0;
+        throw common::RequestSpecificException(__FILE__, __LINE__, "Unknown exception in cache transfer recv",
+            requestId, common::RequestErrorCode::kNETWORK_ERROR);
     }
 }
 
@@ -536,6 +552,12 @@ private:
             TLLM_LOG_ERROR("Exception in sendAndRemoveResponse: %s request id: %ld", e.what(), id);
             resp.mPromise.set_exception(std::current_exception());
         }
+        catch (...)
+        {
+            TLLM_LOG_ERROR("Unknown exception in sendAndRemoveResponse for request id: %ld", id);
+            resp.mPromise.set_exception(
+                std::make_exception_ptr(std::runtime_error("Unknown exception in sendAndRemoveResponse")));
+        }
     }
 
     void asyncSendAndRemoveResponse(RequestIdType id, Response resp) noexcept
@@ -671,6 +693,16 @@ private:
                 it.second.mPromise.set_exception(std::current_exception());
             }
         }
+        catch (...)
+        {
+            TLLM_LOG_ERROR("Unknown exception in CacheSender response");
+            auto unknownException
+                = std::make_exception_ptr(std::runtime_error("Unknown exception in CacheSender response"));
+            for (auto& it : mReadyResponses)
+            {
+                it.second.mPromise.set_exception(unknownException);
+            }
+        }
     }
 
     void terminate()
@@ -796,6 +828,10 @@ public:
         {
             TLLM_THROW("%s", e.what());
         }
+        catch (...)
+        {
+            TLLM_THROW("Unknown exception in requestAndReceiveAsyncMultiThreads");
+        }
     }
 
     void receiveSync(TransferSession& session)
@@ -856,11 +892,20 @@ public:
 
         auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
         std::vector<std::optional<size_t>> cacheBufferIds;
+        std::vector<BufferIndexHolder> cacheBufferHolders;
         if (agentConnectionManager)
         {
-            for (auto& cacheTransBufferManager : agentConnectionManager->getCacheTransBufferManagers())
+            auto& cacheTransBufferManagers = agentConnectionManager->getCacheTransBufferManagers();
+            cacheBufferIds.reserve(cacheTransBufferManagers.size());
+            cacheBufferHolders.reserve(cacheTransBufferManagers.size());
+            for (auto& cacheTransBufferManager : cacheTransBufferManagers)
             {
-                cacheBufferIds.push_back(cacheTransBufferManager->assignBufferIndexForRecv());
+                auto holder = BufferIndexHolder::acquireRecv(*cacheTransBufferManager);
+                auto bufferId = holder.get();
+                cacheBufferIds.push_back(
+                    bufferId.has_value() ? std::optional<size_t>{static_cast<size_t>(bufferId.value())}
+                                         : std::nullopt);
+                cacheBufferHolders.emplace_back(std::move(holder));
             }
             TLLM_CHECK(!cacheBufferIds.empty());
         }
@@ -949,10 +994,15 @@ public:
             }
         }
         auto const& resource = getReceiveCacheResource(llmRequest);
-        return TransferSession(std::move(allConnections), DataContext{tagFromRequestId(requestId), mTerminate},
+        auto session = TransferSession(std::move(allConnections), DataContext{tagFromRequestId(requestId), mTerminate},
             std::move(allCounterparts), mSelfState, contextState, resource->mBufferManager,
             requestInfo.getIndexFromEnd(), requestInfo.getLastBlockKey(), &llmRequest,
             !common::getEnvKVCacheTimeOutputPath().empty());
+        for (auto& holder : cacheBufferHolders)
+        {
+            session.addBufferIndexHolder(std::move(holder));
+        }
+        return session;
     }
 
     std::unique_ptr<ReceiveCacheResource> const& getReceiveCacheResource(LlmRequest const& llmRequest)
@@ -1140,6 +1190,17 @@ private:
                 resource.mRequestsQueue.pop_front();
             }
             {
+                auto requestId = [&requestAndPromise]() -> size_t
+                { return requestAndPromise.mRequest != nullptr ? requestAndPromise.mRequest->mRequestId : 0; };
+                auto contextRequestId = [&requestAndPromise]() -> size_t
+                {
+                    if (requestAndPromise.mRequest == nullptr
+                        || !requestAndPromise.mRequest->getContextPhaseParams().has_value())
+                    {
+                        return 0;
+                    }
+                    return requestAndPromise.mRequest->getContextPhaseParams().value().getReqId();
+                };
                 try
                 {
                     TLLM_CHECK_WITH_INFO(requestAndPromise.mRequest != nullptr, "requestAndPromise.mRequest is null");
@@ -1149,18 +1210,23 @@ private:
                 catch (tensorrt_llm::common::RequestSpecificException const& err)
                 {
                     TLLM_LOG_ERROR("Exception in DataRequester request(): request id:%zu , request context id:%zu : %s",
-                        requestAndPromise.mRequest->mRequestId,
-                        requestAndPromise.mRequest->getContextPhaseParams().value().getReqId(), err.what());
-                    auto new_exception = TLLM_REQUEST_EXCEPTION(
-                        requestAndPromise.mRequest->mRequestId, err.getErrorCode(), "%s", err.what());
+                        requestId(), contextRequestId(), err.what());
+                    auto new_exception = TLLM_REQUEST_EXCEPTION(requestId(), err.getErrorCode(), "%s", err.what());
                     requestAndPromise.mPromise->set_exception(std::make_exception_ptr(new_exception));
                 }
                 catch (std::exception const& err)
                 {
-                    TLLM_LOG_ERROR("Exception in CacheReceiver request(): request id:%ld , request context id:%ld : %s",
-                        requestAndPromise.mRequest->mRequestId,
-                        requestAndPromise.mRequest->getContextPhaseParams().value().getReqId(), err.what());
+                    TLLM_LOG_ERROR("Exception in CacheReceiver request(): request id:%zu , request context id:%zu : %s",
+                        requestId(), contextRequestId(), err.what());
                     requestAndPromise.mPromise->set_exception(std::current_exception());
+                }
+                catch (...)
+                {
+                    TLLM_LOG_ERROR(
+                        "Unknown exception in CacheReceiver request(): request id:%zu , request context id:%zu",
+                        requestId(), contextRequestId());
+                    requestAndPromise.mPromise->set_exception(
+                        std::make_exception_ptr(std::runtime_error("Unknown exception in CacheReceiver request")));
                 }
             }
         }

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -296,16 +296,16 @@ public:
         }
     }
 
-    [[nodiscard]] std::future<void> sendAsync(LlmRequest& llmRequest)
+    [[nodiscard]] std::future<void> sendAsync(std::shared_ptr<LlmRequest> const& llmRequest)
     {
         std::promise<void> promise;
         auto future = promise.get_future();
-        llmRequest.setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
+        llmRequest->setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
         {
             {
                 std::scoped_lock lkResp(mSenderMutex);
-                mReadyResponses.emplace(
-                    llmRequest.mRequestId, Response{std::addressof(llmRequest), std::move(promise)});
+                // Keep the request alive until the async-send worker finishes.
+                mReadyResponses.emplace(llmRequest->mRequestId, Response{llmRequest, std::move(promise)});
             }
             std::unique_lock lkCond(mCondMutex);
             mAnyReady = true;
@@ -477,7 +477,8 @@ public:
 private:
     struct Response
     {
-        LlmRequest* mRequest;
+        // Keep the request alive until the async-send worker finishes.
+        std::shared_ptr<LlmRequest> mRequest;
         std::promise<void> mPromise;
     };
 
@@ -753,23 +754,26 @@ public:
         TLLM_CUDA_CHECK(cudaGetDevice(&mDeviceId));
     }
 
-    [[nodiscard]] std::future<void> receiveAsync(LlmRequest& llmRequest)
+    [[nodiscard]] std::future<void> receiveAsync(std::shared_ptr<LlmRequest> const& llmRequest)
     {
         // TODO: Modify the implementation here to avoid frequent thread creation.
-        return std::async(std::launch::async, &CacheReceiver::Impl::requestSync, this, std::ref(llmRequest));
+        // Keep the request alive until the async task completes.
+        auto llmRequestCopy = llmRequest;
+        return std::async(std::launch::async,
+            [this, llmRequestCopy]() { requestSync(*llmRequestCopy); });
     }
 
-    [[nodiscard]] std::future<void> requestAndReceiveAsyncMultiThreads(LlmRequest& llmRequest)
+    [[nodiscard]] std::future<void> requestAndReceiveAsyncMultiThreads(std::shared_ptr<LlmRequest> const& llmRequest)
     {
         try
         {
             auto promise = std::make_unique<std::promise<void>>();
             auto future = promise->get_future();
-            TLLM_CHECK(llmRequest.getDataTransceiverState().getCommState().has_value());
+            TLLM_CHECK(llmRequest->getDataTransceiverState().getCommState().has_value());
             std::string processInfo = kDefaultProcessInfo;
             if (common::getEnvRequestKVCacheConcurrent())
             {
-                processInfo = llmRequest.getDataTransceiverState().getCommState()->toString();
+                processInfo = llmRequest->getDataTransceiverState().getCommState()->toString();
             }
             if (mInstanceToAsyncResource.find(processInfo) == mInstanceToAsyncResource.end())
             {
@@ -782,7 +786,8 @@ public:
             auto& asyncResource = mInstanceToAsyncResource.at(processInfo);
             {
                 std::unique_lock<std::mutex> lck(asyncResource->mMtxForQueue);
-                asyncResource->mRequestsQueue.emplace_back(std::addressof(llmRequest), std::move(promise));
+                // Keep the request alive until the worker finishes.
+                asyncResource->mRequestsQueue.emplace_back(llmRequest, std::move(promise));
             }
             asyncResource->mCVforQueue.notify_all();
             return future;
@@ -1078,7 +1083,8 @@ private:
 
     struct RequestAndPromise
     {
-        LlmRequest* mRequest;
+        // Keep the request alive while it is queued or owned by a worker.
+        std::shared_ptr<LlmRequest> mRequest;
         std::unique_ptr<std::promise<void>> mPromise;
 
         RequestAndPromise()
@@ -1087,38 +1093,16 @@ private:
         {
         }
 
-        RequestAndPromise(LlmRequest* request, std::unique_ptr<std::promise<void>>&& promise)
-            : mRequest(request)
+        RequestAndPromise(std::shared_ptr<LlmRequest> request, std::unique_ptr<std::promise<void>>&& promise)
+            : mRequest(std::move(request))
             , mPromise(std::move(promise))
         {
         }
 
         RequestAndPromise(RequestAndPromise const&) = delete;
 
-        RequestAndPromise(RequestAndPromise&& other) noexcept
-            : mRequest(other.mRequest)
-            , mPromise(std::move(other.mPromise))
-        {
-            other.mRequest = nullptr;
-        }
-
-        RequestAndPromise& operator=(RequestAndPromise&& other) noexcept
-        {
-            if (this != &other)
-            {
-                mRequest = nullptr;
-                if (mPromise)
-                {
-                    mPromise.reset();
-                }
-
-                mRequest = other.mRequest;
-                mPromise = std::move(other.mPromise);
-
-                other.mRequest = nullptr;
-            }
-            return *this;
-        }
+        RequestAndPromise(RequestAndPromise&& other) noexcept = default;
+        RequestAndPromise& operator=(RequestAndPromise&& other) noexcept = default;
     };
 
     struct AsyncResource
@@ -1213,7 +1197,7 @@ CacheSender::CacheSender(
 {
 }
 
-std::future<void> CacheSender::sendAsync(LlmRequest& llmRequest) const
+std::future<void> CacheSender::sendAsync(std::shared_ptr<LlmRequest> const& llmRequest) const
 {
     return mImpl->sendAsync(llmRequest);
 }
@@ -1256,7 +1240,7 @@ CacheReceiver::CacheReceiver(
 {
 }
 
-std::future<void> CacheReceiver::receiveAsync(LlmRequest& llmRequest) const
+std::future<void> CacheReceiver::receiveAsync(std::shared_ptr<LlmRequest> const& llmRequest) const
 {
     return mImpl->requestAndReceiveAsyncMultiThreads(llmRequest);
 }

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
@@ -257,9 +257,10 @@ public:
 
     /// @brief Asynchronously respond to the request and send data.
     /// @param llmRequest Request object. Its data should be ready when called, and the data for this request
-    /// should remain valid until future synchronization.
+    /// should remain valid until future synchronization. Passed as shared_ptr so
+    /// the async worker keeps the LlmRequest alive until the future resolves.
     /// @return Once the data is fully sent, the future object will become valid.
-    [[nodiscard]] virtual std::future<void> sendAsync(LlmRequest& llmRequest) const;
+    [[nodiscard]] virtual std::future<void> sendAsync(std::shared_ptr<LlmRequest> const& llmRequest) const;
 
     /// @brief Return the internal communicator status.
     /// @return The communicator status.
@@ -314,9 +315,10 @@ public:
 
     /// @brief Asynchronously send a request to receive data.
     /// @param llmRequest Request object. Its data should be in an allocated but unwritten state when called, and the
-    /// data for this request should remain intact only after future synchronization.
+    /// data for this request should remain intact only after future synchronization. Passed as shared_ptr so
+    /// the async worker keeps the LlmRequest alive until the future resolves.
     /// @return Once the data is fully received, the future object will become valid.
-    [[nodiscard]] virtual std::future<void> receiveAsync(LlmRequest& llmRequest) const;
+    [[nodiscard]] virtual std::future<void> receiveAsync(std::shared_ptr<LlmRequest> const& llmRequest) const;
 
     virtual TransferSession sendRequestInfo(LlmRequest const& llmRequest);
 

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
@@ -20,8 +20,10 @@
 #include <future>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "tensorrt_llm/batch_manager/baseTransBuffer.h"
 #include "tensorrt_llm/batch_manager/cacheTransceiver.h"
 #include "tensorrt_llm/batch_manager/cacheTransferLayer.h"
 #include "tensorrt_llm/batch_manager/llmRequest.h"
@@ -102,6 +104,11 @@ public:
         }
     }
 
+    TransferSession(TransferSession const&) = delete;
+    TransferSession& operator=(TransferSession const&) = delete;
+    TransferSession(TransferSession&&) noexcept = default;
+    TransferSession& operator=(TransferSession&&) noexcept = default;
+
     [[nodiscard]] std::vector<Connection const*> const& getConnections() const;
 
     // should be called only during the initialization of the TransferSession
@@ -151,6 +158,11 @@ public:
         mCounterPartRanks = std::move(ranks);
     }
 
+    void addBufferIndexHolder(BufferIndexHolder&& holder)
+    {
+        mBufferIndexHolders.emplace_back(std::move(holder));
+    }
+
 private:
     std::vector<Connection const*> mConnections;
     std::vector<SizeType32> mCounterPartRanks;        // Ranks corresponding to mConnections indices
@@ -162,6 +174,7 @@ private:
     std::unique_ptr<KVCacheTimes> mTimes;
     int32_t mIndexFromEnd{0};
     BlockKey mLastBlockKey{};
+    std::vector<BufferIndexHolder> mBufferIndexHolders;
 };
 
 using UniqueToken = tensorrt_llm::runtime::UniqueToken;

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -253,7 +253,8 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             return bufferSizeForTarget;
         };
         auto bufferEleSizes = getBufferSizeForTarget();
-        auto cacheBufferId = mCacheTransBufferManagers[transferIndexerKCache]->assignBufferIndexForSend();
+        auto cacheBufferHolder = BufferIndexHolder::acquireSend(*mCacheTransBufferManagers[transferIndexerKCache]);
+        auto cacheBufferId = cacheBufferHolder.get();
         auto result = mCacheTransBufferManagers[transferIndexerKCache]->getOrAllocateSendBuffers(
             cacheBufferId, static_cast<int>(pPDomainSize * cPDomainSize), bufferEleSizes, bufferManager);
         auto& outputSplitCaches = std::get<0>(result);
@@ -380,7 +381,6 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
         {
             sendBufferFun(deviceId, pickUpConnections[0]);
         }
-        mCacheTransBufferManagers[transferIndexerKCache]->freeBufferIndexForSend(cacheBufferId);
     }
     session.setTime(TransferSession::kTimeTransmissions);
     session.setTime(TransferSession::kTimePostprocess);
@@ -487,13 +487,15 @@ void MLACacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& s
             auto bufferKind = transferIndexerKCache ? static_cast<uint8_t>(BufferKind::kKV_INDEXER)
                                                     : static_cast<uint8_t>(BufferKind::kKV);
             auto preAssignedId = connections[pickUpConnections[0]]->getPreAssignedBufferId(bufferKind);
+            BufferIndexHolder cacheBufferHolder;
             if (preAssignedId.has_value())
             {
                 cacheBufferId = static_cast<int>(*preAssignedId);
             }
             else
             {
-                cacheBufferId = mCacheTransBufferManagers[transferIndexerKCache]->assignBufferIndexForRecv();
+                cacheBufferHolder = BufferIndexHolder::acquireRecv(*mCacheTransBufferManagers[transferIndexerKCache]);
+                cacheBufferId = cacheBufferHolder.get();
             }
 
             auto targetNum = pickUpConnections.size();
@@ -642,10 +644,6 @@ void MLACacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& s
             bufferManager.getStream().synchronize();
         }
 
-        if (cacheBufferId.has_value())
-        {
-            mCacheTransBufferManagers[transferIndexerKCache]->freeBufferIndexForRecv(cacheBufferId);
-        }
     }
     session.setTime(TransferSession::kTimePostprocess);
 

--- a/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
@@ -148,7 +148,8 @@ void RnnCacheFormatter::format(TransferSession& session)
             / targetInfo.mDomainTPSize;
     }
 
-    auto cacheBufferId = mRnnCacheTransBufferManager->assignBufferIndexForSend();
+    auto cacheBufferHolder = BufferIndexHolder::acquireSend(*mRnnCacheTransBufferManager);
+    auto cacheBufferId = cacheBufferHolder.get();
     auto allocationResult = mRnnCacheTransBufferManager->getOrAllocateSendBuffers(
         cacheBufferId, static_cast<int>(bufferTargetNum), bufferSizesPerTarget, bufferManager);
     auto& outputBuffers = std::get<0>(allocationResult);
@@ -191,7 +192,6 @@ void RnnCacheFormatter::format(TransferSession& session)
 
     session.setTime(TransferSession::kTimeTransmissions);
 
-    mRnnCacheTransBufferManager->freeBufferIndexForSend(cacheBufferId);
     session.setTime(TransferSession::kTimePostprocess);
 
     TLLM_LOG_DEBUG(
@@ -312,6 +312,7 @@ void RnnCacheFormatter::unformat(TransferSession& session)
     size_t remainNoCoverSourceNum = 0;
     size_t bufferCoverSourceNum = 0;
     std::optional<int> cacheBufferId = std::nullopt;
+    BufferIndexHolder cacheBufferHolder;
 
     auto preAssignedRnnId
         = connections[pickUpConnections[0]]->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kRNN));
@@ -321,7 +322,8 @@ void RnnCacheFormatter::unformat(TransferSession& session)
     }
     else
     {
-        cacheBufferId = mRnnCacheTransBufferManager->assignBufferIndexForRecv();
+        cacheBufferHolder = BufferIndexHolder::acquireRecv(*mRnnCacheTransBufferManager);
+        cacheBufferId = cacheBufferHolder.get();
     }
 
     auto allocationResult = mRnnCacheTransBufferManager->getOrAllocateRecvBuffers(
@@ -469,10 +471,6 @@ void RnnCacheFormatter::unformat(TransferSession& session)
 
     bufferManager.getStream().synchronize();
 
-    if (cacheBufferId.has_value())
-    {
-        mRnnCacheTransBufferManager->freeBufferIndexForRecv(cacheBufferId);
-    }
     session.setTime(TransferSession::kTimePostprocess);
 
     TLLM_LOG_DEBUG(

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -921,7 +921,7 @@ void TrtGptModelInflightBatching::forwardSync()
                     TLLM_CHECK_WITH_INFO(mCacheTransceiver,
                         "Disaggregated serving is not enabled, please check the configuration of "
                         "cacheTransceiverConfig.");
-                    mCacheTransceiver->respondAndSendAsync(llmReq.get());
+                    mCacheTransceiver->respondAndSendAsync(llmReq);
                 }
                 mSeqSlotManager->freeSequenceSlot(llmReq->mRequestId);
             }
@@ -1602,11 +1602,11 @@ void TrtGptModelInflightBatching::prepareDisaggGenInitRequests(
             mCacheTransceiver, "Disaggregated serving is not enabled, please check the configuration.");
         if (common::getEnvDisableKVCacheTransferOverlap())
         {
-            mCacheTransceiver->requestAndReceiveSync(newGenReq.get());
+            mCacheTransceiver->requestAndReceiveSync(newGenReq);
         }
         else
         {
-            mCacheTransceiver->requestAndReceiveAsync(newGenReq.get());
+            mCacheTransceiver->requestAndReceiveAsync(newGenReq);
         }
     }
     if (!common::getEnvDisableKVCacheTransferOverlap())

--- a/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
@@ -46,17 +46,17 @@ public:
     // using BaseCacheTransceiver::BaseCacheTransceiver; // Inherit constructors
     NB_TRAMPOLINE(tb::BaseCacheTransceiver, 6);
 
-    void respondAndSendAsync(tb::LlmRequest* llmRequest) override
+    void respondAndSendAsync(std::shared_ptr<tb::LlmRequest> llmRequest) override
     {
         NB_OVERRIDE_PURE(respondAndSendAsync, llmRequest);
     }
 
-    void requestAndReceiveSync(tb::LlmRequest* llmRequest) override
+    void requestAndReceiveSync(std::shared_ptr<tb::LlmRequest> llmRequest) override
     {
         NB_OVERRIDE_PURE(requestAndReceiveSync, llmRequest);
     }
 
-    void requestAndReceiveAsync(tb::LlmRequest* llmRequest) override
+    void requestAndReceiveAsync(std::shared_ptr<tb::LlmRequest> llmRequest) override
     {
         NB_OVERRIDE_PURE(requestAndReceiveAsync, llmRequest);
     }
@@ -77,7 +77,7 @@ public:
         NB_OVERRIDE_PURE(checkGenTransferComplete);
     }
 
-    bool cancelRequest(tb::LlmRequest* llmRequest) override
+    bool cancelRequest(std::shared_ptr<tb::LlmRequest> llmRequest) override
     {
         NB_OVERRIDE_PURE(cancelRequest, llmRequest);
     }

--- a/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
@@ -348,11 +348,11 @@ protected:
                     TLLM_CUDA_CHECK(cudaMemset(it->data(), llmRequest->getPromptLen(), it->getSizeInBytes()));
                 }
             }
-            mFutures.emplace_back(mSender->sendAsync(*llmRequest));
+            mFutures.emplace_back(mSender->sendAsync(llmRequest));
         }
         else
         {
-            auto future = mRequester->receiveAsync(*llmRequest);
+            auto future = mRequester->receiveAsync(llmRequest);
             future.get();
             TLLM_CUDA_CHECK(cudaDeviceSynchronize());
             auto blockRange = BlockRange::fromAllBlockIds(*mManager, llmRequest->mRequestId);
@@ -974,7 +974,7 @@ protected:
         auto const onlyWindowSize = blockManager.getPoolWindowSize(0);
 
         blockManager.getBufferManager(onlyWindowSize).getStream().synchronize();
-        auto future = mSender->sendAsync(*llmRequest);
+        auto future = mSender->sendAsync(llmRequest);
         return future;
     }
 
@@ -984,7 +984,7 @@ protected:
         auto constexpr beamWidth{1};
         auto& llmRequest = request->mLlmRequest;
         mManager->addSequence(llmRequest->mRequestId, llmRequest->getNumTokens(beamIdx), beamWidth, llmRequest);
-        return mRequester->receiveAsync(*llmRequest);
+        return mRequester->receiveAsync(llmRequest);
     }
 
     void generationVerifyKVCache(std::shared_ptr<WrappedLlmRequest> const& request)

--- a/docs/source/developer-guide/disagg-kv-transfer-hardening-plan.md
+++ b/docs/source/developer-guide/disagg-kv-transfer-hardening-plan.md
@@ -1,0 +1,471 @@
+# Disaggregated KV Transfer Hardening Plan
+
+This note describes follow-up hardening work for disaggregated KV cache transfer.
+It assumes the conservative request-lifetime patch is already in place: async
+transceiver APIs and worker/future tracking structures carry
+`std::shared_ptr<LlmRequest>` instead of raw `LlmRequest*`.
+
+That patch fixes one class of bug: stale access to the `LlmRequest` object
+itself. It does not, by itself, prove that all resources referenced by a live
+`LlmRequest` are still valid. KV cache blocks, sequence slots, transfer buffer
+pool entries, and cache-manager request mappings have separate lifetimes and
+need their own ownership rules.
+
+## Goals
+
+1. Avoid transfer buffer-index leaks on exceptions and early returns.
+2. Avoid double termination after context transfer completion.
+3. Improve diagnostics for futures, buffer pools, request IDs, and worker drain.
+4. Harden unknown exception handling without pretending the transport is healthy.
+5. Prevent `_terminate_request()` while context KV send is still in progress.
+6. Define a policy for broad `_handle_errors()` when generation KV receive is in
+   flight.
+
+## Non-Goals
+
+- Do not make stuck transport operations magically interruptible.
+- Do not erase a C++ future before the worker has reached quiescence.
+- Do not report `cancel_request()` success for an already in-flight transfer
+  unless the worker is known to have stopped touching request and KV resources.
+- Do not keep serving after an unknown transport/backend exception unless the
+  backend provides a clear health guarantee.
+
+## 1. RAII BufferIndexHolder
+
+### Problem
+
+Several formatter paths manually pair:
+
+- `assignBufferIndexForSend()` with `freeBufferIndexForSend(...)`
+- `assignBufferIndexForRecv()` with `freeBufferIndexForRecv(...)`
+
+Important sites:
+
+- `cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp`
+  - send path around `assignBufferIndexForSend()`
+  - receive path around `assignBufferIndexForRecv()`
+- `cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp`
+  - send path for MLA/indexer cache
+  - receive path for MLA/indexer cache
+- `cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp`
+  - send path
+  - receive path
+- `cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp`
+  - Agent receive pre-assignment path that calls `assignBufferIndexForRecv()`
+    before sending request/buffer info to peers.
+
+Manual free is fragile. Any exception, `TLLM_CHECK`, or early return between
+assignment and free can leave a pool slot marked in use. That can wedge later
+transfers even if the request-level logic is otherwise correct.
+
+### Proposed API
+
+Add a small move-only RAII holder near `BaseTransBufferManager`, for example in
+`cpp/tensorrt_llm/batch_manager/baseTransBuffer.h`.
+
+```cpp
+class BufferIndexHolder
+{
+public:
+    enum class Direction
+    {
+        kSend,
+        kRecv,
+    };
+
+    static BufferIndexHolder assignSend(BaseTransBufferManager& manager);
+    static BufferIndexHolder assignRecv(BaseTransBufferManager& manager);
+
+    // For pre-assigned ids that are owned by a caller but consumed later, allow
+    // construction with an existing id and explicit ownership.
+    BufferIndexHolder(BaseTransBufferManager& manager, Direction direction,
+        std::optional<int> id, bool owns) noexcept;
+
+    BufferIndexHolder(BufferIndexHolder const&) = delete;
+    BufferIndexHolder& operator=(BufferIndexHolder const&) = delete;
+    BufferIndexHolder(BufferIndexHolder&& other) noexcept;
+    BufferIndexHolder& operator=(BufferIndexHolder&& other) noexcept;
+
+    ~BufferIndexHolder() noexcept;
+
+    std::optional<int> get() const noexcept;
+    std::optional<int> release() noexcept;
+    void reset() noexcept;
+
+private:
+    BaseTransBufferManager* mManager{nullptr};
+    Direction mDirection{Direction::kSend};
+    std::optional<int> mId{std::nullopt};
+    bool mOwns{false};
+};
+```
+
+Destructor behavior:
+
+- If `mOwns == false`, do nothing.
+- If `mId == std::nullopt`, do nothing.
+- If direction is send, call `freeBufferIndexForSend(mId)`.
+- If direction is recv, call `freeBufferIndexForRecv(mId)`.
+- Destructors must be `noexcept`. If the free path can throw today, normalize it
+  first or catch/log in the holder destructor.
+
+### Usage Pattern
+
+For a locally assigned send buffer index:
+
+```cpp
+auto bufferId = BufferIndexHolder::assignSend(*mCacheTransBufferManager);
+auto result = mCacheTransBufferManager->getOrAllocateSendBuffers(
+    bufferId.get(), targetNum, bufferSizes, bufferManager);
+
+// Any exception before function exit frees the slot.
+// Normal exit also frees the slot automatically.
+```
+
+For a locally assigned receive buffer index:
+
+```cpp
+auto bufferId = BufferIndexHolder::assignRecv(*mCacheTransBufferManager);
+auto result = mCacheTransBufferManager->getOrAllocateRecvBuffers(
+    bufferId.get(), targetNum, bufferSizes, bufferManager);
+```
+
+For pre-assigned AgentConnection ids, ownership is trickier:
+
+- If the id is assigned in the same formatter scope, use a holder directly.
+- If `dataTransceiver.cpp` assigns ids and passes them through connection
+  metadata for a later formatter to consume, do not let a stack holder free the
+  id at the end of `sendRequestInfo()`. That would be too early.
+- Prefer storing recv buffer-index holders in `TransferSession`, or an
+  equivalent per-request transfer object, so ownership spans from pre-assignment
+  through `CacheFormatter::unformat()` / `MLACacheFormatter::unformat()` /
+  `RnnCacheFormatter::unformat()`.
+- Once the formatter takes ownership, avoid a second manual free.
+
+### Implementation Steps
+
+1. Add `BufferIndexHolder` and unit tests for move, release, reset, send free,
+   and recv free.
+2. Replace manual send/recv buffer-index frees in `cacheFormatter.cpp`.
+3. Replace manual send/recv buffer-index frees in `mlaCacheFormatter.cpp`.
+4. Replace manual send/recv buffer-index frees in `rnnCacheFormatter.cpp`.
+5. For AgentConnection pre-assigned recv ids in `dataTransceiver.cpp`, decide
+   and implement the ownership handoff:
+   - either store holders in `TransferSession`, or
+   - store them in a request-scoped object owned by the receive worker until
+     `unformat()` completes.
+6. Add debug logs on assign/free with request id, direction, buffer id, and
+   manager/buffer kind.
+7. Add a stress test that injects exceptions after assignment and verifies the
+   next transfer can still acquire a slot.
+
+## 2. `is_disagg_context_complete_state` Guard
+
+This guard is already present in the conservative PR. The intended shape in
+`_handle_responses()` is:
+
+```python
+if request.is_disagg_context_complete_state:
+    # Transfer completion already handled cleanup for this request.
+    pass
+elif request.is_disagg_context_transmission_state:
+    # Do not terminate while KV send is still in flight.
+    pass
+elif self.enable_partial_reuse_for_disagg and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1:
+    requests_to_terminate.append(request)
+else:
+    requests_to_terminate.append(request)
+```
+
+The current PR includes the complete-state guard. The next hardening pass should
+also make the in-transmission guard explicit and place it before the partial
+reuse branch, so partial reuse cannot bypass the transmission check.
+
+## 3. Prevent `_terminate_request()` During Context Transmission
+
+### Problem
+
+For context/prefill send, `AsyncTransferManager.start_transfer()` is the object
+that tracks in-flight context transfers. It stores the request in
+`_requests_in_transfer`, optionally pins blocks with
+`kv_cache_manager.store_blocks_for_reuse(request, True)`, and only unpins in
+`end_transfer()`.
+
+Calling `_terminate_request()` while `request.is_disagg_context_transmission_state`
+is true can fight that ownership model. Even if `shared_ptr<LlmRequest>` keeps
+the request object alive, `_terminate_request()` may call
+`resource_manager.free_resources(request)`, and resource managers can remove
+sequence/block mappings that the sender still needs.
+
+### Proposed Python Guard
+
+Add a helper:
+
+```python
+def _can_terminate_request_now(self, request: LlmRequest) -> bool:
+    if self.kv_cache_transceiver is None:
+        return True
+    if request.is_disagg_context_transmission_state:
+        return False
+    return True
+```
+
+Use it in all normal termination paths that are not fatal broad-error cleanup:
+
+- `_handle_responses()`
+- `_end_transfer_and_maybe_terminate()`
+- request-scoped `_handle_errors(..., requests=[...])`
+- cancellation handling after `finish_by_reason(...)`
+
+For `_handle_responses()`, prefer the explicit ordering:
+
+```python
+if request.is_disagg_context_complete_state:
+    pass
+elif request.is_disagg_context_transmission_state:
+    pass
+elif partial_reuse_cleanup_condition:
+    requests_to_terminate.append(request)
+else:
+    requests_to_terminate.append(request)
+```
+
+This means a context request can leave `active_requests` but remain owned by
+`AsyncTransferManager.requests_in_transfer()`. When
+`_check_disagg_ctx_cache_transfer_status()` later sees completion, it calls
+`_end_transfer_and_maybe_terminate()`, which calls
+`async_transfer_manager.end_transfer(request)` and only then terminates.
+
+### Tests
+
+Add a Python unit test with a fake transceiver / fake transfer manager:
+
+1. Put a context-only request in `DISAGG_CONTEXT_TRANS_IN_PROGRESS`.
+2. Force `_handle_responses()` to see `request_done`.
+3. Assert `_terminate_request()` is not called.
+4. Simulate `_check_disagg_ctx_cache_transfer_status()` completion.
+5. Assert termination happens after `end_transfer()`.
+
+## 4. Broad `_handle_errors()` Policy for In-Flight Generation Transfers
+
+### Problem
+
+Generation receive is different from context send:
+
+- It is tracked by C++ `mRequesterFutures`.
+- The receiver worker can be actively writing destination KV blocks.
+- There is no Python `AsyncTransferManager` equivalent that pins/unpins the
+  destination KV resources for receive.
+
+The broad error path:
+
+```python
+def _handle_errors(self, error_msg=None, *, requests=None):
+    failed_requests = requests if requests is not None else self.active_requests
+    if requests is None:
+        self.active_requests.clear()
+    ...
+    for request in failed_requests:
+        self._terminate_request(request)
+```
+
+does not filter out `DISAGG_GENERATION_TRANS_IN_PROGRESS`. If it frees all
+active requests while a generation receive worker is still in flight,
+`shared_ptr<LlmRequest>` keeps the request object alive, but it does not pin the
+destination KV blocks. The worker may still be writing to resources that the
+resource manager has removed or reused.
+
+### Recommended Policy
+
+Treat broad `_handle_errors(requests=None)` as fatal if any active request is in
+disaggregated transfer:
+
+```python
+inflight_transfer_requests = [
+    request for request in self.active_requests
+    if request.is_disagg_context_transmission_state
+    or request.is_disagg_generation_transmission_in_progress
+]
+
+if requests is None and inflight_transfer_requests:
+    self._mark_unhealthy_for_restart(...)
+    self.should_stop_processing = True
+    self.shutdown_event.set()
+    # Do not call _terminate_request() on in-flight transfer requests.
+    # Let process restart release GPU and transport resources.
+```
+
+Reasoning:
+
+- Broad `_handle_errors()` callers include hang detector, decode exceptions,
+  forward exceptions, sampling/setup/update exceptions.
+- These are not narrow request-local cleanup paths.
+- If a worker is inside UCX/NIXL/MPI or writing KV blocks, we do not have a
+  proven safe in-process recovery protocol.
+- The deployment already has canary/health checking that can restart an
+  unhealthy pod.
+
+The fatal path can still enqueue client error responses if that is safe and
+non-blocking, but it should not free in-flight KV transfer resources and then
+continue serving.
+
+### Alternative: Graceful Deferred Termination
+
+If we later need graceful recovery instead of process restart, add real
+generation-transfer tracking:
+
+1. Have `check_gen_transfer_status()` return completed/error request ids, like
+   context status does.
+2. Add a Python `generation_transfer_manager` that records in-flight generation
+   receives and blocks termination while they are active.
+3. Add `_pending_termination_after_transfer[request_id]`.
+4. On request-local error/cancel while generation transfer is in flight:
+   - mark pending error/cancel,
+   - keep resources alive,
+   - do not free the request,
+   - let `check_gen_transfer_status()` complete the future,
+   - then terminate and free resources.
+5. If the future never becomes ready, rely on unhealthy-process restart.
+
+Do not erase the C++ future merely because Python wants cleanup. Erasing the
+future is only safe after the worker has completed or the worker has a proven
+cancel/quiescence handshake.
+
+## 5. Better Diagnostics
+
+Add diagnostics that are actionable but not noisy at normal INFO level.
+
+### Future Tracking
+
+In `CacheTransceiver`:
+
+- On insertion into `mSenderFutures` / `mRequesterFutures`, log request id,
+  pointer address, state, vector size, and whether overlap is enabled.
+- On status poll, log at DEBUG:
+  - number of tracked sender/requester futures,
+  - number ready,
+  - number selected for completion,
+  - oldest transfer age.
+- On timeout or repeated non-ready status, log at WARNING with request id,
+  elapsed time, transfer start time, and vector size.
+- On erase, log request id, final state, and vector size after erase.
+
+### Buffer Pools
+
+In `BaseTransBufferManager`:
+
+- Log assign/free with direction, buffer id, buffer kind, configured count, and
+  dynamic-buffer mode.
+- Expose a debug-only method to count outstanding send/recv slots.
+- On destructor or shutdown, warn if any non-dynamic buffer slot is still
+  marked in use.
+
+### Worker Drain
+
+In `CacheSender::Impl` and `CacheReceiver::Impl`:
+
+- Log worker start/stop and request ids currently queued.
+- On destructor/drain, log queue sizes and number of futures being joined.
+- When a worker sets a promise exception, include request id and context request
+  id when available.
+
+### Python Error Paths
+
+In `_handle_errors()`:
+
+- Log whether `requests` is `None` or request-scoped.
+- Log request ids grouped by state.
+- If broad error cleanup sees in-flight transfer requests, emit a single
+  high-severity log explaining that the process is being marked unhealthy and
+  in-flight transfer resources are intentionally not freed in-process.
+
+## 6. `catch (...)` Hardening
+
+### Current Gap
+
+Several worker paths catch `std::exception`, set promise exceptions, and keep
+going. Unknown non-`std::exception` failures may bypass those handlers. Also,
+continuing to serve after unknown transport/backend exceptions is risky because
+the connection manager, CUDA stream, or transport backend may be in an unknown
+state.
+
+### Proposed C++ Pattern
+
+Add catch-all blocks immediately after existing `catch (std::exception const&)`
+blocks in worker/future completion paths:
+
+```cpp
+catch (...)
+{
+    auto error = std::runtime_error("Unknown exception in KV cache transfer worker");
+    TLLM_LOG_ERROR("%s request id: %ld", error.what(), requestId);
+    markUnhealthy(error.what());
+    promise.set_exception(std::make_exception_ptr(error));
+}
+```
+
+Candidate locations:
+
+- `CacheSender::Impl::sendAndRemoveResponse`
+- `CacheSender::Impl::response`
+- `CacheReceiver::Impl::request`
+- `CacheTransceiver::checkContextTransferStatus`
+- `CacheTransceiver::checkGenTransferStatus`
+- async send/receive helper lambdas launched with `std::async`
+
+### Health Semantics
+
+Prefer fail-closed:
+
+- Convert the unknown exception to `std::runtime_error` for the future/promise.
+- Mark the cache transceiver or process unhealthy.
+- Surface the failure to Python.
+- Let Python stop accepting work and rely on canary/pod restart.
+
+Avoid catching unknown exceptions and continuing to serve unless the specific
+transport backend guarantees it is still valid after that exception class.
+
+## 7. Validation Plan
+
+### Unit Tests
+
+- RAII holder frees send/recv ids on normal scope exit.
+- RAII holder frees send/recv ids on exception.
+- Move construction and move assignment transfer ownership exactly once.
+- Pre-assigned/borrowed ids are not double-freed.
+- `_handle_responses()` does not terminate a context request in
+  `DISAGG_CONTEXT_TRANS_IN_PROGRESS`.
+- `_handle_errors(requests=None)` with in-flight generation transfer marks
+  unhealthy and avoids `_terminate_request()` for those requests.
+
+### Integration / Fault Injection
+
+- Inject exception after send buffer assignment before manual free location.
+  Verify subsequent transfer can acquire the slot.
+- Inject exception after recv buffer assignment before concat/free. Verify slot
+  is released.
+- Simulate a generation receive future that never becomes ready, then trigger
+  broad `_handle_errors()`. Verify process is marked unhealthy and no
+  in-process free happens for the in-flight receive request.
+- Simulate context send in progress and force `_handle_responses()` to emit the
+  logical `LlmResponse`. Verify resource free waits until
+  `AsyncTransferManager.end_transfer()`.
+
+### Observability Checks
+
+- Logs include request id for future insertion, poll, completion, erase, and
+  exception.
+- Buffer pool logs show balanced assign/free counts under fault injection.
+- Broad-error fatal path emits one clear health log, not per-iteration spam.
+
+## Suggested Implementation Order
+
+1. Add `_can_terminate_request_now()` and context transmission guard in Python.
+2. Decide and implement broad `_handle_errors()` policy for in-flight generation
+   transfer. Prefer fail-closed/unhealthy restart first.
+3. Add `BufferIndexHolder` for straightforward local send/recv formatter sites.
+4. Handle AgentConnection pre-assigned recv ids with a request/session-scoped
+   holder.
+5. Add diagnostics.
+6. Add `catch (...)` hardening and unhealthy marking.
+7. Add fault-injection tests.

--- a/docs/source/developer-guide/disagg-kv-transfer-hardening-plan.md
+++ b/docs/source/developer-guide/disagg-kv-transfer-hardening-plan.md
@@ -30,6 +30,36 @@ need their own ownership rules.
 - Do not keep serving after an unknown transport/backend exception unless the
   backend provides a clear health guarantee.
 
+## Current Implementation Status
+
+This branch has started the plan with the pieces that are local and low risk:
+
+- `BufferIndexHolder` now owns send/recv transfer buffer slots and releases them
+  on scope exit.
+- `TransferSession` owns AgentConnection pre-assigned receive buffer slots from
+  pre-assignment through formatter `unformat()`.
+- `CacheFormatter`, `MLACacheFormatter`, and `RnnCacheFormatter` use RAII
+  holders instead of manual free calls.
+- `_handle_responses()` now checks
+  `request.is_disagg_context_transmission_state` before the partial-reuse
+  cleanup branch.
+- `_terminate_request()` now defers termination while context KV send is in
+  progress, including the disaggregated PP termination handler path.
+- Broad `_handle_errors(requests=None)` now fails closed when generation KV
+  receive is in flight: it emits client error responses where possible, clears
+  local scheduling queues, marks the executor shut down, and intentionally does
+  not free active request resources in-process.
+- C++ worker/future paths now have catch-all handling for unknown exceptions and
+  convert them into promise/future errors.
+
+Still remaining:
+
+- Add focused unit/fault-injection tests.
+- Add an explicit process/transceiver unhealthy flag if we want C++ to expose
+  health directly rather than surfacing errors through Python futures.
+- If graceful in-process recovery is required later, add real generation receive
+  transfer tracking instead of relying on fail-closed restart.
+
 ## 1. RAII BufferIndexHolder
 
 ### Problem

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -524,7 +524,7 @@ class PyExecutor:
         self._disagg_pp_termination_handler = None
         if self.dist.pp_size > 1 and self.enable_kv_cache_reuse and self.kv_cache_transceiver:
             self._disagg_pp_termination_handler = DisaggPPTerminationHandler(
-                self.dist, self._do_terminate_request)
+                self.dist, self._do_terminate_request_if_safe)
 
         if self.dist.pp_size > 1:
             self.event_loop = self._executor_loop_pp
@@ -3369,10 +3369,17 @@ class PyExecutor:
                        requests: Optional[List[LlmRequest]] = None):
         error_responses: Dict[int, LlmResponse] = {}
         error_msg = error_msg or "error"
-        failed_requests = requests if requests is not None else self.active_requests
+        if requests is None and self._has_inflight_generation_transfers(
+                self.active_requests):
+            self._fail_closed_for_inflight_generation_transfer(error_msg)
+            return
+
+        failed_requests = list(
+            requests if requests is not None else self.active_requests)
         for request in failed_requests:
             req_id = request.py_request_id
-            request.state = LlmRequestState.GENERATION_COMPLETE
+            if not request.is_disagg_context_transmission_state:
+                request.state = LlmRequestState.GENERATION_COMPLETE
             error_responses[req_id] = LlmResponse(
                 request_id=req_id,
                 error_msg=error_msg,
@@ -3388,7 +3395,58 @@ class PyExecutor:
         for request in failed_requests:
             self._terminate_request(request)
 
-    def _terminate_request(self, request: LlmRequest):
+    def _has_inflight_generation_transfers(self,
+                                           requests: Iterable[LlmRequest]
+                                           ) -> bool:
+        return any(req.is_disagg_generation_transmission_in_progress
+                   for req in requests)
+
+    def _fail_closed_for_inflight_generation_transfer(self, error_msg: str):
+        failed_requests = list(self.active_requests)
+        in_flight_req_ids = [
+            req.py_request_id for req in failed_requests
+            if req.is_disagg_generation_transmission_in_progress
+        ]
+        logger.error(
+            "Fatal executor error while disaggregated generation KV transfer is in flight. "
+            "Failing closed without freeing active request resources. "
+            f"in_flight_generation_request_ids={in_flight_req_ids}, error={error_msg}"
+        )
+
+        error_responses: Dict[int, LlmResponse] = {}
+        for request in failed_requests:
+            req_id = request.py_request_id
+            error_responses[req_id] = LlmResponse(
+                request_id=req_id,
+                error_msg=error_msg,
+                client_id=request.py_client_id)
+
+        self.active_requests.clear()
+        self.waiting_queue.clear()
+        self.request_accumulated.clear()
+        self.control_requests.clear()
+        self.is_shutdown = True
+        self._enqueue_responses(list(error_responses.items()))
+        with self.response_cv:
+            self.response_cv.notify_all()
+
+    def _can_terminate_request_now(self, request: LlmRequest) -> bool:
+        if request.is_disagg_context_transmission_state:
+            logger.warning(
+                f"Deferring termination for request {request.py_request_id} "
+                "because context KV transfer is still in progress")
+            return False
+        return True
+
+    def _do_terminate_request_if_safe(self, request: LlmRequest) -> bool:
+        if not self._can_terminate_request_now(request):
+            return False
+        self._do_terminate_request(request)
+        return True
+
+    def _terminate_request(self, request: LlmRequest) -> bool:
+        if not self._can_terminate_request_now(request):
+            return False
         # Dummy requests don't participate in disagg KV cache transfers,
         # so they must bypass the PP termination handler to avoid stale
         # sequences in the KV cache manager (the handler delays removal,
@@ -3398,6 +3456,7 @@ class PyExecutor:
             self._disagg_pp_termination_handler.terminate(request)
         else:
             self._do_terminate_request(request)
+        return True
 
     def _do_terminate_request(self, request: LlmRequest):
         self.resource_manager.free_resources(request)
@@ -3621,11 +3680,14 @@ class PyExecutor:
                 if request.is_disagg_context_complete_state:
                     # Transfer completion already handled cleanup for this request.
                     pass
+                elif request.is_disagg_context_transmission_state:
+                    # AsyncTransferManager still owns the transfer lifetime.
+                    # Cleanup will run from _end_transfer_and_maybe_terminate().
+                    pass
                 elif self.enable_partial_reuse_for_disagg and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1:
                     requests_to_terminate.append(request)
                 else:
-                    if not request.is_disagg_context_transmission_state:
-                        requests_to_terminate.append(request)
+                    requests_to_terminate.append(request)
             else:
                 new_active_requests.append(request)
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3618,7 +3618,10 @@ class PyExecutor:
                 # If partial reuse is enabled, and the KV cache manager is not VSWA, and the PP size is 1,
                 # then we need to terminate the request. TODO: Remove this once disagg support from KVCache reuse
                 # path is fixed.
-                if self.enable_partial_reuse_for_disagg and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1:
+                if request.is_disagg_context_complete_state:
+                    # Transfer completion already handled cleanup for this request.
+                    pass
+                elif self.enable_partial_reuse_for_disagg and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1:
                     requests_to_terminate.append(request)
                 else:
                     if not request.is_disagg_context_transmission_state:

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py
@@ -78,6 +78,11 @@ class WaitingQueue(ABC):
         pass
 
     @abstractmethod
+    def clear(self) -> None:
+        """Remove all requests from the queue."""
+        pass
+
+    @abstractmethod
     def __bool__(self) -> bool:
         """Check if queue has any requests."""
         pass
@@ -144,6 +149,10 @@ class FCFSWaitingQueue(deque, WaitingQueue):
         filtered_requests = [req for req in self if req.id not in request_ids]
         self.clear()
         self.extend(filtered_requests)
+
+    def clear(self) -> None:
+        """Remove all requests from the queue."""
+        super().clear()
 
     def __bool__(self) -> bool:
         """Check if queue has any requests."""
@@ -247,6 +256,10 @@ class PriorityWaitingQueue(WaitingQueue):
         """Remove requests with the given IDs."""
         self._heap = [e for e in self._heap if e[2].id not in request_ids]
         heapq.heapify(self._heap)
+
+    def clear(self) -> None:
+        """Remove all requests from the queue."""
+        self._heap.clear()
 
     def __bool__(self) -> bool:
         return len(self._heap) > 0


### PR DESCRIPTION
Draft conservative subset of #13056, based on `4e69c14f732a6e6afce4f71616db5b5cd2b10530`.

## Summary

This PR hardens the lifetime and cleanup rules around disaggregated KV cache transfer.

The first key change is to carry `std::shared_ptr<LlmRequest>` through the async transceiver APIs and the C++ future/worker tracking structures, instead of passing raw `LlmRequest*` / `LlmRequest&` into async work. That makes the request lifetime match the actual async work lifetime: if Python drops its reference while C++ is still transferring or polling the future, the C++ side still owns a strong reference and does not dereference freed memory.

The second key change is to avoid freeing transfer-adjacent resources while transfer ownership is still active:

- transfer buffer pool ids are owned by RAII holders,
- AgentConnection pre-assigned receive buffer ids are owned by `TransferSession`,
- context requests are not terminated while context KV send is still in progress,
- broad Python error cleanup fails closed instead of freeing active resources when generation KV receive is in flight.

This PR intentionally does **not** attempt to recover a stuck in-flight KV transfer. If a transfer is wedged inside the transport, the conservative behavior is still to let external health checking / pod restart handle the unhealthy process.

The remaining and completed hardening work is tracked in
`docs/source/developer-guide/disagg-kv-transfer-hardening-plan.md`. That plan
covers RAII buffer-index holders, context-transfer termination deferral,
broad-error handling for in-flight generation receive, diagnostics, and
`catch (...)` fail-closed behavior.

## What This Keeps

- Pass `std::shared_ptr<LlmRequest>` through `BaseCacheTransceiver` / `CacheTransceiver` async APIs.
- Store `std::shared_ptr<LlmRequest>` in `mSenderFutures` and `mRequesterFutures`.
- Store `std::shared_ptr<LlmRequest>` in the sender response queue and receiver worker queue.
- Capture `std::shared_ptr<LlmRequest>` in the async receive task.
- Update production call sites and cache transceiver unit tests to pass the existing shared request object.
- Add a Python guard for `is_disagg_context_complete_state` so a request already completed by transfer cleanup is not terminated a second time.
- Add an explicit `is_disagg_context_transmission_state` guard before partial-reuse cleanup in `_handle_responses()`.
- Defer `_terminate_request()` while context KV send is still in progress, including the disaggregated PP termination path.
- Add `BufferIndexHolder` RAII ownership for send/recv transfer buffer ids.
- Move AgentConnection pre-assigned receive buffer-id ownership into `TransferSession`.
- Make broad `_handle_errors(requests=None)` fail closed when generation KV receive is still in flight.
- Add catch-all hardening around C++ worker/future paths so unknown exceptions become promise/future errors instead of escaping silently.

## What This Leaves Out

- No in-flight cancel flag plumbing for sender/receiver workers.
- No change that makes `cancel_request()` return success for a KV transfer that is already in flight.
- No C++ timeout path that calls `cancelRequest()`, erases a future, and allows Python cleanup before worker quiescence.
- No new timeout recovery behavior beyond the existing queued-only cancel semantics.
- No full graceful in-process recovery for an already in-flight generation receive. That would require Python-side generation transfer tracking and completion/error ids from `check_gen_transfer_status()`.
- No dedicated C++ unhealthy flag yet; unknown C++ transfer failures are surfaced through futures/promises and Python fail-closed behavior.

## Residual Risks

- The generation-transfer broad-error path is intentionally fail-closed, not graceful recovery. Active requests get error responses where possible, but queued/not-yet-active requests may rely on process restart or connection teardown rather than receiving an explicit per-request error.
- A stuck transport worker can still block C++ teardown if the process tries to destruct/join the worker in-process. This PR relies on external health checks / pod restart for true transport wedges.
- `std::shared_ptr<LlmRequest>` protects the request object lifetime, not every external resource. This PR adds context-transfer termination deferral and generation fail-closed behavior for the known resource-free hazards, but it does not implement a general generation receive resource pinning manager.
- `BufferIndexHolder` / `TransferSession` ownership assumes transfer buffer managers outlive active transfer sessions. That matches the current object graph, but it still needs C++ build and fault-injection coverage.
- Catch-all C++ handlers convert unknown exceptions into future/promise errors, but they do not yet set a dedicated C++ unhealthy flag. Python only observes those failures when the future status path is polled.

## Request Lifetime Before

Before this change, Python owned the effective lifetime of the request object, while C++ async transfer state only kept raw pointers/references.

The most concrete generation-side owner-drop path is the broad Python error cleanup path, not the timeout `cancel_request(request)` path.

### Generation-Side Error Cleanup Path

For generation receive, the risky sequence is:

1. `_recv_disagg_gen_cache()` starts async receive with:
   - `self.kv_cache_transceiver.request_and_receive_async(req)`
2. C++ stores raw request addresses in generation transfer state:
   - `CacheTransceiver::mRequesterFutures` stores `LlmRequest*`
   - `CacheReceiver` worker queue stores `LlmRequest*`
3. A broad Python error path calls `_handle_errors()` with `requests=None`.
4. `_handle_errors()` chooses every active request:
   - `failed_requests = self.active_requests`
5. It clears `active_requests`:
   - `self.active_requests.clear()`
6. It terminates every failed request:
   - `self._terminate_request(request)`
   - `_do_terminate_request()` calls `self.resource_manager.free_resources(request)`
   - the KV resource manager path ultimately removes the sequence.
7. `_handle_errors()` does not check whether a request is in `DISAGG_GENERATION_TRANS_IN_PROGRESS`.
8. After local Python references unwind, Python may have released its last pybind `shared_ptr<LlmRequest>` while C++ still has raw pointers in `mRequesterFutures` / receiver worker state.
9. A later `checkGenTransferStatus()` or receiver worker continuation can dereference that stale pointer.

Concrete callers that can hit all active requests include:

- hang detector callback
- decode exception path
- forward exception path
- sampling/setup/update exception paths

By contrast, client cancellation and timeout cancellation are less suspicious pre-PR:

```python
is_cancelled = self.kv_cache_transceiver.cancel_request(request)
```

For an already in-flight transfer, `cancel_request()` generally returned `False`, so the Python path kept cancellation pending instead of terminating the request immediately. That is not the owner-drop path this PR relies on.

```mermaid
sequenceDiagram
    participant Py as Python
    participant CT as CacheTransceiver
    participant Futures as RequesterFutures
    participant Worker as CacheReceiverWorker
    participant RM as ResourceManager
    participant Req as LlmRequest

    Py->>CT: request and receive async
    CT->>Worker: receive async with raw request pointer
    CT->>Futures: store raw request pointer and future
    Worker->>Worker: queue raw request pointer

    Note over Py: Later broad error cleanup runs
    Py->>Py: handle errors for all active requests
    Py->>Py: failed requests equals active requests
    Py->>Py: clear active requests
    Py->>RM: terminate request and free resources
    RM->>RM: remove sequence

    Note over Req: Python local references can unwind here
    Note over Futures: Cpp still tracks raw request pointer
    Futures->>Req: later status check may read stale pointer
    Worker->>Req: worker may read stale pointer
```

### Context-Side LlmResponse Cleanup Path

This is not an assertion that every completed context request is removed before its KV transfer future completes. The issue is that the code permits that interleaving when the transfer future is still not ready after the status checks that run before and after response handling.

Here "response" means the Python `LlmResponse` created by `_handle_responses()` via `request.create_response(False, self.dist.rank)` and later enqueued with `_enqueue_responses(...)`. It is not a KV-cache transfer response from `DataTransceiver`.

For disaggregated context-only requests, `LlmRequest::createResult()` has a special `isDisaggContextTransmissionState() && isContextOnlyRequest()` path that packages `ContextPhaseParams` into the result while the request is in context-transfer state. That lets the executor publish the request result / context phase metadata even though the async KV send future may still be outstanding.

The reason `_handle_responses()` sees `request_done=True` is:

1. `_send_kv_async()` calls `respond_and_send_async(req)`.
2. `CacheTransceiver::respondAndSendAsync()` sets the request state to `DISAGG_CONTEXT_TRANS_IN_PROGRESS`.
3. `LlmRequest::isFinished()` returns true for `DISAGG_CONTEXT_TRANS_IN_PROGRESS`.
4. `_handle_responses()` calls `request.create_response(...)`; when that returns a response, it sets `request_done = request.is_finished`.

So in this context-side path, `request_done` means "the context-only request is ready to emit its logical response / context phase metadata", not "the async KV send future has completed".

For context/prefill transfer, the relevant ordering is:

1. `_send_kv_async()` starts the transfer with:
   - `self.async_transfer_manager.start_transfer(req)`
   - `self.kv_cache_transceiver.respond_and_send_async(req)`
2. C++ stores raw request addresses in the transceiver/worker state:
   - `CacheTransceiver::mSenderFutures` stores `LlmRequest*`
   - `CacheSender` response/worker state stores `LlmRequest*`
3. `_send_kv_async()` calls `_check_disagg_ctx_cache_transfer_status(0)`. If the future is not ready and the non-blocking/timeout path does not complete it, the raw pointer remains in `mSenderFutures`.
4. `_handle_responses()` then runs because the executor loop calls it as the next fixed response-drain step after request state updates, `_send_kv_async(...)`, and `_handle_canceled_requests()`. It is not triggered by KV transfer completion. It may create an `LlmResponse` from the request. The event-loop comment says context send sessions are completed **after** responses are created so `_handle_responses()` sees the request before it is terminated.
5. If `_handle_responses()` sees `request_done`, the pre-PR partial-reuse branch appended the request to `requests_to_terminate` without checking `request.is_disagg_context_transmission_state`.
6. `_handle_responses()` rebuilt `active_requests` without that request:
   - `self.active_requests.clear()`
   - `self.active_requests.extend(new_active_requests)`
7. It finally called `_terminate_request(request)` and returned the finished request list. That returned list may keep the Python object alive until the caller unwinds, but the request is no longer in `active_requests`.
8. If the post-response `_check_disagg_ctx_cache_transfer_status(0)` still cannot complete the future, then after those local Python references unwind the last Python `shared_ptr<LlmRequest>` can be released while C++ still has only raw pointers in `mSenderFutures` / worker state.
9. A later status check or worker continuation can then dereference the raw pointer.

```mermaid
sequenceDiagram
    participant Py as Python
    participant CT as CacheTransceiver
    participant Futures as SenderFutures
    participant Worker as CacheSenderWorker
    participant Req as LlmRequest

    Py->>CT: send kv async starts transfer
    CT->>Worker: send async with raw request pointer
    CT->>Futures: store raw request pointer and future
    Worker->>Worker: queue raw request pointer

    Py->>CT: initial context status check
    CT->>Py: future is not ready

    Py->>Py: handle responses sees request done
    Py->>Py: add request to terminate list
    Py->>Py: rebuild active requests without request
    Py->>Py: terminate request
    Py->>CT: post response context status check
    CT->>Py: future is still not ready

    Note over Req: Python local references can unwind here
    Note over Futures: Cpp still tracks raw request pointer
    Futures->>Req: later status check may read stale pointer
    Worker->>Req: worker may read stale pointer
```

The dangerous shape is that Python can legally release the request while either:

- `CacheTransceiver::mSenderFutures` / `mRequesterFutures` still contains a raw `LlmRequest*`, or
- `CacheSender` / `CacheReceiver` worker state still contains a raw pointer/reference.

That creates a use-after-free risk in timeout/error/cleanup paths that run while transfer work is still outstanding.

## Request Lifetime After

After this change, C++ async state owns a strong reference for as long as the future or worker entry exists.

```mermaid
sequenceDiagram
    participant Py as Python
    participant CT as CacheTransceiver
    participant Futures as FutureVectors
    participant Worker as DataTransceiverWorker
    participant Req as LlmRequest

    Py->>CT: pass shared request
    CT->>Worker: async transfer with shared request
    CT->>Futures: store shared request and future
    Worker->>Worker: queue or capture shared request

    Py->>Req: Python may release its reference
    Note over Futures: Cpp shared references keep request alive
    Worker->>Req: worker safely accesses request
    Futures->>Req: status polling safely accesses request
    Worker->>Futures: future becomes ready or error
    CT->>Futures: get future result
    CT->>Req: record final transfer state
    CT->>Futures: erase tracking entry
    Note over Req: request is destroyed after all shared references are gone
```

The intended invariant is: any async C++ structure that can later touch an `LlmRequest` also owns a `shared_ptr` to it. Once the future is ready or errors, C++ consumes the future, records final state, erases the tracking entry, and releases its strong reference.

This does not make a blocked transport operation interruptible. It only ensures that, while the blocked or pending operation still exists, the request object it touches remains alive.

## Why This Conservative Shape

The broader recovery idea in #13056 attempted to make timeout handling more active: cancel in-flight transfer work, erase the future, and let Python cleanup proceed. That can reduce leaks when recovery works, but it introduces a harder correctness requirement: C++ must not erase its last tracking handle until the worker is actually quiescent.

This draft avoids that risk. It fixes the memory lifetime issue without changing the existing cancel semantics:

- queued transfers can still be cancelled by the existing queued-only path,
- already in-flight transfers are not reported as successfully cancelled just because a flag was flipped,
- future entries are still erased only through the existing completion/error paths.

With a canary health check that restarts pods when the server stops processing new requests, leaving true transport wedges to process restart is the simpler and safer tradeoff.

## Validation

- `git diff --check`
- `PYTHONPYCACHEPREFIX=/tmp/trtllm-pycache python3 -m py_compile tensorrt_llm/_torch/pyexecutor/py_executor.py tensorrt_llm/_torch/pyexecutor/scheduler/waiting_queue.py`

No full C++ build was run locally.
