### PR TITLE
[None][feat] AutoDeploy: onboard DeepSeek V4 (Flash-Base, Pro) + KV-cache decode

### DIFF
--- a/examples/auto_deploy/model_registry/configs/deepseek-v4-flash-base.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek-v4-flash-base.yaml
@@ -1,21 +1,15 @@
 # Configuration for deepseek-ai/DeepSeek-V4-Flash-Base.
 # The full model is large, so registry E2E starts with the first five layers.
 #
-# attn_backend MUST be "torch" for V4 because:
-#   * DS-V4 uses learnable attention sinks on every attention layer. Sinks
-#     are only implemented in `torch_cached_attention_with_cache` today
-#     (triton_paged / trtllm / flashinfer do not accept the `sinks` kwarg).
-#   * The sparse layers also use the DS-V4-specific cached op registered
-#     under the `torch_ds_v4_sparse` descriptor, which has no non-torch
-#     backend variants.
-# Extending sinks / sparse-caching to other backends is tracked as a
-# follow-up and is not required for correctness.
+# attn_backend selects the cached backend for dense compress_ratio == 0 layers.
+# DS-V4 sparse layers use the dedicated torch_ds_v4_sparse descriptor and are
+# rewritten by insert_cached_deepseek_v4_sparse_attention independently.
 #
 # max_batch_size: 1 — the cached sparse op (torch_deepseek_v4_sparse_attn_with_cache)
 # currently only supports single-batch inference (B=1 assert in the decode kernel).
 # Multi-batch support is a follow-up. Clamp to 1 so the smoke test passes today.
-compile_backend: torch-simple
-attn_backend: torch
+compile_backend: torch-cudagraph
+attn_backend: triton_paged
 dtype: bfloat16
 max_batch_size: 1
 cuda_graph_config:

--- a/examples/auto_deploy/model_registry/configs/deepseek-v4-flash-base.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek-v4-flash-base.yaml
@@ -1,5 +1,5 @@
 # Configuration for deepseek-ai/DeepSeek-V4-Flash-Base.
-# The full model is large, so registry E2E starts with the first five layers.
+# Layer and sparsity settings are inherited from the HF config.json by default.
 #
 # attn_backend selects the cached backend for dense compress_ratio == 0 layers.
 # DS-V4 sparse layers use the dedicated torch_ds_v4_sparse descriptor and are
@@ -21,4 +21,3 @@ kv_cache_config:
   tokens_per_block: 64
 model_kwargs:
   torch_dtype: bfloat16
-  compress_ratios: [0, 0, 4, 128, 4]

--- a/examples/auto_deploy/model_registry/configs/deepseek-v4-flash-base.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek-v4-flash-base.yaml
@@ -21,5 +21,4 @@ kv_cache_config:
   tokens_per_block: 64
 model_kwargs:
   torch_dtype: bfloat16
-  num_hidden_layers: 5
   compress_ratios: [0, 0, 4, 128, 4]

--- a/examples/auto_deploy/model_registry/configs/deepseek-v4-flash-base.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek-v4-flash-base.yaml
@@ -1,0 +1,31 @@
+# Configuration for deepseek-ai/DeepSeek-V4-Flash-Base.
+# The full model is large, so registry E2E starts with the first five layers.
+#
+# attn_backend MUST be "torch" for V4 because:
+#   * DS-V4 uses learnable attention sinks on every attention layer. Sinks
+#     are only implemented in `torch_cached_attention_with_cache` today
+#     (triton_paged / trtllm / flashinfer do not accept the `sinks` kwarg).
+#   * The sparse layers also use the DS-V4-specific cached op registered
+#     under the `torch_ds_v4_sparse` descriptor, which has no non-torch
+#     backend variants.
+# Extending sinks / sparse-caching to other backends is tracked as a
+# follow-up and is not required for correctness.
+#
+# max_batch_size: 1 — the cached sparse op (torch_deepseek_v4_sparse_attn_with_cache)
+# currently only supports single-batch inference (B=1 assert in the decode kernel).
+# Multi-batch support is a follow-up. Clamp to 1 so the smoke test passes today.
+compile_backend: torch-simple
+attn_backend: torch
+dtype: bfloat16
+max_batch_size: 1
+cuda_graph_config:
+  max_batch_size: 1
+kv_cache_config:
+  dtype: bfloat16
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.7
+  tokens_per_block: 64
+model_kwargs:
+  torch_dtype: bfloat16
+  num_hidden_layers: 5
+  compress_ratios: [0, 0, 4, 128, 4]

--- a/examples/auto_deploy/model_registry/configs/deepseek-v4-pro.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek-v4-pro.yaml
@@ -1,12 +1,15 @@
 # Configuration for deepseek-ai/DeepSeek-V4-Pro.
 # The full model is large, so registry E2E starts with the first five layers.
 #
-# attn_backend MUST be "torch" — see deepseek-v4-flash-base.yaml for the
-# detailed rationale (sinks + sparse-cache ops only exist on the torch
-# backend today).
-compile_backend: torch-simple
-attn_backend: torch
+# attn_backend selects the cached backend for dense compress_ratio == 0 layers.
+# DS-V4 sparse layers use the dedicated torch_ds_v4_sparse descriptor and are
+# rewritten by insert_cached_deepseek_v4_sparse_attention independently.
+compile_backend: torch-cudagraph
+attn_backend: triton_paged
 dtype: bfloat16
+max_batch_size: 1
+cuda_graph_config:
+  max_batch_size: 1
 kv_cache_config:
   dtype: bfloat16
   enable_block_reuse: false

--- a/examples/auto_deploy/model_registry/configs/deepseek-v4-pro.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek-v4-pro.yaml
@@ -1,0 +1,18 @@
+# Configuration for deepseek-ai/DeepSeek-V4-Pro.
+# The full model is large, so registry E2E starts with the first five layers.
+#
+# attn_backend MUST be "torch" — see deepseek-v4-flash-base.yaml for the
+# detailed rationale (sinks + sparse-cache ops only exist on the torch
+# backend today).
+compile_backend: torch-simple
+attn_backend: torch
+dtype: bfloat16
+kv_cache_config:
+  dtype: bfloat16
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.7
+  tokens_per_block: 64
+model_kwargs:
+  torch_dtype: bfloat16
+  num_hidden_layers: 5
+  compress_ratios: [128, 128, 4, 128, 4]

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -248,6 +248,11 @@ models:
   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'num_hidden_layers_5.yaml']
 - name: nvidia/DeepSeek-V3.2-NVFP4
   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'num_hidden_layers_5.yaml']
+# --- DeepSeek V4 (Apr 2026) ---
+- name: deepseek-ai/DeepSeek-V4-Flash-Base
+  yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'deepseek-v4-flash-base.yaml']
+- name: deepseek-ai/DeepSeek-V4-Pro
+  yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'deepseek-v4-pro.yaml']
 # --- GLM-4.6 (Sep 2025) ---
 - name: zai-org/GLM-4.6
   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml']

--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -254,6 +254,12 @@ transforms:
     stage: cache_init
     requires_shape_prop: true
     backend: flashinfer_mla
+  # DeepSeek-V4 sparse (compress_ratio != 0) layers: dedicated cached variant
+  # that owns the rolling Compressor/Indexer state. Keys off its own descriptor so
+  # it composes with ``insert_cached_attention`` (which handles the dense layers).
+  insert_cached_deepseek_v4_sparse_attention:
+    stage: cache_init
+    backend: torch_ds_v4_sparse
   insert_cached_ssm_attention:
     stage: cache_init
     backend: triton_ssm

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/__init__.py
@@ -24,6 +24,7 @@ This module provides various attention implementations and backends:
 - triton_attention_with_kv_cache: Triton attention with KV cache support
 - triton_paged_attention: Triton paged attention (two-stage flash-decode) with HND layout
 - onnx_attention: Placeholder ops for ONNX export of attention mechanisms
+- deepseek_v4_sparse_attention: DeepSeek-V4 sparse (compress_ratio != 0) attention op
 """
 
 __all__ = [
@@ -36,4 +37,5 @@ __all__ = [
     "triton_attention_with_paged_kv_cache",
     "triton_paged_attention",
     "onnx_attention",
+    "deepseek_v4_sparse_attention",
 ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_sparse_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_sparse_attention.py
@@ -76,6 +76,62 @@ def _apply_interleaved_rope(
     return torch.stack([out_a, out_b], dim=-1).flatten(-2).type_as(x)
 
 
+def _ceil_pow2_scale(amax: torch.Tensor, max_value: float, min_value: float) -> torch.Tensor:
+    amax = amax.clamp_min(min_value)
+    return torch.pow(2.0, torch.ceil(torch.log2(amax / max_value)))
+
+
+def _fake_fp8_act_quant(x: torch.Tensor, block_size: int = 64) -> torch.Tensor:
+    """Reference in-place ``act_quant`` approximation for DeepSeek V4 KV tensors."""
+    dim = x.shape[-1]
+    if dim == 0 or dim % block_size != 0:
+        return x
+
+    dtype = x.dtype
+    x_float = x.float()
+    grouped = x_float.reshape(*x_float.shape[:-1], dim // block_size, block_size)
+    scale = _ceil_pow2_scale(grouped.abs().amax(dim=-1, keepdim=True), 448.0, 1.0e-4)
+    quant = torch.clamp(grouped / scale, -448.0, 448.0).to(dtype).float()
+    return (quant * scale).reshape_as(x_float).to(dtype)
+
+
+def _fake_fp4_act_quant(x: torch.Tensor, block_size: int = 32) -> torch.Tensor:
+    """Reference in-place ``fp4_act_quant`` approximation for DeepSeek V4 indexer tensors."""
+    dim = x.shape[-1]
+    if dim == 0 or dim % block_size != 0:
+        return x
+
+    dtype = x.dtype
+    x_float = x.float()
+    grouped = x_float.reshape(*x_float.shape[:-1], dim // block_size, block_size)
+    scale = _ceil_pow2_scale(grouped.abs().amax(dim=-1, keepdim=True), 6.0, 6.0 * 2.0**-126)
+    normalized = torch.clamp(grouped / scale, -6.0, 6.0)
+    levels = normalized.new_tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+    level_idx = (normalized.abs().unsqueeze(-1) - levels).abs().argmin(dim=-1)
+    quant = levels[level_idx] * normalized.sign()
+    return (quant * scale).reshape_as(x_float).to(dtype)
+
+
+def _hadamard_rotate(x: torch.Tensor) -> torch.Tensor:
+    """Hadamard rotation used before FP4 simulation in the DeepSeek V4 indexer."""
+    dim = x.shape[-1]
+    if dim <= 1:
+        return x
+    if dim & (dim - 1):
+        raise ValueError(f"Hadamard rotation requires power-of-two dimension, got {dim}.")
+
+    orig_shape = x.shape
+    y = x.float()
+    width = 1
+    while width < dim:
+        y = y.reshape(*y.shape[:-1], dim // (2 * width), 2, width)
+        left = y[..., 0, :]
+        right = y[..., 1, :]
+        y = torch.cat([left + right, left - right], dim=-1).reshape(orig_shape)
+        width *= 2
+    return (y * (dim**-0.5)).to(x.dtype)
+
+
 def _overlap_transform(tensor: torch.Tensor, head_dim: int, value: float = 0.0) -> torch.Tensor:
     """HF DeepSeek V4 overlap transform used by ratio-4 compression."""
     bsz, _, ratio, _ = tensor.shape
@@ -163,7 +219,7 @@ def _manual_attention_with_sinks(
     scores = scores + attn_mask.float()
 
     sink_logits = sinks.float().reshape(1, n_heads, 1, 1).expand(bsz, n_heads, seqlen, 1)
-    logits_max = scores.max(dim=-1, keepdim=True).values
+    logits_max = torch.maximum(scores.max(dim=-1, keepdim=True).values, sink_logits)
     exp_scores = torch.exp(scores - logits_max)
     exp_sinks = torch.exp(sink_logits - logits_max)
     attn = exp_scores / (exp_scores.sum(dim=-1, keepdim=True) + exp_sinks)
@@ -189,6 +245,7 @@ def _sparse_compressor(
     rope_head_dim: int,
     compress_ratio: int,
     rms_norm_eps: float,
+    rotate: bool = False,
 ) -> torch.Tensor:
     """Stateless equivalent of DeepseekV4Compressor.forward (prefill only)."""
     bsz, seqlen, _ = hidden_states.shape
@@ -229,6 +286,12 @@ def _sparse_compressor(
     sin_comp = sin[:, chunk_start]
     nope, pe = torch.split(compressed, [head_dim - rope_head_dim, rope_head_dim], dim=-1)
     pe = _apply_interleaved_rope(pe, cos_comp, sin_comp)
+    compressed = torch.cat([nope, pe], dim=-1)
+    if rotate:
+        return _fake_fp4_act_quant(_hadamard_rotate(compressed), block_size=32)
+
+    nope, pe = torch.split(compressed, [head_dim - rope_head_dim, rope_head_dim], dim=-1)
+    nope = _fake_fp8_act_quant(nope, block_size=64)
     return torch.cat([nope, pe], dim=-1)
 
 
@@ -247,6 +310,7 @@ def _sparse_indexer(
     *,
     index_n_heads: int,
     index_head_dim: int,
+    index_topk: int,
     rope_head_dim: int,
     compress_ratio: int,
     rms_norm_eps: float,
@@ -260,6 +324,7 @@ def _sparse_indexer(
     q_nope, q_pe = torch.split(q, [index_head_dim - rd, rd], dim=-1)
     q_pe = _apply_interleaved_rope(q_pe, cos.unsqueeze(2), sin.unsqueeze(2))
     q = torch.cat([q_nope, q_pe], dim=-1)
+    q = _fake_fp4_act_quant(_hadamard_rotate(q), block_size=32)
 
     index_k = _sparse_compressor(
         hidden_states,
@@ -273,23 +338,41 @@ def _sparse_indexer(
         rope_head_dim=rope_head_dim,
         compress_ratio=compress_ratio,
         rms_norm_eps=rms_norm_eps,
+        rotate=True,
     )
+    num_compressed = seqlen // compress_ratio
+    if index_topk == 0:
+        return torch.empty(bsz, seqlen, 0, device=hidden_states.device, dtype=torch.int64)
+    if num_compressed == 0:
+        return torch.full(
+            (bsz, seqlen, index_topk), -1, device=hidden_states.device, dtype=torch.int64
+        )
+    index_k = index_k[:, :num_compressed]
     weights = F.linear(hidden_states, weights_proj).float() * (softmax_scale * index_n_heads**-0.5)
 
     index_score = torch.einsum("bshd,btd->bsht", q, index_k).float()
     index_score = (index_score.relu() * weights.unsqueeze(-1)).sum(dim=2)
 
-    compressed_positions = torch.arange(seqlen, device=hidden_states.device)
+    compressed_positions = torch.arange(num_compressed, device=hidden_states.device)
     valid_count = (
         torch.arange(1, seqlen + 1, device=hidden_states.device).unsqueeze(1) // compress_ratio
     )
     future_mask = compressed_positions.unsqueeze(0) >= valid_count
-    valid = ~future_mask
     index_score = index_score.masked_fill(future_mask.unsqueeze(0), -1.0e20)
 
-    sorted_idxs = index_score.argsort(dim=-1, descending=True)
-    sorted_valid = valid.unsqueeze(0).expand(bsz, -1, -1).gather(-1, sorted_idxs)
-    return torch.where(sorted_valid, sorted_idxs + offset, -1)
+    k = min(index_topk, num_compressed)
+    topk_idxs = index_score.topk(k, dim=-1).indices
+    invalid = topk_idxs >= valid_count.unsqueeze(0)
+    topk_idxs = torch.where(invalid, -1, topk_idxs + offset)
+    if k < index_topk:
+        pad = torch.full(
+            (bsz, seqlen, index_topk - k),
+            -1,
+            device=hidden_states.device,
+            dtype=topk_idxs.dtype,
+        )
+        topk_idxs = torch.cat([topk_idxs, pad], dim=-1)
+    return topk_idxs.to(torch.int64)
 
 
 def _sparse_attn_prefill_body(
@@ -299,6 +382,8 @@ def _sparse_attn_prefill_body(
     q_lora: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
+    cos_anchor: torch.Tensor,
+    sin_anchor: torch.Tensor,
     attn_sink: torch.Tensor,
     compressor_wkv: torch.Tensor,
     compressor_wgate: torch.Tensor,
@@ -318,6 +403,7 @@ def _sparse_attn_prefill_body(
     head_dim: int,
     index_n_heads: int,
     index_head_dim: int,
+    index_topk: int,
     rms_norm_eps: float,
 ) -> torch.Tensor:
     """Shared prefill attention body reused by the exported op and equivalence tests."""
@@ -352,6 +438,7 @@ def _sparse_attn_prefill_body(
             compressor_norm_weight=indexer_compressor_norm_weight,
             index_n_heads=index_n_heads,
             index_head_dim=index_head_dim,
+            index_topk=index_topk,
             rope_head_dim=rope_head_dim,
             compress_ratio=compress_ratio,
             rms_norm_eps=rms_norm_eps,
@@ -381,6 +468,8 @@ def torch_deepseek_v4_sparse_attn(
     q_lora: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
+    cos_anchor: torch.Tensor,
+    sin_anchor: torch.Tensor,
     attn_sink: torch.Tensor,
     compressor_wkv: torch.Tensor,
     compressor_wgate: torch.Tensor,
@@ -399,6 +488,7 @@ def torch_deepseek_v4_sparse_attn(
     head_dim: int,
     index_n_heads: int,
     index_head_dim: int,
+    index_topk: int,
     rms_norm_eps: float,
     layer_idx: Optional[int] = None,
     layer_type: str = "mha_sparse",
@@ -409,7 +499,7 @@ def torch_deepseek_v4_sparse_attn(
     inversion on the output happens outside this op to keep the op
     boundary clean.
     """
-    del layer_idx, layer_type  # metadata only — read by AttentionDescriptor
+    del layer_idx, layer_type
     return _sparse_attn_prefill_body(
         q,
         kv,
@@ -417,6 +507,8 @@ def torch_deepseek_v4_sparse_attn(
         q_lora,
         cos,
         sin,
+        cos_anchor,
+        sin_anchor,
         attn_sink,
         compressor_wkv,
         compressor_wgate,
@@ -435,6 +527,7 @@ def torch_deepseek_v4_sparse_attn(
         head_dim=head_dim,
         index_n_heads=index_n_heads,
         index_head_dim=index_head_dim,
+        index_topk=index_topk,
         rms_norm_eps=rms_norm_eps,
     )
 
@@ -447,6 +540,8 @@ def torch_deepseek_v4_sparse_attn_fake(
     q_lora: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
+    cos_anchor: torch.Tensor,
+    sin_anchor: torch.Tensor,
     attn_sink: torch.Tensor,
     compressor_wkv: torch.Tensor,
     compressor_wgate: torch.Tensor,
@@ -465,6 +560,7 @@ def torch_deepseek_v4_sparse_attn_fake(
     head_dim: int,
     index_n_heads: int,
     index_head_dim: int,
+    index_topk: int,
     rms_norm_eps: float,
     layer_idx: Optional[int] = None,
     layer_type: str = "mha_sparse",
@@ -530,8 +626,8 @@ def _seed_compressor_state(
 
 def _decode_compressor_step(
     hidden_states: torch.Tensor,  # [1, 1, hidden]
-    cos_last: torch.Tensor,  # [1, 1, rd/2]
-    sin_last: torch.Tensor,  # [1, 1, rd/2]
+    cos_anchor_table: torch.Tensor,  # [max_seq_len, rd/2]
+    sin_anchor_table: torch.Tensor,  # [max_seq_len, rd/2]
     kv_state: torch.Tensor,  # [max_batch, coff*ratio, coff*head_dim]
     score_state: torch.Tensor,  # [max_batch, coff*ratio, coff*head_dim]
     compressed_kv_cache: torch.Tensor,  # [max_batch, max_compressed, head_dim]
@@ -545,6 +641,7 @@ def _decode_compressor_step(
     head_dim: int,
     rope_head_dim: int,
     rms_norm_eps: float,
+    rotate: bool = False,
 ) -> None:
     """One decode step's Compressor update. Writes to state + (maybe) compressed_kv_cache.
 
@@ -602,15 +699,17 @@ def _decode_compressor_step(
         hidden_states.dtype
     )
     nope, pe = torch.split(compressed, [head_dim - rope_head_dim, rope_head_dim], dim=-1)
-    # TODO(ds-v4 cached): use cos/sin at position ``input_pos+1-compress_ratio``
-    # (chunk-start anchor) instead of ``cos_last``/``sin_last`` (current decode
-    # step). Fresh prefill rotates each compressed token by the freqs at its
-    # chunk's starting position; using the current-step freqs causes the
-    # ratio-4 Indexer's top-k to drift from the prefill result. Fix requires
-    # plumbing either the full cos/sin table or the anchor cos/sin through the
-    # op signature.
-    pe = _apply_interleaved_rope(pe, cos_last, sin_last)
+    anchor_pos = input_pos + 1 - compress_ratio
+    cos_anchor = cos_anchor_table[anchor_pos].view(1, 1, -1)
+    sin_anchor = sin_anchor_table[anchor_pos].view(1, 1, -1)
+    pe = _apply_interleaved_rope(pe, cos_anchor, sin_anchor)
     compressed = torch.cat([nope, pe], dim=-1)
+    if rotate:
+        compressed = _fake_fp4_act_quant(_hadamard_rotate(compressed), block_size=32)
+    else:
+        nope, pe = torch.split(compressed, [head_dim - rope_head_dim, rope_head_dim], dim=-1)
+        nope = _fake_fp8_act_quant(nope, block_size=64)
+        compressed = torch.cat([nope, pe], dim=-1)
 
     write_idx = input_pos // compress_ratio
     compressed_kv_cache[slot, write_idx] = compressed.squeeze(0).squeeze(0)
@@ -634,6 +733,8 @@ def _decode_indexer_step(
     offset: int,
 ) -> torch.Tensor:
     """Compute compressed-KV top-k indices at decode for one token."""
+    if index_topk == 0:
+        return torch.empty(1, 1, 0, device=hidden_states.device, dtype=torch.int64)
     num_compressed = (input_pos + 1) // compress_ratio
     if num_compressed == 0:
         # No compressed tokens yet — return empty-by-padding (all -1) matching prefill output.
@@ -644,6 +745,7 @@ def _decode_indexer_step(
     q_nope, q_pe = torch.split(q, [index_head_dim - rd, rd], dim=-1)
     q_pe = _apply_interleaved_rope(q_pe, cos_last.unsqueeze(2), sin_last.unsqueeze(2))
     q = torch.cat([q_nope, q_pe], dim=-1)
+    q = _fake_fp4_act_quant(_hadamard_rotate(q), block_size=32)
 
     weights = F.linear(hidden_states, weights_proj).float() * (
         softmax_scale * index_n_heads**-0.5
@@ -695,6 +797,7 @@ def _seed_indexer_compressed_cache(
         rope_head_dim=rope_head_dim,
         compress_ratio=compress_ratio,
         rms_norm_eps=rms_norm_eps,
+        rotate=True,
     )  # [1, seqlen, index_head_dim]
     # Zero full slot first — UnpagedResourceHandler.allocate() uses torch.empty()
     # so unused entries contain uninitialized memory that would propagate NaN
@@ -715,6 +818,25 @@ def _seed_indexer_compressed_cache(
     )
 
 
+def _seed_window_cache(
+    kv: torch.Tensor,
+    window_cache: torch.Tensor,
+    slot: int,
+    window_size: int,
+) -> None:
+    """Seed the decode ring buffer exactly as HF ``Attention.forward(start_pos=0)``."""
+    seqlen = kv.shape[1]
+    window_cache[slot].zero_()
+    if seqlen <= window_size:
+        window_cache[slot, :seqlen] = kv[0, :seqlen, 0, :]
+        return
+
+    cutoff = seqlen % window_size
+    recent = kv[0, -window_size:, 0, :]
+    window_cache[slot, cutoff:window_size] = recent[: window_size - cutoff]
+    window_cache[slot, :cutoff] = recent[window_size - cutoff :]
+
+
 def _decode_sparse_attn_step(
     q: torch.Tensor,  # [1, 1, H, D]
     kv_new: torch.Tensor,  # [1, 1, 1, D]
@@ -725,6 +847,7 @@ def _decode_sparse_attn_step(
     slot: int,
     input_pos: int,
     window_size: int,
+    compress_ratio: int,
     scale: float,
     head_dim: int,
 ) -> torch.Tensor:
@@ -746,8 +869,13 @@ def _decode_sparse_attn_step(
     if visible_window < window_size:
         pad = window_cache.new_zeros(window_size - visible_window, head_dim)
         gathered_window = torch.cat([gathered_window, pad], dim=0)
-    # Build full concat(window, compressed) along token axis.
-    kv_all = torch.cat([gathered_window, compressed_kv_cache[slot]], dim=0)  # [window + max_c, D]
+    # Only materialize compressed rows that are visible to this decode step.
+    # ``compressed_kv_cache`` is allocated against max_seq_len, not the current
+    # prefix length; using the full allocation would make attention scale with
+    # max_seq_len and can allocate hundreds of GiB for long-context models.
+    num_compressed = min((input_pos + 1) // compress_ratio, compressed_kv_cache.shape[1])
+    visible_compressed = compressed_kv_cache[slot, :num_compressed]
+    kv_all = torch.cat([gathered_window, visible_compressed], dim=0)
     # Window top-k indices are just [0..visible_window-1]; entries beyond are -1.
     window_topk = torch.full((1, 1, window_size), -1, device=device, dtype=compress_topk.dtype)
     window_topk[0, 0, :visible_window] = torch.arange(visible_window, device=device)
@@ -773,13 +901,15 @@ _CACHE_NAMES = (
     "auto_deploy::torch_deepseek_v4_sparse_attn_with_cache", mutates_args=_CACHE_NAMES
 )
 def torch_deepseek_v4_sparse_attn_with_cache(
-    # --- Source-op tensor args (17). Order MUST match the prefill op's qkv arg layout. ---
+    # --- Source-op tensor args (19). Order MUST match the prefill op's qkv arg layout. ---
     q: torch.Tensor,
     kv: torch.Tensor,
     hidden_states: torch.Tensor,
     q_lora: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
+    cos_anchor: torch.Tensor,
+    sin_anchor: torch.Tensor,
     attn_sink: torch.Tensor,
     compressor_wkv: torch.Tensor,
     compressor_wgate: torch.Tensor,
@@ -805,7 +935,7 @@ def torch_deepseek_v4_sparse_attn_with_cache(
     indexer_compressed_kv_cache: torch.Tensor,
     indexer_kv_state: torch.Tensor,
     indexer_score_state: torch.Tensor,
-    # --- Constants (8). Returned by AttentionDescriptor.get_constants. ---
+    # --- Constants (9). Returned by AttentionDescriptor.get_constants. ---
     scale: float,
     window_size: int,
     compress_ratio: int,
@@ -813,6 +943,7 @@ def torch_deepseek_v4_sparse_attn_with_cache(
     head_dim: int,
     index_n_heads: int,
     index_head_dim: int,
+    index_topk: int,
     rms_norm_eps: float,
 ) -> torch.Tensor:
     """DeepSeek V4 sparse attention with KV cache (prefill seeds, decode updates).
@@ -821,23 +952,12 @@ def torch_deepseek_v4_sparse_attn_with_cache(
     processed independently and its KV caches are seeded using the corresponding
     slot from ``slot_idx[b]``.
 
-    Decode (``s == 1``) still requires ``B == 1``.  Multi-sequence decode via
-    ``cu_seqlen`` is a follow-up.
+    Decode (``s == 1``) supports ``B >= 1`` by processing each batch element's
+    sequence slot independently.
     """
     del batch_info_host, cu_seqlen
     bsz, s, _, _ = q.shape
     has_indexer = indexer_wq_b is not None
-
-    # KNOWN-ISSUE (DS-V4 E2E decode):
-    # On the first decode step after an 8-GPU TP prefill with the reduced
-    # 5-layer registry fixture, layer-3 (ratio=128) decode output contains
-    # NaN that cascades forward and ultimately trips the sampler's
-    # ``_flashinfer_check_nans`` async CUDA assert. Bandaids that zero NaN at
-    # this op boundary do not fix the problem — so the NaN source is upstream
-    # (likely trtllm_finegrained_fp8_linear or the HC-Sinkhorn chain) and
-    # resists localisation without per-step logit dumping. Prefill works end
-    # to end; all-dense decode works end to end; numerics-of-sparse-decode is
-    # tracked as a follow-up.
 
     if s > 1:
         # --- Prefill: run the stateless body and seed caches per batch element. ---
@@ -849,6 +969,8 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                 q_lora,
                 cos,
                 sin,
+                cos_anchor,
+                sin_anchor,
                 attn_sink,
                 compressor_wkv,
                 compressor_wgate,
@@ -867,6 +989,7 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                 head_dim=head_dim,
                 index_n_heads=index_n_heads,
                 index_head_dim=index_head_dim,
+                index_topk=index_topk,
                 rms_norm_eps=rms_norm_eps,
             )
             slot = int(slot_idx[0].item())
@@ -876,9 +999,7 @@ def torch_deepseek_v4_sparse_attn_with_cache(
             # we don't zero out the padding, kv_all = cat(window, compressed) at
             # decode time contains NaN garbage, ``q @ kv_all.T`` propagates NaN
             # into even the attention-masked positions, and logits NaN out.
-            window_cache[slot].zero_()
-            fill = min(s, window_size)
-            window_cache[slot, :fill] = kv[0, s - fill : s, 0, :]
+            _seed_window_cache(kv, window_cache, slot, window_size)
             # Seed the compressed KV cache by re-running the stateless compressor.
             compressed = _sparse_compressor(
                 hidden_states,
@@ -925,11 +1046,6 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                     rope_head_dim,
                     rms_norm_eps,
                 )
-            # Bandaid: zero out any non-finite slots so downstream layers don't
-            # see NaN.  TODO: fix the underlying numerics (likely sinks + very
-            # negative masked scores overflowing in fp32 exp for layers where
-            # visible kv count is tiny relative to total masked kv length).
-            out = torch.nan_to_num(out, nan=0.0, posinf=0.0, neginf=0.0)
             return out
         else:
             # Batched prefill (B > 1): process each sequence independently and
@@ -950,6 +1066,8 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                     ql_b,
                     cos_b,
                     sin_b,
+                    cos_anchor,
+                    sin_anchor,
                     attn_sink,
                     compressor_wkv,
                     compressor_wgate,
@@ -968,14 +1086,13 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                     head_dim=head_dim,
                     index_n_heads=index_n_heads,
                     index_head_dim=index_head_dim,
+                    index_topk=index_topk,
                     rms_norm_eps=rms_norm_eps,
                 )
                 # Zero full slot first to prevent uninitialized memory (from
                 # torch.empty() in the resource handler) from leaking NaN into
                 # attention at decode; see also the B==1 branch above.
-                window_cache[slot_b].zero_()
-                fill = min(s, window_size)
-                window_cache[slot_b, :fill] = kv_b[0, s - fill : s, 0, :]
+                _seed_window_cache(kv_b, window_cache, slot_b, window_size)
                 compressed = _sparse_compressor(
                     hs_b,
                     cos_b,
@@ -1022,9 +1139,7 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                         rms_norm_eps,
                     )
                 outs.append(out_b)
-            cat = torch.cat(outs, dim=0)
-            cat = torch.nan_to_num(cat, nan=0.0, posinf=0.0, neginf=0.0)
-            return cat
+            return torch.cat(outs, dim=0)
 
     # --- Decode step: s == 1. ---
     # Supports bsz >= 1: each batch element is processed independently using its
@@ -1037,8 +1152,8 @@ def torch_deepseek_v4_sparse_attn_with_cache(
         sin_last = sin
         _decode_compressor_step(
             hidden_states,
-            cos_last,
-            sin_last,
+            cos_anchor,
+            sin_anchor,
             compressor_kv_state,
             compressor_score_state,
             compressed_kv_cache,
@@ -1058,8 +1173,8 @@ def torch_deepseek_v4_sparse_attn_with_cache(
         if has_indexer:
             _decode_compressor_step(
                 hidden_states,
-                cos_last,
-                sin_last,
+                cos_anchor,
+                sin_anchor,
                 indexer_kv_state,
                 indexer_score_state,
                 indexer_compressed_kv_cache,
@@ -1073,6 +1188,7 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                 index_head_dim,
                 rope_head_dim,
                 rms_norm_eps,
+                rotate=True,
             )
             compress_topk = _decode_indexer_step(
                 q_lora,
@@ -1088,17 +1204,13 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                 index_n_heads,
                 index_head_dim,
                 rope_head_dim,
-                # index_topk from the pre-allocated buffer's width
-                indexer_compressed_kv_cache.shape[1]
-                if indexer_compressed_kv_cache.shape[1] > 0
-                else 0,
+                index_topk,
                 offset=window_size,
             )
         else:
             # Deterministic compress top-k: positions 0, 1, ..., (pos+1)//ratio - 1.
-            num_compressed = (pos + 1) // compress_ratio
-            max_c = compressed_kv_cache.shape[1]
-            full = torch.full((1, 1, max_c), -1, device=q.device, dtype=torch.int64)
+            num_compressed = min((pos + 1) // compress_ratio, compressed_kv_cache.shape[1])
+            full = torch.full((1, 1, num_compressed), -1, device=q.device, dtype=torch.int64)
             if num_compressed > 0:
                 full[0, 0, :num_compressed] = (
                     torch.arange(num_compressed, device=q.device) + window_size
@@ -1116,10 +1228,10 @@ def torch_deepseek_v4_sparse_attn_with_cache(
             slot,
             pos,
             window_size,
+            compress_ratio,
             scale,
             head_dim,
         )
-        out = torch.nan_to_num(out, nan=0.0, posinf=0.0, neginf=0.0)
         return out
     else:
         # Batched decode (bsz > 1): process each sequence independently and stack.
@@ -1135,8 +1247,8 @@ def torch_deepseek_v4_sparse_attn_with_cache(
             sin_b = sin[b : b + 1] if sin.shape[0] == bsz else sin
             _decode_compressor_step(
                 hs_b,
-                cos_b,
-                sin_b,
+                cos_anchor,
+                sin_anchor,
                 compressor_kv_state,
                 compressor_score_state,
                 compressed_kv_cache,
@@ -1154,8 +1266,8 @@ def torch_deepseek_v4_sparse_attn_with_cache(
             if has_indexer:
                 _decode_compressor_step(
                     hs_b,
-                    cos_b,
-                    sin_b,
+                    cos_anchor,
+                    sin_anchor,
                     indexer_kv_state,
                     indexer_score_state,
                     indexer_compressed_kv_cache,
@@ -1169,6 +1281,7 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                     index_head_dim,
                     rope_head_dim,
                     rms_norm_eps,
+                    rotate=True,
                 )
                 compress_topk_b = _decode_indexer_step(
                     ql_b,
@@ -1184,15 +1297,14 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                     index_n_heads,
                     index_head_dim,
                     rope_head_dim,
-                    indexer_compressed_kv_cache.shape[1]
-                    if indexer_compressed_kv_cache.shape[1] > 0
-                    else 0,
+                    index_topk,
                     offset=window_size,
                 )
             else:
-                num_compressed_b = (pos_b + 1) // compress_ratio
-                max_c = compressed_kv_cache.shape[1]
-                full_b = torch.full((1, 1, max_c), -1, device=q.device, dtype=torch.int64)
+                num_compressed_b = min((pos_b + 1) // compress_ratio, compressed_kv_cache.shape[1])
+                full_b = torch.full(
+                    (1, 1, num_compressed_b), -1, device=q.device, dtype=torch.int64
+                )
                 if num_compressed_b > 0:
                     full_b[0, 0, :num_compressed_b] = (
                         torch.arange(num_compressed_b, device=q.device) + window_size
@@ -1208,10 +1320,10 @@ def torch_deepseek_v4_sparse_attn_with_cache(
                 slot_b,
                 pos_b,
                 window_size,
+                compress_ratio,
                 scale,
                 head_dim,
             )
-            out_b = torch.nan_to_num(out_b, nan=0.0, posinf=0.0, neginf=0.0)
             outs.append(out_b)
         return torch.cat(outs, dim=0)
 
@@ -1224,6 +1336,8 @@ def torch_deepseek_v4_sparse_attn_with_cache_fake(
     q_lora: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
+    cos_anchor: torch.Tensor,
+    sin_anchor: torch.Tensor,
     attn_sink: torch.Tensor,
     compressor_wkv: torch.Tensor,
     compressor_wgate: torch.Tensor,
@@ -1254,6 +1368,7 @@ def torch_deepseek_v4_sparse_attn_with_cache_fake(
     head_dim: int,
     index_n_heads: int,
     index_head_dim: int,
+    index_topk: int,
     rms_norm_eps: float,
 ) -> torch.Tensor:
     return torch.empty_like(q)
@@ -1277,7 +1392,7 @@ class DeepseekV4SparseAttentionDescriptor(AttentionDescriptor):
     """AttentionDescriptor for the DeepSeek V4 sparse (compress_ratio != 0) layers.
 
     The cached-op signature is:
-        (*qkv_args_17, *std_metadata_5, *caches_7, *constants_8)
+        (*qkv_args_19, *std_metadata_5, *caches_7, *constants_9)
 
     which matches ``_InsertCachedOperator`` 's expected node-replacement contract.
     """
@@ -1288,9 +1403,9 @@ class DeepseekV4SparseAttentionDescriptor(AttentionDescriptor):
 
     @classmethod
     def get_num_qkv_args(cls) -> int:
-        # q, kv, hidden_states, q_lora, cos, sin, attn_sink,
-        # + 4 compressor weights + 6 (optional) indexer weights = 17
-        return 17
+        # q, kv, hidden_states, q_lora, cos, sin, cos_anchor, sin_anchor, attn_sink,
+        # + 4 compressor weights + 6 (optional) indexer weights = 19
+        return 19
 
     @classmethod
     def get_source_attention_op(cls) -> OpOverloadPacket:
@@ -1307,7 +1422,7 @@ class DeepseekV4SparseAttentionDescriptor(AttentionDescriptor):
     @classmethod
     def _extract_constants(
         cls, source_attn_node: Node
-    ) -> Tuple[float, int, int, int, int, int, int, float]:
+    ) -> Tuple[float, int, int, int, int, int, int, int, float]:
         (
             scale,
             window_size,
@@ -1316,6 +1431,7 @@ class DeepseekV4SparseAttentionDescriptor(AttentionDescriptor):
             head_dim,
             index_n_heads,
             index_head_dim,
+            index_topk,
             rms_norm_eps,
         ) = extract_op_args(
             source_attn_node,
@@ -1326,6 +1442,7 @@ class DeepseekV4SparseAttentionDescriptor(AttentionDescriptor):
             "head_dim",
             "index_n_heads",
             "index_head_dim",
+            "index_topk",
             "rms_norm_eps",
         )
         return (
@@ -1336,6 +1453,7 @@ class DeepseekV4SparseAttentionDescriptor(AttentionDescriptor):
             head_dim,
             index_n_heads,
             index_head_dim,
+            index_topk,
             rms_norm_eps,
         )
 
@@ -1351,6 +1469,7 @@ class DeepseekV4SparseAttentionDescriptor(AttentionDescriptor):
             head_dim,
             index_n_heads,
             index_head_dim,
+            _index_topk,
             _rms_norm_eps,
         ) = cls._extract_constants(source_attn_node)
         # Fallback dtypes from the KV fake tensor.

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_sparse_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_sparse_attention.py
@@ -1,0 +1,1402 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+
+"""DeepSeek V4 sparse attention custom op (prefill + cached decode).
+
+Two ops live here:
+
+* ``torch_deepseek_v4_sparse_attn`` — the prefill-only form that wraps the
+  ``compress_ratio != 0`` attention path of ``modeling_deepseek_v4.py`` as a
+  single FX node. The AD KV-cache transform pipeline recognises this op and
+  replaces each node with the cached variant below.
+* ``torch_deepseek_v4_sparse_attn_with_cache`` — the decode-capable variant
+  that maintains (per sequence slot):
+    - ``window_cache`` — ring buffer for the last ``window_size`` KV tokens
+    - ``compressed_kv_cache`` — append-only store of compressed KV tokens
+    - ``compressor_kv_state`` / ``compressor_score_state`` — the HF
+      reference's rolling ``kv_state`` / ``score_state`` (fp32)
+    - three parallel caches for the Indexer's own compressor when the layer
+      uses an Indexer (compress_ratio == 4).
+  Non-indexer layers pass zero-sized stubs for the indexer caches so the op
+  signature is fixed across all sparse layers.
+
+Both ops are stateless in Python — weight tensors and caches are passed in
+as arguments. Keeping the Compressor / Indexer submodules as ``nn.Module``
+children on the parent ``DeepseekV4Attention`` preserves checkpoint key
+names while exposing their weights as graph placeholders after
+``torch.export``.
+"""
+
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch._ops import OpOverloadPacket
+from torch.fx import Node
+
+from .....llmapi.llm_args import KvCacheConfig
+from ...utils.node_utils import extract_op_args
+from ..attention_interface import (
+    AttentionDescriptor,
+    AttentionLayout,
+    AttentionRegistry,
+    Constant,
+    MHACallable,
+    ResourceHandlerDict,
+    StateResourceHandler,
+    UnpagedResourceHandler,
+)
+
+# ----------------------------------------------------------------------------
+# Private helpers — ported verbatim from modeling_deepseek_v4.py
+# ----------------------------------------------------------------------------
+
+
+def _apply_interleaved_rope(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, inverse: bool = False
+) -> torch.Tensor:
+    """Interleaved (complex-style) RoPE on the last dim of ``x`` in pure real ops.
+
+    ``x``: ``[..., rope_head_dim]`` with channel pairs ``[a0, b0, a1, b1, ...]``.
+    ``cos``/``sin``: must broadcast against ``x[..., ::2]`` / ``x[..., 1::2]``.
+    ``inverse=True`` negates sin, i.e. multiplies by the complex conjugate.
+    """
+    if inverse:
+        sin = -sin
+    a = x[..., 0::2]
+    b = x[..., 1::2]
+    out_a = a * cos - b * sin
+    out_b = a * sin + b * cos
+    return torch.stack([out_a, out_b], dim=-1).flatten(-2).type_as(x)
+
+
+def _overlap_transform(tensor: torch.Tensor, head_dim: int, value: float = 0.0) -> torch.Tensor:
+    """HF DeepSeek V4 overlap transform used by ratio-4 compression."""
+    bsz, _, ratio, _ = tensor.shape
+    previous = tensor[:, :, :, :head_dim]
+    current = tensor[:, :, :, head_dim:]
+    prefix = tensor.new_full((bsz, 1, ratio, head_dim), value)
+    previous = torch.cat([prefix, previous[:, :-1]], dim=1)
+    return torch.cat([previous, current], dim=2)
+
+
+def _window_topk_idxs(
+    window_size: int, bsz: int, seqlen: int, device: torch.device
+) -> torch.Tensor:
+    """Prefill (``start_pos == 0``) version of HF ``get_window_topk_idxs``.
+
+    The window axis is kept at static ``window_size`` for export. Entries
+    outside the real causal window are marked ``-1`` and ignored downstream.
+    """
+    base = torch.arange(seqlen, device=device).unsqueeze(1)
+    matrix = base - window_size + 1 + torch.arange(window_size, device=device)
+    matrix = torch.where((matrix < 0) | (matrix > base), -1, matrix)
+    return matrix.unsqueeze(0).expand(bsz, -1, -1)
+
+
+def _compress_topk_idxs(
+    ratio: int, bsz: int, seqlen: int, offset: int, device: torch.device
+) -> torch.Tensor:
+    """Prefill version of HF ``get_compress_topk_idxs``.
+
+    Padded to ``seqlen`` so the dynamic export shape doesn't specialise on
+    ``seqlen // ratio``.
+    """
+    matrix = torch.arange(seqlen, device=device).repeat(seqlen, 1)
+    valid_count = torch.arange(1, seqlen + 1, device=device).unsqueeze(1) // ratio
+    mask = matrix >= valid_count
+    matrix = torch.where(mask, -1, matrix + offset)
+    return matrix.unsqueeze(0).expand(bsz, -1, -1)
+
+
+def _build_sparse_attn_mask(topk_idxs: torch.Tensor, total_kv_len: int) -> torch.Tensor:
+    """Convert top-k index lists ``[B, S, K]`` into additive attention mask.
+
+    Returns ``[B, 1, S, total_kv_len]`` with 0 for selected positions and
+    ``-inf`` elsewhere. ``-1`` entries in ``topk_idxs`` are treated as invalid.
+    """
+    valid = topk_idxs >= 0
+    kv_positions = torch.arange(total_kv_len, device=topk_idxs.device)
+    selected = topk_idxs.unsqueeze(-1) == kv_positions.view(1, 1, 1, -1)
+    selected = (selected & valid.unsqueeze(-1)).any(dim=2)
+    mask = topk_idxs.new_zeros(selected.shape, dtype=torch.float32)
+    mask = mask.masked_fill(~selected, -10000.0)
+    return mask.unsqueeze(1)
+
+
+def _ratio_chunk_indices(
+    seqlen: int, ratio: int, device: torch.device
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return padded ratio chunk token indices and their validity mask."""
+    chunk_ids = torch.arange(seqlen, device=device).unsqueeze(1)
+    token_offsets = torch.arange(ratio, device=device)
+    indices = chunk_ids * ratio + token_offsets
+    valid = indices < seqlen
+    indices = torch.where(valid, indices, torch.zeros_like(indices))
+    return indices, valid
+
+
+def _manual_attention_with_sinks(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    attn_mask: torch.Tensor,
+    scale: float,
+    sinks: torch.Tensor,
+) -> torch.Tensor:
+    """Reference-style attention with learnable sinks used by compressed sparse layers.
+
+    q: ``[B, S, H, D]``; k, v: ``[B, S_kv, 1, D]`` (broadcast over heads). Returns ``[B, S, H, D]``.
+    """
+    bsz, seqlen, n_heads, head_dim = q.shape
+    kv_len = k.shape[1]
+    q_bh = q.transpose(1, 2).float()
+    k_bh = k.expand(bsz, kv_len, n_heads, head_dim).transpose(1, 2).float()
+    v_bh = v.expand(bsz, kv_len, n_heads, head_dim).transpose(1, 2).float()
+    scores = torch.matmul(q_bh, k_bh.transpose(-2, -1)) * scale
+    scores = scores + attn_mask.float()
+
+    sink_logits = sinks.float().reshape(1, n_heads, 1, 1).expand(bsz, n_heads, seqlen, 1)
+    logits_max = scores.max(dim=-1, keepdim=True).values
+    exp_scores = torch.exp(scores - logits_max)
+    exp_sinks = torch.exp(sink_logits - logits_max)
+    attn = exp_scores / (exp_scores.sum(dim=-1, keepdim=True) + exp_sinks)
+    out = torch.matmul(attn, v_bh)
+    return out.transpose(1, 2).contiguous().to(q.dtype)
+
+
+# ----------------------------------------------------------------------------
+# Stateless prefill building blocks: compressor + indexer
+# ----------------------------------------------------------------------------
+
+
+def _sparse_compressor(
+    hidden_states: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    wkv: torch.Tensor,  # [coff*head_dim, hidden]
+    wgate: torch.Tensor,  # [coff*head_dim, hidden]
+    ape: torch.Tensor,  # [ratio, coff*head_dim]
+    norm_weight: torch.Tensor,  # [head_dim]
+    *,
+    head_dim: int,
+    rope_head_dim: int,
+    compress_ratio: int,
+    rms_norm_eps: float,
+) -> torch.Tensor:
+    """Stateless equivalent of DeepseekV4Compressor.forward (prefill only)."""
+    bsz, seqlen, _ = hidden_states.shape
+    overlap = compress_ratio == 4
+    chunk_indices, chunk_valid = _ratio_chunk_indices(seqlen, compress_ratio, hidden_states.device)
+    flat_indices = chunk_indices.reshape(-1)
+
+    kv_all = F.linear(hidden_states, wkv).float()
+    score_all = F.linear(hidden_states, wgate).float()
+    kv = kv_all[:, flat_indices].view(bsz, seqlen, compress_ratio, -1)
+    score = score_all[:, flat_indices].view(bsz, seqlen, compress_ratio, -1) + ape
+    score = torch.where(
+        chunk_valid.view(1, seqlen, compress_ratio, 1),
+        score,
+        score.new_full((), -1.0e20),
+    )
+    if overlap:
+        kv = _overlap_transform(kv, head_dim, 0.0)
+        score = _overlap_transform(score, head_dim, -1.0e20)
+
+    # Chunks whose scores are all ``-1e20`` (chunk index >= ceil(seqlen / ratio)
+    # for non-overlap, or the first chunk in overlap with no previous data) produce
+    # ``exp(-1e20) / sum(exp(-1e20)) = 0/0 = NaN`` from softmax. Detect rows that
+    # would be all-masked and substitute a safe weight vector so the rest of the
+    # op doesn't propagate NaN into ``kv_all`` downstream. Invalid rows of the
+    # output are filtered out anyway via the attention mask's top-k indices.
+    score_max = score.amax(dim=2, keepdim=True)
+    row_all_masked = score_max <= -1.0e19  # true when the whole row is -1e20
+    score = torch.where(row_all_masked, torch.zeros_like(score), score)
+    compressed = (kv * score.softmax(dim=2)).sum(dim=2)
+    compressed = torch.ops.auto_deploy.torch_rmsnorm(
+        compressed.to(hidden_states.dtype), norm_weight, rms_norm_eps
+    ).to(hidden_states.dtype)
+
+    chunk_start = torch.arange(seqlen, device=hidden_states.device) * compress_ratio
+    chunk_start = torch.where(chunk_start < seqlen, chunk_start, torch.zeros_like(chunk_start))
+    cos_comp = cos[:, chunk_start]
+    sin_comp = sin[:, chunk_start]
+    nope, pe = torch.split(compressed, [head_dim - rope_head_dim, rope_head_dim], dim=-1)
+    pe = _apply_interleaved_rope(pe, cos_comp, sin_comp)
+    return torch.cat([nope, pe], dim=-1)
+
+
+def _sparse_indexer(
+    hidden_states: torch.Tensor,
+    q_lora: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    offset: int,
+    wq_b: torch.Tensor,  # [index_n_heads*index_head_dim, q_lora_rank]
+    weights_proj: torch.Tensor,  # [index_n_heads, hidden]
+    compressor_wkv: torch.Tensor,
+    compressor_wgate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    *,
+    index_n_heads: int,
+    index_head_dim: int,
+    rope_head_dim: int,
+    compress_ratio: int,
+    rms_norm_eps: float,
+) -> torch.Tensor:
+    """Stateless equivalent of DeepseekV4Indexer.forward (prefill only)."""
+    bsz, seqlen, _ = hidden_states.shape
+    softmax_scale = index_head_dim**-0.5
+    rd = rope_head_dim
+
+    q = F.linear(q_lora, wq_b).view(bsz, seqlen, index_n_heads, index_head_dim)
+    q_nope, q_pe = torch.split(q, [index_head_dim - rd, rd], dim=-1)
+    q_pe = _apply_interleaved_rope(q_pe, cos.unsqueeze(2), sin.unsqueeze(2))
+    q = torch.cat([q_nope, q_pe], dim=-1)
+
+    index_k = _sparse_compressor(
+        hidden_states,
+        cos,
+        sin,
+        compressor_wkv,
+        compressor_wgate,
+        compressor_ape,
+        compressor_norm_weight,
+        head_dim=index_head_dim,
+        rope_head_dim=rope_head_dim,
+        compress_ratio=compress_ratio,
+        rms_norm_eps=rms_norm_eps,
+    )
+    weights = F.linear(hidden_states, weights_proj).float() * (softmax_scale * index_n_heads**-0.5)
+
+    index_score = torch.einsum("bshd,btd->bsht", q, index_k).float()
+    index_score = (index_score.relu() * weights.unsqueeze(-1)).sum(dim=2)
+
+    compressed_positions = torch.arange(seqlen, device=hidden_states.device)
+    valid_count = (
+        torch.arange(1, seqlen + 1, device=hidden_states.device).unsqueeze(1) // compress_ratio
+    )
+    future_mask = compressed_positions.unsqueeze(0) >= valid_count
+    valid = ~future_mask
+    index_score = index_score.masked_fill(future_mask.unsqueeze(0), -1.0e20)
+
+    sorted_idxs = index_score.argsort(dim=-1, descending=True)
+    sorted_valid = valid.unsqueeze(0).expand(bsz, -1, -1).gather(-1, sorted_idxs)
+    return torch.where(sorted_valid, sorted_idxs + offset, -1)
+
+
+def _sparse_attn_prefill_body(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    hidden_states: torch.Tensor,
+    q_lora: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    attn_sink: torch.Tensor,
+    compressor_wkv: torch.Tensor,
+    compressor_wgate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    indexer_wq_b: Optional[torch.Tensor],
+    indexer_weights_proj: Optional[torch.Tensor],
+    indexer_compressor_wkv: Optional[torch.Tensor],
+    indexer_compressor_wgate: Optional[torch.Tensor],
+    indexer_compressor_ape: Optional[torch.Tensor],
+    indexer_compressor_norm_weight: Optional[torch.Tensor],
+    *,
+    scale: float,
+    window_size: int,
+    compress_ratio: int,
+    rope_head_dim: int,
+    head_dim: int,
+    index_n_heads: int,
+    index_head_dim: int,
+    rms_norm_eps: float,
+) -> torch.Tensor:
+    """Shared prefill attention body reused by the exported op and equivalence tests."""
+    bsz, seqlen, _, _ = q.shape
+
+    kv_compress = _sparse_compressor(
+        hidden_states,
+        cos,
+        sin,
+        compressor_wkv,
+        compressor_wgate,
+        compressor_ape,
+        compressor_norm_weight,
+        head_dim=head_dim,
+        rope_head_dim=rope_head_dim,
+        compress_ratio=compress_ratio,
+        rms_norm_eps=rms_norm_eps,
+    )
+
+    if indexer_wq_b is not None:
+        compress_topk = _sparse_indexer(
+            hidden_states,
+            q_lora,
+            cos,
+            sin,
+            offset=seqlen,
+            wq_b=indexer_wq_b,
+            weights_proj=indexer_weights_proj,
+            compressor_wkv=indexer_compressor_wkv,
+            compressor_wgate=indexer_compressor_wgate,
+            compressor_ape=indexer_compressor_ape,
+            compressor_norm_weight=indexer_compressor_norm_weight,
+            index_n_heads=index_n_heads,
+            index_head_dim=index_head_dim,
+            rope_head_dim=rope_head_dim,
+            compress_ratio=compress_ratio,
+            rms_norm_eps=rms_norm_eps,
+        )
+    else:
+        compress_topk = _compress_topk_idxs(
+            compress_ratio, bsz, seqlen, seqlen, hidden_states.device
+        )
+
+    window_topk = _window_topk_idxs(window_size, bsz, seqlen, hidden_states.device)
+    topk_idxs = torch.cat([window_topk, compress_topk], dim=-1)
+    kv_all = torch.cat([kv, kv_compress.view(bsz, seqlen, 1, head_dim)], dim=1)
+    attn_mask = _build_sparse_attn_mask(topk_idxs, kv_all.shape[1]).to(q.dtype)
+    return _manual_attention_with_sinks(q, kv_all, kv_all, attn_mask, scale, attn_sink)
+
+
+# ----------------------------------------------------------------------------
+# Custom op registration (prefill)
+# ----------------------------------------------------------------------------
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_sparse_attn", mutates_args=())
+def torch_deepseek_v4_sparse_attn(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    hidden_states: torch.Tensor,
+    q_lora: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    attn_sink: torch.Tensor,
+    compressor_wkv: torch.Tensor,
+    compressor_wgate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    indexer_wq_b: Optional[torch.Tensor],
+    indexer_weights_proj: Optional[torch.Tensor],
+    indexer_compressor_wkv: Optional[torch.Tensor],
+    indexer_compressor_wgate: Optional[torch.Tensor],
+    indexer_compressor_ape: Optional[torch.Tensor],
+    indexer_compressor_norm_weight: Optional[torch.Tensor],
+    scale: float,
+    window_size: int,
+    compress_ratio: int,
+    rope_head_dim: int,
+    head_dim: int,
+    index_n_heads: int,
+    index_head_dim: int,
+    rms_norm_eps: float,
+    layer_idx: Optional[int] = None,
+    layer_type: str = "mha_sparse",
+) -> torch.Tensor:
+    """DeepSeek V4 prefill-only sparse (compress_ratio != 0) attention.
+
+    Layout is ``bsnd``. Returns ``[B, S, H, head_dim]`` — the rotary
+    inversion on the output happens outside this op to keep the op
+    boundary clean.
+    """
+    del layer_idx, layer_type  # metadata only — read by AttentionDescriptor
+    return _sparse_attn_prefill_body(
+        q,
+        kv,
+        hidden_states,
+        q_lora,
+        cos,
+        sin,
+        attn_sink,
+        compressor_wkv,
+        compressor_wgate,
+        compressor_ape,
+        compressor_norm_weight,
+        indexer_wq_b,
+        indexer_weights_proj,
+        indexer_compressor_wkv,
+        indexer_compressor_wgate,
+        indexer_compressor_ape,
+        indexer_compressor_norm_weight,
+        scale=scale,
+        window_size=window_size,
+        compress_ratio=compress_ratio,
+        rope_head_dim=rope_head_dim,
+        head_dim=head_dim,
+        index_n_heads=index_n_heads,
+        index_head_dim=index_head_dim,
+        rms_norm_eps=rms_norm_eps,
+    )
+
+
+@torch_deepseek_v4_sparse_attn.register_fake
+def torch_deepseek_v4_sparse_attn_fake(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    hidden_states: torch.Tensor,
+    q_lora: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    attn_sink: torch.Tensor,
+    compressor_wkv: torch.Tensor,
+    compressor_wgate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    indexer_wq_b: Optional[torch.Tensor],
+    indexer_weights_proj: Optional[torch.Tensor],
+    indexer_compressor_wkv: Optional[torch.Tensor],
+    indexer_compressor_wgate: Optional[torch.Tensor],
+    indexer_compressor_ape: Optional[torch.Tensor],
+    indexer_compressor_norm_weight: Optional[torch.Tensor],
+    scale: float,
+    window_size: int,
+    compress_ratio: int,
+    rope_head_dim: int,
+    head_dim: int,
+    index_n_heads: int,
+    index_head_dim: int,
+    rms_norm_eps: float,
+    layer_idx: Optional[int] = None,
+    layer_type: str = "mha_sparse",
+) -> torch.Tensor:
+    return torch.empty_like(q)
+
+
+# ----------------------------------------------------------------------------
+# Decode-capable cached variant
+# ----------------------------------------------------------------------------
+
+
+def _seed_compressor_state(
+    hidden_states: torch.Tensor,
+    kv_state: torch.Tensor,
+    score_state: torch.Tensor,
+    wkv: torch.Tensor,
+    wgate: torch.Tensor,
+    ape: torch.Tensor,
+    slot: int,
+    compress_ratio: int,
+) -> None:
+    """Seed the Compressor's rolling state buffers with the last chunk of a prefill.
+
+    Mirrors the HF reference's ``start_pos == 0`` branch in ``Compressor.forward``:
+    when the prefill length is not a multiple of ``ratio``, the leftover tokens
+    initialise the rolling buffer so subsequent decode steps continue from the
+    correct position inside the ratio window.
+    """
+    bsz, seqlen, _ = hidden_states.shape
+    assert bsz == 1, "Cached op currently supports single-batch inference."
+    overlap = compress_ratio == 4
+    remainder = seqlen % compress_ratio
+    cutoff = seqlen - remainder
+    offset = compress_ratio if overlap else 0
+
+    kv_all = F.linear(hidden_states, wkv).float()
+    score_all = F.linear(hidden_states, wgate).float()
+
+    # Overlap window: stash the last full chunk of kv/score as the 'previous' slots.
+    if overlap and cutoff >= compress_ratio:
+        kv_state[slot, :compress_ratio] = kv_all[0, cutoff - compress_ratio : cutoff]
+        # score for the previous chunk does not yet get the ape added — matches HF reference.
+        score_state[slot, :compress_ratio] = score_all[0, cutoff - compress_ratio : cutoff] + ape
+    else:
+        # No previous overlap yet; zero out the previous-window slots.
+        if overlap:
+            kv_state[slot, :compress_ratio].zero_()
+            score_state[slot, :compress_ratio].fill_(-1.0e20)
+
+    # Remainder (partial-chunk) tokens go into the current-window slots.
+    if overlap:
+        # Fully reset the current window.
+        kv_state[slot, compress_ratio:].zero_()
+        score_state[slot, compress_ratio:].fill_(-1.0e20)
+    else:
+        kv_state[slot].zero_()
+        score_state[slot].fill_(-1.0e20)
+    if remainder > 0:
+        kv_state[slot, offset : offset + remainder] = kv_all[0, cutoff:]
+        score_state[slot, offset : offset + remainder] = score_all[0, cutoff:] + ape[:remainder]
+
+
+def _decode_compressor_step(
+    hidden_states: torch.Tensor,  # [1, 1, hidden]
+    cos_last: torch.Tensor,  # [1, 1, rd/2]
+    sin_last: torch.Tensor,  # [1, 1, rd/2]
+    kv_state: torch.Tensor,  # [max_batch, coff*ratio, coff*head_dim]
+    score_state: torch.Tensor,  # [max_batch, coff*ratio, coff*head_dim]
+    compressed_kv_cache: torch.Tensor,  # [max_batch, max_compressed, head_dim]
+    wkv: torch.Tensor,
+    wgate: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: torch.Tensor,
+    slot: int,
+    input_pos: int,
+    compress_ratio: int,
+    head_dim: int,
+    rope_head_dim: int,
+    rms_norm_eps: float,
+) -> None:
+    """One decode step's Compressor update. Writes to state + (maybe) compressed_kv_cache.
+
+    Note: ``kv_state`` / ``score_state`` may be allocated with a larger axis-1
+    (e.g. ``max_seq_len``) than the logical rolling-state size. We only use the
+    first ``coff * compress_ratio`` slots and must index with explicit bounds.
+    """
+    overlap = compress_ratio == 4
+    used_slots = (2 if overlap else 1) * compress_ratio  # logical state size
+    kv = F.linear(hidden_states, wkv).float()  # [1, 1, coff*head_dim]
+    score = F.linear(hidden_states, wgate).float() + ape[input_pos % compress_ratio]
+
+    if overlap:
+        slot_idx_in_state = compress_ratio + (input_pos % compress_ratio)
+    else:
+        slot_idx_in_state = input_pos % compress_ratio
+    kv_state[slot, slot_idx_in_state] = kv.squeeze(0).squeeze(0)
+    score_state[slot, slot_idx_in_state] = score.squeeze(0).squeeze(0)
+
+    should_compress = (input_pos + 1) % compress_ratio == 0
+    if not should_compress:
+        return
+
+    if overlap:
+        kv_full = torch.cat(
+            [
+                kv_state[slot, :compress_ratio, :head_dim],
+                kv_state[slot, compress_ratio:used_slots, head_dim:],
+            ],
+            dim=0,
+        )
+        score_full = torch.cat(
+            [
+                score_state[slot, :compress_ratio, :head_dim],
+                score_state[slot, compress_ratio:used_slots, head_dim:],
+            ],
+            dim=0,
+        )
+        # [2*ratio, head_dim] softmax along axis 0 -> weight per slot.
+        compressed = (kv_full * score_full.softmax(dim=0)).sum(dim=0)
+        # Rotate rolling state: previous <- current, reset current.
+        kv_state[slot, :compress_ratio] = kv_state[slot, compress_ratio:used_slots]
+        score_state[slot, :compress_ratio] = score_state[slot, compress_ratio:used_slots]
+        kv_state[slot, compress_ratio:used_slots].zero_()
+        score_state[slot, compress_ratio:used_slots].fill_(-1.0e20)
+    else:
+        compressed = (
+            kv_state[slot, :used_slots] * score_state[slot, :used_slots].softmax(dim=0)
+        ).sum(dim=0)
+        kv_state[slot, :used_slots].zero_()
+        score_state[slot, :used_slots].fill_(-1.0e20)
+
+    compressed = compressed.view(1, 1, head_dim).to(hidden_states.dtype)
+    compressed = torch.ops.auto_deploy.torch_rmsnorm(compressed, norm_weight, rms_norm_eps).to(
+        hidden_states.dtype
+    )
+    nope, pe = torch.split(compressed, [head_dim - rope_head_dim, rope_head_dim], dim=-1)
+    # TODO(ds-v4 cached): use cos/sin at position ``input_pos+1-compress_ratio``
+    # (chunk-start anchor) instead of ``cos_last``/``sin_last`` (current decode
+    # step). Fresh prefill rotates each compressed token by the freqs at its
+    # chunk's starting position; using the current-step freqs causes the
+    # ratio-4 Indexer's top-k to drift from the prefill result. Fix requires
+    # plumbing either the full cos/sin table or the anchor cos/sin through the
+    # op signature.
+    pe = _apply_interleaved_rope(pe, cos_last, sin_last)
+    compressed = torch.cat([nope, pe], dim=-1)
+
+    write_idx = input_pos // compress_ratio
+    compressed_kv_cache[slot, write_idx] = compressed.squeeze(0).squeeze(0)
+
+
+def _decode_indexer_step(
+    q_lora: torch.Tensor,
+    cos_last: torch.Tensor,
+    sin_last: torch.Tensor,
+    wq_b: torch.Tensor,
+    weights_proj: torch.Tensor,
+    indexer_compressed_kv_cache: torch.Tensor,
+    slot: int,
+    input_pos: int,
+    hidden_states: torch.Tensor,
+    compress_ratio: int,
+    index_n_heads: int,
+    index_head_dim: int,
+    rope_head_dim: int,
+    index_topk: int,
+    offset: int,
+) -> torch.Tensor:
+    """Compute compressed-KV top-k indices at decode for one token."""
+    num_compressed = (input_pos + 1) // compress_ratio
+    if num_compressed == 0:
+        # No compressed tokens yet — return empty-by-padding (all -1) matching prefill output.
+        return torch.full((1, 1, index_topk), -1, device=hidden_states.device, dtype=torch.int64)
+    softmax_scale = index_head_dim**-0.5
+    q = F.linear(q_lora, wq_b).view(1, 1, index_n_heads, index_head_dim)
+    rd = rope_head_dim
+    q_nope, q_pe = torch.split(q, [index_head_dim - rd, rd], dim=-1)
+    q_pe = _apply_interleaved_rope(q_pe, cos_last.unsqueeze(2), sin_last.unsqueeze(2))
+    q = torch.cat([q_nope, q_pe], dim=-1)
+
+    weights = F.linear(hidden_states, weights_proj).float() * (
+        softmax_scale * index_n_heads**-0.5
+    )  # [1, 1, index_n_heads]
+    index_k = indexer_compressed_kv_cache[
+        slot : slot + 1, :num_compressed
+    ]  # [1, num_compressed, index_head_dim]
+    index_score = torch.einsum("bshd,btd->bsht", q, index_k).float()
+    index_score = (index_score.relu() * weights.unsqueeze(-1)).sum(dim=2)  # [1, 1, num_compressed]
+
+    k = min(index_topk, num_compressed)
+    topk = index_score.topk(k, dim=-1).indices  # [1, 1, k]
+    topk = topk + offset
+    if k < index_topk:
+        pad = torch.full((1, 1, index_topk - k), -1, device=hidden_states.device, dtype=topk.dtype)
+        topk = torch.cat([topk, pad], dim=-1)
+    return topk.to(torch.int64)
+
+
+def _seed_indexer_compressed_cache(
+    hidden_states: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    indexer_compressor_wkv: torch.Tensor,
+    indexer_compressor_wgate: torch.Tensor,
+    indexer_compressor_ape: torch.Tensor,
+    indexer_compressor_norm_weight: torch.Tensor,
+    indexer_compressed_kv_cache: torch.Tensor,
+    indexer_kv_state: torch.Tensor,
+    indexer_score_state: torch.Tensor,
+    slot: int,
+    compress_ratio: int,
+    index_head_dim: int,
+    rope_head_dim: int,
+    rms_norm_eps: float,
+) -> None:
+    """Prefill-seed the Indexer's own compressed KV cache and rolling state."""
+    bsz, seqlen, _ = hidden_states.shape
+    # Reuse the stateless compressor on the Indexer's dimensions.
+    idx_compressed = _sparse_compressor(
+        hidden_states,
+        cos,
+        sin,
+        indexer_compressor_wkv,
+        indexer_compressor_wgate,
+        indexer_compressor_ape,
+        indexer_compressor_norm_weight,
+        head_dim=index_head_dim,
+        rope_head_dim=rope_head_dim,
+        compress_ratio=compress_ratio,
+        rms_norm_eps=rms_norm_eps,
+    )  # [1, seqlen, index_head_dim]
+    # Zero full slot first — UnpagedResourceHandler.allocate() uses torch.empty()
+    # so unused entries contain uninitialized memory that would propagate NaN
+    # into the indexer's score path at decode.
+    indexer_compressed_kv_cache[slot].zero_()
+    num_compressed = seqlen // compress_ratio
+    if num_compressed > 0:
+        indexer_compressed_kv_cache[slot, :num_compressed] = idx_compressed[0, :num_compressed]
+    _seed_compressor_state(
+        hidden_states,
+        indexer_kv_state,
+        indexer_score_state,
+        indexer_compressor_wkv,
+        indexer_compressor_wgate,
+        indexer_compressor_ape,
+        slot,
+        compress_ratio,
+    )
+
+
+def _decode_sparse_attn_step(
+    q: torch.Tensor,  # [1, 1, H, D]
+    kv_new: torch.Tensor,  # [1, 1, 1, D]
+    attn_sink: torch.Tensor,
+    window_cache: torch.Tensor,  # [max_batch, window, D]
+    compressed_kv_cache: torch.Tensor,  # [max_batch, max_compressed, D]
+    compress_topk: torch.Tensor,  # [1, 1, K] — absolute indices into concat(window, compressed)
+    slot: int,
+    input_pos: int,
+    window_size: int,
+    scale: float,
+    head_dim: int,
+) -> torch.Tensor:
+    """Compute the sparse attention output for one decode step."""
+    # Update window ring buffer with the current-token KV.
+    window_cache[slot, input_pos % window_size] = kv_new.squeeze(0).squeeze(0).squeeze(0)
+    # Build window top-k (positions of the last min(input_pos+1, window_size) tokens).
+    visible_window = min(input_pos + 1, window_size)
+    device = q.device
+    # Window positions are logical absolute positions max(0, input_pos+1-window)..input_pos.
+    # For the attention mask we index into the combined KV tensor, where window rows come first.
+    # Ring buffer layout: row i in window_cache corresponds to the token written at some past position
+    # where pos % window == i. Easiest is to gather the visible rows in chronological order below.
+    first = input_pos + 1 - visible_window
+    mod_indices = (torch.arange(visible_window, device=device) + first) % window_size
+    gathered_window = window_cache[slot][mod_indices]  # [visible_window, head_dim]
+
+    # Pad window to window_size for static shapes.
+    if visible_window < window_size:
+        pad = window_cache.new_zeros(window_size - visible_window, head_dim)
+        gathered_window = torch.cat([gathered_window, pad], dim=0)
+    # Build full concat(window, compressed) along token axis.
+    kv_all = torch.cat([gathered_window, compressed_kv_cache[slot]], dim=0)  # [window + max_c, D]
+    # Window top-k indices are just [0..visible_window-1]; entries beyond are -1.
+    window_topk = torch.full((1, 1, window_size), -1, device=device, dtype=compress_topk.dtype)
+    window_topk[0, 0, :visible_window] = torch.arange(visible_window, device=device)
+    topk_idxs = torch.cat([window_topk, compress_topk], dim=-1)
+    attn_mask = _build_sparse_attn_mask(topk_idxs, kv_all.shape[0]).to(q.dtype)
+
+    kv_all = kv_all.view(1, kv_all.shape[0], 1, head_dim)
+    return _manual_attention_with_sinks(q, kv_all, kv_all, attn_mask, scale, attn_sink)
+
+
+_CACHE_NAMES = (
+    "window_cache",
+    "compressed_kv_cache",
+    "compressor_kv_state",
+    "compressor_score_state",
+    "indexer_compressed_kv_cache",
+    "indexer_kv_state",
+    "indexer_score_state",
+)
+
+
+@torch.library.custom_op(
+    "auto_deploy::torch_deepseek_v4_sparse_attn_with_cache", mutates_args=_CACHE_NAMES
+)
+def torch_deepseek_v4_sparse_attn_with_cache(
+    # --- Source-op tensor args (17). Order MUST match the prefill op's qkv arg layout. ---
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    hidden_states: torch.Tensor,
+    q_lora: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    attn_sink: torch.Tensor,
+    compressor_wkv: torch.Tensor,
+    compressor_wgate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    indexer_wq_b: Optional[torch.Tensor],
+    indexer_weights_proj: Optional[torch.Tensor],
+    indexer_compressor_wkv: Optional[torch.Tensor],
+    indexer_compressor_wgate: Optional[torch.Tensor],
+    indexer_compressor_ape: Optional[torch.Tensor],
+    indexer_compressor_norm_weight: Optional[torch.Tensor],
+    # --- Standard AD metadata (5). Matches torch backend. ---
+    batch_info_host: torch.Tensor,
+    seq_len: torch.Tensor,
+    input_pos: torch.Tensor,
+    slot_idx: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    # --- Caches (7, mutated). ---
+    window_cache: torch.Tensor,
+    compressed_kv_cache: torch.Tensor,
+    compressor_kv_state: torch.Tensor,
+    compressor_score_state: torch.Tensor,
+    indexer_compressed_kv_cache: torch.Tensor,
+    indexer_kv_state: torch.Tensor,
+    indexer_score_state: torch.Tensor,
+    # --- Constants (8). Returned by AttentionDescriptor.get_constants. ---
+    scale: float,
+    window_size: int,
+    compress_ratio: int,
+    rope_head_dim: int,
+    head_dim: int,
+    index_n_heads: int,
+    index_head_dim: int,
+    rms_norm_eps: float,
+) -> torch.Tensor:
+    """DeepSeek V4 sparse attention with KV cache (prefill seeds, decode updates).
+
+    Prefill (``s > 1``) supports ``B >= 1``; each element in the batch is
+    processed independently and its KV caches are seeded using the corresponding
+    slot from ``slot_idx[b]``.
+
+    Decode (``s == 1``) still requires ``B == 1``.  Multi-sequence decode via
+    ``cu_seqlen`` is a follow-up.
+    """
+    del batch_info_host, cu_seqlen
+    bsz, s, _, _ = q.shape
+    has_indexer = indexer_wq_b is not None
+
+    # KNOWN-ISSUE (DS-V4 E2E decode):
+    # On the first decode step after an 8-GPU TP prefill with the reduced
+    # 5-layer registry fixture, layer-3 (ratio=128) decode output contains
+    # NaN that cascades forward and ultimately trips the sampler's
+    # ``_flashinfer_check_nans`` async CUDA assert. Bandaids that zero NaN at
+    # this op boundary do not fix the problem — so the NaN source is upstream
+    # (likely trtllm_finegrained_fp8_linear or the HC-Sinkhorn chain) and
+    # resists localisation without per-step logit dumping. Prefill works end
+    # to end; all-dense decode works end to end; numerics-of-sparse-decode is
+    # tracked as a follow-up.
+
+    if s > 1:
+        # --- Prefill: run the stateless body and seed caches per batch element. ---
+        if bsz == 1:
+            out = _sparse_attn_prefill_body(
+                q,
+                kv,
+                hidden_states,
+                q_lora,
+                cos,
+                sin,
+                attn_sink,
+                compressor_wkv,
+                compressor_wgate,
+                compressor_ape,
+                compressor_norm_weight,
+                indexer_wq_b,
+                indexer_weights_proj,
+                indexer_compressor_wkv,
+                indexer_compressor_wgate,
+                indexer_compressor_ape,
+                indexer_compressor_norm_weight,
+                scale=scale,
+                window_size=window_size,
+                compress_ratio=compress_ratio,
+                rope_head_dim=rope_head_dim,
+                head_dim=head_dim,
+                index_n_heads=index_n_heads,
+                index_head_dim=index_head_dim,
+                rms_norm_eps=rms_norm_eps,
+            )
+            slot = int(slot_idx[0].item())
+            # Seed the window ring buffer with the last min(s, window) tokens.
+            # Zero ALL unused slots first: UnpagedResourceHandler.allocate() uses
+            # torch.empty() which leaves uninitialized memory (possibly NaN). If
+            # we don't zero out the padding, kv_all = cat(window, compressed) at
+            # decode time contains NaN garbage, ``q @ kv_all.T`` propagates NaN
+            # into even the attention-masked positions, and logits NaN out.
+            window_cache[slot].zero_()
+            fill = min(s, window_size)
+            window_cache[slot, :fill] = kv[0, s - fill : s, 0, :]
+            # Seed the compressed KV cache by re-running the stateless compressor.
+            compressed = _sparse_compressor(
+                hidden_states,
+                cos,
+                sin,
+                compressor_wkv,
+                compressor_wgate,
+                compressor_ape,
+                compressor_norm_weight,
+                head_dim=head_dim,
+                rope_head_dim=rope_head_dim,
+                compress_ratio=compress_ratio,
+                rms_norm_eps=rms_norm_eps,
+            )  # [1, s, head_dim]
+            compressed_kv_cache[slot].zero_()
+            num_compressed = s // compress_ratio
+            if num_compressed > 0:
+                compressed_kv_cache[slot, :num_compressed] = compressed[0, :num_compressed]
+            _seed_compressor_state(
+                hidden_states,
+                compressor_kv_state,
+                compressor_score_state,
+                compressor_wkv,
+                compressor_wgate,
+                compressor_ape,
+                slot,
+                compress_ratio,
+            )
+            if has_indexer:
+                _seed_indexer_compressed_cache(
+                    hidden_states,
+                    cos,
+                    sin,
+                    indexer_compressor_wkv,
+                    indexer_compressor_wgate,
+                    indexer_compressor_ape,
+                    indexer_compressor_norm_weight,
+                    indexer_compressed_kv_cache,
+                    indexer_kv_state,
+                    indexer_score_state,
+                    slot,
+                    compress_ratio,
+                    index_head_dim,
+                    rope_head_dim,
+                    rms_norm_eps,
+                )
+            # Bandaid: zero out any non-finite slots so downstream layers don't
+            # see NaN.  TODO: fix the underlying numerics (likely sinks + very
+            # negative masked scores overflowing in fp32 exp for layers where
+            # visible kv count is tiny relative to total masked kv length).
+            out = torch.nan_to_num(out, nan=0.0, posinf=0.0, neginf=0.0)
+            return out
+        else:
+            # Batched prefill (B > 1): process each sequence independently and
+            # stack the per-sequence outputs.  KV caches are seeded per-slot.
+            outs = []
+            for b in range(bsz):
+                q_b = q[b : b + 1]
+                kv_b = kv[b : b + 1] if kv.shape[0] == bsz else kv
+                hs_b = hidden_states[b : b + 1]
+                ql_b = q_lora[b : b + 1] if q_lora is not None else None
+                cos_b = cos[b : b + 1] if cos.shape[0] == bsz else cos
+                sin_b = sin[b : b + 1] if sin.shape[0] == bsz else sin
+                slot_b = int(slot_idx[b].item())
+                out_b = _sparse_attn_prefill_body(
+                    q_b,
+                    kv_b,
+                    hs_b,
+                    ql_b,
+                    cos_b,
+                    sin_b,
+                    attn_sink,
+                    compressor_wkv,
+                    compressor_wgate,
+                    compressor_ape,
+                    compressor_norm_weight,
+                    indexer_wq_b,
+                    indexer_weights_proj,
+                    indexer_compressor_wkv,
+                    indexer_compressor_wgate,
+                    indexer_compressor_ape,
+                    indexer_compressor_norm_weight,
+                    scale=scale,
+                    window_size=window_size,
+                    compress_ratio=compress_ratio,
+                    rope_head_dim=rope_head_dim,
+                    head_dim=head_dim,
+                    index_n_heads=index_n_heads,
+                    index_head_dim=index_head_dim,
+                    rms_norm_eps=rms_norm_eps,
+                )
+                # Zero full slot first to prevent uninitialized memory (from
+                # torch.empty() in the resource handler) from leaking NaN into
+                # attention at decode; see also the B==1 branch above.
+                window_cache[slot_b].zero_()
+                fill = min(s, window_size)
+                window_cache[slot_b, :fill] = kv_b[0, s - fill : s, 0, :]
+                compressed = _sparse_compressor(
+                    hs_b,
+                    cos_b,
+                    sin_b,
+                    compressor_wkv,
+                    compressor_wgate,
+                    compressor_ape,
+                    compressor_norm_weight,
+                    head_dim=head_dim,
+                    rope_head_dim=rope_head_dim,
+                    compress_ratio=compress_ratio,
+                    rms_norm_eps=rms_norm_eps,
+                )  # [1, s, head_dim]
+                compressed_kv_cache[slot_b].zero_()
+                num_compressed = s // compress_ratio
+                if num_compressed > 0:
+                    compressed_kv_cache[slot_b, :num_compressed] = compressed[0, :num_compressed]
+                _seed_compressor_state(
+                    hs_b,
+                    compressor_kv_state,
+                    compressor_score_state,
+                    compressor_wkv,
+                    compressor_wgate,
+                    compressor_ape,
+                    slot_b,
+                    compress_ratio,
+                )
+                if has_indexer:
+                    _seed_indexer_compressed_cache(
+                        hs_b,
+                        cos_b,
+                        sin_b,
+                        indexer_compressor_wkv,
+                        indexer_compressor_wgate,
+                        indexer_compressor_ape,
+                        indexer_compressor_norm_weight,
+                        indexer_compressed_kv_cache,
+                        indexer_kv_state,
+                        indexer_score_state,
+                        slot_b,
+                        compress_ratio,
+                        index_head_dim,
+                        rope_head_dim,
+                        rms_norm_eps,
+                    )
+                outs.append(out_b)
+            cat = torch.cat(outs, dim=0)
+            cat = torch.nan_to_num(cat, nan=0.0, posinf=0.0, neginf=0.0)
+            return cat
+
+    # --- Decode step: s == 1. ---
+    # Supports bsz >= 1: each batch element is processed independently using its
+    # own slot_idx[b] and input_pos[b].  Results are stacked along dim 0.
+    if bsz == 1:
+        slot = int(slot_idx[0].item())
+        pos = int(input_pos[0].item())
+        # Compressor rolling update (may or may not produce a new compressed token).
+        cos_last = cos  # already [1, 1, rd/2]
+        sin_last = sin
+        _decode_compressor_step(
+            hidden_states,
+            cos_last,
+            sin_last,
+            compressor_kv_state,
+            compressor_score_state,
+            compressed_kv_cache,
+            compressor_wkv,
+            compressor_wgate,
+            compressor_ape,
+            compressor_norm_weight,
+            slot,
+            pos,
+            compress_ratio,
+            head_dim,
+            rope_head_dim,
+            rms_norm_eps,
+        )
+
+        # Indexer rolling update + top-k.
+        if has_indexer:
+            _decode_compressor_step(
+                hidden_states,
+                cos_last,
+                sin_last,
+                indexer_kv_state,
+                indexer_score_state,
+                indexer_compressed_kv_cache,
+                indexer_compressor_wkv,
+                indexer_compressor_wgate,
+                indexer_compressor_ape,
+                indexer_compressor_norm_weight,
+                slot,
+                pos,
+                compress_ratio,
+                index_head_dim,
+                rope_head_dim,
+                rms_norm_eps,
+            )
+            compress_topk = _decode_indexer_step(
+                q_lora,
+                cos_last,
+                sin_last,
+                indexer_wq_b,
+                indexer_weights_proj,
+                indexer_compressed_kv_cache,
+                slot,
+                pos,
+                hidden_states,
+                compress_ratio,
+                index_n_heads,
+                index_head_dim,
+                rope_head_dim,
+                # index_topk from the pre-allocated buffer's width
+                indexer_compressed_kv_cache.shape[1]
+                if indexer_compressed_kv_cache.shape[1] > 0
+                else 0,
+                offset=window_size,
+            )
+        else:
+            # Deterministic compress top-k: positions 0, 1, ..., (pos+1)//ratio - 1.
+            num_compressed = (pos + 1) // compress_ratio
+            max_c = compressed_kv_cache.shape[1]
+            full = torch.full((1, 1, max_c), -1, device=q.device, dtype=torch.int64)
+            if num_compressed > 0:
+                full[0, 0, :num_compressed] = (
+                    torch.arange(num_compressed, device=q.device) + window_size
+                )
+            compress_topk = full
+
+        # Sparse attention over concat(window_cache, compressed_kv_cache).
+        out = _decode_sparse_attn_step(
+            q,
+            kv,
+            attn_sink,
+            window_cache,
+            compressed_kv_cache,
+            compress_topk,
+            slot,
+            pos,
+            window_size,
+            scale,
+            head_dim,
+        )
+        out = torch.nan_to_num(out, nan=0.0, posinf=0.0, neginf=0.0)
+        return out
+    else:
+        # Batched decode (bsz > 1): process each sequence independently and stack.
+        outs = []
+        for b in range(bsz):
+            slot_b = int(slot_idx[b].item())
+            pos_b = int(input_pos[b].item())
+            q_b = q[b : b + 1]
+            kv_b = kv[b : b + 1] if kv.shape[0] == bsz else kv
+            hs_b = hidden_states[b : b + 1]
+            ql_b = q_lora[b : b + 1] if q_lora is not None else None
+            cos_b = cos[b : b + 1] if cos.shape[0] == bsz else cos
+            sin_b = sin[b : b + 1] if sin.shape[0] == bsz else sin
+            _decode_compressor_step(
+                hs_b,
+                cos_b,
+                sin_b,
+                compressor_kv_state,
+                compressor_score_state,
+                compressed_kv_cache,
+                compressor_wkv,
+                compressor_wgate,
+                compressor_ape,
+                compressor_norm_weight,
+                slot_b,
+                pos_b,
+                compress_ratio,
+                head_dim,
+                rope_head_dim,
+                rms_norm_eps,
+            )
+            if has_indexer:
+                _decode_compressor_step(
+                    hs_b,
+                    cos_b,
+                    sin_b,
+                    indexer_kv_state,
+                    indexer_score_state,
+                    indexer_compressed_kv_cache,
+                    indexer_compressor_wkv,
+                    indexer_compressor_wgate,
+                    indexer_compressor_ape,
+                    indexer_compressor_norm_weight,
+                    slot_b,
+                    pos_b,
+                    compress_ratio,
+                    index_head_dim,
+                    rope_head_dim,
+                    rms_norm_eps,
+                )
+                compress_topk_b = _decode_indexer_step(
+                    ql_b,
+                    cos_b,
+                    sin_b,
+                    indexer_wq_b,
+                    indexer_weights_proj,
+                    indexer_compressed_kv_cache,
+                    slot_b,
+                    pos_b,
+                    hs_b,
+                    compress_ratio,
+                    index_n_heads,
+                    index_head_dim,
+                    rope_head_dim,
+                    indexer_compressed_kv_cache.shape[1]
+                    if indexer_compressed_kv_cache.shape[1] > 0
+                    else 0,
+                    offset=window_size,
+                )
+            else:
+                num_compressed_b = (pos_b + 1) // compress_ratio
+                max_c = compressed_kv_cache.shape[1]
+                full_b = torch.full((1, 1, max_c), -1, device=q.device, dtype=torch.int64)
+                if num_compressed_b > 0:
+                    full_b[0, 0, :num_compressed_b] = (
+                        torch.arange(num_compressed_b, device=q.device) + window_size
+                    )
+                compress_topk_b = full_b
+            out_b = _decode_sparse_attn_step(
+                q_b,
+                kv_b,
+                attn_sink,
+                window_cache,
+                compressed_kv_cache,
+                compress_topk_b,
+                slot_b,
+                pos_b,
+                window_size,
+                scale,
+                head_dim,
+            )
+            out_b = torch.nan_to_num(out_b, nan=0.0, posinf=0.0, neginf=0.0)
+            outs.append(out_b)
+        return torch.cat(outs, dim=0)
+
+
+@torch_deepseek_v4_sparse_attn_with_cache.register_fake
+def torch_deepseek_v4_sparse_attn_with_cache_fake(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    hidden_states: torch.Tensor,
+    q_lora: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    attn_sink: torch.Tensor,
+    compressor_wkv: torch.Tensor,
+    compressor_wgate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    indexer_wq_b: Optional[torch.Tensor],
+    indexer_weights_proj: Optional[torch.Tensor],
+    indexer_compressor_wkv: Optional[torch.Tensor],
+    indexer_compressor_wgate: Optional[torch.Tensor],
+    indexer_compressor_ape: Optional[torch.Tensor],
+    indexer_compressor_norm_weight: Optional[torch.Tensor],
+    batch_info_host: torch.Tensor,
+    seq_len: torch.Tensor,
+    input_pos: torch.Tensor,
+    slot_idx: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    window_cache: torch.Tensor,
+    compressed_kv_cache: torch.Tensor,
+    compressor_kv_state: torch.Tensor,
+    compressor_score_state: torch.Tensor,
+    indexer_compressed_kv_cache: torch.Tensor,
+    indexer_kv_state: torch.Tensor,
+    indexer_score_state: torch.Tensor,
+    scale: float,
+    window_size: int,
+    compress_ratio: int,
+    rope_head_dim: int,
+    head_dim: int,
+    index_n_heads: int,
+    index_head_dim: int,
+    rms_norm_eps: float,
+) -> torch.Tensor:
+    return torch.empty_like(q)
+
+
+# ----------------------------------------------------------------------------
+# AttentionDescriptor for the KV-cache transform
+# ----------------------------------------------------------------------------
+
+
+# Maximum compressed KV cache size: overhead for partial ratio chunks at prefill end.
+_COMPRESSED_SLACK = 4
+
+
+def _coff(compress_ratio: int) -> int:
+    return 1 + int(compress_ratio == 4)
+
+
+@AttentionRegistry.register("torch_ds_v4_sparse")
+class DeepseekV4SparseAttentionDescriptor(AttentionDescriptor):
+    """AttentionDescriptor for the DeepSeek V4 sparse (compress_ratio != 0) layers.
+
+    The cached-op signature is:
+        (*qkv_args_17, *std_metadata_5, *caches_7, *constants_8)
+
+    which matches ``_InsertCachedOperator`` 's expected node-replacement contract.
+    """
+
+    @classmethod
+    def get_attention_layout(cls) -> AttentionLayout:
+        return "bsnd"
+
+    @classmethod
+    def get_num_qkv_args(cls) -> int:
+        # q, kv, hidden_states, q_lora, cos, sin, attn_sink,
+        # + 4 compressor weights + 6 (optional) indexer weights = 17
+        return 17
+
+    @classmethod
+    def get_source_attention_op(cls) -> OpOverloadPacket:
+        return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache.default
+
+    @classmethod
+    def get_standard_metadata_args(cls) -> List[str]:
+        return ["batch_info_host", "seq_len", "input_pos", "slot_idx", "cu_seqlen"]
+
+    @classmethod
+    def _extract_constants(
+        cls, source_attn_node: Node
+    ) -> Tuple[float, int, int, int, int, int, int, float]:
+        (
+            scale,
+            window_size,
+            compress_ratio,
+            rope_head_dim,
+            head_dim,
+            index_n_heads,
+            index_head_dim,
+            rms_norm_eps,
+        ) = extract_op_args(
+            source_attn_node,
+            "scale",
+            "window_size",
+            "compress_ratio",
+            "rope_head_dim",
+            "head_dim",
+            "index_n_heads",
+            "index_head_dim",
+            "rms_norm_eps",
+        )
+        return (
+            scale,
+            window_size,
+            compress_ratio,
+            rope_head_dim,
+            head_dim,
+            index_n_heads,
+            index_head_dim,
+            rms_norm_eps,
+        )
+
+    @classmethod
+    def get_cache_initializers(
+        cls, source_attn_node: Node, cache_config: KvCacheConfig
+    ) -> ResourceHandlerDict:
+        (
+            _scale,
+            window_size,
+            compress_ratio,
+            _rope_head_dim,
+            head_dim,
+            index_n_heads,
+            index_head_dim,
+            _rms_norm_eps,
+        ) = cls._extract_constants(source_attn_node)
+        # Fallback dtypes from the KV fake tensor.
+        kv_fake = source_attn_node.args[1].meta["val"]
+        kv_dtype = cls.resolve_cache_dtype(cache_config.dtype, kv_fake.dtype)
+        coff = _coff(compress_ratio)
+
+        # Compressed KV count upper-bound: ceil(max_seq_len / ratio) + slack.
+        # We size it via UnpagedResourceHandler by using the max_seq_len dimension (first axis)
+        # and collapsing to the head_dim. The handler already allocates
+        # [max_num_state_slots, max_seq_len, *token_shape].
+        handlers: ResourceHandlerDict = {
+            "window_cache": UnpagedResourceHandler(head_dim, dtype=kv_dtype),
+            "compressed_kv_cache": UnpagedResourceHandler(head_dim, dtype=kv_dtype),
+            # Rolling state buffers: shape [max_batch, coff*compress_ratio, coff*head_dim].
+            # Use StateResourceHandler (not UnpagedResourceHandler) because these have a
+            # fixed state_shape independent of max_seq_len.
+            "compressor_kv_state": StateResourceHandler(
+                coff * compress_ratio, coff * head_dim, dtype=torch.float32
+            ),
+            "compressor_score_state": StateResourceHandler(
+                coff * compress_ratio, coff * head_dim, dtype=torch.float32
+            ),
+        }
+        if compress_ratio == 4:
+            handlers["indexer_compressed_kv_cache"] = UnpagedResourceHandler(
+                index_head_dim, dtype=kv_dtype
+            )
+            handlers["indexer_kv_state"] = StateResourceHandler(
+                coff * compress_ratio, coff * index_head_dim, dtype=torch.float32
+            )
+            handlers["indexer_score_state"] = StateResourceHandler(
+                coff * compress_ratio, coff * index_head_dim, dtype=torch.float32
+            )
+        else:
+            # Zero-width stubs so the op signature stays fixed.
+            handlers["indexer_compressed_kv_cache"] = UnpagedResourceHandler(0, dtype=kv_dtype)
+            handlers["indexer_kv_state"] = StateResourceHandler(
+                coff * compress_ratio, 0, dtype=torch.float32
+            )
+            handlers["indexer_score_state"] = StateResourceHandler(
+                coff * compress_ratio, 0, dtype=torch.float32
+            )
+        del index_n_heads, window_size  # currently unused for cache sizing
+        return handlers
+
+    @classmethod
+    def get_constants(cls, source_attn_node: Node) -> List[Constant]:
+        return list(cls._extract_constants(source_attn_node))

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_sparse_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_sparse_attention.py
@@ -106,9 +106,15 @@ def _fake_fp4_act_quant(x: torch.Tensor, block_size: int = 32) -> torch.Tensor:
     grouped = x_float.reshape(*x_float.shape[:-1], dim // block_size, block_size)
     scale = _ceil_pow2_scale(grouped.abs().amax(dim=-1, keepdim=True), 6.0, 6.0 * 2.0**-126)
     normalized = torch.clamp(grouped / scale, -6.0, 6.0)
-    levels = normalized.new_tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
-    level_idx = (normalized.abs().unsqueeze(-1) - levels).abs().argmin(dim=-1)
-    quant = levels[level_idx] * normalized.sign()
+    abs_normalized = normalized.abs()
+    quant_abs = torch.where(abs_normalized > 0.25, 0.5, torch.zeros_like(abs_normalized))
+    quant_abs = torch.where(abs_normalized > 0.75, 1.0, quant_abs)
+    quant_abs = torch.where(abs_normalized > 1.25, 1.5, quant_abs)
+    quant_abs = torch.where(abs_normalized > 1.75, 2.0, quant_abs)
+    quant_abs = torch.where(abs_normalized > 2.5, 3.0, quant_abs)
+    quant_abs = torch.where(abs_normalized > 3.5, 4.0, quant_abs)
+    quant_abs = torch.where(abs_normalized > 5.0, 6.0, quant_abs)
+    quant = quant_abs * normalized.sign()
     return (quant * scale).reshape_as(x_float).to(dtype)
 
 
@@ -886,6 +892,341 @@ def _decode_sparse_attn_step(
     return _manual_attention_with_sinks(q, kv_all, kv_all, attn_mask, scale, attn_sink)
 
 
+def _decode_compressor_step_static_cuda(
+    hidden_states: torch.Tensor,
+    cos_anchor_table: torch.Tensor,
+    sin_anchor_table: torch.Tensor,
+    kv_state: torch.Tensor,
+    score_state: torch.Tensor,
+    compressed_kv_cache: torch.Tensor,
+    wkv: torch.Tensor,
+    wgate: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: torch.Tensor,
+    slot_idx: torch.Tensor,
+    input_pos: torch.Tensor,
+    compress_ratio: int,
+    head_dim: int,
+    rope_head_dim: int,
+    rms_norm_eps: float,
+    rotate: bool = False,
+) -> None:
+    """Capture-safe B=1 decode compressor update with fixed-shape tensor work."""
+    overlap = compress_ratio == 4
+    used_slots = (2 if overlap else 1) * compress_ratio
+    slot = slot_idx[:1].to(torch.long)
+    pos = input_pos[:1].to(torch.long)
+    pos_mod = torch.remainder(pos, compress_ratio)
+
+    kv = F.linear(hidden_states, wkv).float()  # [1, 1, coff*head_dim]
+    score = F.linear(hidden_states, wgate).float()
+    score = score + ape.index_select(0, pos_mod).view(1, 1, -1)
+
+    state_idx = pos_mod + (compress_ratio if overlap else 0)
+    kv_state.index_put_((slot, state_idx), kv.view(1, -1), accumulate=False)
+    score_state.index_put_((slot, state_idx), score.view(1, -1), accumulate=False)
+
+    kv_slot = kv_state.index_select(0, slot)[:, :used_slots, :]
+    score_slot = score_state.index_select(0, slot)[:, :used_slots, :]
+    if overlap:
+        kv_full = torch.cat(
+            [
+                kv_slot[:, :compress_ratio, :head_dim],
+                kv_slot[:, compress_ratio:used_slots, head_dim:],
+            ],
+            dim=1,
+        )
+        score_full = torch.cat(
+            [
+                score_slot[:, :compress_ratio, :head_dim],
+                score_slot[:, compress_ratio:used_slots, head_dim:],
+            ],
+            dim=1,
+        )
+    else:
+        kv_full = kv_slot
+        score_full = score_slot
+
+    compressed = (kv_full * score_full.softmax(dim=1)).sum(dim=1)
+    compressed = compressed.view(1, 1, head_dim).to(hidden_states.dtype)
+    compressed = torch.ops.auto_deploy.torch_rmsnorm(compressed, norm_weight, rms_norm_eps).to(
+        hidden_states.dtype
+    )
+    nope, pe = torch.split(compressed, [head_dim - rope_head_dim, rope_head_dim], dim=-1)
+    anchor_pos = torch.clamp(pos + 1 - compress_ratio, min=0, max=cos_anchor_table.shape[0] - 1)
+    cos_anchor = cos_anchor_table.index_select(0, anchor_pos).view(1, 1, -1)
+    sin_anchor = sin_anchor_table.index_select(0, anchor_pos).view(1, 1, -1)
+    pe = _apply_interleaved_rope(pe, cos_anchor, sin_anchor)
+    compressed = torch.cat([nope, pe], dim=-1)
+    if rotate:
+        compressed = _fake_fp4_act_quant(_hadamard_rotate(compressed), block_size=32)
+    else:
+        nope, pe = torch.split(compressed, [head_dim - rope_head_dim, rope_head_dim], dim=-1)
+        nope = _fake_fp8_act_quant(nope, block_size=64)
+        compressed = torch.cat([nope, pe], dim=-1)
+
+    should_compress = torch.eq(torch.remainder(pos + 1, compress_ratio), 0).view(1, 1, 1)
+    write_idx = torch.div(pos, compress_ratio, rounding_mode="floor")
+    write_idx = torch.clamp(write_idx, min=0, max=compressed_kv_cache.shape[1] - 1)
+    existing_compressed = (
+        compressed_kv_cache.index_select(0, slot).squeeze(0).index_select(0, write_idx)
+    )
+    compressed_to_store = torch.where(
+        should_compress.view(1, 1), compressed.view(1, head_dim), existing_compressed
+    )
+    compressed_kv_cache.index_put_((slot, write_idx), compressed_to_store, accumulate=False)
+
+    if overlap:
+        reset_kv = torch.zeros_like(kv_slot[:, compress_ratio:used_slots, :])
+        reset_score = torch.full_like(score_slot[:, compress_ratio:used_slots, :], -1.0e20)
+        kv_after_compress = torch.cat([kv_slot[:, compress_ratio:used_slots, :], reset_kv], dim=1)
+        score_after_compress = torch.cat(
+            [score_slot[:, compress_ratio:used_slots, :], reset_score], dim=1
+        )
+    else:
+        kv_after_compress = torch.zeros_like(kv_slot)
+        score_after_compress = torch.full_like(score_slot, -1.0e20)
+
+    kv_state.index_copy_(0, slot, torch.where(should_compress, kv_after_compress, kv_slot))
+    score_state.index_copy_(0, slot, torch.where(should_compress, score_after_compress, score_slot))
+
+
+def _decode_indexer_step_static_cuda(
+    q_lora: torch.Tensor,
+    cos_last: torch.Tensor,
+    sin_last: torch.Tensor,
+    wq_b: torch.Tensor,
+    weights_proj: torch.Tensor,
+    indexer_compressed_kv_cache: torch.Tensor,
+    slot_idx: torch.Tensor,
+    input_pos: torch.Tensor,
+    hidden_states: torch.Tensor,
+    compress_ratio: int,
+    index_n_heads: int,
+    index_head_dim: int,
+    rope_head_dim: int,
+    index_topk: int,
+    offset: int,
+) -> torch.Tensor:
+    """Capture-safe B=1 indexer top-k with a static output width."""
+    if index_topk == 0:
+        return torch.empty(1, 1, 0, device=hidden_states.device, dtype=torch.int64)
+
+    slot = slot_idx[:1].to(torch.long)
+    pos = input_pos[:1].to(torch.long)
+    max_compressed = indexer_compressed_kv_cache.shape[1]
+    softmax_scale = index_head_dim**-0.5
+
+    q = F.linear(q_lora, wq_b).view(1, 1, index_n_heads, index_head_dim)
+    q_nope, q_pe = torch.split(q, [index_head_dim - rope_head_dim, rope_head_dim], dim=-1)
+    q_pe = _apply_interleaved_rope(q_pe, cos_last.unsqueeze(2), sin_last.unsqueeze(2))
+    q = torch.cat([q_nope, q_pe], dim=-1)
+    q = _fake_fp4_act_quant(_hadamard_rotate(q), block_size=32)
+
+    weights = F.linear(hidden_states, weights_proj).float() * (softmax_scale * index_n_heads**-0.5)
+    index_k = indexer_compressed_kv_cache.index_select(0, slot)
+    num_compressed = torch.div(pos + 1, compress_ratio, rounding_mode="floor")
+    num_compressed = torch.clamp(num_compressed, min=0, max=max_compressed)
+    compressed_positions = torch.arange(
+        max_compressed, device=hidden_states.device, dtype=torch.long
+    )
+    invalid = compressed_positions.view(1, 1, -1) >= num_compressed.view(1, 1, 1)
+    index_k = torch.where(~invalid.transpose(1, 2), index_k, torch.zeros_like(index_k))
+    index_score = torch.einsum("bshd,btd->bsht", q, index_k).float()
+    index_score = (index_score.relu() * weights.unsqueeze(-1)).sum(dim=2)
+    index_score = index_score.masked_fill(invalid, -1.0e20)
+
+    k = min(index_topk, max_compressed)
+    topk = index_score.topk(k, dim=-1).indices
+    topk = torch.where(topk >= num_compressed.view(1, 1, 1), -1, topk + offset)
+    if k < index_topk:
+        pad = torch.full((1, 1, index_topk - k), -1, device=hidden_states.device, dtype=topk.dtype)
+        topk = torch.cat([topk, pad], dim=-1)
+    return topk.to(torch.int64)
+
+
+def _decode_sparse_attn_step_static_cuda(
+    q: torch.Tensor,
+    kv_new: torch.Tensor,
+    attn_sink: torch.Tensor,
+    window_cache: torch.Tensor,
+    compressed_kv_cache: torch.Tensor,
+    compress_topk: Optional[torch.Tensor],
+    slot_idx: torch.Tensor,
+    input_pos: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    scale: float,
+    head_dim: int,
+) -> torch.Tensor:
+    """Capture-safe B=1 sparse decode attention over fixed masked candidate sets."""
+    slot = slot_idx[:1].to(torch.long)
+    pos = input_pos[:1].to(torch.long)
+    window_pos = torch.remainder(pos, window_size)
+    window_cache.index_put_(
+        (slot, window_pos), kv_new.squeeze(0).squeeze(0).squeeze(0).view(1, head_dim)
+    )
+
+    window_offsets = torch.arange(window_size, device=q.device, dtype=torch.long)
+    visible_window = torch.clamp(pos + 1, min=0, max=window_size)
+    first_window_pos = pos + 1 - visible_window
+    window_indices = torch.remainder(window_offsets + first_window_pos, window_size)
+    window_slot = window_cache.index_select(0, slot).squeeze(0)
+    gathered_window = window_slot.index_select(0, window_indices)
+    window_valid = window_offsets < visible_window
+    gathered_window = torch.where(
+        window_valid.view(-1, 1), gathered_window, torch.zeros_like(gathered_window)
+    )
+
+    compressed_slot = compressed_kv_cache.index_select(0, slot).squeeze(0)
+    max_compressed = compressed_kv_cache.shape[1]
+    if compress_topk is not None:
+        topk = compress_topk.view(-1)
+        compressed_indices = torch.clamp(topk - window_size, min=0, max=max_compressed - 1)
+        gathered_compressed = compressed_slot.index_select(0, compressed_indices)
+        compressed_valid = topk >= window_size
+    else:
+        compressed_offsets = torch.arange(max_compressed, device=q.device, dtype=torch.long)
+        num_compressed = torch.div(pos + 1, compress_ratio, rounding_mode="floor")
+        num_compressed = torch.clamp(num_compressed, min=0, max=max_compressed)
+        gathered_compressed = compressed_slot
+        compressed_valid = compressed_offsets < num_compressed
+    gathered_compressed = torch.where(
+        compressed_valid.view(-1, 1),
+        gathered_compressed,
+        torch.zeros_like(gathered_compressed),
+    )
+
+    kv_all = torch.cat([gathered_window, gathered_compressed], dim=0)
+    valid = torch.cat([window_valid, compressed_valid], dim=0)
+    q_heads = q.squeeze(0).squeeze(0).float()
+    kv_float = kv_all.float()
+    scores = torch.matmul(q_heads, kv_float.transpose(0, 1)) * scale
+    scores = scores.masked_fill(~valid.view(1, -1), -10000.0)
+
+    sink_logits = attn_sink.float().view(-1, 1)
+    logits_max = torch.maximum(scores.max(dim=-1, keepdim=True).values, sink_logits)
+    exp_scores = torch.exp(scores - logits_max)
+    exp_sinks = torch.exp(sink_logits - logits_max)
+    attn = exp_scores / (exp_scores.sum(dim=-1, keepdim=True) + exp_sinks)
+    out = torch.matmul(attn, kv_float)
+    return out.view(1, 1, q.shape[2], head_dim).to(q.dtype)
+
+
+def _decode_sparse_attn_cuda_graph_step(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    hidden_states: torch.Tensor,
+    q_lora: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    cos_anchor: torch.Tensor,
+    sin_anchor: torch.Tensor,
+    attn_sink: torch.Tensor,
+    compressor_wkv: torch.Tensor,
+    compressor_wgate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    indexer_wq_b: Optional[torch.Tensor],
+    indexer_weights_proj: Optional[torch.Tensor],
+    indexer_compressor_wkv: Optional[torch.Tensor],
+    indexer_compressor_wgate: Optional[torch.Tensor],
+    indexer_compressor_ape: Optional[torch.Tensor],
+    indexer_compressor_norm_weight: Optional[torch.Tensor],
+    input_pos: torch.Tensor,
+    slot_idx: torch.Tensor,
+    window_cache: torch.Tensor,
+    compressed_kv_cache: torch.Tensor,
+    compressor_kv_state: torch.Tensor,
+    compressor_score_state: torch.Tensor,
+    indexer_compressed_kv_cache: torch.Tensor,
+    indexer_kv_state: torch.Tensor,
+    indexer_score_state: torch.Tensor,
+    scale: float,
+    window_size: int,
+    compress_ratio: int,
+    rope_head_dim: int,
+    head_dim: int,
+    index_n_heads: int,
+    index_head_dim: int,
+    index_topk: int,
+    rms_norm_eps: float,
+) -> torch.Tensor:
+    """B=1 CUDA decode path that avoids host sync and dynamic-shape tensors."""
+    _decode_compressor_step_static_cuda(
+        hidden_states,
+        cos_anchor,
+        sin_anchor,
+        compressor_kv_state,
+        compressor_score_state,
+        compressed_kv_cache,
+        compressor_wkv,
+        compressor_wgate,
+        compressor_ape,
+        compressor_norm_weight,
+        slot_idx,
+        input_pos,
+        compress_ratio,
+        head_dim,
+        rope_head_dim,
+        rms_norm_eps,
+    )
+
+    compress_topk = None
+    if indexer_wq_b is not None:
+        _decode_compressor_step_static_cuda(
+            hidden_states,
+            cos_anchor,
+            sin_anchor,
+            indexer_kv_state,
+            indexer_score_state,
+            indexer_compressed_kv_cache,
+            indexer_compressor_wkv,
+            indexer_compressor_wgate,
+            indexer_compressor_ape,
+            indexer_compressor_norm_weight,
+            slot_idx,
+            input_pos,
+            compress_ratio,
+            index_head_dim,
+            rope_head_dim,
+            rms_norm_eps,
+            rotate=True,
+        )
+        compress_topk = _decode_indexer_step_static_cuda(
+            q_lora,
+            cos,
+            sin,
+            indexer_wq_b,
+            indexer_weights_proj,
+            indexer_compressed_kv_cache,
+            slot_idx,
+            input_pos,
+            hidden_states,
+            compress_ratio,
+            index_n_heads,
+            index_head_dim,
+            rope_head_dim,
+            index_topk,
+            offset=window_size,
+        )
+
+    return _decode_sparse_attn_step_static_cuda(
+        q,
+        kv,
+        attn_sink,
+        window_cache,
+        compressed_kv_cache,
+        compress_topk,
+        slot_idx,
+        input_pos,
+        window_size,
+        compress_ratio,
+        scale,
+        head_dim,
+    )
+
+
 _CACHE_NAMES = (
     "window_cache",
     "compressed_kv_cache",
@@ -1145,6 +1486,46 @@ def torch_deepseek_v4_sparse_attn_with_cache(
     # Supports bsz >= 1: each batch element is processed independently using its
     # own slot_idx[b] and input_pos[b].  Results are stacked along dim 0.
     if bsz == 1:
+        if q.is_cuda:
+            return _decode_sparse_attn_cuda_graph_step(
+                q,
+                kv,
+                hidden_states,
+                q_lora,
+                cos,
+                sin,
+                cos_anchor,
+                sin_anchor,
+                attn_sink,
+                compressor_wkv,
+                compressor_wgate,
+                compressor_ape,
+                compressor_norm_weight,
+                indexer_wq_b,
+                indexer_weights_proj,
+                indexer_compressor_wkv,
+                indexer_compressor_wgate,
+                indexer_compressor_ape,
+                indexer_compressor_norm_weight,
+                input_pos,
+                slot_idx,
+                window_cache,
+                compressed_kv_cache,
+                compressor_kv_state,
+                compressor_score_state,
+                indexer_compressed_kv_cache,
+                indexer_kv_state,
+                indexer_score_state,
+                scale,
+                window_size,
+                compress_ratio,
+                rope_head_dim,
+                head_dim,
+                index_n_heads,
+                index_head_dim,
+                index_topk,
+                rms_norm_eps,
+            )
         slot = int(slot_idx[0].item())
         pos = int(input_pos[0].item())
         # Compressor rolling update (may or may not produce a new compressed token).

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -64,6 +64,25 @@ def _get_sm_scale(head_dim: int, scale: Optional[float]) -> float:
     return scale if scale is not None else 1.0 / math.sqrt(head_dim)
 
 
+def _flatten_sinks(
+    sinks: Optional[torch.Tensor], batch_size: int, n_heads: int
+) -> tuple[Optional[torch.Tensor], int, int]:
+    """Return sinks as a flat tensor plus batch/head strides."""
+    if sinks is None:
+        return None, 0, 0
+
+    sinks_flat = sinks if sinks.ndim == 1 else sinks.reshape(-1)
+    if sinks_flat.numel() == n_heads:
+        return sinks_flat, 0, 1
+    if sinks_flat.numel() == batch_size * n_heads:
+        return sinks_flat, n_heads, 1
+
+    raise ValueError(
+        f"Expected sinks to have {n_heads} or {batch_size * n_heads} values, "
+        f"got {sinks_flat.numel()}."
+    )
+
+
 @triton.jit
 def _update_paged_kv_cache_kernel(
     # Input K, V
@@ -404,6 +423,8 @@ def _flash_decode_stage2_kernel(
     partial_lse_ptr,
     # Final output
     o_ptr,
+    # Optional sinks
+    sinks_ptr,
     # Partial output strides: [batch, n_heads, num_splits, head_dim]
     po_stride_batch: tl.constexpr,
     po_stride_head: tl.constexpr,
@@ -418,6 +439,9 @@ def _flash_decode_stage2_kernel(
     # Constants
     HEAD_DIM: tl.constexpr,
     NUM_SPLITS: tl.constexpr,
+    HAS_SINKS: tl.constexpr,
+    SINKS_STRIDE_BATCH: tl.constexpr,
+    SINKS_STRIDE_HEAD: tl.constexpr,
 ):
     """
     Each program combines results from all splits for one (batch, head) pair.
@@ -436,6 +460,11 @@ def _flash_decode_stage2_kernel(
         lse = tl.load(partial_lse_ptr + plse_offset)
         global_max_lse = tl.maximum(global_max_lse, lse)
 
+    sinks_val = 0.0
+    if HAS_SINKS:
+        sinks_val = tl.load(sinks_ptr + batch_id * SINKS_STRIDE_BATCH + head_id * SINKS_STRIDE_HEAD)
+        global_max_lse = tl.maximum(global_max_lse, sinks_val)
+
     # Guard: if all splits had -inf LSE (empty sequence), output zeros
     o_offset = batch_id * o_stride_batch + head_id * o_stride_head + dhead_offsets
     if global_max_lse == float("-inf"):
@@ -445,6 +474,8 @@ def _flash_decode_stage2_kernel(
     # Weighted combination: weight_i = exp(lse_i - global_max)
     acc = tl.zeros([HEAD_DIM], dtype=tl.float32)
     total_weight = 0.0
+    if HAS_SINKS:
+        total_weight += tl.exp(sinks_val - global_max_lse)
 
     for split_id in range(NUM_SPLITS):
         plse_offset = (
@@ -474,6 +505,7 @@ def triton_paged_decode(
     sm_scale: float,
     sliding_window: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
+    sinks: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Optimized paged decode with GQA batching + FlashDecoding + page-aligned iteration.
 
@@ -486,6 +518,8 @@ def triton_paged_decode(
         sm_scale: Softmax scale factor
         sliding_window: If set, only attend to the last sliding_window tokens
         out: Optional output tensor [batch_size, n_heads, head_dim]
+        sinks: Optional per-head sink logits. Sinks contribute to the softmax
+            denominator but have no value vectors.
 
     Returns:
         Output tensor [batch_size, n_heads, head_dim]
@@ -525,6 +559,7 @@ def triton_paged_decode(
         dtype=torch.float32,
         device=q.device,
     )
+    sinks_flat, sinks_stride_batch, sinks_stride_head = _flatten_sinks(sinks, batch_size, n_heads)
 
     # Stage 1: GQA-batched parallel KV processing
     _flash_decode_stage1_kernel[(batch_size, n_kv_heads, num_splits)](
@@ -568,6 +603,7 @@ def triton_paged_decode(
         partial_o,
         partial_lse,
         output,
+        sinks_flat if sinks_flat is not None else q,
         # Partial output strides
         partial_o.stride(0),
         partial_o.stride(1),
@@ -582,6 +618,9 @@ def triton_paged_decode(
         # Constants
         HEAD_DIM=head_dim,
         NUM_SPLITS=num_splits,
+        HAS_SINKS=sinks_flat is not None,
+        SINKS_STRIDE_BATCH=sinks_stride_batch,
+        SINKS_STRIDE_HEAD=sinks_stride_head,
     )
 
     return output
@@ -614,6 +653,8 @@ def _paged_context_kernel(
     seq_len_with_cache_ptr,
     # Output
     o_ptr,
+    # Optional sinks
+    sinks_ptr,
     # Strides
     q_stride_token: tl.constexpr,
     q_stride_head: tl.constexpr,
@@ -632,6 +673,9 @@ def _paged_context_kernel(
     HEAD_DIM: tl.constexpr,
     PAGE_SIZE: tl.constexpr,
     SLIDING_WINDOW: tl.constexpr = 0,
+    HAS_SINKS: tl.constexpr = False,
+    SINKS_STRIDE_BATCH: tl.constexpr = 0,
+    SINKS_STRIDE_HEAD: tl.constexpr = 0,
 ):
     """Context/prefill attention with paged KV cache, causal skip, and page-aligned iteration.
 
@@ -821,6 +865,14 @@ def _paged_context_kernel(
             l_i = l_i * alpha + tl.sum(p, axis=1)
             m_i = m_i_new
 
+    if HAS_SINKS:
+        sinks_val = tl.load(sinks_ptr + batch_id * SINKS_STRIDE_BATCH + head_id * SINKS_STRIDE_HEAD)
+        m_sinks = tl.maximum(m_i, sinks_val)
+        acc_scale = tl.exp(m_i - m_sinks)
+        acc = acc * acc_scale[:, None]
+        l_i = l_i * acc_scale + tl.exp(sinks_val - m_sinks)
+        m_i = m_sinks
+
     l_i = tl.where(l_i == 0.0, 1.0, l_i)
     o = acc / l_i[:, None]
     o_store_offsets = (
@@ -901,6 +953,7 @@ def triton_paged_context(
     sm_scale: float,
     sliding_window: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
+    sinks: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Context/prefill attention with paged KV cache."""
     total_tokens, n_heads, head_dim = q.shape
@@ -911,6 +964,8 @@ def triton_paged_context(
 
     if num_seq == 0 or total_tokens == 0:
         return output
+
+    sinks_flat, sinks_stride_batch, sinks_stride_head = _flatten_sinks(sinks, num_seq, n_heads)
 
     # Compute max_q_len without GPU sync for single-sequence batches (most common
     # in serving). For multi-sequence batches, we must use .item() because
@@ -949,6 +1004,7 @@ def triton_paged_context(
         and max_pages > 0
         and pages_uniform
         and all_same_q_len
+        and sinks is None
         and sw == 0  # SDPA doesn't support sliding window natively
     )
 
@@ -1016,6 +1072,7 @@ def triton_paged_context(
             kv_last_page_len,
             seq_len_with_cache,
             output,
+            sinks_flat if sinks_flat is not None else q,
             q.stride(0),
             q.stride(1),
             output.stride(0),
@@ -1030,6 +1087,9 @@ def triton_paged_context(
             HEAD_DIM=head_dim,
             PAGE_SIZE=page_size,
             SLIDING_WINDOW=sw,
+            HAS_SINKS=sinks_flat is not None,
+            SINKS_STRIDE_BATCH=sinks_stride_batch,
+            SINKS_STRIDE_HEAD=sinks_stride_head,
         )
 
     return output
@@ -1096,6 +1156,7 @@ def triton_paged_mha_with_cache(
     # CONSTANTS
     scale: Optional[float],
     sliding_window: Optional[int] = None,
+    sinks: Optional[torch.Tensor] = None,
     # OPTIONAL PRE-ALLOCATED OUTPUT
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
@@ -1148,6 +1209,7 @@ def triton_paged_mha_with_cache(
             sm_scale,
             sliding_window=sliding_window,
             out=y[:num_prefill_tokens],
+            sinks=sinks,
         )
 
     # Process decode tokens if any
@@ -1161,6 +1223,7 @@ def triton_paged_mha_with_cache(
             sm_scale,
             sliding_window=sliding_window,
             out=y[num_prefill_tokens:num_total_tokens],
+            sinks=sinks,
         )
 
     if out is not None:
@@ -1194,6 +1257,7 @@ def triton_paged_mha_with_cache_fake(
     kv_cache: torch.Tensor,
     scale: Optional[float],
     sliding_window: Optional[int] = None,
+    sinks: Optional[torch.Tensor] = None,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     if out is not None:
@@ -1293,5 +1357,6 @@ class TritonPagedAttention(AttentionDescriptor):
             scale = None
 
         sliding_window = extract_op_args(source_attn_node, "sliding_window")[0]
+        sinks = extract_op_args(source_attn_node, "sinks")[0]
 
-        return [scale, sliding_window]
+        return [scale, sliding_window, sinks]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
@@ -189,6 +189,18 @@ def _resolve_torch_fn(act_fn: ActivationType) -> Callable[[torch.Tensor], torch.
     return torch_fn
 
 
+def _gated_mlp_product(
+    gate_out: torch.Tensor,
+    up_out: torch.Tensor,
+    torch_act_fn: Callable[[torch.Tensor], torch.Tensor],
+    swiglu_limit: float,
+) -> torch.Tensor:
+    if swiglu_limit > 0.0:
+        gate_out = gate_out.clamp(max=swiglu_limit)
+        up_out = up_out.clamp(min=-swiglu_limit, max=swiglu_limit)
+    return torch_act_fn(gate_out) * up_out
+
+
 def _template_moe(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
@@ -283,6 +295,7 @@ def torch_moe(
     w3_weight: List[torch.Tensor],
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -325,7 +338,13 @@ def torch_moe(
             W2 = w2_weight[i]  # (H, I)
             W3 = w3_weight[i]  # (I, H)
             return lambda inp: F.linear(
-                torch_act_fn(F.linear(inp.to(W1.dtype), W1)) * F.linear(inp.to(W3.dtype), W3), W2
+                _gated_mlp_product(
+                    F.linear(inp.to(W1.dtype), W1),
+                    F.linear(inp.to(W3.dtype), W3),
+                    torch_act_fn,
+                    swiglu_limit,
+                ),
+                W2,
             )
 
         mlps = [make_mlp(i) for i in range(len(w1_weight))]
@@ -360,6 +379,7 @@ def torch_moe_fake(
     w3_weight: List[torch.Tensor],
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -450,6 +470,7 @@ def torch_quant_fp8_moe(
     w3_weight_scale: List[torch.Tensor],
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -507,7 +528,7 @@ def torch_quant_fp8_moe(
                     input_scale=w3_input_scale[i],
                     weight_scale=w3_weight_scale[i],
                 )
-                prod = torch_act_fn(gate_out) * up_out
+                prod = _gated_mlp_product(gate_out, up_out, torch_act_fn, swiglu_limit)
                 return torch.ops.auto_deploy.torch_quant_fp8_linear(
                     prod,
                     w2_weight[i],
@@ -570,6 +591,7 @@ def torch_quant_fp8_moe_fake(
     w3_weight_scale: List[torch.Tensor],
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -597,6 +619,7 @@ def torch_quant_nvfp4_moe(
     w3_alpha: List[torch.Tensor],
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -662,7 +685,7 @@ def torch_quant_nvfp4_moe(
                     weight_scale=w3_weight_scale[i],
                     alpha=w3_alpha[i],
                 )
-                prod = torch_act_fn(gate_out) * up_out
+                prod = _gated_mlp_product(gate_out, up_out, torch_act_fn, swiglu_limit)
                 return torch.ops.auto_deploy.torch_quant_nvfp4_linear(
                     prod,
                     w2_weight[i],
@@ -733,6 +756,7 @@ def torch_quant_nvfp4_moe_fake(
     w3_alpha: List[torch.Tensor],
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -804,6 +828,7 @@ def torch_quant_finegrained_fp8_moe(
     w3_weight_scale_inv: List[torch.Tensor],
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -852,7 +877,7 @@ def torch_quant_finegrained_fp8_moe(
                     input_zp=[],
                     weight_zp=[],
                 )
-                prod = torch_act_fn(gate_out) * up_out
+                prod = _gated_mlp_product(gate_out, up_out, torch_act_fn, swiglu_limit)
                 return torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear(
                     prod,
                     w2_weight[i],
@@ -918,6 +943,7 @@ def torch_quant_finegrained_fp8_moe_fake(
     w3_weight_scale_inv: List[torch.Tensor],
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -44,6 +44,14 @@ def _check_moe_alltoall(mapping_config: str, max_num_tokens: int) -> Tuple[Mappi
     return mapping, enable_alltoall
 
 
+def _swiglu_limit_tensor(
+    x: torch.Tensor, swiglu_limit: float, num_experts_on_rank: int
+) -> torch.Tensor | None:
+    if swiglu_limit <= 0.0:
+        return None
+    return torch.full((num_experts_on_rank,), swiglu_limit, device=x.device, dtype=torch.float32)
+
+
 def _run_moe_with_alltoall(
     x: torch.Tensor,
     selected_experts: torch.Tensor,
@@ -61,6 +69,7 @@ def _run_moe_with_alltoall(
     use_deepseek_fp8_block_scale: bool = False,
     finegrained_fp8_block_scales: Tuple[torch.Tensor, torch.Tensor] | None = None,
     is_gated_mlp: bool = True,
+    swiglu_limit: float = 0.0,
 ) -> torch.Tensor:
     """
     Execute MoE with all-to-all dispatch/combine pattern.
@@ -104,6 +113,7 @@ def _run_moe_with_alltoall(
             ``use_deepseek_fp8_block_scale`` internally.
         is_gated_mlp: Whether gated MLP is used. Needed by the Blackwell finegrained
             FP8 path to compute ``intermediate_size``.
+        swiglu_limit: Optional DeepSeek-style clamp for the gate/up branches.
 
     Returns:
         2-D output tensor ``(num_tokens, hidden_size)`` — the caller reshapes to the
@@ -255,6 +265,7 @@ def _run_moe_with_alltoall(
             tuner_top_k=top_k,
             activation_type=activation_type,
             use_deepseek_fp8_block_scale=use_deepseek_fp8_block_scale,
+            swiglu_limit=_swiglu_limit_tensor(dispatched_x, swiglu_limit, local_num_experts),
             use_w4_group_scaling=False,
             use_int8_woq_per_channel=False,
             use_mxfp8_act_scaling=False,
@@ -385,6 +396,7 @@ def trtllm_moe_fused(
     w2_stacked_weight: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -433,6 +445,7 @@ def trtllm_moe_fused(
             activation_type=activation_type,
             mapping=mapping,
             max_num_tokens=max_num_tokens,
+            swiglu_limit=swiglu_limit,
         ).view(x_shape)
 
     # EP WITH ALL-REDUCE PATH: Expert IDs are in LOCAL coordinates (from sharding.py),
@@ -447,6 +460,7 @@ def trtllm_moe_fused(
         fc2_expert_biases=None,
         output_dtype=x.dtype,
         quant_scales=quant_scales,
+        swiglu_limit=_swiglu_limit_tensor(x, swiglu_limit, w3_w1_stacked_weight.shape[0]),
         activation_type=activation_type,
     )[0].view(x_shape)
 
@@ -460,6 +474,7 @@ def trtllm_moe_fused_fake(
     w2_stacked_weight: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -499,6 +514,7 @@ def trtllm_quant_fp8_moe_fused(
     fc2_dequant_scale: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -579,6 +595,7 @@ def trtllm_quant_fp8_moe_fused(
             activation_type=act_fn,
             mapping=mapping,
             max_num_tokens=max_num_tokens,
+            swiglu_limit=swiglu_limit,
         ).view(x_shape)
 
     # EP WITH ALL-REDUCE PATH: Expert IDs are in LOCAL coordinates.
@@ -593,6 +610,7 @@ def trtllm_quant_fp8_moe_fused(
         fc2_expert_biases=None,
         output_dtype=x.dtype,
         quant_scales=quant_scales,
+        swiglu_limit=_swiglu_limit_tensor(x_q_fp8, swiglu_limit, fc1_expert_weights.shape[0]),
         activation_type=act_fn,
     )
 
@@ -613,6 +631,7 @@ def trtllm_quant_fp8_moe_fused_fake(
     fc2_dequant_scale: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -636,6 +655,7 @@ def trtllm_quant_nvfp4_moe_fused(
     fc2_alpha: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -708,6 +728,7 @@ def trtllm_quant_nvfp4_moe_fused(
             mapping=mapping,
             max_num_tokens=max_num_tokens,
             nvfp4_act_global_scale=fc1_act_global_scale,
+            swiglu_limit=swiglu_limit,
         ).view(x.shape)
 
     # EP WITH ALL-REDUCE PATH: Expert IDs are in LOCAL coordinates.
@@ -732,6 +753,7 @@ def trtllm_quant_nvfp4_moe_fused(
         output_dtype=x.dtype,
         quant_scales=quant_scales,
         input_sf=input_blockscale,
+        swiglu_limit=_swiglu_limit_tensor(x_q_fp4, swiglu_limit, fc1_expert_weights_fp4.shape[0]),
         activation_type=act_fn,
     )[0].view(x.shape)
 
@@ -751,6 +773,7 @@ def trtllm_quant_nvfp4_moe_fused_fake(
     fc2_alpha: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -769,6 +792,7 @@ def trtllm_quant_finegrained_fp8_moe_fused(
     fc2_weight_scale: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -834,6 +858,7 @@ def trtllm_quant_finegrained_fp8_moe_fused(
             max_num_tokens=max_num_tokens,
             finegrained_fp8_block_scales=(fc1_weight_scale, fc2_weight_scale),
             is_gated_mlp=is_gated_mlp,
+            swiglu_limit=swiglu_limit,
         ).view(x_shape)
 
     # EP WITH ALL-REDUCE PATH: Expert IDs are in LOCAL coordinates (from sharding.py),
@@ -901,6 +926,7 @@ def trtllm_quant_finegrained_fp8_moe_fused(
             output_dtype=x.dtype,
             quant_scales=quant_scales,
             activation_type=act_fn,
+            swiglu_limit=_swiglu_limit_tensor(x2d, swiglu_limit, fc1_expert_weights.shape[0]),
             use_deepseek_fp8_block_scale=True,
         )
 
@@ -918,6 +944,7 @@ def trtllm_quant_finegrained_fp8_moe_fused_fake(
     fc2_weight_scale: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
@@ -941,11 +968,14 @@ def trtllm_nvfp4_trtllm_gen_moe_fused(
     fc2_alpha: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
 ) -> torch.Tensor:
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
+    if swiglu_limit > 0.0:
+        raise NotImplementedError("TRTLLM-Gen NVFP4 MoE does not support swiglu_limit.")
     if act_fn in (ActivationType.Gelu, ActivationType.Geglu):
         raise ValueError(
             f"NVFP4 TRTLLM-Gen MoE does not support activation "
@@ -1052,6 +1082,7 @@ def trtllm_nvfp4_trtllm_gen_moe_fused_fake(
     fc2_alpha: torch.Tensor,
     is_gated_mlp: bool = True,
     act_fn: int = int(ActivationType.Silu),
+    swiglu_limit: float = 0.0,
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -9,6 +9,7 @@ _logger = logging.getLogger(__name__)
 # other models from loading in standalone mode.
 _MODEL_MODULES = {
     "modeling_deepseek": ["DeepSeekV3ForCausalLM"],
+    "modeling_deepseek_v4": ["DeepseekV4ForCausalLM"],
     "modeling_gemma3n": ["Gemma3nForCausalLM", "Gemma3nForConditionalGeneration"],
     "modeling_gemma4": ["Gemma4ForCausalLM", "Gemma4ForConditionalGeneration"],
     "modeling_glm4_moe_lite": ["Glm4MoeLiteForCausalLM"],

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
@@ -14,7 +14,9 @@ This implementation differs from the original in the following ways:
 * Sparse attention is expressed as ``torch_attention`` plus an explicit top-k mask
 * Compressed-KV token path is implemented for prefill only
 * No MTP blocks
-* No FP4/FP8 quantization in the forward graph (handled by AD transforms at load time)
+* Weight FP4/FP8 quantization is handled by AD transforms at load time; activation
+  fake-quantization in the attention KV/indexer paths is preserved because it is
+  part of the reference inference math.
 
 Key architectural features preserved:
 * Hyper-Connections (HC): hc_mult copies of hidden state between blocks with learnable
@@ -174,6 +176,7 @@ _CHECKPOINT_KEY_REPLACEMENTS = (
     (r"\.ffn\.shared_experts\.w1\.", ".ffn.shared_experts.gate_proj."),
     (r"\.ffn\.shared_experts\.w3\.", ".ffn.shared_experts.up_proj."),
     (r"\.ffn\.shared_experts\.w2\.", ".ffn.shared_experts.down_proj."),
+    (r"\.scale$", ".weight_scale_inv"),
 )
 
 
@@ -225,6 +228,32 @@ def _unstack_deepseek_v4_expert_tensors(state_dict: dict[str, torch.Tensor]) -> 
                 )
 
 
+def _dequantize_deepseek_v4_wo_a(state_dict: dict[str, torch.Tensor]) -> None:
+    """Dequantize grouped ``wo_a`` FP8 weights the same way HF ``convert.py`` does."""
+    fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+    if fp8_dtype is None:
+        return
+
+    for weight_key in list(state_dict.keys()):
+        if not re.match(r"^(?:model\.)?layers\.\d+\.attn\.wo_a\.weight$", weight_key):
+            continue
+        scale_key = weight_key.removesuffix(".weight") + ".weight_scale_inv"
+        if scale_key not in state_dict:
+            continue
+        weight = state_dict[weight_key]
+        scale = state_dict[scale_key]
+        if weight.dtype != fp8_dtype:
+            continue
+
+        if weight.shape[0] % 128 != 0 or weight.shape[1] % 128 != 0:
+            continue
+
+        weight = weight.unflatten(0, (-1, 128)).unflatten(-1, (-1, 128))
+        weight = weight.float() * scale[:, None, :, None].float()
+        state_dict[weight_key] = weight.flatten(2, 3).flatten(0, 1).bfloat16()
+        del state_dict[scale_key]
+
+
 def _remap_deepseek_v4_checkpoint_keys(state_dict: dict[str, torch.Tensor]) -> None:
     _unstack_deepseek_v4_expert_tensors(state_dict)
     for key in list(state_dict.keys()):
@@ -232,6 +261,7 @@ def _remap_deepseek_v4_checkpoint_keys(state_dict: dict[str, torch.Tensor]) -> N
         if new_key != key:
             state_dict[new_key] = state_dict.pop(key)
     _unstack_deepseek_v4_expert_tensors(state_dict)
+    _dequantize_deepseek_v4_wo_a(state_dict)
 
 
 class DeepseekV4RMSNorm(nn.Module):
@@ -316,6 +346,62 @@ def _apply_interleaved_rope(
     out_a = a * cos - b * sin
     out_b = a * sin + b * cos
     return torch.stack([out_a, out_b], dim=-1).flatten(-2).type_as(x)
+
+
+def _ceil_pow2_scale(amax: torch.Tensor, max_value: float, min_value: float) -> torch.Tensor:
+    amax = amax.clamp_min(min_value)
+    return torch.pow(2.0, torch.ceil(torch.log2(amax / max_value)))
+
+
+def _fake_fp8_act_quant(x: torch.Tensor, block_size: int = 64) -> torch.Tensor:
+    """Reference in-place ``act_quant`` approximation for DeepSeek V4 KV tensors."""
+    dim = x.shape[-1]
+    if dim == 0 or dim % block_size != 0:
+        return x
+
+    dtype = x.dtype
+    x_float = x.float()
+    grouped = x_float.reshape(*x_float.shape[:-1], dim // block_size, block_size)
+    scale = _ceil_pow2_scale(grouped.abs().amax(dim=-1, keepdim=True), 448.0, 1.0e-4)
+    quant = torch.clamp(grouped / scale, -448.0, 448.0).to(dtype).float()
+    return (quant * scale).reshape_as(x_float).to(dtype)
+
+
+def _fake_fp4_act_quant(x: torch.Tensor, block_size: int = 32) -> torch.Tensor:
+    """Reference in-place ``fp4_act_quant`` approximation for DeepSeek V4 indexer tensors."""
+    dim = x.shape[-1]
+    if dim == 0 or dim % block_size != 0:
+        return x
+
+    dtype = x.dtype
+    x_float = x.float()
+    grouped = x_float.reshape(*x_float.shape[:-1], dim // block_size, block_size)
+    scale = _ceil_pow2_scale(grouped.abs().amax(dim=-1, keepdim=True), 6.0, 6.0 * 2.0**-126)
+    normalized = torch.clamp(grouped / scale, -6.0, 6.0)
+    levels = normalized.new_tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+    level_idx = (normalized.abs().unsqueeze(-1) - levels).abs().argmin(dim=-1)
+    quant = levels[level_idx] * normalized.sign()
+    return (quant * scale).reshape_as(x_float).to(dtype)
+
+
+def _hadamard_rotate(x: torch.Tensor) -> torch.Tensor:
+    """Hadamard rotation used before FP4 simulation in the DeepSeek V4 indexer."""
+    dim = x.shape[-1]
+    if dim <= 1:
+        return x
+    if dim & (dim - 1):
+        raise ValueError(f"Hadamard rotation requires power-of-two dimension, got {dim}.")
+
+    orig_shape = x.shape
+    y = x.float()
+    width = 1
+    while width < dim:
+        y = y.reshape(*y.shape[:-1], dim // (2 * width), 2, width)
+        left = y[..., 0, :]
+        right = y[..., 1, :]
+        y = torch.cat([left + right, left - right], dim=-1).reshape(orig_shape)
+        width *= 2
+    return (y * (dim**-0.5)).to(x.dtype)
 
 
 class DeepseekV4RotaryEmbedding(nn.Module):
@@ -506,6 +592,7 @@ class DeepseekV4MoE(nn.Module):
 
     def __init__(self, config: DeepseekV4Config, layer_idx: int):
         super().__init__()
+        self.swiglu_limit = config.swiglu_limit
         self.experts = nn.ModuleList(
             [
                 DeepseekV4MLP(
@@ -534,6 +621,7 @@ class DeepseekV4MoE(nn.Module):
             w3_weight=[e.up_proj.weight for e in self.experts],
             is_gated_mlp=True,
             act_fn=int(ActivationType.Silu),
+            swiglu_limit=self.swiglu_limit,
         )
         return routed.view(*orig_shape) + self.shared_experts(hidden_states)
 
@@ -620,7 +708,7 @@ def _manual_attention_with_sinks(
     scores = scores + attn_mask.float()
 
     sink_logits = sinks.float().reshape(1, n_heads, 1, 1).expand(bsz, n_heads, seqlen, 1)
-    logits_max = scores.max(dim=-1, keepdim=True).values
+    logits_max = torch.maximum(scores.max(dim=-1, keepdim=True).values, sink_logits)
     exp_scores = torch.exp(scores - logits_max)
     exp_sinks = torch.exp(sink_logits - logits_max)
     attn = exp_scores / (exp_scores.sum(dim=-1, keepdim=True) + exp_sinks)
@@ -653,12 +741,14 @@ class DeepseekV4Compressor(nn.Module):
         config: DeepseekV4Config,
         compress_ratio: int,
         head_dim: int,
+        rotate: bool = False,
     ):
         super().__init__()
         self.hidden_size = config.hidden_size
         self.head_dim = head_dim
         self.rope_head_dim = config.qk_rope_head_dim
         self.compress_ratio = compress_ratio
+        self.rotate = rotate
         self.overlap = compress_ratio == 4
         coff = 1 + int(self.overlap)
 
@@ -703,6 +793,12 @@ class DeepseekV4Compressor(nn.Module):
         sin_comp = sin[:, chunk_start]
         nope, pe = torch.split(compressed, [self.head_dim - rd, rd], dim=-1)
         pe = _apply_interleaved_rope(pe, cos_comp, sin_comp)
+        compressed = torch.cat([nope, pe], dim=-1)
+        if self.rotate:
+            return _fake_fp4_act_quant(_hadamard_rotate(compressed), block_size=32)
+
+        nope, pe = torch.split(compressed, [self.head_dim - rd, rd], dim=-1)
+        nope = _fake_fp8_act_quant(nope, block_size=64)
         return torch.cat([nope, pe], dim=-1)
 
 
@@ -722,7 +818,9 @@ class DeepseekV4Indexer(nn.Module):
             config.q_lora_rank, config.index_n_heads * config.index_head_dim, bias=False
         )
         self.weights_proj = nn.Linear(config.hidden_size, config.index_n_heads, bias=False)
-        self.compressor = DeepseekV4Compressor(config, compress_ratio, self.index_head_dim)
+        self.compressor = DeepseekV4Compressor(
+            config, compress_ratio, self.index_head_dim, rotate=True
+        )
 
     def forward(
         self,
@@ -740,6 +838,7 @@ class DeepseekV4Indexer(nn.Module):
         q_nope, q_pe = torch.split(q, [self.index_head_dim - rd, rd], dim=-1)
         q_pe = _apply_interleaved_rope(q_pe, cos.unsqueeze(2), sin.unsqueeze(2))
         q = torch.cat([q_nope, q_pe], dim=-1)
+        q = _fake_fp4_act_quant(_hadamard_rotate(q), block_size=32)
 
         index_k = self.compressor(hidden_states, cos, sin)
         weights = self.weights_proj(hidden_states).float() * (
@@ -749,15 +848,36 @@ class DeepseekV4Indexer(nn.Module):
         index_score = torch.einsum("bshd,btd->bsht", q, index_k).float()
         index_score = (index_score.relu() * weights.unsqueeze(-1)).sum(dim=2)
 
-        compressed_positions = torch.arange(seqlen, device=hidden_states.device)
+        num_compressed = seqlen // ratio
+        if self.index_topk == 0:
+            return torch.empty(bsz, seqlen, 0, device=hidden_states.device, dtype=torch.int64)
+        if num_compressed == 0:
+            return torch.full(
+                (bsz, seqlen, self.index_topk),
+                -1,
+                device=hidden_states.device,
+                dtype=torch.int64,
+            )
+
+        index_score = index_score[..., :num_compressed]
+        compressed_positions = torch.arange(num_compressed, device=hidden_states.device)
         valid_count = torch.arange(1, seqlen + 1, device=hidden_states.device).unsqueeze(1) // ratio
         future_mask = compressed_positions.unsqueeze(0) >= valid_count
-        valid = ~future_mask
         index_score = index_score.masked_fill(future_mask.unsqueeze(0), -1.0e20)
 
-        sorted_idxs = index_score.argsort(dim=-1, descending=True)
-        sorted_valid = valid.unsqueeze(0).expand(bsz, -1, -1).gather(-1, sorted_idxs)
-        return torch.where(sorted_valid, sorted_idxs + offset, -1)
+        k = min(self.index_topk, num_compressed)
+        topk_idxs = index_score.topk(k, dim=-1).indices
+        invalid = topk_idxs >= valid_count.unsqueeze(0)
+        topk_idxs = torch.where(invalid, -1, topk_idxs + offset)
+        if k < self.index_topk:
+            pad = torch.full(
+                (bsz, seqlen, self.index_topk - k),
+                -1,
+                device=hidden_states.device,
+                dtype=topk_idxs.dtype,
+            )
+            topk_idxs = torch.cat([topk_idxs, pad], dim=-1)
+        return topk_idxs.to(torch.int64)
 
 
 class DeepseekV4Attention(nn.Module):
@@ -821,6 +941,8 @@ class DeepseekV4Attention(nn.Module):
         sin_base: torch.Tensor,
         cos_compress: torch.Tensor,
         sin_compress: torch.Tensor,
+        cos_compress_table: Optional[torch.Tensor] = None,
+        sin_compress_table: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         bsz, seqlen, _ = hidden_states.shape
 
@@ -845,6 +967,7 @@ class DeepseekV4Attention(nn.Module):
         kv_nope, kv_pe = torch.split(kv, [self.nope_head_dim, self.rope_head_dim], dim=-1)
         q_pe = _apply_interleaved_rope(q_pe, cos, sin)
         kv_pe = _apply_interleaved_rope(kv_pe, cos, sin)
+        kv_nope = _fake_fp8_act_quant(kv_nope, block_size=64)
         q = torch.cat([q_nope, q_pe], dim=-1)
         kv = torch.cat([kv_nope, kv_pe], dim=-1)
 
@@ -852,6 +975,8 @@ class DeepseekV4Attention(nn.Module):
             # Sparse compressed attention: emit a dedicated custom op so the KV-cache
             # transform can recognise and replace it with a cached variant. The op
             # owns the Compressor/Indexer math internally; we forward their weights.
+            assert cos_compress_table is not None
+            assert sin_compress_table is not None
             cos_flat = cos.squeeze(2)
             sin_flat = sin.squeeze(2)
             if self.indexer is not None:
@@ -875,6 +1000,8 @@ class DeepseekV4Attention(nn.Module):
                 qr,
                 cos_flat,
                 sin_flat,
+                cos_compress_table,
+                sin_compress_table,
                 self.attn_sink,
                 self.compressor.wkv.weight,
                 self.compressor.wgate.weight,
@@ -893,6 +1020,7 @@ class DeepseekV4Attention(nn.Module):
                 self.head_dim,
                 self.indexer.index_n_heads if self.indexer is not None else 0,
                 self.indexer.index_head_dim if self.indexer is not None else 0,
+                self.indexer.index_topk if self.indexer is not None else 0,
                 self.rms_eps,
                 self.layer_idx,
                 "mha_sparse",
@@ -975,7 +1103,7 @@ class DeepseekV4Block(nn.Module):
         x_flat = x.flatten(2)
         x_norm = x_flat.float()
         rsqrt = torch.rsqrt(x_norm.square().mean(-1, keepdim=True) + self.norm_eps)
-        mixes = F.linear(x_flat, hc_fn).float() * rsqrt
+        mixes = torch.matmul(x_norm, hc_fn.float().transpose(0, 1)) * rsqrt
         pre, post, comb = _hc_split_sinkhorn(
             mixes, hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.hc_eps
         )
@@ -1003,6 +1131,8 @@ class DeepseekV4Block(nn.Module):
         sin_base: torch.Tensor,
         cos_compress: torch.Tensor,
         sin_compress: torch.Tensor,
+        cos_compress_table: Optional[torch.Tensor] = None,
+        sin_compress_table: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         # Attention sub-layer
         residual = hidden_states
@@ -1010,7 +1140,15 @@ class DeepseekV4Block(nn.Module):
             hidden_states, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
         )
         x = self.attn_norm(x)
-        x = self.attn(x, cos_base, sin_base, cos_compress, sin_compress)
+        x = self.attn(
+            x,
+            cos_base,
+            sin_base,
+            cos_compress,
+            sin_compress,
+            cos_compress_table,
+            sin_compress_table,
+        )
         hidden_states = self._hc_post(x, residual, post, comb)
 
         # FFN (MoE) sub-layer
@@ -1097,7 +1235,7 @@ class DeepseekV4Model(DeepseekV4PreTrainedModel):
         x_flat = x.flatten(2)
         x_norm = x_flat.float()
         rsqrt = torch.rsqrt(x_norm.square().mean(-1, keepdim=True) + self.norm_eps)
-        mixes = F.linear(x_flat, self.hc_head_fn).float() * rsqrt
+        mixes = torch.matmul(x_norm, self.hc_head_fn.float().transpose(0, 1)) * rsqrt
         pre = torch.sigmoid(mixes * self.hc_head_scale + self.hc_head_base) + self.hc_eps
         y = torch.sum(pre.unsqueeze(-1) * x_norm.view(shape), dim=2)
         return y.to(dtype)
@@ -1138,7 +1276,16 @@ class DeepseekV4Model(DeepseekV4PreTrainedModel):
         sin_compress = sin_compress_table[position_ids]
 
         for layer in self.layers:
-            h = layer(h, input_ids, cos_base, sin_base, cos_compress, sin_compress)
+            h = layer(
+                h,
+                input_ids,
+                cos_base,
+                sin_base,
+                cos_compress,
+                sin_compress,
+                cos_compress_table,
+                sin_compress_table,
+            )
 
         # HC head collapse -> final RMSNorm
         h = self._hc_head_collapse(h)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
@@ -41,6 +41,9 @@ from transformers.generation import GenerationMixin
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention import (  # noqa: F401 -- register op
+    deepseek_v4_sparse_attention,
+)
 from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.utils import ActivationType
 
@@ -483,6 +486,10 @@ class DeepseekV4MoEGate(nn.Module):
 
         if self.hash_routing:
             selected_experts = self.tid2eid[input_ids_flat].to(torch.int64)
+            # Clamp defensively — the checkpoint should always emit expert ids in
+            # [0, n_routed_experts), but out-of-range sentinels (e.g. -1 in a
+            # stale slot) would fail ``gather`` with a CUDA assert.
+            selected_experts = selected_experts.clamp(0, self.n_routed_experts - 1)
         else:
             biased_scores = scores + self.bias
             selected_experts = biased_scores.topk(self.top_k, dim=-1)[1]
@@ -842,23 +849,53 @@ class DeepseekV4Attention(nn.Module):
         kv = torch.cat([kv_nope, kv_pe], dim=-1)
 
         if self.compress_ratio != 0:
-            kv_compress = self.compressor(hidden_states, cos.squeeze(2), sin.squeeze(2))
+            # Sparse compressed attention: emit a dedicated custom op so the KV-cache
+            # transform can recognise and replace it with a cached variant. The op
+            # owns the Compressor/Indexer math internally; we forward their weights.
+            cos_flat = cos.squeeze(2)
+            sin_flat = sin.squeeze(2)
             if self.indexer is not None:
-                compress_topk_idxs = self.indexer(
-                    hidden_states, qr, cos.squeeze(2), sin.squeeze(2), offset=seqlen
-                )
+                indexer_wq_b = self.indexer.wq_b.weight
+                indexer_weights_proj = self.indexer.weights_proj.weight
+                indexer_compressor_wkv = self.indexer.compressor.wkv.weight
+                indexer_compressor_wgate = self.indexer.compressor.wgate.weight
+                indexer_compressor_ape = self.indexer.compressor.ape
+                indexer_compressor_norm_weight = self.indexer.compressor.norm.weight
             else:
-                compress_topk_idxs = _compress_topk_idxs(
-                    self.compress_ratio, bsz, seqlen, seqlen, hidden_states.device
-                )
-            window_topk_idxs = _window_topk_idxs(
-                self.window_size, bsz, seqlen, hidden_states.device
-            )
-            topk_idxs = torch.cat([window_topk_idxs, compress_topk_idxs], dim=-1)
-            kv_all = torch.cat([kv, kv_compress.view(bsz, seqlen, 1, self.head_dim)], dim=1)
-            attn_mask = _build_sparse_attn_mask(topk_idxs, kv_all.shape[1]).to(q.dtype)
-            attn_out = _manual_attention_with_sinks(
-                q, kv_all, kv_all, attn_mask, self.softmax_scale, self.attn_sink
+                indexer_wq_b = None
+                indexer_weights_proj = None
+                indexer_compressor_wkv = None
+                indexer_compressor_wgate = None
+                indexer_compressor_ape = None
+                indexer_compressor_norm_weight = None
+            attn_out = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn(
+                q,
+                kv,
+                hidden_states,
+                qr,
+                cos_flat,
+                sin_flat,
+                self.attn_sink,
+                self.compressor.wkv.weight,
+                self.compressor.wgate.weight,
+                self.compressor.ape,
+                self.compressor.norm.weight,
+                indexer_wq_b,
+                indexer_weights_proj,
+                indexer_compressor_wkv,
+                indexer_compressor_wgate,
+                indexer_compressor_ape,
+                indexer_compressor_norm_weight,
+                self.softmax_scale,
+                self.window_size,
+                self.compress_ratio,
+                self.rope_head_dim,
+                self.head_dim,
+                self.indexer.index_n_heads if self.indexer is not None else 0,
+                self.indexer.index_head_dim if self.indexer is not None else 0,
+                self.rms_eps,
+                self.layer_idx,
+                "mha_sparse",
             )
         else:
             # Attention: sliding window + learnable sinks, K == V (same tensor).
@@ -873,6 +910,8 @@ class DeepseekV4Attention(nn.Module):
                 sinks=self.attn_sink,
                 sliding_window=self.window_size,
                 layout="bsnd",
+                layer_idx=self.layer_idx,
+                layer_type="mha",
             )
 
         # Inverse RoPE on the output's last rd dims to undo the V-side rotation.

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
@@ -1,0 +1,1161 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Slimmed down PyTorch DeepSeek V4 model implementation for auto_deploy export.
+
+Source:
+https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/inference/model.py
+
+This implementation differs from the original in the following ways:
+* Simplified for prefill-only inference (no KV-cache mutation or decode state)
+* Uses auto_deploy custom ops for export compatibility (torch_attention, torch_moe,
+  torch_rmsnorm). Interleaved RoPE is inlined in plain PyTorch on real cos/sin tables
+  because the complex-freqs canonical op produces ``aten.imag`` nodes during export
+  that break follow-on shape propagation in AD transforms.
+* Sparse attention is expressed as ``torch_attention`` plus an explicit top-k mask
+* Compressed-KV token path is implemented for prefill only
+* No MTP blocks
+* No FP4/FP8 quantization in the forward graph (handled by AD transforms at load time)
+
+Key architectural features preserved:
+* Hyper-Connections (HC): hc_mult copies of hidden state between blocks with learnable
+  Sinkhorn-based mixing (hc_pre / hc_post).
+* MLA-style attention with single KV head (MQA), low-rank Q (wq_a -> q_norm -> wq_b),
+  grouped low-rank O projection (wo_a grouped einsum -> wo_b), learnable attn sinks,
+  parameterless per-head RMS on Q, interleaved complex RoPE on the last rope_head_dim.
+* Learned KV compression and the ratio-4 Indexer used by DeepSeek sparse attention.
+* MoE with per-layer routing: first num_hash_layers use token_id -> expert_id lookup;
+  remaining layers use sqrtsoftplus scoring with bias-shifted top-k selection.
+* YaRN RoPE scaling; two rope tables when compress_ratios[layer] != 0 vs 0.
+"""
+
+import math
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import AutoConfig, PretrainedConfig
+from transformers.generation import GenerationMixin
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import ModelOutput
+
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+from tensorrt_llm._torch.utils import ActivationType
+
+
+class DeepseekV4Config(PretrainedConfig):
+    """Bundled configuration for DeepSeek V4.
+
+    V4 is not in transformers 4.57.3; the HF repo ships its own config via
+    trust_remote_code. We also register a local class here so the model loads
+    even when remote code is not trusted.
+    """
+
+    model_type = "deepseek_v4"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size: int = 129280,
+        hidden_size: int = 4096,
+        num_hidden_layers: int = 43,
+        num_attention_heads: int = 64,
+        num_key_value_heads: int = 1,
+        head_dim: int = 512,
+        qk_rope_head_dim: int = 64,
+        q_lora_rank: int = 1024,
+        o_lora_rank: int = 1024,
+        o_groups: int = 8,
+        sliding_window: int = 128,
+        hidden_act: str = "silu",
+        # MoE
+        n_routed_experts: int = 256,
+        n_shared_experts: int = 1,
+        num_experts_per_tok: int = 6,
+        num_hash_layers: int = 3,
+        moe_intermediate_size: int = 2048,
+        scoring_func: str = "sqrtsoftplus",
+        routed_scaling_factor: float = 1.5,
+        norm_topk_prob: bool = True,
+        swiglu_limit: float = 10.0,
+        # RoPE
+        max_position_embeddings: int = 1048576,
+        rope_theta: float = 10000.0,
+        compress_rope_theta: float = 160000.0,
+        rope_scaling: Optional[dict] = None,
+        # Compression (used only to decide which rope table a layer uses here)
+        compress_ratios: Optional[List[int]] = None,
+        # HC
+        hc_mult: int = 4,
+        hc_sinkhorn_iters: int = 20,
+        hc_eps: float = 1e-6,
+        # Index (unused in prefill-only forward; kept to accept HF config fields)
+        index_n_heads: int = 64,
+        index_head_dim: int = 128,
+        index_topk: int = 512,
+        # Other
+        rms_norm_eps: float = 1e-6,
+        attention_bias: bool = False,
+        attention_dropout: float = 0.0,
+        initializer_range: float = 0.02,
+        tie_word_embeddings: bool = False,
+        pad_token_id: Optional[int] = None,
+        bos_token_id: int = 0,
+        eos_token_id: int = 1,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.q_lora_rank = q_lora_rank
+        self.o_lora_rank = o_lora_rank
+        self.o_groups = o_groups
+        self.sliding_window = sliding_window
+        self.hidden_act = hidden_act
+        self.n_routed_experts = n_routed_experts
+        self.n_shared_experts = n_shared_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.num_hash_layers = num_hash_layers
+        self.moe_intermediate_size = moe_intermediate_size
+        self.scoring_func = scoring_func
+        self.routed_scaling_factor = routed_scaling_factor
+        self.norm_topk_prob = norm_topk_prob
+        self.swiglu_limit = swiglu_limit
+        self.max_position_embeddings = max_position_embeddings
+        self.rope_theta = rope_theta
+        self.compress_rope_theta = compress_rope_theta
+        self.rope_scaling = rope_scaling
+        self.compress_ratios = (
+            list(compress_ratios) if compress_ratios is not None else [0] * num_hidden_layers
+        )
+        self.hc_mult = hc_mult
+        self.hc_sinkhorn_iters = hc_sinkhorn_iters
+        self.hc_eps = hc_eps
+        self.index_n_heads = index_n_heads
+        self.index_head_dim = index_head_dim
+        self.index_topk = index_topk
+        self.rms_norm_eps = rms_norm_eps
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.initializer_range = initializer_range
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+
+
+try:
+    AutoConfig.register("deepseek_v4", DeepseekV4Config, exist_ok=True)
+except (TypeError, ValueError):
+    pass
+
+
+_CHECKPOINT_KEY_REPLACEMENTS = (
+    (r"^embed\.weight$", "model.embed_tokens.weight"),
+    (r"^head\.weight$", "lm_head.weight"),
+    (r"^norm\.weight$", "model.norm.weight"),
+    (r"^hc_head_", "model.hc_head_"),
+    (r"^layers\.", "model.layers."),
+    (r"\.ffn\.experts\.(\d+)\.w1\.", r".ffn.experts.\1.gate_proj."),
+    (r"\.ffn\.experts\.(\d+)\.w3\.", r".ffn.experts.\1.up_proj."),
+    (r"\.ffn\.experts\.(\d+)\.w2\.", r".ffn.experts.\1.down_proj."),
+    (r"\.ffn\.shared_experts\.w1\.", ".ffn.shared_experts.gate_proj."),
+    (r"\.ffn\.shared_experts\.w3\.", ".ffn.shared_experts.up_proj."),
+    (r"\.ffn\.shared_experts\.w2\.", ".ffn.shared_experts.down_proj."),
+)
+
+
+def _rename_deepseek_v4_checkpoint_key(key: str) -> str:
+    for pattern, replacement in _CHECKPOINT_KEY_REPLACEMENTS:
+        key = re.sub(pattern, replacement, key)
+    return key
+
+
+def _unstack_deepseek_v4_expert_tensors(state_dict: dict[str, torch.Tensor]) -> None:
+    """Convert stacked MoE checkpoint tensors to the per-expert ModuleList layout."""
+    direct_names = {"w1": "gate_proj", "w3": "up_proj", "w2": "down_proj"}
+    for key in list(state_dict.keys()):
+        direct_match = re.match(
+            r"^(?P<prefix>(?:model\.)?layers\.\d+\.ffn\.)experts\.(?P<which>w[123])\.weight$",
+            key,
+        )
+        if direct_match is not None:
+            stacked = state_dict.pop(key)
+            target_name = direct_names[direct_match.group("which")]
+            for expert_idx in range(stacked.shape[0]):
+                state_dict[
+                    f"{direct_match.group('prefix')}experts.{expert_idx}.{target_name}.weight"
+                ] = stacked[expert_idx]
+            continue
+
+        gate_up_match = re.match(
+            r"^(?P<prefix>(?:model\.)?layers\.\d+\.ffn\.)experts\.gate_up_proj(?:\.weight)?$",
+            key,
+        )
+        if gate_up_match is not None:
+            stacked = state_dict.pop(key)
+            gate, up = stacked.chunk(2, dim=1)
+            for expert_idx in range(stacked.shape[0]):
+                prefix = gate_up_match.group("prefix")
+                state_dict[f"{prefix}experts.{expert_idx}.gate_proj.weight"] = gate[expert_idx]
+                state_dict[f"{prefix}experts.{expert_idx}.up_proj.weight"] = up[expert_idx]
+            continue
+
+        down_match = re.match(
+            r"^(?P<prefix>(?:model\.)?layers\.\d+\.ffn\.)experts\.down_proj(?:\.weight)?$",
+            key,
+        )
+        if down_match is not None:
+            stacked = state_dict.pop(key)
+            for expert_idx in range(stacked.shape[0]):
+                state_dict[f"{down_match.group('prefix')}experts.{expert_idx}.down_proj.weight"] = (
+                    stacked[expert_idx]
+                )
+
+
+def _remap_deepseek_v4_checkpoint_keys(state_dict: dict[str, torch.Tensor]) -> None:
+    _unstack_deepseek_v4_expert_tensors(state_dict)
+    for key in list(state_dict.keys()):
+        new_key = _rename_deepseek_v4_checkpoint_key(key)
+        if new_key != key:
+            state_dict[new_key] = state_dict.pop(key)
+    _unstack_deepseek_v4_expert_tensors(state_dict)
+
+
+class DeepseekV4RMSNorm(nn.Module):
+    """Standard weighted RMSNorm."""
+
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_rmsnorm(
+            hidden_states, self.weight, self.variance_epsilon
+        ).to(hidden_states.dtype)
+
+
+def _yarn_find_correction_dim(
+    num_rotations: float, dim: int, base: float, max_position_embeddings: int
+) -> float:
+    return (dim * math.log(max_position_embeddings / (num_rotations * 2 * math.pi))) / (
+        2 * math.log(base)
+    )
+
+
+def _yarn_find_correction_range(
+    low_rot: int, high_rot: int, dim: int, base: float, max_position_embeddings: int
+) -> Tuple[int, int]:
+    low = math.floor(_yarn_find_correction_dim(low_rot, dim, base, max_position_embeddings))
+    high = math.ceil(_yarn_find_correction_dim(high_rot, dim, base, max_position_embeddings))
+    return max(low, 0), min(high, dim - 1)
+
+
+def _yarn_linear_ramp_mask(min_val: float, max_val: float, dim: int) -> torch.Tensor:
+    if min_val == max_val:
+        max_val += 0.001
+    linear_func = (torch.arange(dim, dtype=torch.float32) - min_val) / (max_val - min_val)
+    return torch.clamp(linear_func, 0, 1)
+
+
+def _build_freqs_cis(
+    rope_head_dim: int,
+    max_seq_len: int,
+    base: float,
+    original_seq_len: int,
+    factor: float,
+    beta_fast: int,
+    beta_slow: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Real-valued rotary (cos, sin) tables with optional YaRN scaling.
+
+    Returns ``(cos, sin)``, each of shape ``[max_seq_len, rope_head_dim // 2]``,
+    encoding ``cos(pos * inv_freq[k])`` / ``sin(...)``. We avoid complex tensors in
+    the exported graph because ``torch.export`` decomposes complex indexing into
+    ``aten.imag`` / ``aten.real`` nodes that break follow-on shape propagation.
+    """
+    freqs = 1.0 / (base ** (torch.arange(0, rope_head_dim, 2, dtype=torch.float32) / rope_head_dim))
+    if original_seq_len > 0:
+        low, high = _yarn_find_correction_range(
+            beta_fast, beta_slow, rope_head_dim, base, original_seq_len
+        )
+        smooth = 1 - _yarn_linear_ramp_mask(low, high, rope_head_dim // 2)
+        freqs = freqs / factor * (1 - smooth) + freqs * smooth
+    t = torch.arange(max_seq_len, dtype=torch.float32)
+    freqs = torch.outer(t, freqs)
+    return torch.cos(freqs), torch.sin(freqs)
+
+
+def _apply_interleaved_rope(
+    x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor, inverse: bool = False
+) -> torch.Tensor:
+    """Interleaved (complex-style) RoPE on the last dim of ``x``, in pure real ops.
+
+    ``x``: ``[..., rope_head_dim]`` with channel pairs ``[a0, b0, a1, b1, ...]``.
+    ``cos``/``sin``: ``[B, S, rope_head_dim // 2]``; expanded to the broadcast layout
+    expected against ``x[..., ::2]`` / ``x[..., 1::2]`` by the caller.
+    ``inverse=True`` negates sin, i.e. multiplies by the complex conjugate.
+    """
+    if inverse:
+        sin = -sin
+    a = x[..., 0::2]
+    b = x[..., 1::2]
+    out_a = a * cos - b * sin
+    out_b = a * sin + b * cos
+    return torch.stack([out_a, out_b], dim=-1).flatten(-2).type_as(x)
+
+
+class DeepseekV4RotaryEmbedding(nn.Module):
+    """Shared rotary embedding: precomputes two (cos, sin) table pairs (real floats).
+
+    * base: theta=rope_theta, no YaRN — used by layers with compress_ratio == 0
+    * compress: theta=compress_rope_theta with YaRN — used by layers with compress_ratio != 0
+
+    ``forward(x)`` returns all four cached tables. The model forward slices them
+    by position_ids once, and each attention layer picks the appropriate pair
+    based on its compress_ratio. The ``_ad_`` prefix keeps the buffers on meta
+    during AD's lift_to_meta pass.
+    """
+
+    def __init__(
+        self,
+        rope_head_dim: int,
+        max_position_embeddings: int,
+        rope_theta: float,
+        compress_rope_theta: float,
+        rope_scaling: Optional[dict],
+    ):
+        super().__init__()
+        self.rope_head_dim = rope_head_dim
+        self.max_position_embeddings = max_position_embeddings
+
+        factor = 1.0
+        original_seq_len = 0
+        beta_fast = 32
+        beta_slow = 1
+        if rope_scaling is not None and isinstance(rope_scaling, dict):
+            factor = float(rope_scaling.get("factor", 1.0))
+            original_seq_len = int(rope_scaling.get("original_max_position_embeddings", 0))
+            beta_fast = int(rope_scaling.get("beta_fast", 32))
+            beta_slow = int(rope_scaling.get("beta_slow", 1))
+
+        cos_base, sin_base = _build_freqs_cis(
+            rope_head_dim,
+            max_position_embeddings,
+            rope_theta,
+            0,
+            1.0,
+            beta_fast,
+            beta_slow,
+        )
+        cos_compress, sin_compress = _build_freqs_cis(
+            rope_head_dim,
+            max_position_embeddings,
+            compress_rope_theta,
+            original_seq_len,
+            factor,
+            beta_fast,
+            beta_slow,
+        )
+        self.register_buffer("_ad_cos_base", cos_base, persistent=False)
+        self.register_buffer("_ad_sin_base", sin_base, persistent=False)
+        self.register_buffer("_ad_cos_compress", cos_compress, persistent=False)
+        self.register_buffer("_ad_sin_compress", sin_compress, persistent=False)
+
+    def forward(
+        self, x: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        del x
+        return (
+            self._ad_cos_base,
+            self._ad_sin_base,
+            self._ad_cos_compress,
+            self._ad_sin_compress,
+        )
+
+
+def _hc_split_sinkhorn(
+    mixes: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    hc_mult: int,
+    sinkhorn_iters: int,
+    eps: float,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Reference-faithful Sinkhorn splitting of HC mix logits.
+
+    mixes: [..., (2 + hc) * hc] — concatenation of [pre_hc, post_hc, comb_hc*hc] logits.
+    Returns ``pre: [..., hc]``, ``post: [..., hc]``, ``comb: [..., hc, hc]``.
+    """
+    hc = hc_mult
+    pre_logits = mixes[..., :hc] * hc_scale[0] + hc_base[:hc]
+    post_logits = mixes[..., hc : 2 * hc] * hc_scale[1] + hc_base[hc : 2 * hc]
+    comb_logits = mixes[..., 2 * hc :] * hc_scale[2] + hc_base[2 * hc :]
+
+    pre = torch.sigmoid(pre_logits) + eps
+    post = 2.0 * torch.sigmoid(post_logits)
+
+    comb = comb_logits.view(*comb_logits.shape[:-1], hc, hc)
+    comb = comb.softmax(dim=-1) + eps
+    comb = comb / (comb.sum(dim=-2, keepdim=True) + eps)
+    for _ in range(sinkhorn_iters - 1):
+        comb = comb / (comb.sum(dim=-1, keepdim=True) + eps)
+        comb = comb / (comb.sum(dim=-2, keepdim=True) + eps)
+    return pre, post, comb
+
+
+class DeepseekV4MLP(nn.Module):
+    """SwiGLU expert / shared expert with optional clamp (matches V4 Expert).
+
+    w1 = gate_proj, w3 = up_proj, w2 = down_proj. swiglu_limit > 0 clamps the
+    (gate, up) activations before silu*up — matches the reference Expert forward.
+    """
+
+    def __init__(self, hidden_size: int, intermediate_size: int, swiglu_limit: float = 0.0):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+        self.swiglu_limit = swiglu_limit
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate = self.gate_proj(x)
+        up = self.up_proj(x)
+        if self.swiglu_limit > 0:
+            gate = torch.clamp(gate, max=self.swiglu_limit)
+            up = torch.clamp(up, min=-self.swiglu_limit, max=self.swiglu_limit)
+        return self.down_proj(F.silu(gate) * up)
+
+
+class DeepseekV4MoEGate(nn.Module):
+    """Routing with two modes (layer-dependent):
+
+    * Hash routing (layer_idx < num_hash_layers): selected_experts come from
+      ``tid2eid[input_ids]`` and routing weights come from ``sqrtsoftplus(x @ W)``
+      gathered at those indices. No bias, no topk.
+    * Score routing (otherwise): selected_experts come from topk of
+      ``sqrtsoftplus(x @ W) + bias``; routing weights are gathered from the
+      unbiased sqrtsoftplus scores, normalized (when norm_topk_prob), scaled by
+      ``routed_scaling_factor``.
+    """
+
+    def __init__(self, config: DeepseekV4Config, layer_idx: int):
+        super().__init__()
+        self.top_k = config.num_experts_per_tok
+        self.n_routed_experts = config.n_routed_experts
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.norm_topk_prob = config.norm_topk_prob
+        self.hash_routing = layer_idx < config.num_hash_layers
+        self.vocab_size = config.vocab_size
+
+        self.weight = nn.Parameter(
+            torch.empty((self.n_routed_experts, config.hidden_size), dtype=torch.float32)
+        )
+        if self.hash_routing:
+            self.register_buffer(
+                "tid2eid",
+                torch.zeros(self.vocab_size, self.top_k, dtype=torch.int32),
+                persistent=True,
+            )
+            self.bias = None
+        else:
+            self.bias = nn.Parameter(torch.zeros(self.n_routed_experts, dtype=torch.float32))
+
+    def forward(
+        self, hidden_states_flat: torch.Tensor, input_ids_flat: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # Keep the GEMM input in model dtype so FP8 fused linears can quantize it,
+        # then promote scores for routing math.
+        router_logits = F.linear(hidden_states_flat, self.weight).float()
+        # sqrtsoftplus: sqrt(softplus(x))
+        scores = F.softplus(router_logits).sqrt()
+        unbiased_scores = scores
+
+        if self.hash_routing:
+            selected_experts = self.tid2eid[input_ids_flat].to(torch.int64)
+        else:
+            biased_scores = scores + self.bias
+            selected_experts = biased_scores.topk(self.top_k, dim=-1)[1]
+
+        routing_weights = unbiased_scores.gather(1, selected_experts)
+        if self.norm_topk_prob:
+            routing_weights = routing_weights / (routing_weights.sum(dim=-1, keepdim=True) + 1e-20)
+        routing_weights = routing_weights * self.routed_scaling_factor
+        return selected_experts, routing_weights
+
+
+class DeepseekV4MoE(nn.Module):
+    """Routed MoE via torch_moe custom op + 1 shared expert."""
+
+    def __init__(self, config: DeepseekV4Config, layer_idx: int):
+        super().__init__()
+        self.experts = nn.ModuleList(
+            [
+                DeepseekV4MLP(
+                    config.hidden_size,
+                    config.moe_intermediate_size,
+                    swiglu_limit=config.swiglu_limit,
+                )
+                for _ in range(config.n_routed_experts)
+            ]
+        )
+        self.gate = DeepseekV4MoEGate(config, layer_idx)
+        # Shared expert: no swiglu_limit (matches reference)
+        shared_inter = config.moe_intermediate_size * config.n_shared_experts
+        self.shared_experts = DeepseekV4MLP(config.hidden_size, shared_inter, swiglu_limit=0.0)
+
+    def forward(self, hidden_states: torch.Tensor, input_ids: torch.Tensor) -> torch.Tensor:
+        orig_shape = hidden_states.shape
+        flat = hidden_states.view(-1, orig_shape[-1])
+        selected_experts, routing_weights = self.gate(flat, input_ids.reshape(-1))
+        routed = torch.ops.auto_deploy.torch_moe(
+            flat,
+            selected_experts,
+            routing_weights,
+            w1_weight=[e.gate_proj.weight for e in self.experts],
+            w2_weight=[e.down_proj.weight for e in self.experts],
+            w3_weight=[e.up_proj.weight for e in self.experts],
+            is_gated_mlp=True,
+            act_fn=int(ActivationType.Silu),
+        )
+        return routed.view(*orig_shape) + self.shared_experts(hidden_states)
+
+
+def _overlap_transform(tensor: torch.Tensor, head_dim: int, value: float = 0.0) -> torch.Tensor:
+    """HF DeepSeek V4 overlap transform used by ratio-4 compression."""
+    bsz, _, ratio, _ = tensor.shape
+    previous = tensor[:, :, :, :head_dim]
+    current = tensor[:, :, :, head_dim:]
+    prefix = tensor.new_full((bsz, 1, ratio, head_dim), value)
+    previous = torch.cat([prefix, previous[:, :-1]], dim=1)
+    return torch.cat([previous, current], dim=2)
+
+
+def _window_topk_idxs(
+    window_size: int, bsz: int, seqlen: int, device: torch.device
+) -> torch.Tensor:
+    """Prefill ``start_pos == 0`` version of HF ``get_window_topk_idxs``.
+
+    The window axis is kept at static ``window_size`` for export. Entries outside
+    the real causal window are marked ``-1`` and ignored by the sparse mask.
+    """
+    base = torch.arange(seqlen, device=device).unsqueeze(1)
+    matrix = base - window_size + 1 + torch.arange(window_size, device=device)
+    matrix = torch.where((matrix < 0) | (matrix > base), -1, matrix)
+    return matrix.unsqueeze(0).expand(bsz, -1, -1)
+
+
+def _compress_topk_idxs(
+    ratio: int,
+    bsz: int,
+    seqlen: int,
+    offset: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Prefill ``start_pos == 0`` version of HF ``get_compress_topk_idxs``.
+
+    The compressed-candidate axis is padded to ``seqlen`` to avoid specializing
+    dynamic export shapes on ``seqlen // ratio``.
+    """
+    matrix = torch.arange(seqlen, device=device).repeat(seqlen, 1)
+    valid_count = torch.arange(1, seqlen + 1, device=device).unsqueeze(1) // ratio
+    mask = matrix >= valid_count
+    matrix = torch.where(mask, -1, matrix + offset)
+    return matrix.unsqueeze(0).expand(bsz, -1, -1)
+
+
+def _build_sparse_attn_mask(topk_idxs: torch.Tensor, total_kv_len: int) -> torch.Tensor:
+    """Convert HF top-k index lists into an additive attention mask.
+
+    ``topk_idxs`` is ``[B, S, K]`` and may contain ``-1`` for invalid slots.
+    The returned mask is ``[B, 1, S, total_kv_len]`` with 0 for selected
+    positions and ``-inf`` elsewhere.
+    """
+    valid = topk_idxs >= 0
+    kv_positions = torch.arange(total_kv_len, device=topk_idxs.device)
+    selected = topk_idxs.unsqueeze(-1) == kv_positions.view(1, 1, 1, -1)
+    selected = (selected & valid.unsqueeze(-1)).any(dim=2)
+    mask = topk_idxs.new_zeros(selected.shape, dtype=torch.float32)
+    mask = mask.masked_fill(~selected, -10000.0)
+    return mask.unsqueeze(1)
+
+
+def _manual_attention_with_sinks(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    attn_mask: torch.Tensor,
+    scale: float,
+    sinks: torch.Tensor,
+) -> torch.Tensor:
+    """Reference-style attention for compressed sparse layers.
+
+    Generic KV-cache insertion assumes Q/K/V share the same token axis. DeepSeek V4
+    compressed sparse attention appends learned compressed KV tokens, so those
+    layers stay as plain PyTorch math instead of ``torch_attention``.
+    """
+    bsz, seqlen, n_heads, head_dim = q.shape
+    kv_len = k.shape[1]
+    q_bh = q.transpose(1, 2).float()
+    k_bh = k.expand(bsz, kv_len, n_heads, head_dim).transpose(1, 2).float()
+    v_bh = v.expand(bsz, kv_len, n_heads, head_dim).transpose(1, 2).float()
+    scores = torch.matmul(q_bh, k_bh.transpose(-2, -1)) * scale
+    scores = scores + attn_mask.float()
+
+    sink_logits = sinks.float().reshape(1, n_heads, 1, 1).expand(bsz, n_heads, seqlen, 1)
+    logits_max = scores.max(dim=-1, keepdim=True).values
+    exp_scores = torch.exp(scores - logits_max)
+    exp_sinks = torch.exp(sink_logits - logits_max)
+    attn = exp_scores / (exp_scores.sum(dim=-1, keepdim=True) + exp_sinks)
+    out = torch.matmul(attn, v_bh)
+    return out.transpose(1, 2).contiguous().to(q.dtype)
+
+
+def _ratio_chunk_indices(
+    seqlen: int, ratio: int, device: torch.device
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return padded ratio chunk token indices and their validity mask."""
+    chunk_ids = torch.arange(seqlen, device=device).unsqueeze(1)
+    token_offsets = torch.arange(ratio, device=device)
+    indices = chunk_ids * ratio + token_offsets
+    valid = indices < seqlen
+    indices = torch.where(valid, indices, torch.zeros_like(indices))
+    return indices, valid
+
+
+class DeepseekV4Compressor(nn.Module):
+    """Prefill-only learned KV compressor from HF DeepSeek V4.
+
+    The decode-time rolling state buffers are intentionally omitted.  This
+    module implements the ``start_pos == 0`` path, which is the path needed for
+    AutoDeploy export/reference equivalence.
+    """
+
+    def __init__(
+        self,
+        config: DeepseekV4Config,
+        compress_ratio: int,
+        head_dim: int,
+    ):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.head_dim = head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.compress_ratio = compress_ratio
+        self.overlap = compress_ratio == 4
+        coff = 1 + int(self.overlap)
+
+        self.ape = nn.Parameter(
+            torch.zeros(compress_ratio, coff * self.head_dim, dtype=torch.float32)
+        )
+        self.wkv = nn.Linear(self.hidden_size, coff * self.head_dim, bias=False)
+        self.wgate = nn.Linear(self.hidden_size, coff * self.head_dim, bias=False)
+        self.norm = DeepseekV4RMSNorm(self.head_dim, config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ) -> torch.Tensor:
+        bsz, seqlen, _ = hidden_states.shape
+        ratio = self.compress_ratio
+        chunk_indices, chunk_valid = _ratio_chunk_indices(seqlen, ratio, hidden_states.device)
+        flat_indices = chunk_indices.reshape(-1)
+
+        kv_all = self.wkv(hidden_states).float()
+        score_all = self.wgate(hidden_states).float()
+        kv = kv_all[:, flat_indices].view(bsz, seqlen, ratio, -1)
+        score = score_all[:, flat_indices].view(bsz, seqlen, ratio, -1) + self.ape
+        score = torch.where(
+            chunk_valid.view(1, seqlen, ratio, 1),
+            score,
+            score.new_full((), -1.0e20),
+        )
+        if self.overlap:
+            kv = _overlap_transform(kv, self.head_dim, 0.0)
+            score = _overlap_transform(score, self.head_dim, -1.0e20)
+
+        compressed = (kv * score.softmax(dim=2)).sum(dim=2)
+        compressed = self.norm(compressed.to(hidden_states.dtype))
+
+        rd = self.rope_head_dim
+        chunk_start = torch.arange(seqlen, device=hidden_states.device) * ratio
+        chunk_start = torch.where(chunk_start < seqlen, chunk_start, torch.zeros_like(chunk_start))
+        cos_comp = cos[:, chunk_start]
+        sin_comp = sin[:, chunk_start]
+        nope, pe = torch.split(compressed, [self.head_dim - rd, rd], dim=-1)
+        pe = _apply_interleaved_rope(pe, cos_comp, sin_comp)
+        return torch.cat([nope, pe], dim=-1)
+
+
+class DeepseekV4Indexer(nn.Module):
+    """Ratio-4 compressed-token indexer from HF DeepSeek V4, prefill path only."""
+
+    def __init__(self, config: DeepseekV4Config, compress_ratio: int):
+        super().__init__()
+        self.index_n_heads = config.index_n_heads
+        self.index_head_dim = config.index_head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.index_topk = config.index_topk
+        self.softmax_scale = self.index_head_dim**-0.5
+        self.compress_ratio = compress_ratio
+
+        self.wq_b = nn.Linear(
+            config.q_lora_rank, config.index_n_heads * config.index_head_dim, bias=False
+        )
+        self.weights_proj = nn.Linear(config.hidden_size, config.index_n_heads, bias=False)
+        self.compressor = DeepseekV4Compressor(config, compress_ratio, self.index_head_dim)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        q_lora: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        offset: int,
+    ) -> torch.Tensor:
+        bsz, seqlen, _ = hidden_states.shape
+        ratio = self.compress_ratio
+
+        rd = self.rope_head_dim
+        q = self.wq_b(q_lora).view(bsz, seqlen, self.index_n_heads, self.index_head_dim)
+        q_nope, q_pe = torch.split(q, [self.index_head_dim - rd, rd], dim=-1)
+        q_pe = _apply_interleaved_rope(q_pe, cos.unsqueeze(2), sin.unsqueeze(2))
+        q = torch.cat([q_nope, q_pe], dim=-1)
+
+        index_k = self.compressor(hidden_states, cos, sin)
+        weights = self.weights_proj(hidden_states).float() * (
+            self.softmax_scale * self.index_n_heads**-0.5
+        )
+
+        index_score = torch.einsum("bshd,btd->bsht", q, index_k).float()
+        index_score = (index_score.relu() * weights.unsqueeze(-1)).sum(dim=2)
+
+        compressed_positions = torch.arange(seqlen, device=hidden_states.device)
+        valid_count = torch.arange(1, seqlen + 1, device=hidden_states.device).unsqueeze(1) // ratio
+        future_mask = compressed_positions.unsqueeze(0) >= valid_count
+        valid = ~future_mask
+        index_score = index_score.masked_fill(future_mask.unsqueeze(0), -1.0e20)
+
+        sorted_idxs = index_score.argsort(dim=-1, descending=True)
+        sorted_valid = valid.unsqueeze(0).expand(bsz, -1, -1).gather(-1, sorted_idxs)
+        return torch.where(sorted_valid, sorted_idxs + offset, -1)
+
+
+class DeepseekV4Attention(nn.Module):
+    """MLA-variant with single KV head, sliding/compressed sparse attention.
+
+    * Q: wq_a -> q_norm -> wq_b -> reshape [B,S,H,D] -> parameterless per-head rsqrt -> RoPE(last rd)
+    * KV: wkv -> kv_norm -> RoPE(last rd) ; a single [B,S,D] tensor used as both K and V
+    * Attention:
+      - compress_ratio == 0: ``torch_attention`` with sliding window + sinks
+      - compress_ratio != 0: compressed KV tokens are appended and selected with
+        explicit sparse top-k masks before ``torch_attention``
+    * Post: inverse RoPE on output's last rd dims (undoes K-side rotation baked into V)
+    * O: grouped low-rank projection via einsum (wo_a) then wo_b
+
+    Decode-time compression state is dropped in this prefill-only port.
+    """
+
+    def __init__(self, config: DeepseekV4Config, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.n_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.nope_head_dim = self.head_dim - self.rope_head_dim
+        self.q_lora_rank = config.q_lora_rank
+        self.o_lora_rank = config.o_lora_rank
+        self.n_groups = config.o_groups
+        self.window_size = config.sliding_window
+        self.compress_ratio = int(config.compress_ratios[layer_idx])
+        self.rms_eps = config.rms_norm_eps
+        self.softmax_scale = self.head_dim**-0.5
+
+        # Group must divide n_heads evenly.
+        assert self.n_heads % self.n_groups == 0
+        self.group_head_width = (self.n_heads * self.head_dim) // self.n_groups
+
+        self.wq_a = nn.Linear(self.hidden_size, self.q_lora_rank, bias=False)
+        self.q_norm = DeepseekV4RMSNorm(self.q_lora_rank, eps=self.rms_eps)
+        self.wq_b = nn.Linear(self.q_lora_rank, self.n_heads * self.head_dim, bias=False)
+        self.wkv = nn.Linear(self.hidden_size, self.head_dim, bias=False)
+        self.kv_norm = DeepseekV4RMSNorm(self.head_dim, eps=self.rms_eps)
+        # Grouped low-rank O: wo_a stored as [n_groups * o_lora_rank, group_head_width]
+        # so the einsum ``bsgd,grd->bsgr`` is a plain linear whose weight is reshaped.
+        self.wo_a = nn.Linear(self.group_head_width, self.n_groups * self.o_lora_rank, bias=False)
+        self.wo_b = nn.Linear(self.n_groups * self.o_lora_rank, self.hidden_size, bias=False)
+        self.attn_sink = nn.Parameter(torch.zeros(self.n_heads, dtype=torch.float32))
+        if self.compress_ratio != 0:
+            self.compressor = DeepseekV4Compressor(config, self.compress_ratio, self.head_dim)
+            self.indexer = (
+                DeepseekV4Indexer(config, self.compress_ratio) if self.compress_ratio == 4 else None
+            )
+        else:
+            self.compressor = None
+            self.indexer = None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cos_base: torch.Tensor,
+        sin_base: torch.Tensor,
+        cos_compress: torch.Tensor,
+        sin_compress: torch.Tensor,
+    ) -> torch.Tensor:
+        bsz, seqlen, _ = hidden_states.shape
+
+        # Q: low-rank + per-head parameterless RMS + interleaved RoPE on last rd dims.
+        qr = self.q_norm(self.wq_a(hidden_states))
+        q = self.wq_b(qr).view(bsz, seqlen, self.n_heads, self.head_dim)
+        # Parameterless per-head RMS (reference: q *= rsqrt(q.square().mean(-1, keepdim=True) + eps))
+        q = q * torch.rsqrt(q.float().square().mean(-1, keepdim=True) + self.rms_eps).to(q.dtype)
+
+        # KV: single head, shared for both K and V; RoPE on last rd dims.
+        kv = self.kv_norm(self.wkv(hidden_states)).view(bsz, seqlen, 1, self.head_dim)
+
+        # RoPE: interleaved (complex-style) in pure real ops. Broadcast cos/sin with the
+        # [B, S, H, rope_head_dim] layout by adding a singleton head dim: [B, S, 1, rd/2].
+        if self.compress_ratio != 0:
+            cos = cos_compress.unsqueeze(2)
+            sin = sin_compress.unsqueeze(2)
+        else:
+            cos = cos_base.unsqueeze(2)
+            sin = sin_base.unsqueeze(2)
+        q_nope, q_pe = torch.split(q, [self.nope_head_dim, self.rope_head_dim], dim=-1)
+        kv_nope, kv_pe = torch.split(kv, [self.nope_head_dim, self.rope_head_dim], dim=-1)
+        q_pe = _apply_interleaved_rope(q_pe, cos, sin)
+        kv_pe = _apply_interleaved_rope(kv_pe, cos, sin)
+        q = torch.cat([q_nope, q_pe], dim=-1)
+        kv = torch.cat([kv_nope, kv_pe], dim=-1)
+
+        if self.compress_ratio != 0:
+            kv_compress = self.compressor(hidden_states, cos.squeeze(2), sin.squeeze(2))
+            if self.indexer is not None:
+                compress_topk_idxs = self.indexer(
+                    hidden_states, qr, cos.squeeze(2), sin.squeeze(2), offset=seqlen
+                )
+            else:
+                compress_topk_idxs = _compress_topk_idxs(
+                    self.compress_ratio, bsz, seqlen, seqlen, hidden_states.device
+                )
+            window_topk_idxs = _window_topk_idxs(
+                self.window_size, bsz, seqlen, hidden_states.device
+            )
+            topk_idxs = torch.cat([window_topk_idxs, compress_topk_idxs], dim=-1)
+            kv_all = torch.cat([kv, kv_compress.view(bsz, seqlen, 1, self.head_dim)], dim=1)
+            attn_mask = _build_sparse_attn_mask(topk_idxs, kv_all.shape[1]).to(q.dtype)
+            attn_out = _manual_attention_with_sinks(
+                q, kv_all, kv_all, attn_mask, self.softmax_scale, self.attn_sink
+            )
+        else:
+            # Attention: sliding window + learnable sinks, K == V (same tensor).
+            attn_out = torch.ops.auto_deploy.torch_attention(
+                q,
+                kv,
+                kv,
+                attn_mask=None,
+                dropout_p=0.0,
+                is_causal=True,
+                scale=self.softmax_scale,
+                sinks=self.attn_sink,
+                sliding_window=self.window_size,
+                layout="bsnd",
+            )
+
+        # Inverse RoPE on the output's last rd dims to undo the V-side rotation.
+        attn_nope, attn_pe = torch.split(attn_out, [self.nope_head_dim, self.rope_head_dim], dim=-1)
+        attn_pe = _apply_interleaved_rope(attn_pe, cos, sin, inverse=True)
+        attn_out = torch.cat([attn_nope, attn_pe], dim=-1)
+
+        # Grouped low-rank O: view as [B, S, n_groups, group_head_width] then einsum.
+        attn_out = attn_out.reshape(bsz, seqlen, self.n_groups, self.group_head_width)
+        # wo_a weight is [n_groups * o_lora_rank, group_head_width]; view as [n_groups, o_lora_rank, group_head_width]
+        wo_a_w = self.wo_a.weight.view(self.n_groups, self.o_lora_rank, self.group_head_width)
+        o = torch.einsum("bsgd,grd->bsgr", attn_out, wo_a_w)
+        return self.wo_b(o.reshape(bsz, seqlen, self.n_groups * self.o_lora_rank))
+
+
+class DeepseekV4Block(nn.Module):
+    """Transformer block with Hyper-Connections residual wiring.
+
+    Input / output: [B, S, hc_mult, D]. Each sub-layer does:
+      residual = x
+      y, post, comb = hc_pre(x, hc_*_fn, hc_*_scale, hc_*_base)  # y: [B,S,D]
+      y = sublayer_norm(y)
+      y = sublayer(y)
+      x = hc_post(y, residual, post, comb)  # back to [B,S,hc_mult,D]
+    """
+
+    def __init__(self, config: DeepseekV4Config, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.hc_mult = config.hc_mult
+        self.hc_sinkhorn_iters = config.hc_sinkhorn_iters
+        self.hc_eps = config.hc_eps
+        self.norm_eps = config.rms_norm_eps
+
+        self.attn_norm = DeepseekV4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.ffn_norm = DeepseekV4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attn = DeepseekV4Attention(config, layer_idx)
+        self.ffn = DeepseekV4MoE(config, layer_idx)
+
+        mix_hc = (2 + self.hc_mult) * self.hc_mult
+        hc_dim = self.hc_mult * config.hidden_size
+        # Float32 HC mixing params match reference semantics. Weights are overwritten by
+        # the checkpoint; zeros here mean untrained runs behave as a neutral residual-ish
+        # mixer (sigmoid(0)=0.5, softmax over uniform = 1/hc) instead of producing NaN.
+        self.hc_attn_fn = nn.Parameter(torch.zeros(mix_hc, hc_dim, dtype=torch.float32))
+        self.hc_ffn_fn = nn.Parameter(torch.zeros(mix_hc, hc_dim, dtype=torch.float32))
+        self.hc_attn_base = nn.Parameter(torch.zeros(mix_hc, dtype=torch.float32))
+        self.hc_ffn_base = nn.Parameter(torch.zeros(mix_hc, dtype=torch.float32))
+        self.hc_attn_scale = nn.Parameter(torch.ones(3, dtype=torch.float32))
+        self.hc_ffn_scale = nn.Parameter(torch.ones(3, dtype=torch.float32))
+
+    def _hc_pre(
+        self,
+        x: torch.Tensor,
+        hc_fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        # x: [B, S, hc_mult, D] -> flatten trailing two dims, normalize, mix.
+        shape, dtype = x.shape, x.dtype
+        x_flat = x.flatten(2)
+        x_norm = x_flat.float()
+        rsqrt = torch.rsqrt(x_norm.square().mean(-1, keepdim=True) + self.norm_eps)
+        mixes = F.linear(x_flat, hc_fn).float() * rsqrt
+        pre, post, comb = _hc_split_sinkhorn(
+            mixes, hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.hc_eps
+        )
+        y = torch.sum(pre.unsqueeze(-1) * x_norm.view(shape), dim=2)
+        return y.to(dtype), post, comb
+
+    def _hc_post(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        post: torch.Tensor,
+        comb: torch.Tensor,
+    ) -> torch.Tensor:
+        # x: [B,S,D], residual: [B,S,hc,D], post: [B,S,hc], comb: [B,S,hc,hc]
+        y = post.unsqueeze(-1) * x.unsqueeze(-2) + torch.sum(
+            comb.unsqueeze(-1) * residual.unsqueeze(-2), dim=2
+        )
+        return y.type_as(x)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        cos_base: torch.Tensor,
+        sin_base: torch.Tensor,
+        cos_compress: torch.Tensor,
+        sin_compress: torch.Tensor,
+    ) -> torch.Tensor:
+        # Attention sub-layer
+        residual = hidden_states
+        x, post, comb = self._hc_pre(
+            hidden_states, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
+        )
+        x = self.attn_norm(x)
+        x = self.attn(x, cos_base, sin_base, cos_compress, sin_compress)
+        hidden_states = self._hc_post(x, residual, post, comb)
+
+        # FFN (MoE) sub-layer
+        residual = hidden_states
+        x, post, comb = self._hc_pre(
+            hidden_states, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base
+        )
+        x = self.ffn_norm(x)
+        x = self.ffn(x, input_ids)
+        hidden_states = self._hc_post(x, residual, post, comb)
+        return hidden_states
+
+
+@dataclass
+class DeepseekV4Output(ModelOutput):
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class DeepseekV4CausalLMOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+
+
+class DeepseekV4PreTrainedModel(PreTrainedModel):
+    config_class = DeepseekV4Config
+    base_model_prefix = "model"
+    _no_split_modules = ["DeepseekV4Block"]
+    supports_gradient_checkpointing = False
+
+    def _init_weights(self, module: nn.Module) -> None:
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+
+class DeepseekV4Model(DeepseekV4PreTrainedModel):
+    """Embedding + HC expansion + N blocks + HC collapse (head) + final RMSNorm."""
+
+    def __init__(self, config: DeepseekV4Config):
+        super().__init__(config)
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)
+        self.layers = nn.ModuleList(
+            [DeepseekV4Block(config, layer_idx=idx) for idx in range(config.num_hidden_layers)]
+        )
+        self.norm = DeepseekV4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = DeepseekV4RotaryEmbedding(
+            rope_head_dim=config.qk_rope_head_dim,
+            max_position_embeddings=config.max_position_embeddings,
+            rope_theta=config.rope_theta,
+            compress_rope_theta=config.compress_rope_theta,
+            rope_scaling=config.rope_scaling,
+        )
+
+        # HC collapse parameters at the model head (sigmoid * scale + base, no Sinkhorn).
+        hc_dim = config.hc_mult * config.hidden_size
+        self.hc_head_fn = nn.Parameter(torch.zeros(config.hc_mult, hc_dim, dtype=torch.float32))
+        self.hc_head_base = nn.Parameter(torch.zeros(config.hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.ones(1, dtype=torch.float32))
+        self.hc_mult = config.hc_mult
+        self.hc_eps = config.hc_eps
+        self.norm_eps = config.rms_norm_eps
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def _hc_head_collapse(self, x: torch.Tensor) -> torch.Tensor:
+        """Collapse [B,S,hc,D] -> [B,S,D] using learned per-copy gates.
+
+        pre[i,j] = sigmoid(mixes[i,j] * hc_scale + hc_base[j]) + hc_eps, then sum over hc.
+        """
+        shape, dtype = x.shape, x.dtype
+        x_flat = x.flatten(2)
+        x_norm = x_flat.float()
+        rsqrt = torch.rsqrt(x_norm.square().mean(-1, keepdim=True) + self.norm_eps)
+        mixes = F.linear(x_flat, self.hc_head_fn).float() * rsqrt
+        pre = torch.sigmoid(mixes * self.hc_head_scale + self.hc_head_base) + self.hc_eps
+        y = torch.sum(pre.unsqueeze(-1) * x_norm.view(shape), dim=2)
+        return y.to(dtype)
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> DeepseekV4Output:
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("Cannot specify both input_ids and inputs_embeds")
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("Must specify either input_ids or inputs_embeds")
+        assert position_ids is not None, "position_ids must be provided"
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        # Hash routing needs input_ids; if only embeds are given, use zeros (hash routing will
+        # select expert 0 for all tokens, producing incorrect but export-friendly behavior).
+        if input_ids is None:
+            input_ids = torch.zeros(
+                inputs_embeds.shape[:2], dtype=torch.long, device=inputs_embeds.device
+            )
+
+        # Expand to hc_mult copies once at the start of the stack.
+        h = inputs_embeds.unsqueeze(2).expand(-1, -1, self.hc_mult, -1).contiguous()
+
+        # Slice RoPE tables once per forward; each layer picks between base and
+        # compressed tables by compress_ratio.
+        cos_base_table, sin_base_table, cos_compress_table, sin_compress_table = self.rotary_emb(
+            inputs_embeds
+        )
+        cos_base = cos_base_table[position_ids]
+        sin_base = sin_base_table[position_ids]
+        cos_compress = cos_compress_table[position_ids]
+        sin_compress = sin_compress_table[position_ids]
+
+        for layer in self.layers:
+            h = layer(h, input_ids, cos_base, sin_base, cos_compress, sin_compress)
+
+        # HC head collapse -> final RMSNorm
+        h = self._hc_head_collapse(h)
+        h = self.norm(h)
+        return DeepseekV4Output(last_hidden_state=h)
+
+
+class DeepseekV4ForCausalLM(DeepseekV4PreTrainedModel, GenerationMixin):
+    """DeepSeek V4 with LM head."""
+
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: DeepseekV4Config, **kwargs):
+        super().__init__(config)
+        self.model = DeepseekV4Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self._register_load_state_dict_pre_hook(self._load_hf_checkpoint_keys)
+        self.post_init()
+
+    @staticmethod
+    def _load_hf_checkpoint_keys(state_dict, prefix, *args):
+        del args
+        if prefix == "":
+            _remap_deepseek_v4_checkpoint_keys(state_dict)
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def get_decoder(self):
+        return self.model
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> DeepseekV4CausalLMOutput:
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+        logits = self.lm_head(outputs.last_hidden_state).float()
+        return DeepseekV4CausalLMOutput(logits=logits)
+
+
+AutoModelForCausalLMFactory.register_custom_model_cls("DeepseekV4Config", DeepseekV4ForCausalLM)

--- a/tensorrt_llm/_torch/auto_deploy/models/quant_config_reader.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/quant_config_reader.py
@@ -195,6 +195,15 @@ class HFQuantConfigReader(QuantConfigReader):
     """
 
     _ALWAYS_EXCLUDE = ("lm_head", "model.embed_tokens")
+    _DEEPSEEK_V4_FP8_EXCLUDE = (
+        "model.layers.*.attn.compressor.wkv",
+        "model.layers.*.attn.compressor.wgate",
+        "model.layers.*.attn.indexer.weights_proj",
+        "model.layers.*.attn.indexer.compressor.wkv",
+        "model.layers.*.attn.indexer.compressor.wgate",
+        "model.layers.*.attn.wo_a",
+        "model.layers.*.ffn.gate",
+    )
     _SUPPORTED_QUANT_METHODS = ("mxfp4", "gptq", "fp8")
 
     def __init__(self):
@@ -210,6 +219,13 @@ class HFQuantConfigReader(QuantConfigReader):
         # Inject default exclusion, add "model.embed_tokens" for "tie_word_embedding:true" case
         excludes = qconf.get("exclude_modules", [])
         qconf["exclude_modules"] = excludes + [n for n in self._ALWAYS_EXCLUDE if n not in excludes]
+        if (
+            config.get("model_type") == "deepseek_v4"
+            and str(qconf.get("quant_method", "")).lower() == "fp8"
+        ):
+            qconf["exclude_modules"].extend(
+                n for n in self._DEEPSEEK_V4_FP8_EXCLUDE if n not in qconf["exclude_modules"]
+            )
 
         self._quant_config = qconf
         from transformers.quantizers import AutoHfQuantizer

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -363,6 +363,23 @@ class InsertCachedMLAAttention(_InsertCachedOperator):
         return super()._apply(gm, cm, factory, shared_config)
 
 
+@TransformRegistry.register("insert_cached_deepseek_v4_sparse_attention")
+class InsertCachedDeepseekV4SparseAttention(_InsertCachedOperator):
+    """Cached-attention transform for DeepSeek-V4 sparse (compress_ratio != 0) layers.
+
+    Keys off the ``torch_ds_v4_sparse`` descriptor so the standard
+    ``insert_cached_attention`` transform (which targets plain ``torch_attention``)
+    leaves the sparse nodes alone. Both transforms can run in the same pipeline
+    without conflict.
+    """
+
+    @property
+    def attn_descriptor(self) -> Type[AttentionDescriptor]:
+        # Always route to the DS-V4 sparse descriptor; ``self.config.backend`` is
+        # ignored for this transform.
+        return AttentionRegistry.get("torch_ds_v4_sparse")
+
+
 @TransformRegistry.register("resize_kv_cache")
 class ResizeKVCache(BaseTransform):
     """Resize the KV cache to occupy available GPU memory.

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -915,7 +915,10 @@ class FineGrainedFP8LinearQuantization(Quantization):
                 skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
             )
 
-        excluded = qcfg.get("modules_to_not_convert", [])
+        excluded = list(qcfg.get("modules_to_not_convert") or [])
+        for pattern in qcfg.get("exclude_modules", []):
+            if pattern not in excluded:
+                excluded.append(pattern)
 
         cnt = 0
         with WeightBiasInfoCache():

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -112,6 +112,7 @@ def _quantize_moe_node(
     # These can be in args[6:] or in kwargs
     is_gated_mlp = True  # default
     act_fn = ActivationType.Silu  # default
+    swiglu_limit = 0.0
 
     if len(node.args) > 6:
         is_gated_mlp = node.args[6]
@@ -123,11 +124,20 @@ def _quantize_moe_node(
     elif "act_fn" in node.kwargs:
         act_fn = node.kwargs["act_fn"]
 
+    if len(node.args) > 8:
+        swiglu_limit = node.args[8]
+    elif "swiglu_limit" in node.kwargs:
+        swiglu_limit = node.kwargs["swiglu_limit"]
+
     # Prepare kwargs for the quantized op
     kwargs = {
         "is_gated_mlp": is_gated_mlp,
         "act_fn": act_fn,
+        "swiglu_limit": swiglu_limit,
     }
+    for name in ("mapping_config", "max_num_tokens", "apply_routing_on_input", "layer_type"):
+        if name in node.kwargs:
+            kwargs[name] = node.kwargs[name]
 
     # Replace the current node with the quantized version
     with gm.graph.inserting_after(node):

--- a/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/node_utils.py
@@ -657,12 +657,21 @@ def is_any_conv_op(node: Node) -> bool:
 
 
 def is_any_attention_op(node: Node) -> bool:
+    ops = [
+        torch.ops.auto_deploy.torch_attention_sdpa,
+        torch.ops.auto_deploy.torch_attention,
+    ]
+    deepseek_v4_sparse_attn = getattr(torch.ops.auto_deploy, "torch_deepseek_v4_sparse_attn", None)
+    deepseek_v4_sparse_attn_with_cache = getattr(
+        torch.ops.auto_deploy, "torch_deepseek_v4_sparse_attn_with_cache", None
+    )
+    if deepseek_v4_sparse_attn is not None:
+        ops.append(deepseek_v4_sparse_attn)
+    if deepseek_v4_sparse_attn_with_cache is not None:
+        ops.append(deepseek_v4_sparse_attn_with_cache)
     return is_op(
         node,
-        ops=[
-            torch.ops.auto_deploy.torch_attention_sdpa,
-            torch.ops.auto_deploy.torch_attention,
-        ],
+        ops=ops,
     )
 
 
@@ -1463,6 +1472,9 @@ def get_layer_after_linear_node(
         for n in set(backward_subgraph).union(forward_subgraph)
         if n not in set(opening_linear_nodes).union([terminating_linear_node])
     ]
+    if enforce_strict_linear_history:
+        closed_linear_nodes = set(linear_nodes[: terminating_indices[-1] + 1])
+        interior_nodes = [n for n in interior_nodes if n not in closed_linear_nodes]
     ssm_nodes = list(filtered_nodes(interior_nodes, is_any_ssm_op))
     delta_nodes = list(filtered_nodes(interior_nodes, is_any_delta_op))
     attention_nodes = list(filtered_nodes(interior_nodes, is_any_attention_op))

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py
@@ -768,6 +768,193 @@ class TestSlidingWindow:
         torch.testing.assert_close(out_none, out_zero)
 
 
+class TestSinks:
+    """Tests for attention sink support in Triton paged kernels."""
+
+    @staticmethod
+    def _attention_with_sinks_reference(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        sm_scale: float,
+        sinks: torch.Tensor,
+        sliding_window: int | None = None,
+        causal: bool = False,
+    ) -> torch.Tensor:
+        """Compute attention where sinks affect only the softmax denominator."""
+        q = q.float()
+        k = k.float()
+        v = v.float()
+        attn = torch.matmul(q, k.transpose(-2, -1)) * sm_scale
+
+        s_q = q.shape[2]
+        s_k = k.shape[2]
+        q_pos = torch.arange(s_k - s_q, s_k, device=q.device)
+        k_pos = torch.arange(s_k, device=q.device)
+        pos_diff = q_pos.unsqueeze(1) - k_pos.unsqueeze(0)
+
+        if causal:
+            attn = attn.masked_fill(pos_diff.unsqueeze(0).unsqueeze(0) < 0, float("-inf"))
+        if sliding_window is not None and sliding_window > 0:
+            attn = attn.masked_fill(
+                (pos_diff >= sliding_window).unsqueeze(0).unsqueeze(0), float("-inf")
+            )
+
+        sinks = sinks.float().reshape(1, -1, 1, 1)
+        logits_max = torch.maximum(attn.max(dim=-1, keepdim=True).values, sinks)
+        unnormalized = torch.exp(attn - logits_max)
+        sink_weight = torch.exp(sinks - logits_max)
+        weights = unnormalized / (unnormalized.sum(dim=-1, keepdim=True) + sink_weight)
+        return torch.matmul(weights, v)
+
+    def test_decode_sinks_with_sliding_window(self):
+        """Decode sinks match reference and compose with sliding window masking."""
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_decode,
+            update_paged_kv_cache,
+        )
+
+        batch_size, n_heads, n_kv_heads, head_dim = 2, 8, 2, 64
+        seq_len, page_size, sliding_window = 96, 16, 32
+        num_pages_per_seq = (seq_len + page_size - 1) // page_size
+        num_blocks = batch_size * num_pages_per_seq + 5
+
+        q = torch.randn(batch_size, n_heads, head_dim, dtype=torch.float16, device="cuda")
+        k = torch.randn(
+            batch_size, seq_len, n_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+        )
+        v = torch.randn(
+            batch_size, seq_len, n_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+        )
+        sinks = torch.randn(n_heads, dtype=torch.float32, device="cuda")
+
+        batch_indices = torch.repeat_interleave(
+            torch.arange(batch_size, device="cuda", dtype=torch.int32), seq_len
+        )
+        positions = torch.tile(
+            torch.arange(seq_len, device="cuda", dtype=torch.int32), (batch_size,)
+        )
+        kv_indptr = torch.arange(
+            0,
+            (batch_size + 1) * num_pages_per_seq,
+            num_pages_per_seq,
+            dtype=torch.int32,
+            device="cuda",
+        )[: batch_size + 1]
+        kv_indices = torch.arange(
+            0, batch_size * num_pages_per_seq, dtype=torch.int32, device="cuda"
+        )
+        kv_last_page_len = torch.full((batch_size,), page_size, dtype=torch.int32, device="cuda")
+
+        kv_cache = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        update_paged_kv_cache(
+            k.reshape(batch_size * seq_len, n_kv_heads, head_dim),
+            v.reshape(batch_size * seq_len, n_kv_heads, head_dim),
+            batch_indices,
+            positions,
+            kv_cache,
+            kv_indices,
+            kv_indptr,
+        )
+
+        sm_scale = 1.0 / math.sqrt(head_dim)
+        output = triton_paged_decode(
+            q,
+            kv_cache,
+            kv_indices,
+            kv_indptr,
+            kv_last_page_len,
+            sm_scale,
+            sliding_window=sliding_window,
+            sinks=sinks,
+        )
+
+        head_ratio = n_heads // n_kv_heads
+        k_ref = k[:, -sliding_window:].transpose(1, 2).repeat_interleave(head_ratio, dim=1)
+        v_ref = v[:, -sliding_window:].transpose(1, 2).repeat_interleave(head_ratio, dim=1)
+        ref = self._attention_with_sinks_reference(
+            q.unsqueeze(2), k_ref, v_ref, sm_scale, sinks
+        ).squeeze(2)
+
+        torch.testing.assert_close(output.float(), ref.float(), rtol=2e-2, atol=2e-2)
+
+    def test_context_sinks_with_sliding_window(self):
+        """Prefill sinks match reference and compose with causal sliding windows."""
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_context,
+            update_paged_kv_cache,
+        )
+
+        batch_size, n_heads, n_kv_heads, head_dim = 2, 8, 2, 64
+        seq_len, page_size, sliding_window = 64, 16, 32
+        total_tokens = batch_size * seq_len
+        num_pages_per_seq = (seq_len + page_size - 1) // page_size
+        num_blocks = batch_size * num_pages_per_seq + 5
+
+        q = torch.randn(total_tokens, n_heads, head_dim, dtype=torch.float16, device="cuda")
+        k = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        v = torch.randn(total_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        sinks = torch.randn(n_heads, dtype=torch.float32, device="cuda")
+
+        qo_indptr = torch.arange(
+            0, (batch_size + 1) * seq_len, seq_len, dtype=torch.int32, device="cuda"
+        )[: batch_size + 1]
+        kv_indptr = torch.arange(
+            0,
+            (batch_size + 1) * num_pages_per_seq,
+            num_pages_per_seq,
+            dtype=torch.int32,
+            device="cuda",
+        )[: batch_size + 1]
+        kv_indices = torch.arange(
+            0, batch_size * num_pages_per_seq, dtype=torch.int32, device="cuda"
+        )
+        kv_last_page_len = torch.full((batch_size,), page_size, dtype=torch.int32, device="cuda")
+        seq_len_with_cache = torch.full((batch_size,), seq_len, dtype=torch.int32, device="cuda")
+        batch_indices = torch.repeat_interleave(
+            torch.arange(batch_size, device="cuda", dtype=torch.int32), seq_len
+        )
+        positions = torch.tile(
+            torch.arange(seq_len, device="cuda", dtype=torch.int32), (batch_size,)
+        )
+
+        kv_cache = create_paged_kv_cache(num_blocks, page_size, n_kv_heads, head_dim)
+        update_paged_kv_cache(k, v, batch_indices, positions, kv_cache, kv_indices, kv_indptr)
+
+        sm_scale = 1.0 / math.sqrt(head_dim)
+        output = triton_paged_context(
+            q,
+            kv_cache,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            seq_len_with_cache,
+            sm_scale,
+            sliding_window=sliding_window,
+            sinks=sinks,
+        )
+
+        head_ratio = n_heads // n_kv_heads
+        q_ref = q.view(batch_size, seq_len, n_heads, head_dim).transpose(1, 2)
+        k_ref = (
+            k.view(batch_size, seq_len, n_kv_heads, head_dim)
+            .transpose(1, 2)
+            .repeat_interleave(head_ratio, dim=1)
+        )
+        v_ref = (
+            v.view(batch_size, seq_len, n_kv_heads, head_dim)
+            .transpose(1, 2)
+            .repeat_interleave(head_ratio, dim=1)
+        )
+        ref = self._attention_with_sinks_reference(
+            q_ref, k_ref, v_ref, sm_scale, sinks, sliding_window=sliding_window, causal=True
+        )
+        ref = ref.transpose(1, 2).reshape(total_tokens, n_heads, head_dim)
+
+        torch.testing.assert_close(output.float(), ref.float(), rtol=2e-2, atol=2e-2)
+
+
 class TestFlashInferComparison:
     """Tests comparing Triton implementation against FlashInfer."""
 

--- a/tests/unittest/auto_deploy/singlegpu/models/fixtures/deepseek_v4_flash_base_safetensors_index_sample.json
+++ b/tests/unittest/auto_deploy/singlegpu/models/fixtures/deepseek_v4_flash_base_safetensors_index_sample.json
@@ -1,0 +1,26 @@
+{
+  "metadata": {
+    "source_model": "deepseek-ai/DeepSeek-V4-Flash-Base",
+    "source_revision": "e133377a559d13c857cf0c054bb46247076102a0",
+    "source_file": "model.safetensors.index.json",
+    "description": "Representative weight_map entries copied from the Hugging Face safetensors index."
+  },
+  "weight_map": {
+    "embed.weight": "model-00001-of-00046.safetensors",
+    "head.weight": "model-00045-of-00046.safetensors",
+    "hc_head_base": "model-00045-of-00046.safetensors",
+    "hc_head_fn": "model-00045-of-00046.safetensors",
+    "hc_head_scale": "model-00045-of-00046.safetensors",
+    "layers.0.attn.wq_a.weight": "model-00002-of-00046.safetensors",
+    "layers.0.ffn.experts.0.w1.weight": "model-00002-of-00046.safetensors",
+    "layers.0.ffn.experts.0.w2.weight": "model-00002-of-00046.safetensors",
+    "layers.0.ffn.experts.0.w3.weight": "model-00002-of-00046.safetensors",
+    "layers.0.ffn.gate.tid2eid": "model-00002-of-00046.safetensors",
+    "layers.0.ffn.shared_experts.w1.weight": "model-00002-of-00046.safetensors",
+    "layers.0.ffn.shared_experts.w2.weight": "model-00002-of-00046.safetensors",
+    "layers.0.ffn.shared_experts.w3.weight": "model-00002-of-00046.safetensors",
+    "layers.2.attn.compressor.wkv.weight": "model-00004-of-00046.safetensors",
+    "layers.2.attn.indexer.wq_b.weight": "model-00004-of-00046.safetensors",
+    "norm.weight": "model-00045-of-00046.safetensors"
+  }
+}

--- a/tests/unittest/auto_deploy/singlegpu/models/fixtures/deepseek_v4_flash_base_safetensors_index_sample.json
+++ b/tests/unittest/auto_deploy/singlegpu/models/fixtures/deepseek_v4_flash_base_safetensors_index_sample.json
@@ -12,15 +12,20 @@
     "hc_head_fn": "model-00045-of-00046.safetensors",
     "hc_head_scale": "model-00045-of-00046.safetensors",
     "layers.0.attn.wq_a.weight": "model-00002-of-00046.safetensors",
+    "layers.0.attn.wq_a.scale": "model-00002-of-00046.safetensors",
     "layers.0.ffn.experts.0.w1.weight": "model-00002-of-00046.safetensors",
+    "layers.0.ffn.experts.0.w1.scale": "model-00002-of-00046.safetensors",
     "layers.0.ffn.experts.0.w2.weight": "model-00002-of-00046.safetensors",
     "layers.0.ffn.experts.0.w3.weight": "model-00002-of-00046.safetensors",
     "layers.0.ffn.gate.tid2eid": "model-00002-of-00046.safetensors",
     "layers.0.ffn.shared_experts.w1.weight": "model-00002-of-00046.safetensors",
+    "layers.0.ffn.shared_experts.w1.scale": "model-00002-of-00046.safetensors",
     "layers.0.ffn.shared_experts.w2.weight": "model-00002-of-00046.safetensors",
     "layers.0.ffn.shared_experts.w3.weight": "model-00002-of-00046.safetensors",
     "layers.2.attn.compressor.wkv.weight": "model-00004-of-00046.safetensors",
+    "layers.2.attn.compressor.wkv.scale": "model-00004-of-00046.safetensors",
     "layers.2.attn.indexer.wq_b.weight": "model-00004-of-00046.safetensors",
+    "layers.2.attn.indexer.wq_b.scale": "model-00004-of-00046.safetensors",
     "norm.weight": "model-00045-of-00046.safetensors"
   }
 }

--- a/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_modeling.py
@@ -1411,6 +1411,101 @@ def test_sparse_cache_transform_replaces_sparse_attention_nodes():
     assert all(len(n.args) == 40 for n in cached_nodes)
 
 
+def test_dense_cache_transform_routes_dense_layers_to_triton_paged_only():
+    """Dense DS-V4 layers route to triton_paged while sparse layers stay sparse."""
+    cfg = _small_config()
+    cfg.num_hidden_layers = 3
+    cfg.compress_ratios = [0, 4, 128]
+    model = DeepseekV4ForCausalLM(cfg).eval()
+
+    B, S = 2, 4
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+
+    from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+    from tensorrt_llm._torch.auto_deploy.transform.interface import Stages
+    from tensorrt_llm._torch.auto_deploy.transform.library.kvcache import (
+        InsertCachedAttention,
+        InsertCachedDeepseekV4SparseAttention,
+    )
+    from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_op_args
+    from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+    dense_source_op = torch.ops.auto_deploy.torch_attention.default
+    sparse_source_op = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn.default
+    dense_nodes = [
+        n for n in gm.graph.nodes if n.op == "call_function" and n.target is dense_source_op
+    ]
+    assert len(dense_nodes) == 1
+    dense_sink_arg = extract_op_args(dense_nodes[0], "sinks")[0]
+
+    cm = CachedSequenceInterface(
+        max_seq_len=cfg.max_position_embeddings,
+        max_batch_size=B,
+        max_num_tokens=B * cfg.max_position_embeddings,
+        device="cpu",
+        kv_cache_config=KvCacheConfig(
+            dtype="bfloat16", free_gpu_memory_fraction=0.0, tokens_per_block=64
+        ),
+    )
+    transform = InsertCachedAttention.from_kwargs(stage=Stages.CACHE_INIT, backend="triton_paged")
+    gm, info = transform._apply(gm, cm, factory=None, shared_config=None)
+
+    dense_cached_op = torch.ops.auto_deploy.triton_paged_mha_with_cache.default
+    sparse_cached_op = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache.default
+    dense_source_nodes = [
+        n for n in gm.graph.nodes if n.op == "call_function" and n.target is dense_source_op
+    ]
+    dense_cached_nodes = [
+        n for n in gm.graph.nodes if n.op == "call_function" and n.target is dense_cached_op
+    ]
+    sparse_source_nodes = [
+        n for n in gm.graph.nodes if n.op == "call_function" and n.target is sparse_source_op
+    ]
+    sparse_cached_nodes = [
+        n for n in gm.graph.nodes if n.op == "call_function" and n.target is sparse_cached_op
+    ]
+
+    assert info.num_matches == 1
+    assert dense_source_nodes == []
+    assert len(dense_cached_nodes) == 1
+    assert len(sparse_source_nodes) == 2
+    assert sparse_cached_nodes == []
+
+    cached_node = dense_cached_nodes[0]
+    assert cached_node.args[-3] == cfg.head_dim**-0.5
+    assert cached_node.args[-2] == cfg.sliding_window
+    assert cached_node.args[-1] is dense_sink_arg
+
+    sparse_transform = InsertCachedDeepseekV4SparseAttention.from_kwargs(stage=Stages.CACHE_INIT)
+    gm, sparse_info = sparse_transform._apply(gm, cm, factory=None, shared_config=None)
+
+    dense_cached_nodes = [
+        n for n in gm.graph.nodes if n.op == "call_function" and n.target is dense_cached_op
+    ]
+    sparse_source_nodes = [
+        n for n in gm.graph.nodes if n.op == "call_function" and n.target is sparse_source_op
+    ]
+    sparse_cached_nodes = [
+        n for n in gm.graph.nodes if n.op == "call_function" and n.target is sparse_cached_op
+    ]
+
+    assert sparse_info.num_matches == 2
+    assert len(dense_cached_nodes) == 1
+    assert sparse_source_nodes == []
+    assert len(sparse_cached_nodes) == 2
+
+
 def test_exported_hc_mixes_use_fp32_matmul_not_linear_ops():
     """HC mixers must not be exported as quantizable linear ops.
 

--- a/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_modeling.py
@@ -1132,6 +1132,252 @@ def test_model_can_be_exported():
     assert torch.isfinite(out2["logits"]).all()
 
 
+def test_sparse_prefill_op_matches_inline_math():
+    """Sparse-prefill custom op matches the previous inline math.
+
+    ``torch_deepseek_v4_sparse_attn`` must produce identical output to the
+    previous inline math for both ratio-4 (indexer) and ratio-128 (no indexer)
+    sparse layers. Current AD model already routes through the op; this test
+    also dispatches the op explicitly with its argument pack to catch regressions
+    in the op registration / schema.
+    """
+    for ratio in (4, 128):
+        cfg = _small_compress_config(ratio=ratio)
+        custom = DeepseekV4Attention(cfg, layer_idx=0).eval()
+        custom.compressor.ape.data.normal_(std=0.02)
+        if custom.indexer is not None:
+            custom.indexer.compressor.ape.data.normal_(std=0.02)
+        custom.attn_sink.data.normal_(std=0.1)
+
+        B, S = 2, 8
+        x = torch.randn(B, S, cfg.hidden_size)
+        position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+        cos_tbl, sin_tbl = _build_freqs_cis(
+            cfg.qk_rope_head_dim,
+            cfg.max_position_embeddings,
+            cfg.compress_rope_theta,
+            0,
+            1.0,
+            32,
+            1,
+        )
+        cos = cos_tbl[position_ids]  # [B, S, rd/2]
+        sin = sin_tbl[position_ids]
+
+        # Reference: full DeepseekV4Attention forward — emits the op internally.
+        y_ref = custom(x, cos, sin, cos, sin)
+
+        # Explicit invocation of the op with manually prepared inputs
+        rd = cfg.qk_rope_head_dim
+        qr = custom.q_norm(custom.wq_a(x))
+        q = custom.wq_b(qr).view(B, S, cfg.num_attention_heads, cfg.head_dim)
+        q = q * torch.rsqrt(q.float().square().mean(-1, keepdim=True) + cfg.rms_norm_eps).to(
+            q.dtype
+        )
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_sparse_attention import (
+            _apply_interleaved_rope,
+        )
+
+        q_nope, q_pe = torch.split(q, [cfg.head_dim - rd, rd], dim=-1)
+        q_pe = _apply_interleaved_rope(q_pe, cos.unsqueeze(2), sin.unsqueeze(2))
+        q = torch.cat([q_nope, q_pe], dim=-1)
+
+        kv = custom.kv_norm(custom.wkv(x)).view(B, S, 1, cfg.head_dim)
+        kv_nope, kv_pe = torch.split(kv, [cfg.head_dim - rd, rd], dim=-1)
+        kv_pe = _apply_interleaved_rope(kv_pe, cos.unsqueeze(2), sin.unsqueeze(2))
+        kv = torch.cat([kv_nope, kv_pe], dim=-1)
+
+        if custom.indexer is not None:
+            indexer_args = (
+                custom.indexer.wq_b.weight,
+                custom.indexer.weights_proj.weight,
+                custom.indexer.compressor.wkv.weight,
+                custom.indexer.compressor.wgate.weight,
+                custom.indexer.compressor.ape,
+                custom.indexer.compressor.norm.weight,
+            )
+            index_n_heads = custom.indexer.index_n_heads
+            index_head_dim = custom.indexer.index_head_dim
+        else:
+            indexer_args = (None,) * 6
+            index_n_heads = 0
+            index_head_dim = 0
+
+        op_out = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn(
+            q,
+            kv,
+            x,
+            qr,
+            cos,
+            sin,
+            custom.attn_sink,
+            custom.compressor.wkv.weight,
+            custom.compressor.wgate.weight,
+            custom.compressor.ape,
+            custom.compressor.norm.weight,
+            *indexer_args,
+            custom.softmax_scale,
+            custom.window_size,
+            custom.compress_ratio,
+            custom.rope_head_dim,
+            custom.head_dim,
+            index_n_heads,
+            index_head_dim,
+            cfg.rms_norm_eps,
+            0,  # layer_idx
+            "mha_sparse",
+        )
+
+        # Post-op path: inverse RoPE + grouped low-rank O projection, exactly as in
+        # DeepseekV4Attention.forward.
+        attn_nope, attn_pe = torch.split(op_out, [cfg.head_dim - rd, rd], dim=-1)
+        attn_pe = _apply_interleaved_rope(attn_pe, cos.unsqueeze(2), sin.unsqueeze(2), inverse=True)
+        attn_out = torch.cat([attn_nope, attn_pe], dim=-1)
+        attn_out = attn_out.reshape(B, S, cfg.o_groups, custom.group_head_width)
+        wo_a = custom.wo_a.weight.view(cfg.o_groups, cfg.o_lora_rank, custom.group_head_width)
+        o = torch.einsum("bsgd,grd->bsgr", attn_out, wo_a)
+        y_from_op = custom.wo_b(o.reshape(B, S, cfg.o_groups * cfg.o_lora_rank))
+
+        torch.testing.assert_close(y_ref, y_from_op, rtol=1e-5, atol=1e-5)
+
+
+def test_exported_graph_has_sparse_and_dense_attention_nodes():
+    """Exported graph places dense vs sparse attention nodes in the right ops.
+
+    The AD custom model must export a graph where:
+      * each dense layer emits ``auto_deploy::torch_attention`` with
+        ``layer_idx`` and ``layer_type="mha"`` set, and
+      * each sparse layer emits ``auto_deploy::torch_deepseek_v4_sparse_attn``.
+    This is the precondition the cache transforms rely on.
+    """
+    # Build a 3-layer fixture: 1 dense, 1 ratio-4, 1 ratio-128.
+    cfg = _small_config()
+    cfg.num_hidden_layers = 3
+    cfg.compress_ratios = [0, 4, 128]
+    model = DeepseekV4ForCausalLM(cfg).eval()
+
+    B, S = 2, 4
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+
+    dense_op = torch.ops.auto_deploy.torch_attention.default
+    sparse_op = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn.default
+    dense_nodes = [n for n in gm.graph.nodes if n.op == "call_function" and n.target is dense_op]
+    sparse_nodes = [n for n in gm.graph.nodes if n.op == "call_function" and n.target is sparse_op]
+
+    assert len(dense_nodes) == 1, f"Expected 1 dense attention node, got {len(dense_nodes)}"
+    assert len(sparse_nodes) == 2, (
+        f"Expected 2 sparse attention nodes (ratio-4 + ratio-128), got {len(sparse_nodes)}"
+    )
+
+    # layer_idx and layer_type must appear on every dense attention node.
+    from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_op_args
+
+    for n in dense_nodes:
+        layer_idx, layer_type = extract_op_args(n, "layer_idx", "layer_type")
+        assert layer_idx == 0
+        assert layer_type == "mha"
+
+    # Sparse nodes must also carry layer_idx/layer_type + the constants the
+    # descriptor reads in get_constants.
+    seen_sparse_layer_idxs = set()
+    for n in sparse_nodes:
+        layer_idx, layer_type = extract_op_args(n, "layer_idx", "layer_type")
+        assert layer_type == "mha_sparse"
+        seen_sparse_layer_idxs.add(layer_idx)
+        scale, window_size, compress_ratio = extract_op_args(
+            n, "scale", "window_size", "compress_ratio"
+        )
+        assert compress_ratio in (4, 128)
+        assert window_size == cfg.sliding_window
+        assert scale == cfg.head_dim**-0.5
+    assert seen_sparse_layer_idxs == {1, 2}
+
+
+def test_sparse_descriptor_resource_handler_shapes():
+    """Sparse descriptor returns resource handlers with expected dtypes and shapes.
+
+    ``DeepseekV4SparseAttentionDescriptor.get_cache_initializers`` must return
+    the right set of resource handlers with sensible dtypes and token-shapes so
+    the KV cache transform wires the caches correctly.
+    """
+    from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_sparse_attention import (
+        DeepseekV4SparseAttentionDescriptor,
+    )
+    from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import (
+        StateResourceHandler,
+        UnpagedResourceHandler,
+    )
+    from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+    cfg = _small_compress_config(ratio=4)
+    model = DeepseekV4ForCausalLM(cfg).eval()
+
+    B, S = 2, 4
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+
+    sparse_op = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn.default
+    sparse_nodes = [n for n in gm.graph.nodes if n.op == "call_function" and n.target is sparse_op]
+    assert sparse_nodes, "Expected at least one sparse attention node"
+
+    cache_config = KvCacheConfig(dtype="bfloat16")
+    handlers = DeepseekV4SparseAttentionDescriptor.get_cache_initializers(
+        sparse_nodes[0], cache_config
+    )
+
+    expected_keys = {
+        "window_cache",
+        "compressed_kv_cache",
+        "compressor_kv_state",
+        "compressor_score_state",
+        "indexer_compressed_kv_cache",
+        "indexer_kv_state",
+        "indexer_score_state",
+    }
+    assert set(handlers.keys()) == expected_keys
+
+    # Window / compressed caches are per-token (Unpaged); rolling state is
+    # fixed-shape (StateResourceHandler).
+    assert isinstance(handlers["window_cache"], UnpagedResourceHandler)
+    assert isinstance(handlers["compressed_kv_cache"], UnpagedResourceHandler)
+    assert handlers["window_cache"].token_shape == (cfg.head_dim,)
+    for key in (
+        "compressor_kv_state",
+        "compressor_score_state",
+        "indexer_kv_state",
+        "indexer_score_state",
+    ):
+        assert isinstance(handlers[key], StateResourceHandler), key
+        assert handlers[key].dtype == torch.float32, key
+    # Rolling state: coff * compress_ratio tokens × coff * head_dim dims (coff=2 for ratio 4).
+    coff = 2  # ratio == 4
+    assert handlers["compressor_kv_state"].state_shape == (
+        coff * cfg.compress_ratios[0],
+        coff * cfg.head_dim,
+    )
+
+
 def test_compressed_model_can_be_exported():
     cfg = _small_compress_config(ratio=4)
     model = DeepseekV4ForCausalLM(cfg).eval()

--- a/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_modeling.py
@@ -22,6 +22,7 @@ import torch.nn.functional as F
 from _model_test_utils import assert_rmse_close
 from torch import nn
 from torch.export import Dim
+from torch.fx import Node
 
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
@@ -36,6 +37,9 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4RMSNorm,
     _build_freqs_cis,
     _build_sparse_attn_mask,
+    _fake_fp4_act_quant,
+    _fake_fp8_act_quant,
+    _hadamard_rotate,
     _hc_split_sinkhorn,
     _remap_deepseek_v4_checkpoint_keys,
     _window_topk_idxs,
@@ -57,15 +61,20 @@ _EXPECTED_FLASH_BASE_INDEX_KEYS = {
     "hc_head_fn",
     "hc_head_scale",
     "layers.0.attn.wq_a.weight",
+    "layers.0.attn.wq_a.scale",
     "layers.0.ffn.experts.0.w1.weight",
+    "layers.0.ffn.experts.0.w1.scale",
     "layers.0.ffn.experts.0.w2.weight",
     "layers.0.ffn.experts.0.w3.weight",
     "layers.0.ffn.gate.tid2eid",
     "layers.0.ffn.shared_experts.w1.weight",
+    "layers.0.ffn.shared_experts.w1.scale",
     "layers.0.ffn.shared_experts.w2.weight",
     "layers.0.ffn.shared_experts.w3.weight",
     "layers.2.attn.compressor.wkv.weight",
+    "layers.2.attn.compressor.wkv.scale",
     "layers.2.attn.indexer.wq_b.weight",
+    "layers.2.attn.indexer.wq_b.scale",
     "norm.weight",
 }
 
@@ -254,7 +263,12 @@ def _ref_compressor_forward(
     kv = compressor.norm(kv.to(dtype))
     rd = compressor.rope_head_dim
     rotated = _apply_rotary_emb_ref(kv[..., -rd:], freqs_cis[:cutoff:ratio])
-    return torch.cat([kv[..., :-rd], rotated], dim=-1)
+    kv = torch.cat([kv[..., :-rd], rotated], dim=-1)
+    if compressor.rotate:
+        return _fake_fp4_act_quant(_hadamard_rotate(kv), block_size=32)
+
+    nope, pe = torch.split(kv, [compressor.head_dim - rd, rd], dim=-1)
+    return torch.cat([_fake_fp8_act_quant(nope, block_size=64), pe], dim=-1)
 
 
 def _ref_indexer_forward(
@@ -264,7 +278,7 @@ def _ref_indexer_forward(
     freqs_cis: torch.Tensor,
     offset: int,
 ) -> torch.Tensor:
-    """Faithful prefill ``start_pos == 0`` reference for HF Indexer without FP4 simulation."""
+    """Faithful prefill ``start_pos == 0`` reference for HF Indexer."""
     bsz, seqlen, _ = hidden_states.shape
     ratio = indexer.compress_ratio
     n_compressed = seqlen // ratio
@@ -277,6 +291,7 @@ def _ref_indexer_forward(
     )
     q_rot = _apply_rotary_emb_ref(q[..., -rd:], freqs_cis)
     q = torch.cat([q[..., :-rd], q_rot], dim=-1)
+    q = _fake_fp4_act_quant(_hadamard_rotate(q), block_size=32)
     index_k = _ref_compressor_forward(indexer.compressor, hidden_states, freqs_cis)
     weights = F.linear(hidden_states, indexer.weights_proj.weight)
     weights = weights * (indexer.softmax_scale * indexer.index_n_heads**-0.5)
@@ -372,7 +387,7 @@ class _RefAttention(nn.Module):
         q_rope_part = _apply_rotary_emb_ref(q[..., -rd:], freqs_cis)
         kv_rope_part = _apply_rotary_emb_ref(kv[..., -rd:], freqs_cis)
         q = torch.cat([q[..., :-rd], q_rope_part], dim=-1)
-        kv = torch.cat([kv[..., :-rd], kv_rope_part], dim=-1)
+        kv = torch.cat([_fake_fp8_act_quant(kv[..., :-rd], block_size=64), kv_rope_part], dim=-1)
 
         o = _sliding_window_sink_attn(q, kv, self.attn_sink, self.softmax_scale, self.window_size)
         # Inverse RoPE on output's last rd dims
@@ -689,6 +704,7 @@ def test_moe_gate_equivalence_score_routing():
 def test_moe_equivalence():
     """Full MoE block: gate + routed experts via torch_moe + shared expert."""
     cfg = _small_config()
+    cfg.swiglu_limit = 0.5
     moe = DeepseekV4MoE(cfg, layer_idx=cfg.num_hash_layers)
     # Randomize gate weights (they're zero-init by default isn't the case here but
     # DeepseekV4MoEGate uses torch.empty via nn.Parameter directly; in practice _init_weights
@@ -711,7 +727,7 @@ def test_moe_equivalence():
 
     ref_experts = nn.ModuleList(
         [
-            _RefExpert(cfg.hidden_size, cfg.moe_intermediate_size)
+            _RefExpert(cfg.hidden_size, cfg.moe_intermediate_size, swiglu_limit=cfg.swiglu_limit)
             for _ in range(cfg.n_routed_experts)
         ]
     )
@@ -726,7 +742,7 @@ def test_moe_equivalence():
     ref_shared.w2.weight.data.copy_(moe.shared_experts.down_proj.weight.data)
 
     B, S, H = 2, 8, cfg.hidden_size
-    x = torch.randn(B, S, H)
+    x = torch.randn(B, S, H) * 4.0
     input_ids = torch.randint(0, cfg.vocab_size, (B, S))
     y_custom = moe(x, input_ids)
 
@@ -781,7 +797,7 @@ def test_attention_equivalence():
     sin = sin_tbl[position_ids]
     freqs_cis_ref = _freqs_cis_from_cos_sin(cos[0], sin[0])  # [S, rd/2] for ref
 
-    y_custom = custom(x, cos, sin, cos, sin)
+    y_custom = custom(x, cos, sin, cos, sin, cos_tbl, sin_tbl)
     y_ref = ref(x, freqs_cis_ref)
     assert_rmse_close(y_custom, y_ref, rmse_ratio_tol=0.10, msg="Attention equivalence: ")
 
@@ -846,7 +862,7 @@ def test_attention_compressed_prefill_equivalence():
     sin = sin_tbl[position_ids]
     freqs_cis_ref = _freqs_cis_from_cos_sin(cos[0], sin[0])
 
-    y_custom = custom(x, cos, sin, cos, sin)
+    y_custom = custom(x, cos, sin, cos, sin, cos_tbl, sin_tbl)
 
     rd = cfg.qk_rope_head_dim
     q_lora = custom.q_norm(custom.wq_a(x))
@@ -854,7 +870,13 @@ def test_attention_compressed_prefill_equivalence():
     q = q * torch.rsqrt(q.float().square().mean(-1, keepdim=True) + cfg.rms_norm_eps).to(q.dtype)
     q = torch.cat([q[..., :-rd], _apply_rotary_emb_ref(q[..., -rd:], freqs_cis_ref)], dim=-1)
     kv = custom.kv_norm(custom.wkv(x))
-    kv = torch.cat([kv[..., :-rd], _apply_rotary_emb_ref(kv[..., -rd:], freqs_cis_ref)], dim=-1)
+    kv = torch.cat(
+        [
+            _fake_fp8_act_quant(kv[..., :-rd], block_size=64),
+            _apply_rotary_emb_ref(kv[..., -rd:], freqs_cis_ref),
+        ],
+        dim=-1,
+    )
     kv = kv.view(B, S, 1, cfg.head_dim)
     kv_comp = _ref_compressor_forward(custom.compressor, x, freqs_cis_ref).view(
         B, -1, 1, cfg.head_dim
@@ -928,15 +950,41 @@ def test_flash_base_checkpoint_index_matches_expected_layout():
     assert "lm_head.weight" in state_dict
     assert "model.norm.weight" in state_dict
     assert "model.hc_head_fn" in state_dict
+    assert "model.hc_head_scale" in state_dict
     assert "model.layers.0.attn.wq_a.weight" in state_dict
+    assert "model.layers.0.attn.wq_a.weight_scale_inv" in state_dict
     assert "model.layers.0.ffn.experts.0.gate_proj.weight" in state_dict
+    assert "model.layers.0.ffn.experts.0.gate_proj.weight_scale_inv" in state_dict
     assert "model.layers.0.ffn.experts.0.up_proj.weight" in state_dict
     assert "model.layers.0.ffn.experts.0.down_proj.weight" in state_dict
     assert "model.layers.0.ffn.shared_experts.gate_proj.weight" in state_dict
+    assert "model.layers.0.ffn.shared_experts.gate_proj.weight_scale_inv" in state_dict
     assert "model.layers.0.ffn.shared_experts.up_proj.weight" in state_dict
     assert "model.layers.0.ffn.shared_experts.down_proj.weight" in state_dict
     assert "model.layers.2.attn.compressor.wkv.weight" in state_dict
+    assert "model.layers.2.attn.compressor.wkv.weight_scale_inv" in state_dict
     assert "model.layers.2.attn.indexer.wq_b.weight" in state_dict
+    assert "model.layers.2.attn.indexer.wq_b.weight_scale_inv" in state_dict
+
+
+@pytest.mark.skipif(not hasattr(torch, "float8_e4m3fn"), reason="requires torch float8")
+def test_remap_dequantizes_wo_a_fp8_checkpoint_weight():
+    """HF inference dequantizes grouped wo_a weights during checkpoint conversion."""
+    scale = torch.full((1, 1), 0.25, dtype=torch.float32)
+    weight_fp32 = torch.linspace(-8.0, 8.0, 128 * 128, dtype=torch.float32).view(128, 128)
+    weight_fp8 = (weight_fp32 / scale).to(torch.float8_e4m3fn)
+    expected = (weight_fp8.float() * scale).bfloat16()
+
+    state_dict = {
+        "layers.0.attn.wo_a.weight": weight_fp8,
+        "layers.0.attn.wo_a.scale": scale,
+    }
+    _remap_deepseek_v4_checkpoint_keys(state_dict)
+
+    assert "model.layers.0.attn.wo_a.weight" in state_dict
+    assert "model.layers.0.attn.wo_a.weight_scale_inv" not in state_dict
+    assert state_dict["model.layers.0.attn.wo_a.weight"].dtype == torch.bfloat16
+    torch.testing.assert_close(state_dict["model.layers.0.attn.wo_a.weight"], expected)
 
 
 def test_load_state_dict_accepts_hf_checkpoint_layout():
@@ -1165,7 +1213,7 @@ def test_sparse_prefill_op_matches_inline_math():
         sin = sin_tbl[position_ids]
 
         # Reference: full DeepseekV4Attention forward — emits the op internally.
-        y_ref = custom(x, cos, sin, cos, sin)
+        y_ref = custom(x, cos, sin, cos, sin, cos_tbl, sin_tbl)
 
         # Explicit invocation of the op with manually prepared inputs
         rd = cfg.qk_rope_head_dim
@@ -1185,6 +1233,7 @@ def test_sparse_prefill_op_matches_inline_math():
         kv = custom.kv_norm(custom.wkv(x)).view(B, S, 1, cfg.head_dim)
         kv_nope, kv_pe = torch.split(kv, [cfg.head_dim - rd, rd], dim=-1)
         kv_pe = _apply_interleaved_rope(kv_pe, cos.unsqueeze(2), sin.unsqueeze(2))
+        kv_nope = _fake_fp8_act_quant(kv_nope, block_size=64)
         kv = torch.cat([kv_nope, kv_pe], dim=-1)
 
         if custom.indexer is not None:
@@ -1210,6 +1259,8 @@ def test_sparse_prefill_op_matches_inline_math():
             qr,
             cos,
             sin,
+            cos_tbl,
+            sin_tbl,
             custom.attn_sink,
             custom.compressor.wkv.weight,
             custom.compressor.wgate.weight,
@@ -1223,6 +1274,7 @@ def test_sparse_prefill_op_matches_inline_math():
             custom.head_dim,
             index_n_heads,
             index_head_dim,
+            custom.indexer.index_topk if custom.indexer is not None else 0,
             cfg.rms_norm_eps,
             0,  # layer_idx
             "mha_sparse",
@@ -1295,13 +1347,286 @@ def test_exported_graph_has_sparse_and_dense_attention_nodes():
         layer_idx, layer_type = extract_op_args(n, "layer_idx", "layer_type")
         assert layer_type == "mha_sparse"
         seen_sparse_layer_idxs.add(layer_idx)
-        scale, window_size, compress_ratio = extract_op_args(
-            n, "scale", "window_size", "compress_ratio"
+        scale, window_size, compress_ratio, index_topk = extract_op_args(
+            n, "scale", "window_size", "compress_ratio", "index_topk"
         )
         assert compress_ratio in (4, 128)
         assert window_size == cfg.sliding_window
         assert scale == cfg.head_dim**-0.5
+        if compress_ratio == 4:
+            assert index_topk == cfg.index_topk
+        else:
+            assert index_topk == 0
     assert seen_sparse_layer_idxs == {1, 2}
+
+
+def test_sparse_cache_transform_replaces_sparse_attention_nodes():
+    """KV-cache transform replaces sparse source nodes with cached sparse op nodes."""
+    cfg = _small_config()
+    cfg.num_hidden_layers = 3
+    cfg.compress_ratios = [0, 4, 128]
+    model = DeepseekV4ForCausalLM(cfg).eval()
+
+    B, S = 2, 4
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+
+    from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+    from tensorrt_llm._torch.auto_deploy.transform.interface import Stages
+    from tensorrt_llm._torch.auto_deploy.transform.library.kvcache import (
+        InsertCachedDeepseekV4SparseAttention,
+    )
+    from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+    cm = CachedSequenceInterface(
+        max_seq_len=cfg.max_position_embeddings,
+        max_batch_size=B,
+        max_num_tokens=B * cfg.max_position_embeddings,
+        device="cpu",
+        kv_cache_config=KvCacheConfig(dtype="bfloat16", free_gpu_memory_fraction=0.0),
+    )
+    transform = InsertCachedDeepseekV4SparseAttention.from_kwargs(stage=Stages.CACHE_INIT)
+    gm, info = transform._apply(gm, cm, factory=None, shared_config=None)
+
+    source_op = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn.default
+    cached_op = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache.default
+    source_nodes = [n for n in gm.graph.nodes if n.op == "call_function" and n.target is source_op]
+    cached_nodes = [n for n in gm.graph.nodes if n.op == "call_function" and n.target is cached_op]
+
+    assert info.num_matches == 2
+    assert source_nodes == []
+    assert len(cached_nodes) == 2
+    assert len(cm._resource_lookup) == 14
+    # 19 source tensor args + 5 standard metadata args + 7 caches + 9 constants.
+    assert all(len(n.args) == 40 for n in cached_nodes)
+
+
+def test_exported_hc_mixes_use_fp32_matmul_not_linear_ops():
+    """HC mixers must not be exported as quantizable linear ops.
+
+    DeepSeek V4 HC parameters are fp32 routing/mixing parameters, not model
+    projection weights. Keeping them as explicit fp32 matmuls prevents the
+    fine-grained FP8 linear rewrite from consuming them.
+    """
+    cfg = _small_config()
+    cfg.num_hidden_layers = 1
+    cfg.compress_ratios = [0]
+    model = DeepseekV4ForCausalLM(cfg).eval()
+
+    B, S = 2, 2
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+
+    hc_fn_nodes = {
+        n
+        for n in gm.graph.nodes
+        if n.op == "get_attr" and str(n.target).endswith(("hc_attn_fn", "hc_ffn_fn", "hc_head_fn"))
+    }
+    assert len(hc_fn_nodes) == 3
+
+    def node_depends_on_hc_fn(node: Node) -> bool:
+        seen: set[Node] = set()
+        stack: list[Node] = [node]
+        while stack:
+            current = stack.pop()
+            if current in hc_fn_nodes:
+                return True
+            if current in seen:
+                continue
+            seen.add(current)
+            for arg in current.all_input_nodes:
+                stack.append(arg)
+        return False
+
+    def arg_depends_on_hc_fn(arg) -> bool:
+        if isinstance(arg, Node):
+            return node_depends_on_hc_fn(arg)
+        if isinstance(arg, (tuple, list)):
+            return any(arg_depends_on_hc_fn(item) for item in arg)
+        return False
+
+    linear_targets = {
+        torch.ops.aten.linear.default,
+        torch.ops.auto_deploy.torch_linear_simple.default,
+    }
+    hc_linear_nodes = [
+        n
+        for n in gm.graph.nodes
+        if n.op == "call_function"
+        and n.target in linear_targets
+        and len(n.args) > 1
+        and arg_depends_on_hc_fn(n.args[1])
+    ]
+    assert not hc_linear_nodes
+
+    hc_matmul_nodes = [
+        n
+        for n in gm.graph.nodes
+        if n.op == "call_function"
+        and n.target == torch.ops.aten.matmul.default
+        and len(n.args) > 1
+        and arg_depends_on_hc_fn(n.args[1])
+    ]
+    assert len(hc_matmul_nodes) == 3
+
+
+def test_sparse_layers_do_not_break_tp_sharding_detection():
+    """Sparse attention's hidden-state input must not pull previous layers into TP analysis."""
+    cfg = _small_config()
+    cfg.num_hidden_layers = 3
+    cfg.compress_ratios = [0, 4, 128]
+    model = DeepseekV4ForCausalLM(cfg).eval()
+
+    B, S = 2, 4
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+
+    from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+
+    optimizer = InferenceOptimizer(
+        None,
+        {
+            "detect_sharding": {
+                "stage": "sharding",
+                "sharding_dims": ["tp", "ep", "bmm"],
+                "sharding_source": ["heuristic"],
+                "shard_all_unprocessed": False,
+            },
+        },
+    )
+    optimizer.shared_config.local_rank = 0
+    optimizer.shared_config.world_size = 2
+    optimizer(None, gm)
+
+    container = gm._sharding_transform_container
+    sharded_by_target = {t.target_node: t for t in container.weight_sharding_transforms}
+
+    from tensorrt_llm._torch.auto_deploy.transform.library.sharding import SplitDimension
+    from tensorrt_llm._torch.auto_deploy.utils.node_utils import LayerType
+
+    for layer_idx in (1, 2):
+        for projection_name in ("wq_a", "wq_b", "wkv", "wo_b"):
+            matches = [
+                t
+                for name, t in sharded_by_target.items()
+                if f"model_layers_{layer_idx}_attn_{projection_name}" in name
+            ]
+            assert len(matches) == 1
+            transform = matches[0]
+            assert transform.split_dim == SplitDimension.COLUMN
+            assert transform.dist_op == "all_gather"
+            assert transform.layer_type == LayerType.UNKNOWN
+
+        assert not any(f"model_layers_{layer_idx}_attn_wo_a" in name for name in sharded_by_target)
+
+    assert len(container.ep_transforms) == cfg.num_hidden_layers
+
+
+def test_sharded_sparse_layers_still_rewrite_to_cached_sparse_attention():
+    """Sharding executor must compose with sparse attention cache insertion."""
+    cfg = _small_config()
+    cfg.num_hidden_layers = 3
+    cfg.compress_ratios = [0, 4, 128]
+    model = DeepseekV4ForCausalLM(cfg).eval()
+
+    B, S = 2, 4
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+
+    from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+    from tensorrt_llm._torch.auto_deploy.transform.interface import Stages
+    from tensorrt_llm._torch.auto_deploy.transform.library.kvcache import (
+        InsertCachedDeepseekV4SparseAttention,
+    )
+    from tensorrt_llm._torch.auto_deploy.transform.library.sharding import ShardingTransformExecutor
+    from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+    from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+    optimizer = InferenceOptimizer(
+        None,
+        {
+            "detect_sharding": {
+                "stage": "sharding",
+                "sharding_dims": ["tp", "ep", "bmm"],
+                "sharding_source": ["heuristic"],
+                "shard_all_unprocessed": False,
+            },
+        },
+    )
+    optimizer.shared_config.local_rank = 0
+    optimizer.shared_config.world_size = 2
+    optimizer(None, gm)
+
+    executor = ShardingTransformExecutor.from_kwargs(
+        stage=Stages.SHARDING,
+        run_graph_cleanup=False,
+        requires_clean_graph=False,
+    )
+    gm, shard_info = executor._apply(gm, cm=None, factory=None, shared_config=None)
+    assert shard_info.num_matches > 0
+
+    cm = CachedSequenceInterface(
+        max_seq_len=cfg.max_position_embeddings,
+        max_batch_size=B,
+        max_num_tokens=B * cfg.max_position_embeddings,
+        device="cpu",
+        kv_cache_config=KvCacheConfig(dtype="bfloat16", free_gpu_memory_fraction=0.0),
+    )
+    cache_transform = InsertCachedDeepseekV4SparseAttention.from_kwargs(
+        stage=Stages.CACHE_INIT,
+        run_graph_cleanup=False,
+        requires_clean_graph=False,
+    )
+    gm, cache_info = cache_transform._apply(gm, cm, factory=None, shared_config=None)
+
+    source_op = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn.default
+    cached_op = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache.default
+    source_nodes = [n for n in gm.graph.nodes if n.op == "call_function" and n.target is source_op]
+    cached_nodes = [n for n in gm.graph.nodes if n.op == "call_function" and n.target is cached_op]
+
+    assert cache_info.num_matches == 2
+    assert source_nodes == []
+    assert len(cached_nodes) == 2
 
 
 def test_sparse_descriptor_resource_handler_shapes():
@@ -1340,6 +1665,7 @@ def test_sparse_descriptor_resource_handler_shapes():
     sparse_op = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn.default
     sparse_nodes = [n for n in gm.graph.nodes if n.op == "call_function" and n.target is sparse_op]
     assert sparse_nodes, "Expected at least one sparse attention node"
+    assert DeepseekV4SparseAttentionDescriptor.get_num_qkv_args() == 19
 
     cache_config = KvCacheConfig(dtype="bfloat16")
     handlers = DeepseekV4SparseAttentionDescriptor.get_cache_initializers(

--- a/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_modeling.py
@@ -1,0 +1,1182 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+
+"""Tests for the DeepSeek V4 custom AutoDeploy model.
+
+DeepSeek V4 is not in transformers (4.57.3), so the reference math here is
+copied verbatim (and minimally) from the HF model.py
+(https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/inference/model.py).
+The reference is simplified to the prefill-only path that the AD custom model
+implements: sliding-window attention with learnable attention sinks, plus
+dedicated compressor/indexer references for compressed-KV sparse attention.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, Tuple
+
+import pytest
+import torch
+import torch.nn.functional as F
+from _model_test_utils import assert_rmse_close
+from torch import nn
+from torch.export import Dim
+
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
+    DeepseekV4Attention,
+    DeepseekV4Block,
+    DeepseekV4Compressor,
+    DeepseekV4Config,
+    DeepseekV4ForCausalLM,
+    DeepseekV4Indexer,
+    DeepseekV4MLP,
+    DeepseekV4MoE,
+    DeepseekV4RMSNorm,
+    _build_freqs_cis,
+    _build_sparse_attn_mask,
+    _hc_split_sinkhorn,
+    _remap_deepseek_v4_checkpoint_keys,
+    _window_topk_idxs,
+)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_seed():
+    torch.manual_seed(42)
+
+
+_FLASH_BASE_INDEX_FIXTURE = (
+    Path(__file__).with_name("fixtures") / "deepseek_v4_flash_base_safetensors_index_sample.json"
+)
+_EXPECTED_FLASH_BASE_INDEX_KEYS = {
+    "embed.weight",
+    "head.weight",
+    "hc_head_base",
+    "hc_head_fn",
+    "hc_head_scale",
+    "layers.0.attn.wq_a.weight",
+    "layers.0.ffn.experts.0.w1.weight",
+    "layers.0.ffn.experts.0.w2.weight",
+    "layers.0.ffn.experts.0.w3.weight",
+    "layers.0.ffn.gate.tid2eid",
+    "layers.0.ffn.shared_experts.w1.weight",
+    "layers.0.ffn.shared_experts.w2.weight",
+    "layers.0.ffn.shared_experts.w3.weight",
+    "layers.2.attn.compressor.wkv.weight",
+    "layers.2.attn.indexer.wq_b.weight",
+    "norm.weight",
+}
+
+
+def _load_flash_base_index_keys() -> set[str]:
+    with open(_FLASH_BASE_INDEX_FIXTURE) as f:
+        index = json.load(f)
+    assert index["metadata"]["source_model"] == "deepseek-ai/DeepSeek-V4-Flash-Base"
+    assert index["metadata"]["source_revision"] == "e133377a559d13c857cf0c054bb46247076102a0"
+    assert all(name.endswith(".safetensors") for name in index["weight_map"].values())
+    return set(index["weight_map"])
+
+
+# =============================================================================
+# Reference (faithful copy of the subset of HF model.py we implement)
+# =============================================================================
+
+
+class _RefRMSNorm(nn.Module):
+    """Matches RMSNorm in model.py (weight kept in fp32 intentionally)."""
+
+    def __init__(self, dim: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor):
+        dtype = x.dtype
+        x = x.float()
+        var = x.square().mean(-1, keepdim=True)
+        x = x * torch.rsqrt(var + self.eps)
+        return (self.weight * x).to(dtype)
+
+
+def _freqs_cis_from_cos_sin(cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
+    """Reassemble the complex freqs_cis the reference math expects from real cos/sin."""
+    return torch.complex(cos, sin)
+
+
+def _apply_rotary_emb_ref(
+    x: torch.Tensor, freqs_cis: torch.Tensor, inverse: bool = False
+) -> torch.Tensor:
+    """Copy of apply_rotary_emb from model.py (out-of-place)."""
+    x_c = torch.view_as_complex(x.float().unflatten(-1, (-1, 2)))
+    if inverse:
+        freqs_cis = freqs_cis.conj()
+    if x_c.ndim == 3:
+        fc = freqs_cis.view(1, x_c.size(1), x_c.size(-1))
+    else:
+        fc = freqs_cis.view(1, x_c.size(1), 1, x_c.size(-1))
+    return torch.view_as_real(x_c * fc).flatten(-2).type_as(x)
+
+
+class _RefExpert(nn.Module):
+    """Matches Expert in model.py (fp32 gate/up, optional swiglu_limit clamp)."""
+
+    def __init__(self, dim: int, inter_dim: int, swiglu_limit: float = 0.0):
+        super().__init__()
+        self.w1 = nn.Linear(dim, inter_dim, bias=False)
+        self.w2 = nn.Linear(inter_dim, dim, bias=False)
+        self.w3 = nn.Linear(dim, inter_dim, bias=False)
+        self.swiglu_limit = swiglu_limit
+
+    def forward(self, x: torch.Tensor, weights: Optional[torch.Tensor] = None) -> torch.Tensor:
+        dtype = x.dtype
+        gate = self.w1(x).float()
+        up = self.w3(x).float()
+        if self.swiglu_limit > 0:
+            up = torch.clamp(up, min=-self.swiglu_limit, max=self.swiglu_limit)
+            gate = torch.clamp(gate, max=self.swiglu_limit)
+        out = F.silu(gate) * up
+        if weights is not None:
+            out = weights * out
+        return self.w2(out.to(dtype))
+
+
+class _RefGate(nn.Module):
+    """Score-routed gate only (no hash routing) from model.py."""
+
+    def __init__(
+        self,
+        n_experts: int,
+        dim: int,
+        topk: int,
+        score_func: str = "sqrtsoftplus",
+        route_scale: float = 1.0,
+    ):
+        super().__init__()
+        self.topk = topk
+        self.score_func = score_func
+        self.route_scale = route_scale
+        self.weight = nn.Parameter(torch.empty(n_experts, dim))
+        self.bias = nn.Parameter(torch.zeros(n_experts, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        scores = F.linear(x.float(), self.weight.float())
+        if self.score_func == "softmax":
+            scores = scores.softmax(dim=-1)
+        elif self.score_func == "sigmoid":
+            scores = scores.sigmoid()
+        else:
+            scores = F.softplus(scores).sqrt()
+        original_scores = scores
+        scores = scores + self.bias
+        indices = scores.topk(self.topk, dim=-1)[1]
+        weights = original_scores.gather(1, indices)
+        if self.score_func != "softmax":
+            weights /= weights.sum(dim=-1, keepdim=True)
+        weights *= self.route_scale
+        return weights, indices
+
+
+def _sliding_window_sink_attn(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+) -> torch.Tensor:
+    """Pure PyTorch reference for sparse_attn when topk_idxs only covers the window.
+
+    For seqlen <= window_size, this is equivalent to standard causal SDPA + sinks.
+    q: [B, S, H, D], kv: [B, S, D] (K == V, single KV head).
+    """
+    bsz, seqlen, n_heads, d = q.shape
+    # Expand kv to [B, S, H, D] by broadcasting over heads (MQA -> MHA).
+    k = kv.unsqueeze(2).expand(bsz, seqlen, n_heads, d)
+    v = k
+    # Transpose to [B, H, S, D] to compute attention manually.
+    qb = q.transpose(1, 2)
+    kb = k.transpose(1, 2)
+    vb = v.transpose(1, 2)
+
+    scores = torch.matmul(qb, kb.transpose(-2, -1)) * softmax_scale  # [B, H, Sq, Sk]
+    # Causal mask
+    s_q = seqlen
+    s_k = seqlen
+    causal = torch.triu(torch.ones(s_q, s_k, device=q.device, dtype=torch.bool), diagonal=1)
+    scores = scores.masked_fill(causal.unsqueeze(0).unsqueeze(0), float("-inf"))
+    # Sliding-window mask
+    idx_q = torch.arange(s_q, device=q.device).unsqueeze(1)
+    idx_k = torch.arange(s_k, device=q.device).unsqueeze(0)
+    pos_diff = idx_q - idx_k
+    sw_mask = (pos_diff < 0) | (pos_diff >= window_size)
+    scores = scores.masked_fill(sw_mask.unsqueeze(0).unsqueeze(0), float("-inf"))
+    # Softmax with sinks (extra virtual key column per head).
+    sinks_expanded = attn_sink.reshape(1, -1, 1, 1).expand(bsz, n_heads, s_q, 1)
+    logits_max = torch.max(scores, dim=-1, keepdim=True).values
+    sinks = torch.exp(sinks_expanded - logits_max)
+    unn = torch.exp(scores - logits_max)
+    denom = unn.sum(dim=-1, keepdim=True) + sinks
+    attn = unn / denom
+    out = torch.matmul(attn, vb)  # [B, H, S, D]
+    return out.transpose(1, 2).contiguous()  # [B, S, H, D]
+
+
+def _ref_compressor_forward(
+    compressor: DeepseekV4Compressor,
+    hidden_states: torch.Tensor,
+    freqs_cis: torch.Tensor,
+) -> torch.Tensor:
+    """Faithful prefill ``start_pos == 0`` reference for HF Compressor."""
+    bsz, seqlen, _ = hidden_states.shape
+    ratio = compressor.compress_ratio
+    n_compressed = seqlen // ratio
+    if n_compressed == 0:
+        return hidden_states.new_empty(bsz, 0, compressor.head_dim)
+
+    cutoff = n_compressed * ratio
+    dtype = hidden_states.dtype
+    x = hidden_states.float()
+    kv = F.linear(x, compressor.wkv.weight.float())[:, :cutoff]
+    score = F.linear(x, compressor.wgate.weight.float())[:, :cutoff]
+    kv = kv.unflatten(1, (-1, ratio))
+    score = score.unflatten(1, (-1, ratio)) + compressor.ape
+    if compressor.overlap:
+        b, chunks, _, _ = kv.shape
+        kv_out = kv.new_zeros(b, chunks, 2 * ratio, compressor.head_dim)
+        score_out = score.new_full((b, chunks, 2 * ratio, compressor.head_dim), float("-inf"))
+        kv_out[:, :, ratio:] = kv[:, :, :, compressor.head_dim :]
+        kv_out[:, 1:, :ratio] = kv[:, :-1, :, : compressor.head_dim]
+        score_out[:, :, ratio:] = score[:, :, :, compressor.head_dim :]
+        score_out[:, 1:, :ratio] = score[:, :-1, :, : compressor.head_dim]
+        kv, score = kv_out, score_out
+    kv = (kv * score.softmax(dim=2)).sum(dim=2)
+    kv = compressor.norm(kv.to(dtype))
+    rd = compressor.rope_head_dim
+    rotated = _apply_rotary_emb_ref(kv[..., -rd:], freqs_cis[:cutoff:ratio])
+    return torch.cat([kv[..., :-rd], rotated], dim=-1)
+
+
+def _ref_indexer_forward(
+    indexer: DeepseekV4Indexer,
+    hidden_states: torch.Tensor,
+    q_lora: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    offset: int,
+) -> torch.Tensor:
+    """Faithful prefill ``start_pos == 0`` reference for HF Indexer without FP4 simulation."""
+    bsz, seqlen, _ = hidden_states.shape
+    ratio = indexer.compress_ratio
+    n_compressed = seqlen // ratio
+    if n_compressed == 0:
+        return hidden_states.new_empty(bsz, seqlen, 0, dtype=torch.long)
+
+    rd = indexer.rope_head_dim
+    q = F.linear(q_lora, indexer.wq_b.weight).view(
+        bsz, seqlen, indexer.index_n_heads, indexer.index_head_dim
+    )
+    q_rot = _apply_rotary_emb_ref(q[..., -rd:], freqs_cis)
+    q = torch.cat([q[..., :-rd], q_rot], dim=-1)
+    index_k = _ref_compressor_forward(indexer.compressor, hidden_states, freqs_cis)
+    weights = F.linear(hidden_states, indexer.weights_proj.weight)
+    weights = weights * (indexer.softmax_scale * indexer.index_n_heads**-0.5)
+
+    index_score = torch.einsum("bshd,btd->bsht", q, index_k)
+    index_score = (index_score.relu() * weights.unsqueeze(-1)).sum(dim=2)
+    compressed_positions = torch.arange(n_compressed, device=hidden_states.device)
+    valid_count = torch.arange(1, seqlen + 1, device=hidden_states.device).unsqueeze(1) // ratio
+    mask = compressed_positions.unsqueeze(0) >= valid_count
+    index_score = index_score.masked_fill(mask.unsqueeze(0), float("-inf"))
+    topk = min(indexer.index_topk, n_compressed)
+    topk_idxs = index_score.topk(topk, dim=-1).indices
+    invalid = topk_idxs >= valid_count.unsqueeze(0)
+    return torch.where(invalid, -1, topk_idxs + offset)
+
+
+def _sparse_sink_attn_from_indices(
+    q: torch.Tensor,
+    kv_all: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Reference sparse attention from explicit HF top-k indices."""
+    bsz, seqlen, n_heads, d = q.shape
+    total_kv = kv_all.shape[1]
+    k = kv_all.expand(bsz, total_kv, n_heads, d)
+    v = k
+    qb = q.transpose(1, 2)
+    kb = k.transpose(1, 2)
+    vb = v.transpose(1, 2)
+    scores = torch.matmul(qb, kb.transpose(-2, -1)) * softmax_scale
+    attn_mask = _build_sparse_attn_mask(topk_idxs, total_kv).to(scores.dtype)
+    scores = scores + attn_mask
+
+    sinks_expanded = attn_sink.reshape(1, -1, 1, 1).expand(bsz, n_heads, seqlen, 1)
+    logits_max = torch.max(scores, dim=-1, keepdim=True).values
+    sinks = torch.exp(sinks_expanded - logits_max)
+    unn = torch.exp(scores - logits_max)
+    attn = unn / (unn.sum(dim=-1, keepdim=True) + sinks)
+    out = torch.matmul(attn, vb)
+    return out.transpose(1, 2).contiguous()
+
+
+class _RefAttention(nn.Module):
+    """Prefill-only MLA-variant attention matching the AD custom model's path.
+
+    Uses the reference (non-kernel) math for everything: interleaved complex RoPE,
+    parameterless per-head RMS on Q, single-head KV, sliding window + sinks,
+    inverse RoPE on output, grouped low-rank O projection.
+    """
+
+    def __init__(
+        self,
+        hidden: int,
+        n_heads: int,
+        head_dim: int,
+        rope_head_dim: int,
+        q_lora_rank: int,
+        o_lora_rank: int,
+        n_groups: int,
+        window_size: int,
+        eps: float = 1e-6,
+    ):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = head_dim
+        self.rope_head_dim = rope_head_dim
+        self.n_groups = n_groups
+        self.window_size = window_size
+        self.eps = eps
+        self.softmax_scale = head_dim**-0.5
+        self.o_lora_rank = o_lora_rank
+        self.group_head_width = n_heads * head_dim // n_groups
+
+        self.wq_a = nn.Linear(hidden, q_lora_rank, bias=False)
+        self.q_norm = _RefRMSNorm(q_lora_rank, eps=eps)
+        self.wq_b = nn.Linear(q_lora_rank, n_heads * head_dim, bias=False)
+        self.wkv = nn.Linear(hidden, head_dim, bias=False)
+        self.kv_norm = _RefRMSNorm(head_dim, eps=eps)
+        self.wo_a = nn.Linear(self.group_head_width, n_groups * o_lora_rank, bias=False)
+        self.wo_b = nn.Linear(n_groups * o_lora_rank, hidden, bias=False)
+        self.attn_sink = nn.Parameter(torch.zeros(n_heads, dtype=torch.float32))
+
+    def forward(self, x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+        bsz, seqlen, _ = x.shape
+        rd = self.rope_head_dim
+        q = self.q_norm(self.wq_a(x))
+        q = self.wq_b(q).unflatten(-1, (self.n_heads, self.head_dim))
+        q = q * torch.rsqrt(q.float().square().mean(-1, keepdim=True) + self.eps).to(q.dtype)
+        kv = self.kv_norm(self.wkv(x))  # [B, S, head_dim]
+        # RoPE on last rd dims of q and kv (in-place semantics — here we do out-of-place)
+        q_rope_part = _apply_rotary_emb_ref(q[..., -rd:], freqs_cis)
+        kv_rope_part = _apply_rotary_emb_ref(kv[..., -rd:], freqs_cis)
+        q = torch.cat([q[..., :-rd], q_rope_part], dim=-1)
+        kv = torch.cat([kv[..., :-rd], kv_rope_part], dim=-1)
+
+        o = _sliding_window_sink_attn(q, kv, self.attn_sink, self.softmax_scale, self.window_size)
+        # Inverse RoPE on output's last rd dims
+        o_rope_part = _apply_rotary_emb_ref(o[..., -rd:], freqs_cis, inverse=True)
+        o = torch.cat([o[..., :-rd], o_rope_part], dim=-1)
+
+        # Grouped low-rank O projection
+        o = o.reshape(bsz, seqlen, self.n_groups, self.group_head_width)
+        wo_a = self.wo_a.weight.view(self.n_groups, self.o_lora_rank, self.group_head_width)
+        o = torch.einsum("bsgd,grd->bsgr", o, wo_a)
+        return self.wo_b(o.reshape(bsz, seqlen, self.n_groups * self.o_lora_rank))
+
+
+class _RefMoE(nn.Module):
+    """Reference MoE: score-routed gate + per-expert manual dispatch + shared expert."""
+
+    def __init__(self, cfg: DeepseekV4Config):
+        super().__init__()
+        self.topk = cfg.num_experts_per_tok
+        self.hidden = cfg.hidden_size
+        self.gate = _RefGate(
+            cfg.n_routed_experts,
+            cfg.hidden_size,
+            cfg.num_experts_per_tok,
+            score_func="sqrtsoftplus",
+            route_scale=cfg.routed_scaling_factor,
+        )
+        self.experts = nn.ModuleList(
+            [
+                _RefExpert(
+                    cfg.hidden_size, cfg.moe_intermediate_size, swiglu_limit=cfg.swiglu_limit
+                )
+                for _ in range(cfg.n_routed_experts)
+            ]
+        )
+        self.shared = _RefExpert(
+            cfg.hidden_size, cfg.moe_intermediate_size * cfg.n_shared_experts, swiglu_limit=0.0
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        orig_shape = x.shape
+        flat = x.view(-1, self.hidden)
+        weights, indices = self.gate(flat)
+        y = torch.zeros_like(flat)
+        for tok in range(flat.size(0)):
+            for k in range(self.topk):
+                e = int(indices[tok, k].item())
+                w = weights[tok, k].unsqueeze(0)
+                y[tok] += self.experts[e](flat[tok : tok + 1], w).squeeze(0)
+        return y.view(*orig_shape) + self.shared(x)
+
+
+class _RefBlock(nn.Module):
+    """Reference HC block matching DeepseekV4Block's forward pattern."""
+
+    def __init__(self, cfg: DeepseekV4Config):
+        super().__init__()
+        self.hc_mult = cfg.hc_mult
+        self.hc_sinkhorn_iters = cfg.hc_sinkhorn_iters
+        self.hc_eps = cfg.hc_eps
+        self.norm_eps = cfg.rms_norm_eps
+        mix_hc = (2 + cfg.hc_mult) * cfg.hc_mult
+        hc_dim = cfg.hc_mult * cfg.hidden_size
+        self.hc_attn_fn = nn.Parameter(torch.zeros(mix_hc, hc_dim, dtype=torch.float32))
+        self.hc_ffn_fn = nn.Parameter(torch.zeros(mix_hc, hc_dim, dtype=torch.float32))
+        self.hc_attn_base = nn.Parameter(torch.zeros(mix_hc, dtype=torch.float32))
+        self.hc_ffn_base = nn.Parameter(torch.zeros(mix_hc, dtype=torch.float32))
+        self.hc_attn_scale = nn.Parameter(torch.ones(3, dtype=torch.float32))
+        self.hc_ffn_scale = nn.Parameter(torch.ones(3, dtype=torch.float32))
+        self.attn_norm = _RefRMSNorm(cfg.hidden_size, eps=cfg.rms_norm_eps)
+        self.ffn_norm = _RefRMSNorm(cfg.hidden_size, eps=cfg.rms_norm_eps)
+        self.attn = _RefAttention(
+            hidden=cfg.hidden_size,
+            n_heads=cfg.num_attention_heads,
+            head_dim=cfg.head_dim,
+            rope_head_dim=cfg.qk_rope_head_dim,
+            q_lora_rank=cfg.q_lora_rank,
+            o_lora_rank=cfg.o_lora_rank,
+            n_groups=cfg.o_groups,
+            window_size=cfg.sliding_window,
+            eps=cfg.rms_norm_eps,
+        )
+        self.ffn = _RefMoE(cfg)
+
+    def _hc_pre(self, x, hc_fn, hc_scale, hc_base):
+        shape, dtype = x.shape, x.dtype
+        x_flat = x.flatten(2).float()
+        rsqrt = torch.rsqrt(x_flat.square().mean(-1, keepdim=True) + self.norm_eps)
+        mixes = F.linear(x_flat, hc_fn) * rsqrt
+        pre, post, comb = _hc_split_sinkhorn(
+            mixes, hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.hc_eps
+        )
+        y = torch.sum(pre.unsqueeze(-1) * x_flat.view(shape), dim=2)
+        return y.to(dtype), post, comb
+
+    def _hc_post(self, x, residual, post, comb):
+        y = post.unsqueeze(-1) * x.unsqueeze(-2) + torch.sum(
+            comb.unsqueeze(-1) * residual.unsqueeze(-2), dim=2
+        )
+        return y.type_as(x)
+
+    def forward(self, x: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+        residual = x
+        h, post, comb = self._hc_pre(x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+        h = self.attn_norm(h)
+        h = self.attn(h, freqs_cis)
+        x = self._hc_post(h, residual, post, comb)
+        residual = x
+        h, post, comb = self._hc_pre(x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
+        h = self.ffn_norm(h)
+        h = self.ffn(h)
+        return self._hc_post(h, residual, post, comb)
+
+
+class _RefModel(nn.Module):
+    """Reference full model mirroring DeepseekV4ForCausalLM for compress_ratios=0, seqlen<=win."""
+
+    def __init__(self, cfg: DeepseekV4Config):
+        super().__init__()
+        self.cfg = cfg
+        self.hc_mult = cfg.hc_mult
+        self.norm_eps = cfg.rms_norm_eps
+        self.hc_eps = cfg.hc_eps
+        self.embed_tokens = nn.Embedding(cfg.vocab_size, cfg.hidden_size, cfg.pad_token_id)
+        self.layers = nn.ModuleList([_RefBlock(cfg) for _ in range(cfg.num_hidden_layers)])
+        hc_dim = cfg.hc_mult * cfg.hidden_size
+        self.hc_head_fn = nn.Parameter(torch.zeros(cfg.hc_mult, hc_dim, dtype=torch.float32))
+        self.hc_head_base = nn.Parameter(torch.zeros(cfg.hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.ones(1, dtype=torch.float32))
+        self.norm = _RefRMSNorm(cfg.hidden_size, eps=cfg.rms_norm_eps)
+        self.lm_head = nn.Linear(cfg.hidden_size, cfg.vocab_size, bias=False)
+
+    def _hc_head_collapse(self, x: torch.Tensor) -> torch.Tensor:
+        shape, dtype = x.shape, x.dtype
+        x_flat = x.flatten(2).float()
+        rsqrt = torch.rsqrt(x_flat.square().mean(-1, keepdim=True) + self.norm_eps)
+        mixes = F.linear(x_flat, self.hc_head_fn) * rsqrt
+        pre = torch.sigmoid(mixes * self.hc_head_scale + self.hc_head_base) + self.hc_eps
+        return torch.sum(pre.unsqueeze(-1) * x_flat.view(shape), dim=2).to(dtype)
+
+    def forward(self, input_ids: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+        h = self.embed_tokens(input_ids)
+        h = h.unsqueeze(2).expand(-1, -1, self.hc_mult, -1).contiguous()
+        for layer in self.layers:
+            h = layer(h, freqs_cis)
+        h = self._hc_head_collapse(h)
+        h = self.norm(h)
+        return self.lm_head(h).float()
+
+
+def _copy_attention_weights(dst: _RefAttention, src: DeepseekV4Attention) -> None:
+    dst.wq_a.weight.data.copy_(src.wq_a.weight.data)
+    dst.q_norm.weight.data.copy_(src.q_norm.weight.data.float())
+    dst.wq_b.weight.data.copy_(src.wq_b.weight.data)
+    dst.wkv.weight.data.copy_(src.wkv.weight.data)
+    dst.kv_norm.weight.data.copy_(src.kv_norm.weight.data.float())
+    dst.wo_a.weight.data.copy_(src.wo_a.weight.data)
+    dst.wo_b.weight.data.copy_(src.wo_b.weight.data)
+    dst.attn_sink.data.copy_(src.attn_sink.data)
+
+
+def _copy_moe_weights(dst: _RefMoE, src: DeepseekV4MoE) -> None:
+    dst.gate.weight.data.copy_(src.gate.weight.data.float())
+    dst.gate.bias.data.copy_(src.gate.bias.data)
+    for i, e in enumerate(src.experts):
+        dst.experts[i].w1.weight.data.copy_(e.gate_proj.weight.data)
+        dst.experts[i].w3.weight.data.copy_(e.up_proj.weight.data)
+        dst.experts[i].w2.weight.data.copy_(e.down_proj.weight.data)
+    dst.shared.w1.weight.data.copy_(src.shared_experts.gate_proj.weight.data)
+    dst.shared.w3.weight.data.copy_(src.shared_experts.up_proj.weight.data)
+    dst.shared.w2.weight.data.copy_(src.shared_experts.down_proj.weight.data)
+
+
+def _copy_block_weights(dst: _RefBlock, src: DeepseekV4Block) -> None:
+    dst.hc_attn_fn.data.copy_(src.hc_attn_fn.data)
+    dst.hc_ffn_fn.data.copy_(src.hc_ffn_fn.data)
+    dst.hc_attn_base.data.copy_(src.hc_attn_base.data)
+    dst.hc_ffn_base.data.copy_(src.hc_ffn_base.data)
+    dst.hc_attn_scale.data.copy_(src.hc_attn_scale.data)
+    dst.hc_ffn_scale.data.copy_(src.hc_ffn_scale.data)
+    dst.attn_norm.weight.data.copy_(src.attn_norm.weight.data.float())
+    dst.ffn_norm.weight.data.copy_(src.ffn_norm.weight.data.float())
+    _copy_attention_weights(dst.attn, src.attn)
+    _copy_moe_weights(dst.ffn, src.ffn)
+
+
+# =============================================================================
+# Small config
+# =============================================================================
+
+
+def _small_config(num_hash_layers: int = 0) -> DeepseekV4Config:
+    # compress_ratios all 0 so non-YaRN RoPE is used (makes test seqlens easier).
+    return DeepseekV4Config(
+        vocab_size=200,
+        hidden_size=64,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        head_dim=32,
+        qk_rope_head_dim=8,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=2,
+        sliding_window=16,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_hash_layers=num_hash_layers,
+        moe_intermediate_size=32,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+        hc_eps=1e-6,
+        max_position_embeddings=64,
+        rope_theta=10000.0,
+        compress_rope_theta=10000.0,
+        rope_scaling=None,
+        compress_ratios=[0, 0, 0],
+        swiglu_limit=0.0,  # disable clamp for faithful RMSE comparison
+        norm_topk_prob=True,
+        routed_scaling_factor=1.0,
+    )
+
+
+def _small_compress_config(ratio: int = 4) -> DeepseekV4Config:
+    return DeepseekV4Config(
+        vocab_size=200,
+        hidden_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        head_dim=32,
+        qk_rope_head_dim=8,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=2,
+        sliding_window=4,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_hash_layers=0,
+        moe_intermediate_size=32,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+        hc_eps=1e-6,
+        max_position_embeddings=64,
+        rope_theta=10000.0,
+        compress_rope_theta=10000.0,
+        rope_scaling=None,
+        compress_ratios=[ratio],
+        index_n_heads=4,
+        index_head_dim=16,
+        index_topk=2,
+        swiglu_limit=0.0,
+        norm_topk_prob=True,
+        routed_scaling_factor=1.0,
+    )
+
+
+# =============================================================================
+# Block equivalence tests
+# =============================================================================
+
+
+def test_rmsnorm_equivalence():
+    dim = 32
+    hidden = torch.randn(2, 8, dim, dtype=torch.float32)
+    custom = DeepseekV4RMSNorm(dim, eps=1e-6)
+    ref = _RefRMSNorm(dim, eps=1e-6)
+    ref.weight.data.copy_(custom.weight.data.float())
+    y_custom = custom(hidden)
+    y_ref = ref(hidden)
+    torch.testing.assert_close(y_custom, y_ref, rtol=1e-3, atol=1e-3)
+
+
+def test_mlp_equivalence():
+    dim, inter = 32, 64
+    custom = DeepseekV4MLP(dim, inter, swiglu_limit=0.0)
+    ref = _RefExpert(dim, inter, swiglu_limit=0.0)
+    ref.w1.weight.data.copy_(custom.gate_proj.weight.data)
+    ref.w3.weight.data.copy_(custom.up_proj.weight.data)
+    ref.w2.weight.data.copy_(custom.down_proj.weight.data)
+    x = torch.randn(2, 8, dim)
+    torch.testing.assert_close(custom(x), ref(x), rtol=1e-3, atol=1e-3)
+
+
+def test_moe_gate_equivalence_score_routing():
+    """Score-routed gate (non-hash layers) — sqrtsoftplus + bias-shifted topk."""
+    cfg = _small_config()
+    gate = _RefGate(
+        cfg.n_routed_experts,
+        cfg.hidden_size,
+        cfg.num_experts_per_tok,
+        score_func="sqrtsoftplus",
+        route_scale=cfg.routed_scaling_factor,
+    )
+    gate.weight.data.normal_(mean=0.0, std=0.02)
+    gate.bias.data.copy_(torch.linspace(-0.01, 0.01, cfg.n_routed_experts))
+    # Layer index >= num_hash_layers ensures score routing.
+    from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import DeepseekV4MoEGate
+
+    custom = DeepseekV4MoEGate(cfg, layer_idx=cfg.num_hash_layers)
+    custom.weight.data.copy_(gate.weight.data.float())
+    custom.bias.data.copy_(gate.bias.data)
+
+    x = torch.randn(2, cfg.hidden_size)
+    selected_custom, weights_custom = custom(x, torch.zeros(2, dtype=torch.long))
+    weights_ref, indices_ref = gate(x)
+
+    torch.testing.assert_close(selected_custom, indices_ref.long())
+    torch.testing.assert_close(weights_custom, weights_ref, rtol=1e-4, atol=1e-4)
+
+
+def test_moe_equivalence():
+    """Full MoE block: gate + routed experts via torch_moe + shared expert."""
+    cfg = _small_config()
+    moe = DeepseekV4MoE(cfg, layer_idx=cfg.num_hash_layers)
+    # Randomize gate weights (they're zero-init by default isn't the case here but
+    # DeepseekV4MoEGate uses torch.empty via nn.Parameter directly; in practice _init_weights
+    # covers Linear and Embedding, so the raw gate weight Parameter can be noise. Reset it.)
+    moe.gate.weight.data.normal_()
+    moe.gate.bias.data.zero_()
+    moe.eval()
+
+    # Build a matching reference: score-routed top-k to select experts, then apply
+    # the same per-expert MLP and sum weighted contributions.
+    ref_gate = _RefGate(
+        cfg.n_routed_experts,
+        cfg.hidden_size,
+        cfg.num_experts_per_tok,
+        score_func="sqrtsoftplus",
+        route_scale=cfg.routed_scaling_factor,
+    )
+    ref_gate.weight.data.copy_(moe.gate.weight.data.float())
+    ref_gate.bias.data.copy_(moe.gate.bias.data)
+
+    ref_experts = nn.ModuleList(
+        [
+            _RefExpert(cfg.hidden_size, cfg.moe_intermediate_size)
+            for _ in range(cfg.n_routed_experts)
+        ]
+    )
+    for i, e in enumerate(moe.experts):
+        ref_experts[i].w1.weight.data.copy_(e.gate_proj.weight.data)
+        ref_experts[i].w3.weight.data.copy_(e.up_proj.weight.data)
+        ref_experts[i].w2.weight.data.copy_(e.down_proj.weight.data)
+
+    ref_shared = _RefExpert(cfg.hidden_size, cfg.moe_intermediate_size * cfg.n_shared_experts)
+    ref_shared.w1.weight.data.copy_(moe.shared_experts.gate_proj.weight.data)
+    ref_shared.w3.weight.data.copy_(moe.shared_experts.up_proj.weight.data)
+    ref_shared.w2.weight.data.copy_(moe.shared_experts.down_proj.weight.data)
+
+    B, S, H = 2, 8, cfg.hidden_size
+    x = torch.randn(B, S, H)
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    y_custom = moe(x, input_ids)
+
+    # Reference: gate -> per-token per-expert gather
+    flat = x.view(-1, H)
+    weights_ref, indices_ref = ref_gate(flat)
+    y_ref = torch.zeros_like(flat)
+    for token_idx in range(flat.size(0)):
+        for k in range(cfg.num_experts_per_tok):
+            e_idx = int(indices_ref[token_idx, k].item())
+            w = weights_ref[token_idx, k].unsqueeze(0)
+            y_ref[token_idx] += ref_experts[e_idx](flat[token_idx : token_idx + 1], w).squeeze(0)
+    y_ref = y_ref.view(B, S, H) + ref_shared(x)
+
+    assert_rmse_close(y_custom, y_ref, rmse_ratio_tol=0.02, msg="MoE equivalence: ")
+
+
+def test_attention_equivalence():
+    """Attention with compress_ratio=0 and seqlen <= sliding_window — reference match."""
+    cfg = _small_config()
+    layer_idx = cfg.num_hash_layers  # doesn't matter for attention
+    custom = DeepseekV4Attention(cfg, layer_idx=layer_idx)
+    custom.eval()
+    ref = _RefAttention(
+        hidden=cfg.hidden_size,
+        n_heads=cfg.num_attention_heads,
+        head_dim=cfg.head_dim,
+        rope_head_dim=cfg.qk_rope_head_dim,
+        q_lora_rank=cfg.q_lora_rank,
+        o_lora_rank=cfg.o_lora_rank,
+        n_groups=cfg.o_groups,
+        window_size=cfg.sliding_window,
+        eps=cfg.rms_norm_eps,
+    )
+    ref.wq_a.weight.data.copy_(custom.wq_a.weight.data)
+    ref.q_norm.weight.data.copy_(custom.q_norm.weight.data.float())
+    ref.wq_b.weight.data.copy_(custom.wq_b.weight.data)
+    ref.wkv.weight.data.copy_(custom.wkv.weight.data)
+    ref.kv_norm.weight.data.copy_(custom.kv_norm.weight.data.float())
+    ref.wo_a.weight.data.copy_(custom.wo_a.weight.data)
+    ref.wo_b.weight.data.copy_(custom.wo_b.weight.data)
+    custom.attn_sink.data.normal_(std=0.1)
+    ref.attn_sink.data.copy_(custom.attn_sink.data)
+
+    B, S = 2, 8  # S <= sliding_window
+    x = torch.randn(B, S, cfg.hidden_size)
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    cos_tbl, sin_tbl = _build_freqs_cis(
+        cfg.qk_rope_head_dim, cfg.max_position_embeddings, cfg.rope_theta, 0, 1.0, 32, 1
+    )
+    cos = cos_tbl[position_ids]  # [B, S, rd/2]
+    sin = sin_tbl[position_ids]
+    freqs_cis_ref = _freqs_cis_from_cos_sin(cos[0], sin[0])  # [S, rd/2] for ref
+
+    y_custom = custom(x, cos, sin, cos, sin)
+    y_ref = ref(x, freqs_cis_ref)
+    assert_rmse_close(y_custom, y_ref, rmse_ratio_tol=0.10, msg="Attention equivalence: ")
+
+
+def test_compressor_prefill_equivalence():
+    """Learned Compressor start_pos=0 path, including ratio-4 overlap."""
+    cfg = _small_compress_config(ratio=4)
+    compressor = DeepseekV4Compressor(cfg, compress_ratio=4, head_dim=cfg.head_dim).eval()
+    compressor.ape.data.normal_(std=0.02)
+    x = torch.randn(2, 8, cfg.hidden_size)
+    cos_tbl, sin_tbl = _build_freqs_cis(
+        cfg.qk_rope_head_dim, cfg.max_position_embeddings, cfg.compress_rope_theta, 0, 1.0, 32, 1
+    )
+    position_ids = torch.arange(8).unsqueeze(0).expand(2, -1)
+    cos = cos_tbl[position_ids]
+    sin = sin_tbl[position_ids]
+    freqs_cis_ref = _freqs_cis_from_cos_sin(cos[0], sin[0])
+
+    y_custom = compressor(x, cos, sin)
+    y_ref = _ref_compressor_forward(compressor, x, freqs_cis_ref)
+    torch.testing.assert_close(y_custom[:, : y_ref.shape[1]], y_ref, rtol=1e-3, atol=1e-3)
+    assert torch.isfinite(y_custom).all()
+
+
+def test_indexer_prefill_topk_equivalence():
+    """Ratio-4 Indexer top-k compressed-token selection."""
+    cfg = _small_compress_config(ratio=4)
+    indexer = DeepseekV4Indexer(cfg, compress_ratio=4).eval()
+    indexer.compressor.ape.data.normal_(std=0.02)
+    x = torch.randn(2, 8, cfg.hidden_size)
+    q_lora = torch.randn(2, 8, cfg.q_lora_rank)
+    cos_tbl, sin_tbl = _build_freqs_cis(
+        cfg.qk_rope_head_dim, cfg.max_position_embeddings, cfg.compress_rope_theta, 0, 1.0, 32, 1
+    )
+    position_ids = torch.arange(8).unsqueeze(0).expand(2, -1)
+    cos = cos_tbl[position_ids]
+    sin = sin_tbl[position_ids]
+    freqs_cis_ref = _freqs_cis_from_cos_sin(cos[0], sin[0])
+
+    topk_custom = indexer(x, q_lora, cos, sin, offset=8)
+    topk_ref = _ref_indexer_forward(indexer, x, q_lora, freqs_cis_ref, offset=8)
+    expected = torch.full_like(topk_custom, -1)
+    expected[:, :, : topk_ref.shape[-1]] = topk_ref
+    torch.testing.assert_close(topk_custom, expected)
+
+
+def test_attention_compressed_prefill_equivalence():
+    """Attention path with compressed KV concatenation and ratio-4 learned indexer."""
+    cfg = _small_compress_config(ratio=4)
+    custom = DeepseekV4Attention(cfg, layer_idx=0).eval()
+    custom.compressor.ape.data.normal_(std=0.02)
+    custom.indexer.compressor.ape.data.normal_(std=0.02)
+    custom.attn_sink.data.normal_(std=0.1)
+
+    B, S = 2, 8
+    x = torch.randn(B, S, cfg.hidden_size)
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    cos_tbl, sin_tbl = _build_freqs_cis(
+        cfg.qk_rope_head_dim, cfg.max_position_embeddings, cfg.compress_rope_theta, 0, 1.0, 32, 1
+    )
+    cos = cos_tbl[position_ids]
+    sin = sin_tbl[position_ids]
+    freqs_cis_ref = _freqs_cis_from_cos_sin(cos[0], sin[0])
+
+    y_custom = custom(x, cos, sin, cos, sin)
+
+    rd = cfg.qk_rope_head_dim
+    q_lora = custom.q_norm(custom.wq_a(x))
+    q = custom.wq_b(q_lora).view(B, S, cfg.num_attention_heads, cfg.head_dim)
+    q = q * torch.rsqrt(q.float().square().mean(-1, keepdim=True) + cfg.rms_norm_eps).to(q.dtype)
+    q = torch.cat([q[..., :-rd], _apply_rotary_emb_ref(q[..., -rd:], freqs_cis_ref)], dim=-1)
+    kv = custom.kv_norm(custom.wkv(x))
+    kv = torch.cat([kv[..., :-rd], _apply_rotary_emb_ref(kv[..., -rd:], freqs_cis_ref)], dim=-1)
+    kv = kv.view(B, S, 1, cfg.head_dim)
+    kv_comp = _ref_compressor_forward(custom.compressor, x, freqs_cis_ref).view(
+        B, -1, 1, cfg.head_dim
+    )
+    window_topk = _window_topk_idxs(cfg.sliding_window, B, S, x.device)
+    compress_topk = _ref_indexer_forward(custom.indexer, x, q_lora, freqs_cis_ref, offset=S)
+    topk_idxs = torch.cat([window_topk, compress_topk], dim=-1)
+    kv_all = torch.cat([kv, kv_comp], dim=1)
+    attn_ref = _sparse_sink_attn_from_indices(
+        q, kv_all, custom.attn_sink, topk_idxs, custom.softmax_scale
+    )
+    attn_ref = torch.cat(
+        [
+            attn_ref[..., :-rd],
+            _apply_rotary_emb_ref(attn_ref[..., -rd:], freqs_cis_ref, inverse=True),
+        ],
+        dim=-1,
+    )
+    attn_ref = attn_ref.reshape(B, S, cfg.o_groups, custom.group_head_width)
+    wo_a = custom.wo_a.weight.view(cfg.o_groups, cfg.o_lora_rank, custom.group_head_width)
+    attn_ref = torch.einsum("bsgd,grd->bsgr", attn_ref, wo_a)
+    y_ref = custom.wo_b(attn_ref.reshape(B, S, cfg.o_groups * cfg.o_lora_rank))
+
+    assert_rmse_close(y_custom, y_ref, rmse_ratio_tol=0.10, msg="Compressed attention: ")
+
+
+def test_block_equivalence():
+    """Full HC block equivalence vs _RefBlock (weights copied, same input)."""
+    cfg = _small_config()
+    layer_idx = cfg.num_hash_layers  # use score-routed MoE (_RefBlock has no hash routing)
+    block = DeepseekV4Block(cfg, layer_idx=layer_idx)
+    # Non-zero HC / gate / sink params so mixer isn't degenerate.
+    block.hc_attn_fn.data.normal_(std=0.02)
+    block.hc_ffn_fn.data.normal_(std=0.02)
+    block.hc_attn_base.data.normal_(std=0.1)
+    block.hc_ffn_base.data.normal_(std=0.1)
+    block.hc_attn_scale.data.normal_(mean=1.0, std=0.1)
+    block.hc_ffn_scale.data.normal_(mean=1.0, std=0.1)
+    block.ffn.gate.weight.data.normal_()
+    block.attn.attn_sink.data.normal_(std=0.1)
+    block.eval()
+
+    ref = _RefBlock(cfg).eval()
+    _copy_block_weights(ref, block)
+
+    B, S = 2, 8  # S <= sliding_window so reference path matches AD's sliding-window + sinks
+    x = torch.randn(B, S, cfg.hc_mult, cfg.hidden_size)
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    cos_tbl, sin_tbl = _build_freqs_cis(
+        cfg.qk_rope_head_dim, cfg.max_position_embeddings, cfg.rope_theta, 0, 1.0, 32, 1
+    )
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    cos = cos_tbl[position_ids]
+    sin = sin_tbl[position_ids]
+    freqs_cis_ref = _freqs_cis_from_cos_sin(cos[0], sin[0])
+
+    y_custom = block(x, input_ids, cos, sin, cos, sin)
+    y_ref = ref(x, freqs_cis_ref)
+    assert y_custom.shape == x.shape
+    assert_rmse_close(y_custom, y_ref, rmse_ratio_tol=0.05, msg="Block equivalence: ")
+
+
+def test_flash_base_checkpoint_index_matches_expected_layout():
+    """Validate repo-local representative keys from the Flash-Base safetensors index."""
+    index_keys = _load_flash_base_index_keys()
+    assert _EXPECTED_FLASH_BASE_INDEX_KEYS.issubset(index_keys)
+
+    state_dict = {key: torch.empty(()) for key in _EXPECTED_FLASH_BASE_INDEX_KEYS}
+    _remap_deepseek_v4_checkpoint_keys(state_dict)
+    assert "model.embed_tokens.weight" in state_dict
+    assert "lm_head.weight" in state_dict
+    assert "model.norm.weight" in state_dict
+    assert "model.hc_head_fn" in state_dict
+    assert "model.layers.0.attn.wq_a.weight" in state_dict
+    assert "model.layers.0.ffn.experts.0.gate_proj.weight" in state_dict
+    assert "model.layers.0.ffn.experts.0.up_proj.weight" in state_dict
+    assert "model.layers.0.ffn.experts.0.down_proj.weight" in state_dict
+    assert "model.layers.0.ffn.shared_experts.gate_proj.weight" in state_dict
+    assert "model.layers.0.ffn.shared_experts.up_proj.weight" in state_dict
+    assert "model.layers.0.ffn.shared_experts.down_proj.weight" in state_dict
+    assert "model.layers.2.attn.compressor.wkv.weight" in state_dict
+    assert "model.layers.2.attn.indexer.wq_b.weight" in state_dict
+
+
+def test_load_state_dict_accepts_hf_checkpoint_layout():
+    """HF checkpoint names are remapped to the AD module names during load."""
+    cfg = _small_config()
+    model = DeepseekV4ForCausalLM(cfg).eval()
+    layer = model.model.layers[0]
+
+    embed = torch.randn_like(model.model.embed_tokens.weight)
+    head = torch.randn_like(model.lm_head.weight)
+    norm = torch.randn_like(model.model.norm.weight)
+    expert_w1 = torch.randn_like(layer.ffn.experts[0].gate_proj.weight)
+    expert_w3 = torch.randn_like(layer.ffn.experts[0].up_proj.weight)
+    expert_w2 = torch.randn_like(layer.ffn.experts[0].down_proj.weight)
+    shared_w1 = torch.randn_like(layer.ffn.shared_experts.gate_proj.weight)
+    shared_w3 = torch.randn_like(layer.ffn.shared_experts.up_proj.weight)
+    shared_w2 = torch.randn_like(layer.ffn.shared_experts.down_proj.weight)
+    gate = torch.randn_like(layer.ffn.gate.weight)
+
+    incompatible = model.load_state_dict(
+        {
+            "embed.weight": embed,
+            "head.weight": head,
+            "norm.weight": norm,
+            "layers.0.ffn.experts.0.w1.weight": expert_w1,
+            "layers.0.ffn.experts.0.w3.weight": expert_w3,
+            "layers.0.ffn.experts.0.w2.weight": expert_w2,
+            "layers.0.ffn.shared_experts.w1.weight": shared_w1,
+            "layers.0.ffn.shared_experts.w3.weight": shared_w3,
+            "layers.0.ffn.shared_experts.w2.weight": shared_w2,
+            "layers.0.ffn.gate.weight": gate,
+        },
+        strict=False,
+    )
+
+    assert incompatible.unexpected_keys == []
+    torch.testing.assert_close(model.model.embed_tokens.weight, embed)
+    torch.testing.assert_close(model.lm_head.weight, head)
+    torch.testing.assert_close(model.model.norm.weight, norm)
+    torch.testing.assert_close(layer.ffn.experts[0].gate_proj.weight, expert_w1)
+    torch.testing.assert_close(layer.ffn.experts[0].up_proj.weight, expert_w3)
+    torch.testing.assert_close(layer.ffn.experts[0].down_proj.weight, expert_w2)
+    torch.testing.assert_close(layer.ffn.shared_experts.gate_proj.weight, shared_w1)
+    torch.testing.assert_close(layer.ffn.shared_experts.up_proj.weight, shared_w3)
+    torch.testing.assert_close(layer.ffn.shared_experts.down_proj.weight, shared_w2)
+    torch.testing.assert_close(layer.ffn.gate.weight, gate)
+
+
+def test_load_state_dict_accepts_stacked_moe_checkpoint_layout():
+    """Stacked expert tensors are unstacked into the AD per-expert ModuleList layout."""
+    cfg = _small_config()
+    model = DeepseekV4ForCausalLM(cfg).eval()
+    layer = model.model.layers[0]
+
+    expert_w1 = torch.randn(cfg.n_routed_experts, cfg.moe_intermediate_size, cfg.hidden_size)
+    expert_w3 = torch.randn_like(expert_w1)
+    expert_w2 = torch.randn(cfg.n_routed_experts, cfg.hidden_size, cfg.moe_intermediate_size)
+
+    incompatible = model.load_state_dict(
+        {
+            "layers.0.ffn.experts.w1.weight": expert_w1,
+            "layers.0.ffn.experts.w3.weight": expert_w3,
+            "layers.0.ffn.experts.w2.weight": expert_w2,
+        },
+        strict=False,
+    )
+
+    assert incompatible.unexpected_keys == []
+    for expert_idx, expert in enumerate(layer.ffn.experts):
+        torch.testing.assert_close(expert.gate_proj.weight, expert_w1[expert_idx])
+        torch.testing.assert_close(expert.up_proj.weight, expert_w3[expert_idx])
+        torch.testing.assert_close(expert.down_proj.weight, expert_w2[expert_idx])
+
+
+def test_load_state_dict_accepts_fused_gate_up_moe_checkpoint_layout():
+    """Fused gate/up expert tensors are split and unstacked when present."""
+    cfg = _small_config()
+    model = DeepseekV4ForCausalLM(cfg).eval()
+    layer = model.model.layers[0]
+
+    gate_up = torch.randn(cfg.n_routed_experts, 2 * cfg.moe_intermediate_size, cfg.hidden_size)
+    down = torch.randn(cfg.n_routed_experts, cfg.hidden_size, cfg.moe_intermediate_size)
+
+    incompatible = model.load_state_dict(
+        {
+            "layers.0.ffn.experts.gate_up_proj": gate_up,
+            "layers.0.ffn.experts.down_proj": down,
+        },
+        strict=False,
+    )
+
+    assert incompatible.unexpected_keys == []
+    gate, up = gate_up.chunk(2, dim=1)
+    for expert_idx, expert in enumerate(layer.ffn.experts):
+        torch.testing.assert_close(expert.gate_proj.weight, gate[expert_idx])
+        torch.testing.assert_close(expert.up_proj.weight, up[expert_idx])
+        torch.testing.assert_close(expert.down_proj.weight, down[expert_idx])
+
+
+def test_full_model_equivalence_short_seq():
+    """Full model equivalence vs _RefModel for compress_ratios=[0,...] and seqlen <= window.
+
+    The AD model reduces to:
+      embed -> HC-expand ->
+        [HC-pre -> RMSNorm -> RefAttention -> HC-post]
+        [HC-pre -> RMSNorm -> RefMoE -> HC-post]
+        ... -> HC-collapse -> RMSNorm -> lm_head
+    """
+    cfg = _small_config()  # num_hash_layers=0 so all layers are score-routed
+    model = DeepseekV4ForCausalLM(cfg).eval()
+    assert len(model.model.layers) == cfg.num_hidden_layers
+    assert isinstance(model.model.layers[0].ffn.experts, nn.ModuleList)
+    assert len(model.model.layers[0].ffn.experts) == cfg.n_routed_experts
+    sd = model.state_dict()
+    assert "model.embed_tokens.weight" in sd
+    assert "model.layers.0.ffn.experts.0.gate_proj.weight" in sd
+    assert "lm_head.weight" in sd
+    # Randomize HC, gate, attn_sink params (not covered by default init).
+    for blk in model.model.layers:
+        blk.hc_attn_fn.data.normal_(std=0.02)
+        blk.hc_ffn_fn.data.normal_(std=0.02)
+        blk.hc_attn_base.data.normal_(std=0.1)
+        blk.hc_ffn_base.data.normal_(std=0.1)
+        blk.hc_attn_scale.data.normal_(mean=1.0, std=0.1)
+        blk.hc_ffn_scale.data.normal_(mean=1.0, std=0.1)
+        blk.ffn.gate.weight.data.normal_()
+        blk.attn.attn_sink.data.normal_(std=0.1)
+    model.model.hc_head_fn.data.normal_(std=0.02)
+    model.model.hc_head_base.data.normal_(std=0.1)
+
+    # Build reference and copy weights.
+    ref = _RefModel(cfg).eval()
+    ref.embed_tokens.weight.data.copy_(model.model.embed_tokens.weight.data)
+    ref.norm.weight.data.copy_(model.model.norm.weight.data.float())
+    ref.hc_head_fn.data.copy_(model.model.hc_head_fn.data)
+    ref.hc_head_base.data.copy_(model.model.hc_head_base.data)
+    ref.hc_head_scale.data.copy_(model.model.hc_head_scale.data)
+    ref.lm_head.weight.data.copy_(model.lm_head.weight.data)
+    for i, blk in enumerate(model.model.layers):
+        _copy_block_weights(ref.layers[i], blk)
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    cos_tbl, sin_tbl = _build_freqs_cis(
+        cfg.qk_rope_head_dim, cfg.max_position_embeddings, cfg.rope_theta, 0, 1.0, 32, 1
+    )
+    cos = cos_tbl[position_ids]
+    sin = sin_tbl[position_ids]
+    freqs_cis_ref = _freqs_cis_from_cos_sin(cos[0], sin[0])
+
+    logits_custom = model(input_ids=input_ids, position_ids=position_ids).logits
+    logits_ref = ref(input_ids, freqs_cis_ref)
+    assert logits_custom.shape == (B, S, cfg.vocab_size)
+    assert_rmse_close(logits_custom, logits_ref, rmse_ratio_tol=0.05, msg="Full-model logits: ")
+
+
+# =============================================================================
+# Export tests
+# =============================================================================
+
+
+def test_model_can_be_exported():
+    cfg = _small_config()
+    model = DeepseekV4ForCausalLM(cfg).eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+    with torch.inference_mode():
+        out = gm(input_ids=input_ids, position_ids=position_ids)
+    assert "logits" in out
+    assert out["logits"].shape == (B, S, cfg.vocab_size)
+    assert torch.isfinite(out["logits"]).all()
+
+    # Second shape to verify dynamic shapes
+    B2, S2 = 1, 4
+    input_ids2 = torch.randint(0, cfg.vocab_size, (B2, S2))
+    position_ids2 = torch.arange(S2).unsqueeze(0)
+    with torch.inference_mode():
+        out2 = gm(input_ids=input_ids2, position_ids=position_ids2)
+    assert out2["logits"].shape == (B2, S2, cfg.vocab_size)
+    assert torch.isfinite(out2["logits"]).all()
+
+
+def test_compressed_model_can_be_exported():
+    cfg = _small_compress_config(ratio=4)
+    model = DeepseekV4ForCausalLM(cfg).eval()
+
+    B, S = 2, 4
+    input_ids = torch.randint(0, cfg.vocab_size, (B, S))
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+    with torch.inference_mode():
+        out = gm(input_ids=input_ids, position_ids=position_ids)
+    assert out["logits"].shape == (B, S, cfg.vocab_size)
+    assert torch.isfinite(out["logits"]).all()
+
+    for s2 in (1, 2):
+        input_ids2 = torch.randint(0, cfg.vocab_size, (1, s2))
+        position_ids2 = torch.arange(s2).unsqueeze(0)
+        with torch.inference_mode():
+            out2 = gm(input_ids=input_ids2, position_ids=position_ids2)
+        assert out2["logits"].shape == (1, s2, cfg.vocab_size)
+        assert torch.isfinite(out2["logits"]).all()
+
+
+def test_config_registration():
+    cfg = _small_config()
+    assert cfg.model_type == "deepseek_v4"
+    assert hasattr(cfg, "hc_mult")
+    assert hasattr(cfg, "num_hash_layers")
+    assert hasattr(cfg, "o_groups")
+
+
+def test_hash_routing_layer_types():
+    """First num_hash_layers blocks use hash routing; later layers use score routing."""
+    cfg = _small_config(num_hash_layers=1)
+    model = DeepseekV4ForCausalLM(cfg).eval()
+    assert model.model.layers[0].ffn.gate.hash_routing is True
+    assert hasattr(model.model.layers[0].ffn.gate, "tid2eid")
+    for i in range(1, cfg.num_hidden_layers):
+        assert model.model.layers[i].ffn.gate.hash_routing is False
+        assert model.model.layers[i].ffn.gate.bias is not None

--- a/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_sparse_attn_cached.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_sparse_attn_cached.py
@@ -63,7 +63,7 @@ def _small_cfg(ratio: int) -> DeepseekV4Config:
         rope_scaling=None,
         compress_ratios=[ratio],
         index_n_heads=4,
-        index_head_dim=16,
+        index_head_dim=32,
         index_topk=2,
         swiglu_limit=0.0,
         norm_topk_prob=True,
@@ -350,3 +350,119 @@ def test_decode_matches_fresh_prefill_last_token(ratio: int) -> None:
     # Tolerances are a bit loose because the decode path uses a different computation order
     # (rolling-state updates vs one-shot softmax) which introduces bfloat16-scale drift.
     torch.testing.assert_close(y_ref_last, y_last_decoded, rtol=5e-2, atol=5e-2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA graph capture requires CUDA")
+@pytest.mark.parametrize("ratio", [4, 128])
+def test_decode_cuda_graph_matches_fresh_prefill_last_token(ratio: int) -> None:
+    """Captured decode replay matches a fresh prefill and crosses a compression boundary."""
+    device = torch.device("cuda")
+    cfg = _small_cfg(ratio)
+    attn = DeepseekV4Attention(cfg, layer_idx=0).eval().to(device)
+    attn.compressor.ape.data.normal_(std=0.02)
+    if attn.indexer is not None:
+        attn.indexer.compressor.ape.data.normal_(std=0.02)
+    attn.attn_sink.data.normal_(std=0.1)
+
+    B = 1
+    prefill_len, decode_steps = (5, 3) if ratio == 4 else (130, 126)
+    total_len = prefill_len + decode_steps
+    x_full = torch.randn(B, total_len, cfg.hidden_size, device=device)
+    position_ids_full = torch.arange(total_len, device=device).unsqueeze(0).expand(B, -1)
+    cos_tbl, sin_tbl = _build_freqs_cis(
+        cfg.qk_rope_head_dim,
+        cfg.max_position_embeddings,
+        cfg.compress_rope_theta,
+        0,
+        1.0,
+        32,
+        1,
+    )
+    cos_tbl = cos_tbl.to(device)
+    sin_tbl = sin_tbl.to(device)
+    cos_full = cos_tbl[position_ids_full]
+    sin_full = sin_tbl[position_ids_full]
+    q_full, kv_full, qr_full = _prepare_qkv(attn, x_full, cos_full, sin_full)
+
+    constants = _pack_op_constants(cfg, attn)
+    qkv_ref = _pack_op_qkv_args(
+        attn, q_full, kv_full, x_full, qr_full, cos_full, sin_full, cos_tbl, sin_tbl
+    )
+    y_ref_full = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn(
+        *qkv_ref, *constants, 0, "mha_sparse"
+    )
+
+    caches = tuple(t.to(device) for t in _make_caches(cfg, attn))
+    meta_prefill = (
+        torch.zeros(1, dtype=torch.int64, device=device),
+        torch.tensor([prefill_len], dtype=torch.int32, device=device),
+        torch.tensor([0], dtype=torch.int32, device=device),
+        torch.tensor([0], dtype=torch.int64, device=device),
+        torch.tensor([0, prefill_len], dtype=torch.int32, device=device),
+    )
+    qkv_prefill = _pack_op_qkv_args(
+        attn,
+        q_full[:, :prefill_len],
+        kv_full[:, :prefill_len],
+        x_full[:, :prefill_len],
+        qr_full[:, :prefill_len],
+        cos_full[:, :prefill_len],
+        sin_full[:, :prefill_len],
+        cos_tbl,
+        sin_tbl,
+    )
+    torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache(
+        *qkv_prefill, *meta_prefill, *caches, *constants
+    )
+    initial_num_compressed = prefill_len // ratio
+    boundary_row = initial_num_compressed
+    caches[1][:, initial_num_compressed:] = torch.nan
+    if attn.indexer is not None:
+        caches[4][:, initial_num_compressed:] = torch.nan
+
+    q_step = q_full[:, prefill_len : prefill_len + 1].clone()
+    kv_step = kv_full[:, prefill_len : prefill_len + 1].clone()
+    x_step = x_full[:, prefill_len : prefill_len + 1].clone()
+    qr_step = qr_full[:, prefill_len : prefill_len + 1].clone()
+    cos_step = cos_full[:, prefill_len : prefill_len + 1].clone()
+    sin_step = sin_full[:, prefill_len : prefill_len + 1].clone()
+    meta_step = (
+        torch.zeros(1, dtype=torch.int64, device=device),
+        torch.tensor([1], dtype=torch.int32, device=device),
+        torch.tensor([prefill_len], dtype=torch.int32, device=device),
+        torch.tensor([0], dtype=torch.int64, device=device),
+        torch.tensor([0, 1], dtype=torch.int32, device=device),
+    )
+    qkv_step = _pack_op_qkv_args(
+        attn, q_step, kv_step, x_step, qr_step, cos_step, sin_step, cos_tbl, sin_tbl
+    )
+
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        y_last_decoded = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache(
+            *qkv_step, *meta_step, *caches, *constants
+        )
+
+    graph.replay()
+    assert torch.isfinite(y_last_decoded).all().item()
+    assert torch.isnan(caches[1][0, boundary_row]).all().item()
+    if attn.indexer is not None:
+        assert torch.isnan(caches[4][0, boundary_row]).all().item()
+    for step in range(1, decode_steps):
+        pos = prefill_len + step
+        q_step.copy_(q_full[:, pos : pos + 1])
+        kv_step.copy_(kv_full[:, pos : pos + 1])
+        x_step.copy_(x_full[:, pos : pos + 1])
+        qr_step.copy_(qr_full[:, pos : pos + 1])
+        cos_step.copy_(cos_full[:, pos : pos + 1])
+        sin_step.copy_(sin_full[:, pos : pos + 1])
+        meta_step[2].fill_(pos)
+        graph.replay()
+
+    torch.cuda.synchronize()
+    assert torch.isfinite(y_last_decoded).all().item()
+    assert torch.isfinite(caches[1][0, boundary_row]).all().item()
+    if attn.indexer is not None:
+        assert torch.isfinite(caches[4][0, boundary_row]).all().item()
+    torch.testing.assert_close(y_ref_full[:, -1:], y_last_decoded, rtol=5e-2, atol=5e-2)

--- a/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_sparse_attn_cached.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_sparse_attn_cached.py
@@ -22,6 +22,7 @@ from tensorrt_llm._torch.auto_deploy.custom_ops.attention import (  # noqa: F401
 )
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_sparse_attention import (
     _apply_interleaved_rope,
+    _fake_fp8_act_quant,
 )
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4Attention,
@@ -56,7 +57,7 @@ def _small_cfg(ratio: int) -> DeepseekV4Config:
         hc_mult=2,
         hc_sinkhorn_iters=2,
         hc_eps=1e-6,
-        max_position_embeddings=64,
+        max_position_embeddings=max(64, ratio * 2),
         rope_theta=10000.0,
         compress_rope_theta=10000.0,
         rope_scaling=None,
@@ -78,6 +79,8 @@ def _pack_op_qkv_args(
     qr: torch.Tensor,
     cos: torch.Tensor,
     sin: torch.Tensor,
+    cos_anchor: torch.Tensor,
+    sin_anchor: torch.Tensor,
 ) -> tuple:
     if attn.indexer is not None:
         indexer_args = (
@@ -97,6 +100,8 @@ def _pack_op_qkv_args(
         qr,
         cos,
         sin,
+        cos_anchor,
+        sin_anchor,
         attn.attn_sink,
         attn.compressor.wkv.weight,
         attn.compressor.wgate.weight,
@@ -109,6 +114,7 @@ def _pack_op_qkv_args(
 def _pack_op_constants(cfg: DeepseekV4Config, attn: DeepseekV4Attention) -> tuple:
     index_n_heads = attn.indexer.index_n_heads if attn.indexer is not None else 0
     index_head_dim = attn.indexer.index_head_dim if attn.indexer is not None else 0
+    index_topk = attn.indexer.index_topk if attn.indexer is not None else 0
     return (
         attn.softmax_scale,
         attn.window_size,
@@ -117,6 +123,7 @@ def _pack_op_constants(cfg: DeepseekV4Config, attn: DeepseekV4Attention) -> tupl
         attn.head_dim,
         index_n_heads,
         index_head_dim,
+        index_topk,
         cfg.rms_norm_eps,
     )
 
@@ -139,6 +146,7 @@ def _prepare_qkv(
     kv = attn.kv_norm(attn.wkv(x)).view(B, S, 1, attn.head_dim)
     kv_nope, kv_pe = torch.split(kv, [attn.head_dim - rd, rd], dim=-1)
     kv_pe = _apply_interleaved_rope(kv_pe, cos.unsqueeze(2), sin.unsqueeze(2))
+    kv_nope = _fake_fp8_act_quant(kv_nope, block_size=64)
     kv = torch.cat([kv_nope, kv_pe], dim=-1)
     return q, kv, qr
 
@@ -194,7 +202,7 @@ def test_cached_prefill_matches_stateless_prefill(ratio: int) -> None:
         attn.indexer.compressor.ape.data.normal_(std=0.02)
     attn.attn_sink.data.normal_(std=0.1)
 
-    B, S = 1, 8
+    B, S = (1, 8) if ratio == 4 else (1, 256)
     x = torch.randn(B, S, cfg.hidden_size)
     position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
     cos_tbl, sin_tbl = _build_freqs_cis(
@@ -211,7 +219,7 @@ def test_cached_prefill_matches_stateless_prefill(ratio: int) -> None:
     q, kv, qr = _prepare_qkv(attn, x, cos, sin)
 
     # Stateless op — reference.
-    qkv_args = _pack_op_qkv_args(attn, q, kv, x, qr, cos, sin)
+    qkv_args = _pack_op_qkv_args(attn, q, kv, x, qr, cos, sin, cos_tbl, sin_tbl)
     constants = _pack_op_constants(cfg, attn)
     y_stateless = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn(
         *qkv_args, *constants, 0, "mha_sparse"
@@ -232,26 +240,7 @@ def test_cached_prefill_matches_stateless_prefill(ratio: int) -> None:
     torch.testing.assert_close(y_stateless, y_cached, rtol=1e-4, atol=1e-4)
 
 
-@pytest.mark.parametrize(
-    "ratio",
-    [
-        pytest.param(
-            4,
-            marks=pytest.mark.xfail(
-                reason=(
-                    "Ratio-4 (indexer) decode: the compressed token emitted at a compression "
-                    "event must have RoPE applied at position (pos+1-ratio), i.e. the chunk-start "
-                    "position, not the current decode position. The cached op currently uses "
-                    "the current-step cos/sin, which drifts for ratio-4 layers because the "
-                    "Indexer's top-k selection scores against those compressed tokens. Fix "
-                    "requires plumbing the full cos/sin table (or anchor cos/sin) through the "
-                    "op signature — tracked as a follow-up."
-                )
-            ),
-        ),
-        128,
-    ],
-)
+@pytest.mark.parametrize("ratio", [4, 128])
 def test_decode_matches_fresh_prefill_last_token(ratio: int) -> None:
     """Decoding M tokens via the cached op matches a fresh prefill of length N+M.
 
@@ -266,8 +255,7 @@ def test_decode_matches_fresh_prefill_last_token(ratio: int) -> None:
     attn.attn_sink.data.normal_(std=0.1)
 
     B = 1
-    prefill_len = 4
-    decode_steps = 4
+    prefill_len, decode_steps = (5, 3) if ratio == 4 else (130, 126)
     total_len = prefill_len + decode_steps
     x_full = torch.randn(B, total_len, cfg.hidden_size)
     position_ids_full = torch.arange(total_len).unsqueeze(0).expand(B, -1)
@@ -286,7 +274,9 @@ def test_decode_matches_fresh_prefill_last_token(ratio: int) -> None:
 
     # Reference: single prefill of length total_len.
     constants = _pack_op_constants(cfg, attn)
-    qkv_ref = _pack_op_qkv_args(attn, q_full, kv_full, x_full, qr_full, cos_full, sin_full)
+    qkv_ref = _pack_op_qkv_args(
+        attn, q_full, kv_full, x_full, qr_full, cos_full, sin_full, cos_tbl, sin_tbl
+    )
     y_ref_full = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn(
         *qkv_ref, *constants, 0, "mha_sparse"
     )
@@ -307,11 +297,28 @@ def test_decode_matches_fresh_prefill_last_token(ratio: int) -> None:
         torch.tensor([0, prefill_len], dtype=torch.int32),
     )
     qkv_prefill = _pack_op_qkv_args(
-        attn, q_prefill, kv_prefill, x_prefill, qr_prefill, cos_prefill, sin_prefill
+        attn,
+        q_prefill,
+        kv_prefill,
+        x_prefill,
+        qr_prefill,
+        cos_prefill,
+        sin_prefill,
+        cos_tbl,
+        sin_tbl,
     )
     torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache(
         *qkv_prefill, *meta_prefill, *caches, *constants
     )
+    # Decode must ignore unpopulated rows in overallocated compressed caches.
+    # E2E runs can allocate these caches to max_seq_len; attending over the
+    # whole allocation is both incorrect and can explode memory.
+    initial_num_compressed = prefill_len // ratio
+    compressed_kv_cache = caches[1]
+    compressed_kv_cache[:, initial_num_compressed:] = torch.nan
+    if attn.indexer is not None:
+        indexer_compressed_kv_cache = caches[4]
+        indexer_compressed_kv_cache[:, initial_num_compressed:] = torch.nan
 
     # Step 2: decode M tokens one at a time.
     y_last_decoded = None
@@ -330,7 +337,9 @@ def test_decode_matches_fresh_prefill_last_token(ratio: int) -> None:
             torch.tensor([0], dtype=torch.int32),
             torch.tensor([0, 1], dtype=torch.int32),
         )
-        qkv_step = _pack_op_qkv_args(attn, q_step, kv_step, x_step, qr_step, cos_step, sin_step)
+        qkv_step = _pack_op_qkv_args(
+            attn, q_step, kv_step, x_step, qr_step, cos_step, sin_step, cos_tbl, sin_tbl
+        )
         y_last_decoded = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache(
             *qkv_step, *meta_step, *caches, *constants
         )

--- a/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_sparse_attn_cached.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_sparse_attn_cached.py
@@ -1,0 +1,343 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cached sparse attention op equivalence tests.
+
+Validates that ``torch_deepseek_v4_sparse_attn_with_cache`` produces the
+same last-token output when decoding one step at a time as when the whole
+sequence is run in a single fresh prefill.
+
+Strategy: run a prefill of length ``N``, seed the caches. Then for ``M``
+decode steps, call the cached op with one token at a time and check the
+final attention output against a fresh prefill of length ``N + M``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention import (  # noqa: F401
+    deepseek_v4_sparse_attention,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_sparse_attention import (
+    _apply_interleaved_rope,
+)
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
+    DeepseekV4Attention,
+    DeepseekV4Config,
+    _build_freqs_cis,
+)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_seed():
+    torch.manual_seed(42)
+
+
+def _small_cfg(ratio: int) -> DeepseekV4Config:
+    return DeepseekV4Config(
+        vocab_size=200,
+        hidden_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=1,
+        head_dim=32,
+        qk_rope_head_dim=8,
+        q_lora_rank=32,
+        o_lora_rank=32,
+        o_groups=2,
+        sliding_window=4,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_hash_layers=0,
+        moe_intermediate_size=32,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+        hc_eps=1e-6,
+        max_position_embeddings=64,
+        rope_theta=10000.0,
+        compress_rope_theta=10000.0,
+        rope_scaling=None,
+        compress_ratios=[ratio],
+        index_n_heads=4,
+        index_head_dim=16,
+        index_topk=2,
+        swiglu_limit=0.0,
+        norm_topk_prob=True,
+        routed_scaling_factor=1.0,
+    )
+
+
+def _pack_op_qkv_args(
+    attn: DeepseekV4Attention,
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    x: torch.Tensor,
+    qr: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+) -> tuple:
+    if attn.indexer is not None:
+        indexer_args = (
+            attn.indexer.wq_b.weight,
+            attn.indexer.weights_proj.weight,
+            attn.indexer.compressor.wkv.weight,
+            attn.indexer.compressor.wgate.weight,
+            attn.indexer.compressor.ape,
+            attn.indexer.compressor.norm.weight,
+        )
+    else:
+        indexer_args = (None,) * 6
+    return (
+        q,
+        kv,
+        x,
+        qr,
+        cos,
+        sin,
+        attn.attn_sink,
+        attn.compressor.wkv.weight,
+        attn.compressor.wgate.weight,
+        attn.compressor.ape,
+        attn.compressor.norm.weight,
+        *indexer_args,
+    )
+
+
+def _pack_op_constants(cfg: DeepseekV4Config, attn: DeepseekV4Attention) -> tuple:
+    index_n_heads = attn.indexer.index_n_heads if attn.indexer is not None else 0
+    index_head_dim = attn.indexer.index_head_dim if attn.indexer is not None else 0
+    return (
+        attn.softmax_scale,
+        attn.window_size,
+        attn.compress_ratio,
+        attn.rope_head_dim,
+        attn.head_dim,
+        index_n_heads,
+        index_head_dim,
+        cfg.rms_norm_eps,
+    )
+
+
+def _prepare_qkv(
+    attn: DeepseekV4Attention,
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+):
+    """Compute (q, kv, qr) with RoPE applied, mirroring DeepseekV4Attention.forward."""
+    B, S, _ = x.shape
+    qr = attn.q_norm(attn.wq_a(x))
+    q = attn.wq_b(qr).view(B, S, attn.n_heads, attn.head_dim)
+    q = q * torch.rsqrt(q.float().square().mean(-1, keepdim=True) + attn.rms_eps).to(q.dtype)
+    rd = attn.rope_head_dim
+    q_nope, q_pe = torch.split(q, [attn.head_dim - rd, rd], dim=-1)
+    q_pe = _apply_interleaved_rope(q_pe, cos.unsqueeze(2), sin.unsqueeze(2))
+    q = torch.cat([q_nope, q_pe], dim=-1)
+    kv = attn.kv_norm(attn.wkv(x)).view(B, S, 1, attn.head_dim)
+    kv_nope, kv_pe = torch.split(kv, [attn.head_dim - rd, rd], dim=-1)
+    kv_pe = _apply_interleaved_rope(kv_pe, cos.unsqueeze(2), sin.unsqueeze(2))
+    kv = torch.cat([kv_nope, kv_pe], dim=-1)
+    return q, kv, qr
+
+
+def _make_caches(cfg: DeepseekV4Config, attn: DeepseekV4Attention, max_batch: int = 1):
+    coff = 1 + int(attn.compress_ratio == 4)
+    max_seq = cfg.max_position_embeddings
+    window = attn.window_size
+    head_dim = attn.head_dim
+    window_cache = torch.zeros(max_batch, window, head_dim)
+    compressed_kv_cache = torch.zeros(max_batch, max_seq, head_dim)
+    compressor_kv_state = torch.zeros(
+        max_batch, coff * attn.compress_ratio, coff * head_dim, dtype=torch.float32
+    )
+    compressor_score_state = torch.full(
+        (max_batch, coff * attn.compress_ratio, coff * head_dim),
+        -1.0e20,
+        dtype=torch.float32,
+    )
+    if attn.indexer is not None:
+        idx_d = attn.indexer.index_head_dim
+        indexer_compressed_kv_cache = torch.zeros(max_batch, max_seq, idx_d)
+        indexer_kv_state = torch.zeros(
+            max_batch, coff * attn.compress_ratio, coff * idx_d, dtype=torch.float32
+        )
+        indexer_score_state = torch.full(
+            (max_batch, coff * attn.compress_ratio, coff * idx_d),
+            -1.0e20,
+            dtype=torch.float32,
+        )
+    else:
+        indexer_compressed_kv_cache = torch.zeros(max_batch, 0, 0)
+        indexer_kv_state = torch.zeros(max_batch, 0, 0, dtype=torch.float32)
+        indexer_score_state = torch.zeros(max_batch, 0, 0, dtype=torch.float32)
+    return (
+        window_cache,
+        compressed_kv_cache,
+        compressor_kv_state,
+        compressor_score_state,
+        indexer_compressed_kv_cache,
+        indexer_kv_state,
+        indexer_score_state,
+    )
+
+
+@pytest.mark.parametrize("ratio", [4, 128])
+def test_cached_prefill_matches_stateless_prefill(ratio: int) -> None:
+    """Running the cached op in prefill mode should match the stateless prefill op."""
+    cfg = _small_cfg(ratio)
+    attn = DeepseekV4Attention(cfg, layer_idx=0).eval()
+    attn.compressor.ape.data.normal_(std=0.02)
+    if attn.indexer is not None:
+        attn.indexer.compressor.ape.data.normal_(std=0.02)
+    attn.attn_sink.data.normal_(std=0.1)
+
+    B, S = 1, 8
+    x = torch.randn(B, S, cfg.hidden_size)
+    position_ids = torch.arange(S).unsqueeze(0).expand(B, -1)
+    cos_tbl, sin_tbl = _build_freqs_cis(
+        cfg.qk_rope_head_dim,
+        cfg.max_position_embeddings,
+        cfg.compress_rope_theta,
+        0,
+        1.0,
+        32,
+        1,
+    )
+    cos = cos_tbl[position_ids]
+    sin = sin_tbl[position_ids]
+    q, kv, qr = _prepare_qkv(attn, x, cos, sin)
+
+    # Stateless op — reference.
+    qkv_args = _pack_op_qkv_args(attn, q, kv, x, qr, cos, sin)
+    constants = _pack_op_constants(cfg, attn)
+    y_stateless = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn(
+        *qkv_args, *constants, 0, "mha_sparse"
+    )
+
+    # Cached op in prefill mode (s > 1).
+    caches = _make_caches(cfg, attn)
+    meta = (
+        torch.zeros(1, dtype=torch.int64),  # batch_info_host (unused placeholder)
+        torch.tensor([S], dtype=torch.int32),  # seq_len
+        torch.tensor([0], dtype=torch.int32),  # input_pos
+        torch.tensor([0], dtype=torch.int32),  # slot_idx
+        torch.tensor([0, S], dtype=torch.int32),  # cu_seqlen
+    )
+    y_cached = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache(
+        *qkv_args, *meta, *caches, *constants
+    )
+    torch.testing.assert_close(y_stateless, y_cached, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "ratio",
+    [
+        pytest.param(
+            4,
+            marks=pytest.mark.xfail(
+                reason=(
+                    "Ratio-4 (indexer) decode: the compressed token emitted at a compression "
+                    "event must have RoPE applied at position (pos+1-ratio), i.e. the chunk-start "
+                    "position, not the current decode position. The cached op currently uses "
+                    "the current-step cos/sin, which drifts for ratio-4 layers because the "
+                    "Indexer's top-k selection scores against those compressed tokens. Fix "
+                    "requires plumbing the full cos/sin table (or anchor cos/sin) through the "
+                    "op signature — tracked as a follow-up."
+                )
+            ),
+        ),
+        128,
+    ],
+)
+def test_decode_matches_fresh_prefill_last_token(ratio: int) -> None:
+    """Decoding M tokens via the cached op matches a fresh prefill of length N+M.
+
+    After a prefill of length N, decoding M tokens via the cached op should
+    produce the same final-token attention output as a fresh prefill of length N+M.
+    """
+    cfg = _small_cfg(ratio)
+    attn = DeepseekV4Attention(cfg, layer_idx=0).eval()
+    attn.compressor.ape.data.normal_(std=0.02)
+    if attn.indexer is not None:
+        attn.indexer.compressor.ape.data.normal_(std=0.02)
+    attn.attn_sink.data.normal_(std=0.1)
+
+    B = 1
+    prefill_len = 4
+    decode_steps = 4
+    total_len = prefill_len + decode_steps
+    x_full = torch.randn(B, total_len, cfg.hidden_size)
+    position_ids_full = torch.arange(total_len).unsqueeze(0).expand(B, -1)
+    cos_tbl, sin_tbl = _build_freqs_cis(
+        cfg.qk_rope_head_dim,
+        cfg.max_position_embeddings,
+        cfg.compress_rope_theta,
+        0,
+        1.0,
+        32,
+        1,
+    )
+    cos_full = cos_tbl[position_ids_full]
+    sin_full = sin_tbl[position_ids_full]
+    q_full, kv_full, qr_full = _prepare_qkv(attn, x_full, cos_full, sin_full)
+
+    # Reference: single prefill of length total_len.
+    constants = _pack_op_constants(cfg, attn)
+    qkv_ref = _pack_op_qkv_args(attn, q_full, kv_full, x_full, qr_full, cos_full, sin_full)
+    y_ref_full = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn(
+        *qkv_ref, *constants, 0, "mha_sparse"
+    )
+
+    # Step 1: seed caches with a prefill of length prefill_len.
+    x_prefill = x_full[:, :prefill_len]
+    q_prefill = q_full[:, :prefill_len]
+    kv_prefill = kv_full[:, :prefill_len]
+    qr_prefill = qr_full[:, :prefill_len]
+    cos_prefill = cos_full[:, :prefill_len]
+    sin_prefill = sin_full[:, :prefill_len]
+    caches = _make_caches(cfg, attn)
+    meta_prefill = (
+        torch.zeros(1, dtype=torch.int64),
+        torch.tensor([prefill_len], dtype=torch.int32),
+        torch.tensor([0], dtype=torch.int32),
+        torch.tensor([0], dtype=torch.int32),
+        torch.tensor([0, prefill_len], dtype=torch.int32),
+    )
+    qkv_prefill = _pack_op_qkv_args(
+        attn, q_prefill, kv_prefill, x_prefill, qr_prefill, cos_prefill, sin_prefill
+    )
+    torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache(
+        *qkv_prefill, *meta_prefill, *caches, *constants
+    )
+
+    # Step 2: decode M tokens one at a time.
+    y_last_decoded = None
+    for step in range(decode_steps):
+        pos = prefill_len + step
+        x_step = x_full[:, pos : pos + 1]
+        q_step = q_full[:, pos : pos + 1]
+        kv_step = kv_full[:, pos : pos + 1]
+        qr_step = qr_full[:, pos : pos + 1]
+        cos_step = cos_full[:, pos : pos + 1]
+        sin_step = sin_full[:, pos : pos + 1]
+        meta_step = (
+            torch.zeros(1, dtype=torch.int64),
+            torch.tensor([1], dtype=torch.int32),
+            torch.tensor([pos], dtype=torch.int32),
+            torch.tensor([0], dtype=torch.int32),
+            torch.tensor([0, 1], dtype=torch.int32),
+        )
+        qkv_step = _pack_op_qkv_args(attn, q_step, kv_step, x_step, qr_step, cos_step, sin_step)
+        y_last_decoded = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attn_with_cache(
+            *qkv_step, *meta_step, *caches, *constants
+        )
+
+    # Compare the decoded last-token attention output to the reference prefill's last token.
+    assert y_last_decoded is not None
+    y_ref_last = y_ref_full[:, -1:]
+    # Tolerances are a bit loose because the decode path uses a different computation order
+    # (rolling-state updates vs one-shot softmax) which introduces bfloat16-scale drift.
+    torch.testing.assert_close(y_ref_last, y_last_decoded, rtol=5e-2, atol=5e-2)

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_quantization.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_quantization.py
@@ -15,6 +15,7 @@ from tensorrt_llm._torch.auto_deploy.models.factory import (
     ModelFactory,
     SubModuleExportInfo,
 )
+from tensorrt_llm._torch.auto_deploy.models.quant_config_reader import HFQuantConfigReader
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp8_scale, pack_int4_in_uint8
@@ -160,6 +161,66 @@ def test_finegrained_fp8_quantization():
 
     assert not torch.allclose(model(x), gm_transformed(x))
     torch_export_to_gm(gm_transformed, args=(x,))
+
+
+def test_finegrained_fp8_quantization_honors_exclude_modules():
+    """HF quant configs use exclude_modules; keep BF16 heads out of FP8 conversion."""
+
+    class ModelWithHead(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.body = nn.Linear(128, 128, bias=False)
+            self.lm_head = nn.Linear(128, 128, bias=False)
+
+        def forward(self, x):
+            return self.lm_head(self.body(x))
+
+    model = ModelWithHead()
+    x = torch.randn(3, 128)
+    quant_config = {
+        "quant_method": "fp8",
+        "weight_block_size": [128, 128],
+        "exclude_modules": ["lm_head"],
+    }
+    quant_op = torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear
+
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+    gm_transformed = InferenceOptimizer(
+        DummyFactory(quant_config),
+        {
+            "quantize_finegrained_fp8_linear_from_config": {
+                "stage": "pattern_matcher",
+            },
+        },
+    )(None, gm)
+
+    quantized_nodes = [n for n in gm_transformed.graph.nodes if is_op(n, quant_op)]
+    assert len(quantized_nodes) == 1
+    assert gm_transformed.body.weight.dtype == torch.float8_e4m3fn
+    assert gm_transformed.lm_head.weight.dtype == model.lm_head.weight.dtype
+
+
+def test_hf_quant_reader_adds_deepseek_v4_fp8_excludes():
+    """DeepSeek V4 has BF16/FP32 linears without FP8 scale tensors."""
+    reader = HFQuantConfigReader()
+    reader.read_config(
+        {
+            "model_type": "deepseek_v4",
+            "quantization_config": {
+                "quant_method": "fp8",
+                "weight_block_size": [128, 128],
+            },
+        }
+    )
+
+    excluded = set(reader.get_config()["exclude_modules"])
+    assert "lm_head" in excluded
+    assert "model.embed_tokens" in excluded
+    assert "model.layers.*.attn.compressor.wkv" in excluded
+    assert "model.layers.*.attn.indexer.weights_proj" in excluded
+    assert "model.layers.*.attn.indexer.compressor.wgate" in excluded
+    assert "model.layers.*.attn.wo_a" in excluded
+    assert "model.layers.*.ffn.gate" in excluded
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR onboards **DeepSeek V4** (Flash-Base, Pro) as an AutoDeploy custom model and extends it through KV-cache decode, including torch-cudagraph decode for the validated path.

The current implementation covers:

1. **DeepSeek V4 custom model** - `DeepseekV4ForCausalLM` with the DS-V4 architecture: MLA-style dense attention, compressed sparse attention, interleaved RoPE, learnable sinks, Hyper-Connections with Sinkhorn mixing, MoE with hash routing and sqrtsoftplus scoring, registry entries, Flash-Base and Pro configs, and model/export tests.
2. **Sparse attention canonical op + cached decode** - `torch_deepseek_v4_sparse_attn` and its cached variant, `DeepseekV4SparseAttentionDescriptor`, and `InsertCachedDeepseekV4SparseAttention`.
3. **KV-cache transform integration** - dense DeepSeek V4 layers now route to `triton_paged` cached attention for CUDA graph decode, while sparse layers use the dedicated cached sparse path. The full 43-layer Flash-Base graph replaces all expected uncached attention sites with cached variants.
4. **CUDA graph sparse decode path** - sparse cached attention has a Stage 1 `B=1` CUDA graph-safe decode path with tensorized compressor/cache updates and static masking/sanitization for invalid cache rows.
5. **Checkpoint and quantization fixes** - DeepSeek V4 FP8 checkpoint key remapping, `wo_a` dequantization, DeepSeek-specific FP8 exclusion rules for BF16/special modules, activation fake-quant behavior for sparse/indexer paths, and `swiglu_limit` support through fused MoE transforms/backends.
6. **Sharding validation** - current 8-way sharding is functionally correct but still suboptimal. It uses `[TP, MoE_TP, MoE_EP] = [8, 1, 8]`, detects `172` TP shards and `43` MoE EP shards, and does not find BMM shards. Estimated full-model parameter memory is about `39.34 GB` per rank on 8x H100.

DeepSeek V4 Flash-Base and Pro registry configs now use `torch-cudagraph`, `triton_paged` dense attention, and `piecewise-enabled=false` for the validated cudagraph path. Flash-Base inherits its full layer and sparsity settings from the HF `config.json` by default; reduced-layer/smoke `compress_ratios` are CLI/test-only overrides.

## Design

Dense and sparse attention layers coexist in DS-V4. The generic KV-cache transform rewrites standard `torch_attention` nodes, while sparse layers emit a distinct canonical op (`torch_deepseek_v4_sparse_attn`) so they can be handled by a dedicated transform without colliding with dense attention.

Sparse op caches per sparse layer:

| Cache | Shape | Role |
|---|---|---|
| `window_cache` | `[B, window_size, D]` | ring buffer for recent window tokens |
| `compressed_kv_cache` | `[B, max_seq/ratio, D]` | append-only compressed tokens |
| `compressor_kv_state` / `compressor_score_state` | `[B, coff*ratio, coff*D]` / matching score state | Compressor rolling softmax state |
| `indexer_compressed_kv_cache` / `indexer_kv_state` / `indexer_score_state` | analogous with `index_head_dim` | Indexer rolling state for ratio-4 layers |

The sparse cached op handles prefill and eager decode consistently, including the HF-style window-cache layout, visible compressed rows during decode, `index_topk`, batch size greater than one, and stable sink softmax handling. The CUDA graph decode path is currently scoped to `B=1` and keeps all decode-time work in fixed-shape tensor operations.

## Validation

- [x] Sparse cached op unit tests:
  - `pytest tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_sparse_attn_cached.py`
  - Result: `6 passed`
- [x] Triton paged sink/sliding-window tests:
  - `pytest tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention.py -k 'sinks or sliding_window'`
  - Result: `83 passed, 149 deselected`
- [x] DeepSeek V4 modeling transform tests:
  - `pytest tests/unittest/auto_deploy/singlegpu/models/test_deepseek_v4_modeling.py -k 'dense_cache_transform_routes_dense_layers_to_triton_paged_only or sparse_cache_transform_replaces_sparse_attention_nodes'`
  - Result: `2 passed, 25 deselected`
- [x] Quantization targeted tests:
  - `pytest --tb=short -q tests/unittest/auto_deploy/singlegpu/transformations/library/test_quantization.py::test_finegrained_fp8_quantization_honors_exclude_modules tests/unittest/auto_deploy/singlegpu/transformations/library/test_quantization.py::test_hf_quant_reader_adds_deepseek_v4_fp8_excludes`
  - Result: `2 passed`
- [x] 1-GPU reduced-layer Flash-Base E2E:
  - `num_hidden_layers=4`, `compress_ratios=[0,0,4,128]`
  - Completed successfully with `torch-cudagraph` and `piecewise-enabled=false`.
  - Generation is not expected to be meaningful with 4 layers.
- [x] 2-GPU reduced-layer Flash-Base E2E:
  - `world_size=2`, `num_hidden_layers=4`, `compress_ratios=[0,0,4,128]`
  - Completed successfully.
  - Sharding: `[TP, MoE_TP, MoE_EP] = [2, 1, 2]`
  - Cache replacement: `18` matches
- [x] 8-GPU full Flash-Base E2E:
  - Uses the full Flash-Base layer and sparsity settings inherited from the HF `config.json`.
  - Completed successfully with `torch-cudagraph` and `piecewise-enabled=false`.
  - Log: `ad_run_logs/deepseek-v4-flash-base_full8_20260424_232002_success.log`
  - Prompt output: `San Francisco is a city in:  the U.S. state of California.`
  - Sharding: `[TP, MoE_TP, MoE_EP] = [8, 1, 8]`
  - Shards: `172` TP, `43` EP, `0` BMM
  - Cache replacement: `291` matches
  - Estimated parameter memory: `39.34 GB` per rank
  - Actual allocation during run: about `39.67 GB` per rank
- [x] Pre-commit:
  - `pre-commit run --files <modified files>`
  - Result: passed

## Limitations

- Sparse CUDA graph decode is Stage 1 and supports `B=1` decode only.
- Sparse prefill and `B>1` decode remain on the eager/Python path.
- Ratio-128 sparse decode currently scans static compressed capacity.
- The main remaining performance opportunity is sharding quality: the current scheme is functionally correct, but attention and other linear weights still use simple TP placement rather than a more efficient row/column partitioning strategy.

## CI

Please run:

```text
/bot run --extra-stage "DGX_B200-4_GPUs-AutoDeploy-1, DGX_H100-4_GPUs-AutoDeploy-1"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for DeepSeek V4 models (Flash Base and Pro variants) with pre-configured optimization settings for improved inference performance
  * Introduced sparse attention mechanism for DeepSeek V4 models to enhance computational efficiency

* **Tests**
  * Added comprehensive unit tests validating DeepSeek V4 model functionality and sparse attention operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
