### PR TITLE
[None][feat] WIP AutoDeploy: Add DeepSeek v4 support

### DIFF
--- a/ad_dsv4_ramp_up.md
+++ b/ad_dsv4_ramp_up.md
@@ -1,0 +1,264 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# AutoDeploy DeepSeek V4 Ramp-Up
+
+This note is a quick ramp-up for agents working on DeepSeek V4 Flash support in
+AutoDeploy. It summarizes the local workflow, what AutoDeploy is doing, what is
+reasonable to add or change, and the important DeepSeek V4 model/checkpoint
+facts.
+
+For the detailed feature plan, see `deepseek_v4_ad_plan.md`.
+
+For parallel work packets, see `subagents/README.md`.
+
+## Command Rule
+
+Run commands through the project shell setup:
+
+```bash
+bash -ic "f9 && <command>"
+```
+
+Examples:
+
+```bash
+bash -ic "f9 && pytest -q tests/unittest/_torch/auto_deploy/unit"
+bash -ic "f9 && python3 -m py_compile path/to/file.py"
+bash -ic "f9 && rg -n \"deepseek_v4\" tensorrt_llm/_torch/auto_deploy"
+bash -ic "f9 && git status --short"
+```
+
+Do not run Python, pytest, or repo commands directly without the `bash -ic
+"f9 && ..."` wrapper unless the user explicitly changes this rule.
+
+## Local Checkpoint
+
+The DeepSeek V4 Flash checkpoint is already downloaded here:
+
+```text
+/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash
+```
+
+This directory contains the model config, tokenizer files, safetensors index,
+and 46 checkpoint shards. Use this path for local metadata and weight-loading
+work instead of assuming the model exists in the default Hugging Face cache.
+
+Useful metadata files:
+
+```text
+/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash/config.json
+/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash/model.safetensors.index.json
+/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash/tokenizer.json
+```
+
+Suggested local model path for experiments:
+
+```bash
+bash -ic "f9 && python examples/auto_deploy/build_and_run_ad.py --model /lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash --args.yaml-extra examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml"
+```
+
+Only use the full run command after the required model/config pieces are ready.
+For early work, prefer unit tests with small synthetic tensors or metadata-only
+fixtures.
+
+## AutoDeploy Flow: High-Level Mental Model
+
+AutoDeploy takes a Hugging Face-style model and turns it into an optimized
+runtime graph for PyTorch backend serving.
+
+The high-level flow is:
+
+1. Load model config and tokenizer metadata.
+2. Build a model instance, using an AutoDeploy custom model if registered.
+3. Export the model graph.
+4. Prefer AutoDeploy canonical ops in the exported graph:
+   - `torch_linear_simple`
+   - `torch_rmsnorm`
+   - `torch_moe`
+   - attention/MLA custom ops
+   - quantized linear/MoE custom ops
+5. Run graph transforms:
+   - pattern cleanup
+   - quantization transforms
+   - MoE and SwiGLU matching
+   - sharding and expert parallel transforms
+   - cache insertion
+   - post-load fusions
+6. Load checkpoint weights into the transformed graph.
+7. Compile with the selected backend, commonly `torch-cudagraph`.
+8. At runtime, `ADExecutor` prepares sequence metadata, cache page tables, and
+   padded CUDA graph batch shapes.
+9. The runtime executes prefill, mixed prefill/decode, and decode paths using
+   AutoDeploy's cache manager and compiled graph segments.
+
+The important idea: model code should be lean and semantic. It should expose
+recognizable canonical ops that later transforms can replace with optimized
+kernels. Avoid hiding core model behavior inside opaque Python loops if a
+custom op or transform will need to recognize it later.
+
+## What Is Allowed To Add Or Change
+
+For DeepSeek V4 support, it is reasonable to add or change:
+
+- AutoDeploy custom model code for `deepseek_v4`.
+- Custom AutoDeploy ops:
+  - sparse DeepSeek V4 attention source op
+  - DeepSeek V4 router op
+  - DeepSeek V4 MoE op
+  - E8M0/FP8/MXFP4 helper ops if needed
+- Quantization readers and transforms.
+- Checkpoint load hooks and key remapping.
+- FineGrained FP8 linear support for DeepSeek V4 `.scale` tensors.
+- Packed MXFP4/FP4 expert loading and layout conversion.
+- MoE lowering to Triton, TRT-LLM, FlashInfer, or DeepGEMM-style kernels.
+- V4-specific paged cache resource handlers.
+- Sequence/cache metadata extensions needed by V4 sparse attention.
+- CUDA graph dynamic-op registration and piecewise capture support.
+- AutoDeploy model registry YAML and test configs.
+- Unit tests, graph tests, and reduced-model integration tests.
+
+Keep changes scoped. Do not refactor unrelated TensorRT-LLM or AutoDeploy code
+unless the refactor is required to expose a clean V4 extension point.
+
+## Development Guardrails
+
+- Read `CODING_GUIDELINES.md` before code changes.
+- New files need the NVIDIA copyright and Apache-2.0 header.
+- Do not guess checkpoint formats. Verify with config, safetensors index, or
+  safetensors headers.
+- Do not assume generic `fp8` support is enough for DeepSeek V4.
+- Do not treat the dense expert fallback as a production path.
+- Avoid unpaged long-context V4 caches.
+- Keep model code export-friendly.
+- Add focused tests with synthetic data before trying full checkpoint runs.
+- If committing, use `git commit -s`; do not manually write sign-off lines.
+
+## DeepSeek V4 Model Summary
+
+DeepSeek V4 Flash is a large sparse MoE model with heterogeneous attention.
+
+Key config facts:
+
+| Field | Value |
+| - | - |
+| Model type | `deepseek_v4` |
+| Layers | 43 |
+| Hidden size | 4096 |
+| Attention heads | 64 |
+| KV heads | 1 |
+| Head dim | 512 |
+| Q LoRA rank | 1024 |
+| RoPE head dim | 64 |
+| Sliding window | 128 |
+| Routed experts | 256 |
+| Experts per token | 6 |
+| Shared experts | 1 |
+| Hash-routed layers | 3 |
+| Router scoring | `sqrtsoftplus` |
+| Router scale | 1.5 |
+| SwiGLU limit | 10.0 |
+| Max position embeddings | 1,048,576 |
+
+Attention is not classic DeepSeek V3 MLA. It combines:
+
+- local sliding-window attention
+- compressed KV memory
+- ratio-4 compressed layers with indexer top-k
+- ratio-128 compressed layers
+- attention sinks
+- inverse RoPE on output
+- grouped output projection
+
+The model also uses hyper-connections around attention and MoE blocks.
+
+## Checkpoint Quantization Summary
+
+The checkpoint is mixed precision:
+
+- Attention and output projection linears:
+  - weights: `F8_E4M3`
+  - scales: `F8_E8M0`
+  - runtime target: FineGrained FP8 linear
+- Shared expert linears:
+  - weights: `F8_E4M3`
+  - scales: `F8_E8M0`
+  - runtime target: FineGrained FP8 linear or fused shared expert path
+- Routed expert linears:
+  - weights: packed FP4 stored as `I8`
+  - scales: `F8_E8M0`
+  - runtime target: MXFP4/FP4 fused MoE
+- Router, compressor, embeddings/head, norms, hyper-connections, and attention
+  sinks:
+  - BF16/F32/I64 as appropriate
+
+Important scale rule:
+
+```text
+E8M0 scales are exponent-only.
+Use scale.view(torch.uint8) when raw exponent bytes are required.
+Do not use scale.to(torch.uint8) for raw-byte preservation.
+```
+
+## Recommended Work Order
+
+The current parallel plan is organized into waves:
+
+```text
+subagents/wave1
+  foundational metadata, E8M0 helpers, router, source attention op, cache
+  resources, CUDA graph config
+
+subagents/wave2
+  FP8 linears, packed MXFP4 expert loader, attention kernel microfeatures
+
+subagents/wave3
+  DeepSeek V4 MoE op
+
+subagents/wave4
+  full model integration
+```
+
+Files inside a single wave are intended to be worked on in parallel.
+
+## Practical Test Strategy
+
+Prefer this order:
+
+1. CPU metadata tests:
+   - checkpoint classifier
+   - key naming
+   - dtype/shape classification
+2. CPU quantization helper tests:
+   - E8M0 decode
+   - raw-byte preservation
+3. Small synthetic graph tests:
+   - FineGrained FP8 linears
+   - packed MXFP4 expert layout
+   - router math
+   - sparse attention reference op
+4. GPU kernel tests:
+   - FP8 linear backend
+   - MXFP4 MoE backend
+   - attention kernel microfeatures
+5. Reduced-layer AutoDeploy run.
+6. Full 43-layer load and transform.
+7. Serving path with chunked prefill and CUDA graph decode.
+
+Do not start by running the full checkpoint unless the targeted feature already
+has small tests passing. Full model runs are expensive and make failures harder
+to isolate.

--- a/deepseek_v4_ad_plan.md
+++ b/deepseek_v4_ad_plan.md
@@ -1,0 +1,1092 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# DeepSeek V4 Flash AutoDeploy Support Plan
+
+This document lays out a performance-oriented plan for serving
+`deepseek-ai/DeepSeek-V4-Flash` through AutoDeploy. It focuses on the model
+architecture, checkpoint quantization format, AutoDeploy cache/runtime
+constraints, custom kernels, CUDA graph capture, and validation order.
+
+The plan assumes:
+
+- The modeling scaffold may be customized for AutoDeploy.
+- AutoDeploy graph transforms may be extended.
+- Custom Triton, TRT-LLM, or DeepGEMM-style kernels may be added.
+- The initial target is reliable prefill/decode serving through AutoDeploy,
+  with CUDA graph support.
+- MTP support is not required for the first production path.
+
+## Executive Summary
+
+DeepSeek V4 Flash should not be treated as a normal FP8 model, and it should
+not be forced into the existing classic DeepSeek V3 MLA path.
+
+The deployment should introduce two DeepSeek V4-specific AutoDeploy surfaces:
+
+1. `torch_deepseek_v4_sparse_attention`
+   - Canonical source op for heterogeneous attention.
+   - Lowered to sparse cached attention kernels with V4-specific paged cache
+     resources.
+
+2. `torch_deepseek_v4_moe`
+   - Canonical source op for the V4 router and MoE block.
+   - Lowered to fused routed+shared MoE kernels using packed MXFP4/FP4 expert
+     weights.
+
+The checkpoint is mixed precision:
+
+- Attention, output projections, and shared expert linears are FP8 E4M3 with
+  E8M0 block scales.
+- Routed expert weights are packed FP4 stored in `I8` tensors, with E8M0
+  scales.
+- Router, compressor, embeddings/head, norms, hyper-connection tensors, and
+  attention sinks are BF16/F32/I64.
+
+Generic AutoDeploy `quant_method: fp8` handling is therefore insufficient.
+DeepSeek V4 needs a model-specific mixed-quantization bridge that routes
+ordinary linears to FineGrained FP8 and routed experts to MXFP4.
+
+## Evidence Collected
+
+The visible `HF_HOME` in the current environment points to:
+
+```text
+/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/bmarimuthu/dev/hf_home
+```
+
+That cache visibly contains `deepseek-ai/DeepSeek-V3`, but not
+`deepseek-ai/DeepSeek-V4-Flash`. To avoid relying on guesswork, the following
+small public metadata files were inspected directly:
+
+- `config.json`
+- `inference/config.json`
+- `model.safetensors.index.json`
+- selected safetensors headers from shards `00002`, `00005`, and `00045`
+
+No full DeepSeek V4 weight download is required to identify the tensor dtypes,
+shapes, and checkpoint naming convention.
+
+Primary sources:
+
+- Hugging Face model: <https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash>
+- Hugging Face config:
+  <https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/raw/main/config.json>
+- Hugging Face reference implementation:
+  <https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/raw/main/inference/model.py>
+- vLLM blog: <https://vllm.ai/blog/deepseek-v4>
+- vLLM support PR: <https://github.com/vllm-project/vllm/pull/40760>
+
+## Model Architecture Facts
+
+From the DeepSeek V4 Flash config:
+
+| Field | Value |
+| - | - |
+| Model type | `deepseek_v4` |
+| Architecture | `DeepseekV4ForCausalLM` |
+| Total layers | 43 |
+| Hidden size | 4096 |
+| Attention heads | 64 |
+| KV heads | 1 |
+| Head dim | 512 |
+| Q LoRA rank | 1024 |
+| QK RoPE head dim | 64 |
+| Output groups | 8 |
+| Output LoRA rank | 1024 |
+| Sliding window | 128 |
+| Routed experts | 256 |
+| Experts per token | 6 |
+| Shared experts | 1 |
+| Hash-routed layers | 3 |
+| MoE intermediate size | 2048 |
+| Router scoring | `sqrtsoftplus` |
+| Router scale | 1.5 |
+| SwiGLU limit | 10.0 |
+| Max position embeddings | 1,048,576 |
+
+The `compress_ratios` pattern is:
+
+```text
+layer 0:  0
+layer 1:  0
+layer 2:  4
+layer 3:  128
+layer 4:  4
+layer 5:  128
+...
+layer 40: 4
+layer 41: 128
+layer 42: 4
+layer 43 entry in config list: 0
+```
+
+For the 43 actual transformer layers, the practical pattern is:
+
+- first two layers: uncompressed attention
+- middle layers: alternating ratio-4 and ratio-128 compression
+- final listed ratio includes an uncompressed sentinel-style entry in the config
+  list
+
+The reference implementation uses:
+
+- Sparse/local window attention over the last 128 tokens.
+- Multi-head compression (MHC) over older context.
+- Ratio-4 compressed layers with an indexer top-k path.
+- Ratio-128 compressed layers without the same high-cost indexer path.
+- Attention sink values per head.
+- Hyper-connections around attention and MoE.
+- One MTP block in the checkpoint/reference, but normal serving can initially
+  omit MTP.
+
+## Checkpoint Anatomy
+
+The safetensors index reports:
+
+```text
+total_size: 159,609,485,896 bytes
+num_tensors: 69,187
+num_shards: 46
+```
+
+Tensor suffix counts:
+
+```text
+34,600  weight
+34,167  scale
+    62  ape
+    44  hc_ffn_scale
+    44  hc_ffn_fn
+    44  hc_ffn_base
+    44  hc_attn_scale
+    44  hc_attn_fn
+    44  hc_attn_base
+    44  attn_sink
+    41  bias
+     3  tid2eid
+```
+
+Scale tensor categories:
+
+```text
+33,792  ffn.experts
+   241  attn
+   132  ffn.shared_experts
+     2  other
+```
+
+The routed expert scale count matches:
+
+```text
+44 MoE-like blocks * 256 experts * 3 projections = 33,792
+```
+
+The extra MoE-like block is `mtp.0`.
+
+### Representative Tensor Headers
+
+Selected safetensors headers show the exact mixed checkpoint format:
+
+```text
+layers.0.attn.wq_a.weight   F8_E4M3  [1024, 4096]
+layers.0.attn.wq_a.scale    F8_E8M0  [8, 32]
+
+layers.0.attn.wq_b.weight   F8_E4M3  [32768, 1024]
+layers.0.attn.wq_b.scale    F8_E8M0  [256, 8]
+
+layers.0.attn.wkv.weight    F8_E4M3  [512, 4096]
+layers.0.attn.wkv.scale     F8_E8M0  [4, 32]
+
+layers.0.attn.wo_a.weight   F8_E4M3  [8192, 4096]
+layers.0.attn.wo_a.scale    F8_E8M0  [64, 32]
+
+layers.0.attn.wo_b.weight   F8_E4M3  [4096, 8192]
+layers.0.attn.wo_b.scale    F8_E8M0  [32, 64]
+
+layers.0.ffn.experts.0.w1.weight  I8       [2048, 2048]
+layers.0.ffn.experts.0.w1.scale   F8_E8M0  [2048, 128]
+
+layers.0.ffn.experts.0.w2.weight  I8       [4096, 1024]
+layers.0.ffn.experts.0.w2.scale   F8_E8M0  [4096, 64]
+
+layers.0.ffn.experts.0.w3.weight  I8       [2048, 2048]
+layers.0.ffn.experts.0.w3.scale   F8_E8M0  [2048, 128]
+
+layers.0.ffn.shared_experts.w1.weight  F8_E4M3  [2048, 4096]
+layers.0.ffn.shared_experts.w1.scale   F8_E8M0  [16, 32]
+
+layers.0.ffn.gate.weight    BF16  [256, 4096]
+layers.0.ffn.gate.tid2eid   I64   [129280, 6]
+
+layers.3.ffn.gate.weight    BF16  [256, 4096]
+layers.3.ffn.gate.bias      F32   [256]
+
+layers.3.attn.compressor.wkv.weight    BF16  [512, 4096]
+layers.3.attn.compressor.wgate.weight  BF16  [512, 4096]
+
+head.weight                 BF16  [129280, 4096]
+norm.weight                 BF16  [4096]
+```
+
+### Quantization Interpretation
+
+The checkpoint should be classified as:
+
+| Component | Checkpoint dtype | Scale dtype | Runtime plan |
+| - | - | - | - |
+| Attention linears | `F8_E4M3` | `F8_E8M0` | FineGrained FP8 linear |
+| Output low-rank projections | `F8_E4M3` | `F8_E8M0` | FineGrained FP8 linear |
+| Shared expert linears | `F8_E4M3` | `F8_E8M0` | FineGrained FP8 linear or fused shared expert |
+| Routed expert linears | packed FP4 in `I8` | `F8_E8M0` | MXFP4/FP4 fused MoE |
+| Router weights | `BF16` | none | BF16 router kernel |
+| Hash route table | `I64` | none | gather-based routing table |
+| Compressor linears | `BF16` | none | BF16, later optionally quantized only after validation |
+| Embedding/head | `BF16` | none | BF16 |
+| Norms/HC/sinks | `BF16`/`F32` | none | BF16/F32 |
+
+The advertised HF quantization config is:
+
+```json
+{
+  "activation_scheme": "dynamic",
+  "fmt": "e4m3",
+  "quant_method": "fp8",
+  "scale_fmt": "ue8m0",
+  "weight_block_size": [128, 128]
+}
+```
+
+That config is accurate for many dense linears, but it is not sufficient for
+routed experts. `inference/config.json` separately states:
+
+```text
+dtype: fp8
+expert_dtype: fp4
+scale_fmt: ue8m0
+```
+
+## Existing AutoDeploy Capabilities
+
+Relevant AutoDeploy components:
+
+- `tensorrt_llm/_torch/auto_deploy/models/quant_config_reader.py`
+  - Reads HF `quantization_config`.
+  - Supports `quant_method` values including `fp8` and `mxfp4`.
+
+- `tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py`
+  - `quantize_finegrained_fp8_linear_from_config`
+  - Converts eligible linear ops to FineGrained FP8 quantized ops.
+
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py`
+  - `torch_fake_quant_finegrained_fp8_linear`
+  - `trtllm_finegrained_fp8_linear`
+  - Dynamic activation quantization plus block-scaled FP8 GEMM.
+
+- `tensorrt_llm/_torch/auto_deploy/transform/library/quantize_moe.py`
+  - FineGrained FP8 MoE transform.
+  - NVFP4 MoE transform.
+  - Does not directly model DeepSeek V4's FP8+packed-FP4 mixed checkpoint.
+
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py`
+  - `triton_mxfp4_moe`
+  - `triton_mxfp4_moe_ep`
+  - Triton-kernels-based MXFP4 MoE execution.
+
+- `tensorrt_llm/_torch/auto_deploy/transform/library/mxfp4_moe.py`
+  - Replaces router+dense MLP pattern with MXFP4 MoE.
+  - Currently oriented toward `quant_method: mxfp4`.
+
+- `tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py`
+  - Has sharding support for `triton_mxfp4_moe`.
+  - Rewrites to `triton_mxfp4_moe_ep`.
+
+The useful pieces are present, but the automatic dispatch must be made
+DeepSeek V4-aware.
+
+## Key Gaps To Close
+
+### 1. Generic `fp8` Handling Will Misclassify Routed Experts
+
+If AutoDeploy only sees:
+
+```json
+"quant_method": "fp8"
+```
+
+then the natural generic path is FineGrained FP8 for all eligible linear/MoE
+ops. That is wrong for routed experts because their weights are not FP8:
+
+```text
+layers.*.ffn.experts.*.w*.weight  I8
+layers.*.ffn.experts.*.w*.scale   F8_E8M0
+```
+
+The support plan must override quantization per module family.
+
+### 2. V4 Uses `.scale`, While Some AD Hooks Expect `weight_scale_inv`
+
+AutoDeploy's FineGrained FP8 transforms currently expect or create buffers named
+`weight_scale_inv`, while the V4 checkpoint stores sibling keys:
+
+```text
+layers.0.attn.wq_a.weight
+layers.0.attn.wq_a.scale
+```
+
+The loader needs a V4-specific remap:
+
+```text
+<module>.weight + <module>.scale -> <module>.weight + <module>.weight_scale_inv
+```
+
+or the transform should accept `.scale` as an alias for FineGrained FP8.
+
+### 3. E8M0 Scales Need Raw-Bit Awareness
+
+E8M0 is exponent-only. In PyTorch, headers show `F8_E8M0`; locally this maps to
+`torch.float8_e8m0fnu`.
+
+For kernels that need FP32 scales, upcast by reinterpreting the exponent byte:
+
+```text
+exp_bits = scale.view(torch.uint8).to(torch.int32)
+fp32_bits = exp_bits << 23
+scale_fp32 = fp32_bits.view(torch.float32)
+```
+
+For kernels that expect raw exponent bytes, such as many MXFP4 layouts:
+
+```text
+good: loaded_scale.view(torch.uint8)
+bad:  loaded_scale.to(torch.uint8)
+```
+
+Numeric conversion can destroy the exponent encoding.
+
+### 4. Routed Expert Shapes Are Packed
+
+Representative routed expert tensors:
+
+```text
+w1.weight  I8 [2048, 2048]  -> logical FP4 [2048, 4096]
+w3.weight  I8 [2048, 2048]  -> logical FP4 [2048, 4096]
+w2.weight  I8 [4096, 1024]  -> logical FP4 [4096, 2048]
+```
+
+The second dimension is halved because two FP4 values are packed per byte.
+
+The scale shapes use 32-element FP4 blocks:
+
+```text
+w1.scale F8_E8M0 [2048, 128]  -> 4096 / 32 = 128
+w3.scale F8_E8M0 [2048, 128]
+w2.scale F8_E8M0 [4096, 64]   -> 2048 / 32 = 64
+```
+
+Any stacking, sharding, or conversion code must preserve this packed layout.
+
+### 5. Current Modeling Fallback Is Not Production-Ready
+
+The current `DeepseekV4MoE` scaffold can fall back to a dense expert loop when
+`swiglu_limit > 0`. The real model has:
+
+```text
+swiglu_limit = 10.0
+```
+
+So production must not rely on the dense loop. It needs a V4-specific fused MoE
+lowering that supports `swiglu_limit`.
+
+## Proposed Quantization Architecture
+
+Add a DeepSeek V4-specific quantization classification layer.
+
+### Option A: Model-Specific Quant Config Reader
+
+Introduce a reader/override that recognizes:
+
+```text
+model_type == "deepseek_v4"
+quantization_config.quant_method == "fp8"
+inference config expert_dtype == "fp4"
+```
+
+and returns an internal mixed quantization plan:
+
+```yaml
+quant_method: deepseek_v4_fp8
+linear_quant_method: finegrained_fp8
+expert_quant_method: mxfp4
+scale_fmt: ue8m0
+weight_block_size: [128, 128]
+expert_block_size: 32
+exclude_modules:
+  - embed
+  - head
+  - "*.ffn.gate"
+  - "*.attn.compressor"
+  - "*.norm"
+  - "*.hc_*"
+  - "*.attn_sink"
+  - "mtp.*"   # until MTP is supported
+```
+
+This is conceptually the same as vLLM's `DeepseekV4FP8Config`: standard FP8
+behavior for non-MoE layers, MXFP4 behavior for `FusedMoE`.
+
+### Option B: Transform-Level Detection
+
+Keep the HF reader generic, but make quantization transforms inspect checkpoint
+dtypes and module names:
+
+- If module path matches `*.ffn.experts.*.w[123]` and checkpoint dtype is `I8`,
+  route to MXFP4.
+- If module path has paired `.scale` and checkpoint dtype is `F8_E4M3`, route to
+  FineGrained FP8.
+- If no matching quantized weight exists, keep BF16/F32.
+
+This is more robust to future checkpoints but requires more loader metadata to
+flow into transform decisions.
+
+Recommended approach: start with Option A for clarity and speed, then factor
+the useful pieces into transform-level detection once validated.
+
+## Checkpoint Loading Plan
+
+### Name Mapping
+
+The custom model hierarchy should match checkpoint names where possible:
+
+```text
+embed.weight
+layers.{i}.attn.wq_a.weight
+layers.{i}.attn.wq_a.scale
+layers.{i}.attn.wq_b.weight
+layers.{i}.attn.wq_b.scale
+layers.{i}.attn.wkv.weight
+layers.{i}.attn.wkv.scale
+layers.{i}.attn.wo_a.weight
+layers.{i}.attn.wo_a.scale
+layers.{i}.attn.wo_b.weight
+layers.{i}.attn.wo_b.scale
+layers.{i}.ffn.gate.weight
+layers.{i}.ffn.gate.bias
+layers.{i}.ffn.gate.tid2eid
+layers.{i}.ffn.experts.{e}.w1.weight
+layers.{i}.ffn.experts.{e}.w1.scale
+layers.{i}.ffn.experts.{e}.w2.weight
+layers.{i}.ffn.experts.{e}.w2.scale
+layers.{i}.ffn.experts.{e}.w3.weight
+layers.{i}.ffn.experts.{e}.w3.scale
+layers.{i}.ffn.shared_experts.w1.weight
+layers.{i}.ffn.shared_experts.w1.scale
+...
+```
+
+For the first production path:
+
+- Load normal transformer layers.
+- Load `tid2eid` for the first three hash-routed layers.
+- Skip `mtp.0.*`.
+- Treat missing MTP keys as expected if the model omits MTP.
+- Treat unexpected `mtp.0.*` keys as expected/skipped, not fatal.
+
+### FineGrained FP8 Linears
+
+For each eligible FP8 linear:
+
+1. Keep `weight` as `torch.float8_e4m3fn`.
+2. Load checkpoint `.scale`.
+3. Store scale in an AD buffer accepted by the FineGrained FP8 op.
+4. Upcast E8M0 to FP32 only when the backend requires FP32 scales.
+5. Preserve E8M0 as raw bytes when the backend requires E8M0 bytes.
+
+Eligible linears:
+
+```text
+layers.*.attn.wq_a
+layers.*.attn.wq_b
+layers.*.attn.wkv
+layers.*.attn.wo_a
+layers.*.attn.wo_b
+layers.*.ffn.shared_experts.w1
+layers.*.ffn.shared_experts.w2
+layers.*.ffn.shared_experts.w3
+```
+
+Not initially eligible:
+
+```text
+layers.*.ffn.gate
+layers.*.attn.compressor.*
+embed
+head
+norms
+hyper-connection tensors
+attn_sink
+mtp.*
+```
+
+### Routed MXFP4 Experts
+
+For each layer's routed experts:
+
+1. Load packed `I8` weights as raw bytes.
+2. Load E8M0 scales as raw exponent bytes.
+3. Stack expert weights into grouped MoE layout.
+4. Concatenate gate/up path in the order expected by the chosen backend.
+5. Keep down path separate.
+6. Preserve scales with the same packing and expert order as weights.
+7. Apply EP sharding only after the packed layout is established.
+
+The desired logical layout is:
+
+```text
+gate_up_blocks:  [E_local, 2 * I, H / 32, 16]  uint8
+gate_up_scales:  [E_local, 2 * I, H / 32]      uint8 or E8M0-backed
+down_blocks:     [E_local, H, I / 32, 16]      uint8
+down_scales:     [E_local, H, I / 32]          uint8 or E8M0-backed
+```
+
+The exact conversion depends on the backend:
+
+- Triton-kernels MXFP4 path may swizzle via `convert_layout`.
+- TRT-LLM/FlashInfer path may require NVFP4 block-scale interleave.
+- DeepGEMM-style path may consume FP8 activations and FP4 weights directly.
+
+The key invariant is that E8M0 scale bytes must remain exponent bytes until the
+backend explicitly asks for FP32 scales.
+
+## MoE Runtime Plan
+
+DeepSeek V4 MoE consists of:
+
+- BF16 router weight `[256, 4096]`
+- optional router bias for non-hash layers
+- `tid2eid` table for the first three hash-routed layers
+- top-k = 6
+- scoring function = `sqrtsoftplus`
+- normalization of selected weights
+- route scale = 1.5
+- routed MXFP4 experts
+- one shared FP8 expert
+- `swiglu_limit = 10.0`
+
+### Canonical Op Contract
+
+Introduce:
+
+```text
+torch_deepseek_v4_moe(
+    hidden_states,
+    input_ids,
+    router_weight,
+    router_bias_or_none,
+    tid2eid_or_none,
+    routed_expert_packed_weights,
+    routed_expert_scales,
+    shared_expert_weights,
+    shared_expert_scales,
+    top_k,
+    route_scale,
+    swiglu_limit,
+    is_hash_layer,
+)
+```
+
+The source implementation may be a reference PyTorch path for export and unit
+tests, but production lowering should replace it with fused kernels.
+
+### Router Lowering
+
+Hash-routed layers:
+
+```text
+indices = tid2eid[input_ids]
+scores = sqrt(softplus(router_logits))
+weights = gather(scores, indices)
+weights = normalize(weights) * route_scale
+```
+
+Top-k layers:
+
+```text
+scores = sqrt(softplus(router_logits))
+biased_scores = scores + bias
+indices = topk(biased_scores, k=6)
+weights = gather(scores, indices)
+weights = normalize(weights) * route_scale
+```
+
+Add a fused `topk_sqrtsoftplus` kernel for non-hash layers. vLLM added an
+analogous `topk_softplus_sqrt` path.
+
+### Expert Lowering
+
+Production path:
+
+```text
+router -> selected experts/weights
+routed experts -> MXFP4 grouped MoE kernel
+shared expert -> FineGrained FP8 SwiGLU or fused shared expert kernel
+sum routed + shared
+```
+
+Important: the routed expert activation is not vanilla SwiGLU if
+`swiglu_limit > 0`:
+
+```text
+up = clamp(up, -limit, limit)
+gate = clamp(gate, max=limit)
+hidden = silu(gate) * up
+```
+
+The selected MoE backend must support this activation variant, either directly
+or via a small V4-specific fused activation wrapper.
+
+## Attention Runtime Plan
+
+DeepSeek V4 attention combines:
+
+- Q low-rank path: `wq_a -> q_norm -> wq_b`
+- per-head Q RMSNorm
+- KV path: `wkv -> kv_norm`
+- RoPE on the last 64 dims
+- local sliding window of 128 tokens
+- compressed KV memory for older context
+- ratio-4 indexer top-k path
+- ratio-128 compressed path
+- attention sink
+- inverse RoPE on output
+- grouped output projection: `wo_a -> wo_b`
+
+### Existing MLA Support Is Not Sufficient
+
+AutoDeploy's existing classic MLA support is designed for DeepSeek V2/V3-style
+MLA, not V4 HMA/MHC. It assumes different cache semantics and dimensions. V4
+needs a new sparse attention descriptor and cache resource design.
+
+### Canonical Op Contract
+
+Introduce:
+
+```text
+torch_deepseek_v4_sparse_attention(
+    hidden_states,
+    position_ids,
+    layer_id,
+    compress_ratio,
+    sliding_window,
+    index_topk,
+    q_weights,
+    kv_weights,
+    compressor_weights_or_none,
+    indexer_weights_or_none,
+    output_weights,
+    attn_sink,
+)
+```
+
+The exact source op can be split into smaller canonical ops if that makes
+transform matching easier. The important point is that production lowering
+should see a single semantic attention region rather than many opaque PyTorch
+gather/einsum operations.
+
+### Cache Resource Design
+
+Add a DeepSeek V4 composite cache resource:
+
+```text
+swa_kv_cache
+  local high-resolution KV for sliding window attention
+
+mhc_cache
+  compressed KV entries for ratio-4 and ratio-128 layers
+
+indexer_cache
+  compact indexer KV for ratio-4 top-k selection
+
+compressor_state
+  per-sequence partial-window state for decode when compression windows are
+  incomplete
+```
+
+Recommended AutoDeploy runtime extension:
+
+- Allow `SequenceInfo` and `CachedSequenceInterface` to carry named page tables
+  per resource group.
+- Keep all long-lived KV-like resources paged.
+- Avoid unpaged `[max_batch, max_seq, ...]` V4 caches.
+
+Reason: unpaged caches are not acceptable for 1M-context-capable models and can
+disable important block-reuse behavior.
+
+### Attention Kernel Roadmap
+
+Bring-up:
+
+1. BF16 correctness path for sparse attention.
+2. Ratio-0/SWA layers first.
+3. Ratio-128 compressed layers second.
+4. Ratio-4 indexer layers third.
+
+Production:
+
+1. Fuse Q RMSNorm + RoPE.
+2. Fuse KV RMSNorm + RoPE + cache insert.
+3. Fuse compressor pooling + RMSNorm + RoPE + cache insert.
+4. Quantize NoPE KV dims to FP8 E4M3 with E8M0 scales.
+5. Keep RoPE dims BF16 unless a validated quantized path is added.
+6. Add sparse attention over local window plus compressed/indexed entries.
+7. Add fused inverse RoPE + output quantization before output projection.
+8. Add optional FP4 indexer cache after FP8 path is stable.
+
+vLLM's PR provides a useful reference structure:
+
+- fused Q/K RMSNorm, RoPE, and KV insert
+- fused compressor quant/cache insert
+- fused indexer Q RoPE quant
+- fused inverse RoPE FP8 quant
+- sparse FlashMLA-style attention
+- optional FP4 indexer cache on newer hardware
+
+## CUDA Graph Plan
+
+Use AutoDeploy's `torch-cudagraph` backend.
+
+Recommended serving settings:
+
+```yaml
+compile_backend: torch-cudagraph
+
+cuda_graph_config:
+  batch_sizes: [1, 2, 4, 8, 16, 32, 64]
+
+transforms:
+  compile_model:
+    piecewise_enabled: true
+```
+
+Requirements:
+
+- Mark V4 sparse cached attention and V4 cache metadata prep as dynamic for
+  piecewise capture.
+- Capture static regions: RMSNorm, FP8 linears, shared expert, MoE post-router
+  matmuls where shape buckets are fixed, output projections.
+- Keep dynamic sparse/indexer/cache-update kernels graph-safe:
+  - no allocation during replay
+  - fixed output buffers
+  - fixed metadata tensor shapes per bucket
+  - deterministic workspace sizing
+- Use decode batch padding through existing CUDA graph batch sizes.
+- For mixed prefill/decode, rely on piecewise CUDA graph until the full dynamic
+  V4 metadata path is graph-safe.
+
+## Proposed AutoDeploy Config Direction
+
+Initial correctness config:
+
+```yaml
+model_kwargs:
+  skip_mtp: true
+  ad_rope_cache_len: 8192
+
+compile_backend: torch-cudagraph
+
+runtime:
+  enable_chunked_prefill: true
+
+cuda_graph_config:
+  batch_sizes: [1, 2, 4, 8, 16, 32, 64]
+
+transforms:
+  quantize_deepseek_v4_from_config:
+    enabled: true
+  compile_model:
+    piecewise_enabled: true
+  multi_stream_moe:
+    enabled: false
+```
+
+Production config knobs to benchmark:
+
+```yaml
+max_batch_size: 32 | 64 | 128
+max_seq_len: 8192 | 16384 | 32768
+tokens_per_block: 32 | 64 | 128
+expert_parallel_size: 8 | 16
+attention_dp: false initially
+multi_stream_moe: false initially, then benchmark
+multi_stream_v4_attention: false initially, then benchmark
+```
+
+Do not target 1M context first. The advertised maximum is an architectural
+capability, but production support should prove correctness and cache behavior
+at shorter contexts before scaling.
+
+## Implementation Milestones
+
+### Milestone 1: Checkpoint Classifier
+
+Deliverables:
+
+- A read-only checkpoint scanner that categorizes every tensor.
+- Counts by component and dtype.
+- Assertions:
+  - all routed expert weights are packed `I8`
+  - all routed expert scales are `F8_E8M0`
+  - all FP8 linears have paired `.scale`
+  - compressor weights are BF16
+  - `mtp.0.*` is either supported or explicitly skipped
+
+Exit criteria:
+
+- No unknown tensor families except explicitly waived keys.
+- Classification matches the tensor counts from the safetensors index.
+
+### Milestone 2: FineGrained FP8 Linear Loading
+
+Deliverables:
+
+- DeepSeek V4-specific `.scale` -> `weight_scale_inv` remap.
+- E8M0 scale handling helper.
+- FineGrained FP8 op support for attention and shared expert linears.
+
+Validation:
+
+- Pick one attention linear and one shared expert linear.
+- Dequantize using a reference E8M0 helper.
+- Compare AD op output against reference matmul.
+- Test both unsharded and TP-sharded shapes.
+
+### Milestone 3: Packed MXFP4 Expert Loader
+
+Deliverables:
+
+- Packed expert loader for `I8` weights.
+- Raw-byte E8M0 scale preservation.
+- Per-layer expert stacking.
+- EP-compatible expert partitioning.
+
+Validation:
+
+- Unpack/dequantize one `w1`, `w2`, and `w3` expert against a reference.
+- Compare one-token and multi-token expert outputs.
+- Verify no numeric conversion is applied to E8M0 scale bytes.
+
+### Milestone 4: V4 Router
+
+Deliverables:
+
+- Hash routing for first three layers using `tid2eid`.
+- Fused or canonical `sqrtsoftplus` top-k router.
+- Correct route normalization and scaling.
+
+Validation:
+
+- Compare hash-routed indices exactly.
+- Compare top-k indices and weights against reference.
+- Include bias path for non-hash layers.
+
+### Milestone 5: Fused V4 MoE
+
+Deliverables:
+
+- `torch_deepseek_v4_moe` canonical op.
+- Lowering to MXFP4 routed experts.
+- Shared expert FineGrained FP8 path.
+- Support for `swiglu_limit`.
+
+Validation:
+
+- Tiny-model MoE parity.
+- Full hidden-size single-layer MoE parity on a small token batch.
+- EP sharding parity across world sizes.
+- CUDA graph replay test.
+
+### Milestone 6: V4 Sparse Attention Source Op
+
+Deliverables:
+
+- Canonical sparse attention op or op region.
+- Reference implementation for export tests.
+- Existing modeling code converted away from opaque Python sparse loops where
+  needed.
+
+Validation:
+
+- Ratio-0/SWA correctness.
+- Ratio-128 compressed correctness.
+- Ratio-4 indexer correctness.
+- Chunked prefill equivalence.
+
+### Milestone 7: Paged V4 Cache
+
+Deliverables:
+
+- Named page tables or composite V4 cache handler.
+- SWA cache.
+- MHC cache.
+- Indexer cache.
+- Per-sequence compressor state.
+
+Validation:
+
+- Decode equivalence vs full prefill.
+- Chunked prefill equivalence.
+- Prefix reuse and partial reuse tests.
+- Long-context memory growth test.
+
+### Milestone 8: Production Attention Kernels
+
+Deliverables:
+
+- Fused qnorm/rope.
+- Fused kvnorm/rope/cache insert.
+- Fused compressor/cache insert.
+- Sparse attention kernel over local and compressed selected positions.
+- Optional FP4 indexer cache path.
+
+Validation:
+
+- Kernel unit tests for numerics.
+- End-to-end attention parity.
+- CUDA graph replay.
+- Nsight Systems/Compute sanity pass for launch count and occupancy.
+
+### Milestone 9: End-to-End Serving
+
+Deliverables:
+
+- AutoDeploy registry YAML.
+- `trtllm-serve` path.
+- CUDAGraph-enabled decode path.
+- Chunked prefill.
+
+Validation:
+
+- Reduced-layer run.
+- Full 43-layer run.
+- Deterministic prompt sanity tests.
+- Throughput and latency benchmark.
+- Regression test for checkpoint loading.
+
+## Testing Matrix
+
+### Unit Tests
+
+- Checkpoint key classification.
+- E8M0 upcast and raw-byte reinterpretation.
+- FP8 linear reference.
+- MXFP4 expert unpack/dequant reference.
+- Router hash and top-k paths.
+- `swiglu_limit` activation.
+- Shared expert FP8 path.
+- MTP skip behavior.
+
+### Graph Tests
+
+- Export with dynamic batch and sequence dimensions.
+- Transform matching for V4 quantization.
+- Transform matching for V4 MoE.
+- Transform matching for V4 sparse attention.
+- Shape propagation after each transform stage.
+
+### Runtime Tests
+
+- Single GPU reduced config.
+- Multi-GPU TP.
+- Expert parallel routed MoE.
+- Chunked prefill.
+- Decode with paged cache.
+- CUDA graph decode replay.
+- Piecewise CUDA graph mixed prefill/decode.
+
+### Performance Tests
+
+Metrics:
+
+- TTFT by input length.
+- TPOT by batch size.
+- Tokens/sec under concurrency.
+- GPU memory by context length.
+- Kernel launch count.
+- CUDA graph replay hit rate.
+- Expert load balance.
+- All-to-all overhead under EP.
+
+Initial comparison target:
+
+- vLLM's public DeepSeek V4 blog numbers on 16xH100 should be treated as an
+  external sanity target, not a guaranteed requirement.
+
+## Risk Register
+
+| Risk | Impact | Mitigation |
+| - | - | - |
+| Generic FP8 quantization captures routed experts | Incorrect weights or load failure | Add V4-specific quant reader/transform |
+| E8M0 scale numeric conversion | Severe accuracy loss | Use raw-byte view for MXFP4 scales |
+| `.scale` naming mismatch | Missing scales or all-ones scales | Add V4 load hook/remap |
+| Dense MoE fallback | Unusable performance | Make fused V4 MoE a release blocker |
+| Existing MLA cache path mismatch | Incorrect decode or poor memory behavior | Add V4 sparse attention cache resource |
+| Unpaged compressed caches | Memory blowup at long context | Use paged named cache resources |
+| CUDA graph dynamic metadata | Replay failure or eager fallback | Piecewise capture and preallocated metadata |
+| MTP checkpoint keys | Load warnings/failures | Explicitly skip until MTP support lands |
+| Compressor BF16 cost | Prefill bottleneck | Optimize after correctness with fused compressor kernel |
+
+## Open Questions
+
+1. Which production MoE backend should be first?
+   - Triton-kernels MXFP4 is closest to existing AD code.
+   - TRT-LLM/FlashInfer MXFP4 may be faster if layout conversion is available.
+   - DeepGEMM FP8xFP4 grouped GEMM may be best for Blackwell/Hopper depending
+     on availability.
+
+2. Should routed expert scales stay E8M0 bytes end-to-end?
+   - Preferred for MXFP4 kernels.
+   - FP32 upcast only for backends that explicitly require FP32 scales.
+
+3. Should the FP8 `.scale` tensors be renamed to `weight_scale_inv` or should
+   the FineGrained FP8 op accept `scale` directly?
+   - Rename is least invasive.
+   - Direct aliasing is cleaner for future HF checkpoints.
+
+4. What is the first supported context length?
+   - Recommendation: start with 8K or 16K.
+   - Scale after paged V4 cache and chunked prefill are proven.
+
+5. Should MTP be loaded later?
+   - Initial serving can omit MTP.
+   - MTP can be added after base model correctness and performance are stable.
+
+## Recommended First Patch Series
+
+1. Add DeepSeek V4 checkpoint classifier and tests.
+2. Add DeepSeek V4 quant config override.
+3. Add `.scale` -> `weight_scale_inv` load remap for FineGrained FP8.
+4. Add E8M0 helpers:
+   - upcast E8M0 to FP32
+   - reinterpret E8M0 as raw `uint8`
+5. Add packed MXFP4 expert loader and stacking.
+6. Add V4 router canonical op or fused router transform.
+7. Add `torch_deepseek_v4_moe` and lower to MXFP4 routed experts.
+8. Add V4 sparse attention canonical op.
+9. Add V4 paged cache resource handler.
+10. Add CUDA graph dynamic-op registration and piecewise capture support.
+
+This order keeps correctness and weight loading ahead of kernel performance
+work, while still setting up the final high-performance serving path.

--- a/deepseek_v4_branch_summary.md
+++ b/deepseek_v4_branch_summary.md
@@ -1,0 +1,239 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# DeepSeek V4 AutoDeploy Branch Summary
+
+Generated from branch `bala/dsv4` on 2026-04-24.
+
+## Branch Snapshot
+
+| Item | Value |
+| --- | --- |
+| Branch | `bala/dsv4` |
+| Compared against | `upstream/main` |
+| Merge base | `43cd23f5c9e2d63f982898702dfe9f4e9f6f5b2f` |
+| Local HEAD | `8fa8790e71` |
+| `origin/bala/dsv4` | `97ad658fbe` |
+| Local delta vs origin | `0` behind, `1` ahead |
+| Commits in branch | `17` |
+| Diff size | `47 files changed, 10677 insertions(+), 189 deletions(-)` |
+
+The latest local commit is the sharding IR commit. Everything below is based on
+the committed branch range `upstream/main..HEAD`.
+
+## Current Support Stage
+
+DeepSeek V4 AutoDeploy support is now in a code-complete bring-up state for the
+core model path. The branch contains model onboarding, checkpoint quantization
+classification, FP8 and MXFP4 loading/lowering support, DeepSeek V4 custom
+attention and MoE ops, cache resource integration, CUDA graph configuration,
+registry wiring, sharding IR, and focused unit/single-GPU tests.
+
+The next stage should be full-model integration validation: load the downloaded
+DeepSeek V4 Flash checkpoint, run the configured AutoDeploy path end to end,
+exercise CUDA graph capture, validate multi-rank sharding, and collect serving
+and performance results. The commits show extensive implementation and focused
+tests, but they do not by themselves establish completed full-checkpoint
+serving validation.
+
+## Added Capabilities
+
+### Model Onboarding And Registry
+
+- Added `DeepseekV4Config`, `DeepseekV4ForCausalLM`, and
+  `DeepseekV4AutoModelForCausalLMFactory` in
+  `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py`.
+- Registered the custom model through
+  `tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py` and
+  `examples/auto_deploy/model_registry/models.yaml`.
+- Added the deployment config
+  `examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml`.
+- The registry config uses:
+  - `runtime: trtllm`
+  - `model_factory: DeepseekV4AutoModelForCausalLM`
+  - `compile_backend: torch-cudagraph`
+  - `max_batch_size: 64`
+  - `max_seq_len: 8192`
+  - `max_num_tokens: 8192`
+  - `enable_chunked_prefill: true`
+  - `skip_mtp: true`
+  - CUDA graph batch sizes `[1, 2, 4, 8, 16, 32, 64]`
+
+### Checkpoint Quantization Support
+
+- Added DeepSeek V4 quantization metadata handling in
+  `tensorrt_llm/_torch/auto_deploy/models/deepseek_v4_quant.py`.
+- Introduced the branch-specific quant method
+  `deepseek_v4_fp8`, with checkpoint categories for fine-grained FP8 linear
+  tensors and packed MXFP4 expert tensors.
+- Added config-reader integration in
+  `tensorrt_llm/_torch/auto_deploy/models/quant_config_reader.py`.
+- Added E8M0 helper utilities in
+  `tensorrt_llm/_torch/auto_deploy/utils/e8m0.py`.
+- Extended FP8 dequant utilities in
+  `tensorrt_llm/_torch/auto_deploy/utils/fp8_dequant.py`.
+- Added support for DeepSeek V4 `wo_a` grouped fine-grained FP8 quantization in
+  `tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py`.
+- Added MXFP4 expert checkpoint loading and layout handling in
+  `tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_mxfp4.py`.
+
+### Attention And KV Cache
+
+- Added the DeepSeek V4 sparse attention source op in
+  `tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py`.
+- Added DeepSeek V4 attention microkernels in
+  `tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_kernels.py`.
+- Added masked sparse-attention index support.
+- Extended the AutoDeploy attention interface with DeepSeek V4 paged resources:
+  `DeepSeekV4PagedResourceHandler` and `DeepSeekV4CacheResourceDescriptor`.
+- The cache work covers named paged resources such as SWA, MHC, indexer, and
+  compressor state, while preserving paged-resource behavior instead of falling
+  back to large unpaged allocations.
+
+### Router And MoE
+
+- Added the DeepSeek V4 router op in
+  `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_router.py`.
+- Added the DeepSeek V4 source MoE op in
+  `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_moe.py`.
+- Extended MXFP4 MoE support in
+  `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py`.
+- Added the `lower_deepseek_v4_moe` transform in
+  `tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py`.
+- The model registry config enables:
+  - `lower_deepseek_v4_moe`
+  - `quantize_mxfp4_moe`
+  - `quantize_finegrained_fp8_linear_from_config`
+- The config keeps `multi_stream_moe` disabled for this bring-up path.
+
+### CUDA Graph Runtime Path
+
+- Added DeepSeek V4 CUDA graph configuration in the model registry config.
+- Extended `tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py`
+  and `tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py`.
+- The final config intentionally sets
+  `transforms.compile_model.piecewise_enabled: false`, so the current default
+  path is monolithic CUDA graph capture rather than piecewise prefill capture.
+
+### Sharding And Distributed IR
+
+- Added a sharding-aware DeepSeek V4 model IR file:
+  `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4_ir.py`.
+- Added DeepSeek V4 shardable-node support in
+  `tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py`,
+  including rules for:
+  - grouped `wo_a` FP8 quantized linear
+  - DeepSeek V4 sparse attention
+  - DeepSeek V4 MXFP4 MoE from routing
+- Added `dsv4_sharding_guide.md`, which documents the recommended first
+  distributed target:
+  - `world_size: 8`
+  - `tp: 8`
+  - `moe_ep: 8`
+  - `moe_tp: 1`
+  - `enable_attention_dp: false`
+- The guide positions expert parallelism over the expert dimension as the first
+  target, with `moe_tp > 1` deferred because packed MXFP4 block slicing requires
+  more careful kernel and loader work.
+
+### Demos, Tests, And Validation Assets
+
+- Added `examples/deepseek_v4_5layer_forward.py` as a focused forward/demo
+  harness.
+- Added unit and single-GPU coverage for:
+  - DeepSeek V4 modeling
+  - quant config classification
+  - E8M0 helpers
+  - FP8 linear handling
+  - MXFP4 loader
+  - router
+  - MoE lowering
+  - sparse attention and attention kernels
+  - paged cache resources
+  - piecewise CUDA graph behavior
+  - sparse attention sharding
+- Existing RoPE and MRoPE delta cache tests were adjusted for the new behavior.
+
+## Commit Inventory
+
+| Commit | Area | Summary |
+| --- | --- | --- |
+| `7b4019c82b` | Model | Onboarded the initial DeepSeek V4 AutoDeploy model. |
+| `c8618e15bb` | Quantization | Added E8M0 scale helpers. |
+| `9efb63a2a4` | Attention | Added DeepSeek V4 sparse attention source op. |
+| `da05c3a1bd` | MoE/router | Added DeepSeek V4 router op. |
+| `dbb376a092` | Runtime | Added DeepSeek V4 CUDA graph config. |
+| `86378f94ed` | Quantization | Classified DeepSeek V4 quant metadata. |
+| `c85d53ee80` | KV cache | Added DeepSeek V4 paged cache resources. |
+| `7fcc9f6111` | Attention | Supported masked sparse attention indices. |
+| `fdef542542` | Quantization/MoE | Added DeepSeek V4 MXFP4 expert loader. |
+| `08c13798de` | Attention | Added attention microkernels. |
+| `b3fc1e52b3` | Quantization | Supported DeepSeek V4 FP8 linear scales. |
+| `328fda50ab` | MoE | Added DeepSeek V4 MoE source op. |
+| `bb47b6ad83` | Demo/test | Added 5-layer forward demo. |
+| `58fc7f9c7b` | Quantization | Supported `wo_a` FP8 quantization. |
+| `530dc6eca2` | Integration | Wired DeepSeek V4 AutoDeploy integration. |
+| `97ad658fbe` | Runtime | Disabled piecewise CUDA graph by default. |
+| `8fa8790e71` | Sharding | Added DeepSeek V4 AutoDeploy sharding IR. |
+
+## Focused Test Files Added
+
+- `tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py`
+- `tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py`
+- `tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py`
+- `tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_mxfp4_loader.py`
+- `tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_router.py`
+- `tests/unittest/_torch/auto_deploy/unit/models/test_deepseek_v4_quant_config.py`
+- `tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py`
+- `tests/unittest/_torch/auto_deploy/unit/runtime/test_deepseek_v4_cache_resources.py`
+- `tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py`
+- `tests/unittest/_torch/auto_deploy/unit/utils/test_e8m0.py`
+- `tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_kernels.py`
+- `tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py`
+
+## Current Configuration Choices
+
+- MTP is skipped with `model_kwargs.skip_mtp: true`.
+- Chunked prefill is enabled.
+- CUDA graph support is selected through `compile_backend: torch-cudagraph`.
+- CUDA graph capture sizes are configured up to batch size 64.
+- Piecewise CUDA graph capture is disabled by default.
+- Fine-grained FP8 quantization from checkpoint config is enabled.
+- Fine-grained FP8 linear fusion is disabled in the current YAML.
+- MXFP4 MoE quantization/lowering is enabled.
+- Multi-stream MoE is disabled in the current YAML.
+
+## Recommended Next Validation Stage
+
+1. Run the focused unit tests added by the branch.
+2. Run the 5-layer forward demo against the downloaded checkpoint path:
+   `/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash`.
+3. Run full-checkpoint AutoDeploy graph construction using
+   `examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml`.
+4. Validate CUDA graph capture for the configured batch sizes.
+5. Validate full serving through `trtllm-serve` or the AutoDeploy model registry
+   flow.
+6. Validate multi-rank sharding, starting with the documented `tp=8, moe_ep=8,
+   moe_tp=1` layout.
+7. Collect correctness, memory, throughput, and latency data before declaring
+   production-ready DeepSeek V4 support.
+
+All commands for this workspace should be run through the requested wrapper:
+
+```bash
+bash -ic "f9 && <command>"
+```

--- a/deepseek_v4_sparse_attention_next_steps.md
+++ b/deepseek_v4_sparse_attention_next_steps.md
@@ -1,0 +1,670 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# DeepSeek V4 Sparse Attention Next Steps
+
+This note captures the current end-to-end AutoDeploy flow for
+`torch_deepseek_v4_sparse_attention`, the exact boundary between what works now
+and what is still missing, and a concrete plan for making DeepSeek V4 sparse
+attention serve correctly with chunked prefill, decode, paged caches, and CUDA
+graphs.
+
+The current branch state supports a full-context/prefill-style model forward
+through a DeepSeek V4 source attention op. It does not yet implement the cached
+decode attention path needed for normal token-by-token serving.
+
+## Current End-To-End Flow
+
+### 1. Model Registry And Compile Path
+
+The model registry config selects:
+
+```yaml
+runtime: trtllm
+model_factory: DeepseekV4AutoModelForCausalLM
+compile_backend: torch-cudagraph
+max_batch_size: 64
+max_seq_len: 8192
+max_num_tokens: 8192
+enable_chunked_prefill: true
+model_kwargs:
+  skip_mtp: true
+  ad_rope_cache_len: 8192
+```
+
+The same config enables quantization and MoE lowering, but it does not select a
+DeepSeek V4 cached attention backend. Default AutoDeploy cache insertion still
+targets standard `torch_attention` and standard `torch_mla` source ops.
+
+### 2. Model Forward Contract
+
+`DeepseekV4ForCausalLM.forward` requires both `input_ids` and `position_ids`.
+It embeds the full current token tensor, runs every layer, and returns logits for
+all positions.
+
+The model file explicitly documents the current scope:
+
+```text
+* prefill-only forward with mandatory position_ids
+* omits decode caches and MTP blocks from the exported path
+```
+
+This is the first important boundary: the model can export and run a
+full-context forward graph, but it is not yet a cache-aware incremental decode
+model.
+
+### 3. DeepSeek V4 Attention Forward
+
+`DeepseekV4Attention.forward` performs these steps:
+
+1. Build query states:
+   - `wq_a`
+   - `q_norm`
+   - `wq_b`
+   - per-head RMS normalization
+   - RoPE on the trailing `qk_rope_head_dim`
+
+2. Build high-resolution KV rows for the current forward tensor:
+   - `wkv`
+   - `kv_norm`
+   - RoPE on the trailing `qk_rope_head_dim`
+
+3. Build local-window indices:
+   - `_window_topk_idxs(window_size, batch_size, seq_len, device)`
+   - negative entries are padding/masked slots
+
+4. For compressed layers, build compressed KV rows from the current forward
+   tensor:
+   - `DeepseekV4Compressor.forward`
+   - `wkv`, `wgate`, APE, optional ratio-4 overlap transform
+   - softmax pooling
+   - RMSNorm
+   - compressed-position RoPE
+
+5. For compressed layers, append compressed rows:
+   - `_compress_topk_idxs(...)`
+   - concatenate local-window and compressed indices
+   - concatenate high-resolution KV and compressed KV rows
+
+6. Call the source attention op:
+
+```python
+torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+    q, kv, attn_sink, topk_idxs, softmax_scale
+)
+```
+
+7. Apply inverse RoPE to the attention output, then run the `wo_a`/`wo_b`
+   output projection path.
+
+### 4. Source Op Semantics
+
+The source op is defined as:
+
+```python
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_sparse_attention", mutates_args=())
+def torch_deepseek_v4_sparse_attention(
+    q,
+    kv,
+    attn_sink,
+    topk_idxs,
+    softmax_scale,
+    out=None,
+    enable_sharding=False,
+    layer_type="unknown",
+):
+    ...
+```
+
+Important properties:
+
+- `q` shape: `[batch, seq_len, num_heads, head_dim]`
+- `kv` shape: `[batch, kv_rows, head_dim]`
+- `attn_sink` shape: `[num_heads]`
+- `topk_idxs` shape: `[batch, seq_len, k_select]`
+- duplicate indices receive independent probability mass
+- negative indices are masked before softmax
+- the sink participates in softmax normalization but contributes no value vector
+- `mutates_args=()` means it does not write any cache
+- it has an optional `out=` contract for piecewise CUDA graph output injection
+
+The tests cover output shape/dtype, duplicate index semantics, negative masks,
+sink behavior, dynamic export, and the `out` buffer contract.
+
+### 5. Existing Kernel Building Blocks
+
+`deepseek_v4_kernels.py` contains reference-first semantic ops that look like
+building blocks for a production cached path:
+
+- `torch_deepseek_v4_q_rmsnorm_rope`
+- `torch_deepseek_v4_kv_rmsnorm_rope_cache_insert`
+- `torch_deepseek_v4_compressor_pool_norm_rope`
+- `torch_deepseek_v4_indexer_q_rope_quant`
+- `torch_deepseek_v4_inverse_rope_fp8_output_quant`
+- `torch_deepseek_v4_sparse_attention_microkernel`
+
+The most relevant one for decode is
+`torch_deepseek_v4_kv_rmsnorm_rope_cache_insert`, which mutates flat
+`nope_cache`, `rope_cache`, and `scale_cache` tensors using caller-supplied
+`cache_indices`. Its own docstring says the current flat index contract
+deliberately does not encode V4 paged-cache metadata.
+
+The microkernel op currently assembles:
+
+```text
+local window KV + compressed KV + local/compressed topk indices
+```
+
+and then calls the same source op. It is a useful correctness wrapper, not yet a
+paged-cache decode kernel.
+
+### 6. Current Sharding Support
+
+`DeepSeekV4SparseAttentionShardableNode` registers the source op as shardable.
+The current rule shards `attn_sink` across tensor-parallel heads when
+`enable_sharding` is set and `tp_size > 1`.
+
+This is useful for the full-context source op. A future cached op will need its
+own sharding rules for:
+
+- local head ranges
+- local `attn_sink`
+- local or replicated cache metadata
+- local slices of cache rows
+- any all-reduce or gather needed after `wo_b`
+
+## Existing Cache Resource Plumbing
+
+The branch adds named DeepSeek V4 resource names:
+
+```text
+swa
+mhc
+indexer
+compressor_state
+```
+
+The intended meanings are:
+
+| Resource | Intended role |
+| --- | --- |
+| `swa` | high-resolution sliding-window KV |
+| `mhc` | compressed KV entries for ratio-4 and ratio-128 layers |
+| `indexer` | compact indexer/top-k selection state |
+| `compressor_state` | per-sequence state for incomplete compression windows |
+
+`DeepSeekV4PagedResourceHandler` reports `is_paged=True`, registers named page
+table metadata, and allocates a local paged pool with shape:
+
+```text
+[num_pages, tokens_per_block, *token_shape]
+```
+
+`SequenceInfo.register_paged_resource_metadata(name, ...)` creates:
+
+```text
+<name>_cache_loc
+<name>_cu_num_pages
+<name>_last_page_len
+<name>_seq_len_with_cache
+```
+
+The tests verify:
+
+- V4 resources are paged, not unpaged fallback resources.
+- SWA and MHC can have different logical lengths and page counts.
+- ratio-128 compressed metadata uses fewer logical entries than token cache.
+- prefix/block reuse remains enabled.
+- `copy_on_partial_reuse` is disabled when non-KV-manager-owned paged resources
+  exist.
+
+This is necessary infrastructure, but it is not enough for decode by itself.
+
+## Why Decode Is Missing Today
+
+### 1. The Current Source Op Is Stateless
+
+The source op takes `q`, `kv`, `attn_sink`, and `topk_idxs`. It does not take any
+of:
+
+```text
+cache_loc
+cu_num_pages
+last_page_len
+seq_len_with_cache
+swa_cache
+mhc_cache
+indexer_cache
+compressor_state
+```
+
+It also declares `mutates_args=()`, so it cannot update cache state.
+
+During token-by-token decode, AutoDeploy normally passes only the new token
+through the model and relies on cached attention to read prior context. If the
+DeepSeek V4 source op sees only `seq_len == 1`, it only has the current token's
+KV rows and cannot attend to earlier tokens.
+
+### 2. Cache Insertion Cannot Find A DeepSeek V4 Backend
+
+The generic cache insertion transform resolves an `AttentionDescriptor` through
+`AttentionRegistry.get(self.config.backend)`. Existing registered backends
+target source ops such as:
+
+```text
+auto_deploy::torch_attention
+auto_deploy::torch_mla
+```
+
+There is no registered DeepSeek V4 sparse attention descriptor in the current
+branch. A repository search finds no:
+
+```text
+@AttentionRegistry.register("deepseek...")
+DeepSeek...Attention(AttentionDescriptor)
+```
+
+As a result, default `insert_cached_attention` and `insert_cached_mla_attention`
+do not rewrite `torch_deepseek_v4_sparse_attention` into a cached op.
+
+### 3. The Cached Op Name Exists Only As A Placeholder String
+
+`piecewise_utils.py` lists:
+
+```text
+auto_deploy::triton_deepseek_v4_sparse_attention_with_cache
+```
+
+as a dynamic DeepSeek V4 attention op, but there is no implementation of that
+custom op in the branch. That string is useful as a future compile partitioning
+hook, but it is not an executable decode path.
+
+### 4. Named Page Metadata Is Staged, But Not Advanced For Decode
+
+`SequenceInfo.nest_sequences(..., paged_resource_metadata=...)` can stage named
+page tables for `swa`, `mhc`, `indexer`, and `compressor_state`.
+
+However, the decode offset helpers currently update the standard page metadata
+path. They do not yet loop over all registered named resource metadata to
+advance:
+
+```text
+swa_cache_loc
+swa_cu_num_pages
+swa_last_page_len
+swa_seq_len_with_cache
+...
+```
+
+That means a production decode path needs either:
+
+1. fresh named page metadata supplied by the scheduler for every step, or
+2. extended `SequenceInfo` offset/adjust logic for named paged resources.
+
+### 5. Resource Layout Is Still Synthetic
+
+The cache resource tests intentionally use synthetic shapes such as:
+
+```python
+swa: token_shape=(2, 1, 8), dtype=torch.float16
+mhc: token_shape=(1, 8), dtype=torch.bfloat16
+indexer: token_shape=(1, 4), dtype=torch.float16
+compressor_state: token_shape=(4, 8), dtype=torch.bfloat16
+```
+
+Production DeepSeek V4 attention likely needs split or composite layouts,
+especially for FP8 cache insertion:
+
+```text
+NoPE cache: FP8 E4M3 rows
+RoPE cache: BF16/FP16 rows
+Scale cache: E8M0 or FP32 fallback rows
+```
+
+The existing `torch_deepseek_v4_kv_rmsnorm_rope_cache_insert` already uses this
+three-cache contract. The named resource abstraction needs to converge with
+that contract before the cached attention op can be production-real.
+
+### 6. Compression And Indexing Are Not Incremental
+
+Current full-context model code computes compressed KV from the full current
+`x` tensor. During decode, the compressor needs to update state incrementally.
+
+Missing semantics include:
+
+- how ratio-128 compressed entries are emitted when a compression block closes
+- how ratio-4 overlap state is preserved across step boundaries
+- how `compressor_state` stores incomplete windows
+- how `mhc_cache` appends new compressed rows
+- how the `indexer_cache` participates in top-k compressed row selection
+- how local-window and compressed indices are built from paged metadata
+
+Current `_compress_topk_idxs` is a full-context construction over rows already
+present in the current `kv` tensor. It is not a paged-cache lookup plan.
+
+## Required Implementation Pieces
+
+### Piece 1: DeepSeek V4 Cached Attention Descriptor
+
+Add an `AttentionDescriptor` implementation, for example:
+
+```python
+@AttentionRegistry.register("deepseek_v4_sparse")
+class DeepSeekV4SparseAttention(AttentionDescriptor):
+    ...
+```
+
+It should define:
+
+- `get_source_attention_op()` returning
+  `torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention`
+- `get_cached_attention_op()` returning the new cached op
+- `get_num_qkv_args()` for the source op contract
+- `get_standard_metadata_args()` for sequence metadata needed by the cached op
+- `get_cache_initializers()` returning DeepSeek V4 resource handlers
+- constants or node metadata for layer index, window size, compression ratio,
+  head dimensions, RoPE dimensions, cache dtypes, and FP8 block sizes
+
+The deployment YAML should explicitly select this backend for DeepSeek V4
+rather than relying on the default `trtllm` or `flashinfer_mla` attention cache
+backends.
+
+### Piece 2: Better Source Op Metadata
+
+The current source op signature does not carry enough information for a cache
+descriptor to allocate and lower correctly. Add explicit metadata to the source
+op or attach reliable node metadata during export.
+
+Recommended explicit arguments:
+
+```text
+layer_idx
+window_size
+compress_ratio
+max_compressed_len
+head_dim
+rope_dim
+num_heads
+fp8_block_size
+cache_dtype policy
+```
+
+This avoids fragile inference from fake tensor shapes and lets
+`get_cache_initializers()` make per-layer decisions.
+
+### Piece 3: Cached Op Contract
+
+Define a first reference op, then a Triton/CUDA implementation. A likely
+progression is:
+
+```text
+torch_deepseek_v4_sparse_attention_with_cache
+triton_deepseek_v4_sparse_attention_with_cache
+```
+
+The cached op should:
+
+1. accept current-token or current-chunk query/KV inputs
+2. accept standard sequence metadata
+3. accept named V4 page metadata
+4. accept V4 cache tensors
+5. update the cache tensors for new tokens/compressed rows
+6. gather the local-window and compressed rows needed for attention
+7. apply the sink-softmax sparse attention
+8. return attention output
+9. support an optional `out=` contract for piecewise CUDA graph integration
+
+Start with a pure Torch reference op even if it is slow. That gives
+AutoDeploy graph replacement, cache metadata, and correctness tests something
+solid to target before optimizing kernels.
+
+### Piece 4: Production Cache Layout
+
+Replace synthetic cache shapes with an explicit production layout.
+
+Open decisions:
+
+- Should `swa` be one composite resource or separate resources for NoPE, RoPE,
+  and scale?
+- Should `mhc` use the same FP8 split layout as `swa`?
+- Does `indexer` store FP8-quantized indexer keys, scales, or both?
+- Is `compressor_state` one per sequence or one per layer/sequence?
+- Does each layer own separate resources, or can compatible layers share a
+  manager/pool with per-layer offsets?
+
+The existing `DeepSeekV4CacheResourceDescriptor` supports one tensor per
+resource descriptor. If production needs multiple tensors per logical resource,
+add either:
+
+- a composite resource handler, or
+- separate stable resource names/suffixes for subresources.
+
+### Piece 5: Named Page Allocation And Reuse
+
+Decide how page IDs are assigned and reused for V4 resources.
+
+The tests manually build `PagedResourceSequenceMetadata`. Production needs a
+real source of these page assignments:
+
+- reuse KVCacheManager page assignments where possible, or
+- add a small V4 page allocator, or
+- derive deterministic per-slot pages for the first bring-up and disable
+  prefix-sharing for V4 side caches until correctness is established.
+
+The final design must define behavior for:
+
+- request admission
+- prefix reuse
+- partial reuse
+- page allocation
+- page free
+- cache compaction, if any
+- cuda graph padding slots
+- multi-rank consistency
+
+### Piece 6: Named Metadata Advancement
+
+Extend `SequenceInfo`/`CachedSequenceInterface` so registered named paged
+resources can advance during decode.
+
+Required behavior:
+
+- update each named `seq_len_with_cache`
+- update each named `last_page_len`
+- add pages when a named resource crosses its `tokens_per_block`
+- respect different logical-length divisors per resource
+- handle resources that do not advance every token, such as ratio-128 MHC
+- handle `compressor_state`, which is per-sequence state rather than ordinary
+  append-only token KV
+
+An alternative is requiring the scheduler to provide fresh named metadata every
+step. That may be simpler initially, but it has to be explicit and tested.
+
+### Piece 7: Incremental Compression Semantics
+
+Implement and test the decode update rules independently from attention.
+
+Suggested staged scope:
+
+1. Ratio-0 layers:
+   - update `swa`
+   - attend over local sliding window only
+
+2. Ratio-128 layers:
+   - accumulate compressor state
+   - emit one compressed row when a block closes
+   - append to `mhc`
+   - attend over SWA plus compressed rows
+
+3. Ratio-4 layers:
+   - implement overlap handling across step boundaries
+   - maintain `compressor_state`
+   - build/update indexer cache
+   - implement top-k compressed selection
+
+### Piece 8: CUDA Graph Integration
+
+The source op already has an `out=` contract. The cached op needs the same
+contract.
+
+For CUDA graph support:
+
+- decode-only should be capturable with static batch sizes
+- prefill/mixed batches may need piecewise mode because sparse/cache ops are
+  dynamic
+- `piecewise_utils.py` already anticipates a DSV4 cached op name, but the op
+  must actually exist
+- the DeepSeek V4 YAML currently sets `compile_model.piecewise_enabled: false`,
+  so mixed/prefill piecewise capture is not part of the current default path
+
+### Piece 9: Sharding Rules For Cached Attention
+
+Add shardable-node support for the cached op.
+
+The rule should validate and/or rewrite:
+
+- local head count
+- local `attn_sink`
+- local cache row layout
+- page metadata visibility across TP/EP ranks
+- output shape before grouped `wo_a`
+
+The current source-op sharding rule only shards `attn_sink`.
+
+## Suggested Milestones
+
+### Milestone A: Make The Gap Impossible To Miss
+
+- Add a test or config guard that fails clearly if DeepSeek V4 is used for
+  decode without a cached sparse attention backend.
+- Update the branch summary/config comments to say "prefill/full-forward only"
+  until cached decode lands.
+
+### Milestone B: Ratio-0 Cached Reference Path
+
+- Add `DeepSeekV4SparseAttention` descriptor.
+- Add `torch_deepseek_v4_sparse_attention_with_cache`.
+- Implement only SWA/local-window cache.
+- Prove:
+  - full prefill logits equal prefix prefill plus decode logits
+  - cache metadata is staged correctly
+  - CUDA graph decode capture works for fixed batch sizes
+
+### Milestone C: Ratio-128 Compressed Cache
+
+- Add incremental compressor state for ratio-128.
+- Append completed compressed rows to MHC.
+- Prove chunked prefill equivalence against full prefill.
+- Prove decode equivalence after a prefix.
+
+### Milestone D: Ratio-4 And Indexer Path
+
+- Add overlap compressor state.
+- Add indexer cache update.
+- Add top-k compressed-row selection.
+- Prove correctness on synthetic cases with forced top-k selections, then on
+  model-level tests.
+
+### Milestone E: Optimized Triton/CUDA Kernels
+
+- Replace the Torch reference cached op with Triton/CUDA kernels.
+- Keep the same op contract and tests.
+- Add performance counters for:
+  - local-window gather
+  - compressed gather
+  - sink softmax
+  - cache insert bandwidth
+  - FP8 dequant/scale overhead
+
+### Milestone F: Full Serving Validation
+
+- Run full-checkpoint AutoDeploy load.
+- Run prefill-only correctness first.
+- Run chunked prefill.
+- Run decode generation.
+- Run CUDA graph decode.
+- Run multi-rank sharding.
+- Benchmark serving throughput/latency and memory.
+
+## Test Plan
+
+### Unit Tests
+
+- Descriptor registration:
+  - `AttentionRegistry.has("deepseek_v4_sparse")`
+  - source op maps to cached op
+  - cache initializers include expected V4 resources
+
+- Cache metadata:
+  - named page tables for all resources
+  - different logical divisors
+  - decode advancement
+  - ratio-specific page creation
+  - prefix reuse behavior
+
+- Cached op reference:
+  - ratio-0 local window
+  - ratio-128 compressed rows
+  - ratio-4 overlap
+  - masked and duplicate indices
+  - sink probability mass
+  - `out=` buffer contract
+
+### Model-Level Tests
+
+- Full prefill vs chunked prefill logits.
+- Full prefill vs prefix prefill plus decode logits.
+- Layer subsets:
+  - all ratio-0
+  - ratio-128 only
+  - ratio-4 only
+  - mixed ratios matching the real config pattern
+
+### Runtime Tests
+
+- AutoDeploy transform replaces source op with cached op when backend is
+  `deepseek_v4_sparse`.
+- `initialize_cache` creates all expected resources.
+- Decode CUDA graph capture works for configured batch sizes.
+- Piecewise path handles DSV4 dynamic op if enabled.
+
+### Integration Tests
+
+- Run the downloaded checkpoint:
+
+```text
+/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash
+```
+
+- Serve with the DeepSeek V4 registry config.
+- Compare generated tokens/logits against a trusted reference for short
+  prompts.
+- Stress long prompts, chunked prefill, and decode continuation.
+
+All commands in this workspace should be run as:
+
+```bash
+bash -ic "f9 && <command>"
+```
+
+## Bottom Line
+
+The current branch has a real DeepSeek V4 sparse attention source op and can run
+that op in the exported AutoDeploy forward graph. The missing work is the
+cache-aware decode path: descriptor, cached op, production cache layouts,
+metadata advancement, incremental compression/indexing, sharding for the cached
+op, and CUDA graph validation.

--- a/dsv4_sharding_guide.md
+++ b/dsv4_sharding_guide.md
@@ -1,0 +1,304 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# DeepSeek V4 AutoDeploy Sharding Guide
+
+This guide describes the recommended sharding design for DeepSeek V4 in
+AutoDeploy. It is based on the current AutoDeploy DeepSeek V4 model, the
+DeepSeek V4 custom ops, the dumped graphs in `dsv4-graphs/`, and the vLLM
+DeepSeek V4 reference PR:
+
+```text
+https://github.com/vllm-project/vllm/pull/40760
+```
+
+The main recommendation is to make DeepSeek V4 sharding explicit in the model
+IR and in a small number of DeepSeek V4-specific shardable ops. Avoid relying on
+late graph heuristics for the MLA shapes, grouped output projection, and
+pre-routed MXFP4 MoE.
+
+## Current State
+
+The current DeepSeek V4 AutoDeploy path has the main pieces required for a
+single-rank graph:
+
+- `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py`
+  emits the prefill model.
+- `torch_deepseek_v4_sparse_attention` implements the source sparse attention
+  contract.
+- `torch_deepseek_v4_router` implements DeepSeek V4 routing, including hash
+  layers.
+- `torch_deepseek_v4_moe` and
+  `triton_deepseek_v4_mxfp4_moe_from_routing` cover the routed expert path.
+- `lower_deepseek_v4_moe` lowers the source MoE into router, MXFP4 routed MoE,
+  and shared FP8 expert linears.
+- `deepseek_v4_quant.py` and the quantization transform identify DeepSeek V4
+  mixed FP8/MXFP4 checkpoint tensors.
+
+The dumped graphs show the gap. After `apply_sharding_hints`, the graph still
+contains full DeepSeek V4 dimensions:
+
+- attention uses full `64` heads;
+- `wo_a` uses all `8` output groups;
+- `triton_deepseek_v4_mxfp4_moe_from_routing` owns all `256` routed experts;
+- the DeepSeek V4 sparse attention, grouped `wo_a`, and pre-routed MXFP4 MoE
+  ops are not registered as shardable nodes.
+
+The generic sharding pass already supports normal linears, fine-grained FP8
+linears, NVFP4 linears, `auto_deploy.view`, `auto_deploy.all_reduce`, and some
+MoE forms. DeepSeek V4 needs a thin layer on top of that machinery rather than a
+separate distributed system.
+
+## Recommended Parallel Layout
+
+Use tensor parallelism for dense attention and expert parallelism for routed
+experts. The first production target should keep the two groups aligned:
+
+```yaml
+world_size: 8
+transforms:
+  apply_sharding_hints:
+    enabled: true
+    dist_mapping:
+      tp: 8
+      moe_ep: 8
+      moe_tp: 1
+      moe_cluster: 1
+    enable_attention_dp: false
+```
+
+This matches the clean shape used by the vLLM DeepSeek V4 implementation:
+attention heads/groups are local to each tensor-parallel rank, routed experts
+are partitioned across the same ranks, and the partial hidden output is
+all-reduced.
+
+Keep `moe_tp > 1` out of the first implementation. The routed experts use
+packed MXFP4 blocks and E8M0 scales, so intermediate-dimension tensor
+parallelism requires careful block-aligned slicing in the kernel and loader.
+Expert parallelism over the expert dimension is much simpler and should be the
+first target.
+
+## Model IR Strategy
+
+Prefer a DeepSeek V4 sharding-aware model file, for example
+`modeling_deepseek_v4_sharding_ir.py`, over post-export pattern surgery. The
+existing `modeling_*_ir.py` files show the local pattern: emit standard
+AutoDeploy custom ops with sharding hints, use `auto_deploy.view` for shape
+changes that depend on parallel dimensions, and let `apply_sharding_hints`
+materialize local weights and collectives.
+
+DeepSeek V4 should follow that pattern for:
+
+- MLA query and output projections;
+- local-head sparse attention;
+- grouped `wo_a`;
+- shared expert FP8 linears;
+- routed MXFP4 expert tensors.
+
+Plain `aten.view` is fine for rank-local reshapes whose dimensions are already
+local. Any reshape that encodes `num_heads`, `o_groups`, or a sharded hidden
+dimension should use `auto_deploy.view` so the sharding pass can rewrite the
+shape safely.
+
+## Attention Sharding
+
+Shard attention by head and output group:
+
+| Component | Sharding |
+| --- | --- |
+| `wq_a` | replicated |
+| `wq_b` | column/head-sharded |
+| `q_norm`, RoPE | local heads |
+| `wkv` | replicated |
+| compressor | replicated |
+| indexer | replicated |
+| `attn_sink` | sliced by local head range |
+| sparse attention | local heads, no collective |
+| inverse RoPE | local heads |
+| `wo_a` | group-sharded |
+| `wo_b` | row-sharded, followed by all-reduce |
+
+This preserves the DeepSeek V4 dataflow: compressed KV is shared, while each
+rank computes only its local query heads and local output groups.
+
+The initial constraints should be explicit:
+
+```text
+num_heads % tp_size == 0
+o_groups % tp_size == 0
+```
+
+For the current DeepSeek V4 Flash shape, `num_heads = 64` and `o_groups = 8`,
+so `tp_size = 8` is the natural first target. Larger TP values need a different
+`wo_a` strategy because there are fewer output groups than ranks.
+
+### Required Attention Shardable Ops
+
+Add a shardable rule for `torch_deepseek_v4_sparse_attention` that validates
+local head inputs and slices head-owned parameters such as `attn_sink`. The op
+itself should not insert a collective; the collective belongs after the
+row-sharded `wo_b`.
+
+Add a shardable rule for
+`torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear`. It should
+split by output group, not by an arbitrary flattened row range. For each rank it
+should produce:
+
+```text
+input:  [batch, sequence, local_o_groups, group_hidden]
+weight: [local_o_groups * o_lora_rank, group_hidden]
+scale:  matching local output rows
+output: [batch, sequence, local_o_groups, o_lora_rank]
+```
+
+Then flatten the local groups and pass the result to row-sharded `wo_b`.
+
+## MoE Sharding
+
+Keep the router replicated. It is cheap, and its output is a global expert id
+contract used by both normal and hash-routed layers.
+
+Shard routed expert tensors over `moe_ep_size`:
+
+- `gate_up_blocks`;
+- `gate_up_scales`;
+- `down_blocks`;
+- `down_scales`;
+- expert biases, when present.
+
+Use the same contiguous expert partitioning as
+`expert_parallel_slice` in
+`tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_mxfp4.py`.
+The first implementation can require:
+
+```text
+n_routed_experts % moe_ep_size == 0
+```
+
+The DeepSeek V4 Flash shape has `256` routed experts, so this is fine for
+common sizes such as `2`, `4`, and `8`.
+
+### Required Routed MoE Shardable Op
+
+Add a DeepSeek V4-specific shardable rule for
+`triton_deepseek_v4_mxfp4_moe_from_routing`.
+
+The rule should:
+
+1. Slice all routed expert tensors along expert dimension `0`.
+2. Convert global selected expert ids to local expert ids for experts owned by
+   this rank.
+3. Mask or zero routing weights for experts not owned by this rank.
+4. Run the local MXFP4 MoE op.
+5. All-reduce the local partial routed output across the MoE parallel group.
+
+This mirrors the existing idea in generic MoE sharding, but it must be applied
+to the precomputed-routing DeepSeek V4 op. The current helper inside
+`mxfp4_moe.py` computes token grouping from `selected_experts`, so the selected
+expert ids must be localized before the local kernel sees them.
+
+### Shared Expert Sharding
+
+The shared expert should be tensor-parallel like a normal SwiGLU MLP:
+
+| Component | Sharding |
+| --- | --- |
+| shared `w1` | column-sharded |
+| shared `w3` | column-sharded |
+| activation | local |
+| shared `w2` | row-sharded |
+
+The cleanest collective placement is one all-reduce after adding the local
+routed expert output and the local shared expert output. This requires the first
+implementation to keep `tp` and `moe_ep` aligned. If future configs split those
+groups differently, the collectives need to become group-specific.
+
+## Weight Loading
+
+Sharding should happen before weight loading. That lets load hooks allocate and
+load only local expert tensors.
+
+For routed MXFP4 experts, prefer passing local `expert_indices` into
+`load_deepseek_v4_mxfp4_experts` instead of loading all `256` experts and
+slicing afterward. Load-all-then-slice is acceptable for bring-up tests, but it
+defeats one of the main memory benefits of expert parallelism.
+
+For FP8 linears, reuse the existing fine-grained FP8 scale sharding. DeepSeek V4
+checkpoint aliases `.scale` to `weight_scale_inv`, and the E8M0 scale bytes must
+continue to be handled by the DeepSeek V4 quantization path rather than generic
+floating-point conversion.
+
+## Transform Order
+
+The preferred order is:
+
+```text
+export
+quantize DeepSeek V4 FP8/MXFP4
+lower DeepSeek V4 MoE
+apply sharding hints
+strip sharding hints
+load weights
+```
+
+This preserves the current lowering structure while giving the sharding pass
+the final ops it needs to slice: grouped `wo_a`, shared FP8 linears, sparse
+attention, and pre-routed MXFP4 MoE.
+
+## Validation Checklist
+
+Add graph-level tests for `tp_size = 2`, `4`, and `8` with small synthetic
+configs where possible:
+
+- `wq_b` weights and FP8 scales are sharded by output/head dimension.
+- head views are rewritten to local `num_heads / tp_size`.
+- `attn_sink` is local.
+- sparse attention consumes local query heads.
+- grouped `wo_a` owns local output groups and local scale rows.
+- `wo_b` is row-sharded and followed by an all-reduce.
+- routed MXFP4 tensors have `num_experts / moe_ep_size` experts locally.
+- global expert ids are localized or masked before the MXFP4 op.
+- shared expert `w1`, `w3`, and `w2` are sharded.
+- the initial `tp == moe_ep` MoE path has a single final all-reduce after
+  combining routed and shared outputs.
+
+Add numeric tests that compare unsharded and sharded execution for one small
+DeepSeek V4 layer. These tests should cover both ordinary routed layers and hash
+layers, because hash routing bypasses top-k selection but still produces global
+expert ids.
+
+Add loader tests for local expert slices. A minimal case with `4` experts and
+`moe_ep_size = 2` should prove that rank `0` receives experts `[0, 1]` and rank
+`1` receives experts `[2, 3]`, with MXFP4 blocks and E8M0 scales kept in the
+checkpoint-native layout.
+
+## Open Constraints
+
+- `tp_size` must divide `num_heads`.
+- The first implementation should require `tp_size` to divide `o_groups`.
+- The first implementation should require `moe_ep_size` to divide
+  `n_routed_experts`.
+- `moe_tp > 1` should wait until the MXFP4 kernel and loader support
+  block-aligned intermediate-dimension slicing.
+- Attention DP should stay disabled for this path. DeepSeek V4 attention is
+  naturally head-parallel, and enabling attention DP would skip the dense
+  sharding that this model needs.
+
+With these constraints, DeepSeek V4 sharding stays close to the existing
+AutoDeploy sharding IR design: model code declares the semantic parallel axes,
+DeepSeek V4-specific shardable nodes handle the few unusual ops, and the generic
+pass still owns weight slicing, local shape rewrites, and collectives.

--- a/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
@@ -26,6 +26,8 @@ model_kwargs:
 cuda_graph_config:
   batch_sizes: [1, 2, 4, 8, 16, 32, 64]
 transforms:
+  insert_cached_attention:
+    backend: deepseek_v4_sparse
   export_to_gm:
     num_moe_experts_for_export: 2
   quantize_finegrained_fp8_linear_from_config:

--- a/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
@@ -15,6 +15,7 @@
 
 runtime: trtllm
 model_factory: DeepseekV4AutoModelForCausalLM
+attn_backend: deepseek_v4_sparse
 compile_backend: torch-cudagraph
 max_batch_size: 64
 max_seq_len: 8192

--- a/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
@@ -26,6 +26,19 @@ model_kwargs:
 cuda_graph_config:
   batch_sizes: [1, 2, 4, 8, 16, 32, 64]
 transforms:
+  detect_sharding:
+    enabled: false
+  sharding_transform_executor:
+    enabled: false
+  apply_sharding_hints:
+    enabled: true
+    dist_mapping:
+      tp: 8
+      moe_ep: 8
+      moe_tp: 1
+      moe_cluster: 1
+    enable_attention_dp: false
+    shard_layers: ["mla", "moe"]
   insert_cached_attention:
     backend: deepseek_v4_sparse
   export_to_gm:

--- a/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
@@ -14,14 +14,28 @@
 # limitations under the License.
 
 runtime: trtllm
+model_factory: DeepseekV4AutoModelForCausalLM
 compile_backend: torch-cudagraph
 max_batch_size: 64
 max_seq_len: 8192
 max_num_tokens: 8192
 enable_chunked_prefill: true
+model_kwargs:
+  skip_mtp: true
+  ad_rope_cache_len: 8192
 cuda_graph_config:
   batch_sizes: [1, 2, 4, 8, 16, 32, 64]
 transforms:
+  export_to_gm:
+    num_moe_experts_for_export: 2
+  quantize_finegrained_fp8_linear_from_config:
+    enabled: true
+  fuse_finegrained_fp8_linear:
+    enabled: false
+  lower_deepseek_v4_moe:
+    stage: pattern_matcher
+  quantize_mxfp4_moe:
+    enabled: true
   compile_model:
     piecewise_enabled: true
   multi_stream_moe:

--- a/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
@@ -37,6 +37,6 @@ transforms:
   quantize_mxfp4_moe:
     enabled: true
   compile_model:
-    piecewise_enabled: true
+    piecewise_enabled: false
   multi_stream_moe:
     enabled: false

--- a/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+runtime: trtllm
+compile_backend: torch-cudagraph
+max_batch_size: 64
+max_seq_len: 8192
+max_num_tokens: 8192
+enable_chunked_prefill: true
+cuda_graph_config:
+  batch_sizes: [1, 2, 4, 8, 16, 32, 64]
+transforms:
+  compile_model:
+    piecewise_enabled: true
+  multi_stream_moe:
+    enabled: false

--- a/examples/auto_deploy/model_registry/configs/deepseek_v4_flash_5layer_validation.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek_v4_flash_5layer_validation.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Stack this fragment after deepseek_v4_flash.yaml for reduced functional validation only.
+# It keeps production DeepSeek V4 defaults untouched while avoiding opportunistic KV-cache
+# growth that can hide the real graph/runtime blocker behind validation-only OOMs.
+max_batch_size: 1
+max_seq_len: 256
+max_num_tokens: 512
+attn_backend: deepseek_v4_sparse
+cuda_graph_config:
+  max_batch_size: 1
+  batch_sizes: [1]
+kv_cache_config:
+  max_tokens: 512
+  free_gpu_memory_fraction: 0.0
+model_kwargs:
+  num_hidden_layers: 5
+transforms:
+  compile_model:
+    piecewise_enabled: false

--- a/examples/auto_deploy/model_registry/configs/functional_single_request_cuda_graph.yaml
+++ b/examples/auto_deploy/model_registry/configs/functional_single_request_cuda_graph.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Functional build_and_run_ad gates use a prompt batch of 1. Keep dashboard/perf configs free to
+# capture larger batches, and stack this fragment last for single-request validation runs.
+max_batch_size: 1
+cuda_graph_config:
+  max_batch_size: 1
+  batch_sizes: [1]

--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -185,6 +185,8 @@ models:
   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'deepseek-r1.yaml']
 - name: deepseek-ai/DeepSeek-R1-0528
   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'deepseek-r1.yaml']
+- name: deepseek-ai/DeepSeek-V4-Flash
+  yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'deepseek_v4_flash.yaml']
 - name: deepseek-ai/DeepSeek-Coder-V2-Instruct
   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml']
 - name: Qwen/Qwen3-VL-8B-Instruct

--- a/examples/deepseek_v4_5layer_forward.py
+++ b/examples/deepseek_v4_5layer_forward.py
@@ -1,0 +1,580 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run a truncated DeepSeek V4 Flash reference model with real quantized weights.
+
+The DeepSeek V4 Flash checkpoint ships an ``inference/model.py`` reference that
+expects TileLang kernels for FP8/FP4 matmuls, sparse attention, and HC mixing.
+This script imports that checkpoint model and replaces those kernel entry points
+with eager PyTorch emulation so a small, 5-layer model can be loaded directly
+from the original safetensor shards and run through ``forward``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import types
+from collections import defaultdict
+from collections.abc import Iterator
+from contextlib import contextmanager
+from importlib import util
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+from torch import nn
+
+_DEFAULT_CHECKPOINT_DIR = Path(
+    "/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/"
+    "bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash"
+)
+
+_FP4_BOUNDS = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0])
+_FP4_VALUES = torch.tensor(
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0]
+)
+
+
+@contextmanager
+def _torch_defaults(dtype: torch.dtype, device: torch.device) -> Iterator[None]:
+    old_dtype = torch.get_default_dtype()
+    old_device = torch.get_default_device()
+    torch.set_default_dtype(dtype)
+    torch.set_default_device(device)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(old_dtype)
+        torch.set_default_device(old_device)
+
+
+def _missing_kernel(*args, **kwargs):
+    raise RuntimeError("DeepSeek V4 kernel stub was called before eager emulation was installed.")
+
+
+def _import_checkpoint_model(checkpoint_dir: Path):
+    inference_dir = checkpoint_dir / "inference"
+    model_path = inference_dir / "model.py"
+    if not model_path.is_file():
+        raise FileNotFoundError(f"DeepSeek V4 reference model not found: {model_path}")
+
+    kernel_stub = types.ModuleType("kernel")
+    for name in (
+        "act_quant",
+        "fp4_act_quant",
+        "fp8_gemm",
+        "fp4_gemm",
+        "sparse_attn",
+        "hc_split_sinkhorn",
+    ):
+        setattr(kernel_stub, name, _missing_kernel)
+
+    old_kernel = sys.modules.get("kernel")
+    sys.modules["kernel"] = kernel_stub
+    sys.path.insert(0, str(inference_dir))
+    try:
+        spec = util.spec_from_file_location("deepseek_v4_checkpoint_model", model_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not import {model_path}")
+        module = util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(inference_dir))
+        if old_kernel is None:
+            sys.modules.pop("kernel", None)
+        else:
+            sys.modules["kernel"] = old_kernel
+    return module
+
+
+def _maybe_e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if e8m0_dtype is not None and scale.dtype == e8m0_dtype:
+        fp32_bits = scale.view(torch.uint8).to(torch.int32) << 23
+        return fp32_bits.view(torch.float32)
+    return scale.to(torch.float32)
+
+
+def _round_up_power_of_two(x: torch.Tensor) -> torch.Tensor:
+    return torch.pow(2.0, torch.ceil(torch.log2(x)))
+
+
+def _fake_quant_dequant_fp8_activation(
+    x: torch.Tensor,
+    block_size: int,
+    scale_fmt: str | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if x.shape[-1] % block_size != 0:
+        raise ValueError(f"activation K={x.shape[-1]} must be divisible by block_size={block_size}")
+
+    x_shape = x.shape
+    x_blocks = (
+        x.contiguous().view(-1, x.shape[-1]).float().view(-1, x.shape[-1] // block_size, block_size)
+    )
+    amax = torch.clamp(x_blocks.abs().amax(dim=-1, keepdim=True), min=1e-4)
+    if scale_fmt is None:
+        scale = amax / 448.0
+    else:
+        scale = _round_up_power_of_two(amax / 448.0)
+
+    q = torch.clamp(x_blocks / scale, min=-448.0, max=448.0).to(torch.float8_e4m3fn)
+    dequant = (q.to(torch.float32) * scale).view(*x_shape)
+    return dequant.to(x.dtype), scale.squeeze(-1).view(*x_shape[:-1], x_shape[-1] // block_size)
+
+
+def _emulated_act_quant(
+    x: torch.Tensor,
+    block_size: int = 128,
+    scale_fmt: str | None = None,
+    scale_dtype: torch.dtype = torch.float32,
+    inplace: bool = False,
+):
+    del scale_dtype
+    dequant, scale = _fake_quant_dequant_fp8_activation(x, block_size, scale_fmt)
+    if inplace:
+        x.copy_(dequant)
+        return x
+    q = torch.clamp(
+        x.contiguous().view(-1, x.shape[-1]).float().view(-1, x.shape[-1] // block_size, block_size)
+        / scale.view(-1, x.shape[-1] // block_size, 1),
+        min=-448.0,
+        max=448.0,
+    ).to(torch.float8_e4m3fn)
+    return q.view(*x.shape), scale
+
+
+def _cast_to_fp4_indices(x: torch.Tensor) -> torch.Tensor:
+    bounds = _FP4_BOUNDS.to(device=x.device)
+    mask = torch.tensor([0, 1, 0, 1, 0, 1, 0], dtype=torch.bool, device=x.device)
+    x_abs = x.abs()
+    ordinal = torch.searchsorted(bounds, x_abs, out_int32=True).to(torch.uint8)
+    round_up = (x_abs.unsqueeze(-1) == bounds).logical_and(mask).any(dim=-1).to(torch.uint8)
+    sign = (x < 0).to(torch.uint8) << 3
+    return sign + ordinal + round_up
+
+
+def _fake_quant_dequant_fp4_activation(
+    x: torch.Tensor, block_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if x.shape[-1] % block_size != 0:
+        raise ValueError(f"activation K={x.shape[-1]} must be divisible by block_size={block_size}")
+
+    x_shape = x.shape
+    x_blocks = (
+        x.contiguous().view(-1, x.shape[-1]).float().view(-1, x.shape[-1] // block_size, block_size)
+    )
+    amax = torch.clamp(x_blocks.abs().amax(dim=-1, keepdim=True), min=6.0 * (2.0**-126))
+    scale = _round_up_power_of_two(amax / 6.0)
+    indices = _cast_to_fp4_indices(torch.clamp(x_blocks / scale, min=-6.0, max=6.0))
+    values = _FP4_VALUES.to(device=x.device)[indices.long()]
+    return (values * scale).view(*x_shape).to(x.dtype), scale.squeeze(-1).view(
+        *x_shape[:-1], x_shape[-1] // block_size
+    )
+
+
+def _emulated_fp4_act_quant(x: torch.Tensor, block_size: int = 32, inplace: bool = False):
+    dequant, scale = _fake_quant_dequant_fp4_activation(x, block_size)
+    if inplace:
+        x.copy_(dequant)
+        return x
+
+    indices = _cast_to_fp4_indices(
+        x.contiguous().view(-1, x.shape[-1]).float().view(-1, x.shape[-1] // block_size, block_size)
+        / scale.view(-1, x.shape[-1] // block_size, 1)
+    ).view(*x.shape)
+    packed = (indices[..., 1::2] << 4) | indices[..., 0::2]
+    return packed.contiguous(), scale
+
+
+def _dequant_fp8_weight(
+    weight: torch.Tensor, scale: torch.Tensor, dtype: torch.dtype
+) -> torch.Tensor:
+    rows, cols = weight.shape
+    scale_fp32 = _maybe_e8m0_to_fp32(scale)
+    scale_rows, scale_cols = scale_fp32.shape
+    block_rows = math.ceil(rows / scale_rows)
+    block_cols = math.ceil(cols / scale_cols)
+    expanded_scale = scale_fp32.repeat_interleave(block_rows, dim=0).repeat_interleave(
+        block_cols, dim=1
+    )
+    return (weight.to(torch.float32) * expanded_scale[:rows, :cols]).to(dtype)
+
+
+def _dequant_fp4_weight(
+    weight: torch.Tensor, scale: torch.Tensor, dtype: torch.dtype
+) -> torch.Tensor:
+    raw = weight.view(torch.uint8)
+    rows, packed_cols = raw.shape
+    cols = packed_cols * 2
+    low = raw & 0x0F
+    high = (raw >> 4) & 0x0F
+    indices = torch.empty(rows, cols, dtype=torch.long, device=raw.device)
+    indices[..., 0::2] = low.long()
+    indices[..., 1::2] = high.long()
+    values = _FP4_VALUES.to(device=raw.device)[indices]
+
+    scale_fp32 = _maybe_e8m0_to_fp32(scale)
+    if scale_fp32.shape != (rows, cols // 32):
+        raise ValueError(
+            f"FP4 scale shape {tuple(scale_fp32.shape)} does not match packed weight "
+            f"shape {tuple(raw.shape)}; expected {(rows, cols // 32)}"
+        )
+    expanded_scale = scale_fp32.repeat_interleave(32, dim=1)[:, :cols]
+    return (values * expanded_scale).to(dtype)
+
+
+def _linear_compute_dtype(x: torch.Tensor) -> torch.dtype:
+    if x.dtype in (torch.float16, torch.bfloat16):
+        return x.dtype
+    return torch.bfloat16
+
+
+def _emulated_linear(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
+) -> torch.Tensor:
+    fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+    scale = getattr(weight, "scale", None)
+    if weight.dtype == torch.float8_e4m3fn:
+        if scale is None:
+            raise RuntimeError("FP8 weight is missing its per-block .scale tensor.")
+        compute_dtype = _linear_compute_dtype(x)
+        x_dequant, _ = _fake_quant_dequant_fp8_activation(x, 128, "ue8m0")
+        weight_dequant = _dequant_fp8_weight(weight, scale, compute_dtype)
+        out = F.linear(x_dequant.to(compute_dtype), weight_dequant, bias)
+        return out.to(x.dtype)
+
+    if fp4_dtype is not None and weight.dtype == fp4_dtype:
+        if scale is None:
+            raise RuntimeError("FP4 weight is missing its per-block .scale tensor.")
+        compute_dtype = _linear_compute_dtype(x)
+        x_dequant, _ = _fake_quant_dequant_fp8_activation(x, 128, "ue8m0")
+        weight_dequant = _dequant_fp4_weight(weight, scale, compute_dtype)
+        out = F.linear(x_dequant.to(compute_dtype), weight_dequant, bias)
+        return out.to(x.dtype)
+
+    return F.linear(x, weight, bias)
+
+
+def _emulated_grouped_wo_a(o: torch.Tensor, wo_a: nn.Module) -> torch.Tensor:
+    scale = getattr(wo_a.weight, "scale", None)
+    if wo_a.weight.dtype != torch.float8_e4m3fn or scale is None:
+        weight = wo_a.weight.view(o.shape[-2], -1, o.shape[-1])
+        return torch.einsum("bsgd,grd->bsgr", o, weight)
+
+    compute_dtype = _linear_compute_dtype(o)
+    o_dequant, _ = _fake_quant_dequant_fp8_activation(o, 128, "ue8m0")
+    weight_dequant = _dequant_fp8_weight(wo_a.weight, scale, compute_dtype)
+    weight = weight_dequant.view(o.shape[-2], -1, o.shape[-1])
+    return torch.einsum("bsgd,grd->bsgr", o_dequant.to(compute_dtype), weight).to(o.dtype)
+
+
+def _emulated_sparse_attn(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    batch_size, seq_len, _, head_dim = q.shape
+    gather_idxs = topk_idxs.to(torch.long).clamp(min=0)
+    gather = gather_idxs.unsqueeze(-1).expand(-1, -1, -1, head_dim)
+    selected_kv = torch.gather(kv.unsqueeze(1).expand(-1, seq_len, -1, -1), 2, gather)
+    scores = torch.einsum("bshd,bskd->bshk", q.float(), selected_kv.float()) * softmax_scale
+    scores = torch.where(topk_idxs.unsqueeze(2) < 0, torch.full_like(scores, float("-inf")), scores)
+    sink = attn_sink.view(1, 1, -1, 1).expand(batch_size, seq_len, -1, -1)
+    probs = torch.softmax(torch.cat([scores, sink], dim=-1), dim=-1)[..., :-1]
+    return torch.einsum("bshk,bskd->bshd", probs.to(selected_kv.dtype), selected_kv).to(q.dtype)
+
+
+def _emulated_hc_split_sinkhorn(
+    mixes: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    hc_mult: int = 4,
+    sinkhorn_iters: int = 20,
+    eps: float = 1e-6,
+):
+    pre = torch.sigmoid(mixes[..., :hc_mult] * hc_scale[0] + hc_base[:hc_mult]) + eps
+    post = 2 * torch.sigmoid(
+        mixes[..., hc_mult : 2 * hc_mult] * hc_scale[1] + hc_base[hc_mult : 2 * hc_mult]
+    )
+    comb = mixes[..., 2 * hc_mult :].view(*mixes.shape[:-1], hc_mult, hc_mult)
+    comb_base = hc_base[2 * hc_mult :].view(hc_mult, hc_mult)
+    comb = torch.softmax(comb * hc_scale[2] + comb_base, dim=-1) + eps
+    comb = comb / (comb.sum(dim=-2, keepdim=True) + eps)
+    for _ in range(sinkhorn_iters - 1):
+        comb = comb / (comb.sum(dim=-1, keepdim=True) + eps)
+        comb = comb / (comb.sum(dim=-2, keepdim=True) + eps)
+    return pre, post, comb
+
+
+def _emulated_rotate_activation(x: torch.Tensor) -> torch.Tensor:
+    if x.shape[-1] & (x.shape[-1] - 1):
+        raise ValueError(f"Hadamard rotation requires power-of-two dim, got {x.shape[-1]}")
+    orig_shape = x.shape
+    y = x.float().reshape(-1, x.shape[-1])
+    width = 1
+    while width < y.shape[-1]:
+        y = y.view(-1, y.shape[-1] // (2 * width), 2 * width)
+        left = y[..., :width].clone()
+        right = y[..., width : 2 * width].clone()
+        y[..., :width] = left + right
+        y[..., width : 2 * width] = left - right
+        y = y.view(-1, orig_shape[-1])
+        width *= 2
+    return (y.view(orig_shape) * (orig_shape[-1] ** -0.5)).to(x.dtype)
+
+
+def _make_attention_forward(model_module):
+    def _attention_forward(self, x: torch.Tensor, start_pos: int):
+        bsz, seqlen, _ = x.size()
+        freqs_cis = self.freqs_cis[start_pos : start_pos + seqlen]
+        win = self.window_size
+        ratio = self.compress_ratio
+        rd = self.rope_head_dim
+        if self.compress_ratio and self.compressor.kv_cache is None:
+            self.compressor.kv_cache = self.kv_cache[:, win:]
+            self.compressor.freqs_cis = self.freqs_cis
+            if self.indexer is not None:
+                self.indexer.freqs_cis = self.freqs_cis
+
+        qr = q = self.q_norm(self.wq_a(x))
+        q = self.wq_b(q).unflatten(-1, (self.n_local_heads, self.head_dim))
+        q *= torch.rsqrt(q.square().mean(-1, keepdim=True) + self.eps)
+        model_module.apply_rotary_emb(q[..., -rd:], freqs_cis)
+
+        kv = self.wkv(x)
+        kv = self.kv_norm(kv)
+        model_module.apply_rotary_emb(kv[..., -rd:], freqs_cis)
+        model_module.act_quant(
+            kv[..., :-rd], 64, model_module.scale_fmt, model_module.scale_dtype, True
+        )
+        topk_idxs = model_module.get_window_topk_idxs(win, bsz, seqlen, start_pos)
+        if self.compress_ratio:
+            offset = kv.size(1) if start_pos == 0 else win
+            if self.indexer is not None:
+                compress_topk_idxs = self.indexer(x, qr, start_pos, offset)
+            else:
+                compress_topk_idxs = model_module.get_compress_topk_idxs(
+                    ratio, bsz, seqlen, start_pos, offset
+                )
+            topk_idxs = torch.cat([topk_idxs, compress_topk_idxs], dim=-1)
+        topk_idxs = topk_idxs.int()
+
+        if start_pos == 0:
+            if seqlen <= win:
+                self.kv_cache[:bsz, :seqlen] = kv
+            else:
+                cutoff = seqlen % win
+                self.kv_cache[:bsz, cutoff:win], self.kv_cache[:bsz, :cutoff] = kv[:, -win:].split(
+                    [win - cutoff, cutoff], dim=1
+                )
+            if self.compress_ratio:
+                kv_compress = self.compressor(x, start_pos)
+                if kv_compress is not None:
+                    kv = torch.cat([kv, kv_compress], dim=1)
+            o = model_module.sparse_attn(q, kv, self.attn_sink, topk_idxs, self.softmax_scale)
+        else:
+            self.kv_cache[:bsz, start_pos % win] = kv.squeeze(1)
+            if self.compress_ratio:
+                self.compressor(x, start_pos)
+            o = model_module.sparse_attn(
+                q, self.kv_cache[:bsz], self.attn_sink, topk_idxs, self.softmax_scale
+            )
+
+        model_module.apply_rotary_emb(o[..., -rd:], freqs_cis, True)
+        o = o.view(bsz, seqlen, self.n_local_groups, -1)
+        o = _emulated_grouped_wo_a(o, self.wo_a)
+        return self.wo_b(o.flatten(2))
+
+    return _attention_forward
+
+
+def _patch_checkpoint_model(model_module) -> None:
+    model_module.act_quant = _emulated_act_quant
+    model_module.fp4_act_quant = _emulated_fp4_act_quant
+    model_module.linear = _emulated_linear
+    model_module.sparse_attn = _emulated_sparse_attn
+    model_module.hc_split_sinkhorn = _emulated_hc_split_sinkhorn
+    model_module.rotate_activation = _emulated_rotate_activation
+    model_module.Attention.forward = _make_attention_forward(model_module)
+
+
+def _convert_wo_a_to_fp8(model: nn.Module) -> None:
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if e8m0_dtype is None:
+        raise RuntimeError("torch.float8_e8m0fnu is required for DeepSeek V4 FP8 scales.")
+
+    for layer in model.layers:
+        wo_a = layer.attn.wo_a
+        rows, cols = wo_a.weight.shape
+        wo_a.weight = nn.Parameter(
+            torch.empty(rows, cols, dtype=torch.float8_e4m3fn, device=wo_a.weight.device),
+            requires_grad=False,
+        )
+        wo_a.scale = nn.Parameter(
+            torch.empty(
+                math.ceil(rows / 128),
+                math.ceil(cols / 128),
+                dtype=e8m0_dtype,
+                device=wo_a.weight.device,
+            ),
+            requires_grad=False,
+        )
+        wo_a.weight.scale = wo_a.scale
+
+
+def _prepare_tensor_for_load(key: str, tensor: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    fp4_dtype = getattr(torch, "float4_e2m1fn_x2", None)
+    if (
+        fp4_dtype is not None
+        and target.dtype == fp4_dtype
+        and tensor.dtype in (torch.int8, torch.uint8)
+    ):
+        return tensor.view(torch.uint8).view(fp4_dtype)
+    if tensor.dtype == torch.float8_e4m3fn and target.dtype != torch.float8_e4m3fn:
+        raise TypeError(
+            f"{key} is FP8 in the checkpoint but the instantiated model expects {target.dtype}; "
+            "the model patch missed a quantized path."
+        )
+    return tensor
+
+
+def _load_checkpoint_subset(model: nn.Module, checkpoint_dir: Path, device: torch.device) -> None:
+    index_path = checkpoint_dir / "model.safetensors.index.json"
+    if not index_path.is_file():
+        raise FileNotFoundError(f"Missing safetensor index: {index_path}")
+
+    with index_path.open() as f:
+        weight_map = json.load(f)["weight_map"]
+
+    target_state = model.state_dict()
+    wanted = {key for key in target_state if key in weight_map}
+    missing_from_checkpoint = sorted(set(target_state) - set(weight_map))
+    if missing_from_checkpoint:
+        raise KeyError(
+            "The checkpoint is missing keys required by the truncated model, first few: "
+            f"{missing_from_checkpoint[:10]}"
+        )
+
+    keys_by_shard: dict[str, list[str]] = defaultdict(list)
+    for key in sorted(wanted):
+        keys_by_shard[weight_map[key]].append(key)
+
+    loaded: set[str] = set()
+    device_arg = "cpu" if device.type == "cpu" else str(device)
+    for shard_name, keys in sorted(keys_by_shard.items()):
+        shard_path = checkpoint_dir / shard_name
+        chunk = {}
+        with safe_open(shard_path, framework="pt", device=device_arg) as f:
+            for key in keys:
+                tensor = f.get_tensor(key)
+                chunk[key] = _prepare_tensor_for_load(key, tensor, target_state[key])
+        model.load_state_dict(chunk, strict=False)
+        loaded.update(chunk)
+        print(f"loaded {len(keys):5d} tensors from {shard_name}")
+        del chunk
+
+    missing_after_load = sorted(wanted - loaded)
+    if missing_after_load:
+        raise RuntimeError(f"Failed to load expected tensors, first few: {missing_after_load[:10]}")
+
+
+def _load_model_args(checkpoint_dir: Path, layers: int, batch_size: int, seq_len: int):
+    config_path = checkpoint_dir / "inference" / "config.json"
+    with config_path.open() as f:
+        config = json.load(f)
+    config["n_layers"] = layers
+    config["n_mtp_layers"] = 0
+    config["max_batch_size"] = batch_size
+    config["max_seq_len"] = seq_len
+    return config
+
+
+def _make_input_ids(
+    args: argparse.Namespace, checkpoint_dir: Path, device: torch.device
+) -> torch.Tensor:
+    if args.prompt:
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(checkpoint_dir, trust_remote_code=True)
+        input_ids = tokenizer(args.prompt, return_tensors="pt").input_ids[:, : args.seq_len]
+        if input_ids.shape[-1] == 0:
+            raise ValueError("The prompt produced no tokens.")
+        return input_ids.to(device)
+
+    generator = torch.Generator(device=device)
+    generator.manual_seed(args.seed)
+    return torch.randint(
+        0, args.vocab_size, (args.batch_size, args.seq_len), generator=generator, device=device
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint-dir", type=Path, default=_DEFAULT_CHECKPOINT_DIR)
+    parser.add_argument("--layers", type=int, default=5)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--seq-len", type=int, default=4)
+    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--prompt", default=None)
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument("--load-only", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    checkpoint_dir = args.checkpoint_dir.resolve()
+    device = torch.device(args.device)
+    if device.type == "cuda":
+        torch.cuda.set_device(device)
+
+    model_module = _import_checkpoint_model(checkpoint_dir)
+    _patch_checkpoint_model(model_module)
+    model_config = _load_model_args(checkpoint_dir, args.layers, args.batch_size, args.seq_len)
+    args.vocab_size = model_config["vocab_size"]
+
+    with _torch_defaults(torch.bfloat16, device):
+        model_args = model_module.ModelArgs(**model_config)
+        model = model_module.Transformer(model_args).eval()
+        _convert_wo_a_to_fp8(model)
+        _load_checkpoint_subset(model, checkpoint_dir, device)
+
+        if args.load_only:
+            print("load-only requested; skipping forward")
+            return
+
+        input_ids = _make_input_ids(args, checkpoint_dir, device)
+        with torch.inference_mode():
+            logits = model(input_ids, start_pos=0)
+            if not torch.isfinite(logits).all():
+                raise RuntimeError("forward produced non-finite logits")
+            top_values, top_indices = logits.float().topk(args.top_k, dim=-1)
+
+        print(f"input_ids shape: {tuple(input_ids.shape)}")
+        print(f"logits shape:    {tuple(logits.shape)}")
+        print(f"logits dtype:     {logits.dtype}")
+        print(f"top-{args.top_k} token ids for batch 0: {top_indices[0].tolist()}")
+        print(f"top-{args.top_k} logits for batch 0:    {top_values[0].tolist()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/subagents/README.md
+++ b/subagents/README.md
@@ -1,0 +1,81 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# DeepSeek V4 AutoDeploy Parallel Work Plans
+
+This directory splits `deepseek_v4_ad_plan.md` into feature waves. Files inside
+the same wave can be implemented and tested by separate agents in parallel.
+Later waves should wait for the earlier wave contracts to land, or use the
+mock boundaries described in the individual plan files.
+
+Each feature plan is written to be useful even before the full DeepSeek V4 model
+works end to end. Agents should use synthetic tensors, reduced configs, or
+checkpoint metadata where possible. Full-model integration is intentionally kept
+in `wave4/11_full_model_integration.md`.
+
+## Wave Map
+
+| Wave | Plan | Feature | Can Test Without Full Model |
+| - | - | - |
+| `wave1` | `01_checkpoint_classifier_and_quant_config.md` | Checkpoint classification and V4 quant config override | yes |
+| `wave1` | `02_e8m0_scale_utils.md` | E8M0 upcast/raw-byte scale helpers | yes |
+| `wave1` | `05_deepseek_v4_router.md` | Hash/top-k `sqrtsoftplus` router | yes |
+| `wave1` | `07_sparse_attention_source_op.md` | Canonical sparse attention source op | yes |
+| `wave1` | `08_paged_v4_cache_resources.md` | V4 named/composite paged cache resources | yes |
+| `wave1` | `10_cuda_graph_runtime_config.md` | CUDA graph dynamic-op/runtime config support | yes |
+| `wave2` | `03_finegrained_fp8_linear_path.md` | FP8 linears and `.scale` aliasing | yes |
+| `wave2` | `04_packed_mxfp4_expert_loader.md` | Packed FP4 expert loading/layout | yes |
+| `wave2` | `09_attention_kernel_microfeatures.md` | Standalone attention kernel microfeatures | yes |
+| `wave3` | `06_deepseek_v4_moe_op.md` | Canonical V4 MoE op and lowering skeleton | yes, with synthetic expert tensors |
+| `wave4` | `11_full_model_integration.md` | Full model integration and serving validation | no |
+
+## Dependency Graph
+
+```text
+wave1/
+  01 checkpoint classifier / quant config
+  02 E8M0 scale utilities
+  05 router
+  07 sparse attention source op
+  08 paged V4 cache resources
+  10 CUDA graph/runtime config
+
+wave2/
+  03 FP8 linear path              depends on 01, 02
+  04 packed MXFP4 expert loader   depends on 01, 02
+  09 attention kernel features    depends on 02, 07, 08
+
+wave3/
+  06 DeepSeek V4 MoE op           depends on 03, 04, 05
+
+wave4/
+  11 full model integration       depends on all prior waves
+```
+
+## Coordination Rules
+
+- Each agent owns only the files listed in its plan.
+- Agents must not revert edits made by other agents.
+- Agents should prefer new focused unit tests over broad end-to-end tests.
+- Agents should keep public interfaces small and documented.
+- Shared names should use the same vocabulary across plans:
+  - `deepseek_v4_fp8` for the mixed quantization plan.
+  - `torch_deepseek_v4_moe` for the canonical MoE op.
+  - `torch_deepseek_v4_sparse_attention` for the canonical attention op.
+  - `DeepSeekV4CacheResource` or equivalent for the V4 cache resource family.
+- Full-model behavior should not be assumed until
+  `wave4/11_full_model_integration.md`.

--- a/subagents/wave1/01_checkpoint_classifier_and_quant_config.md
+++ b/subagents/wave1/01_checkpoint_classifier_and_quant_config.md
@@ -1,0 +1,122 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 01: Checkpoint Classifier And Quant Config
+
+## Goal
+
+Add a DeepSeek V4-aware checkpoint classification and quantization config
+override. This feature must prove from metadata that DeepSeek V4 Flash is mixed
+FP8 plus packed FP4, and it must expose enough structured information for later
+transforms to avoid generic `fp8` misclassification.
+
+This work is independent because it only needs model config files,
+`model.safetensors.index.json`, and safetensors headers. It does not need full
+model execution.
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/models/quant_config_reader.py`
+- `tensorrt_llm/_torch/auto_deploy/models/deepseek_v4_quant.py` if a new helper
+  module is cleaner
+- `tests/unittest/_torch/auto_deploy/unit/models/test_deepseek_v4_quant_config.py`
+
+Do not edit MoE kernels, attention kernels, cache handlers, or model code except
+for minimal imports needed by the quant reader.
+
+## Inputs
+
+Use small metadata fixtures in tests. Do not require downloading the full model.
+
+Minimum fixture content:
+
+- `config.json` with:
+  - `model_type: deepseek_v4`
+  - `quantization_config.quant_method: fp8`
+  - `quantization_config.scale_fmt: ue8m0`
+  - `quantization_config.weight_block_size: [128, 128]`
+- safetensors header snippets containing:
+  - `layers.0.attn.wq_a.weight` as `F8_E4M3`
+  - `layers.0.attn.wq_a.scale` as `F8_E8M0`
+  - `layers.0.ffn.experts.0.w1.weight` as `I8`
+  - `layers.0.ffn.experts.0.w1.scale` as `F8_E8M0`
+  - `layers.0.ffn.gate.weight` as `BF16`
+  - `layers.0.ffn.gate.tid2eid` as `I64`
+
+## Deliverables
+
+- A structured classifier output with categories:
+  - `finegrained_fp8_linear`
+  - `packed_mxfp4_expert`
+  - `bf16_or_f32`
+  - `integer_metadata`
+  - `skipped_mtp`
+  - `unknown`
+- A DeepSeek V4 quantization config override, for example:
+
+```python
+{
+    "quant_method": "deepseek_v4_fp8",
+    "linear_quant_method": "finegrained_fp8",
+    "expert_quant_method": "mxfp4",
+    "scale_fmt": "ue8m0",
+    "weight_block_size": [128, 128],
+    "expert_block_size": 32,
+}
+```
+
+- Clear excluded module patterns:
+  - `embed`
+  - `head`
+  - `*.ffn.gate`
+  - `*.attn.compressor`
+  - `*.norm`
+  - `*.hc_*`
+  - `*.attn_sink`
+  - `mtp.*` until MTP support lands
+
+## Implementation Steps
+
+1. Add a classifier function that accepts parsed config and tensor metadata.
+2. Add path-pattern rules for DeepSeek V4 tensor families.
+3. Add dtype/shape sanity checks for representative tensors.
+4. Add a quant reader path that recognizes `model_type == "deepseek_v4"` and
+   HF `quant_method == "fp8"`.
+5. Preserve existing generic HF quant reader behavior for all other models.
+6. Return a normalized config that downstream transforms can inspect.
+
+## Standalone Tests
+
+Add tests that use tiny JSON/header fixtures:
+
+- DeepSeek V4 config returns `quant_method: deepseek_v4_fp8`.
+- FP8 attention/shared-expert linears are classified correctly.
+- Routed experts are classified as packed MXFP4.
+- Router, compressor, head, embed, norms, and HC tensors are not quantized.
+- `mtp.0.*` keys are classified as skipped.
+- Unknown keys fail loudly unless explicitly waived.
+- Non-DeepSeek `fp8` config still uses existing behavior.
+
+## Done Criteria
+
+- Tests pass without GPU.
+- No full checkpoint download is required.
+- Later agents can consume the normalized quant config without parsing HF files
+  again.
+- The implementation does not change runtime behavior for other model families.

--- a/subagents/wave1/02_e8m0_scale_utils.md
+++ b/subagents/wave1/02_e8m0_scale_utils.md
@@ -1,0 +1,98 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 02: E8M0 Scale Utilities
+
+## Goal
+
+Add small, well-tested utilities for handling E8M0 scale tensors correctly.
+DeepSeek V4 uses E8M0 scales for both FP8 dense linears and packed FP4 routed
+experts. Some kernels need FP32 scale values, while others need raw exponent
+bytes.
+
+This work is independent because it operates on tiny synthetic tensors.
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/utils/e8m0.py`
+- `tests/unittest/_torch/auto_deploy/unit/utils/test_e8m0.py`
+
+Avoid editing quantization transforms directly unless adding import points or
+small wrappers.
+
+## Required APIs
+
+Provide utilities equivalent to:
+
+```python
+def e8m0_to_uint8(scale: torch.Tensor) -> torch.Tensor:
+    """Return raw exponent bytes without numeric conversion."""
+
+def e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
+    """Decode E8M0 exponent-only values to FP32 powers of two."""
+
+def maybe_e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
+    """Decode E8M0 scales; return non-E8M0 scales as FP32."""
+```
+
+The implementation must preserve raw bytes with `view(torch.uint8)`, not
+`to(torch.uint8)`.
+
+## Implementation Notes
+
+PyTorch exposes E8M0 locally as:
+
+```python
+torch.float8_e8m0fnu
+```
+
+Decode to FP32 by placing exponent bits into the IEEE-754 FP32 exponent field:
+
+```python
+exp_bits = scale.view(torch.uint8).to(torch.int32)
+fp32_bits = exp_bits << 23
+scale_fp32 = fp32_bits.view(torch.float32)
+```
+
+Handle environments where `torch.float8_e8m0fnu` is unavailable by checking
+`hasattr(torch, "float8_e8m0fnu")` and failing with a clear message only when an
+actual E8M0 tensor is required.
+
+## Standalone Tests
+
+Use tiny tensors and explicit bit patterns:
+
+- Raw byte preservation:
+  - construct bytes, view as E8M0, round trip to uint8.
+- Numeric conversion guard:
+  - prove `view(torch.uint8)` differs from `.to(torch.uint8)` for small scales.
+- FP32 decode:
+  - byte `127` decodes to `1.0`
+  - byte `128` decodes to `2.0`
+  - byte `126` decodes to `0.5`
+- Non-E8M0 input:
+  - `maybe_e8m0_to_fp32` returns FP32 values for BF16/FP32 scales.
+- CPU-only execution.
+
+## Done Criteria
+
+- Utilities are importable without initializing CUDA.
+- Tests pass on CPU.
+- Utilities are documented enough for the FP8 and MXFP4 loader agents to use
+  them without re-implementing scale handling.

--- a/subagents/wave1/05_deepseek_v4_router.md
+++ b/subagents/wave1/05_deepseek_v4_router.md
@@ -1,0 +1,122 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 05: DeepSeek V4 Router
+
+## Goal
+
+Implement and test DeepSeek V4 routing independently from expert execution.
+The router must support hash-routed layers and normal top-k layers with
+`sqrtsoftplus` scoring.
+
+This work is independent because it only consumes hidden states, router weights,
+optional bias, `tid2eid`, and input IDs.
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_router.py`
+- `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py` only
+  if replacing local router logic with the canonical op is in scope
+- `tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_router.py`
+
+Do not edit MXFP4 expert loading or MoE matmul kernels.
+
+## Router Contract
+
+Inputs:
+
+```text
+hidden_states: [T, H]
+input_ids: [T] or [B, S]
+router_weight: [E, H]
+router_bias: [E] or None
+tid2eid: [vocab, top_k] or None
+top_k: int
+route_scale: float
+is_hash_layer: bool
+```
+
+Outputs:
+
+```text
+selected_experts: [T, top_k] int64 or int32
+routing_weights: [T, top_k] same floating dtype as hidden compute
+```
+
+## Math
+
+Shared score path:
+
+```text
+logits = hidden_states @ router_weight.T
+scores = sqrt(softplus(logits))
+```
+
+Hash-routed layers:
+
+```text
+selected_experts = tid2eid[input_ids]
+weights = gather(scores, selected_experts)
+weights = weights / sum(weights, dim=-1)
+weights = weights * route_scale
+```
+
+Top-k layers:
+
+```text
+biased_scores = scores + router_bias
+selected_experts = topk(biased_scores, top_k)
+weights = gather(scores, selected_experts)
+weights = weights / sum(weights, dim=-1)
+weights = weights * route_scale
+```
+
+Bias influences selection only; weights are gathered from original scores.
+
+## Deliverables
+
+- A reference PyTorch router implementation.
+- Optional custom op:
+  - `torch_deepseek_v4_router`
+- Optional fused CUDA/Triton top-k kernel:
+  - `triton_deepseek_v4_topk_sqrtsoftplus`
+- Export-safe fake implementation if registered as a custom op.
+
+## Standalone Tests
+
+- Hash routing:
+  - exact `tid2eid[input_ids]` selected experts
+  - exact normalization and scaling
+- Top-k routing:
+  - bias affects selected experts
+  - weights come from un-biased scores
+- Numerical stability:
+  - large positive and negative logits
+  - no NaNs for BF16/FP32 inputs
+- Shape tests:
+  - `[T, H]`
+  - `[B, S, H]` flattened boundary
+- Export test if a canonical op is added.
+
+## Done Criteria
+
+- CPU reference tests pass.
+- GPU fused kernel is optional for this feature plan.
+- Later MoE work can consume selected experts and routing weights without
+  duplicating router math.

--- a/subagents/wave1/07_sparse_attention_source_op.md
+++ b/subagents/wave1/07_sparse_attention_source_op.md
@@ -1,0 +1,107 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 07: Sparse Attention Source Op
+
+## Goal
+
+Create a canonical AutoDeploy source op for DeepSeek V4 sparse/HMA attention.
+This op should replace opaque Python gather/einsum attention logic with a
+semantic graph node that later transforms can lower to cached kernels.
+
+This work is independent because it can use tiny Q/K/V tensors and synthetic
+top-k indices.
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py`
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py` only for
+  descriptor registration if needed
+- `tests/unittest/_torch/auto_deploy/unit/custom_ops/test_deepseek_v4_sparse_attention.py`
+
+Do not implement paged cache resources or production kernels here.
+
+## Source Op Contract
+
+Initial op:
+
+```text
+torch_deepseek_v4_sparse_attention(
+    q,
+    kv,
+    attn_sink,
+    topk_idxs,
+    softmax_scale,
+)
+```
+
+Shapes:
+
+```text
+q:          [B, S, H, D]
+kv:         [B, K, D]
+attn_sink:  [H]
+topk_idxs:  [B, S, K_select]
+output:     [B, S, H, D]
+```
+
+This minimal contract keeps the source op independent. Higher-level model code
+can compute Q/KV/compressor/indexer tensors separately until production kernels
+are added.
+
+## Reference Math
+
+For each batch, token, and head:
+
+1. Gather selected KV rows using `topk_idxs`.
+2. Compute logits:
+
+```text
+logits = dot(q, selected_kv) * softmax_scale
+```
+
+3. Add attention sink as an extra logit.
+4. Softmax over selected positions plus sink.
+5. Weighted sum selected values.
+6. Sink contributes probability mass but no value vector unless the reference
+   implementation defines an explicit sink value.
+
+## Deliverables
+
+- Custom op registration.
+- Meta/fake implementation for export.
+- PyTorch reference implementation.
+- Optional descriptor object that later cache transforms can recognize.
+
+## Standalone Tests
+
+- Output shape and dtype.
+- Compare op output against plain PyTorch reference.
+- Masking/index behavior:
+  - local sliding-window indices
+  - synthetic compressed indices
+  - duplicate indices
+- Attention sink behavior.
+- Export test with dynamic batch and sequence.
+
+## Done Criteria
+
+- The op is stable and can be used by the model scaffold.
+- No paged cache or Triton dependency is required.
+- Later kernel/cache agents can pattern-match this op by name.

--- a/subagents/wave1/08_paged_v4_cache_resources.md
+++ b/subagents/wave1/08_paged_v4_cache_resources.md
@@ -1,0 +1,98 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 08: Paged V4 Cache Resources
+
+## Goal
+
+Add AutoDeploy runtime/cache support for DeepSeek V4's heterogeneous cache
+needs. The feature should prove named or composite paged resources can be
+allocated, indexed, and reused without requiring the full attention kernel.
+
+This work is independent because it can use synthetic cache descriptors and
+metadata tests.
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/shim/interface.py`
+- `tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py`
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py`
+- `tests/unittest/_torch/auto_deploy/unit/runtime/test_deepseek_v4_cache_resources.py`
+
+Coordinate carefully with existing KV cache behavior. Do not change generic
+cache semantics unless covered by tests.
+
+## Required Resources
+
+DeepSeek V4 needs:
+
+```text
+swa_kv_cache
+  high-resolution local window cache
+
+mhc_cache
+  compressed KV entries for ratio-4 and ratio-128 layers
+
+indexer_cache
+  compact indexer KV for ratio-4 top-k selection
+
+compressor_state
+  per-sequence state for incomplete compression windows during decode
+```
+
+## Design Direction
+
+Prefer named page tables per resource group:
+
+```text
+SequenceInfo.cache_loc["swa"]
+SequenceInfo.cache_loc["mhc"]
+SequenceInfo.cache_loc["indexer"]
+SequenceInfo.cu_num_pages["swa"]
+...
+```
+
+If dictionary-style metadata is too invasive for export or runtime code, use a
+small fixed struct/list of named resource metadata with stable ordering.
+
+Avoid unpaged `[max_batch, max_seq, ...]` caches for long-lived V4 cache data.
+
+## Deliverables
+
+- A cache resource descriptor for V4 attention.
+- Allocation of multiple paged resource pools or a composite pool.
+- Per-resource page metadata in `SequenceInfo` or equivalent.
+- Prefix reuse and partial reuse behavior documented for V4 resources.
+- A way for future V4 attention kernels to retrieve page tables by resource
+  name.
+
+## Standalone Tests
+
+- Allocate synthetic V4 resources with small page sizes.
+- Nest two or more sequences and verify page metadata.
+- Verify SWA and MHC can have different logical lengths.
+- Verify ratio-128 compressed cache uses fewer logical entries than token cache.
+- Verify prefix reuse does not silently disable all cache reuse.
+- Verify local/non-paged fallback is not used for long-lived V4 resources.
+
+## Done Criteria
+
+- Tests run without full model weights.
+- Existing standard attention/MLA cache tests still pass.
+- V4 attention kernel agents can consume stable metadata names and shapes.

--- a/subagents/wave1/10_cuda_graph_runtime_config.md
+++ b/subagents/wave1/10_cuda_graph_runtime_config.md
@@ -1,0 +1,100 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 10: CUDA Graph Runtime Config
+
+## Goal
+
+Prepare AutoDeploy's compile/runtime path for DeepSeek V4 dynamic sparse
+attention and MoE operations. This feature should make the graph compiler aware
+of new dynamic ops and provide a model registry/runtime config skeleton.
+
+This work is independent because it can use dummy custom ops and small toy
+graphs.
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py`
+- `tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py`
+- `examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml`
+- `tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py`
+
+Do not implement attention or MoE kernels here.
+
+## Dynamic Ops To Register
+
+Reserve names for:
+
+```text
+auto_deploy::torch_deepseek_v4_sparse_attention
+auto_deploy::triton_deepseek_v4_sparse_attention_with_cache
+auto_deploy::torch_deepseek_v4_moe
+auto_deploy::triton_mxfp4_moe
+auto_deploy::triton_mxfp4_moe_ep
+deepseek_v4 cache metadata prep ops
+```
+
+The exact list should be updated as Plans 06-09 land.
+
+## Config Skeleton
+
+Initial config direction:
+
+```yaml
+compile_backend: torch-cudagraph
+
+runtime:
+  enable_chunked_prefill: true
+
+cuda_graph_config:
+  batch_sizes: [1, 2, 4, 8, 16, 32, 64]
+
+transforms:
+  compile_model:
+    piecewise_enabled: true
+  multi_stream_moe:
+    enabled: false
+```
+
+Avoid enabling multi-stream MoE by default until the V4 MoE path is stable.
+
+## Deliverables
+
+- Piecewise CUDA graph dynamic-op registration.
+- Toy graph tests showing static regions are captured around V4-like dynamic
+  ops.
+- Decode-only padding behavior test for configured batch sizes.
+- YAML skeleton for DeepSeek V4 AutoDeploy bring-up.
+
+## Standalone Tests
+
+- Construct a toy graph:
+  - static linear
+  - dummy V4 dynamic op
+  - static linear
+- Verify piecewise splitting.
+- Verify fallback behavior when piecewise capture is disabled.
+- Verify configured CUDA graph batch sizes are parsed.
+- Verify no full checkpoint/model is required.
+
+## Done Criteria
+
+- DeepSeek V4 op names can be added without changing compile architecture.
+- The config skeleton is usable by integration agents.
+- Existing CUDA graph tests still pass.

--- a/subagents/wave1/README.md
+++ b/subagents/wave1/README.md
@@ -1,0 +1,31 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Wave 1
+
+All plans in this folder can start immediately and can be implemented in
+parallel. They define foundational contracts, helpers, and runtime hooks that
+later waves consume.
+
+Plans:
+
+- `01_checkpoint_classifier_and_quant_config.md`
+- `02_e8m0_scale_utils.md`
+- `05_deepseek_v4_router.md`
+- `07_sparse_attention_source_op.md`
+- `08_paged_v4_cache_resources.md`
+- `10_cuda_graph_runtime_config.md`

--- a/subagents/wave2/03_finegrained_fp8_linear_path.md
+++ b/subagents/wave2/03_finegrained_fp8_linear_path.md
@@ -1,0 +1,108 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 03: FineGrained FP8 Linear Path
+
+## Goal
+
+Make DeepSeek V4's FP8 dense linears load and lower through AutoDeploy's
+FineGrained FP8 linear path. The feature must handle checkpoint sibling
+`.scale` tensors and E8M0 scale values.
+
+This work can be tested independently using a tiny module with one or two
+linear layers and synthetic FP8 weights.
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py`
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py`
+- `tensorrt_llm/_torch/auto_deploy/utils/e8m0.py` only if Plan 02 has not
+  landed yet
+- `tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py`
+
+Do not modify routed MoE, attention kernels, or cache resources.
+
+## Inputs And Mock Boundary
+
+Use a tiny module:
+
+```python
+class TinyV4FP8Module(nn.Module):
+    def __init__(self):
+        self.wq_a = DeepseekV4Linear(...)
+        self.shared_w1 = DeepseekV4Linear(...)
+```
+
+Use a synthetic state dict with:
+
+```text
+wq_a.weight  torch.float8_e4m3fn
+wq_a.scale   torch.float8_e8m0fnu
+```
+
+If `torch.float8_e8m0fnu` is not available in a test environment, create a
+small skip with a clear reason.
+
+## Deliverables
+
+- A load hook or transform alias that maps:
+
+```text
+<module>.scale -> <module>.weight_scale_inv
+```
+
+for FineGrained FP8 linears.
+
+- E8M0 scale support:
+  - Use FP32 decoded scales for `trtllm_finegrained_fp8_linear` if required.
+  - Preserve raw E8M0 only if a backend asks for raw bytes.
+
+- Exclusion behavior for DeepSeek V4:
+  - Do not quantize router, compressor, head, embed, norms, HC tensors, or
+    `attn_sink`.
+
+## Implementation Steps
+
+1. Add a helper to recognize DeepSeek V4 FP8 linear module paths.
+2. Extend FineGrained FP8 load logic to accept `.scale` as an alias.
+3. Verify loaded scale shapes match `[ceil(N/128), ceil(K/128)]`.
+4. Add a path for `F8_E8M0` scales.
+5. Ensure the transform still skips generic `quantize_fp8_linear_from_config`
+   when `weight_block_size` is present.
+6. Ensure non-DeepSeek models keep existing behavior.
+
+## Standalone Tests
+
+- Load synthetic state dict using `.scale` and assert internal buffer is set.
+- Compare dequantized FP8 matmul against `trtllm_finegrained_fp8_linear` or the
+  fake/reference op on small shapes.
+- Test shape validation for:
+  - `[8, 32]` scale for `[1024, 4096]`
+  - smaller non-multiple dimensions using ceil behavior
+- Test exclusions:
+  - `ffn.gate.weight` remains BF16
+  - `attn.compressor.wkv.weight` remains BF16
+- Test no regression for a generic FineGrained FP8 model using
+  `weight_scale_inv`.
+
+## Done Criteria
+
+- CPU tests cover load hooks and shape classification.
+- GPU test is optional but should be added if available for the optimized op.
+- The transform never treats packed routed expert `I8` weights as FP8.

--- a/subagents/wave2/04_packed_mxfp4_expert_loader.md
+++ b/subagents/wave2/04_packed_mxfp4_expert_loader.md
@@ -1,0 +1,110 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 04: Packed MXFP4 Expert Loader
+
+## Goal
+
+Load, validate, and stack DeepSeek V4 routed expert weights stored as packed
+FP4 in `I8` tensors with E8M0 scales. This feature should produce backend-ready
+expert tensors without needing the full MoE op to exist.
+
+This work is independent because it can use synthetic packed expert tensors and
+reference unpack/dequant helpers.
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_mxfp4.py`
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py` only for
+  small interface extensions
+- `tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py` only for
+  MXFP4 EP shape handling, if needed
+- `tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_mxfp4_loader.py`
+
+Do not implement the router or full `torch_deepseek_v4_moe` here.
+
+## Checkpoint Layout
+
+Representative routed expert tensors:
+
+```text
+w1.weight  I8 [2048, 2048]  -> logical FP4 [2048, 4096]
+w3.weight  I8 [2048, 2048]  -> logical FP4 [2048, 4096]
+w2.weight  I8 [4096, 1024]  -> logical FP4 [4096, 2048]
+
+w1.scale   F8_E8M0 [2048, 128]
+w3.scale   F8_E8M0 [2048, 128]
+w2.scale   F8_E8M0 [4096, 64]
+```
+
+Two FP4 values are packed per byte. Scales use one E8M0 value per 32 logical K
+elements.
+
+## Deliverables
+
+- A packed expert metadata validator.
+- A loader that preserves:
+  - packed weight bytes
+  - E8M0 scale exponent bytes
+- A stacker that emits:
+
+```text
+gate_up_blocks: [E_local, 2 * I, H / 32, 16] uint8
+gate_up_scales: [E_local, 2 * I, H / 32]     uint8
+down_blocks:    [E_local, H, I / 32, 16]     uint8
+down_scales:    [E_local, H, I / 32]         uint8
+```
+
+or an equivalent backend-specific layout with explicit documentation.
+
+## Implementation Steps
+
+1. Add a parser for per-expert keys:
+   - `layers.{i}.ffn.experts.{e}.w1.weight`
+   - `layers.{i}.ffn.experts.{e}.w1.scale`
+   - same for `w2` and `w3`
+2. Add shape checks for hidden/intermediate dimensions.
+3. Reinterpret `I8` weights as `uint8` raw bytes.
+4. Reinterpret E8M0 scales as `uint8` raw bytes.
+5. Stack `w3` and `w1` in the order required by the chosen MoE backend.
+6. Keep `w2` as the down path.
+7. Add an EP slicing helper that partitions the expert dimension without
+   changing packed K layout.
+
+## Standalone Tests
+
+- Synthetic packed tensors:
+  - construct small logical FP4 values
+  - pack two values per byte
+  - unpack in reference helper
+- Verify shape transforms:
+  - packed `[I, H/2]` -> blocks `[I, H/32, 16]`
+  - packed `[H, I/2]` -> blocks `[H, I/32, 16]`
+- Verify E8M0 scale byte preservation:
+  - `view(torch.uint8)` round trip
+  - `.to(torch.uint8)` is not used
+- Verify per-expert stacking order.
+- Verify EP split over experts for `E=8`, `ep_size=2`.
+
+## Done Criteria
+
+- Loader tests pass on CPU.
+- The output layout is documented and stable.
+- The full MoE agent can consume these tensors without needing to inspect the
+  original checkpoint naming convention.

--- a/subagents/wave2/09_attention_kernel_microfeatures.md
+++ b/subagents/wave2/09_attention_kernel_microfeatures.md
@@ -1,0 +1,98 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 09: Attention Kernel Microfeatures
+
+## Goal
+
+Develop and test standalone DeepSeek V4 attention kernel building blocks before
+integrating them into the full cached attention backend.
+
+This work is independent because each kernel can be tested with synthetic
+tensors and compared against a PyTorch reference.
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_kernels.py`
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_deepseek_v4_*.py`
+- `tests/unittest/_torch/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_kernels.py`
+
+Do not own the source op contract or paged cache metadata. Consume interfaces
+from Plans 07 and 08 when available.
+
+## Kernel Work Items
+
+Implement independently testable kernels:
+
+1. Q RMSNorm + RoPE
+   - input: Q after `wq_b`
+   - output: per-head normalized and RoPE-applied Q
+
+2. KV RMSNorm + RoPE + optional FP8 cache insert
+   - input: KV after `wkv`
+   - output: BF16 RoPE dims and FP8 NoPE dims with E8M0 scales
+
+3. Compressor pooling + RMSNorm + RoPE
+   - supports ratio 4 with overlap
+   - supports ratio 128 without overlap
+
+4. Indexer Q RoPE + quant
+   - initial FP8 path
+   - optional MXFP4 path after FP8 correctness
+
+5. Inverse RoPE + FP8 output quant
+   - prepares attention output for quantized output projection
+
+6. Sparse attention microkernel
+   - local window plus selected compressed indices
+   - attention sink
+
+## Deliverables
+
+- Kernel wrappers with fake/meta implementations if registered as custom ops.
+- PyTorch references for each kernel.
+- Clear dtype contracts:
+  - BF16 compute where required
+  - FP8 E4M3 NoPE cache where enabled
+  - E8M0 scales preserved or decoded as required
+- Shape contracts for hidden size 4096, head dim 512, RoPE dim 64, plus tiny
+  shapes for tests.
+
+## Standalone Tests
+
+GPU tests where kernels require CUDA:
+
+- Q RMSNorm + RoPE vs reference.
+- KV norm/RoPE/cache insert vs reference.
+- Compressor ratio-4 and ratio-128 vs reference.
+- E8M0 quant error bound tests.
+- Sparse attention vs `torch_deepseek_v4_sparse_attention`.
+- CUDA graph replay for fixed shapes.
+
+CPU tests:
+
+- reference math helpers
+- shape/meta/fake implementations
+
+## Done Criteria
+
+- Each kernel has an isolated test.
+- Kernel wrappers do not allocate inside CUDA graph replay paths.
+- The full attention backend can assemble kernels without rewriting reference
+  math.

--- a/subagents/wave2/README.md
+++ b/subagents/wave2/README.md
@@ -1,0 +1,29 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Wave 2
+
+All plans in this folder can be implemented in parallel after Wave 1 contracts
+are available. They may use local mocks while Wave 1 is still landing, but final
+versions should consume the Wave 1 classifier, E8M0 helpers, source attention
+op, and cache metadata contracts.
+
+Plans:
+
+- `03_finegrained_fp8_linear_path.md`
+- `04_packed_mxfp4_expert_loader.md`
+- `09_attention_kernel_microfeatures.md`

--- a/subagents/wave3/06_deepseek_v4_moe_op.md
+++ b/subagents/wave3/06_deepseek_v4_moe_op.md
@@ -1,0 +1,127 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 06: DeepSeek V4 MoE Op
+
+## Goal
+
+Introduce a canonical DeepSeek V4 MoE op and a production lowering path that
+combines:
+
+- DeepSeek V4 router output
+- packed MXFP4 routed experts
+- FineGrained FP8 shared expert
+- `swiglu_limit`
+
+This feature can start with synthetic selected experts and packed expert
+tensors. It should not wait for the full model.
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_moe.py`
+- `tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py`
+- `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py` only for
+  minimal activation or argument support
+- `tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py`
+
+Coordinate with Plans 04 and 05 but do not edit their owned files unless
+necessary and agreed.
+
+## Canonical Op
+
+Recommended source op:
+
+```text
+torch_deepseek_v4_moe(
+    hidden_states,
+    input_ids,
+    router_weight,
+    router_bias_or_none,
+    tid2eid_or_none,
+    routed_expert_packed_weights,
+    routed_expert_scales,
+    shared_expert_weights,
+    shared_expert_scales,
+    top_k,
+    route_scale,
+    swiglu_limit,
+    is_hash_layer,
+)
+```
+
+An alternative is two ops:
+
+```text
+torch_deepseek_v4_router
+torch_deepseek_v4_moe_from_routing
+```
+
+The two-op form may be easier to test and compose.
+
+## Production Lowering
+
+Target graph:
+
+```text
+hidden -> router -> selected_experts, routing_weights
+hidden + selected_experts + routing_weights + MXFP4 weights -> routed output
+hidden + FP8 shared expert weights -> shared output
+routed + shared -> output
+```
+
+The routed expert activation must implement:
+
+```text
+up = clamp(up, -limit, limit)
+gate = clamp(gate, max=limit)
+hidden = silu(gate) * up
+```
+
+## Mock Boundary
+
+Until Plan 04 lands, use synthetic packed expert tensors generated in test
+helpers.
+
+Until Plan 05 lands, allow tests to pass precomputed `selected_experts` and
+`routing_weights` into a lower-level op.
+
+## Deliverables
+
+- Canonical op and fake implementation for export.
+- Reference PyTorch implementation for tiny tests.
+- Transform that lowers to an available MXFP4 backend where possible.
+- Shared expert path using FineGrained FP8 linears or a mocked BF16 reference in
+  early tests.
+- Clear error if the selected backend cannot support `swiglu_limit`.
+
+## Standalone Tests
+
+- Tiny BF16 reference MoE with `E=4`, `top_k=2`, small hidden/intermediate.
+- `swiglu_limit=0` and `swiglu_limit=10` cases.
+- Precomputed routing path independent of router.
+- Hash-router integrated path once Plan 05 is available.
+- Synthetic packed MXFP4 path once Plan 04 is available.
+- Export test for the canonical op.
+- CUDA graph replay test for fixed token count if a GPU is available.
+
+## Done Criteria
+
+- The dense expert fallback is not used in production lowering.
+- Tests can run without the full DeepSeek V4 checkpoint.
+- The op exposes a stable interface for model integration.

--- a/subagents/wave3/README.md
+++ b/subagents/wave3/README.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Wave 3
+
+This wave consumes the Wave 2 FP8/MXFP4 loader work and the Wave 1 router
+contract. There is currently one plan in this wave; if it is split further, the
+new files should share the same Wave 1 and Wave 2 dependency boundary.
+
+Plans:
+
+- `06_deepseek_v4_moe_op.md`

--- a/subagents/wave4/11_full_model_integration.md
+++ b/subagents/wave4/11_full_model_integration.md
@@ -1,0 +1,155 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plan 11: Full Model Integration
+
+## Goal
+
+Integrate the independently developed DeepSeek V4 AutoDeploy features and run
+reduced-layer, full-layer, and serving validation.
+
+This plan should start only after enough independent features have landed:
+
+- checkpoint classifier and quant override
+- E8M0 helpers
+- FP8 linear path
+- packed MXFP4 expert loader
+- router
+- V4 MoE op
+- sparse attention source op
+- V4 cache resources or a temporary correctness fallback
+- CUDA graph config support
+
+## Owner Scope
+
+Suggested files:
+
+- `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py`
+- `tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py`
+- `examples/auto_deploy/model_registry/models.yaml`
+- `examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml`
+- integration tests under `tests/unittest/_torch/auto_deploy/` as appropriate
+
+This agent must not rewrite independent feature implementations unless fixing
+integration bugs with focused patches.
+
+## Integration Steps
+
+1. Update the model scaffold to emit canonical V4 ops:
+   - `torch_deepseek_v4_sparse_attention`
+   - `torch_deepseek_v4_moe`
+2. Ensure checkpoint loading:
+   - loads normal layers
+   - loads `tid2eid`
+   - skips `mtp.0.*` explicitly
+   - treats skipped MTP as expected
+3. Add model registry entry and standalone YAML.
+4. Run reduced-layer AutoDeploy flow.
+5. Run full 43-layer load and graph transform.
+6. Enable decode with CUDA graph batch padding.
+7. Enable chunked prefill.
+8. Run serving sanity check.
+
+## Initial Runtime Config
+
+Start conservative:
+
+```yaml
+compile_backend: torch-cudagraph
+
+model_kwargs:
+  skip_mtp: true
+  ad_rope_cache_len: 8192
+
+runtime:
+  enable_chunked_prefill: true
+
+cuda_graph_config:
+  batch_sizes: [1, 2, 4, 8, 16, 32, 64]
+
+transforms:
+  quantize_deepseek_v4_from_config:
+    enabled: true
+  compile_model:
+    piecewise_enabled: true
+  multi_stream_moe:
+    enabled: false
+```
+
+## Validation Sequence
+
+### Reduced Layer
+
+- 2 to 4 layers.
+- Include at least:
+  - one uncompressed attention layer
+  - one ratio-4 layer
+  - one ratio-128 layer
+  - one hash-routed MoE layer
+  - one top-k MoE layer if possible
+
+### Full Layer
+
+- Load all 43 layers.
+- Skip MTP.
+- Confirm no accidental BF16 fallback for routed experts.
+- Confirm FP8 linears use loaded E8M0 scales.
+- Confirm no unexpected missing checkpoint keys except waived MTP keys.
+
+### Serving
+
+- Short prompt sanity.
+- Chunked prefill.
+- Decode with CUDA graphs.
+- Batch sizes 1, 2, 4, 8 first.
+- Larger batch sizes only after memory is characterized.
+
+## Integration Tests
+
+- Full checkpoint key loading test using metadata fixtures.
+- Reduced model export test.
+- Reduced model transform test.
+- Reduced model CUDA graph replay test.
+- Optional GPU generation smoke test.
+
+## Performance Bring-Up
+
+Record:
+
+- model load time
+- peak memory
+- prefill tokens/sec
+- decode tokens/sec
+- TTFT
+- TPOT
+- CUDA graph replay hit rate
+- routed expert load balance
+- all-to-all time if EP is enabled
+
+Compare against vLLM public numbers only as a directional sanity target.
+
+## Done Criteria
+
+- Reduced-layer run succeeds.
+- Full model loads and transforms.
+- Serving path works with CUDA graph enabled.
+- Known limitations are documented:
+  - MTP skipped
+  - maximum supported context length
+  - enabled MoE backend
+  - enabled attention backend
+  - any eager fallback regions

--- a/subagents/wave4/README.md
+++ b/subagents/wave4/README.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Wave 4
+
+This wave is for full model integration and should wait until prior waves have
+usable contracts. It is not intended to run in parallel with feature
+development except for read-only planning.
+
+Plans:
+
+- `11_full_model_integration.md`

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Compile backend with cudagraph.
 
 1. Monolithic CUDA graph: captures entire model as one graph for decode-only.
@@ -308,6 +323,14 @@ class PiecewiseCapturedGraph(nn.Module):
     Metadata-prep ops are wrapped in MetadataWrapper to keep their output
     addresses stable across capture and replay (prevents CUDA graph crashes).
     Inplace dynamic ops (see _INPLACE_DYNAMIC_OPS) run eagerly without wrapping.
+
+    DSV4 kernel contract:
+    - attention-like kernels that produce hidden states accept caller-owned out=
+      buffers and return a dummy tensor when out= is provided;
+    - metadata-prep and workspace tensors are caller-owned graph inputs, sized
+      for the captured bucket and interpreted through real token counts;
+    - cache resources such as swa_cache, mhc_cache, compressor_kv_cache, and
+      compressor_gate_cache stay graph inputs and are never allocated here.
     """
 
     def __init__(
@@ -721,6 +744,8 @@ class DualModeCapturedGraph(nn.Module):
       The tail beyond total_num_tokens is zeroed via reset_val=0 in nest_sequences
       to prevent stale values from leaking into the padding region during graph replay.
     - batch_info reflects real counts so dynamic ops process only real tokens.
+    - Dynamic kernels must zero or ignore padded slots before updating caller-owned
+      cache resources.
     - Output logits are truncated to total_num_tokens in forward().
     """
 

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
@@ -11,6 +11,7 @@ When piecewise_enabled=True, a DualModeCapturedGraph is returned that dispatches
 
 import copy  # noqa: I001
 import gc
+import math
 from collections import abc
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
@@ -879,6 +880,19 @@ def _setup_piecewise_mixed_batch(seq_info: Any, num_tokens: int) -> None:
     )
     max_seq = seq_info.max_seq_len
     max_batch = seq_info.max_batch_size
+
+    if not getattr(seq_info, "_use_flattened_layout", False):
+        min_batch = math.ceil(num_tokens / max_seq)
+        for batch_size in range(min_batch, max_batch + 1):
+            if num_tokens % batch_size == 0:
+                seq_len = num_tokens // batch_size
+                seq_info.set_example_sequence(torch.ones(batch_size, seq_len, dtype=torch.int))
+                return
+        raise ValueError(
+            f"Cannot build an unflattened piecewise sample for {num_tokens} tokens with "
+            f"max_seq_len={max_seq} and max_batch_size={max_batch}. Use a piecewise bucket "
+            "that can be represented as batch_size * seq_len."
+        )
 
     seq_lens: List[int] = []
     remaining = num_tokens - 1

--- a/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
@@ -73,6 +73,9 @@ _CACHED_DELTA_OPS = [
 
 _DEEPSEEK_V4_ATTENTION_OPS = [
     "auto_deploy::torch_deepseek_v4_sparse_attention",
+    "auto_deploy::torch_deepseek_v4_sparse_attention_with_cache",
+    "auto_deploy::torch_deepseek_v4_sparse_attention_v2",
+    "auto_deploy::torch_deepseek_v4_sparse_attention_v2_with_cache",
     "auto_deploy::triton_deepseek_v4_sparse_attention_with_cache",
 ]
 

--- a/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
@@ -25,7 +25,7 @@ This module provides the logic to:
 
 import operator
 from dataclasses import dataclass, field
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 import torch.nn as nn
 from torch.fx import GraphModule, Node
@@ -38,6 +38,69 @@ from ..utils.logger import ad_logger
 # mixed/prefill batches because they have data-dependent control flow or
 # dynamic kernel configurations.
 # ---------------------------------------------------------------------------
+
+DEEPSEEK_V4_CUDA_GRAPH_METADATA_ARG_NAMES = (
+    "batch_info_host",
+    "seq_len_host",
+    "input_pos_host",
+    "cu_seqlen_host",
+    "cache_loc_host",
+    "cu_num_pages_host",
+)
+
+DEEPSEEK_V4_CUDA_GRAPH_CACHE_RESOURCE_ARG_NAMES = (
+    "swa_cache",
+    "mhc_cache",
+    "compressor_kv_cache",
+    "compressor_gate_cache",
+)
+
+DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_ARG_NAME = "workspace"
+DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_SIZE_ARG_NAME = "workspace_size_bytes"
+
+DEEPSEEK_V4_CUDA_GRAPH_PADDED_SLOT_RULE = (
+    "Kernels must read real token/sequence counts from metadata tensors, zero any padded "
+    "output rows they materialize, and ignore padded slots for cache/resource updates."
+)
+
+
+@dataclass(frozen=True)
+class CudaGraphKernelContract:
+    """CUDA graph contract shared by dynamic DeepSeek V4 custom kernels.
+
+    ``out=`` buffers and workspace tensors are caller-owned. Dynamic kernels may
+    mutate those buffers but must not allocate replacement outputs/resources
+    during CUDA graph replay.
+    """
+
+    uses_out_buffer: bool
+    workspace_arg_name: Optional[str]
+    workspace_size_arg_name: Optional[str]
+    metadata_arg_names: tuple[str, ...] = ()
+    cache_resource_arg_names: tuple[str, ...] = ()
+    padded_slot_rule: str = DEEPSEEK_V4_CUDA_GRAPH_PADDED_SLOT_RULE
+
+
+DEEPSEEK_V4_ATTENTION_CUDA_GRAPH_CONTRACT = CudaGraphKernelContract(
+    uses_out_buffer=True,
+    workspace_arg_name=DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_ARG_NAME,
+    workspace_size_arg_name=DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_SIZE_ARG_NAME,
+    metadata_arg_names=DEEPSEEK_V4_CUDA_GRAPH_METADATA_ARG_NAMES,
+    cache_resource_arg_names=DEEPSEEK_V4_CUDA_GRAPH_CACHE_RESOURCE_ARG_NAMES,
+)
+
+DEEPSEEK_V4_METADATA_PREP_CUDA_GRAPH_CONTRACT = CudaGraphKernelContract(
+    uses_out_buffer=False,
+    workspace_arg_name=DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_ARG_NAME,
+    workspace_size_arg_name=DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_SIZE_ARG_NAME,
+    metadata_arg_names=DEEPSEEK_V4_CUDA_GRAPH_METADATA_ARG_NAMES,
+)
+
+DEEPSEEK_V4_ROUTE_METADATA_CUDA_GRAPH_CONTRACT = CudaGraphKernelContract(
+    uses_out_buffer=False,
+    workspace_arg_name=DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_ARG_NAME,
+    workspace_size_arg_name=DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_SIZE_ARG_NAME,
+)
 
 # Cached attention ops (grid depends on per-sequence lengths)
 _CACHED_ATTENTION_OPS = [
@@ -77,6 +140,7 @@ _DEEPSEEK_V4_ATTENTION_OPS = [
     "auto_deploy::torch_deepseek_v4_sparse_attention_v2",
     "auto_deploy::torch_deepseek_v4_sparse_attention_v2_with_cache",
     "auto_deploy::triton_deepseek_v4_sparse_attention_with_cache",
+    "auto_deploy::triton_deepseek_v4_sparse_attention_v2_with_cache",
 ]
 
 _DEEPSEEK_V4_MOE_OPS = [
@@ -89,6 +153,12 @@ _DEEPSEEK_V4_METADATA_PREP_OPS = [
     "auto_deploy::deepseek_v4_prepare_cache_metadata",
     "auto_deploy::torch_deepseek_v4_prepare_cache_metadata",
     "auto_deploy::triton_deepseek_v4_prepare_cache_metadata",
+    "auto_deploy::deepseek_v4_prepare_indexer_metadata",
+    "auto_deploy::torch_deepseek_v4_prepare_indexer_metadata",
+    "auto_deploy::triton_deepseek_v4_prepare_indexer_metadata",
+    "auto_deploy::deepseek_v4_prepare_route_metadata",
+    "auto_deploy::torch_deepseek_v4_prepare_route_metadata",
+    "auto_deploy::triton_deepseek_v4_prepare_route_metadata",
 ]
 
 # Metadata preparation ops (branch on batch_info_host, do CPU math on CUDA tensors)
@@ -137,6 +207,55 @@ _STREAM_SWITCH_FUNCTION_NAMES = frozenset(
 )
 
 
+def _op_target_name(node: Node) -> str:
+    target = node.target
+    if hasattr(target, "name"):
+        return target.name()
+    if hasattr(target, "__qualname__"):
+        return target.__qualname__
+    return str(target)
+
+
+def _matches_registered_op_name(op_name: str, registered_ops: list[str]) -> bool:
+    for registered_op in registered_ops:
+        if registered_op in op_name:
+            return True
+        base_name = registered_op.split("::")[-1] if "::" in registered_op else registered_op
+        if base_name in op_name:
+            return True
+    return False
+
+
+def _is_deepseek_v4_metadata_prep_op_name(op_name: str) -> bool:
+    if _matches_registered_op_name(op_name, _DEEPSEEK_V4_METADATA_PREP_OPS):
+        return True
+
+    base_name = op_name.split("::")[-1].split(".")[0].lower()
+    if "deepseek_v4" not in base_name or "metadata" not in base_name:
+        return False
+    return "prepare" in base_name or "prep" in base_name
+
+
+def get_deepseek_v4_cuda_graph_kernel_contract(
+    op_name: str,
+) -> Optional[CudaGraphKernelContract]:
+    """Return the DeepSeek V4 CUDA graph contract for a registered op name.
+
+    Workspace convention: kernels that need scratch memory take a caller-owned
+    tensor named ``workspace`` and a size/count argument named
+    ``workspace_size_bytes``. The size is for the captured bucket, and kernels
+    use metadata counts to ignore padded slots at runtime.
+    """
+    if _matches_registered_op_name(op_name, _DEEPSEEK_V4_ATTENTION_OPS):
+        return DEEPSEEK_V4_ATTENTION_CUDA_GRAPH_CONTRACT
+    if _is_deepseek_v4_metadata_prep_op_name(op_name):
+        base_name = op_name.split("::")[-1].lower()
+        if "route" in base_name or "routing" in base_name or "moe" in base_name:
+            return DEEPSEEK_V4_ROUTE_METADATA_CUDA_GRAPH_CONTRACT
+        return DEEPSEEK_V4_METADATA_PREP_CUDA_GRAPH_CONTRACT
+    return None
+
+
 def _get_all_dynamic_op_names() -> Set[str]:
     """Return the full set of dynamic op qualified names."""
     return set(
@@ -161,28 +280,15 @@ def is_dynamic_cached_op(node: Node) -> bool:
     if node.op != "call_function":
         return False
 
-    target = node.target
-    # Handle OpOverload: get the qualified name
-    if hasattr(target, "name"):
-        # torch._ops.OpOverload has .name() method
-        op_name = target.name()
-    elif hasattr(target, "__qualname__"):
-        op_name = target.__qualname__
-    else:
-        op_name = str(target)
+    op_name = _op_target_name(node)
+
+    if _is_deepseek_v4_metadata_prep_op_name(op_name):
+        return True
 
     # Strip the ".default" suffix if present for matching
     dynamic_ops = _get_all_dynamic_op_names()
     # Check with namespace::name format AND base name (for wrapper functions
-    for dyn_op in dynamic_ops:
-        if dyn_op in op_name:
-            return True
-        # Also check by base op name without namespace prefix
-        base_name = dyn_op.split("::")[-1] if "::" in dyn_op else dyn_op
-        if base_name in op_name:
-            return True
-
-    return False
+    return _matches_registered_op_name(op_name, list(dynamic_ops))
 
 
 # ---------------------------------------------------------------------------
@@ -258,7 +364,9 @@ def needs_out_buffer(submod: nn.Module) -> bool:
 
     for node in submod.graph.nodes:
         if node.op == "call_function" and is_dynamic_cached_op(node):
-            op_name = node.target.name() if hasattr(node.target, "name") else str(node.target)
+            op_name = _op_target_name(node)
+            if _is_deepseek_v4_metadata_prep_op_name(op_name):
+                return False
             for skip_op in _SKIP_OUT_DYNAMIC_OPS:
                 if skip_op in op_name:
                     return False
@@ -275,7 +383,9 @@ def is_metadata_prep(submod: nn.Module) -> bool:
 
     for node in submod.graph.nodes:
         if node.op == "call_function" and is_dynamic_cached_op(node):
-            op_name = node.target.name() if hasattr(node.target, "name") else str(node.target)
+            op_name = _op_target_name(node)
+            if _is_deepseek_v4_metadata_prep_op_name(op_name):
+                return True
             for prep_op in _METADATA_PREP_OPS:
                 if prep_op in op_name:
                     return True

--- a/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
@@ -1,7 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Utilities for piecewise CUDA graph: dynamic op registry, classification, and graph splitting.
 
 This module provides the logic to:
-1. Identify dynamic (uncapturable) custom ops in the FX graph (attention, SSM, conv, delta).
+1. Identify dynamic (uncapturable) custom ops in the FX graph
+   (attention, SSM, conv, delta, DeepSeek V4 sparse attention/MoE).
 2. Classify dynamic submodules by behaviour (inplace, metadata-prep, needs out= buffer).
 3. Split the FX GraphModule at dynamic op boundaries using torch.fx.passes.split_module.
 4. Return the split GraphModule and metadata about which submodules are dynamic vs static.
@@ -55,13 +71,30 @@ _CACHED_DELTA_OPS = [
     "auto_deploy::fla_cached_gated_delta_rule",
 ]
 
+_DEEPSEEK_V4_ATTENTION_OPS = [
+    "auto_deploy::torch_deepseek_v4_sparse_attention",
+    "auto_deploy::triton_deepseek_v4_sparse_attention_with_cache",
+]
+
+_DEEPSEEK_V4_MOE_OPS = [
+    "auto_deploy::torch_deepseek_v4_moe",
+    "auto_deploy::triton_mxfp4_moe",
+    "auto_deploy::triton_mxfp4_moe_ep",
+]
+
+_DEEPSEEK_V4_METADATA_PREP_OPS = [
+    "auto_deploy::deepseek_v4_prepare_cache_metadata",
+    "auto_deploy::torch_deepseek_v4_prepare_cache_metadata",
+    "auto_deploy::triton_deepseek_v4_prepare_cache_metadata",
+]
+
 # Metadata preparation ops (branch on batch_info_host, do CPU math on CUDA tensors)
 _METADATA_PREP_OPS = [
     "auto_deploy::flashinfer_attention_prepare_metadata",
     "auto_deploy::flashinfer_mla_prepare_metadata",
     "auto_deploy::triton_paged_prepare_metadata",
     "auto_deploy::mamba_ssm_prepare_metadata",
-]
+] + _DEEPSEEK_V4_METADATA_PREP_OPS
 
 # Logits gather ops (CPU branching on host tensor + shape-dependent logic)
 _LOGITS_GATHER_OPS = [
@@ -108,6 +141,8 @@ def _get_all_dynamic_op_names() -> Set[str]:
         + _CACHED_SSM_OPS
         + _CACHED_CONV_OPS
         + _CACHED_DELTA_OPS
+        + _DEEPSEEK_V4_ATTENTION_OPS
+        + _DEEPSEEK_V4_MOE_OPS
         + _METADATA_PREP_OPS
         + _LOGITS_GATHER_OPS
         + _PERSISTENT_BUFFER_OPS

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/README.md
@@ -15,6 +15,7 @@ The table below lists the operators grouped by category.
 | `torch.ops.auto_deploy.torch_attention` | Grouped SDPA implementation with `bsnd` and `bnsd` layout supported |
 | `torch.ops.auto_deploy.torch_attention_sdpa` | Standard scaled dot-product attention (SDPA) implementation |
 | `torch.ops.auto_deploy.torch_attention_repeat_kv` | KV repetition for grouped-query attention |
+| `torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention` | DeepSeek V4 sparse/HMA source attention with sink logits |
 | `torch.ops.auto_deploy.torch_cached_attention_with_cache` | PyTorch backend attention with KV cache management |
 | `torch.ops.auto_deploy.flashinfer_attention_mha_with_cache` | FlashInfer multi-head attention with KV cache support |
 | `torch.ops.auto_deploy.flashinfer_attention_prepare_metadata` | FlashInfer attention metadata preparation |

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/__init__.py
@@ -24,9 +24,11 @@ This module provides various attention implementations and backends:
 - triton_attention_with_kv_cache: Triton attention with KV cache support
 - triton_paged_attention: Triton paged attention (two-stage flash-decode) with HND layout
 - onnx_attention: Placeholder ops for ONNX export of attention mechanisms
+- deepseek_v4_attention: DeepSeek V4 sparse/HMA attention source op
 """
 
 __all__ = [
+    "deepseek_v4_attention",
     "torch_attention",
     "torch_backend_attention",
     "flashinfer_attention",

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/__init__.py
@@ -25,10 +25,12 @@ This module provides various attention implementations and backends:
 - triton_paged_attention: Triton paged attention (two-stage flash-decode) with HND layout
 - onnx_attention: Placeholder ops for ONNX export of attention mechanisms
 - deepseek_v4_attention: DeepSeek V4 sparse/HMA attention source op
+- deepseek_v4_kernels: DeepSeek V4 standalone attention kernel microfeatures
 """
 
 __all__ = [
     "deepseek_v4_attention",
+    "deepseek_v4_kernels",
     "torch_attention",
     "torch_backend_attention",
     "flashinfer_attention",

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/__init__.py
@@ -24,7 +24,7 @@ This module provides various attention implementations and backends:
 - triton_attention_with_kv_cache: Triton attention with KV cache support
 - triton_paged_attention: Triton paged attention (two-stage flash-decode) with HND layout
 - onnx_attention: Placeholder ops for ONNX export of attention mechanisms
-- deepseek_v4_attention: DeepSeek V4 sparse/HMA attention source op
+- deepseek_v4_attention: DeepSeek V4 sparse/HMA attention source and cached reference ops
 - deepseek_v4_kernels: DeepSeek V4 standalone attention kernel microfeatures
 """
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
@@ -71,9 +71,8 @@ def _validate_deepseek_v4_sparse_attention_inputs(
 def _gather_selected_kv(kv: torch.Tensor, topk_idxs: torch.Tensor) -> torch.Tensor:
     batch_size, seq_len, k_select = topk_idxs.shape
     head_dim = kv.shape[-1]
-    gather_idx = (
-        topk_idxs.to(torch.long).unsqueeze(-1).expand(batch_size, seq_len, k_select, head_dim)
-    )
+    gather_topk_idxs = topk_idxs.to(torch.long).clamp(min=0)
+    gather_idx = gather_topk_idxs.unsqueeze(-1).expand(batch_size, seq_len, k_select, head_dim)
     expanded_kv = kv.unsqueeze(1).expand(batch_size, seq_len, kv.shape[1], head_dim)
     return torch.gather(expanded_kv, dim=2, index=gather_idx)
 
@@ -94,7 +93,8 @@ def torch_deepseek_v4_sparse_attention(
         attn_sink: Per-head sink logits with shape ``[num_heads]``.
         topk_idxs: Selected row indices into ``kv`` with shape
             ``[batch, seq_len, k_select]``. Duplicate indices are preserved and
-            receive independent probability mass.
+            receive independent probability mass. Negative indices are masked
+            slots and receive zero probability.
         softmax_scale: Scale applied to query/key logits before adding the sink
             logit.
 
@@ -112,6 +112,8 @@ def torch_deepseek_v4_sparse_attention(
 
     logits = torch.einsum("bshd,bskd->bshk", q_compute, selected_kv_compute)
     logits = logits * softmax_scale
+    invalid = topk_idxs < 0
+    logits = logits.masked_fill(invalid.unsqueeze(2), float("-inf"))
     sink_logits = attn_sink.to(dtype=compute_dtype).reshape(1, 1, -1, 1)
     sink_logits = sink_logits.expand(q.shape[0], q.shape[1], q.shape[2], 1)
     logits_with_sink = torch.cat([logits, sink_logits], dim=-1)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
@@ -15,6 +15,8 @@
 
 """DeepSeek V4 sparse/HMA attention source op."""
 
+from typing import Optional
+
 import torch
 
 
@@ -28,6 +30,7 @@ def _validate_deepseek_v4_sparse_attention_inputs(
     kv: torch.Tensor,
     attn_sink: torch.Tensor,
     topk_idxs: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
 ) -> None:
     _validate_rank("q", q, 4)
     _validate_rank("kv", kv, 3)
@@ -66,6 +69,13 @@ def _validate_deepseek_v4_sparse_attention_inputs(
         raise ValueError(f"kv head dimension must be {head_dim}, got {kv_head_dim}")
     if attn_sink.shape[0] != num_heads:
         raise ValueError(f"attn_sink length must be {num_heads}, got {attn_sink.shape[0]}")
+    if out is not None:
+        if out.shape != q.shape:
+            raise ValueError(f"out shape must be {q.shape}, got {out.shape}")
+        if out.dtype != q.dtype:
+            raise TypeError(f"out dtype must be {q.dtype}, got {out.dtype}")
+        if out.device != q.device:
+            raise ValueError(f"out must be on {q.device}, got {out.device}")
 
 
 def _gather_selected_kv(kv: torch.Tensor, topk_idxs: torch.Tensor) -> torch.Tensor:
@@ -84,6 +94,7 @@ def torch_deepseek_v4_sparse_attention(
     attn_sink: torch.Tensor,
     topk_idxs: torch.Tensor,
     softmax_scale: float,
+    out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Reference DeepSeek V4 sparse/HMA attention source op.
 
@@ -103,7 +114,7 @@ def torch_deepseek_v4_sparse_attention(
         The sink participates in softmax normalization but contributes no value
         vector.
     """
-    _validate_deepseek_v4_sparse_attention_inputs(q, kv, attn_sink, topk_idxs)
+    _validate_deepseek_v4_sparse_attention_inputs(q, kv, attn_sink, topk_idxs, out)
 
     compute_dtype = torch.float32 if q.dtype in (torch.float16, torch.bfloat16) else q.dtype
     selected_kv = _gather_selected_kv(kv, topk_idxs)
@@ -121,7 +132,11 @@ def torch_deepseek_v4_sparse_attention(
     weights_with_sink = torch.softmax(logits_with_sink, dim=-1, dtype=torch.float32)
     weights = weights_with_sink[..., :-1].to(compute_dtype)
     output = torch.einsum("bshk,bskd->bshd", weights, selected_kv_compute)
-    return output.to(q.dtype).contiguous()
+    output = output.to(q.dtype).contiguous()
+    if out is not None:
+        out.copy_(output)
+        return out.new_empty(0)
+    return output
 
 
 @torch_deepseek_v4_sparse_attention.register_fake
@@ -131,10 +146,13 @@ def torch_deepseek_v4_sparse_attention_fake(
     attn_sink: torch.Tensor,
     topk_idxs: torch.Tensor,
     softmax_scale: float,
+    out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Fake implementation for torch.export tracing."""
     _validate_rank("q", q, 4)
     _validate_rank("kv", kv, 3)
     _validate_rank("attn_sink", attn_sink, 1)
     _validate_rank("topk_idxs", topk_idxs, 3)
+    if out is not None:
+        return out.new_empty(0)
     return q.new_empty(q.shape).contiguous()

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
@@ -15,9 +15,13 @@
 
 """DeepSeek V4 sparse/HMA attention source and cached reference ops."""
 
+import os
+import warnings
 from typing import List, Optional
 
 import torch
+import triton
+import triton.language as tl
 from torch.fx import Node
 
 from ..._compat import KvCacheConfig
@@ -32,14 +36,93 @@ from ..attention_interface import (
     MHACallable,
     ResourceHandlerDict,
 )
+from .deepseek_v4_fp8_cache import DSV4_FP8_NOPE_ATTENTION_UNSUPPORTED_REASON, FP8_E4M3_DTYPE
+from .triton_deepseek_v4_sparse_attention import (
+    _cache_layout_for_triton,
+    deepseek_v4_ratio0_swa_triton_skip_reason,
+    triton_deepseek_v4_ratio0_swa_attention_with_cache,
+)
 
 _SPARSE_ATTENTION_CHUNK_TARGET_BYTES = 512 * 1024 * 1024
 _SPARSE_ATTENTION_MAX_CHUNK_TOKENS = 64
+_DSV4_TRITON_LOCAL_NUM_HEADS = 8
+_DSV4_TRITON_HEAD_DIM = 512
+_DSV4_TRITON_ROPE_DIM = 64
+_DSV4_TRITON_WINDOW_SIZE = 128
+_DSV4_TRITON_RATIO4_MAX_COMPRESSED_LEN = 2048
+_DSV4_TRITON_RATIO4_COMPRESSED_TOPK = 512
+_DSV4_TRITON_RATIO128_MAX_COMPRESSED_LEN = 64
+_DSV4_TRITON_TOPK_WIDTH_BY_RATIO = {
+    0: 128,
+    4: 640,
+    128: 192,
+}
+_DSV4_TRITON_COMPRESSOR_DIM_BY_RATIO = {
+    0: 0,
+    4: 1024,
+    128: 512,
+}
+_DSV4_FORCE_TORCH_REFERENCE_ENV = "TRTLLM_AD_DSV4_SPARSE_ATTENTION_FORCE_TORCH"
+_DSV4_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
+
+
+def _force_torch_cached_reference() -> bool:
+    return os.getenv(_DSV4_FORCE_TORCH_REFERENCE_ENV, "").strip().lower() in _DSV4_TRUE_ENV_VALUES
+
+
+def _warn_torch_cached_reference_fallback(reason: str) -> None:
+    warnings.warn(
+        "auto_deploy::triton_deepseek_v4_sparse_attention_v2_with_cache is falling back to "
+        f"torch_deepseek_v4_sparse_attention_v2_with_cache: {reason}",
+        RuntimeWarning,
+        stacklevel=2,
+    )
 
 
 def _validate_rank(name: str, tensor: torch.Tensor, rank: int) -> None:
     if tensor.dim() != rank:
         raise ValueError(f"{name} must have rank {rank}, got rank {tensor.dim()}")
+
+
+def _validate_int_metadata(name: str, tensor: torch.Tensor) -> None:
+    if tensor.dim() != 1:
+        raise ValueError(f"{name} must have rank 1, got rank {tensor.dim()}")
+    if tensor.dtype not in (torch.int32, torch.int64, torch.int):
+        raise TypeError(f"{name} must be an int32/int64 tensor, got {tensor.dtype}")
+
+
+def _validate_contract_cache(
+    name: str,
+    cache: torch.Tensor,
+    head_dim: int,
+    dtype: torch.dtype,
+) -> None:
+    if cache.dim() not in (3, 4, 5):
+        raise ValueError(f"{name} must have rank 3, 4, or 5, got rank {cache.dim()}")
+    if cache.shape[-1] != head_dim:
+        raise ValueError(f"{name} last dimension must be {head_dim}, got {cache.shape[-1]}")
+    if cache.dtype != dtype:
+        if name == "swa_cache" and cache.dtype == FP8_E4M3_DTYPE:
+            raise TypeError(
+                f"{name} must have dtype {dtype}, got {cache.dtype}. "
+                f"{DSV4_FP8_NOPE_ATTENTION_UNSUPPORTED_REASON}"
+            )
+        raise TypeError(f"{name} must have dtype {dtype}, got {cache.dtype}")
+
+
+def _validate_contract_resource_placeholder(
+    name: str,
+    cache: torch.Tensor,
+) -> None:
+    if cache.dim() not in (3, 4, 5):
+        raise ValueError(f"{name} must have rank 3, 4, or 5, got rank {cache.dim()}")
+    if cache.shape[-1] not in (0, _DSV4_TRITON_HEAD_DIM, 2 * _DSV4_TRITON_HEAD_DIM):
+        raise ValueError(
+            f"{name} last dimension must be 0, {_DSV4_TRITON_HEAD_DIM}, or "
+            f"{2 * _DSV4_TRITON_HEAD_DIM}; got {cache.shape[-1]}"
+        )
+    if not (cache.is_floating_point() or cache.dtype == getattr(torch, "float8_e4m3fn", None)):
+        raise TypeError(f"{name} must be a floating-point cache placeholder, got {cache.dtype}")
 
 
 def _validate_deepseek_v4_sparse_attention_inputs(
@@ -701,6 +784,7 @@ def _update_compressed_caches(
     eps: float,
     rope_dim: int,
     compress_ratio: int,
+    max_compressed_len: int,
 ) -> None:
     if compress_ratio <= 0 or compressor_kv_seq.numel() == 0:
         return
@@ -724,8 +808,11 @@ def _update_compressed_caches(
         input_pos,
     )
 
-    old_completed = input_pos // compress_ratio
-    new_completed = (input_pos + compressor_kv_seq.shape[0]) // compress_ratio
+    old_completed = min(input_pos // compress_ratio, max_compressed_len)
+    new_completed = min(
+        (input_pos + compressor_kv_seq.shape[0]) // compress_ratio,
+        max_compressed_len,
+    )
     compressed_rows = []
     for row_idx in range(old_completed, new_completed):
         compressed_rows.append(
@@ -769,6 +856,7 @@ def _cached_compressed_attention(
     input_pos: int,
     window_size: int,
     compress_ratio: int,
+    max_compressed_len: int,
     softmax_scale: float,
 ) -> torch.Tensor:
     outputs = []
@@ -784,7 +872,7 @@ def _cached_compressed_attention(
             query_pos + 1,
             q_seq.dtype,
         )
-        compressed_len = (query_pos + 1) // compress_ratio
+        compressed_len = min((query_pos + 1) // compress_ratio, max_compressed_len)
         compressed_kv = _gather_paged_rows(
             mhc_cache,
             cache_loc_host,
@@ -1130,6 +1218,16 @@ def torch_deepseek_v4_sparse_attention_v2_with_cache(
     q_flat = q.reshape(-1, *q.shape[2:])
     output_flat = torch.zeros_like(q_flat)
 
+    if compress_ratio:
+        if max_compressed_len is None or max_compressed_len <= 0:
+            raise ValueError(
+                f"max_compressed_len must be positive for compress_ratio={compress_ratio}, "
+                f"got {max_compressed_len}"
+            )
+        compressed_capacity = int(max_compressed_len)
+    else:
+        compressed_capacity = 0
+
     for seq_idx in range(num_seq):
         seq_len_i = int(seq_len_host[seq_idx].item())
         if seq_len_i == 0:
@@ -1170,6 +1268,7 @@ def torch_deepseek_v4_sparse_attention_v2_with_cache(
                 rms_norm_eps,
                 rope_dim,
                 compress_ratio,
+                compressed_capacity,
             )
 
         if compress_ratio and input_pos_i > 0:
@@ -1184,6 +1283,7 @@ def torch_deepseek_v4_sparse_attention_v2_with_cache(
                 input_pos_i,
                 window_size,
                 compress_ratio,
+                compressed_capacity,
                 softmax_scale,
             )
         elif compress_ratio:
@@ -1292,9 +1392,3331 @@ def torch_deepseek_v4_sparse_attention_v2_with_cache_fake(
     return q.new_empty(q.shape).contiguous()
 
 
+def _device_skip_reason(name: str, tensor: torch.Tensor, path: str) -> str | None:
+    if not tensor.is_cuda:
+        return f"{name} must be a CUDA tensor for the Triton {path} path"
+    return None
+
+
+def _triton_metadata_on_q_device(tensor: torch.Tensor, q: torch.Tensor) -> torch.Tensor:
+    if q.is_cuda and tensor.device != q.device:
+        return tensor.to(device=q.device, non_blocking=True)
+    return tensor
+
+
+def _deepseek_v4_ratio0_prefill_mixed_triton_skip_reason(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    out: Optional[torch.Tensor],
+    num_seq: int,
+    active_tokens: int,
+) -> str | None:
+    """Return why the ratio-0 prefill/mixed Triton path cannot run, or ``None``."""
+    path = "ratio-0 prefill/mixed"
+    if compress_ratio != 0:
+        return f"compress_ratio must be 0 for the Triton {path} path, got {compress_ratio}"
+    if window_size != _DSV4_TRITON_WINDOW_SIZE:
+        return f"window_size must be {_DSV4_TRITON_WINDOW_SIZE}, got {window_size}"
+    if q.shape[2] != _DSV4_TRITON_LOCAL_NUM_HEADS:
+        return f"q local head count must be {_DSV4_TRITON_LOCAL_NUM_HEADS}, got {q.shape[2]}"
+    if q.shape[3] != _DSV4_TRITON_HEAD_DIM:
+        return f"q head dimension must be {_DSV4_TRITON_HEAD_DIM}, got {q.shape[3]}"
+    if kv.shape[:2] != q.shape[:2] or kv.shape[2] != _DSV4_TRITON_HEAD_DIM:
+        return (
+            f"kv must have shape {(q.shape[0], q.shape[1], _DSV4_TRITON_HEAD_DIM)}, "
+            f"got {tuple(kv.shape)}"
+        )
+    if topk_idxs.shape != (
+        q.shape[0],
+        q.shape[1],
+        _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[0],
+    ):
+        return (
+            "topk_idxs must have shape "
+            f"{(q.shape[0], q.shape[1], _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[0])}, "
+            f"got {tuple(topk_idxs.shape)}"
+        )
+    if attn_sink.shape != (_DSV4_TRITON_LOCAL_NUM_HEADS,):
+        return (
+            f"attn_sink must have shape ({_DSV4_TRITON_LOCAL_NUM_HEADS},), "
+            f"got {tuple(attn_sink.shape)}"
+        )
+    if q.dtype != torch.bfloat16:
+        return f"q must be bfloat16, got {q.dtype}"
+    if kv.dtype != torch.bfloat16:
+        return f"kv must be bfloat16, got {kv.dtype}"
+    if attn_sink.dtype != torch.float32:
+        return f"attn_sink must be float32, got {attn_sink.dtype}"
+    if topk_idxs.dtype not in (torch.int32, torch.int64):
+        return f"topk_idxs must be int32 or int64, got {topk_idxs.dtype}"
+    if swa_cache.dtype != torch.bfloat16:
+        return f"swa_cache must be bfloat16, got {swa_cache.dtype}"
+    if swa_cache.shape[-1] != _DSV4_TRITON_HEAD_DIM:
+        return (
+            f"swa_cache last dimension must be {_DSV4_TRITON_HEAD_DIM}, got {swa_cache.shape[-1]}"
+        )
+    if active_tokens <= 0:
+        return f"active_tokens must be positive, got {active_tokens}"
+    flat_capacity = int(q.shape[0] * q.shape[1])
+    if active_tokens > flat_capacity:
+        return f"active_tokens ({active_tokens}) exceed q capacity ({flat_capacity})"
+    if num_seq <= 0:
+        return f"num_seq must be positive, got {num_seq}"
+    if seq_len_host.numel() < num_seq:
+        return f"seq_len_host needs at least {num_seq} entries, got {seq_len_host.numel()}"
+    if input_pos_host.numel() < num_seq:
+        return f"input_pos_host needs at least {num_seq} entries, got {input_pos_host.numel()}"
+    if cu_seqlen_host.numel() < num_seq + 1:
+        return f"cu_seqlen_host needs at least {num_seq + 1} entries, got {cu_seqlen_host.numel()}"
+    if cu_num_pages_host.numel() < num_seq + 1:
+        return (
+            f"cu_num_pages_host needs at least {num_seq + 1} entries, "
+            f"got {cu_num_pages_host.numel()}"
+        )
+
+    for name, tensor in (
+        ("q", q),
+        ("kv", kv),
+        ("attn_sink", attn_sink),
+        ("topk_idxs", topk_idxs),
+        ("seq_len_host", seq_len_host),
+        ("input_pos_host", input_pos_host),
+        ("cu_seqlen_host", cu_seqlen_host),
+        ("cache_loc_host", cache_loc_host),
+        ("cu_num_pages_host", cu_num_pages_host),
+        ("swa_cache", swa_cache),
+    ):
+        reason = _device_skip_reason(name, tensor, path)
+        if reason is not None:
+            return reason
+        if tensor.device != q.device:
+            return f"{name} must be on {q.device}, got {tensor.device}"
+    if out is not None:
+        reason = _device_skip_reason("out", out, path)
+        if reason is not None:
+            return reason
+        if out.device != q.device:
+            return f"out must be on {q.device}, got {out.device}"
+        if out.shape != q.shape:
+            return f"out shape must be {tuple(q.shape)}, got {tuple(out.shape)}"
+        if out.dtype != q.dtype:
+            return f"out dtype must be {q.dtype}, got {out.dtype}"
+        if not out.is_contiguous():
+            return "out must be contiguous for the Triton ratio-0 prefill/mixed path"
+
+    for name, tensor in (
+        ("q", q),
+        ("kv", kv),
+        ("topk_idxs", topk_idxs),
+    ):
+        if not tensor.is_contiguous():
+            return f"{name} must be contiguous for the Triton ratio-0 prefill/mixed path"
+    if swa_cache.stride(-1) != 1:
+        return f"swa_cache last dimension must be contiguous, got stride {swa_cache.stride(-1)}"
+
+    try:
+        tokens_per_block, _, _ = _cache_layout_for_triton(swa_cache)
+    except ValueError as exc:
+        return str(exc)
+    if tokens_per_block <= 0:
+        return f"swa_cache tokens_per_block must be positive, got {tokens_per_block}"
+    return None
+
+
+@triton.jit
+def _update_ratio0_prefill_mixed_swa_cache_kernel(
+    kv_ptr,
+    input_pos_ptr,
+    cu_seqlen_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    swa_cache_ptr,
+    kv_stride_token: tl.constexpr,
+    kv_stride_dim: tl.constexpr,
+    cache_page_stride: tl.constexpr,
+    cache_token_stride: tl.constexpr,
+    tokens_per_block: tl.constexpr,
+    num_seq: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+    seq_idx = tl.full((), 0, dtype=tl.int64)
+    seq_start = tl.full((), 0, dtype=tl.int64)
+
+    for idx in range(num_seq):
+        start = tl.load(cu_seqlen_ptr + idx).to(tl.int64)
+        end = tl.load(cu_seqlen_ptr + idx + 1).to(tl.int64)
+        in_seq = (token_idx >= start) & (token_idx < end)
+        seq_idx = tl.where(in_seq, idx, seq_idx)
+        seq_start = tl.where(in_seq, start, seq_start)
+
+    token_offset = token_idx - seq_start
+    input_pos = tl.load(input_pos_ptr + seq_idx).to(tl.int64) + token_offset
+    page_ordinal = input_pos // tokens_per_block
+    page_offset = input_pos - page_ordinal * tokens_per_block
+    page_table_start = tl.load(cu_num_pages_ptr + seq_idx).to(tl.int64)
+    page_idx = tl.load(cache_loc_ptr + page_table_start + page_ordinal).to(tl.int64)
+
+    kv_offsets = token_idx * kv_stride_token + dim_offsets * kv_stride_dim
+    cache_offsets = page_idx * cache_page_stride + page_offset * cache_token_stride + dim_offsets
+    tl.store(
+        swa_cache_ptr + cache_offsets,
+        tl.load(kv_ptr + kv_offsets, mask=dim_mask, other=0.0),
+        mask=dim_mask,
+    )
+
+
+@triton.jit
+def _ratio0_prefill_mixed_swa_attention_kernel(
+    q_ptr,
+    attn_sink_ptr,
+    topk_idxs_ptr,
+    input_pos_ptr,
+    cu_seqlen_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    swa_cache_ptr,
+    out_ptr,
+    q_stride_token: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    q_stride_dim: tl.constexpr,
+    topk_stride_token: tl.constexpr,
+    topk_stride_topk: tl.constexpr,
+    out_stride_token: tl.constexpr,
+    out_stride_head: tl.constexpr,
+    out_stride_dim: tl.constexpr,
+    cache_page_stride: tl.constexpr,
+    cache_token_stride: tl.constexpr,
+    tokens_per_block: tl.constexpr,
+    num_seq: tl.constexpr,
+    active_tokens: tl.constexpr,
+    softmax_scale: tl.constexpr,
+    topk_width: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+    token_is_active = token_idx < active_tokens
+
+    out_offsets = (
+        token_idx * out_stride_token + head_idx * out_stride_head + dim_offsets * out_stride_dim
+    )
+    if not token_is_active:
+        tl.store(out_ptr + out_offsets, tl.zeros([block_dim], dtype=tl.float32), mask=dim_mask)
+        return
+
+    seq_idx = tl.full((), 0, dtype=tl.int64)
+    seq_start = tl.full((), 0, dtype=tl.int64)
+    for idx in range(num_seq):
+        start = tl.load(cu_seqlen_ptr + idx).to(tl.int64)
+        end = tl.load(cu_seqlen_ptr + idx + 1).to(tl.int64)
+        in_seq = (token_idx >= start) & (token_idx < end)
+        seq_idx = tl.where(in_seq, idx, seq_idx)
+        seq_start = tl.where(in_seq, start, seq_start)
+
+    token_offset = token_idx - seq_start
+    query_pos = tl.load(input_pos_ptr + seq_idx).to(tl.int64) + token_offset
+    page_table_start = tl.load(cu_num_pages_ptr + seq_idx).to(tl.int64)
+    q_offsets = token_idx * q_stride_token + head_idx * q_stride_head + dim_offsets * q_stride_dim
+    q_vec = tl.load(q_ptr + q_offsets, mask=dim_mask, other=0.0).to(tl.float32)
+
+    acc = tl.zeros([block_dim], dtype=tl.float32)
+    m_i = tl.load(attn_sink_ptr + head_idx).to(tl.float32)
+    l_i = tl.full((), 1.0, dtype=tl.float32)
+
+    for topk_offset in range(topk_width):
+        selected = tl.load(
+            topk_idxs_ptr + token_idx * topk_stride_token + topk_offset * topk_stride_topk
+        )
+        valid_topk = (selected >= 0) & (selected <= query_pos)
+        row_pos = selected.to(tl.int64)
+        page_ordinal = row_pos // tokens_per_block
+        page_offset = row_pos - page_ordinal * tokens_per_block
+        page_idx = tl.load(
+            cache_loc_ptr + page_table_start + page_ordinal,
+            mask=valid_topk,
+            other=0,
+        ).to(tl.int64)
+        cache_offsets = (
+            page_idx * cache_page_stride + page_offset * cache_token_stride + dim_offsets
+        )
+        kv_vec = tl.load(swa_cache_ptr + cache_offsets, mask=dim_mask & valid_topk, other=0.0).to(
+            tl.float32
+        )
+        logit = tl.sum(q_vec * kv_vec, axis=0) * softmax_scale
+        logit = tl.where(valid_topk, logit, float("-inf"))
+
+        m_next = tl.maximum(m_i, logit)
+        alpha = tl.exp(m_i - m_next)
+        beta = tl.exp(logit - m_next)
+        acc = acc * alpha + kv_vec * beta
+        l_i = l_i * alpha + beta
+        m_i = m_next
+
+    tl.store(out_ptr + out_offsets, acc / l_i, mask=dim_mask)
+
+
+def triton_deepseek_v4_ratio0_swa_prefill_mixed_attention_with_cache(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run ratio-0 cached DSV4 prefill/mixed attention through Triton kernels."""
+    batch_info = BatchInfo(batch_info_host)
+    num_prefill, num_prefill_tokens, num_decode = batch_info.get_absorbed_info()
+    num_seq = num_prefill + num_decode
+    active_tokens = num_prefill_tokens + num_decode
+
+    reason = _deepseek_v4_ratio0_prefill_mixed_triton_skip_reason(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        window_size,
+        0,
+        out,
+        num_seq,
+        active_tokens,
+    )
+    if reason is not None:
+        raise RuntimeError(reason)
+
+    tokens_per_block, cache_page_stride, cache_token_stride = _cache_layout_for_triton(swa_cache)
+    output = torch.empty_like(q) if out is None else out
+    flat_capacity = int(q.shape[0] * q.shape[1])
+    q_flat = q.reshape(flat_capacity, q.shape[2], q.shape[3])
+    kv_flat = kv.reshape(flat_capacity, kv.shape[2])
+    topk_flat = topk_idxs.reshape(flat_capacity, topk_idxs.shape[2])
+    output_flat = output.reshape(flat_capacity, output.shape[2], output.shape[3])
+    block_dim = triton.next_power_of_2(_DSV4_TRITON_HEAD_DIM)
+
+    _update_ratio0_prefill_mixed_swa_cache_kernel[(active_tokens,)](
+        kv_flat,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        kv_flat.stride(0),
+        kv_flat.stride(1),
+        cache_page_stride,
+        cache_token_stride,
+        tokens_per_block,
+        num_seq,
+        _DSV4_TRITON_HEAD_DIM,
+        block_dim,
+        num_warps=8,
+    )
+    _ratio0_prefill_mixed_swa_attention_kernel[(flat_capacity, _DSV4_TRITON_LOCAL_NUM_HEADS)](
+        q_flat,
+        attn_sink,
+        topk_flat,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        output_flat,
+        q_flat.stride(0),
+        q_flat.stride(1),
+        q_flat.stride(2),
+        topk_flat.stride(0),
+        topk_flat.stride(1),
+        output_flat.stride(0),
+        output_flat.stride(1),
+        output_flat.stride(2),
+        cache_page_stride,
+        cache_token_stride,
+        tokens_per_block,
+        num_seq,
+        active_tokens,
+        softmax_scale,
+        _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[0],
+        _DSV4_TRITON_HEAD_DIM,
+        block_dim,
+        num_warps=8,
+    )
+
+    if out is not None:
+        return out.new_empty(0)
+    return output
+
+
+def _deepseek_v4_ratio4_triton_skip_reason(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    max_compressed_len: Optional[int],
+    rope_dim: int,
+    out: Optional[torch.Tensor],
+    active_tokens: int,
+) -> str | None:
+    """Return why the ratio-4 Triton decode path cannot run, or ``None``."""
+    path = "ratio-4 compressed decode"
+    if compress_ratio != 4:
+        return f"compress_ratio must be 4 for the Triton {path} path, got {compress_ratio}"
+    if max_compressed_len != _DSV4_TRITON_RATIO4_MAX_COMPRESSED_LEN:
+        return (
+            "max_compressed_len must be "
+            f"{_DSV4_TRITON_RATIO4_MAX_COMPRESSED_LEN} for the Triton {path} path, "
+            f"got {max_compressed_len}"
+        )
+    if window_size != _DSV4_TRITON_WINDOW_SIZE:
+        return f"window_size must be {_DSV4_TRITON_WINDOW_SIZE}, got {window_size}"
+    if rope_dim != _DSV4_TRITON_ROPE_DIM:
+        return f"rope_dim must be {_DSV4_TRITON_ROPE_DIM}, got {rope_dim}"
+    if q.shape[1] != 1:
+        return "the Triton ratio-4 compressed path currently supports decode-only q.shape[1] == 1"
+    if topk_idxs.shape != (q.shape[0], q.shape[1], _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[4]):
+        return (
+            "topk_idxs must have shape "
+            f"{(q.shape[0], q.shape[1], _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[4])}, "
+            f"got {tuple(topk_idxs.shape)}"
+        )
+    if compressor_kv.shape != (q.shape[0], q.shape[1], 2 * _DSV4_TRITON_HEAD_DIM):
+        return (
+            "compressor_kv must have shape "
+            f"{(q.shape[0], q.shape[1], 2 * _DSV4_TRITON_HEAD_DIM)}, "
+            f"got {tuple(compressor_kv.shape)}"
+        )
+    if compressor_gate.shape != compressor_kv.shape:
+        return (
+            "compressor_gate must match compressor_kv shape, "
+            f"got {tuple(compressor_gate.shape)} and {tuple(compressor_kv.shape)}"
+        )
+    if compressor_ape.shape != (4, 2 * _DSV4_TRITON_HEAD_DIM):
+        return (
+            f"compressor_ape must have shape {(4, 2 * _DSV4_TRITON_HEAD_DIM)}, "
+            f"got {tuple(compressor_ape.shape)}"
+        )
+    if compressor_norm_weight.shape != (_DSV4_TRITON_HEAD_DIM,):
+        return (
+            f"compressor_norm_weight must have shape ({_DSV4_TRITON_HEAD_DIM},), "
+            f"got {tuple(compressor_norm_weight.shape)}"
+        )
+    if active_tokens <= 0:
+        return f"active_tokens must be positive, got {active_tokens}"
+    if active_tokens > q.shape[0]:
+        return f"active_tokens ({active_tokens}) exceed decode batch capacity ({q.shape[0]})"
+    if seq_len_host.numel() < active_tokens:
+        return f"seq_len_host needs at least {active_tokens} entries, got {seq_len_host.numel()}"
+    if input_pos_host.numel() < active_tokens:
+        return (
+            f"input_pos_host needs at least {active_tokens} entries, got {input_pos_host.numel()}"
+        )
+    if cu_seqlen_host.numel() < active_tokens + 1:
+        return (
+            f"cu_seqlen_host needs at least {active_tokens + 1} entries, "
+            f"got {cu_seqlen_host.numel()}"
+        )
+    if cu_num_pages_host.numel() < active_tokens + 1:
+        return (
+            f"cu_num_pages_host needs at least {active_tokens + 1} entries, "
+            f"got {cu_num_pages_host.numel()}"
+        )
+    if not freqs_cis_table.is_complex():
+        return f"freqs_cis_table must be complex, got {freqs_cis_table.dtype}"
+    if freqs_cis_table.shape[-1] != rope_dim // 2:
+        return (
+            f"freqs_cis_table last dimension must be {rope_dim // 2}, "
+            f"got {freqs_cis_table.shape[-1]}"
+        )
+
+    dtype_checks = (
+        ("q", q, torch.bfloat16),
+        ("kv", kv, torch.bfloat16),
+        ("attn_sink", attn_sink, torch.float32),
+        ("compressor_kv", compressor_kv, torch.bfloat16),
+        ("compressor_gate", compressor_gate, torch.bfloat16),
+        ("compressor_norm_weight", compressor_norm_weight, torch.float32),
+        ("swa_cache", swa_cache, torch.bfloat16),
+        ("mhc_cache", mhc_cache, torch.bfloat16),
+    )
+    for name, tensor, dtype in dtype_checks:
+        if tensor.dtype != dtype:
+            return f"{name} must be {dtype}, got {tensor.dtype}"
+    if compressor_ape.dtype not in (torch.bfloat16, torch.float32):
+        return f"compressor_ape must be bfloat16 or float32, got {compressor_ape.dtype}"
+    if compressor_kv_cache.dtype not in (torch.bfloat16, torch.float32):
+        return f"compressor_kv_cache must be bfloat16 or float32, got {compressor_kv_cache.dtype}"
+    if compressor_gate_cache.dtype not in (torch.bfloat16, torch.float32):
+        return (
+            f"compressor_gate_cache must be bfloat16 or float32, got {compressor_gate_cache.dtype}"
+        )
+    if topk_idxs.dtype not in (torch.int32, torch.int64):
+        return f"topk_idxs must be int32 or int64, got {topk_idxs.dtype}"
+
+    for name, tensor in (
+        ("q", q),
+        ("kv", kv),
+        ("attn_sink", attn_sink),
+        ("topk_idxs", topk_idxs),
+        ("compressor_kv", compressor_kv),
+        ("compressor_gate", compressor_gate),
+        ("compressor_ape", compressor_ape),
+        ("compressor_norm_weight", compressor_norm_weight),
+        ("freqs_cis_table", freqs_cis_table),
+        ("seq_len_host", seq_len_host),
+        ("input_pos_host", input_pos_host),
+        ("cu_seqlen_host", cu_seqlen_host),
+        ("cache_loc_host", cache_loc_host),
+        ("cu_num_pages_host", cu_num_pages_host),
+        ("swa_cache", swa_cache),
+        ("mhc_cache", mhc_cache),
+        ("compressor_kv_cache", compressor_kv_cache),
+        ("compressor_gate_cache", compressor_gate_cache),
+    ):
+        reason = _device_skip_reason(name, tensor, path)
+        if reason is not None:
+            return reason
+    if out is not None:
+        reason = _device_skip_reason("out", out, path)
+        if reason is not None:
+            return reason
+
+    for name, tensor in (
+        ("q", q),
+        ("kv", kv),
+        ("compressor_kv", compressor_kv),
+        ("compressor_gate", compressor_gate),
+        ("swa_cache", swa_cache),
+        ("mhc_cache", mhc_cache),
+        ("compressor_kv_cache", compressor_kv_cache),
+        ("compressor_gate_cache", compressor_gate_cache),
+    ):
+        if tensor.stride(-1) != 1:
+            return f"{name} last dimension must be contiguous, got stride {tensor.stride(-1)}"
+    if compressor_kv_cache.shape[-1] < 2 * _DSV4_TRITON_HEAD_DIM:
+        return (
+            f"compressor_kv_cache last dimension must be at least {2 * _DSV4_TRITON_HEAD_DIM}, "
+            f"got {compressor_kv_cache.shape[-1]}"
+        )
+    if compressor_gate_cache.shape[-1] < 2 * _DSV4_TRITON_HEAD_DIM:
+        return (
+            f"compressor_gate_cache last dimension must be at least {2 * _DSV4_TRITON_HEAD_DIM}, "
+            f"got {compressor_gate_cache.shape[-1]}"
+        )
+    try:
+        for cache_name, cache in (
+            ("swa_cache", swa_cache),
+            ("mhc_cache", mhc_cache),
+            ("compressor_kv_cache", compressor_kv_cache),
+            ("compressor_gate_cache", compressor_gate_cache),
+        ):
+            tokens_per_block, _, _ = _cache_layout_for_triton(cache)
+            if tokens_per_block <= 0:
+                return f"{cache_name} tokens_per_block must be positive, got {tokens_per_block}"
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def _deepseek_v4_ratio128_triton_skip_reason(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    max_compressed_len: Optional[int],
+    rope_dim: int,
+    out: Optional[torch.Tensor],
+    active_tokens: int,
+) -> str | None:
+    """Return why the ratio-128 Triton decode path cannot run, or ``None``."""
+    path = "ratio-128 compressed decode"
+    if compress_ratio != 128:
+        return f"compress_ratio must be 128 for the Triton {path} path, got {compress_ratio}"
+    if max_compressed_len != _DSV4_TRITON_RATIO128_MAX_COMPRESSED_LEN:
+        return (
+            "max_compressed_len must be "
+            f"{_DSV4_TRITON_RATIO128_MAX_COMPRESSED_LEN} for the Triton {path} path, "
+            f"got {max_compressed_len}"
+        )
+    if window_size != _DSV4_TRITON_WINDOW_SIZE:
+        return f"window_size must be {_DSV4_TRITON_WINDOW_SIZE}, got {window_size}"
+    if rope_dim != _DSV4_TRITON_ROPE_DIM:
+        return f"rope_dim must be {_DSV4_TRITON_ROPE_DIM}, got {rope_dim}"
+    if q.shape[1] != 1:
+        return "the Triton ratio-128 compressed path currently supports decode-only q.shape[1] == 1"
+    if topk_idxs.shape != (q.shape[0], q.shape[1], _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[128]):
+        return (
+            "topk_idxs must have shape "
+            f"{(q.shape[0], q.shape[1], _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[128])}, "
+            f"got {tuple(topk_idxs.shape)}"
+        )
+    if compressor_kv.shape != (q.shape[0], q.shape[1], _DSV4_TRITON_HEAD_DIM):
+        return (
+            f"compressor_kv must have shape {(q.shape[0], q.shape[1], _DSV4_TRITON_HEAD_DIM)}, "
+            f"got {tuple(compressor_kv.shape)}"
+        )
+    if compressor_gate.shape != compressor_kv.shape:
+        return (
+            "compressor_gate must match compressor_kv shape, "
+            f"got {tuple(compressor_gate.shape)} and {tuple(compressor_kv.shape)}"
+        )
+    if compressor_ape.shape != (128, _DSV4_TRITON_HEAD_DIM):
+        return (
+            f"compressor_ape must have shape {(128, _DSV4_TRITON_HEAD_DIM)}, "
+            f"got {tuple(compressor_ape.shape)}"
+        )
+    if compressor_norm_weight.shape != (_DSV4_TRITON_HEAD_DIM,):
+        return (
+            f"compressor_norm_weight must have shape ({_DSV4_TRITON_HEAD_DIM},), "
+            f"got {tuple(compressor_norm_weight.shape)}"
+        )
+    if active_tokens <= 0:
+        return f"active_tokens must be positive, got {active_tokens}"
+    if active_tokens > q.shape[0]:
+        return f"active_tokens ({active_tokens}) exceed decode batch capacity ({q.shape[0]})"
+    if seq_len_host.numel() < active_tokens:
+        return f"seq_len_host needs at least {active_tokens} entries, got {seq_len_host.numel()}"
+    if input_pos_host.numel() < active_tokens:
+        return (
+            f"input_pos_host needs at least {active_tokens} entries, got {input_pos_host.numel()}"
+        )
+    if cu_seqlen_host.numel() < active_tokens + 1:
+        return (
+            f"cu_seqlen_host needs at least {active_tokens + 1} entries, "
+            f"got {cu_seqlen_host.numel()}"
+        )
+    if cu_num_pages_host.numel() < active_tokens + 1:
+        return (
+            f"cu_num_pages_host needs at least {active_tokens + 1} entries, "
+            f"got {cu_num_pages_host.numel()}"
+        )
+    if not freqs_cis_table.is_complex():
+        return f"freqs_cis_table must be complex, got {freqs_cis_table.dtype}"
+    if freqs_cis_table.shape[-1] != rope_dim // 2:
+        return (
+            f"freqs_cis_table last dimension must be {rope_dim // 2}, "
+            f"got {freqs_cis_table.shape[-1]}"
+        )
+
+    dtype_checks = (
+        ("q", q, torch.bfloat16),
+        ("kv", kv, torch.bfloat16),
+        ("attn_sink", attn_sink, torch.float32),
+        ("compressor_kv", compressor_kv, torch.bfloat16),
+        ("compressor_gate", compressor_gate, torch.bfloat16),
+        ("compressor_norm_weight", compressor_norm_weight, torch.float32),
+        ("swa_cache", swa_cache, torch.bfloat16),
+        ("mhc_cache", mhc_cache, torch.bfloat16),
+    )
+    for name, tensor, dtype in dtype_checks:
+        if tensor.dtype != dtype:
+            return f"{name} must be {dtype}, got {tensor.dtype}"
+    if compressor_ape.dtype not in (torch.bfloat16, torch.float32):
+        return f"compressor_ape must be bfloat16 or float32, got {compressor_ape.dtype}"
+    if compressor_kv_cache.dtype not in (torch.bfloat16, torch.float32):
+        return f"compressor_kv_cache must be bfloat16 or float32, got {compressor_kv_cache.dtype}"
+    if compressor_gate_cache.dtype not in (torch.bfloat16, torch.float32):
+        return (
+            f"compressor_gate_cache must be bfloat16 or float32, got {compressor_gate_cache.dtype}"
+        )
+    if topk_idxs.dtype not in (torch.int32, torch.int64):
+        return f"topk_idxs must be int32 or int64, got {topk_idxs.dtype}"
+
+    for name, tensor in (
+        ("q", q),
+        ("kv", kv),
+        ("attn_sink", attn_sink),
+        ("topk_idxs", topk_idxs),
+        ("compressor_kv", compressor_kv),
+        ("compressor_gate", compressor_gate),
+        ("compressor_ape", compressor_ape),
+        ("compressor_norm_weight", compressor_norm_weight),
+        ("freqs_cis_table", freqs_cis_table),
+        ("seq_len_host", seq_len_host),
+        ("input_pos_host", input_pos_host),
+        ("cu_seqlen_host", cu_seqlen_host),
+        ("cache_loc_host", cache_loc_host),
+        ("cu_num_pages_host", cu_num_pages_host),
+        ("swa_cache", swa_cache),
+        ("mhc_cache", mhc_cache),
+        ("compressor_kv_cache", compressor_kv_cache),
+        ("compressor_gate_cache", compressor_gate_cache),
+    ):
+        reason = _device_skip_reason(name, tensor, path)
+        if reason is not None:
+            return reason
+    if out is not None:
+        reason = _device_skip_reason("out", out, path)
+        if reason is not None:
+            return reason
+
+    for name, tensor in (
+        ("q", q),
+        ("kv", kv),
+        ("compressor_kv", compressor_kv),
+        ("compressor_gate", compressor_gate),
+        ("swa_cache", swa_cache),
+        ("mhc_cache", mhc_cache),
+        ("compressor_kv_cache", compressor_kv_cache),
+        ("compressor_gate_cache", compressor_gate_cache),
+    ):
+        if tensor.stride(-1) != 1:
+            return f"{name} last dimension must be contiguous, got stride {tensor.stride(-1)}"
+    if compressor_kv_cache.shape[-1] < _DSV4_TRITON_HEAD_DIM:
+        return (
+            f"compressor_kv_cache last dimension must be at least {_DSV4_TRITON_HEAD_DIM}, "
+            f"got {compressor_kv_cache.shape[-1]}"
+        )
+    if compressor_gate_cache.shape[-1] < _DSV4_TRITON_HEAD_DIM:
+        return (
+            f"compressor_gate_cache last dimension must be at least {_DSV4_TRITON_HEAD_DIM}, "
+            f"got {compressor_gate_cache.shape[-1]}"
+        )
+    try:
+        for cache_name, cache in (
+            ("swa_cache", swa_cache),
+            ("mhc_cache", mhc_cache),
+            ("compressor_kv_cache", compressor_kv_cache),
+            ("compressor_gate_cache", compressor_gate_cache),
+        ):
+            tokens_per_block, _, _ = _cache_layout_for_triton(cache)
+            if tokens_per_block <= 0:
+                return f"{cache_name} tokens_per_block must be positive, got {tokens_per_block}"
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def _deepseek_v4_compressed_prefill_mixed_triton_skip_reason(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    max_compressed_len: Optional[int],
+    rope_dim: int,
+    out: Optional[torch.Tensor],
+    num_seq: int,
+    active_tokens: int,
+) -> str | None:
+    """Return why the compressed prefill/mixed Triton path cannot run, or ``None``."""
+    path = f"ratio-{compress_ratio} compressed prefill/mixed"
+    if compress_ratio not in (4, 128):
+        return f"compress_ratio must be 4 or 128 for the Triton {path} path, got {compress_ratio}"
+    expected_max_compressed_len = (
+        _DSV4_TRITON_RATIO4_MAX_COMPRESSED_LEN
+        if compress_ratio == 4
+        else _DSV4_TRITON_RATIO128_MAX_COMPRESSED_LEN
+    )
+    if max_compressed_len != expected_max_compressed_len:
+        return (
+            f"max_compressed_len must be {expected_max_compressed_len} for the Triton "
+            f"{path} path, got {max_compressed_len}"
+        )
+    if window_size != _DSV4_TRITON_WINDOW_SIZE:
+        return f"window_size must be {_DSV4_TRITON_WINDOW_SIZE}, got {window_size}"
+    if rope_dim != _DSV4_TRITON_ROPE_DIM:
+        return f"rope_dim must be {_DSV4_TRITON_ROPE_DIM}, got {rope_dim}"
+    if q.shape[2] != _DSV4_TRITON_LOCAL_NUM_HEADS:
+        return f"q local head count must be {_DSV4_TRITON_LOCAL_NUM_HEADS}, got {q.shape[2]}"
+    if q.shape[3] != _DSV4_TRITON_HEAD_DIM:
+        return f"q head dimension must be {_DSV4_TRITON_HEAD_DIM}, got {q.shape[3]}"
+    if kv.shape != (q.shape[0], q.shape[1], _DSV4_TRITON_HEAD_DIM):
+        return (
+            f"kv must have shape {(q.shape[0], q.shape[1], _DSV4_TRITON_HEAD_DIM)}, "
+            f"got {tuple(kv.shape)}"
+        )
+    expected_topk_shape = (
+        q.shape[0],
+        q.shape[1],
+        _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[compress_ratio],
+    )
+    if topk_idxs.shape != expected_topk_shape:
+        return f"topk_idxs must have shape {expected_topk_shape}, got {tuple(topk_idxs.shape)}"
+    state_dim = _DSV4_TRITON_COMPRESSOR_DIM_BY_RATIO[compress_ratio]
+    expected_state_shape = (q.shape[0], q.shape[1], state_dim)
+    if compressor_kv.shape != expected_state_shape:
+        return f"compressor_kv must have shape {expected_state_shape}, got {tuple(compressor_kv.shape)}"
+    if compressor_gate.shape != expected_state_shape:
+        return (
+            f"compressor_gate must have shape {expected_state_shape}, "
+            f"got {tuple(compressor_gate.shape)}"
+        )
+    if compressor_ape.shape != (compress_ratio, state_dim):
+        return (
+            f"compressor_ape must have shape {(compress_ratio, state_dim)}, "
+            f"got {tuple(compressor_ape.shape)}"
+        )
+    if compressor_norm_weight.shape != (_DSV4_TRITON_HEAD_DIM,):
+        return (
+            f"compressor_norm_weight must have shape ({_DSV4_TRITON_HEAD_DIM},), "
+            f"got {tuple(compressor_norm_weight.shape)}"
+        )
+    if attn_sink.shape != (_DSV4_TRITON_LOCAL_NUM_HEADS,):
+        return (
+            f"attn_sink must have shape ({_DSV4_TRITON_LOCAL_NUM_HEADS},), "
+            f"got {tuple(attn_sink.shape)}"
+        )
+    if active_tokens <= 0:
+        return f"active_tokens must be positive, got {active_tokens}"
+    flat_capacity = int(q.shape[0] * q.shape[1])
+    if active_tokens > flat_capacity:
+        return f"active_tokens ({active_tokens}) exceed q capacity ({flat_capacity})"
+    if num_seq <= 0:
+        return f"num_seq must be positive, got {num_seq}"
+    if seq_len_host.numel() < num_seq:
+        return f"seq_len_host needs at least {num_seq} entries, got {seq_len_host.numel()}"
+    if input_pos_host.numel() < num_seq:
+        return f"input_pos_host needs at least {num_seq} entries, got {input_pos_host.numel()}"
+    if cu_seqlen_host.numel() < num_seq + 1:
+        return f"cu_seqlen_host needs at least {num_seq + 1} entries, got {cu_seqlen_host.numel()}"
+    if cu_num_pages_host.numel() < num_seq + 1:
+        return (
+            f"cu_num_pages_host needs at least {num_seq + 1} entries, "
+            f"got {cu_num_pages_host.numel()}"
+        )
+    if not freqs_cis_table.is_complex():
+        return f"freqs_cis_table must be complex, got {freqs_cis_table.dtype}"
+    if freqs_cis_table.shape[-1] != rope_dim // 2:
+        return (
+            f"freqs_cis_table last dimension must be {rope_dim // 2}, "
+            f"got {freqs_cis_table.shape[-1]}"
+        )
+
+    dtype_checks = (
+        ("q", q, torch.bfloat16),
+        ("kv", kv, torch.bfloat16),
+        ("attn_sink", attn_sink, torch.float32),
+        ("compressor_kv", compressor_kv, torch.bfloat16),
+        ("compressor_gate", compressor_gate, torch.bfloat16),
+        ("compressor_norm_weight", compressor_norm_weight, torch.float32),
+        ("swa_cache", swa_cache, torch.bfloat16),
+        ("mhc_cache", mhc_cache, torch.bfloat16),
+    )
+    for name, tensor, dtype in dtype_checks:
+        if tensor.dtype != dtype:
+            return f"{name} must be {dtype}, got {tensor.dtype}"
+    if compressor_ape.dtype not in (torch.bfloat16, torch.float32):
+        return f"compressor_ape must be bfloat16 or float32, got {compressor_ape.dtype}"
+    if compressor_kv_cache.dtype not in (torch.bfloat16, torch.float32):
+        return f"compressor_kv_cache must be bfloat16 or float32, got {compressor_kv_cache.dtype}"
+    if compressor_gate_cache.dtype not in (torch.bfloat16, torch.float32):
+        return (
+            f"compressor_gate_cache must be bfloat16 or float32, got {compressor_gate_cache.dtype}"
+        )
+    if topk_idxs.dtype not in (torch.int32, torch.int64):
+        return f"topk_idxs must be int32 or int64, got {topk_idxs.dtype}"
+
+    for name, tensor in (
+        ("q", q),
+        ("kv", kv),
+        ("attn_sink", attn_sink),
+        ("topk_idxs", topk_idxs),
+        ("compressor_kv", compressor_kv),
+        ("compressor_gate", compressor_gate),
+        ("compressor_ape", compressor_ape),
+        ("compressor_norm_weight", compressor_norm_weight),
+        ("freqs_cis_table", freqs_cis_table),
+        ("seq_len_host", seq_len_host),
+        ("input_pos_host", input_pos_host),
+        ("cu_seqlen_host", cu_seqlen_host),
+        ("cache_loc_host", cache_loc_host),
+        ("cu_num_pages_host", cu_num_pages_host),
+        ("swa_cache", swa_cache),
+        ("mhc_cache", mhc_cache),
+        ("compressor_kv_cache", compressor_kv_cache),
+        ("compressor_gate_cache", compressor_gate_cache),
+    ):
+        reason = _device_skip_reason(name, tensor, path)
+        if reason is not None:
+            return reason
+        if tensor.device != q.device:
+            return f"{name} must be on {q.device}, got {tensor.device}"
+    if out is not None:
+        reason = _device_skip_reason("out", out, path)
+        if reason is not None:
+            return reason
+        if out.device != q.device:
+            return f"out must be on {q.device}, got {out.device}"
+        if out.shape != q.shape:
+            return f"out shape must be {tuple(q.shape)}, got {tuple(out.shape)}"
+        if out.dtype != q.dtype:
+            return f"out dtype must be {q.dtype}, got {out.dtype}"
+        if not out.is_contiguous():
+            return f"out must be contiguous for the Triton {path} path"
+
+    for name, tensor in (
+        ("q", q),
+        ("kv", kv),
+        ("topk_idxs", topk_idxs),
+        ("compressor_kv", compressor_kv),
+        ("compressor_gate", compressor_gate),
+    ):
+        if not tensor.is_contiguous():
+            return f"{name} must be contiguous for the Triton {path} path"
+    for name, tensor in (
+        ("swa_cache", swa_cache),
+        ("mhc_cache", mhc_cache),
+        ("compressor_kv_cache", compressor_kv_cache),
+        ("compressor_gate_cache", compressor_gate_cache),
+    ):
+        if tensor.stride(-1) != 1:
+            return f"{name} last dimension must be contiguous, got stride {tensor.stride(-1)}"
+    if compressor_kv_cache.shape[-1] < state_dim:
+        return (
+            f"compressor_kv_cache last dimension must be at least {state_dim}, "
+            f"got {compressor_kv_cache.shape[-1]}"
+        )
+    if compressor_gate_cache.shape[-1] < state_dim:
+        return (
+            f"compressor_gate_cache last dimension must be at least {state_dim}, "
+            f"got {compressor_gate_cache.shape[-1]}"
+        )
+    try:
+        for cache_name, cache in (
+            ("swa_cache", swa_cache),
+            ("mhc_cache", mhc_cache),
+            ("compressor_kv_cache", compressor_kv_cache),
+            ("compressor_gate_cache", compressor_gate_cache),
+        ):
+            tokens_per_block, _, _ = _cache_layout_for_triton(cache)
+            if tokens_per_block <= 0:
+                return f"{cache_name} tokens_per_block must be positive, got {tokens_per_block}"
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+@triton.jit
+def _build_prefill_mixed_token_metadata_kernel(
+    seq_len_ptr,
+    input_pos_ptr,
+    cu_seqlen_ptr,
+    cu_num_pages_ptr,
+    token_input_pos_ptr,
+    token_cu_num_pages_ptr,
+    num_seq: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    seq_idx = tl.full((), 0, dtype=tl.int64)
+    seq_start = tl.full((), 0, dtype=tl.int64)
+
+    for idx in range(num_seq):
+        start = tl.load(cu_seqlen_ptr + idx).to(tl.int64)
+        end = tl.load(cu_seqlen_ptr + idx + 1).to(tl.int64)
+        in_seq = (token_idx >= start) & (token_idx < end)
+        seq_idx = tl.where(in_seq, idx, seq_idx)
+        seq_start = tl.where(in_seq, start, seq_start)
+
+    token_offset = token_idx - seq_start
+    input_pos = tl.load(input_pos_ptr + seq_idx).to(tl.int64) + token_offset
+    page_table_start = tl.load(cu_num_pages_ptr + seq_idx).to(tl.int64)
+    tl.store(token_input_pos_ptr + token_idx, input_pos)
+    tl.store(token_cu_num_pages_ptr + token_idx, page_table_start)
+
+
+@triton.jit
+def _update_ratio4_decode_caches_kernel(
+    kv_ptr,
+    compressor_kv_ptr,
+    compressor_gate_ptr,
+    input_pos_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    swa_cache_ptr,
+    compressor_kv_cache_ptr,
+    compressor_gate_cache_ptr,
+    kv_stride_batch: tl.constexpr,
+    kv_stride_dim: tl.constexpr,
+    compressor_kv_stride_batch: tl.constexpr,
+    compressor_kv_stride_dim: tl.constexpr,
+    compressor_gate_stride_batch: tl.constexpr,
+    compressor_gate_stride_dim: tl.constexpr,
+    swa_cache_page_stride: tl.constexpr,
+    swa_cache_token_stride: tl.constexpr,
+    compressor_cache_page_stride: tl.constexpr,
+    compressor_cache_token_stride: tl.constexpr,
+    swa_tokens_per_block: tl.constexpr,
+    compressor_tokens_per_block: tl.constexpr,
+    head_dim: tl.constexpr,
+    state_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    dim_offsets = tl.arange(0, block_dim)
+    head_mask = dim_offsets < head_dim
+    state_mask = dim_offsets < state_dim
+    input_pos = tl.load(input_pos_ptr + token_idx)
+    page_table_start = tl.load(cu_num_pages_ptr + token_idx)
+
+    swa_page_ordinal = input_pos // swa_tokens_per_block
+    swa_token_offset = input_pos - swa_page_ordinal * swa_tokens_per_block
+    swa_page_idx = tl.load(cache_loc_ptr + page_table_start + swa_page_ordinal).to(tl.int64)
+    swa_offsets = swa_page_idx * swa_cache_page_stride + swa_token_offset * swa_cache_token_stride
+    kv_offsets = token_idx * kv_stride_batch + dim_offsets * kv_stride_dim
+    tl.store(
+        swa_cache_ptr + swa_offsets + dim_offsets,
+        tl.load(kv_ptr + kv_offsets, mask=head_mask),
+        mask=head_mask,
+    )
+
+    compressor_page_ordinal = input_pos // compressor_tokens_per_block
+    compressor_token_offset = input_pos - compressor_page_ordinal * compressor_tokens_per_block
+    compressor_page_idx = tl.load(cache_loc_ptr + page_table_start + compressor_page_ordinal).to(
+        tl.int64
+    )
+    compressor_offsets = (
+        compressor_page_idx * compressor_cache_page_stride
+        + compressor_token_offset * compressor_cache_token_stride
+        + dim_offsets
+    )
+    compressor_kv_offsets = (
+        token_idx * compressor_kv_stride_batch + dim_offsets * compressor_kv_stride_dim
+    )
+    compressor_gate_offsets = (
+        token_idx * compressor_gate_stride_batch + dim_offsets * compressor_gate_stride_dim
+    )
+    tl.store(
+        compressor_kv_cache_ptr + compressor_offsets,
+        tl.load(compressor_kv_ptr + compressor_kv_offsets, mask=state_mask),
+        mask=state_mask,
+    )
+    tl.store(
+        compressor_gate_cache_ptr + compressor_offsets,
+        tl.load(compressor_gate_ptr + compressor_gate_offsets, mask=state_mask),
+        mask=state_mask,
+    )
+
+
+@triton.jit
+def _emit_ratio4_mhc_rows_kernel(
+    compressor_kv_cache_ptr,
+    compressor_gate_cache_ptr,
+    compressor_ape_ptr,
+    compressor_norm_weight_ptr,
+    freqs_real_ptr,
+    input_pos_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    mhc_cache_ptr,
+    compressor_cache_page_stride: tl.constexpr,
+    compressor_cache_token_stride: tl.constexpr,
+    mhc_cache_page_stride: tl.constexpr,
+    mhc_cache_token_stride: tl.constexpr,
+    compressor_tokens_per_block: tl.constexpr,
+    mhc_tokens_per_block: tl.constexpr,
+    compressor_ape_stride_row: tl.constexpr,
+    compressor_ape_stride_dim: tl.constexpr,
+    compressor_norm_weight_stride: tl.constexpr,
+    freqs_stride_pos: tl.constexpr,
+    freqs_stride_pair: tl.constexpr,
+    freqs_stride_component: tl.constexpr,
+    max_compressed_len: tl.constexpr,
+    eps: tl.constexpr,
+    head_dim: tl.constexpr,
+    rope_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+    input_pos = tl.load(input_pos_ptr + token_idx)
+    row_idx = input_pos // 4
+    emits_row = ((input_pos + 1) % 4 == 0) & (row_idx < max_compressed_len)
+    anchor = row_idx * 4
+    page_table_start = tl.load(cu_num_pages_ptr + token_idx)
+
+    m_i = tl.full([block_dim], float("-inf"), dtype=tl.float32)
+    l_i = tl.zeros([block_dim], dtype=tl.float32)
+    acc = tl.zeros([block_dim], dtype=tl.float32)
+    paired_m_i = tl.full([block_dim], float("-inf"), dtype=tl.float32)
+    paired_l_i = tl.zeros([block_dim], dtype=tl.float32)
+    paired_acc = tl.zeros([block_dim], dtype=tl.float32)
+
+    rope_start = head_dim - rope_dim
+    rope_offsets = dim_offsets - rope_start
+    is_rope_dim = dim_offsets >= rope_start
+    is_odd_rope_dim = (rope_offsets % 2) == 1
+    pair_offsets = (rope_offsets // 2) * 2 + tl.where(is_odd_rope_dim, 0, 1)
+    paired_dim_offsets = tl.where(is_rope_dim, rope_start + pair_offsets, dim_offsets)
+
+    for ratio_offset in range(4):
+        position = anchor - 4 + ratio_offset
+        valid_position = emits_row & (position >= 0)
+        safe_position = tl.maximum(position, 0)
+        page_ordinal = safe_position // compressor_tokens_per_block
+        token_offset = safe_position - page_ordinal * compressor_tokens_per_block
+        page_idx = tl.load(
+            cache_loc_ptr + page_table_start + page_ordinal,
+            mask=valid_position,
+            other=0,
+        ).to(tl.int64)
+        cache_base = (
+            page_idx * compressor_cache_page_stride + token_offset * compressor_cache_token_stride
+        )
+        ape_base = ratio_offset * compressor_ape_stride_row
+
+        valid_vec = valid_position & dim_mask
+        kv_vec = tl.load(
+            compressor_kv_cache_ptr + cache_base + dim_offsets,
+            mask=valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+        gate_vec = tl.load(
+            compressor_gate_cache_ptr + cache_base + dim_offsets,
+            mask=valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+        gate_vec += tl.load(
+            compressor_ape_ptr + ape_base + dim_offsets * compressor_ape_stride_dim,
+            mask=valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+
+        safe_m = tl.where(valid_vec, m_i, 0.0)
+        safe_gate = tl.where(valid_vec, gate_vec, 0.0)
+        m_next_candidate = tl.maximum(safe_m, safe_gate)
+        alpha = tl.where(valid_vec, tl.exp(safe_m - m_next_candidate), 1.0)
+        beta = tl.where(valid_vec, tl.exp(safe_gate - m_next_candidate), 0.0)
+        acc = acc * alpha + kv_vec * beta
+        l_i = l_i * alpha + beta
+        m_i = tl.where(valid_vec, m_next_candidate, m_i)
+
+        paired_valid_vec = valid_position & dim_mask
+        paired_kv_vec = tl.load(
+            compressor_kv_cache_ptr + cache_base + paired_dim_offsets,
+            mask=paired_valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+        paired_gate_vec = tl.load(
+            compressor_gate_cache_ptr + cache_base + paired_dim_offsets,
+            mask=paired_valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+        paired_gate_vec += tl.load(
+            compressor_ape_ptr + ape_base + paired_dim_offsets * compressor_ape_stride_dim,
+            mask=paired_valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+
+        safe_paired_m = tl.where(paired_valid_vec, paired_m_i, 0.0)
+        safe_paired_gate = tl.where(paired_valid_vec, paired_gate_vec, 0.0)
+        paired_m_next_candidate = tl.maximum(safe_paired_m, safe_paired_gate)
+        paired_alpha = tl.where(
+            paired_valid_vec,
+            tl.exp(safe_paired_m - paired_m_next_candidate),
+            1.0,
+        )
+        paired_beta = tl.where(
+            paired_valid_vec,
+            tl.exp(safe_paired_gate - paired_m_next_candidate),
+            0.0,
+        )
+        paired_acc = paired_acc * paired_alpha + paired_kv_vec * paired_beta
+        paired_l_i = paired_l_i * paired_alpha + paired_beta
+        paired_m_i = tl.where(paired_valid_vec, paired_m_next_candidate, paired_m_i)
+
+    for ratio_offset in range(4):
+        position = anchor + ratio_offset
+        page_ordinal = position // compressor_tokens_per_block
+        token_offset = position - page_ordinal * compressor_tokens_per_block
+        page_idx = tl.load(
+            cache_loc_ptr + page_table_start + page_ordinal,
+            mask=emits_row,
+            other=0,
+        ).to(tl.int64)
+        cache_base = (
+            page_idx * compressor_cache_page_stride + token_offset * compressor_cache_token_stride
+        )
+        state_base = head_dim
+        ape_base = ratio_offset * compressor_ape_stride_row + head_dim * compressor_ape_stride_dim
+
+        valid_vec = emits_row & dim_mask
+        kv_vec = tl.load(
+            compressor_kv_cache_ptr + cache_base + state_base + dim_offsets,
+            mask=valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+        gate_vec = tl.load(
+            compressor_gate_cache_ptr + cache_base + state_base + dim_offsets,
+            mask=valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+        gate_vec += tl.load(
+            compressor_ape_ptr + ape_base + dim_offsets * compressor_ape_stride_dim,
+            mask=valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+
+        safe_m = tl.where(valid_vec, m_i, 0.0)
+        safe_gate = tl.where(valid_vec, gate_vec, 0.0)
+        m_next_candidate = tl.maximum(safe_m, safe_gate)
+        alpha = tl.where(valid_vec, tl.exp(safe_m - m_next_candidate), 1.0)
+        beta = tl.where(valid_vec, tl.exp(safe_gate - m_next_candidate), 0.0)
+        acc = acc * alpha + kv_vec * beta
+        l_i = l_i * alpha + beta
+        m_i = tl.where(valid_vec, m_next_candidate, m_i)
+
+        paired_kv_vec = tl.load(
+            compressor_kv_cache_ptr + cache_base + state_base + paired_dim_offsets,
+            mask=valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+        paired_gate_vec = tl.load(
+            compressor_gate_cache_ptr + cache_base + state_base + paired_dim_offsets,
+            mask=valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+        paired_gate_vec += tl.load(
+            compressor_ape_ptr + ape_base + paired_dim_offsets * compressor_ape_stride_dim,
+            mask=valid_vec,
+            other=0.0,
+        ).to(tl.float32)
+
+        safe_paired_m = tl.where(valid_vec, paired_m_i, 0.0)
+        safe_paired_gate = tl.where(valid_vec, paired_gate_vec, 0.0)
+        paired_m_next_candidate = tl.maximum(safe_paired_m, safe_paired_gate)
+        paired_alpha = tl.where(valid_vec, tl.exp(safe_paired_m - paired_m_next_candidate), 1.0)
+        paired_beta = tl.where(valid_vec, tl.exp(safe_paired_gate - paired_m_next_candidate), 0.0)
+        paired_acc = paired_acc * paired_alpha + paired_kv_vec * paired_beta
+        paired_l_i = paired_l_i * paired_alpha + paired_beta
+        paired_m_i = tl.where(valid_vec, paired_m_next_candidate, paired_m_i)
+
+    pooled = acc / tl.maximum(l_i, 1.0e-20)
+    paired_pooled = paired_acc / tl.maximum(paired_l_i, 1.0e-20)
+    sum_sq = tl.sum(pooled * pooled, axis=0)
+    norm_scale = tl.rsqrt(sum_sq / head_dim + eps)
+    norm_weight = tl.load(
+        compressor_norm_weight_ptr + dim_offsets * compressor_norm_weight_stride,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+    paired_norm_weight = tl.load(
+        compressor_norm_weight_ptr + paired_dim_offsets * compressor_norm_weight_stride,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+    normed = pooled * norm_scale * norm_weight
+    paired_normed = paired_pooled * norm_scale * paired_norm_weight
+
+    safe_pair_idx = tl.where(is_rope_dim, rope_offsets // 2, 0)
+    freqs_base = anchor * freqs_stride_pos + safe_pair_idx * freqs_stride_pair
+    cos = tl.load(
+        freqs_real_ptr + freqs_base,
+        mask=dim_mask & is_rope_dim & emits_row,
+        other=1.0,
+    ).to(tl.float32)
+    sin = tl.load(
+        freqs_real_ptr + freqs_base + freqs_stride_component,
+        mask=dim_mask & is_rope_dim & emits_row,
+        other=0.0,
+    ).to(tl.float32)
+    rope_value = tl.where(
+        is_odd_rope_dim,
+        paired_normed * sin + normed * cos,
+        normed * cos - paired_normed * sin,
+    )
+    output = tl.where(is_rope_dim, rope_value, normed)
+
+    mhc_page_ordinal = row_idx // mhc_tokens_per_block
+    mhc_token_offset = row_idx - mhc_page_ordinal * mhc_tokens_per_block
+    mhc_page_idx = tl.load(
+        cache_loc_ptr + page_table_start + mhc_page_ordinal,
+        mask=emits_row,
+        other=0,
+    ).to(tl.int64)
+    mhc_offsets = mhc_page_idx * mhc_cache_page_stride + mhc_token_offset * mhc_cache_token_stride
+    tl.store(mhc_cache_ptr + mhc_offsets + dim_offsets, output, mask=dim_mask & emits_row)
+
+
+@triton.jit
+def _ratio4_selected_attention_kernel(
+    q_ptr,
+    attn_sink_ptr,
+    topk_idxs_ptr,
+    input_pos_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    swa_cache_ptr,
+    mhc_cache_ptr,
+    out_ptr,
+    q_stride_batch: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    q_stride_dim: tl.constexpr,
+    topk_stride_batch: tl.constexpr,
+    topk_stride_topk: tl.constexpr,
+    out_stride_batch: tl.constexpr,
+    out_stride_head: tl.constexpr,
+    out_stride_dim: tl.constexpr,
+    swa_cache_page_stride: tl.constexpr,
+    swa_cache_token_stride: tl.constexpr,
+    mhc_cache_page_stride: tl.constexpr,
+    mhc_cache_token_stride: tl.constexpr,
+    swa_tokens_per_block: tl.constexpr,
+    mhc_tokens_per_block: tl.constexpr,
+    active_tokens: tl.constexpr,
+    softmax_scale: tl.constexpr,
+    max_compressed_len: tl.constexpr,
+    topk_width: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+    token_is_active = token_idx < active_tokens
+
+    out_offsets = (
+        token_idx * out_stride_batch + head_idx * out_stride_head + dim_offsets * out_stride_dim
+    )
+    input_pos = tl.load(input_pos_ptr + token_idx, mask=token_is_active, other=0)
+    source_seq_len = input_pos + 1
+    page_table_start = tl.load(cu_num_pages_ptr + token_idx, mask=token_is_active, other=0)
+    q_offsets = token_idx * q_stride_batch + head_idx * q_stride_head + dim_offsets * q_stride_dim
+    q_vec = tl.load(q_ptr + q_offsets, mask=dim_mask & token_is_active, other=0.0).to(tl.float32)
+
+    acc = tl.zeros([block_dim], dtype=tl.float32)
+    m_i = tl.load(attn_sink_ptr + head_idx, mask=token_is_active, other=0.0).to(tl.float32)
+    l_i = tl.full((), 1.0, dtype=tl.float32)
+    compressed_len = tl.minimum(source_seq_len // 4, max_compressed_len)
+
+    for topk_offset in range(topk_width):
+        selected = tl.load(
+            topk_idxs_ptr + token_idx * topk_stride_batch + topk_offset * topk_stride_topk,
+            mask=token_is_active,
+            other=-1,
+        )
+        selected_is_valid = token_is_active & (selected >= 0)
+        selected_is_local = selected_is_valid & (selected < source_seq_len)
+        compressed_row = selected - source_seq_len
+        selected_is_compressed = (
+            selected_is_valid & (selected >= source_seq_len) & (compressed_row < compressed_len)
+        )
+
+        local_page_ordinal = selected // swa_tokens_per_block
+        local_token_offset = selected - local_page_ordinal * swa_tokens_per_block
+        local_page_idx = tl.load(
+            cache_loc_ptr + page_table_start + local_page_ordinal,
+            mask=selected_is_local,
+            other=0,
+        ).to(tl.int64)
+        local_offsets = (
+            local_page_idx * swa_cache_page_stride + local_token_offset * swa_cache_token_stride
+        )
+        local_vec = tl.load(
+            swa_cache_ptr + local_offsets + dim_offsets,
+            mask=dim_mask & selected_is_local,
+            other=0.0,
+        ).to(tl.float32)
+
+        compressed_page_ordinal = compressed_row // mhc_tokens_per_block
+        compressed_token_offset = compressed_row - compressed_page_ordinal * mhc_tokens_per_block
+        compressed_page_idx = tl.load(
+            cache_loc_ptr + page_table_start + compressed_page_ordinal,
+            mask=selected_is_compressed,
+            other=0,
+        ).to(tl.int64)
+        compressed_offsets = (
+            compressed_page_idx * mhc_cache_page_stride
+            + compressed_token_offset * mhc_cache_token_stride
+        )
+        compressed_vec = tl.load(
+            mhc_cache_ptr + compressed_offsets + dim_offsets,
+            mask=dim_mask & selected_is_compressed,
+            other=0.0,
+        ).to(tl.float32)
+
+        valid_entry = selected_is_local | selected_is_compressed
+        kv_vec = tl.where(selected_is_local, local_vec, compressed_vec)
+        logit = tl.sum(q_vec * kv_vec, axis=0) * softmax_scale
+        m_next_candidate = tl.maximum(m_i, logit)
+        alpha = tl.where(valid_entry, tl.exp(m_i - m_next_candidate), 1.0)
+        beta = tl.where(valid_entry, tl.exp(logit - m_next_candidate), 0.0)
+        acc = acc * alpha + kv_vec * beta
+        l_i = l_i * alpha + beta
+        m_i = tl.where(valid_entry, m_next_candidate, m_i)
+
+    output = tl.where(token_is_active, acc / l_i, tl.zeros([block_dim], dtype=tl.float32))
+    tl.store(out_ptr + out_offsets, output, mask=dim_mask)
+
+
+@triton.jit
+def _ratio4_prefill_mixed_selected_attention_kernel(
+    q_ptr,
+    attn_sink_ptr,
+    topk_idxs_ptr,
+    seq_len_ptr,
+    input_pos_ptr,
+    cu_seqlen_ptr,
+    token_input_pos_ptr,
+    token_cu_num_pages_ptr,
+    cache_loc_ptr,
+    swa_cache_ptr,
+    mhc_cache_ptr,
+    out_ptr,
+    q_stride_token: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    q_stride_dim: tl.constexpr,
+    topk_stride_token: tl.constexpr,
+    topk_stride_topk: tl.constexpr,
+    out_stride_token: tl.constexpr,
+    out_stride_head: tl.constexpr,
+    out_stride_dim: tl.constexpr,
+    swa_cache_page_stride: tl.constexpr,
+    swa_cache_token_stride: tl.constexpr,
+    mhc_cache_page_stride: tl.constexpr,
+    mhc_cache_token_stride: tl.constexpr,
+    swa_tokens_per_block: tl.constexpr,
+    mhc_tokens_per_block: tl.constexpr,
+    num_seq: tl.constexpr,
+    active_tokens: tl.constexpr,
+    softmax_scale: tl.constexpr,
+    max_compressed_len: tl.constexpr,
+    topk_width: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+    token_is_active = token_idx < active_tokens
+
+    seq_idx = tl.full((), 0, dtype=tl.int64)
+    for idx in range(num_seq):
+        start = tl.load(cu_seqlen_ptr + idx).to(tl.int64)
+        end = tl.load(cu_seqlen_ptr + idx + 1).to(tl.int64)
+        in_seq = (token_idx >= start) & (token_idx < end)
+        seq_idx = tl.where(in_seq, idx, seq_idx)
+
+    input_pos = tl.load(token_input_pos_ptr + token_idx, mask=token_is_active, other=0)
+    seq_len = tl.load(seq_len_ptr + seq_idx, mask=token_is_active, other=0)
+    compressed_offset = tl.maximum(seq_len, input_pos + 1)
+    compressed_len = tl.minimum((input_pos + 1) // 4, max_compressed_len)
+    page_table_start = tl.load(token_cu_num_pages_ptr + token_idx, mask=token_is_active, other=0)
+
+    q_offsets = token_idx * q_stride_token + head_idx * q_stride_head + dim_offsets * q_stride_dim
+    q_vec = tl.load(q_ptr + q_offsets, mask=dim_mask & token_is_active, other=0.0).to(tl.float32)
+    out_offsets = (
+        token_idx * out_stride_token + head_idx * out_stride_head + dim_offsets * out_stride_dim
+    )
+
+    acc = tl.zeros([block_dim], dtype=tl.float32)
+    m_i = tl.load(attn_sink_ptr + head_idx, mask=token_is_active, other=0.0).to(tl.float32)
+    l_i = tl.full((), 1.0, dtype=tl.float32)
+
+    for topk_offset in range(topk_width):
+        selected = tl.load(
+            topk_idxs_ptr + token_idx * topk_stride_token + topk_offset * topk_stride_topk,
+            mask=token_is_active,
+            other=-1,
+        ).to(tl.int64)
+        selected_is_valid = token_is_active & (selected >= 0)
+        selected_is_local = selected_is_valid & (selected <= input_pos)
+        compressed_row = selected - compressed_offset
+        selected_is_compressed = (
+            selected_is_valid & (selected >= compressed_offset) & (compressed_row < compressed_len)
+        )
+
+        local_page_ordinal = selected // swa_tokens_per_block
+        local_token_offset = selected - local_page_ordinal * swa_tokens_per_block
+        local_page_idx = tl.load(
+            cache_loc_ptr + page_table_start + local_page_ordinal,
+            mask=selected_is_local,
+            other=0,
+        ).to(tl.int64)
+        local_offsets = (
+            local_page_idx * swa_cache_page_stride + local_token_offset * swa_cache_token_stride
+        )
+        local_vec = tl.load(
+            swa_cache_ptr + local_offsets + dim_offsets,
+            mask=dim_mask & selected_is_local,
+            other=0.0,
+        ).to(tl.float32)
+
+        compressed_page_ordinal = compressed_row // mhc_tokens_per_block
+        compressed_token_offset = compressed_row - compressed_page_ordinal * mhc_tokens_per_block
+        compressed_page_idx = tl.load(
+            cache_loc_ptr + page_table_start + compressed_page_ordinal,
+            mask=selected_is_compressed,
+            other=0,
+        ).to(tl.int64)
+        compressed_offsets = (
+            compressed_page_idx * mhc_cache_page_stride
+            + compressed_token_offset * mhc_cache_token_stride
+        )
+        compressed_vec = tl.load(
+            mhc_cache_ptr + compressed_offsets + dim_offsets,
+            mask=dim_mask & selected_is_compressed,
+            other=0.0,
+        ).to(tl.float32)
+
+        valid_entry = selected_is_local | selected_is_compressed
+        kv_vec = tl.where(selected_is_local, local_vec, compressed_vec)
+        logit = tl.sum(q_vec * kv_vec, axis=0) * softmax_scale
+        m_next_candidate = tl.maximum(m_i, logit)
+        alpha = tl.where(valid_entry, tl.exp(m_i - m_next_candidate), 1.0)
+        beta = tl.where(valid_entry, tl.exp(logit - m_next_candidate), 0.0)
+        acc = acc * alpha + kv_vec * beta
+        l_i = l_i * alpha + beta
+        m_i = tl.where(valid_entry, m_next_candidate, m_i)
+
+    output = tl.where(token_is_active, acc / l_i, tl.zeros([block_dim], dtype=tl.float32))
+    tl.store(out_ptr + out_offsets, output, mask=dim_mask)
+
+
+@triton.jit
+def _update_ratio128_decode_caches_kernel(
+    kv_ptr,
+    compressor_kv_ptr,
+    compressor_gate_ptr,
+    input_pos_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    swa_cache_ptr,
+    compressor_kv_cache_ptr,
+    compressor_gate_cache_ptr,
+    kv_stride_batch: tl.constexpr,
+    kv_stride_dim: tl.constexpr,
+    compressor_kv_stride_batch: tl.constexpr,
+    compressor_kv_stride_dim: tl.constexpr,
+    compressor_gate_stride_batch: tl.constexpr,
+    compressor_gate_stride_dim: tl.constexpr,
+    swa_cache_page_stride: tl.constexpr,
+    swa_cache_token_stride: tl.constexpr,
+    compressor_cache_page_stride: tl.constexpr,
+    compressor_cache_token_stride: tl.constexpr,
+    swa_tokens_per_block: tl.constexpr,
+    compressor_tokens_per_block: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+    input_pos = tl.load(input_pos_ptr + token_idx)
+
+    swa_page_ordinal = input_pos // swa_tokens_per_block
+    swa_token_offset = input_pos - swa_page_ordinal * swa_tokens_per_block
+    page_table_start = tl.load(cu_num_pages_ptr + token_idx)
+    swa_page_idx = tl.load(cache_loc_ptr + page_table_start + swa_page_ordinal).to(tl.int64)
+    swa_offsets = swa_page_idx * swa_cache_page_stride + swa_token_offset * swa_cache_token_stride
+    kv_offsets = token_idx * kv_stride_batch + dim_offsets * kv_stride_dim
+    tl.store(
+        swa_cache_ptr + swa_offsets + dim_offsets,
+        tl.load(kv_ptr + kv_offsets, mask=dim_mask),
+        mask=dim_mask,
+    )
+
+    compressor_page_ordinal = input_pos // compressor_tokens_per_block
+    compressor_token_offset = input_pos - compressor_page_ordinal * compressor_tokens_per_block
+    compressor_page_idx = tl.load(cache_loc_ptr + page_table_start + compressor_page_ordinal).to(
+        tl.int64
+    )
+    compressor_offsets = (
+        compressor_page_idx * compressor_cache_page_stride
+        + compressor_token_offset * compressor_cache_token_stride
+        + dim_offsets
+    )
+    compressor_kv_offsets = (
+        token_idx * compressor_kv_stride_batch + dim_offsets * compressor_kv_stride_dim
+    )
+    compressor_gate_offsets = (
+        token_idx * compressor_gate_stride_batch + dim_offsets * compressor_gate_stride_dim
+    )
+    tl.store(
+        compressor_kv_cache_ptr + compressor_offsets,
+        tl.load(compressor_kv_ptr + compressor_kv_offsets, mask=dim_mask),
+        mask=dim_mask,
+    )
+    tl.store(
+        compressor_gate_cache_ptr + compressor_offsets,
+        tl.load(compressor_gate_ptr + compressor_gate_offsets, mask=dim_mask),
+        mask=dim_mask,
+    )
+
+
+@triton.jit
+def _emit_ratio128_mhc_rows_kernel(
+    compressor_kv_cache_ptr,
+    compressor_gate_cache_ptr,
+    compressor_ape_ptr,
+    compressor_norm_weight_ptr,
+    freqs_real_ptr,
+    input_pos_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    mhc_cache_ptr,
+    compressor_cache_page_stride: tl.constexpr,
+    compressor_cache_token_stride: tl.constexpr,
+    mhc_cache_page_stride: tl.constexpr,
+    mhc_cache_token_stride: tl.constexpr,
+    compressor_tokens_per_block: tl.constexpr,
+    mhc_tokens_per_block: tl.constexpr,
+    compressor_ape_stride_row: tl.constexpr,
+    compressor_ape_stride_dim: tl.constexpr,
+    compressor_norm_weight_stride: tl.constexpr,
+    freqs_stride_pos: tl.constexpr,
+    freqs_stride_pair: tl.constexpr,
+    freqs_stride_component: tl.constexpr,
+    max_compressed_len: tl.constexpr,
+    eps: tl.constexpr,
+    head_dim: tl.constexpr,
+    rope_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+    input_pos = tl.load(input_pos_ptr + token_idx)
+    row_idx = input_pos // 128
+    emits_row = ((input_pos + 1) % 128 == 0) & (row_idx < max_compressed_len)
+    anchor = row_idx * 128
+    page_table_start = tl.load(cu_num_pages_ptr + token_idx)
+
+    m_i = tl.full([block_dim], float("-inf"), dtype=tl.float32)
+    l_i = tl.zeros([block_dim], dtype=tl.float32)
+    acc = tl.zeros([block_dim], dtype=tl.float32)
+    paired_m_i = tl.full([block_dim], float("-inf"), dtype=tl.float32)
+    paired_l_i = tl.zeros([block_dim], dtype=tl.float32)
+    paired_acc = tl.zeros([block_dim], dtype=tl.float32)
+
+    rope_start = head_dim - rope_dim
+    rope_offsets = dim_offsets - rope_start
+    is_rope_dim = dim_offsets >= rope_start
+    is_odd_rope_dim = (rope_offsets % 2) == 1
+    pair_offsets = (rope_offsets // 2) * 2 + tl.where(is_odd_rope_dim, 0, 1)
+    paired_dim_offsets = tl.where(is_rope_dim, rope_start + pair_offsets, dim_offsets)
+
+    for ratio_offset in range(128):
+        position = anchor + ratio_offset
+        page_ordinal = position // compressor_tokens_per_block
+        token_offset = position - page_ordinal * compressor_tokens_per_block
+        page_idx = tl.load(
+            cache_loc_ptr + page_table_start + page_ordinal,
+            mask=emits_row,
+            other=0,
+        ).to(tl.int64)
+        cache_base = (
+            page_idx * compressor_cache_page_stride + token_offset * compressor_cache_token_stride
+        )
+        ape_base = ratio_offset * compressor_ape_stride_row
+
+        kv_vec = tl.load(
+            compressor_kv_cache_ptr + cache_base + dim_offsets,
+            mask=dim_mask & emits_row,
+            other=0.0,
+        ).to(tl.float32)
+        gate_vec = tl.load(
+            compressor_gate_cache_ptr + cache_base + dim_offsets,
+            mask=dim_mask & emits_row,
+            other=float("-inf"),
+        ).to(tl.float32)
+        gate_vec += tl.load(
+            compressor_ape_ptr + ape_base + dim_offsets * compressor_ape_stride_dim,
+            mask=dim_mask & emits_row,
+            other=0.0,
+        ).to(tl.float32)
+
+        m_next = tl.maximum(m_i, gate_vec)
+        alpha = tl.exp(m_i - m_next)
+        beta = tl.exp(gate_vec - m_next)
+        acc = acc * alpha + kv_vec * beta
+        l_i = l_i * alpha + beta
+        m_i = m_next
+
+        paired_kv_vec = tl.load(
+            compressor_kv_cache_ptr + cache_base + paired_dim_offsets,
+            mask=dim_mask & emits_row,
+            other=0.0,
+        ).to(tl.float32)
+        paired_gate_vec = tl.load(
+            compressor_gate_cache_ptr + cache_base + paired_dim_offsets,
+            mask=dim_mask & emits_row,
+            other=float("-inf"),
+        ).to(tl.float32)
+        paired_gate_vec += tl.load(
+            compressor_ape_ptr + ape_base + paired_dim_offsets * compressor_ape_stride_dim,
+            mask=dim_mask & emits_row,
+            other=0.0,
+        ).to(tl.float32)
+
+        paired_m_next = tl.maximum(paired_m_i, paired_gate_vec)
+        paired_alpha = tl.exp(paired_m_i - paired_m_next)
+        paired_beta = tl.exp(paired_gate_vec - paired_m_next)
+        paired_acc = paired_acc * paired_alpha + paired_kv_vec * paired_beta
+        paired_l_i = paired_l_i * paired_alpha + paired_beta
+        paired_m_i = paired_m_next
+
+    pooled = acc / tl.maximum(l_i, 1.0e-20)
+    paired_pooled = paired_acc / tl.maximum(paired_l_i, 1.0e-20)
+    sum_sq = tl.sum(pooled * pooled, axis=0)
+    norm_scale = tl.rsqrt(sum_sq / head_dim + eps)
+    norm_weight = tl.load(
+        compressor_norm_weight_ptr + dim_offsets * compressor_norm_weight_stride,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+    paired_norm_weight = tl.load(
+        compressor_norm_weight_ptr + paired_dim_offsets * compressor_norm_weight_stride,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+    normed = pooled * norm_scale * norm_weight
+    paired_normed = paired_pooled * norm_scale * paired_norm_weight
+
+    safe_pair_idx = tl.where(is_rope_dim, rope_offsets // 2, 0)
+    freqs_base = anchor * freqs_stride_pos + safe_pair_idx * freqs_stride_pair
+    cos = tl.load(
+        freqs_real_ptr + freqs_base,
+        mask=dim_mask & is_rope_dim & emits_row,
+        other=1.0,
+    ).to(tl.float32)
+    sin = tl.load(
+        freqs_real_ptr + freqs_base + freqs_stride_component,
+        mask=dim_mask & is_rope_dim & emits_row,
+        other=0.0,
+    ).to(tl.float32)
+    rope_value = tl.where(
+        is_odd_rope_dim,
+        paired_normed * sin + normed * cos,
+        normed * cos - paired_normed * sin,
+    )
+    output = tl.where(is_rope_dim, rope_value, normed)
+
+    mhc_page_ordinal = row_idx // mhc_tokens_per_block
+    mhc_token_offset = row_idx - mhc_page_ordinal * mhc_tokens_per_block
+    mhc_page_idx = tl.load(
+        cache_loc_ptr + page_table_start + mhc_page_ordinal,
+        mask=emits_row,
+        other=0,
+    ).to(tl.int64)
+    mhc_offsets = mhc_page_idx * mhc_cache_page_stride + mhc_token_offset * mhc_cache_token_stride
+    tl.store(mhc_cache_ptr + mhc_offsets + dim_offsets, output, mask=dim_mask & emits_row)
+
+
+@triton.jit
+def _ratio128_compressed_attention_kernel(
+    q_ptr,
+    attn_sink_ptr,
+    input_pos_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    swa_cache_ptr,
+    mhc_cache_ptr,
+    out_ptr,
+    q_stride_batch: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    q_stride_dim: tl.constexpr,
+    out_stride_batch: tl.constexpr,
+    out_stride_head: tl.constexpr,
+    out_stride_dim: tl.constexpr,
+    swa_cache_page_stride: tl.constexpr,
+    swa_cache_token_stride: tl.constexpr,
+    mhc_cache_page_stride: tl.constexpr,
+    mhc_cache_token_stride: tl.constexpr,
+    swa_tokens_per_block: tl.constexpr,
+    mhc_tokens_per_block: tl.constexpr,
+    active_tokens: tl.constexpr,
+    softmax_scale: tl.constexpr,
+    window_size: tl.constexpr,
+    max_compressed_len: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+    token_is_active = token_idx < active_tokens
+
+    out_offsets = (
+        token_idx * out_stride_batch + head_idx * out_stride_head + dim_offsets * out_stride_dim
+    )
+    input_pos = tl.load(input_pos_ptr + token_idx, mask=token_is_active, other=0)
+    q_offsets = token_idx * q_stride_batch + head_idx * q_stride_head + dim_offsets * q_stride_dim
+    q_vec = tl.load(q_ptr + q_offsets, mask=dim_mask & token_is_active, other=0.0).to(tl.float32)
+
+    acc = tl.zeros([block_dim], dtype=tl.float32)
+    m_i = tl.load(attn_sink_ptr + head_idx, mask=token_is_active, other=0.0).to(tl.float32)
+    l_i = tl.full((), 1.0, dtype=tl.float32)
+    page_table_start = tl.load(cu_num_pages_ptr + token_idx, mask=token_is_active, other=0)
+    local_len = tl.minimum(input_pos + 1, window_size)
+    local_start = input_pos + 1 - local_len
+
+    for local_offset in range(window_size):
+        valid_local = token_is_active & (local_offset < local_len)
+        row_pos = local_start + local_offset
+        page_ordinal = row_pos // swa_tokens_per_block
+        token_offset = row_pos - page_ordinal * swa_tokens_per_block
+        page_idx = tl.load(
+            cache_loc_ptr + page_table_start + page_ordinal,
+            mask=valid_local,
+            other=0,
+        ).to(tl.int64)
+        cache_offsets = (
+            page_idx * swa_cache_page_stride + token_offset * swa_cache_token_stride + dim_offsets
+        )
+        kv_vec = tl.load(
+            swa_cache_ptr + cache_offsets,
+            mask=dim_mask & valid_local,
+            other=0.0,
+        ).to(tl.float32)
+        logit = tl.sum(q_vec * kv_vec, axis=0) * softmax_scale
+        logit = tl.where(valid_local, logit, float("-inf"))
+        m_next = tl.maximum(m_i, logit)
+        alpha = tl.exp(m_i - m_next)
+        beta = tl.exp(logit - m_next)
+        acc = acc * alpha + kv_vec * beta
+        l_i = l_i * alpha + beta
+        m_i = m_next
+
+    compressed_len = tl.minimum((input_pos + 1) // 128, max_compressed_len)
+    for compressed_offset in range(max_compressed_len):
+        valid_compressed = token_is_active & (compressed_offset < compressed_len)
+        page_ordinal = compressed_offset // mhc_tokens_per_block
+        token_offset = compressed_offset - page_ordinal * mhc_tokens_per_block
+        page_idx = tl.load(
+            cache_loc_ptr + page_table_start + page_ordinal,
+            mask=valid_compressed,
+            other=0,
+        ).to(tl.int64)
+        cache_offsets = (
+            page_idx * mhc_cache_page_stride + token_offset * mhc_cache_token_stride + dim_offsets
+        )
+        kv_vec = tl.load(
+            mhc_cache_ptr + cache_offsets,
+            mask=dim_mask & valid_compressed,
+            other=0.0,
+        ).to(tl.float32)
+        logit = tl.sum(q_vec * kv_vec, axis=0) * softmax_scale
+        logit = tl.where(valid_compressed, logit, float("-inf"))
+        m_next = tl.maximum(m_i, logit)
+        alpha = tl.exp(m_i - m_next)
+        beta = tl.exp(logit - m_next)
+        acc = acc * alpha + kv_vec * beta
+        l_i = l_i * alpha + beta
+        m_i = m_next
+
+    output = tl.where(token_is_active, acc / l_i, tl.zeros([block_dim], dtype=tl.float32))
+    tl.store(out_ptr + out_offsets, output, mask=dim_mask)
+
+
+def triton_deepseek_v4_ratio4_attention_with_cache(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    max_compressed_len: int,
+    rms_norm_eps: float,
+    rope_dim: int,
+    active_tokens: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run ratio-4 cached compressed DSV4 decode through Triton kernels."""
+    reason = _deepseek_v4_ratio4_triton_skip_reason(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        compressor_kv_cache,
+        compressor_gate_cache,
+        window_size,
+        4,
+        max_compressed_len,
+        rope_dim,
+        out,
+        active_tokens,
+    )
+    if reason is not None:
+        raise RuntimeError(reason)
+
+    swa_tokens_per_block, swa_page_stride, swa_token_stride = _cache_layout_for_triton(swa_cache)
+    mhc_tokens_per_block, mhc_page_stride, mhc_token_stride = _cache_layout_for_triton(mhc_cache)
+    compressor_tokens_per_block, compressor_page_stride, compressor_token_stride = (
+        _cache_layout_for_triton(compressor_kv_cache)
+    )
+    gate_tokens_per_block, gate_page_stride, gate_token_stride = _cache_layout_for_triton(
+        compressor_gate_cache
+    )
+    if gate_tokens_per_block != compressor_tokens_per_block:
+        raise RuntimeError(
+            "compressor_kv_cache and compressor_gate_cache must use the same tokens_per_block"
+        )
+    if gate_page_stride != compressor_page_stride or gate_token_stride != compressor_token_stride:
+        raise RuntimeError(
+            "compressor_kv_cache and compressor_gate_cache must share layout strides"
+        )
+
+    output = torch.empty_like(q) if out is None else out
+    freqs_real = torch.view_as_real(freqs_cis_table)
+    head_block_dim = triton.next_power_of_2(_DSV4_TRITON_HEAD_DIM)
+    state_dim = 2 * _DSV4_TRITON_HEAD_DIM
+    state_block_dim = triton.next_power_of_2(state_dim)
+
+    _update_ratio4_decode_caches_kernel[(active_tokens,)](
+        kv,
+        compressor_kv,
+        compressor_gate,
+        input_pos_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        compressor_kv_cache,
+        compressor_gate_cache,
+        kv.stride(0),
+        kv.stride(2),
+        compressor_kv.stride(0),
+        compressor_kv.stride(2),
+        compressor_gate.stride(0),
+        compressor_gate.stride(2),
+        swa_page_stride,
+        swa_token_stride,
+        compressor_page_stride,
+        compressor_token_stride,
+        swa_tokens_per_block,
+        compressor_tokens_per_block,
+        _DSV4_TRITON_HEAD_DIM,
+        state_dim,
+        state_block_dim,
+        num_warps=8,
+    )
+    _emit_ratio4_mhc_rows_kernel[(active_tokens,)](
+        compressor_kv_cache,
+        compressor_gate_cache,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_real,
+        input_pos_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        mhc_cache,
+        compressor_page_stride,
+        compressor_token_stride,
+        mhc_page_stride,
+        mhc_token_stride,
+        compressor_tokens_per_block,
+        mhc_tokens_per_block,
+        compressor_ape.stride(0),
+        compressor_ape.stride(1),
+        compressor_norm_weight.stride(0),
+        freqs_real.stride(0),
+        freqs_real.stride(1),
+        freqs_real.stride(2),
+        max_compressed_len,
+        rms_norm_eps,
+        _DSV4_TRITON_HEAD_DIM,
+        rope_dim,
+        head_block_dim,
+        num_warps=8,
+    )
+    _ratio4_selected_attention_kernel[(q.shape[0], _DSV4_TRITON_LOCAL_NUM_HEADS)](
+        q,
+        attn_sink,
+        topk_idxs,
+        input_pos_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        output,
+        q.stride(0),
+        q.stride(2),
+        q.stride(3),
+        topk_idxs.stride(0),
+        topk_idxs.stride(2),
+        output.stride(0),
+        output.stride(2),
+        output.stride(3),
+        swa_page_stride,
+        swa_token_stride,
+        mhc_page_stride,
+        mhc_token_stride,
+        swa_tokens_per_block,
+        mhc_tokens_per_block,
+        active_tokens,
+        softmax_scale,
+        max_compressed_len,
+        _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[4],
+        _DSV4_TRITON_HEAD_DIM,
+        head_block_dim,
+        num_warps=8,
+    )
+
+    if out is not None:
+        return out.new_empty(0)
+    return output
+
+
+def triton_deepseek_v4_ratio128_attention_with_cache(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    max_compressed_len: int,
+    rms_norm_eps: float,
+    rope_dim: int,
+    active_tokens: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run ratio-128 cached compressed DSV4 decode through Triton kernels."""
+    reason = _deepseek_v4_ratio128_triton_skip_reason(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        compressor_kv_cache,
+        compressor_gate_cache,
+        window_size,
+        128,
+        max_compressed_len,
+        rope_dim,
+        out,
+        active_tokens,
+    )
+    if reason is not None:
+        raise RuntimeError(reason)
+
+    swa_tokens_per_block, swa_page_stride, swa_token_stride = _cache_layout_for_triton(swa_cache)
+    mhc_tokens_per_block, mhc_page_stride, mhc_token_stride = _cache_layout_for_triton(mhc_cache)
+    compressor_tokens_per_block, compressor_page_stride, compressor_token_stride = (
+        _cache_layout_for_triton(compressor_kv_cache)
+    )
+    gate_tokens_per_block, gate_page_stride, gate_token_stride = _cache_layout_for_triton(
+        compressor_gate_cache
+    )
+    if gate_tokens_per_block != compressor_tokens_per_block:
+        raise RuntimeError(
+            "compressor_kv_cache and compressor_gate_cache must use the same tokens_per_block"
+        )
+    if gate_page_stride != compressor_page_stride or gate_token_stride != compressor_token_stride:
+        raise RuntimeError(
+            "compressor_kv_cache and compressor_gate_cache must share layout strides"
+        )
+
+    output = torch.empty_like(q) if out is None else out
+    freqs_real = torch.view_as_real(freqs_cis_table)
+    block_dim = triton.next_power_of_2(_DSV4_TRITON_HEAD_DIM)
+
+    _update_ratio128_decode_caches_kernel[(active_tokens,)](
+        kv,
+        compressor_kv,
+        compressor_gate,
+        input_pos_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        compressor_kv_cache,
+        compressor_gate_cache,
+        kv.stride(0),
+        kv.stride(2),
+        compressor_kv.stride(0),
+        compressor_kv.stride(2),
+        compressor_gate.stride(0),
+        compressor_gate.stride(2),
+        swa_page_stride,
+        swa_token_stride,
+        compressor_page_stride,
+        compressor_token_stride,
+        swa_tokens_per_block,
+        compressor_tokens_per_block,
+        _DSV4_TRITON_HEAD_DIM,
+        block_dim,
+        num_warps=8,
+    )
+    _emit_ratio128_mhc_rows_kernel[(active_tokens,)](
+        compressor_kv_cache,
+        compressor_gate_cache,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_real,
+        input_pos_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        mhc_cache,
+        compressor_page_stride,
+        compressor_token_stride,
+        mhc_page_stride,
+        mhc_token_stride,
+        compressor_tokens_per_block,
+        mhc_tokens_per_block,
+        compressor_ape.stride(0),
+        compressor_ape.stride(1),
+        compressor_norm_weight.stride(0),
+        freqs_real.stride(0),
+        freqs_real.stride(1),
+        freqs_real.stride(2),
+        max_compressed_len,
+        rms_norm_eps,
+        _DSV4_TRITON_HEAD_DIM,
+        rope_dim,
+        block_dim,
+        num_warps=8,
+    )
+    _ratio128_compressed_attention_kernel[(q.shape[0], _DSV4_TRITON_LOCAL_NUM_HEADS)](
+        q,
+        attn_sink,
+        input_pos_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        output,
+        q.stride(0),
+        q.stride(2),
+        q.stride(3),
+        output.stride(0),
+        output.stride(2),
+        output.stride(3),
+        swa_page_stride,
+        swa_token_stride,
+        mhc_page_stride,
+        mhc_token_stride,
+        swa_tokens_per_block,
+        mhc_tokens_per_block,
+        active_tokens,
+        softmax_scale,
+        window_size,
+        max_compressed_len,
+        _DSV4_TRITON_HEAD_DIM,
+        block_dim,
+        num_warps=8,
+    )
+
+    if out is not None:
+        return out.new_empty(0)
+    return output
+
+
+def triton_deepseek_v4_compressed_prefill_mixed_attention_with_cache(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    compress_ratio: int,
+    max_compressed_len: int,
+    rms_norm_eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run compressed cached DSV4 prefill/mixed attention through Triton kernels."""
+    batch_info = BatchInfo(batch_info_host)
+    num_prefill, num_prefill_tokens, num_decode = batch_info.get_absorbed_info()
+    num_seq = num_prefill + num_decode
+    active_tokens = num_prefill_tokens + num_decode
+
+    reason = _deepseek_v4_compressed_prefill_mixed_triton_skip_reason(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        compressor_kv_cache,
+        compressor_gate_cache,
+        window_size,
+        compress_ratio,
+        max_compressed_len,
+        rope_dim,
+        out,
+        num_seq,
+        active_tokens,
+    )
+    if reason is not None:
+        raise RuntimeError(reason)
+
+    swa_tokens_per_block, swa_page_stride, swa_token_stride = _cache_layout_for_triton(swa_cache)
+    mhc_tokens_per_block, mhc_page_stride, mhc_token_stride = _cache_layout_for_triton(mhc_cache)
+    compressor_tokens_per_block, compressor_page_stride, compressor_token_stride = (
+        _cache_layout_for_triton(compressor_kv_cache)
+    )
+    gate_tokens_per_block, gate_page_stride, gate_token_stride = _cache_layout_for_triton(
+        compressor_gate_cache
+    )
+    if gate_tokens_per_block != compressor_tokens_per_block:
+        raise RuntimeError(
+            "compressor_kv_cache and compressor_gate_cache must use the same tokens_per_block"
+        )
+    if gate_page_stride != compressor_page_stride or gate_token_stride != compressor_token_stride:
+        raise RuntimeError(
+            "compressor_kv_cache and compressor_gate_cache must share layout strides"
+        )
+
+    flat_capacity = int(q.shape[0] * q.shape[1])
+    q_flat = q.reshape(flat_capacity, q.shape[2], q.shape[3])
+    kv_flat = kv.reshape(flat_capacity, kv.shape[2])
+    compressor_kv_flat = compressor_kv.reshape(flat_capacity, compressor_kv.shape[2])
+    compressor_gate_flat = compressor_gate.reshape(flat_capacity, compressor_gate.shape[2])
+    topk_flat = topk_idxs.reshape(flat_capacity, topk_idxs.shape[2])
+    output = torch.empty_like(q) if out is None else out
+    output_flat = output.reshape(flat_capacity, output.shape[2], output.shape[3])
+    token_input_pos = input_pos_host.new_empty((active_tokens,))
+    token_cu_num_pages = cu_num_pages_host.new_empty((active_tokens,))
+    freqs_real = torch.view_as_real(freqs_cis_table)
+    block_dim = triton.next_power_of_2(_DSV4_TRITON_HEAD_DIM)
+    state_dim = _DSV4_TRITON_COMPRESSOR_DIM_BY_RATIO[compress_ratio]
+    state_block_dim = triton.next_power_of_2(state_dim)
+
+    _build_prefill_mixed_token_metadata_kernel[(active_tokens,)](
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cu_num_pages_host,
+        token_input_pos,
+        token_cu_num_pages,
+        num_seq,
+        num_warps=1,
+    )
+
+    if compress_ratio == 4:
+        _update_ratio4_decode_caches_kernel[(active_tokens,)](
+            kv_flat,
+            compressor_kv_flat,
+            compressor_gate_flat,
+            token_input_pos,
+            cache_loc_host,
+            token_cu_num_pages,
+            swa_cache,
+            compressor_kv_cache,
+            compressor_gate_cache,
+            kv_flat.stride(0),
+            kv_flat.stride(1),
+            compressor_kv_flat.stride(0),
+            compressor_kv_flat.stride(1),
+            compressor_gate_flat.stride(0),
+            compressor_gate_flat.stride(1),
+            swa_page_stride,
+            swa_token_stride,
+            compressor_page_stride,
+            compressor_token_stride,
+            swa_tokens_per_block,
+            compressor_tokens_per_block,
+            _DSV4_TRITON_HEAD_DIM,
+            state_dim,
+            state_block_dim,
+            num_warps=8,
+        )
+        _emit_ratio4_mhc_rows_kernel[(active_tokens,)](
+            compressor_kv_cache,
+            compressor_gate_cache,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_real,
+            token_input_pos,
+            cache_loc_host,
+            token_cu_num_pages,
+            mhc_cache,
+            compressor_page_stride,
+            compressor_token_stride,
+            mhc_page_stride,
+            mhc_token_stride,
+            compressor_tokens_per_block,
+            mhc_tokens_per_block,
+            compressor_ape.stride(0),
+            compressor_ape.stride(1),
+            compressor_norm_weight.stride(0),
+            freqs_real.stride(0),
+            freqs_real.stride(1),
+            freqs_real.stride(2),
+            max_compressed_len,
+            rms_norm_eps,
+            _DSV4_TRITON_HEAD_DIM,
+            rope_dim,
+            block_dim,
+            num_warps=8,
+        )
+        _ratio4_prefill_mixed_selected_attention_kernel[
+            (flat_capacity, _DSV4_TRITON_LOCAL_NUM_HEADS)
+        ](
+            q_flat,
+            attn_sink,
+            topk_flat,
+            seq_len_host,
+            token_input_pos,
+            cu_seqlen_host,
+            token_input_pos,
+            token_cu_num_pages,
+            cache_loc_host,
+            swa_cache,
+            mhc_cache,
+            output_flat,
+            q_flat.stride(0),
+            q_flat.stride(1),
+            q_flat.stride(2),
+            topk_flat.stride(0),
+            topk_flat.stride(1),
+            output_flat.stride(0),
+            output_flat.stride(1),
+            output_flat.stride(2),
+            swa_page_stride,
+            swa_token_stride,
+            mhc_page_stride,
+            mhc_token_stride,
+            swa_tokens_per_block,
+            mhc_tokens_per_block,
+            num_seq,
+            active_tokens,
+            softmax_scale,
+            max_compressed_len,
+            _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[4],
+            _DSV4_TRITON_HEAD_DIM,
+            block_dim,
+            num_warps=8,
+        )
+    elif compress_ratio == 128:
+        _update_ratio128_decode_caches_kernel[(active_tokens,)](
+            kv_flat,
+            compressor_kv_flat,
+            compressor_gate_flat,
+            token_input_pos,
+            cache_loc_host,
+            token_cu_num_pages,
+            swa_cache,
+            compressor_kv_cache,
+            compressor_gate_cache,
+            kv_flat.stride(0),
+            kv_flat.stride(1),
+            compressor_kv_flat.stride(0),
+            compressor_kv_flat.stride(1),
+            compressor_gate_flat.stride(0),
+            compressor_gate_flat.stride(1),
+            swa_page_stride,
+            swa_token_stride,
+            compressor_page_stride,
+            compressor_token_stride,
+            swa_tokens_per_block,
+            compressor_tokens_per_block,
+            _DSV4_TRITON_HEAD_DIM,
+            block_dim,
+            num_warps=8,
+        )
+        _emit_ratio128_mhc_rows_kernel[(active_tokens,)](
+            compressor_kv_cache,
+            compressor_gate_cache,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_real,
+            token_input_pos,
+            cache_loc_host,
+            token_cu_num_pages,
+            mhc_cache,
+            compressor_page_stride,
+            compressor_token_stride,
+            mhc_page_stride,
+            mhc_token_stride,
+            compressor_tokens_per_block,
+            mhc_tokens_per_block,
+            compressor_ape.stride(0),
+            compressor_ape.stride(1),
+            compressor_norm_weight.stride(0),
+            freqs_real.stride(0),
+            freqs_real.stride(1),
+            freqs_real.stride(2),
+            max_compressed_len,
+            rms_norm_eps,
+            _DSV4_TRITON_HEAD_DIM,
+            rope_dim,
+            block_dim,
+            num_warps=8,
+        )
+        _ratio128_compressed_attention_kernel[(flat_capacity, _DSV4_TRITON_LOCAL_NUM_HEADS)](
+            q_flat,
+            attn_sink,
+            token_input_pos,
+            cache_loc_host,
+            token_cu_num_pages,
+            swa_cache,
+            mhc_cache,
+            output_flat,
+            q_flat.stride(0),
+            q_flat.stride(1),
+            q_flat.stride(2),
+            output_flat.stride(0),
+            output_flat.stride(1),
+            output_flat.stride(2),
+            swa_page_stride,
+            swa_token_stride,
+            mhc_page_stride,
+            mhc_token_stride,
+            swa_tokens_per_block,
+            mhc_tokens_per_block,
+            active_tokens,
+            softmax_scale,
+            window_size,
+            max_compressed_len,
+            _DSV4_TRITON_HEAD_DIM,
+            block_dim,
+            num_warps=8,
+        )
+    else:
+        raise RuntimeError(f"unsupported Triton DSV4 compress_ratio={compress_ratio}")
+
+    if out is not None:
+        return out.new_empty(0)
+    return output
+
+
+def _validate_triton_deepseek_v4_sparse_attention_v2_contract(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    compress_ratio: int,
+    max_compressed_len: Optional[int],
+    rms_norm_eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor],
+    *,
+    validate_metadata_values: bool,
+) -> None:
+    _validate_rank("q", q, 4)
+    _validate_rank("kv", kv, 3)
+    _validate_rank("attn_sink", attn_sink, 1)
+    _validate_rank("topk_idxs", topk_idxs, 3)
+    _validate_rank("compressor_kv", compressor_kv, 3)
+    _validate_rank("compressor_gate", compressor_gate, 3)
+    _validate_rank("compressor_ape", compressor_ape, 2)
+    _validate_rank("compressor_norm_weight", compressor_norm_weight, 1)
+    _validate_rank("freqs_cis_table", freqs_cis_table, 2)
+    _validate_rank("position_ids", position_ids, 2)
+    _validate_int_metadata("batch_info_host", batch_info_host)
+    _validate_int_metadata("seq_len_host", seq_len_host)
+    _validate_int_metadata("input_pos_host", input_pos_host)
+    _validate_int_metadata("cu_seqlen_host", cu_seqlen_host)
+    _validate_int_metadata("cache_loc_host", cache_loc_host)
+    _validate_int_metadata("cu_num_pages_host", cu_num_pages_host)
+
+    if q.dtype != torch.bfloat16:
+        raise TypeError(f"q must be bfloat16 for the Triton DSV4 contract, got {q.dtype}")
+    if kv.dtype != torch.bfloat16:
+        raise TypeError(f"kv must be bfloat16 for the Triton DSV4 contract, got {kv.dtype}")
+    if attn_sink.dtype != torch.float32:
+        raise TypeError(f"attn_sink must be float32, got {attn_sink.dtype}")
+    if topk_idxs.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"topk_idxs must be int32 or int64, got {topk_idxs.dtype}")
+    if position_ids.dtype not in (torch.int32, torch.int64, torch.int):
+        raise TypeError(f"position_ids must be int32/int64, got {position_ids.dtype}")
+    if not freqs_cis_table.is_complex():
+        raise TypeError(f"freqs_cis_table must be complex, got {freqs_cis_table.dtype}")
+
+    batch_size, seq_len, num_heads, head_dim = q.shape
+    if num_heads != _DSV4_TRITON_LOCAL_NUM_HEADS:
+        raise ValueError(
+            f"q local head count must be {_DSV4_TRITON_LOCAL_NUM_HEADS}, got {num_heads}"
+        )
+    if head_dim != _DSV4_TRITON_HEAD_DIM:
+        raise ValueError(f"q head dimension must be {_DSV4_TRITON_HEAD_DIM}, got {head_dim}")
+    if kv.shape != (batch_size, seq_len, _DSV4_TRITON_HEAD_DIM):
+        raise ValueError(
+            f"kv must have shape {(batch_size, seq_len, _DSV4_TRITON_HEAD_DIM)}, "
+            f"got {tuple(kv.shape)}"
+        )
+    if attn_sink.shape != (num_heads,):
+        raise ValueError(f"attn_sink must have shape ({num_heads},), got {tuple(attn_sink.shape)}")
+    if topk_idxs.shape[:2] != (batch_size, seq_len):
+        raise ValueError(
+            f"topk_idxs prefix must be {(batch_size, seq_len)}, got {tuple(topk_idxs.shape[:2])}"
+        )
+    if position_ids.shape != (batch_size, seq_len):
+        raise ValueError(
+            f"position_ids must have shape {(batch_size, seq_len)}, got {tuple(position_ids.shape)}"
+        )
+
+    if compress_ratio not in _DSV4_TRITON_TOPK_WIDTH_BY_RATIO:
+        raise ValueError(f"compress_ratio must be one of 0, 4, or 128; got {compress_ratio}")
+    expected_topk_width = _DSV4_TRITON_TOPK_WIDTH_BY_RATIO[compress_ratio]
+    if topk_idxs.shape[-1] != expected_topk_width:
+        raise ValueError(
+            f"topk_idxs width must be {expected_topk_width} for compress_ratio={compress_ratio}, "
+            f"got {topk_idxs.shape[-1]}"
+        )
+
+    expected_compressor_dim = _DSV4_TRITON_COMPRESSOR_DIM_BY_RATIO[compress_ratio]
+    expected_compressor_shape = (batch_size, seq_len, expected_compressor_dim)
+    if compressor_kv.shape != expected_compressor_shape:
+        raise ValueError(
+            f"compressor_kv must have shape {expected_compressor_shape}, "
+            f"got {tuple(compressor_kv.shape)}"
+        )
+    if compressor_gate.shape != expected_compressor_shape:
+        raise ValueError(
+            f"compressor_gate must have shape {expected_compressor_shape}, "
+            f"got {tuple(compressor_gate.shape)}"
+        )
+    expected_ape_shape = (
+        (0, 0) if compress_ratio == 0 else (compress_ratio, expected_compressor_dim)
+    )
+    if compressor_ape.shape != expected_ape_shape:
+        raise ValueError(
+            f"compressor_ape must have shape {expected_ape_shape}, "
+            f"got {tuple(compressor_ape.shape)}"
+        )
+    expected_norm_shape = (0,) if compress_ratio == 0 else (_DSV4_TRITON_HEAD_DIM,)
+    if compressor_norm_weight.shape != expected_norm_shape:
+        raise ValueError(
+            f"compressor_norm_weight must have shape {expected_norm_shape}, "
+            f"got {tuple(compressor_norm_weight.shape)}"
+        )
+
+    if window_size != _DSV4_TRITON_WINDOW_SIZE:
+        raise ValueError(f"window_size must be {_DSV4_TRITON_WINDOW_SIZE}, got {window_size}")
+    if rope_dim != _DSV4_TRITON_ROPE_DIM:
+        raise ValueError(f"rope_dim must be {_DSV4_TRITON_ROPE_DIM}, got {rope_dim}")
+    if softmax_scale <= 0.0:
+        raise ValueError(f"softmax_scale must be positive, got {softmax_scale}")
+    if rms_norm_eps <= 0.0:
+        raise ValueError(f"rms_norm_eps must be positive, got {rms_norm_eps}")
+    if freqs_cis_table.shape[-1] != rope_dim // 2:
+        raise ValueError(
+            f"freqs_cis_table last dimension must be {rope_dim // 2}, "
+            f"got {freqs_cis_table.shape[-1]}"
+        )
+    if compress_ratio == 0:
+        if max_compressed_len not in (None, 0):
+            raise ValueError(
+                "max_compressed_len must be None or 0 for ratio-0 DSV4 attention, "
+                f"got {max_compressed_len}"
+            )
+    elif max_compressed_len is None or max_compressed_len <= 0:
+        raise ValueError(
+            f"max_compressed_len must be positive for compress_ratio={compress_ratio}, "
+            f"got {max_compressed_len}"
+        )
+
+    _validate_contract_cache("swa_cache", swa_cache, _DSV4_TRITON_HEAD_DIM, torch.bfloat16)
+    _validate_contract_cache("mhc_cache", mhc_cache, _DSV4_TRITON_HEAD_DIM, torch.bfloat16)
+    _validate_contract_resource_placeholder("compressor_kv_cache", compressor_kv_cache)
+    _validate_contract_resource_placeholder("compressor_gate_cache", compressor_gate_cache)
+
+    if out is not None:
+        if out.shape != q.shape:
+            raise ValueError(f"out shape must be {tuple(q.shape)}, got {tuple(out.shape)}")
+        if out.dtype != q.dtype:
+            raise TypeError(f"out dtype must be {q.dtype}, got {out.dtype}")
+        if out.device != q.device:
+            raise ValueError(f"out must be on {q.device}, got {out.device}")
+
+    if not validate_metadata_values:
+        return
+
+    batch_info = BatchInfo(batch_info_host)
+    num_prefill, num_prefill_tokens, num_decode = batch_info.get_absorbed_info()
+    num_seq = num_prefill + num_decode
+    active_tokens = num_prefill_tokens + num_decode
+    max_graph_tokens = int(batch_size * seq_len)
+    if active_tokens > max_graph_tokens:
+        raise ValueError(
+            f"active tokens ({active_tokens}) exceed q capacity ({max_graph_tokens}); "
+            "padded graph slots may be present, but active tokens must fit."
+        )
+    if seq_len_host.numel() < num_seq:
+        raise ValueError(
+            f"seq_len_host needs at least {num_seq} entries, got {seq_len_host.numel()}"
+        )
+    if input_pos_host.numel() < num_seq:
+        raise ValueError(
+            f"input_pos_host needs at least {num_seq} entries, got {input_pos_host.numel()}"
+        )
+    if cu_seqlen_host.numel() < num_seq + 1:
+        raise ValueError(
+            f"cu_seqlen_host needs at least {num_seq + 1} entries, got {cu_seqlen_host.numel()}"
+        )
+    if cu_num_pages_host.numel() < num_seq + 1:
+        raise ValueError(
+            f"cu_num_pages_host needs at least {num_seq + 1} entries, "
+            f"got {cu_num_pages_host.numel()}"
+        )
+
+
+def _deepseek_v4_triton_cached_attention_fallback_reason(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    out: Optional[torch.Tensor],
+    *,
+    compressor_kv: Optional[torch.Tensor] = None,
+    compressor_gate: Optional[torch.Tensor] = None,
+    compressor_ape: Optional[torch.Tensor] = None,
+    compressor_norm_weight: Optional[torch.Tensor] = None,
+    freqs_cis_table: Optional[torch.Tensor] = None,
+    mhc_cache: Optional[torch.Tensor] = None,
+    compressor_kv_cache: Optional[torch.Tensor] = None,
+    compressor_gate_cache: Optional[torch.Tensor] = None,
+    max_compressed_len: Optional[int] = None,
+    rope_dim: Optional[int] = None,
+) -> tuple[Optional[str], int]:
+    """Return why the Triton cached kernel is not selected, plus active token count."""
+    batch_info = BatchInfo(batch_info_host)
+    num_prefill, num_prefill_tokens, num_decode = batch_info.get_absorbed_info()
+    num_seq = num_prefill + num_decode
+    active_tokens = num_prefill_tokens + num_decode
+
+    if _force_torch_cached_reference():
+        return (
+            f"{_DSV4_FORCE_TORCH_REFERENCE_ENV} is set; using Torch cached reference.",
+            active_tokens,
+        )
+
+    if compress_ratio == 0:
+        if num_prefill != 0 or num_prefill_tokens != 0:
+            return (
+                _deepseek_v4_ratio0_prefill_mixed_triton_skip_reason(
+                    q,
+                    kv,
+                    attn_sink,
+                    topk_idxs,
+                    seq_len_host,
+                    input_pos_host,
+                    cu_seqlen_host,
+                    cache_loc_host,
+                    cu_num_pages_host,
+                    swa_cache,
+                    window_size,
+                    compress_ratio,
+                    out,
+                    num_seq,
+                    active_tokens,
+                ),
+                active_tokens,
+            )
+        return (
+            deepseek_v4_ratio0_swa_triton_skip_reason(
+                q,
+                kv,
+                attn_sink,
+                topk_idxs,
+                seq_len_host,
+                input_pos_host,
+                cu_seqlen_host,
+                cache_loc_host,
+                cu_num_pages_host,
+                swa_cache,
+                window_size,
+                compress_ratio,
+                out,
+                num_decode,
+            ),
+            active_tokens,
+        )
+
+    if compress_ratio == 4:
+        required_tensors = (
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            mhc_cache,
+            compressor_kv_cache,
+            compressor_gate_cache,
+        )
+        if any(tensor is None for tensor in required_tensors) or rope_dim is None:
+            return (
+                "ratio-4 compressed Triton attention requires compressor and cache resources; "
+                "using the incremental Torch cached reference.",
+                active_tokens,
+            )
+        if num_prefill != 0 or num_prefill_tokens != 0:
+            return (
+                _deepseek_v4_compressed_prefill_mixed_triton_skip_reason(
+                    q,
+                    kv,
+                    attn_sink,
+                    topk_idxs,
+                    compressor_kv,
+                    compressor_gate,
+                    compressor_ape,
+                    compressor_norm_weight,
+                    freqs_cis_table,
+                    seq_len_host,
+                    input_pos_host,
+                    cu_seqlen_host,
+                    cache_loc_host,
+                    cu_num_pages_host,
+                    swa_cache,
+                    mhc_cache,
+                    compressor_kv_cache,
+                    compressor_gate_cache,
+                    window_size,
+                    compress_ratio,
+                    max_compressed_len,
+                    rope_dim,
+                    out,
+                    num_seq,
+                    active_tokens,
+                ),
+                active_tokens,
+            )
+        if num_decode <= 0:
+            return (f"active_tokens must be positive, got {active_tokens}", active_tokens)
+        return (
+            _deepseek_v4_ratio4_triton_skip_reason(
+                q,
+                kv,
+                attn_sink,
+                topk_idxs,
+                compressor_kv,
+                compressor_gate,
+                compressor_ape,
+                compressor_norm_weight,
+                freqs_cis_table,
+                seq_len_host,
+                input_pos_host,
+                cu_seqlen_host,
+                cache_loc_host,
+                cu_num_pages_host,
+                swa_cache,
+                mhc_cache,
+                compressor_kv_cache,
+                compressor_gate_cache,
+                window_size,
+                compress_ratio,
+                max_compressed_len,
+                rope_dim,
+                out,
+                num_decode,
+            ),
+            active_tokens,
+        )
+
+    if compress_ratio == 128:
+        required_tensors = (
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            mhc_cache,
+            compressor_kv_cache,
+            compressor_gate_cache,
+        )
+        if any(tensor is None for tensor in required_tensors) or rope_dim is None:
+            return (
+                "ratio-128 compressed Triton attention requires compressor and cache resources; "
+                "using the incremental Torch cached reference.",
+                active_tokens,
+            )
+        if num_prefill != 0 or num_prefill_tokens != 0:
+            return (
+                _deepseek_v4_compressed_prefill_mixed_triton_skip_reason(
+                    q,
+                    kv,
+                    attn_sink,
+                    topk_idxs,
+                    compressor_kv,
+                    compressor_gate,
+                    compressor_ape,
+                    compressor_norm_weight,
+                    freqs_cis_table,
+                    seq_len_host,
+                    input_pos_host,
+                    cu_seqlen_host,
+                    cache_loc_host,
+                    cu_num_pages_host,
+                    swa_cache,
+                    mhc_cache,
+                    compressor_kv_cache,
+                    compressor_gate_cache,
+                    window_size,
+                    compress_ratio,
+                    max_compressed_len,
+                    rope_dim,
+                    out,
+                    num_seq,
+                    active_tokens,
+                ),
+                active_tokens,
+            )
+        if num_decode <= 0:
+            return (f"active_tokens must be positive, got {active_tokens}", active_tokens)
+        return (
+            _deepseek_v4_ratio128_triton_skip_reason(
+                q,
+                kv,
+                attn_sink,
+                topk_idxs,
+                compressor_kv,
+                compressor_gate,
+                compressor_ape,
+                compressor_norm_weight,
+                freqs_cis_table,
+                seq_len_host,
+                input_pos_host,
+                cu_seqlen_host,
+                cache_loc_host,
+                cu_num_pages_host,
+                swa_cache,
+                mhc_cache,
+                compressor_kv_cache,
+                compressor_gate_cache,
+                window_size,
+                compress_ratio,
+                max_compressed_len,
+                rope_dim,
+                out,
+                num_decode,
+            ),
+            active_tokens,
+        )
+
+    return (
+        f"compress_ratio must be one of 0, 4, or 128; got {compress_ratio}",
+        active_tokens,
+    )
+
+
+@torch.library.custom_op(
+    "auto_deploy::triton_deepseek_v4_sparse_attention_v2_with_cache",
+    mutates_args=(),
+)
+def triton_deepseek_v4_sparse_attention_v2_with_cache(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    compress_ratio: int,
+    max_compressed_len: Optional[int],
+    rms_norm_eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Executable Plan 01 contract for the Triton DSV4 cached attention op.
+
+    The production paths cover guarded ratio-0 SWA prefill/mixed/decode and
+    compressed ratio-4 / ratio-128 prefill/mixed/decode with CUDA BF16 tensors
+    and device page metadata. Unsupported cases intentionally keep using the
+    Torch cached reference so the public op boundary remains debuggable. The
+    local-rank graph contract observed for DeepSeek V4 TP=8 attention is:
+
+    - ``q`` is BF16 ``[batch, seq_len, 8, 512]`` and ``kv`` is BF16
+      ``[batch, seq_len, 512]``.
+    - ``topk_idxs`` is caller-built graph/debug metadata. Its width is 128 for
+      ratio-0, 640 for ratio-4, and 192 for ratio-128. Negative entries are
+      masked, duplicate indices receive independent probability mass, and sink
+      logits normalize softmax without contributing values.
+    - ``swa_cache`` and ``mhc_cache`` are caller-owned BF16 paged resources.
+      Compressor cache tensors are caller-owned placeholders for later kernel
+      plans; FP8 NoPE cache resources are not consumed by this Wave 1 boundary.
+    - Passing ``out=`` selects the CUDA-graph replay convention: the caller-owned
+      output buffer is filled and the op returns an empty tensor sentinel.
+    """
+    _validate_triton_deepseek_v4_sparse_attention_v2_contract(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        compressor_kv_cache,
+        compressor_gate_cache,
+        softmax_scale,
+        window_size,
+        compress_ratio,
+        max_compressed_len,
+        rms_norm_eps,
+        rope_dim,
+        out,
+        validate_metadata_values=True,
+    )
+    batch_info = BatchInfo(batch_info_host)
+    num_prefill, num_prefill_tokens, num_decode = batch_info.get_absorbed_info()
+    seq_len_triton = _triton_metadata_on_q_device(seq_len_host, q)
+    input_pos_triton = _triton_metadata_on_q_device(input_pos_host, q)
+    cu_seqlen_triton = _triton_metadata_on_q_device(cu_seqlen_host, q)
+    cache_loc_triton = _triton_metadata_on_q_device(cache_loc_host, q)
+    cu_num_pages_triton = _triton_metadata_on_q_device(cu_num_pages_host, q)
+    fallback_reason, active_tokens = _deepseek_v4_triton_cached_attention_fallback_reason(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        batch_info_host,
+        seq_len_triton,
+        input_pos_triton,
+        cu_seqlen_triton,
+        cache_loc_triton,
+        cu_num_pages_triton,
+        swa_cache,
+        window_size,
+        compress_ratio,
+        out,
+        compressor_kv=compressor_kv,
+        compressor_gate=compressor_gate,
+        compressor_ape=compressor_ape,
+        compressor_norm_weight=compressor_norm_weight,
+        freqs_cis_table=freqs_cis_table,
+        mhc_cache=mhc_cache,
+        compressor_kv_cache=compressor_kv_cache,
+        compressor_gate_cache=compressor_gate_cache,
+        max_compressed_len=max_compressed_len,
+        rope_dim=rope_dim,
+    )
+    if fallback_reason is None:
+        if compress_ratio == 0:
+            if num_prefill != 0 or num_prefill_tokens != 0:
+                return triton_deepseek_v4_ratio0_swa_prefill_mixed_attention_with_cache(
+                    q,
+                    kv,
+                    attn_sink,
+                    topk_idxs,
+                    batch_info_host,
+                    seq_len_triton,
+                    input_pos_triton,
+                    cu_seqlen_triton,
+                    cache_loc_triton,
+                    cu_num_pages_triton,
+                    swa_cache,
+                    softmax_scale,
+                    window_size,
+                    out=out,
+                )
+            return triton_deepseek_v4_ratio0_swa_attention_with_cache(
+                q,
+                kv,
+                attn_sink,
+                topk_idxs,
+                seq_len_triton,
+                input_pos_triton,
+                cu_seqlen_triton,
+                cache_loc_triton,
+                cu_num_pages_triton,
+                swa_cache,
+                softmax_scale,
+                window_size,
+                active_tokens,
+                out=out,
+            )
+        if compress_ratio == 4:
+            if num_prefill != 0 or num_prefill_tokens != 0:
+                return triton_deepseek_v4_compressed_prefill_mixed_attention_with_cache(
+                    q,
+                    kv,
+                    attn_sink,
+                    topk_idxs,
+                    compressor_kv,
+                    compressor_gate,
+                    compressor_ape,
+                    compressor_norm_weight,
+                    freqs_cis_table,
+                    batch_info_host,
+                    seq_len_triton,
+                    input_pos_triton,
+                    cu_seqlen_triton,
+                    cache_loc_triton,
+                    cu_num_pages_triton,
+                    swa_cache,
+                    mhc_cache,
+                    compressor_kv_cache,
+                    compressor_gate_cache,
+                    softmax_scale,
+                    window_size,
+                    compress_ratio,
+                    int(max_compressed_len),
+                    rms_norm_eps,
+                    rope_dim,
+                    out=out,
+                )
+            return triton_deepseek_v4_ratio4_attention_with_cache(
+                q,
+                kv,
+                attn_sink,
+                topk_idxs,
+                compressor_kv,
+                compressor_gate,
+                compressor_ape,
+                compressor_norm_weight,
+                freqs_cis_table,
+                seq_len_triton,
+                input_pos_triton,
+                cu_seqlen_triton,
+                cache_loc_triton,
+                cu_num_pages_triton,
+                swa_cache,
+                mhc_cache,
+                compressor_kv_cache,
+                compressor_gate_cache,
+                softmax_scale,
+                window_size,
+                int(max_compressed_len),
+                rms_norm_eps,
+                rope_dim,
+                num_decode,
+                out=out,
+            )
+        if compress_ratio == 128:
+            if num_prefill != 0 or num_prefill_tokens != 0:
+                return triton_deepseek_v4_compressed_prefill_mixed_attention_with_cache(
+                    q,
+                    kv,
+                    attn_sink,
+                    topk_idxs,
+                    compressor_kv,
+                    compressor_gate,
+                    compressor_ape,
+                    compressor_norm_weight,
+                    freqs_cis_table,
+                    batch_info_host,
+                    seq_len_triton,
+                    input_pos_triton,
+                    cu_seqlen_triton,
+                    cache_loc_triton,
+                    cu_num_pages_triton,
+                    swa_cache,
+                    mhc_cache,
+                    compressor_kv_cache,
+                    compressor_gate_cache,
+                    softmax_scale,
+                    window_size,
+                    compress_ratio,
+                    int(max_compressed_len),
+                    rms_norm_eps,
+                    rope_dim,
+                    out=out,
+                )
+            return triton_deepseek_v4_ratio128_attention_with_cache(
+                q,
+                kv,
+                attn_sink,
+                topk_idxs,
+                compressor_kv,
+                compressor_gate,
+                compressor_ape,
+                compressor_norm_weight,
+                freqs_cis_table,
+                seq_len_triton,
+                input_pos_triton,
+                cu_seqlen_triton,
+                cache_loc_triton,
+                cu_num_pages_triton,
+                swa_cache,
+                mhc_cache,
+                compressor_kv_cache,
+                compressor_gate_cache,
+                softmax_scale,
+                window_size,
+                int(max_compressed_len),
+                rms_norm_eps,
+                rope_dim,
+                num_decode,
+                out=out,
+            )
+        raise RuntimeError(f"unsupported Triton DSV4 compress_ratio={compress_ratio}")
+    _warn_torch_cached_reference_fallback(fallback_reason)
+    return torch_deepseek_v4_sparse_attention_v2_with_cache(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        compressor_kv_cache,
+        compressor_gate_cache,
+        softmax_scale,
+        window_size,
+        compress_ratio,
+        max_compressed_len,
+        rms_norm_eps,
+        rope_dim,
+        out=out,
+    )
+
+
+@triton_deepseek_v4_sparse_attention_v2_with_cache.register_fake
+def triton_deepseek_v4_sparse_attention_v2_with_cache_fake(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    compress_ratio: int,
+    max_compressed_len: Optional[int],
+    rms_norm_eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    _validate_triton_deepseek_v4_sparse_attention_v2_contract(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        compressor_kv_cache,
+        compressor_gate_cache,
+        softmax_scale,
+        window_size,
+        compress_ratio,
+        max_compressed_len,
+        rms_norm_eps,
+        rope_dim,
+        out,
+        validate_metadata_values=False,
+    )
+    if out is not None:
+        return out.new_empty(0)
+    return q.new_empty(q.shape).contiguous()
+
+
 @AttentionRegistry.register("deepseek_v4_sparse")
 class DeepSeekV4SparseAttention(AttentionDescriptor):
-    """Cached DeepSeek V4 sparse attention descriptor for the SWA reference path."""
+    """Cached DeepSeek V4 sparse attention descriptor for the integrated DSV4 path."""
 
     @classmethod
     def get_attention_layout(cls) -> AttentionLayout:
@@ -1310,7 +4732,9 @@ class DeepSeekV4SparseAttention(AttentionDescriptor):
 
     @classmethod
     def get_cached_attention_op(cls) -> MHACallable:
-        return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache.default
+        if _force_torch_cached_reference():
+            return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache.default
+        return torch.ops.auto_deploy.triton_deepseek_v4_sparse_attention_v2_with_cache.default
 
     @classmethod
     def get_standard_metadata_args(cls) -> List[str]:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
@@ -273,7 +273,7 @@ def _to_host_long(tensor: torch.Tensor, length: int) -> torch.Tensor:
 def _cache_token_view(cache: torch.Tensor, page_idx: int, token_offset: int) -> torch.Tensor:
     """Return a mutable view for one DeepSeek V4 SWA cache row."""
     if cache.dim() == 5:
-        if int(cache.shape[1]) <= 2:
+        if int(cache.shape[1]) == 1:
             # KVCacheManager.get_buffers(..., kv_layout="NHD"):
             # [num_pages, kv_factor, tokens_per_block, num_kv_heads, head_dim].
             if int(cache.shape[2]) >= int(cache.shape[3]):
@@ -294,7 +294,7 @@ def _cache_token_view(cache: torch.Tensor, page_idx: int, token_offset: int) -> 
 def _cache_tokens_per_block(cache: torch.Tensor) -> int:
     if cache.dim() not in (3, 4, 5):
         raise ValueError(f"swa_cache must have rank 3, 4, or 5, got rank {cache.dim()}")
-    if cache.dim() == 5 and int(cache.shape[1]) <= 2:
+    if cache.dim() == 5 and int(cache.shape[1]) == 1:
         return int(cache.shape[2] if int(cache.shape[2]) >= int(cache.shape[3]) else cache.shape[3])
     return int(cache.shape[1])
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
@@ -95,6 +95,8 @@ def torch_deepseek_v4_sparse_attention(
     topk_idxs: torch.Tensor,
     softmax_scale: float,
     out: Optional[torch.Tensor] = None,
+    enable_sharding: bool = False,
+    layer_type: str = "unknown",
 ) -> torch.Tensor:
     """Reference DeepSeek V4 sparse/HMA attention source op.
 
@@ -114,6 +116,8 @@ def torch_deepseek_v4_sparse_attention(
         The sink participates in softmax normalization but contributes no value
         vector.
     """
+    del enable_sharding, layer_type
+
     _validate_deepseek_v4_sparse_attention_inputs(q, kv, attn_sink, topk_idxs, out)
 
     compute_dtype = torch.float32 if q.dtype in (torch.float16, torch.bfloat16) else q.dtype
@@ -147,8 +151,11 @@ def torch_deepseek_v4_sparse_attention_fake(
     topk_idxs: torch.Tensor,
     softmax_scale: float,
     out: Optional[torch.Tensor] = None,
+    enable_sharding: bool = False,
+    layer_type: str = "unknown",
 ) -> torch.Tensor:
     """Fake implementation for torch.export tracing."""
+    del softmax_scale, enable_sharding, layer_type
     _validate_rank("q", q, 4)
     _validate_rank("kv", kv, 3)
     _validate_rank("attn_sink", attn_sink, 1)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepSeek V4 sparse/HMA attention source op."""
+
+import torch
+
+
+def _validate_rank(name: str, tensor: torch.Tensor, rank: int) -> None:
+    if tensor.dim() != rank:
+        raise ValueError(f"{name} must have rank {rank}, got rank {tensor.dim()}")
+
+
+def _validate_deepseek_v4_sparse_attention_inputs(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+) -> None:
+    _validate_rank("q", q, 4)
+    _validate_rank("kv", kv, 3)
+    _validate_rank("attn_sink", attn_sink, 1)
+    _validate_rank("topk_idxs", topk_idxs, 3)
+
+    if not q.is_floating_point():
+        raise TypeError(f"q must be floating point, got {q.dtype}")
+    if not kv.is_floating_point():
+        raise TypeError(f"kv must be floating point, got {kv.dtype}")
+    if not attn_sink.is_floating_point():
+        raise TypeError(f"attn_sink must be floating point, got {attn_sink.dtype}")
+    if q.dtype != kv.dtype:
+        raise TypeError(f"q and kv must have the same dtype, got {q.dtype} and {kv.dtype}")
+    if topk_idxs.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"topk_idxs must be int32 or int64, got {topk_idxs.dtype}")
+
+    if kv.device != q.device:
+        raise ValueError(f"kv must be on {q.device}, got {kv.device}")
+    if attn_sink.device != q.device:
+        raise ValueError(f"attn_sink must be on {q.device}, got {attn_sink.device}")
+    if topk_idxs.device != q.device:
+        raise ValueError(f"topk_idxs must be on {q.device}, got {topk_idxs.device}")
+
+    batch_size, seq_len, num_heads, head_dim = q.shape
+    kv_batch_size, _, kv_head_dim = kv.shape
+    topk_batch_size, topk_seq_len, _ = topk_idxs.shape
+
+    if kv_batch_size != batch_size:
+        raise ValueError(f"kv batch dimension must be {batch_size}, got {kv_batch_size}")
+    if topk_batch_size != batch_size:
+        raise ValueError(f"topk_idxs batch dimension must be {batch_size}, got {topk_batch_size}")
+    if topk_seq_len != seq_len:
+        raise ValueError(f"topk_idxs sequence dimension must be {seq_len}, got {topk_seq_len}")
+    if kv_head_dim != head_dim:
+        raise ValueError(f"kv head dimension must be {head_dim}, got {kv_head_dim}")
+    if attn_sink.shape[0] != num_heads:
+        raise ValueError(f"attn_sink length must be {num_heads}, got {attn_sink.shape[0]}")
+
+
+def _gather_selected_kv(kv: torch.Tensor, topk_idxs: torch.Tensor) -> torch.Tensor:
+    batch_size, seq_len, k_select = topk_idxs.shape
+    head_dim = kv.shape[-1]
+    gather_idx = (
+        topk_idxs.to(torch.long).unsqueeze(-1).expand(batch_size, seq_len, k_select, head_dim)
+    )
+    expanded_kv = kv.unsqueeze(1).expand(batch_size, seq_len, kv.shape[1], head_dim)
+    return torch.gather(expanded_kv, dim=2, index=gather_idx)
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_sparse_attention", mutates_args=())
+def torch_deepseek_v4_sparse_attention(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Reference DeepSeek V4 sparse/HMA attention source op.
+
+    Args:
+        q: Query states with shape ``[batch, seq_len, num_heads, head_dim]``.
+        kv: Shared sparse key/value rows with shape ``[batch, kv_rows, head_dim]``.
+        attn_sink: Per-head sink logits with shape ``[num_heads]``.
+        topk_idxs: Selected row indices into ``kv`` with shape
+            ``[batch, seq_len, k_select]``. Duplicate indices are preserved and
+            receive independent probability mass.
+        softmax_scale: Scale applied to query/key logits before adding the sink
+            logit.
+
+    Returns:
+        Attention output with shape ``[batch, seq_len, num_heads, head_dim]``.
+        The sink participates in softmax normalization but contributes no value
+        vector.
+    """
+    _validate_deepseek_v4_sparse_attention_inputs(q, kv, attn_sink, topk_idxs)
+
+    compute_dtype = torch.float32 if q.dtype in (torch.float16, torch.bfloat16) else q.dtype
+    selected_kv = _gather_selected_kv(kv, topk_idxs)
+    q_compute = q.to(compute_dtype)
+    selected_kv_compute = selected_kv.to(compute_dtype)
+
+    logits = torch.einsum("bshd,bskd->bshk", q_compute, selected_kv_compute)
+    logits = logits * softmax_scale
+    sink_logits = attn_sink.to(dtype=compute_dtype).reshape(1, 1, -1, 1)
+    sink_logits = sink_logits.expand(q.shape[0], q.shape[1], q.shape[2], 1)
+    logits_with_sink = torch.cat([logits, sink_logits], dim=-1)
+
+    weights_with_sink = torch.softmax(logits_with_sink, dim=-1, dtype=torch.float32)
+    weights = weights_with_sink[..., :-1].to(compute_dtype)
+    output = torch.einsum("bshk,bskd->bshd", weights, selected_kv_compute)
+    return output.to(q.dtype).contiguous()
+
+
+@torch_deepseek_v4_sparse_attention.register_fake
+def torch_deepseek_v4_sparse_attention_fake(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Fake implementation for torch.export tracing."""
+    _validate_rank("q", q, 4)
+    _validate_rank("kv", kv, 3)
+    _validate_rank("attn_sink", attn_sink, 1)
+    _validate_rank("topk_idxs", topk_idxs, 3)
+    return q.new_empty(q.shape).contiguous()

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
@@ -33,6 +33,9 @@ from ..attention_interface import (
     ResourceHandlerDict,
 )
 
+_SPARSE_ATTENTION_CHUNK_TARGET_BYTES = 512 * 1024 * 1024
+_SPARSE_ATTENTION_MAX_CHUNK_TOKENS = 64
+
 
 def _validate_rank(name: str, tensor: torch.Tensor, rank: int) -> None:
     if tensor.dim() != rank:
@@ -92,13 +95,42 @@ def _validate_deepseek_v4_sparse_attention_inputs(
             raise ValueError(f"out must be on {q.device}, got {out.device}")
 
 
-def _gather_selected_kv(kv: torch.Tensor, topk_idxs: torch.Tensor) -> torch.Tensor:
+def _gather_selected_kv(
+    kv: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    batch_idxs: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    gather_topk_idxs = topk_idxs.to(torch.long).clamp(min=0)
+    if batch_idxs is not None:
+        return kv[batch_idxs.to(torch.long).unsqueeze(1), gather_topk_idxs]
+
     batch_size, seq_len, k_select = topk_idxs.shape
     head_dim = kv.shape[-1]
-    gather_topk_idxs = topk_idxs.to(torch.long).clamp(min=0)
     gather_idx = gather_topk_idxs.unsqueeze(-1).expand(batch_size, seq_len, k_select, head_dim)
     expanded_kv = kv.unsqueeze(1).expand(batch_size, seq_len, kv.shape[1], head_dim)
     return torch.gather(expanded_kv, dim=2, index=gather_idx)
+
+
+def _sparse_attention_query_chunk_size(
+    num_tokens: int,
+    num_heads: int,
+    head_dim: int,
+    k_select: int,
+    compute_dtype: torch.dtype,
+) -> int:
+    compute_element_size = torch.empty((), dtype=compute_dtype).element_size()
+    logits_element_size = torch.empty((), dtype=torch.float32).element_size()
+    bytes_per_token = (
+        k_select * head_dim * compute_element_size
+        + 3 * num_heads * (k_select + 1) * logits_element_size
+        + num_heads * head_dim * compute_element_size
+    )
+    if bytes_per_token <= 0:
+        return 1
+    chunk_size = _SPARSE_ATTENTION_CHUNK_TARGET_BYTES // bytes_per_token
+    chunk_size = max(1, int(chunk_size))
+    chunk_size = min(chunk_size, _SPARSE_ATTENTION_MAX_CHUNK_TOKENS)
+    return min(num_tokens, chunk_size)
 
 
 @torch.library.custom_op("auto_deploy::torch_deepseek_v4_sparse_attention", mutates_args=())
@@ -150,22 +182,46 @@ def torch_deepseek_v4_sparse_attention(
     _validate_deepseek_v4_sparse_attention_inputs(q, kv, attn_sink, topk_idxs, out)
 
     compute_dtype = torch.float32 if q.dtype in (torch.float16, torch.bfloat16) else q.dtype
-    selected_kv = _gather_selected_kv(kv, topk_idxs)
-    q_compute = q.to(compute_dtype)
-    selected_kv_compute = selected_kv.to(compute_dtype)
+    batch_size, seq_len, num_heads, q_head_dim = q.shape
+    _, _, k_select = topk_idxs.shape
+    num_tokens = batch_size * seq_len
+    output = torch.empty(q.shape, dtype=q.dtype, device=q.device)
+    if num_tokens == 0:
+        if out is not None:
+            out.copy_(output)
+            return out.new_empty(0)
+        return output
 
-    logits = torch.einsum("bshd,bskd->bshk", q_compute, selected_kv_compute)
-    logits = logits * softmax_scale
-    invalid = topk_idxs < 0
-    logits = logits.masked_fill(invalid.unsqueeze(2), float("-inf"))
-    sink_logits = attn_sink.to(dtype=compute_dtype).reshape(1, 1, -1, 1)
-    sink_logits = sink_logits.expand(q.shape[0], q.shape[1], q.shape[2], 1)
-    logits_with_sink = torch.cat([logits, sink_logits], dim=-1)
+    chunk_size = _sparse_attention_query_chunk_size(
+        num_tokens, num_heads, q_head_dim, k_select, compute_dtype
+    )
 
-    weights_with_sink = torch.softmax(logits_with_sink, dim=-1, dtype=torch.float32)
-    weights = weights_with_sink[..., :-1].to(compute_dtype)
-    output = torch.einsum("bshk,bskd->bshd", weights, selected_kv_compute)
-    output = output.to(q.dtype).contiguous()
+    q_flat = q.reshape(num_tokens, num_heads, q_head_dim)
+    topk_flat = topk_idxs.reshape(num_tokens, k_select)
+    batch_idxs = torch.arange(batch_size, device=q.device).view(batch_size, 1)
+    batch_idxs = batch_idxs.expand(batch_size, seq_len).reshape(num_tokens)
+    output_flat = output.reshape(num_tokens, num_heads, q_head_dim)
+    sink_logits = attn_sink.to(dtype=compute_dtype).reshape(1, num_heads, 1)
+
+    for start in range(0, num_tokens, chunk_size):
+        end = min(start + chunk_size, num_tokens)
+        topk_chunk = topk_flat[start:end]
+        selected_kv_compute = _gather_selected_kv(kv, topk_chunk, batch_idxs[start:end]).to(
+            compute_dtype
+        )
+        q_compute = q_flat[start:end].to(compute_dtype)
+
+        logits = torch.einsum("thd,tkd->thk", q_compute, selected_kv_compute)
+        logits = logits * softmax_scale
+        logits = logits.masked_fill((topk_chunk < 0).unsqueeze(1), float("-inf"))
+        chunk_sink_logits = sink_logits.expand(end - start, num_heads, 1)
+        logits_with_sink = torch.cat([logits, chunk_sink_logits], dim=-1)
+
+        weights_with_sink = torch.softmax(logits_with_sink, dim=-1, dtype=torch.float32)
+        weights = weights_with_sink[..., :-1].to(compute_dtype)
+        chunk_output = torch.einsum("thk,tkd->thd", weights, selected_kv_compute)
+        output_flat[start:end].copy_(chunk_output.to(q.dtype))
+
     if out is not None:
         out.copy_(output)
         return out.new_empty(0)
@@ -217,8 +273,15 @@ def _to_host_long(tensor: torch.Tensor, length: int) -> torch.Tensor:
 def _cache_token_view(cache: torch.Tensor, page_idx: int, token_offset: int) -> torch.Tensor:
     """Return a mutable view for one DeepSeek V4 SWA cache row."""
     if cache.dim() == 5:
-        # KVPagedResourceHandler with NHD layout:
-        # [num_pages, tokens_per_block, kv_factor, num_kv_heads, head_dim].
+        if int(cache.shape[1]) <= 2:
+            # KVCacheManager.get_buffers(..., kv_layout="NHD"):
+            # [num_pages, kv_factor, tokens_per_block, num_kv_heads, head_dim].
+            if int(cache.shape[2]) >= int(cache.shape[3]):
+                return cache[page_idx, 0, token_offset, 0]
+            # KVCacheManager.get_buffers(..., kv_layout="HND"):
+            # [num_pages, kv_factor, num_kv_heads, tokens_per_block, head_dim].
+            return cache[page_idx, 0, 0, token_offset]
+        # Local unit tests use [num_pages, tokens_per_block, kv_factor, num_kv_heads, head_dim].
         return cache[page_idx, token_offset, 0, 0]
     if cache.dim() == 4:
         # Local unit tests often use [num_pages, tokens_per_block, num_heads, head_dim].
@@ -231,6 +294,8 @@ def _cache_token_view(cache: torch.Tensor, page_idx: int, token_offset: int) -> 
 def _cache_tokens_per_block(cache: torch.Tensor) -> int:
     if cache.dim() not in (3, 4, 5):
         raise ValueError(f"swa_cache must have rank 3, 4, or 5, got rank {cache.dim()}")
+    if cache.dim() == 5 and int(cache.shape[1]) <= 2:
+        return int(cache.shape[2] if int(cache.shape[2]) >= int(cache.shape[3]) else cache.shape[3])
     return int(cache.shape[1])
 
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py
@@ -13,11 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""DeepSeek V4 sparse/HMA attention source op."""
+"""DeepSeek V4 sparse/HMA attention source and cached reference ops."""
 
-from typing import Optional
+from typing import List, Optional
 
 import torch
+from torch.fx import Node
+
+from ..._compat import KvCacheConfig
+from ...utils.node_utils import extract_op_args
+from ..attention_interface import (
+    AttentionDescriptor,
+    AttentionLayout,
+    AttentionRegistry,
+    BatchInfo,
+    Constant,
+    KVPagedResourceHandler,
+    MHACallable,
+    ResourceHandlerDict,
+)
 
 
 def _validate_rank(name: str, tensor: torch.Tensor, rank: int) -> None:
@@ -97,6 +111,12 @@ def torch_deepseek_v4_sparse_attention(
     out: Optional[torch.Tensor] = None,
     enable_sharding: bool = False,
     layer_type: str = "unknown",
+    layer_idx: Optional[int] = None,
+    window_size: Optional[int] = None,
+    compress_ratio: int = 0,
+    max_compressed_len: Optional[int] = None,
+    head_dim: Optional[int] = None,
+    rope_dim: Optional[int] = None,
 ) -> torch.Tensor:
     """Reference DeepSeek V4 sparse/HMA attention source op.
 
@@ -116,7 +136,16 @@ def torch_deepseek_v4_sparse_attention(
         The sink participates in softmax normalization but contributes no value
         vector.
     """
-    del enable_sharding, layer_type
+    del (
+        enable_sharding,
+        layer_type,
+        layer_idx,
+        window_size,
+        compress_ratio,
+        max_compressed_len,
+        head_dim,
+        rope_dim,
+    )
 
     _validate_deepseek_v4_sparse_attention_inputs(q, kv, attn_sink, topk_idxs, out)
 
@@ -153,9 +182,25 @@ def torch_deepseek_v4_sparse_attention_fake(
     out: Optional[torch.Tensor] = None,
     enable_sharding: bool = False,
     layer_type: str = "unknown",
+    layer_idx: Optional[int] = None,
+    window_size: Optional[int] = None,
+    compress_ratio: int = 0,
+    max_compressed_len: Optional[int] = None,
+    head_dim: Optional[int] = None,
+    rope_dim: Optional[int] = None,
 ) -> torch.Tensor:
     """Fake implementation for torch.export tracing."""
-    del softmax_scale, enable_sharding, layer_type
+    del (
+        softmax_scale,
+        enable_sharding,
+        layer_type,
+        layer_idx,
+        window_size,
+        compress_ratio,
+        max_compressed_len,
+        head_dim,
+        rope_dim,
+    )
     _validate_rank("q", q, 4)
     _validate_rank("kv", kv, 3)
     _validate_rank("attn_sink", attn_sink, 1)
@@ -163,3 +208,1117 @@ def torch_deepseek_v4_sparse_attention_fake(
     if out is not None:
         return out.new_empty(0)
     return q.new_empty(q.shape).contiguous()
+
+
+def _to_host_long(tensor: torch.Tensor, length: int) -> torch.Tensor:
+    return tensor.detach().cpu().to(torch.long).flatten()[:length]
+
+
+def _cache_token_view(cache: torch.Tensor, page_idx: int, token_offset: int) -> torch.Tensor:
+    """Return a mutable view for one DeepSeek V4 SWA cache row."""
+    if cache.dim() == 5:
+        # KVPagedResourceHandler with NHD layout:
+        # [num_pages, tokens_per_block, kv_factor, num_kv_heads, head_dim].
+        return cache[page_idx, token_offset, 0, 0]
+    if cache.dim() == 4:
+        # Local unit tests often use [num_pages, tokens_per_block, num_heads, head_dim].
+        return cache[page_idx, token_offset, 0]
+    if cache.dim() == 3:
+        return cache[page_idx, token_offset]
+    raise ValueError(f"swa_cache must have rank 3, 4, or 5, got rank {cache.dim()}")
+
+
+def _cache_tokens_per_block(cache: torch.Tensor) -> int:
+    if cache.dim() not in (3, 4, 5):
+        raise ValueError(f"swa_cache must have rank 3, 4, or 5, got rank {cache.dim()}")
+    return int(cache.shape[1])
+
+
+def _page_for_position(
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    position: int,
+    tokens_per_block: int,
+) -> tuple[int, int]:
+    page_ordinal = position // tokens_per_block
+    page_table_start = int(cu_num_pages_host[seq_idx].item())
+    page_table_end = int(cu_num_pages_host[seq_idx + 1].item())
+    page_table_idx = page_table_start + page_ordinal
+    if page_table_idx >= page_table_end:
+        raise ValueError(
+            f"Sequence {seq_idx} position {position} needs page ordinal {page_ordinal}, "
+            f"but only {page_table_end - page_table_start} page(s) are available."
+        )
+    page_idx = int(cache_loc_host[page_table_idx].item())
+    return page_idx, position % tokens_per_block
+
+
+def _write_swa_cache(
+    kv_seq: torch.Tensor,
+    cache: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    input_pos: int,
+) -> None:
+    tokens_per_block = _cache_tokens_per_block(cache)
+    for token_offset in range(kv_seq.shape[0]):
+        page_idx, page_offset = _page_for_position(
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            input_pos + token_offset,
+            tokens_per_block,
+        )
+        _cache_token_view(cache, page_idx, page_offset).copy_(kv_seq[token_offset].to(cache.dtype))
+
+
+def _gather_swa_rows(
+    cache: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    start_pos: int,
+    end_pos: int,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    tokens_per_block = _cache_tokens_per_block(cache)
+    rows = []
+    for position in range(start_pos, end_pos):
+        page_idx, page_offset = _page_for_position(
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            position,
+            tokens_per_block,
+        )
+        rows.append(_cache_token_view(cache, page_idx, page_offset).to(dtype))
+    if not rows:
+        head_dim = int(cache.shape[-1])
+        return torch.empty(0, head_dim, dtype=dtype, device=cache.device)
+    return torch.stack(rows, dim=0)
+
+
+def _slice_sequence_tokens(
+    tensor: torch.Tensor,
+    seq_idx: int,
+    flat_start: int,
+    seq_len: int,
+) -> torch.Tensor:
+    if tensor.shape[0] > seq_idx and tensor.shape[0] != 1:
+        return tensor[seq_idx, :seq_len]
+    return tensor.reshape(-1, *tensor.shape[2:])[flat_start : flat_start + seq_len]
+
+
+def _cached_local_window_attention(
+    q_seq: torch.Tensor,
+    attn_sink: torch.Tensor,
+    cache: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    input_pos: int,
+    window_size: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    outputs = []
+    for token_offset in range(q_seq.shape[0]):
+        query_pos = input_pos + token_offset
+        start_pos = max(0, query_pos - window_size + 1)
+        kv_seq = _gather_swa_rows(
+            cache,
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            start_pos,
+            query_pos + 1,
+            q_seq.dtype,
+        )
+        topk = torch.arange(kv_seq.shape[0], dtype=torch.int64, device=q_seq.device).view(1, 1, -1)
+        out = torch_deepseek_v4_sparse_attention(
+            q_seq[token_offset : token_offset + 1].unsqueeze(0),
+            kv_seq.unsqueeze(0),
+            attn_sink,
+            topk,
+            softmax_scale,
+        )
+        outputs.append(out.squeeze(0).squeeze(0))
+    if not outputs:
+        return q_seq.new_empty(q_seq.shape)
+    return torch.stack(outputs, dim=0)
+
+
+def _rms_norm_ref(
+    x: torch.Tensor,
+    weight: Optional[torch.Tensor],
+    eps: float,
+) -> torch.Tensor:
+    compute = x.to(torch.float32)
+    output = compute * torch.rsqrt(compute.square().mean(dim=-1, keepdim=True) + eps)
+    if weight is not None and weight.numel() != 0:
+        output = output * weight.to(device=x.device, dtype=torch.float32)
+    return output.to(x.dtype)
+
+
+def _apply_rope_ref(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+) -> torch.Tensor:
+    if rope_dim == 0:
+        return x.contiguous()
+    nope = x[..., : x.shape[-1] - rope_dim]
+    rope = x[..., -rope_dim:]
+    rope_complex = torch.view_as_complex(rope.float().reshape(*rope.shape[:-1], -1, 2))
+    if freqs_cis.dim() == rope_complex.dim() - 1:
+        freqs_cis = freqs_cis.unsqueeze(-2)
+    rope_out = torch.view_as_real(rope_complex * freqs_cis).flatten(-2).to(x.dtype)
+    return torch.cat([nope, rope_out], dim=-1).contiguous()
+
+
+def _overlap_transform_projected(
+    tensor: torch.Tensor,
+    ratio: int,
+    head_dim: int,
+    value: float,
+) -> torch.Tensor:
+    batch_size, compressed_len, _, _ = tensor.shape
+    out = tensor.new_full((batch_size, compressed_len, 2 * ratio, head_dim), value)
+    out[:, :, ratio:] = tensor[:, :, :, head_dim:]
+    out[:, 1:, :ratio] = tensor[:, :-1, :, :head_dim]
+    return out
+
+
+def _build_full_compressed_kv(
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    compress_ratio: int,
+    max_compressed_len: int,
+) -> torch.Tensor:
+    """Build full-context compressed rows from source-op compressor projections."""
+    if compress_ratio <= 0:
+        return compressor_kv.new_empty(compressor_kv.shape[0], 0, compressor_kv.shape[-1])
+
+    _validate_rank("compressor_kv", compressor_kv, 3)
+    _validate_rank("compressor_gate", compressor_gate, 3)
+    if compressor_kv.shape != compressor_gate.shape:
+        raise ValueError(
+            "compressor_kv and compressor_gate must have matching shapes, "
+            f"got {tuple(compressor_kv.shape)} and {tuple(compressor_gate.shape)}"
+        )
+    if max_compressed_len <= 0:
+        raise ValueError(f"max_compressed_len must be positive, got {max_compressed_len}")
+
+    batch_size, seq_len, state_dim = compressor_kv.shape
+    overlap = compress_ratio == 4
+    channels = 2 if overlap else 1
+    if state_dim % channels != 0:
+        raise ValueError(f"compressor state dim {state_dim} is not divisible by {channels}")
+    head_dim = state_dim // channels
+
+    max_compressed_tokens = max_compressed_len * compress_ratio
+    pad_len = max_compressed_tokens - seq_len
+    if pad_len < 0:
+        raise ValueError(f"seq_len {seq_len} exceeds compressed capacity {max_compressed_tokens}")
+
+    kv = torch.nn.functional.pad(compressor_kv, (0, 0, 0, pad_len))
+    gate = torch.nn.functional.pad(compressor_gate, (0, 0, 0, pad_len), value=float("-inf"))
+    kv = kv.view(batch_size, max_compressed_len, compress_ratio, state_dim)
+    gate = gate.view(batch_size, max_compressed_len, compress_ratio, state_dim)
+    gate = gate + compressor_ape.to(device=gate.device, dtype=gate.dtype)
+    if overlap:
+        kv = _overlap_transform_projected(kv, compress_ratio, head_dim, 0.0)
+        gate = _overlap_transform_projected(gate, compress_ratio, head_dim, float("-inf"))
+
+    pooled = (kv * gate.softmax(dim=2)).sum(dim=2)
+    pooled = _rms_norm_ref(pooled, compressor_norm_weight, eps)
+
+    row_idx = torch.arange(max_compressed_len, device=compressor_kv.device) * compress_ratio
+    row_idx = torch.minimum(row_idx, torch.full_like(row_idx, seq_len - 1))
+    row_idx = row_idx.unsqueeze(0).expand(batch_size, -1)
+    compressed_position_ids = torch.gather(position_ids, 1, row_idx)
+    compressed_freqs = freqs_cis_table[compressed_position_ids]
+    return _apply_rope_ref(pooled, compressed_freqs, rope_dim)
+
+
+def _write_paged_rows(
+    rows: torch.Tensor,
+    cache: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    input_pos: int,
+) -> None:
+    tokens_per_block = _cache_tokens_per_block(cache)
+    for token_offset in range(rows.shape[0]):
+        page_idx, page_offset = _page_for_position(
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            input_pos + token_offset,
+            tokens_per_block,
+        )
+        row_view = _cache_token_view(cache, page_idx, page_offset)
+        row = rows[token_offset].to(cache.dtype)
+        row_view[..., : row.shape[-1]].copy_(row)
+
+
+def _gather_paged_rows(
+    cache: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    start_pos: int,
+    end_pos: int,
+    dtype: torch.dtype,
+    width: Optional[int] = None,
+) -> torch.Tensor:
+    tokens_per_block = _cache_tokens_per_block(cache)
+    rows = []
+    for position in range(start_pos, end_pos):
+        page_idx, page_offset = _page_for_position(
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            position,
+            tokens_per_block,
+        )
+        row = _cache_token_view(cache, page_idx, page_offset)
+        if width is not None:
+            row = row[..., :width]
+        rows.append(row.to(dtype))
+    head_dim = int(cache.shape[-1] if width is None else width)
+    if not rows:
+        return torch.empty(0, head_dim, dtype=dtype, device=cache.device)
+    return torch.stack(rows, dim=0)
+
+
+def _compressed_row_from_state(
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    row_idx: int,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    compress_ratio: int,
+    head_dim: int,
+    state_dim: int,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    anchor = row_idx * compress_ratio
+    kv_rows = []
+    gate_rows = []
+    if compress_ratio == 4:
+        for offset in range(compress_ratio):
+            position = anchor - compress_ratio + offset
+            if position < 0:
+                kv_rows.append(
+                    torch.zeros(head_dim, dtype=dtype, device=compressor_kv_cache.device)
+                )
+                gate_rows.append(
+                    torch.full(
+                        (head_dim,),
+                        float("-inf"),
+                        dtype=dtype,
+                        device=compressor_gate_cache.device,
+                    )
+                )
+                continue
+            kv_state = _gather_paged_rows(
+                compressor_kv_cache,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                position,
+                position + 1,
+                dtype,
+                state_dim,
+            )[0]
+            gate_state = _gather_paged_rows(
+                compressor_gate_cache,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                position,
+                position + 1,
+                dtype,
+                state_dim,
+            )[0]
+            kv_rows.append(kv_state[:head_dim])
+            gate_rows.append(gate_state[:head_dim] + compressor_ape[offset, :head_dim].to(dtype))
+
+        for offset in range(compress_ratio):
+            position = anchor + offset
+            kv_state = _gather_paged_rows(
+                compressor_kv_cache,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                position,
+                position + 1,
+                dtype,
+                state_dim,
+            )[0]
+            gate_state = _gather_paged_rows(
+                compressor_gate_cache,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                position,
+                position + 1,
+                dtype,
+                state_dim,
+            )[0]
+            kv_rows.append(kv_state[head_dim : 2 * head_dim])
+            gate_rows.append(
+                gate_state[head_dim : 2 * head_dim]
+                + compressor_ape[offset, head_dim : 2 * head_dim].to(dtype)
+            )
+    else:
+        for offset in range(compress_ratio):
+            position = anchor + offset
+            kv_state = _gather_paged_rows(
+                compressor_kv_cache,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                position,
+                position + 1,
+                dtype,
+                state_dim,
+            )[0]
+            gate_state = _gather_paged_rows(
+                compressor_gate_cache,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                position,
+                position + 1,
+                dtype,
+                state_dim,
+            )[0]
+            kv_rows.append(kv_state[:head_dim])
+            gate_rows.append(gate_state[:head_dim] + compressor_ape[offset, :head_dim].to(dtype))
+
+    kv = torch.stack(kv_rows, dim=0)
+    gate = torch.stack(gate_rows, dim=0)
+    pooled = (kv * gate.softmax(dim=0)).sum(dim=0)
+    pooled = _rms_norm_ref(pooled.unsqueeze(0), compressor_norm_weight, eps).squeeze(0)
+    freqs = freqs_cis_table[anchor].unsqueeze(0)
+    return _apply_rope_ref(pooled.unsqueeze(0), freqs, rope_dim).squeeze(0)
+
+
+def _update_compressed_caches(
+    compressor_kv_seq: torch.Tensor,
+    compressor_gate_seq: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    input_pos: int,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    compress_ratio: int,
+) -> None:
+    if compress_ratio <= 0 or compressor_kv_seq.numel() == 0:
+        return
+
+    state_dim = int(compressor_kv_seq.shape[-1])
+    head_dim = state_dim // (2 if compress_ratio == 4 else 1)
+    _write_paged_rows(
+        compressor_kv_seq,
+        compressor_kv_cache,
+        cache_loc_host,
+        cu_num_pages_host,
+        seq_idx,
+        input_pos,
+    )
+    _write_paged_rows(
+        compressor_gate_seq,
+        compressor_gate_cache,
+        cache_loc_host,
+        cu_num_pages_host,
+        seq_idx,
+        input_pos,
+    )
+
+    old_completed = input_pos // compress_ratio
+    new_completed = (input_pos + compressor_kv_seq.shape[0]) // compress_ratio
+    compressed_rows = []
+    for row_idx in range(old_completed, new_completed):
+        compressed_rows.append(
+            _compressed_row_from_state(
+                compressor_kv_cache,
+                compressor_gate_cache,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                row_idx,
+                compressor_ape,
+                compressor_norm_weight,
+                freqs_cis_table,
+                eps,
+                rope_dim,
+                compress_ratio,
+                head_dim,
+                state_dim,
+                compressor_kv_seq.dtype,
+            )
+        )
+    if compressed_rows:
+        _write_paged_rows(
+            torch.stack(compressed_rows, dim=0),
+            mhc_cache,
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            old_completed,
+        )
+
+
+def _cached_compressed_attention(
+    q_seq: torch.Tensor,
+    attn_sink: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    input_pos: int,
+    window_size: int,
+    compress_ratio: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    outputs = []
+    for token_offset in range(q_seq.shape[0]):
+        query_pos = input_pos + token_offset
+        local_start = max(0, query_pos - window_size + 1)
+        local_kv = _gather_swa_rows(
+            swa_cache,
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            local_start,
+            query_pos + 1,
+            q_seq.dtype,
+        )
+        compressed_len = (query_pos + 1) // compress_ratio
+        compressed_kv = _gather_paged_rows(
+            mhc_cache,
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            0,
+            compressed_len,
+            q_seq.dtype,
+        )
+        local_idxs = torch.arange(local_kv.shape[0], dtype=torch.int64, device=q_seq.device)
+        compressed_idxs = torch.arange(
+            compressed_kv.shape[0], dtype=torch.int64, device=q_seq.device
+        )
+        compressed_idxs = compressed_idxs + local_kv.shape[0]
+        topk = torch.cat([local_idxs, compressed_idxs], dim=0).view(1, 1, -1)
+        kv = torch.cat([local_kv, compressed_kv], dim=0)
+        out = torch_deepseek_v4_sparse_attention(
+            q_seq[token_offset : token_offset + 1].unsqueeze(0),
+            kv.unsqueeze(0),
+            attn_sink,
+            topk,
+            softmax_scale,
+        )
+        outputs.append(out.squeeze(0).squeeze(0))
+    if not outputs:
+        return q_seq.new_empty(q_seq.shape)
+    return torch.stack(outputs, dim=0)
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_sparse_attention_v2", mutates_args=())
+def torch_deepseek_v4_sparse_attention_v2(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    softmax_scale: float,
+    out: Optional[torch.Tensor] = None,
+    enable_sharding: bool = False,
+    layer_type: str = "unknown",
+    layer_idx: Optional[int] = None,
+    window_size: Optional[int] = None,
+    compress_ratio: int = 0,
+    max_compressed_len: Optional[int] = None,
+    head_dim: Optional[int] = None,
+    rope_dim: Optional[int] = None,
+    rms_norm_eps: float = 1e-6,
+) -> torch.Tensor:
+    """DSV4 sparse source op with explicit compressor projections for cache insertion."""
+    del enable_sharding, layer_type, layer_idx, window_size, head_dim
+    if compress_ratio:
+        if max_compressed_len is None:
+            raise ValueError("max_compressed_len is required for compressed DeepSeek V4 attention.")
+        if rope_dim is None:
+            raise ValueError("rope_dim is required for compressed DeepSeek V4 attention.")
+        compressed_kv = _build_full_compressed_kv(
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            position_ids,
+            rms_norm_eps,
+            rope_dim,
+            compress_ratio,
+            max_compressed_len,
+        )
+        kv = torch.cat([kv, compressed_kv], dim=1)
+    result = torch_deepseek_v4_sparse_attention(q, kv, attn_sink, topk_idxs, softmax_scale)
+    if out is not None:
+        out.copy_(result)
+        return out.new_empty(0)
+    return result
+
+
+@torch_deepseek_v4_sparse_attention_v2.register_fake
+def torch_deepseek_v4_sparse_attention_v2_fake(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    softmax_scale: float,
+    out: Optional[torch.Tensor] = None,
+    enable_sharding: bool = False,
+    layer_type: str = "unknown",
+    layer_idx: Optional[int] = None,
+    window_size: Optional[int] = None,
+    compress_ratio: int = 0,
+    max_compressed_len: Optional[int] = None,
+    head_dim: Optional[int] = None,
+    rope_dim: Optional[int] = None,
+    rms_norm_eps: float = 1e-6,
+) -> torch.Tensor:
+    del (
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        softmax_scale,
+        enable_sharding,
+        layer_type,
+        layer_idx,
+        window_size,
+        compress_ratio,
+        max_compressed_len,
+        head_dim,
+        rope_dim,
+        rms_norm_eps,
+    )
+    _validate_rank("q", q, 4)
+    if out is not None:
+        return out.new_empty(0)
+    return q.new_empty(q.shape).contiguous()
+
+
+@torch.library.custom_op(
+    "auto_deploy::torch_deepseek_v4_sparse_attention_with_cache",
+    mutates_args=(),
+)
+def torch_deepseek_v4_sparse_attention_with_cache(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    compress_ratio: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Reference cached DeepSeek V4 sparse attention.
+
+    The executable decode path implemented here covers uncompressed DeepSeek V4
+    layers, i.e. the SWA/local-window path.  Compressed layers still use the
+    full source op during prefill, but decode requires incremental compressor
+    and indexer state that is not available at this source-op boundary.
+    """
+    _validate_rank("q", q, 4)
+    _validate_rank("kv", kv, 3)
+    _validate_rank("attn_sink", attn_sink, 1)
+    _validate_rank("topk_idxs", topk_idxs, 3)
+    if window_size <= 0:
+        raise ValueError(f"window_size must be positive, got {window_size}")
+
+    batch_info = BatchInfo(batch_info_host)
+    num_prefill, num_prefill_tokens, num_decode = batch_info.get_absorbed_info()
+    num_seq = num_prefill + num_decode
+    active_tokens = num_prefill_tokens + num_decode
+
+    seq_len_host = _to_host_long(seq_len_host, num_seq)
+    input_pos_host = _to_host_long(input_pos_host, num_seq)
+    cu_seqlen_host = _to_host_long(cu_seqlen_host, num_seq + 1)
+    cache_loc_host = cache_loc_host.detach().cpu().to(torch.long).flatten()
+    cu_num_pages_host = _to_host_long(cu_num_pages_host, num_seq + 1)
+
+    if compress_ratio != 0 and any(int(pos.item()) > 0 for pos in input_pos_host):
+        raise NotImplementedError(
+            "DeepSeek V4 compressed sparse-attention decode is not implemented yet. "
+            "The current cached reference backend supports ratio-0 SWA/local-window decode only; "
+            "ratio-4 and ratio-128 layers need incremental compressor/indexer cache state."
+        )
+
+    if compress_ratio != 0:
+        result = torch_deepseek_v4_sparse_attention(
+            q, kv, attn_sink, topk_idxs, softmax_scale, out=out
+        )
+        local_flat_start = 0
+        for seq_idx in range(num_seq):
+            seq_len_i = int(seq_len_host[seq_idx].item())
+            kv_seq = _slice_sequence_tokens(kv, seq_idx, local_flat_start, seq_len_i)
+            _write_swa_cache(
+                kv_seq,
+                swa_cache,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                int(input_pos_host[seq_idx].item()),
+            )
+            local_flat_start += seq_len_i
+        return result
+
+    q_flat = q.reshape(-1, *q.shape[2:])
+    output_flat = torch.zeros_like(q_flat)
+
+    for seq_idx in range(num_seq):
+        seq_len_i = int(seq_len_host[seq_idx].item())
+        if seq_len_i == 0:
+            continue
+        flat_start = int(cu_seqlen_host[seq_idx].item())
+        input_pos_i = int(input_pos_host[seq_idx].item())
+        q_seq = q_flat[flat_start : flat_start + seq_len_i]
+        kv_seq = _slice_sequence_tokens(kv, seq_idx, flat_start, seq_len_i)
+        _write_swa_cache(
+            kv_seq,
+            swa_cache,
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            input_pos_i,
+        )
+        output_flat[flat_start : flat_start + seq_len_i] = _cached_local_window_attention(
+            q_seq,
+            attn_sink,
+            swa_cache,
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            input_pos_i,
+            window_size,
+            softmax_scale,
+        )
+
+    output = output_flat.view_as(q)
+    if active_tokens < q_flat.shape[0]:
+        output.reshape(-1, *q.shape[2:])[active_tokens:].zero_()
+    if out is not None:
+        out.copy_(output)
+        return out.new_empty(0)
+    return output
+
+
+@torch_deepseek_v4_sparse_attention_with_cache.register_fake
+def torch_deepseek_v4_sparse_attention_with_cache_fake(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    compress_ratio: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    del (
+        kv,
+        attn_sink,
+        topk_idxs,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        softmax_scale,
+        window_size,
+        compress_ratio,
+    )
+    _validate_rank("q", q, 4)
+    if out is not None:
+        return out.new_empty(0)
+    return q.new_empty(q.shape).contiguous()
+
+
+@torch.library.custom_op(
+    "auto_deploy::torch_deepseek_v4_sparse_attention_v2_with_cache",
+    mutates_args=(),
+)
+def torch_deepseek_v4_sparse_attention_v2_with_cache(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    compress_ratio: int,
+    max_compressed_len: Optional[int],
+    rms_norm_eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Reference cached DSV4 sparse attention with incremental compressed rows.
+
+    The compressed path stores high-resolution SWA rows, raw compressor
+    projections, and emitted compressed MHC rows in paged tensors. A c4/c128 row
+    is emitted when its final source token has arrived, matching the visibility
+    rule used by the full source op.
+    """
+    _validate_rank("q", q, 4)
+    _validate_rank("kv", kv, 3)
+    _validate_rank("attn_sink", attn_sink, 1)
+    _validate_rank("topk_idxs", topk_idxs, 3)
+    if window_size <= 0:
+        raise ValueError(f"window_size must be positive, got {window_size}")
+    if compress_ratio not in (0, 4, 128):
+        raise ValueError(f"compress_ratio must be one of 0, 4, or 128; got {compress_ratio}")
+
+    batch_info = BatchInfo(batch_info_host)
+    num_prefill, num_prefill_tokens, num_decode = batch_info.get_absorbed_info()
+    num_seq = num_prefill + num_decode
+    active_tokens = num_prefill_tokens + num_decode
+
+    seq_len_host = _to_host_long(seq_len_host, num_seq)
+    input_pos_host = _to_host_long(input_pos_host, num_seq)
+    cu_seqlen_host = _to_host_long(cu_seqlen_host, num_seq + 1)
+    cache_loc_host = cache_loc_host.detach().cpu().to(torch.long).flatten()
+    cu_num_pages_host = _to_host_long(cu_num_pages_host, num_seq + 1)
+
+    q_flat = q.reshape(-1, *q.shape[2:])
+    output_flat = torch.zeros_like(q_flat)
+
+    for seq_idx in range(num_seq):
+        seq_len_i = int(seq_len_host[seq_idx].item())
+        if seq_len_i == 0:
+            continue
+        flat_start = int(cu_seqlen_host[seq_idx].item())
+        input_pos_i = int(input_pos_host[seq_idx].item())
+        q_seq = q_flat[flat_start : flat_start + seq_len_i]
+        kv_seq = _slice_sequence_tokens(kv, seq_idx, flat_start, seq_len_i)
+        _write_swa_cache(
+            kv_seq,
+            swa_cache,
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            input_pos_i,
+        )
+
+        if compress_ratio:
+            compressor_kv_seq = _slice_sequence_tokens(
+                compressor_kv, seq_idx, flat_start, seq_len_i
+            )
+            compressor_gate_seq = _slice_sequence_tokens(
+                compressor_gate, seq_idx, flat_start, seq_len_i
+            )
+            _update_compressed_caches(
+                compressor_kv_seq,
+                compressor_gate_seq,
+                compressor_ape,
+                compressor_norm_weight,
+                freqs_cis_table,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                input_pos_i,
+                mhc_cache,
+                compressor_kv_cache,
+                compressor_gate_cache,
+                rms_norm_eps,
+                rope_dim,
+                compress_ratio,
+            )
+
+        if compress_ratio and input_pos_i > 0:
+            output_flat[flat_start : flat_start + seq_len_i] = _cached_compressed_attention(
+                q_seq,
+                attn_sink,
+                swa_cache,
+                mhc_cache,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                input_pos_i,
+                window_size,
+                compress_ratio,
+                softmax_scale,
+            )
+        elif compress_ratio:
+            full = torch_deepseek_v4_sparse_attention_v2(
+                q,
+                kv,
+                attn_sink,
+                topk_idxs,
+                compressor_kv,
+                compressor_gate,
+                compressor_ape,
+                compressor_norm_weight,
+                freqs_cis_table,
+                position_ids,
+                softmax_scale,
+                window_size=window_size,
+                compress_ratio=compress_ratio,
+                max_compressed_len=max_compressed_len,
+                rope_dim=rope_dim,
+                rms_norm_eps=rms_norm_eps,
+            )
+            output_flat = full.reshape_as(output_flat)
+            break
+        else:
+            output_flat[flat_start : flat_start + seq_len_i] = _cached_local_window_attention(
+                q_seq,
+                attn_sink,
+                swa_cache,
+                cache_loc_host,
+                cu_num_pages_host,
+                seq_idx,
+                input_pos_i,
+                window_size,
+                softmax_scale,
+            )
+
+    output = output_flat.view_as(q)
+    if active_tokens < q_flat.shape[0]:
+        output.reshape(-1, *q.shape[2:])[active_tokens:].zero_()
+    if out is not None:
+        out.copy_(output)
+        return out.new_empty(0)
+    return output
+
+
+@torch_deepseek_v4_sparse_attention_v2_with_cache.register_fake
+def torch_deepseek_v4_sparse_attention_v2_with_cache_fake(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    compress_ratio: int,
+    max_compressed_len: Optional[int],
+    rms_norm_eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    del (
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        compressor_kv_cache,
+        compressor_gate_cache,
+        softmax_scale,
+        window_size,
+        compress_ratio,
+        max_compressed_len,
+        rms_norm_eps,
+        rope_dim,
+    )
+    _validate_rank("q", q, 4)
+    if out is not None:
+        return out.new_empty(0)
+    return q.new_empty(q.shape).contiguous()
+
+
+@AttentionRegistry.register("deepseek_v4_sparse")
+class DeepSeekV4SparseAttention(AttentionDescriptor):
+    """Cached DeepSeek V4 sparse attention descriptor for the SWA reference path."""
+
+    @classmethod
+    def get_attention_layout(cls) -> AttentionLayout:
+        return "bsnd"
+
+    @classmethod
+    def get_num_qkv_args(cls) -> int:
+        return 10
+
+    @classmethod
+    def get_source_attention_op(cls):
+        return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2
+
+    @classmethod
+    def get_cached_attention_op(cls) -> MHACallable:
+        return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache.default
+
+    @classmethod
+    def get_standard_metadata_args(cls) -> List[str]:
+        return [
+            "batch_info_host",
+            "seq_len_host",
+            "input_pos_host",
+            "cu_seqlen_host",
+            "cache_loc_host",
+            "cu_num_pages_host",
+        ]
+
+    @classmethod
+    def get_cache_initializers(
+        cls, source_attn_node: Node, cache_config: KvCacheConfig
+    ) -> ResourceHandlerDict:
+        kv_fake = source_attn_node.args[1].meta["val"]
+        head_dim = int(kv_fake.shape[-1])
+        dtype = cls.resolve_cache_dtype(cache_config.dtype, kv_fake.dtype)
+        compressor_state_dim = head_dim * 2
+        return {
+            "swa_cache": KVPagedResourceHandler(
+                num_kv_heads=1,
+                head_dim=head_dim,
+                dtype=dtype,
+                kv_factor=1,
+                kv_layout="NHD",
+            ),
+            "mhc_cache": KVPagedResourceHandler(
+                num_kv_heads=1,
+                head_dim=head_dim,
+                dtype=dtype,
+                kv_factor=1,
+                kv_layout="NHD",
+            ),
+            "compressor_kv_cache": KVPagedResourceHandler(
+                num_kv_heads=1,
+                head_dim=compressor_state_dim,
+                dtype=torch.float32,
+                kv_factor=1,
+                kv_layout="NHD",
+            ),
+            "compressor_gate_cache": KVPagedResourceHandler(
+                num_kv_heads=1,
+                head_dim=compressor_state_dim,
+                dtype=torch.float32,
+                kv_factor=1,
+                kv_layout="NHD",
+            ),
+        }
+
+    @classmethod
+    def get_constants(cls, source_attn_node: Node) -> List[Constant]:
+        softmax_scale, window_size, compress_ratio, max_compressed_len, rms_norm_eps, rope_dim = (
+            extract_op_args(
+                source_attn_node,
+                "softmax_scale",
+                "window_size",
+                "compress_ratio",
+                "max_compressed_len",
+                "rms_norm_eps",
+                "rope_dim",
+            )
+        )
+        if window_size is None:
+            raise RuntimeError(
+                "DeepSeek V4 sparse attention source node is missing window_size metadata."
+            )
+        return [
+            softmax_scale,
+            window_size,
+            compress_ratio,
+            max_compressed_len,
+            rms_norm_eps,
+            rope_dim,
+        ]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_fp8_cache.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_fp8_cache.py
@@ -1,0 +1,879 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepSeek V4 FP8 NoPE cache helpers.
+
+The public DSV4 sparse attention op keeps the BF16 paged cache as its reference
+path. These helpers provide the narrower FP8 NoPE storage contract used by
+kernel experiments: split normalized KV rows into 448 NoPE dims and 64 RoPE
+dims, quantize NoPE values to E4M3 with one E8M0 scale per 128 values, and
+store RoPE values as BF16.
+"""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import torch
+
+from ...utils.e8m0 import fp8_block_dequant_ref, fp8_block_quant_ref, fp8_block_scale_shape
+
+if TYPE_CHECKING:
+    from ..attention_interface import DeepSeekV4PagedResourceHandler
+
+DSV4_FP8_BLOCK_SIZE = 128
+DSV4_HEAD_DIM = 512
+DSV4_NOPE_DIM = 448
+DSV4_NOPE_SCALE_BLOCKS = 4
+DSV4_ROPE_DIM = 64
+FP8_E4M3_DTYPE = torch.float8_e4m3fn
+DSV4_SWA_PAGED_RESOURCE_NAME = "swa"
+DSV4_BF16_SWA_CACHE_ARG = "swa_cache"
+DSV4_FP8_NOPE_CACHE_ARG = "nope_cache"
+DSV4_BF16_ROPE_CACHE_ARG = "rope_cache"
+DSV4_E8M0_SCALE_CACHE_ARG = "scale_cache"
+DSV4_FP8_NOPE_CACHE_SUFFIX = "swa_nope_cache"
+DSV4_BF16_ROPE_CACHE_SUFFIX = "swa_rope_cache"
+DSV4_E8M0_SCALE_CACHE_SUFFIX = "swa_scale_cache"
+DSV4_FP8_NOPE_CACHE_MUTATED_ARGS = (
+    DSV4_FP8_NOPE_CACHE_ARG,
+    DSV4_BF16_ROPE_CACHE_ARG,
+    DSV4_E8M0_SCALE_CACHE_ARG,
+)
+DSV4_FP8_NOPE_PAGED_WRITE_OP_NAME = "auto_deploy::torch_deepseek_v4_fp8_nope_paged_cache_write"
+DSV4_FP8_NOPE_PAGED_GATHER_OP_NAME = "auto_deploy::torch_deepseek_v4_fp8_nope_paged_cache_gather"
+DSV4_FP8_NOPE_ATTENTION_UNSUPPORTED_REASON = (
+    "FP8 NoPE split cache writes are not consumed by the current DeepSeek V4 cached "
+    "attention contract because the registered op still accepts one full-width BF16 "
+    "swa_cache and has no NoPE, RoPE, and E8M0 scale cache resources."
+)
+
+__all__ = [
+    "DSV4_BF16_ROPE_CACHE_ARG",
+    "DSV4_BF16_ROPE_CACHE_SUFFIX",
+    "DSV4_BF16_SWA_CACHE_ARG",
+    "DSV4_E8M0_SCALE_CACHE_ARG",
+    "DSV4_E8M0_SCALE_CACHE_SUFFIX",
+    "DSV4_FP8_BLOCK_SIZE",
+    "DSV4_FP8_NOPE_ATTENTION_UNSUPPORTED_REASON",
+    "DSV4_FP8_NOPE_CACHE_ARG",
+    "DSV4_FP8_NOPE_CACHE_MUTATED_ARGS",
+    "DSV4_FP8_NOPE_CACHE_SUFFIX",
+    "DSV4_FP8_NOPE_PAGED_GATHER_OP_NAME",
+    "DSV4_FP8_NOPE_PAGED_WRITE_OP_NAME",
+    "DSV4_HEAD_DIM",
+    "DSV4_NOPE_DIM",
+    "DSV4_NOPE_SCALE_BLOCKS",
+    "DSV4_ROPE_DIM",
+    "DSV4_SWA_PAGED_RESOURCE_NAME",
+    "DeepSeekV4FP8NopeCacheResourceSpec",
+    "DeepSeekV4FP8NopeCacheRows",
+    "deepseek_v4_fp8_nope_cache_resource_handlers",
+    "deepseek_v4_fp8_nope_cache_resource_specs",
+    "gather_deepseek_v4_fp8_nope_paged_cache_rows",
+    "quantize_deepseek_v4_fp8_nope_cache_rows",
+    "reconstruct_deepseek_v4_fp8_nope_cache_rows",
+    "split_deepseek_v4_kv_nope_rope",
+    "torch_deepseek_v4_fp8_nope_paged_cache_gather",
+    "torch_deepseek_v4_fp8_nope_paged_cache_write",
+    "validate_deepseek_v4_fp8_nope_paged_cache_resources",
+    "write_deepseek_v4_attention_cache_rows",
+    "write_deepseek_v4_bf16_flat_cache_rows",
+    "write_deepseek_v4_fp8_nope_flat_cache_rows",
+    "write_deepseek_v4_fp8_nope_paged_cache_rows",
+]
+
+
+@dataclass(frozen=True)
+class DeepSeekV4FP8NopeCacheRows:
+    """Quantized DSV4 KV rows ready for split NoPE/RoPE cache storage."""
+
+    nope: torch.Tensor
+    rope: torch.Tensor
+    scale: torch.Tensor
+
+
+@dataclass(frozen=True)
+class DeepSeekV4FP8NopeCacheResourceSpec:
+    """Graph-visible resource contract for one split DSV4 SWA cache tensor."""
+
+    schema_arg: str
+    cache_suffix: str
+    resource_name: str
+    token_shape: tuple[int, ...]
+    dtype: torch.dtype
+
+
+def _get_e8m0_dtype() -> torch.dtype | None:
+    return getattr(torch, "float8_e8m0fnu", None)
+
+
+def _default_scale_cache_dtype() -> torch.dtype:
+    return _get_e8m0_dtype() or torch.float32
+
+
+def _requires_raw_byte_copy(dtype: torch.dtype) -> bool:
+    e8m0_dtype = _get_e8m0_dtype()
+    return dtype == FP8_E4M3_DTYPE or (e8m0_dtype is not None and dtype == e8m0_dtype)
+
+
+def deepseek_v4_fp8_nope_cache_resource_specs(
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+) -> tuple[DeepSeekV4FP8NopeCacheResourceSpec, ...]:
+    """Return the split SWA resource specs used by the FP8 NoPE cache path.
+
+    All three tensors share the DSV4 ``swa`` page table but use distinct graph
+    cache arguments and cache suffixes so cached attention can tell them apart
+    from the full-width BF16 ``swa_cache`` resource.
+    """
+    expected_scale_blocks = fp8_block_scale_shape((DSV4_NOPE_DIM,), block_size)[-1]
+    return (
+        DeepSeekV4FP8NopeCacheResourceSpec(
+            schema_arg=DSV4_FP8_NOPE_CACHE_ARG,
+            cache_suffix=DSV4_FP8_NOPE_CACHE_SUFFIX,
+            resource_name=DSV4_SWA_PAGED_RESOURCE_NAME,
+            token_shape=(1, 1, DSV4_NOPE_DIM),
+            dtype=FP8_E4M3_DTYPE,
+        ),
+        DeepSeekV4FP8NopeCacheResourceSpec(
+            schema_arg=DSV4_BF16_ROPE_CACHE_ARG,
+            cache_suffix=DSV4_BF16_ROPE_CACHE_SUFFIX,
+            resource_name=DSV4_SWA_PAGED_RESOURCE_NAME,
+            token_shape=(1, 1, DSV4_ROPE_DIM),
+            dtype=torch.bfloat16,
+        ),
+        DeepSeekV4FP8NopeCacheResourceSpec(
+            schema_arg=DSV4_E8M0_SCALE_CACHE_ARG,
+            cache_suffix=DSV4_E8M0_SCALE_CACHE_SUFFIX,
+            resource_name=DSV4_SWA_PAGED_RESOURCE_NAME,
+            token_shape=(1, 1, expected_scale_blocks),
+            dtype=_default_scale_cache_dtype(),
+        ),
+    )
+
+
+def deepseek_v4_fp8_nope_cache_resource_handlers(
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+    tokens_per_block: int | None = None,
+    max_logical_entries_per_seq: int | None = None,
+) -> dict[str, "DeepSeekV4PagedResourceHandler"]:
+    """Build resource handlers for the split FP8 NoPE SWA cache tensors."""
+    from ..attention_interface import DeepSeekV4PagedResourceHandler
+
+    return {
+        spec.cache_suffix: DeepSeekV4PagedResourceHandler(
+            resource_name=spec.resource_name,
+            token_shape=spec.token_shape,
+            dtype=spec.dtype,
+            logical_length_divisor=1,
+            tokens_per_block=tokens_per_block,
+            max_logical_entries_per_seq=max_logical_entries_per_seq,
+        )
+        for spec in deepseek_v4_fp8_nope_cache_resource_specs(block_size)
+    }
+
+
+def _validate_floating_rows(name: str, rows: torch.Tensor, expected_dim: int) -> None:
+    if rows.dim() == 0:
+        raise ValueError(f"{name} must have at least one dimension")
+    if not rows.is_floating_point():
+        raise TypeError(f"{name} must be floating point, got {rows.dtype}")
+    if rows.shape[-1] != expected_dim:
+        raise ValueError(f"{name} last dimension must be {expected_dim}, got {rows.shape[-1]}")
+
+
+def _validate_cache_rows(name: str, cache: torch.Tensor, row_dim: int) -> None:
+    if cache.dim() != 2:
+        raise ValueError(f"{name} must have rank 2, got rank {cache.dim()}")
+    if cache.shape[-1] != row_dim:
+        raise ValueError(f"{name} last dimension must be {row_dim}, got {cache.shape[-1]}")
+
+
+def _validate_fp8_cache_shape(nope_cache: torch.Tensor, rope_cache: torch.Tensor) -> None:
+    _validate_cache_rows("nope_cache", nope_cache, DSV4_NOPE_DIM)
+    _validate_cache_rows("rope_cache", rope_cache, DSV4_ROPE_DIM)
+    if nope_cache.dtype != FP8_E4M3_DTYPE:
+        raise TypeError(f"nope_cache must have dtype {FP8_E4M3_DTYPE}, got {nope_cache.dtype}")
+    if rope_cache.dtype != torch.bfloat16:
+        raise TypeError(f"rope_cache must have dtype torch.bfloat16, got {rope_cache.dtype}")
+
+
+def _validate_scale_cache_dtype(scale_cache: torch.Tensor) -> None:
+    e8m0_dtype = _get_e8m0_dtype()
+    allowed_dtypes = [torch.float32, torch.uint8]
+    if e8m0_dtype is not None:
+        allowed_dtypes.append(e8m0_dtype)
+    if scale_cache.dtype not in allowed_dtypes:
+        raise TypeError(
+            f"scale_cache must have dtype torch.float32, torch.uint8"
+            f"{', or ' + str(e8m0_dtype) if e8m0_dtype is not None else ''}, "
+            f"got {scale_cache.dtype}"
+        )
+
+
+def _validate_scale_cache(scale_cache: torch.Tensor, block_size: int) -> None:
+    expected_scale_blocks = fp8_block_scale_shape((DSV4_NOPE_DIM,), block_size)[-1]
+    _validate_cache_rows("scale_cache", scale_cache, expected_scale_blocks)
+    _validate_scale_cache_dtype(scale_cache)
+
+
+def _validate_paged_cache_rank(name: str, cache: torch.Tensor) -> None:
+    if cache.dim() not in (3, 4, 5):
+        raise ValueError(f"{name} must have rank 3, 4, or 5, got rank {cache.dim()}")
+
+
+def _validate_fp8_paged_cache_shape(
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    block_size: int,
+) -> int:
+    expected_scale_blocks = fp8_block_scale_shape((DSV4_NOPE_DIM,), block_size)[-1]
+    _validate_paged_cache_rank("nope_cache", nope_cache)
+    _validate_paged_cache_rank("rope_cache", rope_cache)
+    _validate_paged_cache_rank("scale_cache", scale_cache)
+    if nope_cache.shape[:-1] != rope_cache.shape[:-1]:
+        raise ValueError(
+            "nope_cache and rope_cache must have identical page geometry before the "
+            f"last dimension, got {tuple(nope_cache.shape[:-1])} and "
+            f"{tuple(rope_cache.shape[:-1])}"
+        )
+    if nope_cache.shape[:-1] != scale_cache.shape[:-1]:
+        raise ValueError(
+            "nope_cache and scale_cache must have identical page geometry before the "
+            f"last dimension, got {tuple(nope_cache.shape[:-1])} and "
+            f"{tuple(scale_cache.shape[:-1])}"
+        )
+    if nope_cache.shape[-1] != DSV4_NOPE_DIM:
+        raise ValueError(f"nope_cache last dimension must be {DSV4_NOPE_DIM}")
+    if rope_cache.shape[-1] != DSV4_ROPE_DIM:
+        raise ValueError(f"rope_cache last dimension must be {DSV4_ROPE_DIM}")
+    if scale_cache.shape[-1] != expected_scale_blocks:
+        raise ValueError(f"scale_cache last dimension must be {expected_scale_blocks}")
+    if nope_cache.dtype != FP8_E4M3_DTYPE:
+        raise TypeError(f"nope_cache must have dtype {FP8_E4M3_DTYPE}, got {nope_cache.dtype}")
+    if rope_cache.dtype != torch.bfloat16:
+        raise TypeError(f"rope_cache must have dtype torch.bfloat16, got {rope_cache.dtype}")
+    _validate_scale_cache_dtype(scale_cache)
+    if rope_cache.device != nope_cache.device or scale_cache.device != nope_cache.device:
+        raise ValueError("nope_cache, rope_cache, and scale_cache must be on the same device")
+    return expected_scale_blocks
+
+
+def validate_deepseek_v4_fp8_nope_paged_cache_resources(
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+) -> int:
+    """Validate the split FP8 NoPE paged-cache resources.
+
+    Args:
+        nope_cache: FP8 E4M3 NoPE paged cache with last dimension ``448``.
+        rope_cache: BF16 RoPE paged cache with last dimension ``64``.
+        scale_cache: E8M0/raw-byte/FP32 scale paged cache with last dimension
+            ``ceil(448 / block_size)``.
+        block_size: Number of contiguous NoPE values covered by one scale.
+
+    Returns:
+        The expected number of scale blocks per cache row.
+    """
+    return _validate_fp8_paged_cache_shape(nope_cache, rope_cache, scale_cache, block_size)
+
+
+def _validate_int_vector(name: str, tensor: torch.Tensor) -> None:
+    if tensor.dim() != 1:
+        raise ValueError(f"{name} must have rank 1, got rank {tensor.dim()}")
+    if tensor.dtype not in (torch.int32, torch.int64, torch.int):
+        raise TypeError(f"{name} must be an int32/int64 tensor, got {tensor.dtype}")
+
+
+def _validate_scalar_int_tensor(name: str, tensor: torch.Tensor) -> None:
+    if tensor.numel() != 1:
+        raise ValueError(f"{name} tensor must have one element, got {tensor.numel()}")
+    if tensor.dtype not in (torch.int32, torch.int64, torch.int):
+        raise TypeError(f"{name} must be an int32/int64 tensor, got {tensor.dtype}")
+
+
+def _validate_fp8_nope_paged_cache_write_contract(
+    kv_rows: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    input_pos: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    block_size: int,
+) -> None:
+    _validate_floating_rows("kv_rows", kv_rows, DSV4_HEAD_DIM)
+    _validate_int_vector("cache_loc_host", cache_loc_host)
+    _validate_int_vector("cu_num_pages_host", cu_num_pages_host)
+    _validate_scalar_int_tensor("input_pos", input_pos)
+    validate_deepseek_v4_fp8_nope_paged_cache_resources(
+        nope_cache,
+        rope_cache,
+        scale_cache,
+        block_size,
+    )
+
+
+def _flatten_rows(rows: torch.Tensor, expected_dim: int, name: str) -> torch.Tensor:
+    if rows.shape[-1] != expected_dim:
+        raise ValueError(f"{name} last dimension must be {expected_dim}, got {rows.shape[-1]}")
+    return rows.reshape(-1, expected_dim)
+
+
+def _normalize_indices(
+    cache_indices: torch.Tensor, expected_rows: int, device: torch.device
+) -> torch.Tensor:
+    if cache_indices.numel() != expected_rows:
+        raise ValueError(
+            f"cache_indices must have {expected_rows} entries, got {cache_indices.numel()}"
+        )
+    return cache_indices.reshape(-1).to(device=device, dtype=torch.long)
+
+
+def _copy_raw_or_numeric(dst: torch.Tensor, src: torch.Tensor) -> None:
+    if dst.shape != src.shape:
+        raise ValueError(
+            f"dst shape {tuple(dst.shape)} does not match src shape {tuple(src.shape)}"
+        )
+
+    if _requires_raw_byte_copy(dst.dtype):
+        if not dst.is_contiguous():
+            raise ValueError("FP8/E8M0 destinations must be contiguous for raw-byte copy")
+        values = src.contiguous() if src.dtype == dst.dtype else src.to(dst.dtype).contiguous()
+        dst.view(torch.uint8).copy_(values.view(torch.uint8))
+    else:
+        values = src.to(dst.dtype).contiguous()
+        dst.copy_(values)
+
+
+def _scale_rows_for_cache(scale_rows: torch.Tensor, scale_cache: torch.Tensor) -> torch.Tensor:
+    if scale_cache.dtype != torch.uint8:
+        return scale_rows
+
+    if scale_rows.dtype == torch.uint8:
+        return scale_rows.contiguous()
+
+    e8m0_dtype = _get_e8m0_dtype()
+    if e8m0_dtype is not None and scale_rows.dtype == e8m0_dtype:
+        return scale_rows.contiguous().view(torch.uint8)
+
+    e8m0_dtype_name = str(e8m0_dtype) if e8m0_dtype is not None else "E8M0 scale rows"
+    raise TypeError(
+        "torch.uint8 scale_cache requires raw uint8 scale rows or "
+        f"{e8m0_dtype_name}; got {scale_rows.dtype}"
+    )
+
+
+def _index_copy_rows(cache: torch.Tensor, row_indices: torch.Tensor, values: torch.Tensor) -> None:
+    if cache.shape[1:] != values.shape[1:]:
+        raise ValueError(
+            f"cache row shape {tuple(cache.shape[1:])} does not match values row shape "
+            f"{tuple(values.shape[1:])}"
+        )
+
+    if _requires_raw_byte_copy(cache.dtype):
+        if not cache.is_contiguous():
+            raise ValueError("FP8/E8M0 cache tensors must be contiguous for raw-byte row copy")
+        values = (
+            values.contiguous()
+            if values.dtype == cache.dtype
+            else values.to(cache.dtype).contiguous()
+        )
+        cache_bytes = cache.view(torch.uint8).reshape(cache.shape[0], -1)
+        value_bytes = values.view(torch.uint8).reshape(values.shape[0], -1)
+        cache_bytes.index_copy_(0, row_indices, value_bytes)
+    else:
+        values = values.to(cache.dtype).contiguous()
+        cache.index_copy_(0, row_indices, values)
+
+
+def _index_copy_scale_rows(
+    scale_cache: torch.Tensor, row_indices: torch.Tensor, scale_rows: torch.Tensor
+) -> None:
+    _index_copy_rows(
+        scale_cache,
+        row_indices,
+        _scale_rows_for_cache(scale_rows, scale_cache),
+    )
+
+
+def _cache_token_rows(cache: torch.Tensor) -> torch.Tensor:
+    tokens_per_block = _cache_tokens_per_block(cache)
+    if cache.dim() == 5:
+        if int(cache.shape[1]) == 1:
+            if int(cache.shape[2]) >= int(cache.shape[3]):
+                token_rows = cache[:, 0, :, 0]
+            else:
+                token_rows = cache[:, 0, 0, :]
+        else:
+            token_rows = cache[:, :, 0, 0]
+    elif cache.dim() == 4:
+        token_rows = cache[:, :, 0]
+    elif cache.dim() == 3:
+        token_rows = cache
+    else:
+        raise ValueError(f"cache must have rank 3, 4, or 5, got rank {cache.dim()}")
+    return token_rows.reshape(cache.shape[0] * tokens_per_block, cache.shape[-1])
+
+
+def _input_pos_tensor(input_pos: int | torch.Tensor, device: torch.device) -> torch.Tensor:
+    if isinstance(input_pos, torch.Tensor):
+        if input_pos.numel() != 1:
+            raise ValueError(f"input_pos tensor must have one element, got {input_pos.numel()}")
+        return input_pos.reshape(()).to(device=device, dtype=torch.long)
+    return torch.tensor(input_pos, dtype=torch.long, device=device)
+
+
+def _paged_cache_row_indices(
+    cache_loc: torch.Tensor,
+    cu_num_pages: torch.Tensor,
+    seq_idx: int,
+    input_pos: int | torch.Tensor,
+    row_count: int,
+    tokens_per_block: int,
+    device: torch.device,
+) -> torch.Tensor:
+    position_offsets = torch.arange(row_count, dtype=torch.long, device=device)
+    input_pos_base = (
+        _input_pos_tensor(input_pos, device)
+        if isinstance(input_pos, torch.Tensor)
+        else int(input_pos)
+    )
+    positions = input_pos_base + position_offsets
+    page_ordinal = torch.div(positions, tokens_per_block, rounding_mode="floor")
+    token_offset = positions - page_ordinal * tokens_per_block
+    page_table_start = cu_num_pages.to(device=device, dtype=torch.long).reshape(-1)[seq_idx]
+    page_table_indices = page_table_start + page_ordinal
+    page_indices = (
+        cache_loc.to(device=device, dtype=torch.long)
+        .reshape(-1)
+        .index_select(0, page_table_indices)
+    )
+    return page_indices * tokens_per_block + token_offset
+
+
+def split_deepseek_v4_kv_nope_rope(kv_rows: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Split DSV4 KV rows into 448 NoPE dims and 64 RoPE dims.
+
+    Args:
+        kv_rows: Floating-point tensor with shape ``[..., 512]``.
+
+    Returns:
+        ``(nope, rope)`` where ``nope`` has shape ``[..., 448]`` and ``rope``
+        has shape ``[..., 64]``.
+    """
+    _validate_floating_rows("kv_rows", kv_rows, DSV4_HEAD_DIM)
+    nope = kv_rows[..., :DSV4_NOPE_DIM].contiguous()
+    rope = kv_rows[..., DSV4_NOPE_DIM:].contiguous()
+    return nope, rope
+
+
+def quantize_deepseek_v4_fp8_nope_cache_rows(
+    kv_rows: torch.Tensor,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+) -> DeepSeekV4FP8NopeCacheRows:
+    """Quantize DSV4 NoPE dims to FP8 and keep RoPE dims in BF16."""
+    nope, rope = split_deepseek_v4_kv_nope_rope(kv_rows)
+    nope_fp8, scale = fp8_block_quant_ref(nope, block_size)
+    return DeepSeekV4FP8NopeCacheRows(
+        nope=nope_fp8,
+        rope=rope.to(torch.bfloat16).contiguous(),
+        scale=scale,
+    )
+
+
+def reconstruct_deepseek_v4_fp8_nope_cache_rows(
+    nope: torch.Tensor,
+    rope: torch.Tensor,
+    scale: torch.Tensor,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Reconstruct BF16/FP32 DSV4 KV rows from split FP8-NoPE/BF16-RoPE cache rows."""
+    if nope.shape[-1] != DSV4_NOPE_DIM:
+        raise ValueError(f"nope last dimension must be {DSV4_NOPE_DIM}, got {nope.shape[-1]}")
+    if rope.shape[-1] != DSV4_ROPE_DIM:
+        raise ValueError(f"rope last dimension must be {DSV4_ROPE_DIM}, got {rope.shape[-1]}")
+    expected_scale_shape = fp8_block_scale_shape(tuple(nope.shape), block_size)
+    if tuple(scale.shape) != expected_scale_shape:
+        raise ValueError(
+            f"scale shape {tuple(scale.shape)} must match expected shape {expected_scale_shape}"
+        )
+
+    nope_dequant = fp8_block_dequant_ref(nope, scale, block_size, dtype=dtype)
+    return torch.cat([nope_dequant, rope.to(dtype)], dim=-1).contiguous()
+
+
+def write_deepseek_v4_fp8_nope_flat_cache_rows(
+    kv_rows: torch.Tensor,
+    cache_indices: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+) -> DeepSeekV4FP8NopeCacheRows:
+    """Write quantized DSV4 rows into split flat NoPE/RoPE/scale caches."""
+    _validate_fp8_cache_shape(nope_cache, rope_cache)
+    _validate_scale_cache(scale_cache, block_size)
+
+    rows = quantize_deepseek_v4_fp8_nope_cache_rows(kv_rows, block_size)
+    row_count = rows.nope.reshape(-1, DSV4_NOPE_DIM).shape[0]
+    row_indices = _normalize_indices(cache_indices, row_count, nope_cache.device)
+
+    _index_copy_rows(nope_cache, row_indices, _flatten_rows(rows.nope, DSV4_NOPE_DIM, "nope"))
+    _index_copy_rows(rope_cache, row_indices, _flatten_rows(rows.rope, DSV4_ROPE_DIM, "rope"))
+    _index_copy_scale_rows(
+        scale_cache,
+        row_indices.to(device=scale_cache.device),
+        rows.scale.reshape(row_count, -1),
+    )
+    return rows
+
+
+def write_deepseek_v4_bf16_flat_cache_rows(
+    kv_rows: torch.Tensor,
+    cache_indices: torch.Tensor,
+    bf16_cache: torch.Tensor,
+) -> torch.Tensor:
+    """Reference fallback: write full DSV4 KV rows into a flat BF16 cache."""
+    _validate_floating_rows("kv_rows", kv_rows, DSV4_HEAD_DIM)
+    _validate_cache_rows("bf16_cache", bf16_cache, DSV4_HEAD_DIM)
+    if bf16_cache.dtype != torch.bfloat16:
+        raise TypeError(f"bf16_cache must have dtype torch.bfloat16, got {bf16_cache.dtype}")
+
+    flat_rows = kv_rows.reshape(-1, DSV4_HEAD_DIM).to(torch.bfloat16).contiguous()
+    row_indices = _normalize_indices(cache_indices, flat_rows.shape[0], bf16_cache.device)
+    _index_copy_rows(bf16_cache, row_indices, flat_rows)
+    return flat_rows.reshape(*kv_rows.shape[:-1], DSV4_HEAD_DIM)
+
+
+def write_deepseek_v4_attention_cache_rows(
+    kv_rows: torch.Tensor,
+    cache_indices: torch.Tensor,
+    *,
+    bf16_cache: torch.Tensor | None = None,
+    nope_cache: torch.Tensor | None = None,
+    rope_cache: torch.Tensor | None = None,
+    scale_cache: torch.Tensor | None = None,
+    use_fp8_nope_cache: bool = False,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+) -> torch.Tensor | DeepSeekV4FP8NopeCacheRows:
+    """Write DSV4 rows through either the BF16 fallback or split FP8 NoPE path.
+
+    ``use_fp8_nope_cache=False`` is the default so callers can keep the BF16
+    cache as a local debug/reference path while opt-in FP8 cache experiments
+    share the same row preparation helper.
+    """
+    if not use_fp8_nope_cache:
+        if bf16_cache is None:
+            raise ValueError("bf16_cache must be provided when use_fp8_nope_cache=False")
+        return write_deepseek_v4_bf16_flat_cache_rows(kv_rows, cache_indices, bf16_cache)
+
+    if nope_cache is None or rope_cache is None or scale_cache is None:
+        missing = [
+            name
+            for name, cache in (
+                ("nope_cache", nope_cache),
+                ("rope_cache", rope_cache),
+                ("scale_cache", scale_cache),
+            )
+            if cache is None
+        ]
+        raise ValueError(f"{', '.join(missing)} must be provided when use_fp8_nope_cache=True")
+    return write_deepseek_v4_fp8_nope_flat_cache_rows(
+        kv_rows,
+        cache_indices,
+        nope_cache,
+        rope_cache,
+        scale_cache,
+        block_size,
+    )
+
+
+def _cache_tokens_per_block(cache: torch.Tensor) -> int:
+    if cache.dim() == 5:
+        if int(cache.shape[1]) == 1:
+            token_dim = 2 if int(cache.shape[2]) >= int(cache.shape[3]) else 3
+        else:
+            token_dim = 1
+    elif cache.dim() in (3, 4):
+        token_dim = 1
+    else:
+        raise ValueError(f"cache must have rank 3, 4, or 5, got rank {cache.dim()}")
+    return int(cache.shape[token_dim])
+
+
+def _cache_token_view(cache: torch.Tensor, page_idx: int, token_offset: int) -> torch.Tensor:
+    if cache.dim() == 5:
+        if int(cache.shape[1]) == 1:
+            if int(cache.shape[2]) >= int(cache.shape[3]):
+                return cache[page_idx, 0, token_offset, 0]
+            return cache[page_idx, 0, 0, token_offset]
+        return cache[page_idx, token_offset, 0, 0]
+    if cache.dim() == 4:
+        return cache[page_idx, token_offset, 0]
+    if cache.dim() == 3:
+        return cache[page_idx, token_offset]
+    raise ValueError(f"cache must have rank 3, 4, or 5, got rank {cache.dim()}")
+
+
+def _page_for_position(
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    position: int,
+    tokens_per_block: int,
+) -> tuple[int, int]:
+    page_ordinal = position // tokens_per_block
+    token_offset = position - page_ordinal * tokens_per_block
+    page_table_start = int(cu_num_pages_host[seq_idx].item())
+    page_table_end = int(cu_num_pages_host[seq_idx + 1].item())
+    page_table_idx = page_table_start + page_ordinal
+    if page_table_idx >= page_table_end:
+        raise ValueError(
+            f"Sequence {seq_idx} position {position} needs page ordinal {page_ordinal}, "
+            f"but only {page_table_end - page_table_start} page(s) are available"
+        )
+    return int(cache_loc_host[page_table_idx].item()), token_offset
+
+
+def write_deepseek_v4_fp8_nope_paged_cache_rows(
+    kv_rows: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    input_pos: int | torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+) -> DeepSeekV4FP8NopeCacheRows:
+    """Write one sequence of DSV4 rows into split paged NoPE/RoPE/scale caches."""
+    expected_scale_blocks = _validate_fp8_paged_cache_shape(
+        nope_cache, rope_cache, scale_cache, block_size
+    )
+
+    tokens_per_block = _cache_tokens_per_block(nope_cache)
+    if _cache_tokens_per_block(rope_cache) != tokens_per_block:
+        raise ValueError("rope_cache tokens_per_block must match nope_cache")
+    if _cache_tokens_per_block(scale_cache) != tokens_per_block:
+        raise ValueError("scale_cache tokens_per_block must match nope_cache")
+
+    rows = quantize_deepseek_v4_fp8_nope_cache_rows(kv_rows, block_size)
+    nope_rows = _flatten_rows(rows.nope, DSV4_NOPE_DIM, "nope")
+    rope_rows = _flatten_rows(rows.rope, DSV4_ROPE_DIM, "rope")
+    scale_rows = rows.scale.reshape(nope_rows.shape[0], expected_scale_blocks)
+    row_indices = _paged_cache_row_indices(
+        cache_loc_host,
+        cu_num_pages_host,
+        seq_idx,
+        input_pos,
+        nope_rows.shape[0],
+        tokens_per_block,
+        nope_cache.device,
+    )
+
+    _index_copy_rows(_cache_token_rows(nope_cache), row_indices, nope_rows)
+    _index_copy_rows(_cache_token_rows(rope_cache), row_indices, rope_rows)
+    _index_copy_scale_rows(_cache_token_rows(scale_cache), row_indices, scale_rows)
+
+    return rows
+
+
+def gather_deepseek_v4_fp8_nope_paged_cache_rows(
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    start_pos: int,
+    end_pos: int,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Gather and dequantize DSV4 rows from split paged NoPE/RoPE/scale caches.
+
+    Args:
+        cache_loc_host: Page-table entries for the sequence batch.
+        cu_num_pages_host: Cumulative page-table offsets per sequence.
+        seq_idx: Sequence index into ``cu_num_pages_host``.
+        start_pos: First logical token position to gather.
+        end_pos: Exclusive logical token position.
+        nope_cache: FP8 E4M3 NoPE paged cache with last dimension ``448``.
+        rope_cache: BF16 RoPE paged cache with last dimension ``64``.
+        scale_cache: E8M0/raw-byte/FP32 scale paged cache with last dimension ``4``.
+        block_size: NoPE FP8 block size. DeepSeek V4 uses ``128``.
+        dtype: Reconstructed output dtype.
+
+    Returns:
+        Reconstructed rows with shape ``[end_pos - start_pos, 512]``.
+    """
+    _validate_fp8_paged_cache_shape(nope_cache, rope_cache, scale_cache, block_size)
+    if end_pos < start_pos:
+        raise ValueError(f"end_pos must be >= start_pos, got {end_pos} < {start_pos}")
+
+    tokens_per_block = _cache_tokens_per_block(nope_cache)
+    if _cache_tokens_per_block(rope_cache) != tokens_per_block:
+        raise ValueError("rope_cache tokens_per_block must match nope_cache")
+    if _cache_tokens_per_block(scale_cache) != tokens_per_block:
+        raise ValueError("scale_cache tokens_per_block must match nope_cache")
+
+    row_count = end_pos - start_pos
+    if row_count == 0:
+        return torch.empty(0, DSV4_HEAD_DIM, dtype=dtype, device=nope_cache.device)
+
+    row_indices = _paged_cache_row_indices(
+        cache_loc_host,
+        cu_num_pages_host,
+        seq_idx,
+        start_pos,
+        row_count,
+        tokens_per_block,
+        nope_cache.device,
+    )
+    nope_rows = _cache_token_rows(nope_cache).index_select(0, row_indices)
+    rope_rows = _cache_token_rows(rope_cache).index_select(0, row_indices)
+    scale_rows = _cache_token_rows(scale_cache).index_select(0, row_indices)
+    return reconstruct_deepseek_v4_fp8_nope_cache_rows(
+        nope_rows,
+        rope_rows,
+        scale_rows,
+        block_size=block_size,
+        dtype=dtype,
+    )
+
+
+@torch.library.custom_op(
+    DSV4_FP8_NOPE_PAGED_WRITE_OP_NAME,
+    mutates_args=DSV4_FP8_NOPE_CACHE_MUTATED_ARGS,
+)
+def torch_deepseek_v4_fp8_nope_paged_cache_write(
+    kv_rows: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    input_pos: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+) -> torch.Tensor:
+    """Graph-visible split FP8 NoPE paged-cache write contract."""
+    _validate_fp8_nope_paged_cache_write_contract(
+        kv_rows,
+        cache_loc_host,
+        cu_num_pages_host,
+        input_pos,
+        nope_cache,
+        rope_cache,
+        scale_cache,
+        block_size,
+    )
+    write_deepseek_v4_fp8_nope_paged_cache_rows(
+        kv_rows,
+        cache_loc_host,
+        cu_num_pages_host,
+        seq_idx,
+        input_pos,
+        nope_cache,
+        rope_cache,
+        scale_cache,
+        block_size,
+    )
+    return kv_rows.new_empty(0)
+
+
+@torch_deepseek_v4_fp8_nope_paged_cache_write.register_fake
+def torch_deepseek_v4_fp8_nope_paged_cache_write_fake(
+    kv_rows: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    input_pos: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+) -> torch.Tensor:
+    del seq_idx
+    _validate_fp8_nope_paged_cache_write_contract(
+        kv_rows,
+        cache_loc_host,
+        cu_num_pages_host,
+        input_pos,
+        nope_cache,
+        rope_cache,
+        scale_cache,
+        block_size,
+    )
+    return kv_rows.new_empty(0)
+
+
+@torch.library.custom_op(DSV4_FP8_NOPE_PAGED_GATHER_OP_NAME, mutates_args=())
+def torch_deepseek_v4_fp8_nope_paged_cache_gather(
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    start_pos: int,
+    end_pos: int,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+) -> torch.Tensor:
+    """Graph-visible BF16 gather from split FP8 NoPE paged-cache resources."""
+    _validate_int_vector("cache_loc_host", cache_loc_host)
+    _validate_int_vector("cu_num_pages_host", cu_num_pages_host)
+    return gather_deepseek_v4_fp8_nope_paged_cache_rows(
+        cache_loc_host,
+        cu_num_pages_host,
+        seq_idx,
+        start_pos,
+        end_pos,
+        nope_cache,
+        rope_cache,
+        scale_cache,
+        block_size=block_size,
+        dtype=torch.bfloat16,
+    )
+
+
+@torch_deepseek_v4_fp8_nope_paged_cache_gather.register_fake
+def torch_deepseek_v4_fp8_nope_paged_cache_gather_fake(
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    start_pos: int,
+    end_pos: int,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    block_size: int = DSV4_FP8_BLOCK_SIZE,
+) -> torch.Tensor:
+    del seq_idx
+    _validate_int_vector("cache_loc_host", cache_loc_host)
+    _validate_int_vector("cu_num_pages_host", cu_num_pages_host)
+    validate_deepseek_v4_fp8_nope_paged_cache_resources(
+        nope_cache,
+        rope_cache,
+        scale_cache,
+        block_size,
+    )
+    if end_pos < start_pos:
+        raise ValueError(f"end_pos must be >= start_pos, got {end_pos} < {start_pos}")
+    return rope_cache.new_empty((end_pos - start_pos, DSV4_HEAD_DIM)).contiguous()

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_kernels.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_kernels.py
@@ -1,0 +1,667 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standalone DeepSeek V4 attention kernel building blocks.
+
+The functions in this module are intentionally small and reference-first. They
+mirror the math used by the prefill-only DeepSeek V4 scaffold while exposing
+semantic custom-op wrappers that later Triton/CUDA kernels can replace.
+"""
+
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from ...utils.e8m0 import maybe_e8m0_to_fp32
+from .deepseek_v4_attention import torch_deepseek_v4_sparse_attention
+
+FP8_E4M3_DTYPE = torch.float8_e4m3fn
+FP8_E4M3_MAX = torch.finfo(FP8_E4M3_DTYPE).max
+FP8_E4M3_MIN = torch.finfo(FP8_E4M3_DTYPE).min
+
+__all__ = [
+    "deepseek_v4_compressor_pool_norm_rope_ref",
+    "deepseek_v4_fp8_block_dequant_ref",
+    "deepseek_v4_fp8_block_quant_ref",
+    "deepseek_v4_indexer_q_rope_quant_ref",
+    "deepseek_v4_inverse_rope_fp8_output_quant_ref",
+    "deepseek_v4_kv_rmsnorm_rope_cache_insert_ref",
+    "deepseek_v4_kv_rmsnorm_rope_ref",
+    "deepseek_v4_local_window_topk_idxs",
+    "deepseek_v4_q_rmsnorm_rope_ref",
+    "deepseek_v4_sparse_attention_microkernel_ref",
+    "torch_deepseek_v4_compressor_pool_norm_rope",
+    "torch_deepseek_v4_indexer_q_rope_quant",
+    "torch_deepseek_v4_inverse_rope_fp8_output_quant",
+    "torch_deepseek_v4_kv_rmsnorm_rope_cache_insert",
+    "torch_deepseek_v4_q_rmsnorm_rope",
+    "torch_deepseek_v4_sparse_attention_microkernel",
+]
+
+
+def _get_e8m0_dtype() -> torch.dtype | None:
+    return getattr(torch, "float8_e8m0fnu", None)
+
+
+def _scale_dtype() -> torch.dtype:
+    return _get_e8m0_dtype() or torch.float32
+
+
+def _validate_rank(name: str, tensor: torch.Tensor, rank: int) -> None:
+    if tensor.dim() != rank:
+        raise ValueError(f"{name} must have rank {rank}, got rank {tensor.dim()}")
+
+
+def _validate_floating(name: str, tensor: torch.Tensor) -> None:
+    if not tensor.is_floating_point():
+        raise TypeError(f"{name} must be floating point, got {tensor.dtype}")
+
+
+def _validate_rope_dim(rope_dim: int, head_dim: int) -> None:
+    if rope_dim < 0:
+        raise ValueError(f"rope_dim must be non-negative, got {rope_dim}")
+    if rope_dim > head_dim:
+        raise ValueError(f"rope_dim must be <= head_dim ({head_dim}), got {rope_dim}")
+    if rope_dim % 2 != 0:
+        raise ValueError(f"rope_dim must be even, got {rope_dim}")
+
+
+def _validate_block_size(block_size: int) -> None:
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+
+
+def _rms_norm_ref(
+    x: torch.Tensor,
+    weight: Optional[torch.Tensor],
+    eps: float,
+) -> torch.Tensor:
+    _validate_floating("x", x)
+    compute = x.to(torch.float32)
+    output = compute * torch.rsqrt(compute.square().mean(dim=-1, keepdim=True) + eps)
+    if weight is not None:
+        if weight.shape != (x.shape[-1],):
+            raise ValueError(f"weight must have shape ({x.shape[-1]},), got {tuple(weight.shape)}")
+        output = output * weight.to(device=x.device, dtype=torch.float32)
+    return output.to(x.dtype)
+
+
+def _apply_rope_ref(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+    *,
+    inverse: bool = False,
+) -> torch.Tensor:
+    _validate_floating("x", x)
+    _validate_rope_dim(rope_dim, x.shape[-1])
+    if rope_dim == 0:
+        return x.contiguous()
+
+    if freqs_cis.shape[-1] != rope_dim // 2:
+        raise ValueError(
+            f"freqs_cis last dim must be rope_dim // 2 ({rope_dim // 2}), got {freqs_cis.shape[-1]}"
+        )
+
+    nope = x[..., : x.shape[-1] - rope_dim]
+    rope = x[..., -rope_dim:]
+    rope_complex = torch.view_as_complex(rope.float().reshape(*rope.shape[:-1], -1, 2))
+    freqs = freqs_cis.conj() if inverse else freqs_cis
+    if freqs.dim() == rope_complex.dim() - 1:
+        freqs = freqs.unsqueeze(-2)
+    rope_out = torch.view_as_real(rope_complex * freqs).flatten(-2).to(x.dtype)
+    return torch.cat([nope, rope_out], dim=-1).contiguous()
+
+
+def _quantize_scale_to_e8m0(scale: torch.Tensor) -> torch.Tensor:
+    safe_scale = torch.clamp(scale, min=torch.finfo(torch.float32).tiny)
+    exponent = torch.ceil(torch.log2(safe_scale))
+    exp_bits = torch.clamp(exponent + 127, min=0, max=255).to(torch.uint8)
+
+    e8m0_dtype = _get_e8m0_dtype()
+    if e8m0_dtype is not None:
+        return exp_bits.view(e8m0_dtype)
+
+    # Fallback for older PyTorch builds: keep the exponent-only contract by
+    # rounding positive scales up to powers of two and storing them as FP32.
+    return torch.pow(2.0, exp_bits.to(torch.float32) - 127).to(torch.float32)
+
+
+def _fake_scale(shape: tuple[int, ...], device: torch.device) -> torch.Tensor:
+    return torch.empty(shape, dtype=_scale_dtype(), device=device)
+
+
+def _requires_byte_index_copy(dtype: torch.dtype) -> bool:
+    e8m0_dtype = _get_e8m0_dtype()
+    return dtype == FP8_E4M3_DTYPE or (e8m0_dtype is not None and dtype == e8m0_dtype)
+
+
+def _index_copy_rows(cache: torch.Tensor, row_indices: torch.Tensor, values: torch.Tensor) -> None:
+    if cache.shape[1:] != values.shape[1:]:
+        raise ValueError(
+            f"cache row shape {tuple(cache.shape[1:])} does not match values row shape "
+            f"{tuple(values.shape[1:])}"
+        )
+    values = values.to(cache.dtype).contiguous()
+    if _requires_byte_index_copy(cache.dtype):
+        if not cache.is_contiguous():
+            raise ValueError("FP8/E8M0 cache tensors must be contiguous for raw-byte row copy.")
+        cache_u8 = cache.view(torch.uint8).reshape(cache.shape[0], -1)
+        values_u8 = values.view(torch.uint8).reshape(values.shape[0], -1)
+        cache_u8.index_copy_(0, row_indices, values_u8)
+    else:
+        cache.index_copy_(0, row_indices, values)
+
+
+def _insert_flat_cache(
+    cache: torch.Tensor, cache_indices: torch.Tensor, values: torch.Tensor
+) -> None:
+    flat_values = values.reshape(-1, values.shape[-1])
+    if cache_indices.numel() != flat_values.shape[0]:
+        raise ValueError(
+            f"cache_indices must have {flat_values.shape[0]} entries, got {cache_indices.numel()}"
+        )
+    if flat_values.numel() == 0:
+        return
+    flat_indices = cache_indices.reshape(-1).to(device=cache.device, dtype=torch.long)
+    _index_copy_rows(cache, flat_indices, flat_values)
+
+
+def deepseek_v4_fp8_block_quant_ref(
+    x: torch.Tensor,
+    block_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize ``x`` to E4M3 with one E8M0 scale per last-dim block.
+
+    Args:
+        x: Tensor of shape ``[..., dim]``.
+        block_size: Number of contiguous last-dimension elements covered by one
+            scale. Partial tail blocks are zero-padded for amax calculation.
+
+    Returns:
+        ``(x_fp8, scale)`` where ``x_fp8`` has shape ``[..., dim]`` and dtype
+        ``torch.float8_e4m3fn``. ``scale`` has shape
+        ``[..., ceil(dim / block_size)]`` and uses ``torch.float8_e8m0fnu`` when
+        available, otherwise FP32 powers of two.
+    """
+    _validate_floating("x", x)
+    _validate_block_size(block_size)
+
+    last_dim = x.shape[-1]
+    num_blocks = (last_dim + block_size - 1) // block_size
+    scale_shape = (*x.shape[:-1], num_blocks)
+    if last_dim == 0:
+        return x.to(FP8_E4M3_DTYPE).contiguous(), _fake_scale(scale_shape, x.device)
+
+    pad = num_blocks * block_size - last_dim
+    x_float = x.to(torch.float32)
+    if pad:
+        x_float = F.pad(x_float, (0, pad))
+    blocked = x_float.reshape(*x.shape[:-1], num_blocks, block_size)
+    amax = blocked.abs().amax(dim=-1)
+    scale_fp32 = torch.where(
+        amax > 0,
+        amax / FP8_E4M3_MAX,
+        torch.ones((), device=x.device, dtype=torch.float32),
+    )
+    scale = _quantize_scale_to_e8m0(scale_fp32)
+    scale_decoded = maybe_e8m0_to_fp32(scale).to(device=x.device, dtype=torch.float32)
+    quant = (blocked / scale_decoded.unsqueeze(-1)).clamp(FP8_E4M3_MIN, FP8_E4M3_MAX)
+    quant = quant.to(FP8_E4M3_DTYPE).reshape(*x.shape[:-1], num_blocks * block_size)
+    return quant[..., :last_dim].contiguous(), scale.contiguous()
+
+
+def deepseek_v4_fp8_block_dequant_ref(
+    x_fp8: torch.Tensor,
+    scale: torch.Tensor,
+    block_size: int = 128,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize tensors produced by :func:`deepseek_v4_fp8_block_quant_ref`."""
+    _validate_block_size(block_size)
+    if x_fp8.dtype != FP8_E4M3_DTYPE:
+        raise TypeError(f"x_fp8 must have dtype {FP8_E4M3_DTYPE}, got {x_fp8.dtype}")
+
+    scale_expanded = maybe_e8m0_to_fp32(scale).repeat_interleave(block_size, dim=-1)
+    scale_expanded = scale_expanded[..., : x_fp8.shape[-1]]
+    return (x_fp8.to(torch.float32) * scale_expanded.to(torch.float32)).to(dtype).contiguous()
+
+
+def deepseek_v4_q_rmsnorm_rope_ref(
+    q: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+) -> torch.Tensor:
+    """Apply per-head RMSNorm and complex RoPE to query states ``[B, S, H, D]``."""
+    _validate_rank("q", q, 4)
+    q_norm = _rms_norm_ref(q, norm_weight, eps)
+    return _apply_rope_ref(q_norm, freqs_cis, rope_dim)
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_q_rmsnorm_rope", mutates_args=())
+def torch_deepseek_v4_q_rmsnorm_rope(
+    q: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+) -> torch.Tensor:
+    return deepseek_v4_q_rmsnorm_rope_ref(q, norm_weight, freqs_cis, eps, rope_dim)
+
+
+@torch_deepseek_v4_q_rmsnorm_rope.register_fake
+def torch_deepseek_v4_q_rmsnorm_rope_fake(
+    q: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+) -> torch.Tensor:
+    _validate_rank("q", q, 4)
+    _validate_rope_dim(rope_dim, q.shape[-1])
+    return q.new_empty(q.shape).contiguous()
+
+
+def deepseek_v4_kv_rmsnorm_rope_ref(
+    kv: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+) -> torch.Tensor:
+    """Apply RMSNorm and complex RoPE to shared KV states ``[B, S, D]``."""
+    _validate_rank("kv", kv, 3)
+    kv_norm = _rms_norm_ref(kv, norm_weight, eps)
+    return _apply_rope_ref(kv_norm, freqs_cis, rope_dim)
+
+
+def deepseek_v4_kv_rmsnorm_rope_cache_insert_ref(
+    kv: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    cache_indices: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    fp8_block_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Normalize/RoPE KV, FP8-quantize NoPE dims, and insert flat cache rows.
+
+    ``cache_indices`` is a flat gather/scatter contract supplied by the caller.
+    It deliberately does not encode V4 paged-cache metadata.
+    """
+    kv_out = deepseek_v4_kv_rmsnorm_rope_ref(kv, norm_weight, freqs_cis, eps, rope_dim)
+    nope = kv_out[..., : kv_out.shape[-1] - rope_dim]
+    rope = kv_out[..., -rope_dim:] if rope_dim else kv_out.new_empty(*kv_out.shape[:-1], 0)
+    nope_fp8, nope_scale = deepseek_v4_fp8_block_quant_ref(nope, fp8_block_size)
+
+    _insert_flat_cache(nope_cache, cache_indices, nope_fp8)
+    _insert_flat_cache(rope_cache, cache_indices, rope)
+    flat_scale = nope_scale.reshape(-1, nope_scale.shape[-1])
+    if cache_indices.numel() != flat_scale.shape[0]:
+        raise ValueError(
+            f"cache_indices must have {flat_scale.shape[0]} entries, got {cache_indices.numel()}"
+        )
+    if flat_scale.numel() != 0:
+        _index_copy_rows(
+            scale_cache,
+            cache_indices.reshape(-1).to(device=scale_cache.device, dtype=torch.long),
+            flat_scale,
+        )
+    return kv_out, nope_fp8, nope_scale
+
+
+@torch.library.custom_op(
+    "auto_deploy::torch_deepseek_v4_kv_rmsnorm_rope_cache_insert",
+    mutates_args=("nope_cache", "rope_cache", "scale_cache"),
+)
+def torch_deepseek_v4_kv_rmsnorm_rope_cache_insert(
+    kv: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    cache_indices: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    fp8_block_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return deepseek_v4_kv_rmsnorm_rope_cache_insert_ref(
+        kv,
+        norm_weight,
+        freqs_cis,
+        cache_indices,
+        nope_cache,
+        rope_cache,
+        scale_cache,
+        eps,
+        rope_dim,
+        fp8_block_size,
+    )
+
+
+@torch_deepseek_v4_kv_rmsnorm_rope_cache_insert.register_fake
+def torch_deepseek_v4_kv_rmsnorm_rope_cache_insert_fake(
+    kv: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    cache_indices: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    fp8_block_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    _validate_rank("kv", kv, 3)
+    _validate_rope_dim(rope_dim, kv.shape[-1])
+    _validate_block_size(fp8_block_size)
+    nope_dim = kv.shape[-1] - rope_dim
+    num_blocks = (nope_dim + fp8_block_size - 1) // fp8_block_size
+    return (
+        kv.new_empty(kv.shape).contiguous(),
+        torch.empty((*kv.shape[:-1], nope_dim), dtype=FP8_E4M3_DTYPE, device=kv.device),
+        scale_cache.new_empty((*kv.shape[:-1], num_blocks)).contiguous(),
+    )
+
+
+def _overlap_transform_ref(
+    tensor: torch.Tensor, ratio: int, head_dim: int, value: float
+) -> torch.Tensor:
+    batch_size, compressed_len, _, _ = tensor.shape
+    out = tensor.new_full((batch_size, compressed_len, 2 * ratio, head_dim), value)
+    out[:, :, ratio:] = tensor[:, :, :, head_dim:]
+    out[:, 1:, :ratio] = tensor[:, :-1, :, :head_dim]
+    return out
+
+
+def deepseek_v4_compressor_pool_norm_rope_ref(
+    kv: torch.Tensor,
+    gate: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    compress_ratio: int,
+    overlap: bool,
+) -> torch.Tensor:
+    """Apply DeepSeek V4 compressor pooling, RMSNorm, and RoPE.
+
+    Args:
+        kv: Compressor value projection with shape ``[B, S, channels * D]``.
+        gate: Compressor gate projection with shape ``[B, S, channels * D]``.
+        ape: Additive positional embedding with shape ``[ratio, channels * D]``.
+        norm_weight: Optional RMSNorm weight with shape ``[D]``.
+        freqs_cis: Full-token complex RoPE frequencies ``[B, S, rope_dim // 2]``.
+        eps: RMSNorm epsilon.
+        rope_dim: Number of trailing dimensions using RoPE.
+        compress_ratio: Compression ratio, e.g. 4 or 128.
+        overlap: Whether to use the ratio-4 overlapping compressor layout.
+    """
+    _validate_rank("kv", kv, 3)
+    _validate_rank("gate", gate, 3)
+    _validate_rank("ape", ape, 2)
+    if kv.shape != gate.shape:
+        raise ValueError(
+            f"kv and gate shapes must match, got {tuple(kv.shape)} and {tuple(gate.shape)}"
+        )
+    if compress_ratio <= 0:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+
+    channels = 2 if overlap else 1
+    if kv.shape[-1] % channels != 0:
+        raise ValueError(f"kv last dim {kv.shape[-1]} is not divisible by channels={channels}")
+    head_dim = kv.shape[-1] // channels
+    _validate_rope_dim(rope_dim, head_dim)
+    if ape.shape != (compress_ratio, channels * head_dim):
+        raise ValueError(
+            f"ape must have shape ({compress_ratio}, {channels * head_dim}), got {tuple(ape.shape)}"
+        )
+
+    batch_size, seq_len, _ = kv.shape
+    cutoff = (seq_len // compress_ratio) * compress_ratio
+    compressed_len = cutoff // compress_ratio
+    if cutoff == 0:
+        return kv.new_empty(batch_size, 0, head_dim)
+
+    kv_blocks = kv[:, :cutoff].view(batch_size, compressed_len, compress_ratio, -1)
+    gate_blocks = gate[:, :cutoff].view(batch_size, compressed_len, compress_ratio, -1)
+    gate_blocks = gate_blocks + ape.to(device=gate.device, dtype=gate.dtype)
+    if overlap:
+        kv_blocks = _overlap_transform_ref(kv_blocks, compress_ratio, head_dim, 0.0)
+        gate_blocks = _overlap_transform_ref(gate_blocks, compress_ratio, head_dim, float("-inf"))
+
+    pooled = (kv_blocks * gate_blocks.softmax(dim=2)).sum(dim=2)
+    pooled = _rms_norm_ref(pooled, norm_weight, eps)
+    compressed_freqs = freqs_cis[:, :cutoff:compress_ratio]
+    return _apply_rope_ref(pooled, compressed_freqs, rope_dim)
+
+
+@torch.library.custom_op(
+    "auto_deploy::torch_deepseek_v4_compressor_pool_norm_rope", mutates_args=()
+)
+def torch_deepseek_v4_compressor_pool_norm_rope(
+    kv: torch.Tensor,
+    gate: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    compress_ratio: int,
+    overlap: bool,
+) -> torch.Tensor:
+    return deepseek_v4_compressor_pool_norm_rope_ref(
+        kv, gate, ape, norm_weight, freqs_cis, eps, rope_dim, compress_ratio, overlap
+    )
+
+
+@torch_deepseek_v4_compressor_pool_norm_rope.register_fake
+def torch_deepseek_v4_compressor_pool_norm_rope_fake(
+    kv: torch.Tensor,
+    gate: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    compress_ratio: int,
+    overlap: bool,
+) -> torch.Tensor:
+    _validate_rank("kv", kv, 3)
+    if compress_ratio <= 0:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+    channels = 2 if overlap else 1
+    head_dim = kv.shape[-1] // channels
+    _validate_rope_dim(rope_dim, head_dim)
+    return kv.new_empty(kv.shape[0], kv.shape[1] // compress_ratio, head_dim).contiguous()
+
+
+def deepseek_v4_indexer_q_rope_quant_ref(
+    q: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+    fp8_block_size: int = 128,
+    quant_format: str = "fp8",
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply RoPE to indexer Q and quantize it for the initial FP8 path."""
+    if quant_format != "fp8":
+        raise ValueError(f"Only quant_format='fp8' is supported, got {quant_format!r}")
+    q_rope = _apply_rope_ref(q, freqs_cis, rope_dim)
+    return deepseek_v4_fp8_block_quant_ref(q_rope, fp8_block_size)
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_indexer_q_rope_quant", mutates_args=())
+def torch_deepseek_v4_indexer_q_rope_quant(
+    q: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+    fp8_block_size: int = 128,
+    quant_format: str = "fp8",
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return deepseek_v4_indexer_q_rope_quant_ref(
+        q, freqs_cis, rope_dim, fp8_block_size, quant_format
+    )
+
+
+@torch_deepseek_v4_indexer_q_rope_quant.register_fake
+def torch_deepseek_v4_indexer_q_rope_quant_fake(
+    q: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+    fp8_block_size: int = 128,
+    quant_format: str = "fp8",
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    _validate_rope_dim(rope_dim, q.shape[-1])
+    _validate_block_size(fp8_block_size)
+    if quant_format != "fp8":
+        raise ValueError(f"Only quant_format='fp8' is supported, got {quant_format!r}")
+    num_blocks = (q.shape[-1] + fp8_block_size - 1) // fp8_block_size
+    return (
+        torch.empty(q.shape, dtype=FP8_E4M3_DTYPE, device=q.device),
+        _fake_scale((*q.shape[:-1], num_blocks), q.device),
+    )
+
+
+def deepseek_v4_inverse_rope_fp8_output_quant_ref(
+    output: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+    fp8_block_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Apply inverse RoPE to attention output and quantize for FP8 output projection."""
+    output = _apply_rope_ref(output, freqs_cis, rope_dim, inverse=True)
+    return deepseek_v4_fp8_block_quant_ref(output, fp8_block_size)
+
+
+@torch.library.custom_op(
+    "auto_deploy::torch_deepseek_v4_inverse_rope_fp8_output_quant", mutates_args=()
+)
+def torch_deepseek_v4_inverse_rope_fp8_output_quant(
+    output: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+    fp8_block_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    return deepseek_v4_inverse_rope_fp8_output_quant_ref(
+        output, freqs_cis, rope_dim, fp8_block_size
+    )
+
+
+@torch_deepseek_v4_inverse_rope_fp8_output_quant.register_fake
+def torch_deepseek_v4_inverse_rope_fp8_output_quant_fake(
+    output: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+    fp8_block_size: int = 128,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    _validate_rope_dim(rope_dim, output.shape[-1])
+    _validate_block_size(fp8_block_size)
+    num_blocks = (output.shape[-1] + fp8_block_size - 1) // fp8_block_size
+    return (
+        torch.empty(output.shape, dtype=FP8_E4M3_DTYPE, device=output.device),
+        _fake_scale((*output.shape[:-1], num_blocks), output.device),
+    )
+
+
+def deepseek_v4_local_window_topk_idxs(
+    window_size: int,
+    batch_size: int,
+    seq_len: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build source-op indices for causal local-window attention."""
+    if window_size <= 0:
+        raise ValueError(f"window_size must be positive, got {window_size}")
+    positions = torch.arange(seq_len, device=device)
+    offsets = torch.arange(window_size, device=device)
+    matrix = (positions[:, None] - window_size + 1).clamp(min=0) + offsets[None, :]
+    matrix = torch.where(matrix <= positions[:, None], matrix, -1)
+    return matrix.unsqueeze(0).expand(batch_size, -1, -1)
+
+
+def deepseek_v4_sparse_attention_microkernel_ref(
+    q: torch.Tensor,
+    local_kv: torch.Tensor,
+    compressed_kv: torch.Tensor,
+    compressed_idxs: torch.Tensor,
+    attn_sink: torch.Tensor,
+    window_size: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Sparse attention over local-window rows plus selected compressed rows.
+
+    ``compressed_idxs`` is relative to ``compressed_kv``. Non-negative entries
+    are offset internally before calling the Plan 07 source op.
+    """
+    _validate_rank("q", q, 4)
+    _validate_rank("local_kv", local_kv, 3)
+    _validate_rank("compressed_kv", compressed_kv, 3)
+    _validate_rank("compressed_idxs", compressed_idxs, 3)
+
+    batch_size, seq_len, _, _ = q.shape
+    local_idxs = deepseek_v4_local_window_topk_idxs(window_size, batch_size, seq_len, q.device)
+    if compressed_idxs.shape[:2] != (batch_size, seq_len):
+        raise ValueError(
+            f"compressed_idxs prefix must be {(batch_size, seq_len)}, "
+            f"got {tuple(compressed_idxs.shape[:2])}"
+        )
+
+    compressed_offset = torch.where(
+        compressed_idxs >= 0,
+        compressed_idxs + local_kv.shape[1],
+        compressed_idxs,
+    )
+    topk_idxs = torch.cat([local_idxs.to(compressed_idxs.dtype), compressed_offset], dim=-1)
+    kv = torch.cat([local_kv, compressed_kv], dim=1)
+    return torch_deepseek_v4_sparse_attention(q, kv, attn_sink, topk_idxs, softmax_scale)
+
+
+@torch.library.custom_op(
+    "auto_deploy::torch_deepseek_v4_sparse_attention_microkernel", mutates_args=()
+)
+def torch_deepseek_v4_sparse_attention_microkernel(
+    q: torch.Tensor,
+    local_kv: torch.Tensor,
+    compressed_kv: torch.Tensor,
+    compressed_idxs: torch.Tensor,
+    attn_sink: torch.Tensor,
+    window_size: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    return deepseek_v4_sparse_attention_microkernel_ref(
+        q, local_kv, compressed_kv, compressed_idxs, attn_sink, window_size, softmax_scale
+    )
+
+
+@torch_deepseek_v4_sparse_attention_microkernel.register_fake
+def torch_deepseek_v4_sparse_attention_microkernel_fake(
+    q: torch.Tensor,
+    local_kv: torch.Tensor,
+    compressed_kv: torch.Tensor,
+    compressed_idxs: torch.Tensor,
+    attn_sink: torch.Tensor,
+    window_size: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    _validate_rank("q", q, 4)
+    return q.new_empty(q.shape).contiguous()

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_kernels.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_kernels.py
@@ -24,31 +24,61 @@ from typing import Optional, Tuple
 
 import torch
 import torch.nn.functional as F
+import triton
+import triton.language as tl
 
 from ...utils.e8m0 import maybe_e8m0_to_fp32
+from ..attention_interface import BatchInfo
 from .deepseek_v4_attention import torch_deepseek_v4_sparse_attention
 
 FP8_E4M3_DTYPE = torch.float8_e4m3fn
 FP8_E4M3_MAX = torch.finfo(FP8_E4M3_DTYPE).max
 FP8_E4M3_MIN = torch.finfo(FP8_E4M3_DTYPE).min
+_DSV4_TRITON_LOCAL_NUM_HEADS = 8
+_DSV4_TRITON_HEAD_DIM = 512
+_DSV4_TRITON_ROPE_DIM = 64
+_DSV4_RATIO4_COMPRESS_RATIO = 4
+_DSV4_RATIO4_WINDOW_SIZE = 128
+_DSV4_RATIO4_TOPK = 512
+_DSV4_RATIO4_TOPK_WIDTH = _DSV4_RATIO4_WINDOW_SIZE + _DSV4_RATIO4_TOPK
+_DSV4_RATIO4_MAX_COMPRESSED_LEN = 2048
+_DSV4_RATIO4_INDEXER_NUM_HEADS = 8
+_DSV4_RATIO4_INDEXER_HEAD_DIM = 128
+_DSV4_RATIO4_INDEXER_STATE_DIM = 2 * _DSV4_RATIO4_INDEXER_HEAD_DIM
+_DSV4_RATIO4_INDEXER_FP4_BLOCK_SIZE = 32
+_DSV4_TRITON_BLOCK_DIM = triton.next_power_of_2(_DSV4_TRITON_HEAD_DIM)
 
 __all__ = [
     "deepseek_v4_compressor_pool_norm_rope_ref",
     "deepseek_v4_fp8_block_dequant_ref",
     "deepseek_v4_fp8_block_quant_ref",
     "deepseek_v4_indexer_q_rope_quant_ref",
+    "deepseek_v4_indexer_fp4_quant_dequant_ref",
     "deepseek_v4_inverse_rope_fp8_output_quant_ref",
+    "deepseek_v4_kv_rmsnorm_rope_bf16_cache_insert_ref",
     "deepseek_v4_kv_rmsnorm_rope_cache_insert_ref",
     "deepseek_v4_kv_rmsnorm_rope_ref",
     "deepseek_v4_local_window_topk_idxs",
     "deepseek_v4_q_rmsnorm_rope_ref",
+    "deepseek_v4_ratio4_indexer_build_topk_ref",
+    "deepseek_v4_ratio4_indexer_compressed_kv_ref",
+    "deepseek_v4_ratio4_indexer_q_ref",
+    "deepseek_v4_ratio4_indexer_scores_ref",
+    "deepseek_v4_ratio4_indexer_topk_ref",
+    "deepseek_v4_ratio4_overlap_compress_ref",
     "deepseek_v4_sparse_attention_microkernel_ref",
     "torch_deepseek_v4_compressor_pool_norm_rope",
     "torch_deepseek_v4_indexer_q_rope_quant",
     "torch_deepseek_v4_inverse_rope_fp8_output_quant",
     "torch_deepseek_v4_kv_rmsnorm_rope_cache_insert",
     "torch_deepseek_v4_q_rmsnorm_rope",
+    "torch_deepseek_v4_ratio4_indexer_scores",
+    "torch_deepseek_v4_ratio4_indexer_topk",
     "torch_deepseek_v4_sparse_attention_microkernel",
+    "triton_deepseek_v4_kv_norm_rope_cache_insert",
+    "triton_deepseek_v4_q_rmsnorm_rope",
+    "triton_deepseek_v4_ratio4_indexer_scores",
+    "triton_deepseek_v4_ratio4_indexer_topk",
 ]
 
 
@@ -180,6 +210,727 @@ def _insert_flat_cache(
     _index_copy_rows(cache, flat_indices, flat_values)
 
 
+def _validate_int_metadata(name: str, tensor: torch.Tensor) -> None:
+    if tensor.dim() != 1:
+        raise ValueError(f"{name} must have rank 1, got rank {tensor.dim()}")
+    if tensor.dtype not in (torch.int32, torch.int64, torch.int):
+        raise TypeError(f"{name} must be an int32/int64 tensor, got {tensor.dtype}")
+
+
+def _validate_norm_weight_for_dim(
+    norm_weight: Optional[torch.Tensor],
+    dim: int,
+) -> None:
+    if norm_weight is None:
+        return
+    _validate_floating("norm_weight", norm_weight)
+    if norm_weight.shape != (dim,):
+        raise ValueError(f"norm_weight must have shape ({dim},), got {tuple(norm_weight.shape)}")
+
+
+def _validate_dsv4_freqs(
+    freqs_cis: torch.Tensor,
+    batch_size: int,
+    seq_len: int,
+    rope_dim: int,
+) -> None:
+    _validate_rank("freqs_cis", freqs_cis, 3)
+    if not freqs_cis.is_complex():
+        raise TypeError(f"freqs_cis must be complex, got {freqs_cis.dtype}")
+    expected_shape = (batch_size, seq_len, rope_dim // 2)
+    if freqs_cis.shape != expected_shape:
+        raise ValueError(
+            f"freqs_cis must have shape {expected_shape}, got {tuple(freqs_cis.shape)}"
+        )
+
+
+def _validate_triton_q_rmsnorm_rope_contract(
+    q: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor],
+) -> None:
+    _validate_rank("q", q, 4)
+    if q.dtype != torch.bfloat16:
+        raise TypeError(f"q must be bfloat16 for the DSV4 Triton contract, got {q.dtype}")
+    _validate_rope_dim(rope_dim, q.shape[-1])
+    if rope_dim != _DSV4_TRITON_ROPE_DIM:
+        raise ValueError(f"rope_dim must be {_DSV4_TRITON_ROPE_DIM}, got {rope_dim}")
+    if eps <= 0.0:
+        raise ValueError(f"eps must be positive, got {eps}")
+
+    batch_size, seq_len, num_heads, head_dim = q.shape
+    if num_heads != _DSV4_TRITON_LOCAL_NUM_HEADS:
+        raise ValueError(
+            f"q local head count must be {_DSV4_TRITON_LOCAL_NUM_HEADS}, got {num_heads}"
+        )
+    if head_dim != _DSV4_TRITON_HEAD_DIM:
+        raise ValueError(f"q head dimension must be {_DSV4_TRITON_HEAD_DIM}, got {head_dim}")
+    _validate_norm_weight_for_dim(norm_weight, head_dim)
+    _validate_dsv4_freqs(freqs_cis, batch_size, seq_len, rope_dim)
+
+    if out is not None:
+        if out.shape != q.shape:
+            raise ValueError(f"out shape must be {tuple(q.shape)}, got {tuple(out.shape)}")
+        if out.dtype != q.dtype:
+            raise TypeError(f"out dtype must be {q.dtype}, got {out.dtype}")
+        if out.device != q.device:
+            raise ValueError(f"out must be on {q.device}, got {out.device}")
+
+
+def _cache_token_view(
+    cache: torch.Tensor,
+    page_idx: int,
+    token_offset: int,
+) -> torch.Tensor:
+    if cache.dim() == 5:
+        if int(cache.shape[1]) == 1:
+            if int(cache.shape[2]) >= int(cache.shape[3]):
+                return cache[page_idx, 0, token_offset, 0]
+            return cache[page_idx, 0, 0, token_offset]
+        return cache[page_idx, token_offset, 0, 0]
+    if cache.dim() == 4:
+        return cache[page_idx, token_offset, 0]
+    if cache.dim() == 3:
+        return cache[page_idx, token_offset]
+    raise ValueError(f"swa_cache must have rank 3, 4, or 5, got rank {cache.dim()}")
+
+
+def _cache_tokens_per_block(cache: torch.Tensor) -> int:
+    if cache.dim() not in (3, 4, 5):
+        raise ValueError(f"swa_cache must have rank 3, 4, or 5, got rank {cache.dim()}")
+    if cache.dim() == 5 and int(cache.shape[1]) == 1:
+        return int(cache.shape[2] if int(cache.shape[2]) >= int(cache.shape[3]) else cache.shape[3])
+    return int(cache.shape[1])
+
+
+def _page_for_position(
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    position: int,
+    tokens_per_block: int,
+) -> tuple[int, int]:
+    page_ordinal = position // tokens_per_block
+    page_table_start = int(cu_num_pages_host[seq_idx].item())
+    page_table_end = int(cu_num_pages_host[seq_idx + 1].item())
+    page_table_idx = page_table_start + page_ordinal
+    if page_table_idx >= page_table_end:
+        raise ValueError(
+            f"Sequence {seq_idx} position {position} needs page ordinal {page_ordinal}, "
+            f"but only {page_table_end - page_table_start} page(s) are available."
+        )
+    page_idx = int(cache_loc_host[page_table_idx].item())
+    return page_idx, position % tokens_per_block
+
+
+def _write_bf16_swa_cache(
+    kv_seq: torch.Tensor,
+    cache: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    seq_idx: int,
+    input_pos: int,
+) -> None:
+    tokens_per_block = _cache_tokens_per_block(cache)
+    for token_offset in range(kv_seq.shape[0]):
+        page_idx, page_offset = _page_for_position(
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            input_pos + token_offset,
+            tokens_per_block,
+        )
+        _cache_token_view(cache, page_idx, page_offset).copy_(kv_seq[token_offset].to(cache.dtype))
+
+
+def _to_host_long(name: str, tensor: torch.Tensor, min_numel: int) -> torch.Tensor:
+    _validate_int_metadata(name, tensor)
+    if tensor.numel() < min_numel:
+        raise ValueError(f"{name} needs at least {min_numel} entries, got {tensor.numel()}")
+    return tensor.detach().cpu().to(torch.long).flatten()
+
+
+def _validate_triton_kv_norm_rope_cache_insert_contract(
+    kv: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor],
+    *,
+    validate_metadata_values: bool,
+) -> None:
+    _validate_rank("kv", kv, 3)
+    if kv.dtype != torch.bfloat16:
+        raise TypeError(f"kv must be bfloat16 for the DSV4 Triton contract, got {kv.dtype}")
+    _validate_rope_dim(rope_dim, kv.shape[-1])
+    if rope_dim != _DSV4_TRITON_ROPE_DIM:
+        raise ValueError(f"rope_dim must be {_DSV4_TRITON_ROPE_DIM}, got {rope_dim}")
+    if eps <= 0.0:
+        raise ValueError(f"eps must be positive, got {eps}")
+
+    batch_size, seq_len, head_dim = kv.shape
+    if head_dim != _DSV4_TRITON_HEAD_DIM:
+        raise ValueError(f"kv head dimension must be {_DSV4_TRITON_HEAD_DIM}, got {head_dim}")
+    _validate_norm_weight_for_dim(norm_weight, head_dim)
+    _validate_dsv4_freqs(freqs_cis, batch_size, seq_len, rope_dim)
+    _validate_int_metadata("batch_info_host", batch_info_host)
+    _validate_int_metadata("seq_len_host", seq_len_host)
+    _validate_int_metadata("input_pos_host", input_pos_host)
+    _validate_int_metadata("cu_seqlen_host", cu_seqlen_host)
+    _validate_int_metadata("cache_loc_host", cache_loc_host)
+    _validate_int_metadata("cu_num_pages_host", cu_num_pages_host)
+
+    if swa_cache.dim() not in (3, 4, 5):
+        raise ValueError(f"swa_cache must have rank 3, 4, or 5, got rank {swa_cache.dim()}")
+    if swa_cache.dtype != torch.bfloat16:
+        raise TypeError(f"swa_cache must be bfloat16, got {swa_cache.dtype}")
+    if swa_cache.shape[-1] != _DSV4_TRITON_HEAD_DIM:
+        raise ValueError(
+            f"swa_cache last dimension must be {_DSV4_TRITON_HEAD_DIM}, got {swa_cache.shape[-1]}"
+        )
+
+    if out is not None:
+        if out.shape != kv.shape:
+            raise ValueError(f"out shape must be {tuple(kv.shape)}, got {tuple(out.shape)}")
+        if out.dtype != kv.dtype:
+            raise TypeError(f"out dtype must be {kv.dtype}, got {out.dtype}")
+        if out.device != kv.device:
+            raise ValueError(f"out must be on {kv.device}, got {out.device}")
+
+    if not validate_metadata_values:
+        return
+
+    batch_info = BatchInfo(batch_info_host)
+    num_prefill, num_prefill_tokens, num_decode = batch_info.get_absorbed_info()
+    num_seq = num_prefill + num_decode
+    active_tokens = num_prefill_tokens + num_decode
+    max_graph_tokens = int(batch_size * seq_len)
+    if active_tokens > max_graph_tokens:
+        raise ValueError(
+            f"active tokens ({active_tokens}) exceed kv capacity ({max_graph_tokens}); "
+            "padded graph slots may be present, but active tokens must fit."
+        )
+    _to_host_long("seq_len_host", seq_len_host, num_seq)
+    _to_host_long("input_pos_host", input_pos_host, num_seq)
+    _to_host_long("cu_seqlen_host", cu_seqlen_host, num_seq + 1)
+    _to_host_long("cu_num_pages_host", cu_num_pages_host, num_seq + 1)
+
+    if cache_loc_host.numel() == 0 and active_tokens:
+        raise ValueError("cache_loc_host must contain at least one page for active tokens")
+
+
+def _any_cuda_tensor(*tensors: Optional[torch.Tensor]) -> bool:
+    return any(tensor is not None and tensor.is_cuda for tensor in tensors)
+
+
+def _device_skip_reason(name: str, tensor: torch.Tensor, device: torch.device) -> str | None:
+    if not tensor.is_cuda:
+        return f"{name} must be a CUDA tensor for the DSV4 Triton path"
+    if tensor.device != device:
+        return f"{name} must be on {device}, got {tensor.device}"
+    return None
+
+
+def _triton_q_rmsnorm_rope_skip_reason(
+    q: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    out: Optional[torch.Tensor],
+) -> str | None:
+    for name, tensor in (("q", q), ("freqs_cis", freqs_cis)):
+        reason = _device_skip_reason(name, tensor, q.device)
+        if reason is not None:
+            return reason
+    if norm_weight is not None:
+        reason = _device_skip_reason("norm_weight", norm_weight, q.device)
+        if reason is not None:
+            return reason
+    if out is not None:
+        reason = _device_skip_reason("out", out, q.device)
+        if reason is not None:
+            return reason
+    if freqs_cis.dtype != torch.complex64:
+        return f"freqs_cis must be complex64 for the DSV4 Triton path, got {freqs_cis.dtype}"
+    return None
+
+
+def _cache_layout_for_triton(cache: torch.Tensor) -> tuple[int, int, int, int]:
+    """Return ``(tokens_per_block, page_stride, token_stride, dim_stride)``."""
+    if cache.dim() == 5:
+        if int(cache.shape[1]) == 1:
+            token_dim = 2 if int(cache.shape[2]) >= int(cache.shape[3]) else 3
+        else:
+            token_dim = 1
+    elif cache.dim() in (3, 4):
+        token_dim = 1
+    else:
+        raise ValueError(f"swa_cache must have rank 3, 4, or 5, got rank {cache.dim()}")
+
+    return (
+        int(cache.shape[token_dim]),
+        int(cache.stride(0)),
+        int(cache.stride(token_dim)),
+        int(cache.stride(-1)),
+    )
+
+
+def _triton_kv_norm_rope_cache_insert_skip_reason(
+    kv: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    out: Optional[torch.Tensor],
+) -> str | None:
+    for name, tensor in (
+        ("kv", kv),
+        ("freqs_cis", freqs_cis),
+        ("batch_info_host", batch_info_host),
+        ("seq_len_host", seq_len_host),
+        ("input_pos_host", input_pos_host),
+        ("cu_seqlen_host", cu_seqlen_host),
+        ("cache_loc_host", cache_loc_host),
+        ("cu_num_pages_host", cu_num_pages_host),
+        ("swa_cache", swa_cache),
+    ):
+        reason = _device_skip_reason(name, tensor, kv.device)
+        if reason is not None:
+            return reason
+    if norm_weight is not None:
+        reason = _device_skip_reason("norm_weight", norm_weight, kv.device)
+        if reason is not None:
+            return reason
+    if out is not None:
+        reason = _device_skip_reason("out", out, kv.device)
+        if reason is not None:
+            return reason
+    if freqs_cis.dtype != torch.complex64:
+        return f"freqs_cis must be complex64 for the DSV4 Triton path, got {freqs_cis.dtype}"
+
+    batch_size = int(kv.shape[0])
+    if batch_info_host.numel() < 5:
+        return f"batch_info_host needs at least 5 entries, got {batch_info_host.numel()}"
+    if seq_len_host.numel() < batch_size:
+        return f"seq_len_host needs at least {batch_size} entries, got {seq_len_host.numel()}"
+    if input_pos_host.numel() < batch_size:
+        return f"input_pos_host needs at least {batch_size} entries, got {input_pos_host.numel()}"
+    if cu_seqlen_host.numel() < batch_size + 1:
+        return (
+            f"cu_seqlen_host needs at least {batch_size + 1} entries, got {cu_seqlen_host.numel()}"
+        )
+    if cu_num_pages_host.numel() < batch_size + 1:
+        return (
+            f"cu_num_pages_host needs at least {batch_size + 1} entries, "
+            f"got {cu_num_pages_host.numel()}"
+        )
+    if cache_loc_host.numel() == 0:
+        return "cache_loc_host must contain at least one page for the DSV4 Triton path"
+
+    try:
+        tokens_per_block, _, _, _ = _cache_layout_for_triton(swa_cache)
+    except ValueError as exc:
+        return str(exc)
+    if tokens_per_block <= 0:
+        return f"swa_cache tokens_per_block must be positive, got {tokens_per_block}"
+    return None
+
+
+@triton.jit
+def _dsv4_q_rmsnorm_kernel(
+    q_ptr,
+    norm_weight_ptr,
+    out_ptr,
+    q_stride_batch: tl.constexpr,
+    q_stride_seq: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    q_stride_dim: tl.constexpr,
+    weight_stride: tl.constexpr,
+    out_stride_batch: tl.constexpr,
+    out_stride_seq: tl.constexpr,
+    out_stride_head: tl.constexpr,
+    out_stride_dim: tl.constexpr,
+    seq_len: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+    eps: tl.constexpr,
+    has_weight: tl.constexpr,
+):
+    token_head_idx = tl.program_id(0)
+    head_idx = token_head_idx % num_heads
+    token_idx = token_head_idx // num_heads
+    seq_idx = token_idx % seq_len
+    batch_idx = token_idx // seq_len
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+
+    q_offsets = (
+        batch_idx * q_stride_batch
+        + seq_idx * q_stride_seq
+        + head_idx * q_stride_head
+        + dim_offsets * q_stride_dim
+    )
+    values = tl.load(q_ptr + q_offsets, mask=dim_mask, other=0.0).to(tl.float32)
+    square_sum = tl.sum(tl.where(dim_mask, values * values, 0.0), axis=0)
+    rms_scale = tl.rsqrt(square_sum / head_dim + eps)
+    output = values * rms_scale
+    if has_weight:
+        weight = tl.load(norm_weight_ptr + dim_offsets * weight_stride, mask=dim_mask, other=0.0)
+        output = output * weight.to(tl.float32)
+
+    out_offsets = (
+        batch_idx * out_stride_batch
+        + seq_idx * out_stride_seq
+        + head_idx * out_stride_head
+        + dim_offsets * out_stride_dim
+    )
+    tl.store(out_ptr + out_offsets, output, mask=dim_mask)
+
+
+@triton.jit
+def _dsv4_q_rope_kernel(
+    freqs_real_ptr,
+    out_ptr,
+    freq_stride_batch: tl.constexpr,
+    freq_stride_seq: tl.constexpr,
+    freq_stride_pair: tl.constexpr,
+    freq_stride_component: tl.constexpr,
+    out_stride_batch: tl.constexpr,
+    out_stride_seq: tl.constexpr,
+    out_stride_head: tl.constexpr,
+    out_stride_dim: tl.constexpr,
+    seq_len: tl.constexpr,
+    num_heads: tl.constexpr,
+    nope_dim: tl.constexpr,
+    rope_dim: tl.constexpr,
+):
+    token_head_idx = tl.program_id(0)
+    head_idx = token_head_idx % num_heads
+    token_idx = token_head_idx // num_heads
+    seq_idx = token_idx % seq_len
+    batch_idx = token_idx // seq_len
+
+    rope_offsets = tl.arange(0, rope_dim)
+    dim_offsets = nope_dim + rope_offsets
+    pair_offsets = rope_offsets // 2
+    is_second = rope_offsets != pair_offsets * 2
+    partner_offsets = tl.where(is_second, dim_offsets - 1, dim_offsets + 1)
+
+    out_base = batch_idx * out_stride_batch + seq_idx * out_stride_seq + head_idx * out_stride_head
+    values = tl.load(out_ptr + out_base + dim_offsets * out_stride_dim).to(tl.float32)
+    partner_values = tl.load(out_ptr + out_base + partner_offsets * out_stride_dim).to(tl.float32)
+    first = tl.where(is_second, partner_values, values)
+    second = tl.where(is_second, values, partner_values)
+
+    freq_base = batch_idx * freq_stride_batch + seq_idx * freq_stride_seq
+    cos = tl.load(freqs_real_ptr + freq_base + pair_offsets * freq_stride_pair).to(tl.float32)
+    sin = tl.load(
+        freqs_real_ptr + freq_base + pair_offsets * freq_stride_pair + freq_stride_component
+    ).to(tl.float32)
+    rotated = tl.where(is_second, first * sin + second * cos, first * cos - second * sin)
+    tl.store(out_ptr + out_base + dim_offsets * out_stride_dim, rotated)
+
+
+@triton.jit
+def _dsv4_kv_rmsnorm_kernel(
+    kv_ptr,
+    norm_weight_ptr,
+    out_ptr,
+    kv_stride_batch: tl.constexpr,
+    kv_stride_seq: tl.constexpr,
+    kv_stride_dim: tl.constexpr,
+    weight_stride: tl.constexpr,
+    out_stride_batch: tl.constexpr,
+    out_stride_seq: tl.constexpr,
+    out_stride_dim: tl.constexpr,
+    seq_len: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+    eps: tl.constexpr,
+    has_weight: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    batch_idx = token_idx // seq_len
+    seq_idx = token_idx - batch_idx * seq_len
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+
+    kv_offsets = batch_idx * kv_stride_batch + seq_idx * kv_stride_seq + dim_offsets * kv_stride_dim
+    values = tl.load(kv_ptr + kv_offsets, mask=dim_mask, other=0.0).to(tl.float32)
+    square_sum = tl.sum(tl.where(dim_mask, values * values, 0.0), axis=0)
+    rms_scale = tl.rsqrt(square_sum / head_dim + eps)
+    output = values * rms_scale
+    if has_weight:
+        weight = tl.load(norm_weight_ptr + dim_offsets * weight_stride, mask=dim_mask, other=0.0)
+        output = output * weight.to(tl.float32)
+
+    out_offsets = (
+        batch_idx * out_stride_batch + seq_idx * out_stride_seq + dim_offsets * out_stride_dim
+    )
+    tl.store(out_ptr + out_offsets, output, mask=dim_mask)
+
+
+@triton.jit
+def _dsv4_kv_rope_cache_insert_kernel(
+    freqs_real_ptr,
+    batch_info_ptr,
+    input_pos_ptr,
+    cu_seqlen_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    swa_cache_ptr,
+    out_ptr,
+    freq_stride_batch: tl.constexpr,
+    freq_stride_seq: tl.constexpr,
+    freq_stride_pair: tl.constexpr,
+    freq_stride_component: tl.constexpr,
+    cache_page_stride: tl.constexpr,
+    cache_token_stride: tl.constexpr,
+    cache_dim_stride: tl.constexpr,
+    out_stride_batch: tl.constexpr,
+    out_stride_seq: tl.constexpr,
+    out_stride_dim: tl.constexpr,
+    batch_size: tl.constexpr,
+    seq_len: tl.constexpr,
+    tokens_per_block: tl.constexpr,
+    head_dim: tl.constexpr,
+    nope_dim: tl.constexpr,
+    rope_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    batch_idx = token_idx // seq_len
+    seq_idx_in_tensor = token_idx - batch_idx * seq_len
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+
+    num_prefill = tl.load(batch_info_ptr) + tl.load(batch_info_ptr + 2)
+    num_prefill_tokens = tl.load(batch_info_ptr + 1) + tl.load(batch_info_ptr + 3)
+    num_decode = tl.load(batch_info_ptr + 4)
+    num_seq = num_prefill + num_decode
+    active_tokens = num_prefill_tokens + num_decode
+
+    found = token_idx < 0
+    selected_seq = tl.full((), 0, dtype=tl.int64)
+    selected_seq_start = tl.full((), 0, dtype=tl.int64)
+    for metadata_seq in range(batch_size):
+        seq_start = tl.load(cu_seqlen_ptr + metadata_seq, mask=metadata_seq < num_seq, other=0).to(
+            tl.int64
+        )
+        seq_end = tl.load(
+            cu_seqlen_ptr + metadata_seq + 1,
+            mask=metadata_seq < num_seq,
+            other=0,
+        ).to(tl.int64)
+        in_seq = (metadata_seq < num_seq) & (token_idx >= seq_start) & (token_idx < seq_end)
+        selected_seq = tl.where(in_seq, metadata_seq, selected_seq)
+        selected_seq_start = tl.where(in_seq, seq_start, selected_seq_start)
+        found = found | in_seq
+
+    token_is_active = (token_idx < active_tokens) & found
+    seq_token_offset = token_idx - selected_seq_start
+    input_pos = tl.load(input_pos_ptr + selected_seq, mask=token_is_active, other=0).to(tl.int64)
+    cache_position = input_pos + seq_token_offset
+    page_ordinal = cache_position // tokens_per_block
+    page_offset = cache_position - page_ordinal * tokens_per_block
+    page_table_start = tl.load(cu_num_pages_ptr + selected_seq, mask=token_is_active, other=0).to(
+        tl.int64
+    )
+    page_idx = tl.load(
+        cache_loc_ptr + page_table_start + page_ordinal,
+        mask=token_is_active,
+        other=0,
+    ).to(tl.int64)
+
+    out_offsets = (
+        batch_idx * out_stride_batch
+        + seq_idx_in_tensor * out_stride_seq
+        + dim_offsets * out_stride_dim
+    )
+    values = tl.load(out_ptr + out_offsets, mask=dim_mask, other=0.0).to(tl.float32)
+    partner_offsets = tl.where((dim_offsets - nope_dim) % 2 == 1, dim_offsets - 1, dim_offsets + 1)
+    partner_values = tl.load(
+        out_ptr + out_offsets - dim_offsets * out_stride_dim + partner_offsets * out_stride_dim,
+        mask=dim_mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    rope_idx = dim_offsets - nope_dim
+    rope_mask = (rope_idx >= 0) & (rope_idx < rope_dim)
+    pair_offsets = rope_idx // 2
+    is_second = rope_idx != pair_offsets * 2
+    first = tl.where(is_second, partner_values, values)
+    second = tl.where(is_second, values, partner_values)
+    freq_base = batch_idx * freq_stride_batch + seq_idx_in_tensor * freq_stride_seq
+    cos = tl.load(
+        freqs_real_ptr + freq_base + pair_offsets * freq_stride_pair,
+        mask=rope_mask,
+        other=1.0,
+    ).to(tl.float32)
+    sin = tl.load(
+        freqs_real_ptr + freq_base + pair_offsets * freq_stride_pair + freq_stride_component,
+        mask=rope_mask,
+        other=0.0,
+    ).to(tl.float32)
+    rotated = tl.where(is_second, first * sin + second * cos, first * cos - second * sin)
+    output = tl.where(rope_mask, rotated, values)
+    output = tl.where(token_is_active, output, 0.0)
+
+    tl.store(out_ptr + out_offsets, output, mask=dim_mask)
+
+    cache_offsets = (
+        page_idx * cache_page_stride
+        + page_offset * cache_token_stride
+        + dim_offsets * cache_dim_stride
+    )
+    tl.store(swa_cache_ptr + cache_offsets, output, mask=dim_mask & token_is_active)
+
+
+def _run_triton_q_rmsnorm_rope(
+    q: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    out: Optional[torch.Tensor],
+) -> torch.Tensor:
+    output = torch.empty_like(q) if out is None else out
+    freqs_real = torch.view_as_real(freqs_cis)
+    weight_arg = q if norm_weight is None else norm_weight
+    weight_stride = 1 if norm_weight is None else int(norm_weight.stride(0))
+
+    grid = (int(q.shape[0] * q.shape[1] * q.shape[2]),)
+    _dsv4_q_rmsnorm_kernel[grid](
+        q,
+        weight_arg,
+        output,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        weight_stride,
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        output.stride(3),
+        int(q.shape[1]),
+        _DSV4_TRITON_LOCAL_NUM_HEADS,
+        _DSV4_TRITON_HEAD_DIM,
+        _DSV4_TRITON_BLOCK_DIM,
+        eps,
+        norm_weight is not None,
+        num_warps=8,
+    )
+    _dsv4_q_rope_kernel[grid](
+        freqs_real,
+        output,
+        freqs_real.stride(0),
+        freqs_real.stride(1),
+        freqs_real.stride(2),
+        freqs_real.stride(3),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        output.stride(3),
+        int(q.shape[1]),
+        _DSV4_TRITON_LOCAL_NUM_HEADS,
+        _DSV4_TRITON_HEAD_DIM - _DSV4_TRITON_ROPE_DIM,
+        _DSV4_TRITON_ROPE_DIM,
+        num_warps=2,
+    )
+    if out is not None:
+        return out.new_empty(0)
+    return output
+
+
+def _run_triton_kv_norm_rope_cache_insert(
+    kv: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    eps: float,
+    out: Optional[torch.Tensor],
+) -> torch.Tensor:
+    output = torch.empty_like(kv) if out is None else out
+    freqs_real = torch.view_as_real(freqs_cis)
+    weight_arg = kv if norm_weight is None else norm_weight
+    weight_stride = 1 if norm_weight is None else int(norm_weight.stride(0))
+    tokens_per_block, cache_page_stride, cache_token_stride, cache_dim_stride = (
+        _cache_layout_for_triton(swa_cache)
+    )
+    grid = (int(kv.shape[0] * kv.shape[1]),)
+
+    _dsv4_kv_rmsnorm_kernel[grid](
+        kv,
+        weight_arg,
+        output,
+        kv.stride(0),
+        kv.stride(1),
+        kv.stride(2),
+        weight_stride,
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        int(kv.shape[1]),
+        _DSV4_TRITON_HEAD_DIM,
+        _DSV4_TRITON_BLOCK_DIM,
+        eps,
+        norm_weight is not None,
+        num_warps=8,
+    )
+    _dsv4_kv_rope_cache_insert_kernel[grid](
+        freqs_real,
+        batch_info_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        output,
+        freqs_real.stride(0),
+        freqs_real.stride(1),
+        freqs_real.stride(2),
+        freqs_real.stride(3),
+        cache_page_stride,
+        cache_token_stride,
+        cache_dim_stride,
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        int(kv.shape[0]),
+        int(kv.shape[1]),
+        tokens_per_block,
+        _DSV4_TRITON_HEAD_DIM,
+        _DSV4_TRITON_HEAD_DIM - _DSV4_TRITON_ROPE_DIM,
+        _DSV4_TRITON_ROPE_DIM,
+        _DSV4_TRITON_BLOCK_DIM,
+        num_warps=8,
+    )
+    if out is not None:
+        return out.new_empty(0)
+    return output
+
+
 def deepseek_v4_fp8_block_quant_ref(
     x: torch.Tensor,
     block_size: int = 128,
@@ -277,6 +1028,50 @@ def torch_deepseek_v4_q_rmsnorm_rope_fake(
     return q.new_empty(q.shape).contiguous()
 
 
+@torch.library.custom_op("auto_deploy::triton_deepseek_v4_q_rmsnorm_rope", mutates_args=())
+def triton_deepseek_v4_q_rmsnorm_rope(
+    q: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Guarded Triton-facing DSV4 Q RMSNorm+RoPE contract.
+
+    The device path accepts the observed local BF16 DSV4 query shape
+    ``[batch, seq_len, 8, 512]`` and applies RoPE to the trailing 64 dims while
+    preserving the caller-owned ``out=`` replay convention.
+    """
+    _validate_triton_q_rmsnorm_rope_contract(q, norm_weight, freqs_cis, eps, rope_dim, out)
+    skip_reason = _triton_q_rmsnorm_rope_skip_reason(q, norm_weight, freqs_cis, out)
+    if skip_reason is None:
+        return _run_triton_q_rmsnorm_rope(q, norm_weight, freqs_cis, eps, out)
+    if _any_cuda_tensor(q, norm_weight, freqs_cis, out):
+        raise RuntimeError(skip_reason)
+
+    output = deepseek_v4_q_rmsnorm_rope_ref(q, norm_weight, freqs_cis, eps, rope_dim)
+    if out is not None:
+        out.copy_(output)
+        return out.new_empty(0)
+    return output
+
+
+@triton_deepseek_v4_q_rmsnorm_rope.register_fake
+def triton_deepseek_v4_q_rmsnorm_rope_fake(
+    q: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    _validate_triton_q_rmsnorm_rope_contract(q, norm_weight, freqs_cis, eps, rope_dim, out)
+    if out is not None:
+        return out.new_empty(0)
+    return q.new_empty(q.shape).contiguous()
+
+
 def deepseek_v4_kv_rmsnorm_rope_ref(
     kv: torch.Tensor,
     norm_weight: Optional[torch.Tensor],
@@ -288,6 +1083,240 @@ def deepseek_v4_kv_rmsnorm_rope_ref(
     _validate_rank("kv", kv, 3)
     kv_norm = _rms_norm_ref(kv, norm_weight, eps)
     return _apply_rope_ref(kv_norm, freqs_cis, rope_dim)
+
+
+def deepseek_v4_kv_rmsnorm_rope_bf16_cache_insert_ref(
+    kv: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+) -> torch.Tensor:
+    """Normalize/RoPE KV rows and insert active tokens into BF16 SWA cache pages.
+
+    Args:
+        kv: BF16 KV states with shape ``[batch, seq_len, 512]``.
+        norm_weight: Optional RMSNorm weight with shape ``[512]``.
+        freqs_cis: Per-token RoPE frequencies with shape
+            ``[batch, seq_len, rope_dim // 2]``.
+        batch_info_host: Serialized :class:`BatchInfo` metadata.
+        seq_len_host: Active per-sequence token counts.
+        input_pos_host: Absolute starting positions for each active sequence.
+        cu_seqlen_host: Prefix sums mapping active sequences into flattened
+            graph tokens.
+        cache_loc_host: Paged-cache page table.
+        cu_num_pages_host: Prefix sums mapping active sequences into
+            ``cache_loc_host``.
+        swa_cache: Caller-owned BF16 SWA cache with rank 3, 4, or 5 and last
+            dimension 512.
+        eps: RMSNorm epsilon.
+        rope_dim: Number of trailing dimensions using RoPE; must be 64 for the
+            guarded Triton contract.
+
+    Returns:
+        Normalized/RoPE KV tensor with shape ``[batch, seq_len, 512]``. Padded
+        graph slots beyond active tokens are zeroed.
+    """
+    _validate_triton_kv_norm_rope_cache_insert_contract(
+        kv,
+        norm_weight,
+        freqs_cis,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        eps,
+        rope_dim,
+        out=None,
+        validate_metadata_values=True,
+    )
+
+    batch_info = BatchInfo(batch_info_host)
+    num_prefill, num_prefill_tokens, num_decode = batch_info.get_absorbed_info()
+    num_seq = num_prefill + num_decode
+    active_tokens = num_prefill_tokens + num_decode
+
+    seq_len_host = _to_host_long("seq_len_host", seq_len_host, num_seq)
+    input_pos_host = _to_host_long("input_pos_host", input_pos_host, num_seq)
+    cu_seqlen_host = _to_host_long("cu_seqlen_host", cu_seqlen_host, num_seq + 1)
+    cache_loc_host = _to_host_long("cache_loc_host", cache_loc_host, 1 if active_tokens else 0)
+    cu_num_pages_host = _to_host_long("cu_num_pages_host", cu_num_pages_host, num_seq + 1)
+
+    kv_out = deepseek_v4_kv_rmsnorm_rope_ref(kv, norm_weight, freqs_cis, eps, rope_dim)
+    kv_out_flat = kv_out.reshape(-1, kv_out.shape[-1])
+    output_flat = torch.zeros_like(kv_out_flat)
+
+    for seq_idx in range(num_seq):
+        seq_len_i = int(seq_len_host[seq_idx].item())
+        if seq_len_i == 0:
+            continue
+        flat_start = int(cu_seqlen_host[seq_idx].item())
+        flat_end = flat_start + seq_len_i
+        if flat_end > kv_out_flat.shape[0]:
+            raise ValueError(
+                f"Sequence {seq_idx} flat range [{flat_start}, {flat_end}) exceeds "
+                f"kv capacity {kv_out_flat.shape[0]}"
+            )
+        input_pos_i = int(input_pos_host[seq_idx].item())
+        kv_seq = kv_out_flat[flat_start:flat_end]
+        output_flat[flat_start:flat_end].copy_(kv_seq)
+        _write_bf16_swa_cache(
+            kv_seq,
+            swa_cache,
+            cache_loc_host,
+            cu_num_pages_host,
+            seq_idx,
+            input_pos_i,
+        )
+
+    if active_tokens < output_flat.shape[0]:
+        output_flat[active_tokens:].zero_()
+    return output_flat.view_as(kv)
+
+
+@torch.library.custom_op(
+    "auto_deploy::triton_deepseek_v4_kv_norm_rope_cache_insert",
+    mutates_args=("swa_cache",),
+)
+def triton_deepseek_v4_kv_norm_rope_cache_insert(
+    kv: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Guarded Triton-facing DSV4 KV RMSNorm+RoPE+BF16 SWA cache insert."""
+    _validate_triton_kv_norm_rope_cache_insert_contract(
+        kv,
+        norm_weight,
+        freqs_cis,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        eps,
+        rope_dim,
+        out,
+        validate_metadata_values=False,
+    )
+    skip_reason = _triton_kv_norm_rope_cache_insert_skip_reason(
+        kv,
+        norm_weight,
+        freqs_cis,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        out,
+    )
+    if skip_reason is None:
+        return _run_triton_kv_norm_rope_cache_insert(
+            kv,
+            norm_weight,
+            freqs_cis,
+            batch_info_host,
+            input_pos_host,
+            cu_seqlen_host,
+            cache_loc_host,
+            cu_num_pages_host,
+            swa_cache,
+            eps,
+            out,
+        )
+    if _any_cuda_tensor(
+        kv,
+        norm_weight,
+        freqs_cis,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        out,
+    ):
+        raise RuntimeError(skip_reason)
+
+    output = deepseek_v4_kv_rmsnorm_rope_bf16_cache_insert_ref(
+        kv,
+        norm_weight,
+        freqs_cis,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        eps,
+        rope_dim,
+    )
+    if out is not None:
+        out.copy_(output)
+        return out.new_empty(0)
+    return output
+
+
+@triton_deepseek_v4_kv_norm_rope_cache_insert.register_fake
+def triton_deepseek_v4_kv_norm_rope_cache_insert_fake(
+    kv: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    _validate_triton_kv_norm_rope_cache_insert_contract(
+        kv,
+        norm_weight,
+        freqs_cis,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        eps,
+        rope_dim,
+        out,
+        validate_metadata_values=False,
+    )
+    if out is not None:
+        return out.new_empty(0)
+    return kv.new_empty(kv.shape).contiguous()
 
 
 def deepseek_v4_kv_rmsnorm_rope_cache_insert_ref(
@@ -494,6 +1523,1054 @@ def torch_deepseek_v4_compressor_pool_norm_rope_fake(
     head_dim = kv.shape[-1] // channels
     _validate_rope_dim(rope_dim, head_dim)
     return kv.new_empty(kv.shape[0], kv.shape[1] // compress_ratio, head_dim).contiguous()
+
+
+def _validate_ratio4_indexer_q(
+    q: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+    fp4_block_size: int,
+) -> None:
+    _validate_rank("q", q, 4)
+    _validate_rope_dim(rope_dim, q.shape[-1])
+    _validate_block_size(fp4_block_size)
+    if q.shape[2:] != (_DSV4_RATIO4_INDEXER_NUM_HEADS, _DSV4_RATIO4_INDEXER_HEAD_DIM):
+        raise ValueError(
+            "q must have observed ratio-4 indexer tail shape "
+            f"({_DSV4_RATIO4_INDEXER_NUM_HEADS}, {_DSV4_RATIO4_INDEXER_HEAD_DIM}), "
+            f"got {tuple(q.shape[2:])}"
+        )
+    if q.shape[-1] % fp4_block_size != 0:
+        raise ValueError(
+            f"q head dimension {q.shape[-1]} must be divisible by fp4_block_size={fp4_block_size}"
+        )
+    _validate_dsv4_freqs(freqs_cis, int(q.shape[0]), int(q.shape[1]), rope_dim)
+
+
+def _validate_ratio4_compressor_inputs(
+    kv: torch.Tensor,
+    gate: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    max_compressed_len: int,
+) -> int:
+    _validate_rank("kv", kv, 3)
+    _validate_rank("gate", gate, 3)
+    _validate_rank("ape", ape, 2)
+    if kv.shape != gate.shape:
+        raise ValueError(
+            f"kv and gate shapes must match, got {tuple(kv.shape)} and {tuple(gate.shape)}"
+        )
+    if kv.shape[1] == 0:
+        raise ValueError("kv sequence length must be positive for ratio-4 compression")
+    if kv.shape[-1] % 2 != 0:
+        raise ValueError(f"kv last dim {kv.shape[-1]} must be even for two-channel overlap")
+    if max_compressed_len <= 0:
+        raise ValueError(f"max_compressed_len must be positive, got {max_compressed_len}")
+    if kv.shape[1] > max_compressed_len * _DSV4_RATIO4_COMPRESS_RATIO:
+        raise ValueError(
+            f"kv sequence length {kv.shape[1]} exceeds ratio-4 capacity "
+            f"{max_compressed_len * _DSV4_RATIO4_COMPRESS_RATIO}"
+        )
+    if eps <= 0.0:
+        raise ValueError(f"eps must be positive, got {eps}")
+
+    head_dim = kv.shape[-1] // 2
+    if ape.shape != (_DSV4_RATIO4_COMPRESS_RATIO, kv.shape[-1]):
+        raise ValueError(
+            f"ape must have shape {(_DSV4_RATIO4_COMPRESS_RATIO, kv.shape[-1])}, "
+            f"got {tuple(ape.shape)}"
+        )
+    _validate_norm_weight_for_dim(norm_weight, head_dim)
+    _validate_rope_dim(rope_dim, head_dim)
+    _validate_dsv4_freqs(freqs_cis, int(kv.shape[0]), int(kv.shape[1]), rope_dim)
+    return head_dim
+
+
+def _hadamard_transform_ref(x: torch.Tensor) -> torch.Tensor:
+    last_dim = int(x.shape[-1])
+    if last_dim <= 0 or (last_dim & (last_dim - 1)) != 0:
+        raise ValueError(f"x last dimension must be a positive power of two, got {last_dim}")
+
+    out = x.to(torch.float32).reshape(-1, last_dim)
+    h = 1
+    while h < last_dim:
+        out = out.reshape(-1, 2, h)
+        left, right = out.unbind(dim=-2)
+        out = torch.stack((left + right, left - right), dim=-2).reshape(-1, last_dim)
+        h *= 2
+    return (out * (last_dim**-0.5)).to(x.dtype).reshape_as(x)
+
+
+def deepseek_v4_indexer_fp4_quant_dequant_ref(
+    x: torch.Tensor,
+    block_size: int = _DSV4_RATIO4_INDEXER_FP4_BLOCK_SIZE,
+) -> torch.Tensor:
+    """Reference DSV4 indexer activation fake-quantization for 32-value FP4 groups."""
+    _validate_floating("x", x)
+    _validate_block_size(block_size)
+    last_dim = int(x.shape[-1])
+    if last_dim % block_size != 0:
+        raise ValueError(f"x last dim {last_dim} must be divisible by block_size={block_size}")
+
+    x_blocks = x.contiguous().to(torch.float32).reshape(-1, last_dim)
+    x_blocks = x_blocks.reshape(-1, last_dim // block_size, block_size)
+    min_scale = torch.full((), 6.0 * (2.0**-126), dtype=torch.float32, device=x.device)
+    scale = torch.pow(
+        2.0,
+        torch.ceil(
+            torch.log2(x_blocks.abs().amax(dim=-1, keepdim=True).clamp_min(min_scale) / 6.0)
+        ),
+    )
+    scaled = (x_blocks / scale).clamp(-6.0, 6.0)
+
+    abs_scaled = scaled.abs()
+    quantized = torch.zeros_like(abs_scaled)
+    quantized = torch.where(abs_scaled > 0.25, torch.full_like(quantized, 0.5), quantized)
+    quantized = torch.where(abs_scaled >= 0.75, torch.full_like(quantized, 1.0), quantized)
+    quantized = torch.where(abs_scaled > 1.25, torch.full_like(quantized, 1.5), quantized)
+    quantized = torch.where(abs_scaled >= 1.75, torch.full_like(quantized, 2.0), quantized)
+    quantized = torch.where(abs_scaled > 2.5, torch.full_like(quantized, 3.0), quantized)
+    quantized = torch.where(abs_scaled >= 3.5, torch.full_like(quantized, 4.0), quantized)
+    quantized = torch.where(abs_scaled > 5.0, torch.full_like(quantized, 6.0), quantized)
+    quantized = torch.where(scaled < 0, -quantized, quantized)
+    return (quantized * scale).to(x.dtype).reshape_as(x)
+
+
+def deepseek_v4_ratio4_overlap_compress_ref(
+    kv: torch.Tensor,
+    gate: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: Optional[torch.Tensor],
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    max_compressed_len: int = _DSV4_RATIO4_MAX_COMPRESSED_LEN,
+) -> torch.Tensor:
+    """Build padded ratio-4 overlap-compressed rows for attention or indexer projections.
+
+    ``kv`` and ``gate`` use the observed two-channel layout ``[..., 2 * head_dim]``.
+    The returned rows are padded to ``max_compressed_len`` so the indexer score
+    boundary has a stable graph shape across prefill chunks and decode.
+    """
+    head_dim = _validate_ratio4_compressor_inputs(
+        kv, gate, ape, norm_weight, freqs_cis, eps, rope_dim, max_compressed_len
+    )
+
+    batch_size, seq_len, state_dim = kv.shape
+    max_tokens = max_compressed_len * _DSV4_RATIO4_COMPRESS_RATIO
+    pad_len = max_tokens - seq_len
+    kv_padded = F.pad(kv, (0, 0, 0, pad_len))
+    gate_padded = F.pad(gate, (0, 0, 0, pad_len), value=float("-inf"))
+    kv_blocks = kv_padded.view(
+        batch_size, max_compressed_len, _DSV4_RATIO4_COMPRESS_RATIO, state_dim
+    )
+    gate_blocks = gate_padded.view(
+        batch_size, max_compressed_len, _DSV4_RATIO4_COMPRESS_RATIO, state_dim
+    )
+    gate_blocks = gate_blocks + ape.to(device=gate.device, dtype=gate.dtype)
+    kv_overlap = _overlap_transform_ref(kv_blocks, _DSV4_RATIO4_COMPRESS_RATIO, head_dim, 0.0)
+    gate_overlap = _overlap_transform_ref(
+        gate_blocks, _DSV4_RATIO4_COMPRESS_RATIO, head_dim, float("-inf")
+    )
+
+    weights = torch.nan_to_num(gate_overlap.softmax(dim=2), nan=0.0)
+    pooled = (kv_overlap * weights).sum(dim=2)
+    pooled = _rms_norm_ref(pooled, norm_weight, eps)
+
+    row_idx = torch.arange(max_compressed_len, device=kv.device) * _DSV4_RATIO4_COMPRESS_RATIO
+    row_idx = torch.minimum(row_idx, torch.full_like(row_idx, seq_len - 1))
+    row_idx = row_idx.view(1, max_compressed_len, 1).expand(batch_size, -1, rope_dim // 2)
+    compressed_freqs = torch.gather(freqs_cis, 1, row_idx)
+    return _apply_rope_ref(pooled, compressed_freqs, rope_dim)
+
+
+def deepseek_v4_ratio4_indexer_q_ref(
+    q: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int = _DSV4_TRITON_ROPE_DIM,
+    fp4_block_size: int = _DSV4_RATIO4_INDEXER_FP4_BLOCK_SIZE,
+) -> torch.Tensor:
+    """Apply RoPE, Hadamard, and 4x32 FP4 fake quantization to indexer Q rows."""
+    _validate_ratio4_indexer_q(q, freqs_cis, rope_dim, fp4_block_size)
+    q = _apply_rope_ref(q, freqs_cis, rope_dim)
+    q = _hadamard_transform_ref(q)
+    return deepseek_v4_indexer_fp4_quant_dequant_ref(q, fp4_block_size)
+
+
+def deepseek_v4_ratio4_indexer_compressed_kv_ref(
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int = _DSV4_TRITON_ROPE_DIM,
+    max_compressed_len: int = _DSV4_RATIO4_MAX_COMPRESSED_LEN,
+    fp4_block_size: int = _DSV4_RATIO4_INDEXER_FP4_BLOCK_SIZE,
+) -> torch.Tensor:
+    """Build ratio-4 indexer compressed rows ``[B, max_compressed_len, 128]``."""
+    if compressor_kv.shape[-1] != _DSV4_RATIO4_INDEXER_STATE_DIM:
+        raise ValueError(
+            f"compressor_kv last dim must be {_DSV4_RATIO4_INDEXER_STATE_DIM}, "
+            f"got {compressor_kv.shape[-1]}"
+        )
+    rows = deepseek_v4_ratio4_overlap_compress_ref(
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+    )
+    rows = _hadamard_transform_ref(rows)
+    return deepseek_v4_indexer_fp4_quant_dequant_ref(rows, fp4_block_size)
+
+
+def _validate_ratio4_indexer_scores_contract(
+    q: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    weights: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    max_compressed_len: int,
+    fp4_block_size: int,
+) -> None:
+    _validate_ratio4_indexer_q(q, freqs_cis, rope_dim, fp4_block_size)
+    if weights.shape != (*q.shape[:2], _DSV4_RATIO4_INDEXER_NUM_HEADS):
+        raise ValueError(
+            f"weights must have shape {(*q.shape[:2], _DSV4_RATIO4_INDEXER_NUM_HEADS)}, "
+            f"got {tuple(weights.shape)}"
+        )
+    if not weights.is_floating_point():
+        raise TypeError(f"weights must be floating point, got {weights.dtype}")
+    _validate_ratio4_compressor_inputs(
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+    )
+    if compressor_kv.shape[-1] != _DSV4_RATIO4_INDEXER_STATE_DIM:
+        raise ValueError(
+            f"compressor_kv last dim must be {_DSV4_RATIO4_INDEXER_STATE_DIM}, "
+            f"got {compressor_kv.shape[-1]}"
+        )
+
+
+def deepseek_v4_ratio4_indexer_scores_ref(
+    q: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    weights: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int = _DSV4_TRITON_ROPE_DIM,
+    max_compressed_len: int = _DSV4_RATIO4_MAX_COMPRESSED_LEN,
+    fp4_block_size: int = _DSV4_RATIO4_INDEXER_FP4_BLOCK_SIZE,
+    weights_are_scaled: bool = False,
+) -> torch.Tensor:
+    """Compute local ratio-4 indexer scores before the required all-reduce."""
+    _validate_ratio4_indexer_scores_contract(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+        fp4_block_size,
+    )
+    q = deepseek_v4_ratio4_indexer_q_ref(q, freqs_cis, rope_dim, fp4_block_size)
+    compressed_kv = deepseek_v4_ratio4_indexer_compressed_kv_ref(
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+        fp4_block_size,
+    )
+    score = torch.einsum("bshd,btd->bsht", q.float(), compressed_kv.float())
+    scaled_weights = weights.float()
+    if not weights_are_scaled:
+        scaled_weights = scaled_weights * (
+            _DSV4_RATIO4_INDEXER_HEAD_DIM**-0.5 * _DSV4_RATIO4_INDEXER_NUM_HEADS**-0.5
+        )
+    return (score.relu() * scaled_weights.unsqueeze(-1)).sum(dim=2).contiguous()
+
+
+def _validate_ratio4_indexer_topk_inputs(
+    index_score: torch.Tensor,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    window_size: int,
+    topk_count: int,
+    compress_ratio: int,
+) -> None:
+    _validate_rank("index_score", index_score, 3)
+    if not index_score.is_floating_point():
+        raise TypeError(f"index_score must be floating point, got {index_score.dtype}")
+    _validate_int_metadata("source_seq_lens", source_seq_lens)
+    _validate_int_metadata("input_pos", input_pos)
+    if source_seq_lens.numel() != index_score.shape[0]:
+        raise ValueError(
+            f"source_seq_lens must have {index_score.shape[0]} entries, got {source_seq_lens.numel()}"
+        )
+    if input_pos.numel() != index_score.shape[0]:
+        raise ValueError(
+            f"input_pos must have {index_score.shape[0]} entries, got {input_pos.numel()}"
+        )
+    if window_size <= 0:
+        raise ValueError(f"window_size must be positive, got {window_size}")
+    if topk_count <= 0:
+        raise ValueError(f"topk_count must be positive, got {topk_count}")
+    if compress_ratio != _DSV4_RATIO4_COMPRESS_RATIO:
+        raise ValueError(
+            f"compress_ratio must be {_DSV4_RATIO4_COMPRESS_RATIO}, got {compress_ratio}"
+        )
+
+
+def deepseek_v4_ratio4_indexer_topk_ref(
+    index_score: torch.Tensor,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    topk_count: int = _DSV4_RATIO4_TOPK,
+    compress_ratio: int = _DSV4_RATIO4_COMPRESS_RATIO,
+) -> torch.Tensor:
+    """Mask invisible compressed rows and select offset ratio-4 indexer rows."""
+    _validate_ratio4_indexer_topk_inputs(
+        index_score,
+        source_seq_lens,
+        input_pos,
+        window_size=1,
+        topk_count=topk_count,
+        compress_ratio=compress_ratio,
+    )
+    batch_size, seq_len, max_compressed_len = index_score.shape
+    device = index_score.device
+    source_seq_lens = source_seq_lens.to(device=device, dtype=torch.long).flatten()
+    input_pos = input_pos.to(device=device, dtype=torch.long).flatten()
+    query_positions = input_pos[:, None] + torch.arange(1, seq_len + 1, device=device)
+    valid_lengths = query_positions // compress_ratio
+    compressed_positions = torch.arange(max_compressed_len, device=device)
+    invalid = compressed_positions.view(1, 1, -1) >= valid_lengths.unsqueeze(-1)
+    masked_score = torch.where(
+        invalid,
+        torch.full_like(index_score, float("-inf")),
+        index_score,
+    )
+
+    selected = masked_score.topk(min(topk_count, max_compressed_len), dim=-1).indices
+    valid_selected = selected < valid_lengths.unsqueeze(-1)
+    offset = source_seq_lens.view(batch_size, 1, 1)
+    selected = torch.where(valid_selected, selected + offset, torch.full_like(selected, -1))
+    if selected.shape[-1] < topk_count:
+        pad = selected.new_full((*selected.shape[:-1], topk_count - selected.shape[-1]), -1)
+        selected = torch.cat([selected, pad], dim=-1)
+    return selected.to(torch.int32).contiguous()
+
+
+def _ratio4_local_window_topk_idxs(
+    window_size: int,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    seq_len: int,
+    device: torch.device,
+) -> torch.Tensor:
+    source_seq_lens = source_seq_lens.to(device=device, dtype=torch.long).flatten()
+    input_pos = input_pos.to(device=device, dtype=torch.long).flatten()
+    positions = input_pos[:, None] + torch.arange(seq_len, device=device)
+    start = (positions - window_size + 1).clamp(min=0)
+    offsets = torch.arange(window_size, device=device)
+    local = start.unsqueeze(-1) + offsets.view(1, 1, window_size)
+    valid = (local <= positions.unsqueeze(-1)) & (local < source_seq_lens.view(-1, 1, 1))
+    return torch.where(valid, local, torch.full_like(local, -1)).to(torch.int32)
+
+
+def deepseek_v4_ratio4_indexer_build_topk_ref(
+    index_score: torch.Tensor,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    window_size: int = _DSV4_RATIO4_WINDOW_SIZE,
+    topk_count: int = _DSV4_RATIO4_TOPK,
+    compress_ratio: int = _DSV4_RATIO4_COMPRESS_RATIO,
+) -> torch.Tensor:
+    """Build final ratio-4 sparse-attention indices with 128 local and 512 compressed rows."""
+    _validate_ratio4_indexer_topk_inputs(
+        index_score, source_seq_lens, input_pos, window_size, topk_count, compress_ratio
+    )
+    local = _ratio4_local_window_topk_idxs(
+        window_size,
+        source_seq_lens,
+        input_pos,
+        int(index_score.shape[1]),
+        index_score.device,
+    )
+    compressed = deepseek_v4_ratio4_indexer_topk_ref(
+        index_score, source_seq_lens, input_pos, topk_count, compress_ratio
+    )
+    return torch.cat([local, compressed], dim=-1).contiguous()
+
+
+def _apply_rope_device(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+) -> torch.Tensor:
+    if rope_dim == 0:
+        return x.contiguous()
+
+    nope = x[..., : x.shape[-1] - rope_dim]
+    rope = x[..., -rope_dim:]
+    rope_complex = torch.view_as_complex(rope.float().reshape(*rope.shape[:-1], -1, 2))
+    freqs = freqs_cis
+    if freqs.dim() == rope_complex.dim() - 1:
+        freqs = freqs.unsqueeze(-2)
+    rope_out = torch.view_as_real(rope_complex * freqs).flatten(-2).to(x.dtype)
+    return torch.cat([nope, rope_out], dim=-1).contiguous()
+
+
+def _hadamard_transform_device(x: torch.Tensor) -> torch.Tensor:
+    last_dim = int(x.shape[-1])
+    out = x.to(torch.float32).reshape(-1, last_dim)
+    h = 1
+    while h < last_dim:
+        out = out.reshape(-1, 2, h)
+        left, right = out.unbind(dim=-2)
+        out = torch.stack((left + right, left - right), dim=-2).reshape(-1, last_dim)
+        h *= 2
+    return (out * (last_dim**-0.5)).to(x.dtype).reshape_as(x)
+
+
+def _indexer_fp4_quant_dequant_device(
+    x: torch.Tensor,
+    block_size: int,
+) -> torch.Tensor:
+    last_dim = int(x.shape[-1])
+    x_blocks = x.contiguous().to(torch.float32).reshape(-1, last_dim)
+    x_blocks = x_blocks.reshape(-1, last_dim // block_size, block_size)
+    min_scale = torch.full((), 6.0 * (2.0**-126), dtype=torch.float32, device=x.device)
+    scale = torch.pow(
+        2.0,
+        torch.ceil(
+            torch.log2(x_blocks.abs().amax(dim=-1, keepdim=True).clamp_min(min_scale) / 6.0)
+        ),
+    )
+    scaled = (x_blocks / scale).clamp(-6.0, 6.0)
+
+    abs_scaled = scaled.abs()
+    quantized = torch.zeros_like(abs_scaled)
+    quantized = torch.where(abs_scaled > 0.25, torch.full_like(quantized, 0.5), quantized)
+    quantized = torch.where(abs_scaled >= 0.75, torch.full_like(quantized, 1.0), quantized)
+    quantized = torch.where(abs_scaled > 1.25, torch.full_like(quantized, 1.5), quantized)
+    quantized = torch.where(abs_scaled >= 1.75, torch.full_like(quantized, 2.0), quantized)
+    quantized = torch.where(abs_scaled > 2.5, torch.full_like(quantized, 3.0), quantized)
+    quantized = torch.where(abs_scaled >= 3.5, torch.full_like(quantized, 4.0), quantized)
+    quantized = torch.where(abs_scaled > 5.0, torch.full_like(quantized, 6.0), quantized)
+    quantized = torch.where(scaled < 0, -quantized, quantized)
+    return (quantized * scale).to(x.dtype).reshape_as(x)
+
+
+def _overlap_transform_device(
+    tensor: torch.Tensor,
+    value: float,
+) -> torch.Tensor:
+    batch_size, compressed_len, ratio, _ = tensor.shape
+    out = tensor.new_full(
+        (batch_size, compressed_len, 2 * ratio, _DSV4_RATIO4_INDEXER_HEAD_DIM), value
+    )
+    out[:, :, ratio:] = tensor[:, :, :, _DSV4_RATIO4_INDEXER_HEAD_DIM:]
+    out[:, 1:, :ratio] = tensor[:, :-1, :, :_DSV4_RATIO4_INDEXER_HEAD_DIM]
+    return out
+
+
+def _ratio4_overlap_compress_device(
+    kv: torch.Tensor,
+    gate: torch.Tensor,
+    ape: torch.Tensor,
+    norm_weight: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    max_compressed_len: int,
+) -> torch.Tensor:
+    batch_size, seq_len, state_dim = kv.shape
+    max_tokens = max_compressed_len * _DSV4_RATIO4_COMPRESS_RATIO
+    pad_len = max_tokens - seq_len
+    kv_padded = F.pad(kv, (0, 0, 0, pad_len))
+    gate_padded = F.pad(gate, (0, 0, 0, pad_len), value=float("-inf"))
+    kv_blocks = kv_padded.view(
+        batch_size, max_compressed_len, _DSV4_RATIO4_COMPRESS_RATIO, state_dim
+    )
+    gate_blocks = gate_padded.view(
+        batch_size, max_compressed_len, _DSV4_RATIO4_COMPRESS_RATIO, state_dim
+    )
+    gate_blocks = gate_blocks + ape.to(device=gate.device, dtype=gate.dtype)
+    kv_overlap = _overlap_transform_device(kv_blocks, 0.0)
+    gate_overlap = _overlap_transform_device(gate_blocks, float("-inf"))
+
+    weights = torch.nan_to_num(gate_overlap.softmax(dim=2), nan=0.0)
+    pooled = (kv_overlap * weights).sum(dim=2)
+    pooled_float = pooled.to(torch.float32)
+    pooled = pooled_float * torch.rsqrt(pooled_float.square().mean(dim=-1, keepdim=True) + eps)
+    pooled = pooled * norm_weight.to(device=pooled.device, dtype=torch.float32)
+    pooled = pooled.to(kv.dtype)
+
+    row_idx = torch.arange(max_compressed_len, device=kv.device) * _DSV4_RATIO4_COMPRESS_RATIO
+    row_idx = torch.minimum(row_idx, torch.full_like(row_idx, seq_len - 1))
+    row_idx = row_idx.view(1, max_compressed_len, 1).expand(batch_size, -1, rope_dim // 2)
+    compressed_freqs = torch.gather(freqs_cis, 1, row_idx)
+    return _apply_rope_device(pooled, compressed_freqs, rope_dim)
+
+
+def _ratio4_indexer_q_device(
+    q: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+    fp4_block_size: int,
+) -> torch.Tensor:
+    q = _apply_rope_device(q, freqs_cis, rope_dim)
+    q = _hadamard_transform_device(q)
+    return _indexer_fp4_quant_dequant_device(q, fp4_block_size)
+
+
+def _ratio4_indexer_compressed_kv_device(
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    max_compressed_len: int,
+    fp4_block_size: int,
+) -> torch.Tensor:
+    rows = _ratio4_overlap_compress_device(
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+    )
+    rows = _hadamard_transform_device(rows)
+    return _indexer_fp4_quant_dequant_device(rows, fp4_block_size)
+
+
+def _validate_ratio4_indexer_scores_out(
+    q: torch.Tensor,
+    max_compressed_len: int,
+    out: Optional[torch.Tensor],
+) -> None:
+    if out is None:
+        return
+    expected_shape = (q.shape[0], q.shape[1], max_compressed_len)
+    if out.shape != expected_shape:
+        raise ValueError(f"out shape must be {expected_shape}, got {tuple(out.shape)}")
+    if out.dtype != torch.float32:
+        raise TypeError(f"out dtype must be torch.float32, got {out.dtype}")
+    if out.device != q.device:
+        raise ValueError(f"out must be on {q.device}, got {out.device}")
+
+
+def _triton_ratio4_indexer_scores_skip_reason(
+    q: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    weights: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    out: Optional[torch.Tensor],
+) -> str | None:
+    for name, tensor in (
+        ("q", q),
+        ("compressor_kv", compressor_kv),
+        ("compressor_gate", compressor_gate),
+        ("compressor_ape", compressor_ape),
+        ("compressor_norm_weight", compressor_norm_weight),
+        ("weights", weights),
+        ("freqs_cis", freqs_cis),
+    ):
+        reason = _device_skip_reason(name, tensor, q.device)
+        if reason is not None:
+            return reason
+    if out is not None:
+        reason = _device_skip_reason("out", out, q.device)
+        if reason is not None:
+            return reason
+    if freqs_cis.dtype != torch.complex64:
+        return f"freqs_cis must be complex64 for the DSV4 Triton path, got {freqs_cis.dtype}"
+    return None
+
+
+def _run_ratio4_indexer_scores_device(
+    q: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    weights: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int,
+    max_compressed_len: int,
+    fp4_block_size: int,
+    weights_are_scaled: bool,
+    out: Optional[torch.Tensor],
+) -> torch.Tensor:
+    q_indexer = _ratio4_indexer_q_device(q, freqs_cis, rope_dim, fp4_block_size)
+    compressed_kv = _ratio4_indexer_compressed_kv_device(
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+        fp4_block_size,
+    )
+    score = torch.einsum("bshd,btd->bsht", q_indexer.float(), compressed_kv.float())
+    scaled_weights = weights.float()
+    if not weights_are_scaled:
+        scaled_weights = scaled_weights * (
+            _DSV4_RATIO4_INDEXER_HEAD_DIM**-0.5 * _DSV4_RATIO4_INDEXER_NUM_HEADS**-0.5
+        )
+    output = (score.relu() * scaled_weights.unsqueeze(-1)).sum(dim=2).contiguous()
+    if out is not None:
+        out.copy_(output)
+        return out.new_empty(0)
+    return output
+
+
+def _validate_ratio4_indexer_topk_out(
+    index_score: torch.Tensor,
+    window_size: int,
+    topk_count: int,
+    out: Optional[torch.Tensor],
+) -> None:
+    if out is None:
+        return
+    expected_shape = (index_score.shape[0], index_score.shape[1], window_size + topk_count)
+    if out.shape != expected_shape:
+        raise ValueError(f"out shape must be {expected_shape}, got {tuple(out.shape)}")
+    if out.dtype != torch.int32:
+        raise TypeError(f"out dtype must be torch.int32, got {out.dtype}")
+    if out.device != index_score.device:
+        raise ValueError(f"out must be on {index_score.device}, got {out.device}")
+
+
+def _triton_ratio4_indexer_topk_skip_reason(
+    index_score: torch.Tensor,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    out: Optional[torch.Tensor],
+) -> str | None:
+    for name, tensor in (
+        ("index_score", index_score),
+        ("source_seq_lens", source_seq_lens),
+        ("input_pos", input_pos),
+    ):
+        reason = _device_skip_reason(name, tensor, index_score.device)
+        if reason is not None:
+            return reason
+    if out is not None:
+        reason = _device_skip_reason("out", out, index_score.device)
+        if reason is not None:
+            return reason
+    return None
+
+
+def _ratio4_indexer_topk_device(
+    index_score: torch.Tensor,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    window_size: int,
+    topk_count: int,
+    compress_ratio: int,
+) -> torch.Tensor:
+    batch_size, seq_len, max_compressed_len = index_score.shape
+    device = index_score.device
+    source_seq_lens = source_seq_lens.to(device=device, dtype=torch.long).flatten()
+    input_pos = input_pos.to(device=device, dtype=torch.long).flatten()
+
+    positions = input_pos[:, None] + torch.arange(seq_len, device=device)
+    start = (positions - window_size + 1).clamp(min=0)
+    local_offsets = torch.arange(window_size, device=device)
+    local = start.unsqueeze(-1) + local_offsets.view(1, 1, window_size)
+    local_valid = (local <= positions.unsqueeze(-1)) & (
+        local < source_seq_lens.view(batch_size, 1, 1)
+    )
+    local = torch.where(local_valid, local, torch.full_like(local, -1)).to(torch.int32)
+
+    query_positions = input_pos[:, None] + torch.arange(1, seq_len + 1, device=device)
+    valid_lengths = query_positions // compress_ratio
+    compressed_positions = torch.arange(max_compressed_len, device=device)
+    invalid = compressed_positions.view(1, 1, -1) >= valid_lengths.unsqueeze(-1)
+    masked_score = torch.where(invalid, torch.full_like(index_score, float("-inf")), index_score)
+
+    selected = masked_score.topk(min(topk_count, max_compressed_len), dim=-1).indices
+    valid_selected = selected < valid_lengths.unsqueeze(-1)
+    selected = torch.where(
+        valid_selected,
+        selected + source_seq_lens.view(batch_size, 1, 1),
+        torch.full_like(selected, -1),
+    )
+    if selected.shape[-1] < topk_count:
+        pad = selected.new_full((*selected.shape[:-1], topk_count - selected.shape[-1]), -1)
+        selected = torch.cat([selected, pad], dim=-1)
+    return torch.cat([local, selected.to(torch.int32)], dim=-1).contiguous()
+
+
+def _run_ratio4_indexer_topk_device(
+    index_score: torch.Tensor,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    window_size: int,
+    topk_count: int,
+    compress_ratio: int,
+    out: Optional[torch.Tensor],
+) -> torch.Tensor:
+    output = _ratio4_indexer_topk_device(
+        index_score, source_seq_lens, input_pos, window_size, topk_count, compress_ratio
+    )
+    if out is not None:
+        out.copy_(output)
+        return out.new_empty(0)
+    return output
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_ratio4_indexer_scores", mutates_args=())
+def torch_deepseek_v4_ratio4_indexer_scores(
+    q: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    weights: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int = _DSV4_TRITON_ROPE_DIM,
+    max_compressed_len: int = _DSV4_RATIO4_MAX_COMPRESSED_LEN,
+    fp4_block_size: int = _DSV4_RATIO4_INDEXER_FP4_BLOCK_SIZE,
+    weights_are_scaled: bool = False,
+) -> torch.Tensor:
+    return deepseek_v4_ratio4_indexer_scores_ref(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+        fp4_block_size,
+        weights_are_scaled,
+    )
+
+
+@torch_deepseek_v4_ratio4_indexer_scores.register_fake
+def torch_deepseek_v4_ratio4_indexer_scores_fake(
+    q: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    weights: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int = _DSV4_TRITON_ROPE_DIM,
+    max_compressed_len: int = _DSV4_RATIO4_MAX_COMPRESSED_LEN,
+    fp4_block_size: int = _DSV4_RATIO4_INDEXER_FP4_BLOCK_SIZE,
+    weights_are_scaled: bool = False,
+) -> torch.Tensor:
+    del weights_are_scaled
+    _validate_ratio4_indexer_scores_contract(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+        fp4_block_size,
+    )
+    return q.new_empty(q.shape[0], q.shape[1], max_compressed_len, dtype=torch.float32)
+
+
+@torch.library.custom_op("auto_deploy::triton_deepseek_v4_ratio4_indexer_scores", mutates_args=())
+def triton_deepseek_v4_ratio4_indexer_scores(
+    q: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    weights: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int = _DSV4_TRITON_ROPE_DIM,
+    max_compressed_len: int = _DSV4_RATIO4_MAX_COMPRESSED_LEN,
+    fp4_block_size: int = _DSV4_RATIO4_INDEXER_FP4_BLOCK_SIZE,
+    weights_are_scaled: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    _validate_ratio4_indexer_scores_contract(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+        fp4_block_size,
+    )
+    if max_compressed_len != _DSV4_RATIO4_MAX_COMPRESSED_LEN:
+        raise ValueError(
+            f"max_compressed_len must be {_DSV4_RATIO4_MAX_COMPRESSED_LEN}, got {max_compressed_len}"
+        )
+    _validate_ratio4_indexer_scores_out(q, max_compressed_len, out)
+    skip_reason = _triton_ratio4_indexer_scores_skip_reason(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs_cis,
+        out,
+    )
+    if skip_reason is None:
+        return _run_ratio4_indexer_scores_device(
+            q,
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            weights,
+            freqs_cis,
+            eps,
+            rope_dim,
+            max_compressed_len,
+            fp4_block_size,
+            weights_are_scaled,
+            out,
+        )
+    if _any_cuda_tensor(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs_cis,
+        out,
+    ):
+        raise RuntimeError(skip_reason)
+
+    output = deepseek_v4_ratio4_indexer_scores_ref(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+        fp4_block_size,
+        weights_are_scaled,
+    )
+    if out is not None:
+        out.copy_(output)
+        return out.new_empty(0)
+    return output
+
+
+@triton_deepseek_v4_ratio4_indexer_scores.register_fake
+def triton_deepseek_v4_ratio4_indexer_scores_fake(
+    q: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    weights: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    eps: float,
+    rope_dim: int = _DSV4_TRITON_ROPE_DIM,
+    max_compressed_len: int = _DSV4_RATIO4_MAX_COMPRESSED_LEN,
+    fp4_block_size: int = _DSV4_RATIO4_INDEXER_FP4_BLOCK_SIZE,
+    weights_are_scaled: bool = False,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    del weights_are_scaled
+    _validate_ratio4_indexer_scores_contract(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs_cis,
+        eps,
+        rope_dim,
+        max_compressed_len,
+        fp4_block_size,
+    )
+    if max_compressed_len != _DSV4_RATIO4_MAX_COMPRESSED_LEN:
+        raise ValueError(
+            f"max_compressed_len must be {_DSV4_RATIO4_MAX_COMPRESSED_LEN}, got {max_compressed_len}"
+        )
+    if out is not None:
+        return out.new_empty(0)
+    return q.new_empty(q.shape[0], q.shape[1], max_compressed_len, dtype=torch.float32)
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_ratio4_indexer_topk", mutates_args=())
+def torch_deepseek_v4_ratio4_indexer_topk(
+    index_score: torch.Tensor,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    window_size: int = _DSV4_RATIO4_WINDOW_SIZE,
+    topk_count: int = _DSV4_RATIO4_TOPK,
+    compress_ratio: int = _DSV4_RATIO4_COMPRESS_RATIO,
+) -> torch.Tensor:
+    return deepseek_v4_ratio4_indexer_build_topk_ref(
+        index_score, source_seq_lens, input_pos, window_size, topk_count, compress_ratio
+    )
+
+
+@torch_deepseek_v4_ratio4_indexer_topk.register_fake
+def torch_deepseek_v4_ratio4_indexer_topk_fake(
+    index_score: torch.Tensor,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    window_size: int = _DSV4_RATIO4_WINDOW_SIZE,
+    topk_count: int = _DSV4_RATIO4_TOPK,
+    compress_ratio: int = _DSV4_RATIO4_COMPRESS_RATIO,
+) -> torch.Tensor:
+    _validate_ratio4_indexer_topk_inputs(
+        index_score, source_seq_lens, input_pos, window_size, topk_count, compress_ratio
+    )
+    return torch.empty(
+        index_score.shape[0],
+        index_score.shape[1],
+        window_size + topk_count,
+        dtype=torch.int32,
+        device=index_score.device,
+    )
+
+
+@torch.library.custom_op("auto_deploy::triton_deepseek_v4_ratio4_indexer_topk", mutates_args=())
+def triton_deepseek_v4_ratio4_indexer_topk(
+    index_score: torch.Tensor,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    window_size: int = _DSV4_RATIO4_WINDOW_SIZE,
+    topk_count: int = _DSV4_RATIO4_TOPK,
+    compress_ratio: int = _DSV4_RATIO4_COMPRESS_RATIO,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    _validate_ratio4_indexer_topk_inputs(
+        index_score, source_seq_lens, input_pos, window_size, topk_count, compress_ratio
+    )
+    if index_score.shape[-1] != _DSV4_RATIO4_MAX_COMPRESSED_LEN:
+        raise ValueError(
+            f"index_score width must be {_DSV4_RATIO4_MAX_COMPRESSED_LEN}, "
+            f"got {index_score.shape[-1]}"
+        )
+    if window_size != _DSV4_RATIO4_WINDOW_SIZE:
+        raise ValueError(f"window_size must be {_DSV4_RATIO4_WINDOW_SIZE}, got {window_size}")
+    if topk_count != _DSV4_RATIO4_TOPK:
+        raise ValueError(f"topk_count must be {_DSV4_RATIO4_TOPK}, got {topk_count}")
+    _validate_ratio4_indexer_topk_out(index_score, window_size, topk_count, out)
+    skip_reason = _triton_ratio4_indexer_topk_skip_reason(
+        index_score, source_seq_lens, input_pos, out
+    )
+    if skip_reason is None:
+        return _run_ratio4_indexer_topk_device(
+            index_score,
+            source_seq_lens,
+            input_pos,
+            window_size,
+            topk_count,
+            compress_ratio,
+            out,
+        )
+    if _any_cuda_tensor(index_score, source_seq_lens, input_pos, out):
+        raise RuntimeError(skip_reason)
+
+    output = deepseek_v4_ratio4_indexer_build_topk_ref(
+        index_score, source_seq_lens, input_pos, window_size, topk_count, compress_ratio
+    )
+    if out is not None:
+        out.copy_(output)
+        return out.new_empty(0)
+    return output
+
+
+@triton_deepseek_v4_ratio4_indexer_topk.register_fake
+def triton_deepseek_v4_ratio4_indexer_topk_fake(
+    index_score: torch.Tensor,
+    source_seq_lens: torch.Tensor,
+    input_pos: torch.Tensor,
+    window_size: int = _DSV4_RATIO4_WINDOW_SIZE,
+    topk_count: int = _DSV4_RATIO4_TOPK,
+    compress_ratio: int = _DSV4_RATIO4_COMPRESS_RATIO,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    _validate_ratio4_indexer_topk_inputs(
+        index_score, source_seq_lens, input_pos, window_size, topk_count, compress_ratio
+    )
+    if index_score.shape[-1] != _DSV4_RATIO4_MAX_COMPRESSED_LEN:
+        raise ValueError(
+            f"index_score width must be {_DSV4_RATIO4_MAX_COMPRESSED_LEN}, "
+            f"got {index_score.shape[-1]}"
+        )
+    if window_size != _DSV4_RATIO4_WINDOW_SIZE:
+        raise ValueError(f"window_size must be {_DSV4_RATIO4_WINDOW_SIZE}, got {window_size}")
+    if topk_count != _DSV4_RATIO4_TOPK:
+        raise ValueError(f"topk_count must be {_DSV4_RATIO4_TOPK}, got {topk_count}")
+    if out is not None:
+        return out.new_empty(0)
+    return torch.empty(
+        index_score.shape[0],
+        index_score.shape[1],
+        window_size + topk_count,
+        dtype=torch.int32,
+        device=index_score.device,
+    )
 
 
 def deepseek_v4_indexer_q_rope_quant_ref(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_deepseek_v4_sparse_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_deepseek_v4_sparse_attention.py
@@ -1,0 +1,743 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton kernels for DeepSeek V4 ratio-0 cached sparse attention."""
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+_RATIO0_TOPK_WIDTH = 128
+_RATIO0_LOCAL_HEADS = 8
+_RATIO0_HEAD_DIM = 512
+_RATIO0_NOPE_DIM = 448
+_RATIO0_ROPE_DIM = 64
+_RATIO0_FP8_BLOCK_SIZE = 128
+_RATIO0_SCALE_BLOCKS = 4
+_FP8_E4M3_DTYPE = torch.float8_e4m3fn
+
+
+def _device_skip_reason(name: str, tensor: torch.Tensor) -> str | None:
+    if not tensor.is_cuda:
+        return f"{name} must be a CUDA tensor for the Triton ratio-0 SWA path"
+    return None
+
+
+def _e8m0_dtype() -> torch.dtype | None:
+    return getattr(torch, "float8_e8m0fnu", None)
+
+
+def _scale_cache_raw_bytes(scale_cache: torch.Tensor) -> torch.Tensor:
+    if scale_cache.dtype == torch.uint8:
+        return scale_cache
+
+    e8m0_dtype = _e8m0_dtype()
+    if e8m0_dtype is not None and scale_cache.dtype == e8m0_dtype:
+        return scale_cache.view(torch.uint8)
+
+    raise TypeError(
+        "scale_cache must contain raw E8M0 bytes as torch.uint8 or "
+        f"{e8m0_dtype}; got {scale_cache.dtype}"
+    )
+
+
+def _cache_layout_for_triton(cache: torch.Tensor) -> tuple[int, int, int]:
+    """Return ``(tokens_per_block, page_stride, token_stride)`` for supported cache layouts."""
+    if cache.dim() == 5:
+        if int(cache.shape[1]) == 1:
+            token_dim = 2 if int(cache.shape[2]) >= int(cache.shape[3]) else 3
+        else:
+            token_dim = 1
+    elif cache.dim() in (3, 4):
+        token_dim = 1
+    else:
+        raise ValueError(f"swa_cache must have rank 3, 4, or 5, got rank {cache.dim()}")
+
+    return int(cache.shape[token_dim]), int(cache.stride(0)), int(cache.stride(token_dim))
+
+
+def deepseek_v4_ratio0_swa_triton_skip_reason(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    window_size: int,
+    compress_ratio: int,
+    out: Optional[torch.Tensor],
+    active_tokens: Optional[int] = None,
+) -> str | None:
+    """Return why the ratio-0 Triton SWA path cannot run, or ``None`` if it can."""
+    if compress_ratio != 0:
+        return f"compress_ratio must be 0 for the Triton SWA path, got {compress_ratio}"
+    if window_size != _RATIO0_TOPK_WIDTH:
+        return f"window_size must be {_RATIO0_TOPK_WIDTH}, got {window_size}"
+    if q.dim() != 4:
+        return f"q must have rank 4, got rank {q.dim()}"
+    if kv.dim() != 3:
+        return f"kv must have rank 3, got rank {kv.dim()}"
+    if topk_idxs.dim() != 3:
+        return f"topk_idxs must have rank 3, got rank {topk_idxs.dim()}"
+    if q.shape[1] != 1:
+        return "the Triton ratio-0 SWA path currently supports decode-only q.shape[1] == 1"
+    if q.shape[2] != _RATIO0_LOCAL_HEADS:
+        return f"q local head count must be {_RATIO0_LOCAL_HEADS}, got {q.shape[2]}"
+    if q.shape[3] != _RATIO0_HEAD_DIM:
+        return f"q head dimension must be {_RATIO0_HEAD_DIM}, got {q.shape[3]}"
+    if kv.shape != (q.shape[0], q.shape[1], _RATIO0_HEAD_DIM):
+        return (
+            f"kv must have shape {(q.shape[0], q.shape[1], _RATIO0_HEAD_DIM)}, "
+            f"got {tuple(kv.shape)}"
+        )
+    if attn_sink.shape != (_RATIO0_LOCAL_HEADS,):
+        return f"attn_sink must have shape ({_RATIO0_LOCAL_HEADS},), got {tuple(attn_sink.shape)}"
+    if topk_idxs.shape != (q.shape[0], q.shape[1], _RATIO0_TOPK_WIDTH):
+        return (
+            f"topk_idxs must have shape {(q.shape[0], q.shape[1], _RATIO0_TOPK_WIDTH)}, "
+            f"got {tuple(topk_idxs.shape)}"
+        )
+    if q.dtype != torch.bfloat16:
+        return f"q must be bfloat16, got {q.dtype}"
+    if kv.dtype != torch.bfloat16:
+        return f"kv must be bfloat16, got {kv.dtype}"
+    if attn_sink.dtype != torch.float32:
+        return f"attn_sink must be float32, got {attn_sink.dtype}"
+    if topk_idxs.dtype not in (torch.int32, torch.int64):
+        return f"topk_idxs must be int32 or int64, got {topk_idxs.dtype}"
+    if swa_cache.dtype != torch.bfloat16:
+        return f"swa_cache must be bfloat16, got {swa_cache.dtype}"
+    if swa_cache.shape[-1] != _RATIO0_HEAD_DIM:
+        return f"swa_cache last dimension must be {_RATIO0_HEAD_DIM}, got {swa_cache.shape[-1]}"
+    if swa_cache.stride(-1) != 1:
+        return f"swa_cache last dimension must be contiguous, got stride {swa_cache.stride(-1)}"
+    if q.stride(-1) != 1:
+        return f"q last dimension must be contiguous, got stride {q.stride(-1)}"
+    if kv.stride(-1) != 1:
+        return f"kv last dimension must be contiguous, got stride {kv.stride(-1)}"
+    if out is not None:
+        if out.shape != q.shape:
+            return f"out shape must be {tuple(q.shape)}, got {tuple(out.shape)}"
+        if out.dtype != q.dtype:
+            return f"out dtype must be {q.dtype}, got {out.dtype}"
+        if out.stride(-1) != 1:
+            return f"out last dimension must be contiguous, got stride {out.stride(-1)}"
+
+    for name, tensor in (
+        ("q", q),
+        ("kv", kv),
+        ("attn_sink", attn_sink),
+        ("topk_idxs", topk_idxs),
+        ("seq_len_host", seq_len_host),
+        ("input_pos_host", input_pos_host),
+        ("cu_seqlen_host", cu_seqlen_host),
+        ("cache_loc_host", cache_loc_host),
+        ("cu_num_pages_host", cu_num_pages_host),
+        ("swa_cache", swa_cache),
+    ):
+        reason = _device_skip_reason(name, tensor)
+        if reason is not None:
+            return reason
+    if out is not None:
+        reason = _device_skip_reason("out", out)
+        if reason is not None:
+            return reason
+
+    try:
+        tokens_per_block, _, _ = _cache_layout_for_triton(swa_cache)
+    except ValueError as exc:
+        return str(exc)
+    if tokens_per_block <= 0:
+        return f"swa_cache tokens_per_block must be positive, got {tokens_per_block}"
+    if active_tokens is not None:
+        if active_tokens <= 0:
+            return f"active_tokens must be positive, got {active_tokens}"
+        if active_tokens > q.shape[0]:
+            return f"active_tokens ({active_tokens}) exceed decode batch capacity ({q.shape[0]})"
+        if input_pos_host.numel() < active_tokens:
+            return (
+                f"input_pos_host needs at least {active_tokens} entries, "
+                f"got {input_pos_host.numel()}"
+            )
+        if cu_num_pages_host.numel() < active_tokens + 1:
+            return (
+                f"cu_num_pages_host needs at least {active_tokens + 1} entries, "
+                f"got {cu_num_pages_host.numel()}"
+            )
+
+    return None
+
+
+def deepseek_v4_ratio0_swa_fp8_triton_skip_reason(
+    q: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    window_size: int,
+    out: Optional[torch.Tensor],
+    active_tokens: Optional[int] = None,
+) -> str | None:
+    """Return why the ratio-0 split FP8 SWA cache path cannot run, or ``None``."""
+    if window_size != _RATIO0_TOPK_WIDTH:
+        return f"window_size must be {_RATIO0_TOPK_WIDTH}, got {window_size}"
+    if q.dim() != 4:
+        return f"q must have rank 4, got rank {q.dim()}"
+    if topk_idxs.dim() != 3:
+        return f"topk_idxs must have rank 3, got rank {topk_idxs.dim()}"
+    if q.shape[1] != 1:
+        return (
+            "the Triton ratio-0 split FP8 SWA path currently supports decode-only q.shape[1] == 1"
+        )
+    if q.shape[2] != _RATIO0_LOCAL_HEADS:
+        return f"q local head count must be {_RATIO0_LOCAL_HEADS}, got {q.shape[2]}"
+    if q.shape[3] != _RATIO0_HEAD_DIM:
+        return f"q head dimension must be {_RATIO0_HEAD_DIM}, got {q.shape[3]}"
+    if attn_sink.shape != (_RATIO0_LOCAL_HEADS,):
+        return f"attn_sink must have shape ({_RATIO0_LOCAL_HEADS},), got {tuple(attn_sink.shape)}"
+    if topk_idxs.shape != (q.shape[0], q.shape[1], _RATIO0_TOPK_WIDTH):
+        return (
+            f"topk_idxs must have shape {(q.shape[0], q.shape[1], _RATIO0_TOPK_WIDTH)}, "
+            f"got {tuple(topk_idxs.shape)}"
+        )
+    if q.dtype != torch.bfloat16:
+        return f"q must be bfloat16, got {q.dtype}"
+    if attn_sink.dtype != torch.float32:
+        return f"attn_sink must be float32, got {attn_sink.dtype}"
+    if topk_idxs.dtype not in (torch.int32, torch.int64):
+        return f"topk_idxs must be int32 or int64, got {topk_idxs.dtype}"
+    if nope_cache.dtype != _FP8_E4M3_DTYPE:
+        return f"nope_cache must be {_FP8_E4M3_DTYPE}, got {nope_cache.dtype}"
+    if rope_cache.dtype != torch.bfloat16:
+        return f"rope_cache must be bfloat16, got {rope_cache.dtype}"
+    try:
+        _scale_cache_raw_bytes(scale_cache)
+    except TypeError as exc:
+        return str(exc)
+    if nope_cache.shape[-1] != _RATIO0_NOPE_DIM:
+        return f"nope_cache last dimension must be {_RATIO0_NOPE_DIM}, got {nope_cache.shape[-1]}"
+    if rope_cache.shape[-1] != _RATIO0_ROPE_DIM:
+        return f"rope_cache last dimension must be {_RATIO0_ROPE_DIM}, got {rope_cache.shape[-1]}"
+    if scale_cache.shape[-1] != _RATIO0_SCALE_BLOCKS:
+        return (
+            f"scale_cache last dimension must be {_RATIO0_SCALE_BLOCKS}, "
+            f"got {scale_cache.shape[-1]}"
+        )
+    if q.stride(-1) != 1:
+        return f"q last dimension must be contiguous, got stride {q.stride(-1)}"
+    if nope_cache.stride(-1) != 1:
+        return f"nope_cache last dimension must be contiguous, got stride {nope_cache.stride(-1)}"
+    if rope_cache.stride(-1) != 1:
+        return f"rope_cache last dimension must be contiguous, got stride {rope_cache.stride(-1)}"
+    if scale_cache.stride(-1) != 1:
+        return f"scale_cache last dimension must be contiguous, got stride {scale_cache.stride(-1)}"
+    if out is not None:
+        if out.shape != q.shape:
+            return f"out shape must be {tuple(q.shape)}, got {tuple(out.shape)}"
+        if out.dtype != q.dtype:
+            return f"out dtype must be {q.dtype}, got {out.dtype}"
+        if out.stride(-1) != 1:
+            return f"out last dimension must be contiguous, got stride {out.stride(-1)}"
+
+    for name, tensor in (
+        ("q", q),
+        ("attn_sink", attn_sink),
+        ("topk_idxs", topk_idxs),
+        ("seq_len_host", seq_len_host),
+        ("input_pos_host", input_pos_host),
+        ("cu_seqlen_host", cu_seqlen_host),
+        ("cache_loc_host", cache_loc_host),
+        ("cu_num_pages_host", cu_num_pages_host),
+        ("nope_cache", nope_cache),
+        ("rope_cache", rope_cache),
+        ("scale_cache", scale_cache),
+    ):
+        reason = _device_skip_reason(name, tensor)
+        if reason is not None:
+            return reason
+    if out is not None:
+        reason = _device_skip_reason("out", out)
+        if reason is not None:
+            return reason
+
+    try:
+        tokens_per_block, _, _ = _cache_layout_for_triton(nope_cache)
+        rope_tokens_per_block, _, _ = _cache_layout_for_triton(rope_cache)
+        scale_tokens_per_block, _, _ = _cache_layout_for_triton(scale_cache)
+    except ValueError as exc:
+        return str(exc)
+    if tokens_per_block <= 0:
+        return f"nope_cache tokens_per_block must be positive, got {tokens_per_block}"
+    if rope_tokens_per_block != tokens_per_block:
+        return "rope_cache tokens_per_block must match nope_cache"
+    if scale_tokens_per_block != tokens_per_block:
+        return "scale_cache tokens_per_block must match nope_cache"
+    if active_tokens is not None:
+        if active_tokens <= 0:
+            return f"active_tokens must be positive, got {active_tokens}"
+        if active_tokens > q.shape[0]:
+            return f"active_tokens ({active_tokens}) exceed decode batch capacity ({q.shape[0]})"
+        if input_pos_host.numel() < active_tokens:
+            return (
+                f"input_pos_host needs at least {active_tokens} entries, "
+                f"got {input_pos_host.numel()}"
+            )
+        if cu_num_pages_host.numel() < active_tokens + 1:
+            return (
+                f"cu_num_pages_host needs at least {active_tokens + 1} entries, "
+                f"got {cu_num_pages_host.numel()}"
+            )
+
+    return None
+
+
+@triton.jit
+def _update_ratio0_swa_cache_kernel(
+    kv_ptr,
+    input_pos_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    swa_cache_ptr,
+    kv_stride_batch: tl.constexpr,
+    kv_stride_seq: tl.constexpr,
+    kv_stride_dim: tl.constexpr,
+    cache_page_stride: tl.constexpr,
+    cache_token_stride: tl.constexpr,
+    tokens_per_block: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+
+    input_pos = tl.load(input_pos_ptr + token_idx)
+    page_ordinal = input_pos // tokens_per_block
+    token_offset = input_pos - page_ordinal * tokens_per_block
+    page_table_start = tl.load(cu_num_pages_ptr + token_idx)
+    page_idx = tl.load(cache_loc_ptr + page_table_start + page_ordinal).to(tl.int64)
+
+    kv_offsets = token_idx * kv_stride_batch + dim_offsets * kv_stride_dim
+    kv_values = tl.load(kv_ptr + kv_offsets, mask=dim_mask, other=0.0)
+    cache_offsets = page_idx * cache_page_stride + token_offset * cache_token_stride + dim_offsets
+    tl.store(swa_cache_ptr + cache_offsets, kv_values, mask=dim_mask)
+
+
+@triton.jit
+def _ratio0_swa_attention_kernel(
+    q_ptr,
+    attn_sink_ptr,
+    topk_idxs_ptr,
+    input_pos_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    swa_cache_ptr,
+    out_ptr,
+    q_stride_batch: tl.constexpr,
+    q_stride_seq: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    q_stride_dim: tl.constexpr,
+    topk_stride_batch: tl.constexpr,
+    topk_stride_seq: tl.constexpr,
+    topk_stride_idx: tl.constexpr,
+    out_stride_batch: tl.constexpr,
+    out_stride_seq: tl.constexpr,
+    out_stride_head: tl.constexpr,
+    out_stride_dim: tl.constexpr,
+    cache_page_stride: tl.constexpr,
+    cache_token_stride: tl.constexpr,
+    tokens_per_block: tl.constexpr,
+    active_tokens: tl.constexpr,
+    softmax_scale: tl.constexpr,
+    head_dim: tl.constexpr,
+    topk_width: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+    token_is_active = token_idx < active_tokens
+
+    out_offsets = (
+        token_idx * out_stride_batch + head_idx * out_stride_head + dim_offsets * out_stride_dim
+    )
+    if not token_is_active:
+        tl.store(out_ptr + out_offsets, tl.zeros([block_dim], dtype=tl.float32), mask=dim_mask)
+        return
+
+    q_offsets = token_idx * q_stride_batch + head_idx * q_stride_head + dim_offsets * q_stride_dim
+    q_vec = tl.load(q_ptr + q_offsets, mask=dim_mask, other=0.0).to(tl.float32)
+
+    acc = tl.zeros([block_dim], dtype=tl.float32)
+    m_i = tl.load(attn_sink_ptr + head_idx).to(tl.float32)
+    l_i = tl.full((), 1.0, dtype=tl.float32)
+    page_table_start = tl.load(cu_num_pages_ptr + token_idx)
+
+    for topk_offset in range(topk_width):
+        topk = tl.load(
+            topk_idxs_ptr + token_idx * topk_stride_batch + topk_offset * topk_stride_idx
+        )
+        valid_topk = topk >= 0
+        row_pos = topk.to(tl.int64)
+        page_ordinal = row_pos // tokens_per_block
+        token_offset = row_pos - page_ordinal * tokens_per_block
+        page_idx = tl.load(
+            cache_loc_ptr + page_table_start + page_ordinal,
+            mask=valid_topk,
+            other=0,
+        ).to(tl.int64)
+        cache_offsets = (
+            page_idx * cache_page_stride + token_offset * cache_token_stride + dim_offsets
+        )
+        kv_vec = tl.load(swa_cache_ptr + cache_offsets, mask=dim_mask & valid_topk, other=0.0).to(
+            tl.float32
+        )
+        logit = tl.sum(q_vec * kv_vec, axis=0) * softmax_scale
+        logit = tl.where(valid_topk, logit, float("-inf"))
+
+        m_next = tl.maximum(m_i, logit)
+        alpha = tl.exp(m_i - m_next)
+        beta = tl.exp(logit - m_next)
+        acc = acc * alpha + kv_vec * beta
+        l_i = l_i * alpha + beta
+        m_i = m_next
+
+    output = acc / l_i
+    tl.store(out_ptr + out_offsets, output, mask=dim_mask)
+
+
+@triton.jit
+def _ratio0_swa_fp8_attention_kernel(
+    q_ptr,
+    attn_sink_ptr,
+    topk_idxs_ptr,
+    cache_loc_ptr,
+    cu_num_pages_ptr,
+    nope_cache_ptr,
+    rope_cache_ptr,
+    scale_cache_ptr,
+    out_ptr,
+    q_stride_batch: tl.constexpr,
+    q_stride_head: tl.constexpr,
+    q_stride_dim: tl.constexpr,
+    topk_stride_batch: tl.constexpr,
+    topk_stride_idx: tl.constexpr,
+    out_stride_batch: tl.constexpr,
+    out_stride_head: tl.constexpr,
+    out_stride_dim: tl.constexpr,
+    nope_cache_page_stride: tl.constexpr,
+    nope_cache_token_stride: tl.constexpr,
+    rope_cache_page_stride: tl.constexpr,
+    rope_cache_token_stride: tl.constexpr,
+    scale_cache_page_stride: tl.constexpr,
+    scale_cache_token_stride: tl.constexpr,
+    tokens_per_block: tl.constexpr,
+    active_tokens: tl.constexpr,
+    softmax_scale: tl.constexpr,
+    head_dim: tl.constexpr,
+    nope_dim: tl.constexpr,
+    fp8_block_size: tl.constexpr,
+    topk_width: tl.constexpr,
+    block_dim: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+    dim_offsets = tl.arange(0, block_dim)
+    dim_mask = dim_offsets < head_dim
+    nope_dim_mask = dim_offsets < nope_dim
+    rope_dim_mask = (dim_offsets >= nope_dim) & dim_mask
+    token_is_active = token_idx < active_tokens
+
+    out_offsets = (
+        token_idx * out_stride_batch + head_idx * out_stride_head + dim_offsets * out_stride_dim
+    )
+    if not token_is_active:
+        tl.store(out_ptr + out_offsets, tl.zeros([block_dim], dtype=tl.float32), mask=dim_mask)
+        return
+
+    q_offsets = token_idx * q_stride_batch + head_idx * q_stride_head + dim_offsets * q_stride_dim
+    q_vec = tl.load(q_ptr + q_offsets, mask=dim_mask, other=0.0).to(tl.float32)
+
+    acc = tl.zeros([block_dim], dtype=tl.float32)
+    m_i = tl.load(attn_sink_ptr + head_idx).to(tl.float32)
+    l_i = tl.full((), 1.0, dtype=tl.float32)
+    page_table_start = tl.load(cu_num_pages_ptr + token_idx)
+
+    for topk_offset in range(topk_width):
+        topk = tl.load(
+            topk_idxs_ptr + token_idx * topk_stride_batch + topk_offset * topk_stride_idx
+        )
+        valid_topk = topk >= 0
+        row_pos = topk.to(tl.int64)
+        page_ordinal = row_pos // tokens_per_block
+        token_offset = row_pos - page_ordinal * tokens_per_block
+        page_idx = tl.load(
+            cache_loc_ptr + page_table_start + page_ordinal,
+            mask=valid_topk,
+            other=0,
+        ).to(tl.int64)
+
+        scale_offsets = (
+            page_idx * scale_cache_page_stride
+            + token_offset * scale_cache_token_stride
+            + dim_offsets // fp8_block_size
+        )
+        scale_exp_bits = tl.load(
+            scale_cache_ptr + scale_offsets,
+            mask=nope_dim_mask & valid_topk,
+            other=127,
+        ).to(tl.float32)
+        scale = tl.exp2(scale_exp_bits - 127.0)
+
+        nope_offsets = (
+            page_idx * nope_cache_page_stride + token_offset * nope_cache_token_stride + dim_offsets
+        )
+        nope_vec = tl.load(
+            nope_cache_ptr + nope_offsets,
+            mask=nope_dim_mask & valid_topk,
+            other=0.0,
+        ).to(tl.float32)
+        nope_vec = nope_vec * scale
+
+        rope_offsets = (
+            page_idx * rope_cache_page_stride
+            + token_offset * rope_cache_token_stride
+            + dim_offsets
+            - nope_dim
+        )
+        rope_vec = tl.load(
+            rope_cache_ptr + rope_offsets,
+            mask=rope_dim_mask & valid_topk,
+            other=0.0,
+        ).to(tl.float32)
+        kv_vec = tl.where(nope_dim_mask, nope_vec, rope_vec)
+
+        logit = tl.sum(q_vec * kv_vec, axis=0) * softmax_scale
+        logit = tl.where(valid_topk, logit, float("-inf"))
+
+        m_next = tl.maximum(m_i, logit)
+        alpha = tl.exp(m_i - m_next)
+        beta = tl.exp(logit - m_next)
+        acc = acc * alpha + kv_vec * beta
+        l_i = l_i * alpha + beta
+        m_i = m_next
+
+    output = acc / l_i
+    tl.store(out_ptr + out_offsets, output, mask=dim_mask)
+
+
+def triton_deepseek_v4_ratio0_swa_attention_with_cache(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    active_tokens: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run ratio-0 DeepSeek V4 cached SWA attention through Triton.
+
+    The path is intentionally decode-only: one query/KV token per active
+    sequence, caller-owned SWA cache pages, and caller-provided local
+    ``topk_idxs``. Unsupported shapes and metadata placements should be filtered
+    by :func:`deepseek_v4_ratio0_swa_triton_skip_reason` before calling here.
+    """
+    reason = deepseek_v4_ratio0_swa_triton_skip_reason(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        window_size,
+        0,
+        out,
+        active_tokens,
+    )
+    if reason is not None:
+        raise RuntimeError(reason)
+
+    tokens_per_block, cache_page_stride, cache_token_stride = _cache_layout_for_triton(swa_cache)
+    output = torch.empty_like(q) if out is None else out
+    block_dim = triton.next_power_of_2(_RATIO0_HEAD_DIM)
+
+    _update_ratio0_swa_cache_kernel[(active_tokens,)](
+        kv,
+        input_pos_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        kv.stride(0),
+        kv.stride(1),
+        kv.stride(2),
+        cache_page_stride,
+        cache_token_stride,
+        tokens_per_block,
+        _RATIO0_HEAD_DIM,
+        block_dim,
+        num_warps=8,
+    )
+    _ratio0_swa_attention_kernel[(q.shape[0], _RATIO0_LOCAL_HEADS)](
+        q,
+        attn_sink,
+        topk_idxs,
+        input_pos_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        output,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q.stride(3),
+        topk_idxs.stride(0),
+        topk_idxs.stride(1),
+        topk_idxs.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        output.stride(3),
+        cache_page_stride,
+        cache_token_stride,
+        tokens_per_block,
+        active_tokens,
+        softmax_scale,
+        _RATIO0_HEAD_DIM,
+        _RATIO0_TOPK_WIDTH,
+        block_dim,
+        num_warps=8,
+    )
+
+    if out is not None:
+        return out.new_empty(0)
+    return output
+
+
+def triton_deepseek_v4_ratio0_swa_attention_with_fp8_cache(
+    q: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    nope_cache: torch.Tensor,
+    rope_cache: torch.Tensor,
+    scale_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    active_tokens: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Run ratio-0 DeepSeek V4 cached SWA attention from split FP8 NoPE cache rows.
+
+    This narrow path consumes caller-populated ``nope_cache`` (FP8 E4M3),
+    ``rope_cache`` (BF16), and ``scale_cache`` (raw E8M0 bytes or E8M0 dtype).
+    It does not update the cache from ``kv``; unsupported inputs raise instead
+    of falling back to the Torch cached reference.
+    """
+    reason = deepseek_v4_ratio0_swa_fp8_triton_skip_reason(
+        q,
+        attn_sink,
+        topk_idxs,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        nope_cache,
+        rope_cache,
+        scale_cache,
+        window_size,
+        out,
+        active_tokens,
+    )
+    if reason is not None:
+        raise RuntimeError(reason)
+
+    tokens_per_block, nope_cache_page_stride, nope_cache_token_stride = _cache_layout_for_triton(
+        nope_cache
+    )
+    _, rope_cache_page_stride, rope_cache_token_stride = _cache_layout_for_triton(rope_cache)
+    scale_cache_bytes = _scale_cache_raw_bytes(scale_cache)
+    _, scale_cache_page_stride, scale_cache_token_stride = _cache_layout_for_triton(
+        scale_cache_bytes
+    )
+
+    output = torch.empty_like(q) if out is None else out
+    block_dim = triton.next_power_of_2(_RATIO0_HEAD_DIM)
+    _ratio0_swa_fp8_attention_kernel[(q.shape[0], _RATIO0_LOCAL_HEADS)](
+        q,
+        attn_sink,
+        topk_idxs,
+        cache_loc_host,
+        cu_num_pages_host,
+        nope_cache,
+        rope_cache,
+        scale_cache_bytes,
+        output,
+        q.stride(0),
+        q.stride(2),
+        q.stride(3),
+        topk_idxs.stride(0),
+        topk_idxs.stride(2),
+        output.stride(0),
+        output.stride(2),
+        output.stride(3),
+        nope_cache_page_stride,
+        nope_cache_token_stride,
+        rope_cache_page_stride,
+        rope_cache_token_stride,
+        scale_cache_page_stride,
+        scale_cache_token_stride,
+        tokens_per_block,
+        active_tokens,
+        softmax_scale,
+        _RATIO0_HEAD_DIM,
+        _RATIO0_NOPE_DIM,
+        _RATIO0_FP8_BLOCK_SIZE,
+        _RATIO0_TOPK_WIDTH,
+        block_dim,
+        num_warps=8,
+    )
+
+    if out is not None:
+        return out.new_empty(0)
+    return output

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -26,6 +26,7 @@ and operates on a purely functional paradigm that is compatible with the torch c
 
 import math
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Dict, List, Literal, Optional, Protocol, Sequence, Set, Tuple, Type, Union
 
 import numpy as np
@@ -39,6 +40,8 @@ from ..utils.logger import ad_logger
 from ..utils.node_utils import extract_op_args, get_op_schema
 
 Constant = Union[int, float, str, None]
+
+DEEPSEEK_V4_CACHE_RESOURCE_NAMES = ("swa", "mhc", "indexer", "compressor_state")
 
 # Torch dtype → numpy dtype for fast list-to-tensor conversion.
 # numpy's list→array conversion is ~2-3x faster than torch.tensor(list) for large lists.
@@ -70,6 +73,36 @@ def _extract_optional_op_arg(node: Node, arg_name: str):
     if arg_name not in schema_arg_names:
         return None
     return extract_op_args(node, arg_name)[0]
+
+
+@dataclass(frozen=True)
+class PagedResourceMetadataNames:
+    """SequenceInfo argument names for one named paged resource."""
+
+    name: str
+    cache_loc: str
+    cu_num_pages: str
+    last_page_len: str
+    seq_len_with_cache: str
+
+    def all_arg_names(self) -> Tuple[str, str, str, str]:
+        """Return all device argument names in stable metadata order."""
+        return (
+            self.cache_loc,
+            self.cu_num_pages,
+            self.last_page_len,
+            self.seq_len_with_cache,
+        )
+
+
+@dataclass(frozen=True)
+class PagedResourceSequenceMetadata:
+    """Host-side page-table metadata for one named paged resource."""
+
+    cache_loc: Union[Sequence[int], torch.Tensor]
+    cu_num_pages: Union[Sequence[int], torch.Tensor]
+    seq_len_with_cache: Optional[Union[Sequence[int], torch.Tensor]] = None
+    last_page_len: Optional[Union[Sequence[int], torch.Tensor]] = None
 
 
 class PrepareMetadataHostCallable(Protocol):
@@ -180,6 +213,45 @@ class InputBuffer:
     def tensor_names(self) -> List[str]:
         """Return the list of tensor names in spec order."""
         return self._tensor_order.copy()
+
+    def add_tensor(
+        self,
+        name: str,
+        max_numel: int,
+        dtype: torch.dtype,
+        truncatable: bool = True,
+    ) -> None:
+        """Add a tensor buffer after construction.
+
+        Dynamic additions are used for optional metadata families, such as DeepSeek V4's named
+        page tables. They are kept as independent truncatable buffers so existing contiguous buffer
+        views and offsets remain stable.
+        """
+        if name in self._tensor_specs:
+            old_numel, old_dtype = self._tensor_specs[name]
+            assert old_numel == max_numel and old_dtype == dtype, (
+                f"Existing tensor spec for {name} differs: {(old_numel, old_dtype)} "
+                f"!= {(max_numel, dtype)}"
+            )
+            return
+
+        if not truncatable:
+            raise ValueError("Dynamically added tensors must be truncatable.")
+
+        self._tensor_specs[name] = (max_numel, dtype)
+        self._tensor_order.append(name)
+        self._current_lengths[name] = 0
+        self._truncatable_names.add(name)
+
+        byte_size = max_numel * dtype.itemsize
+        self._trunc_device_bufs[name] = torch.empty(
+            byte_size, dtype=torch.uint8, device=self.device
+        )
+        self._trunc_host_bufs[name] = torch.empty(
+            byte_size, dtype=torch.uint8, device="cpu", pin_memory=prefer_pinned()
+        )
+        self._device_views[name] = self._trunc_device_bufs[name].view(dtype)
+        self._host_views[name] = self._trunc_host_bufs[name].view(dtype)
 
     @property
     def total_bytes(self) -> int:
@@ -678,6 +750,8 @@ class SequenceInfo:
             | {name + self._host_suffix for name in self._input_buffer.tensor_names}
             | {"batch_info_host"}
         )
+        self._paged_resource_metadata: Dict[str, PagedResourceMetadataNames] = {}
+        self._paged_resource_tokens_per_block: Dict[str, int] = {}
 
         # active args that are included in the graph inputs
         self._active_args = ("input_ids", "position_ids")
@@ -785,6 +859,81 @@ class SequenceInfo:
     def available_args(self) -> Set[str]:
         """Return a list of available arguments."""
         return self._available_args
+
+    @staticmethod
+    def _validate_paged_resource_name(name: str) -> None:
+        """Validate a name used to derive SequenceInfo argument names."""
+        assert name and name.replace("_", "").isalnum(), f"Invalid paged resource name: {name}"
+
+    def register_paged_resource_metadata(
+        self,
+        name: str,
+        tokens_per_block: Optional[int] = None,
+        max_pages_per_seq: Optional[int] = None,
+    ) -> PagedResourceMetadataNames:
+        """Register named page-table metadata for a paged resource.
+
+        The standard attention metadata keeps its historical ``cache_loc`` and ``cu_num_pages``
+        names. V4 sparse attention needs multiple page tables with different logical lengths, so
+        this method creates opt-in tensors such as ``swa_cache_loc`` and ``mhc_cu_num_pages``.
+        """
+        self._validate_paged_resource_name(name)
+        resource_tokens_per_block = tokens_per_block or self.tokens_per_block
+        assert resource_tokens_per_block > 0, f"{resource_tokens_per_block=}"
+
+        if name in self._paged_resource_metadata:
+            assert self._paged_resource_tokens_per_block[name] == resource_tokens_per_block, (
+                f"Resource {name} already registered with "
+                f"{self._paged_resource_tokens_per_block[name]} tokens per block."
+            )
+            return self._paged_resource_metadata[name]
+
+        pages_per_seq = max_pages_per_seq or self.max_blocks_per_seq
+        assert pages_per_seq > 0, f"{pages_per_seq=}"
+        max_page_entries = self.max_batch_size * pages_per_seq + 1
+
+        names = PagedResourceMetadataNames(
+            name=name,
+            cache_loc=f"{name}_cache_loc",
+            cu_num_pages=f"{name}_cu_num_pages",
+            last_page_len=f"{name}_last_page_len",
+            seq_len_with_cache=f"{name}_seq_len_with_cache",
+        )
+
+        self._input_buffer.add_tensor(names.cache_loc, max_page_entries, torch.int, True)
+        self._input_buffer.add_tensor(names.cu_num_pages, self.max_batch_size + 1, torch.int, True)
+        self._input_buffer.add_tensor(names.last_page_len, self.max_batch_size, torch.int, True)
+        self._input_buffer.add_tensor(
+            names.seq_len_with_cache, self.max_batch_size, torch.int, True
+        )
+
+        for arg_name in names.all_arg_names():
+            self._available_args.add(arg_name)
+            self._available_args.add(arg_name + self._host_suffix)
+
+        self._paged_resource_metadata[name] = names
+        self._paged_resource_tokens_per_block[name] = resource_tokens_per_block
+        return names
+
+    def get_paged_resource_metadata_names(self, name: str) -> PagedResourceMetadataNames:
+        """Return SequenceInfo argument names for a registered paged resource."""
+        assert name in self._paged_resource_metadata, f"Unknown paged resource metadata: {name}"
+        return self._paged_resource_metadata[name]
+
+    def get_paged_resource_args(
+        self, name: str, host: bool = False, truncate: bool = True
+    ) -> Dict[str, torch.Tensor]:
+        """Return page-table tensors for a registered paged resource by resource name."""
+        suffix = self._host_suffix if host else ""
+        names = self.get_paged_resource_metadata_names(name)
+        return {
+            "cache_loc": self.get_arg(names.cache_loc + suffix, truncate=truncate),
+            "cu_num_pages": self.get_arg(names.cu_num_pages + suffix, truncate=truncate),
+            "last_page_len": self.get_arg(names.last_page_len + suffix, truncate=truncate),
+            "seq_len_with_cache": self.get_arg(
+                names.seq_len_with_cache + suffix, truncate=truncate
+            ),
+        }
 
     @property
     def named_args(self) -> Dict[str, torch.Tensor]:
@@ -1012,6 +1161,68 @@ class SequenceInfo:
             name = name.removesuffix(self._host_suffix)
             self._input_buffer.stage(name, data, fill_value=reset_val)
 
+    @staticmethod
+    def _metadata_to_host_int_tensor(
+        data: Union[Sequence[int], torch.Tensor],
+    ) -> torch.Tensor:
+        """Convert page metadata to a 1-D CPU int tensor."""
+        if isinstance(data, torch.Tensor):
+            return data.detach().cpu().to(torch.int).flatten()
+        return _list_to_tensor(list(data), torch.int)
+
+    def _stage_paged_resource_metadata(
+        self,
+        paged_resource_metadata: Optional[Dict[str, PagedResourceSequenceMetadata]],
+    ) -> None:
+        """Stage page-table metadata for registered named paged resources."""
+        metadata_by_name = paged_resource_metadata or {}
+
+        for resource_name in metadata_by_name:
+            assert resource_name in self._paged_resource_metadata, (
+                f"Unknown paged resource metadata {resource_name}. Registered resources: "
+                f"{tuple(self._paged_resource_metadata)}"
+            )
+
+        for resource_name, names in self._paged_resource_metadata.items():
+            metadata = metadata_by_name.get(resource_name)
+            if metadata is None:
+                missing_required = [
+                    arg_name for arg_name in names.all_arg_names() if self._is_required(arg_name)
+                ]
+                assert not missing_required, (
+                    f"Paged resource metadata for {resource_name} is required: {missing_required}"
+                )
+                continue
+
+            assert len(metadata.cache_loc) >= int(
+                self._metadata_to_host_int_tensor(metadata.cu_num_pages)[-1].item()
+            ), f"cache_loc for {resource_name} is shorter than cu_num_pages requires."
+
+            self._stage_arg(names.cache_loc, metadata.cache_loc)
+            self._stage_arg(names.cu_num_pages, metadata.cu_num_pages)
+
+            seq_len_with_cache = metadata.seq_len_with_cache
+            seq_len_tensor = None
+            if seq_len_with_cache is not None:
+                seq_len_tensor = self._metadata_to_host_int_tensor(seq_len_with_cache)
+                self._stage_arg(names.seq_len_with_cache, seq_len_tensor)
+            elif self._is_required(names.seq_len_with_cache):
+                raise AssertionError(f"{names.seq_len_with_cache} is required for {resource_name}")
+
+            last_page_len = metadata.last_page_len
+            if last_page_len is None and seq_len_tensor is not None:
+                tokens_per_block = self._paged_resource_tokens_per_block[resource_name]
+                last_page_len_tensor = (seq_len_tensor - 1) % tokens_per_block + 1
+                last_page_len_tensor = torch.where(
+                    seq_len_tensor > 0, last_page_len_tensor, torch.zeros_like(seq_len_tensor)
+                )
+                last_page_len = last_page_len_tensor
+
+            if last_page_len is not None:
+                self._stage_arg(names.last_page_len, last_page_len)
+            elif self._is_required(names.last_page_len):
+                raise AssertionError(f"{names.last_page_len} is required for {resource_name}")
+
     def _store_extra_arg(
         self, name: str, tnsr_like: Optional[Union[torch.Tensor, Sequence[torch.Tensor]]]
     ) -> None:
@@ -1045,6 +1256,7 @@ class SequenceInfo:
         batch_info: Union[Sequence[int], torch.Tensor, None] = None,
         cache_loc: Union[Sequence[int], torch.Tensor, None] = None,
         cu_num_pages: Union[Sequence[int], torch.Tensor, None] = None,
+        paged_resource_metadata: Optional[Dict[str, PagedResourceSequenceMetadata]] = None,
         extra_page_per_seq: Optional[Sequence[int]] = None,
         slot_idx: Union[Sequence[int], torch.Tensor, None] = None,
         ### RUNTIME ARGUMENTS ######################################################################
@@ -1072,6 +1284,8 @@ class SequenceInfo:
                 cu_num_pages.
             cu_num_pages: Cumulative number of pages for all sequences. Must be provided together with
                 cache_loc.
+            paged_resource_metadata: Optional page-table metadata for named paged resources, keyed
+                by resource name. Used by cache families that need multiple logical page tables.
             extra_page_per_seq: Extra page per sequence for deferred page insertion.
             slot_idx: State slot index for each sequence in the batch.
             gather_context_logits: If True, keep all context logits (no selective gathering).
@@ -1140,6 +1354,7 @@ class SequenceInfo:
         self._stage_arg("cu_num_pages", cu_num_pages)
         lpl_host = (ip_host + sl_host - 1) % self.tokens_per_block + 1
         self._stage_arg("last_page_len", lpl_host)
+        self._stage_paged_resource_metadata(paged_resource_metadata)
 
         # check for updated slot_idx
         self._stage_arg("slot_idx", slot_idx)
@@ -1588,6 +1803,177 @@ class KVPagedResourceHandler(ResourceHandler):
             )
         else:
             raise ValueError(f"Invalid kv_layout: {self.kv_layout}")
+
+
+class DeepSeekV4PagedResourceHandler(ResourceHandler):
+    """Handler for DeepSeek V4 paged resources with named page-table metadata.
+
+    These resources are not standard dense KV tensors and therefore are not claimed by
+    ``KVCacheManager``. They still report ``is_paged=True`` so V4 long-lived cache data does not
+    fall back to unpaged ``[max_batch, max_seq, ...]`` allocation.
+    """
+
+    @property
+    def is_paged(self) -> bool:
+        """Whether the resource is paged."""
+        return True
+
+    def __init__(
+        self,
+        resource_name: str,
+        token_shape: Sequence[int],
+        dtype: torch.dtype,
+        logical_length_divisor: int = 1,
+        tokens_per_block: Optional[int] = None,
+        max_logical_entries_per_seq: Optional[int] = None,
+    ) -> None:
+        """Initialize a DeepSeek V4 paged resource handler.
+
+        Args:
+            resource_name: Stable resource metadata name, such as ``swa`` or ``mhc``.
+            token_shape: Shape of one logical cache entry.
+            dtype: Data type of the cache entries.
+            logical_length_divisor: Number of original tokens represented by one logical entry.
+            tokens_per_block: Page size for this resource. Defaults to SequenceInfo tokens/block.
+            max_logical_entries_per_seq: Optional explicit per-sequence logical capacity.
+        """
+        assert resource_name in DEEPSEEK_V4_CACHE_RESOURCE_NAMES, (
+            f"Unexpected DeepSeek V4 cache resource {resource_name}."
+        )
+        assert logical_length_divisor > 0, f"{logical_length_divisor=}"
+        if tokens_per_block is not None:
+            assert tokens_per_block > 0, f"{tokens_per_block=}"
+        if max_logical_entries_per_seq is not None:
+            assert max_logical_entries_per_seq > 0, f"{max_logical_entries_per_seq=}"
+
+        self.resource_name = resource_name
+        self.token_shape = tuple(token_shape)
+        self.dtype = dtype
+        self.logical_length_divisor = logical_length_divisor
+        self.tokens_per_block = tokens_per_block
+        self.max_logical_entries_per_seq = max_logical_entries_per_seq
+
+    def _resource_tokens_per_block(self, sequence_info: SequenceInfo) -> int:
+        return self.tokens_per_block or sequence_info.tokens_per_block
+
+    def max_logical_entries(self, sequence_info: SequenceInfo) -> int:
+        """Return per-sequence logical capacity for this resource."""
+        if self.max_logical_entries_per_seq is not None:
+            return self.max_logical_entries_per_seq
+        return math.ceil(sequence_info.max_seq_len / self.logical_length_divisor)
+
+    def max_pages_per_seq(self, sequence_info: SequenceInfo) -> int:
+        """Return per-sequence page capacity for this resource."""
+        return math.ceil(
+            self.max_logical_entries(sequence_info) / self._resource_tokens_per_block(sequence_info)
+        )
+
+    def register_metadata(self, sequence_info: SequenceInfo) -> PagedResourceMetadataNames:
+        """Register SequenceInfo metadata tensors needed to index this resource."""
+        return sequence_info.register_paged_resource_metadata(
+            self.resource_name,
+            tokens_per_block=self._resource_tokens_per_block(sequence_info),
+            max_pages_per_seq=self.max_pages_per_seq(sequence_info),
+        )
+
+    def _get_bytes_per_token(self) -> int:
+        """Approximate bytes per original token for capacity estimation."""
+        bytes_per_entry = math.prod(self.token_shape) * self.dtype.itemsize
+        return math.ceil(bytes_per_entry / self.logical_length_divisor)
+
+    def allocate(self, sequence_info: SequenceInfo) -> torch.Tensor:
+        """Allocate a paged local pool for this V4 resource."""
+        tokens_per_block = self._resource_tokens_per_block(sequence_info)
+        num_pages = sequence_info.max_batch_size * self.max_pages_per_seq(sequence_info) + 1
+        return torch.empty(
+            num_pages,
+            tokens_per_block,
+            *self.token_shape,
+            device=sequence_info.device,
+            dtype=self.dtype,
+        )
+
+    def __eq__(self, other: Optional[ResourceHandler]) -> bool:
+        """Check whether two V4 paged resources have identical allocation metadata."""
+        if type(other) is not type(self):
+            return False
+        return (
+            self.resource_name == other.resource_name
+            and self.token_shape == other.token_shape
+            and self.dtype == other.dtype
+            and self.logical_length_divisor == other.logical_length_divisor
+            and self.tokens_per_block == other.tokens_per_block
+            and self.max_logical_entries_per_seq == other.max_logical_entries_per_seq
+        )
+
+
+@dataclass(frozen=True)
+class DeepSeekV4CacheResourceDescriptor:
+    """Descriptor for one DeepSeek V4 paged cache resource."""
+
+    resource_name: str
+    cache_suffix: str
+    token_shape: Tuple[int, ...]
+    dtype: torch.dtype
+    logical_length_divisor: int = 1
+    tokens_per_block: Optional[int] = None
+    max_logical_entries_per_seq: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        assert self.resource_name in DEEPSEEK_V4_CACHE_RESOURCE_NAMES, (
+            f"Unexpected DeepSeek V4 cache resource {self.resource_name}."
+        )
+        assert self.logical_length_divisor > 0, f"{self.logical_length_divisor=}"
+
+    def create_handler(self) -> DeepSeekV4PagedResourceHandler:
+        """Create the resource handler represented by this descriptor."""
+        return DeepSeekV4PagedResourceHandler(
+            resource_name=self.resource_name,
+            token_shape=self.token_shape,
+            dtype=self.dtype,
+            logical_length_divisor=self.logical_length_divisor,
+            tokens_per_block=self.tokens_per_block,
+            max_logical_entries_per_seq=self.max_logical_entries_per_seq,
+        )
+
+    def logical_lengths(self, token_lengths: Union[Sequence[int], torch.Tensor]) -> torch.Tensor:
+        """Convert token lengths to this resource's logical lengths."""
+        if isinstance(token_lengths, torch.Tensor):
+            lengths = token_lengths.detach().cpu().to(torch.int)
+        else:
+            lengths = _list_to_tensor(list(token_lengths), torch.int)
+        return torch.div(
+            lengths + self.logical_length_divisor - 1,
+            self.logical_length_divisor,
+            rounding_mode="floor",
+        )
+
+    def page_counts(self, token_lengths: Union[Sequence[int], torch.Tensor]) -> torch.Tensor:
+        """Return page counts for token lengths under this descriptor."""
+        logical_lengths = self.logical_lengths(token_lengths)
+        tokens_per_block = self.tokens_per_block or 1
+        return torch.div(
+            logical_lengths + tokens_per_block - 1,
+            tokens_per_block,
+            rounding_mode="floor",
+        )
+
+    def build_metadata(
+        self,
+        page_assignments: Sequence[Sequence[int]],
+        token_lengths: Union[Sequence[int], torch.Tensor],
+    ) -> PagedResourceSequenceMetadata:
+        """Build flattened page metadata from nested page assignments."""
+        cu_num_pages = [0]
+        cache_loc: List[int] = []
+        for pages in page_assignments:
+            cache_loc.extend(pages)
+            cu_num_pages.append(cu_num_pages[-1] + len(pages))
+        return PagedResourceSequenceMetadata(
+            cache_loc=cache_loc,
+            cu_num_pages=cu_num_pages,
+            seq_len_with_cache=self.logical_lengths(token_lengths),
+        )
 
 
 class StateResourceHandler(ResourceHandler):

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -289,6 +289,13 @@ class InputBuffer:
         """Get the current stored length for the specified tensor."""
         return self._current_lengths[name]
 
+    def set_current_length(self, name: str, length: int) -> None:
+        """Set the current stored length for the specified tensor."""
+        assert 0 <= length <= self.get_capacity(name), (
+            f"Invalid current length for {name}: {length}"
+        )
+        self._current_lengths[name] = length
+
     def stage(
         self,
         name: str,
@@ -752,6 +759,9 @@ class SequenceInfo:
         )
         self._paged_resource_metadata: Dict[str, PagedResourceMetadataNames] = {}
         self._paged_resource_tokens_per_block: Dict[str, int] = {}
+        self._paged_resource_max_pages_per_seq: Dict[str, int] = {}
+        self._paged_resource_logical_length_divisor: Dict[str, int] = {}
+        self._paged_resource_advance_on_decode: Dict[str, bool] = {}
 
         # active args that are included in the graph inputs
         self._active_args = ("input_ids", "position_ids")
@@ -870,6 +880,8 @@ class SequenceInfo:
         name: str,
         tokens_per_block: Optional[int] = None,
         max_pages_per_seq: Optional[int] = None,
+        logical_length_divisor: int = 1,
+        advance_on_decode: bool = True,
     ) -> PagedResourceMetadataNames:
         """Register named page-table metadata for a paged resource.
 
@@ -880,16 +892,29 @@ class SequenceInfo:
         self._validate_paged_resource_name(name)
         resource_tokens_per_block = tokens_per_block or self.tokens_per_block
         assert resource_tokens_per_block > 0, f"{resource_tokens_per_block=}"
+        pages_per_seq = max_pages_per_seq or self.max_blocks_per_seq
+        assert pages_per_seq > 0, f"{pages_per_seq=}"
+        assert logical_length_divisor > 0, f"{logical_length_divisor=}"
 
         if name in self._paged_resource_metadata:
             assert self._paged_resource_tokens_per_block[name] == resource_tokens_per_block, (
                 f"Resource {name} already registered with "
                 f"{self._paged_resource_tokens_per_block[name]} tokens per block."
             )
+            assert self._paged_resource_max_pages_per_seq[name] == pages_per_seq, (
+                f"Resource {name} already registered with "
+                f"{self._paged_resource_max_pages_per_seq[name]} max pages per sequence."
+            )
+            assert self._paged_resource_logical_length_divisor[name] == logical_length_divisor, (
+                f"Resource {name} already registered with "
+                f"{self._paged_resource_logical_length_divisor[name]} logical length divisor."
+            )
+            assert self._paged_resource_advance_on_decode[name] == advance_on_decode, (
+                f"Resource {name} already registered with "
+                f"{self._paged_resource_advance_on_decode[name]} advance_on_decode."
+            )
             return self._paged_resource_metadata[name]
 
-        pages_per_seq = max_pages_per_seq or self.max_blocks_per_seq
-        assert pages_per_seq > 0, f"{pages_per_seq=}"
         max_page_entries = self.max_batch_size * pages_per_seq + 1
 
         names = PagedResourceMetadataNames(
@@ -913,6 +938,9 @@ class SequenceInfo:
 
         self._paged_resource_metadata[name] = names
         self._paged_resource_tokens_per_block[name] = resource_tokens_per_block
+        self._paged_resource_max_pages_per_seq[name] = pages_per_seq
+        self._paged_resource_logical_length_divisor[name] = logical_length_divisor
+        self._paged_resource_advance_on_decode[name] = advance_on_decode
         return names
 
     def get_paged_resource_metadata_names(self, name: str) -> PagedResourceMetadataNames:
@@ -1223,6 +1251,118 @@ class SequenceInfo:
             elif self._is_required(names.last_page_len):
                 raise AssertionError(f"{names.last_page_len} is required for {resource_name}")
 
+    def _has_staged_paged_resource_metadata(
+        self, names: PagedResourceMetadataNames, num_sequences: int
+    ) -> bool:
+        """Return whether enough named metadata is staged for the current batch."""
+        return (
+            self._input_buffer.get_current_length(names.cu_num_pages) >= num_sequences + 1
+            and self._input_buffer.get_current_length(names.last_page_len) >= num_sequences
+            and self._input_buffer.get_current_length(names.seq_len_with_cache) >= num_sequences
+        )
+
+    def _adjust_ragged_cache_(
+        self,
+        cache_loc_name: str,
+        cache_loc: torch.Tensor,
+        cu_num_pages: torch.Tensor,
+        extra_page_per_seq: torch.Tensor,
+        delta: torch.Tensor,
+        num_sequences: int,
+        max_pages_per_seq: int,
+    ) -> None:
+        """Adjust ragged page metadata, using the Torch fallback for CPU tensors."""
+        if delta.device.type == "cpu" and not bool((delta[:num_sequences] != 0).any().item()):
+            return
+
+        adjust_ragged = (
+            torch.ops.auto_deploy.adjust_ragged_torch
+            if cache_loc.device.type == "cpu"
+            else torch.ops.auto_deploy.adjust_ragged_triton
+        )
+        adjust_ragged(
+            cache_loc=cache_loc,
+            cu_num_blocks=cu_num_pages,
+            extra_idx=extra_page_per_seq,
+            delta=delta,
+            num_sequences=num_sequences,
+            max_blocks_per_seq=max_pages_per_seq,
+        )
+        if delta.device.type == "cpu":
+            old_length = self._input_buffer.get_current_length(cache_loc_name)
+            new_length = old_length + int(delta[:num_sequences].sum().item())
+            self._input_buffer.set_current_length(cache_loc_name, new_length)
+        else:
+            self._input_buffer.set_current_length(
+                cache_loc_name, self._input_buffer.get_capacity(cache_loc_name)
+            )
+
+    def _advance_registered_paged_resource_metadata_(
+        self,
+        offset: torch.Tensor,
+        seq_len_with_cache_before: torch.Tensor,
+        num_sequences: int,
+    ) -> None:
+        """Advance registered named paged-resource metadata for decode offsets."""
+        if not self._paged_resource_metadata:
+            return
+
+        offset = offset.to(
+            device=seq_len_with_cache_before.device, dtype=seq_len_with_cache_before.dtype
+        )
+        token_seq_len_with_cache = seq_len_with_cache_before + offset
+        extra_page_per_seq = self.get_arg("extra_page_per_seq")
+
+        for resource_name, names in self._paged_resource_metadata.items():
+            if not self._paged_resource_advance_on_decode[resource_name]:
+                continue
+
+            if not self._has_staged_paged_resource_metadata(names, num_sequences):
+                missing_required = [
+                    arg_name for arg_name in names.all_arg_names() if self._is_required(arg_name)
+                ]
+                assert not missing_required, (
+                    f"Paged resource metadata for {resource_name} is required before decode "
+                    f"advancement: {missing_required}"
+                )
+                continue
+
+            divisor = self._paged_resource_logical_length_divisor[resource_name]
+            target_seq_len = torch.div(
+                token_seq_len_with_cache + divisor - 1,
+                divisor,
+                rounding_mode="floor",
+            )
+
+            seq_len_with_cache = self.get_arg(names.seq_len_with_cache, truncate=True)
+            resource_offset = target_seq_len.to(seq_len_with_cache.dtype) - seq_len_with_cache
+            seq_len_with_cache.copy_(target_seq_len.to(seq_len_with_cache.dtype))
+
+            tokens_per_block = self._paged_resource_tokens_per_block[resource_name]
+            last_page_len = self.get_arg(names.last_page_len, truncate=True)
+            last_page_len += resource_offset.to(last_page_len.dtype)
+            valid_page = seq_len_with_cache > 0
+            delta = torch.where(
+                valid_page,
+                (last_page_len > tokens_per_block).int() - (last_page_len <= 0).int(),
+                torch.zeros_like(last_page_len, dtype=torch.int),
+            )
+
+            self._adjust_ragged_cache_(
+                cache_loc_name=names.cache_loc,
+                cache_loc=self.get_arg(names.cache_loc),
+                cu_num_pages=self.get_arg(names.cu_num_pages),
+                extra_page_per_seq=extra_page_per_seq,
+                delta=delta,
+                num_sequences=num_sequences,
+                max_pages_per_seq=self._paged_resource_max_pages_per_seq[resource_name],
+            )
+
+            wrapped_last_page_len = (last_page_len - 1) % tokens_per_block + 1
+            last_page_len.copy_(
+                torch.where(valid_page, wrapped_last_page_len, torch.zeros_like(last_page_len))
+            )
+
     def _store_extra_arg(
         self, name: str, tnsr_like: Optional[Union[torch.Tensor, Sequence[torch.Tensor]]]
     ) -> None:
@@ -1529,6 +1669,8 @@ class SequenceInfo:
             "seq_len_with_cache",
             "use_initial_states",
         }
+        for names in self._paged_resource_metadata.values():
+            _REQUIRES_UPDATE.update(names.all_arg_names())
         needs_d2h_sync = [
             k + self._host_suffix
             for k in _REQUIRES_UPDATE
@@ -1551,13 +1693,14 @@ class SequenceInfo:
             last_page_len = self.get_arg("last_page_len", truncate=True)
             last_page_len += offset
             delta = (last_page_len > self.tokens_per_block).int() - (last_page_len <= 0).int()
-            torch.ops.auto_deploy.adjust_ragged_triton(
+            self._adjust_ragged_cache_(
+                cache_loc_name="cache_loc",
                 cache_loc=self.get_arg("cache_loc"),
-                cu_num_blocks=self.get_arg("cu_num_pages"),
-                extra_idx=self.get_arg("extra_page_per_seq"),
+                cu_num_pages=self.get_arg("cu_num_pages"),
+                extra_page_per_seq=self.get_arg("extra_page_per_seq"),
                 delta=delta,
                 num_sequences=num_sequences,
-                max_blocks_per_seq=self.max_blocks_per_seq,
+                max_pages_per_seq=self.max_blocks_per_seq,
             )
             last_page_len -= 1
             last_page_len %= self.tokens_per_block
@@ -1575,6 +1718,8 @@ class SequenceInfo:
 
         # --- seq_len_with_cache (device) ---
         swc = self.get_arg("seq_len_with_cache", truncate=True)
+        swc_before = swc.clone()
+        self._advance_registered_paged_resource_metadata_(offset, swc_before, num_sequences)
         swc += offset
 
         # --- use_initial_states (device) ---
@@ -1874,6 +2019,8 @@ class DeepSeekV4PagedResourceHandler(ResourceHandler):
             self.resource_name,
             tokens_per_block=self._resource_tokens_per_block(sequence_info),
             max_pages_per_seq=self.max_pages_per_seq(sequence_info),
+            logical_length_divisor=self.logical_length_divisor,
+            advance_on_decode=self.resource_name != "compressor_state",
         )
 
     def _get_bytes_per_token(self) -> int:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_moe.py
@@ -1,0 +1,503 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepSeek V4 MoE source ops.
+
+The production DeepSeek V4 path lowers routed experts to packed MXFP4 kernels and
+the shared expert to FineGrained FP8 linears. This module keeps the exported
+source surface small and testable: the eager implementation is a dense PyTorch
+reference for tiny synthetic tests, while production lowering is handled by the
+transform library.
+"""
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+from .deepseek_v4_router import deepseek_v4_router_reference
+
+__all__ = [
+    "deepseek_v4_limited_swiglu",
+    "deepseek_v4_moe_from_routing_reference",
+    "deepseek_v4_moe_reference",
+    "torch_deepseek_v4_moe",
+    "torch_deepseek_v4_moe_from_routing",
+]
+
+
+def _num_tokens(hidden_states: torch.Tensor) -> int:
+    if hidden_states.dim() < 2:
+        raise ValueError("hidden_states must have shape [T, H] or [B, S, H]")
+    return hidden_states.numel() // hidden_states.shape[-1]
+
+
+def _validate_rank(name: str, tensor: torch.Tensor, rank: int) -> None:
+    if tensor.dim() != rank:
+        raise ValueError(f"{name} must have rank {rank}, got rank {tensor.dim()}")
+
+
+def _validate_device(name: str, tensor: torch.Tensor, device: torch.device) -> None:
+    if tensor.device != device:
+        raise ValueError(f"{name} must be on {device}, got {tensor.device}")
+
+
+def _validate_routed_weights(
+    hidden_size: int,
+    routed_w1_weight: torch.Tensor,
+    routed_w2_weight: torch.Tensor,
+    routed_w3_weight: torch.Tensor,
+) -> tuple[int, int]:
+    _validate_rank("routed_w1_weight", routed_w1_weight, 3)
+    _validate_rank("routed_w2_weight", routed_w2_weight, 3)
+    _validate_rank("routed_w3_weight", routed_w3_weight, 3)
+
+    num_experts, intermediate_size, w1_hidden = routed_w1_weight.shape
+    if w1_hidden != hidden_size:
+        raise ValueError(
+            f"routed_w1_weight hidden dimension must be {hidden_size}, got {w1_hidden}"
+        )
+    if routed_w3_weight.shape != routed_w1_weight.shape:
+        raise ValueError(
+            "routed_w3_weight must match routed_w1_weight shape "
+            f"{tuple(routed_w1_weight.shape)}, got {tuple(routed_w3_weight.shape)}"
+        )
+    expected_w2_shape = (num_experts, hidden_size, intermediate_size)
+    if routed_w2_weight.shape != expected_w2_shape:
+        raise ValueError(
+            "routed_w2_weight must have shape "
+            f"{expected_w2_shape}, got {tuple(routed_w2_weight.shape)}"
+        )
+    return num_experts, intermediate_size
+
+
+def _shared_weights_are_present(
+    shared_w1_weight: Optional[torch.Tensor],
+    shared_w2_weight: Optional[torch.Tensor],
+    shared_w3_weight: Optional[torch.Tensor],
+) -> bool:
+    present = (
+        shared_w1_weight is not None,
+        shared_w2_weight is not None,
+        shared_w3_weight is not None,
+    )
+    if any(present) and not all(present):
+        raise ValueError("shared_w1_weight, shared_w2_weight, and shared_w3_weight must all be set")
+    return all(present)
+
+
+def _validate_shared_weights(
+    hidden_size: int,
+    shared_w1_weight: Optional[torch.Tensor],
+    shared_w2_weight: Optional[torch.Tensor],
+    shared_w3_weight: Optional[torch.Tensor],
+) -> bool:
+    if not _shared_weights_are_present(shared_w1_weight, shared_w2_weight, shared_w3_weight):
+        return False
+
+    assert shared_w1_weight is not None
+    assert shared_w2_weight is not None
+    assert shared_w3_weight is not None
+    _validate_rank("shared_w1_weight", shared_w1_weight, 2)
+    _validate_rank("shared_w2_weight", shared_w2_weight, 2)
+    _validate_rank("shared_w3_weight", shared_w3_weight, 2)
+
+    intermediate_size, w1_hidden = shared_w1_weight.shape
+    if w1_hidden != hidden_size:
+        raise ValueError(
+            f"shared_w1_weight hidden dimension must be {hidden_size}, got {w1_hidden}"
+        )
+    if shared_w3_weight.shape != shared_w1_weight.shape:
+        raise ValueError(
+            "shared_w3_weight must match shared_w1_weight shape "
+            f"{tuple(shared_w1_weight.shape)}, got {tuple(shared_w3_weight.shape)}"
+        )
+    expected_w2_shape = (hidden_size, intermediate_size)
+    if shared_w2_weight.shape != expected_w2_shape:
+        raise ValueError(
+            f"shared_w2_weight must have shape {expected_w2_shape}, "
+            f"got {tuple(shared_w2_weight.shape)}"
+        )
+    return True
+
+
+def _validate_from_routing_inputs(
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    routed_w1_weight: torch.Tensor,
+    routed_w2_weight: torch.Tensor,
+    routed_w3_weight: torch.Tensor,
+    shared_w1_weight: Optional[torch.Tensor],
+    shared_w2_weight: Optional[torch.Tensor],
+    shared_w3_weight: Optional[torch.Tensor],
+    swiglu_limit: float,
+) -> tuple[int, int, bool]:
+    if swiglu_limit < 0:
+        raise ValueError(f"swiglu_limit must be non-negative, got {swiglu_limit}")
+
+    _validate_rank("selected_experts", selected_experts, 2)
+    _validate_rank("routing_weights", routing_weights, 2)
+    if selected_experts.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"selected_experts must be int32 or int64, got {selected_experts.dtype}")
+    if not routing_weights.is_floating_point():
+        raise TypeError(f"routing_weights must be floating point, got {routing_weights.dtype}")
+
+    num_tokens = _num_tokens(hidden_states)
+    hidden_size = hidden_states.shape[-1]
+    if selected_experts.shape[0] != num_tokens:
+        raise ValueError(
+            f"selected_experts token dimension must be {num_tokens}, got {selected_experts.shape[0]}"
+        )
+    if routing_weights.shape != selected_experts.shape:
+        raise ValueError(
+            "routing_weights must match selected_experts shape "
+            f"{tuple(selected_experts.shape)}, got {tuple(routing_weights.shape)}"
+        )
+
+    device = hidden_states.device
+    _validate_device("selected_experts", selected_experts, device)
+    _validate_device("routing_weights", routing_weights, device)
+    for name, tensor in (
+        ("routed_w1_weight", routed_w1_weight),
+        ("routed_w2_weight", routed_w2_weight),
+        ("routed_w3_weight", routed_w3_weight),
+    ):
+        _validate_device(name, tensor, device)
+    for name, tensor in (
+        ("shared_w1_weight", shared_w1_weight),
+        ("shared_w2_weight", shared_w2_weight),
+        ("shared_w3_weight", shared_w3_weight),
+    ):
+        if tensor is not None:
+            _validate_device(name, tensor, device)
+
+    num_experts, _ = _validate_routed_weights(
+        hidden_size, routed_w1_weight, routed_w2_weight, routed_w3_weight
+    )
+    has_shared_expert = _validate_shared_weights(
+        hidden_size, shared_w1_weight, shared_w2_weight, shared_w3_weight
+    )
+    return num_tokens, num_experts, has_shared_expert
+
+
+def deepseek_v4_limited_swiglu(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    swiglu_limit: float,
+) -> torch.Tensor:
+    """Apply DeepSeek V4's routed-expert SwiGLU limit.
+
+    The clamp is unconditional, so ``swiglu_limit=0`` produces a zero ``up``
+    branch and therefore a zero gated hidden state.
+    """
+    if swiglu_limit < 0:
+        raise ValueError(f"swiglu_limit must be non-negative, got {swiglu_limit}")
+    up = torch.clamp(up, min=-swiglu_limit, max=swiglu_limit)
+    gate = torch.clamp(gate, max=swiglu_limit)
+    return F.silu(gate) * up
+
+
+def _expert_mlp(
+    hidden_states: torch.Tensor,
+    w1_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+    w3_weight: torch.Tensor,
+    swiglu_limit: float,
+    *,
+    apply_swiglu_limit: bool,
+) -> torch.Tensor:
+    gate = F.linear(hidden_states.to(w1_weight.dtype), w1_weight).float()
+    up = F.linear(hidden_states.to(w3_weight.dtype), w3_weight).float()
+    if apply_swiglu_limit:
+        activated = deepseek_v4_limited_swiglu(gate, up, swiglu_limit)
+    else:
+        activated = F.silu(gate) * up
+    return F.linear(activated.to(w2_weight.dtype), w2_weight).to(hidden_states.dtype)
+
+
+def deepseek_v4_moe_from_routing_reference(
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    routed_w1_weight: torch.Tensor,
+    routed_w2_weight: torch.Tensor,
+    routed_w3_weight: torch.Tensor,
+    shared_w1_weight: Optional[torch.Tensor],
+    shared_w2_weight: Optional[torch.Tensor],
+    shared_w3_weight: Optional[torch.Tensor],
+    swiglu_limit: float,
+) -> torch.Tensor:
+    """Dense PyTorch reference for DeepSeek V4 MoE with precomputed routing.
+
+    Args:
+        hidden_states: Hidden states with shape ``[T, H]`` or ``[B, S, H]``.
+        selected_experts: Expert ids with shape ``[T, top_k]``.
+        routing_weights: Per-route weights with shape ``[T, top_k]``.
+        routed_w1_weight: Routed gate weights with shape ``[E, I, H]``.
+        routed_w2_weight: Routed down weights with shape ``[E, H, I]``.
+        routed_w3_weight: Routed up weights with shape ``[E, I, H]``.
+        shared_w1_weight: Optional shared gate weight with shape ``[I, H]``.
+        shared_w2_weight: Optional shared down weight with shape ``[H, I]``.
+        shared_w3_weight: Optional shared up weight with shape ``[I, H]``.
+        swiglu_limit: Non-negative routed-expert clamp limit.
+
+    Returns:
+        MoE output with the same shape and dtype as ``hidden_states``.
+    """
+    _, num_experts, has_shared_expert = _validate_from_routing_inputs(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        routed_w1_weight,
+        routed_w2_weight,
+        routed_w3_weight,
+        shared_w1_weight,
+        shared_w2_weight,
+        shared_w3_weight,
+        swiglu_limit,
+    )
+
+    hidden_shape = hidden_states.shape
+    hidden_size = hidden_shape[-1]
+    hidden_flat = hidden_states.reshape(-1, hidden_size)
+    output = torch.zeros_like(hidden_flat)
+
+    valid_mask = (selected_experts >= 0) & (selected_experts < num_experts)
+    selected_fixed = torch.where(
+        valid_mask, selected_experts, torch.full_like(selected_experts, num_experts)
+    )
+    expert_mask = F.one_hot(selected_fixed.long(), num_classes=num_experts + 1)
+    expert_mask = expert_mask[..., :num_experts].permute(2, 1, 0)
+
+    for expert_idx in range(num_experts):
+        route_idx, token_idx = torch.where(expert_mask[expert_idx])
+        if token_idx.numel() == 0:
+            continue
+        expert_input = hidden_flat[None, token_idx].reshape(-1, hidden_size)
+        expert_output = _expert_mlp(
+            expert_input,
+            routed_w1_weight[expert_idx],
+            routed_w2_weight[expert_idx],
+            routed_w3_weight[expert_idx],
+            swiglu_limit,
+            apply_swiglu_limit=True,
+        )
+        scaled = expert_output * routing_weights[token_idx, route_idx, None].to(expert_output.dtype)
+        output.index_add_(0, token_idx, scaled.to(output.dtype))
+
+    if has_shared_expert:
+        assert shared_w1_weight is not None
+        assert shared_w2_weight is not None
+        assert shared_w3_weight is not None
+        shared_output = _expert_mlp(
+            hidden_flat,
+            shared_w1_weight,
+            shared_w2_weight,
+            shared_w3_weight,
+            swiglu_limit,
+            apply_swiglu_limit=False,
+        )
+        output = output + shared_output.to(output.dtype)
+
+    return output.view(hidden_shape)
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_moe_from_routing", mutates_args=())
+def torch_deepseek_v4_moe_from_routing(
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    routed_w1_weight: torch.Tensor,
+    routed_w2_weight: torch.Tensor,
+    routed_w3_weight: torch.Tensor,
+    shared_w1_weight: Optional[torch.Tensor],
+    shared_w2_weight: Optional[torch.Tensor],
+    shared_w3_weight: Optional[torch.Tensor],
+    swiglu_limit: float,
+    layer_type: str = "moe",
+) -> torch.Tensor:
+    """Reference source op for DeepSeek V4 MoE with precomputed routing.
+
+    ``layer_type`` is graph metadata for sharding/lowering transforms and does
+    not affect the eager reference result.
+    """
+    del layer_type
+    return deepseek_v4_moe_from_routing_reference(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        routed_w1_weight,
+        routed_w2_weight,
+        routed_w3_weight,
+        shared_w1_weight,
+        shared_w2_weight,
+        shared_w3_weight,
+        swiglu_limit,
+    )
+
+
+@torch_deepseek_v4_moe_from_routing.register_fake
+def _torch_deepseek_v4_moe_from_routing_fake(
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    routed_w1_weight: torch.Tensor,
+    routed_w2_weight: torch.Tensor,
+    routed_w3_weight: torch.Tensor,
+    shared_w1_weight: Optional[torch.Tensor],
+    shared_w2_weight: Optional[torch.Tensor],
+    shared_w3_weight: Optional[torch.Tensor],
+    swiglu_limit: float,
+    layer_type: str = "moe",
+) -> torch.Tensor:
+    del (
+        selected_experts,
+        routing_weights,
+        routed_w1_weight,
+        routed_w2_weight,
+        routed_w3_weight,
+        shared_w1_weight,
+        shared_w2_weight,
+        shared_w3_weight,
+        swiglu_limit,
+        layer_type,
+    )
+    if hidden_states.dim() < 2:
+        raise ValueError("hidden_states must have shape [T, H] or [B, S, H]")
+    return hidden_states.new_empty(hidden_states.shape).contiguous()
+
+
+def deepseek_v4_moe_reference(
+    hidden_states: torch.Tensor,
+    input_ids: Optional[torch.Tensor],
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    tid2eid: Optional[torch.Tensor],
+    routed_w1_weight: torch.Tensor,
+    routed_w2_weight: torch.Tensor,
+    routed_w3_weight: torch.Tensor,
+    shared_w1_weight: Optional[torch.Tensor],
+    shared_w2_weight: Optional[torch.Tensor],
+    shared_w3_weight: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+    swiglu_limit: float,
+    is_hash_layer: bool,
+) -> torch.Tensor:
+    """Dense PyTorch reference for router-integrated DeepSeek V4 MoE."""
+    selected_experts, routing_weights = deepseek_v4_router_reference(
+        hidden_states,
+        input_ids,
+        router_weight,
+        router_bias,
+        tid2eid,
+        top_k,
+        route_scale,
+        is_hash_layer,
+    )
+    return deepseek_v4_moe_from_routing_reference(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        routed_w1_weight,
+        routed_w2_weight,
+        routed_w3_weight,
+        shared_w1_weight,
+        shared_w2_weight,
+        shared_w3_weight,
+        swiglu_limit,
+    )
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_moe", mutates_args=())
+def torch_deepseek_v4_moe(
+    hidden_states: torch.Tensor,
+    input_ids: Optional[torch.Tensor],
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    tid2eid: Optional[torch.Tensor],
+    routed_w1_weight: torch.Tensor,
+    routed_w2_weight: torch.Tensor,
+    routed_w3_weight: torch.Tensor,
+    shared_w1_weight: Optional[torch.Tensor],
+    shared_w2_weight: Optional[torch.Tensor],
+    shared_w3_weight: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+    swiglu_limit: float,
+    is_hash_layer: bool,
+    layer_type: str = "moe",
+) -> torch.Tensor:
+    """Router-integrated canonical DeepSeek V4 MoE source op."""
+    del layer_type
+    return deepseek_v4_moe_reference(
+        hidden_states,
+        input_ids,
+        router_weight,
+        router_bias,
+        tid2eid,
+        routed_w1_weight,
+        routed_w2_weight,
+        routed_w3_weight,
+        shared_w1_weight,
+        shared_w2_weight,
+        shared_w3_weight,
+        top_k,
+        route_scale,
+        swiglu_limit,
+        is_hash_layer,
+    )
+
+
+@torch_deepseek_v4_moe.register_fake
+def _torch_deepseek_v4_moe_fake(
+    hidden_states: torch.Tensor,
+    input_ids: Optional[torch.Tensor],
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    tid2eid: Optional[torch.Tensor],
+    routed_w1_weight: torch.Tensor,
+    routed_w2_weight: torch.Tensor,
+    routed_w3_weight: torch.Tensor,
+    shared_w1_weight: Optional[torch.Tensor],
+    shared_w2_weight: Optional[torch.Tensor],
+    shared_w3_weight: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+    swiglu_limit: float,
+    is_hash_layer: bool,
+    layer_type: str = "moe",
+) -> torch.Tensor:
+    del (
+        input_ids,
+        router_weight,
+        router_bias,
+        tid2eid,
+        routed_w1_weight,
+        routed_w2_weight,
+        routed_w3_weight,
+        shared_w1_weight,
+        shared_w2_weight,
+        shared_w3_weight,
+        top_k,
+        route_scale,
+        swiglu_limit,
+        is_hash_layer,
+        layer_type,
+    )
+    if hidden_states.dim() < 2:
+        raise ValueError("hidden_states must have shape [T, H] or [B, S, H]")
+    return hidden_states.new_empty(hidden_states.shape).contiguous()

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_router.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_router.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+
+def _num_tokens(hidden_states: torch.Tensor) -> int:
+    if hidden_states.dim() < 2:
+        raise ValueError("hidden_states must have shape [T, H] or [B, S, H]")
+    return hidden_states.numel() // hidden_states.shape[-1]
+
+
+def _normalize_and_scale(weights: torch.Tensor, route_scale: float) -> torch.Tensor:
+    finite_weights = torch.where(torch.isfinite(weights), weights, torch.zeros_like(weights))
+    has_inf = torch.isinf(weights).any(dim=-1, keepdim=True)
+    inf_mask = torch.isinf(weights).to(weights.dtype)
+    inf_count = inf_mask.sum(dim=-1, keepdim=True).clamp_min(1)
+    inf_normalized = inf_mask / inf_count
+
+    row_max = finite_weights.amax(dim=-1, keepdim=True)
+    tiny = torch.finfo(weights.dtype).tiny
+    scaled_weights = finite_weights / row_max.clamp_min(tiny)
+    finite_normalized = scaled_weights / scaled_weights.sum(dim=-1, keepdim=True).clamp_min(tiny)
+    normalized = torch.where(has_inf, inf_normalized, finite_normalized)
+    return normalized * route_scale
+
+
+def deepseek_v4_router_reference(
+    hidden_states: torch.Tensor,
+    input_ids: Optional[torch.Tensor],
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    tid2eid: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+    is_hash_layer: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference DeepSeek V4 sqrtsoftplus router.
+
+    Args:
+        hidden_states: Hidden states with shape ``[T, H]`` or ``[B, S, H]``.
+        input_ids: Token ids with shape ``[T]`` or ``[B, S]``. Required for hash layers.
+        router_weight: Router projection weight with shape ``[E, H]``.
+        router_bias: Optional expert bias with shape ``[E]``. It affects top-k selection only.
+        tid2eid: Hash routing table with shape ``[vocab, top_k]``. Required for hash layers.
+        top_k: Number of experts selected per token.
+        route_scale: Post-normalization routing scale.
+        is_hash_layer: Whether to use ``tid2eid[input_ids]`` instead of score top-k.
+
+    Returns:
+        ``(selected_experts, routing_weights)`` with shapes ``[T, top_k]``.
+    """
+    hidden_dim = hidden_states.shape[-1]
+    hidden_flat = hidden_states.reshape(-1, hidden_dim)
+    logits = F.linear(hidden_flat.float(), router_weight.float())
+    scores = torch.sqrt(F.softplus(logits))
+
+    if is_hash_layer:
+        if input_ids is None:
+            raise ValueError("input_ids is required for DeepSeek V4 hash-routed layers")
+        if tid2eid is None:
+            raise ValueError("tid2eid is required for DeepSeek V4 hash-routed layers")
+        selected_experts = tid2eid[input_ids.reshape(-1).long()]
+        if selected_experts.shape[-1] != top_k:
+            selected_experts = selected_experts[..., :top_k]
+    else:
+        selection_scores = scores
+        if router_bias is not None:
+            selection_scores = selection_scores + router_bias.float()
+        selected_experts = torch.topk(selection_scores, top_k, dim=-1).indices
+
+    weights = scores.gather(1, selected_experts.long())
+    routing_weights = _normalize_and_scale(weights, route_scale)
+    return selected_experts, routing_weights
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_router", mutates_args=())
+def torch_deepseek_v4_router(
+    hidden_states: torch.Tensor,
+    input_ids: Optional[torch.Tensor],
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    tid2eid: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+    is_hash_layer: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return deepseek_v4_router_reference(
+        hidden_states,
+        input_ids,
+        router_weight,
+        router_bias,
+        tid2eid,
+        top_k,
+        route_scale,
+        is_hash_layer,
+    )
+
+
+@torch_deepseek_v4_router.register_fake
+def _torch_deepseek_v4_router_fake(
+    hidden_states: torch.Tensor,
+    input_ids: Optional[torch.Tensor],
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    tid2eid: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+    is_hash_layer: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del input_ids, router_weight, router_bias, route_scale
+
+    num_tokens = _num_tokens(hidden_states)
+    selected_dtype = tid2eid.dtype if is_hash_layer and tid2eid is not None else torch.int64
+    selected_experts = hidden_states.new_empty(
+        (num_tokens, top_k), dtype=selected_dtype, device=hidden_states.device
+    )
+    routing_weights = hidden_states.new_empty(
+        (num_tokens, top_k), dtype=torch.float32, device=hidden_states.device
+    )
+    return selected_experts, routing_weights

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_router.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_router.py
@@ -13,10 +13,283 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import dataclass
 from typing import Optional
 
 import torch
 import torch.nn.functional as F
+
+try:
+    import triton
+    import triton.language as tl
+except ImportError:
+    triton = None
+    tl = None
+
+DEEPSEEK_V4_NUM_ROUTED_EXPERTS = 256
+DEEPSEEK_V4_TOP_K = 6
+DEEPSEEK_V4_ROUTE_SCALE = 1.5
+DEEPSEEK_V4_HASH_ROUTED_LAYER_INDICES = (0, 1, 2)
+DEEPSEEK_V4_OBSERVED_MOE_EP_SIZE = 8
+DEEPSEEK_V4_OBSERVED_EXPERTS_PER_RANK = 32
+_TRITON_MAX_ROUTER_EXPERTS = 4096
+_FLOAT32_TINY = torch.finfo(torch.float32).tiny
+
+
+if triton is not None and tl is not None:
+
+    @triton.jit
+    def _tl_deepseek_v4_sqrt_softplus(logits):
+        softplus = tl.where(logits > 20.0, logits, tl.log(1.0 + tl.exp(logits)))
+        return tl.sqrt(softplus)
+
+    @triton.jit
+    def _tl_deepseek_v4_normalize_and_scale(weights, route_scale, tiny: tl.constexpr):
+        is_finite = (weights == weights) & (weights != float("inf")) & (weights != -float("inf"))
+        is_pos_inf = weights == float("inf")
+        finite_weights = tl.where(is_finite, weights, 0.0)
+
+        inf_count = tl.sum(tl.where(is_pos_inf, 1.0, 0.0), axis=0)
+        inf_normalized = tl.where(is_pos_inf, 1.0 / tl.maximum(inf_count, 1.0), 0.0)
+
+        row_max = tl.max(finite_weights, axis=0)
+        scaled_weights = finite_weights / tl.maximum(row_max, tiny)
+        scaled_sum = tl.sum(scaled_weights, axis=0)
+        finite_normalized = scaled_weights / tl.maximum(scaled_sum, tiny)
+        normalized = tl.where(inf_count > 0.0, inf_normalized, finite_normalized)
+        return normalized * route_scale
+
+    @triton.jit
+    def _deepseek_v4_router_hash_kernel(
+        logits_ptr,
+        input_ids_ptr,
+        tid2eid_ptr,
+        selected_ptr,
+        weights_ptr,
+        num_experts: tl.constexpr,
+        tid2eid_width: tl.constexpr,
+        route_scale,
+        BLOCK_K: tl.constexpr,
+        TOP_K: tl.constexpr,
+        TINY: tl.constexpr,
+    ):
+        token_id = tl.program_id(0)
+        offs_k = tl.arange(0, BLOCK_K)
+        mask_k = offs_k < TOP_K
+
+        input_id = tl.load(input_ids_ptr + token_id).to(tl.int64)
+        selected = tl.load(
+            tid2eid_ptr + input_id * tid2eid_width + offs_k,
+            mask=mask_k,
+            other=0,
+        ).to(tl.int64)
+        valid_expert = mask_k & (selected >= 0) & (selected < num_experts)
+        logits = tl.load(
+            logits_ptr + token_id * num_experts + selected,
+            mask=valid_expert,
+            other=-float("inf"),
+        ).to(tl.float32)
+        scores = _tl_deepseek_v4_sqrt_softplus(logits)
+        routing_weights = _tl_deepseek_v4_normalize_and_scale(scores, route_scale, TINY)
+
+        tl.store(selected_ptr + token_id * TOP_K + offs_k, selected, mask=mask_k)
+        tl.store(weights_ptr + token_id * TOP_K + offs_k, routing_weights, mask=mask_k)
+
+    @triton.jit
+    def _deepseek_v4_router_topk_kernel(
+        logits_ptr,
+        bias_ptr,
+        selected_ptr,
+        weights_ptr,
+        num_experts: tl.constexpr,
+        route_scale,
+        HAS_BIAS: tl.constexpr,
+        BLOCK_E: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        TOP_K: tl.constexpr,
+        TINY: tl.constexpr,
+    ):
+        token_id = tl.program_id(0)
+        offs_e = tl.arange(0, BLOCK_E)
+        mask_e = offs_e < num_experts
+
+        logits = tl.load(
+            logits_ptr + token_id * num_experts + offs_e,
+            mask=mask_e,
+            other=-float("inf"),
+        ).to(tl.float32)
+        scores = _tl_deepseek_v4_sqrt_softplus(logits)
+        selection_scores = scores
+        if HAS_BIAS:
+            bias = tl.load(bias_ptr + offs_e, mask=mask_e, other=0.0).to(tl.float32)
+            selection_scores = selection_scores + bias
+        selection_scores = tl.where(mask_e, selection_scores, -float("inf"))
+
+        offs_k = tl.arange(0, BLOCK_K)
+        topk_scores = tl.zeros([BLOCK_K], dtype=tl.float32)
+        topk_idxs = tl.zeros([BLOCK_K], dtype=tl.int64)
+
+        for k_i in tl.static_range(TOP_K):
+            max_val = tl.max(selection_scores, axis=0)
+            is_max = selection_scores == max_val
+            candidate = tl.where(is_max, offs_e, BLOCK_E)
+            max_idx = tl.min(candidate, axis=0)
+            score_val = tl.max(tl.where(offs_e == max_idx, scores, 0.0), axis=0)
+
+            slot_mask = offs_k == k_i
+            topk_scores = tl.where(slot_mask, score_val, topk_scores)
+            topk_idxs = tl.where(slot_mask, max_idx.to(tl.int64), topk_idxs)
+            selection_scores = tl.where(offs_e == max_idx, -float("inf"), selection_scores)
+
+        routing_weights = _tl_deepseek_v4_normalize_and_scale(topk_scores, route_scale, TINY)
+        mask_k = offs_k < TOP_K
+        tl.store(selected_ptr + token_id * TOP_K + offs_k, topk_idxs, mask=mask_k)
+        tl.store(weights_ptr + token_id * TOP_K + offs_k, routing_weights, mask=mask_k)
+
+else:
+    _deepseek_v4_router_hash_kernel = None
+    _deepseek_v4_router_topk_kernel = None
+
+
+@dataclass(frozen=True)
+class DeepSeekV4ExpertParallelRoutingMetadata:
+    """Explicit global-to-EP-local routing contract for DeepSeek V4 MoE.
+
+    ``torch_deepseek_v4_router`` returns global expert ids in ``selected_experts``.
+    For expert parallel execution, the MXFP4 weight tensors are sliced along the
+    expert dimension and route ids must be converted to the local coordinate
+    system for the rank-owned slice. Nonlocal routes keep the original
+    ``[T, top_k]`` shape, are assigned local id 0, and have routing weight 0.
+
+    Attributes:
+        selected_experts_global: Global expert ids with shape ``[T, top_k]``.
+        routing_weights_global: Router weights with shape ``[T, top_k]``.
+        selected_experts_local: EP-local expert ids with shape ``[T, top_k]``.
+        routing_weights_local: Weights with nonlocal routes zeroed.
+        rank_mask: Boolean mask selecting routes owned by ``moe_ep_rank``.
+        local_expert_start: Inclusive global expert id for this rank.
+        local_expert_end: Exclusive global expert id for this rank.
+        experts_per_rank: Number of global routed experts assigned to each rank.
+        moe_ep_size: Expert-parallel world size.
+        moe_ep_rank: Expert-parallel rank.
+        num_global_experts: Total global routed expert count.
+    """
+
+    selected_experts_global: torch.Tensor
+    routing_weights_global: torch.Tensor
+    selected_experts_local: torch.Tensor
+    routing_weights_local: torch.Tensor
+    rank_mask: torch.Tensor
+    local_expert_start: int
+    local_expert_end: int
+    experts_per_rank: int
+    moe_ep_size: int
+    moe_ep_rank: int
+    num_global_experts: int
+
+
+def is_deepseek_v4_hash_routed_layer(layer_idx: int) -> bool:
+    """Return whether ``layer_idx`` uses the observed DeepSeek V4 hash router."""
+    return layer_idx in DEEPSEEK_V4_HASH_ROUTED_LAYER_INDICES
+
+
+def deepseek_v4_experts_per_rank(
+    *,
+    moe_ep_size: int = DEEPSEEK_V4_OBSERVED_MOE_EP_SIZE,
+    num_global_experts: int = DEEPSEEK_V4_NUM_ROUTED_EXPERTS,
+) -> int:
+    """Return the contiguous expert count per EP rank.
+
+    The inspected DeepSeek V4 graph has 256 routed experts and uses 8-way EP in
+    the MXFP4 path, so each rank owns 32 experts.
+    """
+    if moe_ep_size <= 0:
+        raise ValueError(f"moe_ep_size must be positive, got {moe_ep_size}")
+    if num_global_experts <= 0:
+        raise ValueError(f"num_global_experts must be positive, got {num_global_experts}")
+    if num_global_experts % moe_ep_size != 0:
+        raise ValueError(
+            "DeepSeek V4 EP-local routing requires an even expert split, got "
+            f"{num_global_experts} experts across {moe_ep_size} ranks"
+        )
+    return num_global_experts // moe_ep_size
+
+
+def deepseek_v4_ep_expert_range(
+    moe_ep_rank: int,
+    *,
+    moe_ep_size: int = DEEPSEEK_V4_OBSERVED_MOE_EP_SIZE,
+    num_global_experts: int = DEEPSEEK_V4_NUM_ROUTED_EXPERTS,
+) -> tuple[int, int]:
+    """Return the global expert id interval owned by one EP rank."""
+    if moe_ep_rank < 0 or moe_ep_rank >= moe_ep_size:
+        raise ValueError(f"moe_ep_rank must be in [0, {moe_ep_size}), got {moe_ep_rank}")
+
+    experts_per_rank = deepseek_v4_experts_per_rank(
+        moe_ep_size=moe_ep_size,
+        num_global_experts=num_global_experts,
+    )
+    local_expert_start = experts_per_rank * moe_ep_rank
+    return local_expert_start, local_expert_start + experts_per_rank
+
+
+def deepseek_v4_localize_expert_ids(
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    *,
+    moe_ep_size: int = DEEPSEEK_V4_OBSERVED_MOE_EP_SIZE,
+    moe_ep_rank: int = 0,
+    num_global_experts: int = DEEPSEEK_V4_NUM_ROUTED_EXPERTS,
+) -> DeepSeekV4ExpertParallelRoutingMetadata:
+    """Convert global router ids to rank-local ids and an explicit rank mask.
+
+    Args:
+        selected_experts: Global expert ids with shape ``[T, top_k]``.
+        routing_weights: Router weights with shape ``[T, top_k]``.
+        moe_ep_size: Expert-parallel world size.
+        moe_ep_rank: Expert-parallel rank.
+        num_global_experts: Total global routed expert count.
+
+    Returns:
+        Metadata containing global ids, local ids, rank mask, and masked weights.
+    """
+    if selected_experts.dim() != 2:
+        raise ValueError(f"selected_experts must have rank 2, got rank {selected_experts.dim()}")
+    if routing_weights.shape != selected_experts.shape:
+        raise ValueError(
+            "routing_weights must match selected_experts shape "
+            f"{tuple(selected_experts.shape)}, got {tuple(routing_weights.shape)}"
+        )
+    if selected_experts.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"selected_experts must be int32 or int64, got {selected_experts.dtype}")
+    if not routing_weights.is_floating_point():
+        raise TypeError(f"routing_weights must be floating point, got {routing_weights.dtype}")
+
+    local_expert_start, local_expert_end = deepseek_v4_ep_expert_range(
+        moe_ep_rank,
+        moe_ep_size=moe_ep_size,
+        num_global_experts=num_global_experts,
+    )
+    experts_per_rank = local_expert_end - local_expert_start
+    rank_mask = (selected_experts >= local_expert_start) & (selected_experts < local_expert_end)
+    selected_experts_local = (selected_experts - local_expert_start) * rank_mask.to(
+        selected_experts.dtype
+    )
+    routing_weights_local = routing_weights * rank_mask.to(routing_weights.dtype)
+
+    return DeepSeekV4ExpertParallelRoutingMetadata(
+        selected_experts_global=selected_experts,
+        routing_weights_global=routing_weights,
+        selected_experts_local=selected_experts_local,
+        routing_weights_local=routing_weights_local,
+        rank_mask=rank_mask,
+        local_expert_start=local_expert_start,
+        local_expert_end=local_expert_end,
+        experts_per_rank=experts_per_rank,
+        moe_ep_size=moe_ep_size,
+        moe_ep_rank=moe_ep_rank,
+        num_global_experts=num_global_experts,
+    )
 
 
 def _num_tokens(hidden_states: torch.Tensor) -> int:
@@ -89,6 +362,175 @@ def deepseek_v4_router_reference(
     return selected_experts, routing_weights
 
 
+def _next_power_of_2(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+def _same_cuda_device(*tensors: torch.Tensor) -> bool:
+    if not tensors:
+        return False
+    device = tensors[0].device
+    return device.type == "cuda" and all(tensor.device == device for tensor in tensors)
+
+
+def _router_shape_supported(
+    hidden_states: torch.Tensor,
+    router_weight: torch.Tensor,
+    top_k: int,
+) -> bool:
+    if hidden_states.dim() < 2 or router_weight.dim() != 2:
+        return False
+    num_experts, hidden_dim = router_weight.shape
+    return (
+        hidden_states.shape[-1] == hidden_dim
+        and 0 < top_k <= num_experts
+        and num_experts <= _TRITON_MAX_ROUTER_EXPERTS
+    )
+
+
+def _can_use_triton_router_base(
+    hidden_states: torch.Tensor,
+    router_weight: torch.Tensor,
+    top_k: int,
+) -> bool:
+    return (
+        _deepseek_v4_router_topk_kernel is not None
+        and _router_shape_supported(hidden_states, router_weight, top_k)
+        and _same_cuda_device(hidden_states, router_weight)
+    )
+
+
+def _router_logits(hidden_states: torch.Tensor, router_weight: torch.Tensor) -> torch.Tensor:
+    hidden_dim = hidden_states.shape[-1]
+    hidden_flat = hidden_states.reshape(-1, hidden_dim)
+    return F.linear(hidden_flat.float(), router_weight.float()).contiguous()
+
+
+def _deepseek_v4_router_hash_impl(
+    hidden_states: torch.Tensor,
+    input_ids: Optional[torch.Tensor],
+    router_weight: torch.Tensor,
+    tid2eid: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if input_ids is None:
+        raise ValueError("input_ids is required for DeepSeek V4 hash-routed layers")
+    if tid2eid is None:
+        raise ValueError("tid2eid is required for DeepSeek V4 hash-routed layers")
+
+    can_use_triton = (
+        _can_use_triton_router_base(hidden_states, router_weight, top_k)
+        and _same_cuda_device(hidden_states, router_weight, input_ids, tid2eid)
+        and input_ids.numel() == _num_tokens(hidden_states)
+        and tid2eid.dim() == 2
+        and top_k <= tid2eid.shape[1]
+        and tid2eid.dtype in (torch.int32, torch.int64)
+    )
+    if not can_use_triton:
+        return deepseek_v4_router_reference(
+            hidden_states,
+            input_ids,
+            router_weight,
+            router_bias=None,
+            tid2eid=tid2eid,
+            top_k=top_k,
+            route_scale=route_scale,
+            is_hash_layer=True,
+        )
+
+    logits = _router_logits(hidden_states, router_weight)
+    num_tokens, num_experts = logits.shape
+    selected_experts = torch.empty(
+        (num_tokens, top_k), dtype=tid2eid.dtype, device=hidden_states.device
+    )
+    routing_weights = torch.empty(
+        (num_tokens, top_k), dtype=torch.float32, device=hidden_states.device
+    )
+    input_ids_flat = input_ids.reshape(-1).contiguous()
+    tid2eid_contiguous = tid2eid.contiguous()
+
+    with torch.cuda.device(hidden_states.device):
+        _deepseek_v4_router_hash_kernel[(num_tokens,)](
+            logits,
+            input_ids_flat,
+            tid2eid_contiguous,
+            selected_experts,
+            routing_weights,
+            num_experts,
+            tid2eid_contiguous.shape[1],
+            float(route_scale),
+            BLOCK_K=_next_power_of_2(top_k),
+            TOP_K=top_k,
+            TINY=_FLOAT32_TINY,
+        )
+    return selected_experts, routing_weights
+
+
+def _deepseek_v4_router_topk_impl(
+    hidden_states: torch.Tensor,
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    can_use_triton = _can_use_triton_router_base(hidden_states, router_weight, top_k) and (
+        router_bias is None or _same_cuda_device(hidden_states, router_weight, router_bias)
+    )
+    if not can_use_triton:
+        return deepseek_v4_router_reference(
+            hidden_states,
+            input_ids=None,
+            router_weight=router_weight,
+            router_bias=router_bias,
+            tid2eid=None,
+            top_k=top_k,
+            route_scale=route_scale,
+            is_hash_layer=False,
+        )
+
+    logits = _router_logits(hidden_states, router_weight)
+    num_tokens, num_experts = logits.shape
+    selected_experts = torch.empty(
+        (num_tokens, top_k), dtype=torch.int64, device=hidden_states.device
+    )
+    routing_weights = torch.empty(
+        (num_tokens, top_k), dtype=torch.float32, device=hidden_states.device
+    )
+    bias = router_bias.contiguous() if router_bias is not None else logits
+
+    with torch.cuda.device(hidden_states.device):
+        _deepseek_v4_router_topk_kernel[(num_tokens,)](
+            logits,
+            bias,
+            selected_experts,
+            routing_weights,
+            num_experts,
+            float(route_scale),
+            HAS_BIAS=router_bias is not None,
+            BLOCK_E=_next_power_of_2(num_experts),
+            BLOCK_K=_next_power_of_2(top_k),
+            TOP_K=top_k,
+            TINY=_FLOAT32_TINY,
+        )
+    return selected_experts, routing_weights
+
+
+def _router_fake_outputs(
+    hidden_states: torch.Tensor,
+    top_k: int,
+    selected_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens = _num_tokens(hidden_states)
+    selected_experts = hidden_states.new_empty(
+        (num_tokens, top_k), dtype=selected_dtype, device=hidden_states.device
+    )
+    routing_weights = hidden_states.new_empty(
+        (num_tokens, top_k), dtype=torch.float32, device=hidden_states.device
+    )
+    return selected_experts, routing_weights
+
+
 @torch.library.custom_op("auto_deploy::torch_deepseek_v4_router", mutates_args=())
 def torch_deepseek_v4_router(
     hidden_states: torch.Tensor,
@@ -125,12 +567,114 @@ def _torch_deepseek_v4_router_fake(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     del input_ids, router_weight, router_bias, route_scale
 
-    num_tokens = _num_tokens(hidden_states)
     selected_dtype = tid2eid.dtype if is_hash_layer and tid2eid is not None else torch.int64
-    selected_experts = hidden_states.new_empty(
-        (num_tokens, top_k), dtype=selected_dtype, device=hidden_states.device
+    return _router_fake_outputs(hidden_states, top_k, selected_dtype)
+
+
+@torch.library.custom_op("auto_deploy::triton_deepseek_v4_router_hash", mutates_args=())
+def triton_deepseek_v4_router_hash(
+    hidden_states: torch.Tensor,
+    input_ids: torch.Tensor,
+    router_weight: torch.Tensor,
+    tid2eid: torch.Tensor,
+    top_k: int,
+    route_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """DeepSeek V4 hash router using Triton when supported, reference otherwise."""
+    return _deepseek_v4_router_hash_impl(
+        hidden_states,
+        input_ids,
+        router_weight,
+        tid2eid,
+        top_k,
+        route_scale,
     )
-    routing_weights = hidden_states.new_empty(
-        (num_tokens, top_k), dtype=torch.float32, device=hidden_states.device
+
+
+@triton_deepseek_v4_router_hash.register_fake
+def _triton_deepseek_v4_router_hash_fake(
+    hidden_states: torch.Tensor,
+    input_ids: torch.Tensor,
+    router_weight: torch.Tensor,
+    tid2eid: torch.Tensor,
+    top_k: int,
+    route_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del input_ids, router_weight, route_scale
+    return _router_fake_outputs(hidden_states, top_k, tid2eid.dtype)
+
+
+@torch.library.custom_op("auto_deploy::triton_deepseek_v4_router_topk", mutates_args=())
+def triton_deepseek_v4_router_topk(
+    hidden_states: torch.Tensor,
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """DeepSeek V4 top-k router using Triton when supported, reference otherwise."""
+    return _deepseek_v4_router_topk_impl(
+        hidden_states,
+        router_weight,
+        router_bias,
+        top_k,
+        route_scale,
     )
-    return selected_experts, routing_weights
+
+
+@triton_deepseek_v4_router_topk.register_fake
+def _triton_deepseek_v4_router_topk_fake(
+    hidden_states: torch.Tensor,
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del router_weight, router_bias, route_scale
+    return _router_fake_outputs(hidden_states, top_k, torch.int64)
+
+
+@torch.library.custom_op("auto_deploy::triton_deepseek_v4_router", mutates_args=())
+def triton_deepseek_v4_router(
+    hidden_states: torch.Tensor,
+    input_ids: Optional[torch.Tensor],
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    tid2eid: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+    is_hash_layer: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Source-op-compatible DeepSeek V4 router with guarded Triton paths."""
+    if is_hash_layer:
+        return _deepseek_v4_router_hash_impl(
+            hidden_states,
+            input_ids,
+            router_weight,
+            tid2eid,
+            top_k,
+            route_scale,
+        )
+    return _deepseek_v4_router_topk_impl(
+        hidden_states,
+        router_weight,
+        router_bias,
+        top_k,
+        route_scale,
+    )
+
+
+@triton_deepseek_v4_router.register_fake
+def _triton_deepseek_v4_router_fake(
+    hidden_states: torch.Tensor,
+    input_ids: Optional[torch.Tensor],
+    router_weight: torch.Tensor,
+    router_bias: Optional[torch.Tensor],
+    tid2eid: Optional[torch.Tensor],
+    top_k: int,
+    route_scale: float,
+    is_hash_layer: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del input_ids, router_weight, router_bias, route_scale
+    selected_dtype = tid2eid.dtype if is_hash_layer and tid2eid is not None else torch.int64
+    return _router_fake_outputs(hidden_states, top_k, selected_dtype)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py
@@ -15,6 +15,7 @@
 
 # Triton-kernels-based MXFP4 MoE ops (GPT-OSS style) with routing, swizzling, and fused activation
 
+import weakref
 from typing import Callable, Tuple
 
 import torch
@@ -47,6 +48,107 @@ def _swizzle_mxfp4(w, w_scale):
 
 
 RouteFn = Callable[[torch.Tensor], Tuple[RoutingData, GatherIndx, ScatterIndx]]
+
+_TensorCacheKey = tuple[
+    int,
+    int,
+    int,
+    int,
+    tuple[int, ...],
+    tuple[int, ...],
+    torch.dtype,
+    str,
+    int | None,
+    torch.layout,
+    int | None,
+]
+_PrepareCacheKey = tuple[int, _TensorCacheKey, _TensorCacheKey, _TensorCacheKey, _TensorCacheKey]
+_PreparedWeightsScales = tuple[object, object, object, object]
+_TensorRef = weakref.ReferenceType[torch.Tensor] | None
+_PrepareCacheEntry = tuple[
+    tuple[_TensorRef, _TensorRef, _TensorRef, _TensorRef], _PreparedWeightsScales
+]
+_PREPARED_WEIGHTS_SCALES_CACHE: dict[_PrepareCacheKey, _PrepareCacheEntry] = {}
+_INFERENCE_TENSOR_VERSION_ERROR = "Inference tensors do not track version counter."
+
+
+def _tensor_version(tensor: torch.Tensor) -> int | None:
+    try:
+        return tensor._version
+    except RuntimeError as error:
+        if str(error) == _INFERENCE_TENSOR_VERSION_ERROR:
+            return None
+        raise
+
+
+def _tensor_cache_key(tensor: torch.Tensor) -> _TensorCacheKey:
+    storage = tensor.untyped_storage()
+    device = tensor.device
+    return (
+        id(tensor),
+        storage.data_ptr(),
+        storage.nbytes(),
+        tensor.storage_offset(),
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        device.type,
+        device.index,
+        tensor.layout,
+        _tensor_version(tensor),
+    )
+
+
+def _prepare_cache_key(
+    hidden_size: int,
+    gate_up_blocks: torch.Tensor,
+    gate_up_scales: torch.Tensor,
+    down_blocks: torch.Tensor,
+    down_scales: torch.Tensor,
+) -> _PrepareCacheKey:
+    return (
+        hidden_size,
+        _tensor_cache_key(gate_up_blocks),
+        _tensor_cache_key(gate_up_scales),
+        _tensor_cache_key(down_blocks),
+        _tensor_cache_key(down_scales),
+    )
+
+
+def _make_tensor_ref(tensor: torch.Tensor) -> _TensorRef:
+    try:
+        return weakref.ref(tensor)
+    except TypeError:
+        return None
+
+
+def _cache_entry_matches(
+    tensor_refs: tuple[_TensorRef, _TensorRef, _TensorRef, _TensorRef],
+    tensors: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+) -> bool:
+    return all(
+        tensor_ref is None or tensor_ref() is tensor
+        for tensor_ref, tensor in zip(tensor_refs, tensors)
+    )
+
+
+def _remove_prepare_cache_entry(cache_key: _PrepareCacheKey) -> None:
+    _PREPARED_WEIGHTS_SCALES_CACHE.pop(cache_key, None)
+
+
+def _register_cache_finalizers(
+    cache_key: _PrepareCacheKey,
+    tensors: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+) -> None:
+    for tensor in tensors:
+        try:
+            weakref.finalize(tensor, _remove_prepare_cache_entry, cache_key)
+        except TypeError:
+            pass
+
+
+def _clear_mxfp4_weights_scales_cache() -> None:
+    _PREPARED_WEIGHTS_SCALES_CACHE.clear()
 
 
 def _routing_from_precomputed(
@@ -89,7 +191,18 @@ def _prepare_weights_scales(
     gate_up_scales: torch.Tensor,  # [E_local, 2I, H//32] in unit8
     down_blocks: torch.Tensor,  # [E_local, H, I//32, 16] in uint8
     down_scales: torch.Tensor,  # [E_local, H, I//32] in uint8
-):
+) -> _PreparedWeightsScales:
+    cache_tensors = (gate_up_blocks, gate_up_scales, down_blocks, down_scales)
+    cache_key = _prepare_cache_key(
+        hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+    )
+    cache_entry = _PREPARED_WEIGHTS_SCALES_CACHE.get(cache_key)
+    if cache_entry is not None:
+        tensor_refs, cached_weights_scales = cache_entry
+        if _cache_entry_matches(tensor_refs, cache_tensors):
+            return cached_weights_scales
+        del _PREPARED_WEIGHTS_SCALES_CACHE[cache_key]
+
     local_experts = gate_up_blocks.size(0)
     intermediate_size = gate_up_blocks.shape[1] // 2
 
@@ -106,12 +219,18 @@ def _prepare_weights_scales(
     )
     triton_down_w.shape = torch.Size([local_experts, intermediate_size, hidden_size])
 
-    return (
+    prepared_weights_scales = (
         triton_gate_up_w,
         gate_up_w_scale_raw,
         triton_down_w,
         down_w_scale_raw,
     )
+    _PREPARED_WEIGHTS_SCALES_CACHE[cache_key] = (
+        tuple(_make_tensor_ref(tensor) for tensor in cache_tensors),
+        prepared_weights_scales,
+    )
+    _register_cache_finalizers(cache_key, cache_tensors)
+    return prepared_weights_scales
 
 
 def _run_mxfp4_mlp_core(

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py
@@ -20,6 +20,8 @@ from typing import Callable, Tuple
 
 import torch
 import torch.nn.functional as F
+import triton
+import triton.language as tl
 from triton_kernels.matmul_ogs import (
     FlexCtx,
     FnSpecs,
@@ -47,6 +49,38 @@ def _swizzle_mxfp4(w, w_scale):
     return w, w_scale
 
 
+@triton.jit
+def _deepseek_v4_swiglu_fn(input, alpha, limit):
+    gate, up = tl.split(tl.reshape(input, (input.shape[0], input.shape[1] // 2, 2)))
+    gate = gate.to(tl.float32)
+    up = up.to(tl.float32)
+    if limit is not None:
+        gate = tl.minimum(gate, limit)
+        up = tl.clamp(up, -limit, limit)
+    return gate / (1 + tl.exp(-alpha * gate)) * up
+
+
+def _deepseek_v4_swiglu_torch(input: torch.Tensor, alpha: float, limit: float) -> torch.Tensor:
+    gate = input[..., 0::2].float()
+    up = input[..., 1::2].float()
+    gate = torch.clamp(gate, max=limit)
+    up = torch.clamp(up, min=-limit, max=limit)
+    return (gate * torch.sigmoid(alpha * gate) * up).to(input.dtype)
+
+
+def _interleave_deepseek_v4_gate_up(tensor: torch.Tensor) -> torch.Tensor:
+    """Convert DeepSeek checkpoint order [w3, w1] to activation lane order [w1, w3]."""
+    if tensor.dim() < 2:
+        raise ValueError(f"gate/up tensor must have rank at least 2, got rank {tensor.dim()}")
+    if tensor.shape[1] % 2 != 0:
+        raise ValueError(f"gate/up dimension must be even, got {tensor.shape[1]}")
+
+    intermediate_size = tensor.shape[1] // 2
+    up = tensor[:, :intermediate_size]
+    gate = tensor[:, intermediate_size:]
+    return torch.stack((gate, up), dim=2).flatten(1, 2).contiguous()
+
+
 RouteFn = Callable[[torch.Tensor], Tuple[RoutingData, GatherIndx, ScatterIndx]]
 
 _TensorCacheKey = tuple[
@@ -62,7 +96,9 @@ _TensorCacheKey = tuple[
     torch.layout,
     int | None,
 ]
-_PrepareCacheKey = tuple[int, _TensorCacheKey, _TensorCacheKey, _TensorCacheKey, _TensorCacheKey]
+_PrepareCacheKey = tuple[
+    int, bool, _TensorCacheKey, _TensorCacheKey, _TensorCacheKey, _TensorCacheKey
+]
 _PreparedWeightsScales = tuple[object, object, object, object]
 _TensorRef = weakref.ReferenceType[torch.Tensor] | None
 _PrepareCacheEntry = tuple[
@@ -101,6 +137,7 @@ def _tensor_cache_key(tensor: torch.Tensor) -> _TensorCacheKey:
 
 def _prepare_cache_key(
     hidden_size: int,
+    interleave_gate_up: bool,
     gate_up_blocks: torch.Tensor,
     gate_up_scales: torch.Tensor,
     down_blocks: torch.Tensor,
@@ -108,6 +145,7 @@ def _prepare_cache_key(
 ) -> _PrepareCacheKey:
     return (
         hidden_size,
+        interleave_gate_up,
         _tensor_cache_key(gate_up_blocks),
         _tensor_cache_key(gate_up_scales),
         _tensor_cache_key(down_blocks),
@@ -191,10 +229,17 @@ def _prepare_weights_scales(
     gate_up_scales: torch.Tensor,  # [E_local, 2I, H//32] in unit8
     down_blocks: torch.Tensor,  # [E_local, H, I//32, 16] in uint8
     down_scales: torch.Tensor,  # [E_local, H, I//32] in uint8
+    *,
+    interleave_gate_up: bool = False,
 ) -> _PreparedWeightsScales:
     cache_tensors = (gate_up_blocks, gate_up_scales, down_blocks, down_scales)
     cache_key = _prepare_cache_key(
-        hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+        hidden_size,
+        interleave_gate_up,
+        gate_up_blocks,
+        gate_up_scales,
+        down_blocks,
+        down_scales,
     )
     cache_entry = _PREPARED_WEIGHTS_SCALES_CACHE.get(cache_key)
     if cache_entry is not None:
@@ -205,6 +250,9 @@ def _prepare_weights_scales(
 
     local_experts = gate_up_blocks.size(0)
     intermediate_size = gate_up_blocks.shape[1] // 2
+    if interleave_gate_up:
+        gate_up_blocks = _interleave_deepseek_v4_gate_up(gate_up_blocks)
+        gate_up_scales = _interleave_deepseek_v4_gate_up(gate_up_scales)
 
     # canon shapes for swizzling (use last two dims as [K, N] style)
     gate_up_blocks = gate_up_blocks.view(local_experts, intermediate_size * 2, -1)
@@ -287,6 +335,10 @@ def _run_mxfp4_mlp_core_from_routing(
     routing_data: RoutingData,
     gather_idx: GatherIndx,
     scatter_idx: ScatterIndx,
+    *,
+    activation_fn=swiglu_fn,
+    activation_name: str = "swiglu",
+    interleave_gate_up: bool = False,
 ) -> torch.Tensor:
     leading_shape = hidden_states.shape[:-1]
     hidden_size = hidden_states.shape[-1]
@@ -298,8 +350,15 @@ def _run_mxfp4_mlp_core_from_routing(
         triton_down_w,
         down_w_scale_raw,
     ) = _prepare_weights_scales(
-        hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+        hidden_size,
+        gate_up_blocks,
+        gate_up_scales,
+        down_blocks,
+        down_scales,
+        interleave_gate_up=interleave_gate_up,
     )
+    if interleave_gate_up:
+        gate_up_bias = _interleave_deepseek_v4_gate_up(gate_up_bias)
 
     gate_pc = PrecisionConfig(
         weight_scale=gate_up_w_scale_raw, flex_ctx=FlexCtx(rhs_data=InFlexData())
@@ -309,7 +368,7 @@ def _run_mxfp4_mlp_core_from_routing(
     )
 
     act = FusedActivation(
-        FnSpecs("swiglu", swiglu_fn, ("alpha", "limit"), reduction_n=2),
+        FnSpecs(activation_name, activation_fn, ("alpha", "limit"), reduction_n=2),
         (float(alpha), float(limit)),
     )
 
@@ -434,6 +493,9 @@ def triton_deepseek_v4_mxfp4_moe_from_routing(
         routing_data,
         gather_idx,
         scatter_idx,
+        activation_fn=_deepseek_v4_swiglu_fn,
+        activation_name="deepseek_v4_swiglu",
+        interleave_gate_up=True,
     )
 
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py
@@ -49,6 +49,40 @@ def _swizzle_mxfp4(w, w_scale):
 RouteFn = Callable[[torch.Tensor], Tuple[RoutingData, GatherIndx, ScatterIndx]]
 
 
+def _routing_from_precomputed(
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    num_experts: int,
+) -> Tuple[RoutingData, GatherIndx, ScatterIndx]:
+    from triton_kernels.tensor import make_ragged_tensor_metadata
+
+    flat_experts = selected_experts.reshape(-1).to(torch.int64)
+    col_sorted_indx = torch.argsort(flat_experts, stable=True).to(torch.int32)
+    row_sorted_indx = torch.argsort(col_sorted_indx, stable=True).to(torch.int32)
+    col_sum = torch.zeros(num_experts, dtype=torch.int32, device=flat_experts.device)
+    col_sum.scatter_add_(0, flat_experts, torch.ones_like(flat_experts, dtype=torch.int32))
+    expt_data = make_ragged_tensor_metadata(
+        col_sum, routing_weights.shape[0] * routing_weights.shape[1]
+    )
+    gate_scal_sorted = routing_weights.reshape(-1)[col_sorted_indx.to(torch.int64)]
+    routing_data = RoutingData(
+        gate_scal=gate_scal_sorted,
+        expt_hist=col_sum,
+        n_expts_tot=num_experts,
+        n_expts_act=routing_weights.shape[1],
+        expt_data=expt_data,
+    )
+    gather_idx = GatherIndx(
+        src_indx=col_sorted_indx,
+        dst_indx=row_sorted_indx,
+    )
+    scatter_idx = ScatterIndx(
+        src_indx=row_sorted_indx,
+        dst_indx=col_sorted_indx,
+    )
+    return routing_data, gather_idx, scatter_idx
+
+
 def _prepare_weights_scales(
     hidden_size: int,
     gate_up_blocks: torch.Tensor,  # [E_local, 2I, H//32, 16] in unit8
@@ -98,14 +132,46 @@ def _run_mxfp4_mlp_core(
     Shared core for both triton_mxfp4_moe and triton_mxfp4_moe_ep.
     - route_fn encapsulates the only difference: how we produce (routing_data, gather_idx, scatter_idx).
     """
-    leading_shape = hidden_states.shape[:-1]
     hidden_size = hidden_states.shape[-1]
     x = hidden_states.reshape(-1, hidden_size)
-
     router_logits = F.linear(x, router_weight, router_bias)
     # route (global vs EP-aware)
     with torch.cuda.device(router_logits.device):
         routing_data, gather_idx, scatter_idx = route_fn(router_logits)
+
+    return _run_mxfp4_mlp_core_from_routing(
+        hidden_states,
+        gate_up_blocks,
+        gate_up_bias,
+        gate_up_scales,
+        alpha,
+        limit,
+        down_blocks,
+        down_bias,
+        down_scales,
+        routing_data,
+        gather_idx,
+        scatter_idx,
+    )
+
+
+def _run_mxfp4_mlp_core_from_routing(
+    hidden_states: torch.Tensor,
+    gate_up_blocks: torch.Tensor,
+    gate_up_bias: torch.Tensor,
+    gate_up_scales: torch.Tensor,
+    alpha: float,
+    limit: float,
+    down_blocks: torch.Tensor,
+    down_bias: torch.Tensor,
+    down_scales: torch.Tensor,
+    routing_data: RoutingData,
+    gather_idx: GatherIndx,
+    scatter_idx: ScatterIndx,
+) -> torch.Tensor:
+    leading_shape = hidden_states.shape[:-1]
+    hidden_size = hidden_states.shape[-1]
+    x = hidden_states.reshape(-1, hidden_size)
 
     (
         triton_gate_up_w,
@@ -211,6 +277,75 @@ def _mxfp4_mlp_fake(
     down_scales: torch.Tensor,
     layer_type: str = "moe",
 ):
+    return torch.empty_like(hidden_states)
+
+
+@torch.library.custom_op("auto_deploy::triton_deepseek_v4_mxfp4_moe_from_routing", mutates_args=())
+def triton_deepseek_v4_mxfp4_moe_from_routing(
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    gate_up_blocks: torch.Tensor,
+    gate_up_bias: torch.Tensor,
+    gate_up_scales: torch.Tensor,
+    alpha: float,
+    limit: float,
+    down_blocks: torch.Tensor,
+    down_bias: torch.Tensor,
+    down_scales: torch.Tensor,
+    layer_type: str = "moe",
+) -> torch.Tensor:
+    del layer_type
+
+    with torch.cuda.device(hidden_states.device):
+        routing_data, gather_idx, scatter_idx = _routing_from_precomputed(
+            selected_experts, routing_weights, gate_up_blocks.shape[0]
+        )
+
+    return _run_mxfp4_mlp_core_from_routing(
+        hidden_states,
+        gate_up_blocks,
+        gate_up_bias,
+        gate_up_scales,
+        alpha,
+        limit,
+        down_blocks,
+        down_bias,
+        down_scales,
+        routing_data,
+        gather_idx,
+        scatter_idx,
+    )
+
+
+@triton_deepseek_v4_mxfp4_moe_from_routing.register_fake
+def _deepseek_v4_mxfp4_moe_from_routing_fake(
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    gate_up_blocks: torch.Tensor,
+    gate_up_bias: torch.Tensor,
+    gate_up_scales: torch.Tensor,
+    alpha: float,
+    limit: float,
+    down_blocks: torch.Tensor,
+    down_bias: torch.Tensor,
+    down_scales: torch.Tensor,
+    layer_type: str = "moe",
+) -> torch.Tensor:
+    del (
+        selected_experts,
+        routing_weights,
+        gate_up_blocks,
+        gate_up_bias,
+        gate_up_scales,
+        alpha,
+        limit,
+        down_blocks,
+        down_bias,
+        down_scales,
+        layer_type,
+    )
     return torch.empty_like(hidden_states)
 
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py
@@ -15,8 +15,10 @@
 
 # Triton-kernels-based MXFP4 MoE ops (GPT-OSS style) with routing, swizzling, and fused activation
 
+import contextlib
 import weakref
-from typing import Callable, Tuple
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -34,10 +36,14 @@ from triton_kernels.matmul_ogs import (
 )
 from triton_kernels.numerics import InFlexData
 from triton_kernels.swiglu import swiglu_fn
-from triton_kernels.tensor import FP4, convert_layout, wrap_torch_tensor
+from triton_kernels.tensor import FP4, RaggedTensorMetadata, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 from triton_kernels.tensor_details.layout import StridedLayout
 
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.deepseek_v4_router import (
+    DeepSeekV4ExpertParallelRoutingMetadata,
+    deepseek_v4_localize_expert_ids,
+)
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_triton import TritonEPRouter
 
 
@@ -82,6 +88,86 @@ def _interleave_deepseek_v4_gate_up(tensor: torch.Tensor) -> torch.Tensor:
 
 
 RouteFn = Callable[[torch.Tensor], Tuple[RoutingData, GatherIndx, ScatterIndx]]
+
+
+@dataclass(frozen=True)
+class DeepSeekV4RouteMetadata:
+    """Graph-safe route metadata for ``triton_deepseek_v4_mxfp4_moe_from_routing``.
+
+    ``selected_experts`` must already be in the coordinate system of the MXFP4
+    expert weight slice: global ids when ``moe_ep == 1`` and EP-local ids when
+    ``moe_ep > 1``. Use ``deepseek_v4_localize_expert_ids`` to convert router
+    global ids before calling this path on EP-sharded weights. Nonlocal EP
+    routes keep their ``[T, top_k]`` slots but carry routing weight 0.
+
+    Attributes:
+        selected_experts: EP-local expert ids with shape ``[T, top_k]``.
+        routing_weights: Routing weights with shape ``[T, top_k]``.
+        flat_expert_ids: Flattened local expert ids with shape ``[T * top_k]``.
+        sorted_route_indices: Stable permutation of flattened routes by expert.
+        inverse_route_indices: Inverse permutation back to original route order.
+        expert_histogram: Number of route slots assigned to each local expert.
+        sorted_routing_weights: Routing weights ordered by ``sorted_route_indices``.
+        num_experts: Number of experts in the local MXFP4 weight slice.
+        top_k: Number of route slots per token.
+        num_routes: Total route slots, ``T * top_k``.
+    """
+
+    selected_experts: torch.Tensor
+    routing_weights: torch.Tensor
+    flat_expert_ids: torch.Tensor
+    sorted_route_indices: torch.Tensor
+    inverse_route_indices: torch.Tensor
+    expert_histogram: torch.Tensor
+    sorted_routing_weights: torch.Tensor
+    num_experts: int
+    top_k: int
+    num_routes: int
+
+
+@dataclass(frozen=True)
+class DeepSeekV4RouteMetadataTensors:
+    """Prebuilt matmul_ogs route metadata tensors.
+
+    Attributes:
+        sorted_routing_weights: Routing weights sorted by expert, shape ``[T * top_k]``.
+        expert_histogram: Per-local-expert route counts, shape ``[E_local]``.
+        sorted_route_indices: Stable gather permutation into expert-major route order.
+        inverse_route_indices: Inverse permutation back to original route order.
+        expert_offsets: Ragged slice offsets, shape ``[E_local + 1]``.
+        expert_block_offsets: Ragged block offsets for supported matmul_ogs block sizes.
+        expert_block_schedule: Ragged block schedules for supported matmul_ogs block sizes.
+    """
+
+    sorted_routing_weights: torch.Tensor
+    expert_histogram: torch.Tensor
+    sorted_route_indices: torch.Tensor
+    inverse_route_indices: torch.Tensor
+    expert_offsets: torch.Tensor
+    expert_block_offsets: torch.Tensor
+    expert_block_schedule: torch.Tensor
+
+    def as_tuple(
+        self,
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor,
+    ]:
+        return (
+            self.sorted_routing_weights,
+            self.expert_histogram,
+            self.sorted_route_indices,
+            self.inverse_route_indices,
+            self.expert_offsets,
+            self.expert_block_offsets,
+            self.expert_block_schedule,
+        )
+
 
 _TensorCacheKey = tuple[
     int,
@@ -189,38 +275,344 @@ def _clear_mxfp4_weights_scales_cache() -> None:
     _PREPARED_WEIGHTS_SCALES_CACHE.clear()
 
 
+def _device_guard(tensor: torch.Tensor) -> contextlib.AbstractContextManager[None]:
+    if tensor.device.type == "cuda":
+        return torch.cuda.device(tensor.device)
+    return contextlib.nullcontext()
+
+
+def prepare_deepseek_v4_route_metadata(
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    num_experts: int,
+) -> DeepSeekV4RouteMetadata:
+    """Prepare stable sort, histogram, gather, and scatter metadata.
+
+    Args:
+        selected_experts: Local expert ids with shape ``[T, top_k]``. These are
+            global ids only in the non-EP case where the weight slice contains
+            all routed experts.
+        routing_weights: Per-route weights with shape ``[T, top_k]``. For EP,
+            nonlocal routes should already be zeroed by rank mask.
+        num_experts: Number of experts in the current MXFP4 weight slice.
+
+    Returns:
+        ``DeepSeekV4RouteMetadata`` consumed by the matmul_ogs metadata bridge.
+    """
+    if num_experts <= 0:
+        raise ValueError(f"num_experts must be positive, got {num_experts}")
+    if selected_experts.dim() != 2:
+        raise ValueError(f"selected_experts must have rank 2, got rank {selected_experts.dim()}")
+    if selected_experts.shape[1] <= 0:
+        raise ValueError("selected_experts must include at least one route per token")
+    if routing_weights.shape != selected_experts.shape:
+        raise ValueError(
+            "routing_weights must match selected_experts shape "
+            f"{tuple(selected_experts.shape)}, got {tuple(routing_weights.shape)}"
+        )
+    if routing_weights.device != selected_experts.device:
+        raise ValueError(
+            "routing_weights must be on the same device as selected_experts, got "
+            f"{routing_weights.device} and {selected_experts.device}"
+        )
+    if selected_experts.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"selected_experts must be int32 or int64, got {selected_experts.dtype}")
+    if not routing_weights.is_floating_point():
+        raise TypeError(f"routing_weights must be floating point, got {routing_weights.dtype}")
+
+    flat_expert_ids = selected_experts.reshape(-1).to(torch.int64)
+    sorted_route_indices = torch.argsort(flat_expert_ids, stable=True).to(torch.int32)
+    inverse_route_indices = torch.argsort(sorted_route_indices, stable=True).to(torch.int32)
+    expert_histogram = torch.zeros(num_experts, dtype=torch.int32, device=flat_expert_ids.device)
+    expert_histogram.scatter_add_(
+        0,
+        flat_expert_ids,
+        torch.ones_like(flat_expert_ids, dtype=torch.int32),
+    )
+    sorted_routing_weights = routing_weights.reshape(-1)[sorted_route_indices.to(torch.int64)]
+
+    return DeepSeekV4RouteMetadata(
+        selected_experts=selected_experts,
+        routing_weights=routing_weights,
+        flat_expert_ids=flat_expert_ids,
+        sorted_route_indices=sorted_route_indices,
+        inverse_route_indices=inverse_route_indices,
+        expert_histogram=expert_histogram,
+        sorted_routing_weights=sorted_routing_weights,
+        num_experts=num_experts,
+        top_k=selected_experts.shape[1],
+        num_routes=selected_experts.numel(),
+    )
+
+
+def _make_deepseek_v4_ragged_metadata(
+    expert_histogram: torch.Tensor,
+    num_routes: int,
+) -> RaggedTensorMetadata:
+    if expert_histogram.device.type == "cpu":
+        from triton_kernels.tensor import make_ragged_tensor_metadata_torch
+
+        return make_ragged_tensor_metadata_torch(expert_histogram, num_routes)
+
+    from triton_kernels.tensor import make_ragged_tensor_metadata
+
+    return make_ragged_tensor_metadata(expert_histogram, num_routes)
+
+
+def _route_metadata_to_tensors(
+    route_metadata: DeepSeekV4RouteMetadata,
+) -> DeepSeekV4RouteMetadataTensors:
+    expert_data = _make_deepseek_v4_ragged_metadata(
+        route_metadata.expert_histogram,
+        route_metadata.num_routes,
+    )
+    return DeepSeekV4RouteMetadataTensors(
+        sorted_routing_weights=route_metadata.sorted_routing_weights,
+        expert_histogram=route_metadata.expert_histogram,
+        sorted_route_indices=route_metadata.sorted_route_indices,
+        inverse_route_indices=route_metadata.inverse_route_indices,
+        expert_offsets=expert_data.slice_offs.clone(),
+        expert_block_offsets=expert_data.block_offs_data.clone(),
+        expert_block_schedule=expert_data.block_schedule_data.clone(),
+    )
+
+
+def prepare_deepseek_v4_route_metadata_tensors(
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    num_experts: int,
+) -> DeepSeekV4RouteMetadataTensors:
+    """Prepare tensor metadata that can be passed to the MXFP4 fast path."""
+    return _route_metadata_to_tensors(
+        prepare_deepseek_v4_route_metadata(
+            selected_experts,
+            routing_weights,
+            num_experts,
+        )
+    )
+
+
+@torch.library.custom_op("auto_deploy::torch_deepseek_v4_mxfp4_route_metadata", mutates_args=())
+def torch_deepseek_v4_mxfp4_route_metadata(
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    num_experts: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    return prepare_deepseek_v4_route_metadata_tensors(
+        selected_experts,
+        routing_weights,
+        num_experts,
+    ).as_tuple()
+
+
+@torch_deepseek_v4_mxfp4_route_metadata.register_fake
+def _torch_deepseek_v4_mxfp4_route_metadata_fake(
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    num_experts: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    num_routes = selected_experts.numel()
+    device = selected_experts.device
+    block_size_count = len(RaggedTensorMetadata.block_sizes_log2())
+    max_num_blocks = RaggedTensorMetadata.max_n_tiles(num_experts, num_routes)
+    return (
+        torch.empty((num_routes,), dtype=routing_weights.dtype, device=device),
+        torch.empty((num_experts,), dtype=torch.int32, device=device),
+        torch.empty((num_routes,), dtype=torch.int32, device=device),
+        torch.empty((num_routes,), dtype=torch.int32, device=device),
+        torch.empty((num_experts + 1,), dtype=torch.int32, device=device),
+        torch.empty((block_size_count, num_experts + 1), dtype=torch.int32, device=device),
+        torch.empty((block_size_count, max_num_blocks), dtype=torch.int32, device=device),
+    )
+
+
+def _routing_from_route_metadata(
+    route_metadata: DeepSeekV4RouteMetadata,
+) -> Tuple[RoutingData, GatherIndx, ScatterIndx]:
+    return _routing_from_prebuilt_metadata(
+        *_route_metadata_to_tensors(route_metadata).as_tuple(),
+        num_experts=route_metadata.num_experts,
+        top_k=route_metadata.top_k,
+    )
+
+
+def _validate_route_metadata_tensor(
+    name: str,
+    tensor: torch.Tensor,
+    dtype: torch.dtype,
+) -> None:
+    if tensor.dtype != dtype:
+        raise TypeError(f"{name} must have dtype {dtype}, got {tensor.dtype}")
+
+
+def _validate_route_metadata_devices(
+    reference: torch.Tensor,
+    tensors: dict[str, torch.Tensor],
+) -> None:
+    mismatched = [
+        f"{name}={tensor.device}"
+        for name, tensor in tensors.items()
+        if tensor.device != reference.device
+    ]
+    if mismatched:
+        raise ValueError(
+            "prebuilt route metadata tensors must be on the same device as "
+            f"sorted_routing_weights={reference.device}, got {', '.join(mismatched)}"
+        )
+
+
+def _routing_from_prebuilt_metadata(
+    sorted_routing_weights: torch.Tensor,
+    expert_histogram: torch.Tensor,
+    sorted_route_indices: torch.Tensor,
+    inverse_route_indices: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    expert_block_offsets: torch.Tensor,
+    expert_block_schedule: torch.Tensor,
+    *,
+    num_experts: int,
+    top_k: int,
+) -> Tuple[RoutingData, GatherIndx, ScatterIndx]:
+    """Build matmul_ogs routing objects from prebuilt tensor metadata."""
+    if num_experts <= 0:
+        raise ValueError(f"num_experts must be positive, got {num_experts}")
+    if top_k <= 0:
+        raise ValueError(f"top_k must be positive, got {top_k}")
+    if not sorted_routing_weights.is_floating_point():
+        raise TypeError(
+            f"sorted_routing_weights must be floating point, got {sorted_routing_weights.dtype}"
+        )
+    _validate_route_metadata_tensor("expert_histogram", expert_histogram, torch.int32)
+    _validate_route_metadata_tensor("sorted_route_indices", sorted_route_indices, torch.int32)
+    _validate_route_metadata_tensor("inverse_route_indices", inverse_route_indices, torch.int32)
+    _validate_route_metadata_tensor("expert_offsets", expert_offsets, torch.int32)
+    _validate_route_metadata_tensor("expert_block_offsets", expert_block_offsets, torch.int32)
+    _validate_route_metadata_tensor("expert_block_schedule", expert_block_schedule, torch.int32)
+    _validate_route_metadata_devices(
+        sorted_routing_weights,
+        {
+            "expert_histogram": expert_histogram,
+            "sorted_route_indices": sorted_route_indices,
+            "inverse_route_indices": inverse_route_indices,
+            "expert_offsets": expert_offsets,
+            "expert_block_offsets": expert_block_offsets,
+            "expert_block_schedule": expert_block_schedule,
+        },
+    )
+
+    if sorted_routing_weights.dim() != 1:
+        raise ValueError("sorted_routing_weights must have rank 1")
+    if sorted_routing_weights.shape[0] % top_k != 0:
+        raise ValueError(
+            "sorted_routing_weights route count must be divisible by top_k, got "
+            f"{sorted_routing_weights.shape[0]} routes and top_k={top_k}"
+        )
+    if expert_histogram.shape != (num_experts,):
+        raise ValueError(
+            f"expert_histogram must have shape ({num_experts},), got "
+            f"{tuple(expert_histogram.shape)}"
+        )
+    if sorted_route_indices.shape != sorted_routing_weights.shape:
+        raise ValueError(
+            "sorted_route_indices must match sorted_routing_weights shape "
+            f"{tuple(sorted_routing_weights.shape)}, got {tuple(sorted_route_indices.shape)}"
+        )
+    if inverse_route_indices.shape != sorted_route_indices.shape:
+        raise ValueError(
+            "inverse_route_indices must match sorted_route_indices shape "
+            f"{tuple(sorted_route_indices.shape)}, got {tuple(inverse_route_indices.shape)}"
+        )
+    if expert_offsets.shape != (num_experts + 1,):
+        raise ValueError(
+            f"expert_offsets must have shape ({num_experts + 1},), got "
+            f"{tuple(expert_offsets.shape)}"
+        )
+    if expert_block_offsets.dim() != 2 or expert_block_offsets.shape[1] != num_experts + 1:
+        raise ValueError(
+            "expert_block_offsets must have shape "
+            f"[block_size_count, {num_experts + 1}], got {tuple(expert_block_offsets.shape)}"
+        )
+    block_size_count = len(RaggedTensorMetadata.block_sizes_log2())
+    if expert_block_offsets.shape[0] != block_size_count:
+        raise ValueError(
+            "expert_block_offsets first dimension must match supported ragged block size count "
+            f"{block_size_count}, got {expert_block_offsets.shape[0]}"
+        )
+    if expert_block_schedule.dim() != 2 or expert_block_schedule.shape[0] != block_size_count:
+        raise ValueError(
+            "expert_block_schedule must have shape "
+            f"[{block_size_count}, max_num_blocks], got {tuple(expert_block_schedule.shape)}"
+        )
+
+    expert_data = RaggedTensorMetadata(
+        expert_histogram,
+        expert_offsets,
+        expert_block_offsets,
+        expert_block_schedule,
+    )
+    routing_data = RoutingData(
+        gate_scal=sorted_routing_weights,
+        expt_hist=expert_histogram,
+        n_expts_tot=num_experts,
+        n_expts_act=top_k,
+        expt_data=expert_data,
+    )
+    gather_idx = GatherIndx(
+        src_indx=sorted_route_indices,
+        dst_indx=inverse_route_indices,
+    )
+    scatter_idx = ScatterIndx(
+        src_indx=inverse_route_indices,
+        dst_indx=sorted_route_indices,
+    )
+    return routing_data, gather_idx, scatter_idx
+
+
 def _routing_from_precomputed(
     selected_experts: torch.Tensor,
     routing_weights: torch.Tensor,
     num_experts: int,
 ) -> Tuple[RoutingData, GatherIndx, ScatterIndx]:
-    from triton_kernels.tensor import make_ragged_tensor_metadata
+    route_metadata = prepare_deepseek_v4_route_metadata(
+        selected_experts,
+        routing_weights,
+        num_experts,
+    )
+    return _routing_from_route_metadata(route_metadata)
 
-    flat_experts = selected_experts.reshape(-1).to(torch.int64)
-    col_sorted_indx = torch.argsort(flat_experts, stable=True).to(torch.int32)
-    row_sorted_indx = torch.argsort(col_sorted_indx, stable=True).to(torch.int32)
-    col_sum = torch.zeros(num_experts, dtype=torch.int32, device=flat_experts.device)
-    col_sum.scatter_add_(0, flat_experts, torch.ones_like(flat_experts, dtype=torch.int32))
-    expt_data = make_ragged_tensor_metadata(
-        col_sum, routing_weights.shape[0] * routing_weights.shape[1]
+
+def localize_deepseek_v4_routes_for_mxfp4(
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    *,
+    moe_ep_size: int,
+    moe_ep_rank: int,
+    num_global_experts: int,
+) -> DeepSeekV4ExpertParallelRoutingMetadata:
+    """Return EP-local route tensors for a local MXFP4 expert weight slice."""
+    return deepseek_v4_localize_expert_ids(
+        selected_experts,
+        routing_weights,
+        moe_ep_size=moe_ep_size,
+        moe_ep_rank=moe_ep_rank,
+        num_global_experts=num_global_experts,
     )
-    gate_scal_sorted = routing_weights.reshape(-1)[col_sorted_indx.to(torch.int64)]
-    routing_data = RoutingData(
-        gate_scal=gate_scal_sorted,
-        expt_hist=col_sum,
-        n_expts_tot=num_experts,
-        n_expts_act=routing_weights.shape[1],
-        expt_data=expt_data,
-    )
-    gather_idx = GatherIndx(
-        src_indx=col_sorted_indx,
-        dst_indx=row_sorted_indx,
-    )
-    scatter_idx = ScatterIndx(
-        src_indx=row_sorted_indx,
-        dst_indx=col_sorted_indx,
-    )
-    return routing_data, gather_idx, scatter_idx
 
 
 def _prepare_weights_scales(
@@ -303,7 +695,7 @@ def _run_mxfp4_mlp_core(
     x = hidden_states.reshape(-1, hidden_size)
     router_logits = F.linear(x, router_weight, router_bias)
     # route (global vs EP-aware)
-    with torch.cuda.device(router_logits.device):
+    with _device_guard(router_logits):
         routing_data, gather_idx, scatter_idx = route_fn(router_logits)
 
     return _run_mxfp4_mlp_core_from_routing(
@@ -472,13 +864,38 @@ def triton_deepseek_v4_mxfp4_moe_from_routing(
     down_bias: torch.Tensor,
     down_scales: torch.Tensor,
     layer_type: str = "moe",
+    sorted_routing_weights: Optional[torch.Tensor] = None,
+    expert_histogram: Optional[torch.Tensor] = None,
+    sorted_route_indices: Optional[torch.Tensor] = None,
+    inverse_route_indices: Optional[torch.Tensor] = None,
+    expert_offsets: Optional[torch.Tensor] = None,
+    expert_block_offsets: Optional[torch.Tensor] = None,
+    expert_block_schedule: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     del layer_type
 
-    with torch.cuda.device(hidden_states.device):
-        routing_data, gather_idx, scatter_idx = _routing_from_precomputed(
-            selected_experts, routing_weights, gate_up_blocks.shape[0]
-        )
+    prebuilt_metadata = (
+        sorted_routing_weights,
+        expert_histogram,
+        sorted_route_indices,
+        inverse_route_indices,
+        expert_offsets,
+        expert_block_offsets,
+        expert_block_schedule,
+    )
+    with _device_guard(hidden_states):
+        if any(tensor is not None for tensor in prebuilt_metadata):
+            if not all(tensor is not None for tensor in prebuilt_metadata):
+                raise ValueError("prebuilt route metadata must be fully specified")
+            routing_data, gather_idx, scatter_idx = _routing_from_prebuilt_metadata(
+                *prebuilt_metadata,
+                num_experts=gate_up_blocks.shape[0],
+                top_k=selected_experts.shape[1],
+            )
+        else:
+            routing_data, gather_idx, scatter_idx = _routing_from_precomputed(
+                selected_experts, routing_weights, gate_up_blocks.shape[0]
+            )
 
     return _run_mxfp4_mlp_core_from_routing(
         hidden_states,
@@ -513,6 +930,13 @@ def _deepseek_v4_mxfp4_moe_from_routing_fake(
     down_bias: torch.Tensor,
     down_scales: torch.Tensor,
     layer_type: str = "moe",
+    sorted_routing_weights: Optional[torch.Tensor] = None,
+    expert_histogram: Optional[torch.Tensor] = None,
+    sorted_route_indices: Optional[torch.Tensor] = None,
+    inverse_route_indices: Optional[torch.Tensor] = None,
+    expert_offsets: Optional[torch.Tensor] = None,
+    expert_block_offsets: Optional[torch.Tensor] = None,
+    expert_block_schedule: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     del (
         selected_experts,
@@ -526,6 +950,13 @@ def _deepseek_v4_mxfp4_moe_from_routing_fake(
         down_bias,
         down_scales,
         layer_type,
+        sorted_routing_weights,
+        expert_histogram,
+        sorted_route_indices,
+        inverse_route_indices,
+        expert_offsets,
+        expert_block_offsets,
+        expert_block_schedule,
     )
     return torch.empty_like(hidden_states)
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -32,6 +32,7 @@ e2m1_values = torch.tensor([0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -
 
 _FINEGRAINED_FP8_BLOCK_N = 128
 _FINEGRAINED_FP8_BLOCK_K = 128
+_DEEPSEEK_V4_WO_A_BLOCK_M = 32
 
 
 # ===== Helpers =====
@@ -498,6 +499,56 @@ def _act_quant_kernel(x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr):
     tl.store(s_ptr + pid, s)
 
 
+@triton.jit
+def _deepseek_v4_wo_a_grouped_fp8_kernel(
+    input_ptr,
+    weight_ptr,
+    weight_scale_ptr,
+    output_ptr,
+    M: tl.constexpr,
+    G: tl.constexpr,
+    R: tl.constexpr,
+    K: tl.constexpr,
+    SCALE_K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    pid_g = tl.program_id(axis=2)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    weight_rows = pid_g * R + offs_n
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k_start in range(0, K, BLOCK_K):
+        k_offsets = k_start + offs_k
+        a = tl.load(
+            input_ptr + (offs_m[:, None] * G + pid_g) * K + k_offsets[None, :],
+            mask=offs_m[:, None] < M,
+            other=0.0,
+        )
+        b = tl.load(
+            weight_ptr + weight_rows[:, None] * K + k_offsets[None, :],
+            mask=offs_n[:, None] < R,
+            other=0.0,
+        )
+        scale_row = (pid_g * R + pid_n * BLOCK_N) // BLOCK_N
+        scale_col = k_start // BLOCK_K
+        weight_scale = tl.load(weight_scale_ptr + scale_row * SCALE_K + scale_col).to(tl.float32)
+        b_dequant = (b.to(tl.float32) * weight_scale).to(a.dtype)
+        acc += tl.dot(a, tl.trans(b_dequant))
+
+    tl.store(
+        output_ptr + (offs_m[:, None] * G + pid_g) * R + offs_n[None, :],
+        acc,
+        mask=(offs_m[:, None] < M) & (offs_n[None, :] < R),
+    )
+
+
 def _safe_act_quant(x: torch.Tensor, block_size: int = 128) -> tuple:
     """Block-wise FP8 activation quantization (CUDA-graph safe).
 
@@ -523,6 +574,124 @@ def _dequant_block_fp8_weight(weight_fp8, weight_scale, block_n, block_k, dtype=
     return dequant_fp8_weight_two_dim_block_grid(
         weight_fp8, weight_scale, block_n, block_k, dtype=dtype
     )
+
+
+def _is_deepseek_v4_wo_a_grouped_fp8_triton_shape_supported(
+    input: torch.Tensor,
+    weight_quantized: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+) -> bool:
+    if input.dim() != 4 or weight_quantized.dim() != 2 or weight_scale_inv.dim() != 2:
+        return False
+    if weight_quantized.dtype != torch.float8_e4m3fn:
+        return False
+
+    num_groups = input.shape[-2]
+    group_dim = input.shape[-1]
+    out_rows, weight_group_dim = weight_quantized.shape
+    if num_groups <= 0 or group_dim <= 0 or weight_group_dim != group_dim:
+        return False
+    if out_rows % num_groups != 0:
+        return False
+
+    o_lora_rank = out_rows // num_groups
+    if group_dim % _FINEGRAINED_FP8_BLOCK_K != 0:
+        return False
+    if o_lora_rank % _FINEGRAINED_FP8_BLOCK_N != 0:
+        return False
+
+    expected_scale_shape = (
+        out_rows // _FINEGRAINED_FP8_BLOCK_N,
+        group_dim // _FINEGRAINED_FP8_BLOCK_K,
+    )
+    return tuple(weight_scale_inv.shape) == expected_scale_shape
+
+
+def _can_use_deepseek_v4_wo_a_grouped_fp8_triton(
+    input: torch.Tensor,
+    weight_quantized: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    weight_scale_inv: torch.Tensor,
+) -> bool:
+    if bias is not None:
+        return False
+    if input.dtype not in (torch.bfloat16, torch.float16):
+        return False
+    if not _is_deepseek_v4_wo_a_grouped_fp8_triton_shape_supported(
+        input, weight_quantized, weight_scale_inv
+    ):
+        return False
+    return (
+        input.is_cuda
+        and weight_quantized.is_cuda
+        and weight_scale_inv.is_cuda
+        and input.is_contiguous()
+        and weight_quantized.is_contiguous()
+        and weight_scale_inv.is_contiguous()
+        and input.numel() > 0
+    )
+
+
+def _deepseek_v4_wo_a_grouped_fp8_triton(
+    input: torch.Tensor,
+    weight_quantized: torch.Tensor,
+    weight_scale_inv: torch.Tensor,
+) -> torch.Tensor:
+    input_shape = input.shape
+    num_groups = input_shape[-2]
+    group_dim = input_shape[-1]
+    out_rows = weight_quantized.shape[0]
+    o_lora_rank = out_rows // num_groups
+    input_3d = input.reshape(-1, num_groups, group_dim)
+    output = torch.empty(
+        (*input_3d.shape[:-1], o_lora_rank),
+        dtype=input.dtype,
+        device=input.device,
+    )
+
+    grid = (
+        triton.cdiv(input_3d.shape[0], _DEEPSEEK_V4_WO_A_BLOCK_M),
+        triton.cdiv(o_lora_rank, _FINEGRAINED_FP8_BLOCK_N),
+        num_groups,
+    )
+    _deepseek_v4_wo_a_grouped_fp8_kernel[grid](
+        input_3d,
+        weight_quantized,
+        weight_scale_inv,
+        output,
+        input_3d.shape[0],
+        num_groups,
+        o_lora_rank,
+        group_dim,
+        weight_scale_inv.shape[1],
+        BLOCK_M=_DEEPSEEK_V4_WO_A_BLOCK_M,
+        BLOCK_N=_FINEGRAINED_FP8_BLOCK_N,
+        BLOCK_K=_FINEGRAINED_FP8_BLOCK_K,
+    )
+    return output.reshape(*input_shape[:-1], o_lora_rank)
+
+
+def _deepseek_v4_wo_a_grouped_reference(
+    input: torch.Tensor,
+    weight_quantized: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    weight_scale_inv: torch.Tensor,
+    num_groups: int,
+    o_lora_rank: int,
+    group_dim: int,
+) -> torch.Tensor:
+    weight_dequant = _dequant_block_fp8_weight(
+        weight_quantized,
+        weight_scale_inv,
+        _FINEGRAINED_FP8_BLOCK_N,
+        _FINEGRAINED_FP8_BLOCK_K,
+        dtype=input.dtype,
+    )
+    weight_grouped = weight_dequant.view(num_groups, o_lora_rank, group_dim)
+    output = torch.einsum("bsgd,grd->bsgr", input, weight_grouped)
+    if bias is not None:
+        output = output + bias.to(output.dtype).view(num_groups, o_lora_rank)
+    return output.to(dtype=input.dtype)
 
 
 @torch.library.custom_op("auto_deploy::torch_fake_quant_finegrained_fp8_linear", mutates_args=())
@@ -602,11 +771,12 @@ def torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear(
     weight_scale: List[torch.Tensor],  # [weight_scale_inv], shape [ceil(G*R/128), ceil(Dg/128)]
     layer_type: str = "unknown",
 ) -> torch.Tensor:
-    """Reference DeepSeek V4 ``wo_a`` grouped FineGrainedFP8 projection.
+    """DeepSeek V4 ``wo_a`` grouped FineGrainedFP8 projection.
 
     ``wo_a`` is stored compactly as ``[G * R, Dg]`` but executed as ``G`` independent
-    ``[R, Dg]`` projections.  The fallback keeps that compact layout, dequantizes
-    with fixed 128x128 weight blocks, and contracts each group with its own block.
+    ``[R, Dg]`` projections.  Supported CUDA shapes use a Triton path that consumes
+    the compact FP8 weight and 128x128 scales directly; other cases use the
+    reference BF16 dequantization fallback.
     """
     del layer_type
     if input.dim() != 4:
@@ -628,18 +798,24 @@ def torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear(
         )
 
     o_lora_rank = out_rows // num_groups
-    weight_dequant = _dequant_block_fp8_weight(
+    if _can_use_deepseek_v4_wo_a_grouped_fp8_triton(
+        input, weight_quantized, bias, weight_scale_inv
+    ):
+        return _deepseek_v4_wo_a_grouped_fp8_triton(
+            input,
+            weight_quantized,
+            weight_scale_inv,
+        )
+
+    return _deepseek_v4_wo_a_grouped_reference(
+        input,
         weight_quantized,
+        bias,
         weight_scale_inv,
-        _FINEGRAINED_FP8_BLOCK_N,
-        _FINEGRAINED_FP8_BLOCK_K,
-        dtype=input.dtype,
+        num_groups,
+        o_lora_rank,
+        group_dim,
     )
-    weight_grouped = weight_dequant.view(num_groups, o_lora_rank, group_dim)
-    output = torch.einsum("bsgd,grd->bsgr", input, weight_grouped)
-    if bias is not None:
-        output = output + bias.to(output.dtype).view(num_groups, o_lora_rank)
-    return output.to(dtype=input.dtype)
 
 
 @torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear.register_fake

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -600,6 +600,7 @@ def torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear(
     weight_quantized: torch.Tensor,  # [G * R, Dg] float8_e4m3fn
     bias: Optional[torch.Tensor],  # [G * R], [G, R], or None
     weight_scale: List[torch.Tensor],  # [weight_scale_inv], shape [ceil(G*R/128), ceil(Dg/128)]
+    layer_type: str = "unknown",
 ) -> torch.Tensor:
     """Reference DeepSeek V4 ``wo_a`` grouped FineGrainedFP8 projection.
 
@@ -607,6 +608,7 @@ def torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear(
     ``[R, Dg]`` projections.  The fallback keeps that compact layout, dequantizes
     with fixed 128x128 weight blocks, and contracts each group with its own block.
     """
+    del layer_type
     if input.dim() != 4:
         raise ValueError(f"input must have shape [B, S, G, Dg], got {tuple(input.shape)}")
     if weight_quantized.dtype != torch.float8_e4m3fn:
@@ -646,8 +648,10 @@ def _torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear_fake(
     weight_quantized: torch.Tensor,
     bias: Optional[torch.Tensor],
     weight_scale: List[torch.Tensor],
+    layer_type: str = "unknown",
 ) -> torch.Tensor:
     """Fake implementation for torch.export tracing."""
+    del bias, weight_scale, layer_type
     num_groups = input.shape[-2]
     o_lora_rank = weight_quantized.shape[0] // num_groups
     return torch.empty((*input.shape[:-1], o_lora_rank), dtype=input.dtype, device=input.device)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -19,6 +19,7 @@ import torch
 import triton
 import triton.language as tl
 
+from ...utils.e8m0 import maybe_e8m0_to_fp32
 from ...utils.fp8_dequant import dequant_fp8_weight_two_dim_block_grid
 from ...utils.quantization_utils import (
     cutlass_fp4_scale_to_modelopt_fp4_scale,
@@ -611,10 +612,11 @@ def trtllm_finegrained_fp8_linear(
     if input.dtype == torch.float8_e4m3fn:
         raise ValueError("trtllm_finegrained_fp8_linear expects bfloat16 input, not FP8")
 
-    # TRT-LLM fp8_block_scaling_gemm requires float32 scales; HF checkpoints may
-    # store weight_scale_inv in bfloat16 to save space, so cast here.
+    # TRT-LLM fp8_block_scaling_gemm requires float32 scales.  DeepSeek V4
+    # checkpoints may store exponent-only E8M0 scales; decode those before the
+    # kernel sees them.
     if weight_scale.dtype != torch.float32:
-        weight_scale = weight_scale.float()
+        weight_scale = maybe_e8m0_to_fp32(weight_scale)
 
     # Derive effective block size from weight and scale shapes.
     input_shape = input.shape

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py
@@ -30,6 +30,9 @@ from ...utils.quantization_utils import (
 e2m1_bounds = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5])
 e2m1_values = torch.tensor([0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6])
 
+_FINEGRAINED_FP8_BLOCK_N = 128
+_FINEGRAINED_FP8_BLOCK_K = 128
+
 
 # ===== Helpers =====
 def _expect_single_scale(scales: List[Optional[torch.Tensor]], name: str) -> torch.Tensor:
@@ -586,6 +589,68 @@ def _torch_fake_quant_finegrained_fp8_linear_fake(
     """Fake implementation for torch.export tracing."""
     out_features = weight_quantized.shape[0]
     return torch.empty((*input.shape[:-1], out_features), dtype=input.dtype, device=input.device)
+
+
+@torch.library.custom_op(
+    "auto_deploy::torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear",
+    mutates_args=(),
+)
+def torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear(
+    input: torch.Tensor,  # [B, S, G, Dg]
+    weight_quantized: torch.Tensor,  # [G * R, Dg] float8_e4m3fn
+    bias: Optional[torch.Tensor],  # [G * R], [G, R], or None
+    weight_scale: List[torch.Tensor],  # [weight_scale_inv], shape [ceil(G*R/128), ceil(Dg/128)]
+) -> torch.Tensor:
+    """Reference DeepSeek V4 ``wo_a`` grouped FineGrainedFP8 projection.
+
+    ``wo_a`` is stored compactly as ``[G * R, Dg]`` but executed as ``G`` independent
+    ``[R, Dg]`` projections.  The fallback keeps that compact layout, dequantizes
+    with fixed 128x128 weight blocks, and contracts each group with its own block.
+    """
+    if input.dim() != 4:
+        raise ValueError(f"input must have shape [B, S, G, Dg], got {tuple(input.shape)}")
+    if weight_quantized.dtype != torch.float8_e4m3fn:
+        raise TypeError("DeepSeek V4 wo_a FineGrained FP8 path requires float8_e4m3fn weight")
+
+    weight_scale_inv = maybe_e8m0_to_fp32(_expect_single_scale(weight_scale, "weight_scale"))
+    num_groups = input.shape[-2]
+    group_dim = input.shape[-1]
+    out_rows, weight_group_dim = weight_quantized.shape
+    if weight_group_dim != group_dim:
+        raise ValueError(
+            f"weight Dg ({weight_group_dim}) must match input Dg ({group_dim}) for grouped wo_a"
+        )
+    if out_rows % num_groups != 0:
+        raise ValueError(
+            f"weight rows ({out_rows}) must be divisible by input groups ({num_groups})"
+        )
+
+    o_lora_rank = out_rows // num_groups
+    weight_dequant = _dequant_block_fp8_weight(
+        weight_quantized,
+        weight_scale_inv,
+        _FINEGRAINED_FP8_BLOCK_N,
+        _FINEGRAINED_FP8_BLOCK_K,
+        dtype=input.dtype,
+    )
+    weight_grouped = weight_dequant.view(num_groups, o_lora_rank, group_dim)
+    output = torch.einsum("bsgd,grd->bsgr", input, weight_grouped)
+    if bias is not None:
+        output = output + bias.to(output.dtype).view(num_groups, o_lora_rank)
+    return output.to(dtype=input.dtype)
+
+
+@torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear.register_fake
+def _torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear_fake(
+    input: torch.Tensor,
+    weight_quantized: torch.Tensor,
+    bias: Optional[torch.Tensor],
+    weight_scale: List[torch.Tensor],
+) -> torch.Tensor:
+    """Fake implementation for torch.export tracing."""
+    num_groups = input.shape[-2]
+    o_lora_rank = weight_quantized.shape[0] // num_groups
+    return torch.empty((*input.shape[:-1], o_lora_rank), dtype=input.dtype, device=input.device)
 
 
 @torch.library.custom_op("auto_deploy::trtllm_finegrained_fp8_linear", mutates_args=())

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/torch_rope.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/rope/torch_rope.py
@@ -66,8 +66,9 @@ def torch_apply_rope_with_complex_freqs(
     - Frequencies are combined into a single complex-valued tensor `freqs_cis`
         of shape [B, S, head_dim // 2].
     """
-    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], -1, 2))
-    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], -1, 2))
+    half_head_dim = xq.shape[-1] // 2
+    xq_ = torch.view_as_complex(xq.float().reshape(*xq.shape[:-1], half_head_dim, 2))
+    xk_ = torch.view_as_complex(xk.float().reshape(*xk.shape[:-1], half_head_dim, 2))
     freqs = freqs_cis.unsqueeze(unsqueeze_dim)
     xq_out = torch.view_as_real(xq_ * freqs).flatten(3)
     xk_out = torch.view_as_real(xk_ * freqs).flatten(3)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -9,7 +9,7 @@ _logger = logging.getLogger(__name__)
 # other models from loading in standalone mode.
 _MODEL_MODULES = {
     "modeling_deepseek": ["DeepSeekV3ForCausalLM"],
-    "modeling_deepseek_v4": ["DeepseekV4ForCausalLM"],
+    "modeling_deepseek_v4": ["DeepseekV4AutoModelForCausalLMFactory", "DeepseekV4ForCausalLM"],
     "modeling_gemma3n": ["Gemma3nForCausalLM", "Gemma3nForConditionalGeneration"],
     "modeling_gemma4": ["Gemma4ForCausalLM", "Gemma4ForConditionalGeneration"],
     "modeling_glm4_moe_lite": ["Glm4MoeLiteForCausalLM"],

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -23,6 +23,10 @@ _MODEL_MODULES = {
 
 if os.environ.get("AD_USE_IR_MODELS"):
     _MODEL_MODULES["modeling_deepseek_ir"] = ["DeepSeekV3ForCausalLM"]
+    _MODEL_MODULES["modeling_deepseek_v4_ir"] = [
+        "DeepseekV4AutoModelForCausalLMFactory",
+        "DeepseekV4ForCausalLM",
+    ]
     _MODEL_MODULES["modeling_nemotron_h_ir"] = ["NemotronHForCausalLM"]
     _MODEL_MODULES["modeling_qwen3_5_moe_ir"] = [
         "Qwen3_5MoeForCausalLM",

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -9,6 +9,7 @@ _logger = logging.getLogger(__name__)
 # other models from loading in standalone mode.
 _MODEL_MODULES = {
     "modeling_deepseek": ["DeepSeekV3ForCausalLM"],
+    "modeling_deepseek_v4": ["DeepseekV4ForCausalLM"],
     "modeling_gemma3n": ["Gemma3nForCausalLM", "Gemma3nForConditionalGeneration"],
     "modeling_gemma4": ["Gemma4ForCausalLM", "Gemma4ForConditionalGeneration"],
     "modeling_glm4_moe_lite": ["Glm4MoeLiteForCausalLM"],

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
@@ -26,15 +26,16 @@ keeps the checkpoint module hierarchy from that reference implementation:
 Differences from the reference implementation:
 * prefill-only forward with mandatory ``position_ids``
 * returns logits for all sequence positions instead of only the final token
-* uses AutoDeploy canonical ops where they exist: RMSNorm, RoPE, linear, MoE
-* keeps V4-specific sparse attention and hyper-connections as PyTorch reference
-  math because no canonical AutoDeploy op currently covers those operations
+* uses AutoDeploy canonical ops where they exist: RMSNorm, RoPE, linear, sparse
+  attention, MoE
+* keeps V4-specific hyper-connections as PyTorch reference math because no
+  canonical AutoDeploy op currently covers those operations
 * omits decode caches and MTP blocks from the exported path
 """
 
 import math
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -45,8 +46,8 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 -- register all ops
+from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
 from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
-from tensorrt_llm._torch.utils import ActivationType
 
 
 @dataclass
@@ -97,6 +98,8 @@ class DeepseekV4Config(PretrainedConfig):
         hc_sinkhorn_iters: int = 20,
         hc_eps: float = 1e-6,
         ad_rope_cache_len: Optional[int] = None,
+        ad_compress_max_seq_len: Optional[int] = None,
+        skip_mtp: bool = True,
         attention_bias: bool = False,
         tie_word_embeddings: bool = False,
         **kwargs,
@@ -140,6 +143,8 @@ class DeepseekV4Config(PretrainedConfig):
         self.hc_sinkhorn_iters = hc_sinkhorn_iters
         self.hc_eps = hc_eps
         self.ad_rope_cache_len = ad_rope_cache_len or min(max_position_embeddings, 4096)
+        self.ad_compress_max_seq_len = ad_compress_max_seq_len or self.ad_rope_cache_len
+        self.skip_mtp = skip_mtp
         self.attention_bias = attention_bias
         super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
 
@@ -248,9 +253,14 @@ def _window_topk_idxs(window_size: int, batch_size: int, seq_len: int, device) -
 
 
 def _compress_topk_idxs(
-    ratio: int, batch_size: int, seq_len: int, offset: int, device
+    ratio: int,
+    batch_size: int,
+    seq_len: int,
+    offset: int,
+    device,
+    max_compressed_len: Optional[int] = None,
 ) -> torch.Tensor:
-    compressed_len = seq_len // ratio
+    compressed_len = max_compressed_len if max_compressed_len is not None else seq_len // ratio
     compressed = torch.arange(compressed_len, device=device)
     matrix = compressed.unsqueeze(0).expand(seq_len, -1)
     valid_lengths = torch.arange(1, seq_len + 1, device=device).unsqueeze(1) // ratio
@@ -265,20 +275,9 @@ def _sparse_attention(
     topk_idxs: torch.Tensor,
     softmax_scale: float,
 ) -> torch.Tensor:
-    batch_size, seq_len, _, head_dim = q.shape
-    gather_idxs = topk_idxs.clamp(min=0)
-    gather = gather_idxs.unsqueeze(-1).expand(-1, -1, -1, head_dim)
-    kv_for_gather = kv.unsqueeze(1).expand(-1, seq_len, -1, -1)
-    selected_kv = torch.gather(kv_for_gather, 2, gather)
-
-    scores = torch.einsum("bshd,bskd->bshk", q.float(), selected_kv.float()) * softmax_scale
-    invalid = topk_idxs < 0
-    scores = torch.where(invalid.unsqueeze(2), torch.full_like(scores, float("-inf")), scores)
-
-    sink = attn_sink.view(1, 1, -1, 1).expand(batch_size, seq_len, -1, -1)
-    probs = torch.softmax(torch.cat([scores, sink], dim=-1), dim=-1)[..., :-1]
-    output = torch.einsum("bshk,bskd->bshd", probs.to(selected_kv.dtype), selected_kv)
-    return output.to(q.dtype)
+    return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+        q, kv, attn_sink, topk_idxs, softmax_scale
+    )
 
 
 def _hc_split_sinkhorn(
@@ -350,6 +349,9 @@ class DeepseekV4Compressor(nn.Module):
         self.wkv = DeepseekV4Linear(self.hidden_size, channels * self.head_dim)
         self.wgate = DeepseekV4Linear(self.hidden_size, channels * self.head_dim)
         self.norm = DeepseekV4RMSNorm(self.head_dim, config.rms_norm_eps)
+        max_seq_len = int(getattr(config, "ad_compress_max_seq_len", config.ad_rope_cache_len))
+        self.max_compressed_len = max(1, (max_seq_len + compress_ratio - 1) // compress_ratio)
+        self.max_compressed_tokens = self.max_compressed_len * compress_ratio
 
     def _overlap_transform(self, tensor: torch.Tensor, value: float) -> torch.Tensor:
         batch_size, compressed_len, _, _ = tensor.shape
@@ -361,22 +363,28 @@ class DeepseekV4Compressor(nn.Module):
         return out
 
     def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor, freqs_cis: torch.Tensor
+        self, x: torch.Tensor, position_ids: torch.Tensor, freqs_cis_table: torch.Tensor
     ) -> torch.Tensor:
         batch_size, seq_len, _ = x.shape
         ratio = self.compress_ratio
-        cutoff = (seq_len // ratio) * ratio
-        kv = self.wkv(x.float())[:, :cutoff]
-        score = self.wgate(x.float())[:, :cutoff]
-        kv = kv.view(batch_size, -1, ratio, kv.shape[-1])
-        score = score.view(batch_size, -1, ratio, score.shape[-1]) + self.ape
+        pad_len = self.max_compressed_tokens - seq_len
+        kv = F.pad(self.wkv(x.to(self.wkv.weight.dtype)), (0, 0, 0, pad_len))
+        score = F.pad(
+            self.wgate(x.to(self.wgate.weight.dtype)), (0, 0, 0, pad_len), value=float("-inf")
+        )
+        kv = kv.view(batch_size, self.max_compressed_len, ratio, kv.shape[-1])
+        score = score.view(batch_size, self.max_compressed_len, ratio, score.shape[-1]) + self.ape
         if self.overlap:
             kv = self._overlap_transform(kv, 0)
             score = self._overlap_transform(score, float("-inf"))
         kv = (kv * score.softmax(dim=2)).sum(dim=2)
         kv = self.norm(kv.to(x.dtype))
 
-        compressed_freqs = freqs_cis[:, :cutoff:ratio]
+        row_idx = torch.arange(self.max_compressed_len, device=x.device) * ratio
+        row_idx = torch.minimum(row_idx, torch.full_like(row_idx, seq_len - 1))
+        row_idx = row_idx.unsqueeze(0).expand(batch_size, -1)
+        compressed_position_ids = torch.gather(position_ids, 1, row_idx)
+        compressed_freqs = freqs_cis_table[compressed_position_ids]
         rope = _apply_rope(kv[..., -self.rope_head_dim :], compressed_freqs)
         return torch.cat([kv[..., : -self.rope_head_dim], rope], dim=-1)
 
@@ -437,7 +445,8 @@ class DeepseekV4Attention(nn.Module):
 
     def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
         batch_size, seq_len, _ = x.shape
-        freqs_cis = self._freqs_cis(position_ids)
+        freqs_cis_table = self.rotary_emb()
+        freqs_cis = freqs_cis_table[position_ids]
 
         qr = self.q_norm(self.wq_a(x, layer_type="mla"))
         q = self.wq_b(qr, tp_mode="colwise", layer_type="mla")
@@ -452,9 +461,14 @@ class DeepseekV4Attention(nn.Module):
 
         topk_idxs = _window_topk_idxs(self.window_size, batch_size, seq_len, x.device)
         if self.compress_ratio:
-            compressed_kv = self.compressor(x, position_ids, freqs_cis)
+            compressed_kv = self.compressor(x, position_ids, freqs_cis_table)
             compressed_idxs = _compress_topk_idxs(
-                self.compress_ratio, batch_size, seq_len, seq_len, x.device
+                self.compress_ratio,
+                batch_size,
+                seq_len,
+                seq_len,
+                x.device,
+                self.compressor.max_compressed_len,
             )
             topk_idxs = torch.cat([topk_idxs, compressed_idxs], dim=-1)
             kv = torch.cat([kv, compressed_kv], dim=1)
@@ -477,7 +491,7 @@ class DeepseekV4Gate(nn.Module):
         self.is_hash = layer_idx < config.num_hash_layers
         self.weight = nn.Parameter(torch.empty(config.n_routed_experts, config.hidden_size))
         if self.is_hash:
-            initial = torch.arange(self.topk, dtype=torch.int32) % config.n_routed_experts
+            initial = torch.arange(self.topk, dtype=torch.long) % config.n_routed_experts
             tid2eid = initial.unsqueeze(0).expand(config.vocab_size, -1).clone()
             self.tid2eid = nn.Parameter(tid2eid, requires_grad=False)
             self.register_parameter("bias", None)
@@ -560,6 +574,10 @@ class DeepseekV4MoE(nn.Module):
         self.hidden_size = config.hidden_size
         self.n_routed_experts = config.n_routed_experts
         self.swiglu_limit = config.swiglu_limit
+        self.topk = config.num_experts_per_tok
+        self.route_scale = config.routed_scaling_factor
+        self.score_func = config.scoring_func
+        self.is_hash = layer_idx < config.num_hash_layers
         self.gate = DeepseekV4Gate(config, layer_idx)
         self.experts = nn.ModuleList(
             [
@@ -574,41 +592,30 @@ class DeepseekV4MoE(nn.Module):
             config.hidden_size, config.moe_intermediate_size, swiglu_limit=0.0
         )
 
-    def _dense_experts(
-        self,
-        x: torch.Tensor,
-        selected_experts: torch.Tensor,
-        routing_weights: torch.Tensor,
-    ) -> torch.Tensor:
-        output = torch.zeros_like(x)
-        for expert_idx, expert in enumerate(self.experts):
-            expert_weight = torch.where(
-                selected_experts == expert_idx,
-                routing_weights,
-                torch.zeros_like(routing_weights),
-            ).sum(dim=-1, keepdim=True)
-            output = output + expert(x) * expert_weight.to(x.dtype)
-        return output
-
     def forward(self, x: torch.Tensor, input_ids: torch.Tensor) -> torch.Tensor:
+        if self.score_func != "sqrtsoftplus":
+            raise ValueError(f"Unsupported DeepSeek V4 scoring_func: {self.score_func}")
+
         shape = x.shape
         x_flat = x.view(-1, self.hidden_size)
-        weights, indices = self.gate(x_flat, input_ids.flatten())
-        if self.swiglu_limit == 0:
-            routed = torch.ops.auto_deploy.torch_moe(
-                x_flat,
-                indices,
-                weights,
-                w1_weight=[expert.w1.weight for expert in self.experts],
-                w2_weight=[expert.w2.weight for expert in self.experts],
-                w3_weight=[expert.w3.weight for expert in self.experts],
-                is_gated_mlp=True,
-                act_fn=int(ActivationType.Silu),
-                layer_type="moe",
-            )
-        else:
-            routed = self._dense_experts(x_flat, indices, weights)
-        routed = routed + self.shared_experts(x_flat)
+        routed = torch.ops.auto_deploy.torch_deepseek_v4_moe(
+            x_flat,
+            input_ids.flatten(),
+            self.gate.weight,
+            self.gate.bias,
+            self.gate.tid2eid if self.is_hash else None,
+            torch.stack([expert.w1.weight for expert in self.experts]),
+            torch.stack([expert.w2.weight for expert in self.experts]),
+            torch.stack([expert.w3.weight for expert in self.experts]),
+            self.shared_experts.w1.weight,
+            self.shared_experts.w2.weight,
+            self.shared_experts.w3.weight,
+            self.topk,
+            self.route_scale,
+            self.swiglu_limit,
+            self.is_hash,
+            layer_type="moe",
+        )
         return routed.to(x.dtype).view(shape)
 
 
@@ -693,8 +700,26 @@ class DeepseekV4PreTrainedModel(PreTrainedModel):
     config_class = DeepseekV4Config
     base_model_prefix = ""
     _no_split_modules = ["DeepseekV4Block"]
-    _keys_to_ignore_on_load_unexpected = [r"^mtp\."]
+    _keys_to_ignore_on_load_unexpected = [r"^mtp\.0\."]
     supports_gradient_checkpointing = False
+
+    def __init__(self, config: PretrainedConfig) -> None:
+        super().__init__(config)
+        self.register_load_state_dict_pre_hook(self._skip_mtp_load_hook)
+
+    @staticmethod
+    def _skip_mtp_load_hook(
+        module: nn.Module,
+        state_dict: dict[str, torch.Tensor],
+        prefix: str,
+        *args,
+    ) -> None:
+        del module, args
+        if prefix:
+            return
+        for key in list(state_dict):
+            if key.startswith("mtp.0."):
+                state_dict.pop(key)
 
     def _init_weights(self, module: nn.Module) -> None:
         std = getattr(self.config, "initializer_range", 0.02)
@@ -730,7 +755,11 @@ class DeepseekV4PreTrainedModel(PreTrainedModel):
 
 
 class DeepseekV4ForCausalLM(DeepseekV4PreTrainedModel, GenerationMixin):
-    def __init__(self, config: PretrainedConfig) -> None:
+    def __init__(self, config: PretrainedConfig, **kwargs) -> None:
+        kwargs.pop("skip_mtp", None)
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs))
+            raise TypeError(f"Unexpected DeepSeek V4 model kwarg(s): {unexpected}")
         super().__init__(config)
         self.embed = nn.Embedding(config.vocab_size, config.hidden_size)
         self.layers = nn.ModuleList(
@@ -787,3 +816,20 @@ class DeepseekV4ForCausalLM(DeepseekV4PreTrainedModel, GenerationMixin):
 
 
 AutoModelForCausalLMFactory.register_custom_model_cls("DeepseekV4Config", DeepseekV4ForCausalLM)
+
+
+@ModelFactoryRegistry.register("DeepseekV4AutoModelForCausalLM")
+class DeepseekV4AutoModelForCausalLMFactory(AutoModelForCausalLMFactory):
+    def get_example_inputs(self) -> Dict[str, torch.Tensor]:
+        model_config, _ = self._get_model_config()
+        ratios = tuple(getattr(model_config, "compress_ratios", ()))
+        num_layers = getattr(model_config, "num_hidden_layers", len(ratios))
+        active_ratios = [int(ratio) for ratio in ratios[:num_layers] if int(ratio) > 0]
+        export_seq_len = max(4, 2 * max(active_ratios, default=0))
+        export_seq_len = max(1, min(self.max_seq_len, export_seq_len))
+        return {"input_ids": torch.ones(2, export_seq_len, dtype=torch.int)}
+
+
+DeepseekV4AutoModelForCausalLMFactory.register_custom_model_cls(
+    "DeepseekV4Config", DeepseekV4ForCausalLM
+)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
@@ -28,6 +28,8 @@ Differences from the reference implementation:
 * returns logits for all sequence positions instead of only the final token
 * uses AutoDeploy canonical ops where they exist: RMSNorm, RoPE, linear, sparse
   attention, MoE
+* implements the ratio-4 learned sparse-attention indexer so checkpoint indexer
+  tensors are loaded and used for compressed-row selection
 * keeps V4-specific hyper-connections as PyTorch reference math because no
   canonical AutoDeploy op currently covers those operations
 * omits decode caches and MTP blocks from the exported path
@@ -244,6 +246,46 @@ def _apply_rope(x: torch.Tensor, freqs_cis: torch.Tensor, inverse: bool = False)
     return x_out
 
 
+def _hadamard_transform(x: torch.Tensor) -> torch.Tensor:
+    last_dim = int(x.shape[-1])
+    if last_dim <= 0 or last_dim & (last_dim - 1):
+        raise ValueError(f"Hadamard transform requires a positive power-of-two dim, got {last_dim}")
+
+    out = x.float().reshape(-1, last_dim)
+    h = 1
+    while h < last_dim:
+        out = out.reshape(-1, 2, h)
+        left, right = out.unbind(dim=-2)
+        out = torch.stack((left + right, left - right), dim=-2).reshape(-1, last_dim)
+        h *= 2
+    return (out * (last_dim**-0.5)).to(x.dtype).reshape_as(x)
+
+
+def _fake_fp4_activation_quant_dequant(x: torch.Tensor, block_size: int = 32) -> torch.Tensor:
+    last_dim = int(x.shape[-1])
+    if last_dim % block_size != 0:
+        return x
+
+    original_dtype = x.dtype
+    x_blocks = x.contiguous().float().reshape(-1, last_dim)
+    x_blocks = x_blocks.reshape(-1, last_dim // block_size, block_size)
+    amax = x_blocks.abs().amax(dim=-1, keepdim=True).clamp_min(6.0 * (2.0**-126))
+    scale = torch.pow(2.0, torch.ceil(torch.log2(amax / 6.0)))
+    scaled = (x_blocks / scale).clamp(-6.0, 6.0)
+
+    abs_scaled = scaled.abs()
+    quantized = torch.zeros_like(abs_scaled)
+    quantized = torch.where(abs_scaled > 0.25, torch.full_like(quantized, 0.5), quantized)
+    quantized = torch.where(abs_scaled >= 0.75, torch.full_like(quantized, 1.0), quantized)
+    quantized = torch.where(abs_scaled > 1.25, torch.full_like(quantized, 1.5), quantized)
+    quantized = torch.where(abs_scaled >= 1.75, torch.full_like(quantized, 2.0), quantized)
+    quantized = torch.where(abs_scaled > 2.5, torch.full_like(quantized, 3.0), quantized)
+    quantized = torch.where(abs_scaled >= 3.5, torch.full_like(quantized, 4.0), quantized)
+    quantized = torch.where(abs_scaled > 5.0, torch.full_like(quantized, 6.0), quantized)
+    quantized = torch.where(scaled < 0, -quantized, quantized)
+    return (quantized * scale).to(original_dtype).reshape_as(x)
+
+
 def _window_topk_idxs(window_size: int, batch_size: int, seq_len: int, device) -> torch.Tensor:
     positions = torch.arange(seq_len, device=device)
     offsets = torch.arange(window_size, device=device)
@@ -406,6 +448,7 @@ class DeepseekV4Compressor(nn.Module):
         score: torch.Tensor,
         position_ids: torch.Tensor,
         freqs_cis_table: torch.Tensor,
+        norm_dtype: torch.dtype,
     ) -> torch.Tensor:
         batch_size, seq_len, _ = kv.shape
         ratio = self.compress_ratio
@@ -418,6 +461,7 @@ class DeepseekV4Compressor(nn.Module):
             kv = self._overlap_transform(kv, 0)
             score = self._overlap_transform(score, float("-inf"))
         kv = (kv * score.softmax(dim=2)).sum(dim=2)
+        kv = kv.to(norm_dtype)
         kv = self.norm(kv)
 
         row_idx = torch.arange(self.max_compressed_len, device=kv.device) * ratio
@@ -432,7 +476,72 @@ class DeepseekV4Compressor(nn.Module):
         self, x: torch.Tensor, position_ids: torch.Tensor, freqs_cis_table: torch.Tensor
     ) -> torch.Tensor:
         kv, score = self.project(x)
-        return self.pool_norm_rope(kv, score, position_ids, freqs_cis_table)
+        return self.pool_norm_rope(kv, score, position_ids, freqs_cis_table, kv.dtype)
+
+
+class DeepseekV4Indexer(nn.Module):
+    def __init__(self, config: PretrainedConfig, compress_ratio: int) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.index_n_heads
+        self.head_dim = config.index_head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.index_topk = config.index_topk
+        self.q_lora_rank = config.q_lora_rank
+        self.compress_ratio = compress_ratio
+        self.softmax_scale = self.head_dim**-0.5
+
+        self.wq_b = DeepseekV4Linear(self.q_lora_rank, self.num_heads * self.head_dim)
+        self.weights_proj = DeepseekV4Linear(self.hidden_size, self.num_heads)
+        self.compressor = DeepseekV4Compressor(config, compress_ratio, self.head_dim)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        qr: torch.Tensor,
+        position_ids: torch.Tensor,
+        freqs_cis_table: torch.Tensor,
+        offset: int,
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = x.shape
+        freqs_cis = freqs_cis_table[position_ids]
+
+        q = self.wq_b(qr, tp_mode="colwise", layer_type="mla")
+        q = torch.ops.auto_deploy.view(
+            q,
+            [batch_size, seq_len, self.num_heads, self.head_dim],
+            tp_scaled_dim=2,
+            layer_type="mla",
+        )
+        q_rope = _apply_rope(q[..., -self.rope_head_dim :], freqs_cis)
+        q = torch.cat([q[..., : -self.rope_head_dim], q_rope], dim=-1)
+        q = _hadamard_transform(q)
+        q = _fake_fp4_activation_quant_dequant(q)
+
+        compressed_kv = self.compressor(x, position_ids, freqs_cis_table)
+        compressed_kv = _hadamard_transform(compressed_kv)
+        compressed_kv = _fake_fp4_activation_quant_dequant(compressed_kv)
+        weights = self.weights_proj(x, tp_mode="colwise", layer_type="mla")
+        weights = weights * (self.softmax_scale * self.num_heads**-0.5)
+
+        index_score = torch.einsum("bshd,btd->bsht", q.float(), compressed_kv.float())
+        index_score = (index_score.relu() * weights.float().unsqueeze(-1)).sum(dim=2)
+        index_score = torch.ops.auto_deploy.all_reduce(index_score, layer_type="mla")
+
+        compressed_positions = torch.arange(self.compressor.max_compressed_len, device=x.device)
+        valid_lengths = torch.arange(1, seq_len + 1, device=x.device).unsqueeze(1)
+        valid_lengths = valid_lengths // self.compress_ratio
+        invalid = compressed_positions.unsqueeze(0) >= valid_lengths
+        index_score = torch.where(
+            invalid.unsqueeze(0),
+            torch.full_like(index_score, float("-inf")),
+            index_score,
+        )
+
+        topk_count = min(self.index_topk, self.compressor.max_compressed_len)
+        topk_idxs = index_score.topk(topk_count, dim=-1)[1]
+        valid_topk = topk_idxs < valid_lengths.unsqueeze(0)
+        return torch.where(valid_topk, topk_idxs + offset, -1)
 
 
 class DeepseekV4Attention(nn.Module):
@@ -462,8 +571,11 @@ class DeepseekV4Attention(nn.Module):
             self.num_groups * self.o_lora_rank,
         )
         self.wo_b = DeepseekV4Linear(self.num_groups * self.o_lora_rank, self.hidden_size)
+        self.indexer = None
         if self.compress_ratio:
             self.compressor = DeepseekV4Compressor(config, self.compress_ratio, self.head_dim)
+            if self.compress_ratio == 4:
+                self.indexer = DeepseekV4Indexer(config, self.compress_ratio)
 
         if self.compress_ratio:
             self.rope_original_seq_len = _rope_scaling_value(
@@ -517,14 +629,17 @@ class DeepseekV4Attention(nn.Module):
         compressor_norm_weight = x.new_empty(0)
         if self.compress_ratio:
             compressor_kv, compressor_gate = self.compressor.project(x)
-            compressed_idxs = _compress_topk_idxs(
-                self.compress_ratio,
-                batch_size,
-                seq_len,
-                seq_len,
-                x.device,
-                self.compressor.max_compressed_len,
-            )
+            if self.indexer is not None:
+                compressed_idxs = self.indexer(x, qr, position_ids, freqs_cis_table, seq_len)
+            else:
+                compressed_idxs = _compress_topk_idxs(
+                    self.compress_ratio,
+                    batch_size,
+                    seq_len,
+                    seq_len,
+                    x.device,
+                    self.compressor.max_compressed_len,
+                )
             topk_idxs = torch.cat([topk_idxs, compressed_idxs], dim=-1)
             compressor_ape = self.compressor.ape
             compressor_norm_weight = self.compressor.norm.weight

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
@@ -273,10 +273,44 @@ def _sparse_attention(
     kv: torch.Tensor,
     attn_sink: torch.Tensor,
     topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
     softmax_scale: float,
+    enable_sharding: bool = False,
+    layer_type: str = "unknown",
+    layer_idx: Optional[int] = None,
+    window_size: Optional[int] = None,
+    compress_ratio: int = 0,
+    max_compressed_len: Optional[int] = None,
+    head_dim: Optional[int] = None,
+    rope_dim: Optional[int] = None,
+    rms_norm_eps: float = 1e-6,
 ) -> torch.Tensor:
-    return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
-        q, kv, attn_sink, topk_idxs, softmax_scale
+    return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        softmax_scale,
+        enable_sharding=enable_sharding,
+        layer_type=layer_type,
+        layer_idx=layer_idx,
+        window_size=window_size,
+        compress_ratio=compress_ratio,
+        max_compressed_len=max_compressed_len,
+        head_dim=head_dim,
+        rope_dim=rope_dim,
+        rms_norm_eps=rms_norm_eps,
     )
 
 
@@ -362,31 +396,43 @@ class DeepseekV4Compressor(nn.Module):
         out[:, 1:, :ratio] = tensor[:, :-1, :, :head_dim]
         return out
 
-    def forward(
-        self, x: torch.Tensor, position_ids: torch.Tensor, freqs_cis_table: torch.Tensor
+    def project(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        x = x.to(self.wkv.weight.dtype)
+        return self.wkv(x), self.wgate(x)
+
+    def pool_norm_rope(
+        self,
+        kv: torch.Tensor,
+        score: torch.Tensor,
+        position_ids: torch.Tensor,
+        freqs_cis_table: torch.Tensor,
     ) -> torch.Tensor:
-        batch_size, seq_len, _ = x.shape
+        batch_size, seq_len, _ = kv.shape
         ratio = self.compress_ratio
         pad_len = self.max_compressed_tokens - seq_len
-        kv = F.pad(self.wkv(x.to(self.wkv.weight.dtype)), (0, 0, 0, pad_len))
-        score = F.pad(
-            self.wgate(x.to(self.wgate.weight.dtype)), (0, 0, 0, pad_len), value=float("-inf")
-        )
+        kv = F.pad(kv, (0, 0, 0, pad_len))
+        score = F.pad(score, (0, 0, 0, pad_len), value=float("-inf"))
         kv = kv.view(batch_size, self.max_compressed_len, ratio, kv.shape[-1])
         score = score.view(batch_size, self.max_compressed_len, ratio, score.shape[-1]) + self.ape
         if self.overlap:
             kv = self._overlap_transform(kv, 0)
             score = self._overlap_transform(score, float("-inf"))
         kv = (kv * score.softmax(dim=2)).sum(dim=2)
-        kv = self.norm(kv.to(x.dtype))
+        kv = self.norm(kv)
 
-        row_idx = torch.arange(self.max_compressed_len, device=x.device) * ratio
+        row_idx = torch.arange(self.max_compressed_len, device=kv.device) * ratio
         row_idx = torch.minimum(row_idx, torch.full_like(row_idx, seq_len - 1))
         row_idx = row_idx.unsqueeze(0).expand(batch_size, -1)
         compressed_position_ids = torch.gather(position_ids, 1, row_idx)
         compressed_freqs = freqs_cis_table[compressed_position_ids]
         rope = _apply_rope(kv[..., -self.rope_head_dim :], compressed_freqs)
         return torch.cat([kv[..., : -self.rope_head_dim], rope], dim=-1)
+
+    def forward(
+        self, x: torch.Tensor, position_ids: torch.Tensor, freqs_cis_table: torch.Tensor
+    ) -> torch.Tensor:
+        kv, score = self.project(x)
+        return self.pool_norm_rope(kv, score, position_ids, freqs_cis_table)
 
 
 class DeepseekV4Attention(nn.Module):
@@ -460,8 +506,12 @@ class DeepseekV4Attention(nn.Module):
         kv = torch.cat([kv[..., : -self.rope_head_dim], kv_rope], dim=-1)
 
         topk_idxs = _window_topk_idxs(self.window_size, batch_size, seq_len, x.device)
+        compressor_kv = x.new_empty(batch_size, seq_len, 0)
+        compressor_gate = x.new_empty(batch_size, seq_len, 0)
+        compressor_ape = x.new_empty(0, 0)
+        compressor_norm_weight = x.new_empty(0)
         if self.compress_ratio:
-            compressed_kv = self.compressor(x, position_ids, freqs_cis_table)
+            compressor_kv, compressor_gate = self.compressor.project(x)
             compressed_idxs = _compress_topk_idxs(
                 self.compress_ratio,
                 batch_size,
@@ -471,9 +521,30 @@ class DeepseekV4Attention(nn.Module):
                 self.compressor.max_compressed_len,
             )
             topk_idxs = torch.cat([topk_idxs, compressed_idxs], dim=-1)
-            kv = torch.cat([kv, compressed_kv], dim=1)
+            compressor_ape = self.compressor.ape
+            compressor_norm_weight = self.compressor.norm.weight
 
-        o = _sparse_attention(q, kv, self.attn_sink, topk_idxs.int(), self.softmax_scale)
+        max_compressed_len = self.compressor.max_compressed_len if self.compress_ratio else None
+        o = _sparse_attention(
+            q,
+            kv,
+            self.attn_sink,
+            topk_idxs.int(),
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            position_ids,
+            self.softmax_scale,
+            layer_idx=self.layer_idx,
+            window_size=self.window_size,
+            compress_ratio=self.compress_ratio,
+            max_compressed_len=max_compressed_len,
+            head_dim=self.head_dim,
+            rope_dim=self.rope_head_dim,
+            rms_norm_eps=self.eps,
+        )
         o_rope = _apply_rope(o[..., -self.rope_head_dim :], freqs_cis, inverse=True)
         o = torch.cat([o[..., : -self.rope_head_dim], o_rope], dim=-1)
         o = o.view(batch_size, seq_len, self.num_groups, -1)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
@@ -1,0 +1,776 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Prefill-only DeepSeek V4 model for AutoDeploy export.
+
+Source:
+https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash/blob/main/inference/model.py
+
+The HuggingFace repo ships a direct reference implementation under
+``inference/model.py`` rather than a standard ``modeling_*.py`` file. This file
+keeps the checkpoint module hierarchy from that reference implementation:
+``embed``, ``layers``, ``norm``, ``head`` and top-level HC head parameters.
+
+Differences from the reference implementation:
+* prefill-only forward with mandatory ``position_ids``
+* returns logits for all sequence positions instead of only the final token
+* uses AutoDeploy canonical ops where they exist: RMSNorm, RoPE, linear, MoE
+* keeps V4-specific sparse attention and hyper-connections as PyTorch reference
+  math because no canonical AutoDeploy op currently covers those operations
+* omits decode caches and MTP blocks from the exported path
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import AutoConfig, PretrainedConfig
+from transformers.generation import GenerationMixin
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import ModelOutput
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 -- register all ops
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+from tensorrt_llm._torch.utils import ActivationType
+
+
+@dataclass
+class DeepseekV4ModelOutput(ModelOutput):
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class DeepseekV4CausalLMOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+
+
+class DeepseekV4Config(PretrainedConfig):
+    model_type = "deepseek_v4"
+
+    def __init__(
+        self,
+        vocab_size: int = 129280,
+        hidden_size: int = 4096,
+        num_hidden_layers: int = 43,
+        num_attention_heads: int = 64,
+        num_key_value_heads: int = 1,
+        head_dim: int = 512,
+        q_lora_rank: int = 1024,
+        qk_rope_head_dim: int = 64,
+        o_groups: int = 8,
+        o_lora_rank: int = 1024,
+        sliding_window: int = 128,
+        compress_ratios: Optional[Tuple[int, ...]] = None,
+        compress_rope_theta: float = 160000.0,
+        index_n_heads: int = 64,
+        index_head_dim: int = 128,
+        index_topk: int = 512,
+        moe_intermediate_size: int = 2048,
+        n_routed_experts: int = 256,
+        n_shared_experts: int = 1,
+        num_experts_per_tok: int = 6,
+        num_hash_layers: int = 0,
+        scoring_func: str = "sqrtsoftplus",
+        routed_scaling_factor: float = 1.5,
+        swiglu_limit: float = 10.0,
+        hidden_act: str = "silu",
+        max_position_embeddings: int = 1048576,
+        rope_theta: float = 10000.0,
+        rope_scaling: Optional[dict] = None,
+        rms_norm_eps: float = 1e-6,
+        hc_mult: int = 4,
+        hc_sinkhorn_iters: int = 20,
+        hc_eps: float = 1e-6,
+        ad_rope_cache_len: Optional[int] = None,
+        attention_bias: bool = False,
+        tie_word_embeddings: bool = False,
+        **kwargs,
+    ) -> None:
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.q_lora_rank = q_lora_rank
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.o_groups = o_groups
+        self.o_lora_rank = o_lora_rank
+        self.sliding_window = sliding_window
+        self.compress_ratios = tuple(compress_ratios or (0,) * num_hidden_layers)
+        self.compress_rope_theta = compress_rope_theta
+        self.index_n_heads = index_n_heads
+        self.index_head_dim = index_head_dim
+        self.index_topk = index_topk
+        self.moe_intermediate_size = moe_intermediate_size
+        self.n_routed_experts = n_routed_experts
+        self.n_shared_experts = n_shared_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.num_hash_layers = num_hash_layers
+        self.scoring_func = scoring_func
+        self.routed_scaling_factor = routed_scaling_factor
+        self.swiglu_limit = swiglu_limit
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling or {
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 0,
+            "beta_fast": 32,
+            "beta_slow": 1,
+        }
+        self.rms_norm_eps = rms_norm_eps
+        self.hc_mult = hc_mult
+        self.hc_sinkhorn_iters = hc_sinkhorn_iters
+        self.hc_eps = hc_eps
+        self.ad_rope_cache_len = ad_rope_cache_len or min(max_position_embeddings, 4096)
+        self.attention_bias = attention_bias
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+
+
+try:
+    AutoConfig.register(DeepseekV4Config.model_type, DeepseekV4Config, exist_ok=True)
+except TypeError:
+    try:
+        AutoConfig.register(DeepseekV4Config.model_type, DeepseekV4Config)
+    except ValueError:
+        pass
+
+
+def _linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: Optional[torch.Tensor] = None,
+    tp_mode: str = "none",
+    layer_type: str = "unknown",
+) -> torch.Tensor:
+    return torch.ops.auto_deploy.torch_linear_simple(
+        x, weight, bias, tp_mode=tp_mode, layer_type=layer_type
+    )
+
+
+def _rope_scaling_value(config: PretrainedConfig, key: str, default):
+    rope_scaling = getattr(config, "rope_scaling", None) or {}
+    return rope_scaling.get(key, default)
+
+
+def _compute_freqs_cis(
+    position_ids: torch.Tensor,
+    dim: int,
+    original_seq_len: int,
+    base: float,
+    factor: float,
+    beta_fast: int,
+    beta_slow: int,
+) -> torch.Tensor:
+    freqs = 1.0 / (
+        base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=position_ids.device) / dim)
+    )
+    if original_seq_len > 0:
+
+        def _find_correction_dim(num_rotations: float) -> float:
+            return (
+                dim
+                * math.log(original_seq_len / (num_rotations * 2 * math.pi))
+                / (2 * math.log(base))
+            )
+
+        low = max(math.floor(_find_correction_dim(beta_fast)), 0)
+        high = min(math.ceil(_find_correction_dim(beta_slow)), dim - 1)
+        if low == high:
+            high += 0.001
+        ramp = (torch.arange(dim // 2, dtype=torch.float32, device=position_ids.device) - low) / (
+            high - low
+        )
+        smooth = 1 - torch.clamp(ramp, 0, 1)
+        freqs = freqs / factor * (1 - smooth) + freqs * smooth
+
+    phases = position_ids.to(torch.float32).unsqueeze(-1) * freqs
+    return torch.polar(torch.ones_like(phases), phases)
+
+
+class DeepseekV4RotaryEmbedding(nn.Module):
+    """Precomputed DeepSeek V4 complex RoPE table for an AD export sequence cap."""
+
+    def __init__(
+        self,
+        dim: int,
+        max_position_embeddings: int,
+        original_seq_len: int,
+        base: float,
+        factor: float,
+        beta_fast: int,
+        beta_slow: int,
+    ) -> None:
+        super().__init__()
+        position_ids = torch.arange(max_position_embeddings, dtype=torch.long).unsqueeze(0)
+        freqs_cis = _compute_freqs_cis(
+            position_ids, dim, original_seq_len, base, factor, beta_fast, beta_slow
+        ).squeeze(0)
+        self.register_buffer("_ad_freqs_cis_cached", freqs_cis, persistent=False)
+
+    def forward(self) -> torch.Tensor:
+        return self._ad_freqs_cis_cached
+
+
+def _apply_rope(x: torch.Tensor, freqs_cis: torch.Tensor, inverse: bool = False) -> torch.Tensor:
+    freqs = freqs_cis.conj() if inverse else freqs_cis
+    if x.ndim == 3:
+        x_in = x.unsqueeze(2)
+        x_out, _ = torch.ops.auto_deploy.torch_rope_with_complex_freqs(x_in, x_in, freqs, 2)
+        return x_out.squeeze(2)
+    x_out, _ = torch.ops.auto_deploy.torch_rope_with_complex_freqs(x, x, freqs, 2)
+    return x_out
+
+
+def _window_topk_idxs(window_size: int, batch_size: int, seq_len: int, device) -> torch.Tensor:
+    positions = torch.arange(seq_len, device=device)
+    offsets = torch.arange(window_size, device=device)
+    matrix = (positions[:, None] - window_size + 1).clamp(min=0) + offsets[None, :]
+    matrix = torch.where(matrix <= positions[:, None], matrix, -1)
+    return matrix.unsqueeze(0).expand(batch_size, -1, -1)
+
+
+def _compress_topk_idxs(
+    ratio: int, batch_size: int, seq_len: int, offset: int, device
+) -> torch.Tensor:
+    compressed_len = seq_len // ratio
+    compressed = torch.arange(compressed_len, device=device)
+    matrix = compressed.unsqueeze(0).expand(seq_len, -1)
+    valid_lengths = torch.arange(1, seq_len + 1, device=device).unsqueeze(1) // ratio
+    matrix = torch.where(matrix < valid_lengths, matrix + offset, -1)
+    return matrix.unsqueeze(0).expand(batch_size, -1, -1)
+
+
+def _sparse_attention(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    batch_size, seq_len, _, head_dim = q.shape
+    gather_idxs = topk_idxs.clamp(min=0)
+    gather = gather_idxs.unsqueeze(-1).expand(-1, -1, -1, head_dim)
+    kv_for_gather = kv.unsqueeze(1).expand(-1, seq_len, -1, -1)
+    selected_kv = torch.gather(kv_for_gather, 2, gather)
+
+    scores = torch.einsum("bshd,bskd->bshk", q.float(), selected_kv.float()) * softmax_scale
+    invalid = topk_idxs < 0
+    scores = torch.where(invalid.unsqueeze(2), torch.full_like(scores, float("-inf")), scores)
+
+    sink = attn_sink.view(1, 1, -1, 1).expand(batch_size, seq_len, -1, -1)
+    probs = torch.softmax(torch.cat([scores, sink], dim=-1), dim=-1)[..., :-1]
+    output = torch.einsum("bshk,bskd->bshd", probs.to(selected_kv.dtype), selected_kv)
+    return output.to(q.dtype)
+
+
+def _hc_split_sinkhorn(
+    mixes: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    hc_mult: int,
+    sinkhorn_iters: int,
+    eps: float,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    pre = torch.sigmoid(mixes[..., :hc_mult] * hc_scale[0] + hc_base[:hc_mult]) + eps
+    post = 2 * torch.sigmoid(
+        mixes[..., hc_mult : 2 * hc_mult] * hc_scale[1] + hc_base[hc_mult : 2 * hc_mult]
+    )
+    comb = mixes[..., 2 * hc_mult :].view(*mixes.shape[:-1], hc_mult, hc_mult)
+    comb_base = hc_base[2 * hc_mult :].view(hc_mult, hc_mult)
+    comb = comb * hc_scale[2] + comb_base
+    comb = torch.softmax(comb, dim=-1) + eps
+    comb = comb / (comb.sum(dim=-2, keepdim=True) + eps)
+    for _ in range(sinkhorn_iters - 1):
+        comb = comb / (comb.sum(dim=-1, keepdim=True) + eps)
+        comb = comb / (comb.sum(dim=-2, keepdim=True) + eps)
+    return pre, post, comb
+
+
+class DeepseekV4Linear(nn.Module):
+    def __init__(self, in_features: int, out_features: int, bias: bool = False) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.empty(out_features, in_features))
+        if bias:
+            self.bias = nn.Parameter(torch.empty(out_features))
+        else:
+            self.register_parameter("bias", None)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        tp_mode: str = "none",
+        layer_type: str = "unknown",
+    ) -> torch.Tensor:
+        return _linear(x, self.weight, self.bias, tp_mode=tp_mode, layer_type=layer_type)
+
+
+class DeepseekV4RMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=torch.float32))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_rmsnorm(x, self.weight, self.eps)
+
+
+class DeepseekV4Compressor(nn.Module):
+    def __init__(self, config: PretrainedConfig, compress_ratio: int, head_dim: int) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.head_dim = head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.compress_ratio = compress_ratio
+        self.overlap = compress_ratio == 4
+        channels = 2 if self.overlap else 1
+
+        self.ape = nn.Parameter(
+            torch.empty(compress_ratio, channels * self.head_dim, dtype=torch.float32)
+        )
+        self.wkv = DeepseekV4Linear(self.hidden_size, channels * self.head_dim)
+        self.wgate = DeepseekV4Linear(self.hidden_size, channels * self.head_dim)
+        self.norm = DeepseekV4RMSNorm(self.head_dim, config.rms_norm_eps)
+
+    def _overlap_transform(self, tensor: torch.Tensor, value: float) -> torch.Tensor:
+        batch_size, compressed_len, _, _ = tensor.shape
+        ratio = self.compress_ratio
+        head_dim = self.head_dim
+        out = tensor.new_full((batch_size, compressed_len, 2 * ratio, head_dim), value)
+        out[:, :, ratio:] = tensor[:, :, :, head_dim:]
+        out[:, 1:, :ratio] = tensor[:, :-1, :, :head_dim]
+        return out
+
+    def forward(
+        self, x: torch.Tensor, position_ids: torch.Tensor, freqs_cis: torch.Tensor
+    ) -> torch.Tensor:
+        batch_size, seq_len, _ = x.shape
+        ratio = self.compress_ratio
+        cutoff = (seq_len // ratio) * ratio
+        kv = self.wkv(x.float())[:, :cutoff]
+        score = self.wgate(x.float())[:, :cutoff]
+        kv = kv.view(batch_size, -1, ratio, kv.shape[-1])
+        score = score.view(batch_size, -1, ratio, score.shape[-1]) + self.ape
+        if self.overlap:
+            kv = self._overlap_transform(kv, 0)
+            score = self._overlap_transform(score, float("-inf"))
+        kv = (kv * score.softmax(dim=2)).sum(dim=2)
+        kv = self.norm(kv.to(x.dtype))
+
+        compressed_freqs = freqs_cis[:, :cutoff:ratio]
+        rope = _apply_rope(kv[..., -self.rope_head_dim :], compressed_freqs)
+        return torch.cat([kv[..., : -self.rope_head_dim], rope], dim=-1)
+
+
+class DeepseekV4Attention(nn.Module):
+    def __init__(self, config: PretrainedConfig, layer_idx: int) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.q_lora_rank = config.q_lora_rank
+        self.o_lora_rank = config.o_lora_rank
+        self.num_groups = config.o_groups
+        self.window_size = config.sliding_window
+        self.compress_ratio = config.compress_ratios[layer_idx]
+        self.eps = config.rms_norm_eps
+        self.softmax_scale = self.head_dim**-0.5
+
+        self.attn_sink = nn.Parameter(torch.empty(self.num_heads, dtype=torch.float32))
+        self.wq_a = DeepseekV4Linear(self.hidden_size, self.q_lora_rank)
+        self.q_norm = DeepseekV4RMSNorm(self.q_lora_rank, self.eps)
+        self.wq_b = DeepseekV4Linear(self.q_lora_rank, self.num_heads * self.head_dim)
+        self.wkv = DeepseekV4Linear(self.hidden_size, self.head_dim)
+        self.kv_norm = DeepseekV4RMSNorm(self.head_dim, self.eps)
+        self.wo_a = DeepseekV4Linear(
+            self.num_heads * self.head_dim // self.num_groups,
+            self.num_groups * self.o_lora_rank,
+        )
+        self.wo_b = DeepseekV4Linear(self.num_groups * self.o_lora_rank, self.hidden_size)
+        if self.compress_ratio:
+            self.compressor = DeepseekV4Compressor(config, self.compress_ratio, self.head_dim)
+
+        if self.compress_ratio:
+            self.rope_original_seq_len = _rope_scaling_value(
+                config, "original_max_position_embeddings", 0
+            )
+            self.rope_base = config.compress_rope_theta
+        else:
+            self.rope_original_seq_len = 0
+            self.rope_base = config.rope_theta
+        self.rope_factor = _rope_scaling_value(config, "factor", 1.0)
+        self.rope_beta_fast = _rope_scaling_value(config, "beta_fast", 32)
+        self.rope_beta_slow = _rope_scaling_value(config, "beta_slow", 1)
+        self.rotary_emb = DeepseekV4RotaryEmbedding(
+            self.rope_head_dim,
+            config.ad_rope_cache_len,
+            self.rope_original_seq_len,
+            self.rope_base,
+            self.rope_factor,
+            self.rope_beta_fast,
+            self.rope_beta_slow,
+        )
+
+    def _freqs_cis(self, position_ids: torch.Tensor) -> torch.Tensor:
+        return self.rotary_emb()[position_ids]
+
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, _ = x.shape
+        freqs_cis = self._freqs_cis(position_ids)
+
+        qr = self.q_norm(self.wq_a(x, layer_type="mla"))
+        q = self.wq_b(qr, tp_mode="colwise", layer_type="mla")
+        q = q.view(batch_size, seq_len, self.num_heads, self.head_dim)
+        q = q * torch.rsqrt(q.square().mean(-1, keepdim=True) + self.eps)
+        q_rope = _apply_rope(q[..., -self.rope_head_dim :], freqs_cis)
+        q = torch.cat([q[..., : -self.rope_head_dim], q_rope], dim=-1)
+
+        kv = self.kv_norm(self.wkv(x, layer_type="mla"))
+        kv_rope = _apply_rope(kv[..., -self.rope_head_dim :], freqs_cis)
+        kv = torch.cat([kv[..., : -self.rope_head_dim], kv_rope], dim=-1)
+
+        topk_idxs = _window_topk_idxs(self.window_size, batch_size, seq_len, x.device)
+        if self.compress_ratio:
+            compressed_kv = self.compressor(x, position_ids, freqs_cis)
+            compressed_idxs = _compress_topk_idxs(
+                self.compress_ratio, batch_size, seq_len, seq_len, x.device
+            )
+            topk_idxs = torch.cat([topk_idxs, compressed_idxs], dim=-1)
+            kv = torch.cat([kv, compressed_kv], dim=1)
+
+        o = _sparse_attention(q, kv, self.attn_sink, topk_idxs.int(), self.softmax_scale)
+        o_rope = _apply_rope(o[..., -self.rope_head_dim :], freqs_cis, inverse=True)
+        o = torch.cat([o[..., : -self.rope_head_dim], o_rope], dim=-1)
+        o = o.view(batch_size, seq_len, self.num_groups, -1)
+        wo_a = self.wo_a.weight.view(self.num_groups, self.o_lora_rank, -1)
+        o = torch.einsum("bsgd,grd->bsgr", o, wo_a)
+        return self.wo_b(o.flatten(2), tp_mode="rowwise", layer_type="mla")
+
+
+class DeepseekV4Gate(nn.Module):
+    def __init__(self, config: PretrainedConfig, layer_idx: int) -> None:
+        super().__init__()
+        self.topk = config.num_experts_per_tok
+        self.score_func = config.scoring_func
+        self.route_scale = config.routed_scaling_factor
+        self.is_hash = layer_idx < config.num_hash_layers
+        self.weight = nn.Parameter(torch.empty(config.n_routed_experts, config.hidden_size))
+        if self.is_hash:
+            initial = torch.arange(self.topk, dtype=torch.int32) % config.n_routed_experts
+            tid2eid = initial.unsqueeze(0).expand(config.vocab_size, -1).clone()
+            self.tid2eid = nn.Parameter(tid2eid, requires_grad=False)
+            self.register_parameter("bias", None)
+        else:
+            self.bias = nn.Parameter(torch.zeros(config.n_routed_experts, dtype=torch.float32))
+
+    def forward(
+        self, x: torch.Tensor, input_ids: Optional[torch.Tensor]
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        scores = _linear(x.float(), self.weight.float())
+        if self.score_func == "softmax":
+            scores = scores.softmax(dim=-1)
+        elif self.score_func == "sigmoid":
+            scores = scores.sigmoid()
+        elif self.score_func == "sqrtsoftplus":
+            scores = F.softplus(scores).sqrt()
+        else:
+            raise ValueError(f"Unsupported DeepSeek V4 scoring_func: {self.score_func}")
+
+        original_scores = scores
+        if self.bias is not None:
+            scores = scores + self.bias
+        if self.is_hash:
+            assert input_ids is not None, "input_ids is required for DeepSeek V4 hash-routed layers"
+            indices = self.tid2eid[input_ids]
+        else:
+            indices = scores.topk(self.topk, dim=-1)[1]
+        weights = original_scores.gather(1, indices)
+        if self.score_func != "softmax":
+            weights = weights / weights.sum(dim=-1, keepdim=True)
+        return weights * self.route_scale, indices
+
+
+class DeepseekV4Expert(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int, swiglu_limit: float = 0.0) -> None:
+        super().__init__()
+        self.w1 = DeepseekV4Linear(hidden_size, intermediate_size)
+        self.w2 = DeepseekV4Linear(intermediate_size, hidden_size)
+        self.w3 = DeepseekV4Linear(hidden_size, intermediate_size)
+        self.swiglu_limit = swiglu_limit
+
+    @property
+    def gate_proj(self) -> DeepseekV4Linear:
+        return self.w1
+
+    @property
+    def down_proj(self) -> DeepseekV4Linear:
+        return self.w2
+
+    @property
+    def up_proj(self) -> DeepseekV4Linear:
+        return self.w3
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate = self.w1(x, tp_mode="colwise", layer_type="moe").float()
+        up = self.w3(x, tp_mode="colwise", layer_type="moe").float()
+        if self.swiglu_limit > 0:
+            up = torch.clamp(up, min=-self.swiglu_limit, max=self.swiglu_limit)
+            gate = torch.clamp(gate, max=self.swiglu_limit)
+        hidden = F.silu(gate) * up
+        return self.w2(hidden.to(x.dtype), tp_mode="rowwise", layer_type="moe")
+
+
+class DeepseekV4MoE(nn.Module):
+    def __init__(self, config: PretrainedConfig, layer_idx: int) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.n_routed_experts = config.n_routed_experts
+        self.swiglu_limit = config.swiglu_limit
+        self.gate = DeepseekV4Gate(config, layer_idx)
+        self.experts = nn.ModuleList(
+            [
+                DeepseekV4Expert(
+                    config.hidden_size, config.moe_intermediate_size, config.swiglu_limit
+                )
+                for _ in range(config.n_routed_experts)
+            ]
+        )
+        assert config.n_shared_experts == 1, "DeepSeek V4 reference expects one shared expert"
+        self.shared_experts = DeepseekV4Expert(
+            config.hidden_size, config.moe_intermediate_size, swiglu_limit=0.0
+        )
+
+    def _dense_experts(
+        self,
+        x: torch.Tensor,
+        selected_experts: torch.Tensor,
+        routing_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        output = torch.zeros_like(x)
+        for expert_idx, expert in enumerate(self.experts):
+            expert_weight = torch.where(
+                selected_experts == expert_idx,
+                routing_weights,
+                torch.zeros_like(routing_weights),
+            ).sum(dim=-1, keepdim=True)
+            output = output + expert(x) * expert_weight.to(x.dtype)
+        return output
+
+    def forward(self, x: torch.Tensor, input_ids: torch.Tensor) -> torch.Tensor:
+        shape = x.shape
+        x_flat = x.view(-1, self.hidden_size)
+        weights, indices = self.gate(x_flat, input_ids.flatten())
+        if self.swiglu_limit == 0:
+            routed = torch.ops.auto_deploy.torch_moe(
+                x_flat,
+                indices,
+                weights,
+                w1_weight=[expert.w1.weight for expert in self.experts],
+                w2_weight=[expert.w2.weight for expert in self.experts],
+                w3_weight=[expert.w3.weight for expert in self.experts],
+                is_gated_mlp=True,
+                act_fn=int(ActivationType.Silu),
+                layer_type="moe",
+            )
+        else:
+            routed = self._dense_experts(x_flat, indices, weights)
+        routed = routed + self.shared_experts(x_flat)
+        return routed.to(x.dtype).view(shape)
+
+
+class DeepseekV4Block(nn.Module):
+    def __init__(self, config: PretrainedConfig, layer_idx: int) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.norm_eps = config.rms_norm_eps
+        self.hc_mult = config.hc_mult
+        self.hc_sinkhorn_iters = config.hc_sinkhorn_iters
+        self.hc_eps = config.hc_eps
+        self.attn = DeepseekV4Attention(config, layer_idx)
+        self.ffn = DeepseekV4MoE(config, layer_idx)
+        self.attn_norm = DeepseekV4RMSNorm(config.hidden_size, self.norm_eps)
+        self.ffn_norm = DeepseekV4RMSNorm(config.hidden_size, self.norm_eps)
+
+        mix_hc = (2 + self.hc_mult) * self.hc_mult
+        hc_dim = self.hc_mult * config.hidden_size
+        self.hc_attn_fn = nn.Parameter(torch.empty(mix_hc, hc_dim, dtype=torch.float32))
+        self.hc_ffn_fn = nn.Parameter(torch.empty(mix_hc, hc_dim, dtype=torch.float32))
+        self.hc_attn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+        self.hc_ffn_base = nn.Parameter(torch.empty(mix_hc, dtype=torch.float32))
+        self.hc_attn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+        self.hc_ffn_scale = nn.Parameter(torch.empty(3, dtype=torch.float32))
+
+    def _hc_pre(
+        self,
+        x: torch.Tensor,
+        hc_fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        shape = x.shape
+        flat = x.flatten(2).float()
+        rsqrt = torch.rsqrt(flat.square().mean(-1, keepdim=True) + self.norm_eps)
+        mixes = _linear(flat, hc_fn, None) * rsqrt
+        pre, post, comb = _hc_split_sinkhorn(
+            mixes,
+            hc_scale,
+            hc_base,
+            self.hc_mult,
+            self.hc_sinkhorn_iters,
+            self.hc_eps,
+        )
+        y = torch.sum(pre.unsqueeze(-1) * flat.view(shape), dim=2)
+        return y.to(x.dtype), post, comb
+
+    @staticmethod
+    def _hc_post(
+        x: torch.Tensor, residual: torch.Tensor, post: torch.Tensor, comb: torch.Tensor
+    ) -> torch.Tensor:
+        y = post.unsqueeze(-1) * x.unsqueeze(-2)
+        y = y + torch.sum(comb.unsqueeze(-1) * residual.unsqueeze(-2), dim=2)
+        return y.to(x.dtype)
+
+    def forward(
+        self, x: torch.Tensor, position_ids: torch.Tensor, input_ids: torch.Tensor
+    ) -> torch.Tensor:
+        residual = x
+        x, post, comb = self._hc_pre(x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+        x = self.attn_norm(x)
+        x = self.attn(x, position_ids)
+        x = self._hc_post(x, residual, post, comb)
+
+        residual = x
+        x, post, comb = self._hc_pre(x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
+        x = self.ffn_norm(x)
+        x = self.ffn(x, input_ids)
+        return self._hc_post(x, residual, post, comb)
+
+
+class DeepseekV4Head(nn.Module):
+    def __init__(self, vocab_size: int, hidden_size: int) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(vocab_size, hidden_size))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _linear(x.float(), self.weight.float(), None).to(x.dtype)
+
+
+class DeepseekV4PreTrainedModel(PreTrainedModel):
+    config_class = DeepseekV4Config
+    base_model_prefix = ""
+    _no_split_modules = ["DeepseekV4Block"]
+    _keys_to_ignore_on_load_unexpected = [r"^mtp\."]
+    supports_gradient_checkpointing = False
+
+    def _init_weights(self, module: nn.Module) -> None:
+        std = getattr(self.config, "initializer_range", 0.02)
+        if isinstance(module, DeepseekV4Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, DeepseekV4Head):
+            module.weight.data.normal_(mean=0.0, std=std)
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+        elif isinstance(module, DeepseekV4RMSNorm):
+            module.weight.data.fill_(1.0)
+        elif isinstance(module, DeepseekV4Gate):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, DeepseekV4Compressor):
+            module.ape.data.normal_(mean=0.0, std=std)
+        elif isinstance(module, DeepseekV4Attention):
+            module.attn_sink.data.zero_()
+        elif isinstance(module, DeepseekV4Block):
+            module.hc_attn_fn.data.normal_(mean=0.0, std=std)
+            module.hc_ffn_fn.data.normal_(mean=0.0, std=std)
+            module.hc_attn_base.data.zero_()
+            module.hc_ffn_base.data.zero_()
+            module.hc_attn_scale.data.fill_(1.0)
+            module.hc_ffn_scale.data.fill_(1.0)
+        elif isinstance(module, DeepseekV4ForCausalLM):
+            module.hc_head_fn.data.normal_(mean=0.0, std=std)
+            module.hc_head_base.data.zero_()
+            module.hc_head_scale.data.fill_(1.0)
+
+
+class DeepseekV4ForCausalLM(DeepseekV4PreTrainedModel, GenerationMixin):
+    def __init__(self, config: PretrainedConfig) -> None:
+        super().__init__(config)
+        self.embed = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = nn.ModuleList(
+            [DeepseekV4Block(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = DeepseekV4RMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.head = DeepseekV4Head(config.vocab_size, config.hidden_size)
+        self.hc_mult = config.hc_mult
+        hc_dim = config.hc_mult * config.hidden_size
+        self.hc_head_fn = nn.Parameter(torch.empty(config.hc_mult, hc_dim, dtype=torch.float32))
+        self.hc_head_base = nn.Parameter(torch.empty(config.hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed
+
+    def set_input_embeddings(self, new_embeddings):
+        self.embed = new_embeddings
+
+    def get_output_embeddings(self):
+        return self.head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.head = new_embeddings
+
+    def _hc_head(self, x: torch.Tensor) -> torch.Tensor:
+        shape = x.shape
+        flat = x.flatten(2).float()
+        rsqrt = torch.rsqrt(flat.square().mean(-1, keepdim=True) + self.config.rms_norm_eps)
+        mixes = _linear(flat, self.hc_head_fn, None) * rsqrt
+        pre = torch.sigmoid(mixes * self.hc_head_scale + self.hc_head_base) + self.config.hc_eps
+        return torch.sum(pre.unsqueeze(-1) * flat.view(shape), dim=2).to(x.dtype)
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> DeepseekV4CausalLMOutput:
+        assert position_ids is not None, "position_ids is required"
+        assert input_ids is not None, "input_ids is required"
+        if inputs_embeds is None:
+            inputs_embeds = self.embed(input_ids)
+
+        hidden_states = inputs_embeds.unsqueeze(2).expand(-1, -1, self.hc_mult, -1)
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, position_ids, input_ids)
+        hidden_states = self._hc_head(hidden_states)
+        hidden_states = self.norm(hidden_states)
+        logits = self.head(hidden_states)
+        return DeepseekV4CausalLMOutput(logits=logits)
+
+
+AutoModelForCausalLMFactory.register_custom_model_cls("DeepseekV4Config", DeepseekV4ForCausalLM)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
@@ -487,6 +487,19 @@ class DeepseekV4Gate(nn.Module):
     def forward(
         self, x: torch.Tensor, input_ids: Optional[torch.Tensor]
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.score_func == "sqrtsoftplus":
+            selected_experts, routing_weights = torch.ops.auto_deploy.torch_deepseek_v4_router(
+                x,
+                input_ids,
+                self.weight,
+                self.bias,
+                self.tid2eid if self.is_hash else None,
+                self.topk,
+                self.route_scale,
+                self.is_hash,
+            )
+            return routing_weights, selected_experts
+
         scores = _linear(x.float(), self.weight.float())
         if self.score_func == "softmax":
             scores = scores.softmax(dim=-1)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py
@@ -35,7 +35,7 @@ Differences from the reference implementation:
 
 import math
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -496,7 +496,12 @@ class DeepseekV4Attention(nn.Module):
 
         qr = self.q_norm(self.wq_a(x, layer_type="mla"))
         q = self.wq_b(qr, tp_mode="colwise", layer_type="mla")
-        q = q.view(batch_size, seq_len, self.num_heads, self.head_dim)
+        q = torch.ops.auto_deploy.view(
+            q,
+            [batch_size, seq_len, self.num_heads, self.head_dim],
+            tp_scaled_dim=2,
+            layer_type="mla",
+        )
         q = q * torch.rsqrt(q.square().mean(-1, keepdim=True) + self.eps)
         q_rope = _apply_rope(q[..., -self.rope_head_dim :], freqs_cis)
         q = torch.cat([q[..., : -self.rope_head_dim], q_rope], dim=-1)
@@ -537,6 +542,8 @@ class DeepseekV4Attention(nn.Module):
             freqs_cis_table,
             position_ids,
             self.softmax_scale,
+            enable_sharding=True,
+            layer_type="mla",
             layer_idx=self.layer_idx,
             window_size=self.window_size,
             compress_ratio=self.compress_ratio,
@@ -547,10 +554,16 @@ class DeepseekV4Attention(nn.Module):
         )
         o_rope = _apply_rope(o[..., -self.rope_head_dim :], freqs_cis, inverse=True)
         o = torch.cat([o[..., : -self.rope_head_dim], o_rope], dim=-1)
-        o = o.view(batch_size, seq_len, self.num_groups, -1)
+        o = torch.ops.auto_deploy.view(
+            o,
+            [batch_size, seq_len, self.num_groups, -1],
+            tp_scaled_dim=2,
+            layer_type="mla",
+        )
         wo_a = self.wo_a.weight.view(self.num_groups, self.o_lora_rank, -1)
         o = torch.einsum("bsgd,grd->bsgr", o, wo_a)
-        return self.wo_b(o.flatten(2), tp_mode="rowwise", layer_type="mla")
+        o = self.wo_b(o.flatten(2), tp_mode="rowwise", layer_type="mla")
+        return torch.ops.auto_deploy.all_reduce(o, layer_type="mla")
 
 
 class DeepseekV4Gate(nn.Module):
@@ -891,6 +904,17 @@ AutoModelForCausalLMFactory.register_custom_model_cls("DeepseekV4Config", Deepse
 
 @ModelFactoryRegistry.register("DeepseekV4AutoModelForCausalLM")
 class DeepseekV4AutoModelForCausalLMFactory(AutoModelForCausalLMFactory):
+    def _get_model_config(self) -> Tuple[PretrainedConfig, Dict[str, Any]]:
+        model_config, unused_kwargs = super()._get_model_config()
+        if (
+            "ad_rope_cache_len" in self.model_kwargs
+            and "ad_compress_max_seq_len" not in self.model_kwargs
+            and hasattr(model_config, "ad_rope_cache_len")
+            and hasattr(model_config, "ad_compress_max_seq_len")
+        ):
+            model_config.ad_compress_max_seq_len = model_config.ad_rope_cache_len
+        return model_config, unused_kwargs
+
     def get_example_inputs(self) -> Dict[str, torch.Tensor]:
         model_config, _ = self._get_model_config()
         ratios = tuple(getattr(model_config, "compress_ratios", ()))

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4_ir.py
@@ -35,6 +35,7 @@ from .modeling_deepseek_v4 import (
     DeepseekV4Config,
     _apply_rope,
     _compress_topk_idxs,
+    _sparse_attention,
     _window_topk_idxs,
 )
 from .modeling_deepseek_v4 import DeepseekV4ForCausalLM as _BaseDeepseekV4ForCausalLM
@@ -65,8 +66,12 @@ class DeepseekV4Attention(_BaseDeepseekV4Attention):
         kv = torch.cat([kv[..., : -self.rope_head_dim], kv_rope], dim=-1)
 
         topk_idxs = _window_topk_idxs(self.window_size, batch_size, seq_len, x.device)
+        compressor_kv = x.new_empty(batch_size, seq_len, 0)
+        compressor_gate = x.new_empty(batch_size, seq_len, 0)
+        compressor_ape = x.new_empty(0, 0)
+        compressor_norm_weight = x.new_empty(0)
         if self.compress_ratio:
-            compressed_kv = self.compressor(x, position_ids, freqs_cis_table)
+            compressor_kv, compressor_gate = self.compressor.project(x)
             compressed_idxs = _compress_topk_idxs(
                 self.compress_ratio,
                 batch_size,
@@ -76,16 +81,30 @@ class DeepseekV4Attention(_BaseDeepseekV4Attention):
                 self.compressor.max_compressed_len,
             )
             topk_idxs = torch.cat([topk_idxs, compressed_idxs], dim=-1)
-            kv = torch.cat([kv, compressed_kv], dim=1)
+            compressor_ape = self.compressor.ape
+            compressor_norm_weight = self.compressor.norm.weight
 
-        o = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+        o = _sparse_attention(
             q,
             kv,
             self.attn_sink,
             topk_idxs.int(),
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            position_ids,
             self.softmax_scale,
             enable_sharding=True,
             layer_type="mla",
+            layer_idx=self.layer_idx,
+            window_size=self.window_size,
+            compress_ratio=self.compress_ratio,
+            max_compressed_len=self.compressor.max_compressed_len if self.compress_ratio else None,
+            head_dim=self.head_dim,
+            rope_dim=self.rope_head_dim,
+            rms_norm_eps=self.eps,
         )
         o_rope = _apply_rope(o[..., -self.rope_head_dim :], freqs_cis, inverse=True)
         o = torch.cat([o[..., : -self.rope_head_dim], o_rope], dim=-1)

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4_ir.py
@@ -72,14 +72,17 @@ class DeepseekV4Attention(_BaseDeepseekV4Attention):
         compressor_norm_weight = x.new_empty(0)
         if self.compress_ratio:
             compressor_kv, compressor_gate = self.compressor.project(x)
-            compressed_idxs = _compress_topk_idxs(
-                self.compress_ratio,
-                batch_size,
-                seq_len,
-                seq_len,
-                x.device,
-                self.compressor.max_compressed_len,
-            )
+            if self.indexer is not None:
+                compressed_idxs = self.indexer(x, qr, position_ids, freqs_cis_table, seq_len)
+            else:
+                compressed_idxs = _compress_topk_idxs(
+                    self.compress_ratio,
+                    batch_size,
+                    seq_len,
+                    seq_len,
+                    x.device,
+                    self.compressor.max_compressed_len,
+                )
             topk_idxs = torch.cat([topk_idxs, compressed_idxs], dim=-1)
             compressor_ape = self.compressor.ape
             compressor_norm_weight = self.compressor.norm.weight

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4_ir.py
@@ -90,10 +90,9 @@ class DeepseekV4Attention(_BaseDeepseekV4Attention):
         o_rope = _apply_rope(o[..., -self.rope_head_dim :], freqs_cis, inverse=True)
         o = torch.cat([o[..., : -self.rope_head_dim], o_rope], dim=-1)
 
-        group_hidden = self.num_heads * self.head_dim // self.num_groups
         o = torch.ops.auto_deploy.view(
             o,
-            [batch_size, seq_len, self.num_groups, group_hidden],
+            [batch_size, seq_len, self.num_groups, -1],
             tp_scaled_dim=2,
             layer_type="mla",
         )

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4_ir.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepSeek V4 model variant with explicit AutoDeploy sharding IR hints.
+
+This module is imported only when ``AD_USE_IR_MODELS`` is set.  It keeps the
+base DeepSeek V4 module hierarchy and checkpoint key names intact while making
+the attention head/group reshapes and rowwise output collective explicit.
+"""
+
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
+from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+
+from .modeling_deepseek_v4 import DeepseekV4Attention as _BaseDeepseekV4Attention
+from .modeling_deepseek_v4 import (
+    DeepseekV4AutoModelForCausalLMFactory as _BaseDeepseekV4AutoModelForCausalLMFactory,
+)
+from .modeling_deepseek_v4 import DeepseekV4Block as _BaseDeepseekV4Block
+from .modeling_deepseek_v4 import (
+    DeepseekV4Config,
+    _apply_rope,
+    _compress_topk_idxs,
+    _window_topk_idxs,
+)
+from .modeling_deepseek_v4 import DeepseekV4ForCausalLM as _BaseDeepseekV4ForCausalLM
+
+
+class DeepseekV4Attention(_BaseDeepseekV4Attention):
+    """DeepSeek V4 attention that emits explicit sharding-aware IR ops."""
+
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, _ = x.shape
+        freqs_cis_table = self.rotary_emb()
+        freqs_cis = freqs_cis_table[position_ids]
+
+        qr = self.q_norm(self.wq_a(x, layer_type="mla"))
+        q = self.wq_b(qr, tp_mode="colwise", layer_type="mla")
+        q = torch.ops.auto_deploy.view(
+            q,
+            [batch_size, seq_len, self.num_heads, self.head_dim],
+            tp_scaled_dim=2,
+            layer_type="mla",
+        )
+        q = q * torch.rsqrt(q.square().mean(-1, keepdim=True) + self.eps)
+        q_rope = _apply_rope(q[..., -self.rope_head_dim :], freqs_cis)
+        q = torch.cat([q[..., : -self.rope_head_dim], q_rope], dim=-1)
+
+        kv = self.kv_norm(self.wkv(x, layer_type="mla"))
+        kv_rope = _apply_rope(kv[..., -self.rope_head_dim :], freqs_cis)
+        kv = torch.cat([kv[..., : -self.rope_head_dim], kv_rope], dim=-1)
+
+        topk_idxs = _window_topk_idxs(self.window_size, batch_size, seq_len, x.device)
+        if self.compress_ratio:
+            compressed_kv = self.compressor(x, position_ids, freqs_cis_table)
+            compressed_idxs = _compress_topk_idxs(
+                self.compress_ratio,
+                batch_size,
+                seq_len,
+                seq_len,
+                x.device,
+                self.compressor.max_compressed_len,
+            )
+            topk_idxs = torch.cat([topk_idxs, compressed_idxs], dim=-1)
+            kv = torch.cat([kv, compressed_kv], dim=1)
+
+        o = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+            q,
+            kv,
+            self.attn_sink,
+            topk_idxs.int(),
+            self.softmax_scale,
+            enable_sharding=True,
+            layer_type="mla",
+        )
+        o_rope = _apply_rope(o[..., -self.rope_head_dim :], freqs_cis, inverse=True)
+        o = torch.cat([o[..., : -self.rope_head_dim], o_rope], dim=-1)
+
+        group_hidden = self.num_heads * self.head_dim // self.num_groups
+        o = torch.ops.auto_deploy.view(
+            o,
+            [batch_size, seq_len, self.num_groups, group_hidden],
+            tp_scaled_dim=2,
+            layer_type="mla",
+        )
+        wo_a = self.wo_a.weight.view(self.num_groups, self.o_lora_rank, -1)
+        o = torch.einsum("bsgd,grd->bsgr", o, wo_a)
+        o = self.wo_b(o.flatten(2), tp_mode="rowwise", layer_type="mla")
+        return torch.ops.auto_deploy.all_reduce(o, layer_type="mla")
+
+
+class DeepseekV4Block(_BaseDeepseekV4Block):
+    """DeepSeek V4 block that swaps in the sharding-aware attention module."""
+
+    def __init__(self, config: DeepseekV4Config, layer_idx: int) -> None:
+        super().__init__(config, layer_idx)
+        self.attn = DeepseekV4Attention(config, layer_idx)
+
+
+class DeepseekV4ForCausalLM(_BaseDeepseekV4ForCausalLM):
+    """DeepSeek V4 causal LM using sharding-aware decoder blocks."""
+
+    def __init__(self, config: DeepseekV4Config, **kwargs) -> None:
+        super().__init__(config, **kwargs)
+        self.layers = nn.ModuleList(
+            [DeepseekV4Block(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.post_init()
+
+
+AutoModelForCausalLMFactory.register_custom_model_cls("DeepseekV4Config", DeepseekV4ForCausalLM)
+
+
+@ModelFactoryRegistry.register("DeepseekV4AutoModelForCausalLM")
+class DeepseekV4AutoModelForCausalLMFactory(_BaseDeepseekV4AutoModelForCausalLMFactory):
+    pass
+
+
+DeepseekV4AutoModelForCausalLMFactory.register_custom_model_cls(
+    "DeepseekV4Config", DeepseekV4ForCausalLM
+)

--- a/tensorrt_llm/_torch/auto_deploy/models/deepseek_v4_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/deepseek_v4_quant.py
@@ -1,0 +1,390 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepSeek V4 checkpoint quantization metadata helpers."""
+
+import json
+import re
+import struct
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import TypeAlias
+
+DEEPSEEK_V4_QUANT_METHOD = "deepseek_v4_fp8"
+DEEPSEEK_V4_HF_QUANT_METHOD = "fp8"
+DEEPSEEK_V4_LINEAR_QUANT_METHOD = "finegrained_fp8"
+DEEPSEEK_V4_EXPERT_QUANT_METHOD = "mxfp4"
+DEEPSEEK_V4_SCALE_FMT = "ue8m0"
+DEEPSEEK_V4_WEIGHT_BLOCK_SIZE = [128, 128]
+DEEPSEEK_V4_EXPERT_BLOCK_SIZE = 32
+
+FINEGRAINED_FP8_LINEAR = "finegrained_fp8_linear"
+PACKED_MXFP4_EXPERT = "packed_mxfp4_expert"
+BF16_OR_F32 = "bf16_or_f32"
+INTEGER_METADATA = "integer_metadata"
+SKIPPED_MTP = "skipped_mtp"
+UNKNOWN = "unknown"
+
+CLASSIFIER_CATEGORIES = (
+    FINEGRAINED_FP8_LINEAR,
+    PACKED_MXFP4_EXPERT,
+    BF16_OR_F32,
+    INTEGER_METADATA,
+    SKIPPED_MTP,
+    UNKNOWN,
+)
+
+DEEPSEEK_V4_EXCLUDED_MODULES = (
+    "embed",
+    "head",
+    "*.ffn.gate",
+    "*.attn.compressor",
+    "*.attn.indexer.compressor",
+    "*.attn.indexer.weights_proj",
+    "*.norm",
+    "*.hc_*",
+    "*.attn_sink",
+    "mtp.*",
+)
+
+TensorMetadata: TypeAlias = Mapping[str, object]
+CheckpointMetadata: TypeAlias = Mapping[str, TensorMetadata]
+
+
+class DeepSeekV4QuantConfigError(ValueError):
+    """Raised when DeepSeek V4 quantization metadata is missing or inconsistent."""
+
+
+_FINEGRAINED_FP8_LINEAR_RE = re.compile(
+    r"^layers\.\d+\.(?:"
+    r"attn\.(?:wq_a|wq_b|wkv|wo_a|wo_b)|"
+    r"attn\.indexer\.wq_b|"
+    r"ffn\.shared_experts\.w[123]"
+    r")\.(?:weight|scale)$"
+)
+_PACKED_MXFP4_EXPERT_RE = re.compile(r"^layers\.\d+\.ffn\.experts\.\d+\.w[123]\.(?:weight|scale)$")
+_INTEGER_METADATA_RE = re.compile(r"^layers\.\d+\.ffn\.gate\.tid2eid$")
+_BF16_F32_PATTERNS = (
+    re.compile(r"^(?:embed|head|norm)\.weight$"),
+    re.compile(r"^hc_head_(?:base|fn|scale)$"),
+    re.compile(r"^layers\.\d+\.attn\.attn_sink$"),
+    re.compile(r"^layers\.\d+\.attn\.(?:q_norm|kv_norm)\.weight$"),
+    re.compile(r"^layers\.\d+\.(?:attn_norm|ffn_norm)\.weight$"),
+    re.compile(r"^layers\.\d+\.ffn\.gate\.(?:weight|bias)$"),
+    re.compile(r"^layers\.\d+\.hc_(?:attn|ffn)_(?:base|fn|scale)$"),
+    re.compile(
+        r"^layers\.\d+\.attn\.compressor\."
+        r"(?:ape|norm\.weight|wgate\.weight|wkv\.weight)$"
+    ),
+    re.compile(
+        r"^layers\.\d+\.attn\.indexer\.(?:"
+        r"compressor\.(?:ape|norm\.weight|wgate\.weight|wkv\.weight)|"
+        r"weights_proj\.weight"
+        r")$"
+    ),
+)
+
+
+def is_deepseek_v4_fp8_config(config: Mapping[str, object]) -> bool:
+    """Return whether an HF config describes a DeepSeek V4 FP8 checkpoint."""
+    qconf = config.get("quantization_config")
+    if not isinstance(qconf, Mapping):
+        return False
+    return (
+        config.get("model_type") == "deepseek_v4"
+        and str(qconf.get("quant_method", "")).lower() == DEEPSEEK_V4_HF_QUANT_METHOD
+    )
+
+
+def read_deepseek_v4_safetensors_metadata(ckpt_dir: str | Path) -> dict[str, dict[str, object]]:
+    """Read tensor dtype and shape metadata from safetensors headers only."""
+    ckpt_path = Path(ckpt_dir)
+    index_path = ckpt_path / "model.safetensors.index.json"
+    if index_path.exists():
+        with index_path.open("r", encoding="utf-8") as f:
+            index = json.load(f)
+        weight_map = index.get("weight_map")
+        if not isinstance(weight_map, Mapping) or not weight_map:
+            raise DeepSeekV4QuantConfigError(
+                f"DeepSeek V4 safetensors index is missing a non-empty weight_map: {index_path}"
+            )
+        safetensors_files = sorted({str(filename) for filename in weight_map.values()})
+    else:
+        safetensors_files = sorted(path.name for path in ckpt_path.glob("*.safetensors"))
+
+    if not safetensors_files:
+        raise DeepSeekV4QuantConfigError(
+            f"DeepSeek V4 quantization requires safetensors metadata in {ckpt_path}"
+        )
+
+    tensor_metadata: dict[str, dict[str, object]] = {}
+    for filename in safetensors_files:
+        tensor_metadata.update(_read_safetensors_header(ckpt_path / filename))
+
+    return tensor_metadata
+
+
+def classify_deepseek_v4_checkpoint(
+    config: Mapping[str, object],
+    tensor_metadata: CheckpointMetadata,
+    *,
+    allow_unknown: bool = False,
+) -> dict[str, object]:
+    """Classify DeepSeek V4 checkpoint tensors by quantization family."""
+    if config.get("model_type") != "deepseek_v4":
+        raise DeepSeekV4QuantConfigError(
+            "DeepSeek V4 classifier requires model_type='deepseek_v4'."
+        )
+    if not tensor_metadata:
+        raise DeepSeekV4QuantConfigError("DeepSeek V4 classifier requires tensor metadata.")
+
+    qconf = _get_quantization_config(config)
+    weight_block_size = _get_weight_block_size(qconf)
+    _validate_scale_fmt(qconf)
+
+    categories = {category: [] for category in CLASSIFIER_CATEGORIES}
+    tensors: dict[str, dict[str, object]] = {}
+
+    for name in sorted(tensor_metadata):
+        metadata = tensor_metadata[name]
+        dtype = _get_dtype(name, metadata)
+        shape = _get_shape(name, metadata)
+        category = _classify_tensor_name(name)
+        _validate_tensor(name, dtype, shape, category, tensor_metadata, weight_block_size)
+
+        categories[category].append(name)
+        tensors[name] = {
+            "category": category,
+            "dtype": dtype,
+            "shape": shape,
+        }
+
+    unknown_tensors = categories[UNKNOWN]
+    if unknown_tensors and not allow_unknown:
+        sample = ", ".join(unknown_tensors[:10])
+        raise DeepSeekV4QuantConfigError(f"Unknown DeepSeek V4 checkpoint tensor(s): {sample}")
+
+    _validate_required_quantized_families(categories)
+    return {
+        "categories": categories,
+        "counts": {category: len(names) for category, names in categories.items()},
+        "tensors": tensors,
+    }
+
+
+def build_deepseek_v4_quant_config(
+    config: Mapping[str, object],
+    tensor_metadata: CheckpointMetadata,
+    *,
+    allow_unknown: bool = False,
+) -> dict[str, object]:
+    """Build the normalized AutoDeploy quantization config for DeepSeek V4."""
+    if not is_deepseek_v4_fp8_config(config):
+        raise DeepSeekV4QuantConfigError("Expected DeepSeek V4 HF fp8 quantization config.")
+
+    qconf = _get_quantization_config(config)
+    _validate_scale_fmt(qconf)
+    weight_block_size = _get_weight_block_size(qconf)
+    classifier = classify_deepseek_v4_checkpoint(
+        config, tensor_metadata, allow_unknown=allow_unknown
+    )
+
+    normalized = dict(qconf)
+    normalized.update(
+        {
+            "quant_method": DEEPSEEK_V4_QUANT_METHOD,
+            "hf_quant_method": DEEPSEEK_V4_HF_QUANT_METHOD,
+            "linear_quant_method": DEEPSEEK_V4_LINEAR_QUANT_METHOD,
+            "expert_quant_method": DEEPSEEK_V4_EXPERT_QUANT_METHOD,
+            "scale_fmt": DEEPSEEK_V4_SCALE_FMT,
+            "weight_block_size": weight_block_size,
+            "expert_block_size": DEEPSEEK_V4_EXPERT_BLOCK_SIZE,
+            "exclude_modules": list(DEEPSEEK_V4_EXCLUDED_MODULES),
+            "checkpoint_classification": classifier,
+        }
+    )
+    return normalized
+
+
+def _read_safetensors_header(path: Path) -> dict[str, dict[str, object]]:
+    with path.open("rb") as f:
+        header_size_bytes = f.read(8)
+        if len(header_size_bytes) != 8:
+            raise DeepSeekV4QuantConfigError(f"Invalid safetensors header in {path}")
+        header_size = struct.unpack("<Q", header_size_bytes)[0]
+        header = json.loads(f.read(header_size))
+
+    tensor_metadata: dict[str, dict[str, object]] = {}
+    for name, metadata in header.items():
+        if name == "__metadata__":
+            continue
+        if not isinstance(metadata, Mapping):
+            raise DeepSeekV4QuantConfigError(f"Invalid metadata for tensor {name} in {path}")
+        tensor_metadata[name] = {
+            "dtype": metadata.get("dtype"),
+            "shape": metadata.get("shape"),
+        }
+    return tensor_metadata
+
+
+def _get_quantization_config(config: Mapping[str, object]) -> Mapping[str, object]:
+    qconf = config.get("quantization_config")
+    if not isinstance(qconf, Mapping):
+        raise DeepSeekV4QuantConfigError("DeepSeek V4 config is missing quantization_config.")
+    return qconf
+
+
+def _validate_scale_fmt(qconf: Mapping[str, object]) -> None:
+    scale_fmt = str(qconf.get("scale_fmt", "")).lower()
+    if scale_fmt != DEEPSEEK_V4_SCALE_FMT:
+        raise DeepSeekV4QuantConfigError(
+            f"DeepSeek V4 requires scale_fmt='{DEEPSEEK_V4_SCALE_FMT}', got '{scale_fmt}'."
+        )
+
+
+def _get_weight_block_size(qconf: Mapping[str, object]) -> list[int]:
+    block_size = qconf.get("weight_block_size")
+    if not isinstance(block_size, Sequence) or isinstance(block_size, str):
+        raise DeepSeekV4QuantConfigError("DeepSeek V4 requires weight_block_size=[128, 128].")
+    normalized = [int(dim) for dim in block_size]
+    if normalized != DEEPSEEK_V4_WEIGHT_BLOCK_SIZE:
+        raise DeepSeekV4QuantConfigError(
+            "DeepSeek V4 requires weight_block_size="
+            f"{DEEPSEEK_V4_WEIGHT_BLOCK_SIZE}, got {normalized}."
+        )
+    return normalized
+
+
+def _classify_tensor_name(name: str) -> str:
+    if name.startswith("mtp."):
+        return SKIPPED_MTP
+    if _FINEGRAINED_FP8_LINEAR_RE.match(name):
+        return FINEGRAINED_FP8_LINEAR
+    if _PACKED_MXFP4_EXPERT_RE.match(name):
+        return PACKED_MXFP4_EXPERT
+    if _INTEGER_METADATA_RE.match(name):
+        return INTEGER_METADATA
+    if any(pattern.match(name) for pattern in _BF16_F32_PATTERNS):
+        return BF16_OR_F32
+    return UNKNOWN
+
+
+def _validate_tensor(
+    name: str,
+    dtype: str,
+    shape: list[int],
+    category: str,
+    tensor_metadata: CheckpointMetadata,
+    weight_block_size: Sequence[int],
+) -> None:
+    if category == FINEGRAINED_FP8_LINEAR:
+        _validate_finegrained_fp8_tensor(name, dtype, shape, tensor_metadata, weight_block_size)
+    elif category == PACKED_MXFP4_EXPERT:
+        _validate_packed_mxfp4_tensor(name, dtype, shape, tensor_metadata)
+    elif category == BF16_OR_F32 and dtype not in {"BF16", "F32"}:
+        raise DeepSeekV4QuantConfigError(f"{name} should be BF16/F32, got {dtype}.")
+    elif category == INTEGER_METADATA and dtype != "I64":
+        raise DeepSeekV4QuantConfigError(f"{name} should be I64 metadata, got {dtype}.")
+
+
+def _validate_finegrained_fp8_tensor(
+    name: str,
+    dtype: str,
+    shape: list[int],
+    tensor_metadata: CheckpointMetadata,
+    weight_block_size: Sequence[int],
+) -> None:
+    _require_2d(name, shape)
+    if name.endswith(".weight"):
+        if dtype != "F8_E4M3":
+            raise DeepSeekV4QuantConfigError(f"{name} should be F8_E4M3, got {dtype}.")
+        return
+
+    if dtype != "F8_E8M0":
+        raise DeepSeekV4QuantConfigError(f"{name} should be F8_E8M0 scale, got {dtype}.")
+    weight_name = name.removesuffix(".scale") + ".weight"
+    weight_metadata = tensor_metadata.get(weight_name)
+    if weight_metadata is None:
+        return
+    weight_shape = _get_shape(weight_name, weight_metadata)
+    _require_2d(weight_name, weight_shape)
+    expected = [
+        _ceil_div(weight_shape[0], int(weight_block_size[0])),
+        _ceil_div(weight_shape[1], int(weight_block_size[1])),
+    ]
+    if shape != expected:
+        raise DeepSeekV4QuantConfigError(
+            f"{name} has shape {shape}, expected {expected} for {weight_name}."
+        )
+
+
+def _validate_packed_mxfp4_tensor(
+    name: str,
+    dtype: str,
+    shape: list[int],
+    tensor_metadata: CheckpointMetadata,
+) -> None:
+    _require_2d(name, shape)
+    if name.endswith(".weight"):
+        if dtype != "I8":
+            raise DeepSeekV4QuantConfigError(f"{name} should be packed I8 FP4, got {dtype}.")
+        return
+
+    if dtype != "F8_E8M0":
+        raise DeepSeekV4QuantConfigError(f"{name} should be F8_E8M0 scale, got {dtype}.")
+    weight_name = name.removesuffix(".scale") + ".weight"
+    weight_metadata = tensor_metadata.get(weight_name)
+    if weight_metadata is None:
+        return
+    weight_shape = _get_shape(weight_name, weight_metadata)
+    _require_2d(weight_name, weight_shape)
+    expected = [
+        weight_shape[0],
+        _ceil_div(weight_shape[1] * 2, DEEPSEEK_V4_EXPERT_BLOCK_SIZE),
+    ]
+    if shape != expected:
+        raise DeepSeekV4QuantConfigError(
+            f"{name} has shape {shape}, expected {expected} for packed FP4 {weight_name}."
+        )
+
+
+def _validate_required_quantized_families(categories: Mapping[str, Sequence[str]]) -> None:
+    if not categories[FINEGRAINED_FP8_LINEAR]:
+        raise DeepSeekV4QuantConfigError("DeepSeek V4 metadata has no FP8 linear tensors.")
+    if not categories[PACKED_MXFP4_EXPERT]:
+        raise DeepSeekV4QuantConfigError("DeepSeek V4 metadata has no packed MXFP4 expert tensors.")
+
+
+def _get_dtype(name: str, metadata: TensorMetadata) -> str:
+    dtype = metadata.get("dtype")
+    if not isinstance(dtype, str) or not dtype:
+        raise DeepSeekV4QuantConfigError(f"Tensor {name} is missing dtype metadata.")
+    return dtype.upper()
+
+
+def _get_shape(name: str, metadata: TensorMetadata) -> list[int]:
+    shape = metadata.get("shape")
+    if not isinstance(shape, Sequence) or isinstance(shape, str):
+        raise DeepSeekV4QuantConfigError(f"Tensor {name} is missing shape metadata.")
+    return [int(dim) for dim in shape]
+
+
+def _require_2d(name: str, shape: Sequence[int]) -> None:
+    if len(shape) != 2:
+        raise DeepSeekV4QuantConfigError(f"Tensor {name} should be 2D, got shape {list(shape)}.")
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return -(-a // b)

--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -10,6 +10,7 @@ import os
 import re
 import types
 from abc import abstractmethod
+from collections.abc import Callable
 from contextlib import contextmanager, nullcontext
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
@@ -51,6 +52,355 @@ from .factory import (
     SubModuleExportInfo,
 )
 from .quant_config_reader import QuantConfigReader, autodetect_quant_config_reader
+
+_WEIGHT_LOADING_DEBUG_ENV = "AD_DEBUG_WEIGHT_LOADING"
+_WEIGHT_LOADING_DEBUG_SAMPLE_LIMIT_ENV = "AD_DEBUG_WEIGHT_LOADING_SAMPLE_LIMIT"
+
+
+def _debug_weight_loading_enabled() -> bool:
+    value = os.environ.get(_WEIGHT_LOADING_DEBUG_ENV, "")
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _debug_weight_loading_sample_limit() -> int:
+    value = os.environ.get(_WEIGHT_LOADING_DEBUG_SAMPLE_LIMIT_ENV)
+    if value is None:
+        return 20
+    try:
+        return max(0, int(value))
+    except ValueError:
+        ad_logger.warning(f"Invalid {_WEIGHT_LOADING_DEBUG_SAMPLE_LIMIT_ENV}={value!r}; using 20.")
+        return 20
+
+
+def _debug_weight_loading_prefix(device: DeviceLikeType) -> str:
+    rank = (
+        os.environ.get("RANK")
+        or os.environ.get("LOCAL_RANK")
+        or os.environ.get("PMI_RANK")
+        or os.environ.get("OMPI_COMM_WORLD_RANK")
+        or "unknown"
+    )
+    return f"[weight-load-debug rank={rank} device={device}]"
+
+
+def _is_uninitialized_tensor(value: object) -> bool:
+    uninitialized_types = []
+    for type_name in ("UninitializedParameter", "UninitializedBuffer"):
+        uninitialized_type = getattr(torch.nn.parameter, type_name, None)
+        if uninitialized_type is not None:
+            uninitialized_types.append(uninitialized_type)
+    return bool(uninitialized_types) and isinstance(value, tuple(uninitialized_types))
+
+
+def _tensor_debug_metadata(tensor: torch.Tensor) -> str:
+    dtype = getattr(tensor, "dtype", "<unknown>")
+    device = getattr(tensor, "device", "<unknown>")
+    if _is_uninitialized_tensor(tensor):
+        return f"dtype={dtype} shape=<uninitialized> device={device}"
+    try:
+        shape = tuple(tensor.shape)
+    except RuntimeError:
+        shape = "<unavailable>"
+    return f"dtype={dtype} shape={shape} device={device}"
+
+
+def _tensor_debug_fingerprint(tensor: torch.Tensor) -> tuple[Any, ...]:
+    if _is_uninitialized_tensor(tensor):
+        return ("uninitialized",)
+    if tensor.device.type == "meta":
+        return ("meta",)
+    try:
+        numel = tensor.numel()
+        shape = tuple(tensor.shape)
+    except RuntimeError as exc:
+        return ("metadata-error", type(exc).__name__, str(exc)[:120])
+    if numel == 0:
+        return ("empty",)
+
+    if len(shape) == 0:
+        indices = [()]
+    else:
+        candidate_indices = [
+            tuple(0 for _ in shape),
+            tuple(dim // 2 for dim in shape),
+            tuple(dim - 1 for dim in shape),
+        ]
+        indices = []
+        for index in candidate_indices:
+            if index not in indices:
+                indices.append(index)
+
+    values = []
+    try:
+        with torch.no_grad():
+            detached = tensor.detach()
+            for index in indices:
+                value = detached[index] if index else detached
+                if value.is_complex():
+                    value_cpu = value.detach().to("cpu")
+                    values.append(float(value_cpu.real.float().item()))
+                    values.append(float(value_cpu.imag.float().item()))
+                else:
+                    values.append(float(value.detach().to("cpu").float().item()))
+    except (RuntimeError, TypeError, ValueError) as exc:
+        return ("sample-error", type(exc).__name__, str(exc)[:120])
+
+    return ("data", *values)
+
+
+def _sample_debug_names(names: object, limit: int) -> list[str]:
+    if limit <= 0:
+        return []
+    return sorted(str(name) for name in names)[:limit]
+
+
+def _collect_weight_loading_debug_state(
+    model: nn.Module, collect_fingerprints: bool
+) -> dict[str, Any]:
+    state_dict = model.state_dict()
+    metadata = {}
+    fingerprints = {}
+    meta_keys = []
+    uninitialized_keys = []
+
+    for name, tensor in state_dict.items():
+        metadata[name] = _tensor_debug_metadata(tensor)
+        if _is_uninitialized_tensor(tensor):
+            uninitialized_keys.append(name)
+        elif tensor.device.type == "meta":
+            meta_keys.append(name)
+        if collect_fingerprints:
+            fingerprints[name] = _tensor_debug_fingerprint(tensor)
+
+    return {
+        "keys": set(state_dict.keys()),
+        "metadata": metadata,
+        "fingerprints": fingerprints,
+        "meta_keys": set(meta_keys),
+        "uninitialized_keys": set(uninitialized_keys),
+    }
+
+
+def _log_weight_loading_key_details(
+    prefix: str,
+    label: str,
+    names: object,
+    before_debug: dict[str, Any],
+    after_debug: dict[str, Any],
+    limit: int,
+) -> None:
+    samples = _sample_debug_names(names, limit)
+    if not samples:
+        return
+
+    before_metadata = before_debug.get("metadata", {})
+    after_metadata = after_debug.get("metadata", {})
+    before_fingerprints = before_debug.get("fingerprints", {})
+    after_fingerprints = after_debug.get("fingerprints", {})
+
+    details = []
+    for name in samples:
+        metadata = after_metadata.get(name) or before_metadata.get(name) or "<not in model>"
+        before_fingerprint = before_fingerprints.get(name, "<missing>")
+        after_fingerprint = after_fingerprints.get(name, "<missing>")
+        details.append(
+            f"{name} ({metadata}, before={before_fingerprint}, after={after_fingerprint})"
+        )
+    ad_logger.warning(f"{prefix} {label}: {details}")
+
+
+def _begin_weight_loading_debug(
+    model: nn.Module,
+    raw_state_dict: dict[str, torch.Tensor],
+    device: DeviceLikeType,
+) -> dict[str, Any]:
+    limit = _debug_weight_loading_sample_limit()
+    prefix = _debug_weight_loading_prefix(device)
+    before_debug = _collect_weight_loading_debug_state(model, collect_fingerprints=True)
+    expected_keys = before_debug["keys"]
+    raw_keys = set(raw_state_dict.keys())
+
+    ad_logger.info(
+        f"{prefix} raw checkpoint keys: count={len(raw_keys)} "
+        f"sample={_sample_debug_names(raw_keys, limit)}"
+    )
+    ad_logger.info(
+        f"{prefix} expected model state_dict keys before load: count={len(expected_keys)} "
+        f"meta={len(before_debug['meta_keys'])} "
+        f"uninitialized={len(before_debug['uninitialized_keys'])} "
+        f"sample={_sample_debug_names(expected_keys, limit)}"
+    )
+    ad_logger.info(
+        f"{prefix} raw checkpoint vs expected before root pre-hooks: "
+        f"missing={len(expected_keys - raw_keys)} unexpected={len(raw_keys - expected_keys)}"
+    )
+
+    return {
+        "limit": limit,
+        "prefix": prefix,
+        "before": before_debug,
+        "raw_keys": raw_keys,
+    }
+
+
+def _make_weight_loading_debug_pre_hook(debug_info: dict[str, Any]) -> Callable[..., None]:
+    def _debug_pre_hook(
+        module: nn.Module,
+        state_dict: dict[str, torch.Tensor],
+        prefix: str,
+        *args,
+    ) -> None:
+        del module, args
+        if prefix:
+            return
+
+        transformed_keys = set(state_dict.keys())
+        expected_keys = debug_info["before"]["keys"]
+        missing_keys = expected_keys - transformed_keys
+        unexpected_keys = transformed_keys - expected_keys
+        debug_info["transformed_keys"] = transformed_keys
+        debug_info["root_missing_keys"] = missing_keys
+        debug_info["root_unexpected_keys"] = unexpected_keys
+
+        log_prefix = debug_info["prefix"]
+        limit = debug_info["limit"]
+        ad_logger.info(
+            f"{log_prefix} transformed state_dict keys after root pre-load hooks: "
+            f"count={len(transformed_keys)} missing_vs_expected={len(missing_keys)} "
+            f"unexpected_vs_expected={len(unexpected_keys)} "
+            f"sample={_sample_debug_names(transformed_keys, limit)}"
+        )
+        if missing_keys:
+            ad_logger.warning(
+                f"{log_prefix} sample keys missing after root pre-load hooks: "
+                f"{_sample_debug_names(missing_keys, limit)}"
+            )
+        if unexpected_keys:
+            ad_logger.warning(
+                f"{log_prefix} sample unexpected keys after root pre-load hooks: "
+                f"{_sample_debug_names(unexpected_keys, limit)}"
+            )
+
+    return _debug_pre_hook
+
+
+def _finish_weight_loading_debug(
+    model: nn.Module,
+    incompatible_keys: object,
+    debug_info: dict[str, Any],
+) -> None:
+    prefix = debug_info["prefix"]
+    limit = debug_info["limit"]
+    before_debug = debug_info["before"]
+    after_debug = _collect_weight_loading_debug_state(model, collect_fingerprints=True)
+
+    load_missing_keys = set(getattr(incompatible_keys, "missing_keys", []))
+    load_unexpected_keys = set(getattr(incompatible_keys, "unexpected_keys", []))
+    transformed_keys = debug_info.get("transformed_keys")
+    root_missing_keys = debug_info.get("root_missing_keys", set())
+    root_unexpected_keys = debug_info.get("root_unexpected_keys", set())
+
+    if transformed_keys is None:
+        ad_logger.warning(f"{prefix} debug pre-hook did not observe the root state_dict.")
+        transformed_keys = set()
+
+    before_keys = before_debug["keys"]
+    after_keys = after_debug["keys"]
+    common_keys = before_keys & after_keys
+    before_fingerprints = before_debug["fingerprints"]
+    after_fingerprints = after_debug["fingerprints"]
+    unchanged_keys = {
+        key
+        for key in common_keys
+        if before_fingerprints.get(key) == after_fingerprints.get(key)
+        and before_fingerprints.get(key, ("",))[0] == "data"
+    }
+    unchanged_missing_keys = unchanged_keys & (load_missing_keys | root_missing_keys)
+    unchanged_transformed_keys = unchanged_keys & transformed_keys - unchanged_missing_keys
+
+    ad_logger.info(
+        f"{prefix} load_state_dict result: missing={len(load_missing_keys)} "
+        f"unexpected={len(load_unexpected_keys)}"
+    )
+    if load_missing_keys:
+        ad_logger.warning(
+            f"{prefix} sample load_state_dict missing keys: "
+            f"{_sample_debug_names(load_missing_keys, limit)}"
+        )
+    if load_unexpected_keys:
+        ad_logger.warning(
+            f"{prefix} sample load_state_dict unexpected keys: "
+            f"{_sample_debug_names(load_unexpected_keys, limit)}"
+        )
+
+    ad_logger.info(
+        f"{prefix} post-load model state_dict keys: count={len(after_keys)} "
+        f"lost_vs_before={len(before_keys - after_keys)} "
+        f"added_vs_before={len(after_keys - before_keys)} "
+        f"meta={len(after_debug['meta_keys'])} "
+        f"uninitialized={len(after_debug['uninitialized_keys'])}"
+    )
+    ad_logger.info(
+        f"{prefix} unchanged sampled fingerprints after load: "
+        f"total={len(unchanged_keys)} "
+        f"missing_or_absent={len(unchanged_missing_keys)} "
+        f"present_after_root_pre_hooks={len(unchanged_transformed_keys)}"
+    )
+
+    _log_weight_loading_key_details(
+        prefix,
+        "post-load meta tensors",
+        after_debug["meta_keys"],
+        before_debug,
+        after_debug,
+        limit,
+    )
+    _log_weight_loading_key_details(
+        prefix,
+        "post-load uninitialized tensors",
+        after_debug["uninitialized_keys"],
+        before_debug,
+        after_debug,
+        limit,
+    )
+    _log_weight_loading_key_details(
+        prefix,
+        "load_state_dict missing key details",
+        load_missing_keys,
+        before_debug,
+        after_debug,
+        limit,
+    )
+    _log_weight_loading_key_details(
+        prefix,
+        "root pre-hook missing key details",
+        root_missing_keys,
+        before_debug,
+        after_debug,
+        limit,
+    )
+    _log_weight_loading_key_details(
+        prefix,
+        "unchanged missing/absent key details",
+        unchanged_missing_keys,
+        before_debug,
+        after_debug,
+        limit,
+    )
+    _log_weight_loading_key_details(
+        prefix,
+        "unchanged transformed key details",
+        unchanged_transformed_keys,
+        before_debug,
+        after_debug,
+        limit,
+    )
+    if root_unexpected_keys:
+        ad_logger.warning(
+            f"{prefix} root pre-hook unexpected key count={len(root_unexpected_keys)} "
+            f"sample={_sample_debug_names(root_unexpected_keys, limit)}"
+        )
 
 
 @contextmanager
@@ -513,8 +863,24 @@ class AutoModelForCausalLMFactory(AutoModelFactory):
     ):
         all_weights = self._load_full_checkpoint_to_cpu(ckpt_file)
 
+        debug_info = None
+        debug_handle = None
+        if _debug_weight_loading_enabled():
+            debug_info = _begin_weight_loading_debug(model, all_weights, device)
+            debug_handle = model.register_load_state_dict_pre_hook(
+                _make_weight_loading_debug_pre_hook(debug_info)
+            )
+            model._load_state_dict_pre_hooks.move_to_end(key=debug_handle.id, last=True)
+
         ad_logger.info(f"Loading weights into model (device: {device})...")
-        model.load_state_dict(all_weights, strict=False)
+        try:
+            incompatible_keys = model.load_state_dict(all_weights, strict=False)
+        finally:
+            if debug_handle is not None:
+                debug_handle.remove()
+
+        if debug_info is not None:
+            _finish_weight_loading_debug(model, incompatible_keys, debug_info)
 
         ad_logger.info("Checkpoint loading completed")
 

--- a/tensorrt_llm/_torch/auto_deploy/models/quant_config_reader.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/quant_config_reader.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Quantization Config Reader Registry.
 
@@ -12,6 +27,12 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, Optional, Tuple, Type
 
 from ..utils.logger import ad_logger
+from .deepseek_v4_quant import (
+    DeepSeekV4QuantConfigError,
+    build_deepseek_v4_quant_config,
+    is_deepseek_v4_fp8_config,
+    read_deepseek_v4_safetensors_metadata,
+)
 
 
 class QuantConfigReader(ABC):
@@ -207,6 +228,16 @@ class HFQuantConfigReader(QuantConfigReader):
         if not qconf:
             raise ValueError("HF quantization_config not found.")
 
+        if is_deepseek_v4_fp8_config(config):
+            tensor_metadata = config.get("checkpoint_tensor_metadata")
+            if not isinstance(tensor_metadata, dict):
+                raise DeepSeekV4QuantConfigError(
+                    "DeepSeek V4 HF fp8 config requires checkpoint_tensor_metadata."
+                )
+            self._quant_config = build_deepseek_v4_quant_config(config, tensor_metadata)
+            self._hf_quantizer = None
+            return {}
+
         # Inject default exclusion, add "model.embed_tokens" for "tie_word_embedding:true" case
         excludes = qconf.get("exclude_modules", [])
         qconf["exclude_modules"] = excludes + [n for n in self._ALWAYS_EXCLUDE if n not in excludes]
@@ -237,6 +268,13 @@ class HFQuantConfigReader(QuantConfigReader):
         quant_method = str(qconf.get("quant_method", "")).lower()
         if quant_method not in cls._SUPPORTED_QUANT_METHODS:
             return None
+
+        if is_deepseek_v4_fp8_config(raw):
+            raw = dict(raw)
+            raw["checkpoint_tensor_metadata"] = read_deepseek_v4_safetensors_metadata(ckpt_dir)
+            reader = cls()
+            extra_model_kwargs = reader.read_config(raw)
+            return reader, extra_model_kwargs
 
         # Validate GPTQ config: currently only INT4 with group_size=128 is supported
         if quant_method == "gptq":
@@ -277,6 +315,8 @@ def autodetect_quant_config_reader(
         hf_cls = QuantConfigReaderRegistry.get("hf")
         try:
             result = hf_cls.from_file(fetched_dir)
+        except DeepSeekV4QuantConfigError:
+            raise
         except Exception:
             # Skip HF reader if it errors out during probing
             result = None

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -31,6 +31,7 @@ else:
 
 from ..custom_ops.attention_interface import (
     CausalConvResourceHandler,
+    DeepSeekV4PagedResourceHandler,
     KVPagedResourceHandler,
     ResourceHandler,
     ResourceHandlerDict,
@@ -156,9 +157,19 @@ class CachedSequenceInterface:
         Low-level method that adds a single resource. If you have a group of related resources
         that should share the same index, use add_resource_group() instead.
         """
+        if isinstance(resource_handler, DeepSeekV4PagedResourceHandler):
+            resource_handler.register_metadata(self.info)
+
         full_name = f"r{len(self._resource_lookup)}_{suffix}"
         self._resource_lookup[full_name] = resource_handler
         return full_name
+
+    def add_resource_group(self, resource_handlers: ResourceHandlerDict) -> Dict[str, str]:
+        """Add a group of related resource handlers in declaration order."""
+        return {
+            suffix: self.add_resource(suffix, resource_handler)
+            for suffix, resource_handler in resource_handlers.items()
+        }
 
     @staticmethod
     def _check_n_groups_constraint(

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeepSeek V4 MoE lowering skeleton.
+
+The correct production lowering must preserve three distinct pieces of behavior:
+
+* DeepSeek V4 sqrt-softplus/hash routing.
+* Packed MXFP4 routed experts with the DeepSeek V4 SwiGLU limit.
+* FineGrained FP8 shared expert linears.
+
+Until the packed routed-expert and shared-expert production paths are wired
+together, this transform refuses to replace the canonical op by default. Tests
+can opt into a dense reference lowering that keeps the graph export-friendly
+without pretending to be the production path.
+"""
+
+from __future__ import annotations
+
+import operator
+from typing import Any
+
+import torch
+from pydantic import Field
+from torch.fx import GraphModule, Node
+
+from ...custom_ops.fused_moe.deepseek_v4_moe import (  # noqa: F401
+    torch_deepseek_v4_moe,
+    torch_deepseek_v4_moe_from_routing,
+)
+from ...custom_ops.fused_moe.deepseek_v4_router import torch_deepseek_v4_router  # noqa: F401
+from ...utils.node_utils import is_op
+from ..interface import BaseTransform, TransformConfig, TransformInfo, TransformRegistry
+
+__all__ = [
+    "DeepSeekV4MoELowering",
+    "DeepSeekV4MoELoweringConfig",
+    "DeepSeekV4MoELoweringError",
+]
+
+
+class DeepSeekV4MoELoweringError(RuntimeError):
+    """Raised when a DeepSeek V4 MoE graph cannot be lowered safely."""
+
+
+class DeepSeekV4MoELoweringConfig(TransformConfig):
+    allow_reference_lowering: bool = Field(
+        default=False,
+        description=(
+            "Allow lowering torch_deepseek_v4_moe to router + dense reference "
+            "torch_deepseek_v4_moe_from_routing. This is intended for unit tests, "
+            "not production inference."
+        ),
+    )
+
+
+_ARG_NAMES = (
+    "hidden_states",
+    "input_ids",
+    "router_weight",
+    "router_bias",
+    "tid2eid",
+    "routed_w1_weight",
+    "routed_w2_weight",
+    "routed_w3_weight",
+    "shared_w1_weight",
+    "shared_w2_weight",
+    "shared_w3_weight",
+    "top_k",
+    "route_scale",
+    "swiglu_limit",
+    "is_hash_layer",
+    "layer_type",
+)
+_MISSING = object()
+
+
+def _node_arg(node: Node, name: str, default: Any = _MISSING) -> Any:
+    index = _ARG_NAMES.index(name)
+    if len(node.args) > index:
+        return node.args[index]
+    if name in node.kwargs:
+        return node.kwargs[name]
+    if default is not _MISSING:
+        return default
+    raise DeepSeekV4MoELoweringError(
+        f"Malformed torch_deepseek_v4_moe node is missing required argument {name!r}."
+    )
+
+
+def _unsupported_production_lowering_error() -> DeepSeekV4MoELoweringError:
+    return DeepSeekV4MoELoweringError(
+        "DeepSeek V4 MoE production lowering is not implemented for "
+        "auto_deploy::torch_deepseek_v4_moe yet. A safe production lowering must "
+        "lower routed experts to auto_deploy::triton_mxfp4_moe/triton_mxfp4_moe_ep "
+        "and lower the shared expert through FineGrained FP8 linear/SwiGLU surfaces "
+        "while preserving swiglu_limit. Set allow_reference_lowering=True only for "
+        "tests or reference graphs."
+    )
+
+
+def _lower_to_reference_graph(gm: GraphModule, node: Node) -> None:
+    graph = gm.graph
+    hidden_states = _node_arg(node, "hidden_states")
+    input_ids = _node_arg(node, "input_ids")
+    router_weight = _node_arg(node, "router_weight")
+    router_bias = _node_arg(node, "router_bias")
+    tid2eid = _node_arg(node, "tid2eid")
+    top_k = _node_arg(node, "top_k")
+    route_scale = _node_arg(node, "route_scale")
+    is_hash_layer = _node_arg(node, "is_hash_layer")
+
+    with graph.inserting_before(node):
+        router_node = graph.call_function(
+            torch.ops.auto_deploy.torch_deepseek_v4_router.default,
+            args=(
+                hidden_states,
+                input_ids,
+                router_weight,
+                router_bias,
+                tid2eid,
+                top_k,
+                route_scale,
+                is_hash_layer,
+            ),
+        )
+        selected_experts = graph.call_function(operator.getitem, args=(router_node, 0))
+        routing_weights = graph.call_function(operator.getitem, args=(router_node, 1))
+
+    node.target = torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default
+    node.args = (
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        _node_arg(node, "routed_w1_weight"),
+        _node_arg(node, "routed_w2_weight"),
+        _node_arg(node, "routed_w3_weight"),
+        _node_arg(node, "shared_w1_weight"),
+        _node_arg(node, "shared_w2_weight"),
+        _node_arg(node, "shared_w3_weight"),
+        _node_arg(node, "swiglu_limit"),
+        _node_arg(node, "layer_type", "moe"),
+    )
+    node.kwargs = {}
+
+
+@TransformRegistry.register("lower_deepseek_v4_moe")
+class DeepSeekV4MoELowering(BaseTransform):
+    """Lower DeepSeek V4 MoE source ops.
+
+    The default behavior is intentionally conservative: matching a canonical
+    node raises a clear error until a real MXFP4 + FineGrained FP8 production
+    lowering is available. Unit tests may opt into dense reference lowering.
+    """
+
+    config: DeepSeekV4MoELoweringConfig
+
+    @classmethod
+    def get_config_class(cls) -> type[TransformConfig]:
+        return DeepSeekV4MoELoweringConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm,
+        factory,
+        shared_config,
+    ) -> tuple[GraphModule, TransformInfo]:
+        del cm, factory, shared_config
+
+        num_matches = 0
+        for node in list(gm.graph.nodes):
+            if not is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_moe):
+                continue
+            num_matches += 1
+            if not self.config.allow_reference_lowering:
+                raise _unsupported_production_lowering_error()
+            _lower_to_reference_graph(gm, node)
+
+        if num_matches:
+            gm.graph.lint()
+            gm.recompile()
+
+        return gm, TransformInfo(
+            skipped=num_matches == 0,
+            num_matches=num_matches,
+            is_clean=num_matches == 0,
+            has_valid_shapes=num_matches == 0,
+        )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py
@@ -39,7 +39,10 @@ from ...custom_ops.fused_moe.deepseek_v4_moe import (  # noqa: F401
     torch_deepseek_v4_moe,
     torch_deepseek_v4_moe_from_routing,
 )
-from ...custom_ops.fused_moe.deepseek_v4_router import torch_deepseek_v4_router  # noqa: F401
+from ...custom_ops.fused_moe.deepseek_v4_router import (  # noqa: F401
+    torch_deepseek_v4_router,
+    triton_deepseek_v4_router,
+)
 from ...custom_ops.fused_moe.mxfp4_moe import (  # noqa: F401
     triton_deepseek_v4_mxfp4_moe_from_routing,
 )
@@ -508,7 +511,7 @@ def _lower_to_mxfp4_bridge(gm: GraphModule, node: Node) -> _MoEBridge:
 
     with graph.inserting_before(node):
         router_node = graph.call_function(
-            torch.ops.auto_deploy.torch_deepseek_v4_router.default,
+            torch.ops.auto_deploy.triton_deepseek_v4_router.default,
             args=(
                 hidden_states,
                 input_ids,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py
@@ -224,13 +224,23 @@ def _set_parameter(
     setattr(module, attr_name, nn.Parameter(value, requires_grad=requires_grad))
 
 
-def _register_buffer(gm: GraphModule, full_name: str, value: torch.Tensor) -> None:
+def _register_buffer(
+    gm: GraphModule,
+    full_name: str,
+    value: torch.Tensor,
+    *,
+    persistent: bool = True,
+) -> None:
     module_name, _, attr_name = full_name.rpartition(".")
     module = gm.get_submodule(module_name) if module_name else gm
     if attr_name in module._buffers:
         module._buffers[attr_name] = value
+        if persistent:
+            module._non_persistent_buffers_set.discard(attr_name)
+        else:
+            module._non_persistent_buffers_set.add(attr_name)
     else:
-        module.register_buffer(attr_name, value)
+        module.register_buffer(attr_name, value, persistent=persistent)
 
 
 def _create_get_attr_with_meta(gm: GraphModule, graph: torch.fx.Graph, full_name: str) -> Node:
@@ -241,6 +251,13 @@ def _create_get_attr_with_meta(gm: GraphModule, graph: torch.fx.Graph, full_name
     if isinstance(value, torch.Tensor):
         node.meta["val"] = value.detach()
     return node
+
+
+def _delete_attr(gm: GraphModule, full_name: str) -> None:
+    module_name, _, attr_name = full_name.rpartition(".")
+    module = gm.get_submodule(module_name) if module_name else gm
+    if hasattr(module, attr_name):
+        delattr(module, attr_name)
 
 
 def _fp8_scale_shape(weight_shape: torch.Size) -> tuple[int, int]:
@@ -476,15 +493,17 @@ def _lower_to_mxfp4_bridge(gm: GraphModule, node: Node) -> _MoEBridge:
 
     gate_up_bias_name = f"{info.ffn_path}.mxfp4_gate_up_bias"
     down_bias_name = f"{info.ffn_path}.mxfp4_down_bias"
-    _set_parameter(
+    _register_buffer(
         gm,
         gate_up_bias_name,
         torch.zeros((info.num_experts, 2 * info.intermediate_size), dtype=torch.float32),
+        persistent=False,
     )
-    _set_parameter(
+    _register_buffer(
         gm,
         down_bias_name,
         torch.zeros((info.num_experts, info.hidden_size), dtype=torch.float32),
+        persistent=False,
     )
 
     with graph.inserting_before(node):
@@ -552,6 +571,13 @@ def _lower_to_mxfp4_bridge(gm: GraphModule, node: Node) -> _MoEBridge:
 
     node.replace_all_uses_with(output)
     graph.erase_node(node)
+    graph.eliminate_dead_code()
+    for expert_idx in range(bridge.num_experts):
+        for proj in ("w1", "w2", "w3"):
+            _delete_attr(
+                gm,
+                f"layers.{bridge.layer_idx}.ffn.experts.{expert_idx}.{proj}.weight",
+            )
     return bridge
 
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py
@@ -13,26 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""DeepSeek V4 MoE lowering skeleton.
+"""DeepSeek V4 MoE lowering.
 
-The correct production lowering must preserve three distinct pieces of behavior:
+The production lowering preserves three distinct pieces of behavior:
 
 * DeepSeek V4 sqrt-softplus/hash routing.
 * Packed MXFP4 routed experts with the DeepSeek V4 SwiGLU limit.
 * FineGrained FP8 shared expert linears.
-
-Until the packed routed-expert and shared-expert production paths are wired
-together, this transform refuses to replace the canonical op by default. Tests
-can opt into a dense reference lowering that keeps the graph export-friendly
-without pretending to be the production path.
 """
 
 from __future__ import annotations
 
+import math
 import operator
+import re
+from dataclasses import dataclass
 from typing import Any
 
 import torch
+import torch.nn as nn
 from pydantic import Field
 from torch.fx import GraphModule, Node
 
@@ -41,8 +40,15 @@ from ...custom_ops.fused_moe.deepseek_v4_moe import (  # noqa: F401
     torch_deepseek_v4_moe_from_routing,
 )
 from ...custom_ops.fused_moe.deepseek_v4_router import torch_deepseek_v4_router  # noqa: F401
+from ...custom_ops.fused_moe.mxfp4_moe import (  # noqa: F401
+    triton_deepseek_v4_mxfp4_moe_from_routing,
+)
+from ...custom_ops.quantization.torch_quant import (  # noqa: F401
+    torch_fake_quant_finegrained_fp8_linear,
+)
 from ...utils.node_utils import is_op
 from ..interface import BaseTransform, TransformConfig, TransformInfo, TransformRegistry
+from .deepseek_v4_mxfp4 import load_deepseek_v4_mxfp4_experts
 
 __all__ = [
     "DeepSeekV4MoELowering",
@@ -62,6 +68,13 @@ class DeepSeekV4MoELoweringConfig(TransformConfig):
             "Allow lowering torch_deepseek_v4_moe to router + dense reference "
             "torch_deepseek_v4_moe_from_routing. This is intended for unit tests, "
             "not production inference."
+        ),
+    )
+    enable_mxfp4_bridge: bool = Field(
+        default=True,
+        description=(
+            "Lower canonical DeepSeek V4 MoE to DeepSeek routing plus packed MXFP4 routed "
+            "experts and FineGrained FP8 shared expert linears."
         ),
     )
 
@@ -85,6 +98,32 @@ _ARG_NAMES = (
     "layer_type",
 )
 _MISSING = object()
+_EXPERT_WEIGHT_RE = re.compile(
+    r"^(?P<ffn_path>layers\.(?P<layer_idx>\d+)\.ffn)\.experts\."
+    r"(?P<expert_idx>\d+)\.(?P<proj>w[123])\.weight$"
+)
+
+
+@dataclass(frozen=True)
+class _MoEBridge:
+    layer_idx: int
+    ffn_path: str
+    hidden_size: int
+    intermediate_size: int
+    num_experts: int
+    gate_up_blocks_name: str
+    gate_up_scales_name: str
+    down_blocks_name: str
+    down_scales_name: str
+
+
+@dataclass(frozen=True)
+class _LayerInfo:
+    layer_idx: int
+    ffn_path: str
+    hidden_size: int
+    intermediate_size: int
+    num_experts: int
 
 
 def _node_arg(node: Node, name: str, default: Any = _MISSING) -> Any:
@@ -109,6 +148,219 @@ def _unsupported_production_lowering_error() -> DeepSeekV4MoELoweringError:
         "while preserving swiglu_limit. Set allow_reference_lowering=True only for "
         "tests or reference graphs."
     )
+
+
+def _get_attr_name(node: Any) -> str | None:
+    if isinstance(node, Node) and node.op == "get_attr":
+        return str(node.target)
+    return None
+
+
+def _stack_get_attr_names(stack_node: Any) -> list[str]:
+    if not isinstance(stack_node, Node) or stack_node.op != "call_function":
+        return []
+    if not stack_node.args:
+        return []
+    values = stack_node.args[0]
+    if not isinstance(values, (list, tuple)):
+        return []
+    names = [_get_attr_name(value) for value in values]
+    if any(name is None for name in names):
+        return []
+    return [name for name in names if name is not None]
+
+
+def _infer_layer_info(gm: GraphModule, node: Node) -> _LayerInfo:
+    w1_names = _stack_get_attr_names(_node_arg(node, "routed_w1_weight"))
+    if not w1_names:
+        raise DeepSeekV4MoELoweringError(
+            "DeepSeek V4 MXFP4 bridge requires routed w1 weights to be an exported "
+            "stack of per-expert get_attr nodes."
+        )
+
+    match = _EXPERT_WEIGHT_RE.match(w1_names[0])
+    if match is None:
+        raise DeepSeekV4MoELoweringError(
+            f"Could not infer DeepSeek V4 layer path from routed expert weight {w1_names[0]!r}."
+        )
+
+    ffn_path = match.group("ffn_path")
+    layer_idx = int(match.group("layer_idx"))
+    expected_prefix = f"{ffn_path}.experts."
+    for expert_idx, name in enumerate(w1_names):
+        expected = f"{expected_prefix}{expert_idx}.w1.weight"
+        if name != expected:
+            raise DeepSeekV4MoELoweringError(
+                "DeepSeek V4 MXFP4 bridge requires routed experts in checkpoint order; "
+                f"expected {expected!r}, got {name!r}."
+            )
+
+    first_weight = gm.get_parameter(w1_names[0])
+    if first_weight.ndim != 2:
+        raise DeepSeekV4MoELoweringError(
+            f"Expected routed expert weight {w1_names[0]!r} to be rank 2, got "
+            f"shape {tuple(first_weight.shape)}."
+        )
+
+    return _LayerInfo(
+        layer_idx=layer_idx,
+        ffn_path=ffn_path,
+        hidden_size=int(first_weight.shape[1]),
+        intermediate_size=int(first_weight.shape[0]),
+        num_experts=len(w1_names),
+    )
+
+
+def _set_parameter(
+    gm: GraphModule,
+    full_name: str,
+    value: torch.Tensor,
+    *,
+    requires_grad: bool = False,
+) -> None:
+    module_name, _, attr_name = full_name.rpartition(".")
+    module = gm.get_submodule(module_name) if module_name else gm
+    setattr(module, attr_name, nn.Parameter(value, requires_grad=requires_grad))
+
+
+def _register_buffer(gm: GraphModule, full_name: str, value: torch.Tensor) -> None:
+    module_name, _, attr_name = full_name.rpartition(".")
+    module = gm.get_submodule(module_name) if module_name else gm
+    if attr_name in module._buffers:
+        module._buffers[attr_name] = value
+    else:
+        module.register_buffer(attr_name, value)
+
+
+def _fp8_scale_shape(weight_shape: torch.Size) -> tuple[int, int]:
+    return (math.ceil(int(weight_shape[0]) / 128), math.ceil(int(weight_shape[1]) / 128))
+
+
+def _ensure_shared_fp8_param_and_scale(gm: GraphModule, weight_name: str) -> str:
+    weight = gm.get_parameter(weight_name)
+    if weight.dtype != torch.float8_e4m3fn:
+        _set_parameter(
+            gm,
+            weight_name,
+            torch.empty(tuple(weight.shape), dtype=torch.float8_e4m3fn, device=weight.device),
+        )
+    scale_name = weight_name.rsplit(".", 1)[0] + ".weight_scale_inv"
+    if scale_name not in dict(gm.named_buffers()):
+        _register_buffer(
+            gm,
+            scale_name,
+            torch.ones(_fp8_scale_shape(weight.shape), dtype=torch.float32, device=weight.device),
+        )
+    return scale_name
+
+
+def _register_bridge_params(gm: GraphModule, info: _LayerInfo) -> _MoEBridge:
+    h_blocks = info.hidden_size // 32
+    i_blocks = info.intermediate_size // 32
+    if info.hidden_size % 32 != 0 or info.intermediate_size % 32 != 0:
+        raise DeepSeekV4MoELoweringError(
+            "DeepSeek V4 MXFP4 bridge requires hidden and intermediate sizes to be "
+            f"divisible by 32, got H={info.hidden_size}, I={info.intermediate_size}."
+        )
+
+    ffn_path = info.ffn_path
+    gate_up_blocks_name = f"{ffn_path}.mxfp4_gate_up_blocks"
+    gate_up_scales_name = f"{ffn_path}.mxfp4_gate_up_scales"
+    down_blocks_name = f"{ffn_path}.mxfp4_down_blocks"
+    down_scales_name = f"{ffn_path}.mxfp4_down_scales"
+
+    _set_parameter(
+        gm,
+        gate_up_blocks_name,
+        torch.zeros(
+            (info.num_experts, 2 * info.intermediate_size, h_blocks, 16), dtype=torch.uint8
+        ),
+    )
+    _set_parameter(
+        gm,
+        gate_up_scales_name,
+        torch.zeros((info.num_experts, 2 * info.intermediate_size, h_blocks), dtype=torch.uint8),
+    )
+    _set_parameter(
+        gm,
+        down_blocks_name,
+        torch.zeros((info.num_experts, info.hidden_size, i_blocks, 16), dtype=torch.uint8),
+    )
+    _set_parameter(
+        gm,
+        down_scales_name,
+        torch.zeros((info.num_experts, info.hidden_size, i_blocks), dtype=torch.uint8),
+    )
+
+    return _MoEBridge(
+        layer_idx=info.layer_idx,
+        ffn_path=ffn_path,
+        hidden_size=info.hidden_size,
+        intermediate_size=info.intermediate_size,
+        num_experts=info.num_experts,
+        gate_up_blocks_name=gate_up_blocks_name,
+        gate_up_scales_name=gate_up_scales_name,
+        down_blocks_name=down_blocks_name,
+        down_scales_name=down_scales_name,
+    )
+
+
+def _register_mxfp4_load_hook(gm: GraphModule, bridges: list[_MoEBridge]) -> None:
+    if not bridges:
+        return
+    existing = getattr(gm, "_deepseek_v4_mxfp4_bridges", [])
+    setattr(gm, "_deepseek_v4_mxfp4_bridges", [*existing, *bridges])
+    if getattr(gm, "_deepseek_v4_mxfp4_load_hook_registered", False):
+        return
+
+    def _load_hook(state_dict: dict[str, torch.Tensor], prefix: str, *args) -> None:
+        del args
+        prefix = prefix or ""
+        all_bridges = getattr(gm, "_deepseek_v4_mxfp4_bridges", [])
+        load_state = state_dict
+        if prefix:
+            load_state = {
+                key[len(prefix) :]: value
+                for key, value in state_dict.items()
+                if key.startswith(prefix)
+            }
+
+        for bridge in all_bridges:
+            has_any_expert_key = any(
+                f"layers.{bridge.layer_idx}.ffn.experts.{expert_idx}.w1.weight" in load_state
+                for expert_idx in range(bridge.num_experts)
+            )
+            if has_any_expert_key:
+                layout = load_deepseek_v4_mxfp4_experts(
+                    load_state,
+                    layer_idx=bridge.layer_idx,
+                    hidden_size=bridge.hidden_size,
+                    intermediate_size=bridge.intermediate_size,
+                    num_experts=bridge.num_experts,
+                )
+                state_dict[prefix + bridge.gate_up_blocks_name] = layout.gate_up_blocks
+                state_dict[prefix + bridge.gate_up_scales_name] = layout.gate_up_scales
+                state_dict[prefix + bridge.down_blocks_name] = layout.down_blocks
+                state_dict[prefix + bridge.down_scales_name] = layout.down_scales
+
+            for expert_idx in range(bridge.num_experts):
+                for proj in ("w1", "w2", "w3"):
+                    for suffix in ("weight", "scale"):
+                        state_dict.pop(
+                            prefix
+                            + f"layers.{bridge.layer_idx}.ffn.experts.{expert_idx}."
+                            + f"{proj}.{suffix}",
+                            None,
+                        )
+
+            for proj in ("w1", "w2", "w3"):
+                scale_alias = prefix + f"{bridge.ffn_path}.shared_experts.{proj}.scale"
+                scale_buffer = prefix + f"{bridge.ffn_path}.shared_experts.{proj}.weight_scale_inv"
+                if scale_alias in state_dict:
+                    state_dict[scale_buffer] = state_dict.pop(scale_alias)
+
+    gm._register_load_state_dict_pre_hook(_load_hook)
+    setattr(gm, "_deepseek_v4_mxfp4_load_hook_registered", True)
 
 
 def _lower_to_reference_graph(gm: GraphModule, node: Node) -> None:
@@ -156,13 +408,136 @@ def _lower_to_reference_graph(gm: GraphModule, node: Node) -> None:
     node.kwargs = {}
 
 
+def _call_shared_fp8_linear(
+    graph: torch.fx.Graph,
+    hidden_states: Node,
+    weight: Any,
+    scale: Node,
+) -> Node:
+    return graph.call_function(
+        torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear.default,
+        args=(
+            hidden_states,
+            weight,
+            None,
+            [],
+            [scale],
+            [],
+            [],
+            "none",
+            None,
+            1,
+            "moe",
+        ),
+    )
+
+
+def _lower_to_mxfp4_bridge(gm: GraphModule, node: Node) -> _MoEBridge:
+    graph = gm.graph
+    info = _infer_layer_info(gm, node)
+    bridge = _register_bridge_params(gm, info)
+
+    hidden_states = _node_arg(node, "hidden_states")
+    input_ids = _node_arg(node, "input_ids")
+    router_weight = _node_arg(node, "router_weight")
+    router_bias = _node_arg(node, "router_bias")
+    tid2eid = _node_arg(node, "tid2eid")
+    top_k = _node_arg(node, "top_k")
+    route_scale = _node_arg(node, "route_scale")
+    swiglu_limit = _node_arg(node, "swiglu_limit")
+    is_hash_layer = _node_arg(node, "is_hash_layer")
+    layer_type = _node_arg(node, "layer_type", "moe")
+
+    shared_w1 = _node_arg(node, "shared_w1_weight")
+    shared_w2 = _node_arg(node, "shared_w2_weight")
+    shared_w3 = _node_arg(node, "shared_w3_weight")
+    shared_w1_name = _get_attr_name(shared_w1)
+    shared_w2_name = _get_attr_name(shared_w2)
+    shared_w3_name = _get_attr_name(shared_w3)
+    if shared_w1_name is None or shared_w2_name is None or shared_w3_name is None:
+        raise DeepSeekV4MoELoweringError(
+            "DeepSeek V4 MXFP4 bridge requires shared expert weights to be get_attr nodes."
+        )
+    shared_w1_scale_name = _ensure_shared_fp8_param_and_scale(gm, shared_w1_name)
+    shared_w2_scale_name = _ensure_shared_fp8_param_and_scale(gm, shared_w2_name)
+    shared_w3_scale_name = _ensure_shared_fp8_param_and_scale(gm, shared_w3_name)
+
+    gate_up_bias_name = f"{info.ffn_path}.mxfp4_gate_up_bias"
+    down_bias_name = f"{info.ffn_path}.mxfp4_down_bias"
+    _set_parameter(
+        gm,
+        gate_up_bias_name,
+        torch.zeros((info.num_experts, 2 * info.intermediate_size), dtype=torch.float32),
+    )
+    _set_parameter(
+        gm,
+        down_bias_name,
+        torch.zeros((info.num_experts, info.hidden_size), dtype=torch.float32),
+    )
+
+    with graph.inserting_before(node):
+        router_node = graph.call_function(
+            torch.ops.auto_deploy.torch_deepseek_v4_router.default,
+            args=(
+                hidden_states,
+                input_ids,
+                router_weight,
+                router_bias,
+                tid2eid,
+                top_k,
+                route_scale,
+                is_hash_layer,
+            ),
+        )
+        selected_experts = graph.call_function(operator.getitem, args=(router_node, 0))
+        routing_weights = graph.call_function(operator.getitem, args=(router_node, 1))
+
+        gate_up_blocks = graph.create_node("get_attr", bridge.gate_up_blocks_name)
+        gate_up_bias = graph.create_node("get_attr", gate_up_bias_name)
+        gate_up_scales = graph.create_node("get_attr", bridge.gate_up_scales_name)
+        down_blocks = graph.create_node("get_attr", bridge.down_blocks_name)
+        down_bias = graph.create_node("get_attr", down_bias_name)
+        down_scales = graph.create_node("get_attr", bridge.down_scales_name)
+
+        routed = graph.call_function(
+            torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing.default,
+            args=(
+                hidden_states,
+                selected_experts,
+                routing_weights,
+                gate_up_blocks,
+                gate_up_bias,
+                gate_up_scales,
+                1.0,
+                float(swiglu_limit),
+                down_blocks,
+                down_bias,
+                down_scales,
+                layer_type,
+            ),
+        )
+
+        shared_w1_scale = graph.create_node("get_attr", shared_w1_scale_name)
+        shared_w2_scale = graph.create_node("get_attr", shared_w2_scale_name)
+        shared_w3_scale = graph.create_node("get_attr", shared_w3_scale_name)
+        shared_gate = _call_shared_fp8_linear(graph, hidden_states, shared_w1, shared_w1_scale)
+        shared_up = _call_shared_fp8_linear(graph, hidden_states, shared_w3, shared_w3_scale)
+        shared_act = graph.call_function(torch.ops.aten.silu.default, args=(shared_gate,))
+        shared_hidden = graph.call_function(torch.ops.aten.mul.Tensor, args=(shared_act, shared_up))
+        shared = _call_shared_fp8_linear(graph, shared_hidden, shared_w2, shared_w2_scale)
+        output = graph.call_function(torch.ops.aten.add.Tensor, args=(routed, shared))
+
+    node.replace_all_uses_with(output)
+    graph.erase_node(node)
+    return bridge
+
+
 @TransformRegistry.register("lower_deepseek_v4_moe")
 class DeepSeekV4MoELowering(BaseTransform):
     """Lower DeepSeek V4 MoE source ops.
 
-    The default behavior is intentionally conservative: matching a canonical
-    node raises a clear error until a real MXFP4 + FineGrained FP8 production
-    lowering is available. Unit tests may opt into dense reference lowering.
+    Unit tests may opt into dense reference lowering; production uses packed
+    MXFP4 routed experts plus FineGrained FP8 shared experts.
     """
 
     config: DeepSeekV4MoELoweringConfig
@@ -181,15 +556,20 @@ class DeepSeekV4MoELowering(BaseTransform):
         del cm, factory, shared_config
 
         num_matches = 0
+        bridges: list[_MoEBridge] = []
         for node in list(gm.graph.nodes):
             if not is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_moe):
                 continue
             num_matches += 1
-            if not self.config.allow_reference_lowering:
+            if self.config.allow_reference_lowering:
+                _lower_to_reference_graph(gm, node)
+                continue
+            if not self.config.enable_mxfp4_bridge:
                 raise _unsupported_production_lowering_error()
-            _lower_to_reference_graph(gm, node)
+            bridges.append(_lower_to_mxfp4_bridge(gm, node))
 
         if num_matches:
+            _register_mxfp4_load_hook(gm, bridges)
             gm.graph.lint()
             gm.recompile()
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py
@@ -46,7 +46,8 @@ from ...custom_ops.fused_moe.mxfp4_moe import (  # noqa: F401
 from ...custom_ops.quantization.torch_quant import (  # noqa: F401
     torch_fake_quant_finegrained_fp8_linear,
 )
-from ...utils.node_utils import is_op
+from ...custom_ops.sharding_ops import all_reduce  # noqa: F401
+from ...utils.node_utils import invalidate_weight_node_cache, is_op
 from ..interface import BaseTransform, TransformConfig, TransformInfo, TransformRegistry
 from .deepseek_v4_mxfp4 import load_deepseek_v4_mxfp4_experts
 
@@ -232,6 +233,16 @@ def _register_buffer(gm: GraphModule, full_name: str, value: torch.Tensor) -> No
         module.register_buffer(attr_name, value)
 
 
+def _create_get_attr_with_meta(gm: GraphModule, graph: torch.fx.Graph, full_name: str) -> Node:
+    node = graph.create_node("get_attr", full_name)
+    module_name, _, attr_name = full_name.rpartition(".")
+    module = gm.get_submodule(module_name) if module_name else gm
+    value = getattr(module, attr_name)
+    if isinstance(value, torch.Tensor):
+        node.meta["val"] = value.detach()
+    return node
+
+
 def _fp8_scale_shape(weight_shape: torch.Size) -> tuple[int, int]:
     return (math.ceil(int(weight_shape[0]) / 128), math.ceil(int(weight_shape[1]) / 128))
 
@@ -413,6 +424,7 @@ def _call_shared_fp8_linear(
     hidden_states: Node,
     weight: Any,
     scale: Node,
+    tp_mode: str,
 ) -> Node:
     return graph.call_function(
         torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear.default,
@@ -424,7 +436,7 @@ def _call_shared_fp8_linear(
             [scale],
             [],
             [],
-            "none",
+            tp_mode,
             None,
             1,
             "moe",
@@ -492,12 +504,12 @@ def _lower_to_mxfp4_bridge(gm: GraphModule, node: Node) -> _MoEBridge:
         selected_experts = graph.call_function(operator.getitem, args=(router_node, 0))
         routing_weights = graph.call_function(operator.getitem, args=(router_node, 1))
 
-        gate_up_blocks = graph.create_node("get_attr", bridge.gate_up_blocks_name)
-        gate_up_bias = graph.create_node("get_attr", gate_up_bias_name)
-        gate_up_scales = graph.create_node("get_attr", bridge.gate_up_scales_name)
-        down_blocks = graph.create_node("get_attr", bridge.down_blocks_name)
-        down_bias = graph.create_node("get_attr", down_bias_name)
-        down_scales = graph.create_node("get_attr", bridge.down_scales_name)
+        gate_up_blocks = _create_get_attr_with_meta(gm, graph, bridge.gate_up_blocks_name)
+        gate_up_bias = _create_get_attr_with_meta(gm, graph, gate_up_bias_name)
+        gate_up_scales = _create_get_attr_with_meta(gm, graph, bridge.gate_up_scales_name)
+        down_blocks = _create_get_attr_with_meta(gm, graph, bridge.down_blocks_name)
+        down_bias = _create_get_attr_with_meta(gm, graph, down_bias_name)
+        down_scales = _create_get_attr_with_meta(gm, graph, bridge.down_scales_name)
 
         routed = graph.call_function(
             torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing.default,
@@ -517,14 +529,25 @@ def _lower_to_mxfp4_bridge(gm: GraphModule, node: Node) -> _MoEBridge:
             ),
         )
 
-        shared_w1_scale = graph.create_node("get_attr", shared_w1_scale_name)
-        shared_w2_scale = graph.create_node("get_attr", shared_w2_scale_name)
-        shared_w3_scale = graph.create_node("get_attr", shared_w3_scale_name)
-        shared_gate = _call_shared_fp8_linear(graph, hidden_states, shared_w1, shared_w1_scale)
-        shared_up = _call_shared_fp8_linear(graph, hidden_states, shared_w3, shared_w3_scale)
+        shared_w1_scale = _create_get_attr_with_meta(gm, graph, shared_w1_scale_name)
+        shared_w2_scale = _create_get_attr_with_meta(gm, graph, shared_w2_scale_name)
+        shared_w3_scale = _create_get_attr_with_meta(gm, graph, shared_w3_scale_name)
+        shared_gate = _call_shared_fp8_linear(
+            graph, hidden_states, shared_w1, shared_w1_scale, "colwise"
+        )
+        shared_up = _call_shared_fp8_linear(
+            graph, hidden_states, shared_w3, shared_w3_scale, "colwise"
+        )
         shared_act = graph.call_function(torch.ops.aten.silu.default, args=(shared_gate,))
         shared_hidden = graph.call_function(torch.ops.aten.mul.Tensor, args=(shared_act, shared_up))
-        shared = _call_shared_fp8_linear(graph, shared_hidden, shared_w2, shared_w2_scale)
+        shared = _call_shared_fp8_linear(
+            graph, shared_hidden, shared_w2, shared_w2_scale, "rowwise"
+        )
+        shared = graph.call_function(
+            torch.ops.auto_deploy.all_reduce.default,
+            args=(shared,),
+            kwargs={"layer_type": "moe"},
+        )
         output = graph.call_function(torch.ops.aten.add.Tensor, args=(routed, shared))
 
     node.replace_all_uses_with(output)
@@ -570,6 +593,7 @@ class DeepSeekV4MoELowering(BaseTransform):
 
         if num_matches:
             _register_mxfp4_load_hook(gm, bridges)
+            invalidate_weight_node_cache(gm)
             gm.graph.lint()
             gm.recompile()
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_mxfp4.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_mxfp4.py
@@ -1,0 +1,366 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Packed DeepSeek V4 MXFP4 routed expert loading helpers.
+
+DeepSeek V4 stores routed expert checkpoint weights as signed I8 tensors that
+contain two packed FP4 values per byte. The tensors are already quantized; this
+module only validates, reinterprets, blocks, and stacks their raw bytes for the
+AutoDeploy MXFP4 MoE backend.
+
+The stable output layout is:
+
+* ``gate_up_blocks``: ``[E_local, 2 * I, H / 32, 16]`` ``torch.uint8``
+* ``gate_up_scales``: ``[E_local, 2 * I, H / 32]`` ``torch.uint8``
+* ``down_blocks``: ``[E_local, H, I / 32, 16]`` ``torch.uint8``
+* ``down_scales``: ``[E_local, H, I / 32]`` ``torch.uint8``
+
+``H`` is the model hidden size and ``I`` is the MoE intermediate size. The
+gate/up tensors are stacked in runtime order ``[w3, w1]`` along the ``2 * I``
+dimension, matching the existing fused MoE and ``triton_mxfp4_moe`` contract.
+E8M0 scales are preserved as exponent bytes with ``view(torch.uint8)`` via the
+shared E8M0 helper; they are never numerically converted.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal, cast
+
+import torch
+
+from ...utils.e8m0 import e8m0_to_uint8
+
+DEEPSEEK_V4_MXFP4_BLOCK_SIZE = 32
+DEEPSEEK_V4_MXFP4_PACKED_VALUES_PER_BYTE = 2
+DEEPSEEK_V4_MXFP4_BYTES_PER_BLOCK = (
+    DEEPSEEK_V4_MXFP4_BLOCK_SIZE // DEEPSEEK_V4_MXFP4_PACKED_VALUES_PER_BYTE
+)
+
+DeepSeekV4ExpertProj = Literal["w1", "w2", "w3"]
+DeepSeekV4ExpertSuffix = Literal["weight", "scale"]
+
+_EXPERT_KEY_RE = re.compile(
+    r"^layers\.(?P<layer_idx>\d+)\.ffn\.experts\.(?P<expert_idx>\d+)\."
+    r"(?P<proj>w[123])\.(?P<suffix>weight|scale)$"
+)
+
+__all__ = [
+    "DEEPSEEK_V4_MXFP4_BLOCK_SIZE",
+    "DEEPSEEK_V4_MXFP4_BYTES_PER_BLOCK",
+    "DeepSeekV4ExpertKey",
+    "DeepSeekV4MXFP4Layout",
+    "DeepSeekV4MXFP4LoaderError",
+    "expert_parallel_slice",
+    "load_deepseek_v4_mxfp4_experts",
+    "parse_deepseek_v4_expert_key",
+    "slice_deepseek_v4_mxfp4_experts",
+]
+
+
+class DeepSeekV4MXFP4LoaderError(ValueError):
+    """Raised when DeepSeek V4 packed MXFP4 expert tensors are inconsistent."""
+
+
+@dataclass(frozen=True)
+class DeepSeekV4ExpertKey:
+    """Parsed DeepSeek V4 per-expert checkpoint key components."""
+
+    layer_idx: int
+    expert_idx: int
+    proj: DeepSeekV4ExpertProj
+    suffix: DeepSeekV4ExpertSuffix
+
+
+@dataclass(frozen=True)
+class DeepSeekV4MXFP4Layout:
+    """Backend-ready packed routed expert tensors.
+
+    Attributes:
+        gate_up_blocks: Packed FP4 bytes in ``[E_local, 2 * I, H / 32, 16]`` layout.
+            The ``2 * I`` dimension is ordered as ``[w3, w1]``.
+        gate_up_scales: Raw E8M0 exponent bytes in ``[E_local, 2 * I, H / 32]`` layout,
+            ordered as ``[w3, w1]``.
+        down_blocks: Packed FP4 bytes in ``[E_local, H, I / 32, 16]`` layout.
+        down_scales: Raw E8M0 exponent bytes in ``[E_local, H, I / 32]`` layout.
+        expert_indices: Global expert ids represented by the local expert dimension.
+        hidden_size: Model hidden size ``H``.
+        intermediate_size: MoE intermediate size ``I``.
+    """
+
+    gate_up_blocks: torch.Tensor
+    gate_up_scales: torch.Tensor
+    down_blocks: torch.Tensor
+    down_scales: torch.Tensor
+    expert_indices: tuple[int, ...]
+    hidden_size: int
+    intermediate_size: int
+
+
+def parse_deepseek_v4_expert_key(name: str) -> DeepSeekV4ExpertKey | None:
+    """Parse a DeepSeek V4 routed expert checkpoint key.
+
+    Args:
+        name: Candidate checkpoint key, for example
+            ``layers.3.ffn.experts.42.w1.weight``.
+
+    Returns:
+        Parsed key components, or ``None`` when ``name`` is not a routed expert
+        ``w1``/``w2``/``w3`` weight or scale key.
+    """
+    match = _EXPERT_KEY_RE.match(name)
+    if match is None:
+        return None
+    return DeepSeekV4ExpertKey(
+        layer_idx=int(match.group("layer_idx")),
+        expert_idx=int(match.group("expert_idx")),
+        proj=cast(DeepSeekV4ExpertProj, match.group("proj")),
+        suffix=cast(DeepSeekV4ExpertSuffix, match.group("suffix")),
+    )
+
+
+def load_deepseek_v4_mxfp4_experts(
+    state_dict: Mapping[str, torch.Tensor],
+    *,
+    layer_idx: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int | None = None,
+    expert_indices: Sequence[int] | None = None,
+) -> DeepSeekV4MXFP4Layout:
+    """Load and stack packed MXFP4 routed expert tensors for one DeepSeek V4 layer.
+
+    Args:
+        state_dict: Checkpoint tensors keyed by the DeepSeek V4 HF names
+            ``layers.{layer_idx}.ffn.experts.{expert_idx}.w{1,2,3}.{weight,scale}``.
+        layer_idx: Decoder layer index to load.
+        hidden_size: Model hidden size ``H``. Must be divisible by 32.
+        intermediate_size: MoE intermediate size ``I``. Must be divisible by 32.
+        num_experts: Optional total routed expert count. When provided without
+            ``expert_indices``, the loader requires ``range(num_experts)``.
+        expert_indices: Optional explicit global expert ids to load and stack,
+            in output order.
+
+    Returns:
+        ``DeepSeekV4MXFP4Layout`` containing uint8 packed blocks and raw scale bytes.
+    """
+    _validate_model_dims(hidden_size, intermediate_size)
+    experts = _resolve_expert_indices(state_dict, layer_idx, num_experts, expert_indices)
+
+    gate_up_block_list = []
+    gate_up_scale_list = []
+    down_block_list = []
+    down_scale_list = []
+    for expert_idx in experts:
+        w3_blocks = _load_weight_blocks(
+            state_dict, layer_idx, expert_idx, "w3", intermediate_size, hidden_size
+        )
+        w1_blocks = _load_weight_blocks(
+            state_dict, layer_idx, expert_idx, "w1", intermediate_size, hidden_size
+        )
+        w3_scales = _load_scale_bytes(
+            state_dict, layer_idx, expert_idx, "w3", intermediate_size, hidden_size
+        )
+        w1_scales = _load_scale_bytes(
+            state_dict, layer_idx, expert_idx, "w1", intermediate_size, hidden_size
+        )
+
+        down_blocks = _load_weight_blocks(
+            state_dict, layer_idx, expert_idx, "w2", hidden_size, intermediate_size
+        )
+        down_scales = _load_scale_bytes(
+            state_dict, layer_idx, expert_idx, "w2", hidden_size, intermediate_size
+        )
+
+        gate_up_block_list.append(torch.cat((w3_blocks, w1_blocks), dim=0).contiguous())
+        gate_up_scale_list.append(torch.cat((w3_scales, w1_scales), dim=0).contiguous())
+        down_block_list.append(down_blocks.contiguous())
+        down_scale_list.append(down_scales.contiguous())
+
+    return DeepSeekV4MXFP4Layout(
+        gate_up_blocks=torch.stack(gate_up_block_list, dim=0).contiguous(),
+        gate_up_scales=torch.stack(gate_up_scale_list, dim=0).contiguous(),
+        down_blocks=torch.stack(down_block_list, dim=0).contiguous(),
+        down_scales=torch.stack(down_scale_list, dim=0).contiguous(),
+        expert_indices=experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+
+
+def expert_parallel_slice(num_experts: int, ep_size: int, ep_rank: int) -> slice:
+    """Return the contiguous expert slice owned by an expert-parallel rank.
+
+    The partitioning mirrors the existing ``triton_mxfp4_moe`` sharding path:
+    every rank receives ``num_experts // ep_size`` experts, and the last rank
+    receives any remainder.
+    """
+    if num_experts < 0:
+        raise DeepSeekV4MXFP4LoaderError(f"num_experts must be non-negative, got {num_experts}.")
+    if ep_size <= 0:
+        raise DeepSeekV4MXFP4LoaderError(f"ep_size must be positive, got {ep_size}.")
+    if ep_rank < 0 or ep_rank >= ep_size:
+        raise DeepSeekV4MXFP4LoaderError(f"ep_rank must be in [0, {ep_size}), got {ep_rank}.")
+
+    base = num_experts // ep_size
+    start = base * ep_rank
+    stop = num_experts if ep_rank == ep_size - 1 else base * (ep_rank + 1)
+    return slice(start, stop)
+
+
+def slice_deepseek_v4_mxfp4_experts(
+    layout: DeepSeekV4MXFP4Layout,
+    *,
+    ep_size: int,
+    ep_rank: int,
+) -> DeepSeekV4MXFP4Layout:
+    """Slice a stacked MXFP4 expert layout along the expert dimension only."""
+    expert_slice = expert_parallel_slice(len(layout.expert_indices), ep_size, ep_rank)
+    return DeepSeekV4MXFP4Layout(
+        gate_up_blocks=layout.gate_up_blocks[expert_slice].contiguous(),
+        gate_up_scales=layout.gate_up_scales[expert_slice].contiguous(),
+        down_blocks=layout.down_blocks[expert_slice].contiguous(),
+        down_scales=layout.down_scales[expert_slice].contiguous(),
+        expert_indices=layout.expert_indices[expert_slice],
+        hidden_size=layout.hidden_size,
+        intermediate_size=layout.intermediate_size,
+    )
+
+
+def _validate_model_dims(hidden_size: int, intermediate_size: int) -> None:
+    for name, dim in (("hidden_size", hidden_size), ("intermediate_size", intermediate_size)):
+        if dim <= 0:
+            raise DeepSeekV4MXFP4LoaderError(f"{name} must be positive, got {dim}.")
+        if dim % DEEPSEEK_V4_MXFP4_BLOCK_SIZE != 0:
+            raise DeepSeekV4MXFP4LoaderError(
+                f"{name} must be divisible by {DEEPSEEK_V4_MXFP4_BLOCK_SIZE}, got {dim}."
+            )
+
+
+def _resolve_expert_indices(
+    state_dict: Mapping[str, torch.Tensor],
+    layer_idx: int,
+    num_experts: int | None,
+    expert_indices: Sequence[int] | None,
+) -> tuple[int, ...]:
+    if expert_indices is not None:
+        experts = tuple(int(expert_idx) for expert_idx in expert_indices)
+    elif num_experts is not None:
+        if num_experts <= 0:
+            raise DeepSeekV4MXFP4LoaderError(f"num_experts must be positive, got {num_experts}.")
+        experts = tuple(range(num_experts))
+    else:
+        experts = tuple(
+            sorted(
+                {
+                    parsed.expert_idx
+                    for name in state_dict
+                    if (parsed := parse_deepseek_v4_expert_key(name)) is not None
+                    and parsed.layer_idx == layer_idx
+                }
+            )
+        )
+
+    if not experts:
+        raise DeepSeekV4MXFP4LoaderError(
+            f"No DeepSeek V4 MXFP4 routed experts found for layer {layer_idx}."
+        )
+    if len(set(experts)) != len(experts):
+        raise DeepSeekV4MXFP4LoaderError(f"Duplicate expert indices requested: {experts}.")
+    if any(expert_idx < 0 for expert_idx in experts):
+        raise DeepSeekV4MXFP4LoaderError(f"Expert indices must be non-negative: {experts}.")
+    if num_experts is not None and any(expert_idx >= num_experts for expert_idx in experts):
+        raise DeepSeekV4MXFP4LoaderError(
+            f"Expert indices {experts} are out of range for num_experts={num_experts}."
+        )
+    return experts
+
+
+def _expert_tensor_key(
+    layer_idx: int, expert_idx: int, proj: DeepSeekV4ExpertProj, suffix: DeepSeekV4ExpertSuffix
+) -> str:
+    return f"layers.{layer_idx}.ffn.experts.{expert_idx}.{proj}.{suffix}"
+
+
+def _load_weight_blocks(
+    state_dict: Mapping[str, torch.Tensor],
+    layer_idx: int,
+    expert_idx: int,
+    proj: DeepSeekV4ExpertProj,
+    rows: int,
+    logical_cols: int,
+) -> torch.Tensor:
+    key = _expert_tensor_key(layer_idx, expert_idx, proj, "weight")
+    tensor = _require_tensor(state_dict, key)
+    expected_shape = (rows, logical_cols // DEEPSEEK_V4_MXFP4_PACKED_VALUES_PER_BYTE)
+    _check_shape(key, tensor, expected_shape)
+
+    if tensor.dtype == torch.int8:
+        raw = tensor.view(torch.uint8)
+    elif tensor.dtype == torch.uint8:
+        raw = tensor
+    else:
+        raise DeepSeekV4MXFP4LoaderError(
+            f"{key} must be packed torch.int8 or torch.uint8 bytes, got {tensor.dtype}."
+        )
+
+    return raw.contiguous().view(
+        rows,
+        logical_cols // DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
+        DEEPSEEK_V4_MXFP4_BYTES_PER_BLOCK,
+    )
+
+
+def _load_scale_bytes(
+    state_dict: Mapping[str, torch.Tensor],
+    layer_idx: int,
+    expert_idx: int,
+    proj: DeepSeekV4ExpertProj,
+    rows: int,
+    logical_cols: int,
+) -> torch.Tensor:
+    key = _expert_tensor_key(layer_idx, expert_idx, proj, "scale")
+    tensor = _require_tensor(state_dict, key)
+    expected_shape = (rows, logical_cols // DEEPSEEK_V4_MXFP4_BLOCK_SIZE)
+    _check_shape(key, tensor, expected_shape)
+
+    if tensor.dtype == torch.uint8:
+        raw = tensor
+    else:
+        try:
+            raw = e8m0_to_uint8(tensor)
+        except (RuntimeError, TypeError) as err:
+            raise DeepSeekV4MXFP4LoaderError(
+                f"{key} must be torch.float8_e8m0fnu or raw torch.uint8 scale bytes, "
+                f"got {tensor.dtype}."
+            ) from err
+    return raw.contiguous()
+
+
+def _require_tensor(state_dict: Mapping[str, torch.Tensor], key: str) -> torch.Tensor:
+    tensor = state_dict.get(key)
+    if tensor is None:
+        raise DeepSeekV4MXFP4LoaderError(f"Missing DeepSeek V4 MXFP4 tensor: {key}.")
+    return tensor
+
+
+def _check_shape(key: str, tensor: torch.Tensor, expected_shape: tuple[int, int]) -> None:
+    actual_shape = tuple(int(dim) for dim in tensor.shape)
+    if actual_shape != expected_shape:
+        raise DeepSeekV4MXFP4LoaderError(
+            f"{key} has shape {list(actual_shape)}, expected {list(expected_shape)}."
+        )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -223,11 +223,11 @@ class _InsertCachedOperator(BaseTransform):
                         f"Duplicate KV cache owner detected for layer {layer_idx}. "
                         "Each non-shared attention layer must own exactly one cache."
                     )
-                cache_in_nodes = []
-                for k, resource_handler in attn_descriptor.get_cache_initializers(
+                cache_initializers = attn_descriptor.get_cache_initializers(
                     attn_node, cm.kv_cache_config
-                ).items():
-                    resource_name = cm.add_resource(k, resource_handler)
+                )
+                cache_in_nodes = []
+                for resource_name in cm.add_resource_group(cache_initializers).values():
                     cache_in_nodes.append(self._process_cache_node(gm, resource_name))
                 if layer_idx is not None:
                     cache_nodes_by_layer_idx[layer_idx] = cache_in_nodes

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -27,6 +27,7 @@ from ...utils.node_utils import (
     get_quantization_params_from_linear_node,
     is_bmm_op,
     is_linear_op,
+    is_op,
 )
 from ...utils.quantization_utils import (
     fp4_global_scale,
@@ -59,6 +60,7 @@ _DEEPSEEK_V4_FINEGRAINED_FP8_LINEAR_RE = re.compile(
     r"ffn\.shared_experts\.w[123]"
     r")$"
 )
+_DEEPSEEK_V4_WO_A_WEIGHT_RE = re.compile(r"(?:^|.*\.)layers\.\d+\.attn\.wo_a\.weight$")
 
 
 def _is_deepseek_v4_finegrained_fp8_config(qcfg: Dict) -> bool:
@@ -71,6 +73,99 @@ def _is_deepseek_v4_finegrained_fp8_config(qcfg: Dict) -> bool:
 def _is_deepseek_v4_finegrained_fp8_linear_path(weight_or_module_name: str) -> bool:
     module_name = weight_or_module_name.removesuffix(".weight")
     return _DEEPSEEK_V4_FINEGRAINED_FP8_LINEAR_RE.match(module_name) is not None
+
+
+def _is_deepseek_v4_wo_a_weight_path(weight_name: str) -> bool:
+    return _DEEPSEEK_V4_WO_A_WEIGHT_RE.match(weight_name) is not None
+
+
+def _is_view_or_reshape_node(node: Node) -> bool:
+    if not isinstance(node, Node):
+        return False
+    if node.op == "call_method":
+        return node.target in {"view", "reshape"}
+    return is_op(
+        node,
+        [
+            torch.ops.aten.view,
+            torch.ops.aten.reshape,
+            torch.ops.auto_deploy.view,
+        ],
+    )
+
+
+def _view_base_and_shape(node: Node) -> Tuple[Node, Tuple[object, ...]]:
+    if node.op == "call_method":
+        base = node.args[0]
+        shape_args = node.args[1:]
+    else:
+        base = node.args[0]
+        shape_args = node.args[1:]
+    if len(shape_args) == 1 and isinstance(shape_args[0], (list, tuple)):
+        shape_args = tuple(shape_args[0])
+    return base, tuple(shape_args)
+
+
+def _is_static_dim_value(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _is_einsum_node(node: Node) -> bool:
+    if not isinstance(node, Node) or node.op != "call_function":
+        return False
+    return node.target in {
+        torch.einsum,
+        torch.functional.einsum,
+        torch.ops.aten.einsum.default,
+    }
+
+
+def _extract_deepseek_v4_wo_a_einsum_args(node: Node) -> Tuple[Node, Node, str] | None:
+    if not _is_einsum_node(node) or not node.args:
+        return None
+    if node.args[0] != "bsgd,grd->bsgr":
+        return None
+
+    if len(node.args) >= 3:
+        input_view = node.args[1]
+        weight_view = node.args[2]
+    elif len(node.args) >= 2 and isinstance(node.args[1], (list, tuple)):
+        operands = node.args[1]
+        if len(operands) != 2:
+            return None
+        input_view, weight_view = operands
+    else:
+        return None
+
+    if not isinstance(input_view, Node) or not isinstance(weight_view, Node):
+        return None
+    if not _is_view_or_reshape_node(input_view) or not _is_view_or_reshape_node(weight_view):
+        return None
+
+    input_base, input_shape = _view_base_and_shape(input_view)
+    weight_base, weight_shape = _view_base_and_shape(weight_view)
+    if not isinstance(input_base, Node) or not isinstance(weight_base, Node):
+        return None
+    if weight_base.op != "get_attr" or not isinstance(weight_base.target, str):
+        return None
+    weight_name = weight_base.target
+    if not _is_deepseek_v4_wo_a_weight_path(weight_name):
+        return None
+    if len(input_shape) != 4 or len(weight_shape) != 3:
+        return None
+
+    num_groups = weight_shape[0]
+    o_lora_rank = weight_shape[1]
+    if (
+        not _is_static_dim_value(num_groups)
+        or not _is_static_dim_value(o_lora_rank)
+        or input_shape[2] != num_groups
+        or input_shape[3] != -1
+        or weight_shape[2] != -1
+    ):
+        return None
+
+    return input_view, weight_base, weight_name
 
 
 def _dedupe_patterns(patterns: List[str]) -> List[str]:
@@ -915,6 +1010,12 @@ class FineGrainedFP8LinearQuantization(Quantization):
     def target_op(self):
         return torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear.default
 
+    def deepseek_v4_wo_a_grouped_target_op(self):
+        grouped_op = (
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear
+        )
+        return grouped_op.default
+
     def quantize_weight(self, w: torch.Tensor) -> torch.Tensor:
         return torch.empty_like(w, dtype=torch.float8_e4m3fn, device=w.device)
 
@@ -968,6 +1069,39 @@ class FineGrainedFP8LinearQuantization(Quantization):
             scale = state_dict.pop(scale_name)
         state_dict[scale_buffer_name] = _maybe_decode_e8m0_scale(scale)
 
+    def _insert_deepseek_v4_wo_a_grouped_quantized_linear(
+        self,
+        gm: GraphModule,
+        einsum_node: Node,
+        input_view: Node,
+        weight_node: Node,
+        weight_name: str,
+    ) -> None:
+        original_weight = gm.get_parameter(weight_name)
+        new_param = nn.Parameter(self.quantize_weight(original_weight), requires_grad=False)
+        modname, _, attrname = weight_name.rpartition(".")
+        submod = gm.get_submodule(modname)
+        setattr(submod, attrname, new_param)
+        weight_node.meta["val"] = new_param.detach()
+
+        for scale_name, scale in self.default_scales(original_weight.shape).items():
+            if scale_name in submod._buffers:
+                submod._buffers[scale_name] = scale
+            else:
+                submod.register_buffer(scale_name, scale)
+
+        gm._register_load_state_dict_pre_hook(partial(self.load_hook, weight_name=weight_name))
+
+        with gm.graph.inserting_before(einsum_node):
+            scale_node = gm.graph.create_node("get_attr", f"{modname}.weight_scale_inv")
+            grouped_node = gm.graph.call_function(
+                self.deepseek_v4_wo_a_grouped_target_op(),
+                args=(input_view, weight_node, None, [scale_node]),
+            )
+
+        einsum_node.replace_all_uses_with(grouped_node)
+        gm.graph.erase_node(einsum_node)
+
     def _apply(
         self,
         gm: GraphModule,
@@ -1017,6 +1151,23 @@ class FineGrainedFP8LinearQuantization(Quantization):
                     continue
                 self._insert_quantized_linear(gm, n, is_quantized_graph=False)
                 cnt += 1
+            if is_deepseek_v4:
+                for n in list(gm.graph.nodes):
+                    wo_a_match = _extract_deepseek_v4_wo_a_einsum_args(n)
+                    if wo_a_match is None:
+                        continue
+                    input_view, weight_node, weight_name = wo_a_match
+                    if should_skip_quantization(weight_name, excluded):
+                        continue
+                    self._insert_deepseek_v4_wo_a_grouped_quantized_linear(
+                        gm, n, input_view, weight_node, weight_name
+                    )
+                    cnt += 1
+
+        if cnt:
+            gm.graph.eliminate_dead_code()
+            gm.graph.lint()
+            gm.recompile()
 
         return gm, TransformInfo(
             skipped=False, num_matches=cnt, is_clean=False, has_valid_shapes=(cnt == 0)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -1,4 +1,5 @@
 import math
+import re
 from functools import partial
 from typing import Dict, List, Tuple
 
@@ -16,10 +17,12 @@ from ...custom_ops.quantization.quant import (
 )
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
+from ...utils.e8m0 import maybe_e8m0_to_fp32
 from ...utils.logger import ad_logger
 from ...utils.node_utils import (
     WeightBiasInfoCache,
     extract_op_args,
+    extract_weight_name,
     extract_weight_nodes,
     get_quantization_params_from_linear_node,
     is_bmm_op,
@@ -43,6 +46,71 @@ try:
     from tensorrt_llm.quantization.utils.fp4_utils import float4_sf_dtype
 except ImportError:
     float4_sf_dtype = None
+
+
+DEEPSEEK_V4_QUANT_METHOD = "deepseek_v4_fp8"
+DEEPSEEK_V4_LINEAR_QUANT_METHOD = "finegrained_fp8"
+FINEGRAINED_FP8_BLOCK_SIZE = (128, 128)
+
+_DEEPSEEK_V4_FINEGRAINED_FP8_LINEAR_RE = re.compile(
+    r"(?:^|.*\.)layers\.\d+\.(?:"
+    r"attn\.(?:wq_a|wq_b|wkv|wo_a|wo_b)|"
+    r"attn\.indexer\.wq_b|"
+    r"ffn\.shared_experts\.w[123]"
+    r")$"
+)
+
+
+def _is_deepseek_v4_finegrained_fp8_config(qcfg: Dict) -> bool:
+    return (
+        str(qcfg.get("quant_method", "")).lower() == DEEPSEEK_V4_QUANT_METHOD
+        and str(qcfg.get("linear_quant_method", "")).lower() == DEEPSEEK_V4_LINEAR_QUANT_METHOD
+    )
+
+
+def _is_deepseek_v4_finegrained_fp8_linear_path(weight_or_module_name: str) -> bool:
+    module_name = weight_or_module_name.removesuffix(".weight")
+    return _DEEPSEEK_V4_FINEGRAINED_FP8_LINEAR_RE.match(module_name) is not None
+
+
+def _dedupe_patterns(patterns: List[str]) -> List[str]:
+    return list(dict.fromkeys(patterns))
+
+
+def _finegrained_fp8_excluded_patterns(qcfg: Dict) -> List[str]:
+    exclude_modules = list(qcfg.get("exclude_modules", []))
+    modules_to_not_convert = list(qcfg.get("modules_to_not_convert", []))
+    return _dedupe_patterns(exclude_modules + modules_to_not_convert)
+
+
+def _finegrained_fp8_expected_scale_shape(weight_shape: Tuple) -> Tuple[int, int]:
+    if len(weight_shape) != 2:
+        raise ValueError(f"FineGrained FP8 weight must be 2D, got shape {tuple(weight_shape)}.")
+    N, K = weight_shape
+    block_n, block_k = FINEGRAINED_FP8_BLOCK_SIZE
+    return (math.ceil(N / block_n), math.ceil(K / block_k))
+
+
+def _validate_finegrained_fp8_scale_shape(
+    weight_name: str,
+    weight: torch.Tensor,
+    scale_name: str,
+    scale: torch.Tensor,
+) -> None:
+    expected = _finegrained_fp8_expected_scale_shape(tuple(weight.shape))
+    actual = tuple(scale.shape)
+    if actual != expected:
+        raise ValueError(
+            f"{scale_name} shape {actual} does not match FineGrained FP8 expected "
+            f"shape {expected} for {weight_name} shape {tuple(weight.shape)}."
+        )
+
+
+def _maybe_decode_e8m0_scale(scale: torch.Tensor) -> torch.Tensor:
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if e8m0_dtype is not None and scale.dtype == e8m0_dtype:
+        return maybe_e8m0_to_fp32(scale)
+    return scale
 
 
 class Quantization(BaseTransform):
@@ -855,11 +923,7 @@ class FineGrainedFP8LinearQuantization(Quantization):
 
     def default_scales(self, original_weight_shape: Tuple) -> Dict[str, torch.Tensor]:
         # Default block size is 128x128 for FineGrained FP8
-        N, K = original_weight_shape
-        block_n, block_k = 128, 128
-        # Use ceil to handle dimensions smaller than or not divisible by block size
-        # (e.g. after TP sharding or small projection weights).
-        scale_shape = (math.ceil(N / block_n), math.ceil(K / block_k))
+        scale_shape = _finegrained_fp8_expected_scale_shape(original_weight_shape)
         return {"weight_scale_inv": torch.ones(scale_shape, dtype=torch.bfloat16)}
 
     def build_custom_args_for_linear(self, scales: Dict[str, Node]) -> Tuple:
@@ -871,17 +935,38 @@ class FineGrainedFP8LinearQuantization(Quantization):
         FineGrained FP8 checkpoints store:
         - weight: float8_e4m3fn tensor
         - weight_scale_inv: per-block scale tensor
+        - scale: DeepSeek V4 alias for weight_scale_inv
         """
-        if weight_name not in state_dict:
+        prefix = prefix or ""
+        weight_key = prefix + weight_name
+        if weight_key not in state_dict:
             return
 
-        weight = state_dict[weight_name]
-        if weight.dtype == torch.float8_e4m3fn:
-            scale_inv_name = weight_name + "_scale_inv"
-            if scale_inv_name in state_dict:
-                # Rename to match our buffer name
-                mod_prefix = weight_name.rsplit(".", 1)[0]
-                state_dict[mod_prefix + ".weight_scale_inv"] = state_dict[scale_inv_name]
+        weight = state_dict[weight_key]
+        if weight.dtype != torch.float8_e4m3fn:
+            return
+
+        mod_prefix = weight_key.rsplit(".", 1)[0]
+        scale_buffer_name = mod_prefix + ".weight_scale_inv"
+        scale_name = scale_buffer_name
+        consume_scale_alias = False
+
+        if scale_buffer_name not in state_dict:
+            scale_alias_name = mod_prefix + ".scale"
+            if (
+                _is_deepseek_v4_finegrained_fp8_linear_path(weight_key)
+                and scale_alias_name in state_dict
+            ):
+                scale_name = scale_alias_name
+                consume_scale_alias = True
+            else:
+                return
+
+        scale = state_dict[scale_name]
+        _validate_finegrained_fp8_scale_shape(weight_key, weight, scale_name, scale)
+        if consume_scale_alias:
+            scale = state_dict.pop(scale_name)
+        state_dict[scale_buffer_name] = _maybe_decode_e8m0_scale(scale)
 
     def _apply(
         self,
@@ -905,8 +990,9 @@ class FineGrainedFP8LinearQuantization(Quantization):
                 skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
             )
 
+        is_deepseek_v4 = _is_deepseek_v4_finegrained_fp8_config(qcfg)
         quant_method = str(qcfg.get("quant_method", "")).lower()
-        if quant_method != self.algo_name:
+        if quant_method != self.algo_name and not is_deepseek_v4:
             return gm, TransformInfo(
                 skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
             )
@@ -915,14 +1001,19 @@ class FineGrainedFP8LinearQuantization(Quantization):
                 skipped=True, num_matches=0, is_clean=True, has_valid_shapes=True
             )
 
-        excluded = qcfg.get("modules_to_not_convert", [])
+        excluded = _finegrained_fp8_excluded_patterns(qcfg)
 
         cnt = 0
         with WeightBiasInfoCache():
             for n in gm.graph.nodes:
                 if not is_linear_op(n):
                     continue
-                if should_skip_quantization(n, excluded):
+                weight_name = extract_weight_name(n)
+                if not isinstance(weight_name, str):
+                    continue
+                if is_deepseek_v4 and not _is_deepseek_v4_finegrained_fp8_linear_path(weight_name):
+                    continue
+                if should_skip_quantization(weight_name, excluded):
                     continue
                 self._insert_quantized_linear(gm, n, is_quantized_graph=False)
                 cnt += 1

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -25,6 +25,7 @@ from ...utils.node_utils import (
     extract_weight_name,
     extract_weight_nodes,
     get_quantization_params_from_linear_node,
+    invalidate_weight_node_cache,
     is_bmm_op,
     is_linear_op,
     is_op,
@@ -98,6 +99,9 @@ def _view_base_and_shape(node: Node) -> Tuple[Node, Tuple[object, ...]]:
     if node.op == "call_method":
         base = node.args[0]
         shape_args = node.args[1:]
+    elif is_op(node, torch.ops.auto_deploy.view):
+        base = node.args[0]
+        shape_args = (node.args[1],)
     else:
         base = node.args[0]
         shape_args = node.args[1:]
@@ -372,7 +376,10 @@ class Quantization(BaseTransform):
         with gm.graph.inserting_before(node):
             scales = {}
             for scale_name in self.scale_names():
-                scales[scale_name] = gm.graph.create_node("get_attr", modname + "." + scale_name)
+                scale_node = gm.graph.create_node("get_attr", modname + "." + scale_name)
+                scale_tensor = getattr(lin_weight.submod, scale_name)
+                scale_node.meta["val"] = scale_tensor.detach()
+                scales[scale_name] = scale_node
 
         custom_args = self.build_custom_args_for_linear(scales)
 
@@ -1094,6 +1101,7 @@ class FineGrainedFP8LinearQuantization(Quantization):
 
         with gm.graph.inserting_before(einsum_node):
             scale_node = gm.graph.create_node("get_attr", f"{modname}.weight_scale_inv")
+            scale_node.meta["val"] = submod.weight_scale_inv.detach()
             grouped_node = gm.graph.call_function(
                 self.deepseek_v4_wo_a_grouped_target_op(),
                 args=(input_view, weight_node, None, [scale_node]),
@@ -1168,6 +1176,7 @@ class FineGrainedFP8LinearQuantization(Quantization):
             gm.graph.eliminate_dead_code()
             gm.graph.lint()
             gm.recompile()
+            invalidate_weight_node_cache(gm)
 
         return gm, TransformInfo(
             skipped=False, num_matches=cnt, is_clean=False, has_valid_shapes=(cnt == 0)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/quantization.py
@@ -1105,6 +1105,7 @@ class FineGrainedFP8LinearQuantization(Quantization):
             grouped_node = gm.graph.call_function(
                 self.deepseek_v4_wo_a_grouped_target_op(),
                 args=(input_view, weight_node, None, [scale_node]),
+                kwargs={"layer_type": "mla"},
             )
 
         einsum_node.replace_all_uses_with(grouped_node)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/rms_norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/rms_norm.py
@@ -28,6 +28,33 @@ _BACKEND_OPS = {
 }
 
 
+def _get_node_dtype(node: Node | object) -> torch.dtype | None:
+    if not isinstance(node, Node):
+        return getattr(node, "dtype", None)
+
+    val = node.meta.get("val")
+    if val is not None and hasattr(val, "dtype"):
+        return val.dtype
+
+    tensor_meta = node.meta.get("tensor_meta")
+    if tensor_meta is not None and hasattr(tensor_meta, "dtype"):
+        return tensor_meta.dtype
+
+    return None
+
+
+def _set_cast_node_metadata(node: Node, source: Node, dtype: torch.dtype) -> None:
+    node.meta.update(source.meta)
+
+    val = node.meta.get("val")
+    if val is not None and hasattr(val, "to"):
+        node.meta["val"] = val.to(dtype=dtype)
+
+    tensor_meta = node.meta.get("tensor_meta")
+    if tensor_meta is not None and hasattr(tensor_meta, "_replace"):
+        node.meta["tensor_meta"] = tensor_meta._replace(dtype=dtype)
+
+
 def _rms_norm_pattern(data: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
     """Implements the RMSNorm pattern for pattern matching.
 
@@ -358,11 +385,32 @@ class FuseRMSNorm(BaseTransform):
         # Replace torch_rmsnorm ops with the selected backend
         for node in list(graph.nodes):
             if is_op(node, torch.ops.auto_deploy.torch_rmsnorm):
+                new_args = node.args
+                insertion_anchor = node
+                if backend == "flashinfer":
+                    data, weight, *rest = node.args
+                    data_dtype = _get_node_dtype(data)
+                    weight_dtype = _get_node_dtype(weight)
+                    if (
+                        data_dtype is not None
+                        and weight_dtype is not None
+                        and data_dtype != weight_dtype
+                    ):
+                        with graph.inserting_after(node):
+                            weight = graph.call_function(
+                                torch.ops.aten.to.dtype,
+                                args=(weight, data_dtype),
+                            )
+                        insertion_anchor = weight
+                        if isinstance(node.args[1], Node):
+                            _set_cast_node_metadata(weight, node.args[1], data_dtype)
+                        new_args = (data, weight, *rest)
+
                 # Replace with the selected backend op
-                with graph.inserting_after(node):
+                with graph.inserting_after(insertion_anchor):
                     new_node: Node = graph.call_function(
                         target_op,
-                        args=node.args,
+                        args=new_args,
                         kwargs=node.kwargs,
                     )
                     # Preserve metadata (including val/tensor_meta) for downstream transforms.

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -1641,22 +1641,33 @@ def shard_weight_tensor(
     # Update the parameter in the module
     modname, _, param_name = param_key.rpartition(".")
     submod = gm.get_submodule(modname)
+    is_buffer = param_name in submod._buffers
+    is_non_persistent_buffer = is_buffer and param_name in submod._non_persistent_buffers_set
 
     # Register load hook on the owning submodule (not the top-level gm).
     # This ensures the hook runs *after* any parent-level hooks that transform
     # the state_dict (e.g., unfusing fused MoE checkpoint weights into
     # individual expert keys). With the hook on gm, it would run before
     # unfusing and fail to find the individual expert keys.
-    submod._register_load_state_dict_pre_hook(
-        partial(
-            _load_hook,
-            f_split=f_split,
-            param_key=param_name,
-            param_shape=sharded_shape,
+    if not is_non_persistent_buffer:
+        submod._register_load_state_dict_pre_hook(
+            partial(
+                _load_hook,
+                f_split=f_split,
+                param_key=param_name,
+                param_shape=sharded_shape,
+            )
         )
-    )
-    param_new = nn.Parameter(sharded_weight.detach().clone(), requires_grad=requires_grad)
-    setattr(submod, param_name, param_new)
+    sharded_value = sharded_weight.detach().clone()
+    if is_buffer:
+        submod._buffers[param_name] = sharded_value
+        if is_non_persistent_buffer:
+            submod._non_persistent_buffers_set.add(param_name)
+        else:
+            submod._non_persistent_buffers_set.discard(param_name)
+    else:
+        param_new = nn.Parameter(sharded_value, requires_grad=requires_grad)
+        setattr(submod, param_name, param_new)
 
     return sharded_weight, sharded_shape
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -1609,8 +1609,9 @@ def shard_weight_tensor(
         Tuple of (sharded_tensor, sharded_shape)
     """
 
-    # Handle fused weights
-    if fused_weight_dims is not None:
+    if custom_shard_fn is not None:
+        f_split = custom_shard_fn
+    elif fused_weight_dims is not None:
 
         def f_split(
             t: torch.Tensor,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
@@ -46,8 +46,10 @@ from ...utils.node_utils import (
     _get_op_schema,
     extract_op_args,
     extract_weight_nodes,
+    get_param_or_buffer,
     invalidate_weight_node_cache,
     is_any_lin_op,
+    is_op,
     set_op_args,
     shape,
 )
@@ -97,6 +99,62 @@ def _shard_scale_and_hook(
     sn.submod.register_buffer(buf_name, sharded_scale)
     gm._register_load_state_dict_pre_hook(
         partial(_load_hook, f_split=f_split, param_key=sn.node_key, param_shape=sharded_scale.shape)
+    )
+
+
+def _assert_divisible(value: int, divisor: int, msg: str) -> None:
+    assert value % divisor == 0, f"{msg}: {value} is not divisible by {divisor}"
+
+
+def _contiguous_partition(total: int, world_size: int, rank: int) -> Tuple[int, int]:
+    _assert_divisible(total, world_size, "contiguous partition")
+    part = total // world_size
+    return rank * part, (rank + 1) * part
+
+
+def _split_flattened_groups(
+    tensor: torch.Tensor,
+    *,
+    num_groups: int,
+    rank: int,
+    world_size: int,
+) -> torch.Tensor:
+    """Split a row-major ``[num_groups * rows_per_group, ...]`` tensor by group."""
+    _assert_divisible(num_groups, world_size, "group count")
+    _assert_divisible(int(tensor.shape[0]), num_groups, "flattened grouped rows")
+    group_lo, group_hi = _contiguous_partition(num_groups, world_size, rank)
+    rows_per_group = int(tensor.shape[0]) // num_groups
+    grouped = tensor.reshape(num_groups, rows_per_group, *tensor.shape[1:])
+    return grouped[group_lo:group_hi].reshape(-1, *tensor.shape[1:]).contiguous()
+
+
+def _slice_group_range(tensor: torch.Tensor, group_lo: int, group_hi: int) -> torch.Tensor:
+    return tensor[group_lo:group_hi].contiguous()
+
+
+def _is_tp_local_group_view(node: Node, group_dim: int) -> bool:
+    if not isinstance(node, Node) or not is_op(node, torch.ops.auto_deploy.view):
+        return False
+    [tp_scaled_dim, view_shape] = extract_op_args(node, "tp_scaled_dim", "shape")
+    if tp_scaled_dim < 0:
+        tp_scaled_dim = len(view_shape) + tp_scaled_dim
+    return tp_scaled_dim == group_dim
+
+
+def _get_attr_tensor(gm: GraphModule, node: Node, arg_name: str) -> Tuple[str, torch.Tensor]:
+    assert isinstance(node, Node) and node.op == "get_attr" and isinstance(node.target, str), (
+        f"Expected {arg_name} to be a get_attr node, got {node!r}"
+    )
+    return node.target, get_param_or_buffer(node.target, gm)
+
+
+def _weight_node_from_attr(gm: GraphModule, node: Node, tensor: torch.Tensor) -> WeightNode:
+    node_key = str(node.target)
+    return WeightNode(
+        node=node,
+        node_key=node_key,
+        tensor=tensor,
+        submod=gm.get_submodule(node_key.rpartition(".")[0]),
     )
 
 
@@ -319,6 +377,130 @@ class FineGrainedFP8LinearShardableNode(LinearShardableNode):
             )
             sharded = f_split(sn.tensor)
             _shard_scale_and_hook(gm, sn, sharded, f_split)
+
+
+@ShardableNode.register(
+    torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+)
+class DeepSeekV4GroupedWoAShardableNode(ShardableNode):
+    """DeepSeek V4 grouped ``wo_a`` FP8 linear: shard by output group boundaries."""
+
+    def apply(self, gm: GraphModule, dc: DistConfig, max_num_tokens: int = 0) -> int:
+        if dc.tp_size <= 1:
+            return 0
+
+        [input_node, weight_node, bias_node, weight_scale] = extract_op_args(
+            self.node, "input", "weight_quantized", "bias", "weight_scale"
+        )
+        input_shape = shape(input_node)
+        output_shape = shape(self.node)
+        if input_shape is not None:
+            num_groups = int(input_shape[-2])
+            group_dim = len(input_shape) - 2
+        elif output_shape is not None:
+            num_groups = int(output_shape[-2])
+            group_dim = len(output_shape) - 2
+        else:
+            raise AssertionError(
+                f"Cannot determine DeepSeek V4 wo_a group count for node {self.node.name}."
+            )
+        _assert_divisible(num_groups, dc.tp_size, "DeepSeek V4 wo_a output groups")
+        group_lo, group_hi = _contiguous_partition(num_groups, dc.tp_size, dc.tp_rank)
+
+        weight_name, weight_tensor = _get_attr_tensor(gm, weight_node, "weight_quantized")
+        split_groups = partial(
+            _split_flattened_groups,
+            num_groups=num_groups,
+            rank=dc.tp_rank,
+            world_size=dc.tp_size,
+        )
+        shard_weight_tensor(
+            gm=gm,
+            weight_tensor=weight_tensor,
+            param_key=weight_name,
+            dim=SplitDimension.COLUMN,
+            rank=dc.tp_rank,
+            world_size=dc.tp_size,
+            custom_shard_fn=split_groups,
+        )
+
+        if isinstance(bias_node, Node):
+            bias_name, bias_tensor = _get_attr_tensor(gm, bias_node, "bias")
+            if bias_tensor.ndim == 1:
+                bias_split = split_groups
+            else:
+                bias_split = partial(_slice_group_range, group_lo=group_lo, group_hi=group_hi)
+            shard_weight_tensor(
+                gm=gm,
+                weight_tensor=bias_tensor,
+                param_key=bias_name,
+                dim=SplitDimension.COLUMN,
+                rank=dc.tp_rank,
+                world_size=dc.tp_size,
+                custom_shard_fn=bias_split,
+            )
+
+        assert isinstance(weight_scale, (list, tuple)) and len(weight_scale) == 1, (
+            "DeepSeek V4 wo_a expects a single weight_scale_inv tensor."
+        )
+        scale_node = weight_scale[0]
+        _, scale_tensor = _get_attr_tensor(gm, scale_node, "weight_scale")
+        _assert_divisible(
+            int(scale_tensor.shape[0]),
+            num_groups,
+            "DeepSeek V4 wo_a scale rows",
+        )
+        scale_split = partial(
+            _split_flattened_groups,
+            num_groups=num_groups,
+            rank=dc.tp_rank,
+            world_size=dc.tp_size,
+        )
+        scale_weight_node = _weight_node_from_attr(gm, scale_node, scale_tensor)
+        _shard_scale_and_hook(gm, scale_weight_node, scale_split(scale_tensor), scale_split)
+
+        if isinstance(input_node, Node) and not _is_tp_local_group_view(input_node, group_dim):
+            with gm.graph.inserting_before(self.node):
+                local_input = gm.graph.call_function(
+                    torch.ops.aten.slice.Tensor,
+                    args=(input_node, group_dim, group_lo, group_hi, 1),
+                )
+            set_op_args(self.node, input=local_input)
+
+        ad_logger.debug(f"  sharded DeepSeek V4 wo_a groups [{group_lo}:{group_hi}] / {num_groups}")
+        return 1
+
+
+@ShardableNode.register(torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention)
+class DeepSeekV4SparseAttentionShardableNode(ShardableNode):
+    """DeepSeek V4 sparse attention: shard head-owned parameters, not activations."""
+
+    def apply(self, gm: GraphModule, dc: DistConfig, max_num_tokens: int = 0) -> int:
+        [enable_sharding, attn_sink] = extract_op_args(
+            self.node,
+            "enable_sharding",
+            "attn_sink",
+        )
+        if not enable_sharding or dc.tp_size <= 1:
+            return 0
+
+        sink_name, sink_tensor = _get_attr_tensor(gm, attn_sink, "attn_sink")
+        _assert_divisible(
+            int(sink_tensor.shape[0]),
+            dc.tp_size,
+            "DeepSeek V4 attention heads",
+        )
+        shard_weight_tensor(
+            gm=gm,
+            weight_tensor=sink_tensor,
+            param_key=sink_name,
+            dim=0,
+            rank=dc.tp_rank,
+            world_size=dc.tp_size,
+        )
+
+        ad_logger.debug(f"  sharded DeepSeek V4 sparse attention attn_sink ({sink_name})")
+        return 1
 
 
 @ShardableNode.register(
@@ -783,6 +965,135 @@ class MoEShardableNode(ShardableNode):
             selected_experts=selected_experts_local,
             routing_weights=routing_weights_local,
         )
+
+
+class DeepSeekV4MXFP4FromRoutingShardableNode(ShardableNode):
+    """DeepSeek V4 pre-routed MXFP4 MoE: EP-slice experts and localize expert ids."""
+
+    _EXPERT_ARG_NAMES = (
+        "gate_up_blocks",
+        "gate_up_bias",
+        "gate_up_scales",
+        "down_blocks",
+        "down_bias",
+        "down_scales",
+    )
+
+    def apply(self, gm: GraphModule, dc: DistConfig, max_num_tokens: int = 0) -> int:
+        ep_size = dc.moe_ep_size
+        ep_rank = dc.moe_ep_rank
+
+        if ep_size <= 1:
+            return 0
+
+        op_args = extract_op_args(
+            self.node,
+            "selected_experts",
+            "routing_weights",
+            *self._EXPERT_ARG_NAMES,
+        )
+        selected_experts = op_args[0]
+        routing_weights = op_args[1]
+        expert_nodes = dict(zip(self._EXPERT_ARG_NAMES, op_args[2:]))
+
+        gate_up_name, gate_up_tensor = _get_attr_tensor(
+            gm, expert_nodes["gate_up_blocks"], "gate_up_blocks"
+        )
+        num_experts = int(gate_up_tensor.shape[0])
+        _assert_divisible(
+            num_experts,
+            ep_size,
+            "DeepSeek V4 routed expert count",
+        )
+        expert_lo, expert_hi = _contiguous_partition(num_experts, ep_size, ep_rank)
+
+        shard_weight_tensor(
+            gm=gm,
+            weight_tensor=gate_up_tensor,
+            param_key=gate_up_name,
+            dim=0,
+            rank=ep_rank,
+            world_size=ep_size,
+        )
+        for arg_name in self._EXPERT_ARG_NAMES[1:]:
+            param_name, tensor = _get_attr_tensor(gm, expert_nodes[arg_name], arg_name)
+            shard_weight_tensor(
+                gm=gm,
+                weight_tensor=tensor,
+                param_key=param_name,
+                dim=0,
+                rank=ep_rank,
+                world_size=ep_size,
+            )
+
+        self._localize_expert_indices(
+            gm,
+            selected_experts,
+            routing_weights,
+            expert_lo,
+            expert_hi,
+        )
+        self._insert_all_reduce(gm, dc)
+
+        ad_logger.debug(
+            f"  sharded DeepSeek V4 MXFP4 from routing: {num_experts} experts, "
+            f"ep={ep_size}, rank slice [{expert_lo}:{expert_hi}]"
+        )
+        return 1
+
+    def _localize_expert_indices(
+        self,
+        gm: GraphModule,
+        selected_experts: Node,
+        routing_weights: Node,
+        expert_lo: int,
+        expert_hi: int,
+    ) -> None:
+        with gm.graph.inserting_before(self.node):
+            local_ids = gm.graph.create_node(
+                "call_function",
+                operator.sub,
+                args=(selected_experts, expert_lo),
+                kwargs={},
+            )
+            ge_lower = gm.graph.call_function(torch.ge, args=(selected_experts, expert_lo))
+            lt_upper = gm.graph.call_function(torch.lt, args=(selected_experts, expert_hi))
+            rank_mask = gm.graph.call_function(torch.logical_and, args=(ge_lower, lt_upper))
+            selected_experts_local = gm.graph.create_node(
+                "call_function",
+                operator.mul,
+                args=(local_ids, rank_mask),
+                kwargs={},
+            )
+            routing_weights_local = gm.graph.create_node(
+                "call_function",
+                operator.mul,
+                args=(routing_weights, rank_mask),
+                kwargs={},
+            )
+        set_op_args(
+            self.node,
+            selected_experts=selected_experts_local,
+            routing_weights=routing_weights_local,
+        )
+
+    def _insert_all_reduce(self, gm: GraphModule, dc: DistConfig) -> None:
+        _, all_reduce_op = _get_dist_ops("auto")
+        with gm.graph.inserting_after(self.node):
+            red = gm.graph.call_function(
+                all_reduce_op,
+                args=(self.node, dc.allreduce_strategy),
+            )
+            self.node.replace_all_uses_with(red)
+            red.replace_input_with(red, self.node)
+
+
+try:
+    ShardableNode.register(torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing)(
+        DeepSeekV4MXFP4FromRoutingShardableNode
+    )
+except AttributeError:
+    pass
 
 
 class StackedMoEShardableNode(ShardableNode):

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
@@ -471,7 +471,10 @@ class DeepSeekV4GroupedWoAShardableNode(ShardableNode):
         return 1
 
 
-@ShardableNode.register(torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention)
+@ShardableNode.register(
+    torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention,
+    torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2,
+)
 class DeepSeekV4SparseAttentionShardableNode(ShardableNode):
     """DeepSeek V4 sparse attention: shard head-owned parameters, not activations."""
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
@@ -479,20 +479,30 @@ class DeepSeekV4SparseAttentionShardableNode(ShardableNode):
     """DeepSeek V4 sparse attention: shard head-owned parameters, not activations."""
 
     def apply(self, gm: GraphModule, dc: DistConfig, max_num_tokens: int = 0) -> int:
-        [enable_sharding, attn_sink] = extract_op_args(
+        [enable_sharding, attn_sink, q] = extract_op_args(
             self.node,
             "enable_sharding",
             "attn_sink",
+            "q",
         )
         if not enable_sharding or dc.tp_size <= 1:
             return 0
 
         sink_name, sink_tensor = _get_attr_tensor(gm, attn_sink, "attn_sink")
+        full_heads = int(sink_tensor.shape[0])
         _assert_divisible(
-            int(sink_tensor.shape[0]),
+            full_heads,
             dc.tp_size,
             "DeepSeek V4 attention heads",
         )
+        local_heads = full_heads // dc.tp_size
+        q_shape = shape(q)
+        if q_shape is not None:
+            q_heads = int(q_shape[-2])
+            assert q_heads in (local_heads, full_heads), (
+                "DeepSeek V4 sparse attention q head count must match either local "
+                f"heads ({local_heads}) or pre-shard metadata heads ({full_heads}), got {q_heads}"
+            )
         shard_weight_tensor(
             gm=gm,
             weight_tensor=sink_tensor,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
@@ -530,7 +530,7 @@ class FP4LinearShardableNode(LinearShardableNode):
 
 @ShardableNode.register(torch.ops.auto_deploy.view)
 class ViewShardableNode(ShardableNode):
-    """View op: replace shape[tp_scaled_dim] with -1 so PyTorch infers the sharded size."""
+    """View op: scale one shape dimension so the view matches TP-local tensors."""
 
     @classmethod
     def _strip_node_hints(cls, node: Node) -> bool:
@@ -549,9 +549,16 @@ class ViewShardableNode(ShardableNode):
         if tp_scaled_dim < 0:
             tp_scaled_dim = len(view_shape) + tp_scaled_dim
         if tp_scaled_dim < len(view_shape) and isinstance(view_shape[tp_scaled_dim], int):
-            view_shape[tp_scaled_dim] = -1
+            scaled_size = view_shape[tp_scaled_dim]
+            if scaled_size == -1:
+                return 0
+            if -1 in view_shape:
+                _assert_divisible(scaled_size, dc.tp_size, "view shape dimension")
+                view_shape[tp_scaled_dim] = scaled_size // dc.tp_size
+            else:
+                view_shape[tp_scaled_dim] = -1
             set_op_args(self.node, shape=view_shape)
-            ad_logger.debug(f"  updated view shape at dim {tp_scaled_dim} to -1 (inferred)")
+            ad_logger.debug(f"  updated view shape at dim {tp_scaled_dim}: {view_shape}")
             return 1
         return 0
 
@@ -608,6 +615,7 @@ class AllReduceShardableNode(ShardableNode):
         [x] = extract_op_args(self.node, "x")
         self.node.target = all_reduce_op
         self.node.args = (x, dc.allreduce_strategy)
+        self.node.kwargs = {}
         ad_logger.debug(f"  inserted real all_reduce ({all_reduce_op.__name__})")
         return 1
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
@@ -128,6 +128,56 @@ def _split_flattened_groups(
     return grouped[group_lo:group_hi].reshape(-1, *tensor.shape[1:]).contiguous()
 
 
+def _assert_deepseek_v4_wo_a_tp_supported(num_groups: int, tp_size: int) -> None:
+    assert num_groups >= tp_size, (
+        "DeepSeek V4 grouped wo_a requires o_groups >= tp_size because sharding "
+        f"assigns whole output groups to ranks; got o_groups={num_groups}, tp_size={tp_size}"
+    )
+    _assert_divisible(num_groups, tp_size, "DeepSeek V4 wo_a output groups (o_groups)")
+
+
+def _infer_deepseek_v4_wo_a_global_groups(
+    weight_tensor: torch.Tensor,
+    scale_tensor: torch.Tensor,
+    output_shape: Optional[Tuple[int, ...]],
+) -> int:
+    if (
+        output_shape is not None
+        and len(output_shape) > 0
+        and isinstance(output_shape[-1], int)
+        and output_shape[-1] > 0
+    ):
+        o_lora_rank = int(output_shape[-1])
+        _assert_divisible(
+            int(weight_tensor.shape[0]),
+            o_lora_rank,
+            "DeepSeek V4 wo_a weight rows",
+        )
+        num_groups = int(weight_tensor.shape[0]) // o_lora_rank
+    else:
+        num_groups = int(scale_tensor.shape[0])
+
+    _assert_divisible(
+        int(scale_tensor.shape[0]),
+        num_groups,
+        "DeepSeek V4 wo_a scale rows",
+    )
+    return num_groups
+
+
+def _assert_deepseek_v4_wo_a_observed_groups(
+    observed_groups: int,
+    global_groups: int,
+    dc: DistConfig,
+    source: str,
+) -> None:
+    local_groups = global_groups // dc.tp_size
+    assert observed_groups in (global_groups, local_groups), (
+        f"DeepSeek V4 wo_a {source} group count must be global o_groups "
+        f"({global_groups}) or TP-local groups ({local_groups}), got {observed_groups}"
+    )
+
+
 def _slice_group_range(tensor: torch.Tensor, group_lo: int, group_hi: int) -> torch.Tensor:
     return tensor[group_lo:group_hi].contiguous()
 
@@ -169,6 +219,43 @@ def _set_view_shape(node: Node, view_shape: List[Any]) -> None:
         node.args = (node.args[0], view_shape)
 
 
+def _scaled_view_meta_shape(
+    node: Node,
+    view_shape: List[Any],
+    scaled_dim: int,
+    local_size: int,
+) -> Optional[Tuple[int, ...]]:
+    old_shape = shape(node)
+    if old_shape is None or len(old_shape) != len(view_shape):
+        return None
+
+    meta_shape = []
+    for idx, dim_size in enumerate(view_shape):
+        if idx == scaled_dim:
+            meta_shape.append(local_size)
+        elif isinstance(dim_size, int) and dim_size == -1:
+            meta_shape.append(int(old_shape[idx]))
+        elif isinstance(dim_size, int):
+            meta_shape.append(dim_size)
+        else:
+            return None
+    return tuple(meta_shape)
+
+
+def _set_node_meta_shape(node: Node, meta_shape: Optional[Tuple[int, ...]]) -> None:
+    if meta_shape is None or shape(node) == meta_shape:
+        return
+
+    meta_val = node.meta.get("val")
+    if meta_val is None:
+        return
+    try:
+        node.meta["val"] = meta_val.new_empty(meta_shape)
+    except (AttributeError, RuntimeError, TypeError):
+        dtype = getattr(meta_val, "dtype", torch.float32)
+        node.meta["val"] = torch.empty(meta_shape, dtype=dtype, device="meta")
+
+
 def _is_aten_view_or_reshape(node: Node) -> bool:
     return isinstance(node, Node) and (
         (node.op == "call_method" and node.target in {"view", "reshape"})
@@ -188,12 +275,15 @@ def _scale_view_shape_dim(node: Node, dim: int, dc: DistConfig, reason: str) -> 
     scaled_size = view_shape[dim]
     if scaled_size == -1:
         return False
+    _assert_divisible(scaled_size, dc.tp_size, reason)
+    local_size = scaled_size // dc.tp_size
+    meta_shape = _scaled_view_meta_shape(node, view_shape, dim, local_size)
     if -1 in view_shape:
-        _assert_divisible(scaled_size, dc.tp_size, reason)
-        view_shape[dim] = scaled_size // dc.tp_size
+        view_shape[dim] = local_size
     else:
         view_shape[dim] = -1
     _set_view_shape(node, view_shape)
+    _set_node_meta_shape(node, meta_shape)
     ad_logger.debug(f"  recovered DeepSeek V4 view shape at dim {dim}: {view_shape}")
     return True
 
@@ -501,22 +591,45 @@ class DeepSeekV4GroupedWoAShardableNode(ShardableNode):
         [input_node, weight_node, bias_node, weight_scale] = extract_op_args(
             self.node, "input", "weight_quantized", "bias", "weight_scale"
         )
+        assert isinstance(weight_scale, (list, tuple)) and len(weight_scale) == 1, (
+            "DeepSeek V4 wo_a expects a single weight_scale_inv tensor."
+        )
+        scale_node = weight_scale[0]
+        weight_name, weight_tensor = _get_attr_tensor(gm, weight_node, "weight_quantized")
+        _, scale_tensor = _get_attr_tensor(gm, scale_node, "weight_scale")
         input_shape = shape(input_node)
         output_shape = shape(self.node)
+        num_groups = _infer_deepseek_v4_wo_a_global_groups(
+            weight_tensor,
+            scale_tensor,
+            output_shape,
+        )
+        _assert_deepseek_v4_wo_a_tp_supported(num_groups, dc.tp_size)
+        local_groups = num_groups // dc.tp_size
         if input_shape is not None:
-            num_groups = int(input_shape[-2])
+            observed_groups = int(input_shape[-2])
             group_dim = len(input_shape) - 2
+            _assert_deepseek_v4_wo_a_observed_groups(
+                observed_groups,
+                num_groups,
+                dc,
+                "input",
+            )
         elif output_shape is not None:
-            num_groups = int(output_shape[-2])
+            observed_groups = int(output_shape[-2])
             group_dim = len(output_shape) - 2
+            _assert_deepseek_v4_wo_a_observed_groups(
+                observed_groups,
+                num_groups,
+                dc,
+                "output",
+            )
         else:
             raise AssertionError(
                 f"Cannot determine DeepSeek V4 wo_a group count for node {self.node.name}."
             )
-        _assert_divisible(num_groups, dc.tp_size, "DeepSeek V4 wo_a output groups")
         group_lo, group_hi = _contiguous_partition(num_groups, dc.tp_size, dc.tp_rank)
 
-        weight_name, weight_tensor = _get_attr_tensor(gm, weight_node, "weight_quantized")
         split_groups = partial(
             _split_flattened_groups,
             num_groups=num_groups,
@@ -549,16 +662,6 @@ class DeepSeekV4GroupedWoAShardableNode(ShardableNode):
                 custom_shard_fn=bias_split,
             )
 
-        assert isinstance(weight_scale, (list, tuple)) and len(weight_scale) == 1, (
-            "DeepSeek V4 wo_a expects a single weight_scale_inv tensor."
-        )
-        scale_node = weight_scale[0]
-        _, scale_tensor = _get_attr_tensor(gm, scale_node, "weight_scale")
-        _assert_divisible(
-            int(scale_tensor.shape[0]),
-            num_groups,
-            "DeepSeek V4 wo_a scale rows",
-        )
         scale_split = partial(
             _split_flattened_groups,
             num_groups=num_groups,
@@ -568,12 +671,16 @@ class DeepSeekV4GroupedWoAShardableNode(ShardableNode):
         scale_weight_node = _weight_node_from_attr(gm, scale_node, scale_tensor)
         _shard_scale_and_hook(gm, scale_weight_node, scale_split(scale_tensor), scale_split)
 
-        if isinstance(input_node, Node) and not _is_recovered_tp_local_group_view(
-            input_node,
-            group_dim,
-            num_groups=num_groups,
-            dc=dc,
-        ):
+        input_is_local = observed_groups == local_groups or (
+            isinstance(input_node, Node)
+            and _is_recovered_tp_local_group_view(
+                input_node,
+                group_dim,
+                num_groups=num_groups,
+                dc=dc,
+            )
+        )
+        if isinstance(input_node, Node) and not input_is_local:
             with gm.graph.inserting_before(self.node):
                 local_input = gm.graph.call_function(
                     torch.ops.aten.slice.Tensor,
@@ -617,6 +724,11 @@ class DeepSeekV4SparseAttentionShardableNode(ShardableNode):
                 "DeepSeek V4 sparse attention q head count must match either local "
                 f"heads ({local_heads}) or pre-shard metadata heads ({full_heads}), got {q_heads}"
             )
+            if q_heads == full_heads:
+                local_q_shape = list(q_shape)
+                local_q_shape[-2] = local_heads
+                _set_node_meta_shape(q, tuple(local_q_shape))
+                _set_node_meta_shape(self.node, tuple(local_q_shape))
         shard_weight_tensor(
             gm=gm,
             weight_tensor=sink_tensor,
@@ -679,12 +791,20 @@ class ViewShardableNode(ShardableNode):
             scaled_size = view_shape[tp_scaled_dim]
             if scaled_size == -1:
                 return 0
+            _assert_divisible(scaled_size, dc.tp_size, "view shape dimension")
+            local_size = scaled_size // dc.tp_size
+            meta_shape = _scaled_view_meta_shape(
+                self.node,
+                view_shape,
+                tp_scaled_dim,
+                local_size,
+            )
             if -1 in view_shape:
-                _assert_divisible(scaled_size, dc.tp_size, "view shape dimension")
-                view_shape[tp_scaled_dim] = scaled_size // dc.tp_size
+                view_shape[tp_scaled_dim] = local_size
             else:
                 view_shape[tp_scaled_dim] = -1
             set_op_args(self.node, shape=view_shape)
+            _set_node_meta_shape(self.node, meta_shape)
             ad_logger.debug(f"  updated view shape at dim {tp_scaled_dim}: {view_shape}")
             return 1
         return 0
@@ -1113,6 +1233,15 @@ class DeepSeekV4MXFP4FromRoutingShardableNode(ShardableNode):
         "down_bias",
         "down_scales",
     )
+    _ROUTE_METADATA_ARG_NAMES = (
+        "sorted_routing_weights",
+        "expert_histogram",
+        "sorted_route_indices",
+        "inverse_route_indices",
+        "expert_offsets",
+        "expert_block_offsets",
+        "expert_block_schedule",
+    )
 
     def apply(self, gm: GraphModule, dc: DistConfig, max_num_tokens: int = 0) -> int:
         ep_size = dc.moe_ep_size
@@ -1161,12 +1290,18 @@ class DeepSeekV4MXFP4FromRoutingShardableNode(ShardableNode):
                 world_size=ep_size,
             )
 
-        self._localize_expert_indices(
+        selected_experts_local, routing_weights_local = self._localize_expert_indices(
             gm,
             selected_experts,
             routing_weights,
             expert_lo,
             expert_hi,
+        )
+        self._insert_route_metadata(
+            gm,
+            selected_experts_local,
+            routing_weights_local,
+            expert_hi - expert_lo,
         )
         self._insert_all_reduce(gm, dc)
 
@@ -1183,7 +1318,7 @@ class DeepSeekV4MXFP4FromRoutingShardableNode(ShardableNode):
         routing_weights: Node,
         expert_lo: int,
         expert_hi: int,
-    ) -> None:
+    ) -> Tuple[Node, Node]:
         with gm.graph.inserting_before(self.node):
             local_ids = gm.graph.create_node(
                 "call_function",
@@ -1211,6 +1346,25 @@ class DeepSeekV4MXFP4FromRoutingShardableNode(ShardableNode):
             selected_experts=selected_experts_local,
             routing_weights=routing_weights_local,
         )
+        return selected_experts_local, routing_weights_local
+
+    def _insert_route_metadata(
+        self,
+        gm: GraphModule,
+        selected_experts: Node,
+        routing_weights: Node,
+        num_local_experts: int,
+    ) -> None:
+        with gm.graph.inserting_before(self.node):
+            route_metadata = gm.graph.call_function(
+                torch.ops.auto_deploy.torch_deepseek_v4_mxfp4_route_metadata.default,
+                args=(selected_experts, routing_weights, int(num_local_experts)),
+            )
+            metadata_tensors = tuple(
+                gm.graph.call_function(operator.getitem, args=(route_metadata, idx))
+                for idx in range(len(self._ROUTE_METADATA_ARG_NAMES))
+            )
+        set_op_args(self.node, **dict(zip(self._ROUTE_METADATA_ARG_NAMES, metadata_tensors)))
 
     def _insert_all_reduce(self, gm: GraphModule, dc: DistConfig) -> None:
         _, all_reduce_op = _get_dist_ops("auto")
@@ -1490,15 +1644,42 @@ def _recover_deepseek_v4_wo_a_group_aten_views(gm: GraphModule, dc: DistConfig) 
     for grouped_node in list(gm.graph.nodes):
         if not is_op(grouped_node, grouped_op):
             continue
-        [input_node] = extract_op_args(grouped_node, "input")
+        [input_node, weight_node, weight_scale] = extract_op_args(
+            grouped_node,
+            "input",
+            "weight_quantized",
+            "weight_scale",
+        )
         if not _is_aten_view_or_reshape(input_node):
             continue
 
         _, view_shape = _view_base_and_shape(input_node)
         if view_shape is None or len(view_shape) < 2:
             continue
+        assert isinstance(weight_scale, (list, tuple)) and len(weight_scale) == 1, (
+            "DeepSeek V4 wo_a expects a single weight_scale_inv tensor."
+        )
+        _, weight_tensor = _get_attr_tensor(gm, weight_node, "weight_quantized")
+        _, scale_tensor = _get_attr_tensor(gm, weight_scale[0], "weight_scale")
+        num_groups = _infer_deepseek_v4_wo_a_global_groups(
+            weight_tensor,
+            scale_tensor,
+            shape(grouped_node),
+        )
+        _assert_deepseek_v4_wo_a_tp_supported(num_groups, dc.tp_size)
+        local_groups = num_groups // dc.tp_size
         group_dim = len(view_shape) - 2
-        if view_shape[group_dim] != -1 and _scale_view_shape_dim(
+        view_groups = view_shape[group_dim]
+        if isinstance(view_groups, int) and view_groups != -1:
+            _assert_deepseek_v4_wo_a_observed_groups(
+                view_groups,
+                num_groups,
+                dc,
+                "view",
+            )
+            if view_groups == local_groups:
+                continue
+        if view_groups != -1 and _scale_view_shape_dim(
             input_node,
             group_dim,
             dc,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
@@ -141,6 +141,115 @@ def _is_tp_local_group_view(node: Node, group_dim: int) -> bool:
     return tp_scaled_dim == group_dim
 
 
+def _view_base_and_shape(node: Node) -> Tuple[Optional[Node], Optional[List[Any]]]:
+    if not isinstance(node, Node):
+        return None, None
+    if node.op == "call_method" and node.target in {"view", "reshape"}:
+        shape_args = node.args[1:]
+    elif is_op(node, torch.ops.auto_deploy.view):
+        shape_args = (node.args[1],)
+    elif is_op(node, (torch.ops.aten.view, torch.ops.aten.reshape)):
+        shape_args = node.args[1:]
+    else:
+        return None, None
+
+    if len(shape_args) == 1 and isinstance(shape_args[0], (list, tuple)):
+        view_shape = list(shape_args[0])
+    else:
+        view_shape = list(shape_args)
+    return node.args[0], view_shape
+
+
+def _set_view_shape(node: Node, view_shape: List[Any]) -> None:
+    if is_op(node, torch.ops.auto_deploy.view):
+        set_op_args(node, shape=view_shape)
+    elif node.op == "call_method" and node.target in {"view", "reshape"}:
+        node.args = (node.args[0], *view_shape)
+    else:
+        node.args = (node.args[0], view_shape)
+
+
+def _is_aten_view_or_reshape(node: Node) -> bool:
+    return isinstance(node, Node) and (
+        (node.op == "call_method" and node.target in {"view", "reshape"})
+        or is_op(node, (torch.ops.aten.view, torch.ops.aten.reshape))
+    )
+
+
+def _scale_view_shape_dim(node: Node, dim: int, dc: DistConfig, reason: str) -> bool:
+    _, view_shape = _view_base_and_shape(node)
+    if view_shape is None:
+        return False
+    if dim < 0:
+        dim = len(view_shape) + dim
+    if dim >= len(view_shape) or not isinstance(view_shape[dim], int):
+        return False
+
+    scaled_size = view_shape[dim]
+    if scaled_size == -1:
+        return False
+    if -1 in view_shape:
+        _assert_divisible(scaled_size, dc.tp_size, reason)
+        view_shape[dim] = scaled_size // dc.tp_size
+    else:
+        view_shape[dim] = -1
+    _set_view_shape(node, view_shape)
+    ad_logger.debug(f"  recovered DeepSeek V4 view shape at dim {dim}: {view_shape}")
+    return True
+
+
+def _node_depends_on(node: Node, target: Node) -> bool:
+    def _child_nodes(value):
+        if isinstance(value, Node):
+            return [value]
+        if isinstance(value, (list, tuple)):
+            nodes = []
+            for item in value:
+                nodes.extend(_child_nodes(item))
+            return nodes
+        if isinstance(value, dict):
+            nodes = []
+            for item in value.values():
+                nodes.extend(_child_nodes(item))
+            return nodes
+        return []
+
+    pending = [node]
+    seen = set()
+    while pending:
+        current = pending.pop()
+        if current is target:
+            return True
+        if current in seen:
+            continue
+        seen.add(current)
+        pending.extend(_child_nodes(current.args))
+        pending.extend(_child_nodes(current.kwargs))
+    return False
+
+
+def _is_recovered_tp_local_group_view(
+    node: Node,
+    group_dim: int,
+    *,
+    num_groups: int,
+    dc: DistConfig,
+) -> bool:
+    if _is_tp_local_group_view(node, group_dim):
+        return True
+    if not _is_aten_view_or_reshape(node):
+        return False
+
+    _, view_shape = _view_base_and_shape(node)
+    if view_shape is None:
+        return False
+    if group_dim < 0:
+        group_dim = len(view_shape) + group_dim
+    if group_dim >= len(view_shape):
+        return False
+    return view_shape[group_dim] == num_groups // dc.tp_size
+
+
 def _get_attr_tensor(gm: GraphModule, node: Node, arg_name: str) -> Tuple[str, torch.Tensor]:
     assert isinstance(node, Node) and node.op == "get_attr" and isinstance(node.target, str), (
         f"Expected {arg_name} to be a get_attr node, got {node!r}"
@@ -459,7 +568,12 @@ class DeepSeekV4GroupedWoAShardableNode(ShardableNode):
         scale_weight_node = _weight_node_from_attr(gm, scale_node, scale_tensor)
         _shard_scale_and_hook(gm, scale_weight_node, scale_split(scale_tensor), scale_split)
 
-        if isinstance(input_node, Node) and not _is_tp_local_group_view(input_node, group_dim):
+        if isinstance(input_node, Node) and not _is_recovered_tp_local_group_view(
+            input_node,
+            group_dim,
+            num_groups=num_groups,
+            dc=dc,
+        ):
             with gm.graph.inserting_before(self.node):
                 local_input = gm.graph.call_function(
                     torch.ops.aten.slice.Tensor,
@@ -1326,6 +1440,84 @@ def _apply_simple_shard(gm: GraphModule, dc: DistConfig) -> int:
     return num_updates
 
 
+def _recover_deepseek_v4_sparse_q_aten_views(gm: GraphModule, dc: DistConfig) -> int:
+    num_updates = 0
+    sparse_ops = (
+        torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention,
+        torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2,
+    )
+    for sparse_node in list(gm.graph.nodes):
+        if not is_op(sparse_node, sparse_ops):
+            continue
+        [enable_sharding, attn_sink, q] = extract_op_args(
+            sparse_node,
+            "enable_sharding",
+            "attn_sink",
+            "q",
+        )
+        if not enable_sharding or not isinstance(attn_sink, Node) or not isinstance(q, Node):
+            continue
+
+        _, sink_tensor = _get_attr_tensor(gm, attn_sink, "attn_sink")
+        full_heads = int(sink_tensor.shape[0])
+        _assert_divisible(full_heads, dc.tp_size, "DeepSeek V4 attention heads")
+
+        for view_node in list(gm.graph.nodes):
+            if not _is_aten_view_or_reshape(view_node) or not _node_depends_on(q, view_node):
+                continue
+            _, view_shape = _view_base_and_shape(view_node)
+            if (
+                view_shape is not None
+                and len(view_shape) == 4
+                and view_shape[2] == full_heads
+                and _scale_view_shape_dim(
+                    view_node,
+                    2,
+                    dc,
+                    "DeepSeek V4 sparse attention q heads",
+                )
+            ):
+                num_updates += 1
+                break
+    return num_updates
+
+
+def _recover_deepseek_v4_wo_a_group_aten_views(gm: GraphModule, dc: DistConfig) -> int:
+    num_updates = 0
+    grouped_op = (
+        torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear
+    )
+    for grouped_node in list(gm.graph.nodes):
+        if not is_op(grouped_node, grouped_op):
+            continue
+        [input_node] = extract_op_args(grouped_node, "input")
+        if not _is_aten_view_or_reshape(input_node):
+            continue
+
+        _, view_shape = _view_base_and_shape(input_node)
+        if view_shape is None or len(view_shape) < 2:
+            continue
+        group_dim = len(view_shape) - 2
+        if view_shape[group_dim] != -1 and _scale_view_shape_dim(
+            input_node,
+            group_dim,
+            dc,
+            "DeepSeek V4 wo_a output groups",
+        ):
+            num_updates += 1
+    return num_updates
+
+
+def _recover_deepseek_v4_aten_view_sharding(gm: GraphModule, dc: DistConfig) -> int:
+    """Recover DSV4 view hints when export lowered ``auto_deploy.view`` to aten."""
+    if dc.tp_size <= 1:
+        return 0
+    return _recover_deepseek_v4_sparse_q_aten_views(
+        gm,
+        dc,
+    ) + _recover_deepseek_v4_wo_a_group_aten_views(gm, dc)
+
+
 # =============================================================================
 # Transform classes
 # =============================================================================
@@ -1425,6 +1617,9 @@ class ApplyShardingHints(BaseTransform):
             all_dead_nodes = []
 
             with WeightBiasInfoCache():
+                if shard_layers is None or "mla" in shard_layers:
+                    num_updates += _recover_deepseek_v4_aten_view_sharding(gm, dc)
+
                 for node in list(gm.graph.nodes):
                     shardable_node = ShardableNode.from_node(node)
                     if shardable_node is None:

--- a/tensorrt_llm/_torch/auto_deploy/utils/e8m0.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/e8m0.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+E8M0_DTYPE_NAME = "torch.float8_e8m0fnu"
+
+__all__ = [
+    "e8m0_to_fp32",
+    "e8m0_to_uint8",
+    "maybe_e8m0_to_fp32",
+]
+
+
+def _get_e8m0_dtype() -> torch.dtype | None:
+    return getattr(torch, "float8_e8m0fnu", None)
+
+
+def _require_e8m0_dtype() -> torch.dtype:
+    dtype = _get_e8m0_dtype()
+    if dtype is None:
+        raise RuntimeError(
+            f"{E8M0_DTYPE_NAME} is not available in this PyTorch build; "
+            "E8M0 scale tensors cannot be reinterpreted or decoded."
+        )
+    return dtype
+
+
+def _check_e8m0_tensor(scale: torch.Tensor) -> None:
+    dtype = _require_e8m0_dtype()
+    if scale.dtype != dtype:
+        raise TypeError(f"expected an {E8M0_DTYPE_NAME} tensor, got {scale.dtype}")
+
+
+def e8m0_to_uint8(scale: torch.Tensor) -> torch.Tensor:
+    """Return raw E8M0 exponent bytes without numeric conversion.
+
+    Args:
+        scale: E8M0 scale tensor of any shape.
+
+    Returns:
+        A ``torch.uint8`` view over the same raw bytes as ``scale``.
+
+    Raises:
+        RuntimeError: If this PyTorch build does not expose E8M0 tensors.
+        TypeError: If ``scale`` is not an E8M0 tensor.
+    """
+    _check_e8m0_tensor(scale)
+    return scale.view(torch.uint8)
+
+
+def e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
+    """Decode E8M0 exponent-only scale values to FP32 powers of two.
+
+    Args:
+        scale: E8M0 scale tensor of any shape.
+
+    Returns:
+        A ``torch.float32`` tensor with each E8M0 byte decoded as an IEEE-754
+        FP32 exponent field.
+
+    Raises:
+        RuntimeError: If this PyTorch build does not expose E8M0 tensors.
+        TypeError: If ``scale`` is not an E8M0 tensor.
+    """
+    exp_bits = e8m0_to_uint8(scale).to(torch.int32)
+    fp32_bits = exp_bits << 23
+    return fp32_bits.view(torch.float32)
+
+
+def maybe_e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
+    """Decode E8M0 scales; return non-E8M0 scales as FP32.
+
+    Args:
+        scale: E8M0, BF16, FP16, FP32, or other numeric scale tensor of any shape.
+
+    Returns:
+        ``scale`` decoded from E8M0 when applicable, otherwise ``scale`` converted
+        numerically to ``torch.float32``.
+    """
+    dtype = _get_e8m0_dtype()
+    if dtype is not None and scale.dtype == dtype:
+        return e8m0_to_fp32(scale)
+    return scale.to(torch.float32)

--- a/tensorrt_llm/_torch/auto_deploy/utils/e8m0.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/e8m0.py
@@ -16,10 +16,21 @@
 import torch
 
 E8M0_DTYPE_NAME = "torch.float8_e8m0fnu"
+E8M0_EXPONENT_BIAS = 127
+E8M0_MAX_FINITE_BYTE = 254
+E8M0_NAN_BYTE = 255
+FP8_E4M3_DTYPE = torch.float8_e4m3fn
+FP8_E4M3_MAX = torch.finfo(FP8_E4M3_DTYPE).max
+FP8_E4M3_MIN = torch.finfo(FP8_E4M3_DTYPE).min
 
 __all__ = [
     "e8m0_to_fp32",
     "e8m0_to_uint8",
+    "e8m0_uint8_to_fp32",
+    "fp32_to_e8m0",
+    "fp8_block_dequant_ref",
+    "fp8_block_quant_ref",
+    "fp8_block_scale_shape",
     "maybe_e8m0_to_fp32",
 ]
 
@@ -38,10 +49,41 @@ def _require_e8m0_dtype() -> torch.dtype:
     return dtype
 
 
+def _scale_dtype() -> torch.dtype:
+    return _get_e8m0_dtype() or torch.float32
+
+
 def _check_e8m0_tensor(scale: torch.Tensor) -> None:
     dtype = _require_e8m0_dtype()
     if scale.dtype != dtype:
         raise TypeError(f"expected an {E8M0_DTYPE_NAME} tensor, got {scale.dtype}")
+
+
+def _check_block_quant_input(x: torch.Tensor) -> None:
+    if x.dim() == 0:
+        raise ValueError("x must have at least one dimension")
+    if not x.is_floating_point():
+        raise TypeError(f"x must be floating point, got {x.dtype}")
+
+
+def _check_block_size(block_size: int) -> None:
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+
+
+def _decode_e8m0_like_scale(scale: torch.Tensor) -> torch.Tensor:
+    if scale.dtype == torch.uint8:
+        return e8m0_uint8_to_fp32(scale)
+    return maybe_e8m0_to_fp32(scale)
+
+
+def _validate_fp32_scale_values(scale_fp32: torch.Tensor) -> None:
+    if scale_fp32.device.type != "cpu":
+        return
+    if not bool(torch.all(torch.isfinite(scale_fp32))):
+        raise ValueError("scale must contain only finite values")
+    if bool(torch.any(scale_fp32 < 0)):
+        raise ValueError("scale must be non-negative")
 
 
 def e8m0_to_uint8(scale: torch.Tensor) -> torch.Tensor:
@@ -61,6 +103,30 @@ def e8m0_to_uint8(scale: torch.Tensor) -> torch.Tensor:
     return scale.view(torch.uint8)
 
 
+def e8m0_uint8_to_fp32(exp_bits: torch.Tensor) -> torch.Tensor:
+    """Decode raw E8M0 exponent bytes to FP32 scale values.
+
+    Args:
+        exp_bits: ``torch.uint8`` tensor with raw E8M0 exponent bytes.
+
+    Returns:
+        A ``torch.float32`` tensor where bytes ``0`` through ``254`` decode to
+        ``2 ** (byte - 127)`` and byte ``255`` decodes to ``NaN``.
+
+    Raises:
+        TypeError: If ``exp_bits`` is not a ``torch.uint8`` tensor.
+    """
+    if exp_bits.dtype != torch.uint8:
+        raise TypeError(f"exp_bits must have dtype torch.uint8, got {exp_bits.dtype}")
+
+    fp32_bits = exp_bits.to(torch.int32) << 23
+    tiny_bits = torch.full_like(fp32_bits, 1 << 22)
+    nan_bits = torch.full_like(fp32_bits, 0x7FC00000)
+    fp32_bits = torch.where(exp_bits == 0, tiny_bits, fp32_bits)
+    fp32_bits = torch.where(exp_bits == E8M0_NAN_BYTE, nan_bits, fp32_bits)
+    return fp32_bits.contiguous().view(torch.float32)
+
+
 def e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
     """Decode E8M0 exponent-only scale values to FP32 powers of two.
 
@@ -75,9 +141,7 @@ def e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
         RuntimeError: If this PyTorch build does not expose E8M0 tensors.
         TypeError: If ``scale`` is not an E8M0 tensor.
     """
-    exp_bits = e8m0_to_uint8(scale).to(torch.int32)
-    fp32_bits = exp_bits << 23
-    return fp32_bits.view(torch.float32)
+    return e8m0_uint8_to_fp32(e8m0_to_uint8(scale))
 
 
 def maybe_e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
@@ -94,3 +158,129 @@ def maybe_e8m0_to_fp32(scale: torch.Tensor) -> torch.Tensor:
     if dtype is not None and scale.dtype == dtype:
         return e8m0_to_fp32(scale)
     return scale.to(torch.float32)
+
+
+def fp32_to_e8m0(scale: torch.Tensor) -> torch.Tensor:
+    """Quantize non-negative FP32 scales to E8M0 powers of two.
+
+    The quantization rounds each positive scale up to the next power of two so
+    the decoded scale is never smaller than the input scale. Byte ``255`` is
+    reserved for ``NaN`` and is not emitted.
+
+    Args:
+        scale: Floating-point tensor of non-negative finite scale values.
+
+    Returns:
+        An E8M0 tensor when this PyTorch build exposes ``torch.float8_e8m0fnu``;
+        otherwise a ``torch.float32`` tensor containing the same decoded
+        powers-of-two values.
+
+    Raises:
+        TypeError: If ``scale`` is not floating point.
+        ValueError: If a CPU ``scale`` tensor contains negative or non-finite
+            values. CUDA graph paths avoid data-dependent host checks.
+    """
+    if not scale.is_floating_point():
+        raise TypeError(f"scale must be floating point, got {scale.dtype}")
+
+    scale_fp32 = scale.to(torch.float32)
+    _validate_fp32_scale_values(scale_fp32)
+
+    min_scale = torch.full((), 2.0**-E8M0_EXPONENT_BIAS, dtype=torch.float32, device=scale.device)
+    safe_scale = torch.maximum(scale_fp32, min_scale)
+    exponent = torch.ceil(torch.log2(safe_scale))
+    exp_bits = torch.clamp(
+        exponent + E8M0_EXPONENT_BIAS,
+        min=0,
+        max=E8M0_MAX_FINITE_BYTE,
+    ).to(torch.uint8)
+
+    dtype = _get_e8m0_dtype()
+    if dtype is not None:
+        return exp_bits.contiguous().view(dtype)
+    return e8m0_uint8_to_fp32(exp_bits)
+
+
+def fp8_block_scale_shape(input_shape: tuple[int, ...], block_size: int = 128) -> tuple[int, ...]:
+    """Return the per-last-dimension block scale shape for an input tensor shape."""
+    _check_block_size(block_size)
+    if len(input_shape) == 0:
+        raise ValueError("input_shape must have at least one dimension")
+
+    last_dim = input_shape[-1]
+    if last_dim < 0:
+        raise ValueError(f"last dimension must be non-negative, got {last_dim}")
+    num_blocks = (last_dim + block_size - 1) // block_size
+    return (*input_shape[:-1], num_blocks)
+
+
+def fp8_block_quant_ref(
+    x: torch.Tensor,
+    block_size: int = 128,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference E4M3 quantization with one E8M0 scale per last-dim block.
+
+    Args:
+        x: Floating-point tensor of shape ``[..., dim]``.
+        block_size: Number of contiguous last-dimension elements covered by one
+            scale. Partial tail blocks are padded with zeros only for amax
+            calculation.
+
+    Returns:
+        ``(x_fp8, scale)`` where ``x_fp8`` has shape ``[..., dim]`` and dtype
+        ``torch.float8_e4m3fn``. ``scale`` has shape
+        ``[..., ceil(dim / block_size)]`` and uses ``torch.float8_e8m0fnu`` when
+        available, otherwise decoded ``torch.float32`` powers of two.
+    """
+    _check_block_quant_input(x)
+    _check_block_size(block_size)
+
+    last_dim = x.shape[-1]
+    scale_shape = fp8_block_scale_shape(tuple(x.shape), block_size)
+    if last_dim == 0:
+        scale = torch.empty(scale_shape, dtype=_scale_dtype(), device=x.device)
+        return x.to(FP8_E4M3_DTYPE).contiguous(), scale
+
+    num_blocks = scale_shape[-1]
+    pad = num_blocks * block_size - last_dim
+    x_fp32 = x.to(torch.float32)
+    if pad:
+        x_fp32 = torch.nn.functional.pad(x_fp32, (0, pad))
+
+    blocked = x_fp32.reshape(*x.shape[:-1], num_blocks, block_size)
+    amax = blocked.abs().amax(dim=-1)
+    scale_fp32 = torch.where(
+        amax > 0,
+        amax / FP8_E4M3_MAX,
+        torch.ones((), dtype=torch.float32, device=x.device),
+    )
+    scale = fp32_to_e8m0(scale_fp32)
+    scale_decoded = _decode_e8m0_like_scale(scale).to(device=x.device, dtype=torch.float32)
+    quant = (blocked / scale_decoded.unsqueeze(-1)).clamp(FP8_E4M3_MIN, FP8_E4M3_MAX)
+    quant = quant.to(FP8_E4M3_DTYPE).reshape(*x.shape[:-1], num_blocks * block_size)
+    return quant[..., :last_dim].contiguous(), scale.contiguous()
+
+
+def fp8_block_dequant_ref(
+    x_fp8: torch.Tensor,
+    scale: torch.Tensor,
+    block_size: int = 128,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize tensors produced by :func:`fp8_block_quant_ref`."""
+    _check_block_size(block_size)
+    if x_fp8.dim() == 0:
+        raise ValueError("x_fp8 must have at least one dimension")
+    if x_fp8.dtype != FP8_E4M3_DTYPE:
+        raise TypeError(f"x_fp8 must have dtype {FP8_E4M3_DTYPE}, got {x_fp8.dtype}")
+
+    expected_scale_shape = fp8_block_scale_shape(tuple(x_fp8.shape), block_size)
+    if tuple(scale.shape) != expected_scale_shape:
+        raise ValueError(
+            f"scale shape {tuple(scale.shape)} must match expected shape {expected_scale_shape} "
+            f"for x_fp8 shape {tuple(x_fp8.shape)} and block_size {block_size}"
+        )
+
+    scale_expanded = _decode_e8m0_like_scale(scale).repeat_interleave(block_size, dim=-1)
+    scale_expanded = scale_expanded[..., : x_fp8.shape[-1]]
+    return (x_fp8.to(torch.float32) * scale_expanded.to(torch.float32)).to(dtype).contiguous()

--- a/tensorrt_llm/_torch/auto_deploy/utils/fp8_dequant.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/fp8_dequant.py
@@ -39,11 +39,16 @@ def dequant_fp8_weight_two_dim_block_grid(
     """
     N, K = weight_fp8.shape
     scale_n, scale_k = weight_scale.shape
-    # Ceil division so the expanded scale covers non-divisible dims (see torch_quant).
-    actual_block_n = math.ceil(N / scale_n) if scale_n > 0 else block_n
-    actual_block_k = math.ceil(K / scale_k) if scale_k > 0 else block_k
-    scale_expanded = weight_scale.repeat_interleave(actual_block_n, dim=0).repeat_interleave(
-        actual_block_k, dim=1
+    if block_n <= 0 or block_k <= 0:
+        raise ValueError(f"block sizes must be positive, got block_n={block_n}, block_k={block_k}")
+    if scale_n == 0 or scale_k == 0 or scale_n * block_n < N or scale_k * block_k < K:
+        raise ValueError(
+            f"weight_scale shape {tuple(weight_scale.shape)} with block size "
+            f"({block_n}, {block_k}) does not cover weight shape {tuple(weight_fp8.shape)}."
+        )
+
+    scale_expanded = weight_scale.repeat_interleave(block_n, dim=0).repeat_interleave(
+        block_k, dim=1
     )
     scale_expanded = scale_expanded[:N, :K]
     return weight_fp8.to(dtype) * scale_expanded.to(dtype)

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -456,6 +456,8 @@ _torch_dtype_to_np_typestr_dict = {
     torch.bool: "|b1",
     torch.bfloat16: "<f2",
     torch.uint8: "|u1",
+    torch.complex64: "<c8",
+    torch.complex128: "<c16",
 }
 
 

--- a/tests/integration/defs/auto_deploy/test_deepseek_v4_sparse_attention.py
+++ b/tests/integration/defs/auto_deploy/test_deepseek_v4_sparse_attention.py
@@ -1,0 +1,522 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import yaml
+from torch.export import Dim
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_attention import (
+    _build_full_compressed_kv,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_kernels import (
+    deepseek_v4_local_window_topk_idxs,
+)
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
+    DeepseekV4Config,
+    DeepseekV4ForCausalLM,
+)
+from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
+from tensorrt_llm._torch.auto_deploy.transform.library.kvcache import InsertCachedAttention
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_op_args, is_op
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_REGISTRY_DIR = _REPO_ROOT / "examples" / "auto_deploy" / "model_registry"
+_CONFIGS_DIR = _REGISTRY_DIR / "configs"
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open() as stream:
+        return yaml.safe_load(stream)
+
+
+def _small_config(**overrides) -> DeepseekV4Config:
+    values = dict(
+        vocab_size=64,
+        hidden_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        head_dim=8,
+        q_lora_rank=8,
+        qk_rope_head_dim=4,
+        o_groups=1,
+        o_lora_rank=8,
+        sliding_window=4,
+        compress_ratios=(4, 128),
+        compress_rope_theta=10000.0,
+        moe_intermediate_size=8,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_hash_layers=0,
+        scoring_func="sqrtsoftplus",
+        routed_scaling_factor=1.25,
+        swiglu_limit=0.0,
+        max_position_embeddings=256,
+        ad_rope_cache_len=256,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 0,
+            "beta_fast": 32,
+            "beta_slow": 1,
+        },
+        rms_norm_eps=1e-6,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+        hc_eps=1e-6,
+    )
+    values.update(overrides)
+    return DeepseekV4Config(**values)
+
+
+def _batch_info(num_prefill: int, num_prefill_tokens: int, num_decode: int) -> torch.Tensor:
+    from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo
+
+    batch_info = BatchInfo()
+    batch_info.update([num_prefill, num_prefill_tokens, 0, 0, num_decode, num_decode])
+    batch_info.update_tokens_gather_info(num_prefill_tokens + num_decode, False)
+    return batch_info.serialize()
+
+
+def _paged_cache_metadata(
+    seq_lens: list[int], block_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cache_loc = []
+    cu_num_pages = [0]
+    next_page = 0
+    for seq_len in seq_lens:
+        num_pages = (seq_len + block_size - 1) // block_size
+        cache_loc.extend(range(next_page, next_page + num_pages))
+        next_page += num_pages
+        cu_num_pages.append(len(cache_loc))
+    return torch.tensor(cache_loc, dtype=torch.int), torch.tensor(cu_num_pages, dtype=torch.int)
+
+
+def _freqs_cis_table(max_position: int, rope_dim: int) -> torch.Tensor:
+    freqs = 1.0 / (10000.0 ** (torch.arange(0, rope_dim, 2, dtype=torch.float32) / rope_dim))
+    phases = torch.arange(max_position, dtype=torch.float32).unsqueeze(1) * freqs.unsqueeze(0)
+    return torch.polar(torch.ones_like(phases), phases)
+
+
+def _compressed_topk_idxs(
+    ratio: int,
+    batch_size: int,
+    seq_len: int,
+    offset: int,
+    max_compressed_len: int,
+) -> torch.Tensor:
+    compressed = torch.arange(max_compressed_len)
+    matrix = compressed.unsqueeze(0).expand(seq_len, -1)
+    valid_lengths = torch.arange(1, seq_len + 1).unsqueeze(1) // ratio
+    matrix = torch.where(matrix < valid_lengths, matrix + offset, -1)
+    return matrix.unsqueeze(0).expand(batch_size, -1, -1).to(torch.int32)
+
+
+def _compressed_source_topk(
+    ratio: int,
+    batch_size: int,
+    seq_len: int,
+    window_size: int,
+    max_compressed_len: int,
+) -> torch.Tensor:
+    local = deepseek_v4_local_window_topk_idxs(
+        window_size, batch_size, seq_len, torch.device("cpu")
+    )
+    compressed = _compressed_topk_idxs(ratio, batch_size, seq_len, seq_len, max_compressed_len)
+    return torch.cat([local.to(torch.int32), compressed], dim=-1)
+
+
+def _compressed_caches(
+    total_len: int,
+    block_size: int,
+    head_dim: int,
+    compressor_state_dim: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+]:
+    cache_loc, cu_num_pages = _paged_cache_metadata([total_len], block_size)
+    num_pages = len(cache_loc)
+    caches = (
+        torch.zeros(num_pages, block_size, 1, 1, head_dim),
+        torch.zeros(num_pages, block_size, 1, 1, head_dim),
+        torch.zeros(num_pages, block_size, 1, 1, compressor_state_dim),
+        torch.zeros(num_pages, block_size, 1, 1, compressor_state_dim),
+    )
+    return cache_loc, cu_num_pages, caches
+
+
+def _run_sparse_attention_v2(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    ratio: int,
+    max_compressed_len: int,
+    window_size: int,
+    rope_dim: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        softmax_scale,
+        window_size=window_size,
+        compress_ratio=ratio,
+        max_compressed_len=max_compressed_len,
+        rope_dim=rope_dim,
+        rms_norm_eps=1e-6,
+    )
+
+
+def _run_cached_sparse_attention_v2(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    batch_info: torch.Tensor,
+    seq_len: torch.Tensor,
+    input_pos: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    cache_loc: torch.Tensor,
+    cu_num_pages: torch.Tensor,
+    caches: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+    ratio: int,
+    max_compressed_len: int,
+    window_size: int,
+    rope_dim: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        batch_info,
+        seq_len,
+        input_pos,
+        cu_seqlen,
+        cache_loc,
+        cu_num_pages,
+        *caches,
+        softmax_scale,
+        window_size,
+        ratio,
+        max_compressed_len,
+        1e-6,
+        rope_dim,
+    )
+
+
+def _prefill_then_decode_fixture(ratio: int, prefix_len: int, total_len: int) -> dict:
+    torch.manual_seed(500 + ratio)
+    batch_size = 1
+    num_heads = 2
+    head_dim = 6
+    rope_dim = 2
+    window_size = 3
+    block_size = 4
+    softmax_scale = 0.375
+    channels = 2 if ratio == 4 else 1
+    max_compressed_len = (total_len + ratio - 1) // ratio
+
+    q = torch.randn(batch_size, total_len, num_heads, head_dim)
+    kv = torch.randn(batch_size, total_len, head_dim)
+    compressor_kv = torch.randn(batch_size, total_len, channels * head_dim)
+    compressor_gate = torch.randn(batch_size, total_len, channels * head_dim)
+    compressor_ape = torch.randn(ratio, channels * head_dim)
+    compressor_norm_weight = torch.randn(head_dim)
+    freqs_cis_table = _freqs_cis_table(total_len + ratio, rope_dim)
+    position_ids = torch.arange(total_len).view(1, -1)
+    attn_sink = torch.tensor([-0.2, 0.35])
+
+    full_topk = _compressed_source_topk(
+        ratio, batch_size, total_len, window_size, max_compressed_len
+    )
+    full = _run_sparse_attention_v2(
+        q,
+        kv,
+        attn_sink,
+        full_topk,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        ratio,
+        max_compressed_len,
+        window_size,
+        rope_dim,
+        softmax_scale,
+    )
+
+    cache_loc, cu_num_pages, caches = _compressed_caches(
+        total_len, block_size, head_dim, channels * head_dim
+    )
+    prefix_topk = _compressed_source_topk(
+        ratio, batch_size, prefix_len, window_size, max_compressed_len
+    )
+    prefix = _run_cached_sparse_attention_v2(
+        q[:, :prefix_len],
+        kv[:, :prefix_len],
+        attn_sink,
+        prefix_topk,
+        compressor_kv[:, :prefix_len],
+        compressor_gate[:, :prefix_len],
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids[:, :prefix_len],
+        _batch_info(num_prefill=1, num_prefill_tokens=prefix_len, num_decode=0),
+        torch.tensor([prefix_len], dtype=torch.int),
+        torch.tensor([0], dtype=torch.int),
+        torch.tensor([0, prefix_len], dtype=torch.int),
+        cache_loc,
+        cu_num_pages,
+        caches,
+        ratio,
+        max_compressed_len,
+        window_size,
+        rope_dim,
+        softmax_scale,
+    )
+
+    decode_outputs = []
+    dummy_topk = torch.zeros(batch_size, 1, window_size, dtype=torch.int32)
+    for pos in range(prefix_len, total_len):
+        decode_outputs.append(
+            _run_cached_sparse_attention_v2(
+                q[:, pos : pos + 1],
+                kv[:, pos : pos + 1],
+                attn_sink,
+                dummy_topk,
+                compressor_kv[:, pos : pos + 1],
+                compressor_gate[:, pos : pos + 1],
+                compressor_ape,
+                compressor_norm_weight,
+                freqs_cis_table,
+                position_ids[:, pos : pos + 1],
+                _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=1),
+                torch.tensor([1], dtype=torch.int),
+                torch.tensor([pos], dtype=torch.int),
+                torch.tensor([0, 1], dtype=torch.int),
+                cache_loc,
+                cu_num_pages,
+                caches,
+                ratio,
+                max_compressed_len,
+                window_size,
+                rope_dim,
+                softmax_scale,
+            )
+        )
+
+    return {
+        "full": full,
+        "prefix": prefix,
+        "decode": torch.cat(decode_outputs, dim=1),
+        "caches": caches,
+        "compressor_kv": compressor_kv,
+        "compressor_gate": compressor_gate,
+        "compressor_ape": compressor_ape,
+        "compressor_norm_weight": compressor_norm_weight,
+        "freqs_cis_table": freqs_cis_table,
+        "position_ids": position_ids,
+        "prefix_len": prefix_len,
+        "ratio": ratio,
+        "max_compressed_len": max_compressed_len,
+        "rope_dim": rope_dim,
+    }
+
+
+def test_registry_config_selects_deepseek_v4_sparse_cached_attention() -> None:
+    registry = _load_yaml(_REGISTRY_DIR / "models.yaml")
+    dsv4_entry = next(
+        entry for entry in registry["models"] if entry["name"] == "deepseek-ai/DeepSeek-V4-Flash"
+    )
+    config = _load_yaml(_CONFIGS_DIR / "deepseek_v4_flash.yaml")
+
+    assert dsv4_entry["yaml_extra"] == [
+        "dashboard_default.yaml",
+        "world_size_8.yaml",
+        "deepseek_v4_flash.yaml",
+    ]
+    assert config["model_factory"] == "DeepseekV4AutoModelForCausalLM"
+    assert config["model_kwargs"]["skip_mtp"] is True
+    assert config["transforms"]["insert_cached_attention"]["backend"] == "deepseek_v4_sparse"
+
+
+@pytest.mark.parametrize(
+    "ratio,prefix_len,total_len",
+    [
+        pytest.param(4, 3, 9, id="ratio4-overlap-decode"),
+        pytest.param(128, 127, 130, id="ratio128-boundary-decode"),
+    ],
+)
+def test_compressed_cached_decode_matches_full_source_integration(
+    ratio: int, prefix_len: int, total_len: int
+) -> None:
+    fixture = _prefill_then_decode_fixture(ratio, prefix_len, total_len)
+
+    torch.testing.assert_close(
+        fixture["prefix"],
+        fixture["full"][:, :prefix_len],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    torch.testing.assert_close(
+        fixture["decode"],
+        fixture["full"][:, prefix_len:],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+    expected_compressed = _build_full_compressed_kv(
+        fixture["compressor_kv"],
+        fixture["compressor_gate"],
+        fixture["compressor_ape"],
+        fixture["compressor_norm_weight"],
+        fixture["freqs_cis_table"],
+        fixture["position_ids"],
+        1e-6,
+        fixture["rope_dim"],
+        fixture["ratio"],
+        fixture["max_compressed_len"],
+    )
+    _, mhc_cache, _, _ = fixture["caches"]
+    last_completed_row = (total_len // ratio) - 1
+    if last_completed_row >= 0:
+        page = last_completed_row // 4
+        offset = last_completed_row % 4
+        torch.testing.assert_close(
+            mhc_cache[page, offset, 0, 0],
+            expected_compressed[0, last_completed_row],
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+
+def test_exported_dsv4_graph_cache_insertion_preserves_compressed_ratios() -> None:
+    torch.manual_seed(123)
+    config = _small_config()
+    model = DeepseekV4ForCausalLM(config).eval()
+    input_ids = torch.randint(0, config.vocab_size, (2, 129))
+    position_ids = torch.arange(129).unsqueeze(0).expand(2, -1)
+
+    gm = torch_export_to_gm(
+        model,
+        args=(input_ids,),
+        kwargs={"position_ids": position_ids},
+        dynamic_shapes={
+            "input_ids": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+            "position_ids": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        },
+        num_moe_experts_for_export=2,
+    )
+
+    source_nodes = [
+        node
+        for node in gm.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2)
+    ]
+    assert len(source_nodes) == 2
+
+    cm = CachedSequenceInterface(
+        max_seq_len=256,
+        max_batch_size=2,
+        max_num_tokens=256,
+        device="cpu",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=4,
+            max_tokens=512,
+            free_gpu_memory_fraction=0.0,
+        ),
+    )
+    registry_config = _load_yaml(_CONFIGS_DIR / "deepseek_v4_flash.yaml")
+    transform = InsertCachedAttention.from_kwargs(
+        stage=Stages.CACHE_INIT,
+        backend=registry_config["transforms"]["insert_cached_attention"]["backend"],
+        run_graph_cleanup=False,
+        requires_clean_graph=False,
+    )
+
+    transformed, info = transform._apply(gm, cm, SimpleNamespace(), SharedConfig())
+
+    cached_nodes = [
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache)
+    ]
+    source_after = [
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2)
+    ]
+    placeholder_names = {node.name for node in transformed.graph.nodes if node.op == "placeholder"}
+    ratio_to_max_len = {}
+    for node in cached_nodes:
+        _, compress_ratio, max_compressed_len, _, _ = extract_op_args(
+            node,
+            "window_size",
+            "compress_ratio",
+            "max_compressed_len",
+            "rms_norm_eps",
+            "rope_dim",
+        )
+        ratio_to_max_len[compress_ratio] = max_compressed_len
+
+    assert info.num_matches == 2
+    assert len(cached_nodes) == 2
+    assert source_after == []
+    assert ratio_to_max_len == {4: 64, 128: 2}
+    assert any("mhc_cache" in name for name in placeholder_names)
+    assert any("compressor_kv_cache" in name for name in placeholder_names)
+    assert any("compressor_gate_cache" in name for name in placeholder_names)

--- a/tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py
@@ -19,9 +19,9 @@ import torch.nn as nn
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
-from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import DeepseekV4Config
-from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4_ir import (
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4Attention,
+    DeepseekV4Config,
 )
 from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding_ir import ApplyShardingHints
@@ -186,7 +186,7 @@ def test_deepseek_v4_sparse_attention_shards_attn_sink_without_collective(
     )
 
 
-def test_deepseek_v4_ir_attention_emits_head_group_views_and_sparse_attention_hint() -> None:
+def test_deepseek_v4_attention_emits_head_group_views_and_sparse_attention_hint() -> None:
     config = DeepseekV4Config(
         vocab_size=16,
         hidden_size=16,

--- a/tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py
@@ -25,6 +25,9 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     _fake_fp4_activation_quant_dequant,
 )
 from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
+from tensorrt_llm._torch.auto_deploy.transform.library.quantization import (
+    FineGrainedFP8LinearQuantization,
+)
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding_ir import ApplyShardingHints
 from tensorrt_llm._torch.auto_deploy.utils._graph import run_shape_prop
 from tensorrt_llm._torch.auto_deploy.utils.dist_config import DistConfig
@@ -109,6 +112,80 @@ class _IndexerFp4ViewShapePropFixture(nn.Module):
         return _fake_fp4_activation_quant_dequant(q)
 
 
+class _DummyFactory:
+    def __init__(self, quant_config: dict[str, object]) -> None:
+        self._quant_config = quant_config
+
+    def get_quant_config(self) -> dict[str, object]:
+        return self._quant_config
+
+
+class _DeepSeekV4AttentionTp8Fixture(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.seq_len = 4
+        self.hidden_size = 4096
+        self.head_dim = 512
+        self.o_lora_rank = 128
+        self.local_wo_a_group_dim = 4096
+        self.layers = nn.ModuleList([nn.Module()])
+        config = DeepseekV4Config(
+            vocab_size=16,
+            hidden_size=self.hidden_size,
+            num_hidden_layers=1,
+            num_attention_heads=64,
+            head_dim=self.head_dim,
+            q_lora_rank=32,
+            qk_rope_head_dim=64,
+            o_groups=8,
+            o_lora_rank=self.o_lora_rank,
+            sliding_window=128,
+            compress_ratios=(4,),
+            index_n_heads=64,
+            index_head_dim=128,
+            index_topk=512,
+            ad_rope_cache_len=8,
+            ad_compress_max_seq_len=8192,
+        )
+        self.layers[0].attn = DeepseekV4Attention(config, layer_idx=0)
+
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        return self.layers[0].attn(x, position_ids)
+
+
+class _DeepSeekV4GroupedWoAUnsupportedTpFixture(nn.Module):
+    def __init__(
+        self,
+        num_groups: int = 4,
+        o_lora_rank: int = 128,
+        group_dim: int = 16,
+    ) -> None:
+        super().__init__()
+        self.num_groups = num_groups
+        self.o_lora_rank = o_lora_rank
+        self.group_dim = group_dim
+        self.wo_a = nn.Module()
+        weight = torch.arange(
+            num_groups * o_lora_rank * group_dim,
+            dtype=torch.float32,
+        )
+        weight = weight.reshape(num_groups * o_lora_rank, group_dim)
+        self.wo_a.weight = nn.Parameter(weight.to(torch.float8_e4m3fn), requires_grad=False)
+        self.wo_a.register_buffer(
+            "weight_scale_inv",
+            torch.ones(num_groups, 1, dtype=torch.float32),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear.default(
+            x,
+            self.wo_a.weight,
+            None,
+            [self.wo_a.weight_scale_inv],
+            layer_type="mla",
+        )
+
+
 def _trace_with_meta(module: nn.Module) -> torch.fx.GraphModule:
     gm = torch.fx.symbolic_trace(module)
     params_and_buffers = dict(gm.named_parameters())
@@ -176,6 +253,92 @@ def _set_placeholder_meta(gm: torch.fx.GraphModule, target: str, value: torch.Te
     raise AssertionError(f"placeholder {target!r} not found")
 
 
+def _trace_grouped_wo_a_with_meta(
+    module: _DeepSeekV4GroupedWoAUnsupportedTpFixture,
+    input_group_count: int | None = None,
+) -> torch.fx.GraphModule:
+    gm = torch.fx.symbolic_trace(module)
+    params_and_buffers = dict(gm.named_parameters())
+    params_and_buffers.update(dict(gm.named_buffers()))
+    input_shape = (1, 2, input_group_count or module.num_groups, module.group_dim)
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            node.meta["val"] = torch.empty(input_shape, dtype=torch.bfloat16)
+        elif node.op == "get_attr" and node.target in params_and_buffers:
+            node.meta["val"] = params_and_buffers[node.target].detach()
+        elif is_op(
+            node,
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+        ):
+            node.meta["val"] = torch.empty(
+                (*input_shape[:-1], module.o_lora_rank),
+                dtype=torch.bfloat16,
+            )
+    return gm
+
+
+def _run_finegrained_transform(
+    gm: torch.fx.GraphModule,
+    quant_config: dict[str, object],
+) -> tuple[torch.fx.GraphModule, object]:
+    transform = FineGrainedFP8LinearQuantization.from_kwargs(stage=Stages.PATTERN_MATCHER)
+    return transform._apply(gm, None, _DummyFactory(quant_config), SharedConfig())
+
+
+def _deepseek_v4_quant_config() -> dict[str, object]:
+    return {
+        "quant_method": "deepseek_v4_fp8",
+        "linear_quant_method": "finegrained_fp8",
+        "weight_block_size": [128, 128],
+        "exclude_modules": [
+            "embed",
+            "head",
+            "*.ffn.gate",
+            "*.attn.compressor",
+            "*.attn.indexer.compressor",
+            "*.attn.indexer.weights_proj",
+            "*.norm",
+            "*.hc_*",
+            "*.attn_sink",
+            "mtp.*",
+        ],
+    }
+
+
+def _node_depends_on(node: torch.fx.Node, target: torch.fx.Node) -> bool:
+    def _child_nodes(value: object) -> list[torch.fx.Node]:
+        if isinstance(value, torch.fx.Node):
+            return [value]
+        if isinstance(value, (list, tuple)):
+            nodes = []
+            for item in value:
+                nodes.extend(_child_nodes(item))
+            return nodes
+        if isinstance(value, dict):
+            nodes = []
+            for item in value.values():
+                nodes.extend(_child_nodes(item))
+            return nodes
+        return []
+
+    pending = [node]
+    seen = set()
+    while pending:
+        current = pending.pop()
+        if current is target:
+            return True
+        if current in seen:
+            continue
+        seen.add(current)
+        pending.extend(_child_nodes(current.args))
+        pending.extend(_child_nodes(current.kwargs))
+    return False
+
+
+def _is_dist_all_reduce_node(node: torch.fx.Node) -> bool:
+    return node.op == "call_function" and "dist_all_reduce" in str(node.target)
+
+
 @pytest.mark.parametrize(
     "fixture_cls",
     [
@@ -215,6 +378,28 @@ def test_deepseek_v4_sparse_attention_shards_attn_sink_without_collective(
         rtol=0,
         atol=0,
     )
+
+
+def test_deepseek_v4_sparse_attention_tp8_shards_local_heads_and_attn_sink() -> None:
+    gm = _trace_with_meta(_SparseAttentionShardingFixture(num_heads=64))
+
+    transformed, info = _run_ir_sharding(gm, rank=5, world_size=8)
+
+    assert info.num_matches == 1
+    torch.testing.assert_close(
+        transformed.attn_sink,
+        torch.arange(40, 48, dtype=torch.float32),
+        rtol=0,
+        atol=0,
+    )
+    sparse_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention)
+    )
+    q_node = sparse_node.args[0]
+    assert q_node.meta["val"].shape[-2] == 8
+    assert not any(_is_dist_all_reduce_node(node) for node in transformed.graph.nodes)
 
 
 def test_deepseek_v4_attention_emits_head_group_views_and_sparse_attention_hint() -> None:
@@ -309,3 +494,131 @@ def test_deepseek_v4_indexer_fp4_quant_uses_local_shape_after_tp_sharding() -> N
     run_shape_prop(transformed)
     transformed.recompile()
     assert transformed(local_q).shape == (batch_size, seq_len, local_heads, head_dim)
+
+
+def test_deepseek_v4_attention_tp8_ratio4_sharding_places_groups_and_collectives() -> None:
+    model = _DeepSeekV4AttentionTp8Fixture().to(torch.bfloat16)
+    gm = torch_export_to_gm(
+        model,
+        args=(
+            torch.randn(1, model.seq_len, model.hidden_size, dtype=torch.bfloat16),
+            torch.arange(model.seq_len, dtype=torch.long).unsqueeze(0),
+        ),
+    )
+
+    quantized, quant_info = _run_finegrained_transform(gm, _deepseek_v4_quant_config())
+    transformed, shard_info = _run_ir_sharding(quantized, rank=5, world_size=8)
+
+    assert quant_info.num_matches == 6
+    assert shard_info.num_matches >= 10
+
+    attn = transformed.get_submodule("layers.0.attn")
+    assert attn.attn_sink.shape == (8,)
+    assert attn.wq_b.weight.shape[0] // model.head_dim == 8
+    assert attn.wo_a.weight.shape == (model.o_lora_rank, model.local_wo_a_group_dim)
+    assert attn.wo_a.weight_scale_inv.shape == (1, model.local_wo_a_group_dim // 128)
+    assert attn.wo_b.weight.shape == (4096, model.o_lora_rank)
+    assert attn.indexer.weights_proj.weight.shape == (8, 4096)
+
+    grouped_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+        )
+    )
+    local_group_view = grouped_node.args[0]
+    assert local_group_view.args[1] == [1, model.seq_len, 1, -1]
+
+    sparse_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2)
+    )
+    [
+        q,
+        topk_idxs,
+        window_size,
+        compress_ratio,
+        max_compressed_len,
+        head_dim,
+        rope_dim,
+    ] = extract_op_args(
+        sparse_node,
+        "q",
+        "topk_idxs",
+        "window_size",
+        "compress_ratio",
+        "max_compressed_len",
+        "head_dim",
+        "rope_dim",
+    )
+    assert tuple(q.meta["val"].shape) == (1, model.seq_len, 8, 512)
+    assert tuple(topk_idxs.meta["val"].shape) == (1, model.seq_len, 640)
+    assert window_size == 128
+    assert compress_ratio == 4
+    assert max_compressed_len == 2048
+    assert head_dim == 512
+    assert rope_dim == 64
+
+    wo_b_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear)
+        and node.args[1].target == "layers.0.attn.wo_b.weight"
+    )
+    assert _node_depends_on(wo_b_node.args[0], grouped_node)
+    assert any(
+        _is_dist_all_reduce_node(node) and node.args[0] is wo_b_node
+        for node in transformed.graph.nodes
+    )
+
+    topk_node = next(
+        node
+        for node in transformed.graph.nodes
+        if node.op == "call_function"
+        and node.target == torch.ops.aten.topk.default
+        and "indexer" in node.name
+    )
+    indexer_score_reduce = next(
+        node
+        for node in transformed.graph.nodes
+        if _is_dist_all_reduce_node(node) and _node_depends_on(topk_node.args[0], node)
+    )
+    assert "indexer" in indexer_score_reduce.name
+
+
+def test_deepseek_v4_grouped_wo_a_rejects_tp8_when_o_groups_smaller_than_tp_size() -> None:
+    gm = _trace_grouped_wo_a_with_meta(_DeepSeekV4GroupedWoAUnsupportedTpFixture())
+
+    with pytest.raises(AssertionError, match="o_groups >= tp_size"):
+        _run_ir_sharding(gm, rank=0, world_size=8)
+
+
+def test_deepseek_v4_grouped_wo_a_accepts_tp8_local_group_metadata() -> None:
+    module = _DeepSeekV4GroupedWoAUnsupportedTpFixture(
+        num_groups=8,
+        o_lora_rank=128,
+        group_dim=64,
+    )
+    gm = _trace_grouped_wo_a_with_meta(module, input_group_count=1)
+
+    transformed, info = _run_ir_sharding(gm, rank=5, world_size=8)
+
+    assert info.num_matches == 1
+    assert transformed.wo_a.weight.shape == (module.o_lora_rank, module.group_dim)
+    assert transformed.wo_a.weight_scale_inv.shape == (1, 1)
+    grouped_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+        )
+    )
+    assert grouped_node.args[0].op == "placeholder"
+    assert not any(
+        node.op == "call_function" and node.target == torch.ops.aten.slice.Tensor
+        for node in transformed.graph.nodes
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import torch
 import torch.nn as nn
 
@@ -50,6 +51,45 @@ class _SparseAttentionShardingFixture(nn.Module):
         )
 
 
+class _SparseAttentionV2ShardingFixture(nn.Module):
+    def __init__(self, num_heads: int = 8) -> None:
+        super().__init__()
+        self.attn_sink = nn.Parameter(torch.arange(num_heads, dtype=torch.float32))
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        topk_idxs: torch.Tensor,
+        compressor_kv: torch.Tensor,
+        compressor_gate: torch.Tensor,
+        compressor_ape: torch.Tensor,
+        compressor_norm_weight: torch.Tensor,
+        freqs_cis_table: torch.Tensor,
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2.default(
+            q,
+            kv,
+            self.attn_sink,
+            topk_idxs,
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            position_ids,
+            0.5,
+            enable_sharding=True,
+            layer_type="mla",
+            window_size=3,
+            compress_ratio=0,
+            max_compressed_len=None,
+            head_dim=4,
+            rope_dim=2,
+        )
+
+
 def _trace_with_meta(module: nn.Module) -> torch.fx.GraphModule:
     gm = torch.fx.symbolic_trace(module)
     params_and_buffers = dict(gm.named_parameters())
@@ -62,9 +102,25 @@ def _trace_with_meta(module: nn.Module) -> torch.fx.GraphModule:
                 node.meta["val"] = torch.empty((2, 5, 4), dtype=torch.bfloat16)
             elif node.target == "topk_idxs":
                 node.meta["val"] = torch.empty((2, 3, 2), dtype=torch.int32)
+            elif node.target in {"compressor_kv", "compressor_gate"}:
+                node.meta["val"] = torch.empty((2, 5, 0), dtype=torch.bfloat16)
+            elif node.target == "compressor_ape":
+                node.meta["val"] = torch.empty((0, 0), dtype=torch.bfloat16)
+            elif node.target == "compressor_norm_weight":
+                node.meta["val"] = torch.empty((0,), dtype=torch.bfloat16)
+            elif node.target == "freqs_cis_table":
+                node.meta["val"] = torch.empty((8, 1), dtype=torch.complex64)
+            elif node.target == "position_ids":
+                node.meta["val"] = torch.empty((2, 5), dtype=torch.long)
         elif node.op == "get_attr" and node.target in params_and_buffers:
             node.meta["val"] = params_and_buffers[node.target].detach()
-        elif is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention):
+        elif is_op(
+            node,
+            (
+                torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention,
+                torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2,
+            ),
+        ):
             node.meta["val"] = torch.empty((2, 3, 8, 4), dtype=torch.bfloat16)
     return gm
 
@@ -89,8 +145,17 @@ def _run_ir_sharding(
     return transform._apply(gm, None, None, shared_config)
 
 
-def test_deepseek_v4_sparse_attention_shards_attn_sink_without_collective() -> None:
-    gm = _trace_with_meta(_SparseAttentionShardingFixture())
+@pytest.mark.parametrize(
+    "fixture_cls",
+    [
+        pytest.param(_SparseAttentionShardingFixture, id="legacy-source-op"),
+        pytest.param(_SparseAttentionV2ShardingFixture, id="v2-source-op"),
+    ],
+)
+def test_deepseek_v4_sparse_attention_shards_attn_sink_without_collective(
+    fixture_cls: type[nn.Module],
+) -> None:
+    gm = _trace_with_meta(fixture_cls())
 
     transformed, info = _run_ir_sharding(gm, rank=1, world_size=2)
 
@@ -149,7 +214,7 @@ def test_deepseek_v4_ir_attention_emits_head_group_views_and_sparse_attention_hi
     sparse_node = next(
         node
         for node in gm.graph.nodes
-        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention)
+        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2)
     )
 
     assert len(view_nodes) >= 2

--- a/tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py
@@ -22,9 +22,11 @@ from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4Attention,
     DeepseekV4Config,
+    _fake_fp4_activation_quant_dequant,
 )
 from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding_ir import ApplyShardingHints
+from tensorrt_llm._torch.auto_deploy.utils._graph import run_shape_prop
 from tensorrt_llm._torch.auto_deploy.utils.dist_config import DistConfig
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_op_args, is_op
 
@@ -90,6 +92,23 @@ class _SparseAttentionV2ShardingFixture(nn.Module):
         )
 
 
+class _IndexerFp4ViewShapePropFixture(nn.Module):
+    def __init__(self, num_heads: int = 64, head_dim: int = 128) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+
+    def forward(self, q: torch.Tensor) -> torch.Tensor:
+        batch_size, seq_len, _ = q.shape
+        q = torch.ops.auto_deploy.view(
+            q,
+            [batch_size, seq_len, self.num_heads, self.head_dim],
+            tp_scaled_dim=2,
+            layer_type="mla",
+        )
+        return _fake_fp4_activation_quant_dequant(q)
+
+
 def _trace_with_meta(module: nn.Module) -> torch.fx.GraphModule:
     gm = torch.fx.symbolic_trace(module)
     params_and_buffers = dict(gm.named_parameters())
@@ -143,6 +162,18 @@ def _run_ir_sharding(
         ),
     )
     return transform._apply(gm, None, None, shared_config)
+
+
+def _set_placeholder_meta(gm: torch.fx.GraphModule, target: str, value: torch.Tensor) -> None:
+    for node in gm.graph.nodes:
+        if node.op != "placeholder" or node.target != target:
+            continue
+        fake_mode = getattr(node.meta.get("val"), "fake_mode", None)
+        node.meta["val"] = (
+            fake_mode.from_tensor(value, static_shapes=True) if fake_mode is not None else value
+        )
+        return
+    raise AssertionError(f"placeholder {target!r} not found")
 
 
 @pytest.mark.parametrize(
@@ -221,3 +252,60 @@ def test_deepseek_v4_attention_emits_head_group_views_and_sparse_attention_hint(
     assert any(extract_op_args(node, "tp_scaled_dim")[0] == 2 for node in view_nodes)
     assert extract_op_args(sparse_node, "enable_sharding")[0] is True
     assert any(is_op(node, torch.ops.auto_deploy.all_reduce) for node in gm.graph.nodes)
+
+
+def test_deepseek_v4_indexer_fp4_shape_prop_after_tp_sharding() -> None:
+    config = DeepseekV4Config(
+        vocab_size=16,
+        hidden_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        head_dim=4,
+        q_lora_rank=8,
+        qk_rope_head_dim=2,
+        o_groups=2,
+        o_lora_rank=4,
+        sliding_window=2,
+        compress_ratios=(4,),
+        index_n_heads=4,
+        index_head_dim=32,
+        index_topk=2,
+        ad_rope_cache_len=8,
+        ad_compress_max_seq_len=8,
+    )
+    attention = DeepseekV4Attention(config, layer_idx=0)
+    gm = torch_export_to_gm(
+        attention,
+        args=(
+            torch.randn(1, 8, 16, dtype=torch.bfloat16),
+            torch.arange(8, dtype=torch.long).unsqueeze(0),
+        ),
+    )
+
+    transformed, info = _run_ir_sharding(gm, rank=1, world_size=2)
+
+    assert info.num_matches > 0
+    assert transformed.get_parameter("indexer.wq_b.weight").shape == (64, 8)
+
+
+def test_deepseek_v4_indexer_fp4_quant_uses_local_shape_after_tp_sharding() -> None:
+    batch_size = 1
+    seq_len = 8
+    full_heads = 64
+    head_dim = 128
+    tp_size = 8
+    local_heads = full_heads // tp_size
+    fixture = _IndexerFp4ViewShapePropFixture(full_heads, head_dim)
+    gm = torch_export_to_gm(
+        fixture,
+        args=(torch.randn(batch_size, seq_len, full_heads * head_dim, dtype=torch.bfloat16),),
+    )
+
+    transformed, info = _run_ir_sharding(gm, rank=1, world_size=tp_size)
+    local_q = torch.randn(batch_size, seq_len, local_heads * head_dim, dtype=torch.bfloat16)
+    _set_placeholder_meta(transformed, "q", local_q)
+
+    assert info.num_matches == 1
+    run_shape_prop(transformed)
+    transformed.recompile()
+    assert transformed(local_q).shape == (batch_size, seq_len, local_heads, head_dim)

--- a/tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py
+++ b/tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as nn
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import DeepseekV4Config
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4_ir import (
+    DeepseekV4Attention,
+)
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
+from tensorrt_llm._torch.auto_deploy.transform.library.sharding_ir import ApplyShardingHints
+from tensorrt_llm._torch.auto_deploy.utils.dist_config import DistConfig
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_op_args, is_op
+
+
+class _SparseAttentionShardingFixture(nn.Module):
+    def __init__(self, num_heads: int = 8) -> None:
+        super().__init__()
+        self.attn_sink = nn.Parameter(torch.arange(num_heads, dtype=torch.float32))
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        topk_idxs: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention.default(
+            q,
+            kv,
+            self.attn_sink,
+            topk_idxs,
+            0.5,
+            enable_sharding=True,
+            layer_type="mla",
+        )
+
+
+def _trace_with_meta(module: nn.Module) -> torch.fx.GraphModule:
+    gm = torch.fx.symbolic_trace(module)
+    params_and_buffers = dict(gm.named_parameters())
+    params_and_buffers.update(dict(gm.named_buffers()))
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            if node.target == "q":
+                node.meta["val"] = torch.empty((2, 3, 8, 4), dtype=torch.bfloat16)
+            elif node.target == "kv":
+                node.meta["val"] = torch.empty((2, 5, 4), dtype=torch.bfloat16)
+            elif node.target == "topk_idxs":
+                node.meta["val"] = torch.empty((2, 3, 2), dtype=torch.int32)
+        elif node.op == "get_attr" and node.target in params_and_buffers:
+            node.meta["val"] = params_and_buffers[node.target].detach()
+        elif is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention):
+            node.meta["val"] = torch.empty((2, 3, 8, 4), dtype=torch.bfloat16)
+    return gm
+
+
+def _run_ir_sharding(
+    gm: torch.fx.GraphModule,
+    *,
+    rank: int,
+    world_size: int,
+) -> tuple[torch.fx.GraphModule, object]:
+    transform = ApplyShardingHints.from_kwargs(stage=Stages.SHARDING)
+    shared_config = SharedConfig(
+        local_rank=rank,
+        world_size=world_size,
+        dist_config=DistConfig(
+            world_size=world_size,
+            rank=rank,
+            tp_size=world_size,
+            moe_ep_size=world_size,
+        ),
+    )
+    return transform._apply(gm, None, None, shared_config)
+
+
+def test_deepseek_v4_sparse_attention_shards_attn_sink_without_collective() -> None:
+    gm = _trace_with_meta(_SparseAttentionShardingFixture())
+
+    transformed, info = _run_ir_sharding(gm, rank=1, world_size=2)
+
+    assert info.num_matches == 1
+    torch.testing.assert_close(
+        transformed.attn_sink,
+        torch.tensor([4.0, 5.0, 6.0, 7.0]),
+        rtol=0,
+        atol=0,
+    )
+    assert not any(
+        node.op == "call_function" and "all_reduce" in str(node.target)
+        for node in transformed.graph.nodes
+    )
+
+    load_result = transformed.load_state_dict(
+        {"attn_sink": torch.arange(8, dtype=torch.float32).add(10)},
+        strict=False,
+    )
+
+    assert load_result.missing_keys == []
+    assert load_result.unexpected_keys == []
+    torch.testing.assert_close(
+        transformed.attn_sink,
+        torch.tensor([14.0, 15.0, 16.0, 17.0]),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_deepseek_v4_ir_attention_emits_head_group_views_and_sparse_attention_hint() -> None:
+    config = DeepseekV4Config(
+        vocab_size=16,
+        hidden_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        head_dim=4,
+        q_lora_rank=8,
+        qk_rope_head_dim=2,
+        o_groups=2,
+        o_lora_rank=4,
+        sliding_window=2,
+        compress_ratios=(0,),
+        ad_rope_cache_len=8,
+    )
+    attention = DeepseekV4Attention(config, layer_idx=0)
+    gm = torch_export_to_gm(
+        attention,
+        args=(
+            torch.randn(1, 4, 16, dtype=torch.bfloat16),
+            torch.arange(4, dtype=torch.long).unsqueeze(0),
+        ),
+    )
+
+    view_nodes = [node for node in gm.graph.nodes if is_op(node, torch.ops.auto_deploy.view)]
+    sparse_node = next(
+        node
+        for node in gm.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention)
+    )
+
+    assert len(view_nodes) >= 2
+    assert any(extract_op_args(node, "tp_scaled_dim")[0] == 2 for node in view_nodes)
+    assert extract_op_args(sparse_node, "enable_sharding")[0] is True
+    assert any(is_op(node, torch.ops.auto_deploy.all_reduce) for node in gm.graph.nodes)

--- a/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_graph_dump_inventory.py
+++ b/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_graph_dump_inventory.py
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DeepSeek V4 five-layer graph dump inventory checks."""
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_GRAPH_DUMP_ENV = "DEEPSEEK_V4_GRAPH_DUMP"
+_DEFAULT_GRAPH_DUMP = (
+    _REPO_ROOT
+    / "ad_run_logs"
+    / "graph_dumps"
+    / "deepseek_v4_flash_5layer_sampling_workspace_20260425_131939"
+    / "084_compile_compile_model.txt"
+)
+_DEFAULT_GRAPH_FIXTURE_IS_STALE = _GRAPH_DUMP_ENV not in os.environ
+_STALE_DEFAULT_FIXTURE_XFAIL = pytest.mark.xfail(
+    _DEFAULT_GRAPH_FIXTURE_IS_STALE,
+    reason=(
+        "default five-layer compile graph fixture still records torch_* wrapper "
+        "selection; remove this xfail when the fixture is regenerated with Triton "
+        "attention/router ops"
+    ),
+    strict=True,
+)
+_ATTENTION_OP_MARKERS = (
+    "triton_deepseek_v4_sparse_attention_v2_with_cache.default",
+    "torch_deepseek_v4_sparse_attention_v2_with_cache.default",
+)
+_ROUTER_OP_MARKERS = (
+    "triton_deepseek_v4_router.default",
+    "torch_deepseek_v4_router.default",
+)
+_DEVICE_OP_GATES = (
+    pytest.param(
+        "cached sparse attention",
+        "auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache.default(",
+        "auto_deploy.triton_deepseek_v4_sparse_attention_v2_with_cache.default(",
+        5,
+        "Wave 4",
+        marks=_STALE_DEFAULT_FIXTURE_XFAIL,
+    ),
+    pytest.param(
+        "router",
+        "auto_deploy.torch_deepseek_v4_router.default(",
+        "auto_deploy.triton_deepseek_v4_router.default(",
+        5,
+        "Wave 2/4",
+        marks=_STALE_DEFAULT_FIXTURE_XFAIL,
+    ),
+)
+
+
+def _graph_dump_path() -> Path:
+    return Path(os.environ.get(_GRAPH_DUMP_ENV, _DEFAULT_GRAPH_DUMP))
+
+
+def _read_graph_dump() -> str:
+    graph_dump = _graph_dump_path()
+    if not graph_dump.is_file():
+        pytest.skip(f"DeepSeek V4 graph dump fixture is not present: {graph_dump}")
+    return graph_dump.read_text(encoding="utf-8")
+
+
+def _layer_block(graph_dump: str, layer_idx: int) -> str:
+    layer_marker = f"%layers_{layer_idx}_"
+    start = graph_dump.index(layer_marker)
+    next_start = graph_dump.find(f"%layers_{layer_idx + 1}_", start + len(layer_marker))
+    if next_start == -1:
+        return graph_dump[start:]
+    return graph_dump[start:next_start]
+
+
+def _single_line(block: str, marker: str) -> str:
+    matches = [line for line in block.splitlines() if marker in line]
+    assert len(matches) == 1, f"expected one line containing {marker!r}, found {len(matches)}"
+    return matches[0]
+
+
+def _single_dsv4_op_line(block: str, markers: tuple[str, ...]) -> str:
+    matches = [line for line in block.splitlines() if any(marker in line for marker in markers)]
+    assert len(matches) == 1, f"expected one DSV4 op line for {markers!r}, found {len(matches)}"
+    return matches[0]
+
+
+def _op_call_count(graph_dump: str, op_call: str) -> int:
+    return graph_dump.count(f" = {op_call}")
+
+
+def _assert_has_regex(text: str, pattern: str) -> None:
+    assert re.search(pattern, text), pattern
+
+
+@pytest.mark.parametrize(
+    ("path_name", "reference_op", "device_op", "expected_count", "wave"),
+    _DEVICE_OP_GATES,
+)
+def test_deepseek_v4_5layer_graph_dump_uses_device_custom_ops_for_supported_paths(
+    path_name: str,
+    reference_op: str,
+    device_op: str,
+    expected_count: int,
+    wave: str,
+) -> None:
+    graph_dump = _read_graph_dump()
+    reference_count = _op_call_count(graph_dump, reference_op)
+    device_count = _op_call_count(graph_dump, device_op)
+
+    assert reference_count == 0, (
+        f"{wave}: {path_name} still exposes {reference_count} PyTorch reference "
+        f"wrapper call(s) in {_graph_dump_path()}; expected zero {reference_op} "
+        f"call(s)."
+    )
+    assert device_count == expected_count, (
+        f"{wave}: {path_name} exposes {device_count} device op call(s) in "
+        f"{_graph_dump_path()}; expected {expected_count} {device_op} call(s)."
+    )
+
+
+def test_deepseek_v4_5layer_graph_dump_attention_inventory() -> None:
+    graph_dump = _read_graph_dump()
+    assert (
+        sum(
+            _op_call_count(graph_dump, f"auto_deploy.{marker}(") for marker in _ATTENTION_OP_MARKERS
+        )
+        == 5
+    )
+
+    expected_by_layer = {
+        0: {
+            "topk_width": 128,
+            "compress_ratio": 0,
+            "max_compressed_len": "None",
+            "compressor_fragments": ("s72xs70x0 : torch.bfloat16", "0x0 : torch.bfloat16"),
+        },
+        1: {
+            "topk_width": 128,
+            "compress_ratio": 0,
+            "max_compressed_len": "None",
+            "compressor_fragments": ("s72xs70x0 : torch.bfloat16", "0x0 : torch.bfloat16"),
+        },
+        2: {
+            "topk_width": 640,
+            "compress_ratio": 4,
+            "max_compressed_len": "2048",
+            "compressor_fragments": (
+                "s72xs70x1024 : torch.bfloat16",
+                "4x1024 : torch.float32",
+                "512 : torch.float32",
+            ),
+        },
+        3: {
+            "topk_width": 192,
+            "compress_ratio": 128,
+            "max_compressed_len": "64",
+            "compressor_fragments": (
+                "s72xs70x512 : torch.bfloat16",
+                "128x512 : torch.float32",
+                "512 : torch.float32",
+            ),
+        },
+        4: {
+            "topk_width": 640,
+            "compress_ratio": 4,
+            "max_compressed_len": "2048",
+            "compressor_fragments": (
+                "s72xs70x1024 : torch.bfloat16",
+                "4x1024 : torch.float32",
+                "512 : torch.float32",
+            ),
+        },
+    }
+
+    for layer_idx, expected in expected_by_layer.items():
+        block = _layer_block(graph_dump, layer_idx)
+        attention_line = _single_dsv4_op_line(block, _ATTENTION_OP_MARKERS)
+        assert f"s72xs70x{expected['topk_width']} : torch.int32" in attention_line
+        assert (
+            f", 128, {expected['compress_ratio']}, {expected['max_compressed_len']}, 1e-06, 64)"
+            in attention_line
+        )
+        for fragment in expected["compressor_fragments"]:
+            assert fragment in attention_line
+
+
+def test_deepseek_v4_5layer_graph_dump_ratio4_indexer_inventory() -> None:
+    graph_dump = _read_graph_dump()
+
+    for layer_idx in (2, 4):
+        block = _layer_block(graph_dump, layer_idx)
+        _assert_has_regex(
+            block,
+            rf"%layers_{layer_idx}_attn_indexer_compressor_wkv_torch_linear_simple_\d+ = "
+            rf"auto_deploy\.torch_linear_simple\.default\([^\n]*s72xs70x256 : torch\.bfloat16",
+        )
+        _assert_has_regex(
+            block,
+            rf"%layers_{layer_idx}_attn_indexer_compressor_wgate_torch_linear_simple_\d+ = "
+            rf"auto_deploy\.torch_linear_simple\.default\([^\n]*s72xs70x256 : torch\.bfloat16",
+        )
+        _assert_has_regex(
+            block,
+            rf"%layers_{layer_idx}_attn_indexer_compressor_torch_rope_with_complex_freqs_\d+ = "
+            r"auto_deploy\.torch_rope_with_complex_freqs\.default",
+        )
+        _assert_has_regex(
+            block,
+            rf"%layers_{layer_idx}_attn_indexer_clamp_\d+ = aten\.clamp\.default"
+            rf"\([^\n]*2048\*s72x4x32 : torch\.float32, -6\.0, 6\.0\)",
+        )
+        _assert_has_regex(
+            block,
+            rf"%layers_{layer_idx}_attn_indexer_topk(?:_\d+)? = aten\.topk\.default"
+            rf"\([^\n]*s72xs70x2048 : torch\.float32, 512\)",
+        )
+        _assert_has_regex(
+            block,
+            rf"%layers_{layer_idx}_attn_indexer_all_reduce_\d+ = "
+            rf"auto_deploy\.trtllm_dist_all_reduce\.default"
+            rf"\([^\n]*s72xs70x2048 : torch\.float32, NCCL\)",
+        )
+
+
+def test_deepseek_v4_5layer_graph_dump_moe_and_collective_inventory() -> None:
+    graph_dump = _read_graph_dump()
+    all_reduce_lines = [
+        line
+        for line in graph_dump.splitlines()
+        if " = auto_deploy.trtllm_dist_all_reduce.default(" in line
+    ]
+    assert len(all_reduce_lines) == 17
+
+    for layer_idx in range(5):
+        block = _layer_block(graph_dump, layer_idx)
+        grouped_wo_a_line = _single_line(
+            block,
+            "torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear.default",
+        )
+        assert "s72xs70x1x4096 : torch.bfloat16" in grouped_wo_a_line
+        assert ") : s72xs70x1x1024 : torch.bfloat16" in grouped_wo_a_line
+
+        router_line = _single_dsv4_op_line(block, _ROUTER_OP_MARKERS)
+        assert ") : (s70*s72x6, s70*s72x6) : (torch.int64, torch.float32)" in router_line
+        if layer_idx <= 2:
+            assert f"%layers_{layer_idx}_ffn_gate_tid2eid : 129280x6 : torch.int64" in router_line
+            assert ", 6, 1.5, True)" in router_line
+        else:
+            assert f"%layers_{layer_idx}_ffn_gate_bias : 256 : torch.float32" in router_line
+            assert ", None, 6, 1.5, False)" in router_line
+
+        mxfp4_moe_line = _single_line(block, "triton_deepseek_v4_mxfp4_moe_from_routing.default")
+        for fragment in (
+            "s70*s72x6 : torch.int64",
+            "s70*s72x6 : torch.float32",
+            "32x4096x128x16 : torch.uint8",
+            "32x4096x128 : torch.uint8",
+            "1.0, 10.0",
+            "32x4096x64x16 : torch.uint8",
+            "32x4096x64 : torch.uint8",
+        ):
+            assert fragment in mxfp4_moe_line
+
+        for weight_name, weight_shape in (
+            ("w1", "256x4096"),
+            ("w3", "256x4096"),
+            ("w2", "4096x256"),
+        ):
+            assert (
+                f"%layers_{layer_idx}_ffn_shared_experts_{weight_name}_weight : "
+                f"{weight_shape} : torch.float8_e4m3fn"
+            ) in block
+
+        _assert_has_regex(
+            block,
+            rf"%layers_{layer_idx}_attn_all_reduce(?:_\d+)? = "
+            rf"auto_deploy\.trtllm_dist_all_reduce\.default"
+            rf"\(%layers_{layer_idx}_attn_wo_b_torch_linear_simple_\d+ : "
+            rf"s72xs70x4096 : torch\.bfloat16, NCCL\)",
+        )
+        _assert_has_regex(
+            block,
+            r"%trtllm_dist_all_reduce_default(?:_\d+)? = "
+            r"auto_deploy\.trtllm_dist_all_reduce\.default"
+            r"\(%triton_deepseek_v4_mxfp4_moe_from_routing_default(?:_\d+)? : "
+            r"s70\*s72x4096 : torch\.bfloat16, NCCL\)",
+        )
+        _assert_has_regex(
+            block,
+            r"%all_reduce_default(?:_\d+)? = auto_deploy\.trtllm_dist_all_reduce\.default"
+            r"\(%torch_fake_quant_finegrained_fp8_linear_default(?:_\d+)? : "
+            r"s70\*s72x4096 : torch\.bfloat16, NCCL\)",
+        )

--- a/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py
+++ b/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DeepSeek V4 CUDA graph runtime config and piecewise split tests."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.fx import Graph, GraphModule
+
+from tensorrt_llm._torch.auto_deploy.compile.backends import torch_cudagraph
+from tensorrt_llm._torch.auto_deploy.compile.piecewise_runner import (
+    ADPiecewiseRunner,
+    DynamicOpWrapper,
+)
+from tensorrt_llm._torch.auto_deploy.compile.piecewise_utils import (
+    is_dynamic_cached_op,
+    is_metadata_prep,
+    needs_out_buffer,
+    split_graph_at_dynamic_ops,
+    submod_has_cuda_ops,
+)
+from tensorrt_llm._torch.auto_deploy.llm_args import LlmArgs
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_REGISTRY_CONFIGS_DIR = _REPO_ROOT / "examples" / "auto_deploy" / "model_registry" / "configs"
+_DEEPSEEK_V4_CONFIG = _REGISTRY_CONFIGS_DIR / "deepseek_v4_flash.yaml"
+_DUMMY_MODEL = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+_CONFIGURED_BATCH_SIZES = [1, 2, 4, 8, 16, 32, 64]
+
+
+class _FakeOpOverload:
+    def __init__(self, op_name: str) -> None:
+        self._op_name = op_name
+
+    def name(self) -> str:
+        return self._op_name
+
+
+def torch_deepseek_v4_sparse_attention(
+    x: torch.Tensor, out: torch.Tensor | None = None
+) -> torch.Tensor:
+    y = x + 1
+    if out is not None:
+        out.copy_(y)
+        return torch.empty(0, dtype=x.dtype, device=x.device)
+    return y
+
+
+def deepseek_v4_prepare_cache_metadata(x: torch.Tensor) -> torch.Tensor:
+    return x
+
+
+def _make_call_function_node(op_name: str) -> SimpleNamespace:
+    return SimpleNamespace(op="call_function", target=_FakeOpOverload(op_name))
+
+
+def _make_toy_graph(dynamic_fn: Any = torch_deepseek_v4_sparse_attention) -> GraphModule:
+    root = nn.Module()
+    root.static_0 = nn.Linear(4, 4, bias=False)
+    root.static_1 = nn.Linear(4, 4, bias=False)
+
+    graph = Graph()
+    x = graph.placeholder("x")
+    first_static = graph.call_module("static_0", args=(x,))
+    dynamic = graph.call_function(dynamic_fn, args=(first_static,))
+    second_static = graph.call_module("static_1", args=(dynamic,))
+    graph.output(second_static)
+    graph.lint()
+    return GraphModule(root, graph)
+
+
+@pytest.mark.parametrize(
+    "op_name",
+    [
+        "auto_deploy::torch_deepseek_v4_sparse_attention",
+        "auto_deploy::triton_deepseek_v4_sparse_attention_with_cache",
+        "auto_deploy::torch_deepseek_v4_moe",
+        "auto_deploy::triton_mxfp4_moe",
+        "auto_deploy::triton_mxfp4_moe_ep",
+        "auto_deploy::deepseek_v4_prepare_cache_metadata",
+        "auto_deploy::torch_deepseek_v4_prepare_cache_metadata",
+        "auto_deploy::triton_deepseek_v4_prepare_cache_metadata",
+    ],
+)
+def test_deepseek_v4_reserved_ops_are_dynamic(op_name: str) -> None:
+    assert is_dynamic_cached_op(_make_call_function_node(op_name))
+
+
+def test_deepseek_v4_sparse_attention_splits_static_regions_around_dynamic_op() -> None:
+    split_info = split_graph_at_dynamic_ops(_make_toy_graph())
+
+    assert split_info.dynamic_submod_indices == [1]
+    assert split_info.static_submod_indices == [0, 2]
+    assert submod_has_cuda_ops(split_info.split_gm.submod_0)
+    assert submod_has_cuda_ops(split_info.split_gm.submod_2)
+    assert needs_out_buffer(split_info.split_gm.submod_1)
+
+
+def test_piecewise_prepare_wraps_static_regions_around_deepseek_v4_dynamic_op(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(torch.cuda, "graph_pool_handle", lambda: ("fake_pool",))
+
+    piecewise = torch_cudagraph.PiecewiseCapturedGraph(
+        _make_toy_graph(),
+        piecewise_num_tokens=[4],
+        capture_lm_head=True,
+    )
+
+    piecewise.prepare()
+
+    assert isinstance(piecewise.split_gm.submod_0, ADPiecewiseRunner)
+    assert isinstance(piecewise.split_gm.submod_1, DynamicOpWrapper)
+    assert isinstance(piecewise.split_gm.submod_2, ADPiecewiseRunner)
+    assert piecewise._wrapped_dynamic_indices == {1}
+
+
+def test_deepseek_v4_cache_metadata_prep_is_dynamic_without_out_buffer() -> None:
+    split_info = split_graph_at_dynamic_ops(_make_toy_graph(deepseek_v4_prepare_cache_metadata))
+    metadata_submod = split_info.split_gm.submod_1
+
+    assert is_metadata_prep(metadata_submod)
+    assert not needs_out_buffer(metadata_submod)
+
+
+def test_deepseek_v4_config_parses_cuda_graph_batch_sizes() -> None:
+    args = LlmArgs(model=_DUMMY_MODEL, yaml_extra=[str(_DEEPSEEK_V4_CONFIG)])
+
+    assert args.enable_chunked_prefill
+    assert args.cuda_graph_config.batch_sizes == _CONFIGURED_BATCH_SIZES
+    assert args.cuda_graph_config.max_batch_size == max(_CONFIGURED_BATCH_SIZES)
+    assert args.transforms["compile_model"]["cuda_graph_batch_sizes"] == _CONFIGURED_BATCH_SIZES
+    assert args.transforms["compile_model"]["piecewise_enabled"]
+    assert not args.transforms["multi_stream_moe"]["enabled"]
+
+
+def test_torch_cudagraph_compile_keeps_monolithic_when_piecewise_disabled(monkeypatch) -> None:
+    def fake_capture_graph(
+        self: torch_cudagraph.CapturedGraph,
+        get_args_kwargs: Any,
+        batch_sizes: list[int],
+    ) -> None:
+        self._out_spec = None
+
+    def fail_piecewise_construction(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("PiecewiseCapturedGraph should not be constructed")
+
+    monkeypatch.setattr(torch_cudagraph.CapturedGraph, "capture_graph", fake_capture_graph)
+    monkeypatch.setattr(torch_cudagraph, "PiecewiseCapturedGraph", fail_piecewise_construction)
+
+    model = nn.Identity()
+    compiler = torch_cudagraph.TorchCudagraphCompiler(
+        model=model,
+        get_args_kwargs_for_compile=lambda batch_size: ((torch.ones(batch_size, 4),), {}),
+        cuda_graph_batch_sizes=[1, 2],
+        piecewise_enabled=False,
+    )
+
+    compiled = compiler.compile()
+
+    assert isinstance(compiled, torch_cudagraph.CapturedGraph)
+    assert not isinstance(compiled, torch_cudagraph.DualModeCapturedGraph)
+    assert compiled.model is model
+
+
+class _FakeMonolithic(nn.Module):
+    _output_dynamic_dim = 0
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.model = nn.Identity()
+        self.num_calls = 0
+
+    def forward(self, *args: Any, **kwargs: Any) -> str:
+        self.num_calls += 1
+        return "decode"
+
+
+class _FakePiecewise(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.original_model = nn.Identity()
+        self.piecewise_num_tokens = _CONFIGURED_BATCH_SIZES
+        self.num_calls = 0
+
+    def forward(self, *args: Any, **kwargs: Any) -> str:
+        self.num_calls += 1
+        return "piecewise"
+
+
+def test_decode_only_runtime_uses_monolithic_path_with_configured_piecewise_buckets() -> None:
+    monolithic = _FakeMonolithic()
+    piecewise = _FakePiecewise()
+    runtime = torch_cudagraph.DualModeCapturedGraph(monolithic, piecewise)
+
+    result = runtime(
+        input_ids=torch.ones(3, 1, dtype=torch.int64),
+        batch_info_host=torch.tensor([0, 0, 0, 0, 3, 3], dtype=torch.int64),
+    )
+
+    assert result == "decode"
+    assert monolithic.num_calls == 1
+    assert piecewise.num_calls == 0
+    assert runtime._find_nearest_bucket(33) == 64
+    assert runtime._find_nearest_bucket(65) is None

--- a/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py
+++ b/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py
@@ -35,7 +35,9 @@ from tensorrt_llm._torch.auto_deploy.compile.piecewise_utils import (
     split_graph_at_dynamic_ops,
     submod_has_cuda_ops,
 )
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import SequenceInfo
 from tensorrt_llm._torch.auto_deploy.llm_args import LlmArgs
+from tensorrt_llm._torch.utils import make_weak_ref
 
 _REPO_ROOT = Path(__file__).resolve().parents[6]
 _REGISTRY_CONFIGS_DIR = _REPO_ROOT / "examples" / "auto_deploy" / "model_registry" / "configs"
@@ -148,6 +150,34 @@ def test_deepseek_v4_config_parses_cuda_graph_batch_sizes() -> None:
     assert args.transforms["compile_model"]["cuda_graph_batch_sizes"] == _CONFIGURED_BATCH_SIZES
     assert args.transforms["compile_model"]["piecewise_enabled"]
     assert not args.transforms["multi_stream_moe"]["enabled"]
+
+
+def test_piecewise_setup_uses_rectangular_prefill_for_unflattened_sequence_info() -> None:
+    seq_info = SequenceInfo(
+        max_seq_len=256,
+        max_batch_size=64,
+        max_num_tokens=512,
+        tokens_per_block=32,
+    )
+
+    torch_cudagraph._setup_piecewise_mixed_batch(seq_info, 512)
+    named_args = seq_info.named_args
+
+    assert named_args["input_ids"].shape == (2, 256)
+    assert named_args["position_ids"].shape == (2, 256)
+    assert seq_info.batch_info.get_num_sequences() == (2, 0, 0)
+    assert seq_info.batch_info.get_num_tokens() == (512, 0, 0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_make_weak_ref_accepts_complex_cuda_rope_buffers() -> None:
+    freqs_cis = torch.randn(16, 8, device="cuda", dtype=torch.complex64)
+
+    weak_ref = make_weak_ref(freqs_cis)
+
+    assert weak_ref.dtype == torch.complex64
+    assert weak_ref.shape == freqs_cis.shape
+    assert weak_ref.data_ptr() == freqs_cis.data_ptr()
 
 
 def test_torch_cudagraph_compile_keeps_monolithic_when_piecewise_disabled(monkeypatch) -> None:

--- a/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py
+++ b/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py
@@ -148,7 +148,7 @@ def test_deepseek_v4_config_parses_cuda_graph_batch_sizes() -> None:
     assert args.cuda_graph_config.batch_sizes == _CONFIGURED_BATCH_SIZES
     assert args.cuda_graph_config.max_batch_size == max(_CONFIGURED_BATCH_SIZES)
     assert args.transforms["compile_model"]["cuda_graph_batch_sizes"] == _CONFIGURED_BATCH_SIZES
-    assert args.transforms["compile_model"]["piecewise_enabled"]
+    assert not args.transforms["compile_model"]["piecewise_enabled"]
     assert not args.transforms["multi_stream_moe"]["enabled"]
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py
+++ b/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py
@@ -91,6 +91,8 @@ def _make_toy_graph(dynamic_fn: Any = torch_deepseek_v4_sparse_attention) -> Gra
     "op_name",
     [
         "auto_deploy::torch_deepseek_v4_sparse_attention",
+        "auto_deploy::torch_deepseek_v4_sparse_attention_v2",
+        "auto_deploy::torch_deepseek_v4_sparse_attention_v2_with_cache",
         "auto_deploy::triton_deepseek_v4_sparse_attention_with_cache",
         "auto_deploy::torch_deepseek_v4_moe",
         "auto_deploy::triton_mxfp4_moe",

--- a/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py
+++ b/tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py
@@ -29,13 +29,20 @@ from tensorrt_llm._torch.auto_deploy.compile.piecewise_runner import (
     DynamicOpWrapper,
 )
 from tensorrt_llm._torch.auto_deploy.compile.piecewise_utils import (
+    DEEPSEEK_V4_ATTENTION_CUDA_GRAPH_CONTRACT,
+    DEEPSEEK_V4_CUDA_GRAPH_CACHE_RESOURCE_ARG_NAMES,
+    DEEPSEEK_V4_CUDA_GRAPH_METADATA_ARG_NAMES,
+    DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_ARG_NAME,
+    DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_SIZE_ARG_NAME,
+    DEEPSEEK_V4_ROUTE_METADATA_CUDA_GRAPH_CONTRACT,
+    get_deepseek_v4_cuda_graph_kernel_contract,
     is_dynamic_cached_op,
     is_metadata_prep,
     needs_out_buffer,
     split_graph_at_dynamic_ops,
     submod_has_cuda_ops,
 )
-from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import SequenceInfo
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo, SequenceInfo
 from tensorrt_llm._torch.auto_deploy.llm_args import LlmArgs
 from tensorrt_llm._torch.utils import make_weak_ref
 
@@ -44,6 +51,14 @@ _REGISTRY_CONFIGS_DIR = _REPO_ROOT / "examples" / "auto_deploy" / "model_registr
 _DEEPSEEK_V4_CONFIG = _REGISTRY_CONFIGS_DIR / "deepseek_v4_flash.yaml"
 _DUMMY_MODEL = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 _CONFIGURED_BATCH_SIZES = [1, 2, 4, 8, 16, 32, 64]
+_DSV4_LOCAL_HEADS = 8
+_DSV4_HEAD_DIM = 512
+_DSV4_ROPE_DIM = 64
+_DSV4_WINDOW_SIZE = 128
+_DSV4_SOFTMAX_SCALE = 0.04419417382415922
+_DSV4_RMS_NORM_EPS = 1.0e-6
+
+_SUPPORTED_TRITON_REPLAY_OUT_PTRS: list[int] = []
 
 
 class _FakeOpOverload:
@@ -64,8 +79,85 @@ def torch_deepseek_v4_sparse_attention(
     return y
 
 
+def triton_deepseek_v4_sparse_attention_v2_with_cache(
+    x: torch.Tensor, out: torch.Tensor | None = None
+) -> torch.Tensor:
+    if out is None:
+        raise AssertionError("supported DSV4 Triton replay must receive caller-owned out=")
+    _SUPPORTED_TRITON_REPLAY_OUT_PTRS.append(out.data_ptr())
+    out.copy_(x + 2)
+    return out.new_empty(0)
+
+
 def deepseek_v4_prepare_cache_metadata(x: torch.Tensor) -> torch.Tensor:
     return x
+
+
+def deepseek_v4_route_metadata_prep(x: torch.Tensor) -> torch.Tensor:
+    return x
+
+
+def torch_deepseek_v4_sparse_attention_v2_with_cache(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    batch_info_host: torch.Tensor,
+    seq_len_host: torch.Tensor,
+    input_pos_host: torch.Tensor,
+    cu_seqlen_host: torch.Tensor,
+    cache_loc_host: torch.Tensor,
+    cu_num_pages_host: torch.Tensor,
+    swa_cache: torch.Tensor,
+    mhc_cache: torch.Tensor,
+    compressor_kv_cache: torch.Tensor,
+    compressor_gate_cache: torch.Tensor,
+    softmax_scale: float,
+    window_size: int,
+    compress_ratio: int,
+    max_compressed_len: int,
+    rms_norm_eps: float,
+    rope_dim: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    del (
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        batch_info_host,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        compressor_kv_cache,
+        compressor_gate_cache,
+        softmax_scale,
+        window_size,
+        compress_ratio,
+        max_compressed_len,
+        rms_norm_eps,
+        rope_dim,
+    )
+    y = q + 1
+    if out is not None:
+        out.copy_(y)
+        return torch.empty(0, dtype=q.dtype, device=q.device)
+    return y
 
 
 def _make_call_function_node(op_name: str) -> SimpleNamespace:
@@ -87,6 +179,176 @@ def _make_toy_graph(dynamic_fn: Any = torch_deepseek_v4_sparse_attention) -> Gra
     return GraphModule(root, graph)
 
 
+def _make_dynamic_only_graph(dynamic_fn: Any = torch_deepseek_v4_sparse_attention) -> GraphModule:
+    graph = Graph()
+    x = graph.placeholder("x")
+    dynamic = graph.call_function(dynamic_fn, args=(x,))
+    graph.output(dynamic)
+    graph.lint()
+    return GraphModule(nn.Module(), graph)
+
+
+def _make_cached_attention_graph() -> GraphModule:
+    graph = Graph()
+    placeholders = {
+        name: graph.placeholder(name)
+        for name in (
+            "q",
+            "kv",
+            "attn_sink",
+            "topk_idxs",
+            "compressor_kv",
+            "compressor_gate",
+            "compressor_ape",
+            "compressor_norm_weight",
+            "freqs_cis_table",
+            "position_ids",
+            *DEEPSEEK_V4_CUDA_GRAPH_METADATA_ARG_NAMES,
+            *DEEPSEEK_V4_CUDA_GRAPH_CACHE_RESOURCE_ARG_NAMES,
+        )
+    }
+    q = graph.call_function(torch.relu, args=(placeholders["q"],))
+    dynamic = graph.call_function(
+        torch_deepseek_v4_sparse_attention_v2_with_cache,
+        args=(
+            q,
+            placeholders["kv"],
+            placeholders["attn_sink"],
+            placeholders["topk_idxs"],
+            placeholders["compressor_kv"],
+            placeholders["compressor_gate"],
+            placeholders["compressor_ape"],
+            placeholders["compressor_norm_weight"],
+            placeholders["freqs_cis_table"],
+            placeholders["position_ids"],
+            placeholders["batch_info_host"],
+            placeholders["seq_len_host"],
+            placeholders["input_pos_host"],
+            placeholders["cu_seqlen_host"],
+            placeholders["cache_loc_host"],
+            placeholders["cu_num_pages_host"],
+            placeholders["swa_cache"],
+            placeholders["mhc_cache"],
+            placeholders["compressor_kv_cache"],
+            placeholders["compressor_gate_cache"],
+            1.0,
+            128,
+            4,
+            2048,
+            1.0e-6,
+            64,
+        ),
+    )
+    graph.output(dynamic)
+    graph.lint()
+    return GraphModule(nn.Module(), graph)
+
+
+class _FakeReplayRunner:
+    def __init__(self, out_buf: torch.Tensor) -> None:
+        self.out_buf = out_buf
+        self.requests: list[tuple[int, int]] = []
+
+    def get_dynamic_out_buf(self, num_tokens: int, dynamic_submod_id: int) -> torch.Tensor:
+        self.requests.append((num_tokens, dynamic_submod_id))
+        return self.out_buf
+
+
+def _batch_info(num_decode: int) -> torch.Tensor:
+    batch_info = BatchInfo()
+    batch_info.update([0, 0, 0, 0, num_decode, num_decode])
+    batch_info.update_tokens_gather_info(num_decode, False)
+    return batch_info.serialize()
+
+
+def _freqs_cis_table(max_position: int = 16) -> torch.Tensor:
+    freqs = 1.0 / (
+        10000.0 ** (torch.arange(0, _DSV4_ROPE_DIM, 2, dtype=torch.float32) / _DSV4_ROPE_DIM)
+    )
+    phases = torch.arange(max_position, dtype=torch.float32).unsqueeze(1) * freqs.unsqueeze(0)
+    return torch.polar(torch.ones_like(phases), phases)
+
+
+def _make_cuda_ratio0_decode_args(
+    batch_size: int = 2,
+    active_sequences: int = 1,
+    prefix_len: int = 1,
+) -> list[Any]:
+    device = torch.device("cuda")
+    torch.manual_seed(4096 + batch_size + active_sequences + prefix_len)
+    q = torch.randn(
+        batch_size,
+        1,
+        _DSV4_LOCAL_HEADS,
+        _DSV4_HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    kv = torch.randn(batch_size, 1, _DSV4_HEAD_DIM, dtype=torch.bfloat16, device=device)
+    attn_sink = torch.linspace(-0.5, 0.5, _DSV4_LOCAL_HEADS, dtype=torch.float32, device=device)
+    topk_idxs = torch.full(
+        (batch_size, 1, _DSV4_WINDOW_SIZE),
+        -1,
+        dtype=torch.int32,
+        device=device,
+    )
+    topk_idxs[:active_sequences, 0, 0] = 0
+    topk_idxs[:active_sequences, 0, 1] = prefix_len
+
+    cache_loc_host = torch.arange(active_sequences, dtype=torch.int32, device=device)
+    cu_num_pages_host = torch.arange(active_sequences + 1, dtype=torch.int32, device=device)
+    swa_cache = torch.zeros(
+        active_sequences,
+        1,
+        _DSV4_WINDOW_SIZE,
+        1,
+        _DSV4_HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    mhc_cache = torch.zeros_like(swa_cache)
+    compressor_cache = torch.empty(
+        active_sequences,
+        1,
+        _DSV4_WINDOW_SIZE,
+        1,
+        0,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    if active_sequences:
+        swa_cache[:, 0, 0, 0].normal_()
+
+    return [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        torch.empty(batch_size, 1, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(batch_size, 1, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(0, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(0, dtype=torch.float32, device=device),
+        _freqs_cis_table().to(device),
+        torch.zeros(batch_size, 1, dtype=torch.int32, device=device),
+        _batch_info(active_sequences).to(device),
+        torch.full((active_sequences,), prefix_len + 1, dtype=torch.int32, device=device),
+        torch.full((active_sequences,), prefix_len, dtype=torch.int32, device=device),
+        torch.arange(active_sequences + 1, dtype=torch.int32, device=device),
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        mhc_cache,
+        compressor_cache,
+        compressor_cache.clone(),
+        _DSV4_SOFTMAX_SCALE,
+        _DSV4_WINDOW_SIZE,
+        0,
+        None,
+        _DSV4_RMS_NORM_EPS,
+        _DSV4_ROPE_DIM,
+    ]
+
+
 @pytest.mark.parametrize(
     "op_name",
     [
@@ -94,12 +356,16 @@ def _make_toy_graph(dynamic_fn: Any = torch_deepseek_v4_sparse_attention) -> Gra
         "auto_deploy::torch_deepseek_v4_sparse_attention_v2",
         "auto_deploy::torch_deepseek_v4_sparse_attention_v2_with_cache",
         "auto_deploy::triton_deepseek_v4_sparse_attention_with_cache",
+        "auto_deploy::triton_deepseek_v4_sparse_attention_v2_with_cache",
         "auto_deploy::torch_deepseek_v4_moe",
         "auto_deploy::triton_mxfp4_moe",
         "auto_deploy::triton_mxfp4_moe_ep",
         "auto_deploy::deepseek_v4_prepare_cache_metadata",
         "auto_deploy::torch_deepseek_v4_prepare_cache_metadata",
         "auto_deploy::triton_deepseek_v4_prepare_cache_metadata",
+        "auto_deploy::triton_deepseek_v4_prepare_indexer_metadata",
+        "auto_deploy::triton_deepseek_v4_prepare_route_metadata",
+        "auto_deploy::triton_deepseek_v4_route_metadata_prep",
     ],
 )
 def test_deepseek_v4_reserved_ops_are_dynamic(op_name: str) -> None:
@@ -141,6 +407,148 @@ def test_deepseek_v4_cache_metadata_prep_is_dynamic_without_out_buffer() -> None
 
     assert is_metadata_prep(metadata_submod)
     assert not needs_out_buffer(metadata_submod)
+
+
+def test_deepseek_v4_route_metadata_prep_is_dynamic_without_out_buffer() -> None:
+    split_info = split_graph_at_dynamic_ops(_make_toy_graph(deepseek_v4_route_metadata_prep))
+    metadata_submod = split_info.split_gm.submod_1
+
+    assert is_metadata_prep(metadata_submod)
+    assert not needs_out_buffer(metadata_submod)
+
+
+def test_deepseek_v4_cuda_graph_contract_documents_buffers_and_workspaces() -> None:
+    attention_contract = get_deepseek_v4_cuda_graph_kernel_contract(
+        "auto_deploy::triton_deepseek_v4_sparse_attention_v2_with_cache"
+    )
+    route_contract = get_deepseek_v4_cuda_graph_kernel_contract(
+        "auto_deploy::triton_deepseek_v4_route_metadata_prep"
+    )
+
+    assert attention_contract is DEEPSEEK_V4_ATTENTION_CUDA_GRAPH_CONTRACT
+    assert attention_contract.uses_out_buffer
+    assert attention_contract.workspace_arg_name == DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_ARG_NAME
+    assert (
+        attention_contract.workspace_size_arg_name == DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_SIZE_ARG_NAME
+    )
+    assert attention_contract.metadata_arg_names == DEEPSEEK_V4_CUDA_GRAPH_METADATA_ARG_NAMES
+    assert attention_contract.cache_resource_arg_names == (
+        DEEPSEEK_V4_CUDA_GRAPH_CACHE_RESOURCE_ARG_NAMES
+    )
+
+    assert route_contract is DEEPSEEK_V4_ROUTE_METADATA_CUDA_GRAPH_CONTRACT
+    assert not route_contract.uses_out_buffer
+    assert route_contract.workspace_arg_name == DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_ARG_NAME
+    assert route_contract.workspace_size_arg_name == DEEPSEEK_V4_CUDA_GRAPH_WORKSPACE_SIZE_ARG_NAME
+
+
+def test_deepseek_v4_out_buffer_convention_reuses_caller_buffer() -> None:
+    dynamic_submod = _make_dynamic_only_graph()
+    torch_cudagraph._inject_out_param(dynamic_submod)
+    x = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    out = torch.empty_like(x)
+
+    result = dynamic_submod(x, out=out)
+
+    assert result.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(out, x + 1)
+
+
+def test_deepseek_v4_triton_dynamic_replay_reuses_preallocated_out_buffer() -> None:
+    _SUPPORTED_TRITON_REPLAY_OUT_PTRS.clear()
+    dynamic_submod = _make_dynamic_only_graph(triton_deepseek_v4_sparse_attention_v2_with_cache)
+    torch_cudagraph._inject_out_param(dynamic_submod)
+    x = torch.arange(8, dtype=torch.float32).reshape(2, 4)
+    out_buf = torch.empty_like(x)
+    runner = _FakeReplayRunner(out_buf)
+    wrapper = DynamicOpWrapper(dynamic_submod, preceding_runner=runner, dynamic_submod_id=7)
+
+    ADPiecewiseRunner.set_current_phase("replay")
+    ADPiecewiseRunner.set_current_num_tokens(4)
+    try:
+        result = wrapper(x)
+    finally:
+        ADPiecewiseRunner.set_current_num_tokens(None)
+
+    assert runner.requests == [(4, 7)]
+    assert _SUPPORTED_TRITON_REPLAY_OUT_PTRS == [out_buf.data_ptr()]
+    assert result.data_ptr() == out_buf.data_ptr()
+    torch.testing.assert_close(out_buf, x + 2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_deepseek_v4_triton_attention_replay_uses_device_kernel_not_torch_reference(
+    monkeypatch,
+) -> None:
+    pytest.importorskip("triton")
+
+    from tensorrt_llm._torch.auto_deploy.custom_ops.attention import deepseek_v4_attention
+
+    triton_sparse_attention = pytest.importorskip(
+        "tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_deepseek_v4_sparse_attention"
+    )
+    deepseek_v4_ratio0_swa_triton_skip_reason = (
+        triton_sparse_attention.deepseek_v4_ratio0_swa_triton_skip_reason
+    )
+
+    monkeypatch.delenv("TRTLLM_AD_DSV4_SPARSE_ATTENTION_FORCE_TORCH", raising=False)
+    args = _make_cuda_ratio0_decode_args()
+    out = torch.full_like(args[0], float("nan"))
+    active_sequences = int(args[10][4].item())
+
+    reason = deepseek_v4_ratio0_swa_triton_skip_reason(
+        args[0],
+        args[1],
+        args[2],
+        args[3],
+        args[11],
+        args[12],
+        args[13],
+        args[14],
+        args[15],
+        args[16],
+        _DSV4_WINDOW_SIZE,
+        0,
+        out,
+        active_sequences,
+    )
+    if reason is not None:
+        pytest.skip(f"DSV4 ratio-0 Triton replay path is not locally supported: {reason}")
+
+    def fail_reference_fallback(*args: Any, **kwargs: Any) -> torch.Tensor:
+        raise AssertionError("supported DSV4 Triton replay fell back to the Torch reference")
+
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "torch_deepseek_v4_sparse_attention_v2_with_cache",
+        fail_reference_fallback,
+    )
+
+    result = torch.ops.auto_deploy.triton_deepseek_v4_sparse_attention_v2_with_cache.default(
+        *args,
+        out=out,
+    )
+
+    assert result.numel() == 0
+    assert result.device == out.device
+    assert not torch.isnan(out[:active_sequences]).any()
+    torch.testing.assert_close(
+        out[active_sequences:],
+        torch.zeros_like(out[active_sequences:]),
+    )
+
+
+def test_deepseek_v4_cached_attention_keeps_cache_resources_as_graph_inputs() -> None:
+    split_info = split_graph_at_dynamic_ops(_make_cached_attention_graph())
+    dynamic_submod = getattr(split_info.split_gm, f"submod_{split_info.dynamic_submod_indices[0]}")
+    placeholder_names = {
+        node.target for node in dynamic_submod.graph.nodes if node.op == "placeholder"
+    }
+    get_attr_names = {node.target for node in dynamic_submod.graph.nodes if node.op == "get_attr"}
+
+    assert set(DEEPSEEK_V4_CUDA_GRAPH_CACHE_RESOURCE_ARG_NAMES).issubset(placeholder_names)
+    assert not set(DEEPSEEK_V4_CUDA_GRAPH_CACHE_RESOURCE_ARG_NAMES) & get_attr_names
+    assert needs_out_buffer(dynamic_submod)
 
 
 def test_deepseek_v4_config_parses_cuda_graph_batch_sizes() -> None:
@@ -236,6 +644,18 @@ class _FakePiecewise(nn.Module):
         return "piecewise"
 
 
+class _FakePaddedPiecewise(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.original_model = nn.Identity()
+        self.piecewise_num_tokens = [4]
+
+    def forward(self, *args: Any, num_tokens: int | None = None, **kwargs: Any) -> torch.Tensor:
+        del args, kwargs
+        assert num_tokens is not None
+        return torch.arange(num_tokens * 2, dtype=torch.float32).reshape(num_tokens, 2)
+
+
 def test_decode_only_runtime_uses_monolithic_path_with_configured_piecewise_buckets() -> None:
     monolithic = _FakeMonolithic()
     piecewise = _FakePiecewise()
@@ -251,3 +671,24 @@ def test_decode_only_runtime_uses_monolithic_path_with_configured_piecewise_buck
     assert piecewise.num_calls == 0
     assert runtime._find_nearest_bucket(33) == 64
     assert runtime._find_nearest_bucket(65) is None
+
+
+def test_piecewise_prefill_ignores_padded_bucket_output_slots() -> None:
+    runtime = torch_cudagraph.DualModeCapturedGraph(_FakeMonolithic(), _FakePaddedPiecewise())
+
+    result = runtime(
+        input_ids=torch.ones(3, 1, dtype=torch.int64),
+        batch_info_host=torch.tensor([1, 3, 0, 0, 0, 0], dtype=torch.int64),
+    )
+
+    assert result.shape == (3, 2)
+    torch.testing.assert_close(
+        result,
+        torch.tensor(
+            [
+                [0.0, 1.0],
+                [2.0, 3.0],
+                [4.0, 5.0],
+            ]
+        ),
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import operator
+
 import pytest
 import torch
 import torch.nn as nn
@@ -36,7 +38,9 @@ from tensorrt_llm._torch.auto_deploy.transform.library.deepseek_v4_moe import (
 from tensorrt_llm._torch.auto_deploy.transform.library.deepseek_v4_mxfp4 import (
     load_deepseek_v4_mxfp4_experts,
 )
-from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+from tensorrt_llm._torch.auto_deploy.transform.library.sharding_ir import ApplyShardingHints
+from tensorrt_llm._torch.auto_deploy.utils.dist_config import DistConfig
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_op_args, is_op
 
 
 def _expert_mlp(
@@ -134,6 +138,26 @@ def _stacked_weights(
         .to(dtype)
     )
     return w1, w2, w3
+
+
+def _run_ir_sharding(
+    gm: torch.fx.GraphModule,
+    *,
+    rank: int,
+    world_size: int,
+) -> tuple[torch.fx.GraphModule, object]:
+    transform = ApplyShardingHints.from_kwargs(stage=Stages.SHARDING)
+    shared_config = SharedConfig(
+        local_rank=rank,
+        world_size=world_size,
+        dist_config=DistConfig(
+            world_size=world_size,
+            rank=rank,
+            tp_size=world_size,
+            moe_ep_size=world_size,
+        ),
+    )
+    return transform._apply(gm, None, None, shared_config)
 
 
 def test_from_routing_matches_tiny_bf16_reference_with_precomputed_routing() -> None:
@@ -434,6 +458,140 @@ def test_from_routing_custom_op_exports() -> None:
     assert torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default in targets
 
 
+def _uint8_pattern(shape: tuple[int, ...], offset: int) -> torch.Tensor:
+    values = torch.arange(int(torch.tensor(shape).prod().item()), dtype=torch.int64)
+    return values.reshape(shape).add(offset).remainder(251).to(torch.uint8)
+
+
+class _MXFP4FromRoutingShardingModule(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.ffn = nn.Module()
+        self.ffn.gate_up_blocks = nn.Parameter(
+            _uint8_pattern((4, 8, 2, 16), 1),
+            requires_grad=False,
+        )
+        self.ffn.gate_up_bias = nn.Parameter(
+            torch.arange(4 * 8, dtype=torch.float32).reshape(4, 8),
+            requires_grad=False,
+        )
+        self.ffn.gate_up_scales = nn.Parameter(
+            _uint8_pattern((4, 8, 2), 11),
+            requires_grad=False,
+        )
+        self.ffn.down_blocks = nn.Parameter(
+            _uint8_pattern((4, 4, 2, 16), 23),
+            requires_grad=False,
+        )
+        self.ffn.down_bias = nn.Parameter(
+            torch.arange(4 * 4, dtype=torch.float32).reshape(4, 4).add(100),
+            requires_grad=False,
+        )
+        self.ffn.down_scales = nn.Parameter(
+            _uint8_pattern((4, 4, 2), 37),
+            requires_grad=False,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        selected_experts: torch.Tensor,
+        routing_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing.default(
+            hidden_states,
+            selected_experts,
+            routing_weights,
+            self.ffn.gate_up_blocks,
+            self.ffn.gate_up_bias,
+            self.ffn.gate_up_scales,
+            1.0,
+            10.0,
+            self.ffn.down_blocks,
+            self.ffn.down_bias,
+            self.ffn.down_scales,
+            "moe",
+        )
+
+
+def _trace_mxfp4_from_routing_sharding_module() -> torch.fx.GraphModule:
+    gm = torch.fx.symbolic_trace(_MXFP4FromRoutingShardingModule())
+    params_and_buffers = dict(gm.named_parameters())
+    params_and_buffers.update(dict(gm.named_buffers()))
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            if node.target == "hidden_states":
+                node.meta["val"] = torch.empty((3, 4), dtype=torch.bfloat16)
+            elif node.target == "selected_experts":
+                node.meta["val"] = torch.empty((3, 2), dtype=torch.int64)
+            elif node.target == "routing_weights":
+                node.meta["val"] = torch.empty((3, 2), dtype=torch.float32)
+        elif node.op == "get_attr" and node.target in params_and_buffers:
+            node.meta["val"] = params_and_buffers[node.target].detach()
+        elif is_op(
+            node,
+            torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing,
+        ):
+            node.meta["val"] = torch.empty((3, 4), dtype=torch.bfloat16)
+    return gm
+
+
+def _shift_state_value(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dtype == torch.uint8:
+        return tensor.to(torch.int64).add(19).remainder(251).to(torch.uint8)
+    return tensor + 19
+
+
+def test_deepseek_v4_mxfp4_from_routing_shards_experts_and_localizes_ids() -> None:
+    gm = _trace_mxfp4_from_routing_sharding_module()
+    full_state = {name: tensor.detach().clone() for name, tensor in gm.named_parameters()}
+
+    transformed, info = _run_ir_sharding(gm, rank=1, world_size=2)
+
+    assert info.num_matches == 1
+    for name, full_tensor in full_state.items():
+        local_tensor = transformed.get_parameter(name)
+        assert local_tensor.shape[0] == 2
+        torch.testing.assert_close(local_tensor, full_tensor[2:4], rtol=0, atol=0)
+
+    moe_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing,
+        )
+    )
+    selected_local = moe_node.args[1]
+    routing_local = moe_node.args[2]
+    assert selected_local.target == operator.mul
+    assert routing_local.target == operator.mul
+    assert selected_local.args[1] is routing_local.args[1]
+    assert selected_local.args[0].target == operator.sub
+    assert selected_local.args[0].args[1] == 2
+    assert selected_local.args[1].target == torch.logical_and
+    assert any(
+        node.op == "call_function"
+        and node.args
+        and node.args[0] is moe_node
+        and "all_reduce" in str(node.target)
+        for node in transformed.graph.nodes
+    )
+
+    shifted_full_state = {name: _shift_state_value(tensor) for name, tensor in full_state.items()}
+    load_result = transformed.load_state_dict(shifted_full_state, strict=False)
+
+    assert load_result.missing_keys == []
+    assert load_result.unexpected_keys == []
+    for name, full_tensor in shifted_full_state.items():
+        torch.testing.assert_close(
+            transformed.get_parameter(name),
+            full_tensor[2:4],
+            rtol=0,
+            atol=0,
+        )
+
+
 class _CanonicalMoEModule(nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -513,12 +671,12 @@ class _LayeredMoEBlock(nn.Module):
 
 
 class _LayeredMoEModel(nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, hidden_size: int = 64, moe_intermediate_size: int = 32) -> None:
         super().__init__()
         config = DeepseekV4Config(
             vocab_size=16,
-            hidden_size=64,
-            moe_intermediate_size=32,
+            hidden_size=hidden_size,
+            moe_intermediate_size=moe_intermediate_size,
             n_routed_experts=2,
             n_shared_experts=1,
             num_experts_per_tok=1,
@@ -531,6 +689,135 @@ class _LayeredMoEModel(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor, input_ids: torch.Tensor) -> torch.Tensor:
         return self.layers[0](hidden_states, input_ids)
+
+
+def _lower_layered_moe_model(
+    hidden_size: int = 64,
+    moe_intermediate_size: int = 32,
+) -> tuple[torch.fx.GraphModule, object]:
+    model = _LayeredMoEModel(hidden_size, moe_intermediate_size)
+    gm = torch_export_to_gm(
+        model,
+        args=(torch.randn(1, 2, hidden_size), torch.ones(1, 2, dtype=torch.long)),
+    )
+    transform = DeepSeekV4MoELowering.from_kwargs(stage=Stages.PATTERN_MATCHER)
+    return transform._apply(gm, None, None, SharedConfig())
+
+
+def _shared_fp8_linear_nodes(gm: torch.fx.GraphModule) -> dict[str, torch.fx.Node]:
+    nodes = {}
+    for node in gm.graph.nodes:
+        if not is_op(node, torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear):
+            continue
+        [weight] = extract_op_args(node, "weight_quantized")
+        if isinstance(weight, torch.fx.Node) and weight.op == "get_attr":
+            nodes[str(weight.target)] = node
+    return nodes
+
+
+def _fp8_pattern(shape: tuple[int, ...], offset: int) -> torch.Tensor:
+    values = torch.arange(int(torch.tensor(shape).prod().item()), dtype=torch.float32)
+    values = values.add(offset).remainder(29).sub(14).div(16).reshape(shape)
+    return values.to(torch.float8_e4m3fn)
+
+
+def test_lowering_bridge_shared_fp8_linears_have_tp_hints_and_all_reduce() -> None:
+    lowered, info = _lower_layered_moe_model()
+
+    assert info.num_matches == 1
+    fp8_nodes = _shared_fp8_linear_nodes(lowered)
+    expected_modes = {
+        "layers.0.ffn.shared_experts.w1.weight": "colwise",
+        "layers.0.ffn.shared_experts.w2.weight": "rowwise",
+        "layers.0.ffn.shared_experts.w3.weight": "colwise",
+    }
+    actual_modes = {
+        weight_name: extract_op_args(node, "tp_mode")[0]
+        for weight_name, node in fp8_nodes.items()
+        if weight_name in expected_modes
+    }
+
+    assert actual_modes == expected_modes
+
+    shared_w2_node = fp8_nodes["layers.0.ffn.shared_experts.w2.weight"]
+    shared_all_reduces = [
+        node
+        for node in lowered.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.all_reduce) and node.args[0] is shared_w2_node
+    ]
+    assert len(shared_all_reduces) == 1
+    assert extract_op_args(shared_all_reduces[0], "layer_type") == ["moe"]
+
+
+def test_lowering_bridge_shared_fp8_linears_shard_weights_and_scales() -> None:
+    lowered, _ = _lower_layered_moe_model(hidden_size=256, moe_intermediate_size=256)
+
+    transformed, info = _run_ir_sharding(lowered, rank=1, world_size=2)
+
+    assert info.num_matches >= 4
+    shared_w1 = transformed.get_submodule("layers.0.ffn.shared_experts.w1")
+    shared_w2 = transformed.get_submodule("layers.0.ffn.shared_experts.w2")
+    shared_w3 = transformed.get_submodule("layers.0.ffn.shared_experts.w3")
+    assert shared_w1.weight.shape == (128, 256)
+    assert shared_w2.weight.shape == (256, 128)
+    assert shared_w3.weight.shape == (128, 256)
+    assert shared_w1.weight_scale_inv.shape == (1, 2)
+    assert shared_w2.weight_scale_inv.shape == (2, 1)
+    assert shared_w3.weight_scale_inv.shape == (1, 2)
+
+    full_state = {
+        "layers.0.ffn.shared_experts.w1.weight": _fp8_pattern((256, 256), 1),
+        "layers.0.ffn.shared_experts.w1.weight_scale_inv": torch.arange(
+            4, dtype=torch.float32
+        ).reshape(2, 2),
+        "layers.0.ffn.shared_experts.w2.weight": _fp8_pattern((256, 256), 3),
+        "layers.0.ffn.shared_experts.w2.weight_scale_inv": torch.arange(4, dtype=torch.float32)
+        .reshape(2, 2)
+        .add(10),
+        "layers.0.ffn.shared_experts.w3.weight": _fp8_pattern((256, 256), 5),
+        "layers.0.ffn.shared_experts.w3.weight_scale_inv": torch.arange(4, dtype=torch.float32)
+        .reshape(2, 2)
+        .add(20),
+    }
+    load_result = transformed.load_state_dict(full_state, strict=False)
+
+    assert load_result.unexpected_keys == []
+    torch.testing.assert_close(
+        shared_w1.weight.float(),
+        full_state["layers.0.ffn.shared_experts.w1.weight"][128:256].float(),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        shared_w2.weight.float(),
+        full_state["layers.0.ffn.shared_experts.w2.weight"][:, 128:256].float(),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        shared_w3.weight.float(),
+        full_state["layers.0.ffn.shared_experts.w3.weight"][128:256].float(),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        shared_w1.weight_scale_inv,
+        full_state["layers.0.ffn.shared_experts.w1.weight_scale_inv"][1:2],
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        shared_w2.weight_scale_inv,
+        full_state["layers.0.ffn.shared_experts.w2.weight_scale_inv"][:, 1:2],
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        shared_w3.weight_scale_inv,
+        full_state["layers.0.ffn.shared_experts.w3.weight_scale_inv"][1:2],
+        rtol=0,
+        atol=0,
+    )
 
 
 def _pack_fp4(logical_values: torch.Tensor) -> torch.Tensor:

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import operator
+import os
+from pathlib import Path
 
 import pytest
 import torch
@@ -41,11 +44,20 @@ from tensorrt_llm._torch.auto_deploy.transform.library.deepseek_v4_moe import (
     DeepSeekV4MoELoweringError,
 )
 from tensorrt_llm._torch.auto_deploy.transform.library.deepseek_v4_mxfp4 import (
+    DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
+    DEEPSEEK_V4_MXFP4_BYTES_PER_BLOCK,
     load_deepseek_v4_mxfp4_experts,
 )
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding_ir import ApplyShardingHints
 from tensorrt_llm._torch.auto_deploy.utils.dist_config import DistConfig
+from tensorrt_llm._torch.auto_deploy.utils.e8m0 import e8m0_to_fp32, e8m0_to_uint8
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_op_args, is_op
+
+_DEEPSEEK_V4_REAL_CKPT_ENV = "DEEPSEEK_V4_FLASH_CHECKPOINT"
+_DEFAULT_DEEPSEEK_V4_REAL_CKPT = Path(
+    "/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/"
+    "bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash"
+)
 
 
 def _expert_mlp(
@@ -163,6 +175,157 @@ def _run_ir_sharding(
         ),
     )
     return transform._apply(gm, None, None, shared_config)
+
+
+def _deepseek_v4_real_checkpoint_path() -> Path:
+    checkpoint_path = Path(
+        os.environ.get(_DEEPSEEK_V4_REAL_CKPT_ENV, _DEFAULT_DEEPSEEK_V4_REAL_CKPT)
+    )
+    if not checkpoint_path.exists():
+        pytest.skip(
+            f"DeepSeek V4 real checkpoint not found at {checkpoint_path}; set "
+            f"{_DEEPSEEK_V4_REAL_CKPT_ENV} to run this coverage."
+        )
+    index_path = checkpoint_path / "model.safetensors.index.json"
+    if not index_path.exists():
+        pytest.skip(f"DeepSeek V4 safetensors index not found at {index_path}.")
+    return checkpoint_path
+
+
+def _load_real_checkpoint_tensors(
+    checkpoint_path: Path,
+    tensor_names: list[str],
+) -> dict[str, torch.Tensor]:
+    safetensors = pytest.importorskip("safetensors")
+    index_path = checkpoint_path / "model.safetensors.index.json"
+    weight_map = json.loads(index_path.read_text(encoding="utf-8"))["weight_map"]
+    missing = [name for name in tensor_names if name not in weight_map]
+    assert missing == []
+
+    by_file: dict[str, list[str]] = {}
+    for name in tensor_names:
+        by_file.setdefault(weight_map[name], []).append(name)
+
+    tensors: dict[str, torch.Tensor] = {}
+    for filename, file_tensor_names in by_file.items():
+        with safetensors.safe_open(
+            checkpoint_path / filename,
+            framework="pt",
+            device="cpu",
+        ) as handle:
+            for name in file_tensor_names:
+                tensors[name] = handle.get_tensor(name)
+    return tensors
+
+
+def _real_mxfp4_weight_blocks(
+    tensor: torch.Tensor,
+    *,
+    rows: int,
+    logical_cols: int,
+) -> torch.Tensor:
+    assert tensor.dtype in (torch.int8, torch.uint8)
+    assert tensor.shape == (
+        rows,
+        logical_cols // 2,
+    )
+    return (
+        tensor.view(torch.uint8)
+        .contiguous()
+        .view(
+            rows,
+            logical_cols // DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
+            DEEPSEEK_V4_MXFP4_BYTES_PER_BLOCK,
+        )
+    )
+
+
+def _real_mxfp4_scale_bytes(tensor: torch.Tensor) -> torch.Tensor:
+    if tensor.dtype == torch.uint8:
+        return tensor.contiguous()
+    return e8m0_to_uint8(tensor).contiguous()
+
+
+def _assert_layout_matches_real_checkpoint(
+    layout,
+    state_dict: dict[str, torch.Tensor],
+    *,
+    layer_idx: int,
+    expert_indices: tuple[int, ...],
+    hidden_size: int,
+    intermediate_size: int,
+) -> None:
+    assert layout.expert_indices == expert_indices
+    assert layout.gate_up_blocks.shape == (
+        len(expert_indices),
+        2 * intermediate_size,
+        hidden_size // DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
+        DEEPSEEK_V4_MXFP4_BYTES_PER_BLOCK,
+    )
+    assert layout.gate_up_scales.shape == (
+        len(expert_indices),
+        2 * intermediate_size,
+        hidden_size // DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
+    )
+    assert layout.down_blocks.shape == (
+        len(expert_indices),
+        hidden_size,
+        intermediate_size // DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
+        DEEPSEEK_V4_MXFP4_BYTES_PER_BLOCK,
+    )
+    assert layout.down_scales.shape == (
+        len(expert_indices),
+        hidden_size,
+        intermediate_size // DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
+    )
+
+    for local_idx, expert_idx in enumerate(expert_indices):
+        prefix = f"layers.{layer_idx}.ffn.experts.{expert_idx}"
+        w3_blocks = _real_mxfp4_weight_blocks(
+            state_dict[f"{prefix}.w3.weight"],
+            rows=intermediate_size,
+            logical_cols=hidden_size,
+        )
+        w1_blocks = _real_mxfp4_weight_blocks(
+            state_dict[f"{prefix}.w1.weight"],
+            rows=intermediate_size,
+            logical_cols=hidden_size,
+        )
+        w2_blocks = _real_mxfp4_weight_blocks(
+            state_dict[f"{prefix}.w2.weight"],
+            rows=hidden_size,
+            logical_cols=intermediate_size,
+        )
+        w3_scales = _real_mxfp4_scale_bytes(state_dict[f"{prefix}.w3.scale"])
+        w1_scales = _real_mxfp4_scale_bytes(state_dict[f"{prefix}.w1.scale"])
+        w2_scales = _real_mxfp4_scale_bytes(state_dict[f"{prefix}.w2.scale"])
+
+        torch.testing.assert_close(
+            layout.gate_up_blocks[local_idx, :intermediate_size],
+            w3_blocks,
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            layout.gate_up_blocks[local_idx, intermediate_size:],
+            w1_blocks,
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(layout.down_blocks[local_idx], w2_blocks, rtol=0, atol=0)
+        torch.testing.assert_close(
+            layout.gate_up_scales[local_idx, :intermediate_size],
+            w3_scales,
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            layout.gate_up_scales[local_idx, intermediate_size:],
+            w1_scales,
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(layout.down_scales[local_idx], w2_scales, rtol=0, atol=0)
 
 
 def test_from_routing_matches_tiny_bf16_reference_with_precomputed_routing() -> None:
@@ -984,6 +1147,138 @@ def _packed_checkpoint_state() -> dict[str, torch.Tensor]:
     return state
 
 
+def test_mxfp4_loader_matches_real_deepseek_v4_checkpoint_layout() -> None:
+    checkpoint_path = _deepseek_v4_real_checkpoint_path()
+    hidden_size = 4096
+    intermediate_size = 2048
+
+    for layer_idx, expert_indices in ((0, (0, 1, 255)), (42, (0, 255))):
+        tensor_names = [
+            f"layers.{layer_idx}.ffn.experts.{expert_idx}.{proj}.{suffix}"
+            for expert_idx in expert_indices
+            for proj in ("w1", "w2", "w3")
+            for suffix in ("weight", "scale")
+        ]
+        state_dict = _load_real_checkpoint_tensors(checkpoint_path, tensor_names)
+
+        layout = load_deepseek_v4_mxfp4_experts(
+            state_dict,
+            layer_idx=layer_idx,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            expert_indices=expert_indices,
+        )
+
+        _assert_layout_matches_real_checkpoint(
+            layout,
+            state_dict,
+            layer_idx=layer_idx,
+            expert_indices=expert_indices,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+        )
+
+
+def test_lowering_bridge_loads_real_deepseek_v4_mxfp4_checkpoint_block() -> None:
+    checkpoint_path = _deepseek_v4_real_checkpoint_path()
+    hidden_size = 4096
+    intermediate_size = 2048
+    layer_idx = 0
+    expert_indices = (0, 1)
+    tensor_names = [
+        f"layers.{layer_idx}.ffn.experts.{expert_idx}.{proj}.{suffix}"
+        for expert_idx in expert_indices
+        for proj in ("w1", "w2", "w3")
+        for suffix in ("weight", "scale")
+    ]
+    tensor_names.extend(
+        f"layers.{layer_idx}.ffn.shared_experts.{proj}.{suffix}"
+        for proj in ("w1", "w2", "w3")
+        for suffix in ("weight", "scale")
+    )
+    real_state = _load_real_checkpoint_tensors(checkpoint_path, tensor_names)
+    model = _LayeredMoEModel(hidden_size=hidden_size, moe_intermediate_size=intermediate_size)
+    gm = torch_export_to_gm(
+        model,
+        args=(torch.randn(1, 1, hidden_size), torch.ones(1, 1, dtype=torch.long)),
+    )
+    transform = DeepSeekV4MoELowering.from_kwargs(stage=Stages.PATTERN_MATCHER)
+
+    lowered, info = transform._apply(gm, None, None, SharedConfig())
+
+    assert info.num_matches == 1
+    assert not any(
+        name.startswith("layers.0.ffn.experts.") for name, _ in lowered.named_parameters()
+    )
+
+    state_dict = {
+        name: tensor.detach().clone()
+        for name, tensor in lowered.state_dict().items()
+        if not name.startswith("layers.0.ffn.mxfp4_") and not name.endswith(".weight_scale_inv")
+    }
+    state_dict.update(real_state)
+    load_result = lowered.load_state_dict(state_dict, strict=False)
+    expected_layout = load_deepseek_v4_mxfp4_experts(
+        real_state,
+        layer_idx=layer_idx,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=len(expert_indices),
+    )
+
+    assert load_result.missing_keys == []
+    assert load_result.unexpected_keys == []
+    _assert_layout_matches_real_checkpoint(
+        expected_layout,
+        real_state,
+        layer_idx=layer_idx,
+        expert_indices=expert_indices,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+    torch.testing.assert_close(
+        lowered.get_parameter("layers.0.ffn.mxfp4_gate_up_blocks"),
+        expected_layout.gate_up_blocks,
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        lowered.get_parameter("layers.0.ffn.mxfp4_gate_up_scales"),
+        expected_layout.gate_up_scales,
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        lowered.get_parameter("layers.0.ffn.mxfp4_down_blocks"),
+        expected_layout.down_blocks,
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        lowered.get_parameter("layers.0.ffn.mxfp4_down_scales"),
+        expected_layout.down_scales,
+        rtol=0,
+        atol=0,
+    )
+
+    for proj in ("w1", "w2", "w3"):
+        weight_name = f"layers.0.ffn.shared_experts.{proj}.weight"
+        scale_name = f"layers.0.ffn.shared_experts.{proj}.scale"
+        scale_buffer_name = f"layers.0.ffn.shared_experts.{proj}.weight_scale_inv"
+        torch.testing.assert_close(
+            lowered.get_parameter(weight_name).float(),
+            real_state[weight_name].float(),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            lowered.get_buffer(scale_buffer_name),
+            e8m0_to_fp32(real_state[scale_name]),
+            rtol=0,
+            atol=0,
+        )
+
+
 def test_lowering_bridge_loads_packed_mxfp4_checkpoint_without_dense_shape_mismatch() -> None:
     model = _LayeredMoEModel()
     gm = torch_export_to_gm(
@@ -1003,7 +1298,12 @@ def test_lowering_bridge_loads_packed_mxfp4_checkpoint_without_dense_shape_misma
         is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_moe) for node in lowered.graph.nodes
     )
 
-    state_dict = _packed_checkpoint_state()
+    state_dict = {
+        name: tensor.detach().clone()
+        for name, tensor in lowered.state_dict().items()
+        if not name.startswith("layers.0.ffn.mxfp4_") and not name.endswith(".weight_scale_inv")
+    }
+    state_dict.update(_packed_checkpoint_state())
     load_result = lowered.load_state_dict(state_dict, strict=False)
     expected_layout = load_deepseek_v4_mxfp4_experts(
         _packed_checkpoint_state(),
@@ -1013,7 +1313,22 @@ def test_lowering_bridge_loads_packed_mxfp4_checkpoint_without_dense_shape_misma
         num_experts=2,
     )
 
+    assert load_result.missing_keys == []
     assert load_result.unexpected_keys == []
+    assert "layers.0.ffn.mxfp4_gate_up_bias" not in lowered.state_dict()
+    assert "layers.0.ffn.mxfp4_down_bias" not in lowered.state_dict()
+    torch.testing.assert_close(
+        lowered.get_buffer("layers.0.ffn.mxfp4_gate_up_bias"),
+        torch.zeros((2, 64), dtype=torch.float32),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        lowered.get_buffer("layers.0.ffn.mxfp4_down_bias"),
+        torch.zeros((2, 64), dtype=torch.float32),
+        rtol=0,
+        atol=0,
+    )
     torch.testing.assert_close(
         lowered.get_parameter("layers.0.ffn.mxfp4_gate_up_blocks"),
         expected_layout.gate_up_blocks,

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
@@ -1,0 +1,438 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.deepseek_v4_moe import (
+    deepseek_v4_limited_swiglu,
+    deepseek_v4_moe_reference,
+)
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
+from tensorrt_llm._torch.auto_deploy.transform.library.deepseek_v4_moe import (
+    DeepSeekV4MoELowering,
+    DeepSeekV4MoELoweringError,
+)
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+
+def _expert_mlp(
+    hidden_states: torch.Tensor,
+    w1_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+    w3_weight: torch.Tensor,
+    swiglu_limit: float,
+    *,
+    apply_swiglu_limit: bool,
+) -> torch.Tensor:
+    gate = F.linear(hidden_states.to(w1_weight.dtype), w1_weight).float()
+    up = F.linear(hidden_states.to(w3_weight.dtype), w3_weight).float()
+    if apply_swiglu_limit:
+        hidden = F.silu(torch.clamp(gate, max=swiglu_limit)) * torch.clamp(
+            up, min=-swiglu_limit, max=swiglu_limit
+        )
+    else:
+        hidden = F.silu(gate) * up
+    return F.linear(hidden.to(w2_weight.dtype), w2_weight).to(hidden_states.dtype)
+
+
+def _manual_from_routing(
+    hidden_states: torch.Tensor,
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    routed_w1_weight: torch.Tensor,
+    routed_w2_weight: torch.Tensor,
+    routed_w3_weight: torch.Tensor,
+    shared_w1_weight: torch.Tensor | None,
+    shared_w2_weight: torch.Tensor | None,
+    shared_w3_weight: torch.Tensor | None,
+    swiglu_limit: float,
+) -> torch.Tensor:
+    hidden_shape = hidden_states.shape
+    hidden_flat = hidden_states.reshape(-1, hidden_shape[-1])
+    output = torch.zeros_like(hidden_flat)
+
+    for expert_idx in range(routed_w1_weight.shape[0]):
+        token_idx, route_idx = torch.where(selected_experts == expert_idx)
+        if token_idx.numel() == 0:
+            continue
+        expert_output = _expert_mlp(
+            hidden_flat[token_idx],
+            routed_w1_weight[expert_idx],
+            routed_w2_weight[expert_idx],
+            routed_w3_weight[expert_idx],
+            swiglu_limit,
+            apply_swiglu_limit=True,
+        )
+        output[token_idx] += (
+            expert_output * routing_weights[token_idx, route_idx, None].to(expert_output.dtype)
+        ).to(output.dtype)
+
+    if shared_w1_weight is not None:
+        assert shared_w2_weight is not None
+        assert shared_w3_weight is not None
+        output += _expert_mlp(
+            hidden_flat,
+            shared_w1_weight,
+            shared_w2_weight,
+            shared_w3_weight,
+            swiglu_limit,
+            apply_swiglu_limit=False,
+        )
+
+    return output.view(hidden_shape)
+
+
+def _stacked_weights(
+    num_experts: int = 4,
+    hidden_size: int = 3,
+    intermediate_size: int = 5,
+    dtype: torch.dtype = torch.bfloat16,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    w1 = (
+        torch.arange(num_experts * intermediate_size * hidden_size, dtype=torch.float32)
+        .reshape(num_experts, intermediate_size, hidden_size)
+        .div(37.0)
+        .sub(0.5)
+        .to(dtype)
+    )
+    w2 = (
+        torch.arange(num_experts * hidden_size * intermediate_size, dtype=torch.float32)
+        .reshape(num_experts, hidden_size, intermediate_size)
+        .div(29.0)
+        .sub(0.25)
+        .to(dtype)
+    )
+    w3 = (
+        torch.arange(num_experts * intermediate_size * hidden_size, dtype=torch.float32)
+        .reshape(num_experts, intermediate_size, hidden_size)
+        .div(31.0)
+        .sub(0.75)
+        .to(dtype)
+    )
+    return w1, w2, w3
+
+
+def test_from_routing_matches_tiny_bf16_reference_with_precomputed_routing() -> None:
+    hidden_states = torch.tensor(
+        [
+            [0.5, -1.0, 1.5],
+            [1.25, 0.25, -0.75],
+            [-0.5, 0.75, 0.125],
+        ],
+        dtype=torch.bfloat16,
+    )
+    selected_experts = torch.tensor([[0, 2], [3, 1], [2, 0]], dtype=torch.int32)
+    routing_weights = torch.tensor([[0.75, 0.25], [0.4, 0.6], [0.125, 0.875]], dtype=torch.float32)
+    routed_w1, routed_w2, routed_w3 = _stacked_weights()
+    shared_w1 = torch.linspace(-0.25, 0.5, 15, dtype=torch.float32).view(5, 3).to(torch.bfloat16)
+    shared_w2 = torch.linspace(0.1, 0.8, 15, dtype=torch.float32).view(3, 5).to(torch.bfloat16)
+    shared_w3 = torch.linspace(-0.6, 0.3, 15, dtype=torch.float32).view(5, 3).to(torch.bfloat16)
+
+    expected = _manual_from_routing(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        routed_w1,
+        routed_w2,
+        routed_w3,
+        shared_w1,
+        shared_w2,
+        shared_w3,
+        swiglu_limit=10.0,
+    )
+    actual = torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        routed_w1,
+        routed_w2,
+        routed_w3,
+        shared_w1,
+        shared_w2,
+        shared_w3,
+        10.0,
+        "moe",
+    )
+
+    assert actual.dtype == torch.bfloat16
+    torch.testing.assert_close(actual.float(), expected.float(), rtol=0, atol=0)
+
+
+def test_limited_swiglu_limit_zero_zeroes_up_branch() -> None:
+    gate = torch.tensor([[20.0, -20.0]])
+    up = torch.tensor([[15.0, -15.0]])
+
+    actual = deepseek_v4_limited_swiglu(gate, up, swiglu_limit=0.0)
+
+    torch.testing.assert_close(actual, torch.zeros_like(actual))
+
+
+def test_limited_swiglu_limit_ten_clamps_gate_and_up() -> None:
+    gate = torch.tensor([[20.0, -20.0]])
+    up = torch.tensor([[15.0, -15.0]])
+
+    actual = deepseek_v4_limited_swiglu(gate, up, swiglu_limit=10.0)
+    expected = F.silu(torch.tensor([[10.0, -20.0]])) * torch.tensor([[10.0, -10.0]])
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_from_routing_limit_zero_zeroes_routed_output_without_shared_expert() -> None:
+    hidden_states = torch.tensor([[1.0], [2.0]], dtype=torch.float32)
+    selected_experts = torch.tensor([[0], [0]], dtype=torch.int64)
+    routing_weights = torch.ones((2, 1), dtype=torch.float32)
+    routed_w1 = torch.tensor([[[20.0], [-20.0]]])
+    routed_w2 = torch.tensor([[[1.0, 2.0]]])
+    routed_w3 = torch.tensor([[[15.0], [-15.0]]])
+
+    actual = torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        routed_w1,
+        routed_w2,
+        routed_w3,
+        None,
+        None,
+        None,
+        0.0,
+        "moe",
+    )
+
+    torch.testing.assert_close(actual, torch.zeros_like(hidden_states))
+
+
+def test_from_routing_limit_ten_clamps_gate_and_up_inside_expert() -> None:
+    hidden_states = torch.tensor([[1.0]], dtype=torch.float32)
+    selected_experts = torch.tensor([[0]], dtype=torch.int64)
+    routing_weights = torch.ones((1, 1), dtype=torch.float32)
+    routed_w1 = torch.tensor([[[20.0], [-20.0]]])
+    routed_w2 = torch.tensor([[[1.0, 2.0]]])
+    routed_w3 = torch.tensor([[[15.0], [-15.0]]])
+
+    actual = torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        routed_w1,
+        routed_w2,
+        routed_w3,
+        None,
+        None,
+        None,
+        10.0,
+        "moe",
+    )
+    expected_hidden = F.silu(torch.tensor([[10.0, -20.0]])) * torch.tensor([[10.0, -10.0]])
+    expected = expected_hidden @ torch.tensor([[1.0], [2.0]])
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_canonical_moe_uses_router_surface() -> None:
+    hidden_states = torch.tensor([[0.25, -0.5, 1.0], [1.0, 0.5, -0.25]], dtype=torch.float32)
+    router_weight = torch.tensor(
+        [
+            [0.5, -0.25, 0.75],
+            [-0.25, 0.5, 0.125],
+            [0.75, 0.125, -0.5],
+            [0.25, 0.25, 0.25],
+        ],
+        dtype=torch.float32,
+    )
+    router_bias = torch.tensor([0.0, 0.25, -0.25, 0.125], dtype=torch.float32)
+    routed_w1, routed_w2, routed_w3 = _stacked_weights(
+        num_experts=4, hidden_size=3, intermediate_size=2, dtype=torch.float32
+    )
+
+    expected = deepseek_v4_moe_reference(
+        hidden_states,
+        input_ids=None,
+        router_weight=router_weight,
+        router_bias=router_bias,
+        tid2eid=None,
+        routed_w1_weight=routed_w1,
+        routed_w2_weight=routed_w2,
+        routed_w3_weight=routed_w3,
+        shared_w1_weight=None,
+        shared_w2_weight=None,
+        shared_w3_weight=None,
+        top_k=2,
+        route_scale=1.5,
+        swiglu_limit=10.0,
+        is_hash_layer=False,
+    )
+    actual = torch.ops.auto_deploy.torch_deepseek_v4_moe.default(
+        hidden_states,
+        None,
+        router_weight,
+        router_bias,
+        None,
+        routed_w1,
+        routed_w2,
+        routed_w3,
+        None,
+        None,
+        None,
+        2,
+        1.5,
+        10.0,
+        False,
+        "moe",
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_from_routing_fake_returns_meta_output_shape() -> None:
+    hidden_states = torch.empty((2, 3, 4), dtype=torch.bfloat16, device="meta")
+    selected_experts = torch.empty((6, 2), dtype=torch.int64, device="meta")
+    routing_weights = torch.empty((6, 2), dtype=torch.float32, device="meta")
+    routed_w1 = torch.empty((4, 5, 4), dtype=torch.bfloat16, device="meta")
+    routed_w2 = torch.empty((4, 4, 5), dtype=torch.bfloat16, device="meta")
+    routed_w3 = torch.empty((4, 5, 4), dtype=torch.bfloat16, device="meta")
+
+    actual = torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        routed_w1,
+        routed_w2,
+        routed_w3,
+        None,
+        None,
+        None,
+        10.0,
+        "moe",
+    )
+
+    assert actual.shape == hidden_states.shape
+    assert actual.dtype == torch.bfloat16
+    assert actual.device.type == "meta"
+
+
+class _FromRoutingExportModule(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        routed_w1, routed_w2, routed_w3 = _stacked_weights(
+            num_experts=2, hidden_size=3, intermediate_size=4, dtype=torch.float32
+        )
+        self.routed_w1 = nn.Parameter(routed_w1, requires_grad=False)
+        self.routed_w2 = nn.Parameter(routed_w2, requires_grad=False)
+        self.routed_w3 = nn.Parameter(routed_w3, requires_grad=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        selected_experts: torch.Tensor,
+        routing_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default(
+            hidden_states,
+            selected_experts,
+            routing_weights,
+            self.routed_w1,
+            self.routed_w2,
+            self.routed_w3,
+            None,
+            None,
+            None,
+            10.0,
+            "moe",
+        )
+
+
+def test_from_routing_custom_op_exports() -> None:
+    module = _FromRoutingExportModule()
+    hidden_states = torch.randn(3, 3, dtype=torch.float32)
+    selected_experts = torch.tensor([[0, 1], [1, 0], [0, 1]], dtype=torch.int64)
+    routing_weights = torch.full((3, 2), 0.5, dtype=torch.float32)
+
+    exported = torch.export.export(module, (hidden_states, selected_experts, routing_weights))
+    targets = [node.target for node in exported.graph_module.graph.nodes]
+
+    assert torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default in targets
+
+
+class _CanonicalMoEModule(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.router_weight = nn.Parameter(torch.randn(3, 2), requires_grad=False)
+        self.router_bias = nn.Parameter(torch.zeros(3), requires_grad=False)
+        routed_w1, routed_w2, routed_w3 = _stacked_weights(
+            num_experts=3, hidden_size=2, intermediate_size=4, dtype=torch.float32
+        )
+        self.routed_w1 = nn.Parameter(routed_w1, requires_grad=False)
+        self.routed_w2 = nn.Parameter(routed_w2, requires_grad=False)
+        self.routed_w3 = nn.Parameter(routed_w3, requires_grad=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_deepseek_v4_moe.default(
+            hidden_states,
+            None,
+            self.router_weight,
+            self.router_bias,
+            None,
+            self.routed_w1,
+            self.routed_w2,
+            self.routed_w3,
+            None,
+            None,
+            None,
+            2,
+            1.0,
+            10.0,
+            False,
+            "moe",
+        )
+
+
+def _trace_canonical_moe() -> torch.fx.GraphModule:
+    return torch.fx.symbolic_trace(_CanonicalMoEModule())
+
+
+def test_lowering_skeleton_raises_clear_error_for_production_path() -> None:
+    gm = _trace_canonical_moe()
+    transform = DeepSeekV4MoELowering.from_kwargs(stage=Stages.POST_LOAD_FUSION)
+
+    with pytest.raises(
+        DeepSeekV4MoELoweringError,
+        match="triton_mxfp4_moe.*FineGrained FP8.*swiglu_limit",
+    ):
+        transform._apply(gm, None, None, SharedConfig())
+
+
+def test_lowering_skeleton_can_opt_into_reference_graph_for_tests() -> None:
+    module = _CanonicalMoEModule()
+    gm = torch.fx.symbolic_trace(module)
+    transform = DeepSeekV4MoELowering.from_kwargs(
+        stage=Stages.POST_LOAD_FUSION, allow_reference_lowering=True
+    )
+
+    lowered, info = transform._apply(gm, None, None, SharedConfig())
+    targets = [node.target for node in lowered.graph.nodes]
+
+    assert info.num_matches == 1
+    assert torch.ops.auto_deploy.torch_deepseek_v4_router.default in targets
+    assert torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default in targets
+    assert not any(
+        is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_moe) for node in lowered.graph.nodes
+    )
+
+    hidden_states = torch.randn(4, 2, dtype=torch.float32)
+    torch.testing.assert_close(lowered(hidden_states), module(hidden_states))

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
@@ -31,7 +31,11 @@ from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.deepseek_v4_moe import
 from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.mxfp4_moe import (
     _deepseek_v4_swiglu_torch,
     _interleave_deepseek_v4_gate_up,
+    _routing_from_prebuilt_metadata,
     _routing_from_precomputed,
+    localize_deepseek_v4_routes_for_mxfp4,
+    prepare_deepseek_v4_route_metadata,
+    prepare_deepseek_v4_route_metadata_tensors,
 )
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
@@ -57,6 +61,15 @@ _DEEPSEEK_V4_REAL_CKPT_ENV = "DEEPSEEK_V4_FLASH_CHECKPOINT"
 _DEFAULT_DEEPSEEK_V4_REAL_CKPT = Path(
     "/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/"
     "bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash"
+)
+_ROUTE_METADATA_ARG_NAMES = (
+    "sorted_routing_weights",
+    "expert_histogram",
+    "sorted_route_indices",
+    "inverse_route_indices",
+    "expert_offsets",
+    "expert_block_offsets",
+    "expert_block_schedule",
 )
 
 
@@ -598,6 +611,418 @@ def test_from_routing_fake_returns_meta_output_shape() -> None:
     assert actual.device.type == "meta"
 
 
+def test_deepseek_v4_route_metadata_prepares_sort_histogram_and_indices() -> None:
+    selected_experts = torch.tensor([[2, 0, 2], [1, 0, 3]], dtype=torch.int64)
+    routing_weights = torch.tensor(
+        [[0.2, 0.1, 0.3], [0.4, 0.5, 0.6]],
+        dtype=torch.float32,
+    )
+
+    route_metadata = prepare_deepseek_v4_route_metadata(
+        selected_experts,
+        routing_weights,
+        num_experts=4,
+    )
+    metadata_tensors = prepare_deepseek_v4_route_metadata_tensors(
+        selected_experts,
+        routing_weights,
+        num_experts=4,
+    )
+
+    expected_sorted = torch.tensor([1, 4, 3, 0, 2, 5], dtype=torch.int32)
+    expected_inverse = torch.tensor([3, 0, 4, 2, 1, 5], dtype=torch.int32)
+    expected_histogram = torch.tensor([2, 1, 2, 1], dtype=torch.int32)
+    expected_offsets = torch.tensor([0, 2, 3, 5, 6], dtype=torch.int32)
+
+    assert route_metadata.num_experts == 4
+    assert route_metadata.top_k == 3
+    assert route_metadata.num_routes == 6
+    torch.testing.assert_close(
+        route_metadata.flat_expert_ids,
+        selected_experts.reshape(-1),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(route_metadata.sorted_route_indices, expected_sorted)
+    torch.testing.assert_close(route_metadata.inverse_route_indices, expected_inverse)
+    torch.testing.assert_close(route_metadata.expert_histogram, expected_histogram)
+    torch.testing.assert_close(
+        route_metadata.sorted_routing_weights,
+        routing_weights.reshape(-1)[expected_sorted.to(torch.int64)],
+    )
+    torch.testing.assert_close(metadata_tensors.expert_offsets, expected_offsets)
+    torch.testing.assert_close(metadata_tensors.expert_histogram, expected_histogram)
+    torch.testing.assert_close(metadata_tensors.sorted_route_indices, expected_sorted)
+    torch.testing.assert_close(metadata_tensors.inverse_route_indices, expected_inverse)
+
+
+def _assert_routing_bridge_matches(
+    actual: tuple[object, object, object],
+    expected: tuple[object, object, object],
+) -> None:
+    actual_routing, actual_gather, actual_scatter = actual
+    expected_routing, expected_gather, expected_scatter = expected
+
+    assert actual_routing.n_expts_tot == expected_routing.n_expts_tot
+    assert actual_routing.n_expts_act == expected_routing.n_expts_act
+    torch.testing.assert_close(actual_routing.gate_scal, expected_routing.gate_scal)
+    torch.testing.assert_close(actual_routing.expt_hist, expected_routing.expt_hist)
+    torch.testing.assert_close(
+        actual_routing.expt_data.slice_sizes,
+        expected_routing.expt_data.slice_sizes,
+    )
+    torch.testing.assert_close(
+        actual_routing.expt_data.slice_offs,
+        expected_routing.expt_data.slice_offs,
+    )
+    torch.testing.assert_close(
+        actual_routing.expt_data.block_offs_data,
+        expected_routing.expt_data.block_offs_data,
+    )
+    torch.testing.assert_close(
+        actual_routing.expt_data.block_schedule_data,
+        expected_routing.expt_data.block_schedule_data,
+    )
+    torch.testing.assert_close(actual_gather.src_indx, expected_gather.src_indx)
+    torch.testing.assert_close(actual_gather.dst_indx, expected_gather.dst_indx)
+    torch.testing.assert_close(actual_scatter.src_indx, expected_scatter.src_indx)
+    torch.testing.assert_close(actual_scatter.dst_indx, expected_scatter.dst_indx)
+
+
+def _assert_prebuilt_metadata_matches_precomputed(
+    selected_experts: torch.Tensor,
+    routing_weights: torch.Tensor,
+    num_experts: int,
+) -> None:
+    metadata_tensors = prepare_deepseek_v4_route_metadata_tensors(
+        selected_experts,
+        routing_weights,
+        num_experts,
+    )
+    actual = _routing_from_prebuilt_metadata(
+        *metadata_tensors.as_tuple(),
+        num_experts=num_experts,
+        top_k=selected_experts.shape[1],
+    )
+    expected = _routing_from_precomputed(selected_experts, routing_weights, num_experts)
+
+    _assert_routing_bridge_matches(actual, expected)
+
+
+def test_deepseek_v4_prebuilt_route_metadata_matches_precomputed_bridge() -> None:
+    selected_experts = torch.tensor(
+        [
+            [2, 0, 2, 7, 1, 0],
+            [1, 0, 3, 7, 4, 4],
+            [6, 2, 5, 3, 1, 0],
+        ],
+        dtype=torch.int64,
+    )
+    routing_weights = torch.arange(1, 19, dtype=torch.float32).view(3, 6).div(19.0)
+
+    _assert_prebuilt_metadata_matches_precomputed(
+        selected_experts,
+        routing_weights,
+        num_experts=8,
+    )
+
+
+def test_deepseek_v4_prebuilt_route_metadata_handles_all_routes_to_one_expert() -> None:
+    selected_experts = torch.full((5, 6), 17, dtype=torch.int64)
+    routing_weights = torch.linspace(0.05, 1.5, 30, dtype=torch.float32).view(5, 6)
+    metadata_tensors = prepare_deepseek_v4_route_metadata_tensors(
+        selected_experts,
+        routing_weights,
+        num_experts=32,
+    )
+
+    expected_histogram = torch.zeros(32, dtype=torch.int32)
+    expected_histogram[17] = selected_experts.numel()
+
+    torch.testing.assert_close(metadata_tensors.expert_histogram, expected_histogram)
+    torch.testing.assert_close(
+        metadata_tensors.sorted_route_indices,
+        torch.arange(selected_experts.numel(), dtype=torch.int32),
+    )
+    _assert_prebuilt_metadata_matches_precomputed(
+        selected_experts,
+        routing_weights,
+        num_experts=32,
+    )
+
+
+def test_deepseek_v4_prebuilt_route_metadata_handles_sparse_experts_32_topk6() -> None:
+    selected_experts = torch.tensor(
+        [
+            [0, 31, 0, 31, 7, 7],
+            [7, 0, 31, 7, 0, 31],
+            [31, 31, 7, 0, 7, 0],
+        ],
+        dtype=torch.int64,
+    )
+    routing_weights = torch.arange(1, 19, dtype=torch.float32).view(3, 6).div(18.0)
+
+    metadata_tensors = prepare_deepseek_v4_route_metadata_tensors(
+        selected_experts,
+        routing_weights,
+        num_experts=32,
+    )
+
+    expected_histogram = torch.zeros(32, dtype=torch.int32)
+    expected_histogram[0] = 6
+    expected_histogram[7] = 6
+    expected_histogram[31] = 6
+    expected_sorted = torch.argsort(selected_experts.reshape(-1), stable=True).to(torch.int32)
+    expected_offsets = torch.cumsum(
+        torch.cat((torch.zeros(1, dtype=torch.int32), expected_histogram)),
+        dim=0,
+    ).to(torch.int32)
+
+    torch.testing.assert_close(metadata_tensors.expert_histogram, expected_histogram)
+    torch.testing.assert_close(metadata_tensors.sorted_route_indices, expected_sorted)
+    torch.testing.assert_close(metadata_tensors.expert_offsets, expected_offsets)
+    torch.testing.assert_close(
+        metadata_tensors.sorted_routing_weights,
+        routing_weights.reshape(-1)[expected_sorted.to(torch.int64)],
+    )
+    _assert_prebuilt_metadata_matches_precomputed(
+        selected_experts,
+        routing_weights,
+        num_experts=32,
+    )
+
+
+def test_deepseek_v4_prebuilt_route_metadata_uses_32_local_experts_topk6_shape() -> None:
+    selected_experts = torch.arange(30, dtype=torch.int64).view(5, 6).mul(7).add(3).remainder(32)
+    routing_weights = torch.arange(1, 31, dtype=torch.float32).view(5, 6).div(31.0)
+
+    metadata_tensors = prepare_deepseek_v4_route_metadata_tensors(
+        selected_experts,
+        routing_weights,
+        num_experts=32,
+    )
+
+    assert metadata_tensors.sorted_routing_weights.shape == (30,)
+    assert metadata_tensors.expert_histogram.shape == (32,)
+    assert metadata_tensors.sorted_route_indices.shape == (30,)
+    assert metadata_tensors.inverse_route_indices.shape == (30,)
+    assert metadata_tensors.expert_offsets.shape == (33,)
+    assert metadata_tensors.expert_block_offsets.shape[1] == 33
+    assert metadata_tensors.expert_block_schedule.shape[1] == 30
+    _assert_prebuilt_metadata_matches_precomputed(
+        selected_experts,
+        routing_weights,
+        num_experts=32,
+    )
+
+
+def test_deepseek_v4_route_metadata_custom_op_fake_uses_32_experts_topk6_shape() -> None:
+    selected_experts = torch.empty((7, 6), dtype=torch.int64, device="meta")
+    routing_weights = torch.empty((7, 6), dtype=torch.float32, device="meta")
+
+    (
+        sorted_routing_weights,
+        expert_histogram,
+        sorted_route_indices,
+        inverse_route_indices,
+        expert_offsets,
+        expert_block_offsets,
+        expert_block_schedule,
+    ) = torch.ops.auto_deploy.torch_deepseek_v4_mxfp4_route_metadata.default(
+        selected_experts,
+        routing_weights,
+        32,
+    )
+
+    assert sorted_routing_weights.shape == (42,)
+    assert sorted_routing_weights.dtype == torch.float32
+    assert expert_histogram.shape == (32,)
+    assert sorted_route_indices.shape == (42,)
+    assert inverse_route_indices.shape == (42,)
+    assert expert_offsets.shape == (33,)
+    assert expert_block_offsets.shape[1] == 33
+    assert expert_block_schedule.shape[1] == 32
+
+
+def test_deepseek_v4_route_metadata_localizes_observed_ep8_rank_slice() -> None:
+    selected_experts = torch.tensor([[0, 31, 32, 63, 64, 95, 224, 255]], dtype=torch.int64)
+    routing_weights = torch.arange(1, 9, dtype=torch.float32).view(1, 8)
+
+    ep_metadata = localize_deepseek_v4_routes_for_mxfp4(
+        selected_experts,
+        routing_weights,
+        moe_ep_size=8,
+        moe_ep_rank=7,
+        num_global_experts=256,
+    )
+    route_metadata = prepare_deepseek_v4_route_metadata(
+        ep_metadata.selected_experts_local,
+        ep_metadata.routing_weights_local,
+        num_experts=ep_metadata.experts_per_rank,
+    )
+
+    expected_mask = torch.tensor([[False, False, False, False, False, False, True, True]])
+    expected_local = torch.tensor([[0, 0, 0, 0, 0, 0, 0, 31]], dtype=torch.int64)
+    expected_weights = torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 7.0, 8.0]])
+    expected_histogram = torch.zeros(32, dtype=torch.int32)
+    expected_histogram[0] = 7
+    expected_histogram[31] = 1
+
+    assert ep_metadata.local_expert_start == 224
+    assert ep_metadata.local_expert_end == 256
+    assert ep_metadata.experts_per_rank == 32
+    assert torch.equal(ep_metadata.rank_mask, expected_mask)
+    torch.testing.assert_close(ep_metadata.selected_experts_local, expected_local)
+    torch.testing.assert_close(ep_metadata.routing_weights_local, expected_weights)
+    torch.testing.assert_close(route_metadata.expert_histogram, expected_histogram)
+    _assert_prebuilt_metadata_matches_precomputed(
+        ep_metadata.selected_experts_local,
+        ep_metadata.routing_weights_local,
+        num_experts=ep_metadata.experts_per_rank,
+    )
+
+
+def test_deepseek_v4_route_metadata_localizes_ep8_rank3_topk6_nonlocal_routes() -> None:
+    selected_experts = torch.tensor(
+        [
+            [95, 96, 101, 127, 128, 255],
+            [0, 100, 121, 190, 97, 32],
+        ],
+        dtype=torch.int64,
+    )
+    routing_weights = torch.arange(1, 13, dtype=torch.float32).view(2, 6)
+
+    ep_metadata = localize_deepseek_v4_routes_for_mxfp4(
+        selected_experts,
+        routing_weights,
+        moe_ep_size=8,
+        moe_ep_rank=3,
+        num_global_experts=256,
+    )
+    route_metadata = prepare_deepseek_v4_route_metadata(
+        ep_metadata.selected_experts_local,
+        ep_metadata.routing_weights_local,
+        num_experts=ep_metadata.experts_per_rank,
+    )
+
+    expected_mask = torch.tensor(
+        [
+            [False, True, True, True, False, False],
+            [False, True, True, False, True, False],
+        ]
+    )
+    expected_local = torch.tensor(
+        [
+            [0, 0, 5, 31, 0, 0],
+            [0, 4, 25, 0, 1, 0],
+        ],
+        dtype=torch.int64,
+    )
+    expected_weights = torch.tensor(
+        [
+            [0.0, 2.0, 3.0, 4.0, 0.0, 0.0],
+            [0.0, 8.0, 9.0, 0.0, 11.0, 0.0],
+        ]
+    )
+    expected_histogram = torch.zeros(32, dtype=torch.int32)
+    expected_histogram[0] = 7
+    expected_histogram[1] = 1
+    expected_histogram[4] = 1
+    expected_histogram[5] = 1
+    expected_histogram[25] = 1
+    expected_histogram[31] = 1
+
+    assert ep_metadata.local_expert_start == 96
+    assert ep_metadata.local_expert_end == 128
+    assert ep_metadata.experts_per_rank == 32
+    assert torch.equal(ep_metadata.rank_mask, expected_mask)
+    torch.testing.assert_close(ep_metadata.selected_experts_local, expected_local)
+    torch.testing.assert_close(ep_metadata.routing_weights_local, expected_weights)
+    torch.testing.assert_close(route_metadata.expert_histogram, expected_histogram)
+    _assert_prebuilt_metadata_matches_precomputed(
+        ep_metadata.selected_experts_local,
+        ep_metadata.routing_weights_local,
+        num_experts=ep_metadata.experts_per_rank,
+    )
+
+
+def test_mxfp4_from_routing_uses_prebuilt_metadata_fast_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    selected_experts = torch.tensor([[1, 0], [0, 1]], dtype=torch.int64)
+    routing_weights = torch.tensor([[0.25, 0.75], [0.5, 0.5]], dtype=torch.float32)
+    metadata_tensors = prepare_deepseek_v4_route_metadata_tensors(
+        selected_experts,
+        routing_weights,
+        num_experts=2,
+    )
+    captured = {}
+
+    def _fail_precomputed(*args, **kwargs):
+        raise AssertionError("precomputed route metadata path should not run")
+
+    def _fake_core_from_routing(
+        hidden_states: torch.Tensor,
+        gate_up_blocks: torch.Tensor,
+        gate_up_bias: torch.Tensor,
+        gate_up_scales: torch.Tensor,
+        alpha: float,
+        limit: float,
+        down_blocks: torch.Tensor,
+        down_bias: torch.Tensor,
+        down_scales: torch.Tensor,
+        routing_data,
+        gather_idx,
+        scatter_idx,
+        **kwargs,
+    ) -> torch.Tensor:
+        del (
+            gate_up_blocks,
+            gate_up_bias,
+            gate_up_scales,
+            alpha,
+            limit,
+            down_blocks,
+            down_bias,
+            down_scales,
+            kwargs,
+        )
+        captured["routing"] = (routing_data, gather_idx, scatter_idx)
+        return torch.full_like(hidden_states, 3)
+
+    monkeypatch.setattr(mxfp4_moe, "_routing_from_precomputed", _fail_precomputed)
+    monkeypatch.setattr(
+        mxfp4_moe,
+        "_run_mxfp4_mlp_core_from_routing",
+        _fake_core_from_routing,
+    )
+
+    actual = torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing.default(
+        hidden_states,
+        selected_experts,
+        routing_weights,
+        torch.empty((2, 8, 2, 16), dtype=torch.uint8),
+        torch.empty((2, 8), dtype=torch.float32),
+        torch.empty((2, 8, 2), dtype=torch.uint8),
+        1.0,
+        10.0,
+        torch.empty((2, 4, 2, 16), dtype=torch.uint8),
+        torch.empty((2, 4), dtype=torch.float32),
+        torch.empty((2, 4, 2), dtype=torch.uint8),
+        "moe",
+        *metadata_tensors.as_tuple(),
+    )
+    expected_routing = _routing_from_prebuilt_metadata(
+        *metadata_tensors.as_tuple(),
+        num_experts=2,
+        top_k=2,
+    )
+
+    torch.testing.assert_close(actual, torch.full_like(hidden_states, 3))
+    _assert_routing_bridge_matches(captured["routing"], expected_routing)
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_mxfp4_precomputed_routing_accepts_non_power_of_two_topk() -> None:
     selected_experts = torch.tensor(
@@ -652,6 +1077,39 @@ def test_mxfp4_precomputed_routing_accepts_non_power_of_two_topk() -> None:
         captured_routing_data.gate_scal,
         routing_weights.reshape(-1)[expected_order.to(torch.int64)],
     )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_deepseek_v4_route_metadata_custom_op_replays_in_cuda_graph_32_topk6() -> None:
+    selected_experts = torch.tensor(
+        [
+            [31, 0, 17, 17, 3, 31],
+            [8, 3, 0, 24, 24, 17],
+            [31, 8, 8, 3, 0, 24],
+        ],
+        dtype=torch.int64,
+        device="cuda",
+    )
+    routing_weights = torch.arange(1, 19, dtype=torch.float32, device="cuda").view(3, 6).div(19.0)
+
+    expected = torch.ops.auto_deploy.torch_deepseek_v4_mxfp4_route_metadata.default(
+        selected_experts,
+        routing_weights,
+        32,
+    )
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = torch.ops.auto_deploy.torch_deepseek_v4_mxfp4_route_metadata.default(
+            selected_experts,
+            routing_weights,
+            32,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    for actual, expected_tensor in zip(captured, expected):
+        torch.testing.assert_close(actual, expected_tensor)
 
 
 class _FromRoutingExportModule(nn.Module):
@@ -753,7 +1211,23 @@ class _MXFP4FromRoutingShardingModule(nn.Module):
         )
 
 
-def _trace_mxfp4_from_routing_sharding_module(num_experts: int = 4) -> torch.fx.GraphModule:
+def test_triton_mxfp4_from_routing_custom_op_exports() -> None:
+    module = _MXFP4FromRoutingShardingModule(num_experts=2)
+    hidden_states = torch.randn(3, 4, dtype=torch.bfloat16)
+    selected_experts = torch.tensor([[1, 0], [0, 1], [1, 0]], dtype=torch.int64)
+    routing_weights = torch.full((3, 2), 0.5, dtype=torch.float32)
+
+    exported = torch.export.export(module, (hidden_states, selected_experts, routing_weights))
+    targets = [node.target for node in exported.graph_module.graph.nodes]
+
+    assert torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing.default in targets
+    assert torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default not in targets
+
+
+def _trace_mxfp4_from_routing_sharding_module(
+    num_experts: int = 4,
+    top_k: int = 2,
+) -> torch.fx.GraphModule:
     gm = torch.fx.symbolic_trace(_MXFP4FromRoutingShardingModule(num_experts))
     params_and_buffers = dict(gm.named_parameters())
     params_and_buffers.update(dict(gm.named_buffers()))
@@ -762,9 +1236,9 @@ def _trace_mxfp4_from_routing_sharding_module(num_experts: int = 4) -> torch.fx.
             if node.target == "hidden_states":
                 node.meta["val"] = torch.empty((3, 4), dtype=torch.bfloat16)
             elif node.target == "selected_experts":
-                node.meta["val"] = torch.empty((3, 2), dtype=torch.int64)
+                node.meta["val"] = torch.empty((3, top_k), dtype=torch.int64)
             elif node.target == "routing_weights":
-                node.meta["val"] = torch.empty((3, 2), dtype=torch.float32)
+                node.meta["val"] = torch.empty((3, top_k), dtype=torch.float32)
         elif node.op == "get_attr" and node.target in params_and_buffers:
             node.meta["val"] = params_and_buffers[node.target].detach()
         elif is_op(
@@ -775,10 +1249,187 @@ def _trace_mxfp4_from_routing_sharding_module(num_experts: int = 4) -> torch.fx.
     return gm
 
 
+def _meta_parameter(shape: tuple[int, ...], dtype: torch.dtype) -> nn.Parameter:
+    return nn.Parameter(torch.empty(shape, dtype=dtype, device="meta"), requires_grad=False)
+
+
+class _LoweredDeepSeekV4EP8ShapeRoot(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([nn.Module()])
+        self.layers[0].ffn = nn.Module()
+        ffn = self.layers[0].ffn
+        ffn.mxfp4_gate_up_blocks = _meta_parameter((256, 4096, 128, 16), torch.uint8)
+        ffn.register_buffer(
+            "mxfp4_gate_up_bias",
+            torch.empty((256, 4096), dtype=torch.float32, device="meta"),
+            persistent=False,
+        )
+        ffn.mxfp4_gate_up_scales = _meta_parameter((256, 4096, 128), torch.uint8)
+        ffn.mxfp4_down_blocks = _meta_parameter((256, 4096, 64, 16), torch.uint8)
+        ffn.register_buffer(
+            "mxfp4_down_bias",
+            torch.empty((256, 4096), dtype=torch.float32, device="meta"),
+            persistent=False,
+        )
+        ffn.mxfp4_down_scales = _meta_parameter((256, 4096, 64), torch.uint8)
+        ffn.shared_experts = nn.Module()
+        for proj, weight_shape, scale_shape in (
+            ("w1", (2048, 4096), (16, 32)),
+            ("w2", (4096, 2048), (32, 16)),
+            ("w3", (2048, 4096), (16, 32)),
+        ):
+            linear = nn.Module()
+            linear.weight = _meta_parameter(weight_shape, torch.float8_e4m3fn)
+            linear.register_buffer(
+                "weight_scale_inv",
+                torch.empty(scale_shape, dtype=torch.float32, device="meta"),
+            )
+            setattr(ffn.shared_experts, proj, linear)
+
+
+def _nested_attr(module: nn.Module, name: str) -> torch.Tensor:
+    value: object = module
+    for part in name.split("."):
+        value = getattr(value, part)
+    assert isinstance(value, torch.Tensor)
+    return value
+
+
+def _get_attr_with_meta(graph: torch.fx.Graph, root: nn.Module, name: str) -> torch.fx.Node:
+    node = graph.create_node("get_attr", name)
+    node.meta["val"] = _nested_attr(root, name).detach()
+    return node
+
+
+def _call_fp8_linear_with_meta(
+    graph: torch.fx.Graph,
+    input_node: torch.fx.Node,
+    input_shape: tuple[int, int],
+    weight_node: torch.fx.Node,
+    scale_node: torch.fx.Node,
+    tp_mode: str,
+) -> torch.fx.Node:
+    output_features = int(weight_node.meta["val"].shape[0])
+    if tp_mode == "rowwise":
+        output_features = int(weight_node.meta["val"].shape[0])
+    node = graph.call_function(
+        torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear.default,
+        args=(input_node, weight_node, None, [], [scale_node], [], [], tp_mode, None, 1, "moe"),
+    )
+    node.meta["val"] = torch.empty(
+        (*input_shape[:-1], output_features),
+        dtype=torch.bfloat16,
+        device="meta",
+    )
+    return node
+
+
+def _make_lowered_deepseek_v4_ep8_shape_graph() -> torch.fx.GraphModule:
+    root = _LoweredDeepSeekV4EP8ShapeRoot()
+    graph = torch.fx.Graph()
+    hidden_states = graph.placeholder("hidden_states")
+    hidden_states.meta["val"] = torch.empty((2, 4096), dtype=torch.bfloat16, device="meta")
+    selected_experts = graph.placeholder("selected_experts")
+    selected_experts.meta["val"] = torch.empty((2, 6), dtype=torch.int64, device="meta")
+    routing_weights = graph.placeholder("routing_weights")
+    routing_weights.meta["val"] = torch.empty((2, 6), dtype=torch.float32, device="meta")
+
+    gate_up_blocks = _get_attr_with_meta(graph, root, "layers.0.ffn.mxfp4_gate_up_blocks")
+    gate_up_bias = _get_attr_with_meta(graph, root, "layers.0.ffn.mxfp4_gate_up_bias")
+    gate_up_scales = _get_attr_with_meta(graph, root, "layers.0.ffn.mxfp4_gate_up_scales")
+    down_blocks = _get_attr_with_meta(graph, root, "layers.0.ffn.mxfp4_down_blocks")
+    down_bias = _get_attr_with_meta(graph, root, "layers.0.ffn.mxfp4_down_bias")
+    down_scales = _get_attr_with_meta(graph, root, "layers.0.ffn.mxfp4_down_scales")
+    routed = graph.call_function(
+        torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing.default,
+        args=(
+            hidden_states,
+            selected_experts,
+            routing_weights,
+            gate_up_blocks,
+            gate_up_bias,
+            gate_up_scales,
+            1.0,
+            10.0,
+            down_blocks,
+            down_bias,
+            down_scales,
+            "moe",
+        ),
+    )
+    routed.meta["val"] = torch.empty((2, 4096), dtype=torch.bfloat16, device="meta")
+
+    shared_w1 = _get_attr_with_meta(graph, root, "layers.0.ffn.shared_experts.w1.weight")
+    shared_w1_scale = _get_attr_with_meta(
+        graph,
+        root,
+        "layers.0.ffn.shared_experts.w1.weight_scale_inv",
+    )
+    shared_w2 = _get_attr_with_meta(graph, root, "layers.0.ffn.shared_experts.w2.weight")
+    shared_w2_scale = _get_attr_with_meta(
+        graph,
+        root,
+        "layers.0.ffn.shared_experts.w2.weight_scale_inv",
+    )
+    shared_w3 = _get_attr_with_meta(graph, root, "layers.0.ffn.shared_experts.w3.weight")
+    shared_w3_scale = _get_attr_with_meta(
+        graph,
+        root,
+        "layers.0.ffn.shared_experts.w3.weight_scale_inv",
+    )
+    shared_gate = _call_fp8_linear_with_meta(
+        graph, hidden_states, (2, 4096), shared_w1, shared_w1_scale, "colwise"
+    )
+    shared_up = _call_fp8_linear_with_meta(
+        graph, hidden_states, (2, 4096), shared_w3, shared_w3_scale, "colwise"
+    )
+    shared_act = graph.call_function(torch.ops.aten.silu.default, args=(shared_gate,))
+    shared_act.meta["val"] = torch.empty((2, 2048), dtype=torch.bfloat16, device="meta")
+    shared_hidden = graph.call_function(torch.ops.aten.mul.Tensor, args=(shared_act, shared_up))
+    shared_hidden.meta["val"] = torch.empty((2, 2048), dtype=torch.bfloat16, device="meta")
+    shared = _call_fp8_linear_with_meta(
+        graph, shared_hidden, (2, 2048), shared_w2, shared_w2_scale, "rowwise"
+    )
+    shared_reduced = graph.call_function(
+        torch.ops.auto_deploy.all_reduce.default,
+        args=(shared,),
+        kwargs={"layer_type": "moe"},
+    )
+    shared_reduced.meta["val"] = torch.empty((2, 4096), dtype=torch.bfloat16, device="meta")
+    output = graph.call_function(torch.ops.aten.add.Tensor, args=(routed, shared_reduced))
+    output.meta["val"] = torch.empty((2, 4096), dtype=torch.bfloat16, device="meta")
+    graph.output(output)
+    return torch.fx.GraphModule(root, graph)
+
+
 def _shift_state_value(tensor: torch.Tensor) -> torch.Tensor:
     if tensor.dtype == torch.uint8:
         return tensor.to(torch.int64).add(19).remainder(251).to(torch.uint8)
     return tensor + 19
+
+
+def _is_all_reduce_node(node: torch.fx.Node) -> bool:
+    return node.op == "call_function" and "all_reduce" in str(node.target)
+
+
+def _assert_mxfp4_node_uses_local_route_metadata(
+    moe_node: torch.fx.Node,
+    selected_local: torch.fx.Node,
+    routing_local: torch.fx.Node,
+    num_local_experts: int,
+) -> None:
+    assert is_op(
+        moe_node,
+        torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing,
+    )
+    metadata_nodes = extract_op_args(moe_node, *_ROUTE_METADATA_ARG_NAMES)
+    assert len(metadata_nodes) == len(_ROUTE_METADATA_ARG_NAMES)
+    assert all(isinstance(node, torch.fx.Node) for node in metadata_nodes)
+    route_metadata = metadata_nodes[0].args[0]
+    assert all(node.args[0] is route_metadata for node in metadata_nodes)
+    assert is_op(route_metadata, torch.ops.auto_deploy.torch_deepseek_v4_mxfp4_route_metadata)
+    assert route_metadata.args == (selected_local, routing_local, num_local_experts)
 
 
 def test_deepseek_v4_mxfp4_from_routing_shards_experts_and_localizes_ids() -> None:
@@ -809,11 +1460,14 @@ def test_deepseek_v4_mxfp4_from_routing_shards_experts_and_localizes_ids() -> No
     assert selected_local.args[0].target == operator.sub
     assert selected_local.args[0].args[1] == 2
     assert selected_local.args[1].target == torch.logical_and
+    _assert_mxfp4_node_uses_local_route_metadata(
+        moe_node,
+        selected_local,
+        routing_local,
+        num_local_experts=2,
+    )
     assert any(
-        node.op == "call_function"
-        and node.args
-        and node.args[0] is moe_node
-        and "all_reduce" in str(node.target)
+        node.args and node.args[0] is moe_node and _is_all_reduce_node(node)
         for node in transformed.graph.nodes
     )
 
@@ -866,6 +1520,105 @@ def test_deepseek_v4_mxfp4_from_routing_ep8_localizes_rank7_global_ids() -> None
     assert ge_lower.args[1] == 14
     assert lt_upper.target == torch.lt
     assert lt_upper.args[1] == 16
+    _assert_mxfp4_node_uses_local_route_metadata(
+        moe_node,
+        selected_local,
+        routing_local,
+        num_local_experts=2,
+    )
+
+
+def test_deepseek_v4_mxfp4_from_routing_ep8_uses_32_local_experts_topk6_metadata() -> None:
+    gm = _trace_mxfp4_from_routing_sharding_module(num_experts=256, top_k=6)
+    full_state = {name: tensor.detach().clone() for name, tensor in gm.named_parameters()}
+
+    transformed, info = _run_ir_sharding(gm, rank=5, world_size=8)
+
+    assert info.num_matches == 1
+    for name, full_tensor in full_state.items():
+        local_tensor = transformed.get_parameter(name)
+        assert local_tensor.shape[0] == 32
+        torch.testing.assert_close(local_tensor, full_tensor[160:192], rtol=0, atol=0)
+
+    moe_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing,
+        )
+    )
+    selected_local = moe_node.args[1]
+    routing_local = moe_node.args[2]
+    assert moe_node.args[6] == 1.0
+    assert moe_node.args[7] == 10.0
+    assert selected_local.args[0].target == operator.sub
+    assert selected_local.args[0].args[1] == 160
+    _assert_mxfp4_node_uses_local_route_metadata(
+        moe_node,
+        selected_local,
+        routing_local,
+        num_local_experts=32,
+    )
+    assert any(
+        node.args and node.args[0] is moe_node and _is_all_reduce_node(node)
+        for node in transformed.graph.nodes
+    )
+
+
+def test_lowered_deepseek_v4_ep8_exact_local_shapes_metadata_and_collectives() -> None:
+    gm = _make_lowered_deepseek_v4_ep8_shape_graph()
+
+    transformed, info = _run_ir_sharding(gm, rank=6, world_size=8)
+
+    assert info.num_matches == 5
+    ffn = transformed.get_submodule("layers.0.ffn")
+    assert tuple(ffn.mxfp4_gate_up_blocks.shape) == (32, 4096, 128, 16)
+    assert tuple(ffn.mxfp4_gate_up_bias.shape) == (32, 4096)
+    assert tuple(ffn.mxfp4_gate_up_scales.shape) == (32, 4096, 128)
+    assert tuple(ffn.mxfp4_down_blocks.shape) == (32, 4096, 64, 16)
+    assert tuple(ffn.mxfp4_down_bias.shape) == (32, 4096)
+    assert tuple(ffn.mxfp4_down_scales.shape) == (32, 4096, 64)
+    assert tuple(ffn.shared_experts.w1.weight.shape) == (256, 4096)
+    assert tuple(ffn.shared_experts.w2.weight.shape) == (4096, 256)
+    assert tuple(ffn.shared_experts.w3.weight.shape) == (256, 4096)
+
+    moe_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing,
+        )
+    )
+    selected_local = moe_node.args[1]
+    routing_local = moe_node.args[2]
+    assert moe_node.args[6] == 1.0
+    assert moe_node.args[7] == 10.0
+    assert selected_local.args[0].target == operator.sub
+    assert selected_local.args[0].args[1] == 192
+    _assert_mxfp4_node_uses_local_route_metadata(
+        moe_node,
+        selected_local,
+        routing_local,
+        num_local_experts=32,
+    )
+
+    all_reduce_nodes = [node for node in transformed.graph.nodes if _is_all_reduce_node(node)]
+    shared_w2_node = _shared_fp8_linear_nodes(transformed)["layers.0.ffn.shared_experts.w2.weight"]
+    routed_reduces = [node for node in all_reduce_nodes if node.args[0] is moe_node]
+    shared_reduces = [node for node in all_reduce_nodes if node.args[0] is shared_w2_node]
+    assert len(routed_reduces) == 1
+    assert len(shared_reduces) == 1
+    add_node = next(
+        node for node in transformed.graph.nodes if node.target == torch.ops.aten.add.Tensor
+    )
+    assert add_node.args == (routed_reduces[0], shared_reduces[0])
+    assert not any(
+        is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing)
+        or is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_moe)
+        for node in transformed.graph.nodes
+    )
 
 
 class _CanonicalMoEModule(nn.Module):
@@ -937,6 +1690,144 @@ def test_lowering_skeleton_can_opt_into_reference_graph_for_tests() -> None:
     torch.testing.assert_close(lowered(hidden_states), module(hidden_states))
 
 
+@pytest.mark.parametrize(
+    ("num_hash_layers", "expected_is_hash_layer"),
+    [(0, False), (1, True)],
+)
+def test_lowering_bridge_production_uses_triton_router_source_op(
+    num_hash_layers: int,
+    expected_is_hash_layer: bool,
+) -> None:
+    lowered, info = _lower_layered_moe_model(num_hash_layers=num_hash_layers)
+
+    assert info.num_matches == 1
+    torch_router_nodes = [
+        node
+        for node in lowered.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_router)
+    ]
+    triton_router_nodes = [
+        node
+        for node in lowered.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.triton_deepseek_v4_router)
+    ]
+    assert torch_router_nodes == []
+    assert len(triton_router_nodes) == 1
+
+    router_node = triton_router_nodes[0]
+    assert router_node.args[7] == expected_is_hash_layer
+    if expected_is_hash_layer:
+        assert router_node.args[3] is None
+        assert isinstance(router_node.args[4], torch.fx.Node)
+    else:
+        assert isinstance(router_node.args[3], torch.fx.Node)
+        assert router_node.args[4] is None
+    mxfp4_node = next(
+        node
+        for node in lowered.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing,
+        )
+    )
+    selected_experts = mxfp4_node.args[1]
+    routing_weights = mxfp4_node.args[2]
+
+    assert selected_experts.target == operator.getitem
+    assert selected_experts.args == (router_node, 0)
+    assert routing_weights.target == operator.getitem
+    assert routing_weights.args == (router_node, 1)
+    assert torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default not in [
+        node.target for node in lowered.graph.nodes
+    ]
+
+
+def test_lowering_bridge_ep8_production_uses_triton_router_packed_mxfp4_and_collectives() -> None:
+    lowered, lowering_info = _lower_layered_moe_model(
+        n_routed_experts=256,
+        num_experts_per_tok=6,
+        num_hash_layers=1,
+    )
+
+    transformed, sharding_info = _run_ir_sharding(lowered, rank=6, world_size=8)
+
+    assert lowering_info.num_matches == 1
+    assert sharding_info.num_matches >= 5
+    assert not any(
+        is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_router)
+        or is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing)
+        or is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_moe)
+        for node in transformed.graph.nodes
+    )
+
+    router_nodes = [
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.triton_deepseek_v4_router)
+    ]
+    assert len(router_nodes) == 1
+    router_node = router_nodes[0]
+    assert router_node.args[7] is True
+
+    mxfp4_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing,
+        )
+    )
+    selected_local = mxfp4_node.args[1]
+    routing_local = mxfp4_node.args[2]
+    selected_global = selected_local.args[0].args[0]
+    routing_global = routing_local.args[0]
+
+    assert selected_local.args[0].target == operator.sub
+    assert selected_local.args[0].args[1] == 192
+    assert selected_global.target == operator.getitem
+    assert selected_global.args == (router_node, 0)
+    assert routing_global.target == operator.getitem
+    assert routing_global.args == (router_node, 1)
+    _assert_mxfp4_node_uses_local_route_metadata(
+        mxfp4_node,
+        selected_local,
+        routing_local,
+        num_local_experts=32,
+    )
+
+    ffn = transformed.get_submodule("layers.0.ffn")
+    assert tuple(ffn.mxfp4_gate_up_blocks.shape) == (32, 64, 2, 16)
+    assert tuple(ffn.mxfp4_gate_up_bias.shape) == (32, 64)
+    assert tuple(ffn.mxfp4_gate_up_scales.shape) == (32, 64, 2)
+    assert tuple(ffn.mxfp4_down_blocks.shape) == (32, 64, 1, 16)
+    assert tuple(ffn.mxfp4_down_bias.shape) == (32, 64)
+    assert tuple(ffn.mxfp4_down_scales.shape) == (32, 64, 1)
+
+    fp8_nodes = _shared_fp8_linear_nodes(transformed)
+    expected_modes = {
+        "layers.0.ffn.shared_experts.w1.weight": "colwise",
+        "layers.0.ffn.shared_experts.w2.weight": "rowwise",
+        "layers.0.ffn.shared_experts.w3.weight": "colwise",
+    }
+    assert {
+        weight_name: extract_op_args(node, "tp_mode")[0]
+        for weight_name, node in fp8_nodes.items()
+        if weight_name in expected_modes
+    } == expected_modes
+
+    all_reduce_nodes = [node for node in transformed.graph.nodes if _is_all_reduce_node(node)]
+    shared_w2_node = fp8_nodes["layers.0.ffn.shared_experts.w2.weight"]
+    routed_reduces = [node for node in all_reduce_nodes if node.args[0] is mxfp4_node]
+    shared_reduces = [node for node in all_reduce_nodes if node.args[0] is shared_w2_node]
+    assert len(routed_reduces) == 1
+    assert len(shared_reduces) == 1
+    assert any(
+        node.target == torch.ops.aten.add.Tensor
+        and node.args == (routed_reduces[0], shared_reduces[0])
+        for node in transformed.graph.nodes
+    )
+
+
 class _LayeredMoEBlock(nn.Module):
     def __init__(self, config: DeepseekV4Config) -> None:
         super().__init__()
@@ -947,16 +1838,23 @@ class _LayeredMoEBlock(nn.Module):
 
 
 class _LayeredMoEModel(nn.Module):
-    def __init__(self, hidden_size: int = 64, moe_intermediate_size: int = 32) -> None:
+    def __init__(
+        self,
+        hidden_size: int = 64,
+        moe_intermediate_size: int = 32,
+        num_hash_layers: int = 0,
+        n_routed_experts: int = 2,
+        num_experts_per_tok: int = 1,
+    ) -> None:
         super().__init__()
         config = DeepseekV4Config(
             vocab_size=16,
             hidden_size=hidden_size,
             moe_intermediate_size=moe_intermediate_size,
-            n_routed_experts=2,
+            n_routed_experts=n_routed_experts,
             n_shared_experts=1,
-            num_experts_per_tok=1,
-            num_hash_layers=0,
+            num_experts_per_tok=num_experts_per_tok,
+            num_hash_layers=num_hash_layers,
             scoring_func="sqrtsoftplus",
             routed_scaling_factor=1.0,
             swiglu_limit=10.0,
@@ -970,8 +1868,17 @@ class _LayeredMoEModel(nn.Module):
 def _lower_layered_moe_model(
     hidden_size: int = 64,
     moe_intermediate_size: int = 32,
+    num_hash_layers: int = 0,
+    n_routed_experts: int = 2,
+    num_experts_per_tok: int = 1,
 ) -> tuple[torch.fx.GraphModule, object]:
-    model = _LayeredMoEModel(hidden_size, moe_intermediate_size)
+    model = _LayeredMoEModel(
+        hidden_size,
+        moe_intermediate_size,
+        num_hash_layers,
+        n_routed_experts,
+        num_experts_per_tok,
+    )
     gm = torch_export_to_gm(
         model,
         args=(torch.randn(1, 2, hidden_size), torch.ones(1, 2, dtype=torch.long)),
@@ -1040,14 +1947,21 @@ def test_lowering_bridge_shared_fp8_linears_shard_weights_and_scales() -> None:
     assert shared_w1.weight_scale_inv.shape == (1, 2)
     assert shared_w2.weight_scale_inv.shape == (2, 1)
     assert shared_w3.weight_scale_inv.shape == (1, 2)
-    all_reduce_nodes = [
-        node
-        for node in transformed.graph.nodes
-        if node.op == "call_function" and "all_reduce" in str(node.target)
-    ]
+    all_reduce_nodes = [node for node in transformed.graph.nodes if _is_all_reduce_node(node)]
     assert all_reduce_nodes
     assert all(node.kwargs == {} for node in all_reduce_nodes)
     assert all(len(node.args) == 2 for node in all_reduce_nodes)
+    mxfp4_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing,
+        )
+    )
+    shared_w2_node = _shared_fp8_linear_nodes(transformed)["layers.0.ffn.shared_experts.w2.weight"]
+    assert any(node.args[0] is mxfp4_node for node in all_reduce_nodes)
+    assert any(node.args[0] is shared_w2_node for node in all_reduce_nodes)
 
     full_state = {
         "layers.0.ffn.shared_experts.w1.weight": _fp8_pattern((256, 256), 1),
@@ -1291,9 +2205,9 @@ def test_lowering_bridge_loads_packed_mxfp4_checkpoint_without_dense_shape_misma
     targets = [node.target for node in lowered.graph.nodes]
 
     assert info.num_matches == 1
-    assert torch.ops.auto_deploy.torch_deepseek_v4_router.default in targets
     assert torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing.default in targets
     assert torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear.default in targets
+    assert torch.ops.auto_deploy.torch_deepseek_v4_moe_from_routing.default not in targets
     assert not any(
         is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_moe) for node in lowered.graph.nodes
     )

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
@@ -764,6 +764,14 @@ def test_lowering_bridge_shared_fp8_linears_shard_weights_and_scales() -> None:
     assert shared_w1.weight_scale_inv.shape == (1, 2)
     assert shared_w2.weight_scale_inv.shape == (2, 1)
     assert shared_w3.weight_scale_inv.shape == (1, 2)
+    all_reduce_nodes = [
+        node
+        for node in transformed.graph.nodes
+        if node.op == "call_function" and "all_reduce" in str(node.target)
+    ]
+    assert all_reduce_nodes
+    assert all(node.kwargs == {} for node in all_reduce_nodes)
+    assert all(len(node.args) == 2 for node in all_reduce_nodes)
 
     full_state = {
         "layers.0.ffn.shared_experts.w1.weight": _fp8_pattern((256, 256), 1),

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
@@ -22,10 +22,19 @@ from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.deepseek_v4_moe import
     deepseek_v4_limited_swiglu,
     deepseek_v4_moe_reference,
 )
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.mxfp4_moe import _routing_from_precomputed
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
+    DeepseekV4Config,
+    DeepseekV4MoE,
+)
 from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
 from tensorrt_llm._torch.auto_deploy.transform.library.deepseek_v4_moe import (
     DeepSeekV4MoELowering,
     DeepSeekV4MoELoweringError,
+)
+from tensorrt_llm._torch.auto_deploy.transform.library.deepseek_v4_mxfp4 import (
+    load_deepseek_v4_mxfp4_experts,
 )
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 
@@ -326,6 +335,62 @@ def test_from_routing_fake_returns_meta_output_shape() -> None:
     assert actual.device.type == "meta"
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_mxfp4_precomputed_routing_accepts_non_power_of_two_topk() -> None:
+    selected_experts = torch.tensor(
+        [[0, 2, 4, 6, 8, 10], [1, 3, 5, 7, 9, 11]],
+        dtype=torch.int64,
+        device="cuda",
+    )
+    routing_weights = torch.arange(12, dtype=torch.float32, device="cuda").view(2, 6)
+
+    routing_data, gather_idx, scatter_idx = _routing_from_precomputed(
+        selected_experts,
+        routing_weights,
+        num_experts=256,
+    )
+
+    expected_order = torch.argsort(selected_experts.reshape(-1), stable=True).to(torch.int32)
+    expected_inverse = torch.argsort(expected_order, stable=True).to(torch.int32)
+    expected_hist = torch.zeros(256, dtype=torch.int32, device="cuda")
+    expected_hist[:12] = 1
+
+    assert routing_data.n_expts_act == 6
+    assert routing_data.n_expts_tot == 256
+    torch.testing.assert_close(routing_data.expt_hist, expected_hist)
+    torch.testing.assert_close(gather_idx.src_indx, expected_order)
+    torch.testing.assert_close(gather_idx.dst_indx, expected_inverse)
+    torch.testing.assert_close(scatter_idx.src_indx, expected_inverse)
+    torch.testing.assert_close(scatter_idx.dst_indx, expected_order)
+    torch.testing.assert_close(
+        routing_data.gate_scal,
+        routing_weights.reshape(-1)[expected_order.to(torch.int64)],
+    )
+
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_routing_data, captured_gather_idx, captured_scatter_idx = (
+            _routing_from_precomputed(
+                selected_experts,
+                routing_weights,
+                num_experts=256,
+            )
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(captured_routing_data.expt_hist, expected_hist)
+    torch.testing.assert_close(captured_gather_idx.src_indx, expected_order)
+    torch.testing.assert_close(captured_gather_idx.dst_indx, expected_inverse)
+    torch.testing.assert_close(captured_scatter_idx.src_indx, expected_inverse)
+    torch.testing.assert_close(captured_scatter_idx.dst_indx, expected_order)
+    torch.testing.assert_close(
+        captured_routing_data.gate_scal,
+        routing_weights.reshape(-1)[expected_order.to(torch.int64)],
+    )
+
+
 class _FromRoutingExportModule(nn.Module):
     def __init__(self) -> None:
         super().__init__()
@@ -406,13 +471,13 @@ def _trace_canonical_moe() -> torch.fx.GraphModule:
     return torch.fx.symbolic_trace(_CanonicalMoEModule())
 
 
-def test_lowering_skeleton_raises_clear_error_for_production_path() -> None:
+def test_lowering_bridge_rejects_non_layered_graph_with_clear_error() -> None:
     gm = _trace_canonical_moe()
     transform = DeepSeekV4MoELowering.from_kwargs(stage=Stages.POST_LOAD_FUSION)
 
     with pytest.raises(
         DeepSeekV4MoELoweringError,
-        match="triton_mxfp4_moe.*FineGrained FP8.*swiglu_limit",
+        match="requires routed w1 weights.*stack of per-expert get_attr",
     ):
         transform._apply(gm, None, None, SharedConfig())
 
@@ -436,3 +501,129 @@ def test_lowering_skeleton_can_opt_into_reference_graph_for_tests() -> None:
 
     hidden_states = torch.randn(4, 2, dtype=torch.float32)
     torch.testing.assert_close(lowered(hidden_states), module(hidden_states))
+
+
+class _LayeredMoEBlock(nn.Module):
+    def __init__(self, config: DeepseekV4Config) -> None:
+        super().__init__()
+        self.ffn = DeepseekV4MoE(config, layer_idx=0)
+
+    def forward(self, hidden_states: torch.Tensor, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.ffn(hidden_states, input_ids)
+
+
+class _LayeredMoEModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        config = DeepseekV4Config(
+            vocab_size=16,
+            hidden_size=64,
+            moe_intermediate_size=32,
+            n_routed_experts=2,
+            n_shared_experts=1,
+            num_experts_per_tok=1,
+            num_hash_layers=0,
+            scoring_func="sqrtsoftplus",
+            routed_scaling_factor=1.0,
+            swiglu_limit=10.0,
+        )
+        self.layers = nn.ModuleList([_LayeredMoEBlock(config)])
+
+    def forward(self, hidden_states: torch.Tensor, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.layers[0](hidden_states, input_ids)
+
+
+def _pack_fp4(logical_values: torch.Tensor) -> torch.Tensor:
+    low = logical_values[..., 0::2] & 0x0F
+    high = (logical_values[..., 1::2] & 0x0F) << 4
+    return (low | high).contiguous().view(torch.int8)
+
+
+def _logical_fp4(rows: int, cols: int, offset: int) -> torch.Tensor:
+    return (torch.arange(rows * cols, dtype=torch.uint8).reshape(rows, cols) + offset) & 0x0F
+
+
+def _packed_checkpoint_state() -> dict[str, torch.Tensor]:
+    state: dict[str, torch.Tensor] = {}
+    hidden_size = 64
+    intermediate_size = 32
+    for expert_idx in range(2):
+        prefix = f"layers.0.ffn.experts.{expert_idx}"
+        state[f"{prefix}.w1.weight"] = _pack_fp4(
+            _logical_fp4(intermediate_size, hidden_size, 1 + expert_idx)
+        )
+        state[f"{prefix}.w2.weight"] = _pack_fp4(
+            _logical_fp4(hidden_size, intermediate_size, 5 + expert_idx)
+        )
+        state[f"{prefix}.w3.weight"] = _pack_fp4(
+            _logical_fp4(intermediate_size, hidden_size, 9 + expert_idx)
+        )
+        state[f"{prefix}.w1.scale"] = torch.full(
+            (intermediate_size, hidden_size // 32), 17 + expert_idx, dtype=torch.uint8
+        )
+        state[f"{prefix}.w2.scale"] = torch.full(
+            (hidden_size, intermediate_size // 32), 29 + expert_idx, dtype=torch.uint8
+        )
+        state[f"{prefix}.w3.scale"] = torch.full(
+            (intermediate_size, hidden_size // 32), 43 + expert_idx, dtype=torch.uint8
+        )
+
+    for proj, shape in (("w1", (32, 64)), ("w2", (64, 32)), ("w3", (32, 64))):
+        state[f"layers.0.ffn.shared_experts.{proj}.weight"] = torch.zeros(
+            shape, dtype=torch.float8_e4m3fn
+        )
+        state[f"layers.0.ffn.shared_experts.{proj}.scale"] = torch.ones((1, 1), dtype=torch.float32)
+    return state
+
+
+def test_lowering_bridge_loads_packed_mxfp4_checkpoint_without_dense_shape_mismatch() -> None:
+    model = _LayeredMoEModel()
+    gm = torch_export_to_gm(
+        model,
+        args=(torch.randn(1, 2, 64), torch.ones(1, 2, dtype=torch.long)),
+    )
+    transform = DeepSeekV4MoELowering.from_kwargs(stage=Stages.PATTERN_MATCHER)
+
+    lowered, info = transform._apply(gm, None, None, SharedConfig())
+    targets = [node.target for node in lowered.graph.nodes]
+
+    assert info.num_matches == 1
+    assert torch.ops.auto_deploy.torch_deepseek_v4_router.default in targets
+    assert torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing.default in targets
+    assert torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear.default in targets
+    assert not any(
+        is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_moe) for node in lowered.graph.nodes
+    )
+
+    state_dict = _packed_checkpoint_state()
+    load_result = lowered.load_state_dict(state_dict, strict=False)
+    expected_layout = load_deepseek_v4_mxfp4_experts(
+        _packed_checkpoint_state(),
+        layer_idx=0,
+        hidden_size=64,
+        intermediate_size=32,
+        num_experts=2,
+    )
+
+    assert load_result.unexpected_keys == []
+    torch.testing.assert_close(
+        lowered.get_parameter("layers.0.ffn.mxfp4_gate_up_blocks"),
+        expected_layout.gate_up_blocks,
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        lowered.get_parameter("layers.0.ffn.mxfp4_down_scales"),
+        expected_layout.down_scales,
+        rtol=0,
+        atol=0,
+    )
+    assert (
+        lowered.get_parameter("layers.0.ffn.shared_experts.w1.weight").dtype == torch.float8_e4m3fn
+    )
+    torch.testing.assert_close(
+        lowered.get_buffer("layers.0.ffn.shared_experts.w1.weight_scale_inv"),
+        torch.ones((1, 1), dtype=torch.float32),
+        rtol=0,
+        atol=0,
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py
@@ -20,11 +20,16 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe import mxfp4_moe
 from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.deepseek_v4_moe import (
     deepseek_v4_limited_swiglu,
     deepseek_v4_moe_reference,
 )
-from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.mxfp4_moe import _routing_from_precomputed
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.mxfp4_moe import (
+    _deepseek_v4_swiglu_torch,
+    _interleave_deepseek_v4_gate_up,
+    _routing_from_precomputed,
+)
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4Config,
@@ -223,6 +228,77 @@ def test_limited_swiglu_limit_ten_clamps_gate_and_up() -> None:
     expected = F.silu(torch.tensor([[10.0, -20.0]])) * torch.tensor([[10.0, -10.0]])
 
     torch.testing.assert_close(actual, expected)
+
+
+def test_deepseek_v4_mxfp4_swiglu_matches_reference_without_gptoss_offset() -> None:
+    gate_up_interleaved = torch.tensor([[20.0, 15.0, -20.0, -15.0]], dtype=torch.float32)
+
+    actual = _deepseek_v4_swiglu_torch(gate_up_interleaved, alpha=1.0, limit=10.0)
+
+    expected_gate = torch.tensor([[10.0, -20.0]], dtype=torch.float32)
+    expected_up = torch.tensor([[10.0, -10.0]], dtype=torch.float32)
+    expected = F.silu(expected_gate) * expected_up
+    gptoss_style = F.silu(expected_gate) * (expected_up + 1)
+
+    torch.testing.assert_close(actual, expected)
+    assert not torch.allclose(actual, gptoss_style)
+
+
+def test_deepseek_v4_mxfp4_interleaves_checkpoint_gate_up_order() -> None:
+    checkpoint_order = torch.tensor([[30, 31, 32, 10, 11, 12]], dtype=torch.uint8)
+
+    actual = _interleave_deepseek_v4_gate_up(checkpoint_order)
+
+    expected = torch.tensor([[10, 30, 11, 31, 12, 32]], dtype=torch.uint8)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_prepare_weights_scales_interleaves_deepseek_gate_up_before_swizzle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeSwizzledTensor:
+        shape: torch.Size | None = None
+
+    swizzle_calls = []
+
+    def _fake_swizzle_mxfp4(
+        weight: torch.Tensor, weight_scale: torch.Tensor
+    ) -> tuple[_FakeSwizzledTensor, _FakeSwizzledTensor]:
+        swizzle_calls.append((weight.clone(), weight_scale.clone()))
+        return _FakeSwizzledTensor(), _FakeSwizzledTensor()
+
+    monkeypatch.setattr(mxfp4_moe, "_swizzle_mxfp4", _fake_swizzle_mxfp4)
+    mxfp4_moe._clear_mxfp4_weights_scales_cache()
+    hidden_size = 64
+    intermediate_size = 32
+    gate_up_blocks = (
+        torch.arange(2 * intermediate_size, dtype=torch.uint8)
+        .view(1, 2 * intermediate_size, 1, 1)
+        .expand(1, 2 * intermediate_size, hidden_size // 32, 16)
+        .contiguous()
+    )
+    gate_up_scales = (
+        torch.arange(2 * intermediate_size, dtype=torch.uint8)
+        .view(1, 2 * intermediate_size, 1)
+        .expand(1, 2 * intermediate_size, hidden_size // 32)
+        .contiguous()
+    )
+    down_blocks = torch.zeros((1, hidden_size, intermediate_size // 32, 16), dtype=torch.uint8)
+    down_scales = torch.zeros((1, hidden_size, intermediate_size // 32), dtype=torch.uint8)
+
+    mxfp4_moe._prepare_weights_scales(
+        hidden_size,
+        gate_up_blocks,
+        gate_up_scales,
+        down_blocks,
+        down_scales,
+        interleave_gate_up=True,
+    )
+
+    gate_up_weight, gate_up_scale = swizzle_calls[0]
+    expected_prefix = torch.tensor([32, 0, 33, 1, 34, 2, 35, 3], dtype=torch.uint8)
+    torch.testing.assert_close(gate_up_weight[0, 0, :8], expected_prefix, rtol=0, atol=0)
+    torch.testing.assert_close(gate_up_scale[0, 0, :8], expected_prefix, rtol=0, atol=0)
 
 
 def test_from_routing_limit_zero_zeroes_routed_output_without_shared_expert() -> None:
@@ -464,31 +540,31 @@ def _uint8_pattern(shape: tuple[int, ...], offset: int) -> torch.Tensor:
 
 
 class _MXFP4FromRoutingShardingModule(nn.Module):
-    def __init__(self) -> None:
+    def __init__(self, num_experts: int = 4) -> None:
         super().__init__()
         self.ffn = nn.Module()
         self.ffn.gate_up_blocks = nn.Parameter(
-            _uint8_pattern((4, 8, 2, 16), 1),
+            _uint8_pattern((num_experts, 8, 2, 16), 1),
             requires_grad=False,
         )
         self.ffn.gate_up_bias = nn.Parameter(
-            torch.arange(4 * 8, dtype=torch.float32).reshape(4, 8),
+            torch.arange(num_experts * 8, dtype=torch.float32).reshape(num_experts, 8),
             requires_grad=False,
         )
         self.ffn.gate_up_scales = nn.Parameter(
-            _uint8_pattern((4, 8, 2), 11),
+            _uint8_pattern((num_experts, 8, 2), 11),
             requires_grad=False,
         )
         self.ffn.down_blocks = nn.Parameter(
-            _uint8_pattern((4, 4, 2, 16), 23),
+            _uint8_pattern((num_experts, 4, 2, 16), 23),
             requires_grad=False,
         )
         self.ffn.down_bias = nn.Parameter(
-            torch.arange(4 * 4, dtype=torch.float32).reshape(4, 4).add(100),
+            torch.arange(num_experts * 4, dtype=torch.float32).reshape(num_experts, 4).add(100),
             requires_grad=False,
         )
         self.ffn.down_scales = nn.Parameter(
-            _uint8_pattern((4, 4, 2), 37),
+            _uint8_pattern((num_experts, 4, 2), 37),
             requires_grad=False,
         )
 
@@ -514,8 +590,8 @@ class _MXFP4FromRoutingShardingModule(nn.Module):
         )
 
 
-def _trace_mxfp4_from_routing_sharding_module() -> torch.fx.GraphModule:
-    gm = torch.fx.symbolic_trace(_MXFP4FromRoutingShardingModule())
+def _trace_mxfp4_from_routing_sharding_module(num_experts: int = 4) -> torch.fx.GraphModule:
+    gm = torch.fx.symbolic_trace(_MXFP4FromRoutingShardingModule(num_experts))
     params_and_buffers = dict(gm.named_parameters())
     params_and_buffers.update(dict(gm.named_buffers()))
     for node in gm.graph.nodes:
@@ -590,6 +666,43 @@ def test_deepseek_v4_mxfp4_from_routing_shards_experts_and_localizes_ids() -> No
             rtol=0,
             atol=0,
         )
+
+
+def test_deepseek_v4_mxfp4_from_routing_ep8_localizes_rank7_global_ids() -> None:
+    gm = _trace_mxfp4_from_routing_sharding_module(num_experts=16)
+    full_state = {name: tensor.detach().clone() for name, tensor in gm.named_parameters()}
+
+    transformed, info = _run_ir_sharding(gm, rank=7, world_size=8)
+
+    assert info.num_matches == 1
+    for name, full_tensor in full_state.items():
+        local_tensor = transformed.get_parameter(name)
+        assert local_tensor.shape[0] == 2
+        torch.testing.assert_close(local_tensor, full_tensor[14:16], rtol=0, atol=0)
+
+    moe_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.triton_deepseek_v4_mxfp4_moe_from_routing,
+        )
+    )
+    selected_local = moe_node.args[1]
+    routing_local = moe_node.args[2]
+    assert selected_local.target == operator.mul
+    assert routing_local.target == operator.mul
+    assert selected_local.args[1] is routing_local.args[1]
+    local_ids = selected_local.args[0]
+    assert local_ids.target == operator.sub
+    assert local_ids.args[1] == 14
+    rank_mask = selected_local.args[1]
+    ge_lower, lt_upper = rank_mask.args
+    assert rank_mask.target == torch.logical_and
+    assert ge_lower.target == torch.ge
+    assert ge_lower.args[1] == 14
+    assert lt_upper.target == torch.lt
+    assert lt_upper.args[1] == 16
 
 
 class _CanonicalMoEModule(nn.Module):

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_mxfp4_loader.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_mxfp4_loader.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.auto_deploy.transform.library.deepseek_v4_mxfp4 import (
+    DeepSeekV4ExpertKey,
+    DeepSeekV4MXFP4LoaderError,
+    expert_parallel_slice,
+    load_deepseek_v4_mxfp4_experts,
+    parse_deepseek_v4_expert_key,
+    slice_deepseek_v4_mxfp4_experts,
+)
+
+_HAS_E8M0 = hasattr(torch, "float8_e8m0fnu")
+_requires_e8m0 = pytest.mark.skipif(
+    not _HAS_E8M0,
+    reason="torch.float8_e8m0fnu is not available in this PyTorch build",
+)
+
+
+def _pack_fp4(logical_values: torch.Tensor) -> torch.Tensor:
+    assert logical_values.dtype == torch.uint8
+    assert logical_values.shape[-1] % 2 == 0
+    low = logical_values[..., 0::2] & 0x0F
+    high = (logical_values[..., 1::2] & 0x0F) << 4
+    return (low | high).contiguous().view(torch.int8)
+
+
+def _unpack_fp4(packed_values: torch.Tensor) -> torch.Tensor:
+    raw = packed_values.view(torch.uint8)
+    unpacked = torch.empty(
+        (*raw.shape[:-1], raw.shape[-1] * 2), dtype=torch.uint8, device=raw.device
+    )
+    unpacked[..., 0::2] = raw & 0x0F
+    unpacked[..., 1::2] = raw >> 4
+    return unpacked
+
+
+def _logical_fp4(rows: int, cols: int, offset: int) -> torch.Tensor:
+    return (torch.arange(rows * cols, dtype=torch.uint8).reshape(rows, cols) + offset) & 0x0F
+
+
+def _scale_bytes(rows: int, cols: int, offset: int) -> torch.Tensor:
+    return (
+        torch.arange(rows * cols, dtype=torch.uint8).reshape(rows, cols) * 3 + offset
+    ).contiguous()
+
+
+def _make_expert_state(
+    *,
+    layer_idx: int,
+    expert_idx: int,
+    hidden_size: int,
+    intermediate_size: int,
+    scale_dtype: torch.dtype = torch.uint8,
+) -> tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
+    prefix = f"layers.{layer_idx}.ffn.experts.{expert_idx}"
+    logical = {
+        "w1": _logical_fp4(intermediate_size, hidden_size, 1 + expert_idx),
+        "w2": _logical_fp4(hidden_size, intermediate_size, 5 + expert_idx),
+        "w3": _logical_fp4(intermediate_size, hidden_size, 9 + expert_idx),
+    }
+    scales = {
+        "w1": _scale_bytes(intermediate_size, hidden_size // 32, 17 + expert_idx),
+        "w2": _scale_bytes(hidden_size, intermediate_size // 32, 29 + expert_idx),
+        "w3": _scale_bytes(intermediate_size, hidden_size // 32, 43 + expert_idx),
+    }
+
+    state = {}
+    for proj in ("w1", "w2", "w3"):
+        state[f"{prefix}.{proj}.weight"] = _pack_fp4(logical[proj])
+        scale = scales[proj]
+        if scale_dtype != torch.uint8:
+            scale = scale.view(scale_dtype)
+        state[f"{prefix}.{proj}.scale"] = scale
+    return state, {"logical": logical, "scales": scales}
+
+
+def _make_state_dict(
+    *,
+    num_experts: int,
+    layer_idx: int = 3,
+    hidden_size: int = 64,
+    intermediate_size: int = 32,
+    scale_dtype: torch.dtype = torch.uint8,
+) -> tuple[dict[str, torch.Tensor], dict[int, dict[str, torch.Tensor]]]:
+    state: dict[str, torch.Tensor] = {}
+    expected = {}
+    for expert_idx in range(num_experts):
+        expert_state, expert_expected = _make_expert_state(
+            layer_idx=layer_idx,
+            expert_idx=expert_idx,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            scale_dtype=scale_dtype,
+        )
+        state.update(expert_state)
+        expected[expert_idx] = expert_expected
+    return state, expected
+
+
+def test_parse_deepseek_v4_expert_key_accepts_only_routed_expert_tensors() -> None:
+    assert parse_deepseek_v4_expert_key("layers.12.ffn.experts.34.w2.scale") == (
+        DeepSeekV4ExpertKey(layer_idx=12, expert_idx=34, proj="w2", suffix="scale")
+    )
+    assert parse_deepseek_v4_expert_key("layers.0.ffn.experts.1.w3.weight") == (
+        DeepSeekV4ExpertKey(layer_idx=0, expert_idx=1, proj="w3", suffix="weight")
+    )
+
+    assert parse_deepseek_v4_expert_key("layers.0.ffn.shared_experts.w1.weight") is None
+    assert parse_deepseek_v4_expert_key("layers.0.ffn.experts.1.w4.weight") is None
+    assert parse_deepseek_v4_expert_key("model.layers.0.ffn.experts.1.w1.weight") is None
+
+
+def test_loader_stacks_packed_blocks_in_w3_w1_runtime_order() -> None:
+    hidden_size = 64
+    intermediate_size = 32
+    state, expected = _make_state_dict(
+        num_experts=2,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+    )
+
+    layout = load_deepseek_v4_mxfp4_experts(
+        state,
+        layer_idx=3,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=2,
+    )
+
+    assert layout.gate_up_blocks.shape == (2, 2 * intermediate_size, hidden_size // 32, 16)
+    assert layout.gate_up_scales.shape == (2, 2 * intermediate_size, hidden_size // 32)
+    assert layout.down_blocks.shape == (2, hidden_size, intermediate_size // 32, 16)
+    assert layout.down_scales.shape == (2, hidden_size, intermediate_size // 32)
+    assert layout.gate_up_blocks.dtype == torch.uint8
+    assert layout.gate_up_scales.dtype == torch.uint8
+    assert layout.down_blocks.dtype == torch.uint8
+    assert layout.down_scales.dtype == torch.uint8
+    assert layout.expert_indices == (0, 1)
+
+    first_expert = expected[0]
+    gate_up_packed = layout.gate_up_blocks[0].reshape(2 * intermediate_size, hidden_size // 2)
+    down_packed = layout.down_blocks[0].reshape(hidden_size, intermediate_size // 2)
+
+    torch.testing.assert_close(
+        _unpack_fp4(gate_up_packed[:intermediate_size]),
+        first_expert["logical"]["w3"],
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        _unpack_fp4(gate_up_packed[intermediate_size:]),
+        first_expert["logical"]["w1"],
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        _unpack_fp4(down_packed),
+        first_expert["logical"]["w2"],
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        layout.gate_up_scales[0, :intermediate_size],
+        first_expert["scales"]["w3"],
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        layout.gate_up_scales[0, intermediate_size:],
+        first_expert["scales"]["w1"],
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(layout.down_scales[0], first_expert["scales"]["w2"], rtol=0, atol=0)
+
+
+@_requires_e8m0
+def test_loader_preserves_e8m0_scale_exponent_bytes() -> None:
+    hidden_size = 64
+    intermediate_size = 32
+    state, expected = _make_state_dict(
+        num_experts=1,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        scale_dtype=torch.float8_e8m0fnu,
+    )
+
+    layout = load_deepseek_v4_mxfp4_experts(
+        state,
+        layer_idx=3,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=1,
+    )
+
+    w3_scale_key = "layers.3.ffn.experts.0.w3.scale"
+    numeric_conversion = state[w3_scale_key].to(torch.uint8)
+
+    torch.testing.assert_close(
+        layout.gate_up_scales[0, :intermediate_size],
+        expected[0]["scales"]["w3"],
+        rtol=0,
+        atol=0,
+    )
+    assert not torch.equal(numeric_conversion, expected[0]["scales"]["w3"])
+
+
+def test_loader_validates_required_shapes() -> None:
+    state, _ = _make_state_dict(num_experts=1, hidden_size=64, intermediate_size=32)
+    state["layers.3.ffn.experts.0.w1.weight"] = torch.zeros((32, 31), dtype=torch.int8)
+
+    with pytest.raises(DeepSeekV4MXFP4LoaderError, match=r"w1\.weight.*expected \[32, 32\]"):
+        load_deepseek_v4_mxfp4_experts(
+            state,
+            layer_idx=3,
+            hidden_size=64,
+            intermediate_size=32,
+            num_experts=1,
+        )
+
+
+def test_loader_rejects_missing_expert_keys() -> None:
+    state, _ = _make_state_dict(num_experts=1, hidden_size=64, intermediate_size=32)
+    del state["layers.3.ffn.experts.0.w2.scale"]
+
+    with pytest.raises(DeepSeekV4MXFP4LoaderError, match="Missing.*w2\\.scale"):
+        load_deepseek_v4_mxfp4_experts(
+            state,
+            layer_idx=3,
+            hidden_size=64,
+            intermediate_size=32,
+            num_experts=1,
+        )
+
+
+def test_loader_can_stack_explicit_expert_subset_in_requested_order() -> None:
+    state, expected = _make_state_dict(num_experts=4, hidden_size=64, intermediate_size=32)
+
+    layout = load_deepseek_v4_mxfp4_experts(
+        state,
+        layer_idx=3,
+        hidden_size=64,
+        intermediate_size=32,
+        num_experts=4,
+        expert_indices=(3, 1),
+    )
+
+    assert layout.expert_indices == (3, 1)
+    torch.testing.assert_close(
+        _unpack_fp4(layout.gate_up_blocks[0, :32].reshape(32, 32)),
+        expected[3]["logical"]["w3"],
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        _unpack_fp4(layout.gate_up_blocks[1, :32].reshape(32, 32)),
+        expected[1]["logical"]["w3"],
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_expert_parallel_split_slices_only_expert_dimension() -> None:
+    state, _ = _make_state_dict(num_experts=8, hidden_size=64, intermediate_size=32)
+    layout = load_deepseek_v4_mxfp4_experts(
+        state,
+        layer_idx=3,
+        hidden_size=64,
+        intermediate_size=32,
+        num_experts=8,
+    )
+
+    assert expert_parallel_slice(8, ep_size=2, ep_rank=0) == slice(0, 4)
+    assert expert_parallel_slice(8, ep_size=2, ep_rank=1) == slice(4, 8)
+
+    rank_one = slice_deepseek_v4_mxfp4_experts(layout, ep_size=2, ep_rank=1)
+
+    assert rank_one.expert_indices == (4, 5, 6, 7)
+    assert rank_one.gate_up_blocks.shape == layout.gate_up_blocks[4:8].shape
+    torch.testing.assert_close(rank_one.gate_up_blocks, layout.gate_up_blocks[4:8])
+    torch.testing.assert_close(rank_one.gate_up_scales, layout.gate_up_scales[4:8])
+    torch.testing.assert_close(rank_one.down_blocks, layout.down_blocks[4:8])
+    torch.testing.assert_close(rank_one.down_scales, layout.down_scales[4:8])

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_router.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_router.py
@@ -15,11 +15,31 @@
 
 import pytest
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe import deepseek_v4_router
 from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.deepseek_v4_router import (
+    DEEPSEEK_V4_HASH_ROUTED_LAYER_INDICES,
+    DEEPSEEK_V4_NUM_ROUTED_EXPERTS,
+    DEEPSEEK_V4_OBSERVED_EXPERTS_PER_RANK,
+    DEEPSEEK_V4_OBSERVED_MOE_EP_SIZE,
+    DEEPSEEK_V4_ROUTE_SCALE,
+    DEEPSEEK_V4_TOP_K,
+    _normalize_and_scale,
+    deepseek_v4_ep_expert_range,
+    deepseek_v4_experts_per_rank,
+    deepseek_v4_localize_expert_ids,
     deepseek_v4_router_reference,
+    is_deepseek_v4_hash_routed_layer,
 )
+
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+
+def _fail_router_reference_fallback(*args, **kwargs) -> None:
+    del args, kwargs
+    raise AssertionError("supported Triton router path must not call the torch reference router")
 
 
 def _expected_weights(
@@ -34,6 +54,68 @@ def _expected_weights(
     scores = torch.sqrt(F.softplus(logits))
     weights = scores.gather(1, selected_experts.long())
     return weights / weights.sum(dim=-1, keepdim=True) * route_scale
+
+
+def test_observed_router_contract_constants_and_layer_split() -> None:
+    assert DEEPSEEK_V4_NUM_ROUTED_EXPERTS == 256
+    assert DEEPSEEK_V4_TOP_K == 6
+    assert DEEPSEEK_V4_ROUTE_SCALE == 1.5
+    assert DEEPSEEK_V4_HASH_ROUTED_LAYER_INDICES == (0, 1, 2)
+    assert DEEPSEEK_V4_OBSERVED_MOE_EP_SIZE == 8
+    assert DEEPSEEK_V4_OBSERVED_EXPERTS_PER_RANK == 32
+
+    assert [is_deepseek_v4_hash_routed_layer(layer_idx) for layer_idx in range(5)] == [
+        True,
+        True,
+        True,
+        False,
+        False,
+    ]
+    assert deepseek_v4_experts_per_rank() == DEEPSEEK_V4_OBSERVED_EXPERTS_PER_RANK
+    assert deepseek_v4_ep_expert_range(0) == (0, 32)
+    assert deepseek_v4_ep_expert_range(7) == (224, 256)
+
+
+def test_ep_localize_global_router_ids_preserves_shape_and_masks_rank_routes() -> None:
+    selected_experts = torch.tensor([[0, 31, 32, 63, 64, 255]], dtype=torch.int64)
+    routing_weights = torch.arange(1, 7, dtype=torch.float32).view(1, 6)
+
+    metadata = deepseek_v4_localize_expert_ids(
+        selected_experts,
+        routing_weights,
+        moe_ep_size=DEEPSEEK_V4_OBSERVED_MOE_EP_SIZE,
+        moe_ep_rank=1,
+        num_global_experts=DEEPSEEK_V4_NUM_ROUTED_EXPERTS,
+    )
+
+    expected_mask = torch.tensor([[False, False, True, True, False, False]])
+    expected_local = torch.tensor([[0, 0, 0, 31, 0, 0]], dtype=torch.int64)
+    expected_weights = torch.tensor([[0.0, 0.0, 3.0, 4.0, 0.0, 0.0]])
+
+    assert metadata.local_expert_start == 32
+    assert metadata.local_expert_end == 64
+    assert metadata.experts_per_rank == 32
+    assert metadata.selected_experts_global is selected_experts
+    assert metadata.routing_weights_global is routing_weights
+    assert torch.equal(metadata.rank_mask, expected_mask)
+    torch.testing.assert_close(metadata.selected_experts_local, expected_local)
+    torch.testing.assert_close(metadata.routing_weights_local, expected_weights)
+
+
+def test_router_weight_normalization_preserves_zero_and_inf_behavior() -> None:
+    weights = torch.tensor(
+        [
+            [0.0, 0.0],
+            [float("inf"), 2.0],
+            [float("inf"), float("inf")],
+        ],
+        dtype=torch.float32,
+    )
+
+    actual = _normalize_and_scale(weights, route_scale=1.5)
+
+    expected = torch.tensor([[0.0, 0.0], [1.5, 0.0], [0.75, 0.75]], dtype=torch.float32)
+    torch.testing.assert_close(actual, expected)
 
 
 def test_hash_router_uses_tid2eid_and_normalizes_scaled_weights() -> None:
@@ -241,3 +323,357 @@ def test_custom_op_matches_reference_and_has_meta_fake() -> None:
     assert meta_weights.shape == (6, 3)
     assert meta_weights.dtype == torch.float32
     assert meta_weights.device.type == "meta"
+
+
+def test_triton_router_cpu_fallback_matches_reference_for_hash_and_topk() -> None:
+    hidden_states = torch.tensor(
+        [
+            [0.25, -0.5, 1.0],
+            [1.25, 0.5, -0.25],
+        ],
+        dtype=torch.float32,
+    )
+    input_ids = torch.tensor([2, 0], dtype=torch.long)
+    router_weight = torch.tensor(
+        [
+            [0.5, -0.25, 0.75],
+            [-0.75, 0.5, 0.125],
+            [0.25, 0.75, -0.5],
+            [0.625, -0.125, 0.25],
+        ],
+        dtype=torch.float32,
+    )
+    router_bias = torch.tensor([0.0, 0.5, -0.25, 0.125], dtype=torch.float32)
+    tid2eid = torch.tensor(
+        [
+            [3, 1],
+            [2, 0],
+            [1, 2],
+        ],
+        dtype=torch.int32,
+    )
+
+    expected_hash = deepseek_v4_router_reference(
+        hidden_states,
+        input_ids,
+        router_weight,
+        router_bias=None,
+        tid2eid=tid2eid,
+        top_k=2,
+        route_scale=DEEPSEEK_V4_ROUTE_SCALE,
+        is_hash_layer=True,
+    )
+    actual_hash = torch.ops.auto_deploy.triton_deepseek_v4_router.default(
+        hidden_states,
+        input_ids,
+        router_weight,
+        None,
+        tid2eid,
+        2,
+        DEEPSEEK_V4_ROUTE_SCALE,
+        True,
+    )
+
+    expected_topk = deepseek_v4_router_reference(
+        hidden_states,
+        input_ids=None,
+        router_weight=router_weight,
+        router_bias=router_bias,
+        tid2eid=None,
+        top_k=2,
+        route_scale=1.25,
+        is_hash_layer=False,
+    )
+    actual_topk = torch.ops.auto_deploy.triton_deepseek_v4_router.default(
+        hidden_states,
+        None,
+        router_weight,
+        router_bias,
+        None,
+        2,
+        1.25,
+        False,
+    )
+
+    torch.testing.assert_close(actual_hash[0], expected_hash[0])
+    torch.testing.assert_close(actual_hash[1], expected_hash[1])
+    torch.testing.assert_close(actual_topk[0], expected_topk[0])
+    torch.testing.assert_close(actual_topk[1], expected_topk[1])
+
+
+def test_triton_router_fake_shapes_for_hash_topk_and_source_wrapper() -> None:
+    meta_hidden = torch.empty((2, 3, 4096), device="meta", dtype=torch.bfloat16)
+    meta_input_ids = torch.empty((2, 3), device="meta", dtype=torch.int64)
+    meta_weight = torch.empty(
+        (DEEPSEEK_V4_NUM_ROUTED_EXPERTS, 4096), device="meta", dtype=torch.bfloat16
+    )
+    meta_bias = torch.empty((DEEPSEEK_V4_NUM_ROUTED_EXPERTS,), device="meta", dtype=torch.float32)
+    meta_tid2eid = torch.empty((129280, DEEPSEEK_V4_TOP_K), device="meta", dtype=torch.int64)
+
+    hash_selected, hash_weights = torch.ops.auto_deploy.triton_deepseek_v4_router_hash.default(
+        meta_hidden,
+        meta_input_ids,
+        meta_weight,
+        meta_tid2eid,
+        DEEPSEEK_V4_TOP_K,
+        DEEPSEEK_V4_ROUTE_SCALE,
+    )
+    topk_selected, topk_weights = torch.ops.auto_deploy.triton_deepseek_v4_router_topk.default(
+        meta_hidden,
+        meta_weight,
+        meta_bias,
+        DEEPSEEK_V4_TOP_K,
+        DEEPSEEK_V4_ROUTE_SCALE,
+    )
+    wrapper_selected, wrapper_weights = torch.ops.auto_deploy.triton_deepseek_v4_router.default(
+        meta_hidden,
+        meta_input_ids,
+        meta_weight,
+        None,
+        meta_tid2eid,
+        DEEPSEEK_V4_TOP_K,
+        DEEPSEEK_V4_ROUTE_SCALE,
+        True,
+    )
+
+    assert hash_selected.shape == (6, DEEPSEEK_V4_TOP_K)
+    assert hash_selected.dtype == torch.int64
+    assert hash_weights.shape == (6, DEEPSEEK_V4_TOP_K)
+    assert hash_weights.dtype == torch.float32
+    assert topk_selected.shape == (6, DEEPSEEK_V4_TOP_K)
+    assert topk_selected.dtype == torch.int64
+    assert topk_weights.shape == (6, DEEPSEEK_V4_TOP_K)
+    assert topk_weights.dtype == torch.float32
+    assert wrapper_selected.shape == (6, DEEPSEEK_V4_TOP_K)
+    assert wrapper_selected.dtype == torch.int64
+    assert wrapper_weights.shape == (6, DEEPSEEK_V4_TOP_K)
+    assert wrapper_weights.dtype == torch.float32
+
+
+class _TritonHashRouterExportModule(nn.Module):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        router_weight: torch.Tensor,
+        tid2eid: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.ops.auto_deploy.triton_deepseek_v4_router.default(
+            hidden_states,
+            input_ids,
+            router_weight,
+            None,
+            tid2eid,
+            2,
+            DEEPSEEK_V4_ROUTE_SCALE,
+            True,
+        )
+
+
+class _TritonTopKRouterExportModule(nn.Module):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_weight: torch.Tensor,
+        router_bias: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.ops.auto_deploy.triton_deepseek_v4_router.default(
+            hidden_states,
+            None,
+            router_weight,
+            router_bias,
+            None,
+            2,
+            DEEPSEEK_V4_ROUTE_SCALE,
+            False,
+        )
+
+
+def test_triton_router_source_wrapper_exports_triton_op_name() -> None:
+    hash_graph = torch.fx.symbolic_trace(_TritonHashRouterExportModule())
+    topk_graph = torch.fx.symbolic_trace(_TritonTopKRouterExportModule())
+
+    for gm in (hash_graph, topk_graph):
+        targets = [node.target for node in gm.graph.nodes]
+        assert torch.ops.auto_deploy.triton_deepseek_v4_router.default in targets
+        assert torch.ops.auto_deploy.torch_deepseek_v4_router.default not in targets
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA")
+def test_triton_hash_router_cuda_matches_reference(monkeypatch: pytest.MonkeyPatch) -> None:
+    device = torch.device("cuda")
+    hidden_states = torch.tensor(
+        [
+            [0.5, -1.0, 2.0, 0.25],
+            [1.5, 0.25, -0.75, 0.5],
+            [-1.0, 0.5, 0.25, -0.5],
+            [0.125, -0.625, 0.375, 1.25],
+        ],
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    input_ids = torch.tensor([4, 1, 3, 0], device=device, dtype=torch.int64)
+    router_weight = torch.tensor(
+        [
+            [0.25, -0.5, 0.75, 0.125],
+            [-0.5, 0.5, 0.25, -0.25],
+            [0.75, 0.25, -0.5, 0.5],
+            [0.125, -0.25, 0.5, 0.625],
+        ],
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    tid2eid = torch.tensor(
+        [
+            [0, 2, 3],
+            [3, 0, 1],
+            [2, 3, 0],
+            [1, 2, 3],
+            [2, 0, 1],
+        ],
+        device=device,
+        dtype=torch.int64,
+    )
+
+    expected = deepseek_v4_router_reference(
+        hidden_states,
+        input_ids,
+        router_weight,
+        router_bias=None,
+        tid2eid=tid2eid,
+        top_k=3,
+        route_scale=DEEPSEEK_V4_ROUTE_SCALE,
+        is_hash_layer=True,
+    )
+    assert deepseek_v4_router._deepseek_v4_router_hash_kernel is not None
+    assert deepseek_v4_router._can_use_triton_router_base(hidden_states, router_weight, 3)
+    monkeypatch.setattr(
+        deepseek_v4_router,
+        "deepseek_v4_router_reference",
+        _fail_router_reference_fallback,
+    )
+    actual = torch.ops.auto_deploy.triton_deepseek_v4_router_hash.default(
+        hidden_states,
+        input_ids,
+        router_weight,
+        tid2eid,
+        3,
+        DEEPSEEK_V4_ROUTE_SCALE,
+    )
+
+    assert actual[0].device.type == "cuda"
+    assert actual[1].device.type == "cuda"
+    torch.testing.assert_close(actual[0], expected[0])
+    torch.testing.assert_close(actual[1], expected[1], atol=1.0e-5, rtol=1.0e-5)
+    torch.testing.assert_close(
+        actual[1].sum(dim=-1),
+        torch.full((hidden_states.shape[0],), DEEPSEEK_V4_ROUTE_SCALE, device=device),
+        atol=1.0e-5,
+        rtol=1.0e-5,
+    )
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA")
+def test_triton_topk_router_cuda_matches_reference_and_bias_selection_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch.manual_seed(1234)
+    device = torch.device("cuda")
+    hidden_states = torch.randn(7, 16, device=device, dtype=torch.bfloat16)
+    router_weight = torch.randn(16, 16, device=device, dtype=torch.bfloat16)
+    router_bias = torch.linspace(-0.5, 0.75, 16, device=device, dtype=torch.float32)
+
+    expected = deepseek_v4_router_reference(
+        hidden_states,
+        input_ids=None,
+        router_weight=router_weight,
+        router_bias=router_bias,
+        tid2eid=None,
+        top_k=DEEPSEEK_V4_TOP_K,
+        route_scale=DEEPSEEK_V4_ROUTE_SCALE,
+        is_hash_layer=False,
+    )
+    assert deepseek_v4_router._deepseek_v4_router_topk_kernel is not None
+    assert deepseek_v4_router._can_use_triton_router_base(
+        hidden_states,
+        router_weight,
+        DEEPSEEK_V4_TOP_K,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_router,
+        "deepseek_v4_router_reference",
+        _fail_router_reference_fallback,
+    )
+    actual = torch.ops.auto_deploy.triton_deepseek_v4_router_topk.default(
+        hidden_states,
+        router_weight,
+        router_bias,
+        DEEPSEEK_V4_TOP_K,
+        DEEPSEEK_V4_ROUTE_SCALE,
+    )
+
+    assert actual[0].device.type == "cuda"
+    assert actual[1].device.type == "cuda"
+    scores = torch.sqrt(F.softplus(F.linear(hidden_states.float(), router_weight.float())))
+    biased_weights = (scores + router_bias).gather(1, actual[0])
+    biased_weights = _normalize_and_scale(biased_weights, DEEPSEEK_V4_ROUTE_SCALE)
+
+    torch.testing.assert_close(actual[0], expected[0])
+    torch.testing.assert_close(actual[1], expected[1], atol=1.0e-5, rtol=1.0e-5)
+    assert not torch.allclose(actual[1], biased_weights)
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA")
+def test_triton_source_router_cuda_graph_replay_fixed_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch.manual_seed(5678)
+    device = torch.device("cuda")
+    hidden_states = torch.randn(4, 8, device=device, dtype=torch.bfloat16)
+    router_weight = torch.randn(10, 8, device=device, dtype=torch.bfloat16)
+    router_bias = torch.linspace(-0.25, 0.5, 10, device=device, dtype=torch.float32)
+
+    monkeypatch.setattr(
+        deepseek_v4_router,
+        "deepseek_v4_router_reference",
+        _fail_router_reference_fallback,
+    )
+    for _ in range(3):
+        torch.ops.auto_deploy.triton_deepseek_v4_router.default(
+            hidden_states,
+            None,
+            router_weight,
+            router_bias,
+            None,
+            3,
+            1.25,
+            False,
+        )
+    torch.cuda.synchronize()
+
+    expected = torch.ops.auto_deploy.triton_deepseek_v4_router.default(
+        hidden_states,
+        None,
+        router_weight,
+        router_bias,
+        None,
+        3,
+        1.25,
+        False,
+    )
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        replayed = torch.ops.auto_deploy.triton_deepseek_v4_router.default(
+            hidden_states,
+            None,
+            router_weight,
+            router_bias,
+            None,
+            3,
+            1.25,
+            False,
+        )
+
+    graph.replay()
+    torch.testing.assert_close(replayed[0], expected[0])
+    torch.testing.assert_close(replayed[1], expected[1], atol=1.0e-5, rtol=1.0e-5)

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_router.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_router.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.deepseek_v4_router import (
+    deepseek_v4_router_reference,
+)
+
+
+def _expected_weights(
+    hidden_states: torch.Tensor,
+    router_weight: torch.Tensor,
+    selected_experts: torch.Tensor,
+    route_scale: float,
+) -> torch.Tensor:
+    logits = F.linear(
+        hidden_states.reshape(-1, hidden_states.shape[-1]).float(), router_weight.float()
+    )
+    scores = torch.sqrt(F.softplus(logits))
+    weights = scores.gather(1, selected_experts.long())
+    return weights / weights.sum(dim=-1, keepdim=True) * route_scale
+
+
+def test_hash_router_uses_tid2eid_and_normalizes_scaled_weights() -> None:
+    hidden_states = torch.tensor(
+        [
+            [0.5, -1.0, 2.0],
+            [1.5, 0.25, -0.75],
+            [-1.0, 0.5, 0.25],
+        ],
+        dtype=torch.float32,
+    )
+    input_ids = torch.tensor([4, 1, 3], dtype=torch.long)
+    router_weight = torch.tensor(
+        [
+            [0.25, -0.5, 0.75],
+            [-0.5, 0.5, 0.25],
+            [0.75, 0.25, -0.5],
+            [0.125, -0.25, 0.5],
+        ],
+        dtype=torch.float32,
+    )
+    tid2eid = torch.tensor(
+        [
+            [0, 1],
+            [3, 0],
+            [2, 3],
+            [1, 2],
+            [2, 0],
+        ],
+        dtype=torch.int32,
+    )
+    route_scale = 1.5
+
+    selected_experts, routing_weights = deepseek_v4_router_reference(
+        hidden_states,
+        input_ids,
+        router_weight,
+        router_bias=None,
+        tid2eid=tid2eid,
+        top_k=2,
+        route_scale=route_scale,
+        is_hash_layer=True,
+    )
+
+    expected_experts = tid2eid[input_ids]
+    expected_weights = _expected_weights(
+        hidden_states, router_weight, expected_experts, route_scale
+    )
+
+    torch.testing.assert_close(selected_experts, expected_experts)
+    torch.testing.assert_close(routing_weights, expected_weights)
+    torch.testing.assert_close(
+        routing_weights.sum(dim=-1),
+        torch.full((hidden_states.shape[0],), route_scale),
+    )
+
+
+def test_topk_router_bias_affects_selection_only() -> None:
+    hidden_states = torch.eye(3, dtype=torch.float32)
+    router_weight = torch.tensor(
+        [
+            [1.2, 0.0, 0.0],
+            [0.0, 1.1, 0.0],
+            [0.0, 0.0, 0.5],
+            [0.2, 0.2, 0.2],
+        ],
+        dtype=torch.float32,
+    )
+    router_bias = torch.tensor([-4.0, 0.0, 4.0, 0.0], dtype=torch.float32)
+    route_scale = 1.25
+
+    selected_experts, routing_weights = deepseek_v4_router_reference(
+        hidden_states,
+        input_ids=None,
+        router_weight=router_weight,
+        router_bias=router_bias,
+        tid2eid=None,
+        top_k=2,
+        route_scale=route_scale,
+        is_hash_layer=False,
+    )
+
+    scores = torch.sqrt(F.softplus(F.linear(hidden_states, router_weight)))
+    expected_experts = torch.topk(scores + router_bias, 2, dim=-1).indices
+    expected_weights = scores.gather(1, expected_experts)
+    expected_weights = expected_weights / expected_weights.sum(dim=-1, keepdim=True) * route_scale
+    biased_weights = (scores + router_bias).gather(1, expected_experts)
+    biased_weights = biased_weights / biased_weights.sum(dim=-1, keepdim=True) * route_scale
+
+    torch.testing.assert_close(selected_experts, expected_experts)
+    torch.testing.assert_close(routing_weights, expected_weights)
+    assert not torch.allclose(routing_weights, biased_weights)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_router_is_finite_for_large_logits(dtype: torch.dtype) -> None:
+    hidden_states = torch.tensor(
+        [
+            [1.0e20, 1.0e20],
+            [-1.0e20, -1.0e20],
+        ],
+        dtype=dtype,
+    )
+    router_weight = torch.tensor(
+        [
+            [1.0e20, 1.0e20],
+            [1.0e20, 1.0e20],
+            [1.0e20, 1.0e20],
+        ],
+        dtype=dtype,
+    )
+
+    selected_experts, routing_weights = deepseek_v4_router_reference(
+        hidden_states,
+        input_ids=None,
+        router_weight=router_weight,
+        router_bias=None,
+        tid2eid=None,
+        top_k=2,
+        route_scale=1.0,
+        is_hash_layer=False,
+    )
+
+    assert selected_experts.shape == (2, 2)
+    assert routing_weights.dtype == torch.float32
+    assert torch.isfinite(routing_weights).all()
+
+
+def test_router_flattens_batched_hidden_states_and_input_ids() -> None:
+    hidden_states = torch.randn(2, 3, 4, dtype=torch.float32)
+    input_ids = torch.tensor([[0, 1, 2], [3, 4, 5]], dtype=torch.long)
+    router_weight = torch.randn(5, 4, dtype=torch.float32)
+    tid2eid = torch.tensor(
+        [
+            [0, 1, 2],
+            [1, 2, 3],
+            [2, 3, 4],
+            [3, 4, 0],
+            [4, 0, 1],
+            [0, 2, 4],
+        ],
+        dtype=torch.int64,
+    )
+
+    selected_experts, routing_weights = deepseek_v4_router_reference(
+        hidden_states,
+        input_ids,
+        router_weight,
+        router_bias=None,
+        tid2eid=tid2eid,
+        top_k=3,
+        route_scale=0.75,
+        is_hash_layer=True,
+    )
+
+    assert selected_experts.shape == (6, 3)
+    assert routing_weights.shape == (6, 3)
+    torch.testing.assert_close(selected_experts, tid2eid[input_ids.reshape(-1)])
+
+
+def test_custom_op_matches_reference_and_has_meta_fake() -> None:
+    hidden_states = torch.randn(4, 3, dtype=torch.float32)
+    router_weight = torch.randn(6, 3, dtype=torch.float32)
+    router_bias = torch.randn(6, dtype=torch.float32)
+
+    expected = deepseek_v4_router_reference(
+        hidden_states,
+        input_ids=None,
+        router_weight=router_weight,
+        router_bias=router_bias,
+        tid2eid=None,
+        top_k=2,
+        route_scale=1.0,
+        is_hash_layer=False,
+    )
+    actual = torch.ops.auto_deploy.torch_deepseek_v4_router.default(
+        hidden_states,
+        None,
+        router_weight,
+        router_bias,
+        None,
+        2,
+        1.0,
+        False,
+    )
+
+    torch.testing.assert_close(actual[0], expected[0])
+    torch.testing.assert_close(actual[1], expected[1])
+
+    meta_hidden = torch.empty((2, 3, 4), device="meta", dtype=torch.bfloat16)
+    meta_weight = torch.empty((5, 4), device="meta", dtype=torch.bfloat16)
+    meta_selected, meta_weights = torch.ops.auto_deploy.torch_deepseek_v4_router.default(
+        meta_hidden,
+        None,
+        meta_weight,
+        None,
+        None,
+        3,
+        1.0,
+        False,
+    )
+
+    assert meta_selected.shape == (6, 3)
+    assert meta_selected.dtype == torch.int64
+    assert meta_weights.shape == (6, 3)
+    assert meta_weights.dtype == torch.float32
+    assert meta_weights.device.type == "meta"

--- a/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_mxfp4_moe_runtime_cache.py
+++ b/tests/unittest/_torch/auto_deploy/unit/fused_moe/test_mxfp4_moe_runtime_cache.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Generator
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe import mxfp4_moe
+
+
+class _FakeSwizzledTensor:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.shape: torch.Size | None = None
+
+
+@pytest.fixture(autouse=True)
+def _clear_mxfp4_cache() -> Generator[None, None, None]:
+    mxfp4_moe._clear_mxfp4_weights_scales_cache()
+    yield
+    mxfp4_moe._clear_mxfp4_weights_scales_cache()
+
+
+def _make_inputs(
+    hidden_size: int = 64,
+    intermediate_size: int = 64,
+    num_experts: int = 2,
+) -> tuple[int, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    gate_up_blocks = torch.zeros(
+        (num_experts, intermediate_size * 2, hidden_size // 32, 16), dtype=torch.uint8
+    )
+    gate_up_scales = torch.ones(
+        (num_experts, intermediate_size * 2, hidden_size // 32), dtype=torch.uint8
+    )
+    down_blocks = torch.zeros(
+        (num_experts, hidden_size, intermediate_size // 32, 16), dtype=torch.uint8
+    )
+    down_scales = torch.ones((num_experts, hidden_size, intermediate_size // 32), dtype=torch.uint8)
+    return hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+
+
+def _install_fake_swizzle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    calls: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+
+    def _fake_swizzle_mxfp4(
+        weight: torch.Tensor, weight_scale: torch.Tensor
+    ) -> tuple[_FakeSwizzledTensor, _FakeSwizzledTensor]:
+        calls.append((tuple(weight.shape), tuple(weight_scale.shape)))
+        call_idx = len(calls)
+        return _FakeSwizzledTensor(f"weight_{call_idx}"), _FakeSwizzledTensor(f"scale_{call_idx}")
+
+    monkeypatch.setattr(mxfp4_moe, "_swizzle_mxfp4", _fake_swizzle_mxfp4)
+    return calls
+
+
+def test_prepare_weights_scales_reuses_cached_swizzles_for_same_tensors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_swizzle(monkeypatch)
+    hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales = _make_inputs()
+
+    first = mxfp4_moe._prepare_weights_scales(
+        hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+    )
+    second = mxfp4_moe._prepare_weights_scales(
+        hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+    )
+
+    assert len(calls) == 2
+    assert all(first_item is second_item for first_item, second_item in zip(first, second))
+    assert first[0].shape == torch.Size([2, hidden_size, 128])
+    assert first[2].shape == torch.Size([2, 64, hidden_size])
+    assert calls == [
+        ((2, 32, 128), (2, 2, 128)),
+        ((2, 32, 64), (2, 2, 64)),
+    ]
+
+
+def test_prepare_weights_scales_reuses_cached_swizzles_for_inference_tensors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_swizzle(monkeypatch)
+    with torch.inference_mode():
+        (
+            hidden_size,
+            gate_up_blocks,
+            gate_up_scales,
+            down_blocks,
+            down_scales,
+        ) = _make_inputs()
+
+    first = mxfp4_moe._prepare_weights_scales(
+        hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+    )
+    second = mxfp4_moe._prepare_weights_scales(
+        hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+    )
+
+    assert len(calls) == 2
+    assert all(first_item is second_item for first_item, second_item in zip(first, second))
+
+
+def test_prepare_weights_scales_cache_key_invalidates_for_new_tensors_and_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_swizzle(monkeypatch)
+    hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales = _make_inputs()
+
+    first = mxfp4_moe._prepare_weights_scales(
+        hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+    )
+    same_shape_new_gate = gate_up_blocks.clone()
+    second = mxfp4_moe._prepare_weights_scales(
+        hidden_size, same_shape_new_gate, gate_up_scales, down_blocks, down_scales
+    )
+    smaller_gate_up_blocks = gate_up_blocks[:, :64].contiguous()
+    smaller_gate_up_scales = gate_up_scales[:, :64].contiguous()
+    smaller_down_blocks = down_blocks[:, :, :1].contiguous()
+    smaller_down_scales = down_scales[:, :, :1].contiguous()
+    third = mxfp4_moe._prepare_weights_scales(
+        hidden_size,
+        smaller_gate_up_blocks,
+        smaller_gate_up_scales,
+        smaller_down_blocks,
+        smaller_down_scales,
+    )
+
+    assert len(calls) == 6
+    assert all(first_item is not second_item for first_item, second_item in zip(first, second))
+    assert all(first_item is not third_item for first_item, third_item in zip(first, third))
+    assert calls[4:] == [
+        ((2, 32, 64), (2, 2, 64)),
+        ((2, 16, 64), (2, 1, 64)),
+    ]
+
+
+def test_prepare_weights_scales_cache_key_invalidates_for_in_place_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_swizzle(monkeypatch)
+    hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales = _make_inputs()
+    original_data_ptr = gate_up_blocks.untyped_storage().data_ptr()
+    original_version = gate_up_blocks._version
+
+    first = mxfp4_moe._prepare_weights_scales(
+        hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+    )
+    gate_up_blocks.add_(1)
+    second = mxfp4_moe._prepare_weights_scales(
+        hidden_size, gate_up_blocks, gate_up_scales, down_blocks, down_scales
+    )
+
+    assert gate_up_blocks.untyped_storage().data_ptr() == original_data_ptr
+    assert gate_up_blocks._version > original_version
+    assert len(calls) == 4
+    assert all(first_item is not second_item for first_item, second_item in zip(first, second))

--- a/tests/unittest/_torch/auto_deploy/unit/models/test_deepseek_v4_quant_config.py
+++ b/tests/unittest/_torch/auto_deploy/unit/models/test_deepseek_v4_quant_config.py
@@ -1,0 +1,215 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+
+from tensorrt_llm._torch.auto_deploy.models.deepseek_v4_quant import (
+    BF16_OR_F32,
+    FINEGRAINED_FP8_LINEAR,
+    INTEGER_METADATA,
+    PACKED_MXFP4_EXPERT,
+    SKIPPED_MTP,
+    UNKNOWN,
+    DeepSeekV4QuantConfigError,
+    classify_deepseek_v4_checkpoint,
+)
+from tensorrt_llm._torch.auto_deploy.models.quant_config_reader import HFQuantConfigReader
+
+
+def _deepseek_v4_config() -> dict[str, object]:
+    return {
+        "model_type": "deepseek_v4",
+        "quantization_config": {
+            "activation_scheme": "dynamic",
+            "fmt": "e4m3",
+            "quant_method": "fp8",
+            "scale_fmt": "ue8m0",
+            "weight_block_size": [128, 128],
+        },
+    }
+
+
+def _deepseek_v4_tensor_metadata() -> dict[str, dict[str, object]]:
+    return {
+        "embed.weight": {"dtype": "BF16", "shape": [32000, 4096]},
+        "head.weight": {"dtype": "BF16", "shape": [32000, 4096]},
+        "hc_head_base": {"dtype": "F32", "shape": [2]},
+        "layers.0.attn.attn_sink": {"dtype": "F32", "shape": [64]},
+        "layers.0.attn.compressor.wkv.weight": {"dtype": "BF16", "shape": [1024, 4096]},
+        "layers.0.attn.indexer.compressor.wkv.weight": {
+            "dtype": "BF16",
+            "shape": [1024, 4096],
+        },
+        "layers.0.attn.indexer.weights_proj.weight": {
+            "dtype": "BF16",
+            "shape": [128, 4096],
+        },
+        "layers.0.attn.indexer.wq_b.scale": {"dtype": "F8_E8M0", "shape": [64, 8]},
+        "layers.0.attn.indexer.wq_b.weight": {"dtype": "F8_E4M3", "shape": [8192, 1024]},
+        "layers.0.attn.kv_norm.weight": {"dtype": "BF16", "shape": [1024]},
+        "layers.0.attn.q_norm.weight": {"dtype": "BF16", "shape": [1024]},
+        "layers.0.attn.wq_a.scale": {"dtype": "F8_E8M0", "shape": [8, 32]},
+        "layers.0.attn.wq_a.weight": {"dtype": "F8_E4M3", "shape": [1024, 4096]},
+        "layers.0.attn_norm.weight": {"dtype": "BF16", "shape": [4096]},
+        "layers.0.ffn.experts.0.w1.scale": {"dtype": "F8_E8M0", "shape": [2048, 128]},
+        "layers.0.ffn.experts.0.w1.weight": {"dtype": "I8", "shape": [2048, 2048]},
+        "layers.0.ffn.gate.bias": {"dtype": "F32", "shape": [256]},
+        "layers.0.ffn.gate.tid2eid": {"dtype": "I64", "shape": [1024, 6]},
+        "layers.0.ffn.gate.weight": {"dtype": "BF16", "shape": [256, 4096]},
+        "layers.0.ffn.shared_experts.w1.scale": {"dtype": "F8_E8M0", "shape": [16, 32]},
+        "layers.0.ffn.shared_experts.w1.weight": {"dtype": "F8_E4M3", "shape": [2048, 4096]},
+        "layers.0.ffn_norm.weight": {"dtype": "BF16", "shape": [4096]},
+        "layers.0.hc_attn_base": {"dtype": "F32", "shape": [2]},
+        "layers.0.hc_ffn_fn": {"dtype": "F32", "shape": [2]},
+        "mtp.0.attn.wq_a.weight": {"dtype": "F8_E4M3", "shape": [1024, 4096]},
+        "norm.weight": {"dtype": "BF16", "shape": [4096]},
+    }
+
+
+def _write_deepseek_v4_checkpoint_fixture(tmp_path: Path) -> None:
+    config = _deepseek_v4_config()
+    tensor_metadata = _deepseek_v4_tensor_metadata()
+    safetensors_name = "model-00001-of-00001.safetensors"
+
+    (tmp_path / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "metadata": {"total_size": 0},
+                "weight_map": {name: safetensors_name for name in tensor_metadata},
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_safetensors_header(tmp_path / safetensors_name, tensor_metadata)
+
+
+def _write_safetensors_header(path: Path, tensor_metadata: dict[str, dict[str, object]]) -> None:
+    header = {
+        name: {
+            "dtype": metadata["dtype"],
+            "shape": metadata["shape"],
+            "data_offsets": [0, 0],
+        }
+        for name, metadata in tensor_metadata.items()
+    }
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    path.write_bytes(struct.pack("<Q", len(header_bytes)) + header_bytes)
+
+
+def test_deepseek_v4_hf_reader_returns_normalized_quant_config(tmp_path: Path) -> None:
+    _write_deepseek_v4_checkpoint_fixture(tmp_path)
+
+    result = HFQuantConfigReader.from_file(str(tmp_path))
+
+    assert result is not None
+    reader, extra_model_kwargs = result
+    assert extra_model_kwargs == {}
+    qcfg = reader.get_config()
+    assert qcfg["quant_method"] == "deepseek_v4_fp8"
+    assert qcfg["hf_quant_method"] == "fp8"
+    assert qcfg["linear_quant_method"] == "finegrained_fp8"
+    assert qcfg["expert_quant_method"] == "mxfp4"
+    assert qcfg["scale_fmt"] == "ue8m0"
+    assert qcfg["weight_block_size"] == [128, 128]
+    assert qcfg["expert_block_size"] == 32
+    assert qcfg["fmt"] == "e4m3"
+    assert qcfg["activation_scheme"] == "dynamic"
+    assert {
+        "embed",
+        "head",
+        "*.ffn.gate",
+        "*.attn.compressor",
+        "*.norm",
+        "*.hc_*",
+        "*.attn_sink",
+        "mtp.*",
+    }.issubset(set(qcfg["exclude_modules"]))
+
+
+def test_deepseek_v4_classifier_groups_quantized_and_excluded_tensors() -> None:
+    classification = classify_deepseek_v4_checkpoint(
+        _deepseek_v4_config(), _deepseek_v4_tensor_metadata()
+    )
+    categories = classification["categories"]
+
+    assert "layers.0.attn.wq_a.weight" in categories[FINEGRAINED_FP8_LINEAR]
+    assert "layers.0.attn.wq_a.scale" in categories[FINEGRAINED_FP8_LINEAR]
+    assert "layers.0.attn.indexer.wq_b.weight" in categories[FINEGRAINED_FP8_LINEAR]
+    assert "layers.0.ffn.shared_experts.w1.weight" in categories[FINEGRAINED_FP8_LINEAR]
+    assert "layers.0.ffn.experts.0.w1.weight" in categories[PACKED_MXFP4_EXPERT]
+    assert "layers.0.ffn.experts.0.w1.scale" in categories[PACKED_MXFP4_EXPERT]
+    assert "layers.0.ffn.gate.tid2eid" in categories[INTEGER_METADATA]
+    assert "mtp.0.attn.wq_a.weight" in categories[SKIPPED_MTP]
+
+    for key in (
+        "embed.weight",
+        "head.weight",
+        "norm.weight",
+        "hc_head_base",
+        "layers.0.attn.attn_sink",
+        "layers.0.attn.compressor.wkv.weight",
+        "layers.0.attn.indexer.compressor.wkv.weight",
+        "layers.0.ffn.gate.weight",
+        "layers.0.ffn.gate.bias",
+        "layers.0.hc_attn_base",
+    ):
+        assert key in categories[BF16_OR_F32]
+        assert key not in categories[FINEGRAINED_FP8_LINEAR]
+        assert key not in categories[PACKED_MXFP4_EXPERT]
+
+
+def test_deepseek_v4_classifier_fails_on_unknown_keys_unless_waived() -> None:
+    tensor_metadata = _deepseek_v4_tensor_metadata()
+    tensor_metadata["layers.0.unexpected.weight"] = {"dtype": "BF16", "shape": [16, 16]}
+
+    with pytest.raises(DeepSeekV4QuantConfigError, match="Unknown DeepSeek V4"):
+        classify_deepseek_v4_checkpoint(_deepseek_v4_config(), tensor_metadata)
+
+    classification = classify_deepseek_v4_checkpoint(
+        _deepseek_v4_config(), tensor_metadata, allow_unknown=True
+    )
+    assert "layers.0.unexpected.weight" in classification["categories"][UNKNOWN]
+
+
+def test_deepseek_v4_classifier_validates_scale_shapes() -> None:
+    tensor_metadata = _deepseek_v4_tensor_metadata()
+    tensor_metadata["layers.0.attn.wq_a.scale"] = {"dtype": "F8_E8M0", "shape": [7, 32]}
+
+    with pytest.raises(DeepSeekV4QuantConfigError, match="expected \\[8, 32\\]"):
+        classify_deepseek_v4_checkpoint(_deepseek_v4_config(), tensor_metadata)
+
+
+def test_non_deepseek_fp8_config_uses_generic_hf_behavior() -> None:
+    reader = HFQuantConfigReader()
+    reader.read_config(
+        {
+            "model_type": "llama",
+            "quantization_config": {
+                "quant_method": "fp8",
+                "exclude_modules": ["custom"],
+            },
+        }
+    )
+
+    qcfg = reader.get_config()
+    assert qcfg["quant_method"] == "fp8"
+    assert qcfg["exclude_modules"] == ["custom", "lm_head", "model.embed_tokens"]
+    assert "linear_quant_method" not in qcfg
+    assert "checkpoint_classification" not in qcfg

--- a/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
+++ b/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
@@ -24,6 +24,8 @@ from tensorrt_llm._torch.auto_deploy.transform.library.quantization import (
     FineGrainedFP8LinearQuantization,
     FP8LinearQuantizationFromConfig,
 )
+from tensorrt_llm._torch.auto_deploy.transform.library.sharding_ir import ApplyShardingHints
+from tensorrt_llm._torch.auto_deploy.utils.dist_config import DistConfig
 from tensorrt_llm._torch.auto_deploy.utils.e8m0 import e8m0_to_fp32
 from tensorrt_llm._torch.auto_deploy.utils.fp8_dequant import dequant_fp8_weight_two_dim_block_grid
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
@@ -106,6 +108,67 @@ class _DeepSeekV4WoAFixture(nn.Module):
         return output, torch.einsum("bsgd,grd->bsgr", o, other)
 
 
+class _DeepSeekV4WoAShardingFixture(nn.Module):
+    def __init__(
+        self,
+        num_groups: int = 4,
+        o_lora_rank: int = 128,
+        group_dim: int = 64,
+    ) -> None:
+        super().__init__()
+        self.num_groups = num_groups
+        self.o_lora_rank = o_lora_rank
+        self.group_dim = group_dim
+        self.layers = nn.ModuleList([nn.Module()])
+        self.layers[0].attn = nn.Module()
+        self.layers[0].attn.wo_a = nn.Module()
+        weight = torch.arange(
+            num_groups * o_lora_rank * group_dim,
+            dtype=torch.float32,
+        )
+        weight = (
+            weight.remainder(31)
+            .sub(15)
+            .div(16)
+            .reshape(
+                num_groups * o_lora_rank,
+                group_dim,
+            )
+        )
+        self.layers[0].attn.wo_a.weight = nn.Parameter(
+            weight.to(torch.float8_e4m3fn),
+            requires_grad=False,
+        )
+        self.layers[0].attn.wo_a.register_buffer(
+            "weight_scale_inv",
+            torch.arange(num_groups, dtype=torch.float32).reshape(num_groups, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear.default(
+            x,
+            self.layers[0].attn.wo_a.weight,
+            None,
+            [self.layers[0].attn.wo_a.weight_scale_inv],
+        )
+
+
+class _DeepSeekV4WoALocalViewShardingFixture(_DeepSeekV4WoAShardingFixture):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        local_view = torch.ops.auto_deploy.view(
+            x,
+            [1, 2, self.num_groups, self.group_dim],
+            tp_scaled_dim=2,
+            layer_type="mla",
+        )
+        return torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear.default(
+            local_view,
+            self.layers[0].attn.wo_a.weight,
+            None,
+            [self.layers[0].attn.wo_a.weight_scale_inv],
+        )
+
+
 def _trace_with_weight_meta(module: nn.Module) -> torch.fx.GraphModule:
     gm = torch.fx.symbolic_trace(module)
     params_and_buffers = dict(gm.named_parameters())
@@ -114,6 +177,26 @@ def _trace_with_weight_meta(module: nn.Module) -> torch.fx.GraphModule:
         if node.op == "get_attr" and node.target in params_and_buffers:
             node.meta["val"] = params_and_buffers[node.target].detach()
     return gm
+
+
+def _run_ir_sharding(
+    gm: torch.fx.GraphModule,
+    *,
+    rank: int,
+    world_size: int,
+) -> tuple[torch.fx.GraphModule, object]:
+    transform = ApplyShardingHints.from_kwargs(stage=Stages.SHARDING)
+    shared_config = SharedConfig(
+        local_rank=rank,
+        world_size=world_size,
+        dist_config=DistConfig(
+            world_size=world_size,
+            rank=rank,
+            tp_size=world_size,
+            moe_ep_size=world_size,
+        ),
+    )
+    return transform._apply(gm, None, None, shared_config)
 
 
 def _deepseek_v4_quant_config() -> dict[str, object]:
@@ -343,6 +426,127 @@ def test_deepseek_v4_wo_a_grouped_op_matches_reference_on_ragged_blocks() -> Non
     )
 
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_deepseek_v4_wo_a_grouped_sharding_splits_by_output_group_and_scale_rows() -> None:
+    model = _DeepSeekV4WoAShardingFixture()
+    gm = _trace_with_weight_meta(model)
+    input_shape = (1, 2, model.num_groups, model.group_dim)
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            node.meta["val"] = torch.empty(input_shape, dtype=torch.bfloat16)
+        elif is_op(
+            node,
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+        ):
+            node.meta["val"] = torch.empty(
+                (*input_shape[:-1], model.o_lora_rank),
+                dtype=torch.bfloat16,
+            )
+
+    transformed, info = _run_ir_sharding(gm, rank=1, world_size=2)
+
+    assert info.num_matches == 1
+    wo_a = transformed.get_submodule("layers.0.attn.wo_a")
+    assert wo_a.weight.shape == (2 * model.o_lora_rank, model.group_dim)
+    assert wo_a.weight_scale_inv.shape == (2, 1)
+    torch.testing.assert_close(
+        wo_a.weight_scale_inv,
+        torch.tensor([[2.0], [3.0]], dtype=torch.float32),
+        rtol=0,
+        atol=0,
+    )
+
+    grouped_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+        )
+    )
+    local_input = grouped_node.args[0]
+    assert local_input.target == torch.ops.aten.slice.Tensor
+    assert local_input.args[1:5] == (2, 2, 4, 1)
+
+    full_weight = (
+        torch.arange(
+            model.num_groups * model.o_lora_rank * model.group_dim,
+            dtype=torch.float32,
+        )
+        .remainder(29)
+        .sub(14)
+        .div(16)
+        .reshape(model.num_groups * model.o_lora_rank, model.group_dim)
+        .to(torch.float8_e4m3fn)
+    )
+    full_scale = torch.arange(model.num_groups, dtype=torch.float32).reshape(model.num_groups, 1)
+    full_scale = full_scale.add(10)
+    load_result = transformed.load_state_dict(
+        {
+            "layers.0.attn.wo_a.weight": full_weight,
+            "layers.0.attn.wo_a.weight_scale_inv": full_scale,
+        },
+        strict=False,
+    )
+
+    assert load_result.missing_keys == []
+    assert load_result.unexpected_keys == []
+    expected_weight = full_weight.reshape(
+        model.num_groups,
+        model.o_lora_rank,
+        model.group_dim,
+    )[2:4].reshape(2 * model.o_lora_rank, model.group_dim)
+    torch.testing.assert_close(wo_a.weight.float(), expected_weight.float(), rtol=0, atol=0)
+    torch.testing.assert_close(
+        wo_a.weight_scale_inv,
+        torch.tensor([[12.0], [13.0]], dtype=torch.float32),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_deepseek_v4_wo_a_grouped_sharding_skips_input_slice_after_local_group_view() -> None:
+    model = _DeepSeekV4WoALocalViewShardingFixture()
+    gm = _trace_with_weight_meta(model)
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            node.meta["val"] = torch.empty((1, 2, model.num_groups * model.group_dim))
+        elif is_op(node, torch.ops.auto_deploy.view):
+            node.meta["val"] = torch.empty((1, 2, model.num_groups, model.group_dim))
+        elif is_op(
+            node,
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+        ):
+            node.meta["val"] = torch.empty(
+                (1, 2, model.num_groups, model.o_lora_rank),
+                dtype=torch.bfloat16,
+            )
+
+    transformed, info = _run_ir_sharding(gm, rank=1, world_size=2)
+
+    assert info.num_matches == 2
+    view_node = next(
+        node for node in transformed.graph.nodes if is_op(node, torch.ops.auto_deploy.view)
+    )
+    assert view_node.args[1] == [1, 2, -1, model.group_dim]
+    grouped_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+        )
+    )
+    assert grouped_node.args[0] is view_node
+    assert not any(
+        node.op == "call_function" and node.target == torch.ops.aten.slice.Tensor
+        for node in transformed.graph.nodes
+    )
+    assert transformed.get_submodule("layers.0.attn.wo_a").weight.shape == (
+        2 * model.o_lora_rank,
+        model.group_dim,
+    )
 
 
 def test_fp8_weight_dequant_preserves_fixed_block_scale_for_ragged_shapes() -> None:

--- a/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
+++ b/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
@@ -25,6 +25,7 @@ from tensorrt_llm._torch.auto_deploy.transform.library.quantization import (
     FP8LinearQuantizationFromConfig,
 )
 from tensorrt_llm._torch.auto_deploy.utils.e8m0 import e8m0_to_fp32
+from tensorrt_llm._torch.auto_deploy.utils.fp8_dequant import dequant_fp8_weight_two_dim_block_grid
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 
 _HAS_E8M0 = hasattr(torch, "float8_e8m0fnu")
@@ -74,6 +75,35 @@ class _GenericLinearFixture(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.ops.auto_deploy.torch_linear_simple.default(x, self.proj.weight, None)
+
+
+class _DeepSeekV4WoAFixture(nn.Module):
+    def __init__(
+        self,
+        num_groups: int = 2,
+        o_lora_rank: int = 3,
+        group_dim: int = 5,
+        include_unrelated_einsum: bool = False,
+    ) -> None:
+        super().__init__()
+        self.num_groups = num_groups
+        self.o_lora_rank = o_lora_rank
+        self.include_unrelated_einsum = include_unrelated_einsum
+        self.layers = nn.ModuleList([nn.Module()])
+        self.layers[0].attn = nn.Module()
+        self.layers[0].attn.wo_a = nn.Linear(group_dim, num_groups * o_lora_rank, bias=False)
+        if include_unrelated_einsum:
+            self.layers[0].attn.other = nn.Linear(group_dim, num_groups * o_lora_rank, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        o = x.view(x.shape[0], x.shape[1], self.num_groups, -1)
+        wo_a = self.layers[0].attn.wo_a.weight.view(self.num_groups, self.o_lora_rank, -1)
+        output = torch.einsum("bsgd,grd->bsgr", o, wo_a)
+        if not self.include_unrelated_einsum:
+            return output
+
+        other = self.layers[0].attn.other.weight.view(self.num_groups, self.o_lora_rank, -1)
+        return output, torch.einsum("bsgd,grd->bsgr", o, other)
 
 
 def _trace_with_weight_meta(module: nn.Module) -> torch.fx.GraphModule:
@@ -223,6 +253,117 @@ def test_deepseek_v4_transform_quantizes_only_dense_fp8_linear_paths() -> None:
     ]
     assert len(quantized_nodes) == 1
     assert len(plain_nodes) == 2
+
+
+def test_deepseek_v4_wo_a_grouped_transform_registers_buffer_and_loads_scale_alias() -> None:
+    model = _DeepSeekV4WoAFixture().to(torch.bfloat16)
+    gm = _trace_with_weight_meta(model)
+
+    transformed, info = _run_finegrained_transform(gm, _deepseek_v4_quant_config())
+
+    assert info.num_matches == 1
+    wo_a = transformed.get_submodule("layers.0.attn.wo_a")
+    assert wo_a.weight.dtype == torch.float8_e4m3fn
+    assert wo_a.weight_scale_inv.shape == (1, 1)
+
+    scale = torch.full((1, 1), 3.0, dtype=torch.bfloat16)
+    state_dict = {
+        "layers.0.attn.wo_a.weight": _fp8_weight((6, 5)),
+        "layers.0.attn.wo_a.scale": scale,
+    }
+
+    missing, unexpected = transformed.load_state_dict(state_dict, strict=False)
+
+    assert not missing
+    assert not unexpected
+    torch.testing.assert_close(wo_a.weight_scale_inv, scale, rtol=0, atol=0)
+
+
+def test_deepseek_v4_wo_a_grouped_transform_rewrites_only_scoped_einsum() -> None:
+    model = _DeepSeekV4WoAFixture(include_unrelated_einsum=True).to(torch.bfloat16)
+    gm = _trace_with_weight_meta(model)
+
+    transformed, info = _run_finegrained_transform(gm, _deepseek_v4_quant_config())
+
+    assert info.num_matches == 1
+    assert transformed.get_submodule("layers.0.attn.wo_a").weight.dtype == torch.float8_e4m3fn
+    assert transformed.get_submodule("layers.0.attn.other").weight.dtype == torch.bfloat16
+
+    grouped_nodes = [
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+        )
+    ]
+    remaining_einsum_nodes = [
+        node
+        for node in transformed.graph.nodes
+        if node.op == "call_function" and node.target in {torch.einsum, torch.functional.einsum}
+    ]
+    assert len(grouped_nodes) == 1
+    assert len(remaining_einsum_nodes) == 1
+
+
+def test_deepseek_v4_wo_a_grouped_op_matches_reference_on_ragged_blocks() -> None:
+    batch_size, seq_len, num_groups, o_lora_rank, group_dim = 1, 2, 3, 43, 130
+    weight_rows = num_groups * o_lora_rank
+    input_tensor = (
+        torch.arange(batch_size * seq_len * num_groups * group_dim, dtype=torch.float32)
+        .reshape(batch_size, seq_len, num_groups, group_dim)
+        .remainder(7)
+        .sub(3)
+        .div(8)
+    )
+    weight = (
+        torch.arange(weight_rows * group_dim, dtype=torch.float32)
+        .reshape(weight_rows, group_dim)
+        .remainder(17)
+        .sub(8)
+        .to(torch.float8_e4m3fn)
+    )
+    weight_scale = torch.tensor(
+        [[0.25, 0.5], [1.5, 2.0]],
+        dtype=torch.float32,
+    )
+
+    grouped_op = (
+        torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear
+    )
+    actual = grouped_op.default(input_tensor, weight, None, [weight_scale])
+
+    scale_expanded = weight_scale.repeat_interleave(128, dim=0).repeat_interleave(128, dim=1)
+    scale_expanded = scale_expanded[:weight_rows, :group_dim]
+    expected_weight = weight.to(torch.float32) * scale_expanded
+    expected = torch.einsum(
+        "bsgd,grd->bsgr",
+        input_tensor,
+        expected_weight.view(num_groups, o_lora_rank, group_dim),
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_fp8_weight_dequant_preserves_fixed_block_scale_for_ragged_shapes() -> None:
+    weight = torch.ones((129, 130), dtype=torch.float32).to(torch.float8_e4m3fn)
+    weight_scale = torch.tensor(
+        [[1.0, 2.0], [4.0, 8.0]],
+        dtype=torch.float32,
+    )
+
+    actual = dequant_fp8_weight_two_dim_block_grid(
+        weight,
+        weight_scale,
+        block_n=128,
+        block_k=128,
+        dtype=torch.float32,
+    )
+
+    assert actual[65, 0].item() == 1.0
+    assert actual[0, 128].item() == 2.0
+    assert actual[128, 0].item() == 4.0
+    assert actual[128, 128].item() == 8.0
 
 
 def test_non_deepseek_finegrained_fp8_still_uses_weight_scale_inv() -> None:

--- a/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
+++ b/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
@@ -23,6 +23,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops.quantization import torch_quant
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4Attention,
@@ -43,6 +44,10 @@ _HAS_E8M0 = hasattr(torch, "float8_e8m0fnu")
 _requires_e8m0 = pytest.mark.skipif(
     not _HAS_E8M0,
     reason="torch.float8_e8m0fnu is not available in this PyTorch build",
+)
+_requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CUDA is required for the grouped wo_a Triton path",
 )
 _DEEPSEEK_V4_REAL_CKPT_ENV = "DEEPSEEK_V4_FLASH_CHECKPOINT"
 _DEFAULT_DEEPSEEK_V4_REAL_CKPT = Path(
@@ -376,6 +381,86 @@ def _e8m0_from_bytes(raw_bytes: list[int], shape: tuple[int, ...]) -> torch.Tens
     )
 
 
+def _deepseek_v4_wo_a_supported_tensors(
+    num_groups: int,
+    *,
+    token_count: int,
+    device: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    group_dim = 4096
+    o_lora_rank = 1024
+    input_tensor = (
+        torch.arange(
+            token_count * num_groups * group_dim,
+            dtype=torch.float32,
+            device=device,
+        )
+        .reshape(1, token_count, num_groups, group_dim)
+        .remainder(13)
+        .sub(6)
+        .div(32)
+        .to(torch.bfloat16)
+        .contiguous()
+    )
+    weight = (
+        torch.arange(
+            num_groups * o_lora_rank * group_dim,
+            dtype=torch.float32,
+            device=device,
+        )
+        .reshape(num_groups * o_lora_rank, group_dim)
+        .remainder(17)
+        .sub(8)
+        .div(32)
+        .to(torch.float8_e4m3fn)
+        .contiguous()
+    )
+    weight_scale = (
+        torch.arange(
+            num_groups * (o_lora_rank // 128) * (group_dim // 128),
+            dtype=torch.float32,
+            device=device,
+        )
+        .reshape(num_groups * (o_lora_rank // 128), group_dim // 128)
+        .remainder(3)
+        .sub(1)
+    )
+    weight_scale = torch.pow(torch.full_like(weight_scale, 2.0), weight_scale).contiguous()
+    return input_tensor, weight, weight_scale
+
+
+def _deepseek_v4_wo_a_grouped_reference(
+    input_tensor: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    num_groups = input_tensor.shape[-2]
+    o_lora_rank = weight.shape[0] // num_groups
+    group_dim = input_tensor.shape[-1]
+    weight_dequant = dequant_fp8_weight_two_dim_block_grid(
+        weight,
+        weight_scale,
+        block_n=128,
+        block_k=128,
+        dtype=input_tensor.dtype,
+    )
+    return torch.einsum(
+        "bsgd,grd->bsgr",
+        input_tensor,
+        weight_dequant.view(num_groups, o_lora_rank, group_dim),
+    ).to(input_tensor.dtype)
+
+
+def _fail_if_grouped_wo_a_reference_fallback_runs(*args: object, **kwargs: object) -> None:
+    del args, kwargs
+    raise AssertionError("grouped wo_a reference fallback unexpectedly ran")
+
+
+def _fail_if_grouped_wo_a_triton_runs(*args: object, **kwargs: object) -> None:
+    del args, kwargs
+    raise AssertionError("grouped wo_a Triton path unexpectedly ran")
+
+
 def test_deepseek_v4_scale_alias_loads_into_weight_scale_inv() -> None:
     weight_name = "layers.0.attn.wq_a.weight"
     scale_alias = "layers.0.attn.wq_a.scale"
@@ -587,6 +672,11 @@ def test_deepseek_v4_wo_a_grouped_op_matches_reference_on_ragged_blocks() -> Non
     grouped_op = (
         torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear
     )
+    assert not torch_quant._is_deepseek_v4_wo_a_grouped_fp8_triton_shape_supported(
+        input_tensor,
+        weight,
+        weight_scale,
+    )
     actual = grouped_op.default(input_tensor, weight, None, [weight_scale], layer_type="mla")
 
     scale_expanded = weight_scale.repeat_interleave(128, dim=0).repeat_interleave(128, dim=1)
@@ -599,6 +689,160 @@ def test_deepseek_v4_wo_a_grouped_op_matches_reference_on_ragged_blocks() -> Non
     )
 
     torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_deepseek_v4_wo_a_grouped_triton_shape_guard_covers_observed_shapes() -> None:
+    for num_groups in (1, 8):
+        input_tensor, weight, weight_scale = _deepseek_v4_wo_a_supported_tensors(
+            num_groups,
+            token_count=2,
+            device="cpu",
+        )
+
+        assert torch_quant._is_deepseek_v4_wo_a_grouped_fp8_triton_shape_supported(
+            input_tensor,
+            weight,
+            weight_scale,
+        )
+
+
+def test_deepseek_v4_wo_a_grouped_unsupported_shape_keeps_reference_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_tensor = torch.ones((1, 2, 1, 130), dtype=torch.bfloat16)
+    weight = torch.ones((128, 130), dtype=torch.float32).to(torch.float8_e4m3fn)
+    weight_scale = torch.ones((1, 2), dtype=torch.float32)
+
+    assert not torch_quant._is_deepseek_v4_wo_a_grouped_fp8_triton_shape_supported(
+        input_tensor,
+        weight,
+        weight_scale,
+    )
+    monkeypatch.setattr(
+        torch_quant,
+        "_deepseek_v4_wo_a_grouped_fp8_triton",
+        _fail_if_grouped_wo_a_triton_runs,
+    )
+
+    actual = torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear.default(
+        input_tensor,
+        weight,
+        None,
+        [weight_scale],
+        layer_type="mla",
+    )
+    expected = _deepseek_v4_wo_a_grouped_reference(input_tensor, weight, weight_scale)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@_requires_cuda
+@pytest.mark.parametrize("num_groups", [1, 8], ids=["tp8-g1", "unsharded-g8"])
+def test_deepseek_v4_wo_a_grouped_triton_matches_reference_for_supported_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+    num_groups: int,
+) -> None:
+    input_tensor, weight, weight_scale = _deepseek_v4_wo_a_supported_tensors(
+        num_groups,
+        token_count=2 if num_groups == 1 else 1,
+        device="cuda",
+    )
+    expected = _deepseek_v4_wo_a_grouped_reference(input_tensor, weight, weight_scale)
+    monkeypatch.setattr(
+        torch_quant,
+        "_deepseek_v4_wo_a_grouped_reference",
+        _fail_if_grouped_wo_a_reference_fallback_runs,
+    )
+
+    actual = torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear.default(
+        input_tensor,
+        weight,
+        None,
+        [weight_scale],
+        layer_type="mla",
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=5e-1)
+
+
+@_requires_cuda
+@_requires_e8m0
+def test_deepseek_v4_wo_a_grouped_triton_decodes_raw_e8m0_scale_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_tensor, weight, weight_scale_fp32 = _deepseek_v4_wo_a_supported_tensors(
+        1,
+        token_count=2,
+        device="cuda",
+    )
+    raw_scale = (
+        torch.log2(weight_scale_fp32)
+        .add(127)
+        .to(torch.uint8)
+        .contiguous()
+        .view(torch.float8_e8m0fnu)
+    )
+    expected = _deepseek_v4_wo_a_grouped_reference(
+        input_tensor,
+        weight,
+        e8m0_to_fp32(raw_scale),
+    )
+    monkeypatch.setattr(
+        torch_quant,
+        "_deepseek_v4_wo_a_grouped_reference",
+        _fail_if_grouped_wo_a_reference_fallback_runs,
+    )
+
+    actual = torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear.default(
+        input_tensor,
+        weight,
+        None,
+        [raw_scale],
+        layer_type="mla",
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=5e-1)
+
+
+@_requires_cuda
+def test_deepseek_v4_wo_a_grouped_triton_cuda_graph_replays_fixed_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    input_tensor, weight, weight_scale = _deepseek_v4_wo_a_supported_tensors(
+        1,
+        token_count=2,
+        device="cuda",
+    )
+    replay_input = input_tensor.neg().contiguous()
+    expected = _deepseek_v4_wo_a_grouped_reference(replay_input, weight, weight_scale)
+
+    grouped_op = (
+        torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear
+    )
+    for _ in range(3):
+        grouped_op.default(input_tensor, weight, None, [weight_scale], layer_type="mla")
+    torch.cuda.synchronize()
+
+    monkeypatch.setattr(
+        torch_quant,
+        "_deepseek_v4_wo_a_grouped_reference",
+        _fail_if_grouped_wo_a_reference_fallback_runs,
+    )
+    static_input = input_tensor.clone()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        static_output = grouped_op.default(
+            static_input,
+            weight,
+            None,
+            [weight_scale],
+            layer_type="mla",
+        )
+
+    static_input.copy_(replay_input)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(static_output, expected, rtol=2e-2, atol=5e-1)
 
 
 def test_deepseek_v4_wo_a_grouped_sharding_splits_by_output_group_and_scale_rows() -> None:

--- a/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
+++ b/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
+from tensorrt_llm._torch.auto_deploy.transform.library.quantization import (
+    FineGrainedFP8LinearQuantization,
+    FP8LinearQuantizationFromConfig,
+)
+from tensorrt_llm._torch.auto_deploy.utils.e8m0 import e8m0_to_fp32
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+_HAS_E8M0 = hasattr(torch, "float8_e8m0fnu")
+_requires_e8m0 = pytest.mark.skipif(
+    not _HAS_E8M0,
+    reason="torch.float8_e8m0fnu is not available in this PyTorch build",
+)
+
+
+class _DummyFactory:
+    def __init__(self, quant_config: dict[str, object]) -> None:
+        self._quant_config = quant_config
+
+    def get_quant_config(self) -> dict[str, object]:
+        return self._quant_config
+
+
+class _DeepSeekV4LinearFixture(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([nn.Module()])
+        self.layers[0].attn = nn.Module()
+        self.layers[0].attn.wq_a = nn.Linear(16, 8, bias=False)
+        self.layers[0].attn.compressor = nn.Module()
+        self.layers[0].attn.compressor.wkv = nn.Linear(16, 8, bias=False)
+        self.layers[0].ffn = nn.Module()
+        self.layers[0].ffn.gate = nn.Linear(16, 4, bias=False)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return (
+            torch.ops.auto_deploy.torch_linear_simple.default(
+                x, self.layers[0].attn.wq_a.weight, None
+            ),
+            torch.ops.auto_deploy.torch_linear_simple.default(
+                x, self.layers[0].attn.compressor.wkv.weight, None
+            ),
+            torch.ops.auto_deploy.torch_linear_simple.default(
+                x, self.layers[0].ffn.gate.weight, None
+            ),
+        )
+
+
+class _GenericLinearFixture(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = nn.Linear(16, 8, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_linear_simple.default(x, self.proj.weight, None)
+
+
+def _trace_with_weight_meta(module: nn.Module) -> torch.fx.GraphModule:
+    gm = torch.fx.symbolic_trace(module)
+    params_and_buffers = dict(gm.named_parameters())
+    params_and_buffers.update(dict(gm.named_buffers()))
+    for node in gm.graph.nodes:
+        if node.op == "get_attr" and node.target in params_and_buffers:
+            node.meta["val"] = params_and_buffers[node.target].detach()
+    return gm
+
+
+def _deepseek_v4_quant_config() -> dict[str, object]:
+    return {
+        "quant_method": "deepseek_v4_fp8",
+        "linear_quant_method": "finegrained_fp8",
+        "weight_block_size": [128, 128],
+        "exclude_modules": [
+            "embed",
+            "head",
+            "*.ffn.gate",
+            "*.attn.compressor",
+            "*.attn.indexer.compressor",
+            "*.attn.indexer.weights_proj",
+            "*.norm",
+            "*.hc_*",
+            "*.attn_sink",
+            "mtp.*",
+        ],
+    }
+
+
+def _run_finegrained_transform(
+    gm: torch.fx.GraphModule,
+    quant_config: dict[str, object],
+) -> tuple[torch.fx.GraphModule, object]:
+    transform = FineGrainedFP8LinearQuantization.from_kwargs(stage=Stages.PATTERN_MATCHER)
+    return transform._apply(gm, None, _DummyFactory(quant_config), SharedConfig())
+
+
+def _load_finegrained_state_dict(state_dict: dict[str, torch.Tensor], weight_name: str) -> None:
+    transform = FineGrainedFP8LinearQuantization.from_kwargs(stage=Stages.PATTERN_MATCHER)
+    transform.load_hook(state_dict, "", weight_name=weight_name)
+
+
+def _fp8_weight(shape: tuple[int, int]) -> torch.Tensor:
+    return torch.empty(shape, dtype=torch.float8_e4m3fn, device="cpu")
+
+
+@_requires_e8m0
+def _e8m0_from_bytes(raw_bytes: list[int], shape: tuple[int, ...]) -> torch.Tensor:
+    return (
+        torch.tensor(raw_bytes, dtype=torch.uint8, device="cpu")
+        .view(torch.float8_e8m0fnu)
+        .view(shape)
+    )
+
+
+def test_deepseek_v4_scale_alias_loads_into_weight_scale_inv() -> None:
+    weight_name = "layers.0.attn.wq_a.weight"
+    scale_alias = "layers.0.attn.wq_a.scale"
+    scale_buffer = "layers.0.attn.wq_a.weight_scale_inv"
+    scale = torch.ones((8, 32), dtype=torch.bfloat16, device="cpu")
+    state_dict = {
+        weight_name: _fp8_weight((1024, 4096)),
+        scale_alias: scale,
+    }
+
+    _load_finegrained_state_dict(state_dict, weight_name)
+
+    assert scale_alias not in state_dict
+    assert state_dict[scale_buffer] is scale
+    assert state_dict[scale_buffer].shape == (8, 32)
+
+
+@_requires_e8m0
+def test_deepseek_v4_e8m0_scale_alias_decodes_to_fp32() -> None:
+    weight_name = "layers.0.attn.wq_a.weight"
+    scale_alias = "layers.0.attn.wq_a.scale"
+    scale = _e8m0_from_bytes([126, 127, 128, 129, 130, 131], (2, 3))
+    state_dict = {
+        weight_name: _fp8_weight((129, 257)),
+        scale_alias: scale,
+    }
+
+    _load_finegrained_state_dict(state_dict, weight_name)
+
+    actual = state_dict["layers.0.attn.wq_a.weight_scale_inv"]
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(actual, e8m0_to_fp32(scale), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    ("weight_shape", "scale_shape"),
+    [
+        ((1024, 4096), (8, 32)),
+        ((129, 257), (2, 3)),
+    ],
+)
+def test_deepseek_v4_scale_shape_validation_accepts_ceil_shapes(
+    weight_shape: tuple[int, int],
+    scale_shape: tuple[int, int],
+) -> None:
+    weight_name = "layers.0.attn.wq_a.weight"
+    state_dict = {
+        weight_name: _fp8_weight(weight_shape),
+        "layers.0.attn.wq_a.scale": torch.ones(scale_shape, dtype=torch.float32),
+    }
+
+    _load_finegrained_state_dict(state_dict, weight_name)
+
+    assert state_dict["layers.0.attn.wq_a.weight_scale_inv"].shape == scale_shape
+
+
+def test_deepseek_v4_scale_shape_validation_rejects_mismatches() -> None:
+    weight_name = "layers.0.attn.wq_a.weight"
+    state_dict = {
+        weight_name: _fp8_weight((129, 257)),
+        "layers.0.attn.wq_a.scale": torch.ones((1, 3), dtype=torch.float32),
+    }
+
+    with pytest.raises(ValueError, match=r"expected shape \(2, 3\)"):
+        _load_finegrained_state_dict(state_dict, weight_name)
+
+
+def test_deepseek_v4_transform_quantizes_only_dense_fp8_linear_paths() -> None:
+    model = _DeepSeekV4LinearFixture().to(torch.bfloat16)
+    gm = _trace_with_weight_meta(model)
+
+    transformed, info = _run_finegrained_transform(gm, _deepseek_v4_quant_config())
+
+    assert info.num_matches == 1
+    assert transformed.get_submodule("layers.0.attn.wq_a").weight.dtype == torch.float8_e4m3fn
+    assert transformed.get_submodule("layers.0.attn.wq_a").weight_scale_inv.shape == (1, 1)
+    assert transformed.get_submodule("layers.0.ffn.gate").weight.dtype == torch.bfloat16
+    assert transformed.get_submodule("layers.0.attn.compressor.wkv").weight.dtype == torch.bfloat16
+
+    quantized_nodes = [
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear)
+    ]
+    plain_nodes = [
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_linear_simple)
+    ]
+    assert len(quantized_nodes) == 1
+    assert len(plain_nodes) == 2
+
+
+def test_non_deepseek_finegrained_fp8_still_uses_weight_scale_inv() -> None:
+    weight_name = "proj.weight"
+    state_dict = {
+        weight_name: _fp8_weight((8, 16)),
+        "proj.weight_scale_inv": torch.ones((1, 1), dtype=torch.bfloat16),
+        "proj.scale": torch.full((1, 1), 2.0, dtype=torch.bfloat16),
+    }
+
+    _load_finegrained_state_dict(state_dict, weight_name)
+
+    torch.testing.assert_close(
+        state_dict["proj.weight_scale_inv"],
+        torch.ones((1, 1), dtype=torch.bfloat16),
+        rtol=0,
+        atol=0,
+    )
+    assert "proj.scale" in state_dict
+
+    gm = _trace_with_weight_meta(_GenericLinearFixture().to(torch.bfloat16))
+    transformed, info = _run_finegrained_transform(
+        gm, {"quant_method": "fp8", "weight_block_size": [128, 128]}
+    )
+
+    assert info.num_matches == 1
+    assert transformed.proj.weight.dtype == torch.float8_e4m3fn
+
+
+def test_generic_fp8_transform_skips_weight_block_size_configs() -> None:
+    gm = _trace_with_weight_meta(_GenericLinearFixture().to(torch.bfloat16))
+    transform = FP8LinearQuantizationFromConfig.from_kwargs(stage=Stages.PATTERN_MATCHER)
+
+    transformed, info = transform._apply(
+        gm,
+        None,
+        _DummyFactory({"quant_method": "fp8", "weight_block_size": [128, 128]}),
+        SharedConfig(),
+    )
+
+    assert info.skipped
+    assert transformed.proj.weight.dtype == torch.bfloat16
+
+
+@_requires_e8m0
+def test_trtllm_finegrained_fp8_linear_decodes_e8m0_for_fallback() -> None:
+    input_tensor = torch.tensor([[1.0, -2.0, 3.0, -4.0]], dtype=torch.bfloat16)
+    weight = torch.tensor(
+        [[1.0, 2.0, -1.0, -2.0], [0.5, -0.5, 1.0, -1.0]],
+        dtype=torch.float32,
+    ).to(torch.float8_e4m3fn)
+    bias = torch.tensor([0.25, -0.5], dtype=torch.bfloat16)
+    weight_scale = _e8m0_from_bytes([127], (1, 1))
+
+    actual = torch.ops.auto_deploy.trtllm_finegrained_fp8_linear.default(
+        input_tensor,
+        weight,
+        bias,
+        weight_scale,
+    )
+
+    expected_weight = weight.to(torch.bfloat16) * e8m0_to_fp32(weight_scale).to(torch.bfloat16)
+    expected = F.linear(input_tensor, expected_weight, bias)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
+++ b/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
@@ -295,6 +295,16 @@ def _depends_on(node: torch.fx.Node, target: torch.fx.Node) -> bool:
     return False
 
 
+def _lower_sharding_views_to_aten(gm: torch.fx.GraphModule) -> None:
+    for node in gm.graph.nodes:
+        if is_op(node, torch.ops.auto_deploy.view):
+            node.target = torch.ops.aten.view.default
+            node.args = (node.args[0], node.args[1])
+            node.kwargs = {}
+    gm.graph.lint()
+    gm.recompile()
+
+
 def _fp8_weight(shape: tuple[int, int]) -> torch.Tensor:
     return torch.empty(shape, dtype=torch.float8_e4m3fn, device="cpu")
 
@@ -613,7 +623,14 @@ def test_deepseek_v4_wo_a_grouped_sharding_skips_input_slice_after_local_group_v
     )
 
 
-def test_deepseek_v4_attention_wo_a_sharding_feeds_rowwise_wo_b_local_features() -> None:
+@pytest.mark.parametrize(
+    "lower_views_to_aten",
+    [False, True],
+    ids=["auto-deploy-view", "aten-view"],
+)
+def test_deepseek_v4_attention_wo_a_sharding_feeds_rowwise_wo_b_local_features(
+    lower_views_to_aten: bool,
+) -> None:
     model = _DeepSeekV4AttentionWoBShardingFixture().to(torch.bfloat16)
     gm = torch_export_to_gm(
         model,
@@ -622,6 +639,8 @@ def test_deepseek_v4_attention_wo_a_sharding_feeds_rowwise_wo_b_local_features()
             torch.arange(4, dtype=torch.long).unsqueeze(0),
         ),
     )
+    if lower_views_to_aten:
+        _lower_sharding_views_to_aten(gm)
 
     quantized, quant_info = _run_finegrained_transform(gm, _deepseek_v4_quant_config())
     transformed, shard_info = _run_ir_sharding(
@@ -648,7 +667,10 @@ def test_deepseek_v4_attention_wo_a_sharding_feeds_rowwise_wo_b_local_features()
     q_view_node = next(
         node
         for node in transformed.graph.nodes
-        if is_op(node, torch.ops.auto_deploy.view)
+        if (
+            is_op(node, (torch.ops.auto_deploy.view, torch.ops.aten.view))
+            or node.target == torch.ops.aten.view.default
+        )
         and node.args[1][-1] == model.layers[0].attn.head_dim
     )
     assert q_view_node.args[1] == [1, 4, -1, 16]

--- a/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
+++ b/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
@@ -20,9 +20,9 @@ import torch.nn.functional as F
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
-from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import DeepseekV4Config
-from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4_ir import (
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4Attention,
+    DeepseekV4Config,
 )
 from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
 from tensorrt_llm._torch.auto_deploy.transform.library.quantization import (
@@ -155,6 +155,7 @@ class _DeepSeekV4WoAShardingFixture(nn.Module):
             self.layers[0].attn.wo_a.weight,
             None,
             [self.layers[0].attn.wo_a.weight_scale_inv],
+            layer_type="mla",
         )
 
 
@@ -171,6 +172,7 @@ class _DeepSeekV4WoALocalViewShardingFixture(_DeepSeekV4WoAShardingFixture):
             self.layers[0].attn.wo_a.weight,
             None,
             [self.layers[0].attn.wo_a.weight_scale_inv],
+            layer_type="mla",
         )
 
 
@@ -213,8 +215,10 @@ def _run_ir_sharding(
     *,
     rank: int,
     world_size: int,
+    shard_layers: list[str] | None = None,
 ) -> tuple[torch.fx.GraphModule, object]:
     transform = ApplyShardingHints.from_kwargs(stage=Stages.SHARDING)
+    transform.config.shard_layers = shard_layers
     shared_config = SharedConfig(
         local_rank=rank,
         world_size=world_size,
@@ -259,6 +263,36 @@ def _run_finegrained_transform(
 def _load_finegrained_state_dict(state_dict: dict[str, torch.Tensor], weight_name: str) -> None:
     transform = FineGrainedFP8LinearQuantization.from_kwargs(stage=Stages.PATTERN_MATCHER)
     transform.load_hook(state_dict, "", weight_name=weight_name)
+
+
+def _depends_on(node: torch.fx.Node, target: torch.fx.Node) -> bool:
+    def _node_args(value):
+        if isinstance(value, torch.fx.Node):
+            return [value]
+        if isinstance(value, (list, tuple)):
+            nodes = []
+            for item in value:
+                nodes.extend(_node_args(item))
+            return nodes
+        if isinstance(value, dict):
+            nodes = []
+            for item in value.values():
+                nodes.extend(_node_args(item))
+            return nodes
+        return []
+
+    pending = [node]
+    seen = set()
+    while pending:
+        current = pending.pop()
+        if current is target:
+            return True
+        if current in seen:
+            continue
+        seen.add(current)
+        pending.extend(_node_args(current.args))
+        pending.extend(_node_args(current.kwargs))
+    return False
 
 
 def _fp8_weight(shape: tuple[int, int]) -> torch.Tensor:
@@ -415,6 +449,7 @@ def test_deepseek_v4_wo_a_grouped_transform_rewrites_only_scoped_einsum() -> Non
         if node.op == "call_function" and node.target in {torch.einsum, torch.functional.einsum}
     ]
     assert len(grouped_nodes) == 1
+    assert grouped_nodes[0].kwargs["layer_type"] == "mla"
     assert len(remaining_einsum_nodes) == 1
 
 
@@ -443,7 +478,7 @@ def test_deepseek_v4_wo_a_grouped_op_matches_reference_on_ragged_blocks() -> Non
     grouped_op = (
         torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear
     )
-    actual = grouped_op.default(input_tensor, weight, None, [weight_scale])
+    actual = grouped_op.default(input_tensor, weight, None, [weight_scale], layer_type="mla")
 
     scale_expanded = weight_scale.repeat_interleave(128, dim=0).repeat_interleave(128, dim=1)
     scale_expanded = scale_expanded[:weight_rows, :group_dim]
@@ -589,17 +624,40 @@ def test_deepseek_v4_attention_wo_a_sharding_feeds_rowwise_wo_b_local_features()
     )
 
     quantized, quant_info = _run_finegrained_transform(gm, _deepseek_v4_quant_config())
-    transformed, shard_info = _run_ir_sharding(quantized, rank=1, world_size=8)
+    transformed, shard_info = _run_ir_sharding(
+        quantized,
+        rank=1,
+        world_size=8,
+        shard_layers=["mla"],
+    )
 
     assert quant_info.num_matches == 5
     assert shard_info.num_matches >= 6
+    wq_b = transformed.get_submodule("layers.0.attn.wq_b")
     wo_a = transformed.get_submodule("layers.0.attn.wo_a")
     wo_b = transformed.get_submodule("layers.0.attn.wo_b")
+    assert wq_b.weight.shape == (16, 32)
+    assert wq_b.weight_scale_inv.shape == (1, 1)
     assert wo_a.weight.dtype == torch.float8_e4m3fn
     assert wo_a.weight.shape == (128, 16)
     assert wo_a.weight_scale_inv.shape == (1, 1)
     assert wo_b.weight.shape == (128, 128)
     assert wo_b.weight_scale_inv.shape == (1, 1)
+    assert transformed.get_parameter("layers.0.attn.attn_sink").shape == (1,)
+
+    q_view_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.view)
+        and node.args[1][-1] == model.layers[0].attn.head_dim
+    )
+    assert q_view_node.args[1] == [1, 4, -1, 16]
+    sparse_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2)
+    )
+    assert _depends_on(sparse_node.args[0], q_view_node)
 
     grouped_node = next(
         node
@@ -619,6 +677,12 @@ def test_deepseek_v4_attention_wo_a_sharding_feeds_rowwise_wo_b_local_features()
     )
     assert wo_b_node.args[0].args[0] is grouped_node
     assert wo_a.weight.shape[0] // local_group_view.args[1][2] == wo_b.weight.shape[1]
+    assert any(
+        node.op == "call_function"
+        and "dist_all_reduce" in str(node.target)
+        and node.args[0] is wo_b_node
+        for node in transformed.graph.nodes
+    )
 
 
 def test_fp8_weight_dequant_preserves_fixed_block_scale_for_ragged_shapes() -> None:

--- a/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
+++ b/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
+from pathlib import Path
+
 import pytest
 import torch
 import torch.nn as nn
@@ -40,6 +44,11 @@ _requires_e8m0 = pytest.mark.skipif(
     not _HAS_E8M0,
     reason="torch.float8_e8m0fnu is not available in this PyTorch build",
 )
+_DEEPSEEK_V4_REAL_CKPT_ENV = "DEEPSEEK_V4_FLASH_CHECKPOINT"
+_DEFAULT_DEEPSEEK_V4_REAL_CKPT = Path(
+    "/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/"
+    "bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash"
+)
 
 
 class _DummyFactory:
@@ -56,15 +65,22 @@ class _DeepSeekV4LinearFixture(nn.Module):
         self.layers = nn.ModuleList([nn.Module()])
         self.layers[0].attn = nn.Module()
         self.layers[0].attn.wq_a = nn.Linear(16, 8, bias=False)
+        self.layers[0].attn.indexer = nn.Module()
+        self.layers[0].attn.indexer.wq_b = nn.Linear(16, 8, bias=False)
         self.layers[0].attn.compressor = nn.Module()
         self.layers[0].attn.compressor.wkv = nn.Linear(16, 8, bias=False)
         self.layers[0].ffn = nn.Module()
         self.layers[0].ffn.gate = nn.Linear(16, 4, bias=False)
 
-    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    def forward(
+        self, x: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         return (
             torch.ops.auto_deploy.torch_linear_simple.default(
                 x, self.layers[0].attn.wq_a.weight, None
+            ),
+            torch.ops.auto_deploy.torch_linear_simple.default(
+                x, self.layers[0].attn.indexer.wq_b.weight, None
             ),
             torch.ops.auto_deploy.torch_linear_simple.default(
                 x, self.layers[0].attn.compressor.wkv.weight, None
@@ -265,6 +281,48 @@ def _load_finegrained_state_dict(state_dict: dict[str, torch.Tensor], weight_nam
     transform.load_hook(state_dict, "", weight_name=weight_name)
 
 
+def _deepseek_v4_real_checkpoint_path() -> Path:
+    checkpoint_path = Path(
+        os.environ.get(_DEEPSEEK_V4_REAL_CKPT_ENV, _DEFAULT_DEEPSEEK_V4_REAL_CKPT)
+    )
+    if not checkpoint_path.exists():
+        pytest.skip(
+            f"DeepSeek V4 real checkpoint not found at {checkpoint_path}; set "
+            f"{_DEEPSEEK_V4_REAL_CKPT_ENV} to run this coverage."
+        )
+    index_path = checkpoint_path / "model.safetensors.index.json"
+    if not index_path.exists():
+        pytest.skip(f"DeepSeek V4 safetensors index not found at {index_path}.")
+    return checkpoint_path
+
+
+def _load_real_checkpoint_tensors(
+    checkpoint_path: Path,
+    tensor_names: list[str],
+) -> dict[str, torch.Tensor]:
+    safetensors = pytest.importorskip("safetensors")
+    weight_map = json.loads(
+        (checkpoint_path / "model.safetensors.index.json").read_text(encoding="utf-8")
+    )["weight_map"]
+    missing = [name for name in tensor_names if name not in weight_map]
+    assert missing == []
+
+    by_file: dict[str, list[str]] = {}
+    for name in tensor_names:
+        by_file.setdefault(weight_map[name], []).append(name)
+
+    tensors: dict[str, torch.Tensor] = {}
+    for filename, file_tensor_names in by_file.items():
+        with safetensors.safe_open(
+            checkpoint_path / filename,
+            framework="pt",
+            device="cpu",
+        ) as handle:
+            for name in file_tensor_names:
+                tensors[name] = handle.get_tensor(name)
+    return tensors
+
+
 def _depends_on(node: torch.fx.Node, target: torch.fx.Node) -> bool:
     def _node_args(value):
         if isinstance(value, torch.fx.Node):
@@ -335,6 +393,23 @@ def test_deepseek_v4_scale_alias_loads_into_weight_scale_inv() -> None:
     assert state_dict[scale_buffer].shape == (8, 32)
 
 
+def test_deepseek_v4_indexer_wq_b_scale_alias_loads_into_weight_scale_inv() -> None:
+    weight_name = "layers.10.attn.indexer.wq_b.weight"
+    scale_alias = "layers.10.attn.indexer.wq_b.scale"
+    scale_buffer = "layers.10.attn.indexer.wq_b.weight_scale_inv"
+    scale = torch.ones((64, 8), dtype=torch.bfloat16, device="cpu")
+    state_dict = {
+        weight_name: _fp8_weight((8192, 1024)),
+        scale_alias: scale,
+    }
+
+    _load_finegrained_state_dict(state_dict, weight_name)
+
+    assert scale_alias not in state_dict
+    assert state_dict[scale_buffer] is scale
+    assert state_dict[scale_buffer].shape == (64, 8)
+
+
 @_requires_e8m0
 def test_deepseek_v4_e8m0_scale_alias_decodes_to_fp32() -> None:
     weight_name = "layers.0.attn.wq_a.weight"
@@ -350,6 +425,23 @@ def test_deepseek_v4_e8m0_scale_alias_decodes_to_fp32() -> None:
     actual = state_dict["layers.0.attn.wq_a.weight_scale_inv"]
     assert actual.dtype == torch.float32
     torch.testing.assert_close(actual, e8m0_to_fp32(scale), rtol=0, atol=0)
+
+
+@_requires_e8m0
+def test_deepseek_v4_real_indexer_wq_b_scale_alias_decodes_to_fp32() -> None:
+    checkpoint_path = _deepseek_v4_real_checkpoint_path()
+    weight_name = "layers.10.attn.indexer.wq_b.weight"
+    scale_alias = "layers.10.attn.indexer.wq_b.scale"
+    state_dict = _load_real_checkpoint_tensors(checkpoint_path, [weight_name, scale_alias])
+    expected_scale = e8m0_to_fp32(state_dict[scale_alias])
+
+    _load_finegrained_state_dict(state_dict, weight_name)
+
+    assert scale_alias not in state_dict
+    actual = state_dict["layers.10.attn.indexer.wq_b.weight_scale_inv"]
+    assert actual.dtype == torch.float32
+    assert actual.shape == (64, 8)
+    torch.testing.assert_close(actual, expected_scale, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize(
@@ -391,9 +483,16 @@ def test_deepseek_v4_transform_quantizes_only_dense_fp8_linear_paths() -> None:
 
     transformed, info = _run_finegrained_transform(gm, _deepseek_v4_quant_config())
 
-    assert info.num_matches == 1
+    assert info.num_matches == 2
     assert transformed.get_submodule("layers.0.attn.wq_a").weight.dtype == torch.float8_e4m3fn
     assert transformed.get_submodule("layers.0.attn.wq_a").weight_scale_inv.shape == (1, 1)
+    assert (
+        transformed.get_submodule("layers.0.attn.indexer.wq_b").weight.dtype == torch.float8_e4m3fn
+    )
+    assert transformed.get_submodule("layers.0.attn.indexer.wq_b").weight_scale_inv.shape == (
+        1,
+        1,
+    )
     assert transformed.get_submodule("layers.0.ffn.gate").weight.dtype == torch.bfloat16
     assert transformed.get_submodule("layers.0.attn.compressor.wkv").weight.dtype == torch.bfloat16
 
@@ -407,7 +506,7 @@ def test_deepseek_v4_transform_quantizes_only_dense_fp8_linear_paths() -> None:
         for node in transformed.graph.nodes
         if is_op(node, torch.ops.auto_deploy.torch_linear_simple)
     ]
-    assert len(quantized_nodes) == 1
+    assert len(quantized_nodes) == 2
     assert len(plain_nodes) == 2
 
 

--- a/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
+++ b/tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py
@@ -19,6 +19,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import DeepseekV4Config
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4_ir import (
+    DeepseekV4Attention,
+)
 from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
 from tensorrt_llm._torch.auto_deploy.transform.library.quantization import (
     FineGrainedFP8LinearQuantization,
@@ -167,6 +172,30 @@ class _DeepSeekV4WoALocalViewShardingFixture(_DeepSeekV4WoAShardingFixture):
             None,
             [self.layers[0].attn.wo_a.weight_scale_inv],
         )
+
+
+class _DeepSeekV4AttentionWoBShardingFixture(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        config = DeepseekV4Config(
+            vocab_size=16,
+            hidden_size=128,
+            num_hidden_layers=1,
+            num_attention_heads=8,
+            head_dim=16,
+            q_lora_rank=32,
+            qk_rope_head_dim=4,
+            o_groups=8,
+            o_lora_rank=128,
+            sliding_window=2,
+            compress_ratios=(0,),
+            ad_rope_cache_len=16,
+        )
+        self.layers = nn.ModuleList([nn.Module()])
+        self.layers[0].attn = DeepseekV4Attention(config, layer_idx=0)
+
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        return self.layers[0].attn(x, position_ids)
 
 
 def _trace_with_weight_meta(module: nn.Module) -> torch.fx.GraphModule:
@@ -547,6 +576,49 @@ def test_deepseek_v4_wo_a_grouped_sharding_skips_input_slice_after_local_group_v
         2 * model.o_lora_rank,
         model.group_dim,
     )
+
+
+def test_deepseek_v4_attention_wo_a_sharding_feeds_rowwise_wo_b_local_features() -> None:
+    model = _DeepSeekV4AttentionWoBShardingFixture().to(torch.bfloat16)
+    gm = torch_export_to_gm(
+        model,
+        args=(
+            torch.randn(1, 4, 128, dtype=torch.bfloat16),
+            torch.arange(4, dtype=torch.long).unsqueeze(0),
+        ),
+    )
+
+    quantized, quant_info = _run_finegrained_transform(gm, _deepseek_v4_quant_config())
+    transformed, shard_info = _run_ir_sharding(quantized, rank=1, world_size=8)
+
+    assert quant_info.num_matches == 5
+    assert shard_info.num_matches >= 6
+    wo_a = transformed.get_submodule("layers.0.attn.wo_a")
+    wo_b = transformed.get_submodule("layers.0.attn.wo_b")
+    assert wo_a.weight.dtype == torch.float8_e4m3fn
+    assert wo_a.weight.shape == (128, 16)
+    assert wo_a.weight_scale_inv.shape == (1, 1)
+    assert wo_b.weight.shape == (128, 128)
+    assert wo_b.weight_scale_inv.shape == (1, 1)
+
+    grouped_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(
+            node,
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+        )
+    )
+    local_group_view = grouped_node.args[0]
+    assert local_group_view.args[1] == [1, 4, 1, -1]
+    wo_b_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear)
+        and node.args[1].target == "layers.0.attn.wo_b.weight"
+    )
+    assert wo_b_node.args[0].args[0] is grouped_node
+    assert wo_a.weight.shape[0] // local_group_view.args[1][2] == wo_b.weight.shape[1]
 
 
 def test_fp8_weight_dequant_preserves_fixed_block_scale_for_ragged_shapes() -> None:

--- a/tests/unittest/_torch/auto_deploy/unit/runtime/test_deepseek_v4_cache_resources.py
+++ b/tests/unittest/_torch/auto_deploy/unit/runtime/test_deepseek_v4_cache_resources.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import (
+    DeepSeekV4CacheResourceDescriptor,
+    PagedResourceSequenceMetadata,
+    SequenceInfo,
+    UnpagedResourceHandler,
+)
+from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+
+
+def _descriptor_set() -> dict[str, DeepSeekV4CacheResourceDescriptor]:
+    return {
+        "swa": DeepSeekV4CacheResourceDescriptor(
+            resource_name="swa",
+            cache_suffix="swa_kv_cache",
+            token_shape=(2, 1, 8),
+            dtype=torch.float16,
+            logical_length_divisor=1,
+            tokens_per_block=4,
+            max_logical_entries_per_seq=16,
+        ),
+        "mhc": DeepSeekV4CacheResourceDescriptor(
+            resource_name="mhc",
+            cache_suffix="mhc_cache",
+            token_shape=(1, 8),
+            dtype=torch.bfloat16,
+            logical_length_divisor=4,
+            tokens_per_block=2,
+            max_logical_entries_per_seq=4,
+        ),
+        "indexer": DeepSeekV4CacheResourceDescriptor(
+            resource_name="indexer",
+            cache_suffix="indexer_cache",
+            token_shape=(1, 4),
+            dtype=torch.float16,
+            logical_length_divisor=4,
+            tokens_per_block=2,
+            max_logical_entries_per_seq=4,
+        ),
+        "compressor_state": DeepSeekV4CacheResourceDescriptor(
+            resource_name="compressor_state",
+            cache_suffix="compressor_state",
+            token_shape=(4, 8),
+            dtype=torch.bfloat16,
+            logical_length_divisor=1,
+            tokens_per_block=1,
+            max_logical_entries_per_seq=1,
+        ),
+    }
+
+
+def _sequence_info() -> SequenceInfo:
+    seq_info = SequenceInfo(
+        max_seq_len=256,
+        max_batch_size=2,
+        max_num_tokens=16,
+        tokens_per_block=4,
+    )
+    seq_info.to("cpu")
+    seq_info.update_cache_information(num_blocks=32)
+    return seq_info
+
+
+def test_deepseek_v4_resource_handlers_allocate_paged_pools() -> None:
+    seq_info = _sequence_info()
+
+    for descriptor in _descriptor_set().values():
+        handler = descriptor.create_handler()
+        metadata_names = handler.register_metadata(seq_info)
+        cache = handler.allocate(seq_info)
+
+        assert handler.is_paged
+        assert not isinstance(handler, UnpagedResourceHandler)
+        assert metadata_names.cache_loc in seq_info.available_args
+        assert metadata_names.cu_num_pages in seq_info.available_args
+
+        expected_pages = seq_info.max_batch_size * handler.max_pages_per_seq(seq_info) + 1
+        expected_shape = (
+            expected_pages,
+            handler.tokens_per_block or seq_info.tokens_per_block,
+            *handler.token_shape,
+        )
+        assert cache.shape == expected_shape
+        assert cache.dtype == descriptor.dtype
+        assert cache.device.type == "cpu"
+
+
+def test_sequence_info_indexes_named_v4_page_tables_with_different_lengths() -> None:
+    seq_info = _sequence_info()
+    descriptors = _descriptor_set()
+    for descriptor in descriptors.values():
+        descriptor.create_handler().register_metadata(seq_info)
+
+    token_lengths = [9, 13]
+    paged_metadata = {
+        "swa": PagedResourceSequenceMetadata(
+            cache_loc=[7, 8, 9, 7, 8, 10, 11],
+            cu_num_pages=[0, 3, 7],
+            seq_len_with_cache=descriptors["swa"].logical_lengths(token_lengths),
+        ),
+        "mhc": descriptors["mhc"].build_metadata(
+            page_assignments=[[21, 22], [21, 23]],
+            token_lengths=token_lengths,
+        ),
+        "indexer": descriptors["indexer"].build_metadata(
+            page_assignments=[[31, 32], [31, 33]],
+            token_lengths=token_lengths,
+        ),
+        "compressor_state": descriptors["compressor_state"].build_metadata(
+            page_assignments=[[41], [42]],
+            token_lengths=[1, 1],
+        ),
+    }
+
+    seq_info.nest_sequences(
+        input_ids=torch.arange(4, dtype=torch.int),
+        cu_seqlen=[0, 2, 4],
+        input_pos=[0, 0],
+        paged_resource_metadata=paged_metadata,
+        slot_idx=[0, 1],
+    )
+
+    swa_args = seq_info.get_paged_resource_args("swa", host=True)
+    mhc_args = seq_info.get_paged_resource_args("mhc", host=True)
+
+    assert swa_args["cache_loc"].tolist() == [7, 8, 9, 7, 8, 10, 11]
+    assert swa_args["cu_num_pages"].tolist() == [0, 3, 7]
+    assert mhc_args["cache_loc"].tolist() == [21, 22, 21, 23]
+    assert mhc_args["cu_num_pages"].tolist() == [0, 2, 4]
+
+    assert swa_args["cache_loc"][:2].tolist() == swa_args["cache_loc"][3:5].tolist()
+    assert mhc_args["cache_loc"][0].item() == mhc_args["cache_loc"][2].item()
+    assert swa_args["seq_len_with_cache"].tolist() == token_lengths
+    assert mhc_args["seq_len_with_cache"].tolist() == [3, 4]
+    assert swa_args["last_page_len"].tolist() == [1, 1]
+    assert mhc_args["last_page_len"].tolist() == [1, 2]
+
+
+def test_ratio_128_compressed_metadata_uses_fewer_entries_than_token_cache() -> None:
+    token_cache = DeepSeekV4CacheResourceDescriptor(
+        resource_name="swa",
+        cache_suffix="swa_kv_cache",
+        token_shape=(1, 8),
+        dtype=torch.float16,
+        logical_length_divisor=1,
+        tokens_per_block=8,
+    )
+    ratio_128_cache = DeepSeekV4CacheResourceDescriptor(
+        resource_name="mhc",
+        cache_suffix="mhc_cache",
+        token_shape=(1, 8),
+        dtype=torch.bfloat16,
+        logical_length_divisor=128,
+        tokens_per_block=2,
+    )
+
+    token_lengths = [128, 129, 255]
+
+    assert token_cache.logical_lengths(token_lengths).tolist() == token_lengths
+    assert ratio_128_cache.logical_lengths(token_lengths).tolist() == [1, 2, 2]
+    assert ratio_128_cache.page_counts(token_lengths).tolist() == [1, 1, 1]
+    assert torch.all(
+        ratio_128_cache.page_counts(token_lengths) < token_cache.page_counts(token_lengths)
+    )
+
+
+def test_v4_paged_resources_keep_prefix_reuse_enabled_without_unpaged_fallback() -> None:
+    interface = CachedSequenceInterface(
+        max_seq_len=256,
+        max_batch_size=2,
+        max_num_tokens=16,
+        device="cpu",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=4,
+            max_tokens=64,
+            free_gpu_memory_fraction=0.0,
+            enable_block_reuse=True,
+            copy_on_partial_reuse=True,
+        ),
+    )
+
+    resource_names = interface.add_resource_group(
+        {
+            descriptor.cache_suffix: descriptor.create_handler()
+            for descriptor in _descriptor_set().values()
+        }
+    )
+    interface._caches = {name: None for name in interface._resource_lookup}
+
+    tuned_config = interface._prepare_kv_cache_config(max_tokens=32, kv_managed={})
+
+    assert list(resource_names) == [
+        "swa_kv_cache",
+        "mhc_cache",
+        "indexer_cache",
+        "compressor_state",
+    ]
+    assert all(handler.is_paged for handler in interface._resource_lookup.values())
+    assert tuned_config.enable_block_reuse is True
+    assert tuned_config.copy_on_partial_reuse is False

--- a/tests/unittest/_torch/auto_deploy/unit/runtime/test_deepseek_v4_cache_resources.py
+++ b/tests/unittest/_torch/auto_deploy/unit/runtime/test_deepseek_v4_cache_resources.py
@@ -18,6 +18,7 @@ import torch
 from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import (
     DeepSeekV4CacheResourceDescriptor,
+    PagedResourceMetadataNames,
     PagedResourceSequenceMetadata,
     SequenceInfo,
     UnpagedResourceHandler,
@@ -66,16 +67,39 @@ def _descriptor_set() -> dict[str, DeepSeekV4CacheResourceDescriptor]:
     }
 
 
-def _sequence_info() -> SequenceInfo:
+def _sequence_info(max_num_tokens: int = 16) -> SequenceInfo:
     seq_info = SequenceInfo(
         max_seq_len=256,
         max_batch_size=2,
-        max_num_tokens=16,
+        max_num_tokens=max_num_tokens,
         tokens_per_block=4,
     )
     seq_info.to("cpu")
     seq_info.update_cache_information(num_blocks=32)
     return seq_info
+
+
+def _register_all_metadata(
+    seq_info: SequenceInfo,
+) -> tuple[
+    dict[str, DeepSeekV4CacheResourceDescriptor],
+    dict[str, PagedResourceMetadataNames],
+]:
+    descriptors = _descriptor_set()
+    metadata_names = {}
+    for descriptor in descriptors.values():
+        metadata_names[descriptor.resource_name] = descriptor.create_handler().register_metadata(
+            seq_info
+        )
+    return descriptors, metadata_names
+
+
+def _activate_named_metadata_host_args(
+    seq_info: SequenceInfo, metadata_names: dict[str, PagedResourceMetadataNames]
+) -> None:
+    for names in metadata_names.values():
+        for arg_name in names.all_arg_names():
+            seq_info.activate_arg(f"{arg_name}_host")
 
 
 def test_deepseek_v4_resource_handlers_allocate_paged_pools() -> None:
@@ -151,6 +175,77 @@ def test_sequence_info_indexes_named_v4_page_tables_with_different_lengths() -> 
     assert mhc_args["seq_len_with_cache"].tolist() == [3, 4]
     assert swa_args["last_page_len"].tolist() == [1, 1]
     assert mhc_args["last_page_len"].tolist() == [1, 2]
+
+
+def test_sequence_info_advances_named_v4_page_metadata_after_switch_to_generate() -> None:
+    seq_info = _sequence_info(max_num_tokens=32)
+    descriptors, metadata_names = _register_all_metadata(seq_info)
+    _activate_named_metadata_host_args(seq_info, metadata_names)
+
+    token_lengths = [8, 9]
+    paged_metadata = {
+        "swa": descriptors["swa"].build_metadata(
+            page_assignments=[[10, 11], [20, 21, 22]],
+            token_lengths=token_lengths,
+        ),
+        "mhc": descriptors["mhc"].build_metadata(
+            page_assignments=[[30], [40, 41]],
+            token_lengths=token_lengths,
+        ),
+        "indexer": descriptors["indexer"].build_metadata(
+            page_assignments=[[50], [60, 61]],
+            token_lengths=token_lengths,
+        ),
+        "compressor_state": descriptors["compressor_state"].build_metadata(
+            page_assignments=[[70], [80]],
+            token_lengths=[1, 1],
+        ),
+    }
+
+    seq_info.nest_sequences(
+        input_ids=torch.arange(sum(token_lengths), dtype=torch.int),
+        cu_seqlen=[0, token_lengths[0], sum(token_lengths)],
+        input_pos=[0, 0],
+        paged_resource_metadata=paged_metadata,
+        extra_page_per_seq=[90, 91],
+        slot_idx=[0, 1],
+    )
+
+    seq_info.switch_to_generate_()
+
+    assert seq_info.get_arg("input_pos_host", truncate=True).tolist() == [7, 8]
+    assert seq_info.get_arg("seq_len_host", truncate=True).tolist() == [1, 1]
+    assert seq_info.get_paged_resource_args("swa", host=True)["seq_len_with_cache"].tolist() == [
+        8,
+        9,
+    ]
+
+    seq_info.offset_pos_and_cache_(torch.ones(2, dtype=torch.int32))
+
+    swa_args = seq_info.get_paged_resource_args("swa", host=True)
+    mhc_args = seq_info.get_paged_resource_args("mhc", host=True)
+    indexer_args = seq_info.get_paged_resource_args("indexer", host=True)
+    compressor_args = seq_info.get_paged_resource_args("compressor_state", host=True)
+
+    assert swa_args["seq_len_with_cache"].tolist() == [9, 10]
+    assert swa_args["last_page_len"].tolist() == [1, 2]
+    assert swa_args["cu_num_pages"].tolist() == [0, 3, 6]
+    assert swa_args["cache_loc"].tolist() == [10, 11, 90, 20, 21, 22]
+
+    assert mhc_args["seq_len_with_cache"].tolist() == [3, 3]
+    assert mhc_args["last_page_len"].tolist() == [1, 1]
+    assert mhc_args["cu_num_pages"].tolist() == [0, 2, 4]
+    assert mhc_args["cache_loc"].tolist() == [30, 90, 40, 41]
+
+    assert indexer_args["seq_len_with_cache"].tolist() == [3, 3]
+    assert indexer_args["last_page_len"].tolist() == [1, 1]
+    assert indexer_args["cu_num_pages"].tolist() == [0, 2, 4]
+    assert indexer_args["cache_loc"].tolist() == [50, 90, 60, 61]
+
+    assert compressor_args["seq_len_with_cache"].tolist() == [1, 1]
+    assert compressor_args["last_page_len"].tolist() == [1, 1]
+    assert compressor_args["cu_num_pages"].tolist() == [0, 1, 2]
+    assert compressor_args["cache_loc"].tolist() == [70, 80]
 
 
 def test_ratio_128_compressed_metadata_uses_fewer_entries_than_token_cache() -> None:

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py
@@ -1,0 +1,720 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hierarchical DeepSeek V4 tests against a minimal HF-reference copy.
+
+DeepSeek V4 Flash does not ship a standard HuggingFace ``modeling_*.py`` file.
+The reference implementation lives in ``inference/model.py`` in the HF repo, so
+these tests carry a small plain-PyTorch copy of the prefill math.
+"""
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.export import Dim
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 -- register ops
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
+    DeepseekV4Config,
+    DeepseekV4ForCausalLM,
+    DeepseekV4RMSNorm,
+)
+
+
+def assert_rmse_close(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    rmse_ratio_tol: float,
+    msg: str = "",
+) -> None:
+    diff = actual.float() - expected.float()
+    rmse_diff = torch.sqrt(torch.mean(diff**2))
+    rmse_ref = torch.sqrt(torch.mean(expected.float() ** 2))
+    ratio = (rmse_diff / rmse_ref.clamp_min(1e-12)).item()
+    assert ratio < rmse_ratio_tol, (
+        f"{msg}RMSE ratio {ratio:.6f} exceeds tolerance {rmse_ratio_tol}. "
+        f"(rmse_diff={rmse_diff.item():.6f}, rmse_ref={rmse_ref.item():.6f})"
+    )
+
+
+def _position_ids(batch: int, seq: int, device) -> torch.Tensor:
+    return torch.arange(seq, device=device).unsqueeze(0).expand(batch, -1)
+
+
+def _small_config(**overrides) -> DeepseekV4Config:
+    values = dict(
+        vocab_size=64,
+        hidden_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        head_dim=8,
+        q_lora_rank=8,
+        qk_rope_head_dim=4,
+        o_groups=1,
+        o_lora_rank=8,
+        sliding_window=4,
+        compress_ratios=(0, 4),
+        compress_rope_theta=10000.0,
+        moe_intermediate_size=8,
+        n_routed_experts=4,
+        n_shared_experts=1,
+        num_experts_per_tok=2,
+        num_hash_layers=1,
+        scoring_func="sqrtsoftplus",
+        routed_scaling_factor=1.25,
+        swiglu_limit=0.0,
+        max_position_embeddings=32,
+        rope_scaling={
+            "type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 0,
+            "beta_fast": 32,
+            "beta_slow": 1,
+        },
+        rms_norm_eps=1e-6,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+        hc_eps=1e-6,
+    )
+    values.update(overrides)
+    return DeepseekV4Config(**values)
+
+
+_DEEPSEEK_V4_CHECKPOINT_SAMPLE_KEYS = {
+    "embed.weight",
+    "head.weight",
+    "hc_head_base",
+    "hc_head_fn",
+    "hc_head_scale",
+    "layers.0.attn.attn_sink",
+    "layers.0.attn.wq_a.weight",
+    "layers.0.attn.wq_b.weight",
+    "layers.0.attn.wkv.weight",
+    "layers.0.ffn.experts.0.w1.weight",
+    "layers.0.ffn.experts.0.w2.weight",
+    "layers.0.ffn.experts.0.w3.weight",
+    "layers.0.ffn.gate.tid2eid",
+    "layers.0.ffn.shared_experts.w1.weight",
+    "layers.0.ffn.shared_experts.w2.weight",
+    "layers.0.ffn.shared_experts.w3.weight",
+    "layers.0.hc_attn_fn",
+    "layers.0.hc_ffn_fn",
+    "norm.weight",
+}
+
+
+_STACKED_EXPERT_RE = re.compile(
+    r"^(?P<prefix>layers\.\d+\.ffn\.experts)\.(?P<proj>w[123])\.(?P<suffix>weight|scale)$"
+)
+
+
+def _convert_deepseek_v4_reference_state_dict(state_dict, num_experts):
+    """Convert possible stacked reference MoE tensors to checkpoint-style per-expert keys.
+
+    The observed DeepSeek V4 Flash safetensor index already uses per-expert keys
+    such as ``layers.0.ffn.experts.0.w1.weight``. This helper also supports the
+    common test/reference form ``layers.0.ffn.experts.w1.weight`` with expert
+    stacked on dim 0, so MoE conversion behavior is explicit and covered.
+    """
+    converted = {}
+    for key, value in state_dict.items():
+        match = _STACKED_EXPERT_RE.match(key)
+        if match is None:
+            converted[key] = value
+            continue
+
+        assert value.shape[0] == num_experts
+        prefix = match.group("prefix")
+        proj = match.group("proj")
+        suffix = match.group("suffix")
+        for expert_idx in range(num_experts):
+            converted[f"{prefix}.{expert_idx}.{proj}.{suffix}"] = value[expert_idx]
+    return converted
+
+
+def _ref_linear(x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor] = None):
+    return F.linear(x, weight, bias)
+
+
+def _ref_rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    dtype = x.dtype
+    x = x.float()
+    variance = x.square().mean(-1, keepdim=True)
+    return (weight * x * torch.rsqrt(variance + eps)).to(dtype)
+
+
+def _ref_freqs_cis(
+    position_ids: torch.Tensor,
+    dim: int,
+    original_seq_len: int,
+    base: float,
+    factor: float,
+    beta_fast: int,
+    beta_slow: int,
+) -> torch.Tensor:
+    freqs = 1.0 / (
+        base ** (torch.arange(0, dim, 2, dtype=torch.float32, device=position_ids.device) / dim)
+    )
+    if original_seq_len > 0:
+
+        def find_correction_dim(num_rotations):
+            return (
+                dim
+                * math.log(original_seq_len / (num_rotations * 2 * math.pi))
+                / (2 * math.log(base))
+            )
+
+        low = max(math.floor(find_correction_dim(beta_fast)), 0)
+        high = min(math.ceil(find_correction_dim(beta_slow)), dim - 1)
+        if low == high:
+            high += 0.001
+        smooth = 1 - torch.clamp(
+            (torch.arange(dim // 2, dtype=torch.float32, device=position_ids.device) - low)
+            / (high - low),
+            0,
+            1,
+        )
+        freqs = freqs / factor * (1 - smooth) + freqs * smooth
+    phase = position_ids.to(torch.float32).unsqueeze(-1) * freqs
+    return torch.polar(torch.ones_like(phase), phase)
+
+
+def _ref_apply_rope(x: torch.Tensor, freqs_cis: torch.Tensor, inverse: bool = False):
+    y = torch.view_as_complex(x.float().unflatten(-1, (-1, 2)))
+    freqs = freqs_cis.conj() if inverse else freqs_cis
+    if x.ndim == 3:
+        freqs = freqs.view(x.shape[0], x.shape[1], -1)
+    else:
+        freqs = freqs.view(x.shape[0], x.shape[1], 1, -1)
+    return torch.view_as_real(y * freqs).flatten(-2).to(x.dtype)
+
+
+def _ref_window_topk(window_size: int, batch_size: int, seq_len: int, device):
+    positions = torch.arange(seq_len, device=device)
+    offsets = torch.arange(window_size, device=device)
+    matrix = (positions[:, None] - window_size + 1).clamp(min=0) + offsets[None, :]
+    matrix = torch.where(matrix <= positions[:, None], matrix, -1)
+    return matrix.unsqueeze(0).expand(batch_size, -1, -1)
+
+
+def _ref_compress_topk(ratio: int, batch_size: int, seq_len: int, offset: int, device):
+    compressed_len = seq_len // ratio
+    compressed = torch.arange(compressed_len, device=device)
+    matrix = compressed.unsqueeze(0).expand(seq_len, -1)
+    valid_lengths = torch.arange(1, seq_len + 1, device=device).unsqueeze(1) // ratio
+    matrix = torch.where(matrix < valid_lengths, matrix + offset, -1)
+    return matrix.unsqueeze(0).expand(batch_size, -1, -1)
+
+
+def _ref_sparse_attention(q, kv, attn_sink, topk_idxs, softmax_scale):
+    batch_size, seq_len, _, head_dim = q.shape
+    gather = topk_idxs.clamp(min=0).unsqueeze(-1).expand(-1, -1, -1, head_dim)
+    selected = torch.gather(kv.unsqueeze(1).expand(-1, seq_len, -1, -1), 2, gather)
+    scores = torch.einsum("bshd,bskd->bshk", q.float(), selected.float()) * softmax_scale
+    scores = torch.where(
+        (topk_idxs < 0).unsqueeze(2), torch.full_like(scores, float("-inf")), scores
+    )
+    sink = attn_sink.view(1, 1, -1, 1).expand(batch_size, seq_len, -1, -1)
+    probs = torch.softmax(torch.cat([scores, sink], dim=-1), dim=-1)[..., :-1]
+    return torch.einsum("bshk,bskd->bshd", probs.to(selected.dtype), selected).to(q.dtype)
+
+
+def _ref_hc_split_sinkhorn(mixes, hc_scale, hc_base, hc_mult, sinkhorn_iters, eps):
+    pre = torch.sigmoid(mixes[..., :hc_mult] * hc_scale[0] + hc_base[:hc_mult]) + eps
+    post = 2 * torch.sigmoid(
+        mixes[..., hc_mult : 2 * hc_mult] * hc_scale[1] + hc_base[hc_mult : 2 * hc_mult]
+    )
+    comb = mixes[..., 2 * hc_mult :].view(*mixes.shape[:-1], hc_mult, hc_mult)
+    comb = comb * hc_scale[2] + hc_base[2 * hc_mult :].view(hc_mult, hc_mult)
+    comb = torch.softmax(comb, dim=-1) + eps
+    comb = comb / (comb.sum(dim=-2, keepdim=True) + eps)
+    for _ in range(sinkhorn_iters - 1):
+        comb = comb / (comb.sum(dim=-1, keepdim=True) + eps)
+        comb = comb / (comb.sum(dim=-2, keepdim=True) + eps)
+    return pre, post, comb
+
+
+class _RefLinear(nn.Module):
+    def __init__(self, in_features, out_features):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(out_features, in_features))
+        self.register_parameter("bias", None)
+
+    def forward(self, x):
+        return _ref_linear(x, self.weight, self.bias)
+
+
+class _RefRMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size, dtype=torch.float32))
+        self.eps = eps
+
+    def forward(self, x):
+        return _ref_rmsnorm(x, self.weight, self.eps)
+
+
+class _RefCompressor(nn.Module):
+    def __init__(self, config, compress_ratio, head_dim):
+        super().__init__()
+        self.head_dim = head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.compress_ratio = compress_ratio
+        self.overlap = compress_ratio == 4
+        channels = 2 if self.overlap else 1
+        self.ape = nn.Parameter(torch.empty(compress_ratio, channels * head_dim))
+        self.wkv = _RefLinear(config.hidden_size, channels * head_dim)
+        self.wgate = _RefLinear(config.hidden_size, channels * head_dim)
+        self.norm = _RefRMSNorm(head_dim, config.rms_norm_eps)
+
+    def _overlap_transform(self, tensor, value):
+        batch_size, compressed_len, _, _ = tensor.shape
+        ratio, head_dim = self.compress_ratio, self.head_dim
+        out = tensor.new_full((batch_size, compressed_len, 2 * ratio, head_dim), value)
+        out[:, :, ratio:] = tensor[:, :, :, head_dim:]
+        out[:, 1:, :ratio] = tensor[:, :-1, :, :head_dim]
+        return out
+
+    def forward(self, x, freqs_cis):
+        batch_size, seq_len, _ = x.shape
+        ratio = self.compress_ratio
+        cutoff = (seq_len // ratio) * ratio
+        kv = self.wkv(x.float())[:, :cutoff]
+        score = self.wgate(x.float())[:, :cutoff]
+        kv = kv.view(batch_size, -1, ratio, kv.shape[-1])
+        score = score.view(batch_size, -1, ratio, score.shape[-1]) + self.ape
+        if self.overlap:
+            kv = self._overlap_transform(kv, 0)
+            score = self._overlap_transform(score, float("-inf"))
+        kv = (kv * score.softmax(dim=2)).sum(dim=2)
+        kv = self.norm(kv.to(x.dtype))
+        rope = _ref_apply_rope(kv[..., -self.rope_head_dim :], freqs_cis[:, :cutoff:ratio])
+        return torch.cat([kv[..., : -self.rope_head_dim], rope], dim=-1)
+
+
+class _RefAttention(nn.Module):
+    def __init__(self, config, layer_idx):
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.num_groups = config.o_groups
+        self.o_lora_rank = config.o_lora_rank
+        self.window_size = config.sliding_window
+        self.compress_ratio = config.compress_ratios[layer_idx]
+        self.eps = config.rms_norm_eps
+        self.softmax_scale = self.head_dim**-0.5
+        self.attn_sink = nn.Parameter(torch.empty(self.num_heads))
+        self.wq_a = _RefLinear(config.hidden_size, config.q_lora_rank)
+        self.q_norm = _RefRMSNorm(config.q_lora_rank, self.eps)
+        self.wq_b = _RefLinear(config.q_lora_rank, self.num_heads * self.head_dim)
+        self.wkv = _RefLinear(config.hidden_size, self.head_dim)
+        self.kv_norm = _RefRMSNorm(self.head_dim, self.eps)
+        self.wo_a = _RefLinear(
+            self.num_heads * self.head_dim // self.num_groups,
+            self.num_groups * self.o_lora_rank,
+        )
+        self.wo_b = _RefLinear(self.num_groups * self.o_lora_rank, config.hidden_size)
+        if self.compress_ratio:
+            self.compressor = _RefCompressor(config, self.compress_ratio, self.head_dim)
+            self.rope_original_seq_len = config.rope_scaling["original_max_position_embeddings"]
+            self.rope_base = config.compress_rope_theta
+        else:
+            self.rope_original_seq_len = 0
+            self.rope_base = config.rope_theta
+        self.rope_factor = config.rope_scaling["factor"]
+        self.rope_beta_fast = config.rope_scaling["beta_fast"]
+        self.rope_beta_slow = config.rope_scaling["beta_slow"]
+
+    def _freqs_cis(self, position_ids):
+        return _ref_freqs_cis(
+            position_ids,
+            self.rope_head_dim,
+            self.rope_original_seq_len,
+            self.rope_base,
+            self.rope_factor,
+            self.rope_beta_fast,
+            self.rope_beta_slow,
+        )
+
+    def forward(self, x, position_ids):
+        batch_size, seq_len, _ = x.shape
+        freqs_cis = self._freqs_cis(position_ids)
+        qr = self.q_norm(self.wq_a(x))
+        q = self.wq_b(qr).view(batch_size, seq_len, self.num_heads, self.head_dim)
+        q = q * torch.rsqrt(q.square().mean(-1, keepdim=True) + self.eps)
+        q = torch.cat(
+            [
+                q[..., : -self.rope_head_dim],
+                _ref_apply_rope(q[..., -self.rope_head_dim :], freqs_cis),
+            ],
+            dim=-1,
+        )
+        kv = self.kv_norm(self.wkv(x))
+        kv = torch.cat(
+            [
+                kv[..., : -self.rope_head_dim],
+                _ref_apply_rope(kv[..., -self.rope_head_dim :], freqs_cis),
+            ],
+            dim=-1,
+        )
+        topk_idxs = _ref_window_topk(self.window_size, batch_size, seq_len, x.device)
+        if self.compress_ratio:
+            compressed = self.compressor(x, freqs_cis)
+            compressed_idxs = _ref_compress_topk(
+                self.compress_ratio, batch_size, seq_len, seq_len, x.device
+            )
+            topk_idxs = torch.cat([topk_idxs, compressed_idxs], dim=-1)
+            kv = torch.cat([kv, compressed], dim=1)
+        o = _ref_sparse_attention(q, kv, self.attn_sink, topk_idxs.int(), self.softmax_scale)
+        o = torch.cat(
+            [
+                o[..., : -self.rope_head_dim],
+                _ref_apply_rope(o[..., -self.rope_head_dim :], freqs_cis, inverse=True),
+            ],
+            dim=-1,
+        )
+        o = o.view(batch_size, seq_len, self.num_groups, -1)
+        wo_a = self.wo_a.weight.view(self.num_groups, self.o_lora_rank, -1)
+        return self.wo_b(torch.einsum("bsgd,grd->bsgr", o, wo_a).flatten(2))
+
+
+class _RefGate(nn.Module):
+    def __init__(self, config, layer_idx):
+        super().__init__()
+        self.topk = config.num_experts_per_tok
+        self.score_func = config.scoring_func
+        self.route_scale = config.routed_scaling_factor
+        self.is_hash = layer_idx < config.num_hash_layers
+        self.weight = nn.Parameter(torch.empty(config.n_routed_experts, config.hidden_size))
+        if self.is_hash:
+            initial = torch.arange(self.topk, dtype=torch.int32) % config.n_routed_experts
+            self.tid2eid = nn.Parameter(
+                initial.unsqueeze(0).expand(config.vocab_size, -1).clone(), requires_grad=False
+            )
+            self.register_parameter("bias", None)
+        else:
+            self.bias = nn.Parameter(torch.zeros(config.n_routed_experts))
+
+    def forward(self, x, input_ids):
+        scores = F.linear(x.float(), self.weight.float())
+        if self.score_func == "softmax":
+            scores = scores.softmax(dim=-1)
+        elif self.score_func == "sigmoid":
+            scores = scores.sigmoid()
+        else:
+            scores = F.softplus(scores).sqrt()
+        original_scores = scores
+        if self.bias is not None:
+            scores = scores + self.bias
+        indices = self.tid2eid[input_ids] if self.is_hash else scores.topk(self.topk, dim=-1)[1]
+        weights = original_scores.gather(1, indices)
+        if self.score_func != "softmax":
+            weights = weights / weights.sum(dim=-1, keepdim=True)
+        return weights * self.route_scale, indices
+
+
+class _RefExpert(nn.Module):
+    def __init__(self, hidden_size, intermediate_size, swiglu_limit=0.0):
+        super().__init__()
+        self.w1 = _RefLinear(hidden_size, intermediate_size)
+        self.w2 = _RefLinear(intermediate_size, hidden_size)
+        self.w3 = _RefLinear(hidden_size, intermediate_size)
+        self.swiglu_limit = swiglu_limit
+
+    def forward(self, x):
+        gate = self.w1(x).float()
+        up = self.w3(x).float()
+        if self.swiglu_limit > 0:
+            up = torch.clamp(up, min=-self.swiglu_limit, max=self.swiglu_limit)
+            gate = torch.clamp(gate, max=self.swiglu_limit)
+        return self.w2((F.silu(gate) * up).to(x.dtype))
+
+
+class _RefMoE(nn.Module):
+    def __init__(self, config, layer_idx):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.gate = _RefGate(config, layer_idx)
+        self.experts = nn.ModuleList(
+            [
+                _RefExpert(config.hidden_size, config.moe_intermediate_size, config.swiglu_limit)
+                for _ in range(config.n_routed_experts)
+            ]
+        )
+        self.shared_experts = _RefExpert(config.hidden_size, config.moe_intermediate_size, 0.0)
+
+    def forward(self, x, input_ids):
+        shape = x.shape
+        x_flat = x.view(-1, self.hidden_size)
+        weights, indices = self.gate(x_flat, input_ids.flatten())
+        output = torch.zeros_like(x_flat)
+        for expert_idx, expert in enumerate(self.experts):
+            expert_weight = torch.where(
+                indices == expert_idx, weights, torch.zeros_like(weights)
+            ).sum(dim=-1, keepdim=True)
+            output = output + expert(x_flat) * expert_weight.to(x_flat.dtype)
+        output = output + self.shared_experts(x_flat)
+        return output.view(shape).to(x.dtype)
+
+
+class _RefBlock(nn.Module):
+    def __init__(self, config, layer_idx):
+        super().__init__()
+        self.norm_eps = config.rms_norm_eps
+        self.hc_mult = config.hc_mult
+        self.hc_sinkhorn_iters = config.hc_sinkhorn_iters
+        self.hc_eps = config.hc_eps
+        self.attn = _RefAttention(config, layer_idx)
+        self.ffn = _RefMoE(config, layer_idx)
+        self.attn_norm = _RefRMSNorm(config.hidden_size, self.norm_eps)
+        self.ffn_norm = _RefRMSNorm(config.hidden_size, self.norm_eps)
+        mix_hc = (2 + self.hc_mult) * self.hc_mult
+        hc_dim = self.hc_mult * config.hidden_size
+        self.hc_attn_fn = nn.Parameter(torch.empty(mix_hc, hc_dim))
+        self.hc_ffn_fn = nn.Parameter(torch.empty(mix_hc, hc_dim))
+        self.hc_attn_base = nn.Parameter(torch.empty(mix_hc))
+        self.hc_ffn_base = nn.Parameter(torch.empty(mix_hc))
+        self.hc_attn_scale = nn.Parameter(torch.empty(3))
+        self.hc_ffn_scale = nn.Parameter(torch.empty(3))
+
+    def _hc_pre(self, x, hc_fn, hc_scale, hc_base):
+        shape = x.shape
+        flat = x.flatten(2).float()
+        mixes = F.linear(flat, hc_fn) * torch.rsqrt(
+            flat.square().mean(-1, keepdim=True) + self.norm_eps
+        )
+        pre, post, comb = _ref_hc_split_sinkhorn(
+            mixes, hc_scale, hc_base, self.hc_mult, self.hc_sinkhorn_iters, self.hc_eps
+        )
+        return torch.sum(pre.unsqueeze(-1) * flat.view(shape), dim=2).to(x.dtype), post, comb
+
+    @staticmethod
+    def _hc_post(x, residual, post, comb):
+        return (
+            post.unsqueeze(-1) * x.unsqueeze(-2)
+            + torch.sum(comb.unsqueeze(-1) * residual.unsqueeze(-2), dim=2)
+        ).to(x.dtype)
+
+    def forward(self, x, position_ids, input_ids):
+        residual = x
+        x, post, comb = self._hc_pre(x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
+        x = self._hc_post(self.attn(self.attn_norm(x), position_ids), residual, post, comb)
+        residual = x
+        x, post, comb = self._hc_pre(x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
+        return self._hc_post(self.ffn(self.ffn_norm(x), input_ids), residual, post, comb)
+
+
+class _RefHead(nn.Module):
+    def __init__(self, vocab_size, hidden_size):
+        super().__init__()
+        self.weight = nn.Parameter(torch.empty(vocab_size, hidden_size))
+
+    def forward(self, x):
+        return F.linear(x.float(), self.weight.float()).to(x.dtype)
+
+
+@dataclass
+class _RefOutput:
+    logits: torch.Tensor
+
+
+class _RefForCausalLM(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.embed = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = nn.ModuleList(
+            [_RefBlock(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = _RefRMSNorm(config.hidden_size, config.rms_norm_eps)
+        self.head = _RefHead(config.vocab_size, config.hidden_size)
+        self.hc_mult = config.hc_mult
+        hc_dim = config.hc_mult * config.hidden_size
+        self.hc_head_fn = nn.Parameter(torch.empty(config.hc_mult, hc_dim))
+        self.hc_head_base = nn.Parameter(torch.empty(config.hc_mult))
+        self.hc_head_scale = nn.Parameter(torch.empty(1))
+
+    def _hc_head(self, x):
+        shape = x.shape
+        flat = x.flatten(2).float()
+        mixes = F.linear(flat, self.hc_head_fn) * torch.rsqrt(
+            flat.square().mean(-1, keepdim=True) + self.config.rms_norm_eps
+        )
+        pre = torch.sigmoid(mixes * self.hc_head_scale + self.hc_head_base) + self.config.hc_eps
+        return torch.sum(pre.unsqueeze(-1) * flat.view(shape), dim=2).to(x.dtype)
+
+    def forward(self, input_ids, position_ids):
+        hidden_states = self.embed(input_ids).unsqueeze(2).expand(-1, -1, self.hc_mult, -1)
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, position_ids, input_ids)
+        hidden_states = self.norm(self._hc_head(hidden_states))
+        return _RefOutput(logits=self.head(hidden_states))
+
+
+def _copy_to_reference(ad_module: nn.Module, ref_module: nn.Module) -> None:
+    ref_module.load_state_dict(ad_module.state_dict(), strict=True)
+
+
+def test_stacked_moe_reference_weights_convert_to_per_expert_keys():
+    config = _small_config(n_routed_experts=3)
+    stacked = {
+        "layers.0.ffn.experts.w1.weight": torch.randn(
+            config.n_routed_experts, config.moe_intermediate_size, config.hidden_size
+        ),
+        "layers.0.ffn.experts.w2.weight": torch.randn(
+            config.n_routed_experts, config.hidden_size, config.moe_intermediate_size
+        ),
+        "layers.0.ffn.experts.w3.weight": torch.randn(
+            config.n_routed_experts, config.moe_intermediate_size, config.hidden_size
+        ),
+        "layers.0.ffn.gate.weight": torch.randn(config.n_routed_experts, config.hidden_size),
+    }
+
+    converted = _convert_deepseek_v4_reference_state_dict(stacked, config.n_routed_experts)
+
+    assert "layers.0.ffn.experts.w1.weight" not in converted
+    assert "layers.0.ffn.experts.2.w3.weight" in converted
+    torch.testing.assert_close(
+        converted["layers.0.ffn.experts.1.w2.weight"],
+        stacked["layers.0.ffn.experts.w2.weight"][1],
+    )
+    torch.testing.assert_close(
+        converted["layers.0.ffn.gate.weight"], stacked["layers.0.ffn.gate.weight"]
+    )
+
+
+def test_state_dict_matches_deepseek_v4_checkpoint_hierarchy():
+    config = _small_config(num_hidden_layers=2, compress_ratios=(0, 4), num_hash_layers=1)
+    model = DeepseekV4ForCausalLM(config)
+    keys = set(model.state_dict())
+
+    # Sampled from deepseek-ai/DeepSeek-V4-Flash model.safetensors.index.json.
+    # The reference checkpoint stores routed MoE as per-expert w1/w2/w3 keys, so
+    # no stacked-MoE conversion helper is needed for these names.
+    missing = _DEEPSEEK_V4_CHECKPOINT_SAMPLE_KEYS - keys
+    assert not missing
+    assert "layers.1.ffn.gate.bias" in keys
+    assert "layers.1.ffn.gate.tid2eid" not in keys
+    assert not any(key.startswith("model.") for key in keys)
+
+
+def test_rmsnorm_matches_reference():
+    config = _small_config()
+    ad = DeepseekV4RMSNorm(config.hidden_size, config.rms_norm_eps)
+    x = torch.randn(2, 5, config.hidden_size)
+    expected = _ref_rmsnorm(x, ad.weight, config.rms_norm_eps)
+    torch.testing.assert_close(ad(x), expected, rtol=1e-6, atol=1e-6)
+
+
+def test_attention_matches_reference():
+    torch.manual_seed(1)
+    config = _small_config(num_hidden_layers=2, compress_ratios=(0, 4))
+    layer_idx = 1
+    ad = DeepseekV4ForCausalLM(config).layers[layer_idx].attn.eval()
+    ref = _RefAttention(config, layer_idx).eval()
+    _copy_to_reference(ad, ref)
+    x = torch.randn(2, 8, config.hidden_size)
+    pos = _position_ids(2, 8, x.device)
+    with torch.no_grad():
+        actual = ad(x, pos)
+        expected = ref(x, pos)
+    assert_rmse_close(actual, expected, rmse_ratio_tol=0.01, msg="Attention: ")
+
+
+def test_moe_with_swiglu_limit_matches_reference():
+    torch.manual_seed(2)
+    config = _small_config(swiglu_limit=2.0)
+    layer_idx = 1
+    ad = DeepseekV4ForCausalLM(config).layers[layer_idx].ffn.eval()
+    ref = _RefMoE(config, layer_idx).eval()
+    _copy_to_reference(ad, ref)
+    x = torch.randn(2, 4, config.hidden_size)
+    input_ids = torch.randint(0, config.vocab_size, (2, 4))
+    with torch.no_grad():
+        actual = ad(x, input_ids)
+        expected = ref(x, input_ids)
+    assert_rmse_close(actual, expected, rmse_ratio_tol=0.01, msg="MoE: ")
+
+
+def test_block_matches_reference():
+    torch.manual_seed(3)
+    config = _small_config(num_hidden_layers=1, compress_ratios=(0,))
+    ad = DeepseekV4ForCausalLM(config).layers[0].eval()
+    ref = _RefBlock(config, 0).eval()
+    _copy_to_reference(ad, ref)
+    x = torch.randn(2, 6, config.hc_mult, config.hidden_size)
+    pos = _position_ids(2, 6, x.device)
+    input_ids = torch.randint(0, config.vocab_size, (2, 6))
+    with torch.no_grad():
+        actual = ad(x, pos, input_ids)
+        expected = ref(x, pos, input_ids)
+    assert_rmse_close(actual, expected, rmse_ratio_tol=0.05, msg="Decoder layer: ")
+
+
+def test_full_model_matches_reference():
+    torch.manual_seed(4)
+    config = _small_config()
+    ad = DeepseekV4ForCausalLM(config).eval()
+    ref = _RefForCausalLM(config).eval()
+    _copy_to_reference(ad, ref)
+    input_ids = torch.randint(0, config.vocab_size, (2, 8))
+    pos = _position_ids(2, 8, input_ids.device)
+    with torch.no_grad():
+        actual = ad(input_ids=input_ids, position_ids=pos).logits
+        expected = ref(input_ids, pos).logits
+    assert_rmse_close(actual, expected, rmse_ratio_tol=0.05, msg="Full model: ")
+
+
+def test_export_produces_finite_logits_for_second_shape():
+    torch.manual_seed(5)
+    config = _small_config(num_hidden_layers=1, compress_ratios=(4,), num_hash_layers=0)
+    model = DeepseekV4ForCausalLM(config).eval()
+    input_ids = torch.randint(0, config.vocab_size, (2, 6))
+    pos = _position_ids(2, 6, input_ids.device)
+    dynamic_shapes = {
+        "input_ids": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        "position_ids": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    }
+    gm = torch_export_to_gm(
+        model,
+        args=(input_ids,),
+        kwargs={"position_ids": pos},
+        dynamic_shapes=dynamic_shapes,
+        num_moe_experts_for_export=2,
+    )
+    with torch.no_grad():
+        eager = model(input_ids=input_ids, position_ids=pos).logits
+        exported = gm(input_ids, position_ids=pos)
+    exported_logits = (
+        exported[0] if isinstance(exported, tuple) else getattr(exported, "logits", exported)
+    )
+    assert_rmse_close(exported_logits, eager, rmse_ratio_tol=0.05, msg="Export: ")
+
+    ids2 = torch.randint(0, config.vocab_size, (1, 4))
+    pos2 = _position_ids(1, 4, ids2.device)
+    with torch.no_grad():
+        eager2 = model(input_ids=ids2, position_ids=pos2).logits
+        out = gm(ids2, position_ids=pos2)
+    logits = out[0] if isinstance(out, tuple) else getattr(out, "logits", out)
+    assert logits.shape == (1, 4, config.vocab_size)
+    assert torch.isfinite(logits).all()
+    assert_rmse_close(logits, eager2, rmse_ratio_tol=0.05, msg="Export second shape: ")

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py
@@ -25,6 +25,7 @@ import re
 from dataclasses import dataclass
 from typing import Optional
 
+import pytest
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -33,6 +34,7 @@ from torch.export import Dim
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 -- register ops
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
+    DeepseekV4AutoModelForCausalLMFactory,
     DeepseekV4Config,
     DeepseekV4ForCausalLM,
     DeepseekV4RMSNorm,
@@ -640,6 +642,30 @@ def test_attention_matches_reference():
     assert_rmse_close(actual, expected, rmse_ratio_tol=0.01, msg="Attention: ")
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required for BF16 compressor")
+def test_compressor_accepts_bfloat16_checkpoint_weights():
+    torch.manual_seed(7)
+    config = _small_config(
+        num_hidden_layers=1,
+        compress_ratios=(128,),
+        max_position_embeddings=256,
+        ad_rope_cache_len=256,
+    )
+    attn = DeepseekV4ForCausalLM(config).layers[0].attn.eval().cuda()
+    compressor = attn.compressor
+    compressor.wkv.weight.data = compressor.wkv.weight.data.to(torch.bfloat16)
+    compressor.wgate.weight.data = compressor.wgate.weight.data.to(torch.bfloat16)
+    x = torch.randn(1, 256, config.hidden_size, device="cuda", dtype=torch.bfloat16)
+    pos = _position_ids(1, 256, x.device)
+
+    with torch.no_grad():
+        actual = compressor(x, pos, attn.rotary_emb())
+
+    assert actual.dtype == torch.bfloat16
+    assert actual.shape == (1, compressor.max_compressed_len, config.head_dim)
+    assert torch.isfinite(actual).all()
+
+
 def test_moe_with_swiglu_limit_matches_reference():
     torch.manual_seed(2)
     config = _small_config(swiglu_limit=2.0)
@@ -718,3 +744,115 @@ def test_export_produces_finite_logits_for_second_shape():
     assert logits.shape == (1, 4, config.vocab_size)
     assert torch.isfinite(logits).all()
     assert_rmse_close(logits, eager2, rmse_ratio_tol=0.05, msg="Export second shape: ")
+
+
+def test_export_accepts_short_sequence_with_large_compress_ratio():
+    torch.manual_seed(6)
+    config = _small_config(
+        num_hidden_layers=1,
+        compress_ratios=(128,),
+        num_hash_layers=0,
+        max_position_embeddings=256,
+        ad_rope_cache_len=256,
+    )
+    model = DeepseekV4ForCausalLM(config).eval()
+    input_ids = torch.randint(0, config.vocab_size, (2, 129))
+    pos = _position_ids(2, 129, input_ids.device)
+
+    gm = torch_export_to_gm(
+        model,
+        args=(input_ids,),
+        kwargs={"position_ids": pos},
+        dynamic_shapes={
+            "input_ids": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+            "position_ids": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        },
+        num_moe_experts_for_export=2,
+    )
+
+    short_ids = torch.randint(0, config.vocab_size, (1, 1))
+    short_pos = _position_ids(1, 1, short_ids.device)
+    with torch.no_grad():
+        eager = model(input_ids=short_ids, position_ids=short_pos).logits
+        exported = gm(short_ids, position_ids=short_pos)
+    exported_logits = (
+        exported[0] if isinstance(exported, tuple) else getattr(exported, "logits", exported)
+    )
+    assert exported_logits.shape == (1, 1, config.vocab_size)
+    assert torch.isfinite(exported_logits).all()
+    assert_rmse_close(exported_logits, eager, rmse_ratio_tol=0.05, msg="Export short shape: ")
+
+
+def test_export_emits_canonical_deepseek_v4_ops():
+    torch.manual_seed(6)
+    config = _small_config(
+        num_hidden_layers=2,
+        compress_ratios=(0, 4),
+        num_hash_layers=1,
+        swiglu_limit=10.0,
+    )
+    model = DeepseekV4ForCausalLM(config).eval()
+    input_ids = torch.randint(0, config.vocab_size, (2, 8))
+    pos = _position_ids(2, 8, input_ids.device)
+
+    gm = torch_export_to_gm(
+        model,
+        args=(input_ids,),
+        kwargs={"position_ids": pos},
+        dynamic_shapes={
+            "input_ids": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+            "position_ids": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        },
+        num_moe_experts_for_export=2,
+    )
+
+    targets = {node.target for node in gm.graph.nodes if node.op == "call_function"}
+    assert torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention.default in targets
+    assert torch.ops.auto_deploy.torch_deepseek_v4_moe.default in targets
+    assert torch.ops.auto_deploy.torch_moe.default not in targets
+
+
+def test_load_state_dict_skips_mtp_and_loads_normal_layers_and_tid2eid():
+    config = _small_config(num_hidden_layers=1, compress_ratios=(0,), num_hash_layers=1)
+    model = DeepseekV4ForCausalLM(config)
+    state_dict = {key: value.detach().clone() for key, value in model.state_dict().items()}
+
+    attn_sink = torch.arange(config.num_attention_heads, dtype=torch.float32)
+    tid2eid = (
+        torch.arange(config.vocab_size * config.num_experts_per_tok, dtype=torch.long)
+        .view(config.vocab_size, config.num_experts_per_tok)
+        .remainder(config.n_routed_experts)
+    )
+    state_dict["layers.0.attn.attn_sink"] = attn_sink
+    state_dict["layers.0.ffn.gate.tid2eid"] = tid2eid
+    state_dict["mtp.0.hc_head_fn"] = torch.randn_like(model.hc_head_fn)
+    state_dict["mtp.0.attn.wq_a.weight"] = torch.randn(config.q_lora_rank, config.hidden_size)
+    state_dict["unexpected.weight"] = torch.ones(1)
+
+    result = model.load_state_dict(state_dict, strict=False)
+
+    assert "unexpected.weight" in result.unexpected_keys
+    assert not any(key.startswith("mtp.0.") for key in result.unexpected_keys)
+    torch.testing.assert_close(model.layers[0].attn.attn_sink, attn_sink)
+    torch.testing.assert_close(model.layers[0].ffn.gate.tid2eid, tid2eid)
+    assert model.layers[0].ffn.gate.tid2eid.dtype == torch.long
+
+
+def test_model_accepts_skip_mtp_model_kwarg():
+    config = _small_config(num_hidden_layers=1, compress_ratios=(0,), skip_mtp=True)
+    model = DeepseekV4ForCausalLM(config, skip_mtp=True)
+
+    assert model.config.skip_mtp is True
+
+
+def test_factory_uses_compress_ratio_sized_export_example():
+    config = _small_config(num_hidden_layers=5, compress_ratios=(0, 0, 4, 128, 4))
+    factory = DeepseekV4AutoModelForCausalLMFactory(
+        model="/unused",
+        max_seq_len=8192,
+    )
+    factory._get_model_config = lambda: (config, {})
+
+    example = factory.get_example_inputs()
+
+    assert tuple(example["input_ids"].shape) == (2, 256)

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py
@@ -32,6 +32,7 @@ from torch import nn
 from torch.export import Dim
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 -- register ops
+import tensorrt_llm._torch.auto_deploy.transform.library  # noqa: F401 -- register transforms
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4AutoModelForCausalLMFactory,
@@ -39,6 +40,9 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4ForCausalLM,
     DeepseekV4RMSNorm,
 )
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+from tensorrt_llm._torch.auto_deploy.utils.dist_config import DistConfig
 
 
 def assert_rmse_close(
@@ -98,6 +102,58 @@ def _small_config(**overrides) -> DeepseekV4Config:
     )
     values.update(overrides)
     return DeepseekV4Config(**values)
+
+
+def test_factory_rope_cache_override_updates_default_compressor_capacity(tmp_path):
+    base_config = _small_config(
+        num_hidden_layers=5,
+        compress_ratios=(0, 0, 4, 128, 4),
+        max_position_embeddings=1048576,
+    )
+    base_config.save_pretrained(tmp_path)
+
+    factory = DeepseekV4AutoModelForCausalLMFactory(
+        model=str(tmp_path),
+        model_kwargs={"ad_rope_cache_len": 8192, "num_hidden_layers": 5},
+        max_seq_len=8192,
+        skip_loading_weights=True,
+    )
+
+    config, _ = factory._get_model_config()
+    assert config.ad_rope_cache_len == 8192
+    assert config.ad_compress_max_seq_len == 8192
+
+    model = DeepseekV4ForCausalLM(config)
+    assert model.layers[2].attn.compressor.max_compressed_tokens == 8192
+    assert model.layers[3].attn.compressor.max_compressed_tokens == 8192
+
+
+def test_factory_respects_explicit_compressor_capacity_override(tmp_path):
+    base_config = _small_config(
+        num_hidden_layers=5,
+        compress_ratios=(0, 0, 4, 128, 4),
+        max_position_embeddings=1048576,
+    )
+    base_config.save_pretrained(tmp_path)
+
+    factory = DeepseekV4AutoModelForCausalLMFactory(
+        model=str(tmp_path),
+        model_kwargs={
+            "ad_rope_cache_len": 8192,
+            "ad_compress_max_seq_len": 4096,
+            "num_hidden_layers": 5,
+        },
+        max_seq_len=8192,
+        skip_loading_weights=True,
+    )
+
+    config, _ = factory._get_model_config()
+    assert config.ad_rope_cache_len == 8192
+    assert config.ad_compress_max_seq_len == 4096
+
+    model = DeepseekV4ForCausalLM(config)
+    assert model.layers[2].attn.compressor.max_compressed_tokens == 4096
+    assert model.layers[3].attn.compressor.max_compressed_tokens == 4096
 
 
 _DEEPSEEK_V4_CHECKPOINT_SAMPLE_KEYS = {
@@ -810,6 +866,71 @@ def test_export_emits_canonical_deepseek_v4_ops():
     assert torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2.default in targets
     assert torch.ops.auto_deploy.torch_deepseek_v4_moe.default in targets
     assert torch.ops.auto_deploy.torch_moe.default not in targets
+
+
+def test_moe_only_ir_sharding_slices_deepseek_v4_mxfp4_experts():
+    config = _small_config(
+        hidden_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        head_dim=16,
+        q_lora_rank=16,
+        qk_rope_head_dim=8,
+        o_lora_rank=16,
+        compress_ratios=(0,),
+        moe_intermediate_size=32,
+        n_routed_experts=8,
+        num_hash_layers=0,
+        swiglu_limit=10.0,
+    )
+    model = DeepseekV4ForCausalLM(config).eval()
+    input_ids = torch.randint(0, config.vocab_size, (2, 4))
+    pos = _position_ids(2, 4, input_ids.device)
+    gm = torch_export_to_gm(
+        model,
+        args=(input_ids,),
+        kwargs={"position_ids": pos},
+        dynamic_shapes={
+            "input_ids": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+            "position_ids": {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        },
+        num_moe_experts_for_export=2,
+    )
+
+    opt = InferenceOptimizer(
+        None,
+        {
+            "lower_deepseek_v4_moe": {"stage": "pattern_matcher"},
+            "apply_sharding_hints": {
+                "enabled": True,
+                "stage": "sharding",
+                "run_shape_prop": True,
+                "shard_layers": ["moe"],
+            },
+        },
+    )
+    opt.shared_config = SharedConfig(
+        local_rank=0,
+        world_size=8,
+        dist_config=DistConfig(
+            world_size=8,
+            rank=0,
+            tp_size=8,
+            moe_ep_size=8,
+            moe_tp_size=1,
+        ),
+    )
+
+    gm = opt(None, gm)
+    ffn = gm.get_submodule("layers.0.ffn")
+
+    assert tuple(ffn.mxfp4_gate_up_blocks.shape) == (1, 64, 1, 16)
+    assert tuple(ffn.mxfp4_gate_up_scales.shape) == (1, 64, 1)
+    assert tuple(ffn.mxfp4_down_blocks.shape) == (1, 32, 1, 16)
+    assert tuple(ffn.mxfp4_down_scales.shape) == (1, 32, 1)
+    assert tuple(ffn.shared_experts.w1.weight.shape) == (4, 32)
+    assert tuple(ffn.shared_experts.w2.weight.shape) == (32, 4)
+    assert gm.meta["_autodeploy"]["transform_history"]["apply_sharding_hints"].num_matches == 5
 
 
 def test_load_state_dict_skips_mtp_and_loads_normal_layers_and_tid2eid():

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py
@@ -33,12 +33,18 @@ from torch.export import Dim
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 -- register ops
 import tensorrt_llm._torch.auto_deploy.transform.library  # noqa: F401 -- register transforms
+from examples import deepseek_v4_5layer_forward as demo_dsv4
+from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.torch_quant import (
+    _cast_fp4,
+    e2m1_values,
+)
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4AutoModelForCausalLMFactory,
     DeepseekV4Config,
     DeepseekV4ForCausalLM,
     DeepseekV4RMSNorm,
+    _fake_fp4_activation_quant_dequant,
 )
 from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
@@ -79,6 +85,9 @@ def _small_config(**overrides) -> DeepseekV4Config:
         sliding_window=4,
         compress_ratios=(0, 4),
         compress_rope_theta=10000.0,
+        index_n_heads=2,
+        index_head_dim=8,
+        index_topk=4,
         moe_intermediate_size=8,
         n_routed_experts=4,
         n_shared_experts=1,
@@ -166,6 +175,12 @@ _DEEPSEEK_V4_CHECKPOINT_SAMPLE_KEYS = {
     "layers.0.attn.wq_a.weight",
     "layers.0.attn.wq_b.weight",
     "layers.0.attn.wkv.weight",
+    "layers.1.attn.indexer.compressor.ape",
+    "layers.1.attn.indexer.compressor.norm.weight",
+    "layers.1.attn.indexer.compressor.wgate.weight",
+    "layers.1.attn.indexer.compressor.wkv.weight",
+    "layers.1.attn.indexer.weights_proj.weight",
+    "layers.1.attn.indexer.wq_b.weight",
     "layers.0.ffn.experts.0.w1.weight",
     "layers.0.ffn.experts.0.w2.weight",
     "layers.0.ffn.experts.0.w3.weight",
@@ -263,6 +278,18 @@ def _ref_apply_rope(x: torch.Tensor, freqs_cis: torch.Tensor, inverse: bool = Fa
     else:
         freqs = freqs.view(x.shape[0], x.shape[1], 1, -1)
     return torch.view_as_real(y * freqs).flatten(-2).to(x.dtype)
+
+
+def _ref_hadamard_transform(x: torch.Tensor) -> torch.Tensor:
+    last_dim = int(x.shape[-1])
+    out = x.float().reshape(-1, last_dim)
+    h = 1
+    while h < last_dim:
+        out = out.reshape(-1, 2, h)
+        left, right = out.unbind(dim=-2)
+        out = torch.stack((left + right, left - right), dim=-2).reshape(-1, last_dim)
+        h *= 2
+    return (out * (last_dim**-0.5)).to(x.dtype).reshape_as(x)
 
 
 def _ref_window_topk(window_size: int, batch_size: int, seq_len: int, device):
@@ -368,6 +395,56 @@ class _RefCompressor(nn.Module):
         return torch.cat([kv[..., : -self.rope_head_dim], rope], dim=-1)
 
 
+class _RefIndexer(nn.Module):
+    def __init__(self, config, compress_ratio):
+        super().__init__()
+        self.num_heads = config.index_n_heads
+        self.head_dim = config.index_head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.index_topk = config.index_topk
+        self.compress_ratio = compress_ratio
+        self.softmax_scale = self.head_dim**-0.5
+        self.wq_b = _RefLinear(config.q_lora_rank, self.num_heads * self.head_dim)
+        self.weights_proj = _RefLinear(config.hidden_size, self.num_heads)
+        self.compressor = _RefCompressor(config, compress_ratio, self.head_dim)
+
+    def forward(self, x, qr, freqs_cis, offset):
+        batch_size, seq_len, _ = x.shape
+        q = self.wq_b(qr).view(batch_size, seq_len, self.num_heads, self.head_dim)
+        q = torch.cat(
+            [
+                q[..., : -self.rope_head_dim],
+                _ref_apply_rope(q[..., -self.rope_head_dim :], freqs_cis),
+            ],
+            dim=-1,
+        )
+        q = _ref_hadamard_transform(q)
+        q = _fake_fp4_activation_quant_dequant(q)
+        compressed_kv = _ref_hadamard_transform(self.compressor(x, freqs_cis))
+        compressed_kv = _fake_fp4_activation_quant_dequant(compressed_kv)
+        weights = self.weights_proj(x) * (self.softmax_scale * self.num_heads**-0.5)
+
+        compressed_len = compressed_kv.shape[1]
+        if compressed_len == 0:
+            return torch.empty(batch_size, seq_len, 0, dtype=torch.long, device=x.device)
+
+        index_score = torch.einsum("bshd,btd->bsht", q.float(), compressed_kv.float())
+        index_score = (index_score.relu() * weights.float().unsqueeze(-1)).sum(dim=2)
+        compressed_positions = torch.arange(compressed_len, device=x.device)
+        valid_lengths = torch.arange(1, seq_len + 1, device=x.device).unsqueeze(1)
+        valid_lengths = valid_lengths // self.compress_ratio
+        invalid = compressed_positions.unsqueeze(0) >= valid_lengths
+        index_score = torch.where(
+            invalid.unsqueeze(0),
+            torch.full_like(index_score, float("-inf")),
+            index_score,
+        )
+
+        topk_idxs = index_score.topk(min(self.index_topk, compressed_len), dim=-1)[1]
+        valid_topk = topk_idxs < valid_lengths.unsqueeze(0)
+        return torch.where(valid_topk, topk_idxs + offset, -1)
+
+
 class _RefAttention(nn.Module):
     def __init__(self, config, layer_idx):
         super().__init__()
@@ -393,9 +470,14 @@ class _RefAttention(nn.Module):
         self.wo_b = _RefLinear(self.num_groups * self.o_lora_rank, config.hidden_size)
         if self.compress_ratio:
             self.compressor = _RefCompressor(config, self.compress_ratio, self.head_dim)
+            if self.compress_ratio == 4:
+                self.indexer = _RefIndexer(config, self.compress_ratio)
+            else:
+                self.indexer = None
             self.rope_original_seq_len = config.rope_scaling["original_max_position_embeddings"]
             self.rope_base = config.compress_rope_theta
         else:
+            self.indexer = None
             self.rope_original_seq_len = 0
             self.rope_base = config.rope_theta
         self.rope_factor = config.rope_scaling["factor"]
@@ -437,9 +519,12 @@ class _RefAttention(nn.Module):
         topk_idxs = _ref_window_topk(self.window_size, batch_size, seq_len, x.device)
         if self.compress_ratio:
             compressed = self.compressor(x, freqs_cis)
-            compressed_idxs = _ref_compress_topk(
-                self.compress_ratio, batch_size, seq_len, seq_len, x.device
-            )
+            if self.indexer is not None:
+                compressed_idxs = self.indexer(x, qr, freqs_cis, seq_len)
+            else:
+                compressed_idxs = _ref_compress_topk(
+                    self.compress_ratio, batch_size, seq_len, seq_len, x.device
+                )
             topk_idxs = torch.cat([topk_idxs, compressed_idxs], dim=-1)
             kv = torch.cat([kv, compressed], dim=1)
         o = _ref_sparse_attention(q, kv, self.attn_sink, topk_idxs.int(), self.softmax_scale)
@@ -683,6 +768,125 @@ def test_rmsnorm_matches_reference():
     torch.testing.assert_close(ad(x), expected, rtol=1e-6, atol=1e-6)
 
 
+def test_indexer_fp4_activation_quant_dequant_matches_checkpoint_reference():
+    scale_one_block = torch.tensor(
+        [
+            -6.0,
+            -5.0,
+            -3.5,
+            -2.5,
+            -1.75,
+            -1.25,
+            -0.75,
+            -0.25,
+            0.0,
+            0.25,
+            0.251953125,
+            0.75,
+            1.25,
+            1.2578125,
+            1.75,
+            2.5,
+            2.515625,
+            3.5,
+            5.0,
+            5.03125,
+            6.0,
+            -0.251953125,
+            -1.2578125,
+            -2.515625,
+            -5.03125,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            -4.0,
+        ],
+        dtype=torch.bfloat16,
+    )
+    scale_half_block = scale_one_block * 0.5
+    x = torch.stack([scale_one_block, scale_half_block], dim=0).reshape(1, 2, 32)
+
+    actual = _fake_fp4_activation_quant_dequant(x, block_size=32)
+    expected, expected_scale = demo_dsv4._fake_quant_dequant_fp4_activation(x, block_size=32)
+
+    torch.testing.assert_close(expected_scale, torch.tensor([[[1.0], [0.5]]]), rtol=0, atol=0)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_indexer_fp4_activation_quant_dequant_matches_existing_fp4_cast_oracle():
+    threshold_block = torch.tensor(
+        [
+            -6.0,
+            -5.0,
+            -3.5,
+            -2.5,
+            -1.75,
+            -1.25,
+            -0.75,
+            -0.25,
+            0.0,
+            0.25,
+            0.2509765625,
+            0.75,
+            1.25,
+            1.2509765625,
+            1.75,
+            2.5,
+            2.501953125,
+            3.5,
+            5.0,
+            5.03125,
+            6.0,
+            -0.2509765625,
+            -1.2509765625,
+            -2.501953125,
+            -5.03125,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            -4.0,
+        ],
+        dtype=torch.bfloat16,
+    )
+    scale_half_block = threshold_block * 0.5
+    scale_rounds_up_block = threshold_block * (3.01 / 6.0)
+    scale_rounds_to_two_block = threshold_block * (6.25 / 6.0)
+    x = torch.stack(
+        [
+            threshold_block,
+            scale_half_block,
+            scale_rounds_up_block,
+            scale_rounds_to_two_block,
+        ],
+        dim=0,
+    ).reshape(1, 4, 32)
+
+    actual = _fake_fp4_activation_quant_dequant(x, block_size=32)
+    x_blocks = x.float().reshape(-1, 1, 32)
+    scale = torch.pow(
+        2.0,
+        torch.ceil(
+            torch.log2(x_blocks.abs().amax(dim=-1, keepdim=True).clamp_min(6.0 * (2.0**-126)) / 6.0)
+        ),
+    )
+    indices = _cast_fp4(torch.clamp(x_blocks / scale, min=-6.0, max=6.0))
+    expected = (e2m1_values.to(x.device)[indices.long()] * scale).reshape_as(x).to(x.dtype)
+
+    torch.testing.assert_close(
+        scale.squeeze(-1),
+        torch.tensor([[1.0], [0.5], [1.0], [2.0]]),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
 def test_attention_matches_reference():
     torch.manual_seed(1)
     config = _small_config(num_hidden_layers=2, compress_ratios=(0, 4))
@@ -703,23 +907,36 @@ def test_compressor_accepts_bfloat16_checkpoint_weights():
     torch.manual_seed(7)
     config = _small_config(
         num_hidden_layers=1,
-        compress_ratios=(128,),
+        compress_ratios=(4,),
         max_position_embeddings=256,
         ad_rope_cache_len=256,
     )
     attn = DeepseekV4ForCausalLM(config).layers[0].attn.eval().cuda()
-    compressor = attn.compressor
-    compressor.wkv.weight.data = compressor.wkv.weight.data.to(torch.bfloat16)
-    compressor.wgate.weight.data = compressor.wgate.weight.data.to(torch.bfloat16)
-    x = torch.randn(1, 256, config.hidden_size, device="cuda", dtype=torch.bfloat16)
+    x = torch.randn(1, 256, config.hidden_size, device="cuda", dtype=torch.float32)
     pos = _position_ids(1, 256, x.device)
 
-    with torch.no_grad():
-        actual = compressor(x, pos, attn.rotary_emb())
+    compressors = [
+        (attn.compressor, config.head_dim),
+        (attn.indexer.compressor, config.index_head_dim),
+    ]
+    for compressor, head_dim in compressors:
+        compressor.wkv.weight.data = compressor.wkv.weight.data.to(torch.bfloat16)
+        compressor.wgate.weight.data = compressor.wgate.weight.data.to(torch.bfloat16)
+        norm_input_dtypes = []
+        handle = compressor.norm.register_forward_pre_hook(
+            lambda _module, args: norm_input_dtypes.append(args[0].dtype)
+        )
 
-    assert actual.dtype == torch.bfloat16
-    assert actual.shape == (1, compressor.max_compressed_len, config.head_dim)
-    assert torch.isfinite(actual).all()
+        try:
+            with torch.no_grad():
+                actual = compressor(x, pos, attn.rotary_emb())
+        finally:
+            handle.remove()
+
+        assert norm_input_dtypes == [torch.bfloat16]
+        assert actual.dtype == torch.bfloat16
+        assert actual.shape == (1, compressor.max_compressed_len, head_dim)
+        assert torch.isfinite(actual).all()
 
 
 def test_moe_with_swiglu_limit_matches_reference():

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py
@@ -807,7 +807,7 @@ def test_export_emits_canonical_deepseek_v4_ops():
     )
 
     targets = {node.target for node in gm.graph.nodes if node.op == "call_function"}
-    assert torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention.default in targets
+    assert torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2.default in targets
     assert torch.ops.auto_deploy.torch_deepseek_v4_moe.default in targets
     assert torch.ops.auto_deploy.torch_moe.default not in targets
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_real_checkpoint_prefill.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_real_checkpoint_prefill.py
@@ -1,0 +1,419 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Optional real-checkpoint DeepSeek V4 prefill checks.
+
+A full 5-layer eager AutoDeploy model cannot be materialized densely from the
+real checkpoint without the quantization/lowering transforms because routed FP4
+experts expand to very large BF16 tensors. These checks keep the scope small:
+layer-0 attention exercises the AD FineGrained FP8 transform, while the
+single-layer logits check remaps the fixed input's hash-routed experts into a
+reduced AD model and only dequantizes those selected FP4 experts.
+"""
+
+import gc
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from safetensors import safe_open
+from torch import nn
+
+from examples import deepseek_v4_5layer_forward as demo_dsv4
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
+    DeepseekV4Attention,
+    DeepseekV4Config,
+    DeepseekV4ForCausalLM,
+)
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
+from tensorrt_llm._torch.auto_deploy.transform.library.quantization import (
+    FineGrainedFP8LinearQuantization,
+)
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+_DEFAULT_CHECKPOINT_DIR = Path(
+    "/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/"
+    "bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash"
+)
+_RUN_ENV = "RUN_DEEPSEEK_V4_REAL_CHECKPOINT"
+_LAYER0_ATTENTION_RMSE_RATIO_TOL = 0.08
+_LAYER0_LOGITS_INPUT_IDS = ((1,),)
+_LAYER0_LOGITS_RMSE_RATIO_TOL = 0.03
+
+
+def _checkpoint_dir() -> Path:
+    return Path(os.environ.get("DEEPSEEK_V4_CHECKPOINT_DIR", _DEFAULT_CHECKPOINT_DIR))
+
+
+def _require_real_checkpoint() -> Path:
+    checkpoint_dir = _checkpoint_dir()
+    if os.environ.get(_RUN_ENV) != "1":
+        pytest.skip(f"set {_RUN_ENV}=1 to run the real DeepSeek V4 checkpoint check")
+    if not checkpoint_dir.is_dir():
+        pytest.skip(f"DeepSeek V4 checkpoint directory not found: {checkpoint_dir}")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required by the FineGrained FP8 Triton reference op")
+    return checkpoint_dir
+
+
+def _load_checkpoint_tensors(
+    checkpoint_dir: Path,
+    keys: list[str],
+    device: torch.device,
+) -> dict[str, torch.Tensor]:
+    index_path = checkpoint_dir / "model.safetensors.index.json"
+    weight_map = json.loads(index_path.read_text())["weight_map"]
+    keys_by_shard: dict[str, list[str]] = {}
+    for key in keys:
+        keys_by_shard.setdefault(weight_map[key], []).append(key)
+
+    tensors = {}
+    device_arg = str(device)
+    for shard_name, shard_keys in sorted(keys_by_shard.items()):
+        with safe_open(checkpoint_dir / shard_name, framework="pt", device=device_arg) as shard:
+            for key in shard_keys:
+                tensors[key] = shard.get_tensor(key)
+    return tensors
+
+
+def _load_weight_map(checkpoint_dir: Path) -> dict[str, str]:
+    index_path = checkpoint_dir / "model.safetensors.index.json"
+    return json.loads(index_path.read_text())["weight_map"]
+
+
+def _hf_layer0_ad_config(checkpoint_dir: Path, seq_len: int) -> DeepseekV4Config:
+    config_values = json.loads((checkpoint_dir / "config.json").read_text())
+    config_values["num_hidden_layers"] = 1
+    config_values["ad_rope_cache_len"] = seq_len
+    config_values["ad_compress_max_seq_len"] = seq_len
+    return DeepseekV4Config(**config_values)
+
+
+def _hf_layer0_reduced_expert_ad_config(
+    checkpoint_dir: Path, seq_len: int, num_routed_experts: int
+) -> DeepseekV4Config:
+    config_values = json.loads((checkpoint_dir / "config.json").read_text())
+    config_values["num_hidden_layers"] = 1
+    config_values["ad_rope_cache_len"] = seq_len
+    config_values["ad_compress_max_seq_len"] = seq_len
+    config_values["n_routed_experts"] = num_routed_experts
+    return DeepseekV4Config(**config_values)
+
+
+def _configure_demo_quant_globals(model_module, model_config: dict) -> None:
+    """Mirror the checkpoint Transformer quantization globals for attention-only tests."""
+    model_module.default_dtype = (
+        torch.float8_e4m3fn if model_config.get("dtype", "fp8") == "fp8" else torch.bfloat16
+    )
+    if model_config.get("scale_dtype", "fp8") == "fp8":
+        e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+        if e8m0_dtype is None:
+            raise RuntimeError("torch.float8_e8m0fnu is required for DeepSeek V4 FP8 scales.")
+        model_module.scale_fmt = "ue8m0"
+        model_module.scale_dtype = e8m0_dtype
+    else:
+        model_module.scale_fmt = model_config.get("scale_fmt")
+        model_module.scale_dtype = torch.float32
+
+
+class _AttentionLayer(nn.Module):
+    def __init__(self, config: DeepseekV4Config) -> None:
+        super().__init__()
+        self.attn = DeepseekV4Attention(config, layer_idx=0)
+
+
+class _Layer0AttentionWrapper(nn.Module):
+    """Keep exported parameter names under ``layers.0.attn`` for DSV4 transforms."""
+
+    def __init__(self, config: DeepseekV4Config) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList([_AttentionLayer(config)])
+
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        return self.layers[0].attn(x, position_ids)
+
+
+class _DeepSeekV4QuantFactory:
+    @staticmethod
+    def get_quant_config() -> dict:
+        return {
+            "quant_method": "deepseek_v4_fp8",
+            "linear_quant_method": "finegrained_fp8",
+            "weight_block_size": [128, 128],
+        }
+
+
+def _build_quantized_ad_layer0_attention(
+    checkpoint_dir: Path,
+    device: torch.device,
+    seq_len: int,
+) -> tuple[torch.fx.GraphModule, int]:
+    config = _hf_layer0_ad_config(checkpoint_dir, seq_len)
+    with demo_dsv4._torch_defaults(torch.bfloat16, device):
+        model = _Layer0AttentionWrapper(config).eval().to(device)
+
+    x = torch.randn(1, seq_len, config.hidden_size, device=device, dtype=torch.bfloat16)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+    gm = torch_export_to_gm(model, args=(x, position_ids), kwargs={}, dynamic_shapes=None)
+
+    transform = FineGrainedFP8LinearQuantization.from_kwargs(stage=Stages.PATTERN_MATCHER)
+    gm, info = transform._apply(gm, None, _DeepSeekV4QuantFactory(), SharedConfig())
+
+    weight_map = _load_weight_map(checkpoint_dir)
+    state_dict = {}
+    for key in gm.state_dict():
+        if key in weight_map:
+            state_dict[key] = _load_checkpoint_tensors(checkpoint_dir, [key], device)[key]
+        if key.endswith(".weight"):
+            scale_alias = key.removesuffix(".weight") + ".scale"
+            if scale_alias in weight_map:
+                state_dict[scale_alias] = _load_checkpoint_tensors(
+                    checkpoint_dir, [scale_alias], device
+                )[scale_alias]
+
+    missing, unexpected = gm.load_state_dict(state_dict, strict=False)
+    assert missing == []
+    assert unexpected == []
+    gm.to(device)
+    return gm, info.num_matches
+
+
+def _build_demo_layer0_attention(
+    checkpoint_dir: Path,
+    device: torch.device,
+    seq_len: int,
+) -> nn.Module:
+    model_module = demo_dsv4._import_checkpoint_model(checkpoint_dir)
+    demo_dsv4._patch_checkpoint_model(model_module)
+    model_config = demo_dsv4._load_model_args(
+        checkpoint_dir, layers=1, batch_size=1, seq_len=seq_len
+    )
+    _configure_demo_quant_globals(model_module, model_config)
+    with demo_dsv4._torch_defaults(torch.bfloat16, device):
+        model_args = model_module.ModelArgs(**model_config)
+        attention = model_module.Attention(0, model_args).eval()
+        layer = SimpleNamespace(attn=attention)
+        demo_dsv4._convert_wo_a_to_fp8(SimpleNamespace(layers=[layer]))
+
+    state_keys = [
+        f"layers.0.attn.{key}"
+        for key in attention.state_dict()
+        if f"layers.0.attn.{key}" in _load_weight_map(checkpoint_dir)
+    ]
+    state_dict = {
+        key.removeprefix("layers.0.attn."): tensor
+        for key, tensor in _load_checkpoint_tensors(checkpoint_dir, state_keys, device).items()
+    }
+    attention.load_state_dict(state_dict, strict=False)
+    for linear in (attention.wq_a, attention.wq_b, attention.wkv, attention.wo_a, attention.wo_b):
+        if getattr(linear, "scale", None) is not None:
+            linear.weight.scale = linear.scale
+    return attention
+
+
+def _layer0_hash_selected_experts(
+    checkpoint_dir: Path,
+    input_ids: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, list[int]]:
+    tid2eid = _load_checkpoint_tensors(checkpoint_dir, ["layers.0.ffn.gate.tid2eid"], device)[
+        "layers.0.ffn.gate.tid2eid"
+    ]
+    selected = tid2eid[input_ids].reshape(-1)
+    return tid2eid, torch.unique(selected, sorted=True).tolist()
+
+
+def _load_demo_single_layer_logits(
+    checkpoint_dir: Path,
+    input_ids: torch.Tensor,
+    device: torch.device,
+) -> torch.Tensor:
+    seq_len = input_ids.shape[1]
+    model_module = demo_dsv4._import_checkpoint_model(checkpoint_dir)
+    demo_dsv4._patch_checkpoint_model(model_module)
+    model_config = demo_dsv4._load_model_args(
+        checkpoint_dir, layers=1, batch_size=input_ids.shape[0], seq_len=seq_len
+    )
+    _configure_demo_quant_globals(model_module, model_config)
+
+    with demo_dsv4._torch_defaults(torch.bfloat16, device):
+        model_args = model_module.ModelArgs(**model_config)
+        model = model_module.Transformer(model_args).eval()
+        demo_dsv4._convert_wo_a_to_fp8(model)
+        demo_dsv4._load_checkpoint_subset(model, checkpoint_dir, device)
+        with torch.inference_mode():
+            return model(input_ids, start_pos=0).detach().float().cpu()
+
+
+def _load_ad_checkpoint_tensor(
+    checkpoint_dir: Path,
+    checkpoint_key: str,
+    target: torch.Tensor,
+    device: torch.device,
+) -> torch.Tensor:
+    tensor = _load_checkpoint_tensors(checkpoint_dir, [checkpoint_key], device)[checkpoint_key]
+    if checkpoint_key.startswith("layers.0.ffn.experts.") and checkpoint_key.endswith(".weight"):
+        scale_key = checkpoint_key.removesuffix(".weight") + ".scale"
+        scale = _load_checkpoint_tensors(checkpoint_dir, [scale_key], device)[scale_key]
+        return demo_dsv4._dequant_fp4_weight(tensor, scale, target.dtype)
+    if tensor.dtype == torch.float8_e4m3fn:
+        scale_key = checkpoint_key.removesuffix(".weight") + ".scale"
+        scale = _load_checkpoint_tensors(checkpoint_dir, [scale_key], device)[scale_key]
+        return demo_dsv4._dequant_fp8_weight(tensor, scale, target.dtype)
+    return tensor.to(dtype=target.dtype, device=target.device)
+
+
+def _remap_layer0_tid2eid(
+    tid2eid: torch.Tensor,
+    target: torch.Tensor,
+    input_ids: torch.Tensor,
+    remap: dict[int, int],
+) -> torch.Tensor:
+    remapped = torch.zeros_like(target)
+    for token_id in input_ids.flatten().tolist():
+        remapped[token_id] = torch.tensor(
+            [remap[int(expert)] for expert in tid2eid[token_id].tolist()],
+            dtype=target.dtype,
+            device=target.device,
+        )
+    return remapped
+
+
+def _build_reduced_ad_single_layer_logits(
+    checkpoint_dir: Path,
+    input_ids: torch.Tensor,
+    tid2eid: torch.Tensor,
+    selected_experts: list[int],
+    device: torch.device,
+) -> torch.Tensor:
+    seq_len = input_ids.shape[1]
+    config = _hf_layer0_reduced_expert_ad_config(checkpoint_dir, seq_len, len(selected_experts))
+    with demo_dsv4._torch_defaults(torch.bfloat16, device):
+        model = DeepseekV4ForCausalLM(config).eval().to(device)
+
+    remap = {expert_id: local_id for local_id, expert_id in enumerate(selected_experts)}
+    state_dict = {}
+    for key, target in model.state_dict().items():
+        if key == "layers.0.ffn.gate.tid2eid":
+            state_dict[key] = _remap_layer0_tid2eid(tid2eid, target, input_ids, remap)
+            continue
+        if key == "layers.0.ffn.gate.weight":
+            tensor = _load_checkpoint_tensors(checkpoint_dir, [key], device)[key]
+            state_dict[key] = tensor[selected_experts].to(dtype=target.dtype, device=target.device)
+            continue
+        if key.startswith("layers.0.ffn.experts."):
+            parts = key.split(".")
+            local_expert = int(parts[4])
+            checkpoint_key = ".".join(parts[:4] + [str(selected_experts[local_expert])] + parts[5:])
+        else:
+            checkpoint_key = key
+        state_dict[key] = _load_ad_checkpoint_tensor(checkpoint_dir, checkpoint_key, target, device)
+
+    missing, unexpected = model.load_state_dict(state_dict, strict=True)
+    assert missing == []
+    assert unexpected == []
+
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+    with torch.inference_mode(), demo_dsv4._torch_defaults(torch.bfloat16, device):
+        logits = model(input_ids=input_ids, position_ids=position_ids).logits[:, -1]
+        return logits.detach().float().cpu()
+
+
+def _rmse_ratio(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    diff = actual.float() - expected.float()
+    rmse_diff = torch.sqrt(torch.mean(diff**2))
+    rmse_ref = torch.sqrt(torch.mean(expected.float() ** 2))
+    return (rmse_diff / rmse_ref.clamp_min(1e-12)).item()
+
+
+def test_real_checkpoint_layer0_attention_quant_transform_loads() -> None:
+    checkpoint_dir = _require_real_checkpoint()
+    device = torch.device("cuda:0")
+    seq_len = 4
+
+    gm, num_matches = _build_quantized_ad_layer0_attention(checkpoint_dir, device, seq_len)
+
+    quant_nodes = [
+        node
+        for node in gm.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear)
+        or is_op(
+            node,
+            torch.ops.auto_deploy.torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear,
+        )
+    ]
+    state = gm.state_dict()
+
+    assert num_matches == 5
+    assert len(quant_nodes) == 5
+    assert state["layers.0.attn.wq_a.weight"].dtype == torch.float8_e4m3fn
+    assert state["layers.0.attn.wq_a.weight_scale_inv"].is_floating_point()
+    assert state["layers.0.attn.wo_a.weight"].dtype == torch.float8_e4m3fn
+    assert state["layers.0.attn.wo_a.weight_scale_inv"].is_floating_point()
+
+
+def test_real_checkpoint_layer0_attention_prefill_matches_demo_reference() -> None:
+    checkpoint_dir = _require_real_checkpoint()
+    device = torch.device("cuda:0")
+    seq_len = 4
+    torch.manual_seed(1234)
+
+    ad_attention, _ = _build_quantized_ad_layer0_attention(checkpoint_dir, device, seq_len)
+    demo_attention = _build_demo_layer0_attention(checkpoint_dir, device, seq_len)
+    x = torch.randn(1, seq_len, 4096, device=device, dtype=torch.bfloat16)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+
+    with torch.inference_mode(), demo_dsv4._torch_defaults(torch.bfloat16, device):
+        expected = demo_attention(x.clone(), start_pos=0)
+        actual = ad_attention(x.clone(), position_ids)
+        if isinstance(actual, tuple):
+            actual = actual[0]
+
+    ratio = _rmse_ratio(actual, expected)
+    assert ratio < _LAYER0_ATTENTION_RMSE_RATIO_TOL, (
+        "transformed AD FineGrained FP8 layer-0 attention diverges from the demo reference "
+        f"(RMSE ratio {ratio:.6f}, tolerance {_LAYER0_ATTENTION_RMSE_RATIO_TOL})"
+    )
+
+
+def test_real_checkpoint_single_layer_prefill_logits_match_demo_reference() -> None:
+    checkpoint_dir = _require_real_checkpoint()
+    device = torch.device("cuda:0")
+    input_ids = torch.tensor(_LAYER0_LOGITS_INPUT_IDS, device=device, dtype=torch.long)
+
+    tid2eid, selected_experts = _layer0_hash_selected_experts(checkpoint_dir, input_ids, device)
+    expected = _load_demo_single_layer_logits(checkpoint_dir, input_ids, device)
+    gc.collect()
+    torch.cuda.empty_cache()
+    actual = _build_reduced_ad_single_layer_logits(
+        checkpoint_dir, input_ids, tid2eid, selected_experts, device
+    )
+
+    diff = actual.float() - expected.float()
+    rmse = torch.sqrt(torch.mean(diff**2)).item()
+    ratio = _rmse_ratio(actual, expected)
+    print(
+        "single-layer logits selected_experts="
+        f"{selected_experts}, RMSE={rmse:.8f}, RMSE ratio={ratio:.8f}"
+    )
+    assert ratio < _LAYER0_LOGITS_RMSE_RATIO_TOL, (
+        "reduced-expert dense-dequant AD single-layer logits diverge from the demo reference "
+        f"(selected experts {selected_experts}, RMSE {rmse:.6f}, RMSE ratio {ratio:.6f}, "
+        f"tolerance {_LAYER0_LOGITS_RMSE_RATIO_TOL})"
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_real_checkpoint_prefill.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_real_checkpoint_prefill.py
@@ -40,6 +40,9 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_deepseek_v4 import (
     DeepseekV4Attention,
     DeepseekV4Config,
     DeepseekV4ForCausalLM,
+    _apply_rope,
+    _fake_fp4_activation_quant_dequant,
+    _hadamard_transform,
 )
 from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
 from tensorrt_llm._torch.auto_deploy.transform.library.quantization import (
@@ -53,8 +56,12 @@ _DEFAULT_CHECKPOINT_DIR = Path(
 )
 _RUN_ENV = "RUN_DEEPSEEK_V4_REAL_CHECKPOINT"
 _LAYER0_ATTENTION_RMSE_RATIO_TOL = 0.08
+_RATIO4_ATTENTION_RMSE_RATIO_TOL = 0.10
 _LAYER0_LOGITS_INPUT_IDS = ((1,),)
 _LAYER0_LOGITS_RMSE_RATIO_TOL = 0.03
+_DSV4_FLASH_PROMPT_TOKEN_IDS = ((0, 128803, 4117, 3734, 344, 270, 14277, 33, 223, 128804, 128822),)
+_RATIO4_LAYER_IDX = 2
+_RATIO4_INDEXER_SEQ_LEN = 16
 
 
 def _checkpoint_dir() -> Path:
@@ -105,6 +112,14 @@ def _hf_layer0_ad_config(checkpoint_dir: Path, seq_len: int) -> DeepseekV4Config
     return DeepseekV4Config(**config_values)
 
 
+def _hf_zero_layer_ad_config(checkpoint_dir: Path, seq_len: int) -> DeepseekV4Config:
+    config_values = json.loads((checkpoint_dir / "config.json").read_text())
+    config_values["num_hidden_layers"] = 0
+    config_values["ad_rope_cache_len"] = seq_len
+    config_values["ad_compress_max_seq_len"] = seq_len
+    return DeepseekV4Config(**config_values)
+
+
 def _hf_layer0_reduced_expert_ad_config(
     checkpoint_dir: Path, seq_len: int, num_routed_experts: int
 ) -> DeepseekV4Config:
@@ -133,9 +148,9 @@ def _configure_demo_quant_globals(model_module, model_config: dict) -> None:
 
 
 class _AttentionLayer(nn.Module):
-    def __init__(self, config: DeepseekV4Config) -> None:
+    def __init__(self, config: DeepseekV4Config, layer_idx: int = 0) -> None:
         super().__init__()
-        self.attn = DeepseekV4Attention(config, layer_idx=0)
+        self.attn = DeepseekV4Attention(config, layer_idx=layer_idx)
 
 
 class _Layer0AttentionWrapper(nn.Module):
@@ -147,6 +162,20 @@ class _Layer0AttentionWrapper(nn.Module):
 
     def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
         return self.layers[0].attn(x, position_ids)
+
+
+class _LayerNAttentionWrapper(nn.Module):
+    """Keep exported parameter names under ``layers.<n>.attn`` for DSV4 transforms."""
+
+    def __init__(self, config: DeepseekV4Config, layer_idx: int) -> None:
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.layers = nn.ModuleList(
+            [nn.Module() for _ in range(layer_idx)] + [_AttentionLayer(config, layer_idx)]
+        )
+
+    def forward(self, x: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        return self.layers[self.layer_idx].attn(x, position_ids)
 
 
 class _DeepSeekV4QuantFactory:
@@ -194,6 +223,57 @@ def _build_quantized_ad_layer0_attention(
     return gm, info.num_matches
 
 
+def _build_quantized_ad_layern_attention(
+    checkpoint_dir: Path,
+    device: torch.device,
+    seq_len: int,
+    layer_idx: int,
+) -> tuple[torch.fx.GraphModule, int]:
+    config = _hf_layern_ad_config(checkpoint_dir, seq_len, layer_idx)
+    with demo_dsv4._torch_defaults(torch.bfloat16, device):
+        model = _LayerNAttentionWrapper(config, layer_idx).eval().to(device)
+
+    x = torch.randn(1, seq_len, config.hidden_size, device=device, dtype=torch.bfloat16)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+    gm = torch_export_to_gm(model, args=(x, position_ids), kwargs={}, dynamic_shapes=None)
+
+    transform = FineGrainedFP8LinearQuantization.from_kwargs(stage=Stages.PATTERN_MATCHER)
+    gm, info = transform._apply(gm, None, _DeepSeekV4QuantFactory(), SharedConfig())
+    _load_quantized_gm_state(gm, checkpoint_dir, device)
+    gm.to(device)
+    return gm, info.num_matches
+
+
+def _hf_layern_ad_config(checkpoint_dir: Path, seq_len: int, layer_idx: int) -> DeepseekV4Config:
+    config_values = json.loads((checkpoint_dir / "config.json").read_text())
+    config_values["num_hidden_layers"] = layer_idx + 1
+    config_values["ad_rope_cache_len"] = seq_len
+    config_values["ad_compress_max_seq_len"] = seq_len
+    return DeepseekV4Config(**config_values)
+
+
+def _load_quantized_gm_state(
+    gm: torch.fx.GraphModule,
+    checkpoint_dir: Path,
+    device: torch.device,
+) -> None:
+    weight_map = _load_weight_map(checkpoint_dir)
+    state_dict = {}
+    for key in gm.state_dict():
+        if key in weight_map:
+            state_dict[key] = _load_checkpoint_tensors(checkpoint_dir, [key], device)[key]
+        if key.endswith(".weight"):
+            scale_alias = key.removesuffix(".weight") + ".scale"
+            if scale_alias in weight_map:
+                state_dict[scale_alias] = _load_checkpoint_tensors(
+                    checkpoint_dir, [scale_alias], device
+                )[scale_alias]
+
+    missing, unexpected = gm.load_state_dict(state_dict, strict=False)
+    assert missing == []
+    assert unexpected == []
+
+
 def _build_demo_layer0_attention(
     checkpoint_dir: Path,
     device: torch.device,
@@ -225,6 +305,150 @@ def _build_demo_layer0_attention(
         if getattr(linear, "scale", None) is not None:
             linear.weight.scale = linear.scale
     return attention
+
+
+def _attach_demo_linear_scales(module: nn.Module) -> None:
+    for child in module.modules():
+        if getattr(child, "scale", None) is not None and getattr(child, "weight", None) is not None:
+            child.weight.scale = child.scale
+
+
+def _build_demo_layern_attention(
+    checkpoint_dir: Path,
+    device: torch.device,
+    seq_len: int,
+    layer_idx: int,
+) -> nn.Module:
+    model_module = demo_dsv4._import_checkpoint_model(checkpoint_dir)
+    demo_dsv4._patch_checkpoint_model(model_module)
+    model_config = demo_dsv4._load_model_args(
+        checkpoint_dir, layers=layer_idx + 1, batch_size=1, seq_len=seq_len
+    )
+    _configure_demo_quant_globals(model_module, model_config)
+    with demo_dsv4._torch_defaults(torch.bfloat16, device):
+        model_args = model_module.ModelArgs(**model_config)
+        attention = model_module.Attention(layer_idx, model_args).eval()
+        demo_dsv4._convert_wo_a_to_fp8(SimpleNamespace(layers=[SimpleNamespace(attn=attention)]))
+
+    weight_map = _load_weight_map(checkpoint_dir)
+    state_keys = [
+        f"layers.{layer_idx}.attn.{key}"
+        for key in attention.state_dict()
+        if f"layers.{layer_idx}.attn.{key}" in weight_map
+    ]
+    state_dict = {
+        key.removeprefix(f"layers.{layer_idx}.attn."): tensor
+        for key, tensor in _load_checkpoint_tensors(checkpoint_dir, state_keys, device).items()
+    }
+    attention.load_state_dict(state_dict, strict=False)
+    _attach_demo_linear_scales(attention)
+    return attention
+
+
+def _build_demo_layern_attention_subset(
+    checkpoint_dir: Path,
+    device: torch.device,
+    seq_len: int,
+    layer_idx: int,
+    suffixes: list[str],
+) -> nn.Module:
+    model_module = demo_dsv4._import_checkpoint_model(checkpoint_dir)
+    demo_dsv4._patch_checkpoint_model(model_module)
+    model_config = demo_dsv4._load_model_args(
+        checkpoint_dir, layers=layer_idx + 1, batch_size=1, seq_len=seq_len
+    )
+    _configure_demo_quant_globals(model_module, model_config)
+    with demo_dsv4._torch_defaults(torch.bfloat16, device):
+        model_args = model_module.ModelArgs(**model_config)
+        attention = model_module.Attention(layer_idx, model_args).eval()
+
+    weight_map = _load_weight_map(checkpoint_dir)
+    state_keys = [
+        f"layers.{layer_idx}.attn.{suffix}"
+        for suffix in suffixes
+        if f"layers.{layer_idx}.attn.{suffix}" in weight_map
+    ]
+    state_dict = {
+        key.removeprefix(f"layers.{layer_idx}.attn."): tensor
+        for key, tensor in _load_checkpoint_tensors(checkpoint_dir, state_keys, device).items()
+    }
+    attention.load_state_dict(state_dict, strict=False)
+    for linear in (attention.wq_a, attention.indexer.wq_b):
+        if getattr(linear, "scale", None) is not None:
+            linear.weight.scale = linear.scale
+    attention.indexer.freqs_cis = attention.freqs_cis
+    return attention
+
+
+def _build_dense_ad_layern_attention_subset(
+    checkpoint_dir: Path,
+    device: torch.device,
+    seq_len: int,
+    layer_idx: int,
+    suffixes: list[str],
+) -> DeepseekV4Attention:
+    config = _hf_layern_ad_config(checkpoint_dir, seq_len, layer_idx)
+    with demo_dsv4._torch_defaults(torch.bfloat16, device):
+        attention = DeepseekV4Attention(config, layer_idx=layer_idx).eval().to(device)
+
+    state_dict = {}
+    attention_state = attention.state_dict()
+    for suffix in suffixes:
+        checkpoint_key = f"layers.{layer_idx}.attn.{suffix}"
+        state_dict[suffix] = _load_ad_checkpoint_tensor(
+            checkpoint_dir, checkpoint_key, attention_state[suffix], device
+        )
+    _, unexpected = attention.load_state_dict(state_dict, strict=False)
+    assert unexpected == []
+    return attention
+
+
+def _manual_indexer_topk(
+    attention: DeepseekV4Attention,
+    x: torch.Tensor,
+    qr: torch.Tensor,
+    position_ids: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    offset: int,
+    *,
+    apply_fp4: bool,
+) -> torch.Tensor:
+    indexer = attention.indexer
+    batch_size, seq_len, _ = x.shape
+    freqs_cis = freqs_cis_table[position_ids]
+
+    q = indexer.wq_b(qr, tp_mode="colwise", layer_type="mla")
+    q = q.view(batch_size, seq_len, indexer.num_heads, indexer.head_dim)
+    q_rope = _apply_rope(q[..., -indexer.rope_head_dim :], freqs_cis)
+    q = torch.cat([q[..., : -indexer.rope_head_dim], q_rope], dim=-1)
+    q = _hadamard_transform(q)
+    if apply_fp4:
+        q = _fake_fp4_activation_quant_dequant(q)
+
+    compressed_kv = indexer.compressor(x, position_ids, freqs_cis_table)
+    compressed_kv = _hadamard_transform(compressed_kv)
+    if apply_fp4:
+        compressed_kv = _fake_fp4_activation_quant_dequant(compressed_kv)
+    weights = indexer.weights_proj(x, tp_mode="colwise", layer_type="mla")
+    weights = weights * (indexer.softmax_scale * indexer.num_heads**-0.5)
+
+    index_score = torch.einsum("bshd,btd->bsht", q.float(), compressed_kv.float())
+    index_score = (index_score.relu() * weights.float().unsqueeze(-1)).sum(dim=2)
+
+    compressed_positions = torch.arange(indexer.compressor.max_compressed_len, device=x.device)
+    valid_lengths = torch.arange(1, seq_len + 1, device=x.device).unsqueeze(1)
+    valid_lengths = valid_lengths // indexer.compress_ratio
+    invalid = compressed_positions.unsqueeze(0) >= valid_lengths
+    index_score = torch.where(
+        invalid.unsqueeze(0),
+        torch.full_like(index_score, float("-inf")),
+        index_score,
+    )
+
+    topk_count = min(indexer.index_topk, indexer.compressor.max_compressed_len)
+    topk_idxs = index_score.topk(topk_count, dim=-1)[1]
+    valid_topk = topk_idxs < valid_lengths.unsqueeze(0)
+    return torch.where(valid_topk, topk_idxs + offset, -1)
 
 
 def _layer0_hash_selected_experts(
@@ -342,6 +566,66 @@ def _rmse_ratio(actual: torch.Tensor, expected: torch.Tensor) -> float:
     return (rmse_diff / rmse_ref.clamp_min(1e-12)).item()
 
 
+def _manual_rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    normalized = x.float() * torch.rsqrt(x.float().square().mean(-1, keepdim=True) + eps)
+    return (weight.float() * normalized).to(x.dtype)
+
+
+def test_real_checkpoint_zero_layer_hc_head_flashinfer_rmsnorm_weight_dtype() -> None:
+    checkpoint_dir = _require_real_checkpoint()
+    pytest.importorskip("flashinfer")
+    import tensorrt_llm._torch.auto_deploy.custom_ops.normalization.rms_norm  # noqa: F401
+
+    device = torch.device("cuda:0")
+    input_ids = torch.tensor(_DSV4_FLASH_PROMPT_TOKEN_IDS, device=device, dtype=torch.long)
+    config = _hf_zero_layer_ad_config(checkpoint_dir, input_ids.shape[1])
+    with demo_dsv4._torch_defaults(torch.bfloat16, device):
+        model = DeepseekV4ForCausalLM(config).eval().to(device)
+
+    state_keys = {"embed.weight", "hc_head_fn", "hc_head_base", "hc_head_scale", "norm.weight"}
+    state_dict = {
+        key: _load_ad_checkpoint_tensor(checkpoint_dir, key, target, device)
+        for key, target in model.state_dict().items()
+        if key in state_keys
+    }
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    assert set(missing) == {"head.weight"}
+    assert unexpected == []
+
+    with torch.inference_mode(), demo_dsv4._torch_defaults(torch.bfloat16, device):
+        hidden = model.embed(input_ids).unsqueeze(2).expand(-1, -1, model.hc_mult, -1)
+        hc_head = model._hc_head(hidden).contiguous()
+        weight = model.norm.weight
+        eps = model.config.rms_norm_eps
+
+        manual = _manual_rmsnorm(hc_head, weight, eps)
+        torch_ref = torch.ops.auto_deploy.torch_rmsnorm(hc_head, weight, eps)
+        flashinfer_fp32_weight = torch.ops.auto_deploy.flashinfer_rms_norm(hc_head, weight, eps)
+        flashinfer_bf16_weight = torch.ops.auto_deploy.flashinfer_rms_norm(
+            hc_head, weight.to(hc_head.dtype), eps
+        )
+
+    torch.testing.assert_close(torch_ref, manual, rtol=0.01, atol=0.01)
+    torch.testing.assert_close(flashinfer_bf16_weight, manual, rtol=0.01, atol=0.01)
+
+    fp32_weight_rmse = torch.sqrt(
+        torch.mean((flashinfer_fp32_weight.float() - manual.float()) ** 2)
+    ).item()
+    fp32_weight_cosine = torch.nn.functional.cosine_similarity(
+        flashinfer_fp32_weight.flatten().float(), manual.flatten().float(), dim=0
+    ).item()
+    print(
+        "zero-layer hc_head flashinfer_rms_norm fp32_weight "
+        f"RMSE={fp32_weight_rmse:.8f}, cosine={fp32_weight_cosine:.8f}"
+    )
+    if fp32_weight_cosine < 0.99 or fp32_weight_rmse > 0.01:
+        pytest.xfail(
+            "flashinfer_rms_norm diverges from torch/manual RMSNorm with the FP32 "
+            "checkpoint norm weight on the real DeepSeek V4 zero-layer hc_head output"
+        )
+    torch.testing.assert_close(flashinfer_fp32_weight, manual, rtol=0.01, atol=0.01)
+
+
 def test_real_checkpoint_layer0_attention_quant_transform_loads() -> None:
     checkpoint_dir = _require_real_checkpoint()
     device = torch.device("cuda:0")
@@ -390,6 +674,85 @@ def test_real_checkpoint_layer0_attention_prefill_matches_demo_reference() -> No
         "transformed AD FineGrained FP8 layer-0 attention diverges from the demo reference "
         f"(RMSE ratio {ratio:.6f}, tolerance {_LAYER0_ATTENTION_RMSE_RATIO_TOL})"
     )
+
+
+def test_real_checkpoint_layer2_ratio4_attention_prefill_matches_demo_reference() -> None:
+    checkpoint_dir = _require_real_checkpoint()
+    device = torch.device("cuda:0")
+    layer_idx = _RATIO4_LAYER_IDX
+    seq_len = _RATIO4_INDEXER_SEQ_LEN
+    torch.manual_seed(20260426)
+
+    ad_attention, num_matches = _build_quantized_ad_layern_attention(
+        checkpoint_dir, device, seq_len, layer_idx
+    )
+    demo_attention = _build_demo_layern_attention(checkpoint_dir, device, seq_len, layer_idx)
+    x = torch.randn(1, seq_len, 4096, device=device, dtype=torch.bfloat16)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+
+    with torch.inference_mode(), demo_dsv4._torch_defaults(torch.bfloat16, device):
+        expected = demo_attention(x.clone(), start_pos=0)
+        actual = ad_attention(x.clone(), position_ids)
+        if isinstance(actual, tuple):
+            actual = actual[0]
+
+    ratio = _rmse_ratio(actual, expected)
+    cosine = torch.nn.functional.cosine_similarity(
+        actual.flatten().float(), expected.flatten().float(), dim=0
+    ).item()
+    print(
+        "layer2 ratio4 attention num_quant_matches="
+        f"{num_matches}, RMSE ratio={ratio:.8f}, cosine={cosine:.8f}"
+    )
+    if ratio >= _RATIO4_ATTENTION_RMSE_RATIO_TOL:
+        pytest.xfail(
+            "real-checkpoint ratio-4 attention prefill still diverges from the demo reference; "
+            "keep this as a diagnostic until the currently localized zero-layer failure is fixed"
+        )
+    assert ratio < _RATIO4_ATTENTION_RMSE_RATIO_TOL
+
+
+def test_real_checkpoint_layer2_ratio4_indexer_topk_matches_demo_reference() -> None:
+    checkpoint_dir = _require_real_checkpoint()
+    device = torch.device("cuda:0")
+    layer_idx = _RATIO4_LAYER_IDX
+    seq_len = _RATIO4_INDEXER_SEQ_LEN
+    torch.manual_seed(20260425)
+
+    attention = _build_dense_ad_layern_attention_subset(
+        checkpoint_dir,
+        device,
+        seq_len,
+        layer_idx,
+        [
+            "wq_a.weight",
+            "q_norm.weight",
+            "indexer.wq_b.weight",
+            "indexer.weights_proj.weight",
+            "indexer.compressor.ape",
+            "indexer.compressor.wkv.weight",
+            "indexer.compressor.wgate.weight",
+            "indexer.compressor.norm.weight",
+        ],
+    )
+    x = torch.randn(1, seq_len, 4096, device=device, dtype=torch.bfloat16)
+    position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+
+    with torch.inference_mode(), demo_dsv4._torch_defaults(torch.bfloat16, device):
+        freqs_cis_table = attention.rotary_emb()
+        qr = attention.q_norm(attention.wq_a(x.clone(), layer_type="mla"))
+        expected = _manual_indexer_topk(
+            attention, x.clone(), qr, position_ids, freqs_cis_table, seq_len, apply_fp4=True
+        )
+        without_fp4 = _manual_indexer_topk(
+            attention, x.clone(), qr, position_ids, freqs_cis_table, seq_len, apply_fp4=False
+        )
+        actual = attention.indexer(x.clone(), qr, position_ids, freqs_cis_table, seq_len)
+
+    no_fp4_diff_count = (without_fp4 != expected).sum().item()
+    print(f"layer2 ratio4 indexer differing_topk_slots_without_fp4={no_fp4_diff_count}")
+    assert no_fp4_diff_count > 0
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=0, atol=0)
 
 
 def test_real_checkpoint_single_layer_prefill_logits_match_demo_reference() -> None:

--- a/tests/unittest/_torch/auto_deploy/unit/utils/test_e8m0.py
+++ b/tests/unittest/_torch/auto_deploy/unit/utils/test_e8m0.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.auto_deploy.utils import e8m0
+from tensorrt_llm._torch.auto_deploy.utils.e8m0 import (
+    e8m0_to_fp32,
+    e8m0_to_uint8,
+    maybe_e8m0_to_fp32,
+)
+
+_HAS_E8M0 = hasattr(torch, "float8_e8m0fnu")
+_requires_e8m0 = pytest.mark.skipif(
+    not _HAS_E8M0,
+    reason="torch.float8_e8m0fnu is not available in this PyTorch build",
+)
+
+
+def _e8m0_from_bytes(raw_bytes: list[int]) -> torch.Tensor:
+    return torch.tensor(raw_bytes, dtype=torch.uint8, device="cpu").view(torch.float8_e8m0fnu)
+
+
+@_requires_e8m0
+def test_e8m0_to_uint8_preserves_raw_bytes() -> None:
+    raw_bytes = torch.tensor([0, 1, 126, 127, 128, 254], dtype=torch.uint8, device="cpu")
+    scale = raw_bytes.view(torch.float8_e8m0fnu)
+
+    actual = e8m0_to_uint8(scale)
+
+    assert actual.dtype == torch.uint8
+    assert actual.device.type == "cpu"
+    assert actual.data_ptr() == scale.data_ptr()
+    torch.testing.assert_close(actual, raw_bytes, rtol=0, atol=0)
+
+
+@_requires_e8m0
+def test_view_uint8_differs_from_numeric_uint8_conversion_for_small_scales() -> None:
+    scale = _e8m0_from_bytes([126, 127, 128])
+
+    raw_bytes = e8m0_to_uint8(scale)
+    numeric_uint8 = scale.to(torch.uint8)
+
+    torch.testing.assert_close(
+        raw_bytes,
+        torch.tensor([126, 127, 128], dtype=torch.uint8, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        numeric_uint8,
+        torch.tensor([0, 1, 2], dtype=torch.uint8, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+    assert not torch.equal(raw_bytes, numeric_uint8)
+
+
+@_requires_e8m0
+def test_e8m0_to_fp32_decodes_exponent_bytes() -> None:
+    scale = _e8m0_from_bytes([126, 127, 128])
+
+    actual = e8m0_to_fp32(scale)
+
+    assert actual.dtype == torch.float32
+    assert actual.device.type == "cpu"
+    torch.testing.assert_close(
+        actual,
+        torch.tensor([0.5, 1.0, 2.0], dtype=torch.float32, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+
+
+@_requires_e8m0
+def test_maybe_e8m0_to_fp32_decodes_e8m0() -> None:
+    scale = _e8m0_from_bytes([126, 127, 128])
+
+    actual = maybe_e8m0_to_fp32(scale)
+
+    torch.testing.assert_close(
+        actual,
+        torch.tensor([0.5, 1.0, 2.0], dtype=torch.float32, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_maybe_e8m0_to_fp32_returns_non_e8m0_scales_as_fp32(dtype: torch.dtype) -> None:
+    scale = torch.tensor([0.25, 1.5, 8.0], dtype=dtype, device="cpu")
+
+    actual = maybe_e8m0_to_fp32(scale)
+
+    assert actual.dtype == torch.float32
+    assert actual.device.type == "cpu"
+    torch.testing.assert_close(
+        actual,
+        torch.tensor([0.25, 1.5, 8.0], dtype=torch.float32, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+
+
+@_requires_e8m0
+def test_e8m0_helpers_reject_non_e8m0_inputs() -> None:
+    scale = torch.ones(2, dtype=torch.float32, device="cpu")
+
+    with pytest.raises(TypeError, match="expected an torch.float8_e8m0fnu tensor"):
+        e8m0_to_uint8(scale)
+
+    with pytest.raises(TypeError, match="expected an torch.float8_e8m0fnu tensor"):
+        e8m0_to_fp32(scale)
+
+
+def test_required_e8m0_helpers_raise_clear_error_when_dtype_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(e8m0, "_get_e8m0_dtype", lambda: None)
+
+    with pytest.raises(RuntimeError, match="torch.float8_e8m0fnu is not available"):
+        e8m0_to_uint8(torch.ones(1, dtype=torch.float32, device="cpu"))
+
+    with pytest.raises(RuntimeError, match="torch.float8_e8m0fnu is not available"):
+        e8m0_to_fp32(torch.ones(1, dtype=torch.float32, device="cpu"))
+
+
+def test_maybe_e8m0_to_fp32_handles_non_e8m0_when_dtype_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(e8m0, "_get_e8m0_dtype", lambda: None)
+    scale = torch.tensor([1.25, 2.5], dtype=torch.bfloat16, device="cpu")
+
+    actual = maybe_e8m0_to_fp32(scale)
+
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(
+        actual,
+        torch.tensor([1.25, 2.5], dtype=torch.float32, device="cpu"),
+        rtol=0,
+        atol=0,
+    )

--- a/tests/unittest/_torch/auto_deploy/unit/utils/test_e8m0.py
+++ b/tests/unittest/_torch/auto_deploy/unit/utils/test_e8m0.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
+
 import pytest
 import torch
 
@@ -20,6 +22,11 @@ from tensorrt_llm._torch.auto_deploy.utils import e8m0
 from tensorrt_llm._torch.auto_deploy.utils.e8m0 import (
     e8m0_to_fp32,
     e8m0_to_uint8,
+    e8m0_uint8_to_fp32,
+    fp8_block_dequant_ref,
+    fp8_block_quant_ref,
+    fp8_block_scale_shape,
+    fp32_to_e8m0,
     maybe_e8m0_to_fp32,
 )
 
@@ -47,6 +54,13 @@ def test_e8m0_to_uint8_preserves_raw_bytes() -> None:
     torch.testing.assert_close(actual, raw_bytes, rtol=0, atol=0)
 
 
+def test_e8m0_to_uint8_helper_does_not_use_numeric_uint8_conversion() -> None:
+    source = inspect.getsource(e8m0_to_uint8)
+
+    assert ".to(torch.uint8)" not in source
+    assert ".view(torch.uint8)" in source
+
+
 @_requires_e8m0
 def test_view_uint8_differs_from_numeric_uint8_conversion_for_small_scales() -> None:
     scale = _e8m0_from_bytes([126, 127, 128])
@@ -67,6 +81,62 @@ def test_view_uint8_differs_from_numeric_uint8_conversion_for_small_scales() -> 
         atol=0,
     )
     assert not torch.equal(raw_bytes, numeric_uint8)
+
+
+@_requires_e8m0
+def test_fp32_to_e8m0_emits_raw_exponent_bytes_not_numeric_values() -> None:
+    scale = torch.tensor([0.25, 1.25, 2.0], dtype=torch.float32, device="cpu")
+
+    actual = fp32_to_e8m0(scale)
+
+    assert actual.dtype == torch.float8_e8m0fnu
+    torch.testing.assert_close(
+        e8m0_to_uint8(actual),
+        torch.tensor([125, 128, 128], dtype=torch.uint8, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        e8m0_to_fp32(actual),
+        torch.tensor([0.25, 2.0, 2.0], dtype=torch.float32, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_e8m0_uint8_to_fp32_decodes_raw_exponent_bytes() -> None:
+    raw_bytes = torch.tensor([0, 1, 126, 127, 128, 254, 255], dtype=torch.uint8, device="cpu")
+
+    actual = e8m0_uint8_to_fp32(raw_bytes)
+
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(
+        actual[:-1],
+        torch.tensor(
+            [
+                2.0**-127,
+                2.0**-126,
+                0.5,
+                1.0,
+                2.0,
+                2.0**127,
+            ],
+            dtype=torch.float32,
+            device="cpu",
+        ),
+        rtol=0,
+        atol=0,
+    )
+    assert torch.isnan(actual[-1])
+
+
+@_requires_e8m0
+def test_e8m0_to_fp32_matches_torch_decode_for_special_bytes() -> None:
+    scale = _e8m0_from_bytes([0, 1, 126, 127, 128, 254, 255])
+
+    actual = e8m0_to_fp32(scale)
+
+    torch.testing.assert_close(actual, scale.to(torch.float32), rtol=0, atol=0, equal_nan=True)
 
 
 @_requires_e8m0
@@ -153,3 +223,171 @@ def test_maybe_e8m0_to_fp32_handles_non_e8m0_when_dtype_is_unavailable(
         rtol=0,
         atol=0,
     )
+
+
+def test_fp32_to_e8m0_fallback_returns_decoded_powers_when_dtype_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(e8m0, "_get_e8m0_dtype", lambda: None)
+    scale = torch.tensor([0.25, 1.25, 2.0], dtype=torch.float32, device="cpu")
+
+    actual = fp32_to_e8m0(scale)
+
+    assert actual.dtype == torch.float32
+    torch.testing.assert_close(
+        actual,
+        torch.tensor([0.25, 2.0, 2.0], dtype=torch.float32, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("input_shape", "scale_shape"),
+    [
+        ((2, 448), (2, 4)),
+        ((1024, 4096), (1024, 32)),
+        ((256, 4096), (256, 32)),
+        ((4096, 256), (4096, 2)),
+    ],
+)
+def test_fp8_block_scale_shape_uses_exact_tail_block_count(
+    input_shape: tuple[int, ...],
+    scale_shape: tuple[int, ...],
+) -> None:
+    assert fp8_block_scale_shape(input_shape, block_size=128) == scale_shape
+
+
+def test_fp8_block_quant_dequant_handles_nope_dim_448_tail_block() -> None:
+    x = torch.zeros((2, 448), dtype=torch.float32, device="cpu")
+    x[:, 384:] = torch.linspace(-224.0, 224.0, 64, dtype=torch.float32, device="cpu")
+
+    x_fp8, scale = fp8_block_quant_ref(x, block_size=128)
+    actual = fp8_block_dequant_ref(x_fp8, scale, block_size=128, dtype=torch.float32)
+
+    assert x_fp8.shape == x.shape
+    assert x_fp8.dtype == torch.float8_e4m3fn
+    assert scale.shape == (2, 4)
+    scale_fp32 = maybe_e8m0_to_fp32(scale)
+    torch.testing.assert_close(
+        scale_fp32[:, -1],
+        torch.full((2,), 0.5, dtype=torch.float32, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(actual[:, :384], x[:, :384], rtol=0, atol=0)
+    torch.testing.assert_close(actual[:, -1], x[:, -1], rtol=0, atol=0)
+
+
+@_requires_e8m0
+def test_fp8_block_quant_scales_store_raw_e8m0_exponent_bytes() -> None:
+    x = torch.tensor([[112.0, 224.0, 448.0, 0.0]], dtype=torch.float32, device="cpu")
+
+    _, scale = fp8_block_quant_ref(x, block_size=2)
+
+    assert scale.dtype == torch.float8_e8m0fnu
+    torch.testing.assert_close(
+        e8m0_to_uint8(scale),
+        torch.tensor([[126, 127]], dtype=torch.uint8, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        e8m0_to_fp32(scale),
+        torch.tensor([[0.5, 1.0]], dtype=torch.float32, device="cpu"),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_fp8_block_dequant_decodes_raw_uint8_e8m0_scale_bytes() -> None:
+    x_fp8 = torch.tensor(
+        [[1.0, -2.0, 3.0, -4.0, 5.0, -6.0]],
+        dtype=torch.float32,
+        device="cpu",
+    ).to(torch.float8_e4m3fn)
+    raw_scale = torch.tensor([[126, 127, 128]], dtype=torch.uint8, device="cpu")
+
+    actual = fp8_block_dequant_ref(x_fp8, raw_scale, block_size=2, dtype=torch.float32)
+
+    decoded_scale = e8m0_uint8_to_fp32(raw_scale).repeat_interleave(2, dim=-1)
+    expected = x_fp8.to(torch.float32) * decoded_scale
+    numeric_uint8_scale = raw_scale.to(torch.float32).repeat_interleave(2, dim=-1)
+    numeric_uint8_expected = x_fp8.to(torch.float32) * numeric_uint8_scale
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert not torch.equal(actual, numeric_uint8_expected)
+
+
+@pytest.mark.parametrize("shape", [(1024, 4096), (256, 4096), (4096, 256)])
+def test_fp8_block_quant_dequant_shapes_for_observed_local_weight_shapes(
+    shape: tuple[int, int],
+) -> None:
+    x = torch.zeros(shape, dtype=torch.bfloat16, device="cpu")
+
+    x_fp8, scale = fp8_block_quant_ref(x, block_size=128)
+    actual = fp8_block_dequant_ref(x_fp8, scale, block_size=128, dtype=torch.bfloat16)
+
+    assert x_fp8.shape == shape
+    assert scale.shape == fp8_block_scale_shape(shape, block_size=128)
+    assert actual.shape == shape
+    assert actual.dtype == torch.bfloat16
+
+
+@_requires_e8m0
+@pytest.mark.parametrize(
+    "scale_shape",
+    [
+        (8, 32),
+        (2, 32),
+        (32, 2),
+    ],
+)
+def test_e8m0_helpers_cover_observed_finegrained_fp8_scale_shapes(
+    scale_shape: tuple[int, int],
+) -> None:
+    raw_bytes = torch.full(scale_shape, 127, dtype=torch.uint8, device="cpu")
+    scale = raw_bytes.view(torch.float8_e8m0fnu)
+
+    raw_actual = e8m0_to_uint8(scale)
+    fp32_actual = e8m0_to_fp32(scale)
+
+    assert raw_actual.shape == scale_shape
+    assert fp32_actual.shape == scale_shape
+    torch.testing.assert_close(raw_actual, raw_bytes, rtol=0, atol=0)
+    torch.testing.assert_close(
+        fp32_actual,
+        torch.ones(scale_shape, dtype=torch.float32),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_fp8_block_quant_all_zero_blocks_are_finite() -> None:
+    x = torch.zeros((3, 448), dtype=torch.float32, device="cpu")
+
+    x_fp8, scale = fp8_block_quant_ref(x, block_size=128)
+    actual = fp8_block_dequant_ref(x_fp8, scale, block_size=128, dtype=torch.float32)
+    scale_fp32 = maybe_e8m0_to_fp32(scale)
+
+    assert torch.isfinite(x_fp8.to(torch.float32)).all()
+    assert torch.isfinite(scale_fp32).all()
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(scale_fp32, torch.ones((3, 4), dtype=torch.float32), rtol=0, atol=0)
+    torch.testing.assert_close(actual, x, rtol=0, atol=0)
+
+
+def test_fp8_block_quant_fallback_uses_fp32_scales_when_e8m0_dtype_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(e8m0, "_get_e8m0_dtype", lambda: None)
+    x = torch.zeros((1, 448), dtype=torch.float32, device="cpu")
+    x[:, -1] = 448.0
+
+    x_fp8, scale = fp8_block_quant_ref(x, block_size=128)
+    actual = fp8_block_dequant_ref(x_fp8, scale, block_size=128, dtype=torch.float32)
+
+    assert x_fp8.dtype == torch.float8_e4m3fn
+    assert scale.dtype == torch.float32
+    assert scale.shape == (1, 4)
+    assert torch.isfinite(scale).all()
+    torch.testing.assert_close(actual[:, -1], x[:, -1], rtol=0, atol=0)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_attention_contract.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_attention_contract.py
@@ -1,0 +1,2078 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Executable contract tests for the DeepSeek V4 Triton sparse-attention boundary."""
+
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention import deepseek_v4_attention
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention import (
+    triton_deepseek_v4_sparse_attention as dsv4_triton_attention,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_fp8_cache import (
+    DSV4_FP8_NOPE_ATTENTION_UNSUPPORTED_REASON,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_deepseek_v4_sparse_attention import (
+    deepseek_v4_ratio0_swa_triton_skip_reason,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import (
+    AttentionRegistry,
+    BatchInfo,
+)
+
+LOCAL_HEADS = 8
+HEAD_DIM = 512
+ROPE_DIM = 64
+WINDOW_SIZE = 128
+SOFTMAX_SCALE = 0.04419417382415922
+RMS_NORM_EPS = 1e-6
+
+
+def _batch_info(num_prefill: int, num_prefill_tokens: int, num_decode: int) -> torch.Tensor:
+    batch_info = BatchInfo()
+    batch_info.update([num_prefill, num_prefill_tokens, 0, 0, num_decode, num_decode])
+    batch_info.update_tokens_gather_info(num_prefill_tokens + num_decode, False)
+    return batch_info.serialize()
+
+
+def _paged_cache_metadata(
+    seq_lens_with_cache: list[int], block_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cache_loc = []
+    cu_num_pages = [0]
+    next_page = 0
+    for seq_len in seq_lens_with_cache:
+        num_pages = (seq_len + block_size - 1) // block_size
+        cache_loc.extend(range(next_page, next_page + num_pages))
+        next_page += num_pages
+        cu_num_pages.append(len(cache_loc))
+    return torch.tensor(cache_loc, dtype=torch.int32), torch.tensor(cu_num_pages, dtype=torch.int32)
+
+
+def _freqs_cis_table(max_position: int = 16) -> torch.Tensor:
+    freqs = 1.0 / (10000.0 ** (torch.arange(0, ROPE_DIM, 2, dtype=torch.float32) / ROPE_DIM))
+    phases = torch.arange(max_position, dtype=torch.float32).unsqueeze(1) * freqs.unsqueeze(0)
+    return torch.polar(torch.ones_like(phases), phases)
+
+
+def _cache_tuple(
+    num_pages: int,
+    block_size: int,
+    compressor_state_dim: int = 2 * HEAD_DIM,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    return (
+        torch.zeros(num_pages, 1, block_size, 1, HEAD_DIM, dtype=torch.bfloat16),
+        torch.zeros(num_pages, 1, block_size, 1, HEAD_DIM, dtype=torch.bfloat16),
+        torch.zeros(num_pages, 1, block_size, 1, compressor_state_dim, dtype=torch.bfloat16),
+        torch.zeros(num_pages, 1, block_size, 1, compressor_state_dim, dtype=torch.bfloat16),
+    )
+
+
+def _ratio0_decode_args(
+    graph_batch_size: int,
+    active_sequences: int | None = None,
+) -> list[object]:
+    if active_sequences is None:
+        active_sequences = graph_batch_size
+    block_size = WINDOW_SIZE
+    torch.manual_seed(1000 + graph_batch_size + active_sequences)
+    q = torch.randn(graph_batch_size, 1, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16)
+    kv = torch.randn(graph_batch_size, 1, HEAD_DIM, dtype=torch.bfloat16)
+    attn_sink = torch.linspace(-0.5, 0.5, LOCAL_HEADS, dtype=torch.float32)
+    topk_idxs = torch.full((graph_batch_size, 1, WINDOW_SIZE), -1, dtype=torch.int32)
+    topk_idxs[:, :, 0] = 0
+    compressor_kv = torch.empty(graph_batch_size, 1, 0, dtype=torch.bfloat16)
+    compressor_gate = torch.empty(graph_batch_size, 1, 0, dtype=torch.bfloat16)
+    compressor_ape = torch.empty(0, 0, dtype=torch.bfloat16)
+    compressor_norm_weight = torch.empty(0, dtype=torch.float32)
+    position_ids = torch.zeros(graph_batch_size, 1, dtype=torch.int32)
+    cache_loc, cu_num_pages = _paged_cache_metadata([1] * active_sequences, block_size)
+    return [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        _freqs_cis_table(),
+        position_ids,
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=active_sequences),
+        torch.ones(active_sequences, dtype=torch.int32),
+        torch.zeros(active_sequences, dtype=torch.int32),
+        torch.arange(active_sequences + 1, dtype=torch.int32),
+        cache_loc,
+        cu_num_pages,
+        *_cache_tuple(len(cache_loc), block_size),
+        SOFTMAX_SCALE,
+        WINDOW_SIZE,
+        0,
+        None,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    ]
+
+
+def _clone_args(args: list[object]) -> list[object]:
+    return [arg.clone() if isinstance(arg, torch.Tensor) else arg for arg in args]
+
+
+def _triton_contract(*args: object, out: torch.Tensor | None = None) -> torch.Tensor:
+    return torch.ops.auto_deploy.triton_deepseek_v4_sparse_attention_v2_with_cache(
+        *args,
+        out=out,
+    )
+
+
+def _triton_contract_with_fallback_warning(
+    *args: object,
+    match: str = "falling back to torch_deepseek_v4_sparse_attention_v2_with_cache",
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    with pytest.warns(RuntimeWarning, match=match):
+        return _triton_contract(*args, out=out)
+
+
+def _torch_cached_reference(*args: object, out: torch.Tensor | None = None) -> torch.Tensor:
+    return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache(
+        *args,
+        out=out,
+    )
+
+
+class _RecordingTritonKernel:
+    def __init__(self, kernel):
+        self._kernel = kernel
+        self.launches = 0
+
+    def __getitem__(self, grid):
+        launcher = self._kernel[grid]
+
+        def _launch(*args, **kwargs):
+            self.launches += 1
+            return launcher(*args, **kwargs)
+
+        return _launch
+
+
+def _cuda_ratio0_decode_args(
+    batch_size: int,
+    active_sequences: int,
+    prefix_len: int,
+) -> tuple[list[object], torch.Tensor, torch.Tensor]:
+    device = torch.device("cuda")
+    torch.manual_seed(4096 + batch_size + active_sequences + prefix_len)
+    q = torch.randn(batch_size, 1, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(batch_size, 1, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    attn_sink = torch.linspace(-0.5, 0.5, LOCAL_HEADS, dtype=torch.float32, device=device)
+    topk_idxs = torch.full((batch_size, 1, WINDOW_SIZE), -1, dtype=torch.int32, device=device)
+    topk_idxs[:active_sequences, 0, 0] = 0
+    topk_idxs[:active_sequences, 0, 1] = 0
+    topk_idxs[:active_sequences, 0, 2] = max(prefix_len - 1, 0)
+    topk_idxs[:active_sequences, 0, 3] = prefix_len
+
+    cache_loc, cu_num_pages = _paged_cache_metadata(
+        [prefix_len + 1] * active_sequences, WINDOW_SIZE
+    )
+    cache_loc = cache_loc.to(device)
+    cu_num_pages = cu_num_pages.to(device)
+    caches = tuple(cache.to(device) for cache in _cache_tuple(len(cache_loc), WINDOW_SIZE))
+    swa_cache = caches[0]
+    prefix_kv = torch.randn(
+        active_sequences, prefix_len, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    for seq_idx in range(active_sequences):
+        page_idx = int(cache_loc[seq_idx].item())
+        swa_cache[page_idx, 0, :prefix_len, 0].copy_(prefix_kv[seq_idx])
+
+    args = [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        torch.empty(batch_size, 1, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(batch_size, 1, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(0, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(0, dtype=torch.float32, device=device),
+        _freqs_cis_table().to(device),
+        torch.full((batch_size, 1), prefix_len, dtype=torch.int32, device=device),
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=active_sequences),
+        torch.ones(active_sequences, dtype=torch.int32, device=device),
+        torch.full((active_sequences,), prefix_len, dtype=torch.int32, device=device),
+        torch.arange(active_sequences + 1, dtype=torch.int32, device=device),
+        cache_loc,
+        cu_num_pages,
+        *caches,
+        SOFTMAX_SCALE,
+        WINDOW_SIZE,
+        0,
+        None,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    ]
+    return args, prefix_kv, topk_idxs
+
+
+def _cuda_ratio0_prefill_args(seq_len: int = 3) -> tuple[list[object], list[torch.Tensor]]:
+    device = torch.device("cuda")
+    block_size = WINDOW_SIZE
+    torch.manual_seed(5120 + seq_len)
+    q = torch.randn(1, seq_len, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(1, seq_len, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    attn_sink = torch.linspace(-0.5, 0.5, LOCAL_HEADS, dtype=torch.float32, device=device)
+    topk_idxs = torch.full((1, seq_len, WINDOW_SIZE), -1, dtype=torch.int32, device=device)
+    for token_idx in range(seq_len):
+        topk_idxs[0, token_idx, : token_idx + 1] = torch.arange(
+            token_idx + 1, dtype=torch.int32, device=device
+        )
+
+    cache_loc, cu_num_pages = _paged_cache_metadata([seq_len], block_size)
+    caches = tuple(cache.to(device) for cache in _cache_tuple(len(cache_loc), block_size))
+    args = [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        torch.empty(1, seq_len, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(1, seq_len, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(0, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(0, dtype=torch.float32, device=device),
+        _freqs_cis_table(seq_len + 1).to(device),
+        torch.arange(seq_len, dtype=torch.int32, device=device).view(1, seq_len),
+        _batch_info(num_prefill=1, num_prefill_tokens=seq_len, num_decode=0),
+        torch.tensor([seq_len], dtype=torch.int32, device=device),
+        torch.zeros(1, dtype=torch.int32, device=device),
+        torch.tensor([0, seq_len], dtype=torch.int32, device=device),
+        cache_loc.to(device),
+        cu_num_pages.to(device),
+        *caches,
+        SOFTMAX_SCALE,
+        WINDOW_SIZE,
+        0,
+        None,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    ]
+    return args, [torch.empty(0, HEAD_DIM, dtype=torch.bfloat16, device=device)]
+
+
+def _cuda_ratio0_mixed_args() -> tuple[list[object], list[torch.Tensor]]:
+    device = torch.device("cuda")
+    block_size = WINDOW_SIZE
+    seq_lens = [3, 1, 1]
+    input_positions = [0, 4, 6]
+    active_tokens = sum(seq_lens)
+    torch.manual_seed(5632)
+    q = torch.randn(1, active_tokens, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(1, active_tokens, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    attn_sink = torch.linspace(-0.25, 0.25, LOCAL_HEADS, dtype=torch.float32, device=device)
+    topk_idxs = torch.full((1, active_tokens, WINDOW_SIZE), -1, dtype=torch.int32, device=device)
+
+    topk_idxs[0, 0, 0] = 0
+    topk_idxs[0, 1, :2] = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    topk_idxs[0, 2, :4] = torch.tensor([0, 1, 1, 2], dtype=torch.int32, device=device)
+    topk_idxs[0, 3, :4] = torch.tensor([0, 2, 3, 4], dtype=torch.int32, device=device)
+    topk_idxs[0, 4, :4] = torch.tensor([1, 4, 5, 6], dtype=torch.int32, device=device)
+
+    prefix_rows = [
+        torch.empty(0, HEAD_DIM, dtype=torch.bfloat16, device=device),
+        torch.randn(input_positions[1], HEAD_DIM, dtype=torch.bfloat16, device=device),
+        torch.randn(input_positions[2], HEAD_DIM, dtype=torch.bfloat16, device=device),
+    ]
+    cache_lengths = [input_pos + seq_len for input_pos, seq_len in zip(input_positions, seq_lens)]
+    cache_loc, cu_num_pages = _paged_cache_metadata(cache_lengths, block_size)
+    caches = tuple(cache.to(device) for cache in _cache_tuple(len(cache_loc), block_size))
+    for seq_idx, prefix in enumerate(prefix_rows):
+        if prefix.numel() == 0:
+            continue
+        deepseek_v4_attention._write_swa_cache(
+            prefix,
+            caches[0],
+            cache_loc,
+            cu_num_pages,
+            seq_idx=seq_idx,
+            input_pos=0,
+        )
+
+    args = [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        torch.empty(1, active_tokens, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(1, active_tokens, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(0, 0, dtype=torch.bfloat16, device=device),
+        torch.empty(0, dtype=torch.float32, device=device),
+        _freqs_cis_table(max(cache_lengths) + 1).to(device),
+        torch.arange(active_tokens, dtype=torch.int32, device=device).view(1, active_tokens),
+        _batch_info(num_prefill=1, num_prefill_tokens=seq_lens[0], num_decode=2),
+        torch.tensor(seq_lens, dtype=torch.int32, device=device),
+        torch.tensor(input_positions, dtype=torch.int32, device=device),
+        torch.tensor([0, 3, 4, 5], dtype=torch.int32, device=device),
+        cache_loc.to(device),
+        cu_num_pages.to(device),
+        *caches,
+        SOFTMAX_SCALE,
+        WINDOW_SIZE,
+        0,
+        None,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    ]
+    return args, prefix_rows
+
+
+def _compressed_local_topk(
+    seq_len: int,
+    input_pos: int,
+    width: int,
+    device: torch.device,
+) -> torch.Tensor:
+    topk = torch.full((seq_len, width), -1, dtype=torch.int32, device=device)
+    for token_offset in range(seq_len):
+        query_pos = input_pos + token_offset
+        local_start = max(0, query_pos - WINDOW_SIZE + 1)
+        local_idxs = torch.arange(local_start, query_pos + 1, dtype=torch.int32, device=device)
+        topk[token_offset, : local_idxs.numel()] = local_idxs
+    return topk
+
+
+def _compressed_topk(
+    ratio: int,
+    seq_len: int,
+    input_pos: int,
+    compressed_offset: int,
+    width: int,
+    device: torch.device,
+) -> torch.Tensor:
+    topk = torch.full((seq_len, width), -1, dtype=torch.int32, device=device)
+    compressed_slots = width - WINDOW_SIZE
+    for token_offset in range(seq_len):
+        query_pos = input_pos + token_offset
+        compressed_len = min((query_pos + 1) // ratio, compressed_slots)
+        if compressed_len:
+            topk[token_offset, WINDOW_SIZE : WINDOW_SIZE + compressed_len] = (
+                compressed_offset + torch.arange(compressed_len, dtype=torch.int32, device=device)
+            )
+    return topk
+
+
+def _cuda_ratio4_prefill_mixed_args() -> list[object]:
+    device = torch.device("cuda")
+    block_size = WINDOW_SIZE
+    max_compressed_len = deepseek_v4_attention._DSV4_TRITON_RATIO4_MAX_COMPRESSED_LEN
+    width = deepseek_v4_attention._DSV4_TRITON_TOPK_WIDTH_BY_RATIO[4]
+    compressor_state_dim = deepseek_v4_attention._DSV4_TRITON_COMPRESSOR_DIM_BY_RATIO[4]
+    seq_lens = [5, 1]
+    input_positions = [0, 7]
+    active_tokens = sum(seq_lens)
+    cache_lengths = [input_pos + seq_len for input_pos, seq_len in zip(input_positions, seq_lens)]
+    torch.manual_seed(7168)
+
+    q = torch.randn(1, active_tokens, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(1, active_tokens, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    compressor_kv = torch.randn(
+        1, active_tokens, compressor_state_dim, dtype=torch.bfloat16, device=device
+    )
+    compressor_gate = torch.randn_like(compressor_kv)
+    compressor_ape = torch.randn(4, compressor_state_dim, dtype=torch.bfloat16, device=device)
+    compressor_norm_weight = torch.ones(HEAD_DIM, dtype=torch.float32, device=device)
+    attn_sink = torch.linspace(-0.25, 0.25, LOCAL_HEADS, dtype=torch.float32, device=device)
+    topk_idxs = torch.full((1, active_tokens, width), -1, dtype=torch.int32, device=device)
+    cu_seqlen = [0]
+    for seq_len in seq_lens:
+        cu_seqlen.append(cu_seqlen[-1] + seq_len)
+    for seq_idx, (seq_len, input_pos) in enumerate(zip(seq_lens, input_positions)):
+        flat_start = cu_seqlen[seq_idx]
+        topk_idxs[0, flat_start : flat_start + seq_len] = _compressed_local_topk(
+            seq_len, input_pos, width, device
+        )
+        topk_idxs[0, flat_start : flat_start + seq_len] = torch.maximum(
+            topk_idxs[0, flat_start : flat_start + seq_len],
+            _compressed_topk(
+                4, seq_len, input_pos, max(seq_len, input_pos + seq_len), width, device
+            ),
+        )
+
+    cache_loc_cpu, cu_num_pages_cpu = _paged_cache_metadata(cache_lengths, block_size)
+    caches = tuple(
+        cache.to(device=device, dtype=torch.float32 if idx in (2, 3) else cache.dtype)
+        for idx, cache in enumerate(
+            _cache_tuple(len(cache_loc_cpu), block_size, compressor_state_dim)
+        )
+    )
+    prefix_kv = torch.randn(input_positions[1], HEAD_DIM, dtype=torch.bfloat16, device=device)
+    prefix_compressor_kv = torch.randn(
+        input_positions[1], compressor_state_dim, dtype=torch.bfloat16, device=device
+    )
+    prefix_compressor_gate = torch.randn_like(prefix_compressor_kv)
+    deepseek_v4_attention._write_swa_cache(
+        prefix_kv,
+        caches[0],
+        cache_loc_cpu,
+        cu_num_pages_cpu,
+        seq_idx=1,
+        input_pos=0,
+    )
+    freqs_cis_table = _freqs_cis_table(max(cache_lengths) + 8).to(device)
+    deepseek_v4_attention._update_compressed_caches(
+        prefix_compressor_kv,
+        prefix_compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        cache_loc_cpu,
+        cu_num_pages_cpu,
+        1,
+        0,
+        caches[1],
+        caches[2],
+        caches[3],
+        RMS_NORM_EPS,
+        ROPE_DIM,
+        4,
+        max_compressed_len,
+    )
+
+    return [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        torch.arange(active_tokens, dtype=torch.int32, device=device).view(1, active_tokens),
+        _batch_info(num_prefill=1, num_prefill_tokens=seq_lens[0], num_decode=1),
+        torch.tensor(seq_lens, dtype=torch.int32, device=device),
+        torch.tensor(input_positions, dtype=torch.int32, device=device),
+        torch.tensor(cu_seqlen, dtype=torch.int32, device=device),
+        cache_loc_cpu.to(device),
+        cu_num_pages_cpu.to(device),
+        *caches,
+        SOFTMAX_SCALE,
+        WINDOW_SIZE,
+        4,
+        max_compressed_len,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    ]
+
+
+def _cuda_ratio128_prefill_mixed_args() -> list[object]:
+    device = torch.device("cuda")
+    block_size = WINDOW_SIZE
+    max_compressed_len = deepseek_v4_attention._DSV4_TRITON_RATIO128_MAX_COMPRESSED_LEN
+    width = deepseek_v4_attention._DSV4_TRITON_TOPK_WIDTH_BY_RATIO[128]
+    compressor_state_dim = deepseek_v4_attention._DSV4_TRITON_COMPRESSOR_DIM_BY_RATIO[128]
+    seq_lens = [3, 1]
+    input_positions = [0, 127]
+    active_tokens = sum(seq_lens)
+    cache_lengths = [input_pos + seq_len for input_pos, seq_len in zip(input_positions, seq_lens)]
+    torch.manual_seed(8192)
+
+    q = torch.randn(1, active_tokens, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(1, active_tokens, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    compressor_kv = torch.randn(
+        1, active_tokens, compressor_state_dim, dtype=torch.bfloat16, device=device
+    )
+    compressor_gate = torch.randn_like(compressor_kv)
+    compressor_ape = torch.randn(128, compressor_state_dim, dtype=torch.bfloat16, device=device)
+    compressor_norm_weight = torch.ones(HEAD_DIM, dtype=torch.float32, device=device)
+    attn_sink = torch.linspace(-0.25, 0.25, LOCAL_HEADS, dtype=torch.float32, device=device)
+    topk_idxs = torch.full((1, active_tokens, width), -1, dtype=torch.int32, device=device)
+    cu_seqlen = [0]
+    for seq_len in seq_lens:
+        cu_seqlen.append(cu_seqlen[-1] + seq_len)
+    for seq_idx, (seq_len, input_pos) in enumerate(zip(seq_lens, input_positions)):
+        flat_start = cu_seqlen[seq_idx]
+        topk_idxs[0, flat_start : flat_start + seq_len] = _compressed_local_topk(
+            seq_len, input_pos, width, device
+        )
+
+    cache_loc_cpu, cu_num_pages_cpu = _paged_cache_metadata(cache_lengths, block_size)
+    caches = tuple(
+        cache.to(device=device, dtype=torch.float32 if idx in (2, 3) else cache.dtype)
+        for idx, cache in enumerate(
+            _cache_tuple(len(cache_loc_cpu), block_size, compressor_state_dim)
+        )
+    )
+    prefix_kv = torch.randn(input_positions[1], HEAD_DIM, dtype=torch.bfloat16, device=device)
+    prefix_compressor_kv = torch.randn(
+        input_positions[1], compressor_state_dim, dtype=torch.bfloat16, device=device
+    )
+    prefix_compressor_gate = torch.randn_like(prefix_compressor_kv)
+    deepseek_v4_attention._write_swa_cache(
+        prefix_kv,
+        caches[0],
+        cache_loc_cpu,
+        cu_num_pages_cpu,
+        seq_idx=1,
+        input_pos=0,
+    )
+    freqs_cis_table = _freqs_cis_table(max(cache_lengths) + 8).to(device)
+    deepseek_v4_attention._update_compressed_caches(
+        prefix_compressor_kv,
+        prefix_compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        cache_loc_cpu,
+        cu_num_pages_cpu,
+        1,
+        0,
+        caches[1],
+        caches[2],
+        caches[3],
+        RMS_NORM_EPS,
+        ROPE_DIM,
+        128,
+        max_compressed_len,
+    )
+
+    return [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        torch.arange(active_tokens, dtype=torch.int32, device=device).view(1, active_tokens),
+        _batch_info(num_prefill=1, num_prefill_tokens=seq_lens[0], num_decode=1),
+        torch.tensor(seq_lens, dtype=torch.int32, device=device),
+        torch.tensor(input_positions, dtype=torch.int32, device=device),
+        torch.tensor(cu_seqlen, dtype=torch.int32, device=device),
+        cache_loc_cpu.to(device),
+        cu_num_pages_cpu.to(device),
+        *caches,
+        SOFTMAX_SCALE,
+        WINDOW_SIZE,
+        128,
+        max_compressed_len,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    ]
+
+
+def _expected_cuda_ratio0_prefill_mixed(
+    args: list[object],
+    prefix_rows: list[torch.Tensor],
+) -> torch.Tensor:
+    q = args[0]
+    kv = args[1]
+    attn_sink = args[2]
+    topk_idxs = args[3]
+    seq_lens = args[11].detach().cpu().tolist()
+    input_positions = args[12].detach().cpu().tolist()
+    cu_seqlen = args[13].detach().cpu().tolist()
+    q_flat = q.reshape(-1, LOCAL_HEADS, HEAD_DIM)
+    kv_flat = kv.reshape(-1, HEAD_DIM)
+    topk_flat = topk_idxs.reshape(-1, WINDOW_SIZE)
+    expected_flat = torch.zeros_like(q_flat)
+
+    for seq_idx, seq_len in enumerate(seq_lens):
+        flat_start = int(cu_seqlen[seq_idx])
+        input_pos = int(input_positions[seq_idx])
+        current_rows = kv_flat[flat_start : flat_start + seq_len]
+        full_rows = torch.cat([prefix_rows[seq_idx], current_rows], dim=0)
+        for token_offset in range(seq_len):
+            flat_idx = flat_start + token_offset
+            query_pos = input_pos + token_offset
+            selected = topk_flat[flat_idx].to(torch.long)
+            valid = (selected >= 0) & (selected <= query_pos) & (selected < full_rows.shape[0])
+            selected_rows = selected[valid]
+            if selected_rows.numel() == 0:
+                continue
+            values = full_rows[selected_rows].float()
+            logits = torch.einsum("hd,kd->hk", q_flat[flat_idx].float(), values)
+            logits = logits * SOFTMAX_SCALE
+            sink_logits = attn_sink.float().view(LOCAL_HEADS, 1)
+            probs = torch.softmax(torch.cat([sink_logits, logits], dim=1), dim=1)[:, 1:]
+            expected_flat[flat_idx] = torch.einsum("hk,kd->hd", probs, values).to(q.dtype)
+
+    return expected_flat.view_as(q)
+
+
+def _expected_cuda_compressed_prefill_mixed(args: list[object]) -> torch.Tensor:
+    q = args[0]
+    kv = args[1]
+    topk_idxs = args[3]
+    compressor_kv = args[4]
+    compressor_gate = args[5]
+    seq_lens = args[11].detach().cpu().tolist()
+    input_positions = args[12].detach().cpu().tolist()
+    cu_seqlen = args[13].detach().cpu().tolist()
+    cache_loc = args[14].detach().cpu()
+    cu_num_pages = args[15].detach().cpu()
+    caches = tuple(cache.clone() for cache in args[16:20])
+    expected = torch.zeros_like(q)
+
+    compress_ratio = args[22]
+
+    # First sequence is a true prefill at input_pos=0, so the source op is the
+    # exact reference for its rows.
+    prefill_len = seq_lens[0]
+    expected[:, :prefill_len] = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2(
+        q[:, :prefill_len],
+        kv[:, :prefill_len],
+        args[2],
+        topk_idxs[:, :prefill_len],
+        compressor_kv[:, :prefill_len],
+        compressor_gate[:, :prefill_len],
+        args[6],
+        args[7],
+        args[8],
+        args[9][:, :prefill_len],
+        args[20],
+        window_size=args[21],
+        compress_ratio=compress_ratio,
+        max_compressed_len=args[23],
+        rope_dim=args[25],
+        rms_norm_eps=args[24],
+    )
+
+    # Remaining rows are decode-style active tokens with existing cache state.
+    for seq_idx in range(1, len(seq_lens)):
+        flat_start = int(cu_seqlen[seq_idx])
+        flat_end = flat_start + int(seq_lens[seq_idx])
+        page_start = int(cu_num_pages[seq_idx])
+        page_end = int(cu_num_pages[seq_idx + 1])
+        seq_cache_loc = cache_loc[page_start:page_end].to(q.device)
+        seq_cu_num_pages = torch.tensor(
+            [0, page_end - page_start], dtype=torch.int32, device=q.device
+        )
+        expected[:, flat_start:flat_end] = (
+            torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache(
+                q[:, flat_start:flat_end],
+                kv[:, flat_start:flat_end],
+                args[2],
+                topk_idxs[:, flat_start:flat_end],
+                compressor_kv[:, flat_start:flat_end],
+                compressor_gate[:, flat_start:flat_end],
+                args[6],
+                args[7],
+                args[8],
+                args[9][:, flat_start:flat_end],
+                _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=seq_lens[seq_idx]),
+                torch.tensor([seq_lens[seq_idx]], dtype=torch.int32, device=q.device),
+                torch.tensor([input_positions[seq_idx]], dtype=torch.int32, device=q.device),
+                torch.tensor([0, seq_lens[seq_idx]], dtype=torch.int32, device=q.device),
+                seq_cache_loc,
+                seq_cu_num_pages,
+                caches[0],
+                caches[1],
+                caches[2],
+                caches[3],
+                args[20],
+                args[21],
+                compress_ratio,
+                args[23],
+                args[24],
+                args[25],
+            )
+        )
+    return expected
+
+
+def _install_unexpected_attention_reference_guards(monkeypatch, message: str) -> None:
+    def _unexpected_reference(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError(message)
+
+    for name in (
+        "torch_deepseek_v4_sparse_attention_v2_with_cache",
+        "torch_deepseek_v4_sparse_attention_v2",
+        "torch_deepseek_v4_sparse_attention",
+    ):
+        monkeypatch.setattr(deepseek_v4_attention, name, _unexpected_reference)
+
+
+def _cuda_ratio4_decode_args(
+    batch_size: int = 1,
+    active_sequences: int = 1,
+    prefix_len: int = 7,
+) -> list[object]:
+    device = torch.device("cuda")
+    block_size = WINDOW_SIZE
+    max_compressed_len = deepseek_v4_attention._DSV4_TRITON_RATIO4_MAX_COMPRESSED_LEN
+    compressor_state_dim = 2 * HEAD_DIM
+    torch.manual_seed(6144 + batch_size + active_sequences + prefix_len)
+
+    q = torch.randn(batch_size, 1, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(batch_size, 1, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    attn_sink = torch.linspace(-0.25, 0.25, LOCAL_HEADS, dtype=torch.float32, device=device)
+    source_seq_len = prefix_len + 1
+    topk_idxs = torch.full((batch_size, 1, WINDOW_SIZE + 512), -1, dtype=torch.int32, device=device)
+    local_start = max(0, source_seq_len - WINDOW_SIZE)
+    local_idxs = torch.arange(local_start, source_seq_len, dtype=torch.int32, device=device)
+    topk_idxs[:active_sequences, 0, : local_idxs.numel()] = local_idxs
+    compressed_len = source_seq_len // 4
+    compressed_idxs = source_seq_len + torch.arange(
+        compressed_len, dtype=torch.int32, device=device
+    )
+    topk_idxs[
+        :active_sequences,
+        0,
+        WINDOW_SIZE : WINDOW_SIZE + compressed_len,
+    ] = compressed_idxs
+
+    cache_loc_cpu, cu_num_pages_cpu = _paged_cache_metadata(
+        [prefix_len + 1] * active_sequences, block_size
+    )
+    cache_template = _cache_tuple(len(cache_loc_cpu), block_size, compressor_state_dim)
+    caches = (
+        cache_template[0].to(device),
+        cache_template[1].to(device),
+        cache_template[2].to(device=device, dtype=torch.float32),
+        cache_template[3].to(device=device, dtype=torch.float32),
+    )
+    prefix_kv = torch.randn(
+        active_sequences, prefix_len, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    prefix_compressor_kv = torch.randn(
+        active_sequences, prefix_len, compressor_state_dim, dtype=torch.bfloat16, device=device
+    )
+    prefix_compressor_gate = torch.randn(
+        active_sequences, prefix_len, compressor_state_dim, dtype=torch.bfloat16, device=device
+    )
+    compressor_ape = torch.randn(4, compressor_state_dim, dtype=torch.bfloat16, device=device)
+    compressor_norm_weight = torch.ones(HEAD_DIM, dtype=torch.float32, device=device)
+    freqs_cis_table = _freqs_cis_table(prefix_len + 8).to(device)
+
+    for seq_idx in range(active_sequences):
+        deepseek_v4_attention._write_swa_cache(
+            prefix_kv[seq_idx],
+            caches[0],
+            cache_loc_cpu,
+            cu_num_pages_cpu,
+            seq_idx=seq_idx,
+            input_pos=0,
+        )
+        deepseek_v4_attention._update_compressed_caches(
+            prefix_compressor_kv[seq_idx],
+            prefix_compressor_gate[seq_idx],
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            cache_loc_cpu,
+            cu_num_pages_cpu,
+            seq_idx,
+            0,
+            caches[1],
+            caches[2],
+            caches[3],
+            RMS_NORM_EPS,
+            ROPE_DIM,
+            4,
+            max_compressed_len,
+        )
+
+    cache_loc = cache_loc_cpu.to(device)
+    cu_num_pages = cu_num_pages_cpu.to(device)
+    compressor_kv = torch.randn(
+        batch_size, 1, compressor_state_dim, dtype=torch.bfloat16, device=device
+    )
+    compressor_gate = torch.randn_like(compressor_kv)
+
+    return [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        torch.full((batch_size, 1), prefix_len, dtype=torch.int32, device=device),
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=active_sequences),
+        torch.ones(active_sequences, dtype=torch.int32, device=device),
+        torch.full((active_sequences,), prefix_len, dtype=torch.int32, device=device),
+        torch.arange(active_sequences + 1, dtype=torch.int32, device=device),
+        cache_loc,
+        cu_num_pages,
+        *caches,
+        SOFTMAX_SCALE,
+        WINDOW_SIZE,
+        4,
+        max_compressed_len,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    ]
+
+
+def _expected_cuda_ratio0_decode(
+    args: list[object],
+    prefix_kv: torch.Tensor,
+    active_sequences: int,
+) -> torch.Tensor:
+    q = args[0]
+    kv = args[1]
+    attn_sink = args[2]
+    topk_idxs = args[3]
+    expected = torch.zeros_like(q)
+    for seq_idx in range(active_sequences):
+        full_kv = torch.cat(
+            [prefix_kv[seq_idx : seq_idx + 1], kv[seq_idx : seq_idx + 1]],
+            dim=1,
+        )
+        expected[seq_idx : seq_idx + 1] = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+            q[seq_idx : seq_idx + 1],
+            full_kv,
+            attn_sink,
+            topk_idxs[seq_idx : seq_idx + 1],
+            SOFTMAX_SCALE,
+        )
+    return expected
+
+
+def _cuda_ratio128_decode_args(
+    batch_size: int = 1,
+    active_sequences: int = 1,
+    prefix_len: int = 127,
+) -> list[object]:
+    device = torch.device("cuda")
+    block_size = WINDOW_SIZE
+    torch.manual_seed(8192 + batch_size + active_sequences + prefix_len)
+    q = torch.randn(batch_size, 1, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    kv = torch.randn(batch_size, 1, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    attn_sink = torch.linspace(-0.25, 0.25, LOCAL_HEADS, dtype=torch.float32, device=device)
+    topk_idxs = torch.full((batch_size, 1, WINDOW_SIZE + 64), -1, dtype=torch.int32, device=device)
+
+    cache_loc_cpu, cu_num_pages_cpu = _paged_cache_metadata(
+        [prefix_len + 1] * active_sequences, block_size
+    )
+    caches = tuple(
+        cache.to(device) for cache in _cache_tuple(len(cache_loc_cpu), block_size, HEAD_DIM)
+    )
+    prefix_kv = torch.randn(
+        active_sequences, prefix_len, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    prefix_compressor_kv = torch.randn(
+        active_sequences, prefix_len, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    prefix_compressor_gate = torch.randn(
+        active_sequences, prefix_len, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    for seq_idx in range(active_sequences):
+        page_idx = int(cache_loc_cpu[seq_idx].item())
+        caches[0][page_idx, 0, :prefix_len, 0].copy_(prefix_kv[seq_idx])
+        caches[2][page_idx, 0, :prefix_len, 0].copy_(prefix_compressor_kv[seq_idx])
+        caches[3][page_idx, 0, :prefix_len, 0].copy_(prefix_compressor_gate[seq_idx])
+
+    compressor_kv = torch.randn(batch_size, 1, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    compressor_gate = torch.randn(batch_size, 1, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    compressor_ape = torch.randn(128, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    compressor_norm_weight = torch.ones(HEAD_DIM, dtype=torch.float32, device=device)
+    cache_loc = cache_loc_cpu.to(device)
+    cu_num_pages = cu_num_pages_cpu.to(device)
+
+    return [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        _freqs_cis_table(prefix_len + 130).to(device),
+        torch.full((batch_size, 1), prefix_len, dtype=torch.int32, device=device),
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=active_sequences),
+        torch.ones(active_sequences, dtype=torch.int32, device=device),
+        torch.full((active_sequences,), prefix_len, dtype=torch.int32, device=device),
+        torch.arange(active_sequences + 1, dtype=torch.int32, device=device),
+        cache_loc,
+        cu_num_pages,
+        *caches,
+        SOFTMAX_SCALE,
+        WINDOW_SIZE,
+        128,
+        64,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    ]
+
+
+def _compressor_state_dim(compress_ratio: int) -> int:
+    if compress_ratio == 0:
+        return 0
+    if compress_ratio == 4:
+        return 2 * HEAD_DIM
+    if compress_ratio == 128:
+        return HEAD_DIM
+    raise ValueError(f"unsupported compress_ratio={compress_ratio}")
+
+
+def _topk_width(compress_ratio: int) -> int:
+    if compress_ratio == 0:
+        return WINDOW_SIZE
+    if compress_ratio == 4:
+        return WINDOW_SIZE + 512
+    if compress_ratio == 128:
+        return WINDOW_SIZE + 64
+    raise ValueError(f"unsupported compress_ratio={compress_ratio}")
+
+
+def _seed_cached_decode_resources(
+    compress_ratio: int,
+    prefix_len: int,
+    seed: int,
+) -> list[object]:
+    torch.manual_seed(seed)
+    block_size = WINDOW_SIZE
+    compressor_state_dim = _compressor_state_dim(compress_ratio)
+    q = torch.randn(1, 1, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16)
+    kv = torch.randn(1, 1, HEAD_DIM, dtype=torch.bfloat16)
+    attn_sink = torch.linspace(-0.25, 0.25, LOCAL_HEADS, dtype=torch.float32)
+    topk_idxs = torch.full((1, 1, _topk_width(compress_ratio)), -1, dtype=torch.int32)
+    topk_idxs[0, 0, 0] = prefix_len
+    if prefix_len > 0:
+        topk_idxs[0, 0, 1] = prefix_len - 1
+    cache_loc, cu_num_pages = _paged_cache_metadata([prefix_len + 1], block_size)
+    caches = _cache_tuple(len(cache_loc), block_size, max(compressor_state_dim, HEAD_DIM))
+    prefix_kv = torch.randn(prefix_len, HEAD_DIM, dtype=torch.bfloat16)
+    deepseek_v4_attention._write_swa_cache(
+        prefix_kv,
+        caches[0],
+        cache_loc,
+        cu_num_pages,
+        seq_idx=0,
+        input_pos=0,
+    )
+
+    if compress_ratio == 0:
+        compressor_kv = torch.empty(1, 1, 0, dtype=torch.bfloat16)
+        compressor_gate = torch.empty(1, 1, 0, dtype=torch.bfloat16)
+        compressor_ape = torch.empty(0, 0, dtype=torch.bfloat16)
+        compressor_norm_weight = torch.empty(0, dtype=torch.float32)
+        max_compressed_len = None
+    else:
+        prefix_compressor_kv = torch.randn(prefix_len, compressor_state_dim, dtype=torch.bfloat16)
+        prefix_compressor_gate = torch.randn(prefix_len, compressor_state_dim, dtype=torch.bfloat16)
+        deepseek_v4_attention._write_paged_rows(
+            prefix_compressor_kv,
+            caches[2],
+            cache_loc,
+            cu_num_pages,
+            seq_idx=0,
+            input_pos=0,
+        )
+        deepseek_v4_attention._write_paged_rows(
+            prefix_compressor_gate,
+            caches[3],
+            cache_loc,
+            cu_num_pages,
+            seq_idx=0,
+            input_pos=0,
+        )
+        compressor_kv = torch.randn(1, 1, compressor_state_dim, dtype=torch.bfloat16)
+        compressor_gate = torch.randn(1, 1, compressor_state_dim, dtype=torch.bfloat16)
+        compressor_ape = torch.zeros(compress_ratio, compressor_state_dim, dtype=torch.bfloat16)
+        compressor_norm_weight = torch.ones(HEAD_DIM, dtype=torch.float32)
+        max_compressed_len = (
+            deepseek_v4_attention._DSV4_TRITON_RATIO4_MAX_COMPRESSED_LEN
+            if compress_ratio == 4
+            else 64
+        )
+
+    return [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        _freqs_cis_table(prefix_len + max(compress_ratio, 1) + 2),
+        torch.full((1, 1), prefix_len, dtype=torch.int32),
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=1),
+        torch.ones(1, dtype=torch.int32),
+        torch.full((1,), prefix_len, dtype=torch.int32),
+        torch.tensor([0, 1], dtype=torch.int32),
+        cache_loc,
+        cu_num_pages,
+        *caches,
+        SOFTMAX_SCALE,
+        WINDOW_SIZE,
+        compress_ratio,
+        max_compressed_len,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    ]
+
+
+def _ratio0_triton_skip_reason(args: list[object], active_tokens: int) -> str | None:
+    return deepseek_v4_ratio0_swa_triton_skip_reason(
+        args[0],
+        args[1],
+        args[2],
+        args[3],
+        args[11],
+        args[12],
+        args[13],
+        args[14],
+        args[15],
+        args[16],
+        args[21],
+        args[22],
+        None,
+        active_tokens,
+    )
+
+
+def test_triton_contract_schema_matches_plan_01_argument_order():
+    schema = torch.ops.auto_deploy.triton_deepseek_v4_sparse_attention_v2_with_cache.default._schema
+
+    assert [arg.name for arg in schema.arguments] == [
+        "q",
+        "kv",
+        "attn_sink",
+        "topk_idxs",
+        "compressor_kv",
+        "compressor_gate",
+        "compressor_ape",
+        "compressor_norm_weight",
+        "freqs_cis_table",
+        "position_ids",
+        "batch_info_host",
+        "seq_len_host",
+        "input_pos_host",
+        "cu_seqlen_host",
+        "cache_loc_host",
+        "cu_num_pages_host",
+        "swa_cache",
+        "mhc_cache",
+        "compressor_kv_cache",
+        "compressor_gate_cache",
+        "softmax_scale",
+        "window_size",
+        "compress_ratio",
+        "max_compressed_len",
+        "rms_norm_eps",
+        "rope_dim",
+        "out",
+    ]
+
+
+@pytest.mark.parametrize(
+    "compress_ratio,topk_width,max_compressed_len,compressor_dim,ape_shape,norm_shape",
+    [
+        pytest.param(0, 128, None, 0, (0, 0), (0,), id="ratio0-observed"),
+        pytest.param(4, 640, 2048, 1024, (4, 1024), (512,), id="ratio4-observed"),
+        pytest.param(128, 192, 64, 512, (128, 512), (512,), id="ratio128-observed"),
+    ],
+)
+def test_triton_contract_fake_covers_observed_graph_shapes(
+    compress_ratio: int,
+    topk_width: int,
+    max_compressed_len: int | None,
+    compressor_dim: int,
+    ape_shape: tuple[int, int],
+    norm_shape: tuple[int],
+):
+    with FakeTensorMode():
+        batch_size, seq_len, block_size = 2, 3, WINDOW_SIZE
+        num_pages = batch_size
+        q = torch.empty(batch_size, seq_len, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16)
+        kv = torch.empty(batch_size, seq_len, HEAD_DIM, dtype=torch.bfloat16)
+        attn_sink = torch.empty(LOCAL_HEADS, dtype=torch.float32)
+        topk_idxs = torch.empty(batch_size, seq_len, topk_width, dtype=torch.int32)
+        compressor_kv = torch.empty(batch_size, seq_len, compressor_dim, dtype=torch.bfloat16)
+        compressor_gate = torch.empty(batch_size, seq_len, compressor_dim, dtype=torch.bfloat16)
+        compressor_ape = torch.empty(*ape_shape, dtype=torch.bfloat16)
+        compressor_norm_weight = torch.empty(*norm_shape, dtype=torch.float32)
+        freqs_cis_table = torch.empty(8192, ROPE_DIM // 2, dtype=torch.complex64)
+        position_ids = torch.empty(batch_size, seq_len, dtype=torch.int32)
+        cache_loc = torch.empty(num_pages, dtype=torch.int32)
+        cu_num_pages = torch.empty(batch_size + 1, dtype=torch.int32)
+        caches = _cache_tuple(num_pages, block_size)
+
+        output = _triton_contract(
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            position_ids,
+            torch.empty(12, dtype=torch.int32),
+            torch.empty(batch_size, dtype=torch.int32),
+            torch.empty(batch_size, dtype=torch.int32),
+            torch.empty(batch_size + 1, dtype=torch.int32),
+            cache_loc,
+            cu_num_pages,
+            *caches,
+            SOFTMAX_SCALE,
+            WINDOW_SIZE,
+            compress_ratio,
+            max_compressed_len,
+            RMS_NORM_EPS,
+            ROPE_DIM,
+        )
+        out = torch.empty_like(q)
+        replay_result = _triton_contract(
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            position_ids,
+            torch.empty(12, dtype=torch.int32),
+            torch.empty(batch_size, dtype=torch.int32),
+            torch.empty(batch_size, dtype=torch.int32),
+            torch.empty(batch_size + 1, dtype=torch.int32),
+            cache_loc,
+            cu_num_pages,
+            *caches,
+            SOFTMAX_SCALE,
+            WINDOW_SIZE,
+            compress_ratio,
+            max_compressed_len,
+            RMS_NORM_EPS,
+            ROPE_DIM,
+            out=out,
+        )
+
+    assert output.shape == (batch_size, seq_len, LOCAL_HEADS, HEAD_DIM)
+    assert output.dtype == torch.bfloat16
+    assert replay_result.numel() == 0
+
+
+@pytest.mark.parametrize(
+    "compress_ratio,prefix_len,expected_reason",
+    [
+        pytest.param(
+            4,
+            3,
+            "q must be a CUDA tensor for the Triton ratio-4 compressed decode path",
+            id="ratio4-cpu-fallback",
+        ),
+        pytest.param(
+            128,
+            127,
+            "q must be a CUDA tensor for the Triton ratio-128 compressed decode path",
+            id="ratio128-cpu-fallback",
+        ),
+    ],
+)
+def test_triton_contract_compressed_fallback_reasons_are_explicit(
+    compress_ratio: int,
+    prefix_len: int,
+    expected_reason: str,
+):
+    args = _seed_cached_decode_resources(compress_ratio, prefix_len, seed=3100 + compress_ratio)
+
+    reason, num_decode = deepseek_v4_attention._deepseek_v4_triton_cached_attention_fallback_reason(
+        args[0],
+        args[1],
+        args[2],
+        args[3],
+        args[10],
+        args[11],
+        args[12],
+        args[13],
+        args[14],
+        args[15],
+        args[16],
+        args[21],
+        args[22],
+        None,
+        compressor_kv=args[4],
+        compressor_gate=args[5],
+        compressor_ape=args[6],
+        compressor_norm_weight=args[7],
+        freqs_cis_table=args[8],
+        mhc_cache=args[17],
+        compressor_kv_cache=args[18],
+        compressor_gate_cache=args[19],
+        max_compressed_len=args[23],
+        rope_dim=args[25],
+    )
+
+    assert num_decode == 1
+    assert reason is not None
+    assert expected_reason in reason
+
+
+@pytest.mark.parametrize(
+    "compress_ratio,prefix_len,expected_reason",
+    [
+        pytest.param(
+            4,
+            3,
+            "q must be a CUDA tensor for the Triton ratio-4 compressed decode path",
+            id="ratio4-cpu-fallback",
+        ),
+        pytest.param(
+            128,
+            127,
+            "q must be a CUDA tensor for the Triton ratio-128 compressed decode path",
+            id="ratio128-cpu-fallback",
+        ),
+    ],
+)
+def test_triton_contract_compressed_fallback_warns_before_torch_reference(
+    compress_ratio: int,
+    prefix_len: int,
+    expected_reason: str,
+):
+    args = _seed_cached_decode_resources(compress_ratio, prefix_len, seed=3125 + compress_ratio)
+
+    output = _triton_contract_with_fallback_warning(*args, match=expected_reason)
+
+    assert output.shape == (1, 1, LOCAL_HEADS, HEAD_DIM)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio4_cuda_decode_launches_kernels_without_torch_reference(monkeypatch):
+    args = _cuda_ratio4_decode_args()
+    expected_args = _clone_args(args)
+    expected = _torch_cached_reference(*expected_args)
+    out = torch.empty_like(args[0])
+    update_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._update_ratio4_decode_caches_kernel
+    )
+    emit_kernel = _RecordingTritonKernel(deepseek_v4_attention._emit_ratio4_mhc_rows_kernel)
+    attention_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._ratio4_selected_attention_kernel
+    )
+
+    def _unexpected_cached_reference(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("ratio-4 supported decode must not use the Torch cached reference")
+
+    monkeypatch.delenv(deepseek_v4_attention._DSV4_FORCE_TORCH_REFERENCE_ENV, raising=False)
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "torch_deepseek_v4_sparse_attention_v2_with_cache",
+        _unexpected_cached_reference,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_update_ratio4_decode_caches_kernel",
+        update_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_emit_ratio4_mhc_rows_kernel",
+        emit_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_ratio4_selected_attention_kernel",
+        attention_kernel,
+    )
+
+    reason, num_decode = deepseek_v4_attention._deepseek_v4_triton_cached_attention_fallback_reason(
+        args[0],
+        args[1],
+        args[2],
+        args[3],
+        args[10],
+        args[11],
+        args[12],
+        args[13],
+        args[14],
+        args[15],
+        args[16],
+        args[21],
+        args[22],
+        out,
+        compressor_kv=args[4],
+        compressor_gate=args[5],
+        compressor_ape=args[6],
+        compressor_norm_weight=args[7],
+        freqs_cis_table=args[8],
+        mhc_cache=args[17],
+        compressor_kv_cache=args[18],
+        compressor_gate_cache=args[19],
+        max_compressed_len=args[23],
+        rope_dim=args[25],
+    )
+
+    assert reason is None
+    assert num_decode == 1
+    result = _triton_contract(*args, out=out)
+
+    assert result.numel() == 0
+    assert update_kernel.launches == 1
+    assert emit_kernel.launches == 1
+    assert attention_kernel.launches == 1
+    torch.testing.assert_close(out.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(args[16][0, 0, 7, 0], args[1][0, 0])
+    torch.testing.assert_close(args[18][0, 0, 7, 0].float(), args[4][0, 0].float())
+    torch.testing.assert_close(
+        args[17][0, 0, 1, 0].float(),
+        expected_args[17][0, 0, 1, 0].float(),
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio4_cuda_prefill_mixed_launches_device_path_without_torch_references(
+    monkeypatch,
+):
+    args = _cuda_ratio4_prefill_mixed_args()
+    expected = _expected_cuda_compressed_prefill_mixed(_clone_args(args))
+    metadata_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._build_prefill_mixed_token_metadata_kernel
+    )
+    update_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._update_ratio4_decode_caches_kernel
+    )
+    emit_kernel = _RecordingTritonKernel(deepseek_v4_attention._emit_ratio4_mhc_rows_kernel)
+    attention_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._ratio4_prefill_mixed_selected_attention_kernel
+    )
+
+    monkeypatch.delenv(deepseek_v4_attention._DSV4_FORCE_TORCH_REFERENCE_ENV, raising=False)
+    _install_unexpected_attention_reference_guards(
+        monkeypatch,
+        "ratio-4 supported prefill/mixed batch must not use Torch attention references",
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_build_prefill_mixed_token_metadata_kernel",
+        metadata_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_update_ratio4_decode_caches_kernel",
+        update_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_emit_ratio4_mhc_rows_kernel",
+        emit_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_ratio4_prefill_mixed_selected_attention_kernel",
+        attention_kernel,
+    )
+
+    reason, active_tokens = (
+        deepseek_v4_attention._deepseek_v4_triton_cached_attention_fallback_reason(
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            args[10],
+            args[11],
+            args[12],
+            args[13],
+            args[14],
+            args[15],
+            args[16],
+            args[21],
+            args[22],
+            None,
+            compressor_kv=args[4],
+            compressor_gate=args[5],
+            compressor_ape=args[6],
+            compressor_norm_weight=args[7],
+            freqs_cis_table=args[8],
+            mhc_cache=args[17],
+            compressor_kv_cache=args[18],
+            compressor_gate_cache=args[19],
+            max_compressed_len=args[23],
+            rope_dim=args[25],
+        )
+    )
+
+    assert reason is None
+    assert active_tokens == 6
+    actual = _triton_contract(*args)
+
+    assert metadata_kernel.launches == 1
+    assert update_kernel.launches == 1
+    assert emit_kernel.launches == 1
+    assert attention_kernel.launches == 1
+    torch.testing.assert_close(actual.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(args[16][0, 0, 4, 0], args[1][0, 4])
+    torch.testing.assert_close(args[16][1, 0, 7, 0], args[1][0, 5])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio4_cuda_prefill_mixed_accepts_cpu_metadata_without_torch_references(
+    monkeypatch,
+):
+    args = _cuda_ratio4_prefill_mixed_args()
+    expected = _expected_cuda_compressed_prefill_mixed(_clone_args(args))
+    for idx in (11, 12, 13, 14, 15):
+        args[idx] = args[idx].cpu()
+
+    monkeypatch.delenv(deepseek_v4_attention._DSV4_FORCE_TORCH_REFERENCE_ENV, raising=False)
+    _install_unexpected_attention_reference_guards(
+        monkeypatch,
+        "ratio-4 supported CPU-metadata prefill/mixed batch must not use Torch references",
+    )
+
+    actual = _triton_contract(*args)
+
+    torch.testing.assert_close(actual.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(args[16][0, 0, 4, 0], args[1][0, 4])
+    torch.testing.assert_close(args[16][1, 0, 7, 0], args[1][0, 5])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio128_cuda_decode_launches_kernels_without_torch_reference(monkeypatch):
+    args = _cuda_ratio128_decode_args()
+    expected_args = _clone_args(args)
+    expected = _torch_cached_reference(*expected_args)
+    out = torch.empty_like(args[0])
+    update_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._update_ratio128_decode_caches_kernel
+    )
+    emit_kernel = _RecordingTritonKernel(deepseek_v4_attention._emit_ratio128_mhc_rows_kernel)
+    attention_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._ratio128_compressed_attention_kernel
+    )
+
+    def _unexpected_cached_reference(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("ratio-128 supported decode must not use the Torch cached reference")
+
+    monkeypatch.delenv(deepseek_v4_attention._DSV4_FORCE_TORCH_REFERENCE_ENV, raising=False)
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "torch_deepseek_v4_sparse_attention_v2_with_cache",
+        _unexpected_cached_reference,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_update_ratio128_decode_caches_kernel",
+        update_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_emit_ratio128_mhc_rows_kernel",
+        emit_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_ratio128_compressed_attention_kernel",
+        attention_kernel,
+    )
+
+    reason, num_decode = deepseek_v4_attention._deepseek_v4_triton_cached_attention_fallback_reason(
+        args[0],
+        args[1],
+        args[2],
+        args[3],
+        args[10],
+        args[11],
+        args[12],
+        args[13],
+        args[14],
+        args[15],
+        args[16],
+        args[21],
+        args[22],
+        out,
+        compressor_kv=args[4],
+        compressor_gate=args[5],
+        compressor_ape=args[6],
+        compressor_norm_weight=args[7],
+        freqs_cis_table=args[8],
+        mhc_cache=args[17],
+        compressor_kv_cache=args[18],
+        compressor_gate_cache=args[19],
+        max_compressed_len=args[23],
+        rope_dim=args[25],
+    )
+
+    assert reason is None
+    assert num_decode == 1
+    result = _triton_contract(*args, out=out)
+
+    assert result.numel() == 0
+    assert update_kernel.launches == 1
+    assert emit_kernel.launches == 1
+    assert attention_kernel.launches == 1
+    torch.testing.assert_close(out.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(args[16][0, 0, 127, 0], args[1][0, 0])
+    torch.testing.assert_close(
+        args[17][0, 0, 0, 0].float(),
+        expected_args[17][0, 0, 0, 0].float(),
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio128_cuda_prefill_mixed_launches_device_path_without_torch_references(
+    monkeypatch,
+):
+    args = _cuda_ratio128_prefill_mixed_args()
+    expected = _expected_cuda_compressed_prefill_mixed(_clone_args(args))
+    metadata_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._build_prefill_mixed_token_metadata_kernel
+    )
+    update_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._update_ratio128_decode_caches_kernel
+    )
+    emit_kernel = _RecordingTritonKernel(deepseek_v4_attention._emit_ratio128_mhc_rows_kernel)
+    attention_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._ratio128_compressed_attention_kernel
+    )
+
+    monkeypatch.delenv(deepseek_v4_attention._DSV4_FORCE_TORCH_REFERENCE_ENV, raising=False)
+    _install_unexpected_attention_reference_guards(
+        monkeypatch,
+        "ratio-128 supported prefill/mixed batch must not use Torch attention references",
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_build_prefill_mixed_token_metadata_kernel",
+        metadata_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_update_ratio128_decode_caches_kernel",
+        update_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_emit_ratio128_mhc_rows_kernel",
+        emit_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_ratio128_compressed_attention_kernel",
+        attention_kernel,
+    )
+
+    actual = _triton_contract(*args)
+
+    assert metadata_kernel.launches == 1
+    assert update_kernel.launches == 1
+    assert emit_kernel.launches == 1
+    assert attention_kernel.launches == 1
+    torch.testing.assert_close(actual.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(args[16][1, 0, 127, 0], args[1][0, 3])
+
+
+def test_integrated_cached_decode_mix_does_not_call_full_source_attention(monkeypatch):
+    layer_specs = [
+        (0, 2),
+        (0, 5),
+        (4, 3),
+        (128, 127),
+        (4, 7),
+    ]
+    args_by_layer = [
+        _seed_cached_decode_resources(ratio, prefix_len, seed=3200 + layer_idx)
+        for layer_idx, (ratio, prefix_len) in enumerate(layer_specs)
+    ]
+
+    def _unexpected_full_source(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("cached decode must not call full-context DSV4 source attention")
+
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "torch_deepseek_v4_sparse_attention_v2",
+        _unexpected_full_source,
+    )
+
+    for layer_idx, args in enumerate(args_by_layer):
+        output = _triton_contract_with_fallback_warning(*args)
+
+        assert output.shape == (1, 1, LOCAL_HEADS, HEAD_DIM), f"layer {layer_idx}"
+        assert output.dtype == torch.bfloat16
+        assert torch.isfinite(output.float()).all()
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16, 32, 64])
+def test_triton_contract_ratio0_decode_batch_buckets_match_torch_reference(batch_size: int):
+    expected_args = _ratio0_decode_args(batch_size)
+    actual_args = _clone_args(expected_args)
+
+    expected = _torch_cached_reference(*expected_args)
+    actual = _triton_contract_with_fallback_warning(
+        *actual_args,
+        match="q must be a CUDA tensor for the Triton ratio-0 SWA path",
+    )
+
+    assert actual.shape == (batch_size, 1, LOCAL_HEADS, HEAD_DIM)
+    torch.testing.assert_close(actual.float(), expected.float(), rtol=0, atol=0)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio0_cuda_decode_uses_kernel_for_topk_semantics():
+    active_sequences = 1
+    args, prefix_kv, _ = _cuda_ratio0_decode_args(
+        batch_size=1,
+        active_sequences=active_sequences,
+        prefix_len=5,
+    )
+    expected = _expected_cuda_ratio0_decode(args, prefix_kv, active_sequences)
+
+    assert _ratio0_triton_skip_reason(args, active_sequences) is None
+    actual = _triton_contract(*args)
+
+    torch.testing.assert_close(actual.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(args[16][0, 0, 5, 0], args[1][0, 0])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_descriptor_ratio0_cuda_decode_launches_triton_kernels_without_torch_reference(
+    monkeypatch,
+):
+    active_sequences = 2
+    args, prefix_kv, _ = _cuda_ratio0_decode_args(
+        batch_size=2,
+        active_sequences=active_sequences,
+        prefix_len=4,
+    )
+    expected = _expected_cuda_ratio0_decode(args, prefix_kv, active_sequences)
+    update_kernel = _RecordingTritonKernel(dsv4_triton_attention._update_ratio0_swa_cache_kernel)
+    attention_kernel = _RecordingTritonKernel(dsv4_triton_attention._ratio0_swa_attention_kernel)
+
+    def _unexpected_cached_reference(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("ratio-0 supported decode must not use the Torch cached reference")
+
+    monkeypatch.delenv(deepseek_v4_attention._DSV4_FORCE_TORCH_REFERENCE_ENV, raising=False)
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "torch_deepseek_v4_sparse_attention_v2_with_cache",
+        _unexpected_cached_reference,
+    )
+    monkeypatch.setattr(
+        dsv4_triton_attention,
+        "_update_ratio0_swa_cache_kernel",
+        update_kernel,
+    )
+    monkeypatch.setattr(
+        dsv4_triton_attention,
+        "_ratio0_swa_attention_kernel",
+        attention_kernel,
+    )
+
+    cached_op = AttentionRegistry.get("deepseek_v4_sparse").get_cached_attention_op()
+
+    assert (
+        cached_op == torch.ops.auto_deploy.triton_deepseek_v4_sparse_attention_v2_with_cache.default
+    )
+    assert _ratio0_triton_skip_reason(args, active_sequences) is None
+    actual = cached_op(*args)
+
+    assert update_kernel.launches == 1
+    assert attention_kernel.launches == 1
+    torch.testing.assert_close(actual.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(args[16][0, 0, 4, 0], args[1][0, 0])
+    torch.testing.assert_close(args[16][1, 0, 4, 0], args[1][1, 0])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio0_cuda_prefill_launches_device_path_without_torch_references(
+    monkeypatch,
+):
+    args, prefix_rows = _cuda_ratio0_prefill_args(seq_len=3)
+    expected = _expected_cuda_ratio0_prefill_mixed(args, prefix_rows)
+    update_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._update_ratio0_prefill_mixed_swa_cache_kernel
+    )
+    attention_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._ratio0_prefill_mixed_swa_attention_kernel
+    )
+
+    monkeypatch.delenv(deepseek_v4_attention._DSV4_FORCE_TORCH_REFERENCE_ENV, raising=False)
+    _install_unexpected_attention_reference_guards(
+        monkeypatch,
+        "ratio-0 supported prefill must not use Torch attention references",
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_update_ratio0_prefill_mixed_swa_cache_kernel",
+        update_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_ratio0_prefill_mixed_swa_attention_kernel",
+        attention_kernel,
+    )
+
+    result = _triton_contract(*args)
+
+    assert update_kernel.launches == 1
+    assert attention_kernel.launches == 1
+    torch.testing.assert_close(result.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(args[16][0, 0, 2, 0], args[1][0, 2])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio0_cuda_mixed_batch_launches_device_path_without_torch_references(
+    monkeypatch,
+):
+    args, prefix_rows = _cuda_ratio0_mixed_args()
+    expected = _expected_cuda_ratio0_prefill_mixed(args, prefix_rows)
+    out = torch.empty_like(args[0])
+    update_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._update_ratio0_prefill_mixed_swa_cache_kernel
+    )
+    attention_kernel = _RecordingTritonKernel(
+        deepseek_v4_attention._ratio0_prefill_mixed_swa_attention_kernel
+    )
+
+    monkeypatch.delenv(deepseek_v4_attention._DSV4_FORCE_TORCH_REFERENCE_ENV, raising=False)
+    _install_unexpected_attention_reference_guards(
+        monkeypatch,
+        "ratio-0 supported mixed batch must not use Torch attention references",
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_update_ratio0_prefill_mixed_swa_cache_kernel",
+        update_kernel,
+    )
+    monkeypatch.setattr(
+        deepseek_v4_attention,
+        "_ratio0_prefill_mixed_swa_attention_kernel",
+        attention_kernel,
+    )
+
+    result = _triton_contract(*args, out=out)
+
+    assert result.numel() == 0
+    assert update_kernel.launches == 1
+    assert attention_kernel.launches == 1
+    torch.testing.assert_close(out.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(args[16][0, 0, 2, 0], args[1][0, 2])
+    torch.testing.assert_close(args[16][1, 0, 4, 0], args[1][0, 3])
+    torch.testing.assert_close(args[16][2, 0, 6, 0], args[1][0, 4])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio0_cuda_mixed_batch_accepts_cpu_metadata_without_torch_references(
+    monkeypatch,
+):
+    args, prefix_rows = _cuda_ratio0_mixed_args()
+    expected = _expected_cuda_ratio0_prefill_mixed(args, prefix_rows)
+    for idx in (11, 12, 13, 14, 15):
+        args[idx] = args[idx].cpu()
+
+    monkeypatch.delenv(deepseek_v4_attention._DSV4_FORCE_TORCH_REFERENCE_ENV, raising=False)
+    _install_unexpected_attention_reference_guards(
+        monkeypatch,
+        "ratio-0 supported CPU-metadata mixed batch must not use Torch attention references",
+    )
+
+    actual = _triton_contract(*args)
+
+    torch.testing.assert_close(actual.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(args[16][0, 0, 2, 0], args[1][0, 2])
+    torch.testing.assert_close(args[16][1, 0, 4, 0], args[1][0, 3])
+    torch.testing.assert_close(args[16][2, 0, 6, 0], args[1][0, 4])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio0_cuda_out_buffer_zeroes_padded_decode_slots():
+    active_sequences = 2
+    args, prefix_kv, _ = _cuda_ratio0_decode_args(
+        batch_size=4,
+        active_sequences=active_sequences,
+        prefix_len=3,
+    )
+    expected = _expected_cuda_ratio0_decode(args, prefix_kv, active_sequences)
+    out = torch.empty_like(args[0])
+
+    assert _ratio0_triton_skip_reason(args, active_sequences) is None
+    result = _triton_contract(*args, out=out)
+
+    assert result.numel() == 0
+    torch.testing.assert_close(out.float(), expected.float(), rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(
+        out[active_sequences:].float(),
+        torch.zeros_like(out[active_sequences:].float()),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_triton_ratio0_skip_reason_explains_unsupported_metadata_location():
+    args, _, _ = _cuda_ratio0_decode_args(batch_size=1, active_sequences=1, prefix_len=1)
+    args[12] = args[12].cpu()
+
+    assert _ratio0_triton_skip_reason(args, active_tokens=1) == (
+        "input_pos_host must be a CUDA tensor for the Triton ratio-0 SWA path"
+    )
+
+
+def test_triton_contract_out_buffer_and_padded_slots_match_torch_reference():
+    graph_batch_size = 4
+    active_sequences = 2
+    expected_args = _ratio0_decode_args(graph_batch_size, active_sequences)
+    actual_args = _clone_args(expected_args)
+    out = torch.empty_like(actual_args[0])
+
+    expected = _torch_cached_reference(*expected_args)
+    result = _triton_contract_with_fallback_warning(
+        *actual_args,
+        match="q must be a CUDA tensor for the Triton ratio-0 SWA path",
+        out=out,
+    )
+
+    assert result.numel() == 0
+    torch.testing.assert_close(out.float(), expected.float(), rtol=0, atol=0)
+    torch.testing.assert_close(
+        out[active_sequences:].float(),
+        torch.zeros_like(out[active_sequences:].float()),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_triton_contract_fake_accepts_fp8_compressor_resource_placeholders():
+    with FakeTensorMode():
+        batch_size, seq_len, block_size = 1, 1, WINDOW_SIZE
+        q = torch.empty(batch_size, seq_len, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16)
+        kv = torch.empty(batch_size, seq_len, HEAD_DIM, dtype=torch.bfloat16)
+        attn_sink = torch.empty(LOCAL_HEADS, dtype=torch.float32)
+        topk_idxs = torch.empty(batch_size, seq_len, WINDOW_SIZE, dtype=torch.int32)
+        fp8_cache = torch.empty(
+            batch_size,
+            1,
+            block_size,
+            1,
+            HEAD_DIM,
+            dtype=torch.float8_e4m3fn,
+        )
+
+        output = _triton_contract(
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            torch.empty(batch_size, seq_len, 0, dtype=torch.bfloat16),
+            torch.empty(batch_size, seq_len, 0, dtype=torch.bfloat16),
+            torch.empty(0, 0, dtype=torch.bfloat16),
+            torch.empty(0, dtype=torch.float32),
+            torch.empty(16, ROPE_DIM // 2, dtype=torch.complex64),
+            torch.empty(batch_size, seq_len, dtype=torch.int32),
+            torch.empty(12, dtype=torch.int32),
+            torch.empty(batch_size, dtype=torch.int32),
+            torch.empty(batch_size, dtype=torch.int32),
+            torch.empty(batch_size + 1, dtype=torch.int32),
+            torch.empty(batch_size, dtype=torch.int32),
+            torch.empty(batch_size + 1, dtype=torch.int32),
+            torch.empty(batch_size, 1, block_size, 1, HEAD_DIM, dtype=torch.bfloat16),
+            torch.empty(batch_size, 1, block_size, 1, HEAD_DIM, dtype=torch.bfloat16),
+            fp8_cache,
+            fp8_cache,
+            SOFTMAX_SCALE,
+            WINDOW_SIZE,
+            0,
+            None,
+            RMS_NORM_EPS,
+            ROPE_DIM,
+        )
+
+    assert output.shape == (batch_size, seq_len, LOCAL_HEADS, HEAD_DIM)
+
+
+def test_triton_contract_rejects_fp8_swa_cache_as_unconsumed_nope_cache():
+    with FakeTensorMode():
+        batch_size, seq_len, block_size = 1, 1, WINDOW_SIZE
+        q = torch.empty(batch_size, seq_len, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16)
+        kv = torch.empty(batch_size, seq_len, HEAD_DIM, dtype=torch.bfloat16)
+        attn_sink = torch.empty(LOCAL_HEADS, dtype=torch.float32)
+        topk_idxs = torch.empty(batch_size, seq_len, WINDOW_SIZE, dtype=torch.int32)
+        fp8_swa_cache = torch.empty(
+            batch_size,
+            1,
+            block_size,
+            1,
+            HEAD_DIM,
+            dtype=torch.float8_e4m3fn,
+        )
+
+        with pytest.raises(
+            TypeError,
+            match="FP8 NoPE split cache writes are not consumed",
+        ):
+            _triton_contract(
+                q,
+                kv,
+                attn_sink,
+                topk_idxs,
+                torch.empty(batch_size, seq_len, 0, dtype=torch.bfloat16),
+                torch.empty(batch_size, seq_len, 0, dtype=torch.bfloat16),
+                torch.empty(0, 0, dtype=torch.bfloat16),
+                torch.empty(0, dtype=torch.float32),
+                torch.empty(16, ROPE_DIM // 2, dtype=torch.complex64),
+                torch.empty(batch_size, seq_len, dtype=torch.int32),
+                torch.empty(12, dtype=torch.int32),
+                torch.empty(batch_size, dtype=torch.int32),
+                torch.empty(batch_size, dtype=torch.int32),
+                torch.empty(batch_size + 1, dtype=torch.int32),
+                torch.empty(batch_size, dtype=torch.int32),
+                torch.empty(batch_size + 1, dtype=torch.int32),
+                fp8_swa_cache,
+                torch.empty(batch_size, 1, block_size, 1, HEAD_DIM, dtype=torch.bfloat16),
+                torch.empty(batch_size, 1, block_size, 1, HEAD_DIM, dtype=torch.bfloat16),
+                torch.empty(batch_size, 1, block_size, 1, HEAD_DIM, dtype=torch.bfloat16),
+                SOFTMAX_SCALE,
+                WINDOW_SIZE,
+                0,
+                None,
+                RMS_NORM_EPS,
+                ROPE_DIM,
+            )
+
+    assert "E8M0 scale cache resources" in DSV4_FP8_NOPE_ATTENTION_UNSUPPORTED_REASON
+
+
+def test_triton_contract_compressed_row_topk_matches_torch_reference():
+    batch_size, seq_len, block_size = 1, 1, WINDOW_SIZE
+    torch.manual_seed(2048)
+    q = torch.randn(batch_size, seq_len, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16)
+    kv = torch.randn(batch_size, seq_len, HEAD_DIM, dtype=torch.bfloat16)
+    attn_sink = torch.linspace(-0.25, 0.25, LOCAL_HEADS, dtype=torch.float32)
+    topk_idxs = torch.full((batch_size, seq_len, 640), -1, dtype=torch.int32)
+    topk_idxs[0, 0, 0] = 1
+    compressor_kv = torch.zeros(batch_size, seq_len, 1024, dtype=torch.bfloat16)
+    compressor_kv[0, 0, 512] = 8.0
+    compressor_gate = torch.zeros(batch_size, seq_len, 1024, dtype=torch.bfloat16)
+    compressor_ape = torch.zeros(4, 1024, dtype=torch.bfloat16)
+    compressor_norm_weight = torch.ones(HEAD_DIM, dtype=torch.float32)
+    cache_loc, cu_num_pages = _paged_cache_metadata([1], block_size)
+    args = [
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        _freqs_cis_table(),
+        torch.zeros(batch_size, seq_len, dtype=torch.int32),
+        _batch_info(num_prefill=1, num_prefill_tokens=1, num_decode=0),
+        torch.ones(1, dtype=torch.int32),
+        torch.zeros(1, dtype=torch.int32),
+        torch.tensor([0, 1], dtype=torch.int32),
+        cache_loc,
+        cu_num_pages,
+        *_cache_tuple(len(cache_loc), block_size),
+        SOFTMAX_SCALE,
+        WINDOW_SIZE,
+        4,
+        1,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    ]
+
+    expected = _torch_cached_reference(*_clone_args(args))
+    actual = _triton_contract_with_fallback_warning(
+        *_clone_args(args),
+        match="max_compressed_len must be 2048",
+    )
+
+    torch.testing.assert_close(actual.float(), expected.float(), rtol=0, atol=0)
+    assert actual.float().abs().sum() > 0
+
+
+def test_triton_contract_preserves_debug_topk_sink_mask_and_duplicate_semantics():
+    batch_size, seq_len, block_size = 1, 1, WINDOW_SIZE
+    q = torch.zeros(batch_size, seq_len, LOCAL_HEADS, HEAD_DIM, dtype=torch.bfloat16)
+    q[0, 0, 0, 0] = 1.0
+    kv = torch.zeros(batch_size, seq_len, HEAD_DIM, dtype=torch.bfloat16)
+    kv[0, 0, 0] = 2.0
+    attn_sink = torch.zeros(LOCAL_HEADS, dtype=torch.float32)
+    topk_idxs = torch.full((batch_size, seq_len, 640), -1, dtype=torch.int32)
+    topk_idxs[0, 0, :3] = torch.tensor([0, 0, -1], dtype=torch.int32)
+    compressor_kv = torch.zeros(batch_size, seq_len, 1024, dtype=torch.bfloat16)
+    compressor_gate = torch.zeros(batch_size, seq_len, 1024, dtype=torch.bfloat16)
+    compressor_ape = torch.zeros(4, 1024, dtype=torch.bfloat16)
+    compressor_norm_weight = torch.zeros(HEAD_DIM, dtype=torch.float32)
+    cache_loc, cu_num_pages = _paged_cache_metadata([1], block_size)
+    caches = _cache_tuple(len(cache_loc), block_size)
+
+    output = _triton_contract_with_fallback_warning(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        _freqs_cis_table(),
+        torch.zeros(batch_size, seq_len, dtype=torch.int32),
+        _batch_info(num_prefill=1, num_prefill_tokens=1, num_decode=0),
+        torch.ones(1, dtype=torch.int32),
+        torch.zeros(1, dtype=torch.int32),
+        torch.tensor([0, 1], dtype=torch.int32),
+        cache_loc,
+        cu_num_pages,
+        *caches,
+        1.0,
+        WINDOW_SIZE,
+        4,
+        1,
+        RMS_NORM_EPS,
+        ROPE_DIM,
+    )
+
+    weights = torch.softmax(torch.tensor([2.0, 2.0, 0.0]), dim=0)
+    expected_head0_dim0 = (weights[0] + weights[1]) * kv[0, 0, 0].float()
+    torch.testing.assert_close(
+        output[0, 0, 0, 0].float(),
+        expected_head0_dim0,
+        rtol=1e-2,
+        atol=1e-2,
+    )
+
+    high_sink_args = _ratio0_decode_args(1)
+    high_sink_args[0].zero_()
+    high_sink_args[0][0, 0, 0, 0] = 1.0
+    high_sink_args[1].zero_()
+    high_sink_args[1][0, 0, 0] = 2.0
+    high_sink_args[2] = torch.full((LOCAL_HEADS,), 10.0, dtype=torch.float32)
+    high_sink_output = _triton_contract_with_fallback_warning(
+        *high_sink_args,
+        match="q must be a CUDA tensor for the Triton ratio-0 SWA path",
+    )
+    assert high_sink_output[0, 0, 0].float().norm() < output[0, 0, 0].float().norm()
+
+
+def test_triton_contract_rejects_short_page_metadata():
+    args = _ratio0_decode_args(graph_batch_size=2)
+    args[15] = torch.tensor([0], dtype=torch.int32)
+
+    with pytest.raises(ValueError, match="cu_num_pages_host needs at least"):
+        _triton_contract(*args)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_fp8_cache.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_fp8_cache.py
@@ -1,0 +1,830 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for DeepSeek V4 FP8 NoPE cache helpers."""
+
+import inspect
+
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention import deepseek_v4_fp8_cache
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention import (
+    triton_deepseek_v4_sparse_attention as dsv4_triton_attention,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_fp8_cache import (
+    DSV4_BF16_ROPE_CACHE_ARG,
+    DSV4_BF16_ROPE_CACHE_SUFFIX,
+    DSV4_BF16_SWA_CACHE_ARG,
+    DSV4_E8M0_SCALE_CACHE_ARG,
+    DSV4_E8M0_SCALE_CACHE_SUFFIX,
+    DSV4_FP8_BLOCK_SIZE,
+    DSV4_FP8_NOPE_ATTENTION_UNSUPPORTED_REASON,
+    DSV4_FP8_NOPE_CACHE_ARG,
+    DSV4_FP8_NOPE_CACHE_MUTATED_ARGS,
+    DSV4_FP8_NOPE_CACHE_SUFFIX,
+    DSV4_FP8_NOPE_PAGED_GATHER_OP_NAME,
+    DSV4_FP8_NOPE_PAGED_WRITE_OP_NAME,
+    DSV4_HEAD_DIM,
+    DSV4_NOPE_DIM,
+    DSV4_NOPE_SCALE_BLOCKS,
+    DSV4_ROPE_DIM,
+    DSV4_SWA_PAGED_RESOURCE_NAME,
+    FP8_E4M3_DTYPE,
+    deepseek_v4_fp8_nope_cache_resource_handlers,
+    deepseek_v4_fp8_nope_cache_resource_specs,
+    gather_deepseek_v4_fp8_nope_paged_cache_rows,
+    quantize_deepseek_v4_fp8_nope_cache_rows,
+    reconstruct_deepseek_v4_fp8_nope_cache_rows,
+    validate_deepseek_v4_fp8_nope_paged_cache_resources,
+    write_deepseek_v4_attention_cache_rows,
+    write_deepseek_v4_fp8_nope_flat_cache_rows,
+    write_deepseek_v4_fp8_nope_paged_cache_rows,
+)
+from tensorrt_llm._torch.auto_deploy.utils.e8m0 import e8m0_to_uint8, maybe_e8m0_to_fp32
+
+_HAS_CUDA = torch.cuda.is_available()
+_HAS_E8M0 = hasattr(torch, "float8_e8m0fnu")
+_requires_cuda_e8m0 = pytest.mark.skipif(
+    not (_HAS_CUDA and _HAS_E8M0),
+    reason="CUDA or torch.float8_e8m0fnu is not available",
+)
+
+
+def _scale_dtype() -> torch.dtype:
+    return getattr(torch, "float8_e8m0fnu", torch.float32)
+
+
+def _kv_rows(shape: tuple[int, ...]) -> torch.Tensor:
+    torch.manual_seed(300 + len(shape))
+    return torch.randn(*shape, DSV4_HEAD_DIM, dtype=torch.float32) * 0.25
+
+
+def _paged_cache_metadata(
+    seq_lens_with_cache: list[int], block_size: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cache_loc = []
+    cu_num_pages = [0]
+    next_page = 0
+    for seq_len in seq_lens_with_cache:
+        num_pages = (seq_len + block_size - 1) // block_size
+        cache_loc.extend(range(next_page, next_page + num_pages))
+        next_page += num_pages
+        cu_num_pages.append(len(cache_loc))
+    return (
+        torch.tensor(cache_loc, dtype=torch.int32, device=device),
+        torch.tensor(cu_num_pages, dtype=torch.int32, device=device),
+    )
+
+
+def _assert_scale_equal(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    e8m0_dtype = getattr(torch, "float8_e8m0fnu", None)
+    if actual.dtype == torch.uint8:
+        actual = actual.contiguous()
+    elif actual.dtype == e8m0_dtype:
+        actual = e8m0_to_uint8(actual)
+
+    if expected.dtype == torch.uint8:
+        expected = expected.contiguous()
+    elif expected.dtype == e8m0_dtype:
+        expected = e8m0_to_uint8(expected)
+
+    if actual.dtype == torch.uint8 or expected.dtype == torch.uint8:
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    else:
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_resource_specs_name_split_swa_cache_tensors() -> None:
+    specs = deepseek_v4_fp8_nope_cache_resource_specs()
+
+    assert [spec.schema_arg for spec in specs] == [
+        DSV4_FP8_NOPE_CACHE_ARG,
+        DSV4_BF16_ROPE_CACHE_ARG,
+        DSV4_E8M0_SCALE_CACHE_ARG,
+    ]
+    assert [spec.cache_suffix for spec in specs] == [
+        DSV4_FP8_NOPE_CACHE_SUFFIX,
+        DSV4_BF16_ROPE_CACHE_SUFFIX,
+        DSV4_E8M0_SCALE_CACHE_SUFFIX,
+    ]
+    assert all(spec.resource_name == DSV4_SWA_PAGED_RESOURCE_NAME for spec in specs)
+    assert [spec.token_shape for spec in specs] == [
+        (1, 1, DSV4_NOPE_DIM),
+        (1, 1, DSV4_ROPE_DIM),
+        (1, 1, DSV4_NOPE_SCALE_BLOCKS),
+    ]
+    assert [spec.dtype for spec in specs] == [
+        FP8_E4M3_DTYPE,
+        torch.bfloat16,
+        _scale_dtype(),
+    ]
+
+    handlers = deepseek_v4_fp8_nope_cache_resource_handlers(tokens_per_block=8)
+
+    assert list(handlers) == [
+        DSV4_FP8_NOPE_CACHE_SUFFIX,
+        DSV4_BF16_ROPE_CACHE_SUFFIX,
+        DSV4_E8M0_SCALE_CACHE_SUFFIX,
+    ]
+    assert {handler.resource_name for handler in handlers.values()} == {
+        DSV4_SWA_PAGED_RESOURCE_NAME
+    }
+    assert all(handler.tokens_per_block == 8 for handler in handlers.values())
+
+
+def test_graph_visible_split_cache_op_schemas_are_distinct_from_bf16_swa_cache() -> None:
+    write_schema = (
+        torch.ops.auto_deploy.torch_deepseek_v4_fp8_nope_paged_cache_write.default._schema
+    )
+    gather_schema = (
+        torch.ops.auto_deploy.torch_deepseek_v4_fp8_nope_paged_cache_gather.default._schema
+    )
+
+    assert DSV4_FP8_NOPE_PAGED_WRITE_OP_NAME in str(write_schema)
+    assert DSV4_FP8_NOPE_PAGED_GATHER_OP_NAME in str(gather_schema)
+    assert [arg.name for arg in write_schema.arguments] == [
+        "kv_rows",
+        "cache_loc_host",
+        "cu_num_pages_host",
+        "seq_idx",
+        "input_pos",
+        DSV4_FP8_NOPE_CACHE_ARG,
+        DSV4_BF16_ROPE_CACHE_ARG,
+        DSV4_E8M0_SCALE_CACHE_ARG,
+        "block_size",
+    ]
+    assert [arg.name for arg in gather_schema.arguments] == [
+        "cache_loc_host",
+        "cu_num_pages_host",
+        "seq_idx",
+        "start_pos",
+        "end_pos",
+        DSV4_FP8_NOPE_CACHE_ARG,
+        DSV4_BF16_ROPE_CACHE_ARG,
+        DSV4_E8M0_SCALE_CACHE_ARG,
+        "block_size",
+    ]
+    assert DSV4_BF16_SWA_CACHE_ARG not in [arg.name for arg in write_schema.arguments]
+    for cache_arg in DSV4_FP8_NOPE_CACHE_MUTATED_ARGS:
+        assert f"{cache_arg}" in str(write_schema)
+    assert "!" in str(write_schema)
+
+
+def test_split_paged_resource_validation_rejects_full_width_bf16_swa_cache() -> None:
+    tokens_per_block = 2
+    full_width_bf16_swa_cache = torch.empty(
+        1, 1, tokens_per_block, 1, DSV4_HEAD_DIM, dtype=torch.bfloat16
+    )
+    nope_cache = torch.empty(1, 1, tokens_per_block, 1, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE)
+    rope_cache = torch.empty(1, 1, tokens_per_block, 1, DSV4_ROPE_DIM, dtype=torch.bfloat16)
+    scale_cache = torch.empty(
+        1, 1, tokens_per_block, 1, DSV4_NOPE_SCALE_BLOCKS, dtype=_scale_dtype()
+    )
+
+    with pytest.raises(ValueError, match=f"nope_cache last dimension must be {DSV4_NOPE_DIM}"):
+        validate_deepseek_v4_fp8_nope_paged_cache_resources(
+            full_width_bf16_swa_cache,
+            rope_cache,
+            scale_cache,
+        )
+
+    with pytest.raises(TypeError, match="rope_cache must have dtype torch.bfloat16"):
+        validate_deepseek_v4_fp8_nope_paged_cache_resources(
+            nope_cache,
+            torch.empty(
+                1,
+                1,
+                tokens_per_block,
+                1,
+                DSV4_ROPE_DIM,
+                dtype=FP8_E4M3_DTYPE,
+            ),
+            scale_cache,
+        )
+
+    with pytest.raises(ValueError, match="identical page geometry"):
+        validate_deepseek_v4_fp8_nope_paged_cache_resources(
+            nope_cache,
+            torch.empty(1, 1, tokens_per_block + 1, 1, DSV4_ROPE_DIM, dtype=torch.bfloat16),
+            scale_cache,
+        )
+
+
+def test_split_cache_custom_ops_fake_meta_contract() -> None:
+    with FakeTensorMode():
+        tokens_per_block = 2
+        kv = torch.empty(3, DSV4_HEAD_DIM, dtype=torch.bfloat16)
+        cache_loc = torch.empty(2, dtype=torch.int32)
+        cu_num_pages = torch.empty(2, dtype=torch.int32)
+        input_pos = torch.empty((), dtype=torch.int64)
+        nope_cache = torch.empty(2, 1, tokens_per_block, 1, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE)
+        rope_cache = torch.empty(2, 1, tokens_per_block, 1, DSV4_ROPE_DIM, dtype=torch.bfloat16)
+        scale_cache = torch.empty(
+            2, 1, tokens_per_block, 1, DSV4_NOPE_SCALE_BLOCKS, dtype=_scale_dtype()
+        )
+
+        write_result = torch.ops.auto_deploy.torch_deepseek_v4_fp8_nope_paged_cache_write(
+            kv,
+            cache_loc,
+            cu_num_pages,
+            0,
+            input_pos,
+            nope_cache,
+            rope_cache,
+            scale_cache,
+        )
+        gathered = torch.ops.auto_deploy.torch_deepseek_v4_fp8_nope_paged_cache_gather(
+            cache_loc,
+            cu_num_pages,
+            0,
+            1,
+            4,
+            nope_cache,
+            rope_cache,
+            scale_cache,
+        )
+
+    assert write_result.shape == (0,)
+    assert gathered.shape == (3, DSV4_HEAD_DIM)
+    assert gathered.dtype == torch.bfloat16
+
+
+def test_quantize_reconstruct_splits_nope_fp8_and_rope_bf16() -> None:
+    kv = _kv_rows((2, 3))
+
+    rows = quantize_deepseek_v4_fp8_nope_cache_rows(kv)
+
+    assert rows.nope.shape == (2, 3, DSV4_NOPE_DIM)
+    assert rows.nope.dtype == FP8_E4M3_DTYPE
+    assert rows.rope.shape == (2, 3, DSV4_ROPE_DIM)
+    assert rows.rope.dtype == torch.bfloat16
+    assert rows.scale.shape == (2, 3, DSV4_NOPE_SCALE_BLOCKS)
+    assert rows.scale.dtype == _scale_dtype()
+
+    reconstructed = reconstruct_deepseek_v4_fp8_nope_cache_rows(
+        rows.nope, rows.rope, rows.scale, dtype=torch.float32
+    )
+    scale_bound = maybe_e8m0_to_fp32(rows.scale).max().item()
+    torch.testing.assert_close(
+        reconstructed[..., :DSV4_NOPE_DIM],
+        kv[..., :DSV4_NOPE_DIM],
+        rtol=0.25,
+        atol=scale_bound,
+    )
+    torch.testing.assert_close(
+        reconstructed[..., DSV4_NOPE_DIM:],
+        kv[..., DSV4_NOPE_DIM:].to(torch.bfloat16).to(torch.float32),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_flat_cache_writes_preserve_fp8_and_raw_e8m0_scale_bytes() -> None:
+    kv = _kv_rows((2, 2))
+    cache_indices = torch.tensor([3, 0, 2, 1], dtype=torch.int64)
+    nope_cache = torch.empty(4, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE)
+    rope_cache = torch.empty(4, DSV4_ROPE_DIM, dtype=torch.bfloat16)
+    scale_cache = torch.empty(4, DSV4_NOPE_SCALE_BLOCKS, dtype=_scale_dtype())
+
+    rows = write_deepseek_v4_fp8_nope_flat_cache_rows(
+        kv, cache_indices, nope_cache, rope_cache, scale_cache
+    )
+
+    flat_indices = cache_indices.reshape(-1)
+    torch.testing.assert_close(
+        nope_cache[flat_indices].view(torch.uint8),
+        rows.nope.reshape(-1, DSV4_NOPE_DIM).view(torch.uint8),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        rope_cache[flat_indices].float(),
+        rows.rope.reshape(-1, DSV4_ROPE_DIM).float(),
+        rtol=0,
+        atol=0,
+    )
+    _assert_scale_equal(
+        scale_cache[flat_indices],
+        rows.scale.reshape(-1, DSV4_NOPE_SCALE_BLOCKS),
+    )
+
+    copy_source = inspect.getsource(deepseek_v4_fp8_cache._copy_raw_or_numeric)
+    row_copy_source = inspect.getsource(deepseek_v4_fp8_cache._index_copy_rows)
+    assert ".to(torch.uint8)" not in copy_source
+    assert ".to(torch.uint8)" not in row_copy_source
+
+
+@pytest.mark.skipif(not _HAS_E8M0, reason="torch.float8_e8m0fnu is not available")
+def test_flat_cache_can_write_raw_uint8_scale_cache_bytes() -> None:
+    kv = _kv_rows((2, 2))
+    cache_indices = torch.tensor([3, 0, 2, 1], dtype=torch.int64)
+    nope_cache = torch.empty(4, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE)
+    rope_cache = torch.empty(4, DSV4_ROPE_DIM, dtype=torch.bfloat16)
+    scale_cache = torch.empty(4, DSV4_NOPE_SCALE_BLOCKS, dtype=torch.uint8)
+
+    rows = write_deepseek_v4_fp8_nope_flat_cache_rows(
+        kv, cache_indices, nope_cache, rope_cache, scale_cache
+    )
+
+    _assert_scale_equal(
+        scale_cache[cache_indices],
+        rows.scale.reshape(-1, DSV4_NOPE_SCALE_BLOCKS),
+    )
+
+
+def test_attention_cache_writer_keeps_bf16_cache_as_default_fallback() -> None:
+    kv = _kv_rows((1, 3))
+    cache_indices = torch.tensor([2, 0, 1], dtype=torch.int64)
+    bf16_cache = torch.full((3, DSV4_HEAD_DIM), -11.0, dtype=torch.bfloat16)
+
+    returned = write_deepseek_v4_attention_cache_rows(
+        kv,
+        cache_indices,
+        bf16_cache=bf16_cache,
+    )
+
+    assert isinstance(returned, torch.Tensor)
+    assert returned.dtype == torch.bfloat16
+    torch.testing.assert_close(
+        bf16_cache[cache_indices].float(),
+        kv.reshape(-1, DSV4_HEAD_DIM).to(torch.bfloat16).float(),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_attention_cache_writer_can_opt_into_fp8_nope_cache() -> None:
+    kv = _kv_rows((1, 2))
+    cache_indices = torch.tensor([1, 0], dtype=torch.int64)
+    nope_cache = torch.empty(2, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE)
+    rope_cache = torch.empty(2, DSV4_ROPE_DIM, dtype=torch.bfloat16)
+    scale_cache = torch.empty(2, DSV4_NOPE_SCALE_BLOCKS, dtype=_scale_dtype())
+
+    rows = write_deepseek_v4_attention_cache_rows(
+        kv,
+        cache_indices,
+        nope_cache=nope_cache,
+        rope_cache=rope_cache,
+        scale_cache=scale_cache,
+        use_fp8_nope_cache=True,
+    )
+
+    assert not isinstance(rows, torch.Tensor)
+    reconstructed = reconstruct_deepseek_v4_fp8_nope_cache_rows(
+        nope_cache[cache_indices],
+        rope_cache[cache_indices],
+        scale_cache[cache_indices],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(
+        reconstructed[..., DSV4_NOPE_DIM:],
+        kv.reshape(-1, DSV4_HEAD_DIM)[..., DSV4_NOPE_DIM:].to(torch.bfloat16).float(),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_paged_cache_write_crosses_page_boundary_and_preserves_scale_bytes() -> None:
+    kv = _kv_rows((3,))
+    tokens_per_block = 2
+    cache_loc = torch.tensor([1, 0], dtype=torch.int32)
+    cu_num_pages = torch.tensor([0, 2], dtype=torch.int32)
+    nope_cache = torch.empty(2, 1, tokens_per_block, 1, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE)
+    rope_cache = torch.full(
+        (2, 1, tokens_per_block, 1, DSV4_ROPE_DIM),
+        -3.0,
+        dtype=torch.bfloat16,
+    )
+    scale_cache = torch.empty(
+        2, 1, tokens_per_block, 1, DSV4_NOPE_SCALE_BLOCKS, dtype=_scale_dtype()
+    )
+
+    rows = write_deepseek_v4_fp8_nope_paged_cache_rows(
+        kv,
+        cache_loc,
+        cu_num_pages,
+        seq_idx=0,
+        input_pos=1,
+        nope_cache=nope_cache,
+        rope_cache=rope_cache,
+        scale_cache=scale_cache,
+    )
+
+    flat_nope = rows.nope.reshape(-1, DSV4_NOPE_DIM)
+    flat_rope = rows.rope.reshape(-1, DSV4_ROPE_DIM)
+    flat_scale = rows.scale.reshape(-1, DSV4_NOPE_SCALE_BLOCKS)
+    target_slots = [(1, 1), (0, 0), (0, 1)]
+    for token_idx, (page_idx, token_offset) in enumerate(target_slots):
+        torch.testing.assert_close(
+            nope_cache[page_idx, 0, token_offset, 0].view(torch.uint8),
+            flat_nope[token_idx].view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            rope_cache[page_idx, 0, token_offset, 0].float(),
+            flat_rope[token_idx].float(),
+            rtol=0,
+            atol=0,
+        )
+        _assert_scale_equal(scale_cache[page_idx, 0, token_offset, 0], flat_scale[token_idx])
+
+    torch.testing.assert_close(
+        rope_cache[1, 0, 0, 0].float(),
+        torch.full((DSV4_ROPE_DIM,), -3.0, dtype=torch.float32),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_paged_cache_gather_dequantizes_written_fp8_nope_rows() -> None:
+    kv = _kv_rows((3,))
+    tokens_per_block = 2
+    cache_loc = torch.tensor([1, 0], dtype=torch.int32)
+    cu_num_pages = torch.tensor([0, 2], dtype=torch.int32)
+    nope_cache = torch.empty(2, 1, tokens_per_block, 1, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE)
+    rope_cache = torch.empty(2, 1, tokens_per_block, 1, DSV4_ROPE_DIM, dtype=torch.bfloat16)
+    scale_cache = torch.empty(
+        2, 1, tokens_per_block, 1, DSV4_NOPE_SCALE_BLOCKS, dtype=_scale_dtype()
+    )
+
+    rows = write_deepseek_v4_fp8_nope_paged_cache_rows(
+        kv,
+        cache_loc,
+        cu_num_pages,
+        seq_idx=0,
+        input_pos=1,
+        nope_cache=nope_cache,
+        rope_cache=rope_cache,
+        scale_cache=scale_cache,
+    )
+    gathered = gather_deepseek_v4_fp8_nope_paged_cache_rows(
+        cache_loc,
+        cu_num_pages,
+        seq_idx=0,
+        start_pos=1,
+        end_pos=4,
+        nope_cache=nope_cache,
+        rope_cache=rope_cache,
+        scale_cache=scale_cache,
+        dtype=torch.float32,
+    )
+    expected = reconstruct_deepseek_v4_fp8_nope_cache_rows(
+        rows.nope,
+        rows.rope,
+        rows.scale,
+        dtype=torch.float32,
+    ).reshape(3, DSV4_HEAD_DIM)
+
+    torch.testing.assert_close(gathered, expected, rtol=0, atol=0)
+    torch.testing.assert_close(
+        gathered[:, DSV4_NOPE_DIM:],
+        kv[:, DSV4_NOPE_DIM:].to(torch.bfloat16).float(),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_graph_visible_paged_write_and_gather_roundtrip() -> None:
+    kv = _kv_rows((3,))
+    tokens_per_block = 2
+    cache_loc = torch.tensor([1, 0], dtype=torch.int32)
+    cu_num_pages = torch.tensor([0, 2], dtype=torch.int32)
+    nope_cache = torch.empty(2, 1, tokens_per_block, 1, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE)
+    rope_cache = torch.empty(2, 1, tokens_per_block, 1, DSV4_ROPE_DIM, dtype=torch.bfloat16)
+    scale_cache = torch.empty(
+        2, 1, tokens_per_block, 1, DSV4_NOPE_SCALE_BLOCKS, dtype=_scale_dtype()
+    )
+
+    write_result = torch.ops.auto_deploy.torch_deepseek_v4_fp8_nope_paged_cache_write(
+        kv,
+        cache_loc,
+        cu_num_pages,
+        0,
+        torch.tensor(1, dtype=torch.int64),
+        nope_cache,
+        rope_cache,
+        scale_cache,
+    )
+    gathered = torch.ops.auto_deploy.torch_deepseek_v4_fp8_nope_paged_cache_gather(
+        cache_loc,
+        cu_num_pages,
+        0,
+        1,
+        4,
+        nope_cache,
+        rope_cache,
+        scale_cache,
+    )
+    expected_rows = quantize_deepseek_v4_fp8_nope_cache_rows(kv)
+    expected = reconstruct_deepseek_v4_fp8_nope_cache_rows(
+        expected_rows.nope,
+        expected_rows.rope,
+        expected_rows.scale,
+        dtype=torch.bfloat16,
+    ).reshape(3, DSV4_HEAD_DIM)
+
+    assert write_result.shape == (0,)
+    torch.testing.assert_close(gathered, expected, rtol=0, atol=0)
+
+
+@_requires_cuda_e8m0
+def test_ratio0_triton_attention_consumes_fp8_nope_cache_against_bf16_cache() -> None:
+    device = torch.device("cuda")
+    torch.manual_seed(9001)
+    batch_size = 2
+    active_sequences = 2
+    prefix_len = 7
+    block_size = 128
+    softmax_scale = 0.04419417382415922
+
+    q = torch.randn(batch_size, 1, 8, DSV4_HEAD_DIM, dtype=torch.bfloat16, device=device) * 0.05
+    kv = torch.randn(batch_size, 1, DSV4_HEAD_DIM, dtype=torch.bfloat16, device=device) * 0.25
+    prefix_kv = (
+        torch.randn(
+            active_sequences, prefix_len, DSV4_HEAD_DIM, dtype=torch.bfloat16, device=device
+        )
+        * 0.25
+    )
+    attn_sink = torch.linspace(-0.2, 0.2, 8, dtype=torch.float32, device=device)
+    topk_idxs = torch.full((batch_size, 1, block_size), -1, dtype=torch.int32, device=device)
+    topk_idxs[:active_sequences, 0, 0] = prefix_len
+    topk_idxs[:active_sequences, 0, 1] = prefix_len - 1
+    topk_idxs[:active_sequences, 0, 2] = 0
+    topk_idxs[:active_sequences, 0, 3] = 3
+    topk_idxs[:active_sequences, 0, 4] = prefix_len
+
+    cache_loc, cu_num_pages = _paged_cache_metadata(
+        [prefix_len + 1] * active_sequences, block_size, device
+    )
+    seq_len_host = torch.ones(active_sequences, dtype=torch.int32, device=device)
+    input_pos_host = torch.full((active_sequences,), prefix_len, dtype=torch.int32, device=device)
+    cu_seqlen_host = torch.arange(active_sequences + 1, dtype=torch.int32, device=device)
+    num_pages = cache_loc.numel()
+    bf16_cache = torch.zeros(
+        num_pages, 1, block_size, 1, DSV4_HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    nope_cache = torch.empty(
+        num_pages, 1, block_size, 1, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE, device=device
+    )
+    rope_cache = torch.empty(
+        num_pages, 1, block_size, 1, DSV4_ROPE_DIM, dtype=torch.bfloat16, device=device
+    )
+    scale_cache = torch.empty(
+        num_pages, 1, block_size, 1, DSV4_NOPE_SCALE_BLOCKS, dtype=torch.uint8, device=device
+    )
+
+    for seq_idx in range(active_sequences):
+        page_idx = int(cache_loc[seq_idx].item())
+        bf16_cache[page_idx, 0, :prefix_len, 0].copy_(prefix_kv[seq_idx])
+        write_deepseek_v4_fp8_nope_paged_cache_rows(
+            torch.cat([prefix_kv[seq_idx], kv[seq_idx]], dim=0),
+            cache_loc,
+            cu_num_pages,
+            seq_idx=seq_idx,
+            input_pos=torch.tensor(0, dtype=torch.int64, device=device),
+            nope_cache=nope_cache,
+            rope_cache=rope_cache,
+            scale_cache=scale_cache,
+        )
+
+    bf16_out = dsv4_triton_attention.triton_deepseek_v4_ratio0_swa_attention_with_cache(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc,
+        cu_num_pages,
+        bf16_cache,
+        softmax_scale,
+        block_size,
+        active_sequences,
+    )
+    fp8_out = dsv4_triton_attention.triton_deepseek_v4_ratio0_swa_attention_with_fp8_cache(
+        q,
+        attn_sink,
+        topk_idxs,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc,
+        cu_num_pages,
+        nope_cache,
+        rope_cache,
+        scale_cache,
+        softmax_scale,
+        block_size,
+        active_sequences,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(fp8_out.float(), bf16_out.float(), rtol=0.12, atol=0.08)
+
+    with pytest.raises(RuntimeError, match="scale_cache must contain raw E8M0 bytes"):
+        dsv4_triton_attention.triton_deepseek_v4_ratio0_swa_attention_with_fp8_cache(
+            q,
+            attn_sink,
+            topk_idxs,
+            seq_len_host,
+            input_pos_host,
+            cu_seqlen_host,
+            cache_loc,
+            cu_num_pages,
+            nope_cache,
+            rope_cache,
+            scale_cache.float(),
+            softmax_scale,
+            block_size,
+            active_sequences,
+        )
+
+
+def test_attention_consumption_blocker_message_names_missing_split_resources() -> None:
+    assert "not consumed" in DSV4_FP8_NOPE_ATTENTION_UNSUPPORTED_REASON
+    assert "NoPE, RoPE, and E8M0 scale cache resources" in (
+        DSV4_FP8_NOPE_ATTENTION_UNSUPPORTED_REASON
+    )
+
+
+@_requires_cuda_e8m0
+def test_cuda_paged_cache_write_crosses_page_boundary_and_preserves_raw_scale_bytes() -> None:
+    device = torch.device("cuda")
+    kv = _kv_rows((3,)).to(device)
+    tokens_per_block = 2
+    cache_loc = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    cu_num_pages = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    nope_cache = torch.empty(
+        2, 1, tokens_per_block, 1, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE, device=device
+    )
+    rope_cache = torch.full(
+        (2, 1, tokens_per_block, 1, DSV4_ROPE_DIM),
+        -3.0,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    scale_cache = torch.empty(
+        2,
+        1,
+        tokens_per_block,
+        1,
+        DSV4_NOPE_SCALE_BLOCKS,
+        dtype=torch.float8_e8m0fnu,
+        device=device,
+    )
+
+    rows = write_deepseek_v4_fp8_nope_paged_cache_rows(
+        kv,
+        cache_loc,
+        cu_num_pages,
+        seq_idx=0,
+        input_pos=torch.tensor(1, dtype=torch.int64, device=device),
+        nope_cache=nope_cache,
+        rope_cache=rope_cache,
+        scale_cache=scale_cache,
+    )
+
+    flat_nope = rows.nope.reshape(-1, DSV4_NOPE_DIM)
+    flat_rope = rows.rope.reshape(-1, DSV4_ROPE_DIM)
+    flat_scale = rows.scale.reshape(-1, DSV4_NOPE_SCALE_BLOCKS)
+    target_slots = [(1, 1), (0, 0), (0, 1)]
+    for token_idx, (page_idx, token_offset) in enumerate(target_slots):
+        torch.testing.assert_close(
+            nope_cache[page_idx, 0, token_offset, 0].view(torch.uint8),
+            flat_nope[token_idx].view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            rope_cache[page_idx, 0, token_offset, 0].float(),
+            flat_rope[token_idx].float(),
+            rtol=0,
+            atol=0,
+        )
+        _assert_scale_equal(scale_cache[page_idx, 0, token_offset, 0], flat_scale[token_idx])
+
+
+@_requires_cuda_e8m0
+def test_cuda_graph_replay_updates_fp8_nope_paged_cache() -> None:
+    device = torch.device("cuda")
+    tokens_per_block = 2
+    cache_loc = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    cu_num_pages = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    input_pos = torch.tensor(1, dtype=torch.int64, device=device)
+    kv_static = _kv_rows((3,)).to(device)
+    nope_cache = torch.empty(
+        2, 1, tokens_per_block, 1, DSV4_NOPE_DIM, dtype=FP8_E4M3_DTYPE, device=device
+    )
+    rope_cache = torch.empty(
+        2, 1, tokens_per_block, 1, DSV4_ROPE_DIM, dtype=torch.bfloat16, device=device
+    )
+    scale_cache = torch.empty(
+        2,
+        1,
+        tokens_per_block,
+        1,
+        DSV4_NOPE_SCALE_BLOCKS,
+        dtype=torch.float8_e8m0fnu,
+        device=device,
+    )
+    gathered_static = torch.empty(3, DSV4_HEAD_DIM, dtype=torch.bfloat16, device=device)
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            torch.ops.auto_deploy.torch_deepseek_v4_fp8_nope_paged_cache_write(
+                kv_static,
+                cache_loc,
+                cu_num_pages,
+                0,
+                input_pos,
+                nope_cache,
+                rope_cache,
+                scale_cache,
+            )
+            gathered_static.copy_(
+                torch.ops.auto_deploy.torch_deepseek_v4_fp8_nope_paged_cache_gather(
+                    cache_loc,
+                    cu_num_pages,
+                    0,
+                    1,
+                    4,
+                    nope_cache,
+                    rope_cache,
+                    scale_cache,
+                )
+            )
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        torch.ops.auto_deploy.torch_deepseek_v4_fp8_nope_paged_cache_write(
+            kv_static,
+            cache_loc,
+            cu_num_pages,
+            0,
+            input_pos,
+            nope_cache,
+            rope_cache,
+            scale_cache,
+        )
+        gathered_static.copy_(
+            torch.ops.auto_deploy.torch_deepseek_v4_fp8_nope_paged_cache_gather(
+                cache_loc,
+                cu_num_pages,
+                0,
+                1,
+                4,
+                nope_cache,
+                rope_cache,
+                scale_cache,
+            )
+        )
+    first_bytes = nope_cache[1, 0, 1, 0].view(torch.uint8).clone()
+
+    kv_static.copy_((_kv_rows((3,)) + 3.0).to(device))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    expected_rows = quantize_deepseek_v4_fp8_nope_cache_rows(kv_static)
+    torch.testing.assert_close(
+        nope_cache[1, 0, 1, 0].view(torch.uint8),
+        expected_rows.nope[0].view(torch.uint8),
+        rtol=0,
+        atol=0,
+    )
+    _assert_scale_equal(
+        scale_cache[1, 0, 1, 0],
+        expected_rows.scale.reshape(-1, DSV4_NOPE_SCALE_BLOCKS)[0],
+    )
+    expected_gathered = reconstruct_deepseek_v4_fp8_nope_cache_rows(
+        expected_rows.nope,
+        expected_rows.rope,
+        expected_rows.scale,
+        dtype=torch.bfloat16,
+    ).reshape(3, DSV4_HEAD_DIM)
+    torch.testing.assert_close(gathered_static, expected_gathered, rtol=0, atol=0)
+    assert not torch.equal(first_bytes, nope_cache[1, 0, 1, 0].view(torch.uint8))
+
+
+def test_default_scale_block_count_matches_dsv4_nope_tail() -> None:
+    assert DSV4_NOPE_DIM % DSV4_FP8_BLOCK_SIZE != 0
+    assert DSV4_NOPE_SCALE_BLOCKS == 4

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_kernels.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_kernels.py
@@ -15,28 +15,63 @@
 
 """Tests for standalone DeepSeek V4 attention kernel microfeatures."""
 
+from typing import NoReturn
+
 import pytest
 import torch
+import torch.nn as nn
 from torch._subclasses.fake_tensor import FakeTensorMode
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention import deepseek_v4_kernels as dsv4_kernels
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_kernels import (
     FP8_E4M3_DTYPE,
     deepseek_v4_compressor_pool_norm_rope_ref,
     deepseek_v4_fp8_block_dequant_ref,
+    deepseek_v4_indexer_fp4_quant_dequant_ref,
     deepseek_v4_indexer_q_rope_quant_ref,
     deepseek_v4_inverse_rope_fp8_output_quant_ref,
+    deepseek_v4_kv_rmsnorm_rope_bf16_cache_insert_ref,
     deepseek_v4_kv_rmsnorm_rope_ref,
     deepseek_v4_local_window_topk_idxs,
     deepseek_v4_q_rmsnorm_rope_ref,
+    deepseek_v4_ratio4_indexer_build_topk_ref,
+    deepseek_v4_ratio4_indexer_compressed_kv_ref,
+    deepseek_v4_ratio4_indexer_q_ref,
+    deepseek_v4_ratio4_indexer_scores_ref,
+    deepseek_v4_ratio4_indexer_topk_ref,
+    deepseek_v4_ratio4_overlap_compress_ref,
     deepseek_v4_sparse_attention_microkernel_ref,
 )
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.utils.e8m0 import e8m0_to_uint8, maybe_e8m0_to_fp32
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+DSV4_LOCAL_HEADS = 8
+DSV4_HEAD_DIM = 512
+DSV4_ROPE_DIM = 64
+
+
+class _DisabledReferenceError(RuntimeError):
+    pass
+
+
+def _disabled_ref(*args: object, **kwargs: object) -> NoReturn:
+    del args, kwargs
+    raise _DisabledReferenceError("reference helper disabled by readiness test")
 
 
 def _freqs(batch_size: int, seq_len: int, rope_dim: int, device: str | torch.device = "cpu"):
     phases = torch.randn(batch_size, seq_len, rope_dim // 2, dtype=torch.float32, device=device)
     return torch.polar(torch.ones_like(phases), phases)
+
+
+def _batch_info(num_prefill: int, num_prefill_tokens: int, num_decode: int) -> torch.Tensor:
+    batch_info = BatchInfo()
+    batch_info.update([num_prefill, num_prefill_tokens, 0, 0, num_decode, num_decode])
+    batch_info.update_tokens_gather_info(num_prefill_tokens + num_decode, False)
+    return batch_info.serialize()
 
 
 def _manual_rms_norm(
@@ -84,6 +119,80 @@ def test_q_rmsnorm_rope_matches_manual_reference():
         rtol=0,
         atol=0,
     )
+
+
+def test_triton_q_rmsnorm_rope_matches_observed_shape_reference_and_out():
+    torch.manual_seed(11)
+    batch_size, seq_len = 2, 3
+    q = (
+        torch.randn(batch_size, seq_len, DSV4_LOCAL_HEADS, DSV4_HEAD_DIM, dtype=torch.float32)
+        * 0.125
+    ).to(torch.bfloat16)
+    weight = torch.linspace(0.5, 1.25, DSV4_HEAD_DIM, dtype=torch.float32)
+    freqs = _freqs(batch_size, seq_len, DSV4_ROPE_DIM)
+    eps = 1e-6
+
+    actual = torch.ops.auto_deploy.triton_deepseek_v4_q_rmsnorm_rope(
+        q, weight, freqs, eps, DSV4_ROPE_DIM
+    )
+    expected = deepseek_v4_q_rmsnorm_rope_ref(q, weight, freqs, eps, DSV4_ROPE_DIM)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    out = torch.empty_like(q)
+    sentinel = torch.ops.auto_deploy.triton_deepseek_v4_q_rmsnorm_rope(
+        q, weight, freqs, eps, DSV4_ROPE_DIM, out=out
+    )
+    assert sentinel.numel() == 0
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def test_triton_q_rmsnorm_rope_rejects_non_observed_head_count():
+    q = torch.randn(1, 1, 4, DSV4_HEAD_DIM, dtype=torch.float32).to(torch.bfloat16)
+    freqs = _freqs(1, 1, DSV4_ROPE_DIM)
+
+    with pytest.raises(ValueError, match="local head count"):
+        torch.ops.auto_deploy.triton_deepseek_v4_q_rmsnorm_rope(q, None, freqs, 1e-6, DSV4_ROPE_DIM)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for DSV4 Triton Q readiness"
+)
+def test_triton_q_rmsnorm_rope_readiness_survives_disabled_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch.manual_seed(1101)
+    device = torch.device("cuda")
+    batch_size, seq_len = 1, 2
+    q = (
+        torch.randn(
+            batch_size,
+            seq_len,
+            DSV4_LOCAL_HEADS,
+            DSV4_HEAD_DIM,
+            dtype=torch.float32,
+            device=device,
+        )
+        * 0.125
+    ).to(torch.bfloat16)
+    weight = torch.linspace(0.5, 1.25, DSV4_HEAD_DIM, dtype=torch.float32, device=device)
+    freqs = _freqs(batch_size, seq_len, DSV4_ROPE_DIM, device=device)
+    expected = deepseek_v4_q_rmsnorm_rope_ref(q, weight, freqs, 1e-6, DSV4_ROPE_DIM)
+
+    monkeypatch.setattr(dsv4_kernels, "deepseek_v4_q_rmsnorm_rope_ref", _disabled_ref)
+
+    actual = torch.ops.auto_deploy.triton_deepseek_v4_q_rmsnorm_rope(
+        q, weight, freqs, 1e-6, DSV4_ROPE_DIM
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    out = torch.empty_like(q)
+    sentinel = torch.ops.auto_deploy.triton_deepseek_v4_q_rmsnorm_rope(
+        q, weight, freqs, 1e-6, DSV4_ROPE_DIM, out=out
+    )
+    assert sentinel.numel() == 0
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
 
 
 def test_kv_rmsnorm_rope_cache_insert_quantizes_nope_and_preserves_rope():
@@ -150,6 +259,208 @@ def test_kv_rmsnorm_rope_cache_insert_quantizes_nope_and_preserves_rope():
     )
 
 
+def test_triton_kv_norm_rope_cache_insert_writes_bf16_swa_pages():
+    torch.manual_seed(12)
+    batch_size, seq_len, block_size = 2, 5, 4
+    kv = (torch.randn(batch_size, seq_len, DSV4_HEAD_DIM, dtype=torch.float32) * 0.125).to(
+        torch.bfloat16
+    )
+    weight = torch.linspace(0.75, 1.5, DSV4_HEAD_DIM, dtype=torch.float32)
+    freqs = _freqs(batch_size, seq_len, DSV4_ROPE_DIM)
+    batch_info = _batch_info(num_prefill=2, num_prefill_tokens=8, num_decode=0)
+    seq_len_host = torch.tensor([5, 3], dtype=torch.int32)
+    input_pos_host = torch.tensor([2, 0], dtype=torch.int32)
+    cu_seqlen_host = torch.tensor([0, 5, 8], dtype=torch.int32)
+    cache_loc_host = torch.tensor([1, 0, 2], dtype=torch.int32)
+    cu_num_pages_host = torch.tensor([0, 2, 3], dtype=torch.int32)
+    sentinel_value = -7.0
+    swa_cache = torch.full(
+        (3, 1, block_size, 1, DSV4_HEAD_DIM),
+        sentinel_value,
+        dtype=torch.bfloat16,
+    )
+
+    actual = torch.ops.auto_deploy.triton_deepseek_v4_kv_norm_rope_cache_insert(
+        kv,
+        weight,
+        freqs,
+        batch_info,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        swa_cache,
+        1e-6,
+        DSV4_ROPE_DIM,
+    )
+
+    expected_kv = deepseek_v4_kv_rmsnorm_rope_ref(kv, weight, freqs, 1e-6, DSV4_ROPE_DIM)
+    expected_flat = expected_kv.reshape(-1, DSV4_HEAD_DIM)
+    expected_output_flat = torch.zeros_like(expected_flat)
+    expected_output_flat[:8].copy_(expected_flat[:8])
+
+    torch.testing.assert_close(
+        actual.reshape(-1, DSV4_HEAD_DIM),
+        expected_output_flat,
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(swa_cache[1, 0, 2, 0], expected_flat[0], rtol=0, atol=0)
+    torch.testing.assert_close(swa_cache[1, 0, 3, 0], expected_flat[1], rtol=0, atol=0)
+    torch.testing.assert_close(swa_cache[0, 0, 0, 0], expected_flat[2], rtol=0, atol=0)
+    torch.testing.assert_close(swa_cache[0, 0, 1, 0], expected_flat[3], rtol=0, atol=0)
+    torch.testing.assert_close(swa_cache[0, 0, 2, 0], expected_flat[4], rtol=0, atol=0)
+    torch.testing.assert_close(swa_cache[2, 0, 0, 0], expected_flat[5], rtol=0, atol=0)
+    torch.testing.assert_close(swa_cache[2, 0, 1, 0], expected_flat[6], rtol=0, atol=0)
+    torch.testing.assert_close(swa_cache[2, 0, 2, 0], expected_flat[7], rtol=0, atol=0)
+    assert torch.all(swa_cache[0, 0, 3, 0] == sentinel_value)
+    assert torch.all(swa_cache[2, 0, 3, 0] == sentinel_value)
+
+
+def test_triton_kv_norm_rope_cache_insert_matches_reference_and_out():
+    torch.manual_seed(13)
+    batch_size, seq_len, block_size = 1, 3, 2
+    kv = (torch.randn(batch_size, seq_len, DSV4_HEAD_DIM, dtype=torch.float32) * 0.125).to(
+        torch.bfloat16
+    )
+    freqs = _freqs(batch_size, seq_len, DSV4_ROPE_DIM)
+    batch_info = _batch_info(num_prefill=1, num_prefill_tokens=3, num_decode=0)
+    seq_len_host = torch.tensor([3], dtype=torch.int32)
+    input_pos_host = torch.tensor([1], dtype=torch.int32)
+    cu_seqlen_host = torch.tensor([0, 3], dtype=torch.int32)
+    cache_loc_host = torch.tensor([1, 0], dtype=torch.int32)
+    cu_num_pages_host = torch.tensor([0, 2], dtype=torch.int32)
+    cache_actual = torch.zeros(2, 1, block_size, 1, DSV4_HEAD_DIM, dtype=torch.bfloat16)
+    cache_expected = torch.zeros_like(cache_actual)
+
+    out = torch.empty_like(kv)
+    sentinel = torch.ops.auto_deploy.triton_deepseek_v4_kv_norm_rope_cache_insert(
+        kv,
+        None,
+        freqs,
+        batch_info,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        cache_actual,
+        1e-6,
+        DSV4_ROPE_DIM,
+        out=out,
+    )
+    expected = deepseek_v4_kv_rmsnorm_rope_bf16_cache_insert_ref(
+        kv,
+        None,
+        freqs,
+        batch_info,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        cache_expected,
+        1e-6,
+        DSV4_ROPE_DIM,
+    )
+
+    assert sentinel.numel() == 0
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+    torch.testing.assert_close(cache_actual, cache_expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for DSV4 Triton KV readiness"
+)
+def test_triton_kv_norm_rope_cache_insert_readiness_survives_disabled_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch.manual_seed(1102)
+    device = torch.device("cuda")
+    batch_size, seq_len, block_size = 1, 3, 2
+    kv = (
+        torch.randn(batch_size, seq_len, DSV4_HEAD_DIM, dtype=torch.float32, device=device) * 0.125
+    ).to(torch.bfloat16)
+    weight = torch.linspace(0.75, 1.5, DSV4_HEAD_DIM, dtype=torch.float32, device=device)
+    freqs = _freqs(batch_size, seq_len, DSV4_ROPE_DIM, device=device)
+    batch_info = _batch_info(num_prefill=1, num_prefill_tokens=3, num_decode=0).to(device)
+    seq_len_host = torch.tensor([3], dtype=torch.int32, device=device)
+    input_pos_host = torch.tensor([1], dtype=torch.int32, device=device)
+    cu_seqlen_host = torch.tensor([0, 3], dtype=torch.int32, device=device)
+    cache_loc_host = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    cu_num_pages_host = torch.tensor([0, 2], dtype=torch.int32, device=device)
+    cache_actual = torch.zeros(
+        2,
+        1,
+        block_size,
+        1,
+        DSV4_HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    cache_expected = torch.zeros_like(cache_actual)
+    expected = deepseek_v4_kv_rmsnorm_rope_bf16_cache_insert_ref(
+        kv,
+        weight,
+        freqs,
+        batch_info,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        cache_expected,
+        1e-6,
+        DSV4_ROPE_DIM,
+    )
+
+    monkeypatch.setattr(
+        dsv4_kernels,
+        "deepseek_v4_kv_rmsnorm_rope_bf16_cache_insert_ref",
+        _disabled_ref,
+    )
+
+    actual = torch.ops.auto_deploy.triton_deepseek_v4_kv_norm_rope_cache_insert(
+        kv,
+        weight,
+        freqs,
+        batch_info,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        cache_actual,
+        1e-6,
+        DSV4_ROPE_DIM,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(cache_actual, cache_expected, rtol=0, atol=0)
+
+    cache_actual_out = torch.zeros_like(cache_actual)
+    out = torch.empty_like(kv)
+    sentinel = torch.ops.auto_deploy.triton_deepseek_v4_kv_norm_rope_cache_insert(
+        kv,
+        weight,
+        freqs,
+        batch_info,
+        seq_len_host,
+        input_pos_host,
+        cu_seqlen_host,
+        cache_loc_host,
+        cu_num_pages_host,
+        cache_actual_out,
+        1e-6,
+        DSV4_ROPE_DIM,
+        out=out,
+    )
+    assert sentinel.numel() == 0
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+    torch.testing.assert_close(cache_actual_out, cache_expected, rtol=0, atol=0)
+
+
 @pytest.mark.parametrize(
     "compress_ratio,overlap,seq_len",
     [
@@ -180,6 +491,396 @@ def test_compressor_pool_norm_rope_matches_reference(
 
     assert actual.shape == (batch_size, seq_len // compress_ratio, head_dim)
     torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_ratio4_overlap_compress_matches_existing_reference_for_complete_rows():
+    torch.manual_seed(14)
+    batch_size, seq_len, indexer_head_dim, rope_dim = 1, 8, 128, DSV4_ROPE_DIM
+    state_dim = 2 * indexer_head_dim
+    kv = torch.randn(batch_size, seq_len, state_dim, dtype=torch.float32) * 0.1
+    gate = torch.randn_like(kv)
+    ape = torch.randn(4, state_dim, dtype=torch.float32) * 0.01
+    weight = torch.linspace(0.75, 1.25, indexer_head_dim)
+    freqs = _freqs(batch_size, seq_len, rope_dim)
+
+    actual = deepseek_v4_ratio4_overlap_compress_ref(
+        kv, gate, ape, weight, freqs, 1e-6, rope_dim, max_compressed_len=2
+    )
+    expected = deepseek_v4_compressor_pool_norm_rope_ref(
+        kv, gate, ape, weight, freqs, 1e-6, rope_dim, 4, True
+    )
+
+    assert actual.shape == (batch_size, 2, indexer_head_dim)
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_ratio4_indexer_scores_match_manual_score_assembly():
+    torch.manual_seed(15)
+    batch_size, seq_len, max_compressed_len = 1, 8, 2
+    q = torch.randn(batch_size, seq_len, 8, 128, dtype=torch.float32) * 0.125
+    compressor_kv = torch.randn(batch_size, seq_len, 256, dtype=torch.float32) * 0.125
+    compressor_gate = torch.randn_like(compressor_kv)
+    compressor_ape = torch.randn(4, 256, dtype=torch.float32) * 0.01
+    compressor_norm_weight = torch.linspace(0.75, 1.25, 128)
+    weights = torch.randn(batch_size, seq_len, 8, dtype=torch.float32)
+    freqs = _freqs(batch_size, seq_len, DSV4_ROPE_DIM)
+
+    actual = torch.ops.auto_deploy.torch_deepseek_v4_ratio4_indexer_scores(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs,
+        1e-6,
+        DSV4_ROPE_DIM,
+        max_compressed_len,
+        32,
+        False,
+    )
+    q_indexer = deepseek_v4_ratio4_indexer_q_ref(q, freqs, DSV4_ROPE_DIM, 32)
+    compressed = deepseek_v4_ratio4_indexer_compressed_kv_ref(
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs,
+        1e-6,
+        DSV4_ROPE_DIM,
+        max_compressed_len,
+        32,
+    )
+    scaled_weights = weights.float() * (128**-0.5 * 8**-0.5)
+    expected = (
+        torch.einsum("bshd,btd->bsht", q_indexer.float(), compressed.float()).relu()
+        * scaled_weights.unsqueeze(-1)
+    ).sum(dim=2)
+
+    torch.testing.assert_close(
+        actual,
+        deepseek_v4_ratio4_indexer_scores_ref(
+            q,
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            weights,
+            freqs,
+            1e-6,
+            DSV4_ROPE_DIM,
+            max_compressed_len,
+            32,
+        ),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_triton_ratio4_indexer_scores_cpu_fallback_uses_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch.manual_seed(1103)
+    batch_size, seq_len, max_compressed_len = 1, 4, 2048
+    q = (torch.randn(batch_size, seq_len, 8, 128, dtype=torch.float32) * 0.125).to(torch.bfloat16)
+    compressor_kv = (torch.randn(batch_size, seq_len, 256, dtype=torch.float32) * 0.125).to(
+        torch.bfloat16
+    )
+    compressor_gate = (torch.randn(batch_size, seq_len, 256, dtype=torch.float32) * 0.125).to(
+        torch.bfloat16
+    )
+    compressor_ape = (torch.randn(4, 256, dtype=torch.float32) * 0.01).to(torch.bfloat16)
+    compressor_norm_weight = torch.linspace(0.75, 1.25, 128, dtype=torch.float32)
+    weights = (torch.randn(batch_size, seq_len, 8, dtype=torch.float32) * 0.125).to(torch.bfloat16)
+    freqs = _freqs(batch_size, seq_len, DSV4_ROPE_DIM)
+
+    monkeypatch.setattr(dsv4_kernels, "deepseek_v4_ratio4_indexer_scores_ref", _disabled_ref)
+
+    with pytest.raises(_DisabledReferenceError, match="reference helper disabled"):
+        torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_scores(
+            q,
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            weights,
+            freqs,
+            1e-6,
+            DSV4_ROPE_DIM,
+            max_compressed_len,
+            32,
+            False,
+        )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for DSV4 ratio-4 score readiness"
+)
+def test_triton_ratio4_indexer_scores_readiness_survives_disabled_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    torch.manual_seed(1103)
+    device = torch.device("cuda")
+    batch_size, seq_len, max_compressed_len = 1, 4, 2048
+    q = (torch.randn(batch_size, seq_len, 8, 128, dtype=torch.float32, device=device) * 0.125).to(
+        torch.bfloat16
+    )
+    compressor_kv = (
+        torch.randn(batch_size, seq_len, 256, dtype=torch.float32, device=device) * 0.125
+    ).to(torch.bfloat16)
+    compressor_gate = (
+        torch.randn(batch_size, seq_len, 256, dtype=torch.float32, device=device) * 0.125
+    ).to(torch.bfloat16)
+    compressor_ape = (torch.randn(4, 256, dtype=torch.float32, device=device) * 0.01).to(
+        torch.bfloat16
+    )
+    compressor_norm_weight = torch.linspace(0.75, 1.25, 128, dtype=torch.float32, device=device)
+    weights = (torch.randn(batch_size, seq_len, 8, dtype=torch.float32, device=device) * 0.125).to(
+        torch.bfloat16
+    )
+    freqs = _freqs(batch_size, seq_len, DSV4_ROPE_DIM, device=device)
+    expected = deepseek_v4_ratio4_indexer_scores_ref(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs,
+        1e-6,
+        DSV4_ROPE_DIM,
+        max_compressed_len,
+        32,
+    )
+
+    monkeypatch.setattr(dsv4_kernels, "deepseek_v4_ratio4_indexer_scores_ref", _disabled_ref)
+
+    actual = torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_scores(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs,
+        1e-6,
+        DSV4_ROPE_DIM,
+        max_compressed_len,
+        32,
+        False,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    out = torch.empty_like(actual)
+    sentinel = torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_scores(
+        q,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        weights,
+        freqs,
+        1e-6,
+        DSV4_ROPE_DIM,
+        max_compressed_len,
+        32,
+        False,
+        out=out,
+    )
+    assert sentinel.numel() == 0
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def test_ratio4_indexer_topk_respects_decode_continuation_visibility():
+    index_score = torch.tensor(
+        [
+            [
+                [0.0, 9.0, 5.0, 1.0],
+                [1.0, 8.0, 7.0, 6.0],
+            ]
+        ],
+        dtype=torch.float32,
+    )
+    source_seq_lens = torch.tensor([9], dtype=torch.int32)
+
+    partial = deepseek_v4_ratio4_indexer_topk_ref(
+        index_score, source_seq_lens, torch.tensor([3], dtype=torch.int32), topk_count=3
+    )
+    continued = deepseek_v4_ratio4_indexer_topk_ref(
+        index_score, source_seq_lens, torch.tensor([7], dtype=torch.int32), topk_count=3
+    )
+
+    torch.testing.assert_close(
+        partial,
+        torch.tensor([[[9, -1, -1], [9, -1, -1]]], dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        continued,
+        torch.tensor([[[10, 9, -1], [10, 9, -1]]], dtype=torch.int32),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_triton_ratio4_indexer_topk_builds_observed_width640_and_out():
+    batch_size, seq_len, max_compressed_len = 1, 5, 2048
+    index_score = torch.full((batch_size, seq_len, max_compressed_len), -10.0)
+    index_score[0, 3, 0] = 5.0
+    index_score[0, 3, 1] = 50.0
+    source_seq_lens = torch.tensor([seq_len], dtype=torch.int32)
+    input_pos = torch.tensor([0], dtype=torch.int32)
+
+    actual = torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_topk(
+        index_score, source_seq_lens, input_pos
+    )
+    expected = deepseek_v4_ratio4_indexer_build_topk_ref(index_score, source_seq_lens, input_pos)
+
+    assert actual.shape == (batch_size, seq_len, 640)
+    assert actual.dtype == torch.int32
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    assert actual[0, 0, 0].item() == 0
+    assert torch.all(actual[0, 0, 1:128] == -1)
+    assert actual[0, 3, 128].item() == seq_len
+    assert torch.all(actual[0, 3, 129:] == -1)
+
+    out = torch.empty_like(actual)
+    sentinel = torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_topk(
+        index_score, source_seq_lens, input_pos, out=out
+    )
+    assert sentinel.numel() == 0
+    torch.testing.assert_close(out, actual, rtol=0, atol=0)
+
+
+def test_triton_ratio4_indexer_topk_cpu_fallback_uses_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    batch_size, seq_len, max_compressed_len = 1, 5, 2048
+    index_score = torch.full((batch_size, seq_len, max_compressed_len), -10.0)
+    source_seq_lens = torch.tensor([seq_len], dtype=torch.int32)
+    input_pos = torch.tensor([0], dtype=torch.int32)
+
+    monkeypatch.setattr(dsv4_kernels, "deepseek_v4_ratio4_indexer_build_topk_ref", _disabled_ref)
+
+    with pytest.raises(_DisabledReferenceError, match="reference helper disabled"):
+        torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_topk(
+            index_score, source_seq_lens, input_pos
+        )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA required for DSV4 ratio-4 top-k readiness"
+)
+def test_triton_ratio4_indexer_topk_readiness_survives_disabled_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = torch.device("cuda")
+    batch_size, seq_len, max_compressed_len = 1, 5, 2048
+    index_score = torch.full((batch_size, seq_len, max_compressed_len), -10.0, device=device)
+    index_score[0, 3, 0] = 5.0
+    index_score[0, 3, 1] = 50.0
+    source_seq_lens = torch.tensor([seq_len], dtype=torch.int32, device=device)
+    input_pos = torch.tensor([0], dtype=torch.int32, device=device)
+    expected = deepseek_v4_ratio4_indexer_build_topk_ref(index_score, source_seq_lens, input_pos)
+
+    monkeypatch.setattr(dsv4_kernels, "deepseek_v4_ratio4_indexer_build_topk_ref", _disabled_ref)
+
+    actual = torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_topk(
+        index_score, source_seq_lens, input_pos
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    out = torch.empty_like(actual)
+    sentinel = torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_topk(
+        index_score, source_seq_lens, input_pos, out=out
+    )
+    assert sentinel.numel() == 0
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def test_ratio4_indexer_fp4_quant_dequant_uses_four_groups_per_row():
+    row = torch.arange(128, dtype=torch.float32).view(1, 1, 1, 128) / 16.0
+    actual = deepseek_v4_indexer_fp4_quant_dequant_ref(row, block_size=32)
+    group0 = deepseek_v4_indexer_fp4_quant_dequant_ref(row[..., :32], block_size=32)
+    group1 = deepseek_v4_indexer_fp4_quant_dequant_ref(row[..., 32:64], block_size=32)
+    group2 = deepseek_v4_indexer_fp4_quant_dequant_ref(row[..., 64:96], block_size=32)
+    group3 = deepseek_v4_indexer_fp4_quant_dequant_ref(row[..., 96:128], block_size=32)
+    expected = torch.cat([group0, group1, group2, group3], dim=-1)
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+class _Ratio4IndexerAllReduceFixture(nn.Module):
+    def forward(
+        self,
+        q: torch.Tensor,
+        compressor_kv: torch.Tensor,
+        compressor_gate: torch.Tensor,
+        compressor_ape: torch.Tensor,
+        compressor_norm_weight: torch.Tensor,
+        weights: torch.Tensor,
+        freqs: torch.Tensor,
+        source_seq_lens: torch.Tensor,
+        input_pos: torch.Tensor,
+    ) -> torch.Tensor:
+        score = torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_scores(
+            q,
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            weights,
+            freqs,
+            1e-6,
+            DSV4_ROPE_DIM,
+            2048,
+            32,
+            False,
+        )
+        score = torch.ops.auto_deploy.all_reduce(score, layer_type="mla")
+        return torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_topk(
+            score, source_seq_lens, input_pos
+        )
+
+
+def test_ratio4_indexer_graph_places_all_reduce_before_topk():
+    torch.manual_seed(16)
+    batch_size, seq_len = 1, 4
+    gm = torch_export_to_gm(
+        _Ratio4IndexerAllReduceFixture(),
+        args=(
+            torch.randn(batch_size, seq_len, 8, 128, dtype=torch.bfloat16),
+            torch.randn(batch_size, seq_len, 256, dtype=torch.bfloat16),
+            torch.randn(batch_size, seq_len, 256, dtype=torch.bfloat16),
+            torch.randn(4, 256, dtype=torch.bfloat16),
+            torch.ones(128, dtype=torch.float32),
+            torch.randn(batch_size, seq_len, 8, dtype=torch.bfloat16),
+            _freqs(batch_size, seq_len, DSV4_ROPE_DIM),
+            torch.full((batch_size,), seq_len, dtype=torch.int32),
+            torch.zeros(batch_size, dtype=torch.int32),
+        ),
+    )
+
+    score_node = next(
+        node
+        for node in gm.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_scores)
+    )
+    all_reduce_node = next(
+        node for node in gm.graph.nodes if is_op(node, torch.ops.auto_deploy.all_reduce)
+    )
+    topk_node = next(
+        node
+        for node in gm.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.triton_deepseek_v4_ratio4_indexer_topk)
+    )
+
+    assert all_reduce_node.args[0] is score_node
+    assert topk_node.args[0] is all_reduce_node
 
 
 def test_indexer_q_rope_quant_uses_fp8_with_e8m0_scales():
@@ -309,6 +1010,75 @@ def test_fake_implementations_return_expected_shapes_and_dtypes():
     assert indexer_scale.shape == (*q.shape[:-1], 1)
     assert kv_fp8.dtype == FP8_E4M3_DTYPE
     assert indexer_fp8.dtype == FP8_E4M3_DTYPE
+
+
+def test_triton_fake_implementations_return_expected_shapes_and_out_sentinels():
+    with FakeTensorMode():
+        batch_size, seq_len, block_size = 2, 3, 4
+        q = torch.empty(
+            batch_size,
+            seq_len,
+            DSV4_LOCAL_HEADS,
+            DSV4_HEAD_DIM,
+            dtype=torch.bfloat16,
+        )
+        kv = torch.empty(batch_size, seq_len, DSV4_HEAD_DIM, dtype=torch.bfloat16)
+        freqs = torch.empty(batch_size, seq_len, DSV4_ROPE_DIM // 2, dtype=torch.complex64)
+        batch_info = torch.empty(12, dtype=torch.int32)
+        seq_len_host = torch.empty(batch_size, dtype=torch.int32)
+        input_pos_host = torch.empty(batch_size, dtype=torch.int32)
+        cu_seqlen_host = torch.empty(batch_size + 1, dtype=torch.int32)
+        cache_loc_host = torch.empty(batch_size, dtype=torch.int32)
+        cu_num_pages_host = torch.empty(batch_size + 1, dtype=torch.int32)
+        swa_cache = torch.empty(
+            batch_size,
+            1,
+            block_size,
+            1,
+            DSV4_HEAD_DIM,
+            dtype=torch.bfloat16,
+        )
+
+        q_out = torch.ops.auto_deploy.triton_deepseek_v4_q_rmsnorm_rope(
+            q, None, freqs, 1e-6, DSV4_ROPE_DIM
+        )
+        q_sentinel = torch.ops.auto_deploy.triton_deepseek_v4_q_rmsnorm_rope(
+            q, None, freqs, 1e-6, DSV4_ROPE_DIM, out=torch.empty_like(q)
+        )
+        kv_out = torch.ops.auto_deploy.triton_deepseek_v4_kv_norm_rope_cache_insert(
+            kv,
+            None,
+            freqs,
+            batch_info,
+            seq_len_host,
+            input_pos_host,
+            cu_seqlen_host,
+            cache_loc_host,
+            cu_num_pages_host,
+            swa_cache,
+            1e-6,
+            DSV4_ROPE_DIM,
+        )
+        kv_sentinel = torch.ops.auto_deploy.triton_deepseek_v4_kv_norm_rope_cache_insert(
+            kv,
+            None,
+            freqs,
+            batch_info,
+            seq_len_host,
+            input_pos_host,
+            cu_seqlen_host,
+            cache_loc_host,
+            cu_num_pages_host,
+            swa_cache,
+            1e-6,
+            DSV4_ROPE_DIM,
+            out=torch.empty_like(kv),
+        )
+
+    assert q_out.shape == q.shape
+    assert kv_out.shape == kv.shape
+    assert q_sentinel.numel() == 0
+    assert kv_sentinel.numel() == 0
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA graph replay requires CUDA")

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_kernels.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_kernels.py
@@ -1,0 +1,338 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for standalone DeepSeek V4 attention kernel microfeatures."""
+
+import pytest
+import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_kernels import (
+    FP8_E4M3_DTYPE,
+    deepseek_v4_compressor_pool_norm_rope_ref,
+    deepseek_v4_fp8_block_dequant_ref,
+    deepseek_v4_indexer_q_rope_quant_ref,
+    deepseek_v4_inverse_rope_fp8_output_quant_ref,
+    deepseek_v4_kv_rmsnorm_rope_ref,
+    deepseek_v4_local_window_topk_idxs,
+    deepseek_v4_q_rmsnorm_rope_ref,
+    deepseek_v4_sparse_attention_microkernel_ref,
+)
+from tensorrt_llm._torch.auto_deploy.utils.e8m0 import e8m0_to_uint8, maybe_e8m0_to_fp32
+
+
+def _freqs(batch_size: int, seq_len: int, rope_dim: int, device: str | torch.device = "cpu"):
+    phases = torch.randn(batch_size, seq_len, rope_dim // 2, dtype=torch.float32, device=device)
+    return torch.polar(torch.ones_like(phases), phases)
+
+
+def _manual_rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor | None,
+    eps: float,
+) -> torch.Tensor:
+    out = x.float() * torch.rsqrt(x.float().square().mean(dim=-1, keepdim=True) + eps)
+    if weight is not None:
+        out = out * weight.float()
+    return out.to(x.dtype)
+
+
+def _manual_apply_rope(
+    x: torch.Tensor,
+    freqs_cis: torch.Tensor,
+    rope_dim: int,
+    inverse: bool = False,
+) -> torch.Tensor:
+    nope = x[..., : x.shape[-1] - rope_dim]
+    rope = x[..., -rope_dim:]
+    rope_complex = torch.view_as_complex(rope.float().reshape(*rope.shape[:-1], -1, 2))
+    freqs = freqs_cis.conj() if inverse else freqs_cis
+    if freqs.dim() == rope_complex.dim() - 1:
+        freqs = freqs.unsqueeze(-2)
+    rope_out = torch.view_as_real(rope_complex * freqs).flatten(-2).to(x.dtype)
+    return torch.cat([nope, rope_out], dim=-1)
+
+
+def test_q_rmsnorm_rope_matches_manual_reference():
+    torch.manual_seed(1)
+    batch_size, seq_len, num_heads, head_dim, rope_dim = 2, 3, 4, 8, 4
+    q = torch.randn(batch_size, seq_len, num_heads, head_dim, dtype=torch.float32)
+    weight = torch.linspace(0.5, 1.25, head_dim)
+    freqs = _freqs(batch_size, seq_len, rope_dim)
+    eps = 1e-6
+
+    actual = torch.ops.auto_deploy.torch_deepseek_v4_q_rmsnorm_rope(q, weight, freqs, eps, rope_dim)
+    expected = _manual_apply_rope(_manual_rms_norm(q, weight, eps), freqs, rope_dim)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(
+        actual,
+        deepseek_v4_q_rmsnorm_rope_ref(q, weight, freqs, eps, rope_dim),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_kv_rmsnorm_rope_cache_insert_quantizes_nope_and_preserves_rope():
+    torch.manual_seed(2)
+    batch_size, seq_len, head_dim, rope_dim = 2, 3, 10, 4
+    kv = torch.randn(batch_size, seq_len, head_dim, dtype=torch.float32) * 0.25
+    weight = torch.linspace(0.75, 1.5, head_dim)
+    freqs = _freqs(batch_size, seq_len, rope_dim)
+    cache_indices = torch.tensor([4, 2, 0, 5, 3, 1], dtype=torch.int64)
+    nope_dim = head_dim - rope_dim
+    fp8_block_size = 4
+    num_scale_blocks = (nope_dim + fp8_block_size - 1) // fp8_block_size
+
+    nope_cache = torch.empty(batch_size * seq_len, nope_dim, dtype=FP8_E4M3_DTYPE)
+    rope_cache = torch.empty(batch_size * seq_len, rope_dim, dtype=torch.bfloat16)
+    scale_cache = torch.empty(batch_size * seq_len, num_scale_blocks, dtype=torch.float8_e8m0fnu)
+
+    kv_out, nope_fp8, nope_scale = (
+        torch.ops.auto_deploy.torch_deepseek_v4_kv_rmsnorm_rope_cache_insert(
+            kv,
+            weight,
+            freqs,
+            cache_indices,
+            nope_cache,
+            rope_cache,
+            scale_cache,
+            1e-6,
+            rope_dim,
+            fp8_block_size,
+        )
+    )
+
+    expected_kv = deepseek_v4_kv_rmsnorm_rope_ref(kv, weight, freqs, 1e-6, rope_dim)
+    torch.testing.assert_close(kv_out, expected_kv, rtol=1e-6, atol=1e-6)
+
+    flat_indices = cache_indices.reshape(-1)
+    torch.testing.assert_close(
+        nope_cache[flat_indices].view(torch.uint8),
+        nope_fp8.reshape(-1, nope_dim).view(torch.uint8),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        rope_cache[flat_indices].float(),
+        expected_kv[..., -rope_dim:].reshape(-1, rope_dim).to(torch.bfloat16).float(),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        e8m0_to_uint8(scale_cache[flat_indices]),
+        e8m0_to_uint8(nope_scale.reshape(-1, num_scale_blocks)),
+        rtol=0,
+        atol=0,
+    )
+
+    dequant_nope = deepseek_v4_fp8_block_dequant_ref(
+        nope_fp8, nope_scale, fp8_block_size, dtype=torch.float32
+    )
+    torch.testing.assert_close(
+        dequant_nope,
+        expected_kv[..., :nope_dim],
+        rtol=0.25,
+        atol=maybe_e8m0_to_fp32(nope_scale).max().item(),
+    )
+
+
+@pytest.mark.parametrize(
+    "compress_ratio,overlap,seq_len",
+    [
+        (4, True, 8),
+        (128, False, 256),
+    ],
+)
+def test_compressor_pool_norm_rope_matches_reference(
+    compress_ratio: int,
+    overlap: bool,
+    seq_len: int,
+):
+    torch.manual_seed(3 + compress_ratio)
+    batch_size, head_dim, rope_dim = 2, 8, 4
+    channels = 2 if overlap else 1
+    kv = torch.randn(batch_size, seq_len, channels * head_dim, dtype=torch.float32) * 0.1
+    gate = torch.randn_like(kv)
+    ape = torch.randn(compress_ratio, channels * head_dim, dtype=torch.float32) * 0.01
+    weight = torch.linspace(0.5, 1.25, head_dim)
+    freqs = _freqs(batch_size, seq_len, rope_dim)
+
+    actual = torch.ops.auto_deploy.torch_deepseek_v4_compressor_pool_norm_rope(
+        kv, gate, ape, weight, freqs, 1e-6, rope_dim, compress_ratio, overlap
+    )
+    expected = deepseek_v4_compressor_pool_norm_rope_ref(
+        kv, gate, ape, weight, freqs, 1e-6, rope_dim, compress_ratio, overlap
+    )
+
+    assert actual.shape == (batch_size, seq_len // compress_ratio, head_dim)
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_indexer_q_rope_quant_uses_fp8_with_e8m0_scales():
+    torch.manual_seed(5)
+    batch_size, seq_len, num_heads, head_dim, rope_dim = 2, 4, 3, 8, 4
+    q = torch.randn(batch_size, seq_len, num_heads, head_dim, dtype=torch.float32) * 0.125
+    freqs = _freqs(batch_size, seq_len, rope_dim)
+
+    q_fp8, scale = torch.ops.auto_deploy.torch_deepseek_v4_indexer_q_rope_quant(
+        q, freqs, rope_dim, 4, "fp8"
+    )
+
+    assert q_fp8.dtype == FP8_E4M3_DTYPE
+    assert scale.dtype == torch.float8_e8m0fnu
+    torch.testing.assert_close(
+        e8m0_to_uint8(scale),
+        e8m0_to_uint8(deepseek_v4_indexer_q_rope_quant_ref(q, freqs, rope_dim, 4)[1]),
+        rtol=0,
+        atol=0,
+    )
+    dequant = deepseek_v4_fp8_block_dequant_ref(q_fp8, scale, 4, dtype=torch.float32)
+    expected = _manual_apply_rope(q, freqs, rope_dim)
+    torch.testing.assert_close(
+        dequant, expected, rtol=0.25, atol=maybe_e8m0_to_fp32(scale).max().item()
+    )
+
+
+def test_inverse_rope_output_quant_roundtrips_rope_before_fp8_error():
+    torch.manual_seed(6)
+    batch_size, seq_len, num_heads, head_dim, rope_dim = 1, 5, 2, 8, 4
+    q = torch.randn(batch_size, seq_len, num_heads, head_dim, dtype=torch.float32) * 0.1
+    freqs = _freqs(batch_size, seq_len, rope_dim)
+    q_norm = _manual_rms_norm(q, None, 1e-6)
+    q_rope = _manual_apply_rope(q_norm, freqs, rope_dim)
+
+    out_fp8, scale = torch.ops.auto_deploy.torch_deepseek_v4_inverse_rope_fp8_output_quant(
+        q_rope, freqs, rope_dim, 4
+    )
+    expected_fp8, expected_scale = deepseek_v4_inverse_rope_fp8_output_quant_ref(
+        q_rope, freqs, rope_dim, 4
+    )
+
+    torch.testing.assert_close(
+        out_fp8.view(torch.uint8), expected_fp8.view(torch.uint8), rtol=0, atol=0
+    )
+    torch.testing.assert_close(e8m0_to_uint8(scale), e8m0_to_uint8(expected_scale), rtol=0, atol=0)
+    dequant = deepseek_v4_fp8_block_dequant_ref(out_fp8, scale, 4, dtype=torch.float32)
+    torch.testing.assert_close(
+        dequant, q_norm, rtol=0.25, atol=maybe_e8m0_to_fp32(scale).max().item()
+    )
+
+
+def test_sparse_attention_microkernel_matches_source_op_assembly():
+    torch.manual_seed(7)
+    batch_size, seq_len, num_heads, head_dim = 1, 4, 2, 6
+    q = torch.randn(batch_size, seq_len, num_heads, head_dim, dtype=torch.float32)
+    local_kv = torch.randn(batch_size, seq_len, head_dim, dtype=torch.float32)
+    compressed_kv = torch.randn(batch_size, 3, head_dim, dtype=torch.float32)
+    compressed_idxs = torch.tensor([[[0, -1], [0, 1], [1, 2], [2, -1]]], dtype=torch.int64)
+    attn_sink = torch.tensor([0.25, -0.5], dtype=torch.float32)
+    window_size = 3
+    softmax_scale = 0.375
+
+    actual = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_microkernel(
+        q, local_kv, compressed_kv, compressed_idxs, attn_sink, window_size, softmax_scale
+    )
+
+    local_idxs = deepseek_v4_local_window_topk_idxs(window_size, batch_size, seq_len, q.device)
+    compressed_offset = torch.where(
+        compressed_idxs >= 0,
+        compressed_idxs + local_kv.shape[1],
+        compressed_idxs,
+    )
+    topk_idxs = torch.cat([local_idxs, compressed_offset], dim=-1)
+    expected = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+        q, torch.cat([local_kv, compressed_kv], dim=1), attn_sink, topk_idxs, softmax_scale
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(
+        actual,
+        deepseek_v4_sparse_attention_microkernel_ref(
+            q, local_kv, compressed_kv, compressed_idxs, attn_sink, window_size, softmax_scale
+        ),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_fake_implementations_return_expected_shapes_and_dtypes():
+    with FakeTensorMode():
+        batch_size, seq_len, num_heads, head_dim, rope_dim = 2, 3, 4, 8, 4
+        q = torch.empty(batch_size, seq_len, num_heads, head_dim)
+        kv = torch.empty(batch_size, seq_len, head_dim)
+        freqs = torch.empty(batch_size, seq_len, rope_dim // 2, dtype=torch.complex64)
+        cache_indices = torch.empty(batch_size * seq_len, dtype=torch.int64)
+        nope_cache = torch.empty(batch_size * seq_len, head_dim - rope_dim, dtype=FP8_E4M3_DTYPE)
+        rope_cache = torch.empty(batch_size * seq_len, rope_dim, dtype=torch.bfloat16)
+        scale_cache = torch.empty(batch_size * seq_len, 1, dtype=torch.float8_e8m0fnu)
+
+        q_out = torch.ops.auto_deploy.torch_deepseek_v4_q_rmsnorm_rope(
+            q, None, freqs, 1e-6, rope_dim
+        )
+        kv_out, kv_fp8, kv_scale = (
+            torch.ops.auto_deploy.torch_deepseek_v4_kv_rmsnorm_rope_cache_insert(
+                kv,
+                None,
+                freqs,
+                cache_indices,
+                nope_cache,
+                rope_cache,
+                scale_cache,
+                1e-6,
+                rope_dim,
+                128,
+            )
+        )
+        indexer_fp8, indexer_scale = torch.ops.auto_deploy.torch_deepseek_v4_indexer_q_rope_quant(
+            q, freqs, rope_dim, 128, "fp8"
+        )
+
+    assert q_out.shape == q.shape
+    assert kv_out.shape == kv.shape
+    assert kv_fp8.shape == (*kv.shape[:-1], head_dim - rope_dim)
+    assert kv_scale.shape == (*kv.shape[:-1], 1)
+    assert indexer_fp8.shape == q.shape
+    assert indexer_scale.shape == (*q.shape[:-1], 1)
+    assert kv_fp8.dtype == FP8_E4M3_DTYPE
+    assert indexer_fp8.dtype == FP8_E4M3_DTYPE
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA graph replay requires CUDA")
+def test_cuda_graph_replay_for_q_rmsnorm_rope():
+    torch.manual_seed(8)
+    device = torch.device("cuda")
+    batch_size, seq_len, num_heads, head_dim, rope_dim = 2, 4, 3, 8, 4
+    q = torch.randn(batch_size, seq_len, num_heads, head_dim, device=device)
+    freqs = _freqs(batch_size, seq_len, rope_dim, device)
+    weight = torch.linspace(0.75, 1.25, head_dim, device=device)
+
+    for _ in range(3):
+        torch.ops.auto_deploy.torch_deepseek_v4_q_rmsnorm_rope(q, weight, freqs, 1e-6, rope_dim)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        replay_out = torch.ops.auto_deploy.torch_deepseek_v4_q_rmsnorm_rope(
+            q, weight, freqs, 1e-6, rope_dim
+        )
+
+    q.copy_(torch.randn_like(q))
+    expected = torch.ops.auto_deploy.torch_deepseek_v4_q_rmsnorm_rope(
+        q, weight, freqs, 1e-6, rope_dim
+    )
+    graph.replay()
+    torch.testing.assert_close(replay_out, expected, rtol=1e-6, atol=1e-6)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
@@ -33,8 +33,10 @@ def _sparse_attention_reference(
     batch_idx = batch_idx.expand(batch_size, seq_len, topk_idxs.shape[-1])
 
     compute_dtype = torch.float32 if q.dtype in (torch.float16, torch.bfloat16) else q.dtype
-    selected_kv = kv[batch_idx, topk_idxs.to(torch.long)].to(compute_dtype)
+    gather_idxs = topk_idxs.to(torch.long).clamp(min=0)
+    selected_kv = kv[batch_idx, gather_idxs].to(compute_dtype)
     logits = torch.einsum("bshd,bskd->bshk", q.to(compute_dtype), selected_kv) * softmax_scale
+    logits = logits.masked_fill((topk_idxs < 0).unsqueeze(2), float("-inf"))
     sink_logits = attn_sink.to(dtype=compute_dtype).reshape(1, 1, -1, 1)
     sink_logits = sink_logits.expand(batch_size, seq_len, q.shape[2], 1)
     weights_with_sink = torch.softmax(torch.cat([logits, sink_logits], dim=-1), dim=-1)
@@ -88,6 +90,10 @@ def test_output_shape_and_dtype(dtype: torch.dtype):
             torch.tensor([[[1, 1, 4], [2, 5, 2], [3, 3, 3], [6, 0, 6]]], dtype=torch.int32),
             id="duplicate-indices",
         ),
+        pytest.param(
+            torch.tensor([[[0, -1, -1], [1, 2, -1], [3, -1, 4], [5, 6, -1]]], dtype=torch.int32),
+            id="masked-sentinel",
+        ),
     ],
 )
 def test_reference_equality_for_index_patterns(topk_idxs: torch.Tensor):
@@ -116,6 +122,19 @@ def test_duplicate_indices_receive_independent_probability_mass():
     expected = duplicate_weights[0] * kv[:, 0] + duplicate_weights[1] * kv[:, 0]
     expected = expected + duplicate_weights[2] * kv[:, 1]
     torch.testing.assert_close(output[0, 0, 0], expected[0], rtol=1e-6, atol=1e-6)
+
+
+def test_negative_indices_are_masked_before_softmax():
+    q = torch.tensor([[[[1.0, 0.0]]]])
+    kv = torch.tensor([[[1.0, 0.0], [1000.0, 1000.0]]])
+    attn_sink = torch.tensor([0.0])
+    topk_idxs = torch.tensor([[[0, -1]]], dtype=torch.int64)
+
+    output = _run_sparse_attention(q, kv, attn_sink, topk_idxs, softmax_scale=1.0)
+
+    weights = torch.softmax(torch.tensor([1.0, float("-inf"), 0.0]), dim=0)
+    expected = weights[0] * kv[0, 0]
+    torch.testing.assert_close(output[0, 0, 0], expected, rtol=1e-6, atol=1e-6)
 
 
 def test_attention_sink_takes_probability_mass_without_value_vector():

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
@@ -774,6 +774,32 @@ def test_cached_ratio_zero_decode_uses_managed_nhd_page_size_for_swa_cache():
 
 
 @pytest.mark.parametrize(
+    "cache_shape,expected_last_row_index",
+    [
+        pytest.param((2, 2, 1, 1, 3), (1, 1, 0, 0), id="local-unit"),
+        pytest.param((2, 1, 2, 1, 3), (1, 0, 1, 0), id="managed-nhd"),
+        pytest.param((2, 1, 1, 2, 3), (1, 0, 0, 1), id="managed-hnd"),
+    ],
+)
+def test_swa_cache_page_addressing_for_supported_5d_layouts(
+    cache_shape: tuple[int, int, int, int, int],
+    expected_last_row_index: tuple[int, int, int, int],
+) -> None:
+    rows = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+    cache = torch.zeros(cache_shape, dtype=torch.float32)
+    cache_loc = torch.tensor([0, 1], dtype=torch.int)
+    cu_num_pages = torch.tensor([0, 2], dtype=torch.int)
+
+    dsv4_attention._write_swa_cache(rows, cache, cache_loc, cu_num_pages, 0, 0)
+    gathered = dsv4_attention._gather_swa_rows(
+        cache, cache_loc, cu_num_pages, 0, 0, 4, torch.float32
+    )
+
+    torch.testing.assert_close(gathered, rows)
+    torch.testing.assert_close(cache[expected_last_row_index], rows[-1])
+
+
+@pytest.mark.parametrize(
     "ratio,prefix_len,total_len",
     [
         pytest.param(4, 3, 9, id="ratio4-boundary-and-overlap"),

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
@@ -22,6 +22,9 @@ import torch
 
 import tensorrt_llm._torch.auto_deploy  # noqa: F401
 from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention import (
+    deepseek_v4_attention as dsv4_attention,
+)
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_attention import (
     _build_full_compressed_kv,
 )
@@ -475,6 +478,91 @@ def test_attention_sink_takes_probability_mass_without_value_vector():
     assert high_sink_output.norm() < output.norm()
 
 
+def test_chunked_sparse_attention_matches_reference_with_masked_duplicates(monkeypatch):
+    monkeypatch.setattr(dsv4_attention, "_SPARSE_ATTENTION_MAX_CHUNK_TOKENS", 2)
+    torch.manual_seed(23)
+    q = torch.randn(1, 5, 3, 4)
+    kv = torch.randn(1, 7, 4)
+    attn_sink = torch.tensor([-0.5, 0.0, 0.75])
+    topk_idxs = torch.tensor(
+        [[[0, 1, -1, 1], [2, 2, 3, -1], [4, -1, -1, 5], [6, 0, 6, 1], [3, 2, 1, 0]]],
+        dtype=torch.int32,
+    )
+    softmax_scale = 0.625
+
+    actual = _run_sparse_attention(q, kv, attn_sink, topk_idxs, softmax_scale)
+    expected = _sparse_attention_reference(q, kv, attn_sink, topk_idxs, softmax_scale)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_sparse_attention_large_resize_shape_is_chunked():
+    num_tokens = 8192
+    num_heads = 64
+    head_dim = 512
+    k_select = 2176
+
+    chunk_size = dsv4_attention._sparse_attention_query_chunk_size(
+        num_tokens,
+        num_heads,
+        head_dim,
+        k_select,
+        torch.float32,
+    )
+
+    full_logits_bytes = num_tokens * num_heads * k_select * 4
+    chunk_logits_bytes = chunk_size * num_heads * k_select * 4
+    full_selected_kv_bytes = num_tokens * k_select * head_dim * 4
+    chunk_selected_kv_bytes = chunk_size * k_select * head_dim * 4
+
+    assert full_logits_bytes == 4_563_402_752
+    assert chunk_size < num_tokens
+    assert chunk_logits_bytes < full_logits_bytes
+    assert chunk_selected_kv_bytes < full_selected_kv_bytes
+    assert chunk_logits_bytes <= dsv4_attention._SPARSE_ATTENTION_CHUNK_TARGET_BYTES
+
+
+def test_sparse_attention_does_not_materialize_full_selected_kv_or_logits(monkeypatch):
+    monkeypatch.setattr(dsv4_attention, "_SPARSE_ATTENTION_MAX_CHUNK_TOKENS", 2)
+    torch.manual_seed(29)
+    q = torch.randn(1, 5, 2, 4)
+    kv = torch.randn(1, 8, 4)
+    attn_sink = torch.randn(2)
+    topk_idxs = torch.tensor(
+        [[[0, 1, 2], [2, 3, 4], [4, 5, -1], [6, 6, 7], [1, -1, 0]]],
+        dtype=torch.int64,
+    )
+    expected = _sparse_attention_reference(q, kv, attn_sink, topk_idxs, 0.5)
+    original_gather_selected_kv = dsv4_attention._gather_selected_kv
+    original_einsum = torch.einsum
+    gather_shapes = []
+    einsum_shapes = []
+
+    def recording_gather_selected_kv(
+        kv_arg: torch.Tensor,
+        topk_arg: torch.Tensor,
+        batch_idxs: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        gather_shapes.append(tuple(topk_arg.shape))
+        return original_gather_selected_kv(kv_arg, topk_arg, batch_idxs)
+
+    def recording_einsum(equation: str, *operands: torch.Tensor) -> torch.Tensor:
+        einsum_shapes.append((equation, tuple(tuple(operand.shape) for operand in operands)))
+        return original_einsum(equation, *operands)
+
+    monkeypatch.setattr(dsv4_attention, "_gather_selected_kv", recording_gather_selected_kv)
+    monkeypatch.setattr(torch, "einsum", recording_einsum)
+
+    actual = _run_sparse_attention(q, kv, attn_sink, topk_idxs, 0.5)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+    assert gather_shapes
+    assert all(shape[0] <= 2 for shape in gather_shapes)
+    assert (5, 3) not in gather_shapes
+    assert einsum_shapes
+    assert all(operand_shapes[0][0] <= 2 for _, operand_shapes in einsum_shapes)
+
+
 def test_out_buffer_contract_for_piecewise_dynamic_op():
     q = torch.randn(1, 3, 2, 4)
     kv = torch.randn(1, 5, 4)
@@ -622,6 +710,67 @@ def test_cached_ratio_zero_prefill_and_decode_match_full_local_window_reference(
     )
     torch.testing.assert_close(actual_decode, expected_decode, rtol=1e-6, atol=1e-6)
     torch.testing.assert_close(swa_cache[1, 1, 0, 0], kv_decode[0, 0])
+
+
+def test_cached_ratio_zero_decode_uses_managed_nhd_page_size_for_swa_cache():
+    torch.manual_seed(17)
+    prefix_len = 4
+    window_size = 3
+    block_size = 32
+    num_pages = 4
+    num_heads = 2
+    head_dim = 4
+    softmax_scale = 0.5
+
+    q_decode = torch.randn(1, 1, num_heads, head_dim)
+    kv_prefix = torch.randn(1, prefix_len, head_dim)
+    kv_decode = torch.randn(1, 1, head_dim)
+    attn_sink = torch.tensor([0.25, -0.5], dtype=torch.float32)
+    cache_loc = torch.arange(num_pages, dtype=torch.int)
+    cu_num_pages = torch.tensor([0, num_pages], dtype=torch.int)
+    swa_cache = torch.zeros(num_pages, 1, block_size, 1, head_dim)
+    swa_cache[0, 0, :prefix_len, 0].copy_(kv_prefix[0])
+
+    actual = _run_cached_sparse_attention_v2(
+        q_decode,
+        kv_decode,
+        attn_sink,
+        torch.zeros(1, 1, window_size, dtype=torch.int32),
+        torch.empty(1, 1, 0),
+        torch.empty(1, 1, 0),
+        torch.empty(0, 0),
+        torch.empty(0),
+        _freqs_cis_table(8, 2),
+        torch.tensor([[prefix_len]], dtype=torch.int),
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=1),
+        torch.tensor([1], dtype=torch.int),
+        torch.tensor([prefix_len], dtype=torch.int),
+        torch.tensor([0, 1], dtype=torch.int),
+        cache_loc,
+        cu_num_pages,
+        (
+            swa_cache,
+            torch.empty(num_pages, 1, block_size, 1, head_dim),
+            torch.empty(num_pages, 1, block_size, 1, head_dim),
+            torch.empty(num_pages, 1, block_size, 1, head_dim),
+        ),
+        0,
+        0,
+        window_size,
+        2,
+        softmax_scale,
+    )
+
+    full_kv = torch.cat([kv_prefix, kv_decode], dim=1)
+    expected = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+        q_decode,
+        full_kv,
+        attn_sink,
+        torch.tensor([[[prefix_len - window_size + 1, prefix_len - 1, prefix_len]]]),
+        softmax_scale,
+    )
+    torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(swa_cache[0, 0, prefix_len, 0], kv_decode[0, 0])
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the DeepSeek V4 sparse attention source op."""
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
+
+def _sparse_attention_reference(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    batch_size, seq_len, _, _ = q.shape
+    batch_idx = torch.arange(batch_size, device=q.device).reshape(batch_size, 1, 1)
+    batch_idx = batch_idx.expand(batch_size, seq_len, topk_idxs.shape[-1])
+
+    compute_dtype = torch.float32 if q.dtype in (torch.float16, torch.bfloat16) else q.dtype
+    selected_kv = kv[batch_idx, topk_idxs.to(torch.long)].to(compute_dtype)
+    logits = torch.einsum("bshd,bskd->bshk", q.to(compute_dtype), selected_kv) * softmax_scale
+    sink_logits = attn_sink.to(dtype=compute_dtype).reshape(1, 1, -1, 1)
+    sink_logits = sink_logits.expand(batch_size, seq_len, q.shape[2], 1)
+    weights_with_sink = torch.softmax(torch.cat([logits, sink_logits], dim=-1), dim=-1)
+    return torch.einsum("bshk,bskd->bshd", weights_with_sink[..., :-1], selected_kv).to(q.dtype)
+
+
+def _run_sparse_attention(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    softmax_scale: float = 0.25,
+) -> torch.Tensor:
+    return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+        q, kv, attn_sink, topk_idxs, softmax_scale
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_output_shape_and_dtype(dtype: torch.dtype):
+    q = torch.randn(2, 3, 4, 5, dtype=dtype)
+    kv = torch.randn(2, 7, 5, dtype=dtype)
+    attn_sink = torch.randn(4, dtype=torch.float32)
+    topk_idxs = torch.tensor(
+        [
+            [[0, 1, 2], [1, 2, 3], [2, 3, 4]],
+            [[4, 3, 2], [3, 2, 1], [2, 1, 0]],
+        ],
+        dtype=torch.int64,
+    )
+
+    output = _run_sparse_attention(q, kv, attn_sink, topk_idxs)
+
+    assert output.shape == q.shape
+    assert output.dtype == dtype
+    assert output.is_contiguous()
+
+
+@pytest.mark.parametrize(
+    "topk_idxs",
+    [
+        pytest.param(
+            torch.tensor([[[0, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5]]], dtype=torch.int64),
+            id="local-sliding-window",
+        ),
+        pytest.param(
+            torch.tensor([[[7, 2, 5], [6, 0, 4], [5, 1, 3], [4, 7, 2]]], dtype=torch.int64),
+            id="compressed-nonlocal",
+        ),
+        pytest.param(
+            torch.tensor([[[1, 1, 4], [2, 5, 2], [3, 3, 3], [6, 0, 6]]], dtype=torch.int32),
+            id="duplicate-indices",
+        ),
+    ],
+)
+def test_reference_equality_for_index_patterns(topk_idxs: torch.Tensor):
+    torch.manual_seed(7)
+    q = torch.randn(1, 4, 3, 6, dtype=torch.float32)
+    kv = torch.randn(1, 8, 6, dtype=torch.float32)
+    attn_sink = torch.tensor([-0.5, 0.25, 1.0], dtype=torch.float32)
+    softmax_scale = 0.375
+
+    actual = _run_sparse_attention(q, kv, attn_sink, topk_idxs, softmax_scale)
+    expected = _sparse_attention_reference(q, kv, attn_sink, topk_idxs, softmax_scale)
+
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_duplicate_indices_receive_independent_probability_mass():
+    q = torch.tensor([[[[1.0, 0.0]]]])
+    kv = torch.tensor([[[2.0, 0.0], [0.0, 2.0]]])
+    attn_sink = torch.tensor([-20.0])
+    topk_idxs = torch.tensor([[[0, 0, 1]]], dtype=torch.int64)
+
+    output = _run_sparse_attention(q, kv, attn_sink, topk_idxs, softmax_scale=1.0)
+
+    duplicate_logits = torch.tensor([2.0, 2.0, 0.0, -20.0])
+    duplicate_weights = torch.softmax(duplicate_logits, dim=0)
+    expected = duplicate_weights[0] * kv[:, 0] + duplicate_weights[1] * kv[:, 0]
+    expected = expected + duplicate_weights[2] * kv[:, 1]
+    torch.testing.assert_close(output[0, 0, 0], expected[0], rtol=1e-6, atol=1e-6)
+
+
+def test_attention_sink_takes_probability_mass_without_value_vector():
+    q = torch.zeros(1, 1, 1, 2)
+    kv = torch.tensor([[[2.0, 0.0], [0.0, 4.0]]])
+    topk_idxs = torch.tensor([[[0, 1]]], dtype=torch.int64)
+    attn_sink = torch.tensor([0.0])
+
+    output = _run_sparse_attention(q, kv, attn_sink, topk_idxs, softmax_scale=1.0)
+
+    expected = torch.tensor([[[[2.0 / 3.0, 4.0 / 3.0]]]])
+    torch.testing.assert_close(output, expected, rtol=1e-6, atol=1e-6)
+
+    high_sink_output = _run_sparse_attention(
+        q, kv, torch.tensor([10.0]), topk_idxs, softmax_scale=1.0
+    )
+    assert high_sink_output.norm() < output.norm()
+
+
+def test_export_with_dynamic_batch_and_sequence():
+    class SparseAttentionModule(torch.nn.Module):
+        def forward(
+            self,
+            q: torch.Tensor,
+            kv: torch.Tensor,
+            attn_sink: torch.Tensor,
+            topk_idxs: torch.Tensor,
+        ) -> torch.Tensor:
+            return _run_sparse_attention(q, kv, attn_sink, topk_idxs, softmax_scale=0.5)
+
+    batch = torch.export.Dim("batch", min=1, max=4)
+    seq = torch.export.Dim("seq", min=1, max=8)
+    kv_rows = torch.export.Dim("kv_rows", min=4, max=12)
+    k_select = torch.export.Dim("k_select", min=1, max=4)
+
+    q = torch.randn(2, 3, 2, 4)
+    kv = torch.randn(2, 6, 4)
+    attn_sink = torch.randn(2)
+    topk_idxs = torch.tensor(
+        [
+            [[0, 1], [2, 3], [4, 5]],
+            [[5, 4], [3, 2], [1, 0]],
+        ],
+        dtype=torch.int64,
+    )
+
+    exported = torch.export.export(
+        SparseAttentionModule(),
+        (q, kv, attn_sink, topk_idxs),
+        dynamic_shapes={
+            "q": {0: batch, 1: seq},
+            "kv": {0: batch, 1: kv_rows},
+            "attn_sink": {},
+            "topk_idxs": {0: batch, 1: seq, 2: k_select},
+        },
+    )
+
+    assert any(
+        "torch_deepseek_v4_sparse_attention" in str(node.target) for node in exported.graph.nodes
+    )
+
+    q_alt = torch.randn(1, 4, 2, 4)
+    kv_alt = torch.randn(1, 7, 4)
+    attn_sink_alt = torch.randn(2)
+    topk_idxs_alt = torch.tensor([[[0, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5]]])
+    output = exported.module()(q_alt, kv_alt, attn_sink_alt, topk_idxs_alt)
+    assert output.shape == q_alt.shape

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
@@ -154,6 +154,22 @@ def test_attention_sink_takes_probability_mass_without_value_vector():
     assert high_sink_output.norm() < output.norm()
 
 
+def test_out_buffer_contract_for_piecewise_dynamic_op():
+    q = torch.randn(1, 3, 2, 4)
+    kv = torch.randn(1, 5, 4)
+    attn_sink = torch.randn(2)
+    topk_idxs = torch.tensor([[[0, 1], [1, 2], [2, 3]]], dtype=torch.int64)
+    expected = _run_sparse_attention(q, kv, attn_sink, topk_idxs, softmax_scale=0.5)
+    out = torch.empty_like(q)
+
+    result = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+        q, kv, attn_sink, topk_idxs, 0.5, out=out
+    )
+
+    assert result.numel() == 0
+    torch.testing.assert_close(out, expected)
+
+
 def test_export_with_dynamic_batch_and_sequence():
     class SparseAttentionModule(torch.nn.Module):
         def forward(

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
@@ -205,6 +205,7 @@ def _run_cached_sparse_attention_v2(
     window_size: int,
     rope_dim: int,
     softmax_scale: float,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache(
         q,
@@ -230,6 +231,7 @@ def _run_cached_sparse_attention_v2(
         max_compressed_len,
         1e-6,
         rope_dim,
+        out=out,
     )
 
 
@@ -638,6 +640,17 @@ def test_deepseek_v4_sparse_backend_is_registered():
     )
     assert (
         descriptor.get_cached_attention_op()
+        == torch.ops.auto_deploy.triton_deepseek_v4_sparse_attention_v2_with_cache.default
+    )
+
+
+def test_deepseek_v4_sparse_backend_debug_switch_uses_torch_reference(monkeypatch):
+    descriptor = AttentionRegistry.get("deepseek_v4_sparse")
+
+    monkeypatch.setenv(dsv4_attention._DSV4_FORCE_TORCH_REFERENCE_ENV, "1")
+
+    assert (
+        descriptor.get_cached_attention_op()
         == torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache.default
     )
 
@@ -897,6 +910,137 @@ def test_cached_ratio128_emits_row_at_compression_boundary():
     )
 
 
+def test_cached_ratio128_second_block_close_matches_full_source_and_out_buffer():
+    fixture = _prefill_decode_fixture(ratio=128, prefix_len=255, total_len=256)
+    _, mhc_cache, _, _ = fixture["caches"]
+
+    expected_compressed = _expected_compressed_kv(fixture)
+
+    torch.testing.assert_close(
+        mhc_cache[0, 0, 0, 0],
+        expected_compressed[0, 0],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    torch.testing.assert_close(
+        mhc_cache[0, 1, 0, 0],
+        expected_compressed[0, 1],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    torch.testing.assert_close(
+        fixture["decode"],
+        fixture["full"][:, 255:],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+    replay_caches = tuple(cache.clone() for cache in fixture["caches"])
+    out = torch.empty_like(fixture["q"][:, 255:256])
+    sentinel = _run_cached_sparse_attention_v2(
+        fixture["q"][:, 255:256],
+        fixture["kv"][:, 255:256],
+        torch.tensor([-0.2, 0.35]),
+        torch.zeros(1, 1, fixture["window_size"], dtype=torch.int32),
+        fixture["compressor_kv"][:, 255:256],
+        fixture["compressor_gate"][:, 255:256],
+        fixture["compressor_ape"],
+        fixture["compressor_norm_weight"],
+        fixture["freqs_cis_table"],
+        fixture["position_ids"][:, 255:256],
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=1),
+        torch.tensor([1], dtype=torch.int),
+        torch.tensor([255], dtype=torch.int),
+        torch.tensor([0, 1], dtype=torch.int),
+        fixture["cache_loc"],
+        fixture["cu_num_pages"],
+        replay_caches,
+        128,
+        fixture["max_compressed_len"],
+        fixture["window_size"],
+        fixture["rope_dim"],
+        fixture["softmax_scale"],
+        out=out,
+    )
+
+    assert sentinel.numel() == 0
+    torch.testing.assert_close(out, fixture["full"][:, 255:256], rtol=1e-5, atol=1e-5)
+
+
+def test_cached_ratio128_visibility_is_capped_by_max_compressed_len():
+    head_dim = 4
+    window_size = 3
+    block_size = 128
+    ratio = 128
+    max_compressed_len = 1
+    softmax_scale = 0.5
+
+    cache_loc, cu_num_pages, swa_cache, mhc_cache, compressor_kv_cache, compressor_gate_cache = (
+        _compressed_caches(256, block_size, head_dim, head_dim)
+    )
+    swa_cache = swa_cache.to(torch.bfloat16)
+    mhc_cache = mhc_cache.to(torch.bfloat16)
+    caches = (swa_cache, mhc_cache, compressor_kv_cache, compressor_gate_cache)
+
+    row_253 = torch.tensor([0.25, -0.5, 0.75, 0.0], dtype=torch.bfloat16)
+    row_254 = torch.tensor([-0.25, 0.5, 0.25, 1.0], dtype=torch.bfloat16)
+    compressed_row_0 = torch.tensor([0.0, 2.0, 0.0, -0.5], dtype=torch.bfloat16)
+    poison_row = torch.full((head_dim,), 1000.0, dtype=torch.bfloat16)
+    swa_cache[1, 125, 0, 0].copy_(row_253)
+    swa_cache[1, 126, 0, 0].copy_(row_254)
+    mhc_cache[0, 0, 0, 0].copy_(compressed_row_0)
+    mhc_cache[0, 1, 0, 0].copy_(poison_row)
+
+    q = torch.tensor([[[[1.0, 0.5, -0.25, 0.125]]]], dtype=torch.bfloat16)
+    kv = torch.tensor([[[1.0, 0.0, -1.0, 0.5]]], dtype=torch.bfloat16)
+    attn_sink = torch.tensor([-3.0], dtype=torch.float32)
+    topk_idxs = torch.zeros(1, 1, 192, dtype=torch.int32)
+    compressor_kv = torch.full((1, 1, head_dim), 5.0, dtype=torch.bfloat16)
+    compressor_gate = torch.zeros_like(compressor_kv)
+    compressor_ape = torch.zeros(ratio, head_dim, dtype=torch.bfloat16)
+    compressor_norm_weight = torch.ones(head_dim, dtype=torch.float32)
+    freqs_cis_table = _freqs_cis_table(256 + ratio, rope_dim=0)
+    position_ids = torch.tensor([[255]], dtype=torch.int)
+
+    actual = _run_cached_sparse_attention_v2(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=1),
+        torch.tensor([1], dtype=torch.int),
+        torch.tensor([255], dtype=torch.int),
+        torch.tensor([0, 1], dtype=torch.int),
+        cache_loc,
+        cu_num_pages,
+        caches,
+        ratio,
+        max_compressed_len,
+        window_size,
+        0,
+        softmax_scale,
+    )
+
+    expected_kv = torch.stack([row_253, row_254, kv[0, 0], compressed_row_0]).unsqueeze(0)
+    expected_topk = torch.tensor([[[0, 1, 2, 3]]], dtype=torch.int32)
+    expected = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+        q,
+        expected_kv,
+        attn_sink,
+        expected_topk,
+        softmax_scale,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(mhc_cache[0, 1, 0, 0], poison_row, rtol=0, atol=0)
+
+
 def test_cached_compressed_decode_masks_future_compressed_rows_before_boundary():
     fixture = _prefill_decode_fixture(ratio=4, prefix_len=2, total_len=3)
     swa_cache, mhc_cache, _, _ = fixture["caches"]
@@ -1037,7 +1181,7 @@ def test_cache_insertion_replaces_compressed_v2_source_with_cached_op():
     cached_node = next(
         node
         for node in transformed.graph.nodes
-        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache)
+        if is_op(node, torch.ops.auto_deploy.triton_deepseek_v4_sparse_attention_v2_with_cache)
     )
     window_size, compress_ratio, max_compressed_len, rms_norm_eps, rope_dim = extract_op_args(
         cached_node,
@@ -1049,7 +1193,9 @@ def test_cache_insertion_replaces_compressed_v2_source_with_cached_op():
     )
     assert info.num_matches == 1
     assert torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2.default not in targets
-    assert torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache.default in targets
+    assert (
+        torch.ops.auto_deploy.triton_deepseek_v4_sparse_attention_v2_with_cache.default in targets
+    )
     assert window_size == 3
     assert compress_ratio == 4
     assert max_compressed_len == 2

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py
@@ -15,10 +15,27 @@
 
 """Tests for the DeepSeek V4 sparse attention source op."""
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 import tensorrt_llm._torch.auto_deploy  # noqa: F401
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_attention import (
+    _build_full_compressed_kv,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention.deepseek_v4_kernels import (
+    deepseek_v4_local_window_topk_idxs,
+)
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import (
+    AttentionRegistry,
+    BatchInfo,
+)
+from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
+from tensorrt_llm._torch.auto_deploy.transform.library.kvcache import InsertCachedAttention
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_op_args, is_op
 
 
 def _sparse_attention_reference(
@@ -52,6 +69,310 @@ def _run_sparse_attention(
 ) -> torch.Tensor:
     return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
         q, kv, attn_sink, topk_idxs, softmax_scale
+    )
+
+
+def _batch_info(num_prefill: int, num_prefill_tokens: int, num_decode: int) -> torch.Tensor:
+    batch_info = BatchInfo()
+    batch_info.update([num_prefill, num_prefill_tokens, 0, 0, num_decode, num_decode])
+    batch_info.update_tokens_gather_info(num_prefill_tokens + num_decode, False)
+    return batch_info.serialize()
+
+
+def _paged_cache_metadata(
+    seq_lens: list[int], block_size: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cache_loc = []
+    cu_num_pages = [0]
+    next_page = 0
+    for seq_len in seq_lens:
+        num_pages = (seq_len + block_size - 1) // block_size
+        cache_loc.extend(range(next_page, next_page + num_pages))
+        next_page += num_pages
+        cu_num_pages.append(len(cache_loc))
+    return torch.tensor(cache_loc, dtype=torch.int), torch.tensor(cu_num_pages, dtype=torch.int)
+
+
+def _freqs_cis_table(max_position: int, rope_dim: int) -> torch.Tensor:
+    freqs = 1.0 / (10000.0 ** (torch.arange(0, rope_dim, 2, dtype=torch.float32) / rope_dim))
+    phases = torch.arange(max_position, dtype=torch.float32).unsqueeze(1) * freqs.unsqueeze(0)
+    return torch.polar(torch.ones_like(phases), phases)
+
+
+def _compressed_topk_idxs(
+    ratio: int,
+    batch_size: int,
+    seq_len: int,
+    offset: int,
+    max_compressed_len: int,
+) -> torch.Tensor:
+    compressed = torch.arange(max_compressed_len)
+    matrix = compressed.unsqueeze(0).expand(seq_len, -1)
+    valid_lengths = torch.arange(1, seq_len + 1).unsqueeze(1) // ratio
+    matrix = torch.where(matrix < valid_lengths, matrix + offset, -1)
+    return matrix.unsqueeze(0).expand(batch_size, -1, -1).to(torch.int32)
+
+
+def _compressed_source_topk(
+    ratio: int,
+    batch_size: int,
+    seq_len: int,
+    window_size: int,
+    max_compressed_len: int,
+) -> torch.Tensor:
+    local = deepseek_v4_local_window_topk_idxs(
+        window_size, batch_size, seq_len, torch.device("cpu")
+    )
+    compressed = _compressed_topk_idxs(ratio, batch_size, seq_len, seq_len, max_compressed_len)
+    return torch.cat([local.to(torch.int32), compressed], dim=-1)
+
+
+def _compressed_caches(
+    total_len: int,
+    block_size: int,
+    head_dim: int,
+    compressor_state_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    cache_loc, cu_num_pages = _paged_cache_metadata([total_len], block_size)
+    num_pages = len(cache_loc)
+    swa_cache = torch.zeros(num_pages, block_size, 1, 1, head_dim)
+    mhc_cache = torch.zeros(num_pages, block_size, 1, 1, head_dim)
+    compressor_kv_cache = torch.zeros(num_pages, block_size, 1, 1, compressor_state_dim)
+    compressor_gate_cache = torch.zeros(num_pages, block_size, 1, 1, compressor_state_dim)
+    return cache_loc, cu_num_pages, swa_cache, mhc_cache, compressor_kv_cache, compressor_gate_cache
+
+
+def _run_sparse_attention_v2(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    ratio: int,
+    max_compressed_len: int,
+    window_size: int,
+    rope_dim: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        softmax_scale,
+        window_size=window_size,
+        compress_ratio=ratio,
+        max_compressed_len=max_compressed_len,
+        rope_dim=rope_dim,
+        rms_norm_eps=1e-6,
+    )
+
+
+def _run_cached_sparse_attention_v2(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_idxs: torch.Tensor,
+    compressor_kv: torch.Tensor,
+    compressor_gate: torch.Tensor,
+    compressor_ape: torch.Tensor,
+    compressor_norm_weight: torch.Tensor,
+    freqs_cis_table: torch.Tensor,
+    position_ids: torch.Tensor,
+    batch_info: torch.Tensor,
+    seq_len: torch.Tensor,
+    input_pos: torch.Tensor,
+    cu_seqlen: torch.Tensor,
+    cache_loc: torch.Tensor,
+    cu_num_pages: torch.Tensor,
+    caches: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+    ratio: int,
+    max_compressed_len: int,
+    window_size: int,
+    rope_dim: int,
+    softmax_scale: float,
+) -> torch.Tensor:
+    return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        batch_info,
+        seq_len,
+        input_pos,
+        cu_seqlen,
+        cache_loc,
+        cu_num_pages,
+        *caches,
+        softmax_scale,
+        window_size,
+        ratio,
+        max_compressed_len,
+        1e-6,
+        rope_dim,
+    )
+
+
+def _prefill_decode_fixture(ratio: int, prefix_len: int, total_len: int):
+    torch.manual_seed(100 + ratio)
+    batch_size = 1
+    num_heads = 2
+    head_dim = 6
+    rope_dim = 2
+    window_size = 3
+    block_size = 4
+    softmax_scale = 0.375
+    channels = 2 if ratio == 4 else 1
+    max_compressed_len = (total_len + ratio - 1) // ratio
+
+    q = torch.randn(batch_size, total_len, num_heads, head_dim)
+    kv = torch.randn(batch_size, total_len, head_dim)
+    compressor_kv = torch.randn(batch_size, total_len, channels * head_dim)
+    compressor_gate = torch.randn(batch_size, total_len, channels * head_dim)
+    compressor_ape = torch.randn(ratio, channels * head_dim)
+    compressor_norm_weight = torch.randn(head_dim)
+    freqs_cis_table = _freqs_cis_table(total_len + ratio, rope_dim)
+    position_ids = torch.arange(total_len).view(1, -1)
+    attn_sink = torch.tensor([-0.2, 0.35])
+
+    full_topk = _compressed_source_topk(
+        ratio, batch_size, total_len, window_size, max_compressed_len
+    )
+    full = _run_sparse_attention_v2(
+        q,
+        kv,
+        attn_sink,
+        full_topk,
+        compressor_kv,
+        compressor_gate,
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids,
+        ratio,
+        max_compressed_len,
+        window_size,
+        rope_dim,
+        softmax_scale,
+    )
+
+    cache_loc, cu_num_pages, *cache_list = _compressed_caches(
+        total_len, block_size, head_dim, channels * head_dim
+    )
+    caches = tuple(cache_list)
+    prefix_topk = _compressed_source_topk(
+        ratio, batch_size, prefix_len, window_size, max_compressed_len
+    )
+    prefix = _run_cached_sparse_attention_v2(
+        q[:, :prefix_len],
+        kv[:, :prefix_len],
+        attn_sink,
+        prefix_topk,
+        compressor_kv[:, :prefix_len],
+        compressor_gate[:, :prefix_len],
+        compressor_ape,
+        compressor_norm_weight,
+        freqs_cis_table,
+        position_ids[:, :prefix_len],
+        _batch_info(num_prefill=1, num_prefill_tokens=prefix_len, num_decode=0),
+        torch.tensor([prefix_len], dtype=torch.int),
+        torch.tensor([0], dtype=torch.int),
+        torch.tensor([0, prefix_len], dtype=torch.int),
+        cache_loc,
+        cu_num_pages,
+        caches,
+        ratio,
+        max_compressed_len,
+        window_size,
+        rope_dim,
+        softmax_scale,
+    )
+
+    decode_outputs = []
+    dummy_topk = torch.zeros(batch_size, 1, window_size, dtype=torch.int32)
+    for pos in range(prefix_len, total_len):
+        decode_outputs.append(
+            _run_cached_sparse_attention_v2(
+                q[:, pos : pos + 1],
+                kv[:, pos : pos + 1],
+                attn_sink,
+                dummy_topk,
+                compressor_kv[:, pos : pos + 1],
+                compressor_gate[:, pos : pos + 1],
+                compressor_ape,
+                compressor_norm_weight,
+                freqs_cis_table,
+                position_ids[:, pos : pos + 1],
+                _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=1),
+                torch.tensor([1], dtype=torch.int),
+                torch.tensor([pos], dtype=torch.int),
+                torch.tensor([0, 1], dtype=torch.int),
+                cache_loc,
+                cu_num_pages,
+                caches,
+                ratio,
+                max_compressed_len,
+                window_size,
+                rope_dim,
+                softmax_scale,
+            )
+        )
+
+    decode = torch.cat(decode_outputs, dim=1)
+    return {
+        "full": full,
+        "prefix": prefix,
+        "decode": decode,
+        "q": q,
+        "kv": kv,
+        "compressor_kv": compressor_kv,
+        "compressor_gate": compressor_gate,
+        "compressor_ape": compressor_ape,
+        "compressor_norm_weight": compressor_norm_weight,
+        "freqs_cis_table": freqs_cis_table,
+        "position_ids": position_ids,
+        "caches": caches,
+        "cache_loc": cache_loc,
+        "cu_num_pages": cu_num_pages,
+        "prefix_len": prefix_len,
+        "ratio": ratio,
+        "max_compressed_len": max_compressed_len,
+        "rope_dim": rope_dim,
+        "window_size": window_size,
+        "softmax_scale": softmax_scale,
+        "head_dim": head_dim,
+    }
+
+
+def _expected_compressed_kv(fixture: dict[str, torch.Tensor]) -> torch.Tensor:
+    return _build_full_compressed_kv(
+        fixture["compressor_kv"],
+        fixture["compressor_gate"],
+        fixture["compressor_ape"],
+        fixture["compressor_norm_weight"],
+        fixture["freqs_cis_table"],
+        fixture["position_ids"],
+        1e-6,
+        fixture["rope_dim"],
+        fixture["ratio"],
+        fixture["max_compressed_len"],
     )
 
 
@@ -218,3 +539,347 @@ def test_export_with_dynamic_batch_and_sequence():
     topk_idxs_alt = torch.tensor([[[0, 1, 2], [1, 2, 3], [2, 3, 4], [3, 4, 5]]])
     output = exported.module()(q_alt, kv_alt, attn_sink_alt, topk_idxs_alt)
     assert output.shape == q_alt.shape
+
+
+def test_deepseek_v4_sparse_backend_is_registered():
+    assert AttentionRegistry.has("deepseek_v4_sparse")
+    descriptor = AttentionRegistry.get("deepseek_v4_sparse")
+    assert (
+        descriptor.get_source_attention_op()
+        == torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2
+    )
+    assert (
+        descriptor.get_cached_attention_op()
+        == torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache.default
+    )
+
+
+def test_cached_ratio_zero_prefill_and_decode_match_full_local_window_reference():
+    torch.manual_seed(11)
+    prefix_len = 5
+    window_size = 3
+    block_size = 4
+    num_heads = 2
+    head_dim = 4
+    softmax_scale = 0.5
+
+    q_prefill = torch.randn(1, prefix_len, num_heads, head_dim)
+    kv_prefill = torch.randn(1, prefix_len, head_dim)
+    attn_sink = torch.tensor([0.25, -0.5], dtype=torch.float32)
+    cache_loc, cu_num_pages = _paged_cache_metadata([prefix_len + 1], block_size)
+    swa_cache = torch.zeros(len(cache_loc), block_size, 1, 1, head_dim)
+    topk_prefill = deepseek_v4_local_window_topk_idxs(
+        window_size, 1, prefix_len, q_prefill.device
+    ).to(torch.int32)
+
+    actual_prefill = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_with_cache(
+        q_prefill,
+        kv_prefill,
+        attn_sink,
+        topk_prefill,
+        _batch_info(num_prefill=1, num_prefill_tokens=prefix_len, num_decode=0),
+        torch.tensor([prefix_len], dtype=torch.int),
+        torch.tensor([0], dtype=torch.int),
+        torch.tensor([0, prefix_len], dtype=torch.int),
+        cache_loc,
+        cu_num_pages,
+        swa_cache,
+        softmax_scale,
+        window_size,
+        0,
+    )
+    expected_prefill = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+        q_prefill, kv_prefill, attn_sink, topk_prefill, softmax_scale
+    )
+    torch.testing.assert_close(actual_prefill, expected_prefill, rtol=1e-6, atol=1e-6)
+
+    q_decode = torch.randn(1, 1, num_heads, head_dim)
+    kv_decode = torch.randn(1, 1, head_dim)
+    actual_decode = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_with_cache(
+        q_decode,
+        kv_decode,
+        attn_sink,
+        torch.zeros(1, 1, window_size, dtype=torch.int32),
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=1),
+        torch.tensor([1], dtype=torch.int),
+        torch.tensor([prefix_len], dtype=torch.int),
+        torch.tensor([0, 1], dtype=torch.int),
+        cache_loc,
+        cu_num_pages,
+        swa_cache,
+        softmax_scale,
+        window_size,
+        0,
+    )
+
+    full_kv = torch.cat([kv_prefill, kv_decode], dim=1)
+    expected_decode = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+        q_decode,
+        full_kv,
+        attn_sink,
+        torch.tensor([[[prefix_len - window_size + 1, prefix_len - 1, prefix_len]]]),
+        softmax_scale,
+    )
+    torch.testing.assert_close(actual_decode, expected_decode, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(swa_cache[1, 1, 0, 0], kv_decode[0, 0])
+
+
+@pytest.mark.parametrize(
+    "ratio,prefix_len,total_len",
+    [
+        pytest.param(4, 3, 9, id="ratio4-boundary-and-overlap"),
+        pytest.param(128, 127, 130, id="ratio128-boundary"),
+    ],
+)
+def test_cached_compressed_prefill_plus_decode_matches_full_source(
+    ratio: int, prefix_len: int, total_len: int
+):
+    fixture = _prefill_decode_fixture(ratio, prefix_len, total_len)
+
+    torch.testing.assert_close(
+        fixture["prefix"],
+        fixture["full"][:, :prefix_len],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    torch.testing.assert_close(
+        fixture["decode"],
+        fixture["full"][:, prefix_len:],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
+def test_cached_ratio4_emits_overlap_row_at_compression_boundary():
+    fixture = _prefill_decode_fixture(ratio=4, prefix_len=7, total_len=8)
+    _, mhc_cache, _, _ = fixture["caches"]
+
+    expected_compressed = _expected_compressed_kv(fixture)
+
+    torch.testing.assert_close(
+        mhc_cache[0, 1, 0, 0],
+        expected_compressed[0, 1],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    torch.testing.assert_close(fixture["decode"], fixture["full"][:, 7:], rtol=1e-5, atol=1e-5)
+
+    mutated_caches = tuple(cache.clone() for cache in fixture["caches"])
+    mutated_mhc_cache = mutated_caches[1]
+    mutated_compressor_kv_cache = mutated_caches[2]
+    head_dim = fixture["head_dim"]
+    mutated_compressor_kv_cache[0, :4, 0, 0, :head_dim] += 1000.0
+
+    _run_cached_sparse_attention_v2(
+        fixture["q"][:, 7:8],
+        fixture["kv"][:, 7:8],
+        torch.tensor([-0.2, 0.35]),
+        torch.zeros(1, 1, fixture["window_size"], dtype=torch.int32),
+        fixture["compressor_kv"][:, 7:8],
+        fixture["compressor_gate"][:, 7:8],
+        fixture["compressor_ape"],
+        fixture["compressor_norm_weight"],
+        fixture["freqs_cis_table"],
+        fixture["position_ids"][:, 7:8],
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=1),
+        torch.tensor([1], dtype=torch.int),
+        torch.tensor([7], dtype=torch.int),
+        torch.tensor([0, 1], dtype=torch.int),
+        fixture["cache_loc"],
+        fixture["cu_num_pages"],
+        mutated_caches,
+        4,
+        fixture["max_compressed_len"],
+        fixture["window_size"],
+        fixture["rope_dim"],
+        fixture["softmax_scale"],
+    )
+    assert not torch.allclose(
+        mutated_mhc_cache[0, 1, 0, 0],
+        expected_compressed[0, 1],
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+
+def test_cached_ratio128_emits_row_at_compression_boundary():
+    fixture = _prefill_decode_fixture(ratio=128, prefix_len=127, total_len=128)
+    _, mhc_cache, _, _ = fixture["caches"]
+
+    expected_compressed = _expected_compressed_kv(fixture)
+
+    torch.testing.assert_close(
+        mhc_cache[0, 0, 0, 0],
+        expected_compressed[0, 0],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+    torch.testing.assert_close(
+        fixture["decode"],
+        fixture["full"][:, 127:],
+        rtol=1e-5,
+        atol=1e-5,
+    )
+
+
+def test_cached_compressed_decode_masks_future_compressed_rows_before_boundary():
+    fixture = _prefill_decode_fixture(ratio=4, prefix_len=2, total_len=3)
+    swa_cache, mhc_cache, _, _ = fixture["caches"]
+    mhc_cache.fill_(1000.0)
+
+    q = fixture["q"][:, 2:3]
+    kv = fixture["kv"][:, 2:3]
+    attn_sink = torch.tensor([-0.2, 0.35])
+    local_topk = torch.tensor([[[0, 1, 2]]], dtype=torch.int64)
+    local_kv = fixture["kv"][:, :3]
+    expected = torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention(
+        q,
+        local_kv,
+        attn_sink,
+        local_topk,
+        0.375,
+    )
+
+    cache_loc, cu_num_pages = _paged_cache_metadata([3], 4)
+    caches = (
+        swa_cache,
+        mhc_cache,
+        fixture["caches"][2],
+        fixture["caches"][3],
+    )
+    actual = _run_cached_sparse_attention_v2(
+        q,
+        kv,
+        attn_sink,
+        torch.zeros(1, 1, 3, dtype=torch.int32),
+        fixture["compressor_kv"][:, 2:3],
+        fixture["compressor_gate"][:, 2:3],
+        fixture["compressor_ape"],
+        fixture["compressor_norm_weight"],
+        fixture["freqs_cis_table"],
+        fixture["position_ids"][:, 2:3],
+        _batch_info(num_prefill=0, num_prefill_tokens=0, num_decode=1),
+        torch.tensor([1], dtype=torch.int),
+        torch.tensor([2], dtype=torch.int),
+        torch.tensor([0, 1], dtype=torch.int),
+        cache_loc,
+        cu_num_pages,
+        caches,
+        4,
+        fixture["max_compressed_len"],
+        3,
+        fixture["rope_dim"],
+        0.375,
+    )
+
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_cache_insertion_replaces_compressed_v2_source_with_cached_op():
+    class CompressedV2Module(torch.nn.Module):
+        def forward(
+            self,
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            position_ids,
+        ):
+            return torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2(
+                q,
+                kv,
+                attn_sink,
+                topk_idxs,
+                compressor_kv,
+                compressor_gate,
+                compressor_ape,
+                compressor_norm_weight,
+                freqs_cis_table,
+                position_ids,
+                0.375,
+                layer_idx=0,
+                window_size=3,
+                compress_ratio=4,
+                max_compressed_len=2,
+                head_dim=6,
+                rope_dim=2,
+                rms_norm_eps=1e-6,
+            )
+
+    q = torch.randn(1, 4, 2, 6)
+    kv = torch.randn(1, 4, 6)
+    attn_sink = torch.randn(2)
+    topk_idxs = _compressed_source_topk(4, 1, 4, 3, 2)
+    compressor_kv = torch.randn(1, 4, 12)
+    compressor_gate = torch.randn(1, 4, 12)
+    compressor_ape = torch.randn(4, 12)
+    compressor_norm_weight = torch.randn(6)
+    freqs_cis_table = _freqs_cis_table(8, 2)
+    position_ids = torch.arange(4).view(1, -1)
+    gm = torch.export.export(
+        CompressedV2Module(),
+        (
+            q,
+            kv,
+            attn_sink,
+            topk_idxs,
+            compressor_kv,
+            compressor_gate,
+            compressor_ape,
+            compressor_norm_weight,
+            freqs_cis_table,
+            position_ids,
+        ),
+    ).module()
+
+    cm = CachedSequenceInterface(
+        max_seq_len=16,
+        max_batch_size=1,
+        max_num_tokens=16,
+        device="cpu",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=4,
+            max_tokens=16,
+            free_gpu_memory_fraction=0.0,
+        ),
+    )
+    transform = InsertCachedAttention.from_kwargs(
+        stage=Stages.CACHE_INIT,
+        backend="deepseek_v4_sparse",
+        run_graph_cleanup=False,
+        requires_clean_graph=False,
+    )
+
+    transformed, info = transform._apply(gm, cm, SimpleNamespace(), SharedConfig())
+
+    targets = {node.target for node in transformed.graph.nodes if node.op == "call_function"}
+    placeholder_names = {node.name for node in transformed.graph.nodes if node.op == "placeholder"}
+    cached_node = next(
+        node
+        for node in transformed.graph.nodes
+        if is_op(node, torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache)
+    )
+    window_size, compress_ratio, max_compressed_len, rms_norm_eps, rope_dim = extract_op_args(
+        cached_node,
+        "window_size",
+        "compress_ratio",
+        "max_compressed_len",
+        "rms_norm_eps",
+        "rope_dim",
+    )
+    assert info.num_matches == 1
+    assert torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2.default not in targets
+    assert torch.ops.auto_deploy.torch_deepseek_v4_sparse_attention_v2_with_cache.default in targets
+    assert window_size == 3
+    assert compress_ratio == 4
+    assert max_compressed_len == 2
+    assert rms_norm_eps == 1e-6
+    assert rope_dim == 2
+    assert any("mhc_cache" in name for name in placeholder_names)
+    assert any("compressor_kv_cache" in name for name in placeholder_names)
+    assert any("compressor_gate_cache" in name for name in placeholder_names)

--- a/tests/unittest/auto_deploy/singlegpu/test_example_configs.py
+++ b/tests/unittest/auto_deploy/singlegpu/test_example_configs.py
@@ -134,6 +134,7 @@ def test_deepseek_v4_flash_uses_attention_and_moe_ir_sharding_for_full_model_con
     )
 
     assert args.world_size == 8
+    assert args.attn_backend == "deepseek_v4_sparse"
     assert args.transforms["detect_sharding"]["enabled"] is False
     assert args.transforms["sharding_transform_executor"]["enabled"] is False
     assert args.transforms["apply_sharding_hints"]["enabled"] is True
@@ -145,3 +146,4 @@ def test_deepseek_v4_flash_uses_attention_and_moe_ir_sharding_for_full_model_con
     }
     assert args.transforms["apply_sharding_hints"]["enable_attention_dp"] is False
     assert args.transforms["apply_sharding_hints"]["shard_layers"] == ["mla", "moe"]
+    assert args.transforms["insert_cached_attention"]["backend"] == "deepseek_v4_sparse"

--- a/tests/unittest/auto_deploy/singlegpu/test_example_configs.py
+++ b/tests/unittest/auto_deploy/singlegpu/test_example_configs.py
@@ -28,13 +28,14 @@ from pydantic import ValidationError
 from tensorrt_llm._torch.auto_deploy.llm_args import LlmArgs
 
 # Root directory for the example configs
-_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
 _AD_EXAMPLES_DIR = _REPO_ROOT / "examples" / "auto_deploy"
 
 # Files that are not LlmArgs configs and should be excluded from validation
 _EXCLUDED_FILES = {
     "models.yaml",  # model registry index, not an LlmArgs config
     "flux_transforms.yaml",  # for build_and_run_flux.py, different schema
+    "nemotron_fp8_ir_test.yaml",  # build_and_run_ad ExperimentConfig, not an LlmArgs config
 }
 
 # Dummy model name used during validation (model path is not resolved during construction)
@@ -95,3 +96,52 @@ def test_config_yaml_dry_run_ingestion(config_yaml_path):
     except ValidationError as e:
         if not _is_cross_validation_error(e):
             raise
+
+
+def test_functional_single_request_cuda_graph_overrides_deepseek_v4_dashboard_config():
+    """Functional gates can stack a final config to avoid capturing dashboard batch sizes."""
+    config_dir = _AD_EXAMPLES_DIR / "model_registry" / "configs"
+    args = LlmArgs(
+        model=_DUMMY_MODEL,
+        yaml_extra=[
+            str(config_dir / "dashboard_default.yaml"),
+            str(config_dir / "world_size_8.yaml"),
+            str(config_dir / "deepseek_v4_flash.yaml"),
+            str(config_dir / "num_hidden_layers_5.yaml"),
+            str(config_dir / "functional_single_request_cuda_graph.yaml"),
+        ],
+    )
+
+    assert args.model_kwargs["num_hidden_layers"] == 5
+    assert args.max_batch_size == 1
+    assert args.cuda_graph_config is not None
+    assert args.cuda_graph_config.max_batch_size == 1
+    assert args.cuda_graph_config.batch_sizes == [1]
+    assert args.transforms["compile_model"]["cuda_graph_batch_sizes"] == [1]
+
+
+def test_deepseek_v4_flash_uses_attention_and_moe_ir_sharding_for_full_model_config():
+    """Full DeepSeek V4 runs shard attention and packed MoE weights before checkpoint load."""
+    config_dir = _AD_EXAMPLES_DIR / "model_registry" / "configs"
+    args = LlmArgs(
+        model=_DUMMY_MODEL,
+        yaml_extra=[
+            str(config_dir / "dashboard_default.yaml"),
+            str(config_dir / "world_size_8.yaml"),
+            str(config_dir / "deepseek_v4_flash.yaml"),
+            str(config_dir / "functional_single_request_cuda_graph.yaml"),
+        ],
+    )
+
+    assert args.world_size == 8
+    assert args.transforms["detect_sharding"]["enabled"] is False
+    assert args.transforms["sharding_transform_executor"]["enabled"] is False
+    assert args.transforms["apply_sharding_hints"]["enabled"] is True
+    assert args.transforms["apply_sharding_hints"]["dist_mapping"] == {
+        "tp": 8,
+        "moe_ep": 8,
+        "moe_tp": 1,
+        "moe_cluster": 1,
+    }
+    assert args.transforms["apply_sharding_hints"]["enable_attention_dp"] is False
+    assert args.transforms["apply_sharding_hints"]["shard_layers"] == ["mla", "moe"]

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_rmsnorm.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_rmsnorm.py
@@ -54,6 +54,18 @@ class TestModel(torch.nn.Module):
         return x
 
 
+class TorchRMSNormFP32WeightModel(torch.nn.Module):
+    def __init__(self, hidden_size: int = 4096, eps: float = 1e-6):
+        super().__init__()
+        self.weight = torch.nn.Parameter(
+            torch.linspace(0.5, 1.5, hidden_size, device="cuda", dtype=torch.float32)
+        )
+        self.eps = eps
+
+    def forward(self, x):
+        return torch.ops.auto_deploy.torch_rmsnorm(x, self.weight, self.eps)
+
+
 def _run_test(model, op, variant):
     def checker(gm):
         return any(is_op(n, op) for n in gm.graph.nodes)
@@ -134,3 +146,36 @@ def test_fuse_rmsnorm_preserves_node_metadata():
     ]
     assert len(rms_nodes) >= 1
     assert all("val" in n.meta and hasattr(n.meta["val"], "dtype") for n in rms_nodes)
+
+
+def test_fuse_rmsnorm_flashinfer_casts_fp32_weight_to_activation_dtype():
+    model = TorchRMSNormFP32WeightModel().eval()
+    x = torch.randn(2, 8, 4096, device="cuda", dtype=torch.bfloat16)
+    gm = torch_export_to_gm(model, args=(x,), clone=True)
+
+    gm_transformed = InferenceOptimizer(
+        None,
+        {
+            "fuse_rmsnorm": {
+                "stage": "post_load_fusion",
+                "gated_rmsnorm_backend": "triton",
+                "rmsnorm_backend": "flashinfer",
+            },
+        },
+    )(None, gm)
+
+    rms_nodes = [
+        n for n in gm_transformed.graph.nodes if is_op(n, torch.ops.auto_deploy.flashinfer_rms_norm)
+    ]
+    assert len(rms_nodes) == 1
+    weight_arg = rms_nodes[0].args[1]
+    assert is_op(weight_arg, torch.ops.aten.to.dtype)
+    assert weight_arg.args[1] == x.dtype
+    assert "val" in rms_nodes[0].meta and rms_nodes[0].meta["val"].dtype == x.dtype
+
+    torch.testing.assert_close(
+        gm_transformed(x),
+        model(x),
+        atol=1e-2,
+        rtol=1e-2,
+    )

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_rope_transformation.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_rope_transformation.py
@@ -20,6 +20,17 @@ from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_output_tupl
 torch.manual_seed(0)
 
 
+def test_complex_rope_accepts_empty_sequence_dimension():
+    q = torch.empty(2, 0, 3, 8)
+    k = torch.empty(2, 0, 1, 8)
+    freqs = torch.empty(2, 0, 4, dtype=torch.complex64)
+
+    q_out, k_out = torch.ops.auto_deploy.torch_rope_with_complex_freqs(q, k, freqs, 2)
+
+    assert q_out.shape == q.shape
+    assert k_out.shape == k.shape
+
+
 def _precompute_freqs_cis_explicit(
     seq_len: int, head_dim: int, rope_theta: float, dtype: torch.dtype = torch.float32
 ):

--- a/triton_dsv4_kernel_strategy.md
+++ b/triton_dsv4_kernel_strategy.md
@@ -1,0 +1,352 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# DeepSeek V4 Triton Kernel Strategy
+
+This strategy targets the AutoDeploy DeepSeek V4 graph emitted by the current branch. It is based on
+`ad_dsv4_ramp_up.md`, `deepseek_v4_ad_plan.md`, `deepseek_v4_sparse_attention_next_steps.md`,
+`dsv4_sharding_guide.md`, the `dsv4-graphs/` dumps, and the existing AutoDeploy custom ops under
+`tensorrt_llm/_torch/auto_deploy/custom_ops/`.
+
+The short version: make DeepSeek V4 attention the primary Triton workstream, keep the existing
+FineGrained FP8 and MXFP4 MoE paths as the initial production baseline, and add narrow DSV4-specific
+kernels only where the graph still exposes reference or Python-heavy behavior.
+
+## Current Graph Shape
+
+The current fixed validation fixture is:
+
+```text
+ad_run_logs/graph_dumps/deepseek_v4_flash_5layer_sampling_workspace_20260425_131939/084_compile_compile_model.txt
+```
+
+W4R-05 also attempted a fresh current-branch reduced run with graph dumping enabled. That run stopped
+before final compile because executor initialization OOMed, so its dump is partial:
+
+```text
+ad_run_logs/graph_dumps/deepseek_v4_flash_5layer_w4r05_current_20260425_2358/077_cache_init_initialize_cache.txt
+```
+
+It is a reduced five-layer DSV4 graph, but it contains the key sharded surfaces needed for kernel
+planning:
+
+- The completed compile fixture lowers cached sparse attention to
+  `torch_deepseek_v4_sparse_attention_v2_with_cache` in all five layers. The fresh partial graph selects
+  `triton_deepseek_v4_sparse_attention_v2_with_cache` in all five layers. NB-04 adds a real ratio-0 SWA
+  device path for prefill and mixed batches; ratio-4 and ratio-128 compressed prefill/mixed batches
+  still need the active-token packing plus local/compressed attention workstream.
+- Observed local-rank attention classes are layers 0/1 ratio-0 SWA with `topk_idxs` width `128`, layers
+  2/4 ratio-4 indexer with width `640`, and layer 3 ratio-128 with width `192`.
+- Ratio-4 layers still contain inlined indexer construction and elementwise FP-style quantization before
+  `aten.topk(..., 512)`, plus an NCCL all-reduce over `s72xs70x2048` indexer scores.
+- Attention and shared-expert dense projections are FineGrained FP8 with E4M3 weights and E8M0-backed
+  `weight_scale_inv` buffers.
+- `wo_a` is a TP-sharded DSV4 grouped FineGrained FP8 projection in this fixture:
+  `[B, S, 1, 4096] -> [B, S, 1, 1024]`.
+- Routed experts lower to `triton_deepseek_v4_mxfp4_moe_from_routing` with packed uint8 FP4 blocks,
+  raw uint8 E8M0 scale bytes, `top_k=6`, and `swiglu_limit=10.0`; this is true in both the completed
+  compile fixture and the fresh partial graph.
+- NCCL all-reduces are visible after `wo_b`, after ratio-4 indexer score reduction, after routed MoE,
+  and after shared expert down projection.
+
+## Priority 1: Cached Sparse Attention
+
+The first production Triton target should be a cached DSV4 sparse attention op, not a rework of classic
+MLA. Existing `triton_mla.py` is useful as a reference for online softmax, block scheduling, and CUDA
+graph discipline, but it does not match DSV4's local window, compressed-memory rows, sink logit, or
+ratio-specific compression semantics.
+
+Target op family:
+
+```text
+torch_deepseek_v4_sparse_attention_v2
+  -> triton_deepseek_v4_sparse_attention_with_cache
+```
+
+Core contract:
+
+- Inputs: local-rank `q [T, H_local, 512]`, current-token KV, attention sink, sequence metadata, page
+  tables, SWA cache, MHC cache, compressor/indexer state, and layer constants.
+- Outputs: BF16 attention output `[T, H_local, 512]`, with optional `out=` for CUDA graph replay.
+- Dtypes: BF16 for query/RoPE dims and initial values; FP8 E4M3 plus E8M0 scale bytes for NoPE cache
+  once the BF16 path is correct.
+- Scope: ratio-0 SWA now has CUDA BF16 decode, prefill, and mixed-batch coverage without the Torch
+  cached/source attention references. Ratio-4 and ratio-128 currently have CUDA BF16 decode coverage;
+  their prefill/mixed path remains the next sparse-attention blocker.
+
+Kernel structure:
+
+1. One program owns a tile of tokens and heads. For decode, start with `BLOCK_T=1..4`,
+   `BLOCK_H=1..4`, `BLOCK_D=64/128` vector lanes over head dim.
+2. Gather SWA rows from paged cache for the last `window_size=128` positions.
+3. Gather visible compressed rows from MHC cache:
+   - ratio-128 layers can initially scan all emitted compressed rows.
+   - ratio-4 layers need the indexer top-k path before they are performance representative.
+4. Compute dot products in FP32 accumulation over `D=512`.
+5. Add the per-head sink as an extra softmax logit that contributes probability mass but no value.
+6. Use online softmax over local-window and compressed chunks so K does not require a giant logits
+   scratch tensor.
+7. Accumulate values and write BF16 output.
+
+Initial Triton specializations:
+
+| Layer class | K-select shape | First kernel |
+| --- | ---: | --- |
+| Ratio 0 | `<=128` | SWA-only cached sparse attention for decode/prefill/mixed |
+| Ratio 128 | `128 + <=ceil(seq/128)` | SWA + all visible compressed rows |
+| Ratio 4 | `128 + selected compressed rows` | SWA + precomputed compressed index list |
+
+Do not start with a single mega-kernel that also performs Q projection, compressor projection, and
+output projection. That would make correctness and cache semantics harder to isolate. The first Triton
+attention kernel should consume already-formed Q/KV/cache tensors and exactly match the source op's sink
+and duplicate-index semantics.
+
+## Priority 2: Cache Update And Compression Kernels
+
+The next Triton target should replace the reference helper ops in `deepseek_v4_kernels.py` and the
+Python-style paged loops in `deepseek_v4_attention.py`.
+
+Implement these as separate kernels with stable intermediate contracts:
+
+1. `triton_deepseek_v4_q_rmsnorm_rope`
+   - Input after `wq_b`: `[T, H_local, 512]`.
+   - Per-head RMSNorm over 512 dims, then RoPE on trailing 64 dims.
+   - BF16 output.
+
+2. `triton_deepseek_v4_kv_norm_rope_cache_insert`
+   - Input after `wkv`: `[T, 512]`.
+   - RMSNorm, RoPE on trailing 64 dims, optional NoPE FP8 quant on first 448 dims.
+   - Writes SWA pages. Use raw E8M0 bytes for scales; do not numerically cast scale tensors to uint8.
+
+3. `triton_deepseek_v4_compressor_pool_norm_rope`
+   - Ratio 128 path: simple `[128, 512]` softmax-pool to one row.
+   - Ratio 4 path: overlapping two-channel transform, then softmax-pool to one row.
+   - Writes emitted MHC rows only when a compression block closes.
+
+4. `triton_deepseek_v4_indexer_q_rope_quant`
+   - First version should be FP8 E4M3 + E8M0 scales.
+   - Defer FP4 indexer cache until the FP8 path is validated.
+
+5. `triton_deepseek_v4_inverse_rope_output_quant`
+   - Applies inverse RoPE to attention output and prepares for `wo_a`.
+   - Keep a BF16-output version first; add FP8 output quant only when the downstream grouped `wo_a`
+     kernel consumes it directly.
+
+These kernels should all accept caller-owned output/cache buffers and must not allocate during replay.
+
+## Priority 3: Router And MXFP4 MoE
+
+The current routed MoE path already uses `triton_kernels.matmul_ogs` through
+`triton_deepseek_v4_mxfp4_moe_from_routing`. Treat it as the baseline unless profiling proves it is the
+dominant bottleneck after attention is fixed.
+
+The most useful Triton additions are around the router and routing metadata:
+
+1. `triton_deepseek_v4_router_hash`
+   - For the first three hash-routed layers.
+   - Gather `tid2eid[input_ids]`, compute `sqrt(softplus(router_logits))`, gather selected scores,
+     normalize, and scale.
+
+2. `triton_deepseek_v4_router_topk`
+   - For non-hash layers.
+   - Compute BF16/FP32 router matmul output, `sqrt(softplus)`, add bias for selection only, top-k `k=6`,
+     gather unbiased scores, normalize, and scale.
+   - Keep router weight BF16. Router is small enough that correctness and launch overhead matter as much
+     as raw GEMM speed.
+
+3. `triton_deepseek_v4_route_metadata`
+   - Build per-expert histograms, sorted token/expert pairs, gather indices, scatter indices, and EP-local
+     masks.
+   - This may be more valuable than fusing router math because `triton_mxfp4_moe_from_routing` currently
+     prepares routing data around sorted expert ids.
+
+Keep the packed expert GEMMs in `triton_kernels.matmul_ogs` for the first production path:
+
+- It already accepts `RoutingData`, `GatherIndx`, and `ScatterIndx`.
+- It already supports fused SWiGLU with `(alpha, limit)`.
+- The DSV4 loader already produces the expected packed uint8 block layout:
+  `gate_up_blocks [E, 2I, H/32, 16]`, `down_blocks [E, H, I/32, 16]`.
+
+Only write a custom DSV4 MXFP4 matmul kernel if profiling shows the generic `matmul_ogs` path loses
+substantial time to layout conversion, routing metadata preparation, or small per-expert occupancy.
+
+## Priority 4: FineGrained FP8 And Grouped `wo_a`
+
+Existing FP8 linears are viable first. The strategy is to validate and specialize the DSV4-only grouped
+case rather than rewrite all FP8 GEMMs.
+
+Keep:
+
+- `trtllm_finegrained_fp8_linear` for standard `wq_a`, `wq_b`, `wkv`, `wo_b`, and shared-expert
+  projections when block sizes are exactly `128x128`.
+- BF16 dequant + cuBLAS fallback for small or non-standard shapes.
+
+Add or specialize:
+
+- A production `triton_deepseek_v4_wo_a_grouped_fp8_linear` if the current reference grouped op survives
+  into the compiled graph or becomes a throughput issue.
+- Shape specialization for `G=8`, `Dg=4096`, `R=1024`.
+- TP specialization for `tp=8`, where each rank owns one output group:
+  `[T, 1, 4096] x [1024, 4096] -> [T, 1, 1024]`.
+
+Preferred implementation path:
+
+1. For unsharded/single GPU, execute eight independent grouped matmuls inside one launch.
+2. For `tp=8`, compile the single-group case and avoid carrying a group loop.
+3. Reuse the same activation quantization and E8M0 scale decode rules as FineGrained FP8.
+
+## Sharding-Aware Kernel Boundaries
+
+Use the sharding plan in `dsv4_sharding_guide.md` as the first distributed kernel target:
+
+```text
+tp = 8
+moe_ep = 8
+moe_tp = 1
+attention_dp = false
+```
+
+Attention:
+
+- Shard query heads and `attn_sink` by TP rank.
+- Keep compressed KV generation replicated initially, then revisit cache sharing only after correctness.
+- The sparse attention kernel should consume local heads and produce local heads; the collective belongs
+  after row-sharded `wo_b`.
+
+Grouped `wo_a`:
+
+- Split by output group boundaries, not by arbitrary flattened rows.
+- With `G=8` and `tp=8`, each rank owns one group.
+
+Routed MoE:
+
+- Keep router replicated.
+- Slice packed MXFP4 expert tensors along expert dimension.
+- Convert global expert ids to local ids, mask nonlocal weights to zero, run local MoE, then all-reduce
+  the partial routed output.
+
+This makes kernel behavior match the existing `DeepSeekV4GroupedWoAShardableNode`,
+`DeepSeekV4SparseAttentionShardableNode`, and `DeepSeekV4MXFP4FromRoutingShardableNode` contracts.
+
+## CUDA Graph Rules
+
+Every new Triton op should be graph-safe from day one:
+
+- No allocation in the op.
+- No Python-side sorting, `torch.arange`, host sync, or shape-dependent buffer creation during replay.
+- Fixed output buffers supplied by the caller or allocated by AutoDeploy outside capture.
+- Metadata tensor shapes bucketed by CUDA graph batch size.
+- Workspace sizes determined from static bucket configuration.
+- Optional `out=` support for attention-like dynamic ops, matching current source-op conventions.
+
+Piecewise CUDA graph support already recognizes DSV4 sparse attention and placeholder DSV4 metadata prep
+op names. The kernel plan should use that boundary rather than forcing all sparse/index/cache behavior
+inside the static captured graph immediately.
+
+## Bring-Up Order
+
+1. Profile and validate the existing five-layer graph to rank attention, MoE, router, grouped `wo_a`, and
+   FP8 linear time. Use this only after correctness is already established.
+2. Implement SWA-only cached sparse attention for ratio-0 layers.
+3. Add KV RMSNorm/RoPE/cache insert with BF16 cache rows.
+4. Add ratio-128 compressor update and sparse attention over visible compressed rows.
+5. Add ratio-4 overlap compressor and indexer top-k path.
+6. Add FP8 NoPE cache with raw E8M0 scale-byte handling.
+7. Add router metadata kernels if MoE routing overhead is visible.
+8. Specialize grouped `wo_a` for the sharded one-group-per-rank path if it remains in the graph as a
+   reference or dequant fallback.
+9. Validate `tp=8, moe_ep=8, moe_tp=1`, including the all-reduce placements after `wo_b` and routed MoE.
+
+## Validation Targets
+
+Correctness targets:
+
+- Source sparse attention parity for duplicate indices, negative masks, and sink probability mass.
+- Full prefill vs chunked prefill for ratio-0, ratio-128, ratio-4, and mixed layer subsets.
+- Prefix prefill plus decode vs full prefill logits.
+- E8M0 raw-byte preservation tests for cache scales and MXFP4 expert scales.
+- EP sharding parity against unsharded routed MoE.
+
+Performance targets:
+
+- Decode attention latency by ratio class.
+- Cache insert bandwidth for SWA and MHC.
+- Compressor update latency at block-close steps.
+- Router metadata overhead before the MXFP4 MoE matmuls.
+- Grouped `wo_a` latency in single-GPU and `tp=8` shapes.
+- CUDA graph replay overhead and dynamic submodule count.
+
+## Wave4 Profile/Validation Status
+
+W4-03 added a CPU graph-dump inventory check for the fixed five-layer fixture under
+`tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_graph_dump_inventory.py`.
+
+W4R-05 reduced evidence update, 2026-04-25:
+
+- Completed fixture/e2e artifact:
+  `ad_run_logs/graph_dumps/deepseek_v4_flash_5layer_sampling_workspace_20260425_131939/084_compile_compile_model.txt`.
+  Its raw log reached `Running example prompts`, processed `1/1` request, and destroyed all eight
+  process groups.
+- Fresh current-branch artifact:
+  `ad_run_logs/graph_dumps/deepseek_v4_flash_5layer_w4r05_current_20260425_2358/077_cache_init_initialize_cache.txt`.
+  No `*compile_model.txt` was produced because the run failed during executor initialization.
+- Focused inventory tests:
+  - Default fixed fixture: `3 passed, 2 xfailed` in `0.16s`; the two expected xfails are the old
+    torch attention/router gates.
+  - Fresh partial graph via `DEEPSEEK_V4_GRAPH_DUMP=.../077_cache_init_initialize_cache.txt`: `5 passed`
+    in `0.16s`.
+- Fresh e2e blocker:
+  `ad_run_logs/ad_run_deepseek_v4_flash_5layer_w4r05_current_20260425_2358.raw.log` shows repeated
+  `triton_deepseek_v4_sparse_attention_v2_with_cache` fallback warnings for prefill/mixed batches, then
+  CUDA OOM while allocating a `3.19 GiB` unmanaged attention cache after `7.96 GiB` KV cache allocation
+  per rank.
+- One invalid fresh attempt is also logged at
+  `ad_run_logs/ad_run_deepseek_v4_flash_5layer_w4r05_current_20260425_2355.raw.log`: it used
+  `--args.yaml-extra` for a full experiment YAML and failed Pydantic validation with
+  `extra_forbidden`; the corrected command used `--yaml-extra`.
+
+Graph inventory:
+
+| Surface | Completed compile fixture | Fresh partial graph | Evidence-backed status |
+| --- | ---: | ---: | --- |
+| Cached sparse attention wrapper | `torch_deepseek_v4_sparse_attention_v2_with_cache`: 5 | `triton_deepseek_v4_sparse_attention_v2_with_cache`: 5 | Graph-selected Triton in current branch, but fresh runtime observed reference fallback for prefill/mixed batches. Real Triton remains decode-only/guarded by the op. |
+| Router wrapper | `torch_deepseek_v4_router`: 5 | `triton_deepseek_v4_router`: 5 | Graph-selected guarded Triton in current branch. Runtime branch coverage is not closed by this run. |
+| MXFP4 routed MoE | `triton_deepseek_v4_mxfp4_moe_from_routing`: 5 | `triton_deepseek_v4_mxfp4_moe_from_routing`: 5 | Real Triton baseline: implementation uses `triton_kernels.matmul_ogs` and a Triton DeepSeek V4 SwiGLU activation. |
+| MXFP4 route metadata | Not present in old torch-wrapper inventory | `torch_deepseek_v4_mxfp4_route_metadata`: 5 | Torch wrapper remains before MoE. Treat metadata preparation as unresolved until profiled or replaced. |
+| Grouped `wo_a` FP8 | `torch_fake_quant_deepseek_v4_wo_a_grouped_finegrained_fp8_linear`: 5 | Same: 5 | Torch-named wrapper remains. Implementation has a guarded Triton grouped FP8 path and BF16 dequant fallback; graph evidence alone does not prove which branch executes. |
+| Generic FineGrained FP8 linears | `torch_fake_quant_finegrained_fp8_linear`: 37 | Same: 37 | Torch-named wrapper remains, but implementation calls HF `w8a8_block_fp8_matmul_triton`. |
+| Simple linears | `torch_linear_simple`: 24 | Same: 24 | Torch wrappers remain; not proven as DSV4 Triton kernels. |
+| RoPE helper | `torch_rope_with_complex_freqs`: 2 | Same: 2 | Torch wrapper remains. |
+| Ratio-4 indexer top-k | `aten.topk.default`: 2 | Same: 2 | Inlined graph path remains; no standalone DSV4 Triton indexer kernel selected. |
+| Distributed reductions | `trtllm_dist_all_reduce`: 17 | Same: 17 | Graph-selected collective path present after attention/indexer/MoE/shared-expert boundaries. |
+
+Current evidence does not close per-layer runtime latency. It does close which wrappers are selected by
+the completed fixture versus the fresh current-branch graph, and it shows the fresh reduced e2e blocker
+is memory during executor/cache initialization rather than a graph-inventory test failure.
+
+## Recommended Ownership Split
+
+- Attention kernel owner: sparse attention, cache insert, compressor update, indexer path, and inverse RoPE
+  output handling.
+- MoE kernel owner: router kernels, routing metadata, MXFP4 MoE profiling, and EP-local masking.
+- Quantization kernel owner: grouped `wo_a`, FP8 cache quantization, E8M0 byte handling, and scale decode
+  utilities.
+- Runtime owner: DSV4 metadata prep, page-table advancement, fixed workspace sizing, and piecewise CUDA
+  graph boundaries.
+
+Keeping these boundaries separate is important. The DSV4 attention path is already complex enough that
+combining cache semantics, routing, and all quantization into one kernel effort would slow down validation.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeepSeek V4 model support to AutoDeploy with TensorRT-LLM runtime integration
  * Enabled specialized optimizations including sparse attention, mixture-of-experts routing, fine-grained FP8 quantization, and MXFP4 expert quantization
  * Added DeepSeek V4 Flash model registry configuration with configurable batching and sequence length limits
  * Introduced hierarchical attention and KV compression support for DeepSeek V4
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

# DeepSeek V4 AutoDeploy Summary

DeepSeek V4 Flash now generates coherently end-to-end in AutoDeploy with real checkpoint weights.

  Validation summary:

  - Full model, TP=8 / EP=8, actual DeepSeek-V4-Flash checkpoint.
  - Runtime config: attn_backend=deepseek_v4_sparse, compile_backend=torch-simple, CUDA graph disabled.
  - Prompt: How big is the universe?
  - Output was coherent and on-topic:

  > That's one of the most profound questions we can ask. The short answer is: we don't know, but we can measure the observable universe.

  Supporting evidence:

  - All 8 ranks completed checkpoint loading.
  - Request processed successfully: 1/1 in 24.27s.
  - No OOM, traceback, or fatal runtime failure.
  - 0-layer and 5-layer AD/reference logits comparisons pass after the RMSNorm fix.
  - 5-layer comparison reports first_divergence: none.
  - Actual-checkpoint real prefill tests: 5 passed, 1 xfailed.
  - Layer-2 ratio-4 attention prefill matches reference with cosine 0.99746656, RMSE ratio 0.07121898.
  - Weight-loading audit found no representative missing/unloaded tensors across dense, FP8, ratio-4, MoE, MXFP4, and sharded tensor categories.

## Current Support Stage

DeepSeek V4 AutoDeploy support is now in a code-complete bring-up state for the
core model path. The branch contains model onboarding, checkpoint quantization
classification, FP8 and MXFP4 loading/lowering support, DeepSeek V4 custom
attention and MoE ops, cache resource integration, CUDA graph configuration,
registry wiring, sharding IR, and focused unit/single-GPU tests.

The next stage should be full-model integration validation: load the downloaded
DeepSeek V4 Flash checkpoint, run the configured AutoDeploy path end to end,
exercise CUDA graph capture, validate multi-rank sharding, and collect serving
and performance results. The commits show extensive implementation and focused
tests, but they do not by themselves establish completed full-checkpoint
serving validation.

## Added Capabilities

### Model Onboarding And Registry

- Added `DeepseekV4Config`, `DeepseekV4ForCausalLM`, and
  `DeepseekV4AutoModelForCausalLMFactory` in
  `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4.py`.
- Registered the custom model through
  `tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py` and
  `examples/auto_deploy/model_registry/models.yaml`.
- Added the deployment config
  `examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml`.
- The registry config uses:
  - `runtime: trtllm`
  - `model_factory: DeepseekV4AutoModelForCausalLM`
  - `compile_backend: torch-cudagraph`
  - `max_batch_size: 64`
  - `max_seq_len: 8192`
  - `max_num_tokens: 8192`
  - `enable_chunked_prefill: true`
  - `skip_mtp: true`
  - CUDA graph batch sizes `[1, 2, 4, 8, 16, 32, 64]`

### Checkpoint Quantization Support

- Added DeepSeek V4 quantization metadata handling in
  `tensorrt_llm/_torch/auto_deploy/models/deepseek_v4_quant.py`.
- Introduced the branch-specific quant method
  `deepseek_v4_fp8`, with checkpoint categories for fine-grained FP8 linear
  tensors and packed MXFP4 expert tensors.
- Added config-reader integration in
  `tensorrt_llm/_torch/auto_deploy/models/quant_config_reader.py`.
- Added E8M0 helper utilities in
  `tensorrt_llm/_torch/auto_deploy/utils/e8m0.py`.
- Extended FP8 dequant utilities in
  `tensorrt_llm/_torch/auto_deploy/utils/fp8_dequant.py`.
- Added support for DeepSeek V4 `wo_a` grouped fine-grained FP8 quantization in
  `tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/torch_quant.py`.
- Added MXFP4 expert checkpoint loading and layout handling in
  `tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_mxfp4.py`.

### Attention And KV Cache

- Added the DeepSeek V4 sparse attention source op in
  `tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_attention.py`.
- Added DeepSeek V4 attention microkernels in
  `tensorrt_llm/_torch/auto_deploy/custom_ops/attention/deepseek_v4_kernels.py`.
- Added masked sparse-attention index support.
- Extended the AutoDeploy attention interface with DeepSeek V4 paged resources:
  `DeepSeekV4PagedResourceHandler` and `DeepSeekV4CacheResourceDescriptor`.
- The cache work covers named paged resources such as SWA, MHC, indexer, and
  compressor state, while preserving paged-resource behavior instead of falling
  back to large unpaged allocations.

### Router And MoE

- Added the DeepSeek V4 router op in
  `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_router.py`.
- Added the DeepSeek V4 source MoE op in
  `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/deepseek_v4_moe.py`.
- Extended MXFP4 MoE support in
  `tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/mxfp4_moe.py`.
- Added the `lower_deepseek_v4_moe` transform in
  `tensorrt_llm/_torch/auto_deploy/transform/library/deepseek_v4_moe.py`.
- The model registry config enables:
  - `lower_deepseek_v4_moe`
  - `quantize_mxfp4_moe`
  - `quantize_finegrained_fp8_linear_from_config`
- The config keeps `multi_stream_moe` disabled for this bring-up path.

### CUDA Graph Runtime Path

- Added DeepSeek V4 CUDA graph configuration in the model registry config.
- Extended `tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py`
  and `tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py`.
- The final config intentionally sets
  `transforms.compile_model.piecewise_enabled: false`, so the current default
  path is monolithic CUDA graph capture rather than piecewise prefill capture.

### Sharding And Distributed IR

- Added a sharding-aware DeepSeek V4 model IR file:
  `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_v4_ir.py`.
- Added DeepSeek V4 shardable-node support in
  `tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py`,
  including rules for:
  - grouped `wo_a` FP8 quantized linear
  - DeepSeek V4 sparse attention
  - DeepSeek V4 MXFP4 MoE from routing
- Added `dsv4_sharding_guide.md`, which documents the recommended first
  distributed target:
  - `world_size: 8`
  - `tp: 8`
  - `moe_ep: 8`
  - `moe_tp: 1`
  - `enable_attention_dp: false`
- The guide positions expert parallelism over the expert dimension as the first
  target, with `moe_tp > 1` deferred because packed MXFP4 block slicing requires
  more careful kernel and loader work.


commits that brought DeepSeek V4 Flash
from sharded graph integration to Triton-backed full-model execution.

# Recent Commits

### `747b6c257f` - `[None][feat] add DeepSeek V4 Triton kernels`

Adds the main Triton kernel implementation and test coverage for DeepSeek V4
AutoDeploy execution.

- Adds Triton cached sparse-attention support, including ratio-0 sliding-window
  attention and compressed ratio-4/ratio-128 prefill, mixed, and decode paths.
- Adds FP8 NoPE cache helpers and the supporting split-cache tests.
- Adds or updates Triton router, MXFP4 MoE, E8M0, quantization, and sharding
  helpers needed by the full model.
- Registers DeepSeek V4 attention/router/MoE paths with piecewise CUDA graph
  dynamic-op handling so prefill and mixed batches split around dynamic kernels
  instead of falling back to PyTorch or being captured incorrectly.
- Adds graph inventory, contract, kernel, FP8 cache, piecewise CUDA graph, MoE,
  router, E8M0, FP8 linear, and sparse-attention tests.
- Adds `triton_dsv4_kernel_strategy.md` and a five-layer validation config.

### `ee5ea528db` - `[None][fix] select DeepSeek V4 sparse attention backend`

Fixes the production config path so full DeepSeek V4 Flash runs select the
DeepSeek sparse cached-attention backend instead of inheriting the dashboard
default `trtllm` attention backend.

- Sets top-level `attn_backend: deepseek_v4_sparse` in
  `deepseek_v4_flash.yaml`.
- Adds merged-config assertions proving `dashboard_default.yaml`,
  `world_size_8.yaml`, and `deepseek_v4_flash.yaml` resolve both
  `attn_backend` and `transforms.insert_cached_attention.backend` to
  `deepseek_v4_sparse`.
- This is what made the full model graph replace all
  `torch_deepseek_v4_sparse_attention_v2` source calls with
  `triton_deepseek_v4_sparse_attention_v2_with_cache`.

### `9b2f4f147c` - `[None][fix] enable DeepSeek V4 coherent generation`

Fixes model/graph correctness issues needed for coherent end-to-end generation.

- Updates DeepSeek V4 custom model and IR handling.
- Updates HF model loading and checkpoint-related paths.
- Fixes supporting RMSNorm, sharding, quantization, and MoE transforms.
- Expands real-checkpoint prefill, modeling, sharding, MoE, FP8 linear, and
  RMSNorm tests.

### `8954e1024c` - `[None][fix] fix DeepSeek V4 decode sharding and MoE`

Fixes decode-time sharding and MoE behavior for the DeepSeek V4 graph.

- Updates sparse-attention metadata handling.
- Fixes MXFP4 MoE runtime behavior.
- Expands sharding IR support and tests for decode/MoE paths.
- Adds coverage for FP8 linear and sparse-attention decode behavior.

### `5232d6a5eb` - `[None][fix] complete DeepSeek V4 sharding`

Completes the earlier DeepSeek V4 sharding and validation setup.

- Adds DeepSeek V4 Flash model-registry and single-request CUDA graph config
  fragments.
- Updates attention, MXFP4 MoE, quantization, custom model, and sharding IR
  code for the DeepSeek V4 topology.
- Adds runtime cache, modeling, FP8 linear, sparse-attention, sharding, and
  example-config tests.

## Full-Model Validation Evidence

After `747b6c257f` and `ee5ea528db`, the full 43-layer DeepSeek V4 Flash run
completed on 8 GPUs with `torch-cudagraph`.

Resolved runtime configuration:

- `compile_backend: torch-cudagraph`
- `compile_model.backend: torch-cudagraph`
- `attn_backend: deepseek_v4_sparse`
- `insert_cached_attention.backend: deepseek_v4_sparse`

Final graph inventory from `084_compile_compile_model.txt`:

- `43` `triton_deepseek_v4_sparse_attention_v2_with_cache` calls
- `0` `torch_deepseek_v4_sparse_attention_v2` source calls
- `0` torch cached DeepSeek V4 attention calls
- `43` Triton DeepSeek V4 router calls
- `43` Triton DeepSeek V4 MXFP4 MoE calls

The generated answer to the sky-blue prompt was coherent English again. It was
repetitive and cut off at the 96-token sampling limit, but it was no longer the
previous multilingual token soup.


### Demos, Tests, And Validation Assets

- Added `examples/deepseek_v4_5layer_forward.py` as a focused forward/demo
  harness.
- Added unit and single-GPU coverage for:
  - DeepSeek V4 modeling
  - quant config classification
  - E8M0 helpers
  - FP8 linear handling
  - MXFP4 loader
  - router
  - MoE lowering
  - sparse attention and attention kernels
  - paged cache resources
  - piecewise CUDA graph behavior
  - sparse attention sharding
- Existing RoPE and MRoPE delta cache tests were adjusted for the new behavior.

## Commit Inventory

| Commit | Area | Summary |
| --- | --- | --- |
| `7b4019c82b` | Model | Onboarded the initial DeepSeek V4 AutoDeploy model. |
| `c8618e15bb` | Quantization | Added E8M0 scale helpers. |
| `9efb63a2a4` | Attention | Added DeepSeek V4 sparse attention source op. |
| `da05c3a1bd` | MoE/router | Added DeepSeek V4 router op. |
| `dbb376a092` | Runtime | Added DeepSeek V4 CUDA graph config. |
| `86378f94ed` | Quantization | Classified DeepSeek V4 quant metadata. |
| `c85d53ee80` | KV cache | Added DeepSeek V4 paged cache resources. |
| `7fcc9f6111` | Attention | Supported masked sparse attention indices. |
| `fdef542542` | Quantization/MoE | Added DeepSeek V4 MXFP4 expert loader. |
| `08c13798de` | Attention | Added attention microkernels. |
| `b3fc1e52b3` | Quantization | Supported DeepSeek V4 FP8 linear scales. |
| `328fda50ab` | MoE | Added DeepSeek V4 MoE source op. |
| `bb47b6ad83` | Demo/test | Added 5-layer forward demo. |
| `58fc7f9c7b` | Quantization | Supported `wo_a` FP8 quantization. |
| `530dc6eca2` | Integration | Wired DeepSeek V4 AutoDeploy integration. |
| `97ad658fbe` | Runtime | Disabled piecewise CUDA graph by default. |
| `8fa8790e71` | Sharding | Added DeepSeek V4 AutoDeploy sharding IR. |

## Focused Test Files Added

- `tests/unittest/_torch/auto_deploy/unit/attention/test_deepseek_v4_sparse_attention_sharding.py`
- `tests/unittest/_torch/auto_deploy/unit/compile/test_deepseek_v4_piecewise_cuda_graph.py`
- `tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_moe.py`
- `tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_mxfp4_loader.py`
- `tests/unittest/_torch/auto_deploy/unit/fused_moe/test_deepseek_v4_router.py`
- `tests/unittest/_torch/auto_deploy/unit/models/test_deepseek_v4_quant_config.py`
- `tests/unittest/_torch/auto_deploy/unit/quantization/test_deepseek_v4_fp8_linear.py`
- `tests/unittest/_torch/auto_deploy/unit/runtime/test_deepseek_v4_cache_resources.py`
- `tests/unittest/_torch/auto_deploy/unit/singlegpu/models/test_deepseek_v4_modeling.py`
- `tests/unittest/_torch/auto_deploy/unit/utils/test_e8m0.py`
- `tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_kernels.py`
- `tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_deepseek_v4_sparse_attention.py`

## Current Configuration Choices

- MTP is skipped with `model_kwargs.skip_mtp: true`.
- Chunked prefill is enabled.
- CUDA graph support is selected through `compile_backend: torch-cudagraph`.
- CUDA graph capture sizes are configured up to batch size 64.
- Piecewise CUDA graph capture is disabled by default.
- Fine-grained FP8 quantization from checkpoint config is enabled.
- Fine-grained FP8 linear fusion is disabled in the current YAML.
- MXFP4 MoE quantization/lowering is enabled.
- Multi-stream MoE is disabled in the current YAML.

## Recommended Next Validation Stage

1. Run the focused unit tests added by the branch.
2. Run the 5-layer forward demo against the downloaded checkpoint path:
   `/lustre/fs1/portfolios/coreai/projects/coreai_comparch_autodeploy/users/bmarimuthu/dev/hf_home/manual/deepseek-ai__DeepSeek-V4-Flash`.
3. Run full-checkpoint AutoDeploy graph construction using
   `examples/auto_deploy/model_registry/configs/deepseek_v4_flash.yaml`.
4. Validate CUDA graph capture for the configured batch sizes.
5. Validate full serving through `trtllm-serve` or the AutoDeploy model registry
   flow.
6. Validate multi-rank sharding, starting with the documented `tp=8, moe_ep=8,
   moe_tp=1` layout.
7. Collect correctness, memory, throughput, and latency data before declaring
   production-ready DeepSeek V4 support.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
