### PR TITLE
[None][feat] Add Llama sequence classification / reward-model support

### DIFF
--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -32,6 +32,7 @@ The following is a table of supported models for the PyTorch backend:
 | `KimiK25ForConditionalGeneration`    | Kimi-K2.5                          | `moonshotai/Kimi-K2.5`                       |
 | `LagunaForCausalLM`                  | Laguna-XS                          | `poolside/laguna-XS.2`                       |
 | `LlamaForCausalLM`                   | Llama 3.1, Llama 3, Llama 2, LLaMA | `meta-llama/Meta-Llama-3.1-70B`              |
+| `LlamaForSequenceClassification`     | Llama-based classifier/reward model | `Skywork/Skywork-Reward-Llama-3.1-8B-v0.2` |
 | `Llama4ForConditionalGeneration`     | Llama 4                            | `meta-llama/Llama-4-Scout-17B-16E-Instruct`  |
 | `MiniMaxM2ForCausalLM` [^5]          | MiniMax M2/M2.1/M2.7              | `MiniMaxAI/MiniMax-M2.7`                    |
 | `MiniMaxM3SparseForConditionalGeneration` [^12]| MiniMax-M3                       | `MiniMaxAI/MiniMax-M3`                      |

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -324,7 +324,7 @@ class ModelConfig(Generic[TConfig]):
         return model_architectures[0] not in [
             "BertForSequenceClassification", "Qwen2ForProcessRewardModel",
             "Qwen2ForRewardModel", "LlamaForTextEmbedding",
-            "Qwen3ForTextEmbedding"
+            "LlamaForSequenceClassification", "Qwen3ForTextEmbedding"
         ]
         # TODO: should be 'not model_type == ModelType.ENCODER_ONLY'
         # once ModelType is used in pytorch flow.

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -31,7 +31,7 @@ from .modeling_hunyuan_moe import HunYuanMoEV1ForCausalLM
 from .modeling_hyperclovax import HCXVisionForCausalLM
 from .modeling_kimi_k25 import KimiK25ForConditionalGeneration
 from .modeling_laguna import LagunaForCausalLM
-from .modeling_llama import LlamaForCausalLM
+from .modeling_llama import LlamaForCausalLM, LlamaForSequenceClassification
 from .modeling_llava_next import LlavaNextModel
 from .modeling_minimaxm2 import MiniMaxM2ForCausalLM
 from .modeling_minimaxm3 import (MiniMaxM3ForCausalLM,
@@ -88,6 +88,7 @@ __all__ = [
     "HunYuanMoEV1ForCausalLM",
     "KimiK25ForConditionalGeneration",
     "LlamaForCausalLM",
+    "LlamaForSequenceClassification",
     "LlavaNextModel",
     "Mistral3VLM",
     "MistralForCausalLM",

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import copy
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -727,8 +742,11 @@ class LlamaDecoderLayer(DecoderLayer):
         self.next_attn: LlamaAttention = None
 
         self.attention_mask = PredefinedAttentionMask.CAUSAL
-        # If the model is being used as an encoder model (prefill only) we use a full attention mask
-        if not model_config.is_generation:
+        architectures = getattr(config, "architectures", []) or []
+        is_sequence_classification = ("LlamaForSequenceClassification"
+                                      in architectures)
+        # Encoder models use full attention; decoder-based reward models remain causal.
+        if not model_config.is_generation and not is_sequence_classification:
             self.attention_mask = PredefinedAttentionMask.FULL
 
         self.enable_fusion = os.environ.get(
@@ -1151,6 +1169,63 @@ class LlamaForCausalLM(SpecDecOneEngineForCausalLM[LlamaModel, LlamaConfig]):
                     idx + 1].input_layernorm
                 self.model.layers[idx + 1].skip_input_layernorm = True
                 layer.next_attn = self.model.layers[idx + 1].self_attn
+
+
+@register_auto_model("LlamaForSequenceClassification")
+class LlamaForSequenceClassification(DecoderModelForCausalLM[LlamaModel,
+                                                             LlamaConfig]):
+    """Llama backbone with a sequence-classification or reward head."""
+
+    def __init__(self, model_config: ModelConfig[LlamaConfig]):
+        nn.Module.__init__(self)
+        self.model_config = model_config
+        self.model = LlamaModel(model_config)
+
+        config = model_config.pretrained_config
+        self.score = Linear(
+            config.hidden_size,
+            config.num_labels,
+            bias=False,
+            dtype=config.torch_dtype,
+        )
+        self.prologue = []
+        self.epilogue = [self.score]
+
+    def setup_aliases(self) -> None:
+        for idx, layer in enumerate(
+                self.model.layers[:self.config.num_hidden_layers]):
+            if idx == self.config.num_hidden_layers - 1:
+                layer.next_layer_layernorm = self.model.norm
+                self.model.skip_norm = True
+            else:
+                layer.next_layer_layernorm = self.model.layers[
+                    idx + 1].input_layernorm
+                self.model.layers[idx + 1].skip_input_layernorm = True
+                layer.next_attn = self.model.layers[idx + 1].self_attn
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: torch.IntTensor,
+        position_ids: Optional[torch.IntTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        assert attn_metadata.seq_lens is not None
+
+        hidden_states = self.model(
+            attn_metadata,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+        )
+        logits = self.score(hidden_states)
+
+        seq_lens = attn_metadata.seq_lens.to(device=logits.device,
+                                             dtype=torch.long)
+        end_indices = torch.cumsum(seq_lens, dim=0) - 1
+        return logits[end_indices]
 
 
 def _load_checkpoint_into_module(module: nn.Module,

--- a/tensorrt_llm/serialization.py
+++ b/tensorrt_llm/serialization.py
@@ -29,6 +29,7 @@ BASE_EXAMPLE_CLASSES = {
     "tensorrt_llm._torch.models.modeling_llama": [
         "Eagle3LlamaForCausalLM",
         "LlamaForCausalLM",
+        "LlamaForSequenceClassification",
         "Llama4ForCausalLM",
         "Llama4ForConditionalGeneration",
     ],

--- a/tests/unittest/_torch/modeling/test_modeling_llama.py
+++ b/tests/unittest/_torch/modeling/test_modeling_llama.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from copy import deepcopy
 from dataclasses import dataclass
@@ -8,6 +23,8 @@ from _torch.helpers import create_mock_cuda_graph_runner
 from parameterized import parameterized
 from transformers import LlamaConfig
 from transformers import LlamaForCausalLM as HFLlamaForCausalLM
+from transformers import \
+    LlamaForSequenceClassification as HFLlamaForSequenceClassification
 from utils.llm_data import llm_models_root
 from utils.util import default_dtype, getSMVersion
 
@@ -15,7 +32,8 @@ import tensorrt_llm
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
-from tensorrt_llm._torch.models.modeling_llama import LlamaForCausalLM
+from tensorrt_llm._torch.models.modeling_llama import (
+    LlamaForCausalLM, LlamaForSequenceClassification)
 from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import \
     _update_kv_cache_draft_token_location
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
@@ -197,6 +215,94 @@ class TestLlama(unittest.TestCase):
         self.assertEqual(input_ids.shape, logits.shape[:-1])
 
         kv_cache_manager.shutdown()
+
+    @torch.no_grad()
+    def test_llama_sequence_classification_allclose_to_hf(self) -> None:
+        metadata_cls = get_attention_backend("VANILLA").Metadata
+
+        torch.random.manual_seed(0)
+        config_dict = deepcopy(LLAMA_3_1_8B_CONFIG)
+        config_dict.update({
+            "architectures": ["LlamaForSequenceClassification"],
+            "hidden_size": 128,
+            "intermediate_size": 256,
+            "num_attention_heads": 4,
+            "num_hidden_layers": 2,
+            "num_key_value_heads": 2,
+            "max_position_embeddings": 128,
+            "vocab_size": 512,
+            "num_labels": 3,
+            "pad_token_id": 0,
+            "torch_dtype": "float16",
+        })
+        llama_config = LlamaConfig.from_dict(config_dict)
+        dtype = llama_config.torch_dtype
+        device = torch.device("cuda")
+
+        with torch.device(device), default_dtype(dtype):
+            hf_llama = (HFLlamaForSequenceClassification(llama_config).to(
+                dtype).to(device).eval())
+            model_config = ModelConfig(
+                pretrained_config=llama_config,
+                attn_backend="VANILLA",
+            )
+            self.assertFalse(model_config.is_generation)
+            llama = (LlamaForSequenceClassification(model_config).to(dtype).to(
+                device))
+            llama.load_weights(hf_llama.state_dict())
+            llama.post_load_weights()
+
+        hf_input_ids = torch.tensor(
+            [[100, 200, 2], [100, 2, 0]],
+            dtype=torch.long,
+            device=device,
+        )
+        hf_attention_mask = torch.tensor(
+            [[1, 1, 1], [1, 1, 0]],
+            dtype=torch.long,
+            device=device,
+        )
+
+        hf_outputs = hf_llama(
+            input_ids=hf_input_ids,
+            attention_mask=hf_attention_mask,
+        )
+
+        input_ids = torch.tensor(
+            [100, 200, 2, 100, 2],
+            dtype=torch.int,
+            device=device,
+        )
+        position_ids = torch.tensor(
+            [[0, 1, 2, 0, 1]],
+            dtype=torch.int,
+            device=device,
+        )
+        seq_lens = torch.tensor([3, 2], dtype=torch.int)
+        attn_metadata = metadata_cls(
+            max_num_requests=2,
+            max_num_tokens=8192,
+            kv_cache_manager=None,
+            request_ids=[0, 1],
+            prompt_lens=seq_lens.tolist(),
+            seq_lens=seq_lens,
+            num_contexts=2,
+        )
+        attn_metadata.max_seq_len = 3
+        attn_metadata.prepare()
+
+        tllm_outputs = llama(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            attn_metadata=attn_metadata,
+        )
+
+        torch.testing.assert_close(
+            hf_outputs.logits.float(),
+            tllm_outputs.float(),
+            rtol=1.5e-2,
+            atol=1.5e-2,
+        )
 
     @parameterized.expand([
         Scenario(backend="VANILLA"),


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Llama sequence classification models, enabling classifier and reward model use cases. Models can now be loaded from Hugging Face and converted to TensorRT-LLM format.

* **Documentation**
  * Updated support matrix and model documentation to include the new classifier architecture.

* **Tests**
  * Added comprehensive unit tests for sequence classification model validation against Hugging Face implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Add support for `LlamaForSequenceClassification` in the PyTorch backend so that Llama-based reward / classifier checkpoints (e.g. `Skywork/Skywork-Reward-Llama-3.1-8B-v0.2`) can be served via the TensorRT-LLM PyTorch runtime.

Implementation follows the existing `Qwen2ForRewardModel` pattern:

- Register `@register_auto_model("LlamaForSequenceClassification")` for a new class that inherits from `DecoderModelForCausalLM[LlamaModel, LlamaConfig]` and bypasses its `__init__` via `nn.Module.__init__(self)`, so that the vocab-sized `lm_head` is replaced with a small `score` head of size `num_labels`. The parent's `PostInitCaller` metaclass still triggers `__post_init__`, which handles `create_weights()` on leaf modules.
- Forward pass returns the per-request score read from the last token of each sequence: `logits[cumsum(seq_lens) - 1]`.
- `is_generation_model` returns `False` for this architecture (same as `Qwen2ForRewardModel`, `BertForSequenceClassification`, `LlamaForTextEmbedding`).
- Legacy TensorRT engine-build path in `tensorrt_llm/models/llama/{config,convert,model}.py` and `MODEL_MAP` in `tensorrt_llm/models/__init__.py` route `LlamaForSequenceClassification` through `LLaMAForCausalLM`, reusing the Llama weight converter with the `score` head mapped to `lm_head`.
- `LlamaConfig.num_labels` is plumbed through `from_hugging_face` and `to_dict` for checkpoint round-trip.

## Test Coverage

- `tests/unittest/_torch/modeling/test_modeling_llama.py::TestLlama::test_llama_sequence_classification_allclose_to_hf` builds a tiny random `LlamaForSequenceClassification` with 2 layers, `hidden_size=128`, `num_labels=3`, loads the same weights into the HF reference implementation, and asserts `torch.testing.assert_close(hf_logits, tllm_logits, rtol=1.5e-2, atol=1.5e-2)` on a batched forward through the VANILLA attention backend.

- Manually validated against the real `Skywork/Skywork-Reward-Llama-3.1-8B-v0.2` reward model on RTX PRO 6000 in `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc12` (bf16, TRTLLM attention backend):

  | prompt | HF `AutoModelForSequenceClassification` | TRT-LLM `LlamaForSequenceClassification` |
  | --- | ---: | ---: |
  | "What is 2+2?" &rarr; "2 + 2 = 4." (good) | 11.5625 | 11.75 |
  | "What is 2+2?" &rarr; "Banana." (bad)     | -22.5   | -22.625 |

  Max abs diff 0.1875 on scores of magnitude ~22 (within bf16 noise), and both implementations correctly rank the good answer above the bad.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.
