### PR TITLE
[None][feat] Assert attention DP disabled when KV connector is in use

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -674,6 +674,11 @@ def create_py_executor(
                 "KV connector is not supported with VSWA (Variable Sliding Window Attention)."
             )
 
+        if mapping.enable_attention_dp:
+            raise NotImplementedError(
+                "KV connector is not supported with attention data parallelism (enable_attention_dp=True)."
+            )
+
         try:
             module = importlib.import_module(
                 kv_connector_config.connector_module)


### PR DESCRIPTION
## Summary
- KV connector initialization currently has no compatibility check against attention data parallelism. The combination has not been validated and there is no established plumbing for the connector scheduler/worker to reason about per-DP-rank KV state.
- Adds a `NotImplementedError` in `py_executor_creator._create_py_executor` that fires when `mapping.enable_attention_dp` is True and a `kv_connector_config` is provided, matching the style of the existing scheduler-policy and VSWA guards.

## Test plan
- [x] Launch with `kv_connector_config` + `enable_attention_dp=True` and confirm the new `NotImplementedError` is raised before any connector worker is instantiated.
- [x] Launch with `kv_connector_config` + `enable_attention_dp=False` and confirm startup is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration validation to prevent incompatible feature combinations. The system now explicitly rejects the concurrent use of KV connector with attention data parallelism, providing a clear error message. This improvement prevents unexpected behavior and configuration errors by blocking unsupported feature interactions at initialization time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->