### PR TITLE
[None][fix] Avoid unfinished_test race condition in Pytest hooks

### DIFF
--- a/tests/integration/defs/utils/periodic_junit.py
+++ b/tests/integration/defs/utils/periodic_junit.py
@@ -98,6 +98,7 @@ class PeriodicJUnitXML:
         self.completed_tests = 0
         self.last_save_time = time.time()
         self.suite_start_time = time.time()
+        self._owned_nodeids: set[str] = set()
 
         # Store raw reports for batch processing
         self.pending_reports = [
@@ -120,6 +121,16 @@ class PeriodicJUnitXML:
             self.logger['warning'](message)
         else:
             print(f"WARNING: {message}")
+
+    def _remove_nodeids_from_file(self, path: str, nodeids_to_remove):
+        """Remove lines matching *nodeids_to_remove* from *path* in-place."""
+        with open(path, "r+", encoding="utf-8") as f:
+            lines = f.readlines()
+            f.seek(0)
+            f.truncate()
+            for line in lines:
+                if line.strip() not in nodeids_to_remove:
+                    f.write(line)
 
     def pytest_configure(self, config: Config):
         """Configure and initialize the reporter."""
@@ -169,6 +180,7 @@ class PeriodicJUnitXML:
 
         # save unfinished test nodeid to output-dir/unfinished_test.txt
         if self.save_unfinished_test and report.when == "setup":
+            self._owned_nodeids.add(report.nodeid)
             try:
                 # Create directory if it doesn't exist
                 os.makedirs(output_dir, exist_ok=True)
@@ -185,20 +197,15 @@ class PeriodicJUnitXML:
             current_time = time.time()
 
             if self.save_unfinished_test:
-                if os.path.exists(unfinished_test_path):
-                    try:
-                        with open(unfinished_test_path, "r+",
-                                  encoding="utf-8") as f:
-                            lines = f.readlines()
-                            f.seek(0)
-                            f.truncate()
-                            for line in lines:
-                                if line.strip() != report.nodeid:
-                                    f.write(line)
-                    except Exception as e:
-                        self._log_warning(
-                            f"Error clearing nodeid {report.nodeid} from {unfinished_test_path}: {e}"
-                        )
+                try:
+                    self._remove_nodeids_from_file(unfinished_test_path,
+                                                   {report.nodeid})
+                except FileNotFoundError:
+                    pass
+                except Exception as e:
+                    self._log_warning(
+                        f"Error clearing nodeid {report.nodeid} from {unfinished_test_path}: {e}"
+                    )
 
             # Flush if batch threshold reached OR time interval elapsed
             should_flush_by_time = (current_time -
@@ -225,6 +232,20 @@ class PeriodicJUnitXML:
             self._generate_report(is_final=True)
         except Exception as e:
             self._log_warning(f"Error generating final report: {e}")
+
+        # Final sweep: remove every nodeid this session wrote.  Teardown
+        # already removed most, but racy file I/O (e.g. xdist workers) can
+        # leave stale entries.  Scoped to our own nodeids so other sessions
+        # are unaffected.  If killed, this hook never runs and the file is
+        # preserved for legitimate timeout detection.
+        if self.save_unfinished_test and self._owned_nodeids:
+            unfinished_test_path = os.path.join(os.path.dirname(self.xmlpath),
+                                                "unfinished_test.txt")
+            try:
+                self._remove_nodeids_from_file(unfinished_test_path,
+                                               self._owned_nodeids)
+            except FileNotFoundError:
+                pass
 
     def _process_pending_reports(self):
         """Process all pending reports through LogXML (lightweight mode only)."""


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Summary from Cursor:
The `PeriodicJUnitXML` plugin tracks in-flight tests by appending to
`unfinished_test.txt` on setup and removing on teardown. When multiple pytest
processes (outer integration runner + inner unit test subprocess) share the
same output directory, entries can survive past normal completion. Jenkins
post-processing then converts these stale entries into spurious "terminated
unexpectedly" errors.

This PR avoids this race condition by deleting `unfinished_test.txt` entries in `pytest_sessionfinish`. If the session
finishes, all tests completed their teardown, so any remaining entries are
stale. If the process is killed (OOM, SIGKILL), this hook never runs and the
file is preserved for legitimate timeout detection.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test suite reliability by cleaning up leftover test state files after test sessions complete, preventing phantom timeout failures from prior incomplete runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->