### PR TITLE
[None][feat] llmc: standalone package improvements and enforce import discipline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2861,6 +2861,11 @@ repos:
         entry: ./scripts/check_pinned_memory_usage.py
         language: script
         files: ^(tensorrt_llm|triton_backend)/.*\.py$
+    -   id: auto-deploy-import-discipline
+        name: Enforce relative imports inside auto_deploy
+        entry: python scripts/check_auto_deploy_imports.py
+        language: python
+        files: ^tensorrt_llm/_torch/auto_deploy/.*\.py$
     -   id:  type-check
         name: Run static analysis of type correctness using mypy
         entry: scripts/run_mypy.sh

--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -2,7 +2,7 @@
 
 This folder contains runnable examples for **AutoDeploy** as it ships inside [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM). For general AutoDeploy documentation, motivation, support matrix, and feature overview, please see the [official docs](https://nvidia.github.io/TensorRT-LLM/features/auto_deploy/auto-deploy.html).
 
-> Looking for the lightweight standalone package (no TRT-LLM required)? See [`llmc/README.md`](./llmc/README.md). The standalone repo is generated from this source tree by [`llmc/create_standalone_package.py`](./llmc/create_standalone_package.py).
+> Looking for the lightweight standalone package (no TRT-LLM required)? See **LLM Compiler** at [github.com/NVIDIA/llm-compiler](https://github.com/NVIDIA/llm-compiler). That repo is generated from this source tree by [`llmc/create_standalone_package.py`](./llmc/create_standalone_package.py).
 
 ______________________________________________________________________
 

--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -1,16 +1,14 @@
-# 🔥🚀⚡ AutoDeploy
+# 🔥🚀⚡ AutoDeploy Examples
 
-**AutoDeploy** automatically optimizes and deploys HuggingFace LLM checkpoints for high-performance inference on NVIDIA GPUs. It works as part of [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) or as a **standalone** lightweight package (`llm-compiler`).
+This folder contains runnable examples for **AutoDeploy** as it ships inside [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM). For general AutoDeploy documentation, motivation, support matrix, and feature overview, please see the [official docs](https://nvidia.github.io/TensorRT-LLM/features/auto_deploy/auto-deploy.html).
 
-For general AutoDeploy documentation, motivation, support matrix, and feature overview, please see the [official docs](https://nvidia.github.io/TensorRT-LLM/features/auto_deploy/auto-deploy.html).
+> Looking for the lightweight standalone package (no TRT-LLM required)? See [`llmc/README.md`](./llmc/README.md). The standalone repo is generated from this source tree by [`llmc/create_standalone_package.py`](./llmc/create_standalone_package.py).
 
 ______________________________________________________________________
 
 ## Quick Start
 
-### Option A: As part of TensorRT-LLM (full features)
-
-AutoDeploy is included with the TRT-LLM installation:
+AutoDeploy is included with the TRT-LLM installation.
 
 ```bash
 sudo apt-get -y install libopenmpi-dev && pip3 install --upgrade pip setuptools && pip3 install tensorrt_llm
@@ -18,46 +16,7 @@ sudo apt-get -y install libopenmpi-dev && pip3 install --upgrade pip setuptools 
 
 You can refer to the [TRT-LLM installation guide](../../docs/source/installation/installation-guide.md) for more information.
 
-### Option B: Standalone package (lightweight, no TRT-LLM required)
-
-```bash
-pip install llm-compiler
-```
-
-Or install from source with [uv](https://docs.astral.sh/uv/) (recommended):
-
-```bash
-uv venv .venv --python 3.12
-source .venv/bin/activate
-uv pip install -e '.[dev]'
-```
-
-Or with pip:
-
-```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -e '.[dev]'
-```
-
-In standalone mode, AutoDeploy uses PyTorch, Triton, and FlashInfer backends. TRT-LLM-specific optimizations (custom CUDA kernels, optimized all-reduce, etc.) are available only when using TRT-LLM.
-
-```python
-# Standalone usage
-from auto_deploy._compat import TRTLLM_AVAILABLE
-print(f"TRT-LLM available: {TRTLLM_AVAILABLE}")
-
-# When using TRT-LLM, the import path is:
-# from tensorrt_llm._torch.auto_deploy import LLM, LlmArgs
-```
-
-#### Running tests (standalone)
-
-```bash
-pytest tests/
-```
-
-### Run an example
+Run a simple example with a Hugging Face model:
 
 ```bash
 cd examples/auto_deploy

--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -143,15 +143,6 @@ llm = LLM(
 )
 ```
 
-In standalone mode, you can directly use the graph transformation and compilation pipeline:
-
-```python
-# Standalone
-from auto_deploy.export import torch_export_to_gm
-from auto_deploy.transform.interface import TransformRegistry
-from auto_deploy.models.factory import ModelFactoryRegistry
-```
-
 ### Expert Configuration of LLM API
 
 For expert TensorRT LLM users, we also expose the full set of [`LlmArgs`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py)

--- a/examples/auto_deploy/llmc/.github_for_llmc/ISSUE_TEMPLATE/config.yml
+++ b/examples/auto_deploy/llmc/.github_for_llmc/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,20 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🐞 Bug report (file at TensorRT-LLM)
+    url: https://github.com/NVIDIA/TensorRT-LLM/issues/new/choose
+    about: |
+      llmc is generated from the AutoDeploy source tree inside TensorRT-LLM.
+      Please report bugs against NVIDIA/TensorRT-LLM so they reach the source of truth.
+  - name: 🚀 Feature request (file at TensorRT-LLM)
+    url: https://github.com/NVIDIA/TensorRT-LLM/issues/new/choose
+    about: |
+      Feature requests for llmc / AutoDeploy should be filed in NVIDIA/TensorRT-LLM.
+  - name: 🤔 Questions and discussions
+    url: https://github.com/NVIDIA/TensorRT-LLM/discussions
+    about: |
+      Ask questions and discuss with the TensorRT-LLM community.
+  - name: 🔒 Security vulnerability
+    url: https://www.nvidia.com/en-us/support/submit-security-vulnerability/
+    about: |
+      Do not file public GitHub issues for security reports.
+      Report security vulnerabilities to NVIDIA PSIRT (see SECURITY.md).

--- a/examples/auto_deploy/llmc/.github_for_llmc/PULL_REQUEST_TEMPLATE.md
+++ b/examples/auto_deploy/llmc/.github_for_llmc/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+  ⚠️  STOP — please read before opening this PR.
+
+  The `llm-compiler` (`llmc`) repository is READ-ONLY. It is regenerated from the
+  AutoDeploy source tree in NVIDIA/TensorRT-LLM on every release, so any change
+  merged here will be overwritten on the next sync.
+
+  Pull requests opened against this repository will be closed without review.
+
+  Please open your PR against NVIDIA/TensorRT-LLM instead:
+    https://github.com/NVIDIA/TensorRT-LLM
+
+  See CONTRIBUTING.md in this repository for the supported workflow:
+    1. Fork NVIDIA/TensorRT-LLM
+    2. Edit `tensorrt_llm/_torch/auto_deploy/` and its tests
+    3. (Optional) Validate locally with the standalone test suite
+    4. Open a PR against `main` of NVIDIA/TensorRT-LLM
+
+  If you are a maintainer making an intentional out-of-band change to this mirror,
+  delete this comment and describe the reason below.
+-->
+
+## Why is this PR opened against the mirror repository?
+
+<!-- Explain the exception. Otherwise this PR will be closed and you should
+     reopen it against NVIDIA/TensorRT-LLM. -->

--- a/examples/auto_deploy/llmc/CONTRIBUTING.md
+++ b/examples/auto_deploy/llmc/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to llmc
+
+## Where to send PRs
+
+The `llmc` standalone package is **generated from the AutoDeploy source tree inside [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM)**. The standalone repo (`nvidia-llmc` on PyPI / the mirror repo on GitHub) is **read-only** — it is overwritten on every release by [`create_standalone_package.py`](./create_standalone_package.py).
+
+**Do not open pull requests against the standalone `llmc` repo.** Any changes pushed there will be lost the next time the package is regenerated.
+
+The supported workflow is:
+
+1. **Fork** [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM).
+1. Edit the AutoDeploy source under `tensorrt_llm/_torch/auto_deploy/` (and its tests under `tests/unittest/_torch/auto_deploy/` and `tests/unittest/auto_deploy/`).
+1. **Optional:** validate your change against the standalone repo by regenerating it locally and running its test suite (see below).
+1. Open a PR against `main` of `NVIDIA/TensorRT-LLM`.
+
+You're welcome to fork the standalone `llmc` repo to experiment, iterate, or build on top — just remember the upstream source of truth is TensorRT-LLM.
+
+## Validating a change with the standalone build
+
+You can run the full standalone test suite locally before sending a PR. From the TensorRT-LLM checkout:
+
+```bash
+# 1. Run the import-discipline lint (also enforced as a pre-commit hook)
+python scripts/check_auto_deploy_imports.py
+
+# 2. Generate, install, and test the standalone package end-to-end
+pytest tests/unittest/auto_deploy/standalone/ -q
+```
+
+`tests/unittest/auto_deploy/standalone/test_standalone_package.py` regenerates the `llmc` tree, installs it in an isolated venv, and runs the copied unit tests against the standalone install. This is the same job that gates merges.
+
+To regenerate the standalone tree without running tests:
+
+```bash
+python examples/auto_deploy/llmc/create_standalone_package.py \
+    --output-dir /path/to/llmc_pkg
+```
+
+## PR conventions
+
+PRs against `NVIDIA/TensorRT-LLM` follow the project-wide rules:
+
+- **Title format:** `[JIRA/NVBUG/None][type] description` (e.g. `[None][feat] llmc: add foo transform`).
+- **DCO sign-off** is required: commit with `git commit -s`. Don't add AI tools or co-authors to the sign-off line.
+- The pre-commit hooks (formatting, lint, the `auto-deploy-import-discipline` hook) run on commit. If they modify files, re-stage and commit again.
+
+For the rest (full coding guidelines, branching policy, CI commands), see [the TensorRT-LLM `CONTRIBUTING.md`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CONTRIBUTING.md) and the [project-level `AGENTS.md`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/AGENTS.md).
+
+## Import discipline
+
+`llmc` source is the same files as `tensorrt_llm/_torch/auto_deploy/` — copied verbatim, never rewritten. For that to work cleanly:
+
+- Imports **inside** the auto_deploy package must be **relative** (`from ..foo import bar`).
+- Imports **to the rest of TensorRT-LLM** must be **absolute** (`from tensorrt_llm.X import Y`) and gated at runtime by `_compat.TRTLLM_AVAILABLE` so they fail gracefully in standalone mode.
+
+Both rules are enforced by `scripts/check_auto_deploy_imports.py`, which runs as a pre-commit hook on every change to `tensorrt_llm/_torch/auto_deploy/`.

--- a/examples/auto_deploy/llmc/CONTRIBUTING.md
+++ b/examples/auto_deploy/llmc/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to llmc
+# Contributing to llm-compiler
 
 ## Where to send PRs
 
-The `llmc` standalone package is **generated from the AutoDeploy source tree inside [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM)**. The standalone repo (`nvidia-llmc` on PyPI / the mirror repo on GitHub) is **read-only** — it is overwritten on every release by [`create_standalone_package.py`](./create_standalone_package.py).
+The `llmc` standalone package is **generated from the AutoDeploy source tree inside [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM)**. The mirror repo on GitHub is **read-only** — it is overwritten on every release by [`create_standalone_package.py`](./create_standalone_package.py).
 
 **Do not open pull requests against the standalone `llmc` repo.** Any changes pushed there will be lost the next time the package is regenerated.
 

--- a/examples/auto_deploy/llmc/README.md
+++ b/examples/auto_deploy/llmc/README.md
@@ -1,6 +1,6 @@
-# 🔥🚀⚡ llmc
+# 🔥🚀⚡ LLM Compiler
 
-**llmc** is the standalone, lightweight distribution of the AutoDeploy graph-transformation pipeline. It exposes the same `ModelFactory` and `InferenceOptimizer` building blocks as TensorRT-LLM's AutoDeploy backend, but with a minimal dependency footprint (PyTorch + Triton + FlashInfer), so you can prototype optimization pipelines or run inference without a full TRT-LLM install.
+**LLM Compiler** (Python package: `llmc`) is the standalone, lightweight distribution of the AutoDeploy graph-transformation pipeline. It exposes the same `ModelFactory` and `InferenceOptimizer` building blocks as TensorRT-LLM's AutoDeploy backend, but with a minimal dependency footprint (PyTorch + Triton + FlashInfer), so you can prototype optimization pipelines or run inference without a full TRT-LLM install.
 
 The `llmc` package is **generated** from the AutoDeploy source tree inside the [TensorRT-LLM repo](https://github.com/NVIDIA/TensorRT-LLM). The standalone repo is **read-only** — see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for how to land changes.
 
@@ -10,40 +10,20 @@ ______________________________________________________________________
 
 ## Install
 
-From PyPI (when published):
+We don't publish wheels yet. Install with [uv](https://docs.astral.sh/uv/) directly from the latest commit using the `pip install git+…` convention:
 
 ```bash
-pip install nvidia-llmc
+uv pip install "git+<this-repo-url>.git"
 ```
 
-The distribution name is `nvidia-llmc`; the importable Python package is `llmc`.
-
-### From source (recommended for development)
-
-Generate the standalone source tree from the TRT-LLM checkout:
+For development, clone this repo and do an editable install:
 
 ```bash
-# inside the TensorRT-LLM repo
-python examples/auto_deploy/llmc/create_standalone_package.py \
-    --output-dir /path/to/llmc_pkg
-```
-
-Then install with [uv](https://docs.astral.sh/uv/):
-
-```bash
-cd /path/to/llmc_pkg
+git clone <this-repo-url>.git
+cd llm-compiler
 uv venv .venv --python 3.12
 source .venv/bin/activate
-uv pip install -e '.[dev]'
-```
-
-Or with pip:
-
-```bash
-cd /path/to/llmc_pkg
-python -m venv .venv
-source .venv/bin/activate
-pip install -e '.[dev]'
+uv pip install -e ".[dev]"
 ```
 
 ### Sanity check
@@ -161,16 +141,3 @@ print(logits.shape)
 | Configuration data classes | `llmc/transform/interface.py`, `llmc/llm_args.py` |
 
 For higher-level usage, the `llmc.LLM` class (available when running inside TRT-LLM) wraps all of the above behind a familiar generate API. In pure-standalone mode use `InferenceOptimizer` directly as shown.
-
-______________________________________________________________________
-
-## Regenerating the standalone repo
-
-The standalone source tree is regenerated from TensorRT-LLM by running:
-
-```bash
-python examples/auto_deploy/llmc/create_standalone_package.py \
-    --output-dir /path/to/llmc_repo
-```
-
-The script overwrites only its managed paths (`llmc/`, `tests/`, `pyproject.toml`, `README.md`, `CONTRIBUTING.md`, `LICENSE`, `.gitignore`); existing `.git/`, `.github/`, and any other repo-specific files are preserved, so the resulting tree can be committed and pushed directly.

--- a/examples/auto_deploy/llmc/README.md
+++ b/examples/auto_deploy/llmc/README.md
@@ -10,16 +10,24 @@ ______________________________________________________________________
 
 ## Install
 
-We don't publish wheels yet. Install with [uv](https://docs.astral.sh/uv/) directly from the latest commit using the `pip install git+…` convention:
+Install with [uv](https://docs.astral.sh/uv/) directly from the latest commit:
 
 ```bash
-uv pip install "git+<this-repo-url>.git"
+# https
+uv pip install "git+https://github.com/NVIDIA/llm-compiler.git"
+
+# ssh
+uv pip install "git+ssh://git@github.com/NVIDIA/llm-compiler.git"
 ```
 
-For development, clone this repo and do an editable install:
+For development, clone the repo and do an editable install:
 
 ```bash
-git clone <this-repo-url>.git
+# https
+git clone https://github.com/NVIDIA/llm-compiler.git
+# or ssh
+git clone git@github.com:NVIDIA/llm-compiler.git
+
 cd llm-compiler
 uv venv .venv --python 3.12
 source .venv/bin/activate

--- a/examples/auto_deploy/llmc/README.md
+++ b/examples/auto_deploy/llmc/README.md
@@ -1,0 +1,176 @@
+# 🔥🚀⚡ llmc
+
+**llmc** is the standalone, lightweight distribution of the AutoDeploy graph-transformation pipeline. It exposes the same `ModelFactory` and `InferenceOptimizer` building blocks as TensorRT-LLM's AutoDeploy backend, but with a minimal dependency footprint (PyTorch + Triton + FlashInfer), so you can prototype optimization pipelines or run inference without a full TRT-LLM install.
+
+The `llmc` package is **generated** from the AutoDeploy source tree inside the [TensorRT-LLM repo](https://github.com/NVIDIA/TensorRT-LLM). The standalone repo is **read-only** — see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for how to land changes.
+
+For general AutoDeploy documentation (motivation, support matrix, feature overview), see the [official docs](https://nvidia.github.io/TensorRT-LLM/features/auto_deploy/auto-deploy.html).
+
+______________________________________________________________________
+
+## Install
+
+From PyPI (when published):
+
+```bash
+pip install nvidia-llmc
+```
+
+The distribution name is `nvidia-llmc`; the importable Python package is `llmc`.
+
+### From source (recommended for development)
+
+Generate the standalone source tree from the TRT-LLM checkout:
+
+```bash
+# inside the TensorRT-LLM repo
+python examples/auto_deploy/llmc/create_standalone_package.py \
+    --output-dir /path/to/llmc_pkg
+```
+
+Then install with [uv](https://docs.astral.sh/uv/):
+
+```bash
+cd /path/to/llmc_pkg
+uv venv .venv --python 3.12
+source .venv/bin/activate
+uv pip install -e '.[dev]'
+```
+
+Or with pip:
+
+```bash
+cd /path/to/llmc_pkg
+python -m venv .venv
+source .venv/bin/activate
+pip install -e '.[dev]'
+```
+
+### Sanity check
+
+```python
+from llmc._compat import TRTLLM_AVAILABLE
+print(f"TRT-LLM available: {TRTLLM_AVAILABLE}")  # False in standalone mode
+```
+
+In standalone mode the package uses the PyTorch, Triton, and FlashInfer kernel paths. TRT-LLM-only kernels (custom CUDA, optimized all-reduce, MoE fused kernels, the `pyexecutor` runtime) are skipped at registration time.
+
+### Run the bundled tests
+
+```bash
+pytest tests/
+```
+
+______________________________________________________________________
+
+## Building a custom inference pipeline
+
+The two core abstractions in `llmc` are:
+
+- **`ModelFactory`** — wraps a HuggingFace checkpoint (or any other source) and produces an initialized `nn.Module` plus dynamic-shape metadata for export.
+- **`InferenceOptimizer`** — runs a configured pipeline of graph transforms (export → fuse → quantize → shard → compile → cache) over a model produced by a factory, against a `CachedSequenceInterface` that defines the input contract.
+
+The code below builds a custom optimization pipeline end-to-end, without going through the higher-level `LLM` API. It's the same machinery `LLM(...)` uses internally — direct access is useful when you want to insert your own transforms, target ONNX/MLIR export, or drive a non-standard runtime.
+
+```python
+import torch
+
+from llmc.models.factory import ModelFactoryRegistry
+from llmc.shim.interface import CachedSequenceInterface
+from llmc.transform.optimizer import InferenceOptimizer
+from llmc.utils.dist_config import DistConfig
+
+# 1. Build a ModelFactory.
+#
+#    The registry is populated at import time. Built-in factories include
+#    "AutoModelForCausalLM" (text generation) and
+#    "AutoModelForImageTextToText" (multimodal). Factories know how to
+#    resolve a HF model id, instantiate the architecture, optionally load
+#    weights, and report dynamic shapes for export.
+factory_cls = ModelFactoryRegistry.get("AutoModelForCausalLM")
+factory = factory_cls(
+    model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    model_kwargs={"torch_dtype": "float16"},
+    skip_loading_weights=False,  # set True to inspect graph without weights
+    max_seq_len=2048,
+)
+
+# 2. Define the runtime input contract via a CachedSequenceInterface.
+#
+#    This object owns the dummy inputs (input_ids, position_ids, ...) used
+#    during export and tracing, and — when running with a TRT-LLM-style
+#    KV cache — manages cache tensors. In standalone mode the cache
+#    manager is a no-op; CachedSequenceInterface still drives the
+#    transform pipeline.
+cache_seq = CachedSequenceInterface(
+    max_seq_len=2048,
+    max_batch_size=4,
+    device="cuda",
+    kv_cache_config=None,           # or llmc._compat.KvCacheConfig(...)
+    max_num_tokens=4 * 2048,
+    vocab_size_padded=factory.vocab_size_padded,
+)
+
+# 3. Describe the transform pipeline.
+#
+#    Each entry maps a registered transform name to its config.
+#    `stage` controls ordering across the pipeline; transforms are
+#    re-sorted by stage at construction time. The names below are
+#    illustrative — see `llmc.transform.library` for the full set.
+transforms_config = {
+    "export_to_gm":         {"stage": "export"},
+    "fuse_gemms":           {"stage": "post_export"},
+    "fuse_rmsnorm":         {"stage": "post_export"},
+    "shard_attention":      {"stage": "sharding", "world_size": 1},
+    "compile_model":        {"stage": "compile",  "backend": "torch-simple"},
+    "initialize_cache":     {"stage": "cache_init"},
+}
+
+# 4. Build the optimizer and run it.
+#
+#    `dist_config` is required when sharding across devices; for a single
+#    GPU the default (world_size=1) is fine.
+optimizer = InferenceOptimizer(
+    factory=factory,
+    config=transforms_config,
+    dist_config=DistConfig(world_size=1, rank=0, tp_size=1),
+)
+optimized_model = optimizer(cache_seq)
+
+# 5. Run the optimized model.
+#
+#    The exact call signature depends on the runtime your pipeline
+#    targets — for prefill-style cached attention, the inputs are
+#    (input_ids, position_ids) plus the cache state owned by `cache_seq`.
+input_ids = torch.tensor([[1, 2, 3, 4]], device="cuda")
+position_ids = torch.arange(input_ids.size(1), device="cuda").unsqueeze(0)
+with torch.inference_mode():
+    logits = optimized_model(input_ids, position_ids)
+print(logits.shape)
+```
+
+### Where to look next
+
+| Topic | Path |
+|-------|------|
+| Available transforms | `llmc/transform/library/` |
+| Available factories  | `llmc/models/`, `llmc/models/custom/` |
+| Custom ops & backends | `llmc/custom_ops/` |
+| Compile backends | `llmc/compile/backends/` |
+| Type compatibility shims | `llmc/_compat.py` |
+| Configuration data classes | `llmc/transform/interface.py`, `llmc/llm_args.py` |
+
+For higher-level usage, the `llmc.LLM` class (available when running inside TRT-LLM) wraps all of the above behind a familiar generate API. In pure-standalone mode use `InferenceOptimizer` directly as shown.
+
+______________________________________________________________________
+
+## Regenerating the standalone repo
+
+The standalone source tree is regenerated from TensorRT-LLM by running:
+
+```bash
+python examples/auto_deploy/llmc/create_standalone_package.py \
+    --output-dir /path/to/llmc_repo
+```
+
+The script overwrites only its managed paths (`llmc/`, `tests/`, `pyproject.toml`, `README.md`, `CONTRIBUTING.md`, `LICENSE`, `.gitignore`); existing `.git/`, `.github/`, and any other repo-specific files are preserved, so the resulting tree can be committed and pushed directly.

--- a/examples/auto_deploy/llmc/create_standalone_package.py
+++ b/examples/auto_deploy/llmc/create_standalone_package.py
@@ -53,8 +53,16 @@ TRTLLM_REQUIREMENTS = os.path.join(REPO_ROOT, "requirements.txt")
 TRTLLM_DEV_REQUIREMENTS = os.path.join(REPO_ROOT, "requirements-dev.txt")
 TRTLLM_LICENSE = os.path.join(REPO_ROOT, "LICENSE")
 TRTLLM_GITIGNORE = os.path.join(REPO_ROOT, ".gitignore")
+TRTLLM_EDITORCONFIG = os.path.join(REPO_ROOT, ".editorconfig")
+TRTLLM_CODE_OF_CONDUCT = os.path.join(REPO_ROOT, "CODE_OF_CONDUCT.md")
+TRTLLM_SECURITY = os.path.join(REPO_ROOT, "SECURITY.md")
+TRTLLM_ATTRIBUTIONS_PYTHON = os.path.join(REPO_ROOT, "ATTRIBUTIONS-Python.md")
 LLMC_README = os.path.join(SCRIPT_DIR, "README.md")
 LLMC_CONTRIBUTING = os.path.join(SCRIPT_DIR, "CONTRIBUTING.md")
+# Source-of-truth for the standalone repo's .github/ tree (issue/PR templates).
+# Stored under a non-".github" name so it does not interfere with TRT-LLM's own
+# .github/. Copied to ".github/" in the standalone output.
+LLMC_GITHUB_DIR = os.path.join(SCRIPT_DIR, ".github_for_llmc")
 
 # Test source directories
 AD_TESTS_DIR = os.path.join(REPO_ROOT, "tests", "unittest", "auto_deploy")
@@ -177,6 +185,11 @@ _MANAGED_PATHS = [
     "LICENSE",
     "CONTRIBUTING.md",
     ".gitignore",
+    ".editorconfig",
+    "CODE_OF_CONDUCT.md",
+    "SECURITY.md",
+    "ATTRIBUTIONS-Python.md",
+    ".github",
 ]
 
 
@@ -518,6 +531,27 @@ def create_standalone_package(output_dir: str) -> None:
     if os.path.exists(TRTLLM_GITIGNORE):
         shutil.copy2(TRTLLM_GITIGNORE, os.path.join(output_dir, ".gitignore"))
         print("  Copied .gitignore")
+
+    # 8. Copy .editorconfig
+    if os.path.exists(TRTLLM_EDITORCONFIG):
+        shutil.copy2(TRTLLM_EDITORCONFIG, os.path.join(output_dir, ".editorconfig"))
+        print("  Copied .editorconfig")
+
+    # 9. Copy OSS compliance files (CODE_OF_CONDUCT, SECURITY, ATTRIBUTIONS-Python)
+    for src, name in (
+        (TRTLLM_CODE_OF_CONDUCT, "CODE_OF_CONDUCT.md"),
+        (TRTLLM_SECURITY, "SECURITY.md"),
+        (TRTLLM_ATTRIBUTIONS_PYTHON, "ATTRIBUTIONS-Python.md"),
+    ):
+        if os.path.exists(src):
+            shutil.copy2(src, os.path.join(output_dir, name))
+            print(f"  Copied {name}")
+
+    # 10. Copy .github/ tree (issue/PR templates) from .github_for_llmc/
+    if os.path.isdir(LLMC_GITHUB_DIR):
+        github_dst = os.path.join(output_dir, ".github")
+        github_count = _copy_tree(LLMC_GITHUB_DIR, github_dst)
+        print(f"  Copied {github_count} .github/ files")
 
     print(f"\nStandalone package created at: {output_dir}")
     print("\nTo install:")

--- a/examples/auto_deploy/llmc/create_standalone_package.py
+++ b/examples/auto_deploy/llmc/create_standalone_package.py
@@ -228,12 +228,10 @@ def _rewrite_imports_in_file(filepath: str) -> int:
     relative imports (enforced by the ``auto-deploy-import-discipline``
     pre-commit hook), so no rewriting is needed for them. Tests, however,
     are written against the canonical absolute path
-    ``tensorrt_llm._torch.auto_deploy`` and need to be rewritten.
-
-    Handles:
-    - tensorrt_llm._torch.auto_deploy.X -> llmc.X
-    - from tensorrt_llm.llmapi.llm_args import KvCacheConfig -> from llmc._compat import KvCacheConfig
-    - from tensorrt_llm._torch.utils import ActivationType -> from llmc._compat import ActivationType
+    ``tensorrt_llm._torch.auto_deploy`` and need to be rewritten to
+    ``llmc``. Cross-package types (e.g. ``KvCacheConfig``,
+    ``ActivationType``) are sourced via ``..._torch.auto_deploy._compat``,
+    so the primary rewrite handles them too.
 
     Returns the number of line-level changes made.
     """
@@ -241,18 +239,7 @@ def _rewrite_imports_in_file(filepath: str) -> int:
         content = f.read()
 
     original = content
-    # Primary rewrite: tensorrt_llm._torch.auto_deploy -> llmc
     content = content.replace(_IMPORT_REWRITE, _IMPORT_TARGET)
-    # Test files that import KvCacheConfig from tensorrt_llm.llmapi
-    content = content.replace(
-        "from tensorrt_llm.llmapi.llm_args import KvCacheConfig",
-        "from llmc._compat import KvCacheConfig",
-    )
-    # Test files that import ActivationType from tensorrt_llm._torch.utils
-    content = content.replace(
-        "from tensorrt_llm._torch.utils import ActivationType",
-        "from llmc._compat import ActivationType",
-    )
 
     replacements = sum(1 for a, b in zip(original, content) if a != b)  # rough count
     if content != original:

--- a/examples/auto_deploy/llmc/create_standalone_package.py
+++ b/examples/auto_deploy/llmc/create_standalone_package.py
@@ -14,19 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Create a standalone auto_deploy package from the TensorRT-LLM source tree.
+"""Create a standalone llmc package from the TensorRT-LLM source tree.
 
-This script copies auto_deploy source files and tests into a standalone
-pip-installable package. The output directory can be pushed directly to the
-standalone repository.
+This script copies the ``tensorrt_llm/_torch/auto_deploy`` source tree and
+tests into a standalone pip-installable package. The output directory can
+be pushed directly to the read-only standalone repository.
 
 Usage:
     python create_standalone_package.py [--output-dir /path/to/output]
 
-The generated package uses ``auto_deploy`` as the top-level package name:
+The generated package uses ``llmc`` as the top-level Python package name and
+``nvidia-llmc`` as the distribution name:
 
-    from auto_deploy._compat import TRTLLM_AVAILABLE
-    from auto_deploy.custom_ops.attention_interface import SequenceInfo
+    from llmc._compat import TRTLLM_AVAILABLE
+    from llmc.custom_ops.attention_interface import SequenceInfo
+
+The ``auto_deploy`` source tree itself is copied verbatim — internal imports
+must already be relative (enforced by the
+``auto-deploy-import-discipline`` pre-commit hook), so no source rewriting
+is required. Test files use absolute ``tensorrt_llm._torch.auto_deploy``
+imports by design and ARE rewritten to ``llmc`` on copy.
 """
 
 import argparse
@@ -40,14 +47,14 @@ import textwrap
 # Path constants
 # ---------------------------------------------------------------------------
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", ".."))
+REPO_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, "..", "..", ".."))
 AUTO_DEPLOY_SRC = os.path.join(REPO_ROOT, "tensorrt_llm", "_torch", "auto_deploy")
 TRTLLM_REQUIREMENTS = os.path.join(REPO_ROOT, "requirements.txt")
 TRTLLM_DEV_REQUIREMENTS = os.path.join(REPO_ROOT, "requirements-dev.txt")
 TRTLLM_LICENSE = os.path.join(REPO_ROOT, "LICENSE")
 TRTLLM_GITIGNORE = os.path.join(REPO_ROOT, ".gitignore")
-AD_README = os.path.join(SCRIPT_DIR, "README.md")
-AD_CONTRIBUTING = os.path.join(SCRIPT_DIR, "CONTRIBUTING.md")
+LLMC_README = os.path.join(SCRIPT_DIR, "README.md")
+LLMC_CONTRIBUTING = os.path.join(SCRIPT_DIR, "CONTRIBUTING.md")
 
 # Test source directories
 AD_TESTS_DIR = os.path.join(REPO_ROOT, "tests", "unittest", "auto_deploy")
@@ -156,14 +163,14 @@ EXCLUDE_TEST_FILES = {
     "test_export_glm4_moe_lite.py",
 }
 
-# Import path rewrite: old -> new
+# Import path rewrite: old -> new (applied to test files only).
 _IMPORT_REWRITE = "tensorrt_llm._torch.auto_deploy"
-_IMPORT_TARGET = "auto_deploy"
+_IMPORT_TARGET = "llmc"
 
 # Paths that the script owns and regenerates on every run.
 # Everything else in the output directory (e.g., .git/, .github/) is preserved.
 _MANAGED_PATHS = [
-    "auto_deploy",
+    "llmc",
     "tests",
     "pyproject.toml",
     "README.md",
@@ -202,30 +209,36 @@ def _copy_tree(src_dir: str, dst_dir: str) -> int:
 
 
 def _rewrite_imports_in_file(filepath: str) -> int:
-    """Rewrite imports in a copied file for standalone mode.
+    """Rewrite imports in a copied test file for standalone mode.
+
+    Source files inside ``tensorrt_llm/_torch/auto_deploy`` already use
+    relative imports (enforced by the ``auto-deploy-import-discipline``
+    pre-commit hook), so no rewriting is needed for them. Tests, however,
+    are written against the canonical absolute path
+    ``tensorrt_llm._torch.auto_deploy`` and need to be rewritten.
 
     Handles:
-    - tensorrt_llm._torch.auto_deploy.X -> auto_deploy.X
-    - from tensorrt_llm.llmapi.llm_args import KvCacheConfig -> from auto_deploy._compat import KvCacheConfig
-    - from tensorrt_llm._torch.utils import ActivationType -> from auto_deploy._compat import ActivationType
+    - tensorrt_llm._torch.auto_deploy.X -> llmc.X
+    - from tensorrt_llm.llmapi.llm_args import KvCacheConfig -> from llmc._compat import KvCacheConfig
+    - from tensorrt_llm._torch.utils import ActivationType -> from llmc._compat import ActivationType
 
-    Returns the number of replacements made.
+    Returns the number of line-level changes made.
     """
     with open(filepath) as f:
         content = f.read()
 
     original = content
-    # Primary rewrite: tensorrt_llm._torch.auto_deploy -> auto_deploy
+    # Primary rewrite: tensorrt_llm._torch.auto_deploy -> llmc
     content = content.replace(_IMPORT_REWRITE, _IMPORT_TARGET)
     # Test files that import KvCacheConfig from tensorrt_llm.llmapi
     content = content.replace(
         "from tensorrt_llm.llmapi.llm_args import KvCacheConfig",
-        "from auto_deploy._compat import KvCacheConfig",
+        "from llmc._compat import KvCacheConfig",
     )
     # Test files that import ActivationType from tensorrt_llm._torch.utils
     content = content.replace(
         "from tensorrt_llm._torch.utils import ActivationType",
-        "from auto_deploy._compat import ActivationType",
+        "from llmc._compat import ActivationType",
     )
 
     replacements = sum(1 for a, b in zip(original, content) if a != b)  # rough count
@@ -413,9 +426,10 @@ def _create_pyproject_toml(output_dir: str, dependencies: list, dev_dependencies
         'build-backend = "setuptools.build_meta"\n'
         "\n"
         "[project]\n"
-        'name = "llm-compiler"\n'
+        'name = "nvidia-llmc"\n'
         'version = "0.1.0"\n'
-        'description = "LLM Compiler (llmc): Automatic model optimization and deployment for LLM inference"\n'
+        'description = "llmc: standalone LLM compiler — '
+        'automatic model optimization and deployment for LLM inference"\n'
         'readme = "README.md"\n'
         'license = {text = "Apache-2.0"}\n'
         'requires-python = ">=3.10"\n'
@@ -429,7 +443,7 @@ def _create_pyproject_toml(output_dir: str, dependencies: list, dev_dependencies
         "]\n"
         "\n"
         "[tool.setuptools.packages.find]\n"
-        'include = ["auto_deploy*"]\n'
+        'include = ["llmc*"]\n'
         "\n"
         "[tool.pytest.ini_options]\n"
         'testpaths = ["tests"]\n'
@@ -440,7 +454,7 @@ def _create_pyproject_toml(output_dir: str, dependencies: list, dev_dependencies
 
 
 def create_standalone_package(output_dir: str) -> None:
-    """Create the standalone auto_deploy package at the given output directory.
+    """Create the standalone llmc package at the given output directory.
 
     Safe to run against an existing git repository: only the managed paths
     (source, tests, and packaging files) are deleted and regenerated. The .git
@@ -463,12 +477,14 @@ def create_standalone_package(output_dir: str) -> None:
 
     print(f"Creating standalone package at: {output_dir}")
 
-    # 1. Copy auto_deploy source as top-level `auto_deploy/` package
-    ad_dst = os.path.join(output_dir, "auto_deploy")
+    # 1. Copy auto_deploy source as top-level `llmc/` package. No import
+    #    rewriting is needed: in-package imports are relative (enforced by
+    #    the auto-deploy-import-discipline pre-commit hook).
+    ad_dst = os.path.join(output_dir, "llmc")
     count = _copy_tree(AUTO_DEPLOY_SRC, ad_dst)
-    print(f"  Copied {count} source files to auto_deploy/")
+    print(f"  Copied {count} source files to llmc/")
 
-    # 2. Copy and rewrite tests
+    # 2. Copy and rewrite tests (tests use absolute self-imports by design).
     test_count = _copy_tests(output_dir)
     rewrite_count = _rewrite_imports_in_dir(os.path.join(output_dir, "tests"))
     print(f"  Copied {test_count} test files to tests/ ({rewrite_count} import rewrites)")
@@ -489,13 +505,13 @@ def create_standalone_package(output_dir: str) -> None:
         print("  Copied LICENSE")
 
     # 5. Copy README
-    if os.path.exists(AD_README):
-        shutil.copy2(AD_README, os.path.join(output_dir, "README.md"))
+    if os.path.exists(LLMC_README):
+        shutil.copy2(LLMC_README, os.path.join(output_dir, "README.md"))
         print("  Copied README.md")
 
     # 6. Copy CONTRIBUTING.md
-    if os.path.exists(AD_CONTRIBUTING):
-        shutil.copy2(AD_CONTRIBUTING, os.path.join(output_dir, "CONTRIBUTING.md"))
+    if os.path.exists(LLMC_CONTRIBUTING):
+        shutil.copy2(LLMC_CONTRIBUTING, os.path.join(output_dir, "CONTRIBUTING.md"))
         print("  Copied CONTRIBUTING.md")
 
     # 7. Copy .gitignore
@@ -511,18 +527,18 @@ def create_standalone_package(output_dir: str) -> None:
     print("  uv pip install -e '.[dev]'")
     print("\nTo run tests:     pytest tests/")
     print(
-        'To verify:        python -c "from auto_deploy._compat import TRTLLM_AVAILABLE; print(TRTLLM_AVAILABLE)"'
+        'To verify:        python -c "from llmc._compat import TRTLLM_AVAILABLE; print(TRTLLM_AVAILABLE)"'
     )
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Create a standalone auto_deploy package from TensorRT-LLM source.",
+        description="Create a standalone llmc package from TensorRT-LLM source.",
     )
     parser.add_argument(
         "--output-dir",
-        default=os.path.join(REPO_ROOT, "build", "auto_deploy_standalone"),
-        help="Output directory for the standalone package (default: build/auto_deploy_standalone)",
+        default=os.path.join(REPO_ROOT, "build", "llmc_standalone"),
+        help="Output directory for the standalone package (default: build/llmc_standalone)",
     )
     args = parser.parse_args()
     create_standalone_package(os.path.abspath(args.output_dir))

--- a/scripts/check_auto_deploy_imports.py
+++ b/scripts/check_auto_deploy_imports.py
@@ -22,32 +22,33 @@ in-package import statements.
 import ast
 import pathlib
 import sys
-from typing import List, Tuple
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 AD_ROOT = REPO_ROOT / "tensorrt_llm" / "_torch" / "auto_deploy"
 AD_PKG = "tensorrt_llm._torch.auto_deploy"
 
 
-def _file_package_parts(path: pathlib.Path) -> List[str]:
+def _file_package_parts(path: pathlib.Path) -> list[str]:
     """Return the dotted package path of the directory containing *path*."""
     rel = path.resolve().relative_to(REPO_ROOT)
     parts = list(rel.parts[:-1])  # drop filename
     return parts
 
 
-def _check_file(path: pathlib.Path) -> List[Tuple[int, str]]:
+def _check_file(path: pathlib.Path) -> list[tuple[int, str]]:
     try:
         source = path.read_text()
     except (OSError, UnicodeDecodeError):
         return []
     try:
         tree = ast.parse(source, filename=str(path))
-    except SyntaxError:
-        return []
+    except SyntaxError as exc:
+        # Treat parse failures as violations rather than silently passing —
+        # a malformed file should never sneak through the discipline check.
+        return [(exc.lineno or 1, f"failed to parse file: {exc.msg}")]
 
     pkg_parts = _file_package_parts(path)
-    violations: List[Tuple[int, str]] = []
+    violations: list[tuple[int, str]] = []
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
@@ -101,14 +102,14 @@ def _check_file(path: pathlib.Path) -> List[Tuple[int, str]]:
     return violations
 
 
-def main(argv: List[str]) -> int:
+def main(argv: list[str]) -> int:
     if len(argv) > 1:
         targets = [pathlib.Path(p).resolve() for p in argv[1:]]
     else:
         targets = sorted(AD_ROOT.rglob("*.py"))
 
     ad_root_resolved = AD_ROOT.resolve()
-    failures: List[Tuple[pathlib.Path, int, str]] = []
+    failures: list[tuple[pathlib.Path, int, str]] = []
     for path in targets:
         try:
             path.resolve().relative_to(ad_root_resolved)

--- a/scripts/check_auto_deploy_imports.py
+++ b/scripts/check_auto_deploy_imports.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Enforce import discipline inside ``tensorrt_llm/_torch/auto_deploy``.
+
+Two rules:
+
+A. Imports that resolve inside the auto_deploy package MUST be relative.
+   Absolute forms like ``import tensorrt_llm._torch.auto_deploy.X`` or
+   ``from tensorrt_llm._torch.auto_deploy.X import Y`` are forbidden.
+
+B. Relative imports MUST stay inside the auto_deploy package. A relative
+   import that escapes (e.g. ``from ....llmapi import X``) is forbidden;
+   reach the rest of TensorRT-LLM via absolute ``tensorrt_llm.X`` imports
+   instead.
+
+These rules keep auto_deploy's source tree portable: it can be copied
+verbatim into the standalone ``llmc`` package without rewriting any
+in-package import statements.
+"""
+
+import ast
+import pathlib
+import sys
+from typing import List, Tuple
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+AD_ROOT = REPO_ROOT / "tensorrt_llm" / "_torch" / "auto_deploy"
+AD_PKG = "tensorrt_llm._torch.auto_deploy"
+
+
+def _file_package_parts(path: pathlib.Path) -> List[str]:
+    """Return the dotted package path of the directory containing *path*."""
+    rel = path.resolve().relative_to(REPO_ROOT)
+    parts = list(rel.parts[:-1])  # drop filename
+    return parts
+
+
+def _check_file(path: pathlib.Path) -> List[Tuple[int, str]]:
+    try:
+        source = path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    pkg_parts = _file_package_parts(path)
+    violations: List[Tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == AD_PKG or alias.name.startswith(AD_PKG + "."):
+                    violations.append(
+                        (
+                            node.lineno,
+                            f"absolute self-import `import {alias.name}` — "
+                            f"use a relative import instead",
+                        )
+                    )
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0:
+                # Absolute import.
+                mod = node.module or ""
+                if mod == AD_PKG or mod.startswith(AD_PKG + "."):
+                    violations.append(
+                        (
+                            node.lineno,
+                            f"absolute self-import `from {mod} import ...` — "
+                            f"use a relative import instead",
+                        )
+                    )
+            else:
+                # Relative import — make sure it stays inside auto_deploy.
+                if node.level > len(pkg_parts):
+                    violations.append(
+                        (
+                            node.lineno,
+                            f"relative import with level={node.level} escapes the package root",
+                        )
+                    )
+                    continue
+                # Resolve the target package the relative import points to.
+                # `from .foo import bar` at depth 0 -> pkg_parts (the file's pkg)
+                # `from ..foo import bar` -> pkg_parts[:-1]
+                base_parts = pkg_parts[: len(pkg_parts) - (node.level - 1)]
+                base = ".".join(base_parts)
+                if not (base == AD_PKG or base.startswith(AD_PKG + ".")):
+                    target = base + (("." + node.module) if node.module else "")
+                    violations.append(
+                        (
+                            node.lineno,
+                            f"relative import resolves to `{target}` which is "
+                            f"outside `{AD_PKG}` — use an absolute "
+                            f"`from tensorrt_llm.<...> import ...` instead",
+                        )
+                    )
+
+    return violations
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) > 1:
+        targets = [pathlib.Path(p).resolve() for p in argv[1:]]
+    else:
+        targets = sorted(AD_ROOT.rglob("*.py"))
+
+    ad_root_resolved = AD_ROOT.resolve()
+    failures: List[Tuple[pathlib.Path, int, str]] = []
+    for path in targets:
+        try:
+            path.resolve().relative_to(ad_root_resolved)
+        except ValueError:
+            # File passed in by pre-commit that isn't under auto_deploy — skip.
+            continue
+        for lineno, msg in _check_file(path):
+            failures.append((path, lineno, msg))
+
+    if failures:
+        print(
+            "Import discipline check failed for tensorrt_llm/_torch/auto_deploy/.",
+            file=sys.stderr,
+        )
+        for path, lineno, msg in failures:
+            try:
+                rel = path.resolve().relative_to(REPO_ROOT)
+            except ValueError:
+                rel = path
+            print(f"  {rel}:{lineno}: {msg}", file=sys.stderr)
+        print(
+            "\nFix: replace absolute `tensorrt_llm._torch.auto_deploy.X` imports "
+            "with relative imports (e.g. `from ..X import Y`). For paths outside "
+            "auto_deploy, use absolute `tensorrt_llm.<...>` imports instead of "
+            "relative imports that escape the package.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/flashinfer_attention.py
@@ -25,7 +25,7 @@ from torch.fx import Node
 from ..._compat import KvCacheConfig
 
 try:
-    from ....flashinfer_utils import get_env_enable_pdl
+    from tensorrt_llm._torch.flashinfer_utils import get_env_enable_pdl
 except (ModuleNotFoundError, ImportError):
     import os
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla/trtllm_mla.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla/trtllm_mla.py
@@ -60,11 +60,15 @@ from torch._ops import OpOverloadPacket
 from torch._subclasses import FakeTensor
 from torch.fx import GraphModule, Node
 
+from tensorrt_llm._torch.attention_backend.interface import (
+    AttentionInputType,
+    PositionEmbeddingType,
+    RopeParams,
+)
 from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import AttentionMaskType
 from tensorrt_llm.quantization import QuantMode
 
-from ....attention_backend.interface import AttentionInputType, PositionEmbeddingType, RopeParams
 from ..._compat import KvCacheConfig, get_sm_version, prefer_pinned
 from ...utils.cuda_graph import cuda_graph_state
 from ...utils.node_utils import extract_op_args

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/flashinfer_fused_add_rms_norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/flashinfer_fused_add_rms_norm.py
@@ -13,7 +13,7 @@ import flashinfer
 import torch
 
 try:
-    from ....flashinfer_utils import get_env_enable_pdl
+    from tensorrt_llm._torch.flashinfer_utils import get_env_enable_pdl
 except (ModuleNotFoundError, ImportError):
     import os
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/rms_norm.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/normalization/rms_norm.py
@@ -22,7 +22,7 @@ import torch.nn.functional as F
 from einops import rearrange
 
 try:
-    from ....flashinfer_utils import get_env_enable_pdl
+    from tensorrt_llm._torch.flashinfer_utils import get_env_enable_pdl
 except (ModuleNotFoundError, ImportError):
     import os
 

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -3,11 +3,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 
-from ...executor.result import CompletionOutput
-from ...inputs.registry import DefaultInputProcessor, ExtraProcessedInputs
-from ...llmapi.llm import RequestOutput, _TorchLLM
-from ...llmapi.tokenizer import TokenizerBase, TransformersTokenizer, tokenizer_factory
-from ...sampling_params import SamplingParams
+from tensorrt_llm.executor.result import CompletionOutput
+from tensorrt_llm.inputs.registry import DefaultInputProcessor, ExtraProcessedInputs
+from tensorrt_llm.llmapi.llm import RequestOutput, _TorchLLM
+from tensorrt_llm.llmapi.tokenizer import TokenizerBase, TransformersTokenizer, tokenizer_factory
+from tensorrt_llm.sampling_params import SamplingParams
+
 from .distributed import common as dist_ad
 from .llm_args import LlmArgs
 from .models.factory import ModelFactory

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import types
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/tensorrt_llm/_torch/auto_deploy/llm.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -6,15 +6,16 @@ import torch
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from tensorrt_llm.mapping import Mapping
-
-from ...llmapi.llm_args import (
+from tensorrt_llm.llmapi.llm_args import (
     BuildConfig,
     EagleDecodingConfig,
     MTPDecodingConfig,
     TorchLlmArgs,
     _ParallelConfig,
 )
+from tensorrt_llm.mapping import Mapping
+
+from . import config as _ad_config_pkg
 from .models import ModelFactory, ModelFactoryRegistry
 from .utils._config import DynamicYamlMixInForSettings
 from .utils.dist_config import DistConfig
@@ -459,7 +460,7 @@ class LlmArgs(DynamicYamlMixInForSettings, TorchLlmArgs, BaseSettings):
     ### PRIVATE METHODS ############################################################################
     @classmethod
     def _get_yaml_default_from_mode(cls, mode: Optional[str]) -> Optional[str]:
-        config_path = files("tensorrt_llm._torch.auto_deploy.config")
+        config_path = files(_ad_config_pkg)
         mapping = {
             "graph": str(config_path / "default.yaml"),
             "transformers": str(config_path / "transformers.yaml"),

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek_ir.py
@@ -48,10 +48,11 @@ from transformers.generation import GenerationMixin
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
-import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 -- register all ops
-from tensorrt_llm._torch.auto_deploy.models.custom import mla_rope_utils
-from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.utils import ActivationType
+
+from ... import custom_ops  # noqa: F401 -- register all ops
+from ..hf import AutoModelForCausalLMFactory
+from . import mla_rope_utils
 
 
 class DeepSeekV3RMSNorm(nn.Module):

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_eagle.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_eagle.py
@@ -37,7 +37,8 @@ from transformers import PretrainedConfig, PreTrainedModel
 from transformers.activations import ACT2FN
 from transformers.utils import ModelOutput
 
-from ....pyexecutor.mamba_cache_manager import MambaHybridCacheManager
+from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import MambaHybridCacheManager
+
 from ...distributed.common import broadcast
 from ...shim.interface import CachedSequenceInterface
 from ...utils._config import deep_merge_dicts

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_llama3_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_llama3_ir.py
@@ -39,8 +39,8 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.utils import ModelOutput
 
-import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 -- register all ops
-from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+from ... import custom_ops  # noqa: F401 -- register all ops
+from ..hf import AutoModelForCausalLMFactory
 
 
 class Llama3RMSNorm(nn.Module):

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_minimax_m2.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_minimax_m2.py
@@ -33,8 +33,9 @@ from transformers.generation import GenerationMixin
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
-from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.utils import ActivationType
+
+from ..hf import AutoModelForCausalLMFactory
 
 # ---------------------------------------------------------------------------
 # Output dataclasses

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_nemotron_h_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_nemotron_h_ir.py
@@ -44,9 +44,10 @@ from transformers.generation import GenerationMixin
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
-import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401, I001 -- register all ops
-from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
 from tensorrt_llm._torch.utils import ActivationType
+
+from ... import custom_ops  # noqa: F401, I001 -- register all ops
+from ..hf import AutoModelForCausalLMFactory
 
 
 class MambaRMSNormGated(torch.nn.Module):

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe_ir.py
@@ -53,16 +53,17 @@ from transformers.modeling_outputs import BaseModelOutputWithPooling
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import ModelOutput
 
-import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401, I001 -- register all ops
-from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo
-from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
-from tensorrt_llm._torch.auto_deploy.models.hf import (
+from tensorrt_llm.inputs.multimodal import MultimodalInput, apply_mm_hashes, hexdigest_to_int32
+from tensorrt_llm.inputs.utils import VideoData
+
+from ... import custom_ops  # noqa: F401, I001 -- register all ops
+from ...custom_ops.attention_interface import BatchInfo
+from ..factory import ModelFactoryRegistry
+from ..hf import (
     AutoModelForCausalLMFactory,
     AutoModelForImageTextToTextFactory,
     TextModelExportInfo,
 )
-from tensorrt_llm.inputs.multimodal import MultimodalInput, apply_mm_hashes, hexdigest_to_int32
-from tensorrt_llm.inputs.utils import VideoData
 
 # =============================================================================
 # Configuration

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_ir.py
@@ -38,8 +38,8 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
 from transformers.utils import ModelOutput
 
-import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 -- register all ops
-from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+from ... import custom_ops  # noqa: F401 -- register all ops
+from ..hf import AutoModelForCausalLMFactory
 
 
 class Qwen3RMSNorm(nn.Module):

--- a/tensorrt_llm/_torch/auto_deploy/models/eagle.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/eagle.py
@@ -32,7 +32,8 @@ from torch._prims_common import DeviceLikeType
 from torch.export import Dim
 from torch.fx import GraphModule
 
-from ....llmapi.llm_args import MTPDecodingConfig
+from tensorrt_llm.llmapi.llm_args import MTPDecodingConfig
+
 from ..utils.logger import ad_logger
 from .custom.modeling_eagle import (
     EagleConfig,

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -23,6 +23,7 @@ from torch._prims_common import DeviceLikeType
 
 from tensorrt_llm._torch.attention_backend.interface import AttentionRuntimeFeatures
 from tensorrt_llm._torch.autotuner import AutoTuner
+from tensorrt_llm._torch.distributed import Distributed
 from tensorrt_llm._torch.models.modeling_speculative import Eagle3ForCausalLM
 from tensorrt_llm._torch.pyexecutor._util import (
     _create_kv_cache_manager,
@@ -32,11 +33,28 @@ from tensorrt_llm._torch.pyexecutor._util import (
 from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import CUDA_GRAPH_DUMMY_REQUEST_ID
 from tensorrt_llm._torch.pyexecutor.guided_decoder import GuidedDecoder
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, get_draft_token_length
+from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import BaseMambaCacheManager
+from tensorrt_llm._torch.pyexecutor.model_engine import ModelEngine, PyTorchModelEngine
+from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
 from tensorrt_llm._torch.pyexecutor.py_executor_creator import get_guided_decoding_config
+from tensorrt_llm._torch.pyexecutor.resource_manager import (
+    BaseResourceManager,
+    KVCacheManager,
+    ResourceManager,
+    ResourceManagerType,
+)
+from tensorrt_llm._torch.pyexecutor.sampler import TorchSampler, TRTLLMSampler
+from tensorrt_llm._torch.pyexecutor.scheduler import (
+    BindCapacityScheduler,
+    BindMicroBatchScheduler,
+    RequestList,
+    ScheduledRequests,
+    SimpleScheduler,
+)
 from tensorrt_llm._torch.pyexecutor.seq_slot_manager import SeqSlotManager
 from tensorrt_llm._torch.speculative import get_spec_drafter
 from tensorrt_llm._torch.speculative.eagle3 import Eagle3OneModelSampler, Eagle3ResourceManager
-from tensorrt_llm._utils import nvtx_range
+from tensorrt_llm._utils import get_free_port, mpi_rank, mpi_world_size, nvtx_range
 from tensorrt_llm.inputs.multimodal import MultimodalRuntimeData, check_mm_embed_cumsum_if_needed
 from tensorrt_llm.llmapi.llm_args import (
     ContextChunkingPolicy,
@@ -47,27 +65,8 @@ from tensorrt_llm.llmapi.llm_args import (
     TorchLlmArgs,
 )
 from tensorrt_llm.llmapi.tokenizer import TokenizerBase
+from tensorrt_llm.mapping import Mapping
 
-from ...._utils import get_free_port, mpi_rank, mpi_world_size
-from ....mapping import Mapping
-from ...distributed import Distributed
-from ...pyexecutor.mamba_cache_manager import BaseMambaCacheManager
-from ...pyexecutor.model_engine import ModelEngine, PyTorchModelEngine
-from ...pyexecutor.py_executor import PyExecutor
-from ...pyexecutor.resource_manager import (
-    BaseResourceManager,
-    KVCacheManager,
-    ResourceManager,
-    ResourceManagerType,
-)
-from ...pyexecutor.sampler import TorchSampler, TRTLLMSampler
-from ...pyexecutor.scheduler import (
-    BindCapacityScheduler,
-    BindMicroBatchScheduler,
-    RequestList,
-    ScheduledRequests,
-    SimpleScheduler,
-)
 from ..distributed.common import initialize_or_skip
 from ..llm_args import LlmArgs
 from ..transform.optimizer import InferenceOptimizer

--- a/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/demollm.py
@@ -8,12 +8,16 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import torch
 import torch.multiprocessing as mp
 
-from ....executor import GenerationExecutor
-from ....executor.request import GenerationRequest
-from ....executor.result import CompletionOutput, GenerationResult
-from ....inputs.multimodal import MultimodalParams
-from ....sampling_params import SamplingParams
-from ...pyexecutor.sampling_utils import greedy_search_sampling_batch, top_k_sampling_batch
+from tensorrt_llm._torch.pyexecutor.sampling_utils import (
+    greedy_search_sampling_batch,
+    top_k_sampling_batch,
+)
+from tensorrt_llm.executor import GenerationExecutor
+from tensorrt_llm.executor.request import GenerationRequest
+from tensorrt_llm.executor.result import CompletionOutput, GenerationResult
+from tensorrt_llm.inputs.multimodal import MultimodalParams
+from tensorrt_llm.sampling_params import SamplingParams
+
 from ..distributed import common as dist_ad
 from ..utils.logger import ad_logger
 from .ad_executor import ADEngine

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import copy
 import functools
 from typing import Callable, Dict, List, Optional, Tuple, Union, final

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -10,14 +10,13 @@ from .._compat import TRTLLM_AVAILABLE, KvCacheConfig
 
 if TRTLLM_AVAILABLE:
     import tensorrt_llm.bindings
-    from tensorrt_llm.mapping import Mapping
-
-    from ...._utils import torch_dtype_to_binding
-    from ...pyexecutor.mamba_cache_manager import (
+    from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import (
         MambaHybridCacheManager,
         MixedMambaHybridCacheManager,
     )
-    from ...pyexecutor.resource_manager import KVCacheManager
+    from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
+    from tensorrt_llm._utils import torch_dtype_to_binding
+    from tensorrt_llm.mapping import Mapping
 
     CacheTypeCpp = tensorrt_llm.bindings.internal.batch_manager.CacheType
     DataType = tensorrt_llm.bindings.DataType
@@ -27,6 +26,7 @@ else:
     # but initialize_resources() and other cache-manager methods will raise.
     KVCacheManager = None
     MambaHybridCacheManager = None
+    MixedMambaHybridCacheManager = None
     CacheTypeCpp = None
     DataType = None
     Mapping = None

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/moe_routing.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/moe_routing.py
@@ -37,8 +37,7 @@ import torch
 from torch.fx import GraphModule, Node
 
 # Importing this module registers the torch.ops.auto_deploy.triton_fused_topk_softmax op.
-import tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.triton_routing  # noqa: F401
-
+from ...custom_ops.fused_moe import triton_routing  # noqa: F401
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
 from ...utils._graph import eliminate_dead_code

--- a/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/quantization_utils.py
@@ -20,7 +20,7 @@ from .node_utils import (
 )
 
 try:
-    from ....quantization.utils.fp4_utils import float4_sf_dtype
+    from tensorrt_llm.quantization.utils.fp4_utils import float4_sf_dtype
 except ImportError:
     float4_sf_dtype = None
 

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_triton_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_triton_moe.py
@@ -3,8 +3,8 @@ import torch
 from utils.util import skip_pre_hopper
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy._compat import ActivationType  # noqa: F401
 from tensorrt_llm._torch.auto_deploy.custom_ops.fused_moe.load_moe_align import moe_align_block_size
-from tensorrt_llm._torch.utils import ActivationType  # noqa: F401
 
 
 def _pack_routed_tokens_reference(

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_trtllm_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_trtllm_moe.py
@@ -13,12 +13,12 @@ from torch.nn import functional as F
 from utils.util import skip_pre_hopper
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy._compat import ActivationType
 from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.quant import (
     TRTLLM_NVFP4_COLUMN_SIZE,
     TRTLLM_NVFP4_ROW_SIZE,
     TRTLLM_NVFP4_SCALING_VECTOR_SIZE,
 )
-from tensorrt_llm._torch.utils import ActivationType
 
 FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
 FLOAT4_E2M1_MAX = 6.0

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_cached_sequence_interface.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_cached_sequence_interface.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 from _model_test_utils import default_max_num_tokens
 
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import (
     CausalConvResourceHandler,
     KVPagedResourceHandler,
@@ -24,7 +25,6 @@ from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterfa
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import MambaHybridCacheManager
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm.llmapi import DraftTargetDecodingConfig
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 
 # =============================================================================
 # Fixtures

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_engine.py
@@ -6,11 +6,11 @@ import torch.nn as nn
 from _model_test_utils import default_max_num_tokens
 
 from tensorrt_llm import SamplingParams
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
 from tensorrt_llm._torch.auto_deploy.shim.ad_executor import ADEngine
 from tensorrt_llm._torch.auto_deploy.shim.demollm import DemoEngine
 from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 
 
 class TransformerLikeModelwithFakeCachePool(nn.Module):

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_trtllm_attention_quant_fp8.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_fuse_trtllm_attention_quant_fp8.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 from _torch_test_utils import fp8_compatible
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention.trtllm_attention import (
     get_trtllm_attention_fp8_input_scale,
 )
@@ -11,7 +12,6 @@ from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import extract_op_args, is_op
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 
 
 def _build_fp8_linear_args(hidden_size: int, out_features: int, device: torch.device):

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_gated_delta_rule_cache.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_gated_delta_rule_cache.py
@@ -29,6 +29,7 @@ from _torch_test_utils import all_close
 
 # Register all auto_deploy custom ops
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
 from tensorrt_llm._torch.auto_deploy.models.factory import (
     FullModelExportInfo,
     ModelFactory,
@@ -36,7 +37,6 @@ from tensorrt_llm._torch.auto_deploy.models.factory import (
 )
 from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 
 # ---------------------------------------------------------------------------
 # Dummy factory (same pattern as test_kv_cache.py)

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_gemm_fusion_trtllm.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_gemm_fusion_trtllm.py
@@ -14,11 +14,11 @@ import torch.nn as nn
 from test_gemm_fusion import TestModel  # type: ignore
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401 (registers torch_attention op)
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_linear_op, is_op
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 
 torch.manual_seed(0)
 

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_kv_cache.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_kv_cache.py
@@ -8,6 +8,8 @@ import torch.nn as nn
 from _model_test_utils import GQA, default_max_num_tokens
 from _torch_test_utils import all_close
 
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
+
 # Initialize resources first (KVPagedResourceHandler is used within tests below)
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import KVPagedResourceHandler
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
@@ -24,7 +26,6 @@ from tensorrt_llm._torch.auto_deploy.transform.library.kvcache import (
     ResizeKVCache,
 )
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 
 
 class DummyFactory(ModelFactory):

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_moe_fusion.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_moe_fusion.py
@@ -12,11 +12,11 @@ from _torch_test_utils import fp4_compatible, fp8_compatible, trtllm_ops_availab
 from utils.util import skip_pre_blackwell, skip_pre_hopper
 
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy._compat import ActivationType
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import fp4_global_scale
-from tensorrt_llm._torch.utils import ActivationType
 
 
 class BlockSparseTop2MLP(nn.Module):

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_torch_gated_delta_rule_cache.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_torch_gated_delta_rule_cache.py
@@ -21,6 +21,7 @@ from _torch_test_utils import all_close
 
 # Register all auto_deploy custom ops
 import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
 from tensorrt_llm._torch.auto_deploy.models.factory import (
     FullModelExportInfo,
     ModelFactory,
@@ -28,7 +29,6 @@ from tensorrt_llm._torch.auto_deploy.models.factory import (
 )
 from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 
 # ---------------------------------------------------------------------------
 # Dummy factory (same pattern as test_kv_cache.py)

--- a/tests/unittest/auto_deploy/standalone/test_standalone_package.py
+++ b/tests/unittest/auto_deploy/standalone/test_standalone_package.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""End-to-end test for the standalone auto_deploy package.
+"""End-to-end test for the standalone llmc package.
 
 This test:
 1. Runs create_standalone_package.py to generate the standalone package
@@ -35,7 +35,9 @@ import textwrap
 import pytest
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
-CREATE_SCRIPT = os.path.join(REPO_ROOT, "examples", "auto_deploy", "create_standalone_package.py")
+CREATE_SCRIPT = os.path.join(
+    REPO_ROOT, "examples", "auto_deploy", "llmc", "create_standalone_package.py"
+)
 
 
 def _find_uv():
@@ -107,19 +109,19 @@ class TestStandalonePackage:
         result = _run_isolated(
             standalone_package,
             """
-            from auto_deploy._compat import TRTLLM_AVAILABLE
+            from llmc._compat import TRTLLM_AVAILABLE
             assert not TRTLLM_AVAILABLE, f"Got {TRTLLM_AVAILABLE}"
             print("OK")
             """,
         )
         assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
 
-    def test_import_auto_deploy(self, standalone_package):
-        """The full auto_deploy module should import."""
+    def test_import_llmc(self, standalone_package):
+        """The full llmc module should import."""
         result = _run_isolated(
             standalone_package,
             """
-            import auto_deploy
+            import llmc
             print("OK")
             """,
         )
@@ -131,7 +133,7 @@ class TestStandalonePackage:
             standalone_package,
             """
             import torch
-            import auto_deploy
+            import llmc
             ops = [n for n in dir(torch.ops.auto_deploy) if not n.startswith('_')]
             assert len(ops) > 0, f"No ops: {ops}"
             print(f"{len(ops)} ops")
@@ -144,10 +146,10 @@ class TestStandalonePackage:
         result = _run_isolated(
             standalone_package,
             """
-            from auto_deploy._compat import (
+            from llmc._compat import (
                 ActivationType, KvCacheConfig, str_dtype_to_torch,
             )
-            from auto_deploy.utils.dist_config import DistConfig
+            from llmc.utils.dist_config import DistConfig
             import torch
             assert ActivationType.Silu == 4
             assert KvCacheConfig().tokens_per_block == 32
@@ -161,7 +163,7 @@ class TestStandalonePackage:
     def test_run_unit_tests(self, standalone_package):
         """Run the copied unit tests from the standalone package's tests/ dir.
 
-        Tests have been import-rewritten to use `auto_deploy` instead of
+        Tests have been import-rewritten to use `llmc` instead of
         `tensorrt_llm._torch.auto_deploy`, so they run directly against the
         standalone package.
         """
@@ -173,8 +175,8 @@ class TestStandalonePackage:
             pytest.skip("No tests directory in standalone package")
 
         # Pass through the host env but override PYTHONPATH to use standalone tests.
-        # The venv's pip install already put auto_deploy in the venv's site-packages,
-        # so `import auto_deploy` resolves there (not to the host TRT-LLM).
+        # The venv's pip install already put llmc in the venv's site-packages,
+        # so `import llmc` resolves there (not to the host TRT-LLM).
         standalone_env = {
             **os.environ,
             "PYTHONPATH": tests_dir + os.pathsep + os.path.join(tests_dir, "_utils_test"),


### PR DESCRIPTION
## Summary

- Renames the standalone AutoDeploy distribution to **`llmc`** (PyPI: `nvidia-llmc`); the AutoDeploy source tree itself stays put. The renaming happens at standalone-package generation time only.
- Adds a pre-commit hook (`auto-deploy-import-discipline`) that enforces relative-only imports inside `tensorrt_llm/_torch/auto_deploy/`, so the source tree can be copied verbatim into the standalone repo without rewriting in-package imports.
- Splits the example READMEs/CONTRIBUTING for in-tree (TRT-LLM) vs standalone (`llmc`) usage; relocates `create_standalone_package.py` to `examples/auto_deploy/llmc/`.
- Makes TRT-LLM the source of truth for the standalone repo's OSS compliance metadata: `CODE_OF_CONDUCT.md`, `SECURITY.md`, `ATTRIBUTIONS-Python.md`, `.editorconfig`, and a `.github/` tree (issue/PR templates) are now copied into the standalone package on every regen.

### Notable changes

- **Lint hook + script** — `scripts/check_auto_deploy_imports.py` (AST-based). Two rules: (A) imports resolving inside `tensorrt_llm._torch.auto_deploy` must be relative; (B) relative imports must not escape the package — use absolute `tensorrt_llm.X` for that.
- **Source fixes for the hook to pass** — 7 absolute self-imports in `models/custom/modeling_*_ir.py` and `transform/library/moe_routing.py` converted to relative; 9 escaping relative imports in `llm.py`, `llm_args.py`, `shim/{ad_executor,demollm,interface}.py`, `models/eagle.py`, `models/custom/modeling_eagle.py`, several custom-ops files, and `utils/quantization_utils.py` flipped to absolute `from tensorrt_llm.X`. ``llm_args.py`` resolves the bundled config dir via ``files(_ad_config_pkg)`` instead of a hardcoded ``"tensorrt_llm._torch.auto_deploy.config"`` string so it works under both flavors.
- **Standalone generator** — moved to ``examples/auto_deploy/llmc/create_standalone_package.py``. Output package is now ``llmc/`` with distribution name ``nvidia-llmc`` (Python import: ``import llmc``). Source-side import rewriting is dropped (no longer needed); test files keep absolute imports and are still rewritten on copy.
- **OSS compliance copy-over** — the generator additionally pulls `CODE_OF_CONDUCT.md`, `SECURITY.md`, `ATTRIBUTIONS-Python.md`, and `.editorconfig` from the TRT-LLM repo root, plus a `.github/` tree (issue/PR templates) from `examples/auto_deploy/llmc/.github_for_llmc/` (stored under that non-`.github` name to avoid colliding with TRT-LLM's own `.github/`). The issue-template `config.yml` disables blank issues and redirects bug reports / feature requests / discussions / security reports back to NVIDIA/TensorRT-LLM (or PSIRT). The PR template likewise points contributors at `NVIDIA/TensorRT-LLM`. All copied paths are added to `_MANAGED_PATHS` so the regen stays idempotent.
- **READMEs** — ``examples/auto_deploy/README.md`` reverted to TRT-LLM-only and links to ``llmc/``. New ``examples/auto_deploy/llmc/README.md`` adds install instructions and a comprehensive ``ModelFactory`` + ``InferenceOptimizer`` + ``CachedSequenceInterface`` example showing how to build a custom inference pipeline.
- **CONTRIBUTING** — new ``examples/auto_deploy/llmc/CONTRIBUTING.md`` documents that the standalone repo is read-only and PRs must land on TensorRT-LLM (you can fork llmc to experiment, but the upstream source of truth is here).

The torch op namespace stays as ``torch.ops.auto_deploy`` (no rename). No public-API changes.

## Test plan

- [x] ``scripts/check_auto_deploy_imports.py`` passes on the entire ``tensorrt_llm/_torch/auto_deploy/`` tree.
- [x] ``pre-commit run --all-files`` passes for the new ``auto-deploy-import-discipline`` hook.
- [x] ``pre-commit run`` on every changed file passes (ruff, ruff-format, mdformat, codespell, the new hook, etc.).
- [x] Smoke import: ``python -c "import tensorrt_llm._torch.auto_deploy; from tensorrt_llm._torch.auto_deploy.llm_args import LlmArgs; from tensorrt_llm._torch.auto_deploy.shim.demollm import DemoEngine; from tensorrt_llm._torch.auto_deploy.shim.ad_executor import ADEngine"``.
- [x] ``pytest tests/unittest/auto_deploy/standalone/`` — 12/12 passed (~4m30s, re-run after OSS compliance changes). This includes the nested run of the standalone package's own unit-test suite (`test_run_unit_tests` installs ``nvidia-llmc`` into an isolated venv and runs the copied tests).
- [x] Regen smoke: ``python examples/auto_deploy/llmc/create_standalone_package.py --output-dir /tmp/<...>`` writes the new files (``CODE_OF_CONDUCT.md``, ``SECURITY.md``, ``ATTRIBUTIONS-Python.md``, ``.editorconfig``, ``.github/ISSUE_TEMPLATE/config.yml``, ``.github/PULL_REQUEST_TEMPLATE.md``) byte-identical to their TRT-LLM sources.
- [x] CI must include the AutoDeploy stages: please run with ``/bot run --extra-stage "DGX_B200-4_GPUs-AutoDeploy-1, DGX_H100-4_GPUs-AutoDeploy-1"``.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for the standalone `llmc` package, including installation, usage examples, and contributing guidelines.

* **Developer Tools**
  * Introduced import validation enforcement via pre-commit hook for improved code consistency.

* **Updates**
  * Standalone package rebranded as `llmc` with updated generation and packaging configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
