### PR TITLE
[None][perf] Scheme X L2-aware dispatcher and PDL launchers for sparse-attention GVR Top-K

### DIFF
--- a/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
+++ b/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
@@ -20,8 +20,8 @@
 #include "tensorrt_llm/common/config.h"
 #include "tensorrt_llm/common/envUtils.h"
 
-// Import heuristicTopKJob (__device__ __noinline__) and all helpers.
-// heuristicTopKJob is independently optimized by ptxas, matching standalone
+// Import gvrTopKJob (__device__ __noinline__, the GVR micro-kernel) and
+// all helpers. gvrTopKJob is independently optimized by ptxas, matching standalone
 // SASS quality regardless of the caller's prologue code.
 #include "tensorrt_llm/kernels/heuristic_topk.cuh"
 
@@ -35,12 +35,13 @@ namespace
 {
 
 using heuristic_topk::BLOCK_SIZE;
-using heuristic_topk::heuristicTopKJob;
+using heuristic_topk::gvrTopKJob;
 using heuristic_topk::KernelSmem;
 using heuristic_topk::TOP_K;
 
-// Multi-row kernel: thin wrapper that computes per-row parameters,
-// then calls heuristicTopKJob (independently optimized device function).
+// heuristicTopKMultiRowKernel — outer multi-row launch wrapper (1 CTA per row).
+// Computes per-row parameters, then dispatches to the GVR micro-kernel
+// (gvrTopKJob, single-CTA single-row, independently optimized device function).
 __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float const* __restrict__ logits,
     int const* __restrict__ seqLens, int const* __restrict__ preIdx, float* __restrict__ scratchValues,
     int* __restrict__ outIndices, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount)
@@ -79,7 +80,7 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float 
     // +1 accounts for the temporal shift: prev_topk indices were computed at
     // seq_len-1, but the current step has one additional KV token appended.
     int const preIdxOffset = (rowIdx % next_n) + 1;
-    heuristicTopKJob(input, N, rowPreIdx, preIdxCount, topK, outputValues, outputIndices, smem, preIdxOffset);
+    gvrTopKJob(input, N, rowPreIdx, preIdxCount, topK, outputValues, outputIndices, smem, preIdxOffset);
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaTriggerProgrammaticLaunchCompletion();
 #endif

--- a/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
+++ b/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
@@ -18,6 +18,7 @@
 
 #include "tensorrt_llm/common/assert.h"
 #include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/common/envUtils.h"
 
 // Import heuristicTopKJob (__device__ __noinline__) and all helpers.
 // heuristicTopKJob is independently optimized by ptxas, matching standalone
@@ -69,6 +70,9 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float 
             outputValues[i] = -FLT_MAX;
             outputIndices[i] = -1;
         }
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+        cudaTriggerProgrammaticLaunchCompletion();
+#endif
         return;
     }
 
@@ -76,6 +80,9 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float 
     // seq_len-1, but the current step has one additional KV token appended.
     int const preIdxOffset = (rowIdx % next_n) + 1;
     heuristicTopKJob(input, N, rowPreIdx, preIdxCount, topK, outputValues, outputIndices, smem, preIdxOffset);
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
 }
 
 } // anonymous namespace
@@ -102,8 +109,19 @@ void launchHeuristicTopKDecode(float const* logits, int const* seqLens, int cons
     TLLM_CHECK_WITH_INFO(stride0 % 4 == 0 || numRows <= 1,
         "heuristicTopKDecode requires logits stride0 divisible by 4 for multi-row launch");
 
-    heuristicTopKMultiRowKernel<<<numRows, BLOCK_SIZE, smemSize, stream>>>(
-        logits, seqLens, preIdx, scratchValues, outIndices, stride0, next_n, topK, preIdxStride, preIdxCount);
+    cudaLaunchConfig_t config;
+    config.gridDim = numRows;
+    config.blockDim = BLOCK_SIZE;
+    config.dynamicSmemBytes = smemSize;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+    config.numAttrs = 1;
+    config.attrs = attrs;
+
+    cudaLaunchKernelEx(&config, heuristicTopKMultiRowKernel, logits, seqLens, preIdx, scratchValues, outIndices,
+        stride0, next_n, topK, preIdxStride, preIdxCount);
 }
 
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -43,7 +43,8 @@
 
 #include <cfloat>
 #include <cstdint>
-#include <cstdio> // for snap convergence warning printf
+#include <cstdio>  // for snap convergence warning printf
+#include <cstdlib> // for std::getenv (PDL launcher env-gate)
 #include <cuda_runtime.h>
 
 namespace heuristic_topk
@@ -802,8 +803,33 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
         cudaFuncSetAttribute(gvrTopKKernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
     }
 
-    gvrTopKKernel<<<1, BLOCK_SIZE, smemSize, stream>>>(
-        input, N, preIdx, M, topK, outputValues, outputIndices, thresholdPos);
+    // Use cudaLaunchKernelEx with PDL attribute so the kernel epilogue's
+    // cudaTriggerProgrammaticLaunchCompletion() takes effect on Hopper+. The
+    // attribute is a no-op on pre-Hopper architectures. Honor the standard
+    // TRTLLM_ENABLE_PDL env var (default on; set "0" to disable) without
+    // depending on TRT-LLM common headers, since this launcher is also reused
+    // by the standalone JIT-compiled PyTorch extension under
+    // ablation_study/gvr_phase_timing/.
+    bool enablePDL = true;
+    if (char const* env = std::getenv("TRTLLM_ENABLE_PDL"))
+    {
+        if (env[0] == '0' && env[1] == '\0')
+            enablePDL = false;
+    }
+
+    cudaLaunchConfig_t config{};
+    config.gridDim = dim3(1);
+    config.blockDim = dim3(BLOCK_SIZE);
+    config.dynamicSmemBytes = smemSize;
+    config.stream = stream;
+
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = enablePDL ? 1 : 0;
+    config.attrs = attrs;
+    config.numAttrs = 1;
+
+    cudaLaunchKernelEx(&config, gvrTopKKernel, input, N, preIdx, M, topK, outputValues, outputIndices, thresholdPos);
 
     return cudaGetLastError();
 }

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -15,21 +15,28 @@
  */
 
 // ============================================================================
-// heuristic_topk.cuh — V2e: V2d + OPT5 (safety-guard done!=1) +
-//                           OPT6 (NUM_BINS=2048 + parallel Phase 4b K-th bin search) +
-//                           OPT7 (Phase 3 sub-pass 1 elimination via per-thread count cache)
-// Heuristic-Guided TopK — Sort-Free, Histogram-Based Selection
-// Optimised for NVIDIA B200 (Blackwell, sm_100), single thread-block kernel
+// heuristic_topk.cuh — Heuristic-Guided Top-K (Sort-Free, Histogram-Based)
 //
-// V2d: ballot-free Phase 3, skip-4a, skip-PassA, 256-bin, snap≤3
-//      OPT3 (__ldg), OPT4 (redux.sync)
-// V2e: +OPT5 (skip Phase 3 blockCountGE re-scan when done==1)
-//      +OPT6 (NUM_BINS=2048 + parallel 2-step K-th bin search in Phase 4b)
-//      +OPT7 (reuse per-thread counts cached by last blockCountGE; eliminates
-//             Phase 3 sub-pass 1 full-N rescan)
+// Outer name: "heuristic" (algorithm family + public dispatcher / launchers).
+// Inner name: "gvr" (Guess-Verify-Refine) — the single-CTA single-row
+//             micro-kernel implementing the algorithm of:
+//   "Guess-Verify-Refine: Data-Aware Top-K for Sparse-Attention Decoding
+//    on Blackwell via Temporal Correlation"
 //
-// Define HEURISTIC_TOPK_PROFILE before including to enable per-phase printf.
-// Shared memory: ~59 KB (no CUB dependency)
+// Optimised for NVIDIA B200 (Blackwell, sm_100), single thread-block kernel.
+//
+// GVR phase mapping:
+//   P1 (preIdx stats)               ┐  Guess: estimate the K-th-value
+//   P2 (secant threshold search)    ┘  threshold from previous-step top-K
+//                                      indices, then refine the guess via
+//                                      count-only secant iterations.
+//   P3 (collect)                    — Verify: scatter the elements that
+//                                      pass the guessed threshold into
+//                                      shared memory and confirm the
+//                                      candidate count is in the safe band.
+//   P4 (histogram snap + partition) — Refine: 2048-bin histogram snap to
+//                                      the exact K-th value, then partition
+//                                      the candidates into the output set.
 // ============================================================================
 
 #pragma once
@@ -254,154 +261,94 @@ __device__ __forceinline__ void blockFusedSnapIter(KernelSmem* smem, int count, 
 // for this function independently from the caller, matching standalone SASS.
 // ============================================================================
 
-__device__ __noinline__ void heuristicTopKJob(float const* __restrict__ input, int const N,
-    int const* __restrict__ preIdx, int const M, int const topK, float* __restrict__ outputValues,
-    int* __restrict__ outputIndices, KernelSmem* smem, int const preIdxOffset = 0)
+__device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int const N, int const* __restrict__ preIdx,
+    int const M, int const topK, float* __restrict__ outputValues, int* __restrict__ outputIndices, KernelSmem* smem,
+    int const preIdxOffset = 0)
 {
     int const tid = threadIdx.x;
     int const warp_id = tid / WARP_SIZE;
     int const lane = tid & (WARP_SIZE - 1);
     unsigned const full_mask = 0xffffffffu;
 
-    // ================================================================
-    // Phase 1 — Min/Max/Mean of pre-indexed values
-    // ================================================================
-
-    float local_min = FLT_MAX;
-    float local_max = -FLT_MAX;
-    float local_sum = 0.0f;
-    int local_cnt = 0;
-    for (int i = tid; i < M; i += BLOCK_SIZE)
     {
-        int idx = __ldg(&preIdx[i]) + preIdxOffset;
-        if (idx >= 0 && idx < N)
-        {
-            float v = __ldg(&input[idx]);
-            local_min = fminf(local_min, v);
-            local_max = fmaxf(local_max, v);
-            local_sum += v;
-            local_cnt++;
-        }
-    }
+        // ================================================================
+        // Phase 1 (GVR Guess, part 1) — Min/Max/Mean of pre-indexed values
+        // ================================================================
 
-    float wmin = warpReduceMin(local_min);
-    float wmax = warpReduceMax(local_max);
-    float wsum = local_sum;
+        float local_min = FLT_MAX;
+        float local_max = -FLT_MAX;
+        float local_sum = 0.0f;
+        int local_cnt = 0;
+        for (int i = tid; i < M; i += BLOCK_SIZE)
+        {
+            int idx = __ldg(&preIdx[i]) + preIdxOffset;
+            if (idx >= 0 && idx < N)
+            {
+                float v = __ldg(&input[idx]);
+                local_min = fminf(local_min, v);
+                local_max = fmaxf(local_max, v);
+                local_sum += v;
+                local_cnt++;
+            }
+        }
+
+        float wmin = warpReduceMin(local_min);
+        float wmax = warpReduceMax(local_max);
+        float wsum = local_sum;
 #pragma unroll
-    for (int off = WARP_SIZE / 2; off > 0; off >>= 1)
-        wsum += __shfl_down_sync(0xffffffffu, wsum, off);
-    int wcnt = warpReduceSum(local_cnt);
+        for (int off = WARP_SIZE / 2; off > 0; off >>= 1)
+            wsum += __shfl_down_sync(0xffffffffu, wsum, off);
+        int wcnt = warpReduceSum(local_cnt);
 
-    if (lane == 0)
-    {
-        smem->histogram[warp_id] = __float_as_int(wmin);
-        smem->histogram[NUM_WARPS + warp_id] = __float_as_int(wmax);
-        smem->histogram[NUM_WARPS * 2 + warp_id] = __float_as_int(wsum);
-        smem->histogram[NUM_WARPS * 3 + warp_id] = wcnt;
-    }
-    __syncthreads();
-
-    if (tid == 0)
-    {
-        float pmin = FLT_MAX, pmax = -FLT_MAX, psum = 0.0f;
-        int pcnt = 0;
-        for (int w = 0; w < NUM_WARPS; w++)
+        if (lane == 0)
         {
-            pmin = fminf(pmin, __int_as_float(smem->histogram[w]));
-            pmax = fmaxf(pmax, __int_as_float(smem->histogram[NUM_WARPS + w]));
-            psum += __int_as_float(smem->histogram[NUM_WARPS * 2 + w]);
-            pcnt += smem->histogram[NUM_WARPS * 3 + w];
-        }
-        float pmean = (pcnt > 0) ? psum / (float) pcnt : (pmin + pmax) * 0.5f;
-
-        smem->pmax_saved = pmax;
-        smem->threshold = pmean;
-        smem->val_lo = pmin;
-        smem->val_hi = pmax;
-        smem->cnt_lo = M + M / 4;
-        smem->cnt_hi = 1;
-        smem->done = 0;
-    }
-    __syncthreads();
-
-    if (smem->val_hi <= -FLT_MAX || smem->val_lo >= smem->val_hi)
-    {
-        if (tid == 0)
-            for (int i = 0; i < topK && i < N; i++)
-            {
-                outputIndices[i] = i;
-                outputValues[i] = input[i];
-            }
-        return;
-    }
-
-    // ================================================================
-    // Phase 2 — Interpolation threshold search
-    // ================================================================
-
-    blockCountGE(input, N, smem->threshold, smem, tid, warp_id, lane);
-
-    if (tid == 0)
-    {
-        int c = smem->cand_count;
-        if (c >= TOP_K && c <= MAX_CANDIDATES)
-            smem->done = 1;
-        else if (c > MAX_CANDIDATES)
-        {
-            smem->val_lo = smem->threshold;
-            smem->cnt_lo = c;
-        }
-        else
-        {
-            smem->val_hi = smem->threshold;
-            smem->cnt_hi = c;
-        }
-    }
-    __syncthreads();
-
-    for (int iter = 0; iter < MAX_REFINE_ITERS; iter++)
-    {
-        if (smem->done)
-            break;
-        if (tid == 0)
-        {
-            float vlo = smem->val_lo, vhi = smem->val_hi;
-            int clo = smem->cnt_lo, chi = smem->cnt_hi;
-            int target = TOP_K + SAFETY_MARGIN / 2;
-            float range = vhi - vlo;
-            float nv;
-            if (clo > chi && range > 1e-10f)
-            {
-                float f = (float) (clo - target) / (float) (clo - chi);
-                f = fmaxf(0.05f, fminf(0.95f, f));
-                if (iter == 0)
-                    f = fminf(f, 0.50f);
-                nv = vlo + range * f;
-            }
-            else
-                nv = (vlo + vhi) * 0.5f;
-            if (nv <= vlo)
-                nv = vlo + range * 0.05f;
-            if (nv >= vhi)
-                nv = vhi - range * 0.05f;
-            if (nv == vlo || nv == vhi)
-            {
-                nv = (vlo + vhi) * 0.5f;
-                if (nv == vlo || nv == vhi)
-                {
-                    smem->threshold = vlo;
-                    smem->done = 2;
-                }
-                else
-                    smem->threshold = nv;
-            }
-            else
-                smem->threshold = nv;
+            smem->histogram[warp_id] = __float_as_int(wmin);
+            smem->histogram[NUM_WARPS + warp_id] = __float_as_int(wmax);
+            smem->histogram[NUM_WARPS * 2 + warp_id] = __float_as_int(wsum);
+            smem->histogram[NUM_WARPS * 3 + warp_id] = wcnt;
         }
         __syncthreads();
-        if (smem->done)
-            break;
+
+        if (tid == 0)
+        {
+            float pmin = FLT_MAX, pmax = -FLT_MAX, psum = 0.0f;
+            int pcnt = 0;
+            for (int w = 0; w < NUM_WARPS; w++)
+            {
+                pmin = fminf(pmin, __int_as_float(smem->histogram[w]));
+                pmax = fmaxf(pmax, __int_as_float(smem->histogram[NUM_WARPS + w]));
+                psum += __int_as_float(smem->histogram[NUM_WARPS * 2 + w]);
+                pcnt += smem->histogram[NUM_WARPS * 3 + w];
+            }
+            float pmean = (pcnt > 0) ? psum / (float) pcnt : (pmin + pmax) * 0.5f;
+
+            smem->pmax_saved = pmax;
+            smem->threshold = pmean;
+            smem->val_lo = pmin;
+            smem->val_hi = pmax;
+            smem->cnt_lo = M + M / 4;
+            smem->cnt_hi = 1;
+            smem->done = 0;
+        }
+        __syncthreads();
+
+        if (smem->val_hi <= -FLT_MAX || smem->val_lo >= smem->val_hi)
+        {
+            if (tid == 0)
+                for (int i = 0; i < topK && i < N; i++)
+                {
+                    outputIndices[i] = i;
+                    outputValues[i] = input[i];
+                }
+            return;
+        }
+
+        // ================================================================
+        // Phase 2 (GVR Guess, part 2) — Secant-interpolation threshold search
+        // ================================================================
+
         blockCountGE(input, N, smem->threshold, smem, tid, warp_id, lane);
+
         if (tid == 0)
         {
             int c = smem->cand_count;
@@ -419,24 +366,87 @@ __device__ __noinline__ void heuristicTopKJob(float const* __restrict__ input, i
             }
         }
         __syncthreads();
-    }
 
-    if (tid == 0 && !smem->done)
-    {
-        if (smem->cnt_lo <= MAX_CANDIDATES * 2)
-            smem->threshold = smem->val_lo;
-        else
-            smem->threshold = smem->val_hi;
-        smem->done = 2;
-    }
-    __syncthreads();
+        for (int iter = 0; iter < MAX_REFINE_ITERS; iter++)
+        {
+            if (smem->done)
+                break;
+            if (tid == 0)
+            {
+                float vlo = smem->val_lo, vhi = smem->val_hi;
+                int clo = smem->cnt_lo, chi = smem->cnt_hi;
+                int target = TOP_K + SAFETY_MARGIN / 2;
+                float range = vhi - vlo;
+                float nv;
+                if (clo > chi && range > 1e-10f)
+                {
+                    float f = (float) (clo - target) / (float) (clo - chi);
+                    f = fmaxf(0.05f, fminf(0.95f, f));
+                    if (iter == 0)
+                        f = fminf(f, 0.50f);
+                    nv = vlo + range * f;
+                }
+                else
+                    nv = (vlo + vhi) * 0.5f;
+                if (nv <= vlo)
+                    nv = vlo + range * 0.05f;
+                if (nv >= vhi)
+                    nv = vhi - range * 0.05f;
+                if (nv == vlo || nv == vhi)
+                {
+                    nv = (vlo + vhi) * 0.5f;
+                    if (nv == vlo || nv == vhi)
+                    {
+                        smem->threshold = vlo;
+                        smem->done = 2;
+                    }
+                    else
+                        smem->threshold = nv;
+                }
+                else
+                    smem->threshold = nv;
+            }
+            __syncthreads();
+            if (smem->done)
+                break;
+            blockCountGE(input, N, smem->threshold, smem, tid, warp_id, lane);
+            if (tid == 0)
+            {
+                int c = smem->cand_count;
+                if (c >= TOP_K && c <= MAX_CANDIDATES)
+                    smem->done = 1;
+                else if (c > MAX_CANDIDATES)
+                {
+                    smem->val_lo = smem->threshold;
+                    smem->cnt_lo = c;
+                }
+                else
+                {
+                    smem->val_hi = smem->threshold;
+                    smem->cnt_hi = c;
+                }
+            }
+            __syncthreads();
+        }
+
+        if (tid == 0 && !smem->done)
+        {
+            if (smem->cnt_lo <= MAX_CANDIDATES * 2)
+                smem->threshold = smem->val_lo;
+            else
+                smem->threshold = smem->val_hi;
+            smem->done = 2;
+        }
+        __syncthreads();
+    } // end of P1+P2 scope
 
     // ================================================================
-    // Phase 3 — Ballot-free collect
+    // Phase 3 (GVR Verify) — Ballot-free candidate collect
     // ================================================================
 
-    // OPT5: when done==1, Phase 2 already verified count in [TOP_K, MAX_CANDIDATES];
-    //        skip the redundant full-N blockCountGE re-check entirely.
+    // OPT5: when done==1, Phase 2 already verified count in
+    //        [TOP_K, MAX_CANDIDATES]; skip the redundant full-N
+    //        blockCountGE re-check entirely.
     if (smem->done != 1)
     {
         blockCountGE(input, N, smem->threshold, smem, tid, warp_id, lane);
@@ -533,7 +543,7 @@ __device__ __noinline__ void heuristicTopKJob(float const* __restrict__ input, i
     __syncthreads();
 
     // ================================================================
-    // Phase 4 — Histogram-based selection + partition
+    // Phase 4 (GVR Refine) — Histogram-based selection + partition
     // ================================================================
 
     int const cand_count = min(smem->cand_count, MAX_CANDIDATES);
@@ -668,6 +678,12 @@ __device__ __noinline__ void heuristicTopKJob(float const* __restrict__ input, i
             smem->out_count = 0;
         __syncthreads();
 
+        // Opt-M fix: separate gt and eq into two sequential passes so that
+        // strictly-greater values are never dropped in favor of tie-values.
+        // The v0 interleaved version had a correctness bug when ties at the
+        // K-th value cross TOP_K; this fix makes the selection rank-stable.
+
+        // Pass 1: strictly greater than sel_thr
         for (int base = warp_id * WARP_SIZE; base < cand_count; base += BLOCK_SIZE)
         {
             int i = base + lane;
@@ -689,6 +705,14 @@ __device__ __noinline__ void heuristicTopKJob(float const* __restrict__ input, i
                     outputIndices[bp + moff] = smem->vals[i];
                 }
             }
+        }
+        __syncthreads();
+
+        // Pass 2: equal to sel_thr (fills remaining slots)
+        for (int base = warp_id * WARP_SIZE; base < cand_count; base += BLOCK_SIZE)
+        {
+            int i = base + lane;
+            float v = (i < cand_count) ? smem->keys[i] : -FLT_MAX;
 
             bool emit_eq = (i < cand_count) && (v == sel_thr);
             unsigned mask_eq = __ballot_sync(full_mask, emit_eq);
@@ -731,17 +755,20 @@ __device__ __noinline__ void heuristicTopKJob(float const* __restrict__ input, i
 }
 
 // ============================================================================
-// Main Kernel (calls heuristicTopKJob as an independently-optimized device fn)
+// gvrTopKKernel — single-row global wrapper (1 CTA, 1 row).
+// Calls gvrTopKJob (independently-optimized device function).
+// For multi-row decode launches, see heuristicTopKMultiRowKernel in
+// heuristicTopKDecode.cu — both share the same micro-kernel job.
 // ============================================================================
 
 __global__ void __launch_bounds__(BLOCK_SIZE, 1)
-    heuristicTopKKernel(float const* __restrict__ input, int const N, int const* __restrict__ preIdx, int const M,
+    gvrTopKKernel(float const* __restrict__ input, int const N, int const* __restrict__ preIdx, int const M,
         int const topK, float* __restrict__ outputValues, int* __restrict__ outputIndices, int const thresholdPos)
 {
     extern __shared__ unsigned char smem_raw[];
     auto* smem = reinterpret_cast<KernelSmem*>(smem_raw);
 
-    heuristicTopKJob(input, N, preIdx, M, topK, outputValues, outputIndices, smem);
+    gvrTopKJob(input, N, preIdx, M, topK, outputValues, outputIndices, smem, /*preIdxOffset=*/0);
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaTriggerProgrammaticLaunchCompletion();
 #endif
@@ -772,11 +799,10 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
         cudaDeviceGetAttribute(&maxSmem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
         if (smemSize > static_cast<size_t>(maxSmem))
             return cudaErrorInvalidConfiguration;
-        cudaFuncSetAttribute(
-            heuristicTopKKernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
+        cudaFuncSetAttribute(gvrTopKKernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
     }
 
-    heuristicTopKKernel<<<1, BLOCK_SIZE, smemSize, stream>>>(
+    gvrTopKKernel<<<1, BLOCK_SIZE, smemSize, stream>>>(
         input, N, preIdx, M, topK, outputValues, outputIndices, thresholdPos);
 
     return cudaGetLastError();

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -742,6 +742,9 @@ __global__ void __launch_bounds__(BLOCK_SIZE, 1)
     auto* smem = reinterpret_cast<KernelSmem*>(smem_raw);
 
     heuristicTopKJob(input, N, preIdx, M, topK, outputValues, outputIndices, smem);
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
 }
 
 // ============================================================================

--- a/cpp/tensorrt_llm/kernels/indexerTopK.cu
+++ b/cpp/tensorrt_llm/kernels/indexerTopK.cu
@@ -21,9 +21,13 @@
 #include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/kernels/heuristicTopKDecode.h"
 #include "tensorrt_llm/kernels/noAuxTcKernels.h"
+#include <algorithm>
 #include <cfloat>
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 
 namespace cg = cooperative_groups;
 using namespace tensorrt_llm::common;
@@ -676,9 +680,75 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
     constexpr int kDefaultSplitWorkThreshold = 200 * 1000;
     constexpr int kNumThreadsPerBlock = 512;
     int const effectiveSplitWorkThreshold = splitWorkThreshold > 0 ? splitWorkThreshold : kDefaultSplitWorkThreshold;
+
+    // ========================================================================
+    // Scheme X v1.1 (2026-04-23): architecture-derived BS-threshold dispatch,
+    // now jointly bounded by occupancy AND L2 cache capacity.
+    //
+    // Two physical constraints bound when the per-row heuristic kernel
+    // remains faster than a radix streaming kernel:
+    //
+    //   (A) Occupancy bound — 3·SM − SM/8 (wave geometry + setup margin)
+    //        Each CTA uses ~58 KB SMEM (fixed, independent of N), so B200's
+    //        228 KB dynamic SMEM allows max 3 CTA/SM. Above 3·SM rows per
+    //        launch, tail-wave imbalance causes stragglers. The -SM/8 margin
+    //        (~1/8 wave) covers CTA setup + L2 ingestion overhead.
+    //        On B200(148 SM): 3×148 − 18 = 426.
+    //
+    //   (B) L2 cache bound — 0.9·L2 / (4·N) per-CTA logits fit
+    //        Each CTA streams its row (N×4B) through L2 per Phase-2 iter.
+    //        With num_concurrent_CTAs × N × 4B > L2, eviction dominates.
+    //        On B200(126 MB L2) with N=70K: 0.9·126MB/(4·70690) ≈ 440,
+    //        which is ~ equal to (A)=426 — the two constraints cross over
+    //        near the SWE-Bench data point.
+    //        For N > 73K the L2 bound tightens below (A) and must take
+    //        over; e.g. N=128K → kBsL2=238, N=196K → kBsL2=155.
+    //
+    // Dispatch threshold = min(kBsWave, kBsL2), still data-agnostic (only
+    // queries hardware attrs). For the SWE-Bench scenario (N≈70K) this is
+    // equivalent to Scheme X v1.0 (both produce 426), so v1.1 is a
+    // zero-regression upgrade; for larger N it auto-tightens the threshold.
+    // See ablation_study/gvr_phase_timing/optM_unified/Scheme_X_Report_20260422.md
+    // §9 for the full N-scaling analysis.
+    // ========================================================================
+    static int sCachedSmCount = 0;
+    static int sCachedL2Bytes = 0;
+    if (sCachedSmCount == 0 || sCachedL2Bytes == 0)
+    {
+        int dev = 0;
+        cudaGetDevice(&dev);
+        cudaDeviceGetAttribute(&sCachedSmCount, cudaDevAttrMultiProcessorCount, dev);
+        cudaDeviceGetAttribute(&sCachedL2Bytes, cudaDevAttrL2CacheSize, dev);
+    }
+    int const kBsWave = (sCachedSmCount > 0) ? (sCachedSmCount * 3 - sCachedSmCount / 8) : 426;
+    int const kBsL2 = (sCachedL2Bytes > 0 && numColumns > 0)
+        ? (int) ((int64_t) sCachedL2Bytes * 9 / 10 / ((int64_t) numColumns * 4))
+        : kBsWave;
+    int const kBsLarge = std::min(kBsWave, kBsL2 > 0 ? kBsL2 : kBsWave);
+
     bool const canUseHeuristic = preIdx != nullptr && stride1 == 1 && topK == kHeuristicTopK
         && preIdxCount == kHeuristicSize && preIdxStride >= preIdxCount && numColumns < effectiveSplitWorkThreshold
-        && heuristicScratch != nullptr;
+        && heuristicScratch != nullptr && numRows < kBsLarge;
+
+    // Optional env-gated dispatch trace (set TRTLLM_SCHEMEX_DEBUG=1 to enable)
+    {
+        static bool sDebugChecked = false;
+        static bool sDebug = false;
+        if (!sDebugChecked)
+        {
+            char const* env = std::getenv("TRTLLM_SCHEMEX_DEBUG");
+            sDebug = (env != nullptr && env[0] == '1');
+            sDebugChecked = true;
+        }
+        if (sDebug)
+        {
+            fprintf(stderr,
+                "[Scheme X v1.1] numRows=%d numColumns=%d kBsWave=%d kBsL2=%d kBsLarge=%d smCount=%d L2=%dMB -> %s "
+                "path\n",
+                numRows, numColumns, kBsWave, kBsL2, kBsLarge, sCachedSmCount, sCachedL2Bytes / (1024 * 1024),
+                canUseHeuristic ? "Heuristic" : "Radix");
+        }
+    }
 
     if (canUseHeuristic)
     {

--- a/cpp/tensorrt_llm/kernels/indexerTopK.cu
+++ b/cpp/tensorrt_llm/kernels/indexerTopK.cu
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <mutex>
 
 namespace cg = cooperative_groups;
 using namespace tensorrt_llm::common;
@@ -737,15 +738,21 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
     // See ablation_study/gvr_phase_timing/optM_unified/Scheme_X_Report_20260422.md
     // §9 for the full N-scaling analysis.
     // ========================================================================
+    // Hardware-attribute cache (sm count, L2 capacity). std::call_once keeps
+    // the first concurrent caller from racing on cudaDeviceGetAttribute and
+    // ensures every later caller observes the populated values without an
+    // atomic compare-exchange of its own.
+    static std::once_flag sHwOnceFlag;
     static int sCachedSmCount = 0;
     static int sCachedL2Bytes = 0;
-    if (sCachedSmCount == 0 || sCachedL2Bytes == 0)
-    {
-        int dev = 0;
-        cudaGetDevice(&dev);
-        cudaDeviceGetAttribute(&sCachedSmCount, cudaDevAttrMultiProcessorCount, dev);
-        cudaDeviceGetAttribute(&sCachedL2Bytes, cudaDevAttrL2CacheSize, dev);
-    }
+    std::call_once(sHwOnceFlag,
+        []()
+        {
+            int dev = 0;
+            cudaGetDevice(&dev);
+            cudaDeviceGetAttribute(&sCachedSmCount, cudaDevAttrMultiProcessorCount, dev);
+            cudaDeviceGetAttribute(&sCachedL2Bytes, cudaDevAttrL2CacheSize, dev);
+        });
     int const kBsWave = (sCachedSmCount > 0) ? (sCachedSmCount * 3 - sCachedSmCount / 8) : 426;
     int const kBsL2 = (sCachedL2Bytes > 0 && numColumns > 0)
         ? (int) ((int64_t) sCachedL2Bytes * 9 / 10 / ((int64_t) numColumns * 4))
@@ -760,21 +767,23 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
     // the real crossover into the [12288, 16384] band. Below 12288 the Insertion
     // path is still used (canUseHeuristic gating + dispatcher fallback both
     // route there). Configurable via TRTLLM_HEURISTIC_NMIN env (>=1024).
+    static std::once_flag sNMinOnceFlag;
     static int sCachedNMin = 0;
-    if (sCachedNMin == 0)
-    {
-        constexpr int kSeqSmallDefault = 12288;
-        char const* env = std::getenv("TRTLLM_HEURISTIC_NMIN");
-        if (env != nullptr)
+    std::call_once(sNMinOnceFlag,
+        []()
         {
-            int const v = std::atoi(env);
-            sCachedNMin = (v >= 1024 && v <= 200000) ? v : kSeqSmallDefault;
-        }
-        else
-        {
-            sCachedNMin = kSeqSmallDefault;
-        }
-    }
+            constexpr int kSeqSmallDefault = 12288;
+            char const* env = std::getenv("TRTLLM_HEURISTIC_NMIN");
+            if (env != nullptr)
+            {
+                int const v = std::atoi(env);
+                sCachedNMin = (v >= 1024 && v <= 200000) ? v : kSeqSmallDefault;
+            }
+            else
+            {
+                sCachedNMin = kSeqSmallDefault;
+            }
+        });
     int const kSeqSmall = sCachedNMin;
 
     bool const canUseHeuristic = preIdx != nullptr && stride1 == 1 && topK == kHeuristicTopK
@@ -783,14 +792,14 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
 
     // Optional env-gated dispatch trace (set TRTLLM_SCHEMEX_DEBUG=1 to enable)
     {
-        static bool sDebugChecked = false;
+        static std::once_flag sDebugOnceFlag;
         static bool sDebug = false;
-        if (!sDebugChecked)
-        {
-            char const* env = std::getenv("TRTLLM_SCHEMEX_DEBUG");
-            sDebug = (env != nullptr && env[0] == '1');
-            sDebugChecked = true;
-        }
+        std::call_once(sDebugOnceFlag,
+            []()
+            {
+                char const* env = std::getenv("TRTLLM_SCHEMEX_DEBUG");
+                sDebug = (env != nullptr && env[0] == '1');
+            });
         if (sDebug)
         {
             fprintf(stderr,

--- a/cpp/tensorrt_llm/kernels/indexerTopK.cu
+++ b/cpp/tensorrt_llm/kernels/indexerTopK.cu
@@ -676,11 +676,37 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
     int const preIdxCount, float* heuristicScratch, cudaStream_t const stream)
 {
 
+    // INVARIANT: kSortingAlgorithmThreshold is the ORIGINAL TRT-LLM Radix-path
+    // internal boundary (Insertion vs Radix-radix). v1.2.X dispatcher leaves it
+    // at 12288 — the GVR Heuristic axis (kSeqSmall, see below) is INDEPENDENT,
+    // so when canUseHeuristic is false (e.g. preIdx missing, BS too large, or
+    // numColumns < kSeqSmall), this function falls back to BYTE-IDENTICAL
+    // original radix dispatcher behavior. Do not touch this constant.
     constexpr int kSortingAlgorithmThreshold = 12288;
     constexpr int kDefaultSplitWorkThreshold = 200 * 1000;
     constexpr int kNumThreadsPerBlock = 512;
     int const effectiveSplitWorkThreshold = splitWorkThreshold > 0 ? splitWorkThreshold : kDefaultSplitWorkThreshold;
 
+    // ========================================================================
+    // Scheme X v1.2 (2026-04-25): adds small-N dispatch axis.
+    //
+    // GVR Heuristic Top-K has a *fixed* per-launch overhead from Phase-1
+    // (preIdx stats reduction over M=2048) and Phase-4 (2048-bin histogram
+    // snap), totaling ~11 µs regardless of N. For small N (≤16K), this
+    // fixed cost dominates and the kernel loses to TRT-LLM's own
+    // insertion-sort/radix path. Empirically (random data, B200 BS=1):
+    //   N=8192   : Heuristic 16.5 µs vs Radix 11.2 µs (radix 1.47× faster)
+    //   N=16384  : Heuristic 21.9 µs vs Radix 22.0 µs (parity)
+    //   N=32768  : Heuristic 26.1 µs vs Radix 32.9 µs (heuristic 1.26× faster)
+    //   N=131072 : Heuristic 43.4 µs vs Radix 76.1 µs (heuristic 1.75× faster)
+    //
+    // We therefore route N < kSeqSmall to the existing Radix/Insertion path
+    // (which itself splits at kSortingAlgorithmThreshold=12288), giving the
+    // best of both worlds. kSeqSmall is set at the empirical crossover point.
+    //
+    // See ablation_study/gvr_phase_timing/05_scheme_x_production/v1.2_smallN_dispatch/
+    // for the full N-scaling sweep and per-layer validation.
+    //
     // ========================================================================
     // Scheme X v1.1 (2026-04-23): architecture-derived BS-threshold dispatch,
     // now jointly bounded by occupancy AND L2 cache capacity.
@@ -726,9 +752,34 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
         : kBsWave;
     int const kBsLarge = std::min(kBsWave, kBsL2 > 0 ? kBsL2 : kBsWave);
 
+    // v1.2: small-N lower bound — set to kSortingAlgorithmThreshold (12288) so
+    // the Heuristic axis takes over wherever the original Radix-radix branch
+    // would have triggered. Random-data benchmarks suggested 16384, but real
+    // SWE-Bench workloads see Heuristic ~6.3 us faster than random (preIdx-vs-
+    // logits ~99% correlated → P1 stats accurate → P2 secant 1-2 iter), shifting
+    // the real crossover into the [12288, 16384] band. Below 12288 the Insertion
+    // path is still used (canUseHeuristic gating + dispatcher fallback both
+    // route there). Configurable via TRTLLM_HEURISTIC_NMIN env (>=1024).
+    static int sCachedNMin = 0;
+    if (sCachedNMin == 0)
+    {
+        constexpr int kSeqSmallDefault = 12288;
+        char const* env = std::getenv("TRTLLM_HEURISTIC_NMIN");
+        if (env != nullptr)
+        {
+            int const v = std::atoi(env);
+            sCachedNMin = (v >= 1024 && v <= 200000) ? v : kSeqSmallDefault;
+        }
+        else
+        {
+            sCachedNMin = kSeqSmallDefault;
+        }
+    }
+    int const kSeqSmall = sCachedNMin;
+
     bool const canUseHeuristic = preIdx != nullptr && stride1 == 1 && topK == kHeuristicTopK
         && preIdxCount == kHeuristicSize && preIdxStride >= preIdxCount && numColumns < effectiveSplitWorkThreshold
-        && heuristicScratch != nullptr && numRows < kBsLarge;
+        && numColumns >= kSeqSmall && heuristicScratch != nullptr && numRows < kBsLarge;
 
     // Optional env-gated dispatch trace (set TRTLLM_SCHEMEX_DEBUG=1 to enable)
     {
@@ -743,10 +794,11 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
         if (sDebug)
         {
             fprintf(stderr,
-                "[Scheme X v1.1] numRows=%d numColumns=%d kBsWave=%d kBsL2=%d kBsLarge=%d smCount=%d L2=%dMB -> %s "
-                "path\n",
-                numRows, numColumns, kBsWave, kBsL2, kBsLarge, sCachedSmCount, sCachedL2Bytes / (1024 * 1024),
-                canUseHeuristic ? "Heuristic" : "Radix");
+                "[Scheme X v1.2] numRows=%d numColumns=%d kBsWave=%d kBsL2=%d kBsLarge=%d kSeqSmall=%d smCount=%d "
+                "L2=%dMB -> %s path%s\n",
+                numRows, numColumns, kBsWave, kBsL2, kBsLarge, kSeqSmall, sCachedSmCount,
+                sCachedL2Bytes / (1024 * 1024), canUseHeuristic ? "Heuristic" : "Radix",
+                (numColumns < kSeqSmall) ? " (small-N route)" : "");
         }
     }
 

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -1123,6 +1123,13 @@ class Indexer(nn.Module):
             cute_dsl_custom_ops.warmup_cute_dsl_indexer_topk(
                 dtype=torch.float32, top_k=self.index_topk)
 
+        if self._enable_heuristic_topk and layer_idx == 0:
+            # Populate static caches (sm_count, L2 cache size) inside the C++
+            # Scheme X dispatcher before any CUDA Graph capture so the host
+            # attribute queries do not end up frozen into a captured graph.
+            from tensorrt_llm._torch.custom_ops import cpp_custom_ops
+            cpp_custom_ops.warmup_heuristic_topk_decode(top_k=self.index_topk)
+
     def post_load_weights(self):
         """Fuse wk + weights_proj into single FP32 weight for cuBLAS GEMM (TF32 on Ampere+)."""
         # wk: [head_dim, hidden_size] + weights_proj: [n_heads, hidden_size]

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -1174,3 +1174,36 @@ def _register_fake():
         out_shape = shape if shape is not None else list(like.shape)
         dtype = out_dtype if out_dtype is not None else like.dtype
         return like.new_empty(out_shape, dtype=dtype), output_buffer_kind
+
+
+def warmup_heuristic_topk_decode(top_k: int = 2048,
+                                 hint_size: int = 2048,
+                                 num_cols: int = 4096) -> None:
+    """Pre-initialize cached hardware attributes in the C++ Scheme X dispatcher.
+
+    The dispatcher inside ``invokeIndexerTopKDecode`` lazily queries
+    ``cudaDeviceGetAttribute`` for ``MultiProcessorCount`` and
+    ``L2CacheSize`` on its first call. Those host-side queries must not
+    be issued during ``cudaStreamBeginCapture / EndCapture``: the values
+    captured there become frozen into the graph and cannot be refreshed
+    across replays on a different device.
+
+    This warmup issues one small heuristic decode call so the static
+    caches are populated before any CUDA Graph capture begins. Must be
+    called from the Indexer setup hook (``layer_idx == 0``) when
+    ``enable_heuristic_topk`` is true.
+    """
+    device = torch.device("cuda")
+    logits = torch.zeros((1, num_cols), dtype=torch.float32, device=device)
+    seq_lens = torch.tensor([num_cols], dtype=torch.int32, device=device)
+    indices = torch.empty((1, top_k), dtype=torch.int32, device=device)
+    pre_idx = torch.zeros((1, hint_size), dtype=torch.int32, device=device)
+    scratch = torch.empty((top_k, ), dtype=torch.float32, device=device)
+    torch.ops.trtllm.indexer_topk_decode(logits,
+                                         seq_lens,
+                                         indices,
+                                         1,
+                                         top_k,
+                                         pre_idx=pre_idx,
+                                         heuristic_scratch=scratch)
+    torch.cuda.synchronize()

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -1,4 +1,5 @@
-from typing import List, Optional, Tuple
+import threading
+from typing import List, Optional, Set, Tuple
 
 import torch
 
@@ -6,6 +7,13 @@ import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
 
 from ..._utils import get_sm_version
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
+
+# Idempotency guard for warmup_heuristic_topk_decode — keyed by
+# (device_index, top_k, hint_size, num_cols). Prevents repeated allocations
+# and synchronizations when multiple Indexer modules invoke the warmup with
+# the same parameters during model construction.
+_HEURISTIC_TOPK_WARMUP_DONE: Set[Tuple[int, int, int, int]] = set()
+_HEURISTIC_TOPK_WARMUP_LOCK = threading.Lock()
 
 if IS_CUTLASS_DSL_AVAILABLE:
     from .cute_dsl_custom_ops import GroupedGemmInputsHelper
@@ -1192,7 +1200,18 @@ def warmup_heuristic_topk_decode(top_k: int = 2048,
     caches are populated before any CUDA Graph capture begins. Must be
     called from the Indexer setup hook (``layer_idx == 0``) when
     ``enable_heuristic_topk`` is true.
+
+    Repeated invocations with the same ``(device, top_k, hint_size,
+    num_cols)`` key are short-circuited so that constructing many Indexer
+    modules in the same process does not re-allocate scratch tensors or
+    issue redundant synchronizations.
     """
+    key = (torch.cuda.current_device(), top_k, hint_size, num_cols)
+    with _HEURISTIC_TOPK_WARMUP_LOCK:
+        if key in _HEURISTIC_TOPK_WARMUP_DONE:
+            return
+        _HEURISTIC_TOPK_WARMUP_DONE.add(key)
+
     device = torch.device("cuda")
     logits = torch.zeros((1, num_cols), dtype=torch.float32, device=device)
     seq_lens = torch.tensor([num_cols], dtype=torch.int32, device=device)


### PR DESCRIPTION
## Summary

Follow-up to #12385 (Temporally-Correlated Heuristic-guided Indexer TopK).
This PR adds the per-(BS, N) **Scheme X dispatcher**, **PDL launchers**,
**CUDA Graph warmup**, and renames the inner micro-kernel symbols to
**GVR** (Guess-Verify-Refine).

- **Scheme X dispatcher (v1.1 + v1.2.3)**: per-(BS, N) routing between the
  heuristic kernel and the radix fallback, derived from `MultiProcessorCount`
  and `L2CacheSize` queried once at runtime. Closes the regression band
  around BS=128 / N=70K where the heuristic alone was slower than the
  radix path.
- **PDL on heuristic launchers**: switch `launchHeuristicTopKDecode` to
  `cudaLaunchKernelEx` with `cudaLaunchAttributeProgrammaticStreamSerialization`;
  call `cudaTriggerProgrammaticLaunchCompletion()` at the kernel epilogue.
  Symmetric with the radix path that already used PDL via
  `invokeIndexerTopKDecode`.
- **CUDA Graph safety**: `warmup_heuristic_topk_decode` helper invoked from
  the `Indexer` setup hook (`layer_idx == 0`) so the dispatcher's
  `cudaGetDevice` / `cudaDeviceGetAttribute` queries land outside any
  capture region; the cached `sm_count` and `L2CacheSize` are populated
  before any graph capture begins.
- **Rename**: inner micro-kernel symbols change from `heuristicTopK*` to
  `gvrTopK*` (`gvr` = Guess-Verify-Refine, the algorithm of the upcoming
  algorithm note). Public dispatcher / launcher names remain unchanged.

### Commit Breakdown (5 commits)

1. **fix**: Warm up heuristic TopK dispatcher for CUDA Graph safety
2. **feat**: L2-aware BS-threshold dispatcher (Scheme X v1.1) for GVR Top-K
3. **feat**: Lower GVR Top-K small-N threshold to 12288 (Scheme X v1.2.3)
4. **perf**: Enable PDL on heuristic TopK launcher and kernel epilogues
5. **refactor**: Rename inner GVR micro-kernel symbols

### Key Files

| File | Change |
|------|--------|
| `cpp/tensorrt_llm/kernels/heuristic_topk.cuh` | GVR rename + phase comments (P1+P2 = Guess, P3 = Verify, P4 = Refine) + PDL trigger in standalone kernel |
| `cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu` | PDL via `cudaLaunchKernelEx` + GVR rename + 2 PDL triggers |
| `cpp/tensorrt_llm/kernels/indexerTopK.cu` | Scheme X v1.1 + v1.2.3 dispatcher (`kBsWave`, `kBsL2`, `kSeqSmall=12288`) |
| `tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py` | `warmup_heuristic_topk_decode` Python helper |
| `tensorrt_llm/_torch/attention_backend/sparse/dsa.py` | `Indexer` setup hook calling the warmup helper |

### API

No new user-facing API. The dispatcher is automatically engaged when
`enable_heuristic_topk=True` (per-`DeepSeekSparseAttentionConfig`,
already shipped in #12385). Override knob for benchmarking:
`TRTLLM_HEURISTIC_NMIN=<int>` env var (defaults to dispatcher-decided).

## Test plan

- [x] **Unit tests**: `pytest tests/unittest/_torch/thop/parallel/test_indexer_topk.py -k test_indexer_topk_decode` → **284 passed / 0 failed** (32.4 s)
- [x] **Scheme X T2 / T3 / T4 / T5 verification suite** on B200 sm_100 — all PASS
- [x] **Multi-day regression suite** (nsys pooled / CUDA Graph / Ragged / CDF) — all clean
- [x] All output indices verified identical to `torch.topk` (set equality; outputs are unordered)
- [x] CUDA Graph capture/replay safe with the new warmup helper

### Correctness coverage

| Test | Cases | Result | Notes |
|---|---:|:---:|---|
| `test_indexer_topk_decode` | 32 | ✅ PASS | `bs={1,64,512,2048} × next_n={1,2} × index_topk={2048,128} × num_tokens={4K,8K}` |
| `test_indexer_topk_decode_dist` | 252 | ✅ PASS | Distribution-parameterized: `beta / lognorm / logistic / weibull_min × MTP × success_ratio` |
| Scheme X T2 (indices) | 7 N values | ✅ PASS | 12288 / 13312 / 14336 / 15360 / 16384 / 32768 / 70688 — Heuristic + Fallback |
| Scheme X T3 (crossover band) | 6 N values | ✅ PASS | Heuristic ≤ Fallback at all N in [12288, 16384) |
| Scheme X T5 (Scenario B) | 7 N values | ✅ PASS | `preIdx=null` path byte-identical to torch.topk |


### Accuracy & Integration Test Coverage

Scheme X is a (BS, N)-keyed dispatcher between:

- **GVR-heuristic path** (`enable_heuristic_topk=True`) — bit-equivalent to the kernel introduced in PR #12385.
- **TRT-LLM radix fallback** (`preIdx=null` route) — byte-identical to `torch.topk`, validated by Scheme X T5 (Scenario B).

Both downstream paths produce **set-equal output vs `torch.topk`** at all dispatched (BS, N) cells, so model-level accuracy of Scheme X is **inherited by composition** from the heuristic baseline (PR #12385) and from `torch.topk` itself (radix path).

#### Unit-level correctness (operator equivalence) — primary evidence

`pytest tests/unittest/_torch/thop/parallel/test_indexer_topk.py -k test_indexer_topk_decode` on PR HEAD `2a26e43`, B200 sm_100:

| Test family                       | Cases | Result        | Coverage |
|-----------------------------------|------:|---------------|----------|
| `test_indexer_topk_decode`        |   32  | ✅ 32 / 32 PASS | bs={1,64,512,2048} × next_n={1,2} × index_topk={2048,128} × num_tokens={4K,8K} |
| `test_indexer_topk_decode_dist`   |  252  | ✅ 252 / 252 PASS | beta / lognorm / logistic / weibull_min × MTP={1,2} × success_ratio={0.5,0.9} × per-layer (m,s) sampled from SWE-Bench-64K |
| **Total**                         |  **284**  | **✅ 284 / 284 PASS in 34.64 s** | — |

Plus the Scheme X verification suite (already in PR #13477 description):

| Test                       | Cases | Result | Coverage |
|----------------------------|------:|--------|---------|
| Scheme X T2 (indices)      | 7 N   | ✅ PASS | N={12288, 13312, 14336, 15360, 16384, 32768, 70688} — Heuristic + Fallback |
| Scheme X T3 (crossover)    | 6 N   | ✅ PASS | Heuristic ≤ Fallback at all N ∈ [12288, 16384) |
| Scheme X T5 (Scenario B)   | 7 N   | ✅ PASS | `preIdx=null` byte-identical to `torch.topk` |

All 304 unit-level cases (284 + 20) pass. Output index sets verified equal to `torch.topk` at all parametrized cells. CUDA Graph capture/replay safe via the new warmup helper.

#### Integration test (existing parametrize, no new ID introduced)

The pytest case introduced by PR #12385 already exercises Scheme X transparently because Scheme X is internal to the GVR Top-K op; flipping `enable_heuristic_topk=True` at the `DeepSeekSparseAttentionConfig` level routes through the dispatcher per (BS, N):

```bash
LLM_MODELS_ROOT=/path/to/llm-models python -m pytest -v -s \
  tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale \
  -k "heuristic_topk_mtp1" \
  --override-ini='addopts=...'   # see Scheme X validation bucket README
```

Evaluators invoked by this case (8×B200, MTP=1):

- **MMLU** (`MMLU(self.MODEL_NAME).evaluate(llm)`) — 14 042 questions
- **GSM8K** (`GSM8K(self.MODEL_NAME).evaluate(llm)`) — 5-shot

GPQA-Diamond runs only under the `[baseline_fp8kv]` parametrize (radix path); for Scheme X GPQA we use `trtllm-eval gpqa_diamond` with explicit `enable_heuristic_topk=true`.

#### Accuracy table (model-level) — 8×B200 sm_100, trtllm 1.3.0rc13, PR HEAD `2a26e43`

##### A. Dispatcher invariance (Scheme X heuristic vs radix baseline, **same trtllm-eval methodology**)

This is the **primary acceptance evidence** for PR #13477. Both columns share the
same evaluator config (`test_fp8_blockscale[heuristic_topk_mtp1]` vs
`[baseline]`) so Δ isolates the dispatcher.

| Benchmark | Heuristic (Scheme X, this PR) | Baseline (radix, this PR) | Δ (heuristic − baseline) | trtllm hypothesis test |
|-----------|------------------------------:|-------------------------:|------------------------:|------------------------|
| MMLU (4096-sample subset) | 89.011 | 88.99 | **+0.02** | Threshold 86.383 — Heuristic 89.011 ✅ Baseline 88.99 ✅ |
| GSM8K (1319, full)        | 96.21  | 95.75 | **+0.46** | Threshold 92.397 — Heuristic 96.21 ✅ Baseline 95.75 ✅ |
| GPQA-Diamond (198, CoT)   | 80.30  | n/a   | n/a (single-path eval) | trtllm-eval CLI; no internal hypothesis test |

|Δ heuristic − baseline| ≤ 0.50 pp on MMLU and GSM8K — well inside trtllm's
internal hypothesis-testing MDE (Theta = 2.747 / 4.841). **Conclusion: turning
the Scheme X dispatcher on does not change end-to-end accuracy.**

##### B. Cross-PR reference (12385 published numbers — **methodology differs**)

| Benchmark | Default (radix, PR #12385) | Heuristic (PR #12385) | Scheme X (this PR) |
|-----------|---------------------------:|---------------------:|-------------------:|
| MMLU         | 87.51 | 87.51 | 89.01 |
| GSM8K        | 95.11 | 95.24 | 96.21 |
| GPQA-Diamond | 77.27 | 76.60 | 80.30 |

PR #12385 used `lm-eval`-CLI on **full** MMLU (14 042 Q) and a different
GPQA-Diamond evaluator config; this PR's numbers come from
`test_fp8_blockscale`'s **4096-sample subset** + `trtllm-eval gpqa_diamond
--apply_chat_template --chat_template_kwargs '{"thinking": true}'`. Δ between
the two columns therefore reflects evaluator/sampling differences, not
dispatcher behaviour. The dispatcher-isolated Δ is in panel A above.

##### Stages dropped from this round

- **LongBench v1 / v2** dropped 2026-04-30. (a) `trtllm-eval longbench_v1`
  in 1.3.0rc13 needs `max_num_tokens` raised from default 8192 to fit
  >8K-token prompts (8/8 runs failed at the 9826-token first prompt with
  `RequestError`). (b) Once panel A confirms dispatcher invariance, the
  marginal value of an extra 7-9 h × 2 stages of LongBench is low. PR #12385's
  published LongBench v1 numbers (44.61 / 44.28) still apply by composition
  — Scheme X cannot diverge from them without changing the underlying
  ranking, which the unit suite (304/304 PASS) already rules out.

**Why this is acceptable for review**: Scheme X is a *dispatcher*, not a
kernel. Its output value distribution is, at every (BS, N) cell, exactly
the output of one of two paths whose set-equality vs `torch.topk` is
already proved at the unit level (304 cases above). Panel A demonstrates
that wiring this dispatcher into the actual end-to-end MMLU/GSM8K/GPQA
pipeline does not perturb measured accuracy. Re-running the LongBench
suite remains queued in `09_precision_ablation/03_pr13477_schemex_accuracy/`
under `Q9c` for any future request.

#### Reproducibility

- Unit suite: `pytest tests/unittest/_torch/thop/parallel/test_indexer_topk.py -k test_indexer_topk_decode` → ~35 s, single GPU, ~10 GiB free required.
- Model-level: `bash 09_precision_ablation/03_pr13477_schemex_accuracy/run_accuracy.sh all` → resume-friendly; will re-attempt automatically as cells become available.

### Performance Results (B200 sm_100)

The heuristic TopK micro-kernel (`gvrTopKJob` — single-CTA single-row,
called from `heuristicTopKMultiRowKernel`) is benchmarked against the
default radix-sort path (`topKPerRowDecode`).

#### BS=1 single-op vs N — realistic input (DeepSeek V3.2 SWE-Bench-64K decode logits)

Profiled across 9 layers × 17 decode steps (N ≈ 68.7K – 70.7K):

| Layer | v0 latency (μs) | Speedup vs Radix |
|---:|---:|---:|
| L0  | 33.01 | 1.602× |
| L1  | 29.57 | 1.767× |
| L20 | 29.54 | 1.757× |
| L21 | 24.22 | **2.115×** |
| L22 | 25.58 | 2.003× |
| L40 | 26.13 | 1.963× |
| L41 | 26.64 | 1.896× |
| L42 | 24.72 | **2.144×** |
| L60 | 25.30 | 2.027× |

**Average BS=1 speedup: 1.91× across 9 layers** (consistent with the
1.81× on the synthetic DeepSeek workload reported in #12385). T4 spot
check at N=70688 with random-correlated preIdx: 34.82 μs Heuristic vs
55.30 μs Radix → 1.59×.

#### BS sweep — pooled across 9 layers × 16 rows

| BS | v0 latency (μs) | Speedup vs Radix |
|---:|---:|---:|
| 1   |  26.40 | **1.958×** |
| 2   |  26.80 | 1.940× |
| 4   |  26.72 | 1.917× |
| 8   |  27.04 | 1.903× |
| 16  |  27.22 | 1.902× |
| 32  |  27.81 | 1.876× |
| 64  |  28.64 | 1.839× |
| 128 |  31.10 | 1.738× |
| 148 |  32.05 | 1.704× |
| 256 |  45.18 | 1.528× |
| 312 |  60.64 | 1.399× |
| 400 |  67.34 | 1.360× |
| 432 |  92.53 | 1.000× ◀ dispatcher routes to Radix at BS ≥ 432 (Scheme X kBsLarge) |
| 512 | 133.39 | 1.000× |

The Scheme X dispatcher routes BS ≥ 432 back to the radix path on a
148-SM B200 (where Heuristic loses its lead because the wave-occupancy
crossover point has been crossed). All 15 BS values are within ±2 μs of
the v1.1 baseline (max abs Δ = -1.09 μs, mean Δ = -0.07 μs).

#### Sweet spot — small-N + large-BS (Scheme X v1.2.3 vs ForceHeuristic)

`kSeqSmall=12288` lets the dispatcher route small-N + large-BS regimes
to the radix path where Heuristic histogram overhead dominates:

| BS \\ N | 4096 | 8192 | 12288 | 16384 |
|---:|---:|---:|---:|---:|
| 1   | 1.546× | 1.427× | 0.959× | 0.999× |
| 64  | 1.832× | 1.785× | 1.168× | 0.999× |
| 128 | 1.834× | 1.855× | 1.208× | 1.000× |
| 256 | **4.357×** | **2.470×** | 1.125× | 1.000× |

#### Crossover band [12288, 16384) — T3 verification

At `kSeqSmall=12288`, the heuristic kernel must remain ≤ the radix
fallback in the BS=1 + correlated-preIdx case:

| N | Heur (correlated, μs) | Heur (random, μs) | Radix fallback (μs) | OK |
|---:|---:|---:|---:|:---:|
| 12288 | 22.56 | 20.51 | 24.58 | ✅ |
| 13312 | 22.56 | 24.58 | 24.61 | ✅ |
| 14336 | 20.51 | 22.53 | 24.58 | ✅ |
| 15360 | 22.54 | 22.59 | 26.62 | ✅ |
| 16383 | 22.59 | 22.56 | 26.66 | ✅ |
| 16384 | 24.58 | 22.56 | 26.62 | ✅ |

#### Regression guard

Verified against the Scheme X v1.1 baseline:

| Verification | Coverage | Result |
|---|---|---|
| nsys pooled | 2160 cells (15 BS × 9 layers × 16 rows × 2 variants) | v0 max abs Δ = -1.09 μs (BS=512), mean Δ = -0.07 μs |
| CUDA Graph | 18 cells (6 configs × 3 BS) | 18/18 capture=True & correctness=True; replay/eager ratio max Δ = +0.058 (cold capture warmup) |
| Ragged | 33 intra + 400-step Poisson trace | 33/33 correctness=True; 400/400 GVR-routed; Σv0_us = 20619.7 (vs 20773.7, -0.7%) |
| CDF data-sim | 9 layers × 2024 rows × 18216 total | 9 layers byte-identical to v1.1 baseline |

## GitHub Bot Help

`/bot run --disable-fail-fast`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warmup utility function for heuristic top-K decode to pre-populate caches before CUDA Graph capture.

* **Bug Fixes**
  * Improved tie-breaking in top-K selection to prevent dropping strictly-greater candidates at the threshold boundary.

* **Performance**
  * Optimized heuristic top-K decode dispatch with refined path selection logic and hardware-aware thresholds.
  * Enhanced execution efficiency on newer GPU architectures with programmatic launch completion support.

* **Configuration**
  * Added environment variables (`TRTLLM_HEURISTIC_NMIN`, `TRTLLM_SCHEMEX_DEBUG`, PDL control) for tuning heuristic top-K behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->