### PR TITLE
[#11823][feat] AutoDeploy MLA with PWCG support on Deepseek R1

### DIFF
--- a/examples/auto_deploy/model_registry/configs/deepseek-r1.yaml
+++ b/examples/auto_deploy/model_registry/configs/deepseek-r1.yaml
@@ -2,6 +2,7 @@
 compile_backend: torch-cudagraph
 max_batch_size: 64
 max_seq_len: 8192
+max_num_tokens: 15360
 enable_chunked_prefill: true
 # Opt into FP8 KV cache for ~2x capacity; default ("auto") keeps bf16.
 kv_cache_config:
@@ -25,3 +26,6 @@ transforms:
   multi_stream_mla_attn:
     stage: compile
     enabled: true
+  compile_model:
+    piecewise_enabled: true
+    piecewise_num_tokens: [256, 512, 1024, 2048, 3072, 4096, 5120, 6144, 8192]

--- a/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/backends/torch_cudagraph.py
@@ -348,6 +348,7 @@ class PiecewiseCapturedGraph(nn.Module):
         self.split_gm: Optional[GraphModule] = None
         self._is_prepared = False
         self._wrapped_dynamic_indices: Set[int] = set()
+        self._static_runners: Dict[int, ADPiecewiseRunner] = {}
         # Pre-allocated static buffers for kwargs whose addresses change between
         # calls.  Allocated during warmup_and_capture, used at runtime to ensure
         # CUDA graph replay sees stable addresses.
@@ -441,6 +442,7 @@ class PiecewiseCapturedGraph(nn.Module):
             )
             setattr(self.split_gm, submod_name, runner)
             runner_by_idx[idx] = runner
+            self._static_runners[idx] = runner
             num_wrapped_static += 1
 
         # Phase 2: wrap dynamic ops.
@@ -518,7 +520,8 @@ class PiecewiseCapturedGraph(nn.Module):
             f"PiecewiseCapturedGraph: prepared with {self.split_info.num_submodules} submodules "
             f"({num_wrapped_static} static runners, {num_skipped_static} trivial skipped, "
             f"{num_wrapped_dynamic} dynamic wrapped, {num_metadata_wrapped} metadata wrapped, "
-            f"{num_dynamic_eager} dynamic eager), piecewise_num_tokens={self.piecewise_num_tokens}"
+            f"{num_dynamic_eager} dynamic eager), "
+            f"piecewise_num_tokens={self.piecewise_num_tokens}"
         )
 
     def _discover_dynamic_output_shapes(self, args: Tuple, kwargs: Dict) -> Dict[int, OutputInfo]:
@@ -686,7 +689,11 @@ class PiecewiseCapturedGraph(nn.Module):
 
                 # Capture phase
                 ADPiecewiseRunner.set_current_phase("capture")
-                self.split_gm(*args, **kwargs)
+                try:
+                    self.split_gm(*args, **kwargs)
+                finally:
+                    for runner in self._static_runners.values():
+                        runner.finalize_capture(nt)
 
             ad_logger.info(f"PiecewiseCapturedGraph: captured graphs for num_tokens={nt}")
 
@@ -711,7 +718,12 @@ class PiecewiseCapturedGraph(nn.Module):
             )
             return result
 
-    def forward(self, *args, num_tokens: Optional[int] = None, **kwargs) -> Any:
+    def forward(
+        self,
+        *args,
+        num_tokens: Optional[int] = None,
+        **kwargs,
+    ) -> Any:
         """Forward pass: static segments replay graphs, dynamic segments run eagerly."""
         if self.split_gm is not None:
             self._copy_to_static_buffers(kwargs)
@@ -866,7 +878,11 @@ class DualModeCapturedGraph(nn.Module):
         bucket = self._find_nearest_bucket(num_tokens)
         if bucket is not None:
             try:
-                result = self.piecewise(*args, num_tokens=bucket, **kwargs)
+                result = self.piecewise(
+                    *args,
+                    num_tokens=bucket,
+                    **kwargs,
+                )
             finally:
                 ADPiecewiseRunner.set_current_num_tokens(None)
             if bucket > num_tokens:

--- a/tensorrt_llm/_torch/auto_deploy/compile/piecewise_runner.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/piecewise_runner.py
@@ -313,6 +313,22 @@ class ADPiecewiseRunner(nn.Module):
         """
         self._next_dynamic_out_infos[dynamic_submod_id] = info
 
+    def finalize_capture(self, num_tokens: int) -> None:
+        """Release strong dynamic output refs after downstream captures finish.
+
+        Dynamic output buffers are allocated inside the preceding static runner's
+        graph capture, but following static runners consume them as inputs during
+        the same split-graph capture.  Keep the real tensor objects live until
+        that whole bucket capture finishes so the shared graph pool cannot reuse
+        their addresses for downstream graph outputs.  Runtime only needs stable
+        addresses, so weak refs are enough after capture.
+        """
+        entry = self.entries.get(num_tokens)
+        if entry is None:
+            return
+        for submod_id, buf in list(entry.dynamic_out_bufs.items()):
+            entry.dynamic_out_bufs[submod_id] = make_weak_ref(buf)
+
     def get_dynamic_out_buf(
         self, num_tokens: int, dynamic_submod_id: int
     ) -> Optional[torch.Tensor]:
@@ -383,7 +399,7 @@ class ADPiecewiseRunner(nn.Module):
             entry.cuda_graph = graph
             entry.static_output = make_weak_ref(output)
             for submod_id, buf in dynamic_out_bufs.items():
-                entry.dynamic_out_bufs[submod_id] = make_weak_ref(buf)
+                entry.dynamic_out_bufs[submod_id] = buf
 
             # Debug: record input addresses for assertion in replay
             flat_args, _ = tree_flatten((args, kwargs))

--- a/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/compile/piecewise_utils.py
@@ -61,7 +61,6 @@ _METADATA_PREP_OPS = [
     "auto_deploy::flashinfer_attention_prepare_metadata",
     "auto_deploy::flashinfer_mla_prepare_metadata",
     "auto_deploy::triton_paged_prepare_metadata",
-    "auto_deploy::trtllm_mla_prepare_metadata",
     "auto_deploy::mamba_ssm_prepare_metadata",
 ]
 
@@ -77,6 +76,7 @@ _LOGITS_GATHER_OPS = [
 # DynamicOpWrapper (no fresh allocation, returns persistent buffer directly).
 _PERSISTENT_BUFFER_OPS = [
     "auto_deploy::trtllm_attention_prepare_metadata",
+    "auto_deploy::trtllm_mla_prepare_metadata",
 ]
 
 # Inplace dynamic ops: these ops mutate their input tensor and return None,

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla/trtllm_mla.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla/trtllm_mla.py
@@ -93,11 +93,20 @@ from ..attention_interface import (
 # rope info on torch_mla nodes, consumed by prepare_node_for_cache_insertion
 # (at cache_init) to materialize the rotary_cos_sin buffer as a graph node.
 _TRTLLM_MLA_ROPE_INFO_KEY = "_trtllm_mla_rope_info"
-# The cache-reused prefill path (``_handle_prefill_thop_cached_kv``) loads the
-# full ``[past + new]`` context from the paged KV cache; ``thop.attention``'s
-# context FMHA scratch grows with that total.  256 MiB suffices for fresh
-# prefill but is undersized once host_past_kv_lengths is non-zero.
-_TRTLLM_MLA_WORKSPACE_BYTES = 512 * 1024 * 1024
+# ``thop.attention``'s C++ side (``cpp/tensorrt_llm/thop/attentionOp.cpp``)
+# auto-resizes the workspace tensor when its sizing formula exceeds the
+# tensor's capacity.  ``resize_()`` reallocates storage and rebinds the
+# ``data_ptr_`` — which **invalidates any captured CUDA graph that
+# recorded the old address**.  Mirroring the standard trtllm_attention
+# backend, we keep two workspaces and route per call:
+#
+# * ``workspace`` — used by eager paths (prefill).  Free to grow on demand
+#   via ``resize_()``; no captured graph references it.
+# * ``cuda_graph_workspace`` — used during CUDA-graph warmup and capture.
+#   Grows lazily during warmup so the captured graph records the final
+#   pointer; afterwards no resize fires for the captured workload.
+#
+# Both start size-0 and grow on first use.
 
 
 def get_trtllm_mla_rope_info(attn_node: Node) -> Optional[dict]:
@@ -126,7 +135,9 @@ class _TrtllmMLAPlanner:
     Mirrors ``_TrtllmPlanner`` from the standard trtllm backend.  Only stores data
     that cannot be derived from ``SequenceInfo`` or tensor shapes:
 
-    - ``workspace``: scratch for thop.attention
+    - ``workspace`` / ``cuda_graph_workspace``: scratch for thop.attention,
+      split between eager (prefill) and captured (decode) paths so the
+      C++ side's ``resize_()`` cannot invalidate captured graphs
     - Host metadata not in SequenceInfo: ``host_request_types``, ``host_total_kv_lens``,
       ``host_past_kv_lengths``, ``host_context_lengths``
     - ``block_offsets`` / ``block_ids_per_seq``: filled by the device-side
@@ -143,6 +154,7 @@ class _TrtllmMLAPlanner:
 
     def __init__(self):
         self.workspace: Optional[torch.Tensor] = None
+        self.cuda_graph_workspace: Optional[torch.Tensor] = None
         # Per-layer caches, keyed by the relevant tensor's data_ptr().
         self._pool_ptr_cache: dict = {}
         self._kv_b_proj_bmm_cache: dict = {}
@@ -205,10 +217,12 @@ class _TrtllmMLAPlanner:
         if self.workspace is not None:
             return
 
-        # Pre-allocate workspace large enough to avoid cudaMalloc during
-        # CUDA graph capture (matching the standard trtllm_attention backend).
-        # See ``_TRTLLM_MLA_WORKSPACE_BYTES`` for sizing rationale.
-        self.workspace = torch.empty(_TRTLLM_MLA_WORKSPACE_BYTES, dtype=torch.uint8, device=device)
+        # Two size-0 workspaces; ``thop.attention``'s C++ side resizes on
+        # first use.  Splitting eager (prefill) from captured (decode)
+        # callers prevents a prefill-driven ``resize_()`` from invalidating
+        # captured-graph kernel pointers (see ``_select_workspace``).
+        self.workspace = torch.empty(0, dtype=torch.uint8, device=device)
+        self.cuda_graph_workspace = torch.empty(0, dtype=torch.uint8, device=device)
         # Shape: [_CONTEXT_LAYER_OFFSET + 1, 2] — one row per distinct mLayerIdx
         # we actually pass to thop.attention (decode=0, prefill=_CONTEXT_LAYER_OFFSET).
         # All zeros: each layer's pool pointer already points to that layer's
@@ -277,6 +291,18 @@ class _TrtllmMLAPlanner:
                 sm_count * 8, dtype=torch.int32, device=device
             )
             self.flash_mla_num_splits = torch.zeros(max_batch + 1, dtype=torch.int32, device=device)
+
+    def _select_workspace(self) -> torch.Tensor:
+        """Return the right workspace for the current execution context.
+
+        During CUDA-graph warmup or live capture, return ``cuda_graph_workspace``
+        so any C++-side ``resize_()`` happens before the graph records the
+        kernel's pointer.  Otherwise return ``workspace`` — captured graphs
+        do not reference it, so it is free to grow on demand.
+        """
+        if torch.cuda.is_current_stream_capturing() or cuda_graph_state.in_warm_up():
+            return self.cuda_graph_workspace
+        return self.workspace
 
     def ensure_decode_buffers(
         self,
@@ -754,7 +780,7 @@ def _handle_prefill_thop(
         v,  # v
         output,  # output
         None,  # output_sf
-        planner.workspace,  # workspace
+        planner._select_workspace(),  # workspace
         context_lengths[:pf],  # sequence_length (new tokens only)
         host_past_kv_lengths[:pf],  # host_past_key_value_lengths (all zero here)
         planner.ctx_total_kv_lens_host,  # host_total_kv_lens
@@ -1020,7 +1046,7 @@ def _handle_prefill_thop_cached_kv(
         full_v,  # v
         output,  # output
         None,  # output_sf
-        planner.workspace,  # workspace
+        planner._select_workspace(),  # workspace
         sequence_length[:pf],  # sequence_length (past + new tokens)
         host_past_kv_lengths[:pf],  # host_past_key_value_lengths (real)
         planner.ctx_total_kv_lens_host,  # host_total_kv_lens
@@ -1067,7 +1093,17 @@ def _handle_prefill_thop_cached_kv(
         True,  # use_paged_context_fmha
         int(AttentionInputType.context_only),  # attention_input_type
         True,  # is_mla_enable
-        1,  # chunked_prefill_buffer_batch_size
+        # FP8 context-MLA workspace (``fp8_k_buf`` / ``fp8_v_buf``) is sized
+        # to ``chunked_prefill_buffer_batch_size * max_num_tokens`` tokens.
+        # The cache-reused-prefill path passes the FULL ``[past + new]`` K/V
+        # in one call; ``num_full_tokens`` can exceed ``max_num_tokens`` at
+        # high prefill concurrency (e.g. 84 prefill seqs × 1003 tokens =
+        # 84252 vs ``max_num_tokens=15360`` at bs=256, isl=1000).  Hard-
+        # coding ``1`` caused IMA inside ``AttentionOp::enqueueContext``.
+        # Use ``16`` — covers up to ``16 * max_num_tokens`` tokens of FP8
+        # K/V scratch, ~1 GiB extra workspace at our config, while leaving
+        # KV-cache budget intact.
+        16,  # chunked_prefill_buffer_batch_size
         0,  # q_lora_rank
         kv_lora_rank,
         qk_nope_head_dim,
@@ -1264,7 +1300,7 @@ def _handle_decode_impl(
         None,  # v
         output_latent,  # output
         None,  # output_sf
-        planner.workspace,  # workspace
+        planner._select_workspace(),  # workspace
         sequence_length,  # sequence_length
         host_past_kv_lengths,  # host_past_key_value_lengths
         host_total_kv_lens,  # host_total_kv_lens
@@ -1367,6 +1403,7 @@ def _mla_with_cache_impl(
     scale: Optional[float],
     kv_lora_rank: int,
     rotary_cos_sin: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Shared implementation for both MLA attention ops (with and without fused RoPE).
 
@@ -1489,9 +1526,25 @@ def _mla_with_cache_impl(
     # otherwise identity table so the kernel's RoPE is a no-op.
     decode_rotary_cos_sin = rotary_cos_sin if fused_rope else planner.identity_cos_sin
 
-    # Allocate output with bs rows (may include CG padding); only real-token
-    # positions are filled — padding stays zero, matching the FI MLA pattern.
-    y = torch.zeros(bs, num_heads * v_head_dim, dtype=q_nope_flat.dtype, device=q_nope_flat.device)
+    # Allocate output with padding capacity.  Piecewise CUDA graph replay may
+    # pass real-token-shaped inputs while the stable ``out`` buffer is sized to
+    # the bucket captured for the following static segment.
+    if out is not None:
+        y = out.view(-1, num_heads * v_head_dim)
+        output_tokens = y.shape[0]
+        if output_tokens < num_tokens:
+            raise RuntimeError(
+                "trtllm_mla_with_cache out buffer is too small: "
+                f"capacity={output_tokens}, required={num_tokens}"
+            )
+    else:
+        output_tokens = bs
+        y = torch.zeros(
+            output_tokens,
+            num_heads * v_head_dim,
+            dtype=q_nope_flat.dtype,
+            device=q_nope_flat.device,
+        )
 
     if num_prefill > 0:
         y[:num_prefill_tokens] = _handle_prefill_thop(
@@ -1562,6 +1615,11 @@ def _mla_with_cache_impl(
             decode_rotary_cos_sin,
         )
 
+    if out is not None:
+        if num_tokens < output_tokens:
+            y[num_tokens:].zero_()
+        return out.new_empty(0)
+
     return y.view(b, s, num_heads, v_head_dim)
 
 
@@ -1607,6 +1665,7 @@ def trtllm_mla_with_cache(
     scale: Optional[float],
     kv_lora_rank: int,
     rotary_cos_sin: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """TRT-LLM MLA attention with paged latent cache.
 
@@ -1627,6 +1686,7 @@ def trtllm_mla_with_cache(
         scale,
         kv_lora_rank,
         rotary_cos_sin=rotary_cos_sin,
+        out=out,
     )
 
 
@@ -1645,8 +1705,11 @@ def trtllm_mla_with_cache_fake(
     scale: Optional[float],
     kv_lora_rank: int,
     rotary_cos_sin: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Fake implementation for torch.compile tracing."""
+    if out is not None:
+        return out.new_empty(0)
     return _mla_with_cache_fake_impl(q_nope, kv_b_proj_weight)
 
 

--- a/tests/unittest/auto_deploy/singlegpu/compile/test_captured_graph.py
+++ b/tests/unittest/auto_deploy/singlegpu/compile/test_captured_graph.py
@@ -1,4 +1,5 @@
 import operator
+from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,13 +13,14 @@ from _model_test_utils import (
 from pydantic import ValidationError
 from torch.fx import Graph, GraphModule
 
+from tensorrt_llm._torch.auto_deploy.compile import piecewise_runner as piecewise_runner_mod
 from tensorrt_llm._torch.auto_deploy.compile.backends.torch_cudagraph import (
     CapturedGraph,
     DualModeCapturedGraph,
     PiecewiseCapturedGraph,
     _args_kwargs_flatten_spec,
 )
-from tensorrt_llm._torch.auto_deploy.compile.piecewise_runner import ADPiecewiseRunner
+from tensorrt_llm._torch.auto_deploy.compile.piecewise_runner import ADPiecewiseRunner, OutputInfo
 from tensorrt_llm._torch.auto_deploy.compile.piecewise_utils import submod_has_cuda_ops
 from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import BatchInfo
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
@@ -609,6 +611,61 @@ class TestPiecewiseCapturedGraphStaticInputBuffers:
         assert copied.data_ptr() == static_buffer.data_ptr()
         assert copied is static_buffer
         assert torch.equal(copied, src)
+
+
+# ============================================================================
+# Tests for ADPiecewiseRunner capture-time output liveness
+# ============================================================================
+
+
+class TestADPiecewiseRunnerCapture:
+    """Tests for dynamic output buffers allocated during runner capture."""
+
+    def test_dynamic_out_buf_stays_strong_until_capture_finalized(self, monkeypatch):
+        @contextmanager
+        def fake_cuda_graph(*args, **kwargs):
+            yield
+
+        class FakeCudaGraph:
+            def pool(self):
+                return ("fake-pool",)
+
+        def fake_make_weak_ref(value):
+            if isinstance(value, torch.Tensor):
+                return ("weak", value.data_ptr())
+            return value
+
+        monkeypatch.setattr(torch.cuda, "synchronize", lambda: None)
+        monkeypatch.setattr(torch.cuda, "CUDAGraph", FakeCudaGraph)
+        monkeypatch.setattr(torch.cuda, "graph", fake_cuda_graph)
+        monkeypatch.setattr(piecewise_runner_mod, "make_weak_ref", fake_make_weak_ref)
+
+        runner = ADPiecewiseRunner(nn.Identity())
+        runner.set_dynamic_out_info(
+            7,
+            OutputInfo(
+                shape=torch.Size([8, 4]),
+                dtype=torch.float32,
+                device=torch.device("cpu"),
+            ),
+        )
+
+        ADPiecewiseRunner.set_current_phase("capture")
+        ADPiecewiseRunner.set_current_num_tokens(8)
+        try:
+            runner(torch.zeros(8, 4))
+        finally:
+            ADPiecewiseRunner.set_current_phase("replay")
+            ADPiecewiseRunner.set_current_num_tokens(None)
+
+        entry = runner.entries[8]
+        out_buf = entry.dynamic_out_bufs[7]
+        assert isinstance(out_buf, torch.Tensor)
+
+        ptr = out_buf.data_ptr()
+        runner.finalize_capture(8)
+
+        assert entry.dynamic_out_bufs[7] == ("weak", ptr)
 
 
 # ============================================================================

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/mla/test_trtllm_mla_op.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/mla/test_trtllm_mla_op.py
@@ -276,7 +276,7 @@ def _create_trtllm_paged_metadata(
     }
 
 
-def _run_trtllm_mla(inputs, meta, kv_lora_rank):
+def _run_trtllm_mla(inputs, meta, kv_lora_rank, rotary_cos_sin=None, out=None):
     """Run the trtllm_mla_with_cache op with proper planner setup."""
     # Reset planner so it re-initializes
     _GlobalTrtllmMLAPlanner.__init__()
@@ -315,6 +315,8 @@ def _run_trtllm_mla(inputs, meta, kv_lora_rank):
         meta["kv_cache"],
         None,  # scale
         kv_lora_rank,
+        rotary_cos_sin=rotary_cos_sin,
+        out=out,
     )
 
 
@@ -359,6 +361,266 @@ def test_trtllm_mla_multi_step(num_heads, batch_size, dtype, device):
         num_decode_steps,
         dtype,
         device,
+    )
+
+
+@pytest.mark.parametrize("num_heads", [4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("device", ["cuda"])
+def test_trtllm_mla_out_buffer_padding(num_heads, dtype, device):
+    """PWCG passes padded inputs and an out= buffer; real-token output must match."""
+    qk_nope_head_dim = 128
+    qk_rope_head_dim = 64
+    kv_lora_rank = 512
+    v_head_dim = 128
+    batch_size = 4
+    prefill_len = 16
+    total_tokens = batch_size * prefill_len
+    padded_tokens = 128
+    page_size = _MLA_TOKENS_PER_BLOCK
+    max_num_pages = batch_size * (prefill_len // page_size + 2)
+
+    inputs = _create_mla_inputs(
+        batch_size,
+        prefill_len,
+        num_heads,
+        qk_nope_head_dim,
+        qk_rope_head_dim,
+        kv_lora_rank,
+        v_head_dim,
+        dtype,
+        device,
+    )
+
+    real_inputs = {
+        "q_nope": inputs["q_nope"].reshape(1, total_tokens, num_heads, qk_nope_head_dim),
+        "q_pe": inputs["q_pe"].reshape(1, total_tokens, num_heads, qk_rope_head_dim),
+        "compressed_kv": inputs["compressed_kv"].reshape(1, total_tokens, kv_lora_rank),
+        "kpe": inputs["kpe"].reshape(1, total_tokens, 1, qk_rope_head_dim),
+        "kv_b_proj_weight": inputs["kv_b_proj_weight"],
+    }
+    padded_inputs = {
+        name: torch.zeros(
+            1,
+            padded_tokens,
+            *value.shape[2:],
+            dtype=value.dtype,
+            device=value.device,
+        )
+        if name != "kv_b_proj_weight"
+        else value
+        for name, value in real_inputs.items()
+    }
+    for name, value in real_inputs.items():
+        if name != "kv_b_proj_weight":
+            padded_inputs[name][:, :total_tokens].copy_(value)
+
+    real_meta = _create_trtllm_paged_metadata(
+        batch_size,
+        max_num_pages,
+        page_size,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        dtype,
+        device,
+        [prefill_len] * batch_size,
+        [0] * batch_size,
+    )
+    padded_meta = _create_trtllm_paged_metadata(
+        batch_size,
+        max_num_pages,
+        page_size,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        dtype,
+        device,
+        [prefill_len] * batch_size,
+        [0] * batch_size,
+    )
+
+    real_out = _run_trtllm_mla(real_inputs, real_meta, kv_lora_rank)
+    bucket_out = torch.empty(1, padded_tokens, num_heads, v_head_dim, dtype=dtype, device=device)
+    bucket_result = _run_trtllm_mla(real_inputs, real_meta, kv_lora_rank, out=bucket_out)
+
+    assert bucket_result.numel() == 0
+    torch.testing.assert_close(
+        bucket_out[:, :total_tokens],
+        real_out,
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    torch.testing.assert_close(
+        bucket_out[:, total_tokens:],
+        torch.zeros_like(bucket_out[:, total_tokens:]),
+        atol=0,
+        rtol=0,
+    )
+
+    out = torch.empty(1, padded_tokens, num_heads, v_head_dim, dtype=dtype, device=device)
+    out_result = _run_trtllm_mla(padded_inputs, padded_meta, kv_lora_rank, out=out)
+
+    assert out_result.numel() == 0
+    torch.testing.assert_close(
+        out[:, :total_tokens],
+        real_out,
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    torch.testing.assert_close(
+        out[:, total_tokens:],
+        torch.zeros_like(out[:, total_tokens:]),
+        atol=0,
+        rtol=0,
+    )
+
+
+@pytest.mark.parametrize("num_heads", [4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("device", ["cuda"])
+def test_trtllm_mla_fused_rope_out_buffer_padding(num_heads, dtype, device):
+    """Fused-RoPE PWCG path should match pre-rotated MLA while writing out=."""
+    qk_nope_head_dim = 128
+    qk_rope_head_dim = 64
+    kv_lora_rank = 512
+    v_head_dim = 128
+    batch_size = 4
+    prefill_len = 16
+    total_tokens = batch_size * prefill_len
+    padded_tokens = 128
+    page_size = _MLA_TOKENS_PER_BLOCK
+    max_num_pages = batch_size * (prefill_len // page_size + 2)
+
+    inputs = _create_mla_inputs(
+        batch_size,
+        prefill_len,
+        num_heads,
+        qk_nope_head_dim,
+        qk_rope_head_dim,
+        kv_lora_rank,
+        v_head_dim,
+        dtype,
+        device,
+    )
+
+    positions = torch.arange(prefill_len, device=device).repeat(batch_size)
+    inv_freq = 1.0 / (
+        10000.0
+        ** (
+            torch.arange(0, qk_rope_head_dim // 2, dtype=torch.float32, device=device)
+            / (qk_rope_head_dim // 2)
+        )
+    )
+    freqs = torch.outer(torch.arange(prefill_len, dtype=torch.float32, device=device), inv_freq)
+    emb = torch.cat([freqs, freqs], dim=-1)
+    cos = emb.cos()
+    sin = emb.sin()
+    rotary_cos_sin = torch.stack([cos, sin], dim=-1).reshape(1, -1).contiguous()
+
+    def apply_neox_rope(x):
+        cos_pos = cos[positions].view(1, total_tokens, 1, qk_rope_head_dim).to(x.dtype)
+        sin_pos = sin[positions].view(1, total_tokens, 1, qk_rope_head_dim).to(x.dtype)
+        x_flat = x.reshape(1, total_tokens, *x.shape[2:])
+        x1 = x_flat[..., : qk_rope_head_dim // 2]
+        x2 = x_flat[..., qk_rope_head_dim // 2 :]
+        rotated = torch.cat((-x2, x1), dim=-1)
+        return x_flat * cos_pos + rotated * sin_pos
+
+    pre_rope_inputs = {
+        "q_nope": inputs["q_nope"].reshape(1, total_tokens, num_heads, qk_nope_head_dim),
+        "q_pe": inputs["q_pe"].reshape(1, total_tokens, num_heads, qk_rope_head_dim),
+        "compressed_kv": inputs["compressed_kv"].reshape(1, total_tokens, kv_lora_rank),
+        "kpe": inputs["kpe"].reshape(1, total_tokens, 1, qk_rope_head_dim),
+        "kv_b_proj_weight": inputs["kv_b_proj_weight"],
+    }
+    post_rope_inputs = {
+        **pre_rope_inputs,
+        "q_pe": apply_neox_rope(inputs["q_pe"]),
+        "kpe": apply_neox_rope(inputs["kpe"]),
+    }
+    padded_inputs = {
+        name: torch.zeros(
+            1,
+            padded_tokens,
+            *value.shape[2:],
+            dtype=value.dtype,
+            device=value.device,
+        )
+        if name != "kv_b_proj_weight"
+        else value
+        for name, value in pre_rope_inputs.items()
+    }
+    for name, value in pre_rope_inputs.items():
+        if name != "kv_b_proj_weight":
+            padded_inputs[name][:, :total_tokens].copy_(value)
+
+    real_meta = _create_trtllm_paged_metadata(
+        batch_size,
+        max_num_pages,
+        page_size,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        dtype,
+        device,
+        [prefill_len] * batch_size,
+        [0] * batch_size,
+    )
+    padded_meta = _create_trtllm_paged_metadata(
+        batch_size,
+        max_num_pages,
+        page_size,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        dtype,
+        device,
+        [prefill_len] * batch_size,
+        [0] * batch_size,
+    )
+
+    real_out = _run_trtllm_mla(post_rope_inputs, real_meta, kv_lora_rank)
+    bucket_out = torch.empty(1, padded_tokens, num_heads, v_head_dim, dtype=dtype, device=device)
+    bucket_result = _run_trtllm_mla(
+        pre_rope_inputs,
+        real_meta,
+        kv_lora_rank,
+        rotary_cos_sin=rotary_cos_sin,
+        out=bucket_out,
+    )
+
+    assert bucket_result.numel() == 0
+    torch.testing.assert_close(
+        bucket_out[:, :total_tokens],
+        real_out,
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    torch.testing.assert_close(
+        bucket_out[:, total_tokens:],
+        torch.zeros_like(bucket_out[:, total_tokens:]),
+        atol=0,
+        rtol=0,
+    )
+
+    out = torch.empty(1, padded_tokens, num_heads, v_head_dim, dtype=dtype, device=device)
+    out_result = _run_trtllm_mla(
+        padded_inputs,
+        padded_meta,
+        kv_lora_rank,
+        rotary_cos_sin=rotary_cos_sin,
+        out=out,
+    )
+
+    assert out_result.numel() == 0
+    torch.testing.assert_close(
+        out[:, :total_tokens],
+        real_out,
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    torch.testing.assert_close(
+        out[:, total_tokens:],
+        torch.zeros_like(out[:, total_tokens:]),
+        atol=0,
+        rtol=0,
     )
 
 


### PR DESCRIPTION
  - piecewise_utils.py: re-classify auto_deploy::trtllm_mla_prepare_metadata from _METADATA_PREP_OPS to _PERSISTENT_BUFFER_OPS — its output (planner.block_offsets) lives at a stable persistent address.
  - torch_cudagraph.py + piecewise_runner.py (finalize_capture hook): keep dynamic-op output buffers strong-ref'd through the entire bucket's split-graph capture; without this the shared graph pool reuses captured slots across segments
  mid-capture and replay reads garbage (verified — MMLU collapsed from 87.33 → 35.70 when we tried immediate weak-refs).
  - trtllm_mla.py: add the out= kwarg to trtllm_mla_with_cache and plumb it through _mla_with_cache_impl to honor the DynamicOpWrapper contract (write real-token rows into the bucket-sized buffer, zero the padded tail, return the empty
  alias).

- Split the AutoDeploy MLA thop.attention workspace into separate eager (prefill) and captured (decode) tensors so the C++ side's resize_() can grow the eager one freely without invalidating CUDA-graph-captured pointers — replacing the prior 512MB static reserve which failed on large setups.

- examples/auto_deploy/model_registry/configs/deepseek-r1.yaml: enable PWCG (buckets [256..8192], max_num_tokens=15360).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TRT-LLM MLA (Multi-Head Latent Attention) backend with paged KV cache support.
  * Introduced RoPE fusion optimization into TRT-LLM MLA attention path.
  * Added explicit V tensor stride override for improved non-contiguous tensor handling.

* **Bug Fixes**
  * Fixed extend request routing in decode-only detection logic.
  * Improved output buffer lifecycle management during CUDA graph capture.

* **Tests**
  * Added coverage for non-contiguous tensor view handling and RMSNorm operations.
  * Added tests for decode-only detection and output buffer finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
