### PR TITLE
[https://nvbugs/6115036][fix] Fix NVFP4 engine size estimation and attention DP batch size in trtllm-bench

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -869,6 +869,30 @@ class PyTorchModelEngine(ModelEngine):
         with self.no_cuda_graph():
             self._general_warmup_impl(resource_manager, warmup_requests_configs)
 
+    def _assert_all_tp_ranks_have_warmup_batch(self, batch,
+                                               num_tokens: int) -> None:
+        """Assert every TP rank has a valid warmup batch, or raise with diagnostics.
+
+        Under attention-DP, each rank's KV cache available capacity can differ at
+        runtime, causing _create_warmup_request to return None on some ranks while
+        others proceed into forward() with tp_comm collectives — deadlocking the
+        job. This check prevents the deadlock by failing early with diagnostic info.
+        """
+        if self.mapping.tp_size <= 1:
+            return
+        has_batch = int(batch is not None)
+        all_flags = list(self.dist.tp_allgather(has_batch))
+        if any(all_flags) and not all(all_flags):
+            # Gather token counts for diagnostics
+            all_tokens = list(self.dist.tp_allgather(num_tokens))
+            failed_ranks = [i for i, f in enumerate(all_flags) if not f]
+            raise RuntimeError(
+                f"Warmup batch creation failed on TP rank(s) {failed_ranks} "
+                f"but succeeded on others. This would cause a collective "
+                f"deadlock. Per-rank curr_max_num_tokens: {all_tokens}. "
+                f"This indicates asymmetric KV cache capacity across TP ranks. "
+                f"Consider increasing --kv_cache_free_gpu_mem_fraction.")
+
     def _general_warmup_impl(
             self, resource_manager: ResourceManager,
             warmup_requests_configs: List[Tuple[int, int]]) -> None:
@@ -882,8 +906,12 @@ class PyTorchModelEngine(ModelEngine):
                         self._create_warmup_request(resource_manager,
                                                     num_tokens, num_gen_tokens),
                         resource_manager) as batch:
+                    if batch is None and self.mapping.tp_size <= 1:
+                        continue  # Not enough KV cache space (single rank, safe to skip)
+                    self._assert_all_tp_ranks_have_warmup_batch(
+                        batch, num_tokens)
                     if batch is None:
-                        continue  # Not enough KV cache space
+                        continue  # All ranks agree: not enough space
                     logger.info(
                         f"Run warmup with {num_tokens} tokens, include {num_gen_tokens} generation tokens"
                     )
@@ -917,6 +945,11 @@ class PyTorchModelEngine(ModelEngine):
                 resource_manager, curr_max_num_tokens, 0)
             with self._release_batch_context(warmup_request,
                                              resource_manager) as batch:
+                if batch is None and self.mapping.tp_size <= 1:
+                    pass  # Single rank, safe to skip
+                else:
+                    self._assert_all_tp_ranks_have_warmup_batch(
+                        batch, curr_max_num_tokens)
                 if batch is not None:
                     # Reset the flag is_first_draft for the draft model.
                     # This is necessary for overlap scheduler.

--- a/tensorrt_llm/bench/benchmark/utils/general.py
+++ b/tensorrt_llm/bench/benchmark/utils/general.py
@@ -87,12 +87,16 @@ def get_settings(params: dict, dataset_metadata: DatasetMetadata, model: str,
     if extra_llm_api_options:
         with open(extra_llm_api_options, 'r') as f:
             llm_args_dict = yaml.safe_load(f)
-            kv_cache_config = llm_args_dict.get("kv_cache_config", {
-                "dtype": "auto",
-            })
-            kv_cache_dtype = kv_cache_config.get("dtype", "auto")
-            mamba_ssm_cache_dtype = kv_cache_config.get("mamba_ssm_cache_dtype",
-                                                        mamba_ssm_cache_dtype)
+        if not isinstance(llm_args_dict, dict):
+            raise TypeError(
+                f"extra_llm_api_options must contain a YAML mapping, "
+                f"got {type(llm_args_dict)}")
+        kv_cache_config = llm_args_dict.get("kv_cache_config", {
+            "dtype": "auto",
+        })
+        kv_cache_dtype = kv_cache_config.get("dtype", "auto")
+        mamba_ssm_cache_dtype = kv_cache_config.get("mamba_ssm_cache_dtype",
+                                                    mamba_ssm_cache_dtype)
 
         enable_chunked_prefill = llm_args_dict.get("enable_chunked_prefill",
                                                    enable_chunked_prefill)

--- a/tensorrt_llm/bench/benchmark/utils/general.py
+++ b/tensorrt_llm/bench/benchmark/utils/general.py
@@ -79,6 +79,7 @@ def get_settings(params: dict, dataset_metadata: DatasetMetadata, model: str,
     """
     extra_llm_api_options = params.get("extra_llm_api_options")
     enable_chunked_prefill = params.get("enable_chunked_prefill", False)
+    enable_attention_dp = False
 
     kv_cache_dtype = "auto"
     mamba_ssm_cache_dtype = params.get("mamba_ssm_cache_dtype", "auto")
@@ -95,6 +96,7 @@ def get_settings(params: dict, dataset_metadata: DatasetMetadata, model: str,
 
         enable_chunked_prefill = llm_args_dict.get("enable_chunked_prefill",
                                                    enable_chunked_prefill)
+        enable_attention_dp = llm_args_dict.get("enable_attention_dp", False)
 
     mapping = {
         "pp_size": params.get("pp"),
@@ -137,6 +139,7 @@ def get_settings(params: dict, dataset_metadata: DatasetMetadata, model: str,
             dataset_metadata.avg_isl,
             dataset_metadata.avg_osl,
             params.get("kv_cache_free_gpu_mem_fraction"),
+            enable_attention_dp=enable_attention_dp,
         )
 
         logger.info(

--- a/tensorrt_llm/bench/build/build.py
+++ b/tensorrt_llm/bench/build/build.py
@@ -33,6 +33,7 @@ def get_benchmark_engine_settings(
     target_input_len: int,
     target_output_len: int,
     kv_cache_gpu_mem_fraction: float = 0.95,
+    enable_attention_dp: bool = False,
 ) -> Tuple[int, int]:
     """ Retrieve benchmark settings for a specific model + configuration.
 
@@ -43,6 +44,10 @@ def get_benchmark_engine_settings(
         pp_size (int): Number of pipeline parallel stages.
         target_input_len (int): Target input length to compile the engine.
         target_output_len (int): Target output length to compile the engine.
+        kv_cache_gpu_mem_fraction (float): Fraction of free memory to allocate
+            for KV cache.
+        enable_attention_dp (bool): Whether attention data parallelism is
+            enabled.
 
     Raises:
         ValueError: When the model_name is not supported.
@@ -61,6 +66,7 @@ def get_benchmark_engine_settings(
             target_input_len,
             target_output_len,
             kv_cache_gpu_mem_fraction,
+            enable_attention_dp=enable_attention_dp,
         )
     else:
         max_batch_size = DEFAULT_MAX_BATCH_SIZE

--- a/tensorrt_llm/bench/build/dataclasses.py
+++ b/tensorrt_llm/bench/build/dataclasses.py
@@ -219,7 +219,8 @@ class ModelConfig(BaseModel):
                 count * SAFETENSORS_DTYPE_BYTES.get(dtype, 1)
                 for dtype, count in metadata.parameter_count.items())
             checkpoint_size_in_gb = checkpoint_size_in_bytes / (1024**3)
-        assert param_count, (f"Can't get valid parameter count for model: "
+        if not param_count:
+            raise ValueError(f"Can't get valid parameter count for model: "
                              f"{hf_model_path or model_hf_name}.")
 
         return param_count, checkpoint_size_in_gb

--- a/tensorrt_llm/bench/build/dataclasses.py
+++ b/tensorrt_llm/bench/build/dataclasses.py
@@ -16,6 +16,22 @@ import struct
 from tensorrt_llm._torch.pyexecutor.config_utils import (
     load_pretrained_config, get_qwen3_hybrid_layer_types)
 
+# Mapping from safetensors dtype strings to bytes per element.
+# Used to compute checkpoint size from per-dtype element counts.
+SAFETENSORS_DTYPE_BYTES = {
+    'F64': 8,
+    'F32': 4,
+    'F16': 2,
+    'BF16': 2,
+    'I64': 8,
+    'I32': 4,
+    'I16': 2,
+    'I8': 1,
+    'U8': 1,
+    'BOOL': 1,
+    'F8_E4M3': 1,
+}
+
 
 def parse_safetensors_file_metadata(model_path, filename):
 
@@ -121,6 +137,7 @@ class ModelConfig(BaseModel):
     name: str
     model_type: str
     param_count: int
+    checkpoint_size_in_gb: float = Field(default=0.0)
     num_hidden_layers: int = Field(validation_alias=AliasChoices(
         "num_hidden_layers",
         "n_layer",
@@ -181,17 +198,31 @@ class ModelConfig(BaseModel):
         return self
 
     @classmethod
-    def get_param_count(cls, model_hf_name, hf_model_path):
-        """ Read the parameter count from HF safetensor metadata. """
+    def get_param_count_and_checkpoint_size(cls, model_hf_name, hf_model_path):
+        """Read parameter count and checkpoint size from safetensors metadata.
+
+        Returns:
+            Tuple[int, float]: (param_count, checkpoint_size_in_gb).
+        """
         if model_hf_name == "EleutherAI/gpt-j-6b":  # GPT-J repo doesn't use safetensor format.
             param_count = 6053381344
+            checkpoint_size_in_gb = param_count * 2 / (1024**3)
         else:
             model_name_or_path = hf_model_path or model_hf_name
             metadata = get_safetensors_metadata(model_name_or_path)
             param_count = sum(metadata.parameter_count.values())
-        assert param_count, f"Can't get valid parameter count for model: {model_name_or_path}."
+            # Compute actual checkpoint size using per-dtype byte sizes.
+            # This is critical for quantized models (e.g. NVFP4) where
+            # different tensors have different dtypes (U8 for packed weights,
+            # BF16 for non-quantized layers, F8_E4M3 for scales, etc.).
+            checkpoint_size_in_bytes = sum(
+                count * SAFETENSORS_DTYPE_BYTES.get(dtype, 1)
+                for dtype, count in metadata.parameter_count.items())
+            checkpoint_size_in_gb = checkpoint_size_in_bytes / (1024**3)
+        assert param_count, (f"Can't get valid parameter count for model: "
+                             f"{hf_model_path or model_hf_name}.")
 
-        return param_count
+        return param_count, checkpoint_size_in_gb
 
     @classmethod
     def from_hf(cls, model_hf_name, hf_model_path):
@@ -199,9 +230,14 @@ class ModelConfig(BaseModel):
                                                    or model_hf_name,
                                                    trust_remote_code=True)
         hf_config = pretrained_config.to_dict()
-        param_count = cls.get_param_count(model_hf_name, hf_model_path)
+        param_count, checkpoint_size_in_gb = (
+            cls.get_param_count_and_checkpoint_size(model_hf_name,
+                                                    hf_model_path))
 
-        return cls(name=model_hf_name, param_count=param_count, **hf_config)
+        return cls(name=model_hf_name,
+                   param_count=param_count,
+                   checkpoint_size_in_gb=checkpoint_size_in_gb,
+                   **hf_config)
 
     def extra_model_cache_in_gb(self, bytes_per_elem, target_seq_len=None):
         return 0

--- a/tensorrt_llm/bench/build/tuning.py
+++ b/tensorrt_llm/bench/build/tuning.py
@@ -26,6 +26,7 @@ def calc_engine_setting(
     target_input_len: int,
     target_output_len: int,
     kv_cache_gpu_mem_fraction: float = 0.95,
+    enable_attention_dp: bool = False,
 ) -> Tuple[int, int]:
     """ Calculate the engine build settings (max batch size and max num tokens)
         for a specific model + parallelism mapping + dataset configuration.
@@ -44,6 +45,9 @@ def calc_engine_setting(
         target_output_len (int): Target output length to compile the engine.
         kv_cache_gpu_mem_fraction (float): Fraction of free memory to allocate
             for KV cache.
+        enable_attention_dp (bool): Whether attention data parallelism is
+            enabled. When True, each TP rank independently manages its own
+            KV cache and batch, so max_batch_size is computed per-rank.
 
     Raises:
         RuntimeError: When the number of GPUs or amount of KV cache is unable to
@@ -67,9 +71,22 @@ def calc_engine_setting(
 
     # Number of GPU used for this run.
     n_gpus = tp_size * pp_size
-    # Total engine size.
-    engine_size = model_config.param_count * byte_per_elem / (1024**3)
-    total_gpu_memory = get_device_memory() * n_gpus
+    # Use checkpoint size from safetensors metadata for accurate estimation.
+    # This is critical for quantized models (e.g. NVFP4) where different
+    # tensors have different dtypes.
+    if model_config.checkpoint_size_in_gb > 0:
+        engine_size = model_config.checkpoint_size_in_gb
+    else:
+        # Fallback to param_count-based estimation for backward compatibility.
+        engine_size = model_config.param_count * byte_per_elem / (1024**3)
+    # With attention DP, each TP rank independently manages its own KV cache
+    # and holds a TP shard of the model weights. Compute per-rank available
+    # memory: single GPU memory minus per-rank engine size.
+    if enable_attention_dp:
+        total_gpu_memory = get_device_memory() * pp_size
+        engine_size = engine_size / tp_size
+    else:
+        total_gpu_memory = get_device_memory() * n_gpus
     # Available memory to allocate KV cache.
     available_memory = total_gpu_memory - engine_size
     logger.info(f"Estimated engine size: {engine_size:.2f} GB")

--- a/tensorrt_llm/bench/build/tuning.py
+++ b/tensorrt_llm/bench/build/tuning.py
@@ -79,9 +79,11 @@ def calc_engine_setting(
     else:
         # Fallback to param_count-based estimation for backward compatibility.
         engine_size = model_config.param_count * byte_per_elem / (1024**3)
-    # With attention DP, each TP rank independently manages its own KV cache
-    # and holds a TP shard of the model weights. Compute per-rank available
-    # memory: single GPU memory minus per-rank engine size.
+    # With attention DP, each TP rank independently manages its own KV cache.
+    # Attention weights are replicated across TP ranks, while MoE/MLP weights
+    # are distributed via expert parallelism (EP). We approximate per-rank
+    # engine size as total / tp_size, which slightly underestimates because
+    # replicated attention weights are small relative to distributed MoE weights.
     if enable_attention_dp:
         total_gpu_memory = get_device_memory() * pp_size
         engine_size = engine_size / tp_size
@@ -153,7 +155,8 @@ def calc_engine_setting(
     if kv_cache_max_requests < 1:
         raise RuntimeError("The amount of KV cache memory is insufficient to "
                            "run this model. Please try with more GPUs.")
-    if cache_memory / n_gpus < 10.0:
+    warning_gpu_count = pp_size if enable_attention_dp else n_gpus
+    if cache_memory / warning_gpu_count < 10.0:
         logger.warning(
             f"The KV cache memory per GPU is less than 10 GB. "
             "Performance may be undesirable. Please consider using a different "


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attention data parallelism (DP) support for improved memory allocation and batch sizing calculations.
  * Implemented checkpoint size tracking in model configurations for more accurate engine sizing.

* **Enhancements**
  * Engine size estimation now uses checkpoint size metadata when available, with fallback to parameter count-based estimation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Two fixes for the autotuner in `trtllm-bench`:

**Issue 1: NVFP4 engine size underestimated by ~2x**

The previous calculation used `param_count * byte_per_elem` (with `byte_per_elem=0.5` for NVFP4) to estimate engine size. This significantly underestimates quantized models because NVFP4 checkpoints contain mixed dtypes: `U8` for packed FP4 weights, `BF16` for non-quantized layers (embeddings, norms), and `F8_E4M3` for scale factors. The `param_count` from safetensors sums element counts across all dtypes, so multiplying by a single `byte_per_elem` is incorrect.

Fix: Compute checkpoint size from per-dtype byte sizes using safetensors metadata. Added `SAFETENSORS_DTYPE_BYTES` mapping and `checkpoint_size_in_gb` field to `ModelConfig`.

Verified with DeepSeek-V3.2-NVFP4 on disk: buggy=183.70 GB vs fixed=386.54 GB (2.10x ratio).

**Issue 2: Attention DP max_batch_size computed from pooled GPU memory instead of per-rank**

When attention data parallelism is enabled, each TP rank independently manages its own KV cache. The autotuner was pooling GPU memory across all ranks (`n_gpus = tp_size * pp_size`), producing a total `max_batch_size` that exceeds what a single rank can handle. This caused OOM when each rank tried to allocate the full pooled cache (e.g., 360 GB on a 276.5 GB GPU).

Fix: When `enable_attention_dp=True` (read from the `extra_llm_api_options` YAML config), compute per-rank available memory (`single_gpu * pp_size`) and divide engine size by `tp_size` (since TP still shards model weights).

## Test Coverage

- No existing unit tests cover the autotuner code (`bench/build/tuning.py`, `bench/build/dataclasses.py`).
- Verified with a standalone repro script using real DeepSeek-V3.2-NVFP4 safetensors metadata.
- Integration coverage via `trtllm-bench` perf tests in CI (e.g., `test_perf.py`, `test_perf_sanity.py`).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.