### PR TITLE
[None][infra] Add apt cache mounts to devel stage and use existing pip cache

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -39,6 +39,8 @@ ARG CUBLAS_VER
 ARG TORCH_INSTALL_TYPE="skip"
 RUN --mount=type=bind,source=docker/common,target=/opt/docker/common \
     --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     echo "Using GitHub mirror: ${GITHUB_MIRROR}" && \
     echo "Using Python version: ${PYTHON_VERSION}" && \
     GITHUB_MIRROR=${GITHUB_MIRROR} \
@@ -56,13 +58,15 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip3 uninstall -y tornado black nbconvert pillow nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base || true && \
     # Remove any leftover namespace dirs or dist-info that pip missed
     rm -rf $(python3 -c "import site; print(site.getsitepackages()[0])")/nvidia_cutlass_dsl* && \
-    pip3 install --ignore-installed --no-cache-dir -r /tmp/constraints.txt && \
+    pip3 install --ignore-installed -r /tmp/constraints.txt && \
     rm /tmp/constraints.txt
 
 # Install UCX, NIXL, etcd
 # TODO: Combine these into the main install.sh script
 RUN --mount=type=bind,source=docker/common,target=/opt/docker/common \
     --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
     GITHUB_MIRROR=${GITHUB_MIRROR} bash /opt/docker/common/install_ucx.sh && \
     GITHUB_MIRROR=${GITHUB_MIRROR} bash /opt/docker/common/install_nixl.sh && \
     bash /opt/docker/common/install_etcd.sh && \

--- a/docker/common/install_base.sh
+++ b/docker/common/install_base.sh
@@ -36,13 +36,18 @@ set_bash_env() {
 }
 
 cleanup() {
-  # Clean up apt/dnf cache
+  # Clean up apt/dnf cache.
+  # NOTE: When this script runs under a BuildKit RUN with cache mounts on
+  # /var/cache/apt and /var/lib/apt (see docker/Dockerfile.multi), `apt-get
+  # clean` and `rm -rf /var/lib/apt/lists/*` operate on the persistent cache
+  # mount rather than the image layer, so they would wipe the cache between
+  # builds. The mount itself ensures these paths are not baked into the
+  # layer, so skipping the apt cleanup here keeps the image size unchanged
+  # while preserving the cache for incremental rebuilds.
   if [ -f /etc/debian_version ]; then
     echo "Removing python3-pygments from Ubuntu..."
     apt-get remove -y python3-pygments || true
     apt-get autoremove -y || true
-    apt-get clean
-    rm -rf /var/lib/apt/lists/*
   elif [ -f /etc/redhat-release ]; then
     echo "Removing python3-pygments from Rocky Linux..."
     dnf remove -y python3-pygments || true
@@ -53,8 +58,9 @@ cleanup() {
   # Clean up temporary files
   rm -rf /tmp/* /var/tmp/*
 
-  # Clean up pip cache
-  pip3 cache purge || true
+  # pip's wheel cache lives at /root/.cache/pip, which is also a BuildKit
+  # cache mount in the devel stage. `pip3 cache purge` would empty that
+  # mount; rely on the mount lifecycle instead.
 
   # Clean up documentation
   rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/info/*

--- a/docker/common/install_nixl.sh
+++ b/docker/common/install_nixl.sh
@@ -18,7 +18,7 @@ fi
 if [ -n "${GITHUB_MIRROR}" ]; then
   export PIP_INDEX_URL="https://urm.nvidia.com/artifactory/api/pypi/pypi-remote/simple"
 fi
-pip3 install --no-cache-dir meson ninja pybind11 setuptools
+pip3 install meson ninja pybind11 setuptools
 
 git clone --depth 1 -b ${NIXL_VERSION} ${NIXL_REPO}
 cd nixl


### PR DESCRIPTION
## Description

The `devel` stage of `docker/Dockerfile.multi` already mounts a BuildKit pip cache, but two issues prevent the cache from helping incremental rebuilds:

1. `apt-get install` calls in `install_base.sh` run without an apt cache mount, so every rebuild re-downloads every `.deb`. The `install.sh` layer takes ~260s on a typical compute node, dominated by apt fetch + extract.
2. `pip3 install --no-cache-dir` is used in two places that run *inside* RUN layers already mounting `/root/.cache/pip`, defeating the existing pip cache mount:
   - `docker/Dockerfile.multi` line 57 (constraints.txt install).
   - `docker/common/install_nixl.sh` line 21 (meson, ninja, pybind11, setuptools).

   Wheels are downloaded fresh every rebuild instead of being served from the persistent cache.

### What this PR changes

- `docker/Dockerfile.multi`: add `--mount=type=cache,target=/var/cache/apt,sharing=locked` and `--mount=type=cache,target=/var/lib/apt,sharing=locked` to the two devel-stage RUN layers that invoke apt (the `install.sh` layer and the UCX/NIXL/etcd layer).
- `docker/Dockerfile.multi`: drop `--no-cache-dir` from the constraints.txt pip install (the surrounding RUN already mounts the pip cache).
- `docker/common/install_nixl.sh`: drop `--no-cache-dir` from the meson/ninja/pybind11/setuptools install for the same reason.
- `docker/common/install_base.sh`: update `cleanup()` to skip `apt-get clean`, `rm -rf /var/lib/apt/lists/*`, and `pip3 cache purge`. Under cache-mount RUNs these commands operate on the persistent mount rather than the image layer, so running them wipes the cache between builds. The cache mounts themselves ensure the layer never persists these paths, so image size is unchanged.

The `release` stage (`docker/Dockerfile.multi` lines 116, 122) already follows this same pattern; this PR extends the pattern to `devel`.

### Expected impact

- **Incremental rebuilds** (Dockerfile content changes but install scripts and constraints don't): the install.sh layer drops from ~260s to a few seconds — apt fetches resolve from the cache and pip wheels are served from the persistent cache.
- **From-scratch builds**: unchanged.
- **Resulting image size**: unchanged (cache mounts are not baked into the image).

### Out of scope / potential follow-ups

- Adding the same apt cache mount to the `tritondevel` RUN (Dockerfile.multi lines 91-98) — same pattern, separate change to keep this PR focused.
- Caching the 20 MB etcd tarball that `install_etcd.sh` downloads on every build.
- ccache mount for the UCX and NIXL source builds.

## Test Coverage

This is a build-system-only change with no runtime code path, so it relies on the existing image-build CI for validation:

- The image-build CI stages exercise `make -C docker build` end-to-end on a cold runner. A successful build proves the new `--mount=type=cache` lines parse correctly under BuildKit and that removing `--no-cache-dir` plus the cleanup changes still produce a functional `tensorrt_llm/devel:latest`.
- BuildKit cache mounts are a pass-through: when no cache layer is present (cold runner), they behave like normal directories, so the from-scratch build path is unchanged.
- The cache-hit path (incremental rebuild) was verified locally: after this change, a no-op rebuild after a small Dockerfile edit drops the install.sh layer from ~260s to seconds. This requires a warm BuildKit cache, which CI runners typically don't have, but the warm path is exercised by anyone running `make -C docker build` repeatedly on the same machine.
- No new runtime tests required — the resulting image is functionally equivalent to baseline; only build-time behavior changes.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
