### PR TITLE
[None][fix] fix PEFT page accumulation in MaxUtilizationPolicy scheduler

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
@@ -1097,7 +1097,7 @@ class MaxUtilizationPolicy(SchedulerPolicyBase):
                 req_it += 1
                 continue
 
-            was_scheduled = self._try_scheduling_request(
+            was_scheduled, num_scheduled_peft_pages = self._try_scheduling_request(
                 scheduler,
                 req,
                 scheduled_requests,
@@ -1139,15 +1139,15 @@ class MaxUtilizationPolicy(SchedulerPolicyBase):
         num_scheduled_peft_pages: int,
         seen_task_ids: set[int],
         cached_summary: Optional[PrefixReuseSummary] = None,
-    ) -> bool:
+    ) -> tuple[bool, int]:
         if len(scheduled_requests) >= scheduler.max_num_requests:
-            return False
+            return False, num_scheduled_peft_pages
 
         blocks_if_scheduled = scheduled_blocks_manager.prepare_blocks_if_schedulable(
             req, cached_summary=cached_summary
         )
         if blocks_if_scheduled is None:
-            return False
+            return False, num_scheduled_peft_pages
 
         # PEFT check only when needed
         if scheduler.peft_cache_manager is not None:
@@ -1160,16 +1160,17 @@ class MaxUtilizationPolicy(SchedulerPolicyBase):
             )
             max_peft_pages = scheduler._get_max_peft_pages()
             if num_required_peft_pages + num_scheduled_peft_pages > max_peft_pages:
-                return False
+                return False, num_scheduled_peft_pages
             logger.debug(
                 f"MaxUtilizationScheduler: scheduled peft pages: {num_required_peft_pages}"
             )
+            num_scheduled_peft_pages += num_required_peft_pages
             if is_new_task:
                 seen_task_ids.add(lora_task_id)
 
         scheduled_blocks_manager.update_scheduled_blocks(blocks_if_scheduled)
         scheduled_requests.append(req)
-        return True
+        return True, num_scheduled_peft_pages
 
 
 class NoEvictScheduledBlocksManager:

--- a/tests/unittest/_torch/executor/test_py_scheduler.py
+++ b/tests/unittest/_torch/executor/test_py_scheduler.py
@@ -2198,7 +2198,7 @@ class TestPyCapacitySchedulerLora:
         r0 = _make_request(0, lora_task_id=1)
         r1 = _make_request(1, lora_task_id=2)
         r2 = _make_request(2, lora_task_id=3)
-        fitting, disagg, paused = scheduler.schedule_request([r0, r1, r2])
+        fitting, _disagg, _paused = scheduler.schedule_request([r0, r1, r2])
         # 2 tasks x 10 pages = 20 <= 25; 3rd task would push to 30 > 25
         assert len(fitting) == 2
 

--- a/tests/unittest/_torch/executor/test_py_scheduler.py
+++ b/tests/unittest/_torch/executor/test_py_scheduler.py
@@ -2177,6 +2177,31 @@ class TestPyCapacitySchedulerLora:
         # First task: 10 pages, second task: 10 pages, total 20 > 15
         assert len(fitting) == 1
 
+    def test_max_utilization_peft_page_accumulation(self):
+        """
+        MAX_UTILIZATION policy must accumulate scheduled PEFT pages across
+        requests so the per-batch page cap is enforced.
+
+        With max_pages=25 and 10 pages per new task:
+          req 0 (task 1): total =  0+10 = 10 <= 25 -> admit
+          req 1 (task 2): total = 10+10 = 20 <= 25 -> admit
+          req 2 (task 3): total = 20+10 = 30  > 25 -> reject
+        """
+        kv = MockKVCacheManager(num_free_blocks=100, blocks_per_request=5)
+        peft = MockPeftCacheManager(max_pages=25, pages_per_request=10)
+        scheduler = PyCapacityScheduler(
+            max_num_requests=4,
+            kv_cache_manager=kv,
+            peft_cache_manager=peft,
+            scheduler_policy=CapacitySchedulerPolicy.MAX_UTILIZATION,
+        )
+        r0 = _make_request(0, lora_task_id=1)
+        r1 = _make_request(1, lora_task_id=2)
+        r2 = _make_request(2, lora_task_id=3)
+        fitting, disagg, paused = scheduler.schedule_request([r0, r1, r2])
+        # 2 tasks x 10 pages = 20 <= 25; 3rd task would push to 30 > 25
+        assert len(fitting) == 2
+
 
 # ############################################################################
 #


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PEFT page counter tracking in the scheduler to properly maintain cumulative page usage across multiple requests, preventing resource accounting inconsistencies.

* **Tests**
  * Added comprehensive test to validate that PEFT page limits are correctly enforced when scheduling multiple LoRA/PEFT requests with distinct task identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

In MaxUtilizationPolicy._try_scheduling_request, num_scheduled_peft_pages was passed by value and never returned, so the caller's accumulator stayed at 0 across all requests. This caused the per-batch PEFT page cap to be checked against 0 already-scheduled pages for every request, potentially over-admitting LoRA tasks beyond the device cache limit.

Fix mirrors the C++ reference (in capacityScheduler.cpp) return the updated count from _try_scheduling_request and accumulate it in the caller.

Add a unit test that fails before the fix (3 tasks admitted when only 2 fit within max_pages=25) and passes after.

## Test Coverage

Added new test

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
