### PR TITLE
[None][fix] Always sync local ranks after prefetch in HfWeightLoader

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -85,8 +85,12 @@ class HfWeightLoader(BaseWeightLoader):
                     f"Prefetching {prefetch_size / (1024**3):.2f}GB checkpoint files."
                 )
                 self.prefetch_files(weight_files)
-                # Ensure that all local ranks have finished prefetching before loading weights
-                local_mpi_barrier()
+            # Sync all local ranks unconditionally. `enable_prefetch` depends on
+            # `psutil.virtual_memory().available`, a per-rank volatile value, so
+            # different ranks may take different branches; gating the barrier on
+            # it would deadlock between ranks that prefetched and ranks that
+            # skipped. Ranks that didn't prefetch reach the barrier immediately.
+            local_mpi_barrier()
 
             return self._load_weights_in_parallel(
                 weight_files, self._load_safetensors_file,


### PR DESCRIPTION
## Summary

Move `local_mpi_barrier()` in `HfWeightLoader.load_weights` out of the `if enable_prefetch:` branch so all local ranks invoke the collective unconditionally. The previous code gated a collective on a per-rank volatile value, which caused a 4-rank deadlock during DeepSeek-V4 Pro (NVFP4) loading with MTP=1 + DEP4.

## Root cause

`enable_prefetch` is computed as:

```python
enable_prefetch = prefetch_size < psutil.virtual_memory().available * 0.9 \
                  and num_layers == 0
```

`psutil.virtual_memory().available` is an OS-level instantaneous value. Even though `_get_local_available_host_memory()` does an `MPI.MIN` allreduce, the snapshot itself is taken at slightly different wall-clock moments per rank, and per-rank CPU memory peaks (model meta init, `model.to("cuda")`, GC, page-cache churn) drift. Observed on a single node:

```
rank0: avail=  846.33 GB
rank2: avail=  881.24 GB
rank3: avail= 1389.18 GB
rank1: avail= 1657.35 GB
```

For DSV4 Pro (`prefetch_size = 805 GB`), the 0.9x threshold (~894 GB) landed in the middle of the per-rank distribution, so two ranks took `enable_prefetch = True` and two took `False`. The two `True` ranks entered `local_mpi_barrier()` while the other two had already moved on, producing a hard deadlock.

## Why this was not discovered before

Introduced in PR #6486 (2025-08-01, DeepSeek R1 FP8 on Blackwell). The deadlock requires two conditions:

1. `prefetch_size ~ 0.45-0.55 x system_mem`, so the threshold cuts through the per-rank `available` distribution.
2. Large enough per-rank memory-timing skew to cross the threshold.

Every prior model (Llama 70B / 405B FP8, Mixtral 8x22B, DeepSeek-V3 / R1 FP8) had `prefetch_size` well below the threshold on typical nodes, so all ranks unanimously chose `True`. DSV4 Pro NVFP4 (805 GB) is the first model whose footprint sits near `system_mem / 2`. MTP=1 with DEP4 amplifies condition (2): the extra `DeepseekV4MTP` draft layer with attention-DP shifts per-rank `model.to("cuda")` completion by hundreds of milliseconds, widening the per-rank `available` spread enough to straddle the threshold.

## Fix

Move the barrier out of the conditional. Ranks that did not prefetch reach the barrier immediately, so cost is negligible and no decision semantics change.

```python
if enable_prefetch:
    self.prefetch_files(weight_files)
local_mpi_barrier()  # always invoked by all local ranks
```