### PR TITLE
[TRTLLM-12338][feat] Lift TOKENIZER_ALIASES to module level in llmapi.llm_args

### DIFF
--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -601,6 +601,14 @@ class MoeConfig(StrictBaseModel):
 
 Nvfp4Backend = Literal['cutlass', 'cublaslt', 'cutedsl', 'cuda_core']
 
+# Short aliases for built-in custom tokenizers.
+# Maps alias → full import path (module.ClassName).
+TOKENIZER_ALIASES = {
+    'deepseek_v32': 'tensorrt_llm.tokenizer.deepseek_v32.DeepseekV32Tokenizer',
+    'deepseek_v4': 'tensorrt_llm.tokenizer.deepseek_v4.DeepseekV4Tokenizer',
+    'glm_moe_dsa': 'tensorrt_llm.tokenizer.glm_moe_dsa.GlmMoeDsaTokenizer',
+}
+
 
 class Nvfp4GemmConfig(StrictBaseModel):
     """
@@ -2918,16 +2926,7 @@ class BaseLlmArgs(StrictBaseModel):
                     "Please specify a tokenizer path or leave it as None to load from model path."
                 )
 
-            # Support short aliases for built-in tokenizers
-            TOKENIZER_ALIASES = {
-                'deepseek_v32':
-                'tensorrt_llm.tokenizer.deepseek_v32.DeepseekV32Tokenizer',
-                'deepseek_v4':
-                'tensorrt_llm.tokenizer.deepseek_v4.DeepseekV4Tokenizer',
-                'glm_moe_dsa':
-                'tensorrt_llm.tokenizer.glm_moe_dsa.GlmMoeDsaTokenizer',
-            }
-
+            # Resolve short aliases via the module-level TOKENIZER_ALIASES.
             tokenizer_path = TOKENIZER_ALIASES.get(self.custom_tokenizer,
                                                    self.custom_tokenizer)
 


### PR DESCRIPTION
## Summary

Hoist `TOKENIZER_ALIASES` from a method-local variable inside `BaseLlmArgs.validate_and_init_tokenizer` to a module-level constant in `tensorrt_llm/llmapi/llm_args.py`. Mirrors the equivalent change made on `main` in #12990 (\"Support custom_tokenizer in KvCacheAwareRouter for disagg serving\"); difference here is that this branch's dict also includes `'deepseek_v4'` → `DeepseekV4Tokenizer`, since DeepSeek-V4 lives on this branch and isn't on `main` yet.

## Why

External code outside TRT-LLM legitimately needs to resolve the same short aliases TRT-LLM uses internally. Concretely, the Dynamo TRT-LLM worker ([`dynamo.trtllm.workers.llm_worker`](https://github.com/ai-dynamo/dynamo/blob/release/deepseekv4/components/src/dynamo/trtllm/workers/llm_worker.py), added in [ai-dynamo/dynamo#8079](https://github.com/ai-dynamo/dynamo/pull/8079)) does:

\`\`\`python
from tensorrt_llm.llmapi.llm_args import TOKENIZER_ALIASES
\`\`\`

so it can build the V4 tokenizer **before** instantiating \`LLM(...)\`. Dynamo needs the tokenizer object early to:
- populate \`SamplingParams\` defaults from model-specific special tokens, and
- wire up its health-check logits processor (it then passes \`skip_tokenizer_init=True\` to the engine).

On this branch, \`TOKENIZER_ALIASES\` is defined as a method-local variable, so the import fails at module load time with:

\`\`\`
ImportError: cannot import name 'TOKENIZER_ALIASES' from 'tensorrt_llm.llmapi.llm_args'
\`\`\`

…and the Dynamo worker crashes before any runtime work begins (CrashLoopBackOff in K8s deployments).

`main` already has the dict module-level (#12990, 2026-04-19), so once this branch rebases onto `main`, the import will work for the V32/GLM aliases. This PR adds the V4 entry now (so DeepSeek-V4 deployments via Dynamo work today on this branch) and trims one local copy of the dict — making the eventual rebase a no-op merge for this surface.

## Behavior

No semantic change for existing callers. \`validate_and_init_tokenizer\` now references the module-level constant instead of redefining its own copy.

## Test plan

- [x] Smoke: \`python3 -c 'from tensorrt_llm.llmapi.llm_args import TOKENIZER_ALIASES; print(sorted(TOKENIZER_ALIASES))'\` prints \`['deepseek_v32', 'deepseek_v4', 'glm_moe_dsa']\`
- [x] Smoke: \`trtllm-serve <flash-snapshot> --custom_tokenizer deepseek_v4 ...\` continues to load the V4 tokenizer (validates the local function body still works)
- [x] Verified locally on a Dynamo+TRT-LLM K8s deployment of DeepSeek-V4-Flash on B200×4: \`from ... import TOKENIZER_ALIASES\` succeeds, worker boots, and \`/v1/chat/completions\` returns coherent answers.