### PR TITLE
[TRTLLM-12390][feat] Support fractional synthetic acceptance rates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1019,7 +1019,6 @@ common-files: &common_files |
         tests/unittest/_torch/speculative/test_draft_token_tree_verification.py |
         tests/unittest/_torch/speculative/test_dynamic_spec_decode.py |
         tests/unittest/_torch/speculative/test_eagle3.py |
-        tests/unittest/_torch/speculative/test_force_accepted_tokens.py |
         tests/unittest/_torch/speculative/test_kv_cache_reuse.py |
         tests/unittest/_torch/speculative/test_mtp.py |
         tests/unittest/_torch/speculative/test_ngram.py |
@@ -2376,7 +2375,6 @@ legacy-files: &legacy_files |
         tests/unittest/_torch/speculative/test_draft_token_tree_verification.py |
         tests/unittest/_torch/speculative/test_dynamic_spec_decode.py |
         tests/unittest/_torch/speculative/test_eagle3.py |
-        tests/unittest/_torch/speculative/test_force_accepted_tokens.py |
         tests/unittest/_torch/speculative/test_kv_cache_reuse.py |
         tests/unittest/_torch/speculative/test_mtp.py |
         tests/unittest/_torch/speculative/test_ngram.py |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1019,6 +1019,7 @@ common-files: &common_files |
         tests/unittest/_torch/speculative/test_draft_token_tree_verification.py |
         tests/unittest/_torch/speculative/test_dynamic_spec_decode.py |
         tests/unittest/_torch/speculative/test_eagle3.py |
+        tests/unittest/_torch/speculative/test_force_accepted_tokens.py |
         tests/unittest/_torch/speculative/test_kv_cache_reuse.py |
         tests/unittest/_torch/speculative/test_mtp.py |
         tests/unittest/_torch/speculative/test_ngram.py |
@@ -2375,6 +2376,7 @@ legacy-files: &legacy_files |
         tests/unittest/_torch/speculative/test_draft_token_tree_verification.py |
         tests/unittest/_torch/speculative/test_dynamic_spec_decode.py |
         tests/unittest/_torch/speculative/test_eagle3.py |
+        tests/unittest/_torch/speculative/test_force_accepted_tokens.py |
         tests/unittest/_torch/speculative/test_kv_cache_reuse.py |
         tests/unittest/_torch/speculative/test_mtp.py |
         tests/unittest/_torch/speculative/test_ngram.py |

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -137,7 +137,14 @@ def restore_attn_metadata_after_draft_replay(attn_metadata, saved_state):
 
 def get_force_num_accepted_tokens() -> int:
     """
-    Read and parse the TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS environment variable.
+    Read and parse the TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS environment
+    variable as an integer.
+
+    Used by speculative decoding paths that operate on Python lists/slices and
+    therefore require an integer count (e.g. the two-model path in
+    ``TorchSampler``). For the one-model path, see
+    :func:`get_force_num_accepted_tokens_float`, which supports fractional
+    synthetic acceptance rates.
 
     Returns:
         int: The forced number of accepted tokens, or 0 if not set or invalid.
@@ -150,6 +157,31 @@ def get_force_num_accepted_tokens() -> int:
             f"{FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR} must be a valid integer, "
             f"got '{env_value}'. Using default value 0.")
         return 0
+
+
+def get_force_num_accepted_tokens_float() -> float:
+    """
+    Read and parse the TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS environment
+    variable as a (possibly fractional) float.
+
+    Used by the one-model speculative decoding path to synthesize non-integer
+    acceptance rates: the integer part is the number of draft tokens accepted
+    on every iteration, and the fractional part is the probability of
+    accepting one additional draft token. For example, "2.6" means always
+    accept 2 draft tokens and accept one more with probability 0.6.
+
+    Returns:
+        float: The forced (possibly fractional) number of accepted draft
+        tokens, or 0.0 if not set or invalid.
+    """
+    env_value = os.environ.get(FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR, "0")
+    try:
+        return float(env_value)
+    except ValueError:
+        logger.warning(
+            f"{FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR} must be a valid number "
+            f"(int or float), got '{env_value}'. Using default value 0.0.")
+        return 0.0
 
 
 class SpeculativeDecodingMode(IntEnum):
@@ -517,7 +549,8 @@ class SpecWorkerBase(nn.Module, ABC):
     def __init__(self, use_separate_draft_kv_cache: bool = False):
         super().__init__()
         self.guided_decoder: Optional["CapturableGuidedDecoder"] = None
-        self.force_num_accepted_tokens = get_force_num_accepted_tokens()
+        self.force_num_accepted_tokens: float = get_force_num_accepted_tokens_float(
+        )
         self.use_flashinfer = IS_FLASHINFER_AVAILABLE and Version(
             flashinfer.__version__) >= Version("0.6.4")
         self.seed: Optional[torch.Tensor] = None
@@ -634,22 +667,65 @@ class SpecWorkerBase(nn.Module, ABC):
     def _apply_force_accepted_tokens(self, num_accepted_tokens, num_contexts,
                                      runtime_draft_len: int):
         """
-        Apply forced number of accepted tokens if environment variable is set.
-        This is used for testing and debugging.
+        Apply a forced (synthetic) number of accepted draft tokens if the
+        ``TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS`` environment variable is
+        set. This is used for testing and debugging speculative decoding.
+
+        The forced value supports fractional synthetic acceptance rates: the
+        integer part is the number of draft tokens accepted on every
+        generation iteration, and the fractional part is the probability of
+        accepting one additional draft token on that iteration. For example,
+        a value of ``2.6`` means: always accept 2 draft tokens, and accept
+        one more with probability 0.6 (per generation request).
+
+        The implementation is CUDA-graph-compatible: only tensor ops with
+        statically-known shapes are used, and per-iteration randomness is
+        produced by ``torch.rand`` against the default CUDA generator, whose
+        Philox state is captured/replayed in graph-safe mode by PyTorch's
+        ``torch.cuda.graph`` context.
 
         Args:
-            num_accepted_tokens: Tensor of shape [batch_size] with current accepted counts
-            num_contexts: Number of context (prefill) requests
+            num_accepted_tokens: Tensor of shape [batch_size] with current
+                accepted counts (target token + accepted draft tokens).
+            num_contexts: Number of context (prefill) requests in the batch.
             runtime_draft_len: The draft length for the current iteration.
 
         Returns:
-            Modified num_accepted_tokens tensor
+            Modified num_accepted_tokens tensor.
         """
-        if self.force_num_accepted_tokens != 0:
-            # total tokens per iteration = accepted draft tokens + 1 target token
-            force_total_tokens = min(self.force_num_accepted_tokens + 1,
-                                     runtime_draft_len + 1)
+        if self.force_num_accepted_tokens == 0.0:
+            return num_accepted_tokens
+
+        # Decompose into a deterministic integer part (always accepted) and a
+        # probabilistic fractional part. ``int(...)`` truncates toward zero,
+        # which matches floor for the supported non-negative range.
+        int_part = int(self.force_num_accepted_tokens)
+        frac_part = self.force_num_accepted_tokens - int_part
+
+        # ``num_accepted_tokens`` counts the target token + accepted draft
+        # tokens, so the maximum reachable value is ``runtime_draft_len + 1``.
+        max_total = runtime_draft_len + 1
+        base_total = min(int_part + 1, max_total)
+
+        if frac_part > 0.0 and base_total < max_total:
+            # Sample one Bernoulli per generation request: with probability
+            # ``frac_part`` accept one additional draft token. ``num_gens``
+            # is fixed at CUDA-graph capture time (graphs are captured for a
+            # specific batch shape with ``num_contexts`` typically 0), so
+            # ``torch.rand`` allocates a static-shape tensor that is safely
+            # captured and replayed.
+            num_gens = num_accepted_tokens.shape[0] - num_contexts
+            rand = torch.rand(num_gens,
+                              device=num_accepted_tokens.device,
+                              dtype=torch.float32)
+            extra = (rand < frac_part).to(num_accepted_tokens.dtype)
+            # ``base_total + extra`` is at most ``int_part + 2``; clamp so we
+            # never exceed the available draft slots.
+            force_total_tokens = (base_total + extra).clamp_(max=max_total)
             num_accepted_tokens[num_contexts:] = force_total_tokens
+        else:
+            num_accepted_tokens[num_contexts:] = base_total
+
         return num_accepted_tokens
 
     def _sample_and_accept_draft_tokens_base(

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -28,6 +28,20 @@ if IS_FLASHINFER_AVAILABLE:
 # Environment variable name for forcing the number of accepted tokens in speculative decoding
 FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR = "TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS"
 
+# RNG pool configuration for the fractional (probabilistic) component of the
+# synthetic acceptance rate. Pool size MUST be a power of two so we can use
+# a bitmask (`& (pool_size - 1)`) for wrap-around — this stays cheap and
+# keeps tensor shapes static for CUDA graph capture. The fixed seed is what
+# guarantees identical random draws on every TP rank (so all ranks accept the
+# same number of tokens per iteration and downstream collectives stay in
+# lock-step). The two stride primes mix the per-call counter with the
+# per-slot index so consecutive calls / consecutive slots map to decorrelated
+# pool entries.
+_FORCE_ACCEPT_RNG_POOL_SIZE = 1 << 16  # 65536 entries (256 KiB float32)
+_FORCE_ACCEPT_RNG_SEED = 0xACCE9D
+_FORCE_ACCEPT_RNG_COUNTER_STRIDE = 6007
+_FORCE_ACCEPT_RNG_SLOT_STRIDE = 1009
+
 
 def should_use_separate_draft_kv_cache(spec_config) -> bool:
     """
@@ -556,6 +570,13 @@ class SpecWorkerBase(nn.Module, ABC):
         self.seed: Optional[torch.Tensor] = None
         self.offset: Optional[torch.Tensor] = None
         self.use_separate_draft_kv_cache = use_separate_draft_kv_cache
+        # Lazily-initialized state for the fractional synthetic acceptance
+        # rate. The pool is a fixed-seed, rank-independent table of uniform
+        # [0, 1) values; the counter is a device-side int64 advanced in-place
+        # inside captured CUDA graphs (mirroring the existing flashinfer
+        # seed/offset pattern in `_sample_tokens_for_batch`).
+        self._force_accept_rng_pool: Optional[torch.Tensor] = None
+        self._force_accept_rng_counter: Optional[torch.Tensor] = None
 
     @property
     @abstractmethod
@@ -664,6 +685,33 @@ class SpecWorkerBase(nn.Module, ABC):
         attn_metadata.restore_from_spec_dec()
         attn_metadata.on_update()
 
+    def _ensure_force_accept_rng_state(self, device: torch.device) -> None:
+        """
+        Lazily build the deterministic RNG state used by
+        :meth:`_apply_force_accepted_tokens` for fractional synthetic
+        acceptance rates.
+
+        The pool is filled from a CPU generator with a fixed seed so that
+        every tensor-parallel rank produces the bit-for-bit identical pool
+        (TP ranks must agree on the per-iteration accepted-token count, or
+        downstream collectives expecting identical shapes will hang).
+
+        First-call allocation must happen during eager warmup — never inside
+        a captured CUDA graph. The CUDA-graph runner already runs warmup
+        forwards before capture, which satisfies this in practice.
+        """
+        if self._force_accept_rng_pool is not None:
+            return
+        cpu_gen = torch.Generator(device="cpu")
+        cpu_gen.manual_seed(_FORCE_ACCEPT_RNG_SEED)
+        pool_cpu = torch.rand(_FORCE_ACCEPT_RNG_POOL_SIZE,
+                              dtype=torch.float32,
+                              generator=cpu_gen)
+        self._force_accept_rng_pool = pool_cpu.to(device=device)
+        self._force_accept_rng_counter = torch.zeros(1,
+                                                     dtype=torch.int64,
+                                                     device=device)
+
     def _apply_force_accepted_tokens(self, num_accepted_tokens, num_contexts,
                                      runtime_draft_len: int):
         """
@@ -678,11 +726,14 @@ class SpecWorkerBase(nn.Module, ABC):
         a value of ``2.6`` means: always accept 2 draft tokens, and accept
         one more with probability 0.6 (per generation request).
 
-        The implementation is CUDA-graph-compatible: only tensor ops with
-        statically-known shapes are used, and per-iteration randomness is
-        produced by ``torch.rand`` against the default CUDA generator, whose
-        Philox state is captured/replayed in graph-safe mode by PyTorch's
-        ``torch.cuda.graph`` context.
+        The implementation is CUDA-graph-compatible AND tensor-parallel
+        deterministic. Randomness is sourced from a fixed-seed lookup pool
+        plus a device-side counter that is advanced in place each call —
+        the same pattern as the flashinfer seed/offset state used by
+        :meth:`_sample_tokens_for_batch`. Because every rank seeds the pool
+        identically and increments the counter on the same captured ops,
+        every rank draws the same uniform values and therefore agrees on the
+        accepted-token count for every request in every iteration.
 
         Args:
             num_accepted_tokens: Tensor of shape [batch_size] with current
@@ -708,16 +759,30 @@ class SpecWorkerBase(nn.Module, ABC):
         base_total = min(int_part + 1, max_total)
 
         if frac_part > 0.0 and base_total < max_total:
-            # Sample one Bernoulli per generation request: with probability
-            # ``frac_part`` accept one additional draft token. ``num_gens``
-            # is fixed at CUDA-graph capture time (graphs are captured for a
-            # specific batch shape with ``num_contexts`` typically 0), so
-            # ``torch.rand`` allocates a static-shape tensor that is safely
-            # captured and replayed.
+            self._ensure_force_accept_rng_state(num_accepted_tokens.device)
+
+            # ``num_gens`` is fixed at CUDA-graph capture time (graphs are
+            # captured for a specific batch shape with ``num_contexts``
+            # typically 0), so all of the ops below have static shapes.
             num_gens = num_accepted_tokens.shape[0] - num_contexts
-            rand = torch.rand(num_gens,
-                              device=num_accepted_tokens.device,
-                              dtype=torch.float32)
+
+            # In-place counter bump is captured by the graph and replayed on
+            # every iteration, so each replay yields fresh draws from the
+            # pool. All TP ranks bump in lock-step → identical indices.
+            self._force_accept_rng_counter += 1
+
+            slot_ids = torch.arange(num_gens,
+                                    device=num_accepted_tokens.device,
+                                    dtype=torch.int64)
+            # Hash (counter, slot) → pool index. ``& (pool_size - 1)`` is a
+            # cheap power-of-two modulo. The two stride primes are coprime
+            # to ``pool_size`` so consecutive calls and consecutive slots
+            # land on decorrelated pool entries.
+            indices = (self._force_accept_rng_counter *
+                       _FORCE_ACCEPT_RNG_COUNTER_STRIDE +
+                       slot_ids * _FORCE_ACCEPT_RNG_SLOT_STRIDE) & (
+                           _FORCE_ACCEPT_RNG_POOL_SIZE - 1)
+            rand = self._force_accept_rng_pool[indices]
             extra = (rand < frac_part).to(num_accepted_tokens.dtype)
             # ``base_total + extra`` is at most ``int_part + 2``; clamp so we
             # never exceed the available draft slots.

--- a/tests/unittest/_torch/speculative/test_force_accepted_tokens.py
+++ b/tests/unittest/_torch/speculative/test_force_accepted_tokens.py
@@ -36,8 +36,11 @@ import pytest
 import torch
 
 from tensorrt_llm._torch.speculative.interface import (
-    FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR, SpecWorkerBase,
-    get_force_num_accepted_tokens, get_force_num_accepted_tokens_float)
+    FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR,
+    SpecWorkerBase,
+    get_force_num_accepted_tokens,
+    get_force_num_accepted_tokens_float,
+)
 
 
 class _StubSpecWorker(SpecWorkerBase):
@@ -72,28 +75,32 @@ def _require_cuda():
 # ---------------- env-var parsing helpers -----------------------------------
 
 
-@pytest.mark.parametrize("env_value, expected", [
-    ("0", 0.0),
-    ("3", 3.0),
-    ("2.6", 2.6),
-    ("0.5", 0.5),
-    ("not-a-number", 0.0),
-])
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        ("0", 0.0),
+        ("3", 3.0),
+        ("2.6", 2.6),
+        ("0.5", 0.5),
+        ("not-a-number", 0.0),
+    ],
+)
 def test_get_force_num_accepted_tokens_float(env_value, expected):
-    with patch.dict(os.environ,
-                    {FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR: env_value}):
+    with patch.dict(os.environ, {FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR: env_value}):
         assert get_force_num_accepted_tokens_float() == pytest.approx(expected)
 
 
-@pytest.mark.parametrize("env_value, expected", [
-    ("0", 0),
-    ("3", 3),
-    ("2.6", 0),
-])
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        ("0", 0),
+        ("3", 3),
+        ("2.6", 0),
+    ],
+)
 def test_get_force_num_accepted_tokens_int_unchanged(env_value, expected):
     """The int helper must keep its original behavior (used by 2-model)."""
-    with patch.dict(os.environ,
-                    {FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR: env_value}):
+    with patch.dict(os.environ, {FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR: env_value}):
         assert get_force_num_accepted_tokens() == expected
 
 
@@ -105,9 +112,7 @@ def test_zero_value_is_noop():
     worker = _make_worker(0.0)
     base = _make_input(batch_size=4)
     before = base.clone()
-    out = worker._apply_force_accepted_tokens(base,
-                                              num_contexts=0,
-                                              runtime_draft_len=4)
+    out = worker._apply_force_accepted_tokens(base, num_contexts=0, runtime_draft_len=4)
     assert torch.equal(out, before)
     # No RNG state should have been touched in the early-exit path.
     assert worker._force_accept_rng_pool is None
@@ -118,9 +123,9 @@ def test_zero_value_is_noop():
 def test_integer_value_matches_legacy_behavior(value):
     _require_cuda()
     worker = _make_worker(value)
-    out = worker._apply_force_accepted_tokens(_make_input(batch_size=8),
-                                              num_contexts=0,
-                                              runtime_draft_len=4)
+    out = worker._apply_force_accepted_tokens(
+        _make_input(batch_size=8), num_contexts=0, runtime_draft_len=4
+    )
     expected = min(int(value) + 1, 4 + 1)
     assert torch.all(out == expected)
     # Pure-integer path must not allocate the RNG pool.
@@ -130,9 +135,9 @@ def test_integer_value_matches_legacy_behavior(value):
 def test_integer_value_caps_at_runtime_draft_len_plus_one():
     _require_cuda()
     worker = _make_worker(10.0)
-    out = worker._apply_force_accepted_tokens(_make_input(batch_size=4),
-                                              num_contexts=0,
-                                              runtime_draft_len=2)
+    out = worker._apply_force_accepted_tokens(
+        _make_input(batch_size=4), num_contexts=0, runtime_draft_len=2
+    )
     # 10 draft tokens requested but only 2 available → all 3 (= 2 + target).
     assert torch.all(out == 3)
 
@@ -142,9 +147,9 @@ def test_fractional_only_emits_two_values():
     worker = _make_worker(2.6)
     seen = set()
     for _ in range(50):
-        out = worker._apply_force_accepted_tokens(_make_input(batch_size=64),
-                                                  num_contexts=0,
-                                                  runtime_draft_len=4)
+        out = worker._apply_force_accepted_tokens(
+            _make_input(batch_size=64), num_contexts=0, runtime_draft_len=4
+        )
         seen.update(out.unique().tolist())
     # Either 2 draft + target = 3, or 3 draft + target = 4.
     assert seen == {3, 4}
@@ -160,25 +165,26 @@ def test_fractional_distribution_matches_target_probability():
     extra_count = 0
     total = 0
     for _ in range(n_iters):
-        out = worker._apply_force_accepted_tokens(_make_input(batch_size=batch),
-                                                  num_contexts=0,
-                                                  runtime_draft_len=4)
+        out = worker._apply_force_accepted_tokens(
+            _make_input(batch_size=batch), num_contexts=0, runtime_draft_len=4
+        )
         extra_count += int((out == 4).sum().item())
         total += batch
     measured = extra_count / total
     # Pool-based RNG is deterministic; the empirical mean over ~13k draws
     # is tight against 0.6.
     assert abs(measured - target_frac) < 0.03, (
-        f"measured fraction {measured:.4f} differs from target {target_frac}")
+        f"measured fraction {measured:.4f} differs from target {target_frac}"
+    )
 
 
 def test_fractional_capped_when_no_room():
     """If ``int_part + 1`` already saturates the cap, no extra is granted."""
     _require_cuda()
     worker = _make_worker(9.5)
-    out = worker._apply_force_accepted_tokens(_make_input(batch_size=8),
-                                              num_contexts=0,
-                                              runtime_draft_len=2)
+    out = worker._apply_force_accepted_tokens(
+        _make_input(batch_size=8), num_contexts=0, runtime_draft_len=2
+    )
     # max_total = runtime_draft_len + 1 = 3, base_total = min(10, 3) = 3.
     # frac_part > 0 but ``base_total < max_total`` is False → all 3, no RNG.
     assert torch.all(out == 3)
@@ -194,9 +200,7 @@ def test_num_contexts_offset_is_respected():
     base = _make_input(batch_size=batch_size)
     sentinel = torch.iinfo(base.dtype).max
     base[:num_contexts] = sentinel
-    out = worker._apply_force_accepted_tokens(base,
-                                              num_contexts=num_contexts,
-                                              runtime_draft_len=4)
+    out = worker._apply_force_accepted_tokens(base, num_contexts=num_contexts, runtime_draft_len=4)
     assert torch.all(out[:num_contexts] == sentinel)
     assert torch.all((out[num_contexts:] == 3) | (out[num_contexts:] == 4))
 
@@ -216,12 +220,12 @@ def test_tp_determinism_across_independent_workers():
     # Use a non-power-of-two batch to make accidental shape coincidences
     # less likely to mask divergence.
     for _ in range(32):
-        out0 = rank0._apply_force_accepted_tokens(_make_input(batch_size=33),
-                                                  num_contexts=0,
-                                                  runtime_draft_len=4)
-        out1 = rank1._apply_force_accepted_tokens(_make_input(batch_size=33),
-                                                  num_contexts=0,
-                                                  runtime_draft_len=4)
+        out0 = rank0._apply_force_accepted_tokens(
+            _make_input(batch_size=33), num_contexts=0, runtime_draft_len=4
+        )
+        out1 = rank1._apply_force_accepted_tokens(
+            _make_input(batch_size=33), num_contexts=0, runtime_draft_len=4
+        )
         assert torch.equal(out0, out1)
 
 
@@ -244,13 +248,13 @@ def test_tp_determinism_survives_default_generator_drift():
         _ = torch.rand(128, device="cuda")
 
     _advance_default_generator(seed=11)
-    out0 = rank0._apply_force_accepted_tokens(_make_input(batch_size=33),
-                                              num_contexts=0,
-                                              runtime_draft_len=4)
+    out0 = rank0._apply_force_accepted_tokens(
+        _make_input(batch_size=33), num_contexts=0, runtime_draft_len=4
+    )
     _advance_default_generator(seed=999)
-    out1 = rank1._apply_force_accepted_tokens(_make_input(batch_size=33),
-                                              num_contexts=0,
-                                              runtime_draft_len=4)
+    out1 = rank1._apply_force_accepted_tokens(
+        _make_input(batch_size=33), num_contexts=0, runtime_draft_len=4
+    )
     assert torch.equal(out0, out1)
 
 
@@ -274,9 +278,8 @@ def test_cuda_graph_capture_and_replay_match_eager():
     eager_outputs = []
     for _ in range(n_iters):
         out = eager_worker._apply_force_accepted_tokens(
-            _make_input(batch_size=batch_size),
-            num_contexts=0,
-            runtime_draft_len=runtime_draft_len)
+            _make_input(batch_size=batch_size), num_contexts=0, runtime_draft_len=runtime_draft_len
+        )
         eager_outputs.append(out.clone())
 
     # 2) Captured-graph run, aligned to the eager reference.
@@ -284,9 +287,8 @@ def test_cuda_graph_capture_and_replay_match_eager():
     static_input = _make_input(batch_size=batch_size)
     # Eager warmup: forces lazy RNG state allocation OUTSIDE capture.
     graph_worker._apply_force_accepted_tokens(
-        static_input,
-        num_contexts=0,
-        runtime_draft_len=runtime_draft_len)
+        static_input, num_contexts=0, runtime_draft_len=runtime_draft_len
+    )
     # Realign the device-side counter so the captured graph's first replay
     # advances 0 → 1, matching the eager loop's first iteration.
     graph_worker._force_accept_rng_counter.zero_()
@@ -296,9 +298,8 @@ def test_cuda_graph_capture_and_replay_match_eager():
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         graph_worker._apply_force_accepted_tokens(
-            static_input,
-            num_contexts=0,
-            runtime_draft_len=runtime_draft_len)
+            static_input, num_contexts=0, runtime_draft_len=runtime_draft_len
+        )
         # ``_apply_force_accepted_tokens`` mutates ``static_input`` in place;
         # mirror it into ``static_output`` so we can snapshot per replay.
         static_output.copy_(static_input)
@@ -314,8 +315,8 @@ def test_cuda_graph_capture_and_replay_match_eager():
 
     for i, (eager, graphed) in enumerate(zip(eager_outputs, graph_outputs)):
         assert torch.equal(eager, graphed), (
-            f"Iteration {i}: eager={eager.tolist()} vs graphed="
-            f"{graphed.tolist()}")
+            f"Iteration {i}: eager={eager.tolist()} vs graphed={graphed.tolist()}"
+        )
 
 
 def test_cuda_graph_replay_advances_rng_state():
@@ -331,9 +332,9 @@ def test_cuda_graph_replay_advances_rng_state():
     runtime_draft_len = 4
 
     static_input = _make_input(batch_size=batch_size)
-    worker._apply_force_accepted_tokens(static_input,
-                                        num_contexts=0,
-                                        runtime_draft_len=runtime_draft_len)
+    worker._apply_force_accepted_tokens(
+        static_input, num_contexts=0, runtime_draft_len=runtime_draft_len
+    )
     worker._force_accept_rng_counter.zero_()
 
     static_input.fill_(1)
@@ -341,9 +342,8 @@ def test_cuda_graph_replay_advances_rng_state():
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         worker._apply_force_accepted_tokens(
-            static_input,
-            num_contexts=0,
-            runtime_draft_len=runtime_draft_len)
+            static_input, num_contexts=0, runtime_draft_len=runtime_draft_len
+        )
         static_output.copy_(static_input)
 
     snapshots = []
@@ -357,7 +357,8 @@ def test_cuda_graph_replay_advances_rng_state():
     # not advancing (the original bug-class).
     assert any(not torch.equal(snapshots[0], s) for s in snapshots[1:]), (
         "Captured graph produced identical outputs on every replay — "
-        "RNG counter is not advancing inside the captured graph.")
+        "RNG counter is not advancing inside the captured graph."
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/speculative/test_force_accepted_tokens.py
+++ b/tests/unittest/_torch/speculative/test_force_accepted_tokens.py
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the synthetic forced acceptance rate in 1-model spec dec.
+
+These tests exercise ``SpecWorkerBase._apply_force_accepted_tokens``, which
+honors the ``TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS`` environment
+variable. The implementation must be:
+
+  - Faithful to fractional rates: integer part always accepts, fractional
+    part acts as the per-iteration probability of accepting one extra draft
+    token.
+  - Tensor-parallel deterministic: identical seed/counter state across
+    ranks so all ranks agree on per-request accepted counts (otherwise
+    downstream collectives expecting matching shapes deadlock).
+  - CUDA-graph compatible: pure-tensor ops with statically-known shapes,
+    captureable and replayable.
+"""
+
+import os
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.speculative.interface import (
+    FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR, SpecWorkerBase,
+    get_force_num_accepted_tokens, get_force_num_accepted_tokens_float)
+
+
+class _StubSpecWorker(SpecWorkerBase):
+    """Concrete ``SpecWorkerBase`` that stubs out the only abstract API.
+
+    Used purely to drive ``_apply_force_accepted_tokens`` in isolation.
+    """
+
+    @property
+    def max_draft_len(self) -> int:
+        return 8
+
+
+def _make_worker(value: Optional[float] = None) -> _StubSpecWorker:
+    worker = _StubSpecWorker()
+    if value is not None:
+        worker.force_num_accepted_tokens = value
+    return worker
+
+
+def _make_input(batch_size: int, device: str = "cuda") -> torch.Tensor:
+    # Initial counts: 1 (target token, no draft accepts yet). The forced
+    # override only ever rewrites entries from ``num_contexts:`` onward.
+    return torch.ones(batch_size, dtype=torch.int32, device=device)
+
+
+def _require_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required for this test.")
+
+
+# ---------------- env-var parsing helpers -----------------------------------
+
+
+@pytest.mark.parametrize("env_value, expected", [
+    ("0", 0.0),
+    ("3", 3.0),
+    ("2.6", 2.6),
+    ("0.5", 0.5),
+    ("not-a-number", 0.0),
+])
+def test_get_force_num_accepted_tokens_float(env_value, expected):
+    with patch.dict(os.environ,
+                    {FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR: env_value}):
+        assert get_force_num_accepted_tokens_float() == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("env_value, expected", [
+    ("0", 0),
+    ("3", 3),
+    ("2.6", 0),
+])
+def test_get_force_num_accepted_tokens_int_unchanged(env_value, expected):
+    """The int helper must keep its original behavior (used by 2-model)."""
+    with patch.dict(os.environ,
+                    {FORCE_NUM_ACCEPTED_TOKENS_ENV_VAR: env_value}):
+        assert get_force_num_accepted_tokens() == expected
+
+
+# ---------------- _apply_force_accepted_tokens semantics --------------------
+
+
+def test_zero_value_is_noop():
+    _require_cuda()
+    worker = _make_worker(0.0)
+    base = _make_input(batch_size=4)
+    before = base.clone()
+    out = worker._apply_force_accepted_tokens(base,
+                                              num_contexts=0,
+                                              runtime_draft_len=4)
+    assert torch.equal(out, before)
+    # No RNG state should have been touched in the early-exit path.
+    assert worker._force_accept_rng_pool is None
+    assert worker._force_accept_rng_counter is None
+
+
+@pytest.mark.parametrize("value", [1.0, 2.0, 4.0])
+def test_integer_value_matches_legacy_behavior(value):
+    _require_cuda()
+    worker = _make_worker(value)
+    out = worker._apply_force_accepted_tokens(_make_input(batch_size=8),
+                                              num_contexts=0,
+                                              runtime_draft_len=4)
+    expected = min(int(value) + 1, 4 + 1)
+    assert torch.all(out == expected)
+    # Pure-integer path must not allocate the RNG pool.
+    assert worker._force_accept_rng_pool is None
+
+
+def test_integer_value_caps_at_runtime_draft_len_plus_one():
+    _require_cuda()
+    worker = _make_worker(10.0)
+    out = worker._apply_force_accepted_tokens(_make_input(batch_size=4),
+                                              num_contexts=0,
+                                              runtime_draft_len=2)
+    # 10 draft tokens requested but only 2 available → all 3 (= 2 + target).
+    assert torch.all(out == 3)
+
+
+def test_fractional_only_emits_two_values():
+    _require_cuda()
+    worker = _make_worker(2.6)
+    seen = set()
+    for _ in range(50):
+        out = worker._apply_force_accepted_tokens(_make_input(batch_size=64),
+                                                  num_contexts=0,
+                                                  runtime_draft_len=4)
+        seen.update(out.unique().tolist())
+    # Either 2 draft + target = 3, or 3 draft + target = 4.
+    assert seen == {3, 4}
+
+
+def test_fractional_distribution_matches_target_probability():
+    """Average over many draws should converge to the target fraction."""
+    _require_cuda()
+    worker = _make_worker(2.6)
+    target_frac = 0.6
+    n_iters = 200
+    batch = 64
+    extra_count = 0
+    total = 0
+    for _ in range(n_iters):
+        out = worker._apply_force_accepted_tokens(_make_input(batch_size=batch),
+                                                  num_contexts=0,
+                                                  runtime_draft_len=4)
+        extra_count += int((out == 4).sum().item())
+        total += batch
+    measured = extra_count / total
+    # Pool-based RNG is deterministic; the empirical mean over ~13k draws
+    # is tight against 0.6.
+    assert abs(measured - target_frac) < 0.03, (
+        f"measured fraction {measured:.4f} differs from target {target_frac}")
+
+
+def test_fractional_capped_when_no_room():
+    """If ``int_part + 1`` already saturates the cap, no extra is granted."""
+    _require_cuda()
+    worker = _make_worker(9.5)
+    out = worker._apply_force_accepted_tokens(_make_input(batch_size=8),
+                                              num_contexts=0,
+                                              runtime_draft_len=2)
+    # max_total = runtime_draft_len + 1 = 3, base_total = min(10, 3) = 3.
+    # frac_part > 0 but ``base_total < max_total`` is False → all 3, no RNG.
+    assert torch.all(out == 3)
+    assert worker._force_accept_rng_pool is None
+
+
+def test_num_contexts_offset_is_respected():
+    """Context (prefill) rows must be left untouched by the override."""
+    _require_cuda()
+    worker = _make_worker(2.6)
+    batch_size = 8
+    num_contexts = 3
+    base = _make_input(batch_size=batch_size)
+    sentinel = torch.iinfo(base.dtype).max
+    base[:num_contexts] = sentinel
+    out = worker._apply_force_accepted_tokens(base,
+                                              num_contexts=num_contexts,
+                                              runtime_draft_len=4)
+    assert torch.all(out[:num_contexts] == sentinel)
+    assert torch.all((out[num_contexts:] == 3) | (out[num_contexts:] == 4))
+
+
+# ---------------- TP determinism --------------------------------------------
+
+
+def test_tp_determinism_across_independent_workers():
+    """
+    Two independently-instantiated workers (simulating two TP ranks) must
+    produce bit-identical accepted-token counts when fed the same call
+    sequence. This is the property whose absence used to hang TP>1.
+    """
+    _require_cuda()
+    rank0 = _make_worker(2.6)
+    rank1 = _make_worker(2.6)
+    # Use a non-power-of-two batch to make accidental shape coincidences
+    # less likely to mask divergence.
+    for _ in range(32):
+        out0 = rank0._apply_force_accepted_tokens(_make_input(batch_size=33),
+                                                  num_contexts=0,
+                                                  runtime_draft_len=4)
+        out1 = rank1._apply_force_accepted_tokens(_make_input(batch_size=33),
+                                                  num_contexts=0,
+                                                  runtime_draft_len=4)
+        assert torch.equal(out0, out1)
+
+
+def test_tp_determinism_survives_default_generator_drift():
+    """
+    Even if the default CUDA generator state diverges between ranks (e.g.
+    because some other component consumed random numbers), the synthetic
+    AR draws must still match. This is the regression guard for the
+    original bug, where ``torch.rand`` against the default generator gave
+    each rank a different sequence.
+    """
+    _require_cuda()
+    rank0 = _make_worker(2.6)
+    rank1 = _make_worker(2.6)
+
+    def _advance_default_generator(seed: int):
+        # Seed the default CUDA generator on the same device differently
+        # for each "rank" and consume some randoms, simulating drift.
+        torch.cuda.manual_seed(seed)
+        _ = torch.rand(128, device="cuda")
+
+    _advance_default_generator(seed=11)
+    out0 = rank0._apply_force_accepted_tokens(_make_input(batch_size=33),
+                                              num_contexts=0,
+                                              runtime_draft_len=4)
+    _advance_default_generator(seed=999)
+    out1 = rank1._apply_force_accepted_tokens(_make_input(batch_size=33),
+                                              num_contexts=0,
+                                              runtime_draft_len=4)
+    assert torch.equal(out0, out1)
+
+
+# ---------------- CUDA graph capture/replay ---------------------------------
+
+
+def test_cuda_graph_capture_and_replay_match_eager():
+    """
+    Capturing the override into a CUDA graph and replaying it must produce
+    the exact same per-replay output sequence as running it eagerly.
+    """
+    _require_cuda()
+
+    n_iters = 8
+    batch_size = 16
+    runtime_draft_len = 4
+    value = 2.6
+
+    # 1) Eager reference.
+    eager_worker = _make_worker(value)
+    eager_outputs = []
+    for _ in range(n_iters):
+        out = eager_worker._apply_force_accepted_tokens(
+            _make_input(batch_size=batch_size),
+            num_contexts=0,
+            runtime_draft_len=runtime_draft_len)
+        eager_outputs.append(out.clone())
+
+    # 2) Captured-graph run, aligned to the eager reference.
+    graph_worker = _make_worker(value)
+    static_input = _make_input(batch_size=batch_size)
+    # Eager warmup: forces lazy RNG state allocation OUTSIDE capture.
+    graph_worker._apply_force_accepted_tokens(
+        static_input,
+        num_contexts=0,
+        runtime_draft_len=runtime_draft_len)
+    # Realign the device-side counter so the captured graph's first replay
+    # advances 0 → 1, matching the eager loop's first iteration.
+    graph_worker._force_accept_rng_counter.zero_()
+
+    static_input.fill_(1)
+    static_output = torch.empty_like(static_input)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_worker._apply_force_accepted_tokens(
+            static_input,
+            num_contexts=0,
+            runtime_draft_len=runtime_draft_len)
+        # ``_apply_force_accepted_tokens`` mutates ``static_input`` in place;
+        # mirror it into ``static_output`` so we can snapshot per replay.
+        static_output.copy_(static_input)
+
+    graph_outputs = []
+    for _ in range(n_iters):
+        # Reset input each replay so the override semantics match eager
+        # (which also starts from all-1s every iteration).
+        static_input.fill_(1)
+        graph.replay()
+        torch.cuda.synchronize()
+        graph_outputs.append(static_output.clone())
+
+    for i, (eager, graphed) in enumerate(zip(eager_outputs, graph_outputs)):
+        assert torch.equal(eager, graphed), (
+            f"Iteration {i}: eager={eager.tolist()} vs graphed="
+            f"{graphed.tolist()}")
+
+
+def test_cuda_graph_replay_advances_rng_state():
+    """
+    Across replays, the captured counter must advance, producing different
+    (but deterministic) draws. A constant output across replays would mean
+    the counter increment was not captured.
+    """
+    _require_cuda()
+
+    worker = _make_worker(0.5)
+    batch_size = 64
+    runtime_draft_len = 4
+
+    static_input = _make_input(batch_size=batch_size)
+    worker._apply_force_accepted_tokens(static_input,
+                                        num_contexts=0,
+                                        runtime_draft_len=runtime_draft_len)
+    worker._force_accept_rng_counter.zero_()
+
+    static_input.fill_(1)
+    static_output = torch.empty_like(static_input)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        worker._apply_force_accepted_tokens(
+            static_input,
+            num_contexts=0,
+            runtime_draft_len=runtime_draft_len)
+        static_output.copy_(static_input)
+
+    snapshots = []
+    for _ in range(8):
+        static_input.fill_(1)
+        graph.replay()
+        torch.cuda.synchronize()
+        snapshots.append(static_output.clone())
+
+    # At least two replays must differ; otherwise the captured counter is
+    # not advancing (the original bug-class).
+    assert any(not torch.equal(snapshots[0], s) for s in snapshots[1:]), (
+        "Captured graph produced identical outputs on every replay — "
+        "RNG counter is not advancing inside the captured graph.")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

<!--
Please explain the issue and the solution in short.
-->

Support fractional synthetic ARs. This is useful for perf debug. It can also be used for benchmarks that use random inputs (since ARs are not meaningfully high with random inputs usually).

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
Added new test.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Speculative decoding now supports fractional acceptance rates for generated tokens using deterministic selection logic.

* **Tests**
  * Added comprehensive test coverage for fractional token acceptance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->