### PR TITLE
[TRTLLM-12128][feat] enable SageAttention for Wan/FLUX (new commits)

### DIFF
--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -653,8 +653,8 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
 
     bool const use_sage_attn
         = sage_attn_num_elts_per_blk_q > 0 || sage_attn_num_elts_per_blk_k > 0 || sage_attn_num_elts_per_blk_v > 0;
-    TLLM_CHECK_WITH_INFO(
-        is_mla_enable || is_fused_qkv || use_sage_attn, "Only fused QKV is supported for non-MLA attention now");
+    TLLM_CHECK_WITH_INFO(is_mla_enable || is_fused_qkv || use_sage_attn,
+        "Context attention only allows these non-MLA cases: fused QKV; separate QKV with SageAttention");
     TLLM_CHECK_WITH_INFO(update_kv_cache, "KV cache update cannot be disabled now");
     auto qkv_or_q = q;
     if (is_fused_qkv)
@@ -666,6 +666,13 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
     {
         TLLM_CHECK_WITH_INFO(k.has_value(), "The k tensor should be provided if updating KV cache with unfused K/V");
         TLLM_CHECK_WITH_INFO(v.has_value(), "The v tensor should be provided if updating KV cache with unfused K/V");
+    }
+    if (use_sage_attn)
+    {
+        TLLM_CHECK_WITH_INFO(
+            !is_fused_qkv, "SageAttention requires separate q/k/v tensors (is_fused_qkv must be false).");
+        TLLM_CHECK_WITH_INFO(k.has_value(), "SageAttention requires k tensor to be provided.");
+        TLLM_CHECK_WITH_INFO(v.has_value(), "SageAttention requires v tensor to be provided.");
     }
 
     auto const dtype = tensorrt_llm::runtime::TorchUtils::dataType(qkv_or_q.scalar_type());

--- a/examples/visual_gen/README.md
+++ b/examples/visual_gen/README.md
@@ -88,6 +88,17 @@ python visual_gen_wan_t2v.py \
     --output_path output.mp4
 ```
 
+**With SageAttention (FP8/INT8 per-block quantized attention):**
+```bash
+python visual_gen_wan_t2v.py \
+    --model_path ${MODEL_ROOT}/Wan2.1-T2V-1.3B-Diffusers \
+    --prompt "A cute cat playing piano" \
+    --height 480 --width 832 --num_frames 33 \
+    --attention_backend TRTLLM \
+    --enable_sage_attention \
+    --output_path output.mp4
+```
+
 **With TeaCache:**
 ```bash
 python visual_gen_wan_t2v.py \
@@ -275,6 +286,7 @@ python visual_gen_ltx2.py \
 | `--enable_teacache` | ✓ | ✓ | — | False | Cache optimization |
 | `--teacache_thresh` | ✓ | ✓ | — | 0.2 | TeaCache similarity threshold |
 | `--attention_backend` | ✓ | ✓ | — | VANILLA | `VANILLA`, `TRTLLM`, or `FA4` |
+| `--enable_sage_attention` | ✓ | ✓ | — | False | SageAttention (requires `TRTLLM` attention backend) |
 | `--cfg_size` | — | ✓ | — | 1 | CFG parallelism |
 | `--ulysses_size` | ✓ | ✓ | — | 1 | Ulysses parallelism |
 | `--attn2d_row_size` | ✓ | ✓ | ✓ | 1 | Attention2D mesh row size |

--- a/examples/visual_gen/visual_gen_flux.py
+++ b/examples/visual_gen/visual_gen_flux.py
@@ -215,6 +215,11 @@ def parse_args():
         "FA4: Flash Attention 4). "
         "Note: TRTLLM falls back to VANILLA for cross-attention.",
     )
+    parser.add_argument(
+        "--enable_sage_attention",
+        action="store_true",
+        help="Enable SageAttention (per-block quantized Q/K/V). Requires TRTLLM backend.",
+    )
 
     # Parallelism
     parser.add_argument(
@@ -337,9 +342,19 @@ def build_diffusion_args(args) -> VisualGenArgs:
     else:
         cache_kwargs = {}
 
+    attention_cfg: dict = {"backend": args.attention_backend}
+    if args.enable_sage_attention:
+        attention_cfg["sage_attention_config"] = {
+            "num_elts_per_blk_q": 1,
+            "num_elts_per_blk_k": 16,
+            "num_elts_per_blk_v": 1,
+            "qk_int8": True,
+        }
+        logger.info("SageAttention: INT8 Q/K, blocks (1, 16, 1)")
+
     kwargs = dict(
         revision=args.revision,
-        attention={"backend": args.attention_backend},
+        attention=attention_cfg,
         **cache_kwargs,
         parallel={
             "dit_ulysses_size": args.ulysses_size,

--- a/examples/visual_gen/visual_gen_ltx2.py
+++ b/examples/visual_gen/visual_gen_ltx2.py
@@ -295,7 +295,6 @@ def parse_args():
         help="Attention backend (VANILLA: PyTorch SDPA, TRTLLM: optimized kernels). "
         "Note: TRTLLM automatically falls back to VANILLA for cross-attention.",
     )
-
     return parser.parse_args()
 
 
@@ -339,10 +338,12 @@ def _build_diffusion_args(args) -> VisualGenArgs:
     else:
         cache_kwargs = {}
 
+    attention_cfg: dict = {"backend": args.attention_backend}
+
     kwargs = dict(
         text_encoder_path=args.text_encoder_path,
         **cache_kwargs,
-        attention={"backend": args.attention_backend},
+        attention=attention_cfg,
         parallel={
             "dit_cfg_size": args.cfg_size,
             "dit_ulysses_size": args.ulysses_size,

--- a/examples/visual_gen/visual_gen_wan_i2v.py
+++ b/examples/visual_gen/visual_gen_wan_i2v.py
@@ -198,6 +198,17 @@ def parse_args():
         "Note: TRTLLM falls back to VANILLA for cross-attention.",
     )
 
+    # SageAttention (requires --attention_backend TRTLLM)
+    parser.add_argument(
+        "--enable_sage_attention",
+        action="store_true",
+        help=(
+            "Enable SageAttention (per-block quantized Q/K/V). Requires TRTLLM backend. "
+            "Block layout is chosen from --model_path: (1, 4, 1) for Wan2.1, "
+            "(1, 16, 1) otherwise."
+        ),
+    )
+
     # Parallelism
     parser.add_argument(
         "--cfg_size",
@@ -300,8 +311,29 @@ def _cache_dit_config_from_args(args) -> CacheDiTConfig:
     return CacheDiTConfig(**overrides)
 
 
+def _wan_needs_fine_grained_sage(model_path: str) -> bool:
+    """Hard-coded heuristics for determining if a WAN model needs finer-grained SageAttentionConfig."""
+    lower = model_path.lower().replace(".", "_").replace("-", "_")
+    # For I2V, Wan2.1 14B is also observed to require higher granularity
+    return "_1_3b" in lower or "wan2_1_i" in lower
+
+
 def main():
     args = parse_args()
+
+    attention_cfg = {
+        "backend": args.attention_backend,
+    }
+    if args.enable_sage_attention:
+        num_elts_per_blk_k = 4 if _wan_needs_fine_grained_sage(args.model_path) else 16
+        sage_cfg = {
+            "num_elts_per_blk_q": 1,
+            "num_elts_per_blk_k": num_elts_per_blk_k,
+            "num_elts_per_blk_v": 1,
+            "qk_int8": True,
+        }
+        attention_cfg["sage_attention_config"] = sage_cfg
+        logger.info(f"SageAttention: INT8 Q/K, blocks (1, {num_elts_per_blk_k}, 1)")
 
     if args.enable_cache_dit:
         cache_kwargs = {"cache": _cache_dit_config_from_args(args)}
@@ -327,7 +359,7 @@ def main():
         parallel_str = "None"
 
     kwargs = dict(
-        attention={"backend": args.attention_backend},
+        attention=attention_cfg,
         **cache_kwargs,
         parallel={
             "dit_cfg_size": args.cfg_size,

--- a/examples/visual_gen/visual_gen_wan_t2v.py
+++ b/examples/visual_gen/visual_gen_wan_t2v.py
@@ -192,6 +192,17 @@ def parse_args():
         "Note: TRTLLM falls back to VANILLA for cross-attention.",
     )
 
+    # SageAttention (requires --attention_backend TRTLLM)
+    parser.add_argument(
+        "--enable_sage_attention",
+        action="store_true",
+        help=(
+            "Enable SageAttention (per-block quantized Q/K/V). Requires TRTLLM backend. "
+            "Block layout is chosen from --model_path: (1, 4, 1) for Wan2.x 1.3B, "
+            "(1, 16, 1) otherwise."
+        ),
+    )
+
     # Parallelism
     parser.add_argument(
         "--cfg_size",
@@ -299,6 +310,12 @@ def _cache_dit_config_from_args(args) -> CacheDiTConfig:
     return CacheDiTConfig(**overrides)
 
 
+def _wan_needs_fine_grained_sage(model_path: str) -> bool:
+    """Hard-coded heuristics for determining if a WAN model needs finer-grained SageAttentionConfig."""
+    lower = model_path.lower().replace(".", "_").replace("-", "_")
+    return "_1_3b" in lower
+
+
 def main():
     args = parse_args()
 
@@ -318,6 +335,20 @@ def main():
     else:
         parallel_str = "None"
 
+    attention_cfg = {
+        "backend": args.attention_backend,
+    }
+    if args.enable_sage_attention:
+        num_elts_per_blk_k = 4 if _wan_needs_fine_grained_sage(args.model_path) else 16
+        sage_cfg = {
+            "num_elts_per_blk_q": 1,
+            "num_elts_per_blk_k": num_elts_per_blk_k,
+            "num_elts_per_blk_v": 1,
+            "qk_int8": True,
+        }
+        attention_cfg["sage_attention_config"] = sage_cfg
+        logger.info(f"SageAttention: INT8 Q/K, blocks (1, {num_elts_per_blk_k}, 1)")
+
     if args.enable_cache_dit:
         cache_kwargs = {"cache": _cache_dit_config_from_args(args)}
     elif args.enable_teacache:
@@ -327,7 +358,7 @@ def main():
 
     kwargs = dict(
         revision=args.revision,
-        attention={"backend": args.attention_backend},
+        attention=attention_cfg,
         **cache_kwargs,
         parallel={
             "dit_cfg_size": args.cfg_size,

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1337,7 +1337,10 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                                  metadata.max_num_tokens)
 
         helix_active = metadata.helix_position_offsets is not None
-        if _TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION and not helix_active and trtllm_gen.is_supported(
+        use_sage_attn = (forward_args.sage_attn_num_elts_per_blk_q > 0
+                         or forward_args.sage_attn_num_elts_per_blk_k > 0
+                         or forward_args.sage_attn_num_elts_per_blk_v > 0)
+        if _TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION and not helix_active and not use_sage_attn and trtllm_gen.is_supported(
                 q=q,
                 num_heads=self.num_heads,
                 num_kv_heads=self.num_kv_heads,

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
@@ -116,6 +116,7 @@ class UlyssesAttention(AttentionBackend):
 
         # Caller passed pre-A2A (sharded) seq_len; the inner backend
         # reshapes by it, so hand it the post-A2A length instead.
+        kwargs["batch_size"] = batch_size
         kwargs["seq_len"] = seq_len
         kwargs["seq_len_kv"] = seq_len
 
@@ -146,6 +147,7 @@ class UlyssesAttention(AttentionBackend):
 
         # Caller passed pre-A2A (sharded) seq_lens; hand the inner
         # backend the post-A2A lengths instead.
+        kwargs["batch_size"] = batch_size
         kwargs["seq_len"] = seq_len_full
         kwargs["seq_len_kv"] = kv_seq_len_full
 

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/trtllm.py
@@ -29,6 +29,7 @@ from tensorrt_llm.models.modeling_utils import QuantConfig
 from ...attention_backend.interface import AttentionRuntimeFeatures, PredefinedAttentionMask
 from ...attention_backend.trtllm import TrtllmAttention as BaseTrtllmAttention
 from ...attention_backend.trtllm import TrtllmAttentionMetadata as BaseTrtllmAttentionMetadata
+from ..config import SageAttentionConfig
 from .interface import AttentionBackend, AttentionTensorLayout
 
 
@@ -103,7 +104,6 @@ class TrtllmAttentionMetadata:
         prev_batch, prev_seq = self._metadata_state["capacity"]
         alloc_batch = max(batch_size, prev_batch)
         alloc_seq_len = max(max_seq_len, prev_seq)
-
         self._metadata = BaseTrtllmAttentionMetadata(
             max_num_requests=alloc_batch,
             max_num_tokens=alloc_batch * alloc_seq_len,
@@ -112,7 +112,6 @@ class TrtllmAttentionMetadata:
             mapping=Mapping(),
             runtime_features=AttentionRuntimeFeatures(),
         )
-
         self._metadata_state["metadata"] = self._metadata
         self._metadata_state["capacity"] = (alloc_batch, alloc_seq_len)
         self._prepared = False  # Reset prepare state on new metadata
@@ -133,7 +132,6 @@ class TrtllmAttentionMetadata:
             seq_lens_tensor = torch.full((batch_size,), seq_lens, dtype=torch.int32)
         else:
             seq_lens_tensor = seq_lens.to(dtype=torch.int32)
-
         max_seq_len = seq_lens_tensor.max().item()
 
         if self._needs_new_metadata(batch_size, max_seq_len):
@@ -163,10 +161,10 @@ class TrtllmAttention(BaseTrtllmAttention, AttentionBackend):
     TRTLLM Attention wrapper for diffusion models.
 
     Handles:
-    - Fused QKV requirement for TRTLLM kernel
+    - Fused QKV requirement for TRTLLM kernel (when sage params are not provided)
     - Metadata creation and preparation
     - No KV cache operation
-    - SageAttention per-block Q/K/V quantization (when sage params are provided)
+    - SageAttention per-block QKV quantization (when sage params are provided. requires unfused QKV)
     """
 
     def __init__(
@@ -179,11 +177,8 @@ class TrtllmAttention(BaseTrtllmAttention, AttentionBackend):
         dtype: Optional[torch.dtype] = None,
         max_batch_size: int = 16,
         max_seq_len: int = 4096,
+        sage_attention_config: Optional[SageAttentionConfig] = None,
         attention_metadata_state: Optional[dict] = None,
-        sage_attn_num_elts_per_blk_q: int = 0,
-        sage_attn_num_elts_per_blk_k: int = 0,
-        sage_attn_num_elts_per_blk_v: int = 0,
-        sage_attn_qk_int8: bool = False,
     ):
         num_kv_heads = num_kv_heads or num_heads
 
@@ -196,16 +191,6 @@ class TrtllmAttention(BaseTrtllmAttention, AttentionBackend):
             dtype=dtype,
         )
 
-        self.sage_attn_num_elts_per_blk_q = sage_attn_num_elts_per_blk_q
-        self.sage_attn_num_elts_per_blk_k = sage_attn_num_elts_per_blk_k
-        self.sage_attn_num_elts_per_blk_v = sage_attn_num_elts_per_blk_v
-        self.sage_attn_qk_int8 = sage_attn_qk_int8
-        self._use_sage_attn = (
-            sage_attn_num_elts_per_blk_q > 0
-            or sage_attn_num_elts_per_blk_k > 0
-            or sage_attn_num_elts_per_blk_v > 0
-        )
-
         # TRTLLM expects flat [B*S, H*D] format
         self._preferred_layout = AttentionTensorLayout.NHD
 
@@ -214,6 +199,9 @@ class TrtllmAttention(BaseTrtllmAttention, AttentionBackend):
             max_seq_len=max_seq_len,
             attention_metadata_state=attention_metadata_state,
         )
+
+        # SageAttention: presence of config object implies enablement
+        self.sage_attention_config = sage_attention_config
 
     # Needed to work with torch compile cause of attention metadata
     # make attn metadata as input for it to work
@@ -241,10 +229,12 @@ class TrtllmAttention(BaseTrtllmAttention, AttentionBackend):
     def forward(
         self,
         q: torch.Tensor,
-        k: Optional[torch.Tensor] = None,
-        v: Optional[torch.Tensor] = None,
-        *,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        batch_size: int,
+        seq_len: int,
         attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.FULL,
+        seq_len_kv: Optional[int] = None,
         **kwargs,
     ) -> torch.Tensor:
         """
@@ -253,45 +243,45 @@ class TrtllmAttention(BaseTrtllmAttention, AttentionBackend):
         Dimensions are derived from tensor shapes (NHD layout: ``[B, S, H, D]``).
 
         For diffusion models, expects:
-        - Fused QKV: q contains [Q, K, V] stacked, k and v are None
-        - OR separate Q, K, V which will be fused internally
-        - When SageAttention is enabled (sage_attn_num_elts_per_blk_* set at init),
-          separate Q, K, V must be provided and will be passed as-is (not fused).
+        - Fused QKV: q contains [Q, K, V] concatenated, k and v are None
+            - does not support SageAttention
+        - OR separate Q, K, V which:
+            - for regular TRTLLM attention, will be fused internally
+            - for SageAttention, will be used directly
 
         Args:
-            q: Fused QKV [B, S, 3, H, D] or Query [B, S, H, D]
+            q: Query tensor [B, S, H, D] or fused QKV [B, S, H_qkv, D]
             k: Key tensor [B, S_kv, H_kv, D] or None if fused
             v: Value tensor [B, S_kv, H_kv, D] or None if fused
+            batch_size: Batch size
+            seq_len: Sequence length for Q
             attention_mask: Attention mask type
+            seq_len_kv: Sequence length for K/V (for cross-attention, defaults to seq_len)
 
         Returns:
             Output tensor [B, S, H*D]
         """
-        batch_size = q.shape[0]
-        seq_len = q.shape[1]
-        kv_seq_len = k.shape[1] if k is not None else seq_len
-
+        kv_seq_len = seq_len_kv if seq_len_kv is not None else seq_len
         prepared_metadata = self._prepare_metadata(batch_size, seq_len)
 
-        if self._use_sage_attn:
-            # SageAttention: pass separate Q, K, V (not fused) so the C++ kernel
-            # can quantize them independently per-block.
+        if self.sage_attention_config is not None:
             assert k is not None and v is not None, (
                 "SageAttention requires separate Q, K, V tensors"
             )
-            q_flat = q.reshape(batch_size * seq_len, -1)
-            k_flat = k.reshape(batch_size * kv_seq_len, -1)
-            v_flat = v.reshape(batch_size * kv_seq_len, -1)
+            sage_cfg = self.sage_attention_config
+            q = q.reshape(batch_size * seq_len, -1).contiguous()
+            k = k.reshape(batch_size * kv_seq_len, -1).contiguous()
+            v = v.reshape(batch_size * kv_seq_len, -1).contiguous()
             output = super().forward(
-                q=q_flat,
-                k=k_flat,
-                v=v_flat,
+                q=q,
+                k=k,
+                v=v,
                 metadata=prepared_metadata,
                 attention_mask=attention_mask,
-                sage_attn_num_elts_per_blk_q=self.sage_attn_num_elts_per_blk_q,
-                sage_attn_num_elts_per_blk_k=self.sage_attn_num_elts_per_blk_k,
-                sage_attn_num_elts_per_blk_v=self.sage_attn_num_elts_per_blk_v,
-                sage_attn_qk_int8=self.sage_attn_qk_int8,
+                sage_attn_num_elts_per_blk_q=sage_cfg.num_elts_per_blk_q,
+                sage_attn_num_elts_per_blk_k=sage_cfg.num_elts_per_blk_k,
+                sage_attn_num_elts_per_blk_v=sage_cfg.num_elts_per_blk_v,
+                sage_attn_qk_int8=sage_cfg.qk_int8,
             )
         else:
             if k is None and v is None:
@@ -314,4 +304,5 @@ class TrtllmAttention(BaseTrtllmAttention, AttentionBackend):
         return self._preferred_layout
 
     def support_fused_qkv(self) -> bool:
-        return not self._use_sage_attn
+        """Standard path fuses QKV; SageAttention path does not."""
+        return self.sage_attention_config is None

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -100,7 +100,8 @@ def create_attention(
             will automatically reallocate if larger batches are encountered.
         max_seq_len: Initial sequence length for metadata pre-allocation. The backend
             will automatically reallocate if longer sequences are encountered.
-        attention_config: Optional AttentionConfig
+        attention_config: Optional AttentionConfig; sage_attention_config is
+            extracted and forwarded to the TRTLLM backend when present.
         attention_metadata_state: Optional model-scoped metadata state from
             visual-gen config. Required for TRTLLM backend.
         **kwargs: Additional backend-specific arguments
@@ -110,6 +111,11 @@ def create_attention(
     """
     attn_cls = get_visual_gen_attention_backend(backend)
 
+    # Extract sage_attention_config from AttentionConfig and pass to TRTLLM backend.
+    # AttentionConfig validation disables unsupported SageAttention configs by
+    # normalizing sage_attention_config to None.
+    if attention_config is not None and attention_config.sage_attention_config is not None:
+        kwargs["sage_attention_config"] = attention_config.sage_attention_config
     if backend.upper() == "TRTLLM":
         if attention_metadata_state is None:
             raise ValueError(

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import json
 from enum import Enum
 from pathlib import Path
@@ -51,12 +65,81 @@ class PipelineComponent(str, Enum):
 # =============================================================================
 
 
+class SageAttentionConfig(StrictBaseModel):
+    """Configuration for SageAttention quantization (TRTLLM backend only).
+
+    SageAttention quantizes Q/K/V into FP8 (or INT8 for Q/K) with per-block
+    scaling factors, enabling faster attention kernels. Providing this config
+    to AttentionConfig enables SageAttention; omitting it (None) disables it.
+
+    Similar to ``sparse_attention_config`` for the base TRTLLM attention
+    backend — the presence of the config object signals enablement.
+
+    Currently these (num_elts_per_blk_q, num_elts_per_blk_k, num_elts_per_blk_v)
+    combinations are enabled:
+    - (1, 1, 1)
+    - (1, 4, 1)
+    - (1, 16, 1) [for qk_int8 == True only]
+    """
+
+    num_elts_per_blk_q: int = PydanticField(
+        1, ge=0, description="Elements per quantization block for Q (0 disables)"
+    )
+    num_elts_per_blk_k: int = PydanticField(
+        4, ge=0, description="Elements per quantization block for K (0 disables)"
+    )
+    num_elts_per_blk_v: int = PydanticField(
+        1, ge=0, description="Elements per quantization block for V (0 disables)"
+    )
+    qk_int8: bool = PydanticField(True, description="Use INT8 (vs E4M3) for Q/K quantization")
+
+
 class AttentionConfig(StrictBaseModel):
     """Configuration for Attention layers."""
 
     backend: Literal["VANILLA", "TRTLLM", "FA4"] = PydanticField(
         "VANILLA", description="Attention backend: VANILLA (PyTorch SDPA), TRTLLM, FA4"
     )
+    sage_attention_config: Optional[SageAttentionConfig] = PydanticField(
+        None,
+        description=(
+            "SageAttention config (TRTLLM backend only). "
+            "Set to a SageAttentionConfig instance to enable SageAttention; "
+            "leave as None to disable."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_sage_attn_config(self) -> "AttentionConfig":
+        SUPPORTED_SAGE_CONFIGS = {
+            (1, 1, 1, False),
+            (1, 4, 1, False),
+            (1, 1, 1, True),
+            (1, 4, 1, True),
+            (1, 16, 1, True),
+        }
+
+        if self.sage_attention_config is not None:
+            if self.backend != "TRTLLM":
+                logger.critical(
+                    f"sage_attention_config requires backend='TRTLLM', "
+                    f"got backend='{self.backend}'. Either set backend='TRTLLM' "
+                    f"or remove sage_attention_config. Disabling SageAttention."
+                )
+                self.sage_attention_config = None
+                return self
+
+            if (
+                self.sage_attention_config.num_elts_per_blk_q,
+                self.sage_attention_config.num_elts_per_blk_k,
+                self.sage_attention_config.num_elts_per_blk_v,
+                self.sage_attention_config.qk_int8,
+            ) not in SUPPORTED_SAGE_CONFIGS:
+                logger.critical(
+                    f"Unsupported {self.sage_attention_config=}. Disabling SageAttention."
+                )
+                self.sage_attention_config = None
+        return self
 
 
 class ParallelConfig(StrictBaseModel):

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -586,6 +586,10 @@ class LTX2Pipeline(BasePipeline):
         the reference ``LTXModelConfigurator.from_config()``.  Missing keys
         fall back to the same defaults the reference uses.
         """
+        attn_cfg = getattr(self.model_config, "attention", None)
+        if attn_cfg is not None and getattr(attn_cfg, "sage_attention_config", None) is not None:
+            raise NotImplementedError("SageAttention is not yet supported for the LTX-2 pipeline.")
+
         cfg = self.model_config.pretrained_config
 
         rope_type = LTXRopeType(getattr(cfg, "rope_type", "interleaved"))

--- a/tensorrt_llm/_torch/visual_gen/modules/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/attention.py
@@ -312,6 +312,8 @@ class Attention(nn.Module):
         backend_layout = getattr(self.attn, "preferred_layout", AttentionTensorLayout.NHD)
 
         batch_size = q.shape[0]
+        seq_len = q.shape[1]
+        seq_len_kv = k.shape[1] if k is not None else seq_len
 
         # Reshape inputs: [B, S, H*D] -> backend's preferred 4D layout
         if backend_layout == AttentionTensorLayout.HND:
@@ -323,7 +325,20 @@ class Attention(nn.Module):
             k = k.view(batch_size, -1, self.num_key_value_heads, self.head_dim)
             v = v.view(batch_size, -1, self.num_key_value_heads, self.head_dim)
 
-        out = self.attn.forward(q=q, k=k, v=v, **kwargs)
+        kwargs.update(
+            {
+                "batch_size": batch_size,
+                "seq_len": seq_len,
+                "seq_len_kv": seq_len_kv,
+            }
+        )
+
+        out = self.attn.forward(
+            q=q,
+            k=k,
+            v=v,
+            **kwargs,
+        )
 
         # Flatten back to [B, S, H*D]
         if backend_layout == AttentionTensorLayout.HND:

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_sage_attention.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ulysses_sage_attention.py
@@ -39,7 +39,10 @@ import torch.nn.functional as F
 try:
     from tensorrt_llm._torch.visual_gen.attention_backend import UlyssesAttention
     from tensorrt_llm._torch.visual_gen.attention_backend.trtllm import TrtllmAttention
-    from tensorrt_llm._torch.visual_gen.config import create_attention_metadata_state
+    from tensorrt_llm._torch.visual_gen.config import (
+        SageAttentionConfig,
+        create_attention_metadata_state,
+    )
     from tensorrt_llm._utils import get_free_port
 
     MODULES_AVAILABLE = True
@@ -133,10 +136,12 @@ def _logic_sage_ulysses_forward(rank, world_size, *, sage_attn_qk_int8: bool):
         layer_idx=0,
         num_heads=num_heads // world_size,
         head_dim=head_dim,
-        sage_attn_num_elts_per_blk_q=1,
-        sage_attn_num_elts_per_blk_k=blk_k,
-        sage_attn_num_elts_per_blk_v=1,
-        sage_attn_qk_int8=sage_attn_qk_int8,
+        sage_attention_config=SageAttentionConfig(
+            num_elts_per_blk_q=1,
+            num_elts_per_blk_k=blk_k,
+            num_elts_per_blk_v=1,
+            qk_int8=sage_attn_qk_int8,
+        ),
         attention_metadata_state=ATTENTION_META_DICT.metadata,
     )
     attention = UlyssesAttention(inner_backend=inner, process_group=None)
@@ -190,10 +195,12 @@ def _logic_sage_ulysses_vs_reference(
         layer_idx=0,
         num_heads=num_heads // world_size,
         head_dim=head_dim,
-        sage_attn_num_elts_per_blk_q=1,
-        sage_attn_num_elts_per_blk_k=sage_attn_num_elts_per_blk_k,
-        sage_attn_num_elts_per_blk_v=1,
-        sage_attn_qk_int8=sage_attn_qk_int8,
+        sage_attention_config=SageAttentionConfig(
+            num_elts_per_blk_q=1,
+            num_elts_per_blk_k=sage_attn_num_elts_per_blk_k,
+            num_elts_per_blk_v=1,
+            qk_int8=sage_attn_qk_int8,
+        ),
         attention_metadata_state=ATTENTION_META_DICT.metadata,
     )
     attention = UlyssesAttention(inner_backend=inner, process_group=None)

--- a/tests/unittest/_torch/visual_gen/test_attention_integration.py
+++ b/tests/unittest/_torch/visual_gen/test_attention_integration.py
@@ -22,6 +22,7 @@ from tensorrt_llm._torch.visual_gen.attention_backend.flash_attn4 import _flash_
 from tensorrt_llm._torch.visual_gen.config import (
     AttentionConfig,
     DiffusionModelConfig,
+    SageAttentionConfig,
     create_attention_metadata_state,
 )
 
@@ -117,6 +118,7 @@ def create_model_config(
     head_dim: int,
     eps: float = 1e-6,
     attn_backend: str = "VANILLA",
+    sage_attention_config: "SageAttentionConfig | None" = None,
 ):
     """Create a mock DiffusionModelConfig for testing."""
     pretrained_config = SimpleNamespace(
@@ -129,7 +131,10 @@ def create_model_config(
     # Create a minimal config without quantization
     config = DiffusionModelConfig(
         pretrained_config=pretrained_config,
-        attention=AttentionConfig(backend=attn_backend),
+        attention=AttentionConfig(
+            backend=attn_backend,
+            sage_attention_config=sage_attention_config,
+        ),
         skip_create_weights_in_init=False,
     )
     config.attention_metadata_state = (
@@ -279,6 +284,107 @@ def test_self_attention_equivalence(attn_backend: str):
         f"Self-attention outputs differ: max_diff={max_diff:.2e}, mean_diff={mean_diff:.2e}"
     )
     return is_close
+
+
+# seq_len: pow2 baselines + real WAN latent token counts (VAE 8x spatial, 4x temporal, patch [1,2,2])
+# batch_size: B=1 (cfg_size=2, split across GPUs) / B=2 (cfg_size=1, single GPU)
+@pytest.mark.parametrize("seq_len", [256, 512, 1560, 3600, 4096, 16384, 32760])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("qk_int8", [False, True])
+def test_sage_attention_self_attention(qk_int8: bool, batch_size: int, seq_len: int):
+    """Test SageAttention (TRTLLM + sage_attention_config) self-attention.
+
+    SageAttention quantizes Q/K/V with per-block scaling factors, so outputs
+    are expected to differ from the naive SDPA reference. We verify:
+    1. Forward pass completes without error
+    2. Output shape matches naive
+    3. Outputs are finite (no NaN/Inf)
+    4. Approximate agreement with naive (cosine similarity > 0.99)
+    """
+    print("\n" + "=" * 60)
+    print(f"Testing SageAttention (qk_int8={qk_int8}, B={batch_size}, S={seq_len})")
+    print("=" * 60)
+
+    # The sm100 sage kernel only has cubins for head_dim=128,
+    # so match the WAN model dimensions (12 heads, head_dim=128).
+    num_heads = 12
+    head_dim = 128
+    hidden_size = num_heads * head_dim  # 1536
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    dtype = torch.bfloat16
+
+    print(f"Config: B={batch_size}, S={seq_len}, H={hidden_size}, heads={num_heads}, D={head_dim}")
+    print(f"Device: {device}, dtype: {dtype}")
+
+    sage_cfg = SageAttentionConfig(
+        num_elts_per_blk_q=1,
+        num_elts_per_blk_k=16 if qk_int8 else 1,
+        num_elts_per_blk_v=1,
+        qk_int8=qk_int8,
+    )
+
+    # Create models
+    naive = NaiveWanSelfAttention(hidden_size, num_heads, head_dim, dtype=dtype).to(device)
+
+    model_config = create_model_config(
+        hidden_size,
+        num_heads,
+        head_dim,
+        attn_backend="TRTLLM",
+        sage_attention_config=sage_cfg,
+    )
+    integrated = Attention(
+        hidden_size, num_heads, qkv_mode=QKVMode.FUSE_QKV, config=model_config
+    ).to(device)
+
+    # Copy weights
+    copy_weights_self_attention(naive, integrated)
+
+    naive.eval()
+    integrated.eval()
+
+    # Create inputs
+    torch.manual_seed(42)
+    hidden_states = torch.randn(batch_size, seq_len, hidden_size, device=device, dtype=dtype)
+    freqs_cos_HSD, freqs_sin_HSD = generate_rope_embeddings(seq_len, head_dim, device, is_HSD=True)
+    freqs_cos_SHD, freqs_sin_SHD = generate_rope_embeddings(seq_len, head_dim, device, is_HSD=False)
+
+    # Forward pass
+    with torch.no_grad():
+        out_naive = naive(hidden_states, freqs_cos_HSD, freqs_sin_HSD)
+        out_sage = integrated(hidden_states, freqs=(freqs_cos_SHD, freqs_sin_SHD))
+
+    # --- Assertions ---
+
+    # 1. Shape match
+    assert out_sage.shape == out_naive.shape, (
+        f"Shape mismatch: sage={out_sage.shape}, naive={out_naive.shape}"
+    )
+
+    # 2. All values finite (no NaN / Inf)
+    assert torch.isfinite(out_sage).all(), (
+        f"SageAttention output contains NaN or Inf (B={batch_size}, S={seq_len})"
+    )
+
+    # 3. Cosine similarity — sage quantization (FP8 per-block) introduces larger
+    #    error than bf16 rounding, so elementwise allclose is too strict.
+    #    Cosine similarity captures directional agreement robustly.
+    max_diff = (out_naive - out_sage).abs().max().item()
+    mean_diff = (out_naive - out_sage).abs().mean().item()
+    cos_sim = F.cosine_similarity(
+        out_naive.reshape(-1).float(), out_sage.reshape(-1).float(), dim=0
+    ).item()
+
+    print(f"\n  Output shape: {out_sage.shape}")
+    print(f"  Max absolute diff:  {max_diff:.2e}")
+    print(f"  Mean absolute diff: {mean_diff:.2e}")
+    print(f"  Cosine similarity:  {cos_sim:.6f}")
+
+    assert cos_sim > 0.99, (
+        f"SageAttention cosine similarity too low: {cos_sim:.4f} < 0.99 "
+        f"(B={batch_size}, S={seq_len}, qk_int8={qk_int8})"
+    )
+    return cos_sim > 0.99
 
 
 @pytest.mark.parametrize("attn_backend", ["VANILLA", "FA4"])
@@ -583,6 +689,15 @@ def run_all_tests():
     # Run self-attention tests with different backends
     for backend in ["VANILLA", "TRTLLM"] + (["FA4"] if _flash_attn4_available else []):
         results[f"self_attention_{backend}"] = test_self_attention_equivalence(backend)
+
+    # Run SageAttention self-attention tests (subset for manual runner)
+    for batch_size in [1, 2]:
+        for seq_len in [4096, 32760]:
+            for qk_int8 in [False, True]:
+                label = f"sage_B{batch_size}_S{seq_len}_QkInt8{qk_int8}"
+                results[label] = test_sage_attention_self_attention(
+                    qk_int8=qk_int8, batch_size=batch_size, seq_len=seq_len
+                )
 
     # Run cross-attention tests
     results["cross_attention_VANILLA"] = test_cross_attention_equivalence("VANILLA")

--- a/tests/unittest/_torch/visual_gen/test_attention_perf.py
+++ b/tests/unittest/_torch/visual_gen/test_attention_perf.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,6 +46,7 @@ from tensorrt_llm._torch.visual_gen.attention_backend.flash_attn4 import (
 from tensorrt_llm._torch.visual_gen.config import (
     AttentionConfig,
     DiffusionModelConfig,
+    SageAttentionConfig,
     create_attention_metadata_state,
 )
 from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode
@@ -145,6 +146,7 @@ def create_model_config(
     head_dim: int,
     eps: float = 1e-6,
     attn_backend: str = "VANILLA",
+    sage_attention_config: "SageAttentionConfig | None" = None,
 ) -> DiffusionModelConfig:
     """Create a mock DiffusionModelConfig for testing."""
     pretrained_config = SimpleNamespace(
@@ -156,7 +158,10 @@ def create_model_config(
 
     config = DiffusionModelConfig(
         pretrained_config=pretrained_config,
-        attention=AttentionConfig(backend=attn_backend),
+        attention=AttentionConfig(
+            backend=attn_backend,
+            sage_attention_config=sage_attention_config,
+        ),
         skip_create_weights_in_init=False,
     )
     config.attention_metadata_state = (
@@ -192,6 +197,13 @@ def generate_rope_embeddings(
         freqs_sin = torch.sin(position * div_term).unsqueeze(0).unsqueeze(2)
 
     return freqs_cos, freqs_sin
+
+
+def _is_sage_attention_enabled(model: Attention) -> bool:
+    """Return whether the created attention model is using SageAttention."""
+    attention_backend = getattr(model, "attn", None)
+    inner_backend = getattr(attention_backend, "inner_backend", attention_backend)
+    return getattr(inner_backend, "sage_attention_config", None) is not None
 
 
 # ============================================================================
@@ -244,10 +256,21 @@ class WanAttentionPerformanceBenchmark:
         self.backends = ["VANILLA", "TRTLLM"]
 
     def create_attention_model(
-        self, hidden_size: int, num_heads: int, head_dim: int, backend: str
+        self,
+        hidden_size: int,
+        num_heads: int,
+        head_dim: int,
+        backend: str,
+        sage_attention_config: "SageAttentionConfig | None" = None,
     ) -> Attention:
         """Create a WAN self-attention model with specified backend."""
-        config = create_model_config(hidden_size, num_heads, head_dim, attn_backend=backend)
+        config = create_model_config(
+            hidden_size,
+            num_heads,
+            head_dim,
+            attn_backend=backend,
+            sage_attention_config=sage_attention_config,
+        )
         model = Attention(hidden_size, num_heads, qkv_mode=QKVMode.FUSE_QKV, config=config).to(
             self.device
         )
@@ -368,6 +391,7 @@ class WanAttentionPerformanceBenchmark:
         head_dim: int,
         backend: str,
         verbose: bool = True,
+        sage_attention_config: "SageAttentionConfig | None" = None,
     ) -> Optional[Dict]:
         """Benchmark a single configuration.
 
@@ -385,7 +409,9 @@ class WanAttentionPerformanceBenchmark:
 
         try:
             # Create model and data
-            model = self.create_attention_model(hidden_size, num_heads, head_dim, backend)
+            model = self.create_attention_model(
+                hidden_size, num_heads, head_dim, backend, sage_attention_config
+            )
             hidden_states, freqs = self.create_test_data(batch_size, seq_len, hidden_size, head_dim)
 
             # Warmup
@@ -419,6 +445,8 @@ class WanAttentionPerformanceBenchmark:
                 "median_ms": times_tensor.median().item(),
                 "p95_ms": torch.quantile(times_tensor, 0.95).item(),
                 "p99_ms": torch.quantile(times_tensor, 0.99).item(),
+                "times_ms": times,
+                "uses_sage": _is_sage_attention_enabled(model),
             }
 
             # Calculate throughput (approximate TOPS)
@@ -832,6 +860,194 @@ class TestFlashAttn4CrossAttnPerformance:
 # ============================================================================
 # Main entry point
 # ============================================================================
+
+
+# ============================================================================
+# SageAttention performance tests
+# ============================================================================
+
+_sm100_only = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 10,
+    reason="SageAttention cubins require SM100 (Blackwell).",
+)
+
+# All five supported (num_elts_per_blk_q, num_elts_per_blk_k, num_elts_per_blk_v, qk_int8) tuples.
+_SAGE_CONFIGS = [
+    SageAttentionConfig(
+        num_elts_per_blk_q=1, num_elts_per_blk_k=1, num_elts_per_blk_v=1, qk_int8=False
+    ),
+    SageAttentionConfig(
+        num_elts_per_blk_q=1, num_elts_per_blk_k=4, num_elts_per_blk_v=1, qk_int8=False
+    ),
+    SageAttentionConfig(
+        num_elts_per_blk_q=1, num_elts_per_blk_k=1, num_elts_per_blk_v=1, qk_int8=True
+    ),
+    SageAttentionConfig(
+        num_elts_per_blk_q=1, num_elts_per_blk_k=4, num_elts_per_blk_v=1, qk_int8=True
+    ),
+    SageAttentionConfig(
+        num_elts_per_blk_q=1, num_elts_per_blk_k=16, num_elts_per_blk_v=1, qk_int8=True
+    ),
+]
+
+# Human-readable labels for the five configs.
+_SAGE_CONFIG_IDS = ["fp8_k1", "fp8_k4", "int8_k1", "int8_k4", "int8_k16"]
+
+
+@_sm100_only
+class TestSageAttentionPerformance:
+    """Performance benchmarks comparing VANILLA, TRTLLM, and TRTLLM+SageAttention.
+
+    All tests use WAN model dimensions (head_dim=128, num_heads=12) because the
+    SM100 SageAttention cubins are generated for head_dim=128 only.
+    """
+
+    # WAN-realistic seq_lens (VAE 8x spatial, 4x temporal, patch [1,2,2])
+    WAN_SEQ_LENS = [
+        (1, 12, 14040, 128, "wan_1.3b_480p_33f"),
+        (1, 12, 32760, 128, "wan_1.3b_480p_81f"),
+        (1, 40, 14040, 128, "wan_14b_480p_33f"),
+        (1, 40, 32760, 128, "wan_14b_480p_81f"),
+        (1, 40, 75600, 128, "wan_14b_720p_81f"),
+    ]
+
+    # Smaller sizes used by quick/CI tests.
+    QUICK_SEQ_LENS = [
+        (1, 12, 1024, 128, "quick_1k"),
+        (1, 12, 4096, 128, "quick_4k"),
+        (2, 12, 1024, 128, "quick_batch2"),
+    ]
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.benchmark = WanAttentionPerformanceBenchmark(
+            warmup_iterations=5,
+            benchmark_iterations=20,
+        )
+
+    def _bench(
+        self,
+        batch: int,
+        num_heads: int,
+        seq_len: int,
+        head_dim: int,
+        sage_cfg: SageAttentionConfig,
+        verbose: bool = True,
+    ) -> Optional[Dict]:
+        return self.benchmark.benchmark_single(
+            batch,
+            num_heads,
+            seq_len,
+            head_dim,
+            backend="TRTLLM",
+            verbose=verbose,
+            sage_attention_config=sage_cfg,
+        )
+
+    # ------------------------------------------------------------------
+    # Quick / CI tests
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("sage_cfg,cfg_id", zip(_SAGE_CONFIGS, _SAGE_CONFIG_IDS))
+    @pytest.mark.parametrize(
+        "batch,num_heads,seq_len,head_dim,desc",
+        QUICK_SEQ_LENS,
+    )
+    def test_sage_runs_and_times(
+        self,
+        batch: int,
+        num_heads: int,
+        seq_len: int,
+        head_dim: int,
+        desc: str,
+        sage_cfg: SageAttentionConfig,
+        cfg_id: str,
+    ):
+        """Verify every sage config produces a valid timing result at quick sizes."""
+        if sage_cfg.qk_int8 and torch.cuda.get_device_capability()[1] == 3:
+            pytest.skip("SM103 does not have Int8 Tensor Cores.")
+
+        result = self._bench(batch, num_heads, seq_len, head_dim, sage_cfg)
+        assert result is not None, f"sage {cfg_id} failed for {desc}"
+        assert result["uses_sage"], f"sage {cfg_id} fell back unexpected for {desc}"
+        assert result["avg_ms"] > 0
+        print(
+            f"  sage {cfg_id} ({desc}): avg={result['avg_ms']:.3f}ms  p95={result['p95_ms']:.3f}ms"
+        )
+
+    @pytest.mark.parametrize("sage_cfg,cfg_id", zip(_SAGE_CONFIGS, _SAGE_CONFIG_IDS))
+    def test_sage_vs_vanilla_quick(self, sage_cfg: SageAttentionConfig, cfg_id: str):
+        """Compare SageAttention timing against VANILLA at a quick size.
+
+        Does not assert a minimum speedup — the goal is to catch regressions
+        where sage unexpectedly becomes much slower than plain SDPA.
+        """
+        if sage_cfg.qk_int8 and torch.cuda.get_device_capability()[1] == 3:
+            pytest.skip("SM103 does not have Int8 Tensor Cores.")
+
+        batch, num_heads, seq_len, head_dim = 1, 12, 4096, 128
+
+        vanilla = self.benchmark.benchmark_single(
+            batch, num_heads, seq_len, head_dim, backend="VANILLA", verbose=False
+        )
+        trtllm = self.benchmark.benchmark_single(
+            batch, num_heads, seq_len, head_dim, backend="TRTLLM", verbose=False
+        )
+        sage = self._bench(batch, num_heads, seq_len, head_dim, sage_cfg)
+
+        assert vanilla is not None, "VANILLA benchmark failed"
+        assert trtllm is not None, "TRTLLM benchmark failed"
+        assert sage is not None, f"SageAttention {cfg_id} benchmark failed"
+        assert sage["uses_sage"], f"SageAttention {cfg_id} fell back unexpected at S={seq_len}"
+
+        speedup_vs_vanilla = vanilla["avg_ms"] / sage["avg_ms"]
+        speedup_vs_trtllm = trtllm["avg_ms"] / sage["avg_ms"]
+        print(
+            f"\n  sage {cfg_id} at S={seq_len}: "
+            f"avg={sage['avg_ms']:.3f}ms  "
+            f"vs_vanilla={speedup_vs_vanilla:.2f}x  "
+            f"vs_trtllm={speedup_vs_trtllm:.2f}x"
+        )
+
+    # ------------------------------------------------------------------
+    # Full WAN-shape benchmarks
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("sage_cfg,cfg_id", zip(_SAGE_CONFIGS, _SAGE_CONFIG_IDS))
+    @pytest.mark.parametrize(
+        "batch,num_heads,seq_len,head_dim,model_name",
+        WAN_SEQ_LENS,
+    )
+    def test_sage_vs_trtllm_wan_shapes(
+        self,
+        batch: int,
+        num_heads: int,
+        seq_len: int,
+        head_dim: int,
+        model_name: str,
+        sage_cfg: SageAttentionConfig,
+        cfg_id: str,
+    ):
+        """SageAttention vs TRTLLM on real WAN model sequence lengths."""
+        if sage_cfg.qk_int8 and torch.cuda.get_device_capability()[1] == 3:
+            pytest.skip("SM103 does not have Int8 Tensor Cores.")
+
+        trtllm = self.benchmark.benchmark_single(
+            batch, num_heads, seq_len, head_dim, backend="TRTLLM", verbose=False
+        )
+        sage = self._bench(batch, num_heads, seq_len, head_dim, sage_cfg)
+
+        assert trtllm is not None, f"TRTLLM failed for {model_name}"
+        assert sage is not None, f"sage {cfg_id} failed for {model_name}"
+        assert sage["uses_sage"], f"sage {cfg_id} fell back unexpected for {model_name}"
+
+        speedup = trtllm["avg_ms"] / sage["avg_ms"]
+        print(
+            f"\n  {model_name} sage={cfg_id}: "
+            f"trtllm={trtllm['avg_ms']:.3f}ms  "
+            f"sage={sage['avg_ms']:.3f}ms  "
+            f"speedup={speedup:.2f}x ({'faster' if speedup > 1 else 'slower'})"
+        )
 
 
 def _run_fa4_benchmark(benchmark: WanAttentionPerformanceBenchmark) -> None:

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -17,6 +17,7 @@ from tensorrt_llm._torch.visual_gen.config import (
     CudaGraphConfig,
     ParallelConfig,
     PipelineConfig,
+    SageAttentionConfig,
     TeaCacheConfig,
     TorchCompileConfig,
     VisualGenArgs,
@@ -72,6 +73,40 @@ class TestVisualGenArgsStrictValidation:
                 checkpoint_path="/tmp/model",
                 linear={"type": "default"},
             )
+
+
+class TestAttentionConfigSageFallback:
+    """Unsupported SageAttention options are logged and disabled."""
+
+    def test_sage_config_fallback_on_non_trtllm_backend(self):
+        with patch("tensorrt_llm._torch.visual_gen.config.logger.critical") as critical:
+            attention = AttentionConfig(
+                backend="VANILLA",
+                sage_attention_config=SageAttentionConfig(),
+            )
+
+        assert attention.sage_attention_config is None
+        critical.assert_called_once()
+        assert "requires backend='TRTLLM'" in critical.call_args.args[0]
+
+    def test_sage_config_fallback_when_unsupported(self):
+        with patch("tensorrt_llm._torch.visual_gen.config.logger.critical") as critical:
+            attention = AttentionConfig(
+                backend="TRTLLM",
+                sage_attention_config=SageAttentionConfig(num_elts_per_blk_q=127),
+            )
+
+        assert attention.sage_attention_config is None
+        critical.assert_called_once()
+        assert "Unsupported self.sage_attention_config" in critical.call_args.args[0]
+
+    def test_supported_sage_configs(self):
+        attention = AttentionConfig(
+            backend="TRTLLM",
+            sage_attention_config=SageAttentionConfig(),
+        )
+
+        assert attention.sage_attention_config is not None
 
 
 class TestVisualGenArgsCacheBackend:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SageAttention optimization support for visual generation models. Users can enable it via the `--enable_sage_attention` flag (requires TRTLLM attention backend).

* **Documentation**
  * Updated visual generation documentation with SageAttention configuration examples and parameter descriptions.

* **Tests**
  * Added SageAttention integration and performance test suites for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Description

**Copied from #13425 with new commits** to fix CI failures.

Integrate SageAttention kernels from https://github.com/NVIDIA/TensorRT-LLM/pull/12937 into VisualGen for Wan and FLUX.2 models. 
LTX-2 SageAttention is not yet supported.

Preliminary perf / quality compared to https://github.com/NVIDIA/TensorRT-LLM/pull/12548 baseline from example scripts:

| Model | Configs | Pipeline Time (Baseline) | Output (Baseline) | Pipeline Time (SageAttention) | Output (SageAttention) | Speedup |
| -------- | -------- | -------- | -------- | -------- | -------- | -------- |
| Wan2.1-T2V-1.3B | "A cute cat playing piano", 480x832, 33 frames, 50 steps, trtllm-fp8-blockwise linear | 7.94s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM/examples/visual_gen/perf_tests_cachedit_pr/Wan2.1-T2V-1.3B-Diffusers/default/output.mp4) | 7.54s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM-2/TensorRT-LLM/examples/visual_gen/sage_attn_test/videos/wan21_t2v_1.3b_fp8block_trtllm_sageattn.mp4) | **1.05x** |
| Wan2.1-I2V-14B-480P | 480x832, 81 frames, 50 steps, trtllm-nvfp4 linear, parallel VAE disabled | 128.79s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM/examples/visual_gen/perf_tests_cachedit_pr/Wan2.1-I2V-14B-480P-Diffusers/default/output.mp4) | 117.38s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM-2/TensorRT-LLM/examples/visual_gen/sage_attn_test/videos/wan21_i2v_14b_480p_nvfp4_trtllm_no_pvae_sageattn.mp4) | **1.10x** |
| Wan2.1-I2V-14B-720P | 720x1280, 81 frames, 50 steps, trtllm-nvfp4 linear, parallel VAE disabled | 501.23s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM/examples/visual_gen/perf_tests_cachedit_pr/Wan2.1-I2V-14B-720P-Diffusers/default/output.mp4) | 458.33s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM-2/TensorRT-LLM/examples/visual_gen/sage_attn_test/videos/wan21_i2v_14b_720p_nvfp4_trtllm_no_pvae_sageattn.mp4) | **1.09x** |
| Wan2.1-T2V-14B-Diffusers | "A cute cat playing piano", 720x1280, 81 frames, 50 steps, trtllm-nvfp4 linear | 484.63s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM/examples/visual_gen/perf_tests_cachedit_pr/Wan2.1-T2V-14B-Diffusers/default/output.mp4) | 413.65s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM-2/TensorRT-LLM/examples/visual_gen/sage_attn_test/videos/wan21_t2v_14b_nvfp4_trtllm_sageattn.mp4) | **1.17x** |
| Wan2.2-I2V-A14B | 720x1280, 81 frames, 40 steps, trtllm-nvfp4 linear, parallel VAE disabled | 387.83s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM/examples/visual_gen/perf_tests_cachedit_pr/Wan2.2-I2V-A14B-Diffusers/default/output.mp4) | 340.48s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM-2/TensorRT-LLM/examples/visual_gen/sage_attn_test/videos/wan22_i2v_a14b_nvfp4_trtllm_no_pvae_sageattn.mp4) | **1.14x** |
| Wan2.2-T2V-A14B | "A cute cat playing piano", 720x1280, 81 frames, 40 steps, trtllm-nvfp4 linear, parallel VAE disabled | 389.10s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM/examples/visual_gen/perf_tests_cachedit_pr/Wan2.2-T2V-A14B-Diffusers/default/output.mp4) | 331.24s | [video](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM-2/TensorRT-LLM/examples/visual_gen/sage_attn_test/videos/wan22_t2v_a14b_nvfp4_trtllm_no_pvae_sageattn.mp4) | **1.17x** |
| FLUX.2-dev | "A cat sitting on a windowsill", 1024x1024, 50 steps, trtllm-nvfp4 linear | 5.60s | [PNG](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM/examples/visual_gen/perf_tests_cachedit_pr/FLUX.2-dev/default/output.png) | 5.61s | [PNG](https://sc.talos.nvidia.com/view/home/scratch.ostoner_coreai_1/TensorRT-LLM-2/TensorRT-LLM/examples/visual_gen/sage_attn_test/videos/flux2_dev_nvfp4_trtllm_sageattn.png) | 1x |

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
