### PR TITLE
[https://nvbugs/5615248][fix] Broader capture of piecewise cudagraph

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -98,6 +98,47 @@ class ModelEngine(ABC):
         return
 
 
+def _filter_piecewise_capture_num_tokens(
+    candidate_num_tokens: list[int],
+    max_num_tokens: int,
+    max_batch_size: int,
+    max_seq_len: int,
+    num_extra_decoding_steps: int = 0,
+) -> Tuple[list[int], list[int]]:
+    """Cap a piecewise CUDA graph capture-set at the largest forward-pass
+    `num_tokens` value the engine can ever construct.
+
+    A piecewise CUDA graph for `num_tokens = N` is only useful if a real
+    forward pass can ever flow N tokens through the model. Every in-flight
+    request must leave room for at least one decode token in its KV cache,
+    so the largest forward-pass num_tokens reachable at runtime (and the
+    largest the warmup builder can construct) is
+    `max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps)`.
+    Without this cap, candidate entries above this bound would be advertised
+    in `_torch_compile_backend.capture_num_tokens` but silently fail warmup
+    in `_create_warmup_request`, making the outer padding logic pad to a
+    target that has no captured graph and fall back to eager (NVBug 5615248).
+
+    Returns:
+        kept: candidate entries that are <= min(max_num_tokens,
+            max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps)),
+            preserving input order.
+        unrecordable: sorted unique candidate entries that are <=
+            max_num_tokens but exceed the engine's reachable ceiling. These
+            are the entries that would have been silently skipped by warmup.
+    """
+    max_capturable_num_tokens = max(
+        0, max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps))
+    piecewise_capacity_limit = min(max_num_tokens, max_capturable_num_tokens)
+    kept = [i for i in candidate_num_tokens if i <= piecewise_capacity_limit]
+    unrecordable = sorted({
+        i
+        for i in candidate_num_tokens
+        if max_capturable_num_tokens < i <= max_num_tokens
+    })
+    return kept, unrecordable
+
+
 def _filter_cuda_graph_batch_sizes(cuda_graph_batch_sizes: list[int],
                                    max_batch_size: int, max_num_tokens: int,
                                    max_total_draft_tokens: int,
@@ -285,10 +326,22 @@ class PyTorchModelEngine(ModelEngine):
             torch_compile_piecewise_cuda_graph_num_tokens
             or cuda_graph_batch_sizes or [])
 
-        self._piecewise_cuda_graph_num_tokens = [
-            i for i in piecewise_cuda_graph_num_tokens
-            if i <= self.max_num_tokens
-        ]
+        num_extra_decoding_steps = self._get_num_extra_decoding_steps()
+        self._piecewise_cuda_graph_num_tokens, unrecordable = (
+            _filter_piecewise_capture_num_tokens(
+                piecewise_cuda_graph_num_tokens,
+                max_num_tokens=self.max_num_tokens,
+                max_batch_size=self.batch_size,
+                max_seq_len=self.max_seq_len,
+                num_extra_decoding_steps=num_extra_decoding_steps,
+            ))
+        if unrecordable:
+            logger.warning(
+                f"Skipping piecewise CUDA graph capture for num_tokens="
+                f"{unrecordable}: exceeds reachable ceiling "
+                f"max_batch_size*(max_seq_len-1-num_extra_decoding_steps)="
+                f"{max(0, self.batch_size * (self.max_seq_len - 1 - num_extra_decoding_steps))}. "
+                f"Raise max_seq_len to capture larger graphs.")
 
         try:
             use_ub_for_nccl = (

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -107,16 +107,29 @@ def _filter_piecewise_capture_num_tokens(
 ) -> Tuple[list[int], list[int]]:
     """Cap piecewise CUDA graph capture candidates at the engine's reachable
     `num_tokens` ceiling `max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps)`
-    (each in-flight request must leave room for one decode token).
+    and ensure the ceiling itself is captured.
 
-    Returns `(kept, unrecordable)` where `kept` preserves input order and
-    `unrecordable` is the sorted unique set of entries above the ceiling
-    but within `max_num_tokens` (i.e. would silently fail warmup).
+    Each in-flight request must leave room for at least one decode token,
+    so the ceiling is the largest forward-pass `num_tokens` the warmup
+    builder can construct. Including it in the capture set closes the
+    runtime padding gap between the next-largest candidate and the ceiling
+    (otherwise ISLs in that gap have no graph >= them and fall back to
+    eager).
+
+    Returns `(kept, unrecordable)` where `kept` is sorted ascending,
+    deduped, and contains the ceiling whenever it is positive.
+    `unrecordable` is the sorted unique set of input entries above the
+    ceiling but within `max_num_tokens`.
     """
     max_capturable_num_tokens = max(
         0, max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps))
     piecewise_capacity_limit = min(max_num_tokens, max_capturable_num_tokens)
-    kept = [i for i in candidate_num_tokens if i <= piecewise_capacity_limit]
+    kept = sorted(
+        {i
+         for i in candidate_num_tokens if 0 < i <= piecewise_capacity_limit})
+    if piecewise_capacity_limit > 0 and (not kept or kept[-1]
+                                         < piecewise_capacity_limit):
+        kept.append(piecewise_capacity_limit)
     unrecordable = sorted({
         i
         for i in candidate_num_tokens
@@ -327,7 +340,8 @@ class PyTorchModelEngine(ModelEngine):
                 f"{unrecordable}: exceeds reachable ceiling "
                 f"max_batch_size*(max_seq_len-1-num_extra_decoding_steps)="
                 f"{max(0, self.batch_size * (self.max_seq_len - 1 - num_extra_decoding_steps))}. "
-                f"Raise max_seq_len to capture larger graphs.")
+                f"Capturing the ceiling itself; raise max_seq_len for larger graphs."
+            )
 
         try:
             use_ub_for_nccl = (

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -105,27 +105,13 @@ def _filter_piecewise_capture_num_tokens(
     max_seq_len: int,
     num_extra_decoding_steps: int = 0,
 ) -> Tuple[list[int], list[int]]:
-    """Cap a piecewise CUDA graph capture-set at the largest forward-pass
-    `num_tokens` value the engine can ever construct.
+    """Cap piecewise CUDA graph capture candidates at the engine's reachable
+    `num_tokens` ceiling `max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps)`
+    (each in-flight request must leave room for one decode token).
 
-    A piecewise CUDA graph for `num_tokens = N` is only useful if a real
-    forward pass can ever flow N tokens through the model. Every in-flight
-    request must leave room for at least one decode token in its KV cache,
-    so the largest forward-pass num_tokens reachable at runtime (and the
-    largest the warmup builder can construct) is
-    `max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps)`.
-    Without this cap, candidate entries above this bound would be advertised
-    in `_torch_compile_backend.capture_num_tokens` but silently fail warmup
-    in `_create_warmup_request`, making the outer padding logic pad to a
-    target that has no captured graph and fall back to eager (NVBug 5615248).
-
-    Returns:
-        kept: candidate entries that are <= min(max_num_tokens,
-            max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps)),
-            preserving input order.
-        unrecordable: sorted unique candidate entries that are <=
-            max_num_tokens but exceed the engine's reachable ceiling. These
-            are the entries that would have been silently skipped by warmup.
+    Returns `(kept, unrecordable)` where `kept` preserves input order and
+    `unrecordable` is the sorted unique set of entries above the ceiling
+    but within `max_num_tokens` (i.e. would silently fail warmup).
     """
     max_capturable_num_tokens = max(
         0, max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps))

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3520,6 +3520,13 @@ class TorchCompileConfig(StrictBaseModel):
         description=
         "The maximum number of CUDA streams to use for torch.compile.")
 
+    @model_validator(mode='after')
+    def set_default_capture_num_tokens(self) -> 'TorchCompileConfig':
+        if self.enable_piecewise_cuda_graph and self.capture_num_tokens is None:
+            self.capture_num_tokens = [2**i for i in range(8)
+                                       ] + [i for i in range(256, 3073, 256)]
+        return self
+
 
 class TorchLlmArgs(BaseLlmArgs):
     # PyTorch backend specific configurations

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3520,13 +3520,6 @@ class TorchCompileConfig(StrictBaseModel):
         description=
         "The maximum number of CUDA streams to use for torch.compile.")
 
-    @model_validator(mode='after')
-    def set_default_capture_num_tokens(self) -> 'TorchCompileConfig':
-        if self.enable_piecewise_cuda_graph and self.capture_num_tokens is None:
-            self.capture_num_tokens = [2**i for i in range(8)
-                                       ] + [i for i in range(256, 3073, 256)]
-        return self
-
 
 class TorchLlmArgs(BaseLlmArgs):
     # PyTorch backend specific configurations

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -728,9 +728,13 @@ class TestPiecewiseCudaGraphCaptureDefaults:
 
     Three invariants are exercised:
 
-    1. `TorchCompileConfig.capture_num_tokens` defaults to `None`, so the
-       model engine can fall back to `cuda_graph_config.batch_sizes` (the
-       behavior documented on the field).
+    1. `TorchCompileConfig.capture_num_tokens` defaults to a fixed
+       powers-of-2 + 256-stride list when `enable_piecewise_cuda_graph`
+       is True (and stays `None` otherwise). The fixed list keeps the
+       capture set small to bound startup time and CUDA graph memory;
+       the model-engine filter (invariants 2 and 3) ensures the largest
+       reachable size is always captured even when it is not in this
+       default list.
     2. `_filter_piecewise_capture_num_tokens` caps the candidate list at
        `max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps)` --
        the largest forward-pass `num_tokens` the warmup builder can
@@ -742,18 +746,44 @@ class TestPiecewiseCudaGraphCaptureDefaults:
        than falling back to eager.
     """
 
-    def test_torch_compile_config_capture_num_tokens_defaults_to_none(self):
-        """`capture_num_tokens` is unset by default.
+    _EXPECTED_DEFAULT_CAPTURE_NUM_TOKENS = [2**i for i in range(8)] + list(
+        range(256, 3073, 256))
 
-        Keeps the documented fallback to `cuda_graph_config.batch_sizes`
-        in the model engine reachable; a non-None default here would
-        silently shadow the user's `cuda_graph_config.batch_sizes` choice.
+    def test_torch_compile_config_capture_num_tokens_default_when_piecewise_enabled(
+            self):
+        """Default capture set is the powers-of-2 + 256-stride list.
+
+        Keeps the capture set bounded (~20 entries) so server startup
+        time and CUDA graph memory stay predictable. The model engine
+        further filters and appends the reachable ceiling, so
+        out-of-range entries (e.g. > max_seq_len-1) are never recorded
+        and gap ISLs still get a graph.
         """
         config = TorchCompileConfig(enable_piecewise_cuda_graph=True)
+        assert config.capture_num_tokens == self._EXPECTED_DEFAULT_CAPTURE_NUM_TOKENS
+
+    def test_torch_compile_config_capture_num_tokens_stays_none_when_piecewise_disabled(
+            self):
+        """No default is populated when piecewise is off.
+
+        The capture set is irrelevant in this case; populating it would
+        be misleading in serialized configs.
+        """
+        config = TorchCompileConfig(enable_piecewise_cuda_graph=False)
         assert config.capture_num_tokens is None
 
-    def test_torch_llm_args_capture_num_tokens_defaults_to_none(self):
-        """Same invariant when reached through `TorchLlmArgs` construction.
+    def test_torch_compile_config_capture_num_tokens_user_override_preserved(
+            self):
+        """User-supplied `capture_num_tokens` is not overwritten by the default."""
+        user_list = [4, 8, 16]
+        config = TorchCompileConfig(enable_piecewise_cuda_graph=True,
+                                    capture_num_tokens=user_list)
+        # `validate_capture_num_tokens` dedupes and reverse-sorts.
+        assert config.capture_num_tokens == sorted(set(user_list), reverse=True)
+
+    def test_torch_llm_args_capture_num_tokens_default_when_piecewise_enabled(
+            self):
+        """Same default applies when reached through `TorchLlmArgs` construction.
 
         This is the path real users hit via `trtllm-serve` YAML.
         """
@@ -768,7 +798,7 @@ class TestPiecewiseCudaGraphCaptureDefaults:
             torch_compile_config=TorchCompileConfig(
                 enable_piecewise_cuda_graph=True),
         )
-        assert args.torch_compile_config.capture_num_tokens is None
+        assert args.torch_compile_config.capture_num_tokens == self._EXPECTED_DEFAULT_CAPTURE_NUM_TOKENS
 
     def test_piecewise_filter_drops_entries_above_reachable_ceiling(self):
         """Drop candidates above `max_batch_size * (max_seq_len - 1)`.

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -723,6 +723,132 @@ class TestTorchLlmArgsCudaGraphSettings:
         assert max_batch_size in batch_sizes
 
 
+class TestPiecewiseCudaGraphCaptureDefaults:
+    """Tests for the piecewise CUDA graph capture-set defaults and the
+    model-engine filter that prunes entries the runtime can never reach.
+
+    Two invariants are exercised:
+
+    1. `TorchCompileConfig.capture_num_tokens` defaults to `None`, so the
+       model engine can fall back to `cuda_graph_config.batch_sizes` (the
+       behavior documented on the field).
+    2. `_filter_piecewise_capture_num_tokens` caps the candidate list at
+       `max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps)` --
+       the largest forward-pass `num_tokens` the warmup builder can
+       construct, since every in-flight request must leave room for at
+       least one decode token.
+    """
+
+    def test_torch_compile_config_capture_num_tokens_defaults_to_none(self):
+        """`capture_num_tokens` is unset by default so the documented
+        fallback to `cuda_graph_config.batch_sizes` in the model engine
+        remains reachable. A non-None default here would silently shadow
+        the user's `cuda_graph_config.batch_sizes` choice.
+        """
+        config = TorchCompileConfig(enable_piecewise_cuda_graph=True)
+        assert config.capture_num_tokens is None
+
+    def test_torch_llm_args_capture_num_tokens_defaults_to_none(self):
+        """Same invariant when the config is built through `TorchLlmArgs`
+        (the path real users hit via `trtllm-serve` YAML).
+        """
+        args = TorchLlmArgs(
+            model=llama_model_path,
+            max_batch_size=1,
+            max_seq_len=128,
+            max_beam_width=10,
+            enable_chunked_prefill=True,
+            cuda_graph_config=CudaGraphConfig(max_batch_size=128,
+                                              enable_padding=True),
+            torch_compile_config=TorchCompileConfig(
+                enable_piecewise_cuda_graph=True),
+        )
+        assert args.torch_compile_config.capture_num_tokens is None
+
+    def test_piecewise_filter_drops_entries_above_reachable_ceiling(self):
+        """When the candidate list contains an entry above the reachable
+        ceiling `max_batch_size * (max_seq_len - 1)`, the filter must drop
+        it from `kept` and surface it in `unrecordable`. Otherwise the
+        warmup loop would silently skip it and the outer padding logic
+        would pad to a target with no captured graph.
+        """
+        from tensorrt_llm._torch.pyexecutor.model_engine import (
+            _filter_piecewise_capture_num_tokens)
+
+        candidates = CudaGraphConfig._generate_cuda_graph_batch_sizes(
+            128, enable_padding=True)
+        max_capturable = 1 * (128 - 1)
+        # Precondition: candidate list contains at least one entry above
+        # the reachable ceiling, otherwise the assertions below are vacuous.
+        assert any(i > max_capturable for i in candidates), (
+            "Test precondition no longer holds: cuda_graph_batch_sizes "
+            f"for max_batch_size=128 no longer contains entries above "
+            f"{max_capturable}. Update this test if CudaGraphConfig "
+            "behavior changed.")
+
+        kept, unrecordable = _filter_piecewise_capture_num_tokens(
+            candidates,
+            max_num_tokens=128,
+            max_batch_size=1,
+            max_seq_len=128,
+        )
+
+        assert max(kept) == 120
+        assert 128 not in kept
+        assert unrecordable == [128]
+
+    def test_piecewise_filter_keeps_all_entries_when_within_ceiling(self):
+        """Symmetric case: when the ceiling
+        `max_batch_size * (max_seq_len - 1)` is at least as large as the
+        biggest candidate, nothing is dropped and `unrecordable` is empty.
+        """
+        from tensorrt_llm._torch.pyexecutor.model_engine import (
+            _filter_piecewise_capture_num_tokens)
+
+        candidates = CudaGraphConfig._generate_cuda_graph_batch_sizes(
+            128, enable_padding=True)
+        kept, unrecordable = _filter_piecewise_capture_num_tokens(
+            candidates,
+            max_num_tokens=129,
+            max_batch_size=1,
+            max_seq_len=129,
+        )
+        assert max(kept) == 128
+        assert 128 in kept
+        assert unrecordable == []
+
+    def test_piecewise_filter_subtracts_extra_decoding_steps(self):
+        """Drafting loops consume extra decode steps. The filter must
+        subtract `num_extra_decoding_steps` from the ceiling, mirroring
+        the `max_seq_len - 1 - num_extra_decoding_steps` constraint
+        applied when warmup requests are built.
+        """
+        from tensorrt_llm._torch.pyexecutor.model_engine import (
+            _filter_piecewise_capture_num_tokens)
+
+        candidates = [1, 2, 4, 8, 16, 32, 64, 100, 120]
+        # max_seq_len=128, batch=1, 5 extra decoding steps -> ceiling 122.
+        kept, unrecordable = _filter_piecewise_capture_num_tokens(
+            candidates,
+            max_num_tokens=128,
+            max_batch_size=1,
+            max_seq_len=128,
+            num_extra_decoding_steps=5,
+        )
+        assert max(kept) == 120
+        assert unrecordable == []
+        # Same setup with 9 extra decoding steps -> ceiling 118; 120 drops.
+        kept, unrecordable = _filter_piecewise_capture_num_tokens(
+            candidates,
+            max_num_tokens=128,
+            max_batch_size=1,
+            max_seq_len=128,
+            num_extra_decoding_steps=9,
+        )
+        assert max(kept) == 100
+        assert unrecordable == [120]
+
+
 class TestTrtLlmArgs:
 
     def test_dynamic_setattr(self):

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -726,7 +726,7 @@ class TestTorchLlmArgsCudaGraphSettings:
 class TestPiecewiseCudaGraphCaptureDefaults:
     """Piecewise CUDA graph capture-set defaults and reachable-ceiling filter.
 
-    Two invariants are exercised:
+    Three invariants are exercised:
 
     1. `TorchCompileConfig.capture_num_tokens` defaults to `None`, so the
        model engine can fall back to `cuda_graph_config.batch_sizes` (the
@@ -736,6 +736,10 @@ class TestPiecewiseCudaGraphCaptureDefaults:
        the largest forward-pass `num_tokens` the warmup builder can
        construct, since every in-flight request must leave room for at
        least one decode token.
+    3. The reachable ceiling itself is always present in the returned
+       capture set (when positive), so runtime ISLs in the gap between
+       the next-largest candidate and the ceiling get a graph rather
+       than falling back to eager.
     """
 
     def test_torch_compile_config_capture_num_tokens_defaults_to_none(self):
@@ -772,7 +776,8 @@ class TestPiecewiseCudaGraphCaptureDefaults:
         Without the cap, the warmup loop would silently skip these entries
         and the outer padding logic would pad to a target with no captured
         graph. They must be removed from `kept` and surfaced in
-        `unrecordable` so the warning fires.
+        `unrecordable` so the warning fires. The ceiling itself is then
+        appended so ISLs in the gap still get a graph.
         """
         from tensorrt_llm._torch.pyexecutor.model_engine import \
             _filter_piecewise_capture_num_tokens
@@ -795,7 +800,8 @@ class TestPiecewiseCudaGraphCaptureDefaults:
             max_seq_len=128,
         )
 
-        assert max(kept) == 120
+        assert kept[-1] == max_capturable  # ceiling appended
+        assert 120 in kept  # densely-packed entries below ceiling preserved
         assert 128 not in kept
         assert unrecordable == [128]
 
@@ -804,7 +810,8 @@ class TestPiecewiseCudaGraphCaptureDefaults:
 
         Symmetric case: when `max_batch_size * (max_seq_len - 1)` is at
         least as large as the biggest candidate, nothing is dropped and
-        `unrecordable` is empty.
+        `unrecordable` is empty. The ceiling (128 here) coincides with the
+        largest candidate so no extra entry is appended.
         """
         from tensorrt_llm._torch.pyexecutor.model_engine import \
             _filter_piecewise_capture_num_tokens
@@ -817,8 +824,10 @@ class TestPiecewiseCudaGraphCaptureDefaults:
             max_batch_size=1,
             max_seq_len=129,
         )
-        assert max(kept) == 128
+        assert kept[-1] == 128
         assert 128 in kept
+        # Ceiling (128) was already in candidates, must not be duplicated.
+        assert kept.count(128) == 1
         assert unrecordable == []
 
     def test_piecewise_filter_subtracts_extra_decoding_steps(self):
@@ -826,7 +835,9 @@ class TestPiecewiseCudaGraphCaptureDefaults:
 
         Drafting loops consume extra decode steps; the filter must mirror
         the `max_seq_len - 1 - num_extra_decoding_steps` constraint
-        applied when warmup requests are built.
+        applied when warmup requests are built. The ceiling is appended
+        whenever it is strictly greater than the largest surviving
+        candidate.
         """
         from tensorrt_llm._torch.pyexecutor.model_engine import \
             _filter_piecewise_capture_num_tokens
@@ -840,7 +851,8 @@ class TestPiecewiseCudaGraphCaptureDefaults:
             max_seq_len=128,
             num_extra_decoding_steps=5,
         )
-        assert max(kept) == 120
+        assert kept[-1] == 122
+        assert 120 in kept
         assert unrecordable == []
         # Same setup with 9 extra decoding steps -> ceiling 118; 120 drops.
         kept, unrecordable = _filter_piecewise_capture_num_tokens(
@@ -850,8 +862,57 @@ class TestPiecewiseCudaGraphCaptureDefaults:
             max_seq_len=128,
             num_extra_decoding_steps=9,
         )
-        assert max(kept) == 100
+        assert kept[-1] == 118
+        assert 100 in kept
+        assert 120 not in kept
         assert unrecordable == [120]
+
+    def test_piecewise_filter_does_not_double_append_ceiling(self):
+        """Ceiling already present in candidates -> not duplicated."""
+        from tensorrt_llm._torch.pyexecutor.model_engine import \
+            _filter_piecewise_capture_num_tokens
+
+        kept, _ = _filter_piecewise_capture_num_tokens(
+            [1, 64, 128],
+            max_num_tokens=129,
+            max_batch_size=1,
+            max_seq_len=129,
+        )
+        assert kept == [1, 64, 128]
+
+    def test_piecewise_filter_returns_empty_when_ceiling_is_zero(self):
+        """`max_seq_len=1` -> ceiling 0 -> nothing captured.
+
+        With ceiling 0 every positive candidate is unrecordable and the
+        ceiling itself is not appended, so the warning "exceeds reachable
+        ceiling 0; raise max_seq_len" fires for the full candidate list.
+        """
+        from tensorrt_llm._torch.pyexecutor.model_engine import \
+            _filter_piecewise_capture_num_tokens
+
+        kept, unrecordable = _filter_piecewise_capture_num_tokens(
+            [1, 2, 4],
+            max_num_tokens=8,
+            max_batch_size=1,
+            max_seq_len=1,
+        )
+        assert kept == []
+        assert unrecordable == [1, 2, 4]
+
+    def test_piecewise_filter_appends_ceiling_when_only_smaller_candidates(
+            self):
+        """No candidate near the ceiling -> ceiling still appended."""
+        from tensorrt_llm._torch.pyexecutor.model_engine import \
+            _filter_piecewise_capture_num_tokens
+
+        kept, _ = _filter_piecewise_capture_num_tokens(
+            [1, 2, 4, 8],
+            max_num_tokens=1024,
+            max_batch_size=8,
+            max_seq_len=128,
+        )
+        # Ceiling: 8 * (128 - 1) = 1016.
+        assert kept == [1, 2, 4, 8, 1016]
 
 
 class TestTrtLlmArgs:

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -724,8 +724,7 @@ class TestTorchLlmArgsCudaGraphSettings:
 
 
 class TestPiecewiseCudaGraphCaptureDefaults:
-    """Tests for the piecewise CUDA graph capture-set defaults and the
-    model-engine filter that prunes entries the runtime can never reach.
+    """Piecewise CUDA graph capture-set defaults and reachable-ceiling filter.
 
     Two invariants are exercised:
 
@@ -740,17 +739,19 @@ class TestPiecewiseCudaGraphCaptureDefaults:
     """
 
     def test_torch_compile_config_capture_num_tokens_defaults_to_none(self):
-        """`capture_num_tokens` is unset by default so the documented
-        fallback to `cuda_graph_config.batch_sizes` in the model engine
-        remains reachable. A non-None default here would silently shadow
-        the user's `cuda_graph_config.batch_sizes` choice.
+        """`capture_num_tokens` is unset by default.
+
+        Keeps the documented fallback to `cuda_graph_config.batch_sizes`
+        in the model engine reachable; a non-None default here would
+        silently shadow the user's `cuda_graph_config.batch_sizes` choice.
         """
         config = TorchCompileConfig(enable_piecewise_cuda_graph=True)
         assert config.capture_num_tokens is None
 
     def test_torch_llm_args_capture_num_tokens_defaults_to_none(self):
-        """Same invariant when the config is built through `TorchLlmArgs`
-        (the path real users hit via `trtllm-serve` YAML).
+        """Same invariant when reached through `TorchLlmArgs` construction.
+
+        This is the path real users hit via `trtllm-serve` YAML.
         """
         args = TorchLlmArgs(
             model=llama_model_path,
@@ -766,14 +767,15 @@ class TestPiecewiseCudaGraphCaptureDefaults:
         assert args.torch_compile_config.capture_num_tokens is None
 
     def test_piecewise_filter_drops_entries_above_reachable_ceiling(self):
-        """When the candidate list contains an entry above the reachable
-        ceiling `max_batch_size * (max_seq_len - 1)`, the filter must drop
-        it from `kept` and surface it in `unrecordable`. Otherwise the
-        warmup loop would silently skip it and the outer padding logic
-        would pad to a target with no captured graph.
+        """Drop candidates above `max_batch_size * (max_seq_len - 1)`.
+
+        Without the cap, the warmup loop would silently skip these entries
+        and the outer padding logic would pad to a target with no captured
+        graph. They must be removed from `kept` and surfaced in
+        `unrecordable` so the warning fires.
         """
-        from tensorrt_llm._torch.pyexecutor.model_engine import (
-            _filter_piecewise_capture_num_tokens)
+        from tensorrt_llm._torch.pyexecutor.model_engine import \
+            _filter_piecewise_capture_num_tokens
 
         candidates = CudaGraphConfig._generate_cuda_graph_batch_sizes(
             128, enable_padding=True)
@@ -798,12 +800,14 @@ class TestPiecewiseCudaGraphCaptureDefaults:
         assert unrecordable == [128]
 
     def test_piecewise_filter_keeps_all_entries_when_within_ceiling(self):
-        """Symmetric case: when the ceiling
-        `max_batch_size * (max_seq_len - 1)` is at least as large as the
-        biggest candidate, nothing is dropped and `unrecordable` is empty.
+        """Keep all candidates when the largest fits within the ceiling.
+
+        Symmetric case: when `max_batch_size * (max_seq_len - 1)` is at
+        least as large as the biggest candidate, nothing is dropped and
+        `unrecordable` is empty.
         """
-        from tensorrt_llm._torch.pyexecutor.model_engine import (
-            _filter_piecewise_capture_num_tokens)
+        from tensorrt_llm._torch.pyexecutor.model_engine import \
+            _filter_piecewise_capture_num_tokens
 
         candidates = CudaGraphConfig._generate_cuda_graph_batch_sizes(
             128, enable_padding=True)
@@ -818,13 +822,14 @@ class TestPiecewiseCudaGraphCaptureDefaults:
         assert unrecordable == []
 
     def test_piecewise_filter_subtracts_extra_decoding_steps(self):
-        """Drafting loops consume extra decode steps. The filter must
-        subtract `num_extra_decoding_steps` from the ceiling, mirroring
+        """Subtract `num_extra_decoding_steps` from the ceiling.
+
+        Drafting loops consume extra decode steps; the filter must mirror
         the `max_seq_len - 1 - num_extra_decoding_steps` constraint
         applied when warmup requests are built.
         """
-        from tensorrt_llm._torch.pyexecutor.model_engine import (
-            _filter_piecewise_capture_num_tokens)
+        from tensorrt_llm._torch.pyexecutor.model_engine import \
+            _filter_piecewise_capture_num_tokens
 
         candidates = [1, 2, 4, 8, 16, 32, 64, 100, 120]
         # max_seq_len=128, batch=1, 5 extra decoding steps -> ceiling 122.
@@ -1482,7 +1487,6 @@ def _get_all_llm_args_classes():
 
 def _get_all_pydantic_models_from_llm_args():
     """Get all Pydantic models referenced by BaseLlmArgs and its subclasses."""
-
     visited = set()
     models = []
 
@@ -1535,8 +1539,7 @@ def _get_qualified_name(cls: type) -> str:
 
 
 class TestPydanticBestPractices:
-    """
-    Ensure that the user-facing LlmArgs and its subfields follow Pydantic best practices.
+    """Ensure that the user-facing LlmArgs and its subfields follow Pydantic best practices.
     """
 
     # Fields exempt from Pydantic compatibility checks due to typing limitations or other edge cases.
@@ -1570,8 +1573,7 @@ class TestPydanticBestPractices:
 
     def _is_allowed_type(self, annotation, model_cls: type,
                          field_name: str) -> tuple[bool, str]:
-        """
-        Check if a type annotation is allowed for user-facing config fields.
+        """Check if a type annotation is allowed for user-facing config fields.
 
         Allowed:
         - Pydantic models (must inherit from StrictBaseModel)
@@ -1583,7 +1585,6 @@ class TestPydanticBestPractices:
 
         Returns (is_allowed, reason) tuple.
         """
-
         # Check if this field is exempt (check class and all parent classes)
         for cls in model_cls.__mro__:
             if field_name in self._COMPATIBILITY_EXEMPT_FIELDS.get(cls, []):
@@ -1669,7 +1670,7 @@ class TestPydanticBestPractices:
 
         if violations:
             pytest.fail(
-                f"The following fields are missing descriptions:\n" +
+                "The following fields are missing descriptions:\n" +
                 "\n".join(violations) +
                 "\n\nPlease add a description to each by using Field(description=\"...\")."
             )
@@ -1695,7 +1696,7 @@ class TestPydanticBestPractices:
 
         if violations:
             pytest.fail(
-                f"The following user-facing fields have types that are not allowed:\n"
+                "The following user-facing fields have types that are not allowed:\n"
                 + "\n".join(violations) +
                 "\n\nPlease use Pydantic-compatible types (primitives, Pydantic models that inherit from StrictBaseModel, "
                 "or other compatible types). If this is intentional, add the field "
@@ -1738,7 +1739,7 @@ class TestPydanticBestPractices:
 
         if violations:
             pytest.fail(
-                f"The following models define forbidden methods:\n" +
+                "The following models define forbidden methods:\n" +
                 "\n".join(violations) +
                 "\n\nPydantic models should follow the recommendations above instead."
             )
@@ -1761,7 +1762,7 @@ class TestPydanticBestPractices:
 
         if violations:
             pytest.fail(
-                f"The following fields use mutable default values:\n" +
+                "The following fields use mutable default values:\n" +
                 "\n".join(violations) +
                 "\n\nMutable defaults are shared across instances and cause bugs. "
                 "Use Field(default_factory=...) instead.")
@@ -1788,7 +1789,7 @@ class TestPydanticBestPractices:
 
         if violations:
             pytest.fail(
-                f"The following Pydantic models define custom __init__ methods:\n"
+                "The following Pydantic models define custom __init__ methods:\n"
                 + "\n".join(violations) +
                 "\n\nThese should be replaced with alternatives like validators, model_post_init, or classmethods. See this test's docstring for more details."
             )


### PR DESCRIPTION
## Description

This is part of a fix for https://nvbugspro.nvidia.com/bug/5615248.

When `enable_piecewise_cuda_graph=True`, the piecewise CUDA graph capture set silently failed to cover `num_tokens` values that the runtime engine could legitimately request, causing those forward passes to fall back to eager execution.

The model-engine filter on the candidate list used `i <= max_num_tokens`, which is looser than the engine's actual reachable ceiling `max_batch_size * (max_seq_len - 1 - num_extra_decoding_steps)`. Entries above the real ceiling were advertised as captured but warmup silently failed to record them; the outer padding logic then padded prefill chunks to a target with no captured graph and dropped to eager.

**_Proposed fix:_**

* Add `_filter_piecewise_capture_num_tokens` helper and use it in `PyTorchModelEngine.__init__` to (a) cap the candidate list at the engine's reachable ceiling and (b) append the ceiling itself so ISLs in the gap between the next-largest candidate and the ceiling still get a graph. Drops are reported via a single `logger.warning` pointing at `max_seq_len` (this was silent earlier).
* Default `capture_num_tokens` (powers-of-2 + 256-stride) is preserved to bound startup time and CUDA graph memory; the new filter handles ceiling correctness.

**_Before/after:_**

`max_batch_size=1`, `max_seq_len=128`, `enable_piecewise_cuda_graph=true`. Reachable ceiling = `1 * (128 - 1) = 127`.

| ISL  | Before (main)                    | After (this PR)         |
| ---- | -------------------------------- | ----------------------- |
| 64   | piecewise (pad to 64)            | piecewise (pad to 64)   |
| 100  | **eager** (pad to 128, no graph) | piecewise (pad to 127)  |
| 107  | **eager** (pad to 128, no graph) | piecewise (pad to 127)  |
| 121  | **eager** (pad to 128, no graph) | piecewise (pad to 127)  |
| 127  | **eager** (pad to 128, no graph) | piecewise (pad to 127)  |

## Test Coverage

```
$ pytest tests/unittest/llmapi/test_llm_args.py::TestPiecewiseCudaGraphCaptureDefaults -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA-graph capture candidate filtering to account for KV-cache constraints and extra decoding steps, preventing silent failures during warmup.
  * Added warning logs for capture candidates that exceed reachable limits.

* **Behavior Changes**
  * `capture_num_tokens` no longer receives automatic defaults; users must now explicitly specify values when enabling piecewise CUDA graphs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->