### PR TITLE
[None][fix] Reject incompatible KV connector configurations at construction time

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -61,7 +61,7 @@ from .hang_detector import HangDetector
 from .kv_cache_transceiver import KvCacheTransceiver
 from .llm_request import (ExecutorRequest, LlmRequest, LlmRequestState,
                           LlmResponse, get_draft_token_length)
-from .mamba_cache_manager import MambaHybridCacheManager
+from .mamba_cache_manager import BaseMambaCacheManager, MambaHybridCacheManager
 from .model_engine import ModelEngine
 from .perf_metrics_manager import PerfMetricsManager
 from .request_utils import (RequestBroadcaster, attach_py_objects_to_requests,
@@ -642,10 +642,27 @@ class PyExecutor:
                     "Both KV Cache Connector and KV Cache Transceiver are enabled. Are you sure you want to do this?"
                 )
 
-            if self.dist.pp_size > 1:
+            if self.dist.pp_size > 1 or self.dist.cp_size > 1:
                 raise NotImplementedError(
-                    "KV Cache Connector is not supported with pipeline parallelism."
-                )
+                    "KV Cache Connector is not supported with pipeline or "
+                    "context parallelism: the connector worker is registered "
+                    "with the local rank's primary pool only, with no "
+                    "coordination across ranks.")
+
+            if self.max_beam_width > 1:
+                raise NotImplementedError(
+                    "KV Cache Connector is not supported with beam search "
+                    "(max_beam_width > 1). The connector's per-request block "
+                    "list has no notion of beams, so non-leading beams would "
+                    "save and restore the wrong KV state.")
+
+            if self.enable_attention_dp:
+                raise NotImplementedError(
+                    "KV Cache Connector is not supported with attention data "
+                    "parallelism (enable_attention_dp). Dummy requests "
+                    "inserted for cross-DP balancing flow through the "
+                    "connector scheduler / worker hooks and are not "
+                    "distinguished from real requests.")
 
             kv_cache_config = getattr(self.llm_args, 'kv_cache_config', None)
             if kv_cache_config is not None and kv_cache_config.host_cache_size:
@@ -661,6 +678,22 @@ class PyExecutor:
             if self.kv_cache_manager is None:
                 raise ValueError(
                     "KV Cache Connector requires a KV Cache Manager.")
+
+            if getattr(self.kv_cache_manager, 'is_vswa', False):
+                raise NotImplementedError(
+                    "KV Cache Connector is not supported with variable "
+                    "sliding-window attention (per-layer max_attention_window "
+                    "with more than one distinct window size). The connector "
+                    "is registered with a single primary pool, but VSWA "
+                    "models allocate one pool per window size.")
+
+            if isinstance(self.kv_cache_manager, BaseMambaCacheManager):
+                raise NotImplementedError(
+                    "KV Cache Connector is not supported with Mamba / hybrid "
+                    "linear-attention models. Mamba layers carry SSM state "
+                    "rather than per-token KV blocks, so the connector's "
+                    "per-layer load/save hooks have nothing meaningful to "
+                    "transfer for those layers.")
 
             kv_tensor = self.kv_cache_manager.get_unique_primary_pool()
             self.kv_connector_manager.worker.register_kv_caches(kv_tensor)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -647,6 +647,17 @@ class PyExecutor:
                     "KV Cache Connector is not supported with pipeline parallelism."
                 )
 
+            kv_cache_config = getattr(self.llm_args, 'kv_cache_config', None)
+            if kv_cache_config is not None and kv_cache_config.host_cache_size:
+                raise NotImplementedError(
+                    "KV Cache Connector is not supported with KV cache host "
+                    "offloading (KvCacheConfig.host_cache_size). The connector "
+                    "worker is only registered with the primary (GPU) pool and "
+                    "cannot read or write blocks that have been evicted to the "
+                    "secondary (host) pool, and the connector's load/save "
+                    "streams are not synchronized with the internal "
+                    "onboard/offload streams.")
+
             if self.kv_cache_manager is None:
                 raise ValueError(
                     "KV Cache Connector requires a KV Cache Manager.")

--- a/tests/integration/defs/llmapi/test_llm_api_connector.py
+++ b/tests/integration/defs/llmapi/test_llm_api_connector.py
@@ -543,17 +543,37 @@ def test_connector_priorities_default(enforce_single_worker,
 
 
 @pytest.mark.threadleak(enabled=False)
-def test_connector_rejects_host_offloading(enforce_single_worker,
-                                           model_with_connector):
-    # The connector worker is only registered with the primary (GPU) pool, so
-    # combining it with host offloading would silently mishandle blocks that
-    # have been evicted to the secondary pool. Until that's wired up, the
-    # combination must fail loudly at construction time.
+@pytest.mark.parametrize(
+    "llm_kwargs,match",
+    [
+        pytest.param(
+            dict(kv_cache_config=KvCacheConfig(free_gpu_memory_fraction=0.1,
+                                               host_cache_size=1024**3)),
+            "host",
+            id="host_offloading",
+        ),
+        pytest.param(
+            dict(max_beam_width=2),
+            "beam",
+            id="beam_search",
+        ),
+        pytest.param(
+            dict(enable_attention_dp=True),
+            "attention data parallelism",
+            id="attention_dp",
+        ),
+    ],
+)
+def test_connector_rejects_unsupported_config(enforce_single_worker,
+                                              model_with_connector, llm_kwargs,
+                                              match):
+    # Configurations the connector cannot handle today must fail loudly at
+    # construction time rather than silently miscompute. This pins the set of
+    # constructor-time exclusions in `_maybe_init_kv_connector_manager`.
     model_fn, _, _ = model_with_connector
 
-    with pytest.raises(NotImplementedError, match="host"):
-        model_fn(kv_cache_config=KvCacheConfig(free_gpu_memory_fraction=0.1,
-                                               host_cache_size=1024**3))
+    with pytest.raises(NotImplementedError, match=match):
+        model_fn(**llm_kwargs)
 
 
 @pytest.mark.threadleak(enabled=False)

--- a/tests/integration/defs/llmapi/test_llm_api_connector.py
+++ b/tests/integration/defs/llmapi/test_llm_api_connector.py
@@ -543,6 +543,20 @@ def test_connector_priorities_default(enforce_single_worker,
 
 
 @pytest.mark.threadleak(enabled=False)
+def test_connector_rejects_host_offloading(enforce_single_worker,
+                                           model_with_connector):
+    # The connector worker is only registered with the primary (GPU) pool, so
+    # combining it with host offloading would silently mishandle blocks that
+    # have been evicted to the secondary pool. Until that's wired up, the
+    # combination must fail loudly at construction time.
+    model_fn, _, _ = model_with_connector
+
+    with pytest.raises(NotImplementedError, match="host"):
+        model_fn(kv_cache_config=KvCacheConfig(free_gpu_memory_fraction=0.1,
+                                               host_cache_size=1024**3))
+
+
+@pytest.mark.threadleak(enabled=False)
 def test_connector_e2e_persistent_cache(enforce_single_worker):
     """Test e2e KV cache connector using PersistentKvCacheConnector from examples.
 

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -142,7 +142,9 @@ l0_a10:
   - llmapi/test_llm_api_connector.py::test_connector_multi_request
   - llmapi/test_llm_api_connector.py::test_connector_priorities
   - llmapi/test_llm_api_connector.py::test_connector_priorities_default
-  - llmapi/test_llm_api_connector.py::test_connector_rejects_host_offloading
+  - llmapi/test_llm_api_connector.py::test_connector_rejects_unsupported_config[host_offloading]
+  - llmapi/test_llm_api_connector.py::test_connector_rejects_unsupported_config[beam_search]
+  - llmapi/test_llm_api_connector.py::test_connector_rejects_unsupported_config[attention_dp]
   - llmapi/test_llm_api_connector.py::test_connector_e2e_persistent_cache
   # third-party policy checks CPU-only
   - thirdparty/test_cmake_third_party.py::test_cmake_listfiles

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -142,6 +142,7 @@ l0_a10:
   - llmapi/test_llm_api_connector.py::test_connector_multi_request
   - llmapi/test_llm_api_connector.py::test_connector_priorities
   - llmapi/test_llm_api_connector.py::test_connector_priorities_default
+  - llmapi/test_llm_api_connector.py::test_connector_rejects_host_offloading
   - llmapi/test_llm_api_connector.py::test_connector_e2e_persistent_cache
   # third-party policy checks CPU-only
   - thirdparty/test_cmake_third_party.py::test_cmake_listfiles


### PR DESCRIPTION
## Summary

The KV connector contract has a number of implicit assumptions that the rest of `PyExecutor` can violate without any runtime check today, leading to silent miscompute. This PR adds an explicit `NotImplementedError` block in `_maybe_init_kv_connector_manager` for every configuration the connector cannot currently service correctly.

### Configurations now rejected at construction time

| Config | Reason |
|---|---|
| `KvCacheConfig.host_cache_size > 0` | Connector worker is registered only with the primary (GPU) pool via `kv_cache_manager.get_unique_primary_pool()` and has no view of the secondary (host) pool. Block ids handed to `update_state_after_alloc` / `request_finished` may already point to blocks evicted to host. The connector's load/save also runs on the forward stream while `KvCacheTransferManager` uses its own onboard/offload streams, so there's no synchronization between the two. |
| `pp_size > 1` **or** `cp_size > 1` | Pool registration is per-rank with no cross-rank coordination. The previous PP-only guard is generalized to PP **or** CP. |
| `max_beam_width > 1` | `RequestData.block_ids` in the connector contract has no notion of beams, so non-leading beams would save and restore the wrong KV state. |
| `enable_attention_dp` | Dummy requests inserted for cross-DP balancing flow through the connector scheduler/worker hooks indistinguishably from real requests. |
| VSWA (`KVCacheManager.is_vswa`) | The connector is registered with a single primary pool, but VSWA models allocate one pool per window size. Today this surfaces as a low-level C++ assertion in `KVCacheManager::getUniquePrimaryPool` (`getWindowSizesMetadata().size() == 1`); this PR surfaces it as a friendly `NotImplementedError` at the same place we reject the others. |
| `BaseMambaCacheManager` instances (Mamba / hybrid linear attention) | Mamba layers carry SSM state rather than per-token KV blocks, so the per-`DecoderLayer` load/save hooks have nothing meaningful to transfer. |

### Already covered elsewhere — no new guard added

- **Cross-attention / encoder-decoder.** Hard-blocked at the resource-manager level via `assert is_cross_attention is False` in `KVCacheManager._calculate_blocks_per_window` (resource_manager.py). The connector cannot reach a cross-attention setup, so a duplicate guard would be dead code.
- **`MambaHybridCacheManager` for Nemotron-Hybrid.** Already raises `NotImplementedError` at cache-manager construction (`_util.py`). The new `BaseMambaCacheManager` `isinstance` check generalizes this to any current/future Mamba manager and gives a uniform diagnostic with the other connector exclusions.

### What is *not* changed

- `enable_block_reuse` — the connector contract is built around it via `get_num_new_matched_tokens` adding on top of on-device reuse; existing tests cover it.
- `enable_chunked_prefill`, overlap scheduler, KV cache transceiver — already covered by dedicated connector tests; no behavioral change.
- LoRA / PEFT, guided decoding, CUDA graphs, MTP-Eagle in-place spec — orthogonal to KV layout.

The longer-term fix (extending the connector contract so the cache manager guarantees onboarding before connector save / no offload during connector load, plumbing per-tier pool tensors and beam/DP-aware metadata through `register_kv_caches` / `build_connector_meta`, etc.) is left for follow-up. This PR just stops the silent-misuse paths.

## Test plan

- [x] `tests/integration/defs/llmapi/test_llm_api_connector.py::test_connector_rejects_unsupported_config[host_offloading]`
- [x] `tests/integration/defs/llmapi/test_llm_api_connector.py::test_connector_rejects_unsupported_config[beam_search]`
- [x] `tests/integration/defs/llmapi/test_llm_api_connector.py::test_connector_rejects_unsupported_config[attention_dp]`
- [x] All three parametrized cases registered in `tests/integration/test_lists/test-db/l0_a10.yml`.
- VSWA, Mamba and CP are detected via state that requires either a specific model checkpoint (VSWA, Mamba) or distributed setup (CP), so they are guarded by code review rather than a parametrized test in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->