### PR TITLE
[https://nvbugs/6094066][fix] Skip Qwen3 skip-softmax on low-memory GPUs

### DIFF
--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -4768,7 +4768,8 @@ class TestQwen3_30B_A3B_Instruct_2507(LlmapiAccuracyTestHarness):
     MODEL_NAME = "Qwen3/Qwen3-30B-A3B-Instruct-2507"
     MODEL_PATH = f"{llm_models_root()}/{MODEL_NAME}"
 
-    @skip_pre_hopper
+    @skip_pre_blackwell
+    @pytest.mark.skip_less_device_memory(140000)
     @parametrize_with_ids("fp8kv", [False, True])
     @pytest.mark.parametrize(
         "target_sparsity,thr_prefill,thr_decode",

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -336,7 +336,6 @@ accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[bf16-1-tr
 accuracy/test_llm_api_autodeploy.py::TestGLM4Flash::test_auto_dtype[trtllm-True] SKIP (https://nvbugs/6093713)
 accuracy/test_llm_api_autodeploy.py::TestGLM4Flash::test_auto_dtype[trtllm-False] SKIP (https://nvbugs/6093713)
 accuracy/test_llm_api_pytorch.py::TestQwen3NextInstruct::test_bf16_4gpu[tp4ep4_cudagraph_overlap_adp_on] SKIP (https://nvbugs/6094068)
-accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention[target_sparsity_0.9-fp8kv=True] SKIP (https://nvbugs/6094066)
 accuracy/test_llm_api_autodeploy.py::TestModelRegistryAccuracy::test_autodeploy_from_registry[nvidia_Llama-3.1-8B-Instruct-NVFP4-True] SKIP (https://nvbugs/6093715)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_4gpus[tp4-mtp_nextn=0-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=True-sampler_async_worker=False] SKIP (https://nvbugs/6084447)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_4gpus[tp4-mtp_nextn=0-fp8kv=True-attention_dp=True-cuda_graph=True-overlap_scheduler=True-torch_compile=False-sampler_async_worker=False] SKIP (https://nvbugs/6084447)


### PR DESCRIPTION
## Description
- Skip `TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention` on pre-Blackwell GPUs.
- Add a `skip_less_device_memory(140000)` guard so low-memory GPUs do not try this Qwen3 30B skip-softmax case.
- Remove the now-stale `waives.txt` entry for the same target test so B200 can run it instead of being waived.
- Use a 140GB requirement based on BF16 model weights plus runtime overhead from CUDA/NCCL/cuBLAS, MoE activation peaks, MoE GEMM profiling workspace, warmup, and KV overlap.

## Validation
- `git diff --check origin/main...HEAD`
- `git commit -s --amend --no-edit` pre-commit hooks passed after the `waives.txt` cleanup
- Computelab B200: target reached runtime/model execution and observed about 60GB GPU memory before hitting environment issues unrelated to this skip marker (`flashinfer`/NVRTC `cuda.h` include setup); no OOM observed.
- OCI GB200 `batch`, `qos=short`, 2h: source build/import succeeded on GB200, pytest collection selected the target test and did not skip it with the 140GB guard. The target then failed at model loading because OCI model shards for `Qwen3/Qwen3-30B-A3B-Instruct-2507` are Git LFS pointer files, not real safetensors; no OOM observed.

NVBug: https://nvbugs/6094066
