### PR TITLE
[TRTLLM-12358][chore] Dedup multimodal unit tests on B200

### DIFF
--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -118,12 +118,10 @@ l0_b200:
   # ------------- MoE: FlashInfer & TRTLLM symbol collision tests ---------------
   - unittest/_torch/flashinfer/test_trtllm_flashinfer_symbol_collision.py
   # --- MoE end
-  - unittest/_torch/multimodal/test_mm_encoder_standalone.py
-  - unittest/_torch/multimodal/test_multimodal_runtime.py
-  - unittest/_torch/multimodal/test_find_num_image_tokens.py
-  - unittest/_torch/multimodal/test_fuse_input_embeds.py
-  - unittest/_torch/multimodal/test_external_embedding.py
-  - unittest/_torch/multimodal/test_share_multiparams.py
+  # B-tier only runs the FP8 MoE parametrize (DEEPGEMM path is SM100-only via
+  # _get_moe_config_for_blackwell); dense bf16 variants are covered on Hopper.
+  # The other 5 multimodal files are HW-agnostic Python plumbing and run on Hopper only.
+  - unittest/_torch/multimodal/test_mm_encoder_standalone.py -k "qwen3_30b_a3b_fp8"
   - unittest/_torch/sampler
   - unittest/_torch/speculative
   - unittest/_torch/thop/parallel TIMEOUT (90)


### PR DESCRIPTION
### Summary                                                        

- `tests/integration/test_lists/test-db/l0_b200.yml` schedules 6 files under `unittest/_torch/multimodal/` on the DGX_B200 stage. Five of them are pure Python plumbing with no SM-specific code path (`test_multimodal_runtime`, `test_find_num_image_tokens`,  `test_fuse_input_embeds`, `test_external_embedding`, `test_share_multiparams`) and `test_mm_encoder_standalone.py`'s  `model_dir` fixture has 4 parametrize values, of which only `qwen3_30b_a3b_fp8` exercises a Blackwell-only path (FP8 MoE + DEEPGEMM backend, gated by `_get_moe_config_for_blackwell()` →  `get_sm_version() >= 100`). The other three (`llava_7b`,  `qwen2.5_3b`, `qwen3_2b`) are dense bf16 and run identical  kernels on Hopper.                                                      

- Replace the six entries with one line that filters the encoder  test to `unittest/_torch/multimodal/test_mm_encoder_standalone.py -k "qwen3_30b_a3b_fp8"`.                                             

- Coverage is preserved on Hopper: `l0_h100.yml:44` runs the whole `unittest/_torch/multimodal` directory, so the five dropped files and the dense bf16 parametrize variants are still exercised.

- **Savings on the DGX_B200 single-GPU PyTorch stage** (90-day OS averages): before ≈ 40.4 min/run (37.1 + 0.4 + 1.8 + 0.4 + 0.4 + 0.4); after ≈ 5.9 min/run (3 FP8 tests). **~33 min/PR saved on this stage.**  



@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
