### PR TITLE
[TRTLLM-12297][fix] Multimodal hash for VideoData ignores extracted audio, breaks KV reuse

### DIFF
--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -629,14 +629,16 @@ def apply_mm_hashes(
                 if isinstance(frame, torch.Tensor):
                     frame = frame.detach().cpu().contiguous()
                 hasher.update(serialize_item(frame))
-            # TODO(TRTLLM-12297): also fold metadata["audio_samples"] /
-            # metadata["audio_sample_rate"] into the hash when present.
-            # extract_audio=true makes audio affect token counts and
-            # embeddings (see modeling_nemotron_nano.py
-            # _expand_video_placeholders_in_token_ids and
-            # get_num_tokens_per_video), but two videos with identical
-            # frames and different audio currently share the same MM hash —
-            # KV-cache reuse can return stale audio-conditioned states.
+            metadata = item.metadata
+            if (isinstance(metadata, dict) and "audio_samples" in metadata
+                    and "audio_sample_rate" in metadata):
+                audio_samples = metadata["audio_samples"]
+                if isinstance(audio_samples, torch.Tensor):
+                    audio_samples = audio_samples.detach().cpu().contiguous()
+                hasher.update(b"<audio>")
+                hasher.update(
+                    serialize_item(
+                        (audio_samples, metadata["audio_sample_rate"])))
         else:
             hasher.update(serialize_item(item))
 

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -310,6 +310,52 @@ def test_apply_mm_hashes_uuid_content_combined():
         "Different UUID + same content should produce different hashes"
 
 
+def test_apply_mm_hashes_video_audio_metadata_affects_hash():
+    """VideoData hashes include extracted audio when it affects model inputs."""
+    import numpy as np
+    from PIL import Image
+
+    from tensorrt_llm.inputs.multimodal import apply_mm_hashes
+    from tensorrt_llm.inputs.utils import VideoData
+
+    frames = [
+        Image.new("RGB", (2, 2), (10, 20, 30)),
+        Image.new("RGB", (2, 2), (40, 50, 60)),
+    ]
+    audio_a = np.array([0.0, 0.25, -0.5, 1.0], dtype=np.float32)
+    audio_a_copy = audio_a.copy()
+    audio_b = np.array([0.0, 0.25, -0.5, -1.0], dtype=np.float32)
+
+    def make_video(audio_samples=None, sample_rate=16000):
+        metadata = {}
+        if audio_samples is not None:
+            metadata = {
+                "audio_samples": audio_samples,
+                "audio_sample_rate": sample_rate,
+            }
+        return VideoData(frames=frames, metadata=metadata)
+
+    hashes_a, _ = apply_mm_hashes({"video": [make_video(audio_a)]})
+    hashes_a_copy, _ = apply_mm_hashes({"video": [make_video(audio_a_copy)]})
+    hashes_b, _ = apply_mm_hashes({"video": [make_video(audio_b)]})
+    hashes_a_different_rate, _ = apply_mm_hashes(
+        {"video": [make_video(audio_a, sample_rate=8000)]})
+    hashes_no_audio, _ = apply_mm_hashes({"video": [make_video()]})
+    hashes_frame_list, _ = apply_mm_hashes({"video": [frames]})
+
+    assert hashes_a["video"][0] == hashes_a_copy["video"][0]
+    assert hashes_a["video"][0] != hashes_b["video"][0]
+    assert hashes_a["video"][0] != hashes_a_different_rate["video"][0]
+    assert hashes_no_audio["video"][0] == hashes_frame_list["video"][0]
+
+    mm_uuids = {"video": ["shared-video-id"]}
+    hashes_uuid_a, _ = apply_mm_hashes({"video": [make_video(audio_a)]},
+                                       mm_uuids)
+    hashes_uuid_b, _ = apply_mm_hashes({"video": [make_video(audio_b)]},
+                                       mm_uuids)
+    assert hashes_uuid_a["video"][0] != hashes_uuid_b["video"][0]
+
+
 def test_int32_hexdigest_roundtrip():
     """Test that hexdigest_to_int32 and int32_to_hexdigest are inverses."""
     from tensorrt_llm.inputs.multimodal import (hexdigest_to_int32,

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -1,7 +1,9 @@
 import asyncio
 import time
 
+import numpy as np
 import pytest
+from PIL import Image
 from utils.util import skip_single_gpu
 
 import tensorrt_llm
@@ -11,6 +13,8 @@ from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._utils import KVCacheEventSerializer
 from tensorrt_llm.bindings.internal.testing import \
     simulate_prefill_completion_only_use_for_testing
+from tensorrt_llm.inputs.multimodal import apply_mm_hashes
+from tensorrt_llm.inputs.utils import VideoData
 from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.sampling_params import SamplingParams
@@ -312,12 +316,6 @@ def test_apply_mm_hashes_uuid_content_combined():
 
 def test_apply_mm_hashes_video_audio_metadata_affects_hash():
     """VideoData hashes include extracted audio when it affects model inputs."""
-    import numpy as np
-    from PIL import Image
-
-    from tensorrt_llm.inputs.multimodal import apply_mm_hashes
-    from tensorrt_llm.inputs.utils import VideoData
-
     frames = [
         Image.new("RGB", (2, 2), (10, 20, 30)),
         Image.new("RGB", (2, 2), (40, 50, 60)),


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed audio extraction from videos during asynchronous loading operations
  * Enhanced consistency of multimodal token position detection

* **New Features**
  * Added audio metadata support for improved video processing
  * Improved token expansion and counting for multimodal content (images, videos, audio)

* **Improvements**
  * Strengthened validation for video processing operations to ensure consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

When `--media_io_kwargs '{"video": {"extract_audio": true'}}` is set, the video loader writes audio samples into `VideoData.metadata["audio_samples"]`, and Nemotron Nano V3 Omni now consumes those samples to produce additional `<so_*>` placeholder tokens and audio embeddings interleaved per video.

However, `_hash_content` in `tensorrt_llm/inputs/multimodal.py` hashes only `VideoData.frames` and ignores `metadata["audio_samples"]` / `metadata["audio_sample_rate"]`, so two requests with identical sampled frames but different audio share the same multimodal hash. With KV-cache reuse enabled, the second request can return stale audio-conditioned states from the first; the fix is to extend `_hash_content` for `VideoData` to fold audio samples and sample rate into the hash when present.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
