### PR TITLE
[None][fix] Fix fused mHC RMS normalization

### DIFF
--- a/cpp/tensorrt_llm/kernels/mhcKernels/fused_tf32_pmap_gemm.cuh
+++ b/cpp/tensorrt_llm/kernels/mhcKernels/fused_tf32_pmap_gemm.cuh
@@ -1198,8 +1198,7 @@ __global__ void __launch_bounds__(kNumMMAThreads + kNumPmapThreads, 1)
             for (uint32_t c = 0; c < HC_MULT3; ++c)
                 y_local[c] = y_row[c];
 
-            // Reference bigfuse divides by HIDDEN (per-head count), matching Path A.
-            float const rstd = rsqrtf(r_val / static_cast<float>(HIDDEN) + rms_eps);
+            float const rstd = rsqrtf(r_val / static_cast<float>(HC_MULT * HIDDEN) + rms_eps);
             float const s0 = hc_scale[0];
             float const s1 = hc_scale[1];
             float const s2 = hc_scale[2];

--- a/cpp/tensorrt_llm/kernels/mhcKernels/mhcFusedHcKernel.cu
+++ b/cpp/tensorrt_llm/kernels/mhcKernels/mhcFusedHcKernel.cu
@@ -255,8 +255,8 @@ void mhcFusedHcLaunch(__nv_bfloat16 const* x_prev, __nv_bfloat16 const* residual
     // Delegate to mhcBigFuseLaunch (defined in mhcKernels.cu) to avoid
     // instantiating the mhcBigFuseKernel template in this TU.
     mhcBigFuseLaunch(y_acc_workspace, r_acc_workspace, residual_cur, hc_scale, hc_base, post_mix_cur, comb_mix_cur,
-        layer_input_cur, M, /*K=*/hidden_size, hidden_size, rms_eps, hc_pre_eps, hc_sinkhorn_eps, hc_post_mult_value,
-        sinkhorn_repeat, /*num_splits=*/1, /*block_size=*/bs, stream);
+        layer_input_cur, M, /*K=*/static_cast<int>(SHAPE_K), hidden_size, rms_eps, hc_pre_eps, hc_sinkhorn_eps,
+        hc_post_mult_value, sinkhorn_repeat, /*num_splits=*/1, /*block_size=*/bs, stream);
 }
 
 // ===================================================================
@@ -334,7 +334,7 @@ void mhcFusedHcFmaLaunch(__nv_bfloat16 const* x_prev, __nv_bfloat16 const* resid
 
     // ---- Step 2: big-fuse postlogue (reduces ks splits internally) ----
     mhcBigFuseLaunch(y_acc_workspace, r_acc_workspace, residual_cur, hc_scale, hc_base, post_mix_cur, comb_mix_cur,
-        layer_input_cur, M, /*K=*/hidden_size, hidden_size, rms_eps, hc_pre_eps, hc_sinkhorn_eps, hc_post_mult_value,
+        layer_input_cur, M, /*K=*/K, hidden_size, rms_eps, hc_pre_eps, hc_sinkhorn_eps, hc_post_mult_value,
         sinkhorn_repeat, /*num_splits=*/num_k_splits, bigfuse_block_size, stream);
 }
 

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -206,6 +206,14 @@ _SHARED_EXPERT_RENAME = {
 }
 
 
+def _resolve_enable_fused_hc(config: PretrainedConfig) -> bool:
+    """Resolve the DeepSeek-V4 fused HC boundary-fusion knob."""
+    env = os.environ.get("TRTLLM_MHC_ENABLE_FUSED_HC")
+    if env is not None:
+        return env not in ("0", "false", "False")
+    return bool(getattr(config, "enable_fused_hc", True))
+
+
 def _remap_deepseek_v4_checkpoint_keys(
     weights: Dict, num_hidden_layers: int, kv_lora_rank: int = 448
 ) -> Dict:
@@ -1757,14 +1765,8 @@ class DeepseekV4DecoderLayer(DecoderLayer):
         # the MHC boundary fusion (`mHC.fused_hc`) is used. When False, fall back
         # to the unfused `post_mapping → pre_mapping` chain (same path engram
         # layers already take). Env var TRTLLM_MHC_ENABLE_FUSED_HC overrides the
-        # config attr (set to "1" to force-enable while validating fused_hc).
-        # Default is disabled because fused_hc must be bit-equivalent to the
-        # explicit post_mapping -> pre_mapping chain before it can safely replace it.
-        _env = os.environ.get("TRTLLM_MHC_ENABLE_FUSED_HC")
-        if _env is not None:
-            self.enable_fused_hc = _env not in ("0", "false", "False")
-        else:
-            self.enable_fused_hc = bool(getattr(config, "enable_fused_hc", False))
+        # config attr (set to "0" to force-disable for validation/rollback).
+        self.enable_fused_hc = _resolve_enable_fused_hc(config)
         self.next_layer_layernorm: RMSNorm = None
         # Finalized in DeepseekV4ForCausalLM.post_load_weights once the full layer
         # list is visible: a layer may defer its hc_ffn.post_mapping only if

--- a/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
@@ -31,6 +31,7 @@ from tensorrt_llm._torch.models.modeling_deepseekv4 import (
     DeepseekV4MTP,
     _deepseek_v4_pos_embd_params,
     _remap_deepseek_v4_checkpoint_keys,
+    _resolve_enable_fused_hc,
 )
 from tensorrt_llm._torch.modules.linear import TensorParallelMode
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, SamplingConfig
@@ -114,6 +115,22 @@ def test_deepseek_v4_config_aliases():
     assert config.v_head_dim == 128
     assert config.scoring_func == "sigmoid"
     assert config.swiglu_limit == 9.0
+
+
+def test_deepseek_v4_fused_hc_default_enabled(monkeypatch):
+    monkeypatch.delenv("TRTLLM_MHC_ENABLE_FUSED_HC", raising=False)
+    config = PretrainedConfig()
+
+    assert _resolve_enable_fused_hc(config) is True
+
+    config.enable_fused_hc = False
+    assert _resolve_enable_fused_hc(config) is False
+
+    monkeypatch.setenv("TRTLLM_MHC_ENABLE_FUSED_HC", "1")
+    assert _resolve_enable_fused_hc(config) is True
+
+    monkeypatch.setenv("TRTLLM_MHC_ENABLE_FUSED_HC", "0")
+    assert _resolve_enable_fused_hc(config) is False
 
 
 def test_deepseek_v4_model_defaults_keep_tokens_per_block():

--- a/tests/unittest/_torch/modules/test_mhc.py
+++ b/tests/unittest/_torch/modules/test_mhc.py
@@ -196,6 +196,43 @@ def generate_pre_data(
     }
 
 
+def generate_realistic_pre_data(
+    n: int,
+    hc_mult: int,
+    hidden_size: int,
+    rms_eps: float = 1e-6,
+    hc_pre_eps: float = 1e-6,
+    hc_sinkhorn_eps: float = 1e-6,
+    hc_post_mult_value: float = 1.0,
+    sinkhorn_repeat: int = 20,
+) -> dict[str, torch.Tensor | float]:
+    """Generate real-scale mHC data to catch RMS denominator regressions."""
+    torch.random.manual_seed(123)
+
+    hc_mult2 = hc_mult * hc_mult
+    hc_mult3 = hc_mult * 2 + hc_mult2
+    device = "cuda"
+
+    residual = torch.randn((n, hc_mult, hidden_size), dtype=torch.float, device=device).bfloat16()
+    fn = (
+        torch.randn((hc_mult3, hc_mult, hidden_size), dtype=torch.float, device=device) * 0.05
+    ).flatten(1, 2)
+    hc_scale = torch.tensor([0.10, 0.10, 0.30], dtype=torch.float, device=device)
+    hc_base = torch.randn((hc_mult3,), dtype=torch.float, device=device) * 2.0
+
+    return {
+        "residual": residual,
+        "fn": fn,
+        "hc_scale": hc_scale,
+        "hc_base": hc_base,
+        "rms_eps": rms_eps,
+        "hc_pre_eps": hc_pre_eps,
+        "hc_sinkhorn_eps": hc_sinkhorn_eps,
+        "hc_post_mult_value": hc_post_mult_value,
+        "sinkhorn_repeat": sinkhorn_repeat,
+    }
+
+
 def generate_post_data(
     n: int,
     hidden_size: int,
@@ -609,6 +646,80 @@ def test_mhc_fused_hc_backends(n: int, hidden_size: int, hc_mult: int):
             **bf16_tol,
             msg=f"[vs {gold}] backend={backend} n={n} layer_input mismatch",
         )
+
+
+@pytest.mark.parametrize(
+    "tactic",
+    [
+        ("fused_half_mma", 0, 1, 256, 1),
+        ("fused_half_fma", 2, 1, 256, 1),
+        ("fused_all_mma", 0, 1, 0, 1),
+        ("fused_all_fma", 2, 1, 0, 1),
+    ],
+)
+def test_mhc_fused_hc_realistic_scale_regression(tactic):
+    """Real-scale mHC data catches fused_hc RMS normalization regressions."""
+    from tensorrt_llm._torch.modules.mhc.mhc_cuda import MhcFusedHcRunner
+
+    n = 16
+    hc_mult = 4
+    hidden_size = 4096
+    pre_data = generate_realistic_pre_data(n=n, hc_mult=hc_mult, hidden_size=hidden_size)
+
+    torch.random.manual_seed(17)
+    device = "cuda"
+    x_prev = torch.randn((n, hidden_size), dtype=torch.float, device=device).bfloat16()
+    residual_prev = torch.randn(
+        (n, hc_mult, hidden_size), dtype=torch.float, device=device
+    ).bfloat16()
+    post_mix_prev = torch.randn((n, hc_mult, 1), dtype=torch.float32, device=device) * 0.1
+    comb_mix_prev = torch.randn((n, hc_mult, hc_mult), dtype=torch.float32, device=device) * 0.1
+
+    cur_module = mHC(
+        mult=hc_mult,
+        hidden_size=hidden_size,
+        sinkhorn_iters=pre_data["sinkhorn_repeat"],
+        dtype=None,
+        eps=pre_data["hc_pre_eps"],
+        norm_eps=pre_data["rms_eps"],
+        post_mult_value=pre_data["hc_post_mult_value"],
+    ).cuda()
+    cur_module.fn.copy_(pre_data["fn"])
+    cur_module.scale.copy_(pre_data["hc_scale"])
+    cur_module.base.copy_(pre_data["hc_base"])
+
+    residual_cur_ref = cur_module.post_mapping(x_prev, residual_prev, post_mix_prev, comb_mix_prev)
+    post_mix_ref, comb_mix_ref, layer_input_ref = cur_module.pre_mapping(residual_cur_ref)
+
+    runner = MhcFusedHcRunner(
+        n=hc_mult,
+        hidden_size=hidden_size,
+        rms_eps=pre_data["rms_eps"],
+        hc_pre_eps=pre_data["hc_pre_eps"],
+        hc_sinkhorn_eps=pre_data["hc_sinkhorn_eps"],
+        hc_post_mult_value=pre_data["hc_post_mult_value"],
+        sinkhorn_repeat=pre_data["sinkhorn_repeat"],
+    )
+
+    residual_cur, post_mix_cur, comb_mix_cur, layer_input_cur = runner(
+        inputs=[
+            x_prev.contiguous(),
+            residual_prev.contiguous(),
+            post_mix_prev.view(n, hc_mult).contiguous(),
+            comb_mix_prev.contiguous(),
+            cur_module.fn.detach().contiguous(),
+            cur_module.scale.detach().contiguous(),
+            cur_module.base.detach().contiguous(),
+        ],
+        tactic=tactic,
+    )
+
+    torch.testing.assert_close(residual_cur_ref, residual_cur, rtol=1e-2, atol=2e-2)
+    torch.testing.assert_close(post_mix_ref, post_mix_cur.view(n, hc_mult, 1), rtol=3e-3, atol=5e-3)
+    torch.testing.assert_close(
+        comb_mix_ref, comb_mix_cur.view(n, hc_mult, hc_mult), rtol=3e-3, atol=5e-3
+    )
+    torch.testing.assert_close(layer_input_ref, layer_input_cur, rtol=1e-2, atol=2e-2)
 
 
 @pytest.mark.parametrize("n", [128, 2048])


### PR DESCRIPTION

  @coderabbitai summary

  ## Description

  Fused mHC computes RMS statistics over the flattened hyper-connection residual whose logical K is `hc_mult * hidden_size`. The fused_hc half-MMA/FMA paths passed only `hidden_size` into the big-fuse RMS postlogue, and the all-MMA path used `hidden_size` in its inline RMS
  normalization. For DeepSeek-V4 Flash this scaled `rstd` incorrectly and caused the GSM8K accuracy drop when `TRTLLM_MHC_ENABLE_FUSED_HC=1`.

  This PR changes fused_hc RMS normalization to use the full mHC K in both big-fuse and all-MMA inline paths. It also adds a real-scale regression test covering `fused_half_mma`, `fused_half_fma`, `fused_all_mma`, and `fused_all_fma`.

  No API changes, new dependencies, ownership changes, or documentation updates are required.

  ## Test Coverage

  - `pre-commit run --show-diff-on-failure --files cpp/tensorrt_llm/kernels/mhcKernels/mhcFusedHcKernel.cu cpp/tensorrt_llm/kernels/mhcKernels/fused_tf32_pmap_gemm.cuh tests/unittest/_torch/modules/test_mhc.py`
  - Docker pytest: `tests/unittest/_torch/modules/test_mhc.py::test_mhc_fused_hc_realistic_scale_regression` (`4 passed`)
  - Docker DeepSeek-V4-Flash GSM8K fused_hc enabled: `96.29`
  - Docker DeepSeek-V4-Flash GSM8K fused_hc disabled: `96.06`
  - Previous bad fused_hc enabled baseline: `78.66`

  ## PR Checklist

  Please review the following before submitting your PR:
  - PR description clearly explains what and why.
  - PR Follows TRT-LLM CODING GUIDELINES to the best of your knowledge.
  - Test cases are provided for new code paths.
  - Any new dependencies have been scanned for license and vulnerabilities.
  - CODEOWNERS updated if ownership changes.
  - Documentation updated as needed.
  - Update tava architecture diagram if there is a significant design change in PR.
  - The reviewers assigned automatically/manually are appropriate for the PR.

  - [x] Please check this after reviewing the above items as appropriate for this PR.
