### PR TITLE
[TRTLLM-12111][feat] Add V2 KV cache event support

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1229,6 +1229,12 @@ class PyTorchModelEngine(ModelEngine):
         if requests is None:
             return None
 
+        def free_warmup_requests() -> None:
+            for r in requests:
+                kv_cache_manager.free_resources(r)
+                if draft_kv_cache_manager is not None:
+                    draft_kv_cache_manager.free_resources(r)
+
         # Add one dummy request with the maximum possible sequence length.
         max_seq_len = min(
             self.max_seq_len if max_seq_len is None else max_seq_len,
@@ -1247,11 +1253,13 @@ class PyTorchModelEngine(ModelEngine):
                 max_num_draft_tokens=draft_len)
             available_tokens = min(available_tokens, draft_available_tokens)
 
-        token_num = max(
-            1,
-            min(
-                available_tokens, max_seq_len - 1 -
-                get_num_extra_kv_tokens(self.spec_config) - draft_len))
+        token_num = min(
+            available_tokens, max_seq_len - 1 -
+            get_num_extra_kv_tokens(self.spec_config) - draft_len)
+        if token_num <= 0:
+            free_warmup_requests()
+            return None
+        token_num = max(1, token_num)
         model_config = self.model.model_config.pretrained_config
         max_position_embeddings = getattr(model_config,
                                           'max_position_embeddings', None)
@@ -1274,8 +1282,7 @@ class PyTorchModelEngine(ModelEngine):
             draft_kv_cache_manager=draft_kv_cache_manager)
 
         if max_seq_len_request is None:
-            for r in requests:
-                kv_cache_manager.free_resources(r)
+            free_warmup_requests()
             return None
         else:
             max_seq_len_request = max_seq_len_request[0]

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -38,6 +38,9 @@ from tensorrt_llm.llmapi.llm_args import KvCacheConfig, PeftCacheConfig
 from tensorrt_llm.lora_helper import LoraConfig
 from tensorrt_llm.lora_manager import LoraManager, LoraModelConfig
 from tensorrt_llm.runtime import ModelConfig as ModelConfigPython
+from tensorrt_llm.runtime.kv_cache_hash import (
+    KV_CACHE_HASH_ALGO_AUTO, KV_CACHE_HASH_ALGO_V1,
+    get_effective_kv_cache_event_hash_algo)
 
 # isort: off
 from tensorrt_llm.runtime.kv_cache_manager_v2 import (
@@ -53,6 +56,8 @@ from tensorrt_llm.runtime.kv_cache_manager_v2 import (LayerId, TokenIdExt,
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import (BAD_PAGE_INDEX,
                                                               GPU_LEVEL)
 from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
+from tensorrt_llm.runtime.kv_cache_manager_v2._event_manager import \
+    KVCacheEventManager
 from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import CuError
 from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import \
     OutOfMemoryError as KVCacheOutOfMemoryError
@@ -86,6 +91,16 @@ TempAttentionWindowInputs = tensorrt_llm.bindings.internal.batch_manager.TempAtt
 BlocksPerWindow = Dict[int, Tuple[
     int,
     int]]  # window_size -> (blocks_in_primary_pool, blocks_in_secondary_pool)
+
+
+def _warn_if_unsupported_v1_kv_cache_event_hash_algo(hash_algo: str) -> None:
+    if hash_algo in (KV_CACHE_HASH_ALGO_AUTO, KV_CACHE_HASH_ALGO_V1):
+        return
+
+    logger.warning(
+        "KV cache manager v1 only supports KV cache event hash algorithm "
+        f"{KV_CACHE_HASH_ALGO_V1}. Ignoring configured hash algorithm "
+        f"{hash_algo}; v1 events will continue to use {KV_CACHE_HASH_ALGO_V1}.")
 
 
 class ResourceManagerType(enum.Enum):
@@ -538,6 +553,8 @@ class KVCacheManager(BaseResourceManager):
         }
 
         if self.event_buffer_max_size > 0:
+            _warn_if_unsupported_v1_kv_cache_event_hash_algo(
+                kv_cache_config.kv_cache_event_hash_algo)
             if mapping.enable_attention_dp:
                 kwargs['event_manager'] = KVCacheEventManagerCpp(
                     max_kv_event_entries=self.event_buffer_max_size,
@@ -1185,7 +1202,7 @@ class KVCacheManager(BaseResourceManager):
     def flush_iteration_events(self):
         self.impl.flush_iteration_events()
 
-    def get_latest_events(self, timeout_ms: Optional[float] = 0):
+    def get_latest_events(self, timeout_ms: Optional[float] = None):
         return self.impl.get_latest_events(timeout_ms)
 
     def get_kv_cache_stats(self):
@@ -1672,8 +1689,10 @@ class KVCacheManagerV2(BaseResourceManager):
         self.max_total_draft_tokens = spec_config.max_total_draft_tokens if spec_config is not None else 0
 
         self.event_buffer_max_size = kv_cache_config.event_buffer_max_size
-
-        assert self.event_buffer_max_size == 0, "event_buffer_max_size must be 0"
+        kv_cache_event_hash_algo = get_effective_kv_cache_event_hash_algo(
+            kv_cache_config.kv_cache_event_hash_algo,
+            use_kv_cache_manager_v2=True,
+        )
 
         self._stream = execution_stream if execution_stream is not None else torch.cuda.current_stream(
         )
@@ -1698,6 +1717,26 @@ class KVCacheManagerV2(BaseResourceManager):
 
         else:
             self.max_attention_window_vec = [None]
+
+        event_window_size = max(
+            self.max_seq_len if window_size is None else int(window_size)
+            for window_size in self.max_attention_window_vec)
+        self.event_manager: Optional[KVCacheEventManager] = None
+        if self.event_buffer_max_size > 0:
+            if mapping.enable_attention_dp:
+                self.event_manager = KVCacheEventManager(
+                    self.event_buffer_max_size,
+                    window_size=event_window_size,
+                    attention_dp_rank=mapping.rank,
+                    attention_dp_gather=Distributed.get(mapping).allgather,
+                    hash_algo=kv_cache_event_hash_algo,
+                )
+            elif mpi_rank() == 0:
+                self.event_manager = KVCacheEventManager(
+                    self.event_buffer_max_size,
+                    window_size=event_window_size,
+                    hash_algo=kv_cache_event_hash_algo,
+                )
 
         if isinstance(num_kv_heads, int):
             self.num_kv_heads_per_layer = [
@@ -1812,7 +1851,8 @@ class KVCacheManagerV2(BaseResourceManager):
         self.kv_cache_manager_py_config = config
 
         try:
-            self.impl = KVCacheManagerPy(config)
+            self.impl = KVCacheManagerPy(config,
+                                         event_manager=self.event_manager)
         except (CuError, KVCacheOutOfMemoryError):
             if len(cache_tiers) > 1:
                 logger.warning(
@@ -1828,10 +1868,21 @@ class KVCacheManagerV2(BaseResourceManager):
                     vocab_size=vocab_size,
                     cache_tiers=cache_tiers_gpu_only,
                 )
+                cache_tiers = cache_tiers_gpu_only
                 self.kv_cache_manager_py_config = config
-                self.impl = KVCacheManagerPy(config)
+                self.impl = KVCacheManagerPy(config,
+                                             event_manager=self.event_manager)
             else:
                 raise
+
+        if self.event_manager is not None:
+            self.event_manager.set_layer_group_window_sizes(
+                self._get_event_window_sizes_by_layer_group())
+            self.event_manager.add_created_event(
+                self._get_event_num_blocks_per_cache_level(
+                    cache_tiers, tokens_per_block),
+                self._get_event_layer_group_ids())
+
         self.num_pools = len(self.impl.layer_grouping)
 
         num_layers = len(config.layers)
@@ -1921,6 +1972,38 @@ class KVCacheManagerV2(BaseResourceManager):
 
     def _get_quota_from_max_tokens(self, max_tokens: int) -> int:
         return int(max_tokens * self.get_cache_bytes_per_token())
+
+    def _get_event_num_blocks_per_cache_level(
+        self,
+        cache_tiers: List[CacheTierConfig],
+        tokens_per_block: int,
+    ) -> List[int]:
+        bytes_per_block = self.get_cache_bytes_per_token() * tokens_per_block
+        if bytes_per_block <= 0:
+            return []
+        return [int(tier.quota // bytes_per_block) for tier in cache_tiers]
+
+    def _get_event_layer_group_ids(self) -> List[int]:
+        return [
+            int(layer_group_id)
+            for layer_group_id in range(len(self.impl.layer_grouping))
+        ]
+
+    def _get_event_window_sizes_by_layer_group(self) -> Dict[int, int]:
+        # Assumes every layer in a group shares the same sliding_window_size,
+        # which is how `impl.layer_grouping` partitions layers today. Only the
+        # first layer's window is read; if the grouping policy ever permits
+        # mixed windows in one group, this needs to fan out per-layer.
+
+        def get_event_window_size(layer_id: int) -> int:
+            window_size = self.kv_cache_manager_py_config.layers[
+                layer_id].sliding_window_size
+            return self.max_seq_len if window_size is None else int(window_size)
+
+        return {
+            int(layer_group_id): get_event_window_size(int(layer_ids[0]))
+            for layer_group_id, layer_ids in enumerate(self.impl.layer_grouping)
+        }
 
     def _build_pool_mapping_tensors(self) -> Tuple[torch.Tensor, torch.Tensor]:
         kv_cache_pool_pointers = torch.tensor([[
@@ -2126,8 +2209,7 @@ class KVCacheManagerV2(BaseResourceManager):
         the next tokens_per_block-aligned boundary.
         """
         draft_len = get_draft_token_length(req)
-        if (draft_len == 0
-                and req.is_disagg_generation_transmission_complete
+        if (draft_len == 0 and req.is_disagg_generation_transmission_complete
                 and req.context_phase_params is not None):
             ctx_draft_tokens = req.context_phase_params.draft_tokens
             if ctx_draft_tokens is not None:
@@ -2343,6 +2425,19 @@ class KVCacheManagerV2(BaseResourceManager):
         kv_cache_stats.allocated_bytes = self.impl.get_quota(GPU_LEVEL)
 
         return kv_cache_stats
+
+    def flush_iteration_events(self):
+        if self.event_manager is not None:
+            self.event_manager.flush_iteration_events()
+
+    def get_latest_events(self, timeout_ms: Optional[float] = None):
+        if self.event_manager is None:
+            return []
+        return self.event_manager.get_latest_events(timeout_ms)
+
+    def get_iteration_stats(self):
+        """V2 does not support per-iteration stats yet."""
+        return None
 
     def get_block_ids_per_seq(self, request_ids: List[int]) -> torch.Tensor:
         block_ids_per_seq = self.get_batch_cache_indices(request_ids)

--- a/tensorrt_llm/_utils.py
+++ b/tensorrt_llm/_utils.py
@@ -1147,6 +1147,12 @@ class KVCacheEventSerializer:
             "data": event_serialize_func(event.data),
             "window_size": event.window_size,
         }
+        hash_algo = getattr(event, "hash_algo", None)
+        if hash_algo is not None:
+            json_str["hash_algo"] = hash_algo
+        layer_group_id = getattr(event, "layer_group_id", None)
+        if layer_group_id is not None:
+            json_str["layer_group_id"] = layer_group_id
         if event.attention_dp_rank is not None:
             json_str["attention_dp_rank"] = event.attention_dp_rank
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2320,6 +2320,16 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         status="prototype",
         description="Whether to use the KV cache manager v2 (experimental).")
 
+    kv_cache_event_hash_algo: Literal[
+        "auto", "v1_block_key", "v2_sha256", "v2_sha256_64"] = Field(
+            default="auto",
+            status="prototype",
+            description=
+            "The block hash algorithm used by KV cache manager events. "
+            "'auto' uses the native hash for each KV cache manager. "
+            "Explicit V2 hash choices are ignored with a warning by the V1 "
+            "KV cache manager.")
+
     max_util_for_resume: float = Field(
         default=0.95,
         ge=0,

--- a/tensorrt_llm/runtime/kv_cache_hash.py
+++ b/tensorrt_llm/runtime/kv_cache_hash.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KV_CACHE_HASH_ALGO_AUTO = "auto"
+KV_CACHE_HASH_ALGO_V1 = "v1_block_key"
+KV_CACHE_HASH_ALGO_V2 = "v2_sha256"
+KV_CACHE_HASH_ALGO_V2_SHA256_64 = "v2_sha256_64"
+KV_CACHE_HASH_ALGO_DEFAULT = KV_CACHE_HASH_ALGO_V1
+
+
+def get_effective_kv_cache_event_hash_algo(hash_algo: str, use_kv_cache_manager_v2: bool) -> str:
+    if hash_algo != KV_CACHE_HASH_ALGO_AUTO:
+        return hash_algo
+    if use_kv_cache_manager_v2:
+        return KV_CACHE_HASH_ALGO_V2
+    return KV_CACHE_HASH_ALGO_V1
+
+
+def truncate_sha256_hash_to_int64(block_hash: bytes) -> int:
+    return int.from_bytes(block_hash[:8], "big", signed=False)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.py
@@ -40,6 +40,17 @@ from ._config import (
     SsmLayerConfig,
 )
 from ._core import DEFAULT_BEAM_INDEX, AggregatedPageDesc, BeamIndex, KVCacheManager, _KVCache
+from ._event_manager import (
+    KVCacheCreatedData,
+    KVCacheEvent,
+    KVCacheEventDiff,
+    KVCacheEventManager,
+    KVCacheRemovedData,
+    KVCacheStoredBlockData,
+    KVCacheStoredData,
+    KVCacheUpdatedData,
+    UniqueToken,
+)
 from ._life_cycle_registry import LayerGroupId, LifeCycleId
 from ._storage import BufferId
 
@@ -50,6 +61,15 @@ __all__ = [
     "TokenIdExt",
     "KVCacheManager",
     "_KVCache",
+    "KVCacheCreatedData",
+    "KVCacheEvent",
+    "KVCacheEventDiff",
+    "KVCacheEventManager",
+    "KVCacheRemovedData",
+    "KVCacheStoredBlockData",
+    "KVCacheStoredData",
+    "KVCacheUpdatedData",
+    "UniqueToken",
     "BeamIndex",
     "DEFAULT_BEAM_INDEX",
     "LayerId",

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
@@ -115,6 +115,98 @@ class KVCacheManagerConfig:
     max_util_for_resume: float = ...
     helix_config: HelixConfig | None = None
 
+# From _event_manager.py
+EventBlockHash: TypeAlias = int | str
+BlockHashLike: TypeAlias = bytes | EventBlockHash
+BlockHashesLike: TypeAlias = BlockHashLike | Iterable[BlockHashLike]
+EventTokenId: TypeAlias = int | str
+MmKey: TypeAlias = tuple[bytes, int] | tuple[bytes, int, str | None]
+AttentionDpGatherFn: TypeAlias = Callable[[list["KVCacheEvent"]], list[list["KVCacheEvent"]]]
+
+@dataclass(slots=True, frozen=True)
+class UniqueToken:
+    token_id: EventTokenId
+    token_extra_id: int = ...
+
+@dataclass(slots=True, frozen=True)
+class KVCacheCreatedData:
+    num_blocks_per_cache_level: list[int]
+
+@dataclass(slots=True, frozen=True)
+class KVCacheStoredBlockData:
+    block_hash: EventBlockHash
+    tokens: list[UniqueToken]
+    cache_level: int
+    priority: int
+    mm_keys: list[MmKey] = ...
+
+@dataclass(slots=True, frozen=True)
+class KVCacheStoredData:
+    parent_hash: EventBlockHash | None
+    blocks: list[KVCacheStoredBlockData]
+
+@dataclass(slots=True, frozen=True)
+class KVCacheRemovedData:
+    block_hashes: list[EventBlockHash]
+
+@dataclass(slots=True, frozen=True)
+class KVCacheEventDiff:
+    old_value: int
+    new_value: int
+
+@dataclass(slots=True, frozen=True)
+class KVCacheUpdatedData:
+    block_hash: EventBlockHash
+    cache_level: KVCacheEventDiff | None
+    priority: KVCacheEventDiff | None
+
+@dataclass(slots=True, frozen=True)
+class KVCacheEvent:
+    event_id: int
+    data: KVCacheCreatedData | KVCacheStoredData | KVCacheRemovedData | KVCacheUpdatedData
+    window_size: int
+    hash_algo: str | None = None
+    attention_dp_rank: int | None = None
+    layer_group_id: int | None = None
+
+class KVCacheEventManager:
+    def __init__(
+        self,
+        max_kv_event_entries: int,
+        *,
+        window_size: int = ...,
+        attention_dp_rank: int | None = None,
+        attention_dp_gather: AttentionDpGatherFn | None = None,
+        hash_algo: str = ...,
+        window_size_by_layer_group: dict[int, int] | None = None,
+    ) -> None: ...
+    def add_created_event(
+        self,
+        num_blocks_per_cache_level: Sequence[int],
+        layer_group_ids: Sequence[int] | None = None,
+    ) -> None: ...
+    def set_layer_group_window_sizes(self, window_sizes: dict[int, int]) -> None: ...
+    def add_stored_event(
+        self,
+        parent_hash: EventBlockHash | None,
+        blocks: Sequence[KVCacheStoredBlockData],
+        layer_group_id: int | None = None,
+    ) -> None: ...
+    def add_stored_block_event_from_block(self, block: Any) -> None: ...
+    def add_stored_life_cycle_event_from_block(self, block: Any, life_cycle_id: int) -> None: ...
+    def add_removed_event(self, block_hashes: BlockHashesLike) -> None: ...
+    def add_removed_life_cycle_event(self, block_hash: bytes, life_cycle_id: int) -> None: ...
+    def add_updated_event(
+        self,
+        block_hash: BlockHashLike,
+        *,
+        cache_level: KVCacheEventDiff | None = None,
+        priority: KVCacheEventDiff | None = None,
+        layer_group_id: int | None = None,
+    ) -> None: ...
+    def flush_iteration_events(self) -> None: ...
+    def get_latest_events(self, timeout_ms: float | None = None) -> list[KVCacheEvent]: ...
+
 # From _block_radix_tree.py
 def gen_multi_modal_tokens(
     id_offset: int, multi_modal_data_digest: bytes, num_tokens: int
@@ -237,7 +329,11 @@ class PageIndexConverter:
     def __call__(self, base_index: int) -> Iterator[int]: ...
 
 class KVCacheManager:
-    def __init__(self, config: KVCacheManagerConfig) -> None: ...
+    def __init__(
+        self,
+        config: KVCacheManagerConfig,
+        event_manager: KVCacheEventManager | None = None,
+    ) -> None: ...
     def __del__(self) -> None: ...
     def shutdown(self) -> None: ...
     def clear_reusable_blocks(self) -> None: ...
@@ -261,6 +357,8 @@ class KVCacheManager:
     def cache_tier_list(self) -> Sequence[CacheTier]: ...
     @property
     def tokens_per_block(self) -> int: ...
+    @property
+    def event_manager(self) -> Any | None: ...
     @property
     def allow_seq_rebasing(self) -> bool: ...
     @property

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_block_radix_tree.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_block_radix_tree.py
@@ -22,6 +22,7 @@ from ._life_cycle_registry import AttnLifeCycle, LifeCycle, LifeCycleId, LifeCyc
 from ._utils import TypedIndexList, chunked, filled_list, unwrap_rawref
 
 if TYPE_CHECKING:
+    from ._event_manager import KVCacheEventManager
     from ._page import CommittedPage
 
 BlockKey = bytes
@@ -99,12 +100,15 @@ def remove_subtree(root: "RootBlock | Block") -> list[rawref.ref["CommittedPage"
     # taking O(1) space
     # remove leaf blocks one by one, in post-order
     ret: list[rawref.ref["CommittedPage"]] = []
+    removed_block_hashes: list[BlockKey] = []
+    event_manager = get_tree(root).event_manager
     block: "RootBlock | Block" = root
     while True:
         if block.next:
             block = next(iter(block.next.values()))
         else:
             if isinstance(block, Block):
+                removed_block_hashes.append(block.key)
                 ret.extend(p for p in block.storage if p is not None)
                 block.storage = filled_list(None, block.num_life_cycles)
             assert isinstance(block, RootBlock) or all(page is None for page in block.storage), (
@@ -122,6 +126,8 @@ def remove_subtree(root: "RootBlock | Block") -> list[rawref.ref["CommittedPage"
                 break
             assert not isinstance(prev_block, BlockRadixTree)
             block = prev_block
+    if event_manager is not None:
+        event_manager.add_removed_event(removed_block_hashes)
     return ret
 
 
@@ -282,8 +288,11 @@ class Block:
             if len(b.tokens) < len(tokens) and tokens[: len(b.tokens)] == b.tokens:
                 assert NDEBUG or (not b.is_full and b is not self and b.key == k and not b.next)
                 to_remove.append(k)
+        event_manager = get_tree(prev).event_manager if to_remove else None
         for k in to_remove:
             b = prev.next.pop(k)
+            if event_manager is not None:
+                event_manager.add_removed_event(b.key)
             assert b.is_orphan  # _KVCache may still hold it.
         # prev.next keeps a strong ref to this _Block, so no need to remove self from prev.next in __del__().
         prev.next[self.key] = self
@@ -319,6 +328,7 @@ class Block:
     def unset_page(self, lc_idx: LifeCycleId, lc: LifeCycle) -> None:
         if self.storage[lc_idx] is None:
             return
+        event_manager = get_tree(self).event_manager
         ordinal = self.ordinal
         self.storage[lc_idx] = None
         assert type(lc) is AttnLifeCycle, "Reuse for SSM layers is not supported yet"
@@ -330,6 +340,8 @@ class Block:
                     assert page.status == PageStatus.DROPPABLE
                     if page.scheduled_for_eviction:
                         page.manager.exclude_from_eviction(page)
+        elif event_manager is not None:
+            event_manager.add_removed_life_cycle_event(self.key, int(lc_idx))
         # It's possible to implement more sophisticated logic to remove useless blocks for SWA, e.g.
         # check if consecutive available blocks is sufficient for window_size. (TRTLLM-8802)
         # But for simplicity, we leave it for now.
@@ -341,6 +353,8 @@ class Block:
         ):
             if curr.key in curr.prev.next:
                 curr.prev.next.pop(curr.key)
+                if event_manager is not None:
+                    event_manager.add_removed_event(curr.key)
             curr = curr.prev
 
     @property
@@ -359,15 +373,28 @@ class Block:
 
 
 class BlockRadixTree:
-    __slots__ = ("_life_cycles", "_tokens_per_block", "next", "__rawref__")
+    __slots__ = (
+        "_life_cycles",
+        "_tokens_per_block",
+        "_event_manager",
+        "next",
+        "__rawref__",
+    )
     _life_cycles: LifeCycleRegistry
     _tokens_per_block: int
+    _event_manager: "KVCacheEventManager | None"
     next: Children[RootBlock]
     __rawref__: rawref.ref["BlockRadixTree"]
 
-    def __init__(self, life_cycles: LifeCycleRegistry, tokens_per_block: int) -> None:
+    def __init__(
+        self,
+        life_cycles: LifeCycleRegistry,
+        tokens_per_block: int,
+        event_manager: "KVCacheEventManager | None" = None,
+    ) -> None:
         self._life_cycles = life_cycles
         self._tokens_per_block = tokens_per_block
+        self._event_manager = event_manager
         self.next = {}
         self.__rawref__ = rawref.NULL
 
@@ -387,6 +414,10 @@ class BlockRadixTree:
     @property
     def life_cycles(self) -> LifeCycleRegistry:
         return self._life_cycles
+
+    @property
+    def event_manager(self) -> "KVCacheEventManager | None":
+        return self._event_manager
 
     @property
     def num_life_cycles(self) -> LifeCycleId:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -757,8 +757,12 @@ class _KVCache:
             seq_block.tree_block = tree_block
             assert self._get_tree_block(ordinal) is tree_block
             self._num_committed_blocks = BlockOrdinal(ordinal + 1)
+            event_manager = self.manager.event_manager
+            if event_manager is not None:
+                event_manager.add_stored_block_event_from_block(tree_block)
         elif tree_block.is_full and self.manager.allow_seq_rebasing:
-            # try to replace our pages with pages from the existing block.
+            # Happens when a concurrent request committed the same tokens before us.
+            # Try to replace our pages with pages from the existing block to save memory.
             reuse_list = list[tuple[LifeCycleId, CommittedPage]]()
             for lc in typed_range(typed_len(beam_block)):
                 if lc == ssm_lc_id:
@@ -772,6 +776,9 @@ class _KVCache:
                     page = cast(UncommittedPage, cast(_SharedPageLock, beam_block[lc]).page)
                     beam_block[lc] = None
                     p = page.convert_to_committed(tree_block)
+                    event_manager = self.manager.event_manager
+                    if event_manager is not None:
+                        event_manager.add_stored_life_cycle_event_from_block(tree_block, int(lc))
                     # The page comes from uncommitted page of self, so safe to skip wait.
                     beam_block[lc] = (
                         p.lock(self, beam_idx, ordinal, lc, skip_wait=True) if locked else p.hold()

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Iterable, Iterator, cast
+from typing import TYPE_CHECKING, Iterable, Iterator, cast
 
 from .. import rawref
 from .._block_radix_tree import BlockRadixTree
@@ -56,6 +56,9 @@ from .._utils import (
 )
 from ._kv_cache import _KVCache
 from ._moving_average import MovingAverage
+
+if TYPE_CHECKING:
+    from .._event_manager import KVCacheEventManager
 
 
 @dataclass(slots=True, frozen=True)
@@ -134,6 +137,7 @@ class KVCacheManager:
         "_num_closed_kv_caches",
         "_last_adjustment_time",
         "_last_update_num_closed_requests",
+        "_event_manager",
     )
     _init_config: KVCacheManagerConfig
     _life_cycles: LifeCycleRegistry
@@ -156,13 +160,18 @@ class KVCacheManager:
     _num_closed_kv_caches: int
     _last_adjustment_time: float
     _last_update_num_closed_requests: int
+    _event_manager: "KVCacheEventManager | None"
 
-    def __init__(self, config: KVCacheManagerConfig) -> None:
+    def __init__(
+        self,
+        config: KVCacheManagerConfig,
+        event_manager: "KVCacheEventManager | None" = None,
+    ) -> None:
         init_cuda_once()
         config = deepcopy(config)
         self._init_config = config
         self._life_cycles = LifeCycleRegistry(config)
-        self._radix_tree = BlockRadixTree(self._life_cycles, config.tokens_per_block)
+        self._radix_tree = BlockRadixTree(self._life_cycles, config.tokens_per_block, event_manager)
         storage_config = create_storage_config(config)
         self._storage = StorageManager(
             self._life_cycles,
@@ -170,6 +179,7 @@ class KVCacheManager:
             config.tokens_per_block,
             typical_batch=config.typical_step,
             constraints=config.constraints,
+            event_manager=event_manager,
         )
         self._living_kv_caches = set[rawref.ref[_KVCache]]()
         decay = 0.9999
@@ -182,6 +192,7 @@ class KVCacheManager:
         self._num_closed_kv_caches = 0
         self._last_adjustment_time = time.monotonic()
         self._last_update_num_closed_requests = 0
+        self._event_manager = event_manager
 
     def __del__(self) -> None:
         self.shutdown()
@@ -308,6 +319,10 @@ class KVCacheManager:
     @property
     def tokens_per_block(self) -> int:
         return self._radix_tree.tokens_per_block
+
+    @property
+    def event_manager(self) -> "KVCacheEventManager | None":
+        return self._event_manager
 
     @property
     def allow_seq_rebasing(self) -> bool:
@@ -552,7 +567,8 @@ class KVCacheManager:
 
         for pg in typed_range(num_pool_groups):
             remaining_slots[pg] -= get_num_slots(1)[pg] * (batch_size - 1)
-            assert remaining_slots[pg] >= 0
+            if remaining_slots[pg] < 0:
+                return 0
 
         def is_enough(num_blocks: int) -> bool:
             return all(
@@ -560,7 +576,8 @@ class KVCacheManager:
                 for cnt, rem in zip(get_num_slots(num_blocks * tokens_per_block), remaining_slots)
             )
 
-        assert is_enough(1)
+        if not is_enough(1):
+            return 0
         lb = 1
         ub = div_up(token_num_upper_bound, tokens_per_block)
         if is_enough(ub):

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_event_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_event_manager.py
@@ -1,0 +1,536 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field, replace
+from threading import Condition
+from typing import Any, Callable
+
+from tensorrt_llm.logger import logger
+from tensorrt_llm.runtime.kv_cache_hash import (
+    KV_CACHE_HASH_ALGO_AUTO,
+    KV_CACHE_HASH_ALGO_V1,
+    KV_CACHE_HASH_ALGO_V2,
+    KV_CACHE_HASH_ALGO_V2_SHA256_64,
+    truncate_sha256_hash_to_int64,
+)
+
+from ._common import GPU_LEVEL, PRIORITY_DEFAULT, CacheLevel, Priority, TokenIdExt
+
+EventBlockHash = int | str
+BlockHashLike = bytes | EventBlockHash
+BlockHashesLike = BlockHashLike | Iterable[BlockHashLike]
+LayerGroupId = int | None
+EventTokenId = int | str
+MmKey = tuple[bytes, int] | tuple[bytes, int, str | None]
+AttentionDpGatherFn = Callable[[list["KVCacheEvent"]], list[list["KVCacheEvent"]]]
+
+
+@dataclass(slots=True, frozen=True)
+class UniqueToken:
+    token_id: EventTokenId
+    token_extra_id: int = 0
+
+
+@dataclass(slots=True, frozen=True)
+class KVCacheCreatedData:
+    num_blocks_per_cache_level: list[int]
+
+
+@dataclass(slots=True, frozen=True)
+class KVCacheStoredBlockData:
+    block_hash: EventBlockHash
+    tokens: list[UniqueToken]
+    cache_level: int
+    priority: int
+    mm_keys: list[MmKey] = field(default_factory=list)
+
+
+@dataclass(slots=True, frozen=True)
+class KVCacheStoredData:
+    parent_hash: EventBlockHash | None
+    blocks: list[KVCacheStoredBlockData]
+
+
+@dataclass(slots=True, frozen=True)
+class KVCacheRemovedData:
+    block_hashes: list[EventBlockHash]
+
+
+@dataclass(slots=True, frozen=True)
+class KVCacheEventDiff:
+    old_value: int
+    new_value: int
+
+
+@dataclass(slots=True, frozen=True)
+class KVCacheUpdatedData:
+    block_hash: EventBlockHash
+    cache_level: KVCacheEventDiff | None
+    priority: KVCacheEventDiff | None
+
+
+@dataclass(slots=True, frozen=True)
+class KVCacheEvent:
+    event_id: int
+    data: KVCacheCreatedData | KVCacheStoredData | KVCacheRemovedData | KVCacheUpdatedData
+    window_size: int
+    hash_algo: str | None = None
+    attention_dp_rank: int | None = None
+    layer_group_id: int | None = None
+
+
+@dataclass(slots=True)
+class _StoredBlockState:
+    block_hash: EventBlockHash
+    life_cycle_ids: set[int]
+
+
+class KVCacheEventManager:
+    """Python event queue matching the C++ KV cache event serializer contract."""
+
+    def __init__(
+        self,
+        max_kv_event_entries: int,
+        *,
+        window_size: int = 0,
+        attention_dp_rank: int | None = None,
+        attention_dp_gather: AttentionDpGatherFn | None = None,
+        hash_algo: str = KV_CACHE_HASH_ALGO_V2,
+        window_size_by_layer_group: dict[int, int] | None = None,
+    ) -> None:
+        if hash_algo == KV_CACHE_HASH_ALGO_AUTO:
+            hash_algo = KV_CACHE_HASH_ALGO_V2
+        elif hash_algo == KV_CACHE_HASH_ALGO_V1:
+            logger.warning(
+                "V1 KV cache event hash algorithm is not supported by V2 "
+                "KV cache manager events: "
+                f"{hash_algo}. Falling back to {KV_CACHE_HASH_ALGO_V2_SHA256_64}."
+            )
+            hash_algo = KV_CACHE_HASH_ALGO_V2_SHA256_64
+        elif hash_algo not in (KV_CACHE_HASH_ALGO_V2, KV_CACHE_HASH_ALGO_V2_SHA256_64):
+            raise ValueError(f"Unsupported V2 KV cache event hash algorithm: {hash_algo}")
+        self._max_kv_event_entries = max_kv_event_entries
+        self._window_size = window_size
+        self._window_size_by_layer_group = dict(window_size_by_layer_group or {})
+        self._attention_dp_rank = attention_dp_rank
+        self._attention_dp_gather = attention_dp_gather
+        self._hash_algo = hash_algo
+        self._next_event_id = 0
+        self._stored_blocks: dict[bytes, _StoredBlockState] = {}
+        self._latest_stored_events: dict[LayerGroupId, KVCacheEvent] = {}
+        self._latest_removed_block_hashes: dict[LayerGroupId, list[EventBlockHash]] = {}
+        self._pending_events: list[KVCacheEvent] = []
+        self._events: deque[KVCacheEvent] = deque()
+        self._condition = Condition()
+
+    def add_created_event(
+        self,
+        num_blocks_per_cache_level: Sequence[int],
+        layer_group_ids: Sequence[int] | None = None,
+    ) -> None:
+        data = KVCacheCreatedData(list(num_blocks_per_cache_level))
+        if layer_group_ids is None:
+            self._add_event(data)
+            return
+        for layer_group_id in layer_group_ids:
+            self._add_event(data, layer_group_id=int(layer_group_id))
+
+    def set_layer_group_window_sizes(self, window_sizes: dict[int, int]) -> None:
+        with self._condition:
+            self._window_size_by_layer_group = dict(window_sizes)
+
+    def add_stored_event(
+        self,
+        parent_hash: EventBlockHash | None,
+        blocks: Sequence[KVCacheStoredBlockData],
+        layer_group_id: int | None = None,
+    ) -> None:
+        if not blocks:
+            return
+        self._flush_removed_events(layer_group_id)
+        self._add_stored_event(
+            KVCacheStoredData(parent_hash, list(blocks)),
+            layer_group_id=layer_group_id,
+        )
+
+    def add_stored_block_event_from_block(self, block: Any) -> None:
+        life_cycle_ids = self._life_cycle_ids_from_radix_block(block)
+        if not life_cycle_ids:
+            return
+        parent_hash = self._parent_hash_from_radix_block(block)
+        self._stored_blocks[block.key] = _StoredBlockState(
+            block_hash=self._normalize_block_hash(block.key),
+            life_cycle_ids=set(life_cycle_ids),
+        )
+        for life_cycle_id in sorted(life_cycle_ids):
+            block_data = self._stored_block_from_radix_block(block, life_cycle_ids={life_cycle_id})
+            if block_data is not None:
+                self.add_stored_event(parent_hash, [block_data], life_cycle_id)
+
+    def add_stored_life_cycle_event_from_block(self, block: Any, life_cycle_id: int) -> None:
+        state = self._stored_blocks.get(block.key)
+        life_cycle_id = int(life_cycle_id)
+        if state is not None:
+            if life_cycle_id in state.life_cycle_ids:
+                return
+            block_data = self._stored_block_from_radix_block(block, life_cycle_ids={life_cycle_id})
+            if block_data is None:
+                return
+            state.life_cycle_ids.add(life_cycle_id)
+            self.add_stored_event(
+                self._parent_hash_from_radix_block(block),
+                [block_data],
+                layer_group_id=life_cycle_id,
+            )
+            return
+        self.add_stored_block_event_from_block(block)
+
+    def add_removed_event(self, block_hashes: BlockHashesLike) -> None:
+        removed_block_hashes_by_layer_group: dict[int, list[EventBlockHash]] = {}
+        removed_block_hashes_without_layer_group: list[EventBlockHash] = []
+        for block_hash in self._iter_block_hashes(block_hashes):
+            removed_state = self._pop_stored_block_state(block_hash)
+            if removed_state is None:
+                continue
+            normalized_hash, life_cycle_ids = removed_state
+            if life_cycle_ids:
+                for life_cycle_id in sorted(life_cycle_ids):
+                    removed_block_hashes_by_layer_group.setdefault(life_cycle_id, []).append(
+                        normalized_hash
+                    )
+            else:
+                removed_block_hashes_without_layer_group.append(normalized_hash)
+
+        if removed_block_hashes_without_layer_group:
+            self._enqueue_removed_event(removed_block_hashes_without_layer_group)
+        for layer_group_id, removed_block_hashes in sorted(
+            removed_block_hashes_by_layer_group.items()
+        ):
+            self._enqueue_removed_event(removed_block_hashes, layer_group_id=layer_group_id)
+
+    def add_removed_life_cycle_event(self, block_hash: bytes, life_cycle_id: int) -> None:
+        removed_state = self._pop_stored_life_cycle_block_state(block_hash, life_cycle_id)
+        if removed_state is None:
+            return
+        normalized_hash, removed_life_cycle_id, _ = removed_state
+        self._enqueue_removed_event(
+            [normalized_hash],
+            layer_group_id=removed_life_cycle_id,
+        )
+
+    def add_updated_event(
+        self,
+        block_hash: BlockHashLike,
+        *,
+        cache_level: KVCacheEventDiff | None = None,
+        priority: KVCacheEventDiff | None = None,
+        layer_group_id: int | None = None,
+    ) -> None:
+        if cache_level is None and priority is None:
+            return
+        normalized_block_hash = self._get_stored_block_hash(block_hash)
+        if normalized_block_hash is None:
+            return
+        self._add_event(
+            KVCacheUpdatedData(
+                block_hash=normalized_block_hash,
+                cache_level=cache_level,
+                priority=priority,
+            ),
+            layer_group_id=layer_group_id,
+        )
+
+    def flush_iteration_events(self) -> None:
+        if self._attention_dp_gather is not None:
+            with self._condition:
+                local_events = self._drain_pending_events_unlocked()
+                local_events = self._trim_events(local_events, self._max_kv_event_entries)
+            gathered_events = self._attention_dp_gather(local_events)
+            if self._attention_dp_rank != 0:
+                return
+            events = [
+                event
+                for rank_events in gathered_events
+                for event in self._trim_events(rank_events, self._max_kv_event_entries)
+            ]
+            with self._condition:
+                self._publish_events_unlocked(
+                    events,
+                    max_kv_event_entries=(
+                        self._max_kv_event_entries * max(1, len(gathered_events))
+                    ),
+                )
+                self._condition.notify_all()
+            return
+
+        with self._condition:
+            self._publish_events_unlocked(self._drain_pending_events_unlocked())
+            self._condition.notify_all()
+
+    def get_latest_events(self, timeout_ms: float | None = None) -> list[KVCacheEvent]:
+        with self._condition:
+            if not self._events and timeout_ms is None:
+                while not self._events:
+                    self._condition.wait()
+            elif not self._events and timeout_ms > 0:
+                deadline = time.monotonic() + timeout_ms / 1000
+                while not self._events:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    self._condition.wait(timeout=remaining)
+
+            events = list(self._events)
+            self._events.clear()
+            return events
+
+    def _add_event(
+        self,
+        data: KVCacheCreatedData | KVCacheStoredData | KVCacheRemovedData | KVCacheUpdatedData,
+        layer_group_id: LayerGroupId = None,
+    ) -> None:
+        if self._max_kv_event_entries <= 0:
+            return
+        with self._condition:
+            self._add_event_unlocked(data, layer_group_id)
+
+    def _add_stored_event(
+        self,
+        data: KVCacheStoredData,
+        layer_group_id: LayerGroupId = None,
+    ) -> None:
+        if self._max_kv_event_entries <= 0:
+            return
+        with self._condition:
+            has_pending_removed_events = bool(self._latest_removed_block_hashes)
+            latest_event = self._latest_stored_events.get(layer_group_id)
+            if (
+                not has_pending_removed_events
+                and latest_event is not None
+                and isinstance(latest_event.data, KVCacheStoredData)
+            ):
+                latest_blocks = latest_event.data.blocks
+                if latest_blocks and latest_blocks[-1].block_hash == data.parent_hash:
+                    merged_data = replace(
+                        latest_event.data,
+                        blocks=[*latest_blocks, *data.blocks],
+                    )
+                    merged_event = replace(latest_event, data=merged_data)
+                    self._replace_pending_event_unlocked(latest_event, merged_event)
+                    self._latest_stored_events[layer_group_id] = merged_event
+                    return
+
+            event = self._add_event_unlocked(data, layer_group_id)
+            self._latest_stored_events[layer_group_id] = event
+
+    def _replace_pending_event_unlocked(
+        self,
+        old_event: KVCacheEvent,
+        new_event: KVCacheEvent,
+    ) -> None:
+        for event_idx in range(len(self._pending_events) - 1, -1, -1):
+            if self._pending_events[event_idx] is old_event:
+                self._pending_events[event_idx] = new_event
+                return
+        raise RuntimeError("Stored event coalescing lost the pending event")
+
+    def _enqueue_removed_event(
+        self,
+        block_hashes: Sequence[EventBlockHash],
+        layer_group_id: LayerGroupId = None,
+    ) -> None:
+        if not block_hashes or self._max_kv_event_entries <= 0:
+            return
+        with self._condition:
+            self._latest_removed_block_hashes.setdefault(layer_group_id, []).extend(block_hashes)
+            self._latest_stored_events.pop(layer_group_id, None)
+
+    def _flush_removed_events(self, layer_group_id: LayerGroupId) -> None:
+        if self._max_kv_event_entries <= 0:
+            return
+        with self._condition:
+            self._flush_removed_events_unlocked(layer_group_id)
+
+    def _flush_removed_events_unlocked(self, layer_group_id: LayerGroupId) -> None:
+        block_hashes = self._latest_removed_block_hashes.pop(layer_group_id, None)
+        if not block_hashes:
+            return
+        self._add_event_unlocked(
+            KVCacheRemovedData(block_hashes),
+            layer_group_id=layer_group_id,
+        )
+
+    def _flush_all_removed_events_unlocked(self) -> None:
+        layer_group_ids = list(self._latest_removed_block_hashes)
+        for layer_group_id in layer_group_ids:
+            self._flush_removed_events_unlocked(layer_group_id)
+
+    def _add_event_unlocked(
+        self,
+        data: KVCacheCreatedData | KVCacheStoredData | KVCacheRemovedData | KVCacheUpdatedData,
+        layer_group_id: LayerGroupId = None,
+    ) -> KVCacheEvent:
+        if not isinstance(data, KVCacheRemovedData):
+            self._flush_all_removed_events_unlocked()
+        event = KVCacheEvent(
+            event_id=self._next_event_id,
+            data=data,
+            window_size=self._get_window_size(layer_group_id),
+            hash_algo=self._hash_algo,
+            attention_dp_rank=self._attention_dp_rank,
+            layer_group_id=layer_group_id,
+        )
+        self._next_event_id += 1
+        self._pending_events.append(event)
+        if not isinstance(data, KVCacheStoredData):
+            self._latest_stored_events.pop(layer_group_id, None)
+        return event
+
+    def _drain_pending_events_unlocked(self) -> list[KVCacheEvent]:
+        self._flush_all_removed_events_unlocked()
+        events = self._pending_events
+        self._pending_events = []
+        self._latest_stored_events.clear()
+        return events
+
+    def _publish_events_unlocked(
+        self,
+        events: Sequence[KVCacheEvent],
+        *,
+        max_kv_event_entries: int | None = None,
+    ) -> None:
+        if not events:
+            return
+        if max_kv_event_entries is None:
+            max_kv_event_entries = self._max_kv_event_entries
+        self._events.extend(events)
+        while len(self._events) > max_kv_event_entries:
+            self._events.popleft()
+
+    @staticmethod
+    def _trim_events(
+        events: Sequence[KVCacheEvent], max_kv_event_entries: int
+    ) -> list[KVCacheEvent]:
+        if max_kv_event_entries <= 0:
+            return []
+        if len(events) <= max_kv_event_entries:
+            return list(events)
+        return list(events[-max_kv_event_entries:])
+
+    def _get_window_size(self, layer_group_id: LayerGroupId) -> int:
+        if layer_group_id is None:
+            return self._window_size
+        return self._window_size_by_layer_group.get(int(layer_group_id), self._window_size)
+
+    @staticmethod
+    def _iter_block_hashes(block_hashes: BlockHashesLike) -> Iterable[BlockHashLike]:
+        if isinstance(block_hashes, (bytes, str, int)):
+            return (block_hashes,)
+        return block_hashes
+
+    def _normalize_block_hash(self, block_hash: BlockHashLike) -> EventBlockHash:
+        if isinstance(block_hash, bytes):
+            if self._hash_algo == KV_CACHE_HASH_ALGO_V2_SHA256_64:
+                return truncate_sha256_hash_to_int64(block_hash)
+            return block_hash.hex()
+        return block_hash
+
+    def _get_stored_block_hash(self, block_hash: BlockHashLike) -> EventBlockHash | None:
+        if isinstance(block_hash, bytes):
+            state = self._stored_blocks.get(block_hash)
+            return None if state is None else state.block_hash
+        return block_hash
+
+    def _pop_stored_block_state(
+        self, block_hash: BlockHashLike
+    ) -> tuple[EventBlockHash, set[int]] | None:
+        if isinstance(block_hash, bytes):
+            state = self._stored_blocks.pop(block_hash, None)
+            if state is None:
+                return None
+            return state.block_hash, set(state.life_cycle_ids)
+        return block_hash, set()
+
+    def _pop_stored_life_cycle_block_state(
+        self, block_hash: bytes, life_cycle_id: int
+    ) -> tuple[EventBlockHash, int, bool] | None:
+        state = self._stored_blocks.get(block_hash)
+        if state is None or not state.life_cycle_ids:
+            return None
+
+        life_cycle_id = int(life_cycle_id)
+        if life_cycle_id not in state.life_cycle_ids:
+            return None
+
+        state.life_cycle_ids.remove(life_cycle_id)
+        is_last_life_cycle = not state.life_cycle_ids
+        if is_last_life_cycle:
+            self._stored_blocks.pop(block_hash, None)
+        return state.block_hash, life_cycle_id, is_last_life_cycle
+
+    @staticmethod
+    def _normalize_token(token: TokenIdExt) -> UniqueToken:
+        if isinstance(token, bytes):
+            return UniqueToken(token.hex())
+        return UniqueToken(int(token))
+
+    def _stored_block_from_radix_block(
+        self, block: Any, life_cycle_ids: set[int] | None = None
+    ) -> KVCacheStoredBlockData | None:
+        cache_level: CacheLevel = GPU_LEVEL
+        priority: Priority = PRIORITY_DEFAULT
+        found_page = False
+        for life_cycle_id, page_ref in enumerate(block.storage):
+            if life_cycle_ids is not None and life_cycle_id not in life_cycle_ids:
+                continue
+            if page_ref is None:
+                continue
+            page = page_ref()
+            if page is None:
+                continue
+            cache_level = page.cache_level
+            priority = page.priority
+            found_page = True
+            break
+
+        if life_cycle_ids is not None and not found_page:
+            return None
+
+        return KVCacheStoredBlockData(
+            block_hash=self._normalize_block_hash(block.key),
+            tokens=[self._normalize_token(token) for token in block.tokens],
+            cache_level=int(cache_level),
+            priority=int(priority),
+            mm_keys=[],
+        )
+
+    @staticmethod
+    def _life_cycle_ids_from_radix_block(block: Any) -> set[int]:
+        return {
+            life_cycle_id
+            for life_cycle_id, page_ref in enumerate(block.storage)
+            if page_ref is not None and page_ref() is not None
+        }
+
+    def _parent_hash_from_radix_block(self, block: Any) -> EventBlockHash | None:
+        parent = block.prev
+        if getattr(parent, "ordinal", -1) == -1:
+            return None
+        return self._normalize_block_hash(parent.key)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -18,7 +18,7 @@ import os
 import warnings
 from collections import deque
 from dataclasses import dataclass
-from typing import Iterator, Sequence, cast
+from typing import TYPE_CHECKING, Iterator, Sequence, cast
 
 from . import rawref
 from ._common import (
@@ -33,10 +33,11 @@ from ._common import (
 )
 from ._config import BatchDesc, CacheTierConfig, DataRole, DiskCacheTierConfig, KVCacheDesc
 from ._copy_engine import CopyTask, batched_copy
+from ._event_manager import KVCacheEventDiff
 from ._eviction_controller import EvictablePage, PerLevelEvictionController
 from ._exceptions import OutOfPagesError
 from ._life_cycle_registry import LifeCycleId, LifeCycleRegistry
-from ._page import Page
+from ._page import CommittedPage, Page
 from ._storage import CacheLevelStorage
 from ._storage._config import BufferAttr, BufferId, SlotDesc, StorageConfig
 from ._storage._core import (
@@ -70,6 +71,9 @@ from ._utils import (
     typed_map,
     typed_range,
 )
+
+if TYPE_CHECKING:
+    from ._event_manager import KVCacheEventManager
 
 
 class CacheLevelManager:
@@ -166,6 +170,7 @@ class StorageManager:
         "_slot_desc_list",
         "_levels",
         "_min_slots",
+        "_event_manager",
         "__rawref__",
     )
     _life_cycles: LifeCycleRegistry
@@ -176,6 +181,7 @@ class StorageManager:
     _slot_desc_list: TypedIndexList[PoolGroupIndex, SlotDesc]
     _levels: TypedIndexList[CacheLevel, CacheLevelManager]
     _min_slots: TypedIndexList[PoolGroupIndex, int]
+    _event_manager: "KVCacheEventManager | None"
     __rawref__: rawref.ref["StorageManager"]
 
     def __init__(
@@ -185,8 +191,10 @@ class StorageManager:
         tokens_per_block: int,
         typical_batch: BatchDesc | None = None,
         constraints: list[BatchDesc] | None = None,
+        event_manager: "KVCacheEventManager | None" = None,
     ) -> None:
         self.__rawref__ = rawref.NULL
+        self._event_manager = event_manager
         assert config.cache_tiers[GPU_LEVEL].tier == CacheTier.GPU_MEM, (
             "The first cache tier must be GPU memory"
         )
@@ -506,6 +514,13 @@ class StorageManager:
                 for pool_idx, tasks in typed_enumerate(tasks_per_pool):
                     batched_copy(dst_tier, src_tier, slot_sizes[pool_idx], tasks, stream.get())
             finish_event = stream.take_finish_event()
+            emit_cache_level_updates = (
+                update_src
+                and not defrag
+                and src_level != dst_level
+                and self._event_manager is not None
+            )
+            emitted_update_keys: set[tuple[bytes, LifeCycleId]] = set()
             for src, dst in zip(src_pages, dst_slots):
                 dst.ready_event = finish_event
                 src.ready_event = (
@@ -518,6 +533,10 @@ class StorageManager:
                     src_pool_group.release(src)
                     src.set_slot(dst)
                     src.cache_level = dst_level
+                    if emit_cache_level_updates:
+                        self._emit_cache_level_updated_event(
+                            src, src_level, dst_level, emitted_update_keys
+                        )
                     if scheduled_for_eviction:
                         self.schedule_for_eviction(src)
             return None if update_src else dst_slots
@@ -525,6 +544,34 @@ class StorageManager:
             for s in dst_slots:
                 dst_pool_group.release(s)
             raise
+
+    def _emit_cache_level_updated_event(
+        self,
+        page: Page,
+        old_level: CacheLevel,
+        new_level: CacheLevel,
+        emitted_keys: set[tuple[bytes, LifeCycleId]],
+    ) -> None:
+        if self._event_manager is None or not isinstance(page, CommittedPage):
+            return
+
+        block = page.block()
+        if block is None or block.is_orphan:
+            return
+
+        event_key = (block.key, page.life_cycle)
+        if event_key in emitted_keys:
+            return
+
+        emitted_keys.add(event_key)
+        self._event_manager.add_updated_event(
+            block.key,
+            cache_level=KVCacheEventDiff(
+                old_value=int(old_level),
+                new_value=int(new_level),
+            ),
+            layer_group_id=int(page.life_cycle),
+        )
 
     def _pool_group(
         self, cache_level: CacheLevel, pool_group_index: PoolGroupIndex

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/setup_mypyc.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/setup_mypyc.py
@@ -76,6 +76,7 @@ modules = [
     "kv_cache_manager_v2/_config.py",
     "kv_cache_manager_v2/_copy_engine.py",
     "kv_cache_manager_v2/_cuda_virt_mem.py",
+    "kv_cache_manager_v2/_event_manager.py",
     "kv_cache_manager_v2/_exceptions.py",
     "kv_cache_manager_v2/_life_cycle_registry.py",
     "kv_cache_manager_v2/_page.py",

--- a/tensorrt_llm/serve/openai_client.py
+++ b/tensorrt_llm/serve/openai_client.py
@@ -271,7 +271,7 @@ class OpenAIHttpClient(OpenAIClient):
 
     async def _finish_request(self, request: UCompletionRequest) -> None:
         self._metrics_collector.completed_requests.inc()
-        await self._router.finish_request(request)
+        await self._router.finish_request(request, self._session)
 
     async def collect_metrics(self) -> Dict[str, Any]:
         metrics = {}

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -43,6 +43,8 @@ from tensorrt_llm.llmapi.disagg_utils import (DisaggClusterConfig,
 from tensorrt_llm.llmapi.llm import RequestOutput
 from tensorrt_llm.logger import logger
 from tensorrt_llm.metrics.collector import MetricsCollector
+from tensorrt_llm.runtime.kv_cache_hash import \
+    get_effective_kv_cache_event_hash_algo
 from tensorrt_llm.sampling_params import GuidedDecodingParams
 from tensorrt_llm.serve.chat_utils import (load_chat_template,
                                            parse_chat_messages_coroutines)
@@ -1632,10 +1634,15 @@ class OpenAIServer:
         return JSONResponse(content={"status": "success"})
 
     async def get_server_info(self) -> JSONResponse:
-        return JSONResponse(
-            content={
-                "disaggregated_params": self.generator.disaggregated_params
-            })
+        content = {"disaggregated_params": self.generator.disaggregated_params}
+        args = getattr(self.generator, "args", None)
+        kv_cache_config = getattr(args, "kv_cache_config", None)
+        if kv_cache_config is not None:
+            content[
+                "kv_cache_hash_algo"] = get_effective_kv_cache_event_hash_algo(
+                    kv_cache_config.kv_cache_event_hash_algo,
+                    kv_cache_config.use_kv_cache_manager_v2)
+        return JSONResponse(content=content)
 
     async def openai_image_generation(self, request: ImageGenerationRequest,
                                       raw_request: Request) -> Response:

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -11,11 +11,21 @@ from tensorrt_llm.bindings.internal.batch_manager import (BlockKey,
 from tensorrt_llm.llmapi.disagg_utils import (MetadataServerConfig,
                                               RouterConfig, ServerRole)
 from tensorrt_llm.logger import logger
+from tensorrt_llm.runtime.kv_cache_hash import (KV_CACHE_HASH_ALGO_DEFAULT,
+                                                KV_CACHE_HASH_ALGO_V1,
+                                                KV_CACHE_HASH_ALGO_V2,
+                                                KV_CACHE_HASH_ALGO_V2_SHA256_64,
+                                                truncate_sha256_hash_to_int64)
+from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import \
+    Block as V2Block
+from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import \
+    RootBlock as V2RootBlock
 from tensorrt_llm.serve.metadata_server import JsonDictionary
 from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
                                                 CompletionRequest)
 
 OpenAIRequest = Union[CompletionRequest, ChatCompletionRequest]
+BlockHash = Union[int, str]
 
 
 def get_request_num_tokens(request: OpenAIRequest) -> int:
@@ -80,16 +90,52 @@ class KvCacheAwareServerState(ServerState):
                  use_tokens: bool = False,
                  tokens_per_block: int = 32):
         super().__init__(server, use_tokens)
-        self._kv_cache_block_table: set[int] = set()
+        self._kv_cache_block_table: set[BlockHash] = set()
+        self._kv_cache_block_tables: dict[str, set[BlockHash]] = {
+            KV_CACHE_HASH_ALGO_V1: self._kv_cache_block_table
+        }
+        self._kv_cache_hash_algo = KV_CACHE_HASH_ALGO_DEFAULT
         self._tokens_per_block = tokens_per_block
 
-    def add_blocks(self, block_hashes: Iterable[int]):
-        for hash in block_hashes:
-            self._kv_cache_block_table.add(hash)
+    @property
+    def hash_algo(self) -> str:
+        return self._kv_cache_hash_algo
 
-    def remove_blocks(self, block_hashes: Iterable[int]):
-        for hash in block_hashes:
-            self._kv_cache_block_table.discard(hash)
+    def _block_table(self, hash_algo: str) -> set[BlockHash]:
+        if hash_algo not in self._kv_cache_block_tables:
+            self._kv_cache_block_tables[hash_algo] = set()
+        return self._kv_cache_block_tables[hash_algo]
+
+    def set_hash_algo(self, hash_algo: str):
+        self._kv_cache_hash_algo = hash_algo
+        self._block_table(hash_algo)
+
+    async def get_hash_algo(self, hash_algo: Optional[str] = None) -> str:
+        async with self._lock:
+            if hash_algo is not None:
+                self.set_hash_algo(hash_algo)
+            return self._kv_cache_hash_algo
+
+    def _resolve_hash_algo(self, hash_algo: Optional[str]) -> str:
+        return self._kv_cache_hash_algo if hash_algo is None else hash_algo
+
+    def add_blocks(self,
+                   block_hashes: Iterable[BlockHash],
+                   hash_algo: Optional[str] = None):
+        hash_algo = self._resolve_hash_algo(hash_algo)
+        self.set_hash_algo(hash_algo)
+        block_table = self._block_table(hash_algo)
+        for block_hash in block_hashes:
+            block_table.add(block_hash)
+
+    def remove_blocks(self,
+                      block_hashes: Iterable[BlockHash],
+                      hash_algo: Optional[str] = None):
+        hash_algo = self._resolve_hash_algo(hash_algo)
+        self.set_hash_algo(hash_algo)
+        block_table = self._block_table(hash_algo)
+        for block_hash in block_hashes:
+            block_table.discard(block_hash)
 
     def update_with_events(self, events: Iterable[dict]):
         # event_raw: {"id": <id>, "data": <event body>}
@@ -99,24 +145,33 @@ class KvCacheAwareServerState(ServerState):
             else:
                 event = event_raw
 
+            hash_algo = event_raw.get(
+                "hash_algo", event.get("hash_algo", KV_CACHE_HASH_ALGO_DEFAULT))
+            if event["type"] == "created":
+                self.set_hash_algo(hash_algo)
             if event["type"] == "stored":
-                self.add_blocks(block["block_hash"]
-                                for block in event["blocks"])
+                self.add_blocks(
+                    (block["block_hash"] for block in event["blocks"]),
+                    hash_algo=hash_algo)
             elif event["type"] == "removed":
-                self.remove_blocks(event["block_hashes"])
+                self.remove_blocks(event["block_hashes"], hash_algo=hash_algo)
 
     async def poll_events(self, session: aiohttp.ClientSession):
         async with session.post(self._server + "/kv_cache_events") as response:
             events_raw = await response.json()
         return events_raw
 
-    async def matched_tokens(self, block_hashes: list[list[int]]) -> int:
+    async def matched_tokens(
+            self,
+            block_hashes: list[list[BlockHash]],
+            hash_algo: str = KV_CACHE_HASH_ALGO_DEFAULT) -> int:
         match_count = 0
         async with self._lock:
+            block_table = self._block_table(hash_algo)
             for hash_list in block_hashes:
-                for hash in hash_list:
+                for block_hash in hash_list:
                     # TODO: 1) parent hash verification, 2) partial matching
-                    if hash in self._kv_cache_block_table:
+                    if block_hash in block_table:
                         match_count += self._tokens_per_block
                     else:
                         break
@@ -126,10 +181,13 @@ class KvCacheAwareServerState(ServerState):
                              request: OpenAIRequest,
                              session: Optional[aiohttp.ClientSession] = None):
         num_tokens = get_request_num_tokens(request) if self._use_tokens else 0
+        events_raw = None
         if session is not None:
-            events_raw = await self.poll_events(session)
-        else:
-            events_raw = None
+            try:
+                events_raw = await self.poll_events(session)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to poll KV cache events from {self._server}: {e}")
         async with self._lock:
             self._num_active_requests -= 1
             self._num_active_tokens -= num_tokens
@@ -250,7 +308,9 @@ class Router(ABC):
         '''Select server by request and return some intermediate information, exclude_server is a server to exclude from the selection'''
 
     @abstractmethod
-    async def finish_request(self, request: OpenAIRequest):
+    async def finish_request(self,
+                             request: OpenAIRequest,
+                             session: Optional[aiohttp.ClientSession] = None):
         pass
 
     async def start_server_monitoring(self, poll_interval: float = 10.0):
@@ -507,8 +567,10 @@ class RoundRobinRouter(Router):
                     )
         return server, {"server_info": self._server_info.get(server, {})}
 
-    async def finish_request(self, request: OpenAIRequest):
-        pass
+    async def finish_request(self,
+                             request: OpenAIRequest,
+                             session: Optional[aiohttp.ClientSession] = None):
+        del request, session
 
 
 class LoadBalancingRouter(Router):
@@ -598,7 +660,10 @@ class LoadBalancingRouter(Router):
         return self._server_state[server]._num_active_tokens if self._use_tokens \
             else self._server_state[server]._num_active_requests
 
-    async def finish_request(self, request: OpenAIRequest):
+    async def finish_request(self,
+                             request: OpenAIRequest,
+                             session: Optional[aiohttp.ClientSession] = None):
+        del session
         async with self._lock:
             server = self._req_routing_table[id(request)]
             await self._server_state[server].decrement_load(request)
@@ -612,6 +677,13 @@ def block_key_hasher(token_ids: list[int],
     block_key = BlockKey(token_ids)
     return BlockKeyHasher.hash(block_key,
                                0 if parent_hash is None else parent_hash)
+
+
+def v2_sha256_block_hasher(token_ids: list[int],
+                           parent_hash: Optional[str] = None) -> str:
+    parent_key = (V2RootBlock.make_key(None)
+                  if parent_hash is None else bytes.fromhex(parent_hash))
+    return V2Block.make_key(parent_key, token_ids).hex()
 
 
 class KvCacheAwareRouter(Router):
@@ -629,10 +701,12 @@ class KvCacheAwareRouter(Router):
                          metadata_server, **kwargs)
         self._lock = asyncio.Lock()
         self._use_tokens = use_tokens
+        self._tokens_per_block = tokens_per_block
 
         # Load map between servers and their number of tokens processed
         self._server_state: dict[str, KvCacheAwareServerState] = {
-            server: KvCacheAwareServerState(server, use_tokens)
+            server: KvCacheAwareServerState(server, use_tokens,
+                                            tokens_per_block)
             for server in servers or []
         }
 
@@ -642,7 +716,6 @@ class KvCacheAwareRouter(Router):
         self._tokenizers = {}
         # TODO: use max_num_tokens? per server?
         self._max_batch_size = max_batch_size
-        self._tokens_per_block = tokens_per_block
 
     def _tokenize(self, request: OpenAIRequest) -> list[list[int]]:
         prompts = request.prompt
@@ -662,6 +735,48 @@ class KvCacheAwareRouter(Router):
         tokenizer = self._tokenizers[request.model]
         return [tokenizer(prompt)["input_ids"] for prompt in prompts]
 
+    async def _get_server_hash_algo(self, server: str) -> str:
+        server_info = self._server_info.get(server, {})
+        hash_algo = server_info.get("kv_cache_hash_algo")
+        return await self._server_state[server].get_hash_algo(hash_algo)
+
+    def _compute_block_hashes(
+            self,
+            token_lists: list[list[int]],
+            hash_algo: str = KV_CACHE_HASH_ALGO_DEFAULT
+    ) -> list[list[BlockHash]]:
+        if hash_algo == KV_CACHE_HASH_ALGO_V1:
+            block_hasher = block_key_hasher
+        elif hash_algo == KV_CACHE_HASH_ALGO_V2:
+            block_hasher = v2_sha256_block_hasher
+        elif hash_algo == KV_CACHE_HASH_ALGO_V2_SHA256_64:
+            block_hashes: list[list[BlockHash]] = []
+            for token_list in token_lists:
+                hash_list = []
+                parent_key = V2RootBlock.make_key(None)
+                for t in range(0, len(token_list) - 1, self._tokens_per_block):
+                    t_end = min(t + self._tokens_per_block, len(token_list) - 1)
+                    parent_key = V2Block.make_key(parent_key,
+                                                  token_list[t:t_end])
+                    hash_list.append(truncate_sha256_hash_to_int64(parent_key))
+                block_hashes.append(hash_list)
+            return block_hashes
+        else:
+            raise ValueError(
+                f"Unsupported KV cache hash algorithm: {hash_algo}")
+
+        block_hashes: list[list[BlockHash]] = []
+        for token_list in token_lists:
+            hash_list = []
+            # in KvCacheManager, the last token is not included in the block key
+            for t in range(0, len(token_list) - 1, self._tokens_per_block):
+                t_end = min(t + self._tokens_per_block, len(token_list) - 1)
+                hash_list.append(
+                    block_hasher(token_list[t:t_end],
+                                 None if t == 0 else hash_list[-1]))
+            block_hashes.append(hash_list)
+        return block_hashes
+
     async def get_next_server(
             self,
             request: OpenAIRequest,
@@ -671,42 +786,53 @@ class KvCacheAwareRouter(Router):
                 server for server in self._server_state.keys()
                 if server != exclude_server
             ])
+            if not servers:
+                raise ValueError(
+                    f"No available servers after excluding {exclude_server}")
         token_lists = self._tokenize(request)
-        block_hashes: list[list[int]] = []
-        for token_list in token_lists:
-            hash_list = []
-            # in KvCacheManager, the last token is not included in the block key
-            for t in range(0, len(token_list) - 1, self._tokens_per_block):
-                t_end = min(t + self._tokens_per_block, len(token_list) - 1)
-                hash_list.append(
-                    block_key_hasher(token_list[t:t_end],
-                                     None if t == 0 else hash_list[-1]))
-            block_hashes.append(hash_list)
-        padded_tokens = sum(
-            len(hash_list)
-            for hash_list in block_hashes) * self._tokens_per_block
+        hash_algo_by_server = {
+            server: await self._get_server_hash_algo(server)
+            for server in servers
+        }
+        block_hashes_by_algo = {
+            hash_algo: self._compute_block_hashes(token_lists, hash_algo)
+            for hash_algo in set(hash_algo_by_server.values())
+        }
+        padded_tokens_by_algo = {
+            hash_algo:
+            max(
+                sum(len(hash_list)
+                    for hash_list in block_hashes) * self._tokens_per_block, 1)
+            for hash_algo, block_hashes in block_hashes_by_algo.items()
+        }
         # select the server by (KV match - load)
         # TODO: more options
         workloads = [
-            state.num_active_requests()
-            for state in self._server_state.values()
+            self._server_state[server].num_active_requests()
+            for server in servers
         ]
         scores = []
         matches = []
         for i in range(len(servers)):
             server = servers[i]
+            hash_algo = hash_algo_by_server[server]
+            block_hashes = block_hashes_by_algo[hash_algo]
+            padded_tokens = padded_tokens_by_algo[hash_algo]
             # https://github.com/ai-dynamo/dynamo/blob/main/docs/kv_cache_routing.md#kv-cache-routing-and-load-balancing
-            matches.append(
-                await self._server_state[server].matched_tokens(block_hashes))
+            matches.append(await self._server_state[server].matched_tokens(
+                block_hashes, hash_algo))
             score = matches[-1] / padded_tokens - workloads[
                 i] / self._max_batch_size
             scores.append(score)
         server = servers[scores.index(max(scores))]
+        hash_algo = hash_algo_by_server[server]
+        block_hashes = block_hashes_by_algo[hash_algo]
         async with self._lock:
             await self._server_state[server].increment_load(request)
             self._req_routing_table[id(request)] = server
         return server, {
-            "block_hashes": block_hashes,  # list[list[int]]
+            "block_hashes": block_hashes,  # list[list[int | str]]
+            "hash_algo": hash_algo,
             "token_lists": token_lists,  # list[list[int]]
             "matches": matches,  # list[int]
             "server_info": self._server_info.get(server, {}),
@@ -718,14 +844,14 @@ class KvCacheAwareRouter(Router):
         async with self._lock:
             server = self._req_routing_table[id(request)]
             del self._req_routing_table[id(request)]
-            if server in self._server_state:
-                await self._server_state[server].decrement_load(request,
-                                                                session=session)
+            server_state = self._server_state.get(server)
+        if server_state is not None:
+            await server_state.decrement_load(request, session=session)
 
     def _on_servers_updated(self, old_servers, new_servers):
         for new_server in new_servers:
             self._server_state[new_server] = KvCacheAwareServerState(
-                new_server, self._use_tokens)
+                new_server, self._use_tokens, self._tokens_per_block)
         for old_server in old_servers:
             self._server_state.pop(old_server, None)
 

--- a/tests/integration/defs/disaggregated/test_workers.py
+++ b/tests/integration/defs/disaggregated/test_workers.py
@@ -21,9 +21,11 @@ from tensorrt_llm import logger
 from tensorrt_llm.serve.openai_client import OpenAIHttpClient
 from tensorrt_llm.serve.openai_protocol import (CompletionRequest,
                                                 DisaggregatedParams)
-from tensorrt_llm.serve.router import (KvCacheAwareRouter,
+from tensorrt_llm.serve.router import (KV_CACHE_HASH_ALGO_V1,
+                                       KV_CACHE_HASH_ALGO_V2,
+                                       KvCacheAwareRouter,
                                        KvCacheAwareServerState, ServerRole,
-                                       block_key_hasher)
+                                       block_key_hasher, v2_sha256_block_hasher)
 
 
 def build_worker_config(base_config, server_type_config, disagg_cluster):
@@ -165,6 +167,8 @@ class BasicWorkerTester:
         events = []
         for event_raw in events_raw:
             event = {"id": event_raw["event_id"]} | event_raw["data"]
+            if "hash_algo" in event_raw:
+                event["hash_algo"] = event_raw["hash_algo"]
             if event["type"] == "stored":
                 for block in event["blocks"]:
                     block["token_id"] = [
@@ -179,6 +183,27 @@ class BasicWorkerTester:
                     del block["tokens"]
             events.append(event)
         return events
+
+    @staticmethod
+    def compute_block_hashes(tokens: list[int], tokens_per_block: int,
+                             hash_algo: str):
+        block_hashes = []
+        if hash_algo == KV_CACHE_HASH_ALGO_V1:
+            block_hasher = block_key_hasher
+        elif hash_algo == KV_CACHE_HASH_ALGO_V2:
+            block_hasher = v2_sha256_block_hasher
+        else:
+            raise ValueError(
+                f"Unsupported KV cache hash algorithm: {hash_algo}")
+        for t in range(0, len(tokens) - 1, tokens_per_block):
+            t_end = min(t + tokens_per_block, len(tokens) - 1)
+            if t_end - t < tokens_per_block:
+                # partial block
+                break
+            block_hashes.append(
+                block_hasher(tokens[t:t_end],
+                             None if t == 0 else block_hashes[-1]))
+        return block_hashes
 
 
 class ConditionalWorkerTester(BasicWorkerTester):
@@ -293,17 +318,16 @@ class KvCacheEventWorkerTester(BasicWorkerTester):
         for i in range(max_rounds):
             # split tokens into blocks and check block match count by hash
             tokens = self.tokenizer(request["prompt"])["input_ids"]
-            block_hashes = []
-            for t in range(0, len(tokens) - 1, tokens_per_block):
-                t_end = min(t + tokens_per_block, len(tokens) - 1)
-                if t_end - t < tokens_per_block:
-                    # partial block
-                    break
-                block_hashes.append(
-                    block_key_hasher(tokens[t:t_end],
-                                     None if t == 0 else block_hashes[-1]))
-            ctx_match_count = await ctx_blocks.matched_tokens([block_hashes])
-            gen_match_count = await gen_blocks.matched_tokens([block_hashes])
+            block_hashes_by_algo = {}
+            for hash_algo in {ctx_blocks.hash_algo, gen_blocks.hash_algo}:
+                block_hashes_by_algo[hash_algo] = self.compute_block_hashes(
+                    tokens, tokens_per_block, hash_algo)
+            ctx_match_count = await ctx_blocks.matched_tokens(
+                [block_hashes_by_algo[ctx_blocks.hash_algo]],
+                hash_algo=ctx_blocks.hash_algo)
+            gen_match_count = await gen_blocks.matched_tokens(
+                [block_hashes_by_algo[gen_blocks.hash_algo]],
+                hash_algo=gen_blocks.hash_algo)
             ctx_evicted = False
             gen_evicted = False
             for event in ctx_events:

--- a/tests/unittest/_torch/executor/test_resource_manager.py
+++ b/tests/unittest/_torch/executor/test_resource_manager.py
@@ -12,8 +12,9 @@ import torch
 import tensorrt_llm
 import tensorrt_llm.bindings
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
-from tensorrt_llm._torch.pyexecutor.resource_manager import (KVCacheManager,
-                                                             PeftCacheManager)
+from tensorrt_llm._torch.pyexecutor.resource_manager import (
+    KVCacheManager, PeftCacheManager,
+    _warn_if_unsupported_v1_kv_cache_event_hash_algo)
 from tensorrt_llm.bindings import LayerType
 from tensorrt_llm.bindings import ModelConfig as ModelConfigCpp
 from tensorrt_llm.bindings import executor as tllm
@@ -22,6 +23,9 @@ from tensorrt_llm.bindings.internal.batch_manager import \
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig, PeftCacheConfig
 from tensorrt_llm.lora_helper import LoraConfig
 from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.runtime.kv_cache_hash import (KV_CACHE_HASH_ALGO_AUTO,
+                                                KV_CACHE_HASH_ALGO_V1,
+                                                KV_CACHE_HASH_ALGO_V2)
 from tensorrt_llm.sampling_params import SamplingParams
 
 DataType = tensorrt_llm.bindings.DataType
@@ -31,6 +35,33 @@ current_dir = pathlib.Path(__file__).parent.resolve()
 root_dir = current_dir.parent.parent.parent.parent
 
 sys.path.append(str(root_dir / "tests" / "integration"))
+
+
+def test_v1_kv_cache_event_hash_algo_warning_for_non_v1():
+    with patch("tensorrt_llm._torch.pyexecutor.resource_manager.logger.warning"
+               ) as warning:
+        _warn_if_unsupported_v1_kv_cache_event_hash_algo(KV_CACHE_HASH_ALGO_V2)
+
+    warning.assert_called_once()
+    assert KV_CACHE_HASH_ALGO_V1 in warning.call_args.args[0]
+    assert KV_CACHE_HASH_ALGO_V2 in warning.call_args.args[0]
+
+
+def test_v1_kv_cache_event_hash_algo_no_warning_for_v1():
+    with patch("tensorrt_llm._torch.pyexecutor.resource_manager.logger.warning"
+               ) as warning:
+        _warn_if_unsupported_v1_kv_cache_event_hash_algo(KV_CACHE_HASH_ALGO_V1)
+
+    warning.assert_not_called()
+
+
+def test_v1_kv_cache_event_hash_algo_no_warning_for_auto():
+    with patch("tensorrt_llm._torch.pyexecutor.resource_manager.logger.warning"
+               ) as warning:
+        _warn_if_unsupported_v1_kv_cache_event_hash_algo(
+            KV_CACHE_HASH_ALGO_AUTO)
+
+    warning.assert_not_called()
 
 
 class TestResourceManager(unittest.TestCase):

--- a/tests/unittest/disaggregated/test_disagg_openai_client.py
+++ b/tests/unittest/disaggregated/test_disagg_openai_client.py
@@ -141,7 +141,7 @@ class TestOpenAIHttpClient:
         assert isinstance(response, CompletionResponse)
         assert response.model == "test-model"
         mock_session.post.assert_called_once()
-        mock_router.finish_request.assert_called_once_with(completion_request)
+        mock_router.finish_request.assert_called_once_with(completion_request, mock_session)
 
     @pytest.mark.asyncio
     async def test_streaming_completion_request(
@@ -183,7 +183,9 @@ class TestOpenAIHttpClient:
         for i, chunk in enumerate(chunks):
             assert chunk == dummy_data[i]
         mock_session.post.assert_called_once()
-        mock_router.finish_request.assert_called_once_with(streaming_completion_request)
+        mock_router.finish_request.assert_called_once_with(
+            streaming_completion_request, mock_session
+        )
 
     @pytest.mark.asyncio
     async def test_request_with_custom_server(
@@ -221,7 +223,7 @@ class TestOpenAIHttpClient:
             await openai_client.send_request(completion_request)
 
         # Should finish request on error
-        mock_router.finish_request.assert_called_once_with(completion_request)
+        mock_router.finish_request.assert_called_once_with(completion_request, mock_session)
 
     @pytest.mark.asyncio
     async def test_request_with_retry(

--- a/tests/unittest/disaggregated/test_openai_server_info.py
+++ b/tests/unittest/disaggregated/test_openai_server_info.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+from tensorrt_llm.runtime.kv_cache_hash import KV_CACHE_HASH_ALGO_V1, KV_CACHE_HASH_ALGO_V2
+from tensorrt_llm.serve.openai_server import OpenAIServer
+
+
+@pytest.mark.asyncio
+async def test_server_info_includes_effective_kv_cache_hash_algo():
+    server = object.__new__(OpenAIServer)
+    server.generator = SimpleNamespace(
+        disaggregated_params=None,
+        args=SimpleNamespace(kv_cache_config=KvCacheConfig()),
+    )
+
+    response = await server.get_server_info()
+    content = json.loads(response.body)
+    assert content["kv_cache_hash_algo"] == KV_CACHE_HASH_ALGO_V1
+
+    server.generator.args.kv_cache_config = KvCacheConfig(use_kv_cache_manager_v2=True)
+    response = await server.get_server_info()
+    content = json.loads(response.body)
+    assert content["kv_cache_hash_algo"] == KV_CACHE_HASH_ALGO_V2

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -5,11 +5,22 @@ from unittest import mock
 import pytest
 
 from tensorrt_llm.llmapi.disagg_utils import RouterConfig
+from tensorrt_llm.runtime.kv_cache_hash import truncate_sha256_hash_to_int64
+from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import \
+    sequence_to_blockchain_keys
 from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
                                                 CompletionRequest,
                                                 DisaggregatedParams)
-from tensorrt_llm.serve.router import (KvCacheAwareRouter, LoadBalancingRouter,
-                                       RoundRobinRouter, create_router)
+# yapf: disable
+from tensorrt_llm.serve.router import (KV_CACHE_HASH_ALGO_V1,
+                                       KV_CACHE_HASH_ALGO_V2,
+                                       KV_CACHE_HASH_ALGO_V2_SHA256_64,
+                                       KvCacheAwareRouter,
+                                       KvCacheAwareServerState,
+                                       LoadBalancingRouter, RoundRobinRouter,
+                                       create_router)
+
+# yapf: enable
 
 
 # Mock class for metadata server
@@ -246,6 +257,254 @@ async def test_gen_tokens_balancing_router(servers, requests_fixture, request):
     # Should throw an error if trying to use tokens load balancing with gen-only requests or chat completion requests
     with pytest.raises(ValueError):
         await router.get_next_server(requests[0])
+
+
+def test_v2_sha256_block_hashes_match_kv_cache_manager_v2(servers):
+    tokens_per_block = 4
+    token_lists = [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                tokens_per_block=tokens_per_block)
+
+    block_hashes = router._compute_block_hashes(token_lists,
+                                                hash_algo=KV_CACHE_HASH_ALGO_V2)
+    expected_block_hashes = [
+        block_key.hex()
+        for token_block, block_key in sequence_to_blockchain_keys(
+            tokens_per_block, None, token_lists[0][:-1]) if token_block
+    ]
+
+    assert block_hashes == [expected_block_hashes]
+
+
+def test_v2_sha256_64_block_hashes_match_truncated_kv_cache_manager_v2(servers):
+    tokens_per_block = 4
+    token_lists = [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                tokens_per_block=tokens_per_block)
+
+    block_hashes = router._compute_block_hashes(
+        token_lists, hash_algo=KV_CACHE_HASH_ALGO_V2_SHA256_64)
+    expected_block_hashes = [
+        truncate_sha256_hash_to_int64(block_key)
+        for token_block, block_key in sequence_to_blockchain_keys(
+            tokens_per_block, None, token_lists[0][:-1]) if token_block
+    ]
+
+    assert block_hashes == [expected_block_hashes]
+    assert all(isinstance(block_hash, int) for block_hash in block_hashes[0])
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_server_state_uses_hash_algo():
+    tokens_per_block = 4
+    token_lists = [[1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server1"],
+                                tokens_per_block=tokens_per_block)
+    v1_block_hashes = router._compute_block_hashes(
+        token_lists, hash_algo=KV_CACHE_HASH_ALGO_V1)
+    v2_block_hashes = router._compute_block_hashes(
+        token_lists, hash_algo=KV_CACHE_HASH_ALGO_V2)
+    v2_64_block_hashes = router._compute_block_hashes(
+        token_lists, hash_algo=KV_CACHE_HASH_ALGO_V2_SHA256_64)
+    state = KvCacheAwareServerState("server1",
+                                    tokens_per_block=tokens_per_block)
+
+    state.update_with_events([{
+        "event_id": 0,
+        "hash_algo": KV_CACHE_HASH_ALGO_V2,
+        "data": {
+            "type":
+            "stored",
+            "parent_hash":
+            None,
+            "blocks": [{
+                "block_hash": block_hash
+            } for block_hash in v2_block_hashes[0]],
+        },
+    }])
+
+    assert state.hash_algo == KV_CACHE_HASH_ALGO_V2
+    assert await state.matched_tokens(v2_block_hashes,
+                                      hash_algo=KV_CACHE_HASH_ALGO_V2) == 8
+    assert await state.matched_tokens(v1_block_hashes,
+                                      hash_algo=KV_CACHE_HASH_ALGO_V1) == 0
+    state.add_blocks(["manual-v2-block"])
+    assert state.hash_algo == KV_CACHE_HASH_ALGO_V2
+    assert await state.matched_tokens([["manual-v2-block"]],
+                                      hash_algo=KV_CACHE_HASH_ALGO_V2) == 4
+    assert await state.matched_tokens([["manual-v2-block"]],
+                                      hash_algo=KV_CACHE_HASH_ALGO_V1) == 0
+    state.remove_blocks(["manual-v2-block"])
+    assert await state.matched_tokens([["manual-v2-block"]],
+                                      hash_algo=KV_CACHE_HASH_ALGO_V2) == 0
+
+    state.update_with_events([{
+        "event_id": 1,
+        "hash_algo": KV_CACHE_HASH_ALGO_V2_SHA256_64,
+        "data": {
+            "type":
+            "stored",
+            "parent_hash":
+            None,
+            "blocks": [{
+                "block_hash": block_hash
+            } for block_hash in v2_64_block_hashes[0]],
+        },
+    }])
+
+    assert state.hash_algo == KV_CACHE_HASH_ALGO_V2_SHA256_64
+    assert await state.matched_tokens(
+        v2_64_block_hashes, hash_algo=KV_CACHE_HASH_ALGO_V2_SHA256_64) == 8
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_routes_to_v2_server(servers):
+    tokens_per_block = 4
+    token_lists = [[1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                use_tokens=False,
+                                max_batch_size=32,
+                                tokens_per_block=tokens_per_block)
+    v2_block_hashes = router._compute_block_hashes(
+        token_lists, hash_algo=KV_CACHE_HASH_ALGO_V2)
+    v2_server = servers[1]
+    router._server_state[v2_server].update_with_events([{
+        "event_id": 0,
+        "hash_algo": KV_CACHE_HASH_ALGO_V2,
+        "data": {
+            "type":
+            "stored",
+            "parent_hash":
+            None,
+            "blocks": [{
+                "block_hash": block_hash
+            } for block_hash in v2_block_hashes[0]],
+        },
+    }])
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    server, info = await router.get_next_server(request)
+    await router.finish_request(request)
+
+    assert server == v2_server
+    assert info["hash_algo"] == KV_CACHE_HASH_ALGO_V2
+    assert info["block_hashes"] == v2_block_hashes
+    assert info["matches"] == [0, 8, 0]
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_uses_server_info_hash_algo(servers):
+    tokens_per_block = 4
+    token_lists = [[1000, 1001, 1002, 1003, 1004]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=[servers[0]],
+                                tokens_per_block=tokens_per_block)
+    router._server_info[servers[0]] = {
+        "kv_cache_hash_algo": KV_CACHE_HASH_ALGO_V2
+    }
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    server, info = await router.get_next_server(request)
+    await router.finish_request(request)
+
+    assert server == servers[0]
+    assert info["hash_algo"] == KV_CACHE_HASH_ALGO_V2
+    assert router._server_state[servers[0]].hash_algo == KV_CACHE_HASH_ALGO_V2
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_finish_request_polls_events(servers):
+
+    class MockPostResponse:
+
+        def __init__(self, events):
+            self._events = events
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def json(self):
+            return self._events
+
+    class MockSession:
+
+        def __init__(self, events):
+            self._events = events
+            self.post_url = None
+
+        def post(self, url):
+            self.post_url = url
+            return MockPostResponse(self._events)
+
+    tokens_per_block = 4
+    token_lists = [[1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=[servers[0]],
+                                use_tokens=False,
+                                max_batch_size=32,
+                                tokens_per_block=tokens_per_block)
+    block_hashes = router._compute_block_hashes(token_lists,
+                                                hash_algo=KV_CACHE_HASH_ALGO_V1)
+    events = [{
+        "event_id": 0,
+        "hash_algo": KV_CACHE_HASH_ALGO_V1,
+        "data": {
+            "type":
+            "stored",
+            "parent_hash":
+            None,
+            "blocks": [{
+                "block_hash": block_hash
+            } for block_hash in block_hashes[0]],
+        },
+    }]
+    session = MockSession(events)
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    await router.get_next_server(request)
+    await router.finish_request(request, session)
+
+    assert session.post_url == f"{servers[0]}/kv_cache_events"
+    assert await router._server_state[servers[0]].matched_tokens(
+        block_hashes, hash_algo=KV_CACHE_HASH_ALGO_V1) == 8
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_finish_request_decrements_on_poll_error(
+        servers):
+
+    class FailingSession:
+
+        def post(self, url):
+            raise RuntimeError(f"failed to post to {url}")
+
+    tokens_per_block = 4
+    token_lists = [[1000, 1001, 1002, 1003, 1004]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=[servers[0]],
+                                use_tokens=False,
+                                max_batch_size=32,
+                                tokens_per_block=tokens_per_block)
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    await router.get_next_server(request)
+    assert router._server_state[servers[0]].num_active_requests() == 1
+
+    await router.finish_request(request, FailingSession())
+
+    assert router._server_state[servers[0]].num_active_requests() == 0
+    assert id(request) not in router._req_routing_table
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_event_manager.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_event_manager.py
@@ -1,0 +1,896 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import gc
+import os
+import threading
+import time
+from importlib.util import find_spec
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from tensorrt_llm._utils import KVCacheEventSerializer
+from tensorrt_llm.runtime.kv_cache_hash import (
+    KV_CACHE_HASH_ALGO_V1,
+    KV_CACHE_HASH_ALGO_V2_SHA256_64,
+    truncate_sha256_hash_to_int64,
+)
+from tensorrt_llm.runtime.kv_cache_manager_v2._event_manager import (
+    KVCacheEventDiff,
+    KVCacheEventManager,
+    KVCacheStoredBlockData,
+    UniqueToken,
+)
+
+if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
+    from kv_cache_manager_v2 import CacheLevel, CudaStream, KVCacheManager, TokenId
+    from kv_cache_manager_v2._block_radix_tree import Block, RootBlock
+    from kv_cache_manager_v2._utils import CachedCudaStream, init_cuda_once, temporary_sys_path
+else:
+    from tensorrt_llm.runtime.kv_cache_manager_v2 import (
+        CacheLevel,
+        CudaStream,
+        KVCacheManager,
+        TokenId,
+    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import Block, RootBlock
+    from tensorrt_llm.runtime.kv_cache_manager_v2._utils import (
+        CachedCudaStream,
+        init_cuda_once,
+        temporary_sys_path,
+    )
+
+try:
+    import torch
+except ImportError:
+    torch = None
+
+
+class _FakePage:
+    def __init__(self, cache_level=CacheLevel(0), priority=0):
+        self.cache_level = cache_level
+        self.priority = priority
+
+
+class _FakePageRef:
+    def __init__(self, page):
+        self._page = page
+
+    def __call__(self):
+        return self._page
+
+
+class _FakeRootBlock:
+    ordinal = -1
+
+
+class _FakeBlock:
+    def __init__(self, key, tokens, num_life_cycles=1, prev=None):
+        self.key = key
+        self.tokens = tokens
+        self.prev = prev or _FakeRootBlock()
+        self.ordinal = getattr(self.prev, "ordinal", -1) + 1
+        self.storage = [_FakePageRef(_FakePage()) for _ in range(num_life_cycles)]
+
+
+with temporary_sys_path(os.path.dirname(os.path.abspath(__file__))):
+    from test_kv_cache_manager_v2 import create_config
+
+
+def _create_test_manager(
+    event_manager,
+    *,
+    tokens_per_block=4,
+    gpu_quota=16 << 20,
+    host_quota=0,
+    window_size=None,
+    kv_buf_size=8192,
+):
+    return KVCacheManager(
+        create_config(
+            tokens_per_block=tokens_per_block,
+            gpu_quota=gpu_quota,
+            host_quota=host_quota,
+            disk_quota=0,
+            num_layers=2,
+            window_size=window_size,
+            sink_tokens=0,
+            kv_buf_size=kv_buf_size,
+        ),
+        event_manager=event_manager,
+    )
+
+
+def _token_ids(start, end):
+    return [TokenId(token_id) for token_id in range(start, end)]
+
+
+def _flush_serialized_events(event_manager):
+    event_manager.flush_iteration_events()
+    return KVCacheEventSerializer.serialize(event_manager.get_latest_events(0))
+
+
+def _stored_events(events):
+    return [event for event in events if event["data"]["type"] == "stored"]
+
+
+def _stored_block_hashes(events):
+    return [
+        block["block_hash"] for event in _stored_events(events) for block in event["data"]["blocks"]
+    ]
+
+
+def _stored_block_hashes_by_layer_group(events):
+    return {
+        event["layer_group_id"]: [block["block_hash"] for block in event["data"]["blocks"]]
+        for event in _stored_events(events)
+    }
+
+
+def _commit_and_close(manager, stream, tokens, *, input_tokens=None):
+    kv_cache = manager.create_kv_cache(input_tokens=input_tokens)
+    assert kv_cache.resume(stream)
+    kv_cache.capacity = len(input_tokens or []) + len(tokens)
+    kv_cache.commit(tokens)
+    kv_cache.close()
+    del kv_cache
+    gc.collect()
+
+
+def test_v2_kv_cache_event_manager_serialization():
+    event_manager = KVCacheEventManager(max_kv_event_entries=4, window_size=128)
+    event_manager.add_created_event([2, 3])
+    event_manager.add_stored_event(
+        parent_hash=None,
+        blocks=[
+            KVCacheStoredBlockData(
+                block_hash="abcd",
+                tokens=[UniqueToken(1), UniqueToken(2)],
+                cache_level=0,
+                priority=0,
+            )
+        ],
+    )
+    event_manager.add_removed_event("abcd")
+
+    event_manager.flush_iteration_events()
+    events = KVCacheEventSerializer.serialize(event_manager.get_latest_events())
+
+    assert [event["event_id"] for event in events] == [0, 1, 2]
+    assert [event["hash_algo"] for event in events] == ["v2_sha256"] * 3
+    assert events[0]["window_size"] == 128
+    assert events[0]["data"] == {
+        "type": "created",
+        "num_blocks_per_cache_level": [2, 3],
+    }
+    assert events[1]["data"]["type"] == "stored"
+    assert events[1]["data"]["parent_hash"] is None
+    assert events[1]["data"]["blocks"][0]["block_hash"] == "abcd"
+    assert events[1]["data"]["blocks"][0]["tokens"][0] == {
+        "type": "unique_token",
+        "token_id": 1,
+        "token_extra_id": 0,
+    }
+    assert events[1]["data"]["blocks"][0]["mm_keys"] == []
+    assert events[2]["data"] == {
+        "type": "removed",
+        "block_hashes": ["abcd"],
+    }
+    assert event_manager.get_latest_events(0) == []
+
+
+def test_v2_kv_cache_event_manager_default_get_latest_events_waits():
+    event_manager = KVCacheEventManager(max_kv_event_entries=4, window_size=128)
+    events = []
+
+    def get_events():
+        events.extend(event_manager.get_latest_events())
+
+    thread = threading.Thread(target=get_events)
+    thread.start()
+    time.sleep(0.05)
+
+    assert thread.is_alive()
+
+    event_manager.add_created_event([1])
+    event_manager.flush_iteration_events()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert len(events) == 1
+    assert events[0].data.num_blocks_per_cache_level == [1]
+
+
+def test_v2_kv_cache_event_manager_uses_layer_group_window_size():
+    event_manager = KVCacheEventManager(
+        max_kv_event_entries=4,
+        window_size=4096,
+        window_size_by_layer_group={
+            0: 128,
+            1: 4096,
+        },
+    )
+
+    event_manager.add_created_event([1], layer_group_ids=[0, 1])
+    event_manager.flush_iteration_events()
+    events = event_manager.get_latest_events(0)
+
+    assert [event.layer_group_id for event in events] == [0, 1]
+    assert [event.window_size for event in events] == [128, 4096]
+
+
+def test_truncate_sha256_hash_to_int64_uses_unsigned_value():
+    assert truncate_sha256_hash_to_int64(b"\x80" + b"\x00" * 31) == 1 << 63
+    assert truncate_sha256_hash_to_int64(b"\xff" * 32) == (1 << 64) - 1
+
+
+def test_v2_kv_cache_event_diff_positional_order_matches_v1():
+    diff = KVCacheEventDiff(3, 5)
+
+    assert diff.old_value == 3
+    assert diff.new_value == 5
+
+
+def test_v2_kv_cache_event_manager_drops_oldest_events():
+    event_manager = KVCacheEventManager(max_kv_event_entries=2, window_size=128)
+    event_manager.add_created_event([1])
+    event_manager.add_stored_event(
+        parent_hash=None,
+        blocks=[
+            KVCacheStoredBlockData(
+                block_hash="stored",
+                tokens=[UniqueToken(1)],
+                cache_level=0,
+                priority=0,
+            )
+        ],
+    )
+    event_manager.add_removed_event("a")
+    event_manager.add_removed_event("b")
+
+    event_manager.flush_iteration_events()
+    events = KVCacheEventSerializer.serialize(event_manager.get_latest_events())
+
+    assert [event["event_id"] for event in events] == [1, 2]
+    assert events[0]["data"]["blocks"][0]["block_hash"] == "stored"
+    assert events[1]["data"]["block_hashes"] == ["a", "b"]
+
+
+def test_v2_kv_cache_event_manager_accepts_removed_iterables():
+    event_manager = KVCacheEventManager(max_kv_event_entries=2, window_size=128)
+    event_manager.add_removed_event(["a", "b"])
+
+    event_manager.flush_iteration_events()
+    events = KVCacheEventSerializer.serialize(event_manager.get_latest_events())
+
+    assert len(events) == 1
+    assert events[0]["data"] == {
+        "type": "removed",
+        "block_hashes": ["a", "b"],
+    }
+
+
+def test_v2_kv_cache_event_manager_coalesces_contiguous_stored_events():
+    event_manager = KVCacheEventManager(max_kv_event_entries=8, window_size=128)
+    block0 = _FakeBlock(b"\xab\xcd", [1, 2], num_life_cycles=2)
+    block1 = _FakeBlock(b"\xab\xce", [3, 4], num_life_cycles=2, prev=block0)
+
+    event_manager.add_stored_block_event_from_block(block0)
+    event_manager.add_stored_block_event_from_block(block1)
+
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["data"]["type"] for event in events] == ["stored", "stored"]
+    assert [event["layer_group_id"] for event in events] == [0, 1]
+    assert [block["block_hash"] for block in events[0]["data"]["blocks"]] == [
+        "abcd",
+        "abce",
+    ]
+    assert [block["block_hash"] for block in events[1]["data"]["blocks"]] == [
+        "abcd",
+        "abce",
+    ]
+    assert events[0]["data"]["parent_hash"] is None
+    assert events[1]["data"]["parent_hash"] is None
+
+
+def test_v2_kv_cache_event_manager_serializes_layer_group_id():
+    event_manager = KVCacheEventManager(max_kv_event_entries=4, window_size=128)
+    event_manager.add_created_event([2, 3], [0, 1])
+
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["layer_group_id"] for event in events] == [0, 1]
+    assert [event["data"] for event in events] == [
+        {
+            "type": "created",
+            "num_blocks_per_cache_level": [2, 3],
+        },
+        {
+            "type": "created",
+            "num_blocks_per_cache_level": [2, 3],
+        },
+    ]
+
+
+def test_v2_kv_cache_event_manager_sha256_64_compatibility_mode():
+    event_manager = KVCacheEventManager(
+        max_kv_event_entries=8,
+        window_size=128,
+        hash_algo=KV_CACHE_HASH_ALGO_V2_SHA256_64,
+    )
+    block0 = _FakeBlock(bytes.fromhex("8000000000000001" + "00" * 24), [1, 2])
+    block1 = _FakeBlock(bytes.fromhex("0102030405060708" + "00" * 24), [3, 4], prev=block0)
+
+    event_manager.add_stored_block_event_from_block(block0)
+    event_manager.add_stored_block_event_from_block(block1)
+    event_manager.add_removed_event(block0.key)
+    events = _flush_serialized_events(event_manager)
+
+    expected_block0_hash = truncate_sha256_hash_to_int64(block0.key)
+    expected_block1_hash = truncate_sha256_hash_to_int64(block1.key)
+    assert [event["hash_algo"] for event in events] == [
+        KV_CACHE_HASH_ALGO_V2_SHA256_64,
+        KV_CACHE_HASH_ALGO_V2_SHA256_64,
+    ]
+    assert events[0]["data"]["type"] == "stored"
+    assert events[0]["data"]["parent_hash"] is None
+    assert [block["block_hash"] for block in events[0]["data"]["blocks"]] == [
+        expected_block0_hash,
+        expected_block1_hash,
+    ]
+    assert events[1]["data"] == {
+        "type": "removed",
+        "block_hashes": [expected_block0_hash],
+    }
+    assert all(isinstance(block_hash, int) for block_hash in events[1]["data"]["block_hashes"])
+
+
+def test_v2_kv_cache_event_manager_v1_hash_algo_falls_back_to_sha256_64():
+    event_manager = KVCacheEventManager(
+        max_kv_event_entries=4,
+        window_size=128,
+        hash_algo=KV_CACHE_HASH_ALGO_V1,
+    )
+    block = _FakeBlock(bytes.fromhex("0102030405060708" + "00" * 24), [1, 2])
+
+    event_manager.add_stored_block_event_from_block(block)
+    events = _flush_serialized_events(event_manager)
+
+    expected_block_hash = truncate_sha256_hash_to_int64(block.key)
+    assert events[0]["hash_algo"] == KV_CACHE_HASH_ALGO_V2_SHA256_64
+    assert events[0]["data"]["blocks"][0]["block_hash"] == expected_block_hash
+
+
+def test_v2_kv_cache_event_manager_unknown_hash_algo_raises():
+    with pytest.raises(ValueError, match="Unsupported V2 KV cache event hash algorithm"):
+        KVCacheEventManager(
+            max_kv_event_entries=4,
+            window_size=128,
+            hash_algo="unknown_hash_algo",
+        )
+
+
+def test_v2_kv_cache_event_manager_gathers_attention_dp_events_on_rank_zero():
+    remote_manager = KVCacheEventManager(
+        max_kv_event_entries=4,
+        window_size=128,
+        attention_dp_rank=1,
+    )
+    remote_manager.add_created_event([3])
+    remote_manager.flush_iteration_events()
+    remote_event_objects = remote_manager.get_latest_events()
+    remote_events = KVCacheEventSerializer.serialize(remote_event_objects)
+    assert remote_events[0]["attention_dp_rank"] == 1
+
+    gathered_local_events = []
+
+    def gather(local_events):
+        gathered_local_events.extend(local_events)
+        return [
+            local_events,
+            remote_event_objects,
+        ]
+
+    event_manager = KVCacheEventManager(
+        max_kv_event_entries=4,
+        window_size=128,
+        attention_dp_rank=0,
+        attention_dp_gather=gather,
+    )
+    event_manager.add_created_event([2])
+
+    events = _flush_serialized_events(event_manager)
+
+    assert len(gathered_local_events) == 1
+    assert [event["attention_dp_rank"] for event in events] == [0, 1]
+    assert [event["data"]["num_blocks_per_cache_level"] for event in events] == [
+        [2],
+        [3],
+    ]
+
+
+def test_v2_kv_cache_event_manager_attention_dp_nonzero_rank_sends_without_publishing():
+    gathered_local_events = []
+
+    def gather(local_events):
+        gathered_local_events.extend(local_events)
+        return [
+            [],
+            local_events,
+        ]
+
+    event_manager = KVCacheEventManager(
+        max_kv_event_entries=1,
+        window_size=128,
+        attention_dp_rank=1,
+        attention_dp_gather=gather,
+    )
+    event_manager.add_created_event([2])
+    event_manager.add_created_event([3])
+
+    events = _flush_serialized_events(event_manager)
+
+    assert len(gathered_local_events) == 1
+    assert gathered_local_events[0].attention_dp_rank == 1
+    assert KVCacheEventSerializer.serialize(gathered_local_events)[0]["data"][
+        "num_blocks_per_cache_level"
+    ] == [3]
+    assert events == []
+
+
+def test_v2_kv_cache_event_manager_attention_dp_rank_zero_uses_dp_capacity():
+    remote_manager = KVCacheEventManager(
+        max_kv_event_entries=2,
+        window_size=128,
+        attention_dp_rank=1,
+    )
+    remote_manager.add_created_event([10])
+    remote_manager.add_created_event([11])
+    remote_manager.flush_iteration_events()
+    remote_event_objects = remote_manager.get_latest_events()
+
+    def gather(local_events):
+        return [
+            local_events,
+            remote_event_objects,
+        ]
+
+    event_manager = KVCacheEventManager(
+        max_kv_event_entries=1,
+        window_size=128,
+        attention_dp_rank=0,
+        attention_dp_gather=gather,
+    )
+    event_manager.add_created_event([1])
+    event_manager.add_created_event([2])
+
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["attention_dp_rank"] for event in events] == [0, 1]
+    assert [event["data"]["num_blocks_per_cache_level"] for event in events] == [
+        [2],
+        [11],
+    ]
+
+
+def test_v2_kv_cache_event_manager_serializes_updated_event():
+    event_manager = KVCacheEventManager(max_kv_event_entries=2, window_size=128)
+    event_manager.add_updated_event(
+        "abcd",
+        cache_level=KVCacheEventDiff(old_value=0, new_value=1),
+        priority=KVCacheEventDiff(old_value=1, new_value=2),
+    )
+
+    event_manager.flush_iteration_events()
+    events = KVCacheEventSerializer.serialize(event_manager.get_latest_events())
+
+    assert len(events) == 1
+    assert events[0]["hash_algo"] == "v2_sha256"
+    assert events[0]["data"] == {
+        "type": "updated",
+        "block_hash": "abcd",
+        "cache_level": {
+            "type": "event_diff",
+            "new_value": 1,
+            "old_value": 0,
+        },
+        "priority": {
+            "type": "event_diff",
+            "new_value": 2,
+            "old_value": 1,
+        },
+    }
+
+
+def test_v2_kv_cache_event_manager_uses_stored_registry_for_removed_event():
+    event_manager = KVCacheEventManager(max_kv_event_entries=8, window_size=128)
+    block = _FakeBlock(b"\xab\xcd", [1, 2])
+
+    event_manager.add_stored_block_event_from_block(block)
+    block.storage = []
+    event_manager.add_removed_event(block.key)
+    event_manager.add_removed_event(block.key)
+
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["data"]["type"] for event in events] == ["stored", "removed"]
+    assert [event["layer_group_id"] for event in events] == [0, 0]
+    assert events[0]["data"]["blocks"][0]["block_hash"] == "abcd"
+    assert "layer_groups" not in events[0]["data"]["blocks"][0]
+    assert events[1]["data"]["block_hashes"] == ["abcd"]
+    assert "layer_groups" not in events[1]["data"]
+
+
+def test_v2_kv_cache_event_manager_emits_partial_life_cycle_removed_events():
+    event_manager = KVCacheEventManager(max_kv_event_entries=8, window_size=128)
+    block = _FakeBlock(b"\xab\xcd", [1, 2], num_life_cycles=2)
+
+    event_manager.add_stored_block_event_from_block(block)
+    event_manager.add_removed_life_cycle_event(block.key, 0)
+
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["data"]["type"] for event in events] == [
+        "stored",
+        "stored",
+        "removed",
+    ]
+    assert [event["layer_group_id"] for event in events] == [0, 1, 0]
+    assert events[0]["data"]["blocks"][0]["block_hash"] == "abcd"
+    assert events[1]["data"]["blocks"][0]["block_hash"] == "abcd"
+    assert "layer_groups" not in events[0]["data"]["blocks"][0]
+    assert "layer_groups" not in events[1]["data"]["blocks"][0]
+    assert events[2]["data"]["block_hashes"] == ["abcd"]
+    assert "layer_groups" not in events[2]["data"]
+
+    event_manager.add_removed_life_cycle_event(block.key, 1)
+    event_manager.add_removed_life_cycle_event(block.key, 1)
+
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["data"]["type"] for event in events] == ["removed"]
+    assert events[0]["layer_group_id"] == 1
+    assert events[0]["data"]["block_hashes"] == ["abcd"]
+    assert "layer_groups" not in events[0]["data"]
+
+
+def test_v2_kv_cache_event_manager_whole_block_removal_clears_life_cycle_state():
+    event_manager = KVCacheEventManager(max_kv_event_entries=8, window_size=128)
+    block = _FakeBlock(b"\xab\xce", [1, 2], num_life_cycles=2)
+
+    event_manager.add_stored_block_event_from_block(block)
+    event_manager.add_removed_life_cycle_event(block.key, 0)
+    event_manager.add_removed_event(block.key)
+    event_manager.add_removed_event(block.key)
+
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["data"]["type"] for event in events] == [
+        "stored",
+        "stored",
+        "removed",
+        "removed",
+    ]
+    assert [event["layer_group_id"] for event in events] == [0, 1, 0, 1]
+    assert events[2]["data"]["block_hashes"] == ["abce"]
+    assert events[3]["data"]["block_hashes"] == ["abce"]
+
+
+def test_v2_kv_cache_event_manager_readds_life_cycle_emits_stored_event():
+    event_manager = KVCacheEventManager(max_kv_event_entries=8, window_size=128)
+    block = _FakeBlock(b"\xab\xcf", [1, 2], num_life_cycles=2)
+
+    event_manager.add_stored_block_event_from_block(block)
+    event_types = [event["data"]["type"] for event in _flush_serialized_events(event_manager)]
+    assert event_types == ["stored", "stored"]
+
+    event_manager.add_removed_life_cycle_event(block.key, 0)
+    event_manager.add_stored_life_cycle_event_from_block(block, 0)
+    event_manager.add_removed_life_cycle_event(block.key, 1)
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["data"]["type"] for event in events] == [
+        "removed",
+        "stored",
+        "removed",
+    ]
+    assert [event["layer_group_id"] for event in events] == [0, 0, 1]
+    assert events[0]["data"]["block_hashes"] == ["abcf"]
+    assert events[1]["data"]["blocks"][0]["block_hash"] == "abcf"
+    assert "layer_groups" not in events[1]["data"]["blocks"][0]
+    assert events[2]["data"]["block_hashes"] == ["abcf"]
+
+    event_manager.add_removed_life_cycle_event(block.key, 0)
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["data"]["type"] for event in events] == ["removed"]
+    assert events[0]["layer_group_id"] == 0
+    assert events[0]["data"]["block_hashes"] == ["abcf"]
+    assert "layer_groups" not in events[0]["data"]
+
+
+def test_v2_kv_cache_event_manager_reemits_stored_after_all_life_cycles_were_removed():
+    event_manager = KVCacheEventManager(max_kv_event_entries=8, window_size=128)
+    block = _FakeBlock(b"\xab\xd0", [1, 2])
+
+    event_manager.add_stored_block_event_from_block(block)
+    event_manager.add_removed_life_cycle_event(block.key, 0)
+    event_types = [event["data"]["type"] for event in _flush_serialized_events(event_manager)]
+    assert event_types == ["stored", "removed"]
+
+    event_manager.add_stored_life_cycle_event_from_block(block, 0)
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["data"]["type"] for event in events] == ["stored"]
+    assert events[0]["layer_group_id"] == 0
+    assert events[0]["data"]["blocks"][0]["block_hash"] == "abd0"
+    assert "layer_groups" not in events[0]["data"]["blocks"][0]
+
+
+def test_v2_kv_cache_event_manager_flushes_removed_before_updated_event():
+    event_manager = KVCacheEventManager(max_kv_event_entries=8, window_size=128)
+    removed_block = _FakeBlock(b"\xab\xd1", [1, 2])
+    updated_block = _FakeBlock(b"\xab\xd2", [3, 4])
+
+    event_manager.add_stored_block_event_from_block(removed_block)
+    event_manager.add_stored_block_event_from_block(updated_block)
+    _flush_serialized_events(event_manager)
+
+    event_manager.add_removed_event(removed_block.key)
+    event_manager.add_updated_event(
+        updated_block.key,
+        cache_level=KVCacheEventDiff(old_value=0, new_value=1),
+        layer_group_id=0,
+    )
+    events = _flush_serialized_events(event_manager)
+
+    assert [event["data"]["type"] for event in events] == ["removed", "updated"]
+    assert events[0]["data"]["block_hashes"] == ["abd1"]
+    assert events[1]["data"]["block_hash"] == "abd2"
+
+
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires CUDA")
+def test_v2_stored_events_match_block_hash_chain():
+    init_cuda_once()
+    gc.collect()
+    gc.disable()
+
+    event_manager = KVCacheEventManager(max_kv_event_entries=16, window_size=128)
+    manager = None
+    try:
+        tokens_per_block = 4
+        manager = _create_test_manager(event_manager, tokens_per_block=tokens_per_block)
+        stream_holder = CachedCudaStream()
+        stream = cast(CudaStream, stream_holder.handle)
+        tokens = _token_ids(0, 2 * tokens_per_block)
+
+        _commit_and_close(manager, stream, tokens)
+        events = _flush_serialized_events(event_manager)
+
+        stored_events = _stored_events(events)
+        assert len(stored_events) == 1
+
+        root_key = RootBlock.make_key(None)
+        block0_key = Block.make_key(root_key, tokens[:tokens_per_block])
+        block1_key = Block.make_key(block0_key, tokens[tokens_per_block:])
+        expected_hashes = [block0_key.hex(), block1_key.hex()]
+
+        assert _stored_block_hashes(stored_events) == expected_hashes
+        assert stored_events[0]["data"]["parent_hash"] is None
+        assert [
+            block["block_hash"] for block in stored_events[0]["data"]["blocks"]
+        ] == expected_hashes
+        assert [
+            token["token_id"] for token in stored_events[0]["data"]["blocks"][0]["tokens"]
+        ] == list(range(tokens_per_block))
+        assert [
+            token["token_id"] for token in stored_events[0]["data"]["blocks"][1]["tokens"]
+        ] == list(range(tokens_per_block, 2 * tokens_per_block))
+    finally:
+        gc.enable()
+        if manager is not None:
+            manager.shutdown()
+
+
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires CUDA")
+def test_v2_reused_prefix_does_not_emit_duplicate_stored_events():
+    init_cuda_once()
+    gc.collect()
+    gc.disable()
+
+    event_manager = KVCacheEventManager(max_kv_event_entries=16, window_size=128)
+    manager = None
+    try:
+        tokens_per_block = 4
+        manager = _create_test_manager(event_manager, tokens_per_block=tokens_per_block)
+        stream_holder = CachedCudaStream()
+        stream = cast(CudaStream, stream_holder.handle)
+        prefix_tokens = _token_ids(0, 2 * tokens_per_block)
+        new_tokens = _token_ids(2 * tokens_per_block, 3 * tokens_per_block)
+
+        _commit_and_close(manager, stream, prefix_tokens)
+        first_events = _flush_serialized_events(event_manager)
+        prefix_hashes = _stored_block_hashes(first_events)
+        assert len(prefix_hashes) == 2
+
+        _commit_and_close(
+            manager,
+            stream,
+            new_tokens,
+            input_tokens=prefix_tokens,
+        )
+        reuse_events = _flush_serialized_events(event_manager)
+        reused_hashes = _stored_block_hashes(reuse_events)
+
+        root_key = RootBlock.make_key(None)
+        block0_key = Block.make_key(root_key, prefix_tokens[:tokens_per_block])
+        block1_key = Block.make_key(block0_key, prefix_tokens[tokens_per_block:])
+        block2_key = Block.make_key(block1_key, new_tokens)
+
+        assert prefix_hashes == [block0_key.hex(), block1_key.hex()]
+        assert reused_hashes == [block2_key.hex()]
+        assert not (set(prefix_hashes) & set(reused_hashes))
+    finally:
+        gc.enable()
+        if manager is not None:
+            manager.shutdown()
+
+
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires CUDA")
+def test_v2_removed_events_match_stored_hashes():
+    init_cuda_once()
+    gc.collect()
+    gc.disable()
+
+    event_manager = KVCacheEventManager(max_kv_event_entries=16, window_size=128)
+    manager = None
+    try:
+        tokens_per_block = 4
+        manager = _create_test_manager(event_manager, tokens_per_block=tokens_per_block)
+        stream_holder = CachedCudaStream()
+        stream = cast(CudaStream, stream_holder.handle)
+        tokens = _token_ids(0, 2 * tokens_per_block)
+
+        _commit_and_close(manager, stream, tokens)
+        stored_events = _flush_serialized_events(event_manager)
+        stored_hashes = _stored_block_hashes(stored_events)
+        assert len(stored_hashes) == 2
+
+        manager.clear_reusable_blocks()
+        removal_events = _flush_serialized_events(event_manager)
+        removed_hashes = [
+            block_hash
+            for event in removal_events
+            if event["data"]["type"] == "removed"
+            for block_hash in event["data"]["block_hashes"]
+        ]
+
+        assert set(removed_hashes) == set(stored_hashes)
+        assert len(removed_hashes) == len(stored_hashes)
+    finally:
+        gc.enable()
+        if manager is not None:
+            manager.shutdown()
+
+
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires CUDA")
+def test_v2_removed_event_emitted_when_last_level_page_is_dropped():
+    init_cuda_once()
+    gc.collect()
+    gc.disable()
+
+    event_manager = KVCacheEventManager(max_kv_event_entries=16, window_size=4096)
+    manager = None
+    try:
+        tokens_per_block = 8
+        manager = _create_test_manager(
+            event_manager,
+            tokens_per_block=tokens_per_block,
+            gpu_quota=8 << 20,
+            window_size=4096,
+            kv_buf_size=1 << 20,
+        )
+        stream_holder = CachedCudaStream()
+        stream = cast(CudaStream, stream_holder.handle)
+        kv_cache = manager.create_kv_cache()
+        assert kv_cache.resume(stream)
+        kv_cache.capacity = tokens_per_block * 2
+        kv_cache.commit(_token_ids(0, tokens_per_block * 2))
+
+        stored_events = _flush_serialized_events(event_manager)
+        stored_hashes_by_layer_group = _stored_block_hashes_by_layer_group(stored_events)
+        assert set(stored_hashes_by_layer_group) == {0, 1}
+        assert stored_hashes_by_layer_group[0] == stored_hashes_by_layer_group[1]
+
+        kv_cache.close()
+        del kv_cache
+        gc.collect()
+
+        assert manager.resize(CacheLevel(0), 4 << 20)
+        removal_events = _flush_serialized_events(event_manager)
+        removed_hashes_by_layer_group = {
+            event["layer_group_id"]: event["data"]["block_hashes"]
+            for event in removal_events
+            if event["data"]["type"] == "removed"
+        }
+
+        assert set(removed_hashes_by_layer_group) == {0, 1}
+        assert removed_hashes_by_layer_group[0] == removed_hashes_by_layer_group[1]
+        for layer_group_id, removed_hashes in removed_hashes_by_layer_group.items():
+            assert len(removed_hashes) == 1
+            assert removed_hashes[0] in stored_hashes_by_layer_group[layer_group_id]
+    finally:
+        gc.enable()
+        if manager is not None:
+            manager.shutdown()
+
+
+@pytest.mark.skipif(torch is None or not torch.cuda.is_available(), reason="requires CUDA")
+def test_v2_kv_cache_event_manager_emits_updated_on_level_migration():
+    init_cuda_once()
+    gc.collect()
+    gc.disable()
+
+    event_manager = KVCacheEventManager(max_kv_event_entries=16, window_size=4096)
+    manager = None
+    try:
+        tokens_per_block = 8
+        manager = _create_test_manager(
+            event_manager,
+            tokens_per_block=tokens_per_block,
+            gpu_quota=8 << 20,
+            host_quota=8 << 20,
+            window_size=4096,
+            kv_buf_size=1 << 20,
+        )
+        stream_holder = CachedCudaStream()
+        stream = cast(CudaStream, stream_holder.handle)
+        kv_cache = manager.create_kv_cache()
+        assert kv_cache.resume(stream)
+        kv_cache.capacity = tokens_per_block * 2
+        kv_cache.commit([TokenId(token_id) for token_id in range(tokens_per_block * 2)])
+
+        stored_events = _flush_serialized_events(event_manager)
+        stored_hashes_by_layer_group = _stored_block_hashes_by_layer_group(stored_events)
+        assert set(stored_hashes_by_layer_group) == {0, 1}
+        assert stored_hashes_by_layer_group[0] == stored_hashes_by_layer_group[1]
+
+        kv_cache.close()
+        del kv_cache
+        gc.collect()
+
+        assert manager.resize(CacheLevel(0), 4 << 20)
+
+        event_manager.flush_iteration_events()
+        events = KVCacheEventSerializer.serialize(event_manager.get_latest_events())
+        updated_events = [event for event in events if event["data"]["type"] == "updated"]
+
+        assert len(updated_events) == 2
+        assert {event["layer_group_id"] for event in updated_events} == {0, 1}
+        assert len({event["data"]["block_hash"] for event in updated_events}) == 1
+        assert updated_events[0]["data"]["block_hash"] in stored_hashes_by_layer_group[0]
+        for event in updated_events:
+            assert event["data"]["cache_level"] == {
+                "type": "event_diff",
+                "old_value": 0,
+                "new_value": 1,
+            }
+            assert event["data"]["priority"] is None
+    finally:
+        gc.enable()
+        if manager is not None:
+            manager.shutdown()

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -311,6 +311,8 @@ class TestModelDefaults:
 
 
 def test_KvCacheConfig_declaration():
+    assert KvCacheConfig().kv_cache_event_hash_algo == "auto"
+
     config = KvCacheConfig(enable_block_reuse=True,
                            max_tokens=1024,
                            max_attention_window=[1024, 1024, 1024],
@@ -321,6 +323,7 @@ def test_KvCacheConfig_declaration():
                            cross_kv_cache_fraction=0.5,
                            secondary_offload_min_priority=1,
                            event_buffer_max_size=0,
+                           kv_cache_event_hash_algo="v2_sha256_64",
                            enable_partial_reuse=True,
                            copy_on_partial_reuse=True,
                            attention_dp_events_gather_period_ms=10)
@@ -336,6 +339,11 @@ def test_KvCacheConfig_declaration():
     assert pybind_config.cross_kv_cache_fraction == 0.5
     assert pybind_config.secondary_offload_min_priority == 1
     assert pybind_config.event_buffer_max_size == 0
+    assert config.kv_cache_event_hash_algo == "v2_sha256_64"
+    assert KvCacheConfig(
+        kv_cache_event_hash_algo="auto").kv_cache_event_hash_algo == "auto"
+    assert KvCacheConfig(kv_cache_event_hash_algo="v1_block_key"
+                         ).kv_cache_event_hash_algo == "v1_block_key"
     assert pybind_config.enable_partial_reuse == True
     assert pybind_config.copy_on_partial_reuse == True
     assert pybind_config.attention_dp_events_gather_period_ms == 10

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -11,6 +11,7 @@ from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._utils import KVCacheEventSerializer
 from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.runtime.kv_cache_hash import KV_CACHE_HASH_ALGO_V2
 from tensorrt_llm.sampling_params import SamplingParams
 from tensorrt_llm.scheduling_params import SchedulingParams
 
@@ -22,7 +23,8 @@ global_kvcache_config = KvCacheConfig(free_gpu_memory_fraction=0.4,
                                       event_buffer_max_size=1024,
                                       enable_block_reuse=True,
                                       onboard_blocks=True,
-                                      max_tokens=256)
+                                      max_tokens=256,
+                                      use_kv_cache_manager_v2=False)
 
 
 def create_kv_cache_manager():
@@ -51,6 +53,17 @@ def create_llm(tensor_parallel_size=1):
     return LLM(model=llama_model_path,
                tensor_parallel_size=tensor_parallel_size,
                kv_cache_config=global_kvcache_config,
+               enable_autotuner=False)
+
+
+def create_v2_llm():
+    v2_kvcache_config = KvCacheConfig(free_gpu_memory_fraction=0.4,
+                                      event_buffer_max_size=1024,
+                                      enable_block_reuse=True,
+                                      max_tokens=256,
+                                      use_kv_cache_manager_v2=True)
+    return LLM(model=llama_model_path,
+               kv_cache_config=v2_kvcache_config,
                enable_autotuner=False)
 
 
@@ -495,6 +508,38 @@ def test_expected_kv_cache_events():
                 assert event["data"]["type"] == "created"
             elif event["event_id"] == 1:
                 assert event["data"]["type"] == "stored"
+
+
+def test_expected_v2_kv_cache_events():
+    llm = create_v2_llm()
+    sampling_params = SamplingParams(max_tokens=6, temperature=0.01)
+    prompt = list(range(127))
+
+    _ = llm.generate(prompt, sampling_params=sampling_params)
+
+    events = llm.get_kv_cache_events(5)
+    assert events and len(events) >= 2
+    assert all(event["hash_algo"] == KV_CACHE_HASH_ALGO_V2 for event in events
+               if event)
+
+    created_events = [
+        event for event in events if event["data"]["type"] == "created"
+    ]
+    stored_events = [
+        event for event in events if event["data"]["type"] == "stored"
+    ]
+    assert created_events
+    assert stored_events
+    assert created_events[0]["event_id"] == 0
+
+    block_hashes = [
+        block["block_hash"] for event in stored_events
+        for block in event["data"]["blocks"]
+    ]
+    assert block_hashes
+    assert all(
+        isinstance(block_hash, str) and len(block_hash) == 64
+        for block_hash in block_hashes)
 
 
 def test_kv_cache_event_async_api():


### PR DESCRIPTION
## Description

Adds KVCacheManagerV2 event emission with V1-compatible public event shapes and explicit `hash_algo` / `layer_group_id` metadata. The V2 path now emits created, stored, removed, and cache-level updated events, serializes the event metadata, and supports attention-DP event gather on rank 0.

Updates the KV-cache-aware router and disaggregated tests so consumers compute block hashes with the server advertised algorithm: legacy `v1_block_key` for V1 and `v2_sha256` for V2. V1 event setup now warns if configured with a non-v1 hash algorithm and continues with the existing V1 behavior.

This PR does not add real `cache_salt` support. Salt-aware event keys and connector behavior remain out of scope here. KV cache connector docs and the V2 implementation notes are intentionally not included in the PR; the notes live under ignored `tmp/` for local reference.

Current limitations: V2 stored events currently cover text KV block event parity. They keep `mm_keys` empty and do not add a `lora_id` JSON field; V1 JSON serialization also does not currently expose `lora_id`. Multimodal `mm_keys` propagation and LoRA routing/event parity are out of scope for this PR.

Also keeps KVCacheManagerV2 selected when cache events or cache transceiver are enabled; unsupported connector manager / beam-width combinations still fall back as before.

## Test Coverage

- `git commit -s` pre-commit hooks passed: isort, yapf, ruff, ruff-format, codespell, merge-conflict checks, and related repo hooks.
- `python3 -m compileall` on touched Python files passed.
- `git diff --check` passed.
- Pytest was not runnable in this local shell: default Python is missing `pytest`.

## Checklist

- [x] I have read the TensorRT-LLM contribution guidelines.
- [x] I have added or updated tests for this change.
- [x] Documentation is out of scope for this PR; local notes are kept under ignored `tmp/`.