### PR TITLE
[None][fix] Clear stale Scheduler V2 request state

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2982,9 +2982,8 @@ class PyTorchModelEngine(ModelEngine):
                     )
                 if segment.shape[0] != 3 and segment.shape[-1] == 3:
                     logger.warning(
-                        "Transposing unexpected mrope_position_ids shape from %s",
-                        tuple(segment.shape),
-                    )
+                        "Transposing unexpected mrope_position_ids shape from "
+                        f"{tuple(segment.shape)}")
                     segment = segment.transpose(0, 2).contiguous()
                 if segment.shape[:2] != (3, 1):
                     raise RuntimeError(

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -306,8 +306,9 @@ class ModelLoader:
                 applied_defaults = apply_model_defaults_to_llm_args(
                     llm_args, model_defaults)
                 if applied_defaults:
-                    logger.info("Applied model defaults for %s: %s",
-                                model_cls.__name__, applied_defaults)
+                    logger.info(
+                        f"Applied model defaults for {model_cls.__name__}: {applied_defaults}"
+                    )
 
         return llm_args
 

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2000,11 +2000,10 @@ class KVCacheManagerV2(BaseResourceManager):
                 mem_available = os.sysconf('SC_PAGE_SIZE') * os.sysconf(
                     'SC_AVPHYS_PAGES')
             except (ValueError, OSError):
+                mem_available = float('inf')
+            host_quota = min(quota, int(mem_available * 0.5))
+            if host_quota <= 0:
                 host_quota = quota
-            else:
-                host_quota = min(quota, int(mem_available * 0.5))
-                if host_quota <= 0:
-                    host_quota = quota
         if host_quota > 0:
             cache_tiers.append(HostCacheTierConfig(quota=host_quota))
             logger.info(

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2000,10 +2000,11 @@ class KVCacheManagerV2(BaseResourceManager):
                 mem_available = os.sysconf('SC_PAGE_SIZE') * os.sysconf(
                     'SC_AVPHYS_PAGES')
             except (ValueError, OSError):
-                mem_available = float('inf')
-            host_quota = min(quota, int(mem_available * 0.5))
-            if host_quota <= 0:
                 host_quota = quota
+            else:
+                host_quota = min(quota, int(mem_available * 0.5))
+                if host_quota <= 0:
+                    host_quota = quota
         if host_quota > 0:
             cache_tiers.append(HostCacheTierConfig(quota=host_quota))
             logger.info(

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -149,9 +149,10 @@ class KVCacheV2Scheduler(RequestScheduler):
         self.draft_kv_cache_manager = draft_kv_cache_manager
         if scheduler_policy != CapacitySchedulerPolicy.MAX_UTILIZATION:
             logger.warning(
-                "KVCacheV2Scheduler only supports MAX_UTILIZATION for now, got %s, setting to MAX_UTILIZATION",
-                scheduler_policy,
+                "KVCacheV2Scheduler only supports MAX_UTILIZATION for now, "
+                f"got {scheduler_policy.name}, setting to MAX_UTILIZATION"
             )
+            scheduler_policy = CapacitySchedulerPolicy.MAX_UTILIZATION
         self.policy = scheduler_policy
         self.peft_cache_manager = peft_cache_manager
 
@@ -160,12 +161,13 @@ class KVCacheV2Scheduler(RequestScheduler):
         self.chunk_unit_size = 0
         self.max_context_length = max_num_tokens
         self.tokens_per_block = kv_cache_manager.tokens_per_block
+        draft_mgr_name = (
+            type(draft_kv_cache_manager).__name__ if draft_kv_cache_manager is not None else "None"
+        )
         logger.info(
-            "KVCacheV2Scheduler: tokens_per_block=%d, max_num_tokens=%s, max_batch_size=%s, draft_mgr=%s",
-            self.tokens_per_block,
-            max_num_tokens,
-            max_batch_size,
-            type(draft_kv_cache_manager).__name__ if draft_kv_cache_manager is not None else "None",
+            f"KVCacheV2Scheduler: tokens_per_block={self.tokens_per_block}, "
+            f"max_num_tokens={max_num_tokens}, max_batch_size={max_batch_size}, "
+            f"draft_mgr={draft_mgr_name}"
         )
         if ctx_chunk_config is not None:
             self.chunking_enabled = True
@@ -388,7 +390,7 @@ class KVCacheV2Scheduler(RequestScheduler):
             f"The number of encoder tokens ({req_tokens}) exceeds the limit value ({self.max_context_length})"
         )
         if not self.kv_cache_manager.prepare_context(req):
-            logger.debug("prepare_context failed for encoder request %s", req.py_request_id)
+            logger.debug(f"prepare_context failed for encoder request {req.py_request_id}")
             return ScheduleAction.STOP, 0
         if not self.kv_cache_manager.resize_context(req, req_tokens):
             return ScheduleAction.STOP, 0
@@ -416,7 +418,7 @@ class KVCacheV2Scheduler(RequestScheduler):
         # Prepare first so block reuse updates context_remaining_length
         # before budget check.
         if not self.kv_cache_manager.prepare_context(req):
-            logger.debug("prepare_context failed for context request %s", req.py_request_id)
+            logger.debug(f"prepare_context failed for context request {req.py_request_id}")
             return ScheduleAction.STOP, 0, False
 
         context_tokens = req.context_remaining_length
@@ -456,7 +458,7 @@ class KVCacheV2Scheduler(RequestScheduler):
 
         # Prepare context (create _KVCache, block reuse, resume — no resize)
         if not self.kv_cache_manager.prepare_context(req):
-            logger.debug("prepare_context failed for chunked context request %s", req.py_request_id)
+            logger.debug(f"prepare_context failed for chunked context request {req.py_request_id}")
             return ScheduleAction.SKIP, 0, False
 
         # Calculate chunk size from remaining budget
@@ -541,9 +543,8 @@ class KVCacheV2Scheduler(RequestScheduler):
         # that frees no pages.
         if self.kv_cache_manager.is_request_active(req.py_request_id):
             logger.debug(
-                "[V2Scheduler] Self-evicting request %s (state=%s) to free GPU pages",
-                req.py_request_id,
-                req.state,
+                f"[V2Scheduler] Self-evicting request {req.py_request_id} "
+                f"(state={req.state.name}) to free GPU pages"
             )
             self._suspend_request(req)
             evicted.append(req)
@@ -570,9 +571,13 @@ class KVCacheV2Scheduler(RequestScheduler):
         remains "active" on device, which could cause ensure_batch to
         fail if it needs to load a different adapter into a full cache.
         """
+        self._clear_request_runtime_state(req)
         self.kv_cache_manager.suspend_request(req)
         if self.draft_kv_cache_manager is not None:
             self.draft_kv_cache_manager.suspend_request(req)
+
+    def _clear_request_runtime_state(self, req: LlmRequest) -> None:
+        req.py_batch_idx = None
 
     def _is_evictable(self, req: LlmRequest) -> bool:
         """A started request whose KV cache is still active on GPU.
@@ -611,10 +616,8 @@ class KVCacheV2Scheduler(RequestScheduler):
 
             victim = requests_list[victim_idx]
             logger.debug(
-                "[V2Scheduler] Evicting request %s (state=%s) to free pages for request %s",
-                victim.py_request_id,
-                victim.state,
-                req.py_request_id,
+                f"[V2Scheduler] Evicting request {victim.py_request_id} "
+                f"(state={victim.state.name}) to free pages for request {req.py_request_id}"
             )
             self._suspend_request(victim)
             evicted.append(victim)

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
@@ -715,6 +715,17 @@ class TestEviction:
         sched.schedule_request(reqs, set())
         mgr.suspend_request.assert_called_once_with(victim)
 
+    def test_eviction_clears_request_runtime_state(self):
+        mgr = make_kv_cache_manager(
+            try_allocate_generation_fn=lambda req: False,
+        )
+        sched = make_scheduler(mgr, max_num_tokens=100)
+        req = make_gen_request(0)
+        req.py_batch_idx = 7
+        out = sched.schedule_request([req], set())
+        assert ids(out.paused_requests) == [0]
+        assert req.py_batch_idx is None
+
     def test_unknown_state_not_evictable(self):
         """UNKNOWN state at tail is not evictable; gen0 self-evicts."""
         mgr = make_kv_cache_manager(


### PR DESCRIPTION
@coderabbitai summary

## Description

This PR fixes stale non-durable request runtime state in KV Cache Manager V2 + Scheduler V2.

### Issue

The DeepSeek V4 GSM8K debug run hit a CUDA illegal access / KV compressor failure where the compressor tried to use a token whose KV-cache block was not allocated for the request.

The failing request was `req 244`. Its request capacity was 895, meaning the request could have at most 895 cached tokens. The observed token access implied one of two possibilities:

1. `request.max_beam_num_tokens` was wrong.
2. The request capacity was already stale or wrong before the iteration.

The evidence points to stale request runtime state, specifically `py_batch_idx`, after a Scheduler V2 suspension/resume path.

### Relevant behavior

`py_batch_idx` identifies the request's row in the current Python batch. Runtime code uses it to index batch-local state produced by the current scheduling/forward/sampling iteration.

That value is only valid while the request is actually in the current scheduled batch. It is not durable request state.

For a scheduled request in the previous iteration, `past_seen_token_num = request.max_beam_num_tokens` can be valid because the new token is being computed and has not been sampled yet, so it is not reflected in `max_beam_num_tokens` until sampling. This assumption breaks when the request was not scheduled in the previous iteration.

### Root cause

In the legacy flow, when a request cannot be scheduled, it is dropped from the active flow. A stale `py_batch_idx` is therefore not reused.

In the KV Cache Manager V2 + Scheduler V2 flow, a request that cannot be scheduled may be suspended instead of dropped. When that suspended request later resumes, the previous `py_batch_idx` can still be present even though it refers to an older batch.

If later logic treats that stale `py_batch_idx` as referring to the current batch, it can read the wrong batch-local token/accounting state. That can make the compressor believe a token is available for a request even though that token is outside the request's allocated KV-cache capacity.

So the bug is not that request capacity is inherently too small. The request runtime state can survive suspension with a stale batch index, which then corrupts how the current iteration interprets the request's token state.

### Fix

Clear non-durable request runtime state when Scheduler V2 suspends a request.

Implemented change:

- Add `KVCacheV2Scheduler._clear_request_runtime_state(req)`.
- Call it from `_suspend_request(req)` before suspending the request in the main and draft KV cache managers.
- Currently clear `req.py_batch_idx = None`.

This keeps suspended requests from carrying a previous iteration's Python batch index into a later resume.

## Test Coverage

Unit validation in the remote container passed:

```text
python3 -m pytest tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py -q
138 passed, 2 warnings in 0.85s
```

The full GSM8K debug script was rerun with `CUDA_LAUNCH_BLOCKING=1` and all ranks printing iteration logs. The original CUDA/block-table/compressor-token failure did not reproduce before the run was manually killed.

Local validation while creating this PR:

```text
pre-commit hooks during cherry-pick: passed
pytest tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py::TestEviction::test_eviction_clears_request_runtime_state: not run locally; pytest is not installed in this shell
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
