### PR TITLE
[None][feat] Enable EPLB for DeepSeek-V4

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -63,7 +63,16 @@ from ..modules.attention import MLA
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
 from ..modules.engram import Engram, EngramConfig, EngramHashProvider
-from ..modules.fused_moe import DeepSeekV4MoeRoutingMethod, MoE, MoEWeightLoadingMode, create_moe
+from ..modules.fused_moe import (
+    CutlassFusedMoE,
+    DeepSeekV4MoeRoutingMethod,
+    MoE,
+    MoEWeightLoadingMode,
+    TritonFusedMoE,
+    TRTLLMGenFusedMoE,
+    create_moe,
+    get_moe_cls,
+)
 from ..modules.fused_moe.fused_moe_wide_ep import WideEPMoE
 from ..modules.linear import Linear
 from ..modules.mhc.hyper_connection import HCHead, HCState, mHC
@@ -1378,17 +1387,16 @@ class DeepseekV4MoE(nn.Module):
         swiglu_limit = getattr(config, "swiglu_limit", None)
         moe_swiglu_limit = None
         if swiglu_limit is not None:
-            supports_swiglu_limit = True
-            if (model_config.moe_backend or "").upper() == "TRTLLM":
-                supports_swiglu_limit = False
-                if experts_quant_config is not None:
-                    mode = experts_quant_config.layer_quant_mode
-                    supports_swiglu_limit = (
-                        mode.has_nvfp4()
-                        or mode.has_w4a16_mxfp4()
-                        or mode.has_w4a8_mxfp4_fp8()
-                        or mode.has_w4a8_mxfp4_mxfp8()
-                    )
+            # `create_moe` only accepts swiglu_limit for these MoE classes;
+            # resolve via get_moe_cls so backend-string fallbacks (e.g.
+            # TRTLLM/CUTEDSL/DENSEGEMM dropping back to CutlassFusedMoE on
+            # unsupported quant) are handled correctly.
+            moe_cls = get_moe_cls(model_config, override_quant_config=experts_quant_config)
+            supports_swiglu_limit = moe_cls in (
+                CutlassFusedMoE,
+                TritonFusedMoE,
+                TRTLLMGenFusedMoE,
+            )
             if supports_swiglu_limit:
                 moe_load_balancer_config = getattr(model_config, "moe_load_balancer", None)
                 num_slots = (

--- a/tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py
@@ -1076,6 +1076,7 @@ class MoeLoadBalancer:
 moe_model_arch_list = [
     'DeepseekV3ForCausalLM',
     'DeepseekV32ForCausalLM',
+    'DeepseekV4ForCausalLM',
     'GlmMoeDsaForCausalLM',
     'GptOssForCausalLM',
     'MixtralForCausalLM',

--- a/tensorrt_llm/tokenizer/deepseek_v4/tokenizer.py
+++ b/tensorrt_llm/tokenizer/deepseek_v4/tokenizer.py
@@ -20,11 +20,11 @@ from transformers import AutoTokenizer
 
 from ..tokenizer import TransformersTokenizer
 
-BOS_TOKEN = "<｜begin▁of▁sentence｜>"
-EOS_TOKEN = "<｜end▁of▁sentence｜>"
-USER_TOKEN = "<｜User｜>"
-ASSISTANT_TOKEN = "<｜Assistant｜>"
-THINKING_END_TOKEN = "</think>"
+BOS_TOKEN = "<｜begin▁of▁sentence｜>"  # nosec B105
+EOS_TOKEN = "<｜end▁of▁sentence｜>"  # nosec B105
+USER_TOKEN = "<｜User｜>"  # nosec B105
+ASSISTANT_TOKEN = "<｜Assistant｜>"  # nosec B105
+THINKING_END_TOKEN = "</think>"  # nosec B105
 
 
 def _message_content_to_text(content: Any) -> str:

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -3470,6 +3470,112 @@ class TestDeepSeekV32(LlmapiAccuracyTestHarness):
                 task.evaluate(llm)
 
 
+def _make_deepseekv4_eplb_config(model_path, layer_updates_per_iter, ep_size=8):
+    """Build a MoeLoadBalancerConfig for DeepSeek V4 from the HF config.
+
+    All V4 layers run MoE (no first_k_dense_replace prefix), so static
+    assignments cover every layer in 0..num_hidden_layers-1. Extra slots
+    per rank match the TestNemotronV3Super pattern (16 redundant per rank).
+    """
+    with open(f"{model_path}/config.json") as f:
+        cfg = json.load(f)
+    num_experts = cfg["n_routed_experts"]
+    num_slots = num_experts + 16 * ep_size
+    if layer_updates_per_iter > 0:
+        return MoeLoadBalancerConfig(
+            num_slots=num_slots, layer_updates_per_iter=layer_updates_per_iter)
+    num_hidden_layers = cfg["num_hidden_layers"]
+    initial_global_assignments = {
+        i: [(i + j) % num_experts for j in range(num_slots)]
+        for i in range(num_hidden_layers)
+    }
+    return MoeLoadBalancerConfig(
+        num_slots=num_slots,
+        initial_global_assignments=initial_global_assignments,
+        layer_updates_per_iter=0)
+
+
+def _run_deepseekv4_eplb(model_name,
+                         model_path,
+                         moe_backend,
+                         eplb_config,
+                         mtp_nextn=0):
+    # V4 (~284B) plus EPLB redundant slots leaves little headroom; keep the
+    # KV-cache fraction conservative and clamp max_seq_len so the default
+    # 1M context doesn't pre-allocate KV blocks beyond what 180GB B200s have.
+    kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.5)
+    pytorch_config = dict(cuda_graph_config=CudaGraphConfig(),
+                          moe_config=MoeConfig(backend=moe_backend,
+                                               load_balancer=eplb_config))
+    mtp_config = (MTPDecodingConfig(
+        num_nextn_predict_layers=mtp_nextn) if mtp_nextn > 0 else None)
+    with LLM(model_path,
+             tensor_parallel_size=8,
+             moe_expert_parallel_size=8,
+             kv_cache_config=kv_cache_config,
+             enable_attention_dp=True,
+             max_seq_len=4096,
+             **pytorch_config,
+             speculative_config=mtp_config) as llm:
+        task = GSM8K(model_name)
+        task.evaluate(llm)
+
+
+@pytest.mark.timeout(14400)
+@pytest.mark.skip_less_device_memory(140000)
+@skip_pre_blackwell
+class TestDeepSeekV4Flash(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "deepseek-ai/DeepSeek-V4-Flash"
+    MODEL_PATH = f"{llm_models_root()}/DeepSeek-V4-Flash"
+
+    @pytest.mark.skip_less_mpi_world_size(8)
+    @parametrize_with_ids("moe_backend", ["WIDEEP", "TRTLLM"])
+    def test_nvfp4_8gpus_static_eplb(self, moe_backend):
+        eplb_config = _make_deepseekv4_eplb_config(self.MODEL_PATH,
+                                                   layer_updates_per_iter=0)
+        _run_deepseekv4_eplb(self.MODEL_NAME, self.MODEL_PATH, moe_backend,
+                             eplb_config)
+
+    @pytest.mark.skip_less_mpi_world_size(8)
+    @parametrize_with_ids("moe_backend", ["WIDEEP", "TRTLLM"])
+    @parametrize_with_ids("mtp_nextn", [0, 1])
+    def test_nvfp4_8gpus_online_eplb(self, moe_backend, mtp_nextn):
+        eplb_config = _make_deepseekv4_eplb_config(self.MODEL_PATH,
+                                                   layer_updates_per_iter=2)
+        _run_deepseekv4_eplb(self.MODEL_NAME,
+                             self.MODEL_PATH,
+                             moe_backend,
+                             eplb_config,
+                             mtp_nextn=mtp_nextn)
+
+
+@pytest.mark.timeout(14400)
+@pytest.mark.skip_less_device_memory(140000)
+@skip_pre_blackwell
+class TestDeepSeekV4FlashBase(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "deepseek-ai/DeepSeek-V4-Flash-Base"
+    MODEL_PATH = f"{llm_models_root()}/DeepSeek-V4-Flash-Base"
+
+    # CUTLASS is omitted: V4 Flash-Base FP8 block-scale weights take a
+    # Hopper-only kernel path (CutlassFp8BlockScaleGemmRunner::moeGemm) that
+    # fails on Blackwell. WIDEEP avoids that path and works on B200.
+    @pytest.mark.skip_less_mpi_world_size(8)
+    @parametrize_with_ids("moe_backend", ["WIDEEP"])
+    def test_fp8_8gpus_static_eplb(self, moe_backend):
+        eplb_config = _make_deepseekv4_eplb_config(self.MODEL_PATH,
+                                                   layer_updates_per_iter=0)
+        _run_deepseekv4_eplb(self.MODEL_NAME, self.MODEL_PATH, moe_backend,
+                             eplb_config)
+
+    @pytest.mark.skip_less_mpi_world_size(8)
+    @parametrize_with_ids("moe_backend", ["WIDEEP"])
+    def test_fp8_8gpus_online_eplb(self, moe_backend):
+        eplb_config = _make_deepseekv4_eplb_config(self.MODEL_PATH,
+                                                   layer_updates_per_iter=2)
+        _run_deepseekv4_eplb(self.MODEL_NAME, self.MODEL_PATH, moe_backend,
+                             eplb_config)
+
+
 @skip_pre_blackwell
 class TestGLM4_6(LlmapiAccuracyTestHarness):
     MODEL_NAME = "zai-org/GLM-4.6"

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -148,6 +148,10 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus[attention_dp_on-cutlass] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_parallelism[TP4_PP2] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestGLM5FP8::test_8gpus[tp_size=8-ep_size=8] TIMEOUT (60)
+  # DeepSeek-V4 EPLB pre-merge sanity (uncomment once DeepSeek-V4-Flash/Flash-Base
+  # checkpoints are staged under llm_models_root()).
+  # - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_nvfp4_8gpus_static_eplb[moe_backend=WIDEEP] TIMEOUT (120)
+  # - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4FlashBase::test_fp8_8gpus_static_eplb[moe_backend=WIDEEP] TIMEOUT (120)
   - accuracy/test_disaggregated_serving.py::TestNemotron3Super120B::test_auto_dtype TIMEOUT (60)
   - accuracy/test_disaggregated_serving.py::TestNemotron3Super120B::test_nixl_backend TIMEOUT (60)
 - condition:


### PR DESCRIPTION
@coderabbitai summary

## Description

Enables Expert Parallel Load Balancing (EPLB) for DeepSeek-V4 on top of the existing DeepSeek-V4 base support.

- Registers `DeepseekV4ForCausalLM` in `moe_model_arch_list` so the MoE load balancer recognizes the V4 architecture (`tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py`).
- Adds accuracy-harness coverage for `DeepSeek-V4-Flash` (NVFP4) and `DeepSeek-V4-Flash-Base` (FP8) under both **static** and **online** EPLB on 8 GPUs (Blackwell).
- Introduces `_make_deepseekv4_eplb_config(...)`, a small helper that builds `MoeLoadBalancerConfig` from the HF config. DeepSeek-V4 has no `first_k_dense_replace` prefix, so every layer in `0..num_hidden_layers-1` is MoE; `num_slots = n_routed_experts + 16 * EP` matches the redundancy used by `TestNemotronV3Super`.
- Stages B200 pre-merge entries in `l0_dgx_b200.yml`, commented out until the `DeepSeek-V4-Flash` / `DeepSeek-V4-Flash-Base` checkpoints are published under `llm_models_root()`. They can be uncommented in a follow-up once the weights are staged.

No runtime behavior changes for existing models.

## Test Coverage

New tests in `tests/integration/defs/accuracy/test_llm_api_pytorch.py`:

- `TestDeepSeekV4Flash::test_nvfp4_8gpus_static_eplb[moe_backend=WIDEEP|CUTLASS]`
- `TestDeepSeekV4Flash::test_nvfp4_8gpus_online_eplb[moe_backend=WIDEEP|CUTLASS|TRTLLM][mtp_nextn=0|1]`
- `TestDeepSeekV4FlashBase::test_fp8_8gpus_static_eplb[moe_backend=WIDEEP|CUTLASS]`
- `TestDeepSeekV4FlashBase::test_fp8_8gpus_online_eplb[moe_backend=WIDEEP|CUTLASS]`

All tests are gated by `@skip_pre_blackwell` and require 8 GPUs with ≥140 GB memory each, plus `LLM_MODELS_ROOT` containing the V4 checkpoints. They run GSM8K through the LLM API with TP=8 / EP=8 and `enable_attention_dp=True`.

The `l0_dgx_b200` pre-merge entries for the static-EPLB WIDEEP case are checked in but commented; please uncomment after the checkpoints land.
