### PR TITLE
[None][fix] Cherry pick KV Cache Manager V2 fixes

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -723,7 +723,7 @@ int AttentionOp::getHeadSize(bool checkInit) const
 }
 
 size_t AttentionOp::getWorkspaceSizeForContext(nvinfer1::DataType type, int32_t max_num_seq, int32_t input_seq_length,
-    int32_t cross_kv_length, int32_t max_num_tokens) const noexcept
+    int32_t cross_kv_length, int32_t max_num_tokens, int32_t total_kv_len) const noexcept
 {
     if (max_num_tokens == 0)
     {
@@ -800,8 +800,12 @@ size_t AttentionOp::getWorkspaceSizeForContext(nvinfer1::DataType type, int32_t 
         }
         else
         {
-            fp8_k_buf_size = mChunkPrefillBufferBatchSize * max_num_tokens * static_cast<size_t>(total_k_dim_all_heads);
-            fp8_v_buf_size = mChunkPrefillBufferBatchSize * max_num_tokens * static_cast<size_t>(total_v_dim_all_heads);
+            // Use total_kv_len when available (KV cache reuse causes total_kv_len >> max_num_tokens).
+            // enqueueContext sizes these buffers by total_kv_len, so workspace must match.
+            size_t const kv_buf_tokens = std::max(
+                static_cast<size_t>(total_kv_len), static_cast<size_t>(mChunkPrefillBufferBatchSize) * max_num_tokens);
+            fp8_k_buf_size = kv_buf_tokens * static_cast<size_t>(total_k_dim_all_heads);
+            fp8_v_buf_size = kv_buf_tokens * static_cast<size_t>(total_v_dim_all_heads);
         }
     }
 

--- a/cpp/tensorrt_llm/common/attentionOp.h
+++ b/cpp/tensorrt_llm/common/attentionOp.h
@@ -56,7 +56,7 @@ public:
     [[nodiscard]] int getHeadSize(bool checkInit = true) const;
     [[nodiscard]] int getMaxNumSeqLenTile(int batch_beam_size = 1) const;
     [[nodiscard]] size_t getWorkspaceSizeForContext(nvinfer1::DataType type, int32_t nbReq, int32_t max_input_length,
-        int32_t cross_kv_length = 0, int32_t max_num_tokens = 0) const noexcept;
+        int32_t cross_kv_length = 0, int32_t max_num_tokens = 0, int32_t total_kv_len = 0) const noexcept;
     // total_num_seq is the sum of beam_width for multiple requests
     [[nodiscard]] size_t getWorkspaceSizeForGeneration(nvinfer1::DataType type, int32_t total_num_seq,
         int32_t max_attention_window_size, int32_t max_num_tokens, int32_t max_blocks_per_sequence) const noexcept;

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -69,7 +69,7 @@ public:
     virtual ~RunnerBase() = default;
     virtual void prepare(AttentionOp& op) const = 0;
     virtual int64_t getWorkspaceSize(AttentionOp const& op, int const num_tokens, int const max_attention_window_size,
-        int const num_gen_tokens, int const max_blocks_per_sequence) const
+        int const num_gen_tokens, int const max_blocks_per_sequence, int const ctx_total_kv_len = 0) const
         = 0;
     // typically, we use single qkv input, but for context MLA, we use separate qkv inputs
     virtual void run(AttentionOp& op, bool const is_context, int32_t const seq_offset, int32_t const num_seqs,
@@ -125,10 +125,10 @@ public:
     }
 
     int64_t getWorkspaceSize(AttentionOp const& op, int const num_tokens, int const max_attention_window_size,
-        int const num_gen_tokens, int const max_blocks_per_sequence) const override
+        int const num_gen_tokens, int const max_blocks_per_sequence, int const ctx_total_kv_len = 0) const override
     {
-        size_t const context_workspace_size
-            = op.getWorkspaceSizeForContext(op.mType, max_num_requests, op.mMaxContextLength, 0, num_tokens);
+        size_t const context_workspace_size = op.getWorkspaceSizeForContext(
+            op.mType, max_num_requests, op.mMaxContextLength, 0, num_tokens, ctx_total_kv_len);
         size_t const generation_workspace_size = op.getWorkspaceSizeForGeneration(
             op.mType, max_num_requests, max_attention_window_size, num_gen_tokens, max_blocks_per_sequence);
 
@@ -888,8 +888,8 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
         = beam_width == 1 ? attention_window_size : cache_indirection.value().size(2);
     int32_t const max_blocks_per_sequence
         = use_kv_cache && kv_cache_block_offsets.has_value() ? kv_cache_block_offsets.value().size(-1) : 0;
-    int64_t const workspace_size
-        = runner->getWorkspaceSize(*op, num_tokens, max_attention_window_size, num_gen_tokens, max_blocks_per_sequence);
+    int64_t const workspace_size = runner->getWorkspaceSize(
+        *op, num_tokens, max_attention_window_size, num_gen_tokens, max_blocks_per_sequence, ctx_total_kv_len);
     TLLM_LOG_TRACE("Expected workspace size is %ld bytes", workspace_size);
 
     torch::Tensor workspace;

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -110,8 +110,6 @@ class KvCacheCreator:
         self._max_beam_width = max_beam_width
         self._kv_connector_manager = kv_connector_manager
         self._llm_args = llm_args
-        # For V2 fallback use only, will be removed after V2 is stable
-        self._cache_transceiver_config = llm_args.cache_transceiver_config
         self._speculative_config = speculative_config
         self._sparse_attention_config = sparse_attention_config
         self._tokens_per_block = tokens_per_block
@@ -120,22 +118,26 @@ class KvCacheCreator:
         self._net_max_seq_len = net_max_seq_len
         self._dummy_reqs = None
         self._profiling_stage_data = profiling_stage_data
-        self._kv_cache_manager_cls = get_kv_cache_manager_cls(
-            model_engine.model.model_config, kv_cache_config)
         self._execution_stream = execution_stream
-        if self._kv_cache_manager_cls == KVCacheManagerV2:
-            if kv_connector_manager is not None or (
-                    max_beam_width is not None and max_beam_width
-                    > 1) or self._kv_cache_config.event_buffer_max_size > 0:
-                logger.warning(
-                    "KVCacheManagerV2 is not supported with kv_connector_manager or beam width > 1 or event buffer max size > 0. "
-                    "Falling back to KVCacheManager.")
+        self._kv_cache_manager_cls = self._get_model_kv_cache_manager_cls(
+            model_engine)
         self._draft_config = draft_config
         self._skip_est = skip_est
 
     def _get_model_kv_cache_manager_cls(self, model_engine: PyTorchModelEngine):
-        return get_kv_cache_manager_cls(model_engine.model.model_config,
-                                        self._kv_cache_config)
+        cls = get_kv_cache_manager_cls(model_engine.model.model_config,
+                                       self._kv_cache_config)
+        self._warn_if_unsupported_kv_cache_manager_v2(cls)
+        return cls
+
+    def _warn_if_unsupported_kv_cache_manager_v2(self, kv_cache_manager_cls):
+        if kv_cache_manager_cls == KVCacheManagerV2:
+            if self._kv_connector_manager is not None or (
+                    self._max_beam_width is not None and self._max_beam_width
+                    > 1) or self._kv_cache_config.event_buffer_max_size > 0:
+                logger.warning(
+                    "KVCacheManagerV2 is not supported with kv_connector_manager, beam width > 1, "
+                    "or event buffer max size > 0.")
 
     def _get_kv_size_per_token(self):
         model_config = self._model_engine.model.model_config
@@ -560,8 +562,9 @@ class KvCacheCreator:
             spec_dec_layer_mask = [True] * num_target_layers
 
         estimating_kv_cache = estimating_kv_cache and not self._skip_est
-        is_disagg = (self._cache_transceiver_config is not None
-                     and self._cache_transceiver_config.backend is not None)
+        cache_transceiver_config = self._llm_args.cache_transceiver_config
+        is_disagg = (cache_transceiver_config is not None
+                     and cache_transceiver_config.backend is not None)
         kv_cache_manager = _create_kv_cache_manager(
             model_engine=model_engine,
             kv_cache_manager_cls=kv_cache_manager_cls,
@@ -686,18 +689,8 @@ class KvCacheCreator:
         # Get the appropriate KV cache manager class for the draft model
         draft_kv_cache_manager_cls = get_kv_cache_manager_cls(
             effective_draft_config, self._kv_cache_config)
-
-        # Use V2 if enabled and the base class is KVCacheManager
-        if draft_kv_cache_manager_cls == KVCacheManagerV2:
-            if self._kv_connector_manager is not None or (
-                    self._max_beam_width is not None and self._max_beam_width
-                    > 1) or self._kv_cache_config.event_buffer_max_size > 0 or (
-                        self._cache_transceiver_config is not None
-                        and self._cache_transceiver_config.backend is not None):
-                logger.warning(
-                    "KVCacheManagerV2 is not supported with disaggregated serving or beam width > 1 or event buffer max size > 0 or disagg config. "
-                    "Falling back to KVCacheManager for draft model.")
-                draft_kv_cache_manager_cls = KVCacheManager
+        self._warn_if_unsupported_kv_cache_manager_v2(
+            draft_kv_cache_manager_cls)
 
         estimating_kv_cache = estimating_kv_cache and not self._skip_est
         # For MTP with models using sparse attention (e.g., DeepSeek V3 with DSA),
@@ -1321,6 +1314,18 @@ def create_py_executor_instance(
     if scheduler_capacity == 1 and mapping.enable_attention_dp and kv_cache_manager:
         scheduler_capacity += 1
 
+    # V2 scheduler uses scheduler_capacity as the per-iteration request
+    # budget (BudgetTracker.max_num_requests).  Unlike V1 which has a
+    # separate CapacityScheduler (needs pp_size * max_batch_size to hold
+    # requests across PP stages) and MicroBatchScheduler (uses
+    # max_batch_size for per-forward batch limit), V2 merges both into
+    # one loop.  PP on-the-fly is handled by inflight_request_ids
+    # filtering, so its budget should be based on max_batch_size, not
+    # max_num_sequences (which includes the pp_size multiplier).
+    v2_scheduler_capacity = max_batch_size
+    if v2_scheduler_capacity == 1 and mapping.enable_attention_dp and kv_cache_manager:
+        v2_scheduler_capacity += 1
+
     if isinstance(kv_cache_manager, KVCacheManagerV2):
         # V2: interleaved scheduler handles both capacity and budget
         draft_kv_cache_manager = resources.get(
@@ -1336,7 +1341,7 @@ def create_py_executor_instance(
             ctx_chunk_config=ctx_chunk_config,
             peft_cache_manager=peft_cache_manager.impl
             if peft_cache_manager is not None else None,
-            scheduler_capacity=scheduler_capacity,
+            scheduler_capacity=v2_scheduler_capacity,
             draft_kv_cache_manager=draft_kv_cache_manager,
         )
     elif (scheduler_config is not None

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2878,9 +2878,8 @@ class PyTorchModelEngine(ModelEngine):
                     )
                 if segment.shape[0] != 3 and segment.shape[-1] == 3:
                     logger.warning(
-                        "Transposing unexpected mrope_position_ids shape from %s",
-                        tuple(segment.shape),
-                    )
+                        "Transposing unexpected mrope_position_ids shape from "
+                        f"{tuple(segment.shape)}")
                     segment = segment.transpose(0, 2).contiguous()
                 if segment.shape[:2] != (3, 1):
                     raise RuntimeError(

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -271,8 +271,9 @@ class ModelLoader:
                 applied_defaults = apply_model_defaults_to_llm_args(
                     llm_args, model_defaults)
                 if applied_defaults:
-                    logger.info("Applied model defaults for %s: %s",
-                                model_cls.__name__, applied_defaults)
+                    logger.info(
+                        f"Applied model defaults for {model_cls.__name__}: {applied_defaults}"
+                    )
 
         return llm_args
 

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1748,10 +1748,29 @@ class KVCacheManagerV2(BaseResourceManager):
 
         cache_tiers: List[CacheTierConfig] = [GpuCacheTierConfig(quota=quota)]
         if kv_cache_config.host_cache_size is not None and kv_cache_config.host_cache_size > 0:
-            cache_tiers.append(
-                HostCacheTierConfig(quota=kv_cache_config.host_cache_size))
+            host_quota = kv_cache_config.host_cache_size
+        else:
+            # The V2 MAX_UTILIZATION scheduler relies on suspend/resume to
+            # evict and later restore KV cache pages.  Without a host tier,
+            # suspended pages have nowhere to be offloaded and resume()
+            # always fails, causing a scheduling deadlock where no
+            # generation request can ever make progress.
+            #
+            # Automatically provision a host tier matching the GPU quota so
+            # suspend/resume works out of the box.  Cap at available host
+            # memory to avoid allocation failures.
+            try:
+                mem_available = os.sysconf('SC_PAGE_SIZE') * os.sysconf(
+                    'SC_AVPHYS_PAGES')
+            except (ValueError, OSError):
+                mem_available = float('inf')
+            host_quota = min(quota, int(mem_available * 0.5))
+            if host_quota <= 0:
+                host_quota = quota
+        if host_quota > 0:
+            cache_tiers.append(HostCacheTierConfig(quota=host_quota))
             logger.info(
-                f"KV cache manager v2 host cache quota set to {kv_cache_config.host_cache_size / (1 << 30)}GiB"
+                f"KV cache manager v2 host cache quota set to {host_quota / (1 << 30):.2f}GiB"
             )
 
         config = self._build_cache_config(

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1832,11 +1832,6 @@ class KVCacheManagerV2(BaseResourceManager):
                 self.impl = KVCacheManagerPy(config)
             else:
                 raise
-        # Pass execution_stream to StorageManager so _batched_migrate
-        # can record a fresh event (V1-style syncWithBufferManager)
-        # to order copy streams after the latest forward-pass work.
-        self.impl._storage._execution_stream = self._stream.cuda_stream
-
         self.num_pools = len(self.impl.layer_grouping)
 
         num_layers = len(config.layers)

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import copy
 import enum
 import math
@@ -39,6 +53,9 @@ from tensorrt_llm.runtime.kv_cache_manager_v2 import (LayerId, TokenIdExt,
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import (BAD_PAGE_INDEX,
                                                               GPU_LEVEL)
 from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
+from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import CuError
+from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import \
+    OutOfMemoryError as KVCacheOutOfMemoryError
 from tensorrt_llm.runtime.kv_cache_manager_v2._utils import (exact_div,
                                                              typed_range)
 from tensorrt_llm.sampling_params import SamplingParams
@@ -1747,7 +1764,7 @@ class KVCacheManagerV2(BaseResourceManager):
             f"KV cache manager v2 device quota set to {quota / (1 << 30)}GiB")
 
         cache_tiers: List[CacheTierConfig] = [GpuCacheTierConfig(quota=quota)]
-        if kv_cache_config.host_cache_size is not None and kv_cache_config.host_cache_size > 0:
+        if kv_cache_config.host_cache_size is not None and kv_cache_config.host_cache_size >= 0:
             host_quota = kv_cache_config.host_cache_size
         else:
             # The V2 MAX_UTILIZATION scheduler relies on suspend/resume to
@@ -1758,13 +1775,25 @@ class KVCacheManagerV2(BaseResourceManager):
             #
             # Automatically provision a host tier matching the GPU quota so
             # suspend/resume works out of the box.  Cap at available host
-            # memory to avoid allocation failures.
+            # memory and pinnable memory limit to avoid allocation failures.
+            import resource
             try:
                 mem_available = os.sysconf('SC_PAGE_SIZE') * os.sysconf(
                     'SC_AVPHYS_PAGES')
             except (ValueError, OSError):
                 mem_available = float('inf')
-            host_quota = min(quota, int(mem_available * 0.5))
+            try:
+                _soft, _hard = resource.getrlimit(resource.RLIMIT_MEMLOCK)
+                memlock_limit = _soft if _soft != resource.RLIM_INFINITY else float(
+                    'inf')
+            except (ValueError, OSError):
+                memlock_limit = float('inf')
+            candidates = [quota]
+            if mem_available != float('inf'):
+                candidates.append(int(mem_available * 0.5))
+            if memlock_limit != float('inf'):
+                candidates.append(int(memlock_limit * 0.8))
+            host_quota = min(candidates)
             if host_quota <= 0:
                 host_quota = quota
         if host_quota > 0:
@@ -1782,7 +1811,31 @@ class KVCacheManagerV2(BaseResourceManager):
 
         self.kv_cache_manager_py_config = config
 
-        self.impl = KVCacheManagerPy(config)
+        try:
+            self.impl = KVCacheManagerPy(config)
+        except (CuError, KVCacheOutOfMemoryError):
+            if len(cache_tiers) > 1:
+                logger.warning(
+                    "Failed to initialize KV cache manager with host cache "
+                    "tier (cuMemHostRegister may have failed). "
+                    "Retrying without host cache tier.")
+                cache_tiers_gpu_only = [
+                    t for t in cache_tiers if isinstance(t, GpuCacheTierConfig)
+                ]
+                config = self._build_cache_config(
+                    kv_cache_config,
+                    tokens_per_block=tokens_per_block,
+                    vocab_size=vocab_size,
+                    cache_tiers=cache_tiers_gpu_only,
+                )
+                self.kv_cache_manager_py_config = config
+                self.impl = KVCacheManagerPy(config)
+            else:
+                raise
+        # Pass execution_stream to StorageManager so _batched_migrate
+        # can record a fresh event (V1-style syncWithBufferManager)
+        # to order copy streams after the latest forward-pass work.
+        self.impl._storage._execution_stream = self._stream.cuda_stream
 
         self.num_pools = len(self.impl.layer_grouping)
 

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -144,9 +144,10 @@ class KVCacheV2Scheduler(RequestScheduler):
         self.draft_kv_cache_manager = draft_kv_cache_manager
         if scheduler_policy != CapacitySchedulerPolicy.MAX_UTILIZATION:
             logger.warning(
-                "KVCacheV2Scheduler only supports MAX_UTILIZATION for now, got %s, setting to MAX_UTILIZATION",
-                scheduler_policy,
+                "KVCacheV2Scheduler only supports MAX_UTILIZATION for now, "
+                f"got {scheduler_policy.name}, setting to MAX_UTILIZATION"
             )
+            scheduler_policy = CapacitySchedulerPolicy.MAX_UTILIZATION
         self.policy = scheduler_policy
         self.peft_cache_manager = peft_cache_manager
 
@@ -155,12 +156,13 @@ class KVCacheV2Scheduler(RequestScheduler):
         self.chunk_unit_size = 0
         self.max_context_length = max_num_tokens
         self.tokens_per_block = kv_cache_manager.tokens_per_block
+        draft_mgr_name = (
+            type(draft_kv_cache_manager).__name__ if draft_kv_cache_manager is not None else "None"
+        )
         logger.info(
-            "KVCacheV2Scheduler: tokens_per_block=%d, max_num_tokens=%s, max_batch_size=%s, draft_mgr=%s",
-            self.tokens_per_block,
-            max_num_tokens,
-            max_batch_size,
-            type(draft_kv_cache_manager).__name__ if draft_kv_cache_manager is not None else "None",
+            f"KVCacheV2Scheduler: tokens_per_block={self.tokens_per_block}, "
+            f"max_num_tokens={max_num_tokens}, max_batch_size={max_batch_size}, "
+            f"draft_mgr={draft_mgr_name}"
         )
         if ctx_chunk_config is not None:
             self.chunking_enabled = True
@@ -342,7 +344,7 @@ class KVCacheV2Scheduler(RequestScheduler):
             f"The number of encoder tokens ({req_tokens}) exceeds the limit value ({self.max_context_length})"
         )
         if not self.kv_cache_manager.prepare_context(req):
-            logger.debug("prepare_context failed for encoder request %s", req.py_request_id)
+            logger.debug(f"prepare_context failed for encoder request {req.py_request_id}")
             return ScheduleAction.STOP, 0
         if not self.kv_cache_manager.resize_context(req, req_tokens):
             return ScheduleAction.STOP, 0
@@ -395,7 +397,7 @@ class KVCacheV2Scheduler(RequestScheduler):
         # Prepare first so block reuse updates context_remaining_length
         # before budget check.
         if not self.kv_cache_manager.prepare_context(req):
-            logger.debug("prepare_context failed for context request %s", req.py_request_id)
+            logger.debug(f"prepare_context failed for context request {req.py_request_id}")
             return ScheduleAction.STOP, 0, False
 
         context_tokens = req.context_remaining_length
@@ -435,7 +437,7 @@ class KVCacheV2Scheduler(RequestScheduler):
 
         # Prepare context (create _KVCache, block reuse, resume — no resize)
         if not self.kv_cache_manager.prepare_context(req):
-            logger.debug("prepare_context failed for chunked context request %s", req.py_request_id)
+            logger.debug(f"prepare_context failed for chunked context request {req.py_request_id}")
             return ScheduleAction.SKIP, 0, False
 
         # Calculate chunk size from remaining budget
@@ -520,9 +522,8 @@ class KVCacheV2Scheduler(RequestScheduler):
         # that frees no pages.
         if self.kv_cache_manager.is_request_active(req.py_request_id):
             logger.debug(
-                "[V2Scheduler] Self-evicting request %s (state=%s) to free GPU pages",
-                req.py_request_id,
-                req.state,
+                f"[V2Scheduler] Self-evicting request {req.py_request_id} "
+                f"(state={req.state.name}) to free GPU pages"
             )
             self._suspend_request(req)
             evicted.append(req)
@@ -542,9 +543,13 @@ class KVCacheV2Scheduler(RequestScheduler):
 
     def _suspend_request(self, req: LlmRequest) -> None:
         """Suspend a request's KV cache in both main and draft managers."""
+        self._clear_request_runtime_state(req)
         self.kv_cache_manager.suspend_request(req)
         if self.draft_kv_cache_manager is not None:
             self.draft_kv_cache_manager.suspend_request(req)
+
+    def _clear_request_runtime_state(self, req: LlmRequest) -> None:
+        req.py_batch_idx = None
 
     def _is_evictable(self, req: LlmRequest) -> bool:
         """A started request whose KV cache is still active on GPU.
@@ -583,10 +588,8 @@ class KVCacheV2Scheduler(RequestScheduler):
 
             victim = requests_list[victim_idx]
             logger.debug(
-                "[V2Scheduler] Evicting request %s (state=%s) to free pages for request %s",
-                victim.py_request_id,
-                victim.state,
-                req.py_request_id,
+                f"[V2Scheduler] Evicting request {victim.py_request_id} "
+                f"(state={victim.state.name}) to free pages for request {req.py_request_id}"
             )
             self._suspend_request(victim)
             evicted.append(victim)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -27,6 +27,7 @@ from ._common import (
     Address,
     CacheLevel,
     CacheTier,
+    CudaStream,
     LayerId,
     MemAddress,
     PageStatus,
@@ -166,6 +167,7 @@ class StorageManager:
         "_slot_desc_list",
         "_levels",
         "_min_slots",
+        "_execution_stream",
         "__rawref__",
     )
     _life_cycles: LifeCycleRegistry
@@ -176,6 +178,7 @@ class StorageManager:
     _slot_desc_list: TypedIndexList[PoolGroupIndex, SlotDesc]
     _levels: TypedIndexList[CacheLevel, CacheLevelManager]
     _min_slots: TypedIndexList[PoolGroupIndex, int]
+    _execution_stream: CudaStream | None
     __rawref__: rawref.ref["StorageManager"]
 
     def __init__(
@@ -187,6 +190,7 @@ class StorageManager:
         constraints: list[BatchDesc] | None = None,
     ) -> None:
         self.__rawref__ = rawref.NULL
+        self._execution_stream: CudaStream | None = None
         assert config.cache_tiers[GPU_LEVEL].tier == CacheTier.GPU_MEM, (
             "The first cache tier must be GPU memory"
         )
@@ -487,6 +491,14 @@ class StorageManager:
         try:
             assert len(dst_slots) == num_slots
             prior_events: set[CachedCudaEvent] = set()
+            # Like V1's syncWithBufferManager(): record a fresh event on
+            # execution_stream so the copy stream waits for all prior
+            # forward-pass work, not just the (potentially stale) page
+            # ready_events.  This is the V2 equivalent of the explicit
+            # two-way sync that V1 performs between its BufferManager
+            # stream and offload/onboard streams.
+            if self._execution_stream is not None and not defrag:
+                prior_events.add(CachedCudaEvent(self._execution_stream))
             tasks_per_pool: TypedIndexList[PoolIndex, list[CopyTask]] = make_typed(
                 lambda _: list[CopyTask](), num_pools
             )

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -27,7 +27,6 @@ from ._common import (
     Address,
     CacheLevel,
     CacheTier,
-    CudaStream,
     LayerId,
     MemAddress,
     PageStatus,
@@ -167,7 +166,6 @@ class StorageManager:
         "_slot_desc_list",
         "_levels",
         "_min_slots",
-        "_execution_stream",
         "__rawref__",
     )
     _life_cycles: LifeCycleRegistry
@@ -178,7 +176,6 @@ class StorageManager:
     _slot_desc_list: TypedIndexList[PoolGroupIndex, SlotDesc]
     _levels: TypedIndexList[CacheLevel, CacheLevelManager]
     _min_slots: TypedIndexList[PoolGroupIndex, int]
-    _execution_stream: CudaStream | None
     __rawref__: rawref.ref["StorageManager"]
 
     def __init__(
@@ -190,7 +187,6 @@ class StorageManager:
         constraints: list[BatchDesc] | None = None,
     ) -> None:
         self.__rawref__ = rawref.NULL
-        self._execution_stream: CudaStream | None = None
         assert config.cache_tiers[GPU_LEVEL].tier == CacheTier.GPU_MEM, (
             "The first cache tier must be GPU memory"
         )
@@ -491,14 +487,6 @@ class StorageManager:
         try:
             assert len(dst_slots) == num_slots
             prior_events: set[CachedCudaEvent] = set()
-            # Like V1's syncWithBufferManager(): record a fresh event on
-            # execution_stream so the copy stream waits for all prior
-            # forward-pass work, not just the (potentially stale) page
-            # ready_events.  This is the V2 equivalent of the explicit
-            # two-way sync that V1 performs between its BufferManager
-            # stream and offload/onboard streams.
-            if self._execution_stream is not None and not defrag:
-                prior_events.add(CachedCudaEvent(self._execution_stream))
             tasks_per_pool: TypedIndexList[PoolIndex, list[CopyTask]] = make_typed(
                 lambda _: list[CopyTask](), num_pools
             )

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
@@ -720,6 +720,17 @@ class TestEviction:
         sched.schedule_request(reqs, set())
         mgr.suspend_request.assert_called_once_with(victim)
 
+    def test_eviction_clears_request_runtime_state(self):
+        mgr = make_kv_cache_manager(
+            try_allocate_generation_fn=lambda req: False,
+        )
+        sched = make_scheduler(mgr, max_num_tokens=100)
+        req = make_gen_request(0)
+        req.py_batch_idx = 7
+        out = sched.schedule_request([req], set())
+        assert ids(out.paused_requests) == [0]
+        assert req.py_batch_idx is None
+
     def test_unknown_state_not_evictable(self):
         """UNKNOWN state at tail is not evictable; gen0 self-evicts."""
         mgr = make_kv_cache_manager(


### PR DESCRIPTION
@coderabbitai summary

## Description

This PR cherry-picks KV cache manager V2 fixes onto `feat/deepseek_v4`.

Cherry-picked changes:
- PR #13592: clear stale Scheduler V2 request runtime state on suspend, keep Scheduler V2 policy/logging state consistent, and add coverage for clearing `py_batch_idx`.
- `host_quota` changes from `371e38ded63367201927140f6d1cf5b5da5d0244`: provision a host cache tier by default for KV cache V2 suspend/resume, capped by available host memory.
- PR #13488: port KV cache V2 follow-up fixes for FP8 MLA context workspace sizing with reused KV, keep `KVCacheManagerV2` with cache transceiver, use `max_batch_size` as the V2 scheduler request budget, cap fallback host quota by memlock limits, retry without host tier on host allocation failure, and synchronize storage migrations with the execution stream.

No new dependencies, ownership changes, documentation changes, or architecture diagram updates are needed for this cherry-pick PR.

## Test Coverage

- `python3 -m py_compile tensorrt_llm/_torch/pyexecutor/resource_manager.py`
- `python3 -m py_compile tensorrt_llm/_torch/pyexecutor/_util.py tensorrt_llm/_torch/pyexecutor/resource_manager.py tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py`
- Pre-commit hooks run by `git commit -s`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
