### PR TITLE
[None][infra] disable -G in default Debug CUDA flags to fix CI OOM

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -328,10 +328,10 @@ endif()
 # configurations for all CUDA architectures at once will fail to link --
 # build_wheel.py enforces that a specific --cuda_architectures must be passed in
 # that case. Note: full device debug info (-G) is intentionally NOT enabled by
-# default for Debug -- it makes ptxas memory usage explode on cutlass GEMM
-# kernels and gets OOM-killed in CI. Developers who need cuda-gdb stepping can
-# opt in via `build_wheel.py --extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G`,
-# ideally combined with --fast_build to skip the heavy cutlass instantiations.
+# default for Debug -- it makes ptxas memory usage explode on some kernels and
+# get OOM-killed in CI. Developers who need cuda-gdb stepping can opt in via
+# `build_wheel.py --extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G`, ideally
+# combined with --fast_build to skip the heaviest kernels.
 # cmake-format: off
 set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "${CMAKE_CUDA_FLAGS_RELWITHDEBINFO} --generate-line-info")
 set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} --generate-line-info")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -324,14 +324,17 @@ if(UNIX)
 endif()
 
 # Emit CUDA line info for Debug and RelWithDebInfo so nsys/ncu can map samples
-# back to source, and emit full device debug info (-G) for Debug so cuda-gdb can
-# step through kernels. These flags inflate section sizes significantly, so
-# building these configurations for all CUDA architectures at once will fail to
-# link -- build_wheel.py enforces that a specific --cuda_architectures must be
-# passed in that case.
+# back to source. This inflates section sizes significantly, so building these
+# configurations for all CUDA architectures at once will fail to link --
+# build_wheel.py enforces that a specific --cuda_architectures must be passed in
+# that case. Note: full device debug info (-G) is intentionally NOT enabled by
+# default for Debug -- it makes ptxas memory usage explode on cutlass GEMM
+# kernels and gets OOM-killed in CI. Developers who need cuda-gdb stepping can
+# opt in via `build_wheel.py --extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G`,
+# ideally combined with --fast_build to skip the heavy cutlass instantiations.
 # cmake-format: off
 set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "${CMAKE_CUDA_FLAGS_RELWITHDEBINFO} --generate-line-info")
-set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} --generate-line-info -G")
+set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} --generate-line-info")
 # cmake-format: on
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_SYSTEM=cmake_oss ")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -328,10 +328,10 @@ endif()
 # configurations for all CUDA architectures at once will fail to link --
 # build_wheel.py enforces that a specific --cuda_architectures must be passed in
 # that case. Note: full device debug info (-G) is intentionally NOT enabled by
-# default for Debug -- it makes ptxas memory usage explode on some kernels and
-# get OOM-killed in CI. Developers who need cuda-gdb stepping can opt in via
-# `build_wheel.py --extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G`, ideally
-# combined with --fast_build to skip the heaviest kernels.
+# default for Debug -- it can make ptxas memory usage explode on some kernels
+# and get OOM-killed in CI. Developers who need cuda-gdb stepping can opt in via
+# `build_wheel.py --extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G` on a host with
+# enough memory for ptxas.
 # cmake-format: off
 set(CMAKE_CUDA_FLAGS_RELWITHDEBINFO "${CMAKE_CUDA_FLAGS_RELWITHDEBINFO} --generate-line-info")
 set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} --generate-line-info")

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -565,11 +565,11 @@ def main(*,
     if build_type == "Debug":
         print(
             "-- Debug build: only --generate-line-info is enabled by default. "
-            "Full device debug info (-G) is NOT enabled because ptxas runs "
-            "out of memory on heavy cutlass GEMM kernels and gets OOM-killed. "
+            "Full device debug info (-G) is NOT enabled because it makes "
+            "ptxas memory usage explode and get OOM-killed on some kernels. "
             "If you need cuda-gdb stepping inside kernels, opt in with "
             "`--extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G`, ideally combined "
-            "with `--fast_build` to skip the heaviest instantiations.")
+            "with `--fast_build` to skip the heaviest kernels.")
 
     cuda_architectures = cuda_architectures or 'all'
     cmake_cuda_architectures = f'"-DCMAKE_CUDA_ARCHITECTURES={cuda_architectures}"'

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -565,11 +565,11 @@ def main(*,
     if build_type == "Debug":
         print(
             "-- Debug build: only --generate-line-info is enabled by default. "
-            "Full device debug info (-G) is NOT enabled because it makes "
+            "Full device debug info (-G) is NOT enabled because it can make "
             "ptxas memory usage explode and get OOM-killed on some kernels. "
             "If you need cuda-gdb stepping inside kernels, opt in with "
-            "`--extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G`, ideally combined "
-            "with `--fast_build` to skip the heaviest kernels.")
+            "`--extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G` and make sure "
+            "the build host has enough memory for ptxas.")
 
     cuda_architectures = cuda_architectures or 'all'
     cmake_cuda_architectures = f'"-DCMAKE_CUDA_ARCHITECTURES={cuda_architectures}"'

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -562,6 +562,15 @@ def main(*,
             "limits. Pass a narrow arch list matching the GPU you intend to "
             "debug/profile.")
 
+    if build_type == "Debug":
+        print(
+            "-- Debug build: only --generate-line-info is enabled by default. "
+            "Full device debug info (-G) is NOT enabled because ptxas runs "
+            "out of memory on heavy cutlass GEMM kernels and gets OOM-killed. "
+            "If you need cuda-gdb stepping inside kernels, opt in with "
+            "`--extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G`, ideally combined "
+            "with `--fast_build` to skip the heaviest instantiations.")
+
     cuda_architectures = cuda_architectures or 'all'
     cmake_cuda_architectures = f'"-DCMAKE_CUDA_ARCHITECTURES={cuda_architectures}"'
 


### PR DESCRIPTION
## Summary
Follow-up to #13334. The previous PR enabled `-G` (full device debug info) by default for `Debug` builds. CI's post-merge `Build-x86_64` Debug job started failing because `ptxas` got OOM-killed on the cutlass FpA-IntB GEMM SM90 instantiations:

\`\`\`
nvcc warning : '--device-debug (-G)' overrides '--generate-line-info (-lineinfo)'
ptxas warning : Conflicting options --device-debug and --generate-line-info specified, ignoring --generate-line-info option
nvcc error   : 'ptxas' died due to signal 9 (Kill signal)
\`\`\`

`-G` makes ptxas memory usage explode on heavy cutlass templates even when restricted to a single architecture, so it's not safe as a default. nvcc/ptxas also explicitly warn that `-G` overrides `--generate-line-info` — keeping both bought us nothing.

## Changes
- `cpp/CMakeLists.txt`: drop `-G` from `CMAKE_CUDA_FLAGS_DEBUG`. `--generate-line-info` is still enabled for both `Debug` and `RelWithDebInfo` so `nsys`/`ncu` can map samples to source.
- `scripts/build_wheel.py`: print a hint when a `Debug` build is requested, telling developers how to opt into `-G` if they really need cuda-gdb kernel stepping (`--extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G`, ideally combined with `--fast_build`).

## Test plan
- [ ] `python scripts/build_wheel.py -b Debug --cuda_architectures 90-real` no longer OOMs ptxas on cutlass SM90 GEMM instantiations.
- [ ] `python scripts/build_wheel.py -b Debug --cuda_architectures 90-real` prints the hint about how to opt into `-G`.
- [ ] `python scripts/build_wheel.py -b Debug --cuda_architectures 90-real --extra-cmake-vars CMAKE_CUDA_FLAGS_DEBUG=-G --fast_build` still works for developers who explicitly want kernel debug info.
- [ ] CI `Build-x86_64` Debug stage passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized default Debug build settings for faster builds and reduced storage overhead
  * Enhanced guidance for advanced debugging scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->