### PR TITLE
[https://nvbugs/6072808][fix] Retry on EADDRINUSE in AutoDeploy allreduce-fusion test

### DIFF
--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 from _dist_test_utils import get_device_counts
+from torch.distributed import DistNetworkError
 from torch.export import export
 
 from tensorrt_llm._torch.auto_deploy.custom_ops.distributed.trtllm_dist import (
@@ -152,16 +153,31 @@ def _test_allreduce_fusion(port: int, ModuleCls, strategy: str):
 def test_allreduce_fusion(device_count, ModuleCls, strategy):
     if device_count <= 1:
         pytest.skip("Require multi GPUs to run test_allreduce_fusion.")
-    port = get_free_port()
 
     n_workers = device_count
-    mpi_pool = MpiPoolSession(n_workers=n_workers)
-    try:
-        mpi_pool.submit_sync(
-            _test_allreduce_fusion,
-            port=port,
-            ModuleCls=ModuleCls,
-            strategy=strategy,
-        )
-    finally:
-        mpi_pool.shutdown()
+    # Retry on EADDRINUSE: there is a TOCTOU race between get_free_port() in
+    # the parent and dist.init_process_group("nccl") in the workers. The
+    # spawn_multiprocess_job path handles this internally; the MpiPoolSession
+    # path used here does not, so retry with a fresh port and pool.
+    max_retries = 5
+    last_exc: Exception | None = None
+    for attempt in range(max_retries):
+        port = get_free_port()
+        mpi_pool = MpiPoolSession(n_workers=n_workers)
+        try:
+            mpi_pool.submit_sync(
+                _test_allreduce_fusion,
+                port=port,
+                ModuleCls=ModuleCls,
+                strategy=strategy,
+            )
+            return
+        except DistNetworkError as e:
+            last_exc = e
+            if "EADDRINUSE" not in str(e) and "address already in use" not in str(e).lower():
+                raise
+        finally:
+            mpi_pool.shutdown()
+    raise RuntimeError(
+        f"Failed to initialize distributed group after {max_retries} attempts due to repeated port conflicts"
+    ) from last_exc

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
@@ -151,11 +151,14 @@ def _test_allreduce_fusion(port: int, ModuleCls, strategy: str):
     ids=["strategy_auto", "strategy_nccl", "strategy_oneshot"],
 )
 def test_allreduce_fusion(device_count, ModuleCls, strategy):
+    # Test the allreduce, residual, and rmsnorm fusion.
+    # MpiPoolSession is required because the test exercises trtllm's MPI-mode allreduce ops,
+    # which only activate when is_ompi() is true.
     if device_count <= 1:
         pytest.skip("Require multi GPUs to run test_allreduce_fusion.")
 
     n_workers = device_count
-    # Retry on EADDRINUSE: there is a TOCTOU race between get_free_port() in
+    # Retry on EADDRINUSE: there is a Time-of-check-to-time-of-use (TOCTOU) race between get_free_port() in
     # the parent and dist.init_process_group("nccl") in the workers. The
     # spawn_multiprocess_job path handles this internally; the MpiPoolSession
     # path used here does not, so retry with a fresh port and pool.


### PR DESCRIPTION
The multi-GPU test_allreduce_fusion test reserves a port via get_free_port() in the parent and broadcasts it to MpiPoolSession workers, which then call dist.init_process_group("nccl"). There is a TOCTOU race: the port can be grabbed between the parent socket close and the NCCL bind, producing DistNetworkError(EADDRINUSE) and a CI failure (e.g. on DGX_H100-4_GPUs-AutoDeploy-1).

The spawn_multiprocess_job path already recovers from this via _PORT_CONFLICT_EXIT_CODE, but the MpiPoolSession path does not. Wrap submit_sync in a 5-attempt retry that fetches a fresh port and recreates the MPI pool when DistNetworkError(EADDRINUSE) is observed; other errors propagate immediately, mirroring the existing spawn_multiprocess_job behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability by implementing retry logic to handle port allocation conflicts during distributed training initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
