### PR TITLE
[https://nvbugs/6079901][fix] Avoid divide-by-zero in KVCacheTransfer…

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheTransferManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheTransferManager.cpp
@@ -441,8 +441,12 @@ std::size_t KVCacheTransferManager::computeBlockTransferBytes(
         }
 
         auto const dataType = pool.primaryPtr->getDataType();
-        auto const bytesPerElement
-            = pool.primaryPtr->getSizeInBytes() / static_cast<std::size_t>(pool.primaryPtr->getSize());
+        auto const numElements = static_cast<std::size_t>(pool.primaryPtr->getSize());
+        if (numElements == 0)
+        {
+            continue; // empty pool contributes 0 bytes; avoids divide-by-zero
+        }
+        auto const bytesPerElement = pool.primaryPtr->getSizeInBytes() / numElements;
 
         // Mirror the logic in copyBlock: a partial copy only happens when numTokensToCopy > 0,
         // the data type supports it (not kINT4/kFP4), not block scales, and numTokensToCopy < tokensPerBlock.


### PR DESCRIPTION
…Manager::computeBlockTransferBytes for empty pools

The recent kv-cache statistics monitoring commit (580c7a65d2, "[TRTLLM-11421][feat] Support better kv cache statistics monitoring") derives bytesPerElement as getSizeInBytes()/getSize() inside KVCacheTransferManager::computeBlockTransferBytes. Pools whose primaryPtr is non-null but has zero elements (e.g. layers that contribute no KV cache in NAS-style heterogeneous models such as Llama-3_3-Nemotron-Super-49B-v1) trigger a SIGFPE / integer divide-by-zero on the first onboard transfer that touches such a pool.

Skip pools with zero elements: they legitimately contribute zero transfer bytes, so the stats are unchanged and the divide-by-zero is avoided.

Repro before fix: post-merge L0 stage RTXPro6000D-PyTorch-Post-Merge-1 (test_e2e.py::test_ptp_quickstart_advanced[Nemotron-Super-49B-v1-FP8-...]) crashes with "Floating point exception (8) / Integer divide-by-zero (1)" inside computeBlockTransferBytes during KVCacheManager::addSequenceBatch. After fix the test passes locally on RTX Pro 6000 (SM120) in 73s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a crash risk in KV cache transfer operations when encountering empty cache pools, enhancing system reliability and preventing unexpected failures during batch processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
