### PR TITLE
[https://nvbugs/6114821][fix] Fix extra_tokens in V2 KV cache

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2185,7 +2185,7 @@ class KVCacheManagerV2(BaseResourceManager):
         # Token num upper bound is the maximum number of tokens that can be allocated in the kv cache manager.
         # We need to add extra tokens to the token num upper bound to account for the extra tokens.
         clamped = self.impl.clamp_max_seq_len_for_mem(
-            batch_size, token_num_upper_bound) - extra_tokens
+            batch_size, token_num_upper_bound + extra_tokens) - extra_tokens
         # clamp_max_seq_len_for_mem considers all tiers (GPU + host).  When
         # max_tokens is explicitly set, cap by GPU-only capacity so callers
         # (e.g. CUDA graph warmup) don't exceed the GPU pool.


### PR DESCRIPTION
clamp_max_seq_len_for_mem must be called with (token_num_upper_bound
+ extra_tokens) so the function answers "given each seq actually uses N+extra actual tokens, what seq_len fits?" PR #12306 dropped the
+ extra_tokens from the arg, making it answer the wrong question and under-report user-visible capacity by extra_tokens.

In the memory-plentiful case this clamps self.max_seq_len down by extra_tokens during V2 init (resource_manager.py:1874), which triggers the SWA-detection branch in _util.py:591 to rebuild _dummy_reqs mid-init, leaving estimation results and warmup state internally inconsistent. Under sustained spec-dec load (GPT-OSS-120B + Eagle3 one-model + V2 KV cache + non-greedy sampling) this manifests as intermittent OutOfPagesError on draft KV cache resize, IMA in spec sampler, or hangs at cuda_event.synchronize() during GPQA evaluation.

The _gpu_max_tokens - extra_tokens cap from PR #12306 is preserved as it correctly converts the GPU-only cap to user-visible token units.

Tested test_eagle3_4gpus[v2_kv_cache-trtllm-one_model-no_overlap_scheduler]:
  baseline (PR #12306 applied): ~18% fail rate
  with this fix: 41/41 passing across 2 nodes

Tracking: nvbugs/6113016 (overlap_scheduler), nvbugs/6114821 (no_overlap_scheduler)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token capacity calculation logic for better memory constraint handling during inference. The system now more accurately accounts for extra KV tokens when determining available capacity, potentially enhancing memory utilization efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
