### PR TITLE
[None][cleanup] Remove unused code path

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 NVIDIA CORPORATION & AFFILIATES
+# Copyright 2024-2026 NVIDIA CORPORATION & AFFILIATES
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -113,11 +113,11 @@ def _cache_multimodal_embeddings(
 def get_multimodal_embeddings(
     encoder_forward_fn: Callable[
         [List[MultimodalParams]],
-        Union[torch.Tensor, Tuple[torch.Tensor, Any]],
+        List[torch.Tensor],
     ],
     multimodal_params: List[MultimodalParams],
     encoder_kwargs: Optional[Dict[str, Any]] = None,
-) -> Union[List[torch.Tensor], Tuple[List[torch.Tensor], Any]]:
+) -> List[torch.Tensor]:
     """
     High-level utility to get multimodal embeddings from encoder or cached embeddings.
 
@@ -129,16 +129,11 @@ def get_multimodal_embeddings(
 
     Args:
         encoder_forward_fn: Callable that performs encoder forward pass.
-                           Should accept List[MultimodalParams] and return List[torch.Tensor] or
-                           Tuple[List[torch.Tensor], aux_data] for models with auxiliary outputs.
-                           When returning a tuple, the first element must be a List[torch.Tensor]
-                           (one tensor per multimodal param), and aux_data is passed through to
-                           the caller unchanged.
+                           Should accept List[MultimodalParams] and return List[torch.Tensor].
         multimodal_params: All multimodal parameters in the batch.
         encoder_kwargs: Optional kwargs to pass to encoder_forward_fn.
     Returns:
-        List of multimodal embeddings for all multimodal params in the batch, or a
-        (List[torch.Tensor], aux_data) tuple if encoder_forward_fn returned auxiliary data.
+        List of multimodal embeddings for all multimodal params in the batch.
     """
     if not multimodal_params:
         return []
@@ -147,26 +142,11 @@ def get_multimodal_embeddings(
     uncached_multimodal_params = _get_uncached_multimodal_params(
         multimodal_params)
 
-    aux_data = None
-
     # Step 2: Run encoder forward only on uncached parameters
     if uncached_multimodal_params:
         kwargs = encoder_kwargs or {}
-        encoder_output = encoder_forward_fn(uncached_multimodal_params,
-                                            **kwargs)
-
-        # Handle encoder returning (embeddings, aux_data) tuple.
-        # In this case the first element is a List[torch.Tensor] with one tensor per
-        # multimodal param (not yet concatenated), which we concatenate before caching.
-        if isinstance(encoder_output, tuple):
-            encoder_embeddings, aux_data = encoder_output
-            # Concatenate per-param tensors into a single tensor for the caching path
-            if isinstance(encoder_embeddings,
-                          list) and encoder_embeddings and isinstance(
-                              encoder_embeddings[0], torch.Tensor):
-                encoder_embeddings = [torch.cat(encoder_embeddings, dim=0)]
-        else:
-            encoder_embeddings = encoder_output
+        encoder_embeddings = encoder_forward_fn(uncached_multimodal_params,
+                                                **kwargs)
 
         # TODO: support multiple multimodal modalities per request
         if len(encoder_embeddings) > 1:
@@ -187,8 +167,6 @@ def get_multimodal_embeddings(
             logger.warning(
                 "Multimodal runtime data missing or incomplete, will not cache embeddings."
             )
-            if aux_data is not None:
-                return encoder_embeddings, aux_data
             return encoder_embeddings
 
         # Step 3: Cache the computed embeddings to multimodal_data["multimodal_embedding"]
@@ -211,8 +189,6 @@ def get_multimodal_embeddings(
         param.multimodal_data["multimodal_embedding"] for param in valid_params
     ],
                                dim=0)
-    if aux_data is not None:
-        return [all_embeddings], aux_data
     return [all_embeddings]
 
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the multimodal embeddings utility function to improve API clarity and consistency. The function now consistently returns only embeddings in a unified format, removing the previous capability to optionally return auxiliary data alongside embeddings. This streamlines the interface for more predictable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

The `aux_data` code path in `get_multimodal_embeddings` was recently introduced by commit `2a0bcb17d3a`. However, the reasons for this are now no longer valid.
This commit therefore removes it for code clarity and maintainability.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
