### PR TITLE
[https://nvbugs/5839028][test] Unwaive DeepSeekR1 fp8 blockscale throughput_mtp

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -248,7 +248,6 @@ unittest/disaggregated/test_agent_multi_backends.py::test_run_with_different_env
 verl/test_verl_cases.py::test_adapter SKIP (https://nvbugs/5981833)
 verl/test_verl_cases.py::test_async_server SKIP (https://nvbugs/5981833)
 verl/test_verl_cases.py::test_rollout_utils SKIP (https://nvbugs/5981833)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp] SKIP (https://nvbugs/5839028)
 accuracy/test_llm_api_pytorch.py::TestGLM4_5Air::test_nvfp4_multi_gpus[throughput_trtllm] SKIP (https://nvbugs/5981293)
 accuracy/test_llm_api_pytorch.py::TestGLM4_5Air::test_nvfp4_2_model_mtp[2model] SKIP (https://nvbugs/5981293)
 test_e2e.py::test_draft_token_tree_quickstart_advanced_eagle3_depth_1_tree[Llama-3.1-8b-Instruct-llama-3.1-model/Llama-3.1-8B-Instruct-EAGLE3-LLaMA3.1-Instruct-8B] SKIP (https://nvbugs/5989907)


### PR DESCRIPTION
## Summary
- Remove the stale waiver for `accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp]`.
- NVBug 5839028 has recent repair-bot comments showing this test passes on current `main`, so the waiver can be removed.

## Test plan
- `git commit -s` with pre-commit hooks enabled.
- Pre-commit passed: `codespell`, `verify-legacy-config`, `test lists format`, `waive list check`, `validate-test-lists`, and DCO commit-msg check.
- Full GPU test was not rerun in this task; NVBug comments list repeated successful B200 runs on 2026-04-21, 2026-04-28, and 2026-04-29.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * A previously skipped throughput performance test for FP8 block scale configuration has been re-enabled, indicating the underlying issue has been resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->