### PR TITLE
[None][fix] kv_cache_manager_v2: swallow dangling-rawref in _SharedPageLock.__del__

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
@@ -404,6 +404,15 @@ class _SharedPageLock:
         assert old_base_index == BAD_PAGE_INDEX
 
     def __del__(self) -> None:
+        """Release the underlying unique lock on garbage collection.
+
+        Calls ``self.unlock()`` if a lock is still held. Swallows the
+        ``ValueError`` raised by ``unwrap_rawref`` when the C++ KV cache
+        has already been freed during interpreter shutdown — at that
+        point the page lock has nothing left to release, so quietly
+        dropping the wrapper state is the correct behaviour and lets
+        the surrounding destructor chain return cleanly.
+        """
         if self._uniq_lock is not None:
             try:
                 self.unlock()

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_page.py
@@ -405,7 +405,20 @@ class _SharedPageLock:
 
     def __del__(self) -> None:
         if self._uniq_lock is not None:
-            self.unlock()
+            try:
+                self.unlock()
+            except ValueError:
+                # Interpreter shutdown can release the C++ KV cache before
+                # its outstanding _SharedPageLocks finalize, leaving
+                # self._user.kv_cache as a dangling rawref. Registering a
+                # finish_event on a freed cache is meaningless (no consumer
+                # remains), so drop the lock state quietly. Without this
+                # guard the ValueError raised from unwrap_rawref propagates
+                # out of __del__ and Python prints it but the surrounding
+                # destructor chain stalls — visible as srun timing out
+                # waiting for the worker rank to exit even though all
+                # bench iters and report_json writes have completed.
+                self._uniq_lock = None
 
     def unlock(self) -> Page:
         assert self._uniq_lock is not None


### PR DESCRIPTION
## Description

When an `LLM` worker shuts down (interpreter teardown), the C++ KV-cache object is sometimes released before its outstanding `_SharedPageLock` Python instances are finalized. At that point `self._user.kv_cache` becomes a dangling rawref. When `__del__` calls `self.unlock()`, the code path lands in `unwrap_rawref(self._user.kv_cache)` which raises `ValueError("Dereferencing a dangling rawref")`. Because the exception is raised from within `__del__`, Python prints it but the surrounding destructor chain stalls — externally visible as `srun` timing out waiting for the worker rank to exit even though all bench iters and `--report_json` writes have completed normally.

Fix: wrap `self.unlock()` in a try/except for `ValueError` and drop the lock state quietly when the cache is already gone. Registering a `finish_event` on a freed cache is meaningless (no consumer remains), so swallowing the error preserves correctness while letting the destructor return.

Surface symptom is post-bench `srun` hang of ~120s before the SLURM step is force-killed, with the process that *did* finish all forward passes and write its report appearing as a TIME LIMIT termination in CI logs. Repros reliably on multi-rank PyTorch-backend benches that exercise the v2 KV cache manager.

## Test Coverage

- [x] Reproduced + verified on multi-rank `trtllm-bench throughput` runs against DSv4 (TEP4 c128 and DEP4 c128 shapes); without the fix the `ValueError` in `__del__` consistently stalls worker shutdown ~120s; with the fix the rank exits cleanly.
- [x] No behavioural change on the happy path — when the lock can be released normally, `unlock()` runs exactly as before.
- [x] ~~Existing TRT-LLM unit tests under `tests/unittest/runtime/kv_cache_manager_v2/` should still pass.~~ (not run from this session; the fix is a narrow try/except in a destructor, no semantics change on the non-error path).

## PR Checklist

- [x] PR description clearly explains what and why
- [x] PR follows TRT-LLM CODING GUIDELINES
- [x] Test cases are provided where relevant (here: external bench repro)
- [x] Commits are signed-off (DCO)
- [x] Pre-commit hooks pass on changed files
- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot run` to trigger CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during application shutdown by handling exceptions that could occur during resource cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->