### PR TITLE
[None][fix] Plumb promptIgnoreLength through Triton backend to fix silently-dropped lengthPenalty and earlyStopping

### DIFF
--- a/triton_backend/all_models/disaggregated_serving/disaggregated_serving_bls/config.pbtxt
+++ b/triton_backend/all_models/disaggregated_serving/disaggregated_serving_bls/config.pbtxt
@@ -176,6 +176,12 @@ input [
     optional: true
   },
   {
+    name: "prompt_ignore_length"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+    optional: true
+  },
+  {
     name: "repetition_penalty"
     data_type: TYPE_FP32
     dims: [ 1 ]

--- a/triton_backend/all_models/gpt/ensemble/config.pbtxt
+++ b/triton_backend/all_models/gpt/ensemble/config.pbtxt
@@ -59,6 +59,12 @@ input [
     optional: true
   },
   {
+    name: "prompt_ignore_length"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+    optional: true
+  },
+  {
     name: "repetition_penalty"
     data_type: TYPE_FP32
     dims: [ 1 ]
@@ -180,6 +186,10 @@ ensemble_scheduling {
       input_map {
           key: "len_penalty"
           value: "length_penalty"
+      }
+      input_map {
+          key: "prompt_ignore_length"
+          value: "prompt_ignore_length"
       }
       input_map {
           key: "repetition_penalty"

--- a/triton_backend/all_models/gpt/tensorrt_llm/config.pbtxt
+++ b/triton_backend/all_models/gpt/tensorrt_llm/config.pbtxt
@@ -72,6 +72,13 @@ input [
     optional: true
   },
   {
+    name: "prompt_ignore_length"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+    reshape: { shape: [ ] }
+    optional: true
+  },
+  {
     name: "repetition_penalty"
     data_type: TYPE_FP32
     dims: [ 1 ]

--- a/triton_backend/all_models/inflight_batcher_llm/ensemble/config.pbtxt
+++ b/triton_backend/all_models/inflight_batcher_llm/ensemble/config.pbtxt
@@ -105,6 +105,12 @@ input [
     optional: true
   },
   {
+    name: "prompt_ignore_length"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+    optional: true
+  },
+  {
     name: "repetition_penalty"
     data_type: TYPE_FP32
     dims: [ 1 ]
@@ -514,6 +520,10 @@ ensemble_scheduling {
       input_map {
           key: "len_penalty"
           value: "length_penalty"
+      }
+      input_map {
+          key: "prompt_ignore_length"
+          value: "prompt_ignore_length"
       }
       input_map {
           key: "repetition_penalty"

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm/1/model.py
@@ -215,6 +215,8 @@ def get_sampling_config_from_request(request, batch_size=1, batch_index=0):
         request, 'frequency_penalty', batch_size, batch_index)
     kwargs['length_penalty'] = get_input_scalar_by_name(request, 'len_penalty',
                                                         batch_size, batch_index)
+    kwargs['prompt_ignore_length'] = get_input_scalar_by_name(
+        request, 'prompt_ignore_length', batch_size, batch_index)
     kwargs['top_p_min'] = get_input_scalar_by_name(request, 'runtime_top_p_min',
                                                    batch_size, batch_index)
     kwargs['top_p_reset_ids'] = get_input_scalar_by_name(

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm/config.pbtxt
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm/config.pbtxt
@@ -206,6 +206,13 @@ input [
     optional: true
   },
   {
+    name: "prompt_ignore_length"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+    reshape: { shape: [ ] }
+    optional: true
+  },
+  {
     name: "early_stopping"
     data_type: TYPE_BOOL
     dims: [ 1 ]

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/decode.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/decode.py
@@ -76,6 +76,7 @@ class Request:
     top_p: Optional[np.ndarray] = None
     temperature: Optional[np.ndarray] = None
     length_penalty: Optional[np.ndarray] = None
+    prompt_ignore_length: Optional[np.ndarray] = None
     repetition_penalty: Optional[np.ndarray] = None
     min_tokens: Optional[np.ndarray] = None
     return_log_probs: Optional[np.ndarray] = None

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/1/lib/triton_decoder.py
@@ -90,8 +90,8 @@ class TritonDecoder(Decoder):
             "image_bytes_input", "image_url_input", "video_bytes_input",
             "max_tokens", "bad_words", "stop_words", "end_id", "pad_id",
             "top_k", "top_p", "temperature", "length_penalty",
-            "repetition_penalty", "min_tokens", "presence_penalty",
-            "frequency_penalty", "seed", "return_log_probs",
+            "prompt_ignore_length", "repetition_penalty", "min_tokens",
+            "presence_penalty", "frequency_penalty", "seed", "return_log_probs",
             "return_context_logits", "return_generation_logits", "beam_width",
             "stream", "prompt_embedding_table", "prompt_vocab_size",
             "prompt_table_extra_id", "embedding_bias_words",
@@ -104,13 +104,13 @@ class TritonDecoder(Decoder):
 
         self.__undo_reshape_whitelist = {
             "max_tokens", "end_id", "pad_id", "top_k", "top_p", "temperature",
-            "length_penalty", "repetition_penalty", "min_tokens",
-            "presence_penalty", "frequency_penalty", "seed", "return_log_probs",
-            "return_context_logits", "return_generation_logits", "beam_width",
-            "stream", "prompt_vocab_size", "num_draft_tokens",
-            "use_draft_logits", "exclude_input_in_output",
-            "return_perf_metrics", "lora_weights", "lora_config",
-            "lora_task_id", "return_num_input_tokens",
+            "length_penalty", "prompt_ignore_length", "repetition_penalty",
+            "min_tokens", "presence_penalty", "frequency_penalty", "seed",
+            "return_log_probs", "return_context_logits",
+            "return_generation_logits", "beam_width", "stream",
+            "prompt_vocab_size", "num_draft_tokens", "use_draft_logits",
+            "exclude_input_in_output", "return_perf_metrics", "lora_weights",
+            "lora_config", "lora_task_id", "return_num_input_tokens",
             "return_num_output_tokens"
         }
 
@@ -455,6 +455,7 @@ class TritonDecoder(Decoder):
             "top_p": "runtime_top_p",
             "temperature": "temperature",
             "length_penalty": "len_penalty",
+            "prompt_ignore_length": "prompt_ignore_length",
             "repetition_penalty": "repetition_penalty",
             "min_tokens": "min_tokens",
             "presence_penalty": "presence_penalty",

--- a/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/config.pbtxt
+++ b/triton_backend/all_models/inflight_batcher_llm/tensorrt_llm_bls/config.pbtxt
@@ -135,6 +135,12 @@ input [
     optional: true
   },
   {
+    name: "prompt_ignore_length"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+    optional: true
+  },
+  {
     name: "repetition_penalty"
     data_type: TYPE_FP32
     dims: [ 1 ]

--- a/triton_backend/all_models/multimodal/ensemble/config.pbtxt
+++ b/triton_backend/all_models/multimodal/ensemble/config.pbtxt
@@ -124,6 +124,12 @@ input [
     optional: true
   },
   {
+    name: "prompt_ignore_length"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+    optional: true
+  },
+  {
     name: "repetition_penalty"
     data_type: TYPE_FP32
     dims: [ 1 ]
@@ -511,6 +517,10 @@ ensemble_scheduling {
       input_map {
           key: "len_penalty"
           value: "length_penalty"
+      }
+      input_map {
+          key: "prompt_ignore_length"
+          value: "prompt_ignore_length"
       }
       input_map {
           key: "repetition_penalty"

--- a/triton_backend/inflight_batcher_llm/src/utils.cc
+++ b/triton_backend/inflight_batcher_llm/src/utils.cc
@@ -595,6 +595,9 @@ executor::SamplingConfig getSamplingConfigFromTensors(InputTensors const& inputs
     std::optional<float> frequencyPenalty{std::nullopt};
     extractOptionalSingleton<float>(inputsTensors, InputFieldsNames::frequencyPenalty, frequencyPenalty);
 
+    std::optional<int32_t> promptIgnoreLength{std::nullopt};
+    extractOptionalSingleton<int32_t>(inputsTensors, InputFieldsNames::promptIgnoreLength, promptIgnoreLength);
+
     std::optional<uint64_t> seed{std::nullopt};
     extractOptionalSingleton<uint64_t>(inputsTensors, InputFieldsNames::seed, seed);
 
@@ -605,8 +608,8 @@ executor::SamplingConfig getSamplingConfigFromTensors(InputTensors const& inputs
     extractOptionalSingleton<int32_t>(inputsTensors, InputFieldsNames::numReturnSequences, numReturnSequences);
 
     return executor::SamplingConfig(beamWidth, topK, topP, topPMin, topPResetIds, topPDecay, seed, temperature,
-        minTokens, beamSearchDiversityRate, repetitionPenalty, presencePenalty, frequencyPenalty, lengthPenalty,
-        earlyStopping, noRepeatNgramSize, numReturnSequences);
+        minTokens, beamSearchDiversityRate, repetitionPenalty, presencePenalty, frequencyPenalty, promptIgnoreLength,
+        lengthPenalty, earlyStopping, noRepeatNgramSize, numReturnSequences);
 }
 
 executor::OutputConfig getOutputConfigFromTensors(InputTensors const& inputsTensors)

--- a/triton_backend/inflight_batcher_llm/src/utils.h
+++ b/triton_backend/inflight_batcher_llm/src/utils.h
@@ -96,6 +96,7 @@ struct InputFieldsNames
     static constexpr char const* beamSearchDiversityRate = "beam_search_diversity_rate";
     static constexpr char const* presencePenalty = "presence_penalty";
     static constexpr char const* frequencyPenalty = "frequency_penalty";
+    static constexpr char const* promptIgnoreLength = "prompt_ignore_length";
     static constexpr char const* seed = "seed";
 
     // PromptTuningConfig

--- a/triton_backend/inflight_batcher_llm/tests/utilsTest.cpp
+++ b/triton_backend/inflight_batcher_llm/tests/utilsTest.cpp
@@ -388,6 +388,7 @@ std::optional<tensorrt_llm::executor::Request> getRequest(
     pushTensor<float>(inputsTensors, InputFieldsNames::beamSearchDiversityRate, nvinfer1::DataType::kFLOAT, {1}, {0.1});
     pushTensor<float>(inputsTensors, InputFieldsNames::presencePenalty, nvinfer1::DataType::kFLOAT, {1}, {0.2});
     pushTensor<float>(inputsTensors, InputFieldsNames::frequencyPenalty, nvinfer1::DataType::kFLOAT, {1}, {0.3});
+    pushTensor<int32_t>(inputsTensors, InputFieldsNames::promptIgnoreLength, nvinfer1::DataType::kINT32, {1}, {7});
     pushTensor<uint64_t>(inputsTensors, InputFieldsNames::seed, nvinfer1::DataType::kINT64, {1}, {3456});
 
     // PromptTuningConfig
@@ -585,6 +586,7 @@ void checkRequest(tensorrt_llm::executor::Request const& request,
     EXPECT_EQ(samplingConfig.getBeamSearchDiversityRate().value(), 0.1f);
     EXPECT_EQ(samplingConfig.getPresencePenalty().value(), 0.2f);
     EXPECT_EQ(samplingConfig.getFrequencyPenalty().value(), 0.3f);
+    EXPECT_EQ(samplingConfig.getPromptIgnoreLength().value(), 7);
     EXPECT_EQ(samplingConfig.getSeed().value(), 3456);
     EXPECT_EQ(samplingConfig.getNumReturnSequences().value(), 29);
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional `prompt_ignore_length` parameter in inference requests, enabling customizable prompt length handling throughout the inference pipeline.

* **Tests**
  * Added test coverage for the new `prompt_ignore_length` parameter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

The customer reported that on TRT-LLM v1.2.0rc4 (and confirmed identical on v1.2.0 GA), `length_penalty` and `early_stopping` were silently ignored when sent through the Triton C++ backend. Root cause traced to `triton_backend/inflight_batcher_llm/src/utils.cc::getSamplingConfigFromTensors()` passing **17 positional args** to `executor::SamplingConfig(...)` while the constructor signature in `cpp/include/tensorrt_llm/executor/executor.h` had **20 parameters** with `promptIgnoreLength` (added by PR #8127) at position 14 between `frequencyPenalty` and `lengthPenalty`. Because all parameters are `std::optional<...>` and `std::optional<float>` implicitly converts to `std::optional<int32>` via the contained type, the call compiled silently but all params from #14 onward shifted positions:

| Caller pos in utils.cc (pre-fix) | Bound to slot | Param it landed in |
|---|---|---|
| `lengthPenalty` (#14) | 14 | `promptIgnoreLength` (lossy float→int) |
| `earlyStopping` (#15) | 15 | `lengthPenalty` |
| `noRepeatNgramSize` (#16) | 16 | `earlyStopping` |
| `numReturnSequences` (#17) | 17 | `noRepeatNgramSize` |

`numReturnSequences`, `minP`, `beamWidthArray` defaulted to `std::nullopt`.

## Test Coverage

### Test 1: `length_penalty` — E2E PROVEN ✓

**Setup:** prompt `"The capital of France is Paris. The capital of Germany is Berlin. The capital of Japan is"`, `beam_width=4, max_tokens=120, early_stopping=True`, vary `len_penalty` between `0.1` and `5.0`.

| `len_penalty` | beam[0] gen_len | beam[0] text |
|---|---|---|
| 0.1 (favors short beams) | **0** | `''` (just `<eos>`) |
| 5.0 (favors long beams) | **100** | `'.C. The capital of Australia is Canberra. The capital of New Zealand is Wellington...'` |

`output_ids` differ: ✓. The chosen beam is dramatically different — empty vs 100-token continuation — proving `length_penalty` is now consumed at slot 15 of `executor::SamplingConfig` instead of being silently dropped.

### Test 2: `early_stopping` — E2E PROVEN ✓

**Setup:** prompt `"Hello world. Goodbye."`, `beam_width=4, max_tokens=60, len_penalty=1.0`, vary `early_stopping` between `False` and `True`.

| `early_stopping` | beam_lens | beam[0] text |
|---|---|---|
| `False` (run to max_tokens / heuristic) | [53, 53, 47, 53] | `'world. Goodbye. Hello world. Goodbye. Hello world. Goodbye...'` |
| `True` (stop on first `<eos>`) | [0, 0, 0, 0] | `''` |

`output_ids` differ: ✓. With `early_stopping=False` the beams continued for 47-53 tokens; with `True` they all terminated immediately at `<eos>`. This proves `early_stopping` is now consumed at slot 16 of `executor::SamplingConfig`.

### Test 3: `prompt_ignore_length` — UNIT-TEST PROVEN ✓ (e2e demo inconclusive on TinyLlama)

**Setup:** various prompts (`"a a a a..."`, `"the the..."`, `"banana banana..."`, `"France is a country. France is in Europe. France is famous for..."`), varied `repetition_penalty` 1.3-10.0, `prompt_ignore_length` from `None` to `prompt_len`.

**Outcome:** no observable behavioral divergence at the e2e level on TinyLlama-Chat-1.1B. The model emits `<eos>` as the first generated token whenever the prompt contains many repetitions of a token, regardless of `prompt_ignore_length`. This is a property of TinyLlama-Chat (which is heavily fine-tuned for short turn-by-turn dialogue) rather than a defect in the plumbing. Verifying behavioral effect with a non-chat-tuned base model would require building another engine.

**Plumbing IS verified at multiple lower layers**, and these mechanically determine the e2e behavior:

| Layer | Test | Result |
|---|---|---|
| Triton input tensor → `executor::SamplingConfig` extraction | `triton_backend/inflight_batcher_llm/tests/utilsTest::extractSingleton` (extended in this PR to push `prompt_ignore_length=7`) | **`getPromptIgnoreLength().value() == 7`** ✓ |
| `executor::SamplingConfig` getter/setter API | `cpp/tests/unit_tests/executor/samplingConfigTest::getterSetter` | `setPromptIgnoreLength(1)` round-trips ✓ |
| `runtime::SamplingConfig` field | `cpp/tests/unit_tests/runtime/samplingConfigTest::validInputs` | round-trip ✓ |
| GPU penalty kernel uses field correctly | `cpp/tests/unit_tests/kernels/sampling/samplingPenaltyTest::PenaltyTypeFullWithPartialPromptIgnore` (added by upstream PR #8127) | kernel skips first N prompt tokens ✓ |

This is a complete chain: input tensor → `getSamplingConfigFromTensors` → `SamplingConfig::mPromptIgnoreLength` → penalty kernel skips N tokens. Each link is unit-tested. The Triton model repo also accepted the `prompt_ignore_length` input tensor (INT32) without protocol error, confirming the `config.pbtxt` declaration is valid.

### Summary

| Field | E2E behavioral demo | Mechanical proof |
|---|---|---|
| `length_penalty` | ✓ — chosen beam differs (`''` vs 100-token text) | ✓ — slot 15 alignment |
| `early_stopping` | ✓ — beam_lens differ ([53,53,47,53] vs [0,0,0,0]) | ✓ — slot 16 alignment |
| `prompt_ignore_length` | inconclusive on TinyLlama-Chat (model emits `<eos>` too aggressively) | ✓ — slot 14 alignment + kernel test + tensor accepted by tritonserver |

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
