### PR TITLE
[None][feat] add batch-full benchmark throughput metric

### DIFF
--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -85,7 +85,65 @@ class StatsKeeper:
         """Set the total energy for the benchmark."""
         self.total_energy = energy
 
-    def generate_statistics_summary(self, max_draft_tokens: int) -> None:
+    @staticmethod
+    def _compute_batch_full_output_throughput(
+            requests: List[RequestRecord], batch_size: int) -> Optional[float]:
+        """Estimate output token throughput while active requests fill a batch.
+
+        Request records do not carry per-token timestamps, so output tokens are
+        prorated uniformly over each request's start/end interval.  This keeps
+        the existing end-to-end throughput while adding a steady-state view that
+        excludes the final drain phase when active requests drop below
+        ``batch_size``.
+        """
+        if batch_size <= 0:
+            return None
+
+        events: Dict[int, int] = {}
+        request_spans = []
+        for request in requests:
+            start = request.start_timestamp
+            end = request.end_timestamp
+            if end <= start:
+                continue
+            request_spans.append((start, end, request.num_total_output_tokens))
+            events[start] = events.get(start, 0) + 1
+            events[end] = events.get(end, 0) - 1
+
+        if not request_spans:
+            return None
+
+        active_requests = 0
+        last_timestamp = None
+        batch_full_intervals = []
+        for timestamp in sorted(events):
+            if (last_timestamp is not None and timestamp > last_timestamp
+                    and active_requests >= batch_size):
+                batch_full_intervals.append((last_timestamp, timestamp))
+            active_requests += events[timestamp]
+            last_timestamp = timestamp
+
+        batch_full_duration_ns = sum(end - start
+                                     for start, end in batch_full_intervals)
+        if batch_full_duration_ns <= 0:
+            return None
+
+        batch_full_output_tokens = 0.0
+        for request_start, request_end, output_tokens in request_spans:
+            request_duration_ns = request_end - request_start
+            for interval_start, interval_end in batch_full_intervals:
+                overlap_ns = max(
+                    0,
+                    min(request_end, interval_end) -
+                    max(request_start, interval_start))
+                if overlap_ns:
+                    batch_full_output_tokens += (output_tokens * overlap_ns /
+                                                 request_duration_ns)
+
+        return batch_full_output_tokens / batch_full_duration_ns
+
+    def generate_statistics_summary(self, max_draft_tokens: int,
+                                    batch_size: int) -> BenchmarkStatistics:
         """Generate summary statistics from internally stored statistics.
 
         Returns:
@@ -154,11 +212,14 @@ class StatsKeeper:
         acceptance_length_percentiles = PercentileStats.from_iterable(
             acceptance_length) if acceptance_length else None
 
+        requests = list(self.requests.values())
         stats = BenchmarkStatistics(
             num_requests=num_requests,
             total_latency_ns=end_time - start_time,
             total_output_tokens=sum(output_tokens),
             total_input_tokens=total_input_tokens,
+            batch_full_output_throughput_tok_ns=self.
+            _compute_batch_full_output_throughput(requests, batch_size),
             total_energy=self.total_energy,
             request_latency_percentiles=PercentileStats.from_iterable(
                 request_latencies),
@@ -209,7 +270,8 @@ class ReportUtility:
         self.kwargs = kwargs
         self.raw_statistics = statistics
         self.statistics = statistics.generate_statistics_summary(
-            self.get_max_draft_len())
+            self.get_max_draft_len(),
+            self.rt_cfg.settings_config.max_batch_size)
         self.streaming = streaming
 
     def _query_gpu_info(self) -> Dict[str, Any]:
@@ -273,6 +335,13 @@ class ReportUtility:
     def output_throughput_tok_s(self) -> float:
         """Output throughput in tokens per second."""
         return self.convert_rate_to_s(self.statistics.output_throughput_tok_ns)
+
+    @property
+    def batch_full_output_throughput_tok_s(self) -> Optional[float]:
+        """Estimated output throughput while active requests fill a batch."""
+        throughput = self.statistics.batch_full_output_throughput_tok_ns
+        return self.convert_rate_to_s(
+            throughput) if throughput is not None else None
 
     @property
     def total_token_throughput_tok_s(self) -> float:
@@ -428,6 +497,9 @@ class ReportUtility:
             # Output throughput (total output (OSL) tokens / end-to-end latency)
             "system_output_throughput_tok_s":
             self.output_throughput_tok_s,
+            # Estimated output throughput while active requests fill a batch.
+            "batch_full_output_throughput_tok_s":
+            self.batch_full_output_throughput_tok_s,
             # Output throughput per user (average per request output throughput)
             "system_total_throughput_tok_s":
             self.total_token_throughput_tok_s,
@@ -647,9 +719,15 @@ class ReportUtility:
             "= PERFORMANCE OVERVIEW \n"
             "===========================================================\n")
 
+        batch_full_output_throughput = perf[
+            "batch_full_output_throughput_tok_s"]
+        batch_full_output_throughput_text = (
+            f"{batch_full_output_throughput:.4f}"
+            if batch_full_output_throughput is not None else "N/A")
         perf_stats = (
             f"Request Throughput (req/sec):                     {perf['request_throughput_req_s']:.4f}\n"
             f"Total Output Throughput (tokens/sec):             {perf['system_output_throughput_tok_s']:.4f}\n"
+            f"Batch-Full Output Throughput (tokens/sec):        {batch_full_output_throughput_text}\n"
             f"Total Token Throughput (tokens/sec):              {perf['system_total_throughput_tok_s']:.4f}\n"
             f"Total Latency (ms):                               {perf['total_latency_ms']:.4f}\n"
             f"Average request latency (ms):                     {perf['avg_request_latency_ms']:.4f}\n"

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -99,46 +99,41 @@ class StatsKeeper:
         if batch_size <= 0:
             return None
 
-        events: Dict[int, int] = {}
-        request_spans = []
+        events: Dict[int, tuple[int, float]] = {}
         for request in requests:
             start = request.start_timestamp
             end = request.end_timestamp
             if end <= start:
                 continue
-            request_spans.append((start, end, request.num_total_output_tokens))
-            events[start] = events.get(start, 0) + 1
-            events[end] = events.get(end, 0) - 1
+            token_rate = request.num_total_output_tokens / (end - start)
+            start_request_delta, start_rate_delta = events.get(start, (0, 0.0))
+            events[start] = (start_request_delta + 1,
+                             start_rate_delta + token_rate)
+            end_request_delta, end_rate_delta = events.get(end, (0, 0.0))
+            events[end] = (end_request_delta - 1, end_rate_delta - token_rate)
 
-        if not request_spans:
+        if not events:
             return None
 
         active_requests = 0
+        active_token_rate = 0.0
+        batch_full_duration_ns = 0
+        batch_full_output_tokens = 0.0
         last_timestamp = None
-        batch_full_intervals = []
         for timestamp in sorted(events):
             if (last_timestamp is not None and timestamp > last_timestamp
                     and active_requests >= batch_size):
-                batch_full_intervals.append((last_timestamp, timestamp))
-            active_requests += events[timestamp]
+                duration_ns = timestamp - last_timestamp
+                batch_full_duration_ns += duration_ns
+                batch_full_output_tokens += active_token_rate * duration_ns
+
+            request_delta, rate_delta = events[timestamp]
+            active_requests += request_delta
+            active_token_rate += rate_delta
             last_timestamp = timestamp
 
-        batch_full_duration_ns = sum(end - start
-                                     for start, end in batch_full_intervals)
         if batch_full_duration_ns <= 0:
             return None
-
-        batch_full_output_tokens = 0.0
-        for request_start, request_end, output_tokens in request_spans:
-            request_duration_ns = request_end - request_start
-            for interval_start, interval_end in batch_full_intervals:
-                overlap_ns = max(
-                    0,
-                    min(request_end, interval_end) -
-                    max(request_start, interval_start))
-                if overlap_ns:
-                    batch_full_output_tokens += (output_tokens * overlap_ns /
-                                                 request_duration_ns)
 
         return batch_full_output_tokens / batch_full_duration_ns
 

--- a/tensorrt_llm/bench/dataclasses/statistics.py
+++ b/tensorrt_llm/bench/dataclasses/statistics.py
@@ -121,6 +121,7 @@ class BenchmarkStatistics(BaseModel):
     # Token-related Properties
     total_output_tokens: int
     total_input_tokens: int
+    batch_full_output_throughput_tok_ns: Optional[float] = None
 
     # General Information
     num_requests: int


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new batch-full output throughput metric that measures output tokens per second when the batch is operating at full capacity. This metric estimates performance during peak load conditions and provides visibility into maximum achievable throughput. Now included in performance statistics and reporting overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Motivation

In speculative decoding benchmarks, we want generated outputs to remain valid user-facing content. For that reason, these tests should not ignore EOS, and the input prompts should use the chat template when appropriate.

That makes the benchmark closer to real serving behavior, but it also means output lengths are naturally uneven. With 80 test samples and larger batch sizes such as 32 or 64, a single long-tail request can keep running after most other requests have finished. This final drain phase can noticeably reduce end-to-end output throughput, even when the steady-state full-batch throughput is healthy.

For example, in one Llama 8B rejection-sampling run:

- `bs32/linear_rejection_on`
  - End-to-end output throughput: `637.2 tok/s`
  - Batch-full output throughput: `2445.8 tok/s`
  - One request reached the `2000` token cap without EOS, which heavily dragged down the end-to-end metric.

- `bs32/dynamic_tree_rejection_on`
  - End-to-end output throughput: `1473.6 tok/s`
  - Batch-full output throughput: `2502.5 tok/s`
  - Two requests reached the `2000` token cap, creating a visible tail/drain effect.

The existing output throughput metric is still useful because it reflects total wall-clock behavior, including tail latency. However, it can obscure the steady-state throughput when the batch is full.

## Changes

This PR adds a new benchmark metric:

- `batch_full_output_throughput_tok_s`

The metric estimates output token throughput only over intervals where the number of active requests is at least the configured batch size. Since request records do not include per-token timestamps, output tokens are prorated uniformly over each request's start/end interval.

This gives us a complementary steady-state throughput view while preserving the existing end-to-end throughput metric.


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
