### PR TITLE
[TRTLLM-12374][fix] Tighten DSv4 cache constraint floor to match warmup shapes

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -450,7 +450,6 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         # Build constraints and typical_step for better pool ratio.
         max_batch_size = self.max_batch_size
         max_seq_len = self.max_seq_len
-        max_input_len = self._max_input_len
         max_num_tokens = self._max_num_tokens
         max_draft_len = self._max_draft_len
 
@@ -459,32 +458,29 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         # the typical step. An all-generation typical_step over-provisions the
         # compressed-cache pool at the expense of the SWA pool, starving the
         # SWA pool and artificially capping the achievable batch size.
+        ctx_capacity = max_num_tokens if max_num_tokens is not None else max_seq_len
         typical_step = BatchDesc(
             kv_caches=[
-                KVCacheDesc(capacity=max_seq_len, history_length=0),
+                KVCacheDesc(capacity=ctx_capacity, history_length=0),
             ]
             + [KVCacheDesc(capacity=max_seq_len, history_length=max_seq_len - max_draft_len - 1)]
             * (max_batch_size - 1),
         )
 
         constraints = []
-        # Constraint 1: one context request at max_seq_len, this case is used in warmup stage.
-        # max_draft_len is already included in max_seq_len, so no need to add it again.
-        constraints.append(BatchDesc([KVCacheDesc(capacity=max_seq_len, history_length=0)]))
+        # Constraint 1: cuda graph generation warmup — one decode request that has
+        # accumulated to the tail of max_seq_len. Using history_length=max_seq_len-1
+        # (instead of 0) lets SWA / SSM pools collapse to their windowed working set,
+        # while full-cache pools still need max_seq_len/tokens_per_block blocks
+        # because they don't age.
+        constraints.append(
+            BatchDesc([KVCacheDesc(capacity=max_seq_len, history_length=max_seq_len - 1)])
+        )
 
-        # Constraint 2: when user given max_input_len and max_num_tokens, we can build constraints for context requests.
-        if max_input_len is not None and max_num_tokens is not None:
-            # There are at most max_batch_size generation requests, and each generation request consumes
-            # (max_draft_len + 1) tokens, so the remaining tokens are for context requests.
-            max_context_tokens = max_num_tokens - max_batch_size * (max_draft_len + 1)
-            if max_context_tokens > 0:
-                max_num_context = min(max_context_tokens // max_input_len, max_batch_size)
-                constraints.append(
-                    BatchDesc(
-                        [KVCacheDesc(capacity=max_input_len + max_draft_len + 1, history_length=0)]
-                        * max_num_context
-                    )
-                )
+        # Constraint 2: general / chunked-prefill warmup — one fresh context request
+        # at max_num_tokens (the per-iteration token budget).
+        if max_num_tokens is not None:
+            constraints.append(BatchDesc([KVCacheDesc(capacity=max_num_tokens, history_length=0)]))
 
         return KVCacheManagerConfigPy(
             tokens_per_block=tokens_per_block,


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                          
  DSv4-Pro hits `cuMemCreate-FAIL` during V2 KV cache initialization at small batch sizes (e.g., `max_batch_size=8`), with accumulated allocation reaching ~124.7 GiB even though the user-derived `quota_from_max_tokens` is only 117.84 GiB. This is
  **not** a batch-size problem — the constraint floor is over-reserving.                                                                                                                                                                                  
                                                      
  ## Root cause                                                                                                                                                                                                                                           
                                         
  `_storage_manager.py::_compute_slot_count_for_level` takes:                                                                                                                                                                                             
                                       
  ```python                                                                                                                                                                                                                                               
  quota = max(min_quota_from_constraints, user_quota)
                                         
  so once min_quota_from_constraints exceeds user_quota, the user's free_gpu_memory_fraction is silently overridden.                                                                                                                                      
                                                      
  The previous Constraint 1 was:                                                                                                                                                                                                                          
                                          
  KVCacheDesc(capacity=max_seq_len, history_length=0)                                                                                                                                                                                                     
                                                                                                                                                                                                                                                          
  history_length=0 represents the freshest state of a request that has the full max_seq_len capacity — a worst case that never actually occurs at runtime. With 64-layer DSv4-Pro and max_seq_len=300K, every pool group's min_slots was forced to        
  max_seq_len / tokens_per_block ≈ 2344, including SWA and SSM pools that should collapse to their windowed working set. The resulting floor (~125 GiB) directly exceeded the user quota and triggered the OOM.                                           
                                                      
  Fix                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                          
  Reshape the constraints to match the two real warmup shapes used by _capture_generation_cuda_graphs and _general_warmup_impl:                                                                                                                           
                                                                                                                                                                                                                                                          
  ┌────────────┬────────────────────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────┐                                                                                    
  │ Constraint │                                          Warmup form                                           │                    KVCacheDesc                     │
  ├────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ C1         │ CUDA graph generation warmup — one decode request at the tail of max_seq_len                   │ capacity=max_seq_len, history_length=max_seq_len-1 │                                                                                    
  ├────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ C2         │ General / chunked-prefill warmup — one fresh context request of the per-iteration token budget │ capacity=max_num_tokens, history_length=0          │                                                                                    
  └────────────┴────────────────────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────┘