### PR TITLE
[#3324][fix] Honor tie_word_embeddings when sharing lm_head and embedding weights

### DIFF
--- a/tensorrt_llm/models/commandr/config.py
+++ b/tensorrt_llm/models/commandr/config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,7 +60,8 @@ class CohereConfig(PretrainedConfig):
 
         dtype = infer_dtype(dtype, getattr(hf_config, 'torch_dtype', None))
 
-        if hf_config.tie_word_embeddings:
+        tie_word_embeddings = getattr(hf_config, 'tie_word_embeddings', False)
+        if tie_word_embeddings:
             kwargs['use_parallel_embedding'] = True
             kwargs['embedding_sharding_dim'] = 0
 
@@ -82,6 +83,7 @@ class CohereConfig(PretrainedConfig):
             rotary_base=hf_config.rope_theta,
             attn_bias=hf_config.attention_bias,
             qk_layernorm=hf_config.use_qk_norm,
+            tie_word_embeddings=tie_word_embeddings,
             mapping=mapping,
             quantization=quant_config,
             **kwargs)

--- a/tensorrt_llm/models/model_weights_loader.py
+++ b/tensorrt_llm/models/model_weights_loader.py
@@ -335,7 +335,8 @@ class ModelWeightsLoader:
             if self.tllm_to_externel_key_dict['layers'] != 'layers':
                 del self.tllm_to_externel_key_dict['layers']
 
-        # Share embedding; only applies to standard structure with lm_head and transformer.vocab_embedding
+        # Share embedding when config.tie_word_embeddings is set; only applies
+        # to the standard lm_head + transformer.vocab_embedding structure.
         if hasattr(self.model, 'lm_head') and hasattr(
                 self.model, 'transformer') and hasattr(self.model.transformer,
                                                        'vocab_embedding'):
@@ -344,12 +345,16 @@ class ModelWeightsLoader:
             vocab_embed_weights = self.load_tensor(
                 self.translate_to_external_key(
                     'transformer.vocab_embedding.weight'))
-            if lm_head_weights is None and vocab_embed_weights is not None:
+            tie_word_embeddings = getattr(model.config, 'tie_word_embeddings',
+                                          False)
+            if (tie_word_embeddings and lm_head_weights is None
+                    and vocab_embed_weights is not None):
                 self.tllm_to_externel_key_dict[
                     'lm_head'] = self.tllm_to_externel_key_dict[
                         'transformer'] + '.' + self.tllm_to_externel_key_dict[
                             'vocab_embedding']
-            elif lm_head_weights is not None and vocab_embed_weights is None:
+            elif (tie_word_embeddings and lm_head_weights is not None
+                  and vocab_embed_weights is None):
                 self.tllm_to_externel_key_dict[
                     'vocab_embedding'] = self.tllm_to_externel_key_dict[
                         'lm_head']


### PR DESCRIPTION
## Description

`ModelWeightsLoader.update_key_mapping` silently tied `lm_head` and
`transformer.vocab_embedding` whenever exactly one of the two weights was
missing from the checkpoint, regardless of `model.config.tie_word_embeddings`.
That hid genuine load failures behind tied weights for models that do not tie
embeddings, which is the issue poedator reported in #3324.

This PR gates both tying branches on
`getattr(model.config, 'tie_word_embeddings', False)` so a missing weight
surfaces as a regular load error when tying was not requested. The PyTorch
backend already does this check in
`tensorrt_llm/_torch/models/checkpoints/hf/weight_mapper.py`
(`HfWeightMapper.should_skip_module`); this brings the legacy TensorRT backend
in line.

`CohereConfig.from_hugging_face` previously read `hf_config.tie_word_embeddings`
only to flip `use_parallel_embedding` and never propagated it to the TRT-LLM
config. Without that propagation the new gate would refuse to tie for tied
Cohere/CommandR checkpoints, where the silent auto-tying was load-bearing. The
flag is now passed through so tied Cohere checkpoints continue to load.

Fixes #3324

## Test Coverage

- Existing integration test
  `examples/test_commandr.py::test_llm_commandr_v01_single_gpu_summary`
  (`l0_a30.yml:129-130`) exercises the Cohere conversion path end-to-end with
  a real `c4ai-command-r-v01` checkpoint, covering the propagation change.
- Manually verified: a HF checkpoint with `tie_word_embeddings=False` and a
  missing `lm_head.weight` now raises a load error instead of silently tying
  to `transformer.vocab_embedding.weight`.
- Manually verified: a HF checkpoint with `tie_word_embeddings=True` and
  `lm_head.weight` absent still resolves to the embedding weight (tying
  preserved when explicitly requested).

## PR Checklist

- [x] PR description clearly explains what and why
- [x] PR follows TRT-LLM coding guidelines
- [x] No new dependencies introduced
- [x] No ownership or architecture changes
- [x] Documentation changes not required for this fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved handling of word embedding configuration. The model now properly defaults and propagates the tied embeddings setting across initialization and weight loading stages, ensuring consistent and predictable behavior when embedding weights are shared between the vocabulary embeddings and language model output head components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->