### PR TITLE
[None][perf] Improve TRTLLM MoE autotune in DEP

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -16,6 +16,38 @@ from ..autotuner import (AutoTuner, ConstraintSpec, DynamicTensorSpec,
 
 _MOE_AUTOTUNE_DUMMY_DISTRIBUTION_ENV = (
     "TRTLLM_GEN_MOE_AUTOTUNE_DUMMY_DISTRIBUTION")
+# Distribution names control the *shape* of the autotune dummy topk
+# (random vs balanced). Whether the dummy targets the local expert shard
+# or all experts is decided by the caller via the `use_dp` argument:
+#
+#   use_dp=True — mimics load-balanced DEP (Attention DP + MoE EP).
+#   The system globally holds `ep_size * runtime_max_tokens_per_rank`
+#   tokens which A2A perfectly distributes across the ep_size ranks,
+#   so each rank's autotune dummy carries `runtime_max_tokens_per_rank`
+#   rows whose top_k slots all live in the local expert shard
+#   `[local_expert_offset, local_expert_offset + local_num_experts)`.
+#   m_local per local expert = `num_tokens * top_k / local_num_experts`.
+#
+#   use_dp=False — pure EP (no Attention DP). The system never holds
+#   `ep_size * runtime_max_tokens_per_rank` tokens; each rank sees its
+#   own `runtime_max_tokens_per_rank` rows whose top_k slots span global
+#   experts, so only ~1/ep_size of slots hit local experts. m_local per
+#   local expert = `num_tokens * top_k / num_experts`.
+#
+# The same `use_dp` flag also drives `round_rule` in each runner's
+# `get_dynamic_tensor_specs`. The autotuner sees `x` = the kernel m-dim
+# of the input buffer (= the inflated A2A recv pool when use_dp=True,
+# = per-rank tokens when use_dp=False) and must map it to one of the
+# m_values profile buckets. The mapping:
+#
+#   1. Round to last power of 2.
+#   2. If use_dp=True, deflate by ep_size to assume the avg-case
+#      perfectly-distributed per-rank load `runtime_max_tokens_per_rank`.
+#   3. If the result still exceeds MAX_PROFILE_BUCKET (8192) and the
+#      caller appended a `tune_max_num_tokens` bucket past it, route
+#      there — the caller added that bucket precisely so the kernel
+#      gets timed at runtime scale instead of being clamped to 8192.
+#   4. Otherwise clamp into the small pow2 ladder.
 _BALANCED = "balanced"
 _RANDOM = "random"
 
@@ -34,6 +66,8 @@ def prepare_dummy_topk_and_hook(
     topk_group: Optional[int],
     routed_scaling_factor: Optional[float],
     hidden_states_index: int = 2,
+    local_expert_offset: int = 0,
+    use_dp: bool = False,
 ) -> Tuple[Optional[torch.Tensor], torch.Tensor, torch.Tensor, TuningConfig]:
     """
     Prepare dummy topk tensors and input pre-hook for AutoTuner profiling.
@@ -59,6 +93,15 @@ def prepare_dummy_topk_and_hook(
         local_num_experts: Number of experts owned by this rank (for the
             balanced dummy-topk stride; ignored by the random distribution)
         hidden_states_index: Index of hidden_states in input_tensors list (default: 2)
+        local_expert_offset: First global expert id owned by this rank;
+            used to translate local-shard indices back to global ids
+            when `use_dp=True` (default 0).
+        use_dp: When True, the dummy mimics the load-balanced DEP
+            (Attention DP + MoE EP) regime — every top_k slot targets the
+            local expert shard. When False (default), the dummy spans
+            all global experts (pure-EP regime). See the module-level
+            distribution comment for the full framing and the
+            corresponding profile-bucket math driven by `round_rule`.
 
     Returns:
         Tuple of (routing_logits_for_tuner, topk_weights_for_tuner, topk_ids_for_tuner, tuning_config_with_hook)
@@ -77,50 +120,58 @@ def prepare_dummy_topk_and_hook(
         raise ValueError(
             f"Unsupported {_MOE_AUTOTUNE_DUMMY_DISTRIBUTION_ENV}={autotune_distribution!r}; "
             f"expected one of {sorted(supported_distributions)}")
+    is_balanced = autotune_distribution == _BALANCED
+    # Caller-supplied flag: under Attention DP + MoE EP each rank's autotune
+    # dummy carries `runtime_max_tokens_per_rank` rows whose top_k slots
+    # all target the local expert shard (the perfectly-distributed
+    # post-A2A state). Under pure EP (use_dp=False) the dummy spans all
+    # experts and only ~1/ep_size of slots hit local.
+    is_local = use_dp
 
     def make_balanced_dummy_topk(
             num_tokens: int,
             device: torch.device) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Deterministic round-robin topk_ids of shape [num_tokens, top_k].
+
+        `is_local` selects between two MoE deployment regimes:
+
+          * `is_local=True` — DEP (Data + Expert Parallel + Attention
+            DP). Mimics the load-balanced post-A2A layout: the global
+            pool of `ep_size * runtime_max_tokens_per_rank` tokens is
+            perfectly distributed across the ep_size ranks, so each
+            rank sees `runtime_max_tokens_per_rank` rows whose top_k
+            slots all live in the local expert shard
+            `[local_expert_offset, local_expert_offset + local_num_experts)`.
+            m_local per local expert = `num_tokens * top_k / local_num_experts`.
+            Pure EP without Attention DP never has that many tokens in
+            the system, so this regime is specific to DEP.
+
+          * `is_local=False` — pure EP. Round-robin over all
+            `num_experts`; only ~1/ep_size of slots hit local experts.
+            m_local per local expert = `num_tokens * top_k / num_experts`.
+
+        Formula (both regimes):
+            n_target = local_num_experts if is_local else num_experts
+            topk_ids[t, k] = (t + k * stride) % n_target  (+ local_expert_offset if is_local)
+
+        Stride is picked so each row's `top_k` entries stay distinct;
+        the assertion guards against degenerate (n_target < top_k) configs
+        that would produce in-row duplicates.
         """
-        Build deterministic topk_ids of shape [num_tokens, top_k] that are
-        perfectly balanced over [0, num_experts) and round-robin across ranks,
-        so each token's top_k experts fan out across EP ranks instead of
-        clumping onto consecutive ids.
-
-        Formula: topk_ids[t, k] = (t + k * stride) % num_experts,
-        with stride = min(local_num_experts, num_experts // top_k).
-
-        The min() has two regimes:
-          * top_k <= ep_size: stride == local_num_experts, so each k slot
-            lands on a distinct rank and every token touches top_k ranks.
-          * top_k  > ep_size: stride == num_experts // top_k, which keeps
-            top_k * stride <= num_experts so row entries stay distinct; each
-            token hits each rank ~top_k/ep_size times.
-
-        Example (ep_size=2, num_experts=8, local_num_experts=4, top_k=2,
-        num_tokens=4):
-            stride = min(4, 4) = 4
-            base   = [0, 4]
-            topk_ids = [[0, 4],
-                        [1, 5],
-                        [2, 6],
-                        [3, 7]]
-        Each token sends one expert to rank 0 (ids 0-3) and one to rank 1
-        (ids 4-7); every local expert receives exactly one token. Globally
-        uniform per-expert load matches the balanced attention-DP case.
-
-        Precondition: num_experts >= top_k. Real MoE configs always satisfy
-        this; the assertion catches degenerate tuning configurations that
-        would otherwise produce in-row duplicates.
-        """
-        assert num_experts >= top_k, (
-            f"make_balanced_dummy_topk requires num_experts >= top_k; "
-            f"got num_experts={num_experts}, top_k={top_k}")
-        stride = max(1, min(local_num_experts, num_experts // top_k))
+        n_target = local_num_experts if is_local else num_experts
+        assert n_target >= top_k, (
+            f"make_balanced_dummy_topk requires n_target>={top_k}; "
+            f"got n_target={n_target}, is_local={is_local}, "
+            f"num_experts={num_experts}, local_num_experts={local_num_experts}")
+        stride = max(1, min(local_num_experts, n_target // top_k))
+        if stride * top_k > n_target:
+            stride = max(1, n_target // top_k)
         base = torch.arange(top_k, device=device, dtype=torch.int32) * stride
         token_idx = torch.arange(num_tokens, device=device,
                                  dtype=torch.int32).unsqueeze(1)
-        topk_ids = (base + token_idx) % num_experts
+        topk_ids = (base + token_idx) % n_target
+        if is_local:
+            topk_ids = topk_ids + local_expert_offset
         topk_weights = torch.ones(num_tokens,
                                   top_k,
                                   dtype=torch.bfloat16,
@@ -131,15 +182,23 @@ def prepare_dummy_topk_and_hook(
             num_tokens: int, device: torch.device,
             logits: Optional[torch.Tensor]
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        if autotune_distribution == _RANDOM:
-            return make_routing_dummy_topk(num_tokens, device, logits)
-        elif autotune_distribution == _BALANCED:
+        if is_balanced:
             return make_balanced_dummy_topk(num_tokens, device)
-        else:
-            raise ValueError(
-                f"Unsupported autotune distribution {autotune_distribution!r}")
+        # Random regime: `is_local` decides whether the dummy topk
+        # targets only local experts (DEP) or spans all experts (pure EP).
+        # The local path bypasses `routing_method.apply` and does a plain
+        # `torch.topk` on per-rank logits, since the model's routing
+        # method emits global indices and would have to be re-projected.
+        return make_routing_dummy_topk(num_tokens, device,
+                                       None if is_local else logits)
 
     def make_routing_method():
+
+        # Lazy import to avoid circular import: fused_moe imports from this module.
+        from tensorrt_llm._torch.modules.fused_moe.routing import (
+            ROUTING_METHOD_TYPE_TO_CLASS, RoutingMethodType)
+
+        # Get routing method
         routing_cls_kwargs = {}
         if routing_method_type == RoutingMethodType.DeepSeekV3:
             routing_cls_kwargs.update({
@@ -150,7 +209,7 @@ def prepare_dummy_topk_and_hook(
                 'routed_scaling_factor':
                 routed_scaling_factor,
                 'is_fused':
-                False,
+                False,  # fuse_routing_kernel
                 'callable_e_score_correction_bias':
                 lambda: torch.randn(num_experts,
                                     dtype=torch.bfloat16,
@@ -159,11 +218,14 @@ def prepare_dummy_topk_and_hook(
         if routing_method_type == RoutingMethodType.MiniMax2:
             routing_cls_kwargs.update({
                 'callable_e_score_correction_bias':
-                lambda: torch.randn(num_experts,
-                                    dtype=torch.bfloat16,
-                                    device=hidden_states.device),
+                lambda: torch.randn(
+                    num_experts, dtype=torch.bfloat16, device=hidden_states.device),
                 'num_experts':
                 num_experts,
+            })
+        if routing_method_type == RoutingMethodType.SigmoidRenorm:
+            routing_cls_kwargs.update({
+                'num_experts': num_experts,
             })
         return ROUTING_METHOD_TYPE_TO_CLASS[routing_method_type](
             top_k=top_k, **routing_cls_kwargs)
@@ -171,8 +233,52 @@ def prepare_dummy_topk_and_hook(
     def make_routing_dummy_topk(
         num_tokens: int,
         device: torch.device,
-        logits: Optional[torch.Tensor] = None
+        logits: Optional[torch.Tensor] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Random topk dummy.
+
+        `is_local` selects between two MoE deployment regimes (see the
+        module-level distribution comment):
+
+          * `is_local=True` (DEP) — generate logits over
+            `local_num_experts`, take a plain `torch.topk`, then offset
+            indices into the local expert shard. We deliberately bypass
+            `routing_method.apply` here: the model's routing operates
+            on the global `num_experts` and emits global indices, while
+            the post-A2A dummy must fall entirely inside the local
+            shard. CAVEAT: routing methods that group experts at global
+            scale (e.g. DeepSeekV3 with `n_group` / `topk_group`,
+            Llama4) won't have their group structure reflected, and
+            grouped methods can be ill-defined when `local_num_experts`
+            is smaller than the group cardinality. For a tuning dummy
+            the distributional difference is acceptable; runtime still
+            uses the real routing method.
+
+          * `is_local=False` (pure EP) — generate logits over
+            `num_experts` and run them through the model's routing method
+            so the per-expert distribution matches what real inference
+            would observe.
+        """
+        if is_local:
+            assert local_num_experts >= top_k, (
+                f"random_local requires local_num_experts >= top_k; "
+                f"got local_num_experts={local_num_experts}, top_k={top_k}")
+            if (logits is None or logits.shape[0] != num_tokens
+                    or logits.shape[-1] != local_num_experts):
+                logits = torch.randn(num_tokens,
+                                     local_num_experts,
+                                     dtype=torch.bfloat16,
+                                     device=device)
+            # Plain topk over local logits — bypasses the model's
+            # routing_method on purpose (see docstring caveat re:
+            # grouped routings like DeepSeekV3 / Llama4).
+            topk_ids = torch.topk(logits.float(), top_k, dim=-1).indices.to(
+                torch.int32) + local_expert_offset
+            topk_weights = torch.ones(num_tokens,
+                                      top_k,
+                                      dtype=torch.bfloat16,
+                                      device=device)
+            return topk_weights, topk_ids
         routing_method = make_routing_method()
         if logits is None or logits.shape[0] != num_tokens:
             logits = torch.randn(num_tokens,
@@ -192,41 +298,6 @@ def prepare_dummy_topk_and_hook(
 
     # Determine if we need dummy topk tensors (attention DP scenario)
     need_dummy_topk = (topk_weights is not None or topk_ids is not None)
-
-    # Lazy import to avoid circular import: fused_moe imports from this module.
-    from tensorrt_llm._torch.modules.fused_moe.routing import (
-        ROUTING_METHOD_TYPE_TO_CLASS, RoutingMethodType)
-
-    # Get routing method
-    routing_cls_kwargs = {}
-    if routing_method_type == RoutingMethodType.DeepSeekV3:
-        routing_cls_kwargs.update({
-            'n_group':
-            n_group,
-            'topk_group':
-            topk_group,
-            'routed_scaling_factor':
-            routed_scaling_factor,
-            'is_fused':
-            False,  # fuse_routing_kernel
-            'callable_e_score_correction_bias':
-            lambda: torch.randn(
-                num_experts, dtype=torch.bfloat16, device=hidden_states.device)
-        })
-    if routing_method_type == RoutingMethodType.MiniMax2:
-        routing_cls_kwargs.update({
-            'callable_e_score_correction_bias':
-            lambda: torch.randn(
-                num_experts, dtype=torch.bfloat16, device=hidden_states.device),
-            'num_experts':
-            num_experts,
-        })
-    if routing_method_type == RoutingMethodType.SigmoidRenorm:
-        routing_cls_kwargs.update({
-            'num_experts': num_experts,
-        })
-    routing_method = ROUTING_METHOD_TYPE_TO_CLASS[routing_method_type](
-        top_k=top_k, **routing_cls_kwargs)
 
     # Create dummy topk tensors for attention DP scenario
     if need_dummy_topk:
@@ -332,11 +403,20 @@ class FP4BlockScaleMoERunner(TunableRunner):
     runner_dict = dict()
     tuning_config = None
 
-    def __init__(self, num_experts: int, top_k: int, n_group: Optional[int],
-                 topk_group: Optional[int], intermediate_size: int,
-                 local_expert_offset: int, local_num_experts: int,
+    def __init__(self,
+                 num_experts: int,
+                 top_k: int,
+                 n_group: Optional[int],
+                 topk_group: Optional[int],
+                 intermediate_size: int,
+                 local_expert_offset: int,
+                 local_num_experts: int,
                  routed_scaling_factor: Optional[float],
-                 routing_method_type: int, do_finalize: bool, act_type: int):
+                 routing_method_type: int,
+                 do_finalize: bool,
+                 act_type: int,
+                 tune_max_num_tokens: int = 8192,
+                 use_dp: bool = False):
 
         self.num_experts = num_experts
         self.top_k = top_k
@@ -351,7 +431,9 @@ class FP4BlockScaleMoERunner(TunableRunner):
         self.act_type = act_type
 
         self.tuning_config = FP4BlockScaleMoERunner.get_tuning_config(
-            self.num_experts // self.local_num_experts)
+            self.num_experts // self.local_num_experts,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_dp=use_dp)
 
     # The unique_id is used by the autotuner to get the cache key, so we hash on members
     # that influence tactic validity here. e.g. we are tuning FC1 and FC2 so the routing type does not matter
@@ -416,16 +498,27 @@ class FP4BlockScaleMoERunner(TunableRunner):
         return tactics
 
     @classmethod
-    def get_dynamic_tensor_specs(cls,
-                                 ep_size: int) -> Tuple[DynamicTensorSpec, ...]:
+    def get_dynamic_tensor_specs(
+            cls,
+            ep_size: int,
+            tune_max_num_tokens: int = 8192,
+            use_dp: bool = False) -> Tuple[DynamicTensorSpec, ...]:
         HIDDEN_STATES_IDX = 2
         TUNED_DIM = 0
         MAX_PROFILE_BUCKET = 8192
 
         m_values = get_last_power_of_2_num_tokens_buckets(MAX_PROFILE_BUCKET)
+        if tune_max_num_tokens > MAX_PROFILE_BUCKET:
+            m_values = tuple(m_values) + (tune_max_num_tokens, )
 
         def round_rule(x: int) -> int:
-            value = last_positive_power_of_2(x) // ep_size
+            # See the module-level distribution comment for the use_dp
+            # / ep_size deflation and tune_max_num_tokens fall-through.
+            deflated = x // ep_size if use_dp else x
+            if (deflated > MAX_PROFILE_BUCKET
+                    and tune_max_num_tokens > MAX_PROFILE_BUCKET):
+                return tune_max_num_tokens
+            value = last_positive_power_of_2(deflated)
             return min(max(1, value), MAX_PROFILE_BUCKET)
 
         specs = (DynamicTensorSpec(HIDDEN_STATES_IDX,
@@ -492,50 +585,56 @@ class FP4BlockScaleMoERunner(TunableRunner):
 
     @classmethod
     @lru_cache(maxsize=None)
-    def get_tuning_config(cls, ep_size: int) -> TuningConfig:
+    def get_tuning_config(cls,
+                          ep_size: int,
+                          tune_max_num_tokens: int = 8192,
+                          use_dp: bool = False) -> TuningConfig:
 
-        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(ep_size)
+        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(
+            ep_size, tune_max_num_tokens, use_dp)
         constraint_specs = cls.get_constraint_specs()
 
         tuning_config = TuningConfig(dynamic_tensor_specs=dynamic_tensor_specs,
                                      constraint_specs=constraint_specs,
-                                     tune_max_num_tokens=8192)
+                                     tune_max_num_tokens=max(
+                                         8192, tune_max_num_tokens))
 
         return tuning_config
 
 
 @torch.library.custom_op("trtllm::fp4_block_scale_moe_runner", mutates_args=())
-def fp4_block_scale_moe_runner(
-        routing_logits: Optional[torch.Tensor],
-        routing_bias: Optional[torch.Tensor],
-        hidden_states: torch.Tensor,
-        hidden_states_scale: torch.Tensor,
-        gemm1_weights: torch.Tensor,
-        gemm1_weights_scale: torch.Tensor,
-        gemm1_bias: torch.Tensor,
-        gemm1_alpha: torch.Tensor,
-        gemm1_beta: torch.Tensor,
-        gemm1_clamp_limit: torch.Tensor,
-        gemm2_weights: torch.Tensor,
-        gemm2_weights_scale: torch.Tensor,
-        gemm2_bias: torch.Tensor,
-        output1_scale_scalar: torch.Tensor,
-        output1_scale_gate_scalar: torch.Tensor,
-        output2_scale_scalar: torch.Tensor,
-        num_experts: int,
-        top_k: int,
-        n_group: Optional[int],
-        topk_group: Optional[int],
-        intermediate_size: int,
-        local_expert_offset: int,
-        local_num_experts: int,
-        routed_scaling_factor: Optional[float],
-        routing_method_type: int,
-        do_finalize: bool,
-        act_type: int = ActType_TrtllmGen.SwiGlu.value,
-        topk_weights: Optional[torch.Tensor] = None,
-        topk_ids: Optional[torch.Tensor] = None,
-        output: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
+def fp4_block_scale_moe_runner(routing_logits: Optional[torch.Tensor],
+                               routing_bias: Optional[torch.Tensor],
+                               hidden_states: torch.Tensor,
+                               hidden_states_scale: torch.Tensor,
+                               gemm1_weights: torch.Tensor,
+                               gemm1_weights_scale: torch.Tensor,
+                               gemm1_bias: torch.Tensor,
+                               gemm1_alpha: torch.Tensor,
+                               gemm1_beta: torch.Tensor,
+                               gemm1_clamp_limit: torch.Tensor,
+                               gemm2_weights: torch.Tensor,
+                               gemm2_weights_scale: torch.Tensor,
+                               gemm2_bias: torch.Tensor,
+                               output1_scale_scalar: torch.Tensor,
+                               output1_scale_gate_scalar: torch.Tensor,
+                               output2_scale_scalar: torch.Tensor,
+                               num_experts: int,
+                               top_k: int,
+                               n_group: Optional[int],
+                               topk_group: Optional[int],
+                               intermediate_size: int,
+                               local_expert_offset: int,
+                               local_num_experts: int,
+                               routed_scaling_factor: Optional[float],
+                               routing_method_type: int,
+                               do_finalize: bool,
+                               act_type: int = ActType_TrtllmGen.SwiGlu.value,
+                               topk_weights: Optional[torch.Tensor] = None,
+                               topk_ids: Optional[torch.Tensor] = None,
+                               output: Optional[torch.Tensor] = None,
+                               tune_max_num_tokens: int = 8192,
+                               use_dp: bool = False) -> List[torch.Tensor]:
 
     tuner = AutoTuner.get()
     kernel_runner = FP4BlockScaleMoERunner(
@@ -550,6 +649,8 @@ def fp4_block_scale_moe_runner(
         routing_method_type,
         do_finalize,
         act_type,
+        tune_max_num_tokens=tune_max_num_tokens,
+        use_dp=use_dp,
     )
 
     # Prepare dummy topk tensors and hook for AutoTuner profiling
@@ -568,6 +669,8 @@ def fp4_block_scale_moe_runner(
             topk_group=topk_group,
             routed_scaling_factor=routed_scaling_factor,
             hidden_states_index=2,
+            local_expert_offset=local_expert_offset,
+            use_dp=use_dp,
         )
 
     # Build input_tensors_for_tuner
@@ -673,7 +776,9 @@ def _(routing_logits,
       act_type,
       topk_weights: Optional[torch.Tensor] = None,
       topk_ids: Optional[torch.Tensor] = None,
-      output: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
+      output: Optional[torch.Tensor] = None,
+      tune_max_num_tokens: int = 8192,
+      use_dp: bool = False) -> List[torch.Tensor]:
     if do_finalize:
         num_tokens = hidden_states.shape[0]
         hidden_size = hidden_states.shape[1] * 2
@@ -722,6 +827,8 @@ class FP8BlockScaleMoERunner(TunableRunner):
         routed_scaling_factor: Optional[float],
         routing_method_type: int,
         act_type: int,
+        tune_max_num_tokens: int = 8192,
+        use_dp: bool = False,
     ):
 
         self.num_experts = num_experts
@@ -735,7 +842,9 @@ class FP8BlockScaleMoERunner(TunableRunner):
         self.routing_method_type = routing_method_type
         self.act_type = 0
         self.tuning_config = FP8BlockScaleMoERunner.get_tuning_config(
-            self.num_experts // self.local_num_experts)
+            self.num_experts // self.local_num_experts,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_dp=use_dp)
 
     # The unique_id is used by the autotuner to get the cache key, so we hash on members
     # that influence tactic validity here. e.g. we are tuning FC1 and FC2 so the routing
@@ -794,16 +903,27 @@ class FP8BlockScaleMoERunner(TunableRunner):
         return tactics
 
     @classmethod
-    def get_dynamic_tensor_specs(cls,
-                                 ep_size: int) -> Tuple[DynamicTensorSpec, ...]:
+    def get_dynamic_tensor_specs(
+            cls,
+            ep_size: int,
+            tune_max_num_tokens: int = 8192,
+            use_dp: bool = False) -> Tuple[DynamicTensorSpec, ...]:
         HIDDEN_STATES_IDX = 2
         TUNED_DIM = 0
         MAX_PROFILE_BUCKET = 8192
 
         m_values = get_last_power_of_2_num_tokens_buckets(MAX_PROFILE_BUCKET)
+        if tune_max_num_tokens > MAX_PROFILE_BUCKET:
+            m_values = tuple(m_values) + (tune_max_num_tokens, )
 
         def round_rule(x: int) -> int:
-            value = last_positive_power_of_2(x) // ep_size
+            # See the module-level distribution comment for the use_dp
+            # / ep_size deflation and tune_max_num_tokens fall-through.
+            deflated = x // ep_size if use_dp else x
+            if (deflated > MAX_PROFILE_BUCKET
+                    and tune_max_num_tokens > MAX_PROFILE_BUCKET):
+                return tune_max_num_tokens
+            value = last_positive_power_of_2(deflated)
             return min(max(1, value), MAX_PROFILE_BUCKET)
 
         specs = (DynamicTensorSpec(HIDDEN_STATES_IDX,
@@ -852,40 +972,47 @@ class FP8BlockScaleMoERunner(TunableRunner):
 
     @classmethod
     @lru_cache(maxsize=None)
-    def get_tuning_config(cls, ep_size: int) -> TuningConfig:
+    def get_tuning_config(cls,
+                          ep_size: int,
+                          tune_max_num_tokens: int = 8192,
+                          use_dp: bool = False) -> TuningConfig:
 
-        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(ep_size)
+        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(
+            ep_size, tune_max_num_tokens, use_dp)
         constraint_specs = cls.get_constraint_specs()
 
         tuning_config = TuningConfig(dynamic_tensor_specs=dynamic_tensor_specs,
-                                     constraint_specs=constraint_specs)
+                                     constraint_specs=constraint_specs,
+                                     tune_max_num_tokens=max(
+                                         8192, tune_max_num_tokens))
 
         return tuning_config
 
 
 @torch.library.custom_op("trtllm::fp8_block_scale_moe_runner", mutates_args=())
-def fp8_block_scale_moe_runner(
-        routing_logits: Optional[torch.Tensor],
-        routing_bias: torch.Tensor,
-        hidden_states: torch.Tensor,
-        hidden_states_scale: torch.Tensor,
-        gemm1_weights: torch.Tensor,
-        gemm1_weights_scale: torch.Tensor,
-        gemm2_weights: torch.Tensor,
-        gemm2_weights_scale: torch.Tensor,
-        num_experts: int,
-        top_k: int,
-        n_group: Optional[int],
-        topk_group: Optional[int],
-        intermediate_size: int,
-        local_expert_offset: int,
-        local_num_experts: int,
-        routed_scaling_factor: Optional[float],
-        routing_method_type: int,
-        topk_weights: Optional[torch.Tensor] = None,
-        topk_ids: Optional[torch.Tensor] = None,
-        act_type: int = 0,
-        output: Optional[torch.Tensor] = None) -> torch.Tensor:
+def fp8_block_scale_moe_runner(routing_logits: Optional[torch.Tensor],
+                               routing_bias: torch.Tensor,
+                               hidden_states: torch.Tensor,
+                               hidden_states_scale: torch.Tensor,
+                               gemm1_weights: torch.Tensor,
+                               gemm1_weights_scale: torch.Tensor,
+                               gemm2_weights: torch.Tensor,
+                               gemm2_weights_scale: torch.Tensor,
+                               num_experts: int,
+                               top_k: int,
+                               n_group: Optional[int],
+                               topk_group: Optional[int],
+                               intermediate_size: int,
+                               local_expert_offset: int,
+                               local_num_experts: int,
+                               routed_scaling_factor: Optional[float],
+                               routing_method_type: int,
+                               topk_weights: Optional[torch.Tensor] = None,
+                               topk_ids: Optional[torch.Tensor] = None,
+                               act_type: int = 0,
+                               output: Optional[torch.Tensor] = None,
+                               tune_max_num_tokens: int = 8192,
+                               use_dp: bool = False) -> torch.Tensor:
 
     tuner = AutoTuner.get()
     kernel_runner = FP8BlockScaleMoERunner(
@@ -899,6 +1026,8 @@ def fp8_block_scale_moe_runner(
         routed_scaling_factor,
         routing_method_type,
         act_type,
+        tune_max_num_tokens=tune_max_num_tokens,
+        use_dp=use_dp,
     )
 
     # Prepare dummy topk tensors and hook for AutoTuner profiling
@@ -917,6 +1046,8 @@ def fp8_block_scale_moe_runner(
             topk_group=topk_group,
             routed_scaling_factor=routed_scaling_factor,
             hidden_states_index=2,
+            local_expert_offset=local_expert_offset,
+            use_dp=use_dp,
         )
 
     input_tensors_for_tuner = [
@@ -978,7 +1109,9 @@ def _(routing_logits: torch.Tensor,
       topk_weights: Optional[torch.Tensor] = None,
       topk_ids: Optional[torch.Tensor] = None,
       act_type: int = 0,
-      output: Optional[torch.Tensor] = None) -> torch.Tensor:
+      output: Optional[torch.Tensor] = None,
+      tune_max_num_tokens: int = 8192,
+      use_dp: bool = False) -> torch.Tensor:
     num_tokens = hidden_states.shape[0]
     hidden_size = hidden_states.shape[1] * 2
 
@@ -1010,12 +1143,21 @@ class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
     runner_dict = dict()
     tuning_config = None
 
-    def __init__(self, num_experts: int, top_k: int, n_group: Optional[int],
-                 topk_group: Optional[int], intermediate_size: int,
-                 valid_hidden_size: int, valid_intermediate_size: int,
-                 local_expert_offset: int, local_num_experts: int,
+    def __init__(self,
+                 num_experts: int,
+                 top_k: int,
+                 n_group: Optional[int],
+                 topk_group: Optional[int],
+                 intermediate_size: int,
+                 valid_hidden_size: int,
+                 valid_intermediate_size: int,
+                 local_expert_offset: int,
+                 local_num_experts: int,
                  routed_scaling_factor: Optional[float],
-                 routing_method_type: int, act_type: int):
+                 routing_method_type: int,
+                 act_type: int,
+                 tune_max_num_tokens: int = 8192,
+                 use_dp: bool = False):
 
         self.num_experts = num_experts
         self.top_k = top_k
@@ -1031,7 +1173,9 @@ class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
         self.act_type = act_type
 
         self.tuning_config = MxE4m3MxE2m1BlockScaleMoERunner.get_tuning_config(
-            self.num_experts // self.local_num_experts)
+            self.num_experts // self.local_num_experts,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_dp=use_dp)
 
     # The unique_id is used by the autotuner to get the cache key, so we hash on members
     # that influence tactic validity here. e.g. we are tuning FC1 and FC2 so the routing
@@ -1102,16 +1246,27 @@ class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
         return tactics
 
     @classmethod
-    def get_dynamic_tensor_specs(cls,
-                                 ep_size: int) -> Tuple[DynamicTensorSpec, ...]:
+    def get_dynamic_tensor_specs(
+            cls,
+            ep_size: int,
+            tune_max_num_tokens: int = 8192,
+            use_dp: bool = False) -> Tuple[DynamicTensorSpec, ...]:
         HIDDEN_STATES_IDX = 2
         TUNED_DIM = 0
         MAX_PROFILE_BUCKET = 8192
 
         m_values = get_last_power_of_2_num_tokens_buckets(MAX_PROFILE_BUCKET)
+        if tune_max_num_tokens > MAX_PROFILE_BUCKET:
+            m_values = tuple(m_values) + (tune_max_num_tokens, )
 
         def round_rule(x: int) -> int:
-            value = last_positive_power_of_2(x) // ep_size
+            # See the module-level distribution comment for the use_dp
+            # / ep_size deflation and tune_max_num_tokens fall-through.
+            deflated = x // ep_size if use_dp else x
+            if (deflated > MAX_PROFILE_BUCKET
+                    and tune_max_num_tokens > MAX_PROFILE_BUCKET):
+                return tune_max_num_tokens
+            value = last_positive_power_of_2(deflated)
             return min(max(1, value), MAX_PROFILE_BUCKET)
 
         specs = (DynamicTensorSpec(HIDDEN_STATES_IDX,
@@ -1171,13 +1326,19 @@ class MxE4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 
     @classmethod
     @lru_cache(maxsize=None)
-    def get_tuning_config(cls, ep_size: int) -> TuningConfig:
+    def get_tuning_config(cls,
+                          ep_size: int,
+                          tune_max_num_tokens: int = 8192,
+                          use_dp: bool = False) -> TuningConfig:
 
-        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(ep_size)
+        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(
+            ep_size, tune_max_num_tokens, use_dp)
         constraint_specs = cls.get_constraint_specs()
 
         tuning_config = TuningConfig(dynamic_tensor_specs=dynamic_tensor_specs,
-                                     constraint_specs=constraint_specs)
+                                     constraint_specs=constraint_specs,
+                                     tune_max_num_tokens=max(
+                                         8192, tune_max_num_tokens))
 
         return tuning_config
 
@@ -1212,7 +1373,9 @@ def mxe4m3_mxe2m1_block_scale_moe_runner(
         act_type: int,
         topk_weights: Optional[torch.Tensor] = None,
         topk_ids: Optional[torch.Tensor] = None,
-        output: Optional[torch.Tensor] = None) -> torch.Tensor:
+        output: Optional[torch.Tensor] = None,
+        tune_max_num_tokens: int = 8192,
+        use_dp: bool = False) -> torch.Tensor:
 
     tuner = AutoTuner.get()
     kernel_runner = MxE4m3MxE2m1BlockScaleMoERunner(
@@ -1228,6 +1391,8 @@ def mxe4m3_mxe2m1_block_scale_moe_runner(
         routed_scaling_factor,
         routing_method_type,
         act_type,
+        tune_max_num_tokens=tune_max_num_tokens,
+        use_dp=use_dp,
     )
 
     # Prepare dummy topk tensors and hook for AutoTuner profiling
@@ -1246,6 +1411,8 @@ def mxe4m3_mxe2m1_block_scale_moe_runner(
             topk_group=topk_group,
             routed_scaling_factor=routed_scaling_factor,
             hidden_states_index=2,
+            local_expert_offset=local_expert_offset,
+            use_dp=use_dp,
         )
 
     input_tensors_for_tuner = [
@@ -1317,12 +1484,21 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
     runner_dict = dict()
     tuning_config = None
 
-    def __init__(self, num_experts: int, top_k: int, n_group: Optional[int],
-                 topk_group: Optional[int], intermediate_size: int,
-                 valid_hidden_size: int, valid_intermediate_size: int,
-                 local_expert_offset: int, local_num_experts: int,
+    def __init__(self,
+                 num_experts: int,
+                 top_k: int,
+                 n_group: Optional[int],
+                 topk_group: Optional[int],
+                 intermediate_size: int,
+                 valid_hidden_size: int,
+                 valid_intermediate_size: int,
+                 local_expert_offset: int,
+                 local_num_experts: int,
                  routed_scaling_factor: Optional[float],
-                 routing_method_type: int, act_type: int):
+                 routing_method_type: int,
+                 act_type: int,
+                 tune_max_num_tokens: int = 8192,
+                 use_dp: bool = False):
 
         self.num_experts = num_experts
         self.top_k = top_k
@@ -1338,7 +1514,9 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
         self.act_type = act_type
 
         self.tuning_config = E4m3MxE2m1BlockScaleMoERunner.get_tuning_config(
-            self.num_experts // self.local_num_experts)
+            self.num_experts // self.local_num_experts,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_dp=use_dp)
 
     # The unique_id is used by the autotuner to get the cache key, so we hash on members
     # that influence tactic validity here. e.g. we are tuning FC1 and FC2 so the routing
@@ -1409,16 +1587,27 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
         return tactics
 
     @classmethod
-    def get_dynamic_tensor_specs(cls,
-                                 ep_size: int) -> Tuple[DynamicTensorSpec, ...]:
+    def get_dynamic_tensor_specs(
+            cls,
+            ep_size: int,
+            tune_max_num_tokens: int = 8192,
+            use_dp: bool = False) -> Tuple[DynamicTensorSpec, ...]:
         HIDDEN_STATES_IDX = 2
         TUNED_DIM = 0
         MAX_PROFILE_BUCKET = 8192
 
         m_values = get_last_power_of_2_num_tokens_buckets(MAX_PROFILE_BUCKET)
+        if tune_max_num_tokens > MAX_PROFILE_BUCKET:
+            m_values = tuple(m_values) + (tune_max_num_tokens, )
 
         def round_rule(x: int) -> int:
-            value = last_positive_power_of_2(x) // ep_size
+            # See the module-level distribution comment for the use_dp
+            # / ep_size deflation and tune_max_num_tokens fall-through.
+            deflated = x // ep_size if use_dp else x
+            if (deflated > MAX_PROFILE_BUCKET
+                    and tune_max_num_tokens > MAX_PROFILE_BUCKET):
+                return tune_max_num_tokens
+            value = last_positive_power_of_2(deflated)
             return min(max(1, value), MAX_PROFILE_BUCKET)
 
         specs = (DynamicTensorSpec(HIDDEN_STATES_IDX,
@@ -1458,13 +1647,19 @@ class E4m3MxE2m1BlockScaleMoERunner(TunableRunner):
 
     @classmethod
     @lru_cache(maxsize=None)
-    def get_tuning_config(cls, ep_size: int) -> TuningConfig:
+    def get_tuning_config(cls,
+                          ep_size: int,
+                          tune_max_num_tokens: int = 8192,
+                          use_dp: bool = False) -> TuningConfig:
 
-        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(ep_size)
+        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(
+            ep_size, tune_max_num_tokens, use_dp)
         constraint_specs = cls.get_constraint_specs()
 
         tuning_config = TuningConfig(dynamic_tensor_specs=dynamic_tensor_specs,
-                                     constraint_specs=constraint_specs)
+                                     constraint_specs=constraint_specs,
+                                     tune_max_num_tokens=max(
+                                         8192, tune_max_num_tokens))
 
         return tuning_config
 
@@ -1501,7 +1696,9 @@ def e4m3_mxe2m1_block_scale_moe_runner(
         act_type: int,
         topk_weights: Optional[torch.Tensor] = None,
         topk_ids: Optional[torch.Tensor] = None,
-        output: Optional[torch.Tensor] = None) -> torch.Tensor:
+        output: Optional[torch.Tensor] = None,
+        tune_max_num_tokens: int = 8192,
+        use_dp: bool = False) -> torch.Tensor:
 
     tuner = AutoTuner.get()
     kernel_runner = E4m3MxE2m1BlockScaleMoERunner(
@@ -1517,6 +1714,8 @@ def e4m3_mxe2m1_block_scale_moe_runner(
         routed_scaling_factor,
         routing_method_type,
         act_type,
+        tune_max_num_tokens=tune_max_num_tokens,
+        use_dp=use_dp,
     )
 
     # Prepare dummy topk tensors and hook for AutoTuner profiling
@@ -1535,6 +1734,8 @@ def e4m3_mxe2m1_block_scale_moe_runner(
             topk_group=topk_group,
             routed_scaling_factor=routed_scaling_factor,
             hidden_states_index=2,
+            local_expert_offset=local_expert_offset,
+            use_dp=use_dp,
         )
 
     input_tensors_for_tuner = [
@@ -1606,12 +1807,21 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
     runner_dict = dict()
     tuning_config = None
 
-    def __init__(self, num_experts: int, top_k: int, n_group: Optional[int],
-                 topk_group: Optional[int], intermediate_size: int,
-                 valid_hidden_size: int, valid_intermediate_size: int,
-                 local_expert_offset: int, local_num_experts: int,
+    def __init__(self,
+                 num_experts: int,
+                 top_k: int,
+                 n_group: Optional[int],
+                 topk_group: Optional[int],
+                 intermediate_size: int,
+                 valid_hidden_size: int,
+                 valid_intermediate_size: int,
+                 local_expert_offset: int,
+                 local_num_experts: int,
                  routed_scaling_factor: Optional[float],
-                 routing_method_type: int, act_type: int):
+                 routing_method_type: int,
+                 act_type: int,
+                 tune_max_num_tokens: int = 8192,
+                 use_dp: bool = False):
 
         self.num_experts = num_experts
         self.top_k = top_k
@@ -1627,7 +1837,9 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
         self.act_type = act_type
 
         self.tuning_config = Bf16MxE2m1BlockScaleMoERunner.get_tuning_config(
-            self.num_experts // self.local_num_experts)
+            self.num_experts // self.local_num_experts,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_dp=use_dp)
 
     # The unique_id is used by the autotuner to get the cache key, so we hash on members
     # that influence tactic validity here. e.g. we are tuning FC1 and FC2 so the routing
@@ -1698,16 +1910,27 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
         return tactics
 
     @classmethod
-    def get_dynamic_tensor_specs(cls,
-                                 ep_size: int) -> Tuple[DynamicTensorSpec, ...]:
+    def get_dynamic_tensor_specs(
+            cls,
+            ep_size: int,
+            tune_max_num_tokens: int = 8192,
+            use_dp: bool = False) -> Tuple[DynamicTensorSpec, ...]:
         HIDDEN_STATES_IDX = 2
         TUNED_DIM = 0
         MAX_PROFILE_BUCKET = 8192
 
         m_values = get_last_power_of_2_num_tokens_buckets(MAX_PROFILE_BUCKET)
+        if tune_max_num_tokens > MAX_PROFILE_BUCKET:
+            m_values = tuple(m_values) + (tune_max_num_tokens, )
 
         def round_rule(x: int) -> int:
-            value = last_positive_power_of_2(x) // ep_size
+            # See the module-level distribution comment for the use_dp
+            # / ep_size deflation and tune_max_num_tokens fall-through.
+            deflated = x // ep_size if use_dp else x
+            if (deflated > MAX_PROFILE_BUCKET
+                    and tune_max_num_tokens > MAX_PROFILE_BUCKET):
+                return tune_max_num_tokens
+            value = last_positive_power_of_2(deflated)
             return min(max(1, value), MAX_PROFILE_BUCKET)
 
         specs = (DynamicTensorSpec(HIDDEN_STATES_IDX,
@@ -1747,13 +1970,19 @@ class Bf16MxE2m1BlockScaleMoERunner(TunableRunner):
 
     @classmethod
     @lru_cache(maxsize=None)
-    def get_tuning_config(cls, ep_size: int) -> TuningConfig:
+    def get_tuning_config(cls,
+                          ep_size: int,
+                          tune_max_num_tokens: int = 8192,
+                          use_dp: bool = False) -> TuningConfig:
 
-        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(ep_size)
+        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(
+            ep_size, tune_max_num_tokens, use_dp)
         constraint_specs = cls.get_constraint_specs()
 
         tuning_config = TuningConfig(dynamic_tensor_specs=dynamic_tensor_specs,
-                                     constraint_specs=constraint_specs)
+                                     constraint_specs=constraint_specs,
+                                     tune_max_num_tokens=max(
+                                         8192, tune_max_num_tokens))
 
         return tuning_config
 
@@ -1787,7 +2016,9 @@ def bf16_mxe2m1_block_scale_moe_runner(
         act_type: int,
         topk_weights: Optional[torch.Tensor] = None,
         topk_ids: Optional[torch.Tensor] = None,
-        output: Optional[torch.Tensor] = None) -> torch.Tensor:
+        output: Optional[torch.Tensor] = None,
+        tune_max_num_tokens: int = 8192,
+        use_dp: bool = False) -> torch.Tensor:
 
     tuner = AutoTuner.get()
     kernel_runner = Bf16MxE2m1BlockScaleMoERunner(
@@ -1803,6 +2034,8 @@ def bf16_mxe2m1_block_scale_moe_runner(
         routed_scaling_factor,
         routing_method_type,
         act_type,
+        tune_max_num_tokens=tune_max_num_tokens,
+        use_dp=use_dp,
     )
 
     # Prepare dummy topk tensors and hook for AutoTuner profiling
@@ -1821,6 +2054,8 @@ def bf16_mxe2m1_block_scale_moe_runner(
             topk_group=topk_group,
             routed_scaling_factor=routed_scaling_factor,
             hidden_states_index=2,
+            local_expert_offset=local_expert_offset,
+            use_dp=use_dp,
         )
 
     input_tensors_for_tuner = [
@@ -1889,11 +2124,20 @@ class FP8FP4BlockScaleMoERunner(TunableRunner):
     runner_dict = dict()
     tuning_config = None
 
-    def __init__(self, num_experts: int, top_k: int, n_group: Optional[int],
-                 topk_group: Optional[int], intermediate_size: int,
-                 local_expert_offset: int, local_num_experts: int,
+    def __init__(self,
+                 num_experts: int,
+                 top_k: int,
+                 n_group: Optional[int],
+                 topk_group: Optional[int],
+                 intermediate_size: int,
+                 local_expert_offset: int,
+                 local_num_experts: int,
                  routed_scaling_factor: Optional[float],
-                 routing_method_type: int, do_finalize: bool, act_type: int):
+                 routing_method_type: int,
+                 do_finalize: bool,
+                 act_type: int,
+                 tune_max_num_tokens: int = 8192,
+                 use_dp: bool = False):
 
         self.num_experts = num_experts
         self.top_k = top_k
@@ -1908,7 +2152,9 @@ class FP8FP4BlockScaleMoERunner(TunableRunner):
         self.act_type = act_type
 
         self.tuning_config = FP8FP4BlockScaleMoERunner.get_tuning_config(
-            self.num_experts // self.local_num_experts)
+            self.num_experts // self.local_num_experts,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_dp=use_dp)
 
     def unique_id(self):
         return (
@@ -1971,16 +2217,27 @@ class FP8FP4BlockScaleMoERunner(TunableRunner):
         return tactics
 
     @classmethod
-    def get_dynamic_tensor_specs(cls,
-                                 ep_size: int) -> Tuple[DynamicTensorSpec, ...]:
+    def get_dynamic_tensor_specs(
+            cls,
+            ep_size: int,
+            tune_max_num_tokens: int = 8192,
+            use_dp: bool = False) -> Tuple[DynamicTensorSpec, ...]:
         HIDDEN_STATES_IDX = 2
         TUNED_DIM = 0
         MAX_PROFILE_BUCKET = 8192
 
         m_values = get_last_power_of_2_num_tokens_buckets(MAX_PROFILE_BUCKET)
+        if tune_max_num_tokens > MAX_PROFILE_BUCKET:
+            m_values = tuple(m_values) + (tune_max_num_tokens, )
 
         def round_rule(x: int) -> int:
-            value = last_positive_power_of_2(x) // ep_size
+            # See the module-level distribution comment for the use_dp
+            # / ep_size deflation and tune_max_num_tokens fall-through.
+            deflated = x // ep_size if use_dp else x
+            if (deflated > MAX_PROFILE_BUCKET
+                    and tune_max_num_tokens > MAX_PROFILE_BUCKET):
+                return tune_max_num_tokens
+            value = last_positive_power_of_2(deflated)
             return min(max(1, value), MAX_PROFILE_BUCKET)
 
         specs = (DynamicTensorSpec(HIDDEN_STATES_IDX,
@@ -2022,44 +2279,51 @@ class FP8FP4BlockScaleMoERunner(TunableRunner):
 
     @classmethod
     @lru_cache(maxsize=None)
-    def get_tuning_config(cls, ep_size: int) -> TuningConfig:
+    def get_tuning_config(cls,
+                          ep_size: int,
+                          tune_max_num_tokens: int = 8192,
+                          use_dp: bool = False) -> TuningConfig:
 
-        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(ep_size)
+        dynamic_tensor_specs = cls.get_dynamic_tensor_specs(
+            ep_size, tune_max_num_tokens, use_dp)
         constraint_specs = cls.get_constraint_specs()
 
         tuning_config = TuningConfig(dynamic_tensor_specs=dynamic_tensor_specs,
-                                     constraint_specs=constraint_specs)
+                                     constraint_specs=constraint_specs,
+                                     tune_max_num_tokens=max(
+                                         8192, tune_max_num_tokens))
 
         return tuning_config
 
 
 @torch.library.custom_op("trtllm::fp8_fp4_block_scale_moe_runner",
                          mutates_args=())
-def fp8_fp4_block_scale_moe_runner(
-        routing_logits: Optional[torch.Tensor],
-        routing_bias: Optional[torch.Tensor],
-        hidden_states: torch.Tensor,
-        gemm1_weights: torch.Tensor,
-        gemm1_weights_scale: torch.Tensor,
-        gemm2_weights: torch.Tensor,
-        gemm2_weights_scale: torch.Tensor,
-        output1_scale_scalar: torch.Tensor,
-        output1_scale_gate_scalar: torch.Tensor,
-        output2_scale_scalar: torch.Tensor,
-        num_experts: int,
-        top_k: int,
-        n_group: Optional[int],
-        topk_group: Optional[int],
-        intermediate_size: int,
-        local_expert_offset: int,
-        local_num_experts: int,
-        routed_scaling_factor: Optional[float],
-        routing_method_type: int,
-        do_finalize: bool,
-        act_type: int,
-        topk_weights: Optional[torch.Tensor] = None,
-        topk_ids: Optional[torch.Tensor] = None,
-        output: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
+def fp8_fp4_block_scale_moe_runner(routing_logits: Optional[torch.Tensor],
+                                   routing_bias: Optional[torch.Tensor],
+                                   hidden_states: torch.Tensor,
+                                   gemm1_weights: torch.Tensor,
+                                   gemm1_weights_scale: torch.Tensor,
+                                   gemm2_weights: torch.Tensor,
+                                   gemm2_weights_scale: torch.Tensor,
+                                   output1_scale_scalar: torch.Tensor,
+                                   output1_scale_gate_scalar: torch.Tensor,
+                                   output2_scale_scalar: torch.Tensor,
+                                   num_experts: int,
+                                   top_k: int,
+                                   n_group: Optional[int],
+                                   topk_group: Optional[int],
+                                   intermediate_size: int,
+                                   local_expert_offset: int,
+                                   local_num_experts: int,
+                                   routed_scaling_factor: Optional[float],
+                                   routing_method_type: int,
+                                   do_finalize: bool,
+                                   act_type: int,
+                                   topk_weights: Optional[torch.Tensor] = None,
+                                   topk_ids: Optional[torch.Tensor] = None,
+                                   output: Optional[torch.Tensor] = None,
+                                   tune_max_num_tokens: int = 8192,
+                                   use_dp: bool = False) -> List[torch.Tensor]:
 
     tuner = AutoTuner.get()
     kernel_runner = FP8FP4BlockScaleMoERunner(
@@ -2074,6 +2338,8 @@ def fp8_fp4_block_scale_moe_runner(
         routing_method_type,
         do_finalize,
         act_type,
+        tune_max_num_tokens=tune_max_num_tokens,
+        use_dp=use_dp,
     )
 
     # Prepare dummy topk tensors and hook for AutoTuner profiling
@@ -2092,6 +2358,8 @@ def fp8_fp4_block_scale_moe_runner(
             topk_group=topk_group,
             routed_scaling_factor=routed_scaling_factor,
             hidden_states_index=2,
+            local_expert_offset=local_expert_offset,
+            use_dp=use_dp,
         )
 
     input_tensors_for_tuner = [
@@ -2159,7 +2427,9 @@ def _(routing_logits,
       act_type,
       topk_weights: Optional[torch.Tensor] = None,
       topk_ids: Optional[torch.Tensor] = None,
-      output: Optional[torch.Tensor] = None) -> List[torch.Tensor]:
+      output: Optional[torch.Tensor] = None,
+      tune_max_num_tokens: int = 8192,
+      use_dp: bool = False) -> List[torch.Tensor]:
 
     num_tokens = hidden_states.shape[0]
     hidden_size = hidden_states.shape[1]

--- a/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py
@@ -218,8 +218,9 @@ def prepare_dummy_topk_and_hook(
         if routing_method_type == RoutingMethodType.MiniMax2:
             routing_cls_kwargs.update({
                 'callable_e_score_correction_bias':
-                lambda: torch.randn(
-                    num_experts, dtype=torch.bfloat16, device=hidden_states.device),
+                lambda: torch.randn(num_experts,
+                                    dtype=torch.bfloat16,
+                                    device=hidden_states.device),
                 'num_experts':
                 num_experts,
             })

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -213,6 +213,10 @@ class TRTLLMGenFusedMoE(MoE):
             activation_type=activation_type,
         )
 
+        # Cached for autotune profile sizing (forward path passes
+        # tune_max_num_tokens to the MoE op).
+        self.max_num_tokens = model_config.max_num_tokens
+
         sm_version = get_sm_version()
         if sm_version >= 120:
             raise NotImplementedError(
@@ -646,6 +650,8 @@ class TRTLLMGenFusedMoE(MoE):
                 topk_weights=token_final_scales,
                 topk_ids=token_selected_experts,
                 output=moe_output,
+                tune_max_num_tokens=self.max_num_tokens,
+                use_dp=self.use_dp,
             )
             # When output is provided, use it directly as the result
             final_hidden_states = moe_output if moe_output is not None else result
@@ -696,6 +702,9 @@ class TRTLLMGenFusedMoE(MoE):
                     None),
                 gated_act_type=act_type,
                 output=moe_output,
+                # Pass that to the autotuner so the top bucket profiles per-expert load at runtime scale.
+                tune_max_num_tokens=self.max_num_tokens,
+                use_dp=self.use_dp,
             )
 
             if not do_finalize:

--- a/tensorrt_llm/_torch/modules/fused_moe/moe_op_backend.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_op_backend.py
@@ -120,6 +120,7 @@ class MoEOpBackend:
         weight_layout: int = 0,
         enable_pdl: Optional[bool] = None,
         tune_max_num_tokens: int = 8192,
+        use_dp: bool = False,
     ) -> torch.Tensor:
         """Run FP8 block scale MoE computation."""
         raise NotImplementedError
@@ -160,6 +161,7 @@ class MoEOpBackend:
         gated_act_type: int = 0,
         output: Optional[torch.Tensor] = None,
         tune_max_num_tokens: int = 8192,
+        use_dp: bool = False,
     ) -> List[torch.Tensor]:
         """Run FP4 block scale MoE computation."""
         raise NotImplementedError
@@ -230,6 +232,7 @@ class TRTLLMOpBackend(MoEOpBackend):
         weight_layout=0,
         enable_pdl=None,
         tune_max_num_tokens=8192,
+        use_dp=False,
     ):
         return torch.ops.trtllm.fp8_block_scale_moe_runner(
             router_logits,
@@ -253,6 +256,8 @@ class TRTLLMOpBackend(MoEOpBackend):
             topk_ids=topk_ids,
             act_type=gated_act_type,
             output=output,
+            tune_max_num_tokens=tune_max_num_tokens,
+            use_dp=use_dp,
         )
 
     def run_fp4_block_scale_moe(
@@ -291,6 +296,7 @@ class TRTLLMOpBackend(MoEOpBackend):
         gated_act_type=0,
         output=None,
         tune_max_num_tokens=8192,
+        use_dp=False,
     ):
         hidden_size = gemm1_weights.shape[-1] * 2
         if hidden_states.dtype == torch.uint8 or hidden_states.dtype == torch.float8_e4m3fn:
@@ -332,6 +338,8 @@ class TRTLLMOpBackend(MoEOpBackend):
                     topk_weights=topk_weights,
                     topk_ids=topk_ids,
                     output=output,
+                    tune_max_num_tokens=tune_max_num_tokens,
+                    use_dp=use_dp,
                 )
                 if not do_finalize:
                     return outputs
@@ -372,6 +380,8 @@ class TRTLLMOpBackend(MoEOpBackend):
                     topk_weights,
                     topk_ids,
                     output=output,
+                    tune_max_num_tokens=tune_max_num_tokens,
+                    use_dp=use_dp,
                 )
 
         elif hidden_states.dtype == torch.bfloat16:
@@ -403,6 +413,8 @@ class TRTLLMOpBackend(MoEOpBackend):
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
                 output=output,
+                tune_max_num_tokens=tune_max_num_tokens,
+                use_dp=use_dp,
             )
 
 
@@ -519,6 +531,7 @@ class FlashinferOpBackend(MoEOpBackend):
         weight_layout=0,
         enable_pdl=None,
         tune_max_num_tokens=8192,
+        use_dp=False,
     ):
         if router_logits is not None:
             return self._fused_moe.trtllm_fp8_block_scale_moe(
@@ -608,6 +621,7 @@ class FlashinferOpBackend(MoEOpBackend):
         gated_act_type=0,
         output=None,
         tune_max_num_tokens=8192,
+        use_dp=False,
     ):
         if router_logits is not None:
             outputs = self._fused_moe.trtllm_fp4_block_scale_moe(

--- a/tests/unittest/_torch/modules/moe/test_moe_module.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_module.py
@@ -48,6 +48,7 @@ from _torch.modules.moe.moe_test_utils import (
     get_quick_skip_reason,
     iter_base_test_configs,
     replay_tactics_and_check,
+    resolve_deepseek_group_config,
     should_skip_cutedsl,
     should_skip_cutlass,
     should_skip_deepgemm,
@@ -319,7 +320,7 @@ def _run_eplb_test(
     )
 
 
-def _create_routing_method(routing_method_cls, top_k, num_experts, dtype):
+def _create_routing_method(routing_method_cls, top_k, num_experts, dtype, model_config=None):
     """
     Create a routing method instance with appropriate parameters for each routing method type.
 
@@ -328,6 +329,7 @@ def _create_routing_method(routing_method_cls, top_k, num_experts, dtype):
         top_k: Number of experts to select per token
         num_experts: Total number of experts
         dtype: Data type for tensors
+        model_config: Optional model config with routing-specific parameters
 
     Returns:
         An instance of the routing method
@@ -342,13 +344,9 @@ def _create_routing_method(routing_method_cls, top_k, num_experts, dtype):
 
     # DeepSeekV3 routing method requires special parameters
     if routing_method_cls == DeepSeekV3MoeRoutingMethod:
-        # DeepSeek-V3 routing: groups experts, selects top groups, then selects top_k from those
-        # The routing logic does topk(k=2) within each group, so each group must have >= 2 experts
-        # Calculate n_group such that each group has at least 2 experts
-        experts_per_group = 2
-        n_group = max(1, num_experts // experts_per_group)
-        # topk_group should be <= n_group and reasonable for the selection
-        topk_group = min(n_group, max(1, n_group // 2))
+        if model_config is None:
+            model_config = MoeModelConfig(num_experts, top_k, hidden_size=0, intermediate_size=0)
+        n_group, topk_group = resolve_deepseek_group_config(model_config)
         routed_scaling_factor = 1.0
         # Create e_score_correction_bias as a zero tensor (no bias correction in test)
         e_score_correction_bias = torch.zeros(num_experts, dtype=dtype, device="cuda")
@@ -487,7 +485,11 @@ def _test_moe_worker_impl(
         # Create routing method and input tensors
         effective_bias_dtype = bias_dtype if bias_dtype is not None else dtype
         routing_method = _create_routing_method(
-            routing_method_cls, top_k=top_k, num_experts=num_experts, dtype=effective_bias_dtype
+            routing_method_cls,
+            top_k=top_k,
+            num_experts=num_experts,
+            dtype=effective_bias_dtype,
+            model_config=model_config,
         )
         x = torch.randn((seq_len, hidden_size), dtype=dtype, device="cuda")
         if enable_eplb:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added configurable MoE autotuning through environment variable support, enabling selection between balanced or random dummy expert distributions
* Enabled data parallelism mode support for Mixture of Experts operations with automatic tensor specification bucketing adjustments
* Introduced maximum token configuration capability for enhanced MoE autotuning control and optimization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This PR improves the TRTLLM MoE perf in DEP case. With DP (Attention DP + MoE EP), there are `ep_size * runtime_max_tokens_per_rank` total tokens in the system. In an ideal world, each rank gets `runtime_max_tokens_per_rank`. Therefore, during autotune, we must ensure all `runtime_max_tokens_per_rank` tokens after topk expansion are local to each rank so we profile with the right workload amount. We do that by generate expert distribution in range `[0, num_local_experts]` and offset that by `ep_rank * num_local_experts`.

Without DP, the system processes `max_num_tokens` amount of tokens across all EP ranks. Each rank would get `max_num_tokens / ep_size` amount of tokens in an ideal world. To simulate the reduced amount of workload, each rank simply generates the expert distribution across all experts, and let MoE op itself filter out non-local part of the distribution. 

TPS/gpu of Qwen3-235B-A22B NVFP4 DEP2 1k/2k

| bsz  | baseline | new(this PR + #12440) | Δ |
|----:|------:|------:|------:|
|    8 |  340.9 |  347.5 |  +1.94% |
|   32 | 1186.1 | 1186.2 |  +0.01% |
|   64 | 2017.8 | 2069.1 |  +2.54% |
|  128 | 3335.6 | 3404.6 |  +2.07% |
|  256 | 5335.9 | 5361.7 |  +0.48% |
|  512 | 7157.5 | 8151.9 | **+13.89%** |
| 1024 | 3724.8 | 3655.2 |  −1.87% |
| 2048 | 3869.3 | 3615.9 |  −6.55% |

TPS/gpu of DS-R1 NVFP4 DEP8 1k/2k

| bsz  | baseline | new (this PR + #12440) | Δ |
|----:|------:|------:|------:|
|    8 |   74.93 |   77.85 |  +3.90% |
|   64 |  504.81 |  505.61 |  +0.16% |
|  128 |  905.26 |  907.41 |  +0.24% |
|  512 | 2700.5 | 2661.4 |  −1.45% |
| 1024 | 3450.0 | 4213.5 | **+22.13%** |
| 2048 | 5244.4 | 5725.4 |  **+9.17%** |
| 4096 | 3375.3 | 3429.1 |  +1.59% |

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

```
python -m pytest -s -v tests/unittest/_torch/modules/moe/test_moe_backend.py -k TRTLLM
```
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
