### PR TITLE
[None][fix] Update FlashInfer MoE routing import

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/moe_op_backend.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_op_backend.py
@@ -477,8 +477,8 @@ class FlashinferOpBackend(MoEOpBackend):
         import flashinfer.fused_moe as _flashinfer_fused_moe
         from flashinfer.fp4_quantization import fp4_quantize as _flashinfer_fp4_quantize
         from flashinfer.fp8_quantization import mxfp8_quantize as _flashinfer_mxfp8_quantize
+        from flashinfer.fused_moe import RoutingMethodType as _flashinfer_routing_method_type
         from flashinfer.fused_moe.core import ActivationType as _flashinfer_activation_type
-        from flashinfer.fused_moe.core import RoutingMethodType as _flashinfer_routing_method_type
 
         from ..fused_moe.routing import RoutingMethodType as _trtllmgen_routing_method_type
 


### PR DESCRIPTION
## Summary
- Update FlashInfer MoE RoutingMethodType import for flashinfer-python 0.6.9.
- Addresses the B200/B300 TRTLLM BF16 MoE CI issue where tests fail with ImportError: cannot import name RoutingMethodType from flashinfer.fused_moe.core.
- Context: observed in Jenkins L0_MergeRequest_PR/36504 subjob L0_Test-x86_64-Single-GPU #1653 and the Slack-linked L0_Test-x86_64-Single-GPU #1554 after the FlashInfer 0.6.9 dependency bump.

## Test Plan
- PYTHONPYCACHEPREFIX=/tmp/trtllm_pycache python3 -m py_compile tensorrt_llm/_torch/modules/fused_moe/moe_op_backend.py
- git diff --check

Note: GPU CI reproduction requires the internal flashinfer-python 0.6.9 wheel and B200/B300 CI environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency imports for improved module organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->