### PR TITLE
[https://nvbugs/6082303][fix] Treat <tool_call> as implicit end-of-reasoning in nano-v3 parser

### DIFF
--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -296,6 +311,7 @@ class NemotronV3ReasoningParser(DeepSeekR1Parser):
                 "force_nonempty_content", False) is True
         super().__init__(reasoning_at_start=reasoning_at_start,
                          chat_template_kwargs=chat_template_kwargs)
+        self._tool_call_start = "<tool_call>"
         # Workaround: the model sometimes does not send closing think tags
         # which affects downstream applications. This is addressed by
         # optionally accumulating reasoning tokens and returning them as
@@ -318,10 +334,30 @@ class NemotronV3ReasoningParser(DeepSeekR1Parser):
         return result
 
     def parse_delta(self, delta_text: str) -> ReasoningParserResult:
-        """Wraps the parent parse_delta to track accumulated reasoning when
-        force_nonempty_content is set. When the closing tag is found
-        (in_reasoning transitions from True to False), the accumulation
-        is cleared to free memory."""
+        """Wraps the parent parse_delta to also treat `<tool_call>` as an
+        implicit end-of-reasoning marker.  When the model omits `</think>`
+        before generating a tool call, the tag would otherwise be absorbed
+        into reasoning_content and the downstream tool parser would never
+        see it (NVBug 6082303).
+
+        `<tool_call>` is a special token that always arrives as a single
+        atomic delta, so we only need to check `delta_text` (not the
+        parent's internal buffer)."""
+        if (self.in_reasoning and self._tool_call_start in delta_text
+                and self.reasoning_end not in self._buffer):
+            remaining = self._buffer
+            self._buffer = ""
+            self.in_reasoning = False
+            # Guaranteed non-negative: guarded by `in delta_text` above.
+            tool_idx = delta_text.find(self._tool_call_start)
+            reasoning = remaining + delta_text[:tool_idx]
+            content = delta_text[tool_idx:]
+            if self._force_nonempty_content:
+                self._found_closing_tag = True
+                self._accumulated_reasoning = ""
+            return ReasoningParserResult(content=content,
+                                         reasoning_content=reasoning)
+
         was_in_reasoning = self.in_reasoning
         result = super().parse_delta(delta_text)
         if self._force_nonempty_content:
@@ -363,7 +399,14 @@ class NemotronV3ReasoningParser(DeepSeekR1Parser):
         return ReasoningParserResult()
 
     def parse(self, text: str) -> ReasoningParserResult:
-        return self._maybe_swap_content(super().parse(text))
+        result = super().parse(text)
+        tc = (result.reasoning_content.find(self._tool_call_start)
+              if result.reasoning_content else -1)
+        if tc != -1:
+            result = ReasoningParserResult(
+                content=result.reasoning_content[tc:] + result.content,
+                reasoning_content=result.reasoning_content[:tc])
+        return self._maybe_swap_content(result)
 
 
 @register_reasoning_parser("gemma4")

--- a/tests/unittest/llmapi/test_reasoning_parser.py
+++ b/tests/unittest/llmapi/test_reasoning_parser.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import os
 
@@ -233,6 +248,10 @@ def test_qwen3_reasoning_parser_stream(delta_texts: list, content: list,
         assert result.reasoning_content == reasoning_context[i]
 
 
+TOOL_CALL = "<tool_call>"
+TOOL_CALL_END = "</tool_call>"
+
+
 @pytest.mark.parametrize(
     ("text", "content", "reasoning_context", "chat_template_kwargs"),
     [
@@ -273,6 +292,30 @@ def test_qwen3_reasoning_parser_stream(delta_texts: list, content: list,
         (f"a {R1_END} \t ", "a ", "", {
             "force_nonempty_content": True
         }),
+        # NVBug 6082303: <tool_call> as implicit end-of-reasoning.
+        # No </think> before <tool_call> — tool call must appear in content.
+        (f"I need weather{TOOL_CALL}get_weather{TOOL_CALL_END}",
+         f"{TOOL_CALL}get_weather{TOOL_CALL_END}", "I need weather", None),
+        # </think> before <tool_call> — standard end wins.
+        (f"reasoning{R1_END}{TOOL_CALL}get_weather{TOOL_CALL_END}",
+         f"{TOOL_CALL}get_weather{TOOL_CALL_END}", "reasoning", None),
+        # <tool_call> with enable_thinking=False — all goes to content.
+        (f"content{TOOL_CALL}get_weather{TOOL_CALL_END}",
+         f"content{TOOL_CALL}get_weather{TOOL_CALL_END}", "", {
+             "enable_thinking": False
+         }),
+        # <tool_call> with force_nonempty_content — content is non-empty, no swap.
+        (f"reasoning{TOOL_CALL}get_weather{TOOL_CALL_END}",
+         f"{TOOL_CALL}get_weather{TOOL_CALL_END}", "reasoning", {
+             "force_nonempty_content": True
+         }),
+        # <think> then <tool_call> without </think> with enable_thinking=False:
+        # reasoning_at_start is False so parse() looks for <think> tag,
+        # strips it, then tool_call acts as implicit end-of-reasoning.
+        (f"{R1_START}reasoning{TOOL_CALL}get_weather{TOOL_CALL_END}",
+         f"{TOOL_CALL}get_weather{TOOL_CALL_END}", "reasoning", {
+             "enable_thinking": False
+         }),
     ])
 def test_nano_v3_reasoning_parser(text: str, content: str,
                                   reasoning_context: str,
@@ -317,6 +360,75 @@ def test_nano_v3_reasoning_parser(text: str, content: str,
         (["a", f"{R1_END}r", "b"], ["a", f"{R1_END}r", "b"], ["", "", ""], {
             "enable_thinking": False
         }),
+        # NVBug 6082303: <tool_call> as implicit end-of-reasoning in streaming.
+        # Single-token <tool_call> after reasoning deltas.
+        (
+            ["I need ", "weather", TOOL_CALL, "get_weather"],
+            ["", "", f"{TOOL_CALL}", "get_weather"],
+            ["I need ", "weather", "", ""],
+            None,
+        ),
+        # <tool_call> combined with preceding reasoning text in one delta.
+        (
+            ["reasoning" + TOOL_CALL + "tool_data"],
+            [TOOL_CALL + "tool_data"],
+            ["reasoning"],
+            None,
+        ),
+        # </think> before <tool_call> — standard handling.
+        (
+            ["reasoning", R1_END, TOOL_CALL + "data"],
+            ["", "", TOOL_CALL + "data"],
+            ["reasoning", "", ""],
+            None,
+        ),
+        # Token-level chunks mimicking the bug scenario from NVBug 6082303.
+        (
+            [
+                "I", " need to check", " the weather in", " New York City",
+                TOOL_CALL, "<function=get_weather>", "<parameter=location>NYC",
+                "</parameter>", "</function>", TOOL_CALL_END
+            ],
+            [
+                "", "", "", "", TOOL_CALL, "<function=get_weather>",
+                "<parameter=location>NYC", "</parameter>", "</function>",
+                TOOL_CALL_END
+            ],
+            [
+                "I", " need to check", " the weather in", " New York City", "",
+                "", "", "", "", ""
+            ],
+            None,
+        ),
+        # Parent buffers trailing "<" (prefix of "</think>") from a text
+        # token, then the full <tool_call> special token arrives atomically.
+        (
+            ["reasoning<", "<tool_call>data"],
+            ["", "<tool_call>data"],
+            ["reasoning", "<"],
+            None,
+        ),
+        # force_nonempty_content + streaming tool call: tool_call ends
+        # reasoning, accumulated reasoning is discarded (not swapped into
+        # content), and content carries the tool markup.
+        (
+            ["I need ", "weather", TOOL_CALL, "get_weather"],
+            ["", "", TOOL_CALL, "get_weather"],
+            ["I need ", "weather", "", ""],
+            {
+                "force_nonempty_content": True
+            },
+        ),
+        # enable_thinking=False + streaming tool call: everything is content
+        # (no buffering since <tool_call> is not a prefix of <think>).
+        (
+            ["content", TOOL_CALL, "data"],
+            ["content", TOOL_CALL, "data"],
+            ["", "", ""],
+            {
+                "enable_thinking": False
+            },
+        ),
     ])
 def test_nano_v3_reasoning_parser_stream(delta_texts: list, content: list,
                                          reasoning_context: list,
@@ -330,27 +442,36 @@ def test_nano_v3_reasoning_parser_stream(delta_texts: list, content: list,
         assert result.reasoning_content == reasoning_context[i]
 
 
-@pytest.mark.parametrize(("delta_texts", "finish_content", "finish_reasoning",
-                          "chat_template_kwargs"), [
-                              (["a", "b"], "", "", None),
-                              ([R1_END, "a", "b"], "", "", None),
-                              (["a", R1_END, "b"], "", "", None),
-                              (["a", "b"], "", "", {
-                                  "enable_thinking": False
-                              }),
-                              ([f"{R1_START}a", "b"], "", "", {
-                                  "enable_thinking": False
-                              }),
-                              (["a", "b"], "", "", {
-                                  "force_nonempty_content": False
-                              }),
-                              (["a", "b"], "ab", "", {
-                                  "force_nonempty_content": True
-                              }),
-                              ([R1_END, "a", "b"], "", "", {
-                                  "force_nonempty_content": True
-                              }),
-                          ])
+@pytest.mark.parametrize(
+    ("delta_texts", "finish_content", "finish_reasoning",
+     "chat_template_kwargs"),
+    [
+        (["a", "b"], "", "", None),
+        ([R1_END, "a", "b"], "", "", None),
+        (["a", R1_END, "b"], "", "", None),
+        (["a", "b"], "", "", {
+            "enable_thinking": False
+        }),
+        ([f"{R1_START}a", "b"], "", "", {
+            "enable_thinking": False
+        }),
+        (["a", "b"], "", "", {
+            "force_nonempty_content": False
+        }),
+        (["a", "b"], "ab", "", {
+            "force_nonempty_content": True
+        }),
+        ([R1_END, "a", "b"], "", "", {
+            "force_nonempty_content": True
+        }),
+        # NVBug 6082303: <tool_call> ends reasoning,
+        # finish should return empty (tag acted as
+        # implicit closing).
+        (["reasoning", "<tool_call>data"], "", "", None),
+        (["reasoning", "<tool_call>data"], "", "", {
+            "force_nonempty_content": True
+        }),
+    ])
 def test_nano_v3_reasoning_parser_finish(delta_texts: list, finish_content: str,
                                          finish_reasoning: str,
                                          chat_template_kwargs: dict):


### PR DESCRIPTION
When serving Nemotron-3-Super with --reasoning_parser nano-v3, the model occasionally omits </think> before generating <tool_call>. The parser stayed in reasoning mode and absorbed the tool call markup into reasoning_content, causing the downstream tool parser to never see it (~2-8% of streaming tool-call requests silently failed).

Treat <tool_call> as an implicit </think> in NemotronV3ReasoningParser, following the same pattern as KimiK2ReasoningParser which treats <|tool_calls_section_begin|> as an implicit reasoning end.


Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reasoning parser now recognizes `<tool_call>` tags as an implicit end-of-reasoning boundary, improving handling of tool invocations within reasoning blocks in both streaming and non-streaming modes.

* **Tests**
  * Extended test coverage to validate tool call tag handling across various scenarios, including streaming and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
