### PR TITLE
[TRTLLM-12432][perf] ltx2: drop redundant pe all-gather in AV cross-attention

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/transformer_args.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/transformer_args.py
@@ -261,8 +261,17 @@ class MultiModalTransformerArgsPreprocessor:
         static_mask: torch.Tensor | None,
         static_pe: tuple[torch.Tensor, torch.Tensor],
         static_cross_pe: tuple[torch.Tensor, torch.Tensor],
+        static_cross_pe_local: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> TransformerArgs:
-        """Build TransformerArgs for one denoise step with pre-computed static outputs."""
+        """Build TransformerArgs for one denoise step with pre-computed static outputs.
+
+        ``static_cross_pe_local`` is the sharded-contiguous variant of
+        ``static_cross_pe`` (matches the local Q shard for Q-side rope).  When
+        ``None`` (single-rank or caller didn't pre-shard) we fall back to
+        ``static_cross_pe`` so behavior is unchanged.  Pre-sharding it once in
+        ``prepare_text_cache`` instead of every step's ``_shard_transformer_args``
+        avoids the per-step slice + downstream non-contiguous reshape copy.
+        """
         transformer_args = self.simple_preprocessor.prepare(
             modality,
             static_context=static_context,
@@ -275,9 +284,11 @@ class MultiModalTransformerArgsPreprocessor:
             batch_size=transformer_args.x.shape[0],
             hidden_dtype=modality.latent.dtype,
         )
+        if static_cross_pe_local is None:
+            static_cross_pe_local = static_cross_pe
         return replace(
             transformer_args,
-            cross_positional_embeddings_local=static_cross_pe,
+            cross_positional_embeddings_local=static_cross_pe_local,
             cross_positional_embeddings_full=static_cross_pe,
             cross_scale_shift_timestep=cross_scale_shift_timestep,
             cross_gate_timestep=cross_gate_timestep,

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/transformer_args.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/transformer_args.py
@@ -28,7 +28,12 @@ class TransformerArgs:
     timesteps: torch.Tensor
     embedded_timestep: torch.Tensor
     positional_embeddings: tuple[torch.Tensor, torch.Tensor]
-    cross_positional_embeddings: tuple[torch.Tensor, torch.Tensor] | None
+    # Cross-modal (AV) RoPE pe carried in two layouts:
+    #   *_local : sharded along seq (matches sharded Q for Q-side rope)
+    #   *_full  : un-sharded (matches all-gathered K for K-side rope)
+    # Equal at construction time; *_local is sliced inside _shard_transformer_args.
+    cross_positional_embeddings_local: tuple[torch.Tensor, torch.Tensor] | None
+    cross_positional_embeddings_full: tuple[torch.Tensor, torch.Tensor] | None
     cross_scale_shift_timestep: torch.Tensor | None
     cross_gate_timestep: torch.Tensor | None
     enabled: bool
@@ -172,7 +177,8 @@ class TransformerArgsPreprocessor:
             timesteps=timestep,
             embedded_timestep=embedded_timestep,
             positional_embeddings=static_pe,
-            cross_positional_embeddings=None,
+            cross_positional_embeddings_local=None,
+            cross_positional_embeddings_full=None,
             cross_scale_shift_timestep=None,
             cross_gate_timestep=None,
             enabled=modality.enabled,
@@ -271,7 +277,8 @@ class MultiModalTransformerArgsPreprocessor:
         )
         return replace(
             transformer_args,
-            cross_positional_embeddings=static_cross_pe,
+            cross_positional_embeddings_local=static_cross_pe,
+            cross_positional_embeddings_full=static_cross_pe,
             cross_scale_shift_timestep=cross_scale_shift_timestep,
             cross_gate_timestep=cross_gate_timestep,
         )

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/transformer_args.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/transformer_args.py
@@ -160,23 +160,32 @@ class TransformerArgsPreprocessor:
         static_mask: torch.Tensor | None,
         static_pe: tuple[torch.Tensor, torch.Tensor],
         static_cross_pe: tuple[torch.Tensor, torch.Tensor] | None = None,
+        static_pe_local: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> TransformerArgs:
         """Build TransformerArgs for one denoise step.
 
         Step-invariant static args are always required.  *static_cross_pe*
         is only used by the MultiModal subclass; ignored here.
+        ``static_pe_local`` is the sharded-contiguous variant of
+        ``static_pe``; when ``None`` (single-rank) we fall back to
+        ``static_pe`` so behavior is unchanged.  Pre-sharding it once in
+        ``prepare_text_cache`` instead of every step in
+        ``_shard_transformer_args`` avoids the per-step slice + downstream
+        non-contiguous reshape copy.
         """
         x = self.patchify_proj(modality.latent.contiguous())
         timestep, embedded_timestep = self._prepare_timestep(
             modality.timesteps, x.shape[0], modality.latent.dtype
         )
+        if static_pe_local is None:
+            static_pe_local = static_pe
         return TransformerArgs(
             x=x,
             context=static_context,
             context_mask=static_mask,
             timesteps=timestep,
             embedded_timestep=embedded_timestep,
-            positional_embeddings=static_pe,
+            positional_embeddings=static_pe_local,
             cross_positional_embeddings_local=None,
             cross_positional_embeddings_full=None,
             cross_scale_shift_timestep=None,
@@ -262,21 +271,24 @@ class MultiModalTransformerArgsPreprocessor:
         static_pe: tuple[torch.Tensor, torch.Tensor],
         static_cross_pe: tuple[torch.Tensor, torch.Tensor],
         static_cross_pe_local: tuple[torch.Tensor, torch.Tensor] | None = None,
+        static_pe_local: tuple[torch.Tensor, torch.Tensor] | None = None,
     ) -> TransformerArgs:
         """Build TransformerArgs for one denoise step with pre-computed static outputs.
 
-        ``static_cross_pe_local`` is the sharded-contiguous variant of
-        ``static_cross_pe`` (matches the local Q shard for Q-side rope).  When
-        ``None`` (single-rank or caller didn't pre-shard) we fall back to
-        ``static_cross_pe`` so behavior is unchanged.  Pre-sharding it once in
-        ``prepare_text_cache`` instead of every step's ``_shard_transformer_args``
-        avoids the per-step slice + downstream non-contiguous reshape copy.
+        ``static_cross_pe_local`` / ``static_pe_local`` are the sharded-contiguous
+        variants of ``static_cross_pe`` / ``static_pe`` (match the local Q shard
+        for Q-side rope).  When ``None`` (single-rank or caller didn't pre-shard)
+        we fall back to the un-sharded version so behavior is unchanged.
+        Pre-sharding once in ``prepare_text_cache`` instead of every step's
+        ``_shard_transformer_args`` avoids the per-step slice + downstream
+        non-contiguous reshape copy.
         """
         transformer_args = self.simple_preprocessor.prepare(
             modality,
             static_context=static_context,
             static_mask=static_mask,
             static_pe=static_pe,
+            static_pe_local=static_pe_local,
         )
         cross_scale_shift_timestep, cross_gate_timestep = self._prepare_cross_attention_timestep(
             timestep=modality.timesteps,

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -289,12 +289,14 @@ class _LTX2CUDAGraphRunner(CUDAGraphRunner):
                 video_context=v.video_context.clone() if v.video_context is not None else None,
                 video_mask=v.video_mask.clone() if v.video_mask is not None else None,
                 video_pe=clone_pair(v.video_pe),
+                video_pe_local=clone_pair(v.video_pe_local),
                 video_cross_pe=clone_pair(v.video_cross_pe),
                 video_cross_pe_local=clone_pair(v.video_cross_pe_local),
                 video_kv=[clone_pair(kv) for kv in v.video_kv] if v.video_kv is not None else None,
                 audio_context=v.audio_context.clone() if v.audio_context is not None else None,
                 audio_mask=v.audio_mask.clone() if v.audio_mask is not None else None,
                 audio_pe=clone_pair(v.audio_pe),
+                audio_pe_local=clone_pair(v.audio_pe_local),
                 audio_cross_pe=clone_pair(v.audio_cross_pe),
                 audio_cross_pe_local=clone_pair(v.audio_cross_pe_local),
                 audio_kv=[clone_pair(kv) for kv in v.audio_kv] if v.audio_kv is not None else None,
@@ -325,6 +327,7 @@ class _LTX2CUDAGraphRunner(CUDAGraphRunner):
             if dst.video_mask is not None and src.video_mask is not None:
                 dst.video_mask.copy_(src.video_mask)
             copy_pair(dst.video_pe, src.video_pe)
+            copy_pair(dst.video_pe_local, src.video_pe_local)
             copy_pair(dst.video_cross_pe, src.video_cross_pe)
             copy_pair(dst.video_cross_pe_local, src.video_cross_pe_local)
             if dst.video_kv is not None and src.video_kv is not None:
@@ -335,6 +338,7 @@ class _LTX2CUDAGraphRunner(CUDAGraphRunner):
             if dst.audio_mask is not None and src.audio_mask is not None:
                 dst.audio_mask.copy_(src.audio_mask)
             copy_pair(dst.audio_pe, src.audio_pe)
+            copy_pair(dst.audio_pe_local, src.audio_pe_local)
             copy_pair(dst.audio_cross_pe, src.audio_cross_pe)
             copy_pair(dst.audio_cross_pe_local, src.audio_cross_pe_local)
             if dst.audio_kv is not None and src.audio_kv is not None:

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -290,11 +290,13 @@ class _LTX2CUDAGraphRunner(CUDAGraphRunner):
                 video_mask=v.video_mask.clone() if v.video_mask is not None else None,
                 video_pe=clone_pair(v.video_pe),
                 video_cross_pe=clone_pair(v.video_cross_pe),
+                video_cross_pe_local=clone_pair(v.video_cross_pe_local),
                 video_kv=[clone_pair(kv) for kv in v.video_kv] if v.video_kv is not None else None,
                 audio_context=v.audio_context.clone() if v.audio_context is not None else None,
                 audio_mask=v.audio_mask.clone() if v.audio_mask is not None else None,
                 audio_pe=clone_pair(v.audio_pe),
                 audio_cross_pe=clone_pair(v.audio_cross_pe),
+                audio_cross_pe_local=clone_pair(v.audio_cross_pe_local),
                 audio_kv=[clone_pair(kv) for kv in v.audio_kv] if v.audio_kv is not None else None,
             )
         if isinstance(v, torch.Tensor):
@@ -324,6 +326,7 @@ class _LTX2CUDAGraphRunner(CUDAGraphRunner):
                 dst.video_mask.copy_(src.video_mask)
             copy_pair(dst.video_pe, src.video_pe)
             copy_pair(dst.video_cross_pe, src.video_cross_pe)
+            copy_pair(dst.video_cross_pe_local, src.video_cross_pe_local)
             if dst.video_kv is not None and src.video_kv is not None:
                 for d, s in zip(dst.video_kv, src.video_kv):
                     copy_pair(d, s)
@@ -333,6 +336,7 @@ class _LTX2CUDAGraphRunner(CUDAGraphRunner):
                 dst.audio_mask.copy_(src.audio_mask)
             copy_pair(dst.audio_pe, src.audio_pe)
             copy_pair(dst.audio_cross_pe, src.audio_cross_pe)
+            copy_pair(dst.audio_cross_pe_local, src.audio_cross_pe_local)
             if dst.audio_kv is not None and src.audio_kv is not None:
                 for d, s in zip(dst.audio_kv, src.audio_kv):
                     copy_pair(d, s)

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/text_cache.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/text_cache.py
@@ -28,7 +28,12 @@ class TextCache:
         audio_mask: Attention mask for audio text cross-attention.
         audio_pe: RoPE (cos, sin) for audio.
         video_cross_pe: Cross-modal RoPE for video (audio-video model only).
-        audio_cross_pe: Cross-modal RoPE for audio (audio-video model only).
+            Full (un-sharded) layout, used for K-rope after all-gather.
+        video_cross_pe_local: Sharded contiguous Cross-modal RoPE for video.
+            Pre-sharded once here so the per-step ``_shard_pe`` slice + downstream
+            non-contiguous reshape copy in the fuse-op prologue both go away.
+        audio_cross_pe: Cross-modal RoPE for audio.  Full layout (see above).
+        audio_cross_pe_local: Sharded contiguous Cross-modal RoPE for audio.
         video_kv: Per-layer pre-projected text K/V for video cross-attention.
         audio_kv: Per-layer pre-projected text K/V for audio cross-attention.
     """
@@ -37,9 +42,11 @@ class TextCache:
     video_mask: Optional[torch.Tensor] = None
     video_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
     video_cross_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
+    video_cross_pe_local: Optional[tuple[torch.Tensor, torch.Tensor]] = None
     video_kv: Optional[list[tuple[torch.Tensor, torch.Tensor]]] = None
     audio_context: Optional[torch.Tensor] = None
     audio_mask: Optional[torch.Tensor] = None
     audio_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
     audio_cross_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
+    audio_cross_pe_local: Optional[tuple[torch.Tensor, torch.Tensor]] = None
     audio_kv: Optional[list[tuple[torch.Tensor, torch.Tensor]]] = None

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/text_cache.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/text_cache.py
@@ -23,16 +23,18 @@ class TextCache:
     Attributes:
         video_context: Projected text embedding for video cross-attention.
         video_mask: Attention mask for video text cross-attention.
-        video_pe: RoPE (cos, sin) for video.
+        video_pe: RoPE (cos, sin) for video self-attention. Full (un-sharded) layout.
+        video_pe_local: Sharded contiguous self-attn RoPE for video. Pre-sharded
+            once here so neither the per-step ``_shard_pe`` slice nor the
+            downstream non-contiguous reshape copy in the fuse-op prologue runs.
+        video_cross_pe: Cross-modal RoPE for video (audio-video model only).
+            Full layout, used for K-rope after all-gather.
+        video_cross_pe_local: Sharded contiguous Cross-modal RoPE for video.
         audio_context: Projected text embedding for audio cross-attention.
         audio_mask: Attention mask for audio text cross-attention.
-        audio_pe: RoPE (cos, sin) for audio.
-        video_cross_pe: Cross-modal RoPE for video (audio-video model only).
-            Full (un-sharded) layout, used for K-rope after all-gather.
-        video_cross_pe_local: Sharded contiguous Cross-modal RoPE for video.
-            Pre-sharded once here so the per-step ``_shard_pe`` slice + downstream
-            non-contiguous reshape copy in the fuse-op prologue both go away.
-        audio_cross_pe: Cross-modal RoPE for audio.  Full layout (see above).
+        audio_pe: RoPE (cos, sin) for audio self-attention. Full layout.
+        audio_pe_local: Sharded contiguous self-attn RoPE for audio.
+        audio_cross_pe: Cross-modal RoPE for audio. Full layout.
         audio_cross_pe_local: Sharded contiguous Cross-modal RoPE for audio.
         video_kv: Per-layer pre-projected text K/V for video cross-attention.
         audio_kv: Per-layer pre-projected text K/V for audio cross-attention.
@@ -41,12 +43,14 @@ class TextCache:
     video_context: Optional[torch.Tensor] = None
     video_mask: Optional[torch.Tensor] = None
     video_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
+    video_pe_local: Optional[tuple[torch.Tensor, torch.Tensor]] = None
     video_cross_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
     video_cross_pe_local: Optional[tuple[torch.Tensor, torch.Tensor]] = None
     video_kv: Optional[list[tuple[torch.Tensor, torch.Tensor]]] = None
     audio_context: Optional[torch.Tensor] = None
     audio_mask: Optional[torch.Tensor] = None
     audio_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
+    audio_pe_local: Optional[tuple[torch.Tensor, torch.Tensor]] = None
     audio_cross_pe: Optional[tuple[torch.Tensor, torch.Tensor]] = None
     audio_cross_pe_local: Optional[tuple[torch.Tensor, torch.Tensor]] = None
     audio_kv: Optional[list[tuple[torch.Tensor, torch.Tensor]]] = None

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -1176,7 +1176,11 @@ class LTXModel(nn.Module):
             timesteps=_shard(args.timesteps),
             embedded_timestep=_shard(args.embedded_timestep),
             positional_embeddings=_shard_pe(args.positional_embeddings),
-            cross_positional_embeddings_local=_shard_pe(args.cross_positional_embeddings_full),
+            # cross_positional_embeddings_local is pre-sharded + contiguous in
+            # prepare_text_cache (see _make_cross_pe_local) and threaded through
+            # preprocessor.prepare(static_cross_pe_local=...), so we leave it
+            # unchanged here — re-slicing every step would re-introduce the
+            # non-contiguous reshape copy this caching is meant to eliminate.
             cross_scale_shift_timestep=_shard(args.cross_scale_shift_timestep),
             cross_gate_timestep=_shard(args.cross_gate_timestep),
         )
@@ -1269,18 +1273,22 @@ class LTXModel(nn.Module):
         is passed to ``forward()`` on every step.  Does not require latent
         data — only text context, positions, and dtype are needed.
         """
-        v_ctx = v_mask = v_pe = v_cross_pe = v_kv = None
-        a_ctx = a_mask = a_pe = a_cross_pe = a_kv = None
+        v_ctx = v_mask = v_pe = v_cross_pe = v_cross_pe_local = v_kv = None
+        a_ctx = a_mask = a_pe = a_cross_pe = a_cross_pe_local = a_kv = None
 
         if video_context is not None:
             v_ctx, v_mask, v_pe, v_cross_pe = self.video_args_preprocessor.prepare_text_cache(
                 video_context, video_context_mask, video_positions, dtype
             )
+            v_cross_pe_local = self._make_cross_pe_local(v_cross_pe, is_sharded=self.use_ulysses)
             v_kv = [block.attn2.project_kv(v_ctx) for block in self.transformer_blocks]
 
         if audio_context is not None:
             a_ctx, a_mask, a_pe, a_cross_pe = self.audio_args_preprocessor.prepare_text_cache(
                 audio_context, audio_context_mask, audio_positions, dtype
+            )
+            a_cross_pe_local = self._make_cross_pe_local(
+                a_cross_pe, is_sharded=self._audio_is_sharded
             )
             a_kv = [block.audio_attn2.project_kv(a_ctx) for block in self.transformer_blocks]
 
@@ -1289,13 +1297,47 @@ class LTXModel(nn.Module):
             video_mask=v_mask,
             video_pe=v_pe,
             video_cross_pe=v_cross_pe,
+            video_cross_pe_local=v_cross_pe_local,
             video_kv=v_kv,
             audio_context=a_ctx,
             audio_mask=a_mask,
             audio_pe=a_pe,
             audio_cross_pe=a_cross_pe,
+            audio_cross_pe_local=a_cross_pe_local,
             audio_kv=a_kv,
         )
+
+    def _make_cross_pe_local(
+        self,
+        cross_pe: tuple[torch.Tensor, torch.Tensor] | None,
+        is_sharded: bool,
+    ) -> tuple[torch.Tensor, torch.Tensor] | None:
+        """Pre-shard + contiguous-ify cross_pe for the local Ulysses rank.
+
+        Computed once in ``prepare_text_cache``; stored on ``TextCache`` and
+        consumed each step via ``preprocessor.prepare(..., static_cross_pe_local=...)``.
+        Eliminates the per-step ``_shard_pe`` slice + downstream reshape copy
+        on a non-contiguous slice that would otherwise show up as a triton
+        prologue kernel before the fused norm+rope op.
+        """
+        if cross_pe is None:
+            return None
+        if not is_sharded:
+            return cross_pe
+        cos, sin = cross_pe
+        if cos.ndim == 4:
+            seq_len = cos.shape[2]
+            chunk = seq_len // self.ulysses_size
+            s = self.ulysses_rank * chunk
+            e = s + chunk
+            return (cos[:, :, s:e].contiguous(), sin[:, :, s:e].contiguous())
+        elif cos.ndim == 3:
+            seq_len = cos.shape[1]
+            chunk = seq_len // self.ulysses_size
+            s = self.ulysses_rank * chunk
+            e = s + chunk
+            return (cos[:, s:e].contiguous(), sin[:, s:e].contiguous())
+        return cross_pe
 
     def forward(
         self,
@@ -1329,6 +1371,7 @@ class LTXModel(nn.Module):
                 text_cache.video_mask,
                 text_cache.video_pe,
                 text_cache.video_cross_pe,
+                static_cross_pe_local=text_cache.video_cross_pe_local,
             )
             if video is not None
             else None
@@ -1340,6 +1383,7 @@ class LTXModel(nn.Module):
                 text_cache.audio_mask,
                 text_cache.audio_pe,
                 text_cache.audio_cross_pe,
+                static_cross_pe_local=text_cache.audio_cross_pe_local,
             )
             if audio is not None
             else None

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -1158,29 +1158,17 @@ class LTXModel(nn.Module):
                 return t
             return t[:, s:e]
 
-        def _shard_pe(pe):
-            if pe is None:
-                return None
-            cos, sin = pe
-            if cos.ndim == 4 and cos.shape[2] == seq_len:
-                # Split RoPE: [B, H, S, D] — sequence dim at index 2
-                return (cos[:, :, s:e], sin[:, :, s:e])
-            elif cos.ndim == 3 and cos.shape[1] == seq_len:
-                # Interleaved RoPE: [B, S, D] — sequence dim at index 1
-                return (cos[:, s:e], sin[:, s:e])
-            return pe
-
+        # All step-invariant pe fields (positional_embeddings,
+        # cross_positional_embeddings_local) are pre-sharded + contiguous in
+        # prepare_text_cache via LTXModel._shard_pe and threaded through
+        # preprocessor.prepare(static_pe_local=..., static_cross_pe_local=...).
+        # Re-slicing here every step would re-introduce the non-contiguous
+        # reshape copy that the caching is meant to eliminate.
         return replace(
             args,
             x=args.x[:, s:e],
             timesteps=_shard(args.timesteps),
             embedded_timestep=_shard(args.embedded_timestep),
-            positional_embeddings=_shard_pe(args.positional_embeddings),
-            # cross_positional_embeddings_local is pre-sharded + contiguous in
-            # prepare_text_cache (see _make_cross_pe_local) and threaded through
-            # preprocessor.prepare(static_cross_pe_local=...), so we leave it
-            # unchanged here — re-slicing every step would re-introduce the
-            # non-contiguous reshape copy this caching is meant to eliminate.
             cross_scale_shift_timestep=_shard(args.cross_scale_shift_timestep),
             cross_gate_timestep=_shard(args.cross_gate_timestep),
         )
@@ -1273,71 +1261,72 @@ class LTXModel(nn.Module):
         is passed to ``forward()`` on every step.  Does not require latent
         data — only text context, positions, and dtype are needed.
         """
-        v_ctx = v_mask = v_pe = v_cross_pe = v_cross_pe_local = v_kv = None
-        a_ctx = a_mask = a_pe = a_cross_pe = a_cross_pe_local = a_kv = None
+        v_ctx = v_mask = v_pe = v_pe_local = v_cross_pe = v_cross_pe_local = v_kv = None
+        a_ctx = a_mask = a_pe = a_pe_local = a_cross_pe = a_cross_pe_local = a_kv = None
 
         if video_context is not None:
             v_ctx, v_mask, v_pe, v_cross_pe = self.video_args_preprocessor.prepare_text_cache(
                 video_context, video_context_mask, video_positions, dtype
             )
-            v_cross_pe_local = self._make_cross_pe_local(v_cross_pe, is_sharded=self.use_ulysses)
+            v_pe_local = self._shard_pe(v_pe, is_sharded=self.use_ulysses)
+            v_cross_pe_local = self._shard_pe(v_cross_pe, is_sharded=self.use_ulysses)
             v_kv = [block.attn2.project_kv(v_ctx) for block in self.transformer_blocks]
 
         if audio_context is not None:
             a_ctx, a_mask, a_pe, a_cross_pe = self.audio_args_preprocessor.prepare_text_cache(
                 audio_context, audio_context_mask, audio_positions, dtype
             )
-            a_cross_pe_local = self._make_cross_pe_local(
-                a_cross_pe, is_sharded=self._audio_is_sharded
-            )
+            a_pe_local = self._shard_pe(a_pe, is_sharded=self._audio_is_sharded)
+            a_cross_pe_local = self._shard_pe(a_cross_pe, is_sharded=self._audio_is_sharded)
             a_kv = [block.audio_attn2.project_kv(a_ctx) for block in self.transformer_blocks]
 
         return TextCache(
             video_context=v_ctx,
             video_mask=v_mask,
             video_pe=v_pe,
+            video_pe_local=v_pe_local,
             video_cross_pe=v_cross_pe,
             video_cross_pe_local=v_cross_pe_local,
             video_kv=v_kv,
             audio_context=a_ctx,
             audio_mask=a_mask,
             audio_pe=a_pe,
+            audio_pe_local=a_pe_local,
             audio_cross_pe=a_cross_pe,
             audio_cross_pe_local=a_cross_pe_local,
             audio_kv=a_kv,
         )
 
-    def _make_cross_pe_local(
+    def _shard_pe(
         self,
-        cross_pe: tuple[torch.Tensor, torch.Tensor] | None,
+        pe: tuple[torch.Tensor, torch.Tensor] | None,
         is_sharded: bool,
     ) -> tuple[torch.Tensor, torch.Tensor] | None:
-        """Pre-shard + contiguous-ify cross_pe for the local Ulysses rank.
+        """Pre-shard + contiguous-ify a (cos, sin) tuple for the local Ulysses rank.
 
-        Computed once in ``prepare_text_cache``; stored on ``TextCache`` and
-        consumed each step via ``preprocessor.prepare(..., static_cross_pe_local=...)``.
-        Eliminates the per-step ``_shard_pe`` slice + downstream reshape copy
-        on a non-contiguous slice that would otherwise show up as a triton
-        prologue kernel before the fused norm+rope op.
+        Computed once in ``prepare_text_cache`` for self-attn pe and AV
+        cross-attn pe; stored on ``TextCache`` and threaded through
+        ``preprocessor.prepare(static_pe_local=..., static_cross_pe_local=...)``.
+        Eliminates the per-step slice + downstream non-contiguous reshape copy
+        in the fused norm+rope op prologue. Returns input unchanged when not
+        sharded. Auto-handles 4D ``[B, H, T, D]`` (split rope) and 3D
+        ``[B, T, D]`` (interleaved rope) layouts.
         """
-        if cross_pe is None:
-            return None
-        if not is_sharded:
-            return cross_pe
-        cos, sin = cross_pe
+        if pe is None or not is_sharded or self.ulysses_size <= 1:
+            return pe
+        cos, sin = pe
         if cos.ndim == 4:
             seq_len = cos.shape[2]
-            chunk = seq_len // self.ulysses_size
-            s = self.ulysses_rank * chunk
-            e = s + chunk
-            return (cos[:, :, s:e].contiguous(), sin[:, :, s:e].contiguous())
         elif cos.ndim == 3:
             seq_len = cos.shape[1]
-            chunk = seq_len // self.ulysses_size
-            s = self.ulysses_rank * chunk
-            e = s + chunk
-            return (cos[:, s:e].contiguous(), sin[:, s:e].contiguous())
-        return cross_pe
+        else:
+            return pe
+        chunk = seq_len // self.ulysses_size
+        s = self.ulysses_rank * chunk
+        e = s + chunk
+        if cos.ndim == 4:
+            return (cos[:, :, s:e].contiguous(), sin[:, :, s:e].contiguous())
+        return (cos[:, s:e].contiguous(), sin[:, s:e].contiguous())
 
     def forward(
         self,
@@ -1372,6 +1361,7 @@ class LTXModel(nn.Module):
                 text_cache.video_pe,
                 text_cache.video_cross_pe,
                 static_cross_pe_local=text_cache.video_cross_pe_local,
+                static_pe_local=text_cache.video_pe_local,
             )
             if video is not None
             else None
@@ -1384,6 +1374,7 @@ class LTXModel(nn.Module):
                 text_cache.audio_pe,
                 text_cache.audio_cross_pe,
                 static_cross_pe_local=text_cache.audio_cross_pe_local,
+                static_pe_local=text_cache.audio_pe_local,
             )
             if audio is not None
             else None

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -473,16 +473,6 @@ class BasicAVTransformerBlock(nn.Module):
         dist.all_gather(gathered, x, group=self._seq_parallel_pg)
         return torch.cat(gathered, dim=dim)
 
-    def _sp_gather_pe(self, pe):
-        """All-gather RoPE (cos, sin) tuple along the sequence dim."""
-        if pe is None:
-            return None
-        cos, sin = pe
-        # Split RoPE: [B, H, S, D] — sequence at dim 2
-        # Interleaved RoPE: [B, S, D] — sequence at dim 1
-        seq_dim = 2 if cos.ndim == 4 else 1
-        return (self._sp_all_gather(cos, dim=seq_dim), self._sp_all_gather(sin, dim=seq_dim))
-
     # -- Forward -------------------------------------------------------------
 
     def forward(
@@ -617,16 +607,13 @@ class BasicAVTransformerBlock(nn.Module):
                 if self._audio_is_sharded:
                     k_a2v = self._sp_all_gather(k_a2v)
                     v_a2v = self._sp_all_gather(v_a2v)
-                    k_pe_a2v = self._sp_gather_pe(audio.cross_positional_embeddings)
-                else:
-                    k_pe_a2v = audio.cross_positional_embeddings
 
                 a2v_out = (
                     self.audio_to_video_attn(
                         vx_scaled,
                         pre_projected_kv=(k_a2v, v_a2v),
-                        pe=video.cross_positional_embeddings,
-                        k_pe=k_pe_a2v,
+                        pe=video.cross_positional_embeddings_local,
+                        k_pe=audio.cross_positional_embeddings_full,
                     )
                     * gate_out_a2v
                 )
@@ -647,16 +634,13 @@ class BasicAVTransformerBlock(nn.Module):
                 if self._use_seq_parallel:
                     k_v2a = self._sp_all_gather(k_v2a)
                     v_v2a = self._sp_all_gather(v_v2a)
-                    k_pe_v2a = self._sp_gather_pe(video.cross_positional_embeddings)
-                else:
-                    k_pe_v2a = video.cross_positional_embeddings
 
                 v2a_out = (
                     self.video_to_audio_attn(
                         ax_scaled,
                         pre_projected_kv=(k_v2a, v_v2a),
-                        pe=audio.cross_positional_embeddings,
-                        k_pe=k_pe_v2a,
+                        pe=audio.cross_positional_embeddings_local,
+                        k_pe=video.cross_positional_embeddings_full,
                     )
                     * gate_out_v2a
                 )
@@ -1192,7 +1176,7 @@ class LTXModel(nn.Module):
             timesteps=_shard(args.timesteps),
             embedded_timestep=_shard(args.embedded_timestep),
             positional_embeddings=_shard_pe(args.positional_embeddings),
-            cross_positional_embeddings=_shard_pe(args.cross_positional_embeddings),
+            cross_positional_embeddings_local=_shard_pe(args.cross_positional_embeddings_full),
             cross_scale_shift_timestep=_shard(args.cross_scale_shift_timestep),
             cross_gate_timestep=_shard(args.cross_gate_timestep),
         )


### PR DESCRIPTION
@coderabbitai summary

## Description

Under Ulysses sequence parallelism, LTX-2's AV cross-attention K-side does an explicit `dist.all_gather` on the (cos, sin) RoPE tensors every block × every step (`BasicAVTransformerBlock._sp_gather_pe`). The pe is **deterministic** — precomputed once per `generate()` and held un-sharded inside `MultiModalTransformerArgsPreprocessor.prepare`, then sliced for Ulysses scatter. The all-gather rebuilds data the rank already had a copy of pre-shard.

This PR removes the cos/sin all-gathers by carrying both layouts on `TransformerArgs`.

### Design

| Field | Layout | Used by |
|---|---|---|
| `cross_positional_embeddings_local` | sharded along seq | Q-side rope on sharded query |
| `cross_positional_embeddings_full`  | un-sharded         | K-side rope on all-gathered K |

Both fields are populated once at construction (`MultiModalTransformerArgsPreprocessor.prepare`) from the same `static_cross_pe`. `LTXModel._shard_transformer_args` slices `_local = _shard_pe(args.cross_positional_embeddings_full)`; `_full` passes through. AV cross-attn reads `pe=*._local` and `k_pe=*._full` directly — no `_sp_gather_pe` call.

Why precomputed fields rather than a Python conditional or env-var gate? cuda_graph captures the kernel sequence, so a Python branch has no effect on the captured graph (we verified empirically that an env-var-gated approach left the AllGather kernel count unchanged). A field whose value is fixed at trace time is captured directly. Pre-computing in `_shard_transformer_args` instead of slicing inline keeps the sharding policy in one place and avoids creating fresh view objects per block × step.

### Changes

- `transformer_args.py`: replace `cross_positional_embeddings` with `_local` + `_full`; populate both at construction.
- `transformer_ltx2.py::LTXModel._shard_transformer_args`: slice `_local` from `_full`; pass `_full` through.
- `transformer_ltx2.py::BasicAVTransformerBlock.forward`: AV cross-attn reads `_local` (Q) / `_full` (K).
- Delete the now-unused `_sp_gather_pe` method.

Net diff: `+15 / −24` across two files.

### Lossless

cos/sin are deterministic and computed once. The previous shard→gather→concat round-trip is memcpy-only (no fp ops). Reusing the un-sharded source produces a bit-identical tensor for K-side rope. Q-side path is unchanged (just renamed `_local`).

### Validation

Setup: 2-GPU pure Ulysses (`dit_cfg=1, dit_ulysses=2`), single-stage 768×1280×121 fr, gs=3.0, seed=42, `cuda_graph + torch_compile` both ON. A/B by toggling git commits on the same worktree.

**Bit-identical** — raw video tensor sha256 (pre-encode), 40-step end-to-end:

```
baseline (HEAD~1):   371cee010e51cfc4ebb0af74a783a2f95b069ad49c70f703b07d406edc5e1c98
this patch (HEAD):   371cee010e51cfc4ebb0af74a783a2f95b069ad49c70f703b07d406edc5e1c98
```

**NCCL kernels** (10-step profiled iter, nsys with `--cuda-graph-trace=node`, sum over both GPUs):

| | baseline | this patch | Δ |
|---|---:|---:|---:|
| AllGather count | 7720 | **3880** | **−3840 (−49.7 %)** |
| AllGather total | 605.45 ms | 434.61 ms | **−170.84 ms (−28.2 %)** |
| SendRecv count | 7680 | 7680 | 0 (unchanged ✓) |
| SendRecv total | 1275.09 ms | 1277.20 ms | +2 ms (noise) |
| **Total NCCL** | **1880.54 ms** | **1711.83 ms** | **−168.71 ms (−9.0 %)** |

AllGather count is exactly halved — every cos/sin all-gather scheduled by `_sp_gather_pe` is removed from the captured graph. SendRecv (project-before-gather K/V collective) is untouched, as designed.

**E2E** (40-step, single timed run, post-warmup):

| | baseline | this patch |
|---|---|---|
| E2E | 26.104 s | 25.894 s (−210 ms, −0.8 %) |

Per-GPU NCCL saving (~85 ms / 10-step iter) translates to ~1 % E2E at 2 GPU; observed delta direction is consistent. Larger Ulysses sizes are expected to see similar ~9 % NCCL kernel-time reduction.

## Test Coverage

No new tests — change is a data-routing rewrite of an existing collective, covered by existing LTX-2 generate-path and `tests/unittest/_torch/visual_gen/...` pipeline tests. No-op for single-GPU / non-Ulysses configurations: `_shard_transformer_args` is not called and both fields hold the same un-sharded tensor.

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
