### PR TITLE
[None][feat] Add TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE env var for V2 hos…

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1803,7 +1803,21 @@ class KVCacheManagerV2(BaseResourceManager):
             f"KV cache manager v2 device quota set to {quota / (1 << 30)}GiB")
 
         cache_tiers: List[CacheTierConfig] = [GpuCacheTierConfig(quota=quota)]
-        if kv_cache_config.host_cache_size is not None and kv_cache_config.host_cache_size >= 0:
+        _host_override = os.environ.get("TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE")
+        if _host_override is not None:
+            try:
+                host_quota = max(0, int(_host_override))
+            except ValueError:
+                logger.warning(
+                    f"TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE={_host_override!r} is not "
+                    f"a valid integer; ignoring override.")
+                _host_override = None
+        if _host_override is not None:
+            logger.info(
+                f"TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE is set; "
+                f"V2 host cache quota forced to {host_quota / (1 << 30):.2f}GiB"
+            )
+        elif kv_cache_config.host_cache_size is not None and kv_cache_config.host_cache_size >= 0:
             host_quota = kv_cache_config.host_cache_size
         else:
             # The V2 MAX_UTILIZATION scheduler relies on suspend/resume to


### PR DESCRIPTION
…t tier

The V2 KV cache manager auto-provisions a host tier matching the GPU quota when host_cache_size is unset, to keep MAX_UTILIZATION suspend/resume working. The host tier is registered with CUDA via cuMemHostRegister(...CU_MEMHOSTREGISTER_DEVICEMAP), which can charge substantial GPU device memory and starve the executor's NCCL workspace or autotuner buffers — observable as OOMs at small batch sizes during EXTRA_RESOURCES allocation.

Add TRTLLM_KVCACHE_HOST_SIZE_OVERRIDE so operators can force the host tier to a specific size (or 0 to disable entirely) without modifying the KvCacheConfig schema. The override takes precedence over both the explicit kv_cache_config.host_cache_size and the auto-provisioning fallback.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
