### PR TITLE
[TRTLLM-None][feat] Add mixed-precision per-layer KV cache dtype support

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -676,6 +676,10 @@ public:
     // Used for recurrent state (linear attention) pools.
     bool layerFirstLayout;
 
+    // The dtype of the data stored in this pool. May differ from the KVCacheManager's global
+    // mDataType when mixed-precision KV cache is enabled (e.g. some layers use FP8, others NVFP4).
+    nvinfer1::DataType dataType{nvinfer1::DataType::kFLOAT};
+
     KVCacheBlockPool(SizeType32 numLayers, SizeType32 kvFactor, SizeType32 numKvHeads, SizeType32 sizePerHead,
         SizeType32 tokensPerBlock, runtime::ITensor::SharedPtr primaryPtr = nullptr,
         runtime::ITensor::SharedPtr secondaryPtr = nullptr, bool containsBlockScales = false,
@@ -755,7 +759,8 @@ public:
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
         SizeType32 indexerKCacheIndexHeadDim = 0,
         std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt,
-        SizeType32 numPlaceholderBlocks = 0);
+        SizeType32 numPlaceholderBlocks = 0,
+        std::unordered_map<SizeType32, nvinfer1::DataType> perLayerDtype = {});
 
     ~WindowBlockManager();
 
@@ -1198,6 +1203,10 @@ private:
     nvinfer1::DataType mDataType;
     SizeType32 mWindowSize;
 
+    // Per-layer dtype overrides. Layers absent from this map use mDataType.
+    // Enables mixed-precision KV cache (e.g., layers 0-3: FP8, layers 4-35: NVFP4).
+    std::unordered_map<SizeType32, nvinfer1::DataType> mPerLayerDtype;
+
     // Number of blocks in pools
     SizeType32 mNumPrimaryBlocks;
     SizeType32 mNumSecondaryBlocks;
@@ -1205,7 +1214,7 @@ private:
     // List of allocated blocks for each sequences
     std::unordered_map<LlmRequest::RequestIdType, std::vector<BlockPtr>> mAllocatedBlocksPerSeq;
 
-    // Pool per unique numKvHeads in the model
+    // Pool per unique (numKvHeads, dtype) pair in the model
     std::vector<KVCacheBlockPool> mPools;
 
     // Matching layers to their respective pools: {<layer #0>: <pool idx 2>, }, etc.
@@ -1328,7 +1337,8 @@ public:
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         std::optional<kvc::BaseAgentConfig> agentConfig = std::nullopt, bool enableIndexerKCache = false,
         SizeType32 indexerKCacheQuantBlockSize = 128, SizeType32 indexerKCacheIndexHeadDim = 0,
-        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt,
+        std::unordered_map<SizeType32, nvinfer1::DataType> perLayerDtype = {});
 
     [[nodiscard]] bool isEnableIndexerKCache() const
     {
@@ -2075,7 +2085,8 @@ public:
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
         SizeType32 indexerKCacheIndexHeadDim = 0,
-        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt,
+        std::unordered_map<SizeType32, nvinfer1::DataType> perLayerDtype = {});
 
     KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -2089,7 +2100,8 @@ public:
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
         SizeType32 indexerKCacheIndexHeadDim = 0,
-        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt,
+        std::unordered_map<SizeType32, nvinfer1::DataType> perLayerDtype = {});
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -573,7 +573,8 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager,
     std::optional<BaseAgentConfig> agentConfig, bool enableIndexerKCache, SizeType32 indexerKCacheQuantBlockSize,
-    SizeType32 indexerKCacheIndexHeadDim, std::optional<LinearAttentionMetadata> linearAttentionMetadata)
+    SizeType32 indexerKCacheIndexHeadDim, std::optional<LinearAttentionMetadata> linearAttentionMetadata,
+    std::unordered_map<SizeType32, nvinfer1::DataType> perLayerDtype)
     : mNumLayers{static_cast<SizeType32>(numKvHeadsPerLayer.size())}
     , mTokensPerBlock{tokensPerBlock}
     , mEventManager{std::move(eventManager)}
@@ -655,7 +656,7 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
             enablePartialReuse, copyOnPartialReuse, kvCacheConnectorManager, mLookupTree, mLoopbackAgent,
             enableIndexerKCache, indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim,
             LinearAttentionMetadata::hasLinearCache(windowSize) ? linearAttentionMetadata : std::nullopt,
-            numPlaceholderBlocks);
+            numPlaceholderBlocks, perLayerDtype);
     }
 
     auto const numAllPools = getNumPools();
@@ -714,8 +715,10 @@ WindowBlockManager::WindowBlockManager(nvinfer1::DataType dtype, SizeType32 wind
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager,
     radix_block_tree::UnifiedBlockTree& lookupTree, std::shared_ptr<kvc::BaseLoopbackAgent> loopbackAgent,
     bool enableIndexerKCache, SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim,
-    std::optional<LinearAttentionMetadata> linearAttentionMetadata, SizeType32 numPlaceholderBlocks)
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata, SizeType32 numPlaceholderBlocks,
+    std::unordered_map<SizeType32, nvinfer1::DataType> perLayerDtype)
     : mDataType{dtype}
+    , mPerLayerDtype{std::move(perLayerDtype)}
     , mWindowSize{windowSize}
     , mNumPrimaryBlocks{blocksInPrimaryPool}
     , mNumSecondaryBlocks{blocksInSecondaryPool}
@@ -756,28 +759,48 @@ WindowBlockManager::WindowBlockManager(nvinfer1::DataType dtype, SizeType32 wind
     , mLinearAttentionMetadata{std::move(linearAttentionMetadata)}
 {
     TLLM_LOG_DEBUG("Creating WindowBlockManager for windowSize=%d", windowSize);
-    std::map<SizeType32, SizeType32> numLayersPerPool;
+
+    // Helper: resolve the dtype for a given layer (falls back to the global mDataType).
+    auto poolDtypeOf = [&](SizeType32 layerIdx) -> nvinfer1::DataType
+    {
+        auto it = mPerLayerDtype.find(layerIdx);
+        return it != mPerLayerDtype.end() ? it->second : mDataType;
+    };
+
+    // Group layers by (numKvHeads, dtype) so that layers with the same head count but different
+    // precisions are allocated to separate memory pools.
+    using PoolKey = std::pair<SizeType32, nvinfer1::DataType>;
+    std::map<PoolKey, SizeType32> numLayersPerPool;
 
     for (auto const layerIdx : managedLayers)
     {
-        auto const& layerIndexWithinPool = numLayersPerPool[numKvHeadsPerLayer.at(layerIdx)]++;
+        PoolKey const key{numKvHeadsPerLayer.at(layerIdx), poolDtypeOf(layerIdx)};
+        auto const layerIndexWithinPool = numLayersPerPool[key]++;
         mLayerToIndexWithinPool[layerIdx] = layerIndexWithinPool;
     }
 
-    auto numEltsPerContainer = getNumEltsPerContainer();
 #ifdef ENABLE_FP4
-    if (numEltsPerContainer == 2)
+    constexpr SizeType32 kQuantBlockSizeNVFP4 = 16;
+    for (auto const& [key, numLayers] : numLayersPerPool)
     {
-        TLLM_CHECK_WITH_INFO(sizePerHead % 2 == 0, "sizePerHead must be divisible by 2 for 4-bit KV cache.");
+        if (key.second == nvinfer1::DataType::kFP4)
+        {
+            TLLM_CHECK_WITH_INFO(sizePerHead % 2 == 0, "sizePerHead must be divisible by 2 for 4-bit KV cache.");
+            break;
+        }
     }
 #endif
 
     size_t poolIndex = 0;
-    for (auto const [numKvHeads, numLayers] : numLayersPerPool)
+    for (auto const& [poolKey, numLayers] : numLayersPerPool)
     {
+        auto const [numKvHeads, poolDtype] = poolKey;
+        // FP4 packs 2 values per byte; all other dtypes are 1 element per container.
+        SizeType32 const numEltsForThisPool = (poolDtype == nvinfer1::DataType::kFP4) ? 2 : 1;
+
         for (auto const layerIdx : managedLayers)
         {
-            if (numKvHeadsPerLayer.at(layerIdx) == numKvHeads)
+            if (numKvHeadsPerLayer.at(layerIdx) == numKvHeads && poolDtypeOf(layerIdx) == poolDtype)
             {
                 mLayerToPoolIndex[layerIdx] = poolIndex;
             }
@@ -785,25 +808,36 @@ WindowBlockManager::WindowBlockManager(nvinfer1::DataType dtype, SizeType32 wind
         if (isRecurrentState())
         {
             TLLM_CHECK(numLayersPerPool.size() == 1);
-            auto bytesPerElement = common::getDTypeSize(mDataType);
+            auto bytesPerElement = common::getDTypeSize(poolDtype);
             KVCacheBlockPool pool(numLayers, /*kvFactor=*/1, /*numKvHeads=*/-1,
                 /*sizePerHead=*/-1, tokensPerBlock);
             pool.blockSize = mLinearAttentionMetadata->allRecurrentStatesBytes / bytesPerElement;
+            pool.dataType = poolDtype;
             mPools.push_back(std::move(pool));
         }
         else
         {
-            mPools.emplace_back(numLayers, mKVFactor, numKvHeads, sizePerHead / numEltsPerContainer, tokensPerBlock);
+            auto& newPool = mPools.emplace_back(
+                numLayers, mKVFactor, numKvHeads, sizePerHead / numEltsForThisPool, tokensPerBlock);
+            newPool.dataType = poolDtype;
         }
         ++poolIndex;
     }
 
 #ifdef ENABLE_FP4
-    // TODO(miovine): make the block size configurable. Should we have an additional argument
-    // to specify FP4 related parameters (scale dtypes, etc)? This can also be passed
-    // in the constructor.
-    constexpr SizeType32 kQuantBlockSizeNVFP4 = 16;
-    if (dtype == nvinfer1::DataType::kFP4)
+    // Create block-scale pools for any FP4 data pools. Non-FP4 pools are skipped inside
+    // createBlockScalePools via the pool.dataType check.
+    bool hasAnyFP4Pool = false;
+    for (auto const& pool : mPools)
+    {
+        if (!pool.containsBlockScales && !pool.containsIndexerKCache
+            && pool.dataType == nvinfer1::DataType::kFP4)
+        {
+            hasAnyFP4Pool = true;
+            break;
+        }
+    }
+    if (hasAnyFP4Pool)
     {
         createBlockScalePools(kQuantBlockSizeNVFP4);
     }
@@ -940,7 +974,9 @@ void BlockManager::storeContextBlocks(GenerationRequest& sequence, LlmRequest co
 
 void WindowBlockManager::createBlockScalePools(SizeType32 quantBlockSize)
 {
-    SizeType32 const numEltsPerContainer = getNumEltsPerContainer();
+    // FP4 packs 2 values per byte.
+    constexpr SizeType32 kFP4EltsPerContainer = 2;
+
     SizeType32 numPools = mPools.size();
     for (SizeType32 i = 0; i < numPools; ++i)
     {
@@ -949,9 +985,14 @@ void WindowBlockManager::createBlockScalePools(SizeType32 quantBlockSize)
         {
             continue;
         }
-        TLLM_CHECK_WITH_INFO((kvPool.sizePerHead * numEltsPerContainer) % quantBlockSize == 0,
+        // Only create scale pools for FP4 data pools.
+        if (kvPool.dataType != nvinfer1::DataType::kFP4)
+        {
+            continue;
+        }
+        TLLM_CHECK_WITH_INFO((kvPool.sizePerHead * kFP4EltsPerContainer) % quantBlockSize == 0,
             "Cannot use FP4 quantization since kvPool.sizePerHead is not divisible by FP4 quantBlockSize.");
-        auto blockScaleSizePerHead = kvPool.sizePerHead * numEltsPerContainer / quantBlockSize;
+        auto blockScaleSizePerHead = kvPool.sizePerHead * kFP4EltsPerContainer / quantBlockSize;
         mPools.emplace_back(kvPool.numLayers, kvPool.kvFactor, kvPool.numKvHeads, blockScaleSizePerHead,
             kvPool.tokensPerBlock,
             /*primaryPool=*/nullptr,
@@ -973,12 +1014,15 @@ void WindowBlockManager::createIndexerKCachePools()
         }
         SizeType32 scaleSize = mIndexerKCacheIndexHeadDim / mIndexerKCacheQuantBlockSize * 4;
 
-        mPools.emplace_back(kvPool.numLayers, kvPool.kvFactor, 1, scaleSize + mIndexerKCacheIndexHeadDim,
-            kvPool.tokensPerBlock,
+        auto& newPool = mPools.emplace_back(kvPool.numLayers, kvPool.kvFactor, 1,
+            scaleSize + mIndexerKCacheIndexHeadDim, kvPool.tokensPerBlock,
             /*primaryPool=*/nullptr,
             /*secondaryPool=*/nullptr,
             /*containsBlockScales=*/false,
             /*containsIndexerKCache=*/true);
+        // Indexer-K cache buffers are always allocated as kUINT8; record that so the
+        // byte-accounting in KVCacheManager::allocatePools() uses the correct element size.
+        newPool.dataType = nvinfer1::DataType::kUINT8;
     }
 }
 
@@ -994,12 +1038,13 @@ void WindowBlockManager::allocatePools(bool useUvm)
 {
     constexpr nvinfer1::DataType kScaleDtypeNVFP4 = nvinfer1::DataType::kFP8;
 
-    // Allocate a memory pool backing the blocks for each numKvHeads
+    // Allocate a memory pool backing the blocks for each (numKvHeads, dtype) group.
     // TODO(oargov): allocate pools in a single buffer and split it, to avoid fragmentation
     for (auto& pool : mPools)
     {
         auto blockSize = pool.blockSize;
-        auto poolDtype = pool.containsBlockScales ? kScaleDtypeNVFP4 : mDataType;
+        // Scale pools are always FP8; data pools use their own per-pool dtype.
+        auto poolDtype = pool.containsBlockScales ? kScaleDtypeNVFP4 : pool.dataType;
 #ifdef ENABLE_FP4
         auto const poolIsFP4 = poolDtype == nvinfer1::DataType::kFP4;
 #else
@@ -2792,13 +2837,14 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, bool enableIndexerKCache,
     SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim,
-    std::optional<LinearAttentionMetadata> linearAttentionMetadata)
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata,
+    std::unordered_map<SizeType32, nvinfer1::DataType> perLayerDtype)
     : KVCacheManager(numKvHeadsPerLayer, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences, maxBeamWidth,
         maxAttentionWindowVec, tempAttentionWindowInputs, dtype, sinkTokenLength,
         std::make_shared<runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream)), maxSequenceLength,
         enableBlockReuse, cacheType, secondaryOffloadMinPriority, eventManager, enablePartialReuse, copyOnPartialReuse,
         kvCacheConnectorManager, enableIndexerKCache, indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim,
-        linearAttentionMetadata)
+        linearAttentionMetadata, std::move(perLayerDtype))
 {
 }
 
@@ -2811,7 +2857,8 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, bool enableIndexerKCache,
     SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim,
-    std::optional<LinearAttentionMetadata> linearAttentionMetadata)
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata,
+    std::unordered_map<SizeType32, nvinfer1::DataType> perLayerDtype)
     : mMaxBeamWidth(maxBeamWidth)
     , mDataType(dtype)
     , mMaxAttentionWindow(*std::max_element(maxAttentionWindowVec.begin(), maxAttentionWindowVec.end()))
@@ -2822,7 +2869,8 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
           std::move(stream), maxSequenceLength, maxBeamWidth, maxAttentionWindowVec, tempAttentionWindowInputs, dtype,
           mSinkBubbleLength, cacheType, secondaryOffloadMinPriority, std::move(eventManager), enablePartialReuse,
           copyOnPartialReuse, std::move(kvCacheConnectorManager), std::nullopt, enableIndexerKCache,
-          indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim, linearAttentionMetadata)
+          indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim, linearAttentionMetadata,
+          std::move(perLayerDtype))
     // disable block reuse for sink bubble since chopVectorIntoBlocks does not match KV cache blocks in this case
     , mEnableBlockReuse{mSinkBubbleLength > 0 ? false : enableBlockReuse}
 {
@@ -2865,66 +2913,137 @@ void KVCacheManager::allocatePools(bool useUvm)
     mBlockManager.allocatePools(useUvm);
     auto const numPools = mBlockManager.getNumPools();
 
+    // Compute the total bytes occupied by all primary KV-cache pools.
+    //
+    // There are two categories of pools for NVFP4 KV cache:
+    //   1. KV element pools  — store the actual K/V data, packed as INT8
+    //                          (2 FP4 values per byte).
+    //   2. Block scale pools — store per-block FP8 quantization scales
+    //                          (1 scale per 16 FP4 elements).
+    //
+    // BUG FIX 1 (scale pool dtype):
+    //   The original code applied the FP4 byte formula `(volume * 4) / 8` to
+    //   every pool when mDataType == kFP4, including block scale pools whose
+    //   elements are FP8 (1 byte each).  This caused a 2× undercount of the
+    //   scale pool size.  Fix: detect containsBlockScales and use the FP8
+    //   element size unconditionally for those pools.
+    //
+    // BUG FIX 2 (FP4 element pool double-halving):
+    //   When a FP4 element pool is constructed, sizePerHead is already divided
+    //   by numEltsPerContainer=2 so that each "element" in the pool tensor
+    //   represents one packed INT8 byte (holding 2 FP4 values).  The original
+    //   formula `(cacheVolume * 4) / 8` = cacheVolume * 0.5 halved the volume
+    //   a second time, reporting half the actual GPU allocation.  Fix: treat
+    //   each element as 1 byte (kINT8), matching how allocatePools() allocates
+    //   the buffer (see WindowBlockManager::allocatePools where poolDtype is
+    //   set to kINT8 for FP4 pools before calling gpuSync).
     uint64_t cacheSizeBytes = 0;
+    uint64_t elemPoolBytes = 0;
+    uint64_t scalePoolBytes = 0;
     for (SizeType32 poolIdx = 0; poolIdx < numPools; poolIdx++)
     {
+        auto const& pool = mBlockManager.getPool(poolIdx);
         auto const cacheShape = mBlockManager.getPrimaryPool(poolIdx)->getShape();
         auto const cacheVolume = ITensor::volume(cacheShape);
-#ifdef ENABLE_FP4
-        auto const isFp4 = mDataType == nvinfer1::DataType::kFP4;
-#else
-        auto const isFp4 = false;
-#endif
-        if (!isFp4)
+        uint64_t poolBytes = 0;
+        if (pool.containsBlockScales)
         {
-            cacheSizeBytes += cacheVolume * BufferDataType(mDataType).getSize();
+            // BUG FIX 1: scale pools are FP8 regardless of mDataType.
+            poolBytes = cacheVolume * BufferDataType(nvinfer1::DataType::kFP8).getSize();
+            scalePoolBytes += poolBytes;
         }
         else
         {
-            cacheSizeBytes += (cacheVolume * 4) / 8;
+#ifdef ENABLE_FP4
+            // Use each pool's own dtype (not the global mDataType) to handle mixed-precision.
+            auto const isFp4 = pool.dataType == nvinfer1::DataType::kFP4;
+#else
+            auto const isFp4 = false;
+#endif
+            if (isFp4)
+            {
+                // BUG FIX 2: sizePerHead was already halved at pool construction
+                // (sizePerHead / numEltsPerContainer), so cacheVolume is already
+                // in bytes (INT8 elements).  Use size 1, not 0.5.
+                poolBytes = cacheVolume * BufferDataType(nvinfer1::DataType::kINT8).getSize();
+            }
+            else
+            {
+                poolBytes = cacheVolume * BufferDataType(pool.dataType).getSize();
+            }
+            elemPoolBytes += poolBytes;
         }
+        cacheSizeBytes += poolBytes;
     }
     // Save the total number of bytes allocated for the KV-cache for KvCacheStats
     mAllocatedBytes = cacheSizeBytes;
     if (tc::Logger::getLogger()->getLevel() <= tc::Logger::INFO)
     {
-
         TLLM_LOG_INFO("Number of tokens per block: %d.", mBlockManager.getTokensPerBlock());
         auto const maxNumTokens = mBlockManager.getNumPrimaryBlocks() * mBlockManager.getTokensPerBlock();
         TLLM_LOG_INFO("[MemUsageChange] Allocated %0.2f GiB for max tokens in paged KV cache (%d).",
+            cacheSizeBytes / static_cast<double>(1 << 30), maxNumTokens);
+        TLLM_LOG_DEBUG(
+            "KV cache pool breakdown: element pool=%.2f GiB, scale pool=%.2f GiB, total=%.2f GiB"
+            " [max tokens=%d]",
+            elemPoolBytes / static_cast<double>(1 << 30), scalePoolBytes / static_cast<double>(1 << 30),
             cacheSizeBytes / static_cast<double>(1 << 30), maxNumTokens);
     }
 
     auto const numKVPools
         = mBlockManager.getNumPools(/*include_block_scalar_pools=*/false, /*include_indexer_k_cache_pools=*/false);
-    auto const numBlockScalePools
-        = mBlockManager.getNumPools(/*includeBlockScalePools=*/true, /*includeIndexerKCachePools=*/false) - numKVPools;
 
-    // Code in the attention kernels is cleaner if we can access the KV values and block scales separately.
+    // Data pool pointers: shape (numKVPools, 2) — [primary_ptr, secondary_ptr].
     mBlockPoolPointers = BufferManager::cpu(ITensor::makeShape({numKVPools, 2}), TRTDataType<void*>::value);
-    mBlockScalePoolPointers
-        = BufferManager::cpu(ITensor::makeShape({numBlockScalePools, 2}), TRTDataType<void*>::value);
+
+    // Scale pool pointers: shape (numKVPools, 2) — aligned 1:1 with data pools.
+    // Non-FP4 data pools have zero (null) scale pointer entries. This uniform shape
+    // lets Python always stack (data, scale) into a (numKVPools, 2, 2) tensor for
+    // mixed-precision KV cache without special-casing.
+    mBlockScalePoolPointers = BufferManager::cpu(ITensor::makeShape({numKVPools, 2}), TRTDataType<void*>::value);
 
     auto poolPtrsRange = BufferRange<void*>(*mBlockPoolPointers);
     auto blockScalePtrsRange = BufferRange<void*>(*mBlockScalePoolPointers);
-    SizeType32 kvPoolIdx = 0;
-    SizeType32 blockScalePoolIdx = 0;
+    // Zero-initialise scale pointers; non-FP4 data pool entries remain null.
+    std::fill(blockScalePtrsRange.begin(), blockScalePtrsRange.end(), nullptr);
 
+    // First pass: fill data pool pointers and record, in order, which KV pool slots belong
+    // to FP4 data pools (they will be matched to scale pools below).
+    std::vector<SizeType32> fp4DataPoolSlots;
+    SizeType32 kvPoolIdx = 0;
     for (SizeType32 poolIdx = 0; poolIdx < numPools; poolIdx++)
     {
         auto const& pool = mBlockManager.getPool(poolIdx);
-        auto& outIdx = pool.containsBlockScales ? blockScalePoolIdx : kvPoolIdx;
-        auto& outRange = pool.containsBlockScales ? blockScalePtrsRange : poolPtrsRange;
         if (pool.containsIndexerKCache)
         {
             mIndexerKCachePoolPointers = pool.primaryPtr;
         }
-        else
+        else if (!pool.containsBlockScales)
         {
-            outRange[outIdx * 2] = pool.primaryPtr->data();
-            outRange[outIdx * 2 + 1] = pool.secondaryPtr ? pool.secondaryPtr->data() : nullptr;
-            outIdx++;
+            poolPtrsRange[kvPoolIdx * 2] = pool.primaryPtr->data();
+            poolPtrsRange[kvPoolIdx * 2 + 1] = pool.secondaryPtr ? pool.secondaryPtr->data() : nullptr;
+            if (pool.dataType == nvinfer1::DataType::kFP4)
+            {
+                fp4DataPoolSlots.push_back(kvPoolIdx);
+            }
+            kvPoolIdx++;
         }
+    }
+    // Second pass: match scale pools to their FP4 data pools in creation order.
+    // createBlockScalePools() creates one scale pool per FP4 data pool in the same order.
+    SizeType32 scaleIdx = 0;
+    for (SizeType32 poolIdx = 0; poolIdx < numPools && scaleIdx < static_cast<SizeType32>(fp4DataPoolSlots.size());
+         poolIdx++)
+    {
+        auto const& pool = mBlockManager.getPool(poolIdx);
+        if (!pool.containsBlockScales || pool.containsIndexerKCache)
+        {
+            continue;
+        }
+        SizeType32 const kvSlot = fp4DataPoolSlots[scaleIdx];
+        blockScalePtrsRange[kvSlot * 2] = pool.primaryPtr->data();
+        blockScalePtrsRange[kvSlot * 2 + 1] = pool.secondaryPtr ? pool.secondaryPtr->data() : nullptr;
+        scaleIdx++;
     }
 
     auto const numLayers = mBlockManager.getNumLayers();

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -623,7 +623,7 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
                  nvinfer1::DataType, SizeType32, int64_t, runtime::SizeType32, bool, tbk::CacheType,
                  std::optional<tensorrt_llm::executor::RetentionPriority>, std::shared_ptr<tbk::KVCacheEventManager>,
                  bool, bool, std::shared_ptr<tbc::KvCacheConnectorManager>, bool, SizeType32, SizeType32,
-                 std::optional<tbk::LinearAttentionMetadata>>(),
+                 std::optional<tbk::LinearAttentionMetadata>, std::unordered_map<SizeType32, nvinfer1::DataType>>(),
             nb::arg("num_kv_heads_per_layer"), nb::arg("size_per_head"), nb::arg("tokens_per_block"),
             nb::arg("blocks_per_window"), nb::arg("max_num_sequences"), nb::arg("max_beam_width"),
             nb::arg("max_attention_window_vec"), nb::arg("temp_attention_window_inputs").none(), nb::arg("dtype"),
@@ -633,7 +633,9 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
             nb::arg("enable_partial_reuse") = true, nb::arg("copy_on_partial_reuse") = true,
             nb::arg("kv_connector_manager") = nullptr, nb::arg("enable_indexer_k_cache") = false,
             nb::arg("indexer_k_cache_quant_block_size") = 128, nb::arg("indexer_k_cache_index_head_dim") = 0,
-            nb::arg("linear_attention_metadata").none() = std::nullopt, nb::call_guard<nb::gil_scoped_release>())
+            nb::arg("linear_attention_metadata").none() = std::nullopt,
+            nb::arg("per_layer_dtype") = std::unordered_map<SizeType32, nvinfer1::DataType>(),
+            nb::call_guard<nb::gil_scoped_release>())
         .def(
             "scheduling_has_free_blocks",
             [](tbk::KVCacheManager& self, SizeType32 numRequired, SizeType32 windowSize)

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -1013,11 +1013,28 @@ KvCachePoolPointers buildKvCachePoolPointers(at::Tensor const& hostKvCachePoolPo
     }
     else
     {
-        TORCH_CHECK(hostKvCachePoolPointers.dim() == 2);
-        pointers.primaryPoolPtr = reinterpret_cast<void*>(
-            reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 0}).item<int64_t>()) + intraPoolOffset);
-        pointers.secondaryPoolPtr = reinterpret_cast<void*>(
-            reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 1}).item<int64_t>()) + intraPoolOffset);
+        TORCH_CHECK(hostKvCachePoolPointers.dim() == 2 || hostKvCachePoolPointers.dim() == 3);
+        // In mixed-precision KV cache (e.g. fp8 + nvfp4), the tensor is built as 3D to
+        // accommodate FP4 scale pool pointers. For non-FP4 pools the data pointers sit at
+        // index [..., 0] of the last dimension; secondary scale entries are unused zeros.
+        if (hostKvCachePoolPointers.dim() == 3)
+        {
+            pointers.primaryPoolPtr = reinterpret_cast<void*>(
+                reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 0, 0}).item<int64_t>())
+                + intraPoolOffset);
+            pointers.secondaryPoolPtr = reinterpret_cast<void*>(
+                reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 1, 0}).item<int64_t>())
+                + intraPoolOffset);
+        }
+        else
+        {
+            pointers.primaryPoolPtr = reinterpret_cast<void*>(
+                reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 0}).item<int64_t>())
+                + intraPoolOffset);
+            pointers.secondaryPoolPtr = reinterpret_cast<void*>(
+                reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 1}).item<int64_t>())
+                + intraPoolOffset);
+        }
     }
     return pointers;
 }

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -17,7 +17,7 @@ from tensorrt_llm.llmapi.llm_args import (
     CacheTransceiverConfig, CapacitySchedulerPolicy, EagleDecodingConfig,
     KvCacheConfig, MTPDecodingConfig, PeftCacheConfig, SamplerType,
     SchedulerConfig, SparseAttentionConfig, SpeculativeConfig, TorchLlmArgs,
-    WaitingQueuePolicy)
+    WaitingQueuePolicy, parse_kv_cache_dtype_spec)
 # isort: on
 from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_helper import (LoraConfig,
@@ -876,6 +876,152 @@ def _build_per_layer_num_kv_heads(
                                                         ] * num_spec_layers
 
 
+def _dtype_str_to_binding(dtype_str: str,
+                          fallback_dtype: "tensorrt_llm.bindings.DataType",
+                          quant_config) -> "tensorrt_llm.bindings.DataType":
+    """Map a per-layer KV cache dtype string to a binding DataType."""
+    s = dtype_str.lower()
+    if s == "auto":
+        return fallback_dtype
+    if s in ("fp8", "float8"):
+        return tensorrt_llm.bindings.DataType.FP8
+    if s in ("nvfp4", "fp4"):
+        return tensorrt_llm.bindings.DataType.NVFP4
+    if s in ("fp16", "float16"):
+        return tensorrt_llm.bindings.DataType.HALF
+    if s in ("bf16", "bfloat16"):
+        return tensorrt_llm.bindings.DataType.BF16
+    raise ValueError(f"Unsupported per-layer KV cache dtype: '{dtype_str}'")
+
+
+def _resolve_per_layer_dtype(
+    dtype_spec: Union[str, Dict[int, str]],
+    num_layers: int,
+    quant_config,
+    fallback_dtype: "tensorrt_llm.bindings.DataType",
+) -> Dict[int, "tensorrt_llm.bindings.DataType"]:
+    """Resolve KvCacheConfig.dtype into a full per-layer DataType mapping."""
+    raw_map = parse_kv_cache_dtype_spec(dtype_spec, num_layers)
+    return {
+        i: _dtype_str_to_binding(s, fallback_dtype, quant_config)
+        for i, s in raw_map.items()
+    }
+
+
+def _apply_per_layer_kv_quant_config(model, per_layer_dtype_map: Dict,
+                                     base_quant_config):
+    """Call update_quant_config on each attention layer with the right KV dtype.
+
+    Handles two cases:
+      1. The module found by _get_attention_module has ``update_quant_config``
+         directly (e.g. TrtllmAttention when it is the leaf attention).
+      2. The module is an ``Attention`` wrapper (e.g. Qwen3Attention) whose
+         inner ``TrtllmAttention`` is stored in ``.attn``.  In this case we
+         update ``wrapper.quant_config`` so that ``attention.py`` picks up the
+         new KV dtype when building ``kv_scales_sf``, and then call
+         ``wrapper.attn.update_quant_config`` so the C++ wrapper's quant_mode
+         is also updated.
+
+    For NVFP4 KV cache used with BF16 model weights the ``qkv_proj`` may not
+    have ``kv_scales`` / ``inv_kv_scales`` attributes because those are only
+    created when the module is instantiated with an FP4 quant config.  We add
+    identity-scale tensors (value 1.0) so the forward pass can pass them to
+    the kernel without raising AttributeError.
+    """
+    import copy
+    from torch.nn import Parameter
+    from tensorrt_llm.models.modeling_utils import QuantConfig
+    from tensorrt_llm.quantization import QuantMode
+
+    # Pre-compute the base mode (weight quant bits only, no KV cache bits).
+    base_mode = (base_quant_config.layer_quant_mode
+                 if base_quant_config is not None else QuantMode(0))
+    base_mode_no_kv = (base_mode & ~QuantMode.FP8_KV_CACHE
+                       & ~QuantMode.NVFP4_KV_CACHE & ~QuantMode.INT8_KV_CACHE)
+
+    for layer_idx, dtype in per_layer_dtype_map.items():
+        attn = _get_attention_module(model, layer_idx)
+        if attn is None:
+            continue
+        qcfg = copy.deepcopy(base_quant_config) if base_quant_config else None
+        if qcfg is None:
+            qcfg = QuantConfig()
+        # Compute the desired per-layer KV cache quant mode.
+        mode = base_mode_no_kv
+        if dtype == tensorrt_llm.bindings.DataType.FP8:
+            mode = mode.set_fp8_kv_cache()
+        elif dtype == tensorrt_llm.bindings.DataType.NVFP4:
+            mode = mode.set_fp4_kv_cache()
+        # layer_quant_mode is a @cached_property; inject the pre-computed value
+        # directly into the instance cache so update_quant_config sees it correctly.
+        qcfg.__dict__['layer_quant_mode'] = mode
+
+        if hasattr(attn, 'update_quant_config'):
+            # Case 1: leaf TrtllmAttention (or any module with the method).
+            attn.update_quant_config(qcfg)
+        else:
+            # Case 2: Attention wrapper (e.g. QKNormRoPEAttention / Qwen3Attention).
+            # Update the wrapper's quant_config so attention.py reads kv_scales_sf.
+            attn.quant_config = qcfg
+            # Update the inner TrtllmAttention so the C++ wrapper uses the right
+            # quantMode when computing intraPoolOffset / cacheElemBits.
+            inner = getattr(attn, 'attn', None)
+            if inner is not None and hasattr(inner, 'update_quant_config'):
+                inner.update_quant_config(qcfg)
+
+        # For NVFP4 KV cache with BF16 model weights: qkv_proj may lack
+        # kv_scales / inv_kv_scales because they are only added at Linear
+        # creation time when the quant config already has fp4_kv_cache set.
+        # Inject identity-scale tensors so the attention forward succeeds.
+        if mode.has_fp4_kv_cache():
+            qkv_proj = getattr(attn, 'qkv_proj', None)
+            if qkv_proj is not None and not hasattr(qkv_proj, 'kv_scales'):
+                # Determine device from an existing model parameter.
+                try:
+                    dev = next(attn.parameters()).device
+                except StopIteration:
+                    dev = torch.device('cuda')
+                qkv_proj.kv_scales = Parameter(
+                    torch.ones(3, dtype=torch.float32, device=dev),
+                    requires_grad=False)
+                qkv_proj.inv_kv_scales = Parameter(
+                    torch.ones(3, dtype=torch.float32, device=dev),
+                    requires_grad=False)
+
+
+def _get_attention_module(model, layer_idx: int):
+    """Walk model.layers[layer_idx] to find the self-attention module.
+
+    Handles flat models (model.layers), single-wrapped models
+    (model.{model,llm}.layers), and double-wrapped VL models
+    (model.llm.model.layers, e.g. Qwen3VLForConditionalGeneration wrapping
+    Qwen3ForCausalLM wrapping Qwen3Model).
+    """
+    layers = getattr(model, 'layers', None)
+    if layers is None:
+        for first_attr in ('model', 'llm'):
+            inner = getattr(model, first_attr, None)
+            if inner is None:
+                continue
+            layers = getattr(inner, 'layers', None)
+            if layers is not None:
+                break
+            # Two levels: VL wrapper -> ForCausalLM -> inner Model
+            inner2 = getattr(inner, 'model', None)
+            if inner2 is not None:
+                layers = getattr(inner2, 'layers', None)
+                if layers is not None:
+                    break
+    if layers is None or layer_idx >= len(layers):
+        return None
+    layer = layers[layer_idx]
+    for attr in ('self_attn', 'self_attention', 'attention', 'attn'):
+        attn = getattr(layer, attr, None)
+        if attn is not None:
+            return attn
+    return None
+
+
 def _create_kv_cache_manager(
         model_engine: Optional[PyTorchModelEngine],
         kv_cache_manager_cls,
@@ -936,6 +1082,26 @@ def _create_kv_cache_manager(
 
     # Use provided num_layers if available, otherwise use config
     num_hidden_layers = num_layers if num_layers is not None else config.num_hidden_layers
+
+    # --- Mixed-precision per-layer KV cache ---
+    # If the dtype spec is a per-layer mapping (dict or range syntax like
+    # "0-3:fp8,4-35:nvfp4"), resolve it now and pass as per_layer_dtype to
+    # the standard KVCacheManager constructor.  The single manager handles all
+    # layer groups; no wrapper is needed.
+    per_layer_dtype_map: dict[int, "tensorrt_llm.bindings.DataType"] | None = None
+    if not is_mla(config):
+        raw_dtype_spec = kv_cache_config.dtype
+        if isinstance(raw_dtype_spec, (dict, str)) and (
+                isinstance(raw_dtype_spec, dict)
+                or ":" in str(raw_dtype_spec)):
+            per_layer_dtype_map = _resolve_per_layer_dtype(
+                raw_dtype_spec, num_hidden_layers, quant_config, kv_cache_dtype)
+            unique_dtypes = set(per_layer_dtype_map.values())
+            if len(unique_dtypes) == 1:
+                # Uniform — collapse to global dtype; no per-layer map needed.
+                (kv_cache_dtype, ) = unique_dtypes
+                per_layer_dtype_map = None
+
     # Only include draft KV heads in the per-layer list when draft layers
     # are NOT handled by a separate draft KV cache manager.  When layer_mask
     # is provided from the caller, it means the main KV cache covers only
@@ -1145,7 +1311,13 @@ def _create_kv_cache_manager(
             is_estimating_kv_cache=estimating_kv_cache,
             execution_stream=execution_stream,
             layer_mask=layer_mask,
+            per_layer_dtype=per_layer_dtype_map,
         )
+
+    if per_layer_dtype_map and model_engine is not None:
+        _apply_per_layer_kv_quant_config(model_engine.model, per_layer_dtype_map,
+                                         quant_config)
+
     return kv_cache_manager
 
 

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -76,6 +76,16 @@ def validate_and_set_kv_cache_quant(model_config: ModelConfig,
             "checkpoint KV quantization.")
         return
 
+    # Per-layer mixed-precision spec (e.g. "0-1:fp8,2-35:nvfp4" or a dict).
+    # Per-layer quant config is applied later by _apply_per_layer_kv_quant_config;
+    # skip global override here.
+    if isinstance(pyt_kv_cache_dtype, dict) or (
+            isinstance(pyt_kv_cache_dtype, str) and ":" in pyt_kv_cache_dtype):
+        logger.info(
+            f'Per-layer mixed KV cache dtype spec "{pyt_kv_cache_dtype}" detected; '
+            "skipping global quant override.")
+        return
+
     # If we have an invalid quantization, simply raise an exception.
     if not valid_pyt_quant:
         raise ValueError(

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -290,10 +290,12 @@ class KVCacheManager(BaseResourceManager):
         is_estimating_kv_cache: bool = False,
         execution_stream: Optional[torch.cuda.Stream] = None,
         linear_attention_metadata: Optional[LinearAttentionMetadata] = None,
+        per_layer_dtype: dict[int, DataType] | None = None,
         **kwargs,
     ) -> None:
         self.mapping = mapping
         self.dtype = dtype
+        self.per_layer_dtype = per_layer_dtype
         self.kv_cache_type = kv_cache_type
         self.pp_layers, self.num_layers = get_pp_layers(
             num_layers,
@@ -557,6 +559,8 @@ class KVCacheManager(BaseResourceManager):
             'indexer_k_cache_index_head_dim': indexer_k_cache_index_head_dim,
             'linear_attention_metadata': linear_attention_metadata
         }
+        if per_layer_dtype:
+            kwargs['per_layer_dtype'] = per_layer_dtype
 
         if self.event_buffer_max_size > 0:
             if mapping.enable_attention_dp:
@@ -591,6 +595,21 @@ class KVCacheManager(BaseResourceManager):
         self.max_blocks_per_seq = self.impl.max_blocks_per_seq
         self.enable_block_reuse = kv_cache_config.enable_block_reuse
         self.enable_partial_reuse = kv_cache_config.enable_partial_reuse
+
+        pool_bytes = (self.blocks_in_primary_pool * self.tokens_per_block *
+                      self.get_cache_bytes_per_token())
+        layer_list = self.pp_layers
+        if layer_list:
+            layer_str = (f"{layer_list[0]}-{layer_list[-1]}"
+                         if len(layer_list) > 1 else str(layer_list[0]))
+        else:
+            layer_str = "(none)"
+        logger.info(
+            f"KV cache pool: dtype={self.dtype}, layers=[{layer_str}], "
+            f"num_layers={len(layer_list)}, "
+            f"pool_size={pool_bytes / (1 << 30):.2f} GiB "
+            f"({self.blocks_in_primary_pool} blocks × {self.tokens_per_block} tokens/block)")
+
         self.host_kv_cache_block_offsets = torch.empty(
             self.num_pools,
             max_batch_size * max_beam_width,
@@ -1001,11 +1020,32 @@ class KVCacheManager(BaseResourceManager):
         return mem_per_token
 
     def get_cache_bytes_per_token(self):
+        supported_dtypes = (DataType.FP8, DataType.HALF, DataType.BF16,
+                            DataType.FLOAT, DataType.NVFP4)
+
+        if self.per_layer_dtype:
+            total_bytes = 0
+            for local_idx, global_idx in enumerate(self.pp_layers):
+                layer_dtype = self.per_layer_dtype.get(global_idx, self.dtype)
+                if layer_dtype not in supported_dtypes:
+                    raise ValueError(
+                        f'Cannot support {layer_dtype} KV cache on layer {global_idx}.'
+                    )
+                layer_kv_heads = self.num_kv_heads_per_layer[local_idx]
+                cache_size = self.kv_factor * layer_kv_heads * self.head_dim
+                layer_bytes = get_size_in_bytes(cache_size, layer_dtype)
+                if layer_dtype == DataType.NVFP4:
+                    layer_bytes += self.calculate_scaling_factor_size_bytes(
+                        cache_size,
+                        quant_vector_size=16,
+                        scaling_factor_dtype=DataType.FP8)
+                total_bytes += layer_bytes
+            return total_bytes
+
         cache_size_per_token = self.kv_factor * sum(
             self.num_kv_heads_per_layer) * self.head_dim
 
-        if self.dtype not in (DataType.FP8, DataType.HALF, DataType.BF16,
-                              DataType.FLOAT, DataType.NVFP4):
+        if self.dtype not in supported_dtypes:
             raise ValueError(f'Cannot support {self.dtype} KV cache.')
 
         cache_size_bytes_per_token = get_size_in_bytes(cache_size_per_token,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2378,6 +2378,61 @@ SparseAttentionConfig: TypeAlias = Annotated[
 ]
 
 
+def parse_kv_cache_dtype_spec(
+        spec: Union[str, Dict[int, str]],
+        num_layers: int) -> Dict[int, str]:
+    """Parse a KV cache dtype specification into a per-layer dict.
+
+    Supported formats:
+    - Plain string (no colon): uniform dtype for all layers, e.g. "fp8"
+    - Range-syntax string: "0-1:fp8,2-35:nvfp4"
+    - Dict: {0: "fp8", 2: "nvfp4"} — missing layers default to "auto"
+
+    Returns a full mapping {layer_idx: dtype_str} for all num_layers layers.
+    """
+    result: Dict[int, str] = {i: "auto" for i in range(num_layers)}
+
+    if isinstance(spec, dict):
+        for k, v in spec.items():
+            if not (0 <= k < num_layers):
+                raise ValueError(
+                    f"Layer index {k} out of range [0, {num_layers})")
+            result[k] = v
+        return result
+
+    # String spec
+    if ":" not in spec:
+        # Uniform dtype
+        return {i: spec for i in range(num_layers)}
+
+    # Range syntax: "0-1:fp8,2-35:nvfp4"
+    for segment in spec.split(","):
+        segment = segment.strip()
+        if ":" not in segment:
+            raise ValueError(
+                f"Invalid per-layer dtype segment '{segment}'. "
+                "Expected format 'start-end:dtype' or 'idx:dtype'.")
+        range_part, dtype_str = segment.rsplit(":", 1)
+        dtype_str = dtype_str.strip()
+        range_part = range_part.strip()
+        if "-" in range_part:
+            parts = range_part.split("-", 1)
+            start, end = int(parts[0]), int(parts[1])
+            if start > end:
+                raise ValueError(
+                    f"Invalid range '{range_part}': start ({start}) must not "
+                    f"exceed end ({end}).")
+        else:
+            start = end = int(range_part)
+        for i in range(start, end + 1):
+            if not (0 <= i < num_layers):
+                raise ValueError(
+                    f"Layer index {i} out of range [0, {num_layers})")
+            result[i] = dtype_str
+
+    return result
+
+
 @PybindMirror.mirror_pybind_fields(_KvCacheConfig)
 class KvCacheConfig(StrictBaseModel, PybindMirror):
     """
@@ -2461,10 +2516,19 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
     )
 
     # This is a pure python field, not a pybind field. It is only for the Pytorch backend.
-    dtype: str = Field(
+    # Accepts a uniform dtype string ("auto", "fp8", "nvfp4", …) OR a per-layer
+    # range-syntax string ("0-1:fp8,2-35:nvfp4") OR a dict mapping layer index
+    # to dtype string ({0: "fp8", 2: "nvfp4"}).
+    dtype: Union[str, Dict[int, str]] = Field(
         default="auto",
-        description=
-        "The data type to use for the KV cache. Use 'auto' to follow checkpoint metadata, otherwise force the specified dtype."
+        description=(
+            "The data type to use for the KV cache. "
+            "Use 'auto' to follow checkpoint metadata. "
+            "For uniform precision use a dtype string (e.g. 'fp8', 'nvfp4'). "
+            "For per-layer mixed precision use a range-syntax string "
+            "(e.g. '0-1:fp8,2-35:nvfp4') or a dict mapping layer index to "
+            "dtype string (e.g. {0: 'fp8', 2: 'nvfp4'})."
+        )
     )
 
     # This is a pure python field, not a pybind field. It is only for the Pytorch backend.
@@ -2545,14 +2609,45 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
 
     @field_validator('dtype')
     @classmethod
-    def validate_dtype(cls, v: str):
-        v = v.lower()
-        if v in ("auto", "fp8",
-                 "nvfp4") or v in _str_to_torch_dtype_dict.keys():
+    def validate_dtype(cls, v):
+        # Dtype tokens that are valid for per-layer KV cache specs.
+        # Must stay in sync with _dtype_str_to_binding() in _util.py.
+        _VALID_PER_LAYER_TOKENS = {
+            "auto", "fp8", "float8", "nvfp4", "fp4",
+            "fp16", "float16", "bf16", "bfloat16",
+        }
+
+        def _check_token(token: str, context: str) -> None:
+            if token.lower() not in _VALID_PER_LAYER_TOKENS:
+                raise ValueError(
+                    f"Unsupported KV cache dtype '{token}' in {context}. "
+                    f"Allowed values: {sorted(_VALID_PER_LAYER_TOKENS)}")
+
+        if isinstance(v, dict):
+            for k, val in v.items():
+                _check_token(str(val), f"per-layer dict key {k}")
             return v
 
+        v_lower = v.lower()
+        # Uniform string: "auto", "fp8", "nvfp4", or a plain torch dtype like "float16".
+        if v_lower in ("auto", "fp8", "nvfp4") or v_lower in _str_to_torch_dtype_dict.keys():
+            return v_lower
+
+        # Per-layer range syntax: "0-1:fp8,2-35:nvfp4"
+        if ":" in v_lower:
+            for segment in v_lower.split(","):
+                segment = segment.strip()
+                if ":" not in segment:
+                    raise ValueError(
+                        f"Invalid per-layer dtype segment '{segment}'. "
+                        "Expected format 'start-end:dtype' or 'idx:dtype'.")
+                _, dtype_token = segment.rsplit(":", 1)
+                _check_token(dtype_token.strip(), f"segment '{segment}'")
+            return v_lower
+
         raise ValueError(
-            'kv_cache_config.dtype must be one of "auto", "fp8", "nvfp4", or valid torch.dtype string'
+            'kv_cache_config.dtype must be one of "auto", "fp8", "nvfp4", '
+            'a valid torch.dtype string, or a per-layer range spec like "0-1:fp8,2-35:nvfp4"'
         )
 
     @field_validator('max_gpu_total_bytes')

--- a/tests/unittest/llmapi/test_kv_cache_dtype_override.py
+++ b/tests/unittest/llmapi/test_kv_cache_dtype_override.py
@@ -65,3 +65,14 @@ def test_update_from_hf_quant_config_explicit_dtype_overrides(tmp_path):
 
     assert model_loader._update_from_hf_quant_config() is True
     assert llm_args.quant_config.kv_cache_quant_algo == QuantAlgo.NVFP4
+
+
+def test_kv_cache_config_range_dtype_passes_validation():
+    cfg = KvCacheConfig(dtype="0-3:fp8,4-35:nvfp4")
+    assert cfg.dtype == "0-3:fp8,4-35:nvfp4"
+
+
+def test_kv_cache_config_descending_range_raises():
+    with pytest.raises(ValueError, match="start.*must not exceed end"):
+        from tensorrt_llm.llmapi.llm_args import parse_kv_cache_dtype_spec
+        parse_kv_cache_dtype_spec("5-2:fp8", num_layers=36)

--- a/tests/unittest/llmapi/test_kv_cache_dtype_spec.py
+++ b/tests/unittest/llmapi/test_kv_cache_dtype_spec.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from tensorrt_llm.llmapi.llm_args import parse_kv_cache_dtype_spec
+
+
+def test_uniform_string():
+    result = parse_kv_cache_dtype_spec("fp8", num_layers=4)
+    assert result == {0: "fp8", 1: "fp8", 2: "fp8", 3: "fp8"}
+
+
+def test_range_syntax():
+    result = parse_kv_cache_dtype_spec("0-3:fp8,4-35:nvfp4", num_layers=36)
+    for i in range(4):
+        assert result[i] == "fp8"
+    for i in range(4, 36):
+        assert result[i] == "nvfp4"
+
+
+def test_single_index_syntax():
+    result = parse_kv_cache_dtype_spec("2:fp8", num_layers=4)
+    assert result[2] == "fp8"
+    for i in (0, 1, 3):
+        assert result[i] == "auto"
+
+
+def test_dict_input_passthrough():
+    spec = {0: "fp8", 35: "nvfp4"}
+    result = parse_kv_cache_dtype_spec(spec, num_layers=36)
+    assert result[0] == "fp8"
+    assert result[35] == "nvfp4"
+    assert result[1] == "auto"
+
+
+def test_descending_range_raises():
+    with pytest.raises(ValueError, match="start.*must not exceed end"):
+        parse_kv_cache_dtype_spec("5-2:fp8", num_layers=36)
+
+
+def test_out_of_range_layer_raises():
+    with pytest.raises(ValueError, match="out of range"):
+        parse_kv_cache_dtype_spec("0-40:fp8", num_layers=36)
+
+
+def test_missing_colon_in_segment_raises():
+    # The full spec has a colon (triggers range parsing), but one segment is missing it.
+    with pytest.raises(ValueError, match="Invalid per-layer dtype segment"):
+        parse_kv_cache_dtype_spec("0-3,4-35:fp8", num_layers=36)
+
+
+def test_dict_out_of_range_raises():
+    with pytest.raises(ValueError, match="out of range"):
+        parse_kv_cache_dtype_spec({100: "fp8"}, num_layers=36)


### PR DESCRIPTION
Extends KVCacheManager to support per-layer KV cache dtypes (e.g., 0-3:fp8,4-35:nvfp4) by grouping pools in WindowBlockManager by (numKvHeads, dtype) instead of numKvHeads alone, replacing the previous MixedPrecisionKVCacheManager wrapper with a single unified manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-layer mixed-precision KV cache support, enabling different layers to use different data types (FP8, NVFP4, FP16, BF16) for optimized performance.
  * Extended KvCacheConfig to accept per-layer dtype specifications via range syntax (e.g., "0-3:fp8,4-35:nvfp4") or dictionary mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

  This PR extends `KVCacheManager` to support **mixed-precision per-layer KV cache**: different transformer layers can store K/V tensors in different dtypes (e.g., FP8 for early layers and NVFP4 for later layers) within a single unified manager.

  ### Motivation

Hybrid-quantized models (e.g., FP8-weight + partial NVFP4 KV cache, or MLA layers needing a different KV precision than dense layers) previously required a separate wrapper class (`MixedPrecisionKVCacheManager`) that duplicated pool-management logic and was hard to maintain. This PR folds the feature into the core `KVCacheManager` by treating dtype as a first-class pool-grouping dimension.

**Evaluation: nvidia/Qwen3-8B-FP8 on GPQA**
| KV Cache Config | GPQA Score |
|---|---|
| All FP8 | 0.5513 |
| All FP4 | 0.5295 |
| First 3 layers FP8, rest FP4 | **0.5547** |



## Test Coverage
  **New file: `tests/unittest/llmapi/test_kv_cache_dtype_spec.py`** (7 unit tests)
  - Uniform string spec expands to all layers correctly.
  - Range syntax `"0-3:fp8,4-35:nvfp4"` maps each layer to the right dtype.
  - Single-index syntax `"2:fp8"` sets one layer and defaults the rest to `"auto"`.
  - Dict input passthrough preserves explicit entries and fills missing with `"auto"`.
  - Descending range `"5-2:fp8"` raises `ValueError`.
  - Out-of-range layer index raises `ValueError`.
  - Missing colon in a range segment raises `ValueError`.
  **Additions to `tests/unittest/llmapi/test_kv_cache_dtype_override.py`** (2 new tests)
  - `KvCacheConfig(dtype="0-3:fp8,4-35:nvfp4")` passes field validation.
  - `parse_kv_cache_dtype_spec("5-2:fp8", num_layers=36)` raises on descending range.
  - 
## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
