### PR TITLE
[None][fix] Fix Qwen3.5 NVFP4 weight loading by preserving weight_scales

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
@@ -61,15 +61,21 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         return normalized_weights
 
     def _preprocess_modelopt_ckpt(self, weights: dict) -> tuple[bool, dict]:
+        nvfp4_prefixes = {
+            key[: -len(".weight_scale_2")] for key in weights if key.endswith(".weight_scale_2")
+        }
+
         remapped_weights = {}
         is_modelopt_ckpt = False
         for key, tensor in weights.items():
             new_key = key
             if key.endswith(".weight_scale"):
                 is_modelopt_ckpt = True
-                new_key = f"{key}_inv"
-                # modelopt fp8_pb_wo has 2 extra singleton dimensions
-                tensor = tensor.squeeze(1).squeeze(-1)
+                prefix = key[: -len(".weight_scale")]
+                if prefix not in nvfp4_prefixes:
+                    new_key = f"{key}_inv"
+                    # modelopt fp8_pb_wo has 2 extra singleton dimensions
+                    tensor = tensor.squeeze(1).squeeze(-1)
             if new_key in remapped_weights:
                 raise ValueError(f"Duplicate remapped key found: {new_key}")
             remapped_weights[new_key] = tensor


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen 3.5 model checkpoint loading with enhanced detection and processing of different ModelOpt checkpoint formats, providing better support for nvfp4-style checkpoints and ensuring proper handling of model weight parameters throughout the checkpoint loading process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

_preprocess_modelopt_ckpt was blindly renaming all weight_scale keys to weight_scale_inv, which is correct for FP8 but breaks NVFP4 since NVFP4LinearMethod.load_weight_scales expects weight_scale. Detect NVFP4 layers by the presence of weight_scale_2 and skip the renaming for those.

## Test Coverage

TestQwen3_5_379B_A17B

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
