### PR TITLE
[None][test] Add Wan 2.2 5B TI2V pipeline test in CI

### DIFF
--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -193,6 +193,7 @@ l0_b200:
   - unittest/_torch/visual_gen/test_wan21_t2v_pipeline.py
   - unittest/_torch/visual_gen/test_wan22_i2v_pipeline.py
   - unittest/_torch/visual_gen/test_wan22_t2v_pipeline.py
+  - unittest/_torch/visual_gen/test_wan22_ti2v_5b_pipeline.py
   - unittest/_torch/visual_gen/test_wan21_i2v_teacache.py
   - unittest/_torch/visual_gen/test_wan21_t2v_teacache.py
   - unittest/_torch/visual_gen/test_wan_transformer.py


### PR DESCRIPTION
## Description

PR #13256 added a new unit test `tests/unittest/_torch/visual_gen/test_wan22_ti2v_5b_pipeline.py` for the Wan 2.2 5B TI2V model, but did not register it in any test list. As a result the test is not exercised by pre-merge or nightly CI.

This PR adds a single line to `tests/integration/test_lists/test-db/l0_b200.yml`, alongside the existing `test_wan22_i2v_pipeline.py` / `test_wan22_t2v_pipeline.py` entries, so the new test runs on B200.

## Test Coverage

- New: `unittest/_torch/visual_gen/test_wan22_ti2v_5b_pipeline.py` will now run in the B200 unit-test stage.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] Follows TRT-LLM coding guidelines.
- [x] Test cases are provided for new code paths (this PR is the test-list registration itself).
- [x] No new dependencies.
- [x] CODEOWNERS unaffected.
- [x] Documentation unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage with additional test cases to the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->