### PR TITLE
[None][chore] Update flashinfer-python from 0.6.9 to 0.6.10

### DIFF
--- a/ATTRIBUTIONS-Python.md
+++ b/ATTRIBUTIONS-Python.md
@@ -5261,7 +5261,7 @@ For more information, please refer to <http://unlicense.org>
   - `Tracker`: https://github.com/tox-dev/py-filelock/issues
 
 
-## flashinfer-python (0.6.9)
+## flashinfer-python (0.6.10)
 
 ### Licenses
 License: `Apache-2.0`

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ ordered-set
 peft>=0.18.1,<0.19.0
 patchelf
 einops
-flashinfer-python==0.6.9
+flashinfer-python==0.6.10
 opencv-python-headless
 xgrammar==0.1.32
 llguidance==0.7.29

--- a/security_scanning/pyproject.toml
+++ b/security_scanning/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "peft (>=0.18.1,<0.19.0)",
     "patchelf (>=0.17.2.4,<0.18.0.0)",
     "einops (>=0.8.2,<0.9.0)",
-    "flashinfer-python (==0.6.9)",
+    "flashinfer-python (==0.6.10)",
     "opencv-python-headless (>=4.13.0.92,<5.0.0.0)",
     "xgrammar (==0.1.32)",
     "llguidance (==0.7.29)",

--- a/tensorrt_llm/_torch/speculative/interface.py
+++ b/tensorrt_llm/_torch/speculative/interface.py
@@ -7,6 +7,7 @@ from enum import IntEnum, auto
 from typing import TYPE_CHECKING, List, Optional, Type
 
 import torch
+from packaging.version import Version
 from torch import nn
 
 from tensorrt_llm.logger import logger
@@ -517,7 +518,8 @@ class SpecWorkerBase(nn.Module, ABC):
         super().__init__()
         self.guided_decoder: Optional["CapturableGuidedDecoder"] = None
         self.force_num_accepted_tokens = get_force_num_accepted_tokens()
-        self.use_flashinfer = IS_FLASHINFER_AVAILABLE and flashinfer.__version__ >= "0.6.4"
+        self.use_flashinfer = IS_FLASHINFER_AVAILABLE and Version(
+            flashinfer.__version__) >= Version("0.6.4")
         self.seed: Optional[torch.Tensor] = None
         self.offset: Optional[torch.Tensor] = None
         self.use_separate_draft_kv_cache = use_separate_draft_kv_cache


### PR DESCRIPTION
## Summary
- Bump flashinfer-python from 0.6.9 to 0.6.10 (latest stable, released 2026-05-04).
- Update version pins in `requirements.txt`, `security_scanning/pyproject.toml`, `security_scanning/poetry.lock`, and `ATTRIBUTIONS-Python.md`.
- Replace string version comparison with `packaging.version.Version` in `tensorrt_llm/_torch/speculative/interface.py` so the `>= 0.6.4` gate evaluates correctly. Lexicographic compare gave `"0.6.10" >= "0.6.4"` → False, which would have silently disabled flashinfer in `SpecWorkerBase` after the bump.

## Test plan
- [x] `pip install -r requirements.txt` installs successfully
- [x] `pytest tests/unittest/_torch/flashinfer/ -v`
- [x] `pytest tests/unittest/_torch/attention/test_flashinfer_attention.py -v`
- [x] CI pre-merge passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated flashinfer-python dependency to version 0.6.10 across all project configurations.

* **Bug Fixes**
  * Improved version compatibility checking to use proper semantic versioning comparison for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->