### PR TITLE
[https://nvbugs/5615248][fix] Reduce beam-search prefill->decode handoff cost

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -1422,7 +1422,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         def update_for_new_request(
             self,
             *,
-            seq_slots_cuda: torch.Tensor,
+            seq_slots_cuda_long: torch.Tensor,
             max_lengths_cuda: torch.Tensor,
             end_ids_cuda: torch.Tensor,
             seq_slots_host: torch.Tensor,
@@ -1436,8 +1436,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             need to be re-processed.
 
             Args:
-                seq_slots_cuda: The sequence slots of the processed requests. Used for accessing device buffers.
-                  Shape: [len(requests)]
+                seq_slots_cuda_long: The sequence slots of the processed requests, as int64
+                  CUDA indices (required by ``index_copy_``). Shape: [len(requests)]
                 max_lengths_cuda: The maximum lengths for each request.
                   Shape: [len(requests)]
                 end_ids_cuda: The end ids for each request.
@@ -1450,8 +1450,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
 
             temp_data = self._temp_data
             store = self.store
-            store.max_lengths_cuda[seq_slots_cuda] = max_lengths_cuda
-            store.end_ids_cuda[seq_slots_cuda] = end_ids_cuda
+            store.max_lengths_cuda.index_copy_(0, seq_slots_cuda_long, max_lengths_cuda)
+            store.end_ids_cuda.index_copy_(0, seq_slots_cuda_long, end_ids_cuda)
             store.max_stop_word_lengths_host[seq_slots_host] = torch.tensor(
                 temp_data.max_stop_word_lengths, device="cpu", dtype=torch.int32
             )
@@ -2036,6 +2036,14 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         """Shape: batch_size, beam_width, sequence_length
            Usage: Stores the original tokens for each beam.
            This is used to recover the original tokens for each beam when streaming is enabled"""
+        seq_offsets: torch.Tensor
+        """Shape: (max_num_sequences,), dtype int64
+           Usage: Cached `arange(max_num_sequences) * max_beam_width` used by
+           ``beam_search_sampling_batch`` to flatten (batch_idx, beam_idx) pairs."""
+        beam_idx_arange: torch.Tensor
+        """Shape: (max_beam_width,), dtype int32
+           Usage: Cached `arange(max_beam_width)` used as the scatter source in the
+           per-step ``cache_indirection.scatter_``."""
 
     @dataclass(kw_only=True)
     class LogProbsStore:
@@ -2103,6 +2111,11 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             predecessor_beams = int_tensor(self.CACHE_INDIRECTION_SHAPE[:-1])
             original_tokens = int_tensor(self.CACHE_INDIRECTION_SHAPE)
             first_finish_reasons = int_tensor(self.CACHE_INDIRECTION_SHAPE[:-1])
+            seq_offsets = (
+                torch.arange(self.max_num_sequences, device="cuda", dtype=torch.int64)
+                * self.max_beam_width
+            )
+            beam_idx_arange = torch.arange(self.max_beam_width, device="cuda", dtype=torch.int32)
             beam_search_store = self.BeamSearchStore(
                 cache_indirection=cache_indirection,
                 cache_indirection_buffer=cache_indirection_buffer,
@@ -2110,6 +2123,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                 predecessor_beams=predecessor_beams,
                 original_tokens=original_tokens,
                 first_finish_reasons=first_finish_reasons,
+                seq_offsets=seq_offsets,
+                beam_idx_arange=beam_idx_arange,
             )
         return self.Store(
             new_tokens=new_tokens,
@@ -2746,8 +2761,12 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         seq_slots_tensor_cuda = full_list_tensor_cuda[0]
         max_lens_tensor_cuda = full_list_tensor_cuda[1]
         end_ids_tensor_cuda = full_list_tensor_cuda[2]
+
+        # Cast to int64 once for downstream ``index_copy_`` / ``index_fill_`` calls.
+        seq_slots_tensor_cuda_long = seq_slots_tensor_cuda.long()
+
         self._finish_reasons_handler.update_for_new_request(
-            seq_slots_cuda=seq_slots_tensor_cuda,
+            seq_slots_cuda_long=seq_slots_tensor_cuda_long,
             max_lengths_cuda=max_lens_tensor_cuda,
             end_ids_cuda=end_ids_tensor_cuda,
             seq_slots_host=seq_slots_tensor_host,
@@ -2760,7 +2779,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
             self._prepare_beam_search(
                 beam_search_store,
                 self.store.log_probs_store,
-                seq_slots=seq_slots_tensor_cuda,
+                seq_slots_long=seq_slots_tensor_cuda_long,
                 max_prompt_len=max_prompt_len,
             )
 
@@ -2768,60 +2787,27 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
     def _prepare_beam_search(
         beam_search_store: BeamSearchStore,
         log_probs_store: LogProbsStore,
-        seq_slots: torch.Tensor,
+        seq_slots_long: torch.Tensor,
         max_prompt_len: int,
     ) -> None:
         """Prepare the beam search buffers for the requests
 
         If the last context chunk is being processed,
-        initialize/reset the buffers for the request
+        initialize/reset the buffers for the request.
+
+        ``seq_slots_long`` must be int64 (required by ``index_fill_``).
         """
-        cache_indirection = beam_search_store.cache_indirection
-        cache_indirection[seq_slots, :, :max_prompt_len] = torch.zeros(
-            (1),
-            dtype=cache_indirection.dtype,
-            device=cache_indirection.device,
+        beam_search_store.cache_indirection.narrow(2, 0, max_prompt_len).index_fill_(
+            0, seq_slots_long, 0
         )
-        cum_log_probs = beam_search_store.cum_log_probs
-        cum_log_probs[seq_slots] = torch.zeros(
-            (1,),
-            dtype=cum_log_probs.dtype,
-            device=cum_log_probs.device,
+        beam_search_store.cum_log_probs.index_fill_(0, seq_slots_long, 0)
+        log_probs_store.sampled_log_probs.index_fill_(0, seq_slots_long, 0)
+        log_probs_store.sampled_log_prob_ranks.index_fill_(0, seq_slots_long, 0)
+        beam_search_store.predecessor_beams.index_fill_(0, seq_slots_long, 0)
+        beam_search_store.first_finish_reasons.index_fill_(
+            0, seq_slots_long, FinishReason.NOT_FINISHED.value
         )
-        sampled_log_probs = log_probs_store.sampled_log_probs
-        sampled_log_probs[seq_slots] = torch.zeros(
-            (1,),
-            dtype=sampled_log_probs.dtype,
-            device=sampled_log_probs.device,
-        )
-        sampled_log_prob_ranks = log_probs_store.sampled_log_prob_ranks
-        sampled_log_prob_ranks[seq_slots] = torch.zeros(
-            (1,),
-            dtype=sampled_log_prob_ranks.dtype,
-            device=sampled_log_prob_ranks.device,
-        )
-        predecessor_beams = beam_search_store.predecessor_beams
-        predecessor_beams[seq_slots] = torch.zeros(
-            (1,),
-            dtype=predecessor_beams.dtype,
-            device=predecessor_beams.device,
-        )
-        first_finish_reasons = beam_search_store.first_finish_reasons
-        first_finish_reasons[seq_slots] = (
-            torch.tensor(
-                FinishReason.NOT_FINISHED.value,
-                pin_memory=prefer_pinned(),
-                dtype=first_finish_reasons.dtype,
-            )
-            .to(first_finish_reasons.device, non_blocking=True)
-            .unsqueeze(0)
-        )
-        original_tokens = beam_search_store.original_tokens
-        original_tokens[seq_slots] = torch.zeros(
-            (1,),
-            dtype=original_tokens.dtype,
-            device=original_tokens.device,
-        )
+        beam_search_store.original_tokens.index_fill_(0, seq_slots_long, 0)
 
     @torch.inference_mode()
     def _process_draft_tokens_rejection_sampling(
@@ -3231,6 +3217,8 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                     ),  # Should be on device for beam search
                     finished_beams=beam_search_store.first_finish_reasons,
                     predecessor_beams=beam_search_store.predecessor_beams,
+                    seq_offsets=beam_search_store.seq_offsets,
+                    beam_idx_arange=beam_search_store.beam_idx_arange,
                 )
             elif metadata_type is None:
                 metadata = None

--- a/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampling_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,6 +64,11 @@ class BeamSearchMetadata(StrategyMetadata):
     seq_lens: torch.Tensor
     finished_beams: torch.Tensor
     predecessor_beams: torch.Tensor
+    # Pre-computed indexer constants sliced (not allocated) per call.
+    # seq_offsets[i] = i * max_beam_width, shape (max_num_sequences,), int64.
+    # beam_idx_arange[j] = j, shape (max_beam_width,), int32.
+    seq_offsets: torch.Tensor
+    beam_idx_arange: torch.Tensor
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -361,10 +366,9 @@ def beam_search_sampling_batch(
     max_beam_width = beam_search_args.finished_beams.size(1)
     finished_beams = beam_search_args.finished_beams[beam_search_args.seq_slots].view(-1)
 
-    offset_predecessor_beam = predecessor_beam + (
-        torch.arange(predecessor_beam.size(0), device=predecessor_beam.device).unsqueeze(1)
-        * max_beam_width
-    )
+    offset_predecessor_beam = predecessor_beam + beam_search_args.seq_offsets[
+        : predecessor_beam.size(0)
+    ].unsqueeze(1)
     finished_beams = finished_beams[offset_predecessor_beam]
     beam_search_args.finished_beams[beam_search_args.seq_slots] = finished_beams.view(
         batch_size, max_beam_width
@@ -385,19 +389,15 @@ def beam_search_sampling_batch(
         out=cache_indirection,
     )
 
-    # Prepare target values
-    target_values = (
-        torch.arange(
-            beam_width_out * batch_size, device=cache_indirection.device, dtype=torch.int32
-        )
-        % beam_width_out
-    )
-
     # seq lens is of shape (batch_size), we assume all beams have the same seq len
     # therefore we can use expand
     index = beam_search_args.seq_lens.view(-1, 1, 1).expand(-1, beam_width_out, 1)
     # index is of shape (batch_size, beam_width, 1)
-    src = target_values.view(batch_size, beam_width_out, 1)
+    src = (
+        beam_search_args.beam_idx_arange[:beam_width_out]
+        .view(1, beam_width_out, 1)
+        .expand(batch_size, beam_width_out, 1)
+    )
     # src is of shape (batch_size, beam_width, 1)
     # cache_indirection is of shape (batch_size, beam_width, max_seq_len)
     cache_indirection.scatter_(2, index, src)

--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -488,6 +488,10 @@ def test_beam_search_sampling_batch_basic():
     new_log_probs_result = new_log_probs.clone()
     predecessor_beams_result = predecessor_beams.clone()
 
+    # Pre-computed per-step constants (matches production cache contract).
+    seq_offsets = torch.arange(max_batch_size, dtype=torch.int64) * beam_width
+    beam_idx_arange = torch.arange(beam_width, dtype=torch.int32)
+
     # Create BeamSearchMetadata
     beam_search_args = BeamSearchMetadata(
         cache_indirection=cache_indirection_result,
@@ -498,6 +502,8 @@ def test_beam_search_sampling_batch_basic():
         finished_beams=finished_beams_result,
         new_log_probs=new_log_probs_result,
         predecessor_beams=predecessor_beams_result,
+        seq_offsets=seq_offsets,
+        beam_idx_arange=beam_idx_arange,
     )
 
     # Run beam search sampling


### PR DESCRIPTION
## Description

This MR adds some optimizations on top of https://github.com/NVIDIA/TensorRT-LLM/pull/13574.

Following updates were made to speed up beam-search prefill->decode handoff. This helps TTFT.

- `_prepare_beam_search`: indexed-assign -> `Tensor.index_fill_` for the seven beam-buffer resets (21 -> 8 kernels per handoff).
- `FinishReasonsHandler.update_for_new_request`: indexed-assign -> `Tensor.index_copy_` for the max_lengths/end_ids scatters (2 -> 1 kernel each); int64 seq_slots cast hoisted once into `setup_sampler_step`.
- `BeamSearchStore` / `BeamSearchMetadata`: cache `seq_offsets` and `beam_idx_arange` once at construction so `beam_search_sampling_batch` slices them instead of re-allocating per step (4 fewer kernels per step).

Experiment vs. Baseline

### Pooled per-request  (n=80 vs n=80)

| metric | baseline mean | exp mean | Δ (ms) | Δ (%) |
|---|---:|---:|---:|---:|
| TTFT |   11.182 |   10.945 |   -0.238 |   -2.13% |
| E2E  |   84.033 |   83.680 |   -0.352 |   -0.42% |
| ITL  |    0.366 |    0.366 |   -0.001 |   -0.16% |

## Test Coverage

Existing tests updated.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal beam search sampling implementation for improved performance through more efficient tensor computation and caching.
  
* **Tests**
  * Updated beam search sampling tests to reflect internal implementation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->