### PR TITLE
[None][fix] Fix KVCacheManager constructor call in connector test helper

### DIFF
--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -9547,10 +9547,10 @@ std::unique_ptr<KVCacheManager> makeConnectorTestKVCacheManager(
     auto mgr
         = std::make_unique<KVCacheManager>(std::vector<SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock,
             blocksPerWindow, maxNumSequences, beamWidth, std::vector<BlockManager::SizeType32>{maxAttentionWindow},
-            /*tempAttentionWindowInputs*/ std::nullopt,
             /*dtype*/ nvinfer1::DataType::kHALF,
             /*sinkTokenLength*/ 0, stream,
             /*maxSequenceLength*/ maxAttentionWindow,
+            /*chunkSize*/ maxAttentionWindow,
             /*enableBlockReuse*/ true,
             /*cacheType*/ CacheType::kSELF,
             /*secondaryOffloadMinPriority*/ std::nullopt,


### PR DESCRIPTION
## Summary

- `cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp` fails to compile at HEAD because `makeConnectorTestKVCacheManager` (added by #13553) still uses the pre-#12450 `KVCacheManager` constructor signature.
- #12450 removed the `tempAttentionWindowInputs` parameter and added a required `chunkSize` parameter, and updated every other call site in this file — but missed the newly-added helper.
- This PR drops the obsolete `tempAttentionWindowInputs` argument and passes `chunkSize`, mirroring the canonical post-#12450 call at `kvCacheManagerTest.cpp:7850`.

## Reproduction (before this fix)

```
cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp:9548:43:
  required from here
/usr/include/c++/13/bits/unique_ptr.h:1070:30: error: no matching function for call to
  'tensorrt_llm::batch_manager::kv_cache_manager::KVCacheManager::KVCacheManager(
    std::vector<int>, const int&, const int&, const std::map<int, std::tuple<int, int>>&,
    const int&, const int&, std::vector<int>, const std::nullopt_t&, ...)'
```

The first overload candidate rejected `std::nullopt` for the `dtype` argument because the test was passing `tempAttentionWindowInputs` at that position.

## Test plan

- [x] C++ unit-test build succeeds (cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp compiles).
- [x] KvCacheConnector_* tests added in #13553 pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated KV cache manager testing infrastructure for improved test consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->