### PR TITLE
[TRTLLM-12453][fix] Accommodate chunked prefill in Nemotron's EVS merging logic

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2145,6 +2145,9 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         elif audios is not None:
             modality_type = "audio"
             input_ids, modality_data = self._process_audio(text_prompt, audios)
+            modality_data["evs_ids"] = (
+                input_ids[0].to(torch.int32) if self.video_pruning_rate > 0 else None
+            )
 
         # Will package inputs for language model forward in AGGREGATE mode.
         multimodal_data = {}
@@ -2514,20 +2517,26 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         if "video" not in modalities:
             return input_ids
 
-        evs_ids_lst = [
-            multimodal_data[modality]["evs_ids"]
-            for modality, multimodal_data in zip(modalities, multimodal_data_lst)
-        ]
+        evs_ids_lst = []
+        for modality, multimodal_data in zip(modalities, multimodal_data_lst, strict=True):
+            if modality not in ("image", "video", "audio"):
+                raise ValueError(f"Unsupported modality for EVS merge: {modality}")
+            evs_ids = multimodal_data[modality].get("evs_ids")
+            if evs_ids is None:
+                raise ValueError(
+                    f"Missing evs_ids for {modality} modality while merging EVS inputs."
+                )
+            evs_ids_lst.append(evs_ids)
         # Iterate over batch, replacing video_context_token_id placeholders with
         # the actual per-tubelet img_context_token counts from EVS.
         context_parts = []
         for multimodal_param, evs_ids, modality, num_tokens_in_video in zip(
-            multimodal_params, evs_ids_lst, modalities, num_tokens_in_videos
+            multimodal_params, evs_ids_lst, modalities, num_tokens_in_videos, strict=True
         ):
-            # Image modality: keep input_ids unchanged during inflight-batching.
-            if modality == "image":
+            # Image/audio modalities: keep input_ids unchanged during inflight-batching.
+            if modality in ("image", "audio"):
                 context_ids = evs_ids
-            else:
+            elif modality == "video":
                 # evs_ids is a flat 1-D tensor built at token-ID level.
                 # Find placeholder positions and replace each with the EVS count.
                 request_context_parts = []
@@ -2555,6 +2564,8 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                 if prev_end < len(evs_ids):
                     request_context_parts.append(evs_ids[prev_end:])
                 context_ids = torch.cat(request_context_parts, dim=0)
+            else:
+                raise ValueError(f"Unsupported modality for EVS merge: {modality}")
 
             runtime = multimodal_param.multimodal_runtime
             if runtime is not None:

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2506,6 +2506,101 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         self.config = self.llm.config
         self.model_config.pretrained_config = self.llm.config
 
+    def _build_evs_adjusted_context_ids(
+        self,
+        evs_ids: torch.Tensor,
+        modality: str,
+        num_tokens_in_video: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Build full per-request token IDs after EVS placeholder expansion.
+
+        Args:
+            evs_ids: Full per-request token IDs from preprocessing. For video,
+                this contains one video placeholder per tubelet before final EVS
+                expansion. For image/audio, this is already the final token ID layout.
+            modality: Request modality, one of "image", "video", or "audio".
+            num_tokens_in_video: Per-tubelet retained image-token counts after
+                EVS for video requests. Unused for image/audio requests.
+
+        Returns:
+            Full per-request token IDs with video placeholders replaced by the
+            post-EVS number of image context tokens.
+        """
+        if modality in ("image", "audio"):
+            return evs_ids
+        if modality != "video":
+            raise ValueError(f"Unsupported modality for EVS merge: {modality}")
+
+        # evs_ids is a flat 1-D tensor built at token-ID level. Replace each
+        # video placeholder with the post-EVS count for the corresponding tubelet.
+        request_context_parts = []
+        placeholder_mask = evs_ids == self.video_context_token_id
+        placeholder_positions = placeholder_mask.nonzero(as_tuple=True)[0]
+        image_idx = 0
+        prev_end = 0
+        for pos in placeholder_positions:
+            pos = pos.item()
+            if pos > prev_end:
+                request_context_parts.append(evs_ids[prev_end:pos])
+            request_context_parts.append(
+                torch.full(
+                    (int(num_tokens_in_video[image_idx]),),
+                    fill_value=self.img_context_token_id,
+                    dtype=evs_ids.dtype,
+                    device=evs_ids.device,
+                )
+            )
+            image_idx += 1
+            prev_end = pos + 1
+        if prev_end < len(evs_ids):
+            request_context_parts.append(evs_ids[prev_end:])
+        return torch.cat(request_context_parts, dim=0)
+
+    def _refresh_evs_runtime_and_slice_context_ids(
+        self,
+        context_ids: torch.Tensor,
+        multimodal_param: MultimodalParams,
+    ) -> torch.Tensor:
+        """Refresh runtime MM counters and slice to the current context chunk.
+
+        Args:
+            context_ids: Full per-request token IDs after EVS adjustment.
+            multimodal_param: Per-request multimodal parameters. When
+                `multimodal_runtime` is present, its MM-token counters are
+                updated from `context_ids`.
+
+        Returns:
+            `context_ids` narrowed to the current context chunk when runtime
+            metadata is present; otherwise the original `context_ids`.
+        """
+        runtime = multimodal_param.multimodal_runtime
+        if runtime is None:
+            return context_ids
+        if runtime.chunk_end_pos > context_ids.shape[0]:
+            raise ValueError(
+                "EVS context chunk end position "
+                f"({runtime.chunk_end_pos}) exceeds full context "
+                f"length ({context_ids.shape[0]})."
+            )
+
+        embed_mask = context_ids == self.img_context_token_id
+        sound_context_token_id = getattr(self, "sound_context_token_id", None)
+        if sound_context_token_id is not None:
+            embed_mask = torch.logical_or(embed_mask, context_ids == sound_context_token_id)
+        embed_mask_cumsum = embed_mask.cumsum(0, dtype=torch.int64)
+        runtime.num_cached_mm_tokens = (
+            int(embed_mask_cumsum[runtime.past_seen_token_num - 1])
+            if runtime.past_seen_token_num > 0
+            else 0
+        )
+        runtime.num_mm_tokens_in_chunk = (
+            int(embed_mask_cumsum[runtime.chunk_end_pos - 1]) - runtime.num_cached_mm_tokens
+            if runtime.chunk_end_pos > 0
+            else 0
+        )
+        runtime.total_embeds_in_request = int(embed_mask_cumsum[-1])
+        return context_ids[runtime.past_seen_token_num : runtime.chunk_end_pos]
+
     def merge_evs_mm_embeds(
         self,
         num_tokens_in_videos: List[int],
@@ -2547,68 +2642,14 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         for multimodal_param, evs_ids, modality, num_tokens_in_video in zip(
             multimodal_params, evs_ids_lst, modalities, num_tokens_in_videos, strict=True
         ):
-            # Image/audio modalities: keep input_ids unchanged during inflight-batching.
-            if modality in ("image", "audio"):
-                context_ids = evs_ids
-            elif modality == "video":
-                # evs_ids is a flat 1-D tensor built at token-ID level.
-                # Find placeholder positions and replace each with the EVS count.
-                request_context_parts = []
-                placeholder_mask = evs_ids == self.video_context_token_id
-                placeholder_positions = placeholder_mask.nonzero(as_tuple=True)[0]
-                image_idx = 0
-                prev_end = 0
-                for pos in placeholder_positions:
-                    pos = pos.item()
-                    # Append tokens before this placeholder.
-                    if pos > prev_end:
-                        request_context_parts.append(evs_ids[prev_end:pos])
-                    # Replace placeholder with actual img_context_token count.
-                    request_context_parts.append(
-                        torch.full(
-                            (int(num_tokens_in_video[image_idx]),),
-                            fill_value=self.img_context_token_id,
-                            dtype=evs_ids.dtype,
-                            device=evs_ids.device,
-                        )
-                    )
-                    image_idx += 1
-                    prev_end = pos + 1
-                # Append remaining tokens after the last placeholder.
-                if prev_end < len(evs_ids):
-                    request_context_parts.append(evs_ids[prev_end:])
-                context_ids = torch.cat(request_context_parts, dim=0)
-            else:
-                raise ValueError(f"Unsupported modality for EVS merge: {modality}")
-
-            runtime = multimodal_param.multimodal_runtime
-            if runtime is not None:
-                if runtime.chunk_end_pos > context_ids.shape[0]:
-                    raise ValueError(
-                        "EVS context chunk end position "
-                        f"({runtime.chunk_end_pos}) exceeds full context "
-                        f"length ({context_ids.shape[0]})."
-                    )
-                # EVS can redistribute image tokens across tubelets, so refresh
-                # runtime counters (that were originally computed from the dummy/pre-EVS
-                # token layout) from the post-EVS layout before slicing embeddings.
-                embed_mask = context_ids == self.img_context_token_id
-                sound_context_token_id = getattr(self, "sound_context_token_id", None)
-                if sound_context_token_id is not None:
-                    embed_mask = torch.logical_or(embed_mask, context_ids == sound_context_token_id)
-                embed_mask_cumsum = embed_mask.cumsum(0, dtype=torch.int64)
-                runtime.num_cached_mm_tokens = (
-                    int(embed_mask_cumsum[runtime.past_seen_token_num - 1])
-                    if runtime.past_seen_token_num > 0
-                    else 0
-                )
-                runtime.num_mm_tokens_in_chunk = (
-                    int(embed_mask_cumsum[runtime.chunk_end_pos - 1]) - runtime.num_cached_mm_tokens
-                    if runtime.chunk_end_pos > 0
-                    else 0
-                )
-                runtime.total_embeds_in_request = int(embed_mask_cumsum[-1])
-                context_ids = context_ids[runtime.past_seen_token_num : runtime.chunk_end_pos]
+            context_ids = self._build_evs_adjusted_context_ids(
+                evs_ids, modality, num_tokens_in_video
+            )
+            # EVS can redistribute image tokens across tubelets, so refresh
+            # runtime counters from the post-EVS layout before slicing embeddings.
+            context_ids = self._refresh_evs_runtime_and_slice_context_ids(
+                context_ids, multimodal_param
+            )
             context_parts.append(context_ids)
 
         if not context_parts:

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2601,6 +2601,41 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         runtime.total_embeds_in_request = int(embed_mask_cumsum[-1])
         return context_ids[runtime.past_seen_token_num : runtime.chunk_end_pos]
 
+    @staticmethod
+    def _validate_evs_context_batch(
+        ctx_params: List[MultimodalParams],
+        num_context_requests: int,
+    ) -> None:
+        """Reject EVS video mixed with text-only context requests.
+
+        Args:
+            ctx_params: Multimodal params associated with current context
+                requests. Today this list contains only context requests with
+                multimodal content.
+            num_context_requests: Total number of current context requests in
+                the flattened forward batch, including text-only requests.
+
+        Raises:
+            ValueError: If an EVS video context is batched together with a
+                text-only context request.
+        """
+        has_video = any(
+            param.has_content() and param.multimodal_data.get("modality_type") == "video"
+            for param in ctx_params
+        )
+        has_text_only_context = len(ctx_params) < num_context_requests or any(
+            not param.has_content() for param in ctx_params
+        )
+        if has_video and has_text_only_context:
+            # TODO(TRTLLM-12534): Remove this guard once merge_evs_mm_embeds writes each
+            # multimodal context chunk using its flattened input_ids offset
+            # instead of assuming a contiguous multimodal prefix.
+            raise ValueError(
+                "EVS video requests cannot be inflight-batched with text-only "
+                "context requests yet. merge_evs_mm_embeds currently assumes "
+                "multimodal context chunks form a contiguous input_ids prefix."
+            )
+
     def merge_evs_mm_embeds(
         self,
         num_tokens_in_videos: List[int],
@@ -2859,10 +2894,13 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         multimodal_params = kwargs.get("multimodal_params", [])
         mm_embedding = []
         if len(multimodal_params) > 0:
+            ctx_params = multimodal_params[:num_context_requests]
+            if self.video_pruning_rate > 0:
+                self._validate_evs_context_batch(ctx_params, num_context_requests)
             if not _is_disagg():
                 mm_embedding = get_multimodal_embeddings(
                     encoder_forward_fn=self._encode_multimodal,
-                    multimodal_params=multimodal_params[:num_context_requests],
+                    multimodal_params=ctx_params,
                 )
             else:
                 raise NotImplementedError(
@@ -2872,7 +2910,6 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
             # Adjust input_ids in videos if EVS is applied.
             if self.video_pruning_rate > 0:
                 # Retrieve per-video count stashed by `_encode_multimodal`.
-                ctx_params = multimodal_params[:num_context_requests]
                 num_tokens_in_videos = [
                     param.multimodal_data.get("num_tokens_in_video")
                     for param in ctx_params
@@ -2884,9 +2921,7 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                     input_ids=input_ids,
                 )
 
-            mm_embedding = find_input_mm_embeds(
-                mm_embedding, multimodal_params[:num_context_requests]
-            )
+            mm_embedding = find_input_mm_embeds(mm_embedding, ctx_params)
 
         mm_token_ids_list = [self.img_context_token_id]
         if self.sound_context_token_id is not None:

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -1251,8 +1251,8 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
                 video).
                 `mm_data_updates` (Optional[Dict]) — additional fields to
                 merge into `extra_processed_inputs["multimodal_data"]`.
-                Currently only non-None for EVS-enabled video, in which case
-                it is `{"video": {"evs_ids": evs_ids_tensor}}`.
+                Currently non-None for EVS-enabled image/audio/video requests,
+                in which case it carries a modality-specific `evs_ids` tensor.
         """
         # Detect modality primarily from `mm_data`, which is authoritative and
         # independent of tokenizer quirks. The token-scanning fallback is only
@@ -1286,12 +1286,26 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
             expanded = self._expand_image_placeholders_in_token_ids(
                 prompt_token_ids, num_mm_tokens_per_placeholder
             )
-            return expanded, None
+            mm_data_updates = None
+            if self.video_pruning_rate > 0:
+                mm_data_updates = {
+                    "image": {
+                        "evs_ids": torch.tensor(expanded, dtype=torch.long),
+                    },
+                }
+            return expanded, mm_data_updates
         if has_audio:
             expanded = self._expand_audio_placeholders_in_token_ids(
                 prompt_token_ids, num_mm_tokens_per_placeholder
             )
-            return expanded, None
+            mm_data_updates = None
+            if self.video_pruning_rate > 0:
+                mm_data_updates = {
+                    "audio": {
+                        "evs_ids": torch.tensor(expanded, dtype=torch.long),
+                    },
+                }
+            return expanded, mm_data_updates
         # has_video -- reuse `mm_data` already extracted above for detection.
         expanded_ids, evs_ids_tensor = self._expand_video_placeholders_in_token_ids(
             prompt_token_ids, num_mm_tokens_per_placeholder, mm_data or None

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
 import copy
 import math
 import os
@@ -2521,45 +2521,89 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         # Iterate over batch, replacing video_context_token_id placeholders with
         # the actual per-tubelet img_context_token counts from EVS.
         context_parts = []
-        for evs_ids, modality, num_tokens_in_video in zip(
-            evs_ids_lst, modalities, num_tokens_in_videos
+        for multimodal_param, evs_ids, modality, num_tokens_in_video in zip(
+            multimodal_params, evs_ids_lst, modalities, num_tokens_in_videos
         ):
             # Image modality: keep input_ids unchanged during inflight-batching.
             if modality == "image":
-                context_parts.append(evs_ids)
-                continue
-
-            # evs_ids is a flat 1-D tensor built at token-ID level.
-            # Find placeholder positions and replace each with the EVS count.
-            placeholder_mask = evs_ids == self.video_context_token_id
-            placeholder_positions = placeholder_mask.nonzero(as_tuple=True)[0]
-            image_idx = 0
-            prev_end = 0
-            for pos in placeholder_positions:
-                pos = pos.item()
-                # Append tokens before this placeholder.
-                if pos > prev_end:
-                    context_parts.append(evs_ids[prev_end:pos])
-                # Replace placeholder with actual img_context_token count.
-                context_parts.append(
-                    torch.full(
-                        (int(num_tokens_in_video[image_idx]),),
-                        fill_value=self.img_context_token_id,
-                        dtype=evs_ids.dtype,
-                        device=evs_ids.device,
+                context_ids = evs_ids
+            else:
+                # evs_ids is a flat 1-D tensor built at token-ID level.
+                # Find placeholder positions and replace each with the EVS count.
+                request_context_parts = []
+                placeholder_mask = evs_ids == self.video_context_token_id
+                placeholder_positions = placeholder_mask.nonzero(as_tuple=True)[0]
+                image_idx = 0
+                prev_end = 0
+                for pos in placeholder_positions:
+                    pos = pos.item()
+                    # Append tokens before this placeholder.
+                    if pos > prev_end:
+                        request_context_parts.append(evs_ids[prev_end:pos])
+                    # Replace placeholder with actual img_context_token count.
+                    request_context_parts.append(
+                        torch.full(
+                            (int(num_tokens_in_video[image_idx]),),
+                            fill_value=self.img_context_token_id,
+                            dtype=evs_ids.dtype,
+                            device=evs_ids.device,
+                        )
                     )
-                )
-                image_idx += 1
-                prev_end = pos + 1
-            # Append remaining tokens after the last placeholder.
-            if prev_end < len(evs_ids):
-                context_parts.append(evs_ids[prev_end:])
+                    image_idx += 1
+                    prev_end = pos + 1
+                # Append remaining tokens after the last placeholder.
+                if prev_end < len(evs_ids):
+                    request_context_parts.append(evs_ids[prev_end:])
+                context_ids = torch.cat(request_context_parts, dim=0)
 
+            runtime = multimodal_param.multimodal_runtime
+            if runtime is not None:
+                if runtime.chunk_end_pos > context_ids.shape[0]:
+                    raise ValueError(
+                        "EVS context chunk end position "
+                        f"({runtime.chunk_end_pos}) exceeds full context "
+                        f"length ({context_ids.shape[0]})."
+                    )
+                # EVS can redistribute image tokens across tubelets, so refresh
+                # runtime counters (that were originally computed from the dummy/pre-EVS
+                # token layout) from the post-EVS layout before slicing embeddings.
+                embed_mask = context_ids == self.img_context_token_id
+                sound_context_token_id = getattr(self, "sound_context_token_id", None)
+                if sound_context_token_id is not None:
+                    embed_mask = torch.logical_or(embed_mask, context_ids == sound_context_token_id)
+                embed_mask_cumsum = embed_mask.cumsum(0, dtype=torch.int64)
+                runtime.num_cached_mm_tokens = (
+                    int(embed_mask_cumsum[runtime.past_seen_token_num - 1])
+                    if runtime.past_seen_token_num > 0
+                    else 0
+                )
+                runtime.num_mm_tokens_in_chunk = (
+                    int(embed_mask_cumsum[runtime.chunk_end_pos - 1]) - runtime.num_cached_mm_tokens
+                    if runtime.chunk_end_pos > 0
+                    else 0
+                )
+                runtime.total_embeds_in_request = int(embed_mask_cumsum[-1])
+                context_ids = context_ids[runtime.past_seen_token_num : runtime.chunk_end_pos]
+            context_parts.append(context_ids)
+
+        if not context_parts:
+            return input_ids
         context_ids = torch.cat(context_parts, dim=0)
         # -> [num_tokens, ]
 
         # Special handling for inflight-batching.
         # Assume input ids format is [context_ids, generation_ids].
+        # Under chunked prefill, multimodal_runtime narrows context_ids to the current
+        # context chunk so decode ids after it are preserved.
+        if context_ids.shape[0] > input_ids.shape[0]:
+            raise ValueError(
+                "EVS-adjusted context length "
+                f"({context_ids.shape[0]}) exceeds input_ids length "
+                f"({input_ids.shape[0]}). This usually means a chunked "
+                "multimodal request reached merge_evs_mm_embeds without "
+                "multimodal_runtime metadata."
+            )
+        context_ids = context_ids.to(device=input_ids.device, dtype=input_ids.dtype)
         input_ids[: context_ids.shape[0]] = context_ids
         del context_ids
 

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -520,6 +520,21 @@ class TestAudioInputProcessor:
             "audio_num_clips",
         } <= audio_inputs.keys()
 
+    def test_call_audio_stashes_evs_ids_when_evs_enabled(self):
+        proc = _make_audio_processor()
+        proc.video_pruning_rate = 0.5
+        audio = np.random.randn(16000).astype(np.float32)
+        inputs = {
+            "prompt": f"Listen: {AUDIO_PLACEHOLDER}",
+            "multi_modal_data": {"audio": [(audio, 16000)]},
+        }
+
+        input_ids, extra_inputs = proc(inputs, None)
+
+        evs_ids = extra_inputs["multimodal_data"]["audio"]["evs_ids"]
+        assert evs_ids.dtype == torch.int32
+        assert evs_ids.tolist() == input_ids
+
     def test_process_audio_raises_without_sound_config(self):
         proc = _make_audio_processor()
         proc._audio_extractor = None
@@ -799,6 +814,9 @@ class TestGetNumTokensPerVideoTemporal:
 # Arbitrary token IDs used across the merge_evs tests.
 _IMG_CTX_ID = 20
 _VIDEO_CTX_ID = 21
+_SOUND_CTX_ID = 30
+_SOUND_START = 200
+_SOUND_END = 201
 _TEXT_TOKEN = 99  # stand-in for any non-special token
 _IMG_START = 50
 _IMG_END = 51
@@ -809,6 +827,7 @@ def _make_merge_model():
     model = mock.MagicMock(spec=NemotronH_Nano_VL_V2)
     model.img_context_token_id = _IMG_CTX_ID
     model.video_context_token_id = _VIDEO_CTX_ID
+    model.sound_context_token_id = _SOUND_CTX_ID
     return model
 
 
@@ -907,6 +926,43 @@ class TestMergeEvsMMEmbeds:
             + [_IMG_END]
             # Image: passthrough
             + [10, 11],
+            dtype=torch.long,
+        )
+        assert result.shape == input_ids.shape
+        assert (result[: len(expected)] == expected).all()
+
+    def test_mixed_audio_video_batch(self):
+        """Audio entry passes through; video entry gets placeholders replaced."""
+        model = _make_merge_model()
+        video_evs = torch.tensor(
+            [
+                _TEXT_TOKEN,
+                _IMG_START,
+                _VIDEO_CTX_ID,
+                _IMG_END,
+            ],
+            dtype=torch.long,
+        )
+        audio_evs = torch.tensor(
+            [_SOUND_START, _SOUND_CTX_ID, _SOUND_CTX_ID, _SOUND_END],
+            dtype=torch.long,
+        )
+        params = [
+            _make_mm_param("video", video_evs),
+            _make_mm_param("audio", audio_evs),
+        ]
+        num_tokens_in_videos = [torch.tensor([2]), None]
+        input_ids = torch.zeros(20, dtype=torch.long)
+
+        result = NemotronH_Nano_VL_V2.merge_evs_mm_embeds(
+            model, num_tokens_in_videos, params, input_ids
+        )
+
+        expected = torch.tensor(
+            [_TEXT_TOKEN, _IMG_START]
+            + [_IMG_CTX_ID] * 2
+            + [_IMG_END]
+            + [_SOUND_START, _SOUND_CTX_ID, _SOUND_CTX_ID, _SOUND_END],
             dtype=torch.long,
         )
         assert result.shape == input_ids.shape

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -1657,6 +1657,42 @@ class TestExpandPromptTokenIdsForMM:
         assert 200 in result  # sound_start_token_id
         assert 201 in result  # sound_end_token_id
 
+    def test_evs_dispatch_returns_image_evs_ids_in_mm_data_updates(self):
+        proc = _make_fast_path_processor()
+        proc.video_pruning_rate = 0.5
+        img_ctx = proc.img_context_token_id
+        prompt = [1, img_ctx, 2]
+
+        result, mm_data_updates = proc.expand_prompt_token_ids_for_mm(
+            prompt,
+            [5],
+            mm_data={"image": [object()]},
+        )
+
+        assert mm_data_updates is not None
+        evs_ids = mm_data_updates["image"]["evs_ids"]
+        assert isinstance(evs_ids, torch.Tensor)
+        assert evs_ids.dtype == torch.long
+        assert evs_ids.tolist() == result
+
+    def test_evs_dispatch_returns_audio_evs_ids_in_mm_data_updates(self):
+        proc = _make_fast_path_audio_processor()
+        proc.video_pruning_rate = 0.5
+        snd_ctx = proc._sound_context_token_id
+        prompt = [1, snd_ctx, 2]
+
+        result, mm_data_updates = proc.expand_prompt_token_ids_for_mm(
+            prompt,
+            [5],
+            mm_data={"audio": [object()]},
+        )
+
+        assert mm_data_updates is not None
+        evs_ids = mm_data_updates["audio"]["evs_ids"]
+        assert isinstance(evs_ids, torch.Tensor)
+        assert evs_ids.dtype == torch.long
+        assert evs_ids.tolist() == result
+
     def test_no_placeholders_returns_unchanged(self):
         proc = _make_fast_path_processor()
         prompt = [1, 2, 3, 4]

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -859,6 +859,16 @@ def _make_mm_param(modality: str, evs_ids, runtime=None):
 class TestMergeEvsMMEmbeds:
     """Tests for `NemotronH_Nano_VL_V2.merge_evs_mm_embeds`."""
 
+    def test_evs_video_with_text_only_context_raises(self):
+        """Reject batches where text-only context chunks would shift EVS writes."""
+        params = [_make_mm_param("video", torch.tensor([_VIDEO_CTX_ID], dtype=torch.long))]
+
+        with pytest.raises(ValueError, match="text-only context requests"):
+            NemotronH_Nano_VL_V2._validate_evs_context_batch(
+                params,
+                num_context_requests=2,
+            )
+
     def test_single_video_two_tubelets(self):
         """Each video_context_token_id placeholder is replaced with the right count."""
         model = _make_merge_model()

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 """Preprocessing unit tests for modeling_nemotron_nano.py."""
 
 import functools
@@ -25,6 +26,7 @@ from tensorrt_llm._torch.models.modeling_nemotron_nano import (
 )
 from tensorrt_llm.inputs.multimodal import (
     MultimodalParams,
+    MultimodalRuntimeData,
     _compute_mm_masks,
     _find_mm_token_start_pos_from_masks,
 )
@@ -810,13 +812,22 @@ def _make_merge_model():
     return model
 
 
-def _make_mm_param(modality: str, evs_ids):
+def _make_runtime(past_seen_token_num: int, chunk_end_pos: int, prompt_len: int):
+    return MultimodalRuntimeData(
+        past_seen_token_num=past_seen_token_num,
+        chunk_end_pos=chunk_end_pos,
+        embed_mask_cumsum=torch.zeros(prompt_len, dtype=torch.int64),
+    )
+
+
+def _make_mm_param(modality: str, evs_ids, runtime=None):
     """Build a MultimodalParams for merge_evs_mm_embeds."""
     return MultimodalParams(
         multimodal_data={
             "modality_type": modality,
             modality: {"evs_ids": evs_ids},
-        }
+        },
+        multimodal_runtime=runtime,
     )
 
 
@@ -922,6 +933,96 @@ class TestMergeEvsMMEmbeds:
         )
         assert result.shape == input_ids.shape
         assert (result[: len(expected)] == expected).all()
+
+    def test_chunked_prefill_uses_current_context_slice(self):
+        """Chunked prefill should write only the active context window."""
+        model = _make_merge_model()
+        evs_ids = torch.tensor(
+            [
+                _TEXT_TOKEN,
+                _IMG_START,
+                _VIDEO_CTX_ID,
+                _IMG_END,
+                88,
+                _IMG_START,
+                _VIDEO_CTX_ID,
+                _IMG_END,
+                77,
+            ],
+            dtype=torch.long,
+        )
+        full_context = torch.tensor(
+            [_TEXT_TOKEN, _IMG_START]
+            + [_IMG_CTX_ID] * 3
+            + [_IMG_END, 88, _IMG_START]
+            + [_IMG_CTX_ID] * 2
+            + [_IMG_END, 77],
+            dtype=torch.long,
+        )
+        runtime = _make_runtime(
+            past_seen_token_num=4,
+            chunk_end_pos=9,
+            prompt_len=len(full_context),
+        )
+        param = _make_mm_param("video", evs_ids, runtime=runtime)
+        num_tokens_in_videos = [torch.tensor([3, 2])]
+        generation_tail = torch.tensor([700, 701], dtype=torch.long)
+        input_ids = torch.cat([torch.zeros(5, dtype=torch.long), generation_tail.clone()])
+
+        result = NemotronH_Nano_VL_V2.merge_evs_mm_embeds(
+            model, num_tokens_in_videos, [param], input_ids
+        )
+
+        expected_context_chunk = full_context[4:9]
+        assert result.shape == input_ids.shape
+        assert (result[: len(expected_context_chunk)] == expected_context_chunk).all()
+        assert (result[len(expected_context_chunk) :] == generation_tail).all()
+        assert runtime.num_cached_mm_tokens == 2
+        assert runtime.num_mm_tokens_in_chunk == 2
+        assert runtime.total_embeds_in_request == 5
+
+    def test_chunked_prefill_first_chunk_can_be_shorter_than_full_context(self):
+        """A full EVS context longer than input_ids must not be assigned wholesale."""
+        model = _make_merge_model()
+        evs_ids = torch.tensor(
+            [
+                _TEXT_TOKEN,
+                _IMG_START,
+                _VIDEO_CTX_ID,
+                _IMG_END,
+                _IMG_START,
+                _VIDEO_CTX_ID,
+                _IMG_END,
+                _TEXT_TOKEN,
+            ],
+            dtype=torch.long,
+        )
+        full_context = torch.tensor(
+            [_TEXT_TOKEN, _IMG_START]
+            + [_IMG_CTX_ID] * 5
+            + [_IMG_END, _IMG_START]
+            + [_IMG_CTX_ID] * 4
+            + [_IMG_END, _TEXT_TOKEN],
+            dtype=torch.long,
+        )
+        runtime = _make_runtime(
+            past_seen_token_num=0,
+            chunk_end_pos=4,
+            prompt_len=len(full_context),
+        )
+        param = _make_mm_param("video", evs_ids, runtime=runtime)
+        num_tokens_in_videos = [torch.tensor([5, 4])]
+        input_ids = torch.zeros(4, dtype=torch.long)
+
+        result = NemotronH_Nano_VL_V2.merge_evs_mm_embeds(
+            model, num_tokens_in_videos, [param], input_ids
+        )
+
+        assert result.shape == input_ids.shape
+        assert (result == full_context[:4]).all()
+        assert runtime.num_cached_mm_tokens == 0
+        assert runtime.num_mm_tokens_in_chunk == 2
+        assert runtime.total_embeds_in_request == 9
 
 
 class TestProcessVideoPromptsEvs:

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -823,11 +823,17 @@ _IMG_END = 51
 
 
 def _make_merge_model():
-    """Create a minimal mock with the two token-ID attrs that `merge_evs_mm_embeds` reads."""
+    """Create a minimal mock with the attrs/helpers that `merge_evs_mm_embeds` reads."""
     model = mock.MagicMock(spec=NemotronH_Nano_VL_V2)
     model.img_context_token_id = _IMG_CTX_ID
     model.video_context_token_id = _VIDEO_CTX_ID
     model.sound_context_token_id = _SOUND_CTX_ID
+    model._build_evs_adjusted_context_ids = functools.partial(
+        NemotronH_Nano_VL_V2._build_evs_adjusted_context_ids, model
+    )
+    model._refresh_evs_runtime_and_slice_context_ids = functools.partial(
+        NemotronH_Nano_VL_V2._refresh_evs_runtime_and_slice_context_ids, model
+    )
     return model
 
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate multimodal context handling: video placeholders expand to the correct number of image tokens and audio tokens pass through intact.
  * Safer chunked prefill behavior with runtime-aware validation and token accounting; preserves generation tail and prevents out-of-range context writes.
* **Tests**
  * Added tests covering chunked prefill, mixed audio+video batches, and runtime-aware multimodal processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

EVS MM token merging has not been chunked-prefill aware.

In `modeling_nemotron_nano.py`, `merge_evs_mm_embeds` now:
- rebuilds the full post-EVS context per multimodal request
- uses `multimodal_runtime.past_seen_token_num:chunk_end_pos` to splice only the active chunk into `input_ids`
- preserves any generation tokens after the context chunk
- refreshes runtime MM-token counters from the post-EVS layout so `find_input_mm_embeds` slices embeddings consistently

## Test Coverage

Ran the full Video-MME accuracy benchmarks.

1. With EVS & chunked prefill:
```
            "--reasoning_parser", "nano-v3",
            "--max_batch_size", "64",
            "--max_num_tokens", "64",
            "--enable_chunked_prefill",
            "--video_pruning_rate", "0.5",
```
Results:
```
    "short": {
        "overall": "0.648",
[...]
    "medium": {
        "overall": "0.530",
[...]
    "long": {
        "overall": "0.498",
[...]
    "overall": {
        "overall": "0.559",
```

2. With EVS & without chunked prefill:
```
            "--reasoning_parser", "nano-v3",
            "--max_batch_size", "64",
            "--video_pruning_rate", "0.5",
```
Results:
```
    "short": {
        "overall": "0.652",
[...]
    "medium": {
        "overall": "0.526",
[...]
    "long": {
        "overall": "0.498",
[...]
    "overall": {
        "overall": "0.559",
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
