### PR TITLE
[None][perf] optimize trtllm-gen fused attention preprocessing

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -16,6 +16,7 @@
  */
 #include "attentionOp.h"
 #include "tensorrt_llm/common/assert.h"
+#include "tensorrt_llm/common/attentionWorkspace.h"
 #include "tensorrt_llm/common/config.h"
 #include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/common/logger.h"
@@ -37,7 +38,12 @@
 
 using namespace tensorrt_llm::kernels;
 namespace tc = tensorrt_llm::common;
+using tensorrt_llm::common::op::AttentionContextWorkspaceSizes;
+using tensorrt_llm::common::op::AttentionFlashMlaWorkspaceSizes;
+using tensorrt_llm::common::op::AttentionGenerationWorkspaceSizes;
 using tensorrt_llm::common::op::AttentionOp;
+using tensorrt_llm::common::op::AttentionWorkspaceManager;
+using tensorrt_llm::common::op::AttentionXqaWorkspaceSizes;
 using tensorrt_llm::common::op::KvCacheBuffers;
 
 template <typename T>
@@ -837,35 +843,33 @@ size_t AttentionOp::getWorkspaceSizeForContext(nvinfer1::DataType type, int32_t 
         ? 0
         : (2 * size * cpMaxPaddedSequenceLength * getHeadSize() * (mNumHeads + 2 * mNumKVHeads) + cu_seqlens_size);
 
-    int const NUM_BUFFERS = 26;
-    size_t workspaces[NUM_BUFFERS];
-    workspaces[0] = CUBLAS_WORKSPACE_SIZE;
-    workspaces[1] = attention_mask_size;
-    workspaces[2] = cu_seqlens_size; // cu_seqlen_q
-    workspaces[3] = cu_seqlens_size; // cu_seqlen_kv
-    workspaces[4] = cu_seqlens_size; // cu_mask_rows
-    workspaces[5] = rotary_inv_freq_size;
-    workspaces[6] = q_buf_2_size;
-    workspaces[7] = k_buf_2_size;
-    workspaces[8] = v_buf_2_size;
-    workspaces[9] = qk_buf_size;
-    workspaces[10] = qkv_buf_2_size;
-    workspaces[11] = qk_buf_float_size;
-    workspaces[12] = fp8_qkv_buffer_size;
-    workspaces[13] = fp8_q_buf_size;
-    workspaces[14] = fp8_k_buf_size;
-    workspaces[15] = fp8_v_buf_size;
-    workspaces[16] = padding_offset_size;
-    workspaces[17] = encoder_padding_offset_size;
-    workspaces[18] = tokens_info_size;
-    workspaces[19] = fmha_scheduler_counter;
-    workspaces[20] = fmha_bmm1_scale_size;
-    workspaces[21] = fmha_bmm2_scale_size;
-    workspaces[22] = sage_q_sfs_buffer_size;
-    workspaces[23] = sage_k_sfs_buffer_size;
-    workspaces[24] = sage_v_sfs_buffer_size;
-    workspaces[25] = cpWorkspaceSize;
-    context_workspace_size = tc::calculateTotalWorkspaceSize(workspaces, NUM_BUFFERS);
+    AttentionContextWorkspaceSizes workspaceSizes{};
+    workspaceSizes.attentionMask = attention_mask_size;
+    workspaceSizes.cuQSeqlens = cu_seqlens_size;
+    workspaceSizes.cuKvSeqlens = cu_seqlens_size;
+    workspaceSizes.cuMaskRows = cu_seqlens_size;
+    workspaceSizes.rotaryInvFreq = rotary_inv_freq_size;
+    workspaceSizes.qBuf = q_buf_2_size;
+    workspaceSizes.kBuf = k_buf_2_size;
+    workspaceSizes.vBuf = v_buf_2_size;
+    workspaceSizes.qkBuf = qk_buf_size;
+    workspaceSizes.qkvBuf = qkv_buf_2_size;
+    workspaceSizes.qkFloatBuf = qk_buf_float_size;
+    workspaceSizes.fp8QkvBuf = fp8_qkv_buffer_size;
+    workspaceSizes.fp8QBuf = fp8_q_buf_size;
+    workspaceSizes.fp8KBuf = fp8_k_buf_size;
+    workspaceSizes.fp8VBuf = fp8_v_buf_size;
+    workspaceSizes.paddingOffset = padding_offset_size;
+    workspaceSizes.encoderPaddingOffset = encoder_padding_offset_size;
+    workspaceSizes.tokensInfo = tokens_info_size;
+    workspaceSizes.fmhaTileCounter = fmha_scheduler_counter;
+    workspaceSizes.fmhaBmm1Scale = fmha_bmm1_scale_size;
+    workspaceSizes.fmhaBmm2Scale = fmha_bmm2_scale_size;
+    workspaceSizes.sageQScale = sage_q_sfs_buffer_size;
+    workspaceSizes.sageKScale = sage_k_sfs_buffer_size;
+    workspaceSizes.sageVScale = sage_v_sfs_buffer_size;
+    workspaceSizes.cpWorkspace = cpWorkspaceSize;
+    context_workspace_size = AttentionWorkspaceManager::buildContextLayout(workspaceSizes).totalSize;
 
     return context_workspace_size;
 }
@@ -888,9 +892,6 @@ size_t AttentionOp::getWorkspaceSizeForGeneration(nvinfer1::DataType type, int32
         size_t flash_mla_workspace_size = 0;
         if (mUseGenFlashMLA)
         {
-            int const FLASH_MLA_NUM_BUFFERS = 5;
-            size_t flash_mla_workspaces[FLASH_MLA_NUM_BUFFERS];
-
             static constexpr int TileSchedulerMetaDataSize = 8;
 
             int s_q = mMLAParams.predicted_tokens_per_seq;
@@ -901,17 +902,14 @@ size_t AttentionOp::getWorkspaceSizeForGeneration(nvinfer1::DataType type, int32
 
             int num_sm_parts = getFlashMlaNumSmParts(s_q, num_q_heads, num_kv_heads, head_size_v);
 
-            // for mla  metadata
-            flash_mla_workspaces[0] = sizeof(int) * (num_sm_parts * TileSchedulerMetaDataSize);
-            flash_mla_workspaces[1] = sizeof(int) * (batch_beam + 1); // to check in MTP
-
-            // for mla kernel
-            flash_mla_workspaces[2] = sizeof(float) * (batch_beam * s_q * num_q_heads);            // softmax_lse
-            flash_mla_workspaces[3]
-                = sizeof(float) * ((batch_beam + num_sm_parts) * num_q_heads * s_q);               // softmax_lse_accum
-            flash_mla_workspaces[4]
-                = sizeof(float) * ((batch_beam + num_sm_parts) * num_q_heads * s_q * head_size_v); // out_accum
-            flash_mla_workspace_size = tc::calculateTotalWorkspaceSize(flash_mla_workspaces, FLASH_MLA_NUM_BUFFERS);
+            AttentionFlashMlaWorkspaceSizes flashMlaWorkspaceSizes{};
+            flashMlaWorkspaceSizes.tileSchedulerMetadata = sizeof(int) * (num_sm_parts * TileSchedulerMetaDataSize);
+            flashMlaWorkspaceSizes.numSplits = sizeof(int) * (batch_beam + 1);
+            flashMlaWorkspaceSizes.softmaxLse = sizeof(float) * (batch_beam * s_q * num_q_heads);
+            flashMlaWorkspaceSizes.softmaxLseAccum = sizeof(float) * ((batch_beam + num_sm_parts) * num_q_heads * s_q);
+            flashMlaWorkspaceSizes.outAccum
+                = sizeof(float) * ((batch_beam + num_sm_parts) * num_q_heads * s_q * head_size_v);
+            flash_mla_workspace_size = AttentionWorkspaceManager::buildFlashMlaLayout(flashMlaWorkspaceSizes).totalSize;
         }
 
         size_t cu_seqlens_size = sizeof(int) * (max_num_seq + 1);
@@ -952,20 +950,17 @@ size_t AttentionOp::getWorkspaceSizeForGeneration(nvinfer1::DataType type, int32
     size_t const cpWorkspaceSize
         = mCpSize == 1 ? 0 : (2 * size * cpMaxPaddedSequenceLength * getHeadSize() * (mNumHeads + 2 * mNumKVHeads));
 
-    int const NUM_BUFFERS = 5;
-    size_t workspaces[NUM_BUFFERS];
-    workspaces[0] = partial_out_size;
-    workspaces[1] = partial_sum_size;
-    workspaces[2] = partial_max_size;
-    workspaces[3] = shift_k_cache_size;
-    workspaces[4] = cpWorkspaceSize;
-    generation_workspace_size = tc::calculateTotalWorkspaceSize(workspaces, NUM_BUFFERS);
+    AttentionGenerationWorkspaceSizes generationWorkspaceSizes{};
+    generationWorkspaceSizes.cpWorkspace = cpWorkspaceSize;
+    generationWorkspaceSizes.partialOut = partial_out_size;
+    generationWorkspaceSizes.partialSum = partial_sum_size;
+    generationWorkspaceSizes.partialMax = partial_max_size;
+    generationWorkspaceSizes.shiftKCache = shift_k_cache_size;
+    generation_workspace_size = AttentionWorkspaceManager::buildGenerationLayout(generationWorkspaceSizes).totalSize;
 
     size_t xqa_workspace_size = 0;
     if (mEnableXQA)
     {
-        int const XQA_NUM_BUFFERS = 8;
-        size_t xqa_workspaces[XQA_NUM_BUFFERS];
         size_t const cu_seqlens_size = sizeof(int) * (batch_beam + 1);
         size_t const cu_kv_seqlens_size = sizeof(int) * (batch_beam + 1);
         size_t const rotary_inv_freq_size = sizeof(float) * batch_beam * mRotaryEmbeddingDim / 2;
@@ -973,19 +968,19 @@ size_t AttentionOp::getWorkspaceSizeForGeneration(nvinfer1::DataType type, int32
         size_t const sparse_attn_cache_size = useTllmGenSparseAttentionPaged()
             ? sizeof(int) * (batch_beam + batch_beam * 2 * max_blocks_per_sequence) * mNumKVHeads
             : 0;
-        xqa_workspaces[0] = cu_seqlens_size;
-        xqa_workspaces[1] = cu_kv_seqlens_size;
-        xqa_workspaces[2] = rotary_inv_freq_size;
-        // The tokensInfo.
-        xqa_workspaces[3] = max_num_tokens * sizeof(int2);
-        // Scales used for trtllm-gen kernels.
-        xqa_workspaces[4] = sizeof(float) * 2;
-        xqa_workspaces[5] = sizeof(float);
-        xqa_workspaces[6] = sparse_attn_cache_size;
-        xqa_workspaces[7] = mXqaDispatcher->getWorkspaceSize(
+        AttentionXqaWorkspaceSizes xqaWorkspaceSizes{};
+        xqaWorkspaceSizes.cuSeqlens = cu_seqlens_size;
+        xqaWorkspaceSizes.cuKvSeqlens = cu_kv_seqlens_size;
+        xqaWorkspaceSizes.rotaryInvFreq = rotary_inv_freq_size;
+        xqaWorkspaceSizes.tokensInfo = max_num_tokens * sizeof(int2);
+        xqaWorkspaceSizes.bmm1Scale = sizeof(float) * 2;
+        xqaWorkspaceSizes.bmm2Scale = sizeof(float);
+        xqaWorkspaceSizes.sparseAttnCache = sparse_attn_cache_size;
+        xqaWorkspaceSizes.kernelWorkspace = mXqaDispatcher->getWorkspaceSize(
             std::min<uint32_t>(mSpecDecodingMaxGenerationLength * max_num_seq, max_num_tokens));
         xqa_workspace_size
-            = tc::calculateTotalWorkspaceSize(xqa_workspaces, XQA_NUM_BUFFERS, mXqaDispatcher->getWorkspaceAlignment());
+            = AttentionWorkspaceManager::buildXqaLayout(xqaWorkspaceSizes, mXqaDispatcher->getWorkspaceAlignment())
+                  .totalSize;
     }
 
     return std::max(std::max(generation_workspace_size, xqa_workspace_size), fmha_v2_mla_workspace_size);
@@ -1035,10 +1030,7 @@ int AttentionOp::mlaGeneration(
     // Currently NVFP4 KV cache is not supported for MLA. An empty placeholder is provided.
     auto kv_scale_cache_buffer = KVBlockArray();
 
-    // Workspace pointer shift
-    int8_t* workspace_byte_ptr = reinterpret_cast<int8_t*>(params.workspace);
-    size_t offset = 0;
-    void* scratch_ptr = nextWorkspacePtr(workspace_byte_ptr, offset);
+    void* scratchPtr = params.workspace;
 
     params.quant_scale_o = generation_params.attention_output_orig_quant;
     params.quant_scale_q = generation_params.kv_scale_orig_quant;
@@ -1088,7 +1080,7 @@ int AttentionOp::mlaGeneration(
 
         // The partial buffers' pointers when the multiCtasKv mode is enabled.
         tllmRunnerParams.multiCtasKvCounterPtr = generation_params.semaphores;
-        tllmRunnerParams.multiCtasKvScratchPtr = scratch_ptr;
+        tllmRunnerParams.multiCtasKvScratchPtr = scratchPtr;
 
         // The sequence lengths for K/V.
         tllmRunnerParams.seqLensKvPtr = params.cache_seq_lens;
@@ -1173,14 +1165,19 @@ int AttentionOp::mlaGeneration(
         size_t const softmax_lse_accum_size = sizeof(float) * ((batch_beam + num_sm_parts) * num_q_heads * s_q);
         size_t const out_accum_size = sizeof(float) * ((batch_beam + num_sm_parts) * num_q_heads * s_q * head_size_v);
 
-        // Workspace pointers for softmax accumulators (tile_scheduler and num_splits come from Python).
-        nextWorkspacePtr(workspace_byte_ptr, offset, tile_scheduler_metadata_size);
-        nextWorkspacePtr(workspace_byte_ptr, offset, num_splits_size);
+        AttentionFlashMlaWorkspaceSizes flashMlaWorkspaceSizes{};
+        flashMlaWorkspaceSizes.tileSchedulerMetadata = tile_scheduler_metadata_size;
+        flashMlaWorkspaceSizes.numSplits = num_splits_size;
+        flashMlaWorkspaceSizes.softmaxLse = softmax_lse_size;
+        flashMlaWorkspaceSizes.softmaxLseAccum = softmax_lse_accum_size;
+        flashMlaWorkspaceSizes.outAccum = out_accum_size;
+        auto const flashMlaWorkspaceLayout = AttentionWorkspaceManager::buildFlashMlaLayout(flashMlaWorkspaceSizes);
         float* softmax_lse_ptr
-            = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, softmax_lse_size));
+            = AttentionWorkspaceManager::ptr<float>(params.workspace, flashMlaWorkspaceLayout.softmaxLse);
         float* softmax_lse_accum_ptr
-            = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, softmax_lse_accum_size));
-        float* out_accum_ptr = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, out_accum_size));
+            = AttentionWorkspaceManager::ptr<float>(params.workspace, flashMlaWorkspaceLayout.softmaxLseAccum);
+        float* out_accum_ptr
+            = AttentionWorkspaceManager::ptr<float>(params.workspace, flashMlaWorkspaceLayout.outAccum);
 
         // Metadata must always be pre-computed by Python (compute_flash_mla_metadata) and passed in.
         TLLM_CHECK_WITH_INFO(params.flash_mla_tile_scheduler_metadata != nullptr,
@@ -1502,71 +1499,53 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
 
     bool const is_qk_buf_float_ = true;
 
-    // Workspace pointer shift
-    int8_t* workspace_byte_ptr = reinterpret_cast<int8_t*>(params.workspace);
-    size_t offset = CUBLAS_WORKSPACE_SIZE;
+    AttentionContextWorkspaceSizes workspaceSizes{};
+    workspaceSizes.attentionMask = attention_mask_size;
+    workspaceSizes.cuQSeqlens = cu_seqlens_size;
+    workspaceSizes.cuKvSeqlens = cu_seqlens_size;
+    workspaceSizes.cuMaskRows = cu_seqlens_size;
+    workspaceSizes.rotaryInvFreq = rotary_inv_freq_size;
+    workspaceSizes.qBuf = q_buf_2_size;
+    workspaceSizes.kBuf = k_buf_2_size;
+    workspaceSizes.vBuf = v_buf_2_size;
+    workspaceSizes.qkBuf = qk_buf_size;
+    workspaceSizes.qkvBuf = qkv_buf_2_size;
+    workspaceSizes.qkFloatBuf = qk_buf_float_size;
+    workspaceSizes.fp8QkvBuf = fp8_qkv_buffer_size;
+    workspaceSizes.fp8QBuf = fp8_q_buf_size;
+    workspaceSizes.fp8KBuf = fp8_k_buf_size;
+    workspaceSizes.fp8VBuf = fp8_v_buf_size;
+    workspaceSizes.paddingOffset = padding_offset_size;
+    workspaceSizes.encoderPaddingOffset = encoder_padding_offset_size;
+    workspaceSizes.tokensInfo = tokens_info_size;
+    workspaceSizes.fmhaTileCounter = fmha_scheduler_counter;
+    workspaceSizes.fmhaBmm1Scale = fmha_bmm1_scale_size;
+    workspaceSizes.fmhaBmm2Scale = fmha_bmm2_scale_size;
+    workspaceSizes.sageQScale = sage_q_sfs_buffer_size;
+    workspaceSizes.sageKScale = sage_k_sfs_buffer_size;
+    workspaceSizes.sageVScale = sage_v_sfs_buffer_size;
+    workspaceSizes.cpWorkspace = cpWorkspaceSize;
+    auto const workspaceLayout = AttentionWorkspaceManager::buildContextLayout(workspaceSizes);
+    auto const workspaceViews = AttentionWorkspaceManager::materializeContext<T>(
+        params.workspace, workspaceLayout, cpMaxPadedSequenceLength, getHeadSize(), mNumHeads, mNumKVHeads);
 
-    T* attention_mask = reinterpret_cast<T*>(nextWorkspacePtr(workspace_byte_ptr, offset, attention_mask_size));
-    int* cu_q_seqlens = reinterpret_cast<int*>(nextWorkspacePtr(workspace_byte_ptr, offset, cu_seqlens_size));
-    int* cu_kv_seqlens = reinterpret_cast<int*>(nextWorkspacePtr(workspace_byte_ptr, offset, cu_seqlens_size));
-    int* cu_mask_rows = reinterpret_cast<int*>(nextWorkspacePtr(workspace_byte_ptr, offset, cu_seqlens_size));
-    float* rotary_inv_freq_buf
-        = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, rotary_inv_freq_size));
-    T* q_buf_2_ = reinterpret_cast<T*>(nextWorkspacePtr(workspace_byte_ptr, offset, q_buf_2_size));
-    T* k_buf_2_ = reinterpret_cast<T*>(nextWorkspacePtr(workspace_byte_ptr, offset, k_buf_2_size));
-    T* v_buf_2_ = reinterpret_cast<T*>(nextWorkspacePtr(workspace_byte_ptr, offset, v_buf_2_size));
-    T* qk_buf_ = reinterpret_cast<T*>(nextWorkspacePtr(workspace_byte_ptr, offset, qk_buf_size));
-    T* qkv_buf_2_ = reinterpret_cast<T*>(nextWorkspacePtr(workspace_byte_ptr, offset, qkv_buf_2_size));
-    float* qk_buf_float_ = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, qk_buf_float_size));
-    __nv_fp8_e4m3* fp8_qkv_buffer
-        = reinterpret_cast<__nv_fp8_e4m3*>(nextWorkspacePtr(workspace_byte_ptr, offset, fp8_qkv_buffer_size));
-    __nv_fp8_e4m3* fp8_q_buf
-        = reinterpret_cast<__nv_fp8_e4m3*>(nextWorkspacePtr(workspace_byte_ptr, offset, fp8_q_buf_size));
-    __nv_fp8_e4m3* fp8_k_buf
-        = reinterpret_cast<__nv_fp8_e4m3*>(nextWorkspacePtr(workspace_byte_ptr, offset, fp8_k_buf_size));
-    __nv_fp8_e4m3* fp8_v_buf
-        = reinterpret_cast<__nv_fp8_e4m3*>(nextWorkspacePtr(workspace_byte_ptr, offset, fp8_v_buf_size));
-    int* padding_offset = mEnableContextFMHA
-        ? nullptr
-        : reinterpret_cast<int*>(nextWorkspacePtr(workspace_byte_ptr, offset, padding_offset_size));
-    int* encoder_padding_offset = (mEnableContextFMHA && !isCrossAttention())
-        ? nullptr
-        : reinterpret_cast<int*>(nextWorkspacePtr(workspace_byte_ptr, offset, encoder_padding_offset_size));
-    int2* tokens_info = reinterpret_cast<int2*>(nextWorkspacePtr(workspace_byte_ptr, offset, tokens_info_size));
-    uint32_t* fmha_tile_counter_ptr
-        = reinterpret_cast<uint32_t*>(nextWorkspacePtr(workspace_byte_ptr, offset, fmha_scheduler_counter));
-    float* fmha_bmm1_scale_ptr
-        = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, fmha_bmm1_scale_size));
-    float* fmha_bmm2_scale_ptr
-        = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, fmha_bmm2_scale_size));
-    float* sage_q_sfs_buf
-        = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, sage_q_sfs_buffer_size));
-    float* sage_k_sfs_buf
-        = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, sage_k_sfs_buffer_size));
-    float* sage_v_sfs_buf
-        = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, sage_v_sfs_buffer_size));
-
-    T* gatherInBuffer = reinterpret_cast<T*>(nextWorkspacePtr(workspace_byte_ptr, offset, cpWorkspaceSize));
-    T* gatherOutBuffer = gatherInBuffer + cpMaxPadedSequenceLength * getHeadSize() * (mNumHeads + 2 * mNumKVHeads);
-    int* cu_cp_partial_seqlens = reinterpret_cast<int*>(
-        gatherOutBuffer + cpMaxPadedSequenceLength * getHeadSize() * (mNumHeads + 2 * mNumKVHeads));
-
-    // build attention_mask, cu_seqlens, and padding_offset tensors
+    // build attention mask, cu_seqlens, and padding offset tensors
     // Note: self attn and cross attn should use different params
     // cross attn's seqlen info is from encoder input lengths, not decoder input lengths!
     // moreover, attn mask for cross attn should be set separately (see below)
     BuildDecoderInfoParams<T> decoder_params{};
-    decoder_params.seqQOffsets = cu_q_seqlens;
-    decoder_params.seqKVOffsets = cu_kv_seqlens;
-    decoder_params.seqCpPartialOffsets = cu_cp_partial_seqlens;
+    decoder_params.seqQOffsets = workspaceViews.cuQSeqlens;
+    decoder_params.seqKVOffsets = workspaceViews.cuKvSeqlens;
+    decoder_params.seqCpPartialOffsets = workspaceViews.cuCpPartialSeqlens;
     decoder_params.cpSize = mCpSize;
-    decoder_params.packedMaskRowOffsets = cu_mask_rows;
-    decoder_params.paddingOffsets = padding_offset;
-    decoder_params.tokensInfo = tokens_info;
-    decoder_params.encoderPaddingOffsets
-        = isCrossAttention() ? encoder_padding_offset : nullptr; // cross attention takes offsets from encoder inputs
-    decoder_params.attentionMask = isCrossAttention() ? nullptr : attention_mask; // manually set for unfused cross attn
-    // Fixed sequence length offset if not removing the padding (cu_q_seqlens[i] = i * seq_length).
+    decoder_params.packedMaskRowOffsets = workspaceViews.cuMaskRows;
+    decoder_params.paddingOffsets = workspaceViews.paddingOffset;
+    decoder_params.tokensInfo = workspaceViews.tokensInfo;
+    // Cross attention takes offsets from encoder inputs.
+    decoder_params.encoderPaddingOffsets = isCrossAttention() ? workspaceViews.encoderPaddingOffset : nullptr;
+    // Manually set attention mask for unfused cross attention.
+    decoder_params.attentionMask = isCrossAttention() ? nullptr : workspaceViews.attentionMask;
+    // Fixed sequence length offset if not removing the padding (seqQOffsets[i] = i * seq_length).
     decoder_params.seqQLengths = params.context_lengths;
     decoder_params.seqKVLengths = isCrossAttention() ? params.encoder_input_lengths : params.sequence_lengths;
     decoder_params.batchSize = params.batch_size;
@@ -1579,20 +1558,20 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
     decoder_params.removePadding = mRemovePadding;
     decoder_params.attentionMaskType = mMaskType;
     decoder_params.blockSparseParams = mBlockSparseParams;
-    decoder_params.fmhaTileCounter = fmha_tile_counter_ptr;
+    decoder_params.fmhaTileCounter = workspaceViews.fmhaTileCounter;
     decoder_params.quantScaleO = params.attention_output_orig_quant;
     decoder_params.dequantScaleQkv = params.kv_scale_quant_orig;
     decoder_params.separateQkvScales = mKVCacheQuantMode.hasFp4KvCache();
     decoder_params.fmhaHostBmm1Scale = 1.0f / (sqrtf(getHeadSize() * 1.0f) * q_scaling);
-    decoder_params.fmhaBmm1Scale = fmha_bmm1_scale_ptr;
-    decoder_params.fmhaBmm2Scale = fmha_bmm2_scale_ptr;
+    decoder_params.fmhaBmm1Scale = workspaceViews.fmhaBmm1Scale;
+    decoder_params.fmhaBmm2Scale = workspaceViews.fmhaBmm2Scale;
     // Rotary embedding inv_freq buffer.
     decoder_params.rotaryEmbeddingScale = mRotaryEmbeddingScale;
     decoder_params.rotaryEmbeddingBase = mRotaryEmbeddingBase;
     decoder_params.rotaryEmbeddingDim = mRotaryEmbeddingDim;
     decoder_params.rotaryScalingType = mRotaryEmbeddingScaleType;
     // The inv freq might be updated during runtime with dynamic scaling type.
-    decoder_params.rotaryEmbeddingInvFreq = rotary_inv_freq_buf;
+    decoder_params.rotaryEmbeddingInvFreq = workspaceViews.rotaryInvFreq;
     // This is pre-computed when building the engines.
     decoder_params.rotaryEmbeddingInvFreqCache = params.rotary_inv_freq;
     decoder_params.rotaryEmbeddingMaxPositions = mRotaryEmbeddingMaxPositions;
@@ -1601,7 +1580,7 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
     sync_check_cuda_error(stream);
 
     // In cross attention context phase, the attention mask should be a matrix of all ones.
-    // We reassign attention_mask to override what previous invokeBuildDecoderInfo() does
+    // Override the attention mask produced by invokeBuildDecoderInfo().
     // also, invokeBuildDecoderInfo can only handle square mask, not cross B x q_len x kv_len mask
     // TODO: put this logic in the kernel above. currently not much concern because q_len is mostly = 1
     if (isUnfusedCrossAttention())
@@ -1626,7 +1605,7 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
                     }
                 }
             }
-            cudaMemcpyAsync(attention_mask, h_attention_mask.data(),
+            cudaMemcpyAsync(workspaceViews.attentionMask, h_attention_mask.data(),
                 sizeof(T) * params.batch_size * params.cross_kv_length * params.input_seq_length,
                 cudaMemcpyHostToDevice, stream);
             sync_check_cuda_error(stream);
@@ -1665,9 +1644,10 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         T* attention_input = const_cast<T*>(params.attention_input);
         if (mCpSize > 1 && mAttnTpSize > 1 && mAttnCpSize == 1)
         {
-            this->template ulyssesContextPreprocess<T>(
-                attention_input, gatherInBuffer, gatherOutBuffer, params, cu_q_seqlens, cu_cp_partial_seqlens, stream);
-            attention_input = gatherInBuffer;
+            this->template ulyssesContextPreprocess<T>(attention_input, workspaceViews.gatherInBuffer,
+                workspaceViews.gatherOutBuffer, params, workspaceViews.cuQSeqlens, workspaceViews.cuCpPartialSeqlens,
+                stream);
+            attention_input = workspaceViews.gatherInBuffer;
             sync_check_cuda_error(stream);
         }
 
@@ -1686,8 +1666,8 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         // Buffers.
         preprocessingParams.qkv_input = const_cast<T*>(attention_input);
         preprocessingParams.cross_kv_input = const_cast<T*>(params.cross_kv);
-        preprocessingParams.quantized_qkv_output = fp8_qkv_buffer;
-        preprocessingParams.q_output = q_buf_2_;
+        preprocessingParams.quantized_qkv_output = workspaceViews.fp8QkvBuf;
+        preprocessingParams.q_output = workspaceViews.qBuf;
         preprocessingParams.kv_cache_buffer = kv_cache_buffer;
         preprocessingParams.kv_cache_block_scales_buffer = kv_scale_cache_buffer;
         preprocessingParams.qkv_bias = params.qkv_bias;
@@ -1696,10 +1676,10 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         // Indicate if chunked-context is used (i.e. q_seqlen > kv_seqlen).
         preprocessingParams.cache_seq_lens = params.sequence_lengths;
         preprocessingParams.encoder_seq_lens = params.encoder_input_lengths;
-        preprocessingParams.cu_seq_lens = cu_q_seqlens;
+        preprocessingParams.cu_seq_lens = workspaceViews.cuQSeqlens;
         // Cross-attention only.
-        preprocessingParams.cu_kv_seq_lens = cu_kv_seqlens;
-        preprocessingParams.rotary_embedding_inv_freq = rotary_inv_freq_buf;
+        preprocessingParams.cu_kv_seq_lens = workspaceViews.cuKvSeqlens;
+        preprocessingParams.rotary_embedding_inv_freq = workspaceViews.rotaryInvFreq;
         preprocessingParams.rotary_coef_cache_buffer = params.rotary_cos_sin;
         preprocessingParams.mrope_rotary_cos_sin = params.mrope_rotary_cos_sin;
         preprocessingParams.qkv_scale_orig_quant = params.kv_scale_orig_quant;
@@ -1757,14 +1737,14 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         {
             TLLM_CHECK_WITH_INFO(params.mla_param != nullptr, "MLA param is nullptr");
             params.mla_param->cache_type = cache_type;
-            params.mla_param->cu_q_seqlens = cu_q_seqlens;
+            params.mla_param->cu_q_seqlens = workspaceViews.cuQSeqlens;
             params.mla_param->quant_scale_kv = params.kv_scale_orig_quant;
             // Set BMM scales for FP8 context computation
-            params.mla_param->bmm1_scale = fmha_bmm1_scale_ptr;
-            params.mla_param->bmm2_scale = fmha_bmm2_scale_ptr;
-            params.mla_param->quant_q_buf = mFP8ContextMLA ? fp8_q_buf : nullptr;
-            params.mla_param->quant_k_buf = mFP8ContextMLA ? fp8_k_buf : nullptr;
-            params.mla_param->quant_v_buf = mFP8ContextMLA ? fp8_v_buf : nullptr;
+            params.mla_param->bmm1_scale = workspaceViews.fmhaBmm1Scale;
+            params.mla_param->bmm2_scale = workspaceViews.fmhaBmm2Scale;
+            params.mla_param->quant_q_buf = mFP8ContextMLA ? workspaceViews.fp8QBuf : nullptr;
+            params.mla_param->quant_k_buf = mFP8ContextMLA ? workspaceViews.fp8KBuf : nullptr;
+            params.mla_param->quant_v_buf = mFP8ContextMLA ? workspaceViews.fp8VBuf : nullptr;
             // Set additional scales for context phase
             params.mla_param->quant_scale_o = params.attention_output_orig_quant;
             params.mla_param->quant_scale_q = params.kv_scale_orig_quant;
@@ -1793,7 +1773,7 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
                 "SageQuant requires positive block sizes for Q and K while the block size for V must be 1.");
             TLLM_CHECK_WITH_INFO(!params.kv_scale_quant_orig,
                 "SageAttention disregards the configured params.kv_scale_quant_orig, invalidating the result.");
-            check_cuda_error(cudaMemsetAsync(sage_v_sfs_buf, 0, sage_v_sfs_buffer_size, stream));
+            check_cuda_error(cudaMemsetAsync(workspaceViews.sageVScale, 0, sage_v_sfs_buffer_size, stream));
 
             // Common params for sageQuant
             tc::SageQuantParams sageQuantParams{};
@@ -1804,8 +1784,8 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
             sageQuantParams.sumSeqLensV = params.total_kv_len;
             sageQuantParams.numHeadsV = mNumAttnKVHeads;
             sageQuantParams.ptrV = params.v_ptr;
-            sageQuantParams.ptrVQuant = fp8_v_buf;
-            sageQuantParams.ptrVScale = sage_v_sfs_buf;
+            sageQuantParams.ptrVQuant = workspaceViews.fp8VBuf;
+            sageQuantParams.ptrVScale = workspaceViews.sageVScale;
             sageQuantParams.smCount = mMultiProcessorCount;
             sageQuantParams.stream = stream;
 
@@ -1814,8 +1794,8 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
             sageQuantParams.numHeads = mNumAttnHeads;
             sageQuantParams.tokenBlockSize = mSageAttnNumEltsPerBlkQ;
             sageQuantParams.ptrQk = attention_input;
-            sageQuantParams.ptrQkQuant = fp8_q_buf;
-            sageQuantParams.ptrQkScale = sage_q_sfs_buf;
+            sageQuantParams.ptrQkQuant = workspaceViews.fp8QBuf;
+            sageQuantParams.ptrQkScale = workspaceViews.sageQScale;
             sageQuantParams.vStage = 1;
             tc::invokeSageQuant(sageQuantParams);
 
@@ -1824,8 +1804,8 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
             sageQuantParams.numHeads = mNumAttnKVHeads;
             sageQuantParams.tokenBlockSize = mSageAttnNumEltsPerBlkK;
             sageQuantParams.ptrQk = params.k_ptr;
-            sageQuantParams.ptrQkQuant = fp8_k_buf;
-            sageQuantParams.ptrQkScale = sage_k_sfs_buf;
+            sageQuantParams.ptrQkQuant = workspaceViews.fp8KBuf;
+            sageQuantParams.ptrQkScale = workspaceViews.sageKScale;
             sageQuantParams.vStage = 2;
             tc::invokeSageQuant(sageQuantParams);
         }
@@ -1891,16 +1871,16 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
             {
                 TLLM_CHECK_WITH_INFO(
                     mFmhaDispatcher->isSeparateQAndKvInput(), "Separate QKV input is required for fp8 context MLA");
-                TLLM_CHECK_WITH_INFO(fp8_q_buf != nullptr, "FP8 q buffer is required for fp8 context MLA");
+                TLLM_CHECK_WITH_INFO(workspaceViews.fp8QBuf != nullptr, "FP8 q buffer is required for fp8 context MLA");
                 // In sparse MLA (absorption mode), K and V are stored in KV cache, not as separate FP8 buffers
-                TLLM_CHECK_WITH_INFO(useSparseMLA() || fp8_k_buf != nullptr,
+                TLLM_CHECK_WITH_INFO(useSparseMLA() || workspaceViews.fp8KBuf != nullptr,
                     "FP8 k buffer is required for fp8 context MLA in non-sparse mode");
-                TLLM_CHECK_WITH_INFO(useSparseMLA() || fp8_v_buf != nullptr,
+                TLLM_CHECK_WITH_INFO(useSparseMLA() || workspaceViews.fp8VBuf != nullptr,
                     "FP8 v buffer is required for fp8 context MLA in non-sparse mode");
 
-                fmhaParams.qPtr = reinterpret_cast<void const*>(fp8_q_buf);
-                fmhaParams.kPtr = useSparseMLA() ? nullptr : reinterpret_cast<void const*>(fp8_k_buf);
-                fmhaParams.vPtr = useSparseMLA() ? nullptr : reinterpret_cast<void const*>(fp8_v_buf);
+                fmhaParams.qPtr = reinterpret_cast<void const*>(workspaceViews.fp8QBuf);
+                fmhaParams.kPtr = useSparseMLA() ? nullptr : reinterpret_cast<void const*>(workspaceViews.fp8KBuf);
+                fmhaParams.vPtr = useSparseMLA() ? nullptr : reinterpret_cast<void const*>(workspaceViews.fp8VBuf);
             }
             else
             {
@@ -1915,19 +1895,19 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
             TLLM_CHECK_WITH_INFO(
                 mFmhaDispatcher->isSeparateQAndKvInput(), "Separate QKV input is required for sage attention FMHA");
             fmhaParams.qkvPtr = nullptr;
-            fmhaParams.qPtr = reinterpret_cast<void const*>(fp8_q_buf);
-            fmhaParams.kPtr = reinterpret_cast<void const*>(fp8_k_buf);
-            fmhaParams.vPtr = reinterpret_cast<void const*>(fp8_v_buf);
+            fmhaParams.qPtr = reinterpret_cast<void const*>(workspaceViews.fp8QBuf);
+            fmhaParams.kPtr = reinterpret_cast<void const*>(workspaceViews.fp8KBuf);
+            fmhaParams.vPtr = reinterpret_cast<void const*>(workspaceViews.fp8VBuf);
             // Set sage attention scaling factor pointers.
-            fmhaParams.qScalePtr = sage_q_sfs_buf;
-            fmhaParams.kScalePtr = sage_k_sfs_buf;
-            fmhaParams.vScalePtr = sage_v_sfs_buf;
+            fmhaParams.qScalePtr = workspaceViews.sageQScale;
+            fmhaParams.kScalePtr = workspaceViews.sageKScale;
+            fmhaParams.vScalePtr = workspaceViews.sageVScale;
         }
         else
         {
-            fmhaParams.qkvPtr = mFP8ContextFMHA ? reinterpret_cast<void const*>(fp8_qkv_buffer)
+            fmhaParams.qkvPtr = mFP8ContextFMHA ? reinterpret_cast<void const*>(workspaceViews.fp8QkvBuf)
                                                 : reinterpret_cast<void const*>(attention_input);
-            fmhaParams.qPtr = reinterpret_cast<void const*>(q_buf_2_);
+            fmhaParams.qPtr = reinterpret_cast<void const*>(workspaceViews.qBuf);
         }
         // TODO: add contiguous kv buffer (cross-attention).
         fmhaParams.kvPtr = nullptr;
@@ -1935,8 +1915,8 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         {
             fmhaParams.kvPtr = params.cross_kv;
         }
-        fmhaParams.outputPtr
-            = mCpSize > 1 ? gatherOutBuffer : params.context_buf; // only use [totalLength, h / cpSize, Dh]
+        // Only use [totalLength, h / cpSize, Dh].
+        fmhaParams.outputPtr = mCpSize > 1 ? workspaceViews.gatherOutBuffer : params.context_buf;
         fmhaParams.outputSfPtr = params.context_buf_sf;
         fmhaParams.attentionSinksPtr = params.attention_sinks;
         fmhaParams.packedMaskPtr = params.attention_packed_mask;
@@ -1945,13 +1925,13 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
             fmhaParams.pagedKvCache = kv_cache_buffer;
             fmhaParams.pagedKvSfCache = kv_scale_cache_buffer;
         }
-        fmhaParams.cuQSeqLenPtr = cu_q_seqlens;
+        fmhaParams.cuQSeqLenPtr = workspaceViews.cuQSeqlens;
         fmhaParams.kvSeqLenPtr = decoder_params.seqKVLengths;
-        fmhaParams.cuKvSeqLenPtr = cu_kv_seqlens;
-        fmhaParams.cuMaskRowsPtr = cu_mask_rows;
-        fmhaParams.tileCounterPtr = fmha_tile_counter_ptr;
-        fmhaParams.scaleBmm1Ptr = fmha_bmm1_scale_ptr;
-        fmhaParams.scaleBmm2Ptr = fmha_bmm2_scale_ptr;
+        fmhaParams.cuKvSeqLenPtr = workspaceViews.cuKvSeqlens;
+        fmhaParams.cuMaskRowsPtr = workspaceViews.cuMaskRows;
+        fmhaParams.tileCounterPtr = workspaceViews.fmhaTileCounter;
+        fmhaParams.scaleBmm1Ptr = workspaceViews.fmhaBmm1Scale;
+        fmhaParams.scaleBmm2Ptr = workspaceViews.fmhaBmm2Scale;
         fmhaParams.oSfScalePtr = params.attention_output_sf_scale;
         fmhaParams.stream = stream;
         fmhaParams.forceFp32Acc = mFMHAForceFP32Acc;
@@ -1986,8 +1966,9 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
 
         if (mCpSize > 1 && mAttnTpSize > 1 && mAttnCpSize == 1)
         {
-            this->template ulyssesContextPostprocess<T>(gatherOutBuffer, reinterpret_cast<T*>(params.context_buf),
-                gatherInBuffer, params, cu_q_seqlens, cu_cp_partial_seqlens, stream);
+            this->template ulyssesContextPostprocess<T>(workspaceViews.gatherOutBuffer,
+                reinterpret_cast<T*>(params.context_buf), workspaceViews.gatherInBuffer, params,
+                workspaceViews.cuQSeqlens, workspaceViews.cuCpPartialSeqlens, stream);
             sync_check_cuda_error(stream);
         }
 
@@ -2003,20 +1984,24 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         TLLM_CHECK_WITH_INFO(mAttentionChunkSize == std::nullopt, "Unfused MHA does not support chunked attention");
         // FIXME: a temporary solution to make sure the padding part of key/value buffer is 0
         // NOTE: pointer subtraction is used below since there could be some extra gap due to alignment.
-        //  Otherwise, we could do cudaMemsetAsync(k_buf_2_, 0, k_buf_2_size + v_buf_2_size, stream);
-        // cudaMemsetAsync(k_buf_2_, 0, reinterpret_cast<int8_t*>(qk_buf_) - reinterpret_cast<int8_t*>(k_buf_2_),
-        // stream);
-        cudaMemsetAsync(k_buf_2_, 0,
-            reinterpret_cast<int8_t*>(v_buf_2_) - reinterpret_cast<int8_t*>(k_buf_2_) + v_buf_2_size, stream);
+        //  Otherwise, we could do cudaMemsetAsync(workspaceViews.kBuf, 0, k_buf_2_size + v_buf_2_size, stream).
+        // cudaMemsetAsync(workspaceViews.kBuf, 0,
+        //     reinterpret_cast<int8_t*>(workspaceViews.qkBuf) - reinterpret_cast<int8_t*>(workspaceViews.kBuf),
+        //     stream);
+        cudaMemsetAsync(workspaceViews.kBuf, 0,
+            reinterpret_cast<int8_t*>(workspaceViews.vBuf) - reinterpret_cast<int8_t*>(workspaceViews.kBuf)
+                + v_buf_2_size,
+            stream);
 
         if (!isCrossAttention())
         {
             // self attention, write to from QKV to Q/K/V
-            invokeAddFusedQKVBiasTranspose(q_buf_2_, k_buf_2_, v_buf_2_, const_cast<T*>(params.attention_input),
-                const_cast<T*>(params.qkv_bias), params.context_lengths, mRemovePadding ? padding_offset : nullptr,
-                params.batch_size, params.input_seq_length, params.num_tokens, mNumHeads, mNumKVHeads, getHeadSize(),
-                mRotaryEmbeddingDim, mRotaryEmbeddingBase, mRotaryEmbeddingScaleType, mRotaryEmbeddingScale,
-                mRotaryEmbeddingMaxPositions, position_embedding_type, (float*) nullptr, 0, stream);
+            invokeAddFusedQKVBiasTranspose(workspaceViews.qBuf, workspaceViews.kBuf, workspaceViews.vBuf,
+                const_cast<T*>(params.attention_input), const_cast<T*>(params.qkv_bias), params.context_lengths,
+                mRemovePadding ? workspaceViews.paddingOffset : nullptr, params.batch_size, params.input_seq_length,
+                params.num_tokens, mNumHeads, mNumKVHeads, getHeadSize(), mRotaryEmbeddingDim, mRotaryEmbeddingBase,
+                mRotaryEmbeddingScaleType, mRotaryEmbeddingScale, mRotaryEmbeddingMaxPositions, position_embedding_type,
+                (float*) nullptr, 0, stream);
             sync_check_cuda_error(stream);
         }
         else
@@ -2024,26 +2009,27 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
             // cross attention, write from self QKV [*, head_num * head_size + 2 * kv_head_num * head_size]to Q, write
             // from cross KV [*, 2 * kv_head_num * head_size] to K/V kernel modified accordingly to handle nullptr
             // buffer
-            invokeAddFusedQKVBiasTranspose(q_buf_2_, (T*) nullptr, (T*) nullptr, const_cast<T*>(params.attention_input),
-                const_cast<T*>(params.qkv_bias), params.context_lengths, mRemovePadding ? padding_offset : nullptr,
-                params.batch_size, params.input_seq_length, params.num_tokens, mNumHeads, mNumKVHeads, getHeadSize(),
-                mRotaryEmbeddingDim, mRotaryEmbeddingBase, mRotaryEmbeddingScaleType, mRotaryEmbeddingScale,
-                mRotaryEmbeddingMaxPositions, position_embedding_type, (float*) nullptr, 0, stream);
+            invokeAddFusedQKVBiasTranspose(workspaceViews.qBuf, (T*) nullptr, (T*) nullptr,
+                const_cast<T*>(params.attention_input), const_cast<T*>(params.qkv_bias), params.context_lengths,
+                mRemovePadding ? workspaceViews.paddingOffset : nullptr, params.batch_size, params.input_seq_length,
+                params.num_tokens, mNumHeads, mNumKVHeads, getHeadSize(), mRotaryEmbeddingDim, mRotaryEmbeddingBase,
+                mRotaryEmbeddingScaleType, mRotaryEmbeddingScale, mRotaryEmbeddingMaxPositions, position_embedding_type,
+                (float*) nullptr, 0, stream);
             sync_check_cuda_error(stream);
 
-            invokeAddFusedQKVBiasTranspose((T*) nullptr, k_buf_2_, v_buf_2_, const_cast<T*>(params.cross_kv),
-                const_cast<T*>(params.qkv_bias), params.encoder_input_lengths,
-                mRemovePadding ? encoder_padding_offset : nullptr, params.batch_size, params.cross_kv_length,
-                params.num_encoder_tokens, /*mNumHeads*/ 0, mNumKVHeads, getHeadSize(), mRotaryEmbeddingDim,
-                mRotaryEmbeddingBase, mRotaryEmbeddingScaleType, mRotaryEmbeddingScale, mRotaryEmbeddingMaxPositions,
-                position_embedding_type, (float*) nullptr, 0, stream);
+            invokeAddFusedQKVBiasTranspose((T*) nullptr, workspaceViews.kBuf, workspaceViews.vBuf,
+                const_cast<T*>(params.cross_kv), const_cast<T*>(params.qkv_bias), params.encoder_input_lengths,
+                mRemovePadding ? workspaceViews.encoderPaddingOffset : nullptr, params.batch_size,
+                params.cross_kv_length, params.num_encoder_tokens, /*mNumHeads*/ 0, mNumKVHeads, getHeadSize(),
+                mRotaryEmbeddingDim, mRotaryEmbeddingBase, mRotaryEmbeddingScaleType, mRotaryEmbeddingScale,
+                mRotaryEmbeddingMaxPositions, position_embedding_type, (float*) nullptr, 0, stream);
             sync_check_cuda_error(stream);
         }
 
         // write KV to cache
         if (useKVCache())
         {
-            invokeTranspose4dBatchMajor(k_buf_2_, v_buf_2_, kv_cache_buffer, params.batch_size,
+            invokeTranspose4dBatchMajor(workspaceViews.kBuf, workspaceViews.vBuf, kv_cache_buffer, params.batch_size,
                 isCrossAttention() ? params.cross_kv_length : params.input_seq_length,
                 isCrossAttention() ? params.cross_kv_length : params.cyclic_attention_window_size, getHeadSize(),
                 mNumKVHeads, cache_type, params.kv_scale_orig_quant,
@@ -2056,7 +2042,8 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         int const relative_attention_bias_stride = isRelativePosition() ? params.relative_attention_bias_stride : 0;
         int const max_distance = mMaxDistance;
         cudaDataType_t gemm_out_data_type = is_qk_buf_float_ ? CUDA_R_32F : gemm_data_type;
-        void* gemm_out_buf_ = is_qk_buf_float_ ? static_cast<void*>(qk_buf_float_) : static_cast<void*>(qk_buf_);
+        void* gemm_out_buf_ = is_qk_buf_float_ ? static_cast<void*>(workspaceViews.qkFloatBuf)
+                                               : static_cast<void*>(workspaceViews.qkBuf);
         if (mNumKVHeads == 1) // MQA
         {
             // Attn_weight[b, h*s_q, s_k] = Q[b, h*s_q, d] * K'[b, d, s_k]
@@ -2065,10 +2052,10 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
                 attention_seq_len_2,                                   // n
                 attention_seq_len_1 * mNumHeads,                       // m
                 getHeadSize(),                                         // k
-                qk_scale_gemm, k_buf_2_, gemm_data_type,
+                qk_scale_gemm, workspaceViews.kBuf, gemm_data_type,
                 getHeadSize(),                                         // k
                 attention_seq_len_2 * getHeadSize(),                   // n * k
-                q_buf_2_, gemm_data_type,
+                workspaceViews.qBuf, gemm_data_type,
                 getHeadSize(),                                         // k
                 attention_seq_len_1 * mNumHeads * getHeadSize(),       // m * k
                 0.0f, gemm_out_buf_, gemm_out_data_type,
@@ -2085,10 +2072,10 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
                 attention_seq_len_2,                 // n
                 attention_seq_len_1,                 // m
                 getHeadSize(),                       // k
-                qk_scale_gemm, k_buf_2_, gemm_data_type,
+                qk_scale_gemm, workspaceViews.kBuf, gemm_data_type,
                 getHeadSize(),                       // k
                 attention_seq_len_2 * getHeadSize(), // n * k
-                q_buf_2_, gemm_data_type,
+                workspaceViews.qBuf, gemm_data_type,
                 getHeadSize(),                       // k
                 attention_seq_len_1 * getHeadSize(), // m * k
                 0.0f, gemm_out_buf_, gemm_out_data_type,
@@ -2106,11 +2093,11 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
             int const num_qheads_per_kv_head = mNumHeads / mNumKVHeads;
             for (int ki = 0; ki < mNumKVHeads; ++ki)
             {
-                T* qptr = q_buf_2_ + (ki * num_qheads_per_kv_head * attention_seq_len_1 * getHeadSize());
-                T* kptr = k_buf_2_ + (ki * attention_seq_len_2 * getHeadSize());
+                T* qptr = workspaceViews.qBuf + (ki * num_qheads_per_kv_head * attention_seq_len_1 * getHeadSize());
+                T* kptr = workspaceViews.kBuf + (ki * attention_seq_len_2 * getHeadSize());
                 int const qk_offset = ki * attention_seq_len_1 * num_qheads_per_kv_head * attention_seq_len_2;
-                void* qkptr = is_qk_buf_float_ ? static_cast<void*>(qk_buf_float_ + qk_offset)
-                                               : static_cast<void*>(qk_buf_ + qk_offset);
+                void* qkptr = is_qk_buf_float_ ? static_cast<void*>(workspaceViews.qkFloatBuf + qk_offset)
+                                               : static_cast<void*>(workspaceViews.qkBuf + qk_offset);
                 mCublasWrapper->stridedBatchedGemm(CUBLAS_OP_T, CUBLAS_OP_N,
                     attention_seq_len_2,                                   // n
                     attention_seq_len_1 * num_qheads_per_kv_head,          // m
@@ -2139,16 +2126,16 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
                 // local_head_num, max_output_len + 1, max_output_len + 1). broadcast along 1st dim. max_seq_len is
                 // already max_output_len + 1. In implicit mode, relative_attention_bias is relative_attention_table
                 // [num_heads, num_buckets], with necessary params (max_distance, num_buckets) passed at the end
-                invokeAddRelativeAttentionBiasUnaligned(qk_buf_float_, relative_attention_bias, params.batch_size,
-                    mNumHeads, attention_seq_len_1,
+                invokeAddRelativeAttentionBiasUnaligned(workspaceViews.qkFloatBuf, relative_attention_bias,
+                    params.batch_size, mNumHeads, attention_seq_len_1,
                     isCrossAttention() ? params.cross_kv_length : params.cyclic_attention_window_size, stream,
                     max_distance > 0, relative_attention_bias_stride, max_distance, false /* bidirectional */);
             }
 
             MaskedSoftmaxParam<T, float> param;
-            param.attention_score = qk_buf_;       // (batch_size, head_num, q_length, k_length)
-            param.qk = qk_buf_float_;              // (batch_size, head_num, q_length, k_length)
-            param.attention_mask = attention_mask; // (batch_size, q_length, k_length)
+            param.attention_score = workspaceViews.qkBuf;        // (batch_size, head_num, q_length, k_length)
+            param.qk = workspaceViews.qkFloatBuf;                // (batch_size, head_num, q_length, k_length)
+            param.attention_mask = workspaceViews.attentionMask; // (batch_size, q_length, k_length)
             param.batch_size = params.batch_size;
             param.q_length = attention_seq_len_1;
             param.k_length = attention_seq_len_2;
@@ -2172,16 +2159,16 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
                 // local_head_num, max_output_len + 1, max_output_len + 1). broadcast along 1st dim. max_seq_len is
                 // already max_output_len + 1. In implicit mode, relative_attention_bias is relative_attention_table
                 // [num_heads, num_buckets], with necessary params (max_distance, num_buckets) passed at the end
-                invokeAddRelativeAttentionBiasUnaligned(qk_buf_, relative_attention_bias, params.batch_size, mNumHeads,
-                    attention_seq_len_1,
+                invokeAddRelativeAttentionBiasUnaligned(workspaceViews.qkBuf, relative_attention_bias,
+                    params.batch_size, mNumHeads, attention_seq_len_1,
                     isCrossAttention() ? params.cross_kv_length : params.cyclic_attention_window_size, stream,
                     max_distance > 0, relative_attention_bias_stride, max_distance, false /* bidirectional */);
             }
 
             MaskedSoftmaxParam<T, T> param;
-            param.attention_score = qk_buf_;       // (batch_size, head_num, q_length, k_length)
-            param.qk = qk_buf_;                    // (batch_size, head_num, q_length, k_length)
-            param.attention_mask = attention_mask; // (batch_size, q_length, k_length)
+            param.attention_score = workspaceViews.qkBuf;        // (batch_size, head_num, q_length, k_length)
+            param.qk = workspaceViews.qkBuf;                     // (batch_size, head_num, q_length, k_length)
+            param.attention_mask = workspaceViews.attentionMask; // (batch_size, q_length, k_length)
             param.batch_size = params.batch_size;
             param.q_length = attention_seq_len_1;
             param.k_length = attention_seq_len_2;
@@ -2205,13 +2192,13 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
                 getHeadSize(),                                         // n
                 mNumHeads * attention_seq_len_1,                       // m
                 attention_seq_len_2,                                   // k
-                v_buf_2_,
+                workspaceViews.vBuf,
                 getHeadSize(),                                         // n
                 getHeadSize() * attention_seq_len_2,                   // n * k
-                qk_buf_,
+                workspaceViews.qkBuf,
                 attention_seq_len_2,                                   // k
                 attention_seq_len_2 * mNumHeads * attention_seq_len_1, // m * k
-                qkv_buf_2_,
+                workspaceViews.qkvBuf,
                 getHeadSize(),                                         // n
                 getHeadSize() * mNumHeads * attention_seq_len_1,       // n * m
                 params.batch_size                                      // global batch size
@@ -2222,9 +2209,10 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
             // O[b*h, s_q, d] = Attn_weight[b*h, s_q, s_k] * V[b*h, s_k, d]
             // O'[b*h, d, s_q] = V'[b*h, d, s_k] * Attn_weight'[b*h, s_k, s_q]
             mCublasWrapper->stridedBatchedGemm(CUBLAS_OP_N, CUBLAS_OP_N, getHeadSize(), attention_seq_len_1,
-                attention_seq_len_2, v_buf_2_, getHeadSize(), attention_seq_len_2 * getHeadSize(), qk_buf_,
-                attention_seq_len_2, attention_seq_len_1 * attention_seq_len_2, qkv_buf_2_, getHeadSize(),
-                attention_seq_len_1 * getHeadSize(), params.batch_size * mNumHeads);
+                attention_seq_len_2, workspaceViews.vBuf, getHeadSize(), attention_seq_len_2 * getHeadSize(),
+                workspaceViews.qkBuf, attention_seq_len_2, attention_seq_len_1 * attention_seq_len_2,
+                workspaceViews.qkvBuf, getHeadSize(), attention_seq_len_1 * getHeadSize(),
+                params.batch_size * mNumHeads);
         }
         else // GQA
         {
@@ -2234,9 +2222,10 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
             int const num_qheads_per_kv_head = mNumHeads / mNumKVHeads;
             for (int ki = 0; ki < mNumKVHeads; ++ki)
             {
-                T* qkptr = qk_buf_ + (ki * num_qheads_per_kv_head * attention_seq_len_1 * attention_seq_len_2);
-                T* vptr = v_buf_2_ + (ki * attention_seq_len_2 * getHeadSize());
-                T* qkvptr = qkv_buf_2_ + (ki * attention_seq_len_1 * num_qheads_per_kv_head * getHeadSize());
+                T* qkptr
+                    = workspaceViews.qkBuf + (ki * num_qheads_per_kv_head * attention_seq_len_1 * attention_seq_len_2);
+                T* vptr = workspaceViews.vBuf + (ki * attention_seq_len_2 * getHeadSize());
+                T* qkvptr = workspaceViews.qkvBuf + (ki * attention_seq_len_1 * num_qheads_per_kv_head * getHeadSize());
                 mCublasWrapper->stridedBatchedGemm(CUBLAS_OP_N, CUBLAS_OP_N,
                     getHeadSize(),                                         // n
                     num_qheads_per_kv_head * attention_seq_len_1,          // m
@@ -2257,14 +2246,14 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
 
         if (!mRemovePadding)
         {
-            invokeTransposeQKV(static_cast<T*>(params.context_buf), qkv_buf_2_, params.batch_size, attention_seq_len_1,
-                mNumHeads, getHeadSize(), (float*) nullptr, 0, stream);
+            invokeTransposeQKV(static_cast<T*>(params.context_buf), workspaceViews.qkvBuf, params.batch_size,
+                attention_seq_len_1, mNumHeads, getHeadSize(), (float*) nullptr, 0, stream);
         }
         else
         {
-            invokeTransposeAttentionOutRemovePadding(qkv_buf_2_, static_cast<T*>(params.context_buf), params.num_tokens,
-                params.batch_size, attention_seq_len_1, mNumHeads, getHeadSize(), padding_offset, (float*) nullptr, 0,
-                stream);
+            invokeTransposeAttentionOutRemovePadding(workspaceViews.qkvBuf, static_cast<T*>(params.context_buf),
+                params.num_tokens, params.batch_size, attention_seq_len_1, mNumHeads, getHeadSize(),
+                workspaceViews.paddingOffset, (float*) nullptr, 0, stream);
         }
     }
     return 0;
@@ -2366,19 +2355,21 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
         !mAttentionChunkSize.has_value() || params.cyclic_attention_window_size >= params.max_past_kv_length,
         "Chunked-attention and sliding-window-attention should not be enabled at the same time.");
 
-    int8_t* workspace_byte_ptr = reinterpret_cast<int8_t*>(params.workspace);
-    size_t offset = 0;
     size_t const cpMaxPaddedSequenceLength = (batch_beam + mCpSize - 1) / mCpSize * mCpSize;
     size_t const cpWorkspaceSize
         = mCpSize == 1 ? 0 : 2 * sizeof(T) * cpMaxPaddedSequenceLength * (mNumHeads + 2 * mNumKVHeads) * mHeadSize;
-    T* mhaOutput = reinterpret_cast<T*>(nextWorkspacePtr(workspace_byte_ptr, offset, cpWorkspaceSize));
-    T* mhaInput = mhaOutput + cpMaxPaddedSequenceLength * (mNumHeads + 2 * mNumKVHeads) * mHeadSize;
+    AttentionGenerationWorkspaceSizes cpWorkspaceSizes{};
+    cpWorkspaceSizes.cpWorkspace = cpWorkspaceSize;
+    auto const cpWorkspaceLayout = AttentionWorkspaceManager::buildGenerationLayout(cpWorkspaceSizes);
+    auto const cpWorkspaceViews = AttentionWorkspaceManager::materializeGeneration<T>(
+        params.workspace, cpWorkspaceLayout, cpMaxPaddedSequenceLength, mNumHeads, mNumKVHeads, mHeadSize);
 
     T* attention_input = const_cast<T*>(params.attention_input);
     if (mCpSize > 1 && mAttnTpSize > 1 && mAttnCpSize == 1)
     {
-        this->template ulyssesGenerationPreprocess<T>(attention_input, mhaInput, mhaOutput, batch_beam, stream);
-        attention_input = mhaInput;
+        this->template ulyssesGenerationPreprocess<T>(
+            attention_input, cpWorkspaceViews.mhaInput, cpWorkspaceViews.mhaOutput, batch_beam, stream);
+        attention_input = cpWorkspaceViews.mhaInput;
         sync_check_cuda_error(stream);
     }
 
@@ -2395,14 +2386,14 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
             xqaParams.stream = stream;
             if (mCpSize > 1)
             {
-                xqaParams.output = mhaOutput;
+                xqaParams.output = cpWorkspaceViews.mhaOutput;
                 xqaParams.qkv = attention_input;
             }
             mXqaDispatcher->run(xqaParams, kv_cache_buffer, kv_scale_cache_buffer);
             if (mCpSize > 1 && mAttnTpSize > 1 && mAttnCpSize == 1)
             {
-                this->template ulyssesGenerationPostprocess<T>(
-                    mhaOutput, reinterpret_cast<T*>(params.context_buf), mhaInput, batch_beam, stream);
+                this->template ulyssesGenerationPostprocess<T>(cpWorkspaceViews.mhaOutput,
+                    reinterpret_cast<T*>(params.context_buf), cpWorkspaceViews.mhaInput, batch_beam, stream);
                 sync_check_cuda_error(stream);
             }
             return 0;
@@ -2456,11 +2447,15 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
         ? 0
         : sizeof(T) * batch_beam * mNumHeads * mHeadSize * params.max_attention_window_size;
 
-    // Workspace pointer shift
-    T* partial_out = reinterpret_cast<T*>(nextWorkspacePtr(workspace_byte_ptr, offset, partial_out_size));
-    float* partial_sum = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, partial_sum_size));
-    float* partial_max = reinterpret_cast<float*>(nextWorkspacePtr(workspace_byte_ptr, offset, partial_max_size));
-    T* shift_k_cache = reinterpret_cast<T*>(nextWorkspacePtr(workspace_byte_ptr, offset, shift_k_cache_size));
+    AttentionGenerationWorkspaceSizes workspaceSizes{};
+    workspaceSizes.cpWorkspace = cpWorkspaceSize;
+    workspaceSizes.partialOut = partial_out_size;
+    workspaceSizes.partialSum = partial_sum_size;
+    workspaceSizes.partialMax = partial_max_size;
+    workspaceSizes.shiftKCache = shift_k_cache_size;
+    auto const workspaceLayout = AttentionWorkspaceManager::buildGenerationLayout(workspaceSizes);
+    auto const workspaceViews = AttentionWorkspaceManager::materializeGeneration<T>(
+        params.workspace, workspaceLayout, cpMaxPaddedSequenceLength, mNumHeads, mNumKVHeads, mHeadSize);
 
     // Apply position embedding to the keys in the K cache
     KVLinearBuffer shift_k_cache_buffer;
@@ -2468,7 +2463,7 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
     {
         shift_k_cache_buffer = KVLinearBuffer(batch_beam, params.max_attention_window_size, sizePerToken,
             params.cyclic_attention_window_size, params.sink_token_length, true,
-            reinterpret_cast<int8_t*>(shift_k_cache));
+            reinterpret_cast<int8_t*>(workspaceViews.shiftKCache));
         sync_check_cuda_error(stream);
         // KV cache type
         KvCacheDataType const kv_cache_type = KvCacheDataType::BASE;
@@ -2492,7 +2487,7 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
     dispatch_params.attention_sinks = params.attention_sinks;
     dispatch_params.max_distance = max_distance;
     dispatch_params.cache_indir = params.cache_indir;
-    dispatch_params.context_buf = mCpSize > 1 ? mhaOutput : params.context_buf; //
+    dispatch_params.context_buf = mCpSize > 1 ? cpWorkspaceViews.mhaOutput : params.context_buf; //
     dispatch_params.finished = finished;
     dispatch_params.sequence_lengths
         = params.sequence_lengths; // NOTE: current seq len including padding (fixed after meeting the finished id)
@@ -2523,9 +2518,9 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
     dispatch_params.multi_block_mode = enable_multi_block;
     dispatch_params.max_seq_len_tile = max_num_seq_len_tiles;
     dispatch_params.min_seq_len_tile = min_num_seq_len_tiles;
-    dispatch_params.partial_out = partial_out;
-    dispatch_params.partial_sum = partial_sum;
-    dispatch_params.partial_max = partial_max;
+    dispatch_params.partial_out = workspaceViews.partialOut;
+    dispatch_params.partial_sum = workspaceViews.partialSum;
+    dispatch_params.partial_max = workspaceViews.partialMax;
     dispatch_params.block_counter = mMultiBlockSemaphores.get();
     dispatch_params.kv_cache_quant_mode = mKVCacheQuantMode;
     dispatch_params.kv_scale_orig_quant = params.kv_scale_orig_quant;
@@ -2568,8 +2563,8 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
 
     if (mCpSize > 1 && mAttnTpSize > 1 && mAttnCpSize == 1)
     {
-        this->template ulyssesGenerationPostprocess<T>(
-            mhaOutput, reinterpret_cast<T*>(params.context_buf), mhaInput, batch_beam, stream);
+        this->template ulyssesGenerationPostprocess<T>(cpWorkspaceViews.mhaOutput,
+            reinterpret_cast<T*>(params.context_buf), cpWorkspaceViews.mhaInput, batch_beam, stream);
         sync_check_cuda_error(stream);
     }
     return 0;

--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -21,6 +21,7 @@
 #include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/common/memoryUtils.h"
+#include "tensorrt_llm/common/nvtxUtils.h"
 #include "tensorrt_llm/common/sageQuant.h"
 #include "tensorrt_llm/kernels/decoderMaskedMultiheadAttention.h"
 #include "tensorrt_llm/kernels/flashMLA/flash_mla.h"
@@ -1350,6 +1351,7 @@ MLA_FUNC_DEFINE(__nv_bfloat16)
 template <typename T, typename KVCacheBuffer>
 int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStream_t stream)
 {
+    NVTX3_SCOPED_RANGE_WITH_NAME(attentionOpEnqueueContextRange, "AttentionOp.enqueueContext");
     int const headSize = getHeadSize();
 
     int const local_hidden_units_qo = mNumHeads * headSize;
@@ -1364,6 +1366,7 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
 
     if (useKVCache())
     {
+        NVTX3_SCOPED_RANGE_WITH_NAME(kvCacheBuffersRange, "AttentionOp.context.kv_cache_buffers");
         auto buffers = buildKvCacheBuffers<KVCacheBuffer>(params.batch_size, params.max_blocks_per_sequence,
             mTokensPerBlock, sizePerToken, params.cyclic_attention_window_size, params.max_cyclic_attention_window_size,
             params.sink_token_length, params.can_use_one_more_block, params.host_primary_pool_pointer,
@@ -1576,8 +1579,11 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
     decoder_params.rotaryEmbeddingInvFreqCache = params.rotary_inv_freq;
     decoder_params.rotaryEmbeddingMaxPositions = mRotaryEmbeddingMaxPositions;
 
-    invokeBuildDecoderInfo(decoder_params, stream);
-    sync_check_cuda_error(stream);
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(buildDecoderInfoRange, "AttentionOp.context.build_decoder_info");
+        invokeBuildDecoderInfo(decoder_params, stream);
+        sync_check_cuda_error(stream);
+    }
 
     // In cross attention context phase, the attention mask should be a matrix of all ones.
     // Override the attention mask produced by invokeBuildDecoderInfo().
@@ -1735,6 +1741,7 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
 
         if (mIsMLAEnabled)
         {
+            NVTX3_SCOPED_RANGE_WITH_NAME(mlaPreprocessRange, "AttentionOp.context.mla_preprocess");
             TLLM_CHECK_WITH_INFO(params.mla_param != nullptr, "MLA param is nullptr");
             params.mla_param->cache_type = cache_type;
             params.mla_param->cu_q_seqlens = workspaceViews.cuQSeqlens;
@@ -1766,6 +1773,7 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         }
         else if (useSageAttnSeparateQkv)
         {
+            NVTX3_SCOPED_RANGE_WITH_NAME(sagePreprocessRange, "AttentionOp.context.sage_preprocess");
             TLLM_CHECK_WITH_INFO(mFP8ContextFMHA, "SageAttention kernel runs under mFP8ContextFMHA option.");
             TLLM_CHECK_WITH_INFO(mFmhaDispatcher->isSupported(), "SageAttention has no unfused fallback implemented.");
             TLLM_CHECK_WITH_INFO(
@@ -1811,6 +1819,7 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         }
         else
         {
+            NVTX3_SCOPED_RANGE_WITH_NAME(qkvPreprocessRange, "AttentionOp.context.qkv_preprocess");
             invokeQKVPreprocessing(preprocessingParams, stream);
         }
         sync_check_cuda_error(stream);
@@ -1961,8 +1970,11 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
         }
 
         // Run the fmha kernel.
-        mFmhaDispatcher->run(fmhaParams);
-        sync_check_cuda_error(stream);
+        {
+            NVTX3_SCOPED_RANGE_WITH_NAME(fmhaRange, "AttentionOp.context.fmha");
+            mFmhaDispatcher->run(fmhaParams);
+            sync_check_cuda_error(stream);
+        }
 
         if (mCpSize > 1 && mAttnTpSize > 1 && mAttnCpSize == 1)
         {
@@ -1974,6 +1986,7 @@ int AttentionOp::enqueueContext(EnqueueContextParams<T> const& params, cudaStrea
 
         if (!mIsMLAEnabled) // Only for non-MLA attention
         {
+            NVTX3_SCOPED_RANGE_WITH_NAME(kvCachePostprocessRange, "AttentionOp.context.kv_cache_postprocess");
             invokeKvCachePostprocessing(preprocessingParams, stream);
             sync_check_cuda_error(stream);
         }
@@ -2284,6 +2297,7 @@ template int AttentionOp::enqueueContext<__nv_bfloat16, KVBlockArray>(
 template <typename T, typename KVCacheBuffer>
 int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cudaStream_t stream)
 {
+    NVTX3_SCOPED_RANGE_WITH_NAME(attentionOpEnqueueGenerationRange, "AttentionOp.enqueueGeneration");
     int const headSize = getHeadSize();
     float const q_scaling = mQScaling;
     float const* logn_scaling_ptr = isLognScaling() ? params.logn_scaling_ptr : nullptr;
@@ -2308,6 +2322,7 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
 
     if (useKVCache())
     {
+        NVTX3_SCOPED_RANGE_WITH_NAME(kvCacheBuffersRange, "AttentionOp.generation.kv_cache_buffers");
         auto buffers = buildKvCacheBuffers<KVCacheBuffer>(batch_beam, params.max_blocks_per_sequence, mTokensPerBlock,
             sizePerToken, params.cyclic_attention_window_size, params.max_cyclic_attention_window_size,
             params.sink_token_length, params.can_use_one_more_block, params.host_primary_pool_pointer,
@@ -2375,6 +2390,7 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
 
     // Try XQA optimization first.
     {
+        NVTX3_SCOPED_RANGE_WITH_NAME(xqaTryRange, "AttentionOp.generation.xqa_try");
         // NOTE: input_seq_length = num_medusa_tokens + 1 (new generated one from the original LM head)
         // self attn
         XQAParams xqaParams{};
@@ -2389,7 +2405,10 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
                 xqaParams.output = cpWorkspaceViews.mhaOutput;
                 xqaParams.qkv = attention_input;
             }
-            mXqaDispatcher->run(xqaParams, kv_cache_buffer, kv_scale_cache_buffer);
+            {
+                NVTX3_SCOPED_RANGE_WITH_NAME(xqaRunRange, "AttentionOp.generation.xqa_run");
+                mXqaDispatcher->run(xqaParams, kv_cache_buffer, kv_scale_cache_buffer);
+            }
             if (mCpSize > 1 && mAttnTpSize > 1 && mAttnCpSize == 1)
             {
                 this->template ulyssesGenerationPostprocess<T>(cpWorkspaceViews.mhaOutput,
@@ -2547,19 +2566,22 @@ int AttentionOp::enqueueGeneration(EnqueueGenerationParams<T> const& params, cud
     dispatch_params.mrope_position_deltas = params.mrope_position_deltas;
 
     using DataType = typename SATypeConverter<T>::Type;
-    if (!isCrossAttention())
     {
-        // self attn
-        Masked_multihead_attention_params<DataType> mmha_params;
-        fusedQKV_masked_attention_dispatch(mmha_params, dispatch_params, stream);
+        NVTX3_SCOPED_RANGE_WITH_NAME(mmhaRange, "AttentionOp.generation.mmha");
+        if (!isCrossAttention())
+        {
+            // self attn
+            Masked_multihead_attention_params<DataType> mmha_params;
+            fusedQKV_masked_attention_dispatch(mmha_params, dispatch_params, stream);
+        }
+        else
+        {
+            // cross attn
+            Cross_multihead_attention_params<DataType> mmhca_params;
+            fusedQKV_masked_attention_dispatch(mmhca_params, dispatch_params, stream);
+        }
+        sync_check_cuda_error(stream);
     }
-    else
-    {
-        // cross attn
-        Cross_multihead_attention_params<DataType> mmhca_params;
-        fusedQKV_masked_attention_dispatch(mmhca_params, dispatch_params, stream);
-    }
-    sync_check_cuda_error(stream);
 
     if (mCpSize > 1 && mAttnTpSize > 1 && mAttnCpSize == 1)
     {

--- a/cpp/tensorrt_llm/common/attentionWorkspace.h
+++ b/cpp/tensorrt_llm/common/attentionWorkspace.h
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/workspace.h"
+
+#include <cstddef>
+#include <cstdint>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace common::op
+{
+
+struct WorkspaceSlice
+{
+    size_t offset{};
+    size_t size{};
+};
+
+struct AttentionContextWorkspaceSizes
+{
+    size_t cublasWorkspace{CUBLAS_WORKSPACE_SIZE};
+    size_t attentionMask{};
+    size_t cuQSeqlens{};
+    size_t cuKvSeqlens{};
+    size_t cuMaskRows{};
+    size_t rotaryInvFreq{};
+    size_t qBuf{};
+    size_t kBuf{};
+    size_t vBuf{};
+    size_t qkBuf{};
+    size_t qkvBuf{};
+    size_t qkFloatBuf{};
+    size_t fp8QkvBuf{};
+    size_t fp8QBuf{};
+    size_t fp8KBuf{};
+    size_t fp8VBuf{};
+    size_t paddingOffset{};
+    size_t encoderPaddingOffset{};
+    size_t tokensInfo{};
+    size_t fmhaTileCounter{};
+    size_t fmhaBmm1Scale{};
+    size_t fmhaBmm2Scale{};
+    size_t sageQScale{};
+    size_t sageKScale{};
+    size_t sageVScale{};
+    size_t cpWorkspace{};
+};
+
+struct AttentionContextWorkspaceLayout
+{
+    WorkspaceSlice cublasWorkspace{};
+    WorkspaceSlice attentionMask{};
+    WorkspaceSlice cuQSeqlens{};
+    WorkspaceSlice cuKvSeqlens{};
+    WorkspaceSlice cuMaskRows{};
+    WorkspaceSlice rotaryInvFreq{};
+    WorkspaceSlice qBuf{};
+    WorkspaceSlice kBuf{};
+    WorkspaceSlice vBuf{};
+    WorkspaceSlice qkBuf{};
+    WorkspaceSlice qkvBuf{};
+    WorkspaceSlice qkFloatBuf{};
+    WorkspaceSlice fp8QkvBuf{};
+    WorkspaceSlice fp8QBuf{};
+    WorkspaceSlice fp8KBuf{};
+    WorkspaceSlice fp8VBuf{};
+    WorkspaceSlice paddingOffset{};
+    WorkspaceSlice encoderPaddingOffset{};
+    WorkspaceSlice tokensInfo{};
+    WorkspaceSlice fmhaTileCounter{};
+    WorkspaceSlice fmhaBmm1Scale{};
+    WorkspaceSlice fmhaBmm2Scale{};
+    WorkspaceSlice sageQScale{};
+    WorkspaceSlice sageKScale{};
+    WorkspaceSlice sageVScale{};
+    WorkspaceSlice cpWorkspace{};
+    size_t totalSize{};
+};
+
+template <typename T>
+struct AttentionContextWorkspaceViews
+{
+    void* cublasWorkspace{};
+    T* attentionMask{};
+    int* cuQSeqlens{};
+    int* cuKvSeqlens{};
+    int* cuMaskRows{};
+    float* rotaryInvFreq{};
+    T* qBuf{};
+    T* kBuf{};
+    T* vBuf{};
+    T* qkBuf{};
+    T* qkvBuf{};
+    float* qkFloatBuf{};
+    __nv_fp8_e4m3* fp8QkvBuf{};
+    __nv_fp8_e4m3* fp8QBuf{};
+    __nv_fp8_e4m3* fp8KBuf{};
+    __nv_fp8_e4m3* fp8VBuf{};
+    int* paddingOffset{};
+    int* encoderPaddingOffset{};
+    int2* tokensInfo{};
+    uint32_t* fmhaTileCounter{};
+    float* fmhaBmm1Scale{};
+    float* fmhaBmm2Scale{};
+    float* sageQScale{};
+    float* sageKScale{};
+    float* sageVScale{};
+    T* gatherInBuffer{};
+    T* gatherOutBuffer{};
+    int* cuCpPartialSeqlens{};
+};
+
+struct AttentionGenerationWorkspaceSizes
+{
+    size_t cpWorkspace{};
+    size_t partialOut{};
+    size_t partialSum{};
+    size_t partialMax{};
+    size_t shiftKCache{};
+};
+
+struct AttentionGenerationWorkspaceLayout
+{
+    WorkspaceSlice cpWorkspace{};
+    WorkspaceSlice partialOut{};
+    WorkspaceSlice partialSum{};
+    WorkspaceSlice partialMax{};
+    WorkspaceSlice shiftKCache{};
+    size_t totalSize{};
+};
+
+template <typename T>
+struct AttentionGenerationWorkspaceViews
+{
+    T* mhaOutput{};
+    T* mhaInput{};
+    T* partialOut{};
+    float* partialSum{};
+    float* partialMax{};
+    T* shiftKCache{};
+};
+
+struct AttentionFlashMlaWorkspaceSizes
+{
+    size_t tileSchedulerMetadata{};
+    size_t numSplits{};
+    size_t softmaxLse{};
+    size_t softmaxLseAccum{};
+    size_t outAccum{};
+};
+
+struct AttentionFlashMlaWorkspaceLayout
+{
+    WorkspaceSlice tileSchedulerMetadata{};
+    WorkspaceSlice numSplits{};
+    WorkspaceSlice softmaxLse{};
+    WorkspaceSlice softmaxLseAccum{};
+    WorkspaceSlice outAccum{};
+    size_t totalSize{};
+};
+
+struct AttentionXqaWorkspaceSizes
+{
+    size_t cuSeqlens{};
+    size_t cuKvSeqlens{};
+    size_t rotaryInvFreq{};
+    size_t tokensInfo{};
+    size_t bmm1Scale{};
+    size_t bmm2Scale{};
+    size_t sparseAttnCache{};
+    size_t kernelWorkspace{};
+};
+
+struct AttentionXqaWorkspaceLayout
+{
+    WorkspaceSlice cuSeqlens{};
+    WorkspaceSlice cuKvSeqlens{};
+    WorkspaceSlice rotaryInvFreq{};
+    WorkspaceSlice tokensInfo{};
+    WorkspaceSlice bmm1Scale{};
+    WorkspaceSlice bmm2Scale{};
+    WorkspaceSlice sparseAttnCache{};
+    WorkspaceSlice kernelWorkspace{};
+    size_t totalSize{};
+};
+
+class AttentionWorkspaceManager
+{
+public:
+    static AttentionContextWorkspaceLayout buildContextLayout(
+        AttentionContextWorkspaceSizes const& sizes, uintptr_t alignment = common::kCudaMemAlign)
+    {
+        AttentionContextWorkspaceLayout layout{};
+        size_t offset = 0;
+        layout.cublasWorkspace = nextSlice(offset, sizes.cublasWorkspace, alignment);
+        layout.attentionMask = nextSlice(offset, sizes.attentionMask, alignment);
+        layout.cuQSeqlens = nextSlice(offset, sizes.cuQSeqlens, alignment);
+        layout.cuKvSeqlens = nextSlice(offset, sizes.cuKvSeqlens, alignment);
+        layout.cuMaskRows = nextSlice(offset, sizes.cuMaskRows, alignment);
+        layout.rotaryInvFreq = nextSlice(offset, sizes.rotaryInvFreq, alignment);
+        layout.qBuf = nextSlice(offset, sizes.qBuf, alignment);
+        layout.kBuf = nextSlice(offset, sizes.kBuf, alignment);
+        layout.vBuf = nextSlice(offset, sizes.vBuf, alignment);
+        layout.qkBuf = nextSlice(offset, sizes.qkBuf, alignment);
+        layout.qkvBuf = nextSlice(offset, sizes.qkvBuf, alignment);
+        layout.qkFloatBuf = nextSlice(offset, sizes.qkFloatBuf, alignment);
+        layout.fp8QkvBuf = nextSlice(offset, sizes.fp8QkvBuf, alignment);
+        layout.fp8QBuf = nextSlice(offset, sizes.fp8QBuf, alignment);
+        layout.fp8KBuf = nextSlice(offset, sizes.fp8KBuf, alignment);
+        layout.fp8VBuf = nextSlice(offset, sizes.fp8VBuf, alignment);
+        layout.paddingOffset = nextSlice(offset, sizes.paddingOffset, alignment);
+        layout.encoderPaddingOffset = nextSlice(offset, sizes.encoderPaddingOffset, alignment);
+        layout.tokensInfo = nextSlice(offset, sizes.tokensInfo, alignment);
+        layout.fmhaTileCounter = nextSlice(offset, sizes.fmhaTileCounter, alignment);
+        layout.fmhaBmm1Scale = nextSlice(offset, sizes.fmhaBmm1Scale, alignment);
+        layout.fmhaBmm2Scale = nextSlice(offset, sizes.fmhaBmm2Scale, alignment);
+        layout.sageQScale = nextSlice(offset, sizes.sageQScale, alignment);
+        layout.sageKScale = nextSlice(offset, sizes.sageKScale, alignment);
+        layout.sageVScale = nextSlice(offset, sizes.sageVScale, alignment);
+        layout.cpWorkspace = nextSlice(offset, sizes.cpWorkspace, alignment);
+        layout.totalSize = offset;
+        return layout;
+    }
+
+    template <typename T>
+    static AttentionContextWorkspaceViews<T> materializeContext(void* workspace,
+        AttentionContextWorkspaceLayout const& layout, size_t cpMaxPaddedSequenceLength, int headSize, int numHeads,
+        int numKvHeads)
+    {
+        AttentionContextWorkspaceViews<T> views{};
+        views.cublasWorkspace = ptr<void>(workspace, layout.cublasWorkspace);
+        views.attentionMask = ptr<T>(workspace, layout.attentionMask);
+        views.cuQSeqlens = ptr<int>(workspace, layout.cuQSeqlens);
+        views.cuKvSeqlens = ptr<int>(workspace, layout.cuKvSeqlens);
+        views.cuMaskRows = ptr<int>(workspace, layout.cuMaskRows);
+        views.rotaryInvFreq = ptr<float>(workspace, layout.rotaryInvFreq);
+        views.qBuf = ptr<T>(workspace, layout.qBuf);
+        views.kBuf = ptr<T>(workspace, layout.kBuf);
+        views.vBuf = ptr<T>(workspace, layout.vBuf);
+        views.qkBuf = ptr<T>(workspace, layout.qkBuf);
+        views.qkvBuf = ptr<T>(workspace, layout.qkvBuf);
+        views.qkFloatBuf = ptr<float>(workspace, layout.qkFloatBuf);
+        views.fp8QkvBuf = ptr<__nv_fp8_e4m3>(workspace, layout.fp8QkvBuf);
+        views.fp8QBuf = ptr<__nv_fp8_e4m3>(workspace, layout.fp8QBuf);
+        views.fp8KBuf = ptr<__nv_fp8_e4m3>(workspace, layout.fp8KBuf);
+        views.fp8VBuf = ptr<__nv_fp8_e4m3>(workspace, layout.fp8VBuf);
+        views.paddingOffset = ptr<int>(workspace, layout.paddingOffset);
+        views.encoderPaddingOffset = ptr<int>(workspace, layout.encoderPaddingOffset);
+        views.tokensInfo = ptr<int2>(workspace, layout.tokensInfo);
+        views.fmhaTileCounter = ptr<uint32_t>(workspace, layout.fmhaTileCounter);
+        views.fmhaBmm1Scale = ptr<float>(workspace, layout.fmhaBmm1Scale);
+        views.fmhaBmm2Scale = ptr<float>(workspace, layout.fmhaBmm2Scale);
+        views.sageQScale = ptr<float>(workspace, layout.sageQScale);
+        views.sageKScale = ptr<float>(workspace, layout.sageKScale);
+        views.sageVScale = ptr<float>(workspace, layout.sageVScale);
+
+        views.gatherInBuffer = ptr<T>(workspace, layout.cpWorkspace);
+        if (views.gatherInBuffer != nullptr)
+        {
+            auto const cpBufferElements
+                = cpMaxPaddedSequenceLength * static_cast<size_t>(headSize) * (numHeads + 2 * numKvHeads);
+            views.gatherOutBuffer = views.gatherInBuffer + cpBufferElements;
+            views.cuCpPartialSeqlens = reinterpret_cast<int*>(views.gatherOutBuffer + cpBufferElements);
+        }
+        return views;
+    }
+
+    static AttentionGenerationWorkspaceLayout buildGenerationLayout(
+        AttentionGenerationWorkspaceSizes const& sizes, uintptr_t alignment = common::kCudaMemAlign)
+    {
+        AttentionGenerationWorkspaceLayout layout{};
+        size_t offset = 0;
+        layout.cpWorkspace = nextSlice(offset, sizes.cpWorkspace, alignment);
+        layout.partialOut = nextSlice(offset, sizes.partialOut, alignment);
+        layout.partialSum = nextSlice(offset, sizes.partialSum, alignment);
+        layout.partialMax = nextSlice(offset, sizes.partialMax, alignment);
+        layout.shiftKCache = nextSlice(offset, sizes.shiftKCache, alignment);
+        layout.totalSize = offset;
+        return layout;
+    }
+
+    template <typename T>
+    static AttentionGenerationWorkspaceViews<T> materializeGeneration(void* workspace,
+        AttentionGenerationWorkspaceLayout const& layout, size_t cpMaxPaddedSequenceLength, int numHeads,
+        int numKvHeads, int headSize)
+    {
+        AttentionGenerationWorkspaceViews<T> views{};
+        views.mhaOutput = ptr<T>(workspace, layout.cpWorkspace);
+        if (views.mhaOutput != nullptr)
+        {
+            auto const cpBufferElements
+                = cpMaxPaddedSequenceLength * (numHeads + 2 * numKvHeads) * static_cast<size_t>(headSize);
+            views.mhaInput = views.mhaOutput + cpBufferElements;
+        }
+        views.partialOut = ptr<T>(workspace, layout.partialOut);
+        views.partialSum = ptr<float>(workspace, layout.partialSum);
+        views.partialMax = ptr<float>(workspace, layout.partialMax);
+        views.shiftKCache = ptr<T>(workspace, layout.shiftKCache);
+        return views;
+    }
+
+    static AttentionFlashMlaWorkspaceLayout buildFlashMlaLayout(
+        AttentionFlashMlaWorkspaceSizes const& sizes, uintptr_t alignment = common::kCudaMemAlign)
+    {
+        AttentionFlashMlaWorkspaceLayout layout{};
+        size_t offset = 0;
+        layout.tileSchedulerMetadata = nextSlice(offset, sizes.tileSchedulerMetadata, alignment);
+        layout.numSplits = nextSlice(offset, sizes.numSplits, alignment);
+        layout.softmaxLse = nextSlice(offset, sizes.softmaxLse, alignment);
+        layout.softmaxLseAccum = nextSlice(offset, sizes.softmaxLseAccum, alignment);
+        layout.outAccum = nextSlice(offset, sizes.outAccum, alignment);
+        layout.totalSize = offset;
+        return layout;
+    }
+
+    static AttentionXqaWorkspaceLayout buildXqaLayout(
+        AttentionXqaWorkspaceSizes const& sizes, uintptr_t alignment = common::kCudaMemAlign)
+    {
+        AttentionXqaWorkspaceLayout layout{};
+        size_t offset = 0;
+        layout.cuSeqlens = nextSlice(offset, sizes.cuSeqlens, alignment);
+        layout.cuKvSeqlens = nextSlice(offset, sizes.cuKvSeqlens, alignment);
+        layout.rotaryInvFreq = nextSlice(offset, sizes.rotaryInvFreq, alignment);
+        layout.tokensInfo = nextSlice(offset, sizes.tokensInfo, alignment);
+        layout.bmm1Scale = nextSlice(offset, sizes.bmm1Scale, alignment);
+        layout.bmm2Scale = nextSlice(offset, sizes.bmm2Scale, alignment);
+        layout.sparseAttnCache = nextSlice(offset, sizes.sparseAttnCache, alignment);
+        layout.kernelWorkspace = nextSlice(offset, sizes.kernelWorkspace, alignment);
+        layout.totalSize = offset;
+        return layout;
+    }
+
+    template <typename T>
+    static T* ptr(void* workspace, WorkspaceSlice const& slice)
+    {
+        if (workspace == nullptr || slice.size == 0)
+        {
+            return nullptr;
+        }
+        return reinterpret_cast<T*>(reinterpret_cast<int8_t*>(workspace) + slice.offset);
+    }
+
+private:
+    static WorkspaceSlice nextSlice(size_t& offset, size_t size, uintptr_t alignment)
+    {
+        auto const slice = WorkspaceSlice{offset, size};
+        offset += common::alignSize(size, alignment);
+        return slice;
+    }
+};
+
+} // namespace common::op
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
@@ -55,8 +55,8 @@ nb::tuple trtllmGenContextPreprocessBinding(torch::Tensor qkv_input, torch::Tens
     int64_t max_past_kv_length, int64_t rotary_embedding_dim, double rotary_embedding_base,
     int64_t rotary_embedding_scale_type, double rotary_embedding_scale, int64_t rotary_embedding_max_positions,
     int64_t position_embedding_type, double bmm1_scale, double bmm2_scale, int64_t attention_chunk_size,
-    bool fp8_context_fmha, bool paged_context_fmha, bool is_mla_enable, int64_t total_num_blocks, int64_t kv_factor,
-    bool need_build_kv_cache_metadata)
+    bool fp8_context_fmha, bool paged_context_fmha, bool is_mla_enable, int64_t multi_processor_count,
+    int64_t total_num_blocks, int64_t kv_factor, bool need_build_kv_cache_metadata)
 {
     auto result = [&]()
     {
@@ -69,7 +69,7 @@ nb::tuple trtllmGenContextPreprocessBinding(torch::Tensor qkv_input, torch::Tens
             input_seq_length, max_past_kv_length, rotary_embedding_dim, rotary_embedding_base,
             rotary_embedding_scale_type, rotary_embedding_scale, rotary_embedding_max_positions,
             position_embedding_type, bmm1_scale, bmm2_scale, attention_chunk_size, fp8_context_fmha, paged_context_fmha,
-            is_mla_enable, total_num_blocks, kv_factor, need_build_kv_cache_metadata);
+            is_mla_enable, multi_processor_count, total_num_blocks, kv_factor, need_build_kv_cache_metadata);
     }();
 
     return nb::make_tuple(std::get<0>(result), optionalTensorToObject(std::get<1>(result)),
@@ -90,7 +90,8 @@ nb::tuple trtllmGenGenerationPreprocessBinding(torch::Tensor qkv_input, torch::T
     int64_t rotary_embedding_dim, double rotary_embedding_base, int64_t rotary_embedding_scale_type,
     double rotary_embedding_scale, int64_t rotary_embedding_max_positions, int64_t position_embedding_type,
     double bmm1_scale, double bmm2_scale, bool fp8_context_fmha, int64_t predicted_tokens_per_seq,
-    int64_t attention_chunk_size, int64_t total_num_blocks, int64_t kv_factor, bool need_build_kv_cache_metadata)
+    int64_t attention_chunk_size, int64_t multi_processor_count, int64_t total_num_blocks, int64_t kv_factor,
+    bool need_build_kv_cache_metadata)
 {
     auto result = [&]()
     {
@@ -103,8 +104,8 @@ nb::tuple trtllmGenGenerationPreprocessBinding(torch::Tensor qkv_input, torch::T
             cyclic_attention_window_size, sink_token_length, num_tokens, batch_beam, input_seq_length,
             max_past_kv_length, rotary_embedding_dim, rotary_embedding_base, rotary_embedding_scale_type,
             rotary_embedding_scale, rotary_embedding_max_positions, position_embedding_type, bmm1_scale, bmm2_scale,
-            fp8_context_fmha, predicted_tokens_per_seq, attention_chunk_size, total_num_blocks, kv_factor,
-            need_build_kv_cache_metadata);
+            fp8_context_fmha, predicted_tokens_per_seq, attention_chunk_size, multi_processor_count, total_num_blocks,
+            kv_factor, need_build_kv_cache_metadata);
     }();
 
     return nb::make_tuple(std::get<0>(result), optionalTensorToObject(std::get<1>(result)),
@@ -260,7 +261,7 @@ void initBindings(nb::module_& m)
         nb::arg("rotary_embedding_scale"), nb::arg("rotary_embedding_max_positions"),
         nb::arg("position_embedding_type"), nb::arg("bmm1_scale"), nb::arg("bmm2_scale"),
         nb::arg("attention_chunk_size"), nb::arg("fp8_context_fmha"), nb::arg("paged_context_fmha"),
-        nb::arg("is_mla_enable"), nb::arg("total_num_blocks"), nb::arg("kv_factor"),
+        nb::arg("is_mla_enable"), nb::arg("multi_processor_count"), nb::arg("total_num_blocks"), nb::arg("kv_factor"),
         nb::arg("need_build_kv_cache_metadata") = true, "Fused nanobind context preprocess for trtllm-gen attention.");
 
     m.def("trtllm_gen_context_postprocess", &torch_ext::trtllmGenContextPostprocess, nb::arg("qkv_input"),
@@ -277,7 +278,8 @@ void initBindings(nb::module_& m)
         nb::arg("rotary_embedding_scale"), nb::arg("rotary_embedding_max_positions"),
         nb::arg("position_embedding_type"), nb::arg("bmm1_scale"), nb::arg("fp8_context_fmha"),
         nb::arg("paged_context_fmha"), nb::arg("is_mla_enable"), nb::arg("attention_chunk_size"),
-        "Fused nanobind context postprocess for trtllm-gen attention.", nb::call_guard<nb::gil_scoped_release>());
+        nb::arg("multi_processor_count"), "Fused nanobind context postprocess for trtllm-gen attention.",
+        nb::call_guard<nb::gil_scoped_release>());
 
     m.def("trtllm_gen_generation_preprocess", &trtllmGenGenerationPreprocessBinding, nb::arg("qkv_input"),
         nb::arg("workspace"), nb::arg("sequence_lengths"), nb::arg("spec_decoding_generation_lengths").none(),
@@ -292,8 +294,8 @@ void initBindings(nb::module_& m)
         nb::arg("rotary_embedding_dim"), nb::arg("rotary_embedding_base"), nb::arg("rotary_embedding_scale_type"),
         nb::arg("rotary_embedding_scale"), nb::arg("rotary_embedding_max_positions"),
         nb::arg("position_embedding_type"), nb::arg("bmm1_scale"), nb::arg("bmm2_scale"), nb::arg("fp8_context_fmha"),
-        nb::arg("predicted_tokens_per_seq"), nb::arg("attention_chunk_size"), nb::arg("total_num_blocks"),
-        nb::arg("kv_factor"), nb::arg("need_build_kv_cache_metadata") = true,
+        nb::arg("predicted_tokens_per_seq"), nb::arg("attention_chunk_size"), nb::arg("multi_processor_count"),
+        nb::arg("total_num_blocks"), nb::arg("kv_factor"), nb::arg("need_build_kv_cache_metadata") = true,
         "Fused nanobind generation preprocess for trtllm-gen attention.");
 }
 } // namespace tensorrt_llm::nanobind::thop

--- a/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
@@ -17,6 +17,7 @@
 #include "bindings.h"
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
+#include <nanobind/stl/tuple.h>
 #include <nanobind/stl/vector.h>
 #include <tensorrt_llm/kernels/helixAllToAll.h>
 #include <tensorrt_llm/thop/attentionOp.h>
@@ -91,6 +92,13 @@ void initBindings(nb::module_& m)
         nb::arg("tile_scheduler_metadata"), nb::arg("num_splits"), nb::arg("batch_size"), nb::arg("s_q"),
         nb::arg("num_q_heads"), nb::arg("num_kv_heads"), nb::arg("head_size_v"),
         "Compute FlashMLA tile-scheduler metadata in-place. Call once per forward pass before attention layers.",
+        nb::call_guard<nb::gil_scoped_release>());
+
+    m.def("build_kv_cache_buffers", &torch_ext::buildFlashinferTrtllmGenPagedKvCacheBuffers,
+        nb::arg("host_kv_cache_pool_pointers"), nb::arg("host_kv_cache_pool_mapping"), nb::arg("layer_idx"),
+        nb::arg("num_kv_heads"), nb::arg("tokens_per_block"), nb::arg("head_dim"), nb::arg("kv_factor"),
+        nb::arg("total_num_blocks"), nb::arg("kv_cache_quant_mode"), nb::arg("dtype"),
+        "Build flat-block KV cache tensor from pool pointers. Returns (kv_pool, kv_scale_pool).",
         nb::call_guard<nb::gil_scoped_release>());
 }
 } // namespace tensorrt_llm::nanobind::thop

--- a/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/thop/bindings.cpp
@@ -23,12 +23,96 @@
 #include <tensorrt_llm/thop/attentionOp.h>
 #include <tensorrt_llm/thop/moeAlltoAllMeta.h>
 #include <tensorrt_llm/thop/outputTensor.h>
+#include <tensorrt_llm/thop/trtllmGenFusedOps.h>
 #include <torch/extension.h>
 
 namespace nb = nanobind;
 
 namespace tensorrt_llm::nanobind::thop
 {
+
+namespace
+{
+
+nb::object optionalTensorToObject(std::optional<at::Tensor> const& tensor)
+{
+    if (tensor.has_value())
+    {
+        return nb::cast(*tensor);
+    }
+    return nb::none();
+}
+
+nb::tuple trtllmGenContextPreprocessBinding(torch::Tensor qkv_input, torch::Tensor workspace,
+    torch::Tensor sequence_lengths, torch::Tensor context_lengths, std::optional<torch::Tensor> kv_cache_block_offsets,
+    std::optional<torch::Tensor> host_kv_cache_pool_pointers, std::optional<torch::Tensor> host_kv_cache_pool_mapping,
+    std::optional<torch::Tensor> kv_scale_orig_quant, std::optional<torch::Tensor> kv_scale_quant_orig,
+    std::optional<torch::Tensor> attention_output_orig_quant, std::optional<torch::Tensor> rotary_inv_freq,
+    std::optional<torch::Tensor> rotary_cos_sin, std::optional<torch::Tensor> mrope_rotary_cos_sin, int64_t layer_idx,
+    int64_t num_heads, int64_t num_kv_heads, int64_t head_size, int64_t tokens_per_block, int64_t mask_type,
+    int64_t kv_cache_quant_mode, int64_t max_attention_window_size, int64_t cyclic_attention_window_size,
+    int64_t sink_token_length, int64_t num_tokens, int64_t batch_size, int64_t input_seq_length,
+    int64_t max_past_kv_length, int64_t rotary_embedding_dim, double rotary_embedding_base,
+    int64_t rotary_embedding_scale_type, double rotary_embedding_scale, int64_t rotary_embedding_max_positions,
+    int64_t position_embedding_type, double bmm1_scale, double bmm2_scale, int64_t attention_chunk_size,
+    bool fp8_context_fmha, bool paged_context_fmha, bool is_mla_enable, int64_t total_num_blocks, int64_t kv_factor,
+    bool need_build_kv_cache_metadata)
+{
+    auto result = [&]()
+    {
+        nb::gil_scoped_release release;
+        return torch_ext::trtllmGenContextPreprocess(qkv_input, workspace, sequence_lengths, context_lengths,
+            kv_cache_block_offsets, host_kv_cache_pool_pointers, host_kv_cache_pool_mapping, kv_scale_orig_quant,
+            kv_scale_quant_orig, attention_output_orig_quant, rotary_inv_freq, rotary_cos_sin, mrope_rotary_cos_sin,
+            layer_idx, num_heads, num_kv_heads, head_size, tokens_per_block, mask_type, kv_cache_quant_mode,
+            max_attention_window_size, cyclic_attention_window_size, sink_token_length, num_tokens, batch_size,
+            input_seq_length, max_past_kv_length, rotary_embedding_dim, rotary_embedding_base,
+            rotary_embedding_scale_type, rotary_embedding_scale, rotary_embedding_max_positions,
+            position_embedding_type, bmm1_scale, bmm2_scale, attention_chunk_size, fp8_context_fmha, paged_context_fmha,
+            is_mla_enable, total_num_blocks, kv_factor, need_build_kv_cache_metadata);
+    }();
+
+    return nb::make_tuple(std::get<0>(result), optionalTensorToObject(std::get<1>(result)),
+        optionalTensorToObject(std::get<2>(result)), std::get<3>(result), std::get<4>(result), std::get<5>(result),
+        std::get<6>(result), std::get<7>(result), std::get<8>(result));
+}
+
+nb::tuple trtllmGenGenerationPreprocessBinding(torch::Tensor qkv_input, torch::Tensor workspace,
+    torch::Tensor sequence_lengths, std::optional<torch::Tensor> spec_decoding_generation_lengths,
+    std::optional<torch::Tensor> spec_decoding_position_offsets, std::optional<torch::Tensor> kv_cache_block_offsets,
+    std::optional<torch::Tensor> host_kv_cache_pool_pointers, std::optional<torch::Tensor> host_kv_cache_pool_mapping,
+    std::optional<torch::Tensor> kv_scale_orig_quant, std::optional<torch::Tensor> kv_scale_quant_orig,
+    std::optional<torch::Tensor> attention_output_orig_quant, std::optional<torch::Tensor> rotary_inv_freq,
+    std::optional<torch::Tensor> rotary_cos_sin, int64_t layer_idx, int64_t seq_offset, int64_t num_heads,
+    int64_t num_kv_heads, int64_t head_size, int64_t tokens_per_block, int64_t kv_cache_quant_mode,
+    int64_t max_attention_window_size, int64_t cyclic_attention_window_size, int64_t sink_token_length,
+    int64_t num_tokens, int64_t batch_beam, int64_t input_seq_length, int64_t max_past_kv_length,
+    int64_t rotary_embedding_dim, double rotary_embedding_base, int64_t rotary_embedding_scale_type,
+    double rotary_embedding_scale, int64_t rotary_embedding_max_positions, int64_t position_embedding_type,
+    double bmm1_scale, double bmm2_scale, bool fp8_context_fmha, int64_t predicted_tokens_per_seq,
+    int64_t attention_chunk_size, int64_t total_num_blocks, int64_t kv_factor, bool need_build_kv_cache_metadata)
+{
+    auto result = [&]()
+    {
+        nb::gil_scoped_release release;
+        return torch_ext::trtllmGenGenerationPreprocess(qkv_input, workspace, sequence_lengths,
+            spec_decoding_generation_lengths, spec_decoding_position_offsets, kv_cache_block_offsets,
+            host_kv_cache_pool_pointers, host_kv_cache_pool_mapping, kv_scale_orig_quant, kv_scale_quant_orig,
+            attention_output_orig_quant, rotary_inv_freq, rotary_cos_sin, layer_idx, seq_offset, num_heads,
+            num_kv_heads, head_size, tokens_per_block, kv_cache_quant_mode, max_attention_window_size,
+            cyclic_attention_window_size, sink_token_length, num_tokens, batch_beam, input_seq_length,
+            max_past_kv_length, rotary_embedding_dim, rotary_embedding_base, rotary_embedding_scale_type,
+            rotary_embedding_scale, rotary_embedding_max_positions, position_embedding_type, bmm1_scale, bmm2_scale,
+            fp8_context_fmha, predicted_tokens_per_seq, attention_chunk_size, total_num_blocks, kv_factor,
+            need_build_kv_cache_metadata);
+    }();
+
+    return nb::make_tuple(std::get<0>(result), optionalTensorToObject(std::get<1>(result)),
+        optionalTensorToObject(std::get<2>(result)), std::get<3>(result), optionalTensorToObject(std::get<4>(result)),
+        std::get<5>(result), std::get<6>(result), std::get<7>(result), std::get<8>(result));
+}
+
+} // namespace
 
 void initBindings(nb::module_& m)
 {
@@ -94,11 +178,122 @@ void initBindings(nb::module_& m)
         "Compute FlashMLA tile-scheduler metadata in-place. Call once per forward pass before attention layers.",
         nb::call_guard<nb::gil_scoped_release>());
 
-    m.def("build_kv_cache_buffers", &torch_ext::buildFlashinferTrtllmGenPagedKvCacheBuffers,
-        nb::arg("host_kv_cache_pool_pointers"), nb::arg("host_kv_cache_pool_mapping"), nb::arg("layer_idx"),
-        nb::arg("num_kv_heads"), nb::arg("tokens_per_block"), nb::arg("head_dim"), nb::arg("kv_factor"),
-        nb::arg("total_num_blocks"), nb::arg("kv_cache_quant_mode"), nb::arg("dtype"),
-        "Build flat-block KV cache tensor from pool pointers. Returns (kv_pool, kv_scale_pool).",
-        nb::call_guard<nb::gil_scoped_release>());
+    m.def(
+        "get_trtllm_gen_context_workspace_layout",
+        [](at::ScalarType dtype, int64_t batch_size, int64_t num_tokens, int64_t num_heads, int64_t head_size,
+            int64_t rotary_embedding_dim, bool separate_q_kv_input, bool fp8_context_fmha)
+        {
+            auto const layout = torch_ext::TrtllmAttentionWorkspaceManager::buildContextLayout(dtype, batch_size,
+                num_tokens, num_heads, head_size, rotary_embedding_dim, separate_q_kv_input, fp8_context_fmha);
+            nb::dict result;
+            result["trtllm_gen_workspace_offset"] = layout.trtllmGenWorkspaceOffset;
+            result["cu_q_seqlens_offset"] = layout.cuQSeqlensOffset;
+            result["cu_kv_seqlens_offset"] = layout.cuKvSeqlensOffset;
+            result["cu_mask_rows_offset"] = layout.cuMaskRowsOffset;
+            result["rotary_inv_freq_offset"] = layout.rotaryInvFreqOffset;
+            result["q_buf_offset"] = layout.qBufOffset;
+            result["tokens_info_offset"] = layout.tokensInfoOffset;
+            result["fmha_tile_counter_offset"] = layout.fmhaTileCounterOffset;
+            result["fmha_bmm1_scale_offset"] = layout.fmhaBmm1ScaleOffset;
+            result["fmha_bmm2_scale_offset"] = layout.fmhaBmm2ScaleOffset;
+            result["trtllm_gen_workspace_size"] = layout.trtllmGenWorkspaceSize;
+            result["cu_seqlens_size"] = layout.cuSeqlensSize;
+            result["rotary_inv_freq_size"] = layout.rotaryInvFreqSize;
+            result["q_buf_size"] = layout.qBufSize;
+            result["tokens_info_size"] = layout.tokensInfoSize;
+            result["fmha_scheduler_counter_size"] = layout.fmhaTileCounterSize;
+            result["fmha_bmm1_scale_size"] = layout.fmhaBmm1ScaleSize;
+            result["fmha_bmm2_scale_size"] = layout.fmhaBmm2ScaleSize;
+            result["total_size"] = layout.totalSize;
+            return result;
+        },
+        nb::arg("dtype"), nb::arg("batch_size"), nb::arg("num_tokens"), nb::arg("num_heads"), nb::arg("head_size"),
+        nb::arg("rotary_embedding_dim"), nb::arg("separate_q_kv_input"), nb::arg("fp8_context_fmha"),
+        "Return the C++ trtllm-gen context workspace layout.");
+
+    m.def(
+        "get_trtllm_gen_generation_workspace_layout",
+        [](at::ScalarType dtype, int64_t batch_beam, int64_t num_tokens, int64_t num_heads, int64_t head_size,
+            int64_t rotary_embedding_dim, int64_t num_kv_heads, int64_t max_blocks_per_sequence,
+            bool use_sparse_attention)
+        {
+            auto const layout = torch_ext::TrtllmAttentionWorkspaceManager::buildGenerationLayout(dtype, batch_beam,
+                num_tokens, num_heads, head_size, rotary_embedding_dim, num_kv_heads, max_blocks_per_sequence,
+                use_sparse_attention);
+            nb::dict result;
+            result["trtllm_gen_workspace_offset"] = layout.trtllmGenWorkspaceOffset;
+            result["cu_seqlens_offset"] = layout.cuSeqlensOffset;
+            result["cu_kv_seqlens_offset"] = layout.cuKvSeqlensOffset;
+            result["rotary_inv_freq_offset"] = layout.rotaryInvFreqOffset;
+            result["tokens_info_offset"] = layout.tokensInfoOffset;
+            result["q_buf_offset"] = layout.qBufOffset;
+            result["bmm1_scale_offset"] = layout.bmm1ScaleOffset;
+            result["bmm2_scale_offset"] = layout.bmm2ScaleOffset;
+            result["sparse_attn_cache_offset"] = layout.sparseAttnCacheOffset;
+            result["trtllm_gen_workspace_size"] = layout.trtllmGenWorkspaceSize;
+            result["cu_seqlens_size"] = layout.cuSeqlensSize;
+            result["cu_kv_seqlens_size"] = layout.cuKvSeqlensSize;
+            result["rotary_inv_freq_size"] = layout.rotaryInvFreqSize;
+            result["tokens_info_size"] = layout.tokensInfoSize;
+            result["q_buf_size"] = layout.qBufSize;
+            result["bmm1_scale_size"] = layout.bmm1ScaleSize;
+            result["bmm2_scale_size"] = layout.bmm2ScaleSize;
+            result["sparse_attn_cache_size"] = layout.sparseAttnCacheSize;
+            result["total_size"] = layout.totalSize;
+            return result;
+        },
+        nb::arg("dtype"), nb::arg("batch_beam"), nb::arg("num_tokens"), nb::arg("num_heads"), nb::arg("head_size"),
+        nb::arg("rotary_embedding_dim"), nb::arg("num_kv_heads"), nb::arg("max_blocks_per_sequence") = 0,
+        nb::arg("use_sparse_attention") = false, "Return the C++ trtllm-gen generation workspace layout.");
+
+    m.def("trtllm_gen_context_preprocess", &trtllmGenContextPreprocessBinding, nb::arg("qkv_input"),
+        nb::arg("workspace"), nb::arg("sequence_lengths"), nb::arg("context_lengths"),
+        nb::arg("kv_cache_block_offsets").none(), nb::arg("host_kv_cache_pool_pointers").none(),
+        nb::arg("host_kv_cache_pool_mapping").none(), nb::arg("kv_scale_orig_quant").none(),
+        nb::arg("kv_scale_quant_orig").none(), nb::arg("attention_output_orig_quant").none(),
+        nb::arg("rotary_inv_freq").none(), nb::arg("rotary_cos_sin").none(), nb::arg("mrope_rotary_cos_sin").none(),
+        nb::arg("layer_idx"), nb::arg("num_heads"), nb::arg("num_kv_heads"), nb::arg("head_size"),
+        nb::arg("tokens_per_block"), nb::arg("mask_type"), nb::arg("kv_cache_quant_mode"),
+        nb::arg("max_attention_window_size"), nb::arg("cyclic_attention_window_size"), nb::arg("sink_token_length"),
+        nb::arg("num_tokens"), nb::arg("batch_size"), nb::arg("input_seq_length"), nb::arg("max_past_kv_length"),
+        nb::arg("rotary_embedding_dim"), nb::arg("rotary_embedding_base"), nb::arg("rotary_embedding_scale_type"),
+        nb::arg("rotary_embedding_scale"), nb::arg("rotary_embedding_max_positions"),
+        nb::arg("position_embedding_type"), nb::arg("bmm1_scale"), nb::arg("bmm2_scale"),
+        nb::arg("attention_chunk_size"), nb::arg("fp8_context_fmha"), nb::arg("paged_context_fmha"),
+        nb::arg("is_mla_enable"), nb::arg("total_num_blocks"), nb::arg("kv_factor"),
+        nb::arg("need_build_kv_cache_metadata") = true, "Fused nanobind context preprocess for trtllm-gen attention.");
+
+    m.def("trtllm_gen_context_postprocess", &torch_ext::trtllmGenContextPostprocess, nb::arg("qkv_input"),
+        nb::arg("workspace"), nb::arg("sequence_lengths"), nb::arg("context_lengths"),
+        nb::arg("kv_cache_block_offsets").none(), nb::arg("host_kv_cache_pool_pointers").none(),
+        nb::arg("host_kv_cache_pool_mapping").none(), nb::arg("kv_scale_orig_quant").none(),
+        nb::arg("kv_scale_quant_orig").none(), nb::arg("attention_output_orig_quant").none(),
+        nb::arg("rotary_cos_sin").none(), nb::arg("mrope_rotary_cos_sin").none(), nb::arg("layer_idx"),
+        nb::arg("num_heads"), nb::arg("num_kv_heads"), nb::arg("head_size"), nb::arg("tokens_per_block"),
+        nb::arg("mask_type"), nb::arg("kv_cache_quant_mode"), nb::arg("max_attention_window_size"),
+        nb::arg("cyclic_attention_window_size"), nb::arg("sink_token_length"), nb::arg("num_tokens"),
+        nb::arg("batch_size"), nb::arg("input_seq_length"), nb::arg("max_past_kv_length"),
+        nb::arg("rotary_embedding_dim"), nb::arg("rotary_embedding_base"), nb::arg("rotary_embedding_scale_type"),
+        nb::arg("rotary_embedding_scale"), nb::arg("rotary_embedding_max_positions"),
+        nb::arg("position_embedding_type"), nb::arg("bmm1_scale"), nb::arg("fp8_context_fmha"),
+        nb::arg("paged_context_fmha"), nb::arg("is_mla_enable"), nb::arg("attention_chunk_size"),
+        "Fused nanobind context postprocess for trtllm-gen attention.", nb::call_guard<nb::gil_scoped_release>());
+
+    m.def("trtllm_gen_generation_preprocess", &trtllmGenGenerationPreprocessBinding, nb::arg("qkv_input"),
+        nb::arg("workspace"), nb::arg("sequence_lengths"), nb::arg("spec_decoding_generation_lengths").none(),
+        nb::arg("spec_decoding_position_offsets").none(), nb::arg("kv_cache_block_offsets").none(),
+        nb::arg("host_kv_cache_pool_pointers").none(), nb::arg("host_kv_cache_pool_mapping").none(),
+        nb::arg("kv_scale_orig_quant").none(), nb::arg("kv_scale_quant_orig").none(),
+        nb::arg("attention_output_orig_quant").none(), nb::arg("rotary_inv_freq").none(),
+        nb::arg("rotary_cos_sin").none(), nb::arg("layer_idx"), nb::arg("seq_offset"), nb::arg("num_heads"),
+        nb::arg("num_kv_heads"), nb::arg("head_size"), nb::arg("tokens_per_block"), nb::arg("kv_cache_quant_mode"),
+        nb::arg("max_attention_window_size"), nb::arg("cyclic_attention_window_size"), nb::arg("sink_token_length"),
+        nb::arg("num_tokens"), nb::arg("batch_beam"), nb::arg("input_seq_length"), nb::arg("max_past_kv_length"),
+        nb::arg("rotary_embedding_dim"), nb::arg("rotary_embedding_base"), nb::arg("rotary_embedding_scale_type"),
+        nb::arg("rotary_embedding_scale"), nb::arg("rotary_embedding_max_positions"),
+        nb::arg("position_embedding_type"), nb::arg("bmm1_scale"), nb::arg("bmm2_scale"), nb::arg("fp8_context_fmha"),
+        nb::arg("predicted_tokens_per_seq"), nb::arg("attention_chunk_size"), nb::arg("total_num_blocks"),
+        nb::arg("kv_factor"), nb::arg("need_build_kv_cache_metadata") = true,
+        "Fused nanobind generation preprocess for trtllm-gen attention.");
 }
 } // namespace tensorrt_llm::nanobind::thop

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -18,6 +18,7 @@
 #include "tensorrt_llm/common/attentionOp.h"
 #include "tensorrt_llm/common/attentionWorkspace.h"
 #include "tensorrt_llm/common/dataType.h"
+#include "tensorrt_llm/common/nvtxUtils.h"
 #include "tensorrt_llm/kernels/flashMLA/flash_mla.h"
 #include "tensorrt_llm/kernels/gptKernels.h"
 #include "tensorrt_llm/kernels/mlaKernels.h"
@@ -29,6 +30,7 @@
 #include <cstdint>
 #include <functional>
 #include <torch/extension.h>
+#include <type_traits>
 #include <unordered_set>
 
 TRTLLM_NAMESPACE_BEGIN
@@ -52,7 +54,61 @@ int64_t exportOffset(tensorrt_llm::common::op::WorkspaceSlice const& slice)
     return static_cast<int64_t>(slice.offset);
 }
 
+template <typename T>
+T readHostTensor2D(at::Tensor const& tensor, int64_t const row, int64_t const col, char const* tensorName)
+{
+    TORCH_CHECK(tensor.device().is_cpu(), tensorName, " must be a CPU tensor.");
+    TORCH_CHECK(tensor.dim() == 2, tensorName, " must be a 2D tensor.");
+    TORCH_CHECK(row >= 0 && row < tensor.size(0), tensorName, " row is out of bounds.");
+    TORCH_CHECK(col >= 0 && col < tensor.size(1), tensorName, " column is out of bounds.");
+
+    auto const* data = tensor.data_ptr<T>();
+    return data[row * tensor.stride(0) + col * tensor.stride(1)];
+}
+
+template <typename T>
+T readHostTensor3D(at::Tensor const& tensor, int64_t const i, int64_t const j, int64_t const k, char const* tensorName)
+{
+    TORCH_CHECK(tensor.device().is_cpu(), tensorName, " must be a CPU tensor.");
+    TORCH_CHECK(tensor.dim() == 3, tensorName, " must be a 3D tensor.");
+    TORCH_CHECK(i >= 0 && i < tensor.size(0), tensorName, " dim 0 index is out of bounds.");
+    TORCH_CHECK(j >= 0 && j < tensor.size(1), tensorName, " dim 1 index is out of bounds.");
+    TORCH_CHECK(k >= 0 && k < tensor.size(2), tensorName, " dim 2 index is out of bounds.");
+
+    auto const* data = tensor.data_ptr<T>();
+    return data[i * tensor.stride(0) + j * tensor.stride(1) + k * tensor.stride(2)];
+}
+
+template <typename T>
+T* tensorPtr2D(at::Tensor const& tensor, int64_t const row, int64_t const col, char const* tensorName)
+{
+    TORCH_CHECK(tensor.dim() >= 2, tensorName, " must have at least 2 dimensions.");
+    TORCH_CHECK(row >= 0 && row < tensor.size(0), tensorName, " row is out of bounds.");
+    TORCH_CHECK(col >= 0 && col < tensor.size(1), tensorName, " column is out of bounds.");
+
+    using ValueType = std::remove_const_t<T>;
+    auto* data = static_cast<ValueType*>(tensor.data_ptr());
+    return data + row * tensor.stride(0) + col * tensor.stride(1);
+}
+
 } // namespace
+
+KvCachePoolMapping readKvCachePoolMapping(at::Tensor const& hostKvCachePoolMapping, int64_t const layerIdx)
+{
+    TORCH_CHECK(hostKvCachePoolMapping.device().is_cpu(), "host_kv_cache_pool_mapping must be a CPU tensor.");
+    TORCH_CHECK(hostKvCachePoolMapping.dim() == 2, "host_kv_cache_pool_mapping must be a 2D tensor.");
+    TORCH_CHECK(hostKvCachePoolMapping.size(1) >= 2, "host_kv_cache_pool_mapping must have at least two columns.");
+    TORCH_CHECK(layerIdx >= 0 && layerIdx < hostKvCachePoolMapping.size(0),
+        "host_kv_cache_pool_mapping layer index is out of bounds.");
+
+    auto const* data = hostKvCachePoolMapping.data_ptr<int32_t>();
+    auto const rowOffset = layerIdx * hostKvCachePoolMapping.stride(0);
+    auto const colStride = hostKvCachePoolMapping.stride(1);
+    KvCachePoolMapping mapping;
+    mapping.poolIndex = data[rowOffset];
+    mapping.layerIdxInCachePool = data[rowOffset + colStride];
+    return mapping;
+}
 
 std::optional<at::Tensor> TrtllmAttentionWorkspaceManager::makeWorkspaceView(
     at::Tensor const& workspace, int64_t const offset, int64_t const sizeBytes, at::ScalarType const scalarType)
@@ -377,6 +433,8 @@ public:
         std::optional<torch::Tensor> quant_q_buffer, std::optional<torch::Tensor> flash_mla_tile_scheduler_metadata,
         std::optional<torch::Tensor> flash_mla_num_splits) const override
     {
+        NVTX3_SCOPED_RANGE_WITH_NAME(
+            thopAttentionRunRange, is_context ? "thop.attention.run.context" : "thop.attention.run.generation");
         auto stream = at::cuda::getCurrentCUDAStream(qkv_or_q.get_device());
         T* attention_input = static_cast<T*>(qkv_or_q.slice(0, token_offset).data_ptr());
         T* k_ptr = nullptr;
@@ -512,10 +570,14 @@ public:
         int const* context_lengths_ptr = context_lengths.slice(0, seq_offset).data_ptr<int>();
         int const* sequence_lengths_ptr = sequence_length.slice(0, seq_offset).data_ptr<int>();
         // Note we still need context length during generation for MMHA optimization.
-        int32_t const max_context_q_len
-            = host_context_lengths.slice(0, seq_offset, seq_offset + num_seqs).max().item<int32_t>();
-        int32_t const max_past_kv_length
-            = host_past_key_value_lengths.slice(0, seq_offset, seq_offset + num_seqs).max().item<int32_t>();
+        int32_t max_context_q_len = 0;
+        int32_t max_past_kv_length = 0;
+        {
+            NVTX3_SCOPED_RANGE_WITH_NAME(lengthMetadataRange, "thop.attention.length_metadata");
+            max_context_q_len = host_context_lengths.slice(0, seq_offset, seq_offset + num_seqs).max().item<int32_t>();
+            max_past_kv_length
+                = host_past_key_value_lengths.slice(0, seq_offset, seq_offset + num_seqs).max().item<int32_t>();
+        }
 
         // Commonly, cyclic_attention_window_size, and max_attention_window_size will be the same
         // unless each layer has different attention window sizes.
@@ -527,33 +589,41 @@ public:
         int const cyclic_attention_window_size = attention_window_size;
         bool const can_use_one_more_block = beam_width > 1;
 
-        int max_blocks_per_sequence
-            = op.useKVCache() && kv_cache_block_offsets.has_value() ? kv_cache_block_offsets.value().size(-1) : 0;
-        int32_t const pool_index = op.useKVCache() && host_kv_cache_pool_mapping.has_value()
-            ? host_kv_cache_pool_mapping.value().index({op.mLayerIdx, 0}).item<int32_t>()
-            : 0;
-        int32_t const layer_idx_in_cache_pool = op.useKVCache() && host_kv_cache_pool_mapping.has_value()
-            ? host_kv_cache_pool_mapping.value().index({op.mLayerIdx, 1}).item<int32_t>()
-            : 0;
-        KVBlockArray::DataType* block_offsets
-            = static_cast<KVBlockArray::DataType*>(op.useKVCache() && kv_cache_block_offsets.has_value()
+        int max_blocks_per_sequence = 0;
+        int32_t pool_index = 0;
+        int32_t layer_idx_in_cache_pool = 0;
+        KVBlockArray::DataType* block_offsets = nullptr;
+        bool use_kv_cache = false;
+        KvCachePoolPointers pool_pointers;
+        {
+            NVTX3_SCOPED_RANGE_WITH_NAME(kvMetadataRange, "thop.attention.kv_metadata");
+            max_blocks_per_sequence
+                = op.useKVCache() && kv_cache_block_offsets.has_value() ? kv_cache_block_offsets.value().size(-1) : 0;
+            pool_index = op.useKVCache() && host_kv_cache_pool_mapping.has_value()
+                ? host_kv_cache_pool_mapping.value().index({op.mLayerIdx, 0}).item<int32_t>()
+                : 0;
+            layer_idx_in_cache_pool = op.useKVCache() && host_kv_cache_pool_mapping.has_value()
+                ? host_kv_cache_pool_mapping.value().index({op.mLayerIdx, 1}).item<int32_t>()
+                : 0;
+            block_offsets = static_cast<KVBlockArray::DataType*>(op.useKVCache() && kv_cache_block_offsets.has_value()
                     ? kv_cache_block_offsets.value().index({pool_index, seq_offset}).data_ptr()
                     : nullptr);
 
-        // The cache element size in bits.
-        int cache_elem_bits = op.getKvCacheElemSizeInBits<T>();
-        auto const block_size = op.mTokensPerBlock * op.mNumKVHeads * op.mHeadSize;
-        auto const bytes_per_block = block_size * cache_elem_bits / 8 /*bits*/;
-        int32_t const kv_factor = op.isMLAEnabled() ? 1 : 2;
-        auto const intra_pool_offset = layer_idx_in_cache_pool * kv_factor * bytes_per_block;
+            // The cache element size in bits.
+            int cache_elem_bits = op.getKvCacheElemSizeInBits<T>();
+            auto const block_size = op.mTokensPerBlock * op.mNumKVHeads * op.mHeadSize;
+            auto const bytes_per_block = block_size * cache_elem_bits / 8 /*bits*/;
+            int32_t const kv_factor = op.isMLAEnabled() ? 1 : 2;
+            auto const intra_pool_offset = layer_idx_in_cache_pool * kv_factor * bytes_per_block;
 
-        // Build KV cache pool pointers from the host tensor.
-        bool const use_kv_cache = op.useKVCache() && host_kv_cache_pool_pointers.has_value();
-        KvCachePoolPointers pool_pointers;
-        if (use_kv_cache)
-        {
-            pool_pointers = buildKvCachePoolPointers(host_kv_cache_pool_pointers.value(), pool_index, intra_pool_offset,
-                block_size, layer_idx_in_cache_pool, kv_factor, op.mKVCacheQuantMode.hasFp4KvCache());
+            // Build KV cache pool pointers from the host tensor.
+            use_kv_cache = op.useKVCache() && host_kv_cache_pool_pointers.has_value();
+            if (use_kv_cache)
+            {
+                pool_pointers
+                    = buildKvCachePoolPointers(host_kv_cache_pool_pointers.value(), pool_index, intra_pool_offset,
+                        block_size, layer_idx_in_cache_pool, kv_factor, op.mKVCacheQuantMode.hasFp4KvCache());
+            }
         }
 
         float const* kv_scale_orig_quant_ptr = nullptr;
@@ -671,30 +741,37 @@ public:
         {
             common_enqueue_params.input_seq_length = max_context_q_len;
             AttentionOp::EnqueueContextParams<T> enqueue_params{common_enqueue_params};
-            enqueue_params.batch_size = num_seqs;
-            enqueue_params.k_ptr = k_ptr;
-            enqueue_params.v_ptr = v_ptr;
-            // Pass V's actual token stride so the FMHA runner handles both
-            // contiguous V (AutoDeploy) and non-contiguous V (PyTorch backend
-            // kv.split() view) correctly.
-            if (v_ptr != nullptr && v.has_value())
             {
-                enqueue_params.v_stride_in_bytes = v->strides()[0] * v->element_size();
-            }
+                NVTX3_SCOPED_RANGE_WITH_NAME(
+                    thopAttentionBuildContextParamsRange, "thop.attention.build_context_params");
+                enqueue_params.batch_size = num_seqs;
+                enqueue_params.k_ptr = k_ptr;
+                enqueue_params.v_ptr = v_ptr;
+                // Pass V's actual token stride so the FMHA runner handles both
+                // contiguous V (AutoDeploy) and non-contiguous V (PyTorch backend
+                // kv.split() view) correctly.
+                if (v_ptr != nullptr && v.has_value())
+                {
+                    enqueue_params.v_stride_in_bytes = v->strides()[0] * v->element_size();
+                }
 
-            if (op.isMLAEnabled())
-            {
-                mla_params.cache_seq_lens = sequence_lengths_ptr;
-                mla_params.max_input_seq_len = max_context_q_len;
-                enqueue_params.mla_param = &mla_params;
+                if (op.isMLAEnabled())
+                {
+                    mla_params.cache_seq_lens = sequence_lengths_ptr;
+                    mla_params.max_input_seq_len = max_context_q_len;
+                    enqueue_params.mla_param = &mla_params;
+                }
+                if (op.isMRoPE() && mrope_rotary_cos_sin.has_value())
+                {
+                    enqueue_params.mrope_rotary_cos_sin
+                        = static_cast<float2 const*>(mrope_rotary_cos_sin.value().data_ptr());
+                }
+                extractHelixParams(enqueue_params);
             }
-            if (op.isMRoPE() && mrope_rotary_cos_sin.has_value())
             {
-                enqueue_params.mrope_rotary_cos_sin
-                    = static_cast<float2 const*>(mrope_rotary_cos_sin.value().data_ptr());
+                NVTX3_SCOPED_RANGE_WITH_NAME(thopAttentionEnqueueContextRange, "thop.attention.enqueue_context");
+                op.enqueueContext<T, KVBlockArray>(enqueue_params, stream);
             }
-            extractHelixParams(enqueue_params);
-            op.enqueueContext<T, KVBlockArray>(enqueue_params, stream);
         }
         else // generation stage
         {
@@ -708,68 +785,75 @@ public:
 
             common_enqueue_params.input_seq_length = input_seq_length;
             AttentionOp::EnqueueGenerationParams<T> enqueue_params{common_enqueue_params};
-            enqueue_params.layer_idx = op.mLayerIdx;
-            enqueue_params.beam_width = beam_width;
-            enqueue_params.num_requests = num_requests;
-            enqueue_params.cache_indir = beam_width == 1
-                ? nullptr
-                : (cache_indirection.has_value() ? cache_indirection.value().data_ptr<int32_t>() : nullptr);
-            enqueue_params.semaphores = op.multiBlockSemaphores();
-            enqueue_params.host_past_key_value_lengths = host_past_key_value_lengths.data_ptr<int32_t>();
-            enqueue_params.start_token_idx_sf = token_offset;
+            {
+                NVTX3_SCOPED_RANGE_WITH_NAME(
+                    thopAttentionBuildGenerationParamsRange, "thop.attention.build_generation_params");
+                enqueue_params.layer_idx = op.mLayerIdx;
+                enqueue_params.beam_width = beam_width;
+                enqueue_params.num_requests = num_requests;
+                enqueue_params.cache_indir = beam_width == 1
+                    ? nullptr
+                    : (cache_indirection.has_value() ? cache_indirection.value().data_ptr<int32_t>() : nullptr);
+                enqueue_params.semaphores = op.multiBlockSemaphores();
+                enqueue_params.host_past_key_value_lengths = host_past_key_value_lengths.data_ptr<int32_t>();
+                enqueue_params.start_token_idx_sf = token_offset;
 
-            if (op.isMRoPE() && mrope_position_deltas.has_value())
-            {
-                enqueue_params.mrope_position_deltas = mrope_position_deltas.value().data_ptr<int32_t>();
-            }
-            if (op.mIsSpecDecodingEnabled && op.mUseSpecDecoding)
-            {
-                bool useTllmGen = tensorrt_llm::common::isSM100Family();
-                if (useTllmGen)
+                if (op.isMRoPE() && mrope_position_deltas.has_value())
                 {
-                    TORCH_CHECK(spec_decoding_tensor_params.size() == 6,
-                        "Expecting 6 tensors for spec-dec mode, spec_decoding_generation_lengths, "
-                        "spec_decoding_position_offsets, spec_decoding_packed_mask, spec_decoding_bl_tree_mask_offset, "
-                        "spec_decoding_bl_tree_mask and spec_bl_tree_first_sparse_mask_offset_kv.");
-                    TORCH_CHECK(spec_decoding_tensor_params[0].has_value(),
-                        "Expecting spec_decoding_generation_lengths spec-dec mode.");
-                    TORCH_CHECK(spec_decoding_tensor_params[1].has_value(),
-                        "Expecting spec_decoding_position_offsets spec-dec mode.");
-                    TORCH_CHECK(spec_decoding_tensor_params[2].has_value(),
-                        "Expecting spec_decoding_packed_mask spec-dec mode.");
-                    TORCH_CHECK(spec_decoding_tensor_params[3].has_value(),
-                        "Expecting spec_decoding_bl_tree_mask_offset spec-dec mode.");
-                    TORCH_CHECK(spec_decoding_tensor_params[4].has_value(),
-                        "Expecting spec_decoding_bl_tree_mask spec-dec mode.");
-                    TORCH_CHECK(spec_decoding_tensor_params[5].has_value(),
-                        "Expecting spec_bl_tree_first_sparse_mask_offset_kv spec-dec mode.");
-                    enqueue_params.spec_decoding_bl_tree_mask_offset
-                        = spec_decoding_tensor_params[3].value().data_ptr<int64_t>();
-                    enqueue_params.spec_decoding_bl_tree_mask
-                        = spec_decoding_tensor_params[4].value().data_ptr<uint32_t>();
-                    enqueue_params.spec_bl_tree_first_sparse_mask_offset_kv
-                        = spec_decoding_tensor_params[5].value().data_ptr<int32_t>();
+                    enqueue_params.mrope_position_deltas = mrope_position_deltas.value().data_ptr<int32_t>();
                 }
-                else
+                if (op.mIsSpecDecodingEnabled && op.mUseSpecDecoding)
                 {
-                    TORCH_CHECK(spec_decoding_tensor_params.size() == 3,
-                        "Expecting 3 tensors for spec-dec mode, spec_decoding_generation_lengths, "
-                        "spec_decoding_position_offsets and spec_decoding_packed_mask.");
-                    TORCH_CHECK(spec_decoding_tensor_params[0].has_value(),
-                        "Expecting spec_decoding_generation_lengths spec-dec mode.");
-                    TORCH_CHECK(spec_decoding_tensor_params[1].has_value(),
-                        "Expecting spec_decoding_position_offsets spec-dec mode.");
-                    TORCH_CHECK(spec_decoding_tensor_params[2].has_value(),
-                        "Expecting spec_decoding_packed_mask spec-dec mode.");
+                    bool useTllmGen = tensorrt_llm::common::isSM100Family();
+                    if (useTllmGen)
+                    {
+                        TORCH_CHECK(spec_decoding_tensor_params.size() == 6,
+                            "Expecting 6 tensors for spec-dec mode, spec_decoding_generation_lengths, "
+                            "spec_decoding_position_offsets, spec_decoding_packed_mask, "
+                            "spec_decoding_bl_tree_mask_offset, "
+                            "spec_decoding_bl_tree_mask and spec_bl_tree_first_sparse_mask_offset_kv.");
+                        TORCH_CHECK(spec_decoding_tensor_params[0].has_value(),
+                            "Expecting spec_decoding_generation_lengths spec-dec mode.");
+                        TORCH_CHECK(spec_decoding_tensor_params[1].has_value(),
+                            "Expecting spec_decoding_position_offsets spec-dec mode.");
+                        TORCH_CHECK(spec_decoding_tensor_params[2].has_value(),
+                            "Expecting spec_decoding_packed_mask spec-dec mode.");
+                        TORCH_CHECK(spec_decoding_tensor_params[3].has_value(),
+                            "Expecting spec_decoding_bl_tree_mask_offset spec-dec mode.");
+                        TORCH_CHECK(spec_decoding_tensor_params[4].has_value(),
+                            "Expecting spec_decoding_bl_tree_mask spec-dec mode.");
+                        TORCH_CHECK(spec_decoding_tensor_params[5].has_value(),
+                            "Expecting spec_bl_tree_first_sparse_mask_offset_kv spec-dec mode.");
+                        enqueue_params.spec_decoding_bl_tree_mask_offset
+                            = spec_decoding_tensor_params[3].value().data_ptr<int64_t>();
+                        enqueue_params.spec_decoding_bl_tree_mask
+                            = spec_decoding_tensor_params[4].value().data_ptr<uint32_t>();
+                        enqueue_params.spec_bl_tree_first_sparse_mask_offset_kv
+                            = spec_decoding_tensor_params[5].value().data_ptr<int32_t>();
+                    }
+                    else
+                    {
+                        TORCH_CHECK(spec_decoding_tensor_params.size() == 3,
+                            "Expecting 3 tensors for spec-dec mode, spec_decoding_generation_lengths, "
+                            "spec_decoding_position_offsets and spec_decoding_packed_mask.");
+                        TORCH_CHECK(spec_decoding_tensor_params[0].has_value(),
+                            "Expecting spec_decoding_generation_lengths spec-dec mode.");
+                        TORCH_CHECK(spec_decoding_tensor_params[1].has_value(),
+                            "Expecting spec_decoding_position_offsets spec-dec mode.");
+                        TORCH_CHECK(spec_decoding_tensor_params[2].has_value(),
+                            "Expecting spec_decoding_packed_mask spec-dec mode.");
+                    }
+                    enqueue_params.spec_decoding_generation_lengths
+                        = spec_decoding_tensor_params[0].value().data_ptr<int32_t>();
+                    enqueue_params.spec_decoding_position_offsets
+                        = spec_decoding_tensor_params[1].value().data_ptr<int32_t>();
+                    enqueue_params.spec_decoding_packed_mask
+                        = spec_decoding_tensor_params[2].value().data_ptr<int32_t>();
+                    enqueue_params.spec_decoding_is_generation_length_variable = true;
+                    TLLM_CHECK(spec_decoding_tensor_params[1].value().dim() == 2); // [batch_size, max_draft_len + 1]
+                    enqueue_params.spec_decoding_max_generation_length
+                        = spec_decoding_tensor_params[1].value().sizes()[1];
                 }
-                enqueue_params.spec_decoding_generation_lengths
-                    = spec_decoding_tensor_params[0].value().data_ptr<int32_t>();
-                enqueue_params.spec_decoding_position_offsets
-                    = spec_decoding_tensor_params[1].value().data_ptr<int32_t>();
-                enqueue_params.spec_decoding_packed_mask = spec_decoding_tensor_params[2].value().data_ptr<int32_t>();
-                enqueue_params.spec_decoding_is_generation_length_variable = true;
-                TLLM_CHECK(spec_decoding_tensor_params[1].value().dim() == 2); // [batch_size, max_draft_len + 1]
-                enqueue_params.spec_decoding_max_generation_length = spec_decoding_tensor_params[1].value().sizes()[1];
             }
 
             // Current mlaGeneration will using fmha to do attention, so we don't go into enqueueGeneration
@@ -791,12 +875,19 @@ public:
                     }
                 }
                 mla_params.cache_seq_lens = sequence_lengths_ptr;
-                op.mlaGeneration<T>(mla_params, enqueue_params, stream);
+                {
+                    NVTX3_SCOPED_RANGE_WITH_NAME(thopAttentionMlaGenerationRange, "thop.attention.mla_generation");
+                    op.mlaGeneration<T>(mla_params, enqueue_params, stream);
+                }
             }
             else
             {
                 extractHelixParams(enqueue_params);
-                op.enqueueGeneration<T, KVBlockArray>(enqueue_params, stream);
+                {
+                    NVTX3_SCOPED_RANGE_WITH_NAME(
+                        thopAttentionEnqueueGenerationRange, "thop.attention.enqueue_generation");
+                    op.enqueueGeneration<T, KVBlockArray>(enqueue_params, stream);
+                }
             }
 
             {
@@ -865,6 +956,7 @@ void attention(torch::Tensor q, std::optional<torch::Tensor> k, std::optional<to
     int64_t sage_attn_num_elts_per_blk_q, int64_t sage_attn_num_elts_per_blk_k, int64_t sage_attn_num_elts_per_blk_v,
     bool sage_attn_qk_int8, int64_t num_contexts, int64_t num_ctx_tokens)
 {
+    NVTX3_SCOPED_RANGE_WITH_NAME(thopAttentionRange, "thop.attention");
     TLLM_LOG_TRACE("Attention op starts at layer %d", layer_idx);
     // Use these tensors to infer if the attention is using KV cache
     bool const use_kv_cache = kv_cache_block_offsets.has_value() && host_kv_cache_pool_pointers.has_value()
@@ -1221,29 +1313,37 @@ KvCachePoolPointers buildKvCachePoolPointers(at::Tensor const& hostKvCachePoolPo
         // The layout of host_kv_cache_pool_pointers is [num_pools, 2 (primary and secondary), 2 (data and scale)].
         TORCH_CHECK(hostKvCachePoolPointers.dim() == 3);
         pointers.primaryPoolPtr = reinterpret_cast<void*>(
-            reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 0, 0}).item<int64_t>())
+            reinterpret_cast<char*>(
+                readHostTensor3D<int64_t>(hostKvCachePoolPointers, poolIndex, 0, 0, "host_kv_cache_pool_pointers"))
             + intraPoolOffset);
         pointers.secondaryPoolPtr = reinterpret_cast<void*>(
-            reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 1, 0}).item<int64_t>())
+            reinterpret_cast<char*>(
+                readHostTensor3D<int64_t>(hostKvCachePoolPointers, poolIndex, 1, 0, "host_kv_cache_pool_pointers"))
             + intraPoolOffset);
         // NVFP4 block scaling uses a fixed vector size of 16.
         auto constexpr vectorSize = 16;
         auto const bytesPerBlockSf = blockSize / vectorSize * 1 /*bytes per E4M3 sf*/;
         auto const intraPoolOffsetSf = layerIdxInCachePool * kvFactor * bytesPerBlockSf;
         pointers.primaryBlockScalePoolPtr = reinterpret_cast<void*>(
-            reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 0, 1}).item<int64_t>())
+            reinterpret_cast<char*>(
+                readHostTensor3D<int64_t>(hostKvCachePoolPointers, poolIndex, 0, 1, "host_kv_cache_pool_pointers"))
             + intraPoolOffsetSf);
         pointers.secondaryBlockScalePoolPtr = reinterpret_cast<void*>(
-            reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 1, 1}).item<int64_t>())
+            reinterpret_cast<char*>(
+                readHostTensor3D<int64_t>(hostKvCachePoolPointers, poolIndex, 1, 1, "host_kv_cache_pool_pointers"))
             + intraPoolOffsetSf);
     }
     else
     {
         TORCH_CHECK(hostKvCachePoolPointers.dim() == 2);
         pointers.primaryPoolPtr = reinterpret_cast<void*>(
-            reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 0}).item<int64_t>()) + intraPoolOffset);
+            reinterpret_cast<char*>(
+                readHostTensor2D<int64_t>(hostKvCachePoolPointers, poolIndex, 0, "host_kv_cache_pool_pointers"))
+            + intraPoolOffset);
         pointers.secondaryPoolPtr = reinterpret_cast<void*>(
-            reinterpret_cast<char*>(hostKvCachePoolPointers.index({poolIndex, 1}).item<int64_t>()) + intraPoolOffset);
+            reinterpret_cast<char*>(
+                readHostTensor2D<int64_t>(hostKvCachePoolPointers, poolIndex, 1, "host_kv_cache_pool_pointers"))
+            + intraPoolOffset);
     }
     return pointers;
 }
@@ -1265,11 +1365,11 @@ common::op::KvCacheBuffers<kernels::KVBlockArray> buildPagedKvCacheBuffers(
         return {};
     }
 
-    int32_t const poolIndex = host_kv_cache_pool_mapping->index({static_cast<int64_t>(layer_idx), 0}).item<int32_t>();
-    int32_t const layerIdxInCachePool
-        = host_kv_cache_pool_mapping->index({static_cast<int64_t>(layer_idx), 1}).item<int32_t>();
-    auto* blockOffsets = static_cast<KVBlockArray::DataType*>(
-        kv_cache_block_offsets->index({poolIndex, static_cast<int64_t>(seq_offset)}).data_ptr());
+    auto const mapping = readKvCachePoolMapping(host_kv_cache_pool_mapping.value(), layer_idx);
+    int32_t const poolIndex = mapping.poolIndex;
+    int32_t const layerIdxInCachePool = mapping.layerIdxInCachePool;
+    auto* blockOffsets = tensorPtr2D<KVBlockArray::DataType>(
+        kv_cache_block_offsets.value(), poolIndex, static_cast<int64_t>(seq_offset), "kv_cache_block_offsets");
 
     int cacheElemBits = common::op::AttentionOp::getKvCacheElemSizeInBits(quantMode, elem_size);
 
@@ -1296,9 +1396,9 @@ at::Tensor buildFlashinferTrtllmGenPagedKvCacheBuffers(at::Tensor host_kv_cache_
     at::Tensor host_kv_cache_pool_mapping, int64_t layer_idx, int64_t num_kv_heads, int64_t tokens_per_block,
     int64_t head_dim, int64_t kv_factor, int64_t total_num_blocks, int64_t kv_cache_quant_mode, at::ScalarType dtype)
 {
-    int32_t const poolIndex = host_kv_cache_pool_mapping.index({static_cast<int64_t>(layer_idx), 0}).item<int32_t>();
-    int32_t const layerIdxInCachePool
-        = host_kv_cache_pool_mapping.index({static_cast<int64_t>(layer_idx), 1}).item<int32_t>();
+    auto const mapping = readKvCachePoolMapping(host_kv_cache_pool_mapping, layer_idx);
+    int32_t const poolIndex = mapping.poolIndex;
+    int32_t const layerIdxInCachePool = mapping.layerIdxInCachePool;
 
     auto quantMode = tensorrt_llm::common::QuantMode(static_cast<uint32_t>(kv_cache_quant_mode));
     bool const isFp4 = quantMode.hasFp4KvCache();

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "tensorrt_llm/common/attentionOp.h"
+#include "tensorrt_llm/common/attentionWorkspace.h"
 #include "tensorrt_llm/common/dataType.h"
 #include "tensorrt_llm/kernels/flashMLA/flash_mla.h"
 #include "tensorrt_llm/kernels/gptKernels.h"
@@ -35,8 +36,226 @@ TRTLLM_NAMESPACE_BEGIN
 namespace torch_ext
 {
 using tensorrt_llm::common::op::AttentionOp;
+using tensorrt_llm::common::op::AttentionWorkspaceManager;
 using tensorrt_llm::common::op::hash;
 using tensorrt_llm::runtime::RequestType;
+
+namespace
+{
+
+int64_t exportOffset(tensorrt_llm::common::op::WorkspaceSlice const& slice)
+{
+    if (slice.size == 0)
+    {
+        return -1;
+    }
+    return static_cast<int64_t>(slice.offset);
+}
+
+} // namespace
+
+std::optional<at::Tensor> TrtllmAttentionWorkspaceManager::makeWorkspaceView(
+    at::Tensor const& workspace, int64_t const offset, int64_t const sizeBytes, at::ScalarType const scalarType)
+{
+    if (sizeBytes == 0)
+    {
+        return std::nullopt;
+    }
+
+    auto const* workspaceBase = static_cast<uint8_t const*>(workspace.data_ptr());
+    auto const workspaceSizeBytes = static_cast<int64_t>(workspace.nbytes());
+    TORCH_CHECK(offset >= 0, "Negative workspace offset is invalid.");
+    TORCH_CHECK(offset + sizeBytes <= workspaceSizeBytes, "Workspace view exceeds workspace bounds.");
+
+    auto const itemSize = static_cast<int64_t>(c10::elementSize(scalarType));
+    TORCH_CHECK(sizeBytes % itemSize == 0, "Workspace slice is not aligned to dtype size.");
+
+    auto options = at::TensorOptions().dtype(scalarType).device(workspace.device());
+    return torch::from_blob(const_cast<uint8_t*>(workspaceBase) + offset, {sizeBytes / itemSize}, options);
+}
+
+TrtllmGenContextWorkspaceLayout TrtllmAttentionWorkspaceManager::buildContextLayout(at::ScalarType const qDtype,
+    int64_t const batchSize, int64_t const numTokens, int64_t const numHeads, int64_t const headSize,
+    int64_t const rotaryEmbeddingDim, bool const separateQKvInput, bool const fp8ContextFmha)
+{
+    auto const dtypeSize = static_cast<int64_t>(c10::elementSize(qDtype));
+    auto const localHiddenUnitsQo = numHeads * headSize;
+    auto const cuSeqlensSize = static_cast<int64_t>(sizeof(int32_t)) * (batchSize + 1);
+    auto const rotaryInvFreqSize
+        = rotaryEmbeddingDim > 0 ? static_cast<int64_t>(sizeof(float)) * batchSize * rotaryEmbeddingDim / 2 : 0;
+    auto const qBufSize = separateQKvInput ? (fp8ContextFmha ? 1 : dtypeSize) * numTokens * localHiddenUnitsQo : 0;
+    auto const tokensInfoSize = static_cast<int64_t>(sizeof(int32_t) * 2) * numTokens;
+    auto const fmhaTileCounterSize = static_cast<int64_t>(sizeof(uint32_t));
+    auto const fmhaBmm1ScaleSize = fp8ContextFmha ? static_cast<int64_t>(sizeof(float) * 2) : 0;
+    auto const fmhaBmm2ScaleSize = fp8ContextFmha ? static_cast<int64_t>(sizeof(float)) : 0;
+
+    tensorrt_llm::common::op::AttentionContextWorkspaceSizes workspaceSizes{};
+    workspaceSizes.cuQSeqlens = cuSeqlensSize;
+    workspaceSizes.cuKvSeqlens = cuSeqlensSize;
+    workspaceSizes.cuMaskRows = cuSeqlensSize;
+    workspaceSizes.rotaryInvFreq = rotaryInvFreqSize;
+    workspaceSizes.qBuf = qBufSize;
+    workspaceSizes.tokensInfo = tokensInfoSize;
+    workspaceSizes.fmhaTileCounter = fmhaTileCounterSize;
+    workspaceSizes.fmhaBmm1Scale = fmhaBmm1ScaleSize;
+    workspaceSizes.fmhaBmm2Scale = fmhaBmm2ScaleSize;
+    auto const layout = AttentionWorkspaceManager::buildContextLayout(workspaceSizes, kWorkspaceAlignment);
+
+    return TrtllmGenContextWorkspaceLayout{
+        .trtllmGenWorkspaceOffset = exportOffset(layout.cublasWorkspace),
+        .cuQSeqlensOffset = exportOffset(layout.cuQSeqlens),
+        .cuKvSeqlensOffset = exportOffset(layout.cuKvSeqlens),
+        .cuMaskRowsOffset = exportOffset(layout.cuMaskRows),
+        .rotaryInvFreqOffset = exportOffset(layout.rotaryInvFreq),
+        .qBufOffset = exportOffset(layout.qBuf),
+        .tokensInfoOffset = exportOffset(layout.tokensInfo),
+        .fmhaTileCounterOffset = exportOffset(layout.fmhaTileCounter),
+        .fmhaBmm1ScaleOffset = exportOffset(layout.fmhaBmm1Scale),
+        .fmhaBmm2ScaleOffset = exportOffset(layout.fmhaBmm2Scale),
+        .trtllmGenWorkspaceSize = kTrtllmGenWorkspaceSize,
+        .cuSeqlensSize = cuSeqlensSize,
+        .rotaryInvFreqSize = rotaryInvFreqSize,
+        .qBufSize = qBufSize,
+        .tokensInfoSize = tokensInfoSize,
+        .fmhaTileCounterSize = fmhaTileCounterSize,
+        .fmhaBmm1ScaleSize = fmhaBmm1ScaleSize,
+        .fmhaBmm2ScaleSize = fmhaBmm2ScaleSize,
+        .totalSize = static_cast<int64_t>(layout.totalSize),
+        .qBufScalarType = fp8ContextFmha ? at::kByte : qDtype,
+    };
+}
+
+TrtllmGenGenerationWorkspaceLayout TrtllmAttentionWorkspaceManager::buildGenerationLayout(at::ScalarType const qDtype,
+    int64_t const batchBeam, int64_t const numTokens, int64_t const numHeads, int64_t const headSize,
+    int64_t const rotaryEmbeddingDim, int64_t const numKvHeads, int64_t const maxBlocksPerSequence,
+    bool const useSparseAttention)
+{
+    auto const dtypeSize = static_cast<int64_t>(c10::elementSize(qDtype));
+    auto const cuSeqlensSize = static_cast<int64_t>(sizeof(int32_t)) * (batchBeam + 1);
+    auto const cuKvSeqlensSize = static_cast<int64_t>(sizeof(int32_t)) * (batchBeam + 1);
+    auto const rotaryInvFreqSize
+        = rotaryEmbeddingDim > 0 ? static_cast<int64_t>(sizeof(float)) * batchBeam * rotaryEmbeddingDim / 2 : 0;
+    auto const tokensInfoSize = static_cast<int64_t>(sizeof(int32_t) * 2) * numTokens;
+    auto const qBufSize = dtypeSize * numTokens * numHeads * headSize;
+    auto const bmm1ScaleSize = static_cast<int64_t>(sizeof(float) * 2);
+    auto const bmm2ScaleSize = static_cast<int64_t>(sizeof(float));
+    auto const sparseAttnCacheSize = useSparseAttention
+        ? static_cast<int64_t>(sizeof(int32_t)) * (batchBeam + batchBeam * 2 * maxBlocksPerSequence) * numKvHeads
+        : 0;
+
+    tensorrt_llm::common::op::AttentionXqaWorkspaceSizes workspaceSizes{};
+    workspaceSizes.cuSeqlens = cuSeqlensSize;
+    workspaceSizes.cuKvSeqlens = cuKvSeqlensSize;
+    workspaceSizes.rotaryInvFreq = rotaryInvFreqSize;
+    workspaceSizes.tokensInfo = tokensInfoSize;
+    workspaceSizes.bmm1Scale = bmm1ScaleSize;
+    workspaceSizes.bmm2Scale = bmm2ScaleSize;
+    workspaceSizes.sparseAttnCache = sparseAttnCacheSize;
+    workspaceSizes.kernelWorkspace = qBufSize;
+    auto const xqaLayout = AttentionWorkspaceManager::buildXqaLayout(workspaceSizes, kWorkspaceAlignment);
+    auto const trtllmGenWorkspaceOffset = static_cast<int64_t>(xqaLayout.totalSize);
+    auto const totalSize = xqaLayout.totalSize
+        + tensorrt_llm::common::alignSize(static_cast<size_t>(kTrtllmGenWorkspaceSize), kWorkspaceAlignment);
+
+    return TrtllmGenGenerationWorkspaceLayout{
+        .trtllmGenWorkspaceOffset = trtllmGenWorkspaceOffset,
+        .cuSeqlensOffset = exportOffset(xqaLayout.cuSeqlens),
+        .cuKvSeqlensOffset = exportOffset(xqaLayout.cuKvSeqlens),
+        .rotaryInvFreqOffset = exportOffset(xqaLayout.rotaryInvFreq),
+        .tokensInfoOffset = exportOffset(xqaLayout.tokensInfo),
+        .qBufOffset = exportOffset(xqaLayout.kernelWorkspace),
+        .bmm1ScaleOffset = exportOffset(xqaLayout.bmm1Scale),
+        .bmm2ScaleOffset = exportOffset(xqaLayout.bmm2Scale),
+        .sparseAttnCacheOffset = exportOffset(xqaLayout.sparseAttnCache),
+        .trtllmGenWorkspaceSize = kTrtllmGenWorkspaceSize,
+        .cuSeqlensSize = cuSeqlensSize,
+        .cuKvSeqlensSize = cuKvSeqlensSize,
+        .rotaryInvFreqSize = rotaryInvFreqSize,
+        .tokensInfoSize = tokensInfoSize,
+        .qBufSize = qBufSize,
+        .bmm1ScaleSize = bmm1ScaleSize,
+        .bmm2ScaleSize = bmm2ScaleSize,
+        .sparseAttnCacheSize = sparseAttnCacheSize,
+        .totalSize = static_cast<int64_t>(totalSize),
+        .qBufScalarType = qDtype,
+    };
+}
+
+int64_t TrtllmAttentionWorkspaceManager::getContextWorkspaceSize(at::ScalarType const qDtype, int64_t const batchSize,
+    int64_t const numTokens, int64_t const numHeads, int64_t const headSize, int64_t const rotaryEmbeddingDim,
+    bool const separateQKvInput, bool const fp8ContextFmha)
+{
+    return buildContextLayout(
+        qDtype, batchSize, numTokens, numHeads, headSize, rotaryEmbeddingDim, separateQKvInput, fp8ContextFmha)
+        .totalSize;
+}
+
+int64_t TrtllmAttentionWorkspaceManager::getGenerationWorkspaceSize(at::ScalarType const qDtype,
+    int64_t const batchBeam, int64_t const numTokens, int64_t const numHeads, int64_t const headSize,
+    int64_t const rotaryEmbeddingDim, int64_t const numKvHeads, int64_t const maxBlocksPerSequence,
+    bool const useSparseAttention)
+{
+    return buildGenerationLayout(qDtype, batchBeam, numTokens, numHeads, headSize, rotaryEmbeddingDim, numKvHeads,
+        maxBlocksPerSequence, useSparseAttention)
+        .totalSize;
+}
+
+TrtllmGenContextWorkspaceViews TrtllmAttentionWorkspaceManager::materializeContextWorkspace(
+    at::Tensor const& workspace, TrtllmGenContextWorkspaceLayout const& layout)
+{
+    return TrtllmGenContextWorkspaceViews{
+        .trtllmGenWorkspace
+        = *makeWorkspaceView(workspace, layout.trtllmGenWorkspaceOffset, layout.trtllmGenWorkspaceSize, at::kByte),
+        .cuQSeqlens = *makeWorkspaceView(workspace, layout.cuQSeqlensOffset, layout.cuSeqlensSize, at::kInt),
+        .cuKvSeqlens = *makeWorkspaceView(workspace, layout.cuKvSeqlensOffset, layout.cuSeqlensSize, at::kInt),
+        .cuMaskRows = *makeWorkspaceView(workspace, layout.cuMaskRowsOffset, layout.cuSeqlensSize, at::kInt),
+        .rotaryInvFreqBuf
+        = makeWorkspaceView(workspace, layout.rotaryInvFreqOffset, layout.rotaryInvFreqSize, at::kFloat),
+        .qBuf = makeWorkspaceView(workspace, layout.qBufOffset, layout.qBufSize, layout.qBufScalarType),
+        .tokensInfo = *makeWorkspaceView(workspace, layout.tokensInfoOffset, layout.tokensInfoSize, at::kInt),
+        .fmhaTileCounter
+        = *makeWorkspaceView(workspace, layout.fmhaTileCounterOffset, layout.fmhaTileCounterSize, at::kUInt32),
+        .fmhaBmm1Scale = makeWorkspaceView(workspace, layout.fmhaBmm1ScaleOffset, layout.fmhaBmm1ScaleSize, at::kFloat),
+        .fmhaBmm2Scale = makeWorkspaceView(workspace, layout.fmhaBmm2ScaleOffset, layout.fmhaBmm2ScaleSize, at::kFloat),
+    };
+}
+
+TrtllmGenContextWorkspaceViews TrtllmAttentionWorkspaceManager::materializeContextWorkspace(at::Tensor const& workspace,
+    at::ScalarType const qDtype, int64_t const batchSize, int64_t const numTokens, int64_t const numHeads,
+    int64_t const headSize, int64_t const rotaryEmbeddingDim, bool const fp8ContextFmha)
+{
+    auto const layout = buildContextLayout(
+        qDtype, batchSize, numTokens, numHeads, headSize, rotaryEmbeddingDim, true, fp8ContextFmha);
+    return materializeContextWorkspace(workspace, layout);
+}
+
+TrtllmGenGenerationWorkspaceViews TrtllmAttentionWorkspaceManager::materializeGenerationWorkspace(
+    at::Tensor const& workspace, TrtllmGenGenerationWorkspaceLayout const& layout)
+{
+    return TrtllmGenGenerationWorkspaceViews{
+        .trtllmGenWorkspace
+        = *makeWorkspaceView(workspace, layout.trtllmGenWorkspaceOffset, layout.trtllmGenWorkspaceSize, at::kByte),
+        .cuSeqlens = *makeWorkspaceView(workspace, layout.cuSeqlensOffset, layout.cuSeqlensSize, at::kInt),
+        .cuKvSeqlens = *makeWorkspaceView(workspace, layout.cuKvSeqlensOffset, layout.cuKvSeqlensSize, at::kInt),
+        .rotaryInvFreqBuf
+        = makeWorkspaceView(workspace, layout.rotaryInvFreqOffset, layout.rotaryInvFreqSize, at::kFloat),
+        .tokensInfo = *makeWorkspaceView(workspace, layout.tokensInfoOffset, layout.tokensInfoSize, at::kInt),
+        .qBuf = *makeWorkspaceView(workspace, layout.qBufOffset, layout.qBufSize, layout.qBufScalarType),
+        .bmm1Scale = *makeWorkspaceView(workspace, layout.bmm1ScaleOffset, layout.bmm1ScaleSize, at::kFloat),
+        .bmm2Scale = *makeWorkspaceView(workspace, layout.bmm2ScaleOffset, layout.bmm2ScaleSize, at::kFloat),
+        .sparseAttnCache
+        = makeWorkspaceView(workspace, layout.sparseAttnCacheOffset, layout.sparseAttnCacheSize, at::kInt),
+    };
+}
+
+TrtllmGenGenerationWorkspaceViews TrtllmAttentionWorkspaceManager::materializeGenerationWorkspace(
+    at::Tensor const& workspace, at::ScalarType const qDtype, int64_t const batchBeam, int64_t const numTokens,
+    int64_t const numHeads, int64_t const headSize, int64_t const rotaryEmbeddingDim, int64_t const numKvHeads)
+{
+    auto const layout = buildGenerationLayout(
+        qDtype, batchBeam, numTokens, numHeads, headSize, rotaryEmbeddingDim, numKvHeads, 0, false);
+    return materializeGenerationWorkspace(workspace, layout);
+}
 
 namespace trtllm::attention
 {
@@ -1073,10 +1292,9 @@ common::op::KvCacheBuffers<kernels::KVBlockArray> buildPagedKvCacheBuffers(
         blockOffsets, quantMode.hasFp4KvCache());
 }
 
-std::tuple<at::Tensor, std::optional<at::Tensor>> buildFlashinferTrtllmGenPagedKvCacheBuffers(
-    at::Tensor host_kv_cache_pool_pointers, at::Tensor host_kv_cache_pool_mapping, int64_t layer_idx,
-    int64_t num_kv_heads, int64_t tokens_per_block, int64_t head_dim, int64_t kv_factor, int64_t total_num_blocks,
-    int64_t kv_cache_quant_mode, at::ScalarType dtype)
+at::Tensor buildFlashinferTrtllmGenPagedKvCacheBuffers(at::Tensor host_kv_cache_pool_pointers,
+    at::Tensor host_kv_cache_pool_mapping, int64_t layer_idx, int64_t num_kv_heads, int64_t tokens_per_block,
+    int64_t head_dim, int64_t kv_factor, int64_t total_num_blocks, int64_t kv_cache_quant_mode, at::ScalarType dtype)
 {
     int32_t const poolIndex = host_kv_cache_pool_mapping.index({static_cast<int64_t>(layer_idx), 0}).item<int32_t>();
     int32_t const layerIdxInCachePool
@@ -1094,6 +1312,7 @@ std::tuple<at::Tensor, std::optional<at::Tensor>> buildFlashinferTrtllmGenPagedK
 
     auto poolPointers = buildKvCachePoolPointers(host_kv_cache_pool_pointers, poolIndex, intraPoolOffset, blockSize,
         layerIdxInCachePool, static_cast<int32_t>(kv_factor), isFp4);
+    TORCH_CHECK(poolPointers.primaryPoolPtr != nullptr, "Primary KV cache pool pointer is null.");
 
     at::ScalarType storageDtype = dtype;
     if (quantMode.hasFp8KvCache())
@@ -1106,20 +1325,13 @@ std::tuple<at::Tensor, std::optional<at::Tensor>> buildFlashinferTrtllmGenPagedK
     int64_t containerDim = isFp4 ? head_dim / 2 : head_dim;
 
     // Flat-block KV cache: [total_blocks, num_kv_heads, tokens_per_block, containerDim]
-    auto options = at::TensorOptions().dtype(storageDtype).device(at::kCUDA);
+    auto options = at::TensorOptions()
+                       .dtype(storageDtype)
+                       .device(c10::Device(at::kCUDA, static_cast<c10::DeviceIndex>(at::cuda::current_device())));
     auto kv_pool = torch::from_blob(
         poolPointers.primaryPoolPtr, {total_num_blocks, num_kv_heads, tokens_per_block, containerDim}, options);
 
-    // FP4 block scale pool (same flat-block layout, E4M3 dtype, vector_size=16)
-    std::optional<at::Tensor> kv_scale_pool = std::nullopt;
-    if (quantMode.hasFp4KvCache() && poolPointers.primaryBlockScalePoolPtr != nullptr)
-    {
-        auto sf_options = at::TensorOptions().dtype(at::kFloat8_e4m3fn).device(at::kCUDA);
-        kv_scale_pool = torch::from_blob(poolPointers.primaryBlockScalePoolPtr,
-            {total_num_blocks, num_kv_heads, tokens_per_block, head_dim / 16}, sf_options);
-    }
-
-    return {kv_pool, kv_scale_pool};
+    return kv_pool;
 }
 
 } // namespace torch_ext

--- a/cpp/tensorrt_llm/thop/attentionOp.cpp
+++ b/cpp/tensorrt_llm/thop/attentionOp.cpp
@@ -1073,6 +1073,55 @@ common::op::KvCacheBuffers<kernels::KVBlockArray> buildPagedKvCacheBuffers(
         blockOffsets, quantMode.hasFp4KvCache());
 }
 
+std::tuple<at::Tensor, std::optional<at::Tensor>> buildFlashinferTrtllmGenPagedKvCacheBuffers(
+    at::Tensor host_kv_cache_pool_pointers, at::Tensor host_kv_cache_pool_mapping, int64_t layer_idx,
+    int64_t num_kv_heads, int64_t tokens_per_block, int64_t head_dim, int64_t kv_factor, int64_t total_num_blocks,
+    int64_t kv_cache_quant_mode, at::ScalarType dtype)
+{
+    int32_t const poolIndex = host_kv_cache_pool_mapping.index({static_cast<int64_t>(layer_idx), 0}).item<int32_t>();
+    int32_t const layerIdxInCachePool
+        = host_kv_cache_pool_mapping.index({static_cast<int64_t>(layer_idx), 1}).item<int32_t>();
+
+    auto quantMode = tensorrt_llm::common::QuantMode(static_cast<uint32_t>(kv_cache_quant_mode));
+    bool const isFp4 = quantMode.hasFp4KvCache();
+
+    size_t const inputElemSize = isFp4 ? 1 : (quantMode.hasFp8KvCache() || quantMode.hasInt8KvCache() ? 1 : 2);
+    int const cacheElemBits = common::op::AttentionOp::getKvCacheElemSizeInBits(quantMode, inputElemSize);
+
+    auto const blockSize = tokens_per_block * num_kv_heads * head_dim;
+    auto const bytesPerBlock = blockSize * cacheElemBits / CHAR_BIT;
+    auto const intraPoolOffset = layerIdxInCachePool * kv_factor * bytesPerBlock;
+
+    auto poolPointers = buildKvCachePoolPointers(host_kv_cache_pool_pointers, poolIndex, intraPoolOffset, blockSize,
+        layerIdxInCachePool, static_cast<int32_t>(kv_factor), isFp4);
+
+    at::ScalarType storageDtype = dtype;
+    if (quantMode.hasFp8KvCache())
+        storageDtype = at::kFloat8_e4m3fn;
+    else if (quantMode.hasInt8KvCache())
+        storageDtype = at::kByte;
+    else if (quantMode.hasFp4KvCache())
+        storageDtype = at::kByte; // FP4 packed as bytes
+
+    int64_t containerDim = isFp4 ? head_dim / 2 : head_dim;
+
+    // Flat-block KV cache: [total_blocks, num_kv_heads, tokens_per_block, containerDim]
+    auto options = at::TensorOptions().dtype(storageDtype).device(at::kCUDA);
+    auto kv_pool = torch::from_blob(
+        poolPointers.primaryPoolPtr, {total_num_blocks, num_kv_heads, tokens_per_block, containerDim}, options);
+
+    // FP4 block scale pool (same flat-block layout, E4M3 dtype, vector_size=16)
+    std::optional<at::Tensor> kv_scale_pool = std::nullopt;
+    if (quantMode.hasFp4KvCache() && poolPointers.primaryBlockScalePoolPtr != nullptr)
+    {
+        auto sf_options = at::TensorOptions().dtype(at::kFloat8_e4m3fn).device(at::kCUDA);
+        kv_scale_pool = torch::from_blob(poolPointers.primaryBlockScalePoolPtr,
+            {total_num_blocks, num_kv_heads, tokens_per_block, head_dim / 16}, sf_options);
+    }
+
+    return {kv_pool, kv_scale_pool};
+}
+
 } // namespace torch_ext
 
 void computeFlashMlaMetadata(torch::Tensor seqlens_k, torch::Tensor tile_scheduler_metadata, torch::Tensor num_splits,

--- a/cpp/tensorrt_llm/thop/attentionOp.h
+++ b/cpp/tensorrt_llm/thop/attentionOp.h
@@ -101,6 +101,11 @@ common::op::KvCacheBuffers<kernels::KVBlockArray> buildPagedKvCacheBuffers(
     int64_t cyclic_attention_window_size, int64_t max_attention_window_size, int64_t sink_token_length,
     int64_t beam_width, int64_t seq_offset, bool is_mla_enable, size_t elem_size);
 
+std::tuple<at::Tensor, std::optional<at::Tensor>> buildFlashinferTrtllmGenPagedKvCacheBuffers(
+    at::Tensor host_kv_cache_pool_pointers, at::Tensor host_kv_cache_pool_mapping, int64_t layer_idx,
+    int64_t num_kv_heads, int64_t tokens_per_block, int64_t head_dim, int64_t kv_factor, int64_t total_num_blocks,
+    int64_t kv_cache_quant_mode, at::ScalarType dtype);
+
 } // namespace torch_ext
 
 /**

--- a/cpp/tensorrt_llm/thop/attentionOp.h
+++ b/cpp/tensorrt_llm/thop/attentionOp.h
@@ -91,6 +91,14 @@ struct KvCachePoolPointers
     void* secondaryBlockScalePoolPtr{nullptr};
 };
 
+struct KvCachePoolMapping
+{
+    int32_t poolIndex{0};
+    int32_t layerIdxInCachePool{0};
+};
+
+KvCachePoolMapping readKvCachePoolMapping(at::Tensor const& hostKvCachePoolMapping, int64_t layerIdx);
+
 KvCachePoolPointers buildKvCachePoolPointers(at::Tensor const& hostKvCachePoolPointers, int32_t poolIndex,
     int64_t intraPoolOffset, int64_t blockSize, int32_t layerIdxInCachePool, int32_t kvFactor, bool isFp4KvCache);
 

--- a/cpp/tensorrt_llm/thop/attentionOp.h
+++ b/cpp/tensorrt_llm/thop/attentionOp.h
@@ -22,6 +22,7 @@
 
 #include "tensorrt_llm/common/attentionOp.h"
 #include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/quantization.h"
 #include "tensorrt_llm/kernels/kvCacheUtils.h"
 #include "tensorrt_llm/kernels/unfusedAttentionKernels.h"
@@ -101,10 +102,128 @@ common::op::KvCacheBuffers<kernels::KVBlockArray> buildPagedKvCacheBuffers(
     int64_t cyclic_attention_window_size, int64_t max_attention_window_size, int64_t sink_token_length,
     int64_t beam_width, int64_t seq_offset, bool is_mla_enable, size_t elem_size);
 
-std::tuple<at::Tensor, std::optional<at::Tensor>> buildFlashinferTrtllmGenPagedKvCacheBuffers(
-    at::Tensor host_kv_cache_pool_pointers, at::Tensor host_kv_cache_pool_mapping, int64_t layer_idx,
-    int64_t num_kv_heads, int64_t tokens_per_block, int64_t head_dim, int64_t kv_factor, int64_t total_num_blocks,
-    int64_t kv_cache_quant_mode, at::ScalarType dtype);
+at::Tensor buildFlashinferTrtllmGenPagedKvCacheBuffers(at::Tensor host_kv_cache_pool_pointers,
+    at::Tensor host_kv_cache_pool_mapping, int64_t layer_idx, int64_t num_kv_heads, int64_t tokens_per_block,
+    int64_t head_dim, int64_t kv_factor, int64_t total_num_blocks, int64_t kv_cache_quant_mode, at::ScalarType dtype);
+
+// Layout manager for the thop attention workspace slices used by trtllm-gen.
+// Context follows AttentionOp::getWorkspaceSizeForContext() ordering. Generation
+// follows the XQA workspace ordering used by AttentionOp generation.
+struct TrtllmGenContextWorkspaceLayout
+{
+    int64_t trtllmGenWorkspaceOffset{};
+    int64_t cuQSeqlensOffset{};
+    int64_t cuKvSeqlensOffset{};
+    int64_t cuMaskRowsOffset{};
+    int64_t rotaryInvFreqOffset{};
+    int64_t qBufOffset{};
+    int64_t tokensInfoOffset{};
+    int64_t fmhaTileCounterOffset{};
+    int64_t fmhaBmm1ScaleOffset{};
+    int64_t fmhaBmm2ScaleOffset{};
+    int64_t trtllmGenWorkspaceSize{};
+    int64_t cuSeqlensSize{};
+    int64_t rotaryInvFreqSize{};
+    int64_t qBufSize{};
+    int64_t tokensInfoSize{};
+    int64_t fmhaTileCounterSize{};
+    int64_t fmhaBmm1ScaleSize{};
+    int64_t fmhaBmm2ScaleSize{};
+    int64_t totalSize{};
+    at::ScalarType qBufScalarType{};
+};
+
+struct TrtllmGenGenerationWorkspaceLayout
+{
+    int64_t trtllmGenWorkspaceOffset{};
+    int64_t cuSeqlensOffset{};
+    int64_t cuKvSeqlensOffset{};
+    int64_t rotaryInvFreqOffset{};
+    int64_t tokensInfoOffset{};
+    int64_t qBufOffset{};
+    int64_t bmm1ScaleOffset{};
+    int64_t bmm2ScaleOffset{};
+    int64_t sparseAttnCacheOffset{};
+    int64_t trtllmGenWorkspaceSize{};
+    int64_t cuSeqlensSize{};
+    int64_t cuKvSeqlensSize{};
+    int64_t rotaryInvFreqSize{};
+    int64_t tokensInfoSize{};
+    int64_t qBufSize{};
+    int64_t bmm1ScaleSize{};
+    int64_t bmm2ScaleSize{};
+    int64_t sparseAttnCacheSize{};
+    int64_t totalSize{};
+    at::ScalarType qBufScalarType{};
+};
+
+struct TrtllmGenContextWorkspaceViews
+{
+    at::Tensor trtllmGenWorkspace;
+    at::Tensor cuQSeqlens;
+    at::Tensor cuKvSeqlens;
+    at::Tensor cuMaskRows;
+    std::optional<at::Tensor> rotaryInvFreqBuf;
+    std::optional<at::Tensor> qBuf;
+    at::Tensor tokensInfo;
+    at::Tensor fmhaTileCounter;
+    std::optional<at::Tensor> fmhaBmm1Scale;
+    std::optional<at::Tensor> fmhaBmm2Scale;
+};
+
+struct TrtllmGenGenerationWorkspaceViews
+{
+    at::Tensor trtllmGenWorkspace;
+    at::Tensor cuSeqlens;
+    at::Tensor cuKvSeqlens;
+    std::optional<at::Tensor> rotaryInvFreqBuf;
+    at::Tensor tokensInfo;
+    at::Tensor qBuf;
+    at::Tensor bmm1Scale;
+    at::Tensor bmm2Scale;
+    std::optional<at::Tensor> sparseAttnCache;
+};
+
+class TrtllmAttentionWorkspaceManager
+{
+public:
+    static constexpr int64_t kWorkspaceAlignment = 256;
+    static constexpr int64_t kTrtllmGenWorkspaceSize = CUBLAS_WORKSPACE_SIZE;
+
+    static TrtllmGenContextWorkspaceLayout buildContextLayout(at::ScalarType qDtype, int64_t batchSize,
+        int64_t numTokens, int64_t numHeads, int64_t headSize, int64_t rotaryEmbeddingDim, bool separateQKvInput,
+        bool fp8ContextFmha);
+
+    static TrtllmGenGenerationWorkspaceLayout buildGenerationLayout(at::ScalarType qDtype, int64_t batchBeam,
+        int64_t numTokens, int64_t numHeads, int64_t headSize, int64_t rotaryEmbeddingDim, int64_t numKvHeads,
+        int64_t maxBlocksPerSequence, bool useSparseAttention);
+
+    static int64_t getContextWorkspaceSize(at::ScalarType qDtype, int64_t batchSize, int64_t numTokens,
+        int64_t numHeads, int64_t headSize, int64_t rotaryEmbeddingDim, bool separateQKvInput, bool fp8ContextFmha);
+
+    //! numKvHeads and maxBlocksPerSequence affect the size only when sparse attention is enabled.
+    static int64_t getGenerationWorkspaceSize(at::ScalarType qDtype, int64_t batchBeam, int64_t numTokens,
+        int64_t numHeads, int64_t headSize, int64_t rotaryEmbeddingDim, int64_t numKvHeads,
+        int64_t maxBlocksPerSequence, bool useSparseAttention);
+
+    static TrtllmGenContextWorkspaceViews materializeContextWorkspace(
+        at::Tensor const& workspace, TrtllmGenContextWorkspaceLayout const& layout);
+
+    static TrtllmGenContextWorkspaceViews materializeContextWorkspace(at::Tensor const& workspace,
+        at::ScalarType qDtype, int64_t batchSize, int64_t numTokens, int64_t numHeads, int64_t headSize,
+        int64_t rotaryEmbeddingDim, bool fp8ContextFmha);
+
+    static TrtllmGenGenerationWorkspaceViews materializeGenerationWorkspace(
+        at::Tensor const& workspace, TrtllmGenGenerationWorkspaceLayout const& layout);
+
+    static TrtllmGenGenerationWorkspaceViews materializeGenerationWorkspace(at::Tensor const& workspace,
+        at::ScalarType qDtype, int64_t batchBeam, int64_t numTokens, int64_t numHeads, int64_t headSize,
+        int64_t rotaryEmbeddingDim, int64_t numKvHeads);
+
+private:
+    static std::optional<at::Tensor> makeWorkspaceView(
+        at::Tensor const& workspace, int64_t offset, int64_t sizeBytes, at::ScalarType scalarType);
+};
 
 } // namespace torch_ext
 

--- a/cpp/tensorrt_llm/thop/trtllmGenFusedOps.h
+++ b/cpp/tensorrt_llm/thop/trtllmGenFusedOps.h
@@ -41,8 +41,8 @@ trtllmGenContextPreprocess(torch::Tensor qkv_input, torch::Tensor workspace, tor
     int64_t max_past_kv_length, int64_t rotary_embedding_dim, double rotary_embedding_base,
     int64_t rotary_embedding_scale_type, double rotary_embedding_scale, int64_t rotary_embedding_max_positions,
     int64_t position_embedding_type, double bmm1_scale, double bmm2_scale, int64_t attention_chunk_size,
-    bool fp8_context_fmha, bool paged_context_fmha, bool is_mla_enable, int64_t total_num_blocks, int64_t kv_factor,
-    bool need_build_kv_cache_metadata);
+    bool fp8_context_fmha, bool paged_context_fmha, bool is_mla_enable, int64_t multi_processor_count,
+    int64_t total_num_blocks, int64_t kv_factor, bool need_build_kv_cache_metadata);
 
 void trtllmGenContextPostprocess(torch::Tensor qkv_input, torch::Tensor workspace, torch::Tensor sequence_lengths,
     torch::Tensor context_lengths, std::optional<torch::Tensor> kv_cache_block_offsets,
@@ -55,8 +55,8 @@ void trtllmGenContextPostprocess(torch::Tensor qkv_input, torch::Tensor workspac
     int64_t num_tokens, int64_t batch_size, int64_t input_seq_length, int64_t max_past_kv_length,
     int64_t rotary_embedding_dim, double rotary_embedding_base, int64_t rotary_embedding_scale_type,
     double rotary_embedding_scale, int64_t rotary_embedding_max_positions, int64_t position_embedding_type,
-    double bmm1_scale, bool fp8_context_fmha, bool paged_context_fmha, bool is_mla_enable,
-    int64_t attention_chunk_size);
+    double bmm1_scale, bool fp8_context_fmha, bool paged_context_fmha, bool is_mla_enable, int64_t attention_chunk_size,
+    int64_t multi_processor_count);
 
 std::tuple<at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>, at::Tensor, std::optional<at::Tensor>,
     int64_t, int64_t, int64_t, bool>
@@ -73,7 +73,8 @@ trtllmGenGenerationPreprocess(torch::Tensor qkv_input, torch::Tensor workspace, 
     int64_t rotary_embedding_dim, double rotary_embedding_base, int64_t rotary_embedding_scale_type,
     double rotary_embedding_scale, int64_t rotary_embedding_max_positions, int64_t position_embedding_type,
     double bmm1_scale, double bmm2_scale, bool fp8_context_fmha, int64_t predicted_tokens_per_seq,
-    int64_t attention_chunk_size, int64_t total_num_blocks, int64_t kv_factor, bool need_build_kv_cache_metadata);
+    int64_t attention_chunk_size, int64_t multi_processor_count, int64_t total_num_blocks, int64_t kv_factor,
+    bool need_build_kv_cache_metadata);
 
 } // namespace torch_ext
 

--- a/cpp/tensorrt_llm/thop/trtllmGenFusedOps.h
+++ b/cpp/tensorrt_llm/thop/trtllmGenFusedOps.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <torch/extension.h>
+#include <tuple>
+
+#include "tensorrt_llm/common/config.h"
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace torch_ext
+{
+
+std::tuple<at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>, at::Tensor, at::Tensor, at::Tensor,
+    int64_t, int64_t, int64_t>
+trtllmGenContextPreprocess(torch::Tensor qkv_input, torch::Tensor workspace, torch::Tensor sequence_lengths,
+    torch::Tensor context_lengths, std::optional<torch::Tensor> kv_cache_block_offsets,
+    std::optional<torch::Tensor> host_kv_cache_pool_pointers, std::optional<torch::Tensor> host_kv_cache_pool_mapping,
+    std::optional<torch::Tensor> kv_scale_orig_quant, std::optional<torch::Tensor> kv_scale_quant_orig,
+    std::optional<torch::Tensor> attention_output_orig_quant, std::optional<torch::Tensor> rotary_inv_freq,
+    std::optional<torch::Tensor> rotary_cos_sin, std::optional<torch::Tensor> mrope_rotary_cos_sin, int64_t layer_idx,
+    int64_t num_heads, int64_t num_kv_heads, int64_t head_size, int64_t tokens_per_block, int64_t mask_type,
+    int64_t kv_cache_quant_mode, int64_t max_attention_window_size, int64_t cyclic_attention_window_size,
+    int64_t sink_token_length, int64_t num_tokens, int64_t batch_size, int64_t input_seq_length,
+    int64_t max_past_kv_length, int64_t rotary_embedding_dim, double rotary_embedding_base,
+    int64_t rotary_embedding_scale_type, double rotary_embedding_scale, int64_t rotary_embedding_max_positions,
+    int64_t position_embedding_type, double bmm1_scale, double bmm2_scale, int64_t attention_chunk_size,
+    bool fp8_context_fmha, bool paged_context_fmha, bool is_mla_enable, int64_t total_num_blocks, int64_t kv_factor,
+    bool need_build_kv_cache_metadata);
+
+void trtllmGenContextPostprocess(torch::Tensor qkv_input, torch::Tensor workspace, torch::Tensor sequence_lengths,
+    torch::Tensor context_lengths, std::optional<torch::Tensor> kv_cache_block_offsets,
+    std::optional<torch::Tensor> host_kv_cache_pool_pointers, std::optional<torch::Tensor> host_kv_cache_pool_mapping,
+    std::optional<torch::Tensor> kv_scale_orig_quant, std::optional<torch::Tensor> kv_scale_quant_orig,
+    std::optional<torch::Tensor> attention_output_orig_quant, std::optional<torch::Tensor> rotary_cos_sin,
+    std::optional<torch::Tensor> mrope_rotary_cos_sin, int64_t layer_idx, int64_t num_heads, int64_t num_kv_heads,
+    int64_t head_size, int64_t tokens_per_block, int64_t mask_type, int64_t kv_cache_quant_mode,
+    int64_t max_attention_window_size, int64_t cyclic_attention_window_size, int64_t sink_token_length,
+    int64_t num_tokens, int64_t batch_size, int64_t input_seq_length, int64_t max_past_kv_length,
+    int64_t rotary_embedding_dim, double rotary_embedding_base, int64_t rotary_embedding_scale_type,
+    double rotary_embedding_scale, int64_t rotary_embedding_max_positions, int64_t position_embedding_type,
+    double bmm1_scale, bool fp8_context_fmha, bool paged_context_fmha, bool is_mla_enable,
+    int64_t attention_chunk_size);
+
+std::tuple<at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>, at::Tensor, std::optional<at::Tensor>,
+    int64_t, int64_t, int64_t, bool>
+trtllmGenGenerationPreprocess(torch::Tensor qkv_input, torch::Tensor workspace, torch::Tensor sequence_lengths,
+    std::optional<torch::Tensor> spec_decoding_generation_lengths,
+    std::optional<torch::Tensor> spec_decoding_position_offsets, std::optional<torch::Tensor> kv_cache_block_offsets,
+    std::optional<torch::Tensor> host_kv_cache_pool_pointers, std::optional<torch::Tensor> host_kv_cache_pool_mapping,
+    std::optional<torch::Tensor> kv_scale_orig_quant, std::optional<torch::Tensor> kv_scale_quant_orig,
+    std::optional<torch::Tensor> attention_output_orig_quant, std::optional<torch::Tensor> rotary_inv_freq,
+    std::optional<torch::Tensor> rotary_cos_sin, int64_t layer_idx, int64_t seq_offset, int64_t num_heads,
+    int64_t num_kv_heads, int64_t head_size, int64_t tokens_per_block, int64_t kv_cache_quant_mode,
+    int64_t max_attention_window_size, int64_t cyclic_attention_window_size, int64_t sink_token_length,
+    int64_t num_tokens, int64_t batch_beam, int64_t input_seq_length, int64_t max_past_kv_length,
+    int64_t rotary_embedding_dim, double rotary_embedding_base, int64_t rotary_embedding_scale_type,
+    double rotary_embedding_scale, int64_t rotary_embedding_max_positions, int64_t position_embedding_type,
+    double bmm1_scale, double bmm2_scale, bool fp8_context_fmha, int64_t predicted_tokens_per_seq,
+    int64_t attention_chunk_size, int64_t total_num_blocks, int64_t kv_factor, bool need_build_kv_cache_metadata);
+
+} // namespace torch_ext
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/thop/trtllmGenQKVProcessOp.cpp
+++ b/cpp/tensorrt_llm/thop/trtllmGenQKVProcessOp.cpp
@@ -17,6 +17,7 @@
 
 #include "tensorrt_llm/common/attentionOp.h"
 #include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/nvtxUtils.h"
 #include "tensorrt_llm/common/quantization.h"
 #include "tensorrt_llm/kernels/gptKernels.h"
 #include "tensorrt_llm/kernels/kvCacheUtils.h"
@@ -25,6 +26,7 @@
 #include "tensorrt_llm/thop/attentionOp.h"
 #include "tensorrt_llm/thop/trtllmGenFusedOps.h"
 #include <ATen/cuda/CUDAContext.h>
+#include <optional>
 #include <torch/extension.h>
 #include <type_traits>
 
@@ -72,242 +74,163 @@ T const* optPtr(OptTensorT&& t, std::enable_if_t<std::is_const_v<OptTensorT>>* =
     return t.has_value() ? static_cast<T const*>(t->data_ptr()) : nullptr;
 }
 
-} // anonymous namespace
-
-// ---------------------------------------------------------------------------
-// build_decoder_info
-// ---------------------------------------------------------------------------
-
-template <typename AttentionMaskDataType>
-bool invokeBuildDecoderInfoTyped(BuildDecoderInfoParams<AttentionMaskDataType>& params, cudaStream_t stream)
-{
-    if (!params.isBuildDecoderInfoKernelNeeded())
-    {
-        return false;
-    }
-    tensorrt_llm::kernels::invokeBuildDecoderInfo(params, stream);
-    sync_check_cuda_error(stream);
-    return true;
-}
-
-bool build_decoder_info(
-    // Tensors
-    std::optional<torch::Tensor> seq_q_offsets, std::optional<torch::Tensor> seq_kv_offsets,
-    std::optional<torch::Tensor> padding_offsets, std::optional<torch::Tensor> tokens_info,
-    std::optional<torch::Tensor> encoder_padding_offsets, std::optional<torch::Tensor> packed_mask_row_offsets,
-    std::optional<torch::Tensor> seq_cp_partial_offsets, std::optional<torch::Tensor> attention_mask,
-    std::optional<torch::Tensor> seq_q_lengths, std::optional<torch::Tensor> seq_kv_lengths,
-    std::optional<torch::Tensor> fmha_tile_counter, std::optional<torch::Tensor> dequant_scale_qkv,
-    std::optional<torch::Tensor> quant_scale_o, std::optional<torch::Tensor> fmha_bmm1_scale,
-    std::optional<torch::Tensor> fmha_bmm2_scale, std::optional<torch::Tensor> rotary_embedding_inv_freq,
-    std::optional<torch::Tensor> rotary_embedding_inv_freq_cache,
-    // Scalars
-    int64_t cp_size, bool separate_qkv_scales, double fmha_host_bmm1_scale, int64_t batch_size,
-    int64_t max_q_seq_length, int64_t max_encoder_q_seq_length, int64_t attention_window_size,
-    int64_t sink_token_length, int64_t num_tokens, bool remove_padding, int64_t attention_mask_type,
-    double rotary_embedding_scale, double rotary_embedding_base, int64_t rotary_embedding_dim,
-    int64_t rotary_scaling_type, int64_t rotary_embedding_max_positions)
+void zeroWorkspaceAsync(at::Tensor const& workspace)
 {
     auto stream = at::cuda::getCurrentCUDAStream().stream();
+    check_cuda_error(cudaMemsetAsync(workspace.data_ptr(), 0, static_cast<size_t>(workspace.nbytes()), stream));
+}
 
-    BuildDecoderInfoParams<void> p{};
-    p.seqQOffsets = optPtr<int>(seq_q_offsets);
-    p.seqKVOffsets = optPtr<int>(seq_kv_offsets);
-    p.paddingOffsets = optPtr<int>(padding_offsets);
-    p.tokensInfo = optPtr<int2>(tokens_info);
-    p.encoderPaddingOffsets = optPtr<int>(encoder_padding_offsets);
-    p.packedMaskRowOffsets = optPtr<int>(packed_mask_row_offsets);
-    p.seqCpPartialOffsets = optPtr<int>(seq_cp_partial_offsets);
-    p.seqQLengths = optPtr<int>(seq_q_lengths);
-    p.seqKVLengths = optPtr<int>(seq_kv_lengths);
-    p.cpSize = static_cast<int>(cp_size);
-    p.fmhaTileCounter = optPtr<uint32_t>(fmha_tile_counter);
-    p.dequantScaleQkv = optPtr<float>(dequant_scale_qkv);
-    p.separateQkvScales = separate_qkv_scales;
-    p.quantScaleO = optPtr<float>(quant_scale_o);
-    p.fmhaHostBmm1Scale = static_cast<float>(fmha_host_bmm1_scale);
-    p.fmhaBmm1Scale = optPtr<float>(fmha_bmm1_scale);
-    p.fmhaBmm2Scale = optPtr<float>(fmha_bmm2_scale);
-    p.batchSize = static_cast<int>(batch_size);
-    p.maxQSeqLength = static_cast<int>(max_q_seq_length);
-    p.maxEncoderQSeqLength = static_cast<int>(max_encoder_q_seq_length);
-    p.attentionWindowSize = static_cast<int>(attention_window_size);
-    p.sinkTokenLength = static_cast<int>(sink_token_length);
-    p.numTokens = static_cast<int>(num_tokens);
-    p.removePadding = remove_padding;
-    p.attentionMaskType = static_cast<AttentionMaskType>(attention_mask_type);
-    p.blockSparseParams = BlockSparseParams{};
-    p.rotaryEmbeddingScale = static_cast<float>(rotary_embedding_scale);
-    p.rotaryEmbeddingBase = static_cast<float>(rotary_embedding_base);
-    p.rotaryEmbeddingDim = static_cast<int>(rotary_embedding_dim);
-    p.rotaryScalingType = static_cast<RotaryScalingType>(rotary_scaling_type);
-    p.rotaryEmbeddingInvFreq = optPtr<float>(rotary_embedding_inv_freq);
-    p.rotaryEmbeddingInvFreqCache = optPtr<float>(rotary_embedding_inv_freq_cache);
-    p.rotaryEmbeddingCoeffCache = nullptr;
-    p.rotaryEmbeddingMaxPositions = static_cast<int>(rotary_embedding_max_positions);
-    p.attentionMask = attention_mask.has_value() ? attention_mask->data_ptr() : nullptr;
+struct WorkspaceAccessor
+{
+    uint8_t* base{};
+    int64_t sizeBytes{};
+    at::Device device;
 
-    if (attention_mask.has_value())
+    explicit WorkspaceAccessor(at::Tensor const& workspace)
+        : base(static_cast<uint8_t*>(workspace.data_ptr()))
+        , sizeBytes(static_cast<int64_t>(workspace.nbytes()))
+        , device(workspace.device())
     {
-        auto dtype = TorchUtils::dataType(attention_mask->scalar_type());
-        switch (dtype)
+    }
+
+    void* ptr(int64_t const offset, int64_t const numBytes) const
+    {
+        if (numBytes == 0)
         {
-        case nvinfer1::DataType::kFLOAT:
-            return invokeBuildDecoderInfoTyped(reinterpret_cast<BuildDecoderInfoParams<float>&>(p), stream);
-        case nvinfer1::DataType::kHALF:
-            return invokeBuildDecoderInfoTyped(reinterpret_cast<BuildDecoderInfoParams<half>&>(p), stream);
-#ifdef ENABLE_BF16
-        case nvinfer1::DataType::kBF16:
-            return invokeBuildDecoderInfoTyped(reinterpret_cast<BuildDecoderInfoParams<__nv_bfloat16>&>(p), stream);
-#endif
-#ifdef ENABLE_FP8
-        case nvinfer1::DataType::kFP8:
-            return invokeBuildDecoderInfoTyped(reinterpret_cast<BuildDecoderInfoParams<__nv_fp8_e4m3>&>(p), stream);
-#endif
-        default: TORCH_CHECK(false, "Unsupported attention mask dtype");
+            return nullptr;
         }
+
+        TORCH_CHECK(offset >= 0, "Negative workspace offset is invalid.");
+        TORCH_CHECK(numBytes >= 0, "Negative workspace slice size is invalid.");
+        TORCH_CHECK(offset + numBytes <= sizeBytes, "Workspace view exceeds bounds.");
+        return base + offset;
     }
-    else
+
+    template <typename T>
+    T* ptr(int64_t const offset, int64_t const numBytes) const
     {
-        return invokeBuildDecoderInfoTyped(reinterpret_cast<BuildDecoderInfoParams<float>&>(p), stream);
+        return static_cast<T*>(ptr(offset, numBytes));
     }
-}
 
-// ---------------------------------------------------------------------------
-// qkv_preprocessing / kv_cache_postprocessing (shared implementation)
-// ---------------------------------------------------------------------------
+    at::TensorOptions options(at::ScalarType const scalarType) const
+    {
+        return at::TensorOptions().dtype(scalarType).device(device);
+    }
 
-template <typename T, bool isPreprocessing>
-void dispatchQkvProcessing(QKVPreprocessingParams<T, KVBlockArray> params, cudaStream_t stream)
+    at::Tensor tensor(int64_t const offset, int64_t const numBytes, int64_t const itemSize,
+        at::TensorOptions const& tensorOptions) const
+    {
+        TORCH_CHECK(numBytes > 0, "Cannot create a Tensor view for an empty workspace slice.");
+        TORCH_CHECK(numBytes % itemSize == 0, "Workspace slice is not aligned to dtype size.");
+        return torch::from_blob(ptr(offset, numBytes), {numBytes / itemSize}, tensorOptions);
+    }
+
+    at::Tensor tensor(int64_t const offset, int64_t const numBytes, at::ScalarType const scalarType) const
+    {
+        auto const itemSize = static_cast<int64_t>(c10::elementSize(scalarType));
+        return tensor(offset, numBytes, itemSize, options(scalarType));
+    }
+};
+
+struct ContextWorkspaceRawPointers
 {
-    if constexpr (isPreprocessing)
-    {
-        tensorrt_llm::kernels::invokeQKVPreprocessing(params, stream);
-    }
-    else
-    {
-        tensorrt_llm::kernels::invokeKvCachePostprocessing(params, stream);
-    }
-    sync_check_cuda_error(stream);
-}
+    int* cuQSeqlensPtr{};
+    int* cuKvSeqlensPtr{};
+    int* cuMaskRowsPtr{};
+    float* rotaryInvFreqBufPtr{};
+    void* qBufPtr{};
+    int2* tokensInfoPtr{};
+    uint32_t* fmhaTileCounterPtr{};
+    float* fmhaBmm1ScalePtr{};
+    float* fmhaBmm2ScalePtr{};
+};
 
-template <bool isPreprocessing>
-void qkv_processing(
-    // Tensors
-    std::optional<torch::Tensor> qkv_input, std::optional<torch::Tensor> cross_kv_input,
-    std::optional<torch::Tensor> quantized_qkv_output, std::optional<torch::Tensor> q_output,
-    std::optional<torch::Tensor> kv_cache_block_offsets, std::optional<torch::Tensor> host_kv_cache_pool_pointers,
-    std::optional<torch::Tensor> host_kv_cache_pool_mapping, std::optional<torch::Tensor> qkv_bias,
-    std::optional<torch::Tensor> qkv_scale_quant_orig, std::optional<torch::Tensor> qkv_scale_orig_quant,
-    std::optional<torch::Tensor> o_scale_orig_quant, std::optional<torch::Tensor> fmha_bmm1_scale,
-    std::optional<torch::Tensor> fmha_bmm2_scale, std::optional<torch::Tensor> fmha_tile_counter,
-    std::optional<torch::Tensor> logn_scaling, std::optional<torch::Tensor> tokens_info,
-    std::optional<torch::Tensor> seq_lens, std::optional<torch::Tensor> cache_seq_lens,
-    std::optional<torch::Tensor> encoder_seq_lens, std::optional<torch::Tensor> cu_seq_lens,
-    std::optional<torch::Tensor> cu_kv_seq_lens, std::optional<torch::Tensor> sparse_kv_offsets,
-    std::optional<torch::Tensor> sparse_kv_indices, std::optional<torch::Tensor> rotary_embedding_inv_freq,
-    std::optional<torch::Tensor> rotary_coef_cache_buffer, std::optional<torch::Tensor> spec_decoding_position_offsets,
-    std::optional<torch::Tensor> mrope_rotary_cos_sin, std::optional<torch::Tensor> mrope_position_deltas,
-    // Scalars
-    int64_t batch_size, int64_t max_input_seq_len, int64_t max_kv_seq_len, int64_t cyclic_kv_cache_len,
-    int64_t sink_token_len, int64_t token_num, bool remove_padding, bool is_last_chunk, bool cross_attention,
-    int64_t head_num, int64_t kv_head_num, int64_t qheads_per_kv_head, int64_t size_per_head,
-    double fmha_host_bmm1_scale, int64_t rotary_embedding_dim, double rotary_embedding_base,
-    int64_t rotary_scaling_type, double rotary_embedding_scale, int64_t rotary_embedding_max_positions,
-    int64_t position_embedding_type, bool position_shift_enabled, bool separate_q_kv_output, bool quantized_fp8_output,
-    bool generation_phase, int64_t rotary_vision_start, int64_t rotary_vision_length,
-    // Extra args (for KV cache computation)
-    int64_t layer_idx, int64_t tokens_per_block, int64_t max_attention_window_size, int64_t kv_cache_quant_mode,
-    int64_t cyclic_attention_window_size, int64_t beam_width, int64_t sink_token_length, int64_t seq_offset,
-    bool is_mla_enable)
+ContextWorkspaceRawPointers makeContextWorkspaceRawPointers(
+    WorkspaceAccessor const& workspace, TrtllmGenContextWorkspaceLayout const& layout)
 {
-    auto stream = at::cuda::getCurrentCUDAStream().stream();
-
-    TORCH_CHECK(qkv_input.has_value(), "qkv_input is required");
-    auto qkvDtype = TorchUtils::dataType(qkv_input->scalar_type());
-
-    auto quantMode = tensorrt_llm::common::QuantMode(static_cast<uint32_t>(kv_cache_quant_mode));
-    auto kvArrays = buildPagedKvCacheBuffers(kv_cache_block_offsets, host_kv_cache_pool_pointers,
-        host_kv_cache_pool_mapping, quantMode, layer_idx, batch_size, tokens_per_block, kv_head_num, size_per_head,
-        cyclic_attention_window_size, max_attention_window_size, sink_token_length, beam_width, seq_offset,
-        is_mla_enable, static_cast<size_t>(qkv_input->element_size()));
-
-    QKVPreprocessingParams<void, KVBlockArray> p{};
-    p.qkv_input = qkv_input.has_value() ? qkv_input->data_ptr() : nullptr;
-    p.cross_kv_input = cross_kv_input.has_value() ? cross_kv_input->data_ptr() : nullptr;
-    p.quantized_qkv_output = optPtr<void>(quantized_qkv_output);
-    p.q_output = q_output.has_value() ? q_output->data_ptr() : nullptr;
-    p.kv_cache_buffer = kvArrays.kvCacheBuffer;
-    p.kv_cache_block_scales_buffer = kvArrays.kvScaleCacheBuffer;
-    p.qkv_bias = qkv_bias.has_value() ? static_cast<void const*>(qkv_bias->data_ptr()) : nullptr;
-    p.qkv_scale_quant_orig = optPtr<float>(qkv_scale_quant_orig);
-    p.qkv_scale_orig_quant = optPtr<float>(qkv_scale_orig_quant);
-    p.o_scale_orig_quant = optPtr<float>(o_scale_orig_quant);
-    p.fmha_bmm1_scale = optPtr<float>(fmha_bmm1_scale);
-    p.fmha_bmm2_scale = optPtr<float>(fmha_bmm2_scale);
-    p.fmha_tile_counter = optPtr<float>(fmha_tile_counter);
-    p.logn_scaling = optPtr<float>(logn_scaling);
-    p.tokens_info = optPtr<int2>(tokens_info);
-    p.seq_lens = optPtr<int>(seq_lens);
-    p.cache_seq_lens = optPtr<int>(cache_seq_lens);
-    p.encoder_seq_lens = optPtr<int>(encoder_seq_lens);
-    p.cu_seq_lens = optPtr<int>(cu_seq_lens);
-    p.cu_kv_seq_lens = optPtr<int>(cu_kv_seq_lens);
-    p.sparse_kv_offsets = optPtr<int>(sparse_kv_offsets);
-    p.sparse_kv_indices = optPtr<int>(sparse_kv_indices);
-    p.rotary_embedding_inv_freq = optPtr<float>(rotary_embedding_inv_freq);
-    p.rotary_coef_cache_buffer = optPtr<float2>(rotary_coef_cache_buffer);
-    p.spec_decoding_position_offsets = optPtr<int>(spec_decoding_position_offsets);
-    p.mrope_rotary_cos_sin = optPtr<float2>(mrope_rotary_cos_sin);
-    p.mrope_position_deltas = optPtr<int32_t>(mrope_position_deltas);
-    p.batch_size = static_cast<int>(batch_size);
-    p.max_input_seq_len = static_cast<int>(max_input_seq_len);
-    p.max_kv_seq_len = static_cast<int>(max_kv_seq_len);
-    p.cyclic_kv_cache_len = static_cast<int>(cyclic_kv_cache_len);
-    p.sink_token_len = static_cast<int>(sink_token_len);
-    p.token_num = static_cast<int>(token_num);
-    p.remove_padding = remove_padding;
-    p.is_last_chunk = is_last_chunk;
-    p.cross_attention = cross_attention;
-    p.head_num = static_cast<int>(head_num);
-    p.kv_head_num = static_cast<int>(kv_head_num);
-    p.qheads_per_kv_head = static_cast<int>(qheads_per_kv_head);
-    p.size_per_head = static_cast<int>(size_per_head);
-    p.fmha_host_bmm1_scale = static_cast<float>(fmha_host_bmm1_scale);
-    p.rotary_embedding_dim = static_cast<int>(rotary_embedding_dim);
-    p.rotary_embedding_base = static_cast<float>(rotary_embedding_base);
-    p.rotary_scale_type = static_cast<RotaryScalingType>(rotary_scaling_type);
-    p.rotary_embedding_scale = static_cast<float>(rotary_embedding_scale);
-    p.rotary_embedding_max_positions = static_cast<int>(rotary_embedding_max_positions);
-    p.position_embedding_type = static_cast<PositionEmbeddingType>(position_embedding_type);
-    p.position_shift_enabled = position_shift_enabled;
-    p.cache_type = cacheTypeFromQuantMode(quantMode);
-    p.separate_q_kv_output = separate_q_kv_output;
-    p.quantized_fp8_output = quantized_fp8_output;
-    p.generation_phase = generation_phase;
-    p.multi_processor_count = tensorrt_llm::common::getMultiProcessorCount();
-    p.rotary_vision_start = static_cast<int>(rotary_vision_start);
-    p.rotary_vision_length = static_cast<int>(rotary_vision_length);
-
-    switch (qkvDtype)
-    {
-    case nvinfer1::DataType::kFLOAT:
-        dispatchQkvProcessing<float, isPreprocessing>(
-            reinterpret_cast<QKVPreprocessingParams<float, KVBlockArray>&>(p), stream);
-        break;
-    case nvinfer1::DataType::kHALF:
-        dispatchQkvProcessing<half, isPreprocessing>(
-            reinterpret_cast<QKVPreprocessingParams<half, KVBlockArray>&>(p), stream);
-        break;
-#ifdef ENABLE_BF16
-    case nvinfer1::DataType::kBF16:
-        dispatchQkvProcessing<__nv_bfloat16, isPreprocessing>(
-            reinterpret_cast<QKVPreprocessingParams<__nv_bfloat16, KVBlockArray>&>(p), stream);
-        break;
-#endif
-    default: TORCH_CHECK(false, "Unsupported data type for QKV processing.");
-    }
+    return ContextWorkspaceRawPointers{
+        .cuQSeqlensPtr = workspace.ptr<int>(layout.cuQSeqlensOffset, layout.cuSeqlensSize),
+        .cuKvSeqlensPtr = workspace.ptr<int>(layout.cuKvSeqlensOffset, layout.cuSeqlensSize),
+        .cuMaskRowsPtr = workspace.ptr<int>(layout.cuMaskRowsOffset, layout.cuSeqlensSize),
+        .rotaryInvFreqBufPtr = workspace.ptr<float>(layout.rotaryInvFreqOffset, layout.rotaryInvFreqSize),
+        .qBufPtr = workspace.ptr(layout.qBufOffset, layout.qBufSize),
+        .tokensInfoPtr = workspace.ptr<int2>(layout.tokensInfoOffset, layout.tokensInfoSize),
+        .fmhaTileCounterPtr = workspace.ptr<uint32_t>(layout.fmhaTileCounterOffset, layout.fmhaTileCounterSize),
+        .fmhaBmm1ScalePtr = workspace.ptr<float>(layout.fmhaBmm1ScaleOffset, layout.fmhaBmm1ScaleSize),
+        .fmhaBmm2ScalePtr = workspace.ptr<float>(layout.fmhaBmm2ScaleOffset, layout.fmhaBmm2ScaleSize),
+    };
 }
+
+struct ContextWorkspaceRawViews
+{
+    at::Tensor trtllmGenWorkspace;
+    at::Tensor cuQSeqlens;
+    at::Tensor cuKvSeqlens;
+    at::Tensor qBuf;
+    ContextWorkspaceRawPointers ptrs;
+};
+
+ContextWorkspaceRawViews makeContextWorkspaceRawViews(
+    at::Tensor const& workspace, TrtllmGenContextWorkspaceLayout const& layout, bool const materializeQBufTensor)
+{
+    WorkspaceAccessor const workspaceView{workspace};
+    auto const byteOptions = workspaceView.options(at::kByte);
+    auto const intOptions = workspaceView.options(at::kInt);
+    at::Tensor qBuf;
+    if (materializeQBufTensor)
+    {
+        qBuf = workspaceView.tensor(layout.qBufOffset, layout.qBufSize, layout.qBufScalarType);
+    }
+
+    return ContextWorkspaceRawViews{
+        .trtllmGenWorkspace
+        = workspaceView.tensor(layout.trtllmGenWorkspaceOffset, layout.trtllmGenWorkspaceSize, 1, byteOptions),
+        .cuQSeqlens = workspaceView.tensor(layout.cuQSeqlensOffset, layout.cuSeqlensSize, sizeof(int32_t), intOptions),
+        .cuKvSeqlens
+        = workspaceView.tensor(layout.cuKvSeqlensOffset, layout.cuSeqlensSize, sizeof(int32_t), intOptions),
+        .qBuf = qBuf,
+        .ptrs = makeContextWorkspaceRawPointers(workspaceView, layout),
+    };
+}
+
+struct GenerationWorkspaceRawViews
+{
+    at::Tensor trtllmGenWorkspace;
+    at::Tensor qBuf;
+    int* cuSeqlensPtr{};
+    int* cuKvSeqlensPtr{};
+    float* rotaryInvFreqBufPtr{};
+    int2* tokensInfoPtr{};
+    void* qBufPtr{};
+    float* bmm1ScalePtr{};
+    float* bmm2ScalePtr{};
+    TrtllmGenGenerationWorkspaceLayout layout{};
+};
+
+GenerationWorkspaceRawViews makeGenerationWorkspaceRawViews(
+    at::Tensor const& workspace, TrtllmGenGenerationWorkspaceLayout const& layout)
+{
+    WorkspaceAccessor const workspaceView{workspace};
+    auto const byteOptions = workspaceView.options(at::kByte);
+    auto const qBufOptions = workspaceView.options(layout.qBufScalarType);
+    auto const qBufItemSize = static_cast<int64_t>(c10::elementSize(layout.qBufScalarType));
+
+    return GenerationWorkspaceRawViews{
+        .trtllmGenWorkspace
+        = workspaceView.tensor(layout.trtllmGenWorkspaceOffset, layout.trtllmGenWorkspaceSize, 1, byteOptions),
+        .qBuf = workspaceView.tensor(layout.qBufOffset, layout.qBufSize, qBufItemSize, qBufOptions),
+        .cuSeqlensPtr = workspaceView.ptr<int>(layout.cuSeqlensOffset, layout.cuSeqlensSize),
+        .cuKvSeqlensPtr = workspaceView.ptr<int>(layout.cuKvSeqlensOffset, layout.cuKvSeqlensSize),
+        .rotaryInvFreqBufPtr = workspaceView.ptr<float>(layout.rotaryInvFreqOffset, layout.rotaryInvFreqSize),
+        .tokensInfoPtr = workspaceView.ptr<int2>(layout.tokensInfoOffset, layout.tokensInfoSize),
+        .qBufPtr = workspaceView.ptr(layout.qBufOffset, layout.qBufSize),
+        .bmm1ScalePtr = workspaceView.ptr<float>(layout.bmm1ScaleOffset, layout.bmm1ScaleSize),
+        .bmm2ScalePtr = workspaceView.ptr<float>(layout.bmm2ScaleOffset, layout.bmm2ScaleSize),
+        .layout = layout,
+    };
+}
+
+} // anonymous namespace
 
 std::tuple<at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>, at::Tensor, at::Tensor, at::Tensor,
     int64_t, int64_t, int64_t>
@@ -325,63 +248,189 @@ trtllmGenContextPreprocess(torch::Tensor qkv_input, torch::Tensor workspace, tor
     int64_t const rotary_embedding_scale_type, double const rotary_embedding_scale,
     int64_t const rotary_embedding_max_positions, int64_t const position_embedding_type, double const bmm1_scale,
     double const bmm2_scale, int64_t const attention_chunk_size, bool const fp8_context_fmha,
-    bool const paged_context_fmha, bool const is_mla_enable, int64_t const total_num_blocks, int64_t const kv_factor,
-    bool const need_build_kv_cache_metadata)
+    bool const paged_context_fmha, bool const is_mla_enable, int64_t const multi_processor_count,
+    int64_t const total_num_blocks, int64_t const kv_factor, bool const need_build_kv_cache_metadata)
 {
+    NVTX3_SCOPED_RANGE_WITH_NAME(contextPreprocessRange, "trtllm_gen.cpp.context_preprocess");
     (void) bmm2_scale;
     TORCH_CHECK(host_kv_cache_pool_pointers.has_value(), "host_kv_cache_pool_pointers is required.");
     TORCH_CHECK(host_kv_cache_pool_mapping.has_value(), "host_kv_cache_pool_mapping is required.");
     TORCH_CHECK(kv_cache_block_offsets.has_value(), "kv_cache_block_offsets is required.");
 
-    auto const views = TrtllmAttentionWorkspaceManager::materializeContextWorkspace(workspace, qkv_input.scalar_type(),
-        batch_size, num_tokens, num_heads, head_size, rotary_embedding_dim, fp8_context_fmha);
+    bool const separateQKvOutput = paged_context_fmha;
+    auto const qkvScalarType = qkv_input.scalar_type();
+    auto const qkvElementSize = static_cast<size_t>(qkv_input.element_size());
+    auto const quantMode = tensorrt_llm::common::QuantMode(static_cast<uint32_t>(kv_cache_quant_mode));
+    auto const views = [&]
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(materializeWorkspaceRange, "trtllm_gen.cpp.context.materialize_workspace");
+        auto const layout = TrtllmAttentionWorkspaceManager::buildContextLayout(
+            qkvScalarType, batch_size, num_tokens, num_heads, head_size, rotary_embedding_dim, true, fp8_context_fmha);
+        return makeContextWorkspaceRawViews(workspace, layout, separateQKvOutput);
+    }();
+    auto const& ptrs = views.ptrs;
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
 
-    (void) build_decoder_info(views.cuQSeqlens, views.cuKvSeqlens, std::nullopt, views.tokensInfo, std::nullopt,
-        views.cuMaskRows, std::nullopt, std::nullopt, context_lengths, sequence_lengths, views.fmhaTileCounter,
-        kv_scale_quant_orig, attention_output_orig_quant, views.fmhaBmm1Scale, views.fmhaBmm2Scale,
-        views.rotaryInvFreqBuf, rotary_inv_freq, 1,
-        tensorrt_llm::common::QuantMode(static_cast<uint32_t>(kv_cache_quant_mode)).hasFp4KvCache(), bmm1_scale,
-        batch_size, input_seq_length, 0, cyclic_attention_window_size, sink_token_length, num_tokens, true, mask_type,
-        rotary_embedding_scale, rotary_embedding_base, rotary_embedding_dim, rotary_embedding_scale_type,
-        rotary_embedding_max_positions);
+    BuildDecoderInfoParams<float> decoderInfoParams{};
+    decoderInfoParams.seqQOffsets = ptrs.cuQSeqlensPtr;
+    decoderInfoParams.seqKVOffsets = ptrs.cuKvSeqlensPtr;
+    decoderInfoParams.paddingOffsets = nullptr;
+    decoderInfoParams.tokensInfo = ptrs.tokensInfoPtr;
+    decoderInfoParams.encoderPaddingOffsets = nullptr;
+    decoderInfoParams.packedMaskRowOffsets = ptrs.cuMaskRowsPtr;
+    decoderInfoParams.seqCpPartialOffsets = nullptr;
+    decoderInfoParams.attentionMask = nullptr;
+    decoderInfoParams.seqQLengths = static_cast<int*>(context_lengths.data_ptr());
+    decoderInfoParams.seqKVLengths = static_cast<int*>(sequence_lengths.data_ptr());
+    decoderInfoParams.cpSize = 1;
+    decoderInfoParams.fmhaTileCounter = ptrs.fmhaTileCounterPtr;
+    decoderInfoParams.dequantScaleQkv = optPtr<float>(kv_scale_quant_orig);
+    decoderInfoParams.separateQkvScales = quantMode.hasFp4KvCache();
+    decoderInfoParams.quantScaleO = optPtr<float>(attention_output_orig_quant);
+    decoderInfoParams.fmhaHostBmm1Scale = static_cast<float>(bmm1_scale);
+    decoderInfoParams.fmhaBmm1Scale = ptrs.fmhaBmm1ScalePtr;
+    decoderInfoParams.fmhaBmm2Scale = ptrs.fmhaBmm2ScalePtr;
+    decoderInfoParams.batchSize = static_cast<int>(batch_size);
+    decoderInfoParams.maxQSeqLength = static_cast<int>(input_seq_length);
+    decoderInfoParams.maxEncoderQSeqLength = 0;
+    decoderInfoParams.attentionWindowSize = static_cast<int>(cyclic_attention_window_size);
+    decoderInfoParams.sinkTokenLength = static_cast<int>(sink_token_length);
+    decoderInfoParams.numTokens = static_cast<int>(num_tokens);
+    decoderInfoParams.removePadding = true;
+    decoderInfoParams.attentionMaskType = static_cast<AttentionMaskType>(mask_type);
+    decoderInfoParams.blockSparseParams = BlockSparseParams{};
+    decoderInfoParams.rotaryEmbeddingScale = static_cast<float>(rotary_embedding_scale);
+    decoderInfoParams.rotaryEmbeddingBase = static_cast<float>(rotary_embedding_base);
+    decoderInfoParams.rotaryEmbeddingDim = static_cast<int>(rotary_embedding_dim);
+    decoderInfoParams.rotaryScalingType = static_cast<RotaryScalingType>(rotary_embedding_scale_type);
+    decoderInfoParams.rotaryEmbeddingInvFreq = ptrs.rotaryInvFreqBufPtr;
+    decoderInfoParams.rotaryEmbeddingInvFreqCache = optPtr<float>(rotary_inv_freq);
+    decoderInfoParams.rotaryEmbeddingCoeffCache = nullptr;
+    decoderInfoParams.rotaryEmbeddingMaxPositions = static_cast<int>(rotary_embedding_max_positions);
+    if (decoderInfoParams.isBuildDecoderInfoKernelNeeded())
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(buildDecoderInfoRange, "trtllm_gen.cpp.build_decoder_info");
+        tensorrt_llm::kernels::invokeBuildDecoderInfo(decoderInfoParams, stream);
+        sync_check_cuda_error(stream);
+    }
 
-    qkv_processing<true>(qkv_input, std::nullopt, std::nullopt, views.qBuf, kv_cache_block_offsets,
-        host_kv_cache_pool_pointers, host_kv_cache_pool_mapping, std::nullopt, kv_scale_quant_orig, kv_scale_orig_quant,
-        attention_output_orig_quant, views.fmhaBmm1Scale, views.fmhaBmm2Scale, views.fmhaTileCounter, std::nullopt,
-        views.tokensInfo, context_lengths, sequence_lengths, std::nullopt, views.cuQSeqlens, views.cuKvSeqlens,
-        std::nullopt, std::nullopt, views.rotaryInvFreqBuf, rotary_cos_sin, std::nullopt, mrope_rotary_cos_sin,
-        std::nullopt, batch_size, input_seq_length, max_past_kv_length, cyclic_attention_window_size, sink_token_length,
-        num_tokens, true, attention_chunk_size == 0 || input_seq_length == max_past_kv_length, false, num_heads,
-        num_kv_heads, num_heads / num_kv_heads, head_size, bmm1_scale, rotary_embedding_dim, rotary_embedding_base,
-        rotary_embedding_scale_type, rotary_embedding_scale, rotary_embedding_max_positions, position_embedding_type,
-        false, paged_context_fmha, fp8_context_fmha, false, 0, 0, layer_idx, tokens_per_block,
-        max_attention_window_size, kv_cache_quant_mode, cyclic_attention_window_size, 0, sink_token_length, 0,
-        is_mla_enable);
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(qkvProcessingRange, "trtllm_gen.cpp.qkv_preprocess");
+        auto const qkvDtype = TorchUtils::dataType(qkvScalarType);
+        auto const kvArrays = [&]
+        {
+            NVTX3_SCOPED_RANGE_WITH_NAME(kvCacheBuffersRange, "trtllm_gen.cpp.qkv_processing.kv_cache_buffers");
+            return buildPagedKvCacheBuffers(kv_cache_block_offsets, host_kv_cache_pool_pointers,
+                host_kv_cache_pool_mapping, quantMode, layer_idx, batch_size, tokens_per_block, num_kv_heads, head_size,
+                cyclic_attention_window_size, max_attention_window_size, sink_token_length, 0, 0, is_mla_enable,
+                qkvElementSize);
+        }();
+
+        QKVPreprocessingParams<void, KVBlockArray> qkvParams{};
+        qkvParams.qkv_input = qkv_input.data_ptr();
+        qkvParams.cross_kv_input = nullptr;
+        qkvParams.quantized_qkv_output = nullptr;
+        qkvParams.q_output = ptrs.qBufPtr;
+        qkvParams.kv_cache_buffer = kvArrays.kvCacheBuffer;
+        qkvParams.kv_cache_block_scales_buffer = kvArrays.kvScaleCacheBuffer;
+        qkvParams.qkv_bias = nullptr;
+        qkvParams.qkv_scale_quant_orig = optPtr<float>(kv_scale_quant_orig);
+        qkvParams.qkv_scale_orig_quant = optPtr<float>(kv_scale_orig_quant);
+        qkvParams.o_scale_orig_quant = optPtr<float>(attention_output_orig_quant);
+        qkvParams.fmha_bmm1_scale = ptrs.fmhaBmm1ScalePtr;
+        qkvParams.fmha_bmm2_scale = ptrs.fmhaBmm2ScalePtr;
+        qkvParams.fmha_tile_counter = reinterpret_cast<float*>(ptrs.fmhaTileCounterPtr);
+        qkvParams.logn_scaling = nullptr;
+        qkvParams.tokens_info = ptrs.tokensInfoPtr;
+        qkvParams.seq_lens = static_cast<int*>(context_lengths.data_ptr());
+        qkvParams.cache_seq_lens = static_cast<int*>(sequence_lengths.data_ptr());
+        qkvParams.encoder_seq_lens = nullptr;
+        qkvParams.cu_seq_lens = ptrs.cuQSeqlensPtr;
+        qkvParams.cu_kv_seq_lens = ptrs.cuKvSeqlensPtr;
+        qkvParams.sparse_kv_offsets = nullptr;
+        qkvParams.sparse_kv_indices = nullptr;
+        qkvParams.rotary_embedding_inv_freq = ptrs.rotaryInvFreqBufPtr;
+        qkvParams.rotary_coef_cache_buffer = optPtr<float2>(rotary_cos_sin);
+        qkvParams.spec_decoding_position_offsets = nullptr;
+        qkvParams.mrope_rotary_cos_sin = optPtr<float2>(mrope_rotary_cos_sin);
+        qkvParams.mrope_position_deltas = nullptr;
+        qkvParams.batch_size = static_cast<int>(batch_size);
+        qkvParams.max_input_seq_len = static_cast<int>(input_seq_length);
+        qkvParams.max_kv_seq_len = static_cast<int>(max_past_kv_length);
+        qkvParams.cyclic_kv_cache_len = static_cast<int>(cyclic_attention_window_size);
+        qkvParams.sink_token_len = static_cast<int>(sink_token_length);
+        qkvParams.token_num = static_cast<int>(num_tokens);
+        qkvParams.remove_padding = true;
+        qkvParams.is_last_chunk = attention_chunk_size == 0 || input_seq_length == max_past_kv_length;
+        qkvParams.cross_attention = false;
+        qkvParams.head_num = static_cast<int>(num_heads);
+        qkvParams.kv_head_num = static_cast<int>(num_kv_heads);
+        qkvParams.qheads_per_kv_head = static_cast<int>(num_heads / num_kv_heads);
+        qkvParams.size_per_head = static_cast<int>(head_size);
+        qkvParams.fmha_host_bmm1_scale = static_cast<float>(bmm1_scale);
+        qkvParams.rotary_embedding_dim = static_cast<int>(rotary_embedding_dim);
+        qkvParams.rotary_embedding_base = static_cast<float>(rotary_embedding_base);
+        qkvParams.rotary_scale_type = static_cast<RotaryScalingType>(rotary_embedding_scale_type);
+        qkvParams.rotary_embedding_scale = static_cast<float>(rotary_embedding_scale);
+        qkvParams.rotary_embedding_max_positions = static_cast<int>(rotary_embedding_max_positions);
+        qkvParams.position_embedding_type = static_cast<PositionEmbeddingType>(position_embedding_type);
+        qkvParams.position_shift_enabled = false;
+        qkvParams.cache_type = cacheTypeFromQuantMode(quantMode);
+        qkvParams.separate_q_kv_output = paged_context_fmha;
+        qkvParams.quantized_fp8_output = fp8_context_fmha;
+        qkvParams.generation_phase = false;
+        qkvParams.multi_processor_count = static_cast<int>(multi_processor_count);
+        qkvParams.rotary_vision_start = 0;
+        qkvParams.rotary_vision_length = 0;
+
+        switch (qkvDtype)
+        {
+        case nvinfer1::DataType::kFLOAT:
+            tensorrt_llm::kernels::invokeQKVPreprocessing(
+                reinterpret_cast<QKVPreprocessingParams<float, KVBlockArray>&>(qkvParams), stream);
+            break;
+        case nvinfer1::DataType::kHALF:
+            tensorrt_llm::kernels::invokeQKVPreprocessing(
+                reinterpret_cast<QKVPreprocessingParams<half, KVBlockArray>&>(qkvParams), stream);
+            break;
+#ifdef ENABLE_BF16
+        case nvinfer1::DataType::kBF16:
+            tensorrt_llm::kernels::invokeQKVPreprocessing(
+                reinterpret_cast<QKVPreprocessingParams<__nv_bfloat16, KVBlockArray>&>(qkvParams), stream);
+            break;
+#endif
+        default: TORCH_CHECK(false, "Unsupported data type for QKV preprocessing.");
+        }
+        sync_check_cuda_error(stream);
+    }
 
     std::optional<at::Tensor> kvPool;
     std::optional<at::Tensor> blockTables;
     if (need_build_kv_cache_metadata)
     {
+        NVTX3_SCOPED_RANGE_WITH_NAME(kvMetadataRange, "trtllm_gen.cpp.context.kv_metadata");
         kvPool = buildFlashinferTrtllmGenPagedKvCacheBuffers(host_kv_cache_pool_pointers.value(),
             host_kv_cache_pool_mapping.value(), layer_idx, num_kv_heads, tokens_per_block, head_size, kv_factor,
-            total_num_blocks, kv_cache_quant_mode, qkv_input.scalar_type());
+            total_num_blocks, kv_cache_quant_mode, qkvScalarType);
 
-        int32_t const poolIndex = host_kv_cache_pool_mapping.value().index({layer_idx, 0}).item<int32_t>();
-        blockTables = kv_cache_block_offsets.value().index({poolIndex}).slice(0, 0, batch_size);
+        int32_t const poolIndex = readKvCachePoolMapping(host_kv_cache_pool_mapping.value(), layer_idx).poolIndex;
+        blockTables = kv_cache_block_offsets.value().select(0, poolIndex).narrow(0, 0, batch_size);
     }
 
     at::Tensor qProcessed;
-    bool const separateQKvOutput = paged_context_fmha;
     if (separateQKvOutput)
     {
-        qProcessed = views.qBuf.value().view({num_tokens, num_heads, head_size});
+        qProcessed = views.qBuf.view({num_tokens, num_heads, head_size});
     }
     else
     {
         qProcessed = qkv_input.slice(1, 0, num_heads * head_size).view({num_tokens, num_heads, head_size});
     }
 
-    views.trtllmGenWorkspace.zero_();
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(zeroWorkspaceRange, "trtllm_gen.cpp.context.zero_workspace");
+        zeroWorkspaceAsync(views.trtllmGenWorkspace);
+    }
 
     auto const windowLeft = computeWindowLeft(cyclic_attention_window_size, max_past_kv_length, attention_chunk_size);
     return {qProcessed, kvPool, blockTables, views.trtllmGenWorkspace, views.cuQSeqlens, views.cuKvSeqlens,
@@ -401,24 +450,113 @@ void trtllmGenContextPostprocess(torch::Tensor qkv_input, torch::Tensor workspac
     int64_t const rotary_embedding_dim, double const rotary_embedding_base, int64_t const rotary_embedding_scale_type,
     double const rotary_embedding_scale, int64_t const rotary_embedding_max_positions,
     int64_t const position_embedding_type, double const bmm1_scale, bool const fp8_context_fmha,
-    bool const paged_context_fmha, bool const is_mla_enable, int64_t const attention_chunk_size)
+    bool const paged_context_fmha, bool const is_mla_enable, int64_t const attention_chunk_size,
+    int64_t const multi_processor_count)
 {
+    NVTX3_SCOPED_RANGE_WITH_NAME(contextPostprocessRange, "trtllm_gen.cpp.context_postprocess");
     (void) mask_type;
-    auto const views = TrtllmAttentionWorkspaceManager::materializeContextWorkspace(workspace, qkv_input.scalar_type(),
-        batch_size, num_tokens, num_heads, head_size, rotary_embedding_dim, fp8_context_fmha);
+    auto const qkvScalarType = qkv_input.scalar_type();
+    auto const qkvElementSize = static_cast<size_t>(qkv_input.element_size());
+    auto const quantMode = tensorrt_llm::common::QuantMode(static_cast<uint32_t>(kv_cache_quant_mode));
+    auto const ptrs = [&]
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(materializeWorkspaceRange, "trtllm_gen.cpp.context_post.materialize_workspace");
+        auto const layout = TrtllmAttentionWorkspaceManager::buildContextLayout(
+            qkvScalarType, batch_size, num_tokens, num_heads, head_size, rotary_embedding_dim, true, fp8_context_fmha);
+        WorkspaceAccessor const workspaceView{workspace};
+        return makeContextWorkspaceRawPointers(workspaceView, layout);
+    }();
 
-    qkv_processing<false>(qkv_input, std::nullopt, std::nullopt, views.qBuf, kv_cache_block_offsets,
-        host_kv_cache_pool_pointers, host_kv_cache_pool_mapping, std::nullopt, kv_scale_quant_orig, kv_scale_orig_quant,
-        attention_output_orig_quant, views.fmhaBmm1Scale, views.fmhaBmm2Scale, views.fmhaTileCounter, std::nullopt,
-        views.tokensInfo, context_lengths, sequence_lengths, std::nullopt, views.cuQSeqlens, views.cuKvSeqlens,
-        std::nullopt, std::nullopt, views.rotaryInvFreqBuf, rotary_cos_sin, std::nullopt, mrope_rotary_cos_sin,
-        std::nullopt, batch_size, input_seq_length, max_past_kv_length, cyclic_attention_window_size, sink_token_length,
-        num_tokens, true, attention_chunk_size == 0 || input_seq_length == max_past_kv_length, false, num_heads,
-        num_kv_heads, num_heads / num_kv_heads, head_size, bmm1_scale, rotary_embedding_dim, rotary_embedding_base,
-        rotary_embedding_scale_type, rotary_embedding_scale, rotary_embedding_max_positions, position_embedding_type,
-        false, paged_context_fmha, fp8_context_fmha, false, 0, 0, layer_idx, tokens_per_block,
-        max_attention_window_size, kv_cache_quant_mode, cyclic_attention_window_size, 0, sink_token_length, 0,
-        is_mla_enable);
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(qkvProcessingRange, "trtllm_gen.cpp.kv_cache_postprocess");
+        auto stream = at::cuda::getCurrentCUDAStream().stream();
+        auto const qkvDtype = TorchUtils::dataType(qkvScalarType);
+        auto const kvArrays = [&]
+        {
+            NVTX3_SCOPED_RANGE_WITH_NAME(kvCacheBuffersRange, "trtllm_gen.cpp.qkv_processing.kv_cache_buffers");
+            return buildPagedKvCacheBuffers(kv_cache_block_offsets, host_kv_cache_pool_pointers,
+                host_kv_cache_pool_mapping, quantMode, layer_idx, batch_size, tokens_per_block, num_kv_heads, head_size,
+                cyclic_attention_window_size, max_attention_window_size, sink_token_length, 0, 0, is_mla_enable,
+                qkvElementSize);
+        }();
+
+        QKVPreprocessingParams<void, KVBlockArray> qkvParams{};
+        qkvParams.qkv_input = qkv_input.data_ptr();
+        qkvParams.cross_kv_input = nullptr;
+        qkvParams.quantized_qkv_output = nullptr;
+        qkvParams.q_output = ptrs.qBufPtr;
+        qkvParams.kv_cache_buffer = kvArrays.kvCacheBuffer;
+        qkvParams.kv_cache_block_scales_buffer = kvArrays.kvScaleCacheBuffer;
+        qkvParams.qkv_bias = nullptr;
+        qkvParams.qkv_scale_quant_orig = optPtr<float>(kv_scale_quant_orig);
+        qkvParams.qkv_scale_orig_quant = optPtr<float>(kv_scale_orig_quant);
+        qkvParams.o_scale_orig_quant = optPtr<float>(attention_output_orig_quant);
+        qkvParams.fmha_bmm1_scale = ptrs.fmhaBmm1ScalePtr;
+        qkvParams.fmha_bmm2_scale = ptrs.fmhaBmm2ScalePtr;
+        qkvParams.fmha_tile_counter = reinterpret_cast<float*>(ptrs.fmhaTileCounterPtr);
+        qkvParams.logn_scaling = nullptr;
+        qkvParams.tokens_info = ptrs.tokensInfoPtr;
+        qkvParams.seq_lens = static_cast<int*>(context_lengths.data_ptr());
+        qkvParams.cache_seq_lens = static_cast<int*>(sequence_lengths.data_ptr());
+        qkvParams.encoder_seq_lens = nullptr;
+        qkvParams.cu_seq_lens = ptrs.cuQSeqlensPtr;
+        qkvParams.cu_kv_seq_lens = ptrs.cuKvSeqlensPtr;
+        qkvParams.sparse_kv_offsets = nullptr;
+        qkvParams.sparse_kv_indices = nullptr;
+        qkvParams.rotary_embedding_inv_freq = ptrs.rotaryInvFreqBufPtr;
+        qkvParams.rotary_coef_cache_buffer = optPtr<float2>(rotary_cos_sin);
+        qkvParams.spec_decoding_position_offsets = nullptr;
+        qkvParams.mrope_rotary_cos_sin = optPtr<float2>(mrope_rotary_cos_sin);
+        qkvParams.mrope_position_deltas = nullptr;
+        qkvParams.batch_size = static_cast<int>(batch_size);
+        qkvParams.max_input_seq_len = static_cast<int>(input_seq_length);
+        qkvParams.max_kv_seq_len = static_cast<int>(max_past_kv_length);
+        qkvParams.cyclic_kv_cache_len = static_cast<int>(cyclic_attention_window_size);
+        qkvParams.sink_token_len = static_cast<int>(sink_token_length);
+        qkvParams.token_num = static_cast<int>(num_tokens);
+        qkvParams.remove_padding = true;
+        qkvParams.is_last_chunk = attention_chunk_size == 0 || input_seq_length == max_past_kv_length;
+        qkvParams.cross_attention = false;
+        qkvParams.head_num = static_cast<int>(num_heads);
+        qkvParams.kv_head_num = static_cast<int>(num_kv_heads);
+        qkvParams.qheads_per_kv_head = static_cast<int>(num_heads / num_kv_heads);
+        qkvParams.size_per_head = static_cast<int>(head_size);
+        qkvParams.fmha_host_bmm1_scale = static_cast<float>(bmm1_scale);
+        qkvParams.rotary_embedding_dim = static_cast<int>(rotary_embedding_dim);
+        qkvParams.rotary_embedding_base = static_cast<float>(rotary_embedding_base);
+        qkvParams.rotary_scale_type = static_cast<RotaryScalingType>(rotary_embedding_scale_type);
+        qkvParams.rotary_embedding_scale = static_cast<float>(rotary_embedding_scale);
+        qkvParams.rotary_embedding_max_positions = static_cast<int>(rotary_embedding_max_positions);
+        qkvParams.position_embedding_type = static_cast<PositionEmbeddingType>(position_embedding_type);
+        qkvParams.position_shift_enabled = false;
+        qkvParams.cache_type = cacheTypeFromQuantMode(quantMode);
+        qkvParams.separate_q_kv_output = paged_context_fmha;
+        qkvParams.quantized_fp8_output = fp8_context_fmha;
+        qkvParams.generation_phase = false;
+        qkvParams.multi_processor_count = static_cast<int>(multi_processor_count);
+        qkvParams.rotary_vision_start = 0;
+        qkvParams.rotary_vision_length = 0;
+
+        switch (qkvDtype)
+        {
+        case nvinfer1::DataType::kFLOAT:
+            tensorrt_llm::kernels::invokeKvCachePostprocessing(
+                reinterpret_cast<QKVPreprocessingParams<float, KVBlockArray>&>(qkvParams), stream);
+            break;
+        case nvinfer1::DataType::kHALF:
+            tensorrt_llm::kernels::invokeKvCachePostprocessing(
+                reinterpret_cast<QKVPreprocessingParams<half, KVBlockArray>&>(qkvParams), stream);
+            break;
+#ifdef ENABLE_BF16
+        case nvinfer1::DataType::kBF16:
+            tensorrt_llm::kernels::invokeKvCachePostprocessing(
+                reinterpret_cast<QKVPreprocessingParams<__nv_bfloat16, KVBlockArray>&>(qkvParams), stream);
+            break;
+#endif
+        default: TORCH_CHECK(false, "Unsupported data type for KV cache postprocessing.");
+        }
+        sync_check_cuda_error(stream);
+    }
 }
 
 std::tuple<at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>, at::Tensor, std::optional<at::Tensor>,
@@ -438,56 +576,191 @@ trtllmGenGenerationPreprocess(torch::Tensor qkv_input, torch::Tensor workspace, 
     double const rotary_embedding_scale, int64_t const rotary_embedding_max_positions,
     int64_t const position_embedding_type, double const bmm1_scale, double const bmm2_scale,
     bool const fp8_context_fmha, int64_t const predicted_tokens_per_seq, int64_t const attention_chunk_size,
-    int64_t const total_num_blocks, int64_t const kv_factor, bool const need_build_kv_cache_metadata)
+    int64_t const multi_processor_count, int64_t const total_num_blocks, int64_t const kv_factor,
+    bool const need_build_kv_cache_metadata)
 {
+    NVTX3_SCOPED_RANGE_WITH_NAME(generationPreprocessRange, "trtllm_gen.cpp.generation_preprocess");
     TORCH_CHECK(host_kv_cache_pool_pointers.has_value(), "host_kv_cache_pool_pointers is required.");
     TORCH_CHECK(host_kv_cache_pool_mapping.has_value(), "host_kv_cache_pool_mapping is required.");
     TORCH_CHECK(kv_cache_block_offsets.has_value(), "kv_cache_block_offsets is required.");
     (void) bmm2_scale;
 
     bool const isMultiTokenGen = spec_decoding_generation_lengths.has_value() && predicted_tokens_per_seq > 1;
-    auto const views = TrtllmAttentionWorkspaceManager::materializeGenerationWorkspace(workspace,
-        qkv_input.scalar_type(), batch_beam, num_tokens, num_heads, head_size, rotary_embedding_dim, num_kv_heads);
+    auto const qkvScalarType = qkv_input.scalar_type();
+    auto const qkvElementSize = static_cast<size_t>(qkv_input.element_size());
+    auto const quantMode = tensorrt_llm::common::QuantMode(static_cast<uint32_t>(kv_cache_quant_mode));
+    auto const views = [&]
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(materializeWorkspaceRange, "trtllm_gen.cpp.generation.materialize_workspace");
+        auto const layout = TrtllmAttentionWorkspaceManager::buildGenerationLayout(
+            qkvScalarType, batch_beam, num_tokens, num_heads, head_size, rotary_embedding_dim, num_kv_heads, 0, false);
+        return makeGenerationWorkspaceRawViews(workspace, layout);
+    }();
 
-    auto const buildDecoderInfoNeeded = build_decoder_info(views.cuSeqlens, views.cuKvSeqlens, std::nullopt,
-        views.tokensInfo, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
-        isMultiTokenGen ? spec_decoding_generation_lengths : std::nullopt, sequence_lengths, std::nullopt, std::nullopt,
-        std::nullopt, std::nullopt, std::nullopt, views.rotaryInvFreqBuf, rotary_inv_freq, 1,
-        tensorrt_llm::common::QuantMode(static_cast<uint32_t>(kv_cache_quant_mode)).hasFp4KvCache(), bmm1_scale,
-        batch_beam, input_seq_length, 0, 0, 0, num_tokens, true, 0, rotary_embedding_scale, rotary_embedding_base,
-        rotary_embedding_dim, rotary_embedding_scale_type, rotary_embedding_max_positions);
+    auto stream = at::cuda::getCurrentCUDAStream().stream();
+    BuildDecoderInfoParams<float> decoderInfoParams{};
+    decoderInfoParams.seqQOffsets = views.cuSeqlensPtr;
+    decoderInfoParams.seqKVOffsets = views.cuKvSeqlensPtr;
+    decoderInfoParams.paddingOffsets = nullptr;
+    decoderInfoParams.tokensInfo = views.tokensInfoPtr;
+    decoderInfoParams.encoderPaddingOffsets = nullptr;
+    decoderInfoParams.packedMaskRowOffsets = nullptr;
+    decoderInfoParams.seqCpPartialOffsets = nullptr;
+    decoderInfoParams.attentionMask = nullptr;
+    decoderInfoParams.seqQLengths = isMultiTokenGen ? optPtr<int>(spec_decoding_generation_lengths) : nullptr;
+    decoderInfoParams.seqKVLengths = static_cast<int*>(sequence_lengths.data_ptr());
+    decoderInfoParams.cpSize = 1;
+    decoderInfoParams.fmhaTileCounter = nullptr;
+    decoderInfoParams.dequantScaleQkv = nullptr;
+    decoderInfoParams.separateQkvScales = quantMode.hasFp4KvCache();
+    decoderInfoParams.quantScaleO = nullptr;
+    decoderInfoParams.fmhaHostBmm1Scale = static_cast<float>(bmm1_scale);
+    decoderInfoParams.fmhaBmm1Scale = nullptr;
+    decoderInfoParams.fmhaBmm2Scale = nullptr;
+    decoderInfoParams.batchSize = static_cast<int>(batch_beam);
+    decoderInfoParams.maxQSeqLength = static_cast<int>(input_seq_length);
+    decoderInfoParams.maxEncoderQSeqLength = 0;
+    decoderInfoParams.attentionWindowSize = 0;
+    decoderInfoParams.sinkTokenLength = 0;
+    decoderInfoParams.numTokens = static_cast<int>(num_tokens);
+    decoderInfoParams.removePadding = true;
+    decoderInfoParams.attentionMaskType = static_cast<AttentionMaskType>(0);
+    decoderInfoParams.blockSparseParams = BlockSparseParams{};
+    decoderInfoParams.rotaryEmbeddingScale = static_cast<float>(rotary_embedding_scale);
+    decoderInfoParams.rotaryEmbeddingBase = static_cast<float>(rotary_embedding_base);
+    decoderInfoParams.rotaryEmbeddingDim = static_cast<int>(rotary_embedding_dim);
+    decoderInfoParams.rotaryScalingType = static_cast<RotaryScalingType>(rotary_embedding_scale_type);
+    decoderInfoParams.rotaryEmbeddingInvFreq = views.rotaryInvFreqBufPtr;
+    decoderInfoParams.rotaryEmbeddingInvFreqCache = optPtr<float>(rotary_inv_freq);
+    decoderInfoParams.rotaryEmbeddingCoeffCache = nullptr;
+    decoderInfoParams.rotaryEmbeddingMaxPositions = static_cast<int>(rotary_embedding_max_positions);
+    bool const buildDecoderInfoNeeded = decoderInfoParams.isBuildDecoderInfoKernelNeeded();
+    if (buildDecoderInfoNeeded)
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(buildDecoderInfoRange, "trtllm_gen.cpp.build_decoder_info");
+        tensorrt_llm::kernels::invokeBuildDecoderInfo(decoderInfoParams, stream);
+        sync_check_cuda_error(stream);
+    }
 
-    auto rotaryInvFreqBuf = buildDecoderInfoNeeded ? views.rotaryInvFreqBuf : rotary_inv_freq;
-    std::optional<at::Tensor> cuSeqlens = buildDecoderInfoNeeded ? std::make_optional(views.cuSeqlens) : std::nullopt;
+    auto* rotaryInvFreqBuf = buildDecoderInfoNeeded ? views.rotaryInvFreqBufPtr : optPtr<float>(rotary_inv_freq);
+    std::optional<at::Tensor> cuSeqlens;
+    if (buildDecoderInfoNeeded)
+    {
+        WorkspaceAccessor const workspaceView{workspace};
+        auto const intOptions = workspaceView.options(at::kInt);
+        cuSeqlens = workspaceView.tensor(
+            views.layout.cuSeqlensOffset, views.layout.cuSeqlensSize, sizeof(int32_t), intOptions);
+    }
 
-    qkv_processing<true>(qkv_input, std::nullopt, std::nullopt, views.qBuf, kv_cache_block_offsets,
-        host_kv_cache_pool_pointers, host_kv_cache_pool_mapping, std::nullopt, kv_scale_quant_orig, kv_scale_orig_quant,
-        attention_output_orig_quant, views.bmm1Scale, views.bmm2Scale, std::nullopt, std::nullopt,
-        isMultiTokenGen ? std::make_optional(views.tokensInfo) : std::nullopt,
-        isMultiTokenGen ? spec_decoding_generation_lengths : std::nullopt, sequence_lengths, std::nullopt, cuSeqlens,
-        buildDecoderInfoNeeded ? std::make_optional(views.cuKvSeqlens) : std::nullopt, std::nullopt, std::nullopt,
-        rotaryInvFreqBuf, rotary_cos_sin, isMultiTokenGen ? spec_decoding_position_offsets : std::nullopt, std::nullopt,
-        std::nullopt, batch_beam, input_seq_length, max_past_kv_length, cyclic_attention_window_size, sink_token_length,
-        num_tokens, true, false, false, num_heads, num_kv_heads, num_heads / num_kv_heads, head_size, bmm1_scale,
-        rotary_embedding_dim, rotary_embedding_base, rotary_embedding_scale_type, rotary_embedding_scale,
-        rotary_embedding_max_positions, position_embedding_type, false, true, fp8_context_fmha, true, 0, 0, layer_idx,
-        tokens_per_block, max_attention_window_size, kv_cache_quant_mode, cyclic_attention_window_size, 1,
-        sink_token_length, seq_offset, false);
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(qkvProcessingRange, "trtllm_gen.cpp.qkv_preprocess");
+        auto const qkvDtype = TorchUtils::dataType(qkvScalarType);
+        auto const kvArrays = [&]
+        {
+            NVTX3_SCOPED_RANGE_WITH_NAME(kvCacheBuffersRange, "trtllm_gen.cpp.qkv_processing.kv_cache_buffers");
+            return buildPagedKvCacheBuffers(kv_cache_block_offsets, host_kv_cache_pool_pointers,
+                host_kv_cache_pool_mapping, quantMode, layer_idx, batch_beam, tokens_per_block, num_kv_heads, head_size,
+                cyclic_attention_window_size, max_attention_window_size, sink_token_length, 1, seq_offset, false,
+                qkvElementSize);
+        }();
+
+        QKVPreprocessingParams<void, KVBlockArray> qkvParams{};
+        qkvParams.qkv_input = qkv_input.data_ptr();
+        qkvParams.cross_kv_input = nullptr;
+        qkvParams.quantized_qkv_output = nullptr;
+        qkvParams.q_output = views.qBufPtr;
+        qkvParams.kv_cache_buffer = kvArrays.kvCacheBuffer;
+        qkvParams.kv_cache_block_scales_buffer = kvArrays.kvScaleCacheBuffer;
+        qkvParams.qkv_bias = nullptr;
+        qkvParams.qkv_scale_quant_orig = optPtr<float>(kv_scale_quant_orig);
+        qkvParams.qkv_scale_orig_quant = optPtr<float>(kv_scale_orig_quant);
+        qkvParams.o_scale_orig_quant = optPtr<float>(attention_output_orig_quant);
+        qkvParams.fmha_bmm1_scale = views.bmm1ScalePtr;
+        qkvParams.fmha_bmm2_scale = views.bmm2ScalePtr;
+        qkvParams.fmha_tile_counter = nullptr;
+        qkvParams.logn_scaling = nullptr;
+        qkvParams.tokens_info = isMultiTokenGen ? views.tokensInfoPtr : nullptr;
+        qkvParams.seq_lens = isMultiTokenGen ? optPtr<int>(spec_decoding_generation_lengths) : nullptr;
+        qkvParams.cache_seq_lens = static_cast<int*>(sequence_lengths.data_ptr());
+        qkvParams.encoder_seq_lens = nullptr;
+        qkvParams.cu_seq_lens = buildDecoderInfoNeeded ? views.cuSeqlensPtr : nullptr;
+        qkvParams.cu_kv_seq_lens = buildDecoderInfoNeeded ? views.cuKvSeqlensPtr : nullptr;
+        qkvParams.sparse_kv_offsets = nullptr;
+        qkvParams.sparse_kv_indices = nullptr;
+        qkvParams.rotary_embedding_inv_freq = rotaryInvFreqBuf;
+        qkvParams.rotary_coef_cache_buffer = optPtr<float2>(rotary_cos_sin);
+        qkvParams.spec_decoding_position_offsets
+            = isMultiTokenGen ? optPtr<int>(spec_decoding_position_offsets) : nullptr;
+        qkvParams.mrope_rotary_cos_sin = nullptr;
+        qkvParams.mrope_position_deltas = nullptr;
+        qkvParams.batch_size = static_cast<int>(batch_beam);
+        qkvParams.max_input_seq_len = static_cast<int>(input_seq_length);
+        qkvParams.max_kv_seq_len = static_cast<int>(max_past_kv_length);
+        qkvParams.cyclic_kv_cache_len = static_cast<int>(cyclic_attention_window_size);
+        qkvParams.sink_token_len = static_cast<int>(sink_token_length);
+        qkvParams.token_num = static_cast<int>(num_tokens);
+        qkvParams.remove_padding = true;
+        qkvParams.is_last_chunk = false;
+        qkvParams.cross_attention = false;
+        qkvParams.head_num = static_cast<int>(num_heads);
+        qkvParams.kv_head_num = static_cast<int>(num_kv_heads);
+        qkvParams.qheads_per_kv_head = static_cast<int>(num_heads / num_kv_heads);
+        qkvParams.size_per_head = static_cast<int>(head_size);
+        qkvParams.fmha_host_bmm1_scale = static_cast<float>(bmm1_scale);
+        qkvParams.rotary_embedding_dim = static_cast<int>(rotary_embedding_dim);
+        qkvParams.rotary_embedding_base = static_cast<float>(rotary_embedding_base);
+        qkvParams.rotary_scale_type = static_cast<RotaryScalingType>(rotary_embedding_scale_type);
+        qkvParams.rotary_embedding_scale = static_cast<float>(rotary_embedding_scale);
+        qkvParams.rotary_embedding_max_positions = static_cast<int>(rotary_embedding_max_positions);
+        qkvParams.position_embedding_type = static_cast<PositionEmbeddingType>(position_embedding_type);
+        qkvParams.position_shift_enabled = false;
+        qkvParams.cache_type = cacheTypeFromQuantMode(quantMode);
+        qkvParams.separate_q_kv_output = true;
+        qkvParams.quantized_fp8_output = fp8_context_fmha;
+        qkvParams.generation_phase = true;
+        qkvParams.multi_processor_count = static_cast<int>(multi_processor_count);
+        qkvParams.rotary_vision_start = 0;
+        qkvParams.rotary_vision_length = 0;
+
+        switch (qkvDtype)
+        {
+        case nvinfer1::DataType::kFLOAT:
+            tensorrt_llm::kernels::invokeQKVPreprocessing(
+                reinterpret_cast<QKVPreprocessingParams<float, KVBlockArray>&>(qkvParams), stream);
+            break;
+        case nvinfer1::DataType::kHALF:
+            tensorrt_llm::kernels::invokeQKVPreprocessing(
+                reinterpret_cast<QKVPreprocessingParams<half, KVBlockArray>&>(qkvParams), stream);
+            break;
+#ifdef ENABLE_BF16
+        case nvinfer1::DataType::kBF16:
+            tensorrt_llm::kernels::invokeQKVPreprocessing(
+                reinterpret_cast<QKVPreprocessingParams<__nv_bfloat16, KVBlockArray>&>(qkvParams), stream);
+            break;
+#endif
+        default: TORCH_CHECK(false, "Unsupported data type for QKV preprocessing.");
+        }
+        sync_check_cuda_error(stream);
+    }
 
     std::optional<at::Tensor> kvPool;
     std::optional<at::Tensor> blockTables;
     if (need_build_kv_cache_metadata)
     {
+        NVTX3_SCOPED_RANGE_WITH_NAME(kvMetadataRange, "trtllm_gen.cpp.generation.kv_metadata");
         kvPool = buildFlashinferTrtllmGenPagedKvCacheBuffers(host_kv_cache_pool_pointers.value(),
             host_kv_cache_pool_mapping.value(), layer_idx, num_kv_heads, tokens_per_block, head_size, kv_factor,
-            total_num_blocks, kv_cache_quant_mode, qkv_input.scalar_type());
+            total_num_blocks, kv_cache_quant_mode, qkvScalarType);
 
-        int32_t const poolIndex = host_kv_cache_pool_mapping.value().index({layer_idx, 0}).item<int32_t>();
-        blockTables = kv_cache_block_offsets.value().index({poolIndex}).slice(0, seq_offset, seq_offset + batch_beam);
+        int32_t const poolIndex = readKvCachePoolMapping(host_kv_cache_pool_mapping.value(), layer_idx).poolIndex;
+        blockTables = kv_cache_block_offsets.value().select(0, poolIndex).narrow(0, seq_offset, batch_beam);
     }
 
     auto qProcessed = views.qBuf.view({num_tokens, num_heads, head_size});
-    views.trtllmGenWorkspace.zero_();
+    {
+        NVTX3_SCOPED_RANGE_WITH_NAME(zeroWorkspaceRange, "trtllm_gen.cpp.generation.zero_workspace");
+        zeroWorkspaceAsync(views.trtllmGenWorkspace);
+    }
 
     auto const windowLeft = computeWindowLeft(cyclic_attention_window_size, max_past_kv_length, attention_chunk_size);
     return {qProcessed, kvPool, blockTables, views.trtllmGenWorkspace, cuSeqlens, input_seq_length, max_past_kv_length,

--- a/cpp/tensorrt_llm/thop/trtllmGenQKVProcessOp.cpp
+++ b/cpp/tensorrt_llm/thop/trtllmGenQKVProcessOp.cpp
@@ -23,6 +23,7 @@
 #include "tensorrt_llm/kernels/unfusedAttentionKernels.h"
 #include "tensorrt_llm/runtime/torchUtils.h"
 #include "tensorrt_llm/thop/attentionOp.h"
+#include "tensorrt_llm/thop/trtllmGenFusedOps.h"
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/extension.h>
 #include <type_traits>
@@ -46,6 +47,18 @@ using tensorrt_llm::runtime::TorchUtils;
 
 namespace
 {
+
+int64_t computeWindowLeft(
+    int64_t const cyclicAttentionWindowSize, int64_t const maxKvLength, int64_t const attentionChunkSize)
+{
+    TORCH_CHECK(!(attentionChunkSize != 0 && cyclicAttentionWindowSize < maxKvLength),
+        "Chunked-attention and sliding-window-attention should not be enabled at the same time.");
+    if (0 < cyclicAttentionWindowSize && cyclicAttentionWindowSize < maxKvLength)
+    {
+        return cyclicAttentionWindowSize - 1;
+    }
+    return -1;
+}
 
 template <typename T, typename OptTensorT>
 T* optPtr(OptTensorT&& t, std::enable_if_t<!std::is_const_v<OptTensorT>>* = nullptr)
@@ -296,127 +309,191 @@ void qkv_processing(
     }
 }
 
+std::tuple<at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>, at::Tensor, at::Tensor, at::Tensor,
+    int64_t, int64_t, int64_t>
+trtllmGenContextPreprocess(torch::Tensor qkv_input, torch::Tensor workspace, torch::Tensor sequence_lengths,
+    torch::Tensor context_lengths, std::optional<torch::Tensor> kv_cache_block_offsets,
+    std::optional<torch::Tensor> host_kv_cache_pool_pointers, std::optional<torch::Tensor> host_kv_cache_pool_mapping,
+    std::optional<torch::Tensor> kv_scale_orig_quant, std::optional<torch::Tensor> kv_scale_quant_orig,
+    std::optional<torch::Tensor> attention_output_orig_quant, std::optional<torch::Tensor> rotary_inv_freq,
+    std::optional<torch::Tensor> rotary_cos_sin, std::optional<torch::Tensor> mrope_rotary_cos_sin,
+    int64_t const layer_idx, int64_t const num_heads, int64_t const num_kv_heads, int64_t const head_size,
+    int64_t const tokens_per_block, int64_t const mask_type, int64_t const kv_cache_quant_mode,
+    int64_t const max_attention_window_size, int64_t const cyclic_attention_window_size,
+    int64_t const sink_token_length, int64_t const num_tokens, int64_t const batch_size, int64_t const input_seq_length,
+    int64_t const max_past_kv_length, int64_t const rotary_embedding_dim, double const rotary_embedding_base,
+    int64_t const rotary_embedding_scale_type, double const rotary_embedding_scale,
+    int64_t const rotary_embedding_max_positions, int64_t const position_embedding_type, double const bmm1_scale,
+    double const bmm2_scale, int64_t const attention_chunk_size, bool const fp8_context_fmha,
+    bool const paged_context_fmha, bool const is_mla_enable, int64_t const total_num_blocks, int64_t const kv_factor,
+    bool const need_build_kv_cache_metadata)
+{
+    (void) bmm2_scale;
+    TORCH_CHECK(host_kv_cache_pool_pointers.has_value(), "host_kv_cache_pool_pointers is required.");
+    TORCH_CHECK(host_kv_cache_pool_mapping.has_value(), "host_kv_cache_pool_mapping is required.");
+    TORCH_CHECK(kv_cache_block_offsets.has_value(), "kv_cache_block_offsets is required.");
+
+    auto const views = TrtllmAttentionWorkspaceManager::materializeContextWorkspace(workspace, qkv_input.scalar_type(),
+        batch_size, num_tokens, num_heads, head_size, rotary_embedding_dim, fp8_context_fmha);
+
+    (void) build_decoder_info(views.cuQSeqlens, views.cuKvSeqlens, std::nullopt, views.tokensInfo, std::nullopt,
+        views.cuMaskRows, std::nullopt, std::nullopt, context_lengths, sequence_lengths, views.fmhaTileCounter,
+        kv_scale_quant_orig, attention_output_orig_quant, views.fmhaBmm1Scale, views.fmhaBmm2Scale,
+        views.rotaryInvFreqBuf, rotary_inv_freq, 1,
+        tensorrt_llm::common::QuantMode(static_cast<uint32_t>(kv_cache_quant_mode)).hasFp4KvCache(), bmm1_scale,
+        batch_size, input_seq_length, 0, cyclic_attention_window_size, sink_token_length, num_tokens, true, mask_type,
+        rotary_embedding_scale, rotary_embedding_base, rotary_embedding_dim, rotary_embedding_scale_type,
+        rotary_embedding_max_positions);
+
+    qkv_processing<true>(qkv_input, std::nullopt, std::nullopt, views.qBuf, kv_cache_block_offsets,
+        host_kv_cache_pool_pointers, host_kv_cache_pool_mapping, std::nullopt, kv_scale_quant_orig, kv_scale_orig_quant,
+        attention_output_orig_quant, views.fmhaBmm1Scale, views.fmhaBmm2Scale, views.fmhaTileCounter, std::nullopt,
+        views.tokensInfo, context_lengths, sequence_lengths, std::nullopt, views.cuQSeqlens, views.cuKvSeqlens,
+        std::nullopt, std::nullopt, views.rotaryInvFreqBuf, rotary_cos_sin, std::nullopt, mrope_rotary_cos_sin,
+        std::nullopt, batch_size, input_seq_length, max_past_kv_length, cyclic_attention_window_size, sink_token_length,
+        num_tokens, true, attention_chunk_size == 0 || input_seq_length == max_past_kv_length, false, num_heads,
+        num_kv_heads, num_heads / num_kv_heads, head_size, bmm1_scale, rotary_embedding_dim, rotary_embedding_base,
+        rotary_embedding_scale_type, rotary_embedding_scale, rotary_embedding_max_positions, position_embedding_type,
+        false, paged_context_fmha, fp8_context_fmha, false, 0, 0, layer_idx, tokens_per_block,
+        max_attention_window_size, kv_cache_quant_mode, cyclic_attention_window_size, 0, sink_token_length, 0,
+        is_mla_enable);
+
+    std::optional<at::Tensor> kvPool;
+    std::optional<at::Tensor> blockTables;
+    if (need_build_kv_cache_metadata)
+    {
+        kvPool = buildFlashinferTrtllmGenPagedKvCacheBuffers(host_kv_cache_pool_pointers.value(),
+            host_kv_cache_pool_mapping.value(), layer_idx, num_kv_heads, tokens_per_block, head_size, kv_factor,
+            total_num_blocks, kv_cache_quant_mode, qkv_input.scalar_type());
+
+        int32_t const poolIndex = host_kv_cache_pool_mapping.value().index({layer_idx, 0}).item<int32_t>();
+        blockTables = kv_cache_block_offsets.value().index({poolIndex}).slice(0, 0, batch_size);
+    }
+
+    at::Tensor qProcessed;
+    bool const separateQKvOutput = paged_context_fmha;
+    if (separateQKvOutput)
+    {
+        qProcessed = views.qBuf.value().view({num_tokens, num_heads, head_size});
+    }
+    else
+    {
+        qProcessed = qkv_input.slice(1, 0, num_heads * head_size).view({num_tokens, num_heads, head_size});
+    }
+
+    views.trtllmGenWorkspace.zero_();
+
+    auto const windowLeft = computeWindowLeft(cyclic_attention_window_size, max_past_kv_length, attention_chunk_size);
+    return {qProcessed, kvPool, blockTables, views.trtllmGenWorkspace, views.cuQSeqlens, views.cuKvSeqlens,
+        input_seq_length, max_past_kv_length, windowLeft};
+}
+
+void trtllmGenContextPostprocess(torch::Tensor qkv_input, torch::Tensor workspace, torch::Tensor sequence_lengths,
+    torch::Tensor context_lengths, std::optional<torch::Tensor> kv_cache_block_offsets,
+    std::optional<torch::Tensor> host_kv_cache_pool_pointers, std::optional<torch::Tensor> host_kv_cache_pool_mapping,
+    std::optional<torch::Tensor> kv_scale_orig_quant, std::optional<torch::Tensor> kv_scale_quant_orig,
+    std::optional<torch::Tensor> attention_output_orig_quant, std::optional<torch::Tensor> rotary_cos_sin,
+    std::optional<torch::Tensor> mrope_rotary_cos_sin, int64_t const layer_idx, int64_t const num_heads,
+    int64_t const num_kv_heads, int64_t const head_size, int64_t const tokens_per_block, int64_t const mask_type,
+    int64_t const kv_cache_quant_mode, int64_t const max_attention_window_size,
+    int64_t const cyclic_attention_window_size, int64_t const sink_token_length, int64_t const num_tokens,
+    int64_t const batch_size, int64_t const input_seq_length, int64_t const max_past_kv_length,
+    int64_t const rotary_embedding_dim, double const rotary_embedding_base, int64_t const rotary_embedding_scale_type,
+    double const rotary_embedding_scale, int64_t const rotary_embedding_max_positions,
+    int64_t const position_embedding_type, double const bmm1_scale, bool const fp8_context_fmha,
+    bool const paged_context_fmha, bool const is_mla_enable, int64_t const attention_chunk_size)
+{
+    (void) mask_type;
+    auto const views = TrtllmAttentionWorkspaceManager::materializeContextWorkspace(workspace, qkv_input.scalar_type(),
+        batch_size, num_tokens, num_heads, head_size, rotary_embedding_dim, fp8_context_fmha);
+
+    qkv_processing<false>(qkv_input, std::nullopt, std::nullopt, views.qBuf, kv_cache_block_offsets,
+        host_kv_cache_pool_pointers, host_kv_cache_pool_mapping, std::nullopt, kv_scale_quant_orig, kv_scale_orig_quant,
+        attention_output_orig_quant, views.fmhaBmm1Scale, views.fmhaBmm2Scale, views.fmhaTileCounter, std::nullopt,
+        views.tokensInfo, context_lengths, sequence_lengths, std::nullopt, views.cuQSeqlens, views.cuKvSeqlens,
+        std::nullopt, std::nullopt, views.rotaryInvFreqBuf, rotary_cos_sin, std::nullopt, mrope_rotary_cos_sin,
+        std::nullopt, batch_size, input_seq_length, max_past_kv_length, cyclic_attention_window_size, sink_token_length,
+        num_tokens, true, attention_chunk_size == 0 || input_seq_length == max_past_kv_length, false, num_heads,
+        num_kv_heads, num_heads / num_kv_heads, head_size, bmm1_scale, rotary_embedding_dim, rotary_embedding_base,
+        rotary_embedding_scale_type, rotary_embedding_scale, rotary_embedding_max_positions, position_embedding_type,
+        false, paged_context_fmha, fp8_context_fmha, false, 0, 0, layer_idx, tokens_per_block,
+        max_attention_window_size, kv_cache_quant_mode, cyclic_attention_window_size, 0, sink_token_length, 0,
+        is_mla_enable);
+}
+
+std::tuple<at::Tensor, std::optional<at::Tensor>, std::optional<at::Tensor>, at::Tensor, std::optional<at::Tensor>,
+    int64_t, int64_t, int64_t, bool>
+trtllmGenGenerationPreprocess(torch::Tensor qkv_input, torch::Tensor workspace, torch::Tensor sequence_lengths,
+    std::optional<torch::Tensor> spec_decoding_generation_lengths,
+    std::optional<torch::Tensor> spec_decoding_position_offsets, std::optional<torch::Tensor> kv_cache_block_offsets,
+    std::optional<torch::Tensor> host_kv_cache_pool_pointers, std::optional<torch::Tensor> host_kv_cache_pool_mapping,
+    std::optional<torch::Tensor> kv_scale_orig_quant, std::optional<torch::Tensor> kv_scale_quant_orig,
+    std::optional<torch::Tensor> attention_output_orig_quant, std::optional<torch::Tensor> rotary_inv_freq,
+    std::optional<torch::Tensor> rotary_cos_sin, int64_t const layer_idx, int64_t const seq_offset,
+    int64_t const num_heads, int64_t const num_kv_heads, int64_t const head_size, int64_t const tokens_per_block,
+    int64_t const kv_cache_quant_mode, int64_t const max_attention_window_size,
+    int64_t const cyclic_attention_window_size, int64_t const sink_token_length, int64_t const num_tokens,
+    int64_t const batch_beam, int64_t const input_seq_length, int64_t const max_past_kv_length,
+    int64_t const rotary_embedding_dim, double const rotary_embedding_base, int64_t const rotary_embedding_scale_type,
+    double const rotary_embedding_scale, int64_t const rotary_embedding_max_positions,
+    int64_t const position_embedding_type, double const bmm1_scale, double const bmm2_scale,
+    bool const fp8_context_fmha, int64_t const predicted_tokens_per_seq, int64_t const attention_chunk_size,
+    int64_t const total_num_blocks, int64_t const kv_factor, bool const need_build_kv_cache_metadata)
+{
+    TORCH_CHECK(host_kv_cache_pool_pointers.has_value(), "host_kv_cache_pool_pointers is required.");
+    TORCH_CHECK(host_kv_cache_pool_mapping.has_value(), "host_kv_cache_pool_mapping is required.");
+    TORCH_CHECK(kv_cache_block_offsets.has_value(), "kv_cache_block_offsets is required.");
+    (void) bmm2_scale;
+
+    bool const isMultiTokenGen = spec_decoding_generation_lengths.has_value() && predicted_tokens_per_seq > 1;
+    auto const views = TrtllmAttentionWorkspaceManager::materializeGenerationWorkspace(workspace,
+        qkv_input.scalar_type(), batch_beam, num_tokens, num_heads, head_size, rotary_embedding_dim, num_kv_heads);
+
+    auto const buildDecoderInfoNeeded = build_decoder_info(views.cuSeqlens, views.cuKvSeqlens, std::nullopt,
+        views.tokensInfo, std::nullopt, std::nullopt, std::nullopt, std::nullopt,
+        isMultiTokenGen ? spec_decoding_generation_lengths : std::nullopt, sequence_lengths, std::nullopt, std::nullopt,
+        std::nullopt, std::nullopt, std::nullopt, views.rotaryInvFreqBuf, rotary_inv_freq, 1,
+        tensorrt_llm::common::QuantMode(static_cast<uint32_t>(kv_cache_quant_mode)).hasFp4KvCache(), bmm1_scale,
+        batch_beam, input_seq_length, 0, 0, 0, num_tokens, true, 0, rotary_embedding_scale, rotary_embedding_base,
+        rotary_embedding_dim, rotary_embedding_scale_type, rotary_embedding_max_positions);
+
+    auto rotaryInvFreqBuf = buildDecoderInfoNeeded ? views.rotaryInvFreqBuf : rotary_inv_freq;
+    std::optional<at::Tensor> cuSeqlens = buildDecoderInfoNeeded ? std::make_optional(views.cuSeqlens) : std::nullopt;
+
+    qkv_processing<true>(qkv_input, std::nullopt, std::nullopt, views.qBuf, kv_cache_block_offsets,
+        host_kv_cache_pool_pointers, host_kv_cache_pool_mapping, std::nullopt, kv_scale_quant_orig, kv_scale_orig_quant,
+        attention_output_orig_quant, views.bmm1Scale, views.bmm2Scale, std::nullopt, std::nullopt,
+        isMultiTokenGen ? std::make_optional(views.tokensInfo) : std::nullopt,
+        isMultiTokenGen ? spec_decoding_generation_lengths : std::nullopt, sequence_lengths, std::nullopt, cuSeqlens,
+        buildDecoderInfoNeeded ? std::make_optional(views.cuKvSeqlens) : std::nullopt, std::nullopt, std::nullopt,
+        rotaryInvFreqBuf, rotary_cos_sin, isMultiTokenGen ? spec_decoding_position_offsets : std::nullopt, std::nullopt,
+        std::nullopt, batch_beam, input_seq_length, max_past_kv_length, cyclic_attention_window_size, sink_token_length,
+        num_tokens, true, false, false, num_heads, num_kv_heads, num_heads / num_kv_heads, head_size, bmm1_scale,
+        rotary_embedding_dim, rotary_embedding_base, rotary_embedding_scale_type, rotary_embedding_scale,
+        rotary_embedding_max_positions, position_embedding_type, false, true, fp8_context_fmha, true, 0, 0, layer_idx,
+        tokens_per_block, max_attention_window_size, kv_cache_quant_mode, cyclic_attention_window_size, 1,
+        sink_token_length, seq_offset, false);
+
+    std::optional<at::Tensor> kvPool;
+    std::optional<at::Tensor> blockTables;
+    if (need_build_kv_cache_metadata)
+    {
+        kvPool = buildFlashinferTrtllmGenPagedKvCacheBuffers(host_kv_cache_pool_pointers.value(),
+            host_kv_cache_pool_mapping.value(), layer_idx, num_kv_heads, tokens_per_block, head_size, kv_factor,
+            total_num_blocks, kv_cache_quant_mode, qkv_input.scalar_type());
+
+        int32_t const poolIndex = host_kv_cache_pool_mapping.value().index({layer_idx, 0}).item<int32_t>();
+        blockTables = kv_cache_block_offsets.value().index({poolIndex}).slice(0, seq_offset, seq_offset + batch_beam);
+    }
+
+    auto qProcessed = views.qBuf.view({num_tokens, num_heads, head_size});
+    views.trtllmGenWorkspace.zero_();
+
+    auto const windowLeft = computeWindowLeft(cyclic_attention_window_size, max_past_kv_length, attention_chunk_size);
+    return {qProcessed, kvPool, blockTables, views.trtllmGenWorkspace, cuSeqlens, input_seq_length, max_past_kv_length,
+        windowLeft, isMultiTokenGen};
+}
+
 } // namespace torch_ext
 
 TRTLLM_NAMESPACE_END
-
-// Schema string shared by qkv_preprocessing and kv_cache_postprocessing.
-// clang-format off
-#define QKV_PROCESSING_SCHEMA                          \
-    "Tensor(a!)? qkv_input, "                          \
-    "Tensor(b!)? cross_kv_input, "                     \
-    "Tensor(c!)? quantized_qkv_output, "               \
-    "Tensor(d!)? q_output, "                           \
-    "Tensor? kv_cache_block_offsets, "                 \
-    "Tensor? host_kv_cache_pool_pointers, "            \
-    "Tensor? host_kv_cache_pool_mapping, "             \
-    "Tensor? qkv_bias, "                               \
-    "Tensor? qkv_scale_quant_orig, "                   \
-    "Tensor? qkv_scale_orig_quant, "                   \
-    "Tensor? o_scale_orig_quant, "                     \
-    "Tensor(e!)? fmha_bmm1_scale, "                    \
-    "Tensor(f!)? fmha_bmm2_scale, "                    \
-    "Tensor(g!)? fmha_tile_counter, "                  \
-    "Tensor? logn_scaling, "                           \
-    "Tensor? tokens_info, "                            \
-    "Tensor? seq_lens, "                               \
-    "Tensor? cache_seq_lens, "                         \
-    "Tensor? encoder_seq_lens, "                       \
-    "Tensor? cu_seq_lens, "                            \
-    "Tensor? cu_kv_seq_lens, "                         \
-    "Tensor? sparse_kv_offsets, "                      \
-    "Tensor? sparse_kv_indices, "                      \
-    "Tensor? rotary_embedding_inv_freq, "              \
-    "Tensor? rotary_coef_cache_buffer, "               \
-    "Tensor? spec_decoding_position_offsets, "         \
-    "Tensor? mrope_rotary_cos_sin, "                   \
-    "Tensor? mrope_position_deltas, "                  \
-    "int batch_size, "                                 \
-    "int max_input_seq_len, "                          \
-    "int max_kv_seq_len, "                             \
-    "int cyclic_kv_cache_len, "                        \
-    "int sink_token_len, "                             \
-    "int token_num, "                                  \
-    "bool remove_padding, "                            \
-    "bool is_last_chunk, "                             \
-    "bool cross_attention, "                           \
-    "int head_num, "                                   \
-    "int kv_head_num, "                                \
-    "int qheads_per_kv_head, "                         \
-    "int size_per_head, "                              \
-    "float fmha_host_bmm1_scale, "                     \
-    "int rotary_embedding_dim, "                       \
-    "float rotary_embedding_base, "                    \
-    "int rotary_scaling_type, "                        \
-    "float rotary_embedding_scale, "                   \
-    "int rotary_embedding_max_positions, "             \
-    "int position_embedding_type, "                    \
-    "bool position_shift_enabled, "                    \
-    "bool separate_q_kv_output, "                      \
-    "bool quantized_fp8_output, "                      \
-    "bool generation_phase, "                          \
-    "int rotary_vision_start, "                        \
-    "int rotary_vision_length, "                       \
-    "int layer_idx, "                                  \
-    "int tokens_per_block, "                           \
-    "int max_attention_window_size, "                  \
-    "int kv_cache_quant_mode, "                        \
-    "int cyclic_attention_window_size, "               \
-    "int beam_width, "                                 \
-    "int sink_token_length, "                          \
-    "int seq_offset=0, "                               \
-    "bool is_mla_enable=False"
-
-// clang-format on
-
-TORCH_LIBRARY_FRAGMENT(trtllm, m)
-{
-    // clang-format off
-    m.def(
-        "build_decoder_info("
-        "Tensor(a!)? seq_q_offsets, "
-        "Tensor(b!)? seq_kv_offsets, "
-        "Tensor(c!)? padding_offsets, "
-        "Tensor(d!)? tokens_info, "
-        "Tensor(e!)? encoder_padding_offsets, "
-        "Tensor(f!)? packed_mask_row_offsets, "
-        "Tensor(g!)? seq_cp_partial_offsets, "
-        "Tensor(h!)? attention_mask, "
-        "Tensor? seq_q_lengths, "
-        "Tensor? seq_kv_lengths, "
-        "Tensor(i!)? fmha_tile_counter, "
-        "Tensor? dequant_scale_qkv, "
-        "Tensor? quant_scale_o, "
-        "Tensor(j!)? fmha_bmm1_scale, "
-        "Tensor(k!)? fmha_bmm2_scale, "
-        "Tensor(l!)? rotary_embedding_inv_freq, "
-        "Tensor? rotary_embedding_inv_freq_cache, "
-        "int cp_size, "
-        "bool separate_qkv_scales, "
-        "float fmha_host_bmm1_scale, "
-        "int batch_size, "
-        "int max_q_seq_length, "
-        "int max_encoder_q_seq_length, "
-        "int attention_window_size, "
-        "int sink_token_length, "
-        "int num_tokens, "
-        "bool remove_padding, "
-        "int attention_mask_type, "
-        "float rotary_embedding_scale, "
-        "float rotary_embedding_base, "
-        "int rotary_embedding_dim, "
-        "int rotary_scaling_type, "
-        "int rotary_embedding_max_positions"
-        ") -> bool");
-    // clang-format on
-
-    m.def("qkv_preprocessing(" QKV_PROCESSING_SCHEMA ") -> ()");
-    m.def("kv_cache_postprocessing(" QKV_PROCESSING_SCHEMA ") -> ()");
-}
-
-TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
-{
-    m.impl("build_decoder_info", &tensorrt_llm::torch_ext::build_decoder_info);
-    m.impl("qkv_preprocessing", &tensorrt_llm::torch_ext::qkv_processing<true>);
-    m.impl("kv_cache_postprocessing", &tensorrt_llm::torch_ext::qkv_processing<false>);
-}

--- a/cpp/tests/unit_tests/common/CMakeLists.txt
+++ b/cpp/tests/unit_tests/common/CMakeLists.txt
@@ -15,6 +15,7 @@
 
 add_gtest(cudaProfilerUtilsTest cudaProfilerUtilsTest.cpp)
 add_gtest(cudaUtilsTest cudaUtilsTest.cpp)
+add_gtest(attentionWorkspaceTest attentionWorkspaceTest.cpp)
 add_gtest(memoryUtilsTest memoryUtilsTest.cu)
 add_gtest(optionalRefTest optionalRefTest.cpp)
 add_gtest(quantizationTest quantizationTest.cpp)

--- a/cpp/tests/unit_tests/common/attentionWorkspaceTest.cpp
+++ b/cpp/tests/unit_tests/common/attentionWorkspaceTest.cpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/attentionWorkspace.h"
+
+#include "tensorrt_llm/common/workspace.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+
+namespace tc = tensorrt_llm::common;
+namespace tcop = tensorrt_llm::common::op;
+
+namespace
+{
+
+constexpr size_t kAlignment = tc::kCudaMemAlign;
+
+void expectSlice(char const* name, tcop::WorkspaceSlice const& slice, size_t expectedOffset, size_t expectedSize)
+{
+    SCOPED_TRACE(name);
+    EXPECT_EQ(slice.offset, expectedOffset);
+    EXPECT_EQ(slice.size, expectedSize);
+}
+
+template <typename T>
+void expectPtrAt(T* ptr, std::uint8_t* base, tcop::WorkspaceSlice const& slice)
+{
+    EXPECT_EQ(static_cast<void*>(ptr), static_cast<void*>(base + slice.offset));
+}
+
+void expectPtrAt(void* ptr, std::uint8_t* base, tcop::WorkspaceSlice const& slice)
+{
+    EXPECT_EQ(ptr, static_cast<void*>(base + slice.offset));
+}
+
+template <typename Slice>
+void expectNextSlice(char const* name, Slice const& slice, size_t size, size_t& expectedOffset)
+{
+    expectSlice(name, slice, expectedOffset, size);
+    expectedOffset += tc::alignSize(size, kAlignment);
+}
+
+} // namespace
+
+TEST(AttentionWorkspaceManagerTest, ContextLayoutMatchesAttentionOpOrdering)
+{
+    tcop::AttentionContextWorkspaceSizes sizes{};
+    sizes.cublasWorkspace = 13;
+    sizes.attentionMask = 17;
+    sizes.cuQSeqlens = 19;
+    sizes.cuKvSeqlens = 23;
+    sizes.cuMaskRows = 29;
+    sizes.rotaryInvFreq = 31;
+    sizes.qBuf = 37;
+    sizes.kBuf = 41;
+    sizes.vBuf = 43;
+    sizes.qkBuf = 47;
+    sizes.qkvBuf = 53;
+    sizes.qkFloatBuf = 59;
+    sizes.fp8QkvBuf = 61;
+    sizes.fp8QBuf = 67;
+    sizes.fp8KBuf = 71;
+    sizes.fp8VBuf = 0;
+    sizes.paddingOffset = 73;
+    sizes.encoderPaddingOffset = 0;
+    sizes.tokensInfo = 79;
+    sizes.fmhaTileCounter = 83;
+    sizes.fmhaBmm1Scale = 89;
+    sizes.fmhaBmm2Scale = 97;
+    sizes.sageQScale = 101;
+    sizes.sageKScale = 103;
+    sizes.sageVScale = 107;
+    sizes.cpWorkspace = 109;
+
+    auto const layout = tcop::AttentionWorkspaceManager::buildContextLayout(sizes);
+
+    size_t expectedOffset = 0;
+    expectNextSlice("cublasWorkspace", layout.cublasWorkspace, sizes.cublasWorkspace, expectedOffset);
+    expectNextSlice("attentionMask", layout.attentionMask, sizes.attentionMask, expectedOffset);
+    expectNextSlice("cuQSeqlens", layout.cuQSeqlens, sizes.cuQSeqlens, expectedOffset);
+    expectNextSlice("cuKvSeqlens", layout.cuKvSeqlens, sizes.cuKvSeqlens, expectedOffset);
+    expectNextSlice("cuMaskRows", layout.cuMaskRows, sizes.cuMaskRows, expectedOffset);
+    expectNextSlice("rotaryInvFreq", layout.rotaryInvFreq, sizes.rotaryInvFreq, expectedOffset);
+    expectNextSlice("qBuf", layout.qBuf, sizes.qBuf, expectedOffset);
+    expectNextSlice("kBuf", layout.kBuf, sizes.kBuf, expectedOffset);
+    expectNextSlice("vBuf", layout.vBuf, sizes.vBuf, expectedOffset);
+    expectNextSlice("qkBuf", layout.qkBuf, sizes.qkBuf, expectedOffset);
+    expectNextSlice("qkvBuf", layout.qkvBuf, sizes.qkvBuf, expectedOffset);
+    expectNextSlice("qkFloatBuf", layout.qkFloatBuf, sizes.qkFloatBuf, expectedOffset);
+    expectNextSlice("fp8QkvBuf", layout.fp8QkvBuf, sizes.fp8QkvBuf, expectedOffset);
+    expectNextSlice("fp8QBuf", layout.fp8QBuf, sizes.fp8QBuf, expectedOffset);
+    expectNextSlice("fp8KBuf", layout.fp8KBuf, sizes.fp8KBuf, expectedOffset);
+    expectNextSlice("fp8VBuf", layout.fp8VBuf, sizes.fp8VBuf, expectedOffset);
+    expectNextSlice("paddingOffset", layout.paddingOffset, sizes.paddingOffset, expectedOffset);
+    expectNextSlice("encoderPaddingOffset", layout.encoderPaddingOffset, sizes.encoderPaddingOffset, expectedOffset);
+    expectNextSlice("tokensInfo", layout.tokensInfo, sizes.tokensInfo, expectedOffset);
+    expectNextSlice("fmhaTileCounter", layout.fmhaTileCounter, sizes.fmhaTileCounter, expectedOffset);
+    expectNextSlice("fmhaBmm1Scale", layout.fmhaBmm1Scale, sizes.fmhaBmm1Scale, expectedOffset);
+    expectNextSlice("fmhaBmm2Scale", layout.fmhaBmm2Scale, sizes.fmhaBmm2Scale, expectedOffset);
+    expectNextSlice("sageQScale", layout.sageQScale, sizes.sageQScale, expectedOffset);
+    expectNextSlice("sageKScale", layout.sageKScale, sizes.sageKScale, expectedOffset);
+    expectNextSlice("sageVScale", layout.sageVScale, sizes.sageVScale, expectedOffset);
+    expectNextSlice("cpWorkspace", layout.cpWorkspace, sizes.cpWorkspace, expectedOffset);
+    EXPECT_EQ(layout.totalSize, expectedOffset);
+}
+
+TEST(AttentionWorkspaceManagerTest, MaterializeContextReturnsTypedViewsAndNullZeroSlices)
+{
+    constexpr size_t kCpMaxPaddedSequenceLength = 2;
+    constexpr int kHeadSize = 4;
+    constexpr int kNumHeads = 2;
+    constexpr int kNumKvHeads = 1;
+    constexpr size_t kCpBufferElements = kCpMaxPaddedSequenceLength * kHeadSize * (kNumHeads + 2 * kNumKvHeads);
+
+    tcop::AttentionContextWorkspaceSizes sizes{};
+    sizes.cublasWorkspace = 0;
+    sizes.attentionMask = sizeof(float) * 4;
+    sizes.cuQSeqlens = sizeof(int) * 3;
+    sizes.cuKvSeqlens = sizeof(int) * 3;
+    sizes.rotaryInvFreq = 0;
+    sizes.qBuf = sizeof(float) * 8;
+    sizes.fp8QBuf = sizeof(__nv_fp8_e4m3) * 5;
+    sizes.tokensInfo = sizeof(int2) * 2;
+    sizes.fmhaTileCounter = sizeof(uint32_t);
+    sizes.fmhaBmm1Scale = sizeof(float) * 2;
+    sizes.cpWorkspace = 2 * kCpBufferElements * sizeof(float) + sizeof(int) * 3;
+
+    auto const layout = tcop::AttentionWorkspaceManager::buildContextLayout(sizes);
+
+    constexpr size_t kWorkspaceSize = 8192;
+    alignas(kAlignment) std::array<std::uint8_t, kWorkspaceSize> workspace{};
+    auto* base = workspace.data();
+
+    auto const views = tcop::AttentionWorkspaceManager::materializeContext<float>(
+        workspace.data(), layout, kCpMaxPaddedSequenceLength, kHeadSize, kNumHeads, kNumKvHeads);
+
+    EXPECT_EQ(views.cublasWorkspace, nullptr);
+    expectPtrAt(views.attentionMask, base, layout.attentionMask);
+    expectPtrAt(views.cuQSeqlens, base, layout.cuQSeqlens);
+    expectPtrAt(views.cuKvSeqlens, base, layout.cuKvSeqlens);
+    EXPECT_EQ(views.rotaryInvFreq, nullptr);
+    expectPtrAt(views.qBuf, base, layout.qBuf);
+    expectPtrAt(views.fp8QBuf, base, layout.fp8QBuf);
+    expectPtrAt(views.tokensInfo, base, layout.tokensInfo);
+    expectPtrAt(views.fmhaTileCounter, base, layout.fmhaTileCounter);
+    expectPtrAt(views.fmhaBmm1Scale, base, layout.fmhaBmm1Scale);
+    expectPtrAt(views.gatherInBuffer, base, layout.cpWorkspace);
+
+    auto* const expectedGatherOutBuffer
+        = reinterpret_cast<float*>(base + layout.cpWorkspace.offset) + kCpBufferElements;
+    auto* const expectedCuCpPartialSeqlens = reinterpret_cast<int*>(expectedGatherOutBuffer + kCpBufferElements);
+    EXPECT_EQ(static_cast<void*>(views.gatherOutBuffer), static_cast<void*>(expectedGatherOutBuffer));
+    EXPECT_EQ(static_cast<void*>(views.cuCpPartialSeqlens), static_cast<void*>(expectedCuCpPartialSeqlens));
+}
+
+TEST(AttentionWorkspaceManagerTest, GenerationLayoutPlacesCpWorkspaceBeforePartialBuffers)
+{
+    constexpr size_t kCpMaxPaddedSequenceLength = 3;
+    constexpr int kNumHeads = 2;
+    constexpr int kNumKvHeads = 1;
+    constexpr int kHeadSize = 4;
+    constexpr size_t kCpBufferElements = kCpMaxPaddedSequenceLength * (kNumHeads + 2 * kNumKvHeads) * kHeadSize;
+
+    tcop::AttentionGenerationWorkspaceSizes sizes{};
+    sizes.cpWorkspace = 2 * kCpBufferElements * sizeof(float);
+    sizes.partialOut = 33;
+    sizes.partialSum = 9;
+    sizes.partialMax = 0;
+    sizes.shiftKCache = 5;
+
+    auto const layout = tcop::AttentionWorkspaceManager::buildGenerationLayout(sizes);
+
+    size_t expectedOffset = 0;
+    expectNextSlice("cpWorkspace", layout.cpWorkspace, sizes.cpWorkspace, expectedOffset);
+    expectNextSlice("partialOut", layout.partialOut, sizes.partialOut, expectedOffset);
+    expectNextSlice("partialSum", layout.partialSum, sizes.partialSum, expectedOffset);
+    expectNextSlice("partialMax", layout.partialMax, sizes.partialMax, expectedOffset);
+    expectNextSlice("shiftKCache", layout.shiftKCache, sizes.shiftKCache, expectedOffset);
+    EXPECT_EQ(layout.totalSize, expectedOffset);
+
+    constexpr size_t kWorkspaceSize = 4096;
+    alignas(kAlignment) std::array<std::uint8_t, kWorkspaceSize> workspace{};
+    auto* base = workspace.data();
+
+    auto const views = tcop::AttentionWorkspaceManager::materializeGeneration<float>(
+        workspace.data(), layout, kCpMaxPaddedSequenceLength, kNumHeads, kNumKvHeads, kHeadSize);
+
+    expectPtrAt(views.mhaOutput, base, layout.cpWorkspace);
+    auto* const expectedMhaInput = reinterpret_cast<float*>(base + layout.cpWorkspace.offset) + kCpBufferElements;
+    EXPECT_EQ(static_cast<void*>(views.mhaInput), static_cast<void*>(expectedMhaInput));
+    expectPtrAt(views.partialOut, base, layout.partialOut);
+    expectPtrAt(views.partialSum, base, layout.partialSum);
+    EXPECT_EQ(views.partialMax, nullptr);
+    expectPtrAt(views.shiftKCache, base, layout.shiftKCache);
+}
+
+TEST(AttentionWorkspaceManagerTest, XqaLayoutUsesSingleSparseCacheSlice)
+{
+    tcop::AttentionXqaWorkspaceSizes sizes{};
+    sizes.cuSeqlens = 4;
+    sizes.cuKvSeqlens = 8;
+    sizes.rotaryInvFreq = 0;
+    sizes.tokensInfo = 16;
+    sizes.bmm1Scale = 8;
+    sizes.bmm2Scale = 4;
+    sizes.sparseAttnCache = 31;
+    sizes.kernelWorkspace = 64;
+
+    auto const layout = tcop::AttentionWorkspaceManager::buildXqaLayout(sizes);
+
+    size_t expectedOffset = 0;
+    expectNextSlice("cuSeqlens", layout.cuSeqlens, sizes.cuSeqlens, expectedOffset);
+    expectNextSlice("cuKvSeqlens", layout.cuKvSeqlens, sizes.cuKvSeqlens, expectedOffset);
+    expectNextSlice("rotaryInvFreq", layout.rotaryInvFreq, sizes.rotaryInvFreq, expectedOffset);
+    expectNextSlice("tokensInfo", layout.tokensInfo, sizes.tokensInfo, expectedOffset);
+    expectNextSlice("bmm1Scale", layout.bmm1Scale, sizes.bmm1Scale, expectedOffset);
+    expectNextSlice("bmm2Scale", layout.bmm2Scale, sizes.bmm2Scale, expectedOffset);
+
+    auto const sparseCacheOffset = expectedOffset;
+    expectNextSlice("sparseAttnCache", layout.sparseAttnCache, sizes.sparseAttnCache, expectedOffset);
+    EXPECT_EQ(layout.kernelWorkspace.offset, sparseCacheOffset + tc::alignSize(sizes.sparseAttnCache, kAlignment));
+    expectNextSlice("kernelWorkspace", layout.kernelWorkspace, sizes.kernelWorkspace, expectedOffset);
+    EXPECT_EQ(layout.totalSize, expectedOffset);
+}
+
+TEST(AttentionWorkspaceManagerTest, FlashMlaLayoutKeepsAccumulatorOrder)
+{
+    tcop::AttentionFlashMlaWorkspaceSizes sizes{};
+    sizes.tileSchedulerMetadata = 8;
+    sizes.numSplits = 12;
+    sizes.softmaxLse = 20;
+    sizes.softmaxLseAccum = 24;
+    sizes.outAccum = 28;
+
+    auto const layout = tcop::AttentionWorkspaceManager::buildFlashMlaLayout(sizes);
+
+    size_t expectedOffset = 0;
+    expectNextSlice("tileSchedulerMetadata", layout.tileSchedulerMetadata, sizes.tileSchedulerMetadata, expectedOffset);
+    expectNextSlice("numSplits", layout.numSplits, sizes.numSplits, expectedOffset);
+    expectNextSlice("softmaxLse", layout.softmaxLse, sizes.softmaxLse, expectedOffset);
+    expectNextSlice("softmaxLseAccum", layout.softmaxLseAccum, sizes.softmaxLseAccum, expectedOffset);
+    expectNextSlice("outAccum", layout.outAccum, sizes.outAccum, expectedOffset);
+    EXPECT_EQ(layout.totalSize, expectedOffset);
+}

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -30,7 +30,7 @@ from .trtllm_gen import trtllm_gen_attention
 
 # Enable TRTLLM-Gen attention backend via environment variable (default: off).
 _TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION = (os.environ.get(
-    "TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION", "0") == "1")
+    "TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION", "1") == "1")
 
 
 @dataclass(kw_only=True, init=False)
@@ -580,6 +580,7 @@ class TrtllmAttentionWrapper:
                 has_cross_kv=False,
                 quant_config=self.quant_config,
                 kv_cache_manager=self.kv_cache_manager,
+                attention_input_type=self.attention_input_type,
                 skip_softmax_threshold_scale_factor_prefill=self.
                 skip_softmax_threshold_scale_factor_prefill,
                 skip_softmax_threshold_scale_factor_decode=self.

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
 
 from tensorrt_llm._torch.attention_backend import trtllm_gen
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
-from tensorrt_llm._utils import get_sm_version, maybe_pin_memory, prefer_pinned
+from tensorrt_llm._utils import (get_sm_version, maybe_pin_memory,
+                                 prefer_pinned, torch_dtype_to_binding)
 from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import AttentionMaskType
 from tensorrt_llm.llmapi import SkipSoftmaxAttentionConfig
@@ -26,7 +27,6 @@ from .interface import (AttentionBackend, AttentionInputType, AttentionMask,
                         AttentionMetadata, KVCacheParams, MLAParams,
                         PositionalEmbeddingParams, PredefinedAttentionMask,
                         RopeParams)
-from .trtllm_gen import trtllm_gen_attention
 
 # Enable TRTLLM-Gen attention backend via environment variable (default: off).
 _TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION = (os.environ.get(
@@ -404,6 +404,24 @@ class TrtllmAttentionWrapper:
                             dtype=out_dtype)
             ]
 
+    def _get_trtllm_gen_backend(self):
+        backend = getattr(self, "_trtllm_gen_backend", None)
+        backend_kv_cache_manager = getattr(
+            self, "_trtllm_gen_backend_kv_cache_manager", None)
+        backend_quant_config = getattr(self, "_trtllm_gen_backend_quant_config",
+                                       None)
+        if (backend is None
+                or backend_kv_cache_manager is not self.kv_cache_manager
+                or backend_quant_config is not self.quant_config):
+            backend = trtllm_gen.FlashInferTrtllmGenAttention(
+                kv_cache_manager=self.kv_cache_manager,
+                quant_config=self.quant_config,
+            )
+            self._trtllm_gen_backend = backend
+            self._trtllm_gen_backend_kv_cache_manager = self.kv_cache_manager
+            self._trtllm_gen_backend_quant_config = self.quant_config
+        return backend
+
     def run(
         self,
         q: torch.Tensor,
@@ -557,36 +575,44 @@ class TrtllmAttentionWrapper:
         out_scale = self.out_scale_sf if self.use_nvfp4_output else self.out_scale
 
         helix_active = self.helix_position_offsets is not None
-        if _TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION and not helix_active and trtllm_gen.is_supported(
-                q=q,
+        trtllm_gen_backend = None
+        if _TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION and not helix_active:
+            trtllm_gen_backend = self._get_trtllm_gen_backend()
+            kv_cache_dtype = torch_dtype_to_binding(q.dtype)
+            if self.kv_cache_manager is not None:
+                kv_cache_dtype = self.kv_cache_manager.dtype
+
+        if trtllm_gen_backend is not None and trtllm_gen_backend.is_supported(
+                q_dtype=q.dtype,
+                kv_cache_dtype=kv_cache_dtype,
                 num_heads=self.num_heads,
                 num_kv_heads=self.num_kv_heads,
                 head_size=self.head_size,
                 out_dtype=output.dtype,
                 mask_type=int(mask_type),
-                has_alibi=(self.position_embedding_type == 4
-                           or self.position_embedding_type == 5),
-                is_padded=False,
-                use_paged_kv_cache=(self.kv_cache_block_offsets is not None),
-                tokens_per_block=self.tokens_per_block,
                 beam_width=self.beam_width,
-                position_shift_enabled=False,
                 sink_token_length=self.sink_token_length,
-                cross_attention=False,
-                is_spec_decoding=self.is_spec_decoding_enabled,
+                tokens_per_block=self.tokens_per_block,
+                use_paged_kv_cache=(self.kv_cache_block_offsets is not None),
                 is_mla_enable=self.is_mla_enable,
                 is_fused_qkv=is_fused_qkv,
                 update_kv_cache=update_kv_cache,
-                has_cross_kv=False,
+                cross_attention=False,
+                is_spec_decoding=self.is_spec_decoding_enabled,
+                has_alibi=(self.position_embedding_type == 4
+                           or self.position_embedding_type == 5),
+                is_padded=False,
+                position_shift_enabled=False,
                 quant_config=self.quant_config,
-                kv_cache_manager=self.kv_cache_manager,
                 attention_input_type=self.attention_input_type,
+                sparse_kv_indices=self.sparse_kv_indices,
+                sparse_attn_indices=self.sparse_attn_indices,
                 skip_softmax_threshold_scale_factor_prefill=self.
                 skip_softmax_threshold_scale_factor_prefill,
                 skip_softmax_threshold_scale_factor_decode=self.
                 skip_softmax_threshold_scale_factor_decode,
         )[0]:
-            trtllm_gen_attention(
+            trtllm_gen_backend.attention(
                 q,
                 k,
                 v,
@@ -665,8 +691,6 @@ class TrtllmAttentionWrapper:
                 mla_bmm1_scale,
                 mla_bmm2_scale,
                 quant_q_buffer,
-                self.quant_config,
-                self.kv_cache_manager,
                 num_contexts,
                 num_ctx_tokens,
                 global_layer_idx=self.global_layer_idx,

--- a/tensorrt_llm/_torch/attention_backend/trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm_gen.py
@@ -38,7 +38,7 @@ if IS_FLASHINFER_AVAILABLE:
 
 from tensorrt_llm._torch.attention_backend.interface import AttentionInputType
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
-from tensorrt_llm._utils import get_sm_version, is_sm_100f
+from tensorrt_llm._utils import get_sm_version, is_sm_100f, nvtx_range
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import AttentionMaskType
@@ -440,6 +440,7 @@ class EnqueueParams:
     q_scaling: float = 1.0
     latent_cache: Optional[torch.Tensor] = None
     num_layers: int = 0
+    multi_processor_count: int = 0
     batch_size: int = 0
     mrope_rotary_cos_sin: Optional[torch.Tensor] = None
     beam_width: int = 1
@@ -471,6 +472,7 @@ class FlashInferTrtllmGenAttention:
         self._kv_pool_cache = {}
         self._pool_idx_cache = {}
         self._block_tables_cache = {}
+        self._multi_processor_count_cache = {}
         self._enable_pdl = get_env_enable_pdl()
         missing_ops = self._missing_fused_nanobind_ops()
         if missing_ops:
@@ -491,6 +493,21 @@ class FlashInferTrtllmGenAttention:
         if not kwargs.get("use_paged_kv_cache", True):
             return False, "trtllm-gen requires paged KV cache."
         return self._checker.is_supported(**kwargs)
+
+    def _get_multi_processor_count(self, device: torch.device) -> int:
+        device = torch.device(device)
+        if device.type != "cuda":
+            raise RuntimeError("trtllm-gen requires CUDA tensors.")
+        device_index = device.index
+        if device_index is None:
+            device_index = torch.cuda.current_device()
+        multi_processor_count = self._multi_processor_count_cache.get(device_index)
+        if multi_processor_count is None:
+            multi_processor_count = torch.cuda.get_device_properties(
+                device_index
+            ).multi_processor_count
+            self._multi_processor_count_cache[device_index] = multi_processor_count
+        return multi_processor_count
 
     def attention(
         self,
@@ -712,6 +729,7 @@ class FlashInferTrtllmGenAttention:
             num_layers=host_kv_cache_pool_mapping.size(0)
             if host_kv_cache_pool_mapping is not None
             else 0,
+            multi_processor_count=self._get_multi_processor_count(q.device),
         )
 
         if num_contexts > 0 and attn_input_type != AttentionInputType.generation_only:
@@ -991,232 +1009,242 @@ class FlashInferTrtllmGenAttention:
         kv_factor = 0
         total_num_blocks = 0
         # KV metadata is cached in Python; these satisfy the fused op signature.
-        kv_cache, block_tables = self._get_kv_cache_and_block_tables(
-            kv_cache_block_offsets=params.kv_cache_block_offsets,
-            host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
-            host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
-            layer_idx=params.layer_idx,
-            num_kv_heads=params.num_kv_heads,
-            tokens_per_block=params.tokens_per_block,
-            head_dim=params.head_size,
-            kv_cache_quant_mode=params.kv_cache_quant_mode,
-            batch_start=params.seq_offset,
-            batch_size=params.batch_size,
-            dtype=params.qkv_input.dtype,
-            is_mla_enable=params.is_mla_enable,
-        )
-        (
-            q_processed,
-            _kv_pool,
-            _block_tables,
-            fmha_workspace,
-            cu_q_seqlens,
-            cu_kv_seqlens,
-            max_q_len,
-            max_kv_len,
-            window_left,
-        ) = thop.trtllm_gen_context_preprocess(
-            qkv_input=params.qkv_input,
-            workspace=params.workspace,
-            sequence_lengths=params.sequence_lengths,
-            context_lengths=params.context_lengths,
-            kv_cache_block_offsets=params.kv_cache_block_offsets,
-            host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
-            host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
-            kv_scale_orig_quant=params.kv_scale_orig_quant,
-            kv_scale_quant_orig=params.kv_scale_quant_orig,
-            attention_output_orig_quant=params.attention_output_orig_quant,
-            rotary_inv_freq=params.rotary_inv_freq,
-            rotary_cos_sin=params.rotary_cos_sin,
-            mrope_rotary_cos_sin=params.mrope_rotary_cos_sin,
-            layer_idx=params.layer_idx,
-            num_heads=params.num_heads,
-            num_kv_heads=params.num_kv_heads,
-            head_size=params.head_size,
-            tokens_per_block=params.tokens_per_block,
-            mask_type=params.mask_type,
-            kv_cache_quant_mode=params.kv_cache_quant_mode,
-            max_attention_window_size=params.max_attention_window_size,
-            cyclic_attention_window_size=params.cyclic_attention_window_size,
-            sink_token_length=params.sink_token_length,
-            num_tokens=params.num_tokens,
-            batch_size=params.batch_size,
-            input_seq_length=params.input_seq_length,
-            max_past_kv_length=params.max_past_kv_length,
-            rotary_embedding_dim=params.rotary_embedding_dim,
-            rotary_embedding_base=params.rotary_embedding_base,
-            rotary_embedding_scale_type=params.rotary_embedding_scale_type,
-            rotary_embedding_scale=params.rotary_embedding_scale,
-            rotary_embedding_max_positions=params.rotary_embedding_max_positions,
-            position_embedding_type=params.position_embedding_type,
-            bmm1_scale=params.bmm1_scale,
-            bmm2_scale=params.bmm2_scale,
-            attention_chunk_size=params.attention_chunk_size,
-            fp8_context_fmha=params.fp8_context_fmha,
-            paged_context_fmha=params.paged_context_fmha,
-            is_mla_enable=params.is_mla_enable,
-            total_num_blocks=total_num_blocks,
-            kv_factor=kv_factor,
-            need_build_kv_cache_metadata=False,
-        )
+        with nvtx_range("trtllm_gen.context.kv_metadata", color="blue"):
+            kv_cache, block_tables = self._get_kv_cache_and_block_tables(
+                kv_cache_block_offsets=params.kv_cache_block_offsets,
+                host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
+                host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
+                layer_idx=params.layer_idx,
+                num_kv_heads=params.num_kv_heads,
+                tokens_per_block=params.tokens_per_block,
+                head_dim=params.head_size,
+                kv_cache_quant_mode=params.kv_cache_quant_mode,
+                batch_start=params.seq_offset,
+                batch_size=params.batch_size,
+                dtype=params.qkv_input.dtype,
+                is_mla_enable=params.is_mla_enable,
+            )
+        with nvtx_range("trtllm_gen.context.preprocess", color="purple"):
+            (
+                q_processed,
+                _kv_pool,
+                _block_tables,
+                fmha_workspace,
+                cu_q_seqlens,
+                cu_kv_seqlens,
+                max_q_len,
+                max_kv_len,
+                window_left,
+            ) = thop.trtllm_gen_context_preprocess(
+                qkv_input=params.qkv_input,
+                workspace=params.workspace,
+                sequence_lengths=params.sequence_lengths,
+                context_lengths=params.context_lengths,
+                kv_cache_block_offsets=params.kv_cache_block_offsets,
+                host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
+                host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
+                kv_scale_orig_quant=params.kv_scale_orig_quant,
+                kv_scale_quant_orig=params.kv_scale_quant_orig,
+                attention_output_orig_quant=params.attention_output_orig_quant,
+                rotary_inv_freq=params.rotary_inv_freq,
+                rotary_cos_sin=params.rotary_cos_sin,
+                mrope_rotary_cos_sin=params.mrope_rotary_cos_sin,
+                layer_idx=params.layer_idx,
+                num_heads=params.num_heads,
+                num_kv_heads=params.num_kv_heads,
+                head_size=params.head_size,
+                tokens_per_block=params.tokens_per_block,
+                mask_type=params.mask_type,
+                kv_cache_quant_mode=params.kv_cache_quant_mode,
+                max_attention_window_size=params.max_attention_window_size,
+                cyclic_attention_window_size=params.cyclic_attention_window_size,
+                sink_token_length=params.sink_token_length,
+                num_tokens=params.num_tokens,
+                batch_size=params.batch_size,
+                input_seq_length=params.input_seq_length,
+                max_past_kv_length=params.max_past_kv_length,
+                rotary_embedding_dim=params.rotary_embedding_dim,
+                rotary_embedding_base=params.rotary_embedding_base,
+                rotary_embedding_scale_type=params.rotary_embedding_scale_type,
+                rotary_embedding_scale=params.rotary_embedding_scale,
+                rotary_embedding_max_positions=params.rotary_embedding_max_positions,
+                position_embedding_type=params.position_embedding_type,
+                bmm1_scale=params.bmm1_scale,
+                bmm2_scale=params.bmm2_scale,
+                attention_chunk_size=params.attention_chunk_size,
+                fp8_context_fmha=params.fp8_context_fmha,
+                paged_context_fmha=params.paged_context_fmha,
+                is_mla_enable=params.is_mla_enable,
+                multi_processor_count=params.multi_processor_count,
+                total_num_blocks=total_num_blocks,
+                kv_factor=kv_factor,
+                need_build_kv_cache_metadata=False,
+            )
 
-        flashinfer.prefill.trtllm_batch_context_with_kv_cache(
-            query=q_processed,
-            kv_cache=kv_cache,
-            workspace_buffer=fmha_workspace,
-            block_tables=block_tables,
-            seq_lens=params.sequence_lengths,
-            max_q_len=max_q_len,
-            max_kv_len=max_kv_len,
-            bmm1_scale=params.bmm1_scale,
-            bmm2_scale=params.bmm2_scale,
-            batch_size=params.batch_size,
-            cum_seq_lens_q=cu_q_seqlens,
-            cum_seq_lens_kv=cu_kv_seqlens,
-            window_left=window_left,
-            out=params.context_buf,
-            kv_layout=self._layout,
-            sinks=params.attention_sinks,
-            uses_shared_paged_kv_idx=False,
-            enable_pdl=self._enable_pdl,
-        )
+        with nvtx_range("trtllm_gen.context.flashinfer", color="green"):
+            flashinfer.prefill.trtllm_batch_context_with_kv_cache(
+                query=q_processed,
+                kv_cache=kv_cache,
+                workspace_buffer=fmha_workspace,
+                block_tables=block_tables,
+                seq_lens=params.sequence_lengths,
+                max_q_len=max_q_len,
+                max_kv_len=max_kv_len,
+                bmm1_scale=params.bmm1_scale,
+                bmm2_scale=params.bmm2_scale,
+                batch_size=params.batch_size,
+                cum_seq_lens_q=cu_q_seqlens,
+                cum_seq_lens_kv=cu_kv_seqlens,
+                window_left=window_left,
+                out=params.context_buf,
+                kv_layout=self._layout,
+                sinks=params.attention_sinks,
+                uses_shared_paged_kv_idx=False,
+                enable_pdl=self._enable_pdl,
+            )
 
-        thop.trtllm_gen_context_postprocess(
-            qkv_input=params.qkv_input,
-            workspace=params.workspace,
-            sequence_lengths=params.sequence_lengths,
-            context_lengths=params.context_lengths,
-            kv_cache_block_offsets=params.kv_cache_block_offsets,
-            host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
-            host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
-            kv_scale_orig_quant=params.kv_scale_orig_quant,
-            kv_scale_quant_orig=params.kv_scale_quant_orig,
-            attention_output_orig_quant=params.attention_output_orig_quant,
-            rotary_cos_sin=params.rotary_cos_sin,
-            mrope_rotary_cos_sin=params.mrope_rotary_cos_sin,
-            layer_idx=params.layer_idx,
-            num_heads=params.num_heads,
-            num_kv_heads=params.num_kv_heads,
-            head_size=params.head_size,
-            tokens_per_block=params.tokens_per_block,
-            mask_type=params.mask_type,
-            kv_cache_quant_mode=params.kv_cache_quant_mode,
-            max_attention_window_size=params.max_attention_window_size,
-            cyclic_attention_window_size=params.cyclic_attention_window_size,
-            sink_token_length=params.sink_token_length,
-            num_tokens=params.num_tokens,
-            batch_size=params.batch_size,
-            input_seq_length=params.input_seq_length,
-            max_past_kv_length=params.max_past_kv_length,
-            rotary_embedding_dim=params.rotary_embedding_dim,
-            rotary_embedding_base=params.rotary_embedding_base,
-            rotary_embedding_scale_type=params.rotary_embedding_scale_type,
-            rotary_embedding_scale=params.rotary_embedding_scale,
-            rotary_embedding_max_positions=params.rotary_embedding_max_positions,
-            position_embedding_type=params.position_embedding_type,
-            bmm1_scale=params.bmm1_scale,
-            fp8_context_fmha=params.fp8_context_fmha,
-            paged_context_fmha=params.paged_context_fmha,
-            is_mla_enable=params.is_mla_enable,
-            attention_chunk_size=params.attention_chunk_size,
-        )
+        with nvtx_range("trtllm_gen.context.postprocess", color="orange"):
+            thop.trtllm_gen_context_postprocess(
+                qkv_input=params.qkv_input,
+                workspace=params.workspace,
+                sequence_lengths=params.sequence_lengths,
+                context_lengths=params.context_lengths,
+                kv_cache_block_offsets=params.kv_cache_block_offsets,
+                host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
+                host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
+                kv_scale_orig_quant=params.kv_scale_orig_quant,
+                kv_scale_quant_orig=params.kv_scale_quant_orig,
+                attention_output_orig_quant=params.attention_output_orig_quant,
+                rotary_cos_sin=params.rotary_cos_sin,
+                mrope_rotary_cos_sin=params.mrope_rotary_cos_sin,
+                layer_idx=params.layer_idx,
+                num_heads=params.num_heads,
+                num_kv_heads=params.num_kv_heads,
+                head_size=params.head_size,
+                tokens_per_block=params.tokens_per_block,
+                mask_type=params.mask_type,
+                kv_cache_quant_mode=params.kv_cache_quant_mode,
+                max_attention_window_size=params.max_attention_window_size,
+                cyclic_attention_window_size=params.cyclic_attention_window_size,
+                sink_token_length=params.sink_token_length,
+                num_tokens=params.num_tokens,
+                batch_size=params.batch_size,
+                input_seq_length=params.input_seq_length,
+                max_past_kv_length=params.max_past_kv_length,
+                rotary_embedding_dim=params.rotary_embedding_dim,
+                rotary_embedding_base=params.rotary_embedding_base,
+                rotary_embedding_scale_type=params.rotary_embedding_scale_type,
+                rotary_embedding_scale=params.rotary_embedding_scale,
+                rotary_embedding_max_positions=params.rotary_embedding_max_positions,
+                position_embedding_type=params.position_embedding_type,
+                bmm1_scale=params.bmm1_scale,
+                fp8_context_fmha=params.fp8_context_fmha,
+                paged_context_fmha=params.paged_context_fmha,
+                is_mla_enable=params.is_mla_enable,
+                attention_chunk_size=params.attention_chunk_size,
+                multi_processor_count=params.multi_processor_count,
+            )
 
     def run_generation(self, params: EnqueueParams):
         batch_beam = params.num_requests * params.beam_width
         kv_factor = 0
         total_num_blocks = 0
         # KV metadata is cached in Python; these satisfy the fused op signature.
-        kv_cache, block_tables = self._get_kv_cache_and_block_tables(
-            kv_cache_block_offsets=params.kv_cache_block_offsets,
-            host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
-            host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
-            layer_idx=params.layer_idx,
-            num_kv_heads=params.num_kv_heads,
-            tokens_per_block=params.tokens_per_block,
-            head_dim=params.head_size,
-            kv_cache_quant_mode=params.kv_cache_quant_mode,
-            batch_start=params.seq_offset,
-            batch_size=batch_beam,
-            dtype=params.qkv_input.dtype,
-            is_mla_enable=params.is_mla_enable,
-        )
-        (
-            q_processed,
-            _kv_pool,
-            _block_tables,
-            fmha_workspace,
-            cu_seqlens,
-            max_q_len,
-            max_kv_len,
-            window_left,
-            is_multi_token_gen,
-        ) = thop.trtllm_gen_generation_preprocess(
-            qkv_input=params.qkv_input,
-            workspace=params.workspace,
-            sequence_lengths=params.sequence_lengths,
-            spec_decoding_generation_lengths=params.spec_decoding_generation_lengths,
-            spec_decoding_position_offsets=params.spec_decoding_position_offsets,
-            kv_cache_block_offsets=params.kv_cache_block_offsets,
-            host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
-            host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
-            kv_scale_orig_quant=params.kv_scale_orig_quant,
-            kv_scale_quant_orig=params.kv_scale_quant_orig,
-            attention_output_orig_quant=params.attention_output_orig_quant,
-            rotary_inv_freq=params.rotary_inv_freq,
-            rotary_cos_sin=params.rotary_cos_sin,
-            layer_idx=params.layer_idx,
-            seq_offset=params.seq_offset,
-            num_heads=params.num_heads,
-            num_kv_heads=params.num_kv_heads,
-            head_size=params.head_size,
-            tokens_per_block=params.tokens_per_block,
-            kv_cache_quant_mode=params.kv_cache_quant_mode,
-            max_attention_window_size=params.max_attention_window_size,
-            cyclic_attention_window_size=params.cyclic_attention_window_size,
-            sink_token_length=params.sink_token_length,
-            num_tokens=params.num_tokens,
-            batch_beam=batch_beam,
-            input_seq_length=params.input_seq_length,
-            max_past_kv_length=params.max_past_kv_length,
-            rotary_embedding_dim=params.rotary_embedding_dim,
-            rotary_embedding_base=params.rotary_embedding_base,
-            rotary_embedding_scale_type=params.rotary_embedding_scale_type,
-            rotary_embedding_scale=params.rotary_embedding_scale,
-            rotary_embedding_max_positions=params.rotary_embedding_max_positions,
-            position_embedding_type=params.position_embedding_type,
-            bmm1_scale=params.bmm1_scale,
-            bmm2_scale=params.bmm2_scale,
-            fp8_context_fmha=params.fp8_context_fmha,
-            predicted_tokens_per_seq=params.predicted_tokens_per_seq,
-            attention_chunk_size=params.attention_chunk_size,
-            total_num_blocks=total_num_blocks,
-            kv_factor=kv_factor,
-            need_build_kv_cache_metadata=False,
-        )
+        with nvtx_range("trtllm_gen.generation.kv_metadata", color="blue"):
+            kv_cache, block_tables = self._get_kv_cache_and_block_tables(
+                kv_cache_block_offsets=params.kv_cache_block_offsets,
+                host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
+                host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
+                layer_idx=params.layer_idx,
+                num_kv_heads=params.num_kv_heads,
+                tokens_per_block=params.tokens_per_block,
+                head_dim=params.head_size,
+                kv_cache_quant_mode=params.kv_cache_quant_mode,
+                batch_start=params.seq_offset,
+                batch_size=batch_beam,
+                dtype=params.qkv_input.dtype,
+                is_mla_enable=params.is_mla_enable,
+            )
+        with nvtx_range("trtllm_gen.generation.preprocess", color="purple"):
+            (
+                q_processed,
+                _kv_pool,
+                _block_tables,
+                fmha_workspace,
+                cu_seqlens,
+                max_q_len,
+                max_kv_len,
+                window_left,
+                is_multi_token_gen,
+            ) = thop.trtllm_gen_generation_preprocess(
+                qkv_input=params.qkv_input,
+                workspace=params.workspace,
+                sequence_lengths=params.sequence_lengths,
+                spec_decoding_generation_lengths=params.spec_decoding_generation_lengths,
+                spec_decoding_position_offsets=params.spec_decoding_position_offsets,
+                kv_cache_block_offsets=params.kv_cache_block_offsets,
+                host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
+                host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
+                kv_scale_orig_quant=params.kv_scale_orig_quant,
+                kv_scale_quant_orig=params.kv_scale_quant_orig,
+                attention_output_orig_quant=params.attention_output_orig_quant,
+                rotary_inv_freq=params.rotary_inv_freq,
+                rotary_cos_sin=params.rotary_cos_sin,
+                layer_idx=params.layer_idx,
+                seq_offset=params.seq_offset,
+                num_heads=params.num_heads,
+                num_kv_heads=params.num_kv_heads,
+                head_size=params.head_size,
+                tokens_per_block=params.tokens_per_block,
+                kv_cache_quant_mode=params.kv_cache_quant_mode,
+                max_attention_window_size=params.max_attention_window_size,
+                cyclic_attention_window_size=params.cyclic_attention_window_size,
+                sink_token_length=params.sink_token_length,
+                num_tokens=params.num_tokens,
+                batch_beam=batch_beam,
+                input_seq_length=params.input_seq_length,
+                max_past_kv_length=params.max_past_kv_length,
+                rotary_embedding_dim=params.rotary_embedding_dim,
+                rotary_embedding_base=params.rotary_embedding_base,
+                rotary_embedding_scale_type=params.rotary_embedding_scale_type,
+                rotary_embedding_scale=params.rotary_embedding_scale,
+                rotary_embedding_max_positions=params.rotary_embedding_max_positions,
+                position_embedding_type=params.position_embedding_type,
+                bmm1_scale=params.bmm1_scale,
+                bmm2_scale=params.bmm2_scale,
+                fp8_context_fmha=params.fp8_context_fmha,
+                predicted_tokens_per_seq=params.predicted_tokens_per_seq,
+                attention_chunk_size=params.attention_chunk_size,
+                multi_processor_count=params.multi_processor_count,
+                total_num_blocks=total_num_blocks,
+                kv_factor=kv_factor,
+                need_build_kv_cache_metadata=False,
+            )
 
         q_len_per_req = None if is_multi_token_gen else params.input_seq_length
         decode_max_q_len = max_q_len if is_multi_token_gen else None
         decode_cu_seqlens = cu_seqlens if is_multi_token_gen else None
-        flashinfer.decode.trtllm_batch_decode_with_kv_cache(
-            query=q_processed,
-            kv_cache=kv_cache,
-            workspace_buffer=fmha_workspace,
-            block_tables=block_tables,
-            seq_lens=params.sequence_lengths,
-            max_seq_len=max_kv_len,
-            out=params.context_buf,
-            bmm1_scale=params.bmm1_scale,
-            bmm2_scale=params.bmm2_scale,
-            window_left=window_left,
-            kv_layout=self._layout,
-            sinks=params.attention_sinks,
-            q_len_per_req=q_len_per_req,
-            max_q_len=decode_max_q_len,
-            cum_seq_lens_q=decode_cu_seqlens,
-            uses_shared_paged_kv_idx=False,
-            enable_pdl=self._enable_pdl,
-            backend="trtllm-gen",
-        )
+        with nvtx_range("trtllm_gen.generation.flashinfer", color="green"):
+            flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+                query=q_processed,
+                kv_cache=kv_cache,
+                workspace_buffer=fmha_workspace,
+                block_tables=block_tables,
+                seq_lens=params.sequence_lengths,
+                max_seq_len=max_kv_len,
+                out=params.context_buf,
+                bmm1_scale=params.bmm1_scale,
+                bmm2_scale=params.bmm2_scale,
+                window_left=window_left,
+                kv_layout=self._layout,
+                sinks=params.attention_sinks,
+                q_len_per_req=q_len_per_req,
+                max_q_len=decode_max_q_len,
+                cum_seq_lens_q=decode_cu_seqlens,
+                uses_shared_paged_kv_idx=False,
+                enable_pdl=self._enable_pdl,
+                backend="trtllm-gen",
+            )
 
     def run_mla_generation(self, params: EnqueueParams) -> None:
         """MLA generation decode using flashinfer MLA kernel."""
@@ -1228,60 +1256,66 @@ class FlashInferTrtllmGenAttention:
             raise NotImplementedError("Chunked-attention is not supported by MLA decode path.")
 
         batch_beam = params.num_requests * params.beam_width
-        kv_cache_tuple, block_tables = self._get_kv_cache_and_block_tables(
-            kv_cache_block_offsets=params.kv_cache_block_offsets,
-            host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
-            host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
-            layer_idx=params.layer_idx,
-            num_kv_heads=params.num_kv_heads,
-            tokens_per_block=params.tokens_per_block,
-            head_dim=params.head_size,
-            kv_cache_quant_mode=params.kv_cache_quant_mode,
-            batch_start=params.seq_offset,
-            batch_size=batch_beam,
-            dtype=params.attention_input.dtype,
-            is_mla_enable=params.is_mla_enable,
-        )
+        with nvtx_range("trtllm_gen.mla.kv_metadata", color="blue"):
+            kv_cache_tuple, block_tables = self._get_kv_cache_and_block_tables(
+                kv_cache_block_offsets=params.kv_cache_block_offsets,
+                host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
+                host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
+                layer_idx=params.layer_idx,
+                num_kv_heads=params.num_kv_heads,
+                tokens_per_block=params.tokens_per_block,
+                head_dim=params.head_size,
+                kv_cache_quant_mode=params.kv_cache_quant_mode,
+                batch_start=params.seq_offset,
+                batch_size=batch_beam,
+                dtype=params.attention_input.dtype,
+                is_mla_enable=params.is_mla_enable,
+            )
 
-        # MLA decode API takes a single kv tensor [num_pages, 1, page_size, head_dim],
-        # not the (K_pool, V_pool) tuple.
-        kv_cache = kv_cache_tuple[0]
+            # MLA decode API takes a single kv tensor [num_pages, 1, page_size, head_dim],
+            # not the (K_pool, V_pool) tuple.
+            kv_cache = kv_cache_tuple[0]
 
-        pages_per_superblock = 128 // params.tokens_per_block
-        if pages_per_superblock > 1:
-            num_blocks = block_tables.size(-1)
-            remainder = num_blocks % pages_per_superblock
-            if remainder != 0:
-                pad = pages_per_superblock - remainder
-                block_tables = torch.nn.functional.pad(block_tables, (0, pad), value=0)
+        with nvtx_range("trtllm_gen.mla.block_table_pad", color="yellow"):
+            pages_per_superblock = 128 // params.tokens_per_block
+            if pages_per_superblock > 1:
+                num_blocks = block_tables.size(-1)
+                remainder = num_blocks % pages_per_superblock
+                if remainder != 0:
+                    pad = pages_per_superblock - remainder
+                    block_tables = torch.nn.functional.pad(block_tables, (0, pad), value=0)
 
-        mla_head_dim_qk = params.kv_lora_rank + params.qk_rope_head_dim
-        q_len_per_req = params.num_tokens // batch_beam if batch_beam > 0 else 1
+        with nvtx_range("trtllm_gen.mla.prepare", color="purple"):
+            mla_head_dim_qk = params.kv_lora_rank + params.qk_rope_head_dim
+            q_len_per_req = params.num_tokens // batch_beam if batch_beam > 0 else 1
 
-        query = params.qkv_input.view(batch_beam, q_len_per_req, params.num_heads, mla_head_dim_qk)
+            query = params.qkv_input.view(
+                batch_beam, q_len_per_req, params.num_heads, mla_head_dim_qk
+            )
 
-        bmm1_scale = 1.0 / (
-            params.q_scaling * math.sqrt(params.qk_nope_head_dim + params.qk_rope_head_dim)
-        )
-        bmm2_scale = 1.0
+            bmm1_scale = 1.0 / (
+                params.q_scaling * math.sqrt(params.qk_nope_head_dim + params.qk_rope_head_dim)
+            )
+            bmm2_scale = 1.0
 
-        flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla(
-            query=query,
-            kv_cache=kv_cache,
-            workspace_buffer=params.workspace.view(-1, 4),
-            qk_nope_head_dim=params.qk_nope_head_dim,
-            kv_lora_rank=params.kv_lora_rank,
-            qk_rope_head_dim=params.qk_rope_head_dim,
-            block_tables=block_tables,
-            seq_lens=params.sequence_lengths,
-            max_seq_len=params.max_past_kv_length,
-            out=params.context_buf.view(
-                batch_beam, q_len_per_req, params.num_heads, params.kv_lora_rank
-            ),
-            bmm1_scale=bmm1_scale,
-            bmm2_scale=bmm2_scale,
-            sinks=params.attention_sinks,
-            uses_shared_paged_kv_idx=False,
-            enable_pdl=self._enable_pdl,
-            backend="trtllm-gen",
-        )
+        with nvtx_range("trtllm_gen.mla.flashinfer", color="green"):
+            flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla(
+                query=query,
+                kv_cache=kv_cache,
+                workspace_buffer=params.workspace.view(-1, 4),
+                qk_nope_head_dim=params.qk_nope_head_dim,
+                kv_lora_rank=params.kv_lora_rank,
+                qk_rope_head_dim=params.qk_rope_head_dim,
+                block_tables=block_tables,
+                seq_lens=params.sequence_lengths,
+                max_seq_len=params.max_past_kv_length,
+                out=params.context_buf.view(
+                    batch_beam, q_len_per_req, params.num_heads, params.kv_lora_rank
+                ),
+                bmm1_scale=bmm1_scale,
+                bmm2_scale=bmm2_scale,
+                sinks=params.attention_sinks,
+                uses_shared_paged_kv_idx=False,
+                enable_pdl=self._enable_pdl,
+                backend="trtllm-gen",
+            )

--- a/tensorrt_llm/_torch/attention_backend/trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm_gen.py
@@ -12,20 +12,21 @@ Architecture:
       kv_cache_manager.get_buffers() (flashinfer tensor format).
 
 Entry points:
-    is_supported()           - Check if trtllm-gen can handle the given config.
-    trtllm_gen_attention()   - Main attention function (called from TrtllmAttention.run).
+    FlashInferTrtllmGenAttention.is_supported()  - Check if trtllm-gen can handle the given config.
+    FlashInferTrtllmGenAttention.attention()      - Main attention method (called from TrtllmAttention.run).
 
 Example:
-    # Check if configuration is supported
-    supported, reason = is_supported(num_heads=32, num_kv_heads=8, ...)
+    backend = FlashInferTrtllmGenAttention(kv_cache_manager=..., quant_config=...)
+    supported, reason = backend.is_supported(num_heads=32, num_kv_heads=8, ...)
     if supported:
-        trtllm_gen_attention(q, k, v, output, ...)
+        backend.attention(q, k, v, output, ...)
     else:
         Fallback to thop.attention()
 """
 
 import math
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import List, Optional, Tuple
 
 import torch
@@ -37,22 +38,13 @@ if IS_FLASHINFER_AVAILABLE:
 
 from tensorrt_llm._torch.attention_backend.interface import AttentionInputType
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
-from tensorrt_llm._utils import (
-    get_size_in_bytes,
-    get_sm_version,
-    is_sm_100f,
-    torch_dtype_to_binding,
-)
+from tensorrt_llm._utils import get_sm_version, is_sm_100f
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import AttentionMaskType
 from tensorrt_llm.logger import logger
 from tensorrt_llm.models.modeling_utils import QuantConfig
 from tensorrt_llm.quantization.mode import QuantMode
-
-# Default KV layout for flashinfer
-# HND = [max_num_pages, kv_factor, num_kv_heads, page_size, head_dim]
-DEFAULT_KV_LAYOUT = "HND"
 
 
 class TrtllmGenSupportChecker:
@@ -272,554 +264,128 @@ class TrtllmGenSupportChecker:
         return True, ""
 
 
+@lru_cache(maxsize=128)
+def _get_context_workspace_layout(
+    dtype: torch.dtype,
+    batch_size: int,
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    rotary_embedding_dim: int,
+) -> dict[str, int]:
+    return thop.get_trtllm_gen_context_workspace_layout(
+        dtype,
+        batch_size,
+        num_tokens,
+        num_heads,
+        head_size,
+        rotary_embedding_dim,
+        True,
+        False,
+    )
+
+
+@lru_cache(maxsize=128)
+def _get_context_workspace_size(
+    dtype: torch.dtype,
+    max_num_seq: int,
+    max_num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    rotary_embedding_dim: int,
+) -> int:
+    if max_num_tokens == 0:
+        return 0
+    layout = _get_context_workspace_layout(
+        dtype,
+        max_num_seq,
+        max_num_tokens,
+        num_heads,
+        head_size,
+        rotary_embedding_dim,
+    )
+    return int(layout["total_size"])
+
+
+@lru_cache(maxsize=128)
+def _get_generation_workspace_layout(
+    dtype: torch.dtype,
+    batch_beam: int,
+    num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    num_kv_heads: int,
+    rotary_embedding_dim: int,
+) -> dict[str, int]:
+    return thop.get_trtllm_gen_generation_workspace_layout(
+        dtype,
+        batch_beam,
+        num_tokens,
+        num_heads,
+        head_size,
+        rotary_embedding_dim,
+        num_kv_heads,
+    )
+
+
+@lru_cache(maxsize=128)
+def _get_generation_workspace_size(
+    dtype: torch.dtype,
+    max_num_seq: int,
+    max_num_tokens: int,
+    num_heads: int,
+    head_size: int,
+    num_kv_heads: int,
+    rotary_embedding_dim: int,
+) -> int:
+    if max_num_tokens == 0:
+        return 0
+    if num_kv_heads <= 0:
+        num_kv_heads = num_heads
+    layout = _get_generation_workspace_layout(
+        dtype,
+        max_num_seq,
+        max_num_tokens,
+        num_heads,
+        head_size,
+        num_kv_heads,
+        rotary_embedding_dim,
+    )
+    return int(layout["total_size"])
+
+
+@lru_cache(maxsize=128)
+def _get_workspace_size(
+    dtype: torch.dtype,
+    num_tokens: int,
+    num_gen_tokens: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    max_num_requests: int,
+    rotary_embedding_dim: int,
+) -> int:
+    context_size = _get_context_workspace_size(
+        dtype,
+        max_num_requests,
+        num_tokens,
+        num_heads,
+        head_size,
+        rotary_embedding_dim,
+    )
+    generation_size = _get_generation_workspace_size(
+        dtype,
+        max_num_requests,
+        num_gen_tokens,
+        num_heads,
+        head_size,
+        num_kv_heads,
+        rotary_embedding_dim,
+    )
+    return max(context_size, generation_size)
+
+
 @dataclass(slots=True)
-class ContextWorkspaceBuffers:
-    """
-    Workspace buffers for context phase.
-    """
-
-    # Trtllm-gen workspace
-    trtllm_gen_workspace: Optional[torch.Tensor] = None
-
-    # Cumulative sequence lengths
-    cu_q_seqlens: Optional[torch.Tensor] = None
-    cu_kv_seqlens: Optional[torch.Tensor] = None
-    cu_mask_rows: Optional[torch.Tensor] = None
-
-    # Rotary embedding inverse frequencies
-    rotary_inv_freq_buf: Optional[torch.Tensor] = None
-
-    # Q buffer (FMHA output buffer for qkv_preprocessing)
-    q_buf: Optional[torch.Tensor] = None
-
-    # Token info: (batch_idx, token_idx_in_seq) per token
-    tokens_info: Optional[torch.Tensor] = None
-
-    # FMHA scheduler
-    fmha_tile_counter: Optional[torch.Tensor] = None
-
-    # BMM scales for FP8
-    fmha_bmm1_scale: Optional[torch.Tensor] = None
-    fmha_bmm2_scale: Optional[torch.Tensor] = None
-
-
-@dataclass(slots=True)
-class GenerationWorkspaceBuffers:
-    """
-    Workspace buffers for generation phase.
-    """
-
-    # Flashinfer / trtllm-gen FMHA workspace (multi-block handled internally)
-    trtllm_gen_workspace: Optional[torch.Tensor] = None
-
-    # Cumulative sequence lengths
-    cu_seqlens: Optional[torch.Tensor] = None
-    cu_kv_seqlens: Optional[torch.Tensor] = None
-
-    # Rotary embedding inverse frequencies
-    rotary_inv_freq: Optional[torch.Tensor] = None
-
-    # Token info
-    tokens_info: Optional[torch.Tensor] = None
-
-    # Query buffer (output of qkv_preprocessing, input to FMHA)
-    q_buf: Optional[torch.Tensor] = None
-
-    # BMM scales
-    bmm1_scale: Optional[torch.Tensor] = None
-    bmm2_scale: Optional[torch.Tensor] = None
-
-    # Sparse attention cache
-    sparse_attn_cache: Optional[torch.Tensor] = None
-
-
-class WorkspaceManager:
-    """
-    Manages workspace allocation for attention computation.
-    """
-
-    # Alignment for workspace buffers (256 bytes) (same as C++ kCudaMemAlign constant).
-    ALIGNMENT = 256
-
-    # C/CUDA type sizes in bytes, mirroring sizeof() semantics.
-    SIZEOF_INT32 = 4
-    SIZEOF_FLOAT32 = 4
-    SIZEOF_INT2 = 8  # CUDA int2: two int32_t packed
-    SIZEOF_FP8 = 1
-
-    # Flashinfer recommends 128MB workspace, but 32MB is sufficient for
-    # trtllm-gen FMHA kernels.
-    # https://github.com/flashinfer-ai/flashinfer/blob/main/flashinfer/prefill.py#L1378
-    TRTLLM_GEN_WORKSPACE_SIZE = 32 * 1024 * 1024
-
-    @staticmethod
-    def _align_size(size: int) -> int:
-        """Align size to kernel alignment requirement."""
-        alignment = WorkspaceManager.ALIGNMENT
-        if (size % alignment) != 0:
-            size += alignment - (size % alignment)
-        return size
-
-    @classmethod
-    def _calculate_total_workspace_size(cls, workspaces: List[int], alignment: int = None) -> int:
-        """
-        Calculate total workspace size with alignment.
-
-        Args:
-            workspaces: List of workspace sizes.
-            alignment: Alignment boundary (default: ALIGNMENT).
-
-        Returns:
-            Total aligned workspace size.
-        """
-        if alignment is None:
-            alignment = cls.ALIGNMENT
-        total = 0
-        for ws in workspaces:
-            total += ws
-            if ws % alignment:
-                total += alignment - (ws % alignment)
-        return total
-
-    @classmethod
-    def get_context_workspace_size(
-        cls,
-        dtype: torch.dtype,
-        max_num_seq: int,
-        max_num_tokens: int,
-        num_heads: int,
-        head_size: int,
-        rotary_embedding_dim: int = 0,
-        separate_q_kv_input: bool = True,
-        fp8_context_fmha: bool = False,
-    ) -> int:
-        """
-        Calculate workspace size for context phase.
-
-        Args:
-            dtype: Data type for attention computation.
-            max_num_seq: Maximum number of sequences (batch_size).
-            max_num_tokens: Maximum number of tokens.
-            num_heads: Number of query attention heads.
-            head_size: Size of each attention head.
-            rotary_embedding_dim: Rotary embedding dimension (0 if not used).
-            separate_q_kv_input: Whether Q and KV inputs are separate (paged FMHA).
-            fp8_context_fmha: Whether FP8 context FMHA is used.
-
-        Returns:
-            Workspace size in bytes.
-        """
-        if max_num_tokens == 0:
-            return 0
-
-        # Convert torch dtype to binding dtype for get_size_in_bytes
-        binding_dtype = torch_dtype_to_binding(dtype)
-        dtype_size = get_size_in_bytes(dtype=binding_dtype, num_elements=1)
-
-        local_hidden_units_qo = num_heads * head_size
-        batch_size = max_num_seq
-
-        cu_seqlens_size = cls.SIZEOF_INT32 * (batch_size + 1)
-        rotary_inv_freq_size = (
-            cls.SIZEOF_FLOAT32 * batch_size * rotary_embedding_dim // 2
-            if rotary_embedding_dim > 0
-            else 0
-        )
-
-        q_buf_2_size = 0
-        if separate_q_kv_input:
-            q_buf_2_size = (
-                (cls.SIZEOF_FP8 if fp8_context_fmha else dtype_size)
-                * max_num_tokens
-                * local_hidden_units_qo
-            )
-
-        tokens_info_size = cls.SIZEOF_INT2 * max_num_tokens
-        fmha_scheduler_counter = cls.SIZEOF_INT32
-        fmha_bmm1_scale_size = cls.SIZEOF_FLOAT32 * 2 if fp8_context_fmha else 0
-        fmha_bmm2_scale_size = cls.SIZEOF_FLOAT32 if fp8_context_fmha else 0
-
-        # Build workspace array
-        workspaces = [
-            cls.TRTLLM_GEN_WORKSPACE_SIZE,
-            cu_seqlens_size,  # cu_seqlen_q
-            cu_seqlens_size,  # cu_seqlen_kv
-            cu_seqlens_size,  # cu_mask_rows
-            rotary_inv_freq_size,
-            q_buf_2_size,
-            tokens_info_size,
-            fmha_scheduler_counter,
-            fmha_bmm1_scale_size,
-            fmha_bmm2_scale_size,
-        ]
-
-        return cls._calculate_total_workspace_size(workspaces)
-
-    @classmethod
-    def get_generation_workspace_size(
-        cls,
-        dtype: torch.dtype,
-        max_num_seq: int,
-        max_num_tokens: int,
-        num_heads: int,
-        head_size: int,
-        num_kv_heads: int = None,
-        rotary_embedding_dim: int = 0,
-    ) -> int:
-        """
-        Calculate workspace size for generation (decode) phase.
-
-        Args:
-            dtype: Data type for attention computation.
-            max_num_seq: Maximum number of sequences (batch_beam).
-            max_num_tokens: Maximum number of tokens.
-            num_heads: Number of query attention heads.
-            head_size: Size of each attention head.
-            num_kv_heads: Number of KV heads (defaults to num_heads).
-            rotary_embedding_dim: Rotary embedding dimension.
-
-        Returns:
-            Workspace size in bytes.
-        """
-        if max_num_tokens == 0:
-            return 0
-
-        if num_kv_heads is None:
-            num_kv_heads = num_heads
-
-        binding_dtype = torch_dtype_to_binding(dtype)
-        dtype_size = get_size_in_bytes(dtype=binding_dtype, num_elements=1)
-        batch_beam = max_num_seq
-
-        cu_seqlens_size = cls.SIZEOF_INT32 * (batch_beam + 1)
-        cu_kv_seqlens_size = cls.SIZEOF_INT32 * (batch_beam + 1)
-        rotary_inv_freq_size = (
-            cls.SIZEOF_FLOAT32 * batch_beam * rotary_embedding_dim // 2
-            if rotary_embedding_dim > 0
-            else 0
-        )
-        tokens_info_size = cls.SIZEOF_INT2 * max_num_tokens
-        q_buf_size = dtype_size * max_num_tokens * num_heads * head_size
-        bmm1_scale_size = cls.SIZEOF_FLOAT32 * 2
-        bmm2_scale_size = cls.SIZEOF_FLOAT32
-
-        generation_workspaces = [
-            cls.TRTLLM_GEN_WORKSPACE_SIZE,
-            cu_seqlens_size,
-            cu_kv_seqlens_size,
-            rotary_inv_freq_size,
-            tokens_info_size,
-            q_buf_size,
-            bmm1_scale_size,
-            bmm2_scale_size,
-        ]
-
-        return cls._calculate_total_workspace_size(generation_workspaces)
-
-    @classmethod
-    def get_workspace_size(
-        cls,
-        dtype: torch.dtype,
-        num_tokens: int,
-        num_gen_tokens: int,
-        num_heads: int,
-        num_kv_heads: int,
-        head_size: int,
-        max_num_requests: int,
-        rotary_embedding_dim: int = 0,
-    ) -> int:
-        """
-        Calculate total workspace size.
-
-        Returns max(context_workspace, generation_workspace).
-        """
-        if num_kv_heads <= 0:
-            num_kv_heads = num_heads
-
-        context_size = cls.get_context_workspace_size(
-            dtype=dtype,
-            max_num_seq=max_num_requests,
-            max_num_tokens=num_tokens,
-            num_heads=num_heads,
-            head_size=head_size,
-            rotary_embedding_dim=rotary_embedding_dim,
-            separate_q_kv_input=True,
-        )
-
-        generation_size = cls.get_generation_workspace_size(
-            dtype=dtype,
-            max_num_seq=max_num_requests,
-            max_num_tokens=num_gen_tokens,
-            num_heads=num_heads,
-            head_size=head_size,
-            num_kv_heads=num_kv_heads,
-            rotary_embedding_dim=rotary_embedding_dim,
-        )
-
-        min_workspace_size = cls.TRTLLM_GEN_WORKSPACE_SIZE
-        return max(context_size, generation_size, min_workspace_size)
-
-    @classmethod
-    def _next_workspace_ptr(
-        cls, base_offset: int, size: int, alignment: int = None
-    ) -> Tuple[int, int]:
-        """
-        Calculate next workspace pointer offset with alignment.
-
-        Args:
-            base_offset: Current offset in workspace buffer.
-            size: Size of the buffer to allocate.
-            alignment: Alignment boundary.
-
-        Returns:
-            Tuple of (buffer_offset, new_base_offset).
-        """
-        if alignment is None:
-            alignment = cls.ALIGNMENT
-        curr_offset = base_offset
-        next_offset = curr_offset + ((size + alignment - 1) // alignment) * alignment
-        buffer_offset = curr_offset if size > 0 else -1  # -1 indicates nullptr
-        return buffer_offset, next_offset
-
-    @classmethod
-    def _get_view(
-        cls,
-        workspace: torch.Tensor,
-        buf_offset: int,
-        size: int,
-        view_dtype: torch.dtype,
-    ) -> Optional[torch.Tensor]:
-        """
-        Get a view of the workspace buffer.
-
-        Args:
-            workspace: Workspace tensor.
-            buf_offset: Buffer offset.
-            size: Buffer size.
-            view_dtype: View data type.
-
-        Returns:
-            View of the workspace buffer.
-        """
-        if workspace is None or buf_offset < 0 or size == 0:
-            return None
-
-        workspace_byte = workspace.view(torch.uint8)
-        # Validate workspace bounds
-        end_offset = buf_offset + size
-        if end_offset > workspace_byte.numel():
-            raise RuntimeError(
-                f"[trtllm-gen] Split workspace buffer overflow! "
-                f"Trying to access [{buf_offset}:{end_offset}] "
-                f"but workspace size is only {workspace_byte.numel()} bytes. "
-                f"Buffer size needed: {size} bytes"
-            )
-        return workspace_byte[buf_offset : buf_offset + size].view(view_dtype)
-
-    @classmethod
-    def split_context_workspace(
-        cls,
-        workspace: torch.Tensor,
-        dtype: torch.dtype,
-        batch_size: int,
-        num_tokens: int,
-        num_heads: int,
-        head_size: int,
-        rotary_embedding_dim: int = 0,
-        separate_q_kv_input: bool = True,
-        fp8_context_fmha: bool = False,
-        fp8_context_mla: bool = False,
-    ) -> ContextWorkspaceBuffers:
-        """
-        Split workspace buffer into sub-buffers for context phase.
-
-        Args:
-            workspace: Workspace tensor (contiguous byte buffer).
-            dtype: Data type for attention computation.
-            batch_size: Batch size.
-            num_tokens: Number of tokens.
-            num_heads: Number of query attention heads.
-            head_size: Size of each attention head.
-            rotary_embedding_dim: Rotary embedding dimension.
-            separate_q_kv_input: Whether Q and KV inputs are separate.
-            fp8_context_fmha: Whether FP8 context FMHA is used.
-            fp8_context_mla: Whether FP8 context MLA is used.
-
-        Returns:
-            Dictionary containing sub-buffer views and metadata:
-            {
-                'cu_q_seqlens': Tensor,
-                'cu_kv_seqlens': Tensor,
-                'cu_mask_rows': Tensor,
-                'rotary_inv_freq_buf': Tensor or None,
-                'q_buf': Tensor or None,
-                'tokens_info': Tensor,
-                'fmha_tile_counter': Tensor or None,
-                'fmha_bmm1_scale': Tensor or None,
-                'fmha_bmm2_scale': Tensor or None,
-            }
-        """
-        binding_dtype = torch_dtype_to_binding(dtype)
-        dtype_size = get_size_in_bytes(dtype=binding_dtype, num_elements=1)
-
-        local_hidden_units_qo = num_heads * head_size
-        cu_seqlens_size = cls.SIZEOF_INT32 * (batch_size + 1)
-        rotary_inv_freq_size = (
-            cls.SIZEOF_FLOAT32 * batch_size * rotary_embedding_dim // 2
-            if rotary_embedding_dim > 0
-            else 0
-        )
-
-        # Q buffer size (paged context FMHA)
-        q_buf_2_size = 0
-        if separate_q_kv_input:
-            q_buf_2_size = (
-                (cls.SIZEOF_FP8 if fp8_context_fmha else dtype_size)
-                * num_tokens
-                * local_hidden_units_qo
-            )
-
-        tokens_info_size = cls.SIZEOF_INT2 * num_tokens
-        fmha_scheduler_counter = cls.SIZEOF_INT32
-        fmha_bmm1_scale_size = (
-            cls.SIZEOF_FLOAT32 * 2 if (fp8_context_fmha or fp8_context_mla) else 0
-        )
-        fmha_bmm2_scale_size = cls.SIZEOF_FLOAT32 if (fp8_context_fmha or fp8_context_mla) else 0
-
-        offset = 0
-        trtllm_gen_workspace, offset = cls._next_workspace_ptr(
-            offset, cls.TRTLLM_GEN_WORKSPACE_SIZE
-        )
-        cu_q_seqlens_offset, offset = cls._next_workspace_ptr(offset, cu_seqlens_size)
-        cu_kv_seqlens_offset, offset = cls._next_workspace_ptr(offset, cu_seqlens_size)
-        cu_mask_rows_offset, offset = cls._next_workspace_ptr(offset, cu_seqlens_size)
-        rotary_inv_freq_offset, offset = cls._next_workspace_ptr(offset, rotary_inv_freq_size)
-        q_buf_offset, offset = cls._next_workspace_ptr(offset, q_buf_2_size)
-        tokens_info_offset, offset = cls._next_workspace_ptr(offset, tokens_info_size)
-        fmha_tile_counter_offset, offset = cls._next_workspace_ptr(offset, fmha_scheduler_counter)
-        fmha_bmm1_scale_offset, offset = cls._next_workspace_ptr(offset, fmha_bmm1_scale_size)
-        fmha_bmm2_scale_offset, offset = cls._next_workspace_ptr(offset, fmha_bmm2_scale_size)
-
-        q_buf_dtype = torch.uint8 if fp8_context_fmha else dtype
-        return ContextWorkspaceBuffers(
-            trtllm_gen_workspace=cls._get_view(
-                workspace, trtllm_gen_workspace, cls.TRTLLM_GEN_WORKSPACE_SIZE, torch.uint8
-            ),
-            cu_q_seqlens=cls._get_view(
-                workspace, cu_q_seqlens_offset, cu_seqlens_size, torch.int32
-            ),
-            cu_kv_seqlens=cls._get_view(
-                workspace, cu_kv_seqlens_offset, cu_seqlens_size, torch.int32
-            ),
-            cu_mask_rows=cls._get_view(
-                workspace, cu_mask_rows_offset, cu_seqlens_size, torch.int32
-            ),
-            rotary_inv_freq_buf=cls._get_view(
-                workspace, rotary_inv_freq_offset, rotary_inv_freq_size, torch.float32
-            ),
-            q_buf=cls._get_view(workspace, q_buf_offset, q_buf_2_size, q_buf_dtype),
-            tokens_info=cls._get_view(workspace, tokens_info_offset, tokens_info_size, torch.int32),
-            fmha_tile_counter=cls._get_view(
-                workspace, fmha_tile_counter_offset, fmha_scheduler_counter, torch.uint32
-            ),
-            fmha_bmm1_scale=cls._get_view(
-                workspace, fmha_bmm1_scale_offset, fmha_bmm1_scale_size, torch.float32
-            ),
-            fmha_bmm2_scale=cls._get_view(
-                workspace, fmha_bmm2_scale_offset, fmha_bmm2_scale_size, torch.float32
-            ),
-        )
-
-    @classmethod
-    def split_generation_workspace(
-        cls,
-        workspace: torch.Tensor,
-        dtype: torch.dtype,
-        batch_beam: int,
-        num_tokens: int,
-        num_heads: int,
-        head_size: int,
-        rotary_embedding_dim: int = 0,
-        num_kv_heads: int = None,
-        max_blocks_per_sequence: int = 0,
-        use_sparse_attention: bool = False,
-    ) -> GenerationWorkspaceBuffers:
-        """
-        Split workspace buffer into sub-buffers for generation phase.
-
-        Args:
-            workspace: Workspace tensor (contiguous byte buffer).
-            dtype: Data type for attention computation.
-            batch_beam: Batch size * beam width.
-            num_tokens: Number of tokens.
-            num_heads: Number of query attention heads.
-            head_size: Size of each attention head.
-            rotary_embedding_dim: Rotary embedding dimension.
-            num_kv_heads: Number of KV heads.
-            max_blocks_per_sequence: Maximum blocks per sequence.
-            use_sparse_attention: Whether sparse attention is used.
-
-        Returns:
-            GenerationWorkspaceBuffers containing sub-buffer views.
-        """
-        if num_kv_heads is None:
-            num_kv_heads = num_heads
-
-        binding_dtype = torch_dtype_to_binding(dtype)
-        dtype_size = get_size_in_bytes(dtype=binding_dtype, num_elements=1)
-
-        cu_seqlens_size = cls.SIZEOF_INT32 * (batch_beam + 1)
-        cu_kv_seqlens_size = cls.SIZEOF_INT32 * (batch_beam + 1)
-        rotary_inv_freq_size = (
-            cls.SIZEOF_FLOAT32 * batch_beam * rotary_embedding_dim // 2
-            if rotary_embedding_dim > 0
-            else 0
-        )
-        tokens_info_size = cls.SIZEOF_INT2 * num_tokens
-        q_buf_size = dtype_size * num_tokens * num_heads * head_size
-        bmm1_scale_size = cls.SIZEOF_FLOAT32 * 2
-        bmm2_scale_size = cls.SIZEOF_FLOAT32
-        sparse_attn_cache_size = (
-            4 * (batch_beam + batch_beam * 2 * max_blocks_per_sequence) * num_kv_heads
-            if use_sparse_attention
-            else 0
-        )
-
-        offset = 0
-        trtllm_gen_workspace, offset = cls._next_workspace_ptr(
-            offset, cls.TRTLLM_GEN_WORKSPACE_SIZE
-        )
-        cu_seqlens_offset, offset = cls._next_workspace_ptr(offset, cu_seqlens_size)
-        cu_kv_seqlens_offset, offset = cls._next_workspace_ptr(offset, cu_kv_seqlens_size)
-        rotary_inv_freq_offset, offset = cls._next_workspace_ptr(offset, rotary_inv_freq_size)
-        tokens_info_offset, offset = cls._next_workspace_ptr(offset, tokens_info_size)
-        q_buf_offset, offset = cls._next_workspace_ptr(offset, q_buf_size)
-        bmm1_scale_offset, offset = cls._next_workspace_ptr(offset, bmm1_scale_size)
-        bmm2_scale_offset, offset = cls._next_workspace_ptr(offset, bmm2_scale_size)
-        sparse_attn_cache_offset, offset = cls._next_workspace_ptr(offset, sparse_attn_cache_size)
-
-        return GenerationWorkspaceBuffers(
-            trtllm_gen_workspace=cls._get_view(
-                workspace, trtllm_gen_workspace, cls.TRTLLM_GEN_WORKSPACE_SIZE, torch.uint8
-            ),
-            cu_seqlens=cls._get_view(workspace, cu_seqlens_offset, cu_seqlens_size, torch.int32),
-            cu_kv_seqlens=cls._get_view(
-                workspace, cu_kv_seqlens_offset, cu_kv_seqlens_size, torch.int32
-            ),
-            rotary_inv_freq=cls._get_view(
-                workspace, rotary_inv_freq_offset, rotary_inv_freq_size, torch.float32
-            ),
-            tokens_info=cls._get_view(workspace, tokens_info_offset, tokens_info_size, torch.int32),
-            q_buf=cls._get_view(workspace, q_buf_offset, q_buf_size, dtype),
-            bmm1_scale=cls._get_view(workspace, bmm1_scale_offset, bmm1_scale_size, torch.float32),
-            bmm2_scale=cls._get_view(workspace, bmm2_scale_offset, bmm2_scale_size, torch.float32),
-            sparse_attn_cache=cls._get_view(
-                workspace, sparse_attn_cache_offset, sparse_attn_cache_size, torch.int32
-            ),
-        )
-
-
-@dataclass
 class EnqueueParams:
     attention_input: Optional[torch.Tensor] = None
     qkv_input: Optional[torch.Tensor] = None
@@ -874,16 +440,8 @@ class EnqueueParams:
     q_scaling: float = 1.0
     latent_cache: Optional[torch.Tensor] = None
     num_layers: int = 0
-
-
-@dataclass
-class EnqueueContextParams(EnqueueParams):
     batch_size: int = 0
     mrope_rotary_cos_sin: Optional[torch.Tensor] = None
-
-
-@dataclass
-class EnqueueGenerationParams(EnqueueParams):
     beam_width: int = 1
     num_requests: int = 0
     predicted_tokens_per_seq: int = 1
@@ -897,15 +455,28 @@ class FlashInferTrtllmGenAttention:
     An attention backend using pure trtllm-gen kernels from flashinfer.
     """
 
+    # Default KV layout for flashinfer
+    # HND = [max_num_pages, kv_factor, num_kv_heads, page_size, head_dim]
+    DEFAULT_KV_LAYOUT = "HND"
+
     def __init__(
         self,
         kv_cache_manager: Optional[KVCacheManager] = None,
         quant_config: Optional[QuantConfig] = None,
     ):
         self._checker = TrtllmGenSupportChecker()
-        self._layout = DEFAULT_KV_LAYOUT
+        self._layout = self.DEFAULT_KV_LAYOUT
         self._kv_cache_manager = kv_cache_manager
         self._quant_config = quant_config
+        self._kv_pool_cache = {}
+        self._pool_idx_cache = {}
+        self._block_tables_cache = {}
+        self._enable_pdl = get_env_enable_pdl()
+        missing_ops = self._missing_fused_nanobind_ops()
+        if missing_ops:
+            raise RuntimeError(
+                f"trtllm-gen requires fused nanobind ops, missing: {', '.join(missing_ops)}."
+            )
 
     @property
     def layout(self) -> str:
@@ -915,7 +486,303 @@ class FlashInferTrtllmGenAttention:
     def is_supported(self, **kwargs) -> Tuple[bool, str]:
         if not IS_FLASHINFER_AVAILABLE:
             return False, "flashinfer package is not installed."
+        if self._kv_cache_manager is None:
+            return False, "trtllm-gen requires a KVCacheManager."
+        if not kwargs.get("use_paged_kv_cache", True):
+            return False, "trtllm-gen requires paged KV cache."
         return self._checker.is_supported(**kwargs)
+
+    def attention(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        output: torch.Tensor,
+        output_sf: Optional[torch.Tensor],
+        workspace: Optional[torch.Tensor],
+        sequence_length: torch.Tensor,
+        host_past_key_value_lengths: torch.Tensor,
+        host_total_kv_lens: torch.Tensor,
+        context_lengths: torch.Tensor,
+        host_context_lengths: torch.Tensor,
+        host_request_types: torch.Tensor,
+        kv_cache_block_offsets: Optional[torch.Tensor],
+        host_kv_cache_pool_pointers: Optional[torch.Tensor],
+        host_kv_cache_pool_mapping: Optional[torch.Tensor],
+        cache_indirection: Optional[torch.Tensor],
+        kv_scale_orig_quant: Optional[torch.Tensor],
+        kv_scale_quant_orig: Optional[torch.Tensor],
+        out_scale: Optional[torch.Tensor],
+        rotary_inv_freq: Optional[torch.Tensor],
+        rotary_cos_sin: Optional[torch.Tensor],
+        latent_cache: Optional[torch.Tensor],
+        q_pe: Optional[torch.Tensor],
+        block_ids_per_seq: Optional[torch.Tensor],
+        attention_sinks: Optional[torch.Tensor],
+        is_fused_qkv: bool,
+        update_kv_cache: bool,
+        predicted_tokens_per_seq: int,
+        layer_idx: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_size: int,
+        tokens_per_block: Optional[int],
+        max_num_requests: int,
+        max_context_length: int,
+        attention_window_size: int,
+        sink_token_length: int,
+        beam_width: int,
+        mask_type: int,
+        quant_mode: int,
+        q_scaling: float,
+        position_embedding_type: int,
+        rotary_embedding_dim: int,
+        rotary_embedding_base: float,
+        rotary_embedding_scale_type: int,
+        rotary_embedding_scales: List[float],
+        rotary_embedding_max_position_info: List[int],
+        use_paged_context_fmha: bool,
+        attention_input_type: Optional[int],
+        is_mla_enable: bool,
+        chunked_prefill_buffer_batch_size: Optional[int],
+        q_lora_rank: Optional[int],
+        kv_lora_rank: Optional[int],
+        qk_nope_head_dim: Optional[int],
+        qk_rope_head_dim: Optional[int],
+        v_head_dim: Optional[int],
+        mrope_rotary_cos_sin: Optional[torch.Tensor],
+        mrope_position_deltas: Optional[torch.Tensor],
+        helix_tensor_params: List[Optional[torch.Tensor]],
+        attention_chunk_size: Optional[int],
+        softmax_stats_tensor: Optional[torch.Tensor],
+        spec_decoding_bool_params: List[bool],
+        spec_decoding_tensor_params: List[Optional[torch.Tensor]],
+        sparse_kv_indices: Optional[torch.Tensor],
+        sparse_kv_offsets: Optional[torch.Tensor],
+        sparse_attn_indices: Optional[torch.Tensor],
+        sparse_attn_offsets: Optional[torch.Tensor],
+        sparse_attn_indices_block_size: int,
+        sparse_mla_topk: Optional[int],
+        skip_softmax_threshold_scale_factor_prefill: Optional[float],
+        skip_softmax_threshold_scale_factor_decode: Optional[float],
+        skip_softmax_stat: Optional[torch.Tensor],
+        cu_q_seqlens: Optional[torch.Tensor],
+        cu_kv_seqlens: Optional[torch.Tensor],
+        fmha_scheduler_counter: Optional[torch.Tensor],
+        mla_bmm1_scale: Optional[torch.Tensor],
+        mla_bmm2_scale: Optional[torch.Tensor],
+        quant_q_buffer: Optional[torch.Tensor],
+        num_contexts: int,
+        num_ctx_tokens: int,
+        global_layer_idx: Optional[int] = None,
+    ) -> None:
+        logger.debug(f"trtllm_gen_attention starts at layer {layer_idx}")
+
+        is_fp8_out = output.dtype == torch.float8_e4m3fn
+        is_fp4_out = output.dtype == torch.uint8
+        kv_cache_quant_mode = QuantMode(quant_mode)
+
+        has_kv_cache_quant = kv_cache_quant_mode.has_kv_cache_quant()
+        resolved_kv_scale_orig_quant = None
+        resolved_kv_scale_quant_orig = None
+        if (
+            has_kv_cache_quant
+            and kv_scale_orig_quant is not None
+            and kv_scale_quant_orig is not None
+        ):
+            resolved_kv_scale_orig_quant = kv_scale_orig_quant
+            resolved_kv_scale_quant_orig = kv_scale_quant_orig
+            if kv_cache_quant_mode.has_fp4_kv_cache():
+                assert resolved_kv_scale_orig_quant.size(0) == 3, (
+                    f"kv_scale_orig_quant must have size(0)==3 for FP4, got {resolved_kv_scale_orig_quant.size(0)}"
+                )
+                assert resolved_kv_scale_quant_orig.size(0) == 3, (
+                    f"kv_scale_quant_orig must have size(0)==3 for FP4, got {resolved_kv_scale_quant_orig.size(0)}"
+                )
+
+        num_tokens = q.size(0)
+
+        attn_input_type = AttentionInputType.mixed
+        if attention_input_type is not None:
+            attn_input_type = AttentionInputType(attention_input_type)
+
+        is_gen_only = attn_input_type == AttentionInputType.generation_only
+
+        num_generations = host_request_types.size(0) - num_contexts
+        num_gen_tokens = num_tokens if is_gen_only else num_tokens - num_ctx_tokens
+        if num_gen_tokens < 0:
+            raise RuntimeError(
+                f"Invalid trtllm-gen attention token counts: num_tokens={num_tokens}, "
+                f"num_ctx_tokens={num_ctx_tokens}, attention_input_type={attn_input_type}."
+            )
+
+        workspace_max_tokens = max(num_tokens, max_context_length)
+        workspace_max_gen_tokens = max(num_gen_tokens, max_num_requests)
+        required_workspace_size = _get_workspace_size(
+            q.dtype,
+            workspace_max_tokens,
+            workspace_max_gen_tokens,
+            num_heads,
+            num_kv_heads,
+            head_size,
+            max_num_requests,
+            rotary_embedding_dim,
+        )
+
+        current_workspace_size = (
+            workspace.numel() * workspace.element_size() if workspace is not None else 0
+        )
+
+        if current_workspace_size < required_workspace_size:
+            logger.warning(
+                f"Attention workspace size is not enough, increase the size from "
+                f"{current_workspace_size} bytes to {required_workspace_size} bytes"
+            )
+            if workspace is None:
+                workspace = torch.zeros(required_workspace_size, device=q.device, dtype=torch.uint8)
+            else:
+                workspace.resize_(required_workspace_size)
+                workspace.zero_()
+
+        if is_mla_enable and is_gen_only and kv_lora_rank:
+            out_head_size = kv_lora_rank
+        elif is_mla_enable and v_head_dim:
+            out_head_size = v_head_dim
+        else:
+            out_head_size = head_size
+        out_tensor = output.view(num_tokens, num_heads, out_head_size)
+
+        max_attn_window_size = (
+            attention_window_size
+            if beam_width == 1
+            else (
+                cache_indirection.size(2)
+                if cache_indirection is not None
+                else attention_window_size
+            )
+        )
+        cyclic_attn_window_size = attention_window_size
+        params = EnqueueParams(
+            workspace=workspace,
+            max_attention_window_size=max_attn_window_size,
+            cyclic_attention_window_size=cyclic_attn_window_size,
+            sink_token_length=sink_token_length,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            rotary_embedding_dim=rotary_embedding_dim,
+            rotary_embedding_base=rotary_embedding_base,
+            rotary_embedding_scale_type=rotary_embedding_scale_type,
+            rotary_embedding_scale=rotary_embedding_scales[0] if rotary_embedding_scales else 1.0,
+            rotary_embedding_max_positions=rotary_embedding_max_position_info[0]
+            if rotary_embedding_max_position_info
+            else 0,
+            kv_cache_block_offsets=kv_cache_block_offsets,
+            host_kv_cache_pool_pointers=host_kv_cache_pool_pointers,
+            host_kv_cache_pool_mapping=host_kv_cache_pool_mapping,
+            tokens_per_block=tokens_per_block if tokens_per_block is not None else 64,
+            mask_type=mask_type,
+            kv_cache_quant_mode=quant_mode,
+            position_embedding_type=position_embedding_type,
+            layer_idx=layer_idx,
+            global_layer_idx=global_layer_idx if global_layer_idx is not None else layer_idx,
+            kv_scale_orig_quant=resolved_kv_scale_orig_quant,
+            kv_scale_quant_orig=resolved_kv_scale_quant_orig,
+            attention_output_orig_quant=out_scale,
+            bmm1_scale=1.0 / (math.sqrt(head_size) * q_scaling),
+            bmm2_scale=1.0,
+            rotary_inv_freq=rotary_inv_freq,
+            rotary_cos_sin=rotary_cos_sin,
+            attention_chunk_size=attention_chunk_size if attention_chunk_size is not None else 0,
+            fp8_context_fmha=is_fp8_out
+            or is_fp4_out
+            or (kv_cache_quant_mode.has_fp8_kv_cache() and use_paged_context_fmha),
+            remove_padding=True,
+            cross_attention=False,
+            position_shift_enabled=False,
+            paged_context_fmha=use_paged_context_fmha,
+            attention_sinks=attention_sinks,
+            is_mla_enable=is_mla_enable,
+            kv_lora_rank=kv_lora_rank or 0,
+            qk_nope_head_dim=qk_nope_head_dim or 0,
+            qk_rope_head_dim=qk_rope_head_dim or 0,
+            v_head_dim=v_head_dim or 0,
+            q_scaling=q_scaling,
+            latent_cache=latent_cache,
+            num_layers=host_kv_cache_pool_mapping.size(0)
+            if host_kv_cache_pool_mapping is not None
+            else 0,
+        )
+
+        if num_contexts > 0 and attn_input_type != AttentionInputType.generation_only:
+            seq_offset = 0
+            token_offset = 0
+            num_seqs = num_contexts
+
+            max_context_q_len = int(host_context_lengths[seq_offset : seq_offset + num_seqs].max())
+            max_past_kv_len = int(
+                host_past_key_value_lengths[seq_offset : seq_offset + num_seqs].max()
+            )
+
+            params.attention_input = q[token_offset : token_offset + num_ctx_tokens]
+            params.qkv_input = q[token_offset : token_offset + num_ctx_tokens]
+            params.context_buf = out_tensor[token_offset : token_offset + num_ctx_tokens]
+            params.sequence_lengths = sequence_length[seq_offset:]
+            params.context_lengths = context_lengths[seq_offset:]
+            params.max_past_kv_length = max_past_kv_len
+            params.num_tokens = num_ctx_tokens
+            params.seq_offset = seq_offset
+            params.input_seq_length = max_context_q_len
+            params.batch_size = num_seqs
+            params.mrope_rotary_cos_sin = mrope_rotary_cos_sin
+            self.run_context(params)
+
+        if num_generations > 0 and attn_input_type != AttentionInputType.context_only:
+            seq_offset = num_contexts
+            token_offset = 0 if is_gen_only else num_ctx_tokens
+            num_seqs = num_generations
+
+            max_past_kv_len = int(
+                host_past_key_value_lengths[seq_offset : seq_offset + num_seqs].max()
+            )
+            input_seq_length = num_gen_tokens // num_seqs if num_seqs > 0 else 1
+
+            spec_gen_lengths = None
+            spec_pos_offsets = None
+            spec_packed_mask = None
+            if (
+                spec_decoding_bool_params
+                and len(spec_decoding_bool_params) >= 2
+                and spec_decoding_bool_params[0]
+                and spec_decoding_bool_params[1]
+                and predicted_tokens_per_seq > 1
+            ):
+                if spec_decoding_tensor_params and len(spec_decoding_tensor_params) >= 3:
+                    spec_gen_lengths = spec_decoding_tensor_params[0]
+                    spec_pos_offsets = spec_decoding_tensor_params[1]
+                    spec_packed_mask = spec_decoding_tensor_params[2]
+
+            params.attention_input = q[token_offset : token_offset + num_gen_tokens]
+            params.qkv_input = q[token_offset : token_offset + num_gen_tokens]
+            params.context_buf = out_tensor[token_offset : token_offset + num_gen_tokens]
+            params.sequence_lengths = sequence_length[seq_offset:]
+            params.context_lengths = context_lengths[seq_offset:]
+            params.max_past_kv_length = max_past_kv_len
+            params.num_tokens = num_gen_tokens
+            params.seq_offset = seq_offset
+            params.input_seq_length = input_seq_length
+            params.beam_width = beam_width
+            params.num_requests = num_seqs // beam_width
+            params.predicted_tokens_per_seq = predicted_tokens_per_seq
+            params.spec_decoding_generation_lengths = spec_gen_lengths
+            params.spec_decoding_position_offsets = spec_pos_offsets
+            params.spec_decoding_packed_mask = spec_packed_mask
+            if is_mla_enable:
+                self.run_mla_generation(params)
+            else:
+                self.run_generation(params)
+
+        logger.debug(f"trtllm_gen_attention stops at layer {layer_idx}")
 
     @staticmethod
     def _compute_window_left(
@@ -943,7 +810,6 @@ class FlashInferTrtllmGenAttention:
         host_kv_cache_pool_pointers,
         host_kv_cache_pool_mapping,
         layer_idx: int,
-        global_layer_idx: int,
         num_kv_heads: int,
         tokens_per_block: int,
         head_dim: int,
@@ -955,8 +821,7 @@ class FlashInferTrtllmGenAttention:
     ):
         """Get FlashInfer kv_cache and block_tables.
 
-        The kv_cache tensor is a flat-block view of the KV cache pool,
-        created per layer via C++ op build_kv_cache_buffers().
+        The kv_cache tensor is a flat-block view of the per-layer KV cache pool.
 
         Shape: [total_blocks, num_kv_heads, tokens_per_block, head_dim]
         where each dim-0 element = one single K or V block.
@@ -976,435 +841,384 @@ class FlashInferTrtllmGenAttention:
         if kv_cache_block_offsets is None:
             return None, None
 
-        kv_factor = 1 if is_mla_enable else 2
-        total_num_blocks = (
-            self._kv_cache_manager.blocks_in_primary_pool
-            * self._kv_cache_manager.num_local_layers
-            * kv_factor
+        kv_pool = self._get_or_build_kv_pool(
+            host_kv_cache_pool_pointers=host_kv_cache_pool_pointers,
+            host_kv_cache_pool_mapping=host_kv_cache_pool_mapping,
+            layer_idx=layer_idx,
+            num_kv_heads=num_kv_heads,
+            tokens_per_block=tokens_per_block,
+            head_dim=head_dim,
+            kv_cache_quant_mode=kv_cache_quant_mode,
+            dtype=dtype,
+            is_mla_enable=is_mla_enable,
         )
-        kv_pool, _ = thop.build_kv_cache_buffers(
-            host_kv_cache_pool_pointers,
-            host_kv_cache_pool_mapping,
-            layer_idx,
-            num_kv_heads,
-            tokens_per_block,
-            head_dim,
-            kv_factor,
-            total_num_blocks,
-            kv_cache_quant_mode,
-            dtype,
+        block_tables = self._slice_block_tables(
+            kv_cache_block_offsets=kv_cache_block_offsets,
+            host_kv_cache_pool_mapping=host_kv_cache_pool_mapping,
+            layer_idx=layer_idx,
+            batch_start=batch_start,
+            batch_size=batch_size,
         )
-        pool_idx = int(host_kv_cache_pool_mapping[layer_idx, 0])
-
-        # block_tables: pure Python slice, no C++ op, no division
-        block_tables = kv_cache_block_offsets[pool_idx, batch_start : batch_start + batch_size]
 
         return (kv_pool, kv_pool), block_tables
 
-    def run_context(self, params: EnqueueContextParams):
+    def _get_or_build_kv_pool(
+        self,
+        *,
+        host_kv_cache_pool_pointers,
+        host_kv_cache_pool_mapping,
+        layer_idx: int,
+        num_kv_heads: int,
+        tokens_per_block: int,
+        head_dim: int,
+        kv_cache_quant_mode: int,
+        dtype: torch.dtype,
+        is_mla_enable: bool = False,
+    ) -> torch.Tensor:
+        cache_scope = self._get_kv_pool_cache_scope(
+            host_kv_cache_pool_pointers=host_kv_cache_pool_pointers,
+            host_kv_cache_pool_mapping=host_kv_cache_pool_mapping,
+            num_kv_heads=num_kv_heads,
+            tokens_per_block=tokens_per_block,
+            head_dim=head_dim,
+            kv_cache_quant_mode=kv_cache_quant_mode,
+            dtype=dtype,
+            is_mla_enable=is_mla_enable,
+        )
+        cache_key = (layer_idx, cache_scope)
+        cached_kv_pool = self._kv_pool_cache.get(cache_key)
+        if cached_kv_pool is not None:
+            return cached_kv_pool
+
+        kv_cache = self._kv_cache_manager.get_buffers(layer_idx, kv_layout="HND")
+        block_elems = kv_cache.shape[2] * kv_cache.shape[3] * kv_cache.shape[4]
+        storage_numel = kv_cache.untyped_storage().nbytes() // kv_cache.element_size()
+        available_blocks = (storage_numel - kv_cache.storage_offset()) // block_elems
+
+        if kv_cache.shape[2] != num_kv_heads or kv_cache.shape[3] != tokens_per_block:
+            raise RuntimeError(
+                "Invalid trtllm-gen KV cache view shape: "
+                f"shape={tuple(kv_cache.shape)}, num_kv_heads={num_kv_heads}, "
+                f"tokens_per_block={tokens_per_block}."
+            )
+
+        kv_pool = kv_cache.as_strided(
+            (available_blocks, kv_cache.shape[2], kv_cache.shape[3], kv_cache.shape[4]),
+            (block_elems, kv_cache.shape[3] * kv_cache.shape[4], kv_cache.shape[4], 1),
+        )
+        if kv_pool.data_ptr() != kv_cache.data_ptr():
+            raise RuntimeError("Failed to create a no-copy trtllm-gen KV cache pool view.")
+        self._kv_pool_cache[cache_key] = kv_pool
+        return kv_pool
+
+    def _get_kv_pool_cache_scope(
+        self,
+        *,
+        host_kv_cache_pool_pointers,
+        host_kv_cache_pool_mapping,
+        num_kv_heads: int,
+        tokens_per_block: int,
+        head_dim: int,
+        kv_cache_quant_mode: int,
+        dtype: torch.dtype,
+        is_mla_enable: bool,
+    ):
+        blocks_in_primary_pool = getattr(self._kv_cache_manager, "blocks_in_primary_pool", None)
+        if blocks_in_primary_pool is None:
+            blocks_per_window = getattr(self._kv_cache_manager, "blocks_per_window", None)
+            if blocks_per_window:
+                blocks_in_primary_pool = max(
+                    int(primary_blocks) for primary_blocks, _ in blocks_per_window.values()
+                )
+        if blocks_in_primary_pool is not None:
+            blocks_in_primary_pool = int(blocks_in_primary_pool)
+
+        return (
+            host_kv_cache_pool_pointers.data_ptr(),
+            host_kv_cache_pool_pointers._version,
+            host_kv_cache_pool_mapping.data_ptr(),
+            host_kv_cache_pool_mapping._version,
+            blocks_in_primary_pool,
+            int(getattr(self._kv_cache_manager, "num_local_layers", 0) or 0),
+            num_kv_heads,
+            tokens_per_block,
+            head_dim,
+            kv_cache_quant_mode,
+            dtype,
+            is_mla_enable,
+        )
+
+    def _slice_block_tables(
+        self,
+        *,
+        kv_cache_block_offsets,
+        host_kv_cache_pool_mapping,
+        layer_idx: int,
+        batch_start: int,
+        batch_size: int,
+    ):
+        cache_key = (host_kv_cache_pool_mapping.data_ptr(), layer_idx)
+        pool_idx = self._pool_idx_cache.get(cache_key)
+        if pool_idx is None:
+            pool_idx = int(host_kv_cache_pool_mapping[layer_idx, 0])
+            self._pool_idx_cache[cache_key] = pool_idx
+        block_tables_key = (
+            kv_cache_block_offsets.data_ptr(),
+            tuple(kv_cache_block_offsets.shape),
+            tuple(kv_cache_block_offsets.stride()),
+            pool_idx,
+            batch_start,
+            batch_size,
+        )
+        block_tables = self._block_tables_cache.get(block_tables_key)
+        if block_tables is None:
+            block_tables = kv_cache_block_offsets[pool_idx, batch_start : batch_start + batch_size]
+            self._block_tables_cache[block_tables_key] = block_tables
+        return block_tables
+
+    @staticmethod
+    def _missing_fused_nanobind_ops() -> List[str]:
+        required_ops = (
+            "get_trtllm_gen_context_workspace_layout",
+            "get_trtllm_gen_generation_workspace_layout",
+            "trtllm_gen_context_preprocess",
+            "trtllm_gen_context_postprocess",
+            "trtllm_gen_generation_preprocess",
+        )
+        return [op for op in required_ops if not hasattr(thop, op)]
+
+    def run_context(self, params: EnqueueParams):
+        kv_factor = 0
+        total_num_blocks = 0
+        # KV metadata is cached in Python; these satisfy the fused op signature.
         kv_cache, block_tables = self._get_kv_cache_and_block_tables(
             kv_cache_block_offsets=params.kv_cache_block_offsets,
             host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
             host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
             layer_idx=params.layer_idx,
-            global_layer_idx=params.global_layer_idx,
             num_kv_heads=params.num_kv_heads,
             tokens_per_block=params.tokens_per_block,
             head_dim=params.head_size,
             kv_cache_quant_mode=params.kv_cache_quant_mode,
             batch_start=params.seq_offset,
             batch_size=params.batch_size,
-            dtype=params.attention_input.dtype,
+            dtype=params.qkv_input.dtype,
             is_mla_enable=params.is_mla_enable,
         )
-        window_left = self._compute_window_left(
-            params.cyclic_attention_window_size,
-            params.max_past_kv_length,
-            params.attention_chunk_size,
-        )
-
-        ctx_ws = WorkspaceManager.split_context_workspace(
-            workspace=params.workspace,
-            dtype=params.attention_input.dtype,
-            batch_size=params.batch_size,
-            num_tokens=params.num_tokens,
-            num_heads=params.num_heads,
-            head_size=params.head_size,
-            rotary_embedding_dim=params.rotary_embedding_dim,
-            separate_q_kv_input=True,
-            fp8_context_fmha=params.fp8_context_fmha,
-        )
-
-        torch.ops.trtllm.build_decoder_info(
-            seq_q_offsets=ctx_ws.cu_q_seqlens,
-            seq_kv_offsets=ctx_ws.cu_kv_seqlens,
-            padding_offsets=None,
-            tokens_info=ctx_ws.tokens_info,
-            encoder_padding_offsets=None,
-            packed_mask_row_offsets=ctx_ws.cu_mask_rows,
-            seq_cp_partial_offsets=None,
-            attention_mask=None,
-            seq_q_lengths=params.context_lengths,
-            seq_kv_lengths=params.sequence_lengths,
-            fmha_tile_counter=ctx_ws.fmha_tile_counter,
-            dequant_scale_qkv=params.kv_scale_quant_orig,
-            quant_scale_o=params.attention_output_orig_quant,
-            fmha_bmm1_scale=ctx_ws.fmha_bmm1_scale,
-            fmha_bmm2_scale=ctx_ws.fmha_bmm2_scale,
-            rotary_embedding_inv_freq=ctx_ws.rotary_inv_freq_buf,
-            rotary_embedding_inv_freq_cache=params.rotary_inv_freq,
-            cp_size=1,
-            separate_qkv_scales=QuantMode(params.kv_cache_quant_mode).has_fp4_kv_cache(),
-            fmha_host_bmm1_scale=params.bmm1_scale,
-            batch_size=params.batch_size,
-            max_q_seq_length=params.input_seq_length,
-            max_encoder_q_seq_length=0,
-            attention_window_size=params.cyclic_attention_window_size,
-            sink_token_length=params.sink_token_length,
-            num_tokens=params.num_tokens,
-            remove_padding=params.remove_padding,
-            attention_mask_type=params.mask_type,
-            rotary_embedding_scale=params.rotary_embedding_scale,
-            rotary_embedding_base=params.rotary_embedding_base,
-            rotary_embedding_dim=params.rotary_embedding_dim,
-            rotary_scaling_type=params.rotary_embedding_scale_type,
-            rotary_embedding_max_positions=params.rotary_embedding_max_positions,
-        )
-
-        separate_q_kv_output = params.paged_context_fmha or params.cross_attention
-
-        ctx_qkv_args = dict(
+        (
+            q_processed,
+            _kv_pool,
+            _block_tables,
+            fmha_workspace,
+            cu_q_seqlens,
+            cu_kv_seqlens,
+            max_q_len,
+            max_kv_len,
+            window_left,
+        ) = thop.trtllm_gen_context_preprocess(
             qkv_input=params.qkv_input,
-            cross_kv_input=None,
-            quantized_qkv_output=None,
-            q_output=ctx_ws.q_buf,
+            workspace=params.workspace,
+            sequence_lengths=params.sequence_lengths,
+            context_lengths=params.context_lengths,
             kv_cache_block_offsets=params.kv_cache_block_offsets,
             host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
             host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
-            qkv_bias=None,
-            qkv_scale_quant_orig=params.kv_scale_quant_orig,
-            qkv_scale_orig_quant=params.kv_scale_orig_quant,
-            o_scale_orig_quant=params.attention_output_orig_quant,
-            fmha_bmm1_scale=ctx_ws.fmha_bmm1_scale,
-            fmha_bmm2_scale=ctx_ws.fmha_bmm2_scale,
-            fmha_tile_counter=ctx_ws.fmha_tile_counter,
-            logn_scaling=None,
-            tokens_info=ctx_ws.tokens_info,
-            seq_lens=params.context_lengths,
-            cache_seq_lens=params.sequence_lengths,
-            encoder_seq_lens=None,
-            cu_seq_lens=ctx_ws.cu_q_seqlens,
-            cu_kv_seq_lens=ctx_ws.cu_kv_seqlens,
-            sparse_kv_offsets=None,
-            sparse_kv_indices=None,
-            rotary_embedding_inv_freq=ctx_ws.rotary_inv_freq_buf,
-            rotary_coef_cache_buffer=params.rotary_cos_sin,
-            spec_decoding_position_offsets=None,
+            kv_scale_orig_quant=params.kv_scale_orig_quant,
+            kv_scale_quant_orig=params.kv_scale_quant_orig,
+            attention_output_orig_quant=params.attention_output_orig_quant,
+            rotary_inv_freq=params.rotary_inv_freq,
+            rotary_cos_sin=params.rotary_cos_sin,
             mrope_rotary_cos_sin=params.mrope_rotary_cos_sin,
-            mrope_position_deltas=None,
+            layer_idx=params.layer_idx,
+            num_heads=params.num_heads,
+            num_kv_heads=params.num_kv_heads,
+            head_size=params.head_size,
+            tokens_per_block=params.tokens_per_block,
+            mask_type=params.mask_type,
+            kv_cache_quant_mode=params.kv_cache_quant_mode,
+            max_attention_window_size=params.max_attention_window_size,
+            cyclic_attention_window_size=params.cyclic_attention_window_size,
+            sink_token_length=params.sink_token_length,
+            num_tokens=params.num_tokens,
             batch_size=params.batch_size,
-            max_input_seq_len=params.input_seq_length,
-            max_kv_seq_len=params.max_past_kv_length,
-            cyclic_kv_cache_len=params.cyclic_attention_window_size,
-            sink_token_len=params.sink_token_length,
-            token_num=params.num_tokens,
-            remove_padding=params.remove_padding,
-            is_last_chunk=(params.attention_chunk_size == 0)
-            or (params.input_seq_length == params.max_past_kv_length),
-            cross_attention=params.cross_attention,
-            head_num=params.num_heads,
-            kv_head_num=params.num_kv_heads,
-            qheads_per_kv_head=params.num_heads // params.num_kv_heads,
-            size_per_head=params.head_size,
-            fmha_host_bmm1_scale=params.bmm1_scale,
+            input_seq_length=params.input_seq_length,
+            max_past_kv_length=params.max_past_kv_length,
             rotary_embedding_dim=params.rotary_embedding_dim,
             rotary_embedding_base=params.rotary_embedding_base,
-            rotary_scaling_type=params.rotary_embedding_scale_type,
+            rotary_embedding_scale_type=params.rotary_embedding_scale_type,
             rotary_embedding_scale=params.rotary_embedding_scale,
             rotary_embedding_max_positions=params.rotary_embedding_max_positions,
             position_embedding_type=params.position_embedding_type,
-            position_shift_enabled=params.position_shift_enabled,
-            separate_q_kv_output=separate_q_kv_output,
-            quantized_fp8_output=params.fp8_context_fmha,
-            generation_phase=False,
-            rotary_vision_start=0,
-            rotary_vision_length=0,
-            layer_idx=params.layer_idx,
-            tokens_per_block=params.tokens_per_block,
-            max_attention_window_size=params.max_attention_window_size,
-            kv_cache_quant_mode=params.kv_cache_quant_mode,
-            cyclic_attention_window_size=params.cyclic_attention_window_size,
-            beam_width=0,
-            sink_token_length=params.sink_token_length,
+            bmm1_scale=params.bmm1_scale,
+            bmm2_scale=params.bmm2_scale,
+            attention_chunk_size=params.attention_chunk_size,
+            fp8_context_fmha=params.fp8_context_fmha,
+            paged_context_fmha=params.paged_context_fmha,
             is_mla_enable=params.is_mla_enable,
+            total_num_blocks=total_num_blocks,
+            kv_factor=kv_factor,
+            need_build_kv_cache_metadata=False,
         )
-        torch.ops.trtllm.qkv_preprocessing(**ctx_qkv_args)
-
-        # Extract Q for FlashInfer prefill. Two cases depending on whether
-        # qkv_preprocessing wrote Q to a separate buffer:
-        #
-        # separate_q_kv_output=True (FP8/FP4 quantized, or cross-attention):
-        #   qkv_preprocessing wrote RoPE'd Q into ctx_ws.q_buf. Read from it.
-        #
-        # separate_q_kv_output=False (BF16/FP16 non-quantized):
-        #   Q stays in the packed QKV buffer after RoPE. Extract Q as a
-        #   zero-copy strided view: qkv_input[:, :q_hidden_size].
-        #   The view's stride(0) = full QKV hidden size, which the trtllm-gen
-        #   kernel handles correctly via qStrideTokens / qStrideHeads.
-        #   This matches thop's context-phase behavior where FMHA reads Q
-        #   directly from the packed QKV buffer (fmhaParams.qkvPtr).
-        if separate_q_kv_output:
-            q_processed = ctx_ws.q_buf.view(params.num_tokens, params.num_heads, params.head_size)
-        else:
-            q_size = params.num_heads * params.head_size
-            q_processed = params.qkv_input[:, :q_size].view(-1, params.num_heads, params.head_size)
-        ctx_ws.trtllm_gen_workspace.zero_()
 
         flashinfer.prefill.trtllm_batch_context_with_kv_cache(
             query=q_processed,
             kv_cache=kv_cache,
-            workspace_buffer=ctx_ws.trtllm_gen_workspace,
+            workspace_buffer=fmha_workspace,
             block_tables=block_tables,
             seq_lens=params.sequence_lengths,
-            max_q_len=params.input_seq_length,
-            max_kv_len=params.max_past_kv_length,
+            max_q_len=max_q_len,
+            max_kv_len=max_kv_len,
             bmm1_scale=params.bmm1_scale,
             bmm2_scale=params.bmm2_scale,
             batch_size=params.batch_size,
-            cum_seq_lens_q=ctx_ws.cu_q_seqlens,
-            cum_seq_lens_kv=ctx_ws.cu_kv_seqlens,
+            cum_seq_lens_q=cu_q_seqlens,
+            cum_seq_lens_kv=cu_kv_seqlens,
             window_left=window_left,
             out=params.context_buf,
             kv_layout=self._layout,
             sinks=params.attention_sinks,
             uses_shared_paged_kv_idx=False,
-            enable_pdl=get_env_enable_pdl(),
+            enable_pdl=self._enable_pdl,
         )
 
-        torch.ops.trtllm.kv_cache_postprocessing(**ctx_qkv_args)
+        thop.trtllm_gen_context_postprocess(
+            qkv_input=params.qkv_input,
+            workspace=params.workspace,
+            sequence_lengths=params.sequence_lengths,
+            context_lengths=params.context_lengths,
+            kv_cache_block_offsets=params.kv_cache_block_offsets,
+            host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
+            host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
+            kv_scale_orig_quant=params.kv_scale_orig_quant,
+            kv_scale_quant_orig=params.kv_scale_quant_orig,
+            attention_output_orig_quant=params.attention_output_orig_quant,
+            rotary_cos_sin=params.rotary_cos_sin,
+            mrope_rotary_cos_sin=params.mrope_rotary_cos_sin,
+            layer_idx=params.layer_idx,
+            num_heads=params.num_heads,
+            num_kv_heads=params.num_kv_heads,
+            head_size=params.head_size,
+            tokens_per_block=params.tokens_per_block,
+            mask_type=params.mask_type,
+            kv_cache_quant_mode=params.kv_cache_quant_mode,
+            max_attention_window_size=params.max_attention_window_size,
+            cyclic_attention_window_size=params.cyclic_attention_window_size,
+            sink_token_length=params.sink_token_length,
+            num_tokens=params.num_tokens,
+            batch_size=params.batch_size,
+            input_seq_length=params.input_seq_length,
+            max_past_kv_length=params.max_past_kv_length,
+            rotary_embedding_dim=params.rotary_embedding_dim,
+            rotary_embedding_base=params.rotary_embedding_base,
+            rotary_embedding_scale_type=params.rotary_embedding_scale_type,
+            rotary_embedding_scale=params.rotary_embedding_scale,
+            rotary_embedding_max_positions=params.rotary_embedding_max_positions,
+            position_embedding_type=params.position_embedding_type,
+            bmm1_scale=params.bmm1_scale,
+            fp8_context_fmha=params.fp8_context_fmha,
+            paged_context_fmha=params.paged_context_fmha,
+            is_mla_enable=params.is_mla_enable,
+            attention_chunk_size=params.attention_chunk_size,
+        )
 
-    def run_generation(self, params: EnqueueGenerationParams):
+    def run_generation(self, params: EnqueueParams):
         batch_beam = params.num_requests * params.beam_width
+        kv_factor = 0
+        total_num_blocks = 0
+        # KV metadata is cached in Python; these satisfy the fused op signature.
         kv_cache, block_tables = self._get_kv_cache_and_block_tables(
             kv_cache_block_offsets=params.kv_cache_block_offsets,
             host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
             host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
             layer_idx=params.layer_idx,
-            global_layer_idx=params.global_layer_idx,
             num_kv_heads=params.num_kv_heads,
             tokens_per_block=params.tokens_per_block,
             head_dim=params.head_size,
             kv_cache_quant_mode=params.kv_cache_quant_mode,
             batch_start=params.seq_offset,
             batch_size=batch_beam,
-            dtype=params.attention_input.dtype,
+            dtype=params.qkv_input.dtype,
             is_mla_enable=params.is_mla_enable,
         )
-        window_left = self._compute_window_left(
-            params.cyclic_attention_window_size,
-            params.max_past_kv_length,
-            params.attention_chunk_size,
-        )
-
-        is_multi_token_gen = (
-            params.spec_decoding_generation_lengths is not None
-            and params.predicted_tokens_per_seq > 1
-        )
-
-        gen_ws = WorkspaceManager.split_generation_workspace(
-            workspace=params.workspace,
-            dtype=params.attention_input.dtype,
-            batch_beam=batch_beam,
-            num_tokens=params.num_tokens,
-            num_heads=params.num_heads,
-            head_size=params.head_size,
-            rotary_embedding_dim=params.rotary_embedding_dim,
-            num_kv_heads=params.num_kv_heads,
-        )
-
-        is_build_decoder_info_kernel_needed = torch.ops.trtllm.build_decoder_info(
-            seq_q_offsets=gen_ws.cu_seqlens,
-            seq_kv_offsets=gen_ws.cu_kv_seqlens,
-            padding_offsets=None,
-            tokens_info=gen_ws.tokens_info,
-            encoder_padding_offsets=None,
-            packed_mask_row_offsets=None,
-            seq_cp_partial_offsets=None,
-            attention_mask=None,
-            seq_q_lengths=(params.spec_decoding_generation_lengths if is_multi_token_gen else None),
-            seq_kv_lengths=params.sequence_lengths,
-            fmha_tile_counter=None,
-            dequant_scale_qkv=None,
-            quant_scale_o=None,
-            fmha_bmm1_scale=None,
-            fmha_bmm2_scale=None,
-            rotary_embedding_inv_freq=gen_ws.rotary_inv_freq,
-            rotary_embedding_inv_freq_cache=params.rotary_inv_freq,
-            cp_size=1,
-            separate_qkv_scales=QuantMode(params.kv_cache_quant_mode).has_fp4_kv_cache(),
-            fmha_host_bmm1_scale=params.bmm1_scale,
-            batch_size=batch_beam,
-            max_q_seq_length=params.input_seq_length,
-            max_encoder_q_seq_length=0,
-            attention_window_size=0,
-            sink_token_length=0,
-            num_tokens=params.num_tokens,
-            remove_padding=True,
-            attention_mask_type=0,
-            rotary_embedding_scale=params.rotary_embedding_scale,
-            rotary_embedding_base=params.rotary_embedding_base,
-            rotary_embedding_dim=params.rotary_embedding_dim,
-            rotary_scaling_type=params.rotary_embedding_scale_type,
-            rotary_embedding_max_positions=params.rotary_embedding_max_positions,
-        )
-
-        if is_build_decoder_info_kernel_needed:
-            rotary_inv_freq_buf = gen_ws.rotary_inv_freq
-            cu_seqlens = gen_ws.cu_seqlens
-            cu_kv_seqlens = gen_ws.cu_kv_seqlens
-        else:
-            rotary_inv_freq_buf = params.rotary_inv_freq
-            cu_seqlens = None
-            cu_kv_seqlens = None
-
-        torch.ops.trtllm.qkv_preprocessing(
+        (
+            q_processed,
+            _kv_pool,
+            _block_tables,
+            fmha_workspace,
+            cu_seqlens,
+            max_q_len,
+            max_kv_len,
+            window_left,
+            is_multi_token_gen,
+        ) = thop.trtllm_gen_generation_preprocess(
             qkv_input=params.qkv_input,
-            cross_kv_input=None,
-            quantized_qkv_output=None,
-            q_output=gen_ws.q_buf,
+            workspace=params.workspace,
+            sequence_lengths=params.sequence_lengths,
+            spec_decoding_generation_lengths=params.spec_decoding_generation_lengths,
+            spec_decoding_position_offsets=params.spec_decoding_position_offsets,
             kv_cache_block_offsets=params.kv_cache_block_offsets,
             host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
             host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
-            qkv_bias=None,
-            qkv_scale_quant_orig=params.kv_scale_quant_orig,
-            qkv_scale_orig_quant=params.kv_scale_orig_quant,
-            o_scale_orig_quant=params.attention_output_orig_quant,
-            fmha_bmm1_scale=gen_ws.bmm1_scale,
-            fmha_bmm2_scale=gen_ws.bmm2_scale,
-            fmha_tile_counter=None,
-            logn_scaling=None,
-            tokens_info=(gen_ws.tokens_info if is_multi_token_gen else None),
-            seq_lens=(params.spec_decoding_generation_lengths if is_multi_token_gen else None),
-            cache_seq_lens=params.sequence_lengths,
-            encoder_seq_lens=None,
-            cu_seq_lens=cu_seqlens,
-            cu_kv_seq_lens=cu_kv_seqlens,
-            sparse_kv_offsets=None,
-            sparse_kv_indices=None,
-            rotary_embedding_inv_freq=rotary_inv_freq_buf,
-            rotary_coef_cache_buffer=params.rotary_cos_sin,
-            spec_decoding_position_offsets=(
-                params.spec_decoding_position_offsets if is_multi_token_gen else None
-            ),
-            mrope_rotary_cos_sin=None,
-            mrope_position_deltas=None,
-            batch_size=batch_beam,
-            max_input_seq_len=params.input_seq_length,
-            max_kv_seq_len=params.max_past_kv_length,
-            cyclic_kv_cache_len=params.cyclic_attention_window_size,
-            sink_token_len=params.sink_token_length,
-            token_num=params.num_tokens,
-            remove_padding=params.remove_padding,
-            is_last_chunk=False,
-            cross_attention=params.cross_attention,
-            head_num=params.num_heads,
-            kv_head_num=params.num_kv_heads,
-            qheads_per_kv_head=params.num_heads // params.num_kv_heads,
-            size_per_head=params.head_size,
-            fmha_host_bmm1_scale=params.bmm1_scale,
+            kv_scale_orig_quant=params.kv_scale_orig_quant,
+            kv_scale_quant_orig=params.kv_scale_quant_orig,
+            attention_output_orig_quant=params.attention_output_orig_quant,
+            rotary_inv_freq=params.rotary_inv_freq,
+            rotary_cos_sin=params.rotary_cos_sin,
+            layer_idx=params.layer_idx,
+            seq_offset=params.seq_offset,
+            num_heads=params.num_heads,
+            num_kv_heads=params.num_kv_heads,
+            head_size=params.head_size,
+            tokens_per_block=params.tokens_per_block,
+            kv_cache_quant_mode=params.kv_cache_quant_mode,
+            max_attention_window_size=params.max_attention_window_size,
+            cyclic_attention_window_size=params.cyclic_attention_window_size,
+            sink_token_length=params.sink_token_length,
+            num_tokens=params.num_tokens,
+            batch_beam=batch_beam,
+            input_seq_length=params.input_seq_length,
+            max_past_kv_length=params.max_past_kv_length,
             rotary_embedding_dim=params.rotary_embedding_dim,
             rotary_embedding_base=params.rotary_embedding_base,
-            rotary_scaling_type=params.rotary_embedding_scale_type,
+            rotary_embedding_scale_type=params.rotary_embedding_scale_type,
             rotary_embedding_scale=params.rotary_embedding_scale,
             rotary_embedding_max_positions=params.rotary_embedding_max_positions,
             position_embedding_type=params.position_embedding_type,
-            position_shift_enabled=params.position_shift_enabled,
-            separate_q_kv_output=True,
-            quantized_fp8_output=params.fp8_context_fmha,
-            generation_phase=True,
-            rotary_vision_start=0,
-            rotary_vision_length=0,
-            layer_idx=params.layer_idx,
-            tokens_per_block=params.tokens_per_block,
-            max_attention_window_size=params.max_attention_window_size,
-            kv_cache_quant_mode=params.kv_cache_quant_mode,
-            cyclic_attention_window_size=params.cyclic_attention_window_size,
-            beam_width=params.beam_width,
-            sink_token_length=params.sink_token_length,
-            seq_offset=params.seq_offset,
-            is_mla_enable=params.is_mla_enable,
+            bmm1_scale=params.bmm1_scale,
+            bmm2_scale=params.bmm2_scale,
+            fp8_context_fmha=params.fp8_context_fmha,
+            predicted_tokens_per_seq=params.predicted_tokens_per_seq,
+            attention_chunk_size=params.attention_chunk_size,
+            total_num_blocks=total_num_blocks,
+            kv_factor=kv_factor,
+            need_build_kv_cache_metadata=False,
         )
 
-        q_processed = gen_ws.q_buf.view(params.num_tokens, params.num_heads, params.head_size)
-        gen_ws.trtllm_gen_workspace.zero_()
+        q_len_per_req = None if is_multi_token_gen else params.input_seq_length
+        decode_max_q_len = max_q_len if is_multi_token_gen else None
+        decode_cu_seqlens = cu_seqlens if is_multi_token_gen else None
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            query=q_processed,
+            kv_cache=kv_cache,
+            workspace_buffer=fmha_workspace,
+            block_tables=block_tables,
+            seq_lens=params.sequence_lengths,
+            max_seq_len=max_kv_len,
+            out=params.context_buf,
+            bmm1_scale=params.bmm1_scale,
+            bmm2_scale=params.bmm2_scale,
+            window_left=window_left,
+            kv_layout=self._layout,
+            sinks=params.attention_sinks,
+            q_len_per_req=q_len_per_req,
+            max_q_len=decode_max_q_len,
+            cum_seq_lens_q=decode_cu_seqlens,
+            uses_shared_paged_kv_idx=False,
+            enable_pdl=self._enable_pdl,
+            backend="trtllm-gen",
+        )
 
-        # FlashInfer's trtllm-gen decode kernel needs to know the actual
-        # number of query tokens per request to correctly derive batch_size
-        # from the flattened query tensor:
-        #
-        #   query.shape = [num_tokens, num_heads, head_dim]
-        #     where num_tokens = batch_size * input_seq_length
-        #
-        # FlashInfer computes batch_size internally as:
-        #   - If q_len_per_req is set:  batch_size = num_tokens / q_len_per_req
-        #   - If q_len_per_req is None: batch_size = cum_seq_lens_q.size(0) - 1
-        #
-        # This is critical for speculative decoding (e.g., Eagle3) where each
-        # request may have multiple query tokens (input_seq_length > 1) even when
-        # predicted_tokens_per_seq == 1 (as on Blackwell where
-        # is_spec_decoding_enabled is forced False). Without the correct
-        # q_len_per_req, FlashInfer would compute batch_size = num_tokens
-        # (assuming 1 token/req), causing out-of-bounds reads on block_tables
-        # which only has batch_size rows.
-        #
-        # Two branches handle different query-length distributions:
-        #   - is_multi_token_gen (variable lengths): use cum_seq_lens_q from
-        #     build_decoder_info, which encodes per-request query lengths.
-        #   - else (uniform lengths): use q_len_per_req = input_seq_length.
-        #     This covers both normal single-token decode (input_seq_length=1)
-        #     and uniform multi-token decode (input_seq_length>1).
-        if is_multi_token_gen:
-            flashinfer.decode.trtllm_batch_decode_with_kv_cache(
-                query=q_processed,
-                kv_cache=kv_cache,
-                workspace_buffer=gen_ws.trtllm_gen_workspace,
-                block_tables=block_tables,
-                seq_lens=params.sequence_lengths,
-                max_seq_len=params.max_past_kv_length,
-                out=params.context_buf,
-                bmm1_scale=params.bmm1_scale,
-                bmm2_scale=params.bmm2_scale,
-                window_left=window_left,
-                kv_layout=self._layout,
-                sinks=params.attention_sinks,
-                q_len_per_req=None,
-                max_q_len=params.input_seq_length,
-                cum_seq_lens_q=cu_seqlens,
-                uses_shared_paged_kv_idx=False,
-                enable_pdl=get_env_enable_pdl(),
-                backend="trtllm-gen",
-            )
-        else:
-            flashinfer.decode.trtllm_batch_decode_with_kv_cache(
-                query=q_processed,
-                kv_cache=kv_cache,
-                workspace_buffer=gen_ws.trtllm_gen_workspace,
-                block_tables=block_tables,
-                seq_lens=params.sequence_lengths,
-                max_seq_len=params.max_past_kv_length,
-                out=params.context_buf,
-                bmm1_scale=params.bmm1_scale,
-                bmm2_scale=params.bmm2_scale,
-                window_left=window_left,
-                kv_layout=self._layout,
-                sinks=params.attention_sinks,
-                q_len_per_req=params.input_seq_length,
-                uses_shared_paged_kv_idx=False,
-                enable_pdl=get_env_enable_pdl(),
-                backend="trtllm-gen",
-            )
-
-    def run_mla_generation(self, params: EnqueueGenerationParams) -> None:
+    def run_mla_generation(self, params: EnqueueParams) -> None:
         """MLA generation decode using flashinfer MLA kernel."""
         if 0 < params.cyclic_attention_window_size < params.max_past_kv_length:
             raise NotImplementedError(
@@ -1419,7 +1233,6 @@ class FlashInferTrtllmGenAttention:
             host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
             host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
             layer_idx=params.layer_idx,
-            global_layer_idx=params.global_layer_idx,
             num_kv_heads=params.num_kv_heads,
             tokens_per_block=params.tokens_per_block,
             head_dim=params.head_size,
@@ -1469,503 +1282,6 @@ class FlashInferTrtllmGenAttention:
             bmm2_scale=bmm2_scale,
             sinks=params.attention_sinks,
             uses_shared_paged_kv_idx=False,
-            enable_pdl=get_env_enable_pdl(),
+            enable_pdl=self._enable_pdl,
             backend="trtllm-gen",
         )
-
-
-def is_supported(
-    q: torch.Tensor,
-    num_heads: int,
-    num_kv_heads: int,
-    head_size: int,
-    out_dtype: Optional[torch.dtype] = None,
-    mask_type: Optional[int] = None,
-    has_alibi: bool = False,
-    is_padded: bool = False,
-    use_paged_kv_cache: bool = True,
-    tokens_per_block: Optional[int] = 64,
-    beam_width: int = 1,
-    position_shift_enabled: bool = False,
-    sink_token_length: int = 0,
-    cross_attention: bool = False,
-    is_spec_decoding: bool = False,
-    is_mla_enable: bool = False,
-    is_fused_qkv: bool = True,
-    update_kv_cache: bool = True,
-    has_cross_kv: bool = False,
-    quant_config: Optional[QuantConfig] = None,
-    kv_cache_manager: Optional[KVCacheManager] = None,
-    attention_input_type: Optional[int] = None,
-    sparse_kv_indices: Optional[torch.Tensor] = None,
-    sparse_attn_indices: Optional[torch.Tensor] = None,
-    skip_softmax_threshold_scale_factor_prefill: Optional[float] = None,
-    skip_softmax_threshold_scale_factor_decode: Optional[float] = None,
-) -> Tuple[bool, str]:
-    """
-    Check if trtllm-gen backend supports the given configuration.
-
-    This is the compatibility function that wraps TrtllmGenSupportChecker.
-
-    Args:
-        q: Query tensor.
-        num_heads: Number of query attention heads.
-        num_kv_heads: Number of KV attention heads.
-        head_size: Size of each attention head.
-        out_dtype: Output data type.
-        mask_type: Attention mask type.
-        has_alibi: Whether ALiBi is used.
-        is_padded: Whether input is padded.
-        use_paged_kv_cache: Whether paged KV cache is used.
-        tokens_per_block: Tokens per KV cache block.
-        beam_width: Beam search width.
-        position_shift_enabled: Whether position shift is enabled.
-        sink_token_length: Sink token length for StreamingLLM.
-        cross_attention: Whether cross attention is used.
-        is_spec_decoding: Whether speculative decoding is enabled.
-        is_mla_enable: Whether MLA is enabled.
-        is_fused_qkv: Whether QKV is fused.
-        update_kv_cache: Whether KV cache update is enabled.
-        has_cross_kv: Whether cross KV is provided.
-        quant_config: Quantization configuration (QuantConfig).
-        kv_cache_manager: KV cache manager (its .dtype provides KV cache DataType).
-        attention_input_type: Attention input type from TrtllmAttention.
-        sparse_kv_indices: Sparse KV indices tensor for context phase.
-        sparse_attn_indices: Sparse attention indices tensor for generation phase.
-        skip_softmax_threshold_scale_factor_prefill: Scale factor for the skip-softmax
-            threshold in prefill phase. Non-None indicates skip-softmax is enabled.
-        skip_softmax_threshold_scale_factor_decode: Scale factor for the skip-softmax
-            threshold in decode phase. Non-None indicates skip-softmax is enabled.
-
-    Returns:
-        Tuple of (is_supported, reason_if_not_supported).
-    """
-    kv_cache_dtype = torch_dtype_to_binding(q.dtype)
-    if kv_cache_manager is not None:
-        kv_cache_dtype = kv_cache_manager.dtype
-
-    return FlashInferTrtllmGenAttention(
-        kv_cache_manager=kv_cache_manager, quant_config=quant_config
-    ).is_supported(
-        attention_input_type=attention_input_type,
-        q_dtype=q.dtype,
-        kv_cache_dtype=kv_cache_dtype,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_size=head_size,
-        out_dtype=out_dtype,
-        mask_type=mask_type if mask_type is not None else 1,
-        beam_width=beam_width,
-        sink_token_length=sink_token_length,
-        tokens_per_block=tokens_per_block,
-        use_paged_kv_cache=use_paged_kv_cache,
-        is_mla_enable=is_mla_enable,
-        is_fused_qkv=is_fused_qkv,
-        update_kv_cache=update_kv_cache,
-        cross_attention=cross_attention or has_cross_kv,
-        is_spec_decoding=is_spec_decoding,
-        has_alibi=has_alibi,
-        is_padded=is_padded,
-        position_shift_enabled=position_shift_enabled,
-        quant_config=quant_config,
-        sparse_kv_indices=sparse_kv_indices,
-        sparse_attn_indices=sparse_attn_indices,
-        skip_softmax_threshold_scale_factor_prefill=skip_softmax_threshold_scale_factor_prefill,
-        skip_softmax_threshold_scale_factor_decode=skip_softmax_threshold_scale_factor_decode,
-    )
-
-
-def trtllm_gen_attention(
-    q: torch.Tensor,
-    k: Optional[torch.Tensor],
-    v: Optional[torch.Tensor],
-    output: torch.Tensor,
-    output_sf: Optional[torch.Tensor],
-    workspace: Optional[torch.Tensor],
-    sequence_length: torch.Tensor,
-    host_past_key_value_lengths: torch.Tensor,
-    host_total_kv_lens: torch.Tensor,
-    context_lengths: torch.Tensor,
-    host_context_lengths: torch.Tensor,
-    host_request_types: torch.Tensor,
-    kv_cache_block_offsets: Optional[torch.Tensor],
-    host_kv_cache_pool_pointers: Optional[torch.Tensor],
-    host_kv_cache_pool_mapping: Optional[torch.Tensor],
-    cache_indirection: Optional[torch.Tensor],
-    kv_scale_orig_quant: Optional[torch.Tensor],
-    kv_scale_quant_orig: Optional[torch.Tensor],
-    out_scale: Optional[torch.Tensor],
-    rotary_inv_freq: Optional[torch.Tensor],
-    rotary_cos_sin: Optional[torch.Tensor],
-    latent_cache: Optional[torch.Tensor],
-    q_pe: Optional[torch.Tensor],
-    block_ids_per_seq: Optional[torch.Tensor],
-    attention_sinks: Optional[torch.Tensor],
-    is_fused_qkv: bool,
-    update_kv_cache: bool,
-    predicted_tokens_per_seq: int,
-    layer_idx: int,
-    num_heads: int,
-    num_kv_heads: int,
-    head_size: int,
-    tokens_per_block: Optional[int],
-    max_num_requests: int,
-    max_context_length: int,
-    attention_window_size: int,
-    sink_token_length: int,
-    beam_width: int,
-    mask_type: int,
-    quant_mode: int,
-    q_scaling: float,
-    position_embedding_type: int,
-    rotary_embedding_dim: int,
-    rotary_embedding_base: float,
-    rotary_embedding_scale_type: int,
-    rotary_embedding_scales: List[float],
-    rotary_embedding_max_position_info: List[int],
-    use_paged_context_fmha: bool,
-    attention_input_type: Optional[int],
-    is_mla_enable: bool,
-    chunked_prefill_buffer_batch_size: Optional[int],
-    q_lora_rank: Optional[int],
-    kv_lora_rank: Optional[int],
-    qk_nope_head_dim: Optional[int],
-    qk_rope_head_dim: Optional[int],
-    v_head_dim: Optional[int],
-    mrope_rotary_cos_sin: Optional[torch.Tensor],
-    mrope_position_deltas: Optional[torch.Tensor],
-    helix_tensor_params: List[Optional[torch.Tensor]],
-    attention_chunk_size: Optional[int],
-    softmax_stats_tensor: Optional[torch.Tensor],
-    spec_decoding_bool_params: List[bool],
-    spec_decoding_tensor_params: List[Optional[torch.Tensor]],
-    sparse_kv_indices: Optional[torch.Tensor],
-    sparse_kv_offsets: Optional[torch.Tensor],
-    sparse_attn_indices: Optional[torch.Tensor],
-    sparse_attn_offsets: Optional[torch.Tensor],
-    sparse_attn_indices_block_size: int,
-    num_sparse_topk: Optional[int],
-    skip_softmax_threshold_scale_factor_prefill: Optional[float],
-    skip_softmax_threshold_scale_factor_decode: Optional[float],
-    skip_softmax_stat: Optional[torch.Tensor],
-    cu_q_seqlens: Optional[torch.Tensor],
-    cu_kv_seqlens: Optional[torch.Tensor],
-    fmha_scheduler_counter: Optional[torch.Tensor],
-    mla_bmm1_scale: Optional[torch.Tensor],
-    mla_bmm2_scale: Optional[torch.Tensor],
-    quant_q_buffer: Optional[torch.Tensor],
-    quant_config: Optional[QuantConfig],
-    kv_cache_manager: Optional[KVCacheManager],
-    num_contexts: int,
-    num_ctx_tokens: int,
-    global_layer_idx: Optional[int] = None,
-) -> None:
-    """
-    TrtLLM-Gen attention using flashinfer backend.
-
-    This function is a drop-in replacement for thop.attention() but only
-    supports trtllm-gen kernel (Blackwell architecture).
-
-    It uses flashinfer's batch attention APIs:
-    - flashinfer.prefill.trtllm_batch_context_with_kv_cache for context phase
-    - flashinfer.decode.trtllm_batch_decode_with_kv_cache for generation phase
-
-    Args:
-        q: Query tensor [num_tokens, hidden_dim].
-        k: Key tensor (None if fused QKV).
-        v: Value tensor (None if fused QKV).
-        output: Output tensor [num_tokens, num_heads * head_size].
-        output_sf: Output scale factor for FP4 output (optional).
-        workspace: Workspace tensor for attention computation.
-        sequence_length: KV sequence lengths per request [batch_size].
-        host_past_key_value_lengths: Past KV lengths on host [batch_size].
-        host_total_kv_lens: Total KV lengths on host.
-        context_lengths: Context lengths per request [batch_size].
-        host_context_lengths: Context lengths on host [batch_size].
-        host_request_types: Request types on host (0=context, 1=generation) [batch_size].
-        kv_cache_block_offsets: Block offsets for paged KV cache [num_pools, batch, 2, max_blocks].
-        host_kv_cache_pool_pointers: KV cache pool pointers on host.
-        host_kv_cache_pool_mapping: KV cache pool mapping on host [num_layers, num_pools].
-        kv_cache: Actual KV cache tensor from kv_cache_manager [num_blocks, 2, num_kv_heads,
-                  tokens_per_block, head_size].
-        cache_indirection: Cache indirection tensor for beam search.
-        kv_scale_orig_quant: KV cache quantization scales (original to quantized).
-        kv_scale_quant_orig: KV cache dequantization scales (quantized to original).
-        out_scale: Output scaling factor for quantized output.
-        rotary_inv_freq: Rotary embedding inverse frequencies.
-        rotary_cos_sin: Precomputed rotary cosine/sine values.
-        latent_cache: Latent cache for MLA (Multi-head Latent Attention).
-        q_pe: Query positional encoding for MLA.
-        block_ids_per_seq: Block IDs per sequence for sparse attention.
-        attention_sinks: Attention sink tokens for StreamingLLM.
-        is_fused_qkv: Whether Q, K, V are fused in the query tensor.
-        update_kv_cache: Whether to update KV cache with new K, V values.
-        predicted_tokens_per_seq: Number of predicted tokens per sequence (speculative decoding).
-        layer_idx: Current transformer layer index.
-        num_heads: Number of query attention heads.
-        num_kv_heads: Number of key-value attention heads (for GQA/MQA).
-        head_size: Size of each attention head.
-        tokens_per_block: Number of tokens per KV cache block (page size).
-        max_num_requests: Maximum number of requests in a batch.
-        max_context_length: Maximum context/sequence length supported.
-        attention_window_size: Sliding window attention size (0 for full attention).
-        sink_token_length: Number of sink tokens for StreamingLLM.
-        beam_width: Beam search width (1 for greedy decoding).
-        mask_type: Attention mask type (0=padding, 1=causal, 2=bidirectional, 3=custom).
-        quant_mode: Quantization mode flags.
-        q_scaling: Query scaling factor for attention scores.
-        position_embedding_type: Type of position embedding (0=learned, 1=rope, etc.).
-        rotary_embedding_dim: Dimension for rotary embeddings.
-        rotary_embedding_base: Base value for rotary embedding frequencies.
-        rotary_embedding_scale_type: Scaling type for rotary embeddings.
-        rotary_embedding_scales: Scaling factors for rotary embeddings.
-        rotary_embedding_max_position_info: Maximum position info for rotary embeddings.
-        use_paged_context_fmha: Whether to use paged attention for context phase.
-        attention_input_type: Input type (0=context_only, 1=generation_only, 2=mixed).
-        is_mla_enable: Whether Multi-head Latent Attention is enabled.
-        chunked_prefill_buffer_batch_size: Batch size for chunked prefill buffer.
-        q_lora_rank: LoRA rank for query projection (MLA).
-        kv_lora_rank: LoRA rank for key-value projection (MLA).
-        qk_nope_head_dim: Non-positional head dimension for QK (MLA).
-        qk_rope_head_dim: Rotary positional head dimension for QK (MLA).
-        v_head_dim: Value head dimension (MLA).
-        mrope_rotary_cos_sin: Multi-dimensional rotary cosine/sine values.
-        mrope_position_deltas: Position deltas for multi-dimensional rotary.
-        helix_tensor_params: [helix_position_offsets, helix_is_inactive_rank]
-            for Helix parallelism. Unused; accepted for interface parity.
-        attention_chunk_size: Chunk size for chunked attention computation.
-        softmax_stats_tensor: Tensor for storing softmax statistics.
-        spec_decoding_bool_params: Boolean parameters for speculative decoding.
-        spec_decoding_tensor_params: Tensor parameters for speculative decoding.
-        sparse_kv_indices: Indices for sparse KV cache access.
-        sparse_kv_offsets: Offsets for sparse KV cache access.
-        sparse_attn_indices: Indices for sparse attention patterns.
-        sparse_attn_offsets: Offsets for sparse attention patterns.
-        sparse_attn_indices_block_size: Block size for sparse attention indices.
-        num_sparse_topk: Top-K value for sparse attention.
-        skip_softmax_threshold_scale_factor_prefill: Scale factor for skip softmax threshold (prefill).
-        skip_softmax_threshold_scale_factor_decode: Scale factor for skip softmax threshold (decode).
-        skip_softmax_stat: Statistics for skip softmax optimization.
-        cu_q_seqlens: Cumulative query sequence lengths [batch_size + 1].
-        cu_kv_seqlens: Cumulative KV sequence lengths [batch_size + 1].
-        fmha_scheduler_counter: Counter for FMHA scheduler.
-        mla_bmm1_scale: BMM1 scale for MLA attention.
-        mla_bmm2_scale: BMM2 scale for MLA attention.
-        quant_q_buffer: Buffer for quantized query tensor.
-        quant_config: Quantization configuration (QuantConfig).
-        kv_cache_manager: KV cache manager (KVCacheManager).
-
-    Returns:
-        None. Results are written to the output tensor in-place.
-    """
-    logger.debug(f"trtllm_gen_attention starts at layer {layer_idx}")
-
-    backend = FlashInferTrtllmGenAttention(
-        kv_cache_manager=kv_cache_manager, quant_config=quant_config
-    )
-
-    is_fp8_out = output.dtype == torch.float8_e4m3fn
-    is_fp4_out = output.dtype == torch.uint8
-    kv_cache_quant_mode = QuantMode(quant_mode)
-
-    has_kv_cache_quant = kv_cache_quant_mode.has_kv_cache_quant()
-    resolved_kv_scale_orig_quant = None
-    resolved_kv_scale_quant_orig = None
-    if has_kv_cache_quant and kv_scale_orig_quant is not None and kv_scale_quant_orig is not None:
-        resolved_kv_scale_orig_quant = kv_scale_orig_quant
-        resolved_kv_scale_quant_orig = kv_scale_quant_orig
-        if kv_cache_quant_mode.has_fp4_kv_cache():
-            assert resolved_kv_scale_orig_quant.size(0) == 3, (
-                f"kv_scale_orig_quant must have size(0)==3 for FP4, got {resolved_kv_scale_orig_quant.size(0)}"
-            )
-            assert resolved_kv_scale_quant_orig.size(0) == 3, (
-                f"kv_scale_quant_orig must have size(0)==3 for FP4, got {resolved_kv_scale_quant_orig.size(0)}"
-            )
-
-    num_tokens = q.size(0)
-
-    attn_input_type = AttentionInputType.mixed
-    if attention_input_type is not None:
-        attn_input_type = AttentionInputType(attention_input_type)
-
-    is_gen_only = attn_input_type == AttentionInputType.generation_only
-
-    num_generations = host_request_types.size(0) - num_contexts
-    num_gen_tokens = num_tokens if is_gen_only else num_tokens - num_ctx_tokens
-
-    # Prepare Workspace
-    # Use upper-bound token counts for workspace sizing to avoid repeated
-    # resizes during inference. The workspace contains variable-size buffers
-    # (q_buf, tokens_info) whose sizes depend on actual token counts. Using
-    # upper bounds allocates workspace to its maximum from the first call:
-    #   - max_context_length bounds total tokens (= configured max_num_tokens)
-    #   - max_num_requests bounds generation tokens (1 token per gen request)
-    workspace_max_tokens = max(num_tokens, max_context_length)
-    workspace_max_gen_tokens = max(num_gen_tokens, max_num_requests)
-    required_workspace_size = WorkspaceManager.get_workspace_size(
-        dtype=q.dtype,
-        num_tokens=workspace_max_tokens,
-        num_gen_tokens=workspace_max_gen_tokens,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_size=head_size,
-        max_num_requests=max_num_requests,
-        rotary_embedding_dim=rotary_embedding_dim,
-    )
-
-    # Check if we need to create/resize workspace
-    current_workspace_size = (
-        workspace.numel() * workspace.element_size() if workspace is not None else 0
-    )
-
-    if current_workspace_size < required_workspace_size:
-        logger.warning(
-            f"Attention workspace size is not enough, increase the size from "
-            f"{current_workspace_size} bytes to {required_workspace_size} bytes"
-        )
-        if workspace is None:
-            workspace = torch.zeros(required_workspace_size, device=q.device, dtype=torch.uint8)
-        else:
-            workspace.resize_(required_workspace_size)
-            workspace.zero_()
-
-    if is_mla_enable and is_gen_only and kv_lora_rank:
-        out_head_size = kv_lora_rank
-    elif is_mla_enable and v_head_dim:
-        out_head_size = v_head_dim
-    else:
-        out_head_size = head_size
-    out_tensor = output.view(num_tokens, num_heads, out_head_size)
-
-    max_attn_window_size = (
-        attention_window_size
-        if beam_width == 1
-        else (cache_indirection.size(2) if cache_indirection is not None else attention_window_size)
-    )
-    cyclic_attn_window_size = attention_window_size
-
-    common_params = dict(
-        workspace=workspace,
-        max_attention_window_size=max_attn_window_size,
-        cyclic_attention_window_size=cyclic_attn_window_size,
-        sink_token_length=sink_token_length,
-        num_heads=num_heads,
-        num_kv_heads=num_kv_heads,
-        head_size=head_size,
-        rotary_embedding_dim=rotary_embedding_dim,
-        rotary_embedding_base=rotary_embedding_base,
-        rotary_embedding_scale_type=rotary_embedding_scale_type,
-        rotary_embedding_scale=rotary_embedding_scales[0] if rotary_embedding_scales else 1.0,
-        rotary_embedding_max_positions=rotary_embedding_max_position_info[0]
-        if rotary_embedding_max_position_info
-        else 0,
-        kv_cache_block_offsets=kv_cache_block_offsets,
-        host_kv_cache_pool_pointers=host_kv_cache_pool_pointers,
-        host_kv_cache_pool_mapping=host_kv_cache_pool_mapping,
-        tokens_per_block=tokens_per_block if tokens_per_block is not None else 64,
-        mask_type=mask_type,
-        kv_cache_quant_mode=quant_mode,
-        position_embedding_type=position_embedding_type,
-        layer_idx=layer_idx,
-        global_layer_idx=global_layer_idx if global_layer_idx is not None else layer_idx,
-        kv_scale_orig_quant=resolved_kv_scale_orig_quant,
-        kv_scale_quant_orig=resolved_kv_scale_quant_orig,
-        attention_output_orig_quant=out_scale,
-        bmm1_scale=1.0 / (math.sqrt(head_size) * q_scaling),
-        bmm2_scale=1.0,
-        rotary_inv_freq=rotary_inv_freq,
-        rotary_cos_sin=rotary_cos_sin,
-        attention_chunk_size=attention_chunk_size if attention_chunk_size is not None else 0,
-        fp8_context_fmha=is_fp8_out
-        or is_fp4_out
-        or (kv_cache_quant_mode.has_fp8_kv_cache() and use_paged_context_fmha),
-        remove_padding=True,
-        cross_attention=False,
-        position_shift_enabled=False,
-        paged_context_fmha=use_paged_context_fmha,
-        attention_sinks=attention_sinks,
-        is_mla_enable=is_mla_enable,
-        kv_lora_rank=kv_lora_rank or 0,
-        qk_nope_head_dim=qk_nope_head_dim or 0,
-        qk_rope_head_dim=qk_rope_head_dim or 0,
-        v_head_dim=v_head_dim or 0,
-        q_scaling=q_scaling,
-        latent_cache=latent_cache,
-        num_layers=host_kv_cache_pool_mapping.size(0)
-        if host_kv_cache_pool_mapping is not None
-        else 0,
-    )
-
-    # Context Phase
-    if num_contexts > 0 and attn_input_type != AttentionInputType.generation_only:
-        seq_offset = 0
-        token_offset = 0
-        num_seqs = num_contexts
-
-        max_context_q_len = int(host_context_lengths[seq_offset : seq_offset + num_seqs].max())
-        max_past_kv_len = int(host_past_key_value_lengths[seq_offset : seq_offset + num_seqs].max())
-
-        ctx_params = EnqueueContextParams(
-            **common_params,
-            attention_input=q[token_offset : token_offset + num_ctx_tokens],
-            qkv_input=q[token_offset : token_offset + num_ctx_tokens],
-            context_buf=out_tensor[token_offset : token_offset + num_ctx_tokens],
-            sequence_lengths=sequence_length[seq_offset:],
-            context_lengths=context_lengths[seq_offset:],
-            max_past_kv_length=max_past_kv_len,
-            num_tokens=num_ctx_tokens,
-            seq_offset=seq_offset,
-            input_seq_length=max_context_q_len,
-            batch_size=num_seqs,
-            mrope_rotary_cos_sin=mrope_rotary_cos_sin,
-        )
-        backend.run_context(ctx_params)
-
-    # Generation Phase
-    if num_generations > 0 and attn_input_type != AttentionInputType.context_only:
-        seq_offset = num_contexts
-        token_offset = 0 if is_gen_only else num_ctx_tokens
-        num_seqs = num_generations
-
-        max_past_kv_len = int(host_past_key_value_lengths[seq_offset : seq_offset + num_seqs].max())
-        input_seq_length = num_gen_tokens // num_seqs if num_seqs > 0 else 1
-
-        spec_gen_lengths = None
-        spec_pos_offsets = None
-        spec_packed_mask = None
-        if (
-            spec_decoding_bool_params
-            and len(spec_decoding_bool_params) >= 2
-            and spec_decoding_bool_params[0]
-            and spec_decoding_bool_params[1]
-            and predicted_tokens_per_seq > 1
-        ):
-            if spec_decoding_tensor_params and len(spec_decoding_tensor_params) >= 3:
-                spec_gen_lengths = spec_decoding_tensor_params[0]
-                spec_pos_offsets = spec_decoding_tensor_params[1]
-                spec_packed_mask = spec_decoding_tensor_params[2]
-
-        gen_params = EnqueueGenerationParams(
-            **common_params,
-            attention_input=q[token_offset : token_offset + num_gen_tokens],
-            qkv_input=q[token_offset : token_offset + num_gen_tokens],
-            context_buf=out_tensor[token_offset : token_offset + num_gen_tokens],
-            sequence_lengths=sequence_length[seq_offset:],
-            context_lengths=context_lengths[seq_offset:],
-            max_past_kv_length=max_past_kv_len,
-            num_tokens=num_gen_tokens,
-            seq_offset=seq_offset,
-            input_seq_length=input_seq_length,
-            beam_width=beam_width,
-            num_requests=num_seqs // beam_width,
-            predicted_tokens_per_seq=predicted_tokens_per_seq,
-            spec_decoding_generation_lengths=spec_gen_lengths,
-            spec_decoding_position_offsets=spec_pos_offsets,
-            spec_decoding_packed_mask=spec_packed_mask,
-        )
-        if is_mla_enable:
-            backend.run_mla_generation(gen_params)
-        else:
-            backend.run_generation(gen_params)
-
-    logger.debug(f"trtllm_gen_attention stops at layer {layer_idx}")

--- a/tensorrt_llm/_torch/attention_backend/trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm_gen.py
@@ -30,7 +30,7 @@ from typing import List, Optional, Tuple
 
 import torch
 
-from tensorrt_llm._torch.flashinfer_utils import IS_FLASHINFER_AVAILABLE
+from tensorrt_llm._torch.flashinfer_utils import IS_FLASHINFER_AVAILABLE, get_env_enable_pdl
 
 if IS_FLASHINFER_AVAILABLE:
     import flashinfer
@@ -44,6 +44,7 @@ from tensorrt_llm._utils import (
     torch_dtype_to_binding,
 )
 from tensorrt_llm.bindings import DataType
+from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import AttentionMaskType
 from tensorrt_llm.logger import logger
 from tensorrt_llm.models.modeling_utils import QuantConfig
@@ -98,8 +99,10 @@ class TrtllmGenSupportChecker:
         (torch.float16, DataType.FP8, torch.float16),
     }
 
-    # Unsupported head sizes for context FMHA
-    UNSUPPORTED_HEAD_SIZES_CONTEXT = {72, 80}
+    # Unsupported head sizes for context FMHA.
+    # 96 is excluded because trtllm-gen kernel library does not ship
+    # context kernels for headDim=96 (affects Phi-3 family models).
+    UNSUPPORTED_HEAD_SIZES_CONTEXT = {72, 80, 96}
 
     # Maximum heads ratio for generation.
     MAX_HEADS_RATIO_GENERATION = 32
@@ -118,7 +121,7 @@ class TrtllmGenSupportChecker:
         num_heads: int,
         num_kv_heads: int,
         head_size: int,
-        phase: str = "both",
+        attention_input_type: Optional[int] = None,
         out_dtype: Optional[torch.dtype] = None,
         mask_type: int = 1,
         beam_width: int = 1,
@@ -141,6 +144,12 @@ class TrtllmGenSupportChecker:
     ) -> Tuple[bool, str]:
         if tokens_per_block is None:
             tokens_per_block = 0
+        has_context_phase = True
+        has_generation_phase = True
+        if attention_input_type is not None:
+            attn_input_type = AttentionInputType(attention_input_type)
+            has_context_phase = attn_input_type != AttentionInputType.generation_only
+            has_generation_phase = attn_input_type != AttentionInputType.context_only
 
         sm = get_sm_version()
         if not is_sm_100f(sm):
@@ -159,6 +168,11 @@ class TrtllmGenSupportChecker:
         has_sparse_attn = sparse_attn_indices is not None and sparse_attn_indices.numel() > 0
         if has_sparse_kv or has_sparse_attn:
             return False, "Sparse attention is not supported by trtllm-gen backend."
+        if is_mla_enable and has_context_phase:
+            return False, (
+                "MLA context and mixed phases fall back to thop.attention until "
+                "FlashInfer context support is ready."
+            )
         if is_mla_enable and not is_fused_qkv:
             return False, "MLA context (separate Q/K/V) falls back to thop."
         if not update_kv_cache:
@@ -193,7 +207,8 @@ class TrtllmGenSupportChecker:
 
         o_dtype = out_dtype if out_dtype is not None else q_dtype
 
-        if phase in ("context", "both"):
+        check_context_phase = has_context_phase and not is_mla_enable
+        if check_context_phase:
             if head_size in cls.UNSUPPORTED_HEAD_SIZES_CONTEXT:
                 return False, f"[Context] Head size {head_size} is not supported."
             try:
@@ -210,7 +225,7 @@ class TrtllmGenSupportChecker:
                     f"[Context] Unsupported dtype combination: Q={q_dtype}, KV={kv_cache_dtype}, O={o_dtype}."
                 )
 
-        if phase in ("generation", "both"):
+        if has_generation_phase:
             if beam_width != 1:
                 return (
                     False,
@@ -897,10 +912,10 @@ class FlashInferTrtllmGenAttention:
         """KV cache layout."""
         return self._layout
 
-    def is_supported(self, phase: str = "both", **kwargs) -> Tuple[bool, str]:
+    def is_supported(self, **kwargs) -> Tuple[bool, str]:
         if not IS_FLASHINFER_AVAILABLE:
             return False, "flashinfer package is not installed."
-        return self._checker.is_supported(phase=phase, **kwargs)
+        return self._checker.is_supported(**kwargs)
 
     @staticmethod
     def _compute_window_left(
@@ -922,70 +937,85 @@ class FlashInferTrtllmGenAttention:
             return cyclic_attention_window_size - 1
         return -1
 
-    def _build_block_tables(
+    def _get_kv_cache_and_block_tables(
         self,
         kv_cache_block_offsets,
+        host_kv_cache_pool_pointers,
         host_kv_cache_pool_mapping,
         layer_idx: int,
         global_layer_idx: int,
+        num_kv_heads: int,
+        tokens_per_block: int,
+        head_dim: int,
+        kv_cache_quant_mode: int,
         batch_start: int,
         batch_size: int,
+        dtype: torch.dtype,
+        is_mla_enable: bool = False,
     ):
-        """Convert C++ KVBlockArray block offsets to FlashInfer page indices.
+        """Get FlashInfer kv_cache and block_tables.
 
-        The C++ qkv_preprocessing kernel writes K/V via KVBlockArray, which
-        addresses the pool as: pool_base + block_offset * bytes_per_single_kv_block.
-        Each K/V block is a separate entry (K at offset N, V at N+1).
+        The kv_cache tensor is a flat-block view of the KV cache pool,
+        created per layer via C++ op build_kv_cache_buffers().
 
-        FlashInfer indexes into the tensor returned by get_buffers(layer_idx),
-        where each "page" spans one K block + one V block.  The page stride
-        (get_buffers().stride(0)) varies by KV cache manager:
+        Shape: [total_blocks, num_kv_heads, tokens_per_block, head_dim]
+        where each dim-0 element = one single K or V block.
 
-        - KVCacheManager (V1): strided view over multi-layer pool.
-          stride(0) = num_layers * single_kv_block_elems, so
-          divisor = num_layers (e.g. 72).
-          k_offset = page * num_layers -> page = k_offset // 72.
-        - KVCacheManagerV2: contiguous per-layer tensor.
-          stride(0) = kv_factor * single_kv_block_elems, so
-          divisor = kv_factor (= 2).
-          k_offset = page * num_layers * kv_factor + layer * kv_factor
-          -> page_in_tensor = k_offset // 2.
+        FlashInfer receives kv_cache as a tuple (kv_pool, kv_pool) where
+        K and V share the same pool tensor. With uses_shared_paged_kv_idx=
+        False (flashinfer PR #2770), the kernel reads K/V offsets separately
+        from block_tables[batch, 2, max_blocks] and computes:
+            K_addr = pool_ptr + K_offset * block_size
+            V_addr = pool_ptr + V_offset * block_size
 
-        The unified formula k_offsets // (stride(0) // single_kv_block_elems)
-        handles both layouts without branching.
+        Raw block offsets are used directly as indices -- no division needed.
 
-        TODO: This conversion exists because FlashInfer's trtllm-gen FMHA
-        kernels use a shared paged KV cache index (one page index covers both
-        K and V), while TRT-LLM's KVBlockArray uses separate K/V global
-        block offsets (K at offset N, V at offset N+1). Once the trtllm-gen
-        kernels natively support TRT-LLM's separate K/V index layout (i.e.,
-        accepting kv_cache_block_offsets directly with independent K and V
-        columns and pool-pointer-based addressing), this entire method can be
-        removed and kv_cache_block_offsets can be passed through directly.
-        Tracking: https://github.com/flashinfer-ai/flashinfer/issues/2694
-
-        Args:
-            layer_idx: Local layer offset used to index host_kv_cache_pool_mapping.
-            global_layer_idx: Global layer index used as key in
-                kv_cache_manager.get_buffers() / layer_offsets.
+        block_tables is a lightweight Python tensor slice (no C++ op call),
+        computed fresh each forward pass since batch composition changes.
         """
         if kv_cache_block_offsets is None:
-            return None
+            return None, None
+
+        kv_factor = 1 if is_mla_enable else 2
+        total_num_blocks = (
+            self._kv_cache_manager.blocks_in_primary_pool
+            * self._kv_cache_manager.num_local_layers
+            * kv_factor
+        )
+        kv_pool, _ = thop.build_kv_cache_buffers(
+            host_kv_cache_pool_pointers,
+            host_kv_cache_pool_mapping,
+            layer_idx,
+            num_kv_heads,
+            tokens_per_block,
+            head_dim,
+            kv_factor,
+            total_num_blocks,
+            kv_cache_quant_mode,
+            dtype,
+        )
         pool_idx = int(host_kv_cache_pool_mapping[layer_idx, 0])
-        k_offsets = kv_cache_block_offsets[pool_idx, batch_start : batch_start + batch_size, 0, :]
-        kv_buf = self._kv_cache_manager.get_buffers(global_layer_idx, kv_layout=DEFAULT_KV_LAYOUT)
-        single_kv_block_elems = kv_buf.shape[2] * kv_buf.shape[3] * kv_buf.shape[4]
-        divisor = kv_buf.stride(0) // single_kv_block_elems
-        return k_offsets // divisor
+
+        # block_tables: pure Python slice, no C++ op, no division
+        block_tables = kv_cache_block_offsets[pool_idx, batch_start : batch_start + batch_size]
+
+        return (kv_pool, kv_pool), block_tables
 
     def run_context(self, params: EnqueueContextParams):
-        block_tables = self._build_block_tables(
-            params.kv_cache_block_offsets,
-            params.host_kv_cache_pool_mapping,
-            params.layer_idx,
-            params.global_layer_idx,
-            params.seq_offset,
-            params.batch_size,
+        kv_cache, block_tables = self._get_kv_cache_and_block_tables(
+            kv_cache_block_offsets=params.kv_cache_block_offsets,
+            host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
+            host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
+            layer_idx=params.layer_idx,
+            global_layer_idx=params.global_layer_idx,
+            num_kv_heads=params.num_kv_heads,
+            tokens_per_block=params.tokens_per_block,
+            head_dim=params.head_size,
+            kv_cache_quant_mode=params.kv_cache_quant_mode,
+            batch_start=params.seq_offset,
+            batch_size=params.batch_size,
+            dtype=params.attention_input.dtype,
+            is_mla_enable=params.is_mla_enable,
         )
         window_left = self._compute_window_left(
             params.cyclic_attention_window_size,
@@ -1132,9 +1162,7 @@ class FlashInferTrtllmGenAttention:
 
         flashinfer.prefill.trtllm_batch_context_with_kv_cache(
             query=q_processed,
-            kv_cache=self._kv_cache_manager.get_buffers(
-                params.global_layer_idx, kv_layout=DEFAULT_KV_LAYOUT
-            ),
+            kv_cache=kv_cache,
             workspace_buffer=ctx_ws.trtllm_gen_workspace,
             block_tables=block_tables,
             seq_lens=params.sequence_lengths,
@@ -1149,19 +1177,28 @@ class FlashInferTrtllmGenAttention:
             out=params.context_buf,
             kv_layout=self._layout,
             sinks=params.attention_sinks,
+            uses_shared_paged_kv_idx=False,
+            enable_pdl=get_env_enable_pdl(),
         )
 
         torch.ops.trtllm.kv_cache_postprocessing(**ctx_qkv_args)
 
     def run_generation(self, params: EnqueueGenerationParams):
         batch_beam = params.num_requests * params.beam_width
-        block_tables = self._build_block_tables(
-            params.kv_cache_block_offsets,
-            params.host_kv_cache_pool_mapping,
-            params.layer_idx,
-            params.global_layer_idx,
-            params.seq_offset,
-            batch_beam,
+        kv_cache, block_tables = self._get_kv_cache_and_block_tables(
+            kv_cache_block_offsets=params.kv_cache_block_offsets,
+            host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
+            host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
+            layer_idx=params.layer_idx,
+            global_layer_idx=params.global_layer_idx,
+            num_kv_heads=params.num_kv_heads,
+            tokens_per_block=params.tokens_per_block,
+            head_dim=params.head_size,
+            kv_cache_quant_mode=params.kv_cache_quant_mode,
+            batch_start=params.seq_offset,
+            batch_size=batch_beam,
+            dtype=params.attention_input.dtype,
+            is_mla_enable=params.is_mla_enable,
         )
         window_left = self._compute_window_left(
             params.cyclic_attention_window_size,
@@ -1329,9 +1366,7 @@ class FlashInferTrtllmGenAttention:
         if is_multi_token_gen:
             flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=q_processed,
-                kv_cache=self._kv_cache_manager.get_buffers(
-                    params.global_layer_idx, kv_layout=DEFAULT_KV_LAYOUT
-                ),
+                kv_cache=kv_cache,
                 workspace_buffer=gen_ws.trtllm_gen_workspace,
                 block_tables=block_tables,
                 seq_lens=params.sequence_lengths,
@@ -1345,13 +1380,14 @@ class FlashInferTrtllmGenAttention:
                 q_len_per_req=None,
                 max_q_len=params.input_seq_length,
                 cum_seq_lens_q=cu_seqlens,
+                uses_shared_paged_kv_idx=False,
+                enable_pdl=get_env_enable_pdl(),
+                backend="trtllm-gen",
             )
         else:
             flashinfer.decode.trtllm_batch_decode_with_kv_cache(
                 query=q_processed,
-                kv_cache=self._kv_cache_manager.get_buffers(
-                    params.global_layer_idx, kv_layout=DEFAULT_KV_LAYOUT
-                ),
+                kv_cache=kv_cache,
                 workspace_buffer=gen_ws.trtllm_gen_workspace,
                 block_tables=block_tables,
                 seq_lens=params.sequence_lengths,
@@ -1363,6 +1399,9 @@ class FlashInferTrtllmGenAttention:
                 kv_layout=self._layout,
                 sinks=params.attention_sinks,
                 q_len_per_req=params.input_seq_length,
+                uses_shared_paged_kv_idx=False,
+                enable_pdl=get_env_enable_pdl(),
+                backend="trtllm-gen",
             )
 
     def run_mla_generation(self, params: EnqueueGenerationParams) -> None:
@@ -1375,14 +1414,25 @@ class FlashInferTrtllmGenAttention:
             raise NotImplementedError("Chunked-attention is not supported by MLA decode path.")
 
         batch_beam = params.num_requests * params.beam_width
-        block_tables = self._build_block_tables(
-            params.kv_cache_block_offsets,
-            params.host_kv_cache_pool_mapping,
-            params.layer_idx,
-            params.global_layer_idx,
-            params.seq_offset,
-            batch_beam,
+        kv_cache_tuple, block_tables = self._get_kv_cache_and_block_tables(
+            kv_cache_block_offsets=params.kv_cache_block_offsets,
+            host_kv_cache_pool_pointers=params.host_kv_cache_pool_pointers,
+            host_kv_cache_pool_mapping=params.host_kv_cache_pool_mapping,
+            layer_idx=params.layer_idx,
+            global_layer_idx=params.global_layer_idx,
+            num_kv_heads=params.num_kv_heads,
+            tokens_per_block=params.tokens_per_block,
+            head_dim=params.head_size,
+            kv_cache_quant_mode=params.kv_cache_quant_mode,
+            batch_start=params.seq_offset,
+            batch_size=batch_beam,
+            dtype=params.attention_input.dtype,
+            is_mla_enable=params.is_mla_enable,
         )
+
+        # MLA decode API takes a single kv tensor [num_pages, 1, page_size, head_dim],
+        # not the (K_pool, V_pool) tuple.
+        kv_cache = kv_cache_tuple[0]
 
         pages_per_superblock = 128 // params.tokens_per_block
         if pages_per_superblock > 1:
@@ -1397,27 +1447,12 @@ class FlashInferTrtllmGenAttention:
 
         query = params.qkv_input.view(batch_beam, q_len_per_req, params.num_heads, mla_head_dim_qk)
 
-        kv_cache = self._kv_cache_manager.get_buffers(
-            params.global_layer_idx, kv_layout=DEFAULT_KV_LAYOUT
-        )
-        if kv_cache.ndim == 5:
-            kv_cache = kv_cache.squeeze(2)
-
         bmm1_scale = 1.0 / (
             params.q_scaling * math.sqrt(params.qk_nope_head_dim + params.qk_rope_head_dim)
         )
         bmm2_scale = 1.0
 
-        # context_buf: [B*q_len, H, kv_lora_rank]
-        # flashinfer MLA decode out check only accepts [B, H, D] (3D),
-        # but kernel outputs [B, q_len, H, D] when q_len > 1.
-        # For q_len=1: pass context_buf directly (in-place, zero copy).
-        # For q_len>1: let flashinfer allocate, then copy back.
-        # Once https://github.com/flashinfer-ai/flashinfer/issues/2856 is fixed,
-        # we can remove the conditional and always pass params.context_buf.
-        out_buf = params.context_buf if q_len_per_req == 1 else None
-
-        mla_out = flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla(
+        flashinfer.mla.trtllm_batch_decode_with_kv_cache_mla(
             query=query,
             kv_cache=kv_cache,
             workspace_buffer=params.workspace.view(-1, 4),
@@ -1427,14 +1462,16 @@ class FlashInferTrtllmGenAttention:
             block_tables=block_tables,
             seq_lens=params.sequence_lengths,
             max_seq_len=params.max_past_kv_length,
-            out=out_buf,
+            out=params.context_buf.view(
+                batch_beam, q_len_per_req, params.num_heads, params.kv_lora_rank
+            ),
             bmm1_scale=bmm1_scale,
             bmm2_scale=bmm2_scale,
             sinks=params.attention_sinks,
+            uses_shared_paged_kv_idx=False,
+            enable_pdl=get_env_enable_pdl(),
+            backend="trtllm-gen",
         )
-
-        if q_len_per_req > 1:
-            params.context_buf.copy_(mla_out.reshape_as(params.context_buf))
 
 
 def is_supported(
@@ -1459,7 +1496,7 @@ def is_supported(
     has_cross_kv: bool = False,
     quant_config: Optional[QuantConfig] = None,
     kv_cache_manager: Optional[KVCacheManager] = None,
-    phase: str = "both",
+    attention_input_type: Optional[int] = None,
     sparse_kv_indices: Optional[torch.Tensor] = None,
     sparse_attn_indices: Optional[torch.Tensor] = None,
     skip_softmax_threshold_scale_factor_prefill: Optional[float] = None,
@@ -1492,7 +1529,7 @@ def is_supported(
         has_cross_kv: Whether cross KV is provided.
         quant_config: Quantization configuration (QuantConfig).
         kv_cache_manager: KV cache manager (its .dtype provides KV cache DataType).
-        phase: Phase to check ("context", "generation", or "both").
+        attention_input_type: Attention input type from TrtllmAttention.
         sparse_kv_indices: Sparse KV indices tensor for context phase.
         sparse_attn_indices: Sparse attention indices tensor for generation phase.
         skip_softmax_threshold_scale_factor_prefill: Scale factor for the skip-softmax
@@ -1510,7 +1547,7 @@ def is_supported(
     return FlashInferTrtllmGenAttention(
         kv_cache_manager=kv_cache_manager, quant_config=quant_config
     ).is_supported(
-        phase=phase,
+        attention_input_type=attention_input_type,
         q_dtype=q.dtype,
         kv_cache_dtype=kv_cache_dtype,
         num_heads=num_heads,
@@ -1754,7 +1791,7 @@ def trtllm_gen_attention(
     is_gen_only = attn_input_type == AttentionInputType.generation_only
 
     num_generations = host_request_types.size(0) - num_contexts
-    num_gen_tokens = num_tokens - num_ctx_tokens
+    num_gen_tokens = num_tokens if is_gen_only else num_tokens - num_ctx_tokens
 
     # Prepare Workspace
     # Use upper-bound token counts for workspace sizing to avoid repeated

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -1145,20 +1145,6 @@ def _register_fake():
         output_sf = input.new_empty((scale_shape, ), dtype=torch.uint8)
         return output_fp4, output_sf
 
-    @torch.library.register_fake("trtllm::build_decoder_info")
-    def _(seq_q_offsets, seq_kv_offsets, padding_offsets, tokens_info,
-          encoder_padding_offsets, packed_mask_row_offsets,
-          seq_cp_partial_offsets, attention_mask, seq_q_lengths, seq_kv_lengths,
-          fmha_tile_counter, dequant_scale_qkv, quant_scale_o, fmha_bmm1_scale,
-          fmha_bmm2_scale, rotary_embedding_inv_freq,
-          rotary_embedding_inv_freq_cache, cp_size, separate_qkv_scales,
-          fmha_host_bmm1_scale, batch_size, max_q_seq_length,
-          max_encoder_q_seq_length, attention_window_size, sink_token_length,
-          num_tokens, remove_padding, attention_mask_type,
-          rotary_embedding_scale, rotary_embedding_base, rotary_embedding_dim,
-          rotary_scaling_type, rotary_embedding_max_positions):
-        return True
-
     @torch.library.register_fake("trtllm::convert_req_index_to_global")
     def _(req_id: torch.Tensor, block_table: torch.Tensor,
           token_indices: torch.Tensor, block_size: int, num_topk_tokens: int,


### PR DESCRIPTION
## Description

Depends on #12525.

This PR builds on the shared paged index changes and optimizes the trtllm-gen fused attention preprocessing path:

- Share the attention workspace layout manager between `thop.attention` and trtllm-gen.
- Add fused trtllm-gen context/generation preprocess and context postprocess ops.
- Refactor `trtllm_gen.py` around a cached backend object and remove the unfused fallback path.
- Optimize the C++ fused preprocessing path by using internal raw-pointer params and reducing wrapper/materialization overhead.
- Add workspace manager unit coverage.

## Testing

- `git diff --check fork/yihwang/shared_paged_index...HEAD`
- strict conflict-marker scan on touched source directories



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TRTLLM-Gen attention backend now enabled by default.
  * Added public APIs for workspace layout queries and preprocessing operations.
  * Enhanced backend caching for improved performance.

* **Refactor**
  * Workspace management refactored with typed layouts and centralized pointer handling.
  * Performance monitoring enhancements via NVTX scoped ranges.

* **Tests**
  * Added unit tests for workspace management validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->