### PR TITLE
[https://nvbugs/5805494][fix] Limit maximum warmup token count to prevent crash in autotuner

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -504,6 +504,13 @@ class PyTorchModelEngine(ModelEngine):
 
         self.kv_cache_dtype_byte_size = self.get_kv_cache_dtype_byte_size()
 
+        # Upper bound on the per-rank token count used for warmup forward passes
+        # (both the max-shape general warmup and the autotuner warmup). Each
+        # tunable op currently generates tuning buckets only up to 8192 (see
+        # MAX_PROFILE_BUCKET in trtllm_gen_custom_ops.py and related files), so
+        # warmup shapes larger than this do not improve tuning quality.
+        self.max_warmup_tokens = 8192
+
     def register_forward_pass_callable(self, callable: Callable):
         self.forward_pass_callable = callable
 
@@ -684,7 +691,8 @@ class PyTorchModelEngine(ModelEngine):
         kv_cache_manager = resource_manager.get_resource_manager(
             self.kv_cache_manager_key)
         token_num_upper_bound = min(self.max_num_tokens,
-                                    self.batch_size * (self.max_seq_len - 1))
+                                    self.batch_size * (self.max_seq_len - 1),
+                                    self.max_warmup_tokens)
         curr_max_num_tokens = kv_cache_manager.get_num_available_tokens(
             token_num_upper_bound=token_num_upper_bound,
             max_num_draft_tokens=self.original_max_draft_len)
@@ -833,7 +841,8 @@ class PyTorchModelEngine(ModelEngine):
         kv_cache_manager = resource_manager.get_resource_manager(
             self.kv_cache_manager_key)
         token_num_upper_bound = min(self.max_num_tokens,
-                                    self.batch_size * (self.max_seq_len - 1))
+                                    self.batch_size * (self.max_seq_len - 1),
+                                    self.max_warmup_tokens)
         curr_max_num_tokens = kv_cache_manager.get_num_available_tokens(
             token_num_upper_bound=token_num_upper_bound,
             max_num_draft_tokens=self.original_max_draft_len)

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -371,6 +371,7 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
             max_batch_size=max_batch_size,
             max_seq_len=max_seq_len,
             max_num_tokens=max_num_tokens,
+            enable_autotuner=True,
             cuda_graph_config=None,
         )
         model_engine = DummyModelEngine(llm_args, torch.half)

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -340,6 +340,138 @@ class PyTorchModelEngineTestCase(unittest.TestCase):
 
         kv_cache_manager.shutdown()
 
+    def test_warmup_caps_token_count(self):
+        """All warmup forward passes (general, autotuner, max-shape) cap the
+        per-rank token count at ``model_engine.max_warmup_tokens``.
+
+        Regression test for an autotuner-warmup crash discovered with
+        ``max_num_tokens=16384`` and ``enable_attention_dp=True`` on TP=8:
+        the post-allgather MoE input was ``16384 * dp_size`` tokens, and
+        the TRT-LLM-Gen activation kernel overflowed int32 in
+        ``permutedIdx * innerDim`` during the warmup forward pass. The cap
+        is set to 8192 to match ``MAX_PROFILE_BUCKET`` in the tunable ops
+        in ``trtllm_gen_custom_ops.py``, so warmup forwards never exceed
+        the bucket size the autotuner has actually validated.
+
+        Single-GPU regression: configure ``max_num_tokens > 8192`` so the
+        cap is the binding bound, then run the full ``warmup()`` end-to-end
+        (which internally invokes ``_run_autotuner_warmup`` with the real
+        ``autotune()`` context). A wrapper around ``_create_warmup_request``
+        records every per-rank token count the engine asked for; the test
+        asserts none of them exceed the cap.
+        """
+        max_num_tokens = 16384  # > the cap; the regression configuration
+        max_seq_len = 2048
+        max_batch_size = 16
+        # max_seq_len * max_batch_size = 32752, kept above max_num_tokens
+        # so PyTorchModelEngine._init_max_num_tokens does not clamp
+        # max_num_tokens back below the cap.
+        llm_args = TorchLlmArgs(
+            model="dummy",
+            max_batch_size=max_batch_size,
+            max_seq_len=max_seq_len,
+            max_num_tokens=max_num_tokens,
+            cuda_graph_config=None,
+        )
+        model_engine = DummyModelEngine(llm_args, torch.half)
+        # Pin the cap value so a future change forces the author to
+        # revisit the relationship with MAX_PROFILE_BUCKET.
+        self.assertEqual(
+            model_engine.max_warmup_tokens, 8192,
+            "max_warmup_tokens regression: changing the cap without "
+            "coordinating with MAX_PROFILE_BUCKET in "
+            "trtllm_gen_custom_ops.py may re-introduce the "
+            "autotuner-warmup MoE crash.")
+        # The cap must actually be the binding bound under this
+        # configuration; otherwise the test could pass even if the cap
+        # were silently removed.
+        self.assertGreater(
+            model_engine.max_num_tokens, model_engine.max_warmup_tokens,
+            "Test setup must keep max_num_tokens above the cap.")
+        self.assertGreater(
+            model_engine.batch_size * (model_engine.max_seq_len - 1),
+            model_engine.max_warmup_tokens,
+            "Test setup must keep batch_size*(max_seq_len-1) above the cap.")
+
+        # KV cache sized strictly above max_num_tokens so that, without the
+        # cap, ``_get_max_shape_warmup_requests`` and ``_run_autotuner_warmup``
+        # would compute curr_max_num_tokens == max_num_tokens (16384), not a
+        # KV-bounded smaller value. ``max_seq_len * max_batch_size`` (32 768)
+        # is the natural ceiling for a single-rank dummy KV; matching it
+        # gives us free_blocks well above max_num_tokens after extras. If
+        # this is too small, the test would pass even against the unpatched
+        # code because the KV cache (rather than the cap) becomes the
+        # binding bound -- the sanity assertion below detects exactly that.
+        kv_max_tokens = max_seq_len * max_batch_size
+        kv_cache_manager = KVCacheManager(
+            KvCacheConfig(max_tokens=kv_max_tokens),
+            tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+            num_layers=1,
+            num_kv_heads=model_engine.model.config.num_key_value_heads,
+            head_dim=model_engine.model.config.head_dim,
+            tokens_per_block=1,
+            max_seq_len=max_seq_len,
+            max_batch_size=max_batch_size,
+            mapping=Mapping(world_size=1, tp_size=1, rank=0),
+            dtype=tensorrt_llm.bindings.DataType.HALF,
+        )
+        resource_manager = ResourceManager(
+            {ResourceManagerType.KV_CACHE_MANAGER: kv_cache_manager})
+
+        # If the cap were silently removed, ``_get_max_shape_warmup_requests``
+        # would compute curr_max_num_tokens via this exact expression. Assert
+        # that it would exceed the cap, otherwise the KV cache (not the cap)
+        # is the binding bound and the test would pass even without the fix.
+        unpatched_upper = min(
+            model_engine.max_num_tokens,
+            model_engine.batch_size * (model_engine.max_seq_len - 1),
+        )
+        unpatched_curr = kv_cache_manager.get_num_available_tokens(
+            token_num_upper_bound=unpatched_upper, max_num_draft_tokens=0)
+        self.assertGreater(
+            unpatched_curr, model_engine.max_warmup_tokens,
+            f"Test setup is too small to discriminate: without the cap, "
+            f"curr_max_num_tokens would be {unpatched_curr}, which is not "
+            f"above max_warmup_tokens={model_engine.max_warmup_tokens}. "
+            "Increase kv_max_tokens (e.g., via larger max_seq_len or "
+            "max_batch_size) so the KV cache stops being the bottleneck.")
+
+        # Wrap _create_warmup_request to RECORD num_tokens, then delegate
+        # to the original. Every warmup callsite (full general warmup,
+        # post-CUDA-graph max-shape warmup, and autotuner warmup) funnels
+        # through this method, so this single hook covers them all without
+        # short-circuiting the actual forward passes.
+        requested_num_tokens = []
+        original_create = model_engine._create_warmup_request
+
+        def recording_wrapper(resource_manager, num_tokens, num_gen_requests,
+                              **kwargs):
+            requested_num_tokens.append(num_tokens)
+            return original_create(resource_manager, num_tokens,
+                                   num_gen_requests, **kwargs)
+
+        model_engine._create_warmup_request = recording_wrapper
+        try:
+            model_engine.warmup(resource_manager)
+        finally:
+            model_engine._create_warmup_request = original_create
+            kv_cache_manager.shutdown()
+
+        self.assertGreater(
+            len(requested_num_tokens), 0,
+            "warmup() did not exercise _create_warmup_request at all; "
+            "the test setup no longer reaches the regression point.")
+        over_cap = [
+            n for n in requested_num_tokens
+            if n > model_engine.max_warmup_tokens
+        ]
+        self.assertEqual(
+            over_cap, [], f"warmup() requested {over_cap} tokens, exceeding "
+            f"max_warmup_tokens={model_engine.max_warmup_tokens}. "
+            "The cap was bypassed at one or more warmup callsites; this "
+            "regression crashed the TRT-LLM-Gen MoE "
+            "activation kernel during autotuner warmup with attention_dp.")
+
     def test_layerwise_nvtx_marker(self):
         llm_args = TorchLlmArgs(
             model="dummy",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented a maximum token count cap (8,192 tokens) during model warmup initialization, limiting tensor dimensions and optimizing resource consumption.
  * Warmup request-shape selection and autotuner warmup processes now respect this token limit to prevent excessive memory usage.

* **Tests**
  * Added regression test validating that model warmup enforces the token count cap across different configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/5805494]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Caps the per-rank token count used by every warmup forward pass at a new `PyTorchModelEngine.max_warmup_tokens = 8192`, matching the `MAX_PROFILE_BUCKET` already used by every tunable op in `trtllm_gen_custom_ops.py`. The cap is applied both in `_get_max_shape_warmup_requests` (used by the pre- and post-CUDA-graph general warmups) and in `_run_autotuner_warmup`.

Discovered with DeepSeek-R1, `tp=8`, `ep=8`, `enable_attention_dp=True`, `max_num_tokens=16384`. The autotuner warmup ran a forward pass at the full 16384 per-rank context shape. After the MoE all-gather the TRT-LLM-Gen FP8 block-scale activation kernel saw `16384 * dp_size = 131072` tokens, and `permutedIdx * innerDim` overflowed int32 inside `DevKernel.cu:412`, producing an illegal memory access during init:

`RuntimeError: [TensorRT-LLM][ERROR] CUDA runtime error in cudaLaunchKernelEx(...): an illegal memory access was encountered (.../trtllmGenKernels/blockScaleMoe/DevKernel.cu:412)`

The autotuner only validates tactics on profile buckets up to 8192 (see `MAX_PROFILE_BUCKET` and `round_rule` in `tensorrt_llm/_torch/custom_ops/trtllm_gen_custom_ops.py`), so warmup shapes above the bucket size yield no tuning benefit while pushing the kernel into territory it was never validated on. Capping the warmup shape at the same value keeps tuning, warmup and the kernel's validated range consistent.

This was previously caught only at runtime by the scheduler distributing context tokens across ranks unevenly, so production inference does not trigger it; the autotuner warmup, where every rank runs at `max_num_tokens` simultaneously, is the only path that reliably hits the overflow on supported configurations.

## Test Coverage

Adds `test_warmup_caps_token_count` in `tests/unittest/_torch/executor/test_pytorch_model_engine.py` (picked up automatically via `unittest/_torch/executor` in the existing `l0_h100.yml` / `l0_b200.yml` / `l0_b300.yml` lists).

The test:
- Builds a `DummyModelEngine` with `max_num_tokens=16384` and a KV cache sized to `max_seq_len * max_batch_size = 32768` tokens, with sanity assertions that the cap (rather than KV cache or batch sizing) is the binding bound.
- Wraps `_create_warmup_request` with a recording wrapper that delegates to the original, then runs the full `model_engine.warmup()` end-to-end, exercising both general-warmup callsites and `_run_autotuner_warmup` with the real `autotune()` context on a single GPU.
- Asserts that no warmup call requested more tokens than `max_warmup_tokens`. Fails with the recorded list and the resolved `model_engine.py` path when the cap is removed, passes with the cap.

Manual verification on the 8-GPU DeepSeek-R1 deployment that originally crashed: `trtllm-bench --max_num_tokens 16384` now completes the autotuner warmup cleanly and proceeds to throughput measurement.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
