### PR TITLE
[#9164][feat] AutoDeploy: noaux_tc MoE routing pattern matcher

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -72,6 +72,8 @@ transforms:
     stage: pattern_matcher
   match_moe_routing_pattern:
     stage: pattern_matcher
+  match_noaux_tc_pattern:
+    stage: pattern_matcher
   ############################################################################################
   # RUN TRANSFORMATIONS ON STANDARDIZED GRAPH REPRESENTATION
   ############################################################################################

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/moe_routing.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/moe_routing.py
@@ -28,6 +28,9 @@ This leverages the mathematical equivalence:
 
 The fused kernel avoids computing softmax over all experts (e.g. 256), instead
 finding top-k from raw logits and computing softmax only over the k selected values.
+
+Also detects the noaux_tc routing pattern used by DeepSeek-V3 / NemotronH /
+GLM4-MoE / Kimi-K2, replacing it with ``torch.ops.trtllm.noaux_tc_op``.
 """
 
 import operator
@@ -215,6 +218,301 @@ class MatchMoeRoutingPattern(BaseTransform):
             eliminate_dead_code(gm)
             gm.recompile()
             ad_logger.info(f"Fused {num_matches} MoE routing pattern(s).")
+
+        info = TransformInfo(
+            skipped=False,
+            num_matches=num_matches,
+            is_clean=num_matches == 0,
+            has_valid_shapes=num_matches == 0,
+        )
+        return gm, info
+
+
+# ---------------------------------------------------------------------------
+# noaux_tc routing pattern helpers
+# ---------------------------------------------------------------------------
+
+_TOPK_OPS = (torch.ops.aten.topk.default,)
+_VIEW_OPS = (torch.ops.aten.view.default, torch.ops.aten.reshape.default)
+_ADD_OPS = (torch.ops.aten.add.Tensor,)
+
+
+def _scalar_int(node_or_value) -> Optional[int]:
+    """Return *node_or_value* as a Python int if it is a literal, else None."""
+    if isinstance(node_or_value, int):
+        return node_or_value
+    return None
+
+
+def _find_bias_add_after_sigmoid(sigmoid_node: Node) -> Optional[Tuple[Node, Node]]:
+    """Find ``scores + bias`` user of *sigmoid_node*; return (add_node, bias_node)."""
+    for user in sigmoid_node.users:
+        if not is_op(user, _ADD_OPS):
+            continue
+        a, b = user.args[0], user.args[1]
+        if a is sigmoid_node and isinstance(b, Node):
+            return user, b
+        if b is sigmoid_node and isinstance(a, Node):
+            return user, a
+    return None
+
+
+def _find_group_topk(scores_with_bias: Node) -> Optional[Tuple[Node, int]]:
+    """Find the ``topk(view(scores_with_bias, ...), k=2)`` user; return (node, n_group)."""
+    for user in scores_with_bias.users:
+        view_node = user if is_op(user, _VIEW_OPS) else None
+        if view_node is None:
+            continue
+        # view shape can be the second arg (list of ints/Nodes)
+        shape = view_node.args[1] if len(view_node.args) > 1 else None
+        if not isinstance(shape, (list, tuple)) or len(shape) < 2:
+            continue
+        n_group = _scalar_int(shape[-2])
+        if n_group is None:
+            continue
+        for vu in view_node.users:
+            if is_op(vu, _TOPK_OPS) and _scalar_int(vu.args[1]) == 2:
+                return vu, n_group
+    return None
+
+
+def _find_outer_topk(masked_node: Node) -> Optional[Tuple[Node, int]]:
+    """Find ``topk(masked, k=top_k)`` user of *masked_node*; return (node, top_k)."""
+    for user in masked_node.users:
+        candidate = user
+        if is_op(candidate, _TOPK_OPS):
+            top_k = _scalar_int(candidate.args[1])
+            if top_k is not None:
+                return candidate, top_k
+        # allow one view in between
+        if is_op(candidate, _VIEW_OPS):
+            for vu in candidate.users:
+                if is_op(vu, _TOPK_OPS):
+                    top_k = _scalar_int(vu.args[1])
+                    if top_k is not None:
+                        return vu, top_k
+    return None
+
+
+def _descends_from(node: Node, target: Node, max_depth: int = 10) -> bool:
+    """Return True if *target* is reachable from *node*'s input ancestry within max_depth hops."""
+    if not isinstance(node, Node) or not isinstance(target, Node):
+        return False
+    visited = set()
+    frontier = [(node, 0)]
+    while frontier:
+        n, d = frontier.pop()
+        if n is target:
+            return True
+        if d >= max_depth or n in visited:
+            continue
+        visited.add(n)
+        for inp in n.all_input_nodes:
+            frontier.append((inp, d + 1))
+    return False
+
+
+def _find_gather_from_indices(indices_node: Node, scores_node: Node) -> Optional[Node]:
+    """Find ``aten.gather.default(scores_node, dim, indices_node)`` user of *indices_node*."""
+    for user in indices_node.users:
+        if not is_op(user, torch.ops.aten.gather.default):
+            continue
+        if len(user.args) >= 3 and user.args[0] is scores_node and user.args[2] is indices_node:
+            return user
+    return None
+
+
+def _is_sum_of(node, cur: Node) -> bool:
+    return (
+        isinstance(node, Node)
+        and is_op(node, torch.ops.aten.sum.dim_IntList)
+        and node.args[0] is cur
+    )
+
+
+def _is_normalize_divisor(divisor, cur: Node) -> bool:
+    """Accept ``sum(cur, ...)`` or its epsilon-stabilized form ``sum(...) + eps``."""
+    if _is_sum_of(divisor, cur):
+        return True
+    if isinstance(divisor, Node) and is_op(divisor, torch.ops.aten.add.Tensor):
+        a, b = divisor.args[0], divisor.args[1]
+        for sum_cand, eps_cand in ((a, b), (b, a)):
+            if _is_sum_of(sum_cand, cur) and isinstance(eps_cand, (int, float)):
+                return True
+    return False
+
+
+def _walk_div_then_mul(start: Node) -> Tuple[Node, float]:
+    """Walk forward through optional ``div.Tensor(self, sum)`` then ``mul.Tensor(self, scalar)``.
+
+    Returns ``(final_node, routed_scaling_factor)``. If no scale is found, the
+    factor defaults to ``1.0`` and *final_node* is the last node reached on the
+    chain (gather, or div if no mul, etc.).
+    """
+    cur = start
+    # optional norm: div(cur, sum(cur, ..., keepdim=True) [+ eps])
+    for user in cur.users:
+        if (
+            is_op(user, torch.ops.aten.div.Tensor)
+            and user.args[0] is cur
+            and _is_normalize_divisor(user.args[1], cur)
+        ):
+            cur = user
+            break
+    # optional scalar multiply
+    for user in cur.users:
+        if is_op(user, torch.ops.aten.mul.Tensor) and user.args[0] is cur:
+            scalar = user.args[1]
+            if isinstance(scalar, (int, float)):
+                return user, float(scalar)
+    return cur, 1.0
+
+
+@TransformRegistry.register("match_noaux_tc_pattern")
+class MatchNoAuxTCPattern(BaseTransform):
+    """Match the noaux_tc MoE routing chain and replace with a fused trtllm op.
+
+    This transform detects the DeepSeek-V3 style routing pattern::
+
+        sigmoid → +bias → group top-k → mask → top-k → gather → [norm] → scale
+
+    and replaces it with::
+
+        topk_weights, topk_idx = trtllm.noaux_tc_op(
+            router_logits, bias, n_group, topk_group, top_k, routed_scaling_factor
+        )
+
+    The fused kernel performs sigmoid, bias correction, group-based top-k
+    selection, gather, normalization and scaling in a single CUDA kernel.
+    """
+
+    config: TransformConfig
+
+    @classmethod
+    def get_config_class(cls) -> Type[TransformConfig]:
+        return TransformConfig
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        graph = gm.graph
+        num_matches = 0
+
+        for node in list(graph.nodes):
+            # ---- anchor: aten.sigmoid -> add(bias) ------------------------
+            if not is_op(node, torch.ops.aten.sigmoid.default):
+                continue
+            sigmoid_node = node
+            router_logits = sigmoid_node.args[0]
+            if not isinstance(router_logits, Node):
+                continue
+
+            bias_add = _find_bias_add_after_sigmoid(sigmoid_node)
+            if bias_add is None:
+                continue
+            scores_with_bias_node, bias_node = bias_add
+
+            # ---- group top-k(k=2) ----------------------------------------
+            inner = _find_group_topk(scores_with_bias_node)
+            if inner is None:
+                continue
+            inner_topk, n_group = inner
+
+            inner_values = _get_single_getitem_user(inner_topk, 0)
+            if inner_values is None:
+                continue
+
+            # ---- sum -> outer topk(k=topk_group) -------------------------
+            sum_node = None
+            for u in inner_values.users:
+                if is_op(u, torch.ops.aten.sum.dim_IntList):
+                    sum_node = u
+                    break
+            if sum_node is None:
+                continue
+
+            outer_grp_topk = None
+            for u in sum_node.users:
+                if is_op(u, _TOPK_OPS):
+                    outer_grp_topk = u
+                    break
+            if outer_grp_topk is None:
+                continue
+            topk_group = _scalar_int(outer_grp_topk.args[1])
+            if topk_group is None:
+                continue
+
+            # ---- final masked top-k(k=top_k) -----------------------------
+            # Only accept a masked_node whose mask input descends from outer_grp_topk;
+            # otherwise an unrelated branch consuming scores_with_bias could be picked.
+            masked_node = None
+            for u in scores_with_bias_node.users:
+                if not is_op(
+                    u,
+                    (
+                        torch.ops.aten.where.self,
+                        torch.ops.aten.masked_fill.Scalar,
+                        torch.ops.aten.mul.Tensor,
+                    ),
+                ):
+                    continue
+                if not _descends_from(u, outer_grp_topk):
+                    continue
+                masked_node = u
+                break
+            if masked_node is None:
+                continue
+
+            outer_topk = _find_outer_topk(masked_node)
+            if outer_topk is None:
+                continue
+            final_topk_node, top_k = outer_topk
+
+            final_indices = _get_single_getitem_user(final_topk_node, 1)
+            if final_indices is None:
+                continue
+
+            # ---- weights branch: gather(scores, -1, topk_idx) [/ sum] * scale --
+            gather_node = _find_gather_from_indices(final_indices, sigmoid_node)
+            if gather_node is None:
+                continue
+            weights_tail, routed_scaling_factor = _walk_div_then_mul(gather_node)
+
+            # ---- emit fused noaux_tc_op ---------------------------------
+            ad_logger.info(
+                "Matched noaux_tc routing pattern: "
+                f"n_group={n_group}, topk_group={topk_group}, top_k={top_k}, "
+                f"scale={routed_scaling_factor}"
+            )
+
+            with graph.inserting_before(sigmoid_node):
+                fused = graph.call_function(
+                    torch.ops.trtllm.noaux_tc_op,
+                    args=(
+                        router_logits,
+                        bias_node,
+                        n_group,
+                        topk_group,
+                        top_k,
+                        routed_scaling_factor,
+                    ),
+                )
+                fused_weights = graph.call_function(operator.getitem, args=(fused, 0))
+                fused_indices = graph.call_function(operator.getitem, args=(fused, 1))
+
+            final_indices.replace_all_uses_with(fused_indices)
+            weights_tail.replace_all_uses_with(fused_weights)
+
+            num_matches += 1
+
+        if num_matches > 0:
+            eliminate_dead_code(gm)
+            gm.recompile()
+            ad_logger.info(f"Fused {num_matches} noaux_tc routing pattern(s).")
 
         info = TransformInfo(
             skipped=False,

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_match_noaux_tc.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_match_noaux_tc.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import operator
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.transform.interface import (
+    SharedConfig,
+    Stages,
+    TransformConfig,
+)
+from tensorrt_llm._torch.auto_deploy.transform.library.moe_routing import MatchNoAuxTCPattern
+
+
+class _NoAuxTCRouter(nn.Module):
+    def __init__(
+        self,
+        hidden: int = 1024,
+        n_experts: int = 128,
+        n_group: int = 8,
+        topk_group: int = 4,
+        top_k: int = 8,
+        scale: float = 2.5,
+    ):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(n_experts, hidden))
+        self.register_buffer("e_score_correction_bias", torch.zeros(n_experts, dtype=torch.float32))
+        self.n_group = n_group
+        self.topk_group = topk_group
+        self.top_k = top_k
+        self.scale = scale
+        self.n_experts = n_experts
+
+    def forward(self, hidden_states):
+        T = hidden_states.shape[0]
+        E, G = self.n_experts, self.n_group
+        logits = F.linear(hidden_states.float(), self.weight)
+        scores = logits.sigmoid()
+        scores_with_bias = scores + self.e_score_correction_bias
+        grouped = scores_with_bias.view(T, G, E // G)
+        group_scores = grouped.topk(2, dim=-1).values.sum(-1)
+        group_idx = torch.topk(group_scores, k=self.topk_group, dim=-1).indices
+        group_mask = torch.zeros_like(group_scores).scatter_(-1, group_idx, 1.0)
+        score_mask = group_mask.unsqueeze(-1).expand(T, G, E // G).reshape(T, E)
+        masked = torch.where(
+            score_mask.bool(),
+            scores_with_bias,
+            torch.tensor(float("-inf"), dtype=scores_with_bias.dtype),
+        )
+        topk_idx = torch.topk(masked, k=self.top_k, dim=-1).indices
+        topk_w = scores.gather(-1, topk_idx)
+        topk_w = topk_w / topk_w.sum(-1, keepdim=True) * self.scale
+        return topk_w, topk_idx
+
+
+class _PlainSoftmaxRouter(nn.Module):
+    def __init__(self, hidden: int = 64, n_experts: int = 16, top_k: int = 2):
+        super().__init__()
+        self.weight = nn.Parameter(torch.randn(n_experts, hidden))
+        self.top_k = top_k
+
+    def forward(self, hidden_states):
+        logits = F.linear(hidden_states.float(), self.weight)
+        weights = torch.softmax(logits, dim=-1)
+        weights, indices = torch.topk(weights, self.top_k, dim=-1)
+        weights = weights / weights.sum(dim=-1, keepdim=True)
+        return weights, indices
+
+
+def _apply_matcher(gm: torch.fx.GraphModule) -> int:
+    transform = MatchNoAuxTCPattern(TransformConfig(stage=Stages.PATTERN_MATCHER))
+    _, info = transform._apply(gm, cm=None, factory=None, shared_config=SharedConfig())
+    return info.num_matches
+
+
+def _is_noaux_tc(node: torch.fx.Node) -> bool:
+    if node.op != "call_function":
+        return False
+    packet = torch.ops.trtllm.noaux_tc_op
+    return node.target is packet or node.target is getattr(packet, "default", None)
+
+
+def _find_noaux_tc_node(gm: torch.fx.GraphModule):
+    for node in gm.graph.nodes:
+        if _is_noaux_tc(node):
+            return node
+    return None
+
+
+def test_noaux_tc_pattern_matches_and_extracts_constants():
+    n_group, topk_group, top_k, scale = 8, 4, 8, 2.5
+    module = _NoAuxTCRouter(n_group=n_group, topk_group=topk_group, top_k=top_k, scale=scale).eval()
+    gm = torch_export_to_gm(module, args=(torch.randn(4, 1024),))
+
+    assert _apply_matcher(gm) == 1
+
+    fused = _find_noaux_tc_node(gm)
+    assert fused is not None
+
+    # noaux_tc_op(scores, bias, n_group, topk_group, top_k, routed_scaling_factor)
+    assert fused.args[2] == n_group
+    assert fused.args[3] == topk_group
+    assert fused.args[4] == top_k
+    assert fused.args[5] == pytest.approx(scale)
+
+
+def test_noaux_tc_pattern_replaces_outputs():
+    module = _NoAuxTCRouter().eval()
+    gm = torch_export_to_gm(module, args=(torch.randn(4, 1024),))
+    assert _apply_matcher(gm) == 1
+
+    fused = _find_noaux_tc_node(gm)
+    assert fused is not None
+
+    output_node = next(n for n in gm.graph.nodes if n.op == "output")
+    out_args = output_node.args[0]
+    if not isinstance(out_args, (list, tuple)):
+        out_args = (out_args,)
+
+    fused_origins = set()
+    for out in out_args:
+        if (
+            isinstance(out, torch.fx.Node)
+            and out.op == "call_function"
+            and out.target is operator.getitem
+            and out.args[0] is fused
+        ):
+            fused_origins.add(out.args[1])
+    assert fused_origins == {0, 1}
+
+
+def test_plain_softmax_router_is_not_matched():
+    module = _PlainSoftmaxRouter().eval()
+    gm = torch_export_to_gm(module, args=(torch.randn(4, 64),))
+    assert _apply_matcher(gm) == 0
+    assert _find_noaux_tc_node(gm) is None


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optimization support for DeepSeek-V3 MoE (Mixture of Experts) routing patterns, improving model compilation and inference efficiency through graph-level fusion.

* **Tests**
  * Added test suite to validate pattern recognition and fusion behavior for the new routing optimization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Adds a graph-level pattern matcher (`MatchNoAuxTCPattern`) that detects the `noaux_tc` MoE routing chain (sigmoid → +bias → group top-k → mask → top-k → gather → [norm] → scale) used by DeepSeek-V3, NemotronH, GLM4-MoE-Lite and Kimi-K2, and rewrites it into a single `torch.ops.trtllm.noaux_tc_op` call.

Lets HF upstream models that use this routing benefit from the fused kernel without forking their `modeling_*.py` into `auto_deploy/models/custom/`.

Closes #9164.

## Test Coverage

positive match + constant extraction, output rewire to the fused op, and a negative case

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
