### PR TITLE
[TRTLLMINF-54][feat] Migrate retry consumers to classify() + isFinalAttempt fix

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1728,31 +1728,24 @@ def runLLMTestlistOnSlurm(pipeline, platform, testList, config=VANILLA_CONFIG, p
       // User abort / pipeline timeout -- never retry
       throw e
     } catch (Exception e) {
-      // FlowInterruptedException may not extend InterruptedException in all Jenkins versions
-      if (e.toString().contains("FlowInterruptedException") ||
-          e.toString().contains("AbortException: script returned exit code 143")) {
-        throw e
-      }
+      // classify() handles FlowInterruptedException + exit-code-143 +
+      // typed throws + cause-chain pattern matching, returning one of
+      // PipelineInterruption / InfraFailure / UserFailure. Scope=SLURM
+      // ensures we only match catalog rows tagged SLURM or BOTH.
+      def c = classify(e, InfraFailure.SLURM)
+      if (c instanceof PipelineInterruption) throw e
+      if (!(c instanceof InfraFailure))      throw e   // UserFailure -> don't retry
 
-      // Check if this is a retryable infrastructure failure
-      def classification = classifyInfraFailure(e)
-
-      if (!classification.isInfraFailure) {
-        // Not an infrastructure failure (test failure, compilation error, etc.)
-        throw e
-      }
-
-      // Determine effective max retries for this pattern
-      def effectiveMax = classification.isSingleRetryOnly ? 1 : SLURM_INFRA_RETRY_MAX
+      def effectiveMax = (c.severity == InfraFailure.PERSISTENT) ? 1 : SLURM_INFRA_RETRY_MAX
 
       if (attempt > effectiveMax) {
-        echo "[INFRA-RETRY] ${stageName}: Infrastructure failure (${classification.matchedPattern}) " +
+        echo "[INFRA-RETRY] ${stageName}: Infrastructure failure (${c.detectedPattern}) " +
              "but max retries (${effectiveMax}) exhausted after ${attempt} attempts. Failing."
         throw e
       }
 
       echo "[INFRA-RETRY] ${stageName}: Infrastructure failure detected on attempt ${attempt}: " +
-           "${classification.matchedPattern}"
+           "${c.detectedPattern}"
       echo "[INFRA-RETRY] ${stageName}: Exception: ${e.toString()}"
       echo "[INFRA-RETRY] ${stageName}: Will retry (attempt ${attempt + 1} of ${effectiveMax + 1}) after 60s cooldown."
 
@@ -1959,10 +1952,10 @@ def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSu
             // for forensics; only the in-build test reporting is gated.
             boolean suppressTestReporting = false
             if (!isFinalAttempt && stageIsFailed && caughtError != null) {
-                def cls = classifyInfraFailure(caughtError, K8S_INFRA_FAILURE_PATTERNS, K8S_INFRA_SINGLE_RETRY_PATTERNS)
-                suppressTestReporting = cls.isInfraFailure
-                if (suppressTestReporting) {
-                    echo "[INFRA-RETRY] ${stageName}${postTag}: suppressing synthetic stage-fail XML and junit() on intermediate retryable infra failure (${cls.matchedPattern})"
+                def c = classify(caughtError, InfraFailure.K8S)
+                if (c instanceof InfraFailure) {
+                    suppressTestReporting = true
+                    echo "[INFRA-RETRY] ${stageName}${postTag}: suppressing synthetic stage-fail XML and junit() on intermediate retryable infra failure (${c.detectedPattern})"
                 }
             }
 
@@ -3576,6 +3569,11 @@ def runKubernetesPodWithInfraRetry(pipeline, podSpec, containerName, String stag
     }
 
     def attempt = 0
+    // Severity of the previous attempt's classification, or null on first attempt.
+    // Used to compute isFinalAttempt for the next attempt: a PERSISTENT prior
+    // failure caps the budget at 1 retry (attempt 2 is final), so the next
+    // attempt must not suppress synthetic stage-fail XML / junit().
+    def lastSeverity = null
     while (true) {
         attempt++
         try {
@@ -3587,13 +3585,16 @@ def runKubernetesPodWithInfraRetry(pipeline, podSpec, containerName, String stag
             // Retries append "-attempt-N" to dodge the upload-once guard and
             // preserve every attempt's tarball in Artifactory.
             def attemptTag = (attempt == 1) ? "" : "-attempt-${attempt}"
-            // isFinalAttempt uses the worst-case retry budget. Single-retry-only
-            // patterns terminate early at attempt 2, in which case the synthetic
-            // stage-fail XML is suppressed even though the attempt is effectively
-            // final. The tar still uploads to Artifactory for forensics and the
-            // Jenkins build itself surfaces as failed; this is an acceptable
-            // edge case to keep the helper's pre-call decision simple.
-            boolean isFinalAttempt = (attempt > K8S_INFRA_RETRY_MAX)
+            // For attempt 1 we don't yet know whether the failure (if any) will
+            // be PERSISTENT, so use the worst-case multi-retry budget. From
+            // attempt 2 onward we know the prior classification — if it was
+            // PERSISTENT, effectiveMax for THIS attempt is 1, meaning attempt
+            // 2 IS the final attempt; pass isFinalAttempt=true so the inner
+            // cacheErrorAndUploadResult does not suppress synthetic stage-fail
+            // XML / junit() on what would otherwise look (to it) like just
+            // another intermediate attempt.
+            def effectiveMaxThisAttempt = (lastSeverity == InfraFailure.PERSISTENT) ? 1 : K8S_INFRA_RETRY_MAX
+            boolean isFinalAttempt = (attempt > effectiveMaxThisAttempt)
             trtllm_utils.launchKubernetesPod(pipeline, podSpec, containerName, { runner(attemptTag, isFinalAttempt) })
             if (attempt > 1) {
                 echo "[INFRA-RETRY] ${stageName}: Succeeded on attempt ${attempt}"
@@ -3603,32 +3604,32 @@ def runKubernetesPodWithInfraRetry(pipeline, podSpec, containerName, String stag
             // User abort / pipeline timeout -- never retry
             throw e
         } catch (Exception e) {
-            // FlowInterruptedException may not extend InterruptedException in all Jenkins versions
-            if (e.toString().contains("FlowInterruptedException") ||
-                e.toString().contains("AbortException: script returned exit code 143")) {
-                throw e
-            }
+            // classify() handles FlowInterruptedException + exit-code-143 +
+            // typed throws + cause-chain pattern matching, returning one of
+            // PipelineInterruption / InfraFailure / UserFailure. Scope=K8S
+            // ensures we only match catalog rows tagged K8S or BOTH; the new
+            // scope-isolation guard inside classify() also prevents a typed
+            // SLURM-scoped InfraFailure (e.g. from an inner SLURM retry that
+            // exhausted its own budget) from being treated as K8s infra here.
+            def c = classify(e, InfraFailure.K8S)
+            if (c instanceof PipelineInterruption) throw e
+            if (!(c instanceof InfraFailure))      throw e   // UserFailure -> don't retry
 
-            def classification = classifyInfraFailure(e, K8S_INFRA_FAILURE_PATTERNS, K8S_INFRA_SINGLE_RETRY_PATTERNS)
-
-            if (!classification.isInfraFailure) {
-                // Not an infrastructure failure (test failure, compilation error, etc.)
-                throw e
-            }
-
-            def effectiveMax = classification.isSingleRetryOnly ? 1 : K8S_INFRA_RETRY_MAX
+            def effectiveMax = (c.severity == InfraFailure.PERSISTENT) ? 1 : K8S_INFRA_RETRY_MAX
 
             if (attempt > effectiveMax) {
-                echo "[INFRA-RETRY] ${stageName}: Infrastructure failure (${classification.matchedPattern}) " +
+                echo "[INFRA-RETRY] ${stageName}: Infrastructure failure (${c.detectedPattern}) " +
                      "but max retries (${effectiveMax}) exhausted after ${attempt} attempts. Failing."
                 throw e
             }
 
             echo "[INFRA-RETRY] ${stageName}: Infrastructure failure detected on attempt ${attempt}: " +
-                 "${classification.matchedPattern}"
+                 "${c.detectedPattern}"
             echo "[INFRA-RETRY] ${stageName}: Exception: ${e.toString()}"
             echo "[INFRA-RETRY] ${stageName}: Will retry (attempt ${attempt + 1} of ${effectiveMax + 1}) after 60s cooldown."
 
+            // Remember severity so the next attempt's isFinalAttempt is correct.
+            lastSeverity = c.severity
             sleep(60)
         }
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced infrastructure retry logic for SLURM and Kubernetes with improved severity-aware failure classification.
  * Refined retry budget management to dynamically adjust handling based on failure severity levels.
  * Improved error tracking and logging visibility across retry attempts for infrastructure failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Commit 2 of 5 (classifier-consumers).

Migrates the three call sites of classifyInfraFailure() to the new classify(ex, scope). Behavior is unchanged for the SLURM and K8s retry paths EXCEPT for two intentional review-driven fixes:

1. Scope isolation for typed exceptions (review finding -- High). classify() now wraps a typed InfraFailure whose scope mismatches the caller's scope as a UserFailure, so an inner SLURM retry's typed <typed:slurm-job-inactive> exhaustion can no longer be re-retried by the outer K8s pod-launch retry that wraps the SLURM dispatcher pod. (The wrap is implemented inside classify() in the previous commit; this commit activates it by switching consumers to use classify().)

2. isFinalAttempt accuracy for PERSISTENT failures (review finding -- Medium). runKubernetesPodWithInfraRetry now tracks the prior attempt's severity in `lastSeverity`. If the previous attempt was PERSISTENT, the next attempt is the final one (effectiveMax=1), so isFinalAttempt is computed from the actual budget rather than the worst-case K8S_INFRA_RETRY_MAX. This means the inner cacheErrorAndUploadResult no longer suppresses synthetic stage-fail XML / junit() for what is actually the final attempt of an OOMKilled / "Connection failed" sequence, so the build's per-build test report records the failure instead of swallowing it.

Notes:
- The old e.toString().contains("FlowInterruptedException") and AbortException-exit-code-143 substring guards in the SLURM and K8s catch bodies are deleted; classify() returns PipelineInterruption for them and consumers rethrow on PipelineInterruption.
- The legacy classifyInfraFailure() function is intentionally retained in this commit so reviewers can diff old-vs-new classification behavior on the same input. It is deleted by the cleanup commit.
- [INFRA-RETRY] log line shape is preserved verbatim except for the field rename `classification.matchedPattern` -> `c.detectedPattern`. Dashboards and log scrapers keyed on the [INFRA-RETRY] prefix continue to work.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

N/A, this is a CI change
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
