### PR TITLE
[None][fix] Qwen3.5 DFlash

### DIFF
--- a/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
@@ -466,7 +466,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         num_decodes = kwargs["num_decodes"]
 
         if is_target_verify:
-            draft_token_num = spec_metadata.max_draft_len + 1
+            draft_token_num = spec_metadata.max_total_draft_tokens + 1
             assert num_decodes > 0
             assert mixed_qkv.shape[0] == num_decodes * draft_token_num
             assert a.shape[0] == num_decodes * draft_token_num
@@ -634,7 +634,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             )
 
             if is_target_verify:
-                draft_token_num = spec_metadata.max_draft_len + 1
+                draft_token_num = spec_metadata.max_total_draft_tokens + 1
                 assert num_decodes > 0
                 assert mixed_qkv_d.shape[0] == num_decodes * draft_token_num
                 assert a_d.shape[0] == num_decodes * draft_token_num
@@ -738,7 +738,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 last_recurrent_state = last_recurrent_state.to(ssm_states.dtype, copy=False)
                 ssm_states[state_indices_p] = last_recurrent_state
 
-            draft_token_num = spec_metadata.max_draft_len + 1
+            draft_token_num = spec_metadata.max_total_draft_tokens + 1
             query_d = query[:, num_prefill_tokens:, :, :].reshape(
                 num_decodes, draft_token_num, self.num_k_heads // self.attn_tp_size, self.head_k_dim
             )

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -287,8 +287,14 @@ class KvCacheCreator:
             effective_draft_config = self._get_effective_draft_config()
             if self._speculative_config.spec_dec_mode.is_external_drafter():
                 # External drafter: layers start from 0, normal PP distribution
+                # Resolve draft manager class from draft config — may differ
+                # from target (e.g. hybrid target + plain transformer draft).
+                draft_kv_cache_manager_cls = get_kv_cache_manager_cls(
+                    effective_draft_config,
+                    self._kv_cache_config,
+                    is_disagg=self._is_disagg)
                 total += self._per_manager_cache_cost(
-                    self._kv_cache_manager_cls, effective_draft_config)
+                    draft_kv_cache_manager_cls, effective_draft_config)
             elif self._mapping.is_last_pp_rank():
                 # EAGLE3/MTP: draft layers only on last PP rank
                 total += self._per_manager_cache_cost(

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -891,7 +891,7 @@ class MixedMambaHybridCacheManager(KVCacheManager, MambaCacheManager,
             mamba_ssm_cache_dtype,
             mamba_layer_mask,
             execution_stream,
-            speculative_num_draft_tokens=(spec_config.max_draft_len
+            speculative_num_draft_tokens=(spec_config.tokens_per_gen_step - 1
                                           if spec_config is not None else None),
             model_type=model_type,
             use_replay_state_update=use_replay_state_update,
@@ -1497,7 +1497,8 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
         self.intermediate_conv_states = None
         self.intermediate_state_indices = None
         if self.spec_config is not None:
-            speculative_num_draft_tokens = self.spec_config.max_draft_len
+            # DFlash/PARD use 2K query tokens per gen, so size by tokens_per_gen_step.
+            speculative_num_draft_tokens = self.spec_config.tokens_per_gen_step - 1
             num_local_mamba_layers = len(self.mamba_pp_layers)
 
             # Legacy SSM intermediate buffer is only needed when replay is

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1638,8 +1638,14 @@ class PyTorchModelEngine(ModelEngine):
                     'attn_metadata'].num_chunked_ctx_requests
                 previous_batch_tokens = inputs['input_ids'].shape[
                     0] - num_ctx_tokens
-                inputs['position_ids'][0, num_ctx_tokens:] += (
-                    self.previous_pos_id_offsets_cuda[:previous_batch_tokens])
+                if inputs['position_ids'].ndim == 3:  # mrope: [3, 1, N]
+                    inputs['position_ids'][:, :, num_ctx_tokens:] += (
+                        self.
+                        previous_pos_id_offsets_cuda[:previous_batch_tokens])
+                else:
+                    inputs['position_ids'][0, num_ctx_tokens:] += (
+                        self.
+                        previous_pos_id_offsets_cuda[:previous_batch_tokens])
                 if hasattr(inputs['attn_metadata'], 'kv_lens_cuda'):
                     if num_ctx_requests >= num_chunked_ctx_requests and num_chunked_ctx_requests > 0:
                         # The generation requests with draft_tokens are treated as chunked context requests when extend_ctx returns True.
@@ -1679,8 +1685,14 @@ class PyTorchModelEngine(ModelEngine):
                     'attn_metadata'].num_chunked_ctx_requests
                 previous_batch_tokens = inputs['input_ids'].shape[
                     0] - num_ctx_tokens
-                inputs['position_ids'][0, num_ctx_tokens:] -= (
-                    self.previous_pos_id_offsets_cuda[:previous_batch_tokens])
+                if inputs['position_ids'].ndim == 3:  # mrope: [3, 1, N]
+                    inputs['position_ids'][:, :, num_ctx_tokens:] -= (
+                        self.
+                        previous_pos_id_offsets_cuda[:previous_batch_tokens])
+                else:
+                    inputs['position_ids'][0, num_ctx_tokens:] -= (
+                        self.
+                        previous_pos_id_offsets_cuda[:previous_batch_tokens])
                 # Only TrtllmAttentionMetadata has kv_lens_cuda.
                 if isinstance(inputs['attn_metadata'], TrtllmAttentionMetadata):
                     if num_ctx_requests >= num_chunked_ctx_requests and num_chunked_ctx_requests > 0:

--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -409,7 +409,12 @@ class DFlashWorker(SpecWorkerBase):
             attn_metadata, num_accepted_tokens, num_contexts, batch_size
         )
 
-        position_ids = position_ids.squeeze(0)
+        # Collapse mrope [3, 1, N] to 1D by taking the first (temporal) dimension.
+        # The draft model uses standard 1D RoPE, so only scalar positions are needed.
+        if position_ids.ndim == 3:
+            position_ids = position_ids[0, 0]
+        else:
+            position_ids = position_ids.squeeze(0)
 
         # Get total tokens processed by target model (for hidden state extraction)
         total_target_tokens = input_ids.shape[0]

--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -25,6 +25,7 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 from ..attention_backend import AttentionMetadata
+from ..pyexecutor.mamba_cache_manager import MambaHybridCacheManager
 from ..pyexecutor.resource_manager import BaseResourceManager
 from .interface import SpecMetadata, SpecWorkerBase
 
@@ -396,6 +397,14 @@ class DFlashWorker(SpecWorkerBase):
         accepted_tokens, num_accepted_tokens = self._sample_and_accept_draft_tokens_base(
             logits_for_accept, draft_tokens, num_contexts, batch_size, spec_metadata
         )
+
+        # Update GDN/Mamba recurrent states to the accepted token's state.
+        if num_gens > 0 and isinstance(attn_metadata.kv_cache_manager, MambaHybridCacheManager):
+            attn_metadata.kv_cache_manager.update_mamba_states(
+                attn_metadata=attn_metadata,
+                num_accepted_tokens=num_accepted_tokens,
+                state_indices=attn_metadata.mamba_metadata.state_indices,
+            )
 
         # Pad accepted_tokens from (batch, K+1) to (batch, 2K) to match sampler buffer
         if K > 1:

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -200,6 +200,10 @@ Qwen/Qwen3.5-4B:
   - quant_algo: FP8_BLOCK_SCALES
     kv_cache_quant_algo: FP8
     accuracy: 80.5
+  - spec_dec_algo: DFlash
+    quant_algo: FP8_BLOCK_SCALES
+    kv_cache_quant_algo: FP8
+    accuracy: 80.5
 Qwen/Qwen3.5-35B-A3B:
   - dtype: bfloat16
     accuracy: 89.196

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -6234,6 +6234,22 @@ class TestQwen3_5_4B(LlmapiAccuracyTestHarness):
             task.evaluate(llm,
                           extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
 
+    @skip_pre_hopper
+    def test_dflash(self):
+        target_model_path = f"{llm_models_root()}/Qwen3.5-4B-FP8"
+        dflash_model_path = f"{llm_models_root()}/Qwen3.5-4B-DFlash"
+        spec_config = DFlashDecodingConfig(max_draft_len=4,
+                                           speculative_model=dflash_model_path)
+        with LLM(target_model_path,
+                 max_seq_len=4096,
+                 max_batch_size=8,
+                 kv_cache_config=self.kv_cache_config,
+                 cuda_graph_config=self.cuda_graph_config,
+                 speculative_config=spec_config) as llm:
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
+
 
 @pytest.mark.skip_less_device_memory(80000)
 class TestQwen3_5_35B_A3B(LlmapiAccuracyTestHarness):

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -736,6 +736,7 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_sof
 accuracy/test_llm_api_pytorch.py::TestQwen3_4B::test_eagle3
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_bf16
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_fp8
+accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_dflash
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_bf16
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8[enable_block_reuse=False]
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8[enable_block_reuse=True]

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -136,6 +136,7 @@ l0_h100:
   - accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_dflash
   - accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_bf16
   - accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_fp8
+  - accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_dflash
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_cuda_graph_padding[mtp_nextn=0]
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_cuda_graph_padding[mtp_nextn=2]
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Nano::test_fp8

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dflash.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dflash.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
 import unittest
@@ -11,63 +26,82 @@ from tensorrt_llm.llmapi import CudaGraphConfig, DFlashDecodingConfig, KvCacheCo
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
+PROMPTS = [
+    "The capital of France is",
+    "The president of the United States is",
+    "The future of AI is",
+]
 
-@pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
-def test_dflash(disable_overlap_scheduler: bool):
-    """Test DFlash speculative decoding with CUDA graph support.
 
-    This test verifies that DFlash speculative decoding works
-    correctly with CUDA graphs and padding enabled.
-    """
-    attn_backend = "TRTLLM"
-    enable_block_reuse = False
-    enable_chunked_prefill = False
-
-    total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
-    if total_mem_gb < 35:
-        pytest.skip("Not enough memory to load target + draft model")
-
-    models_path = llm_models_root()
-    dflash_model_dir = f"{models_path}/Qwen3-8B-DFlash-b16"
-    target_model_dir = f"{models_path}/Qwen3/Qwen3-8B"
-
-    # Test with 3 requests and max_batch_size=4 to trigger padding
-    max_batch_size = 4
-    max_draft_len = 4
-    kv_cache_config = KvCacheConfig(enable_block_reuse=enable_block_reuse, max_tokens=2048)
-    use_cuda_graph = True
-    cuda_graph_config = (
-        CudaGraphConfig(batch_sizes=[1, 2, 4], enable_padding=True) if use_cuda_graph else None
+def _make_llm_config(
+    target_model_dir: str,
+    dflash_model_dir: str,
+    disable_overlap_scheduler: bool,
+    max_draft_len: int = 4,
+    max_batch_size: int = 4,
+):
+    kv_cache_config = KvCacheConfig(enable_block_reuse=False, max_tokens=2048)
+    cuda_graph_config = CudaGraphConfig(batch_sizes=[1, 2, 4], enable_padding=True)
+    spec_config = DFlashDecodingConfig(
+        max_draft_len=max_draft_len,
+        speculative_model=dflash_model_dir,
     )
-
-    llm_common_config = dict(
+    return dict(
         model=target_model_dir,
-        attn_backend=attn_backend,
+        attn_backend="TRTLLM",
         disable_overlap_scheduler=disable_overlap_scheduler,
         cuda_graph_config=cuda_graph_config,
         max_batch_size=max_batch_size,
         kv_cache_config=kv_cache_config,
         max_seq_len=2048,
-        enable_chunked_prefill=enable_chunked_prefill,
+        enable_chunked_prefill=False,
+        speculative_config=spec_config,
     )
 
-    spec_config = DFlashDecodingConfig(
-        max_draft_len=max_draft_len,
-        speculative_model=dflash_model_dir,
+
+def _run_and_check(llm_config: dict, min_avg_accepted: float):
+    llm = LLM(**llm_config)
+    outputs = llm.generate(PROMPTS, SamplingParams(max_tokens=256, temperature=0))
+    llm.shutdown()
+
+    avg_accepted = [o.avg_decoded_tokens_per_iter - 1 for o in outputs]
+    mean_accepted = sum(avg_accepted) / len(avg_accepted)
+    assert mean_accepted >= min_avg_accepted, (
+        f"mean avg accepted {mean_accepted:.2f} < threshold {min_avg_accepted} "
+        f"(per request: {[f'{a:.2f}' for a in avg_accepted]})"
     )
 
-    # Create the LLM instance
-    llm_spec = LLM(**llm_common_config, speculative_config=spec_config)
 
-    prompts = [
-        "The capital of France is",
-        "The president of the United States is",
-        "The future of AI is",
-    ]
+@pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
+def test_dflash_qwen3_8b(disable_overlap_scheduler: bool):
+    """Test DFlash with Qwen3-8B BF16: CUDA graphs, padding, and draft acceptance."""
+    total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
+    if total_mem_gb < 35:
+        pytest.skip("Not enough memory to load target + draft model")
 
-    sampling_params = SamplingParams(max_tokens=1024, temperature=0)
-    llm_spec.generate(prompts, sampling_params)
-    llm_spec.shutdown()
+    models_path = llm_models_root()
+    llm_config = _make_llm_config(
+        target_model_dir=f"{models_path}/Qwen3/Qwen3-8B",
+        dflash_model_dir=f"{models_path}/Qwen3-8B-DFlash-b16",
+        disable_overlap_scheduler=disable_overlap_scheduler,
+    )
+    _run_and_check(llm_config, min_avg_accepted=1.0)
+
+
+@pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
+def test_dflash_qwen3_5_4b(disable_overlap_scheduler: bool):
+    """Test DFlash with Qwen3.5-4B BF16: CUDA graphs, padding, and draft acceptance."""
+    total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
+    if total_mem_gb < 20:
+        pytest.skip("Not enough memory to load target + draft model")
+
+    models_path = llm_models_root()
+    llm_config = _make_llm_config(
+        target_model_dir=f"{models_path}/Qwen3.5-4B",
+        dflash_model_dir=f"{models_path}/Qwen3.5-4B-DFlash",
+        disable_overlap_scheduler=disable_overlap_scheduler,
+    )
+    _run_and_check(llm_config, min_avg_accepted=1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DFlash speculative decoding now integrates with Mamba cache synchronization for improved efficiency.

* **Improvements**
  * Optimized draft window sizing in speculative decoding paths.
  * Enhanced 3D position ID handling support for MRoPE configurations.
  * Hardened position ID tensor handling for broader compatibility.

* **Tests**
  * Added FP8 DFlash decoding test coverage for Qwen models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Minor fixes to combine DFlash with m-rope and linear attention in Qwen3.5:
1. Since draft uses standard rope, use text dimension position_ids only in draft forward.
2. In GDN attention, adjust buffer sizes to account for 2K total draft tokens in DFlash (vs K + 1 for Eagle).
3. Perform state updates in GDN attention after accepting tokens.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Added new test `tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_dflash`
and extended `tests/unittest/_torch/speculative/test_dflash.py` to test Qwen3.5-4B along with Qwen3-8B.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
