### PR TITLE
[None][fix] Fix Autodeploy standalone package builder script tests

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla/__init__.py
@@ -1,32 +1,10 @@
 """MLA (Multi-head Latent Attention) custom ops.
 
-Exports:
-- TorchBackendMLAAttention: Attention descriptor for MLA (registered as "torch_mla")
-- FlashInferMLAAttention: Attention descriptor for FlashInfer MLA (registered as "flashinfer_mla")
-- FlashInferTrtllmMLAAttention: Attention descriptor for FlashInfer TRTLLM-gen MLA
-- TritonMLAAttention: Attention descriptor for Triton MLA (registered as "triton_mla")
-- torch_mla: Source op for MLA attention
-- torch_backend_mla_with_cache: Cached backend op with FlashInfer-compatible cache
-- flashinfer_mla_with_cache: Cached backend op using FlashInfer MLA kernels
-- flashinfer_trtllm_mla_with_cache: Cached backend op using FlashInfer Path 2 kernels
-- triton_cached_mla_with_cache: Cached backend op using Triton kernels
-- trtllm_mla: TRT-LLM thop.attention-based MLA (requires tensorrt_llm, discovered individually)
+This module provides various MLA implementations and backends:
+- torch_mla: PyTorch reference MLA implementation
+- torch_backend_mla: PyTorch-based MLA backend
+- flashinfer_mla: FlashInfer-based optimized MLA
+- flashinfer_trtllm_mla: FlashInfer TRTLLM-gen MLA (Blackwell Path 2)
+- triton_mla: Triton-based MLA implementation
+- trtllm_mla: TRT-LLM thop.attention-based MLA (requires tensorrt_llm)
 """
-
-from .flashinfer_mla import FlashInferMLAAttention, flashinfer_mla_with_cache
-from .flashinfer_trtllm_mla import FlashInferTrtllmMLAAttention, flashinfer_trtllm_mla_with_cache
-from .torch_backend_mla import TorchBackendMLAAttention, torch_backend_mla_with_cache
-from .torch_mla import torch_mla
-from .triton_mla import TritonMLAAttention, triton_cached_mla_with_cache
-
-__all__ = [
-    "TorchBackendMLAAttention",
-    "FlashInferMLAAttention",
-    "FlashInferTrtllmMLAAttention",
-    "TritonMLAAttention",
-    "torch_mla",
-    "torch_backend_mla_with_cache",
-    "flashinfer_mla_with_cache",
-    "flashinfer_trtllm_mla_with_cache",
-    "triton_cached_mla_with_cache",
-]

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/mla/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/mla/__init__.py
@@ -10,8 +10,7 @@ Exports:
 - flashinfer_mla_with_cache: Cached backend op using FlashInfer MLA kernels
 - flashinfer_trtllm_mla_with_cache: Cached backend op using FlashInfer Path 2 kernels
 - triton_cached_mla_with_cache: Cached backend op using Triton kernels
-- TrtllmMLAAttention: Attention descriptor for TRT-LLM MLA (registered as "trtllm_mla")
-- trtllm_mla_with_cache: Cached backend op using TRT-LLM thop.attention with MLA
+- trtllm_mla: TRT-LLM thop.attention-based MLA (requires tensorrt_llm, discovered individually)
 """
 
 from .flashinfer_mla import FlashInferMLAAttention, flashinfer_mla_with_cache
@@ -19,7 +18,6 @@ from .flashinfer_trtllm_mla import FlashInferTrtllmMLAAttention, flashinfer_trtl
 from .torch_backend_mla import TorchBackendMLAAttention, torch_backend_mla_with_cache
 from .torch_mla import torch_mla
 from .triton_mla import TritonMLAAttention, triton_cached_mla_with_cache
-from .trtllm_mla import TrtllmMLAAttention, prepare_trtllm_mla_metadata, trtllm_mla_with_cache
 
 __all__ = [
     "TorchBackendMLAAttention",
@@ -31,7 +29,4 @@ __all__ = [
     "flashinfer_mla_with_cache",
     "flashinfer_trtllm_mla_with_cache",
     "triton_cached_mla_with_cache",
-    "TrtllmMLAAttention",
-    "trtllm_mla_with_cache",
-    "prepare_trtllm_mla_metadata",
 ]

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -244,7 +244,6 @@ full:GH200/examples/test_multimodal.py::test_llm_multimodal_general[video-neva-p
 full:GH200/examples/test_nemotron.py::test_llm_nemotron_3_8b_1gpu[bfloat16-fp8] SKIP (arm is not supported)
 full:GH200/examples/test_qwen2audio.py::test_llm_qwen2audio_single_gpu[qwen2_audio_7b_instruct] SKIP (arm is not supported)
 full:GH200/unittest/trt/model_api/test_model_quantization.py SKIP (https://nvbugs/4979955)
-full:H100_PCIe/unittest/auto_deploy/standalone SKIP (https://nvbugs/6129630)
 full:H100_PCIe/unittest/llmapi/test_llm_pytorch.py::test_llama_7b_multi_lora_evict_and_reload_lora_gpu_cache SKIP (https://nvbugs/5682551)
 full:H20-3e/accuracy/test_llm_api_pytorch.py::TestLlama4MaverickInstruct::test_fp8[tp8-cuda_graph=True] SKIP (https://nvbugs/5574553)
 full:H20-3e/accuracy/test_llm_api_pytorch.py::TestLlama4MaverickInstruct::test_fp8[tp8ep4-cuda_graph=True] SKIP (https://nvbugs/5574553)

--- a/tests/unittest/auto_deploy/standalone/test_standalone_package.py
+++ b/tests/unittest/auto_deploy/standalone/test_standalone_package.py
@@ -184,6 +184,13 @@ class TestStandalonePackage:
             "PATH": os.path.join(standalone_package["venv_dir"], "bin")
             + os.pathsep
             + os.environ.get("PATH", ""),
+            # FlashInfer JIT-compiles kernels and caches .so files under
+            # FLASHINFER_WORKSPACE_BASE (default: $HOME). Ninja records absolute
+            # source paths from the flashinfer package. Since this venv is
+            # ephemeral, a subsequent run would find stale cache entries pointing
+            # at the old (deleted) venv paths, causing all JIT builds to fail.
+            # Redirect the cache into the venv so it's discarded with it.
+            "FLASHINFER_WORKSPACE_BASE": standalone_package["venv_dir"],
         }
 
         cmd = [


### PR DESCRIPTION

mla/__init__.py was the only custom_ops subdirectory with eager `from .X import ...` statements. When trtllm_mla.py failed to import in standalone mode (no tensorrt_llm), it poisoned the entire mla package — breaking all MLA ops. Remove the eager imports to match every other custom_ops subdirectory and let the pkgutil.walk_packages compat layer in custom_ops/__init__.py handle per-module registration and graceful skipping.

Also unwaive the standalone package test now that the root cause is fixed.

### Additional changes

**Root cause**: PR #13222 (`[#11823][feat] AutoDeploy trtllm_mla attention backend`) added `from .trtllm_mla import ...` to `mla/__init__.py`. Since `trtllm_mla.py` has hard imports of `tensorrt_llm.bindings.internal.thop` and `tensorrt_llm.functional`, loading *any* MLA submodule in standalone mode triggered the entire package to fail — collateral damage that took down all 5 standalone-safe backends (torch, flashinfer, triton).

**Fix approach** (follows the pattern established by PR #13454 for `transform/library/rope.py`):
- Removed all eager imports and `__all__` from `mla/__init__.py`, leaving only the docstring — matching `attention/__init__.py`.
- `custom_ops/__init__.py`'s `walk_packages` discovers each submodule individually, and `_is_trtllm_import_error()` gracefully skips only `trtllm_mla` in standalone mode without affecting the other backends.

**FlashInfer JIT cache fix**: The standalone test creates an ephemeral venv with its own flashinfer install. FlashInfer JIT-compiles CUDA kernels and caches `.so` files under `~/.cache/flashinfer/` by default. Ninja records absolute source paths during compilation. On subsequent test runs, the cache still references paths from the previous (now deleted) venv, causing all JIT builds to fail. Setting `FLASHINFER_WORKSPACE_BASE` to the venv directory ensures each run gets a fresh cache that's discarded with the venv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test environment configuration for better integration testing
  * Re-enabled a test case for enhanced test coverage

* **Chores**
  * Updated module documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for this PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.