### PR TITLE
[None][fix] Use compressed lengths for DeepSeek-V4 indexer

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -388,8 +388,10 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         # (tokens_per_block // compress_ratio), so slot mappings must be built
         # against that stride — not kv_cache_manager.tokens_per_block directly.
         tpb = self.kv_cache_manager.tokens_per_block
+        self._indexer_compress_ratio = 1
         if hasattr(self.kv_cache_manager, 'compressed_block_sizes'):
             compress_ratio = 4 if 4 in self.compress_ratios else 1
+            self._indexer_compress_ratio = compress_ratio
             tpb = tpb // compress_ratio
         self._tokens_per_block = tpb
 
@@ -434,6 +436,16 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
 
         # Prepare metadata for indexer
         Indexer.prepare(metadata=self)
+
+    def get_indexer_kv_lens(self, kv_lens: torch.Tensor) -> torch.Tensor:
+        if self._indexer_compress_ratio == 1:
+            return kv_lens
+        return kv_lens // self._indexer_compress_ratio
+
+    def get_indexer_max_seq_len(self) -> int:
+        return max(
+            1,
+            self.kv_cache_manager.max_seq_len // self._indexer_compress_ratio)
 
     # This function is only used to create the expanded buffers when the max_draft_tokens is changed.
     # TODO: remove this function once fp8_paged_mqa_logits supports an arbitrary number of MTP draft tokens.
@@ -518,30 +530,30 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
                 dim=0,
                 dtype=torch.int64,
                 out=self.gen_cached_token_indptr[1:self.num_generations + 1])
+            gen_kv_lens = self.kv_lens_cuda[self.num_contexts:self.num_seqs]
+            gen_indexer_kv_lens = self.get_indexer_kv_lens(gen_kv_lens)
             scheduler_metadata_buffer = get_paged_mqa_logits_metadata(
-                self.kv_lens_cuda[self.num_contexts:self.num_seqs],
-                self.kv_cache_manager.tokens_per_block, self.num_sms)
+                gen_indexer_kv_lens, self._tokens_per_block, self.num_sms)
             self.scheduler_metadata_buffer.copy_(scheduler_metadata_buffer,
                                                  non_blocking=True)
             if self.use_expanded_buffers_for_mtp:
                 num_draft_tokens = 1 + self.max_draft_tokens
                 num_tokens = self.num_generations * num_draft_tokens
-                gen_kv_lens = self.kv_lens_cuda[self.num_contexts:self.num_seqs]
-                kv_lens_expanded = torch.stack([gen_kv_lens] * num_draft_tokens,
+                kv_lens_expanded = torch.stack([gen_indexer_kv_lens] *
+                                               num_draft_tokens,
                                                dim=0)
                 self.kv_lens_expanded_cuda[:num_tokens] = \
                     kv_lens_expanded.transpose(0, 1).contiguous().flatten()
                 # Expand schedule metadata buffer (only generation)
                 kv_lens_expanded = self.kv_lens_expanded_cuda[:num_tokens]
                 scheduler_metadata_buffer_expanded = get_paged_mqa_logits_metadata(
-                    kv_lens_expanded, self.kv_cache_manager.tokens_per_block,
-                    self.num_sms)
+                    kv_lens_expanded, self._tokens_per_block, self.num_sms)
                 self.scheduler_metadata_buffer_expanded.copy_(
                     scheduler_metadata_buffer_expanded, non_blocking=True)
             elif self.max_draft_tokens == 3:
                 scheduler_metadata_buffer_mtp3 = get_paged_mqa_logits_metadata(
-                    self.kv_lens_cuda[self.num_contexts:self.num_seqs],
-                    self.kv_cache_manager.tokens_per_block, self.num_sms // 2)
+                    gen_indexer_kv_lens, self._tokens_per_block,
+                    self.num_sms // 2)
                 self.scheduler_metadata_buffer_mtp3.copy_(
                     scheduler_metadata_buffer_mtp3, non_blocking=True)
         self.prepare_dense_topk_indices(self.kv_lens_cuda, device=True)
@@ -902,7 +914,8 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         if self.use_expanded_buffers_for_mtp:
             # Expand kv_lens_cuda (only generation)
             num_tokens = self.num_generations * (1 + self.max_draft_tokens)
-            gen_kv_lens = kv_lens[self.num_contexts:self.num_seqs]
+            gen_kv_lens = self.get_indexer_kv_lens(
+                kv_lens[self.num_contexts:self.num_seqs])
             gen_kv_lens_expanded = torch.stack([gen_kv_lens] *
                                                (1 + self.max_draft_tokens),
                                                dim=0)
@@ -1521,10 +1534,11 @@ class Indexer(nn.Module):
         """
         num_contexts = metadata.num_contexts
         num_generations = metadata.num_generations
-        tokens_per_block = metadata.kv_cache_manager.tokens_per_block
+        tokens_per_block = metadata._tokens_per_block
         if not metadata.use_expanded_buffers_for_mtp:
-            gen_seq_lens = metadata.kv_lens_cuda_runtime[
-                num_contexts:num_contexts + num_generations]
+            gen_seq_lens = metadata.get_indexer_kv_lens(
+                metadata.kv_lens_cuda_runtime[num_contexts:num_contexts +
+                                              num_generations])
             scheduler_metadata_buffer = get_paged_mqa_logits_metadata(
                 gen_seq_lens, tokens_per_block, metadata.num_sms)
             metadata.scheduler_metadata_buffer.copy_(scheduler_metadata_buffer,
@@ -1874,7 +1888,6 @@ class Indexer(nn.Module):
                 metadata.topk_indices_buffer[:num_ctx_tokens, :]
 
         if has_decode and not metadata.skip_indexer_for_gen_reqs:
-            max_seq_len = metadata.kv_cache_manager.max_seq_len
             # Get decode lengths per request (from seq_lens) for validation
             gen_seq_lens = metadata.seq_lens[num_contexts:num_contexts +
                                              num_generations]
@@ -1892,8 +1905,9 @@ class Indexer(nn.Module):
             # and expand the corresponding metadata.
             if not metadata.use_expanded_buffers_for_mtp or next_n == 1:
                 q_decode = q_decode.view(num_generations, -1, *q_fp8.shape[1:])
-                context_lens = metadata.kv_lens_cuda_runtime[
+                raw_context_lens = metadata.kv_lens_cuda_runtime[
                     num_contexts:num_contexts + num_generations]
+                context_lens = metadata.get_indexer_kv_lens(raw_context_lens)
                 block_table = metadata.indexer_k_cache_block_offsets[
                     num_contexts:num_contexts + num_generations]
                 if q_decode.shape[1] == 4:
@@ -1915,11 +1929,9 @@ class Indexer(nn.Module):
             # [num_blocks, tokens_per_block, 1, head_dim + scale_size]
             k_cache = metadata.kv_cache_manager.get_indexer_k_cache_buffers(
                 self.layer_idx)
-            logits_decode = fp8_paged_mqa_logits(q_decode, k_cache,
-                                                 weights_decode, context_lens,
-                                                 block_table,
-                                                 scheduler_metadata_buffer,
-                                                 max_seq_len)
+            logits_decode = fp8_paged_mqa_logits(
+                q_decode, k_cache, weights_decode, context_lens, block_table,
+                scheduler_metadata_buffer, metadata.get_indexer_max_seq_len())
 
             if use_custom_topk:
                 # Kernel expects kv_lens (total cache length), not seq_lens (new tokens)
@@ -1931,9 +1943,11 @@ class Indexer(nn.Module):
                 # so we cap it at 256 for now and fall back to the CUDA C++
                 # indexer_topk_decode. This limit can be removed if GPU memory
                 # is not a bottleneck.
-                if self.use_cute_dsl_topk and num_gen_tokens <= 256:
+                if (self.use_cute_dsl_topk and num_gen_tokens <= 256
+                        and (self.compress_ratio == 1 or next_n == 1)):
                     torch.ops.trtllm.cute_dsl_indexer_topk_decode(
-                        logits_decode, gen_kv_lens_cuda,
+                        logits_decode, context_lens
+                        if self.compress_ratio > 1 else gen_kv_lens_cuda,
                         topk_indices_buffer[num_ctx_tokens:num_ctx_tokens +
                                             num_gen_tokens, :], self.index_topk,
                         next_n)
@@ -1946,15 +1960,15 @@ class Indexer(nn.Module):
             else:
                 # padded
                 positions = torch.arange(
-                    max_seq_len, device=q_decode.device).unsqueeze(0).expand(
+                    logits_decode.shape[-1],
+                    device=q_decode.device).unsqueeze(0).expand(
                         num_gen_tokens, -1)
                 row_indices = torch.arange(num_gen_tokens,
                                            device=q_decode.device) // next_n
                 next_n_offset = torch.arange(num_gen_tokens,
                                              device=q_decode.device) % next_n
-                index_end_pos = (
-                    metadata.kv_lens_cuda_runtime[num_contexts + row_indices] -
-                    next_n + next_n_offset).unsqueeze(1)
+                index_end_pos = (context_lens[row_indices] - next_n +
+                                 next_n_offset).unsqueeze(1)
                 # index_end_pos: [B * N, 1]
                 mask = positions <= index_end_pos
                 # mask: [B * N, L]

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -243,6 +243,18 @@ def split_prefill_chunks(
     return chunk_groups
 
 
+def _select_indexer_compress_ratio(compress_ratios: List[int]) -> int:
+    if 4 in compress_ratios:
+        return 4
+    if 1 in compress_ratios:
+        return 1
+    return 0
+
+
+def _effective_compress_ratio_divisor(compress_ratio: int) -> int:
+    return compress_ratio if compress_ratio > 1 else 1
+
+
 def compute_cu_seqlen_kv_bounds_with_cache(
     seq_lens: torch.Tensor,
     num_contexts: int,
@@ -388,11 +400,11 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         # (tokens_per_block // compress_ratio), so slot mappings must be built
         # against that stride — not kv_cache_manager.tokens_per_block directly.
         tpb = self.kv_cache_manager.tokens_per_block
-        self._indexer_compress_ratio = 1
+        self._indexer_compress_ratio = _select_indexer_compress_ratio(
+            self.compress_ratios)
         if hasattr(self.kv_cache_manager, 'compressed_block_sizes'):
-            compress_ratio = 4 if 4 in self.compress_ratios else 1
-            self._indexer_compress_ratio = compress_ratio
-            tpb = tpb // compress_ratio
+            tpb = tpb // _effective_compress_ratio_divisor(
+                self._indexer_compress_ratio)
         self._tokens_per_block = tpb
 
         self.create_buffers_for_mla_rope_append(capture_graph=capture_graph)
@@ -438,11 +450,13 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         Indexer.prepare(metadata=self)
 
     def get_indexer_kv_lens(self, kv_lens: torch.Tensor) -> torch.Tensor:
-        if self._indexer_compress_ratio == 1:
+        if self._indexer_compress_ratio <= 1:
             return kv_lens
         return kv_lens // self._indexer_compress_ratio
 
     def get_indexer_max_seq_len(self) -> int:
+        if self._indexer_compress_ratio <= 1:
+            return self.kv_cache_manager.max_seq_len
         return max(
             1,
             self.kv_cache_manager.max_seq_len // self._indexer_compress_ratio)
@@ -1254,8 +1268,8 @@ class Indexer(nn.Module):
         Note: Cached token counts are derived from metadata.host_ctx_cached_token_indptr
         """
         device = metadata.cu_seqlen_ks.device
-        # Only support compression ratio of 4 and 1 for now
-        compress_ratio = 4 if 4 in metadata.compress_ratios else 1
+        compress_ratio = _effective_compress_ratio_divisor(
+            _select_indexer_compress_ratio(metadata.compress_ratios))
         if len(chunk_specs) == 1:
             # Single request or intra-request Q-block
             req_idx, token_start_in_req, token_end_in_req, req_cum_start = chunk_specs[
@@ -1586,8 +1600,8 @@ class Indexer(nn.Module):
         head_dim = metadata.indexer_head_dim
         quant_block_size = metadata.indexer_quant_block_size
         num_past_tokens = metadata.kv_cache_params.num_cached_tokens_per_seq
-        # Only support compression ratio of 4 and 1 for now
-        compress_ratio = 4 if 4 in metadata.compress_ratios else 1
+        compress_ratio = _effective_compress_ratio_divisor(
+            _select_indexer_compress_ratio(metadata.compress_ratios))
 
         indexer_params = IndexerParams(
             num_contexts=num_contexts,

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -361,6 +361,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
     compress_ratios: List[int] = [1]
     # Number of compressed KV tokens for context requests
     num_ctx_kv_tokens: int = 0
+    gen_indexer_kv_lens_cuda_runtime: Optional[torch.Tensor] = None
 
     def __init__(self, *args, **kwargs):
         self.num_sms = tensorrt_llm.deep_gemm.get_num_sms()
@@ -546,6 +547,7 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
                 out=self.gen_cached_token_indptr[1:self.num_generations + 1])
             gen_kv_lens = self.kv_lens_cuda[self.num_contexts:self.num_seqs]
             gen_indexer_kv_lens = self.get_indexer_kv_lens(gen_kv_lens)
+            self.gen_indexer_kv_lens_cuda_runtime = gen_indexer_kv_lens
             scheduler_metadata_buffer = get_paged_mqa_logits_metadata(
                 gen_indexer_kv_lens, self._tokens_per_block, self.num_sms)
             self.scheduler_metadata_buffer.copy_(scheduler_metadata_buffer,
@@ -1553,6 +1555,7 @@ class Indexer(nn.Module):
             gen_seq_lens = metadata.get_indexer_kv_lens(
                 metadata.kv_lens_cuda_runtime[num_contexts:num_contexts +
                                               num_generations])
+            metadata.gen_indexer_kv_lens_cuda_runtime = gen_seq_lens
             scheduler_metadata_buffer = get_paged_mqa_logits_metadata(
                 gen_seq_lens, tokens_per_block, metadata.num_sms)
             metadata.scheduler_metadata_buffer.copy_(scheduler_metadata_buffer,
@@ -1919,9 +1922,8 @@ class Indexer(nn.Module):
             # and expand the corresponding metadata.
             if not metadata.use_expanded_buffers_for_mtp or next_n == 1:
                 q_decode = q_decode.view(num_generations, -1, *q_fp8.shape[1:])
-                raw_context_lens = metadata.kv_lens_cuda_runtime[
-                    num_contexts:num_contexts + num_generations]
-                context_lens = metadata.get_indexer_kv_lens(raw_context_lens)
+                context_lens = metadata.gen_indexer_kv_lens_cuda_runtime
+                assert context_lens is not None
                 block_table = metadata.indexer_k_cache_block_offsets[
                     num_contexts:num_contexts + num_generations]
                 if q_decode.shape[1] == 4:

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -3616,6 +3616,26 @@ class TestDeepSeekV4FlashBase(LlmapiAccuracyTestHarness):
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm, is_integration_test=True)
 
+    @pytest.mark.skip_less_mpi_world_size(4)
+    def test_fp8_chunked_prefill(self):
+        kv_cache_config = KvCacheConfig(dtype="fp8",
+                                        free_gpu_memory_fraction=0.5,
+                                        enable_block_reuse=False)
+        with LLM(self.MODEL_PATH,
+                 tensor_parallel_size=4,
+                 moe_expert_parallel_size=4,
+                 moe_config=MoeConfig(backend="WIDEEP"),
+                 cuda_graph_config=CudaGraphConfig(max_batch_size=16,
+                                                   enable_padding=True),
+                 enable_attention_dp=True,
+                 enable_chunked_prefill=True,
+                 max_batch_size=16,
+                 max_num_tokens=128,
+                 max_seq_len=4096,
+                 kv_cache_config=kv_cache_config) as llm:
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm, is_integration_test=True)
+
     # CUTLASS is omitted: V4 Flash-Base FP8 block-scale weights take a
     # Hopper-only kernel path (CutlassFp8BlockScaleGemmRunner::moeGemm) that
     # fails on Blackwell. WIDEEP avoids that path and works on B200/B300.

--- a/tests/integration/test_lists/test-db/l0_dgx_b300_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b300_ds.yml
@@ -33,6 +33,12 @@ l0_dgx_b300_ds:
   # model is currently missing on B300 CI workers, so LLM(...) treats the
   # path as an HF repo id and HFValidationError fires.
   # - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4FlashBase::test_auto_dtype[moe_backend=TRTLLM] TIMEOUT (60)
+  # V4-Flash-Base FP8 chunked-prefill smoke with FP8 KV cache. Keep
+  # max_num_tokens small in the test to force chunked prefill scheduling.
+  # Held out for the same model-availability reason as test_auto_dtype above;
+  # re-enable together once DeepSeek-V4-Flash-Base is uploaded to the CI
+  # model share.
+  # - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4FlashBase::test_fp8_chunked_prefill TIMEOUT (60)
   # V4-Flash NVFP4 static EPLB sanity. WIDEEP backend is skipped at the
   # test level because V4-Flash MXFP4 routed experts are unsupported by
   # WIDEEP (raises "Unsupported quantization mode: [65536]"); TRTLLM is the

--- a/tests/integration/test_lists/test-db/l0_dgx_b300_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b300_ds.yml
@@ -33,6 +33,8 @@ l0_dgx_b300_ds:
   # model is currently missing on B300 CI workers, so LLM(...) treats the
   # path as an HF repo id and HFValidationError fires.
   # - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4FlashBase::test_auto_dtype[moe_backend=TRTLLM] TIMEOUT (60)
+  # V4-Flash NVFP4 aggregate smoke (TP=4, no EPLB): 1 MMLU sample.
+  - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_auto_dtype TIMEOUT (60)
   # V4-Flash-Base FP8 chunked-prefill smoke with FP8 KV cache. Keep
   # max_num_tokens small in the test to force chunked prefill scheduling.
   # Held out for the same model-availability reason as test_auto_dtype above;

--- a/tests/unittest/_torch/attention/sparse/dsa/test_dsa_indexer.py
+++ b/tests/unittest/_torch/attention/sparse/dsa/test_dsa_indexer.py
@@ -1011,7 +1011,7 @@ def test_indexer_decode_with_paged_kv_cache(batch_size, next_n, compress_ratio):
         num_contexts=batch_size,
         num_generations=0,
         seq_lens=context_lens_context.clone(),
-        kv_lens=num_ctx_kv_tokens.clone(),
+        kv_lens=context_lens_context.clone(),
         num_cached_tokens=[0] * batch_size,
         cache_manager=cache_manager,
         num_ctx_tokens=total_context_tokens,
@@ -1036,7 +1036,7 @@ def test_indexer_decode_with_paged_kv_cache(batch_size, next_n, compress_ratio):
         num_contexts=0,
         num_generations=batch_size,
         seq_lens=torch.tensor([num_gen_tokens] * batch_size, dtype=torch.int32, device="cpu"),
-        kv_lens=final_kv_lens.clone(),
+        kv_lens=final_lens.clone(),
         num_cached_tokens=context_lens_context.tolist(),
         cache_manager=cache_manager,
         num_ctx_tokens=0,
@@ -1058,7 +1058,7 @@ def test_indexer_decode_with_paged_kv_cache(batch_size, next_n, compress_ratio):
 
     if not metadata_gen.use_expanded_buffers_for_mtp:
         q_fp8 = q_fp8
-        context_lens = metadata_gen.kv_lens_cuda_runtime[0:batch_size]
+        context_lens = metadata_gen.gen_indexer_kv_lens_cuda_runtime
         block_table = metadata_gen.indexer_k_cache_block_offsets[0:batch_size]
         if q_fp8.shape[1] == 4:
             scheduler_metadata_buffer = metadata_gen.scheduler_metadata_buffer_mtp3
@@ -1125,7 +1125,7 @@ def test_indexer_decode_with_paged_kv_cache(batch_size, next_n, compress_ratio):
         gen_offset += seq_gen_len
 
     num_tokens_cuda = final_lens.cuda()
-    num_kv_tokens_cuda = metadata_gen.kv_lens_cuda_runtime
+    num_kv_tokens_cuda = final_kv_lens.cuda()
     ref_logits = _ref_fp8_paged_mqa_logits(
         q,
         kv_cache_bf16,

--- a/tests/unittest/_torch/attention/sparse/dsa/test_dsa_indexer.py
+++ b/tests/unittest/_torch/attention/sparse/dsa/test_dsa_indexer.py
@@ -22,6 +22,8 @@ from tensorrt_llm._torch.attention_backend.sparse.dsa import (
     DSACacheManager,
     DSAtrtllmAttentionMetadata,
     Indexer,
+    _effective_compress_ratio_divisor,
+    _select_indexer_compress_ratio,
     compute_cu_seqlen_kv_bounds_with_cache,
     split_prefill_chunks,
 )
@@ -432,9 +434,9 @@ def _create_mock_metadata(
             # Effective tokens-per-block for the indexer k-cache slot mapping,
             # mirroring DSAtrtllmAttentionMetadata.__post_init__ (dsa.py).
             tpb = self.kv_cache_manager.tokens_per_block
+            self._indexer_compress_ratio = _select_indexer_compress_ratio(self.compress_ratios)
             if hasattr(self.kv_cache_manager, "compressed_block_sizes"):
-                _cr = 4 if 4 in self.compress_ratios else 1
-                tpb = tpb // _cr
+                tpb = tpb // _effective_compress_ratio_divisor(self._indexer_compress_ratio)
             self._tokens_per_block = tpb
             self.kv_lens_cuda_runtime = kv_lens.cuda()
             self.indexer_k_cache_block_offsets = torch.zeros(
@@ -619,6 +621,22 @@ def _create_mock_metadata(
             return self._num_seqs
 
     return MockMetadata()
+
+
+@pytest.mark.parametrize("disabled_ratio", [0, 1])
+def test_indexer_compress_ratio_zero_or_one_means_uncompressed(disabled_ratio):
+    metadata = object.__new__(DSAtrtllmAttentionMetadata)
+    metadata.kv_cache_manager = Mock()
+    metadata.kv_cache_manager.max_seq_len = 4096
+
+    kv_lens = torch.tensor([0, 1, 128, 4096], dtype=torch.int32)
+    metadata._indexer_compress_ratio = disabled_ratio
+    assert torch.equal(metadata.get_indexer_kv_lens(kv_lens), kv_lens)
+    assert metadata.get_indexer_max_seq_len() == 4096
+
+    metadata._indexer_compress_ratio = 4
+    assert torch.equal(metadata.get_indexer_kv_lens(kv_lens), kv_lens // 4)
+    assert metadata.get_indexer_max_seq_len() == 1024
 
 
 def validate_topk_indices(topk_indices_0, topk_indices_1, total_tokens):


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

  Fix DeepSeek-V4 DSA indexer metadata handling for compressed KV cache.

  This PR updates the indexer compression-ratio handling so both `0` and `1` are treated as disabled compression, matching model configs where `0` means no
  compressor. For compressed paths, indexer KV lengths and max sequence length remain in compressed KV-token space.

  It also avoids recomputing `get_indexer_kv_lens()` in the decode forward path by reusing the generation indexer KV lengths prepared together with scheduler
  metadata. This prevents introducing an extra element-wise CUDA division kernel in the hot path.

## Test Coverage

  - `pre-commit run --show-diff-on-failure --files tensorrt_llm/_torch/attention_backend/sparse/dsa.py tests/unittest/_torch/attention/sparse/dsa/
  test_dsa_indexer.py`
  - B300 container:
    - `test_indexer_compress_ratio_zero_or_one_means_uncompressed`
    - `test_indexer_decode_with_paged_kv_cache`


## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
