### PR TITLE
[None][feat] Exact multimodal KV blockhashing

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -149,7 +149,7 @@ public:
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt,
         std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt,
         std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy = std::nullopt,
-        std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalItemRunCuSeqlen = std::nullopt,
+        std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalItemRunCuOffsets = std::nullopt,
         std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalRunPositions = std::nullopt,
         std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalRunLengths = std::nullopt)
         : mRequestId(requestId)
@@ -175,7 +175,7 @@ public:
         , mMultimodalPositions(std::move(multimodalPositions))
         , mMultimodalLengths(std::move(multimodalLengths))
         , mMultimodalUuids(std::move(multimodalUuids))
-        , mMultimodalItemRunCuSeqlen(std::move(multimodalItemRunCuSeqlen))
+        , mMultimodalItemRunCuOffsets(std::move(multimodalItemRunCuOffsets))
         , mMultimodalRunPositions(std::move(multimodalRunPositions))
         , mMultimodalRunLengths(std::move(multimodalRunLengths))
         , mMultimodalEmbedding(std::move(multimodalEmbedding))
@@ -416,10 +416,10 @@ public:
             {
                 mMultimodalUuids = std::make_shared<std::vector<std::optional<std::string>>>(multimodalUuids.value());
             }
-            if (auto const& multimodalItemRunCuSeqlen = multimodalInput->getMultimodalItemRunCuSeqlen())
+            if (auto const& multimodalItemRunCuOffsets = multimodalInput->getMultimodalItemRunCuOffsets())
             {
-                mMultimodalItemRunCuSeqlen
-                    = std::make_shared<std::vector<SizeType32>>(multimodalItemRunCuSeqlen.value());
+                mMultimodalItemRunCuOffsets
+                    = std::make_shared<std::vector<SizeType32>>(multimodalItemRunCuOffsets.value());
             }
             if (auto const& multimodalRunPositions = multimodalInput->getMultimodalRunPositions())
             {
@@ -960,9 +960,9 @@ public:
         return mMultimodalUuids;
     }
 
-    [[nodiscard]] std::optional<std::shared_ptr<std::vector<SizeType32>>> getMultimodalItemRunCuSeqlen() const
+    [[nodiscard]] std::optional<std::shared_ptr<std::vector<SizeType32>>> getMultimodalItemRunCuOffsets() const
     {
-        return mMultimodalItemRunCuSeqlen;
+        return mMultimodalItemRunCuOffsets;
     }
 
     [[nodiscard]] std::optional<std::shared_ptr<std::vector<SizeType32>>> getMultimodalRunPositions() const
@@ -2075,7 +2075,7 @@ protected:
     std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalPositions{std::nullopt};
     std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalLengths{std::nullopt};
     std::optional<std::shared_ptr<std::vector<std::optional<std::string>>>> mMultimodalUuids{std::nullopt};
-    std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalItemRunCuSeqlen{std::nullopt};
+    std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalItemRunCuOffsets{std::nullopt};
     std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalRunPositions{std::nullopt};
     std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalRunLengths{std::nullopt};
     std::optional<TensorPtr> mMultimodalEmbedding{std::nullopt};
@@ -2396,7 +2396,7 @@ public:
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt,
         std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt,
         std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy = std::nullopt,
-        std::optional<std::vector<SizeType32>> multimodalItemRunCuSeqlen = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalItemRunCuOffsets = std::nullopt,
         std::optional<std::vector<SizeType32>> multimodalRunPositions = std::nullopt,
         std::optional<std::vector<SizeType32>> multimodalRunLengths = std::nullopt)
         : Base(requestId, maxNewTokens, std::make_shared<std::vector<TokenIdType>>(std::move(inputTokens)),
@@ -2433,8 +2433,8 @@ public:
             numReturnSequences, std::move(eagleConfig), skipCrossAttnBlocks, returnPerfMetrics,
             std::move(guidedDecodingParams), languageAdapterUid, allottedTimeMs, contextPhaseParams, cacheSaltID,
             arrivalTime, std::move(agent_hierarchy),
-            multimodalItemRunCuSeqlen.has_value()
-                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalItemRunCuSeqlen.value()))
+            multimodalItemRunCuOffsets.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalItemRunCuOffsets.value()))
                 : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),
             multimodalRunPositions.has_value()
                 ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalRunPositions.value()))

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,7 +148,10 @@ public:
         std::optional<MillisecondsType> allottedTimeMs = std::nullopt,
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt,
         std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt,
-        std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy = std::nullopt)
+        std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy = std::nullopt,
+        std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalItemRunCuSeqlen = std::nullopt,
+        std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalRunPositions = std::nullopt,
+        std::optional<std::shared_ptr<std::vector<SizeType32>>> multimodalRunLengths = std::nullopt)
         : mRequestId(requestId)
         , mPromptLen(inputTokens->size())
         , mMaxNewTokens(maxNewTokens)
@@ -172,6 +175,9 @@ public:
         , mMultimodalPositions(std::move(multimodalPositions))
         , mMultimodalLengths(std::move(multimodalLengths))
         , mMultimodalUuids(std::move(multimodalUuids))
+        , mMultimodalItemRunCuSeqlen(std::move(multimodalItemRunCuSeqlen))
+        , mMultimodalRunPositions(std::move(multimodalRunPositions))
+        , mMultimodalRunLengths(std::move(multimodalRunLengths))
         , mMultimodalEmbedding(std::move(multimodalEmbedding))
         , mMropeRotaryCosSin(std::move(mropeRotaryCosSin))
         , mMropePositionDeltas(mropePositionDeltas)
@@ -397,6 +403,32 @@ public:
         {
             mMropeRotaryCosSin = executor::detail::toITensor(mRopeConfig.value().getMRopeRotaryCosSin());
             mMropePositionDeltas = mRopeConfig.value().getMRopePositionDeltas();
+        }
+
+        auto multimodalInput = req.getMultimodalInput();
+        if (multimodalInput)
+        {
+            mMultimodalHashes
+                = std::make_shared<std::vector<std::vector<SizeType32>>>(multimodalInput->getMultimodalHashes());
+            mMultimodalPositions = std::make_shared<std::vector<SizeType32>>(multimodalInput->getMultimodalPositions());
+            mMultimodalLengths = std::make_shared<std::vector<SizeType32>>(multimodalInput->getMultimodalLengths());
+            if (auto const& multimodalUuids = multimodalInput->getMultimodalUuids())
+            {
+                mMultimodalUuids = std::make_shared<std::vector<std::optional<std::string>>>(multimodalUuids.value());
+            }
+            if (auto const& multimodalItemRunCuSeqlen = multimodalInput->getMultimodalItemRunCuSeqlen())
+            {
+                mMultimodalItemRunCuSeqlen
+                    = std::make_shared<std::vector<SizeType32>>(multimodalItemRunCuSeqlen.value());
+            }
+            if (auto const& multimodalRunPositions = multimodalInput->getMultimodalRunPositions())
+            {
+                mMultimodalRunPositions = std::make_shared<std::vector<SizeType32>>(multimodalRunPositions.value());
+            }
+            if (auto const& multimodalRunLengths = multimodalInput->getMultimodalRunLengths())
+            {
+                mMultimodalRunLengths = std::make_shared<std::vector<SizeType32>>(multimodalRunLengths.value());
+            }
         }
 
         auto loraConfig = req.getLoraConfig();
@@ -926,6 +958,21 @@ public:
     [[nodiscard]] std::optional<std::shared_ptr<std::vector<std::optional<std::string>>>> getMultimodalUuids() const
     {
         return mMultimodalUuids;
+    }
+
+    [[nodiscard]] std::optional<std::shared_ptr<std::vector<SizeType32>>> getMultimodalItemRunCuSeqlen() const
+    {
+        return mMultimodalItemRunCuSeqlen;
+    }
+
+    [[nodiscard]] std::optional<std::shared_ptr<std::vector<SizeType32>>> getMultimodalRunPositions() const
+    {
+        return mMultimodalRunPositions;
+    }
+
+    [[nodiscard]] std::optional<std::shared_ptr<std::vector<SizeType32>>> getMultimodalRunLengths() const
+    {
+        return mMultimodalRunLengths;
     }
 
     [[nodiscard]] std::optional<TensorPtr> getMultimodalEmbedding() const
@@ -2028,6 +2075,9 @@ protected:
     std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalPositions{std::nullopt};
     std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalLengths{std::nullopt};
     std::optional<std::shared_ptr<std::vector<std::optional<std::string>>>> mMultimodalUuids{std::nullopt};
+    std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalItemRunCuSeqlen{std::nullopt};
+    std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalRunPositions{std::nullopt};
+    std::optional<std::shared_ptr<std::vector<SizeType32>>> mMultimodalRunLengths{std::nullopt};
     std::optional<TensorPtr> mMultimodalEmbedding{std::nullopt};
     std::optional<TensorPtr> mMropeRotaryCosSin{std::nullopt};
     std::optional<SizeType32> mMropePositionDeltas{std::nullopt};
@@ -2345,7 +2395,10 @@ public:
         std::optional<MillisecondsType> allottedTimeMs = std::nullopt,
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt,
         std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt,
-        std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy = std::nullopt)
+        std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalItemRunCuSeqlen = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalRunPositions = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalRunLengths = std::nullopt)
         : Base(requestId, maxNewTokens, std::make_shared<std::vector<TokenIdType>>(std::move(inputTokens)),
             samplingConfig, isStreaming, endId, padId, std::move(embeddingBias), std::move(badWordsList),
             std::move(stopWordsList),
@@ -2379,7 +2432,16 @@ public:
                                : std::optional<std::shared_ptr<VecTokenExtraIds>>(std::nullopt),
             numReturnSequences, std::move(eagleConfig), skipCrossAttnBlocks, returnPerfMetrics,
             std::move(guidedDecodingParams), languageAdapterUid, allottedTimeMs, contextPhaseParams, cacheSaltID,
-            arrivalTime, std::move(agent_hierarchy))
+            arrivalTime, std::move(agent_hierarchy),
+            multimodalItemRunCuSeqlen.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalItemRunCuSeqlen.value()))
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),
+            multimodalRunPositions.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalRunPositions.value()))
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),
+            multimodalRunLengths.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalRunLengths.value()))
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt))
     {
     }
 

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -299,7 +299,7 @@ public:
     explicit MultimodalInput(std::vector<std::vector<SizeType32>> multimodalHashes,
         std::vector<SizeType32> multimodalPositions, std::vector<SizeType32> multimodalLengths,
         std::optional<std::vector<std::optional<std::string>>> multimodalUuids = std::nullopt,
-        std::optional<std::vector<SizeType32>> multimodalItemRunCuSeqlen = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalItemRunCuOffsets = std::nullopt,
         std::optional<std::vector<SizeType32>> multimodalRunPositions = std::nullopt,
         std::optional<std::vector<SizeType32>> multimodalRunLengths = std::nullopt);
 
@@ -307,7 +307,7 @@ public:
     [[nodiscard]] std::vector<SizeType32> getMultimodalPositions() const;
     [[nodiscard]] std::vector<SizeType32> getMultimodalLengths() const;
     [[nodiscard]] std::optional<std::vector<std::optional<std::string>>> const& getMultimodalUuids() const;
-    [[nodiscard]] std::optional<std::vector<SizeType32>> const& getMultimodalItemRunCuSeqlen() const;
+    [[nodiscard]] std::optional<std::vector<SizeType32>> const& getMultimodalItemRunCuOffsets() const;
     [[nodiscard]] std::optional<std::vector<SizeType32>> const& getMultimodalRunPositions() const;
     [[nodiscard]] std::optional<std::vector<SizeType32>> const& getMultimodalRunLengths() const;
 
@@ -322,8 +322,8 @@ private:
     /// @brief Optional user-provided UUIDs for multimodal items.
     /// When provided, these are returned in KV cache events instead of content hashes.
     std::optional<std::vector<std::optional<std::string>>> mMultimodalUuids;
-    /// @brief Optional prefix sum indexing the flat exact multimodal run arrays per item.
-    std::optional<std::vector<SizeType32>> mMultimodalItemRunCuSeqlen;
+    /// @brief Optional offsets indexing the flat exact multimodal run arrays per item.
+    std::optional<std::vector<SizeType32>> mMultimodalItemRunCuOffsets;
     /// @brief Optional prompt start positions for flat exact multimodal token runs.
     std::optional<std::vector<SizeType32>> mMultimodalRunPositions;
     /// @brief Optional lengths for flat exact multimodal token runs.

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -298,12 +298,18 @@ class MultimodalInput
 public:
     explicit MultimodalInput(std::vector<std::vector<SizeType32>> multimodalHashes,
         std::vector<SizeType32> multimodalPositions, std::vector<SizeType32> multimodalLengths,
-        std::optional<std::vector<std::optional<std::string>>> multimodalUuids = std::nullopt);
+        std::optional<std::vector<std::optional<std::string>>> multimodalUuids = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalItemRunCuSeqlen = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalRunPositions = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalRunLengths = std::nullopt);
 
     [[nodiscard]] std::vector<std::vector<SizeType32>> getMultimodalHashes() const;
     [[nodiscard]] std::vector<SizeType32> getMultimodalPositions() const;
     [[nodiscard]] std::vector<SizeType32> getMultimodalLengths() const;
     [[nodiscard]] std::optional<std::vector<std::optional<std::string>>> const& getMultimodalUuids() const;
+    [[nodiscard]] std::optional<std::vector<SizeType32>> const& getMultimodalItemRunCuSeqlen() const;
+    [[nodiscard]] std::optional<std::vector<SizeType32>> const& getMultimodalRunPositions() const;
+    [[nodiscard]] std::optional<std::vector<SizeType32>> const& getMultimodalRunLengths() const;
 
 private:
     friend class Serialization;
@@ -316,6 +322,12 @@ private:
     /// @brief Optional user-provided UUIDs for multimodal items.
     /// When provided, these are returned in KV cache events instead of content hashes.
     std::optional<std::vector<std::optional<std::string>>> mMultimodalUuids;
+    /// @brief Optional prefix sum indexing the flat exact multimodal run arrays per item.
+    std::optional<std::vector<SizeType32>> mMultimodalItemRunCuSeqlen;
+    /// @brief Optional prompt start positions for flat exact multimodal token runs.
+    std::optional<std::vector<SizeType32>> mMultimodalRunPositions;
+    /// @brief Optional lengths for flat exact multimodal token runs.
+    std::optional<std::vector<SizeType32>> mMultimodalRunLengths;
 };
 
 /// @brief Configuration for mrope
@@ -671,7 +683,8 @@ public:
     /// @param embeddingBias The embedding bias tensor. Expected shape is [vocab_size]
     /// @param externalDraftTokensConfig The speculative decoding with external draft tokens configuration
     /// @param pTuningConfig The prompt tuning configuration
-    /// @param multimodalInput The multimodal input {multimodalHashes, multimodalPositions, multimodalLengths}
+    /// @param multimodalInput The multimodal input {multimodalHashes, multimodalPositions, multimodalLengths, optional
+    /// exact prompt runs}
     /// @param multimodalEmbedding The multimodal embedding tensor. Expected shape is [num_multimodal_tokens,
     /// hidden_dim]
     /// @param mRopeConfig The mrope configuration

--- a/cpp/tensorrt_llm/batch_manager/blockKey.cpp
+++ b/cpp/tensorrt_llm/batch_manager/blockKey.cpp
@@ -44,7 +44,7 @@ enum class RunMetadataStatus
 
 struct RunMetadataView
 {
-    MultimodalSizeVector const* itemRunCuSeqlen{nullptr};
+    MultimodalSizeVector const* itemRunCuOffsets{nullptr};
     MultimodalSizeVector const* runPositions{nullptr};
     MultimodalSizeVector const* runLengths{nullptr};
 };
@@ -93,17 +93,17 @@ std::vector<MmKey> warnAndDisableExtraKeys(char const* warning)
     return {};
 }
 
-RunMetadataResolution resolveRunMetadata(OptionalSizeVectorPtr const& multimodalItemRunCuSeqlen,
+RunMetadataResolution resolveRunMetadata(OptionalSizeVectorPtr const& multimodalItemRunCuOffsets,
     OptionalSizeVectorPtr const& multimodalRunPositions, OptionalSizeVectorPtr const& multimodalRunLengths,
     size_t itemCount)
 {
-    auto const hasRunMetadataFields = multimodalItemRunCuSeqlen || multimodalRunPositions || multimodalRunLengths;
+    auto const hasRunMetadataFields = multimodalItemRunCuOffsets || multimodalRunPositions || multimodalRunLengths;
     if (!hasRunMetadataFields)
     {
         return {};
     }
 
-    auto const hasCompleteRunMetadata = multimodalItemRunCuSeqlen && *multimodalItemRunCuSeqlen
+    auto const hasCompleteRunMetadata = multimodalItemRunCuOffsets && *multimodalItemRunCuOffsets
         && multimodalRunPositions && *multimodalRunPositions && multimodalRunLengths && *multimodalRunLengths;
     if (!hasCompleteRunMetadata)
     {
@@ -111,18 +111,18 @@ RunMetadataResolution resolveRunMetadata(OptionalSizeVectorPtr const& multimodal
         return {RunMetadataStatus::kInvalid, {}};
     }
 
-    auto const& itemRunCuSeqlen = *(*multimodalItemRunCuSeqlen);
+    auto const& itemRunCuOffsets = *(*multimodalItemRunCuOffsets);
     auto const& runPositions = *(*multimodalRunPositions);
     auto const& runLengths = *(*multimodalRunLengths);
-    if (itemRunCuSeqlen.size() != itemCount + 1 || itemRunCuSeqlen.empty() || itemRunCuSeqlen.front() != 0
-        || itemRunCuSeqlen.back() < 0 || static_cast<size_t>(itemRunCuSeqlen.back()) != runPositions.size()
+    if (itemRunCuOffsets.size() != itemCount + 1 || itemRunCuOffsets.empty() || itemRunCuOffsets.front() != 0
+        || itemRunCuOffsets.back() < 0 || static_cast<size_t>(itemRunCuOffsets.back()) != runPositions.size()
         || runPositions.size() != runLengths.size())
     {
         TLLM_LOG_WARNING("Invalid multimodal run metadata shape; disabling multimodal cache hash extra keys");
         return {RunMetadataStatus::kInvalid, {}};
     }
 
-    return {RunMetadataStatus::kPresent, {&itemRunCuSeqlen, &runPositions, &runLengths}};
+    return {RunMetadataStatus::kPresent, {&itemRunCuOffsets, &runPositions, &runLengths}};
 }
 
 std::optional<SizeType32> getValidRunEnd(SizeType32 runStart, SizeType32 runLength)
@@ -139,7 +139,7 @@ std::vector<MmKey> generateRunBasedExtraKeys(MultimodalHashes const& multimodalH
     OptionalUuidVectorPtr const& multimodalUuids, RunMetadataView const& runMetadata, SizeType32 startTokenIdx,
     SizeType32 endTokenIdx)
 {
-    auto const& itemRunCuSeqlen = *runMetadata.itemRunCuSeqlen;
+    auto const& itemRunCuOffsets = *runMetadata.itemRunCuOffsets;
     auto const& runPositions = *runMetadata.runPositions;
     auto const& runLengths = *runMetadata.runLengths;
 
@@ -148,12 +148,12 @@ std::vector<MmKey> generateRunBasedExtraKeys(MultimodalHashes const& multimodalH
 
     for (size_t itemIdx = 0; itemIdx < multimodalHashes.size(); ++itemIdx)
     {
-        auto const runBegin32 = itemRunCuSeqlen[itemIdx];
-        auto const runEnd32 = itemRunCuSeqlen[itemIdx + 1];
+        auto const runBegin32 = itemRunCuOffsets[itemIdx];
+        auto const runEnd32 = itemRunCuOffsets[itemIdx + 1];
         if (runBegin32 < 0 || runEnd32 < runBegin32 || static_cast<size_t>(runEnd32) > runPositions.size())
         {
             return warnAndDisableExtraKeys(
-                "Invalid multimodal run prefix sum; disabling multimodal cache hash extra keys");
+                "Invalid multimodal item run offsets; disabling multimodal cache hash extra keys");
         }
 
         auto const mmHashArray = makeHashArray(multimodalHashes[itemIdx]);
@@ -229,7 +229,7 @@ std::vector<MmKey> generateBlockHashExtraKeys(
     auto const multimodalPositions = llmRequest.getMultimodalPositions();
     auto const multimodalLengths = llmRequest.getMultimodalLengths();
     auto const multimodalUuids = llmRequest.getMultimodalUuids();
-    auto const multimodalItemRunCuSeqlen = llmRequest.getMultimodalItemRunCuSeqlen();
+    auto const multimodalItemRunCuOffsets = llmRequest.getMultimodalItemRunCuOffsets();
     auto const multimodalRunPositions = llmRequest.getMultimodalRunPositions();
     auto const multimodalRunLengths = llmRequest.getMultimodalRunLengths();
 
@@ -240,7 +240,7 @@ std::vector<MmKey> generateBlockHashExtraKeys(
 
     auto const& hashes = *(*multimodalHashes);
     auto const runMetadata
-        = resolveRunMetadata(multimodalItemRunCuSeqlen, multimodalRunPositions, multimodalRunLengths, hashes.size());
+        = resolveRunMetadata(multimodalItemRunCuOffsets, multimodalRunPositions, multimodalRunLengths, hashes.size());
     if (runMetadata.status == RunMetadataStatus::kInvalid)
     {
         return {};

--- a/cpp/tensorrt_llm/batch_manager/blockKey.cpp
+++ b/cpp/tensorrt_llm/batch_manager/blockKey.cpp
@@ -110,7 +110,7 @@ RunMetadataResolution resolveRunMetadata(OptionalSizeVectorPtr const& multimodal
     if (!hasCompleteRunMetadata)
     {
         TLLM_LOG_WARNING(
-            "Incomplete multimodal run metadata; disabling multimodal cache hash extra keys: "
+            "Incomplete multimodal run metadata; falling back to legacy multimodal cache hash extra keys: "
             "hasItemRunCuOffsets=%d, hasRunPositions=%d, hasRunLengths=%d, "
             "itemRunCuOffsets.size=%zu, runPositions.size=%zu, runLengths.size=%zu",
             static_cast<int>(hasItemRunCuOffsets), static_cast<int>(hasRunPositions), static_cast<int>(hasRunLengths),
@@ -132,7 +132,7 @@ RunMetadataResolution resolveRunMetadata(OptionalSizeVectorPtr const& multimodal
         || runPositions.size() != runLengths.size())
     {
         TLLM_LOG_WARNING(
-            "Invalid multimodal run metadata shape; disabling multimodal cache hash extra keys: "
+            "Invalid multimodal run metadata shape; falling back to legacy multimodal cache hash extra keys: "
             "itemCount=%zu, itemRunCuOffsets.size=%zu, expectedItemRunCuOffsets.size=%zu, "
             "itemRunCuOffsets.front=%d, itemRunCuOffsets.back=%d, runPositions.size=%zu, runLengths.size=%zu",
             itemCount, itemRunCuOffsets.size(), itemCount + 1, itemRunCuOffsets.empty() ? 0 : itemRunCuOffsets.front(),
@@ -153,7 +153,7 @@ std::optional<SizeType32> getValidRunEnd(SizeType32 runStart, SizeType32 runLeng
     return static_cast<SizeType32>(runEnd64);
 }
 
-std::vector<MmKey> generateRunBasedExtraKeys(MultimodalHashes const& multimodalHashes,
+std::optional<std::vector<MmKey>> generateRunBasedExtraKeys(MultimodalHashes const& multimodalHashes,
     OptionalUuidVectorPtr const& multimodalUuids, RunMetadataView const& runMetadata, SizeType32 startTokenIdx,
     SizeType32 endTokenIdx)
 {
@@ -188,10 +188,10 @@ std::vector<MmKey> generateRunBasedExtraKeys(MultimodalHashes const& multimodalH
         if (runBegin32 < 0 || runEnd32 < runBegin32 || static_cast<size_t>(runEnd32) > runPositions.size())
         {
             TLLM_LOG_WARNING(
-                "Invalid multimodal item run offsets; disabling multimodal cache hash extra keys: "
+                "Invalid multimodal item run offsets; falling back to legacy multimodal cache hash extra keys: "
                 "itemIdx=%zu, runBegin=%d, runEnd=%d, runPositions.size=%zu",
                 itemIdx, runBegin32, runEnd32, runPositions.size());
-            return {};
+            return std::nullopt;
         }
 
         auto const mmHashArray = makeHashArray(multimodalHashes[itemIdx]);
@@ -206,11 +206,11 @@ std::vector<MmKey> generateRunBasedExtraKeys(MultimodalHashes const& multimodalH
             {
                 auto const runEnd64 = static_cast<int64_t>(runStart) + static_cast<int64_t>(runLength);
                 TLLM_LOG_WARNING(
-                    "Invalid multimodal run range; disabling multimodal cache hash extra keys: "
+                    "Invalid multimodal run range; falling back to legacy multimodal cache hash extra keys: "
                     "itemIdx=%zu, runIdx=%zu, runStart=%d, runLength=%d, runEnd=%lld, maxSizeType32=%d",
                     itemIdx, runIdx, runStart, runLength, static_cast<long long>(runEnd64),
                     std::numeric_limits<SizeType32>::max());
-                return {};
+                return std::nullopt;
             }
 
             if (endTokenIdx > runStart && startTokenIdx < *runEnd)
@@ -257,7 +257,18 @@ std::vector<MmKey> generateLegacyContiguousExtraKeys(MultimodalHashes const& mul
         auto const& startPos = positions[itemIdx];
         auto const& length = lengths[itemIdx];
 
-        if (endTokenIdx > startPos && startTokenIdx < startPos + length)
+        auto const runEnd = getValidRunEnd(startPos, length);
+        if (!runEnd)
+        {
+            auto const runEnd64 = static_cast<int64_t>(startPos) + static_cast<int64_t>(length);
+            TLLM_LOG_WARNING(
+                "Invalid legacy multimodal range; disabling multimodal cache hash extra keys: "
+                "itemIdx=%zu, startPos=%d, length=%d, runEnd=%lld, maxSizeType32=%d",
+                itemIdx, startPos, length, static_cast<long long>(runEnd64), std::numeric_limits<SizeType32>::max());
+            return {};
+        }
+
+        if (endTokenIdx > startPos && startTokenIdx < *runEnd)
         {
             auto const mmStartInBlock = startPos >= startTokenIdx ? 0 : startTokenIdx - startPos;
             extraKeys.emplace_back(
@@ -292,11 +303,19 @@ std::vector<MmKey> generateBlockHashExtraKeys(
         = resolveRunMetadata(multimodalItemRunCuOffsets, multimodalRunPositions, multimodalRunLengths, hashes.size());
     if (runMetadata.status == RunMetadataStatus::kInvalid)
     {
-        return {};
+        return generateLegacyContiguousExtraKeys(
+            hashes, multimodalPositions, multimodalLengths, multimodalUuids, startTokenIdx, endTokenIdx);
     }
     if (runMetadata.status == RunMetadataStatus::kPresent)
     {
-        return generateRunBasedExtraKeys(hashes, multimodalUuids, runMetadata.metadata, startTokenIdx, endTokenIdx);
+        auto runBasedExtraKeys
+            = generateRunBasedExtraKeys(hashes, multimodalUuids, runMetadata.metadata, startTokenIdx, endTokenIdx);
+        if (runBasedExtraKeys)
+        {
+            return std::move(runBasedExtraKeys.value());
+        }
+        return generateLegacyContiguousExtraKeys(
+            hashes, multimodalPositions, multimodalLengths, multimodalUuids, startTokenIdx, endTokenIdx);
     }
 
     return generateLegacyContiguousExtraKeys(

--- a/cpp/tensorrt_llm/batch_manager/blockKey.cpp
+++ b/cpp/tensorrt_llm/batch_manager/blockKey.cpp
@@ -17,11 +17,32 @@
 
 #include "tensorrt_llm/batch_manager/blockKey.h"
 
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
 namespace
 {
 inline uint8_t getNthByte(tensorrt_llm::runtime::SizeType32 hashPart, uint8_t byteIdx) noexcept
 {
     return static_cast<uint8_t>((hashPart >> (24 - byteIdx * 8)) & 0xFF);
+}
+
+std::array<uint8_t, 32> makeHashArray(std::vector<tensorrt_llm::runtime::SizeType32> const& mmHashVector)
+{
+    TLLM_CHECK_WITH_INFO(
+        mmHashVector.size() == 8, "Multimodal hash vector has unexpected size: %zu (expected 8)", mmHashVector.size());
+
+    std::array<uint8_t, 32> mmHashArray;
+    for (size_t j = 0; j < 8; ++j)
+    {
+        auto const& hashPart = mmHashVector[j];
+        for (uint8_t byteIdx = 0; byteIdx < 4; ++byteIdx)
+        {
+            mmHashArray[j * 4 + byteIdx] = getNthByte(hashPart, byteIdx);
+        }
+    }
+    return mmHashArray;
 }
 } // namespace
 
@@ -34,9 +55,89 @@ std::vector<MmKey> generateBlockHashExtraKeys(
     auto const multimodalPositions = llmRequest.getMultimodalPositions();
     auto const multimodalLengths = llmRequest.getMultimodalLengths();
     auto const multimodalUuids = llmRequest.getMultimodalUuids();
+    auto const multimodalItemRunCuSeqlen = llmRequest.getMultimodalItemRunCuSeqlen();
+    auto const multimodalRunPositions = llmRequest.getMultimodalRunPositions();
+    auto const multimodalRunLengths = llmRequest.getMultimodalRunLengths();
 
-    if (!multimodalHashes || !multimodalPositions || !multimodalLengths || !(*multimodalHashes)
-        || (*multimodalHashes)->empty() || !(*multimodalPositions) || (*multimodalPositions)->empty()
+    if (!multimodalHashes || !(*multimodalHashes) || (*multimodalHashes)->empty())
+    {
+        return {};
+    }
+
+    auto getUuid = [&multimodalUuids](size_t itemIdx) -> std::optional<std::string>
+    {
+        if (multimodalUuids && *multimodalUuids && itemIdx < (*multimodalUuids)->size())
+        {
+            return (*(*multimodalUuids))[itemIdx];
+        }
+        return std::nullopt;
+    };
+
+    auto const hasAnyRunMetadata = multimodalItemRunCuSeqlen || multimodalRunPositions || multimodalRunLengths;
+    if (hasAnyRunMetadata)
+    {
+        auto const hasCompleteRunMetadata = multimodalItemRunCuSeqlen && *multimodalItemRunCuSeqlen
+            && multimodalRunPositions && *multimodalRunPositions && multimodalRunLengths && *multimodalRunLengths;
+        if (!hasCompleteRunMetadata)
+        {
+            TLLM_LOG_WARNING("Incomplete multimodal run metadata; disabling multimodal cache hash extra keys");
+            return {};
+        }
+
+        auto const& itemRunCuSeqlen = *(*multimodalItemRunCuSeqlen);
+        auto const& runPositions = *(*multimodalRunPositions);
+        auto const& runLengths = *(*multimodalRunLengths);
+        if (itemRunCuSeqlen.size() != (*multimodalHashes)->size() + 1 || itemRunCuSeqlen.empty()
+            || itemRunCuSeqlen.front() != 0 || itemRunCuSeqlen.back() < 0
+            || static_cast<size_t>(itemRunCuSeqlen.back()) != runPositions.size()
+            || runPositions.size() != runLengths.size())
+        {
+            TLLM_LOG_WARNING("Invalid multimodal run metadata shape; disabling multimodal cache hash extra keys");
+            return {};
+        }
+
+        std::vector<MmKey> extraKeys;
+        extraKeys.reserve((*multimodalHashes)->size());
+
+        for (size_t itemIdx = 0; itemIdx < (*multimodalHashes)->size(); ++itemIdx)
+        {
+            auto const runBegin32 = itemRunCuSeqlen[itemIdx];
+            auto const runEnd32 = itemRunCuSeqlen[itemIdx + 1];
+            if (runBegin32 < 0 || runEnd32 < runBegin32 || static_cast<size_t>(runEnd32) > runPositions.size())
+            {
+                TLLM_LOG_WARNING("Invalid multimodal run prefix sum; disabling multimodal cache hash extra keys");
+                return {};
+            }
+
+            auto const mmHashArray = makeHashArray((*(*multimodalHashes))[itemIdx]);
+            auto const uuid = getUuid(itemIdx);
+            SizeType32 itemOffset = 0;
+            for (size_t runIdx = static_cast<size_t>(runBegin32); runIdx < static_cast<size_t>(runEnd32); ++runIdx)
+            {
+                auto const runStart = runPositions[runIdx];
+                auto const runLength = runLengths[runIdx];
+                auto const runEnd64 = static_cast<int64_t>(runStart) + static_cast<int64_t>(runLength);
+                if (runStart < 0 || runLength <= 0 || runEnd64 > std::numeric_limits<SizeType32>::max())
+                {
+                    TLLM_LOG_WARNING("Invalid multimodal run range; disabling multimodal cache hash extra keys");
+                    return {};
+                }
+
+                auto const runEnd = static_cast<SizeType32>(runEnd64);
+                if (endTokenIdx > runStart && startTokenIdx < runEnd)
+                {
+                    auto const overlapStart = std::max(startTokenIdx, runStart);
+                    auto const startOffset = itemOffset + overlapStart - runStart;
+                    extraKeys.emplace_back(mmHashArray, startOffset, uuid);
+                }
+                itemOffset += runLength;
+            }
+        }
+
+        return extraKeys;
+    }
+
+    if (!multimodalPositions || !multimodalLengths || !(*multimodalPositions) || (*multimodalPositions)->empty()
         || !(*multimodalLengths) || (*multimodalLengths)->empty())
     {
         return {};
@@ -51,7 +152,6 @@ std::vector<MmKey> generateBlockHashExtraKeys(
 
     std::vector<MmKey> extraKeys;
     extraKeys.reserve((*multimodalPositions)->size());
-    std::array<uint8_t, 32> mmHashArray;
 
     for (size_t i = 0; i < (*multimodalPositions)->size(); ++i)
     {
@@ -59,21 +159,11 @@ std::vector<MmKey> generateBlockHashExtraKeys(
         auto const& length = (*(*multimodalLengths))[i];
         auto const& mmHashVector = (*(*multimodalHashes))[i];
 
-        TLLM_CHECK_WITH_INFO(mmHashVector.size() == 8, "Multimodal hash vector has unexpected size: %zu (expected 8)",
-            mmHashVector.size());
-
         // mmHashVector[j] comes from Python's int(hex_chunk, 16)
         // where hex_chunk like "00010203" means 0x00 is MSB and 0x03 is LSB (big endian)
         // Convert 8x 32-bit integers into a 32-byte array preserving Blake3 hash byte order
         // Example: hashPart = 0x00010203 → mmHashArray[0:3] = [0x00, 0x01, 0x02, 0x03]
-        for (size_t j = 0; j < 8; ++j)
-        {
-            auto const& hashPart = mmHashVector[j];
-            for (uint8_t byteIdx = 0; byteIdx < 4; ++byteIdx)
-            {
-                mmHashArray[j * 4 + byteIdx] = getNthByte(hashPart, byteIdx);
-            }
-        }
+        auto const mmHashArray = makeHashArray(mmHashVector);
 
         // Check if this multimodal content overlaps with the current block
         if (endTokenIdx > startPos && startTokenIdx < startPos + length)
@@ -81,12 +171,7 @@ std::vector<MmKey> generateBlockHashExtraKeys(
             uint64_t mmStartInBlock = (startPos >= startTokenIdx) ? 0 : static_cast<uint64_t>(startTokenIdx - startPos);
 
             // Get UUID if available
-            std::optional<std::string> uuid = std::nullopt;
-            if (multimodalUuids && *multimodalUuids && i < (*multimodalUuids)->size())
-            {
-                uuid = (*(*multimodalUuids))[i];
-            }
-
+            auto uuid = getUuid(i);
             extraKeys.emplace_back(mmHashArray, mmStartInBlock, std::move(uuid));
         }
     }

--- a/cpp/tensorrt_llm/batch_manager/blockKey.cpp
+++ b/cpp/tensorrt_llm/batch_manager/blockKey.cpp
@@ -84,13 +84,13 @@ std::optional<std::string> getUuid(OptionalUuidVectorPtr const& multimodalUuids,
     {
         return (*(*multimodalUuids))[itemIdx];
     }
+    // Missing UUIDs intentionally fall back to content-hash cache keys.
     return std::nullopt;
 }
 
-std::vector<MmKey> warnAndDisableExtraKeys(char const* warning)
+size_t getOptionalVectorSize(OptionalSizeVectorPtr const& values)
 {
-    TLLM_LOG_WARNING("%s", warning);
-    return {};
+    return values && *values ? (*values)->size() : 0;
 }
 
 RunMetadataResolution resolveRunMetadata(OptionalSizeVectorPtr const& multimodalItemRunCuOffsets,
@@ -103,22 +103,40 @@ RunMetadataResolution resolveRunMetadata(OptionalSizeVectorPtr const& multimodal
         return {};
     }
 
-    auto const hasCompleteRunMetadata = multimodalItemRunCuOffsets && *multimodalItemRunCuOffsets
-        && multimodalRunPositions && *multimodalRunPositions && multimodalRunLengths && *multimodalRunLengths;
+    auto const hasItemRunCuOffsets = multimodalItemRunCuOffsets && *multimodalItemRunCuOffsets;
+    auto const hasRunPositions = multimodalRunPositions && *multimodalRunPositions;
+    auto const hasRunLengths = multimodalRunLengths && *multimodalRunLengths;
+    auto const hasCompleteRunMetadata = hasItemRunCuOffsets && hasRunPositions && hasRunLengths;
     if (!hasCompleteRunMetadata)
     {
-        TLLM_LOG_WARNING("Incomplete multimodal run metadata; disabling multimodal cache hash extra keys");
+        TLLM_LOG_WARNING(
+            "Incomplete multimodal run metadata; disabling multimodal cache hash extra keys: "
+            "hasItemRunCuOffsets=%d, hasRunPositions=%d, hasRunLengths=%d, "
+            "itemRunCuOffsets.size=%zu, runPositions.size=%zu, runLengths.size=%zu",
+            static_cast<int>(hasItemRunCuOffsets), static_cast<int>(hasRunPositions), static_cast<int>(hasRunLengths),
+            getOptionalVectorSize(multimodalItemRunCuOffsets), getOptionalVectorSize(multimodalRunPositions),
+            getOptionalVectorSize(multimodalRunLengths));
         return {RunMetadataStatus::kInvalid, {}};
     }
 
     auto const& itemRunCuOffsets = *(*multimodalItemRunCuOffsets);
     auto const& runPositions = *(*multimodalRunPositions);
     auto const& runLengths = *(*multimodalRunLengths);
-    if (itemRunCuOffsets.size() != itemCount + 1 || itemRunCuOffsets.empty() || itemRunCuOffsets.front() != 0
-        || itemRunCuOffsets.back() < 0 || static_cast<size_t>(itemRunCuOffsets.back()) != runPositions.size()
+    // - itemRunCuOffsets are exclusive-prefix-sum offsets: item i reads runs
+    //   [offsets[i], offsets[i + 1]). so its size should be 1 + the number of items.
+    // - The first item must start at run 0.
+    // - The final cumulative offset must be non-negative and equal the number of runs.
+    // - runPositions and runLengths describe the same runs, so sizes match.
+    if (itemRunCuOffsets.size() != itemCount + 1 || itemRunCuOffsets.front() != 0 || itemRunCuOffsets.back() < 0
+        || static_cast<size_t>(itemRunCuOffsets.back()) != runPositions.size()
         || runPositions.size() != runLengths.size())
     {
-        TLLM_LOG_WARNING("Invalid multimodal run metadata shape; disabling multimodal cache hash extra keys");
+        TLLM_LOG_WARNING(
+            "Invalid multimodal run metadata shape; disabling multimodal cache hash extra keys: "
+            "itemCount=%zu, itemRunCuOffsets.size=%zu, expectedItemRunCuOffsets.size=%zu, "
+            "itemRunCuOffsets.front=%d, itemRunCuOffsets.back=%d, runPositions.size=%zu, runLengths.size=%zu",
+            itemCount, itemRunCuOffsets.size(), itemCount + 1, itemRunCuOffsets.empty() ? 0 : itemRunCuOffsets.front(),
+            itemRunCuOffsets.empty() ? 0 : itemRunCuOffsets.back(), runPositions.size(), runLengths.size());
         return {RunMetadataStatus::kInvalid, {}};
     }
 
@@ -143,6 +161,23 @@ std::vector<MmKey> generateRunBasedExtraKeys(MultimodalHashes const& multimodalH
     auto const& runPositions = *runMetadata.runPositions;
     auto const& runLengths = *runMetadata.runLengths;
 
+    // Worked example for one logical multimodal item split by text:
+    //
+    //   prompt index: 0    1      2      3    4      5
+    //   prompt token: T0   MM0:0  MM0:1  T1   MM0:2  MM0:3
+    //   flat run:          run0   run0        run1   run1
+    //
+    // Inputs encode the prompt layout as:
+    //
+    //   itemRunCuOffsets = [0, 2]  // item 0 owns flat runs [0, 2)
+    //   runPositions     = [1, 4]  // run0 starts at prompt 1, run1 at 4
+    //   runLengths       = [2, 2]  // token counts for run0 and run1
+    //
+    // The loop below accumulates `itemOffset` across an item's flat runs. For
+    // run1, itemOffset is 2, so a block overlapping prompt [4, 6) mixes MM0's
+    // hash with startOffset=2. A block overlapping prompt [5, 6) mixes the
+    // same hash with startOffset=3.
+    // This makes the block hash calculation accurate to the actual multimodal token locations.
     std::vector<MmKey> extraKeys;
     extraKeys.reserve(multimodalHashes.size());
 
@@ -152,8 +187,11 @@ std::vector<MmKey> generateRunBasedExtraKeys(MultimodalHashes const& multimodalH
         auto const runEnd32 = itemRunCuOffsets[itemIdx + 1];
         if (runBegin32 < 0 || runEnd32 < runBegin32 || static_cast<size_t>(runEnd32) > runPositions.size())
         {
-            return warnAndDisableExtraKeys(
-                "Invalid multimodal item run offsets; disabling multimodal cache hash extra keys");
+            TLLM_LOG_WARNING(
+                "Invalid multimodal item run offsets; disabling multimodal cache hash extra keys: "
+                "itemIdx=%zu, runBegin=%d, runEnd=%d, runPositions.size=%zu",
+                itemIdx, runBegin32, runEnd32, runPositions.size());
+            return {};
         }
 
         auto const mmHashArray = makeHashArray(multimodalHashes[itemIdx]);
@@ -166,13 +204,20 @@ std::vector<MmKey> generateRunBasedExtraKeys(MultimodalHashes const& multimodalH
             auto const runEnd = getValidRunEnd(runStart, runLength);
             if (!runEnd)
             {
-                return warnAndDisableExtraKeys(
-                    "Invalid multimodal run range; disabling multimodal cache hash extra keys");
+                auto const runEnd64 = static_cast<int64_t>(runStart) + static_cast<int64_t>(runLength);
+                TLLM_LOG_WARNING(
+                    "Invalid multimodal run range; disabling multimodal cache hash extra keys: "
+                    "itemIdx=%zu, runIdx=%zu, runStart=%d, runLength=%d, runEnd=%lld, maxSizeType32=%d",
+                    itemIdx, runIdx, runStart, runLength, static_cast<long long>(runEnd64),
+                    std::numeric_limits<SizeType32>::max());
+                return {};
             }
 
             if (endTokenIdx > runStart && startTokenIdx < *runEnd)
             {
                 auto const overlapStart = std::max(startTokenIdx, runStart);
+                // Offset is relative to the logical multimodal item, not this
+                // prompt run. For the example above, run1 starts from MM0:2.
                 auto const startOffset = itemOffset + overlapStart - runStart;
                 extraKeys.emplace_back(mmHashArray, startOffset, uuid);
             }
@@ -197,7 +242,11 @@ std::vector<MmKey> generateLegacyContiguousExtraKeys(MultimodalHashes const& mul
     auto const& lengths = *(*multimodalLengths);
     if (multimodalHashes.size() != positions.size() || positions.size() != lengths.size())
     {
-        return warnAndDisableExtraKeys("Multimodal data arrays have mismatched sizes");
+        TLLM_LOG_WARNING(
+            "Multimodal data arrays have mismatched sizes; disabling multimodal cache hash extra keys: "
+            "multimodalHashes.size=%zu, multimodalPositions.size=%zu, multimodalLengths.size=%zu",
+            multimodalHashes.size(), positions.size(), lengths.size());
+        return {};
     }
 
     std::vector<MmKey> extraKeys;

--- a/cpp/tensorrt_llm/batch_manager/blockKey.cpp
+++ b/cpp/tensorrt_llm/batch_manager/blockKey.cpp
@@ -18,22 +18,55 @@
 #include "tensorrt_llm/batch_manager/blockKey.h"
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace
 {
-inline uint8_t getNthByte(tensorrt_llm::runtime::SizeType32 hashPart, uint8_t byteIdx) noexcept
+using SizeType32 = tensorrt_llm::runtime::SizeType32;
+using MmKey = tensorrt_llm::executor::MmKey;
+using MultimodalHashes = std::vector<std::vector<SizeType32>>;
+using MultimodalSizeVector = std::vector<SizeType32>;
+using OptionalSizeVectorPtr = std::optional<std::shared_ptr<MultimodalSizeVector>>;
+using OptionalUuidVectorPtr = std::optional<std::shared_ptr<std::vector<std::optional<std::string>>>>;
+
+enum class RunMetadataStatus
+{
+    kAbsent,
+    kInvalid,
+    kPresent,
+};
+
+struct RunMetadataView
+{
+    MultimodalSizeVector const* itemRunCuSeqlen{nullptr};
+    MultimodalSizeVector const* runPositions{nullptr};
+    MultimodalSizeVector const* runLengths{nullptr};
+};
+
+struct RunMetadataResolution
+{
+    RunMetadataStatus status{RunMetadataStatus::kAbsent};
+    RunMetadataView metadata{};
+};
+
+inline uint8_t getNthByte(SizeType32 hashPart, uint8_t byteIdx) noexcept
 {
     return static_cast<uint8_t>((hashPart >> (24 - byteIdx * 8)) & 0xFF);
 }
 
-std::array<uint8_t, 32> makeHashArray(std::vector<tensorrt_llm::runtime::SizeType32> const& mmHashVector)
+std::array<uint8_t, 32> makeHashArray(std::vector<SizeType32> const& mmHashVector)
 {
     TLLM_CHECK_WITH_INFO(
         mmHashVector.size() == 8, "Multimodal hash vector has unexpected size: %zu (expected 8)", mmHashVector.size());
 
     std::array<uint8_t, 32> mmHashArray;
+    // Python int(hex_chunk, 16) stores the first hash byte in the most significant byte.
     for (size_t j = 0; j < 8; ++j)
     {
         auto const& hashPart = mmHashVector[j];
@@ -43,6 +76,147 @@ std::array<uint8_t, 32> makeHashArray(std::vector<tensorrt_llm::runtime::SizeTyp
         }
     }
     return mmHashArray;
+}
+
+std::optional<std::string> getUuid(OptionalUuidVectorPtr const& multimodalUuids, size_t itemIdx)
+{
+    if (multimodalUuids && *multimodalUuids && itemIdx < (*multimodalUuids)->size())
+    {
+        return (*(*multimodalUuids))[itemIdx];
+    }
+    return std::nullopt;
+}
+
+std::vector<MmKey> warnAndDisableExtraKeys(char const* warning)
+{
+    TLLM_LOG_WARNING("%s", warning);
+    return {};
+}
+
+RunMetadataResolution resolveRunMetadata(OptionalSizeVectorPtr const& multimodalItemRunCuSeqlen,
+    OptionalSizeVectorPtr const& multimodalRunPositions, OptionalSizeVectorPtr const& multimodalRunLengths,
+    size_t itemCount)
+{
+    auto const hasRunMetadataFields = multimodalItemRunCuSeqlen || multimodalRunPositions || multimodalRunLengths;
+    if (!hasRunMetadataFields)
+    {
+        return {};
+    }
+
+    auto const hasCompleteRunMetadata = multimodalItemRunCuSeqlen && *multimodalItemRunCuSeqlen
+        && multimodalRunPositions && *multimodalRunPositions && multimodalRunLengths && *multimodalRunLengths;
+    if (!hasCompleteRunMetadata)
+    {
+        TLLM_LOG_WARNING("Incomplete multimodal run metadata; disabling multimodal cache hash extra keys");
+        return {RunMetadataStatus::kInvalid, {}};
+    }
+
+    auto const& itemRunCuSeqlen = *(*multimodalItemRunCuSeqlen);
+    auto const& runPositions = *(*multimodalRunPositions);
+    auto const& runLengths = *(*multimodalRunLengths);
+    if (itemRunCuSeqlen.size() != itemCount + 1 || itemRunCuSeqlen.empty() || itemRunCuSeqlen.front() != 0
+        || itemRunCuSeqlen.back() < 0 || static_cast<size_t>(itemRunCuSeqlen.back()) != runPositions.size()
+        || runPositions.size() != runLengths.size())
+    {
+        TLLM_LOG_WARNING("Invalid multimodal run metadata shape; disabling multimodal cache hash extra keys");
+        return {RunMetadataStatus::kInvalid, {}};
+    }
+
+    return {RunMetadataStatus::kPresent, {&itemRunCuSeqlen, &runPositions, &runLengths}};
+}
+
+std::optional<SizeType32> getValidRunEnd(SizeType32 runStart, SizeType32 runLength)
+{
+    auto const runEnd64 = static_cast<int64_t>(runStart) + static_cast<int64_t>(runLength);
+    if (runStart < 0 || runLength <= 0 || runEnd64 > std::numeric_limits<SizeType32>::max())
+    {
+        return std::nullopt;
+    }
+    return static_cast<SizeType32>(runEnd64);
+}
+
+std::vector<MmKey> generateRunBasedExtraKeys(MultimodalHashes const& multimodalHashes,
+    OptionalUuidVectorPtr const& multimodalUuids, RunMetadataView const& runMetadata, SizeType32 startTokenIdx,
+    SizeType32 endTokenIdx)
+{
+    auto const& itemRunCuSeqlen = *runMetadata.itemRunCuSeqlen;
+    auto const& runPositions = *runMetadata.runPositions;
+    auto const& runLengths = *runMetadata.runLengths;
+
+    std::vector<MmKey> extraKeys;
+    extraKeys.reserve(multimodalHashes.size());
+
+    for (size_t itemIdx = 0; itemIdx < multimodalHashes.size(); ++itemIdx)
+    {
+        auto const runBegin32 = itemRunCuSeqlen[itemIdx];
+        auto const runEnd32 = itemRunCuSeqlen[itemIdx + 1];
+        if (runBegin32 < 0 || runEnd32 < runBegin32 || static_cast<size_t>(runEnd32) > runPositions.size())
+        {
+            return warnAndDisableExtraKeys(
+                "Invalid multimodal run prefix sum; disabling multimodal cache hash extra keys");
+        }
+
+        auto const mmHashArray = makeHashArray(multimodalHashes[itemIdx]);
+        auto const uuid = getUuid(multimodalUuids, itemIdx);
+        SizeType32 itemOffset = 0;
+        for (size_t runIdx = static_cast<size_t>(runBegin32); runIdx < static_cast<size_t>(runEnd32); ++runIdx)
+        {
+            auto const runStart = runPositions[runIdx];
+            auto const runLength = runLengths[runIdx];
+            auto const runEnd = getValidRunEnd(runStart, runLength);
+            if (!runEnd)
+            {
+                return warnAndDisableExtraKeys(
+                    "Invalid multimodal run range; disabling multimodal cache hash extra keys");
+            }
+
+            if (endTokenIdx > runStart && startTokenIdx < *runEnd)
+            {
+                auto const overlapStart = std::max(startTokenIdx, runStart);
+                auto const startOffset = itemOffset + overlapStart - runStart;
+                extraKeys.emplace_back(mmHashArray, startOffset, uuid);
+            }
+            itemOffset += runLength;
+        }
+    }
+
+    return extraKeys;
+}
+
+std::vector<MmKey> generateLegacyContiguousExtraKeys(MultimodalHashes const& multimodalHashes,
+    OptionalSizeVectorPtr const& multimodalPositions, OptionalSizeVectorPtr const& multimodalLengths,
+    OptionalUuidVectorPtr const& multimodalUuids, SizeType32 startTokenIdx, SizeType32 endTokenIdx)
+{
+    if (!multimodalPositions || !multimodalLengths || !(*multimodalPositions) || (*multimodalPositions)->empty()
+        || !(*multimodalLengths) || (*multimodalLengths)->empty())
+    {
+        return {};
+    }
+
+    auto const& positions = *(*multimodalPositions);
+    auto const& lengths = *(*multimodalLengths);
+    if (multimodalHashes.size() != positions.size() || positions.size() != lengths.size())
+    {
+        return warnAndDisableExtraKeys("Multimodal data arrays have mismatched sizes");
+    }
+
+    std::vector<MmKey> extraKeys;
+    extraKeys.reserve(positions.size());
+
+    for (size_t itemIdx = 0; itemIdx < positions.size(); ++itemIdx)
+    {
+        auto const& startPos = positions[itemIdx];
+        auto const& length = lengths[itemIdx];
+
+        if (endTokenIdx > startPos && startTokenIdx < startPos + length)
+        {
+            auto const mmStartInBlock = startPos >= startTokenIdx ? 0 : startTokenIdx - startPos;
+            extraKeys.emplace_back(
+                makeHashArray(multimodalHashes[itemIdx]), mmStartInBlock, getUuid(multimodalUuids, itemIdx));
+        }
+    }
+
+    return extraKeys;
 }
 } // namespace
 
@@ -64,119 +238,20 @@ std::vector<MmKey> generateBlockHashExtraKeys(
         return {};
     }
 
-    auto getUuid = [&multimodalUuids](size_t itemIdx) -> std::optional<std::string>
-    {
-        if (multimodalUuids && *multimodalUuids && itemIdx < (*multimodalUuids)->size())
-        {
-            return (*(*multimodalUuids))[itemIdx];
-        }
-        return std::nullopt;
-    };
-
-    auto const hasAnyRunMetadata = multimodalItemRunCuSeqlen || multimodalRunPositions || multimodalRunLengths;
-    if (hasAnyRunMetadata)
-    {
-        auto const hasCompleteRunMetadata = multimodalItemRunCuSeqlen && *multimodalItemRunCuSeqlen
-            && multimodalRunPositions && *multimodalRunPositions && multimodalRunLengths && *multimodalRunLengths;
-        if (!hasCompleteRunMetadata)
-        {
-            TLLM_LOG_WARNING("Incomplete multimodal run metadata; disabling multimodal cache hash extra keys");
-            return {};
-        }
-
-        auto const& itemRunCuSeqlen = *(*multimodalItemRunCuSeqlen);
-        auto const& runPositions = *(*multimodalRunPositions);
-        auto const& runLengths = *(*multimodalRunLengths);
-        if (itemRunCuSeqlen.size() != (*multimodalHashes)->size() + 1 || itemRunCuSeqlen.empty()
-            || itemRunCuSeqlen.front() != 0 || itemRunCuSeqlen.back() < 0
-            || static_cast<size_t>(itemRunCuSeqlen.back()) != runPositions.size()
-            || runPositions.size() != runLengths.size())
-        {
-            TLLM_LOG_WARNING("Invalid multimodal run metadata shape; disabling multimodal cache hash extra keys");
-            return {};
-        }
-
-        std::vector<MmKey> extraKeys;
-        extraKeys.reserve((*multimodalHashes)->size());
-
-        for (size_t itemIdx = 0; itemIdx < (*multimodalHashes)->size(); ++itemIdx)
-        {
-            auto const runBegin32 = itemRunCuSeqlen[itemIdx];
-            auto const runEnd32 = itemRunCuSeqlen[itemIdx + 1];
-            if (runBegin32 < 0 || runEnd32 < runBegin32 || static_cast<size_t>(runEnd32) > runPositions.size())
-            {
-                TLLM_LOG_WARNING("Invalid multimodal run prefix sum; disabling multimodal cache hash extra keys");
-                return {};
-            }
-
-            auto const mmHashArray = makeHashArray((*(*multimodalHashes))[itemIdx]);
-            auto const uuid = getUuid(itemIdx);
-            SizeType32 itemOffset = 0;
-            for (size_t runIdx = static_cast<size_t>(runBegin32); runIdx < static_cast<size_t>(runEnd32); ++runIdx)
-            {
-                auto const runStart = runPositions[runIdx];
-                auto const runLength = runLengths[runIdx];
-                auto const runEnd64 = static_cast<int64_t>(runStart) + static_cast<int64_t>(runLength);
-                if (runStart < 0 || runLength <= 0 || runEnd64 > std::numeric_limits<SizeType32>::max())
-                {
-                    TLLM_LOG_WARNING("Invalid multimodal run range; disabling multimodal cache hash extra keys");
-                    return {};
-                }
-
-                auto const runEnd = static_cast<SizeType32>(runEnd64);
-                if (endTokenIdx > runStart && startTokenIdx < runEnd)
-                {
-                    auto const overlapStart = std::max(startTokenIdx, runStart);
-                    auto const startOffset = itemOffset + overlapStart - runStart;
-                    extraKeys.emplace_back(mmHashArray, startOffset, uuid);
-                }
-                itemOffset += runLength;
-            }
-        }
-
-        return extraKeys;
-    }
-
-    if (!multimodalPositions || !multimodalLengths || !(*multimodalPositions) || (*multimodalPositions)->empty()
-        || !(*multimodalLengths) || (*multimodalLengths)->empty())
+    auto const& hashes = *(*multimodalHashes);
+    auto const runMetadata
+        = resolveRunMetadata(multimodalItemRunCuSeqlen, multimodalRunPositions, multimodalRunLengths, hashes.size());
+    if (runMetadata.status == RunMetadataStatus::kInvalid)
     {
         return {};
     }
-
-    if ((*multimodalHashes)->size() != (*multimodalPositions)->size()
-        || (*multimodalPositions)->size() != (*multimodalLengths)->size())
+    if (runMetadata.status == RunMetadataStatus::kPresent)
     {
-        TLLM_LOG_WARNING("Multimodal data arrays have mismatched sizes");
-        return {};
+        return generateRunBasedExtraKeys(hashes, multimodalUuids, runMetadata.metadata, startTokenIdx, endTokenIdx);
     }
 
-    std::vector<MmKey> extraKeys;
-    extraKeys.reserve((*multimodalPositions)->size());
-
-    for (size_t i = 0; i < (*multimodalPositions)->size(); ++i)
-    {
-        auto const& startPos = (*(*multimodalPositions))[i];
-        auto const& length = (*(*multimodalLengths))[i];
-        auto const& mmHashVector = (*(*multimodalHashes))[i];
-
-        // mmHashVector[j] comes from Python's int(hex_chunk, 16)
-        // where hex_chunk like "00010203" means 0x00 is MSB and 0x03 is LSB (big endian)
-        // Convert 8x 32-bit integers into a 32-byte array preserving Blake3 hash byte order
-        // Example: hashPart = 0x00010203 → mmHashArray[0:3] = [0x00, 0x01, 0x02, 0x03]
-        auto const mmHashArray = makeHashArray(mmHashVector);
-
-        // Check if this multimodal content overlaps with the current block
-        if (endTokenIdx > startPos && startTokenIdx < startPos + length)
-        {
-            uint64_t mmStartInBlock = (startPos >= startTokenIdx) ? 0 : static_cast<uint64_t>(startTokenIdx - startPos);
-
-            // Get UUID if available
-            auto uuid = getUuid(i);
-            extraKeys.emplace_back(mmHashArray, mmStartInBlock, std::move(uuid));
-        }
-    }
-
-    return extraKeys;
+    return generateLegacyContiguousExtraKeys(
+        hashes, multimodalPositions, multimodalLengths, multimodalUuids, startTokenIdx, endTokenIdx);
 }
 
 std::vector<BlockKey> buildBlockKeys(

--- a/cpp/tensorrt_llm/executor/multimodalInput.cpp
+++ b/cpp/tensorrt_llm/executor/multimodalInput.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,11 +22,17 @@ namespace tensorrt_llm::executor
 {
 MultimodalInput::MultimodalInput(std::vector<std::vector<SizeType32>> multimodalHashes,
     std::vector<SizeType32> multimodalPositions, std::vector<SizeType32> multimodalLengths,
-    std::optional<std::vector<std::optional<std::string>>> multimodalUuids)
+    std::optional<std::vector<std::optional<std::string>>> multimodalUuids,
+    std::optional<std::vector<SizeType32>> multimodalItemRunCuSeqlen,
+    std::optional<std::vector<SizeType32>> multimodalRunPositions,
+    std::optional<std::vector<SizeType32>> multimodalRunLengths)
     : mMultimodalHashes(std::move(multimodalHashes))
     , mMultimodalPositions(std::move(multimodalPositions))
     , mMultimodalLengths(std::move(multimodalLengths))
     , mMultimodalUuids(std::move(multimodalUuids))
+    , mMultimodalItemRunCuSeqlen(std::move(multimodalItemRunCuSeqlen))
+    , mMultimodalRunPositions(std::move(multimodalRunPositions))
+    , mMultimodalRunLengths(std::move(multimodalRunLengths))
 {
 }
 
@@ -48,6 +54,21 @@ std::vector<SizeType32> MultimodalInput::getMultimodalLengths() const
 std::optional<std::vector<std::optional<std::string>>> const& MultimodalInput::getMultimodalUuids() const
 {
     return mMultimodalUuids;
+}
+
+std::optional<std::vector<SizeType32>> const& MultimodalInput::getMultimodalItemRunCuSeqlen() const
+{
+    return mMultimodalItemRunCuSeqlen;
+}
+
+std::optional<std::vector<SizeType32>> const& MultimodalInput::getMultimodalRunPositions() const
+{
+    return mMultimodalRunPositions;
+}
+
+std::optional<std::vector<SizeType32>> const& MultimodalInput::getMultimodalRunLengths() const
+{
+    return mMultimodalRunLengths;
 }
 
 } // namespace tensorrt_llm::executor

--- a/cpp/tensorrt_llm/executor/multimodalInput.cpp
+++ b/cpp/tensorrt_llm/executor/multimodalInput.cpp
@@ -23,14 +23,14 @@ namespace tensorrt_llm::executor
 MultimodalInput::MultimodalInput(std::vector<std::vector<SizeType32>> multimodalHashes,
     std::vector<SizeType32> multimodalPositions, std::vector<SizeType32> multimodalLengths,
     std::optional<std::vector<std::optional<std::string>>> multimodalUuids,
-    std::optional<std::vector<SizeType32>> multimodalItemRunCuSeqlen,
+    std::optional<std::vector<SizeType32>> multimodalItemRunCuOffsets,
     std::optional<std::vector<SizeType32>> multimodalRunPositions,
     std::optional<std::vector<SizeType32>> multimodalRunLengths)
     : mMultimodalHashes(std::move(multimodalHashes))
     , mMultimodalPositions(std::move(multimodalPositions))
     , mMultimodalLengths(std::move(multimodalLengths))
     , mMultimodalUuids(std::move(multimodalUuids))
-    , mMultimodalItemRunCuSeqlen(std::move(multimodalItemRunCuSeqlen))
+    , mMultimodalItemRunCuOffsets(std::move(multimodalItemRunCuOffsets))
     , mMultimodalRunPositions(std::move(multimodalRunPositions))
     , mMultimodalRunLengths(std::move(multimodalRunLengths))
 {
@@ -56,9 +56,9 @@ std::optional<std::vector<std::optional<std::string>>> const& MultimodalInput::g
     return mMultimodalUuids;
 }
 
-std::optional<std::vector<SizeType32>> const& MultimodalInput::getMultimodalItemRunCuSeqlen() const
+std::optional<std::vector<SizeType32>> const& MultimodalInput::getMultimodalItemRunCuOffsets() const
 {
-    return mMultimodalItemRunCuSeqlen;
+    return mMultimodalItemRunCuOffsets;
 }
 
 std::optional<std::vector<SizeType32>> const& MultimodalInput::getMultimodalRunPositions() const

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -340,11 +340,11 @@ MultimodalInput Serialization::deserializeMultimodalInput(std::istream& is)
     auto multimodalPositions = su::deserialize<std::vector<SizeType32>>(is);
     auto multimodalLengths = su::deserialize<std::vector<SizeType32>>(is);
     auto multimodalUuids = su::deserialize<std::optional<std::vector<std::optional<std::string>>>>(is);
-    auto multimodalItemRunCuSeqlen = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
+    auto multimodalItemRunCuOffsets = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
     auto multimodalRunPositions = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
     auto multimodalRunLengths = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
     return MultimodalInput{std::move(multimodalHashes), std::move(multimodalPositions), std::move(multimodalLengths),
-        std::move(multimodalUuids), std::move(multimodalItemRunCuSeqlen), std::move(multimodalRunPositions),
+        std::move(multimodalUuids), std::move(multimodalItemRunCuOffsets), std::move(multimodalRunPositions),
         std::move(multimodalRunLengths)};
 }
 
@@ -354,7 +354,7 @@ void Serialization::serialize(MultimodalInput const& multimodalInput, std::ostre
     su::serialize(multimodalInput.mMultimodalPositions, os);
     su::serialize(multimodalInput.mMultimodalLengths, os);
     su::serialize(multimodalInput.mMultimodalUuids, os);
-    su::serialize(multimodalInput.mMultimodalItemRunCuSeqlen, os);
+    su::serialize(multimodalInput.mMultimodalItemRunCuOffsets, os);
     su::serialize(multimodalInput.mMultimodalRunPositions, os);
     su::serialize(multimodalInput.mMultimodalRunLengths, os);
 }
@@ -366,7 +366,7 @@ size_t Serialization::serializedSize(MultimodalInput const& multimodalInput)
     totalSize += su::serializedSize(multimodalInput.mMultimodalPositions);
     totalSize += su::serializedSize(multimodalInput.mMultimodalLengths);
     totalSize += su::serializedSize(multimodalInput.mMultimodalUuids);
-    totalSize += su::serializedSize(multimodalInput.mMultimodalItemRunCuSeqlen);
+    totalSize += su::serializedSize(multimodalInput.mMultimodalItemRunCuOffsets);
     totalSize += su::serializedSize(multimodalInput.mMultimodalRunPositions);
     totalSize += su::serializedSize(multimodalInput.mMultimodalRunLengths);
     return totalSize;

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -412,7 +412,8 @@ void Serialization::serialize(MultimodalInput const& multimodalInput, std::ostre
 size_t Serialization::serializedSize(MultimodalInput const& multimodalInput)
 {
     size_t totalSize = 0;
-    if (hasMultimodalInputRunExtension(multimodalInput))
+    auto const hasRunExtension = hasMultimodalInputRunExtension(multimodalInput);
+    if (hasRunExtension)
     {
         totalSize += su::serializedSize(kMultimodalInputRunExtensionTag);
         totalSize += su::serializedSize(kMultimodalInputRunExtensionVersion);
@@ -421,7 +422,7 @@ size_t Serialization::serializedSize(MultimodalInput const& multimodalInput)
     totalSize += su::serializedSize(multimodalInput.mMultimodalPositions);
     totalSize += su::serializedSize(multimodalInput.mMultimodalLengths);
     totalSize += su::serializedSize(multimodalInput.mMultimodalUuids);
-    if (hasMultimodalInputRunExtension(multimodalInput))
+    if (hasRunExtension)
     {
         totalSize += su::serializedSize(multimodalInput.mMultimodalItemRunCuOffsets);
         totalSize += su::serializedSize(multimodalInput.mMultimodalRunPositions);

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -26,6 +26,7 @@
 #include "tensorrt_llm/runtime/cudaStream.h"
 #include <cstddef>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <type_traits>
 
@@ -33,6 +34,31 @@ namespace su = tensorrt_llm::executor::serialize_utils;
 
 namespace tensorrt_llm::executor
 {
+
+namespace
+{
+
+constexpr size_t kMultimodalInputRunExtensionTag = std::numeric_limits<size_t>::max();
+constexpr SizeType32 kMultimodalInputRunExtensionVersion{1};
+
+bool hasMultimodalInputRunExtension(MultimodalInput const& multimodalInput)
+{
+    return multimodalInput.getMultimodalItemRunCuOffsets().has_value()
+        || multimodalInput.getMultimodalRunPositions().has_value()
+        || multimodalInput.getMultimodalRunLengths().has_value();
+}
+
+std::vector<std::vector<SizeType32>> deserializeMultimodalHashesWithSize(std::istream& is, size_t size)
+{
+    std::vector<std::vector<SizeType32>> multimodalHashes;
+    for (size_t index = 0; index < size; ++index)
+    {
+        multimodalHashes.emplace_back(su::deserialize<std::vector<SizeType32>>(is));
+    }
+    return multimodalHashes;
+}
+
+} // namespace
 
 // TimePoint
 RequestPerfMetrics::TimePoint Serialization::deserializeTimePoint(std::istream& is)
@@ -336,13 +362,28 @@ size_t Serialization::serializedSize(PromptTuningConfig const& config)
 // MultimodalInput
 MultimodalInput Serialization::deserializeMultimodalInput(std::istream& is)
 {
-    auto multimodalHashes = su::deserialize<std::vector<std::vector<SizeType32>>>(is);
+    auto const hashListSizeOrExtensionTag = su::deserialize<size_t>(is);
+    auto const hasRunExtension = hashListSizeOrExtensionTag == kMultimodalInputRunExtensionTag;
+    if (hasRunExtension)
+    {
+        auto const version = su::deserialize<SizeType32>(is);
+        TLLM_CHECK_WITH_INFO(
+            version == kMultimodalInputRunExtensionVersion, "Unsupported MultimodalInput run extension version.");
+    }
+    auto multimodalHashes = hasRunExtension ? su::deserialize<std::vector<std::vector<SizeType32>>>(is)
+                                            : deserializeMultimodalHashesWithSize(is, hashListSizeOrExtensionTag);
     auto multimodalPositions = su::deserialize<std::vector<SizeType32>>(is);
     auto multimodalLengths = su::deserialize<std::vector<SizeType32>>(is);
     auto multimodalUuids = su::deserialize<std::optional<std::vector<std::optional<std::string>>>>(is);
-    auto multimodalItemRunCuOffsets = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
-    auto multimodalRunPositions = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
-    auto multimodalRunLengths = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
+    std::optional<std::vector<SizeType32>> multimodalItemRunCuOffsets = std::nullopt;
+    std::optional<std::vector<SizeType32>> multimodalRunPositions = std::nullopt;
+    std::optional<std::vector<SizeType32>> multimodalRunLengths = std::nullopt;
+    if (hasRunExtension)
+    {
+        multimodalItemRunCuOffsets = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
+        multimodalRunPositions = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
+        multimodalRunLengths = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
+    }
     return MultimodalInput{std::move(multimodalHashes), std::move(multimodalPositions), std::move(multimodalLengths),
         std::move(multimodalUuids), std::move(multimodalItemRunCuOffsets), std::move(multimodalRunPositions),
         std::move(multimodalRunLengths)};
@@ -350,25 +391,42 @@ MultimodalInput Serialization::deserializeMultimodalInput(std::istream& is)
 
 void Serialization::serialize(MultimodalInput const& multimodalInput, std::ostream& os)
 {
+    auto const hasRunExtension = hasMultimodalInputRunExtension(multimodalInput);
+    if (hasRunExtension)
+    {
+        su::serialize(kMultimodalInputRunExtensionTag, os);
+        su::serialize(kMultimodalInputRunExtensionVersion, os);
+    }
     su::serialize(multimodalInput.mMultimodalHashes, os);
     su::serialize(multimodalInput.mMultimodalPositions, os);
     su::serialize(multimodalInput.mMultimodalLengths, os);
     su::serialize(multimodalInput.mMultimodalUuids, os);
-    su::serialize(multimodalInput.mMultimodalItemRunCuOffsets, os);
-    su::serialize(multimodalInput.mMultimodalRunPositions, os);
-    su::serialize(multimodalInput.mMultimodalRunLengths, os);
+    if (hasRunExtension)
+    {
+        su::serialize(multimodalInput.mMultimodalItemRunCuOffsets, os);
+        su::serialize(multimodalInput.mMultimodalRunPositions, os);
+        su::serialize(multimodalInput.mMultimodalRunLengths, os);
+    }
 }
 
 size_t Serialization::serializedSize(MultimodalInput const& multimodalInput)
 {
     size_t totalSize = 0;
+    if (hasMultimodalInputRunExtension(multimodalInput))
+    {
+        totalSize += su::serializedSize(kMultimodalInputRunExtensionTag);
+        totalSize += su::serializedSize(kMultimodalInputRunExtensionVersion);
+    }
     totalSize += su::serializedSize(multimodalInput.mMultimodalHashes);
     totalSize += su::serializedSize(multimodalInput.mMultimodalPositions);
     totalSize += su::serializedSize(multimodalInput.mMultimodalLengths);
     totalSize += su::serializedSize(multimodalInput.mMultimodalUuids);
-    totalSize += su::serializedSize(multimodalInput.mMultimodalItemRunCuOffsets);
-    totalSize += su::serializedSize(multimodalInput.mMultimodalRunPositions);
-    totalSize += su::serializedSize(multimodalInput.mMultimodalRunLengths);
+    if (hasMultimodalInputRunExtension(multimodalInput))
+    {
+        totalSize += su::serializedSize(multimodalInput.mMultimodalItemRunCuOffsets);
+        totalSize += su::serializedSize(multimodalInput.mMultimodalRunPositions);
+        totalSize += su::serializedSize(multimodalInput.mMultimodalRunLengths);
+    }
     return totalSize;
 }
 

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -340,8 +340,12 @@ MultimodalInput Serialization::deserializeMultimodalInput(std::istream& is)
     auto multimodalPositions = su::deserialize<std::vector<SizeType32>>(is);
     auto multimodalLengths = su::deserialize<std::vector<SizeType32>>(is);
     auto multimodalUuids = su::deserialize<std::optional<std::vector<std::optional<std::string>>>>(is);
+    auto multimodalItemRunCuSeqlen = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
+    auto multimodalRunPositions = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
+    auto multimodalRunLengths = su::deserialize<std::optional<std::vector<SizeType32>>>(is);
     return MultimodalInput{std::move(multimodalHashes), std::move(multimodalPositions), std::move(multimodalLengths),
-        std::move(multimodalUuids)};
+        std::move(multimodalUuids), std::move(multimodalItemRunCuSeqlen), std::move(multimodalRunPositions),
+        std::move(multimodalRunLengths)};
 }
 
 void Serialization::serialize(MultimodalInput const& multimodalInput, std::ostream& os)
@@ -350,6 +354,9 @@ void Serialization::serialize(MultimodalInput const& multimodalInput, std::ostre
     su::serialize(multimodalInput.mMultimodalPositions, os);
     su::serialize(multimodalInput.mMultimodalLengths, os);
     su::serialize(multimodalInput.mMultimodalUuids, os);
+    su::serialize(multimodalInput.mMultimodalItemRunCuSeqlen, os);
+    su::serialize(multimodalInput.mMultimodalRunPositions, os);
+    su::serialize(multimodalInput.mMultimodalRunLengths, os);
 }
 
 size_t Serialization::serializedSize(MultimodalInput const& multimodalInput)
@@ -359,6 +366,9 @@ size_t Serialization::serializedSize(MultimodalInput const& multimodalInput)
     totalSize += su::serializedSize(multimodalInput.mMultimodalPositions);
     totalSize += su::serializedSize(multimodalInput.mMultimodalLengths);
     totalSize += su::serializedSize(multimodalInput.mMultimodalUuids);
+    totalSize += su::serializedSize(multimodalInput.mMultimodalItemRunCuSeqlen);
+    totalSize += su::serializedSize(multimodalInput.mMultimodalRunPositions);
+    totalSize += su::serializedSize(multimodalInput.mMultimodalRunLengths);
     return totalSize;
 }
 

--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
@@ -234,15 +234,15 @@ void initBindings(nb::module_& m)
                 }
                 return lengths;
             })
-        .def_prop_ro("multimodal_item_run_cu_seqlen",
+        .def_prop_ro("multimodal_item_run_cu_offsets",
             [](GenLlmReq& self)
             {
-                std::optional<std::vector<GenLlmReq::SizeType32>> cuSeqlen = std::nullopt;
-                if (self.getMultimodalItemRunCuSeqlen())
+                std::optional<std::vector<GenLlmReq::SizeType32>> offsets = std::nullopt;
+                if (self.getMultimodalItemRunCuOffsets())
                 {
-                    cuSeqlen = *self.getMultimodalItemRunCuSeqlen().value();
+                    offsets = *self.getMultimodalItemRunCuOffsets().value();
                 }
-                return cuSeqlen;
+                return offsets;
             })
         .def_prop_ro("multimodal_run_positions",
             [](GenLlmReq& self)
@@ -350,7 +350,7 @@ void initBindings(nb::module_& m)
                 std::optional<tb::LlmRequest::CacheSaltIDType> cache_salt_id,
                 std::optional<tb::LlmRequest::TimePoint> arrival_time,
                 std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy,
-                std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_item_run_cu_seqlen,
+                std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_item_run_cu_offsets,
                 std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_run_positions,
                 std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_run_lengths)
             {
@@ -393,8 +393,8 @@ void initBindings(nb::module_& m)
                     encoder_output_length, cross_attention_mask_tensor_ptr, llm_request_type, input_token_extra_ids,
                     num_return_sequences, eagle_config, skip_cross_attn_blocks_tensor_ptr, return_perf_metrics,
                     guided_decoding_params, language_adapter_uid, allotted_time_ms, context_phase_params, cache_salt_id,
-                    arrival_time, std::move(agent_hierarchy), multimodal_item_run_cu_seqlen, multimodal_run_positions,
-                    multimodal_run_lengths};
+                    arrival_time, std::move(agent_hierarchy), multimodal_item_run_cu_offsets,
+                    multimodal_run_positions, multimodal_run_lengths};
             },
             nb::arg("request_id"), nb::arg("max_new_tokens"), nb::arg("input_tokens"), nb::arg("sampling_config"),
             nb::arg("is_streaming"), nb::arg("end_id") = std::nullopt, nb::arg("pad_id") = std::nullopt,
@@ -422,7 +422,7 @@ void initBindings(nb::module_& m)
             nb::arg("language_adapter_uid") = std::nullopt, nb::arg("allotted_time_ms") = std::nullopt,
             nb::arg("context_phase_params") = std::nullopt, nb::arg("cache_salt_id") = std::nullopt,
             nb::arg("arrival_time") = std::nullopt, nb::arg("agent_hierarchy") = std::nullopt,
-            nb::arg("multimodal_item_run_cu_seqlen") = std::nullopt,
+            nb::arg("multimodal_item_run_cu_offsets") = std::nullopt,
             nb::arg("multimodal_run_positions") = std::nullopt, nb::arg("multimodal_run_lengths") = std::nullopt)
         .def("check_token_id_range", &tb::LlmRequest::checkTokenIdRange, nb::arg("vocab_size"))
         .def(nb::init<tb::LlmRequest const&>())

--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
@@ -393,8 +393,8 @@ void initBindings(nb::module_& m)
                     encoder_output_length, cross_attention_mask_tensor_ptr, llm_request_type, input_token_extra_ids,
                     num_return_sequences, eagle_config, skip_cross_attn_blocks_tensor_ptr, return_perf_metrics,
                     guided_decoding_params, language_adapter_uid, allotted_time_ms, context_phase_params, cache_salt_id,
-                    arrival_time, std::move(agent_hierarchy), multimodal_item_run_cu_offsets,
-                    multimodal_run_positions, multimodal_run_lengths};
+                    arrival_time, std::move(agent_hierarchy), multimodal_item_run_cu_offsets, multimodal_run_positions,
+                    multimodal_run_lengths};
             },
             nb::arg("request_id"), nb::arg("max_new_tokens"), nb::arg("input_tokens"), nb::arg("sampling_config"),
             nb::arg("is_streaming"), nb::arg("end_id") = std::nullopt, nb::arg("pad_id") = std::nullopt,

--- a/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -234,6 +234,36 @@ void initBindings(nb::module_& m)
                 }
                 return lengths;
             })
+        .def_prop_ro("multimodal_item_run_cu_seqlen",
+            [](GenLlmReq& self)
+            {
+                std::optional<std::vector<GenLlmReq::SizeType32>> cuSeqlen = std::nullopt;
+                if (self.getMultimodalItemRunCuSeqlen())
+                {
+                    cuSeqlen = *self.getMultimodalItemRunCuSeqlen().value();
+                }
+                return cuSeqlen;
+            })
+        .def_prop_ro("multimodal_run_positions",
+            [](GenLlmReq& self)
+            {
+                std::optional<std::vector<GenLlmReq::SizeType32>> positions = std::nullopt;
+                if (self.getMultimodalRunPositions())
+                {
+                    positions = *self.getMultimodalRunPositions().value();
+                }
+                return positions;
+            })
+        .def_prop_ro("multimodal_run_lengths",
+            [](GenLlmReq& self)
+            {
+                std::optional<std::vector<GenLlmReq::SizeType32>> lengths = std::nullopt;
+                if (self.getMultimodalRunLengths())
+                {
+                    lengths = *self.getMultimodalRunLengths().value();
+                }
+                return lengths;
+            })
         .def_prop_ro("position_ids",
             [](GenLlmReq& self)
             {
@@ -319,7 +349,10 @@ void initBindings(nb::module_& m)
                 std::optional<executor::ContextPhaseParams> context_phase_params,
                 std::optional<tb::LlmRequest::CacheSaltIDType> cache_salt_id,
                 std::optional<tb::LlmRequest::TimePoint> arrival_time,
-                std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy)
+                std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy,
+                std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_item_run_cu_seqlen,
+                std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_run_positions,
+                std::optional<std::vector<tb::LlmRequest::SizeType32>> multimodal_run_lengths)
             {
                 auto makeOptionalTensor = [](std::optional<at::Tensor> const& atTensor, bool unsqueeze = false)
                 {
@@ -360,7 +393,8 @@ void initBindings(nb::module_& m)
                     encoder_output_length, cross_attention_mask_tensor_ptr, llm_request_type, input_token_extra_ids,
                     num_return_sequences, eagle_config, skip_cross_attn_blocks_tensor_ptr, return_perf_metrics,
                     guided_decoding_params, language_adapter_uid, allotted_time_ms, context_phase_params, cache_salt_id,
-                    arrival_time, std::move(agent_hierarchy)};
+                    arrival_time, std::move(agent_hierarchy), multimodal_item_run_cu_seqlen, multimodal_run_positions,
+                    multimodal_run_lengths};
             },
             nb::arg("request_id"), nb::arg("max_new_tokens"), nb::arg("input_tokens"), nb::arg("sampling_config"),
             nb::arg("is_streaming"), nb::arg("end_id") = std::nullopt, nb::arg("pad_id") = std::nullopt,
@@ -387,7 +421,9 @@ void initBindings(nb::module_& m)
             nb::arg("return_perf_metrics") = false, nb::arg("guided_decoding_params") = std::nullopt,
             nb::arg("language_adapter_uid") = std::nullopt, nb::arg("allotted_time_ms") = std::nullopt,
             nb::arg("context_phase_params") = std::nullopt, nb::arg("cache_salt_id") = std::nullopt,
-            nb::arg("arrival_time") = std::nullopt, nb::arg("agent_hierarchy") = std::nullopt)
+            nb::arg("arrival_time") = std::nullopt, nb::arg("agent_hierarchy") = std::nullopt,
+            nb::arg("multimodal_item_run_cu_seqlen") = std::nullopt,
+            nb::arg("multimodal_run_positions") = std::nullopt, nb::arg("multimodal_run_lengths") = std::nullopt)
         .def("check_token_id_range", &tb::LlmRequest::checkTokenIdRange, nb::arg("vocab_size"))
         .def(nb::init<tb::LlmRequest const&>())
         .def("validate", &tb::LlmRequest::validate, nb::arg("max_input_len"), nb::arg("max_seq_len"),

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
@@ -129,6 +129,7 @@ std::shared_ptr<tb::LlmRequest> LlmRequest::toTrtLlm() const
         mContextPhaseParams,                                       //
         mCacheSaltID,                                              //
         mPerfMetrics.timingMetrics.arrivalTime,                    //
+        mAgentHierarchy,                                           //
         mMultimodalItemRunCuOffsets,                               //
         mMultimodalRunPositions,                                   //
         mMultimodalRunLengths                                      //

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -128,6 +128,9 @@ std::shared_ptr<tb::LlmRequest> LlmRequest::toTrtLlm() const
         mAllottedTimeMs,                                           //
         mContextPhaseParams,                                       //
         mCacheSaltID,                                              //
-        mPerfMetrics.timingMetrics.arrivalTime                     //
+        mPerfMetrics.timingMetrics.arrivalTime,                    //
+        mMultimodalItemRunCuSeqlen,                                //
+        mMultimodalRunPositions,                                   //
+        mMultimodalRunLengths                                      //
     );
 }

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.cpp
@@ -129,7 +129,7 @@ std::shared_ptr<tb::LlmRequest> LlmRequest::toTrtLlm() const
         mContextPhaseParams,                                       //
         mCacheSaltID,                                              //
         mPerfMetrics.timingMetrics.arrivalTime,                    //
-        mMultimodalItemRunCuSeqlen,                                //
+        mMultimodalItemRunCuOffsets,                               //
         mMultimodalRunPositions,                                   //
         mMultimodalRunLengths                                      //
     );

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.h
@@ -88,7 +88,7 @@ public:
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt,
         std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt,
         std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy = std::nullopt,
-        std::optional<std::vector<SizeType32>> multimodalItemRunCuSeqlen = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalItemRunCuOffsets = std::nullopt,
         std::optional<std::vector<SizeType32>> multimodalRunPositions = std::nullopt,
         std::optional<std::vector<SizeType32>> multimodalRunLengths = std::nullopt)
         : Base(requestId,                                                                                       //
@@ -158,8 +158,8 @@ public:
             cacheSaltID,                                                                                         //
             arrivalTime,                                                                                         //
             std::move(agent_hierarchy),                                                                          //
-            multimodalItemRunCuSeqlen.has_value()
-                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalItemRunCuSeqlen.value()))        //
+            multimodalItemRunCuOffsets.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalItemRunCuOffsets.value()))       //
                 : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),                         //
             multimodalRunPositions.has_value()
                 ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalRunPositions.value()))           //

--- a/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.h
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/llmRequest.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,8 +86,11 @@ public:
         std::optional<SizeType32> languageAdapterUid = std::nullopt,
         std::optional<MillisecondsType> allottedTimeMs = std::nullopt,
         std::optional<executor::ContextPhaseParams> const& contextPhaseParams = std::nullopt,
-        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt,
-        std::optional<TimePoint> arrivalTime = std::nullopt)
+        std::optional<CacheSaltIDType> cacheSaltID = std::nullopt, std::optional<TimePoint> arrivalTime = std::nullopt,
+        std::optional<std::vector<std::tuple<std::string, int>>> agent_hierarchy = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalItemRunCuSeqlen = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalRunPositions = std::nullopt,
+        std::optional<std::vector<SizeType32>> multimodalRunLengths = std::nullopt)
         : Base(requestId,                                                                                       //
             maxNewTokens,                                                                                       //
             std::make_shared<std::vector<TokenIdType>>(std::move(inputTokens)),                                 //
@@ -153,7 +156,17 @@ public:
             allottedTimeMs,                                                                                      //
             contextPhaseParams,                                                                                  //
             cacheSaltID,                                                                                         //
-            arrivalTime                                                                                          //
+            arrivalTime,                                                                                         //
+            std::move(agent_hierarchy),                                                                          //
+            multimodalItemRunCuSeqlen.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalItemRunCuSeqlen.value()))        //
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),                         //
+            multimodalRunPositions.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalRunPositions.value()))           //
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt),                         //
+            multimodalRunLengths.has_value()
+                ? std::make_shared<std::vector<SizeType32>>(std::move(multimodalRunLengths.value()))             //
+                : std::optional<std::shared_ptr<std::vector<SizeType32>>>(std::nullopt)                          //
         )
     {
     }

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -307,27 +307,40 @@ void initRequestBindings(nb::module_& m)
     auto multimodalInputGetstate = [](tle::MultimodalInput const& self)
     {
         return nb::make_tuple(self.getMultimodalHashes(), self.getMultimodalPositions(), self.getMultimodalLengths(),
-            self.getMultimodalUuids());
+            self.getMultimodalUuids(), self.getMultimodalItemRunCuSeqlen(), self.getMultimodalRunPositions(),
+            self.getMultimodalRunLengths());
     };
     auto multimodalInputSetstate = [](tle::MultimodalInput& multimodalInput, nb::tuple const& state)
     {
-        if (state.size() != 4)
+        if (state.size() != 4 && state.size() != 7)
         {
             throw std::runtime_error("Invalid MultimodalInput state!");
         }
+        auto multimodalItemRunCuSeqlen = state.size() == 7 ? nb::cast<std::optional<std::vector<SizeType32>>>(state[4])
+                                                           : std::optional<std::vector<SizeType32>>(std::nullopt);
+        auto multimodalRunPositions = state.size() == 7 ? nb::cast<std::optional<std::vector<SizeType32>>>(state[5])
+                                                        : std::optional<std::vector<SizeType32>>(std::nullopt);
+        auto multimodalRunLengths = state.size() == 7 ? nb::cast<std::optional<std::vector<SizeType32>>>(state[6])
+                                                      : std::optional<std::vector<SizeType32>>(std::nullopt);
         new (&multimodalInput) tle::MultimodalInput(nb::cast<std::vector<std::vector<SizeType32>>>(state[0]),
             nb::cast<std::vector<SizeType32>>(state[1]), nb::cast<std::vector<SizeType32>>(state[2]),
-            nb::cast<std::optional<std::vector<std::optional<std::string>>>>(state[3]));
+            nb::cast<std::optional<std::vector<std::optional<std::string>>>>(state[3]),
+            std::move(multimodalItemRunCuSeqlen), std::move(multimodalRunPositions), std::move(multimodalRunLengths));
     };
     nb::class_<tle::MultimodalInput>(m, "MultimodalInput")
         .def(nb::init<std::vector<std::vector<SizeType32>>, std::vector<SizeType32>, std::vector<SizeType32>,
-                 std::optional<std::vector<std::optional<std::string>>>>(),
+                 std::optional<std::vector<std::optional<std::string>>>, std::optional<std::vector<SizeType32>>,
+                 std::optional<std::vector<SizeType32>>, std::optional<std::vector<SizeType32>>>(),
             nb::arg("multimodal_hashes"), nb::arg("multimodal_positions"), nb::arg("multimodal_lengths"),
-            nb::arg("multimodal_uuids") = nb::none())
+            nb::arg("multimodal_uuids") = nb::none(), nb::arg("multimodal_item_run_cu_seqlen") = nb::none(),
+            nb::arg("multimodal_run_positions") = nb::none(), nb::arg("multimodal_run_lengths") = nb::none())
         .def_prop_ro("multimodal_hashes", &tle::MultimodalInput::getMultimodalHashes)
         .def_prop_ro("multimodal_positions", &tle::MultimodalInput::getMultimodalPositions)
         .def_prop_ro("multimodal_lengths", &tle::MultimodalInput::getMultimodalLengths)
         .def_prop_ro("multimodal_uuids", &tle::MultimodalInput::getMultimodalUuids)
+        .def_prop_ro("multimodal_item_run_cu_seqlen", &tle::MultimodalInput::getMultimodalItemRunCuSeqlen)
+        .def_prop_ro("multimodal_run_positions", &tle::MultimodalInput::getMultimodalRunPositions)
+        .def_prop_ro("multimodal_run_lengths", &tle::MultimodalInput::getMultimodalRunLengths)
         .def("__getstate__", multimodalInputGetstate)
         .def("__setstate__", multimodalInputSetstate);
 

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -307,7 +307,7 @@ void initRequestBindings(nb::module_& m)
     auto multimodalInputGetstate = [](tle::MultimodalInput const& self)
     {
         return nb::make_tuple(self.getMultimodalHashes(), self.getMultimodalPositions(), self.getMultimodalLengths(),
-            self.getMultimodalUuids(), self.getMultimodalItemRunCuSeqlen(), self.getMultimodalRunPositions(),
+            self.getMultimodalUuids(), self.getMultimodalItemRunCuOffsets(), self.getMultimodalRunPositions(),
             self.getMultimodalRunLengths());
     };
     auto multimodalInputSetstate = [](tle::MultimodalInput& multimodalInput, nb::tuple const& state)
@@ -316,8 +316,8 @@ void initRequestBindings(nb::module_& m)
         {
             throw std::runtime_error("Invalid MultimodalInput state!");
         }
-        auto multimodalItemRunCuSeqlen = state.size() == 7 ? nb::cast<std::optional<std::vector<SizeType32>>>(state[4])
-                                                           : std::optional<std::vector<SizeType32>>(std::nullopt);
+        auto multimodalItemRunCuOffsets = state.size() == 7 ? nb::cast<std::optional<std::vector<SizeType32>>>(state[4])
+                                                            : std::optional<std::vector<SizeType32>>(std::nullopt);
         auto multimodalRunPositions = state.size() == 7 ? nb::cast<std::optional<std::vector<SizeType32>>>(state[5])
                                                         : std::optional<std::vector<SizeType32>>(std::nullopt);
         auto multimodalRunLengths = state.size() == 7 ? nb::cast<std::optional<std::vector<SizeType32>>>(state[6])
@@ -325,20 +325,20 @@ void initRequestBindings(nb::module_& m)
         new (&multimodalInput) tle::MultimodalInput(nb::cast<std::vector<std::vector<SizeType32>>>(state[0]),
             nb::cast<std::vector<SizeType32>>(state[1]), nb::cast<std::vector<SizeType32>>(state[2]),
             nb::cast<std::optional<std::vector<std::optional<std::string>>>>(state[3]),
-            std::move(multimodalItemRunCuSeqlen), std::move(multimodalRunPositions), std::move(multimodalRunLengths));
+            std::move(multimodalItemRunCuOffsets), std::move(multimodalRunPositions), std::move(multimodalRunLengths));
     };
     nb::class_<tle::MultimodalInput>(m, "MultimodalInput")
         .def(nb::init<std::vector<std::vector<SizeType32>>, std::vector<SizeType32>, std::vector<SizeType32>,
                  std::optional<std::vector<std::optional<std::string>>>, std::optional<std::vector<SizeType32>>,
                  std::optional<std::vector<SizeType32>>, std::optional<std::vector<SizeType32>>>(),
             nb::arg("multimodal_hashes"), nb::arg("multimodal_positions"), nb::arg("multimodal_lengths"),
-            nb::arg("multimodal_uuids") = nb::none(), nb::arg("multimodal_item_run_cu_seqlen") = nb::none(),
+            nb::arg("multimodal_uuids") = nb::none(), nb::arg("multimodal_item_run_cu_offsets") = nb::none(),
             nb::arg("multimodal_run_positions") = nb::none(), nb::arg("multimodal_run_lengths") = nb::none())
         .def_prop_ro("multimodal_hashes", &tle::MultimodalInput::getMultimodalHashes)
         .def_prop_ro("multimodal_positions", &tle::MultimodalInput::getMultimodalPositions)
         .def_prop_ro("multimodal_lengths", &tle::MultimodalInput::getMultimodalLengths)
         .def_prop_ro("multimodal_uuids", &tle::MultimodalInput::getMultimodalUuids)
-        .def_prop_ro("multimodal_item_run_cu_seqlen", &tle::MultimodalInput::getMultimodalItemRunCuSeqlen)
+        .def_prop_ro("multimodal_item_run_cu_offsets", &tle::MultimodalInput::getMultimodalItemRunCuOffsets)
         .def_prop_ro("multimodal_run_positions", &tle::MultimodalInput::getMultimodalRunPositions)
         .def_prop_ro("multimodal_run_lengths", &tle::MultimodalInput::getMultimodalRunLengths)
         .def("__getstate__", multimodalInputGetstate)

--- a/cpp/tests/unit_tests/batch_manager/blockKeyTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/blockKeyTest.cpp
@@ -16,6 +16,8 @@
 
 #include "tensorrt_llm/batch_manager/blockKey.h"
 #include "tensorrt_llm/batch_manager/kvCacheManager.h"
+#include "tensorrt_llm/batch_manager/llmRequest.h"
+#include "tensorrt_llm/executor/executor.h"
 
 #include <gtest/gtest.h>
 
@@ -167,6 +169,45 @@ TEST_F(BlockKeyTest, HashWithExtraKeys)
     BlockKey bk0(false, std::nullopt, {{1, 0}}, {makeMmKey(0xAA, 0)});
     BlockKey bk1(false, std::nullopt, {{1, 0}}, {makeMmKey(0xBB, 0)});
     EXPECT_FALSE(BlockKeyHasher::hash(bk0) == BlockKeyHasher::hash(bk1));
+}
+
+TEST_F(BlockKeyTest, GenerateExtraKeysUsesExactMultimodalRuns)
+{
+    using tensorrt_llm::batch_manager::LlmRequest;
+    using tensorrt_llm::executor::MultimodalInput;
+    using tensorrt_llm::executor::OutputConfig;
+    using tensorrt_llm::executor::Request;
+    using tensorrt_llm::executor::SamplingConfig;
+
+    MultimodalInput multimodalInput({{1, 2, 3, 4, 5, 6, 7, 8}},
+        /*multimodalPositions=*/{1},
+        /*multimodalLengths=*/{4},
+        /*multimodalUuids=*/std::vector<std::optional<std::string>>{std::string("item-0")},
+        /*multimodalItemRunCuSeqlen=*/std::vector<SizeType32>{0, 2},
+        /*multimodalRunPositions=*/std::vector<SizeType32>{1, 8},
+        /*multimodalRunLengths=*/std::vector<SizeType32>{2, 2});
+
+    Request executorRequest({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, /*maxTokens=*/1, /*streaming=*/false, SamplingConfig(),
+        OutputConfig(), /*endId=*/std::nullopt, /*padId=*/std::nullopt,
+        /*positionIds=*/std::nullopt, /*badWords=*/std::nullopt, /*stopWords=*/std::nullopt,
+        /*embeddingBias=*/std::nullopt, /*externalDraftTokensConfig=*/std::nullopt,
+        /*pTuningConfig=*/std::nullopt, multimodalInput);
+    LlmRequest llmRequest(/*requestId=*/0, executorRequest);
+
+    auto firstRunKeys = generateBlockHashExtraKeys(llmRequest, /*startTokenIdx=*/0, /*endTokenIdx=*/4);
+    ASSERT_EQ(firstRunKeys.size(), 1);
+    EXPECT_EQ(firstRunKeys[0].startOffset, 0);
+    ASSERT_TRUE(firstRunKeys[0].uuid.has_value());
+    EXPECT_EQ(firstRunKeys[0].uuid.value(), "item-0");
+
+    auto gapKeys = generateBlockHashExtraKeys(llmRequest, /*startTokenIdx=*/3, /*endTokenIdx=*/8);
+    EXPECT_TRUE(gapKeys.empty());
+
+    auto secondRunKeys = generateBlockHashExtraKeys(llmRequest, /*startTokenIdx=*/7, /*endTokenIdx=*/10);
+    ASSERT_EQ(secondRunKeys.size(), 1);
+    EXPECT_EQ(secondRunKeys[0].startOffset, 2);
+    ASSERT_TRUE(secondRunKeys[0].uuid.has_value());
+    EXPECT_EQ(secondRunKeys[0].uuid.value(), "item-0");
 }
 
 // ---------------------------------------------------------------------------

--- a/cpp/tests/unit_tests/batch_manager/blockKeyTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/blockKeyTest.cpp
@@ -210,7 +210,48 @@ TEST_F(BlockKeyTest, GenerateExtraKeysUsesExactMultimodalRuns)
     EXPECT_EQ(secondRunKeys[0].uuid.value(), "item-0");
 }
 
-TEST_F(BlockKeyTest, GenerateExtraKeysDisablesHashingForIncompleteRunMetadata)
+TEST_F(BlockKeyTest, GenerateExtraKeysFallsBackToLegacyForIncompleteRunMetadata)
+{
+    using tensorrt_llm::batch_manager::LlmRequest;
+    using tensorrt_llm::executor::MultimodalInput;
+    using tensorrt_llm::executor::OutputConfig;
+    using tensorrt_llm::executor::Request;
+    using tensorrt_llm::executor::SamplingConfig;
+
+    MultimodalInput multimodalInputA({{1, 2, 3, 4, 5, 6, 7, 8}},
+        /*multimodalPositions=*/{1},
+        /*multimodalLengths=*/{2},
+        /*multimodalUuids=*/std::nullopt,
+        /*multimodalItemRunCuOffsets=*/std::vector<SizeType32>{0, 1});
+    MultimodalInput multimodalInputB({{8, 7, 6, 5, 4, 3, 2, 1}},
+        /*multimodalPositions=*/{1},
+        /*multimodalLengths=*/{2},
+        /*multimodalUuids=*/std::nullopt,
+        /*multimodalItemRunCuOffsets=*/std::vector<SizeType32>{0, 1});
+
+    Request executorRequestA({101, 32000, 32000, 102, 103}, /*maxTokens=*/1, /*streaming=*/false, SamplingConfig(),
+        OutputConfig(),
+        /*endId=*/std::nullopt, /*padId=*/std::nullopt, /*positionIds=*/std::nullopt, /*badWords=*/std::nullopt,
+        /*stopWords=*/std::nullopt, /*embeddingBias=*/std::nullopt, /*externalDraftTokensConfig=*/std::nullopt,
+        /*pTuningConfig=*/std::nullopt, multimodalInputA);
+    Request executorRequestB({101, 32000, 32000, 102, 103}, /*maxTokens=*/1, /*streaming=*/false, SamplingConfig(),
+        OutputConfig(),
+        /*endId=*/std::nullopt, /*padId=*/std::nullopt, /*positionIds=*/std::nullopt, /*badWords=*/std::nullopt,
+        /*stopWords=*/std::nullopt, /*embeddingBias=*/std::nullopt, /*externalDraftTokensConfig=*/std::nullopt,
+        /*pTuningConfig=*/std::nullopt, multimodalInputB);
+    LlmRequest llmRequestA(/*requestId=*/0, executorRequestA);
+    LlmRequest llmRequestB(/*requestId=*/1, executorRequestB);
+
+    auto keysA = generateBlockHashExtraKeys(llmRequestA, /*startTokenIdx=*/0, /*endTokenIdx=*/4);
+    auto keysB = generateBlockHashExtraKeys(llmRequestB, /*startTokenIdx=*/0, /*endTokenIdx=*/4);
+    ASSERT_EQ(keysA.size(), 1);
+    ASSERT_EQ(keysB.size(), 1);
+    EXPECT_EQ(keysA[0].startOffset, 0);
+    EXPECT_EQ(keysB[0].startOffset, 0);
+    EXPECT_NE(keysA[0].hash, keysB[0].hash);
+}
+
+TEST_F(BlockKeyTest, GenerateExtraKeysFallsBackToLegacyForInvalidRunRange)
 {
     using tensorrt_llm::batch_manager::LlmRequest;
     using tensorrt_llm::executor::MultimodalInput;
@@ -220,18 +261,22 @@ TEST_F(BlockKeyTest, GenerateExtraKeysDisablesHashingForIncompleteRunMetadata)
 
     MultimodalInput multimodalInput({{1, 2, 3, 4, 5, 6, 7, 8}},
         /*multimodalPositions=*/{1},
-        /*multimodalLengths=*/{4},
+        /*multimodalLengths=*/{2},
         /*multimodalUuids=*/std::nullopt,
-        /*multimodalItemRunCuOffsets=*/std::vector<SizeType32>{0, 1});
+        /*multimodalItemRunCuOffsets=*/std::vector<SizeType32>{0, 1},
+        /*multimodalRunPositions=*/std::vector<SizeType32>{1},
+        /*multimodalRunLengths=*/std::vector<SizeType32>{-1});
 
-    Request executorRequest({0, 1, 2, 3, 4}, /*maxTokens=*/1, /*streaming=*/false, SamplingConfig(), OutputConfig(),
-        /*endId=*/std::nullopt, /*padId=*/std::nullopt, /*positionIds=*/std::nullopt, /*badWords=*/std::nullopt,
-        /*stopWords=*/std::nullopt, /*embeddingBias=*/std::nullopt, /*externalDraftTokensConfig=*/std::nullopt,
+    Request executorRequest({101, 32000, 32000, 102, 103}, /*maxTokens=*/1, /*streaming=*/false, SamplingConfig(),
+        OutputConfig(), /*endId=*/std::nullopt, /*padId=*/std::nullopt,
+        /*positionIds=*/std::nullopt, /*badWords=*/std::nullopt, /*stopWords=*/std::nullopt,
+        /*embeddingBias=*/std::nullopt, /*externalDraftTokensConfig=*/std::nullopt,
         /*pTuningConfig=*/std::nullopt, multimodalInput);
     LlmRequest llmRequest(/*requestId=*/0, executorRequest);
 
-    auto keys = generateBlockHashExtraKeys(llmRequest, /*startTokenIdx=*/1, /*endTokenIdx=*/2);
-    EXPECT_TRUE(keys.empty());
+    auto keys = generateBlockHashExtraKeys(llmRequest, /*startTokenIdx=*/0, /*endTokenIdx=*/4);
+    ASSERT_EQ(keys.size(), 1);
+    EXPECT_EQ(keys[0].startOffset, 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/cpp/tests/unit_tests/batch_manager/blockKeyTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/blockKeyTest.cpp
@@ -210,6 +210,30 @@ TEST_F(BlockKeyTest, GenerateExtraKeysUsesExactMultimodalRuns)
     EXPECT_EQ(secondRunKeys[0].uuid.value(), "item-0");
 }
 
+TEST_F(BlockKeyTest, GenerateExtraKeysDisablesHashingForIncompleteRunMetadata)
+{
+    using tensorrt_llm::batch_manager::LlmRequest;
+    using tensorrt_llm::executor::MultimodalInput;
+    using tensorrt_llm::executor::OutputConfig;
+    using tensorrt_llm::executor::Request;
+    using tensorrt_llm::executor::SamplingConfig;
+
+    MultimodalInput multimodalInput({{1, 2, 3, 4, 5, 6, 7, 8}},
+        /*multimodalPositions=*/{1},
+        /*multimodalLengths=*/{4},
+        /*multimodalUuids=*/std::nullopt,
+        /*multimodalItemRunCuSeqlen=*/std::vector<SizeType32>{0, 1});
+
+    Request executorRequest({0, 1, 2, 3, 4}, /*maxTokens=*/1, /*streaming=*/false, SamplingConfig(), OutputConfig(),
+        /*endId=*/std::nullopt, /*padId=*/std::nullopt, /*positionIds=*/std::nullopt, /*badWords=*/std::nullopt,
+        /*stopWords=*/std::nullopt, /*embeddingBias=*/std::nullopt, /*externalDraftTokensConfig=*/std::nullopt,
+        /*pTuningConfig=*/std::nullopt, multimodalInput);
+    LlmRequest llmRequest(/*requestId=*/0, executorRequest);
+
+    auto keys = generateBlockHashExtraKeys(llmRequest, /*startTokenIdx=*/1, /*endTokenIdx=*/2);
+    EXPECT_TRUE(keys.empty());
+}
+
 // ---------------------------------------------------------------------------
 // numMatchingTokens edge cases
 // ---------------------------------------------------------------------------

--- a/cpp/tests/unit_tests/batch_manager/blockKeyTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/blockKeyTest.cpp
@@ -183,7 +183,7 @@ TEST_F(BlockKeyTest, GenerateExtraKeysUsesExactMultimodalRuns)
         /*multimodalPositions=*/{1},
         /*multimodalLengths=*/{4},
         /*multimodalUuids=*/std::vector<std::optional<std::string>>{std::string("item-0")},
-        /*multimodalItemRunCuSeqlen=*/std::vector<SizeType32>{0, 2},
+        /*multimodalItemRunCuOffsets=*/std::vector<SizeType32>{0, 2},
         /*multimodalRunPositions=*/std::vector<SizeType32>{1, 8},
         /*multimodalRunLengths=*/std::vector<SizeType32>{2, 2});
 
@@ -222,7 +222,7 @@ TEST_F(BlockKeyTest, GenerateExtraKeysDisablesHashingForIncompleteRunMetadata)
         /*multimodalPositions=*/{1},
         /*multimodalLengths=*/{4},
         /*multimodalUuids=*/std::nullopt,
-        /*multimodalItemRunCuSeqlen=*/std::vector<SizeType32>{0, 1});
+        /*multimodalItemRunCuOffsets=*/std::vector<SizeType32>{0, 1});
 
     Request executorRequest({0, 1, 2, 3, 4}, /*maxTokens=*/1, /*streaming=*/false, SamplingConfig(), OutputConfig(),
         /*endId=*/std::nullopt, /*padId=*/std::nullopt, /*positionIds=*/std::nullopt, /*badWords=*/std::nullopt,

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -1203,6 +1203,10 @@ TEST(SerializeUtilsTest, MultimodalInputWithUuids)
                 EXPECT_EQ((*origUuids)[i], (*deserUuids)[i]);
             }
         }
+
+        EXPECT_EQ(original.getMultimodalItemRunCuSeqlen(), deserialized.getMultimodalItemRunCuSeqlen());
+        EXPECT_EQ(original.getMultimodalRunPositions(), deserialized.getMultimodalRunPositions());
+        EXPECT_EQ(original.getMultimodalRunLengths(), deserialized.getMultimodalRunLengths());
     };
 
     // Test MultimodalInput with UUIDs
@@ -1217,6 +1221,12 @@ TEST(SerializeUtilsTest, MultimodalInputWithUuids)
     std::vector<std::optional<std::string>> uuids = {std::string("image-uuid-001"), std::string("image-uuid-002")};
     MultimodalInput inputWithUuids(hashes, positions, lengths, uuids);
     verifyMultimodalInput(inputWithUuids);
+
+    std::vector<SizeType32> itemRunCuSeqlen = {0, 2, 3};
+    std::vector<SizeType32> runPositions = {0, 40, 100};
+    std::vector<SizeType32> runLengths = {20, 30, 75};
+    MultimodalInput inputWithRuns(hashes, positions, lengths, uuids, itemRunCuSeqlen, runPositions, runLengths);
+    verifyMultimodalInput(inputWithRuns);
 
     // Test with partial UUIDs (mixed Some and None)
     std::vector<std::optional<std::string>> partialUuids = {std::string("uuid-a"), std::nullopt};

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -1204,7 +1204,7 @@ TEST(SerializeUtilsTest, MultimodalInputWithUuids)
             }
         }
 
-        EXPECT_EQ(original.getMultimodalItemRunCuSeqlen(), deserialized.getMultimodalItemRunCuSeqlen());
+        EXPECT_EQ(original.getMultimodalItemRunCuOffsets(), deserialized.getMultimodalItemRunCuOffsets());
         EXPECT_EQ(original.getMultimodalRunPositions(), deserialized.getMultimodalRunPositions());
         EXPECT_EQ(original.getMultimodalRunLengths(), deserialized.getMultimodalRunLengths());
     };
@@ -1222,10 +1222,10 @@ TEST(SerializeUtilsTest, MultimodalInputWithUuids)
     MultimodalInput inputWithUuids(hashes, positions, lengths, uuids);
     verifyMultimodalInput(inputWithUuids);
 
-    std::vector<SizeType32> itemRunCuSeqlen = {0, 2, 3};
+    std::vector<SizeType32> itemRunCuOffsets = {0, 2, 3};
     std::vector<SizeType32> runPositions = {0, 40, 100};
     std::vector<SizeType32> runLengths = {20, 30, 75};
-    MultimodalInput inputWithRuns(hashes, positions, lengths, uuids, itemRunCuSeqlen, runPositions, runLengths);
+    MultimodalInput inputWithRuns(hashes, positions, lengths, uuids, itemRunCuOffsets, runPositions, runLengths);
     verifyMultimodalInput(inputWithRuns);
 
     // Test with partial UUIDs (mixed Some and None)

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include <gtest/gtest.h>
 
+#include <array>
 #include <optional>
 #include <type_traits>
 #include <variant>
@@ -1248,6 +1249,67 @@ TEST(SerializeUtilsTest, MultimodalInputWithUuids)
             std::string("short")};
     MultimodalInput inputLongUuids(hashes, positions, lengths, longUuids);
     verifyMultimodalInput(inputLongUuids);
+}
+
+TEST(SerializeUtilsTest, MultimodalInputKeepsLegacyStreamAligned)
+{
+    std::vector<std::vector<SizeType32>> hashes = {{1, 2, 3, 4}};
+    std::vector<SizeType32> positions = {10};
+    std::vector<SizeType32> lengths = {20};
+    std::optional<std::vector<std::optional<std::string>>> uuids = std::nullopt;
+
+    std::ostringstream oss;
+    su::serialize(hashes, oss);
+    su::serialize(positions, oss);
+    su::serialize(lengths, oss);
+    su::serialize(uuids, oss);
+
+    std::array<char, 3> nextObjectPrefix{0, 0, 0};
+    oss.write(nextObjectPrefix.data(), nextObjectPrefix.size());
+    su::serialize(SizeType32{0x01020304}, oss);
+
+    auto bufferString = oss.str();
+    std::vector<char> buffer(bufferString.begin(), bufferString.end());
+    su::VectorWrapBuf<char> strbuf{buffer};
+    std::istream iss{&strbuf};
+    auto multimodalInput = texec::Serialization::deserializeMultimodalInput(iss);
+
+    EXPECT_EQ(multimodalInput.getMultimodalHashes(), hashes);
+    EXPECT_EQ(multimodalInput.getMultimodalPositions(), positions);
+    EXPECT_EQ(multimodalInput.getMultimodalLengths(), lengths);
+    EXPECT_EQ(multimodalInput.getMultimodalUuids(), uuids);
+    EXPECT_EQ(multimodalInput.getMultimodalItemRunCuOffsets(), std::nullopt);
+    EXPECT_EQ(multimodalInput.getMultimodalRunPositions(), std::nullopt);
+    EXPECT_EQ(multimodalInput.getMultimodalRunLengths(), std::nullopt);
+
+    std::array<char, 3> readPrefix{};
+    iss.read(readPrefix.data(), readPrefix.size());
+    EXPECT_EQ(readPrefix, nextObjectPrefix);
+    EXPECT_EQ(su::deserialize<SizeType32>(iss), SizeType32{0x01020304});
+}
+
+TEST(SerializeUtilsTest, MultimodalInputWithoutExactRunsUsesLegacyWireFormat)
+{
+    std::vector<std::vector<SizeType32>> hashes = {{1, 2, 3, 4}};
+    std::vector<SizeType32> positions = {10};
+    std::vector<SizeType32> lengths = {20};
+    std::optional<std::vector<std::optional<std::string>>> uuids = std::nullopt;
+    texec::MultimodalInput input{hashes, positions, lengths, uuids};
+
+    std::ostringstream oss;
+    texec::Serialization::serialize(input, oss);
+    std::array<char, 3> nextObjectPrefix{'N', 'E', 'X'};
+    oss.write(nextObjectPrefix.data(), nextObjectPrefix.size());
+
+    std::istringstream iss(oss.str());
+    EXPECT_EQ(su::deserialize<std::vector<std::vector<SizeType32>>>(iss), hashes);
+    EXPECT_EQ(su::deserialize<std::vector<SizeType32>>(iss), positions);
+    EXPECT_EQ(su::deserialize<std::vector<SizeType32>>(iss), lengths);
+    EXPECT_EQ(su::deserialize<std::optional<std::vector<std::optional<std::string>>>>(iss), uuids);
+
+    std::array<char, 3> readPrefix{};
+    iss.read(readPrefix.data(), readPrefix.size());
+    EXPECT_EQ(readPrefix, nextObjectPrefix);
 }
 
 // Connection notification tests

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -358,7 +358,13 @@ class KvCacheCreator:
                     multimodal_hashes=multimodal_input.multimodal_hashes,
                     multimodal_positions=multimodal_input.multimodal_positions,
                     multimodal_lengths=multimodal_input.multimodal_lengths,
-                    multimodal_uuids=multimodal_input.multimodal_uuids
+                    multimodal_uuids=multimodal_input.multimodal_uuids,
+                    multimodal_item_run_cu_seqlen=multimodal_input.
+                    multimodal_item_run_cu_seqlen,
+                    multimodal_run_positions=multimodal_input.
+                    multimodal_run_positions,
+                    multimodal_run_lengths=multimodal_input.
+                    multimodal_run_lengths,
                 ) if multimodal_input else None
 
                 request = trtllm.Request(prompt_token_ids,

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -359,8 +359,8 @@ class KvCacheCreator:
                     multimodal_positions=multimodal_input.multimodal_positions,
                     multimodal_lengths=multimodal_input.multimodal_lengths,
                     multimodal_uuids=multimodal_input.multimodal_uuids,
-                    multimodal_item_run_cu_seqlen=multimodal_input.
-                    multimodal_item_run_cu_seqlen,
+                    multimodal_item_run_cu_offsets=multimodal_input.
+                    multimodal_item_run_cu_offsets,
                     multimodal_run_positions=multimodal_input.
                     multimodal_run_positions,
                     multimodal_run_lengths=multimodal_input.

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -946,11 +946,20 @@ def executor_request_to_llm_request(
     multimodal_positions = None
     multimodal_lengths = None
     multimodal_uuids = None
+    multimodal_item_run_cu_seqlen = None
+    multimodal_run_positions = None
+    multimodal_run_lengths = None
     if executor_request.multimodal_input is not None:
         multimodal_hashes = executor_request.multimodal_input.multimodal_hashes
         multimodal_positions = executor_request.multimodal_input.multimodal_positions
         multimodal_lengths = executor_request.multimodal_input.multimodal_lengths
         multimodal_uuids = executor_request.multimodal_input.multimodal_uuids
+        multimodal_item_run_cu_seqlen = (
+            executor_request.multimodal_input.multimodal_item_run_cu_seqlen)
+        multimodal_run_positions = (
+            executor_request.multimodal_input.multimodal_run_positions)
+        multimodal_run_lengths = (
+            executor_request.multimodal_input.multimodal_run_lengths)
 
     # Extract mrope fields
     mrope_rotary_cos_sin = None
@@ -985,6 +994,9 @@ def executor_request_to_llm_request(
         multimodal_positions=multimodal_positions,
         multimodal_lengths=multimodal_lengths,
         multimodal_uuids=multimodal_uuids,
+        multimodal_item_run_cu_seqlen=multimodal_item_run_cu_seqlen,
+        multimodal_run_positions=multimodal_run_positions,
+        multimodal_run_lengths=multimodal_run_lengths,
         multimodal_embedding=executor_request.multimodal_embedding,
         lora_task_id=executor_request.lora_config.task_id
         if executor_request.lora_config is not None else None,

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -946,7 +946,7 @@ def executor_request_to_llm_request(
     multimodal_positions = None
     multimodal_lengths = None
     multimodal_uuids = None
-    multimodal_item_run_cu_seqlen = None
+    multimodal_item_run_cu_offsets = None
     multimodal_run_positions = None
     multimodal_run_lengths = None
     if executor_request.multimodal_input is not None:
@@ -954,8 +954,8 @@ def executor_request_to_llm_request(
         multimodal_positions = executor_request.multimodal_input.multimodal_positions
         multimodal_lengths = executor_request.multimodal_input.multimodal_lengths
         multimodal_uuids = executor_request.multimodal_input.multimodal_uuids
-        multimodal_item_run_cu_seqlen = (
-            executor_request.multimodal_input.multimodal_item_run_cu_seqlen)
+        multimodal_item_run_cu_offsets = (
+            executor_request.multimodal_input.multimodal_item_run_cu_offsets)
         multimodal_run_positions = (
             executor_request.multimodal_input.multimodal_run_positions)
         multimodal_run_lengths = (
@@ -994,7 +994,7 @@ def executor_request_to_llm_request(
         multimodal_positions=multimodal_positions,
         multimodal_lengths=multimodal_lengths,
         multimodal_uuids=multimodal_uuids,
-        multimodal_item_run_cu_seqlen=multimodal_item_run_cu_seqlen,
+        multimodal_item_run_cu_offsets=multimodal_item_run_cu_offsets,
         multimodal_run_positions=multimodal_run_positions,
         multimodal_run_lengths=multimodal_run_lengths,
         multimodal_embedding=executor_request.multimodal_embedding,

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -113,8 +113,15 @@ class _MmRunMetadata(NamedTuple):
 def _hash_to_digest(hash_ints: Sequence[int]) -> bytes:
     # Convert 8 x int32 hash chunks to the 32-byte digest used by C++ block
     # keys. The byte order matches getNthByte(), which extracts MSB first.
-    assert len(
-        hash_ints) == 8, f"Expected 8 int32 hash values, got {len(hash_ints)}"
+    try:
+        hash_len = len(hash_ints)
+    except TypeError as exc:
+        raise ValueError(
+            "Expected 8 int32 hash values, got non-sized input") from exc
+    if hash_len != 8:
+        raise ValueError(f"Expected 8 int32 hash values, got {hash_len}")
+    if not all(isinstance(value, int) for value in hash_ints):
+        raise ValueError("Expected multimodal hash values to be integers")
     return b''.join(v.to_bytes(4, 'big', signed=True) for v in hash_ints)
 
 
@@ -229,46 +236,36 @@ def _augment_tokens_with_mm_run_metadata(
     # - item_token_offset = item-local run start + intra-run prompt offset
     # Shape [num_overlapping_runs]; item index for each selected flat run.
     overlap_run_item_indices = metadata.run_item_indices[overlap_run_indices]
-    # Shape [num_overlapping_items]; each item is processed once per digest.
-    overlap_item_indices = torch.unique_consecutive(overlap_run_item_indices)
-    for item_idx_tensor in overlap_item_indices:
-        item_idx = int(item_idx_tensor)
-        # Runs from the same item share one digest, so process them together
-        # and only vary the item-local token offset for each overlapping span.
-        # Shape [num_item_overlapping_runs]; selected flat runs for this item.
-        item_overlap_run_indices = overlap_run_indices[overlap_run_item_indices
-                                                       == item_idx]
+    # Materialize the selected run metadata once before the Python loop. These
+    # are CPU tensors by construction, and the loop below is request hot-path
+    # bookkeeping.
+    overlap_run_positions = metadata.run_positions[overlap_run_indices]
+    prompt_overlap_starts = torch.clamp(overlap_run_positions, min=chunk_start)
+    prompt_overlap_ends = torch.clamp(metadata.run_ends[overlap_run_indices],
+                                      max=chunk_end)
+    item_token_offsets = (metadata.run_item_offsets[overlap_run_indices] +
+                          prompt_overlap_starts - overlap_run_positions)
+    chunk_result_offsets = prompt_overlap_starts - chunk_start
+    lengths = prompt_overlap_ends - prompt_overlap_starts
 
-        digest = _hash_to_digest(multimodal_hashes[item_idx])
-        # Shape [num_item_overlapping_runs]; full-prompt bounds clipped to chunk.
-        prompt_overlap_starts = torch.clamp(
-            metadata.run_positions[item_overlap_run_indices], min=chunk_start)
-        prompt_overlap_ends = torch.clamp(
-            metadata.run_ends[item_overlap_run_indices], max=chunk_end)
-        # Shape [num_item_overlapping_runs]; item-local segment start offsets.
-        item_token_offsets = (
-            metadata.run_item_offsets[item_overlap_run_indices] +
-            prompt_overlap_starts -
-            metadata.run_positions[item_overlap_run_indices])
-        # Shape [num_item_overlapping_runs]; chunk-local result start offsets.
-        chunk_result_offsets = prompt_overlap_starts - chunk_start
-        # Shape [num_item_overlapping_runs]; token counts for clipped segments.
-        lengths = prompt_overlap_ends - prompt_overlap_starts
-        for chunk_result_offset_tensor, item_token_offset_tensor, length_tensor in zip(
-                chunk_result_offsets, item_token_offsets, lengths, strict=True):
-            chunk_result_offset = int(chunk_result_offset_tensor)
-            item_token_offset = int(item_token_offset_tensor)
-            length = int(length_tensor)
-            # Feed the coarse item property (content digest) and granular run
-            # properties (item-local offset and span length) into the key
-            # generator, so cache keys reflect the actual multimodal tokens
-            # being rewritten.
-            result[chunk_result_offset:chunk_result_offset +
-                   length] = gen_multimodal_cache_key_tokens(
-                       vocab_size,
-                       digest,
-                       length,
-                       token_offset=item_token_offset)
+    current_item_idx: Optional[int] = None
+    digest = b""
+    for item_idx, chunk_result_offset, item_token_offset, length in zip(
+            overlap_run_item_indices.tolist(),
+            chunk_result_offsets.tolist(),
+            item_token_offsets.tolist(),
+            lengths.tolist(),
+            strict=True):
+        if item_idx != current_item_idx:
+            current_item_idx = item_idx
+            digest = _hash_to_digest(multimodal_hashes[item_idx])
+        # Feed the coarse item property (content digest) and granular run
+        # properties (item-local offset and span length) into the key
+        # generator, so cache keys reflect the actual multimodal tokens being
+        # rewritten.
+        result[chunk_result_offset:chunk_result_offset +
+               length] = gen_multimodal_cache_key_tokens(
+                   vocab_size, digest, length, token_offset=item_token_offset)
 
     return result
 

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
 import copy
 import enum
 import math
@@ -90,31 +93,79 @@ class Role:
 
 
 class _MmRunMetadata(NamedTuple):
+    """CPU tensors for exact multimodal run lookup.
+
+    `num_runs` is the total number of flat multimodal runs across all
+    multimodal items, i.e. `item_run_cu_offsets[-1]`. All members are 1-D CPU
+    int64 tensors with shape `[num_runs]`.
+    """
+
+    # Shape [num_runs]; full-prompt start index for each flat run.
     run_positions: torch.Tensor
+    # Shape [num_runs]; one-past-last full-prompt index for each flat run.
     run_ends: torch.Tensor
+    # Shape [num_runs]; logical multimodal item index for each flat run.
     run_item_indices: torch.Tensor
+    # Shape [num_runs]; item-local token offset where each flat run begins.
     run_item_offsets: torch.Tensor
 
 
 def _hash_to_digest(hash_ints: Sequence[int]) -> bytes:
-    # Convert 8 x int32 hash to 32-byte digest (big-endian, matching v1 C++
-    # getNthByte which extracts MSB first).
+    # Convert 8 x int32 hash chunks to the 32-byte digest used by C++ block
+    # keys. The byte order matches getNthByte(), which extracts MSB first.
     assert len(
         hash_ints) == 8, f"Expected 8 int32 hash values, got {len(hash_ints)}"
     return b''.join(v.to_bytes(4, 'big', signed=True) for v in hash_ints)
 
 
-def _as_int64_cpu_tensor(values: Sequence[int] | torch.Tensor) -> torch.Tensor:
-    # int64 is expected dtype for tensor indexing
-    return torch.as_tensor(values, dtype=torch.int64).cpu()
+def _ensure_int64_cpu_tensor(
+        values: Sequence[int] | torch.Tensor) -> torch.Tensor:
+    # Block-reuse augmentation is Python-side index math. The metadata is
+    # produced by host mm preprocessing and carried in
+    # MultimodalInput metadata. A non-CPU tensor here means the upstream
+    # contract drifted and would introduce an unexpected sync in the
+    # block-reuse path, so fail loudly.
+    if isinstance(values, torch.Tensor):
+        if values.device.type != "cpu":
+            raise ValueError(
+                "multimodal block-reuse metadata must be CPU-resident, "
+                f"got {values.device}")
+        return values.to(dtype=torch.int64)
+    return torch.as_tensor(values, dtype=torch.int64)
 
 
 def _resolve_multimodal_run_metadata(
         req: LlmRequest) -> Optional[_MmRunMetadata]:
-    # NOTE: the following optional fields help in exact mm token position mixing in blockhash key generation
-    item_run_cu_offsets = getattr(req, "multimodal_item_run_cu_offsets", None)
-    run_positions = getattr(req, "multimodal_run_positions", None)
-    run_lengths = getattr(req, "multimodal_run_lengths", None)
+    # Worked example for one logical multimodal item split by text:
+    #
+    #   prompt index: 0    1      2      3    4      5
+    #   prompt token: T0   MM0:0  MM0:1  T1   MM0:2  MM0:3
+    #   flat run:          run0   run0        run1   run1
+    #
+    # Inputs encode the prompt layout as:
+    #
+    #   item_run_cu_offsets = [0, 2]  # item 0 owns flat runs [0, 2)
+    #   run_positions       = [1, 4]  # run0 starts at prompt 1, run1 at 4
+    #   run_lengths         = [2, 2]  # token counts for run0 and run1
+    #
+    # The derived arrays below let the augmentation loop map any overlapping
+    # flat run back to the item digest and to the item-local token offset:
+    #
+    #   item_run_counts        = [2]     # item 0 has two runs
+    #   cumulative_run_lengths = [0,2,4] # tokens before run0, run1, and end
+    #   item_starts            = [0]     # item 0 starts at flat run 0
+    #   run_item_indices       = [0,0]   # run0 and run1 both belong to item 0
+    #   run_item_offsets       = [0,2]   # run1 begins at MM0 token offset 2
+    #
+    # So a chunk slice covering prompt [4, 6) uses MM0's digest with token
+    # offset 2; a slice covering prompt [5, 6) uses token offset 3.
+
+    # Shape [num_items + 1]; item i owns flat runs [offsets[i], offsets[i + 1]).
+    item_run_cu_offsets = req.multimodal_item_run_cu_offsets
+    # Shape [num_runs]; full-prompt start index for each flat run.
+    run_positions = req.multimodal_run_positions
+    # Shape [num_runs]; token count for each flat run.
+    run_lengths = req.multimodal_run_lengths
 
     if all(field is None
            for field in (item_run_cu_offsets, run_positions, run_lengths)):
@@ -126,19 +177,29 @@ def _resolve_multimodal_run_metadata(
             "multimodal run metadata must be validated before block reuse and provided together"
         )
 
-    item_run_cu_offsets = _as_int64_cpu_tensor(item_run_cu_offsets)
-    run_positions = _as_int64_cpu_tensor(run_positions)
-    run_lengths = _as_int64_cpu_tensor(run_lengths)
+    item_run_cu_offsets = _ensure_int64_cpu_tensor(item_run_cu_offsets)
+    run_positions = _ensure_int64_cpu_tensor(run_positions)
+    run_lengths = _ensure_int64_cpu_tensor(run_lengths)
 
+    # Shape [num_items]; number of flat runs owned by each logical item.
     item_run_counts = item_run_cu_offsets[1:] - item_run_cu_offsets[:-1]
+
+    # Shape [num_runs + 1]; item-token count before each flat run, plus end.
     cumulative_run_lengths = torch.cat(
         (torch.zeros(1, dtype=torch.int64), torch.cumsum(run_lengths, dim=0)))
+
+    # Shape [num_items]; first flat-run index for each logical item.
     item_starts = item_run_cu_offsets[:-1]
+
+    # Shape [num_runs]; logical multimodal item index for each flat run.
     run_item_indices = torch.repeat_interleave(
         torch.arange(item_run_counts.numel(), dtype=torch.int64),
         item_run_counts)
+
+    # Shape [num_runs]; item-local token offset where each flat run begins.
     run_item_offsets = (cumulative_run_lengths[:-1] -
                         cumulative_run_lengths[item_starts][run_item_indices])
+    # Shape [num_runs]; one-past-last full-prompt index for each flat run.
     run_ends = run_positions + run_lengths
 
     return _MmRunMetadata(
@@ -149,40 +210,65 @@ def _resolve_multimodal_run_metadata(
     )
 
 
-def _augment_tokens_with_mm_run_metadata(vocab_size: int,
-                                         result: list[TokenIdExt],
-                                         multimodal_hashes: Sequence[
-                                             Sequence[int]],
-                                         metadata: _MmRunMetadata, start: int,
-                                         end: int) -> list[TokenIdExt]:
-    overlap_mask = (metadata.run_ends > start) & (metadata.run_positions < end)
+def _augment_tokens_with_mm_run_metadata(
+        vocab_size: int, result: list[TokenIdExt],
+        multimodal_hashes: Sequence[Sequence[int]], metadata: _MmRunMetadata,
+        chunk_start: int, chunk_end: int) -> list[TokenIdExt]:
+    # Only rewrite multimodal runs that overlap the materialized prompt slice.
+    overlap_mask = ((metadata.run_ends > chunk_start)
+                    & (metadata.run_positions < chunk_end))
+    # Shape [num_overlapping_runs]; flat-run indices that touch this chunk.
     overlap_run_indices = torch.nonzero(overlap_mask).flatten()
     if overlap_run_indices.numel() == 0:
         return result
 
+    # `result` is indexed relative to this chunk, but multimodal cache-key
+    # tokens are indexed relative to the logical multimodal item. The rewrite
+    # below therefore computes, for each selected run segment:
+    # - chunk_result_offset = prompt position - chunk_start
+    # - item_token_offset = item-local run start + intra-run prompt offset
+    # Shape [num_overlapping_runs]; item index for each selected flat run.
     overlap_run_item_indices = metadata.run_item_indices[overlap_run_indices]
+    # Shape [num_overlapping_items]; each item is processed once per digest.
     overlap_item_indices = torch.unique_consecutive(overlap_run_item_indices)
-    for item_idx in overlap_item_indices.tolist():
+    for item_idx_tensor in overlap_item_indices:
+        item_idx = int(item_idx_tensor)
+        # Runs from the same item share one digest, so process them together
+        # and only vary the item-local token offset for each overlapping span.
+        # Shape [num_item_overlapping_runs]; selected flat runs for this item.
         item_overlap_run_indices = overlap_run_indices[overlap_run_item_indices
                                                        == item_idx]
 
         digest = _hash_to_digest(multimodal_hashes[item_idx])
-        overlap_starts = torch.clamp(
-            metadata.run_positions[item_overlap_run_indices], min=start)
-        overlap_ends = torch.clamp(metadata.run_ends[item_overlap_run_indices],
-                                   max=end)
-        token_offsets = (metadata.run_item_offsets[item_overlap_run_indices] +
-                         overlap_starts -
-                         metadata.run_positions[item_overlap_run_indices])
-        result_offsets = overlap_starts - start
-        lengths = overlap_ends - overlap_starts
-        for result_offset, token_offset, length in zip(result_offsets.tolist(),
-                                                       token_offsets.tolist(),
-                                                       lengths.tolist(),
-                                                       strict=True):
-            result[result_offset:result_offset +
+        # Shape [num_item_overlapping_runs]; full-prompt bounds clipped to chunk.
+        prompt_overlap_starts = torch.clamp(
+            metadata.run_positions[item_overlap_run_indices], min=chunk_start)
+        prompt_overlap_ends = torch.clamp(
+            metadata.run_ends[item_overlap_run_indices], max=chunk_end)
+        # Shape [num_item_overlapping_runs]; item-local segment start offsets.
+        item_token_offsets = (
+            metadata.run_item_offsets[item_overlap_run_indices] +
+            prompt_overlap_starts -
+            metadata.run_positions[item_overlap_run_indices])
+        # Shape [num_item_overlapping_runs]; chunk-local result start offsets.
+        chunk_result_offsets = prompt_overlap_starts - chunk_start
+        # Shape [num_item_overlapping_runs]; token counts for clipped segments.
+        lengths = prompt_overlap_ends - prompt_overlap_starts
+        for chunk_result_offset_tensor, item_token_offset_tensor, length_tensor in zip(
+                chunk_result_offsets, item_token_offsets, lengths, strict=True):
+            chunk_result_offset = int(chunk_result_offset_tensor)
+            item_token_offset = int(item_token_offset_tensor)
+            length = int(length_tensor)
+            # Feed the coarse item property (content digest) and granular run
+            # properties (item-local offset and span length) into the key
+            # generator, so cache keys reflect the actual multimodal tokens
+            # being rewritten.
+            result[chunk_result_offset:chunk_result_offset +
                    length] = gen_multimodal_cache_key_tokens(
-                       vocab_size, digest, length, token_offset=token_offset)
+                       vocab_size,
+                       digest,
+                       length,
+                       token_offset=item_token_offset)
 
     return result
 
@@ -191,24 +277,24 @@ def _augment_tokens_with_contiguous_mm_metadata(
         vocab_size: int, result: list[TokenIdExt],
         multimodal_hashes: Sequence[Sequence[int]],
         multimodal_positions: Sequence[int] | torch.Tensor,
-        multimodal_lengths: Sequence[int] | torch.Tensor, start: int,
-        end: int) -> list[TokenIdExt]:
-    # we assume multimodal chunks are contiguous
-    # so mm_token_end_position = mm_token_start_position + mm_token_length
-    # this assumption is not valid for video data, which may contain interleaved text tokens
-    positions = _as_int64_cpu_tensor(multimodal_positions)
-    lengths = _as_int64_cpu_tensor(multimodal_lengths)
+        multimodal_lengths: Sequence[int] | torch.Tensor, chunk_start: int,
+        chunk_end: int) -> list[TokenIdExt]:
+    # Legacy metadata assumes every item is one contiguous prompt span. Exact
+    # run metadata is preferred for video layouts that interleave text tokens.
+    positions = _ensure_int64_cpu_tensor(multimodal_positions)
+    lengths = _ensure_int64_cpu_tensor(multimodal_lengths)
 
     item_ends = positions + lengths
-    overlap_mask = (item_ends > start) & (positions < end)
+    overlap_mask = (item_ends > chunk_start) & (positions < chunk_end)
     overlap_item_indices = torch.nonzero(overlap_mask).flatten()
-    for item_idx in overlap_item_indices.tolist():
+    for item_idx_tensor in overlap_item_indices:
+        item_idx = int(item_idx_tensor)
         pos = positions[item_idx].item()
         length = lengths[item_idx].item()
-        overlap_start = max(pos, start)
-        overlap_end = min(pos + length, end)
+        overlap_start = max(pos, chunk_start)
+        overlap_end = min(pos + length, chunk_end)
         source_offset = overlap_start - pos
-        result_offset = overlap_start - start
+        result_offset = overlap_start - chunk_start
         overlap_length = overlap_end - overlap_start
         result[result_offset:result_offset +
                overlap_length] = gen_multimodal_cache_key_tokens(
@@ -2737,31 +2823,34 @@ class KVCacheManagerV2(BaseResourceManager):
         (Blake3 hash) into the token sequence so that the radix tree can
         distinguish blocks belonging to different images/videos.
 
-        When *start*/*end* are given, only the slice ``tokens[start:end]`` is
-        materialized and returned. This avoids re-augmenting the full prompt
-        on every chunk during chunked prefill.
+        When *start*/*end* are given, they define the chunk bounds; only
+        `tokens[start:end]` is materialized and returned. This avoids
+        re-augmenting the full prompt on every chunk during chunked prefill.
 
         For text-only requests this is a no-op.
         """
         if end is None:
             end = len(tokens)
-        is_sliced = start != 0 or end != len(tokens)
+        chunk_start = start
+        chunk_end = end
+        is_sliced = chunk_start != 0 or chunk_end != len(tokens)
 
         if (req.multimodal_hashes is None or req.multimodal_positions is None
                 or req.multimodal_lengths is None):
-            return tokens[start:end] if is_sliced else tokens
+            return tokens[chunk_start:chunk_end] if is_sliced else tokens
 
-        result: list[TokenIdExt] = list(tokens[start:end])
+        result: list[TokenIdExt] = list(tokens[chunk_start:chunk_end])
         run_metadata = _resolve_multimodal_run_metadata(req)
         if run_metadata is not None:
             return _augment_tokens_with_mm_run_metadata(self.vocab_size, result,
                                                         req.multimodal_hashes,
-                                                        run_metadata, start,
-                                                        end)
+                                                        run_metadata,
+                                                        chunk_start, chunk_end)
 
         return _augment_tokens_with_contiguous_mm_metadata(
             self.vocab_size, result, req.multimodal_hashes,
-            req.multimodal_positions, req.multimodal_lengths, start, end)
+            req.multimodal_positions, req.multimodal_lengths, chunk_start,
+            chunk_end)
 
     def get_kv_cache_stats(self):
         kv_cache_stats = KvCacheStats()

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -112,28 +112,28 @@ def _as_int64_cpu_tensor(values: Sequence[int] | torch.Tensor) -> torch.Tensor:
 def _resolve_multimodal_run_metadata(
         req: LlmRequest) -> Optional[_MmRunMetadata]:
     # NOTE: the following optional fields help in exact mm token position mixing in blockhash key generation
-    item_run_cu_seqlen = getattr(req, "multimodal_item_run_cu_seqlen", None)
+    item_run_cu_offsets = getattr(req, "multimodal_item_run_cu_offsets", None)
     run_positions = getattr(req, "multimodal_run_positions", None)
     run_lengths = getattr(req, "multimodal_run_lengths", None)
 
     if all(field is None
-           for field in (item_run_cu_seqlen, run_positions, run_lengths)):
+           for field in (item_run_cu_offsets, run_positions, run_lengths)):
         return None
 
-    if (item_run_cu_seqlen is None or run_positions is None
+    if (item_run_cu_offsets is None or run_positions is None
             or run_lengths is None):
         raise ValueError(
             "multimodal run metadata must be validated before block reuse and provided together"
         )
 
-    item_run_cu_seqlen = _as_int64_cpu_tensor(item_run_cu_seqlen)
+    item_run_cu_offsets = _as_int64_cpu_tensor(item_run_cu_offsets)
     run_positions = _as_int64_cpu_tensor(run_positions)
     run_lengths = _as_int64_cpu_tensor(run_lengths)
 
-    item_run_counts = item_run_cu_seqlen[1:] - item_run_cu_seqlen[:-1]
+    item_run_counts = item_run_cu_offsets[1:] - item_run_cu_offsets[:-1]
     cumulative_run_lengths = torch.cat(
         (torch.zeros(1, dtype=torch.int64), torch.cumsum(run_lengths, dim=0)))
-    item_starts = item_run_cu_seqlen[:-1]
+    item_starts = item_run_cu_offsets[:-1]
     run_item_indices = torch.repeat_interleave(
         torch.arange(item_run_counts.numel(), dtype=torch.int64),
         item_run_counts)

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2621,6 +2621,80 @@ class KVCacheManagerV2(BaseResourceManager):
             return tokens[start:end] if is_sliced else tokens
 
         result: list[TokenIdExt] = list(tokens[start:end])
+
+        def hash_to_digest(hash_ints: Sequence[int]) -> bytes:
+            # Convert 8 x int32 hash to 32-byte digest (big-endian,
+            # matching v1 C++ getNthByte which extracts MSB first).
+            assert len(
+                hash_ints
+            ) == 8, f"Expected 8 int32 hash values, got {len(hash_ints)}"
+            return b''.join(
+                v.to_bytes(4, 'big', signed=True) for v in hash_ints)
+
+        item_run_cu_seqlen = getattr(req, "multimodal_item_run_cu_seqlen", None)
+        run_positions = getattr(req, "multimodal_run_positions", None)
+        run_lengths = getattr(req, "multimodal_run_lengths", None)
+        if any(field is not None
+               for field in (item_run_cu_seqlen, run_positions, run_lengths)):
+            if (item_run_cu_seqlen is None or run_positions is None
+                    or run_lengths is None):
+                logger.warning(
+                    "Incomplete multimodal run metadata; skipping multimodal token augmentation for block reuse"
+                )
+                return result
+            if (len(item_run_cu_seqlen) != len(req.multimodal_hashes) + 1
+                    or item_run_cu_seqlen[0] != 0
+                    or item_run_cu_seqlen[-1] != len(run_positions)
+                    or len(run_positions) != len(run_lengths)):
+                logger.warning(
+                    "Invalid multimodal run metadata shape; skipping multimodal token augmentation for block reuse"
+                )
+                return result
+
+            for item_idx, hash_ints in enumerate(req.multimodal_hashes):
+                run_begin = item_run_cu_seqlen[item_idx]
+                run_end = item_run_cu_seqlen[item_idx + 1]
+                if run_begin < 0 or run_end < run_begin or run_end > len(
+                        run_positions):
+                    logger.warning(
+                        "Invalid multimodal run prefix sum; skipping multimodal token augmentation for block reuse"
+                    )
+                    return result
+
+                total_item_length = sum(run_lengths[run_begin:run_end])
+                if total_item_length <= 0:
+                    logger.warning(
+                        "Invalid multimodal run length; skipping multimodal token augmentation for block reuse"
+                    )
+                    return result
+
+                digest = hash_to_digest(hash_ints)
+                mm_tokens = gen_multi_modal_tokens(self.vocab_size, digest,
+                                                   total_item_length)
+                item_offset = 0
+                for run_idx in range(run_begin, run_end):
+                    pos = run_positions[run_idx]
+                    length = run_lengths[run_idx]
+                    if pos < 0 or length <= 0:
+                        logger.warning(
+                            "Invalid multimodal run range; skipping multimodal token augmentation for block reuse"
+                        )
+                        return result
+                    mm_end = pos + length
+                    if mm_end <= start or pos >= end:
+                        item_offset += length
+                        continue
+
+                    overlap_start = max(pos, start)
+                    overlap_end = min(mm_end, end)
+                    mm_offset = item_offset + overlap_start - pos
+                    result_offset = overlap_start - start
+                    n = overlap_end - overlap_start
+                    result[result_offset:result_offset +
+                           n] = mm_tokens[mm_offset:mm_offset + n]
+                    item_offset += length
+            return result
+
         for hash_ints, pos, length in zip(req.multimodal_hashes,
                                           req.multimodal_positions,
                                           req.multimodal_lengths,
@@ -2629,13 +2703,7 @@ class KVCacheManagerV2(BaseResourceManager):
             # Skip multimodal items outside [start, end).
             if mm_end <= start or pos >= end:
                 continue
-            # Convert 8 x int32 hash to 32-byte digest (big-endian,
-            # matching v1 C++ getNthByte which extracts MSB first).
-            assert len(
-                hash_ints
-            ) == 8, f"Expected 8 int32 hash values, got {len(hash_ints)}"
-            digest = b''.join(
-                v.to_bytes(4, 'big', signed=True) for v in hash_ints)
+            digest = hash_to_digest(hash_ints)
             mm_tokens = gen_multi_modal_tokens(self.vocab_size, digest, length)
             # Overlap between [pos, mm_end) and [start, end).
             overlap_start = max(pos, start)

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -4,8 +4,8 @@ import math
 import os
 from abc import ABC, abstractmethod
 from collections import OrderedDict, defaultdict, deque
-from typing import (TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence,
-                    Set, Tuple, Union)
+from typing import (TYPE_CHECKING, Dict, Iterable, List, NamedTuple, Optional,
+                    Sequence, Set, Tuple, Union)
 
 import torch
 from mpi4py import MPI
@@ -87,6 +87,164 @@ class Role:
     KEY_BLOCK_SCALE = DataRole("key_block_scale")
     VALUE_BLOCK_SCALE = DataRole("value_block_scale")
     ALL = DataRole("all")
+
+
+class _MmRunMetadata(NamedTuple):
+    item_run_cu_seqlen: torch.Tensor
+    run_positions: torch.Tensor
+    run_lengths: torch.Tensor
+    run_ends: torch.Tensor
+    run_item_indices: torch.Tensor
+    run_item_offsets: torch.Tensor
+    item_lengths: torch.Tensor
+
+
+def _hash_to_digest(hash_ints: Sequence[int]) -> bytes:
+    # Convert 8 x int32 hash to 32-byte digest (big-endian, matching v1 C++
+    # getNthByte which extracts MSB first).
+    assert len(
+        hash_ints) == 8, f"Expected 8 int32 hash values, got {len(hash_ints)}"
+    return b''.join(v.to_bytes(4, 'big', signed=True) for v in hash_ints)
+
+
+def _as_int64_cpu_tensor(values: Sequence[int] | torch.Tensor) -> torch.Tensor:
+    # int64 is expected dtype for tensor indexing
+    return torch.as_tensor(values, dtype=torch.int64).cpu()
+
+
+def _resolve_multimodal_run_metadata(
+        req: LlmRequest, item_count: int) -> Optional[_MmRunMetadata]:
+    # NOTE: the following optional fields help in exact mm token position mixing in blockhash key generation
+    item_run_cu_seqlen = getattr(req, "multimodal_item_run_cu_seqlen", None)
+    run_positions = getattr(req, "multimodal_run_positions", None)
+    run_lengths = getattr(req, "multimodal_run_lengths", None)
+
+    if all(field is None
+           for field in (item_run_cu_seqlen, run_positions, run_lengths)):
+        return None
+
+    if (item_run_cu_seqlen is None or run_positions is None
+            or run_lengths is None):
+        raise ValueError(
+            "multimodal run metadata must be validated before block reuse and provided together"
+        )
+
+    item_run_cu_seqlen = _as_int64_cpu_tensor(item_run_cu_seqlen)
+    run_positions = _as_int64_cpu_tensor(run_positions)
+    run_lengths = _as_int64_cpu_tensor(run_lengths)
+
+    item_run_counts = item_run_cu_seqlen[1:] - item_run_cu_seqlen[:-1]
+    cumulative_run_lengths = torch.cat(
+        (torch.zeros(1, dtype=torch.int64), torch.cumsum(run_lengths, dim=0)))
+    item_starts = item_run_cu_seqlen[:-1]
+    item_ends = item_run_cu_seqlen[1:]
+    item_lengths = cumulative_run_lengths[item_ends] - cumulative_run_lengths[
+        item_starts]
+    run_item_indices = torch.repeat_interleave(
+        torch.arange(item_count, dtype=torch.int64), item_run_counts)
+    run_item_offsets = (cumulative_run_lengths[:-1] -
+                        cumulative_run_lengths[item_starts][run_item_indices])
+    run_ends = run_positions + run_lengths
+
+    return _MmRunMetadata(
+        item_run_cu_seqlen=item_run_cu_seqlen,
+        run_positions=run_positions,
+        run_lengths=run_lengths,
+        run_ends=run_ends,
+        run_item_indices=run_item_indices,
+        run_item_offsets=run_item_offsets,
+        item_lengths=item_lengths,
+    )
+
+
+def _copy_token_spans(result: list[TokenIdExt],
+                      source_tokens: Sequence[TokenIdExt],
+                      result_offsets: torch.Tensor,
+                      source_offsets: torch.Tensor,
+                      lengths: torch.Tensor) -> None:
+    for result_offset, source_offset, length in zip(result_offsets.tolist(),
+                                                    source_offsets.tolist(),
+                                                    lengths.tolist(),
+                                                    strict=True):
+        result[result_offset:result_offset +
+               length] = source_tokens[source_offset:source_offset + length]
+
+
+def _augment_tokens_with_mm_run_metadata(vocab_size: int,
+                                         result: list[TokenIdExt],
+                                         multimodal_hashes: Sequence[
+                                             Sequence[int]],
+                                         metadata: _MmRunMetadata, start: int,
+                                         end: int) -> list[TokenIdExt]:
+    overlap_mask = (metadata.run_ends > start) & (metadata.run_positions < end)
+    overlap_run_indices = torch.nonzero(overlap_mask).flatten()
+    if overlap_run_indices.numel() == 0:
+        return result
+
+    overlap_item_indices = torch.unique_consecutive(
+        metadata.run_item_indices[overlap_run_indices])
+    for item_idx in overlap_item_indices.tolist():
+        item_run_start = metadata.item_run_cu_seqlen[item_idx].item()
+        item_run_end = metadata.item_run_cu_seqlen[item_idx + 1].item()
+        item_overlap_run_indices = overlap_run_indices[
+            (overlap_run_indices >= item_run_start)
+            & (overlap_run_indices < item_run_end)]
+
+        mm_tokens = gen_multi_modal_tokens(
+            vocab_size, _hash_to_digest(multimodal_hashes[item_idx]),
+            metadata.item_lengths[item_idx].item())
+        overlap_starts = torch.clamp(
+            metadata.run_positions[item_overlap_run_indices], min=start)
+        overlap_ends = torch.clamp(metadata.run_ends[item_overlap_run_indices],
+                                   max=end)
+        source_offsets = (metadata.run_item_offsets[item_overlap_run_indices] +
+                          overlap_starts -
+                          metadata.run_positions[item_overlap_run_indices])
+        result_offsets = overlap_starts - start
+        lengths = overlap_ends - overlap_starts
+        _copy_token_spans(result, mm_tokens, result_offsets, source_offsets,
+                          lengths)
+
+    return result
+
+
+def _augment_tokens_with_contiguous_mm_metadata(
+        vocab_size: int, result: list[TokenIdExt],
+        multimodal_hashes: Sequence[Sequence[int]],
+        multimodal_positions: Sequence[int] | torch.Tensor,
+        multimodal_lengths: Sequence[int] | torch.Tensor, start: int,
+        end: int) -> list[TokenIdExt]:
+    # we assume multimodal chunks are contiguous
+    # so mm_token_end_position = mm_token_start_position + mm_token_length
+    # this assumption is not valid for video data, which may contain interleaved text tokens
+    positions = _as_int64_cpu_tensor(multimodal_positions)
+    lengths = _as_int64_cpu_tensor(multimodal_lengths)
+
+    if positions.ndim != 1 or lengths.ndim != 1 or positions.numel() != len(
+            multimodal_hashes) or positions.numel() != lengths.numel():
+        logger.warning(
+            "Invalid multimodal metadata shape; skipping multimodal token augmentation for block reuse"
+        )
+        return result
+
+    item_ends = positions + lengths
+    overlap_mask = (item_ends > start) & (positions < end)
+    overlap_item_indices = torch.nonzero(overlap_mask).flatten()
+    for item_idx in overlap_item_indices.tolist():
+        pos = positions[item_idx].item()
+        length = lengths[item_idx].item()
+        mm_tokens = gen_multi_modal_tokens(
+            vocab_size, _hash_to_digest(multimodal_hashes[item_idx]), length)
+        overlap_start = max(pos, start)
+        overlap_end = min(pos + length, end)
+        source_offset = overlap_start - pos
+        result_offset = overlap_start - start
+        overlap_length = overlap_end - overlap_start
+        result[result_offset:result_offset +
+               overlap_length] = mm_tokens[source_offset:source_offset +
+                                           overlap_length]
+
+    return result
 
 
 def compute_page_count(token_count: int, tokens_per_page: int) -> int:
@@ -2621,99 +2779,17 @@ class KVCacheManagerV2(BaseResourceManager):
             return tokens[start:end] if is_sliced else tokens
 
         result: list[TokenIdExt] = list(tokens[start:end])
+        run_metadata = _resolve_multimodal_run_metadata(
+            req, len(req.multimodal_hashes))
+        if run_metadata is not None:
+            return _augment_tokens_with_mm_run_metadata(self.vocab_size, result,
+                                                        req.multimodal_hashes,
+                                                        run_metadata, start,
+                                                        end)
 
-        def hash_to_digest(hash_ints: Sequence[int]) -> bytes:
-            # Convert 8 x int32 hash to 32-byte digest (big-endian,
-            # matching v1 C++ getNthByte which extracts MSB first).
-            assert len(
-                hash_ints
-            ) == 8, f"Expected 8 int32 hash values, got {len(hash_ints)}"
-            return b''.join(
-                v.to_bytes(4, 'big', signed=True) for v in hash_ints)
-
-        item_run_cu_seqlen = getattr(req, "multimodal_item_run_cu_seqlen", None)
-        run_positions = getattr(req, "multimodal_run_positions", None)
-        run_lengths = getattr(req, "multimodal_run_lengths", None)
-        if any(field is not None
-               for field in (item_run_cu_seqlen, run_positions, run_lengths)):
-            if (item_run_cu_seqlen is None or run_positions is None
-                    or run_lengths is None):
-                logger.warning(
-                    "Incomplete multimodal run metadata; skipping multimodal token augmentation for block reuse"
-                )
-                return result
-            if (len(item_run_cu_seqlen) != len(req.multimodal_hashes) + 1
-                    or item_run_cu_seqlen[0] != 0
-                    or item_run_cu_seqlen[-1] != len(run_positions)
-                    or len(run_positions) != len(run_lengths)):
-                logger.warning(
-                    "Invalid multimodal run metadata shape; skipping multimodal token augmentation for block reuse"
-                )
-                return result
-
-            for item_idx, hash_ints in enumerate(req.multimodal_hashes):
-                run_begin = item_run_cu_seqlen[item_idx]
-                run_end = item_run_cu_seqlen[item_idx + 1]
-                if run_begin < 0 or run_end < run_begin or run_end > len(
-                        run_positions):
-                    logger.warning(
-                        "Invalid multimodal run prefix sum; skipping multimodal token augmentation for block reuse"
-                    )
-                    return result
-
-                total_item_length = sum(run_lengths[run_begin:run_end])
-                if total_item_length <= 0:
-                    logger.warning(
-                        "Invalid multimodal run length; skipping multimodal token augmentation for block reuse"
-                    )
-                    return result
-
-                digest = hash_to_digest(hash_ints)
-                mm_tokens = gen_multi_modal_tokens(self.vocab_size, digest,
-                                                   total_item_length)
-                item_offset = 0
-                for run_idx in range(run_begin, run_end):
-                    pos = run_positions[run_idx]
-                    length = run_lengths[run_idx]
-                    if pos < 0 or length <= 0:
-                        logger.warning(
-                            "Invalid multimodal run range; skipping multimodal token augmentation for block reuse"
-                        )
-                        return result
-                    mm_end = pos + length
-                    if mm_end <= start or pos >= end:
-                        item_offset += length
-                        continue
-
-                    overlap_start = max(pos, start)
-                    overlap_end = min(mm_end, end)
-                    mm_offset = item_offset + overlap_start - pos
-                    result_offset = overlap_start - start
-                    n = overlap_end - overlap_start
-                    result[result_offset:result_offset +
-                           n] = mm_tokens[mm_offset:mm_offset + n]
-                    item_offset += length
-            return result
-
-        for hash_ints, pos, length in zip(req.multimodal_hashes,
-                                          req.multimodal_positions,
-                                          req.multimodal_lengths,
-                                          strict=True):
-            mm_end = pos + length
-            # Skip multimodal items outside [start, end).
-            if mm_end <= start or pos >= end:
-                continue
-            digest = hash_to_digest(hash_ints)
-            mm_tokens = gen_multi_modal_tokens(self.vocab_size, digest, length)
-            # Overlap between [pos, mm_end) and [start, end).
-            overlap_start = max(pos, start)
-            overlap_end = min(mm_end, end)
-            mm_offset = overlap_start - pos
-            result_offset = overlap_start - start
-            n = overlap_end - overlap_start
-            result[result_offset:result_offset +
-                   n] = mm_tokens[mm_offset:mm_offset + n]
-        return result
+        return _augment_tokens_with_contiguous_mm_metadata(
+            self.vocab_size, result, req.multimodal_hashes,
+            req.multimodal_positions, req.multimodal_lengths, start, end)
 
     def get_kv_cache_stats(self):
         kv_cache_stats = KvCacheStats()

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -38,7 +38,7 @@ from tensorrt_llm.runtime.kv_cache_manager_v2 import \
 from tensorrt_llm.runtime.kv_cache_manager_v2 import (LayerId, TokenIdExt,
                                                       _KVCache)
 from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import \
-    gen_multi_modal_tokens
+    gen_multimodal_cache_key_tokens
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import (BAD_PAGE_INDEX,
                                                               GPU_LEVEL)
 from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
@@ -181,10 +181,8 @@ def _augment_tokens_with_mm_run_metadata(vocab_size: int,
                                                        lengths.tolist(),
                                                        strict=True):
             result[result_offset:result_offset +
-                   length] = gen_multi_modal_tokens(vocab_size,
-                                                    digest,
-                                                    length,
-                                                    token_offset=token_offset)
+                   length] = gen_multimodal_cache_key_tokens(
+                       vocab_size, digest, length, token_offset=token_offset)
 
     return result
 
@@ -213,7 +211,7 @@ def _augment_tokens_with_contiguous_mm_metadata(
         result_offset = overlap_start - start
         overlap_length = overlap_end - overlap_start
         result[result_offset:result_offset +
-               overlap_length] = gen_multi_modal_tokens(
+               overlap_length] = gen_multimodal_cache_key_tokens(
                    vocab_size,
                    _hash_to_digest(multimodal_hashes[item_idx]),
                    overlap_length,
@@ -2735,9 +2733,9 @@ class KVCacheManagerV2(BaseResourceManager):
         Multimodal placeholder tokens (e.g. image_token_id) share the same ID
         regardless of the underlying content. This method replaces each
         multimodal token region with TokenIdExt values produced by
-        gen_multi_modal_tokens(), embedding the content digest (Blake3 hash)
-        into the token sequence so that the radix tree can distinguish blocks
-        belonging to different images/videos.
+        gen_multimodal_cache_key_tokens(), embedding the content digest
+        (Blake3 hash) into the token sequence so that the radix tree can
+        distinguish blocks belonging to different images/videos.
 
         When *start*/*end* are given, only the slice ``tokens[start:end]`` is
         materialized and returned. This avoids re-augmenting the full prompt

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -90,13 +90,10 @@ class Role:
 
 
 class _MmRunMetadata(NamedTuple):
-    item_run_cu_seqlen: torch.Tensor
     run_positions: torch.Tensor
-    run_lengths: torch.Tensor
     run_ends: torch.Tensor
     run_item_indices: torch.Tensor
     run_item_offsets: torch.Tensor
-    item_lengths: torch.Tensor
 
 
 def _hash_to_digest(hash_ints: Sequence[int]) -> bytes:
@@ -113,7 +110,7 @@ def _as_int64_cpu_tensor(values: Sequence[int] | torch.Tensor) -> torch.Tensor:
 
 
 def _resolve_multimodal_run_metadata(
-        req: LlmRequest, item_count: int) -> Optional[_MmRunMetadata]:
+        req: LlmRequest) -> Optional[_MmRunMetadata]:
     # NOTE: the following optional fields help in exact mm token position mixing in blockhash key generation
     item_run_cu_seqlen = getattr(req, "multimodal_item_run_cu_seqlen", None)
     run_positions = getattr(req, "multimodal_run_positions", None)
@@ -137,37 +134,19 @@ def _resolve_multimodal_run_metadata(
     cumulative_run_lengths = torch.cat(
         (torch.zeros(1, dtype=torch.int64), torch.cumsum(run_lengths, dim=0)))
     item_starts = item_run_cu_seqlen[:-1]
-    item_ends = item_run_cu_seqlen[1:]
-    item_lengths = cumulative_run_lengths[item_ends] - cumulative_run_lengths[
-        item_starts]
     run_item_indices = torch.repeat_interleave(
-        torch.arange(item_count, dtype=torch.int64), item_run_counts)
+        torch.arange(item_run_counts.numel(), dtype=torch.int64),
+        item_run_counts)
     run_item_offsets = (cumulative_run_lengths[:-1] -
                         cumulative_run_lengths[item_starts][run_item_indices])
     run_ends = run_positions + run_lengths
 
     return _MmRunMetadata(
-        item_run_cu_seqlen=item_run_cu_seqlen,
         run_positions=run_positions,
-        run_lengths=run_lengths,
         run_ends=run_ends,
         run_item_indices=run_item_indices,
         run_item_offsets=run_item_offsets,
-        item_lengths=item_lengths,
     )
-
-
-def _copy_token_spans(result: list[TokenIdExt],
-                      source_tokens: Sequence[TokenIdExt],
-                      result_offsets: torch.Tensor,
-                      source_offsets: torch.Tensor,
-                      lengths: torch.Tensor) -> None:
-    for result_offset, source_offset, length in zip(result_offsets.tolist(),
-                                                    source_offsets.tolist(),
-                                                    lengths.tolist(),
-                                                    strict=True):
-        result[result_offset:result_offset +
-               length] = source_tokens[source_offset:source_offset + length]
 
 
 def _augment_tokens_with_mm_run_metadata(vocab_size: int,
@@ -181,29 +160,31 @@ def _augment_tokens_with_mm_run_metadata(vocab_size: int,
     if overlap_run_indices.numel() == 0:
         return result
 
-    overlap_item_indices = torch.unique_consecutive(
-        metadata.run_item_indices[overlap_run_indices])
+    overlap_run_item_indices = metadata.run_item_indices[overlap_run_indices]
+    overlap_item_indices = torch.unique_consecutive(overlap_run_item_indices)
     for item_idx in overlap_item_indices.tolist():
-        item_run_start = metadata.item_run_cu_seqlen[item_idx].item()
-        item_run_end = metadata.item_run_cu_seqlen[item_idx + 1].item()
-        item_overlap_run_indices = overlap_run_indices[
-            (overlap_run_indices >= item_run_start)
-            & (overlap_run_indices < item_run_end)]
+        item_overlap_run_indices = overlap_run_indices[overlap_run_item_indices
+                                                       == item_idx]
 
-        mm_tokens = gen_multi_modal_tokens(
-            vocab_size, _hash_to_digest(multimodal_hashes[item_idx]),
-            metadata.item_lengths[item_idx].item())
+        digest = _hash_to_digest(multimodal_hashes[item_idx])
         overlap_starts = torch.clamp(
             metadata.run_positions[item_overlap_run_indices], min=start)
         overlap_ends = torch.clamp(metadata.run_ends[item_overlap_run_indices],
                                    max=end)
-        source_offsets = (metadata.run_item_offsets[item_overlap_run_indices] +
-                          overlap_starts -
-                          metadata.run_positions[item_overlap_run_indices])
+        token_offsets = (metadata.run_item_offsets[item_overlap_run_indices] +
+                         overlap_starts -
+                         metadata.run_positions[item_overlap_run_indices])
         result_offsets = overlap_starts - start
         lengths = overlap_ends - overlap_starts
-        _copy_token_spans(result, mm_tokens, result_offsets, source_offsets,
-                          lengths)
+        for result_offset, token_offset, length in zip(result_offsets.tolist(),
+                                                       token_offsets.tolist(),
+                                                       lengths.tolist(),
+                                                       strict=True):
+            result[result_offset:result_offset +
+                   length] = gen_multi_modal_tokens(vocab_size,
+                                                    digest,
+                                                    length,
+                                                    token_offset=token_offset)
 
     return result
 
@@ -220,29 +201,23 @@ def _augment_tokens_with_contiguous_mm_metadata(
     positions = _as_int64_cpu_tensor(multimodal_positions)
     lengths = _as_int64_cpu_tensor(multimodal_lengths)
 
-    if positions.ndim != 1 or lengths.ndim != 1 or positions.numel() != len(
-            multimodal_hashes) or positions.numel() != lengths.numel():
-        logger.warning(
-            "Invalid multimodal metadata shape; skipping multimodal token augmentation for block reuse"
-        )
-        return result
-
     item_ends = positions + lengths
     overlap_mask = (item_ends > start) & (positions < end)
     overlap_item_indices = torch.nonzero(overlap_mask).flatten()
     for item_idx in overlap_item_indices.tolist():
         pos = positions[item_idx].item()
         length = lengths[item_idx].item()
-        mm_tokens = gen_multi_modal_tokens(
-            vocab_size, _hash_to_digest(multimodal_hashes[item_idx]), length)
         overlap_start = max(pos, start)
         overlap_end = min(pos + length, end)
         source_offset = overlap_start - pos
         result_offset = overlap_start - start
         overlap_length = overlap_end - overlap_start
         result[result_offset:result_offset +
-               overlap_length] = mm_tokens[source_offset:source_offset +
-                                           overlap_length]
+               overlap_length] = gen_multi_modal_tokens(
+                   vocab_size,
+                   _hash_to_digest(multimodal_hashes[item_idx]),
+                   overlap_length,
+                   token_offset=source_offset)
 
     return result
 
@@ -2779,8 +2754,7 @@ class KVCacheManagerV2(BaseResourceManager):
             return tokens[start:end] if is_sliced else tokens
 
         result: list[TokenIdExt] = list(tokens[start:end])
-        run_metadata = _resolve_multimodal_run_metadata(
-            req, len(req.multimodal_hashes))
+        run_metadata = _resolve_multimodal_run_metadata(req)
         if run_metadata is not None:
             return _augment_tokens_with_mm_run_metadata(self.vocab_size, result,
                                                         req.multimodal_hashes,

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -458,8 +458,8 @@ class BaseWorker(GenerationExecutor):
                     multimodal_input.multimodal_lengths,
                     multimodal_uuids=request.multimodal_params.multimodal_input.
                     multimodal_uuids,
-                    multimodal_item_run_cu_seqlen=request.multimodal_params.
-                    multimodal_input.multimodal_item_run_cu_seqlen,
+                    multimodal_item_run_cu_offsets=request.multimodal_params.
+                    multimodal_input.multimodal_item_run_cu_offsets,
                     multimodal_run_positions=request.multimodal_params.
                     multimodal_input.multimodal_run_positions,
                     multimodal_run_lengths=request.multimodal_params.

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -457,7 +457,13 @@ class BaseWorker(GenerationExecutor):
                     multimodal_lengths=request.multimodal_params.
                     multimodal_input.multimodal_lengths,
                     multimodal_uuids=request.multimodal_params.multimodal_input.
-                    multimodal_uuids)
+                    multimodal_uuids,
+                    multimodal_item_run_cu_seqlen=request.multimodal_params.
+                    multimodal_input.multimodal_item_run_cu_seqlen,
+                    multimodal_run_positions=request.multimodal_params.
+                    multimodal_input.multimodal_run_positions,
+                    multimodal_run_lengths=request.multimodal_params.
+                    multimodal_input.multimodal_run_lengths)
             # NOTE: Setting to None here to avoid sending multimodal_input again through the 'py_multimodal_data' field
             request.multimodal_params.multimodal_input = None
 

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -16,6 +16,7 @@ from tensorrt_llm.logger import logger
 
 # Default hasher
 default_hasher = blake3
+_INT32_MAX = 2_147_483_647
 
 
 def strip_mm_data_for_generation(mm_data: Dict[str, Any]) -> None:
@@ -86,12 +87,12 @@ class MultimodalInput:
     returned in KV cache events.
     """
 
-    multimodal_item_run_cu_seqlen: Optional[List[int]] = None
-    """Optional prefix sum over the flat multimodal run arrays.
+    multimodal_item_run_cu_offsets: Optional[List[int]] = None
+    """Optional offsets into the flat multimodal run arrays.
 
     Length is ``len(multimodal_hashes) + 1``. Runs for item ``i`` live in
-    ``multimodal_run_positions[cu[i]:cu[i + 1]]`` and the matching slice of
-    ``multimodal_run_lengths``.
+    ``multimodal_run_positions[offsets[i]:offsets[i + 1]]`` and the matching
+    slice of ``multimodal_run_lengths``.
     """
 
     multimodal_run_positions: Optional[List[int]] = None
@@ -149,7 +150,7 @@ class MultimodalInput:
 
     def _validate_multimodal_runs(self) -> None:
         run_fields = (
-            self.multimodal_item_run_cu_seqlen,
+            self.multimodal_item_run_cu_offsets,
             self.multimodal_run_positions,
             self.multimodal_run_lengths,
         )
@@ -157,33 +158,33 @@ class MultimodalInput:
             return
         if any(field is None for field in run_fields):
             raise ValueError(
-                "multimodal_item_run_cu_seqlen, multimodal_run_positions, "
+                "multimodal_item_run_cu_offsets, multimodal_run_positions, "
                 "and multimodal_run_lengths must be provided together")
 
-        assert self.multimodal_item_run_cu_seqlen is not None
+        assert self.multimodal_item_run_cu_offsets is not None
         assert self.multimodal_run_positions is not None
         assert self.multimodal_run_lengths is not None
 
-        if len(self.multimodal_item_run_cu_seqlen) != len(
+        if len(self.multimodal_item_run_cu_offsets) != len(
                 self.multimodal_hashes) + 1:
-            raise ValueError("multimodal_item_run_cu_seqlen length must be "
+            raise ValueError("multimodal_item_run_cu_offsets length must be "
                              "len(multimodal_hashes) + 1")
-        if self.multimodal_item_run_cu_seqlen[0] != 0:
-            raise ValueError("multimodal_item_run_cu_seqlen must start at 0")
+        if self.multimodal_item_run_cu_offsets[0] != 0:
+            raise ValueError("multimodal_item_run_cu_offsets must start at 0")
         if len(self.multimodal_run_positions) != len(
                 self.multimodal_run_lengths):
             raise ValueError(
                 "multimodal_run_positions and multimodal_run_lengths must "
                 "have the same length")
-        if self.multimodal_item_run_cu_seqlen[-1] != len(
+        if self.multimodal_item_run_cu_offsets[-1] != len(
                 self.multimodal_run_positions):
             raise ValueError(
-                "multimodal_item_run_cu_seqlen[-1] must equal the number of "
+                "multimodal_item_run_cu_offsets[-1] must equal the number of "
                 "flat multimodal runs")
 
         for field_name, values in (
-            ("multimodal_item_run_cu_seqlen",
-             self.multimodal_item_run_cu_seqlen),
+            ("multimodal_item_run_cu_offsets",
+             self.multimodal_item_run_cu_offsets),
             ("multimodal_run_positions", self.multimodal_run_positions),
             ("multimodal_run_lengths", self.multimodal_run_lengths),
         ):
@@ -191,20 +192,31 @@ class MultimodalInput:
                 raise TypeError(f"{field_name} must be a list")
             if not all(isinstance(x, int) for x in values):
                 raise TypeError(f"{field_name} must contain only integers")
+            if any(value > _INT32_MAX for value in values):
+                raise ValueError(f"{field_name} values must fit in int32")
 
-        if not all(self.multimodal_item_run_cu_seqlen[i] <=
-                   self.multimodal_item_run_cu_seqlen[i + 1]
-                   for i in range(len(self.multimodal_item_run_cu_seqlen) - 1)):
+        if not all(
+                self.multimodal_item_run_cu_offsets[i] <=
+                self.multimodal_item_run_cu_offsets[i + 1]
+                for i in range(len(self.multimodal_item_run_cu_offsets) - 1)):
             raise ValueError(
-                "multimodal_item_run_cu_seqlen must be non-decreasing")
+                "multimodal_item_run_cu_offsets must be non-decreasing")
         if any(pos < 0 for pos in self.multimodal_run_positions):
             raise ValueError("multimodal_run_positions must be non-negative")
         if any(length <= 0 for length in self.multimodal_run_lengths):
             raise ValueError("multimodal_run_lengths must be positive")
+        for run_idx, (position, length) in enumerate(
+                zip(self.multimodal_run_positions,
+                    self.multimodal_run_lengths)):
+            if position + length > _INT32_MAX:
+                raise ValueError(
+                    f"multimodal run {run_idx} end position exceeds int32 "
+                    f"range: position={position}, length={length}, "
+                    f"max={_INT32_MAX}")
 
         for item_idx, expected_length in enumerate(self.multimodal_lengths):
-            run_begin = self.multimodal_item_run_cu_seqlen[item_idx]
-            run_end = self.multimodal_item_run_cu_seqlen[item_idx + 1]
+            run_begin = self.multimodal_item_run_cu_offsets[item_idx]
+            run_end = self.multimodal_item_run_cu_offsets[item_idx + 1]
             actual_length = sum(self.multimodal_run_lengths[run_begin:run_end])
             if actual_length != expected_length:
                 raise ValueError(
@@ -226,7 +238,7 @@ class MultimodalInput:
         mm_positions: List[int],
         mm_lengths: List[int],
         mm_uuids: Optional[List[Optional[str]]] = None,
-        mm_item_run_cu_seqlen: Optional[List[int]] = None,
+        mm_item_run_cu_offsets: Optional[List[int]] = None,
         mm_run_positions: Optional[List[int]] = None,
         mm_run_lengths: Optional[List[int]] = None,
     ) -> 'MultimodalInput':
@@ -234,7 +246,7 @@ class MultimodalInput:
                    multimodal_positions=mm_positions,
                    multimodal_lengths=mm_lengths,
                    multimodal_uuids=mm_uuids,
-                   multimodal_item_run_cu_seqlen=mm_item_run_cu_seqlen,
+                   multimodal_item_run_cu_offsets=mm_item_run_cu_offsets,
                    multimodal_run_positions=mm_run_positions,
                    multimodal_run_lengths=mm_run_lengths)
 
@@ -1079,9 +1091,9 @@ def _find_mm_token_runs_from_mask(
     num_mm_tokens: List[int],
 ) -> Tuple[List[int], List[int], List[int]]:
     """Compute flat exact prompt token runs for each logical multimodal item."""
-    item_run_cu_seqlen = [0]
+    item_run_cu_offsets = [0]
     if not torch.any(mm_mask):
-        return item_run_cu_seqlen, [], []
+        return item_run_cu_offsets, [], []
 
     mm_positions = torch.where(mm_mask)[0]
     lengths_t = torch.tensor(num_mm_tokens)
@@ -1097,7 +1109,7 @@ def _find_mm_token_runs_from_mask(
         item_positions = mm_positions[offset:offset + item_length].tolist()
         offset += item_length
         if len(item_positions) == 0:
-            item_run_cu_seqlen.append(len(run_positions))
+            item_run_cu_offsets.append(len(run_positions))
             continue
 
         run_start = item_positions[0]
@@ -1115,9 +1127,9 @@ def _find_mm_token_runs_from_mask(
 
         run_positions.append(run_start)
         run_lengths.append(run_length)
-        item_run_cu_seqlen.append(len(run_positions))
+        item_run_cu_offsets.append(len(run_positions))
 
-    return item_run_cu_seqlen, run_positions, run_lengths
+    return item_run_cu_offsets, run_positions, run_lengths
 
 
 def validate_mm_inputs(prompt_token_ids: Union[torch.Tensor, List[int],

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -90,9 +90,10 @@ class MultimodalInput:
     multimodal_item_run_cu_offsets: Optional[List[int]] = None
     """Optional offsets into the flat multimodal run arrays.
 
-    Length is ``len(multimodal_hashes) + 1``. Runs for item ``i`` live in
-    ``multimodal_run_positions[offsets[i]:offsets[i + 1]]`` and the matching
-    slice of ``multimodal_run_lengths``.
+    "Cu" means cumulative: length is `len(multimodal_hashes) + 1`.
+    Runs for item `i` live in
+    `multimodal_run_positions[offsets[i]:offsets[i + 1]]` and the matching
+    slice of `multimodal_run_lengths`.
     """
 
     multimodal_run_positions: Optional[List[int]] = None
@@ -1091,6 +1092,7 @@ def _find_mm_token_runs_from_mask(
     num_mm_tokens: List[int],
 ) -> Tuple[List[int], List[int], List[int]]:
     """Compute flat exact prompt token runs for each logical multimodal item."""
+    # CSR offsets: item i owns flat runs [offsets[i], offsets[i + 1]).
     item_run_cu_offsets = [0]
     if not torch.any(mm_mask):
         return item_run_cu_offsets, [], []
@@ -1102,7 +1104,9 @@ def _find_mm_token_runs_from_mask(
         f"sum of per-unit lengths ({lengths_t.sum().item()}): "
         f"num_mm_tokens={num_mm_tokens}")
 
+    # Full-prompt start index for each emitted flat multimodal run.
     run_positions: List[int] = []
+    # Token count for each emitted flat multimodal run.
     run_lengths: List[int] = []
     offset = 0
     for item_length in num_mm_tokens:

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -16,7 +16,7 @@ from tensorrt_llm.logger import logger
 
 # Default hasher
 default_hasher = blake3
-_INT32_MAX = 2_147_483_647
+_INT32_MAX = 2**31 - 1
 
 
 def strip_mm_data_for_generation(mm_data: Dict[str, Any]) -> None:
@@ -132,6 +132,10 @@ class MultimodalInput:
                 f"Position and length arrays must match in size: "
                 f"positions={len(self.multimodal_positions)}, lengths={len(self.multimodal_lengths)}"
             )
+        if len(self.multimodal_hashes) != len(self.multimodal_positions):
+            raise ValueError(
+                "multimodal_hashes, multimodal_positions, and multimodal_lengths "
+                "must all have the same length")
 
         # Validate multimodal_uuids if provided
         if self.multimodal_uuids is not None:

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -86,6 +86,20 @@ class MultimodalInput:
     returned in KV cache events.
     """
 
+    multimodal_item_run_cu_seqlen: Optional[List[int]] = None
+    """Optional prefix sum over the flat multimodal run arrays.
+
+    Length is ``len(multimodal_hashes) + 1``. Runs for item ``i`` live in
+    ``multimodal_run_positions[cu[i]:cu[i + 1]]`` and the matching slice of
+    ``multimodal_run_lengths``.
+    """
+
+    multimodal_run_positions: Optional[List[int]] = None
+    """Optional prompt start position for each exact multimodal token run."""
+
+    multimodal_run_lengths: Optional[List[int]] = None
+    """Optional length for each exact multimodal token run."""
+
     def __post_init__(self):
         """Validate input data structure and consistency."""
         # Validate multimodal_hashes
@@ -131,6 +145,80 @@ class MultimodalInput:
                         f"multimodal_uuids[{i}] must be a string or None, got {type(uuid)}"
                     )
 
+        self._validate_multimodal_runs()
+
+    def _validate_multimodal_runs(self) -> None:
+        run_fields = (
+            self.multimodal_item_run_cu_seqlen,
+            self.multimodal_run_positions,
+            self.multimodal_run_lengths,
+        )
+        if all(field is None for field in run_fields):
+            return
+        if any(field is None for field in run_fields):
+            raise ValueError(
+                "multimodal_item_run_cu_seqlen, multimodal_run_positions, "
+                "and multimodal_run_lengths must be provided together")
+
+        assert self.multimodal_item_run_cu_seqlen is not None
+        assert self.multimodal_run_positions is not None
+        assert self.multimodal_run_lengths is not None
+
+        if len(self.multimodal_item_run_cu_seqlen) != len(
+                self.multimodal_hashes) + 1:
+            raise ValueError("multimodal_item_run_cu_seqlen length must be "
+                             "len(multimodal_hashes) + 1")
+        if self.multimodal_item_run_cu_seqlen[0] != 0:
+            raise ValueError("multimodal_item_run_cu_seqlen must start at 0")
+        if len(self.multimodal_run_positions) != len(
+                self.multimodal_run_lengths):
+            raise ValueError(
+                "multimodal_run_positions and multimodal_run_lengths must "
+                "have the same length")
+        if self.multimodal_item_run_cu_seqlen[-1] != len(
+                self.multimodal_run_positions):
+            raise ValueError(
+                "multimodal_item_run_cu_seqlen[-1] must equal the number of "
+                "flat multimodal runs")
+
+        for field_name, values in (
+            ("multimodal_item_run_cu_seqlen",
+             self.multimodal_item_run_cu_seqlen),
+            ("multimodal_run_positions", self.multimodal_run_positions),
+            ("multimodal_run_lengths", self.multimodal_run_lengths),
+        ):
+            if not isinstance(values, list):
+                raise TypeError(f"{field_name} must be a list")
+            if not all(isinstance(x, int) for x in values):
+                raise TypeError(f"{field_name} must contain only integers")
+
+        if not all(self.multimodal_item_run_cu_seqlen[i] <=
+                   self.multimodal_item_run_cu_seqlen[i + 1]
+                   for i in range(len(self.multimodal_item_run_cu_seqlen) - 1)):
+            raise ValueError(
+                "multimodal_item_run_cu_seqlen must be non-decreasing")
+        if any(pos < 0 for pos in self.multimodal_run_positions):
+            raise ValueError("multimodal_run_positions must be non-negative")
+        if any(length <= 0 for length in self.multimodal_run_lengths):
+            raise ValueError("multimodal_run_lengths must be positive")
+
+        for item_idx, expected_length in enumerate(self.multimodal_lengths):
+            run_begin = self.multimodal_item_run_cu_seqlen[item_idx]
+            run_end = self.multimodal_item_run_cu_seqlen[item_idx + 1]
+            actual_length = sum(self.multimodal_run_lengths[run_begin:run_end])
+            if actual_length != expected_length:
+                raise ValueError(
+                    f"multimodal run lengths for item {item_idx} sum to "
+                    f"{actual_length}, expected {expected_length}")
+            item_positions = self.multimodal_run_positions[run_begin:run_end]
+            item_lengths = self.multimodal_run_lengths[run_begin:run_end]
+            for prev_pos, prev_len, pos in zip(item_positions, item_lengths,
+                                               item_positions[1:]):
+                if pos < prev_pos + prev_len:
+                    raise ValueError(
+                        "multimodal runs must be ordered and non-overlapping "
+                        "within each item")
+
     @classmethod
     def from_components(
         cls,
@@ -138,11 +226,17 @@ class MultimodalInput:
         mm_positions: List[int],
         mm_lengths: List[int],
         mm_uuids: Optional[List[Optional[str]]] = None,
+        mm_item_run_cu_seqlen: Optional[List[int]] = None,
+        mm_run_positions: Optional[List[int]] = None,
+        mm_run_lengths: Optional[List[int]] = None,
     ) -> 'MultimodalInput':
         return cls(multimodal_hashes=mm_hashes,
                    multimodal_positions=mm_positions,
                    multimodal_lengths=mm_lengths,
-                   multimodal_uuids=mm_uuids)
+                   multimodal_uuids=mm_uuids,
+                   multimodal_item_run_cu_seqlen=mm_item_run_cu_seqlen,
+                   multimodal_run_positions=mm_run_positions,
+                   multimodal_run_lengths=mm_run_lengths)
 
     def to_tensor(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Convert data to tensors"""
@@ -978,6 +1072,52 @@ def _find_mm_token_start_pos_from_masks(
     start_positions = mm_positions[offsets].tolist()
 
     return start_positions, start_special_token_positions
+
+
+def _find_mm_token_runs_from_mask(
+    mm_mask: torch.Tensor,
+    num_mm_tokens: List[int],
+) -> Tuple[List[int], List[int], List[int]]:
+    """Compute flat exact prompt token runs for each logical multimodal item."""
+    item_run_cu_seqlen = [0]
+    if not torch.any(mm_mask):
+        return item_run_cu_seqlen, [], []
+
+    mm_positions = torch.where(mm_mask)[0]
+    lengths_t = torch.tensor(num_mm_tokens)
+    assert mm_positions.numel() == lengths_t.sum().item(), (
+        f"Number of multimodal tokens ({mm_positions.numel()}) does not match "
+        f"sum of per-unit lengths ({lengths_t.sum().item()}): "
+        f"num_mm_tokens={num_mm_tokens}")
+
+    run_positions: List[int] = []
+    run_lengths: List[int] = []
+    offset = 0
+    for item_length in num_mm_tokens:
+        item_positions = mm_positions[offset:offset + item_length].tolist()
+        offset += item_length
+        if len(item_positions) == 0:
+            item_run_cu_seqlen.append(len(run_positions))
+            continue
+
+        run_start = item_positions[0]
+        previous_position = item_positions[0]
+        run_length = 1
+        for position in item_positions[1:]:
+            if position == previous_position + 1:
+                run_length += 1
+            else:
+                run_positions.append(run_start)
+                run_lengths.append(run_length)
+                run_start = position
+                run_length = 1
+            previous_position = position
+
+        run_positions.append(run_start)
+        run_lengths.append(run_length)
+        item_run_cu_seqlen.append(len(run_positions))
+
+    return item_run_cu_seqlen, run_positions, run_lengths
 
 
 def validate_mm_inputs(prompt_token_ids: Union[torch.Tensor, List[int],

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -1017,7 +1017,7 @@ def create_input_processor_with_hash(
         input_ids_tensor = _as_cpu_tensor(prompt_token_ids)
         if input_ids_tensor.numel() == 0:
             start_positions, start_special_token_positions = [], []
-            item_run_cu_seqlen, run_positions, run_lengths = [0], [], []
+            item_run_cu_offsets, run_positions, run_lengths = [0], [], []
         else:
             mm_mask, embed_mask, special_mask = _compute_mm_masks(
                 input_ids_tensor,
@@ -1031,7 +1031,7 @@ def create_input_processor_with_hash(
             start_positions, start_special_token_positions = (
                 _find_mm_token_start_pos_from_masks(mm_mask, special_mask,
                                                     num_mm_tokens))
-            item_run_cu_seqlen, run_positions, run_lengths = (
+            item_run_cu_offsets, run_positions, run_lengths = (
                 _find_mm_token_runs_from_mask(mm_mask, num_mm_tokens))
         # Store special token offsets if available
         if len(start_special_token_positions
@@ -1048,7 +1048,7 @@ def create_input_processor_with_hash(
         extra_processed_inputs[
             "multimodal_input"] = MultimodalInput.from_components(
                 mm_hashes_int32, start_positions, num_mm_tokens, mm_uuid_list,
-                item_run_cu_seqlen, run_positions, run_lengths)
+                item_run_cu_offsets, run_positions, run_lengths)
         return prompt_token_ids, extra_processed_inputs
 
     def process_tokenized_prompt_maybe_hash(

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -20,6 +20,7 @@ from ..sampling_params import SamplingParams
 from .content_format import ContentFormat
 from .data import TextPrompt
 from .multimodal import (MultimodalInput, _as_cpu_tensor, _compute_mm_masks,
+                         _find_mm_token_runs_from_mask,
                          _find_mm_token_start_pos_from_masks, apply_mm_hashes,
                          default_hasher, find_mm_token_lengths,
                          hexdigest_to_int32, validate_mm_inputs)
@@ -1016,6 +1017,7 @@ def create_input_processor_with_hash(
         input_ids_tensor = _as_cpu_tensor(prompt_token_ids)
         if input_ids_tensor.numel() == 0:
             start_positions, start_special_token_positions = [], []
+            item_run_cu_seqlen, run_positions, run_lengths = [0], [], []
         else:
             mm_mask, embed_mask, special_mask = _compute_mm_masks(
                 input_ids_tensor,
@@ -1029,6 +1031,8 @@ def create_input_processor_with_hash(
             start_positions, start_special_token_positions = (
                 _find_mm_token_start_pos_from_masks(mm_mask, special_mask,
                                                     num_mm_tokens))
+            item_run_cu_seqlen, run_positions, run_lengths = (
+                _find_mm_token_runs_from_mask(mm_mask, num_mm_tokens))
         # Store special token offsets if available
         if len(start_special_token_positions
                ) > 0 and mm_special_token_ids is not None:
@@ -1043,7 +1047,8 @@ def create_input_processor_with_hash(
 
         extra_processed_inputs[
             "multimodal_input"] = MultimodalInput.from_components(
-                mm_hashes_int32, start_positions, num_mm_tokens, mm_uuid_list)
+                mm_hashes_int32, start_positions, num_mm_tokens, mm_uuid_list,
+                item_run_cu_seqlen, run_positions, run_lengths)
         return prompt_token_ids, extra_processed_inputs
 
     def process_tokenized_prompt_maybe_hash(

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from . import rawref
-from ._block_radix_tree import ReuseScope, gen_multi_modal_tokens
+from ._block_radix_tree import ReuseScope, gen_multimodal_cache_key_tokens
 from ._common import (
     NDEBUG,
     CacheLevel,
@@ -80,7 +80,7 @@ __all__ = [
     "BatchDesc",
     "CacheTierConfig",
     "KVCacheDesc",
-    "gen_multi_modal_tokens",
+    "gen_multimodal_cache_key_tokens",
     "rawref",
     "AggregatedPageDesc",
     "BufferId",

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
@@ -149,7 +149,10 @@ class KVCacheManagerConfig:
 
 # From _block_radix_tree.py
 def gen_multi_modal_tokens(
-    id_offset: int, multi_modal_data_digest: bytes, num_tokens: int
+    id_offset: int,
+    multi_modal_data_digest: bytes,
+    num_tokens: int,
+    token_offset: int = 0,
 ) -> list[TokenIdExt]: ...
 
 # From _core/_kv_cache.py

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
@@ -148,7 +148,7 @@ class KVCacheManagerConfig:
     enable_swa_scratch_reuse: bool = False
 
 # From _block_radix_tree.py
-def gen_multi_modal_tokens(
+def gen_multimodal_cache_key_tokens(
     id_offset: int,
     multi_modal_data_digest: bytes,
     num_tokens: int,

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_block_radix_tree.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_block_radix_tree.py
@@ -51,16 +51,15 @@ class ReuseScope(NamedTuple):
 
 
 # id_offset is usually vocab_size
-def gen_multi_modal_tokens(
+def gen_multimodal_cache_key_tokens(
     id_offset: int, multi_modal_data_digest: bytes, num_tokens: int, token_offset: int = 0
 ) -> list[TokenIdExt]:
+    """Create synthetic tokens used only when building multimodal KV-cache keys.
+
+    Item-local token 0 carries the content digest; later offsets use deterministic IDs above the vocab.
+    """
     assert num_tokens > 0
     assert token_offset >= 0
-    # Alternatively, we could also use (multi_modal_data_digest + i.to_bytes(8, 'little')) or its hash
-    # digest as token id.
-    # The implementation below is faster and also works because KV cache reuse of a token is with a
-    # precondition that all previous tokens also match. So only the first multi-modal token id needs to
-    # be unique.
     return [
         multi_modal_data_digest if token_offset + i == 0 else TokenId(id_offset + token_offset + i)
         for i in range(num_tokens)

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_block_radix_tree.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_block_radix_tree.py
@@ -52,16 +52,18 @@ class ReuseScope(NamedTuple):
 
 # id_offset is usually vocab_size
 def gen_multi_modal_tokens(
-    id_offset: int, multi_modal_data_digest: bytes, num_tokens: int
+    id_offset: int, multi_modal_data_digest: bytes, num_tokens: int, token_offset: int = 0
 ) -> list[TokenIdExt]:
     assert num_tokens > 0
+    assert token_offset >= 0
     # Alternatively, we could also use (multi_modal_data_digest + i.to_bytes(8, 'little')) or its hash
     # digest as token id.
     # The implementation below is faster and also works because KV cache reuse of a token is with a
     # precondition that all previous tokens also match. So only the first multi-modal token id needs to
     # be unique.
     return [
-        multi_modal_data_digest if i == 0 else TokenId(id_offset + i) for i in range(num_tokens)
+        multi_modal_data_digest if token_offset + i == 0 else TokenId(id_offset + token_offset + i)
+        for i in range(num_tokens)
     ]
 
 

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
@@ -35,7 +35,7 @@ def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
         multimodal_hashes=[_HASH_INTS],
         multimodal_positions=[1],
         multimodal_lengths=[4],
-        multimodal_item_run_cu_seqlen=[0, 2],
+        multimodal_item_run_cu_offsets=[0, 2],
         multimodal_run_positions=[1, 8],
         multimodal_run_lengths=[2, 2],
     )
@@ -66,7 +66,7 @@ def test_augment_tokens_for_block_reuse_skips_out_of_slice_runs(monkeypatch):
         multimodal_hashes=[_HASH_INTS],
         multimodal_positions=[1],
         multimodal_lengths=[4],
-        multimodal_item_run_cu_seqlen=[0, 2],
+        multimodal_item_run_cu_offsets=[0, 2],
         multimodal_run_positions=[1, 8],
         multimodal_run_lengths=[2, 2],
     )
@@ -83,7 +83,7 @@ def test_augment_tokens_for_block_reuse_rejects_incomplete_run_metadata():
         multimodal_hashes=[_HASH_INTS],
         multimodal_positions=[1],
         multimodal_lengths=[4],
-        multimodal_item_run_cu_seqlen=[0, 1],
+        multimodal_item_run_cu_offsets=[0, 1],
     )
 
     tokens = list(range(8))

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
@@ -4,6 +4,7 @@
 from types import SimpleNamespace
 
 import pytest
+import torch
 
 import tensorrt_llm._torch.pyexecutor.resource_manager as resource_manager
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManagerV2
@@ -84,11 +85,19 @@ def test_augment_tokens_for_block_reuse_rejects_incomplete_run_metadata():
         multimodal_positions=[1],
         multimodal_lengths=[4],
         multimodal_item_run_cu_offsets=[0, 1],
+        multimodal_run_positions=None,
+        multimodal_run_lengths=None,
     )
 
     tokens = list(range(8))
     with pytest.raises(ValueError, match="provided together"):
         KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=1, end=3)
+
+
+def test_block_reuse_metadata_rejects_non_cpu_tensors():
+    values = torch.empty(1, dtype=torch.int64, device="meta")
+    with pytest.raises(ValueError, match="must be CPU-resident"):
+        resource_manager._ensure_int64_cpu_tensor(values)
 
 
 def test_augment_tokens_for_block_reuse_keeps_contiguous_metadata_path():
@@ -101,6 +110,9 @@ def test_augment_tokens_for_block_reuse_keeps_contiguous_metadata_path():
         multimodal_hashes=[_HASH_INTS],
         multimodal_positions=[2],
         multimodal_lengths=[3],
+        multimodal_item_run_cu_offsets=None,
+        multimodal_run_positions=None,
+        multimodal_run_lengths=None,
     )
 
     tokens = list(range(8))

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
@@ -7,16 +7,18 @@ import pytest
 
 import tensorrt_llm._torch.pyexecutor.resource_manager as resource_manager
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManagerV2
-from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import gen_multi_modal_tokens
+from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import (
+    gen_multimodal_cache_key_tokens,
+)
 
 _HASH_INTS = [1, 2, 3, 4, 5, 6, 7, 8]
 
 
-def test_gen_multi_modal_tokens_uses_token_offset():
+def test_gen_multimodal_cache_key_tokens_uses_token_offset():
     vocab_size = 1000
     digest = b"".join(v.to_bytes(4, "big", signed=True) for v in _HASH_INTS)
 
-    assert gen_multi_modal_tokens(vocab_size, digest, 3, token_offset=2) == [
+    assert gen_multimodal_cache_key_tokens(vocab_size, digest, 3, token_offset=2) == [
         vocab_size + 2,
         vocab_size + 3,
         vocab_size + 4,
@@ -26,7 +28,7 @@ def test_gen_multi_modal_tokens_uses_token_offset():
 def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
     vocab_size = 1000
     digest = b"".join(v.to_bytes(4, "big", signed=True) for v in _HASH_INTS)
-    mm_tokens = gen_multi_modal_tokens(vocab_size, digest, 4)
+    mm_tokens = gen_multimodal_cache_key_tokens(vocab_size, digest, 4)
 
     manager = SimpleNamespace(vocab_size=vocab_size)
     req = SimpleNamespace(
@@ -51,11 +53,13 @@ def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
 def test_augment_tokens_for_block_reuse_skips_out_of_slice_runs(monkeypatch):
     calls = []
 
-    def fake_gen_multi_modal_tokens(vocab_size, digest, num_tokens, token_offset=0):
+    def fake_gen_multimodal_cache_key_tokens(vocab_size, digest, num_tokens, token_offset=0):
         calls.append((vocab_size, digest, num_tokens, token_offset))
         return [digest, *range(vocab_size + 1, vocab_size + num_tokens)]
 
-    monkeypatch.setattr(resource_manager, "gen_multi_modal_tokens", fake_gen_multi_modal_tokens)
+    monkeypatch.setattr(
+        resource_manager, "gen_multimodal_cache_key_tokens", fake_gen_multimodal_cache_key_tokens
+    )
 
     manager = SimpleNamespace(vocab_size=1000)
     req = SimpleNamespace(
@@ -90,7 +94,7 @@ def test_augment_tokens_for_block_reuse_rejects_incomplete_run_metadata():
 def test_augment_tokens_for_block_reuse_keeps_contiguous_metadata_path():
     vocab_size = 1000
     digest = b"".join(v.to_bytes(4, "big", signed=True) for v in _HASH_INTS)
-    mm_tokens = gen_multi_modal_tokens(vocab_size, digest, 3)
+    mm_tokens = gen_multimodal_cache_key_tokens(vocab_size, digest, 3)
 
     manager = SimpleNamespace(vocab_size=vocab_size)
     req = SimpleNamespace(

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
@@ -12,6 +12,17 @@ from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import gen_multi
 _HASH_INTS = [1, 2, 3, 4, 5, 6, 7, 8]
 
 
+def test_gen_multi_modal_tokens_uses_token_offset():
+    vocab_size = 1000
+    digest = b"".join(v.to_bytes(4, "big", signed=True) for v in _HASH_INTS)
+
+    assert gen_multi_modal_tokens(vocab_size, digest, 3, token_offset=2) == [
+        vocab_size + 2,
+        vocab_size + 3,
+        vocab_size + 4,
+    ]
+
+
 def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
     vocab_size = 1000
     digest = b"".join(v.to_bytes(4, "big", signed=True) for v in _HASH_INTS)
@@ -40,8 +51,8 @@ def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
 def test_augment_tokens_for_block_reuse_skips_out_of_slice_runs(monkeypatch):
     calls = []
 
-    def fake_gen_multi_modal_tokens(vocab_size, digest, num_tokens):
-        calls.append((vocab_size, digest, num_tokens))
+    def fake_gen_multi_modal_tokens(vocab_size, digest, num_tokens, token_offset=0):
+        calls.append((vocab_size, digest, num_tokens, token_offset))
         return [digest, *range(vocab_size + 1, vocab_size + num_tokens)]
 
     monkeypatch.setattr(resource_manager, "gen_multi_modal_tokens", fake_gen_multi_modal_tokens)

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
@@ -3,19 +3,23 @@
 
 from types import SimpleNamespace
 
+import pytest
+
+import tensorrt_llm._torch.pyexecutor.resource_manager as resource_manager
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManagerV2
 from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import gen_multi_modal_tokens
+
+_HASH_INTS = [1, 2, 3, 4, 5, 6, 7, 8]
 
 
 def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
     vocab_size = 1000
-    hash_ints = [1, 2, 3, 4, 5, 6, 7, 8]
-    digest = b"".join(v.to_bytes(4, "big", signed=True) for v in hash_ints)
+    digest = b"".join(v.to_bytes(4, "big", signed=True) for v in _HASH_INTS)
     mm_tokens = gen_multi_modal_tokens(vocab_size, digest, 4)
 
     manager = SimpleNamespace(vocab_size=vocab_size)
     req = SimpleNamespace(
-        multimodal_hashes=[hash_ints],
+        multimodal_hashes=[_HASH_INTS],
         multimodal_positions=[1],
         multimodal_lengths=[4],
         multimodal_item_run_cu_seqlen=[0, 2],
@@ -31,3 +35,59 @@ def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
 
     sliced = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=7, end=10)
     assert sliced == [tokens[7], mm_tokens[2], mm_tokens[3]]
+
+
+def test_augment_tokens_for_block_reuse_skips_out_of_slice_runs(monkeypatch):
+    calls = []
+
+    def fake_gen_multi_modal_tokens(vocab_size, digest, num_tokens):
+        calls.append((vocab_size, digest, num_tokens))
+        return [digest, *range(vocab_size + 1, vocab_size + num_tokens)]
+
+    monkeypatch.setattr(resource_manager, "gen_multi_modal_tokens", fake_gen_multi_modal_tokens)
+
+    manager = SimpleNamespace(vocab_size=1000)
+    req = SimpleNamespace(
+        multimodal_hashes=[_HASH_INTS],
+        multimodal_positions=[1],
+        multimodal_lengths=[4],
+        multimodal_item_run_cu_seqlen=[0, 2],
+        multimodal_run_positions=[1, 8],
+        multimodal_run_lengths=[2, 2],
+    )
+
+    tokens = list(range(12))
+    sliced = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=3, end=8)
+    assert sliced == tokens[3:8]
+    assert calls == []
+
+
+def test_augment_tokens_for_block_reuse_rejects_incomplete_run_metadata():
+    manager = SimpleNamespace(vocab_size=1000)
+    req = SimpleNamespace(
+        multimodal_hashes=[_HASH_INTS],
+        multimodal_positions=[1],
+        multimodal_lengths=[4],
+        multimodal_item_run_cu_seqlen=[0, 1],
+    )
+
+    tokens = list(range(8))
+    with pytest.raises(ValueError, match="provided together"):
+        KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=1, end=3)
+
+
+def test_augment_tokens_for_block_reuse_keeps_contiguous_metadata_path():
+    vocab_size = 1000
+    digest = b"".join(v.to_bytes(4, "big", signed=True) for v in _HASH_INTS)
+    mm_tokens = gen_multi_modal_tokens(vocab_size, digest, 3)
+
+    manager = SimpleNamespace(vocab_size=vocab_size)
+    req = SimpleNamespace(
+        multimodal_hashes=[_HASH_INTS],
+        multimodal_positions=[2],
+        multimodal_lengths=[3],
+    )
+
+    tokens = list(range(8))
+    sliced = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=1, end=5)
+    assert sliced == [tokens[1], *mm_tokens]

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from types import SimpleNamespace
+
+from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManagerV2
+from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import gen_multi_modal_tokens
+
+
+def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
+    vocab_size = 1000
+    hash_ints = [1, 2, 3, 4, 5, 6, 7, 8]
+    digest = b"".join(v.to_bytes(4, "big", signed=True) for v in hash_ints)
+    mm_tokens = gen_multi_modal_tokens(vocab_size, digest, 4)
+
+    manager = SimpleNamespace(vocab_size=vocab_size)
+    req = SimpleNamespace(
+        multimodal_hashes=[hash_ints],
+        multimodal_positions=[1],
+        multimodal_lengths=[4],
+        multimodal_item_run_cu_seqlen=[0, 2],
+        multimodal_run_positions=[1, 8],
+        multimodal_run_lengths=[2, 2],
+    )
+
+    tokens = list(range(12))
+    augmented = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req)
+    assert augmented[1:3] == mm_tokens[0:2]
+    assert augmented[8:10] == mm_tokens[2:4]
+    assert augmented[3:8] == tokens[3:8]
+
+    sliced = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=7, end=10)
+    assert sliced == [tokens[7], mm_tokens[2], mm_tokens[3]]

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py
@@ -1,18 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
-from types import SimpleNamespace
-
 import pytest
 import torch
 
 import tensorrt_llm._torch.pyexecutor.resource_manager as resource_manager
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, SamplingConfig
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManagerV2
 from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import (
     gen_multimodal_cache_key_tokens,
 )
 
-_HASH_INTS = [1, 2, 3, 4, 5, 6, 7, 8]
+_HASH_INTS = (1, 2, 3, 4, 5, 6, 7, 8)
+_OTHER_HASH_INTS = (8, 7, 6, 5, 4, 3, 2, 1)
+
+
+def _make_manager(vocab_size: int):
+    manager = KVCacheManagerV2.__new__(KVCacheManagerV2)
+    manager.vocab_size = vocab_size
+    return manager
+
+
+def _make_request(tokens, **kwargs):
+    return LlmRequest(
+        request_id=0,
+        max_new_tokens=1,
+        input_tokens=tokens,
+        sampling_config=SamplingConfig(1),
+        is_streaming=False,
+        **kwargs,
+    )
 
 
 def test_gen_multimodal_cache_key_tokens_uses_token_offset():
@@ -31,8 +48,10 @@ def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
     digest = b"".join(v.to_bytes(4, "big", signed=True) for v in _HASH_INTS)
     mm_tokens = gen_multimodal_cache_key_tokens(vocab_size, digest, 4)
 
-    manager = SimpleNamespace(vocab_size=vocab_size)
-    req = SimpleNamespace(
+    tokens = list(range(12))
+    manager = _make_manager(vocab_size)
+    req = _make_request(
+        tokens,
         multimodal_hashes=[_HASH_INTS],
         multimodal_positions=[1],
         multimodal_lengths=[4],
@@ -41,7 +60,6 @@ def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
         multimodal_run_lengths=[2, 2],
     )
 
-    tokens = list(range(12))
     augmented = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req)
     assert augmented[1:3] == mm_tokens[0:2]
     assert augmented[8:10] == mm_tokens[2:4]
@@ -49,6 +67,37 @@ def test_augment_tokens_for_block_reuse_uses_exact_multimodal_runs():
 
     sliced = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=7, end=10)
     assert sliced == [tokens[7], mm_tokens[2], mm_tokens[3]]
+
+
+def test_augment_tokens_for_block_reuse_uses_two_item_exact_multimodal_runs():
+    vocab_size = 1000
+    digest_a = b"".join(v.to_bytes(4, "big", signed=True) for v in _HASH_INTS)
+    digest_b = b"".join(v.to_bytes(4, "big", signed=True) for v in _OTHER_HASH_INTS)
+    mm_tokens_a = gen_multimodal_cache_key_tokens(vocab_size, digest_a, 3)
+    mm_tokens_b = gen_multimodal_cache_key_tokens(vocab_size, digest_b, 3)
+
+    tokens = list(range(16))
+    manager = _make_manager(vocab_size)
+    req = _make_request(
+        tokens,
+        multimodal_hashes=[_HASH_INTS, _OTHER_HASH_INTS],
+        multimodal_positions=[1, 9],
+        multimodal_lengths=[3, 3],
+        multimodal_item_run_cu_offsets=[0, 2, 4],
+        multimodal_run_positions=[1, 6, 9, 12],
+        multimodal_run_lengths=[2, 1, 1, 2],
+    )
+
+    augmented = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req)
+    assert augmented[1:3] == mm_tokens_a[0:2]
+    assert augmented[6] == mm_tokens_a[2]
+    assert augmented[9] == mm_tokens_b[0]
+    assert augmented[12:14] == mm_tokens_b[1:3]
+    assert augmented[3:6] == tokens[3:6]
+    assert augmented[10:12] == tokens[10:12]
+
+    sliced = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=8, end=13)
+    assert sliced == [tokens[8], mm_tokens_b[0], tokens[10], tokens[11], mm_tokens_b[1]]
 
 
 def test_augment_tokens_for_block_reuse_skips_out_of_slice_runs(monkeypatch):
@@ -62,8 +111,10 @@ def test_augment_tokens_for_block_reuse_skips_out_of_slice_runs(monkeypatch):
         resource_manager, "gen_multimodal_cache_key_tokens", fake_gen_multimodal_cache_key_tokens
     )
 
-    manager = SimpleNamespace(vocab_size=1000)
-    req = SimpleNamespace(
+    tokens = list(range(12))
+    manager = _make_manager(1000)
+    req = _make_request(
+        tokens,
         multimodal_hashes=[_HASH_INTS],
         multimodal_positions=[1],
         multimodal_lengths=[4],
@@ -72,15 +123,16 @@ def test_augment_tokens_for_block_reuse_skips_out_of_slice_runs(monkeypatch):
         multimodal_run_lengths=[2, 2],
     )
 
-    tokens = list(range(12))
     sliced = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=3, end=8)
     assert sliced == tokens[3:8]
     assert calls == []
 
 
 def test_augment_tokens_for_block_reuse_rejects_incomplete_run_metadata():
-    manager = SimpleNamespace(vocab_size=1000)
-    req = SimpleNamespace(
+    tokens = list(range(8))
+    manager = _make_manager(1000)
+    req = _make_request(
+        tokens,
         multimodal_hashes=[_HASH_INTS],
         multimodal_positions=[1],
         multimodal_lengths=[4],
@@ -89,7 +141,6 @@ def test_augment_tokens_for_block_reuse_rejects_incomplete_run_metadata():
         multimodal_run_lengths=None,
     )
 
-    tokens = list(range(8))
     with pytest.raises(ValueError, match="provided together"):
         KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=1, end=3)
 
@@ -100,13 +151,22 @@ def test_block_reuse_metadata_rejects_non_cpu_tensors():
         resource_manager._ensure_int64_cpu_tensor(values)
 
 
+def test_hash_to_digest_rejects_malformed_hashes():
+    with pytest.raises(ValueError, match="Expected 8 int32 hash values"):
+        resource_manager._hash_to_digest([1, 2, 3])
+    with pytest.raises(ValueError, match="Expected multimodal hash values to be integers"):
+        resource_manager._hash_to_digest([*_HASH_INTS[:-1], "8"])
+
+
 def test_augment_tokens_for_block_reuse_keeps_contiguous_metadata_path():
     vocab_size = 1000
     digest = b"".join(v.to_bytes(4, "big", signed=True) for v in _HASH_INTS)
     mm_tokens = gen_multimodal_cache_key_tokens(vocab_size, digest, 3)
 
-    manager = SimpleNamespace(vocab_size=vocab_size)
-    req = SimpleNamespace(
+    tokens = list(range(8))
+    manager = _make_manager(vocab_size)
+    req = _make_request(
+        tokens,
         multimodal_hashes=[_HASH_INTS],
         multimodal_positions=[2],
         multimodal_lengths=[3],
@@ -115,6 +175,5 @@ def test_augment_tokens_for_block_reuse_keeps_contiguous_metadata_path():
         multimodal_run_lengths=None,
     )
 
-    tokens = list(range(8))
     sliced = KVCacheManagerV2._augment_tokens_for_block_reuse(manager, tokens, req, start=1, end=5)
     assert sliced == [tokens[1], *mm_tokens]

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -1016,7 +1016,7 @@ def test_multimodal_input():
     assert config.multimodal_lengths == multimodal_lengths
     # Default value for multimodal_uuids should be None
     assert config.multimodal_uuids is None
-    assert config.multimodal_item_run_cu_seqlen is None
+    assert config.multimodal_item_run_cu_offsets is None
     assert config.multimodal_run_positions is None
     assert config.multimodal_run_lengths is None
 
@@ -1055,7 +1055,7 @@ def test_multimodal_input_with_exact_run_buffers():
     multimodal_positions = [1, 8]
     multimodal_lengths = [3, 2]
     multimodal_uuids = ["item-a", None]
-    item_run_cu_seqlen = [0, 2, 3]
+    item_run_cu_offsets = [0, 2, 3]
     run_positions = [1, 5, 8]
     run_lengths = [2, 1, 2]
 
@@ -1064,7 +1064,7 @@ def test_multimodal_input_with_exact_run_buffers():
         multimodal_positions,
         multimodal_lengths,
         multimodal_uuids,
-        item_run_cu_seqlen,
+        item_run_cu_offsets,
         run_positions,
         run_lengths,
     )
@@ -1072,7 +1072,7 @@ def test_multimodal_input_with_exact_run_buffers():
     assert config.multimodal_positions == multimodal_positions
     assert config.multimodal_lengths == multimodal_lengths
     assert config.multimodal_uuids == multimodal_uuids
-    assert config.multimodal_item_run_cu_seqlen == item_run_cu_seqlen
+    assert config.multimodal_item_run_cu_offsets == item_run_cu_offsets
     assert config.multimodal_run_positions == run_positions
     assert config.multimodal_run_lengths == run_lengths
 
@@ -1095,11 +1095,11 @@ def test_multimodal_input_pickle_with_uuids():
     assert restored.multimodal_positions == multimodal_positions
     assert restored.multimodal_lengths == multimodal_lengths
     assert restored.multimodal_uuids == multimodal_uuids
-    assert restored.multimodal_item_run_cu_seqlen is None
+    assert restored.multimodal_item_run_cu_offsets is None
     assert restored.multimodal_run_positions is None
     assert restored.multimodal_run_lengths is None
 
-    item_run_cu_seqlen = [0, 2, 3]
+    item_run_cu_offsets = [0, 2, 3]
     run_positions = [10, 20, 100]
     run_lengths = [5, 45, 60]
     config_with_runs = trtllm.MultimodalInput(
@@ -1107,12 +1107,12 @@ def test_multimodal_input_pickle_with_uuids():
         multimodal_positions,
         multimodal_lengths,
         multimodal_uuids,
-        item_run_cu_seqlen,
+        item_run_cu_offsets,
         run_positions,
         run_lengths,
     )
     restored_with_runs = pickle.loads(pickle.dumps(config_with_runs))
-    assert restored_with_runs.multimodal_item_run_cu_seqlen == item_run_cu_seqlen
+    assert restored_with_runs.multimodal_item_run_cu_offsets == item_run_cu_offsets
     assert restored_with_runs.multimodal_run_positions == run_positions
     assert restored_with_runs.multimodal_run_lengths == run_lengths
 

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -1016,6 +1016,9 @@ def test_multimodal_input():
     assert config.multimodal_lengths == multimodal_lengths
     # Default value for multimodal_uuids should be None
     assert config.multimodal_uuids is None
+    assert config.multimodal_item_run_cu_seqlen is None
+    assert config.multimodal_run_positions is None
+    assert config.multimodal_run_lengths is None
 
 
 @pytest.mark.parametrize(
@@ -1046,6 +1049,34 @@ def test_multimodal_input_with_uuids(multimodal_uuids, expected_uuids):
     assert config.multimodal_uuids == expected_uuids
 
 
+def test_multimodal_input_with_exact_run_buffers():
+    """Test MultimodalInput with exact flat run buffers."""
+    multimodal_hashes = [[1, 2, 3, 4, 5, 6, 7, 8], [8, 7, 6, 5, 4, 3, 2, 1]]
+    multimodal_positions = [1, 8]
+    multimodal_lengths = [3, 2]
+    multimodal_uuids = ["item-a", None]
+    item_run_cu_seqlen = [0, 2, 3]
+    run_positions = [1, 5, 8]
+    run_lengths = [2, 1, 2]
+
+    config = trtllm.MultimodalInput(
+        multimodal_hashes,
+        multimodal_positions,
+        multimodal_lengths,
+        multimodal_uuids,
+        item_run_cu_seqlen,
+        run_positions,
+        run_lengths,
+    )
+    assert config.multimodal_hashes == multimodal_hashes
+    assert config.multimodal_positions == multimodal_positions
+    assert config.multimodal_lengths == multimodal_lengths
+    assert config.multimodal_uuids == multimodal_uuids
+    assert config.multimodal_item_run_cu_seqlen == item_run_cu_seqlen
+    assert config.multimodal_run_positions == run_positions
+    assert config.multimodal_run_lengths == run_lengths
+
+
 def test_multimodal_input_pickle_with_uuids():
     """Test pickling and unpickling of MultimodalInput with UUIDs."""
     multimodal_hashes = [[1, 2, 3, 4, 5, 6, 7, 8], [8, 7, 6, 5, 4, 3, 2, 1]]
@@ -1064,6 +1095,26 @@ def test_multimodal_input_pickle_with_uuids():
     assert restored.multimodal_positions == multimodal_positions
     assert restored.multimodal_lengths == multimodal_lengths
     assert restored.multimodal_uuids == multimodal_uuids
+    assert restored.multimodal_item_run_cu_seqlen is None
+    assert restored.multimodal_run_positions is None
+    assert restored.multimodal_run_lengths is None
+
+    item_run_cu_seqlen = [0, 2, 3]
+    run_positions = [10, 20, 100]
+    run_lengths = [5, 45, 60]
+    config_with_runs = trtllm.MultimodalInput(
+        multimodal_hashes,
+        multimodal_positions,
+        multimodal_lengths,
+        multimodal_uuids,
+        item_run_cu_seqlen,
+        run_positions,
+        run_lengths,
+    )
+    restored_with_runs = pickle.loads(pickle.dumps(config_with_runs))
+    assert restored_with_runs.multimodal_item_run_cu_seqlen == item_run_cu_seqlen
+    assert restored_with_runs.multimodal_run_positions == run_positions
+    assert restored_with_runs.multimodal_run_lengths == run_lengths
 
     # Test with None UUIDs
     config_no_uuids = trtllm.MultimodalInput(multimodal_hashes,

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -6,6 +6,7 @@ import time
 
 import numpy as np
 import pytest
+import torch
 from PIL import Image
 from utils.util import skip_single_gpu
 
@@ -16,8 +17,9 @@ from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._utils import KVCacheEventSerializer
 from tensorrt_llm.bindings.internal.testing import \
     simulate_prefill_completion_only_use_for_testing
-from tensorrt_llm.inputs.multimodal import apply_mm_hashes
-from tensorrt_llm.inputs.multimodal_data import AudioData, VideoData
+from tensorrt_llm.inputs.multimodal import (MultimodalInput, apply_mm_hashes,
+                                            _find_mm_token_runs_from_mask)
+from tensorrt_llm.inputs.utils import AudioData, VideoData
 from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.sampling_params import SamplingParams
@@ -476,11 +478,6 @@ def test_multimodal_input_from_components_with_uuids():
 
 def test_multimodal_input_exact_run_buffers():
     """Test optional exact run buffers on Python MultimodalInput."""
-    import torch
-
-    from tensorrt_llm.inputs.multimodal import (MultimodalInput,
-                                                _find_mm_token_runs_from_mask)
-
     mm_mask = torch.tensor(
         [False, True, True, False, False, True, False, False, True, True])
     item_run_cu_offsets, run_positions, run_lengths = _find_mm_token_runs_from_mask(
@@ -523,8 +520,6 @@ def test_multimodal_input_exact_run_buffers():
 
 
 def test_multimodal_input_rejects_exact_run_int32_overflow():
-    from tensorrt_llm.inputs.multimodal import MultimodalInput
-
     int32_max = 2_147_483_647
     with pytest.raises(ValueError, match="end position exceeds int32"):
         MultimodalInput(

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -20,7 +20,7 @@ from tensorrt_llm.bindings.internal.testing import \
 from tensorrt_llm.inputs.multimodal import (MultimodalInput,
                                             _find_mm_token_runs_from_mask,
                                             apply_mm_hashes)
-from tensorrt_llm.inputs.utils import AudioData, VideoData
+from tensorrt_llm.inputs.multimodal_data import AudioData, VideoData
 from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.sampling_params import SamplingParams
@@ -452,6 +452,13 @@ def test_multimodal_input_dataclass_uuid_validation():
                         multimodal_positions=[10],
                         multimodal_lengths=[50],
                         multimodal_uuids="not-a-list")
+
+
+def test_multimodal_input_dataclass_rejects_mismatched_item_arrays():
+    with pytest.raises(ValueError, match="must all have the same length"):
+        MultimodalInput(multimodal_hashes=[[1, 2, 3, 4, 5, 6, 7, 8]],
+                        multimodal_positions=[10, 100],
+                        multimodal_lengths=[50, 60])
 
 
 def test_multimodal_input_from_components_with_uuids():

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -474,6 +474,54 @@ def test_multimodal_input_from_components_with_uuids():
     assert mm_input_no_uuids.multimodal_uuids is None
 
 
+def test_multimodal_input_exact_run_buffers():
+    """Test optional exact run buffers on Python MultimodalInput."""
+    import torch
+
+    from tensorrt_llm.inputs.multimodal import (MultimodalInput,
+                                                _find_mm_token_runs_from_mask)
+
+    mm_mask = torch.tensor(
+        [False, True, True, False, False, True, False, False, True, True])
+    item_run_cu, run_positions, run_lengths = _find_mm_token_runs_from_mask(
+        mm_mask, [3, 2])
+
+    assert item_run_cu == [0, 2, 3]
+    assert run_positions == [1, 5, 8]
+    assert run_lengths == [2, 1, 2]
+
+    mm_input = MultimodalInput.from_components(
+        [[1, 2, 3, 4, 5, 6, 7, 8], [8, 7, 6, 5, 4, 3, 2, 1]],
+        [1, 8],
+        [3, 2],
+        ["item-a", None],
+        item_run_cu,
+        run_positions,
+        run_lengths,
+    )
+    assert mm_input.multimodal_item_run_cu_seqlen == item_run_cu
+    assert mm_input.multimodal_run_positions == run_positions
+    assert mm_input.multimodal_run_lengths == run_lengths
+
+    with pytest.raises(ValueError, match="must be provided together"):
+        MultimodalInput(
+            multimodal_hashes=[[1, 2, 3, 4, 5, 6, 7, 8]],
+            multimodal_positions=[1],
+            multimodal_lengths=[2],
+            multimodal_item_run_cu_seqlen=[0, 1],
+        )
+
+    with pytest.raises(ValueError, match="sum to 3, expected 2"):
+        MultimodalInput(
+            multimodal_hashes=[[1, 2, 3, 4, 5, 6, 7, 8]],
+            multimodal_positions=[1],
+            multimodal_lengths=[2],
+            multimodal_item_run_cu_seqlen=[0, 1],
+            multimodal_run_positions=[1],
+            multimodal_run_lengths=[3],
+        )
+
+
 def test_apply_mm_hashes_uuid_length_mismatch():
     """Test apply_mm_hashes raises error on UUID list length mismatch."""
     import torch

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -17,8 +17,9 @@ from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._utils import KVCacheEventSerializer
 from tensorrt_llm.bindings.internal.testing import \
     simulate_prefill_completion_only_use_for_testing
-from tensorrt_llm.inputs.multimodal import (MultimodalInput, apply_mm_hashes,
-                                            _find_mm_token_runs_from_mask)
+from tensorrt_llm.inputs.multimodal import (MultimodalInput,
+                                            _find_mm_token_runs_from_mask,
+                                            apply_mm_hashes)
 from tensorrt_llm.inputs.utils import AudioData, VideoData
 from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.mapping import Mapping

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -483,10 +483,10 @@ def test_multimodal_input_exact_run_buffers():
 
     mm_mask = torch.tensor(
         [False, True, True, False, False, True, False, False, True, True])
-    item_run_cu, run_positions, run_lengths = _find_mm_token_runs_from_mask(
+    item_run_cu_offsets, run_positions, run_lengths = _find_mm_token_runs_from_mask(
         mm_mask, [3, 2])
 
-    assert item_run_cu == [0, 2, 3]
+    assert item_run_cu_offsets == [0, 2, 3]
     assert run_positions == [1, 5, 8]
     assert run_lengths == [2, 1, 2]
 
@@ -495,11 +495,11 @@ def test_multimodal_input_exact_run_buffers():
         [1, 8],
         [3, 2],
         ["item-a", None],
-        item_run_cu,
+        item_run_cu_offsets,
         run_positions,
         run_lengths,
     )
-    assert mm_input.multimodal_item_run_cu_seqlen == item_run_cu
+    assert mm_input.multimodal_item_run_cu_offsets == item_run_cu_offsets
     assert mm_input.multimodal_run_positions == run_positions
     assert mm_input.multimodal_run_lengths == run_lengths
 
@@ -508,7 +508,7 @@ def test_multimodal_input_exact_run_buffers():
             multimodal_hashes=[[1, 2, 3, 4, 5, 6, 7, 8]],
             multimodal_positions=[1],
             multimodal_lengths=[2],
-            multimodal_item_run_cu_seqlen=[0, 1],
+            multimodal_item_run_cu_offsets=[0, 1],
         )
 
     with pytest.raises(ValueError, match="sum to 3, expected 2"):
@@ -516,10 +516,34 @@ def test_multimodal_input_exact_run_buffers():
             multimodal_hashes=[[1, 2, 3, 4, 5, 6, 7, 8]],
             multimodal_positions=[1],
             multimodal_lengths=[2],
-            multimodal_item_run_cu_seqlen=[0, 1],
+            multimodal_item_run_cu_offsets=[0, 1],
             multimodal_run_positions=[1],
             multimodal_run_lengths=[3],
         )
+
+
+def test_multimodal_input_rejects_exact_run_int32_overflow():
+    from tensorrt_llm.inputs.multimodal import MultimodalInput
+
+    int32_max = 2_147_483_647
+    with pytest.raises(ValueError, match="end position exceeds int32"):
+        MultimodalInput(
+            multimodal_hashes=[[1, 2, 3, 4, 5, 6, 7, 8]],
+            multimodal_positions=[int32_max - 1],
+            multimodal_lengths=[2],
+            multimodal_item_run_cu_offsets=[0, 1],
+            multimodal_run_positions=[int32_max - 1],
+            multimodal_run_lengths=[2],
+        )
+
+    MultimodalInput(
+        multimodal_hashes=[[1, 2, 3, 4, 5, 6, 7, 8]],
+        multimodal_positions=[int32_max - 1],
+        multimodal_lengths=[1],
+        multimodal_item_run_cu_offsets=[0, 1],
+        multimodal_run_positions=[int32_max - 1],
+        multimodal_run_lengths=[1],
+    )
 
 
 def test_apply_mm_hashes_uuid_length_mismatch():


### PR DESCRIPTION
## Description

Today's multimodal KV-cache block hashing assumes each multimodal item occupies one contiguous `[pos, pos+length)` span in the prompt. Production VLM preprocessors already break that assumption.


<img width="5280" height="2128" alt="image" src="https://github.com/user-attachments/assets/817437a6-745b-4270-8f7d-fd4771c74cdd" />


| Model | Real run shape |
|---|---|
| **Nemotron Nano v2 VL**   | 1 video -> 8 runs x 258 patches, separated by 13-token `Frame N sampled at X.XX seconds:` gaps |
| **Nemotron Nano v2 VL** (EVS-pruned) | 1 video -> 8 runs with lengths `[1026, 2, 2, 2, 2, 2, 2, 2]` |
| **Qwen3-VL** (Video-MME) | 1 video -> 2 runs `[10, 890)` and `[898, 1778)` separated by "`<vision_end><0.2 seconds><vision_start>`" |
| **Nano-Omni v3** | video + audio item, frame separator + appended audio block, reuses v2 VL's preprocessor |

### What goes wrong under the contiguous claim

The producer emits `multimodal_lengths[i] = num_mm_tokens` (a *count* of mm tokens, not a span width). Both consumers then re-derive a span as `[pos, pos + length)`, which is not true for any item whose patches sit in non-contiguous runs:

- **C++ block-key extra keys** (`blockKey.cpp::generateBlockHashExtraKeys`) - `MmKey.startOffset` is computed prompt-relative (`block_start - pos`), which only equals the item-local offset for contiguous items. Tail blocks past `pos + length` receive **no `MmKey` at all**, even when they hold real mm patches (e.g. positions `[2088, 2183)` of an 8-frame Nemotron video).
- **Python V2 token augmentation** (`KVCacheManagerV2._augment_tokens_for_block_reuse`) - overwrites positions inside the claimed span with digest-derived synthetic IDs. Real text tokens that fall in the gaps (`Frame 2 sampled at 2.51 seconds:`) are **erased** before hashing. Tail mm positions outside the span keep their placeholder IDs and carry **no digest contribution at all**.

### Practical impact - correctness debt, not a hot incident

Surface-level cross-prompt collisions are rare in production *today*:

- The prefix hash chain means any digest mismatch breaks the chain at block 0, so two prompts with different videos diverge before the buggy bookkeeping ever matters.
- Gap text is deterministic for a given (video, sampling config), so same-digest requests have identical gap content - the masking happens to coincide with the truth.
- Tail-block placeholder IDs are reserved tokens that don't appear in normal text, so accidental tail-block collisions across different prompts are structurally unlikely.

What the PR actually closes is structural fragility that might surface as preprocessors evolve:

- The V2 augmentation relies on gap-text determinism never slipping. Tokenizer drift, locale formatting changes, or mixed-modality preprocessors (Nano-Omni v3 with audio appended) would silently serve wrong KV.
- Correct tail-block reuse past the truncated span is **accidental** - the hash isn't causally tied to the trailing mm content. EVS-pruned and Nano-Omni-style layouts (where the "tail" *is* most of the runs) need this causation to be enforced.

### What this PR adds

Three optional flat arrays alongside the existing fields, so they cross the Python <-> C++ <-> serialization boundary cleanly:

```
multimodal_item_run_cu_offsets : List[int]   # prefix sum into runs, size: n_item_runs + 1
multimodal_run_positions       : List[int]   # prompt start of each run, flat across items, size: n_item_runs
multimodal_run_lengths         : List[int]   # length of each run, flat across items, size: n_item_runs
```

End-to-end plumbing:

- **Producer** (NEW): `tensorrt_llm/inputs/multimodal.py::_find_mm_token_runs_from_mask` extracts the runs from the per-token mm mask, called from `multimodal_hashing_process` in `inputs/registry.py`.
- **API surface**: `MultimodalInput` Python dataclass gains the three fields plus `_validate_multimodal_runs` (all-or-nothing, monotonic `cu`, `sum(run_lengths(item)) == multimodal_lengths[item]`, runs ordered + non-overlapping, values fit in int32, `pos+len <= INT32_MAX`). C++ `executor::MultimodalInput`, `serialization.cpp`, and the nanobind binding follow; `__setstate__` accepts both legacy 4-tuple and new 7-tuple state for backward-compatible deserialization.
- **Request object**: `GenericLlmRequest` gains 3 optional `shared_ptr<vector<SizeType32>>` fields; `executor_request_to_llm_request` and the nanobind ctor forward them.
- **Two consumers** refactored into `resolve + run-based + legacy-fallback` helpers:
  - C++ `generateBlockHashExtraKeys` -> `resolveRunMetadata` / `generateRunBasedExtraKeys` / `generateLegacyContiguousExtraKeys`.
  - Python `_augment_tokens_for_block_reuse` -> `_resolve_multimodal_run_metadata` / `_augment_tokens_with_mm_run_metadata` / `_augment_tokens_with_contiguous_mm_metadata`. `gen_multimodal_cache_key_tokens` (renamed from `gen_multi_modal_tokens`) gains a `token_offset` arg so multi-run items don't re-materialize the full per-item synthetic sequence.

**Backward compatible**: when run buffers are absent on a request, the legacy contiguous path runs exactly as before. Run buffers are only consulted when the producer emits them.

## Test Coverage

- **C++ unit tests** (`cpp/tests/unit_tests/batch_manager/blockKeyTest.cpp`)
  - `GenerateExtraKeysUsesExactMultimodalRuns` - non-contiguous runs produce per-run `MmKey`s with correct item-local offsets; gap-only blocks produce no key; second run's offset reflects accumulated prior run lengths.
  - `GenerateExtraKeysDisablesHashingForIncompleteRunMetadata` - partial run metadata logs a warning and falls back to no extra keys (request continues).
- **C++ serialization round-trip** (`cpp/tests/unit_tests/executor/serializeUtilsTest.cpp::MultimodalInputWithUuids`) extended to cover the 3 new fields.
- **Python unit tests** (`tests/unittest/_torch/executor/test_kv_cache_v2_multimodal_runs.py`) - exact-runs path, out-of-slice run skipping, incomplete-metadata `ValueError`, contiguous-fallback preserved, `gen_multimodal_cache_key_tokens(token_offset)` semantics.
- **Validator** (`tests/unittest/llmapi/test_llm_kv_cache_events.py::test_multimodal_input_exact_run_buffers`) - `from_components`, paired-fields-required, sum-mismatch, int32 overflow.
- **Bindings** (`tests/unittest/bindings/test_executor_bindings.py`) - `MultimodalInput` ctor with run buffers, state-tuple round-trip with both 4-tuple (legacy) and 7-tuple (new) state.


## Performance and accuracy validation

Rule for all perf tables: positive delta means feature is slower.

### Main perf numbers

Nemotron Omni synthetic run. 4x GB200. `tp_size=4`. `/v1/completions`. No profiler. Each cell has 3 runs x 9 measured requests = 27 measured requests per arm.

| Chunked prefill | Block reuse | Baseline mean | Feature mean | Delta | 95% range |
| --- | --- | ---: | ---: | ---: | ---: |
| off | off | 60.16 ms | 60.03 ms | -0.13 ms / -0.21% | -0.39% to -0.04% |
| off | on | 60.39 ms | 61.49 ms | +1.10 ms / +1.83% | -0.42% to +4.08% |
| on | off | 61.17 ms | 59.52 ms | -1.64 ms / -2.65% | -9.69% to +4.39% |
| on | on | 60.23 ms | 60.28 ms | +0.05 ms / +0.08% | -4.88% to +5.05% |

Takeaway: no clear perf regression. Only positive deltas are `+1.83%` and `+0.08%`, and both ranges cross zero.

### Extra perf checks

| Check | Baseline | Feature | Result |
| --- | ---: | ---: | --- |
| Qwen2-VL image, C++ KV, block reuse on, warm median | 0.203896 s | 0.202823 s | feature/baseline `0.994738` |
| Qwen2-VL Video-MME, C++ KV, block reuse off, warm median | 1.134069 s | 1.143502 s | feature/baseline `1.008318` |
| Qwen2-VL Video-MME, C++ KV, block reuse on, warm median | 0.943674 s | 0.951920 s | feature/baseline `1.008738` |
| Qwen2-VL Video-MME, Python KVCacheManagerV2, block reuse off, warm median | 1.106186 s | 1.118415 s | feature/baseline `1.011055` |
| Qwen2-VL Video-MME, Python KVCacheManagerV2, block reuse on, warm median | 0.918805 s | 0.930309 s | feature/baseline `1.012520` |
| Qwen2.5-VL-7B Video-MME, block reuse off, direct generate time | 0.5644 s | 0.5706 s | feature/baseline `1.0110` |
| Qwen2.5-VL-7B Video-MME, block reuse on, direct generate time | 0.5789 s | 0.5557 s | feature/baseline `0.9599` |

Worst warm repeated ratio observed: `1.012520` (+1.25%).

### Accuracy numbers

| Check | Baseline | Feature | Result |
| --- | --- | --- | --- |
| Qwen2-VL MMMU image sample | accuracy `40.0`, MM keys `654`, stored blocks `741` | accuracy `40.0`, MM keys `654`, stored blocks `741` | pass: output text and input IDs matched |
| Qwen2-VL Video-MME, C++ KV, block reuse off | answer `A`, token IDs `[32, 151645]` | answer `A`, token IDs `[32, 151645]` | pass: gold was `A` |
| Qwen2-VL Video-MME, C++ KV, block reuse on | answer `A`, token IDs `[32, 151645]` | answer `A`, token IDs `[32, 151645]` | pass: gold was `A` |
| Qwen2-VL Video-MME, Python KVCacheManagerV2, block reuse off | answer `C` | answer `C` | parity only: gold was `A` |
| Qwen2-VL Video-MME, Python KVCacheManagerV2, block reuse on | answer `C` | answer `C` | parity only: gold was `A` |
| Qwen2.5-VL-7B Video-MME, block reuse off | answer `A`, token IDs `[32, 151645]` | answer `A`, token IDs `[32, 151645]` | parity only: gold was `D` |
| Qwen2.5-VL-7B Video-MME, block reuse on | answer `A`, token IDs `[32, 151645]` | answer `A`, token IDs `[32, 151645]` | parity only: gold was `D` |

Claim boundary: perf numbers above show no clear regression. Accuracy numbers above show one passing local Video-MME sample plus branch-vs-baseline parity in the other completed video lanes. No scorer-backed Nemotron Omni Video-MME accuracy number yet.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] PR follows TRT-LLM CODING GUIDELINES.
- [x] Test cases provided for new code paths.
- [x] No new third-party dependencies.
- [x] CODEOWNERS updated if ownership changes - N/A.
- [x] Documentation updated as needed - pending review (no public-API docs reference the contiguous-span assumption).
- [x] Update tava architecture diagram - N/A (no significant design change to the KV-cache layer).
- [x] The reviewers assigned automatically/manually are appropriate for the PR.
- [x] Please check this after reviewing the above items as appropriate for this PR.
