### PR TITLE
[None][perf] FC2 DenseGEMM autotune: split-K, swap_ab, fine-grained tuning buckets

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -4277,8 +4277,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
             **kwargs,
-        ) -> List[Tuple[Tuple[int, int], Tuple[int, int]]]:
-            """Return valid (mma_tiler_mn, cluster_shape_mn) combinations."""
+        ) -> List[Tuple[Tuple[int, int], Tuple[int, int], int]]:
+            """Return valid (mma_tiler_mn, cluster_shape_mn, split_k) combinations."""
             # Check SM version - only supports SM 100 and SM 103
             major, minor = torch.cuda.get_device_capability()
             if not (major == 10 and minor in [0, 3]):
@@ -4292,9 +4292,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
             n = b.shape[0]
             l = 1  # dense GEMM
 
-            # Define candidates together
-            mma_tiler_mn_candidates = [(128, 64), (128, 128), (128, 256)]
-            cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4)]
+            # Define candidates
+            mma_tiler_mn_candidates = [(128, 64), (128, 128), (128, 256),
+                                       (256, 128)]
+            cluster_shape_mn_candidates = [(1, 1), (1, 2), (1, 4), (2, 1)]
+            split_k_candidates = [1, 2, 4]
 
             # Map torch dtype to cutlass dtype
             if self.output_dtype not in self._CUTLASS_DTYPE_MAP:
@@ -4302,6 +4304,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     f"Unsupported output_dtype {self.output_dtype} for FC2 DenseGEMM runner"
                 )
             c_cutlass_dtype = self._CUTLASS_DTYPE_MAP[self.output_dtype]
+
+            # MMA tile K size for split-K divisibility check
+            _MMA_TILE_K = 256
 
             tactics = []
             for mma_tiler_mn, cluster_shape_mn in itertools.product(
@@ -4323,7 +4328,15 @@ if IS_CUTLASS_DSL_AVAILABLE:
                         self.expert_count,
                         self.weight_per_expert,
                 ):
-                    tactics.append((mma_tiler_mn, cluster_shape_mn))
+                    for split_k in split_k_candidates:
+                        # K-tiles must be evenly divisible by split_k,
+                        # and each split must contain whole experts.
+                        k_tiles = k // _MMA_TILE_K
+                        tiles_per_expert = self.weight_per_expert // _MMA_TILE_K
+                        if (k_tiles % split_k == 0 and
+                            (k_tiles // split_k) % tiles_per_expert == 0):
+                            tactics.append(
+                                (mma_tiler_mn, cluster_shape_mn, split_k))
 
             return tactics
 
@@ -4348,13 +4361,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
         def forward(
             self,
             inputs: List[torch.Tensor],
-            tactic: Optional[Tuple[Tuple[int, int], Tuple[int, int]]],
+            tactic: Optional[Tuple[Tuple[int, int], Tuple[int, int], int]],
         ) -> torch.Tensor:
             """Execute the dense GEMM FC2.
 
             Args:
                 inputs: [a, b, a_sf, b_sf, alpha_scale]
-                tactic: ((mma_m, mma_n), (cluster_m, cluster_n))
+                tactic: ((mma_m, mma_n), (cluster_m, cluster_n), split_k)
 
             Returns:
                 Output tensor
@@ -4369,14 +4382,21 @@ if IS_CUTLASS_DSL_AVAILABLE:
             l = 1  # dense GEMM
 
             # Default tactic if not provided
-            if isinstance(tactic, tuple):
+            if isinstance(tactic, tuple) and len(tactic) == 3:
+                mma_tiler_mn, cluster_shape_mn, split_k = tactic
+            elif isinstance(tactic, tuple) and len(tactic) == 2:
                 mma_tiler_mn, cluster_shape_mn = tactic
+                split_k = 1
             else:
-                mma_tiler_mn, cluster_shape_mn = (128, 128), (1, 1)
+                mma_tiler_mn, cluster_shape_mn, split_k = (128, 128), (1, 1), 1
 
             # Allocate output tensor
             c_dtype = self.output_dtype
-            c = torch.empty((m, n), dtype=c_dtype, device=a.device)
+            if split_k > 1:
+                # Atomic reduction accumulates onto C; must be zero-initialized
+                c = torch.zeros((m, n), dtype=c_dtype, device=a.device)
+            else:
+                c = torch.empty((m, n), dtype=c_dtype, device=a.device)
 
             # Get CUDA stream
             torch_stream = torch.cuda.current_stream()
@@ -4421,6 +4441,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 self.weight_per_expert,
                 mma_tiler_mn,
                 cluster_shape_mn,
+                split_k,
                 self.scaling_vector_size,
                 self.
                 output_dtype,  # Include output dtype to avoid cache collision
@@ -4438,6 +4459,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     cluster_shape_mn=cluster_shape_mn,
                     expert_count=self.expert_count,
                     weight_per_expert=self.weight_per_expert,
+                    split_k=split_k,
                 )
 
                 # Compile the kernel and cache it

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -4345,14 +4345,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
             if key not in self.tuning_config_cache:
                 self.tuning_config_cache[key] = TuningConfig(
                     dynamic_tensor_specs=(DynamicTensorSpec(
-                        0, 0, get_last_power_of_2_num_tokens_buckets,
-                        last_positive_power_of_2), ),
+                        0, 0, deep_gemm_gen_tuning_buckets), ),
                     constraint_specs=(
                         ConstraintSpec(2, 0, fp4_scale_infer_shape),
                         ConstraintSpec(4, 0, lambda shapes: shapes[0][0]),
                     ),
                     use_cold_l2_cache=True,
-                    tune_max_num_tokens=256,
+                    tune_max_num_tokens=512,
                     distributed_tuning_strategy=DistributedTuningStrategy.
                     PARALLEL,
                 )

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -4380,6 +4380,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
             n = b.shape[0]
             l = 1  # dense GEMM
 
+            # The kernel wrapper expects alpha_scale laid out token-major
+            # (token has stride 1, expert has stride m), which gives
+            # warp 6 a coalesced load of 32 contiguous M alphas per expert.
+            # PyTorch's default contiguous (M, expert_count) is expert-major,
+            # so transpose+contiguous to convert.
+            alpha_scale = alpha_scale.t().contiguous()
+
             # Default tactic if not provided
             if isinstance(tactic, tuple) and len(tactic) == 3:
                 mma_tiler_mn, cluster_shape_mn, split_k = tactic

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
@@ -24,6 +24,13 @@ import cutlass.utils.blackwell_helpers as sm100_utils
 import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass.cute.nvgpu import cpasync, tcgen05
 
+from ..utils import (
+    atomic_add_func,
+    vectorized_atomic_add_bf16x8,
+    vectorized_atomic_add_fp16x8,
+    vectorized_atomic_add_fp32x2,
+)
+
 """
 This example provides an experimental implementation of the SM100 batched dense blockscaled
 GEMM kernel, please note that the APIs and implementation details related to this kernel
@@ -159,6 +166,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         weight_per_expert: int,
         use_prefetch: bool = False,
         prefetch_dist: int = 3,
+        split_k: int = 1,
     ):
         """Initializes the configuration for a Blackwell dense GEMM kernel.
 
@@ -207,15 +215,11 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         )
         self.mma_warp_id = 4
         self.tma_warp_id = 5
-        self.alpha_scale_load_warp_id = 6
-        self.dummy_warp_id = 7
         self.threads_per_cta = 32 * len(
             (
                 self.mma_warp_id,
                 self.tma_warp_id,
                 *self.epilog_warp_id,
-                self.alpha_scale_load_warp_id,
-                self.dummy_warp_id,
             )
         )
         # Set barrier id for cta sync, epilogue sync and tmem ptr sync
@@ -240,6 +244,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
         self.use_prefetch = use_prefetch
         self.prefetch_dist = prefetch_dist
+        self.split_k = split_k
 
     def _setup_attributes(self):
         """Set up configurations that are dependent on GEMM inputs
@@ -332,23 +337,43 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.c_dtype,
         )
 
-        # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
-        self.num_acc_stage, self.num_ab_stage, self.num_c_stage, self.num_alpha_scale_stage = (
-            self._compute_stages(
-                tiled_mma,
-                self.mma_tiler,
-                self.a_dtype,
-                self.b_dtype,
-                self.epi_tile,
-                self.c_dtype,
-                self.c_layout,
-                self.sf_dtype,
-                self.sf_vec_size,
-                self.smem_capacity,
-                self.occupancy,
-            )
-        )
+        # Atomic add parameters for split-K epilogue
+        if self.split_k > 1:
+            epi_tile_m = cute.size(self.epi_tile[0])
+            epi_tile_n = cute.size(self.epi_tile[1])
+            num_epilogue_threads = 32 * len(self.epilog_warp_id)
+            self.ttr_racc_size = (epi_tile_m * epi_tile_n) // num_epilogue_threads
+            if self.c_dtype in (cutlass.Float16, cutlass.BFloat16):
+                self.epi_layout_atomic = cute.make_layout(
+                    shape=(self.ttr_racc_size // 8, 4, 2), stride=(8, 2, 1)
+                )
+                self.epi_loop_size_atomic = self.ttr_racc_size // 8
+                self.element_offset_atomic = 8
+            elif self.c_dtype == cutlass.Float32:
+                self.epi_layout_atomic = cute.make_layout(
+                    shape=(self.ttr_racc_size // 2, 2), stride=(2, 1)
+                )
+                self.epi_loop_size_atomic = self.ttr_racc_size // 2
+                self.element_offset_atomic = 2
+            else:
+                self.epi_layout_atomic = cute.make_layout(shape=(self.ttr_racc_size,), stride=(1,))
+                self.epi_loop_size_atomic = self.ttr_racc_size
+                self.element_offset_atomic = 1
 
+        # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.b_dtype,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.smem_capacity,
+            self.occupancy,
+        )
         # Compute A/B/SFA/SFB/C shared memory layout
         self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
             tiled_mma,
@@ -379,17 +404,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.c_layout,
             self.epi_tile,
             self.num_c_stage,
-        )
-
-        self.alpha_scale_smem_layout_staged = cute.make_layout(
-            (
-                self.cta_tile_shape_mnk[0],
-                self.num_alpha_scale_stage,
-            ),
-            stride=(
-                self.num_alpha_scale_stage,
-                1,
-            ),
         )
 
     @cute.jit
@@ -546,12 +560,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.epi_tile,
         )
 
-        # Compute grid size
+        # Compute grid size (inflated by split_k for split-K decomposition)
         self.tile_sched_params, grid = self._compute_grid(
             c_tensor,
             self.cta_tile_shape_mnk,
             self.cluster_shape_mn,
             max_active_clusters,
+            self.split_k,
         )
 
         self.buffer_align_bytes = 1024
@@ -563,9 +578,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
             acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
             acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
-            alpha_scale_load_mbar_ptr: cute.struct.MemRange[
-                cutlass.Int64, self.num_alpha_scale_stage * 2
-            ]
             tmem_dealloc_mbar_ptr: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
             # (EPI_TILE_M, EPI_TILE_N, STAGE)
@@ -596,13 +608,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)],
                 self.buffer_align_bytes,
             ]
-            # Alpha scale shared memory
-            sAlphaScale: cute.struct.Align[
-                cute.struct.MemRange[
-                    cutlass.Float32, cute.cosize(self.alpha_scale_smem_layout_staged)
-                ],
-                16,
-            ]
 
         self.shared_storage = SharedStorage
 
@@ -627,11 +632,12 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.b_smem_layout_staged,
             self.sfa_smem_layout_staged,
             self.sfb_smem_layout_staged,
-            self.alpha_scale_smem_layout_staged,
             self.c_smem_layout_staged,
             self.epi_tile,
             self.tile_sched_params,
             epilogue_op,
+            c_tensor,
+            self.epi_layout_atomic if self.split_k > 1 else cute.make_layout(1),
         ).launch(
             grid=grid,
             block=[self.threads_per_cta, 1, 1],
@@ -664,11 +670,12 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         b_smem_layout_staged: cute.ComposedLayout,
         sfa_smem_layout_staged: cute.Layout,
         sfb_smem_layout_staged: cute.Layout,
-        alpha_scale_smem_layout_staged: cute.Layout,
         c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
         epi_tile: cute.Tile,
         tile_sched_params: utils.PersistentTileSchedulerParams,
         epilogue_op: cutlass.Constexpr,
+        mC_raw: cute.Tensor,
+        epi_layout_atomic: cute.Layout,
     ):
         """
         GPU device kernel performing the Persistent batched GEMM computation.
@@ -738,24 +745,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             cta_layout_vmnk=cluster_layout_vmnk,
         )
 
-        # Initialize alpha_scale_pipeline (barrier) and states
-        alpha_scale_pipeline_producer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            32 * 1,  # alpha_scale_load_warp_id threads
-            32 * 1,
-        )
-        alpha_scale_pipeline_consumer_group = pipeline.CooperativeGroup(
-            pipeline.Agent.Thread,
-            32 * len(self.epilog_warp_id),  # epilogue warps
-            32 * len(self.epilog_warp_id),
-        )
-        alpha_scale_pipeline = pipeline.PipelineCpAsync.create(
-            barrier_storage=storage.alpha_scale_load_mbar_ptr.data_ptr(),
-            num_stages=self.num_alpha_scale_stage,
-            producer_group=alpha_scale_pipeline_producer_group,
-            consumer_group=alpha_scale_pipeline_consumer_group,
-        )
-
         # Tensor memory dealloc barrier init
         tmem = utils.TmemAllocator(
             storage.tmem_holding_buf,
@@ -782,8 +771,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
         # (MMA, MMA_N, MMA_K, STAGE)
         sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
-        # Alpha scale shared memory tensor
-        sAlphaScale = storage.sAlphaScale.get_tensor(alpha_scale_smem_layout_staged)
 
         #
         # Compute multicast mask for A/B/SFA/SFB buffer full
@@ -839,7 +826,10 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         gC_mnl = cute.local_tile(
             mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
         )
-        k_tile_cnt = cutlass.Int32(cute.size(gA_mkl, mode=[3]))
+        k_tile_total = cute.size(gA_mkl, mode=[3])
+        # For split-K: each CTA processes k_tile_total // split_k K-tiles
+        k_tiles_per_split = k_tile_total // self.split_k
+        k_tile_cnt_local = cutlass.Int32(k_tiles_per_split)
 
         #
         # Partition global tensor for TiledMMA_A/B/C
@@ -952,10 +942,17 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             while work_tile.is_valid_tile:
                 # Get tile coord from tile scheduler
                 cur_tile_coord = work_tile.tile_idx
+
+                # Split-K: decompose L coord into batch_idx and split_k_idx
+                # Input tensors use batch_idx for L; K-tiles offset by k_start
+                # For split_k=1: batch_idx = coord[2], k_start = 0
+                batch_idx = cur_tile_coord[2] // self.split_k
+                k_start = (cur_tile_coord[2] % self.split_k) * k_tile_cnt_local
+
                 mma_tile_coord_mnl = (
                     cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
                     cur_tile_coord[1],
-                    cur_tile_coord[2],
+                    batch_idx,
                 )
 
                 #
@@ -979,92 +976,100 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 # Prefetch logic: use_prefetch for both A&B, or explicit A-only/B-only
                 if self.use_prefetch:
                     # Prefetch both A and B (default behavior)
-                    for k_tile in cutlass.range(0, min(prefetch_dist, k_tile_cnt), unroll=1):
+                    for k_tile in cutlass.range(0, min(prefetch_dist, k_tile_cnt_local), unroll=1):
                         # Prefetch both A and B (default behavior)
                         cute.prefetch(
                             tma_atom_a,
-                            tAgA_slice[(None, k_tile)],
+                            tAgA_slice[(None, k_tile + k_start)],
                         )
                         cute.prefetch(
                             tma_atom_b,
-                            tBgB_slice[(None, k_tile)],
+                            tBgB_slice[(None, k_tile + k_start)],
                         )
                         cute.prefetch(
                             tma_atom_sfa,
-                            tAgSFA_slice[(None, k_tile)],
+                            tAgSFA_slice[(None, k_tile + k_start)],
                         )
                         cute.prefetch(
                             tma_atom_sfb,
-                            tBgSFB_slice[(None, k_tile)],
+                            tBgSFB_slice[(None, k_tile + k_start)],
                         )
 
                 # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt
                 ab_producer_state.reset_count()
                 peek_ab_empty_status = cutlass.Boolean(1)
-                if ab_producer_state.count < k_tile_cnt:
+                if ab_producer_state.count < k_tile_cnt_local:
                     peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
                 #
                 # Tma load loop
                 #
-                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                for k_tile in cutlass.range(0, k_tile_cnt_local, 1, unroll=1):
                     # Conditionally wait for AB buffer empty
                     ab_pipeline.producer_acquire(ab_producer_state, peek_ab_empty_status)
 
-                    # TMA load A/B/SFA/SFB
+                    # TMA load A/B/SFA/SFB (offset by k_start for split-K)
                     cute.copy(
                         tma_atom_a,
-                        tAgA_slice[(None, ab_producer_state.count)],
+                        tAgA_slice[(None, ab_producer_state.count + k_start)],
                         tAsA[(None, ab_producer_state.index)],
                         tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
                         mcast_mask=a_full_mcast_mask,
                     )
                     cute.copy(
                         tma_atom_b,
-                        tBgB_slice[(None, ab_producer_state.count)],
+                        tBgB_slice[(None, ab_producer_state.count + k_start)],
                         tBsB[(None, ab_producer_state.index)],
                         tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
                         mcast_mask=b_full_mcast_mask,
                     )
                     cute.copy(
                         tma_atom_sfa,
-                        tAgSFA_slice[(None, ab_producer_state.count)],
+                        tAgSFA_slice[(None, ab_producer_state.count + k_start)],
                         tAsSFA[(None, ab_producer_state.index)],
                         tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
                         mcast_mask=sfa_full_mcast_mask,
                     )
                     cute.copy(
                         tma_atom_sfb,
-                        tBgSFB_slice[(None, ab_producer_state.count)],
+                        tBgSFB_slice[(None, ab_producer_state.count + k_start)],
                         tBsSFB[(None, ab_producer_state.index)],
                         tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
                         mcast_mask=sfb_full_mcast_mask,
                     )
 
                     # Prefetch logic in the loop: use_prefetch for both A&B, or explicit A-only/B-only
-                    if k_tile < k_tile_cnt - prefetch_dist:
+                    if k_tile < k_tile_cnt_local - prefetch_dist:
                         if self.use_prefetch:
                             # Prefetch both A and B (default behavior)
                             cute.prefetch(
                                 tma_atom_a,
-                                tAgA_slice[(None, ab_producer_state.count + prefetch_dist)],
+                                tAgA_slice[
+                                    (None, ab_producer_state.count + k_start + prefetch_dist)
+                                ],
                             )
                             cute.prefetch(
                                 tma_atom_b,
-                                tBgB_slice[(None, ab_producer_state.count + prefetch_dist)],
+                                tBgB_slice[
+                                    (None, ab_producer_state.count + k_start + prefetch_dist)
+                                ],
                             )
                             cute.prefetch(
                                 tma_atom_sfa,
-                                tAgSFA_slice[(None, ab_producer_state.count + prefetch_dist)],
+                                tAgSFA_slice[
+                                    (None, ab_producer_state.count + k_start + prefetch_dist)
+                                ],
                             )
                             cute.prefetch(
                                 tma_atom_sfb,
-                                tBgSFB_slice[(None, ab_producer_state.count + prefetch_dist)],
+                                tBgSFB_slice[
+                                    (None, ab_producer_state.count + k_start + prefetch_dist)
+                                ],
                             )
 
                     # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt + k_tile + 1
                     ab_producer_state.advance()
                     peek_ab_empty_status = cutlass.Boolean(1)
-                    if ab_producer_state.count < k_tile_cnt:
+                    if ab_producer_state.count < k_tile_cnt_local:
                         peek_ab_empty_status = ab_pipeline.producer_try_acquire(ab_producer_state)
 
                 #
@@ -1077,101 +1082,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             # Wait A/B buffer empty
             #
             ab_pipeline.producer_tail(ab_producer_state)
-
-        #
-        # Specialized Alpha Scale Load warp
-        #
-        if warp_idx == self.alpha_scale_load_warp_id:
-            #
-            # Persistent tile scheduling loop
-            #
-            tile_sched = utils.StaticPersistentTileScheduler.create(
-                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
-            )
-            work_tile = tile_sched.initial_work_tile_info()
-
-            alpha_scale_producer_state = pipeline.make_pipeline_state(
-                pipeline.PipelineUserType.Producer, self.num_alpha_scale_stage
-            )
-
-            # Setup copy atom for alpha scale loading
-            atom_copy = cute.make_copy_atom(
-                cute.nvgpu.cpasync.CopyG2SOp(),
-                malpha_scale_mnl.element_type,
-                num_bits_per_copy=malpha_scale_mnl.element_type.width,
-            )
-            tiled_copy_alpha_scale = cute.make_tiled_copy_tv(
-                atom_copy, cute.make_layout((32,)), cute.make_layout((1,))
-            )
-            thr_copy_alpha_scale = tiled_copy_alpha_scale.get_slice(cute.arch.lane_idx())
-
-            while work_tile.is_valid_tile:
-                # Get tile coord from tile scheduler
-                cur_tile_coord = work_tile.tile_idx
-
-                # Reset producer state for this tile
-                alpha_scale_producer_state.reset_count()
-                peek_alpha_scale_empty_status = cutlass.Boolean(1)
-                if alpha_scale_producer_state.count < k_tile_cnt:
-                    peek_alpha_scale_empty_status = alpha_scale_pipeline.producer_try_acquire(
-                        alpha_scale_producer_state
-                    )
-
-                galpha_scale_mnl_current_tile = galpha_scale_mnl[
-                    None, cur_tile_coord[0], None, cur_tile_coord[2]
-                ]
-
-                tAgAlphaScale = thr_copy_alpha_scale.partition_S(galpha_scale_mnl_current_tile)
-                tAsAlphaScale = thr_copy_alpha_scale.partition_D(sAlphaScale)
-
-                # Load alpha scale for each k tile
-                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
-                    # Calculate expert index for this k_tile
-                    expert_idx = k_tile // (self.weight_per_expert // self.mma_tiler[2])
-
-                    # Slice alpha scale for current tile and expert
-                    tAgAlphaScale_slice = tAgAlphaScale[(None, None, expert_idx)]
-                    tAsAlphaScale_slice = tAsAlphaScale[
-                        (None, None, alpha_scale_producer_state.index)
-                    ]
-
-                    # Wait for alpha scale buffer empty
-                    alpha_scale_pipeline.producer_acquire(
-                        alpha_scale_producer_state, peek_alpha_scale_empty_status
-                    )
-
-                    num_iters = cute.size(tAgAlphaScale_slice, mode=[1])
-
-                    # Load alpha scale from global to shared memory
-                    for iter_idx in cutlass.range(num_iters, unroll_full=True):
-                        iter_coord = (None, iter_idx)
-                        pred = cutlass.Boolean(
-                            32 * iter_idx + cute.arch.lane_idx() < malpha_scale_mnl.shape[0]
-                        )
-                        if pred:
-                            cute.copy(
-                                tiled_copy_alpha_scale,
-                                tAgAlphaScale_slice[iter_coord],
-                                tAsAlphaScale_slice[iter_coord],
-                            )
-
-                    # Commit and advance
-                    alpha_scale_pipeline.producer_commit(alpha_scale_producer_state)
-                    alpha_scale_producer_state.advance()
-
-                    # Peek next
-                    peek_alpha_scale_empty_status = cutlass.Boolean(1)
-                    if alpha_scale_producer_state.count < k_tile_cnt:
-                        peek_alpha_scale_empty_status = alpha_scale_pipeline.producer_try_acquire(
-                            alpha_scale_producer_state
-                        )
-
-                # Advance to next tile
-                tile_sched.advance_to_next_work()
-                work_tile = tile_sched.get_current_work()
-
-            # Wait for alpha scale buffer empty
-            alpha_scale_pipeline.producer_tail(alpha_scale_producer_state)
 
         #
         # Specialized MMA warp
@@ -1273,25 +1183,30 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 # Peek (try_wait) AB buffer full for k_tile = 0
                 ab_consumer_state.reset_count()
                 peek_ab_full_status = cutlass.Boolean(1)
-                if ab_consumer_state.count < k_tile_cnt and is_leader_cta:
+                if ab_consumer_state.count < k_tile_cnt_local and is_leader_cta:
                     peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
 
                 #
-                # Mma mainloop
+                # Mma mainloop with expert grouping
+                # Accumulate tiles_per_expert k-tiles per acc buffer to halve
+                # acc pipeline traffic (512 → 256 round-trips).
+                # For split-K: only process k_tiles_per_split K-tiles (a subset of experts).
                 #
-                for k_tile in range(k_tile_cnt):
-                    # Set tensor memory buffer for current tile
-                    # (MMA, MMA_M, MMA_N)
-                    tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+                tiles_per_expert_mma = self.weight_per_expert // self.mma_tiler[2]
+                tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
+                for k_tile in range(k_tiles_per_split):
+                    is_first_of_expert = k_tile % tiles_per_expert_mma == 0
+                    is_last_of_expert = k_tile % tiles_per_expert_mma == tiles_per_expert_mma - 1
+
+                    if is_first_of_expert:
+                        tCtAcc = tCtAcc_base[(None, None, None, acc_producer_state.index)]
 
                     if is_leader_cta:
-                        # Wait for accumulator buffer empty(each kblock)
-                        acc_pipeline.producer_acquire(acc_producer_state)
+                        if is_first_of_expert:
+                            acc_pipeline.producer_acquire(acc_producer_state)
 
-                        # Conditionally wait for AB buffer full
                         ab_pipeline.consumer_wait(ab_consumer_state, peek_ab_full_status)
 
-                        #  Copy SFA/SFB from smem to tmem
                         s2t_stage_coord = (
                             None,
                             None,
@@ -1312,12 +1227,9 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                             tCtSFB_compact_s2t,
                         )
 
-                        #
-                        # Reset the ACCUMULATE field for each tile
-                        #
-                        tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+                        if is_first_of_expert:
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
 
-                        # tCtAcc += tCrA * tCrSFA * tCrB * tCrSFB
                         num_kblocks = cute.size(tCrA, mode=[2])
                         for kblock_idx in cutlass.range(num_kblocks, unroll_full=True):
                             kblock_coord = (
@@ -1327,7 +1239,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                 ab_consumer_state.index,
                             )
 
-                            # Set SFA/SFB tensor to tiled_mma
                             sf_kblock_coord = (None, None, kblock_idx)
                             tiled_mma.set(
                                 tcgen05.Field.SFA,
@@ -1346,25 +1257,20 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                                 tCtAcc,
                             )
 
-                            # Enable accumulate on tCtAcc after first kblock
                             tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
 
-                        # Async arrive AB buffer empty
                         ab_pipeline.consumer_release(ab_consumer_state)
 
-                    # Peek (try_wait) AB buffer full for k_tile = k_tile + 1
                     ab_consumer_state.advance()
                     peek_ab_full_status = cutlass.Boolean(1)
-                    if ab_consumer_state.count < k_tile_cnt:
+                    if ab_consumer_state.count < k_tile_cnt_local:
                         if is_leader_cta:
                             peek_ab_full_status = ab_pipeline.consumer_try_wait(ab_consumer_state)
 
-                    #
-                    # Async arrive accumulator buffer full
-                    #
-                    if is_leader_cta:
-                        acc_pipeline.producer_commit(acc_producer_state)
-                    acc_producer_state.advance()
+                    if is_last_of_expert:
+                        if is_leader_cta:
+                            acc_pipeline.producer_commit(acc_producer_state)
+                        acc_producer_state.advance()
 
                 #
                 # Advance to next tile
@@ -1432,11 +1338,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 pipeline.PipelineUserType.Consumer, self.num_acc_stage
             )
 
-            # Alpha scale consumer state
-            alpha_scale_consumer_state = pipeline.make_pipeline_state(
-                pipeline.PipelineUserType.Consumer, self.num_alpha_scale_stage
-            )
-
             # Threads/warps participating in tma store pipeline
             c_producer_group = pipeline.CooperativeGroup(
                 pipeline.Agent.Thread,
@@ -1448,30 +1349,29 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 producer_group=c_producer_group,
             )
 
-            # Create copy atom for loading alpha scale from smem
-            alpha_scale_copy_atom_s2r = cute.make_copy_atom(
-                cute.nvgpu.CopyUniversalOp(),
-                cutlass.Float32,
-                num_bits_per_copy=32,
-            )
-            tiled_copy_alpha_scale_s2r = cute.make_tiled_copy_tv(
-                alpha_scale_copy_atom_s2r,
-                cute.make_layout((32 * len(self.epilog_warp_id),)),
-                cute.make_layout((1,)),
-            )
-            thr_copy_alpha_scale_s2r = tiled_copy_alpha_scale_s2r.get_slice(tidx)
+            tiles_per_expert = self.weight_per_expert // self.mma_tiler[2]
+            # For split-K: each CTA handles experts_per_split experts
+            experts_per_split = k_tiles_per_split // tiles_per_expert
+            m_total = malpha_scale_mnl.shape[0]
 
             while work_tile.is_valid_tile:
                 # Get tile coord from tile scheduler
                 cur_tile_coord = work_tile.tile_idx
+
+                # Split-K: decompose L coord into batch_idx and split_k_idx
+                # For split_k=1: batch_idx = coord[2], expert_offset = 0
+                batch_idx = cur_tile_coord[2] // self.split_k
+                expert_offset = (cur_tile_coord[2] % self.split_k) * experts_per_split
+
+                # Use batch_idx for output L coordinate (correct for both split_k=1 and >1)
                 mma_tile_coord_mnl = (
                     cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
                     cur_tile_coord[1],
-                    cur_tile_coord[2],
+                    batch_idx,
                 )
 
                 #
-                # Slice to per mma tile index
+                # Slice to per mma tile index (for TMA store path)
                 #
                 # ((ATOM_V, REST_V), EPI_M, EPI_N)
                 bSG_gC = bSG_gC_partitioned[
@@ -1486,54 +1386,33 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 # initialize the final accumulator
                 tTR_rAcc_final.fill(0.0)
 
-                # Initialize alpha_scale consumer state for this tile
-                alpha_scale_consumer_state.reset_count()
-                peek_alpha_scale_full_status = cutlass.Boolean(1)
-                if alpha_scale_consumer_state.count < k_tile_cnt:
-                    peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
-                        alpha_scale_consumer_state
-                    )
+                # Epilogue iterates over experts_per_split experts (not full expert_count)
+                num_experts_k = cutlass.Int32(experts_per_split)
 
                 acc_consumer_state.reset_count()
                 peek_acc_full_status = cutlass.Boolean(1)
-                if acc_consumer_state.count < k_tile_cnt:
+                if acc_consumer_state.count < num_experts_k:
                     peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
 
-                for k_tile in cutlass.range(k_tile_cnt):
-                    # Set tensor memory buffer for current tile
-                    # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
+                m_start = cur_tile_coord[0] * self.cta_tile_shape_mnk[0]
+                m_in_bounds = m_start < m_total
+                thread_in_bounds = epi_tidx < (m_total - m_start) if m_in_bounds else False
+
+                # Prologue: prefetch alpha for first expert in this split
+                prefetched_alpha = cutlass.Float32(0.0)
+                if thread_in_bounds:
+                    prefetched_alpha = galpha_scale_mnl[
+                        epi_tidx, cur_tile_coord[0], expert_offset, batch_idx
+                    ]
+
+                for expert_idx in cutlass.range(num_experts_k):
                     tTR_tAcc = tTR_tAcc_base[
                         (None, None, None, None, None, acc_consumer_state.index)
                     ]
                     tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
-                    #
-                    # Update accumulator by scale factor in subtiles
-                    #
                     subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
 
-                    # for subtile_idx in cutlass.range_dynamic(subtile_cnt):
-
-                    #
-                    # Wait for alpha scale buffer full
-                    #
-                    alpha_scale_pipeline.consumer_wait(
-                        alpha_scale_consumer_state, peek_alpha_scale_full_status
-                    )
-
-                    # Load alpha scale from shared memory for current expert
-                    alpha_scale_smem_slice = sAlphaScale[(None, alpha_scale_consumer_state.index)]
-
-                    tAsAlphaScale_slice = thr_copy_alpha_scale_s2r.partition_S(
-                        alpha_scale_smem_slice
-                    )
-                    current_alpha_scale_reg = cute.make_rmem_tensor(
-                        tAsAlphaScale_slice.shape, cutlass.Float32
-                    )
-
-                    cute.copy(
-                        alpha_scale_copy_atom_s2r, tAsAlphaScale_slice, current_alpha_scale_reg
-                    )
-                    current_alpha_scale = current_alpha_scale_reg[0]
+                    current_alpha_scale = prefetched_alpha
 
                     #
                     # Wait for accumulator buffer full
@@ -1559,16 +1438,6 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         final_vec = acc_vec * current_alpha_scale + final_vec
                         tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
 
-                    # Release alpha scale buffer
-                    alpha_scale_pipeline.consumer_release(alpha_scale_consumer_state)
-                    alpha_scale_consumer_state.advance()
-
-                    # Peek next alpha scale
-                    peek_alpha_scale_full_status = cutlass.Boolean(1)
-                    if alpha_scale_consumer_state.count < k_tile_cnt:
-                        peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
-                            alpha_scale_consumer_state
-                        )
                     #
                     # Async arrive accumulator buffer empty
                     #
@@ -1576,59 +1445,97 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         acc_pipeline.consumer_release(acc_consumer_state)
                     acc_consumer_state.advance()
 
+                    # Prefetch next expert's alpha after releasing acc buffer
+                    next_expert = expert_idx + 1
+                    clamped_expert = (
+                        next_expert if next_expert < num_experts_k else num_experts_k - 1
+                    )
+                    prefetched_alpha = cutlass.Float32(0.0)
+                    if thread_in_bounds:
+                        prefetched_alpha = galpha_scale_mnl[
+                            epi_tidx, cur_tile_coord[0], expert_offset + clamped_expert, batch_idx
+                        ]
+
                     peek_acc_full_status = cutlass.Boolean(1)
-                    if acc_consumer_state.count < k_tile_cnt:
+                    if acc_consumer_state.count < num_experts_k:
                         peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
 
                 #
                 # Store accumulator to global memory in subtiles
                 #
-                bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
-
                 subtile_cnt = cute.size(tTR_rAcc_final.shape, mode=[3])
-                num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
-                for subtile_idx in cutlass.range(subtile_cnt):
-                    #
-                    # Store accumulator to shared memory or global memory
-                    #
-                    tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
 
+                if cutlass.const_expr(self.split_k > 1):
                     #
-                    # Convert to C type
+                    # Split-K atomic add path: each CTA atomically adds its
+                    # partial result directly to the output C tensor.
+                    # Guard with M bounds check to avoid OOB writes when
+                    # M is not a multiple of tile_M.
                     #
-                    acc_vec = tiled_copy_r2s.retile(tTR_rAcc_subtile).load()
-                    acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
-                    tRS_rC.store(acc_vec)
+                    rOut_epi = cute.make_tensor(tTR_rC.iterator, epi_layout_atomic)
+                    m_coord = cur_tile_coord[0] * self.cta_tile_shape_mnk[0] + epi_tidx
+                    scatter_base = cute.domain_offset((m_coord, 0, batch_idx), mC_raw)
 
-                    #
-                    # Store C to shared memory
-                    #
-                    c_buffer = (num_prev_subtiles + subtile_idx) % self.num_c_stage
-                    cute.copy(
-                        tiled_copy_r2s,
-                        tRS_rC,
-                        tRS_sC[(None, None, None, c_buffer)],
-                    )
-                    # Fence and barrier to make sure shared memory store is visible to TMA store
-                    cute.arch.fence_proxy(
-                        cute.arch.ProxyKind.async_shared,
-                        space=cute.arch.SharedSpace.shared_cta,
-                    )
-                    self.epilog_sync_barrier.arrive_and_wait()
+                    if thread_in_bounds:
+                        for subtile_idx in cutlass.range(subtile_cnt):
+                            tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                            acc_vec = tTR_rAcc_subtile.load()
+                            acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                            tTR_rC.store(acc_vec)
 
+                            base_coord_n = cur_tile_coord[1] * self.cta_tile_shape_mnk[
+                                1
+                            ] + subtile_idx * cute.size(tTR_rC)
+
+                            for index in cutlass.range(self.epi_loop_size_atomic, unroll_full=True):
+                                coord_n = base_coord_n + index * self.element_offset_atomic
+                                scatter_out = cute.domain_offset((0, coord_n, 0), scatter_base)
+                                if cutlass.const_expr(self.c_dtype == cutlass.Float16):
+                                    vectorized_atomic_add_fp16x8(
+                                        rOut_epi[index, None, None], scatter_out
+                                    )
+                                elif cutlass.const_expr(self.c_dtype == cutlass.BFloat16):
+                                    vectorized_atomic_add_bf16x8(
+                                        rOut_epi[index, None, None], scatter_out
+                                    )
+                                elif cutlass.const_expr(self.c_dtype == cutlass.Float32):
+                                    vectorized_atomic_add_fp32x2(rOut_epi[index, None], scatter_out)
+                                else:
+                                    atomic_add_func(rOut_epi[index], scatter_out)
+                else:
                     #
-                    # TMA store C to global memory
+                    # Standard TMA store path (split_k=1)
                     #
-                    if warp_idx == self.epilog_warp_id[0]:
+                    bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+                    num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+                    for subtile_idx in cutlass.range(subtile_cnt):
+                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+
+                        acc_vec = tiled_copy_r2s.retile(tTR_rAcc_subtile).load()
+                        acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+                        tRS_rC.store(acc_vec)
+
+                        c_buffer = (num_prev_subtiles + subtile_idx) % self.num_c_stage
                         cute.copy(
-                            tma_atom_c,
-                            bSG_sC[(None, c_buffer)],
-                            bSG_gC[(None, subtile_idx)],
+                            tiled_copy_r2s,
+                            tRS_rC,
+                            tRS_sC[(None, None, None, c_buffer)],
                         )
-                        # Fence and barrier to make sure shared memory store is visible to TMA store
-                        c_pipeline.producer_commit()
-                        c_pipeline.producer_acquire()
-                    self.epilog_sync_barrier.arrive_and_wait()
+                        cute.arch.fence_proxy(
+                            cute.arch.ProxyKind.async_shared,
+                            space=cute.arch.SharedSpace.shared_cta,
+                        )
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                        if warp_idx == self.epilog_warp_id[0]:
+                            cute.copy(
+                                tma_atom_c,
+                                bSG_sC[(None, c_buffer)],
+                                bSG_gC[(None, subtile_idx)],
+                            )
+                            c_pipeline.producer_commit()
+                            c_pipeline.producer_acquire()
+                        self.epilog_sync_barrier.arrive_and_wait()
                 #
                 # Advance to next tile
                 #
@@ -1642,9 +1549,10 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.epilog_sync_barrier.arrive_and_wait()
             tmem.free(acc_tmem_ptr)
             #
-            # Wait for C store complete
+            # Wait for C store complete (only needed for TMA store path)
             #
-            c_pipeline.producer_tail()
+            if cutlass.const_expr(self.split_k <= 1):
+                c_pipeline.producer_tail()
 
     def mainloop_s2t_copy_and_partition(
         self,
@@ -1856,8 +1764,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         sf_vec_size: int,
         smem_capacity: int,
         occupancy: int,
-    ) -> Tuple[int, int, int, int]:
-        """Computes the number of stages for A/B/C/Alpha_Scale operands based on heuristics.
+    ) -> Tuple[int, int, int]:
+        """Computes the number of stages for A/B/C operands based on heuristics.
 
         :param tiled_mma: The tiled MMA object defining the core computation.
         :type tiled_mma: cute.TiledMma
@@ -1883,21 +1791,16 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :type occupancy: int
 
         :return: A tuple containing the computed number of stages for:
-                 (ACC stages, A/B operand stages, C stages, Alpha_Scale stages)
-        :rtype: tuple[int, int, int, int]
+                 (ACC stages, A/B operand stages, C stages)
+        :rtype: tuple[int, int, int]
         """
-        # ACC stages
-        num_acc_stage = 2
+        # ACC stages: 3 for N=128 to allow MMA to run ahead of epilogue
+        num_acc_stage = 3
         if mma_tiler_mnk[1] == 256:
             num_acc_stage = 1
-        # else if mma_tiler_mnk[1] == 64:
-        #     num_acc_stage = 6
 
         # Default C stages
         num_c_stage = 2
-
-        # Default Alpha scale stages
-        num_alpha_scale_stage = 10
 
         # Calculate smem layout and size for one stage of A, B, SFA, SFB and C
         a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
@@ -1942,21 +1845,12 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
         c_bytes = c_bytes_per_stage * num_c_stage
 
-        # Alpha scale shared memory
-        # hardcode cta tile shape
-        alpha_bytes = cute.size_in_bytes(
-            cutlass.Float32,
-            cute.make_layout(
-                (mma_tiler_mnk[0] // tiled_mma.thr_id.shape, num_alpha_scale_stage),
-                stride=(num_alpha_scale_stage, 1),
-            ),
-        )
         # Calculate A/B/SFA/SFB stages:
         # Start with total smem per CTA (capacity / occupancy)
         # Subtract reserved bytes and initial C stages bytes
         # Divide remaining by bytes needed per A/B/SFA/SFB stage
         num_ab_stage = (
-            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes + alpha_bytes)
+            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
         ) // ab_bytes_per_stage
 
         # Refine epilogue stages:
@@ -1965,10 +1859,10 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         num_c_stage += (
             smem_capacity
             - occupancy * ab_bytes_per_stage * num_ab_stage
-            - occupancy * (mbar_helpers_bytes + c_bytes + alpha_bytes)
+            - occupancy * (mbar_helpers_bytes + c_bytes)
         ) // (occupancy * c_bytes_per_stage)
 
-        return num_acc_stage, num_ab_stage, num_c_stage, num_alpha_scale_stage
+        return num_acc_stage, num_ab_stage, num_c_stage
 
     @staticmethod
     def _compute_grid(
@@ -1976,6 +1870,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         cta_tile_shape_mnk: Tuple[int, int, int],
         cluster_shape_mn: Tuple[int, int],
         max_active_clusters: cutlass.Constexpr,
+        split_k: int = 1,
     ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
         """Use persistent tile scheduler to compute the grid size for the output tensor C.
 
@@ -1987,6 +1882,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :type cluster_shape_mn: tuple[int, int]
         :param max_active_clusters: Maximum number of active clusters.
         :type max_active_clusters: cutlass.Constexpr
+        :param split_k: Split-K factor to inflate L dimension.
+        :type split_k: int
 
         :return: A tuple containing:
             - tile_sched_params: Parameters for the persistent tile scheduler.
@@ -1996,6 +1893,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         c_shape = cute.slice_(cta_tile_shape_mnk, (None, None, 0))
         gc = cute.zipped_divide(c, tiler=c_shape)
         num_ctas_mnl = gc[(0, (None, None, None))].shape
+        if split_k > 1:
+            num_ctas_mnl = (num_ctas_mnl[0], num_ctas_mnl[1], num_ctas_mnl[2] * split_k)
         cluster_shape_mnl = (*cluster_shape_mn, 1)
 
         tile_sched_params = utils.PersistentTileSchedulerParams(num_ctas_mnl, cluster_shape_mnl)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
@@ -1211,7 +1211,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 # Reset producer state for this tile
                 alpha_scale_producer_state.reset_count()
                 peek_alpha_scale_empty_status = cutlass.Boolean(1)
-                if alpha_scale_producer_state.count < k_tile_cnt_local:
+                if alpha_scale_producer_state.count < experts_per_split_w6:
                     peek_alpha_scale_empty_status = alpha_scale_pipeline.producer_try_acquire(
                         alpha_scale_producer_state
                     )
@@ -1228,10 +1228,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 tAgAlphaScale = thr_copy_alpha_scale.partition_S(galpha_scale_mnl_current_tile)
                 tAsAlphaScale = thr_copy_alpha_scale.partition_D(sAlphaScale)
 
-                # Load alpha scale for each k tile (one per expert in this split)
-                for k_tile in cutlass.range(0, k_tile_cnt_local, 1, unroll=1):
-                    # Calculate expert index for this k_tile (with split-K offset)
-                    expert_idx = expert_offset_w6 + k_tile // tiles_per_expert_w6
+                # Load alpha scale once per expert in this split. Within an expert
+                # the alpha is invariant across the tiles_per_expert k_tiles, so we
+                # commit once per expert to mirror the MMA accumulator pipeline
+                # (which acquires/commits per expert, not per k_tile).
+                for expert in cutlass.range(0, experts_per_split_w6, 1, unroll=1):
+                    # Calculate expert index for this iteration (with split-K offset)
+                    expert_idx = expert_offset_w6 + expert
 
                     # Slice alpha scale for current tile and expert
                     tAgAlphaScale_slice = tAgAlphaScale[(None, None, expert_idx)]
@@ -1265,7 +1268,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
                     # Peek next
                     peek_alpha_scale_empty_status = cutlass.Boolean(1)
-                    if alpha_scale_producer_state.count < k_tile_cnt_local:
+                    if alpha_scale_producer_state.count < experts_per_split_w6:
                         peek_alpha_scale_empty_status = alpha_scale_pipeline.producer_try_acquire(
                             alpha_scale_producer_state
                         )
@@ -1581,6 +1584,14 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
 
             m_total = malpha_scale_mnl.shape[0]
 
+            # MMA producer accumulates `tiles_per_expert_epi` k_tiles into a single
+            # tmem stage and commits once per expert. The epilogue therefore
+            # consumes the acc / alpha pipelines once per expert (not per k_tile),
+            # otherwise the second consumer_wait would block forever when
+            # weight_per_expert > mma_tiler_k.
+            tiles_per_expert_epi = self.weight_per_expert // self.mma_tiler[2]
+            experts_per_split_epi = k_tile_cnt_local // tiles_per_expert_epi
+
             while work_tile.is_valid_tile:
                 # Get tile coord from tile scheduler
                 cur_tile_coord = work_tile.tile_idx
@@ -1619,21 +1630,22 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 if cutlass.const_expr(not self.swap_ab):
                     #
                     # Standard path: alpha loaded by warp 6 via alpha_scale_pipeline.
-                    # One scalar alpha per M position per expert.
+                    # One scalar alpha per M position per expert. Iterate once per
+                    # expert in this split (matches MMA acc commit cadence).
                     #
                     alpha_scale_consumer_state.reset_count()
                     peek_alpha_scale_full_status = cutlass.Boolean(1)
-                    if alpha_scale_consumer_state.count < k_tile_cnt_local:
+                    if alpha_scale_consumer_state.count < experts_per_split_epi:
                         peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
                             alpha_scale_consumer_state
                         )
 
                     acc_consumer_state.reset_count()
                     peek_acc_full_status = cutlass.Boolean(1)
-                    if acc_consumer_state.count < k_tile_cnt_local:
+                    if acc_consumer_state.count < experts_per_split_epi:
                         peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
 
-                    for k_tile in cutlass.range(k_tile_cnt_local):
+                    for expert in cutlass.range(experts_per_split_epi):
                         tTR_tAcc = tTR_tAcc_base[
                             (None, None, None, None, None, acc_consumer_state.index)
                         ]
@@ -1680,7 +1692,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         alpha_scale_consumer_state.advance()
 
                         peek_alpha_scale_full_status = cutlass.Boolean(1)
-                        if alpha_scale_consumer_state.count < k_tile_cnt_local:
+                        if alpha_scale_consumer_state.count < experts_per_split_epi:
                             peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
                                 alpha_scale_consumer_state
                             )
@@ -1691,7 +1703,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         acc_consumer_state.advance()
 
                         peek_acc_full_status = cutlass.Boolean(1)
-                        if acc_consumer_state.count < k_tile_cnt_local:
+                        if acc_consumer_state.count < experts_per_split_epi:
                             peek_acc_full_status = acc_pipeline.consumer_try_wait(
                                 acc_consumer_state
                             )
@@ -1701,20 +1713,21 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                     # SwapAB path: warp 6 loads cta_N alphas per expert via pipeline.
                     # Epilogue waits on pipeline, then copies epi_tile_n alpha per subtile
                     # to stage-0 region of sAlphaScale for broadcast read.
+                    # Iterate once per expert (matches MMA acc commit cadence).
                     #
                     alpha_scale_consumer_state.reset_count()
                     peek_alpha_scale_full_status = cutlass.Boolean(1)
-                    if alpha_scale_consumer_state.count < k_tile_cnt_local:
+                    if alpha_scale_consumer_state.count < experts_per_split_epi:
                         peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
                             alpha_scale_consumer_state
                         )
 
                     acc_consumer_state.reset_count()
                     peek_acc_full_status = cutlass.Boolean(1)
-                    if acc_consumer_state.count < k_tile_cnt_local:
+                    if acc_consumer_state.count < experts_per_split_epi:
                         peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
 
-                    for k_tile in cutlass.range(k_tile_cnt_local):
+                    for expert in cutlass.range(experts_per_split_epi):
                         tTR_tAcc = tTR_tAcc_base[
                             (None, None, None, None, None, acc_consumer_state.index)
                         ]
@@ -1778,7 +1791,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         alpha_scale_consumer_state.advance()
 
                         peek_alpha_scale_full_status = cutlass.Boolean(1)
-                        if alpha_scale_consumer_state.count < k_tile_cnt_local:
+                        if alpha_scale_consumer_state.count < experts_per_split_epi:
                             peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
                                 alpha_scale_consumer_state
                             )
@@ -1789,7 +1802,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                         acc_consumer_state.advance()
 
                         peek_acc_full_status = cutlass.Boolean(1)
-                        if acc_consumer_state.count < k_tile_cnt_local:
+                        if acc_consumer_state.count < experts_per_split_epi:
                             peek_acc_full_status = acc_pipeline.consumer_try_wait(
                                 acc_consumer_state
                             )
@@ -2606,21 +2619,22 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2)),
             )
 
-        # Create A scale factor tensor (swizzled layout)
-        # Shape: (32, 4, m // 128, 4, scale_k // 4, l)
+        # Create scale factor tensors (swizzled layout)
+        # Layout: (32, 4, ceil_div(dim, 128), 4, scale_k // 4, L) with order (2, 1, 4, 0, 3, 5)
+        # Use ceil_div for the M / N block dim to avoid zero-volume tensors when M < 128 or N < 128.
+        m_blocks = (m + 127) // 128
+        n_blocks = (n + 127) // 128
         a_sf = cute.make_tensor(
             a_sf_ptr,
             layout=cute.make_ordered_layout(
-                (32, 4, m // 128, 4, scale_k // 4, l), order=(2, 1, 4, 0, 3, 5)
+                (32, 4, m_blocks, 4, scale_k // 4, l), order=(2, 1, 4, 0, 3, 5)
             ),
         )
 
-        # Create B scale factor tensor (swizzled layout)
-        # Shape: (32, 4, n // 128, 4, scale_k // 4, l)
         b_sf = cute.make_tensor(
             b_sf_ptr,
             layout=cute.make_ordered_layout(
-                (32, 4, n // 128, 4, scale_k // 4, l), order=(2, 1, 4, 0, 3, 5)
+                (32, 4, n_blocks, 4, scale_k // 4, l), order=(2, 1, 4, 0, 3, 5)
             ),
         )
 

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
@@ -2571,6 +2571,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :param stream: CUDA stream
         :type stream: cuda.CUstream
         """
+        # Cast Int64 → Int32 so all derived tensor shapes and cute.size() calls stay in 32-bit,
+        # which is required by cutlass.range(). The wrapper accepts Int64 for API compatibility
+        # but practical tensor dimensions always fit in Int32.
+        m = cutlass.Int32(m)
+        n = cutlass.Int32(n)
+        k = cutlass.Int32(k)
+        l = cutlass.Int32(l)  # noqa: E741
         scale_k = k // scaling_vector_size
 
         # Create A tensor (M, K, L) - K-major

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/moe_as_dense_gemm/fc2.py
@@ -167,6 +167,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         use_prefetch: bool = False,
         prefetch_dist: int = 3,
         split_k: int = 1,
+        swap_ab: bool = False,
     ):
         """Initializes the configuration for a Blackwell dense GEMM kernel.
 
@@ -215,11 +216,15 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         )
         self.mma_warp_id = 4
         self.tma_warp_id = 5
+        self.alpha_scale_load_warp_id = 6
+        self.dummy_warp_id = 7
         self.threads_per_cta = 32 * len(
             (
                 self.mma_warp_id,
                 self.tma_warp_id,
                 *self.epilog_warp_id,
+                self.alpha_scale_load_warp_id,
+                self.dummy_warp_id,
             )
         )
         # Set barrier id for cta sync, epilogue sync and tmem ptr sync
@@ -245,6 +250,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         self.use_prefetch = use_prefetch
         self.prefetch_dist = prefetch_dist
         self.split_k = split_k
+        self.swap_ab = swap_ab
 
     def _setup_attributes(self):
         """Set up configurations that are dependent on GEMM inputs
@@ -330,12 +336,18 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
 
         # Compute epilogue subtile
+        # For swapAB: use ROW_MAJOR for epi_tile computation to keep consistent
+        # thread-to-(M,N) mapping. The actual C layout (COL_MAJOR) only affects
+        # the TMA store path, not the register computation.
+        self.epi_compute_layout = utils.LayoutEnum.ROW_MAJOR if self.swap_ab else self.c_layout
         self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
             self.cta_tile_shape_mnk,
             self.use_2cta_instrs,
-            self.c_layout,
+            self.epi_compute_layout,
             self.c_dtype,
         )
+        self.epi_tile_m_size = cute.size(self.epi_tile[0])
+        self.epi_tile_n_size = cute.size(self.epi_tile[1])
 
         # Atomic add parameters for split-K epilogue
         if self.split_k > 1:
@@ -343,7 +355,12 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             epi_tile_n = cute.size(self.epi_tile[1])
             num_epilogue_threads = 32 * len(self.epilog_warp_id)
             self.ttr_racc_size = (epi_tile_m * epi_tile_n) // num_epilogue_threads
-            if self.c_dtype in (cutlass.Float16, cutlass.BFloat16):
+            if self.swap_ab:
+                # SwapAB: C is M-major, N elements are strided → scalar atomic add
+                self.epi_layout_atomic = cute.make_layout(shape=(self.ttr_racc_size,), stride=(1,))
+                self.epi_loop_size_atomic = self.ttr_racc_size
+                self.element_offset_atomic = 1
+            elif self.c_dtype in (cutlass.Float16, cutlass.BFloat16):
                 self.epi_layout_atomic = cute.make_layout(
                     shape=(self.ttr_racc_size // 8, 4, 2), stride=(8, 2, 1)
                 )
@@ -361,18 +378,20 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 self.element_offset_atomic = 1
 
         # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
-        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
-            tiled_mma,
-            self.mma_tiler,
-            self.a_dtype,
-            self.b_dtype,
-            self.epi_tile,
-            self.c_dtype,
-            self.c_layout,
-            self.sf_dtype,
-            self.sf_vec_size,
-            self.smem_capacity,
-            self.occupancy,
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage, self.num_alpha_scale_stage = (
+            self._compute_stages(
+                tiled_mma,
+                self.mma_tiler,
+                self.a_dtype,
+                self.b_dtype,
+                self.epi_tile,
+                self.c_dtype,
+                self.epi_compute_layout,
+                self.sf_dtype,
+                self.sf_vec_size,
+                self.smem_capacity,
+                self.occupancy,
+            )
         )
         # Compute A/B/SFA/SFB/C shared memory layout
         self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
@@ -404,6 +423,22 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.c_layout,
             self.epi_tile,
             self.num_c_stage,
+        )
+
+        # SwapAB: alpha is per-N, smem holds cta_tile_N values per stage
+        # Non-swap: alpha is per-M, smem holds cta_tile_M values per stage
+        self.alpha_scale_dim = (
+            self.cta_tile_shape_mnk[1] if self.swap_ab else self.cta_tile_shape_mnk[0]
+        )
+        self.alpha_scale_smem_layout_staged = cute.make_layout(
+            (
+                self.alpha_scale_dim,
+                self.num_alpha_scale_stage,
+            ),
+            stride=(
+                1,
+                self.alpha_scale_dim,
+            ),
         )
 
     @cute.jit
@@ -542,6 +577,24 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.cluster_layout_sfb_vmnk.shape,
             internal_type=cutlass.Int16,
         )
+        if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+            x = tma_tensor_sfb.stride[0][1]
+            y = cute.ceil_div(tma_tensor_sfb.shape[0][1], 4)
+            new_shape = (
+                (tma_tensor_sfb.shape[0][0], ((2, 2), y)),
+                tma_tensor_sfb.shape[1],
+                tma_tensor_sfb.shape[2],
+            )
+            x_times_3 = 3 * x
+            new_stride = (
+                (tma_tensor_sfb.stride[0][0], ((x, x), x_times_3)),
+                tma_tensor_sfb.stride[1],
+                tma_tensor_sfb.stride[2],
+            )
+            tma_tensor_sfb = cute.make_tensor(
+                tma_tensor_sfb.iterator,
+                cute.make_layout(new_shape, stride=new_stride),
+            )
 
         a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
         b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
@@ -608,6 +661,17 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 cute.struct.MemRange[self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)],
                 self.buffer_align_bytes,
             ]
+            # Alpha scale pipeline mbarriers (producer=warp6, consumer=epilogue warps)
+            alpha_scale_load_mbar_ptr: cute.struct.MemRange[
+                cutlass.Int64, self.num_alpha_scale_stage * 2
+            ]
+            # Alpha scale shared memory
+            sAlphaScale: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Float32, cute.cosize(self.alpha_scale_smem_layout_staged)
+                ],
+                16,
+            ]
 
         self.shared_storage = SharedStorage
 
@@ -632,6 +696,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             self.b_smem_layout_staged,
             self.sfa_smem_layout_staged,
             self.sfb_smem_layout_staged,
+            self.alpha_scale_smem_layout_staged,
             self.c_smem_layout_staged,
             self.epi_tile,
             self.tile_sched_params,
@@ -670,6 +735,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         b_smem_layout_staged: cute.ComposedLayout,
         sfa_smem_layout_staged: cute.Layout,
         sfb_smem_layout_staged: cute.Layout,
+        alpha_scale_smem_layout_staged: cute.Layout,
         c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout],
         epi_tile: cute.Tile,
         tile_sched_params: utils.PersistentTileSchedulerParams,
@@ -745,6 +811,24 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             cta_layout_vmnk=cluster_layout_vmnk,
         )
 
+        # Initialize alpha_scale_pipeline (barrier) and states
+        alpha_scale_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            32 * 1,  # alpha_scale_load_warp_id threads
+            32 * 1,
+        )
+        alpha_scale_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            32 * len(self.epilog_warp_id),  # epilogue warps
+            32 * len(self.epilog_warp_id),
+        )
+        alpha_scale_pipeline = pipeline.PipelineCpAsync.create(
+            barrier_storage=storage.alpha_scale_load_mbar_ptr.data_ptr(),
+            num_stages=self.num_alpha_scale_stage,
+            producer_group=alpha_scale_pipeline_producer_group,
+            consumer_group=alpha_scale_pipeline_consumer_group,
+        )
+
         # Tensor memory dealloc barrier init
         tmem = utils.TmemAllocator(
             storage.tmem_holding_buf,
@@ -771,6 +855,8 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
         # (MMA, MMA_N, MMA_K, STAGE)
         sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+        # Alpha scale shared memory tensor
+        sAlphaScale = storage.sAlphaScale.get_tensor(alpha_scale_smem_layout_staged)
 
         #
         # Compute multicast mask for A/B/SFA/SFB buffer full
@@ -815,10 +901,11 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             (None, None, None),
         )
 
-        # (bM, bN, loopM, loopN, loopL)
+        # Tile alpha by alpha_scale_dim (cta_tile_N for swap_ab, cta_tile_M for non-swap)
+        alpha_tiler = (self.alpha_scale_dim, 1, 1)
         galpha_scale_mnl = cute.local_tile(
             malpha_scale_mnl,
-            cute.slice_(self.cta_tile_shape_mnk, (None, 0, 0)),
+            cute.slice_(alpha_tiler, (None, 0, 0)),
             (None, None, None),
         )
 
@@ -1084,6 +1171,113 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             ab_pipeline.producer_tail(ab_producer_state)
 
         #
+        # Specialized Alpha Scale Load warp
+        #
+        if warp_idx == self.alpha_scale_load_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            alpha_scale_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_alpha_scale_stage
+            )
+
+            # Setup copy atom for alpha scale loading
+            atom_copy = cute.make_copy_atom(
+                cute.nvgpu.cpasync.CopyG2SOp(),
+                malpha_scale_mnl.element_type,
+                num_bits_per_copy=malpha_scale_mnl.element_type.width,
+            )
+            tiled_copy_alpha_scale = cute.make_tiled_copy_tv(
+                atom_copy, cute.make_layout((32,)), cute.make_layout((1,))
+            )
+            thr_copy_alpha_scale = tiled_copy_alpha_scale.get_slice(cute.arch.lane_idx())
+
+            tiles_per_expert_w6 = self.weight_per_expert // self.mma_tiler[2]
+            experts_per_split_w6 = k_tile_cnt_local // tiles_per_expert_w6
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+
+                # Split-K: decompose L coord into batch_idx and expert_offset
+                batch_idx_w6 = cur_tile_coord[2] // self.split_k
+                expert_offset_w6 = (cur_tile_coord[2] % self.split_k) * experts_per_split_w6
+
+                # Reset producer state for this tile
+                alpha_scale_producer_state.reset_count()
+                peek_alpha_scale_empty_status = cutlass.Boolean(1)
+                if alpha_scale_producer_state.count < k_tile_cnt_local:
+                    peek_alpha_scale_empty_status = alpha_scale_pipeline.producer_try_acquire(
+                        alpha_scale_producer_state
+                    )
+
+                # Non-swap: alpha indexed by M tile coord; SwapAB: alpha indexed by N tile coord
+                if cutlass.const_expr(self.swap_ab):
+                    alpha_tile_idx = cur_tile_coord[1]
+                else:
+                    alpha_tile_idx = cur_tile_coord[0]
+                galpha_scale_mnl_current_tile = galpha_scale_mnl[
+                    None, alpha_tile_idx, None, batch_idx_w6
+                ]
+
+                tAgAlphaScale = thr_copy_alpha_scale.partition_S(galpha_scale_mnl_current_tile)
+                tAsAlphaScale = thr_copy_alpha_scale.partition_D(sAlphaScale)
+
+                # Load alpha scale for each k tile (one per expert in this split)
+                for k_tile in cutlass.range(0, k_tile_cnt_local, 1, unroll=1):
+                    # Calculate expert index for this k_tile (with split-K offset)
+                    expert_idx = expert_offset_w6 + k_tile // tiles_per_expert_w6
+
+                    # Slice alpha scale for current tile and expert
+                    tAgAlphaScale_slice = tAgAlphaScale[(None, None, expert_idx)]
+                    tAsAlphaScale_slice = tAsAlphaScale[
+                        (None, None, alpha_scale_producer_state.index)
+                    ]
+
+                    # Wait for alpha scale buffer empty
+                    alpha_scale_pipeline.producer_acquire(
+                        alpha_scale_producer_state, peek_alpha_scale_empty_status
+                    )
+
+                    num_iters = cute.size(tAgAlphaScale_slice, mode=[1])
+
+                    # Load alpha scale from global to shared memory
+                    for iter_idx in cutlass.range(num_iters, unroll_full=True):
+                        iter_coord = (None, iter_idx)
+                        pred = cutlass.Boolean(
+                            32 * iter_idx + cute.arch.lane_idx() < malpha_scale_mnl.shape[0]
+                        )
+                        if pred:
+                            cute.copy(
+                                tiled_copy_alpha_scale,
+                                tAgAlphaScale_slice[iter_coord],
+                                tAsAlphaScale_slice[iter_coord],
+                            )
+
+                    # Commit and advance
+                    alpha_scale_pipeline.producer_commit(alpha_scale_producer_state)
+                    alpha_scale_producer_state.advance()
+
+                    # Peek next
+                    peek_alpha_scale_empty_status = cutlass.Boolean(1)
+                    if alpha_scale_producer_state.count < k_tile_cnt_local:
+                        peek_alpha_scale_empty_status = alpha_scale_pipeline.producer_try_acquire(
+                            alpha_scale_producer_state
+                        )
+
+                # Advance to next tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            # Wait for alpha scale buffer empty
+            alpha_scale_pipeline.producer_tail(alpha_scale_producer_state)
+
+        #
         # Specialized MMA warp
         #
         if warp_idx == self.mma_warp_id:
@@ -1168,7 +1362,20 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 )
 
                 tCtSFB_mma = tCtSFB
-                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+                    # Shift TMEM start address for odd tiles (ignores first 64 cols of SFB)
+                    offset = (
+                        cutlass.Int32(2) if mma_tile_coord_mnl[1] % 2 == 1 else cutlass.Int32(0)
+                    )
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr
+                        + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base)
+                        + tcgen05.find_tmem_tensor_col_offset(tCtSFA)
+                        + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+                elif cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
                     # Move in increments of 64 columns of SFB
                     offset = cutlass.Int32((mma_tile_coord_mnl[1] % 2) * 2)
                     shifted_ptr = cute.recast_ptr(
@@ -1326,6 +1533,11 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 bSG_gC_partitioned,
             ) = self.epilog_gmem_copy_and_partition(epi_tidx, tma_atom_c, tCgC, epi_tile, sC)
 
+            # SwapAB: use tiled_copy_r2s (shares T2R thread-value layout) to partition
+            # alpha smem for loading. partition_S on smem gives per-thread alpha source.
+            if cutlass.const_expr(self.swap_ab):
+                thr_copy_r2s_alpha = tiled_copy_r2s.get_slice(epi_tidx)
+
             #
             # Persistent tile scheduling loop
             #
@@ -1349,19 +1561,33 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 producer_group=c_producer_group,
             )
 
-            tiles_per_expert = self.weight_per_expert // self.mma_tiler[2]
-            # For split-K: each CTA handles experts_per_split experts
-            experts_per_split = k_tiles_per_split // tiles_per_expert
+            # Alpha scale consumer state (for non-swap path using warp 6 pipeline)
+            alpha_scale_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_alpha_scale_stage
+            )
+
+            # Create copy atom for loading alpha scale from smem
+            alpha_scale_copy_atom_s2r = cute.make_copy_atom(
+                cute.nvgpu.CopyUniversalOp(),
+                cutlass.Float32,
+                num_bits_per_copy=32,
+            )
+            tiled_copy_alpha_scale_s2r = cute.make_tiled_copy_tv(
+                alpha_scale_copy_atom_s2r,
+                cute.make_layout((32 * len(self.epilog_warp_id),)),
+                cute.make_layout((1,)),
+            )
+            thr_copy_alpha_scale_s2r = tiled_copy_alpha_scale_s2r.get_slice(tidx)
+
             m_total = malpha_scale_mnl.shape[0]
 
             while work_tile.is_valid_tile:
                 # Get tile coord from tile scheduler
                 cur_tile_coord = work_tile.tile_idx
 
-                # Split-K: decompose L coord into batch_idx and split_k_idx
-                # For split_k=1: batch_idx = coord[2], expert_offset = 0
+                # Split-K: decompose L coord into batch_idx
+                # For split_k=1: batch_idx = coord[2]
                 batch_idx = cur_tile_coord[2] // self.split_k
-                expert_offset = (cur_tile_coord[2] % self.split_k) * experts_per_split
 
                 # Use batch_idx for output L coordinate (correct for both split_k=1 and >1)
                 mma_tile_coord_mnl = (
@@ -1386,91 +1612,277 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
                 # initialize the final accumulator
                 tTR_rAcc_final.fill(0.0)
 
-                # Epilogue iterates over experts_per_split experts (not full expert_count)
-                num_experts_k = cutlass.Int32(experts_per_split)
-
-                acc_consumer_state.reset_count()
-                peek_acc_full_status = cutlass.Boolean(1)
-                if acc_consumer_state.count < num_experts_k:
-                    peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
-
                 m_start = cur_tile_coord[0] * self.cta_tile_shape_mnk[0]
                 m_in_bounds = m_start < m_total
                 thread_in_bounds = epi_tidx < (m_total - m_start) if m_in_bounds else False
 
-                # Prologue: prefetch alpha for first expert in this split
-                prefetched_alpha = cutlass.Float32(0.0)
-                if thread_in_bounds:
-                    prefetched_alpha = galpha_scale_mnl[
-                        epi_tidx, cur_tile_coord[0], expert_offset, batch_idx
-                    ]
-
-                for expert_idx in cutlass.range(num_experts_k):
-                    tTR_tAcc = tTR_tAcc_base[
-                        (None, None, None, None, None, acc_consumer_state.index)
-                    ]
-                    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
-                    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
-
-                    current_alpha_scale = prefetched_alpha
-
+                if cutlass.const_expr(not self.swap_ab):
                     #
-                    # Wait for accumulator buffer full
+                    # Standard path: alpha loaded by warp 6 via alpha_scale_pipeline.
+                    # One scalar alpha per M position per expert.
                     #
-                    acc_pipeline.consumer_wait(acc_consumer_state, peek_acc_full_status)
+                    alpha_scale_consumer_state.reset_count()
+                    peek_alpha_scale_full_status = cutlass.Boolean(1)
+                    if alpha_scale_consumer_state.count < k_tile_cnt_local:
+                        peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
+                            alpha_scale_consumer_state
+                        )
 
-                    for subtile_idx in cutlass.range(subtile_cnt):
-                        #
-                        # Load accumulator from tensor memory buffer to register
-                        #
-                        # (T2R, T2R_M, T2R_N)
-                        tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
-                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
-
-                        #
-                        # Update accumulator by scale factor
-                        #
-                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
-
-                        acc_vec = tTR_rAcc.load()
-                        final_vec = tTR_rAcc_subtile.load()
-
-                        final_vec = acc_vec * current_alpha_scale + final_vec
-                        tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
-
-                    #
-                    # Async arrive accumulator buffer empty
-                    #
-                    with cute.arch.elect_one():
-                        acc_pipeline.consumer_release(acc_consumer_state)
-                    acc_consumer_state.advance()
-
-                    # Prefetch next expert's alpha after releasing acc buffer
-                    next_expert = expert_idx + 1
-                    clamped_expert = (
-                        next_expert if next_expert < num_experts_k else num_experts_k - 1
-                    )
-                    prefetched_alpha = cutlass.Float32(0.0)
-                    if thread_in_bounds:
-                        prefetched_alpha = galpha_scale_mnl[
-                            epi_tidx, cur_tile_coord[0], expert_offset + clamped_expert, batch_idx
-                        ]
-
+                    acc_consumer_state.reset_count()
                     peek_acc_full_status = cutlass.Boolean(1)
-                    if acc_consumer_state.count < num_experts_k:
+                    if acc_consumer_state.count < k_tile_cnt_local:
                         peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                    for k_tile in cutlass.range(k_tile_cnt_local):
+                        tTR_tAcc = tTR_tAcc_base[
+                            (None, None, None, None, None, acc_consumer_state.index)
+                        ]
+                        tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+                        subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+
+                        # Wait for alpha scale buffer full
+                        alpha_scale_pipeline.consumer_wait(
+                            alpha_scale_consumer_state, peek_alpha_scale_full_status
+                        )
+
+                        # Load alpha scale from shared memory for current expert
+                        alpha_scale_smem_slice = sAlphaScale[
+                            (None, alpha_scale_consumer_state.index)
+                        ]
+                        tAsAlphaScale_slice = thr_copy_alpha_scale_s2r.partition_S(
+                            alpha_scale_smem_slice
+                        )
+                        current_alpha_scale_reg = cute.make_rmem_tensor(
+                            tAsAlphaScale_slice.shape, cutlass.Float32
+                        )
+                        cute.copy(
+                            alpha_scale_copy_atom_s2r,
+                            tAsAlphaScale_slice,
+                            current_alpha_scale_reg,
+                        )
+                        current_alpha_scale = current_alpha_scale_reg[0]
+
+                        # Wait for accumulator buffer full
+                        acc_pipeline.consumer_wait(acc_consumer_state, peek_acc_full_status)
+
+                        for subtile_idx in cutlass.range(subtile_cnt):
+                            tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                            cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                            tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                            acc_vec = tTR_rAcc.load()
+                            final_vec = tTR_rAcc_subtile.load()
+                            final_vec = acc_vec * current_alpha_scale + final_vec
+                            tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
+
+                        # Release alpha scale buffer
+                        alpha_scale_pipeline.consumer_release(alpha_scale_consumer_state)
+                        alpha_scale_consumer_state.advance()
+
+                        peek_alpha_scale_full_status = cutlass.Boolean(1)
+                        if alpha_scale_consumer_state.count < k_tile_cnt_local:
+                            peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
+                                alpha_scale_consumer_state
+                            )
+
+                        # Async arrive accumulator buffer empty
+                        with cute.arch.elect_one():
+                            acc_pipeline.consumer_release(acc_consumer_state)
+                        acc_consumer_state.advance()
+
+                        peek_acc_full_status = cutlass.Boolean(1)
+                        if acc_consumer_state.count < k_tile_cnt_local:
+                            peek_acc_full_status = acc_pipeline.consumer_try_wait(
+                                acc_consumer_state
+                            )
+
+                else:
+                    #
+                    # SwapAB path: warp 6 loads cta_N alphas per expert via pipeline.
+                    # Epilogue waits on pipeline, then copies epi_tile_n alpha per subtile
+                    # to stage-0 region of sAlphaScale for broadcast read.
+                    #
+                    alpha_scale_consumer_state.reset_count()
+                    peek_alpha_scale_full_status = cutlass.Boolean(1)
+                    if alpha_scale_consumer_state.count < k_tile_cnt_local:
+                        peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
+                            alpha_scale_consumer_state
+                        )
+
+                    acc_consumer_state.reset_count()
+                    peek_acc_full_status = cutlass.Boolean(1)
+                    if acc_consumer_state.count < k_tile_cnt_local:
+                        peek_acc_full_status = acc_pipeline.consumer_try_wait(acc_consumer_state)
+
+                    for k_tile in cutlass.range(k_tile_cnt_local):
+                        tTR_tAcc = tTR_tAcc_base[
+                            (None, None, None, None, None, acc_consumer_state.index)
+                        ]
+                        tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+                        subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+
+                        # Wait for warp 6 to load cta_N alphas for this expert
+                        alpha_scale_pipeline.consumer_wait(
+                            alpha_scale_consumer_state, peek_alpha_scale_full_status
+                        )
+
+                        # Get contiguous alpha slice for this stage: (cta_N,) stride (1,)
+                        alpha_smem_slice = sAlphaScale[(None, alpha_scale_consumer_state.index)]
+
+                        # Wait for acc
+                        acc_pipeline.consumer_wait(acc_consumer_state, peek_acc_full_status)
+
+                        # Create 2D broadcast view of alpha smem:
+                        # (epi_tile_m, cta_N) stride (0, 1) — broadcast M, stride-1 N
+                        sAlpha_bcast = cute.make_tensor(
+                            alpha_smem_slice.iterator,
+                            cute.make_layout(
+                                shape=(self.epi_tile_m_size, self.cta_tile_shape_mnk[1]),
+                                stride=(0, 1),
+                            ),
+                        )
+                        # Partition smem using r2s copy (shares T2R thread-value layout)
+                        tRS_sAlpha = thr_copy_r2s_alpha.partition_D(sAlpha_bcast)
+
+                        for subtile_idx in cutlass.range(subtile_cnt):
+                            # Load alpha from partitioned smem (32 N values)
+                            tRS_sAlpha_sub = tRS_sAlpha[(None, None, subtile_idx)]
+                            rAlpha_n = cute.make_rmem_tensor(tRS_sAlpha_sub.shape, cutlass.Float32)
+                            rAlpha_n.store(tRS_sAlpha_sub.load())
+
+                            # Broadcast alpha across M: (32N,1M) → (32N,32M)
+                            rAlpha_bcast = cute.make_tensor(
+                                rAlpha_n.iterator,
+                                cute.make_layout(
+                                    shape=tTR_rAcc.shape,
+                                    stride=(
+                                        (1, 0),  # (N_stride=1, M_stride=0)
+                                        0,
+                                        0,
+                                    ),
+                                ),
+                            )
+
+                            tTR_tAcc_mn = tTR_tAcc[(None, None, None, subtile_idx)]
+                            cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+                            tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                            acc_vec = tTR_rAcc.load()
+                            final_vec = tTR_rAcc_subtile.load()
+                            alpha_vec = rAlpha_bcast.load()
+                            final_vec = acc_vec * alpha_vec + final_vec
+                            tTR_rAcc_subtile.store(final_vec.to(self.acc_dtype))
+
+                        # Release alpha scale buffer
+                        alpha_scale_pipeline.consumer_release(alpha_scale_consumer_state)
+                        alpha_scale_consumer_state.advance()
+
+                        peek_alpha_scale_full_status = cutlass.Boolean(1)
+                        if alpha_scale_consumer_state.count < k_tile_cnt_local:
+                            peek_alpha_scale_full_status = alpha_scale_pipeline.consumer_try_wait(
+                                alpha_scale_consumer_state
+                            )
+
+                        # Async arrive accumulator buffer empty
+                        with cute.arch.elect_one():
+                            acc_pipeline.consumer_release(acc_consumer_state)
+                        acc_consumer_state.advance()
+
+                        peek_acc_full_status = cutlass.Boolean(1)
+                        if acc_consumer_state.count < k_tile_cnt_local:
+                            peek_acc_full_status = acc_pipeline.consumer_try_wait(
+                                acc_consumer_state
+                            )
 
                 #
                 # Store accumulator to global memory in subtiles
                 #
                 subtile_cnt = cute.size(tTR_rAcc_final.shape, mode=[3])
 
-                if cutlass.const_expr(self.split_k > 1):
+                if cutlass.const_expr(self.split_k > 1 and self.swap_ab):
                     #
-                    # Split-K atomic add path: each CTA atomically adds its
+                    # SwapAB split-K: stage through non-swizzled smem for vectorized
+                    # atomic add. C is M-major → M elements contiguous in global mem.
+                    # Each thread writes its register elements to smem by (M, N) coord,
+                    # then threads read M-contiguous chunks for fp16x8 atomic add.
+                    # Reuse sA storage (mainloop done, sA no longer needed).
+                    #
+                    epi_m = self.epi_tile_m_size
+                    epi_n = self.epi_tile_n_size
+                    m_groups = epi_m // 8
+                    groups_per_thread = (m_groups * epi_n) // (32 * len(self.epilog_warp_id))
+                    m_base_tile = cur_tile_coord[0] * self.cta_tile_shape_mnk[0]
+
+                    # Non-swizzled M-major smem staging (reuse sC memory,
+                    # which is unused during split-K atomic store).
+                    # Remove sC's swizzle by creating a raw pointer view.
+                    sStaging = cute.make_tensor(
+                        cute.recast_ptr(
+                            sC.iterator, swizzle_=cute.make_swizzle(0, 0, 0), dtype=self.c_dtype
+                        ),
+                        cute.make_layout(
+                            shape=(epi_m, epi_n),
+                            stride=(1, epi_m),
+                        ),
+                    )
+
+                    for subtile_idx in cutlass.range(subtile_cnt):
+                        tTR_rAcc_subtile = tTR_rAcc_final[(None, None, None, subtile_idx)]
+                        acc_vec = tTR_rAcc_subtile.load()
+                        acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
+
+                        # Each thread writes its elements to smem at (epi_tidx, n)
+                        # epi_tidx = M position, register elements span N positions
+                        rC_flat = cute.make_tensor(
+                            tTR_rC.iterator,
+                            cute.make_layout((cute.size(tTR_rC),)),
+                        )
+                        tTR_rC.store(acc_vec)
+                        for ei in cutlass.range(cute.size(tTR_rC), unroll_full=True):
+                            sStaging[(epi_tidx, ei)] = rC_flat[ei]
+
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                        # Read M-contiguous groups from staging and vectorized atomic
+                        n_base_subtile = (
+                            cur_tile_coord[1] * self.cta_tile_shape_mnk[1] + subtile_idx * epi_n
+                        )
+
+                        for gi in cutlass.range(groups_per_thread, unroll_full=True):
+                            group_idx = epi_tidx * groups_per_thread + gi
+                            n_local = group_idx // m_groups
+                            m_local_start = (group_idx % m_groups) * 8
+
+                            m_global = m_base_tile + m_local_start
+                            n_global = n_base_subtile + n_local
+                            if m_global + 7 < m_total:
+                                rVec = cute.make_rmem_tensor(
+                                    cute.make_layout((4, 2), stride=(2, 1)),
+                                    self.c_dtype,
+                                )
+                                rVec_flat = cute.make_tensor(rVec.iterator, cute.make_layout((8,)))
+                                for j in cutlass.range(8, unroll_full=True):
+                                    rVec_flat[j] = sStaging[(m_local_start + j, n_local)]
+
+                                scatter_out = cute.domain_offset(
+                                    (m_global, n_global, batch_idx), mC_raw
+                                )
+                                if cutlass.const_expr(self.c_dtype == cutlass.Float16):
+                                    vectorized_atomic_add_fp16x8(rVec, scatter_out)
+                                elif cutlass.const_expr(self.c_dtype == cutlass.BFloat16):
+                                    vectorized_atomic_add_bf16x8(rVec, scatter_out)
+                                else:
+                                    for j in cutlass.range(8, unroll_full=True):
+                                        scatter_j = cute.domain_offset((j, 0, 0), scatter_out)
+                                        atomic_add_func(rVec_flat[j], scatter_j)
+
+                        self.epilog_sync_barrier.arrive_and_wait()
+
+                elif cutlass.const_expr(self.split_k > 1):
+                    #
+                    # Non-swap split-K atomic add path: each CTA atomically adds its
                     # partial result directly to the output C tensor.
-                    # Guard with M bounds check to avoid OOB writes when
-                    # M is not a multiple of tile_M.
+                    # N-major C → vectorize along N.
                     #
                     rOut_epi = cute.make_tensor(tTR_rC.iterator, epi_layout_atomic)
                     m_coord = cur_tile_coord[0] * self.cta_tile_shape_mnk[0] + epi_tidx
@@ -1628,7 +2040,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         # Make tiledCopy for tensor memory load
         copy_atom_t2r = sm100_utils.get_tmem_load_op(
             self.cta_tile_shape_mnk,
-            self.c_layout,
+            self.epi_compute_layout,
             self.c_dtype,
             self.acc_dtype,
             epi_tile,
@@ -1696,7 +2108,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
         """
         copy_atom_r2s = sm100_utils.get_smem_store_op(
-            self.c_layout, self.c_dtype, self.acc_dtype, tiled_copy_t2r
+            self.epi_compute_layout, self.c_dtype, self.acc_dtype, tiled_copy_t2r
         )
         tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
         # (R2S, R2S_M, R2S_N, PIPE_D)
@@ -1764,7 +2176,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         sf_vec_size: int,
         smem_capacity: int,
         occupancy: int,
-    ) -> Tuple[int, int, int]:
+    ) -> Tuple[int, int, int, int]:
         """Computes the number of stages for A/B/C operands based on heuristics.
 
         :param tiled_mma: The tiled MMA object defining the core computation.
@@ -1791,16 +2203,21 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         :type occupancy: int
 
         :return: A tuple containing the computed number of stages for:
-                 (ACC stages, A/B operand stages, C stages)
-        :rtype: tuple[int, int, int]
+                 (ACC stages, A/B operand stages, C stages, alpha scale stages)
+        :rtype: tuple[int, int, int, int]
         """
-        # ACC stages: 3 for N=128 to allow MMA to run ahead of epilogue
-        num_acc_stage = 3
+        # ACC stages: match base gemm heuristic
+        num_acc_stage = 2
         if mma_tiler_mnk[1] == 256:
             num_acc_stage = 1
+        elif mma_tiler_mnk[1] <= 128:
+            num_acc_stage = 3
 
         # Default C stages
         num_c_stage = 2
+
+        # Default Alpha scale stages
+        num_alpha_scale_stage = 10
 
         # Calculate smem layout and size for one stage of A, B, SFA, SFB and C
         a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
@@ -1845,12 +2262,22 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
         c_bytes = c_bytes_per_stage * num_c_stage
 
+        # Alpha scale shared memory (element-contiguous within stage)
+        # Use max(M, N) to cover both swap_ab (cta_tile_N) and non-swap (cta_tile_M)
+        alpha_dim = max(mma_tiler_mnk[0] // tiled_mma.thr_id.shape, mma_tiler_mnk[1])
+        alpha_bytes = cute.size_in_bytes(
+            cutlass.Float32,
+            cute.make_layout(
+                (alpha_dim, num_alpha_scale_stage),
+                stride=(1, alpha_dim),
+            ),
+        )
         # Calculate A/B/SFA/SFB stages:
         # Start with total smem per CTA (capacity / occupancy)
         # Subtract reserved bytes and initial C stages bytes
         # Divide remaining by bytes needed per A/B/SFA/SFB stage
         num_ab_stage = (
-            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
+            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes + alpha_bytes)
         ) // ab_bytes_per_stage
 
         # Refine epilogue stages:
@@ -1859,10 +2286,10 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         num_c_stage += (
             smem_capacity
             - occupancy * ab_bytes_per_stage * num_ab_stage
-            - occupancy * (mbar_helpers_bytes + c_bytes)
+            - occupancy * (mbar_helpers_bytes + c_bytes + alpha_bytes)
         ) // (occupancy * c_bytes_per_stage)
 
-        return num_acc_stage, num_ab_stage, num_c_stage
+        return num_acc_stage, num_ab_stage, num_c_stage, num_alpha_scale_stage
 
     @staticmethod
     def _compute_grid(
@@ -2018,8 +2445,7 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
         # Skip invalid mma tile shape
         if mma_tiler_mn[0] not in [128, 256]:
             is_valid = False
-        # TODO: Add tile_n=64 and tile_n=192 support
-        if mma_tiler_mn[1] not in [64, 128, 256]:
+        if mma_tiler_mn[1] not in [64, 128, 192, 256]:
             is_valid = False
         # Skip illegal cluster shape
         if cluster_shape_mn[0] % (2 if mma_tiler_mn[0] == 256 else 1) != 0:
@@ -2159,11 +2585,19 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             layout=cute.make_ordered_layout((n, k, l), order=(1, 0, 2)),
         )
 
-        # Create C tensor (M, N, L) - N-major
-        c = cute.make_tensor(
-            c_ptr,
-            layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2)),
-        )
+        # Create C tensor (M, N, L)
+        if cutlass.const_expr(self.swap_ab):
+            # SwapAB: M-major (col-major) to transpose output back
+            c = cute.make_tensor(
+                c_ptr,
+                layout=cute.make_ordered_layout((m, n, l), order=(0, 1, 2)),
+            )
+        else:
+            # Default: N-major (row-major)
+            c = cute.make_tensor(
+                c_ptr,
+                layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2)),
+            )
 
         # Create A scale factor tensor (swizzled layout)
         # Shape: (32, 4, m // 128, 4, scale_k // 4, l)
@@ -2183,10 +2617,13 @@ class Sm100BlockScaledPersistentDenseGemmKernel:
             ),
         )
 
-        # Create alpha scale tensor (M, expert_count, L) - expert_count-major
+        # Create alpha scale tensor - token-major for coalesced global memory access
+        # Standard: (M, expert_count, L) — alpha per M (token)
+        # SwapAB: (N, expert_count, L) — alpha per N (token)
+        alpha_token_dim = n if cutlass.const_expr(self.swap_ab) else m
         alpha_scale = cute.make_tensor(
             alpha_scale_ptr,
-            layout=cute.make_ordered_layout((m, expert_count, l), order=(1, 0, 2)),
+            layout=cute.make_ordered_layout((alpha_token_dim, expert_count, l), order=(0, 1, 2)),
         )
 
         # Call the kernel

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/utils.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/utils.py
@@ -257,6 +257,28 @@ def vectorized_atomic_add_bf16x8(rOut_epi_packed,
 
 
 @dsl_user_op
+def vectorized_atomic_add_fp16x8(rOut_epi_packed,
+                                 scatter_out_offset,
+                                 loc=None,
+                                 ip=None):
+    llvm.inline_asm(
+        None,
+        [
+            scatter_out_offset.iterator.llvm_ptr,
+            llvm.bitcast(T.i32(), rOut_epi_packed[0, None].load().ir_value()),
+            llvm.bitcast(T.i32(), rOut_epi_packed[1, None].load().ir_value()),
+            llvm.bitcast(T.i32(), rOut_epi_packed[2, None].load().ir_value()),
+            llvm.bitcast(T.i32(), rOut_epi_packed[3, None].load().ir_value()),
+        ],
+        "red.global.v4.f16x2.add.noftz [$0], {$1, $2, $3, $4};",
+        "l,r,r,r,r",
+        has_side_effects=True,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
 def vectorized_atomic_add_fp32x2(rOut_epi_packed,
                                  scatter_out_offset,
                                  loc=None,
@@ -299,6 +321,19 @@ def atomic_add_func(rOut_epi_packed, scatter_out_offset, loc=None, ip=None):
                 llvm.bitcast(T.i16(), rOut_epi_packed.ir_value()),
             ],
             "red.add.noftz.bf16 [$0], $1;",
+            "l,h",
+            has_side_effects=True,
+            loc=loc,
+            ip=ip,
+        )
+    elif cutlass.const_expr(rOut_epi_packed.dtype == cutlass.Float16):
+        llvm.inline_asm(
+            None,
+            [
+                scatter_out_offset.iterator.llvm_ptr,
+                llvm.bitcast(T.i16(), rOut_epi_packed.ir_value()),
+            ],
+            "red.add.noftz.f16 [$0], $1;",
             "l,h",
             has_side_effects=True,
             loc=loc,

--- a/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
+++ b/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
@@ -102,6 +102,7 @@ def run(
     skip_ref_check: bool = False,
     use_cold_l2: bool = False,
     use_cupti: bool = True,
+    split_k: int = 1,
     **kwargs,
 ):
     """Execute a persistent batched dense blockscaled GEMM operation on Blackwell architecture.
@@ -164,6 +165,7 @@ def run(
     print(f"Skip reference checking: {skip_ref_check}")
     print(f"Use cold L2: {'True' if use_cold_l2 else 'False'}")
     print(f"Use CUPTI: {'True' if use_cupti else 'False'}")
+    print(f"Split-K: {split_k}")
 
     # Skip unsupported testcase
     if not Sm100BlockScaledPersistentDenseGemmKernel.can_implement(
@@ -350,7 +352,12 @@ def run(
         weight_per_expert,
         use_prefetch,
         prefetch_dist,
+        split_k,
     )
+
+    # For split-K > 1: zero-initialize C (kernel uses atomic add for reduction)
+    if split_k > 1:
+        c_torch.zero_()
 
     # Compute max active clusters on current device
     hardware_info = cutlass.utils.HardwareInfo()
@@ -438,9 +445,12 @@ def run(
         b_tensor, _ = cutlass_torch.cute_tensor_like(
             b_ref, ab_dtype, is_dynamic_layout=True, assumed_align=16
         )
-        c_tensor, _ = cutlass_torch.cute_tensor_like(
+        c_tensor, c_torch_gen = cutlass_torch.cute_tensor_like(
             c_ref, c_dtype, is_dynamic_layout=True, assumed_align=16
         )
+        # Zero-init C for split-K (atomic adds accumulate onto initial values)
+        if split_k > 1:
+            c_torch_gen.zero_()
 
         # Mark tensor to be byte aligned
         a_tensor.mark_compact_shape_dynamic(
@@ -575,6 +585,12 @@ if __name__ == "__main__":
         default=True,
         help="Use CUPTI for profiling (default: True)",
     )
+    parser.add_argument(
+        "--split_k",
+        type=int,
+        default=1,
+        help="Split-K factor (default: 1)",
+    )
     args = parser.parse_args()
 
     if len(args.mnkl) != 4:
@@ -606,6 +622,7 @@ if __name__ == "__main__":
         args.skip_ref_check,
         args.use_cold_l2,
         args.use_cupti,
+        args.split_k,
     )
     print(f"Execution time: {exec_time:.2f} us")
     print("PASS")

--- a/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
+++ b/tests/scripts/cute_dsl_kernels/moe_as_dense_gemm/run_moe_as_dense_gemm_fc2.py
@@ -103,6 +103,7 @@ def run(
     use_cold_l2: bool = False,
     use_cupti: bool = True,
     split_k: int = 1,
+    swap_ab: bool = False,
     **kwargs,
 ):
     """Execute a persistent batched dense blockscaled GEMM operation on Blackwell architecture.
@@ -149,6 +150,10 @@ def run(
         raise ValueError(f"k ({k}) must be divisible by expert_count ({expert_count})")
     weight_per_expert = k // expert_count
 
+    # SwapAB: output must be M-major (col-major) to maintain functional equivalence
+    if swap_ab:
+        c_major = "m"
+
     print("Running Sm100 Persistent Dense BlockScaled GEMM test with:")
     print(f"mnkl: {mnkl}")
     print(f"AB dtype: {ab_dtype}, SF dtype: {sf_dtype}, SF Vec size: {sf_vec_size}")
@@ -166,6 +171,7 @@ def run(
     print(f"Use cold L2: {'True' if use_cold_l2 else 'False'}")
     print(f"Use CUPTI: {'True' if use_cupti else 'False'}")
     print(f"Split-K: {split_k}")
+    print(f"Swap AB: {swap_ab}")
 
     # Skip unsupported testcase
     if not Sm100BlockScaledPersistentDenseGemmKernel.can_implement(
@@ -312,22 +318,21 @@ def run(
     # Additional Alpha scale tensor
     def create_alpha_scale_tensor(l, m, n, expert_count, dtype):  # noqa: E741
         ### if not swapAB
-        # True means alpha_scale is expert_count major.
+        # True means alpha_scale is token (m) major for coalesced global memory access.
         alpha_scale_ref = cutlass_torch.matrix(
             l,
             m,
             expert_count,
-            False,  # expert_count is major
+            True,  # m (token) is major
             cutlass.Float32,
             # Debug alpha scale data
             # init_type=cutlass_torch.TensorInitType.SCALAR,
             # init_config=cutlass_torch.ScalarInitConfig(value=1),
         )
-        # currently we assume alpha_scale is n major, which means token major and 4B aligned, should be 4B aligned.
+        # alpha_scale is token major and 4B aligned.
         alpha_scale_tensor, alpha_scale_torch = cutlass_torch.cute_tensor_like(
             alpha_scale_ref, cutlass.Float32, is_dynamic_layout=True, assumed_align=4
         )
-        # print(f"alpha_scale_ref: {alpha_scale_ref.shape}")
         # reshape makes memory contiguous for reference check.
         alpha_scale_ref = (
             alpha_scale_ref.permute(2, 0, 1)
@@ -339,8 +344,11 @@ def run(
 
         return alpha_scale_ref, alpha_scale_tensor, alpha_scale_torch
 
+    # Alpha scale: (token_dim, expert_count, L).
+    # Standard: token_dim = M. SwapAB: token_dim = N (tokens are the N dimension).
+    alpha_token_dim = n if swap_ab else m
     alpha_scale_ref, alpha_scale_tensor, alpha_scale_torch = create_alpha_scale_tensor(
-        l, m, n, expert_count, cutlass.Float32
+        l, alpha_token_dim, n, expert_count, cutlass.Float32
     )
 
     # Configure gemm kernel
@@ -353,6 +361,7 @@ def run(
         use_prefetch,
         prefetch_dist,
         split_k,
+        swap_ab,
     )
 
     # For split-K > 1: zero-initialize C (kernel uses atomic add for reduction)
@@ -396,8 +405,12 @@ def run(
         print("Verifying results...")
         res_a = torch.einsum("mkl,mkl->mkl", a_ref, sfa_ref)
         res_b = torch.einsum("nkl,nkl->nkl", b_ref, sfb_ref)
-        # Final reference result is the product of res_a, res_b and alpha_scale_ref.
-        ref = torch.einsum("mkl,nkl,mkl->mnl", res_a, res_b, alpha_scale_ref)
+        if swap_ab:
+            # SwapAB: alpha indexed by N (token dim), broadcast along M
+            ref = torch.einsum("mkl,nkl,nkl->mnl", res_a, res_b, alpha_scale_ref)
+        else:
+            # Standard: alpha indexed by M (token dim), broadcast along N
+            ref = torch.einsum("mkl,nkl,mkl->mnl", res_a, res_b, alpha_scale_ref)
 
         # Convert c back to f32 for comparison.
         c_ref_device = c_ref.cuda()
@@ -471,7 +484,9 @@ def run(
 
         _, sfa_tensor, _ = create_scale_factor_tensor(l, m, k, sf_vec_size, sf_dtype)
         _, sfb_tensor, _ = create_scale_factor_tensor(l, n, k, sf_vec_size, sf_dtype)
-        _, alpha_scale_tensor, _ = create_alpha_scale_tensor(l, m, n, expert_count, cutlass.Float32)
+        _, alpha_scale_tensor, _ = create_alpha_scale_tensor(
+            l, alpha_token_dim, n, expert_count, cutlass.Float32
+        )
         return cute.testing.JitArguments(
             a_tensor,
             b_tensor,
@@ -591,6 +606,12 @@ if __name__ == "__main__":
         default=1,
         help="Split-K factor (default: 1)",
     )
+    parser.add_argument(
+        "--swap_ab",
+        action="store_true",
+        default=False,
+        help="Swap A/B roles: A=weight, B=activation (default: False)",
+    )
     args = parser.parse_args()
 
     if len(args.mnkl) != 4:
@@ -623,6 +644,7 @@ if __name__ == "__main__":
         args.use_cold_l2,
         args.use_cupti,
         args.split_k,
+        args.swap_ab,
     )
     print(f"Execution time: {exec_time:.2f} us")
     print("PASS")


### PR DESCRIPTION
# [None][perf] FC2 DenseGEMM autotune: split-K, swap_ab, fine-grained tuning buckets

## Summary

Improves the MoE FC2 DenseGEMM kernel and its autotune setup:

- Add split-K (sk ∈ {1, 2, 4}) and additional `(mma_tiler_mn, cluster_shape_mn)` candidates; epilogue uses atomic-add reduction when `split_k > 1`.
- Add `swap_ab` mode in the Blackwell MoE FC2 kernel (token-major alpha-scale buffer, dedicated `cp.async` warp).
- Cast `m/n/k/l` from `Int64` → `Int32` at the kernel entry; required by downstream `cutlass.range` / `cute.size` for small-m autotune profiling.
- Switch FC2 autotuner to `deep_gemm_gen_tuning_buckets` (8-stride below 128, 128-stride above) and raise `tune_max_num_tokens` 256 → 512 to match FC1.

## Performance

NVFP4, n=7168, k=65536, expert_count=256, B200, cold L2.
Brute-force sweep over (m × tactic × split_k × swap_ab) on the new kernel vs baseline (HEAD~4, no split-K / no swap_ab).

| m | new min (us) | new tactic | baseline min (us) | baseline tactic |
| --- | --- | --- | --- | --- |
| 32 | 52.09 | (128, 128),(1, 2),sk=2,swap=0 | 57.63 | (128, 64),(1, 1),sk=1,swap=0 |
| 64 | 52.68 | (128, 128),(1, 2),sk=2,swap=0 | 58.04 | (128, 64),(1, 1),sk=1,swap=0 |
| 96 | 53.15 | (128, 128),(1, 2),sk=2,swap=0 | 58.88 | (128, 64),(1, 1),sk=1,swap=0 |
| 128 | 53.89 | (128, 128),(1, 2),sk=2,swap=0 | 66.20 | (128, 64),(1, 1),sk=1,swap=0 |
| 160 | 68.00 | (256, 128),(2, 1),sk=1,swap=0 | 70.61 | (256, 128),(2, 1),sk=1,swap=0 |
| 192 | 68.30 | (256, 128),(2, 1),sk=1,swap=0 | 70.86 | (256, 128),(2, 1),sk=1,swap=0 |
| 224 | 68.56 | (256, 128),(2, 1),sk=1,swap=0 | 70.92 | (256, 128),(2, 1),sk=1,swap=0 |
| 256 | 68.78 | (256, 128),(2, 1),sk=1,swap=0 | 71.24 | (256, 128),(2, 1),sk=1,swap=0 |
| 288 | 97.32 | (128, 128),(1, 2),sk=4,swap=0 | 135.45 | (256, 128),(2, 1),sk=1,swap=0 |
| 320 | 99.00 | (128, 128),(1, 2),sk=4,swap=0 | 135.56 | (256, 128),(2, 1),sk=1,swap=0 |
| 352 | 99.81 | (128, 128),(1, 2),sk=4,swap=0 | 135.34 | (256, 128),(2, 1),sk=1,swap=0 |
| 384 | 100.75 | (128, 128),(1, 2),sk=4,swap=0 | 135.84 | (256, 128),(2, 1),sk=1,swap=0 |

Highlights:
- **Small m (32–128)**: `split_k=2` lifts per-wave occupancy → +10–23%.
- **Large m (288–384)**: the m=288 step in the baseline (71→135us) is reduced to ~100us by `split_k=4` → **+35–39%**.
- Mid m (160–256): same tactic chosen as baseline, +3–4% kernel-level tweak.

## Test Plan

- [x] Kernel-level sweep across (m × tactic × split_k × swap_ab) on B200; numerical correctness verified against the reference implementation.
- [x] Op-level autotune + bench through `torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_fc2_blackwell`; autotune cache populated for all buckets with no failures.
- [x] CI: `/bot run` on B200 stages.

**contributors**: @mingyangHao @zongfeijing @JacobHu-NV



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added split-K execution support for MoE FC2 dense GEMM with configurable split factors.
  * Added SwapAB mode to change output layout and alpha-scaling behavior.
  * Added optimized vectorized FP16 atomic-reduction operations for split-K paths.

* **Tests**
  * Extended test runner and CLI to validate split-K and SwapAB configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->