### PR TITLE
[None][fix] Use dynamic port in sharded_rmsnorm tests to avoid EADDRINUSE

### DIFF
--- a/tests/unittest/auto_deploy/multigpu/custom_ops/test_sharded_rmsnorm.py
+++ b/tests/unittest/auto_deploy/multigpu/custom_ops/test_sharded_rmsnorm.py
@@ -19,6 +19,7 @@ import torch.distributed as dist
 from mpi4py import MPI
 
 from tensorrt_llm._torch.auto_deploy.distributed.common import initialize, is_initialized
+from tensorrt_llm._utils import get_free_port
 
 # Register this module for cloudpickle serialization for MPI workers
 cloudpickle.register_pickle_by_value(sys.modules[__name__])
@@ -42,6 +43,7 @@ def _reference_rmsnorm(input: torch.Tensor, weight: torch.Tensor, eps: float) ->
 
 def _run_sharded_rmsnorm_test(
     tensor_parallel_size: int,
+    port: int,
     batch_size: int = 2,
     seq_len: int = 8,
     hidden_size: int = 64,
@@ -66,7 +68,7 @@ def _run_sharded_rmsnorm_test(
     torch.cuda.set_device(rank)
 
     if not is_initialized():
-        initialize(rank, port=29500)
+        initialize(rank, port=port)
 
     # Map string to torch.dtype inside worker to avoid cloudpickle serialization issues
     dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16}
@@ -120,18 +122,19 @@ def test_sharded_rmsnorm_functional(mpi_pool_executor):
     """Functional test: verify sharded_rmsnorm produces correct numerical results."""
     torch.manual_seed(0)
     tensor_parallel_size = mpi_pool_executor.num_workers
+    port = get_free_port()
 
     results = mpi_pool_executor.map(
         _run_sharded_rmsnorm_test,
-        *zip(*[(tensor_parallel_size,)] * tensor_parallel_size),
+        *zip(*[(tensor_parallel_size, port)] * tensor_parallel_size),
     )
     for r in results:
         assert r is True
 
 
-def _run_sharded_rmsnorm_hidden_size_test(tensor_parallel_size: int, hidden_size: int):
+def _run_sharded_rmsnorm_hidden_size_test(tensor_parallel_size: int, port: int, hidden_size: int):
     """Worker function for hidden size parametrized test."""
-    return _run_sharded_rmsnorm_test(tensor_parallel_size, hidden_size=hidden_size)
+    return _run_sharded_rmsnorm_test(tensor_parallel_size, port=port, hidden_size=hidden_size)
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for this test")
@@ -141,18 +144,19 @@ def test_sharded_rmsnorm_different_hidden_sizes(mpi_pool_executor, hidden_size):
     """Test sharded_rmsnorm with different hidden sizes."""
     torch.manual_seed(0)
     tensor_parallel_size = mpi_pool_executor.num_workers
+    port = get_free_port()
 
     results = mpi_pool_executor.map(
         _run_sharded_rmsnorm_hidden_size_test,
-        *zip(*[(tensor_parallel_size, hidden_size)] * tensor_parallel_size),
+        *zip(*[(tensor_parallel_size, port, hidden_size)] * tensor_parallel_size),
     )
     for r in results:
         assert r is True
 
 
-def _run_sharded_rmsnorm_dtype_test(tensor_parallel_size: int, dtype_str: str):
+def _run_sharded_rmsnorm_dtype_test(tensor_parallel_size: int, port: int, dtype_str: str):
     """Worker function for dtype parametrized test."""
-    return _run_sharded_rmsnorm_test(tensor_parallel_size, dtype_str=dtype_str)
+    return _run_sharded_rmsnorm_test(tensor_parallel_size, port=port, dtype_str=dtype_str)
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for this test")
@@ -162,10 +166,11 @@ def test_sharded_rmsnorm_different_dtypes(mpi_pool_executor, dtype_str):
     """Test sharded_rmsnorm with different dtypes."""
     torch.manual_seed(0)
     tensor_parallel_size = mpi_pool_executor.num_workers
+    port = get_free_port()
 
     results = mpi_pool_executor.map(
         _run_sharded_rmsnorm_dtype_test,
-        *zip(*[(tensor_parallel_size, dtype_str)] * tensor_parallel_size),
+        *zip(*[(tensor_parallel_size, port, dtype_str)] * tensor_parallel_size),
     )
     for r in results:
         assert r is True


### PR DESCRIPTION
  - test_sharded_rmsnorm tests hardcoded port=29500 for torch.distributed initialization, causing EADDRINUSE failures in CI when another process on the same node already holds that port.
  - Replace with get_free_port() called once in the main pytest process and passed to all MPI workers, matching the pattern used by test_allreduce_residual_rmsnorm_fusion.py.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced multi-GPU test reliability by implementing dynamic port allocation for test coordination, preventing port conflicts during parallel test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
