### PR TITLE
[None][test] Add func and perf case of nemotron-3-Nano-Omni model on DGX-Spark

### DIFF
--- a/tests/integration/defs/examples/serve/test_configs/Nemotron3_Nano_Omni_30B_NVFP4.yml
+++ b/tests/integration/defs/examples/serve/test_configs/Nemotron3_Nano_Omni_30B_NVFP4.yml
@@ -1,0 +1,14 @@
+kv_cache_config:
+  enable_block_reuse: false
+  free_gpu_memory_fraction: 0.80
+  mamba_ssm_cache_dtype: float32
+
+moe_config:
+  backend: CUTLASS
+
+cuda_graph_config:
+  enable_padding: true
+  max_batch_size: 1
+
+enable_chunked_prefill: true
+max_batch_size: 1

--- a/tests/integration/defs/examples/serve/test_configs/Nemotron3_Super_120B_NVFP4.yml
+++ b/tests/integration/defs/examples/serve/test_configs/Nemotron3_Super_120B_NVFP4.yml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Config for Nemotron 3 Super 120B NVFP4 on DGX Spark (1x GB10, 128GB unified memory).
 # Validates chunked prefill + MTP speculative decoding running together.
 
 kv_cache_config:

--- a/tests/integration/defs/examples/serve/test_serve.py
+++ b/tests/integration/defs/examples/serve/test_serve.py
@@ -250,14 +250,14 @@ def test_env_overrides_pdl(tmp_path):
 
 
 @skip_pre_blackwell
-def test_nemotron_super_nvfp4(serve_test_root):
+def test_nemotron3_super_120b_nvfp4(serve_test_root):
     """Test Nemotron 3 Super 120B NVFP4 with chunked prefill + MTP=3.
 
     Sends a mix of short and long prompts concurrently to verify that the server
     starts successfully and all requests complete without errors.
     """
     model_path = f"{llm_models_root()}/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
-    config_file = f"{serve_test_root}/test_configs/Nemotron-Super-120B-NVFP4.yml"
+    config_file = f"{serve_test_root}/test_configs/Nemotron3_Super_120B_NVFP4.yml"
 
     assert os.path.exists(model_path), f"Model not found: {model_path}"
     assert os.path.exists(config_file), f"Config not found: {config_file}"
@@ -368,4 +368,273 @@ def test_nemotron_super_nvfp4(serve_test_root):
             print_info(f"[{label}] reasoning: {msg.reasoning_content!r}")
             print_info(f"[{label}] content:   {msg.content!r}")
 
-    print_info("test_nemotron_super_nvfp4 PASSED")
+    print_info("test_nemotron3_super_120b_nvfp4 PASSED")
+
+
+_NEMOTRON3_NANO_OMNI_MODEL_DIR = "NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4"
+# Public stable media URLs for multimodal tests.
+_OMNI_IMAGE_URL = "https://storage.googleapis.com/sfr-vision-language-research/LAVIS/assets/merlion.png"
+_OMNI_VIDEO_URL = "https://blogs.nvidia.com/wp-content/uploads/2023/04/nvidia-studio-itns-wk53-scene-in-omniverse-1280w.mp4"
+_NO_THINK = {"chat_template_kwargs": {"enable_thinking": False}}
+
+
+@pytest.fixture(scope="module")
+def _nemotron3_nano_omni_server():
+    """Start the Nemotron-3-Nano-Omni-30B NVFP4 server once for all omni tests.
+
+    Module-scoped so the server starts once and stays alive across all four
+    test cases (text_reasoning_on, text_reasoning_off, image, video),
+    avoiding the cost of four separate server startups.
+    """
+    from defs.conftest import get_llm_root
+    llm_root = get_llm_root()
+    model_path = f"{llm_models_root()}/{_NEMOTRON3_NANO_OMNI_MODEL_DIR}"
+    config_file = (f"{llm_root}/tests/integration/defs/examples/serve/"
+                   f"test_configs/Nemotron3_Nano_Omni_30B_NVFP4.yml")
+
+    assert os.path.exists(model_path), f"Model not found: {model_path}"
+    assert os.path.exists(config_file), f"Config not found: {config_file}"
+
+    port = get_free_port_in_ci()
+    env = os.environ.copy()
+    env["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
+
+    cmd = [
+        "trtllm-serve",
+        model_path,
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(port),
+        "--trust_remote_code",
+        "--reasoning_parser",
+        "nano-v3",
+        "--tool_parser",
+        "qwen3_coder",
+        "--extra_llm_api_options",
+        config_file,
+    ]
+
+    with popen(cmd, env=env) as proc:
+        _wait_for_server_ready(proc, http_port=port, timeout=7200)
+        print_info("Nemotron-3-Nano-Omni server ready.")
+        client = OpenAI(
+            base_url=f"http://localhost:{port}/v1",
+            api_key="tensorrt_llm",
+        )
+        yield client, os.path.basename(model_path)
+
+
+# See the step-by-step recipe for Nemotron-3-Nano-Omni inference in the official usage guide:
+# https://github.com/NVIDIA-NeMo/Nemotron/blob/main/usage-cookbook/Nemotron-3-Nano-Omni/trtllm_cookbook.ipynb
+@skip_pre_blackwell
+@pytest.mark.parametrize("modality", [
+    "text_reasoning_on",
+    "text_reasoning_off",
+    "text_streaming",
+    "tool_calling",
+    "image",
+    "video",
+])
+def test_nemotron3_nano_omni_nvfp4(modality, _nemotron3_nano_omni_server):
+    """Nemotron-3-Nano-Omni-30B NVFP4 multimodal functional tests.
+
+    Parametrized over six modality cases sharing a single server instance:
+      text_reasoning_on  — haiku prompt, thinking + answer both present.
+      text_reasoning_off — short prompt, no thinking step.
+      text_streaming     — streaming chat completion, token-by-token delivery.
+      tool_calling       — function calling via OpenAI tools schema.
+      image              — image URL, non-empty description.
+      video              — video URL, non-empty description (also exercises
+                           audio extraction from the video stream).
+    """
+    client, model_name = _nemotron3_nano_omni_server
+
+    if modality == "text_reasoning_on":
+        resp = client.chat.completions.create(
+            model=model_name,
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant."
+                },
+                {
+                    "role": "user",
+                    "content": "Write a haiku about GPUs"
+                },
+            ],
+            temperature=0.6,
+            max_completion_tokens=4096,
+            stream=False,
+        )
+        assert len(resp.choices) == 1
+        msg = resp.choices[0].message
+        assert len(msg.reasoning_content) > 0, \
+            "empty reasoning_content — thinking step did not run"
+        assert len(msg.content) > 0, "empty content — haiku response missing"
+        print_info(
+            f"[text_reasoning_on] thinking: {msg.reasoning_content[:500]!r}...")
+        print_info(f"[text_reasoning_on] content:  {msg.content[:500]!r}...")
+
+    elif modality == "text_reasoning_off":
+        resp = client.chat.completions.create(
+            model=model_name,
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant."
+                },
+                {
+                    "role": "user",
+                    "content": "Give me 3 bullet points about TensorRT-LLM."
+                },
+            ],
+            temperature=0.2,
+            max_completion_tokens=256,
+            stream=False,
+            extra_body=_NO_THINK,
+        )
+        assert len(resp.choices) == 1
+        msg = resp.choices[0].message
+        assert len(msg.content) > 0, "empty content — direct answer missing"
+        print_info(f"[text_reasoning_off] content: {msg.content[:500]!r}...")
+
+    elif modality == "text_streaming":
+        stream = client.chat.completions.create(
+            model=model_name,
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant."
+                },
+                {
+                    "role": "user",
+                    "content": "What are the first 5 prime numbers?"
+                },
+            ],
+            temperature=0.6,
+            max_completion_tokens=1024,
+            stream=True,
+        )
+        chunks = []
+        for chunk in stream:
+            if chunk.choices[0].delta.content:
+                chunks.append(chunk.choices[0].delta.content)
+        full_content = "".join(chunks)
+        assert len(chunks) > 1, "expected multiple streamed chunks"
+        assert len(full_content) > 0, "empty content — streaming failed"
+        print_info(f"[text_streaming] chunks={len(chunks)}, "
+                   f"content: {full_content[:500]!r}...")
+
+    elif modality == "tool_calling":
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "calculate_tip",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "bill_total": {
+                            "type": "integer",
+                            "description": "The total amount of the bill"
+                        },
+                        "tip_percentage": {
+                            "type": "integer",
+                            "description": "The percentage of tip to be applied"
+                        },
+                    },
+                    "required": ["bill_total", "tip_percentage"],
+                },
+            },
+        }]
+        resp = client.chat.completions.create(
+            model=model_name,
+            messages=[
+                {
+                    "role": "system",
+                    "content": ""
+                },
+                {
+                    "role":
+                    "user",
+                    "content":
+                    "My bill is $50. What will be the amount for 15% tip?"
+                },
+            ],
+            tools=tools,
+            temperature=0.6,
+            top_p=0.95,
+            max_completion_tokens=512,
+            stream=False,
+        )
+        assert len(resp.choices) == 1
+        msg = resp.choices[0].message
+        assert msg.tool_calls is not None and len(msg.tool_calls) > 0, \
+            "no tool_calls — function calling failed"
+        tool_call = msg.tool_calls[0]
+        assert tool_call.function.name == "calculate_tip", \
+            f"expected calculate_tip, got {tool_call.function.name}"
+        print_info(f"[tool_calling] reasoning: "
+                   f"{msg.reasoning_content[:500]!r}...")
+        print_info(f"[tool_calling] function: {tool_call.function.name}, "
+                   f"args: {tool_call.function.arguments}")
+
+    elif modality == "image":
+        resp = client.chat.completions.create(
+            model=model_name,
+            messages=[{
+                "role":
+                "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Describe what you see in this image."
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": _OMNI_IMAGE_URL
+                        }
+                    },
+                ],
+            }],
+            temperature=0.2,
+            max_completion_tokens=512,
+            stream=False,
+            extra_body=_NO_THINK,
+        )
+        assert len(resp.choices) == 1
+        msg = resp.choices[0].message
+        assert len(
+            msg.content) > 0, "empty content — image understanding failed"
+        print_info(f"[image] content: {msg.content[:500]!r}...")
+
+    elif modality == "video":
+        resp = client.chat.completions.create(
+            model=model_name,
+            messages=[{
+                "role":
+                "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Describe what happens in this video."
+                    },
+                    {
+                        "type": "video_url",
+                        "video_url": {
+                            "url": _OMNI_VIDEO_URL
+                        }
+                    },
+                ],
+            }],
+            temperature=0.2,
+            max_completion_tokens=2048,
+            stream=False,
+            extra_body=_NO_THINK,
+        )
+        assert len(resp.choices) == 1
+        msg = resp.choices[0].message
+        assert len(
+            msg.content) > 0, "empty content — video understanding failed"
+        print_info(f"[video] content: {msg.content[:500]!r}...")

--- a/tests/integration/defs/perf/pytorch_model_config.py
+++ b/tests/integration/defs/perf/pytorch_model_config.py
@@ -438,6 +438,25 @@ def get_model_yaml_config(model_label: str,
                 'attn_backend': 'FLASHINFER',
             }
         },
+        # Nemotron-3-Nano-Omni-30B-NVFP4 (text + image multimodal)
+        {
+            'patterns': ['nemotron_3_nano_omni_nvfp4'],
+            'config': {
+                'enable_chunked_prefill': True,
+                'moe_config': {
+                    'backend': 'CUTLASS',
+                },
+                'cuda_graph_config': {
+                    'enable_padding': True,
+                    'max_batch_size': 1,
+                },
+                'kv_cache_config': {
+                    'enable_block_reuse': False,
+                    'free_gpu_memory_fraction': 0.80,
+                    'mamba_ssm_cache_dtype': 'float32',
+                },
+            }
+        },
         # Nemotron-3-Super-120B-NVFP4: (no MTP)
         {
             'patterns': ['nemotron_3_super_120b_nvfp4-'],

--- a/tests/integration/defs/perf/test_perf.py
+++ b/tests/integration/defs/perf/test_perf.py
@@ -184,6 +184,11 @@ MODEL_PATH_DICT = {
     "nemotron_3_super_120b_nvfp4": "NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
     "nemotron_3_super_120b_nvfp4_mtp":
     "NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4",
+    # Nemotron-3-Nano-Omni-30B (text + image multimodal)
+    "nemotron_3_nano_omni_nvfp4":
+    "NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
+    "nemotron_3_nano_omni_nvfp4_image":
+    "NVIDIA-Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4",
     "kimi_k2_nvfp4": "Kimi-K2-Thinking-NVFP4",
     # MiniMax M2.5 (FP8 block-scale, ~230B MoE)
     "minimax_m2.5_fp8": "MiniMax-M2.5",
@@ -263,6 +268,8 @@ TIMING_CACHE_DIR = os.environ.get("TIMING_CACHE_DIR", "")
 NEMOTRON_SUPER_MODELS = {
     "nemotron_3_super_120b_nvfp4",
     "nemotron_3_super_120b_nvfp4_mtp",
+    "nemotron_3_nano_omni_nvfp4",
+    "nemotron_3_nano_omni_nvfp4_image",
 }
 
 TRUST_REMOTE_CODE_MODELS = {  # these models require explicit trust_remote_code=True
@@ -274,6 +281,21 @@ TRUST_REMOTE_CODE_MODELS = {  # these models require explicit trust_remote_code=
     "nemotron_3_super_120b_nvfp4",
     "nemotron_3_super_120b_nvfp4_mtp",
     "glm_5_fp8",
+    "nemotron_3_nano_omni_nvfp4",
+    "nemotron_3_nano_omni_nvfp4_image",
+}
+
+# Models that use random_image dataset in serve mode benchmarks.
+# Maps model name to (width, height, num_images) tuple.
+SERVE_IMAGE_MODELS = {
+    "nemotron_3_nano_omni_nvfp4_image": (1526, 1024, 1),
+}
+
+# Models that require openai-chat backend for benchmark_serving
+# (e.g., reasoning / multimodal models that use chat completions API).
+OPENAI_CHAT_BACKEND_MODELS = {
+    "nemotron_3_nano_omni_nvfp4",
+    "nemotron_3_nano_omni_nvfp4_image",
 }
 
 # Spec-dec models real dataset in serve perf tests.
@@ -1585,12 +1607,34 @@ class MultiMetricPerfTest(AbstractPerfScriptTestClass):
             "--percentile-metrics",
             "ttft,tpot,itl,e2el",
         ]
+        if self._config.model_name in OPENAI_CHAT_BACKEND_MODELS:
+            client_cmd += ["--backend", "openai-chat"]
         if real_dataset_path:
             client_cmd += [
                 "--dataset-name",
                 "trtllm_custom",
                 "--dataset-path",
                 real_dataset_path,
+            ]
+        elif self._config.model_name in SERVE_IMAGE_MODELS:
+            width, height, num_images = SERVE_IMAGE_MODELS[
+                self._config.model_name]
+            client_cmd += [
+                "--dataset-name",
+                "random_image",
+                "--random-ids",
+                "--random-input-len",
+                str(input_len),
+                "--random-output-len",
+                str(output_len),
+                "--random-range-ratio",
+                "0.0",
+                "--random-image-width",
+                str(width),
+                "--random-image-height",
+                str(height),
+                "--random-num-images",
+                str(num_images),
             ]
         else:
             client_cmd += [

--- a/tests/integration/test_lists/qa/llm_spark_core.txt
+++ b/tests/integration/test_lists/qa/llm_spark_core.txt
@@ -26,3 +26,10 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_nvfp4[latency_moe_cutl
 accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_nvfp4[latency_moe_cutlass-torch_compile=True]
 
 test_e2e.py::test_trtllm_benchmark_serving[gpt_oss/gpt-oss-20b]
+examples/serve/test_serve.py::test_nemotron3_super_120b_nvfp4
+examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[text_reasoning_on]
+examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[text_reasoning_off]
+examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[text_streaming]
+examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[tool_calling]
+examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[image]
+examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[video]

--- a/tests/integration/test_lists/qa/llm_spark_func.yml
+++ b/tests/integration/test_lists/qa/llm_spark_func.yml
@@ -53,7 +53,13 @@ llm_spark_func:
   - test_e2e.py::test_openai_reasoning[pytorch]
   - test_e2e.py::test_openai_chat_harmony
   - test_e2e.py::test_trtllm_benchmark_serving[llama-3.1-model/Meta-Llama-3.1-8B]
-  - examples/serve/test_serve.py::test_nemotron_super_nvfp4
+  - examples/serve/test_serve.py::test_nemotron3_super_120b_nvfp4
+  - examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[text_reasoning_on]
+  - examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[text_reasoning_off]
+  - examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[text_streaming]
+  - examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[tool_calling]
+  - examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[image]
+  - examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[video]
   - examples/serve/test_serve_negative.py::test_invalid_max_tokens
   - examples/serve/test_serve_negative.py::test_invalid_temperature
   - examples/serve/test_serve_negative.py::test_invalid_top_p[-0.1]

--- a/tests/integration/test_lists/qa/llm_spark_perf.yml
+++ b/tests/integration/test_lists/qa/llm_spark_perf.yml
@@ -18,6 +18,11 @@ llm_spark_perf:
   - perf/test_perf.py::test_perf[gpt_oss_120b_eagle3_throughput-bench-pytorch-streaming-float4-maxbs:1-input_output_len:2048,128-reqs:1-con:1]
   - perf/test_perf.py::test_perf[gpt_oss_120b_eagle3_throughput-bench-pytorch-streaming-float4-maxbs:1-input_output_len:128,2048-reqs:1-con:1]
   - perf/test_perf.py::test_perf[nvidia_nemotron_nano_9b_v2_nvfp4-bench-pytorch-streaming-float4-maxbs:1-input_output_len:2048,128-reqs:1-con:1]
+  # Nemotron-3-Nano-Omni-30B NVFP4: text benchmarks (ISL 2048 and 32768)
+  - perf/test_perf.py::test_perf[nemotron_3_nano_omni_nvfp4-serve-pytorch-streaming-float4-maxbs:1-input_output_len:2048,1024-reqs:1-con:1]
+  - perf/test_perf.py::test_perf[nemotron_3_nano_omni_nvfp4-serve-pytorch-streaming-float4-maxbs:1-input_output_len:32768,1024-reqs:1-con:1]
+  # Nemotron-3-Nano-Omni-30B NVFP4: image benchmark (1526x1024 image + ISL 2048)
+  - perf/test_perf.py::test_perf[nemotron_3_nano_omni_nvfp4_image-serve-pytorch-streaming-float4-maxbs:1-input_output_len:2048,1024-reqs:1-con:1]
   - perf/test_perf.py::test_perf[nemotron_3_super_120b_nvfp4-serve-pytorch-streaming-float4-maxbs:8-maxnt:4096-input_output_len:2048,256-kv_cache_dtype:fp8-reqs:1-con:1]
   - perf/test_perf.py::test_perf[nemotron_3_super_120b_nvfp4_mtp-serve-pytorch-streaming-float4-maxbs:8-maxnt:4096-input_output_len:2048,256-kv_cache_dtype:fp8-reqs:1-con:1]
   - perf/test_perf.py::test_perf[nemotron_3_super_120b_nvfp4-serve-pytorch-streaming-float4-maxbs:8-maxnt:4096-input_output_len:8192,512-kv_cache_dtype:fp8-reqs:1-con:1]


### PR DESCRIPTION
## Test plan
- Follow the cookbook https://github.com/NVIDIA-NeMo/Nemotron/blob/main/usage-cookbook/Nemotron-3-Nano-Omni/trtllm_cookbook.ipynb
- Func cases cover (Omni  model)
   - Reasoning on/off/streaming/tool calling/Video/image
- Perf cases cover
  - Text and image cases
 
## Test list
  ```
  examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[text_reasoning_on]
  examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[text_reasoning_off]
  examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[text_streaming]
  examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[tool_calling]
  examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[image]
  examples/serve/test_serve.py::test_nemotron3_nano_omni_nvfp4[video]
  perf/test_perf.py::test_perf[nemotron_3_nano_omni_nvfp4-serve-pytorch-streaming-float4-maxbs:1-input_output_len:2048,1024-reqs:1-con:1]
 perf/test_perf.py::test_perf[nemotron_3_nano_omni_nvfp4-serve-pytorch-streaming-float4-maxbs:1-input_output_len:32768,1024-reqs:1-con:1]
  # Nemotron-3-Nano-Omni-30B NVFP4: image benchmark (1526x1024 image + ISL 2048)
  perf/test_perf.py::test_perf[nemotron_3_nano_omni_nvfp4_image-serve-pytorch-streaming-float4-maxbs:1-input_output_len:2048,1024-reqs:1-con:1]
  ```

## Test report
- Dry run the functional and perf cases on DGX-Spark based on v1.3.0rc3 image, since the TOT main has the bug [6150288](https://nvbugspro.nvidia.com/bug/6150288)
  - Function report: http://dlswqa-nas.nvidia.com:8080/mobile/Report/release/TRT-llm/project_digits/release/1.3.0rc13/func_job-269_2b02fe7c0/func_1.3.0rc13_report_269.html
  - Performance report: http://dlswqa-nas.nvidia.com:20000/benchmark-management/9f18dbe7-b1ec-43b1-b6fc-7e4976e14636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests & Chores

* Added support for Nemotron-3-Nano-Omni-30B and Nemotron-3-Super-120B model variants with optimized configurations
* Expanded test coverage for multimodal capabilities including text with reasoning modes, image support, video support, and tool calling
* Enhanced performance testing and benchmarking for new Nemotron-3 model variants
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
