### PR TITLE
[None][fix] Apply NUMA binding to LLM API launcher

### DIFF
--- a/examples/disaggregated/slurm/benchmark/start_worker.sh
+++ b/examples/disaggregated/slurm/benchmark/start_worker.sh
@@ -42,7 +42,7 @@ else
     nsys_prefix="nsys profile -o ${nsys_file} -f true -t cuda,nvtx,python-gil -c cudaProfilerApi --cuda-graph-trace node --capture-range-end=stop --gpu-metrics-devices=none"
 fi
 
-${nsys_prefix} trtllm-llmapi-launch ${numa_bind_cmd} \
+${nsys_prefix} ${numa_bind_cmd} trtllm-llmapi-launch \
     trtllm-serve ${model_path} \
         --host $(hostname) --port ${port} \
         --config ${config_file}


### PR DESCRIPTION
## Description

Move NUMA binding before `trtllm-llmapi-launch` in the disaggregated Slurm benchmark worker launcher. When `numactl` is passed after `trtllm-llmapi-launch`, it is only part of the rank-0 task command and does not apply to the `mgmn_leader_node` / `mgmn_worker_node` processes launched by the wrapper. Placing `numactl` before the launcher lets the NUMA memory policy be inherited by the full LLM API process tree.

## Test Coverage

- `bash -n examples/disaggregated/slurm/benchmark/start_worker.sh`
- `git diff --check -- examples/disaggregated/slurm/benchmark/start_worker.sh`
- Reproduced the original issue on GB300 with the previous command order and confirmed non-rank0 `mgmn_*` processes were not covered by `numactl`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.