### PR TITLE
[TRTLLM-7081][refactor] Add MultimodalModelMixin

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -1,6 +1,6 @@
 import copy
 import dataclasses
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
 
 import torch
 import torchvision
@@ -22,9 +22,10 @@ from tensorrt_llm._torch.models.checkpoints.mistral.weight_mapper import \
     MistralWeightMapper
 from tensorrt_llm._torch.models.modeling_mistral_large3 import (
     Mistral3Gate, MistralLarge3ForCausalLM)
+from tensorrt_llm._torch.models.modeling_multimodal_mixin import (
+    MultimodalEncoderOutput, MultimodalModelMixin, PreparedLlmInputs)
 from tensorrt_llm._torch.models.modeling_multimodal_utils import (
-    _MULTIMODAL_ENV_NAME, _is_disagg, find_input_mm_embeds, fuse_input_embeds,
-    get_multimodal_embeddings)
+    _MULTIMODAL_ENV_NAME, _is_disagg)
 from tensorrt_llm._torch.models.modeling_utils import (DecoderModel,
                                                        DecoderModelForCausalLM,
                                                        _load_weights_impl,
@@ -548,7 +549,7 @@ class MistralCommonInputProcessor(Mistral3InputProcessor):
         placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
         content_format=ContentFormat.STRING,
     ))
-class Mistral3VLM(PreTrainedModel):
+class Mistral3VLM(MultimodalModelMixin, PreTrainedModel):
     """Mistral3VLM implementation for TRTLLM.
 
     NOTE: for the time being, image tokens are only placed after the text (see
@@ -662,6 +663,18 @@ class Mistral3VLM(PreTrainedModel):
         )
 
     @property
+    def language_model(self) -> torch.nn.Module:
+        return self.llm
+
+    @property
+    def multimodal_token_ids(self) -> torch.Tensor:
+        return self._image_token_ids
+
+    @property
+    def text_embedding_layer(self) -> torch.nn.Module:
+        return self.llm.model.embed_tokens
+
+    @property
     def draft_config(self):
         return self.llm.draft_config
 
@@ -680,49 +693,92 @@ class Mistral3VLM(PreTrainedModel):
     def infer_max_seq_len(self) -> int:
         return self.llm.infer_max_seq_len()
 
+    def encode_multimodal_inputs(
+        self,
+        multimodal_params: Sequence[MultimodalParams],
+        **encoder_kwargs: Any,
+    ) -> MultimodalEncoderOutput:
+        mm_embeds = self._vision_forward(list(multimodal_params))
+        if len(mm_embeds) != 1:
+            raise ValueError(
+                f"Expected Mistral vision encoder to return 1 tensor, got {len(mm_embeds)}."
+            )
+        return MultimodalEncoderOutput(embeddings=mm_embeds[0])
+
+    def get_language_model_forward_kwargs(
+        self,
+        *,
+        attn_metadata: AttentionMetadata,
+        input_ids: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        inputs_embeds: torch.Tensor | None,
+        mm_inputs: PreparedLlmInputs,
+        return_context_logits: bool,
+        spec_metadata: SpecMetadata | None,
+        resource_manager: Any | None,
+    ) -> dict[str, Any]:
+        return {
+            "attn_metadata": attn_metadata,
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "inputs_embeds": inputs_embeds,
+            "return_context_logits": return_context_logits,
+            "spec_metadata": spec_metadata,
+            "resource_manager": resource_manager,
+        }
+
     @torch.inference_mode()
     def forward(
         self,
         attn_metadata: AttentionMetadata,
         input_ids: torch.LongTensor | None = None,
         position_ids: torch.LongTensor | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
         return_context_logits: bool = False,
         spec_metadata: SpecMetadata | None = None,
         **kwargs,
     ) -> torch.Tensor:
         """Forward method."""
-        num_context_requests, num_generation_requests = attn_metadata.num_contexts, attn_metadata.num_generations
-        logger.debug(f"{num_context_requests=}, {num_generation_requests=}")
+        num_context_requests = attn_metadata.num_contexts
+        # multimodal_params is consumed by prepare_multimodal_inputs; remove it
+        # from passthrough kwargs to avoid rebinding it via **kwargs.
+        multimodal_params = kwargs.pop("multimodal_params", [])
 
-        multimodal_params = kwargs.get("multimodal_params", [])
-        mm_embeds = []
-        multimodal_params_len = len(multimodal_params)
-        if multimodal_params_len > 0:
-            mm_embeds = get_multimodal_embeddings(
-                encoder_forward_fn=self._vision_forward,
-                multimodal_params=multimodal_params[:num_context_requests],
-            )
-            mm_embeds = find_input_mm_embeds(
-                mm_embeds, multimodal_params[:num_context_requests])
-
-        with nvtx_range("[mistral] Fuse input embeds"):
-            input_ids, inputs_embeds = fuse_input_embeds(
-                embedding_layer=self.llm.model.embed_tokens,
-                input_ids=input_ids,
-                mm_embeds=mm_embeds,
-                mm_token_ids=self._image_token_ids,
-                **kwargs,
-            )
-
-        return self.llm.forward(
-            attn_metadata=attn_metadata,
+        mm_inputs = self.prepare_multimodal_inputs(
             input_ids=input_ids,
+            positions=position_ids,
+            multimodal_params=multimodal_params,
+            num_context_requests=num_context_requests,
+            attn_metadata=attn_metadata,
+            **kwargs,
+        )
+        if inputs_embeds is not None:
+            if mm_inputs.inputs_embeds is not None:
+                # The caller supplied pre-computed inputs_embeds while the
+                # multimodal pipeline also produced fused embeds. Refuse to
+                # silently drop one or the other; let the caller resolve it.
+                raise ValueError(
+                    "Mistral3VLM.forward received both caller-supplied inputs_embeds "
+                    "and multimodal-derived inputs_embeds. These paths are mutually "
+                    "exclusive; pass at most one.")
+            mm_inputs = PreparedLlmInputs(
+                input_ids=None,
+                inputs_embeds=inputs_embeds,
+                extra_embeds=mm_inputs.extra_embeds,
+            )
+
+        llm_kwargs = self.get_language_model_forward_kwargs(
+            attn_metadata=attn_metadata,
+            input_ids=mm_inputs.input_ids,
             position_ids=position_ids,
-            inputs_embeds=inputs_embeds,
+            inputs_embeds=mm_inputs.inputs_embeds,
+            mm_inputs=mm_inputs,
             return_context_logits=return_context_logits,
             spec_metadata=spec_metadata,
-            resource_manager=kwargs.get('resource_manager'),
+            resource_manager=kwargs.get("resource_manager"),
         )
+
+        return self.language_model.forward(**llm_kwargs)
 
     @staticmethod
     def _get_sub_model_config(
@@ -771,7 +827,7 @@ class Mistral3VLM(PreTrainedModel):
         return sub_model_config
 
     # NOTE: this is defined as a separate method with this specific signature in order to be compatible
-    # with `get_multimodal_embeddings`.
+    # with `get_multimodal_embeddings` callers.
     def _vision_forward(
             self,
             multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -1,0 +1,349 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+import torch
+
+from tensorrt_llm.inputs.multimodal import MultimodalParams
+from tensorrt_llm.logger import logger
+
+from .modeling_multimodal_utils import (
+    find_input_mm_embeds,
+    fuse_input_embeds,
+    get_multimodal_embeddings,
+)
+
+
+@dataclass(frozen=True)
+class MultimodalEncoderOutput:
+    """Output produced by a model-owned multimodal encoder hook.
+
+    This mixin currently supports a strict primary tensor output:
+    - `embeddings` contains all multimodal embedding rows for the supplied
+      `multimodal_params`.
+    - Rows are concatenated in the same order as `multimodal_params`.
+    - Per-request row counts match `total_embeds_in_request` from runtime
+      metadata when that metadata is available.
+    - Special multimodal tokens occupy token positions but do not have rows in
+      this tensor.
+    """
+
+    embeddings: torch.Tensor
+    cacheable: bool = True
+
+
+@dataclass(frozen=True)
+class PreparedLlmInputs:
+    """Prepared inputs returned by `MultimodalModelMixin`."""
+
+    input_ids: Optional[torch.Tensor]
+    inputs_embeds: Optional[torch.Tensor]
+    extra_embeds: Sequence[torch.Tensor] = ()
+
+
+class MultimodalModelMixin:
+    """Template-method mixin for PyTorch multimodal causal LM models.
+
+    Concrete model forwards can call `prepare_multimodal_inputs` while
+    keeping their explicit language-model delegation. A future optional
+    mixin-owned forward can build on the same template method.
+    """
+
+    def encode_multimodal_inputs(
+        self,
+        multimodal_params: Sequence[MultimodalParams],
+        **encoder_kwargs: Any,
+    ) -> MultimodalEncoderOutput:
+        """Run model-specific multimodal encoder work."""
+        raise NotImplementedError
+
+    @property
+    def multimodal_token_ids(self) -> Optional[Sequence[int] | torch.Tensor]:
+        """Return placeholder token ids in `input_ids` replaced by MM embeds.
+
+        These are sentinel token positions whose text embeddings are replaced
+        by multimodal embeddings. Return `None` to use the out-of-vocabulary
+        sentinel behavior in `fuse_input_embeds`.
+        """
+        raise NotImplementedError
+
+    @property
+    def text_embedding_layer(self):
+        """Return the token embedding layer used by `fuse_input_embeds`."""
+        raise NotImplementedError
+
+    def get_multimodal_encoder_kwargs(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        multimodal_params: Sequence[MultimodalParams],
+        **forward_kwargs: Any,
+    ) -> dict[str, Any]:
+        """Optional model hook for encoder-specific kwargs."""
+        return {}
+
+    def select_multimodal_params(
+        self,
+        multimodal_params: Sequence[MultimodalParams],
+        num_context_requests: int,
+    ) -> Sequence[MultimodalParams]:
+        """Select the params that participate in multimodal encoder work.
+
+        Returns the context-slice params with multimodal content. Helpers below
+        this method (`get_multimodal_embeddings`, `find_input_mm_embeds`,
+        `fuse_input_embeds`) operate on the returned list and therefore see
+        only `has_content()` params. Models overriding this hook must
+        preserve that invariant.
+        """
+        return [
+            param for param in list(multimodal_params)[:num_context_requests] if param.has_content()
+        ]
+
+    def after_full_multimodal_embeddings(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        multimodal_params: Sequence[MultimodalParams],
+        encoder_output: MultimodalEncoderOutput,
+        **forward_kwargs: Any,
+    ) -> tuple[torch.Tensor, MultimodalEncoderOutput]:
+        """Optional hook before active chunk rows are selected.
+
+        Runs after cache lookup or encoder execution has produced full
+        per-request multimodal embeddings, but before the mixin selects rows
+        active in the current forward chunk.
+        """
+        return input_ids, encoder_output
+
+    def after_active_multimodal_embeddings(
+        self,
+        *,
+        active_embeddings: list[torch.Tensor],
+        multimodal_params: Sequence[MultimodalParams],
+        **forward_kwargs: Any,
+    ) -> tuple[list[torch.Tensor], Sequence[torch.Tensor]]:
+        """Optional hook after active chunk rows are selected and before fusion.
+
+        Models can transform or split the active multimodal embeddings here
+        and return additional embedding tensors to fuse alongside the primary
+        multimodal embeddings.
+        """
+        # Future Qwen3-VL migration can split packed deepstack features here
+        # and return them as extra embeds without changing the base flow.
+        return active_embeddings, ()
+
+    def prepare_multimodal_inputs(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        positions: Optional[torch.Tensor],
+        multimodal_params: Optional[Sequence[MultimodalParams]],
+        num_context_requests: int,
+        **forward_kwargs: Any,
+    ) -> PreparedLlmInputs:
+        """Prepare multimodal inputs for a concrete model forward.
+
+        This method owns the common framework sequence around a model-specific
+        encoder hook: retrieve/cache full request embeddings, select active
+        chunk rows, run optional model hooks, and fuse rows into text embeds.
+        """
+        context_params = list(
+            self.select_multimodal_params(
+                multimodal_params or [],
+                num_context_requests,
+            )
+        )
+        if not context_params:
+            return PreparedLlmInputs(input_ids=input_ids, inputs_embeds=None)
+
+        encoder_kwargs = self.get_multimodal_encoder_kwargs(
+            input_ids=input_ids,
+            multimodal_params=context_params,
+            **forward_kwargs,
+        )
+        full_output = self._get_or_encode_multimodal_embeddings(
+            context_params,
+            **encoder_kwargs,
+        )
+
+        input_ids, full_output = self.after_full_multimodal_embeddings(
+            input_ids=input_ids,
+            multimodal_params=context_params,
+            encoder_output=full_output,
+            **forward_kwargs,
+        )
+
+        active_embeddings = self._find_active_multimodal_embeddings(
+            [full_output.embeddings],
+            input_ids=input_ids,
+            positions=positions,
+            multimodal_params=context_params,
+        )
+        active_embeddings, extra_embeds = self.after_active_multimodal_embeddings(
+            active_embeddings=active_embeddings,
+            multimodal_params=context_params,
+            **forward_kwargs,
+        )
+
+        fused_input_ids, inputs_embeds, fused_extra_embeds = self._fuse_multimodal_embeddings(
+            input_ids=input_ids,
+            multimodal_embeddings=active_embeddings,
+            mm_token_ids=self.multimodal_token_ids,
+            embedding_layer=self.text_embedding_layer,
+            extra_embeds=extra_embeds,
+            # `text_token_indices` / `mm_token_indices` are pre-computed by the
+            # executor (see model_engine._prepare_inputs) and must reach
+            # `fuse_input_embeds` to (a) preserve the active-chunk subset
+            # contract when MM rows are a subset of visible MM tokens and
+            # (b) avoid the torch.where host sync inside
+            # `filter_mm_token_from_input_ids`.
+            text_token_indices=forward_kwargs.get("text_token_indices"),
+            mm_token_indices=forward_kwargs.get("mm_token_indices"),
+        )
+        return PreparedLlmInputs(
+            input_ids=fused_input_ids,
+            inputs_embeds=inputs_embeds,
+            extra_embeds=fused_extra_embeds,
+        )
+
+    def _get_or_encode_multimodal_embeddings(
+        self,
+        multimodal_params: Sequence[MultimodalParams],
+        **encoder_kwargs: Any,
+    ) -> MultimodalEncoderOutput:
+        """Return cached multimodal embeddings or run the encoder for misses.
+
+        Delegates cache lookup and gather behavior to
+        `get_multimodal_embeddings`, then validates the single primary tensor
+        contract for both encoded and cached-only paths.
+        """
+
+        def encoder_forward_fn(params: list[MultimodalParams], **kwargs: Any) -> list[torch.Tensor]:
+            encoder_output = self.encode_multimodal_inputs(params, **kwargs)
+            if not isinstance(encoder_output, MultimodalEncoderOutput):
+                raise TypeError("encode_multimodal_inputs must return MultimodalEncoderOutput.")
+            if not isinstance(encoder_output.embeddings, torch.Tensor):
+                raise TypeError("MultimodalEncoderOutput.embeddings must be a torch.Tensor.")
+            if not encoder_output.cacheable:
+                raise ValueError("MultimodalModelMixin requires cacheable encoder outputs.")
+            return [encoder_output.embeddings]
+
+        embeddings = get_multimodal_embeddings(
+            encoder_forward_fn=encoder_forward_fn,
+            multimodal_params=list(multimodal_params),
+            encoder_kwargs=encoder_kwargs,
+        )
+        primary = self._require_primary_embedding(embeddings)
+        # Validate post-gather so cached-only paths (KV reuse, all-cached chunked
+        # prefill) are also checked, not just paths that ran the encoder.
+        self._validate_primary_embedding_rows(primary, multimodal_params)
+        return MultimodalEncoderOutput(embeddings=primary, cacheable=True)
+
+    def _find_active_multimodal_embeddings(
+        self,
+        multimodal_embeddings: list[torch.Tensor],
+        *,
+        input_ids: torch.Tensor,
+        positions: Optional[torch.Tensor],
+        multimodal_params: Sequence[MultimodalParams],
+    ) -> list[torch.Tensor]:
+        """Named internal stage for selecting active chunk multimodal rows.
+
+        This initial template stage currently delegates to
+        `find_input_mm_embeds`. Model-specific behavior around slicing should
+        use `after_full_multimodal_embeddings` or
+        `after_active_multimodal_embeddings` so the common mixin sequence stays
+        centralized.
+        """
+        return find_input_mm_embeds(multimodal_embeddings, list(multimodal_params))
+
+    def _fuse_multimodal_embeddings(
+        self,
+        *,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: list[torch.Tensor],
+        mm_token_ids: Optional[Sequence[int] | torch.Tensor],
+        embedding_layer,
+        extra_embeds: Sequence[torch.Tensor],
+        text_token_indices: Optional[torch.Tensor] = None,
+        mm_token_indices: Optional[torch.Tensor] = None,
+    ) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor], Sequence[torch.Tensor]]:
+        """Thin adapter over `fuse_input_embeds`.
+
+        The framework does not forward `prepare_multimodal_inputs` kwargs
+        into `fuse_input_embeds`; only inputs the helper actually consumes
+        are surfaced here. Models needing to bypass token filtering should
+        pass pre-computed `text_token_indices`/`mm_token_indices`.
+        """
+        if mm_token_ids is not None and not isinstance(mm_token_ids, torch.Tensor):
+            mm_token_ids = torch.tensor(
+                list(mm_token_ids), dtype=input_ids.dtype, device=input_ids.device
+            )
+
+        result = fuse_input_embeds(
+            embedding_layer=embedding_layer,
+            input_ids=input_ids,
+            mm_embeds=multimodal_embeddings,
+            mm_token_ids=mm_token_ids,
+            text_token_indices=text_token_indices,
+            mm_token_indices=mm_token_indices,
+            extra_embeds=list(extra_embeds) if extra_embeds else None,
+        )
+        if len(result) == 3:
+            fused_input_ids, inputs_embeds, fused_extra_embeds = result
+            return fused_input_ids, inputs_embeds, fused_extra_embeds or ()
+
+        fused_input_ids, inputs_embeds = result
+        return fused_input_ids, inputs_embeds, ()
+
+    @staticmethod
+    def _require_primary_embedding(embeddings: list[torch.Tensor]) -> torch.Tensor:
+        if len(embeddings) != 1:
+            raise ValueError(
+                "MultimodalModelMixin requires a single primary embedding tensor, "
+                f"got {len(embeddings)} tensors."
+            )
+        return embeddings[0]
+
+    @staticmethod
+    def _validate_primary_embedding_rows(
+        primary: torch.Tensor,
+        multimodal_params: Sequence[MultimodalParams],
+    ) -> None:
+        """Validate gathered primary embedding row count against runtime metadata.
+
+        Skipped if any param lacks `multimodal_runtime.total_embeds_in_request`, since the contract
+        cannot be evaluated without complete metadata.
+        """
+        expected_rows = 0
+        for param in multimodal_params:
+            runtime = param.multimodal_runtime
+            if runtime is None or runtime.total_embeds_in_request is None:
+                logger.debug(
+                    "Skipping multimodal embedding row-count validation: "
+                    "runtime metadata missing or incomplete for at least one param."
+                )
+                return
+            expected_rows += runtime.total_embeds_in_request
+
+        actual_rows = primary.shape[0]
+        if actual_rows != expected_rows:
+            raise ValueError(
+                "Multimodal embedding row count mismatch: "
+                f"expected {expected_rows}, got {actual_rows}."
+            )

--- a/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
@@ -1,0 +1,86 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.models.modeling_multimodal_mixin import MultimodalModelMixin
+from tensorrt_llm._torch.modules.embedding import Embedding
+from tensorrt_llm.inputs.multimodal import MultimodalParams
+
+
+def make_embedding(
+    num_embeddings: int = 100, hidden_size: int = 16, device: str = "cpu"
+) -> Embedding:
+    torch.manual_seed(0)
+    emb = Embedding(num_embeddings=num_embeddings, embedding_dim=hidden_size)
+    emb.weight.data.normal_(mean=0.0, std=0.02)
+    return emb.to(device)
+
+
+class DummyMultimodalModel(MultimodalModelMixin):
+    def __init__(self, embedding: Embedding, mm_token_ids: torch.Tensor):
+        self.embedding = embedding
+        self._mm_token_ids = mm_token_ids
+
+    @property
+    def multimodal_token_ids(self) -> torch.Tensor:
+        return self._mm_token_ids
+
+    @property
+    def text_embedding_layer(self) -> Embedding:
+        return self.embedding
+
+    def encode_multimodal_inputs(self, multimodal_params, **encoder_kwargs):
+        raise AssertionError("Tests use cached multimodal embeddings and should not encode.")
+
+
+def make_cached_multimodal_param(mm_embeds: torch.Tensor) -> MultimodalParams:
+    return MultimodalParams(multimodal_data={"multimodal_embedding": mm_embeds})
+
+
+@pytest.mark.parametrize("device", ["cpu"] + (["cuda"] if torch.cuda.is_available() else []))
+def test_prepare_multimodal_inputs_forwards_precomputed_indices(device):
+    hidden = 8
+    mm_token_id = 7
+    emb = make_embedding(num_embeddings=40, hidden_size=hidden, device=device)
+    model = DummyMultimodalModel(
+        emb,
+        torch.tensor([mm_token_id], dtype=torch.long, device=device),
+    )
+
+    input_ids = torch.tensor([0, mm_token_id, 1, mm_token_id, 2], dtype=torch.long, device=device)
+    text_idx = torch.tensor([0, 2, 3, 4], dtype=torch.long, device=device)
+    mm_idx = torch.tensor([1], dtype=torch.long, device=device)
+    mm_emb = torch.randn(mm_idx.shape[0], hidden, device=device)
+
+    out = model.prepare_multimodal_inputs(
+        input_ids=input_ids,
+        positions=None,
+        multimodal_params=[make_cached_multimodal_param(mm_emb)],
+        num_context_requests=1,
+        text_token_indices=text_idx,
+        mm_token_indices=mm_idx,
+    )
+
+    assert out.input_ids is None
+    assert out.inputs_embeds is not None
+    assert out.inputs_embeds.shape == (input_ids.numel(), hidden)
+    torch.testing.assert_close(
+        out.inputs_embeds[mm_idx],
+        mm_emb.to(dtype=out.inputs_embeds.dtype, device=out.inputs_embeds.device),
+    )
+    torch.testing.assert_close(out.inputs_embeds[text_idx], emb(input_ids[text_idx]))


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced standardized multimodal input processing framework for consistent embedding integration across models.
  * Added validation to detect and prevent conflicting multimodal input specifications.

* **Refactor**
  * Updated multimodal embedding pipeline in Mistral3VLM for improved consistency with standardized framework.

* **Tests**
  * Added unit tests for multimodal input preparation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

* Why?

All of our existing multimodal models follow a similar pattern:

1. select context requests from the current batch
2. select those that have multimodal parameters
3. run `get_multimodal_embeddings`, which hides encoder
    caching and chunked-prefill reuse behavior with an implicit
    API contract.
4. run `find_input_mm_embeds`, which slices embeddings
    for the current forward chunk.
5. run `fuse_input_embeds`, which places multimodal embeddings
    into text embeddings.
6. Call the underlying language model's `forward` method with
    the fused embeddings.

This means these features are all opt-in, and the code pattern is
duplicated, with developers needing to be aware of several implicit
contracts.

* What?

This commit adds a new `MultimodalModelMixin` that specifies
an interface that hides most of this, allowing model developers to
just implement the forward pass for multimodal embeddings.

As an illustration, it refactors the mistral small model to use this
new mixin.

### Flowchart for new mixin

```mermaid
flowchart TD
    A[Mixin forward] --> B[Count context requests]
    B --> C[Mixin prepare_multimodal_inputs]
    C --> D[Select context multimodal params]
    D --> E{Any params?}
    E -- No --> Z[Return input_ids with no inputs_embeds]

    E -- Yes --> F[Build encoder kwargs via model hook]
    F --> G[Find uncached params]
    G --> H{Encoder work needed?}
    H -- No: all selected params already have cached embeddings --> J[Gather cached embeddings]
    H -- Yes --> I[Call model encode_multimodal_inputs]
    I --> K[Validate primary tensor contract]
    K --> L[Cache per-request embedding slices]
    L --> J

    J --> M[after_full_multimodal_embeddings hook]
    M --> N[Find active chunk embeddings]
    N --> O{Any active MM rows?}
    O -- No: current chunk has no MM rows to fuse --> P[Return text-only chunk inputs]
    O -- Yes --> Q[after_active_multimodal_embeddings hook]
    Q --> R[fuse_input_embeds]
    R --> S[Return PreparedLlmInputs]
    S --> U[Build LLM forward kwargs via model hook]
    U --> T[Call language model forward]

    classDef base fill:#d8f5d0,stroke:#2f8f46,color:#143d1f;
    classDef model fill:#d7e9ff,stroke:#2f6fb3,color:#12365d;
    classDef optional fill:#fff2b8,stroke:#b38b00,color:#4d3b00;
    classDef decision fill:#f5f5f5,stroke:#707070,color:#202020;

    class A,B,C,D,G,J,K,L,N,P,R,S,T,Z base;
    class I model;
    class F,M,Q,U optional;
    class E,H,O decision;
```

Legend:

- Green: framework-owned mixin behavior.
- Blue: required model implementation.
- Yellow: optional model hooks.

Clarifications:

- `Encoder work needed? -> No` means every selected context multimodal request already has cached embeddings, so the mixin gathers cached rows without calling the encoder.
- `Any active MM rows? -> No` means `find_input_mm_embeds` returned no rows for this forward chunk. This can happen when all MM rows are covered by KV-cache reuse or when the current chunk does not overlap the request's multimodal placeholder rows.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
