### PR TITLE
[TRTLLM-12529][feat] Graceful exit when lora unsupported

### DIFF
--- a/tensorrt_llm/_torch/peft/lora/layer.py
+++ b/tensorrt_llm/_torch/peft/lora/layer.py
@@ -4,6 +4,8 @@ from typing import Dict, Iterable, List, Optional
 
 import torch
 
+from tensorrt_llm.logger import logger
+
 from .cuda_graph_lora_params import CudaGraphLoraParams
 
 
@@ -542,55 +544,55 @@ class LoraLayer(torch.nn.Module):
                 return lora_output
 
 
-class UnsupportedLoraTargetModulesError(NotImplementedError):
-    """LoRA target modules requested but not wired into the model's forward path."""
+def filter_unsupported_lora_target_modules(
+        model: torch.nn.Module,
+        lora_target_modules: Iterable[str]) -> list[str]:
+    """Drop LoRA target modules with no registered LoraLayer on this model.
 
-
-def validate_lora_target_modules_supported(
-        model: torch.nn.Module, lora_target_modules: Iterable[str]) -> None:
-    """Fail fast if any requested LoRA target module is unsupported by this model.
-
-    Supported = at least one `LoraLayer` in the model tree registers the
-    corresponding `LoraModuleType` (the canonical "this delta is wired into
-    forward" signal).
-
-    Raises:
-        ValueError: requested name is not a known LoRA module name.
-        UnsupportedLoraTargetModulesError: requested name has no LoraLayer
-            registered on this model+backend combination.
+    Behavior:
+        Empty / None input returns an empty list. Names not present in
+        LoraManager.LORA_MODULE_IDS raise ValueError (typo). When the model
+        exposes no LoraLayer instances (e.g. TRT engine path or AutoDeploy
+        graph), the input is returned unchanged. Otherwise, target modules
+        whose LoraModuleType is not registered on any LoraLayer are dropped
+        with a single warning, mirroring the warn-and-drop behavior used in
+        lora_manager.iterate_hf_lora and load_hf_lora.
     """
     target_modules = list(lora_target_modules) if lora_target_modules else []
     if not target_modules:
-        return
+        return target_modules
 
     from ....lora_manager import LoraManager
 
-    requested: Dict[str, int] = {}
-    unknown: List[str] = []
+    name_to_id: dict[str, int] = {}
+    unknown: list[str] = []
     for name in target_modules:
         try:
-            requested[name] = LoraManager.LORA_MODULE_IDS[name]
+            name_to_id[name] = LoraManager.LORA_MODULE_IDS[name]
         except KeyError:
             unknown.append(name)
     if unknown:
         raise ValueError(f"Unknown LoRA target module name(s): {unknown}. "
                          f"Valid names: {sorted(LoraManager.LORA_MODULE_IDS)}.")
 
-    registered_ids: set = set()
+    registered_ids: set[int] = set()
     for module in model.modules():
         if isinstance(module, LoraLayer):
             registered_ids.update(int(t) for t in module.lora_module_types)
 
-    unsupported = sorted(name for name, mid in requested.items()
-                         if mid not in registered_ids)
-    if not unsupported:
-        return
+    if not registered_ids:
+        return target_modules
 
-    supported_names = sorted(
-        name for name, mid in LoraManager.LORA_MODULE_IDS.items()
-        if mid in registered_ids)
-    raise UnsupportedLoraTargetModulesError(
-        f"LoRA target module(s) {unsupported} have no LoraLayer registered on "
-        f"this model. Supported on this model: {supported_names}. Remove the "
-        f"unsupported entries from `LoraConfig.lora_target_modules` and from "
-        f"`target_modules` in your adapter checkpoints to proceed.")
+    supported = [n for n in target_modules if name_to_id[n] in registered_ids]
+    dropped = sorted(set(target_modules) - set(supported))
+    if dropped:
+        supported_on_model = sorted(
+            n for n, mid in LoraManager.LORA_MODULE_IDS.items()
+            if mid in registered_ids)
+        logger.warning(
+            f"Dropping LoRA target module(s) {dropped}: no LoraLayer is "
+            f"registered for them on this model. Adapter weights for these "
+            f"modules will be ignored. Supported on this model: "
+            f"{supported_on_model}.")
+
+    return supported

--- a/tensorrt_llm/_torch/peft/lora/layer.py
+++ b/tensorrt_llm/_torch/peft/lora/layer.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 import torch
 
@@ -540,3 +540,57 @@ class LoraLayer(torch.nn.Module):
                                         device=x.device))
                 lora_output = torch.cat(lora_output, dim=-1)
                 return lora_output
+
+
+class UnsupportedLoraTargetModulesError(NotImplementedError):
+    """LoRA target modules requested but not wired into the model's forward path."""
+
+
+def validate_lora_target_modules_supported(
+        model: torch.nn.Module, lora_target_modules: Iterable[str]) -> None:
+    """Fail fast if any requested LoRA target module is unsupported by this model.
+
+    Supported = at least one `LoraLayer` in the model tree registers the
+    corresponding `LoraModuleType` (the canonical "this delta is wired into
+    forward" signal).
+
+    Raises:
+        ValueError: requested name is not a known LoRA module name.
+        UnsupportedLoraTargetModulesError: requested name has no LoraLayer
+            registered on this model+backend combination.
+    """
+    target_modules = list(lora_target_modules) if lora_target_modules else []
+    if not target_modules:
+        return
+
+    from ....lora_manager import LoraManager
+
+    requested: Dict[str, int] = {}
+    unknown: List[str] = []
+    for name in target_modules:
+        try:
+            requested[name] = LoraManager.LORA_MODULE_IDS[name]
+        except KeyError:
+            unknown.append(name)
+    if unknown:
+        raise ValueError(f"Unknown LoRA target module name(s): {unknown}. "
+                         f"Valid names: {sorted(LoraManager.LORA_MODULE_IDS)}.")
+
+    registered_ids: set = set()
+    for module in model.modules():
+        if isinstance(module, LoraLayer):
+            registered_ids.update(int(t) for t in module.lora_module_types)
+
+    unsupported = sorted(name for name, mid in requested.items()
+                         if mid not in registered_ids)
+    if not unsupported:
+        return
+
+    supported_names = sorted(
+        name for name, mid in LoraManager.LORA_MODULE_IDS.items()
+        if mid in registered_ids)
+    raise UnsupportedLoraTargetModulesError(
+        f"LoRA target module(s) {unsupported} have no LoraLayer registered on "
+        f"this model. Supported on this model: {supported_names}. Remove the "
+        f"unsupported entries from `LoraConfig.lora_target_modules` and from "
+        f"`target_modules` in your adapter checkpoints to proceed.")

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1335,12 +1335,12 @@ def create_py_executor_instance(
                     if not has_dense_mlp:
                         target_modules.remove(mlp_mod)
 
-        # Reject unsupported LoRA target modules (e.g. per-expert MoE targets
-        # not yet wired through FusedMoE) before any C++ LoRA setup runs.
+        # Drop target modules with no LoraLayer wiring on the PyT model so the
+        # C++ LoRA workspace and CudaGraphLoraParams stay consistent.
         if isinstance(model_engine, PyTorchModelEngine):
-            from ..peft.lora.layer import validate_lora_target_modules_supported
-            validate_lora_target_modules_supported(model_engine.model,
-                                                   target_modules)
+            from ..peft.lora.layer import filter_unsupported_lora_target_modules
+            target_modules = filter_unsupported_lora_target_modules(
+                model_engine.model, target_modules)
 
         lora_modules = LoraModule.create_lora_modules(
             lora_module_names=target_modules,

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1335,6 +1335,13 @@ def create_py_executor_instance(
                     if not has_dense_mlp:
                         target_modules.remove(mlp_mod)
 
+        # Reject unsupported LoRA target modules (e.g. per-expert MoE targets
+        # not yet wired through FusedMoE) before any C++ LoRA setup runs.
+        if isinstance(model_engine, PyTorchModelEngine):
+            from ..peft.lora.layer import validate_lora_target_modules_supported
+            validate_lora_target_modules_supported(model_engine.model,
+                                                   target_modules)
+
         lora_modules = LoraModule.create_lora_modules(
             lora_module_names=target_modules,
             hidden_size=model_binding_config.hidden_size,

--- a/tests/unittest/_torch/lora/test_lora.py
+++ b/tests/unittest/_torch/lora/test_lora.py
@@ -1,7 +1,14 @@
+import pytest
 import torch
 
 from tensorrt_llm._torch.peft.lora.adapter_slot_manager import AdapterSlotManager
 from tensorrt_llm._torch.peft.lora.cuda_graph_lora_params import CudaGraphLoraParams
+from tensorrt_llm._torch.peft.lora.layer import (
+    LoraLayer,
+    LoraModuleType,
+    UnsupportedLoraTargetModulesError,
+    validate_lora_target_modules_supported,
+)
 
 
 def test_cuda_graph_lora_params_handle_missing_peft_table():
@@ -36,3 +43,55 @@ def test_adapter_slot_manager_handles_missing_peft_cache_manager():
 
     assert manager.get_slot_to_task_mapping() == (123, None)
     assert manager.task2slot[123] == 0
+
+
+def _make_attention_only_model() -> torch.nn.Module:
+    """Tiny model registering only the four attention LoRA targets."""
+    model = torch.nn.Module()
+    model.attn_lora = LoraLayer(
+        [
+            LoraModuleType.ATTENTION_Q,
+            LoraModuleType.ATTENTION_K,
+            LoraModuleType.ATTENTION_V,
+            LoraModuleType.ATTENTION_DENSE,
+        ],
+        [16, 16, 16, 16],
+    )
+    return model
+
+
+def test_validate_lora_target_modules_supported_accepts_supported_targets():
+    validate_lora_target_modules_supported(
+        _make_attention_only_model(), ["attn_q", "attn_k", "attn_v", "attn_dense"]
+    )
+
+
+def test_validate_lora_target_modules_supported_noops_on_empty_list():
+    model = _make_attention_only_model()
+    validate_lora_target_modules_supported(model, [])
+    validate_lora_target_modules_supported(model, None)
+
+
+def test_validate_lora_target_modules_supported_rejects_per_expert_moe_targets():
+    with pytest.raises(UnsupportedLoraTargetModulesError) as exc:
+        validate_lora_target_modules_supported(
+            _make_attention_only_model(), ["attn_q", "moe_h_to_4h", "moe_4h_to_h"]
+        )
+    msg = str(exc.value)
+    assert "moe_h_to_4h" in msg
+    assert "moe_4h_to_h" in msg
+    assert "attn_q" in msg  # listed under "Supported on this model"
+
+
+def test_validate_lora_target_modules_supported_unsupported_is_notimplemented():
+    """Subclass of NotImplementedError so callers can `except` broadly."""
+    with pytest.raises(NotImplementedError):
+        validate_lora_target_modules_supported(_make_attention_only_model(), ["moe_h_to_4h"])
+
+
+def test_validate_lora_target_modules_supported_rejects_unknown_names():
+    with pytest.raises(ValueError) as exc:
+        validate_lora_target_modules_supported(
+            _make_attention_only_model(), ["attn_q", "not_a_real_module"]
+        )
+    assert "not_a_real_module" in str(exc.value)

--- a/tests/unittest/_torch/lora/test_lora.py
+++ b/tests/unittest/_torch/lora/test_lora.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 import torch
 
@@ -6,8 +8,7 @@ from tensorrt_llm._torch.peft.lora.cuda_graph_lora_params import CudaGraphLoraPa
 from tensorrt_llm._torch.peft.lora.layer import (
     LoraLayer,
     LoraModuleType,
-    UnsupportedLoraTargetModulesError,
-    validate_lora_target_modules_supported,
+    filter_unsupported_lora_target_modules,
 )
 
 
@@ -60,38 +61,42 @@ def _make_attention_only_model() -> torch.nn.Module:
     return model
 
 
-def test_validate_lora_target_modules_supported_accepts_supported_targets():
-    validate_lora_target_modules_supported(
-        _make_attention_only_model(), ["attn_q", "attn_k", "attn_v", "attn_dense"]
-    )
+def test_filter_lora_target_modules_returns_supported_targets_unchanged():
+    targets = ["attn_q", "attn_k", "attn_v", "attn_dense"]
+    assert filter_unsupported_lora_target_modules(_make_attention_only_model(), targets) == targets
 
 
-def test_validate_lora_target_modules_supported_noops_on_empty_list():
+def test_filter_lora_target_modules_handles_empty_input():
     model = _make_attention_only_model()
-    validate_lora_target_modules_supported(model, [])
-    validate_lora_target_modules_supported(model, None)
+    assert filter_unsupported_lora_target_modules(model, []) == []
+    assert filter_unsupported_lora_target_modules(model, None) == []
 
 
-def test_validate_lora_target_modules_supported_rejects_per_expert_moe_targets():
-    with pytest.raises(UnsupportedLoraTargetModulesError) as exc:
-        validate_lora_target_modules_supported(
-            _make_attention_only_model(), ["attn_q", "moe_h_to_4h", "moe_4h_to_h"]
-        )
-    msg = str(exc.value)
+def test_filter_lora_target_modules_drops_per_expert_moe_targets(caplog):
+    caplog.set_level(logging.WARNING, logger="tensorrt_llm")
+    result = filter_unsupported_lora_target_modules(
+        _make_attention_only_model(),
+        ["attn_q", "moe_h_to_4h", "moe_4h_to_h"],
+    )
+    assert result == ["attn_q"]
+
+    msg = "\n".join(r.getMessage() for r in caplog.records)
+    assert "Dropping LoRA target module(s)" in msg
     assert "moe_h_to_4h" in msg
     assert "moe_4h_to_h" in msg
-    assert "attn_q" in msg  # listed under "Supported on this model"
+    assert "attn_q" in msg
 
 
-def test_validate_lora_target_modules_supported_unsupported_is_notimplemented():
-    """Subclass of NotImplementedError so callers can `except` broadly."""
-    with pytest.raises(NotImplementedError):
-        validate_lora_target_modules_supported(_make_attention_only_model(), ["moe_h_to_4h"])
-
-
-def test_validate_lora_target_modules_supported_rejects_unknown_names():
+def test_filter_lora_target_modules_rejects_unknown_names():
     with pytest.raises(ValueError) as exc:
-        validate_lora_target_modules_supported(
+        filter_unsupported_lora_target_modules(
             _make_attention_only_model(), ["attn_q", "not_a_real_module"]
         )
     assert "not_a_real_module" in str(exc.value)
+
+
+def test_filter_lora_target_modules_noops_when_no_lora_layers_registered():
+    model = torch.nn.Module()
+    model.linear = torch.nn.Linear(4, 4)
+    targets = ["attn_q", "moe_h_to_4h", "moe_4h_to_h"]
+    assert filter_unsupported_lora_target_modules(model, targets) == targets

--- a/tests/unittest/_torch/modules/tests_lora_modules/test_moe_multi_lora.py
+++ b/tests/unittest/_torch/modules/tests_lora_modules/test_moe_multi_lora.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-LoRA correctness on MoE models (Qwen1.5-MoE-A2.7B-Chat, O(10) adapters).
+
+Positive coverage: attention and shared-expert MLP targets across O(10)
+co-resident adapters. Negative coverage: per-expert MoE targets (`moe_*`)
+fail fast at LLM construction time. CPU-only validator unit tests live in
+`tests/unittest/_torch/lora/test_lora.py`.
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+import torch
+from safetensors.torch import save_file
+from utils.llm_data import llm_models_root
+from utils.util import skip_gpu_memory_less_than_40gb
+
+from tensorrt_llm import LLM, SamplingParams
+from tensorrt_llm._torch.peft.lora.layer import UnsupportedLoraTargetModulesError
+from tensorrt_llm.executor.request import LoRARequest
+from tensorrt_llm.lora_helper import LoraConfig
+
+_HF_ATTN_MODULES = ["q_proj", "k_proj", "v_proj", "o_proj"]
+_HF_SHARED_EXPERT_MODULES = ["gate_proj", "up_proj", "down_proj"]
+
+_TRTLLM_ATTN_MODULES = ["attn_q", "attn_k", "attn_v", "attn_dense"]
+# Qwen MoE shared expert is a GatedMLP(is_shared_expert=True) which registers
+# SHARED_EXPERT_* LoRA types; using `mlp_*` would cause lora_manager to drop
+# the weights with a UserWarning.
+_TRTLLM_SHARED_EXPERT_MODULES = [
+    "shared_expert_h_to_4h",
+    "shared_expert_gate",
+    "shared_expert_4h_to_h",
+]
+
+
+def _load_qwen_moe_dims(model_path):
+    """Read dimensions from a Qwen-MoE HF config.json."""
+    with open(os.path.join(model_path, "config.json")) as f:
+        cfg = json.load(f)
+    hidden = cfg["hidden_size"]
+    num_heads = cfg["num_attention_heads"]
+    head_dim = cfg.get("head_dim", hidden // num_heads)
+    num_kv_heads = cfg.get("num_key_value_heads", num_heads)
+    return {
+        "hidden": hidden,
+        "q_dim": num_heads * head_dim,
+        "kv_dim": num_kv_heads * head_dim,
+        "moe_intermediate": cfg["moe_intermediate_size"],
+        "shared_intermediate": cfg["shared_expert_intermediate_size"],
+        "num_layers": cfg["num_hidden_layers"],
+        "num_experts": cfg["num_experts"],
+    }
+
+
+def _rand_lora_pair(rank, in_dim, out_dim, dtype, generator):
+    """Return (lora_A, lora_B) with small but non-trivial magnitudes."""
+    lora_a = (torch.randn(rank, in_dim, dtype=torch.bfloat16, generator=generator) * 0.1).to(dtype)
+    lora_b = (torch.randn(out_dim, rank, dtype=torch.bfloat16, generator=generator) * 0.1).to(dtype)
+    return lora_a, lora_b
+
+
+def _write_adapter(output_dir, weights, target_modules, base_model_path, lora_rank):
+    os.makedirs(output_dir, exist_ok=True)
+    with open(os.path.join(output_dir, "adapter_config.json"), "w") as f:
+        json.dump(
+            {
+                "base_model_name_or_path": base_model_path,
+                "bias": "none",
+                "peft_type": "LORA",
+                "r": lora_rank,
+                "lora_alpha": lora_rank * 2,
+                "target_modules": target_modules,
+                "task_type": "CAUSAL_LM",
+            },
+            f,
+        )
+    save_file(weights, os.path.join(output_dir, "adapter_model.safetensors"))
+    return output_dir
+
+
+def _create_attention_plus_shared_expert_adapter(
+    output_dir, base_model_path, dims, *, lora_rank, dtype, seed, include_shared_expert
+):
+    """Build a Qwen MoE LoRA adapter on attention (+ optionally shared expert)."""
+    generator = torch.Generator().manual_seed(seed)
+    layer_blocks = {
+        "self_attn": {
+            "q_proj": (dims["hidden"], dims["q_dim"]),
+            "k_proj": (dims["hidden"], dims["kv_dim"]),
+            "v_proj": (dims["hidden"], dims["kv_dim"]),
+            "o_proj": (dims["q_dim"], dims["hidden"]),
+        },
+    }
+    target_modules = list(_HF_ATTN_MODULES)
+    if include_shared_expert:
+        layer_blocks["mlp.shared_expert"] = {
+            "gate_proj": (dims["hidden"], dims["shared_intermediate"]),
+            "up_proj": (dims["hidden"], dims["shared_intermediate"]),
+            "down_proj": (dims["shared_intermediate"], dims["hidden"]),
+        }
+        for m in _HF_SHARED_EXPERT_MODULES:
+            if m not in target_modules:
+                target_modules.append(m)
+
+    weights = {}
+    for layer_idx in range(dims["num_layers"]):
+        for block_path, modules in layer_blocks.items():
+            for module, (in_dim, out_dim) in modules.items():
+                key = f"base_model.model.model.layers.{layer_idx}.{block_path}.{module}"
+                lora_a, lora_b = _rand_lora_pair(lora_rank, in_dim, out_dim, dtype, generator)
+                weights[f"{key}.lora_A.weight"] = lora_a
+                weights[f"{key}.lora_B.weight"] = lora_b
+
+    return _write_adapter(output_dir, weights, target_modules, base_model_path, lora_rank)
+
+
+def _outputs_differ(lora_out, base_out, tol=1e-6):
+    """True if a request's LoRA output differs from its base output (tokens or logprobs)."""
+    if list(lora_out.outputs[0].token_ids) != list(base_out.outputs[0].token_ids):
+        return True
+    lp_lora = lora_out.outputs[0].logprobs
+    lp_base = base_out.outputs[0].logprobs
+    if lp_lora and lp_base:
+        for lp_w, lp_wo in zip(lp_lora, lp_base, strict=True):
+            v_w = next(iter(lp_w.values())).logprob
+            v_wo = next(iter(lp_wo.values())).logprob
+            if abs(v_w - v_wo) > tol:
+                return True
+    return False
+
+
+@skip_gpu_memory_less_than_40gb
+class TestQwen15MoEMultiLoRA:
+    """O(10) co-resident LoRA adapters on Qwen1.5-MoE-A2.7B-Chat."""
+
+    NUM_LORAS = 10
+    LORA_RANK = 8
+    DTYPE = torch.bfloat16
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.model_path = f"{llm_models_root()}/Qwen1.5-MoE-A2.7B-Chat"
+        if not os.path.exists(self.model_path):
+            pytest.skip(f"Model not found: {self.model_path}")
+        self.dims = _load_qwen_moe_dims(self.model_path)
+
+    def _build_adapters(self, root, *, include_shared_expert):
+        adapter_dirs = []
+        for i in range(self.NUM_LORAS):
+            adapter_dir = os.path.join(root, f"lora_{i}")
+            _create_attention_plus_shared_expert_adapter(
+                adapter_dir,
+                self.model_path,
+                self.dims,
+                lora_rank=self.LORA_RANK,
+                dtype=self.DTYPE,
+                seed=1000 + i,
+                include_shared_expert=include_shared_expert,
+            )
+            adapter_dirs.append(adapter_dir)
+        return adapter_dirs
+
+    def _run_with_and_without_lora(self, lora_config, adapter_dirs, prompts):
+        assert len(prompts) == self.NUM_LORAS
+        with LLM(
+            model=self.model_path,
+            backend="pytorch",
+            lora_config=lora_config,
+            tensor_parallel_size=1,
+            max_batch_size=self.NUM_LORAS,
+            max_num_tokens=512,
+        ) as llm:
+            sampling = SamplingParams(max_tokens=10, temperature=0.0, logprobs=0)
+            lora_requests = [
+                LoRARequest(f"lora-{i}", i, adapter_dirs[i]) for i in range(self.NUM_LORAS)
+            ]
+            out_lora = llm.generate(prompts, sampling, lora_request=lora_requests)
+            out_base = llm.generate(prompts, sampling)
+        return out_lora, out_base
+
+    def _assert_each_adapter_changes_output(self, out_lora, out_base):
+        unchanged = [
+            i
+            for i, (lora, base) in enumerate(zip(out_lora, out_base, strict=True))
+            if not _outputs_differ(lora, base)
+        ]
+        assert not unchanged, (
+            f"{len(unchanged)}/{self.NUM_LORAS} adapters produced identical outputs to the base "
+            f"model (indices {unchanged}); LoRA likely not applied for those requests."
+        )
+
+    def _build_prompts(self):
+        return [f"Question {i}: What is the capital of France?" for i in range(self.NUM_LORAS)]
+
+    def test_multi_lora_attention(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter_dirs = self._build_adapters(tmpdir, include_shared_expert=False)
+            lora_config = LoraConfig(
+                lora_target_modules=list(_TRTLLM_ATTN_MODULES),
+                max_lora_rank=self.LORA_RANK,
+                max_loras=self.NUM_LORAS,
+                max_cpu_loras=self.NUM_LORAS,
+            )
+            out_lora, out_base = self._run_with_and_without_lora(
+                lora_config, adapter_dirs, self._build_prompts()
+            )
+            self._assert_each_adapter_changes_output(out_lora, out_base)
+
+    def test_multi_lora_attention_and_shared_expert(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter_dirs = self._build_adapters(tmpdir, include_shared_expert=True)
+            lora_config = LoraConfig(
+                lora_target_modules=(_TRTLLM_ATTN_MODULES + _TRTLLM_SHARED_EXPERT_MODULES),
+                max_lora_rank=self.LORA_RANK,
+                max_loras=self.NUM_LORAS,
+                max_cpu_loras=self.NUM_LORAS,
+            )
+            out_lora, out_base = self._run_with_and_without_lora(
+                lora_config, adapter_dirs, self._build_prompts()
+            )
+            self._assert_each_adapter_changes_output(out_lora, out_base)
+
+
+@skip_gpu_memory_less_than_40gb
+class TestPerExpertMoELoRARejected:
+    """Per-expert MoE LoRA targets fail fast at LLM construction."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.model_path = f"{llm_models_root()}/Qwen1.5-MoE-A2.7B-Chat"
+        if not os.path.exists(self.model_path):
+            pytest.skip(f"Model not found: {self.model_path}")
+
+    def test_per_expert_moe_targets_rejected(self):
+        # Mix supported + unsupported targets to confirm the validator
+        # reports all unsupported ones together and isn't masked by the
+        # presence of a valid target.
+        lora_config = LoraConfig(
+            lora_target_modules=[
+                "attn_q",
+                "moe_h_to_4h",
+                "moe_4h_to_h",
+                "moe_gate",
+            ],
+            max_lora_rank=8,
+            max_loras=1,
+            max_cpu_loras=1,
+        )
+
+        # The validator runs inside the executor worker; `proxy.py` re-raises
+        # init failures as `RuntimeError("...") from <original>`, so the
+        # validator error is reachable via `__cause__` on the caller side.
+        with pytest.raises(RuntimeError) as excinfo:
+            LLM(
+                model=self.model_path,
+                backend="pytorch",
+                lora_config=lora_config,
+                tensor_parallel_size=1,
+                max_batch_size=1,
+                max_num_tokens=512,
+            )
+
+        cause = excinfo.value.__cause__ or excinfo.value.__context__
+        assert isinstance(cause, UnsupportedLoraTargetModulesError), (
+            f"Expected UnsupportedLoraTargetModulesError as the cause of the "
+            f"RuntimeError, got {type(cause).__name__}: {cause!r}"
+        )
+
+        msg = str(cause)
+        for name in ("moe_h_to_4h", "moe_4h_to_h", "moe_gate"):
+            assert name in msg, f"Missing '{name}' in: {msg!r}"
+        assert "attn_q" in msg  # listed under supported targets

--- a/tests/unittest/_torch/modules/tests_lora_modules/test_moe_multi_lora.py
+++ b/tests/unittest/_torch/modules/tests_lora_modules/test_moe_multi_lora.py
@@ -15,9 +15,10 @@
 """Multi-LoRA correctness on MoE models (Qwen1.5-MoE-A2.7B-Chat, O(10) adapters).
 
 Positive coverage: attention and shared-expert MLP targets across O(10)
-co-resident adapters. Negative coverage: per-expert MoE targets (`moe_*`)
-fail fast at LLM construction time. CPU-only validator unit tests live in
-`tests/unittest/_torch/lora/test_lora.py`.
+co-resident adapters. Negative coverage: per-expert MoE targets (moe_*)
+are dropped with a warning at LLM construction; the LLM still runs and
+attention LoRA is applied. CPU-only filter unit tests live in
+tests/unittest/_torch/lora/test_lora.py.
 """
 
 import json
@@ -31,7 +32,6 @@ from utils.llm_data import llm_models_root
 from utils.util import skip_gpu_memory_less_than_40gb
 
 from tensorrt_llm import LLM, SamplingParams
-from tensorrt_llm._torch.peft.lora.layer import UnsupportedLoraTargetModulesError
 from tensorrt_llm.executor.request import LoRARequest
 from tensorrt_llm.lora_helper import LoraConfig
 
@@ -238,51 +238,62 @@ class TestQwen15MoEMultiLoRA:
 
 
 @skip_gpu_memory_less_than_40gb
-class TestPerExpertMoELoRARejected:
-    """Per-expert MoE LoRA targets fail fast at LLM construction."""
+class TestPerExpertMoELoRADropped:
+    """Per-expert MoE LoRA targets are dropped with a warning; LLM still runs."""
 
     @pytest.fixture(autouse=True)
     def setup(self):
         self.model_path = f"{llm_models_root()}/Qwen1.5-MoE-A2.7B-Chat"
         if not os.path.exists(self.model_path):
             pytest.skip(f"Model not found: {self.model_path}")
+        self.dims = _load_qwen_moe_dims(self.model_path)
 
-    def test_per_expert_moe_targets_rejected(self):
-        # Mix supported + unsupported targets to confirm the validator
-        # reports all unsupported ones together and isn't masked by the
-        # presence of a valid target.
-        lora_config = LoraConfig(
-            lora_target_modules=[
-                "attn_q",
-                "moe_h_to_4h",
-                "moe_4h_to_h",
-                "moe_gate",
-            ],
-            max_lora_rank=8,
-            max_loras=1,
-            max_cpu_loras=1,
-        )
+    def test_per_expert_moe_targets_dropped(self):
+        # Mixed targets: attention names are wired (LoraLayer registered),
+        # routed-expert names are not. The PyT filter prunes the latter and
+        # construction proceeds; the attention LoRA still affects output.
+        lora_rank = 8
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter_dir = os.path.join(tmpdir, "lora_attn")
+            _create_attention_plus_shared_expert_adapter(
+                adapter_dir,
+                self.model_path,
+                self.dims,
+                lora_rank=lora_rank,
+                dtype=torch.bfloat16,
+                seed=42,
+                include_shared_expert=False,
+            )
 
-        # The validator runs inside the executor worker; `proxy.py` re-raises
-        # init failures as `RuntimeError("...") from <original>`, so the
-        # validator error is reachable via `__cause__` on the caller side.
-        with pytest.raises(RuntimeError) as excinfo:
-            LLM(
+            lora_config = LoraConfig(
+                lora_target_modules=[
+                    "attn_q",
+                    "attn_k",
+                    "attn_v",
+                    "attn_dense",
+                    "moe_h_to_4h",
+                    "moe_4h_to_h",
+                    "moe_gate",
+                ],
+                max_lora_rank=lora_rank,
+                max_loras=1,
+                max_cpu_loras=1,
+            )
+
+            with LLM(
                 model=self.model_path,
                 backend="pytorch",
                 lora_config=lora_config,
                 tensor_parallel_size=1,
                 max_batch_size=1,
                 max_num_tokens=512,
-            )
+            ) as llm:
+                sampling = SamplingParams(max_tokens=10, temperature=0.0, logprobs=0)
+                prompts = ["Question: What is the capital of France?"]
+                lora_request = [LoRARequest("lora-attn", 1, adapter_dir)]
+                out_lora = llm.generate(prompts, sampling, lora_request=lora_request)
+                out_base = llm.generate(prompts, sampling)
 
-        cause = excinfo.value.__cause__ or excinfo.value.__context__
-        assert isinstance(cause, UnsupportedLoraTargetModulesError), (
-            f"Expected UnsupportedLoraTargetModulesError as the cause of the "
-            f"RuntimeError, got {type(cause).__name__}: {cause!r}"
-        )
-
-        msg = str(cause)
-        for name in ("moe_h_to_4h", "moe_4h_to_h", "moe_gate"):
-            assert name in msg, f"Missing '{name}' in: {msg!r}"
-        assert "attn_q" in msg  # listed under supported targets
+                assert _outputs_differ(out_lora[0], out_base[0]), (
+                    "Attention LoRA did not affect output despite being a supported target."
+                )


### PR DESCRIPTION
## Description

This MR enables graceful exit when LoRA is not supported for a module. Also, adds a few tests for multi-lora with MoE models.

Previously:
```
File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/_torch/pyexecutor/model_engine.py", line 3917, in forward
    inputs, gather_ids = self._prepare_inputs(
                         ^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/_torch/pyexecutor/model_engine.py", line 3702, in _prepare_inputs
    return self._prepare_tp_inputs(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/_torch/pyexecutor/model_engine.py", line 3018, in _prepare_tp_inputs
    lora_params = self._get_lora_params_from_requests(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/_torch/pyexecutor/model_engine.py", line 3522, in _get_lora_params_from_requests
    return self.cuda_graph_lora_manager.prepare_cuda_graph_lora_params(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/_torch/peft/lora/cuda_graph_lora_manager.py", line 167, in prepare_cuda_graph_lora_params
    cuda_graph_lora_params.update_weight_pointers(peft_table, slot2task)
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/_torch/peft/lora/cuda_graph_lora_params.py", line 262, in update_weight_pointers
    key = self.layer_module2key[(layer_id, module_id)]
          ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
KeyError: (0, 14)
```

Now. Exception is raised during worker initialization.
```
[05/07/2026-21:57:23] [TRT-LLM] [E] [executor] Traceback (most recent call last):
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/executor/worker.py", line 282, in worker_main
    worker: GenerationExecutorWorker = worker_cls(
                                       ^^^^^^^^^^^
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/executor/worker.py", line 62, in __init__
    self.setup_engine()
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/executor/base_worker.py", line 260, in setup_engine
    self.engine = _create_py_executor(
                  ^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/executor/base_worker.py", line 231, in _create_py_executor
    _executor = create_executor(**args)
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/_torch/pyexecutor/py_executor_creator.py", line 863, in create_py_executor
    py_executor = create_py_executor_instance(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/_torch/pyexecutor/_util.py", line 1291, in create_py_executor_instance
    validate_lora_target_modules_supported(model_engine.model,
  File "/home/scratch.bbuddharaju_gpu/TensorRT-LLM/tests/unittest/utils/../../../tensorrt_llm/_torch/peft/lora/layer.py", line 594, in validate_lora_target_modules_supported
    raise UnsupportedLoraTargetModulesError(
tensorrt_llm._torch.peft.lora.layer.UnsupportedLoraTargetModulesError: LoRA target module(s) ['moe_4h_to_h', 'moe_gate', 'moe_h_to_4h'] have no LoraLayer registered on this model. Supported on this model: ['attn_dense', 'attn_k', 'attn_q', 'attn_qkv', 'attn_v', 'mlp_gate_up', 'shared_expert_4h_to_h', 'shared_expert_gate', 'shared_expert_h_to_4h']. Remove the unsupported entries from `LoraConfig.lora_target_modules` and from `target_modules` in your adapter checkpoints to proceed.
```

## Test Coverage

```
$ pytest -v tests/unittest/_torch/lora/test_lora.py -k validate_lora_target_modules_supported
$ pytest -s -v tests/unittest/_torch/modules/tests_lora_modules/test_moe_multi_lora.py::TestQwen15MoEMultiLoRA::test_multi_lora_attention
$ pytest -s -v tests/unittest/_torch/modules/tests_lora_modules/test_moe_multi_lora.py::TestQwen15MoEMultiLoRA::test_multi_lora_attention_and_shared_expert
$ pytest -s -v tests/unittest/_torch/modules/tests_lora_modules/test_moe_multi_lora.py::TestPerExpertMoELoRARejected::test_per_expert_moe_targets_rejected
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation for LoRA target modules with clear error messages listing supported and unsupported targets
  * Implemented early failure detection to prevent invalid LoRA configurations from proceeding to model initialization
  * Extended LoRA support validation for Mixture of Experts (MoE) models

* **Tests**
  * Added comprehensive unit tests for target module validation logic
  * Added Multi-LoRA tests for Qwen MoE models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->