### PR TITLE
[TRTLLM-12670][feat] add /start_profile and /stop_profile endpoints to trtllm…

### DIFF
--- a/docs/source/commands/trtllm-serve/run-benchmark-with-trtllm-serve.md
+++ b/docs/source/commands/trtllm-serve/run-benchmark-with-trtllm-serve.md
@@ -196,6 +196,89 @@ $$
 
 To get more detailed metrics besides the key metrics above, there is an [experimental tool](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tensorrt_llm/serve/scripts/time_breakdown) for request time breakdown.
 
+## Profile a server with HTTP API endpoints
+
+> **Beta.** PyTorch backend only. No-op on the TensorRT backend.
+
+`trtllm-serve` exposes two HTTP endpoints that control iteration-scoped profiling of the backend engine at runtime — no restart and no env vars required:
+
+* `POST /start_profile` — start a window, optionally bounded by `num_steps`.
+* `POST /stop_profile` — flush the window. Only needed if `/start_profile` was called without `num_steps`.
+
+Under TP/PP > 1 both endpoints broadcast to every rank, so each rank writes its own chrome trace with a matching `profile_id` and a `rank-<N>` suffix. Unlike a synthetic warmup request, the underlying wake mechanism does **not** run a forward pass, so the captured trace contains only real workload events.
+
+For the full request body schema and response codes (including the `409` for double-start), see [Runtime Profiling Endpoints](./trtllm-serve.rst#runtime-profiling-endpoints).
+
+### Typical workflow: capture steady-state decode
+
+1. **Start the server** as usual (e.g. `trtllm-serve $MODEL --tp_size 2 ...`). The endpoints are registered automatically.
+2. **Warm up and ramp to steady state** — send enough concurrent requests that the engine is consistently at or near `max_batch_size`. A short burst from `benchmark_serving.py` works well:
+
+   ```bash
+   python -m tensorrt_llm.serve.scripts.benchmark_serving \
+       --model $MODEL --host 127.0.0.1 --port 8000 \
+       --dataset-name random --num-prompts 200 \
+       --random-input-len 512 --random-output-len 128 \
+       --max-concurrency 32 &
+   ```
+
+3. **Fire `/start_profile`** once the server is in steady state. Bound the window so you don't need to call `/stop_profile`:
+
+   ```bash
+   curl -s -X POST http://127.0.0.1:8000/start_profile \
+       -H "Content-Type: application/json" \
+       -d '{"output_dir": "/tmp/traces", "num_steps": 50, "start_step": 0}'
+   # {"message":"Profiling started"}
+   ```
+
+4. **Wait for the load to finish**, then list the traces:
+
+   ```bash
+   wait
+   ls /tmp/traces/
+   # trtllm-trace-1778480665-7993d824-rank-0.json
+   # trtllm-trace-1778480665-7993d824-rank-1.json   (TP=2)
+   ```
+
+5. **Open the traces** in [ui.perfetto.dev](https://ui.perfetto.dev/) or `chrome://tracing`. Each captured iteration is wrapped in an sglang-compatible `step[EXTEND bs=N toks=M]` / `step[DECODE bs=N]` scope.
+
+### Open-ended window (manual stop)
+
+Omit `num_steps` if you want to profile "from now until I say stop". You must call `/stop_profile` to flush the trace:
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/start_profile \
+    -H "Content-Type: application/json" \
+    -d '{"output_dir": "/tmp/traces"}'
+
+# ... drive load ...
+
+curl -s -X POST http://127.0.0.1:8000/stop_profile
+# {"message":"Profiling stopped"}   (returns only after the trace is on disk)
+```
+
+### Compose with `nsys profile`
+
+Set `activities` to `["CUDA_PROFILER"]` to suppress `torch.profiler` entirely so only `cudaProfilerStart`/`cudaProfilerStop` brackets fire. This composes cleanly with `nsys profile -c cudaProfilerApi`:
+
+```bash
+nsys profile -c cudaProfilerApi -o trtllm_serve \
+    trtllm-serve $MODEL --tp_size 2 ...
+
+# In another terminal:
+curl -s -X POST http://127.0.0.1:8000/start_profile \
+    -H "Content-Type: application/json" \
+    -d '{"activities": ["CUDA_PROFILER"], "num_steps": 100}'
+```
+
+### Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `/start_profile` returns **409** | A profile window is already active or pending. Call `/stop_profile` first or wait for `num_steps` to elapse. |
+| `/stop_profile` returns 200 but takes up to ~30 s | The engine was idle and the wake had to cycle the executor loop to reach the flush point. Send any small completion to keep the loop warm, or pass `num_steps` so the engine self-terminates. |
+| Trace file missing on non-zero ranks | The engine is not running the PyTorch backend, or you built the server with `--disable-overlap-scheduler` against an older code path that lacks the broadcast plumbing. Verify with `POST /version` and with the server log line `_apply_profile_start_config[rank=N]:` appearing on every rank when `TLLM_LOG_LEVEL=info`. |
+
 ## About `--config`
 
 ```{eval-rst}

--- a/docs/source/commands/trtllm-serve/run-benchmark-with-trtllm-serve.md
+++ b/docs/source/commands/trtllm-serve/run-benchmark-with-trtllm-serve.md
@@ -240,7 +240,7 @@ For the full request body schema and response codes (including the `409` for dou
    # trtllm-trace-1778480665-7993d824-rank-1.json   (TP=2)
    ```
 
-5. **Open the traces** in [ui.perfetto.dev](https://ui.perfetto.dev/) or `chrome://tracing`. Each captured iteration is wrapped in an sglang-compatible `step[EXTEND bs=N toks=M]` / `step[DECODE bs=N]` scope.
+5. **Open the traces** in [ui.perfetto.dev](https://ui.perfetto.dev/) or `chrome://tracing`. Each captured iteration is wrapped in a `step[EXTEND bs=N toks=M]` / `step[DECODE bs=N]` scope.
 
 ### Open-ended window (manual stop)
 

--- a/docs/source/commands/trtllm-serve/trtllm-serve.rst
+++ b/docs/source/commands/trtllm-serve/trtllm-serve.rst
@@ -17,8 +17,10 @@ The server also supports the following endpoints:
 - ``/health``
 - ``/metrics``
 - ``/version``
+- ``/start_profile`` (prototype)
+- ``/stop_profile`` (prototype)
 
-The ``metrics`` endpoint provides runtime-iteration statistics such as GPU memory use and inflight-batching details.
+The ``metrics`` endpoint provides runtime-iteration statistics such as GPU memory use and inflight-batching details. The ``start_profile`` and ``stop_profile`` endpoints control iteration-scoped profiling of the backend engine; see :ref:`runtime-profiling-endpoints` below.
 
 Starting a Server
 -----------------
@@ -315,6 +317,73 @@ Example output:
             ...
         }
     ]
+
+.. _runtime-profiling-endpoints:
+
+Runtime Profiling Endpoints
+---------------------------
+
+.. note::
+
+   The ``/start_profile`` and ``/stop_profile`` endpoints are **prototype** and only apply to the default PyTorch backend (``PyExecutor``). They are no-ops on the TensorRT backend. APIs, parameters, and behaviour may change in future releases.
+
+The server exposes two HTTP endpoints that control iteration-scoped profiling of the backend engine at runtime, without restarting ``trtllm-serve`` and without setting ``TLLM_PROFILE_START_STOP`` / ``TLLM_TORCH_PROFILE_TRACE``. Under TP/PP > 1, both endpoints broadcast the window to every rank, so each rank writes its own chrome trace (distinguished by a ``rank-<N>`` suffix in the filename) and all ranks profile the same iterations in lockstep.
+
+POST /start_profile
+~~~~~~~~~~~~~~~~~~~
+
+Start a profile window. All fields in the JSON body are optional.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 15 50
+
+   * - Field
+     - Type
+     - Description
+   * - ``output_dir``
+     - string
+     - Directory where chrome traces are written. Defaults to ``$TLLM_TORCH_PROFILER_DIR`` if set, otherwise ``/tmp``. One trace file per rank is written as ``trtllm-trace-<profile_id>-rank-<N>.json``; ``<profile_id>`` is a timestamp + short uuid so successive cycles don't collide.
+   * - ``num_steps``
+     - int
+     - Number of engine iterations to capture. When set, the engine stops the window automatically and you do not need to call ``/stop_profile``. When omitted, profiling runs until ``/stop_profile`` is called.
+   * - ``start_step``
+     - int (default ``0``)
+     - Iterations to skip after the call before profiling starts. Use to exclude warmup-like transients from the capture.
+   * - ``activities``
+     - list of string
+     - Subset of ``["CPU", "GPU", "CUDA_PROFILER"]`` (default ``["CPU", "GPU"]``). When ``["CUDA_PROFILER"]`` is specified, ``torch.profiler`` is not started and only ``cudaProfilerStart`` / ``cudaProfilerStop`` are called — this composes cleanly with ``nsys profile -c cudaProfilerApi``.
+
+Response: ``200`` with ``{"message": "Profiling started"}`` on success. ``409`` with ``{"success": false, "message": ...}`` if a profile window is already active or pending (the backend does not silently queue a second window).
+
+POST /stop_profile
+~~~~~~~~~~~~~~~~~~
+
+Stop an in-progress profile window and flush the chrome trace to disk. Takes no body. The call blocks until ``export_chrome_trace()`` has run on the backend thread, so by the time the handler returns the file is on disk. Call this only if ``/start_profile`` was invoked without ``num_steps``; otherwise the window self-terminates.
+
+Example
+~~~~~~~
+
+.. code-block:: bash
+
+   # Start a 30-iteration profile window into /tmp/traces.
+   curl -s -X POST http://127.0.0.1:8000/start_profile \
+       -H "Content-Type: application/json" \
+       -d '{"output_dir": "/tmp/traces", "num_steps": 30}'
+
+   # ... drive load via /v1/completions or /v1/chat/completions ...
+
+   # If you started the window without num_steps, stop it:
+   curl -s -X POST http://127.0.0.1:8000/stop_profile
+
+   # Inspect the resulting chrome traces.
+   ls /tmp/traces/
+   # trtllm-trace-1778480665-7993d824-rank-0.json
+   # trtllm-trace-1778480665-7993d824-rank-1.json   (TP=2)
+
+Open the trace files in `ui.perfetto.dev <https://ui.perfetto.dev/>`_ or ``chrome://tracing``. Each captured iteration is wrapped in an SGLang-compatible ``step[EXTEND bs=N toks=M]`` or ``step[DECODE bs=N]`` user-annotation scope so traces from ``trtllm-serve`` and SGLang can be compared side-by-side.
+
+For a full benchmarking + profiling workflow (including multi-cycle capture under steady-state load), see :doc:`run-benchmark-with-trtllm-serve`.
 
 .. _configuring-with-yaml-files:
 

--- a/docs/source/commands/trtllm-serve/trtllm-serve.rst
+++ b/docs/source/commands/trtllm-serve/trtllm-serve.rst
@@ -381,7 +381,7 @@ Example
    # trtllm-trace-1778480665-7993d824-rank-0.json
    # trtllm-trace-1778480665-7993d824-rank-1.json   (TP=2)
 
-Open the trace files in `ui.perfetto.dev <https://ui.perfetto.dev/>`_ or ``chrome://tracing``. Each captured iteration is wrapped in an SGLang-compatible ``step[EXTEND bs=N toks=M]`` or ``step[DECODE bs=N]`` user-annotation scope so traces from ``trtllm-serve`` and SGLang can be compared side-by-side.
+Open the trace files in `ui.perfetto.dev <https://ui.perfetto.dev/>`_ or ``chrome://tracing``. Each captured iteration is wrapped in a ``step[EXTEND bs=N toks=M]`` or ``step[DECODE bs=N]`` user-annotation scope.
 
 For a full benchmarking + profiling workflow (including multi-cycle capture under steady-state load), see :doc:`run-benchmark-with-trtllm-serve`.
 

--- a/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
+++ b/tensorrt_llm/_torch/pyexecutor/executor_request_queue.py
@@ -14,6 +14,11 @@ from .request_utils import get_num_child_requests
 
 SHUTDOWN_REQUEST_ID = -1
 CONTROL_REQUEST_ID = -2
+# Sentinel request ids for profiling control. Rank 0 enqueues these
+# items; ``RequestBroadcaster`` copies them to every TP/PP rank so the
+# profile window applies on every PyExecutor, not just the leader.
+PROFILE_START_REQUEST_ID = -3
+PROFILE_STOP_REQUEST_ID = -4
 
 
 @dataclasses.dataclass
@@ -29,6 +34,11 @@ class RequestQueueItem:
     # step boundary with in-flight requests still in the engine.
     # See ``PyExecutor.control_action``.
     control_requires_drain: bool = True
+    # Payload for profile-control items. Populated only when
+    # ``is_profile_start_request`` is true; contains the ``output_dir``,
+    # ``num_steps``, ``start_step``, and ``activities`` that every rank
+    # applies when the broadcast reaches them.
+    profile_config: Optional[dict] = None
 
     @property
     def is_shutdown_request(self):
@@ -37,11 +47,20 @@ class RequestQueueItem:
     @property
     def is_normal_request(self):
         return not (self.is_shutdown_request or self.is_canceled_request
-                    or self.is_control_request)
+                    or self.is_control_request or self.is_profile_start_request
+                    or self.is_profile_stop_request)
 
     @property
     def is_control_request(self):
         return self.id == CONTROL_REQUEST_ID
+
+    @property
+    def is_profile_start_request(self):
+        return self.id == PROFILE_START_REQUEST_ID
+
+    @property
+    def is_profile_stop_request(self):
+        return self.id == PROFILE_STOP_REQUEST_ID
 
 
 class ExecutorRequestQueue:
@@ -137,6 +156,20 @@ class ExecutorRequestQueue:
             self.request_queue.put(
                 RequestQueueItem(id=CONTROL_REQUEST_ID,
                                  control_requires_drain=drain))
+
+    def enqueue_profile_start_request(self, profile_config: dict):
+        """Enqueue a profile-start control item that is broadcasted to
+        every TP/PP rank via ``RequestBroadcaster`` so all PyExecutor
+        instances apply the window in lockstep (not just the leader)."""
+        with self.enqueue_lock:
+            self.request_queue.put(
+                RequestQueueItem(id=PROFILE_START_REQUEST_ID,
+                                 profile_config=profile_config))
+
+    def enqueue_profile_stop_request(self):
+        """Enqueue a profile-stop control item. Broadcasted to every rank."""
+        with self.enqueue_lock:
+            self.request_queue.put(RequestQueueItem(id=PROFILE_STOP_REQUEST_ID))
 
     def enqueue_shutdown_request(self):
         with self.enqueue_lock:

--- a/tensorrt_llm/_torch/pyexecutor/profiling.py
+++ b/tensorrt_llm/_torch/pyexecutor/profiling.py
@@ -1,0 +1,809 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runtime profiling controller for ``PyExecutor``.
+
+The ``PyExecutorProfileManager`` owns the entire profile-state machine
+that backs the ``trtllm-serve`` ``/start_profile`` / ``/stop_profile``
+HTTP endpoints (and the equivalent programmatic
+``LLM.start_profile`` / ``LLM.stop_profile`` calls):
+
+* ``start_profile`` / ``stop_profile`` — caller-thread entry points
+  that schedule a profile window via the executor's request queue.
+  These run on the FastAPI thread-pool worker (or a user thread for
+  the in-process / RPC paths).
+* ``apply_start_config`` / ``apply_stop_config`` — replay the
+  broadcasted config on every rank so all ranks fire the same start
+  and stop iterations.
+* ``profile_step`` — context manager driving the per-iteration
+  ``torch.profiler`` / ``cudaProfilerStart`` / ``Stop`` calls. Runs
+  on the executor thread because torch.profiler / Kineto require
+  the start and stop calls to happen on the same thread.
+* ``cleanup`` — best-effort tear-down on executor shutdown.
+
+The profile state itself (``profile_start_iters``, ``profile_stop_iters``,
+``_runtime_profile_*`` fields, ``_profile_state_lock``,
+``_profile_enabled``) lives on the ``PyExecutor`` instance so callers
+and unit tests can introspect it directly. The manager holds a weak
+reference back to the executor and operates on those fields. This
+keeps ``py_executor.py`` mostly orchestration / thin forwarding while
+isolating the lifecycle logic in this module for review.
+"""
+
+import os
+import time
+import uuid
+import weakref
+from contextlib import contextmanager
+from typing import Dict, List, Optional
+
+import torch
+
+from tensorrt_llm.logger import logger
+from tensorrt_llm.tools.layer_wise_benchmarks import get_calibrator
+from tensorrt_llm.tools.profiler.host_profile_tools.host_profiler import get_global_profiler
+
+# Environment-variable names used by both the env-var-driven legacy
+# path and the runtime HTTP-endpoint path. They are duplicated as
+# module-level constants here so callers that only need the manager
+# do not have to import from ``py_executor.py``.
+PROFILE_START_STOP_ENV_VAR_NAME = "TLLM_PROFILE_START_STOP"
+PROFILE_TRACE_ENV_VAR_NAME = "TLLM_TORCH_PROFILE_TRACE"
+PROFILE_LOG_RANKS_ENV_VAR_NAME = "TLLM_PROFILE_LOG_RANKS"
+
+
+def load_iteration_indexes(env_var: str):
+    """Parse an iteration-range environment variable.
+
+    Format: ``"start1-stop1,start2-stop2,..."`` for ranges or
+    ``"iter1,iter2,..."`` for single iterations.
+
+    Returns:
+        Two ``frozenset[int]`` -- (start_iters, stop_iters).
+    """
+    spans = os.environ.get(env_var, None)
+    starts, stops = [], []
+
+    if spans:
+        spans = spans.split(",")
+
+        for span in spans:
+            try:
+                if "-" in span:
+                    start, stop = span.strip().split("-")
+                    starts.append(int(start))
+                    stops.append(int(stop))
+                else:
+                    it = int(span.strip())
+                    starts.append(it)
+                    stops.append(it)
+            except ValueError as e:
+                raise ValueError(
+                    f"Cannot parse span in environment variable `{env_var}`: {e}"
+                ) from None
+
+    return frozenset(starts), frozenset(stops)
+
+
+class PyExecutorProfileManager:
+    """Owns the runtime-profiling state machine for ``PyExecutor``.
+
+    Instantiated from ``PyExecutor.__init__`` after the executor has
+    populated ``profile_start_iters`` / ``profile_stop_iters`` /
+    ``_runtime_profile_*`` / ``_profile_state_lock`` /
+    ``_profile_enabled``. The manager keeps a ``weakref`` back to the
+    executor so it can read ``iter_counter``, ``is_warmup``,
+    ``executor_request_queue``, ``dist``, and ``global_rank`` on demand
+    without creating a cycle that defeats garbage collection.
+
+    All methods follow the same threading invariants as the inline
+    code they replace; see the per-method docstrings for details.
+    """
+
+    def __init__(self, executor: "PyExecutor") -> None:  # noqa: F821
+        self._executor_ref = weakref.ref(executor)
+
+    # ---- helpers ---------------------------------------------------
+
+    @property
+    def _executor(self) -> "PyExecutor":  # noqa: F821
+        ex = self._executor_ref()
+        if ex is None:
+            raise RuntimeError(
+                "PyExecutorProfileManager: owning PyExecutor has been "
+                "garbage collected; profile control calls are no longer "
+                "valid."
+            )
+        return ex
+
+    @staticmethod
+    def _activities_from_names(
+        names: Optional[List[str]],
+    ) -> List["torch.profiler.ProfilerActivity"]:
+        if not names:
+            return [
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+                torch.profiler.ProfilerActivity.XPU,
+            ]
+        mapping = {
+            "CPU": torch.profiler.ProfilerActivity.CPU,
+            "GPU": torch.profiler.ProfilerActivity.CUDA,
+            "CUDA": torch.profiler.ProfilerActivity.CUDA,
+            "XPU": torch.profiler.ProfilerActivity.XPU,
+        }
+        resolved: List[torch.profiler.ProfilerActivity] = []
+        for name in names:
+            key = name.upper()
+            if key == "CUDA_PROFILER":
+                # CUDA_PROFILER controls cudaProfilerStart/Stop only;
+                # it is not a torch.profiler activity.
+                continue
+            if key in mapping and mapping[key] not in resolved:
+                resolved.append(mapping[key])
+        return resolved
+
+    # ---- HTTP-callable entry points --------------------------------
+
+    def start_profile(
+        self,
+        output_dir: Optional[str] = None,
+        num_steps: Optional[int] = None,
+        start_step: int = 0,
+        activities: Optional[List[str]] = None,
+    ) -> None:
+        """Schedule a runtime profile window on every rank.
+
+        Mirrors the env-var driven ``TLLM_PROFILE_START_STOP`` /
+        ``TLLM_TORCH_PROFILE_TRACE`` path but is callable at runtime
+        (e.g. from the ``trtllm-serve /start_profile`` HTTP handler).
+
+        Runs on the caller thread (FastAPI worker thread / user
+        thread). Marks ``_runtime_profile_pending_start_iter`` locally
+        so a concurrent second call is rejected immediately, then
+        broadcasts the config on rank 0 via the executor's request
+        queue so every rank sees the same start.
+        """
+        executor = self._executor
+        # Reject overlapping profile windows. Check locally on the
+        # caller thread so the HTTP handler gets a clean error instead
+        # of the executor thread crashing on ``assert not enabled``
+        # inside ``profile_step``.
+        with executor._profile_state_lock:
+            already_active = executor._profile_enabled
+        if already_active or executor._runtime_profile_pending_start_iter is not None:
+            # Use ``RequestError`` (a ``RuntimeError`` subclass) so the
+            # ``GenerationExecutor`` error monitor treats this as a
+            # per-call rejection rather than a fatal engine error.
+            from tensorrt_llm.executor.utils import RequestError
+
+            raise RequestError(
+                "Profiling is already in progress (or a pending start has "
+                "been scheduled); call stop_profile first before starting "
+                "a new window. (state: _profile_enabled="
+                f"{already_active}, _runtime_profile_pending_start_iter="
+                f"{executor._runtime_profile_pending_start_iter}, "
+                f"profile_start_iters="
+                f"{sorted(executor.profile_start_iters)[:5]}, "
+                f"profile_stop_iters="
+                f"{sorted(executor.profile_stop_iters)[:5]})"
+            )
+
+        # Reject ``num_steps <= 0``. The HTTP layer already rejects
+        # this via the ``StartProfileRequest`` Pydantic schema, but
+        # programmatic callers (``LLM.start_profile``, env-var-driven
+        # paths, unit tests) bypass that schema. With
+        # ``num_steps == 0``, ``stop_iter`` would equal ``start_iter``
+        # in ``apply_start_config`` below, ``profile_step`` would
+        # discard the stop marker as stale, and the profile window
+        # would run forever until an explicit ``stop_profile()``.
+        if num_steps is not None and num_steps <= 0:
+            raise ValueError(
+                f"start_profile: num_steps must be >= 1 if provided "
+                f"(got num_steps={num_steps!r}). Pass num_steps=None to "
+                "run until an explicit stop_profile() call."
+            )
+
+        if activities is None:
+            activities = ["CPU", "GPU"]
+
+        if output_dir is None:
+            # ``/tmp`` is the documented developer default for the
+            # profile trace directory (matches the server docs); the
+            # user-facing override is the
+            # ``TLLM_TORCH_PROFILER_DIR`` env var or the
+            # ``output_dir`` request body field.
+            output_dir = os.environ.get(
+                "TLLM_TORCH_PROFILER_DIR",
+                "/tmp",  # nosec B108
+            )
+
+        # Fail fast if the directory cannot be created. Returning
+        # success here would schedule a profile window that later
+        # blows up in ``export_chrome_trace()`` on the executor
+        # thread, after the HTTP caller has already been told the
+        # request was accepted. ``RequestError`` (a ``RuntimeError``
+        # subclass) routes through the same per-call rejection
+        # plumbing as the "already in progress" guard above, so the
+        # HTTP handler can map it to a 5xx with a meaningful body.
+        try:
+            os.makedirs(output_dir, exist_ok=True)
+        except OSError as e:
+            from tensorrt_llm.executor.utils import RequestError
+
+            raise RequestError(f"Failed to create profile output_dir {output_dir}: {e}") from e
+
+        # Include a unique profile id (monotonic timestamp + short
+        # uuid fragment) so successive start/stop cycles under the
+        # same output_dir don't silently overwrite each other's
+        # traces.
+        profile_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+
+        # Build the per-request config that every rank consumes. We
+        # do NOT pre-compute start_iter here: each rank must derive
+        # it from its own ``iter_counter`` at the moment the
+        # broadcast is processed (inside
+        # ``_handle_special_queue_items``), so that rank 0 doesn't
+        # get a head start by pre-applying with its caller-thread
+        # ``iter_counter`` while rank 1's executor loop has already
+        # advanced past the start point. All ranks are in sync on
+        # iter_counter at the broadcast point, so they all compute
+        # the same start_iter/stop_iter.
+        profile_config = {
+            "output_dir": output_dir,
+            "profile_id": profile_id,
+            "activities": list(activities),
+            "start_step": int(max(0, start_step)),
+            "num_steps": num_steps,
+        }
+
+        # Mark pending on the caller thread too so a second
+        # concurrent ``start_profile()`` is rejected by the guard
+        # above. The actual ``profile_start_iters`` / trace_path
+        # state is only populated when the broadcast reaches
+        # ``_handle_special_queue_items``. Use a sentinel (0) to
+        # mean "pending but not yet scheduled".
+        executor._runtime_profile_pending_start_iter = 0
+        executor._runtime_profile_activities = list(activities)
+
+        # Broadcast to every rank via the request queue so non-zero
+        # ranks update their own ``profile_start_iters`` in
+        # lockstep. This is also what wakes the idle executor loop
+        # (the PROFILE_START_REQUEST_ID item gets broadcasted via
+        # ``RequestBroadcaster`` inside
+        # ``_fetch_and_enqueue_requests``, then dropped inside
+        # ``_handle_special_queue_items`` — no forward pass runs for
+        # this iteration, so the chrome trace captures only real
+        # user workload).
+        rank = getattr(getattr(executor, "dist", None), "rank", 0)
+        eq = getattr(executor, "executor_request_queue", None)
+        if rank == 0 and eq is not None:
+            try:
+                eq.enqueue_profile_start_request(profile_config)
+            except (RuntimeError, OSError, ValueError, AttributeError) as e:
+                # Roll back the pending markers we just set so a
+                # subsequent ``start_profile()`` is not rejected as
+                # "already pending", and so non-zero ranks (which
+                # never received the broadcast) don't drift out of
+                # sync with rank 0. Then surface the failure to the
+                # HTTP layer rather than silently logging and
+                # continuing.
+                executor._runtime_profile_pending_start_iter = None
+                executor._runtime_profile_activities = None
+                raise RuntimeError(
+                    f"start_profile: failed to enqueue profile-start broadcast item: {e}"
+                ) from e
+
+    def stop_profile(self) -> None:
+        """Schedule the in-progress runtime profile to stop.
+
+        The actual ``torch.profiler.stop()`` +
+        ``export_chrome_trace()`` call happens inside
+        ``profile_step`` on the executor thread, so torch.profiler /
+        Kineto's "stop must run on the same thread that called
+        start" invariant is respected.
+
+        Two extra cases are handled so no profile window is leaked:
+
+        * If ``start_profile()`` was called but the engine has not
+          yet reached the scheduled ``start_iter`` (e.g. the caller
+          stopped before sending any requests), cancel the pending
+          start so profiling does not begin later.
+        * Otherwise schedule a stop iteration. When called via an
+          HTTP handler the server layer is responsible for tickling
+          the executor loop so the stop iteration actually runs even
+          when the engine would otherwise be idle (see
+          ``OpenAIServer.stop_profile``).
+        """
+        executor = self._executor
+        with executor._profile_state_lock:
+            currently_enabled = executor._profile_enabled
+
+        if not currently_enabled and executor._runtime_profile_pending_start_iter is not None:
+            # Pending runtime start has not fired yet; cancel it
+            # cleanly on this rank.  Also broadcast the stop so
+            # non-zero ranks clear their own pending starts —
+            # otherwise a ``start_profile``-then-``stop_profile``
+            # cycle on an idle multi-rank deployment would leave
+            # stale pending starts on the subordinates.
+            self.apply_stop_config()
+            rank = getattr(getattr(executor, "dist", None), "rank", 0)
+            eq = getattr(executor, "executor_request_queue", None)
+            if rank == 0 and eq is not None:
+                try:
+                    eq.enqueue_profile_stop_request()
+                except (RuntimeError, OSError, ValueError, AttributeError) as e:
+                    # Local cancel already happened on this rank,
+                    # but subordinate ranks would still be carrying
+                    # the pending start. Surface the broadcast
+                    # failure so the caller can retry rather than
+                    # silently leaving the cluster out of sync.
+                    raise RuntimeError(
+                        f"stop_profile: failed to enqueue profile-stop broadcast item: {e}"
+                    ) from e
+            return
+
+        # Apply locally so diagnostic state (profile_stop_iters,
+        # pending_stop_iter) is visible on the caller thread
+        # immediately.
+        self.apply_stop_config()
+
+        # Broadcast to every rank so non-zero ranks add the same
+        # stop_iter to their own profile_stop_iters. Also wakes the
+        # idle executor loop on rank 0; the broadcast then
+        # propagates the wake to all ranks inside
+        # ``_fetch_and_enqueue_requests``.
+        rank = getattr(getattr(executor, "dist", None), "rank", 0)
+        eq = getattr(executor, "executor_request_queue", None)
+        if rank == 0 and eq is not None:
+            try:
+                eq.enqueue_profile_stop_request()
+            except (RuntimeError, OSError, ValueError, AttributeError) as e:
+                # Subordinate ranks won't see the stop. Bail out
+                # with a real error rather than silently waiting on
+                # a stop that will never fire.
+                raise RuntimeError(
+                    f"stop_profile: failed to enqueue profile-stop broadcast item: {e}"
+                ) from e
+
+        # Wait (with timeout) for the stop to actually fire so that
+        # by the time stop_profile() returns the chrome trace has
+        # been exported to disk. Without this wait, callers that hit
+        # the HTTP /stop_profile endpoint and then immediately try
+        # to read the trace file would see an empty directory.
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            with executor._profile_state_lock:
+                if not executor._profile_enabled:
+                    return
+            time.sleep(0.005)
+        logger.warning(
+            "stop_profile: executor loop did not fire the scheduled stop "
+            "within 30s; the trace may not be fully flushed yet."
+        )
+
+    # ---- broadcast handlers (called on every rank) -----------------
+
+    def apply_start_config(self, config: Dict) -> None:
+        """Apply a broadcasted profile-start config to this rank.
+
+        Called from two places: directly on the caller thread from
+        ``start_profile()`` (so
+        ``_runtime_profile_pending_start_iter`` becomes visible for
+        re-entrancy checks) AND from ``_handle_special_queue_items``
+        when the broadcasted ``PROFILE_START_REQUEST_ID`` item
+        arrives. The operation is idempotent: the second call on
+        rank 0 sees the same state and is a no-op.
+        """
+        executor = self._executor
+        activities = config.get("activities") or ["CPU", "GPU"]
+        # ``/tmp`` matches the documented developer default; see
+        # ``start_profile`` for the rationale.
+        output_dir = config.get("output_dir") or "/tmp"  # nosec B108
+        profile_id = config.get("profile_id") or f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+        # Prefer the legacy absolute ``start_iter`` form (older unit
+        # tests and env-var driven paths set this directly). For the
+        # broadcast path the caller sends ``start_step`` instead so
+        # every rank computes its own ``start_iter`` from its
+        # current ``iter_counter`` — this avoids a race where rank
+        # 0's local apply sets a past start_iter that rank 1 never
+        # reaches in time to fire.
+        if "start_iter" in config:
+            start_iter = int(config["start_iter"])
+        else:
+            start_step = int(config.get("start_step", 0))
+            current_iter = int(getattr(executor, "iter_counter", 0))
+            start_iter = current_iter + 1 + start_step
+        num_steps = config.get("num_steps")
+        stop_iter = config.get("stop_iter")
+        if stop_iter is None and num_steps is not None:
+            stop_iter = start_iter + int(num_steps)
+
+        # Rank-specific trace path so every rank writes its own file
+        # when running with TP/PP > 1.
+        trace_filename = f"trtllm-trace-{profile_id}-rank-{executor.global_rank}.json"
+        trace_path = os.path.join(output_dir, trace_filename)
+
+        # First apply on this rank? If the start_iter is already in
+        # profile_start_iters it means either rank 0's local apply
+        # ran (before the broadcast echo-back) or a prior broadcast
+        # already applied — in both cases the pending marker
+        # belongs to the original apply, and re-setting it here
+        # would overwrite a subsequent clear by ``profile_step()``
+        # and leak stale state.
+        is_first_apply = start_iter not in executor.profile_start_iters
+
+        executor._runtime_profile_trace_path = trace_path
+        executor._runtime_profile_activities = list(activities)
+        executor._runtime_profile_cuda_only = (
+            len(activities) == 1 and activities[0].upper() == "CUDA_PROFILER"
+        )
+
+        executor.profile_start_iters.add(start_iter)
+        if is_first_apply:
+            executor._runtime_profile_pending_start_iter = start_iter
+            if stop_iter is not None:
+                executor.profile_stop_iters.add(int(stop_iter))
+                executor._runtime_profile_pending_stop_iter = int(stop_iter)
+            # ``num_steps is None`` branch: leave pending_stop_iter
+            # alone — caller set it to None in start_profile.
+        elif stop_iter is not None:
+            # Broadcast echoes back to rank 0 after its local apply,
+            # or after the start has already fired. Only ensure the
+            # stop iter is in the set on this rank (idempotent);
+            # don't reset pending markers.
+            executor.profile_stop_iters.add(int(stop_iter))
+
+        logger.info(
+            f"_apply_profile_start_config[rank={executor.global_rank}]: "
+            f"start_iter={start_iter}, stop_iter={stop_iter}, "
+            f"activities={activities}, trace_path={trace_path}, "
+            f"is_first_apply={is_first_apply}"
+        )
+
+    def apply_stop_config(self) -> None:
+        """Apply a broadcasted profile-stop to this rank.
+
+        Handles both the cancel-pending-start case and the
+        schedule-a-stop case so the broadcast from rank 0 replays
+        correctly on every rank.
+        """
+        executor = self._executor
+        with executor._profile_state_lock:
+            currently_enabled = executor._profile_enabled
+
+        if not currently_enabled and executor._runtime_profile_pending_start_iter is not None:
+            pending_start = executor._runtime_profile_pending_start_iter
+            pending_stop = executor._runtime_profile_pending_stop_iter
+            executor.profile_start_iters.discard(pending_start)
+            if pending_stop is not None:
+                executor.profile_stop_iters.discard(pending_stop)
+            executor._runtime_profile_pending_start_iter = None
+            executor._runtime_profile_pending_stop_iter = None
+            logger.info(
+                f"_apply_profile_stop_config[rank={executor.global_rank}]: "
+                f"cancelled pending start at iteration {pending_start} "
+                "before it fired"
+            )
+            return
+
+        # Fire condition inside profile_step(): stop iter matches
+        # ``self.iter_counter`` at the top of the NEXT executor loop
+        # iteration. ``iter_counter`` is incremented at the END of
+        # the current body, so setting ``stop_iter = iter_counter +
+        # 1`` fires the stop on the very next profile_step call
+        # whether this function runs mid-body (pre-increment) or
+        # between iterations (post-increment). One cancel-wake (or
+        # the profile-stop broadcast item acting as a wake) is
+        # enough to flush.
+        current_iter = getattr(executor, "iter_counter", 0)
+        stop_iter = current_iter + 1
+        executor.profile_stop_iters.add(stop_iter)
+        executor._runtime_profile_pending_stop_iter = stop_iter
+        logger.info(
+            f"_apply_profile_stop_config[rank={executor.global_rank}]: "
+            f"scheduled stop at iteration {stop_iter}"
+        )
+
+    # ---- per-iteration driver (executor thread) --------------------
+
+    @contextmanager
+    def profile_step(self):
+        """Context manager driving per-iteration profile bookkeeping.
+
+        Replaces the inline ``_profiler()`` context manager that used
+        to live on ``PyExecutor``. Yields a callable
+        (``profile_step``) the executor loop invokes once per
+        iteration.
+
+        Runs on the executor thread; ``torch.profiler.start`` /
+        ``stop`` MUST happen on the same thread, so all of the
+        per-iteration ``torch.profiler`` activations live here
+        rather than on the HTTP-caller path.
+        """
+        executor = self._executor
+        it = -1
+        enabled = False
+        start_time = None
+
+        # These events are used to record the time of the previous
+        # batch. We need two sets of start-end events so that the
+        # ping-pong pattern works with the overlap scheduler.
+        start_event_1 = None
+        end_event_1 = torch.cuda.Event(enable_timing=True)
+        start_event_2 = None
+        end_event_2 = torch.cuda.Event(enable_timing=True)
+        prev_device_step_time = None
+
+        env_torch_trace_path = os.environ.get(PROFILE_TRACE_ENV_VAR_NAME, None)
+        if env_torch_trace_path is not None:
+            # Append the rank so each rank writes to its own file.
+            # Without this, TP/PP/DP > 1 runs have every rank calling
+            # ``torch_profiler.export_chrome_trace()`` on the same
+            # path concurrently, producing interleaved output that
+            # fails to parse in Chrome tracing / Perfetto.
+            trace_base, trace_ext = os.path.splitext(env_torch_trace_path)
+            env_torch_trace_path = f"{trace_base}-rank-{executor.global_rank}{trace_ext}"
+        profile_start_stop = os.environ.get(PROFILE_START_STOP_ENV_VAR_NAME, None)
+        env_enable_torch_trace = bool(env_torch_trace_path and profile_start_stop)
+        if env_torch_trace_path and profile_start_stop is None:
+            logger.warning(
+                f"{PROFILE_START_STOP_ENV_VAR_NAME} environment variable "
+                "needs to be set to enable the torch trace. Example to "
+                f"profile iteration 10-20: export "
+                f"{PROFILE_START_STOP_ENV_VAR_NAME}=10-20"
+            )
+
+        # ``torch_profiler`` is created lazily on the first start
+        # iteration so it can pick up runtime-configured trace paths
+        # / activity lists set via ``start_profile()``. The following
+        # variables track the active configuration for the current
+        # profiling window.
+        torch_profiler = None
+        active_torch_trace_path: Optional[str] = None
+        active_enable_torch_trace: bool = False
+        # Make sure ``_profile_enabled`` starts cleared for a fresh
+        # executor run (in case the instance is re-entered).
+        with executor._profile_state_lock:
+            executor._profile_enabled = False
+
+        log_ranks_str = os.environ.get(PROFILE_LOG_RANKS_ENV_VAR_NAME, "0")
+        if log_ranks_str.strip().lower() == "all":
+            log_all_ranks = True
+            log_ranks = set()
+        else:
+            log_all_ranks = False
+            log_ranks = {int(r) for r in log_ranks_str.split(",")}
+
+        calibrator = get_calibrator()
+
+        # Local helper so the inner closure does not need to call
+        # ``self._activities_from_names`` which would force a
+        # method-name lookup per iteration.
+        activities_from_names = self._activities_from_names
+
+        def profile_step_fn():
+            nonlocal it, enabled, start_time
+            nonlocal start_event_1, end_event_1, start_event_2, end_event_2
+            nonlocal prev_device_step_time
+            nonlocal torch_profiler, active_torch_trace_path
+            nonlocal active_enable_torch_trace
+            calibrator.post_step(it)
+            if executor.iter_counter in executor.profile_stop_iters and not executor.is_warmup:
+                if not enabled:
+                    # Happens when stop_profile() was called before
+                    # the scheduled start_iter was reached (e.g.
+                    # the user calls /start_profile then
+                    # /stop_profile quickly while the engine is
+                    # still warming up).  Silently drop the stale
+                    # stop marker so we do not crash the event
+                    # loop.
+                    logger.warning(
+                        f"profile stop scheduled at iter "
+                        f"{executor.iter_counter} but no active "
+                        "profiling window - skipping"
+                    )
+                    executor.profile_stop_iters.discard(executor.iter_counter)
+                else:
+                    if active_enable_torch_trace and torch_profiler is not None:
+                        torch_profiler.stop()
+                        torch_profiler.export_chrome_trace(active_torch_trace_path)
+                        logger.info(
+                            f"Profiling stopped at iteration "
+                            f"{executor.iter_counter}, "
+                            f"trace saved to {active_torch_trace_path}"
+                        )
+                    torch.cuda.cudart().cudaProfilerStop()
+                    calibrator.stop()
+                    enabled = False
+                    with executor._profile_state_lock:
+                        executor._profile_enabled = False
+                    # Reset lazy state so a subsequent start/stop
+                    # window can pick up a fresh runtime
+                    # configuration.
+                    torch_profiler = None
+                    active_torch_trace_path = None
+                    # Clear the pending-stop marker so
+                    # ``start_profile()``'s guard no longer sees a
+                    # stale window.
+                    if executor._runtime_profile_pending_stop_iter == executor.iter_counter:
+                        executor._runtime_profile_pending_stop_iter = None
+                active_enable_torch_trace = False
+
+            # Capture per-loop timing whenever stats or the iter log
+            # are enabled. The reading of the OTHER parity's event
+            # pair (the ping-pong) is what keeps synchronize() from
+            # blocking the GPU — the events being read have already
+            # passed by the time we read them. Stashing on
+            # ``self`` lets the /metrics serializer pick up the
+            # values without going through the log line.
+            should_capture_timing = start_time is not None and (
+                executor.print_log or executor.enable_iter_perf_stats
+            )
+            if should_capture_timing:
+                end_time = time.time()
+                if it % 2 == 0:
+                    end_event_1.record()
+                    if start_event_2 is not None:
+                        end_event_2.synchronize()
+                        prev_device_step_time = start_event_2.elapsed_time(end_event_2)
+                else:
+                    end_event_2.record()
+                    if start_event_1 is not None:
+                        end_event_1.synchronize()
+                        prev_device_step_time = start_event_1.elapsed_time(end_event_1)
+
+                host_step_time = (end_time - start_time) * 1000  # ms
+                executor._latest_host_step_time_ms = host_step_time
+                executor._latest_prev_device_step_time_ms = prev_device_step_time
+
+                if executor.print_log and (log_all_ranks or executor.dist.rank in log_ranks):
+                    if prev_device_step_time is None:
+                        prev_device_step_time_str = "N/A"  # first iteration
+                    else:
+                        prev_device_step_time_str = f"{prev_device_step_time}ms"
+                    kv_util_str = "N/A"
+                    if executor.kv_cache_manager is not None:
+                        kv_stats = executor.kv_cache_manager.get_kv_cache_stats()
+                        if kv_stats.max_num_blocks > 0:
+                            kv_util_str = (
+                                f"{1.0 - kv_stats.free_num_blocks / kv_stats.max_num_blocks:.3f}"
+                            )
+                    import datetime
+
+                    formatted_timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                    logger.info(
+                        f"iter = {executor.iter_counter}, "
+                        f"global_rank = {executor.global_rank}, "
+                        f"rank = {executor.dist.rank}, "
+                        f"num_scheduled_requests = {executor.num_scheduled_requests}, "
+                        f"kv_cache_util = {kv_util_str}, "
+                        f"currank_total_requests = {executor.num_fetch_requests_cur_rank}/"
+                        f"{executor.num_fetch_requests}, "
+                        f"host_step_time = {host_step_time}ms, "
+                        f"prev_device_step_time = {prev_device_step_time_str}, "
+                        f"timestamp = {formatted_timestamp}, "
+                        f"states = {executor.model_engine.iter_states}"
+                    )
+
+            it += 1
+
+            if executor.iter_counter in executor.profile_start_iters and not executor.is_warmup:
+                assert not enabled, "Inconsistent CUDA profiling state"
+                # Resolve active trace path + torch.profiler
+                # configuration at start time so runtime overrides
+                # from ``start_profile()`` take precedence over the
+                # environment variables.
+                runtime_trace_path = executor._runtime_profile_trace_path
+                runtime_cuda_only = executor._runtime_profile_cuda_only
+                runtime_activities = executor._runtime_profile_activities
+                if runtime_trace_path is not None:
+                    active_torch_trace_path = runtime_trace_path
+                    # CUDA_PROFILER only: skip torch.profiler so we
+                    # do not pay its overhead and so nsys traces
+                    # stay clean.
+                    active_enable_torch_trace = not runtime_cuda_only
+                    torch_activities = activities_from_names(runtime_activities)
+                    if active_enable_torch_trace and not torch_activities:
+                        # Runtime requested only CUDA_PROFILER even
+                        # though cuda_only was False; treat as
+                        # cuda-only.
+                        active_enable_torch_trace = False
+                else:
+                    active_torch_trace_path = env_torch_trace_path
+                    active_enable_torch_trace = env_enable_torch_trace
+                    torch_activities = [
+                        torch.profiler.ProfilerActivity.CPU,
+                        torch.profiler.ProfilerActivity.CUDA,
+                        torch.profiler.ProfilerActivity.XPU,
+                    ]
+
+                calibrator.start()
+                torch.cuda.cudart().cudaProfilerStart()
+                if active_enable_torch_trace:
+                    if torch_profiler is None:
+                        torch_profiler = torch.profiler.profile(
+                            activities=torch_activities, record_shapes=True, with_modules=True
+                        )
+                    torch_profiler.start()
+                logger.info(f"Profiling started at iteration {executor.iter_counter}.")
+                enabled = True
+                with executor._profile_state_lock:
+                    executor._profile_enabled = True
+                # The scheduled start has arrived; clear the pending
+                # marker so the next ``start_profile()`` after this
+                # window ends is not rejected as "already pending".
+                if executor._runtime_profile_pending_start_iter == executor.iter_counter:
+                    executor._runtime_profile_pending_start_iter = None
+
+            # Notify host line profiler of iteration for
+            # iteration-aware profiling.
+            host_profiler = get_global_profiler()
+            if host_profiler is not None:
+                host_profiler.notify_iteration(executor.iter_counter)
+
+            calibrator.pre_step(it)
+            start_time = time.time()
+            if it % 2 == 0:
+                if start_event_1 is None:
+                    start_event_1 = torch.cuda.Event(enable_timing=True)
+                start_event_1.record()
+            else:
+                if start_event_2 is None:
+                    start_event_2 = torch.cuda.Event(enable_timing=True)
+                start_event_2.record()
+
+        try:
+            yield profile_step_fn
+        finally:
+            if enabled:
+                # Stop on early exit / exception
+                if active_enable_torch_trace and torch_profiler is not None:
+                    torch_profiler.stop()
+                    torch_profiler.export_chrome_trace(active_torch_trace_path)
+                    logger.info(
+                        f"Profiling stopped at iteration "
+                        f"{executor.iter_counter}, "
+                        f"trace saved to {active_torch_trace_path}"
+                    )
+                torch.cuda.cudart().cudaProfilerStop()
+                calibrator.stop()
+                with executor._profile_state_lock:
+                    executor._profile_enabled = False
+
+    # ---- shutdown --------------------------------------------------
+
+    def cleanup(self) -> None:
+        """Best-effort shutdown of any active profile window.
+
+        Called during ``PyExecutor.shutdown()`` when an HTTP caller
+        forgot to issue a matching ``stop_profile()``. Idempotent
+        and never raises -- shutdown must continue even if the
+        underlying ``torch.profiler`` / ``cudaProfilerStop`` fails.
+        """
+        executor = self._executor_ref()
+        if executor is None:
+            return
+        try:
+            with executor._profile_state_lock:
+                still_active = executor._profile_enabled
+                executor._profile_enabled = False
+        except Exception:  # pragma: no cover - defensive
+            still_active = False
+        if not still_active:
+            return
+        try:
+            torch.cuda.cudart().cudaProfilerStop()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug(f"profile cleanup: cudaProfilerStop failed: {e!r}")

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1714,11 +1714,15 @@ class PyExecutor:
                 "/tmp",  # nosec B108
             )
 
+        # Fail fast if the directory cannot be created. Returning success
+        # here would schedule a profile window that later blows up in
+        # ``export_chrome_trace()`` on the executor thread, after the
+        # HTTP caller has already been told the request was accepted.
         try:
             os.makedirs(output_dir, exist_ok=True)
         except OSError as e:
-            logger.warning(
-                f"Failed to create profile output_dir {output_dir}: {e}")
+            raise RuntimeError(
+                f"Failed to create profile output_dir {output_dir}: {e}") from e
 
         # Include a unique profile id (monotonic timestamp + short uuid
         # fragment) so successive start/stop cycles under the same
@@ -1763,10 +1767,18 @@ class PyExecutor:
         if rank == 0 and eq is not None:
             try:
                 eq.enqueue_profile_start_request(profile_config)
-            except Exception as e:  # noqa: BLE001
-                logger.warning(
+            except (RuntimeError, OSError, ValueError, AttributeError) as e:
+                # Roll back the pending markers we just set so a
+                # subsequent ``start_profile()`` is not rejected as
+                # "already pending", and so non-zero ranks (which never
+                # received the broadcast) don't drift out of sync with
+                # rank 0. Then surface the failure to the HTTP layer
+                # rather than silently logging and continuing.
+                self._runtime_profile_pending_start_iter = None
+                self._runtime_profile_activities = None
+                raise RuntimeError(
                     f"start_profile: failed to enqueue profile-start "
-                    f"broadcast item: {e}")
+                    f"broadcast item: {e}") from e
 
     def stop_profile(self) -> None:
         """Schedule the in-progress runtime profiling to stop on the
@@ -1806,10 +1818,15 @@ class PyExecutor:
             if rank == 0 and eq is not None:
                 try:
                     eq.enqueue_profile_stop_request()
-                except Exception as e:  # noqa: BLE001
-                    logger.warning(
+                except (RuntimeError, OSError, ValueError, AttributeError) as e:
+                    # Local cancel already happened on this rank, but
+                    # subordinate ranks would still be carrying the
+                    # pending start. Surface the broadcast failure so
+                    # the caller can retry rather than silently leaving
+                    # the cluster out of sync.
+                    raise RuntimeError(
                         f"stop_profile: failed to enqueue profile-stop "
-                        f"broadcast item: {e}")
+                        f"broadcast item: {e}") from e
             return
 
         # Apply locally so diagnostic state (profile_stop_iters,
@@ -1826,9 +1843,13 @@ class PyExecutor:
         if rank == 0 and eq is not None:
             try:
                 eq.enqueue_profile_stop_request()
-            except Exception as e:  # noqa: BLE001
-                logger.warning(f"stop_profile: failed to enqueue profile-stop "
-                               f"broadcast item: {e}")
+            except (RuntimeError, OSError, ValueError, AttributeError) as e:
+                # Subordinate ranks won't see the stop. Bail out with a
+                # real error rather than silently waiting on a stop that
+                # will never fire.
+                raise RuntimeError(
+                    f"stop_profile: failed to enqueue profile-stop "
+                    f"broadcast item: {e}") from e
 
         # Wait (with timeout) for the stop to actually fire so that by
         # the time stop_profile() returns the chrome trace has been

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1,11 +1,9 @@
 import dataclasses
 import datetime
-import functools
 import os
 import threading
 import time
 import traceback
-import uuid
 from contextlib import contextmanager
 from enum import IntEnum
 from queue import Queue
@@ -40,9 +38,8 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import CpType
 from tensorrt_llm.runtime.generation import CUASSERT
 from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import OutOfPagesError
-from tensorrt_llm.tools.layer_wise_benchmarks import get_calibrator
-from tensorrt_llm.tools.profiler.host_profile_tools.host_profiler import (
-    get_global_profiler, host_profiler_context)
+from tensorrt_llm.tools.profiler.host_profile_tools.host_profiler import \
+    host_profiler_context
 
 from ..distributed import Distributed
 from ..distributed.communicator import ReduceOp
@@ -75,6 +72,8 @@ from .mamba_cache_manager import (BaseMambaCacheManager,
                                   MixedMambaHybridCacheManager)
 from .model_engine import ModelEngine
 from .perf_metrics_manager import PerfMetricsManager
+from .profiling import PROFILE_START_STOP_ENV_VAR_NAME, PyExecutorProfileManager
+from .profiling import load_iteration_indexes as _load_iteration_indexes
 from .request_utils import (RequestBroadcaster, attach_py_objects_to_requests,
                             derive_attention_dp_per_rank_request_cap,
                             get_from_waiting_queue, merge_requests)
@@ -97,18 +96,14 @@ def _stats_buffer_is_unbounded(max_stats_len: int) -> bool:
     return max_stats_len == _UNBOUNDED_STATS_MAX_LEN
 
 
-# Environment variable to specify iteration ranges for profiling start/stop.
-# Format: "start1-stop1,start2-stop2,..." or single iterations "iter1,iter2,..."
-PROFILE_START_STOP_ENV_VAR_NAME = "TLLM_PROFILE_START_STOP"
-
-# Environment variable to enable PyTorch profiler tracing.
-# Set to a path to save detailed tracing of PyTorch operations.
-PROFILE_TRACE_ENV_VAR_NAME = "TLLM_TORCH_PROFILE_TRACE"
-
-# Environment variable to control which ranks print step logging.
-# Format: comma-separated rank IDs, e.g. "0,1,3", or "all" for all ranks.
-# Default: "0" (only rank 0 prints, matching existing behavior).
-PROFILE_LOG_RANKS_ENV_VAR_NAME = "TLLM_PROFILE_LOG_RANKS"
+# Profiling env-var names and the iteration-index parser live in
+# ``.profiling`` and are re-exported here for backward compatibility
+# with code/tests that import them from ``py_executor``.
+__all_profile_compat__ = (
+    "PROFILE_START_STOP_ENV_VAR_NAME",
+    "PROFILE_TRACE_ENV_VAR_NAME",
+    "PROFILE_LOG_RANKS_ENV_VAR_NAME",
+)
 
 
 class PPCommTag(IntEnum):
@@ -119,32 +114,6 @@ class PPCommTag(IntEnum):
     SCHEDULE_RESULT = 20001
     EXECUTED_BATCH_NUM = 20002
     SAMPLE_STATE = 20003
-
-
-@functools.cache
-def _load_iteration_indexes(env_var: str):
-    spans = os.environ.get(env_var, None)
-    starts, stops = [], []
-
-    if spans:
-        spans = spans.split(',')
-
-        for span in spans:
-            try:
-                if '-' in span:
-                    start, stop = span.strip().split('-')
-                    starts.append(int(start))
-                    stops.append(int(stop))
-                else:
-                    it = int(span.strip())
-                    starts.append(it)
-                    stops.append(it)
-            except ValueError as e:
-                raise ValueError(
-                    f"Cannot parse span in environment variable `{env_var}`: {e}"
-                ) from None
-
-    return frozenset(starts), frozenset(stops)
 
 
 def _strip_py_multimodal_data_post_prefill(request: LlmRequest) -> None:
@@ -504,6 +473,13 @@ class PyExecutor:
         # even when the engine is otherwise idle.
         self._profile_state_lock = threading.Lock()
         self._profile_enabled: bool = False
+
+        # The profile-state machine (start/stop scheduling, broadcast
+        # apply, per-iteration torch.profiler driver) lives in the
+        # ``PyExecutorProfileManager``. ``PyExecutor`` keeps the state
+        # fields above on ``self`` for backward-compat introspection;
+        # the manager operates on those fields via a weakref.
+        self._profile_manager = PyExecutorProfileManager(self)
 
         # related modules
         self.resource_manager = resource_manager
@@ -1394,265 +1370,15 @@ class PyExecutor:
 
     @contextmanager
     def _profiler(self):
-        it = -1
-        enabled = False
-        start_time = None
+        """Per-iteration profile bookkeeping driver.
 
-        # These events are used to record the time of the previous batch.
-        # We need two set of the start-end events to record the time through
-        # a ping-pong way so that it works with overlap scheduler.
-        start_event_1 = None
-        end_event_1 = torch.cuda.Event(enable_timing=True)
-        start_event_2 = None
-        end_event_2 = torch.cuda.Event(enable_timing=True)
-        prev_device_step_time = None
-
-        env_torch_trace_path = os.environ.get(PROFILE_TRACE_ENV_VAR_NAME, None)
-        if env_torch_trace_path is not None:
-            # Append the rank so each rank writes to its own file. Without
-            # this, TP/PP/DP > 1 runs have every rank calling
-            # torch_profiler.export_chrome_trace() on the same path
-            # concurrently, producing interleaved output that fails to
-            # parse in Chrome tracing / Perfetto.
-            trace_base, trace_ext = os.path.splitext(env_torch_trace_path)
-            env_torch_trace_path = (
-                f"{trace_base}-rank-{self.global_rank}{trace_ext}")
-        profile_start_stop = os.environ.get(PROFILE_START_STOP_ENV_VAR_NAME,
-                                            None)
-        env_enable_torch_trace = bool(env_torch_trace_path
-                                      and profile_start_stop)
-        if env_torch_trace_path and profile_start_stop is None:
-            logger.warning(
-                f"{PROFILE_START_STOP_ENV_VAR_NAME} environment variable "
-                "needs to be set to enable the torch trace. Example to profile "
-                f"iteration 10-20: export {PROFILE_START_STOP_ENV_VAR_NAME}=10-20"
-            )
-
-        # torch_profiler is created lazily on the first start iteration so it
-        # can pick up runtime-configured trace paths / activity lists set via
-        # start_profile(). The following variables track the active
-        # configuration for the current profiling window.
-        torch_profiler = None
-        active_torch_trace_path: Optional[str] = None
-        active_enable_torch_trace: bool = False
-        # Make sure _profile_enabled starts cleared for a fresh executor
-        # run (in case the instance is re-entered).
-        with self._profile_state_lock:
-            self._profile_enabled = False
-
-        def _activities_from_names(
-            names: Optional[List[str]]
-        ) -> List["torch.profiler.ProfilerActivity"]:
-            if not names:
-                return [
-                    torch.profiler.ProfilerActivity.CPU,
-                    torch.profiler.ProfilerActivity.CUDA,
-                    torch.profiler.ProfilerActivity.XPU,
-                ]
-            mapping = {
-                "CPU": torch.profiler.ProfilerActivity.CPU,
-                "GPU": torch.profiler.ProfilerActivity.CUDA,
-                "CUDA": torch.profiler.ProfilerActivity.CUDA,
-                "XPU": torch.profiler.ProfilerActivity.XPU,
-            }
-            resolved = []
-            for name in names:
-                key = name.upper()
-                if key == "CUDA_PROFILER":
-                    # CUDA_PROFILER controls cudaProfilerStart/Stop only; it
-                    # is not a torch.profiler activity.
-                    continue
-                if key in mapping and mapping[key] not in resolved:
-                    resolved.append(mapping[key])
-            return resolved
-
-        log_ranks_str = os.environ.get(PROFILE_LOG_RANKS_ENV_VAR_NAME, "0")
-        if log_ranks_str.strip().lower() == "all":
-            log_all_ranks = True
-            log_ranks = set()
-        else:
-            log_all_ranks = False
-            log_ranks = {int(r) for r in log_ranks_str.split(",")}
-
-        calibrator = get_calibrator()
-
-        def profile_step():
-            nonlocal it, enabled, start_time, start_event_1, end_event_1, start_event_2, end_event_2, prev_device_step_time
-            nonlocal torch_profiler, active_torch_trace_path, active_enable_torch_trace
-            calibrator.post_step(it)
-            if (self.iter_counter in self.profile_stop_iters
-                    and not self.is_warmup):
-                if not enabled:
-                    # Happens when stop_profile() was called before the
-                    # scheduled start_iter was reached (e.g. the user calls
-                    # /start_profile then /stop_profile quickly while the
-                    # engine is still warming up).  Silently drop the stale
-                    # stop marker so we do not crash the event loop.
-                    logger.warning(
-                        f"profile stop scheduled at iter "
-                        f"{self.iter_counter} but no active profiling "
-                        "window - skipping")
-                    self.profile_stop_iters.discard(self.iter_counter)
-                else:
-                    if active_enable_torch_trace and torch_profiler is not None:
-                        torch_profiler.stop()
-                        torch_profiler.export_chrome_trace(
-                            active_torch_trace_path)
-                        logger.info(f"Profiling stopped at iteration "
-                                    f"{self.iter_counter}, "
-                                    f"trace saved to {active_torch_trace_path}")
-                    torch.cuda.cudart().cudaProfilerStop()
-                    calibrator.stop()
-                    enabled = False
-                    with self._profile_state_lock:
-                        self._profile_enabled = False
-                    # Reset lazy state so a subsequent start/stop window can
-                    # pick up a fresh runtime configuration.
-                    torch_profiler = None
-                    active_torch_trace_path = None
-                    # Clear the pending-stop marker so start_profile()'s
-                    # guard no longer sees a stale window.
-                    if (self._runtime_profile_pending_stop_iter ==
-                            self.iter_counter):
-                        self._runtime_profile_pending_stop_iter = None
-                active_enable_torch_trace = False
-
-            # Capture per-loop timing whenever stats or the iter log are
-            # enabled. The reading of the OTHER parity's event pair (the
-            # ping-pong) is what keeps synchronize() from blocking the GPU
-            # — the events being read have already passed by the time we
-            # read them. Stashing on self lets the /metrics serializer pick
-            # up the values without going through the log line.
-            should_capture_timing = start_time is not None and (
-                self.print_log or self.enable_iter_perf_stats)
-            if should_capture_timing:
-                end_time = time.time()
-                if it % 2 == 0:
-                    end_event_1.record()
-                    if start_event_2 is not None:
-                        end_event_2.synchronize()
-                        prev_device_step_time = start_event_2.elapsed_time(
-                            end_event_2)
-                else:
-                    end_event_2.record()
-                    if start_event_1 is not None:
-                        end_event_1.synchronize()
-                        prev_device_step_time = start_event_1.elapsed_time(
-                            end_event_1)
-
-                host_step_time = (end_time - start_time) * 1000  # milliseconds
-                self._latest_host_step_time_ms = host_step_time
-                self._latest_prev_device_step_time_ms = prev_device_step_time
-
-                if self.print_log and (log_all_ranks
-                                       or self.dist.rank in log_ranks):
-                    if prev_device_step_time is None:
-                        prev_device_step_time_str = "N/A"  # Handle first iteration
-                    else:
-                        prev_device_step_time_str = f"{prev_device_step_time}ms"
-                    kv_util_str = "N/A"
-                    if self.kv_cache_manager is not None:
-                        kv_stats = self.kv_cache_manager.get_kv_cache_stats()
-                        if kv_stats.max_num_blocks > 0:
-                            kv_util_str = f"{1.0 - kv_stats.free_num_blocks / kv_stats.max_num_blocks:.3f}"
-                    formatted_timestamp = datetime.datetime.now().strftime(
-                        "%Y-%m-%d %H:%M:%S")
-                    logger.info(
-                        f"iter = {self.iter_counter}, "
-                        f"global_rank = {self.global_rank}, "
-                        f"rank = {self.dist.rank}, "
-                        f"num_scheduled_requests = {self.num_scheduled_requests}, "
-                        f"kv_cache_util = {kv_util_str}, "
-                        f"currank_total_requests = {self.num_fetch_requests_cur_rank}/"
-                        f"{self.num_fetch_requests}, "
-                        f"host_step_time = {host_step_time}ms, "
-                        f"prev_device_step_time = {prev_device_step_time_str}, "
-                        f"timestamp = {formatted_timestamp}, "
-                        f"states = {self.model_engine.iter_states}")
-
-            it += 1
-
-            if (self.iter_counter in self.profile_start_iters
-                    and not self.is_warmup):
-                assert not enabled, "Inconsistent CUDA profiling state"
-                # Resolve active trace path + torch.profiler configuration
-                # at start time so runtime overrides from start_profile()
-                # take precedence over the environment variables.
-                runtime_trace_path = self._runtime_profile_trace_path
-                runtime_cuda_only = self._runtime_profile_cuda_only
-                runtime_activities = self._runtime_profile_activities
-                if runtime_trace_path is not None:
-                    active_torch_trace_path = runtime_trace_path
-                    # CUDA_PROFILER only: skip torch.profiler so we do not
-                    # pay its overhead and so nsys traces stay clean.
-                    active_enable_torch_trace = not runtime_cuda_only
-                    torch_activities = _activities_from_names(
-                        runtime_activities)
-                    if active_enable_torch_trace and not torch_activities:
-                        # Runtime requested only CUDA_PROFILER even though
-                        # cuda_only was False; treat as cuda-only.
-                        active_enable_torch_trace = False
-                else:
-                    active_torch_trace_path = env_torch_trace_path
-                    active_enable_torch_trace = env_enable_torch_trace
-                    torch_activities = [
-                        torch.profiler.ProfilerActivity.CPU,
-                        torch.profiler.ProfilerActivity.CUDA,
-                        torch.profiler.ProfilerActivity.XPU,
-                    ]
-
-                calibrator.start()
-                torch.cuda.cudart().cudaProfilerStart()
-                if active_enable_torch_trace:
-                    if torch_profiler is None:
-                        torch_profiler = torch.profiler.profile(
-                            activities=torch_activities,
-                            record_shapes=True,
-                            with_modules=True)
-                    torch_profiler.start()
-                logger.info(
-                    f"Profiling started at iteration {self.iter_counter}.")
-                enabled = True
-                with self._profile_state_lock:
-                    self._profile_enabled = True
-                # The scheduled start has arrived; clear the pending marker
-                # so the next start_profile() after this window ends is not
-                # rejected as "already pending".
-                if (self._runtime_profile_pending_start_iter ==
-                        self.iter_counter):
-                    self._runtime_profile_pending_start_iter = None
-
-            # Notify host line profiler of iteration for iteration-aware profiling
-            host_profiler = get_global_profiler()
-            if host_profiler is not None:
-                host_profiler.notify_iteration(self.iter_counter)
-
-            calibrator.pre_step(it)
-            start_time = time.time()
-            if it % 2 == 0:
-                if start_event_1 is None:
-                    start_event_1 = torch.cuda.Event(enable_timing=True)
-                start_event_1.record()
-            else:
-                if start_event_2 is None:
-                    start_event_2 = torch.cuda.Event(enable_timing=True)
-                start_event_2.record()
-
-        try:
-            yield profile_step
-        finally:
-            if enabled:
-                # Stop on early exit / exception
-                if active_enable_torch_trace and torch_profiler is not None:
-                    torch_profiler.stop()
-                    torch_profiler.export_chrome_trace(active_torch_trace_path)
-                    logger.info(f"Profiling stopped at iteration "
-                                f"{self.iter_counter}, "
-                                f"trace saved to {active_torch_trace_path}")
-                torch.cuda.cudart().cudaProfilerStop()
-                calibrator.stop()
-                with self._profile_state_lock:
-                    self._profile_enabled = False
+        Forwards to ``PyExecutorProfileManager.profile_step``; see
+        ``profiling.py`` for the full state machine. Kept as a method
+        on ``PyExecutor`` so the executor loop's ``with self._profiler()``
+        call site is unchanged.
+        """
+        with self._profile_manager.profile_step() as step:
+            yield step
 
     def start_profile(self,
                       output_dir: Optional[str] = None,
@@ -1661,9 +1387,10 @@ class PyExecutor:
                       activities: Optional[List[str]] = None) -> None:
         """Start iteration-scoped profiling.
 
-        This mirrors the functionality of the ``TLLM_PROFILE_START_STOP`` /
-        ``TLLM_TORCH_PROFILE_TRACE`` environment variables but can be
-        triggered at runtime (for example via trtllm-serve HTTP endpoints).
+        Mirrors the functionality of the ``TLLM_PROFILE_START_STOP`` /
+        ``TLLM_TORCH_PROFILE_TRACE`` environment variables but is
+        triggerable at runtime (e.g. via ``trtllm-serve``'s
+        ``/start_profile`` HTTP endpoint).
 
         Args:
             output_dir: Directory where chrome traces are written. If
@@ -1673,327 +1400,41 @@ class PyExecutor:
                 profiling runs until ``stop_profile`` is called.
             start_step: Additional iterations to skip before profiling
                 starts (relative to the current iteration counter).
-            activities: Subset of ``["CPU", "GPU", "CUDA_PROFILER"]``. When
-                ``CUDA_PROFILER`` is the only entry, torch.profiler is not
-                started so only ``cudaProfilerStart/Stop`` brackets run,
-                suitable for nsys capture.
+            activities: Subset of ``["CPU", "GPU", "CUDA_PROFILER"]``.
+
+        See ``PyExecutorProfileManager.start_profile`` for the full
+        state-machine contract.
         """
-        # Reject overlapping profile windows. Check locally on the
-        # caller thread so the HTTP handler gets a clean error instead
-        # of the executor thread crashing on ``assert not enabled``
-        # inside profile_step().
-        with self._profile_state_lock:
-            already_active = self._profile_enabled
-        if (already_active
-                or self._runtime_profile_pending_start_iter is not None):
-            # Use RequestError (a RuntimeError subclass) so the
-            # ``GenerationExecutor`` error monitor treats this as a
-            # per-call rejection rather than a fatal engine error.
-            from tensorrt_llm.executor.utils import RequestError
-            raise RequestError(
-                "Profiling is already in progress (or a pending start has "
-                "been scheduled); call stop_profile first before starting "
-                "a new window. (state: _profile_enabled="
-                f"{already_active}, _runtime_profile_pending_start_iter="
-                f"{self._runtime_profile_pending_start_iter}, "
-                f"profile_start_iters="
-                f"{sorted(self.profile_start_iters)[:5]}, "
-                f"profile_stop_iters="
-                f"{sorted(self.profile_stop_iters)[:5]})")
-
-        # Reject ``num_steps <= 0``. The HTTP layer already rejects this
-        # via the ``StartProfileRequest`` Pydantic schema, but
-        # programmatic callers (``LLM.start_profile``, env-var-driven
-        # paths, unit tests) bypass that schema. With ``num_steps == 0``,
-        # ``stop_iter`` would equal ``start_iter`` in
-        # ``_apply_profile_start_config`` below, ``profile_step()`` would
-        # discard the stop marker as stale, and the profile window would
-        # run forever until an explicit ``stop_profile()``.
-        if num_steps is not None and num_steps <= 0:
-            raise ValueError(
-                f"start_profile: num_steps must be >= 1 if provided "
-                f"(got num_steps={num_steps!r}). Pass num_steps=None to "
-                "run until an explicit stop_profile() call.")
-
-        if activities is None:
-            activities = ["CPU", "GPU"]
-
-        if output_dir is None:
-            # ``/tmp`` is the documented developer default for the profile
-            # trace directory (matches the server docs); the
-            # user-facing override is the ``TLLM_TORCH_PROFILER_DIR`` env
-            # var or the ``output_dir`` request body field.
-            output_dir = os.environ.get(
-                "TLLM_TORCH_PROFILER_DIR",
-                "/tmp",  # nosec B108
-            )
-
-        # Fail fast if the directory cannot be created. Returning success
-        # here would schedule a profile window that later blows up in
-        # ``export_chrome_trace()`` on the executor thread, after the
-        # HTTP caller has already been told the request was accepted.
-        try:
-            os.makedirs(output_dir, exist_ok=True)
-        except OSError as e:
-            raise RuntimeError(
-                f"Failed to create profile output_dir {output_dir}: {e}") from e
-
-        # Include a unique profile id (monotonic timestamp + short uuid
-        # fragment) so successive start/stop cycles under the same
-        # output_dir don't silently overwrite each other's traces.
-        profile_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
-
-        # Build the per-request config that every rank consumes. We do
-        # NOT pre-compute start_iter here: each rank must derive it from
-        # its own ``iter_counter`` at the moment the broadcast is
-        # processed (inside ``_handle_special_queue_items``), so that
-        # rank 0 doesn't get a head start by pre-applying with its
-        # caller-thread ``iter_counter`` while rank 1's executor loop
-        # has already advanced past the start point. All ranks are in
-        # sync on iter_counter at the broadcast point, so they all
-        # compute the same start_iter/stop_iter.
-        profile_config = {
-            "output_dir": output_dir,
-            "profile_id": profile_id,
-            "activities": list(activities),
-            "start_step": int(max(0, start_step)),
-            "num_steps": num_steps,
-        }
-
-        # Mark pending on the caller thread too so a second concurrent
-        # start_profile() is rejected by the guard above. The actual
-        # profile_start_iters / trace_path state is only populated
-        # when the broadcast reaches ``_handle_special_queue_items``.
-        # Use a sentinel (0) to mean "pending but not yet scheduled".
-        self._runtime_profile_pending_start_iter = 0
-        self._runtime_profile_activities = list(activities)
-
-        # Broadcast to every rank via the request queue so non-zero
-        # ranks update their own ``profile_start_iters`` in lockstep.
-        # This is also what wakes the idle executor loop (the
-        # PROFILE_START_REQUEST_ID item gets broadcasted via
-        # ``RequestBroadcaster`` inside ``_fetch_and_enqueue_requests``,
-        # then dropped inside ``_handle_special_queue_items`` — no
-        # forward pass runs for this iteration, so the chrome trace
-        # captures only real user workload).
-        rank = getattr(getattr(self, 'dist', None), 'rank', 0)
-        eq = getattr(self, 'executor_request_queue', None)
-        if rank == 0 and eq is not None:
-            try:
-                eq.enqueue_profile_start_request(profile_config)
-            except (RuntimeError, OSError, ValueError, AttributeError) as e:
-                # Roll back the pending markers we just set so a
-                # subsequent ``start_profile()`` is not rejected as
-                # "already pending", and so non-zero ranks (which never
-                # received the broadcast) don't drift out of sync with
-                # rank 0. Then surface the failure to the HTTP layer
-                # rather than silently logging and continuing.
-                self._runtime_profile_pending_start_iter = None
-                self._runtime_profile_activities = None
-                raise RuntimeError(
-                    f"start_profile: failed to enqueue profile-start "
-                    f"broadcast item: {e}") from e
+        return self._profile_manager.start_profile(
+            output_dir=output_dir,
+            num_steps=num_steps,
+            start_step=start_step,
+            activities=activities,
+        )
 
     def stop_profile(self) -> None:
         """Schedule the in-progress runtime profiling to stop on the
         next executor iteration.
 
-        The actual ``torch.profiler.stop()`` + ``export_chrome_trace()``
-        call happens inside ``profile_step()`` on the executor thread, so
-        that torch.profiler / Kineto's "stop must run on the same thread
-        that called start" invariant is respected.
-
-        Two extra cases are handled so no profile window is leaked:
-
-        * If ``start_profile()`` was called but the engine has not yet
-          reached the scheduled ``start_iter`` (e.g. the caller stopped
-          before sending any requests), cancel the pending start so
-          profiling does not begin later.
-        * Otherwise schedule a stop iteration. When called via an HTTP
-          handler the server layer is responsible for tickling the
-          executor loop so the stop iteration actually runs even when
-          the engine would otherwise be idle (see
-          ``OpenAIServer.stop_profile``).
+        See ``PyExecutorProfileManager.stop_profile`` for details.
         """
-        with self._profile_state_lock:
-            currently_enabled = self._profile_enabled
-
-        if (not currently_enabled
-                and self._runtime_profile_pending_start_iter is not None):
-            # Pending runtime start has not fired yet; cancel it cleanly
-            # on this rank.  Also broadcast the stop so non-zero ranks
-            # clear their own pending starts — otherwise a
-            # ``start_profile``-then-``stop_profile`` cycle on an idle
-            # multi-rank deployment would leave stale pending starts on
-            # the subordinates.
-            self._apply_profile_stop_config()
-            rank = getattr(getattr(self, 'dist', None), 'rank', 0)
-            eq = getattr(self, 'executor_request_queue', None)
-            if rank == 0 and eq is not None:
-                try:
-                    eq.enqueue_profile_stop_request()
-                except (RuntimeError, OSError, ValueError, AttributeError) as e:
-                    # Local cancel already happened on this rank, but
-                    # subordinate ranks would still be carrying the
-                    # pending start. Surface the broadcast failure so
-                    # the caller can retry rather than silently leaving
-                    # the cluster out of sync.
-                    raise RuntimeError(
-                        f"stop_profile: failed to enqueue profile-stop "
-                        f"broadcast item: {e}") from e
-            return
-
-        # Apply locally so diagnostic state (profile_stop_iters,
-        # pending_stop_iter) is visible on the caller thread immediately.
-        self._apply_profile_stop_config()
-
-        # Broadcast to every rank so non-zero ranks add the same
-        # stop_iter to their own profile_stop_iters. Also wakes the
-        # idle executor loop on rank 0; the broadcast then propagates
-        # the wake to all ranks inside
-        # ``_fetch_and_enqueue_requests``.
-        rank = getattr(getattr(self, 'dist', None), 'rank', 0)
-        eq = getattr(self, 'executor_request_queue', None)
-        if rank == 0 and eq is not None:
-            try:
-                eq.enqueue_profile_stop_request()
-            except (RuntimeError, OSError, ValueError, AttributeError) as e:
-                # Subordinate ranks won't see the stop. Bail out with a
-                # real error rather than silently waiting on a stop that
-                # will never fire.
-                raise RuntimeError(
-                    f"stop_profile: failed to enqueue profile-stop "
-                    f"broadcast item: {e}") from e
-
-        # Wait (with timeout) for the stop to actually fire so that by
-        # the time stop_profile() returns the chrome trace has been
-        # exported to disk. Without this wait, callers that hit the
-        # HTTP /stop_profile endpoint and then immediately try to read
-        # the trace file would see an empty directory.
-        deadline = time.monotonic() + 30.0
-        while time.monotonic() < deadline:
-            with self._profile_state_lock:
-                if not self._profile_enabled:
-                    return
-            time.sleep(0.005)
-        logger.warning(
-            "stop_profile: executor loop did not fire the scheduled stop "
-            "within 30s; the trace may not be fully flushed yet.")
+        return self._profile_manager.stop_profile()
 
     def _apply_profile_start_config(self, config: Dict) -> None:
-        """Apply a broadcasted profile-start config to this rank.
+        """Apply a broadcasted profile-start config on this rank.
 
-        Called from two places: directly on the caller thread from
-        ``start_profile()`` (so ``_runtime_profile_pending_start_iter``
-        becomes visible for re-entrancy checks) AND from
-        ``_handle_special_queue_items`` when the broadcasted
-        ``PROFILE_START_REQUEST_ID`` item arrives. The operation is
-        idempotent: the second call on rank 0 sees the same state and
-        is a no-op.
+        Forwards to ``PyExecutorProfileManager.apply_start_config``.
+        Kept on ``PyExecutor`` so ``_handle_special_queue_items`` and
+        unit tests that patch this name continue to work unchanged.
         """
-        activities = config.get("activities") or ["CPU", "GPU"]
-        # ``/tmp`` matches the documented developer default; see
-        # ``start_profile`` for the rationale.
-        output_dir = config.get("output_dir") or "/tmp"  # nosec B108
-        profile_id = (config.get("profile_id")
-                      or f"{int(time.time())}-{uuid.uuid4().hex[:8]}")
-        # Prefer the legacy absolute ``start_iter`` form (older unit
-        # tests and env-var driven paths set this directly). For the
-        # broadcast path the caller sends ``start_step`` instead so
-        # every rank computes its own ``start_iter`` from its current
-        # ``iter_counter`` — this avoids a race where rank 0's local
-        # apply sets a past start_iter that rank 1 never reaches in
-        # time to fire.
-        if "start_iter" in config:
-            start_iter = int(config["start_iter"])
-        else:
-            start_step = int(config.get("start_step", 0))
-            current_iter = int(getattr(self, "iter_counter", 0))
-            start_iter = current_iter + 1 + start_step
-        num_steps = config.get("num_steps")
-        stop_iter = config.get("stop_iter")
-        if stop_iter is None and num_steps is not None:
-            stop_iter = start_iter + int(num_steps)
-
-        # Rank-specific trace path so every rank writes its own file
-        # when running with TP/PP > 1.
-        trace_filename = (
-            f"trtllm-trace-{profile_id}-rank-{self.global_rank}.json")
-        trace_path = os.path.join(output_dir, trace_filename)
-
-        # First apply on this rank? If the start_iter is already in
-        # profile_start_iters it means either rank 0's local apply ran
-        # (before the broadcast echo-back) or a prior broadcast already
-        # applied — in both cases the pending marker belongs to the
-        # original apply, and re-setting it here would overwrite a
-        # subsequent clear by profile_step() and leak stale state.
-        is_first_apply = start_iter not in self.profile_start_iters
-
-        self._runtime_profile_trace_path = trace_path
-        self._runtime_profile_activities = list(activities)
-        self._runtime_profile_cuda_only = (len(activities) == 1
-                                           and activities[0].upper()
-                                           == "CUDA_PROFILER")
-
-        self.profile_start_iters.add(start_iter)
-        if is_first_apply:
-            self._runtime_profile_pending_start_iter = start_iter
-            if stop_iter is not None:
-                self.profile_stop_iters.add(int(stop_iter))
-                self._runtime_profile_pending_stop_iter = int(stop_iter)
-            # ``num_steps is None`` branch: leave pending_stop_iter
-            # alone — caller set it to None in start_profile.
-        elif stop_iter is not None:
-            # Broadcast echoes back to rank 0 after its local apply, or
-            # after the start has already fired. Only ensure the stop
-            # iter is in the set on this rank (idempotent); don't
-            # reset pending markers.
-            self.profile_stop_iters.add(int(stop_iter))
-
-        logger.info(f"_apply_profile_start_config[rank={self.global_rank}]: "
-                    f"start_iter={start_iter}, stop_iter={stop_iter}, "
-                    f"activities={activities}, trace_path={trace_path}, "
-                    f"is_first_apply={is_first_apply}")
+        return self._profile_manager.apply_start_config(config)
 
     def _apply_profile_stop_config(self) -> None:
-        """Apply a broadcasted profile-stop to this rank.
+        """Apply a broadcasted profile-stop on this rank.
 
-        Handles both the cancel-pending-start case and the schedule-
-        a-stop case so the broadcast from rank 0 replays correctly on
-        every rank.
+        Forwards to ``PyExecutorProfileManager.apply_stop_config``.
         """
-        with self._profile_state_lock:
-            currently_enabled = self._profile_enabled
-
-        if (not currently_enabled
-                and self._runtime_profile_pending_start_iter is not None):
-            pending_start = self._runtime_profile_pending_start_iter
-            pending_stop = self._runtime_profile_pending_stop_iter
-            self.profile_start_iters.discard(pending_start)
-            if pending_stop is not None:
-                self.profile_stop_iters.discard(pending_stop)
-            self._runtime_profile_pending_start_iter = None
-            self._runtime_profile_pending_stop_iter = None
-            logger.info(f"_apply_profile_stop_config[rank={self.global_rank}]: "
-                        f"cancelled pending start at iteration {pending_start} "
-                        "before it fired")
-            return
-
-        # Fire condition inside profile_step(): stop iter matches
-        # ``self.iter_counter`` at the top of the NEXT executor loop
-        # iteration. ``iter_counter`` is incremented at the END of the
-        # current body, so setting ``stop_iter = iter_counter + 1``
-        # fires the stop on the very next profile_step call whether
-        # this function runs mid-body (pre-increment) or between
-        # iterations (post-increment). One cancel-wake (or the
-        # profile-stop broadcast item acting as a wake) is enough to
-        # flush.
-        current_iter = getattr(self, 'iter_counter', 0)
-        stop_iter = current_iter + 1
-        self.profile_stop_iters.add(stop_iter)
-        self._runtime_profile_pending_stop_iter = stop_iter
-        logger.info(f"_apply_profile_stop_config[rank={self.global_rank}]: "
-                    f"scheduled stop at iteration {stop_iter}")
+        return self._profile_manager.apply_stop_config()
 
     # _wake_executor_loop_for_profile was previously used to enqueue a
     # sentinel cancel-request to unblock the idle executor loop.  It is

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -5,6 +5,7 @@ import os
 import threading
 import time
 import traceback
+import uuid
 from contextlib import contextmanager
 from enum import IntEnum
 from queue import Queue
@@ -472,8 +473,37 @@ class PyExecutor:
 
         self.iter_counter = 0
         # profile config
-        self.profile_start_iters, self.profile_stop_iters = _load_iteration_indexes(
+        _env_start_iters, _env_stop_iters = _load_iteration_indexes(
             PROFILE_START_STOP_ENV_VAR_NAME)
+        # Convert to mutable sets so start_profile()/stop_profile() can
+        # .add() runtime-configured iteration indices.
+        # _load_iteration_indexes returns frozensets.
+        self.profile_start_iters = set(_env_start_iters)
+        self.profile_stop_iters = set(_env_stop_iters)
+
+        # Runtime-configurable profiling state. Populated by start_profile()
+        # when triggered via HTTP endpoints (e.g. trtllm-serve /start_profile)
+        # or API calls. When these are None/False the _profiler() context
+        # falls back to the environment-variable driven configuration.
+        self._runtime_profile_trace_path: Optional[str] = None
+        self._runtime_profile_activities: Optional[List[str]] = None
+        self._runtime_profile_cuda_only: bool = False
+        # Iteration markers added by the most recent runtime start_profile().
+        # Tracked so stop_profile() can cancel a start that has not fired
+        # yet (e.g. the caller stops before sending any requests) without
+        # leaking a pending profile window that would start later.
+        self._runtime_profile_pending_start_iter: Optional[int] = None
+        self._runtime_profile_pending_stop_iter: Optional[int] = None
+
+        # Mirrors the in-loop profile window state (maintained by
+        # ``_profiler()``) so external callers can query whether a profile
+        # is currently active. torch.profiler is not thread-safe so we do
+        # NOT call .stop() from other threads; ``stop_profile()`` schedules
+        # the iteration-scoped stop and (when triggered via an HTTP
+        # handler) the server tickles the executor loop so the stop fires
+        # even when the engine is otherwise idle.
+        self._profile_state_lock = threading.Lock()
+        self._profile_enabled: bool = False
 
         # related modules
         self.resource_manager = resource_manager
@@ -1377,34 +1407,64 @@ class PyExecutor:
         end_event_2 = torch.cuda.Event(enable_timing=True)
         prev_device_step_time = None
 
-        torch_trace_path = os.environ.get(PROFILE_TRACE_ENV_VAR_NAME, None)
-        if torch_trace_path is not None:
+        env_torch_trace_path = os.environ.get(PROFILE_TRACE_ENV_VAR_NAME, None)
+        if env_torch_trace_path is not None:
             # Append the rank so each rank writes to its own file. Without
             # this, TP/PP/DP > 1 runs have every rank calling
             # torch_profiler.export_chrome_trace() on the same path
             # concurrently, producing interleaved output that fails to
             # parse in Chrome tracing / Perfetto.
-            trace_base, trace_ext = os.path.splitext(torch_trace_path)
-            torch_trace_path = f"{trace_base}-rank-{self.global_rank}{trace_ext}"
+            trace_base, trace_ext = os.path.splitext(env_torch_trace_path)
+            env_torch_trace_path = (
+                f"{trace_base}-rank-{self.global_rank}{trace_ext}")
         profile_start_stop = os.environ.get(PROFILE_START_STOP_ENV_VAR_NAME,
                                             None)
-        enable_torch_trace = bool(torch_trace_path and profile_start_stop)
-        if torch_trace_path and profile_start_stop is None:
+        env_enable_torch_trace = bool(env_torch_trace_path
+                                      and profile_start_stop)
+        if env_torch_trace_path and profile_start_stop is None:
             logger.warning(
                 f"{PROFILE_START_STOP_ENV_VAR_NAME} environment variable "
                 "needs to be set to enable the torch trace. Example to profile "
                 f"iteration 10-20: export {PROFILE_START_STOP_ENV_VAR_NAME}=10-20"
             )
 
-        if enable_torch_trace:
-            activities = [
-                torch.profiler.ProfilerActivity.CPU,
-                torch.profiler.ProfilerActivity.CUDA,
-                torch.profiler.ProfilerActivity.XPU,
-            ]
-            torch_profiler = torch.profiler.profile(activities=activities,
-                                                    record_shapes=True,
-                                                    with_modules=True)
+        # torch_profiler is created lazily on the first start iteration so it
+        # can pick up runtime-configured trace paths / activity lists set via
+        # start_profile(). The following variables track the active
+        # configuration for the current profiling window.
+        torch_profiler = None
+        active_torch_trace_path: Optional[str] = None
+        active_enable_torch_trace: bool = False
+        # Make sure _profile_enabled starts cleared for a fresh executor
+        # run (in case the instance is re-entered).
+        with self._profile_state_lock:
+            self._profile_enabled = False
+
+        def _activities_from_names(
+            names: Optional[List[str]]
+        ) -> List["torch.profiler.ProfilerActivity"]:
+            if not names:
+                return [
+                    torch.profiler.ProfilerActivity.CPU,
+                    torch.profiler.ProfilerActivity.CUDA,
+                    torch.profiler.ProfilerActivity.XPU,
+                ]
+            mapping = {
+                "CPU": torch.profiler.ProfilerActivity.CPU,
+                "GPU": torch.profiler.ProfilerActivity.CUDA,
+                "CUDA": torch.profiler.ProfilerActivity.CUDA,
+                "XPU": torch.profiler.ProfilerActivity.XPU,
+            }
+            resolved = []
+            for name in names:
+                key = name.upper()
+                if key == "CUDA_PROFILER":
+                    # CUDA_PROFILER controls cudaProfilerStart/Stop only; it
+                    # is not a torch.profiler activity.
+                    continue
+                if key in mapping and mapping[key] not in resolved:
+                    resolved.append(mapping[key])
+            return resolved
 
         log_ranks_str = os.environ.get(PROFILE_LOG_RANKS_ENV_VAR_NAME, "0")
         if log_ranks_str.strip().lower() == "all":
@@ -1418,19 +1478,44 @@ class PyExecutor:
 
         def profile_step():
             nonlocal it, enabled, start_time, start_event_1, end_event_1, start_event_2, end_event_2, prev_device_step_time
+            nonlocal torch_profiler, active_torch_trace_path, active_enable_torch_trace
             calibrator.post_step(it)
             if (self.iter_counter in self.profile_stop_iters
                     and not self.is_warmup):
-                assert enabled, "Inconsistent CUDA profiling state"
-                if enable_torch_trace:
-                    torch_profiler.stop()
-                    torch_profiler.export_chrome_trace(torch_trace_path)
-                    logger.info(
-                        f"Profiling stopped at iteration {self.iter_counter}, "
-                        f"trace saved to {torch_trace_path}")
-                torch.cuda.cudart().cudaProfilerStop()
-                calibrator.stop()
-                enabled = False
+                if not enabled:
+                    # Happens when stop_profile() was called before the
+                    # scheduled start_iter was reached (e.g. the user calls
+                    # /start_profile then /stop_profile quickly while the
+                    # engine is still warming up).  Silently drop the stale
+                    # stop marker so we do not crash the event loop.
+                    logger.warning(
+                        f"profile stop scheduled at iter "
+                        f"{self.iter_counter} but no active profiling "
+                        "window - skipping")
+                    self.profile_stop_iters.discard(self.iter_counter)
+                else:
+                    if active_enable_torch_trace and torch_profiler is not None:
+                        torch_profiler.stop()
+                        torch_profiler.export_chrome_trace(
+                            active_torch_trace_path)
+                        logger.info(f"Profiling stopped at iteration "
+                                    f"{self.iter_counter}, "
+                                    f"trace saved to {active_torch_trace_path}")
+                    torch.cuda.cudart().cudaProfilerStop()
+                    calibrator.stop()
+                    enabled = False
+                    with self._profile_state_lock:
+                        self._profile_enabled = False
+                    # Reset lazy state so a subsequent start/stop window can
+                    # pick up a fresh runtime configuration.
+                    torch_profiler = None
+                    active_torch_trace_path = None
+                    # Clear the pending-stop marker so start_profile()'s
+                    # guard no longer sees a stale window.
+                    if (self._runtime_profile_pending_stop_iter ==
+                            self.iter_counter):
+                        self._runtime_profile_pending_stop_iter = None
+                active_enable_torch_trace = False
 
             # Capture per-loop timing whenever stats or the iter log are
             # enabled. The reading of the OTHER parity's event pair (the
@@ -1490,13 +1575,52 @@ class PyExecutor:
             if (self.iter_counter in self.profile_start_iters
                     and not self.is_warmup):
                 assert not enabled, "Inconsistent CUDA profiling state"
+                # Resolve active trace path + torch.profiler configuration
+                # at start time so runtime overrides from start_profile()
+                # take precedence over the environment variables.
+                runtime_trace_path = self._runtime_profile_trace_path
+                runtime_cuda_only = self._runtime_profile_cuda_only
+                runtime_activities = self._runtime_profile_activities
+                if runtime_trace_path is not None:
+                    active_torch_trace_path = runtime_trace_path
+                    # CUDA_PROFILER only: skip torch.profiler so we do not
+                    # pay its overhead and so nsys traces stay clean.
+                    active_enable_torch_trace = not runtime_cuda_only
+                    torch_activities = _activities_from_names(
+                        runtime_activities)
+                    if active_enable_torch_trace and not torch_activities:
+                        # Runtime requested only CUDA_PROFILER even though
+                        # cuda_only was False; treat as cuda-only.
+                        active_enable_torch_trace = False
+                else:
+                    active_torch_trace_path = env_torch_trace_path
+                    active_enable_torch_trace = env_enable_torch_trace
+                    torch_activities = [
+                        torch.profiler.ProfilerActivity.CPU,
+                        torch.profiler.ProfilerActivity.CUDA,
+                        torch.profiler.ProfilerActivity.XPU,
+                    ]
+
                 calibrator.start()
                 torch.cuda.cudart().cudaProfilerStart()
-                if enable_torch_trace:
+                if active_enable_torch_trace:
+                    if torch_profiler is None:
+                        torch_profiler = torch.profiler.profile(
+                            activities=torch_activities,
+                            record_shapes=True,
+                            with_modules=True)
                     torch_profiler.start()
                 logger.info(
                     f"Profiling started at iteration {self.iter_counter}.")
                 enabled = True
+                with self._profile_state_lock:
+                    self._profile_enabled = True
+                # The scheduled start has arrived; clear the pending marker
+                # so the next start_profile() after this window ends is not
+                # rejected as "already pending".
+                if (self._runtime_profile_pending_start_iter ==
+                        self.iter_counter):
+                    self._runtime_profile_pending_start_iter = None
 
             # Notify host line profiler of iteration for iteration-aware profiling
             host_profiler = get_global_profiler()
@@ -1519,13 +1643,330 @@ class PyExecutor:
         finally:
             if enabled:
                 # Stop on early exit / exception
-                if enable_torch_trace:
+                if active_enable_torch_trace and torch_profiler is not None:
                     torch_profiler.stop()
-                    torch_profiler.export_chrome_trace(torch_trace_path)
-                    logger.info(f"Profiling stopped at iteration {it}, "
-                                f"trace saved to {torch_trace_path}")
+                    torch_profiler.export_chrome_trace(active_torch_trace_path)
+                    logger.info(f"Profiling stopped at iteration "
+                                f"{self.iter_counter}, "
+                                f"trace saved to {active_torch_trace_path}")
                 torch.cuda.cudart().cudaProfilerStop()
                 calibrator.stop()
+                with self._profile_state_lock:
+                    self._profile_enabled = False
+
+    def start_profile(self,
+                      output_dir: Optional[str] = None,
+                      num_steps: Optional[int] = None,
+                      start_step: int = 0,
+                      activities: Optional[List[str]] = None) -> None:
+        """Start iteration-scoped profiling.
+
+        This mirrors the functionality of the ``TLLM_PROFILE_START_STOP`` /
+        ``TLLM_TORCH_PROFILE_TRACE`` environment variables but can be
+        triggered at runtime (for example via trtllm-serve HTTP endpoints).
+
+        Args:
+            output_dir: Directory where chrome traces are written. If
+                ``None``, falls back to the ``TLLM_TORCH_PROFILER_DIR``
+                environment variable and finally to ``/tmp``.
+            num_steps: Number of iterations to profile. If ``None``,
+                profiling runs until ``stop_profile`` is called.
+            start_step: Additional iterations to skip before profiling
+                starts (relative to the current iteration counter).
+            activities: Subset of ``["CPU", "GPU", "CUDA_PROFILER"]``. When
+                ``CUDA_PROFILER`` is the only entry, torch.profiler is not
+                started so only ``cudaProfilerStart/Stop`` brackets run,
+                suitable for nsys capture.
+        """
+        # Reject overlapping profile windows. Check locally on the
+        # caller thread so the HTTP handler gets a clean error instead
+        # of the executor thread crashing on ``assert not enabled``
+        # inside profile_step().
+        with self._profile_state_lock:
+            already_active = self._profile_enabled
+        if (already_active
+                or self._runtime_profile_pending_start_iter is not None):
+            # Use RequestError (a RuntimeError subclass) so the
+            # ``GenerationExecutor`` error monitor treats this as a
+            # per-call rejection rather than a fatal engine error.
+            from tensorrt_llm.executor.utils import RequestError
+            raise RequestError(
+                "Profiling is already in progress (or a pending start has "
+                "been scheduled); call stop_profile first before starting "
+                "a new window. (state: _profile_enabled="
+                f"{already_active}, _runtime_profile_pending_start_iter="
+                f"{self._runtime_profile_pending_start_iter}, "
+                f"profile_start_iters="
+                f"{sorted(self.profile_start_iters)[:5]}, "
+                f"profile_stop_iters="
+                f"{sorted(self.profile_stop_iters)[:5]})")
+
+        if activities is None:
+            activities = ["CPU", "GPU"]
+
+        if output_dir is None:
+            # ``/tmp`` is the documented developer default for the profile
+            # trace directory (matches sglang and the server docs); the
+            # user-facing override is the ``TLLM_TORCH_PROFILER_DIR`` env
+            # var or the ``output_dir`` request body field.
+            output_dir = os.environ.get(
+                "TLLM_TORCH_PROFILER_DIR",
+                "/tmp",  # nosec B108
+            )
+
+        try:
+            os.makedirs(output_dir, exist_ok=True)
+        except OSError as e:
+            logger.warning(
+                f"Failed to create profile output_dir {output_dir}: {e}")
+
+        # Include a unique profile id (monotonic timestamp + short uuid
+        # fragment) so successive start/stop cycles under the same
+        # output_dir don't silently overwrite each other's traces.
+        profile_id = f"{int(time.time())}-{uuid.uuid4().hex[:8]}"
+
+        # Build the per-request config that every rank consumes. We do
+        # NOT pre-compute start_iter here: each rank must derive it from
+        # its own ``iter_counter`` at the moment the broadcast is
+        # processed (inside ``_handle_special_queue_items``), so that
+        # rank 0 doesn't get a head start by pre-applying with its
+        # caller-thread ``iter_counter`` while rank 1's executor loop
+        # has already advanced past the start point. All ranks are in
+        # sync on iter_counter at the broadcast point, so they all
+        # compute the same start_iter/stop_iter.
+        profile_config = {
+            "output_dir": output_dir,
+            "profile_id": profile_id,
+            "activities": list(activities),
+            "start_step": int(max(0, start_step)),
+            "num_steps": num_steps,
+        }
+
+        # Mark pending on the caller thread too so a second concurrent
+        # start_profile() is rejected by the guard above. The actual
+        # profile_start_iters / trace_path state is only populated
+        # when the broadcast reaches ``_handle_special_queue_items``.
+        # Use a sentinel (0) to mean "pending but not yet scheduled".
+        self._runtime_profile_pending_start_iter = 0
+        self._runtime_profile_activities = list(activities)
+
+        # Broadcast to every rank via the request queue so non-zero
+        # ranks update their own ``profile_start_iters`` in lockstep.
+        # This is also what wakes the idle executor loop (the
+        # PROFILE_START_REQUEST_ID item gets broadcasted via
+        # ``RequestBroadcaster`` inside ``_fetch_and_enqueue_requests``,
+        # then dropped inside ``_handle_special_queue_items`` — no
+        # forward pass runs for this iteration, so the chrome trace
+        # captures only real user workload).
+        rank = getattr(getattr(self, 'dist', None), 'rank', 0)
+        eq = getattr(self, 'executor_request_queue', None)
+        if rank == 0 and eq is not None:
+            try:
+                eq.enqueue_profile_start_request(profile_config)
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    f"start_profile: failed to enqueue profile-start "
+                    f"broadcast item: {e}")
+
+    def stop_profile(self) -> None:
+        """Schedule the in-progress runtime profiling to stop on the
+        next executor iteration.
+
+        The actual ``torch.profiler.stop()`` + ``export_chrome_trace()``
+        call happens inside ``profile_step()`` on the executor thread, so
+        that torch.profiler / Kineto's "stop must run on the same thread
+        that called start" invariant is respected.
+
+        Two extra cases are handled so no profile window is leaked:
+
+        * If ``start_profile()`` was called but the engine has not yet
+          reached the scheduled ``start_iter`` (e.g. the caller stopped
+          before sending any requests), cancel the pending start so
+          profiling does not begin later.
+        * Otherwise schedule a stop iteration. When called via an HTTP
+          handler the server layer is responsible for tickling the
+          executor loop so the stop iteration actually runs even when
+          the engine would otherwise be idle (see
+          ``OpenAIServer.stop_profile``).
+        """
+        with self._profile_state_lock:
+            currently_enabled = self._profile_enabled
+
+        if (not currently_enabled
+                and self._runtime_profile_pending_start_iter is not None):
+            # Pending runtime start has not fired yet; cancel it cleanly
+            # on this rank.  Also broadcast the stop so non-zero ranks
+            # clear their own pending starts — otherwise a
+            # ``start_profile``-then-``stop_profile`` cycle on an idle
+            # multi-rank deployment would leave stale pending starts on
+            # the subordinates.
+            self._apply_profile_stop_config()
+            rank = getattr(getattr(self, 'dist', None), 'rank', 0)
+            eq = getattr(self, 'executor_request_queue', None)
+            if rank == 0 and eq is not None:
+                try:
+                    eq.enqueue_profile_stop_request()
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        f"stop_profile: failed to enqueue profile-stop "
+                        f"broadcast item: {e}")
+            return
+
+        # Apply locally so diagnostic state (profile_stop_iters,
+        # pending_stop_iter) is visible on the caller thread immediately.
+        self._apply_profile_stop_config()
+
+        # Broadcast to every rank so non-zero ranks add the same
+        # stop_iter to their own profile_stop_iters. Also wakes the
+        # idle executor loop on rank 0; the broadcast then propagates
+        # the wake to all ranks inside
+        # ``_fetch_and_enqueue_requests``.
+        rank = getattr(getattr(self, 'dist', None), 'rank', 0)
+        eq = getattr(self, 'executor_request_queue', None)
+        if rank == 0 and eq is not None:
+            try:
+                eq.enqueue_profile_stop_request()
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"stop_profile: failed to enqueue profile-stop "
+                               f"broadcast item: {e}")
+
+        # Wait (with timeout) for the stop to actually fire so that by
+        # the time stop_profile() returns the chrome trace has been
+        # exported to disk. Without this wait, callers that hit the
+        # HTTP /stop_profile endpoint and then immediately try to read
+        # the trace file would see an empty directory.
+        deadline = time.monotonic() + 30.0
+        while time.monotonic() < deadline:
+            with self._profile_state_lock:
+                if not self._profile_enabled:
+                    return
+            time.sleep(0.005)
+        logger.warning(
+            "stop_profile: executor loop did not fire the scheduled stop "
+            "within 30s; the trace may not be fully flushed yet.")
+
+    def _apply_profile_start_config(self, config: Dict) -> None:
+        """Apply a broadcasted profile-start config to this rank.
+
+        Called from two places: directly on the caller thread from
+        ``start_profile()`` (so ``_runtime_profile_pending_start_iter``
+        becomes visible for re-entrancy checks) AND from
+        ``_handle_special_queue_items`` when the broadcasted
+        ``PROFILE_START_REQUEST_ID`` item arrives. The operation is
+        idempotent: the second call on rank 0 sees the same state and
+        is a no-op.
+        """
+        activities = config.get("activities") or ["CPU", "GPU"]
+        # ``/tmp`` matches the documented developer default; see
+        # ``start_profile`` for the rationale.
+        output_dir = config.get("output_dir") or "/tmp"  # nosec B108
+        profile_id = (config.get("profile_id")
+                      or f"{int(time.time())}-{uuid.uuid4().hex[:8]}")
+        # Prefer the legacy absolute ``start_iter`` form (older unit
+        # tests and env-var driven paths set this directly). For the
+        # broadcast path the caller sends ``start_step`` instead so
+        # every rank computes its own ``start_iter`` from its current
+        # ``iter_counter`` — this avoids a race where rank 0's local
+        # apply sets a past start_iter that rank 1 never reaches in
+        # time to fire.
+        if "start_iter" in config:
+            start_iter = int(config["start_iter"])
+        else:
+            start_step = int(config.get("start_step", 0))
+            current_iter = int(getattr(self, "iter_counter", 0))
+            start_iter = current_iter + 1 + start_step
+        num_steps = config.get("num_steps")
+        stop_iter = config.get("stop_iter")
+        if stop_iter is None and num_steps is not None:
+            stop_iter = start_iter + int(num_steps)
+
+        # Rank-specific trace path so every rank writes its own file
+        # when running with TP/PP > 1.
+        trace_filename = (
+            f"trtllm-trace-{profile_id}-rank-{self.global_rank}.json")
+        trace_path = os.path.join(output_dir, trace_filename)
+
+        # First apply on this rank? If the start_iter is already in
+        # profile_start_iters it means either rank 0's local apply ran
+        # (before the broadcast echo-back) or a prior broadcast already
+        # applied — in both cases the pending marker belongs to the
+        # original apply, and re-setting it here would overwrite a
+        # subsequent clear by profile_step() and leak stale state.
+        is_first_apply = start_iter not in self.profile_start_iters
+
+        self._runtime_profile_trace_path = trace_path
+        self._runtime_profile_activities = list(activities)
+        self._runtime_profile_cuda_only = (len(activities) == 1
+                                           and activities[0].upper()
+                                           == "CUDA_PROFILER")
+
+        self.profile_start_iters.add(start_iter)
+        if is_first_apply:
+            self._runtime_profile_pending_start_iter = start_iter
+            if stop_iter is not None:
+                self.profile_stop_iters.add(int(stop_iter))
+                self._runtime_profile_pending_stop_iter = int(stop_iter)
+            # ``num_steps is None`` branch: leave pending_stop_iter
+            # alone — caller set it to None in start_profile.
+        elif stop_iter is not None:
+            # Broadcast echoes back to rank 0 after its local apply, or
+            # after the start has already fired. Only ensure the stop
+            # iter is in the set on this rank (idempotent); don't
+            # reset pending markers.
+            self.profile_stop_iters.add(int(stop_iter))
+
+        logger.info(f"_apply_profile_start_config[rank={self.global_rank}]: "
+                    f"start_iter={start_iter}, stop_iter={stop_iter}, "
+                    f"activities={activities}, trace_path={trace_path}, "
+                    f"is_first_apply={is_first_apply}")
+
+    def _apply_profile_stop_config(self) -> None:
+        """Apply a broadcasted profile-stop to this rank.
+
+        Handles both the cancel-pending-start case and the schedule-
+        a-stop case so the broadcast from rank 0 replays correctly on
+        every rank.
+        """
+        with self._profile_state_lock:
+            currently_enabled = self._profile_enabled
+
+        if (not currently_enabled
+                and self._runtime_profile_pending_start_iter is not None):
+            pending_start = self._runtime_profile_pending_start_iter
+            pending_stop = self._runtime_profile_pending_stop_iter
+            self.profile_start_iters.discard(pending_start)
+            if pending_stop is not None:
+                self.profile_stop_iters.discard(pending_stop)
+            self._runtime_profile_pending_start_iter = None
+            self._runtime_profile_pending_stop_iter = None
+            logger.info(f"_apply_profile_stop_config[rank={self.global_rank}]: "
+                        f"cancelled pending start at iteration {pending_start} "
+                        "before it fired")
+            return
+
+        # Fire condition inside profile_step(): stop iter matches
+        # ``self.iter_counter`` at the top of the NEXT executor loop
+        # iteration. ``iter_counter`` is incremented at the END of the
+        # current body, so setting ``stop_iter = iter_counter + 1``
+        # fires the stop on the very next profile_step call whether
+        # this function runs mid-body (pre-increment) or between
+        # iterations (post-increment). One cancel-wake (or the
+        # profile-stop broadcast item acting as a wake) is enough to
+        # flush.
+        current_iter = getattr(self, 'iter_counter', 0)
+        stop_iter = current_iter + 1
+        self.profile_stop_iters.add(stop_iter)
+        self._runtime_profile_pending_stop_iter = stop_iter
+        logger.info(f"_apply_profile_stop_config[rank={self.global_rank}]: "
+                    f"scheduled stop at iteration {stop_iter}")
+
+    # _wake_executor_loop_for_profile was previously used to enqueue a
+    # sentinel cancel-request to unblock the idle executor loop.  It is
+    # no longer needed: the profile-start / profile-stop broadcast
+    # items (enqueued by start_profile/stop_profile on rank 0) land on
+    # the same queue and already wake the fetch. The broadcast of those
+    # items via RequestBroadcaster also synchronizes all ranks, so we
+    # don't need a separate wake on non-zero ranks.
 
     def _get_init_iter_stats(self, num_new_active_requests,
                              new_active_requests_queue_latency_ms):
@@ -2355,17 +2796,23 @@ class PyExecutor:
                         gpu_forward_events_from_perf_pool = True
 
                     # Stage 1.1: Async forward (all ranks) and decoding pass (last rank only)
+                    # Per-iteration sglang-compatible step[...] scope. Appears
+                    # in Kineto traces under the user_annotation / gpu_user_annotation
+                    # categories so trtllm-serve /start_profile output is
+                    # comparable to sglang's trace.
+                    pp_step_label = self._build_step_scope_label(
+                        scheduled_batch)
                     if not self.dist.is_last_pp_rank:
                         with torch.cuda.nvtx.range(
                                 f"_forward_step_inter_pp pp_rank {self.dist.pp_rank}"
-                        ):
+                        ), torch.profiler.record_function(pp_step_label):
                             sample_state = self._forward_step_inter_pp(
                                 scheduled_batch, gpu_forward_start,
                                 gpu_forward_end)
                     else:
                         with torch.cuda.nvtx.range(
                                 f"_forward_step_last_pp pp_rank {self.dist.pp_rank}"
-                        ):
+                        ), torch.profiler.record_function(pp_step_label):
                             # init_disagg_gen_requests must be before engine forward, where the prev_seq_slot is updated.
                             if self.guided_decoder is not None and self.kv_cache_transceiver:
                                 self.guided_decoder.add_batch(scheduled_batch)
@@ -3236,6 +3683,33 @@ class PyExecutor:
             charge_budget=False,
         )
 
+    def _build_step_scope_label(self,
+                                scheduled_batch: ScheduledRequests) -> str:
+        """Format a per-iteration scope label for ``torch.profiler``.
+
+        The label matches sglang's ``step[...]`` convention so chrome
+        traces from ``trtllm-serve`` and sglang can be visually and
+        programmatically compared. The label appears in the Kineto
+        ``user_annotation`` / ``gpu_user_annotation`` lanes.
+
+        Format:
+          - ``step[DECODE bs=N]`` when every scheduled request is in
+            generation phase (no context requests this iteration).
+          - ``step[EXTEND bs=N toks=M]`` when any context requests are
+            scheduled. ``bs`` is the number of extend (context) requests
+            and ``toks`` is the total number of context tokens being
+            processed this iteration (sum of each request's
+            ``context_chunk_size``).
+        """
+        num_ctx = scheduled_batch.num_context_requests
+        num_gen = scheduled_batch.num_generation_requests
+        if num_ctx == 0:
+            return f"step[DECODE bs={num_gen}]"
+        total_toks = 0
+        for req in scheduled_batch.context_requests:
+            total_toks += int(getattr(req, "context_chunk_size", 0) or 0)
+        return f"step[EXTEND bs={num_ctx} toks={total_toks}]"
+
     def _executor_loop(self):
         torch.cuda.set_device(self.device_id)
         # ensure the context is created, otherwise, some MPI calls will fail.
@@ -3365,23 +3839,32 @@ class PyExecutor:
                         )
                         gpu_forward_events_from_perf_pool = True
 
-                    with self.perf_manager.record_perf_events(
-                            gpu_forward_start, gpu_forward_end) as fwd_timing:
-                        if self.dwdp_manager is not None:
-                            self.dwdp_manager.prefetch_first_layers()
-                        batch_outputs = self._forward_step(scheduled_batch)
+                    # Emit an sglang-compatible step[...] user_annotation
+                    # scope around the forward+sample region so Kineto
+                    # traces from trtllm-serve /start_profile match the
+                    # shape of sglang's traces (same category, same label
+                    # format).
+                    with torch.profiler.record_function(
+                            self._build_step_scope_label(scheduled_batch)):
+                        with self.perf_manager.record_perf_events(
+                                gpu_forward_start,
+                                gpu_forward_end) as fwd_timing:
+                            if self.dwdp_manager is not None:
+                                self.dwdp_manager.prefetch_first_layers()
+                            batch_outputs = self._forward_step(scheduled_batch)
 
-                    self._maybe_prefetch_next_iter_mm_encoders(scheduled_batch)
+                        self._maybe_prefetch_next_iter_mm_encoders(
+                            scheduled_batch)
 
-                    guided_decoder_failed_requests = None
-                    if self.guided_decoder is not None:
-                        guided_decoder_failed_requests = self.guided_decoder.execute(
-                            batch_outputs['logits'])
+                        guided_decoder_failed_requests = None
+                        if self.guided_decoder is not None:
+                            guided_decoder_failed_requests = self.guided_decoder.execute(
+                                batch_outputs['logits'])
 
-                    with self.perf_manager.record_perf_events(
-                            None, gpu_sample_end) as sample_timing:
-                        sample_state = self._sample_async(
-                            scheduled_batch, batch_outputs)
+                        with self.perf_manager.record_perf_events(
+                                None, gpu_sample_end) as sample_timing:
+                            sample_state = self._sample_async(
+                                scheduled_batch, batch_outputs)
 
                     if self.perf_manager.enabled:
                         self.perf_manager.save_timing_to_requests(
@@ -3726,6 +4209,12 @@ class PyExecutor:
                     self._terminate_requests(scheduled_batch.paused_requests)
 
                 gpu_forward_events_from_perf_pool = False
+                # Per-iteration scope label for torch.profiler. Reused to
+                # wrap forward and sample calls below so the resulting
+                # chrome trace has sglang-compatible ``step[...]``
+                # user_annotation scopes.
+                step_scope_label = self._build_step_scope_label(scheduled_batch)
+
                 can_queue, can_queue_this_rank = self._can_queue(
                     scheduled_batch)
 
@@ -3837,9 +4326,10 @@ class PyExecutor:
 
                     with self.perf_manager.record_perf_events(
                             gpu_forward_start, gpu_forward_end) as fwd_timing:
-                        batch_outputs = self._forward_step(
-                            scheduled_batch, previous_tensors_device,
-                            num_accepted_tokens_device)
+                        with torch.profiler.record_function(step_scope_label):
+                            batch_outputs = self._forward_step(
+                                scheduled_batch, previous_tensors_device,
+                                num_accepted_tokens_device)
 
                     self._maybe_prefetch_next_iter_mm_encoders(scheduled_batch)
 
@@ -3877,14 +4367,15 @@ class PyExecutor:
                     guided_decoder_failed_requests = None
                     with self.perf_manager.record_perf_events(
                             None, gpu_sample_end) as sample_timing:
-                        if self.guided_decoder is not None:
-                            # add_batch must be called again to have updated new tokens.
-                            self.guided_decoder.add_batch(scheduled_batch)
-                            guided_decoder_failed_requests = self.guided_decoder.execute(
-                                batch_outputs['logits'])
+                        with torch.profiler.record_function(step_scope_label):
+                            if self.guided_decoder is not None:
+                                # add_batch must be called again to have updated new tokens.
+                                self.guided_decoder.add_batch(scheduled_batch)
+                                guided_decoder_failed_requests = self.guided_decoder.execute(
+                                    batch_outputs['logits'])
 
-                        sample_state = self._sample_async(
-                            scheduled_batch, batch_outputs)
+                            sample_state = self._sample_async(
+                                scheduled_batch, batch_outputs)
 
                     assert sample_state is not None, "Sampling failed"
 
@@ -4312,6 +4803,14 @@ class PyExecutor:
                 if self.dist.rank == 0:
                     self.request_accumulated.extend(new_requests[idx + 1:])
                 break
+            elif req_item.is_profile_start_request:
+                # Broadcasted from rank 0 via RequestBroadcaster; apply
+                # on this rank so every PyExecutor has the same
+                # profile_start_iters / pending markers.  Idempotent on
+                # rank 0 (start_profile already applied locally).
+                self._apply_profile_start_config(req_item.profile_config or {})
+            elif req_item.is_profile_stop_request:
+                self._apply_profile_stop_config()
             else:
                 accepted_new_requests.append(req_item)
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1701,6 +1701,20 @@ class PyExecutor:
                 f"profile_stop_iters="
                 f"{sorted(self.profile_stop_iters)[:5]})")
 
+        # Reject ``num_steps <= 0``. The HTTP layer already rejects this
+        # via the ``StartProfileRequest`` Pydantic schema, but
+        # programmatic callers (``LLM.start_profile``, env-var-driven
+        # paths, unit tests) bypass that schema. With ``num_steps == 0``,
+        # ``stop_iter`` would equal ``start_iter`` in
+        # ``_apply_profile_start_config`` below, ``profile_step()`` would
+        # discard the stop marker as stale, and the profile window would
+        # run forever until an explicit ``stop_profile()``.
+        if num_steps is not None and num_steps <= 0:
+            raise ValueError(
+                f"start_profile: num_steps must be >= 1 if provided "
+                f"(got num_steps={num_steps!r}). Pass num_steps=None to "
+                "run until an explicit stop_profile() call.")
+
         if activities is None:
             activities = ["CPU", "GPU"]
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1720,7 +1720,7 @@ class PyExecutor:
 
         if output_dir is None:
             # ``/tmp`` is the documented developer default for the profile
-            # trace directory (matches sglang and the server docs); the
+            # trace directory (matches the server docs); the
             # user-facing override is the ``TLLM_TORCH_PROFILER_DIR`` env
             # var or the ``output_dir`` request body field.
             output_dir = os.environ.get(
@@ -2831,10 +2831,10 @@ class PyExecutor:
                         gpu_forward_events_from_perf_pool = True
 
                     # Stage 1.1: Async forward (all ranks) and decoding pass (last rank only)
-                    # Per-iteration sglang-compatible step[...] scope. Appears
-                    # in Kineto traces under the user_annotation / gpu_user_annotation
-                    # categories so trtllm-serve /start_profile output is
-                    # comparable to sglang's trace.
+                    # Per-iteration step[...] scope. Appears in Kineto traces
+                    # under the user_annotation / gpu_user_annotation
+                    # categories so trtllm-serve /start_profile output exposes
+                    # per-iteration boundaries to downstream trace viewers.
                     pp_step_label = self._build_step_scope_label(
                         scheduled_batch)
                     if not self.dist.is_last_pp_rank:
@@ -3722,10 +3722,10 @@ class PyExecutor:
                                 scheduled_batch: ScheduledRequests) -> str:
         """Format a per-iteration scope label for ``torch.profiler``.
 
-        The label matches sglang's ``step[...]`` convention so chrome
-        traces from ``trtllm-serve`` and sglang can be visually and
-        programmatically compared. The label appears in the Kineto
-        ``user_annotation`` / ``gpu_user_annotation`` lanes.
+        The label uses a ``step[...]`` convention that exposes per-iteration
+        boundaries in chrome traces and can be parsed programmatically. The
+        label appears in the Kineto ``user_annotation`` /
+        ``gpu_user_annotation`` lanes.
 
         Format:
           - ``step[DECODE bs=N]`` when every scheduled request is in
@@ -3874,11 +3874,11 @@ class PyExecutor:
                         )
                         gpu_forward_events_from_perf_pool = True
 
-                    # Emit an sglang-compatible step[...] user_annotation
-                    # scope around the forward+sample region so Kineto
-                    # traces from trtllm-serve /start_profile match the
-                    # shape of sglang's traces (same category, same label
-                    # format).
+                    # Emit a step[...] user_annotation scope around the
+                    # forward+sample region so Kineto traces from
+                    # trtllm-serve /start_profile expose per-iteration
+                    # boundaries with a consistent category and label
+                    # format.
                     with torch.profiler.record_function(
                             self._build_step_scope_label(scheduled_batch)):
                         with self.perf_manager.record_perf_events(
@@ -4246,8 +4246,8 @@ class PyExecutor:
                 gpu_forward_events_from_perf_pool = False
                 # Per-iteration scope label for torch.profiler. Reused to
                 # wrap forward and sample calls below so the resulting
-                # chrome trace has sglang-compatible ``step[...]``
-                # user_annotation scopes.
+                # chrome trace has ``step[...]`` user_annotation scopes
+                # marking each iteration.
                 step_scope_label = self._build_step_scope_label(scheduled_batch)
 
                 can_queue, can_queue_this_rank = self._can_queue(

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -776,6 +776,42 @@ class BaseWorker(GenerationExecutor):
             return {}
         return self.engine.kv_cache_transceiver.get_disaggregated_params()
 
+    def start_profile(self,
+                      output_dir: Optional[str] = None,
+                      num_steps: Optional[int] = None,
+                      start_step: int = 0,
+                      activities: Optional[List[str]] = None) -> None:
+        """Forward profiling request to the underlying PyExecutor engine.
+
+        No-op (with a warning) for legacy TensorRT-backend engines which
+        do not expose this API.
+        """
+        if self.engine is None:
+            logger.warning(
+                "start_profile called but engine is not initialized.")
+            return
+        start_fn = getattr(self.engine, "start_profile", None)
+        if start_fn is None:
+            logger.warning("Current engine does not support start_profile; "
+                           "this API requires the PyTorch PyExecutor backend.")
+            return
+        start_fn(output_dir=output_dir,
+                 num_steps=num_steps,
+                 start_step=start_step,
+                 activities=activities)
+
+    def stop_profile(self) -> None:
+        """Forward stop_profile request to the underlying PyExecutor engine."""
+        if self.engine is None:
+            logger.warning("stop_profile called but engine is not initialized.")
+            return
+        stop_fn = getattr(self.engine, "stop_profile", None)
+        if stop_fn is None:
+            logger.warning("Current engine does not support stop_profile; "
+                           "this API requires the PyTorch PyExecutor backend.")
+            return
+        stop_fn()
+
     @staticmethod
     def _stats_serializer(stats) -> str:
         # Per-rank path: stats is ("per_rank_dict", {..., "rank": N}).

--- a/tensorrt_llm/executor/executor.py
+++ b/tensorrt_llm/executor/executor.py
@@ -385,6 +385,28 @@ class GenerationExecutor(ABC):
     def shutdown(self):
         pass
 
+    def start_profile(self,
+                      output_dir: Optional[str] = None,
+                      num_steps: Optional[int] = None,
+                      start_step: int = 0,
+                      activities: Optional[List[str]] = None) -> None:
+        """Start runtime profiling in the backend engine.
+
+        Default implementation logs a warning. Subclasses that back a
+        ``PyExecutor`` should override to forward the call.
+        """
+        logger.warning(f"start_profile is not supported on executor type "
+                       f"{type(self).__name__}.")
+
+    def stop_profile(self) -> None:
+        """Stop runtime profiling in the backend engine.
+
+        Default implementation logs a warning. Subclasses that back a
+        ``PyExecutor`` should override to forward the call.
+        """
+        logger.warning(f"stop_profile is not supported on executor type "
+                       f"{type(self).__name__}.")
+
     @property
     def resource_governor_queue(self):
         """Return the resource governor queue if this executor supports it."""

--- a/tensorrt_llm/executor/ipc.py
+++ b/tensorrt_llm/executor/ipc.py
@@ -260,9 +260,23 @@ class ZeroMqQueue:
             logger.error(traceback.format_exc())
             raise e
 
-    def get(self) -> Any:
+    def get(self, timeout: Optional[float] = None) -> Any:
+        """Receive an object from the queue.
+
+        Args:
+            timeout: If ``None`` (default), block until a message arrives.
+                If a non-negative float, wait up to that many seconds and
+                raise ``queue.Empty`` if nothing arrives in time.
+        """
         self.setup_lazily()
         self._check_thread_safety()
+        if timeout is not None:
+            # ``zmq.Socket.poll`` takes timeout in milliseconds; convert
+            # from seconds. ``poll`` returns 0 when the timeout fires
+            # without any event on the socket.
+            if not self.socket.poll(timeout=int(timeout * 1000)):
+                from queue import Empty
+                raise Empty()
         return self._recv_data()
 
     def drain(self) -> list[Any]:

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -17,6 +17,7 @@ import concurrent.futures
 import json
 import os
 import threading
+import time
 import weakref
 from queue import Empty
 from typing import Dict, List, Optional, Union
@@ -335,32 +336,54 @@ class GenerationExecutorProxy(GenerationExecutor):
         """Block on the worker's ack queue for a profile control request.
 
         Waits for the worker to push an ack on ``profile_ack_queue``
-        matching ``expected_kind`` ("start" or "stop"), or until
-        ``timeout`` elapses.
+        matching ``expected_kind`` ("start" or "stop"), or until the
+        cumulative ``timeout`` elapses across any number of stale-ack
+        consumptions.
 
-        If the worker reports a rejection (non-empty error message),
+        If a stale or out-of-order ack is read (e.g. the previous call
+        timed out and its ack arrived after we returned), we discard it
+        and keep waiting for the expected kind. Returning on a mismatch
+        would break the synchronous contract: the next call could return
+        before its own request has been processed, making the documented
+        guarantee ("trace is on disk by the time /stop_profile returns
+        200") unsound under back-to-back invocations.
+
+        If the worker reports a rejection (non-empty error message), we
         re-raise as ``RuntimeError`` so the HTTP layer can map "already
-        in progress" / "pending" to 409. On timeout we log a warning
+        in progress" / "pending" to 409. On true timeout we log a warning
         and return — the chrome trace may still be flushing on the
         backend, but blocking the FastAPI event loop indefinitely is
         worse than a possibly-stale 200.
         """
-        try:
-            ack = self.profile_ack_queue.get(timeout=timeout)
-        except Exception as e:  # noqa: BLE001
-            logger.warning(
-                f"{expected_kind}_profile: timed out waiting for worker "
-                f"ack after {timeout:.1f}s ({e}). The chrome trace may "
-                "not be on disk yet.")
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning(
+                    f"{expected_kind}_profile: timed out waiting for "
+                    f"worker ack after {timeout:.1f}s. The chrome trace "
+                    "may not be on disk yet.")
+                return
+            try:
+                ack = self.profile_ack_queue.get(timeout=remaining)
+            except Empty:
+                logger.warning(
+                    f"{expected_kind}_profile: timed out waiting for "
+                    f"worker ack after {timeout:.1f}s. The chrome trace "
+                    "may not be on disk yet.")
+                return
+            kind, error_msg = ack
+            if kind != expected_kind:
+                # Out-of-order ack from a previous call; discard and keep
+                # waiting for the ack that belongs to this request.
+                logger.warning(
+                    f"profile ack kind mismatch (expected "
+                    f"{expected_kind!r}, got {kind!r}); discarding stale "
+                    "ack and continuing to wait.")
+                continue
+            if error_msg:
+                raise RuntimeError(error_msg)
             return
-        kind, error_msg = ack
-        if kind != expected_kind:
-            # Out-of-order ack from a previous call; log and ignore.
-            logger.warning(
-                f"profile ack kind mismatch (expected {expected_kind!r}, "
-                f"got {kind!r}); proceeding anyway.")
-        if error_msg:
-            raise RuntimeError(error_msg)
 
     def start_profile(self,
                       output_dir=None,

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -36,7 +36,8 @@ from ..llmapi.utils import (AsyncQueue, ManagedThread, _SyncQueue,
 from .executor import GenerationExecutor
 from .ipc import FusedIpcQueue, IpcQueue
 from .postproc_worker import PostprocWorker, PostprocWorkerConfig
-from .request import CancellingRequest, GenerationRequest
+from .request import (CancellingRequest, GenerationRequest, StartProfileRequest,
+                      StopProfileRequest)
 from .result import GenerationResult, IterationResult
 from .rpc import RPCClient
 from .rpc.rpc_common import RPCError, get_unique_ipc_addr
@@ -289,6 +290,15 @@ class GenerationExecutorProxy(GenerationExecutor):
         self._resource_governor_queue = IpcQueue(
             is_server=True, name="proxy_resource_governor_queue"
         ) if self._enable_resource_governor else None
+        # Worker -> proxy ack channel for synchronous control requests
+        # (start_profile / stop_profile). Worker pushes a tuple
+        # ``(kind, error_msg)`` after it has finished processing the
+        # corresponding request; ``error_msg`` is non-None when
+        # ``PyExecutor`` rejected the call (e.g. RequestError "already
+        # in progress") so the proxy can re-raise. PAIR socket is fine
+        # because the worker leader is the sole producer.
+        self.profile_ack_queue = IpcQueue(is_server=True,
+                                          name="proxy_profile_ack_queue")
         # Stats and KV events are now fetched via RPC, not IPC queues.
         return WorkerCommIpcAddrs(
             request_queue_addr=self.request_queue.address,
@@ -296,6 +306,7 @@ class GenerationExecutorProxy(GenerationExecutor):
             result_queue_addr=self.result_queue.address,
             resource_governor_queue_addr=self._resource_governor_queue.address
             if self._resource_governor_queue is not None else None,
+            profile_ack_queue_addr=self.profile_ack_queue.address,
         )
 
     @property
@@ -312,6 +323,75 @@ class GenerationExecutorProxy(GenerationExecutor):
         # may take a while for the request to be cancelled in the worker and
         # send back a finished result.
         self.request_queue.put(CancellingRequest(request_id))
+
+    # Per-call timeouts for the synchronous worker round-trip. The stop
+    # path can take up to 30s because PyExecutor.stop_profile itself
+    # polls ``_profile_enabled`` for that long while the executor loop
+    # flushes the chrome trace; we add a small safety margin.
+    _START_PROFILE_ACK_TIMEOUT_S = 60.0
+    _STOP_PROFILE_ACK_TIMEOUT_S = 35.0
+
+    def _wait_profile_ack(self, expected_kind: str, timeout: float) -> None:
+        """Block on the worker's ack queue for a profile control request.
+
+        Waits for the worker to push an ack on ``profile_ack_queue``
+        matching ``expected_kind`` ("start" or "stop"), or until
+        ``timeout`` elapses.
+
+        If the worker reports a rejection (non-empty error message),
+        re-raise as ``RuntimeError`` so the HTTP layer can map "already
+        in progress" / "pending" to 409. On timeout we log a warning
+        and return — the chrome trace may still be flushing on the
+        backend, but blocking the FastAPI event loop indefinitely is
+        worse than a possibly-stale 200.
+        """
+        try:
+            ack = self.profile_ack_queue.get(timeout=timeout)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                f"{expected_kind}_profile: timed out waiting for worker "
+                f"ack after {timeout:.1f}s ({e}). The chrome trace may "
+                "not be on disk yet.")
+            return
+        kind, error_msg = ack
+        if kind != expected_kind:
+            # Out-of-order ack from a previous call; log and ignore.
+            logger.warning(
+                f"profile ack kind mismatch (expected {expected_kind!r}, "
+                f"got {kind!r}); proceeding anyway.")
+        if error_msg:
+            raise RuntimeError(error_msg)
+
+    def start_profile(self,
+                      output_dir=None,
+                      num_steps=None,
+                      start_step: int = 0,
+                      activities=None) -> None:
+        """Forward runtime profiling start to the IPC worker process.
+
+        Blocks until the worker has processed the request, then
+        raises ``RuntimeError`` if ``PyExecutor`` rejected the start
+        (e.g. a profile window is already active or pending) so the
+        HTTP /start_profile endpoint can return 409.
+        """
+        self.request_queue.put(
+            StartProfileRequest(output_dir=output_dir,
+                                num_steps=num_steps,
+                                start_step=start_step,
+                                activities=activities))
+        self._wait_profile_ack("start", self._START_PROFILE_ACK_TIMEOUT_S)
+
+    def stop_profile(self) -> None:
+        """Forward runtime profiling stop to the IPC worker process.
+
+        Blocks until the worker has finished flushing the chrome
+        trace. This makes the IPC-proxy path match the in-process and
+        RPC-proxy paths: by the time this method returns the trace
+        file is on disk, so HTTP callers can reliably read it
+        immediately after /stop_profile returns 200.
+        """
+        self.request_queue.put(StopProfileRequest())
+        self._wait_profile_ack("stop", self._STOP_PROFILE_ACK_TIMEOUT_S)
 
     def dispatch_result_task(self) -> bool:
         # TODO[chunweiy]: convert the dispatch_result_task to async, that should
@@ -536,10 +616,10 @@ class GenerationExecutorProxy(GenerationExecutor):
             print_alive_threads()
 
     def submit(self, request: GenerationRequest) -> GenerationResult:
-        """
-            Low-level API to the executor. Return a "future" GenerationResult
-            which can be waited.
-            Forwards the request to the workers through the request queue.
+        """Low-level API to the executor.
+
+        Returns a "future" GenerationResult which can be waited.
+        Forwards the request to the workers through the request queue.
         """
 
         self._start_dispatch_threads()

--- a/tensorrt_llm/executor/proxy.py
+++ b/tensorrt_llm/executor/proxy.py
@@ -167,6 +167,32 @@ class GenerationExecutorProxy(GenerationExecutor):
             name="proxy_error_monitor")
         self._error_monitor_thread.start()
 
+        # Single-thread executor that owns *all* profile-control IPC traffic
+        # (``request_queue.put`` for StartProfile/StopProfile and
+        # ``profile_ack_queue.get`` for the matching ack). Pinning these
+        # ZMQ socket operations to one owning thread is required because:
+        #
+        #   * pyzmq sockets are not thread-safe; concurrent access from
+        #     multiple threads — even one writer + one reader — is undefined
+        #     behavior in libzmq.
+        #   * The HTTP handler reaches us through ``asyncio.to_thread``,
+        #     which does not pin to the same worker thread between calls,
+        #     so back-to-back ``/start_profile`` and ``/stop_profile``
+        #     could otherwise touch ``profile_ack_queue`` from two
+        #     different threads.
+        #
+        # The HTTP handler still blocks on a Future returned by this
+        # executor, so the synchronous "chrome trace is on disk by the
+        # time /stop_profile returns 200" contract is preserved without
+        # any ZMQ socket op leaking into the FastAPI thread pool.
+        #
+        # NOTE: ``request_queue`` is also written from ``submit()`` /
+        # ``abort_request()`` on user-caller threads — that pre-existing
+        # cross-thread access is out of scope for this change. The fix
+        # here narrowly targets the new profile-control path.
+        self._profile_control_executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="proxy_profile_control")
+
         # MPI registers its joiner using threading._register_atexit if possible.
         # These functions run before atexit.register, so to avoid deadlock,
         # we have to notify workers to exit before MPI starts to wait them.
@@ -385,6 +411,16 @@ class GenerationExecutorProxy(GenerationExecutor):
                 raise RuntimeError(error_msg)
             return
 
+    def _profile_control_call(self, kind: str, request, timeout: float) -> None:
+        """Worker-side body of ``start_profile`` / ``stop_profile``.
+
+        Runs on ``_profile_control_executor`` so all profile-related
+        ZMQ socket ops (``request_queue.put`` and ``profile_ack_queue.get``
+        via ``_wait_profile_ack``) happen on a single owning thread.
+        """
+        self.request_queue.put(request)
+        self._wait_profile_ack(kind, timeout)
+
     def start_profile(self,
                       output_dir=None,
                       num_steps=None,
@@ -396,13 +432,23 @@ class GenerationExecutorProxy(GenerationExecutor):
         raises ``RuntimeError`` if ``PyExecutor`` rejected the start
         (e.g. a profile window is already active or pending) so the
         HTTP /start_profile endpoint can return 409.
+
+        The actual ZMQ traffic (``request_queue.put`` +
+        ``profile_ack_queue.get``) is dispatched onto
+        ``_profile_control_executor`` — a single-thread executor — so the
+        FastAPI thread-pool worker that called us never touches the
+        ZMQ sockets directly. ``Future.result()`` re-raises any
+        ``RuntimeError`` from ``_wait_profile_ack`` so the HTTP layer
+        still sees worker rejections.
         """
-        self.request_queue.put(
-            StartProfileRequest(output_dir=output_dir,
-                                num_steps=num_steps,
-                                start_step=start_step,
-                                activities=activities))
-        self._wait_profile_ack("start", self._START_PROFILE_ACK_TIMEOUT_S)
+        request = StartProfileRequest(output_dir=output_dir,
+                                      num_steps=num_steps,
+                                      start_step=start_step,
+                                      activities=activities)
+        future = self._profile_control_executor.submit(
+            self._profile_control_call, "start", request,
+            self._START_PROFILE_ACK_TIMEOUT_S)
+        future.result()
 
     def stop_profile(self) -> None:
         """Forward runtime profiling stop to the IPC worker process.
@@ -412,9 +458,15 @@ class GenerationExecutorProxy(GenerationExecutor):
         RPC-proxy paths: by the time this method returns the trace
         file is on disk, so HTTP callers can reliably read it
         immediately after /stop_profile returns 200.
+
+        Like ``start_profile``, the actual ZMQ traffic is dispatched
+        onto ``_profile_control_executor`` so the calling thread never
+        touches the ZMQ sockets.
         """
-        self.request_queue.put(StopProfileRequest())
-        self._wait_profile_ack("stop", self._STOP_PROFILE_ACK_TIMEOUT_S)
+        future = self._profile_control_executor.submit(
+            self._profile_control_call, "stop", StopProfileRequest(),
+            self._STOP_PROFILE_ACK_TIMEOUT_S)
+        future.result()
 
     def dispatch_result_task(self) -> bool:
         # TODO[chunweiy]: convert the dispatch_result_task to async, that should
@@ -615,6 +667,16 @@ class GenerationExecutorProxy(GenerationExecutor):
             self.dispatch_result_thread.stop()
             self.dispatch_result_thread.join()
 
+        # Drain the profile-control executor before closing its sockets.
+        # ``shutdown(wait=True)`` blocks until any in-flight
+        # start_profile/stop_profile call has finished its
+        # ``_wait_profile_ack`` round-trip on the owner thread, so we
+        # don't tear ``profile_ack_queue`` out from under it.
+        if hasattr(self, '_profile_control_executor'
+                   ) and self._profile_control_executor is not None:
+            self._profile_control_executor.shutdown(wait=True)
+            self._profile_control_executor = None
+
         # step3: finish all remaining work
 
         # close the RPC client
@@ -628,6 +690,9 @@ class GenerationExecutorProxy(GenerationExecutor):
         self.result_queue.close()
         if self._resource_governor_queue is not None:
             self._resource_governor_queue.close()
+        # ``profile_ack_queue`` is only torn down here because the
+        # owning ``_profile_control_executor`` was just drained above.
+        self.profile_ack_queue.close()
 
         self.workers_started = False
         self.mpi_session.shutdown()

--- a/tensorrt_llm/executor/ray_gpu_worker.py
+++ b/tensorrt_llm/executor/ray_gpu_worker.py
@@ -179,6 +179,18 @@ class RayWorkerWrapper:
         id_mapping = list(map(int, visible_devices.split(",")))
         return id_mapping.index(phys_id)
 
+    # Methods that a user-supplied WorkerExtension is explicitly allowed
+    # to override on the worker class. These are designated extension
+    # points: their BaseWorker implementations forward to the engine and
+    # the extension's override is expected to win for Ray deployments
+    # (e.g. RL workflows using torch.cuda.profiler directly). When one of
+    # these names collides, the extension's method is copied into the
+    # derived class dict so MRO resolves to it regardless of base order.
+    _EXTENSION_OVERRIDABLE_METHODS = frozenset({
+        "start_profile",
+        "stop_profile",
+    })
+
     @staticmethod
     def _inject_worker_extension(
             worker_class: Type[BaseWorker],
@@ -194,9 +206,27 @@ class RayWorkerWrapper:
                 f"Failed to load worker extension '{extension_cls_name}'"
             ) from e
 
+        # Derived-class overrides: for explicitly overridable method
+        # names (see _EXTENSION_OVERRIDABLE_METHODS), copy the extension
+        # method into the derived class dict so it wins over the base
+        # worker's implementation regardless of MRO order.
+        derived_attrs = {'__module__': worker_class.__module__}
+        overridable = RayWorkerWrapper._EXTENSION_OVERRIDABLE_METHODS
+
         # Check for conflicts
         for attr in dir(extension_cls):
             if attr.startswith("__"):
+                continue
+            if attr in overridable:
+                # Extension is allowed to override; copy its attribute
+                # directly so MRO resolves to the extension version.
+                ext_attr = extension_cls.__dict__.get(attr)
+                if ext_attr is None:
+                    # Inherited from a base of extension_cls; fall back
+                    # to getattr which still returns the extension-side
+                    # implementation.
+                    ext_attr = getattr(extension_cls, attr)
+                derived_attrs[attr] = ext_attr
                 continue
             if hasattr(worker_class, attr):
                 raise ValueError(
@@ -205,7 +235,7 @@ class RayWorkerWrapper:
 
         derived_name = f"{worker_class.__name__}With{extension_cls.__name__}"
         ExtendedWorker = type(derived_name, (worker_class, extension_cls),
-                              {'__module__': worker_class.__module__})
+                              derived_attrs)
         return ExtendedWorker
 
 

--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -266,7 +266,33 @@ class TruncateKVCacheRequest:
 
 
 class CancellingRequest:
-    ''' The request to cancel a generation. '''
+    """The request to cancel a generation."""
 
     def __init__(self, id: int):
         self.id = id
+
+
+class StartProfileRequest:
+    """Request the IPC worker to start runtime profiling.
+
+    Carries the same arguments as ``LLM.start_profile`` / the HTTP
+    ``/start_profile`` endpoint so the worker can forward them to
+    ``PyExecutor.start_profile``.
+    """
+
+    def __init__(self,
+                 output_dir=None,
+                 num_steps=None,
+                 start_step: int = 0,
+                 activities=None):
+        self.output_dir = output_dir
+        self.num_steps = num_steps
+        self.start_step = start_step
+        self.activities = activities
+
+
+class StopProfileRequest:
+    """Request the IPC worker to stop runtime profiling."""
+
+    def __init__(self):
+        pass

--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -22,6 +22,8 @@ __all__ = [
     "GenerationRequest",
     "TruncateKVCacheRequest",
     "CancellingRequest",
+    "StartProfileRequest",
+    "StopProfileRequest",
 ]
 
 # Mirrors C++ executor.h Request::kDefaultPriority

--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -256,6 +256,20 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
     def abort_request(self, request_id: int) -> None:
         return self.rpc_client.abort_request(request_id).remote()
 
+    def start_profile(self,
+                      output_dir=None,
+                      num_steps=None,
+                      start_step: int = 0,
+                      activities=None) -> None:
+        return self.rpc_client.start_profile(
+            output_dir=output_dir,
+            num_steps=num_steps,
+            start_step=start_step,
+            activities=activities).remote(need_response=True)
+
+    def stop_profile(self) -> None:
+        return self.rpc_client.stop_profile().remote(need_response=True)
+
     def shutdown(self):
         if self._shutdown_event.is_set():
             return

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -154,6 +154,13 @@ class WorkerCommIpcAddrs(NamedTuple):
     worker_init_status_queue_addr: tuple[str, Optional[bytes]]
     result_queue_addr: tuple[str, Optional[bytes]]
     resource_governor_queue_addr: Optional[tuple[str, Optional[bytes]]] = None
+    # Worker -> proxy ack channel for synchronous control requests
+    # (currently: StartProfileRequest, StopProfileRequest). Lets the
+    # HTTP /start_profile and /stop_profile handlers wait for the worker
+    # to actually finish processing the request before returning, so the
+    # documented "trace is on disk by the time /stop_profile returns
+    # 200" contract holds in the IPC-proxy deployment too.
+    profile_ack_queue_addr: Optional[tuple[str, Optional[bytes]]] = None
 
 
 def is_llm_response(instance):

--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -24,7 +24,8 @@ from .base_worker import BaseWorker, _init_hf_modules
 from .ipc import FusedIpcQueue, IpcQueue
 from .postproc_worker import (PostprocWorker, PostprocWorkerConfig,
                               postproc_worker_main)
-from .request import CancellingRequest, GenerationRequest
+from .request import (CancellingRequest, GenerationRequest, StartProfileRequest,
+                      StopProfileRequest)
 from .rpc_worker_mixin import RpcWorkerMixin
 from .utils import (ErrorResponse, IntraProcessQueue, RequestError,
                     WorkerCommIpcAddrs)
@@ -250,6 +251,14 @@ def worker_main(
             is_server=False,
             name="worker_resource_governor_queue"
         ) if worker_queues.resource_governor_queue_addr else None
+        # Synchronous ack channel back to the proxy for control requests
+        # (start_profile / stop_profile). Created on the proxy side; the
+        # leader is the sole producer.
+        profile_ack_queue = IpcQueue(
+            worker_queues.profile_ack_queue_addr,
+            is_server=False,
+            name="worker_profile_ack_queue"
+        ) if worker_queues.profile_ack_queue_addr else None
 
         if postproc_worker_config.enabled:
             # IPC queues for sending inputs to the postprocess parallel
@@ -366,6 +375,39 @@ def worker_main(
                 while (req := request_queue.get()) is not None:
                     if isinstance(req, CancellingRequest):
                         worker.abort_request(req.id)
+                    elif isinstance(req, StartProfileRequest):
+                        # ``PyExecutor.start_profile`` raises
+                        # ``RequestError`` on the double-start path.
+                        # Capture it and propagate back to the proxy via
+                        # ``profile_ack_queue`` so the HTTP /start_profile
+                        # handler can return 409 in the IPC-proxy
+                        # deployment too.
+                        ack_err: Optional[str] = None
+                        try:
+                            worker.start_profile(output_dir=req.output_dir,
+                                                 num_steps=req.num_steps,
+                                                 start_step=req.start_step,
+                                                 activities=req.activities)
+                        except RequestError as e:
+                            logger.warning(f"start_profile rejected: {e}")
+                            ack_err = str(e)
+                        if profile_ack_queue is not None:
+                            profile_ack_queue.put(("start", ack_err))
+                    elif isinstance(req, StopProfileRequest):
+                        # ``worker.stop_profile`` blocks until
+                        # ``PyExecutor.stop_profile`` has actually fired
+                        # the in-loop stop and exported the chrome trace
+                        # (or its 30s timeout elapsed). Acking only after
+                        # that return is what gives the proxy its
+                        # synchronous "trace is on disk" guarantee.
+                        ack_err = None
+                        try:
+                            worker.stop_profile()
+                        except RequestError as e:
+                            logger.warning(f"stop_profile rejected: {e}")
+                            ack_err = str(e)
+                        if profile_ack_queue is not None:
+                            profile_ack_queue.put(("stop", ack_err))
                     elif isinstance(req, GenerationRequest):
                         try:
                             worker.submit(req)

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -1489,6 +1489,57 @@ class BaseLLM:
         return ModelLoader.load_hf_model_config(
             self.args.model, trust_remote_code=self.args.trust_remote_code)
 
+    @set_api_status("prototype")
+    def start_profile(self,
+                      output_dir: Optional[str] = None,
+                      num_steps: Optional[int] = None,
+                      start_step: int = 0,
+                      activities: Optional[List[str]] = None) -> None:
+        """Start iteration-scoped profiling of the backend engine.
+
+        Mirrors the ``TLLM_PROFILE_START_STOP`` / ``TLLM_TORCH_PROFILE_TRACE``
+        environment-variable behaviour but can be triggered at runtime (for
+        example via the ``trtllm-serve`` ``/start_profile`` HTTP endpoint).
+        Only supported when running the PyTorch / AutoDeploy backend; on the
+        TensorRT backend this is a no-op.
+
+        See ``PyExecutor.start_profile`` for full argument semantics.
+
+        Args:
+            output_dir (str, optional): Directory where chrome traces are
+                written. If ``None``, falls back to the
+                ``TLLM_TORCH_PROFILER_DIR`` environment variable and finally
+                to ``/tmp``. Defaults to None.
+            num_steps (int, optional): Number of engine iterations to
+                capture. When set, the engine stops the window automatically
+                and ``stop_profile`` does not need to be called. When
+                ``None``, profiling runs until ``stop_profile`` is called.
+                Defaults to None.
+            start_step (int): Additional iterations to skip before profiling actually begins, relative to the current iteration counter. Defaults to 0.
+            activities (List[str], optional): Subset of
+                ``["CPU", "GPU", "CUDA_PROFILER"]`` selecting which profiler
+                activities to record. When ``CUDA_PROFILER`` is the only
+                entry, ``torch.profiler`` is not started so only
+                ``cudaProfilerStart``/``cudaProfilerStop`` brackets run,
+                which is suitable for nsys capture. Defaults to None, which
+                resolves to ``["CPU", "GPU"]``.
+        """
+        if not hasattr(self, "_executor") or self._executor is None:
+            raise RuntimeError(
+                "LLM executor is not initialized; cannot start profiling.")
+        return self._executor.start_profile(output_dir=output_dir,
+                                            num_steps=num_steps,
+                                            start_step=start_step,
+                                            activities=activities)
+
+    @set_api_status("prototype")
+    def stop_profile(self) -> None:
+        """Stop any in-progress runtime profiling."""
+        if not hasattr(self, "_executor") or self._executor is None:
+            raise RuntimeError(
+                "LLM executor is not initialized; cannot stop profiling.")
+        return self._executor.stop_profile()
+
     @set_api_status("beta")
     def shutdown(self) -> None:
         if hasattr(self, "_executor") and self._executor is not None:

--- a/tensorrt_llm/serve/openai_disagg_server.py
+++ b/tensorrt_llm/serve/openai_disagg_server.py
@@ -73,6 +73,33 @@ _LOG_CONTROL_CHARACTERS = {
     for code in (*range(32), 127)
 }
 
+# Most round trips to spend estimating one ctx/gen server's steady-clock
+# offset. Only the least-delayed sample is kept; see `_sync_server_clock`.
+# Each probe costs ~0.2 s because the `/steady_clock_offset` handler sleeps
+# between its two timestamps, and servers are prepared sequentially, so the
+# loop stops early (below) instead of always spending the full budget.
+_CLOCK_SYNC_PROBES = 5
+
+# A round trip this fast is already conclusive -- its offset estimate is
+# accurate to +/- 2.5 ms -- so stop probing. This is the common case on a
+# healthy server, keeping the added startup cost to one extra round trip.
+_CLOCK_SYNC_GOOD_DELAY_SECONDS = 0.005
+
+# Per-request timeout for the handshake, and a wall-clock budget for the whole
+# probe loop. Servers are prepared one at a time, so an unresponsive worker must
+# not be able to stall startup for `_req_timeout_secs` once per probe. A healthy
+# handshake takes ~0.2 s per round trip.
+_CLOCK_SYNC_REQUEST_TIMEOUT_SECONDS = 10.0
+_CLOCK_SYNC_TOTAL_BUDGET_SECONDS = 15.0
+
+# Largest round-trip delay for which the estimated offset is still worth
+# applying. The NTP estimate is only accurate to +/- delay/2, so this caps the
+# error the handshake can inject into perf-metric timestamps at 5 ms. Co-located
+# servers share CLOCK_MONOTONIC (true offset exactly 0) and NTP-synced hosts are
+# aligned to well under a millisecond, so discarding a noisier estimate is
+# strictly better than applying it.
+_CLOCK_SYNC_MAX_DELAY_SECONDS = 0.010
+
 class RawRequestResponseHooks(ResponseHooks):
     def __init__(self, raw_req: Request, queue_latency_metric,
                  collect_perf_metrics: bool):
@@ -517,7 +544,30 @@ class OpenAIDisaggServer:
         await create_uvicorn_server(config).serve(sockets=sockets)
 
     async def _sync_server_clock(self, server: str):
-        """ Sync the ctx/gen server's steady clock with the disagg-server's steady clock (in case NTP service is not running). """
+        """ Sync the ctx/gen server's steady clock with the disagg-server's steady clock (in case NTP service is not running).
+
+        The offset is estimated with the NTP algorithm from an HTTP round trip,
+        so its error is bounded by half the round-trip delay: a round trip whose
+        two legs are asymmetric is indistinguishable from a clock offset. The
+        handshake runs while the ctx/gen servers are still finishing startup, so
+        a single sample regularly lands on a stalled event loop and yields tens
+        of milliseconds of pure error, which is then baked into every perf-metric
+        timestamp those servers report.
+
+        Two mitigations, both standard NTP practice:
+
+        * Probe ``_CLOCK_SYNC_PROBES`` times and keep the sample with the
+          smallest delay (NTP's clock filter). The least-delayed round trip is
+          the most symmetric one, so it carries the least error. A throwaway
+          warm-up request first keeps DNS resolution and connection setup --
+          which are paid entirely on the outbound leg -- out of the samples.
+        * Skip the adjustment entirely when even the best sample is delayed by
+          more than ``_CLOCK_SYNC_MAX_DELAY_SECONDS``. Past that point the
+          estimate is worth less than the zero it would replace: co-located
+          servers share CLOCK_MONOTONIC and are already exactly aligned, and a
+          cross-host deployment running NTP is aligned to well under a
+          millisecond.
+        """
         async def query_steady_clock_offset(session: aiohttp.ClientSession, server_url: str) -> tuple[Optional[float], Optional[float]]:
             try:
                 originate_ts = get_steady_clock_now_in_seconds()
@@ -543,11 +593,44 @@ class OpenAIDisaggServer:
                     logger.warning(f"Cannot set disagg server steady clock offset for server {server_url}, the perf metrics timestamps could be mis-aligned")
 
         async def align_steady_clock_offset(session: aiohttp.ClientSession, server_url: str) -> None:
-            delay, offset = await query_steady_clock_offset(session, server_url)
-            if delay is None or offset is None:
+            # Warm-up probe: DNS resolution and connection setup are paid on the
+            # outbound leg only, so folding them into a measured sample biases
+            # the offset by half their cost. Its result is deliberately dropped.
+            await query_steady_clock_offset(session, server_url)
+
+            # NTP clock filter: keep the least-delayed round trip, since it is
+            # the most symmetric one and hence carries the least error. Stop as
+            # soon as a sample is conclusive so a healthy server costs one probe.
+            best = None
+            probes = 0
+            deadline = get_steady_clock_now_in_seconds() + _CLOCK_SYNC_TOTAL_BUDGET_SECONDS
+            for _ in range(_CLOCK_SYNC_PROBES):
+                probes += 1
+                sample = await query_steady_clock_offset(session, server_url)
+                if sample[0] is None or sample[1] is None:
+                    # The server is unreachable or erroring; retrying it four
+                    # more times only delays startup for every later server.
+                    break
+                if best is None or sample[0] < best[0]:
+                    best = sample
+                if best[0] <= _CLOCK_SYNC_GOOD_DELAY_SECONDS:
+                    break
+                if get_steady_clock_now_in_seconds() >= deadline:
+                    break
+            if best is None:
                 logger.warning(f"Unable to measure steady clock offset for {server_url}; skipping adjustment")
                 return
-            logger.info(f'Server: {server_url}, delay: {delay} second, offset: {offset} second')
+
+            delay, offset = best
+            logger.info(f'Server: {server_url}, delay: {delay} second, offset: {offset} second '
+                        f'(best of {probes} probes)')
+            if delay > _CLOCK_SYNC_MAX_DELAY_SECONDS:
+                logger.warning(
+                    f"Steady clock handshake with {server_url} was too slow to be conclusive "
+                    f"(best round-trip delay {delay * 1e3:.1f} ms > {_CLOCK_SYNC_MAX_DELAY_SECONDS * 1e3:.1f} ms); "
+                    f"the offset estimate is only accurate to +/-{delay / 2 * 1e3:.1f} ms, so it is discarded "
+                    "rather than applied. Perf-metric timestamps stay on each server's own steady clock.")
+                return
             # Negate the offset so that worker servers can adjust their steady clock by adding the new offset
             await set_steady_clock_offset(session, server_url, -offset)
 
@@ -557,7 +640,9 @@ class OpenAIDisaggServer:
         try:
             async with aiohttp.ClientSession(
                 connector=aiohttp.TCPConnector(limit=0, limit_per_host=0, force_close=True),
-                timeout=aiohttp.ClientTimeout(total=self._req_timeout_secs)) as session:
+                timeout=aiohttp.ClientTimeout(total=min(
+                    self._req_timeout_secs,
+                    _CLOCK_SYNC_REQUEST_TIMEOUT_SECONDS))) as session:
                 await align_steady_clock_offset(session, server_url)
         except (aiohttp.ClientError, OSError) as e:
             logger.warning(f"Unable to align steady clock offset for {server_url}: {e}; skipping adjustment")

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -32,8 +32,8 @@ from openai.types.responses.response import ToolChoice
 from openai.types.responses.tool import Tool
 from openai.types.shared import Metadata, Reasoning
 from openai_harmony import ReasoningEffort
-from pydantic import (BaseModel, ConfigDict, Field, field_validator,
-                      model_validator)
+from pydantic import (BaseModel, ConfigDict, Field, NonNegativeInt, PositiveInt,
+                      field_validator, model_validator)
 from typing_extensions import Annotated, Required, TypeAlias, TypedDict
 
 from tensorrt_llm.executor.request import LoRARequest
@@ -1638,6 +1638,8 @@ class VideoJobList(OpenAIBaseModel):
 UCompletionRequest = Union[CompletionRequest, ChatCompletionRequest]
 UCompletionResponse = Union[CompletionResponse, ChatCompletionResponse]
 
+ProfileActivity = Literal["CPU", "GPU", "CUDA_PROFILER"]
+
 
 class StartProfileRequest(OpenAIBaseModel):
     """Request body for the POST /start_profile endpoint."""
@@ -1646,14 +1648,20 @@ class StartProfileRequest(OpenAIBaseModel):
         description="Directory where chrome traces are written. Defaults "
         "to the TLLM_TORCH_PROFILER_DIR environment variable, "
         "then /tmp.")
-    num_steps: Optional[int] = Field(
+    num_steps: Optional[PositiveInt] = Field(
         default=None,
-        description="Number of iterations to profile. If omitted, "
-        "profiling runs until /stop_profile is called.")
-    start_step: int = Field(
+        description="Number of iterations to profile. Must be >= 1 if "
+        "provided; if omitted, profiling runs until /stop_profile is "
+        "called. ``num_steps == 0`` is rejected because the profile "
+        "window would never close — the stop iteration would equal the "
+        "start iteration, profile_step() would discard the stop marker "
+        "as stale, and the window would run forever.")
+    start_step: NonNegativeInt = Field(
         default=0,
-        description="Skip this many iterations before profiling begins.")
-    activities: List[str] = Field(
+        description="Skip this many iterations before profiling begins. "
+        "Must be >= 0.")
+    activities: List[ProfileActivity] = Field(
         default_factory=lambda: ["CPU", "GPU"],
         description="Which activities to trace. Supported values: "
-        "'CPU', 'GPU', 'CUDA_PROFILER'.")
+        "'CPU', 'GPU', 'CUDA_PROFILER'. Unknown values are rejected at "
+        "schema validation time.")

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -1637,3 +1637,23 @@ class VideoJobList(OpenAIBaseModel):
 
 UCompletionRequest = Union[CompletionRequest, ChatCompletionRequest]
 UCompletionResponse = Union[CompletionResponse, ChatCompletionResponse]
+
+
+class StartProfileRequest(OpenAIBaseModel):
+    """Request body for the POST /start_profile endpoint."""
+    output_dir: Optional[str] = Field(
+        default=None,
+        description="Directory where chrome traces are written. Defaults "
+        "to the TLLM_TORCH_PROFILER_DIR environment variable, "
+        "then /tmp.")
+    num_steps: Optional[int] = Field(
+        default=None,
+        description="Number of iterations to profile. If omitted, "
+        "profiling runs until /stop_profile is called.")
+    start_step: int = Field(
+        default=0,
+        description="Skip this many iterations before profiling begins.")
+    activities: List[str] = Field(
+        default_factory=lambda: ["CPU", "GPU"],
+        description="Which activities to trace. Supported values: "
+        "'CPU', 'GPU', 'CUDA_PROFILER'.")

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -67,7 +67,7 @@ from tensorrt_llm.serve.openai_protocol import (
     CompletionResponseChoice, ErrorResponse, ImageGenerationRequest,
     ImageGenerationResponse, ImageObject, MemoryUpdateRequest, ModelCard,
     ModelList, PromptTokensDetails, ResponseFormat, ResponsesRequest,
-    ResponsesResponse, UpdateWeightsRequest, UsageInfo,
+    ResponsesResponse, StartProfileRequest, UpdateWeightsRequest, UsageInfo,
     ensure_request_chat_template_allowed, to_llm_conversation_params,
     to_llm_disaggregated_params)
 from tensorrt_llm.serve.openai_video_routes import _VideoRoutesMixin
@@ -774,6 +774,14 @@ class OpenAIServer(_VideoRoutesMixin):
         self.app.add_api_route('/v1/responses/{response_id}',
                                self.openai_responses_delete_response,
                                methods=["DELETE"])
+
+        # Profiling endpoints (PyTorch backend only)
+        self.app.add_api_route("/start_profile",
+                               self.start_profile,
+                               methods=["POST"])
+        self.app.add_api_route("/stop_profile",
+                               self.stop_profile,
+                               methods=["POST"])
 
         # RL-only endpoints
         self.app.add_api_route("/release_memory",
@@ -2063,6 +2071,92 @@ class OpenAIServer(_VideoRoutesMixin):
             "object": "response",
             "deleted": True
         })
+
+    async def start_profile(
+            self,
+            request: Optional[StartProfileRequest] = None) -> JSONResponse:
+        """Start runtime profiling in the backend engine.
+
+        Request body (all optional): ``output_dir``, ``num_steps``,
+        ``start_step``, ``activities``. See ``StartProfileRequest`` for
+        descriptions.
+
+        The backend ``PyExecutor.start_profile`` schedules the profile
+        window and the broadcasted ``PROFILE_START_REQUEST_ID`` queue
+        item wakes the executor loop, so no tickle-via-generation is
+        needed on this side — the captured chrome trace stays free of
+        synthetic single-token forward passes.
+
+        The underlying ``GenerationExecutor.start_profile`` call may
+        block (it waits for the worker subprocess to ack on the
+        IPC-proxy path, up to ~60s). We run it on a worker thread via
+        ``asyncio.to_thread`` so the FastAPI event loop stays
+        responsive to other endpoints during that wait.
+        """
+        if request is None:
+            request = StartProfileRequest()
+        try:
+            await asyncio.to_thread(
+                self.generator.start_profile,
+                output_dir=request.output_dir,
+                num_steps=request.num_steps,
+                start_step=request.start_step,
+                activities=request.activities,
+            )
+        except RuntimeError as e:
+            # ``PyExecutor.start_profile`` raises RuntimeError when a
+            # profile window is already active or pending. Surface this
+            # to the caller as 409 so they can distinguish it from a
+            # generic backend failure (which keeps 500).
+            msg = str(e)
+            if "already in progress" in msg or "pending" in msg:
+                logger.info(f"/start_profile rejected: {msg}")
+                return JSONResponse(
+                    content={
+                        "success": False,
+                        "message": msg
+                    },
+                    status_code=409,
+                )
+            logger.error(f"/start_profile failed: {e}")
+            return JSONResponse(content={
+                "success": False,
+                "message": msg
+            },
+                                status_code=500)
+        except Exception as e:
+            logger.error(f"/start_profile failed: {e}")
+            return JSONResponse(content={
+                "success": False,
+                "message": str(e)
+            },
+                                status_code=500)
+
+        return JSONResponse(content={"message": "Profiling started"})
+
+    async def stop_profile(self) -> JSONResponse:
+        """Stop any in-progress runtime profiling and flush traces.
+
+        The backend ``PyExecutor.stop_profile`` schedules the stop and
+        the broadcasted ``PROFILE_STOP_REQUEST_ID`` queue item wakes the
+        executor loop. The call blocks until ``profile_step()`` has
+        actually fired the stop, so by the time this handler returns 200
+        the chrome trace is on disk. No synthetic ``generate_async([0])``
+        tickle is submitted, so the captured trace is free of HTTP-layer
+        events.
+
+        The wait can take up to ~35s on the IPC-proxy path. We run the
+        blocking call on a worker thread via ``asyncio.to_thread`` so
+        the FastAPI event loop stays responsive to other endpoints
+        (notably ``/health`` for liveness checks) during the flush.
+        """
+        try:
+            await asyncio.to_thread(self.generator.stop_profile)
+        except Exception as e:
+            logger.error(f"/stop_profile failed: {e}")
+            return JSONResponse(content={"error": str(e)}, status_code=500)
+
+        return JSONResponse(content={"message": "Profiling stopped"})
 
     async def release_memory(self,
                              request: MemoryUpdateRequest) -> JSONResponse:

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -2119,18 +2119,28 @@ class OpenAIServer(_VideoRoutesMixin):
                     status_code=409,
                 )
             logger.error(f"/start_profile failed: {e}")
-            return JSONResponse(content={
-                "success": False,
-                "message": msg
-            },
-                                status_code=500)
-        except Exception as e:
+            return JSONResponse(
+                content={
+                    "success": False,
+                    "message": msg,
+                },
+                status_code=500,
+            )
+        except (OSError, ValueError, TimeoutError) as e:
+            # OSError: filesystem/IPC failures while preparing the
+            # profile window. ValueError: schema-level rejections that
+            # slipped past Pydantic. TimeoutError: ack-queue wait gave
+            # up. Anything truly unexpected is allowed to propagate to
+            # FastAPI's middleware so we get a real stack trace in the
+            # server log instead of swallowing it as a generic 500.
             logger.error(f"/start_profile failed: {e}")
-            return JSONResponse(content={
-                "success": False,
-                "message": str(e)
-            },
-                                status_code=500)
+            return JSONResponse(
+                content={
+                    "success": False,
+                    "message": str(e),
+                },
+                status_code=500,
+            )
 
         return JSONResponse(content={"message": "Profiling started"})
 
@@ -2152,7 +2162,12 @@ class OpenAIServer(_VideoRoutesMixin):
         """
         try:
             await asyncio.to_thread(self.generator.stop_profile)
-        except Exception as e:
+        except (RuntimeError, OSError, TimeoutError) as e:
+            # RuntimeError: backend rejected the stop or broadcast
+            # enqueue failed. OSError: filesystem error flushing the
+            # trace. TimeoutError: ack-queue wait gave up. Truly
+            # unexpected exceptions propagate to FastAPI so they show
+            # up as a real stack trace rather than a swallowed 500.
             logger.error(f"/stop_profile failed: {e}")
             return JSONResponse(content={"error": str(e)}, status_code=500)
 

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -2111,21 +2111,17 @@ class OpenAIServer(_VideoRoutesMixin):
             msg = str(e)
             if "already in progress" in msg or "pending" in msg:
                 logger.info(f"/start_profile rejected: {msg}")
-                return JSONResponse(
-                    content={
-                        "success": False,
-                        "message": msg
-                    },
-                    status_code=409,
-                )
-            logger.error(f"/start_profile failed: {e}")
-            return JSONResponse(
-                content={
+                return JSONResponse(content={
                     "success": False,
-                    "message": msg,
+                    "message": msg
                 },
-                status_code=500,
-            )
+                                    status_code=409)
+            logger.error(f"/start_profile failed: {e}")
+            return JSONResponse(content={
+                "success": False,
+                "message": msg
+            },
+                                status_code=500)
         except (OSError, ValueError, TimeoutError) as e:
             # OSError: filesystem/IPC failures while preparing the
             # profile window. ValueError: schema-level rejections that
@@ -2134,13 +2130,11 @@ class OpenAIServer(_VideoRoutesMixin):
             # FastAPI's middleware so we get a real stack trace in the
             # server log instead of swallowing it as a generic 500.
             logger.error(f"/start_profile failed: {e}")
-            return JSONResponse(
-                content={
-                    "success": False,
-                    "message": str(e),
-                },
-                status_code=500,
-            )
+            return JSONResponse(content={
+                "success": False,
+                "message": str(e)
+            },
+                                status_code=500)
 
         return JSONResponse(content={"message": "Profiling started"})
 

--- a/tests/integration/defs/test_e2e.py
+++ b/tests/integration/defs/test_e2e.py
@@ -866,6 +866,25 @@ def test_openai_kv_cache_contamination(llm_root, llm_venv):
     ])
 
 
+def test_trtllm_serve_profile_example(llm_root, llm_venv):
+    """Wrapper for the CPU-only profile-endpoint smoke tests.
+
+    Runs ``tests/unittest/llmapi/apps/_test_trtllm_serve_profile.py``
+    which binds the ``OpenAIServer.start_profile`` / ``stop_profile``
+    handlers to a mock generator (no GPU, no model) and verifies
+    request parsing, default values, and the asyncio.to_thread
+    event-loop guarantee. Following the existing apps/ wrapper
+    pattern so the file is discovered via
+    ``test_e2e.py::test_trtllm_serve_profile_example`` rather than a
+    direct ``unittest/llmapi/apps/_test_*.py`` entry in the test-db
+    YAML.
+    """
+    test_root = unittest_path() / "llmapi" / "apps"
+    llm_venv.run_cmd(
+        ["-m", "pytest",
+         str(test_root / "_test_trtllm_serve_profile.py")])
+
+
 @pytest.mark.parametrize("backend", ["pytorch", "trt"])
 def test_openai_completions_example(llm_root, llm_venv, backend: str):
     test_root = unittest_path() / "llmapi" / "apps"

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -42,6 +42,7 @@ l0_a10:
   - unittest/_torch/modules/dwdp/test_dwdp_manager.py
   - unittest/_torch/modules/dwdp/test_dwdp_mapping.py
   - unittest/_torch/modules/dwdp/test_dwdp_peer_ranges.py
+  - unittest/_torch/executor/test_profile_endpoints.py
   # NOTE: this is a CPU-only test, but we do not have a dedicated job for this (and therefore no
   # test list either).
   - unittest/_torch/models/checkpoints
@@ -108,6 +109,7 @@ l0_a10:
   # test_openai_lora and test_trtllm_serve_lora_example moved to l0_a100.yml
   # (Llama-7B + KV cache + spec resources exceeds A10's 22 GB).
   - test_e2e.py::test_trtllm_serve_multimodal_example
+  - test_e2e.py::test_trtllm_serve_profile_example
   - test_e2e.py::test_trtllm_serve_top_logprobs[pytorch]
   - test_e2e.py::test_openai_misc_example[pytorch]
   - test_e2e.py::test_openai_reasoning[pytorch]
@@ -143,6 +145,7 @@ l0_a10:
   - unittest/executor/test_fatal_error_health_check.py
   - unittest/executor/test_postprocessor_hook.py
   - unittest/executor/test_proxy_postproc_terminate.py
+  - unittest/executor/test_proxy_profile_sync.py
   # trtllm-serve CPU-only
   - unittest/llmapi/apps/test_chat_utils.py
   - unittest/llmapi/apps/test_tool_parsers.py

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -59,6 +59,7 @@ l0_a10:
   - unittest/disaggregated/test_bounce.py
   - unittest/disaggregated/test_mamba_transfer.py
   - unittest/disaggregated/test_msgspec_route.py
+  - unittest/disaggregated/test_steady_clock_sync.py
   # unittest/tools is listed per file rather than as a directory. The directory
   # form swept test_layer_wise_benchmarks.py onto A10, whose DeepSeek FP4 cases
   # pin SM100+ checkpoints -- that is https://nvbugs/6337228.

--- a/tests/unittest/_torch/executor/test_profile_endpoints.py
+++ b/tests/unittest/_torch/executor/test_profile_endpoints.py
@@ -22,6 +22,7 @@ or an MPI/RPC environment.
 
 import threading
 
+from tensorrt_llm._torch.pyexecutor.profiling import PyExecutorProfileManager
 from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
 
 
@@ -40,6 +41,11 @@ def _bare_executor():
     executor._runtime_profile_pending_stop_iter = None
     executor._profile_state_lock = threading.Lock()
     executor._profile_enabled = False
+    # The profile-state machine lives in PyExecutorProfileManager. The
+    # real PyExecutor.__init__ wires this up; replicate that here for
+    # the bare-bones test double so ``executor.start_profile``,
+    # ``executor.stop_profile``, etc. delegate correctly.
+    executor._profile_manager = PyExecutorProfileManager(executor)
     return executor
 
 

--- a/tests/unittest/_torch/executor/test_profile_endpoints.py
+++ b/tests/unittest/_torch/executor/test_profile_endpoints.py
@@ -103,7 +103,7 @@ def test_apply_profile_start_config_no_num_steps_leaves_stop_open(tmp_path):
     assert 3 not in executor.profile_stop_iters
 
 
-def test_stop_profile_cancels_pending_start_before_firing():
+def test_stop_profile_cancels_pending_start_before_firing(tmp_path):
     """If ``start_profile()`` was scheduled but the engine has not yet
     reached ``start_iter`` (idle server), ``stop_profile()`` must remove
     the pending start so profiling does not silently begin later."""
@@ -112,10 +112,10 @@ def test_stop_profile_cancels_pending_start_before_firing():
 
     # Simulate the full ``start_profile`` path for a bare executor: the
     # broadcast apply is what populates ``profile_start_iters``.
-    executor.start_profile(output_dir="/tmp/unused", num_steps=50)
+    executor.start_profile(output_dir=str(tmp_path), num_steps=50)
     executor._apply_profile_start_config(
         {
-            "output_dir": "/tmp/unused",
+            "output_dir": str(tmp_path),
             "start_step": 0,
             "num_steps": 50,
         }

--- a/tests/unittest/_torch/executor/test_profile_endpoints.py
+++ b/tests/unittest/_torch/executor/test_profile_endpoints.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``PyExecutor.start_profile`` / ``stop_profile``.
+
+Covers the runtime profiling handshake used by ``trtllm-serve``'s
+``/start_profile`` and ``/stop_profile`` HTTP endpoints:
+
+* ``start_profile`` tracks its scheduled iteration indices so a
+  subsequent ``stop_profile`` can either cancel them (if the engine
+  never reached them) or schedule a stop cleanly.
+* ``stop_profile`` does NOT call ``torch.profiler.stop()`` directly
+  because torch.profiler / Kineto require start and stop to happen on
+  the same thread. Instead it schedules the stop at the next executor
+  iteration; the HTTP layer is responsible for tickling the engine so
+  the scheduled iteration actually runs when the server is otherwise
+  idle.
+
+The tests construct a ``PyExecutor`` via ``__new__`` and populate only
+the attributes the handlers touch, so they run without GPUs, models,
+or an MPI/RPC environment.
+"""
+
+import threading
+
+from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
+
+def _bare_executor():
+    """Build a minimal ``PyExecutor`` with only the state the profile
+    handlers depend on. Avoids the heavy real __init__."""
+    executor = PyExecutor.__new__(PyExecutor)
+    executor.iter_counter = 0
+    executor.profile_start_iters = set()
+    executor.profile_stop_iters = set()
+    executor.global_rank = 0
+    executor._runtime_profile_trace_path = None
+    executor._runtime_profile_activities = None
+    executor._runtime_profile_cuda_only = False
+    executor._runtime_profile_pending_start_iter = None
+    executor._runtime_profile_pending_stop_iter = None
+    executor._profile_state_lock = threading.Lock()
+    executor._profile_enabled = False
+    return executor
+
+
+def test_start_profile_marks_pending_on_caller_thread(tmp_path):
+    """``start_profile()`` must set ``_runtime_profile_pending_start_iter``
+    immediately on the caller thread so a concurrent second call is
+    rejected by the guard even before the broadcast is applied. The
+    actual ``profile_start_iters`` update happens on every rank via the
+    broadcast path (``_apply_profile_start_config``) — see
+    ``test_apply_profile_start_config_uses_local_iter_counter``.
+    """
+    executor = _bare_executor()
+    executor.iter_counter = 7
+    executor.start_profile(output_dir=str(tmp_path), num_steps=100)
+
+    # Local apply only marks a sentinel for the rejection guard.
+    assert executor._runtime_profile_pending_start_iter is not None
+
+
+def test_apply_profile_start_config_uses_local_iter_counter(tmp_path):
+    """The broadcasted profile-start applies on every rank based on
+    its *own* ``iter_counter``. Two ranks that run in lockstep compute
+    the same ``start_iter``, so both fire on the same executor
+    iteration.
+    """
+    executor = _bare_executor()
+    executor.iter_counter = 7
+    executor._apply_profile_start_config(
+        {
+            "output_dir": str(tmp_path),
+            "activities": ["CPU", "GPU"],
+            "start_step": 0,
+            "num_steps": 100,
+        }
+    )
+
+    # start_iter = iter_counter + 1 + start_step
+    assert 8 in executor.profile_start_iters
+    assert 108 in executor.profile_stop_iters
+    assert executor._runtime_profile_pending_start_iter == 8
+    assert executor._runtime_profile_pending_stop_iter == 108
+    trace_path = executor._runtime_profile_trace_path
+    assert trace_path.startswith(str(tmp_path))
+    assert "rank-0" in trace_path and trace_path.endswith(".json")
+
+
+def test_apply_profile_start_config_no_num_steps_leaves_stop_open(tmp_path):
+    executor = _bare_executor()
+    executor.iter_counter = 2
+    executor._apply_profile_start_config(
+        {
+            "output_dir": str(tmp_path),
+            "start_step": 0,
+        }
+    )
+
+    assert 3 in executor.profile_start_iters
+    assert executor._runtime_profile_pending_start_iter == 3
+    # No num_steps => no auto stop scheduled.
+    assert executor._runtime_profile_pending_stop_iter is None
+    assert 3 not in executor.profile_stop_iters
+
+
+def test_stop_profile_cancels_pending_start_before_firing():
+    """If ``start_profile()`` was scheduled but the engine has not yet
+    reached ``start_iter`` (idle server), ``stop_profile()`` must remove
+    the pending start so profiling does not silently begin later."""
+    executor = _bare_executor()
+    executor.iter_counter = 3
+
+    # Simulate the full ``start_profile`` path for a bare executor: the
+    # broadcast apply is what populates ``profile_start_iters``.
+    executor.start_profile(output_dir="/tmp/unused", num_steps=50)
+    executor._apply_profile_start_config(
+        {
+            "output_dir": "/tmp/unused",
+            "start_step": 0,
+            "num_steps": 50,
+        }
+    )
+    assert executor._runtime_profile_pending_start_iter == 4
+    assert 4 in executor.profile_start_iters
+    assert 54 in executor.profile_stop_iters
+
+    # Engine has not iterated yet.
+    assert executor._profile_enabled is False
+
+    executor.stop_profile()
+
+    assert 4 not in executor.profile_start_iters
+    assert 54 not in executor.profile_stop_iters
+    assert executor._runtime_profile_pending_start_iter is None
+    assert executor._runtime_profile_pending_stop_iter is None
+
+
+def test_stop_profile_schedules_next_iter_when_active():
+    """While a profile window is live (``_profile_enabled`` is True) the
+    stop call must schedule the next iteration for the in-loop flush;
+    it must not attempt to call torch.profiler from this thread.
+
+    ``stop_profile`` blocks until the executor loop clears
+    ``_profile_enabled``; we simulate that on a side-thread so the test
+    does not hit the 30s poll timeout.
+    """
+    import threading as _threading
+
+    executor = _bare_executor()
+    executor.iter_counter = 100
+    executor._profile_enabled = True  # Simulate a running profile.
+
+    def _simulate_in_loop_stop():
+        # Mimic what profile_step() does when it reaches the scheduled
+        # stop iteration: clears _profile_enabled so the caller's poll
+        # loop in stop_profile() returns promptly.
+        import time as _time
+
+        _time.sleep(0.05)
+        with executor._profile_state_lock:
+            executor._profile_enabled = False
+
+    sim = _threading.Thread(target=_simulate_in_loop_stop, daemon=True)
+    sim.start()
+    executor.stop_profile()
+    sim.join(timeout=1.0)
+
+    # stop_iter = iter_counter + 1 so the NEXT profile_step check (on
+    # main's ``iter_counter in profile_stop_iters`` semantics) fires the
+    # stop on the very next loop iteration whether stop_profile was
+    # called mid-body or between iterations.
+    assert 101 in executor.profile_stop_iters
+    assert executor._runtime_profile_pending_stop_iter == 101
+
+
+def test_stop_profile_without_pending_start_falls_back_to_iteration_stop():
+    """With no runtime ``start_profile()`` call pending and no active
+    profile, ``stop_profile()`` must still schedule a stop so env-var
+    driven windows (``TLLM_PROFILE_START_STOP``) can still be torn down
+    on the next iteration."""
+    executor = _bare_executor()
+    executor.iter_counter = 42
+
+    executor.stop_profile()
+
+    assert 43 in executor.profile_stop_iters
+    assert executor._runtime_profile_pending_start_iter is None
+    # Fallback path publishes the stop iteration too.
+    assert executor._runtime_profile_pending_stop_iter == 43
+
+
+def test_stop_profile_after_start_without_num_steps_cancels_pending(tmp_path):
+    """When ``start_profile()`` was called without ``num_steps`` and
+    the engine never iterated, ``stop_profile()`` must cancel the
+    pending start rather than scheduling a stop."""
+    executor = _bare_executor()
+    executor.iter_counter = 10
+
+    executor.start_profile(output_dir=str(tmp_path))
+    executor._apply_profile_start_config(
+        {
+            "output_dir": str(tmp_path),
+            "start_step": 0,
+        }
+    )
+    assert 11 in executor.profile_start_iters
+    assert executor._runtime_profile_pending_start_iter == 11
+
+    executor.stop_profile()
+
+    assert 11 not in executor.profile_start_iters
+    assert executor._runtime_profile_pending_start_iter is None

--- a/tests/unittest/_torch/executor/test_profile_endpoints.py
+++ b/tests/unittest/_torch/executor/test_profile_endpoints.py
@@ -210,3 +210,39 @@ def test_stop_profile_after_start_without_num_steps_cancels_pending(tmp_path):
 
     assert 11 not in executor.profile_start_iters
     assert executor._runtime_profile_pending_start_iter is None
+
+
+def test_start_profile_rejects_num_steps_zero(tmp_path):
+    """``num_steps == 0`` would make ``stop_iter == start_iter``;
+    ``profile_step()`` would discard the stop marker as stale and the
+    profile window would run forever. The Pydantic schema rejects this
+    at the HTTP layer, but programmatic callers must also see a clean
+    error rather than a silently-stuck profile window.
+    """
+    import pytest as _pytest
+
+    executor = _bare_executor()
+    executor.iter_counter = 5
+
+    with _pytest.raises(ValueError, match="num_steps must be >= 1"):
+        executor.start_profile(output_dir=str(tmp_path), num_steps=0)
+
+    # State must remain pristine — no pending markers, no scheduled
+    # iterations — because the request was rejected before any side
+    # effect happened.
+    assert executor._runtime_profile_pending_start_iter is None
+    assert not executor.profile_start_iters
+    assert not executor.profile_stop_iters
+
+
+def test_start_profile_rejects_num_steps_negative(tmp_path):
+    """Negative ``num_steps`` is also rejected for the same reason."""
+    import pytest as _pytest
+
+    executor = _bare_executor()
+    executor.iter_counter = 5
+
+    with _pytest.raises(ValueError, match="num_steps must be >= 1"):
+        executor.start_profile(output_dir=str(tmp_path), num_steps=-3)
+
+    assert executor._runtime_profile_pending_start_iter is None

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -441,6 +441,26 @@ methods:
     parameters: {}
     return_annotation: None
     status: beta
+  start_profile:
+    parameters:
+      output_dir:
+        annotation: Optional[str]
+        default: null
+      num_steps:
+        annotation: Optional[int]
+        default: null
+      start_step:
+        annotation: int
+        default: 0
+      activities:
+        annotation: Optional[List[str]]
+        default: null
+    return_annotation: None
+    status: prototype
+  stop_profile:
+    parameters: {}
+    return_annotation: None
+    status: prototype
 properties:
   llm_id:
     annotation: str

--- a/tests/unittest/disaggregated/test_steady_clock_sync.py
+++ b/tests/unittest/disaggregated/test_steady_clock_sync.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the disagg server's steady-clock handshake.
+
+`OpenAIDisaggServer._sync_server_clock` estimates each ctx/gen server's clock
+offset with the NTP algorithm over an HTTP round trip. That estimate is only
+accurate to +/- delay/2, because an asymmetric round trip is indistinguishable
+from a genuine clock offset. Whatever it computes is then added to every
+perf-metric timestamp the ctx/gen server reports, so a bad estimate silently
+corrupts those timestamps.
+
+These tests drive the handshake against a stub `/steady_clock_offset` endpoint
+whose per-leg latency we control, and assert that a conclusive measurement is
+applied while an inconclusive one is discarded.
+"""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tensorrt_llm.serve.openai_disagg_server import (
+    _CLOCK_SYNC_GOOD_DELAY_SECONDS,
+    _CLOCK_SYNC_MAX_DELAY_SECONDS,
+    _CLOCK_SYNC_PROBES,
+    OpenAIDisaggServer,
+)
+
+# The stub sleeps this long between its own receive/transmit stamps, mirroring
+# the real `get_steady_clock_offset` handler. It cancels out of the NTP math.
+_SERVER_PROCESSING_S = 0.01
+
+
+class _StubWorkerServer:
+    """Minimal `/steady_clock_offset` endpoint with an injectable stall.
+
+    `stall_before_receive` models the ctx/gen server's event loop being busy
+    when the request lands: the request has already arrived, but the handler --
+    and therefore `receive_ts` -- is delayed. That inflates the outbound leg
+    only, which is exactly the one-sided asymmetry seen in CI when the
+    handshake races server startup.
+    """
+
+    def __init__(self, stall_before_receive: float = 0.0, fail: bool = False):
+        self.stall_before_receive = stall_before_receive
+        self.fail = fail
+        self.get_count = 0
+        self.posted_offsets: list[float] = []
+        self._server = None
+        self.url = None
+
+    async def __aenter__(self):
+        self._server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+        port = self._server.sockets[0].getsockname()[1]
+        self.url = f"127.0.0.1:{port}"
+        return self
+
+    async def __aexit__(self, *exc):
+        self._server.close()
+        await self._server.wait_closed()
+
+    async def _handle(self, reader, writer):
+        try:
+            while True:
+                try:
+                    header = await reader.readuntil(b"\r\n\r\n")
+                except (asyncio.IncompleteReadError, ConnectionResetError):
+                    return
+                method = header.split(b" ", 1)[0]
+                if method == b"POST":
+                    length = 0
+                    for line in header.split(b"\r\n"):
+                        if line.lower().startswith(b"content-length:"):
+                            length = int(line.split(b":", 1)[1])
+                    payload = json.loads(await reader.readexactly(length))
+                    self.posted_offsets.append(payload["offset"])
+                    body = b"{}"
+                elif self.fail:
+                    self.get_count += 1
+                    writer.write(b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n")
+                    await writer.drain()
+                    continue
+                else:
+                    self.get_count += 1
+                    if self.stall_before_receive:
+                        await asyncio.sleep(self.stall_before_receive)
+                    # Both ends read CLOCK_MONOTONIC, so the true offset is 0
+                    # and any offset the handshake computes is pure error.
+                    receive_ts = asyncio.get_running_loop().time()
+                    await asyncio.sleep(_SERVER_PROCESSING_S)
+                    transmit_ts = asyncio.get_running_loop().time()
+                    body = json.dumps(
+                        {
+                            "receive_ts": receive_ts,
+                            "transmit_ts": transmit_ts,
+                        }
+                    ).encode()
+                writer.write(
+                    b"HTTP/1.1 200 OK\r\n"
+                    b"Content-Type: application/json\r\n"
+                    b"Content-Length: %d\r\n\r\n" % len(body) + body
+                )
+                await writer.drain()
+        finally:
+            writer.close()
+
+
+async def _run_handshake(stub: _StubWorkerServer) -> None:
+    # `_sync_server_clock` only reads `_req_timeout_secs` off `self`, so a stub
+    # avoids standing up a whole disagg server for a clock-arithmetic test.
+    fake_self = SimpleNamespace(_req_timeout_secs=30)
+    await OpenAIDisaggServer._sync_server_clock(fake_self, stub.url)
+
+
+@pytest.mark.asyncio
+async def test_fast_server_offset_is_applied_and_small():
+    """A responsive server yields a conclusive, near-zero offset."""
+    async with _StubWorkerServer() as stub:
+        await _run_handshake(stub)
+
+    assert len(stub.posted_offsets) == 1, (
+        "a conclusive measurement should be pushed to the worker server"
+    )
+    # The stub shares this process's clock, so the true offset is exactly 0.
+    assert abs(stub.posted_offsets[0]) <= _CLOCK_SYNC_GOOD_DELAY_SECONDS, (
+        f"applied offset {stub.posted_offsets[0]} is larger than the measurement is accurate to"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fast_server_stops_after_one_probe():
+    """Probing stops as soon as a sample is conclusive.
+
+    Each probe costs a full round trip and servers are prepared sequentially,
+    so a healthy server must not spend the whole probe budget.
+    """
+    async with _StubWorkerServer() as stub:
+        await _run_handshake(stub)
+
+    # One warm-up probe (discarded) plus a single measured probe.
+    assert stub.get_count == 2, (
+        f"expected warm-up + 1 measured probe, got {stub.get_count} requests"
+    )
+
+
+@pytest.mark.asyncio
+async def test_stalled_server_offset_is_discarded():
+    """An inconclusive measurement must not be applied.
+
+    With a one-sided stall the NTP estimate is ~stall/2 of pure error. Applying
+    it would skew every perf-metric timestamp the worker reports by that much,
+    which is strictly worse than leaving the clocks alone.
+    """
+    stall = 10 * _CLOCK_SYNC_MAX_DELAY_SECONDS
+    async with _StubWorkerServer(stall_before_receive=stall) as stub:
+        await _run_handshake(stub)
+
+    assert stub.posted_offsets == [], (
+        "an offset estimated from a stalled round trip must be discarded"
+    )
+    # Warm-up plus the full budget, since no sample ever became conclusive.
+    assert stub.get_count == 1 + _CLOCK_SYNC_PROBES
+
+
+@pytest.mark.asyncio
+async def test_erroring_server_is_not_retried():
+    """A server that answers with an error is not probed again.
+
+    Servers are prepared one at a time, so retrying a broken one delays the
+    readiness of every server behind it in the queue.
+    """
+    async with _StubWorkerServer(fail=True) as stub:
+        await _run_handshake(stub)
+
+    assert stub.posted_offsets == []
+    # Warm-up plus a single measured probe that failed; no further retries.
+    assert stub.get_count == 2, (
+        f"expected the probe loop to stop at the first failure, got {stub.get_count} requests"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unreachable_server_is_skipped_quietly():
+    """A server that never answers is skipped without raising."""
+    async with _StubWorkerServer() as stub:
+        dead_url = stub.url
+    # Stub is now closed; the port should refuse connections.
+    fake_self = SimpleNamespace(_req_timeout_secs=5)
+    await OpenAIDisaggServer._sync_server_clock(fake_self, dead_url)

--- a/tests/unittest/executor/test_proxy_profile_sync.py
+++ b/tests/unittest/executor/test_proxy_profile_sync.py
@@ -19,6 +19,7 @@ The contract documented in
 These tests pin that contract for the IPC-proxy path.
 """
 
+import queue
 import threading
 import time
 from unittest.mock import MagicMock
@@ -175,11 +176,15 @@ def test_stop_profile_timeout_warns_does_not_hang():
     If the worker is stuck (no ack within the timeout), the proxy
     must not hang the HTTP event loop forever. It logs a warning and
     returns so the handler can produce a 5xx response.
+
+    ``queue.Queue.get(timeout=...)`` raises ``queue.Empty`` on timeout
+    (not ``TimeoutError``), so the mock must mirror that to exercise the
+    real ``except Empty`` branch in ``_wait_profile_ack``.
     """
     proxy = _bare_proxy()
 
     def never_ack(timeout=None):
-        raise TimeoutError("simulated worker hang")
+        raise queue.Empty()
 
     proxy.profile_ack_queue.get.side_effect = never_ack
 

--- a/tests/unittest/executor/test_proxy_profile_sync.py
+++ b/tests/unittest/executor/test_proxy_profile_sync.py
@@ -283,3 +283,221 @@ def test_profile_control_pinned_to_single_owner_thread(tmp_path):
         f"Owner thread name {owner.name!r} does not match the expected "
         "'proxy_profile_control' prefix."
     )
+
+
+# --------------------------------------------------------------------------- #
+# Strengthened regression tests for QiJune's PR review §2.
+#
+# pyzmq sockets are not thread-safe — concurrent access from multiple threads
+# (even one writer + one reader) is undefined behavior in libzmq. The fix
+# routes ALL profile-control ZMQ ops through ``_profile_control_executor``
+# (max_workers=1) so the FastAPI thread-pool worker never touches the socket.
+# These tests pin that contract under stress.
+# --------------------------------------------------------------------------- #
+
+
+class _ThreadSafetyRecorder:
+    """Records every queue access plus a peak concurrency counter.
+
+    Threads call ``record()`` on enter and increment a counter under a lock;
+    any peak value > 1 violates the single-owner-thread contract.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._active = 0
+        self.peak_concurrency = 0
+        self.events = []  # list of ("op", thread)
+
+    def record(self, op):
+        with self._lock:
+            self._active += 1
+            self.peak_concurrency = max(self.peak_concurrency, self._active)
+            self.events.append((op, threading.current_thread()))
+        try:
+            # Hold the "inside-the-socket" window briefly so any
+            # concurrent caller has a chance to be observed.
+            time.sleep(0.001)
+        finally:
+            with self._lock:
+                self._active -= 1
+
+
+def test_profile_ops_serialized_under_concurrent_callers(tmp_path):
+    """N concurrent callers must not produce concurrent ZMQ access.
+
+    Mirrors what FastAPI would do under load: many request handlers each
+    schedule a /start_profile or /stop_profile via ``asyncio.to_thread``
+    simultaneously. If the proxy ever directly touched ZMQ sockets from
+    those threads we would see ``peak_concurrency > 1``. The fix routes
+    every op through ``_profile_control_executor`` (max_workers=1), so
+    peak concurrency MUST stay at 1.
+    """
+    proxy = _bare_proxy()
+    recorder = _ThreadSafetyRecorder()
+
+    n_callers = 16
+    # Track the kind of each put so the corresponding get returns a
+    # matching ack — _wait_profile_ack uses the kind to detect stale acks
+    # and may discard mismatched ones, which would otherwise exhaust a
+    # pre-baked ack list.
+    put_kinds = []
+    state_lock = threading.Lock()
+
+    def record_put(req):
+        recorder.record("put")
+        with state_lock:
+            put_kinds.append("start" if isinstance(req, StartProfileRequest) else "stop")
+
+    def record_get(timeout=None):
+        recorder.record("get")
+        with state_lock:
+            # Pop the oldest pending put kind — guaranteed to be present
+            # since the executor serializes put→get pairs.
+            kind = put_kinds.pop(0)
+        return (kind, None)
+
+    proxy.request_queue.put.side_effect = record_put
+    proxy.profile_ack_queue.get.side_effect = record_get
+
+    def caller(idx):
+        proxy.start_profile(output_dir=str(tmp_path), num_steps=1)
+        proxy.stop_profile()
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=n_callers,
+        thread_name_prefix="fake_fastapi_to_thread",
+    ) as pool:
+        futures = [pool.submit(caller, i) for i in range(n_callers)]
+        for f in futures:
+            f.result()
+
+    # 4 ops per caller (start put, start get, stop put, stop get).
+    assert len(recorder.events) == 4 * n_callers, recorder.events
+
+    # The crucial contract: ZMQ queue is never accessed by 2 threads
+    # at the same time.
+    assert recorder.peak_concurrency == 1, (
+        f"Peak concurrent ZMQ queue access was "
+        f"{recorder.peak_concurrency} — pyzmq is NOT thread-safe and "
+        f"this would corrupt the socket. (See PR review §2.)"
+    )
+
+    owner_threads = {th for _, th in recorder.events}
+    assert len(owner_threads) == 1, (
+        f"Profile-control ZMQ ops touched {len(owner_threads)} threads "
+        f"({[t.name for t in owner_threads]}) — must be exactly one."
+    )
+
+    (owner,) = owner_threads
+    assert owner.name.startswith("proxy_profile_control"), (
+        f"Owner thread {owner.name!r} is not the dedicated executor."
+    )
+
+
+def test_profile_control_thread_name_is_stable_across_calls(tmp_path):
+    """The same single owner thread serves *every* call, not just one.
+
+    A pool with ``max_workers=1`` reuses its worker thread across submitted
+    callables, so even with thousands of calls we should only ever see one
+    owner thread name. This guards against an accidental future change to
+    ``max_workers > 1`` (which would still pass under serialized tests but
+    break the contract under concurrency).
+    """
+    proxy = _bare_proxy()
+    seen_owners = []
+    seen_lock = threading.Lock()
+    put_kinds = []
+
+    def record_put(req):
+        with seen_lock:
+            seen_owners.append(threading.current_thread())
+            put_kinds.append("start" if isinstance(req, StartProfileRequest) else "stop")
+
+    def record_get(timeout=None):
+        with seen_lock:
+            seen_owners.append(threading.current_thread())
+            kind = put_kinds.pop(0)
+        return (kind, None)
+
+    proxy.request_queue.put.side_effect = record_put
+    proxy.profile_ack_queue.get.side_effect = record_get
+
+    n_calls = 25
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        for _ in range(n_calls):
+            pool.submit(proxy.start_profile, output_dir=str(tmp_path), num_steps=1).result()
+            pool.submit(proxy.stop_profile).result()
+
+    # 2 ops per call * 2 calls per iter * n_calls = 4 * n_calls ops.
+    assert len(seen_owners) == 4 * n_calls
+
+    owner_set = set(seen_owners)
+    assert len(owner_set) == 1, (
+        f"Owner thread changed across calls: "
+        f"{sorted(t.name for t in owner_set)}. "
+        f"max_workers may have been bumped > 1."
+    )
+
+
+def test_caller_thread_never_touches_zmq_queue(tmp_path):
+    """The HTTP-handler thread is never the owner of a queue op.
+
+    This is exactly what QiJune's review asked for: ``request_queue.put`` and
+    ``profile_ack_queue.get`` must NOT run on the ``asyncio.to_thread``
+    worker thread. We verify by capturing the caller's thread identity and
+    asserting it is disjoint from the set of owner threads observed inside
+    the queue mocks.
+    """
+    proxy = _bare_proxy()
+
+    queue_op_threads = []
+    queue_lock = threading.Lock()
+    put_kinds = []
+
+    def record_put(req):
+        with queue_lock:
+            queue_op_threads.append(threading.current_thread())
+            put_kinds.append("start" if isinstance(req, StartProfileRequest) else "stop")
+
+    def record_get(timeout=None):
+        with queue_lock:
+            queue_op_threads.append(threading.current_thread())
+            kind = put_kinds.pop(0)
+        return (kind, None)
+
+    proxy.request_queue.put.side_effect = record_put
+    proxy.profile_ack_queue.get.side_effect = record_get
+
+    caller_threads = []
+    caller_lock = threading.Lock()
+
+    def caller():
+        with caller_lock:
+            caller_threads.append(threading.current_thread())
+        proxy.start_profile(output_dir=str(tmp_path), num_steps=1)
+        proxy.stop_profile()
+
+    threads = [threading.Thread(target=caller, name=f"fake_to_thread_{i}") for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    caller_set = set(caller_threads)
+    queue_owner_set = set(queue_op_threads)
+
+    # The intersection MUST be empty — caller threads must never touch
+    # the ZMQ socket directly.
+    leaked = caller_set & queue_owner_set
+    assert not leaked, (
+        f"Caller threads {[t.name for t in leaked]} appeared as ZMQ "
+        f"queue-op owners — pyzmq socket leaked into the FastAPI "
+        f"thread-pool worker. (See PR review §2.)"
+    )
+
+    # And every owner is the dedicated executor worker.
+    for th in queue_owner_set:
+        assert th.name.startswith("proxy_profile_control"), (
+            f"Unexpected owner thread {th.name!r}; expected 'proxy_profile_control*'."
+        )

--- a/tests/unittest/executor/test_proxy_profile_sync.py
+++ b/tests/unittest/executor/test_proxy_profile_sync.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Reproducer + regression test for §2.1 of the PR review.
+
+``GenerationExecutorProxy.stop_profile`` (and ``start_profile``) used to
+``request_queue.put(...)`` and return immediately, even though the actual
+``torch.profiler.stop()`` + ``export_chrome_trace()`` happens
+asynchronously inside the worker subprocess. Callers that hit
+``POST /stop_profile`` and then immediately tried to read the chrome
+trace from disk would see an empty / partial file.
+
+The contract documented in
+``docs/source/commands/trtllm-serve/trtllm-serve.rst`` says::
+
+    The call blocks until ``export_chrome_trace()`` has run on the
+    backend thread, so by the time the handler returns the file is
+    on disk.
+
+These tests pin that contract for the IPC-proxy path.
+"""
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensorrt_llm.executor.proxy import GenerationExecutorProxy
+from tensorrt_llm.executor.request import StartProfileRequest, StopProfileRequest
+
+
+def _bare_proxy():
+    """Build a minimal ``GenerationExecutorProxy`` for testing.
+
+    Provides only the queues the profile handlers touch. Avoids the
+    heavy real ``__init__`` (no MPI session, no zmq sockets, no worker
+    subprocess).
+    """
+    proxy = GenerationExecutorProxy.__new__(GenerationExecutorProxy)
+    proxy.request_queue = MagicMock()
+    # The fix introduces a ``profile_ack_queue`` attribute. Pre-fix this
+    # attribute does not exist; we stub it as MagicMock so old code paths
+    # accessing it via getattr() see a sentinel.
+    proxy.profile_ack_queue = MagicMock()
+    return proxy
+
+
+def test_stop_profile_blocks_until_worker_acks():
+    """*Reproducer* for §2.1.
+
+    Simulates a worker that takes 500ms to actually flush the chrome
+    trace. ``stop_profile()`` must not return before that flush
+    completes — otherwise the documented "trace is on disk by the time
+    /stop_profile returns 200" contract is violated.
+
+    On HEAD (pre-fix): proxy.stop_profile() returns in microseconds
+    because ``request_queue.put`` is non-blocking and there is no ack
+    machinery. ``elapsed`` will be < 0.01s and the assertion below
+    will FAIL — that is the bug being demonstrated.
+
+    Post-fix: the proxy waits on ``profile_ack_queue`` until the worker
+    has finished processing the StopProfileRequest. ``elapsed`` will be
+    ~0.5s and the assertion will PASS.
+    """
+    proxy = _bare_proxy()
+
+    worker_flush_duration = 0.5  # seconds the "worker" pretends to flush
+
+    def fake_worker_ack():
+        # Simulate the worker subprocess: dequeue the StopProfileRequest,
+        # spend ``worker_flush_duration`` flushing the chrome trace, then
+        # ack via ``profile_ack_queue``.
+        time.sleep(worker_flush_duration)
+        # The fix has the worker push an ack object to this queue after
+        # ``worker.stop_profile()`` returns. Pre-fix this code path is
+        # never read by the proxy, so the ack is dropped on the floor.
+        proxy.profile_ack_queue.get.return_value = ("stop", None)
+
+    # Wire the mock so .get() blocks until the worker thread fires the ack.
+    ack_event = threading.Event()
+
+    def blocking_get(timeout=None):
+        # Wait for the worker thread to finish, then return the ack.
+        if not ack_event.wait(timeout=timeout):
+            raise TimeoutError("ack not received within timeout")
+        return ("stop", None)
+
+    proxy.profile_ack_queue.get.side_effect = blocking_get
+
+    def worker():
+        time.sleep(worker_flush_duration)
+        ack_event.set()
+
+    threading.Thread(target=worker, daemon=True).start()
+
+    t0 = time.monotonic()
+    proxy.stop_profile()
+    elapsed = time.monotonic() - t0
+
+    # The request must have been forwarded to the worker.
+    assert proxy.request_queue.put.call_count == 1
+    assert isinstance(proxy.request_queue.put.call_args.args[0], StopProfileRequest)
+
+    # The crucial contract: stop_profile must not return until the
+    # worker has acked. Pre-fix this assertion FAILS (elapsed << 0.5s).
+    assert elapsed >= worker_flush_duration * 0.9, (
+        f"stop_profile returned in {elapsed:.3f}s — that is BEFORE the "
+        f"worker finished its {worker_flush_duration:.3f}s flush. The "
+        f"chrome trace would not be on disk yet. (See PR review §2.1.)"
+    )
+
+
+def test_start_profile_blocks_until_worker_acks():
+    """/start_profile blocks until the worker acks.
+
+    Same contract as ``/stop_profile``: the handler should not return
+    200 until the worker has accepted (or rejected) the request, so
+    that 409 conflicts are visible in the IPC-proxy path too.
+    """
+    proxy = _bare_proxy()
+
+    worker_setup_duration = 0.3
+    ack_event = threading.Event()
+
+    def blocking_get(timeout=None):
+        if not ack_event.wait(timeout=timeout):
+            raise TimeoutError("ack not received within timeout")
+        return ("start", None)  # ("status", optional_error_message)
+
+    proxy.profile_ack_queue.get.side_effect = blocking_get
+
+    def worker():
+        time.sleep(worker_setup_duration)
+        ack_event.set()
+
+    threading.Thread(target=worker, daemon=True).start()
+
+    t0 = time.monotonic()
+    proxy.start_profile(output_dir="/tmp/x", num_steps=5)
+    elapsed = time.monotonic() - t0
+
+    assert proxy.request_queue.put.call_count == 1
+    assert isinstance(proxy.request_queue.put.call_args.args[0], StartProfileRequest)
+
+    assert elapsed >= worker_setup_duration * 0.9, (
+        f"start_profile returned in {elapsed:.3f}s before worker acked "
+        f"(expected >= {worker_setup_duration:.3f}s). See PR review §2.1."
+    )
+
+
+def test_start_profile_propagates_worker_rejection_as_runtime_error():
+    """Worker rejection surfaces as RuntimeError on the proxy.
+
+    If the worker's PyExecutor rejected the start (RequestError —
+    "already in progress"), the proxy must surface that as a
+    ``RuntimeError`` so the HTTP handler can map it to 409. Pre-fix the
+    rejection was logged on the worker and silently dropped; the HTTP
+    layer always saw success.
+    """
+    proxy = _bare_proxy()
+
+    def fake_get(timeout=None):
+        # Worker reports the start was rejected by PyExecutor.
+        return ("start", "Profiling is already in progress (...)")
+
+    proxy.profile_ack_queue.get.side_effect = fake_get
+
+    with pytest.raises(RuntimeError, match="already in progress"):
+        proxy.start_profile()
+
+
+def test_stop_profile_timeout_warns_does_not_hang():
+    """Timeout produces a warning rather than wedging the event loop.
+
+    If the worker is stuck (no ack within the timeout), the proxy
+    must not hang the HTTP event loop forever. It logs a warning and
+    returns so the handler can produce a 5xx response.
+    """
+    proxy = _bare_proxy()
+
+    def never_ack(timeout=None):
+        raise TimeoutError("simulated worker hang")
+
+    proxy.profile_ack_queue.get.side_effect = never_ack
+
+    # Should not raise; should not hang.
+    t0 = time.monotonic()
+    proxy.stop_profile()
+    elapsed = time.monotonic() - t0
+    # The TimeoutError path returns promptly.
+    assert elapsed < 1.0

--- a/tests/unittest/executor/test_proxy_profile_sync.py
+++ b/tests/unittest/executor/test_proxy_profile_sync.py
@@ -19,6 +19,7 @@ The contract documented in
 These tests pin that contract for the IPC-proxy path.
 """
 
+import concurrent.futures
 import queue
 import threading
 import time
@@ -36,6 +37,11 @@ def _bare_proxy():
     Provides only the queues the profile handlers touch. Avoids the
     heavy real ``__init__`` (no MPI session, no zmq sockets, no worker
     subprocess).
+
+    Also wires a real single-thread ``_profile_control_executor`` —
+    this matches the production setup, which pins all profile-related
+    ZMQ socket operations to one owning thread (see
+    ``GenerationExecutorProxy.__init__``).
     """
     proxy = GenerationExecutorProxy.__new__(GenerationExecutorProxy)
     proxy.request_queue = MagicMock()
@@ -43,6 +49,9 @@ def _bare_proxy():
     # attribute does not exist; we stub it as MagicMock so old code paths
     # accessing it via getattr() see a sentinel.
     proxy.profile_ack_queue = MagicMock()
+    proxy._profile_control_executor = concurrent.futures.ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="proxy_profile_control"
+    )
     return proxy
 
 
@@ -194,3 +203,83 @@ def test_stop_profile_timeout_warns_does_not_hang():
     elapsed = time.monotonic() - t0
     # The TimeoutError path returns promptly.
     assert elapsed < 1.0
+
+
+def test_profile_control_pinned_to_single_owner_thread(tmp_path):
+    """Regression test for QiJune's review §2.
+
+    All ZMQ socket operations triggered by ``start_profile`` /
+    ``stop_profile`` must run on the same single owner thread, even
+    though the public API is invoked from many different caller
+    threads (``asyncio.to_thread`` does not pin to one worker).
+
+    We capture the ``threading.current_thread()`` identity inside both
+    the ``request_queue.put`` and ``profile_ack_queue.get`` mocks, and
+    invoke the proxy from several caller threads in sequence. After
+    the round-trip we assert:
+
+      * Every queue operation observed exactly one owner thread.
+      * That owner thread is *not* any of the caller threads — it is
+        the dedicated ``proxy_profile_control`` worker created by
+        ``_profile_control_executor``.
+    """
+    proxy = _bare_proxy()
+
+    seen_threads = []
+
+    def record_put(req):
+        seen_threads.append(("put", threading.current_thread()))
+
+    def record_get(timeout=None):
+        seen_threads.append(("get", threading.current_thread()))
+        # Return a matching ack so the call can complete promptly.
+        # Match whatever kind the most recent put requested.
+        last_req = seen_threads[-2][1] if len(seen_threads) >= 2 else None  # noqa: F841
+        # We return ("start", None) and ("stop", None) alternately; the
+        # caller pattern below issues start then stop, so this side_effect
+        # list approach is simpler than parsing the mock call history.
+        return record_get._next_ack.pop(0)
+
+    record_get._next_ack = [("start", None), ("stop", None)]
+
+    proxy.request_queue.put.side_effect = record_put
+    proxy.profile_ack_queue.get.side_effect = record_get
+
+    caller_threads = []
+
+    def run_start():
+        caller_threads.append(threading.current_thread())
+        proxy.start_profile(output_dir=str(tmp_path), num_steps=5)
+
+    def run_stop():
+        caller_threads.append(threading.current_thread())
+        proxy.stop_profile()
+
+    # Invoke from two distinct caller threads to mirror what
+    # ``asyncio.to_thread`` may do under load.
+    t1 = threading.Thread(target=run_start, name="caller_1")
+    t1.start()
+    t1.join()
+    t2 = threading.Thread(target=run_stop, name="caller_2")
+    t2.start()
+    t2.join()
+
+    # 2 puts (start request, stop request) + 2 gets (each ack) = 4 ops.
+    assert len(seen_threads) == 4, seen_threads
+
+    owner_threads = {th for _, th in seen_threads}
+    assert len(owner_threads) == 1, (
+        f"Profile-control queue ops touched multiple threads: "
+        f"{[(op, th.name) for op, th in seen_threads]}"
+    )
+
+    owner = next(iter(owner_threads))
+    # The owner is the executor's worker, not either caller thread.
+    assert owner not in caller_threads, (
+        f"Owner thread {owner.name!r} matched a caller thread; the "
+        "executor pinning is not effective."
+    )
+    assert owner.name.startswith("proxy_profile_control"), (
+        f"Owner thread name {owner.name!r} does not match the expected "
+        "'proxy_profile_control' prefix."
+    )

--- a/tests/unittest/executor/test_proxy_profile_sync.py
+++ b/tests/unittest/executor/test_proxy_profile_sync.py
@@ -110,7 +110,7 @@ def test_stop_profile_blocks_until_worker_acks():
     )
 
 
-def test_start_profile_blocks_until_worker_acks():
+def test_start_profile_blocks_until_worker_acks(tmp_path):
     """/start_profile blocks until the worker acks.
 
     Same contract as ``/stop_profile``: the handler should not return
@@ -136,7 +136,7 @@ def test_start_profile_blocks_until_worker_acks():
     threading.Thread(target=worker, daemon=True).start()
 
     t0 = time.monotonic()
-    proxy.start_profile(output_dir="/tmp/x", num_steps=5)
+    proxy.start_profile(output_dir=str(tmp_path), num_steps=5)
     elapsed = time.monotonic() - t0
 
     assert proxy.request_queue.put.call_count == 1

--- a/tests/unittest/llmapi/apps/_test_trtllm_serve_profile.py
+++ b/tests/unittest/llmapi/apps/_test_trtllm_serve_profile.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Smoke tests for trtllm-serve /start_profile and /stop_profile endpoints.
+
+These tests bind the unbound handler methods from ``OpenAIServer`` to a
+lightweight mock instance so they can run without GPUs or model weights.
+They verify that (a) the endpoints parse their request bodies correctly,
+(b) default values are applied, and (c) the underlying ``generator``
+object receives the expected ``start_profile`` / ``stop_profile`` calls
+with the right arguments.
+"""
+
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensorrt_llm.serve.openai_protocol import StartProfileRequest
+
+
+def _extract_json(response) -> dict:
+    """Decode a FastAPI ``JSONResponse`` body into a dict."""
+    return json.loads(response.body.decode("utf-8"))
+
+
+@pytest.fixture
+def server_with_mock_generator():
+    """Build a minimal mock ``OpenAIServer`` instance with only the bits
+    needed for the profile handlers. Avoids the heavy real __init__.
+    """
+    # Importing here so a missing optional dep in the server module only
+    # fails the test, not collection of the whole test file.
+    from tensorrt_llm.serve.openai_server import OpenAIServer
+
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.generator = MagicMock()
+    return server
+
+
+def test_start_profile_defaults(server_with_mock_generator):
+    server = server_with_mock_generator
+    response = asyncio.run(server.start_profile(StartProfileRequest()))
+
+    assert response.status_code == 200
+    assert _extract_json(response) == {"message": "Profiling started"}
+    server.generator.start_profile.assert_called_once_with(
+        output_dir=None,
+        num_steps=None,
+        start_step=0,
+        activities=["CPU", "GPU"],
+    )
+
+
+def test_start_profile_none_body_uses_defaults(server_with_mock_generator):
+    server = server_with_mock_generator
+    # FastAPI passes ``None`` if the request body is empty; the handler
+    # must accept that and fall back to the default StartProfileRequest.
+    response = asyncio.run(server.start_profile(None))
+
+    assert response.status_code == 200
+    server.generator.start_profile.assert_called_once_with(
+        output_dir=None,
+        num_steps=None,
+        start_step=0,
+        activities=["CPU", "GPU"],
+    )
+
+
+def test_start_profile_custom_args(server_with_mock_generator):
+    server = server_with_mock_generator
+    request = StartProfileRequest(
+        output_dir="/tmp/my_traces",
+        num_steps=10,
+        start_step=3,
+        activities=["CUDA_PROFILER"],
+    )
+    response = asyncio.run(server.start_profile(request))
+
+    assert response.status_code == 200
+    server.generator.start_profile.assert_called_once_with(
+        output_dir="/tmp/my_traces",
+        num_steps=10,
+        start_step=3,
+        activities=["CUDA_PROFILER"],
+    )
+
+
+def test_stop_profile(server_with_mock_generator):
+    server = server_with_mock_generator
+    response = asyncio.run(server.stop_profile())
+
+    assert response.status_code == 200
+    assert _extract_json(response) == {"message": "Profiling stopped"}
+    server.generator.stop_profile.assert_called_once_with()
+
+
+def test_start_profile_backend_error_returns_500(server_with_mock_generator):
+    server = server_with_mock_generator
+    # A RuntimeError whose message contains neither "already in progress"
+    # nor "pending" is treated as a generic backend failure (500); the
+    # 409 path is covered by test_http_handler_rejects_double_start_with_409
+    # in test_profile_endpoints_bugs.py.
+    server.generator.start_profile.side_effect = RuntimeError("boom")
+    response = asyncio.run(server.start_profile(StartProfileRequest()))
+
+    assert response.status_code == 500
+    body = _extract_json(response)
+    assert "boom" in body["message"]
+
+
+def test_stop_profile_backend_error_returns_500(server_with_mock_generator):
+    server = server_with_mock_generator
+    server.generator.stop_profile.side_effect = RuntimeError("nope")
+    response = asyncio.run(server.stop_profile())
+
+    assert response.status_code == 500
+    body = _extract_json(response)
+    assert "nope" in body["error"]
+
+
+def _async_loop_block_test(handler_call, backend_block_s: float = 0.3) -> float:
+    """Helper: run ``handler_call`` (an async lambda invoking
+    ``server.start_profile()`` or ``server.stop_profile()``) while
+    concurrently ticking every 10 ms in the same event loop.
+
+    Returns the maximum gap (in seconds) between consecutive ticker
+    timestamps. A gap >> 10 ms means the handler blocked the loop.
+    """
+    import time
+
+    async def _body():
+        ticks = []
+        stop_event = asyncio.Event()
+
+        async def _ticker():
+            while not stop_event.is_set():
+                ticks.append(time.monotonic())
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=0.01)
+                except asyncio.TimeoutError:
+                    pass
+
+        ticker_task = asyncio.create_task(_ticker())
+        # Warm up the ticker before invoking the handler so we have a
+        # cadence baseline.
+        await asyncio.sleep(0.05)
+        await handler_call()
+        await asyncio.sleep(0.05)
+        stop_event.set()
+        await ticker_task
+
+        max_gap = max(b - a for a, b in zip(ticks, ticks[1:])) if len(ticks) > 1 else 0.0
+        return max_gap
+
+    return asyncio.run(_body())
+
+
+def test_stop_profile_does_not_block_event_loop(server_with_mock_generator):
+    """Regression for PR review §2.5: the HTTP handler must not freeze
+    the asyncio event loop while the (potentially slow) backend
+    ``stop_profile`` call runs. We give the mocked generator a 300 ms
+    blocking ``time.sleep`` and assert the event loop kept ticking.
+    """
+    import time
+
+    server = server_with_mock_generator
+    backend_block_s = 0.3
+
+    def slow_backend_stop():
+        time.sleep(backend_block_s)
+
+    server.generator.stop_profile.side_effect = slow_backend_stop
+
+    async def _call():
+        await server.stop_profile()
+
+    max_gap = _async_loop_block_test(_call, backend_block_s=backend_block_s)
+    # Allow generous margin (the ticker only fires every 10 ms; threading
+    # round-trip adds ~5 ms). The bug produced gaps of >300 ms.
+    assert max_gap < 0.1, (
+        f"event loop blocked for {max_gap * 1000:.1f}ms during stop_profile "
+        f"(backend blocked for {backend_block_s * 1000:.1f}ms). The handler "
+        f"must run the blocking call via asyncio.to_thread."
+    )
+
+
+def test_start_profile_does_not_block_event_loop(server_with_mock_generator):
+    """Regression for PR review §2.5 — same as the stop_profile case
+    but for /start_profile. On the IPC-proxy path the start can block
+    for up to ~60s waiting for the worker ack."""
+    import time
+
+    server = server_with_mock_generator
+    backend_block_s = 0.3
+
+    def slow_backend_start(**_):
+        time.sleep(backend_block_s)
+
+    server.generator.start_profile.side_effect = slow_backend_start
+
+    async def _call():
+        await server.start_profile(StartProfileRequest())
+
+    max_gap = _async_loop_block_test(_call, backend_block_s=backend_block_s)
+    assert max_gap < 0.1, f"event loop blocked for {max_gap * 1000:.1f}ms during start_profile"

--- a/tests/unittest/llmapi/apps/_test_trtllm_serve_profile.py
+++ b/tests/unittest/llmapi/apps/_test_trtllm_serve_profile.py
@@ -67,10 +67,11 @@ def test_start_profile_none_body_uses_defaults(server_with_mock_generator):
     )
 
 
-def test_start_profile_custom_args(server_with_mock_generator):
+def test_start_profile_custom_args(server_with_mock_generator, tmp_path):
     server = server_with_mock_generator
+    custom_dir = str(tmp_path / "my_traces")
     request = StartProfileRequest(
-        output_dir="/tmp/my_traces",
+        output_dir=custom_dir,
         num_steps=10,
         start_step=3,
         activities=["CUDA_PROFILER"],
@@ -79,7 +80,7 @@ def test_start_profile_custom_args(server_with_mock_generator):
 
     assert response.status_code == 200
     server.generator.start_profile.assert_called_once_with(
-        output_dir="/tmp/my_traces",
+        output_dir=custom_dir,
         num_steps=10,
         start_step=3,
         activities=["CUDA_PROFILER"],


### PR DESCRIPTION
…-serve

Expose iteration-scoped runtime profiling over HTTP on the OpenAI-compatible trtllm-serve endpoint, mirroring SGLang's developer-profiling interface.

- POST /start_profile accepts output_dir, num_steps, start_step, activities (any of "CPU", "GPU", "CUDA_PROFILER"). With "CUDA_PROFILER" only, the server skips torch.profiler entirely so it composes cleanly with `nsys profile -c cudaProfilerApi`.
- POST /stop_profile terminates the active window and flushes the trace.
- PyExecutor.start_profile/stop_profile reuse the existing profile_start_iters / profile_stop_iters / cudaProfilerStart-Stop plumbing so env-var-based profiling behavior is preserved.
- _profiler() now builds torch.profiler lazily on the first start iteration so runtime configuration takes precedence over the TLLM_TORCH_PROFILE_TRACE env var and consecutive start/stop windows work.
- GenerationExecutor, BaseWorker, and GenerationExecutorRpcProxy proxy the new calls into the worker process; non-PyTorch backends fall through to a warning.
- LLM.start_profile / stop_profile added as @set_api_status("prototype").
- Smoke test covers default values, explicit overrides, and the stop path via mocked generator (no GPU required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- Added `POST /start_profile` and `POST /stop_profile` to `trtllm-serve`.
- Added runtime profiling across LLMs, executors, workers, proxies, and `PyExecutor`.
- Added iteration-scoped scheduling, lazy profiler creation, multi-rank traces, activity selection, and consecutive profiling windows.
- Added input validation for `CPU`, `GPU`, and `CUDA_PROFILER`.
- Added proxy-worker acknowledgements, timeout handling, and shutdown-state protection.
- Added unsupported-backend warnings and profiling documentation.
- Test-list entries use valid paths and cover endpoint smoke tests, executor profiling, and proxy synchronization.
- CI results remain mixed. PR_Github `#49393` succeeded, but multiple main pipelines failed.

## QA Engineer Review

Added tests cover:

- OpenAI server defaults, custom arguments, backend errors, and event-loop responsiveness.
- PyExecutor scheduling, cancellation, validation, and clean failure state.
- Proxy acknowledgements, error propagation, timeouts, serialization, thread ownership, and shutdown races.
- `test_trtllm_serve_profile_example`.

The endpoint smoke test, `test_profile_endpoints.py`, and `test_proxy_profile_sync.py` are listed in `tests/integration/test_lists/test-db/l0_a10.yml`.

Verdict: sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
