### PR TITLE
[TRTLLM-12503][feat] Parallel VAE independent scaling and fix arg passing

### DIFF
--- a/docs/source/models/visual-generation.md
+++ b/docs/source/models/visual-generation.md
@@ -113,12 +113,11 @@ TeaCache caches transformer outputs when timestep embeddings change slowly betwe
 
 ### Multi-GPU Parallelism
 
-Two parallelism modes can be combined:
+Three parallelism modes can be combined:
 
 - **CFG Parallelism** (`--cfg_size 2`): Splits positive/negative guidance prompts across GPUs.
 - **Ulysses Parallelism** (`--ulysses_size N`): Splits the sequence dimension across GPUs for longer sequences.
-
-Total GPU count = `cfg_size * ulysses_size`.
+- **Parallel VAE** (`--parallel_vae_size N`): Shards the final VAE decode along a spatial axis across GPUs, useful to reduce VAE latency and improve GPU utilization (Constraint: `parallel_vae_size ≤ world_size`). Currently only supported for WAN models.
 
 ## Developer Guide
 

--- a/examples/visual_gen/README.md
+++ b/examples/visual_gen/README.md
@@ -277,6 +277,7 @@ python visual_gen_ltx2.py \
 | `--attention_backend` | ✓ | ✓ | — | VANILLA | `VANILLA`, `TRTLLM`, or `FA4` |
 | `--cfg_size` | — | ✓ | — | 1 | CFG parallelism |
 | `--ulysses_size` | ✓ | ✓ | — | 1 | Ulysses parallelism |
+| `--parallel_vae_size` | - | ✓ | — | 1 | Parallelism used for VAE |
 | `--attn2d_row_size` | ✓ | ✓ | ✓ | 1 | Attention2D mesh row size |
 | `--attn2d_col_size` | ✓ | ✓ | ✓ | 1 | Attention2D mesh column size |
 | `--linear_type` | ✓ | ✓ | — | default | Quantization type |

--- a/examples/visual_gen/configs/wan2.2-t2v-fp4-1gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp4-1gpu.yaml
@@ -23,6 +23,5 @@ attention:
 parallel:
   dit_cfg_size: 1
   dit_ulysses_size: 1
-  enable_parallel_vae: true
 cuda_graph:
   enable_cuda_graph: false

--- a/examples/visual_gen/configs/wan2.2-t2v-fp4-4gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp4-4gpu.yaml
@@ -23,6 +23,6 @@ attention:
 parallel:
   dit_cfg_size: 2
   dit_ulysses_size: 2
-  enable_parallel_vae: true
+  parallel_vae_size: 4
 cuda_graph:
   enable_cuda_graph: false

--- a/examples/visual_gen/configs/wan2.2-t2v-fp8-8gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp8-8gpu.yaml
@@ -23,6 +23,6 @@ attention:
 parallel:
   dit_cfg_size: 2
   dit_ulysses_size: 4
-  enable_parallel_vae: true
+  parallel_vae_size: 8
 cuda_graph:
   enable_cuda_graph: false

--- a/examples/visual_gen/visual_gen_wan_i2v.py
+++ b/examples/visual_gen/visual_gen_wan_i2v.py
@@ -229,7 +229,12 @@ def parse_args():
         "Can be set independently of --attn2d_row_size; asymmetric meshes (e.g. 1x4 or 4x1) are valid. "
         "Cannot be combined with --ulysses_size (not yet implemented).",
     )
-    parser.add_argument("--disable_parallel_vae", action="store_true", help="Disable parallel VAE")
+    parser.add_argument(
+        "--parallel_vae_size",
+        type=int,
+        default=1,
+        help="Number of ranks used for parallel VAE. 1 disables parallel VAE.",
+    )
 
     # CUDA graph
     parser.add_argument(
@@ -333,7 +338,7 @@ def main():
             "dit_ulysses_size": args.ulysses_size,
             "dit_attn2d_row_size": args.attn2d_row_size,
             "dit_attn2d_col_size": args.attn2d_col_size,
-            "enable_parallel_vae": not args.disable_parallel_vae,
+            "parallel_vae_size": args.parallel_vae_size,
         },
         torch_compile={
             "enable_torch_compile": not args.disable_torch_compile,

--- a/examples/visual_gen/visual_gen_wan_t2v.py
+++ b/examples/visual_gen/visual_gen_wan_t2v.py
@@ -228,7 +228,12 @@ def parse_args():
         "Can be set independently of --attn2d_row_size; asymmetric meshes (e.g. 1x4 or 4x1) are valid. "
         "Cannot be combined with --ulysses_size (not yet implemented).",
     )
-    parser.add_argument("--disable_parallel_vae", action="store_true", help="Disable parallel VAE")
+    parser.add_argument(
+        "--parallel_vae_size",
+        type=int,
+        default=1,
+        help="Number of ranks used for parallel VAE. 1 disables parallel VAE.",
+    )
 
     # CUDA graph
     parser.add_argument(
@@ -333,7 +338,7 @@ def main():
             "dit_ulysses_size": args.ulysses_size,
             "dit_attn2d_row_size": args.attn2d_row_size,
             "dit_attn2d_col_size": args.attn2d_col_size,
-            "enable_parallel_vae": not args.disable_parallel_vae,
+            "parallel_vae_size": args.parallel_vae_size,
         },
         torch_compile={
             "enable_torch_compile": not args.disable_torch_compile,

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -95,7 +95,11 @@ class ParallelConfig(StrictBaseModel):
            2x2 mesh: Q gathered across row group, K/V gathered across col group
     """
 
-    enable_parallel_vae: bool = True
+    parallel_vae_size: int = PydanticField(
+        1,
+        ge=1,
+        description="Number of ranks used for VAE parallelism. 1 disables parallel VAE.",
+    )
     parallel_vae_split_dim: Literal["width", "height"] = "width"
 
     # DiT Parallelism
@@ -589,10 +593,6 @@ class DiffusionModelConfig(BaseModel):
 
     # Unified parallelism mapping (populated by setup_visual_gen_mapping)
     visual_gen_mapping: Optional[Any] = None  # VisualGenMapping (lazy import)
-
-    # VAE parallelism (promoted from ParallelConfig for pipeline_loader)
-    enable_parallel_vae: bool = True
-    parallel_vae_split_dim: Literal["width", "height"] = "width"
 
     dynamic_weight_quant: bool = False
 

--- a/tensorrt_llm/_torch/visual_gen/mapping.py
+++ b/tensorrt_llm/_torch/visual_gen/mapping.py
@@ -123,7 +123,7 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
         self.parallel_vae_size = parallel_vae_size
         self._vae_ranks = list(range(self.parallel_vae_size))
         self._vae_group: Optional[ProcessGroup] = None
-        self._vae_adj_groups: list[ProcessGroup] = []
+        self._vae_adj_groups: list[Optional[ProcessGroup]] = []
         self._attn2d_row_group: Optional[ProcessGroup] = None
         self._attn2d_col_group: Optional[ProcessGroup] = None
         self._order = order
@@ -212,18 +212,19 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
         """Create the process group used by parallel VAE."""
         if self.parallel_vae_size <= 1:
             return
-        if self.parallel_vae_size == self.world_size:
-            self._vae_group = dist.group.WORLD
-        else:
-            pg = dist.new_group(self._vae_ranks, use_local_synchronization=True)
-            if self._rank in self._vae_ranks:
-                self._vae_group = pg
 
+        pg = dist.new_group(self._vae_ranks, use_local_synchronization=False)
+        if self._rank in self._vae_ranks:
+            self._vae_group = pg
+
+        adj_groups: list[Optional[ProcessGroup]] = [None] * (self.parallel_vae_size - 1)
         for i in range(self.parallel_vae_size - 1):
             ranks = [self._vae_ranks[i], self._vae_ranks[i + 1]]
-            pg = dist.new_group(ranks, use_local_synchronization=True)
+            pg = dist.new_group(ranks, use_local_synchronization=False)
             if self._rank in ranks:
-                self._vae_adj_groups.append(pg)
+                adj_groups[i] = pg
+        if self._rank in self._vae_ranks:
+            self._vae_adj_groups = adj_groups
 
     # ------------------------------------------------------------------
     # Rank decomposition
@@ -308,7 +309,7 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
         return self._vae_group
 
     @property
-    def vae_adj_groups(self) -> list[ProcessGroup]:
+    def vae_adj_groups(self) -> list[Optional[ProcessGroup]]:
         return self._vae_adj_groups
 
     # ------------------------------------------------------------------

--- a/tensorrt_llm/_torch/visual_gen/mapping.py
+++ b/tensorrt_llm/_torch/visual_gen/mapping.py
@@ -123,6 +123,7 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
         self.parallel_vae_size = parallel_vae_size
         self._vae_ranks = list(range(self.parallel_vae_size))
         self._vae_group: Optional[ProcessGroup] = None
+        self._vae_adj_groups: list[ProcessGroup] = []
         self._attn2d_row_group: Optional[ProcessGroup] = None
         self._attn2d_col_group: Optional[ProcessGroup] = None
         self._order = order
@@ -213,11 +214,16 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
             return
         if self.parallel_vae_size == self.world_size:
             self._vae_group = dist.group.WORLD
-            return
+        else:
+            pg = dist.new_group(self._vae_ranks, use_local_synchronization=True)
+            if self._rank in self._vae_ranks:
+                self._vae_group = pg
 
-        pg = dist.new_group(self._vae_ranks, use_local_synchronization=True)
-        if self._rank in self._vae_ranks:
-            self._vae_group = pg
+        for i in range(self.parallel_vae_size - 1):
+            ranks = [self._vae_ranks[i], self._vae_ranks[i + 1]]
+            pg = dist.new_group(ranks, use_local_synchronization=True)
+            if self._rank in ranks:
+                self._vae_adj_groups.append(pg)
 
     # ------------------------------------------------------------------
     # Rank decomposition
@@ -300,6 +306,10 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
     @property
     def vae_group(self) -> Optional[ProcessGroup]:
         return self._vae_group
+
+    @property
+    def vae_adj_groups(self) -> list[ProcessGroup]:
+        return self._vae_adj_groups
 
     # ------------------------------------------------------------------
     # Bridge to LLM Mapping (for Linear layers)

--- a/tensorrt_llm/_torch/visual_gen/mapping.py
+++ b/tensorrt_llm/_torch/visual_gen/mapping.py
@@ -208,11 +208,48 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
             f"VisualGenMapping._build_attn2d_groups: row_size={row_size}, col_size={col_size}"
         )
 
+    def _validate_vae_ranks_share_cfg_group(self) -> None:
+        """Ensure all ``vae_ranks`` share one cfg coordinate (or span the full world).
+
+        Today ``_vae_ranks = list(range(parallel_vae_size))`` only sits inside
+        one CFG group when ``cfg`` is the outermost axis of ``dit_dim_order``.
+        """
+        if self.parallel_vae_size <= 1 or self.cfg_size <= 1:
+            return
+        if self.parallel_vae_size == self.world_size:
+            return
+
+        # Row-major stride along the cfg axis from the mesh order.
+        stride, cfg_stride = 1, None
+        for dim in reversed(self._dim_names):
+            if dim == "cfg":
+                cfg_stride = stride
+                break
+            stride *= self._dim_sizes[dim]
+        assert cfg_stride is not None  # 'cfg' is always present in _dim_names
+
+        cfg_coords = {(r // cfg_stride) % self.cfg_size for r in self._vae_ranks}
+        if len(cfg_coords) > 1:
+            raise NotImplementedError(
+                f"vae_ranks={self._vae_ranks} straddle CFG groups "
+                f"(cfg coordinates={sorted(cfg_coords)}) under order='{self._order}'. "
+                "VAE ranks must share a single CFG group, or span the full world. "
+                "_vae_ranks is currently hardcoded to list(range(parallel_vae_size)), "
+                "which only lands in one CFG group when 'cfg' is the outermost axis "
+                "of dit_dim_order. Either pick parallel_vae_size <= ranks_per_cfg_group "
+                "or derive _vae_ranks from the mesh."
+            )
+
     def _build_vae_group(self) -> None:
         """Create the process group used by parallel VAE."""
         if self.parallel_vae_size <= 1:
             return
 
+        self._validate_vae_ranks_share_cfg_group()
+
+        # use_local_synchronization=False since new_group is world-collective, so every
+        # rank (including non-VAE ranks) must participate or the next world-wide
+        # collective deadlocks.
         pg = dist.new_group(self._vae_ranks, use_local_synchronization=False)
         if self._rank in self._vae_ranks:
             self._vae_group = pg

--- a/tensorrt_llm/_torch/visual_gen/mapping.py
+++ b/tensorrt_llm/_torch/visual_gen/mapping.py
@@ -67,6 +67,7 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
         ulysses_size: int = 1,
         attn2d_row_size: int = 1,
         attn2d_col_size: int = 1,
+        parallel_vae_size: int = 1,
         order: str = DEFAULT_DIM_ORDER,
     ):
         # cp_size unifies ring and Attention2D under one context-parallelism mesh dimension.
@@ -96,6 +97,12 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
                 f"cfg({cfg_size}) * tp({tp_size}) * cp({cp_size}) * "
                 f"ulysses({ulysses_size}) = {product} != world_size({world_size})"
             )
+        if parallel_vae_size < 1:
+            raise ValueError(f"parallel_vae_size ({parallel_vae_size}) must be >= 1")
+        if parallel_vae_size > world_size:
+            raise ValueError(
+                f"parallel_vae_size ({parallel_vae_size}) cannot exceed world_size ({world_size})"
+            )
 
         dims = order.split("-")
         if set(dims) != _VALID_DIM_NAMES or len(dims) != len(_VALID_DIM_NAMES):
@@ -113,6 +120,9 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
         self.ulysses_size = ulysses_size
         self.attn2d_row_size = attn2d_row_size
         self.attn2d_col_size = attn2d_col_size
+        self.parallel_vae_size = parallel_vae_size
+        self._vae_ranks = list(range(self.parallel_vae_size))
+        self._vae_group: Optional[ProcessGroup] = None
         self._attn2d_row_group: Optional[ProcessGroup] = None
         self._attn2d_col_group: Optional[ProcessGroup] = None
         self._order = order
@@ -129,6 +139,7 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
 
         if dist.is_initialized() and world_size > 1:
             self.build_mesh()
+            self._build_vae_group()
 
     # ------------------------------------------------------------------
     # Mesh construction
@@ -195,6 +206,18 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
         logger.debug(
             f"VisualGenMapping._build_attn2d_groups: row_size={row_size}, col_size={col_size}"
         )
+
+    def _build_vae_group(self) -> None:
+        """Create the process group used by parallel VAE."""
+        if self.parallel_vae_size <= 1:
+            return
+        if self.parallel_vae_size == self.world_size:
+            self._vae_group = dist.group.WORLD
+            return
+
+        pg = dist.new_group(self._vae_ranks, use_local_synchronization=True)
+        if self._rank in self._vae_ranks:
+            self._vae_group = pg
 
     # ------------------------------------------------------------------
     # Rank decomposition
@@ -269,6 +292,14 @@ class VisualGenMapping(DeviceMeshTopologyImpl):
     def attn2d_mesh_group(self) -> Optional[ProcessGroup]:
         """Full CP group for Attention2D (same as cp_group)."""
         return self._group("cp")
+
+    @property
+    def vae_ranks(self) -> list[int]:
+        return self._vae_ranks
+
+    @property
+    def vae_group(self) -> Optional[ProcessGroup]:
+        return self._vae_group
 
     # ------------------------------------------------------------------
     # Bridge to LLM Mapping (for Linear layers)

--- a/tensorrt_llm/_torch/visual_gen/models/wan/parallel_vae.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/parallel_vae.py
@@ -119,6 +119,7 @@ class ParallelVAE_Wan(ParallelVAEBase):
                     self.spec.attn_dim,
                     self.rank,
                     self.world_size,
+                    self.pg,
                 ),
             )
 

--- a/tensorrt_llm/_torch/visual_gen/modules/vae/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/vae/attention.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 import torch
 import torch.distributed as dist
@@ -21,17 +21,25 @@ class ParallelVaeAttentionBlock(torch.nn.Module):
         world_size: Total ranks in the VAE parallel group.
     """
 
-    def __init__(self, module: nn.Module, chunk_dim: int, rank: int, world_size: int) -> None:
+    def __init__(
+        self,
+        module: nn.Module,
+        chunk_dim: int,
+        rank: int,
+        world_size: int,
+        pg: Optional[dist.ProcessGroup] = None,
+    ) -> None:
         super().__init__()
         self.module = module
         self.rank = rank
         self.world_size = world_size
         self.chunk_dim = chunk_dim
+        self.pg = pg
 
     def forward(self, hidden_states: torch.Tensor, *args: Any, **kwargs: Any) -> torch.Tensor:
         gathered_tensors = [torch.zeros_like(hidden_states) for _ in range(self.world_size)]
 
-        dist.all_gather(gathered_tensors, hidden_states.contiguous())
+        dist.all_gather(gathered_tensors, hidden_states.contiguous(), group=self.pg)
         combined_tensor = torch.cat(gathered_tensors, dim=self.chunk_dim)
 
         # Not passing additional args/kwargs to the module since it's not expected to be used.

--- a/tensorrt_llm/_torch/visual_gen/modules/vae/conv.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/vae/conv.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import torch
 import torch.distributed as dist
@@ -33,7 +33,7 @@ class HaloExchangeConv(nn.Module):
         self,
         module: nn.Module,
         chunk_dim: int,
-        adj_groups: List[dist.ProcessGroup],
+        adj_groups: List[Optional[dist.ProcessGroup]],
         rank: int,
         world_size: int,
     ) -> None:
@@ -60,6 +60,14 @@ class HaloExchangeConv(nn.Module):
         d = chunk_kernel - 1
         self.halo_left = d // 2
         self.halo_right = d - self.halo_left
+
+    def _adj_group(self, index: int) -> dist.ProcessGroup:
+        group = self.adj_groups[index]
+        if group is None:
+            raise RuntimeError(
+                f"Missing VAE adjacent process group {index} for local rank {self.rank}"
+            )
+        return group
 
     def _exchange_halos(self, x: torch.Tensor) -> torch.Tensor:
         """Exchange boundary slices with adjacent ranks.
@@ -90,17 +98,17 @@ class HaloExchangeConv(nn.Module):
         if self.rank % 2 == 0:
             if self.rank > 0:
                 gather_buf = [recv_from_left, send_left]
-                dist.all_gather(gather_buf, send_left, group=self.adj_groups[self.rank - 1])
+                dist.all_gather(gather_buf, send_left, group=self._adj_group(self.rank - 1))
             if self.rank < self.world_size - 1:
                 gather_buf = [send_right, recv_from_right]
-                dist.all_gather(gather_buf, send_right, group=self.adj_groups[self.rank])
+                dist.all_gather(gather_buf, send_right, group=self._adj_group(self.rank))
         else:
             if self.rank < self.world_size - 1:
                 gather_buf = [send_right, recv_from_right]
-                dist.all_gather(gather_buf, send_right, group=self.adj_groups[self.rank])
+                dist.all_gather(gather_buf, send_right, group=self._adj_group(self.rank))
             if self.rank > 0:
                 gather_buf = [recv_from_left, send_left]
-                dist.all_gather(gather_buf, send_left, group=self.adj_groups[self.rank - 1])
+                dist.all_gather(gather_buf, send_left, group=self._adj_group(self.rank - 1))
 
         # Trim received data to the actual needed halo sizes.
         # recv_from_left holds the left neighbor's right-edge slices; we need
@@ -166,7 +174,7 @@ class HaloExchangeConv2dStride2(nn.Module):
         self,
         module: nn.Module,
         chunk_dim: int,
-        adj_groups: List[dist.ProcessGroup],
+        adj_groups: List[Optional[dist.ProcessGroup]],
         rank: int,
         world_size: int,
         pad_before_conv: tuple = (0, 1, 0, 1),

--- a/tensorrt_llm/_torch/visual_gen/modules/vae/parallel_vae_interface.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/vae/parallel_vae_interface.py
@@ -139,6 +139,16 @@ class ParallelVAEFactory:
     }
 
     @classmethod
+    def supports(cls, vae_type: type) -> bool:
+        """Return True if a parallel wrapper is registered for ``vae_type``.
+
+        Pure capability check — deterministic and identical on every rank, so
+        callers can use it to make globally-consistent decisions (e.g. whether
+        parallel-VAE decode mode is active across the world).
+        """
+        return cls._resolve(vae_type) is not None
+
+    @classmethod
     def from_vae(
         cls,
         vae: nn.Module,

--- a/tensorrt_llm/_torch/visual_gen/modules/vae/parallel_vae_interface.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/vae/parallel_vae_interface.py
@@ -30,6 +30,7 @@ class ParallelVAEBase(nn.Module):
         vae_backend: nn.Module,
         pg: dist.ProcessGroup,
         spec: SplitSpec,
+        adj_groups: List[dist.ProcessGroup],
     ) -> None:
         super().__init__()
         self.vae_backend = vae_backend
@@ -37,7 +38,7 @@ class ParallelVAEBase(nn.Module):
         self.spec = spec
         self.rank = dist.get_rank(pg)
         self.world_size = dist.get_world_size(pg)
-        self._adj_groups = self._build_adj_groups(pg)
+        self._adj_groups = adj_groups
         self._parallelize_modules()
 
     # ------------------------------------------------------------------
@@ -120,30 +121,6 @@ class ParallelVAEBase(nn.Module):
             parent = getattr(parent, attr)
         setattr(parent, attrs[-1], new_module)
 
-    # ------------------------------------------------------------------
-    # Process-group helpers
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _build_adj_groups(pg: dist.ProcessGroup) -> List[dist.ProcessGroup]:
-        """Create pairwise adjacent-rank groups from *pg*.
-
-        Returns a list where ``adj_groups[i]`` is a group containing global
-        ranks ``ranks[i]`` and ``ranks[i+1]`` from *pg*.
-        """
-        world_size = dist.get_world_size(pg)
-        ranks = list(range(world_size))
-
-        adj_groups: List[dist.ProcessGroup] = []
-        for i in range(world_size - 1):
-            adj_groups.append(
-                dist.new_group(
-                    [ranks[i], ranks[i + 1]],
-                    use_local_synchronization=False,
-                )
-            )
-        return adj_groups
-
 
 class ParallelVAEFactory:
     """Factory that maps VAE classes to their parallel wrappers via lazy imports.
@@ -167,6 +144,7 @@ class ParallelVAEFactory:
         vae: nn.Module,
         split_dim: Literal["height", "width"],
         pg: dist.ProcessGroup,
+        adj_groups: List[dist.ProcessGroup],
     ) -> ParallelVAEBase:
         parallel_cls = cls._resolve(type(vae))
         if parallel_cls is None:
@@ -175,7 +153,7 @@ class ParallelVAEFactory:
                 f"Known VAE types: {list(cls._LAZY_REGISTRY.keys())}"
             )
         spec = parallel_cls.make_spec(split_dim)
-        return parallel_cls(vae, pg, spec)
+        return parallel_cls(vae, pg, spec, adj_groups)
 
     @classmethod
     def _resolve(cls, vae_type: type) -> Type[ParallelVAEBase] | None:

--- a/tensorrt_llm/_torch/visual_gen/modules/vae/parallel_vae_interface.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/vae/parallel_vae_interface.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Tuple, Type
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type
 
 import torch
 import torch.distributed as dist
@@ -30,7 +30,7 @@ class ParallelVAEBase(nn.Module):
         vae_backend: nn.Module,
         pg: dist.ProcessGroup,
         spec: SplitSpec,
-        adj_groups: List[dist.ProcessGroup],
+        adj_groups: List[Optional[dist.ProcessGroup]],
     ) -> None:
         super().__init__()
         self.vae_backend = vae_backend
@@ -144,7 +144,7 @@ class ParallelVAEFactory:
         vae: nn.Module,
         split_dim: Literal["height", "width"],
         pg: dist.ProcessGroup,
-        adj_groups: List[dist.ProcessGroup],
+        adj_groups: List[Optional[dist.ProcessGroup]],
     ) -> ParallelVAEBase:
         parallel_cls = cls._resolve(type(vae))
         if parallel_cls is None:

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -468,46 +468,55 @@ class BasePipeline(nn.Module):
             self.cache_accelerator = acc
 
     def setup_parallel_vae(self):
+        """Enable parallel-VAE decode mode and wrap the VAE on participating ranks.
+
+        ``self._parallel_vae_enabled`` is a *global* mode flag: it is computed
+        from inputs that are identical on every rank (config + mapping +
+        deterministic capability check), so every rank agrees on whether
+        parallel-VAE decode ownership applies. The actual ``ParallelVAEFactory``
+        wrap is a local side effect that only runs on ranks in ``vae_ranks``.
+        """
         parallel_cfg = self.model_config.parallel
-        if parallel_cfg.parallel_vae_size <= 1:
-            return
-        if not dist.is_initialized() or dist.get_world_size() <= 1:
-            return
-        if self.vae is None:
-            return
-
         vgm = self.model_config.visual_gen_mapping
-        if vgm is None:
+
+        # Global preconditions — evaluate identically on every rank.
+        self._parallel_vae_enabled = (
+            parallel_cfg.parallel_vae_size > 1
+            and dist.is_initialized()
+            and dist.get_world_size() > 1
+            and self.vae is not None
+            and vgm is not None
+            and ParallelVAEFactory.supports(type(self.vae))
+        )
+        if not self._parallel_vae_enabled:
+            # Quick check to see if it wasn't enabled due to missing support.
+            if (
+                parallel_cfg.parallel_vae_size > 1
+                and self.vae is not None
+                and not ParallelVAEFactory.supports(type(self.vae))
+            ):
+                logger.warning(
+                    f"Parallel VAE not supported for {self.__class__.__name__} "
+                    f"(VAE type: {type(self.vae).__name__}). "
+                    "Add an entry to ParallelVAEFactory._LAZY_REGISTRY to enable "
+                    "parallel VAE for this VAE type."
+                )
             return
 
-        vae_ranks = vgm.vae_ranks
-        if dist.get_rank() not in vae_ranks:
-            return
-        pg = vgm.vae_group
-        if pg is None:
+        # Local side effect: only ranks in the VAE group wrap the VAE module.
+        if self.rank not in vgm.vae_ranks or vgm.vae_group is None:
             return
 
-        try:
-            self.vae = ParallelVAEFactory.from_vae(
-                self.vae,
-                split_dim=parallel_cfg.parallel_vae_split_dim,
-                pg=pg,
-                adj_groups=vgm.vae_adj_groups,
-            )
-        except ValueError:
-            logger.warning(
-                f"Parallel VAE not supported for {self.__class__.__name__} "
-                f"(VAE type: {type(self.vae).__name__}). "
-                "Add an entry to ParallelVAEFactory._LAZY_REGISTRY to enable "
-                "parallel VAE for this VAE type."
-            )
-            return
-
-        self._parallel_vae_enabled = True
+        self.vae = ParallelVAEFactory.from_vae(
+            self.vae,
+            split_dim=parallel_cfg.parallel_vae_split_dim,
+            pg=vgm.vae_group,
+            adj_groups=vgm.vae_adj_groups,
+        )
         logger.info(
             f"Parallel VAE enabled: {type(self.vae).__name__}, "
             f"split_dim={parallel_cfg.parallel_vae_split_dim}, "
-            f"world_size={dist.get_world_size(pg)}"
+            f"world_size={dist.get_world_size(vgm.vae_group)}"
         )
 
     def torch_compile(self) -> None:
@@ -632,41 +641,40 @@ class BasePipeline(nn.Module):
         decode_fn: Callable[[torch.Tensor], Any],
         extra_latents: Optional[Dict[str, Tuple[torch.Tensor, Callable]]] = None,
     ):
-        """Execute VAE decoding. Only rank 0 performs decoding.
-        If parallel VAE is enabled, only ranks in the VAE process group
-        perform decoding; non-participating ranks return None placeholders.
+        """Execute VAE decoding.
+
+        Decode ownership is decided from the global ``_parallel_vae_enabled``
+        flag set by ``setup_parallel_vae``:
+
+        - parallel-VAE mode on: ranks in ``vgm.vae_ranks`` decode collectively.
+        - parallel-VAE mode off: only rank 0 decodes.
+
+        Non-decoding ranks return ``None`` placeholders.
 
         Args:
-            latents: Primary latents to decode (e.g., video)
-            decode_fn: Decoder function for primary latents
+            latents: Primary latents to decode (e.g., video).
+            decode_fn: Decoder function for primary latents.
             extra_latents: Optional dict of additional latents to decode.
-                          Format: {name: (latents_tensor, decode_fn)}
-                          Example: {"audio": (audio_latents, audio_decode_fn)}
+                Format: ``{name: (latents_tensor, decode_fn)}``.
+                Example: ``{"audio": (audio_latents, audio_decode_fn)}``.
 
         Returns:
-            Single result if no extra_latents, tuple of results if extra_latents provided.
-            Non-rank-0 processes return None placeholders.
+            Single result if no ``extra_latents``, else a tuple of results.
+            Non-decoding ranks return ``None`` (or a tuple of ``None``).
         """
-
         if self._parallel_vae_enabled:
+            vgm = self.model_config.visual_gen_mapping
+            decode_ranks = set(vgm.vae_ranks)
+        else:
+            decode_ranks = {0}
+
+        if self.rank in decode_ranks:
             primary_result = decode_fn(latents)
             if extra_latents:
                 extra_results = [efn(elat) for _, (elat, efn) in extra_latents.items()]
                 return (primary_result,) + tuple(extra_results)
             return primary_result
 
-        if self.rank == 0:
-            primary_result = decode_fn(latents)
-
-            if extra_latents:
-                extra_results = []
-                for name, (extra_latent, extra_decode_fn) in extra_latents.items():
-                    extra_results.append(extra_decode_fn(extra_latent))
-                return (primary_result,) + tuple(extra_results)
-
-            return primary_result
-
-        # Return None placeholders for non-rank-0 processes
         n_results = 1 + (len(extra_latents) if extra_latents else 0)
         return (None,) * n_results if n_results > 1 else None
 

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -492,6 +492,7 @@ class BasePipeline(nn.Module):
                 self.vae,
                 split_dim=parallel_cfg.parallel_vae_split_dim,
                 pg=pg,
+                adj_groups=vgm.vae_adj_groups,
             )
         except ValueError:
             logger.warning(

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -468,19 +468,29 @@ class BasePipeline(nn.Module):
             self.cache_accelerator = acc
 
     def setup_parallel_vae(self):
-        if not self.model_config.enable_parallel_vae:
+        parallel_cfg = self.model_config.parallel
+        if parallel_cfg.parallel_vae_size <= 1:
             return
         if not dist.is_initialized() or dist.get_world_size() <= 1:
             return
         if self.vae is None:
             return
 
-        # Uses all ranks today; replace with a subset to dedicate specific ranks to VAE.
-        pg = dist.new_group(list(range(dist.get_world_size())))
+        vgm = self.model_config.visual_gen_mapping
+        if vgm is None:
+            return
+
+        vae_ranks = vgm.vae_ranks
+        if dist.get_rank() not in vae_ranks:
+            return
+        pg = vgm.vae_group
+        if pg is None:
+            return
+
         try:
             self.vae = ParallelVAEFactory.from_vae(
                 self.vae,
-                split_dim=self.model_config.parallel_vae_split_dim,
+                split_dim=parallel_cfg.parallel_vae_split_dim,
                 pg=pg,
             )
         except ValueError:
@@ -495,7 +505,7 @@ class BasePipeline(nn.Module):
         self._parallel_vae_enabled = True
         logger.info(
             f"Parallel VAE enabled: {type(self.vae).__name__}, "
-            f"split_dim={self.model_config.parallel_vae_split_dim}, "
+            f"split_dim={parallel_cfg.parallel_vae_split_dim}, "
             f"world_size={dist.get_world_size(pg)}"
         )
 
@@ -622,7 +632,8 @@ class BasePipeline(nn.Module):
         extra_latents: Optional[Dict[str, Tuple[torch.Tensor, Callable]]] = None,
     ):
         """Execute VAE decoding. Only rank 0 performs decoding.
-        If parallel VAE is enabled, all processes perform decoding.
+        If parallel VAE is enabled, only ranks in the VAE process group
+        perform decoding; non-participating ranks return None placeholders.
 
         Args:
             latents: Primary latents to decode (e.g., video)

--- a/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
@@ -115,6 +115,7 @@ class PipelineLoader:
                 ring_size=self.args.parallel.dit_ring_size,
                 attn2d_row_size=self.args.parallel.dit_attn2d_row_size,
                 attn2d_col_size=self.args.parallel.dit_attn2d_col_size,
+                parallel_vae_size=self.args.parallel.parallel_vae_size,
                 order=self.args.parallel.dit_dim_order,
             )
         else:
@@ -225,7 +226,7 @@ class PipelineLoader:
         # =====================================================================
 
         t0 = time.time()
-        if config.enable_parallel_vae:
+        if config.parallel.parallel_vae_size > 1:
             pipeline.setup_parallel_vae()
 
         if hasattr(pipeline, "post_load_weights"):

--- a/tests/integration/defs/perf/README_test_visual_gen_perf_sanity.md
+++ b/tests/integration/defs/perf/README_test_visual_gen_perf_sanity.md
@@ -47,7 +47,6 @@ b_enable_teacache
 b_enable_cuda_graph
 b_enable_torch_compile
 b_enable_two_stage
-b_enable_parallel_vae
 l_cfg_size
 l_ulysses_size
 s_generation_mode

--- a/tests/integration/defs/perf/README_test_visual_gen_perf_sanity.md
+++ b/tests/integration/defs/perf/README_test_visual_gen_perf_sanity.md
@@ -49,6 +49,7 @@ b_enable_torch_compile
 b_enable_two_stage
 l_cfg_size
 l_ulysses_size
+l_parallel_vae_size
 s_generation_mode
 s_backend
 s_size

--- a/tests/integration/defs/perf/visual_gen_perf_utils.py
+++ b/tests/integration/defs/perf/visual_gen_perf_utils.py
@@ -48,7 +48,6 @@ MATCH_KEYS = [
     "b_enable_cuda_graph",
     "b_enable_torch_compile",
     "b_enable_two_stage",
-    "b_enable_parallel_vae",
     "l_cfg_size",
     "l_ulysses_size",
     "s_generation_mode",
@@ -174,9 +173,6 @@ def build_visual_gen_db_entry(
         ),
         "b_enable_two_stage": bool(
             server_config.get("spatial_upsampler_path") or server_config.get("distilled_lora_path")
-        ),
-        "b_enable_parallel_vae": bool(
-            _get_nested_value(server_config, "parallel.enable_parallel_vae", False)
         ),
         "l_cfg_size": int(_get_nested_value(server_config, "parallel.dit_cfg_size", 1)),
         "l_ulysses_size": int(_get_nested_value(server_config, "parallel.dit_ulysses_size", 1)),

--- a/tests/integration/defs/perf/visual_gen_perf_utils.py
+++ b/tests/integration/defs/perf/visual_gen_perf_utils.py
@@ -50,6 +50,7 @@ MATCH_KEYS = [
     "b_enable_two_stage",
     "l_cfg_size",
     "l_ulysses_size",
+    "l_parallel_vae_size",
     "s_generation_mode",
     "s_backend",
     "s_size",
@@ -176,6 +177,9 @@ def build_visual_gen_db_entry(
         ),
         "l_cfg_size": int(_get_nested_value(server_config, "parallel.dit_cfg_size", 1)),
         "l_ulysses_size": int(_get_nested_value(server_config, "parallel.dit_ulysses_size", 1)),
+        "l_parallel_vae_size": int(
+            _get_nested_value(server_config, "parallel.parallel_vae_size", 1)
+        ),
         "s_generation_mode": _infer_generation_mode(client_config),
         "s_backend": str(client_config.get("backend")),
         "s_size": str(client_config.get("size")),

--- a/tests/scripts/perf-sanity/visual_gen/flux2_blackwell.yaml
+++ b/tests/scripts/perf-sanity/visual_gen/flux2_blackwell.yaml
@@ -16,7 +16,6 @@ server_configs:
       attention:
         backend: VANILLA
       parallel:
-        enable_parallel_vae: false
         dit_cfg_size: 1
         dit_ulysses_size: 4
       cache:

--- a/tests/scripts/perf-sanity/visual_gen/ltx2_blackwell.yaml
+++ b/tests/scripts/perf-sanity/visual_gen/ltx2_blackwell.yaml
@@ -16,7 +16,6 @@ server_configs:
         backend: VANILLA
       text_encoder_path: google/gemma-3-12b-it
       parallel:
-        enable_parallel_vae: false
         dit_cfg_size: 2
         dit_ulysses_size: 4
       spatial_upsampler_path: LTX-2/ltx-2-spatial-upscaler-x2-1.0.safetensors
@@ -48,7 +47,6 @@ server_configs:
         backend: VANILLA
       text_encoder_path: google/gemma-3-12b-it
       parallel:
-        enable_parallel_vae: false
         dit_cfg_size: 2
         dit_ulysses_size: 4
       spatial_upsampler_path: LTX-2/ltx-2-spatial-upscaler-x2-1.0.safetensors
@@ -78,7 +76,6 @@ server_configs:
         backend: VANILLA
       text_encoder_path: google/gemma-3-12b-it
       parallel:
-        enable_parallel_vae: false
         dit_cfg_size: 2
         dit_ulysses_size: 4
       cuda_graph:

--- a/tests/scripts/perf-sanity/visual_gen/wan21_t2v_14b_blackwell.yaml
+++ b/tests/scripts/perf-sanity/visual_gen/wan21_t2v_14b_blackwell.yaml
@@ -17,7 +17,7 @@ server_configs:
       attention:
         backend: TRTLLM
       parallel:
-        enable_parallel_vae: true
+        parallel_vae_size: 8
         dit_cfg_size: 2
         dit_ulysses_size: 4
       cache:

--- a/tests/scripts/perf-sanity/visual_gen/wan22_i2v_a14b_blackwell.yaml
+++ b/tests/scripts/perf-sanity/visual_gen/wan22_i2v_a14b_blackwell.yaml
@@ -17,7 +17,7 @@ server_configs:
       attention:
         backend: TRTLLM
       parallel:
-        enable_parallel_vae: true
+        parallel_vae_size: 8
         dit_cfg_size: 2
         dit_ulysses_size: 4
       cuda_graph:

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py
@@ -109,6 +109,16 @@ def _create_small_vae(device):
     return vae
 
 
+def _create_parallel_vae(vae, world_size, split_dim):
+    ranks = list(range(world_size))
+    pg = dist.new_group(ranks, use_local_synchronization=True)
+    adj_groups = [
+        dist.new_group([ranks[i], ranks[i + 1]], use_local_synchronization=True)
+        for i in range(world_size - 1)
+    ]
+    return ParallelVAE_Wan(vae, pg, ParallelVAE_Wan.make_spec(split_dim), adj_groups)
+
+
 # ===========================================================================
 # Test-logic functions
 # ===========================================================================
@@ -128,8 +138,7 @@ def _logic_decode_width(rank, world_size):
     with torch.no_grad():
         ref = vae.decode(latent, return_dict=False)[0].detach().clone()
 
-    pg = dist.new_group(list(range(world_size)))
-    parallel = ParallelVAE_Wan(vae, pg, ParallelVAE_Wan.make_spec("width"))
+    parallel = _create_parallel_vae(vae, world_size, "width")
 
     with torch.no_grad():
         par = parallel.decode(latent, return_dict=False)[0]
@@ -153,8 +162,7 @@ def _logic_encode_width(rank, world_size):
     with torch.no_grad():
         ref = vae.encode(video).latent_dist.mode().detach().clone()
 
-    pg = dist.new_group(list(range(world_size)))
-    parallel = ParallelVAE_Wan(vae, pg, ParallelVAE_Wan.make_spec("width"))
+    parallel = _create_parallel_vae(vae, world_size, "width")
 
     with torch.no_grad():
         par = parallel.encode(video).latent_dist.mode()
@@ -176,8 +184,7 @@ def _logic_encode_width_return_dict_false(rank, world_size):
     with torch.no_grad():
         ref = vae.encode(video, return_dict=False)[0].mode().detach().clone()
 
-    pg = dist.new_group(list(range(world_size)))
-    parallel = ParallelVAE_Wan(vae, pg, ParallelVAE_Wan.make_spec("width"))
+    parallel = _create_parallel_vae(vae, world_size, "width")
 
     with torch.no_grad():
         out = parallel.encode(video, return_dict=False)
@@ -202,8 +209,7 @@ def _logic_encode_width_sample(rank, world_size):
     with torch.no_grad():
         ref = vae.encode(video).latent_dist.sample(generator=generator).detach().clone()
 
-    pg = dist.new_group(list(range(world_size)))
-    parallel = ParallelVAE_Wan(vae, pg, ParallelVAE_Wan.make_spec("width"))
+    parallel = _create_parallel_vae(vae, world_size, "width")
 
     generator = torch.Generator(device=device).manual_seed(42)
     with torch.no_grad():
@@ -226,8 +232,7 @@ def _logic_decode_width_return_dict_true(rank, world_size):
     with torch.no_grad():
         ref = vae.decode(latent).sample.detach().clone()
 
-    pg = dist.new_group(list(range(world_size)))
-    parallel = ParallelVAE_Wan(vae, pg, ParallelVAE_Wan.make_spec("width"))
+    parallel = _create_parallel_vae(vae, world_size, "width")
 
     with torch.no_grad():
         out = parallel.decode(latent)
@@ -252,8 +257,7 @@ def _logic_decode_height(rank, world_size):
     with torch.no_grad():
         ref = vae.decode(latent, return_dict=False)[0].detach().clone()
 
-    pg = dist.new_group(list(range(world_size)))
-    parallel = ParallelVAE_Wan(vae, pg, ParallelVAE_Wan.make_spec("height"))
+    parallel = _create_parallel_vae(vae, world_size, "height")
 
     with torch.no_grad():
         par = parallel.decode(latent, return_dict=False)[0]
@@ -276,8 +280,7 @@ def _logic_encode_height(rank, world_size):
     with torch.no_grad():
         ref = vae.encode(video).latent_dist.mode().detach().clone()
 
-    pg = dist.new_group(list(range(world_size)))
-    parallel = ParallelVAE_Wan(vae, pg, ParallelVAE_Wan.make_spec("height"))
+    parallel = _create_parallel_vae(vae, world_size, "height")
 
     with torch.no_grad():
         par = parallel.encode(video).latent_dist.mode()

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_parallel_vae.py
@@ -111,9 +111,9 @@ def _create_small_vae(device):
 
 def _create_parallel_vae(vae, world_size, split_dim):
     ranks = list(range(world_size))
-    pg = dist.new_group(ranks, use_local_synchronization=True)
+    pg = dist.new_group(ranks, use_local_synchronization=False)
     adj_groups = [
-        dist.new_group([ranks[i], ranks[i + 1]], use_local_synchronization=True)
+        dist.new_group([ranks[i], ranks[i + 1]], use_local_synchronization=False)
         for i in range(world_size - 1)
     ]
     return ParallelVAE_Wan(vae, pg, ParallelVAE_Wan.make_spec(split_dim), adj_groups)

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
@@ -374,7 +374,7 @@ def _logic_attn2d_mesh_rank_and_group(rank, world_size):
 
 
 def _logic_vae_group_and_adj_groups(rank, world_size):
-    """VAE group uses the first N ranks and stores adjacent groups only on member ranks."""
+    """VAE group uses the first N ranks and stores adjacent groups by pair index."""
     from tensorrt_llm._torch.device_mesh import DeviceMeshTopologyImpl
 
     DeviceMeshTopologyImpl.device_mesh = None
@@ -390,13 +390,50 @@ def _logic_vae_group_and_adj_groups(rank, world_size):
     if rank < 3:
         assert vgm.vae_group is not None
         assert dist.get_world_size(vgm.vae_group) == 3
-        expected_adj_groups = 1 if rank in (0, 2) else 2
-        assert len(vgm.vae_adj_groups) == expected_adj_groups
-        for adj_group in vgm.vae_adj_groups:
-            assert dist.get_world_size(adj_group) == 2
+        assert len(vgm.vae_adj_groups) == 2
+        for i, adj_group in enumerate(vgm.vae_adj_groups):
+            if rank in (i, i + 1):
+                assert adj_group is not None
+                assert dist.get_world_size(adj_group) == 2
+            else:
+                assert adj_group is None
     else:
         assert vgm.vae_group is None
         assert vgm.vae_adj_groups == []
+
+
+def _logic_vae_group_full_world_cfg2_ulysses2(rank, world_size):
+    """Regression: full-world VAE group works for cfg=2, ulysses=2."""
+    from tensorrt_llm._torch.device_mesh import DeviceMeshTopologyImpl
+
+    DeviceMeshTopologyImpl.device_mesh = None
+
+    vgm = VisualGenMapping(
+        world_size=world_size,
+        rank=rank,
+        cfg_size=2,
+        ulysses_size=2,
+        parallel_vae_size=4,
+    )
+
+    assert vgm.vae_ranks == [0, 1, 2, 3]
+    assert vgm.vae_group is not None
+    assert dist.get_world_size(vgm.vae_group) == 4
+    assert len(vgm.vae_adj_groups) == 3
+
+    for i, adj_group in enumerate(vgm.vae_adj_groups):
+        if rank in (i, i + 1):
+            assert adj_group is not None
+            assert dist.get_world_size(adj_group) == 2
+        else:
+            assert adj_group is None
+
+    device = torch.device(f"cuda:{rank}")
+    tensor = torch.ones(1, device=device)
+    dist.all_reduce(tensor, group=vgm.vae_group)
+    assert tensor.item() == float(world_size), (
+        f"Rank {rank}: expected all_reduce sum {world_size}, got {tensor.item()}"
+    )
 
 
 @pytest.mark.skipif(not MODULES_AVAILABLE, reason="Modules not available")
@@ -416,3 +453,6 @@ class TestMultiGPU:
 
     def test_vae_group_and_adj_groups(self):
         _run_multi_gpu(4, _logic_vae_group_and_adj_groups)
+
+    def test_vae_group_full_world_cfg2_ulysses2(self):
+        _run_multi_gpu(4, _logic_vae_group_full_world_cfg2_ulysses2)

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
@@ -73,6 +73,9 @@ class TestConstruction:
         assert vgm.tp_size == 1
         assert vgm.cp_size == 1
         assert vgm.ulysses_size == 1
+        assert vgm.parallel_vae_size == 1
+        assert vgm.vae_ranks == [0]
+        assert vgm.vae_group is None
 
     def test_stores_sizes(self):
         vgm = VisualGenMapping(
@@ -88,6 +91,17 @@ class TestConstruction:
         assert vgm.ulysses_size == 2
         assert vgm.world_size == 8
 
+    def test_stores_parallel_vae_ranks(self):
+        vgm = VisualGenMapping(
+            world_size=4,
+            rank=0,
+            ulysses_size=4,
+            parallel_vae_size=2,
+        )
+        assert vgm.parallel_vae_size == 2
+        assert vgm.vae_ranks == [0, 1]
+        assert vgm.vae_group is None
+
     def test_stores_attn2d_sizes(self):
         vgm = VisualGenMapping(
             world_size=4,
@@ -102,6 +116,10 @@ class TestConstruction:
     def test_product_mismatch_raises(self):
         with pytest.raises(ValueError, match="!= world_size"):
             VisualGenMapping(world_size=4, rank=0, cfg_size=2, ulysses_size=3)
+
+    def test_parallel_vae_size_cannot_exceed_world_size(self):
+        with pytest.raises(ValueError, match="cannot exceed world_size"):
+            VisualGenMapping(world_size=1, rank=0, parallel_vae_size=2)
 
     def test_invalid_order_raises(self):
         with pytest.raises(ValueError, match="permutation"):

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_visual_gen_mapping.py
@@ -76,6 +76,7 @@ class TestConstruction:
         assert vgm.parallel_vae_size == 1
         assert vgm.vae_ranks == [0]
         assert vgm.vae_group is None
+        assert vgm.vae_adj_groups == []
 
     def test_stores_sizes(self):
         vgm = VisualGenMapping(
@@ -101,6 +102,7 @@ class TestConstruction:
         assert vgm.parallel_vae_size == 2
         assert vgm.vae_ranks == [0, 1]
         assert vgm.vae_group is None
+        assert vgm.vae_adj_groups == []
 
     def test_stores_attn2d_sizes(self):
         vgm = VisualGenMapping(
@@ -371,6 +373,32 @@ def _logic_attn2d_mesh_rank_and_group(rank, world_size):
     )
 
 
+def _logic_vae_group_and_adj_groups(rank, world_size):
+    """VAE group uses the first N ranks and stores adjacent groups only on member ranks."""
+    from tensorrt_llm._torch.device_mesh import DeviceMeshTopologyImpl
+
+    DeviceMeshTopologyImpl.device_mesh = None
+
+    vgm = VisualGenMapping(
+        world_size=world_size,
+        rank=rank,
+        ulysses_size=world_size,
+        parallel_vae_size=3,
+    )
+
+    assert vgm.vae_ranks == [0, 1, 2]
+    if rank < 3:
+        assert vgm.vae_group is not None
+        assert dist.get_world_size(vgm.vae_group) == 3
+        expected_adj_groups = 1 if rank in (0, 2) else 2
+        assert len(vgm.vae_adj_groups) == expected_adj_groups
+        for adj_group in vgm.vae_adj_groups:
+            assert dist.get_world_size(adj_group) == 2
+    else:
+        assert vgm.vae_group is None
+        assert vgm.vae_adj_groups == []
+
+
 @pytest.mark.skipif(not MODULES_AVAILABLE, reason="Modules not available")
 class TestMultiGPU:
     def test_default_order_cfg2_ulysses2(self):
@@ -385,3 +413,6 @@ class TestMultiGPU:
     def test_attn2d_mesh_rank_and_group(self):
         """attn2d_mesh_rank aliases cp_rank and attn2d_mesh_group supports collectives."""
         _run_multi_gpu(4, _logic_attn2d_mesh_rank_and_group)
+
+    def test_vae_group_and_adj_groups(self):
+        _run_multi_gpu(4, _logic_vae_group_and_adj_groups)

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_pipeline_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_wan_pipeline_parallel.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-GPU end-to-end test for the Wan T2V pipeline.
+
+Run with:
+    pytest tests/unittest/_torch/visual_gen/multi_gpu/test_wan_pipeline_parallel.py -v -s
+
+Override checkpoint path:
+    DIFFUSION_MODEL_PATH_WAN21_1_3B=/path/to/1.3b \\
+        pytest tests/unittest/_torch/visual_gen/multi_gpu/test_wan_pipeline_parallel.py -v -s
+"""
+
+import gc
+import os
+from pathlib import Path
+from typing import Callable
+
+os.environ["TLLM_DISABLE_MPI"] = "1"
+
+import numpy as np
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+try:
+    from diffusers import DiffusionPipeline
+
+    from tensorrt_llm._torch.visual_gen.config import (
+        ParallelConfig,
+        TorchCompileConfig,
+        VisualGenArgs,
+    )
+    from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
+    from tensorrt_llm._utils import get_free_port
+
+    MODULES_AVAILABLE = True
+except ImportError:
+    MODULES_AVAILABLE = False
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _cleanup_mpi_env():
+    yield
+    os.environ.pop("TLLM_DISABLE_MPI", None)
+
+
+# =============================================================================
+# Path helpers (mirror tests/unittest/_torch/visual_gen/test_wan21_t2v_pipeline.py)
+# =============================================================================
+
+
+def _llm_models_root() -> str:
+    root = Path("/home/scratch.trt_llm_data_ci/llm-models/")
+    if "LLM_MODELS_ROOT" in os.environ:
+        root = Path(os.environ["LLM_MODELS_ROOT"])
+    if not root.exists():
+        root = Path("/scratch.trt_llm_data/llm-models/")
+    assert root.exists(), (
+        "Set LLM_MODELS_ROOT or ensure /home/scratch.trt_llm_data_ci/llm-models/ is accessible."
+    )
+    return str(root)
+
+
+def _checkpoint(env_var: str, default_name: str) -> str:
+    return os.environ.get(env_var) or os.path.join(_llm_models_root(), default_name)
+
+
+WAN21_1_3B_PATH = _checkpoint("DIFFUSION_MODEL_PATH_WAN21_1_3B", "Wan2.1-T2V-1.3B-Diffusers")
+
+
+# =============================================================================
+# Inference constants
+# =============================================================================
+
+PROMPT = "A cat sitting on a sunny windowsill watching birds outside."
+NEGATIVE_PROMPT = ""
+
+HEIGHT = 480
+WIDTH = 832
+NUM_FRAMES = 9
+NUM_STEPS = 4
+GUIDANCE_SCALE = 5.0
+SEED = 42
+
+# Relaxed vs the 0.99 single-GPU threshold: cross-rank CFG all-gather, Ulysses
+# all-to-all, and parallel-VAE halo exchange add bf16 reduction-order noise.
+COS_SIM_THRESHOLD = 0.97
+
+
+# =============================================================================
+# Distributed harness (mirrors tests/.../multi_gpu/test_wan_attn2d.py)
+# =============================================================================
+
+
+def init_distributed_worker(rank: int, world_size: int, backend: str = "nccl", port: int = 29500):
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank % torch.cuda.device_count())
+    dist.init_process_group(backend=backend, rank=rank, world_size=world_size)
+
+
+def cleanup_distributed():
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _distributed_worker(rank, world_size, backend, test_fn, port, kwargs):
+    try:
+        init_distributed_worker(rank, world_size, backend, port)
+        test_fn(rank, world_size, **kwargs)
+    except Exception as e:
+        print(f"Rank {rank} failed with error: {e}")
+        raise
+    finally:
+        cleanup_distributed()
+
+
+def run_test_in_distributed(world_size: int, test_fn: Callable, **kwargs):
+    if not MODULES_AVAILABLE:
+        pytest.skip("Required modules not available")
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(f"Test requires {world_size} GPUs, only {torch.cuda.device_count()} available")
+    port = get_free_port()
+    mp.spawn(
+        _distributed_worker,
+        args=(world_size, "nccl", test_fn, port, kwargs),
+        nprocs=world_size,
+        join=True,
+    )
+
+
+# =============================================================================
+# Inference helpers
+# =============================================================================
+
+
+def _build_parallel_args(checkpoint_path: str) -> "VisualGenArgs":
+    """Build VisualGenArgs with cfg=2, ulysses=2, parallel_vae=2."""
+    return VisualGenArgs(
+        checkpoint_path=checkpoint_path,
+        device="cuda",
+        dtype="bfloat16",
+        torch_compile=TorchCompileConfig(enable_torch_compile=False),
+        parallel=ParallelConfig(
+            dit_cfg_size=2,
+            dit_ulysses_size=2,
+            parallel_vae_size=2,
+            parallel_vae_split_dim="width",
+        ),
+    )
+
+
+def _capture_trtllm_video(
+    pipeline,
+    height: int,
+    width: int,
+    num_frames: int,
+    num_inference_steps: int,
+    guidance_scale: float,
+    seed: int,
+):
+    """Run full TRTLLM pipeline (text -> denoise -> parallel VAE decode).
+
+    Returns (T, H, W, C) float in [0, 1] on the calling rank if it owns the
+    VAE decode, else ``None``. With parallel-VAE enabled, every rank in
+    ``vae_ranks`` ends up with the gathered full-resolution video, so on the
+    full-world config used here every rank gets a video.
+    """
+    with torch.no_grad():
+        result = pipeline.forward(
+            prompt=PROMPT,
+            negative_prompt=NEGATIVE_PROMPT,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+            seed=seed,
+        )
+    if result is None or result.video is None:
+        return None
+    video = result.video  # (T, H, W, C) uint8
+    return video.float() / 255.0
+
+
+def _capture_hf_video(
+    hf_pipe,
+    height: int,
+    width: int,
+    num_frames: int,
+    num_inference_steps: int,
+    guidance_scale: float,
+    seed: int,
+) -> torch.Tensor:
+    """Single-GPU HF reference. Returns (T, H, W, C) float in [0, 1]."""
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    output = hf_pipe(
+        prompt=PROMPT,
+        negative_prompt=NEGATIVE_PROMPT,
+        height=height,
+        width=width,
+        num_frames=num_frames,
+        num_inference_steps=num_inference_steps,
+        guidance_scale=guidance_scale,
+        generator=generator,
+        output_type="np",
+    )
+    frames = output.frames  # (1, T, H, W, C) np.float32 in [0, 1]
+    if isinstance(frames, np.ndarray):
+        return torch.from_numpy(frames[0]).float()
+    return frames[0].float()
+
+
+def _cosine_similarity(a: torch.Tensor, b: torch.Tensor) -> float:
+    a_flat = a.float().cpu().reshape(-1)
+    b_flat = b.float().cpu().reshape(-1)
+    return F.cosine_similarity(a_flat.unsqueeze(0), b_flat.unsqueeze(0)).clamp(-1.0, 1.0).item()
+
+
+def _free(*objs) -> None:
+    for o in objs:
+        del o
+    gc.collect()
+    torch.cuda.empty_cache()
+
+
+# =============================================================================
+# Worker logic (module-level for mp.spawn pickling)
+# =============================================================================
+
+
+def _logic_wan_cfg_ulysses_pvae(rank: int, world_size: int, *, checkpoint_path: str) -> None:
+    """End-to-end pipeline run with cfg=2, ulysses=2, parallel_vae=2.
+
+    All ranks participate in the TRTLLM forward (CFG parallel, Ulysses, parallel
+    VAE). Only rank 0 holds onto the video and runs the HF reference for the
+    cosine-similarity assertion; other ranks free state and exit.
+    """
+    assert world_size == 4, f"This test is hardcoded to world_size=4, got {world_size}"
+
+    trtllm_pipe = PipelineLoader(_build_parallel_args(checkpoint_path)).load(skip_warmup=True)
+    trtllm_video = _capture_trtllm_video(
+        trtllm_pipe,
+        height=HEIGHT,
+        width=WIDTH,
+        num_frames=NUM_FRAMES,
+        num_inference_steps=NUM_STEPS,
+        guidance_scale=GUIDANCE_SCALE,
+        seed=SEED,
+    )
+
+    # With parallel_vae_size == world_size, rank 0 is in vae_ranks and must
+    # have a decoded video. Surface a clearer error than a downstream None deref.
+    if rank == 0:
+        assert trtllm_video is not None, (
+            "Rank 0 unexpectedly produced no video — parallel VAE decode ownership is broken."
+        )
+
+    # Free TRTLLM state on every rank before rank 0 spins up HF on cuda:0.
+    _free(trtllm_pipe)
+    if rank != 0:
+        trtllm_video = None  # not used; release the reference
+    dist.barrier()
+
+    if rank != 0:
+        return
+
+    hf_pipe = DiffusionPipeline.from_pretrained(checkpoint_path, torch_dtype=torch.bfloat16)
+    hf_pipe = hf_pipe.to("cuda")
+    hf_pipe.set_progress_bar_config(disable=True)
+    hf_video = _capture_hf_video(
+        hf_pipe,
+        height=HEIGHT,
+        width=WIDTH,
+        num_frames=NUM_FRAMES,
+        num_inference_steps=NUM_STEPS,
+        guidance_scale=GUIDANCE_SCALE,
+        seed=SEED,
+    )
+    _free(hf_pipe)
+
+    assert trtllm_video.numel() == hf_video.numel(), (
+        f"Element count mismatch — TRTLLM {tuple(trtllm_video.shape)} "
+        f"({trtllm_video.numel()}) vs HF {tuple(hf_video.shape)} ({hf_video.numel()})"
+    )
+
+    cos_sim = _cosine_similarity(trtllm_video, hf_video)
+    print(
+        f"\n  Wan2.1-T2V-1.3B (cfg=2, ulysses=2, parallel_vae=2) cosine similarity: {cos_sim:.6f}"
+    )
+    assert cos_sim >= COS_SIM_THRESHOLD, (
+        f"Multi-GPU TRTLLM pipeline diverges from HF reference: "
+        f"cosine similarity {cos_sim:.6f} < {COS_SIM_THRESHOLD}. "
+        f"Shapes — TRTLLM: {tuple(trtllm_video.shape)}, HF: {tuple(hf_video.shape)}."
+    )
+
+
+# =============================================================================
+# Test class
+# =============================================================================
+
+
+@pytest.mark.integration
+@pytest.mark.wan_t2v
+class TestWanPipelineParallel:
+    """Multi-GPU correctness for the Wan T2V pipeline with combined parallelism."""
+
+    def test_cfg2_ulysses2_pvae2(self):
+        """world=4, cfg=2, ulysses=2, parallel_vae=2 vs HF reference."""
+        if not MODULES_AVAILABLE:
+            pytest.skip("Required modules not available")
+        if not os.path.exists(WAN21_1_3B_PATH):
+            pytest.skip(
+                f"Checkpoint not found: {WAN21_1_3B_PATH}. Set DIFFUSION_MODEL_PATH_WAN21_1_3B."
+            )
+        run_test_in_distributed(
+            world_size=4,
+            test_fn=_logic_wan_cfg_ulysses_pvae,
+            checkpoint_path=WAN21_1_3B_PATH,
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -220,6 +220,10 @@ class TestParallelConfigValidation:
         pc = ParallelConfig()
         assert pc.seq_parallel_size == 1
 
+    def test_parallel_vae_size_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            ParallelConfig(parallel_vae_size=0)
+
 
 class TestVisualGenArgsPickle:
     """VisualGenArgs must survive pickle round-trip (mp.Process spawn)."""


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallel VAE configuration now uses explicit numeric sizing (`--parallel_vae_size`) instead of boolean enable/disable flag for finer control over VAE parallelization across GPUs.
  * **Default is now 1** - Would prevent errors when scaling Ulysses or CFG as previously assumed VAE size = world size led to errors with some shapes when scaling beyond 4-8 gpus.
  * Can treat this as another dimension but recommended is to maximize the VAE size

* **Configuration Updates**
  * Example configurations and test profiles updated to use the new `parallel_vae_size` parameter format with appropriate GPU-count values.

* **Tests**
  * Added validation tests for parallel VAE size constraints and behavior across different GPU configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
