### PR TITLE
[None][fix] Skip calibration scalars in initialize_dummy_weights

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -113,6 +113,7 @@ def initialize_dummy_weights(
     """
 
     def _get_random_min_max(dtype: torch.dtype) -> Tuple[int, int]:
+        """Return safe (min, max) bounds for uniform sampling of ``dtype``."""
         # These values are not necessarily the largest possible min/max,
         # they need to be small enough to avoid NaNs.
         if dtype in (torch.float8_e4m3fn, torch.int8):
@@ -128,7 +129,24 @@ def initialize_dummy_weights(
         else:
             raise NotImplementedError(f"Unknown quantized type: {dtype}.")
 
-    for param in model.state_dict().values():
+    # Calibration scalars (input_scale / inv_input_scale / kv_scales /
+    # inv_kv_scales / alpha / scalar_alpha) must keep their create_weights
+    # default (typically 1.0). Randomizing them breaks FP8 attention output
+    # and KV cache scaling for any `load_format="dummy"` + IPC update_weights
+    # flow when the checkpoint doesn't ship calibrated values (e.g., HF
+    # FineGrainedFP8, which uses dynamic activation quantization by design).
+    _SKIP_NAME_SUFFIXES = (
+        ".input_scale",
+        ".inv_input_scale",
+        ".kv_scales",
+        ".inv_kv_scales",
+        ".alpha",
+        ".scalar_alpha",
+    )
+
+    for _name, param in model.state_dict().items():
+        if any(_name.endswith(_s) for _s in _SKIP_NAME_SUFFIXES):
+            continue
         generator = torch.Generator(device=param.data.device)
         generator.manual_seed(seed)
         dtype = param.data.dtype

--- a/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py
+++ b/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py
@@ -249,14 +249,17 @@ def test_llm_partial_update_weights(model_dir):
         ("Qwen3/Qwen3-30B-A3B", "Qwen3/Qwen3-30B-A3B-FP8"),
     ],
 )
+@pytest.mark.parametrize("kv_cache_dtype", ["auto", "fp8"])
 @pytest.mark.part2
-def test_llm_update_weights_with_quant_config(model_dir, fp8_model_dir):
+def test_llm_update_weights_with_quant_config(model_dir, fp8_model_dir, kv_cache_dtype):
     model_dir = str(llm_models_root() / model_dir)
     fp8_model_dir = str(llm_models_root() / fp8_model_dir)
     num_hidden_layers = 1
     hf_model = RefHFModelWithIPCHandles(fp8_model_dir, num_hidden_layers=num_hidden_layers)
     tokenizer = AutoTokenizer.from_pretrained(fp8_model_dir)
-    kv_cache_config = KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.1)
+    kv_cache_config = KvCacheConfig(
+        enable_block_reuse=True, free_gpu_memory_fraction=0.1, dtype=kv_cache_dtype
+    )
     moe_config = MoeConfig(backend="DEEPGEMM" if getSMVersion() >= 100 else "CUTLASS")
     llm = LLM(
         model=model_dir,


### PR DESCRIPTION
## Description

`initialize_dummy_weights` randomizes every floating-point Parameter in `state_dict()`, which incorrectly includes 0-D calibration scalars (`input_scale`, `kv_scales`, `alpha`, etc.) that `create_weights` initializes to identity. The seed is reseeded per-Parameter, so every 0-D scalar gets the same value (-2e-4 with seed=0).

For HF FineGrainedFP8 + `load_format="dummy"` + IPC `update_weights`, no calibrated `input_scale` is shipped to overwrite the random value, and attention's FP8-output-quantization path reads it as a scaling factor, saturating FP8 output to noise.

Fix: skip these calibration scalars in the dummy randomization loop.

## Test Coverage

`test_llm_update_weights.py::test_llm_update_weights_with_quant_config` (8B-FP8 & 30B-A3B-FP8).

Before: top-20 ≈14% / ≈47%. After: ≈94% / ≈95%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FP8 attention accuracy by preventing unintended randomization of calibration and scaling parameters during dummy weight initialization when calibrated values are unavailable from checkpoints.
  * Improved KV cache scaling preservation during model loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->