### PR TITLE
[TRTLLM-12430][tests] Add video E2E test for nano v3 omni

### DIFF
--- a/tensorrt_llm/evaluate/audio_asr.py
+++ b/tensorrt_llm/evaluate/audio_asr.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
-import json
 import re
 import unicodedata
 from io import BytesIO
@@ -37,7 +36,7 @@ from tensorrt_llm.llmapi import RequestOutput
 from tensorrt_llm.logger import logger
 from tensorrt_llm.sampling_params import SamplingParams
 
-from .interface import Evaluator, get_chat_template_kwargs
+from .interface import Evaluator, get_chat_template_kwargs, get_model_context
 
 
 class MultimodalASRSample(NamedTuple):
@@ -239,7 +238,7 @@ class AudioASREvaluator(Evaluator):
 
     def _make_input_context(self, llm: Any) -> _ASRInputContext:
         """Resolve the model type, processor, and chat-template settings once per run."""
-        _, model_type = _get_model_context(llm)
+        _, model_type = get_model_context(llm)
         processor = getattr(getattr(llm, "input_processor", None), "processor", None)
         hf_chat_template = resolve_hf_chat_template(llm.tokenizer, processor, None, None)
         return _ASRInputContext(
@@ -302,11 +301,11 @@ class AudioASREvaluator(Evaluator):
             chat_template_kwargs=input_context.chat_template_kwargs,
         )
 
-        input = {"prompt": prompt}
+        request_input = {"prompt": prompt}
         multi_modal_data, _ = mm_data_tracker.retrieve_all_sync()
         if multi_modal_data:
-            input["multi_modal_data"] = multi_modal_data
-        return input
+            request_input["multi_modal_data"] = multi_modal_data
+        return request_input
 
 
 def _resolve_media_path(dataset_path: str, media_path: str) -> str:
@@ -449,7 +448,7 @@ def _compute_wer(
     sample_results = []
     total_edits = 0
     total_words = 0
-    for sample_id, prediction, reference in zip(sample_ids, predictions, references):
+    for sample_id, prediction, reference in zip(sample_ids, predictions, references, strict=True):
         normalized_prediction = _normalize_asr_text(prediction)
         normalized_reference = _normalize_asr_text(reference)
         prediction_words = normalized_prediction.split()
@@ -498,18 +497,3 @@ def _format_worst_sample_report(sample_results: list[ASRWERSampleResult], limit:
             f"  ref ={_truncate_text(result.normalized_reference)!r}"
         )
     return "\n".join(lines)
-
-
-def _get_model_context(llm: Any) -> tuple[str, str]:
-    model_dir = getattr(llm, "_hf_model_dir", None) or getattr(llm, "model", None)
-    if model_dir is None:
-        raise ValueError("The LLM object does not expose a model directory.")
-
-    config_path = Path(model_dir) / "config.json"
-    with open(config_path, "r", encoding="utf-8") as config_file:
-        config = json.load(config_file)
-
-    model_type = config.get("model_type")
-    if model_type is None:
-        raise KeyError(f"'model_type' is missing from {config_path}.")
-    return str(model_dir), model_type

--- a/tensorrt_llm/evaluate/interface.py
+++ b/tensorrt_llm/evaluate/interface.py
@@ -49,6 +49,23 @@ def get_chat_template_kwargs(
     return effective_kwargs
 
 
+def get_model_context(llm: Any) -> tuple[str, str]:
+    """Return the HF model directory and model type for an LLM object."""
+    model_dir = getattr(llm, "_hf_model_dir", None) or getattr(
+        llm, "model", None)
+    if model_dir is None:
+        raise ValueError("The LLM object does not expose a model directory.")
+
+    config_path = os.path.join(str(model_dir), "config.json")
+    with open(config_path, "r", encoding="utf-8") as config_file:
+        config = json.load(config_file)
+
+    model_type = config.get("model_type")
+    if model_type is None:
+        raise KeyError(f"'model_type' is missing from {config_path}.")
+    return str(model_dir), str(model_type)
+
+
 class Evaluator(ABC):
 
     def __init__(self,

--- a/tests/integration/defs/accuracy/accuracy_core.py
+++ b/tests/integration/defs/accuracy/accuracy_core.py
@@ -38,6 +38,7 @@ from tensorrt_llm.quantization import QuantAlgo
 from ..common import venv_check_call, venv_mpi_check_call
 from ..conftest import llm_models_root
 from ..trt_test_alternative import check_call, exists
+from .video_mme import VideoMME as VideoMMEEvaluator
 
 
 def compute_theta(num_samples: int,
@@ -282,6 +283,31 @@ class VoxPopuli(AccuracyTask):
         "dataset_path": DATASET_DIR,
         "split": "test",
         "text_column": "normalized_text",
+    }
+
+
+class VideoMME(AccuracyTask):
+    """Multiple-choice video QA accuracy task on the local Video-MME short shard."""
+
+    DATASET = "videomme"
+    DATASET_DIR = f"{llm_models_root()}/datasets/lmms-lab__Video-MME-short-v1"
+
+    ALPHA = 0.05
+    BETA = 0.2
+    SIGMA = 50.0
+    NUM_SAMPLES = 300
+
+    MAX_BATCH_SIZE = 128
+    MAX_INPUT_LEN = 32768
+    # The prompt asks for one option letter; keep a compact cap with room for
+    # short extra text.
+    MAX_OUTPUT_LEN = 32
+
+    EVALUATOR_CLS = VideoMMEEvaluator
+    EVALUATOR_KWARGS = {
+        "dataset_path": DATASET_DIR,
+        "random_seed": 0,
+        "num_frames": 8,
     }
 
 

--- a/tests/integration/defs/accuracy/references/videomme.yaml
+++ b/tests/integration/defs/accuracy/references/videomme.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Initial Video-MME short-shard guardrail for E2E video QA. Update these values
+# after collecting stable model baselines on the generated 300-question shard.
+nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-FP8:
+  - quant_algo: FP8
+    kv_cache_quant_algo: FP8
+    accuracy: 69.5
+    num_samples: 300
+nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4:
+  - quant_algo: MIXED_PRECISION
+    kv_cache_quant_algo: FP8
+    accuracy: 68.0
+    num_samples: 300

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
@@ -19,7 +19,7 @@ from tensorrt_llm.llmapi import CudaGraphConfig, KvCacheConfig, MoeConfig, Sampl
 from tensorrt_llm.quantization import QuantAlgo
 
 from ..conftest import llm_models_root, skip_pre_blackwell, skip_pre_hopper
-from .accuracy_core import MMMU, LlmapiAccuracyTestHarness, VoxPopuli
+from .accuracy_core import MMMU, LlmapiAccuracyTestHarness, VideoMME, VoxPopuli
 
 
 class TestQwen2_VL_7B(LlmapiAccuracyTestHarness):
@@ -509,7 +509,7 @@ class TestNanoV3Omni(LlmapiAccuracyTestHarness):
         temperature=0.0,
         top_k=1,
     )
-    voxpopuli_extra_evaluator_kwargs = {
+    no_thinking_evaluator_kwargs = {
         # We explicitly disable thinking, because otherwise the thinking traces could
         # be absurdly long (20k+ tokens), which is not helpful for test-runtime, nor
         # for reproducibility (the more tokens there are, the higher likelihood of the
@@ -521,7 +521,19 @@ class TestNanoV3Omni(LlmapiAccuracyTestHarness):
     VOXPOPULI_TASK_SPEC = (
         VoxPopuli,
         voxpopuli_sampling_params,
-        voxpopuli_extra_evaluator_kwargs,
+        no_thinking_evaluator_kwargs,
+    )
+
+    videomme_sampling_params = SamplingParams(
+        max_tokens=VideoMME.MAX_OUTPUT_LEN,
+        truncate_prompt_tokens=VideoMME.MAX_INPUT_LEN,
+        temperature=0.0,
+        top_k=1,
+    )
+    VIDEOMME_TASK_SPEC = (
+        VideoMME,
+        videomme_sampling_params,
+        no_thinking_evaluator_kwargs,
     )
 
     @pytest.mark.skip_less_device_memory(80000)
@@ -552,7 +564,7 @@ class TestNanoV3Omni(LlmapiAccuracyTestHarness):
                 ),
                 64,
                 QuantAlgo.FP8,
-                (MMMU_TASK_SPEC, VOXPOPULI_TASK_SPEC),
+                (MMMU_TASK_SPEC, VOXPOPULI_TASK_SPEC, VIDEOMME_TASK_SPEC),
                 marks=skip_pre_hopper,
                 id="fp8",
             ),
@@ -567,7 +579,7 @@ class TestNanoV3Omni(LlmapiAccuracyTestHarness):
                 ),
                 128,
                 QuantAlgo.MIXED_PRECISION,
-                (MMMU_TASK_SPEC, VOXPOPULI_TASK_SPEC),
+                (MMMU_TASK_SPEC, VOXPOPULI_TASK_SPEC, VIDEOMME_TASK_SPEC),
                 marks=skip_pre_blackwell,
                 id="nvfp4",
             ),

--- a/tests/integration/defs/accuracy/video_mme.py
+++ b/tests/integration/defs/accuracy/video_mme.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable, NamedTuple, Optional
+
+from tqdm import tqdm
+
+import tensorrt_llm.profiler as profiler
+from tensorrt_llm.evaluate.interface import (
+    Evaluator,
+    dump_inference_results,
+    get_chat_template_kwargs,
+    get_model_context,
+)
+from tensorrt_llm.inputs import (
+    ConversationMessage,
+    MultimodalData,
+    MultimodalDataTracker,
+    add_multimodal_placeholders,
+    load_video,
+)
+from tensorrt_llm.inputs.content_format import ContentFormat
+from tensorrt_llm.inputs.utils import _resolve_content_format, resolve_hf_chat_template
+from tensorrt_llm.inputs.utils import apply_chat_template as trtllm_apply_chat_template
+from tensorrt_llm.llmapi import RequestOutput
+from tensorrt_llm.logger import logger
+from tensorrt_llm.sampling_params import SamplingParams
+
+PROMPT_PREAMBLE = (
+    "Answer the question based on the video. Select the best option. "
+    "Respond with only the option letter (A, B, C, or D)."
+)
+ANNOTATIONS_FILE = "annotations.jsonl"
+
+
+class VideoQASample(NamedTuple):
+    """A single multiple-choice video QA sample."""
+
+    sample_id: str
+    video_path: str
+    question: str
+    options: tuple[str, ...]
+    answer: str
+
+
+class VideoQASampleResult(NamedTuple):
+    """Per-sample scoring result for MCQ video QA."""
+
+    sample_id: str
+    prediction: str
+    predicted_letter: Optional[str]
+    reference: str
+
+    @property
+    def is_correct(self) -> bool:
+        return self.predicted_letter == self.reference
+
+
+class _VideoInputContext(NamedTuple):
+    """Per-LLM context needed to render chat-templated video prompts."""
+
+    model_type: str
+    processor: Any
+    content_format: ContentFormat
+    chat_template_kwargs: dict[str, Any]
+
+
+class VideoMME(Evaluator):
+    """Evaluator for a local Video-MME-style multiple-choice video QA shard."""
+
+    def __init__(
+        self,
+        dataset_path: str,
+        num_samples: Optional[int] = None,
+        random_seed: int = 0,
+        num_frames: int = 8,
+        chat_template_kwargs: Optional[dict[str, Any]] = None,
+        output_dir: Optional[str] = None,
+    ) -> None:
+        super().__init__(
+            random_seed=random_seed,
+            apply_chat_template=True,
+            chat_template_kwargs=chat_template_kwargs,
+            output_dir=output_dir,
+        )
+        self.dataset_path = Path(dataset_path)
+        self.annotations_path = self.dataset_path / ANNOTATIONS_FILE
+        self.num_samples = num_samples
+        self.num_frames = num_frames
+
+    def generate_samples(self) -> Iterable[tuple]:
+        # Required by the abstract base, but `evaluate()` is fully overridden so
+        # the base-class flow that would call `generate_samples` is never reached.
+        raise NotImplementedError
+
+    def compute_score(
+        self,
+        outputs: list[RequestOutput],
+        references: list[str],
+        samples: list[VideoQASample],
+    ) -> float:
+        predictions = [output.outputs[0].text for output in outputs]
+        sample_results = _score_video_qa_predictions(predictions, references, samples)
+
+        correct = sum(result.is_correct for result in sample_results)
+        accuracy = 100.0 * correct / len(sample_results) if sample_results else 0.0
+        logger.info(f"VideoMME accuracy: {accuracy:.2f} ({correct}/{len(sample_results)})")
+        if correct != len(sample_results):
+            logger.info(f"VideoMME mismatches:\n{_format_mismatch_report(sample_results)}")
+        return accuracy
+
+    def evaluate(
+        self,
+        llm: Any,
+        sampling_params: Optional[SamplingParams] = None,
+        streaming: bool = False,
+    ) -> float:
+        profiler.start("trtllm exec")
+        input_context = self._make_input_context(llm)
+        samples = list(tqdm(self._iter_samples(), desc="Loading samples", total=self.num_samples))
+        video_cache: dict[str, Any] = {}
+        inputs = [
+            self._make_input(llm, sample, input_context, video_cache)
+            for sample in tqdm(samples, desc="Loading inputs")
+        ]
+
+        futures = []
+        for request_input in tqdm(inputs, desc="Submitting requests"):
+            params = (
+                copy.deepcopy(sampling_params) if sampling_params is not None else SamplingParams()
+            )
+            futures.append(
+                llm.generate_async(
+                    request_input,
+                    sampling_params=params,
+                    streaming=streaming,
+                )
+            )
+        outputs = [future.result() for future in tqdm(futures, desc="Fetching responses")]
+
+        if self.output_dir:
+            dump_inference_results(self.output_dir, outputs, getattr(llm, "tokenizer", None))
+
+        profiler.stop("trtllm exec")
+        elapsed_time = profiler.elapsed_time_in_sec("trtllm exec")
+        logger.info(f"TRTLLM execution time: {elapsed_time:.3f} seconds.")
+        profiler.reset("trtllm exec")
+
+        references = [sample.answer for sample in samples]
+        return self.compute_score(outputs, references, samples)
+
+    def _iter_samples(self) -> Iterable[VideoQASample]:
+        with open(self.annotations_path, "r", encoding="utf-8") as annotations_file:
+            for idx, line in enumerate(annotations_file):
+                if self.num_samples is not None and idx >= self.num_samples:
+                    break
+                row = json.loads(line)
+                video_path = Path(str(row["video_path"]))
+                if not video_path.is_absolute():
+                    video_path = self.dataset_path / video_path
+                yield VideoQASample(
+                    sample_id=str(row.get("sample_id", idx)),
+                    video_path=str(video_path),
+                    question=str(row["question"]),
+                    options=tuple(str(option) for option in row["options"]),
+                    answer=_normalize_answer(str(row["answer"])),
+                )
+
+    def _make_input_context(self, llm: Any) -> _VideoInputContext:
+        _, model_type = get_model_context(llm)
+        processor = getattr(getattr(llm, "input_processor", None), "processor", None)
+        hf_chat_template = resolve_hf_chat_template(llm.tokenizer, processor, None, None)
+        return _VideoInputContext(
+            model_type=model_type,
+            processor=processor,
+            content_format=_resolve_content_format(model_type, hf_chat_template),
+            chat_template_kwargs=get_chat_template_kwargs(
+                processor or llm.tokenizer, self.chat_template_kwargs
+            ),
+        )
+
+    def _make_input(
+        self,
+        llm: Any,
+        sample: VideoQASample,
+        input_context: _VideoInputContext,
+        video_cache: dict[str, Any],
+    ) -> dict[str, Any]:
+        mm_data_tracker = MultimodalDataTracker(input_context.model_type)
+        video = video_cache.get(sample.video_path)
+        if video is None:
+            video = load_video(sample.video_path, num_frames=self.num_frames)
+            video_cache[sample.video_path] = video
+
+        prompt_text = _format_video_qa_prompt(sample)
+        conv = ConversationMessage(
+            role="user",
+            content=prompt_text,
+            media=[
+                MultimodalData(
+                    modality="video",
+                    data=video,
+                    is_embedding=False,
+                )
+            ],
+        )
+        for mdata in conv["media"]:
+            mm_data_tracker.add_data(
+                mdata["modality"],
+                mdata["data"],
+                is_embedding=mdata["is_embedding"],
+            )
+
+        mm_placeholder_counts = mm_data_tracker.placeholder_counts()
+        if mm_placeholder_counts and input_context.content_format != ContentFormat.OPENAI:
+            conv["content"] = add_multimodal_placeholders(
+                input_context.model_type, conv["content"], mm_placeholder_counts
+            )
+
+        prompt = trtllm_apply_chat_template(
+            model_type=input_context.model_type,
+            tokenizer=llm.tokenizer,
+            processor=input_context.processor,
+            conversation=[conv],
+            add_generation_prompt=True,
+            mm_placeholder_counts=[mm_placeholder_counts],
+            chat_template_kwargs=input_context.chat_template_kwargs,
+        )
+
+        request_input = {"prompt": prompt}
+        multi_modal_data, _ = mm_data_tracker.retrieve_all_sync()
+        if multi_modal_data:
+            request_input["multi_modal_data"] = multi_modal_data
+        return request_input
+
+
+def _format_video_qa_prompt(sample: VideoQASample) -> str:
+    option_lines = "\n".join(
+        _normalize_option(option, idx) for idx, option in enumerate(sample.options)
+    )
+    return f"{PROMPT_PREAMBLE}\n\nQuestion: {sample.question}\nOptions:\n{option_lines}\nAnswer:"
+
+
+def _normalize_option(option: str, idx: int) -> str:
+    option = option.strip()
+    if re.match(r"^[A-D][.)]\s+", option, flags=re.IGNORECASE):
+        return option
+    label = chr(ord("A") + idx)
+    return f"{label}. {option}"
+
+
+def _normalize_answer(answer: str) -> str:
+    answer = answer.strip().upper()
+    if answer not in {"A", "B", "C", "D"}:
+        raise ValueError(f"Expected answer to be one of A, B, C, D; got {answer!r}.")
+    return answer
+
+
+def extract_choice_answer(text: str) -> Optional[str]:
+    """Extract an A-D answer from model output."""
+    match = re.search(r"\b([A-D])\b", text, flags=re.IGNORECASE)
+    return match.group(1).upper() if match else None
+
+
+def _score_video_qa_predictions(
+    predictions: list[str],
+    references: list[str],
+    samples: list[VideoQASample],
+) -> list[VideoQASampleResult]:
+    sample_results = []
+    for sample, prediction, reference in zip(samples, predictions, references, strict=True):
+        sample_results.append(
+            VideoQASampleResult(
+                sample_id=sample.sample_id,
+                prediction=prediction,
+                predicted_letter=extract_choice_answer(prediction),
+                reference=reference,
+            )
+        )
+    return sample_results
+
+
+def _format_mismatch_report(
+    sample_results: list[VideoQASampleResult],
+    limit: int = 10,
+) -> str:
+    mismatches = [result for result in sample_results if not result.is_correct][:limit]
+    lines = []
+    for result in mismatches:
+        prediction = re.sub(r"\s+", " ", result.prediction).strip()
+        if len(prediction) > 240:
+            prediction = f"{prediction[:237]}..."
+        lines.append(
+            f"sample={result.sample_id} predicted={result.predicted_letter} "
+            f"reference={result.reference} text={prediction!r}"
+        )
+    return "\n".join(lines)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Audio automatic speech recognition (ASR) evaluation now available
  * Video question-answering (QA) evaluation now available
  * Evaluation framework enhanced to support custom metrics beyond accuracy

* **Tests**
  * Added reference benchmarks for ASR and video QA evaluations
  * Expanded multimodal test support to evaluate multiple tasks concurrently
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR adds a new video MCQ evaluation harness, which is used
with a subset of the Video-MME dataset's short videos against
Nano v3 Omni.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
