### PR TITLE
[None][fix] avoid stale cublas wrapper contexts

### DIFF
--- a/cpp/tensorrt_llm/thop/cublasFp4ScaledMM.cpp
+++ b/cpp/tensorrt_llm/thop/cublasFp4ScaledMM.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,21 +86,12 @@ void cublas_fp4_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::T
     int32_t k_compressed = a.sizes()[1];
     int32_t k = k_compressed * 2;
 
-    // Use device-aware thread-local CublasMMWrapper for FP4 GEMM
     at::cuda::CUDAGuard deviceGuard(a.device());
-
-    thread_local std::unordered_map<int, std::shared_ptr<CublasMMWrapper>> cublasWrappers;
-    auto& cublasWrapper = cublasWrappers[a.get_device()];
-    if (!cublasWrapper)
-    {
-        auto cublasHandle = getCublasHandle();
-        auto cublasLtHandle = getCublasLtHandle();
-        cublasWrapper = std::make_shared<CublasMMWrapper>(cublasHandle, cublasLtHandle, nullptr, nullptr);
-    }
+    CublasMMWrapper cublasWrapper(getCublasHandle(), getCublasLtHandle(), nullptr, nullptr);
 
     // Set FP4 configuration based on output tensor dtype
     cudaDataType_t outType = getCudaDataType(out.scalar_type());
-    cublasWrapper->setFP4GemmConfig(outType);
+    cublasWrapper.setFP4GemmConfig(outType);
 
     // Get workspace (reuse cached workspace for this device)
     auto const& workspace = getWorkspaceTensor(a.device());
@@ -131,8 +122,8 @@ void cublas_fp4_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::T
     TLLM_CHECK_WITH_INFO(alpha_ptr != nullptr, "alpha_ptr is null");
 
     // Set workspace and stream
-    cublasWrapper->setStream(stream);
-    cublasWrapper->setWorkspace(ws_ptr);
+    cublasWrapper.setStream(stream);
+    cublasWrapper.setWorkspace(ws_ptr);
 
     // Perform FP4 GEMM using CublasMMWrapper
     // Matrix layout conversion for cuBLASLt:
@@ -144,11 +135,11 @@ void cublas_fp4_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::T
     //   3. Passing dimensions as (n, m, k) instead of (m, n, k)
     //   4. Swapping scaling factors to match (b_sf_ptr, a_sf_ptr)
     // Note: beta is always 0 and is managed internally by BlockScaleGemm
-    cublasWrapper->BlockScaleGemm(CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, b_ptr, k, // B matrix (swapped to first position)
-        a_ptr, k,                                                              // A matrix (swapped to second position)
-        out_ptr, n,                                                            // Output: C[m, n] in row-major
-        b_sf_ptr, a_sf_ptr,                                                    // Scaling factors (also swapped)
-        alpha_ptr);                                                            // Uses default algorithm (nullptr)
+    cublasWrapper.BlockScaleGemm(CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, b_ptr, k, // B matrix (swapped to first position)
+        a_ptr, k,                                                             // A matrix (swapped to second position)
+        out_ptr, n,                                                           // Output: C[m, n] in row-major
+        b_sf_ptr, a_sf_ptr,                                                   // Scaling factors (also swapped)
+        alpha_ptr);                                                           // Uses default algorithm (nullptr)
 }
 
 } // namespace
@@ -288,21 +279,18 @@ private:
 
             AlgoCache cache;
 
-            // Create cublas wrapper
             at::cuda::CUDAGuard deviceGuard(device);
-            auto cublasHandle = getCublasHandle();
-            auto cublasLtHandle = getCublasLtHandle();
-            auto cublasWrapper = std::make_shared<CublasMMWrapper>(cublasHandle, cublasLtHandle, nullptr, nullptr);
+            CublasMMWrapper cublasWrapper(getCublasHandle(), getCublasLtHandle(), nullptr, nullptr);
 
             // Set FP4 configuration
             cudaDataType_t outType = mOutputDtype == at::ScalarType::Half
                 ? CUDA_R_16F
                 : (mOutputDtype == at::ScalarType::BFloat16 ? CUDA_R_16BF : CUDA_R_32F);
 
-            cublasWrapper->setFP4GemmConfig(outType);
+            cublasWrapper.setFP4GemmConfig(outType);
 
             // Create descriptors
-            cublasWrapper->createDescriptors(CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, k, k, n, 0);
+            cublasWrapper.createDescriptors(CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, k, k, n, 0);
 
             // Use provided scale tensors for descriptor setup
             // FP4 GEMM always requires scale tensors
@@ -310,10 +298,10 @@ private:
             void* b_sf_ptr = const_cast<void*>(reinterpret_cast<void const*>(mat2_scale.data_ptr()));
 
             // Set scale descriptors (required for FP4 GEMM heuristics)
-            cublasWrapper->setScaleDescriptors(a_sf_ptr, b_sf_ptr);
+            cublasWrapper.setScaleDescriptors(a_sf_ptr, b_sf_ptr);
 
             // Get heuristic algorithms
-            auto heuristics = cublasWrapper->getTactics(CUBLAS_OP_T, CUBLAS_OP_N, m, n, k, k, k, n);
+            auto heuristics = cublasWrapper.getTactics(CUBLAS_OP_T, CUBLAS_OP_N, m, n, k, k, k, n);
 
             // Filter valid algorithms
             for (auto const& h : heuristics)
@@ -336,7 +324,7 @@ private:
                     m, k, n);
             }
 
-            cublasWrapper->destroyDescriptors();
+            cublasWrapper.destroyDescriptors();
 
             mAlgoCache[key] = std::move(cache);
         }
@@ -362,19 +350,11 @@ private:
         int32_t k = k_compressed * 2;
 
         at::cuda::CUDAGuard deviceGuard(a.device());
-
-        thread_local std::unordered_map<int, std::shared_ptr<CublasMMWrapper>> cublasWrappers;
-        auto& cublasWrapper = cublasWrappers[a.get_device()];
-        if (!cublasWrapper)
-        {
-            auto cublasHandle = getCublasHandle();
-            auto cublasLtHandle = getCublasLtHandle();
-            cublasWrapper = std::make_shared<CublasMMWrapper>(cublasHandle, cublasLtHandle, nullptr, nullptr);
-        }
+        CublasMMWrapper cublasWrapper(getCublasHandle(), getCublasLtHandle(), nullptr, nullptr);
 
         // Set FP4 configuration with correct output type
         cudaDataType_t outType = getCudaDataType(output_dtype);
-        cublasWrapper->setFP4GemmConfig(outType);
+        cublasWrapper.setFP4GemmConfig(outType);
 
         // Get workspace (reuse cached workspace for this device)
         auto const& workspace = getWorkspaceTensor(a.device());
@@ -397,8 +377,8 @@ private:
 
         TLLM_CHECK_WITH_INFO(alpha_ptr != nullptr, "alpha_ptr is null");
 
-        cublasWrapper->setStream(stream);
-        cublasWrapper->setWorkspace(ws_ptr);
+        cublasWrapper.setStream(stream);
+        cublasWrapper.setWorkspace(ws_ptr);
 
         // Matrix layout conversion for cuBLASLt (same as in cublas_fp4_gemm_caller):
         //   PyTorch uses row-major layout: A[m, k] x B[n, k]^T = C[m, n]
@@ -411,7 +391,7 @@ private:
 
         // Use BlockScaleGemm with specified algorithm for autotuning
         // Note: beta is always 0 and is managed internally by BlockScaleGemm
-        cublasWrapper->BlockScaleGemm(CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, b_ptr,
+        cublasWrapper.BlockScaleGemm(CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, b_ptr,
             k,                  // B matrix (swapped to first position)
             a_ptr, k,           // A matrix (swapped to second position)
             out_ptr, n,         // Output: C[m, n] in row-major

--- a/cpp/tensorrt_llm/thop/cublasScaledMM.cpp
+++ b/cpp/tensorrt_llm/thop/cublasScaledMM.cpp
@@ -24,6 +24,8 @@
 #include "tensorrt_llm/thop/outputTensor.h"
 #include "tensorrt_llm/thop/thUtils.h"
 #include "userbuffersTensor.h"
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <cublasLt.h>
 #include <torch/extension.h>
 
@@ -63,9 +65,9 @@ void set_algo_attr(cublasLtMatmulAlgo_t& algo, std::array<int, 8> const& attr_li
         cublasLtMatmulAlgoConfigSetAttribute(&algo, CUBLASLT_ALGO_CONFIG_CLUSTER_SHAPE_ID, &cga, sizeof(cga)));
 }
 
-bool find_special_algo(cublasLtMatmulAlgo_t& algo, std::shared_ptr<CublasMMWrapper> const& cublasWrapper, int32_t m,
-    int32_t n, int32_t k, cublasComputeType_t compType, cudaDataType_t scaleType, cudaDataType_t aType,
-    cudaDataType_t bType, cudaDataType_t outType)
+bool find_special_algo(cublasLtMatmulAlgo_t& algo, CublasMMWrapper const& cublasWrapper, int32_t m, int32_t n,
+    int32_t k, cublasComputeType_t compType, cudaDataType_t scaleType, cudaDataType_t aType, cudaDataType_t bType,
+    cudaDataType_t outType)
 {
     int32_t mp2 = std::max(nextPowerOfTwo(m), 8);
     AlgoListType const* algo_list = nullptr;
@@ -91,7 +93,7 @@ bool find_special_algo(cublasLtMatmulAlgo_t& algo, std::shared_ptr<CublasMMWrapp
     {
         int const algoID = algo_iter->second[0];
         check_cuda_error(cublasLtMatmulAlgoInit(
-            cublasWrapper->getCublasLtHandle(), compType, scaleType, aType, bType, outType, outType, algoID, &algo));
+            cublasWrapper.getCublasLtHandle(), compType, scaleType, aType, bType, outType, outType, algoID, &algo));
         TLLM_LOG_DEBUG("Found special cublasLt algo for m=%d, k=%d, n=%d\n", m, k, n);
         set_algo_attr(algo, algo_iter->second);
     }
@@ -99,7 +101,7 @@ bool find_special_algo(cublasLtMatmulAlgo_t& algo, std::shared_ptr<CublasMMWrapp
     {
         int const algoID = 66; // CUBLASLT_MATMUL_ALGO_NVJET
         check_cuda_error(cublasLtMatmulAlgoInit(
-            cublasWrapper->getCublasLtHandle(), compType, scaleType, aType, bType, outType, outType, algoID, &algo));
+            cublasWrapper.getCublasLtHandle(), compType, scaleType, aType, bType, outType, outType, algoID, &algo));
         TLLM_LOG_DEBUG("No special cublasLt algo found for m=%d, k=%d, n=%d\n", m, k, n);
         return false;
     }
@@ -107,8 +109,8 @@ bool find_special_algo(cublasLtMatmulAlgo_t& algo, std::shared_ptr<CublasMMWrapp
     return true;
 }
 
-bool find_special_algo_deprecated(cublasLtMatmulAlgo_t& algo, std::shared_ptr<CublasMMWrapper> const& cublasWrapper,
-    int32_t m, int32_t n, int32_t k, cublasComputeType_t compType, cudaDataType_t scaleType, cudaDataType_t aType,
+bool find_special_algo_deprecated(cublasLtMatmulAlgo_t& algo, CublasMMWrapper const& cublasWrapper, int32_t m,
+    int32_t n, int32_t k, cublasComputeType_t compType, cudaDataType_t scaleType, cudaDataType_t aType,
     cudaDataType_t bType, cudaDataType_t outType)
 {
     int32_t mp2 = std::max(nextPowerOfTwo(m), 8);
@@ -118,7 +120,7 @@ bool find_special_algo_deprecated(cublasLtMatmulAlgo_t& algo, std::shared_ptr<Cu
     }
     int const algoID = 52;
     check_cuda_error(cublasLtMatmulAlgoInit(
-        cublasWrapper->getCublasLtHandle(), compType, scaleType, aType, bType, outType, outType, algoID, &algo));
+        cublasWrapper.getCublasLtHandle(), compType, scaleType, aType, bType, outType, outType, algoID, &algo));
     int tileID = CUBLASLT_MATMUL_TILE_256x128;
     int swizzle = 0;
     uint16_t cga = CUBLASLT_CLUSTER_SHAPE_2x1x1;
@@ -172,13 +174,8 @@ void cublas_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::Tenso
     int32_t n = b.sizes()[1];
     int32_t k = a.sizes()[1];
 
-    thread_local std::shared_ptr<CublasMMWrapper> cublasWrapper;
-    if (cublasWrapper == nullptr)
-    {
-        auto cublasHandle = getCublasHandle();
-        auto cublasLtHandle = getCublasLtHandle();
-        cublasWrapper = std::make_shared<CublasMMWrapper>(cublasHandle, cublasLtHandle, nullptr, nullptr);
-    }
+    at::cuda::CUDAGuard deviceGuard(a.device());
+    CublasMMWrapper cublasWrapper(getCublasHandle(), getCublasLtHandle(), nullptr, nullptr);
 
     cudaDataType_t aType = convert_torch_dtype(a.scalar_type());
     cudaDataType_t bType = convert_torch_dtype(b.scalar_type());
@@ -187,7 +184,7 @@ void cublas_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::Tenso
     // hardcode compute type for FP8
     cublasComputeType_t compType = CUBLAS_COMPUTE_32F;
     cudaDataType_t scaleType = CUDA_R_32F;
-    cublasWrapper->setGemmConfig(aType, bType, outType, /*computeType=*/scaleType);
+    cublasWrapper.setGemmConfig(aType, bType, outType, /*computeType=*/scaleType);
 
     auto const workspace_options = torch::TensorOptions().dtype(torch::kUInt8).device(a.device());
     auto workspace = torch::empty(CUBLAS_WORKSPACE_SIZE, workspace_options);
@@ -213,8 +210,8 @@ void cublas_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::Tenso
         bias_ptr = static_cast<void*>(bias.value().data_ptr());
     }
 
-    cublasWrapper->setStream(stream);
-    cublasWrapper->setWorkspace(ws_ptr);
+    cublasWrapper.setStream(stream);
+    cublasWrapper.setWorkspace(ws_ptr);
 
     // set algo according to m/n/k
     cublasLtMatmulAlgo_t algo;
@@ -227,15 +224,19 @@ void cublas_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::Tenso
 #endif
 
     // swap A and B. A is column major, B is row major.
-    cublasWrapper->createDescriptors(
+    cublasWrapper.createDescriptors(
         CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, /*lda=*/k, /*ldb=*/k, /*ldc=*/n, /*fastAcc=*/fast_acc);
     if (use_scale)
-        cublasWrapper->setScaleDescriptors(a_scale, b_scale);
+    {
+        cublasWrapper.setScaleDescriptors(a_scale, b_scale);
+    }
     if (use_bias)
-        cublasWrapper->setBiasDescriptor(bias_ptr);
-    cublasWrapper->Gemm(CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, /*A=*/b_ptr, /*lda=*/k, /*B=*/a_ptr, /*ldb=*/k, out_ptr,
+    {
+        cublasWrapper.setBiasDescriptor(bias_ptr);
+    }
+    cublasWrapper.Gemm(CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, /*A=*/b_ptr, /*lda=*/k, /*B=*/a_ptr, /*ldb=*/k, out_ptr,
         /*ldc=*/n, 1.0F, 0.0F, algo, has_algo, true);
-    cublasWrapper->destroyDescriptors();
+    cublasWrapper.destroyDescriptors();
 }
 
 } // namespace

--- a/cpp/tensorrt_llm/thop/loraOp.cpp
+++ b/cpp/tensorrt_llm/thop/loraOp.cpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,14 +135,8 @@ std::vector<th::Tensor> lora_grouped_gemm(th::Tensor const& input, th::Tensor co
         }
     }
 
-    thread_local std::shared_ptr<tensorrt_llm::common::CublasMMWrapper> cublasWrapper;
-    if (cublasWrapper == nullptr)
-    {
-        auto cublasHandle = getCublasHandle();
-        auto cublasLtHandle = getCublasLtHandle();
-        cublasWrapper
-            = std::make_shared<tensorrt_llm::common::CublasMMWrapper>(cublasHandle, cublasLtHandle, nullptr, nullptr);
-    }
+    auto cublasWrapper
+        = std::make_shared<tc::CublasMMWrapper>(getCublasHandle(), getCublasLtHandle(), nullptr, nullptr);
 
     int const inHiddenSize = input.sizes()[input.sizes().size() - 1];
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal memory allocation and resource management strategy for CUDA-accelerated matrix multiplication operations to enhance efficiency, stability, and performance.
  * Improved FP4 and scaled GEMM kernel execution with refined memory handling, initialization patterns, and resource management.
  * Enhanced workspace allocation, lifecycle management, and resource reuse strategies for grouped LoRA matrix multiplication operations across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Remove thread-local `CublasMMWrapper` caches from thop cublas paths. The underlying cuBLAS/cuBLASLt handles are already cached per CUDA context and thread by `getCublasHandle()` and `getCublasLtHandle()`, but the thread-local wrapper itself was only keyed by thread.

If the same host thread switches CUDA contexts, for example when running multiple uGPU green contexts simultaneously, a cached wrapper can retain handles from a previous CUDA context while later calls use streams and workspaces from the current context. Creating the lightweight wrapper per call keeps wrapper state scoped to the active CUDA context while preserving the existing handle cache.

This PR leaves `gemmPlugin` unchanged. `loraOp` keeps a per-call `shared_ptr<CublasMMWrapper>` because `LoraImpl` stores shared ownership.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.