### PR TITLE
[None][feat] support non-divisible EP in MoE alltoall and slurm benchmark

### DIFF
--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -182,19 +182,38 @@ using tensorrt_llm::common::launchWithPdlWhenEnabled;
 // Helper Functions for Expert-to-Rank Mapping
 // ============================================================================
 
-__device__ int compute_target_rank_id(int expert_id, int num_experts_per_rank)
+__device__ int compute_target_rank_id(int expert_id, int num_experts, int ep_size)
 {
-    // Compute which rank owns a given expert using contiguous partitioning
-    // Experts are divided evenly across EP ranks:
-    // - Rank 0 gets experts [0, num_experts_per_rank)
-    // - Rank 1 gets experts [num_experts_per_rank, 2*num_experts_per_rank)
-    // - etc.
-    // Example: 32 experts, 4 ranks -> 8 experts per rank
-    // - Rank 0: experts 0-7
-    // - Rank 1: experts 8-15
-    // - Rank 2: experts 16-23
-    // - Rank 3: experts 24-31
-    return expert_id / num_experts_per_rank;
+    // Compute which rank owns a given expert using contiguous ceil/floor partitioning.
+    // Supports non-divisible distribution when num_experts % ep_size != 0:
+    //   base      = num_experts / ep_size
+    //   remainder = num_experts % ep_size
+    //   - Ranks [0, remainder) each own (base + 1) experts.
+    //   - Ranks [remainder, ep_size) each own base experts.
+    //
+    // Example A (uniform): 32 experts, 4 ranks -> base=8, remainder=0
+    //   - Rank 0: experts 0-7
+    //   - Rank 1: experts 8-15
+    //   - Rank 2: experts 16-23
+    //   - Rank 3: experts 24-31
+    //
+    // Example B (non-divisible): 384 experts, 5 ranks -> base=76, remainder=4
+    //   - Rank 0: experts 0-76    (77 experts)
+    //   - Rank 1: experts 77-153  (77 experts)
+    //   - Rank 2: experts 154-230 (77 experts)
+    //   - Rank 3: experts 231-307 (77 experts)
+    //   - Rank 4: experts 308-383 (76 experts)
+    int const base = num_experts / ep_size;
+    int const remainder = num_experts - base * ep_size; // == num_experts % ep_size
+    int const split = remainder * (base + 1);           // boundary expert id
+    if (expert_id < split)
+    {
+        // Falls inside the (base + 1)-sized prefix block.
+        return expert_id / (base + 1);
+    }
+    // Falls inside the base-sized suffix block. When remainder == 0, split == 0
+    // and this branch handles all experts uniformly.
+    return remainder + (expert_id - split) / base;
 }
 
 // ============================================================================
@@ -439,15 +458,15 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
         }
 
         uint64_t already_copied = 0;
-        int num_experts_per_rank = num_experts / ep_size;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
         cudaGridDependencySynchronize();
 #endif
         for (int k = 0; k < TOP_K; k++)
         {
             int expert_id = token_selected_experts[local_token_idx * TOP_K + k];
-            // Use contiguous partitioning to determine target rank
-            int target_rank = compute_target_rank_id(expert_id, num_experts_per_rank);
+            // Use contiguous ceil/floor partitioning to determine target rank.
+            // Supports the non-divisible case where num_experts % ep_size != 0.
+            int target_rank = compute_target_rank_id(expert_id, num_experts, ep_size);
 
             if (already_copied & (1ULL << target_rank))
             {

--- a/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/moeAlltoAllKernels.cu
@@ -182,37 +182,43 @@ using tensorrt_llm::common::launchWithPdlWhenEnabled;
 // Helper Functions for Expert-to-Rank Mapping
 // ============================================================================
 
-__device__ int compute_target_rank_id(int expert_id, int num_experts, int ep_size)
+// Compute which rank owns a given expert using contiguous ceil/floor partitioning.
+// Supports non-divisible distribution when num_experts % ep_size != 0:
+//   base      = num_experts / ep_size
+//   remainder = num_experts % ep_size
+//   - Ranks [0, remainder) each own (base + 1) experts.
+//   - Ranks [remainder, ep_size) each own base experts.
+//
+// Example A (uniform): 32 experts, 4 ranks -> base=8, remainder=0
+//   - Rank 0: experts 0-7
+//   - Rank 1: experts 8-15
+//   - Rank 2: experts 16-23
+//   - Rank 3: experts 24-31
+//
+// Example B (non-divisible): 384 experts, 5 ranks -> base=76, remainder=4
+//   - Rank 0: experts 0-76    (77 experts)
+//   - Rank 1: experts 77-153  (77 experts)
+//   - Rank 2: experts 154-230 (77 experts)
+//   - Rank 3: experts 231-307 (77 experts)
+//   - Rank 4: experts 308-383 (76 experts)
+//
+// `base` and `remainder` are precomputed by the caller once outside the per-token TOP_K loop
+// so the hot path performs at most one integer divide.
+__device__ __forceinline__ int compute_target_rank_id(int expert_id, int base, int remainder)
 {
-    // Compute which rank owns a given expert using contiguous ceil/floor partitioning.
-    // Supports non-divisible distribution when num_experts % ep_size != 0:
-    //   base      = num_experts / ep_size
-    //   remainder = num_experts % ep_size
-    //   - Ranks [0, remainder) each own (base + 1) experts.
-    //   - Ranks [remainder, ep_size) each own base experts.
-    //
-    // Example A (uniform): 32 experts, 4 ranks -> base=8, remainder=0
-    //   - Rank 0: experts 0-7
-    //   - Rank 1: experts 8-15
-    //   - Rank 2: experts 16-23
-    //   - Rank 3: experts 24-31
-    //
-    // Example B (non-divisible): 384 experts, 5 ranks -> base=76, remainder=4
-    //   - Rank 0: experts 0-76    (77 experts)
-    //   - Rank 1: experts 77-153  (77 experts)
-    //   - Rank 2: experts 154-230 (77 experts)
-    //   - Rank 3: experts 231-307 (77 experts)
-    //   - Rank 4: experts 308-383 (76 experts)
-    int const base = num_experts / ep_size;
-    int const remainder = num_experts - base * ep_size; // == num_experts % ep_size
-    int const split = remainder * (base + 1);           // boundary expert id
+    // Fast path for the uniform (num_experts % ep_size == 0) case: identical to the
+    // pre-ceil/floor implementation, so existing divisible deployments incur no overhead.
+    if (remainder == 0)
+    {
+        return expert_id / base;
+    }
+    int const split = remainder * (base + 1); // boundary expert id
     if (expert_id < split)
     {
         // Falls inside the (base + 1)-sized prefix block.
         return expert_id / (base + 1);
     }
-    // Falls inside the base-sized suffix block. When remainder == 0, split == 0
-    // and this branch handles all experts uniformly.
+    // Falls inside the base-sized suffix block.
     return remainder + (expert_id - split) / base;
 }
 
@@ -458,6 +464,11 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
         }
 
         uint64_t already_copied = 0;
+        // Precompute the ceil/floor partition parameters once per thread, outside the
+        // per-token TOP_K loop. The fast path (remainder == 0) then collapses to a single
+        // integer divide per call, matching the pre-PR uniform-partition cost exactly.
+        int const ep_base = num_experts / ep_size;
+        int const ep_remainder = num_experts - ep_base * ep_size; // == num_experts % ep_size
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
         cudaGridDependencySynchronize();
 #endif
@@ -466,7 +477,7 @@ __global__ void moeA2ADispatchKernel(int32_t const* token_selected_experts, // [
             int expert_id = token_selected_experts[local_token_idx * TOP_K + k];
             // Use contiguous ceil/floor partitioning to determine target rank.
             // Supports the non-divisible case where num_experts % ep_size != 0.
-            int target_rank = compute_target_rank_id(expert_id, num_experts, ep_size);
+            int target_rank = compute_target_rank_id(expert_id, ep_base, ep_remainder);
 
             if (already_copied & (1ULL << target_rank))
             {

--- a/cpp/tensorrt_llm/thop/moeAlltoAllOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeAlltoAllOp.cpp
@@ -208,7 +208,9 @@ std::tuple<std::vector<torch::Tensor>, int64_t, torch::Tensor> moeA2ADispatchOp(
     TORCH_CHECK(!inputPayloads.empty(), "inputPayloads must not be empty");
     TORCH_CHECK(inputPayloads.size() <= kMaxPayloads, "Too many input payloads");
     TORCH_CHECK(numExperts >= epSize, "numExperts must be greater than or equal to epSize");
-    TORCH_CHECK(numExperts % epSize == 0, "numExperts must be divisible by epSize for contiguous partitioning");
+    // numExperts does not need to be divisible by epSize: the kernel performs
+    // ceil/floor contiguous partitioning so ranks [0, numExperts % epSize)
+    // own (numExperts / epSize + 1) experts and the rest own (numExperts / epSize).
     bool enableEplb = eplbLocalStats.has_value();
     int64_t eplbStatsNumExperts = 0;
     if (enableEplb)

--- a/examples/disaggregated/slurm/benchmark/README.md
+++ b/examples/disaggregated/slurm/benchmark/README.md
@@ -54,7 +54,18 @@ hardware:
   gpus_per_node: 4  # GPUs per node in your cluster
   num_ctx_servers: 1  # Number of context processing servers
   num_gen_servers: 1  # Number of generation servers
+  # compact_packing: false  # Opt-in; see note below
 ```
+
+By default each worker owns whole nodes (round-robin), so cross-worker
+traffic never crosses a node boundary. Set `compact_packing: true` to pack
+all workers into `ceil(total_gpus / gpus_per_node)` nodes, allowing two
+workers to share a physical node when their GPU counts don't align with
+node boundaries (e.g. two TP=6 ctx workers fit in 3 four-GPU nodes via
+4+2 / 2+4). This is **only recommended on full-mesh NVLink fabrics like
+GB200/GB300 NVL72**, where the cross-worker NVLink traffic on the shared
+node is free; on PCIe or partitioned-NVLink hosts the shared node will
+become a bottleneck and you should leave it off.
 
 ### 4. Environment Configuration
 ```yaml

--- a/examples/disaggregated/slurm/benchmark/config.yaml
+++ b/examples/disaggregated/slurm/benchmark/config.yaml
@@ -26,6 +26,13 @@ hardware:
   gpus_per_node: 4  # Modify this with your hardware configuration
   num_ctx_servers: 1  # Number of context servers
   num_gen_servers: 1  # Number of generation servers
+  # compact_packing: false  # Opt-in: pack workers into the minimum number
+  # of nodes and let two workers share a physical node when their GPU counts
+  # straddle a node boundary (e.g. two TP=6 ctx workers in 3 four-GPU nodes
+  # via 4+2 / 2+4). Only recommended on full-mesh NVLink fabrics like
+  # GB200/GB300 NVL72 where cross-worker NVLink traffic on the shared node
+  # is free; on PCIe / partitioned-NVLink hosts the shared node will
+  # bottleneck and you should leave this off.
 
 # Environment Configuration
 environment:

--- a/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
+++ b/examples/disaggregated/slurm/benchmark/disaggr_torch.slurm
@@ -154,6 +154,14 @@ client_cmds_base_file=${full_logdir}/client_cmds_base.sh
 client_cmds_file=${full_logdir}/client_cmds.sh
 replace_placeholder "${client_cmds_base_file}" "${all_nodes_str}" "${client_cmds_file}"
 
+# Per-worker hostfile / gpu_map files for srun --distribution=arbitrary.
+# submit.py emits *_base.txt with <nodeN_placeholder>; rewrite them here.
+for base_file in "${full_logdir}"/hostfile_*_base.txt "${full_logdir}"/gpu_map_*_base.txt; do
+    [ -f "${base_file}" ] || continue
+    runtime_file="${base_file%_base.txt}.txt"
+    replace_placeholder "${base_file}" "${all_nodes_str}" "${runtime_file}"
+done
+
 # start the servers (skip ctx workers if TRTLLM_DISAGG_BENCHMARK_GEN_ONLY is set).
 echo "Starting worker commands from ${start_server_cmds_file}..."
 cat ${start_server_cmds_file} | while read cmd; do

--- a/examples/disaggregated/slurm/benchmark/run_benchmark.sh
+++ b/examples/disaggregated/slurm/benchmark/run_benchmark.sh
@@ -127,7 +127,8 @@ if [ "${ucx_warmup_requests}" -gt 0 ]; then
         --host ${hostname} \
         --port ${port} \
         --ignore-eos \
-        --non-streaming
+        --non-streaming \
+        --trust-remote-code
     echo "UCX warmup done"
 fi
 

--- a/examples/disaggregated/slurm/benchmark/start_worker.sh
+++ b/examples/disaggregated/slurm/benchmark/start_worker.sh
@@ -11,11 +11,11 @@ numa_bind=${5}
 log_dir=${6}
 enable_nsys=${7}
 config_file=${8}
-cuda_devices=${9}
-
-# Set CUDA_VISIBLE_DEVICES from script argument (srun --export cannot
-# reliably pass comma-separated values inside shared containers).
-export CUDA_VISIBLE_DEVICES=${cuda_devices}
+# Set CUDA_VISIBLE_DEVICES to exactly the one GPU for this task.
+# Round-robin allocation guarantees each node is dedicated to one server,
+# so SLURM_LOCALID (0-indexed local rank on this node) directly maps to
+# the physical GPU ID regardless of how SLURM distributes tasks (4+2, 3+3, etc.).
+export CUDA_VISIBLE_DEVICES=${SLURM_LOCALID}
 
 # Clear UCX_TLS for specific clusters
 unset UCX_TLS

--- a/examples/disaggregated/slurm/benchmark/start_worker.sh
+++ b/examples/disaggregated/slurm/benchmark/start_worker.sh
@@ -11,11 +11,25 @@ numa_bind=${5}
 log_dir=${6}
 enable_nsys=${7}
 config_file=${8}
-# Set CUDA_VISIBLE_DEVICES to exactly the one GPU for this task.
-# Round-robin allocation guarantees each node is dedicated to one server,
-# so SLURM_LOCALID (0-indexed local rank on this node) directly maps to
-# the physical GPU ID regardless of how SLURM distributes tasks (4+2, 3+3, etc.).
-export CUDA_VISIBLE_DEVICES=${SLURM_LOCALID}
+# CUDA_VISIBLE_DEVICES selection:
+#   - Default packing (no gpu_map file): each node is dedicated to one
+#     worker, so SLURM_LOCALID maps directly to the physical GPU id.
+#   - Compact packing (gpu_map file emitted by submit.py): two workers may
+#     share a node and would both see LOCALID=0, so look up the per-worker
+#     gpu_map "<rank> <host> <local_gpu_id>" by SLURM_PROCID. srun
+#     --distribution=arbitrary assigns PROCID in hostfile order, so it
+#     indexes directly into the map.
+gpu_map_file="${log_dir}/gpu_map_${role}_${instance_id}.txt"
+if [ -f "${gpu_map_file}" ]; then
+    gpu_id=$(awk -v p="${SLURM_PROCID}" '$1==p {print $3; exit}' "${gpu_map_file}")
+    if [ -z "${gpu_id}" ]; then
+        echo "ERROR: no GPU mapping for SLURM_PROCID=${SLURM_PROCID} in ${gpu_map_file}" >&2
+        exit 1
+    fi
+    export CUDA_VISIBLE_DEVICES=${gpu_id}
+else
+    export CUDA_VISIBLE_DEVICES=${SLURM_LOCALID}
+fi
 
 # Clear UCX_TLS for specific clusters
 unset UCX_TLS

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -68,21 +68,23 @@ def allocate_gpus(
 
     global_gpu_cursor = 0
 
-    def get_gpu_location(gpus_per_node: int):
-        node_id = global_gpu_cursor // gpus_per_node
-        local_gpu_id = global_gpu_cursor % gpus_per_node
-        return node_id, local_gpu_id
-
     def assign_server(server_allocation: Dict[str, Any], world_size: int,
                       gpus_per_node: int):
         nonlocal global_gpu_cursor
-        for _ in range(world_size):
-            node_id, gpu_id = get_gpu_location(gpus_per_node)
-            hostname = hostnames[node_id]
+        # Round-robin across nodes so each node gets ceil(world_size/num_nodes)
+        # GPUs, matching SLURM's block distribution which assigns
+        # ceil(world_size/num_nodes) tasks per node.
+        num_nodes_for_server = math.ceil(world_size / gpus_per_node)
+        start_node = global_gpu_cursor // gpus_per_node
+        for task_idx in range(world_size):
+            node_within = task_idx % num_nodes_for_server
+            gpu_within = task_idx // num_nodes_for_server
+            hostname = hostnames[start_node + node_within]
             if hostname not in server_allocation["nodes"]:
                 server_allocation["nodes"][hostname] = []
-            server_allocation["nodes"][hostname].append(gpu_id)
-            global_gpu_cursor += 1
+            server_allocation["nodes"][hostname].append(gpu_within)
+        # Advance cursor past all nodes owned by this server
+        global_gpu_cursor += num_nodes_for_server * gpus_per_node
 
     port = base_port
 
@@ -453,8 +455,14 @@ def submit_job(config, log_dir, dry_run):
     mtp_size = worker_config['gen'].get('speculative_config',
                                         {}).get('max_draft_len')
 
+    # Get gen moe_expert_parallel_size; only tag when it differs from TP
+    gen_ep_size = worker_config['gen'].get('moe_expert_parallel_size',
+                                           gen_tp_size)
+    ep_tag = f"_ep{gen_ep_size}" if gen_ep_size != gen_tp_size else ""
+
     # Create base log directory path
-    if 'log_dir' in env_config and env_config['log_dir']:
+    # CLI --log-dir takes precedence; fall back to yaml log_dir only when not set
+    if log_dir is None and 'log_dir' in env_config and env_config['log_dir']:
         log_dir = env_config['log_dir']
     if log_dir is None:
         log_base = os.path.join(script_dir, "logs")
@@ -466,9 +474,9 @@ def submit_job(config, log_dir, dry_run):
 
         # Determine directory suffix based on attention_dp
         if gen_enable_attention_dp:
-            dir_suffix = f"disagg_ctx{ctx_num}_gen{gen_num}_dep{gen_tp_size}_batch{gen_batch_size}_eplb{eplb_num_slots}{mtp_suffix}"
+            dir_suffix = f"disagg_ctx{ctx_num}_gen{gen_num}_dep{gen_tp_size}{ep_tag}_batch{gen_batch_size}_eplb{eplb_num_slots}{mtp_suffix}"
         else:
-            dir_suffix = f"disagg_ctx{ctx_num}_gen{gen_num}_tep{gen_tp_size}_batch{gen_batch_size}_eplb{eplb_num_slots}{mtp_suffix}"
+            dir_suffix = f"disagg_ctx{ctx_num}_gen{gen_num}_tep{gen_tp_size}{ep_tag}_batch{gen_batch_size}_eplb{eplb_num_slots}{mtp_suffix}"
 
         # Create full log directory path
         log_dir = os.path.join(log_base, dir_suffix)
@@ -547,9 +555,14 @@ def submit_job(config, log_dir, dry_run):
 
         for server_id in allocations[server_type].keys():
             allocation = allocations[server_type][server_id]
-            gpu_ids = list(allocation["nodes"].values())[0]
 
-            cuda_devices = ','.join(map(str, gpu_ids))
+            # Nodes are in insertion order from round-robin assign_server.
+            # Each node is dedicated to this server (no cross-server sharing),
+            # so start_worker.sh can safely use SLURM_LOCALID as the GPU index
+            # without any pre-specified mapping.
+            node_list = list(allocation["nodes"].keys())
+            num_nodes = len(node_list)
+
             worker_env = build_worker_environment(
                 worker_config=worker_config,
                 env_config=env_config,
@@ -563,10 +576,9 @@ def submit_job(config, log_dir, dry_run):
 
             cmd = [
                 "srun -l",
-                f"--nodelist {','.join(allocation['nodes'].keys())}",
-                f"-N {len(allocation['nodes'])}",
+                f"--nodelist {','.join(node_list)}",
+                f"-N {num_nodes}",
                 f"--ntasks {server_cfg['world_size']}",
-                f"--ntasks-per-node {gpus_per_node}",
                 f"--export=\"{export_str}\"",
                 f"--container-image {env_config['container_image']}",
                 f"--container-name {container_name}",
@@ -581,7 +593,6 @@ def submit_job(config, log_dir, dry_run):
                 log_dir,
                 str(profiling_config['nsys_on']).lower(),
                 server_cfg['config_path'],
-                cuda_devices,
                 f"&> {log_dir}/3_output_{server_type}_{server_id}.log &",
             ]
             start_server_cmds.append(" ".join(cmd))
@@ -631,7 +642,7 @@ def submit_job(config, log_dir, dry_run):
     client_slurm_prefix = [
         f"srun -l --container-name={container_name}",
         f"--container-mounts={container_mount_str}",
-        f"--mpi=pmix --overlap -N 1 -n 1",
+        f"--no-container-mount-home --mpi=pmix --overlap -N 1 -n 1",
     ]
     # Append benchmark commands
     if benchmark_config.get('enable_benchmark', True):

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -62,18 +62,39 @@ def allocate_gpus(
     gen_world_size: int,
     ctx_world_size: int,
     base_port: int = 8000,
+    compact_packing: bool = False,
 ) -> List[Dict[str, Any]]:
     allocations = {}
     hostnames = [f"<node{i}_placeholder>" for i in range(total_nodes)]
 
     global_gpu_cursor = 0
 
-    def assign_server(server_allocation: Dict[str, Any], world_size: int,
-                      gpus_per_node: int):
+    def assign_server_compact(server_allocation: Dict[str, Any],
+                              world_size: int, gpus_per_node: int):
+        # Compact packing: advance cursor by one GPU per task. Workers may
+        # share a physical node when their GPU counts don't align with node
+        # boundaries (e.g. two TP=6 ctx workers fit in 3 four-GPU nodes via
+        # 4+2 / 2+4). Each task's (host, local_gpu_id) is recorded in
+        # insertion order, so the per-worker hostfile/gpu_map drives srun
+        # --distribution=arbitrary and start_worker.sh's CUDA_VISIBLE_DEVICES.
         nonlocal global_gpu_cursor
-        # Round-robin across nodes so each node gets ceil(world_size/num_nodes)
-        # GPUs, matching SLURM's block distribution which assigns
-        # ceil(world_size/num_nodes) tasks per node.
+        for _ in range(world_size):
+            host_idx = global_gpu_cursor // gpus_per_node
+            gpu_idx = global_gpu_cursor % gpus_per_node
+            hostname = hostnames[host_idx]
+            if hostname not in server_allocation["nodes"]:
+                server_allocation["nodes"][hostname] = []
+            server_allocation["nodes"][hostname].append(gpu_idx)
+            global_gpu_cursor += 1
+
+    def assign_server_round_robin(server_allocation: Dict[str, Any],
+                                  world_size: int, gpus_per_node: int):
+        # Default packing: each worker owns ceil(world_size/gpus_per_node)
+        # whole nodes, round-robin across nodes so each node gets
+        # ceil(world_size/num_nodes) GPUs. Matches SLURM block distribution,
+        # so SLURM_LOCALID directly maps to the physical GPU id in
+        # start_worker.sh.
+        nonlocal global_gpu_cursor
         num_nodes_for_server = math.ceil(world_size / gpus_per_node)
         start_node = global_gpu_cursor // gpus_per_node
         for task_idx in range(world_size):
@@ -83,8 +104,10 @@ def allocate_gpus(
             if hostname not in server_allocation["nodes"]:
                 server_allocation["nodes"][hostname] = []
             server_allocation["nodes"][hostname].append(gpu_within)
-        # Advance cursor past all nodes owned by this server
         global_gpu_cursor += num_nodes_for_server * gpus_per_node
+
+    assign_server = (assign_server_compact
+                     if compact_packing else assign_server_round_robin)
 
     port = base_port
 
@@ -412,19 +435,21 @@ def submit_job(config, log_dir, dry_run):
     ctx_num = hw_config['num_ctx_servers']
     gen_num = hw_config['num_gen_servers']
     gpus_per_node = hw_config['gpus_per_node']
+    # Only recommended on full-mesh NVLink fabrics like GB200/GB300 NVL72
+    # where two workers sharing a physical node pay no extra cost. On
+    # PCIe or partitioned-NVLink hosts the shared node becomes a bottleneck.
+    compact_packing = bool(hw_config.get('compact_packing', False))
 
     # Calculate nodes based on world sizes
     ctx_tp_size = worker_config['ctx'].get('tensor_parallel_size', 1)
     ctx_cp_size = worker_config['ctx'].get('context_parallel_size', 1)
     ctx_pp_size = worker_config['ctx'].get('pipeline_parallel_size', 1)
     ctx_world_size = ctx_tp_size * ctx_cp_size * ctx_pp_size
-    ctx_nodes = calculate_nodes(ctx_world_size, ctx_num, gpus_per_node)
 
     gen_tp_size = worker_config['gen'].get('tensor_parallel_size', 1)
     gen_cp_size = worker_config['gen'].get('context_parallel_size', 1)
     gen_pp_size = worker_config['gen'].get('pipeline_parallel_size', 1)
     gen_world_size = gen_tp_size * gen_cp_size * gen_pp_size
-    gen_nodes = calculate_nodes(gen_world_size, gen_num, gpus_per_node)
 
     ctx_dp_size = ctx_tp_size if worker_config['ctx'].get(
         'enable_attention_dp', False) else 1
@@ -433,7 +458,17 @@ def submit_job(config, log_dir, dry_run):
     ucx_warmup_requests = 2 * ctx_num * ctx_dp_size * gen_num * gen_dp_size \
         if benchmark_config['mode'] == "e2e" else 0
 
-    total_nodes = ctx_nodes + gen_nodes
+    if compact_packing:
+        # Compact packing: pack all workers into the minimum number of nodes,
+        # letting workers share a node when their GPU counts straddle a node
+        # boundary. Matches the per-GPU cursor in allocate_gpus.
+        total_gpus = ctx_world_size * ctx_num + gen_world_size * gen_num
+        total_nodes = math.ceil(total_gpus / gpus_per_node)
+    else:
+        # Default: each worker owns whole nodes, no node sharing.
+        ctx_nodes = calculate_nodes(ctx_world_size, ctx_num, gpus_per_node)
+        gen_nodes = calculate_nodes(gen_world_size, gen_num, gpus_per_node)
+        total_nodes = ctx_nodes + gen_nodes
     total_tasks = total_nodes * gpus_per_node
 
     # Generate log directory path based on configuration
@@ -515,6 +550,7 @@ def submit_job(config, log_dir, dry_run):
         num_ctx_servers=ctx_num,
         gen_world_size=gen_world_size,
         ctx_world_size=ctx_world_size,
+        compact_packing=compact_packing,
     )
     with open(os.path.join(log_dir, "allocations.json"), "w") as f:
         json.dump(allocations, f, indent=2)
@@ -556,12 +592,33 @@ def submit_job(config, log_dir, dry_run):
         for server_id in allocations[server_type].keys():
             allocation = allocations[server_type][server_id]
 
-            # Nodes are in insertion order from round-robin assign_server.
-            # Each node is dedicated to this server (no cross-server sharing),
-            # so start_worker.sh can safely use SLURM_LOCALID as the GPU index
-            # without any pre-specified mapping.
-            node_list = list(allocation["nodes"].keys())
-            num_nodes = len(node_list)
+            if compact_packing:
+                # Emit per-worker hostfile (one host per task in rank order)
+                # and gpu_map (rank -> local gpu id). Nodes carry placeholder
+                # names at this point; disaggr_torch.slurm rewrites them at
+                # runtime. SLURM_HOSTFILE + --distribution=arbitrary lets us
+                # express non-uniform layouts (e.g. 4+2 / 2+4) so two workers
+                # can share one physical node.
+                hostfile_base = os.path.join(
+                    log_dir, f"hostfile_{server_type}_{server_id}_base.txt")
+                gpu_map_base = os.path.join(
+                    log_dir, f"gpu_map_{server_type}_{server_id}_base.txt")
+                hostfile_runtime = os.path.join(
+                    log_dir, f"hostfile_{server_type}_{server_id}.txt")
+                with open(hostfile_base, 'w') as hf, \
+                        open(gpu_map_base, 'w') as gm:
+                    rank = 0
+                    for host, gpus in allocation["nodes"].items():
+                        for gpu in gpus:
+                            hf.write(f"{host}\n")
+                            gm.write(f"{rank} {host} {gpu}\n")
+                            rank += 1
+            else:
+                # Default packing: each node is dedicated to one worker, so
+                # SLURM_LOCALID directly maps to the physical GPU id in
+                # start_worker.sh (no hostfile/gpu_map needed).
+                node_list = list(allocation["nodes"].keys())
+                num_nodes = len(node_list)
 
             worker_env = build_worker_environment(
                 worker_config=worker_config,
@@ -574,11 +631,22 @@ def submit_job(config, log_dir, dry_run):
             )
             export_str = format_export_string(worker_env)
 
-            cmd = [
-                "srun -l",
-                f"--nodelist {','.join(node_list)}",
-                f"-N {num_nodes}",
-                f"--ntasks {server_cfg['world_size']}",
+            if compact_packing:
+                srun_prefix = [
+                    f"SLURM_HOSTFILE={hostfile_runtime}",
+                    "srun -l",
+                    f"--ntasks {server_cfg['world_size']}",
+                    "--distribution=arbitrary",
+                ]
+            else:
+                srun_prefix = [
+                    "srun -l",
+                    f"--nodelist {','.join(node_list)}",
+                    f"-N {num_nodes}",
+                    f"--ntasks {server_cfg['world_size']}",
+                ]
+
+            cmd = srun_prefix + [
                 f"--export=\"{export_str}\"",
                 f"--container-image {env_config['container_image']}",
                 f"--container-name {container_name}",

--- a/examples/disaggregated/slurm/benchmark/submit.py
+++ b/examples/disaggregated/slurm/benchmark/submit.py
@@ -50,8 +50,17 @@ def save_worker_config(worker_config, output_path):
 
 
 def calculate_nodes(world_size, num_servers, gpus_per_node):
-    """Calculate required nodes based on world size and server count."""
-    return math.ceil(world_size * num_servers / gpus_per_node)
+    """Required node count under per-worker whole-node ownership.
+
+    Mirrors assign_server_round_robin: each worker consumes
+    ceil(world_size / gpus_per_node) whole nodes, with no node sharing
+    across workers. Pooling all GPUs and rounding once under-counts
+    nodes whenever world_size is not a multiple of gpus_per_node
+    (e.g. world_size=1, num_servers=2, gpus_per_node=4: pooled gives 1,
+    but the allocator needs 2). compact_packing computes nodes
+    separately because it does share nodes across workers.
+    """
+    return num_servers * math.ceil(world_size / gpus_per_node)
 
 
 def allocate_gpus(
@@ -710,7 +719,7 @@ def submit_job(config, log_dir, dry_run):
     client_slurm_prefix = [
         f"srun -l --container-name={container_name}",
         f"--container-mounts={container_mount_str}",
-        f"--no-container-mount-home --mpi=pmix --overlap -N 1 -n 1",
+        "--no-container-mount-home --mpi=pmix --overlap -N 1 -n 1",
     ]
     # Append benchmark commands
     if benchmark_config.get('enable_benchmark', True):

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py
@@ -149,6 +149,14 @@ class CommunicationFactory:
         except Exception as e:
             logger.info(f"NVLinkOneSided not available: {e}")
 
+        # Non-divisible EP: NVLinkTwoSided and DeepEP require num_experts % ep_size == 0.
+        if num_experts % mapping.moe_ep_size != 0:
+            logger.info(
+                f"Non-divisible EP (num_experts={num_experts}, ep_size={mapping.moe_ep_size}): "
+                "falling back to AllGatherReduceScatter"
+            )
+            return AllGatherReduceScatter(mapping)
+
         try:
             if use_flashinfer:
                 strategy = NVLinkTwoSidedFlashinfer(
@@ -245,6 +253,15 @@ class CommunicationFactory:
         use_low_precision_combine = model_config.use_low_precision_moe_combine
 
         method = method.upper()
+
+        # Whitelist check: non-divisible EP only supports NVLinkOneSided and AllGather.
+        _NONDIVISIBLE_EP_ALLOWED = {"NVLINK_ONE_SIDED", "ALLGATHER"}
+        if num_experts % mapping.moe_ep_size != 0 and method not in _NONDIVISIBLE_EP_ALLOWED:
+            raise ValueError(
+                f"Communication method '{method}' requires num_experts % ep_size == 0, "
+                f"but got num_experts={num_experts}, ep_size={mapping.moe_ep_size}. "
+                f"Allowed methods for non-divisible EP: {sorted(_NONDIVISIBLE_EP_ALLOWED)}"
+            )
 
         # Create strategy - will raise RuntimeError if platform not supported
         if method in ["NVLINK_TWO_SIDED"]:

--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -67,6 +67,13 @@ _BACKEND_SYNC_ATTRS = (
 
 
 class ConfigurableMoE(MoE):
+    # ConfigurableMoE is a thin wrapper that dispatches to a concrete backend
+    # (CuteDslFusedMoE / CutlassFusedMoE / ...). Allow the wrapper itself to
+    # pass the non-divisible-EP gate so the inner backend's own gate is the
+    # authoritative check -- if the chosen inner backend doesn't opt in, its
+    # ``MoE.__init__`` will still raise.
+    _supports_non_divisible_ep: bool = True
+
     """
     Configurable MoE layer using composition pattern with automatic configuration
 

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl.py
@@ -336,6 +336,10 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
 
 
 class CuteDslFusedMoE(CutlassFusedMoE):
+    # CuteDSL dispatch/combine path exercises the ceil/floor partition
+    # (NVLinkOneSided alltoall with kernel-level remainder handling), so this
+    # backend is the only opt-in for non-divisible EP today.
+    _supports_non_divisible_ep: bool = True
     """CuteDSL flow of fused mixture of experts (MoE) Layer.
 
     Args:

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_vanilla.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_vanilla.py
@@ -92,6 +92,16 @@ class VanillaMoE(nn.ModuleList):
 
         self.intermediate_size_per_partition = intermediate_size // self.tp_size
 
+        # VanillaMoE uses uniform expert partitioning; non-divisible EP would require
+        # ceil/floor distribution (see MoE._compute_ep_partition in interface.py).
+        # Reject explicitly rather than silently producing wrong local-expert ranges.
+        if num_experts % self.ep_size != 0:
+            raise ValueError(
+                f"VanillaMoE does not support non-divisible EP: "
+                f"num_experts ({num_experts}) must be divisible by ep_size ({self.ep_size}). "
+                f"Use CutlassFusedMoE / TRTLLMGenFusedMoE with NVLINK_ONE_SIDED comm for non-divisible EP."
+            )
+
         self.expert_size_per_partition = num_experts // self.ep_size
         self.expert_start = self.ep_rank * self.expert_size_per_partition
         self.expert_end = min(

--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -217,6 +217,12 @@ class MoE(nn.Module):
     # override this to ``MoESchedulerKind.FUSED_COMM``.
     scheduler_kind: MoESchedulerKind = MoESchedulerKind.EXTERNAL_COMM
 
+    # Opt-in flag for non-divisible EP (num_experts % ep_size != 0). False by default
+    # so backends whose dispatch/combine paths still assume uniform partitioning fail
+    # fast with a clear error. Backends that fully exercise the ceil/floor partition
+    # (see ``_compute_ep_partition``) should override this to ``True``.
+    _supports_non_divisible_ep: bool = False
+
     @classmethod
     @abstractmethod
     def can_implement(
@@ -315,6 +321,20 @@ class MoE(nn.Module):
 
         self.ep_size = model_config.mapping.moe_ep_size
         self.ep_rank = model_config.mapping.moe_ep_rank
+
+        # Non-divisible EP gate. Backends opt in via the class attribute
+        # ``_supports_non_divisible_ep``. Default is to reject so that any backend
+        # whose dispatch/combine paths still assume uniform partitioning fails fast
+        # with a clear error instead of silently using a wrong local-expert range.
+        if (self.num_experts % self.ep_size != 0
+                and not type(self)._supports_non_divisible_ep):
+            raise ValueError(
+                f"{type(self).__name__} does not support non-divisible EP: "
+                f"num_experts ({self.num_experts}) must be divisible by "
+                f"ep_size ({self.ep_size}). Override "
+                f"`_supports_non_divisible_ep = True` on the subclass after "
+                f"verifying the kernel/comm path handles ceil/floor partitioning."
+            )
 
         self.moe_backend = model_config.moe_backend
         self.use_dp = model_config.mapping.enable_attention_dp

--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -67,6 +67,15 @@ def _compute_ep_partition(num_experts: int, ep_size: int,
     Returns:
         (expert_size, slot_start, slot_end)
     """
+    # Reject num_experts < ep_size: would yield zero-expert ranks, which no
+    # MoE backend / comm strategy supports end-to-end. The downstream alltoall
+    # op has a backstop check (numExperts >= epSize) but the AllGatherReduceScatter
+    # fallback path bypasses it, so guard upfront here.
+    if num_experts < ep_size:
+        raise ValueError(
+            f"num_experts ({num_experts}) must be >= ep_size ({ep_size}); "
+            f"configurations producing ranks with zero local experts are not supported."
+        )
     base = num_experts // ep_size
     remainder = num_experts % ep_size
     expert_size = base + (1 if ep_rank < remainder else 0)

--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -56,6 +56,24 @@ from .routing import (BaseMoeRoutingMethod, RoutingMethodType,
                       precompute_common_perfect_router_logits)
 
 
+def _compute_ep_partition(num_experts: int, ep_size: int,
+                          ep_rank: int) -> tuple:
+    """Compute per-rank expert count and slot boundaries.
+
+    Uses ceil/floor distribution: ranks 0..remainder-1 hold (base+1) experts
+    and remaining ranks hold base. Covers all experts even when
+    num_experts % ep_size != 0.
+
+    Returns:
+        (expert_size, slot_start, slot_end)
+    """
+    base = num_experts // ep_size
+    remainder = num_experts % ep_size
+    expert_size = base + (1 if ep_rank < remainder else 0)
+    slot_start = ep_rank * base + min(ep_rank, remainder)
+    return expert_size, slot_start, slot_start + expert_size
+
+
 class MoEWeightLoadingMode(Enum):
     # Gate and up projection are not fused
     VANILLA = 0
@@ -332,10 +350,13 @@ class MoE(nn.Module):
             self.layer_load_balancer = None
             self.repeat_idx = 0
             self.repeat_count = 1
-            self.expert_size_per_partition = self.num_experts // self.ep_size
+            _size, _start, _end = _compute_ep_partition(self.num_experts,
+                                                        self.ep_size,
+                                                        self.ep_rank)
+            self.expert_size_per_partition = _size
             self.num_slots = self.num_experts
-            self.slot_start = self.ep_rank * self.expert_size_per_partition
-            self.slot_end = self.slot_start + self.expert_size_per_partition
+            self.slot_start = _start
+            self.slot_end = _end
             self.initial_local_expert_ids = list(
                 range(self.slot_start, self.slot_end))
             self.initial_global_assignments = list(range(self.num_experts))
@@ -425,15 +446,16 @@ class MoE(nn.Module):
         moe_load_balancer_config = model_config.moe_load_balancer
 
         # Calculate initial expert assignments
-        init_expert_size_per_partition = (
-            moe_load_balancer_config.num_local_slots
-            if moe_load_balancer_config else self.num_experts // self.ep_size)
-
-        self.initial_global_assignments = [
-            (ep_rank * self.num_experts // self.ep_size + local_slot_id) %
-            self.num_experts for ep_rank in range(self.ep_size)
-            for local_slot_id in range(init_expert_size_per_partition)
-        ]
+        if moe_load_balancer_config:
+            init_expert_size_per_partition = moe_load_balancer_config.num_local_slots
+            self.initial_global_assignments = [
+                (ep_rank * self.num_experts // self.ep_size + local_slot_id) %
+                self.num_experts for ep_rank in range(self.ep_size)
+                for local_slot_id in range(init_expert_size_per_partition)
+            ]
+        else:
+            # Sequential mapping: expert i → slot i; covers all experts regardless of divisibility
+            self.initial_global_assignments = list(range(self.num_experts))
 
         # Setup load balancer if available
         if moe_load_balancer:
@@ -478,19 +500,28 @@ class MoE(nn.Module):
             logger.info(
                 f"initial_global_assignments (layer {self.layer_idx}) = {self.initial_global_assignments}"
             )
-        else:
-            # Fallback when no load balancer
-            assert self.num_experts % self.ep_size == 0
-            self.expert_size_per_partition = self.num_experts // self.ep_size
-            self.num_slots = self.num_experts
 
-        # Calculate slot boundaries
-        self.slot_start = self.ep_rank * self.expert_size_per_partition
-        self.slot_end = self.slot_start + self.expert_size_per_partition
-        self.initial_local_expert_ids = self.initial_global_assignments[
-            self.slot_start:self.slot_end]
-        assert len(
-            self.initial_local_expert_ids) == self.expert_size_per_partition
+            # Slot boundaries for EPLB (uniform: all ranks hold same num_local_slots)
+            self.slot_start = self.ep_rank * self.expert_size_per_partition
+            self.slot_end = self.slot_start + self.expert_size_per_partition
+            self.initial_local_expert_ids = self.initial_global_assignments[
+                self.slot_start:self.slot_end]
+            assert len(
+                self.initial_local_expert_ids) == self.expert_size_per_partition
+        else:
+            # Fallback: ceil/floor distribution across ranks.
+            # Ranks 0..remainder-1 each hold (base+1) experts; remaining ranks hold base.
+            _size, _start, _end = _compute_ep_partition(self.num_experts,
+                                                        self.ep_size,
+                                                        self.ep_rank)
+            self.expert_size_per_partition = _size
+            self.num_slots = self.num_experts
+            self.slot_start = _start
+            self.slot_end = _end
+            self.initial_local_expert_ids = self.initial_global_assignments[
+                self.slot_start:self.slot_end]
+            assert len(
+                self.initial_local_expert_ids) == self.expert_size_per_partition
 
         # Setup AllReduce for dynamic routing if needed
         if self._using_dynamic_load_balancer():

--- a/tests/unittest/_torch/modules/moe/test_moe_comm.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_comm.py
@@ -246,12 +246,40 @@ def decode_source_info(
 # ============================================================================
 
 
+def _compute_ep_partition(num_experts: int, ep_size: int, ep_rank: int) -> Tuple[int, int, int]:
+    """Compute per-rank expert count and slot boundaries.
+
+    Mirrors the kernel's compute_target_rank_id ceil/floor distribution:
+    ranks [0, remainder) hold (base + 1) experts, and the remaining ranks
+    hold base experts. Covers all experts even when num_experts % ep_size
+    != 0 (non-divisible EP).
+
+    Returns:
+        (expert_size, slot_start, slot_end)
+    """
+    base = num_experts // ep_size
+    remainder = num_experts % ep_size
+    expert_size = base + (1 if ep_rank < remainder else 0)
+    slot_start = ep_rank * base + min(ep_rank, remainder)
+    return expert_size, slot_start, slot_start + expert_size
+
+
+def _expert_id_to_rank(expert_id: int, num_experts: int, ep_size: int) -> int:
+    """Inverse mapping of _compute_ep_partition. Mirrors kernel logic."""
+    base = num_experts // ep_size
+    remainder = num_experts % ep_size
+    split = remainder * (base + 1)
+    if expert_id < split:
+        return expert_id // (base + 1)
+    return remainder + (expert_id - split) // base
+
+
 def simple_moe(
     hidden_states: torch.Tensor,
     token_selected_slots: torch.Tensor,
     token_final_scales: torch.Tensor,
-    ep_rank: int,
-    experts_per_rank: int,
+    slot_start: int,
+    slot_end: int,
 ) -> torch.Tensor:
     """Trivial MoE: weighted sum of hidden_states for local experts only.
 
@@ -265,8 +293,6 @@ def simple_moe(
     - DeepEPLL: all-ones (combine applies real scales internally)
     """
     output = torch.zeros_like(hidden_states, dtype=torch.float32)
-    slot_start = ep_rank * experts_per_rank
-    slot_end = slot_start + experts_per_rank
 
     for i in range(hidden_states.shape[0]):
         for k in range(token_selected_slots.shape[1]):
@@ -421,8 +447,13 @@ def check_platform_support(comm_type: str) -> Optional[str]:
 
 def check_feasibility(comm_type: str, config: CommTestConfig) -> Optional[str]:
     """Return skip reason string if config is infeasible, else None."""
-    if config.num_experts % config.ep_size != 0:
-        return f"num_experts={config.num_experts} not divisible by ep_size={config.ep_size}"
+    if config.num_experts % config.ep_size != 0 and comm_type != COMM_NVLINK_ONE_SIDED:
+        # Only NVLinkOneSided supports non-divisible EP (ceil/floor partitioning).
+        # Other comm types still require num_experts divisible by ep_size.
+        return (
+            f"comm_type={comm_type} requires num_experts divisible by ep_size, "
+            f"got num_experts={config.num_experts}, ep_size={config.ep_size}"
+        )
 
     if config.use_low_precision_combine and not _supports_low_precision_combine(config):
         return (
@@ -777,7 +808,11 @@ def _worker_full_pipeline(config: CommTestConfig) -> dict:
             config.quant_mode,
         )
 
-        experts_per_rank = config.num_experts // config.ep_size
+        # Use ceil/floor partitioning so the slot range is correct for both
+        # uniform and non-divisible EP (num_experts % ep_size != 0).
+        _, local_slot_start, local_slot_end = _compute_ep_partition(
+            config.num_experts, config.ep_size, rank
+        )
         # Run a minimal local-expert compute step before combine(). This keeps
         # the test aligned with the real MoE pipeline, where combine() consumes
         # per-rank expert outputs rather than raw dispatch payloads.
@@ -785,8 +820,8 @@ def _worker_full_pipeline(config: CommTestConfig) -> dict:
             recv_hs_bf16,
             dispatch_outputs.recv_slots,
             dispatch_outputs.recv_scales,
-            rank,
-            experts_per_rank,
+            local_slot_start,
+            local_slot_end,
         )
 
         combined = comm.combine(
@@ -868,10 +903,9 @@ def _compute_expected_tokens_per_rank(
     """Compute the set of (src_rank, token_idx) each rank should receive.
 
     A token is expected at dest_rank if at least one of its top_k expert
-    selections falls in dest_rank's expert range.
+    selections falls in dest_rank's expert range. Uses the same ceil/floor
+    partitioning as the kernel so this works for non-divisible EP as well.
     """
-    experts_per_rank = config.num_experts // config.ep_size
-
     expected: Dict[int, Set[Tuple[int, int]]] = {r: set() for r in range(config.ep_size)}
     for result in all_results:
         src_rank = result["rank"]
@@ -881,7 +915,8 @@ def _compute_expected_tokens_per_rank(
             for k in range(slots.shape[1]):
                 eid = slots[i, k].item()
                 if 0 <= eid < config.num_experts:
-                    expected[eid // experts_per_rank].add((src_rank, i))
+                    target_rank = _expert_id_to_rank(eid, config.num_experts, config.ep_size)
+                    expected[target_rank].add((src_rank, i))
 
     return expected
 
@@ -1006,7 +1041,6 @@ def verify_dispatch_alltoall(
     4. All tokens that should be routed to this rank are present (completeness)
     """
     num_experts = config.num_experts
-    experts_per_rank = num_experts // config.ep_size
 
     # For fp8/w4afp8, data is transported as fp8 viewed as bf16 (half width).
     # For nvfp4, data is packed uint8 (half width).
@@ -1028,8 +1062,8 @@ def verify_dispatch_alltoall(
         recv_hs = result["recv_hs"]
         recv_slots = result["recv_slots"]
 
-        slot_start = recv_rank * experts_per_rank
-        slot_end = slot_start + experts_per_rank
+        # Per-rank slot range — handles non-divisible EP.
+        _, slot_start, slot_end = _compute_ep_partition(num_experts, config.ep_size, recv_rank)
 
         decoded = decode_source_info(recv_hs, decode_dtype, decode_hidden)
         actually_received: Set[Tuple[int, int]] = set()
@@ -1175,7 +1209,6 @@ def _build_combine_reference(
     """
     num_tokens = config.all_num_tokens[target_rank]
     hidden_size = config.hidden_size
-    experts_per_rank = config.num_experts // config.ep_size
 
     # Use float32 accumulator for all paths (matches kernel behavior)
     ref = torch.zeros(num_tokens, hidden_size, dtype=torch.float32)
@@ -1222,8 +1255,9 @@ def _build_combine_reference(
             recv_hs_bf16 = proc_result["recv_hs_bf16"]
             recv_slots = proc_result["recv_slots"]
             source_info = proc_result["recv_source_info"]
-            slot_start = proc_rank * experts_per_rank
-            slot_end = slot_start + experts_per_rank
+            _, slot_start, slot_end = _compute_ep_partition(
+                config.num_experts, config.ep_size, proc_rank
+            )
 
             for i, (src_rank, token_idx) in enumerate(source_info):
                 if src_rank == target_rank and token_idx < num_tokens:
@@ -1474,6 +1508,41 @@ def _make_boundary_test_params():
     return params
 
 
+def _make_non_divisible_ep_test_params():
+    """Generate non-divisible EP test parameters for NVLinkOneSided.
+
+    Exercises ceil/floor expert partitioning where num_experts % ep_size != 0:
+        base      = num_experts // ep_size
+        remainder = num_experts %  ep_size
+        Ranks [0, remainder)        own (base + 1) experts each
+        Ranks [remainder, ep_size)  own  base      experts each
+
+    Limited to NVLinkOneSided because other comm backends still require
+    num_experts divisible by ep_size (enforced by check_feasibility).
+    """
+    params = []
+    # (ep_size, num_experts, top_k, all_num_tokens) — picked to cover both
+    # uneven ratios (5 / 2 = 2 + 1) and a larger remainder (17 / 4).
+    cases = [
+        (2, 5, 2, [16, 16]),  # base=2, remainder=1: rank0=3, rank1=2
+        (4, 17, 2, [16, 16, 16, 16]),  # base=4, remainder=1: rank0=5, others=4
+        (4, 22, 4, [8, 8, 8, 8]),  # base=5, remainder=2: rank0..1=6, rank2..3=5
+    ]
+    for ep_size, num_experts, top_k, all_num_tokens in cases:
+        for use_low_precision_combine in [False, True]:
+            config = CommTestConfig(
+                comm_type=COMM_NVLINK_ONE_SIDED,
+                ep_size=ep_size,
+                num_experts=num_experts,
+                top_k=top_k,
+                hidden_size=DEFAULT_HIDDEN_SIZE,
+                all_num_tokens=all_num_tokens,
+                use_low_precision_combine=use_low_precision_combine,
+            )
+            params.append(pytest.param(ep_size, config, id=str(config)))
+    return params
+
+
 def _make_postquant_test_params():
     """Generate post-quant test parameters using POSTQUANT_COMM_MAP.
 
@@ -1597,4 +1666,14 @@ class TestMoEComm:
     )
     def test_moe_comm_postquant(self, mpi_pool_executor, config: CommTestConfig):
         """Verify post-quant dispatch -> dequant -> MoE -> combine pipeline."""
+        _run_full_test(mpi_pool_executor, config)
+
+    @pytest.mark.threadleak(enabled=False)
+    @pytest.mark.parametrize(
+        "mpi_pool_executor,config",
+        _make_non_divisible_ep_test_params(),
+        indirect=["mpi_pool_executor"],
+    )
+    def test_moe_comm_non_divisible_ep(self, mpi_pool_executor, config: CommTestConfig):
+        """Verify NVLinkOneSided with non-divisible EP (num_experts % ep_size != 0)."""
         _run_full_test(mpi_pool_executor, config)

--- a/tests/unittest/_torch/modules/moe/test_moe_comm.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_comm.py
@@ -448,7 +448,9 @@ def check_platform_support(comm_type: str) -> Optional[str]:
 def check_feasibility(comm_type: str, config: CommTestConfig) -> Optional[str]:
     """Return skip reason string if config is infeasible, else None."""
     if config.num_experts % config.ep_size != 0 and comm_type not in (
-            COMM_NVLINK_ONE_SIDED, COMM_ALLGATHER_RS):
+        COMM_NVLINK_ONE_SIDED,
+        COMM_ALLGATHER_RS,
+    ):
         # NVLinkOneSided supports non-divisible EP natively (ceil/floor
         # partitioning); AllGatherReduceScatter is the production fallback
         # selected by CommunicationFactory for the same case. Other comm

--- a/tests/unittest/_torch/modules/moe/test_moe_comm.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_comm.py
@@ -447,9 +447,12 @@ def check_platform_support(comm_type: str) -> Optional[str]:
 
 def check_feasibility(comm_type: str, config: CommTestConfig) -> Optional[str]:
     """Return skip reason string if config is infeasible, else None."""
-    if config.num_experts % config.ep_size != 0 and comm_type != COMM_NVLINK_ONE_SIDED:
-        # Only NVLinkOneSided supports non-divisible EP (ceil/floor partitioning).
-        # Other comm types still require num_experts divisible by ep_size.
+    if config.num_experts % config.ep_size != 0 and comm_type not in (
+            COMM_NVLINK_ONE_SIDED, COMM_ALLGATHER_RS):
+        # NVLinkOneSided supports non-divisible EP natively (ceil/floor
+        # partitioning); AllGatherReduceScatter is the production fallback
+        # selected by CommunicationFactory for the same case. Other comm
+        # types still require num_experts divisible by ep_size.
         return (
             f"comm_type={comm_type} requires num_experts divisible by ep_size, "
             f"got num_experts={config.num_experts}, ep_size={config.ep_size}"


### PR DESCRIPTION
This pull request enhances support for non-divisible expert parallelism (EP) in Mixture-of-Experts (MoE) communication by implementing ceil/floor partitioning for expert assignment across ranks. The changes ensure that MoE communication and computation remain correct and efficient when the number of experts is not evenly divisible by the number of ranks. This includes updates to CUDA kernels, Python interfaces, strategy selection logic, and comprehensive unit tests.

Key changes include:

**Core algorithm and kernel updates:**

* Updated the CUDA kernel (`moeAlltoAllKernels.cu`) to use ceil/floor partitioning in `compute_target_rank_id`, allowing non-divisible expert-to-rank mapping and ensuring all experts are correctly assigned even when `num_experts % ep_size != 0`. [[1]](diffhunk://#diff-dd3f018f188d80b2396f32cc0b064e7468a7a4c05db7286c6f1a5e416ba99de6L167-R198) [[2]](diffhunk://#diff-dd3f018f188d80b2396f32cc0b064e7468a7a4c05db7286c6f1a5e416ba99de6L424-R451)
* Removed the requirement for `num_experts` to be divisible by `ep_size` in the C++ operator, reflecting the new partitioning logic.

**Python interface and strategy selection:**

* Introduced `_compute_ep_partition` in the Python interface to mirror the kernel's partitioning logic, ensuring consistent expert slot assignment and correct initialization in both standard and load-balanced MoE scenarios. [[1]](diffhunk://#diff-d94c767f111330a5d528f7b2bf99ed4753bb40d37b1340e3f0be294d49efca34R59-R76) [[2]](diffhunk://#diff-d94c767f111330a5d528f7b2bf99ed4753bb40d37b1340e3f0be294d49efca34L306-R330) [[3]](diffhunk://#diff-d94c767f111330a5d528f7b2bf99ed4753bb40d37b1340e3f0be294d49efca34L399-R429) [[4]](diffhunk://#diff-d94c767f111330a5d528f7b2bf99ed4753bb40d37b1340e3f0be294d49efca34L452-R495)
* Modified communication strategy selection to fall back to `AllGatherReduceScatter` when non-divisible EP is detected, and enforced that only whitelisted methods (NVLinkOneSided, AllGather) are allowed for non-divisible configurations. [[1]](diffhunk://#diff-cf6bf87d145acf6a8166de8b2d86cebdb9e0166407c4c3e9ca17ab204f86799aR152-R159) [[2]](diffhunk://#diff-cf6bf87d145acf6a8166de8b2d86cebdb9e0166407c4c3e9ca17ab204f86799aR257-R265)

**Testing and validation:**

* Updated and expanded unit tests to validate correct behavior for non-divisible EP, including helper functions for partitioning and expert-to-rank mapping, and new test parameter generators to cover edge cases. [[1]](diffhunk://#diff-adf76b17370525046625191634928db77a4de21accc6794a6db4b9355d8f7266R249-R282) [[2]](diffhunk://#diff-adf76b17370525046625191634928db77a4de21accc6794a6db4b9355d8f7266L268-L269) [[3]](diffhunk://#diff-adf76b17370525046625191634928db77a4de21accc6794a6db4b9355d8f7266L424-R456) [[4]](diffhunk://#diff-adf76b17370525046625191634928db77a4de21accc6794a6db4b9355d8f7266L780-R824) [[5]](diffhunk://#diff-adf76b17370525046625191634928db77a4de21accc6794a6db4b9355d8f7266L871-L874) [[6]](diffhunk://#diff-adf76b17370525046625191634928db77a4de21accc6794a6db4b9355d8f7266L1009) [[7]](diffhunk://#diff-adf76b17370525046625191634928db77a4de21accc6794a6db4b9355d8f7266L1031-R1066) [[8]](diffhunk://#diff-adf76b17370525046625191634928db77a4de21accc6794a6db4b9355d8f7266L1178) [[9]](diffhunk://#diff-adf76b17370525046625191634928db77a4de21accc6794a6db4b9355d8f7266L1225-R1260) [[10]](diffhunk://#diff-adf76b17370525046625191634928db77a4de21accc6794a6db4b9355d8f7266R1511-R1545)

These changes collectively make the MoE implementation robust to non-uniform expert distributions, improving flexibility and correctness in distributed training scenarios.

## Performance

**Setup:** GB200 NVL72 (4-node alloc, 4 GPUs/node), DeepSeek-V3 profile (`hidden=7168`, `top_k=8`, `num_experts=256`), BF16, NVLinkOneSided backend. `tests/microbenchmarks/bench_moe_comm.py --backend NVLINK_ONE_SIDED --profile deepseek_v3 --perfect_router --kernel_breakdown --iter_stats -b 1 -e 2048 -f 2`. All values are mean across MPI ranks of per-rank mean latency over 200 iterations (20 warmup).

### Dispatch latency (µs)

PR shows a tiny dispatch-side overhead vs baseline (worst case +1.93% at ep=16 b=2; most points <+1%, large batches ≤+0.1%). This is the cost of the new ceil/floor routing logic in `compute_target_rank_id` (extra `imul` + branch even on the divisible fast path); at small batch the worst Δ% (≤2%) is well within the ~5-6% iteration-to-iteration stdev observed per rank (and ~2-3% inter-rank stdev), and at large batch it amortizes to ≤±0.5% (run-to-run noise).


| batch | BL ep=8 | PR ep=8 | Δµs | Δ% | BL ep=16 | PR ep=16 | Δµs | Δ% |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 25.61 | 25.66 | +0.05 | +0.21% | 27.79 | 27.98 | +0.19 | +0.69% |
| 2 | 26.30 | 26.36 | +0.06 | +0.24% | 28.14 | 28.68 | +0.54 | +1.93% |
| 4 | 26.42 | 26.57 | +0.15 | +0.55% | 28.08 | 28.24 | +0.16 | +0.58% |
| 8 | 26.97 | 27.27 | +0.31 | +1.14% | 28.54 | 28.95 | +0.41 | +1.42% |
| 16 | 26.96 | 27.04 | +0.08 | +0.30% | 28.25 | 28.49 | +0.24 | +0.86% |
| 32 | 27.32 | 27.49 | +0.17 | +0.62% | 29.43 | 29.61 | +0.18 | +0.61% |
| 64 | 31.70 | 31.80 | +0.10 | +0.31% | 34.26 | 34.46 | +0.20 | +0.58% |
| 128 | 41.65 | 41.93 | +0.28 | +0.67% | 44.86 | 45.00 | +0.13 | +0.29% |
| 256 | 59.73 | 59.99 | +0.26 | +0.44% | 65.61 | 65.53 | -0.08 | -0.12% |
| 512 | 98.87 | 99.15 | +0.28 | +0.29% | 108.59 | 108.70 | +0.12 | +0.11% |
| 1024 | 173.87 | 174.10 | +0.23 | +0.13% | 191.43 | 191.58 | +0.15 | +0.08% |
| 2048 | 322.12 | 322.29 | +0.17 | +0.05% | 355.82 | 354.21 | -1.62 | -0.45% |

### Combine latency (µs)

(Combine kernel is unchanged by this PR; table included as a noise-floor reference.)

| batch | BL ep=8 | PR ep=8 | Δµs | Δ% | BL ep=16 | PR ep=16 | Δµs | Δ% |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 31.42 | 31.35 | -0.07 | -0.23% | 32.26 | 32.28 | +0.02 | +0.06% |
| 2 | 31.81 | 31.51 | -0.29 | -0.92% | 32.57 | 32.55 | -0.02 | -0.07% |
| 4 | 32.22 | 32.07 | -0.14 | -0.45% | 33.08 | 33.07 | -0.01 | -0.03% |
| 8 | 32.48 | 32.56 | +0.08 | +0.25% | 33.26 | 33.27 | +0.01 | +0.02% |
| 16 | 33.32 | 33.51 | +0.19 | +0.56% | 33.62 | 33.59 | -0.03 | -0.09% |
| 32 | 34.10 | 34.17 | +0.07 | +0.22% | 35.56 | 35.69 | +0.12 | +0.35% |
| 64 | 36.67 | 36.52 | -0.15 | -0.40% | 37.85 | 37.80 | -0.05 | -0.13% |
| 128 | 43.65 | 43.51 | -0.15 | -0.34% | 45.46 | 45.18 | -0.28 | -0.62% |
| 256 | 63.62 | 63.57 | -0.04 | -0.07% | 67.67 | 67.65 | -0.02 | -0.03% |
| 512 | 111.09 | 111.36 | +0.27 | +0.24% | 124.28 | 124.49 | +0.21 | +0.17% |
| 1024 | 214.46 | 214.24 | -0.23 | -0.11% | 228.45 | 228.15 | -0.30 | -0.13% |
| 2048 | 400.95 | 400.89 | -0.05 | -0.01% | 428.40 | 426.73 | -1.67 | -0.39% |

### Non-divisible EP: `ep_size=7` (256/7 → base=36, remainder=4)

PR-only (the pre-PR kernel `TORCH_CHECK`s `num_experts % ep_size == 0` and refuses to launch).

| batch | dispatch µs | combine µs | dispatch GB/s | combine GB/s |
|---:|---:|---:|---:|---:|
| 1 | 26.12 | 31.50 | 3.84 | 3.19 |
| 2 | 26.82 | 31.50 | 7.48 | 6.37 |
| 4 | 26.24 | 32.07 | 15.30 | 12.52 |
| 8 | 27.28 | 32.48 | 29.42 | 24.71 |
| 16 | 26.96 | 33.20 | 59.55 | 48.36 |
| 32 | 27.40 | 34.11 | 117.20 | 94.14 |
| 64 | 30.53 | 35.69 | 210.35 | 179.98 |
| 128 | 38.85 | 40.40 | 330.63 | 317.93 |
| 256 | 54.73 | 57.07 | 469.38 | 450.14 |
| 512 | 88.39 | 97.87 | 581.31 | 524.97 |
| 1024 | 152.85 | 188.28 | 672.27 | 545.77 |
| 2048 | 279.40 | 349.85 | 735.59 | 587.45 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for non-divisible expert distributions in Mixture-of-Experts configurations
  * Added `compact_packing` option for GPU worker placement in distributed SLURM deployments

* **Improvements**
  * Enhanced CUDA device selection for distributed workers using SLURM environment variables and GPU mapping

* **Documentation**
  * Updated SLURM benchmark configuration documentation with `compact_packing` usage guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/13888?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


