### PR TITLE
[None][fix] Gate DeepSeek V4 rotate activation

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
@@ -1096,7 +1096,7 @@ class DeepseekV4TrtllmAttention(TrtllmAttention):
                 pos_embd_params,
                 kv_cache_dtype=kv_cache_dtype,
                 dtype=dtype,
-                rotate_activation=HAS_FAST_HADAMARD,
+                rotate_activation=False,
             )
 
     def forward(self, *args, **kwargs):

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
@@ -14,7 +14,7 @@ from tensorrt_llm._utils import prefer_pinned
 from tensorrt_llm.models.modeling_utils import QuantConfig
 from tensorrt_llm.quantization.utils import fp8_utils
 
-from ..dsa import DSAtrtllmAttentionMetadata, Indexer, rotate_activation
+from ..dsa import HAS_FAST_HADAMARD, DSAtrtllmAttentionMetadata, Indexer, rotate_activation
 from ..kernel import deepseek_v4_local_to_global_indices
 from .compressor import Compressor, KVCacheDtype, resolve_kv_cache_dtype
 
@@ -949,7 +949,7 @@ class DeepseekV4Indexer(Indexer):
             dtype=dtype,
             kv_cache_dtype=self.indexer_k_cache_dtype,
             is_indexer=True,
-            rotate_activation=True,
+            rotate_activation=HAS_FAST_HADAMARD,
         )
 
     def post_load_weights(self):
@@ -1096,7 +1096,7 @@ class DeepseekV4TrtllmAttention(TrtllmAttention):
                 pos_embd_params,
                 kv_cache_dtype=kv_cache_dtype,
                 dtype=dtype,
-                rotate_activation=False,
+                rotate_activation=HAS_FAST_HADAMARD,
             )
 
     def forward(self, *args, **kwargs):

--- a/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
@@ -332,7 +332,7 @@ def test_deepseek_v4_compressor_rotate_and_indexer_rope_contracts():
     assert "rotate_activation=HAS_FAST_HADAMARD" in indexer_init
 
     attention_init = inspect.getsource(DeepseekV4TrtllmAttention.__init__)
-    assert "rotate_activation=HAS_FAST_HADAMARD" in attention_init
+    assert "rotate_activation=False" in attention_init
 
 
 def test_deepseek_v4_attention_forward_injects_attn_sink(monkeypatch):

--- a/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
@@ -329,10 +329,10 @@ def test_deepseek_v4_compressor_rotate_and_indexer_rope_contracts():
 
     indexer_init = inspect.getsource(DeepseekV4Indexer.__init__)
     assert "is_neox=False" in indexer_init
-    assert "rotate_activation=True" in indexer_init
+    assert "rotate_activation=HAS_FAST_HADAMARD" in indexer_init
 
     attention_init = inspect.getsource(DeepseekV4TrtllmAttention.__init__)
-    assert "rotate_activation=False" in attention_init
+    assert "rotate_activation=HAS_FAST_HADAMARD" in attention_init
 
 
 def test_deepseek_v4_attention_forward_injects_attn_sink(monkeypatch):


### PR DESCRIPTION
@coderabbitai summary

## Description

Gate DeepSeek-V4 compressor rotate activation on `HAS_FAST_HADAMARD` so the fused compressor postprocess only enables Hadamard rotation when `fast-hadamard-transform` is available, matching the DSA `rotate_activation` behavior.

This updates both DeepSeek-V4 `Compressor` construction sites and the corresponding source-contract test assertions.

## Test Coverage

- `python -m pre_commit run --files tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py tests/unittest/_torch/modeling/test_modeling_deepseekv4.py`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.