### PR TITLE
[None][feat] Add TLLM_DISABLE_HF_PREFETCH env to skip HF weight prefetch

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -77,7 +77,12 @@ class HfWeightLoader(BaseWeightLoader):
             # If the layer number is overridden, it indicates that only a subset of layers are loaded.
             # Prefetching all layers is unnecessary.
             num_layers = int(os.environ.get("TLLM_OVERRIDE_LAYER_NUM", "0"))
-            enable_prefetch = (prefetch_size
+            # Allow disabling prefetch via env var, e.g. when host memory is
+            # tight or NUMA-bound (GB200/GB300) and the heuristic mis-estimates
+            # what is actually pinnable.
+            force_disable_prefetch = os.environ.get(
+                "TLLM_DISABLE_HF_PREFETCH", "0") == "1"
+            enable_prefetch = (not force_disable_prefetch and prefetch_size
                                < self._get_local_available_host_memory() * 0.9
                                and num_layers == 0)
             if enable_prefetch:


### PR DESCRIPTION
## Summary
- Add a `TLLM_DISABLE_HF_PREFETCH=1` environment variable that force-disables the HF weight prefetch path in `HfWeightLoader.load_weights`.
- The prefetch heuristic compares total weight size against `psutil.virtual_memory().available`. On NUMA-bound runs (e.g. GB200/GB300 with `numactl -m 0,1`) and when other components (e.g. the V2 KV cache manager auto host tier from #13597) pin large host regions, that snapshot over-estimates what is actually pinnable, causing spurious host-memory pressure during model load.
- This env var gives users a minimal-impact escape hatch without changing the default behavior.

## Test plan
- [ ] Verify on a DSv4 disagg run (TEP=4, MTP=1) that exporting `TLLM_DISABLE_HF_PREFETCH=1` skips the "Prefetching ... checkpoint files" path while non-prefetch loading still completes successfully.
- [ ] Confirm default behavior (env unset) is unchanged (heuristic still controls prefetch).