### PR TITLE
[None][fix] Sync disagg KV transfer error handling under ADP across all executor loops

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1358,6 +1358,10 @@ class PyExecutor:
                 if self.enable_iter_perf_stats:
                     iter_start_time = time.time()
 
+                # First TP collective each iter; keeps disagg error
+                # path symmetric under ADP.
+                self._handle_disagg_cache_errors_synced()
+
                 # Fetch new requests from request queue
                 new_requests = self._fetch_and_activate_new_requests()
                 if self.should_stop_processing:
@@ -2084,6 +2088,28 @@ class PyExecutor:
                 return can_forward, True
         return can_forward, False
 
+    def _handle_disagg_cache_errors_synced(self):
+        """ADP-safe disagg cache error handler.
+
+        Called from the top of every executor iteration so all TP ranks
+        enter ``_handle_errors`` together; otherwise the downstream
+        ``tp_gather`` in ``_enqueue_responses`` deadlocks.
+        """
+        if not (self.kv_cache_transceiver and self.enable_attention_dp
+                and self.dist.world_size != 1):
+            return
+        local_error_requests = self._get_disagg_reqs_in_error_state()
+        any_has_errors = any(self.dist.tp_allgather(bool(local_error_requests)))
+        if not any_has_errors:
+            return
+        logger.warning(
+            f"Disagg KV cache transfer error: rank={self.dist.rank} "
+            f"local_err_count={len(local_error_requests)}")
+        self._handle_errors(
+            "Disagg KV cache transfer error",
+            requests=local_error_requests,
+        )
+
     def _executor_loop(self):
         torch.cuda.set_device(self.device_id)
         # ensure the context is created, otherwise, some MPI calls will fail.
@@ -2098,6 +2124,10 @@ class PyExecutor:
                 profile_step()
                 if self.enable_iter_perf_stats:
                     iter_start_time = time.time()
+
+                # First TP collective each iter; keeps disagg error
+                # path symmetric under ADP.
+                self._handle_disagg_cache_errors_synced()
 
                 scheduled_batch, iter_stats = self._prepare_and_schedule_batch()
                 self._handle_control_request()
@@ -2345,6 +2375,10 @@ class PyExecutor:
                 profile_step()
                 if self.enable_iter_perf_stats:
                     iter_start_time = time.time()
+
+                # First TP collective each iter; keeps disagg error
+                # path symmetric under ADP.
+                self._handle_disagg_cache_errors_synced()
 
                 scheduled_batch, iter_stats = self._prepare_and_schedule_batch()
                 self._handle_control_request()
@@ -3394,7 +3428,14 @@ class PyExecutor:
         ]
 
     def _check_cache_transfer_errors(self, error_msg_prefix: str):
-        """Common helper to check for and handle cache transfer errors."""
+        """Check and handle cache transfer errors.
+
+        Under ADP this is a no-op: errors are routed through
+        ``_handle_disagg_cache_errors_synced`` at the loop top so all
+        TP ranks enter ``_handle_errors`` together.
+        """
+        if self.enable_attention_dp and self.dist.world_size != 1:
+            return
         error_requests = self._get_disagg_reqs_in_error_state()
         if error_requests:
             self._handle_errors(

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -606,3 +606,88 @@ def test_pad_dummy_no_op_when_attention_dp_disabled():
     _run_pad(stub)
 
     assert stub.add_dummy_calls == []
+
+
+class _StubADPSyncedErrorExecutor:
+    """Minimal stub for testing _handle_disagg_cache_errors_synced."""
+
+    def __init__(self, *, enable_attention_dp=True, world_size=2,
+                 kv_cache_transceiver=object()):
+        self.enable_attention_dp = enable_attention_dp
+        self.kv_cache_transceiver = kv_cache_transceiver
+        self.active_requests = []
+        self.handle_errors_calls = []
+
+        self.dist = Mock()
+        self.dist.rank = 1
+        self.dist.world_size = world_size
+
+    _handle_disagg_cache_errors_synced = (
+        PyExecutor._handle_disagg_cache_errors_synced)
+    _get_disagg_reqs_in_error_state = PyExecutor._get_disagg_reqs_in_error_state
+
+    def _handle_errors(self, error_msg=None, *, requests=None):
+        self.handle_errors_calls.append((error_msg, requests))
+
+
+def _make_error_request():
+    req = Mock()
+    req.state = LlmRequestState.DISAGG_TRANS_ERROR
+    return req
+
+
+def test_synced_error_handler_no_op_when_disagg_disabled():
+    stub = _StubADPSyncedErrorExecutor(kv_cache_transceiver=None)
+    stub.active_requests = [_make_error_request()]
+
+    stub._handle_disagg_cache_errors_synced()
+
+    stub.dist.tp_allgather.assert_not_called()
+    assert stub.handle_errors_calls == []
+
+
+def test_synced_error_handler_no_op_when_attention_dp_disabled():
+    stub = _StubADPSyncedErrorExecutor(enable_attention_dp=False)
+    stub.active_requests = [_make_error_request()]
+
+    stub._handle_disagg_cache_errors_synced()
+
+    stub.dist.tp_allgather.assert_not_called()
+    assert stub.handle_errors_calls == []
+
+
+def test_synced_error_handler_skips_when_no_rank_has_errors():
+    stub = _StubADPSyncedErrorExecutor()
+    stub.dist.tp_allgather.return_value = [False, False]
+
+    stub._handle_disagg_cache_errors_synced()
+
+    stub.dist.tp_allgather.assert_called_once_with(False)
+    assert stub.handle_errors_calls == []
+
+
+def test_synced_error_handler_invokes_handle_errors_when_local_has_errors():
+    stub = _StubADPSyncedErrorExecutor()
+    err_req = _make_error_request()
+    stub.active_requests = [err_req]
+    stub.dist.tp_allgather.return_value = [True, True]
+
+    stub._handle_disagg_cache_errors_synced()
+
+    stub.dist.tp_allgather.assert_called_once_with(True)
+    assert len(stub.handle_errors_calls) == 1
+    assert stub.handle_errors_calls[0][1] == [err_req]
+
+
+def test_synced_error_handler_runs_on_silent_rank_when_peer_has_errors():
+    """Reproduces the deadlock scenario: this rank has no local errors
+    but a peer does.  All ranks must enter _handle_errors together."""
+    stub = _StubADPSyncedErrorExecutor()
+    # No local errors on this rank.
+    stub.dist.tp_allgather.return_value = [False, True]
+
+    stub._handle_disagg_cache_errors_synced()
+
+    stub.dist.tp_allgather.assert_called_once_with(False)
+    assert len(stub.handle_errors_calls) == 1
+    assert stub.handle_errors_calls[0][1] == []


### PR DESCRIPTION
## Summary

- Fixes an MPI collective-mismatch deadlock observed on DSv4 dep16 disagg gen.
- Adds `_handle_disagg_cache_errors_synced` and wires it into the top of all three executor loops (`_executor_loop`, `_executor_loop_overlap`, `_executor_loop_pp`).

## Problem

With ADP enabled in disaggregated serving, a NIXL/UCX KV transfer failure is rank-local: only the failing DP rank sees `DISAGG_TRANS_ERROR` and enters `_check_cache_transfer_errors → _handle_errors → _enqueue_responses → tp_gather`. Peer ranks without a local error continue to `_can_queue → tp_allgather`. The two different TP collectives on the same group hang MPI; the hang detector then dumps stacks after 300s.

Repro log (dep16, batch4, eplb0, mtp3): only one rank in `tp_gather` from `_check_cache_transfer_errors`, the other 15 in `tp_allgather` from `_can_queue` (`_executor_loop_overlap`).

## Approach

A new `_handle_disagg_cache_errors_synced`:

1. `tp_allgather` a single `bool` (does this rank have local error requests).
2. If no rank reports errors: return.
3. Otherwise all ranks call `_handle_errors(...)` together, each passing its own (possibly empty) `local_error_requests`.

Wired into the top of every iteration of `_executor_loop`, `_executor_loop_overlap`, and `_executor_loop_pp` so the downstream `tp_gather` in `_enqueue_responses` is reached by all ranks in lockstep.

`_check_cache_transfer_errors` becomes a no-op under ADP to avoid double-handling; the non-ADP path is unchanged.

## Relationship to PR #13900

This is the same root cause and same approach as #13900 by @Shixiaowei02, narrowed to the deadlock fix and extended in two ways:

- #13900 only adds the synced call to `_executor_loop`. Our hang was observed in `_executor_loop_overlap`, so this PR also covers the overlap loop and `_executor_loop_pp`.
- This PR omits #13900's unrelated changes (`_pending_transfer_responses` for the success path, `_adp_dummy_role` refactor, `_count_schedulable_active_requests` GENERATION_TO_COMPLETE exclusion, `_pad_attention_dp_dummy_request` token_nums, NIXL diagnostic logging) so it can land independently. Happy to drop in favor of #13900 if its scope is rebased to cover the overlap loop.

## Cost

Per iteration: one `tp_allgather(bool)` (~30 bytes pickled). The slow path only runs when at least one rank reports errors.

## Test plan

- [x] New unit tests in `tests/unittest/_torch/executor/test_py_executor.py`:
  - `test_synced_error_handler_no_op_when_disagg_disabled`
  - `test_synced_error_handler_no_op_when_attention_dp_disabled`
  - `test_synced_error_handler_skips_when_no_rank_has_errors`
  - `test_synced_error_handler_invokes_handle_errors_when_local_has_errors`
  - `test_synced_error_handler_runs_on_silent_rank_when_peer_has_errors` (deadlock reproducer)
- [ ] Stress run dep16 disagg gen (DSv4) to confirm no 300s hang under transfer-error injection