### PR TITLE
[None][fix] Make SleepConfig picklable by replacing closure lambda in defaultdict

### DIFF
--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1971,6 +1971,17 @@ class ExecutorMemoryType(StrEnum):
     MODEL_WEIGHTS_DRAFT = "draft_model_weights"
 
 
+@dataclass
+class _SleepConfigDefaultFactory:
+    """Picklable replacement for ``lambda: default_mode`` in SleepConfig's defaultdict.
+    """
+
+    default_mode: Any
+
+    def __call__(self) -> Any:
+        return self.default_mode
+
+
 class SleepConfig(StrictBaseModel):
     """Configuration for the LLM sleep/wakeup feature.
     """
@@ -2043,7 +2054,7 @@ class SleepConfig(StrictBaseModel):
             cls._normalize_restore_mode(value)
             for key, value in cases.items()
         }
-        return defaultdict(lambda: default_mode, normalized_cases)
+        return defaultdict(_SleepConfigDefaultFactory(default_mode), normalized_cases)
 
     @field_validator('restore_modes', mode='plain')
     @classmethod

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2054,8 +2054,8 @@ class SleepConfig(StrictBaseModel):
             cls._normalize_restore_mode(value)
             for key, value in cases.items()
         }
-        return defaultdict(
-            _SleepConfigDefaultFactory(default_mode), normalized_cases)
+        factory = _SleepConfigDefaultFactory(default_mode)
+        return defaultdict(factory, normalized_cases)
 
     @field_validator('restore_modes', mode='plain')
     @classmethod

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2054,7 +2054,8 @@ class SleepConfig(StrictBaseModel):
             cls._normalize_restore_mode(value)
             for key, value in cases.items()
         }
-        return defaultdict(_SleepConfigDefaultFactory(default_mode), normalized_cases)
+        return defaultdict(
+            _SleepConfigDefaultFactory(default_mode), normalized_cases)
 
     @field_validator('restore_modes', mode='plain')
     @classmethod

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from utils.llm_data import llm_models_root
+from utils.util import force_ampere
 
 import tensorrt_llm.bindings.executor as tle
 import tensorrt_llm.llmapi.llm_args as llm_args_mod
@@ -381,8 +382,9 @@ def test_SleepConfig_restore_modes_normalized_from_defaultdict():
         ExecutorMemoryType.SAMPLER] == RestoreMode.CPU
 
 
+@force_ampere
 def test_SleepConfig_is_picklable():
-    """SleepConfig must survive a pickle round-trip.
+    """SleepConfig with default construction must survive a pickle round-trip.
 
     MPI worker initialisation serialises llm_args (including SleepConfig) via
     pickle to distribute configuration to each rank.  The defaultdict inside
@@ -391,12 +393,16 @@ def test_SleepConfig_is_picklable():
     """
     import pickle
 
-    # Default construction
     cfg_default = SleepConfig()
     rt = pickle.loads(pickle.dumps(cfg_default))  # noqa: S301
     assert rt.restore_modes == cfg_default.restore_modes
 
-    # Construction with explicit per-key overrides
+
+@force_ampere
+def test_SleepConfig_pickle_custom_restore_modes_roundtrip():
+    """SleepConfig with explicit per-key overrides must survive a pickle round-trip."""
+    import pickle
+
     cfg_custom = SleepConfig(
         restore_modes={
             ExecutorMemoryType.KV_CACHE.value: "NONE",
@@ -409,6 +415,7 @@ def test_SleepConfig_is_picklable():
         ExecutorMemoryType.MODEL_WEIGHTS_MAIN] == RestoreMode.CPU
 
 
+@force_ampere
 def test_SleepConfig_pickle_defaultfactory_survives_roundtrip():
     """The defaultdict default_factory must remain functional after pickle.
 

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -381,6 +381,38 @@ def test_SleepConfig_restore_modes_normalized_from_defaultdict():
         ExecutorMemoryType.SAMPLER] == RestoreMode.CPU
 
 
+def test_SleepConfig_is_picklable():
+    """SleepConfig must survive a pickle round-trip.
+
+    MPI worker initialisation serialises llm_args (including SleepConfig) via
+    pickle to distribute configuration to each rank.  The defaultdict inside
+    restore_modes previously used a closure lambda as its default_factory, which
+    is not picklable.  This test catches any regression to that pattern.
+    """
+    import pickle
+
+    # Default construction
+    cfg_default = SleepConfig()
+    rt = pickle.loads(pickle.dumps(cfg_default))
+    assert rt.restore_modes == cfg_default.restore_modes
+    # Verify the default_factory still works after round-trip (i.e. missing
+    # keys return a RestoreMode, not raise KeyError).
+    missing_key = ExecutorMemoryType.SAMPLER
+    assert isinstance(rt.restore_modes[missing_key], RestoreMode)
+
+    # Construction with explicit per-key overrides
+    cfg_custom = SleepConfig(
+        restore_modes={
+            ExecutorMemoryType.KV_CACHE.value: "NONE",
+            ExecutorMemoryType.MODEL_WEIGHTS_MAIN.value: "CPU",
+        })
+    rt_custom = pickle.loads(pickle.dumps(cfg_custom))
+    assert rt_custom.restore_modes[
+        ExecutorMemoryType.KV_CACHE] == RestoreMode.NONE
+    assert rt_custom.restore_modes[
+        ExecutorMemoryType.MODEL_WEIGHTS_MAIN] == RestoreMode.CPU
+
+
 def test_DynamicBatchConfig_declaration():
     config = DynamicBatchConfig(enable_batch_size_tuning=True,
                                 enable_max_num_tokens_tuning=True,

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -393,12 +393,8 @@ def test_SleepConfig_is_picklable():
 
     # Default construction
     cfg_default = SleepConfig()
-    rt = pickle.loads(pickle.dumps(cfg_default))
+    rt = pickle.loads(pickle.dumps(cfg_default))  # noqa: S301
     assert rt.restore_modes == cfg_default.restore_modes
-    # Verify the default_factory still works after round-trip (i.e. missing
-    # keys return a RestoreMode, not raise KeyError).
-    missing_key = ExecutorMemoryType.SAMPLER
-    assert isinstance(rt.restore_modes[missing_key], RestoreMode)
 
     # Construction with explicit per-key overrides
     cfg_custom = SleepConfig(
@@ -406,11 +402,29 @@ def test_SleepConfig_is_picklable():
             ExecutorMemoryType.KV_CACHE.value: "NONE",
             ExecutorMemoryType.MODEL_WEIGHTS_MAIN.value: "CPU",
         })
-    rt_custom = pickle.loads(pickle.dumps(cfg_custom))
+    rt_custom = pickle.loads(pickle.dumps(cfg_custom))  # noqa: S301
     assert rt_custom.restore_modes[
         ExecutorMemoryType.KV_CACHE] == RestoreMode.NONE
     assert rt_custom.restore_modes[
         ExecutorMemoryType.MODEL_WEIGHTS_MAIN] == RestoreMode.CPU
+
+
+def test_SleepConfig_pickle_defaultfactory_survives_roundtrip():
+    """The defaultdict default_factory must remain functional after pickle.
+
+    Missing keys should return a valid RestoreMode rather than raising
+    KeyError, proving the factory (not just the already-present entries)
+    was serialised correctly.
+    """
+    import pickle
+
+    cfg_default = SleepConfig()
+    rt = pickle.loads(pickle.dumps(cfg_default))  # noqa: S301
+
+    missing_key = ExecutorMemoryType.SAMPLER
+    assert isinstance(rt.restore_modes[missing_key], RestoreMode)
+    assert rt.restore_modes[missing_key] == cfg_default.restore_modes[
+        missing_key]
 
 
 def test_DynamicBatchConfig_declaration():


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `SleepConfig` serialization to properly support pickle-based object persistence and restoration.

* **Tests**
  * Added test coverage verifying `SleepConfig` can be successfully pickled and unpickled while maintaining configuration integrity, including default values and custom overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

`SleepConfig._make_defaulted_restore_modes()` returns a `defaultdict` whose `default_factory` is a closure lambda (lambda: default_mode). Because `defaultdict` stores `default_factory` as an instance attribute, it is serialised when `llm_args` is pickled during MPI worker initialisation (mpi_session.py distributes configuration to each rank via pickle). A closure lambda has no module-level name and raises `AttributeError` at pickle time, making any SleepConfig-enabled multi-rank deployment fail before the engine starts.

**Fix**: introduce `_SleepConfigDefaultFactory`, a private @dataclass that holds the concrete RestoreMode value and returns it via `__call__`. It is a drop-in replacement for the lambda and is fully picklable. No behaviour change — `_validate_restore_modes` calls `v.default_factory()` and continues to work correctly.

## Test Coverage

`test_SleepConfig_is_picklable`:

- Default SleepConfig survives pickle — the core regression check
- default_factory still works after round-trip — a missing key on the restored defaultdict returns a RestoreMode rather than raising KeyError, confirming _SleepConfigDefaultFactory was properly reconstructed by pickle
- Custom overrides survive pickle — ensures the explicit key→value mapping is also preserved correctly

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
