### PR TITLE
[#13909][fix] Reuse hidden_states buffer across CUDA graph captures in Eagle3

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -7,7 +7,6 @@ import torch
 
 from tensorrt_llm.llmapi.llm_args import (BaseSparseAttentionConfig,
                                           DecodingBaseConfig)
-from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 from ...inputs.multimodal import MultimodalParams
@@ -391,12 +390,6 @@ class CUDAGraphRunner:
         self.graphs[key] = graph
         self.graph_outputs[key] = make_weak_ref(output)
         self.memory_pool = graph.pool()
-        logger.debug(
-            f"[Memory-Debug][rank={self.config.mapping.rank}][cuda_graph:capture] "
-            f"key={key} is_draft_model={self.config.is_draft_model} "
-            f"graphs_so_far={len(self.graphs)} "
-            f"torch_memory_allocated={torch.cuda.memory_allocated()/1024**3:.2f}GiB"
-        )
 
     def replay(self, key: KeyType,
                current_inputs: Dict[str, Any]) -> Optional[torch.Tensor]:

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -7,6 +7,7 @@ import torch
 
 from tensorrt_llm.llmapi.llm_args import (BaseSparseAttentionConfig,
                                           DecodingBaseConfig)
+from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 from ...inputs.multimodal import MultimodalParams
@@ -390,6 +391,12 @@ class CUDAGraphRunner:
         self.graphs[key] = graph
         self.graph_outputs[key] = make_weak_ref(output)
         self.memory_pool = graph.pool()
+        logger.debug(
+            f"[Memory-Debug][rank={self.config.mapping.rank}][cuda_graph:capture] "
+            f"key={key} is_draft_model={self.config.is_draft_model} "
+            f"graphs_so_far={len(self.graphs)} "
+            f"torch_memory_allocated={torch.cuda.memory_allocated()/1024**3:.2f}GiB"
+        )
 
     def replay(self, key: KeyType,
                current_inputs: Dict[str, Any]) -> Optional[torch.Tensor]:

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -372,6 +372,10 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
         if self.spec_resource_manager is not None and hasattr(
                 self.spec_resource_manager, 'hidden_states'):
             self.hidden_states = self.spec_resource_manager.hidden_states
+            expected_cols = self.hidden_size * len(self.layers_to_capture)
+            assert self.hidden_states.shape[1] == expected_cols, (
+                f"hidden_states shape mismatch: resource_manager has "
+                f"{self.hidden_states.shape}, expected (:, {expected_cols})")
         else:
             self.hidden_states = torch.empty(
                 (self.max_num_tokens,

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -374,8 +374,11 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
             self.hidden_states = self.spec_resource_manager.hidden_states
             expected_cols = self.hidden_size * len(self.layers_to_capture)
             assert self.hidden_states.shape[1] == expected_cols, (
-                f"hidden_states shape mismatch: resource_manager has "
-                f"{self.hidden_states.shape}, expected (:, {expected_cols})")
+                f"hidden_states shape mismatch: "
+                f"{type(self.spec_resource_manager).__name__} has "
+                f"{self.hidden_states.shape}, but metadata expects "
+                f"(:, {expected_cols}) from hidden_size={self.hidden_size} "
+                f"x capture_layers={list(self.layers_to_capture)}")
         else:
             self.hidden_states = torch.empty(
                 (self.max_num_tokens,

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -369,7 +369,15 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
         else:
             self.layers_to_capture = sorted(list(self.layers_to_capture))
         self.num_capture_layers = len(self.layers_to_capture)
-        self.hidden_states = self.spec_resource_manager.hidden_states
+        if self.spec_resource_manager is not None and hasattr(
+                self.spec_resource_manager, 'hidden_states'):
+            self.hidden_states = self.spec_resource_manager.hidden_states
+        else:
+            self.hidden_states = torch.empty(
+                (self.max_num_tokens,
+                 self.hidden_size * len(self.layers_to_capture)),
+                dtype=self.dtype,
+                device='cuda')
         self.batch_indices_cuda = torch.empty(
             [self.max_num_requests],
             dtype=torch.int,

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -130,6 +130,8 @@ class Eagle3OneModelDynamicTreeResourceManager(BaseResourceManager):
     for tree attention setup and verification routing.
     """
 
+    hidden_states: Optional[torch.Tensor] = None
+
     def __init__(self, config: "EagleDecodingConfig", max_num_requests: int):
         self.max_num_requests = max_num_requests
         self.spec_tree_manager = SpecTreeManager(
@@ -369,8 +371,8 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
         else:
             self.layers_to_capture = sorted(list(self.layers_to_capture))
         self.num_capture_layers = len(self.layers_to_capture)
-        if self.spec_resource_manager is not None and hasattr(
-                self.spec_resource_manager, 'hidden_states'):
+        if (self.spec_resource_manager is not None
+                and self.spec_resource_manager.hidden_states is not None):
             self.hidden_states = self.spec_resource_manager.hidden_states
             expected_cols = self.hidden_size * len(self.layers_to_capture)
             assert self.hidden_states.shape[1] == expected_cols, (

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -369,11 +369,7 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
         else:
             self.layers_to_capture = sorted(list(self.layers_to_capture))
         self.num_capture_layers = len(self.layers_to_capture)
-        self.hidden_states = torch.empty(
-            (self.max_num_tokens,
-             self.hidden_size * len(self.layers_to_capture)),
-            dtype=self.dtype,
-            device='cuda')
+        self.hidden_states = self.spec_resource_manager.hidden_states
         self.batch_indices_cuda = torch.empty(
             [self.max_num_requests],
             dtype=torch.int,

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -212,17 +212,15 @@ def get_spec_resource_manager(model_engine, draft_model_engine=None):
         if sa_cfg is not None:
             sa_manager = SuffixAutomatonManager(sa_cfg, max_num_requests,
                                                 max_seq_len)
-        if sa_manager is not None:
-            return Eagle3ResourceManager(
-                spec_config,
-                model_config.torch_dtype,
-                model_config.hidden_size,
-                max_num_requests,
-                max_seq_len,
-                max_num_tokens,
-                sa_manager=sa_manager,
-            )
-        return None
+        return Eagle3ResourceManager(
+            spec_config,
+            model_config.torch_dtype,
+            model_config.hidden_size,
+            max_num_requests,
+            max_seq_len,
+            max_num_tokens,
+            sa_manager=sa_manager,
+        )
     if spec_dec_mode.is_eagle3() or spec_dec_mode.is_mtp_eagle():
         assert draft_model_engine is not None, "Draft model engine is required for Eagle3 and MTP Eagle two model flow."
         return Eagle3ResourceManager(


### PR DESCRIPTION
## Description

 During CUDA graph capture in the Eagle3 one-model flow, `Eagle3OneModelSpecMetadata` allocated a new `hidden_states` buffer 
  (`max_num_tokens × hidden_size × num_capture_layers`) per graph capture. This caused memory to grow linearly with the number
   of graphs captured, wasting ~2.75 GiB for 16 captures on Qwen3-235B.                                                       
                       
  Fix: Always create `Eagle3ResourceManager` in the one-model flow (previously only created when `sa_manager` was not None)   
  and reuse its pre-allocated `hidden_states` buffer instead of allocating a new one per capture.
                                                                                                                              
  Fixes: https://github.com/NVIDIA/TensorRT-LLM/issues/13909   

## Test Coverage

 Manually validated on Qwen3-235B-A22B with FP8 KV cache, 16 CUDA graph captures:                                            
  - **Without fix**: memory grows from 30.28 GiB → 33.03 GiB (+2.75 GiB, ~183 MiB per capture)
  - **With fix**: memory stays flat at ~30.37 GiB across all 16 captures                                                      
 
## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized hidden state memory allocation in speculative decoding through unified resource buffer usage
  * Enhanced Eagle3ResourceManager initialization to consistently construct the resource manager

* **Chores**
  * Added debug logging for CUDA graph capture operations with runner identification and memory metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->