### PR TITLE
[None][fix] Fix accracy regression in DeepSeek models

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/hf.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/hf.py
@@ -341,7 +341,15 @@ class AutoModelForCausalLMFactory(AutoModelFactory):
         """Initialize the tokenizer—either a custom name or the model's default."""
         if self.tokenizer is None:
             return None
-        return AutoTokenizer.from_pretrained(self.tokenizer, **self.tokenizer_kwargs)
+        tokenizer = AutoTokenizer.from_pretrained(self.tokenizer, **self.tokenizer_kwargs)
+        # Transformers 5.x: LlamaTokenizer forces a Metaspace pre-tokenizer over
+        # the ByteLevel one declared in tokenizer.json for repos like
+        # DeepSeek-V3/R1 that set tokenizer_class="LlamaTokenizer" but ship a
+        # ByteLevel BPE.  Mirror the fix the pytorch backend applies inside
+        # TransformersTokenizer.from_pretrained.
+        from tensorrt_llm.tokenizer import maybe_fix_byte_level_tokenizer
+
+        return maybe_fix_byte_level_tokenizer(tokenizer, self.tokenizer, **self.tokenizer_kwargs)
 
     def build_and_load_model(self, device: DeviceLikeType) -> nn.Module:
         """Automatically build the model from_pretrained and load the weights.


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tokenizer compatibility handling for HuggingFace models, addressing configuration mismatches with newer Transformers library versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
auto_deploy: apply byte-level pre-tokenizer fix in init_tokenizer

DeepSeek-V3/R1 set tokenizer_class="LlamaTokenizer" in tokenizer_config.json but ship a ByteLevel BPE tokenizer.json. Under transformers 5.x, LlamaTokenizer.__init__ forces a Metaspace pre-tokenizer that silently overrides the ByteLevel one, stripping spaces from prompts ("hello world" -> "helloworld") and breaking the few-shot format that GSM8K strict-match depends on (regression: gsm8k strict 95.30 -> 0.00, eval acc 95.38 -> 46.82 with no other change).

PR #12829 added maybe_fix_byte_level_tokenizer in tensorrt_llm/tokenizer and wired it into the pytorch backend via TransformersTokenizer.from_pretrained, but AutoDeploy bypasses that path: AutoModelForCausalLMFactory.init_tokenizer returns AutoTokenizer.from_pretrained(...) directly, and tokenizer_factory's PreTrainedTokenizerBase branch wraps without re-running the fix.

Mirror the fix in init_tokenizer so AutoDeploy gets the same correction. 
Verified on DeepSeek-R1-0528 with transformers 5.3.0

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
