### PR TITLE
[TRTLLM-12440][feat] Add GMS-only weight sharing support

### DIFF
--- a/tensorrt_llm/_torch/memory/__init__.py
+++ b/tensorrt_llm/_torch/memory/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .gpu_memory_backend import GMSBackend, GPUMemoryBackend
+
+__all__ = ["GPUMemoryBackend", "GMSBackend"]

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -70,7 +70,7 @@ class GPUMemoryBackend(Protocol):
     def mem_pool_scope(
         self,
         device: Optional[torch.device] = None,
-    ) -> "Iterator[None]":
+    ) -> Iterator[None]:
         """Return a context manager scoping CUDA allocations to the backend pool."""
         ...
 
@@ -349,31 +349,35 @@ class GMSBackend:
         device_index = self._device_index
         tracked_storage_ptrs: set[int] = set()
 
-        with torch.no_grad():
-            for _name, tensor, tensor_type in _iter_module_tensors(model):
-                if tensor_type != "parameter" or tensor is None or not tensor.is_cuda:
-                    continue
+        # No torch.no_grad() guard: ``tensor.data = X`` bypasses autograd by
+        # definition (it's a data-attribute assignment, not an autograd-tracked
+        # operation), and ``replacement.copy_(tensor)`` is an in-place op on a
+        # freshly created tensor with no autograd history. Model loading also
+        # runs outside any grad-enabled context.
+        for _name, tensor, tensor_type in _iter_module_tensors(model):
+            if tensor_type != "parameter" or tensor is None or not tensor.is_cuda:
+                continue
 
-                # GMS tracks whole storage allocations, so use the storage
-                # base pointer instead of a tensor view's offset pointer.
-                storage_base_ptr = tensor.untyped_storage().data_ptr()
-                if _ptr_in_gms(gms_client, int(storage_base_ptr)):
-                    continue
-                if storage_base_ptr in tracked_storage_ptrs:
-                    continue
-                tracked_storage_ptrs.add(storage_base_ptr)
+            # GMS tracks whole storage allocations, so use the storage
+            # base pointer instead of a tensor view's offset pointer.
+            storage_base_ptr = tensor.untyped_storage().data_ptr()
+            if _ptr_in_gms(gms_client, int(storage_base_ptr)):
+                continue
+            if storage_base_ptr in tracked_storage_ptrs:
+                continue
+            tracked_storage_ptrs.add(storage_base_ptr)
 
-                nbytes = _storage_nbytes(tensor)
-                base_va = gms_client.create_mapping(size=nbytes, tag=self._tag)
-                replacement = _tensor_from_pointer(
-                    int(base_va),
-                    list(tensor.shape),
-                    list(tensor.stride()),
-                    tensor.dtype,
-                    device_index,
-                )
-                replacement.copy_(tensor)
-                tensor.data = replacement
+            nbytes = _storage_nbytes(tensor)
+            base_va = gms_client.create_mapping(size=nbytes, tag=self._tag)
+            replacement = _tensor_from_pointer(
+                int(base_va),
+                list(tensor.shape),
+                list(tensor.stride()),
+                tensor.dtype,
+                device_index,
+            )
+            replacement.copy_(tensor)
+            tensor.data = replacement
 
     def finalize_write(self, model: nn.Module) -> int:
         """Register tensors, commit them, and transition this client to RO.

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -195,6 +195,12 @@ class GMSBackend:
                 tag=self._tag,
             )
         except Exception as e:
+            # TODO(GMS-API): narrow once upstream documents the expected
+            # client-creation failure modes (socket missing, connection
+            # refused, daemon crashed). Today the upstream API doesn't
+            # enumerate them, so the broad catch protects the
+            # "GMS optional / fall through to disk" guarantee at the cost
+            # of also swallowing programming bugs (e.g. signature drift).
             logger.warning(
                 "Failed to connect to GMS at %s (mode=%s, tag=%s): %s",
                 socket_path,
@@ -203,6 +209,7 @@ class GMSBackend:
                 e,
             )
             self._client = None
+            self._is_rw = None
             return False
 
         self._is_rw = self._client.granted_lock_type == GrantedLockType.RW
@@ -347,7 +354,15 @@ class GMSBackend:
 
         gms_client = self._client
         device_index = self._device_index
-        tracked_storage_ptrs: set[int] = set()
+        # Map original storage base ptr -> new GMS base_va. Serves two roles:
+        #   1. Dedups create_mapping() / copy_() calls when multiple tensors
+        #      share a storage (e.g. tied embeddings, sliced fused params).
+        #   2. Lets us rebind every view of a shared storage to the SAME
+        #      GMS mapping, so all tied/aliased parameters end up backed
+        #      by the GMS pool. Without this, only the first encountered
+        #      view was rebound; subsequent views still pointed at the
+        #      original non-GMS storage and were missed by finalize_write.
+        storage_to_gms_va: dict[int, int] = {}
 
         # No torch.no_grad() guard: ``tensor.data = X`` bypasses autograd by
         # definition (it's a data-attribute assignment, not an autograd-tracked
@@ -363,12 +378,14 @@ class GMSBackend:
             storage_base_ptr = tensor.untyped_storage().data_ptr()
             if _ptr_in_gms(gms_client, int(storage_base_ptr)):
                 continue
-            if storage_base_ptr in tracked_storage_ptrs:
-                continue
-            tracked_storage_ptrs.add(storage_base_ptr)
 
-            nbytes = _storage_nbytes(tensor)
-            base_va = gms_client.create_mapping(size=nbytes, tag=self._tag)
+            base_va = storage_to_gms_va.get(storage_base_ptr)
+            first_for_this_storage = base_va is None
+            if first_for_this_storage:
+                nbytes = _storage_nbytes(tensor)
+                base_va = gms_client.create_mapping(size=nbytes, tag=self._tag)
+                storage_to_gms_va[storage_base_ptr] = base_va
+
             replacement = _tensor_from_pointer(
                 int(base_va),
                 list(tensor.shape),
@@ -376,7 +393,11 @@ class GMSBackend:
                 tensor.dtype,
                 device_index,
             )
-            replacement.copy_(tensor)
+            # Copy original bytes exactly once per storage; subsequent
+            # views of the same storage just rebind onto the same GMS
+            # mapping without recopying.
+            if first_for_this_storage:
+                replacement.copy_(tensor)
             tensor.data = replacement
 
     def finalize_write(self, model: nn.Module) -> int:
@@ -511,6 +532,7 @@ class GMSBackend:
             logger.warning("GMS cleanup error: %s", e)
         finally:
             self._client = None
+            self._is_rw = None
 
 
 def _ptr_in_gms(gms_client, ptr: int) -> bool:

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU Memory Backend protocol and GMS implementation.
+
+Defines a thin protocol that adapts the upstream GPU Memory Service
+(``gpu_memory_service`` from ``ai-dynamo/dynamo``) into TRT-LLM's
+``ModelLoader`` pipeline. The protocol intentionally exposes only the
+operations TRT-LLM needs at specific points in the loading lifecycle —
+all heavy lifting (CUDA VMM, FD passing, zero-copy tensor construction)
+is delegated to the GMS library's stable public Python primitives.
+
+Design notes:
+- We deliberately avoid the upstream ``setup_gms()`` monkey-patch entry
+  point. TRT-LLM owns the integration policy in ``ModelLoader``; this
+  backend is a thin adapter over the GMS library's primitive API.
+- The protocol has a single point of contact per concern, so when the
+  upstream GMS Python API drifts, only the methods on ``GMSBackend``
+  need to change — the call sites in ``model_loader.py`` are stable.
+
+Operating modes:
+- **RW (Read-Write)**: First worker loads weights via the normal
+  checkpoint loader pipeline, with allocations captured by a GMS-managed
+  CUDA memory pool. After loading, weights are committed for read-only
+  access by other workers and the client transitions to RO mode in place.
+- **RO (Read-Only)**: Subsequent workers zero-copy import already-committed
+  weights from the GMS pool. ``post_load_weights()`` must run BEFORE
+  materialization so that module aliases are set up correctly.
+"""
+
+from contextlib import contextmanager
+from typing import Iterator, Optional, Protocol, runtime_checkable
+
+import torch
+from torch import nn
+
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
+
+
+@runtime_checkable
+class GPUMemoryBackend(Protocol):
+    """Thin abstraction over GPU memory services for API stability."""
+
+    def connect(self) -> bool:
+        """Establish a session with the backend. Returns True on success."""
+        ...
+
+    @property
+    def is_rw(self) -> Optional[bool]:
+        """Whether this backend was granted RW (vs RO). None pre-connect."""
+        ...
+
+    def has_committed_weights(self) -> bool:
+        """Whether committed weights are ready to be imported (RO-ready)."""
+        ...
+
+    def mem_pool_scope(
+        self,
+        device: Optional[torch.device] = None,
+    ) -> "Iterator[None]":
+        """Return a context manager scoping CUDA allocations to the backend pool."""
+        ...
+
+    def materialize_module(self, model: nn.Module) -> None:
+        """Zero-copy import committed weights into model params (RO path)."""
+        ...
+
+    def finalize_write(self, model: nn.Module) -> int:
+        """Register, commit, and transition to RO. Returns bytes committed."""
+        ...
+
+    def move_untracked_params(self, model: nn.Module) -> None:
+        """Move stray params not in the backend pool into shared memory."""
+        ...
+
+    def cleanup(self) -> None:
+        """Release all resources and disconnect."""
+        ...
+
+
+# String mode -> upstream RequestedLockType. Resolved lazily inside connect()
+# so importing this module does not require the GMS library to be installed.
+_MODE_ALIASES = ("rw", "ro", "auto")
+
+
+class GMSBackend:
+    """Concrete ``GPUMemoryBackend`` using ``gpu_memory_service`` (GMS).
+
+    GMS is a multi-process GPU memory manager (out-of-process server,
+    in-process clients) that lets multiple inference instances share weight
+    bytes via CUDA VMM mappings and Unix-socket FD passing.
+
+    This adapter calls the GMS library's stable per-call primitives
+    (``GMSClientMemoryManager`` + the helpers in
+    ``gpu_memory_service.client.torch.allocator`` and ``.module``) and
+    composes them into the methods TRT-LLM's ``ModelLoader`` invokes for
+    the ``LoadFormat.GMS`` branch. We intentionally do **not** use the
+    upstream ``setup_gms()`` monkey-patch — TRT-LLM owns the integration
+    policy and we keep the dependency surface narrow and explicit.
+    """
+
+    DEFAULT_TAG = "weights"
+
+    def __init__(
+        self,
+        socket_path: Optional[str],
+        mapping: Mapping,
+        mode: str = "auto",
+        tag: str = DEFAULT_TAG,
+    ) -> None:
+        """Initialize the GMS backend.
+
+        Args:
+            socket_path: Unix domain socket path for the per-GPU GMS daemon.
+                When ``None``, the default per-GPU UUID-keyed path from
+                ``gpu_memory_service.common.utils.get_socket_path`` is used
+                (resolved lazily inside :meth:`connect`).
+            mapping: TRT-LLM distributed ``Mapping`` for TP/PP rank info.
+            mode: Operating mode — ``"auto"`` (RW first, RO after committed),
+                ``"rw"`` (require RW), or ``"ro"`` (require RO).
+            tag: Logical tag identifying this weight set in the GMS server.
+                Default ``"weights"`` matches the GMS library convention.
+        """
+        if mode not in _MODE_ALIASES:
+            raise ValueError(f"GMS mode must be one of {_MODE_ALIASES}, got {mode!r}")
+
+        self._socket_path = socket_path
+        self._mapping = mapping
+        self._mode = mode
+        self._tag = tag
+        self._device_index = torch.cuda.current_device()
+
+        # Late-bound state, populated by connect()
+        self._client = None  # GMSClientMemoryManager (lazy-typed)
+        self._is_rw: Optional[bool] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def connect(self) -> bool:
+        """Connect to the per-GPU GMS daemon and acquire a session.
+
+        Returns ``True`` on success. On import failure (library not
+        installed) or socket failure, returns ``False`` and logs a warning
+        — callers are expected to surface a useful error to the user.
+        """
+        try:
+            from gpu_memory_service.client.torch.allocator import (
+                get_or_create_gms_client_memory_manager,
+            )
+            from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
+            from gpu_memory_service.common.utils import get_socket_path
+            from gpu_memory_service.integrations.common.patches import patch_empty_cache
+        except ImportError:
+            logger.warning(
+                "gpu_memory_service library not installed; cannot use "
+                "LoadFormat.GMS. Install from "
+                "https://github.com/ai-dynamo/dynamo/tree/main/lib/gpu_memory_service"
+            )
+            return False
+
+        mode_map = {
+            "rw": RequestedLockType.RW,
+            "ro": RequestedLockType.RO,
+            "auto": RequestedLockType.RW_OR_RO,
+        }
+
+        # Resolve default socket path against the upstream convention so
+        # multiple TRT-LLM instances on the same node automatically share
+        # the same per-GPU daemon.
+        socket_path = self._socket_path
+        if socket_path is None:
+            socket_path = get_socket_path(self._device_index, self._tag)
+        self._socket_path = socket_path
+
+        try:
+            self._client = get_or_create_gms_client_memory_manager(
+                socket_path,
+                self._device_index,
+                mode=mode_map[self._mode],
+                tag=self._tag,
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to connect to GMS at %s (mode=%s, tag=%s): %s",
+                socket_path,
+                self._mode,
+                self._tag,
+                e,
+            )
+            self._client = None
+            return False
+
+        self._is_rw = self._client.granted_lock_type == GrantedLockType.RW
+
+        # GMS-backed VMM tensors can segfault if torch.cuda.empty_cache()
+        # tries to free them. Apply the upstream safety patch once we're
+        # connected. Idempotent and cheap.
+        try:
+            patch_empty_cache()
+        except Exception as e:
+            logger.debug("GMS patch_empty_cache failed (non-fatal): %s", e)
+
+        logger.info(
+            "Connected to GMS at %s (mode=%s, granted=%s, tag=%s)",
+            socket_path,
+            self._mode,
+            "RW" if self._is_rw else "RO",
+            self._tag,
+        )
+        return True
+
+    @property
+    def is_rw(self) -> Optional[bool]:
+        return self._is_rw
+
+    def has_committed_weights(self) -> bool:
+        """Whether the granted session is RO (i.e. committed weights exist)."""
+        if self._client is None:
+            return False
+        try:
+            from gpu_memory_service.common.locks import GrantedLockType
+
+            return self._client.granted_lock_type == GrantedLockType.RO
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------
+    # RW path: scope allocations into the GMS pool, then finalize
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def mem_pool_scope(
+        self,
+        device: Optional[torch.device] = None,
+    ) -> Iterator[None]:
+        """Context manager scoping CUDA allocations to the GMS pool.
+
+        All ``torch.empty``/``torch.zeros``/etc. allocations inside this
+        scope are routed through the GMS pluggable allocator and end up
+        in the shared memory region for the configured ``tag``.
+
+        Only valid when granted RW; raises otherwise.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+        if self._is_rw is False:
+            raise RuntimeError(
+                "GMS mem_pool_scope() is only valid in RW mode (this client was granted RO)."
+            )
+
+        from gpu_memory_service.client.torch.allocator import gms_use_mem_pool
+
+        target_device = device
+        if target_device is None:
+            target_device = torch.device("cuda", self._device_index)
+
+        with gms_use_mem_pool(self._tag, target_device):
+            yield
+
+    def move_untracked_params(self, model: nn.Module) -> None:
+        """Migrate parameters allocated outside the GMS pool into it.
+
+        Some parts of TRT-LLM's loading pipeline (e.g. ``post_load_weights``,
+        ``model.to("cuda")``) may allocate buffers outside the
+        ``mem_pool_scope`` context. ``finalize_write`` requires every
+        registered tensor to live in the GMS pool, so we copy any stray
+        CUDA params into freshly created GMS mappings of the same size.
+
+        Mirrors ``gpu_memory_service.integrations.trtllm.model_loader.
+        _move_untracked_params`` so behavior matches the upstream
+        reference integration.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+
+        # Align with the upstream API contract.
+        from gpu_memory_service.client.torch.module import _iter_module_tensors
+        from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+
+        gms_client = self._client
+        device_index = self._device_index
+        tracked_storage_ptrs: set[int] = set()
+
+        with torch.no_grad():
+            for _name, tensor, tensor_type in _iter_module_tensors(model):
+                if tensor_type != "parameter" or tensor is None or not tensor.is_cuda:
+                    continue
+
+                # GMS tracks whole storage allocations, so use the storage
+                # base pointer instead of a tensor view's offset pointer.
+                storage_base_ptr = tensor.untyped_storage().data_ptr()
+                if _ptr_in_gms(gms_client, int(storage_base_ptr)):
+                    continue
+                if storage_base_ptr in tracked_storage_ptrs:
+                    continue
+                tracked_storage_ptrs.add(storage_base_ptr)
+
+                nbytes = _storage_nbytes(tensor)
+                base_va = gms_client.create_mapping(size=nbytes, tag=self._tag)
+                replacement = _tensor_from_pointer(
+                    int(base_va),
+                    list(tensor.shape),
+                    list(tensor.stride()),
+                    tensor.dtype,
+                    device_index,
+                )
+                replacement.copy_(tensor)
+                tensor.data = replacement
+
+    def finalize_write(self, model: nn.Module) -> int:
+        """Register tensors, commit them, and transition this client to RO.
+
+        Returns the total number of bytes committed. After this returns
+        successfully, ``is_rw`` is ``False`` and other instances on the
+        same node connecting in ``"auto"`` or ``"ro"`` mode will receive
+        a zero-copy RO mapping of the committed layout.
+
+        Mirrors ``gpu_memory_service.integrations.common.utils.
+        finalize_gms_write``.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+        if self._is_rw is False:
+            raise RuntimeError("GMS finalize_write() is only valid in RW mode.")
+
+        from gpu_memory_service.integrations.common.utils import finalize_gms_write
+
+        bytes_committed = int(finalize_gms_write(self._client, model))
+        # finalize_gms_write internally commits and reconnects in RO mode,
+        # so we mirror that state transition here.
+        self._is_rw = False
+        logger.info(
+            "GMS RW->RO: committed %.2f GiB at %s (tag=%s)",
+            bytes_committed / (1 << 30),
+            self._socket_path,
+            self._tag,
+        )
+        return bytes_committed
+
+    # ------------------------------------------------------------------
+    # RO path: zero-copy import committed weights into model params
+    # ------------------------------------------------------------------
+
+    def materialize_module(self, model: nn.Module) -> None:
+        """Zero-copy import committed weights into model params.
+
+        Replaces meta-initialized parameters with CUDA tensors backed by
+        GPU pointers from the shared memory region with no data copies.
+
+        **Important**: ``post_load_weights()`` must be called on the
+        model BEFORE this method, so that module aliases and derived
+        parameters are already in place at materialization time.
+        """
+        if self._client is None:
+            raise RuntimeError("GMS client not connected. Call connect() first.")
+
+        from gpu_memory_service.client.torch.module import materialize_module_from_gms
+
+        materialize_module_from_gms(self._client, model, device_index=self._device_index)
+
+        logger.info(
+            "GMS RO: materialized weights from %s (tag=%s, tp_rank=%d/%d, total_bytes=%.2f GiB)",
+            self._socket_path,
+            self._tag,
+            self._mapping.tp_rank,
+            self._mapping.tp_size,
+            int(self._client.total_bytes) / (1 << 30),
+        )
+
+    # ------------------------------------------------------------------
+    # Teardown
+    # ------------------------------------------------------------------
+
+    def cleanup(self) -> None:
+        """Release the GMS session and evict it from the per-tag registry."""
+        if self._client is None:
+            return
+        try:
+            from gpu_memory_service.client.torch.allocator import evict_gms_client_memory_manager
+
+            client = self._client
+            try:
+                client.close()
+            except Exception as e:
+                # Best-effort: even if close() fails, evict so a future
+                # connect() in the same process can re-establish state.
+                # Log at debug so unrelated shutdown noise doesn't drown
+                # out the warning we already emit for the outer try.
+                logger.debug("GMS client.close() failed (best-effort): %s", e)
+            evict_gms_client_memory_manager(client)
+            logger.info("GMS: disconnected from %s", self._socket_path)
+        except Exception as e:
+            logger.warning("GMS cleanup error: %s", e)
+        finally:
+            self._client = None
+
+
+def _ptr_in_gms(gms_client, ptr: int) -> bool:
+    """Whether a raw CUDA pointer falls inside an existing GMS mapping.
+
+    Mirrors ``gpu_memory_service.integrations.trtllm.model_loader._ptr_in_gms``.
+    Tolerates absence of the ``_mappings`` attribute on older GMS releases.
+    """
+    mappings = getattr(gms_client, "_mappings", None)
+    if not mappings:
+        return False
+    for mapping in mappings.values():
+        base = int(getattr(mapping, "va", 0))
+        size = int(getattr(mapping, "size", 0))
+        if base and size and base <= ptr < base + size:
+            return True
+    return False
+
+
+def _storage_nbytes(tensor: torch.Tensor) -> int:
+    """Bytes owned by ``tensor``'s underlying storage, including any padding."""
+    storage = tensor.untyped_storage()
+    return int(storage.nbytes())

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -207,9 +207,19 @@ class GMSBackend:
 
         self._is_rw = self._client.granted_lock_type == GrantedLockType.RW
 
-        # GMS-backed VMM tensors can segfault if torch.cuda.empty_cache()
-        # tries to free them. Apply the upstream safety patch once we're
-        # connected. Idempotent and cheap.
+        # Process-wide safety patch: torch.cuda.empty_cache() can segfault
+        # when it tries to free GMS-backed VMM regions. Upstream's
+        # patch_empty_cache() rebinds torch.cuda.empty_cache to a GMS-aware
+        # variant that skips those regions.
+        #
+        # Process-wide is intentional, not a leak: torch internals, MoE
+        # balancer, draft-model setup, and unrelated TRT-LLM call sites all
+        # invoke empty_cache and would crash otherwise. A per-call-site
+        # wrapper would miss the calls we don't own.
+        #
+        # TODO(GMS-API): replace with a TRT-LLM-owned implementation once
+        # upstream's API stabilizes (see TODO on move_untracked_params).
+        # Idempotent and cheap.
         try:
             patch_empty_cache()
         except Exception as e:
@@ -226,10 +236,31 @@ class GMSBackend:
 
     @property
     def is_rw(self) -> Optional[bool]:
+        """Whether this client holds the writer lock for the GMS pool.
+
+        Returns:
+            ``True`` if RW (writer) was granted, ``False`` if RO (reader)
+            was granted, ``None`` before :meth:`connect` has been called
+            successfully or after :meth:`cleanup` has run. Transitions
+            from ``True`` to ``False`` after :meth:`finalize_write`.
+        """
         return self._is_rw
 
     def has_committed_weights(self) -> bool:
-        """Whether the granted session is RO (i.e. committed weights exist)."""
+        """Whether committed weights are available for RO materialization.
+
+        Reports the granted lock type at the time of call, which only
+        becomes ``RO`` once a writer in this or another process has
+        published a finalized layout for ``tag``.
+
+        Returns:
+            ``True`` if the granted lock is ``RO`` (committed weights
+            exist and can be zero-copy mapped); ``False`` otherwise,
+            including pre-connect, post-cleanup, and any error paths.
+            Never raises — best-effort by design so callers can use it
+            as a precondition check before invoking
+            :meth:`materialize_module`.
+        """
         if self._client is None:
             return False
         try:
@@ -250,11 +281,25 @@ class GMSBackend:
     ) -> Iterator[None]:
         """Context manager scoping CUDA allocations to the GMS pool.
 
-        All ``torch.empty``/``torch.zeros``/etc. allocations inside this
-        scope are routed through the GMS pluggable allocator and end up
-        in the shared memory region for the configured ``tag``.
+        All ``torch.empty`` / ``torch.zeros`` / etc. allocations inside
+        this scope are routed through the GMS pluggable allocator and
+        land in the shared memory region for the configured ``tag``.
+        Allocations made via paths that bypass the active allocator
+        (e.g. C++ ops that call ``cudaMalloc`` directly) escape this
+        scope and must be swept by :meth:`move_untracked_params`
+        before :meth:`finalize_write` is called.
 
-        Only valid when granted RW; raises otherwise.
+        Args:
+            device: Target CUDA device. Defaults to
+                ``torch.device('cuda', current_device())``.
+
+        Yields:
+            ``None`` — the value is unused; this is a scoping context.
+
+        Raises:
+            RuntimeError: If ``connect()`` has not been called yet, or
+                if the granted lock is RO (only the writer may allocate
+                into the pool).
         """
         if self._client is None:
             raise RuntimeError("GMS client not connected. Call connect() first.")
@@ -284,11 +329,19 @@ class GMSBackend:
         Mirrors ``gpu_memory_service.integrations.trtllm.model_loader.
         _move_untracked_params`` so behavior matches the upstream
         reference integration.
+
+        Args:
+            model: The ``nn.Module`` to scan for stray CUDA parameters.
+                Buffers (``tensor_type != 'parameter'``), CPU tensors,
+                and tensors already backed by a GMS mapping are skipped.
+
+        Raises:
+            RuntimeError: If ``connect()`` has not been called yet.
         """
+        # TODO(GMS-API): Clean up once the stable GMS API becomes available.
         if self._client is None:
             raise RuntimeError("GMS client not connected. Call connect() first.")
 
-        # Align with the upstream API contract.
         from gpu_memory_service.client.torch.module import _iter_module_tensors
         from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
 
@@ -325,13 +378,28 @@ class GMSBackend:
     def finalize_write(self, model: nn.Module) -> int:
         """Register tensors, commit them, and transition this client to RO.
 
-        Returns the total number of bytes committed. After this returns
-        successfully, ``is_rw`` is ``False`` and other instances on the
-        same node connecting in ``"auto"`` or ``"ro"`` mode will receive
-        a zero-copy RO mapping of the committed layout.
+        After this returns successfully, ``is_rw`` flips to ``False``
+        and other instances on the same node connecting in ``"auto"``
+        or ``"ro"`` mode will receive a zero-copy RO mapping of the
+        committed layout. The transition is in-place: this client
+        keeps the same socket connection.
 
         Mirrors ``gpu_memory_service.integrations.common.utils.
         finalize_gms_write``.
+
+        Args:
+            model: The fully-loaded ``nn.Module`` whose CUDA parameters
+                will be registered with the GMS daemon. Every parameter
+                must already live in the GMS pool — call
+                :meth:`move_untracked_params` first to sweep strays
+                allocated outside :meth:`mem_pool_scope`.
+
+        Returns:
+            Total bytes committed to the GMS pool for this ``tag``.
+
+        Raises:
+            RuntimeError: If ``connect()`` has not been called yet, or
+                if the granted lock is RO (only the writer may commit).
         """
         if self._client is None:
             raise RuntimeError("GMS client not connected. Call connect() first.")
@@ -357,14 +425,29 @@ class GMSBackend:
     # ------------------------------------------------------------------
 
     def materialize_module(self, model: nn.Module) -> None:
-        """Zero-copy import committed weights into model params.
+        """Zero-copy import committed weights into model params (RO path).
 
-        Replaces meta-initialized parameters with CUDA tensors backed by
-        GPU pointers from the shared memory region with no data copies.
+        Replaces meta-initialized parameters with CUDA tensors backed
+        by GPU pointers from the shared memory region — no data copies,
+        no disk I/O, just CUDA VMM remapping. The model's submodule
+        layout must already match the writer's at commit time, including
+        any aliases / derived buffers introduced by ``post_load_weights``.
 
-        **Important**: ``post_load_weights()`` must be called on the
-        model BEFORE this method, so that module aliases and derived
-        parameters are already in place at materialization time.
+        Args:
+            model: The ``nn.Module`` to materialize. Walks the full
+                module tree (including submodules like ``draft_model``
+                added for speculative decoding) and rebinds matching
+                parameters to GMS-backed storage.
+
+        Raises:
+            RuntimeError: If ``connect()`` has not been called yet.
+
+        Note:
+            ``post_load_weights()`` must be called on the model BEFORE
+            this method. The order ensures that any aliases / derived
+            parameters created by post-load hooks are present on the
+            module tree at materialization time, so they are bound to
+            the same GMS storage as their primary tensor.
         """
         if self._client is None:
             raise RuntimeError("GMS client not connected. Call connect() first.")
@@ -387,7 +470,23 @@ class GMSBackend:
     # ------------------------------------------------------------------
 
     def cleanup(self) -> None:
-        """Release the GMS session and evict it from the per-tag registry."""
+        """Release the GMS session and evict it from the per-tag registry.
+
+        Idempotent: a second call after a successful cleanup is a no-op
+        because the client handle is dropped. Best-effort: any failure
+        in upstream ``client.close()`` or ``evict_gms_client_memory_manager``
+        is logged (warning for the outer error, debug for ``close()``)
+        and swallowed so callers — including ``__del__`` paths in
+        ``ModelLoader`` and ``PyTorchModelEngine`` — never raise from
+        teardown.
+
+        After return:
+            - The local client handle is unset (``_client is None``).
+            - A subsequent :meth:`connect` may re-establish a fresh
+              session against the same daemon.
+            - GMS-backed CUDA mappings remain alive on-device for any
+              other process holding an RO lock on this ``tag``.
+        """
         if self._client is None:
             return
         try:
@@ -414,7 +513,18 @@ def _ptr_in_gms(gms_client, ptr: int) -> bool:
     """Whether a raw CUDA pointer falls inside an existing GMS mapping.
 
     Mirrors ``gpu_memory_service.integrations.trtllm.model_loader._ptr_in_gms``.
-    Tolerates absence of the ``_mappings`` attribute on older GMS releases.
+    Tolerates absence of the ``_mappings`` attribute on older GMS
+    releases by returning ``False`` (treating the pointer as "untracked"
+    so the caller's stray-handling path runs).
+
+    Args:
+        gms_client: A connected ``GMSClientMemoryManager``.
+        ptr: A raw CUDA virtual address (``tensor.data_ptr()`` or a
+            storage base pointer).
+
+    Returns:
+        ``True`` if ``ptr`` lies inside any mapping the client tracks
+        for any tag, ``False`` otherwise. Never raises.
     """
     mappings = getattr(gms_client, "_mappings", None)
     if not mappings:
@@ -428,6 +538,18 @@ def _ptr_in_gms(gms_client, ptr: int) -> bool:
 
 
 def _storage_nbytes(tensor: torch.Tensor) -> int:
-    """Bytes owned by ``tensor``'s underlying storage, including any padding."""
+    """Bytes owned by ``tensor``'s underlying storage, including any padding.
+
+    Used to size GMS mappings created in :meth:`GMSBackend.move_untracked_params`
+    so the replacement allocation matches the original storage exactly,
+    not the (possibly smaller) view the tensor exposes.
+
+    Args:
+        tensor: Any CUDA ``torch.Tensor``. View-vs-base distinction is
+            intentional: we always want the whole storage size.
+
+    Returns:
+        Total bytes of the underlying ``UntypedStorage``.
+    """
     storage = tensor.untyped_storage()
     return int(storage.nbytes())

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -149,18 +149,13 @@ class MXCheckpointLoader(HfCheckpointLoader):
     def query_timeout_s(self) -> Optional[int]:
         return self._query_timeout_s
 
-    @property
-    def p2p_succeeded(self) -> bool:
-        """Whether the last load_weights() call used P2P transfer.
-
-        ``True`` means weights are already in model parameter buffers
-        and the standard weight-mapping pipeline should be skipped
-        for those parameters.
-        """
-        return self._p2p_succeeded
-
     def is_weights_preloaded(self) -> bool:
-        """Whether the last MX load wrote weights directly into the model."""
+        """Whether the last load_weights() call wired weights directly into the model.
+
+        ``True`` means MX P2P transfer succeeded, weights are already in model
+        parameter buffers, and the standard weight-mapping pipeline should be
+        skipped for those parameters.
+        """
         return self._p2p_succeeded
 
     def load_weights(self, checkpoint_dir: str, mapping: Mapping, **kwargs) -> dict[str, Any]:
@@ -404,7 +399,20 @@ class MXCheckpointLoader(HfCheckpointLoader):
     def post_load_publish(
         self, model, *, checkpoint_dir: str, weights_preloaded: bool = False
     ) -> None:
-        """Publish only workers that loaded locally, not MX P2P receivers."""
+        """Publish locally loaded weights as an MX source when appropriate.
+
+        Args:
+            model: The loaded model whose parameters should be published for
+                future MX P2P receivers.
+            checkpoint_dir: Checkpoint directory used as a fallback model
+                identity when no explicit MX model name is configured.
+            weights_preloaded: Whether this worker already received weights
+                through MX P2P. When true, this worker is an MX receiver and
+                should not republish the same weights as a source.
+
+        Returns:
+            None.
+        """
         if weights_preloaded:
             return
         self.publish_as_source(model, checkpoint_dir=checkpoint_dir)

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -150,11 +150,29 @@ class MXCheckpointLoader(HfCheckpointLoader):
         return self._query_timeout_s
 
     def is_weights_preloaded(self) -> bool:
-        """Whether the last load_weights() call wired weights directly into the model.
+        """Whether the last :meth:`load_weights` call wired weights directly into the model.
 
-        ``True`` means MX P2P transfer succeeded, weights are already in model
-        parameter buffers, and the standard weight-mapping pipeline should be
-        skipped for those parameters.
+        Reports the result of the most recent ``load_weights()`` invocation
+        on this loader instance. ``ModelLoader`` consults this signal to
+        decide whether to run the standard weight-mapping pipeline:
+
+        - ``True``: MX P2P transfer succeeded; weights already live in
+          model parameter buffers via direct writes from the upstream
+          ``MxLiveWeightLoader``. The mapping pipeline is skipped for
+          all parameters covered by P2P.
+        - ``False``: either P2P was never attempted (no MX server URL,
+          no model reference, library missing) or it failed and we
+          fell back to disk; weights still need to flow through
+          ``model.load_weights(...)`` via the standard mapper.
+
+        Note this is a per-loader-instance flag, not a global one. The
+        flag is reset to ``False`` at the start of each ``load_weights``
+        call, so the value is only meaningful immediately after a
+        successful call.
+
+        Returns:
+            ``True`` iff the last ``load_weights`` populated the model
+            via P2P; ``False`` before any call and on any fallback path.
         """
         return self._p2p_succeeded
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1501,17 +1501,58 @@ class PyTorchModelEngine(ModelEngine):
             max_seq_len=self.max_seq_len)
         return self.spec_metadata
 
-    def __del__(self) -> None:
+    def cleanup(self) -> None:
+        """Release resources owned by this model engine."""
+        if getattr(self, "_cleanup_done", False):
+            return
+
+        # Cleanup is not truly atomic: released CUDA/GMS resources cannot be
+        # rolled back.  Keep each handle live until its own release succeeds,
+        # so a failed cleanup can be retried without double-freeing resources
+        # that were already released.
+        model_loader = getattr(self, "model_loader", None)
+        if model_loader is not None:
+            model_loader.cleanup()
+            self.model_loader = None
+
         self.model = None
-        self.model_loader = None
+
         self._release_cuda_graphs()
         self.input_processor = None
         self.input_processor_with_hash = None
-        if getattr(self, 'ub_buffers', None):
-            for u in self.ub_buffers:
-                ub.ub_deallocate(u.addr)
+
+        ub_buffers = getattr(self, 'ub_buffers', None)
+        if ub_buffers:
+            remaining_ub_buffers = []
+            ub_errors = []
+            for u in ub_buffers:
+                try:
+                    ub.ub_deallocate(u.addr)
+                except RuntimeError as e:
+                    # Keep failed buffers attached so a deterministic
+                    # cleanup() call can retry without double-freeing buffers
+                    # that were already deallocated successfully.
+                    remaining_ub_buffers.append(u)
+                    ub_errors.append(e)
+            self.ub_buffers = remaining_ub_buffers or None
+            if ub_errors:
+                raise RuntimeError(
+                    "Failed to deallocate one or more userbuffers during "
+                    "PyTorchModelEngine cleanup") from ub_errors[0]
+
         # Release model weights.
         release_gc()
+        self._cleanup_done = True
+
+    def __del__(self) -> None:
+        try:
+            self.cleanup()
+        except (RuntimeError, AttributeError) as e:
+            # Destructors run during interpreter shutdown and cannot reliably
+            # surface errors. Log best-effort so process-lifetime leaks are
+            # visible; deterministic callers should use cleanup().
+            logger.warning(
+                "PyTorchModelEngine cleanup failed during destruction: %s", e)
 
     def _init_max_seq_len(self):
         # Allow user to override the inferred max_seq_len with a warning.

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1502,7 +1502,36 @@ class PyTorchModelEngine(ModelEngine):
         return self.spec_metadata
 
     def cleanup(self) -> None:
-        """Release resources owned by this model engine."""
+        """Release resources owned by this model engine.
+
+        Tears down, in order:
+
+        1. The optional ``ModelLoader`` (which in turn releases any
+           GMS client; see :meth:`ModelLoader.cleanup`).
+        2. The model module reference.
+        3. CUDA Graph captures (via :meth:`_release_cuda_graphs`).
+        4. Input processors.
+        5. Userbuffers (``ub.ub_deallocate`` per buffer); on per-buffer
+           failure the unfreed buffers are kept attached so a deterministic
+           retry doesn't double-free already-released ones, and the
+           collected errors are re-raised after the loop.
+
+        Idempotency:
+            Subsequent calls are no-ops (guarded by ``_cleanup_done``).
+            The flag is set only at the end, so a partial cleanup that
+            raises mid-way will be retried on the next call.
+
+        Raises:
+            RuntimeError: If one or more userbuffer deallocations fail
+                (chained from the first error). All other steps are
+                best-effort and either succeed or leak silently with
+                their errors logged at warning level by callees.
+
+        Called from:
+            - :meth:`PyExecutor.shutdown` (deterministic teardown).
+            - :meth:`__del__` (best-effort fallback during garbage
+              collection / interpreter shutdown).
+        """
         if getattr(self, "_cleanup_done", False):
             return
 
@@ -1545,12 +1574,21 @@ class PyTorchModelEngine(ModelEngine):
         self._cleanup_done = True
 
     def __del__(self) -> None:
+        """Best-effort cleanup during garbage collection.
+
+        Delegates to :meth:`cleanup`. Catches ``RuntimeError`` (raised
+        when one or more userbuffer deallocations fail) and
+        ``AttributeError`` (typical on partially-initialized engines
+        torn down during interpreter shutdown when module references
+        have already been cleared); both are logged and swallowed
+        because destructors cannot reliably surface exceptions.
+
+        Deterministic callers (``PyExecutor.shutdown``) should call
+        :meth:`cleanup` directly so they see any failure.
+        """
         try:
             self.cleanup()
         except (RuntimeError, AttributeError) as e:
-            # Destructors run during interpreter shutdown and cannot reliably
-            # surface errors. Log best-effort so process-lifetime leaks are
-            # visible; deterministic callers should use cleanup().
             logger.warning(
                 "PyTorchModelEngine cleanup failed during destruction: %s", e)
 

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -421,7 +421,13 @@ class ModelLoader:
                 f"Use {rank_model_storage / (1024**3):.2f} GB for model weights."
             )
             weights_preloaded = False
-            gms_ro_materialized = False
+            # Set when either GMS RW or GMS RO branch has already run the
+            # post_load_* hooks itself, so the shared post-load block below
+            # must skip them. RW handles them inside ``mem_pool_scope`` so the
+            # committed pool reflects the post-post_load layout; RO runs
+            # ``module.post_load_weights()`` before ``materialize_module`` to
+            # wire aliases prior to zero-copy mapping.
+            gms_post_load_handled = False
             if load_format == LoadFormat.AUTO:
                 # Pass model= so format-specific loaders (e.g. MX) can
                 # write weights directly into parameter buffers via P2P.
@@ -470,9 +476,11 @@ class ModelLoader:
                 # GPU Memory Service path: weight tensors live in a
                 # node-shared GPU memory pool so multiple TRT-LLM instances
                 # zero-copy share the same weight bytes. Two roles:
-                #   - RW (writer): allocates weights into the pool via
-                #     ``mem_pool_scope`` and commits the populated pool via
-                #     ``finalize_write`` so RO peers can map it.
+                #   - RW (writer): opens ``mem_pool_scope`` BEFORE meta-
+                #     materialization and to(cuda), runs the entire model
+                #     bring-up (load + draft load + post_load_*) inside the
+                #     pool, then commits via ``finalize_write`` so RO peers
+                #     receive the post-post_load layout.
                 #   - RO (reader): zero-copy materializes weights from the
                 #     pool into the model via ``materialize_module``; no
                 #     disk I/O, no per-instance copies.
@@ -501,9 +509,35 @@ class ModelLoader:
                     # surfaces as a hard error rather than silently falling
                     # through to the RO path.
                     if gms_backend.is_rw is True:
-                        # RW path: load weights normally while GMS owns CUDA
-                        # allocations, then commit the resulting model for RO users.
+                        # RW path: open the GMS pool BEFORE meta-tensor
+                        # materialization and to(cuda), so every CUDA
+                        # allocation needed to bring the model up — meta
+                        # materialization, to(cuda), checkpoint load, draft
+                        # load, post_load hooks — lands in the GMS pool. After
+                        # the pool is closed, finalize_write commits the
+                        # post-post_load layout for RO peers to map zero-copy.
+                        # Mirrors the upstream Dynamo TRT-LLM shim pattern.
                         with gms_backend.mem_pool_scope(torch.device("cuda")):
+                            # Materialize meta tensors inside the pool. Local
+                            # memo because the outer one was deleted (and the
+                            # outer ``init_meta_tensor`` branch is gated off
+                            # for GMS so it never ran).
+                            if is_meta_init:
+                                gms_memo: dict = {}
+
+                                def init_meta_tensor_in_pool(t: torch.Tensor):
+                                    if t.device != torch.device('meta'):
+                                        return t
+                                    if t not in gms_memo:
+                                        gms_memo[t] = torch.empty_like(
+                                            t, device='cuda')
+                                    return gms_memo[t]
+
+                                model._apply(init_meta_tensor_in_pool)
+
+                            # Catch-all for any tensors not on CUDA yet.
+                            model.to("cuda")
+
                             weight_source = (model.llm_checkpoint_dir
                                              if hasattr(model,
                                                         'llm_checkpoint_dir')
@@ -523,13 +557,15 @@ class ModelLoader:
                             #     partial loads (missing keys in a non-empty
                             #     dict) are caught downstream by
                             #     ``model.load_weights`` strict checking.
+                            weights_preloaded = checkpoint_loader.is_weights_preloaded(
+                            )
                             if weights:
                                 self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
                                     model, config)
                                 self._call_load_weights(model.load_weights,
                                                         weights,
                                                         self.weight_mapper)
-                            elif not checkpoint_loader.is_weights_preloaded():
+                            elif not weights_preloaded:
                                 raise RuntimeError(
                                     f"GMS RW: checkpoint loader "
                                     f"'{checkpoint_loader.checkpoint_format}' "
@@ -556,10 +592,42 @@ class ModelLoader:
                                     model.load_draft_weights, draft_weights,
                                     draft_weight_mapper)
 
+                            # Run post_load hooks INSIDE the pool so any
+                            # tensors they create or rebind (fused QKV,
+                            # quantization scales, derived aliases) land in
+                            # GMS and become part of the committed layout
+                            # that RO peers receive. Closes hhzhang16's
+                            # narrow-scope and commit-ordering concerns.
+                            checkpoint_loader.post_load_apply(
+                                model, weights_preloaded=weights_preloaded)
+                            checkpoint_loader.post_load_publish(
+                                model,
+                                checkpoint_dir=checkpoint_dir,
+                                weights_preloaded=weights_preloaded)
+
+                            for module in model.modules():
+                                if hasattr(
+                                        module,
+                                        'post_load_weights') and not getattr(
+                                            module, '_weights_removed', False):
+                                    module.post_load_weights()
+
+                            # Defensive last-mile sweep: catches strays from
+                            # C++ ops that bypassed the active torch
+                            # allocator (e.g. native cudaMalloc).
                             gms_backend.move_untracked_params(model)
+                            # Safe with active GMS mappings: GMSBackend.connect()
+                            # installed upstream's patch_empty_cache(), which makes
+                            # torch.cuda.empty_cache() skip GMS-backed VMM regions.
+                            # Frees the non-GMS originals dropped by
+                            # move_untracked_params (tensor.data was rebound to
+                            # GMS-backed replacements above) before commit so the
+                            # cached size doesn't show as live in memory accounting.
                             torch.cuda.empty_cache()
 
+                        # Pool closed. Commit the post-post_load layout.
                         gms_backend.finalize_write(model)
+                        gms_post_load_handled = True
                         logger.info(
                             "LoadFormat.GMS (RW): loaded and committed weights via %s",
                             checkpoint_loader.checkpoint_format)
@@ -578,7 +646,7 @@ class ModelLoader:
                                 module.post_load_weights()
 
                         gms_backend.materialize_module(model)
-                        gms_ro_materialized = True
+                        gms_post_load_handled = True
                         logger.info("LoadFormat.GMS (RO): materialized weights")
                     else:
                         raise RuntimeError(
@@ -609,7 +677,7 @@ class ModelLoader:
                 raise NotImplementedError(
                     f"No load support for load format: {load_format}")
 
-            if not gms_ro_materialized:
+            if not gms_post_load_handled:
                 checkpoint_loader.post_load_apply(
                     model, weights_preloaded=weights_preloaded)
                 checkpoint_loader.post_load_publish(
@@ -622,6 +690,13 @@ class ModelLoader:
                             module, '_weights_removed', False):
                         module.post_load_weights()
 
+            # TODO(GMS-MOE-LB): the MoE load balancer's
+            # ``register_weight_slots_after_to_cuda`` and ``finalize_model``
+            # run AFTER the GMS RW pool was closed and finalize_write
+            # committed. Any CUDA allocations they make therefore land in
+            # non-GMS memory and are NOT part of the committed layout that
+            # RO peers receive. Out of scope for the GMS-only PR (no MoE
+            # coverage today); fix as part of (MoE, GMS) follow-up.
             if isinstance(moe_load_balancer, MoeLoadBalancer):
                 moe_load_balancer.register_weight_slots_after_to_cuda()
                 logger.info("moe_load_balancer finalizing model...")
@@ -648,7 +723,21 @@ class ModelLoader:
         torch.cuda.current_stream().synchronize()
 
     def cleanup(self) -> None:
-        """Release resources acquired during load."""
+        """Release backend resources acquired during :meth:`load`.
+
+        Currently the only backend held by ``ModelLoader`` is the
+        optional GMS client, established by the ``LoadFormat.GMS``
+        branch. Releasing it disconnects from the GMS daemon and evicts
+        the per-tag client registry entry; weights remain alive
+        on-device for any other process holding an RO lock on the same
+        ``tag``.
+
+        Idempotent: a second call after a successful cleanup is a no-op
+        because the backend handle is dropped. Best-effort: any failure
+        in the underlying ``GMSBackend.cleanup()`` is swallowed there
+        and logged, so this method never raises — safe to call from
+        :meth:`PyTorchModelEngine.cleanup` and ``__del__`` paths.
+        """
         if self._gms_backend is not None:
             self._gms_backend.cleanup()
             self._gms_backend = None

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -542,8 +542,17 @@ class ModelLoader:
                                              if hasattr(model,
                                                         'llm_checkpoint_dir')
                                              else checkpoint_dir)
+                            # Pass model= for symmetry with the LoadFormat.AUTO
+                            # primary load above. Generic loaders (HF) ignore
+                            # this kwarg; loaders that consume a live module
+                            # reference (MX) use it for direct P2P writes into
+                            # parameter buffers. Keeping the call shape
+                            # consistent here avoids forgetting it when MX+GMS
+                            # composition lands later.
                             weights = checkpoint_loader.load_weights(
-                                weight_source, mapping=self.mapping)
+                                weight_source,
+                                mapping=self.mapping,
+                                model=model)
 
                             # ``weights`` may be:
                             #   - non-empty dict: standard mapping pipeline runs
@@ -632,13 +641,30 @@ class ModelLoader:
                             "LoadFormat.GMS (RW): loaded and committed weights via %s",
                             checkpoint_loader.checkpoint_format)
                     elif gms_backend.is_rw is False:
-                        # RO path: run post-load hooks first because GMS
-                        # materializes by walking the final module tree. The
-                        # hook order creates any aliases/derived parameter
-                        # attributes before the zero-copy GMS tensors replace
-                        # the meta tensors across the whole model tree
-                        # (including draft_model when speculative decoding is
-                        # present).
+                        # RO path: weights are coming from a GMS donor that
+                        # has already committed the post-post_load layout, so
+                        # the receiver flags ``weights_preloaded=True`` on the
+                        # checkpoint-loader hooks. ``MXCheckpointLoader.post_load_publish``
+                        # (and any other format-aware loader) honors this flag
+                        # to early-return and not re-publish, while still
+                        # letting ``post_load_apply`` perform any
+                        # receiver-side per-format work (e.g., marking
+                        # presharded modules).
+                        #
+                        # Hook order:
+                        #   1. ``post_load_apply``: format-specific apply
+                        #      work (e.g., MX preshard markers).
+                        #   2. Per-module ``post_load_weights``: creates
+                        #      aliases/derived parameter attributes BEFORE
+                        #      ``materialize_module`` walks the final module
+                        #      tree (including ``draft_model`` for spec dec).
+                        #   3. ``materialize_module``: zero-copy bind GMS
+                        #      pool storage onto the model parameters.
+                        #   4. ``post_load_publish``: any receiver-side
+                        #      publish (no-op via the receiver guard).
+                        checkpoint_loader.post_load_apply(
+                            model, weights_preloaded=True)
+
                         for module in model.modules():
                             if hasattr(module,
                                        'post_load_weights') and not getattr(
@@ -646,6 +672,11 @@ class ModelLoader:
                                 module.post_load_weights()
 
                         gms_backend.materialize_module(model)
+
+                        checkpoint_loader.post_load_publish(
+                            model,
+                            checkpoint_dir=checkpoint_dir,
+                            weights_preloaded=True)
                         gms_post_load_handled = True
                         logger.info("LoadFormat.GMS (RO): materialized weights")
                     else:
@@ -690,13 +721,17 @@ class ModelLoader:
                             module, '_weights_removed', False):
                         module.post_load_weights()
 
-            # TODO(GMS-MOE-LB): the MoE load balancer's
+            # TODO(GMS-MOE-LB): when the (MoE, GMS) combination is enabled,
             # ``register_weight_slots_after_to_cuda`` and ``finalize_model``
-            # run AFTER the GMS RW pool was closed and finalize_write
-            # committed. Any CUDA allocations they make therefore land in
-            # non-GMS memory and are NOT part of the committed layout that
-            # RO peers receive. Out of scope for the GMS-only PR (no MoE
-            # coverage today); fix as part of (MoE, GMS) follow-up.
+            # must run INSIDE ``mem_pool_scope`` and BEFORE ``finalize_write``
+            # so MoE allocations become part of the committed layout that
+            # RO peers receive. Today they run outside the pool and after
+            # commit, which would silently produce a broken MoE routing
+            # state on RO peers — that combination is REJECTED at config
+            # time by ``TorchLlmArgs.validate_gms_moe_compat`` in
+            # ``tensorrt_llm/llmapi/llm_args.py``. When implementing the
+            # follow-up, drop the validator gate AFTER moving these calls
+            # into the pool scope.
             if isinstance(moe_load_balancer, MoeLoadBalancer):
                 moe_load_balancer.register_weight_slots_after_to_cuda()
                 logger.info("moe_load_balancer finalizing model...")

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -275,7 +275,9 @@ class ModelLoader:
         self.lora_config = lora_config
         self.model_weights_memory_tag = model_weights_memory_tag
         self.model_weights_restore_mode = model_weights_restore_mode
+        self.weight_mapper = None
         self._weight_pool_proxy = None
+        self._gms_backend = None
 
     @staticmethod
     def load_config_and_apply_defaults(
@@ -348,7 +350,8 @@ class ModelLoader:
 
             memo = dict()
 
-            if self.model_weights_memory_tag is not None:
+            if (self.model_weights_memory_tag is not None
+                    and load_format != LoadFormat.GMS):
                 # Allocate buffers to the outer virtual_memory_scope,
                 # but parameters (weights) to the dedicated inner virtual_memory_scope.
 
@@ -395,7 +398,7 @@ class ModelLoader:
                         self.model_weights_restore_mode) as pool:
                     model._apply(allocate_weights_on_cuda)
                 self._weight_pool_proxy = pool
-            elif is_meta_init:
+            elif is_meta_init and load_format != LoadFormat.GMS:
 
                 def init_meta_tensor(t: torch.Tensor):
                     if t.device != torch.device('meta'):
@@ -409,7 +412,8 @@ class ModelLoader:
 
             # Ensure everything is at least on CUDA
             # No-op if worked as expected
-            model.to("cuda")
+            if load_format != LoadFormat.GMS:
+                model.to("cuda")
             del memo
 
             rank_model_storage = get_rank_model_storage(model)
@@ -417,6 +421,7 @@ class ModelLoader:
                 f"Use {rank_model_storage / (1024**3):.2f} GB for model weights."
             )
             weights_preloaded = False
+            gms_ro_materialized = False
             if load_format == LoadFormat.AUTO:
                 # Pass model= so format-specific loaders (e.g. MX) can
                 # write weights directly into parameter buffers via P2P.
@@ -461,6 +466,131 @@ class ModelLoader:
                     self._call_load_weights(model.load_draft_weights, weights,
                                             draft_weight_mapper)
 
+            elif load_format == LoadFormat.GMS:
+                # GPU Memory Service path: weight tensors live in a
+                # node-shared GPU memory pool so multiple TRT-LLM instances
+                # zero-copy share the same weight bytes. Two roles:
+                #   - RW (writer): allocates weights into the pool via
+                #     ``mem_pool_scope`` and commits the populated pool via
+                #     ``finalize_write`` so RO peers can map it.
+                #   - RO (reader): zero-copy materializes weights from the
+                #     pool into the model via ``materialize_module``; no
+                #     disk I/O, no per-instance copies.
+                # Imported lazily so the optional ``gpu_memory_service``
+                # dependency only loads when GMS is actually selected.
+                from tensorrt_llm._torch.memory import GMSBackend
+
+                gms_backend = GMSBackend(
+                    socket_path=self.llm_args.gms_config.socket_path,
+                    mapping=self.mapping,
+                    mode=self.llm_args.gms_config.mode,
+                    tag=self.llm_args.gms_config.tag,
+                )
+
+                if not gms_backend.connect():
+                    raise RuntimeError(
+                        "Failed to connect to GMS at "
+                        f"{self.llm_args.gms_config.socket_path}")
+
+                self._gms_backend = gms_backend
+                try:
+                    # ``is_rw`` is ``Optional[bool]`` on the GPU memory backend
+                    # protocol: True = RW lock granted, False = RO lock granted,
+                    # None = unset. After a successful ``connect()`` it must be
+                    # True or False; ``None`` is treated as an adapter bug and
+                    # surfaces as a hard error rather than silently falling
+                    # through to the RO path.
+                    if gms_backend.is_rw is True:
+                        # RW path: load weights normally while GMS owns CUDA
+                        # allocations, then commit the resulting model for RO users.
+                        with gms_backend.mem_pool_scope(torch.device("cuda")):
+                            weight_source = (model.llm_checkpoint_dir
+                                             if hasattr(model,
+                                                        'llm_checkpoint_dir')
+                                             else checkpoint_dir)
+                            weights = checkpoint_loader.load_weights(
+                                weight_source, mapping=self.mapping)
+
+                            # ``weights`` may be:
+                            #   - non-empty dict: standard mapping pipeline runs
+                            #   - empty/None + ``is_weights_preloaded()=True``:
+                            #     the loader populated the model directly
+                            #     (e.g. MX P2P), so no mapping is needed
+                            #   - empty/None + ``is_weights_preloaded()=False``:
+                            #     loader returned nothing AND didn't preload —
+                            #     the model would be committed in an
+                            #     uninitialized state, so abort. Per-tensor
+                            #     partial loads (missing keys in a non-empty
+                            #     dict) are caught downstream by
+                            #     ``model.load_weights`` strict checking.
+                            if weights:
+                                self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
+                                    model, config)
+                                self._call_load_weights(model.load_weights,
+                                                        weights,
+                                                        self.weight_mapper)
+                            elif not checkpoint_loader.is_weights_preloaded():
+                                raise RuntimeError(
+                                    f"GMS RW: checkpoint loader "
+                                    f"'{checkpoint_loader.checkpoint_format}' "
+                                    f"returned empty weights ({weights!r}) and "
+                                    "did not preload the model. Refusing to "
+                                    "commit an unpopulated model to the GMS "
+                                    "pool.")
+
+                            if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
+                            ):
+                                draft_weights = checkpoint_loader.load_weights(
+                                    self.spec_config.speculative_model,
+                                    mapping=self.mapping)
+
+                                draft_model_arch = model.draft_config.pretrained_config.architectures[
+                                    0]
+                                draft_weight_mapper = AutoCheckpointMapper.get(
+                                    checkpoint_loader.checkpoint_format,
+                                    draft_model_arch)
+                                draft_weight_mapper.init_model_and_config(
+                                    model.draft_model, model.draft_config)
+
+                                self._call_load_weights(
+                                    model.load_draft_weights, draft_weights,
+                                    draft_weight_mapper)
+
+                            gms_backend.move_untracked_params(model)
+                            torch.cuda.empty_cache()
+
+                        gms_backend.finalize_write(model)
+                        logger.info(
+                            "LoadFormat.GMS (RW): loaded and committed weights via %s",
+                            checkpoint_loader.checkpoint_format)
+                    elif gms_backend.is_rw is False:
+                        # RO path: run post-load hooks first because GMS
+                        # materializes by walking the final module tree. The
+                        # hook order creates any aliases/derived parameter
+                        # attributes before the zero-copy GMS tensors replace
+                        # the meta tensors across the whole model tree
+                        # (including draft_model when speculative decoding is
+                        # present).
+                        for module in model.modules():
+                            if hasattr(module,
+                                       'post_load_weights') and not getattr(
+                                           module, '_weights_removed', False):
+                                module.post_load_weights()
+
+                        gms_backend.materialize_module(model)
+                        gms_ro_materialized = True
+                        logger.info("LoadFormat.GMS (RO): materialized weights")
+                    else:
+                        raise RuntimeError(
+                            f"GMS backend connected but lock state is unset "
+                            f"(is_rw={gms_backend.is_rw!r}); expected True (RW) "
+                            "or False (RO). This indicates a bug in the GMS "
+                            "adapter or a protocol violation.")
+                except Exception:
+                    gms_backend.cleanup()
+                    self._gms_backend = None
+                    raise
+
             elif load_format == LoadFormat.DUMMY:
                 self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
                     model, config)
@@ -479,17 +609,18 @@ class ModelLoader:
                 raise NotImplementedError(
                     f"No load support for load format: {load_format}")
 
-            checkpoint_loader.post_load_apply(
-                model, weights_preloaded=weights_preloaded)
-            checkpoint_loader.post_load_publish(
-                model,
-                checkpoint_dir=checkpoint_dir,
-                weights_preloaded=weights_preloaded)
+            if not gms_ro_materialized:
+                checkpoint_loader.post_load_apply(
+                    model, weights_preloaded=weights_preloaded)
+                checkpoint_loader.post_load_publish(
+                    model,
+                    checkpoint_dir=checkpoint_dir,
+                    weights_preloaded=weights_preloaded)
 
-            for module in model.modules():
-                if hasattr(module, 'post_load_weights') and not getattr(
-                        module, '_weights_removed', False):
-                    module.post_load_weights()
+                for module in model.modules():
+                    if hasattr(module, 'post_load_weights') and not getattr(
+                            module, '_weights_removed', False):
+                        module.post_load_weights()
 
             if isinstance(moe_load_balancer, MoeLoadBalancer):
                 moe_load_balancer.register_weight_slots_after_to_cuda()
@@ -505,11 +636,22 @@ class ModelLoader:
                model: DecoderModelForCausalLM,
                weights: dict,
                allow_partial_loading: bool = False):
+        if self.weight_mapper is None:
+            raise RuntimeError(
+                "Cannot reload weights: weight_mapper was not initialized. "
+                "This can happen when the initial load used GMS, MX P2P, or "
+                "VISION_ONLY, which bypass the standard weight mapping path.")
         self._call_load_weights(model.load_weights,
                                 weights,
                                 self.weight_mapper,
                                 allow_partial_loading=allow_partial_loading)
         torch.cuda.current_stream().synchronize()
+
+    def cleanup(self) -> None:
+        """Release resources acquired during load."""
+        if self._gms_backend is not None:
+            self._gms_backend.cleanup()
+            self._gms_backend = None
 
     def _load_and_validate_config(
             self, checkpoint_dir: str,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -876,9 +876,16 @@ class PyExecutor:
         for manager in self.resource_manager.resource_managers.values():
             if manager:
                 manager.shutdown()
-        for engine in (self.model_engine, self.draft_model_engine):
-            if engine is not None and hasattr(engine, 'cleanup'):
-                engine.cleanup()
+        # Note: do NOT call engine.cleanup() here. PyExecutor.shutdown() is
+        # also invoked mid-init by configure_kv_cache_capacity() in
+        # tensorrt_llm/_torch/pyexecutor/_util.py — the warmup pass calls
+        # shutdown() and then immediately reads model_engine.model.model_config
+        # to compute kv_cache_max_memory. cleanup() would set
+        # model_engine.model = None, breaking that read with
+        # `'NoneType' object has no attribute 'model_config'`.
+        # The engine's __del__ still calls cleanup() at terminal teardown
+        # (when the executor's reference is dropped), which is sufficient for
+        # the GMS daemon registry eviction the cleanup hook was added for.
         del self.model_engine
         if self.draft_model_engine is not None:
             del self.draft_model_engine

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -876,6 +876,9 @@ class PyExecutor:
         for manager in self.resource_manager.resource_managers.values():
             if manager:
                 manager.shutdown()
+        for engine in (self.model_engine, self.draft_model_engine):
+            if engine is not None and hasattr(engine, 'cleanup'):
+                engine.cleanup()
         del self.model_engine
         if self.draft_model_engine is not None:
             del self.draft_model_engine

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -106,7 +106,8 @@ def Field(default: Any = ...,
 
 
 class CudaGraphConfig(StrictBaseModel):
-    """Configuration for CUDA graphs.
+    """
+    Configuration for CUDA graphs.
     """
     # List of batch sizes to create CUDA graphs for.
     batch_sizes: Optional[List[int]] = Field(
@@ -251,7 +252,8 @@ class GuidedDecodingConfig(StrictBaseModel):
 
 
 class BaseSparseAttentionConfig(StrictBaseModel):
-    """Configuration for sparse attention.
+    """
+    Configuration for sparse attention.
     """
     algorithm: str
 
@@ -280,7 +282,8 @@ class BaseSparseAttentionConfig(StrictBaseModel):
 
 
 class RocketSparseAttentionConfig(BaseSparseAttentionConfig):
-    """Configuration for RocketKV sparse attention.
+    """
+    Configuration for RocketKV sparse attention.
     """
     algorithm: Literal["rocket"] = "rocket"
     window_size: Optional[int] = Field(
@@ -306,7 +309,8 @@ class RocketSparseAttentionConfig(BaseSparseAttentionConfig):
 
 
 class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
-    """Configuration for DeepSeek Sparse Attention.
+    """
+    Configuration for DeepSeek Sparse Attention.
     """
     algorithm: Literal["dsa"] = "dsa"
     index_n_heads: Optional[int] = Field(
@@ -397,7 +401,8 @@ class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
 
 
 class SkipSoftmaxAttentionConfig(BaseSparseAttentionConfig):
-    """Configuration for skip softmax attention.
+    """
+    Configuration for skip softmax attention.
     """
     algorithm: Literal["skip_softmax"] = "skip_softmax"
     threshold_scale_factor: Optional[Union[float, Dict[str, float]]] = Field(
@@ -552,7 +557,8 @@ class MoeLoadBalancerConfig(StrictBaseModel):
 
     def get_layer_initial_global_assignments(
             self, layer_idx: int) -> Optional[List[int]]:
-        """Retrieves the initial global assignments for a specific layer.
+        """
+        Retrieves the initial global assignments for a specific layer.
         """
         if self.initial_global_assignments is None:
             return None
@@ -577,7 +583,8 @@ class MoeLoadBalancerConfig(StrictBaseModel):
 
 
 class MoeConfig(StrictBaseModel):
-    """Configuration for MoE.
+    """
+    Configuration for MoE.
     """
     backend: Literal[
         "AUTO", "CUTLASS", "CUTEDSL", "WIDEEP", "TRTLLM", "DEEPGEMM",
@@ -621,7 +628,8 @@ TOKENIZER_ALIASES = {
 
 
 class Nvfp4GemmConfig(StrictBaseModel):
-    """Configuration for NVFP4 GEMM backend selection.
+    """
+    Configuration for NVFP4 GEMM backend selection.
     """
     allowed_backends: List[Nvfp4Backend] = Field(
         default_factory=lambda: ['cutlass', 'cublaslt', 'cuda_core'],
@@ -633,7 +641,8 @@ class Nvfp4GemmConfig(StrictBaseModel):
 
 
 class AttentionDpConfig(StrictBaseModel):
-    """Configuration for attention DP.
+    """
+    Configuration for attention DP.
     """
     enable_balance: bool = Field(default=False,
                                  description="Whether to enable balance.")
@@ -693,7 +702,8 @@ class AttentionDpConfig(StrictBaseModel):
 
 
 class CpConfig(StrictBaseModel):
-    """Configuration for context parallelism.
+    """
+    Configuration for context parallelism.
     """
     # TODO: given that multiple fields here are only used with specific cp_types, consider
     # making this a Pydantic discriminated union.
@@ -800,7 +810,8 @@ class _ParallelConfig(StrictBaseModel):
 
 
 class CalibConfig(StrictBaseModel):
-    """Calibration configuration.
+    """
+    Calibration configuration.
     """
     device: Literal['cuda',
                     'cpu'] = Field(default='cuda',
@@ -1060,7 +1071,8 @@ class KvCacheConnectorConfig(StrictBaseModel):
 
 
 class LayerwiseBenchmarksConfig(StrictBaseModel):
-    """Configuration for layer-wise benchmarks calibration.
+    """
+    Configuration for layer-wise benchmarks calibration.
     """
     calibration_mode: Literal["NONE", "MARK", "COLLECT"] = Field(
         default="NONE",
@@ -1437,7 +1449,8 @@ class UserProvidedDecodingConfig(DecodingBaseConfig):
 
 
 class NGramDecodingConfig(DecodingBaseConfig):
-    """Configuration for NGram drafter speculative decoding.
+    """
+    Configuration for NGram drafter speculative decoding.
     """
     decoding_type: Literal["NGram"] = "NGram"
     max_matching_ngram_size: PositiveInt = Field(
@@ -2195,7 +2208,8 @@ class PybindMirrorMeta(type(PybindMirror)):
 
 
 class PybindMirrorEnumMeta(EnumMeta, PybindMirrorMeta):
-    """Combined metaclass for Enum and PybindMirror.  This is crucial.
+    """
+    Combined metaclass for Enum and PybindMirror.  This is crucial.
     """
 
 
@@ -2300,7 +2314,8 @@ class SchedulerConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_PeftCacheConfig)
 class PeftCacheConfig(StrictBaseModel, PybindMirror):
-    """Configuration for the PEFT cache.
+    """
+    Configuration for the PEFT cache.
     """
     num_host_module_layer: int = Field(
         default=0,
@@ -2369,7 +2384,8 @@ class PeftCacheConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_LookaheadDecodingConfig)
 class LookaheadDecodingConfig(DecodingBaseConfig, PybindMirror):
-    """Configuration for lookahead speculative decoding.
+    """
+    Configuration for lookahead speculative decoding.
     """
 
     decoding_type: Literal["Lookahead"] = "Lookahead"
@@ -2473,7 +2489,8 @@ class ReorderRequestPolicyConfig(StrictBaseModel):
 
 @PybindMirror.mirror_pybind_fields(_KvCacheConfig)
 class KvCacheConfig(StrictBaseModel, PybindMirror):
-    """Configuration for the KV cache.
+    """
+    Configuration for the KV cache.
     """
     enable_block_reuse: bool = Field(
         default=True,
@@ -2687,7 +2704,8 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_ExtendedRuntimePerfKnobConfig)
 class ExtendedRuntimePerfKnobConfig(StrictBaseModel, PybindMirror):
-    """Configuration for extended runtime performance knobs.
+    """
+    Configuration for extended runtime performance knobs.
     """
 
     multi_block_mode: bool = Field(
@@ -2717,7 +2735,8 @@ class ExtendedRuntimePerfKnobConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_CacheTransceiverConfig)
 class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
-    """Configuration for the cache transceiver.
+    """
+    Configuration for the cache transceiver.
     """
 
     backend: Optional[Literal[
@@ -2828,7 +2847,8 @@ class DwdpConfig(StrictBaseModel):
 
 
 class BaseLlmArgs(StrictBaseModel):
-    """Base class for both TorchLlmArgs and TrtLlmArgs. It contains all the arguments that are common to both.
+    """
+    Base class for both TorchLlmArgs and TrtLlmArgs. It contains all the arguments that are common to both.
     """
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
@@ -3344,7 +3364,8 @@ class TrtLlmArgs(BaseLlmArgs):
 
     @model_validator(mode="after")
     def init_build_config(self):
-        """Creating a default BuildConfig if none is provided
+        """
+        Creating a default BuildConfig if none is provided
         """
         build_config = getattr(self, "build_config", None)
         if build_config is None:
@@ -3745,7 +3766,8 @@ class SamplerType(StrEnum):
 
 
 class TorchCompileConfig(StrictBaseModel):
-    """Configuration for torch.compile.
+    """
+    Configuration for torch.compile.
     """
     enable_fullgraph: bool = Field(
         default=True,
@@ -4306,6 +4328,47 @@ class TorchLlmArgs(BaseLlmArgs):
                 "gms_config is set but load_format is '%s', not 'GMS'. "
                 "The GMS config will be ignored. Set load_format='GMS' to "
                 "enable GPU Memory Service.", self.load_format.name)
+        return self
+
+    @model_validator(mode="after")
+    def validate_gms_moe_compat(self) -> 'TorchLlmArgs':
+        """Reject ``LoadFormat.GMS`` combined with a MoE load balancer.
+
+        The ``MoeLoadBalancer``'s ``register_weight_slots_after_to_cuda``
+        and ``finalize_model`` run AFTER the GMS RW pool is closed and
+        ``finalize_write`` has committed, so any CUDA allocations they
+        make land in non-GMS memory and are NOT part of the committed
+        layout that RO peers receive. The result is "wrong inference,
+        no error" on RO peers (broken MoE routing state). Failing at
+        config-validation time is strictly better than that silent
+        miscompute.
+
+        The fix for this gap (running the MoE finalize work INSIDE
+        ``mem_pool_scope`` and BEFORE ``finalize_write`` so MoE
+        allocations are part of the committed layout) is tracked as
+        the (MoE, GMS) follow-up; see ``model_loader.py``'s
+        ``TODO(GMS-MOE-LB)`` comment.
+
+        Returns:
+            ``self`` (Pydantic ``model_validator`` contract).
+
+        Raises:
+            ValueError: When ``load_format == LoadFormat.GMS`` and
+                ``moe_config.load_balancer`` is set.
+        """
+        if (self.load_format == LoadFormat.GMS and self.moe_config is not None
+                and self.moe_config.load_balancer is not None):
+            raise ValueError(
+                "LoadFormat.GMS is incompatible with moe_config.load_balancer "
+                "in this PR. The MoE load balancer's "
+                "register_weight_slots_after_to_cuda and finalize_model run "
+                "after the GMS pool closes and finalize_write commits, so "
+                "their allocations land outside the committed layout. RO "
+                "peers would receive a broken MoE routing state. Either "
+                "disable moe_config.load_balancer or use LoadFormat.AUTO. "
+                "Tracked as the (MoE, GMS) follow-up at "
+                "tensorrt_llm/_torch/pyexecutor/model_loader.py "
+                "(see TODO(GMS-MOE-LB)).")
         return self
 
     @model_validator(mode="after")

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -93,7 +93,6 @@ def Field(default: Any = ...,
     Returns:
         A Pydantic FieldInfo object with the status added to json_schema_extra if provided
     """
-
     if status is not None:
         json_schema_extra = kwargs.get('json_schema_extra', {})
         if isinstance(json_schema_extra, dict):
@@ -107,8 +106,7 @@ def Field(default: Any = ...,
 
 
 class CudaGraphConfig(StrictBaseModel):
-    """
-    Configuration for CUDA graphs.
+    """Configuration for CUDA graphs.
     """
     # List of batch sizes to create CUDA graphs for.
     batch_sizes: Optional[List[int]] = Field(
@@ -253,8 +251,7 @@ class GuidedDecodingConfig(StrictBaseModel):
 
 
 class BaseSparseAttentionConfig(StrictBaseModel):
-    """
-    Configuration for sparse attention.
+    """Configuration for sparse attention.
     """
     algorithm: str
 
@@ -265,8 +262,7 @@ class BaseSparseAttentionConfig(StrictBaseModel):
     )
 
     def supports_backend(self, backend: str) -> bool:
-        """
-        Override if the sparse attention algorithm does not support
+        """Override if the sparse attention algorithm does not support
         a subset of the possible backends.
         """
         return True
@@ -275,8 +271,7 @@ class BaseSparseAttentionConfig(StrictBaseModel):
         return 1
 
     def needs_separate_short_long_cuda_graphs(self) -> bool:
-        """
-        Determines whether to capture a dedicated CUDA graph for batches consisting entirely of short sequences.
+        """Determines whether to capture a dedicated CUDA graph for batches consisting entirely of short sequences.
         If True, capture distinct graphs for short-only batches and general cases (e.g., long or mixed batches).
         If False, capture a single unified CUDA graph for all sequences regardless of length.
         The seq_len_threshold parameter defines the cutoff boundary between short and long sequences.
@@ -285,8 +280,7 @@ class BaseSparseAttentionConfig(StrictBaseModel):
 
 
 class RocketSparseAttentionConfig(BaseSparseAttentionConfig):
-    """
-    Configuration for RocketKV sparse attention.
+    """Configuration for RocketKV sparse attention.
     """
     algorithm: Literal["rocket"] = "rocket"
     window_size: Optional[int] = Field(
@@ -312,8 +306,7 @@ class RocketSparseAttentionConfig(BaseSparseAttentionConfig):
 
 
 class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
-    """
-    Configuration for DeepSeek Sparse Attention.
+    """Configuration for DeepSeek Sparse Attention.
     """
     algorithm: Literal["dsa"] = "dsa"
     index_n_heads: Optional[int] = Field(
@@ -396,8 +389,7 @@ class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
         return backend == "pytorch"
 
     def needs_separate_short_long_cuda_graphs(self) -> bool:
-        """
-        Whether to capture separate CUDA graphs for short and long sequences.
+        """Whether to capture separate CUDA graphs for short and long sequences.
         Use seq_len_threshold to determine the threshold for separating short and long sequences.
         """
         self.seq_len_threshold = self.index_topk
@@ -405,8 +397,7 @@ class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
 
 
 class SkipSoftmaxAttentionConfig(BaseSparseAttentionConfig):
-    """
-    Configuration for skip softmax attention.
+    """Configuration for skip softmax attention.
     """
     algorithm: Literal["skip_softmax"] = "skip_softmax"
     threshold_scale_factor: Optional[Union[float, Dict[str, float]]] = Field(
@@ -486,8 +477,7 @@ class SkipSoftmaxAttentionConfig(BaseSparseAttentionConfig):
 
 
 class MoeLoadBalancerConfig(StrictBaseModel):
-    """
-    Pydantic configuration model for the Mixture of Experts (MoE) load balancer.
+    """Pydantic configuration model for the Mixture of Experts (MoE) load balancer.
 
     This model holds configuration data (`num_slots`, etc.) as well as
     runtime state (`_ep_rank`, `_ep_size`) which must be set via the
@@ -506,8 +496,7 @@ class MoeLoadBalancerConfig(StrictBaseModel):
     # --- Methods ---
 
     def setup(self, ep_rank: int, ep_size: int) -> None:
-        """
-        Initializes the runtime state of the configuration.
+        """Initializes the runtime state of the configuration.
         This must be called before accessing properties like `num_local_slots`.
         """
         self._ep_rank = ep_rank
@@ -563,8 +552,7 @@ class MoeLoadBalancerConfig(StrictBaseModel):
 
     def get_layer_initial_global_assignments(
             self, layer_idx: int) -> Optional[List[int]]:
-        """
-        Retrieves the initial global assignments for a specific layer.
+        """Retrieves the initial global assignments for a specific layer.
         """
         if self.initial_global_assignments is None:
             return None
@@ -589,8 +577,7 @@ class MoeLoadBalancerConfig(StrictBaseModel):
 
 
 class MoeConfig(StrictBaseModel):
-    """
-    Configuration for MoE.
+    """Configuration for MoE.
     """
     backend: Literal[
         "AUTO", "CUTLASS", "CUTEDSL", "WIDEEP", "TRTLLM", "DEEPGEMM",
@@ -634,8 +621,7 @@ TOKENIZER_ALIASES = {
 
 
 class Nvfp4GemmConfig(StrictBaseModel):
-    """
-    Configuration for NVFP4 GEMM backend selection.
+    """Configuration for NVFP4 GEMM backend selection.
     """
     allowed_backends: List[Nvfp4Backend] = Field(
         default_factory=lambda: ['cutlass', 'cublaslt', 'cuda_core'],
@@ -647,8 +633,7 @@ class Nvfp4GemmConfig(StrictBaseModel):
 
 
 class AttentionDpConfig(StrictBaseModel):
-    """
-    Configuration for attention DP.
+    """Configuration for attention DP.
     """
     enable_balance: bool = Field(default=False,
                                  description="Whether to enable balance.")
@@ -708,8 +693,7 @@ class AttentionDpConfig(StrictBaseModel):
 
 
 class CpConfig(StrictBaseModel):
-    """
-    Configuration for context parallelism.
+    """Configuration for context parallelism.
     """
     # TODO: given that multiple fields here are only used with specific cp_types, consider
     # making this a Pydantic discriminated union.
@@ -816,8 +800,7 @@ class _ParallelConfig(StrictBaseModel):
 
 
 class CalibConfig(StrictBaseModel):
-    """
-    Calibration configuration.
+    """Calibration configuration.
     """
     device: Literal['cuda',
                     'cpu'] = Field(default='cuda',
@@ -995,8 +978,7 @@ class DecodingBaseConfig(StrictBaseModel):
         return self
 
     def supports_backend(self, backend: str) -> bool:
-        """
-        Override if the speculation algorithm does not support
+        """Override if the speculation algorithm does not support
         a subset of the possible backends.
         """
         return True
@@ -1025,8 +1007,7 @@ class DecodingBaseConfig(StrictBaseModel):
 
 
 class KvCacheConnectorConfig(StrictBaseModel):
-    """
-    Configuration for the KV Cache Connector.
+    """Configuration for the KV Cache Connector.
 
     Can be configured either by specifying a named preset via ``connector``
     (e.g. ``"lmcache"``), or by providing explicit ``connector_module``,
@@ -1079,8 +1060,7 @@ class KvCacheConnectorConfig(StrictBaseModel):
 
 
 class LayerwiseBenchmarksConfig(StrictBaseModel):
-    """
-    Configuration for layer-wise benchmarks calibration.
+    """Configuration for layer-wise benchmarks calibration.
     """
     calibration_mode: Literal["NONE", "MARK", "COLLECT"] = Field(
         default="NONE",
@@ -1306,8 +1286,7 @@ class EagleDecodingConfig(DecodingBaseConfig):
 
     @functools.cached_property
     def num_capture_layers(self) -> int:
-        """
-        Returns the number of layers to capture of the target model.
+        """Returns the number of layers to capture of the target model.
         If eagle3_layers_to_capture is not None, return the length of the set.
         Otherwise, assume Eagle3 base set and return 3.
         """
@@ -1417,8 +1396,7 @@ class SaveHiddenStatesDecodingConfig(DecodingBaseConfig):
 
     @functools.cached_property
     def num_capture_layers(self):
-        """
-        Returns the number of layers to save.
+        """Returns the number of layers to save.
         The following hidden states are saved:
         - If eagle3_layers_to_capture is None, save the eagle3 base set plus
         the post norm last hidden state.
@@ -1459,8 +1437,7 @@ class UserProvidedDecodingConfig(DecodingBaseConfig):
 
 
 class NGramDecodingConfig(DecodingBaseConfig):
-    """
-    Configuration for NGram drafter speculative decoding.
+    """Configuration for NGram drafter speculative decoding.
     """
     decoding_type: Literal["NGram"] = "NGram"
     max_matching_ngram_size: PositiveInt = Field(
@@ -1791,8 +1768,7 @@ class DFlashDecodingConfig(DecodingBaseConfig):
 
 
 class AutoDecodingConfig(DecodingBaseConfig):
-    """
-    Configuration for auto speculative decoding.
+    """Configuration for auto speculative decoding.
 
     This config will automatically select a good, draft-model free
     speculation algorithm with some heuristic.
@@ -1812,8 +1788,7 @@ class AutoDecodingConfig(DecodingBaseConfig):
 
 
 class PrometheusMetricsConfig(StrictBaseModel):
-    """
-    Configuration for Prometheus metrics collection.
+    """Configuration for Prometheus metrics collection.
 
     Groups all Prometheus-related parameters including custom histogram bucket
     boundaries for latency metrics.
@@ -1893,8 +1868,7 @@ class PrometheusMetricsConfig(StrictBaseModel):
 
 
 class RayPlacementConfig(StrictBaseModel):
-    """
-    Configuration for Ray GPU workers placement.
+    """Configuration for Ray GPU workers placement.
     Currently, this config is only used with AsyncLLM for RL scenarios.
     """
     defer_workers_init: bool = Field(
@@ -1960,8 +1934,8 @@ class RayPlacementConfig(StrictBaseModel):
 class ExecutorMemoryType(StrEnum):
     """Types of GPU memory used by executor.
 
-     These are used by the sleep/wakeup feature to target specific type of memory.
-     """
+    These are used by the sleep/wakeup feature to target specific type of memory.
+    """
     SAMPLER = "sampler"
     DRAFTER = "drafter"
     GUIDED_DECODER = "guided_decoder"
@@ -2071,9 +2045,9 @@ class SleepConfig(StrictBaseModel):
 
 
 class PybindMirror(ABC):
-    ''' A class containing the utilities for mirroring Python classes to
+    """A class containing the utilities for mirroring Python classes to
     pybind classes.
-    '''
+    """
 
     @abstractmethod
     def _to_pybind(self):
@@ -2089,8 +2063,7 @@ class PybindMirror(ABC):
 
     @staticmethod
     def mirror_pybind_fields(pybind_class):
-        """
-        Class decorator that ensures Python class fields mirror those of a C++ class.
+        """Class decorator that ensures Python class fields mirror those of a C++ class.
 
         Args:
             pybind_class: The C++ class whose fields should be mirrored
@@ -2119,7 +2092,7 @@ class PybindMirror(ABC):
 
     @staticmethod
     def get_pybind_enum_fields(pybind_class):
-        ''' Get all the enum fields from the pybind class. '''
+        """Get all the enum fields from the pybind class."""
         return [
             f for f in pybind_class.__members__.keys()
             if not f.startswith('_') and not callable(getattr(pybind_class, f))
@@ -2127,7 +2100,7 @@ class PybindMirror(ABC):
 
     @staticmethod
     def mirror_pybind_enum(pybind_class):
-        ''' Mirror the enum fields from the pybind class to the Python class. '''
+        """Mirror the enum fields from the pybind class to the Python class."""
 
         def decorator(cls):
             assert issubclass(cls, Enum)
@@ -2145,7 +2118,7 @@ class PybindMirror(ABC):
 
     @staticmethod
     def get_pybind_variable_fields(config_cls):
-        ''' Get all the variable fields from the pybind class. '''
+        """Get all the variable fields from the pybind class."""
         return [
             f for f in dir(config_cls)
             if not f.startswith('_') and not callable(getattr(config_cls, f))
@@ -2153,7 +2126,7 @@ class PybindMirror(ABC):
 
     @staticmethod
     def pybind_equals(obj0, obj1):
-        ''' Check if two pybind objects are equal. '''
+        """Check if two pybind objects are equal."""
         assert type(obj0) is type(obj1)
         for field in PybindMirror.get_pybind_variable_fields(type(obj0)):
             if getattr(obj0, field) != getattr(obj1, field):
@@ -2222,8 +2195,7 @@ class PybindMirrorMeta(type(PybindMirror)):
 
 
 class PybindMirrorEnumMeta(EnumMeta, PybindMirrorMeta):
-    """
-    Combined metaclass for Enum and PybindMirror.  This is crucial.
+    """Combined metaclass for Enum and PybindMirror.  This is crucial.
     """
 
 
@@ -2248,7 +2220,7 @@ class CapacitySchedulerPolicy(StrEnum, metaclass=PybindMirrorEnumMeta):
 
 @PybindMirror.mirror_pybind_enum(_ContextChunkingPolicy)
 class ContextChunkingPolicy(StrEnum, metaclass=PybindMirrorEnumMeta):
-    ''' Context chunking policy. '''
+    """Context chunking policy."""
     FIRST_COME_FIRST_SERVED = "FIRST_COME_FIRST_SERVED"
     EQUAL_PROGRESS = "EQUAL_PROGRESS"
     FORCE_CHUNK = "FORCE_CHUNK"
@@ -2328,8 +2300,7 @@ class SchedulerConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_PeftCacheConfig)
 class PeftCacheConfig(StrictBaseModel, PybindMirror):
-    """
-    Configuration for the PEFT cache.
+    """Configuration for the PEFT cache.
     """
     num_host_module_layer: int = Field(
         default=0,
@@ -2398,8 +2369,7 @@ class PeftCacheConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_LookaheadDecodingConfig)
 class LookaheadDecodingConfig(DecodingBaseConfig, PybindMirror):
-    """
-    Configuration for lookahead speculative decoding.
+    """Configuration for lookahead speculative decoding.
     """
 
     decoding_type: Literal["Lookahead"] = "Lookahead"
@@ -2503,8 +2473,7 @@ class ReorderRequestPolicyConfig(StrictBaseModel):
 
 @PybindMirror.mirror_pybind_fields(_KvCacheConfig)
 class KvCacheConfig(StrictBaseModel, PybindMirror):
-    """
-    Configuration for the KV cache.
+    """Configuration for the KV cache.
     """
     enable_block_reuse: bool = Field(
         default=True,
@@ -2718,8 +2687,7 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_ExtendedRuntimePerfKnobConfig)
 class ExtendedRuntimePerfKnobConfig(StrictBaseModel, PybindMirror):
-    """
-    Configuration for extended runtime performance knobs.
+    """Configuration for extended runtime performance knobs.
     """
 
     multi_block_mode: bool = Field(
@@ -2749,8 +2717,7 @@ class ExtendedRuntimePerfKnobConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_CacheTransceiverConfig)
 class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
-    """
-    Configuration for the cache transceiver.
+    """Configuration for the cache transceiver.
     """
 
     backend: Optional[Literal[
@@ -2861,8 +2828,7 @@ class DwdpConfig(StrictBaseModel):
 
 
 class BaseLlmArgs(StrictBaseModel):
-    """
-    Base class for both TorchLlmArgs and TrtLlmArgs. It contains all the arguments that are common to both.
+    """Base class for both TorchLlmArgs and TrtLlmArgs. It contains all the arguments that are common to both.
     """
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
@@ -3378,8 +3344,7 @@ class TrtLlmArgs(BaseLlmArgs):
 
     @model_validator(mode="after")
     def init_build_config(self):
-        """
-        Creating a default BuildConfig if none is provided
+        """Creating a default BuildConfig if none is provided
         """
         build_config = getattr(self, "build_config", None)
         if build_config is None:
@@ -3549,12 +3514,11 @@ class TrtLlmArgs(BaseLlmArgs):
 
     @model_validator(mode="after")
     def validate_model_format_misc(self):
-        '''
-        Load the model format, and do the following:
+        """Load the model format, and do the following:
 
         1. Load the build_config if got an engine.
         2. Load the parallel_config if got a checkpoint.
-        '''
+        """
         model_obj = _ModelWrapper(self.model)
 
         if model_obj.is_local_model and self.backend not in [
@@ -3700,7 +3664,28 @@ class ModelExpressConfig(StrictBaseModel):
 
 
 class GmsConfig(StrictBaseModel):
-    """Prototype configuration for GPU Memory Service (GMS) weight sharing."""
+    """Prototype configuration for GPU Memory Service (GMS) weight sharing.
+
+    Composes orthogonally with ``checkpoint_format`` on ``TorchLlmArgs``:
+    GMS controls *where* weights live (a node-shared GPU memory pool
+    so multiple TRT-LLM instances zero-copy share the same bytes),
+    while ``checkpoint_format`` controls *how* they get there (HF disk,
+    MX P2P, etc.). Effective only when ``TorchLlmArgs.load_format ==
+    LoadFormat.GMS``; setting any non-default field here without that
+    load_format triggers a warning via :meth:`TorchLlmArgs.validate_gms_config`.
+
+    Two roles are decided at connect time by the GMS daemon, not by
+    config:
+
+    - **RW (writer)**: the first instance loads weights into the pool
+      via the normal checkpoint-loader pipeline, then commits them.
+    - **RO (reader)**: subsequent instances zero-copy materialize the
+      already-committed layout — no disk I/O, no per-instance copies.
+
+    See :class:`tensorrt_llm._torch.memory.gpu_memory_backend.GMSBackend`
+    for the integration adapter and the ``LoadFormat.GMS`` branch in
+    ``ModelLoader.load`` for orchestration.
+    """
 
     socket_path: Optional[str] = Field(
         default=None,
@@ -3728,6 +3713,20 @@ class GmsConfig(StrictBaseModel):
 
     @model_validator(mode="after")
     def validate_gms_config(self) -> 'GmsConfig':
+        """Enforce :attr:`mode` enum membership and non-empty :attr:`tag`.
+
+        Pydantic's ``status='prototype'`` field-level validation only
+        checks types; the cross-field semantics (mode whitelist,
+        non-empty tag) live here so users get a clear error at config
+        time instead of an opaque failure during ``ModelLoader.load``.
+
+        Raises:
+            ValueError: If ``mode`` is not one of ``{'auto', 'rw', 'ro'}``,
+                or if ``tag`` is empty / whitespace-only.
+
+        Returns:
+            ``self`` (Pydantic ``model_validator`` contract).
+        """
         if self.mode not in ("auto", "rw", "ro"):
             raise ValueError(
                 f"gms_config.mode must be 'auto', 'rw', or 'ro', got '{self.mode}'."
@@ -3746,8 +3745,7 @@ class SamplerType(StrEnum):
 
 
 class TorchCompileConfig(StrictBaseModel):
-    """
-    Configuration for torch.compile.
+    """Configuration for torch.compile.
     """
     enable_fullgraph: bool = Field(
         default=True,
@@ -4280,6 +4278,26 @@ class TorchLlmArgs(BaseLlmArgs):
 
     @model_validator(mode="after")
     def validate_gms_config(self) -> 'TorchLlmArgs':
+        """Warn when GMS settings are provided without enabling GMS load.
+
+        Catches the most common misconfiguration: a user customizes
+        :attr:`gms_config` (e.g. sets a custom ``socket_path`` or
+        ``mode``) but forgets to set ``load_format='GMS'``, in which
+        case the entire GMS config is silently ignored. We emit a
+        warning so the user notices at config time instead of
+        debugging "why are my workers not zero-copy sharing weights?"
+        afterwards.
+
+        Detection is by deviation from defaults: any of
+        ``socket_path != None``, ``mode != 'auto'``, or
+        ``tag != 'weights'`` triggers the warning when
+        ``load_format != LoadFormat.GMS``. This is intentionally a
+        warning (not an error) so callers that pre-populate config
+        objects from templates aren't broken.
+
+        Returns:
+            ``self`` (Pydantic ``model_validator`` contract).
+        """
         gms_config_is_non_default = (self.gms_config.socket_path is not None
                                      or self.gms_config.mode != "auto"
                                      or self.gms_config.tag != "weights")
@@ -4377,7 +4395,7 @@ class TorchLlmArgs(BaseLlmArgs):
     def validate_ray_worker_extension_cls(self) -> 'TorchLlmArgs':
         if self.ray_worker_extension_cls is not None and self.orchestrator_type != "ray":
             raise ValueError(
-                f"ray_worker_extension_cls is only supported with orchestrator_type='ray'"
+                "ray_worker_extension_cls is only supported with orchestrator_type='ray'"
             )
         return self
 
@@ -4502,7 +4520,7 @@ def update_llm_args_with_extra_options(llm_args: Dict,
 
 def get_model_format(model_dir: str,
                      trust_remote_code: bool = False) -> _ModelFormatKind:
-    ''' Get the format of the model.  '''
+    """Get the format of the model."""
     if not (Path(model_dir) / 'config.json').exists():
         raise ValueError(
             f"Failed to infer model format because no config.json exists in {model_dir}"

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -4139,6 +4139,14 @@ class TorchLlmArgs(BaseLlmArgs):
     def convert_load_format(cls, v):
         if isinstance(v, LoadFormat):
             return v
+        # ``bool`` is a subclass of ``int`` in Python, so without an
+        # explicit bool check ``load_format=True/False`` would silently
+        # coerce to ``LoadFormat(1) == LoadFormat.DUMMY`` /
+        # ``LoadFormat(0) == LoadFormat.AUTO``. Reject early so callers
+        # who pass a misread boolean flag get an actionable error
+        # instead of a silently wrong checkpoint-load mode.
+        if isinstance(v, bool):
+            raise ValueError(f"Invalid LoadFormat: {v}")
         if isinstance(v, int):
             return LoadFormat(v)
         load_format = v.upper()

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3651,6 +3651,8 @@ class LoadFormat(Enum):
     DUMMY = 1
     # Only load the multimodal(vision) encoder weights
     VISION_ONLY = 2
+    # Load weights through GPU Memory Service.
+    GMS = 3
 
 
 class ModelExpressConfig(StrictBaseModel):
@@ -3694,6 +3696,45 @@ class ModelExpressConfig(StrictBaseModel):
                 "mx_config.preshard_strategy='global' requires "
                 "LoadFormat.PRESHARDED, which is not yet available in "
                 "TRT-LLM main. Use preshard_strategy='per_module' instead.")
+        return self
+
+
+class GmsConfig(StrictBaseModel):
+    """Prototype configuration for GPU Memory Service (GMS) weight sharing."""
+
+    socket_path: Optional[str] = Field(
+        default=None,
+        description="Unix domain socket path of the GPU Memory Service. "
+        "When unset, the GMS library resolves its default per-device path.",
+        status="prototype",
+    )
+
+    mode: str = Field(
+        default="auto",
+        description="GMS operating mode: 'auto' requests RW or RO, 'rw' "
+        "requires writer mode, and 'ro' requires read-only mode.",
+        status="prototype",
+    )
+
+    tag: str = Field(
+        default="weights",
+        description="Tag identifying the model weight set in the GMS memory "
+        "pool. Defaults to 'weights' to match the GMS library convention. "
+        "The tag must uniquely identify a compatible model/parallelism "
+        "layout for a given GMS daemon; reusing a tag for different weights "
+        "can make RO readers attach to the wrong pool.",
+        status="prototype",
+    )
+
+    @model_validator(mode="after")
+    def validate_gms_config(self) -> 'GmsConfig':
+        if self.mode not in ("auto", "rw", "ro"):
+            raise ValueError(
+                f"gms_config.mode must be 'auto', 'rw', or 'ro', got '{self.mode}'."
+            )
+        if not self.tag or not self.tag.strip():
+            raise ValueError(
+                f"gms_config.tag must be a non-empty string, got {self.tag!r}.")
         return self
 
 
@@ -3932,6 +3973,12 @@ class TorchLlmArgs(BaseLlmArgs):
         status="prototype",
     )
 
+    gms_config: GmsConfig = Field(
+        default_factory=GmsConfig,
+        description="GPU Memory Service (GMS) weight sharing config.",
+        status="prototype",
+    )
+
     kv_connector_config: Optional[KvCacheConnectorConfig] = Field(
         default=None,
         description="The config for KV cache connector.",
@@ -4074,6 +4121,8 @@ class TorchLlmArgs(BaseLlmArgs):
     def convert_load_format(cls, v):
         if isinstance(v, LoadFormat):
             return v
+        if isinstance(v, int):
+            return LoadFormat(v)
         load_format = v.upper()
         if load_format not in LoadFormat.__members__:
             raise ValueError(f"Invalid LoadFormat: {v}")
@@ -4227,6 +4276,18 @@ class TorchLlmArgs(BaseLlmArgs):
                 "'MX'. The MX config will be ignored. Set "
                 "checkpoint_format='MX' to enable MX P2P weight transfer.",
                 self.checkpoint_format)
+        return self
+
+    @model_validator(mode="after")
+    def validate_gms_config(self) -> 'TorchLlmArgs':
+        gms_config_is_non_default = (self.gms_config.socket_path is not None
+                                     or self.gms_config.mode != "auto"
+                                     or self.gms_config.tag != "weights")
+        if gms_config_is_non_default and self.load_format != LoadFormat.GMS:
+            logger.warning(
+                "gms_config is set but load_format is '%s', not 'GMS'. "
+                "The GMS config will be ignored. Set load_format='GMS' to "
+                "enable GPU Memory Service.", self.load_format.name)
         return self
 
     @model_validator(mode="after")

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -93,6 +93,7 @@ def Field(default: Any = ...,
     Returns:
         A Pydantic FieldInfo object with the status added to json_schema_extra if provided
     """
+
     if status is not None:
         json_schema_extra = kwargs.get('json_schema_extra', {})
         if isinstance(json_schema_extra, dict):

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3716,7 +3716,7 @@ class GmsConfig(StrictBaseModel):
         status="prototype",
     )
 
-    mode: str = Field(
+    mode: Literal["auto", "rw", "ro"] = Field(
         default="auto",
         description="GMS operating mode: 'auto' requests RW or RO, 'rw' "
         "requires writer mode, and 'ro' requires read-only mode.",
@@ -3735,24 +3735,21 @@ class GmsConfig(StrictBaseModel):
 
     @model_validator(mode="after")
     def validate_gms_config(self) -> 'GmsConfig':
-        """Enforce :attr:`mode` enum membership and non-empty :attr:`tag`.
+        """Enforce non-empty :attr:`tag`.
 
-        Pydantic's ``status='prototype'`` field-level validation only
-        checks types; the cross-field semantics (mode whitelist,
-        non-empty tag) live here so users get a clear error at config
-        time instead of an opaque failure during ``ModelLoader.load``.
+        :attr:`mode` is enforced by its ``Literal`` type annotation —
+        Pydantic rejects out-of-set values at field validation, before
+        this validator runs, so the JSON schema/docs are self-describing
+        (enum) without a duplicated whitelist here.  This validator only
+        enforces the non-empty / non-whitespace contract on :attr:`tag`,
+        which the type system can't express.
 
         Raises:
-            ValueError: If ``mode`` is not one of ``{'auto', 'rw', 'ro'}``,
-                or if ``tag`` is empty / whitespace-only.
+            ValueError: If ``tag`` is empty / whitespace-only.
 
         Returns:
             ``self`` (Pydantic ``model_validator`` contract).
         """
-        if self.mode not in ("auto", "rw", "ro"):
-            raise ValueError(
-                f"gms_config.mode must be 'auto', 'rw', or 'ro', got '{self.mode}'."
-            )
         if not self.tag or not self.tag.strip():
             raise ValueError(
                 f"gms_config.tag must be a non-empty string, got {self.tag!r}.")

--- a/tests/unittest/_torch/memory/test_gms_backend.py
+++ b/tests/unittest/_torch/memory/test_gms_backend.py
@@ -1,0 +1,404 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Unit tests for ``GMSBackend`` (``LoadFormat.GMS``).
+
+These tests intentionally do NOT exercise the upstream
+``gpu_memory_service`` library. Tests for the import-failure fallback
+path mock ``gpu_memory_service.*`` symbols out of ``sys.modules`` so the
+assertion is about *our* fallback behavior, not about the upstream API.
+
+The only piece of real CUDA touched by ``GMSBackend.__init__`` is a
+single ``torch.cuda.current_device()`` call to record the device index.
+We monkeypatch that to a fixed integer for the whole module so every
+control-path test (construction, pre-connect, connect-failure, RW/RO
+gating, protocol conformance) runs on CPU CI without a GPU.
+"""
+
+import sys
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.memory.gpu_memory_backend import (
+    GMSBackend,
+    GPUMemoryBackend,
+    _ptr_in_gms,
+    _storage_nbytes,
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_current_device(monkeypatch):
+    """Make ``GMSBackend.__init__`` runnable on CPU CI.
+
+    The only real-CUDA dependency in our backend's ``__init__`` is
+    ``torch.cuda.current_device()`` — there are no kernel launches.
+    Stubbing it to ``0`` lets every mocked happy/failure connect path
+    actually execute under CPU CI.
+    """
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    """GMSBackend construction-time invariants."""
+
+    @pytest.mark.parametrize("mode", ["rw", "ro", "auto"], ids=["rw", "ro", "auto"])
+    def test_accepts_valid_modes(self, mode):
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock(), mode=mode)
+        assert backend._mode == mode
+        assert backend._client is None
+        assert backend._is_rw is None
+
+    @pytest.mark.parametrize(
+        "bad_mode",
+        ["RW", "Auto", "read", "write", "shadow", "", "rw ", "auto-detect"],
+        ids=[
+            "uppercase-rw",
+            "mixedcase-auto",
+            "read",
+            "write",
+            "shadow",
+            "empty",
+            "trailing-space",
+            "auto-detect",
+        ],
+    )
+    def test_rejects_invalid_modes(self, bad_mode):
+        with pytest.raises(ValueError, match="GMS mode must be"):
+            GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock(), mode=bad_mode)
+
+    def test_default_tag(self):
+        # IMPORTANT: default tag must be ``weights``, NOT ``model_weights``.
+        # Matches the GMS library convention (GMS_TAGS upstream).
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock())
+        assert backend._tag == "weights"
+        assert GMSBackend.DEFAULT_TAG == "weights"
+
+    def test_custom_tag(self):
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock(), tag="custom")
+        assert backend._tag == "custom"
+
+    def test_socket_path_stored(self):
+        backend = GMSBackend(socket_path="/tmp/custom.sock", mapping=MagicMock())
+        assert backend._socket_path == "/tmp/custom.sock"
+
+    def test_socket_path_none_resolved_lazily(self):
+        # Socket-path resolution to upstream get_socket_path(device, tag)
+        # happens inside connect(), not __init__. Construction with
+        # socket_path=None must not raise.
+        backend = GMSBackend(socket_path=None, mapping=MagicMock())
+        assert backend._socket_path is None
+        assert backend._client is None
+
+
+# ---------------------------------------------------------------------------
+# Properties before connect()
+# ---------------------------------------------------------------------------
+
+
+class TestPreConnectState:
+    def _backend(self):
+        return GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock())
+
+    def test_is_rw_is_none(self):
+        assert self._backend().is_rw is None
+
+    def test_has_committed_weights_returns_false(self):
+        # No committed weights when not connected — return False (not raise).
+        assert self._backend().has_committed_weights() is False
+
+    def test_cleanup_safe_when_never_connected(self):
+        # cleanup() must be idempotent and safe to call before connect().
+        self._backend().cleanup()  # must not raise
+
+    @pytest.mark.parametrize(
+        "method_name, invoke",
+        [
+            # invoke(backend) -> trigger; we wrap mem_pool_scope so the
+            # context-manager protocol gets exercised inside pytest.raises.
+            ("mem_pool_scope", lambda backend: backend.mem_pool_scope().__enter__()),
+            ("materialize_module", lambda backend: backend.materialize_module(MagicMock())),
+            ("finalize_write", lambda backend: backend.finalize_write(MagicMock())),
+            ("move_untracked_params", lambda backend: backend.move_untracked_params(MagicMock())),
+        ],
+        ids=["mem-pool-scope", "materialize-module", "finalize-write", "move-untracked-params"],
+    )
+    def test_method_raises_when_not_connected(self, method_name, invoke):
+        # Every method that uses the GMS client must guard with a clear
+        # "not connected" error before dereferencing self._client.
+        with pytest.raises(RuntimeError, match="not connected"):
+            invoke(self._backend())
+
+
+# ---------------------------------------------------------------------------
+# connect() — graceful failure on missing upstream library
+# ---------------------------------------------------------------------------
+
+
+class TestConnectFailure:
+    def test_returns_false_when_upstream_not_installed(self):
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock())
+        with _block_gms():
+            assert backend.connect() is False
+        assert backend._client is None
+        assert backend._is_rw is None
+
+    def test_returns_false_when_upstream_raises(self):
+        # If get_or_create_gms_client_memory_manager raises (e.g. socket
+        # doesn't exist), connect() must surface a False (not propagate).
+        backend = GMSBackend(socket_path="/tmp/nonexistent.sock", mapping=MagicMock())
+
+        fake_gms = _build_fake_gms_lock_failure(error=RuntimeError("socket missing"))
+        with _install_fake_gms(fake_gms):
+            assert backend.connect() is False
+        assert backend._client is None
+
+
+# ---------------------------------------------------------------------------
+# RW-vs-RO method gating
+# ---------------------------------------------------------------------------
+
+
+class TestRwOnlyMethodsGated:
+    """RW-only methods must raise when the granted lock is RO."""
+
+    def _ro_backend(self):
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock())
+        # Simulate "connected, granted RO" without going through real connect().
+        backend._client = MagicMock()
+        backend._is_rw = False
+        return backend
+
+    @pytest.mark.parametrize(
+        "method_name, invoke",
+        [
+            ("mem_pool_scope", lambda backend: backend.mem_pool_scope().__enter__()),
+            ("finalize_write", lambda backend: backend.finalize_write(MagicMock())),
+        ],
+        ids=["mem-pool-scope", "finalize-write"],
+    )
+    def test_method_raises_when_granted_ro(self, method_name, invoke):
+        with pytest.raises(RuntimeError, match="only valid in RW mode"):
+            invoke(self._ro_backend())
+
+
+# ---------------------------------------------------------------------------
+# Helper functions: _ptr_in_gms, _storage_nbytes
+# ---------------------------------------------------------------------------
+
+
+def _make_gms_client_with_mapping(va: int, size: int):
+    """Build a fake GMS client that exposes one mapping at (va, size)."""
+    client = MagicMock()
+    mapping = MagicMock()
+    mapping.va = va
+    mapping.size = size
+    client._mappings = {"k": mapping}
+    return client
+
+
+class TestPtrInGms:
+    """``_ptr_in_gms`` semantics: half-open intervals + defensive guards."""
+
+    def test_returns_false_when_no_mappings_attr(self):
+        # Older GMS releases may not have ``_mappings`` at all.
+        client = MagicMock(spec=[])
+        assert _ptr_in_gms(client, 0xABCDEF) is False
+
+    def test_returns_false_when_mappings_empty(self):
+        client = MagicMock()
+        client._mappings = {}
+        assert _ptr_in_gms(client, 0xABCDEF) is False
+
+    @pytest.mark.parametrize(
+        "label, ptr, expected",
+        [
+            # Reference mapping is at va=0x1000, size=0x100 (range
+            # [0x1000, 0x1100) — half-open).
+            ("inside_mapping", 0x1080, True),
+            ("at_mapping_start", 0x1000, True),
+            ("just_below_end", 0x10FF, True),
+            ("at_mapping_end", 0x1100, False),  # half-open
+            ("just_below_start", 0x0FFF, False),
+            ("far_outside", 0x2000, False),
+        ],
+        ids=[
+            "inside-mapping",
+            "at-mapping-start",
+            "just-below-end",
+            "at-mapping-end",
+            "just-below-start",
+            "far-outside",
+        ],
+    )
+    def test_half_open_interval(self, label, ptr, expected):
+        client = _make_gms_client_with_mapping(va=0x1000, size=0x100)
+        assert _ptr_in_gms(client, ptr) is expected, (
+            f"case={label}: ptr=0x{ptr:x} expected {expected}"
+        )
+
+    @pytest.mark.parametrize(
+        "label, va, size",
+        [
+            ("zero_va_zero_size", 0, 0),
+            ("zero_va_nonzero_size", 0, 0x100),
+            ("nonzero_va_zero_size", 0x1000, 0),
+        ],
+        ids=["zero-va-zero-size", "zero-va-nonzero-size", "nonzero-va-zero-size"],
+    )
+    def test_zero_sentinels_never_match(self, label, va, size):
+        # Defensive: a mapping with va=0 or size=0 must never match,
+        # even when the queried pointer is 0.
+        client = _make_gms_client_with_mapping(va=va, size=size)
+        assert _ptr_in_gms(client, 0) is False, f"case={label}"
+        assert _ptr_in_gms(client, va) is False, f"case={label}"
+
+
+class TestStorageNbytes:
+    def test_cpu_tensor(self):
+        t = torch.empty(10, dtype=torch.float32)
+        # 10 * 4 = 40 bytes minimum
+        assert _storage_nbytes(t) >= 40
+
+    def test_dtype_dependent(self):
+        t_f32 = torch.empty(10, dtype=torch.float32)
+        t_bf16 = torch.empty(10, dtype=torch.bfloat16)
+        # 10 fp32 occupies more than 10 bf16
+        assert _storage_nbytes(t_f32) > _storage_nbytes(t_bf16)
+
+    def test_shape_independent_for_views(self):
+        # Storage size should reflect the underlying buffer, not the view.
+        base = torch.empty(100, dtype=torch.float32)
+        view = base.view(10, 10)
+        assert _storage_nbytes(view) == _storage_nbytes(base)
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolConformance:
+    def test_gms_backend_implements_protocol(self):
+        # GMSBackend instances must satisfy the runtime-checkable
+        # GPUMemoryBackend protocol.
+        backend = GMSBackend(socket_path="/tmp/gms.sock", mapping=MagicMock())
+        assert isinstance(backend, GPUMemoryBackend)
+
+    def test_protocol_method_set(self):
+        # The protocol must keep the methods that model_loader.py invokes
+        # so a different backend (e.g. CudaIpcBackend) can be plugged in.
+        required = {
+            "connect",
+            "is_rw",
+            "has_committed_weights",
+            "mem_pool_scope",
+            "materialize_module",
+            "finalize_write",
+            "move_untracked_params",
+            "cleanup",
+        }
+        for method in required:
+            assert hasattr(GPUMemoryBackend, method), (
+                f"GPUMemoryBackend protocol missing method: {method}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake gpu_memory_service modules and import blockers
+# ---------------------------------------------------------------------------
+
+
+_GMS_MODULE_NAMES = [
+    "gpu_memory_service",
+    "gpu_memory_service.client",
+    "gpu_memory_service.client.torch",
+    "gpu_memory_service.client.torch.allocator",
+    "gpu_memory_service.common",
+    "gpu_memory_service.common.locks",
+    "gpu_memory_service.common.utils",
+    "gpu_memory_service.integrations",
+    "gpu_memory_service.integrations.common",
+    "gpu_memory_service.integrations.common.patches",
+]
+
+
+@contextmanager
+def _block_gms():
+    """Context manager that makes ``import gpu_memory_service.*`` raise."""
+    saved = {name: sys.modules.get(name) for name in _GMS_MODULE_NAMES}
+    try:
+        for name in _GMS_MODULE_NAMES:
+            sys.modules[name] = None  # forces ImportError on import
+        yield
+    finally:
+        for name, prior in saved.items():
+            if prior is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prior
+
+
+def _build_fake_gms_lock_failure(*, error):
+    """Build a fake gpu_memory_service whose factory raises on call."""
+    fake_pkg = MagicMock(name="gpu_memory_service")
+    fake_pkg.client = MagicMock(name="gpu_memory_service.client")
+    fake_pkg.client.torch = MagicMock(name="gpu_memory_service.client.torch")
+    fake_pkg.client.torch.allocator = MagicMock(name="gpu_memory_service.client.torch.allocator")
+    fake_pkg.client.torch.allocator.get_or_create_gms_client_memory_manager = MagicMock(
+        side_effect=error
+    )
+
+    # Lock-type and util modules
+    fake_pkg.common = MagicMock()
+    fake_pkg.common.locks = MagicMock()
+    fake_pkg.common.locks.RequestedLockType = MagicMock(RW="rw", RO="ro", RW_OR_RO="rw_or_ro")
+    fake_pkg.common.locks.GrantedLockType = MagicMock(RW="rw", RO="ro")
+    fake_pkg.common.utils = MagicMock()
+    fake_pkg.common.utils.get_socket_path = MagicMock(return_value="/tmp/fake.sock")
+
+    # patch_empty_cache stub
+    fake_pkg.integrations = MagicMock()
+    fake_pkg.integrations.common = MagicMock()
+    fake_pkg.integrations.common.patches = MagicMock()
+    fake_pkg.integrations.common.patches.patch_empty_cache = MagicMock()
+    return fake_pkg
+
+
+@contextmanager
+def _install_fake_gms(fake_pkg):
+    """Install a fake ``gpu_memory_service`` tree into ``sys.modules``."""
+    saved = {name: sys.modules.get(name) for name in _GMS_MODULE_NAMES}
+    try:
+        sys.modules["gpu_memory_service"] = fake_pkg
+        sys.modules["gpu_memory_service.client"] = fake_pkg.client
+        sys.modules["gpu_memory_service.client.torch"] = fake_pkg.client.torch
+        sys.modules["gpu_memory_service.client.torch.allocator"] = fake_pkg.client.torch.allocator
+        sys.modules["gpu_memory_service.common"] = fake_pkg.common
+        sys.modules["gpu_memory_service.common.locks"] = fake_pkg.common.locks
+        sys.modules["gpu_memory_service.common.utils"] = fake_pkg.common.utils
+        sys.modules["gpu_memory_service.integrations"] = fake_pkg.integrations
+        sys.modules["gpu_memory_service.integrations.common"] = fake_pkg.integrations.common
+        sys.modules["gpu_memory_service.integrations.common.patches"] = (
+            fake_pkg.integrations.common.patches
+        )
+        yield
+    finally:
+        for name, prior in saved.items():
+            if prior is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prior

--- a/tests/unittest/_torch/memory/test_gms_backend.py
+++ b/tests/unittest/_torch/memory/test_gms_backend.py
@@ -18,6 +18,13 @@ single ``torch.cuda.current_device()`` call to record the device index.
 We monkeypatch that to a fixed integer for the whole module so every
 control-path test (construction, pre-connect, connect-failure, RW/RO
 gating, protocol conformance) runs on CPU CI without a GPU.
+
+TODO(GMS-RESTART-E2E): an end-to-end "restart-after-death with weights
+resident in GMS" smoke test is the right precursor to shadow-engine
+failover work — it validates KV-cache memory accounting on the
+restarted worker. Lives in a separate GPU + daemon test suite, not
+here. Tracked as a follow-up PR; see PR #13926 review thread
+(galletas1712) and §06 of the failover design doc.
 """
 
 import sys

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -43,12 +43,12 @@ class TestConstruction:
     def test_no_args_constructs(self):
         loader = MXCheckpointLoader()
         assert loader.mx_server_url is None
-        assert loader.p2p_succeeded is False
+        assert loader.is_weights_preloaded() is False
 
     def test_mx_server_url_stored(self):
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         assert loader.mx_server_url == "http://mx:8001"
-        assert loader.p2p_succeeded is False
+        assert loader.is_weights_preloaded() is False
 
     def test_query_timeout_stored(self):
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001", query_timeout_s=900)
@@ -72,9 +72,9 @@ class TestConstruction:
         loader = MXCheckpointLoader()
         assert loader._checkpoint_format == "MX"
 
-    def test_p2p_succeeded_property_initial(self):
+    def test_is_weights_preloaded_initial(self):
         loader = MXCheckpointLoader()
-        assert loader.p2p_succeeded is False
+        assert loader.is_weights_preloaded() is False
 
 
 # ---------------------------------------------------------------------------
@@ -123,7 +123,7 @@ class TestLoadWeightsFallback:
     """Disk-fallback paths that should not touch the upstream MX library.
 
     All four fallback triggers share the same observable contract:
-    ``p2p_succeeded`` stays False, the parent ``HfCheckpointLoader.
+    ``is_weights_preloaded()`` stays False, the parent ``HfCheckpointLoader.
     load_weights`` is invoked exactly once, and its return value is
     propagated unchanged. We parameterize the trigger to keep that
     contract in one place.
@@ -157,6 +157,12 @@ class TestLoadWeightsFallback:
             ("modelexpress_not_installed", _modelexpress_unavailable),
             ("upstream_raises", _upstream_raises),
         ],
+        ids=[
+            "no-mx-server-url",
+            "no-model-kwarg",
+            "modelexpress-not-installed",
+            "upstream-raises",
+        ],
     )
     def test_falls_back_to_disk(self, trigger_id, setup):
         sentinel = {"disk-load": "result"}
@@ -172,8 +178,8 @@ class TestLoadWeightsFallback:
             f"trigger={trigger_id}: production code must propagate the "
             "parent loader's return value unchanged"
         )
-        assert loader.p2p_succeeded is False, (
-            f"trigger={trigger_id}: p2p_succeeded must stay False on any fallback path"
+        assert loader.is_weights_preloaded() is False, (
+            f"trigger={trigger_id}: is_weights_preloaded() must stay False on any fallback path"
         )
         mock_super_load.assert_called_once()
 
@@ -186,8 +192,9 @@ class TestLoadWeightsFallback:
 class TestLoadWeightsMxPath:
     def test_p2p_full_success_returns_empty_dict(self):
         # Empty fallback dict means MX delivered all weights into model
-        # params; ``ModelLoader`` interprets the empty dict + p2p_succeeded
-        # flag as "skip the standard weight-mapping pipeline".
+        # params; ``ModelLoader`` interprets the empty dict + the
+        # ``is_weights_preloaded()`` signal as "skip the standard
+        # weight-mapping pipeline".
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         fake_mx = _build_fake_modelexpress(load_weights_return={})
         mapping = MagicMock(name="mapping")
@@ -197,7 +204,7 @@ class TestLoadWeightsMxPath:
             result = loader.load_weights("/nonexistent", mapping=mapping, model=model)
 
         assert result == {}
-        assert loader.p2p_succeeded is True
+        assert loader.is_weights_preloaded() is True
 
         # Verify the integration contract with the upstream library:
         # 1. Constructed MxLiveWeightLoader with our mx_server_url.
@@ -224,7 +231,7 @@ class TestLoadWeightsMxPath:
         ):
             result = loader.load_weights("/nonexistent", mapping=MagicMock(), model=MagicMock())
 
-        assert loader.p2p_succeeded is True
+        assert loader.is_weights_preloaded() is True
         assert result is fallback
         mock_super_load.assert_not_called()
 
@@ -515,6 +522,16 @@ class TestNormalizeModelIdentity:
             ("home_expansion", "~/models/my-model", "my-model"),
             # Empty / sentinel.
             ("empty", "", "unknown"),
+        ],
+        ids=[
+            "bare-name",
+            "hub-id",
+            "nested-hub-id",
+            "abs-path-simple",
+            "abs-path-nested",
+            "dot-relative",
+            "home-expansion",
+            "empty",
         ],
     )
     def test_basic_cases(self, label, value, expected):

--- a/tests/unittest/_torch/pyexecutor/test_model_loader_gms.py
+++ b/tests/unittest/_torch/pyexecutor/test_model_loader_gms.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for GMS-specific branches in ``ModelLoader``."""
+
+from contextlib import contextmanager, nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from torch import nn
+
+from tensorrt_llm._torch import memory as memory_mod
+from tensorrt_llm._torch.pyexecutor import model_loader as model_loader_mod
+from tensorrt_llm._torch.pyexecutor.model_loader import ModelLoader
+from tensorrt_llm.llmapi.llm_args import LoadFormat
+
+
+class _TinyModel(nn.Module):
+    def __init__(self, events, *, include_draft=False):
+        super().__init__()
+        self._events = events
+        if include_draft:
+            self.draft_model = nn.Module()
+
+    def _apply(self, fn):
+        self._events.append("_apply")
+        return self
+
+    def to(self, *args, **kwargs):
+        self._events.append("to")
+        return self
+
+    def load_weights(self, weights, mapper):
+        self._events.append("load_weights")
+
+    def post_load_weights(self):
+        self._events.append("post_load_weights")
+
+
+@contextmanager
+def _moe_context(config, mapping):
+    yield None
+
+
+@contextmanager
+def _pool_scope(events):
+    events.append("pool_enter")
+    yield
+    events.append("pool_exit")
+
+
+def _make_loader(monkeypatch, *, events, spec_config=None):
+    llm_args = SimpleNamespace(
+        load_format=LoadFormat.GMS,
+        gms_config=SimpleNamespace(socket_path="/tmp/gms.sock", mode="auto", tag="weights"),
+    )
+    loader = ModelLoader(
+        llm_args=llm_args,
+        mapping=MagicMock(name="mapping"),
+        spec_config=spec_config,
+        sparse_attention_config=None,
+        max_num_tokens=128,
+        max_seq_len=128,
+    )
+    loader._call_load_weights = MagicMock(
+        side_effect=lambda fn, weights, mapper, **kwargs: fn(weights, mapper)
+    )
+    loader._load_and_validate_config = MagicMock(return_value=SimpleNamespace(name="config"))
+
+    monkeypatch.setattr(model_loader_mod, "timing", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(model_loader_mod, "maybe_create_moe_load_balancer", _moe_context)
+    monkeypatch.setattr(model_loader_mod, "MetaInitMode", lambda: nullcontext())
+    monkeypatch.setattr(
+        model_loader_mod.AutoModelForCausalLM,
+        "from_config",
+        MagicMock(return_value=_TinyModel(events, include_draft=spec_config is not None)),
+    )
+    monkeypatch.setattr(model_loader_mod, "get_rank_model_storage", lambda _model: 0)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(
+        torch.cuda,
+        "current_stream",
+        lambda: SimpleNamespace(synchronize=lambda: None),
+    )
+    return loader
+
+
+def _build_gms_backend(*, is_rw, events):
+    backend = MagicMock()
+    backend.connect.return_value = True
+    backend.is_rw = is_rw
+    if is_rw:
+        backend.mem_pool_scope.side_effect = lambda _device: _pool_scope(events)
+    else:
+
+        def _materialize(_model):
+            events.append("materialize")
+
+        backend.materialize_module.side_effect = _materialize
+    return backend
+
+
+def _install_gms_backend(monkeypatch, backend):
+    monkeypatch.setattr(memory_mod, "GMSBackend", MagicMock(return_value=backend))
+
+
+def _spec_config_needing_draft_weights():
+    return SimpleNamespace(
+        spec_dec_mode=SimpleNamespace(need_load_draft_weights=lambda: True),
+        speculative_model="/draft",
+    )
+
+
+@pytest.mark.parametrize(
+    "is_rw, expected_events",
+    [
+        pytest.param(
+            True,
+            ["pool_enter", "load_weights", "pool_exit", "post_load_weights"],
+            id="rw",
+        ),
+        pytest.param(
+            False,
+            ["post_load_weights", "materialize"],
+            id="ro",
+        ),
+    ],
+)
+def test_gms_load_branch(monkeypatch, is_rw, expected_events):
+    """Verify ``ModelLoader.load`` dispatches correctly per GMS lock mode.
+
+    Cases:
+        rw: the writer loads weights under the GMS memory pool, runs them
+            through the standard mapping pipeline, then commits the
+            populated pool for read-only consumers.
+        ro: the reader runs ``post_load_weights`` to wire module aliases
+            first, then GMS materializes weights via zero-copy mapping.
+    """
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+    backend = _build_gms_backend(is_rw=is_rw, events=events)
+    _install_gms_backend(monkeypatch, backend)
+
+    checkpoint_loader = MagicMock(name="checkpoint_loader")
+    checkpoint_loader.checkpoint_format = "HF"
+    if is_rw:
+        # RW path: the checkpoint loader's returned weights flow into the
+        # standard model.load_weights mapping pipeline.
+        checkpoint_loader.load_weights.return_value = {"weight": MagicMock()}
+
+    model, _ = loader.load("/ckpt", checkpoint_loader)
+
+    assert loader._gms_backend is backend
+    assert events == expected_events
+    if is_rw:
+        # RW: load weights, run them through the mapper, then commit
+        # everything that landed in the GMS pool for RO consumers.
+        checkpoint_loader.load_weights.assert_called_once_with("/ckpt", mapping=loader.mapping)
+        loader._call_load_weights.assert_called_once()
+        backend.move_untracked_params.assert_called_once_with(model)
+        backend.finalize_write.assert_called_once_with(model)
+    else:
+        # RO: post_load_weights() must run before the GMS materialize
+        # step so module aliases are wired up before zero-copy mapping.
+        checkpoint_loader.load_weights.assert_not_called()
+        loader._call_load_weights.assert_not_called()
+        backend.materialize_module.assert_called_once_with(model)
+
+
+def test_gms_rw_loader_preload_skips_mapping_pipeline(monkeypatch):
+    """RW + empty ``weights`` + ``is_weights_preloaded()=True`` is legitimate.
+
+    Mirrors the MX P2P preload scenario, where the checkpoint loader
+    writes weights directly into model parameters and signals the
+    preloaded state. ``ModelLoader`` must skip the standard mapping
+    pipeline and still commit the populated pool for RO peers.
+    """
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+    backend = _build_gms_backend(is_rw=True, events=events)
+    _install_gms_backend(monkeypatch, backend)
+
+    checkpoint_loader = MagicMock(name="checkpoint_loader")
+    checkpoint_loader.checkpoint_format = "MX"
+    checkpoint_loader.load_weights.return_value = {}
+    checkpoint_loader.is_weights_preloaded.return_value = True
+
+    model, _ = loader.load("/ckpt", checkpoint_loader)
+
+    loader._call_load_weights.assert_not_called()
+    backend.move_untracked_params.assert_called_once_with(model)
+    backend.finalize_write.assert_called_once_with(model)
+
+
+def test_gms_rw_no_load_and_no_preload_raises(monkeypatch):
+    """RW + empty ``weights`` + ``is_weights_preloaded()=False`` is a bug.
+
+    Without weights and without a loader-driven preload, the model is
+    not populated. Committing it to GMS would expose an uninitialized
+    layout to RO peers, so ``ModelLoader`` must raise.
+    """
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+    backend = _build_gms_backend(is_rw=True, events=events)
+    _install_gms_backend(monkeypatch, backend)
+
+    checkpoint_loader = MagicMock(name="checkpoint_loader")
+    checkpoint_loader.checkpoint_format = "HF"
+    checkpoint_loader.load_weights.return_value = {}
+    checkpoint_loader.is_weights_preloaded.return_value = False
+
+    with pytest.raises(RuntimeError, match="Refusing to commit an unpopulated model"):
+        loader.load("/ckpt", checkpoint_loader)
+
+    # Pool was opened, but nothing must be committed.
+    backend.finalize_write.assert_not_called()
+    backend.cleanup.assert_called_once()
+    assert loader._gms_backend is None
+
+
+def test_gms_rw_exception_during_weight_mapping_cleans_up(monkeypatch):
+    """A writer error after pool population must release the GMS session."""
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+    loader._call_load_weights.side_effect = RuntimeError("mapping failed")
+    backend = _build_gms_backend(is_rw=True, events=events)
+    _install_gms_backend(monkeypatch, backend)
+
+    checkpoint_loader = MagicMock(name="checkpoint_loader")
+    checkpoint_loader.checkpoint_format = "HF"
+    checkpoint_loader.load_weights.return_value = {"weight": MagicMock()}
+
+    with pytest.raises(RuntimeError, match="mapping failed"):
+        loader.load("/ckpt", checkpoint_loader)
+
+    backend.cleanup.assert_called_once()
+    backend.finalize_write.assert_not_called()
+    assert loader._gms_backend is None
+
+
+def test_gms_ro_with_spec_config_materializes_full_model_tree(monkeypatch):
+    """RO materialization receives the root model, including draft_model."""
+    events = []
+    loader = _make_loader(
+        monkeypatch,
+        events=events,
+        spec_config=_spec_config_needing_draft_weights(),
+    )
+    backend = _build_gms_backend(is_rw=False, events=events)
+    _install_gms_backend(monkeypatch, backend)
+
+    checkpoint_loader = MagicMock(name="checkpoint_loader")
+    checkpoint_loader.checkpoint_format = "HF"
+
+    model, _ = loader.load("/ckpt", checkpoint_loader)
+
+    assert hasattr(model, "draft_model")
+    backend.materialize_module.assert_called_once_with(model)
+    checkpoint_loader.load_weights.assert_not_called()
+
+
+def test_gms_connect_failure_raises(monkeypatch):
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+
+    backend = MagicMock()
+    backend.connect.return_value = False
+    monkeypatch.setattr(memory_mod, "GMSBackend", MagicMock(return_value=backend))
+
+    checkpoint_loader = MagicMock(name="checkpoint_loader")
+    checkpoint_loader.checkpoint_format = "HF"
+
+    with pytest.raises(RuntimeError, match="Failed to connect to GMS"):
+        loader.load("/ckpt", checkpoint_loader)
+
+
+def test_gms_unexpected_lock_state_raises(monkeypatch):
+    """``is_rw`` must be True or False after a successful connect.
+
+    A None value indicates an adapter bug or protocol violation; the
+    loader should fail loudly rather than silently take the RO path.
+    """
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+
+    backend = MagicMock()
+    backend.connect.return_value = True
+    backend.is_rw = None  # Adapter bug: connected but lock state unset.
+    monkeypatch.setattr(memory_mod, "GMSBackend", MagicMock(return_value=backend))
+
+    checkpoint_loader = MagicMock(name="checkpoint_loader")
+    checkpoint_loader.checkpoint_format = "HF"
+
+    with pytest.raises(RuntimeError, match="lock state is unset"):
+        loader.load("/ckpt", checkpoint_loader)
+
+    # Neither branch should have run; nothing was written to the model.
+    backend.mem_pool_scope.assert_not_called()
+    backend.finalize_write.assert_not_called()
+    backend.materialize_module.assert_not_called()
+    checkpoint_loader.load_weights.assert_not_called()

--- a/tests/unittest/_torch/pyexecutor/test_model_loader_gms.py
+++ b/tests/unittest/_torch/pyexecutor/test_model_loader_gms.py
@@ -117,7 +117,14 @@ def _spec_config_needing_draft_weights():
     [
         pytest.param(
             True,
-            ["pool_enter", "load_weights", "pool_exit", "post_load_weights"],
+            [
+                "pool_enter",
+                "_apply",
+                "to",
+                "load_weights",
+                "post_load_weights",
+                "pool_exit",
+            ],
             id="rw",
         ),
         pytest.param(
@@ -131,9 +138,11 @@ def test_gms_load_branch(monkeypatch, is_rw, expected_events):
     """Verify ``ModelLoader.load`` dispatches correctly per GMS lock mode.
 
     Cases:
-        rw: the writer loads weights under the GMS memory pool, runs them
-            through the standard mapping pipeline, then commits the
-            populated pool for read-only consumers.
+        rw: the writer opens the GMS pool BEFORE meta-tensor materialization
+            and ``model.to('cuda')``, runs the entire model bring-up
+            (``_apply`` for meta materialization, ``to('cuda')``, weight
+            load, ``post_load_weights``) inside the pool, then commits via
+            ``finalize_write`` once the scope exits.
         ro: the reader runs ``post_load_weights`` to wire module aliases
             first, then GMS materializes weights via zero-copy mapping.
     """
@@ -166,6 +175,72 @@ def test_gms_load_branch(monkeypatch, is_rw, expected_events):
         checkpoint_loader.load_weights.assert_not_called()
         loader._call_load_weights.assert_not_called()
         backend.materialize_module.assert_called_once_with(model)
+
+
+def test_gms_rw_post_load_runs_inside_pool_before_finalize(monkeypatch):
+    """Every step that may allocate or rebind tensors must run inside the GMS pool.
+
+    The widened ``mem_pool_scope`` covers meta-tensor materialization,
+    ``model.to('cuda')``, weight load, and the post_load_* hooks. Only
+    ``finalize_write`` runs after the pool closes, so the committed
+    layout reflects the post-post_load model. Asserts the exact ordering
+    so a future refactor cannot silently re-narrow the scope.
+    """
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+    backend = _build_gms_backend(is_rw=True, events=events)
+
+    backend.move_untracked_params.side_effect = lambda _model: events.append(
+        "move_untracked_params"
+    )
+    backend.finalize_write.side_effect = lambda _model: events.append("finalize_write")
+    _install_gms_backend(monkeypatch, backend)
+
+    checkpoint_loader = MagicMock(name="checkpoint_loader")
+    checkpoint_loader.checkpoint_format = "HF"
+    checkpoint_loader.load_weights.return_value = {"weight": MagicMock()}
+    checkpoint_loader.post_load_apply.side_effect = lambda *_a, **_kw: events.append(
+        "post_load_apply"
+    )
+    checkpoint_loader.post_load_publish.side_effect = lambda *_a, **_kw: events.append(
+        "post_load_publish"
+    )
+
+    loader.load("/ckpt", checkpoint_loader)
+
+    assert events == [
+        "pool_enter",
+        "_apply",
+        "to",
+        "load_weights",
+        "post_load_apply",
+        "post_load_publish",
+        "post_load_weights",
+        "move_untracked_params",
+        "pool_exit",
+        "finalize_write",
+    ]
+
+    # Belt-and-braces: inside the events list, every "interesting" step
+    # must sit between pool_enter and pool_exit, with finalize_write the
+    # only thing strictly after.
+    enter_idx = events.index("pool_enter")
+    exit_idx = events.index("pool_exit")
+    finalize_idx = events.index("finalize_write")
+    assert finalize_idx > exit_idx, "finalize_write must follow pool exit"
+    for inside in (
+        "_apply",
+        "to",
+        "load_weights",
+        "post_load_apply",
+        "post_load_publish",
+        "post_load_weights",
+        "move_untracked_params",
+    ):
+        idx = events.index(inside)
+        assert enter_idx < idx < exit_idx, (
+            f"{inside!r} (idx={idx}) must run inside the pool (enter={enter_idx}, exit={exit_idx})"
+        )
 
 
 def test_gms_rw_loader_preload_skips_mapping_pipeline(monkeypatch):

--- a/tests/unittest/_torch/pyexecutor/test_model_loader_gms.py
+++ b/tests/unittest/_torch/pyexecutor/test_model_loader_gms.py
@@ -165,7 +165,12 @@ def test_gms_load_branch(monkeypatch, is_rw, expected_events):
     if is_rw:
         # RW: load weights, run them through the mapper, then commit
         # everything that landed in the GMS pool for RO consumers.
-        checkpoint_loader.load_weights.assert_called_once_with("/ckpt", mapping=loader.mapping)
+        # ``model=model`` is passed for symmetry with the LoadFormat.AUTO
+        # path (see model_loader.py); HF ignores it, MX uses it for direct
+        # P2P writes when MX+GMS composition eventually lands.
+        checkpoint_loader.load_weights.assert_called_once_with(
+            "/ckpt", mapping=loader.mapping, model=model
+        )
         loader._call_load_weights.assert_called_once()
         backend.move_untracked_params.assert_called_once_with(model)
         backend.finalize_write.assert_called_once_with(model)

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -103,6 +103,10 @@ methods:
         annotation: tensorrt_llm.llmapi.llm_args.ModelExpressConfig
         default: null
         status: prototype
+      gms_config:
+        annotation: tensorrt_llm.llmapi.llm_args.GmsConfig
+        default: null
+        status: prototype
       mm_encoder_only:
         annotation: bool
         default: False

--- a/tests/unittest/llmapi/test_gms_args.py
+++ b/tests/unittest/llmapi/test_gms_args.py
@@ -70,7 +70,12 @@ class TestGmsConfigValidation:
         ],
     )
     def test_rejects_unknown_mode(self, bad_mode):
-        with pytest.raises(ValueError, match="gms_config.mode"):
+        # GmsConfig.mode is typed as Literal["auto", "rw", "ro"], so Pydantic
+        # rejects bad values at field validation with its stable literal_error
+        # template. Match on the rendered allowed-values list rather than the
+        # field path so the assertion is robust across Pydantic 2.x error
+        # path-formatting differences (dot vs arrow).
+        with pytest.raises(ValueError, match=r"Input should be 'auto', 'rw' or 'ro'"):
             _make_args(gms_config={"mode": bad_mode})
 
     @pytest.mark.parametrize(

--- a/tests/unittest/llmapi/test_gms_args.py
+++ b/tests/unittest/llmapi/test_gms_args.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Unit tests for GMS prototype config fields on ``TorchLlmArgs``."""
+
+from unittest.mock import patch
+
+import pytest
+
+from tensorrt_llm.llmapi.llm_args import LoadFormat, TorchLlmArgs
+
+_LOGGER_PATH = "tensorrt_llm.llmapi.llm_args.logger"
+_DUMMY_MODEL = "/tmp/test-gms-args-nonexistent"
+
+
+def _capture_warnings(call_args_list):
+    """Flatten captured ``logger.warning(fmt, *args)`` calls into strings."""
+    rendered = []
+    for call in call_args_list:
+        args, _kwargs = call
+        if not args:
+            continue
+        fmt, *fmt_args = args
+        try:
+            rendered.append(fmt % tuple(fmt_args) if fmt_args else fmt)
+        except (TypeError, ValueError):
+            rendered.append(str(args))
+    return rendered
+
+
+def _warnings_for(keyword: str, call_args_list) -> list[str]:
+    """Return only captured warnings whose rendered text mentions keyword."""
+    return [m for m in _capture_warnings(call_args_list) if keyword in m]
+
+
+def _make_args(**overrides) -> TorchLlmArgs:
+    """Construct a ``TorchLlmArgs`` with the given overrides."""
+    return TorchLlmArgs(model=_DUMMY_MODEL, **overrides)
+
+
+class TestGmsConfigDefaults:
+    def test_defaults(self):
+        args = _make_args()
+        assert args.gms_config.socket_path is None
+        assert args.gms_config.mode == "auto"
+        assert args.gms_config.tag == "weights"
+
+
+class TestGmsConfigValidation:
+    @pytest.mark.parametrize("mode", ["auto", "rw", "ro"], ids=["auto", "rw", "ro"])
+    def test_accepts_known_modes(self, mode):
+        args = _make_args(load_format=LoadFormat.GMS, gms_config={"mode": mode})
+        assert args.gms_config.mode == mode
+
+    @pytest.mark.parametrize(
+        "bad_mode",
+        ["", "AUTO", "Rw", "read", "write", "shadow"],
+        ids=[
+            "empty",
+            "uppercase-auto",
+            "mixedcase-rw",
+            "read",
+            "write",
+            "shadow",
+        ],
+    )
+    def test_rejects_unknown_mode(self, bad_mode):
+        with pytest.raises(ValueError, match="gms_config.mode"):
+            _make_args(gms_config={"mode": bad_mode})
+
+    @pytest.mark.parametrize(
+        "bad_tag",
+        ["", " ", "\t", "\n", "   \t  "],
+        ids=["empty", "space", "tab", "newline", "mixed-whitespace"],
+    )
+    def test_rejects_empty_or_whitespace_tag(self, bad_tag):
+        with pytest.raises(ValueError, match="gms_config.tag must be a non-empty"):
+            _make_args(gms_config={"tag": bad_tag})
+
+    def test_accepts_custom_non_empty_tag(self):
+        args = _make_args(load_format=LoadFormat.GMS, gms_config={"tag": "custom"})
+        assert args.gms_config.tag == "custom"
+
+
+class TestGmsCrossFieldWarning:
+    @pytest.mark.parametrize(
+        "load_format, gms_config, expect_warning",
+        [
+            pytest.param(
+                LoadFormat.GMS, {"socket_path": "/tmp/gms.sock"}, False, id="gms-active-no-warning"
+            ),
+            pytest.param(
+                LoadFormat.AUTO,
+                {"socket_path": "/tmp/gms.sock"},
+                True,
+                id="socket-path-without-gms",
+            ),
+            pytest.param(LoadFormat.AUTO, {"mode": "rw"}, True, id="mode-without-gms"),
+            pytest.param(LoadFormat.AUTO, {"tag": "custom"}, True, id="tag-without-gms"),
+        ],
+    )
+    def test_non_default_config_warns_when_gms_inactive(
+        self, load_format, gms_config, expect_warning
+    ):
+        with patch(_LOGGER_PATH) as mock_logger:
+            args = _make_args(load_format=load_format, gms_config=gms_config)
+
+        for key, value in gms_config.items():
+            assert getattr(args.gms_config, key) == value
+        relevant = _warnings_for("gms_config", mock_logger.warning.call_args_list)
+        if expect_warning:
+            assert relevant, "expected a warning about ignored gms_config"
+        else:
+            assert relevant == []
+
+
+class TestLoadFormatGms:
+    def test_gms_enum_present(self):
+        assert LoadFormat.GMS.name == "GMS"
+        assert LoadFormat.GMS.value == 3
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            pytest.param("GMS", LoadFormat.GMS, id="uppercase-string"),
+            pytest.param("gms", LoadFormat.GMS, id="lowercase-string"),
+            pytest.param(3, LoadFormat.GMS, id="enum-int"),
+        ],
+    )
+    def test_gms_load_format_conversion(self, raw, expected):
+        args = _make_args(load_format=raw)
+        assert args.load_format == expected
+
+    def test_gms_only_two_axis_defaults(self):
+        args = _make_args(load_format=LoadFormat.GMS)
+        assert args.checkpoint_format == "HF"
+        assert args.load_format == LoadFormat.GMS


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GPU Memory Service (GMS) support for model loading and memory management with configurable socket path, mode, and weight tag options.
  * Introduced `LoadFormat.GMS` configuration option for GPU memory backend integration.

* **Improvements**
  * Added `is_weights_preloaded()` method to check weight preload status during model initialization.
  * Enhanced resource cleanup for model engines with idempotent, deterministic teardown.
  * Implemented configuration validation to prevent incompatible GMS and Mixture-of-Experts settings.

* **Tests**
  * Added comprehensive GMS backend and model loader test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/13926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Summary

Adds `LoadFormat.GMS` so multiple TRT-LLM instances on the same node can zero-copy share model weights via the [GPU Memory Service (GMS)](https://github.com/ai-dynamo/dynamo/tree/main/lib/gpu_memory_service) pool. The first instance loads weights as the writer (RW); subsequent peers materialize them read-only (RO) without disk I/O or per-instance copies.

## Scope

In scope:
- `LoadFormat.GMS` enum value and nested `GmsConfig` (`socket_path`, `mode`, `tag`) on `TorchLlmArgs`.
- New `GMSBackend` adapter under `tensorrt_llm/_torch/memory/`, lazily imported only when GMS is selected.
- `ModelLoader` GMS branch with explicit RW / RO / unexpected-state handling, plus a guard that refuses to commit an unpopulated model to the pool.
- Cleanup hook released via `PyTorchModelEngine.__del__`.

Adjacent (sub-PR, ~15 lines): remove the redundant `MXCheckpointLoader.p2p_succeeded` property; `is_weights_preloaded()` (the abstract hook from `BaseCheckpointLoader`) is now the single accessor. Tests updated accordingly.

Out of scope:
- Networking and MX integration (the MX checkpoint format already merged in #13531 composes orthogonally with `LoadFormat.GMS`).
- Packaging the `gpu_memory_service` dependency. Same OSS-allowlist concern as MX; users install it manually for now.


## Test Coverage

New unit test files (mock-based, CPU CI):
- `tests/unittest/llmapi/test_gms_args.py` — `GmsConfig` validation and `LoadFormat.GMS` Pydantic surface.
- `tests/unittest/_torch/memory/test_gms_backend.py` — `GMSBackend` lifecycle and helpers.
- `tests/unittest/_torch/pyexecutor/test_model_loader_gms.py` — `ModelLoader` GMS RW / RO / failure / edge-case branches.

Updated:
- `tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py` — six call sites switched to `is_weights_preloaded()` after removing the redundant `p2p_succeeded` property.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
