### PR TITLE
[None][fix] Run DeepSeek V4 gate test on CUDA

### DIFF
--- a/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
@@ -191,6 +191,10 @@ def test_deepseek_v4_gate_bias_maps_to_score_correction_bias():
 
 
 def test_deepseek_v4_gate_uses_fp32_reference_linear():
+    if not torch.cuda.is_available():
+        pytest.skip("dsv3_router_gemm_op requires CUDA")
+
+    device = torch.device("cuda")
     gate = DeepseekV4Gate(
         hidden_size=4,
         num_experts=3,
@@ -201,11 +205,12 @@ def test_deepseek_v4_gate_uses_fp32_reference_linear():
         is_hashed=False,
         dtype=torch.bfloat16,
         moe_backend="TRTLLM",
-    )
-    hidden_states = torch.tensor([[1.0, -2.0, 3.0, -4.0]], dtype=torch.bfloat16)
+    ).to(device)
+    hidden_states = torch.tensor([[1.0, -2.0, 3.0, -4.0]], dtype=torch.bfloat16, device=device)
     weight = torch.tensor(
         [[1.0, 2.0, 3.0, 4.0], [-1.0, 1.0, -1.0, 1.0], [0.5, -0.5, 0.25, -0.25]],
         dtype=torch.bfloat16,
+        device=device,
     )
     gate.weight.copy_(weight)
 


### PR DESCRIPTION
@coderabbitai summary

## Description

The DeepSeek V4 gate unit test was added to the multi-GPU CI test list, where it exposed that `test_deepseek_v4_gate_uses_fp32_reference_linear` constructed the gate and input tensors on CPU.

`DeepseekV4Gate.forward()` calls `trtllm::dsv3_router_gemm_op`, which is a CUDA-only custom op. This caused the B200 multi-GPU stage to fail with a CPU backend dispatch error.

This PR updates the test to run the gate, hidden states, and reference weights on CUDA, and skips the test when CUDA is unavailable.

## Test Coverage

- `python3 -m pytest -q tests/unittest/_torch/modeling/test_modeling_deepseekv4.py::test_deepseek_v4_gate_uses_fp32_reference_linear`
- `python3 -m pytest -q tests/unittest/_torch/modeling/test_modeling_deepseekv4.py`
- `pre-commit run --files tests/unittest/_torch/modeling/test_modeling_deepseekv4.py`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.