### PR TITLE
[None][test] Add checkpoint_format / load_format keys to test_features_contract

### DIFF
--- a/tests/unittest/llmapi/test_features_contract.py
+++ b/tests/unittest/llmapi/test_features_contract.py
@@ -152,4 +152,6 @@ def test_all_features_enabled_real_configs():
         "cuda_graphs": True,
         "chunked_context": True,
         "data_parallel_size": 8,
+        "checkpoint_format": "HF",
+        "load_format": "AUTO",
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced telemetry contract test to verify additional feature payload fields with their default values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/13933)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Summary

Refresh `test_features_contract.test_all_features_enabled_real_configs` to match the post-#13531 telemetry payload. The MX-only PR added `checkpoint_format` and `load_format` to `usage_lib._FEATURES_DEFAULTS` and updated `test_llm_telemetry` to derive expected keys dynamically, but missed this hardcoded expected dict — so the test has been failing on every fresh checkout of `main` ever since.

This change adds the two missing keys to the expected payload with their default values (`HF` / `AUTO`, since the test doesn't override either field). No production code changes.

## Test Plan

- [x] `pytest tests/unittest/llmapi/test_features_contract.py` — 22/22 pass locally.

## Related

- #13531 (MX-only) — landed the new telemetry keys.
- #13926 (GMS-only) — current open PR; test was discovered failing during its smoke testing.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
