### PR TITLE
[None][fix] Clamp max_num_tokens early so autotune sees the clamped value

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1535,15 +1535,12 @@ class PyTorchModelEngine(ModelEngine):
         return default_max_seq_len
 
     def _init_max_num_tokens(self):
-        # Modified from tensorrt_llm/_common.py check_max_num_tokens
+        # The user-facing clamp `max_num_tokens <= max_seq_len * max_batch_size`
+        # is now performed in `BaseLlmArgs.validate_runtime_args`, so by the
+        # time we get here `self.max_num_tokens` is already clamped whenever
+        # `max_seq_len` was set explicitly. We keep this fallback for the case
+        # where `max_num_tokens` was not provided at all.
         if self.max_num_tokens is None:
-            self.max_num_tokens = self.max_seq_len * self.batch_size
-        if self.max_num_tokens > self.max_seq_len * self.batch_size:
-            logger.warning(
-                f"max_num_tokens ({self.max_num_tokens}) shouldn't be greater than "
-                f"max_seq_len * max_batch_size ({self.max_seq_len * self.batch_size}), "
-                f"specifying to max_seq_len * max_batch_size ({self.max_seq_len * self.batch_size})."
-            )
             self.max_num_tokens = self.max_seq_len * self.batch_size
 
     def _init_model_capacity(self):

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3153,6 +3153,22 @@ class BaseLlmArgs(StrictBaseModel):
                 logger.warning(
                     f"max_batch_size [{self.max_batch_size}] should be less than or equal to max_num_tokens [{self.max_num_tokens}]"
                 )
+        # Clamp max_num_tokens to max_seq_len * max_batch_size so that the
+        # capped value is visible to all downstream consumers (e.g. the
+        # autotuner-facing chunk_size in AttentionRuntimeFeatures and the
+        # max_num_tokens that flows into ModelConfig and the MoE communication
+        # workspace). Otherwise PyTorchModelEngine would only clamp its own
+        # self.max_num_tokens after ModelLoader and AttentionRuntimeFeatures
+        # had already been built from the un-clamped value.
+        if (self.max_num_tokens is not None and self.max_seq_len is not None
+                and self.max_batch_size is not None):
+            cap = self.max_seq_len * self.max_batch_size
+            if self.max_num_tokens > cap:
+                logger.warning(
+                    f"max_num_tokens ({self.max_num_tokens}) shouldn't be greater than "
+                    f"max_seq_len * max_batch_size ({cap}), "
+                    f"specifying to max_seq_len * max_batch_size ({cap}).")
+                self.max_num_tokens = cap
         return self
 
     @model_validator(mode="after")

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -775,6 +775,26 @@ class TestTorchLlmArgs:
             args = TorchLlmArgs(model=llama_model_path)
             args.invalid_arg = 1
 
+    @print_traceback_on_error
+    def test_max_num_tokens_capped_to_max_seq_len_times_max_batch_size(self):
+        # When the user-supplied max_num_tokens is larger than
+        # max_seq_len * max_batch_size, BaseLlmArgs.validate_runtime_args
+        # should cap it so that downstream consumers (chunk_size in
+        # AttentionRuntimeFeatures, model_config.max_num_tokens, MoE
+        # communication workspace, ...) all observe the clamped value.
+        args = TorchLlmArgs(model=llama_model_path,
+                            max_seq_len=8193,
+                            max_batch_size=1,
+                            max_num_tokens=8208)
+        cap = args.max_seq_len * args.max_batch_size
+        assert args.max_num_tokens == cap
+        # get_runtime_sizes() must return the same clamped value.
+        _, max_num_tokens, max_seq_len, max_batch_size = (
+            args.get_runtime_sizes())
+        assert max_num_tokens == cap
+        assert max_seq_len == 8193
+        assert max_batch_size == 1
+
     def test_speculative_model_alias(self):
         spec_config = EagleDecodingConfig(
             max_draft_len=3,


### PR DESCRIPTION
## Summary

When the user specifies `max_num_tokens` larger than `max_seq_len * max_batch_size`, the engine was clamping `self.max_num_tokens` in `PyTorchModelEngine._init_max_num_tokens()`, but only **after** `ModelLoader` and `AttentionRuntimeFeatures` had already been built from the *un-clamped* value. As a result:

- `model_config.max_num_tokens` (which feeds `moe_max_num_tokens = max_num_tokens * dp_size` and the MoE communication workspace, e.g. `NVLinkOneSided.max_num_tokens_per_rank`) was still the un-clamped value.
- `AttentionRuntimeFeatures.chunk_size` (used by the attention autotuner) was still the un-clamped value.

Concretely, with `max_num_tokens=8208`, `max_seq_len=8193`, `max_batch_size=1`, the engine would log `max_num_tokens=8193` while the autotuner-facing `chunk_size` and MoE `max_num_tokens_per_rank` stayed at `8208`.

## Fix

Move the clamp into `BaseLlmArgs.validate_runtime_args` so it runs at config-validation time, before anything else is built. After this, `get_runtime_sizes()`, `py_executor_creator`'s `chunk_size`, the `ModelLoader`, and `PyTorchModelEngine` all observe the clamped `max_num_tokens` consistently.

The existing `_init_max_num_tokens` in `PyTorchModelEngine` is left in place: it is a no-op for the explicit case (already clamped) and still serves the case where `max_seq_len` is `None` at the args level and only inferred from the model after load.

## Test plan
- [ ] `pytest tests/unittest/llmapi/test_llm_args.py::TestTorchLlmArgs::test_max_num_tokens_capped_to_max_seq_len_times_max_batch_size`
- [ ] CI: `/bot run`