### PR TITLE
[None][fix] Account for speculative tokens in KVCacheManagerV2 capacity

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2305,7 +2305,7 @@ class KVCacheManagerV2(BaseResourceManager):
         # Token num upper bound is the maximum number of tokens that can be allocated in the kv cache manager.
         # We need to add extra tokens to the token num upper bound to account for the extra tokens.
         clamped = self.impl.clamp_max_seq_len_for_mem(
-            batch_size, token_num_upper_bound) - extra_tokens
+            batch_size, token_num_upper_bound + extra_tokens) - extra_tokens
         # clamp_max_seq_len_for_mem considers all tiers (GPU + host).  When
         # max_tokens is explicitly set, cap by GPU-only capacity so callers
         # (e.g. CUDA graph warmup) don't exceed the GPU pool.


### PR DESCRIPTION
## Description

Fixes KVCacheManagerV2 capacity accounting for speculative decoding. `get_num_available_tokens()` now passes `token_num_upper_bound + extra_tokens` into `clamp_max_seq_len_for_mem()` before subtracting the speculative extra-token reservation. This keeps an expanded runtime `max_seq_len` from being clamped down by one extra KV token while still reserving capacity for speculative draft and extra KV tokens.

This mirrors the current main branch implementation and avoids future merge conflicts when `feat/deepseek_v4` is merged forward.

## Test Coverage

* `pre-commit run --files tensorrt_llm/_torch/pyexecutor/resource_manager.py`
* Manually verified `tmp/dsv4_bench/dep_dsv4_flash.sh` with `CUDA_LAUNCH_BLOCKING=1 PYTHONPATH=$PWD`; benchmark completed without the previous device-side assert.

## PR Checklist

Please review the following before submitting your PR:

* PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.

* PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.

* Any new dependencies have been scanned for license and vulnerabilities

* [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes

* Documentation updated as needed
* Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.

* The reviewers assigned automatically/manually are appropriate for the PR.

* Please check this after reviewing the above items as appropriate for this PR.
