### PR TITLE
[None][test] Add dsv4 dis-agg module-level unit tests

### DIFF
--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/agentBindings.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/agentBindings.cpp
@@ -214,39 +214,52 @@ NB_MODULE(tensorrt_llm_transfer_agent_binding, m)
         .def_rw("backend_params", &kvc::BaseAgentConfig::backendParams);
 
     // BaseTransferAgent class (abstract base)
+    // All transfer-engine operations release the GIL: they may block on NIXL /
+    // UCX / network / GPU memory pinning, and holding the GIL across them
+    // starves Python listener / progress threads in the same process.
     nb::class_<kvc::BaseTransferAgent>(m, "BaseTransferAgent")
-        .def("register_memory", &kvc::BaseTransferAgent::registerMemory, nb::arg("descs"))
-        .def("deregister_memory", &kvc::BaseTransferAgent::deregisterMemory, nb::arg("descs"))
+        .def("register_memory", &kvc::BaseTransferAgent::registerMemory, nb::arg("descs"),
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("deregister_memory", &kvc::BaseTransferAgent::deregisterMemory, nb::arg("descs"),
+            nb::call_guard<nb::gil_scoped_release>())
         .def("load_remote_agent",
             nb::overload_cast<std::string const&, kvc::AgentDesc const&>(&kvc::BaseTransferAgent::loadRemoteAgent),
-            nb::arg("name"), nb::arg("agent_desc"))
+            nb::arg("name"), nb::arg("agent_desc"), nb::call_guard<nb::gil_scoped_release>())
         .def("load_remote_agent_by_connection",
             nb::overload_cast<std::string const&, kvc::ConnectionInfoType const&>(
                 &kvc::BaseTransferAgent::loadRemoteAgent),
-            nb::arg("name"), nb::arg("connection_info"))
-        .def("get_local_agent_desc", &kvc::BaseTransferAgent::getLocalAgentDesc)
-        .def("invalidate_remote_agent", &kvc::BaseTransferAgent::invalidateRemoteAgent, nb::arg("name"))
+            nb::arg("name"), nb::arg("connection_info"), nb::call_guard<nb::gil_scoped_release>())
+        .def("get_local_agent_desc", &kvc::BaseTransferAgent::getLocalAgentDesc,
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("invalidate_remote_agent", &kvc::BaseTransferAgent::invalidateRemoteAgent, nb::arg("name"),
+            nb::call_guard<nb::gil_scoped_release>())
         .def(
             "submit_transfer_requests",
             [](kvc::BaseTransferAgent& self, kvc::TransferRequest const& request)
             { return self.submitTransferRequests(request).release(); },
-            nb::arg("request"), nb::rv_policy::take_ownership)
-        .def(
-            "notify_sync_message", &kvc::BaseTransferAgent::notifySyncMessage, nb::arg("name"), nb::arg("sync_message"))
-        .def("get_notified_sync_messages", &kvc::BaseTransferAgent::getNotifiedSyncMessages)
-        .def("get_local_connection_info", &kvc::BaseTransferAgent::getLocalConnectionInfo)
-        .def("check_remote_descs", &kvc::BaseTransferAgent::checkRemoteDescs, nb::arg("name"), nb::arg("memory_descs"));
+            nb::arg("request"), nb::rv_policy::take_ownership, nb::call_guard<nb::gil_scoped_release>())
+        .def("notify_sync_message", &kvc::BaseTransferAgent::notifySyncMessage, nb::arg("name"),
+            nb::arg("sync_message"), nb::call_guard<nb::gil_scoped_release>())
+        .def("get_notified_sync_messages", &kvc::BaseTransferAgent::getNotifiedSyncMessages,
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("get_local_connection_info", &kvc::BaseTransferAgent::getLocalConnectionInfo,
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("check_remote_descs", &kvc::BaseTransferAgent::checkRemoteDescs, nb::arg("name"), nb::arg("memory_descs"),
+            nb::call_guard<nb::gil_scoped_release>());
 
 #ifdef ENABLE_NIXL
     // NixlTransferStatus class - release GIL for blocking operations
     nb::class_<kvc::NixlTransferStatus, kvc::TransferStatus>(m, "NixlTransferStatus")
         .def("is_completed", &kvc::NixlTransferStatus::isCompleted, nb::call_guard<nb::gil_scoped_release>())
         .def("wait", &kvc::NixlTransferStatus::wait, nb::arg("timeout_ms") = -1,
-            nb::call_guard<nb::gil_scoped_release>());
+            nb::call_guard<nb::gil_scoped_release>())
+        .def("get_last_status", &kvc::NixlTransferStatus::getLastStatus)
+        .def("get_last_status_str", &kvc::NixlTransferStatus::getLastStatusStr);
 
     // NixlTransferAgent class
     nb::class_<kvc::NixlTransferAgent, kvc::BaseTransferAgent>(m, "NixlTransferAgent")
-        .def(nb::init<kvc::BaseAgentConfig const&>(), nb::arg("config"))
+        .def(nb::init<kvc::BaseAgentConfig const&>(), nb::arg("config"), nb::call_guard<nb::gil_scoped_release>())
+        .def("shutdown", &kvc::NixlTransferAgent::shutdown, nb::call_guard<nb::gil_scoped_release>())
         .def("register_memory", &kvc::NixlTransferAgent::registerMemory, nb::arg("descs"))
         .def("deregister_memory", &kvc::NixlTransferAgent::deregisterMemory, nb::arg("descs"))
         .def("load_remote_agent",

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
@@ -324,6 +324,25 @@ NixlTransferStatus::NixlTransferStatus(nixlAgent* agent, nixlXferReqH* handle)
     TLLM_CHECK(mHandle);
 }
 
+NixlTransferStatus::~NixlTransferStatus() noexcept
+{
+    if (mRawAgent != nullptr && mHandle != nullptr)
+    {
+        try
+        {
+            mRawAgent->releaseXferReq(mHandle);
+        }
+        catch (std::exception const& e)
+        {
+            TLLM_LOG_WARNING("~NixlTransferStatus: releaseXferReq threw: %s", e.what());
+        }
+        catch (...)
+        {
+            TLLM_LOG_WARNING("~NixlTransferStatus: releaseXferReq threw unknown exception");
+        }
+    }
+}
+
 [[nodiscard]] MemoryDescs NixlHelper::coalesceMemoryDescs(MemoryDescs const& descs)
 {
     auto const& descVec = descs.getDescs();
@@ -489,6 +508,7 @@ TransferState NixlTransferStatus::wait(int64_t timeout_ms) const
     while (true)
     {
         auto status = mRawAgent->getXferStatus(mHandle);
+        mLastStatus.store(static_cast<int>(status), std::memory_order_relaxed);
         if (status == NIXL_SUCCESS)
         {
             return TransferState::kSUCCESS;
@@ -518,9 +538,21 @@ TransferState NixlTransferStatus::wait(int64_t timeout_ms) const
     }
 }
 
+int NixlTransferStatus::getLastStatus() const noexcept
+{
+    return mLastStatus.load(std::memory_order_relaxed);
+}
+
+std::string NixlTransferStatus::getLastStatusStr() const
+{
+    return nixlEnumStrings::statusStr(static_cast<nixl_status_t>(getLastStatus()));
+}
+
 [[nodiscard]] bool NixlTransferStatus::isCompleted() const
 {
-    return mRawAgent->getXferStatus(mHandle) == NIXL_SUCCESS;
+    auto status = mRawAgent->getXferStatus(mHandle);
+    mLastStatus.store(static_cast<int>(status), std::memory_order_relaxed);
+    return status == NIXL_SUCCESS;
 }
 
 NixlTransferAgent::NixlTransferAgent(BaseAgentConfig const& config)
@@ -588,10 +620,6 @@ NixlTransferAgent::NixlTransferAgent(BaseAgentConfig const& config)
     }
     mExtraParams.backends.push_back(mRawBackend);
     TLLM_LOG_INFO("NixlTransferAgent::NixlTransferAgent mAddress: %s", mAddress.c_str());
-    mDRamSrcBuffer.resize(16);
-    mDRamDstBuffer.resize(16);
-    MemoryDescs descs{MemoryType::kDRAM, {MemoryDesc{mDRamSrcBuffer}, MemoryDesc{mDRamDstBuffer}}};
-    registerMemory(descs);
 }
 
 void NixlTransferAgent::registerMemory(RegisterDescs const& descs)
@@ -812,9 +840,61 @@ bool NixlTransferAgent::checkRemoteDescs(std::string const& name, MemoryDescs co
     return status == NIXL_SUCCESS;
 }
 
+void NixlTransferAgent::shutdown() noexcept
+{
+    if (mShutdown.exchange(true))
+    {
+        return;
+    }
+    TLLM_LOG_DEBUG("NixlTransferAgent::shutdown");
+
+    if (mRawAgent)
+    {
+        std::vector<std::string> remoteNames;
+        remoteNames.reserve(mRemoteVramRegionInfo.size());
+        for (auto const& [name, _] : mRemoteVramRegionInfo)
+        {
+            remoteNames.push_back(name);
+        }
+        for (auto const& name : remoteNames)
+        {
+            try
+            {
+                invalidateRemoteAgent(name);
+            }
+            catch (std::exception const& e)
+            {
+                TLLM_LOG_WARNING(
+                    "NixlTransferAgent::shutdown: invalidateRemoteAgent(%s) threw: %s", name.c_str(), e.what());
+            }
+            catch (...)
+            {
+            }
+        }
+    }
+
+    mExtraParams.backends.clear();
+    mRawBackend = nullptr;
+    try
+    {
+        mRawAgent.reset();
+    }
+    catch (std::exception const& e)
+    {
+        TLLM_LOG_WARNING("NixlTransferAgent::shutdown: ~nixlAgent threw: %s", e.what());
+    }
+    catch (...)
+    {
+        TLLM_LOG_WARNING("NixlTransferAgent::shutdown: ~nixlAgent threw unknown exception");
+    }
+    mLocalVramRegionInfo.clear();
+    mRemoteVramRegionInfo.clear();
+}
+
 NixlTransferAgent::~NixlTransferAgent()
 {
     TLLM_LOG_DEBUG("NixlTransferAgent::~NixlTransferAgent");
+    shutdown();
 }
 
 NixlLoopbackAgent::NixlLoopbackAgent(BaseAgentConfig const& config)
@@ -841,6 +921,22 @@ NixlLoopbackAgent::NixlLoopbackAgent(BaseAgentConfig const& config)
         status = mRawAgent->createBackend("GDS", init, backend);
         if (status != NIXL_SUCCESS || !backend)
             TLLM_THROW("Failed to create NIXL GDS backend, status = %d", status);
+    }
+}
+
+NixlLoopbackAgent::~NixlLoopbackAgent()
+{
+    try
+    {
+        mRawAgent.reset();
+    }
+    catch (std::exception const& e)
+    {
+        TLLM_LOG_WARNING("NixlLoopbackAgent::~NixlLoopbackAgent: ~nixlAgent threw: %s", e.what());
+    }
+    catch (...)
+    {
+        TLLM_LOG_WARNING("NixlLoopbackAgent::~NixlLoopbackAgent: ~nixlAgent threw unknown exception");
     }
 }
 

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h
@@ -57,14 +57,24 @@ class NixlTransferStatus final : public TransferStatus
 {
 public:
     NixlTransferStatus(nixlAgent* agent, nixlXferReqH* handle);
+    ~NixlTransferStatus() noexcept override;
+
+    NixlTransferStatus(NixlTransferStatus const&) = delete;
+    NixlTransferStatus& operator=(NixlTransferStatus const&) = delete;
+    NixlTransferStatus(NixlTransferStatus&&) = delete;
+    NixlTransferStatus& operator=(NixlTransferStatus&&) = delete;
 
     [[nodiscard]] bool isCompleted() const override;
 
     [[nodiscard]] TransferState wait(int64_t timeout_ms = -1) const override;
 
+    [[nodiscard]] int getLastStatus() const noexcept;
+    [[nodiscard]] std::string getLastStatusStr() const;
+
 private:
     nixlAgent* mRawAgent{};
     nixlXferReqH* mHandle{};
+    mutable std::atomic<int> mLastStatus{0};
 };
 
 class NixlTransferAgent final : public BaseTransferAgent
@@ -72,6 +82,9 @@ class NixlTransferAgent final : public BaseTransferAgent
 public:
     NixlTransferAgent(BaseAgentConfig const& config);
     ~NixlTransferAgent();
+
+    /// Synchronously release NIXL agent / UCX / prog_thread. Idempotent.
+    void shutdown() noexcept;
 
     void registerMemory(RegisterDescs const& descs) override;
 
@@ -111,9 +124,7 @@ private:
     nixl_opt_args_t mExtraParams;
     std::string mName;
     std::string mAddress;
-
-    std::vector<char> mDRamSrcBuffer;
-    std::vector<char> mDRamDstBuffer;
+    std::atomic<bool> mShutdown{false};
 
     /// Local VMM region info (from registerMemory). Keyed by local virtual address.
     VramRegionMap mLocalVramRegionInfo;
@@ -127,7 +138,7 @@ class NixlLoopbackAgent final : public BaseLoopbackAgent
 {
 public:
     NixlLoopbackAgent(BaseAgentConfig const& config);
-    virtual ~NixlLoopbackAgent() = default;
+    ~NixlLoopbackAgent() override;
 
     virtual void executeLoopbackRequest(
         MemoryDescs const& memoryDescs, FileDescs const& fileDescs, bool isOffload) override;

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -209,7 +209,9 @@ class Sender(SenderBase):
         self._sessions_lock = threading.Lock()  # Protects _sessions access
         self._shutdown = False
         self._instance_rank = self._registrar.self_rank_info.instance_rank
+        # Guards concurrent add() from the listener thread.
         self._loaded_remote_agents: set[str] = set()
+        self._loaded_remote_agents_lock = threading.Lock()
         self._num_threads = KV_TRANSFER_NUM_THREADS
         self._send_task_queues: List[queue.Queue] = [
             queue.Queue() for _ in range(self._num_threads)
@@ -388,9 +390,12 @@ class Sender(SenderBase):
             request = Sender._make_agent_request(write_meta, device_id=self._device_id)
             if timer:
                 timer.record_transfer_start(write_meta.peer_rank)
-            if not self._agent.submit_transfer_requests(request).wait():
+            status = self._agent.submit_transfer_requests(request)
+            if not status.wait():
                 agent_result = AgentResult.FAILED
-                logger.error(
+                last_status = getattr(status, "last_status_str", lambda: "<no detail>")()
+                agent_name = getattr(self._agent, "name", "<?>")
+                detail = (
                     f"KV transfer agent failed: "
                     f"unique_rid={write_meta.unique_rid} "
                     f"slice={write_meta.slice_id} "
@@ -399,12 +404,12 @@ class Sender(SenderBase):
                     f"op={getattr(request, 'op', '?')} "
                     f"remote={getattr(request, 'remote_name', '?')} "
                     f"src_size={int(write_meta.src_ptrs.size)} "
-                    f"dst_size={int(write_meta.dst_ptrs.size)}"
+                    f"dst_size={int(write_meta.dst_ptrs.size)} "
+                    f"nixl_status={last_status} agent={agent_name}"
                 )
+                logger.error(detail)
                 if not write_meta.task_future.done():
-                    write_meta.task_future.set_exception(
-                        RuntimeError(f"KV transfer failed for request {write_meta.unique_rid}")
-                    )
+                    write_meta.task_future.set_exception(RuntimeError(detail))
                 task.status = TaskStatus.ERROR
         if timer:
             timer.record_transfer_end(write_meta.peer_rank)
@@ -694,6 +699,9 @@ class Sender(SenderBase):
         self._messenger.start_listener(handle_message)
 
     def _register_peer_rank(self, _send_id: bytes, message: list[bytes]):
+        # Skip late messages so we don't race shutdown's invalidate loop.
+        if self._shutdown:
+            return
         torch.cuda.set_device(self._device_id)
         CUASSERT(cudart.cudaSetDevice(self._device_id))
         ri: RankInfo = RankInfo.from_bytes(message[1])
@@ -706,7 +714,8 @@ class Sender(SenderBase):
             ri.instance_name + str(ri.instance_rank),
             ri.transfer_engine_info,
         )
-        self._loaded_remote_agents.add(agent_name)
+        with self._loaded_remote_agents_lock:
+            self._loaded_remote_agents.add(agent_name)
         logger.debug(
             f"Completed handling REGISTER_RANK_INFO for instance='{ri.instance_name}', rank={ri.instance_rank}"
         )
@@ -772,26 +781,32 @@ class Sender(SenderBase):
             return
         self._shutdown = True
 
+        # Quiesce listener before invalidate to avoid set/map mutation races.
+        self._messenger.stop()
+
         for q in self._send_task_queues:
             q.put(None)
         for t in self._worker_threads:
             t.join(timeout=5)
-        # Invalidate all loaded remote agents to release fabric/POSIX FD resources
-        for agent_name in self._loaded_remote_agents:
+
+        # Snapshot under lock as defense in depth.
+        with self._loaded_remote_agents_lock:
+            loaded_agents = list(self._loaded_remote_agents)
+            self._loaded_remote_agents.clear()
+        # Invalidate all loaded remote agents to release fabric/POSIX FD resources.
+        for agent_name in loaded_agents:
             try:
                 self._agent.invalidate_remote_agent(agent_name)
             except Exception as e:
                 logger.warning(
                     f"Failed to invalidate remote agent '{agent_name}' during shutdown: {e}"
                 )
-        self._loaded_remote_agents.clear()
         for dealer in self._dealers.values():
             try:
                 dealer.stop()
             except Exception as e:
                 logger.warning(f"Failed to stop dealer during Sender shutdown: {e}")
         self._dealers.clear()
-        self._messenger.stop()
 
     def __del__(self):
         try:
@@ -1267,12 +1282,14 @@ class RxSession(RxSessionBase):
                     ri = self._receiver._registrar.self_rank_info
                     task.print_perf_info(peer_rank, ri.instance_name, ri.instance_rank)
         elif status == AgentResult.FAILED:
+            detail = (
+                f"KV transfer failed for request {self.request_id} slice {slice_id} "
+                f"peer_rank={peer_rank} is_last_slice={is_last_slice} "
+                f"(reported by remote agent; see sender-side log for nixl_status)"
+            )
+            logger.error(detail)
             if not task.future.done():
-                task.future.set_exception(
-                    RuntimeError(
-                        f"KV transfer failed for request {self.request_id} slice {slice_id}"
-                    )
-                )
+                task.future.set_exception(RuntimeError(detail))
             task.status = TaskStatus.ERROR
         else:
             raise ValueError(
@@ -1617,6 +1634,13 @@ class TransferWorker:
         finalizer = getattr(self, "_finalizer", None)
         if finalizer is not None:
             finalizer()
+        agent = getattr(self, "_agent", None)
+        if agent is not None:
+            try:
+                agent.shutdown()
+            except Exception as e:
+                logger.warning(f"TransferWorker.shutdown: agent.shutdown error: {e}")
+            self._agent = None
 
     def __del__(self):
         try:

--- a/tensorrt_llm/_torch/disaggregation/nixl/_agent_cpp.py
+++ b/tensorrt_llm/_torch/disaggregation/nixl/_agent_cpp.py
@@ -42,6 +42,14 @@ class BindingsNixlTransferStatus(TransferStatus):
             )
         return result == TransferState.SUCCESS
 
+    def last_status_str(self) -> str:
+        get = getattr(self._cpp_status, "get_last_status_str", None)
+        return get() if get is not None else "<unavailable>"
+
+    def last_status(self) -> int:
+        get = getattr(self._cpp_status, "get_last_status", None)
+        return int(get()) if get is not None else -1
+
 
 class BindingsNixlTransferAgent(BaseTransferAgent):
     """NixlTransferAgent using C++ bindings with GIL release support.
@@ -83,6 +91,22 @@ class BindingsNixlTransferAgent(BaseTransferAgent):
             f"UCX_TLS={os.environ.get('UCX_TLS', '<unset>')} "
             f"UCX_LOG_LEVEL={os.environ.get('UCX_LOG_LEVEL', '<unset>')}"
         )
+
+    def shutdown(self):
+        cpp_agent = getattr(self, "_cpp_agent", None)
+        if cpp_agent is None:
+            return
+        try:
+            cpp_agent.shutdown()
+        except Exception:
+            pass
+        self._cpp_agent = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
+        self.shutdown()
 
     def register_memory(self, descs: RegMemoryDescs):
         """Register memory regions."""

--- a/tensorrt_llm/_torch/disaggregation/nixl/_agent_py.py
+++ b/tensorrt_llm/_torch/disaggregation/nixl/_agent_py.py
@@ -64,6 +64,17 @@ class NixlTransferAgent(BaseTransferAgent):
         )
         self.agent = nixl_agent(name, agent_config)
 
+    def shutdown(self):
+        if getattr(self, "agent", None) is None:
+            return
+        self.agent = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
+        self.shutdown()
+
     def _get_validated_reg_descs(self, descs: RegMemoryDescs):
         if not descs.descs:
             raise ValueError("descs.descs must not be empty")

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -146,6 +146,12 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self._recv_reqs.clear()
         self._transfer_worker.shutdown()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
+        self.shutdown()
+
     def _get_block_ids(self, req: LlmRequest, group_idx: int, lg) -> np.ndarray:
         if self._is_v2_manager:
             kv_cache_map = getattr(self._kv_cache_manager, "kv_cache_map")

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -2269,9 +2269,12 @@ class TestDeepSeekV4Flash(LlmapiAccuracyTestHarness):
                 "num_instances": 1
             },
         }
+        # V4-Flash 148GB weight prefetch + warmup needs >35 min, default wait timeout times out.
         with launch_disaggregated_llm(disaggregated_server_config,
-                                      ctx_server_config, gen_server_config,
-                                      self.MODEL_PATH) as llm:
+                                      ctx_server_config,
+                                      gen_server_config,
+                                      self.MODEL_PATH,
+                                      server_waiting_timeout=3600) as llm:
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm, is_integration_test=True)
 
@@ -2330,8 +2333,11 @@ class TestDeepSeekV4FlashBase(LlmapiAccuracyTestHarness):
                 "num_instances": 1
             },
         }
+        # Same long-init reason as TestDeepSeekV4Flash above.
         with launch_disaggregated_llm(disaggregated_server_config,
-                                      ctx_server_config, gen_server_config,
-                                      self.MODEL_PATH) as llm:
+                                      ctx_server_config,
+                                      gen_server_config,
+                                      self.MODEL_PATH,
+                                      server_waiting_timeout=3600) as llm:
             task = MMLU(self.MODEL_NAME)
             task.evaluate(llm, is_integration_test=True)

--- a/tests/integration/test_lists/test-db/l0_b200_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_b200_ds.yml
@@ -24,5 +24,18 @@ l0_b200_ds:
   - unittest/_torch/attention/sparse/deepseek_v4/test_compressor_kernel.py TIMEOUT (90)
   - unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py TIMEOUT (90)
   - unittest/_torch/attention/sparse/deepseek_v4/test_compressor_tf32.py TIMEOUT (15)
+  # ------------- Disaggregated transfer component tests (single GPU) ---------------
+  - unittest/disaggregated/test_agent.py
+  - unittest/disaggregated/test_agent_multi_backends.py
+  - unittest/disaggregated/test_extractor.py
+  - unittest/disaggregated/test_kv_transfer.py
+  - unittest/disaggregated/test_messenger.py
+  - unittest/disaggregated/test_peer.py
+  - unittest/disaggregated/test_perf_logger.py
+  - unittest/disaggregated/test_rank_info.py
+  - unittest/disaggregated/test_request_id.py
+  - unittest/disaggregated/test_router.py
+  # Disaggregated KV transfer with DeepSeek-V4 cache manager (single B200, threading-based).
+  - unittest/disaggregated/test_deepseek_v4_kv_transfer.py TIMEOUT (180)
   # Tokenizer chat-template tests.
   - unittest/llmapi/test_deepseek_v4_tokenizer.py

--- a/tests/integration/test_lists/test-db/l0_dgx_b200_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200_ds.yml
@@ -23,4 +23,10 @@ l0_dgx_b200_ds:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_auto_dtype TIMEOUT (60)
   # ------------- Disaggregated transfer component tests (multi-process) ---------------
   - unittest/disaggregated/test_kv_transfer_mp.py
-  - unittest/disaggregated/test_py_cache_transceiver_mp.py
+  # Split test_py_cache_transceiver_mp.py by workflow (4 × 12 = 48 combos).
+  # A single wrapper case ran ~3581 s and brushed the outer pytest 3600 s
+  # per-test timeout; per-workflow shards give each ~12 combos a fresh budget.
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "ctx_first and not ctx_first_sync"
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "ctx_first_sync"
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "gen_first1"
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "gen_first2"

--- a/tests/integration/test_lists/test-db/l0_dgx_b200_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200_ds.yml
@@ -21,3 +21,6 @@ l0_dgx_b200_ds:
   # (1 MMLU sample, no GSM8K reference required). Validates the basic
   # forward path without disagg or EPLB complexity.
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_auto_dtype TIMEOUT (60)
+  # ------------- Disaggregated transfer component tests (multi-process) ---------------
+  - unittest/disaggregated/test_kv_transfer_mp.py
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py

--- a/tests/integration/test_lists/test-db/l0_dgx_b300_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b300_ds.yml
@@ -20,6 +20,9 @@ l0_dgx_b300_ds:
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_kv_cache_v2_nixl_python
   - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_kv_cache_v2_nixl_python
   - accuracy/test_disaggregated_serving.py::TestGemma3_1BInstruct::test_kv_cache_v2_nixl_python
+  # ------------- Disaggregated transfer component tests (multi-process) ---------------
+  - unittest/disaggregated/test_kv_transfer_mp.py
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py
   # ------------- DeepSeek-V4 (4x B300, pre_merge) ---------------
   # B300's larger per-GPU memory (~288 GB) lets V4 EPLB and FP8 aggregate
   # smoke fit at TP=4. (Same tests at TP=8 would also fit on 8x B200, but a

--- a/tests/integration/test_lists/test-db/l0_dgx_b300_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b300_ds.yml
@@ -22,7 +22,13 @@ l0_dgx_b300_ds:
   - accuracy/test_disaggregated_serving.py::TestGemma3_1BInstruct::test_kv_cache_v2_nixl_python
   # ------------- Disaggregated transfer component tests (multi-process) ---------------
   - unittest/disaggregated/test_kv_transfer_mp.py
-  - unittest/disaggregated/test_py_cache_transceiver_mp.py
+  # Split test_py_cache_transceiver_mp.py by workflow (4 × 12 = 48 combos).
+  # A single wrapper case ran ~3581 s and brushed the outer pytest 3600 s
+  # per-test timeout; per-workflow shards give each ~12 combos a fresh budget.
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "ctx_first and not ctx_first_sync"
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "ctx_first_sync"
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "gen_first1"
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "gen_first2"
   # ------------- DeepSeek-V4 (4x B300, pre_merge) ---------------
   # B300's larger per-GPU memory (~288 GB) lets V4 EPLB and FP8 aggregate
   # smoke fit at TP=4. (Same tests at TP=8 would also fit on 8x B200, but a

--- a/tests/integration/test_lists/test-db/l0_dgx_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h100.yml
@@ -110,7 +110,14 @@ l0_dgx_h100:
   - test_e2e.py::test_ptp_quickstart_advanced_deepseek_v3_lite_4gpus_adp_balance[DeepSeek-V3-Lite-FP8-DeepSeek-V3-Lite/fp8]
   - test_e2e.py::test_trtllm_bench_llmapi_launch[pytorch_backend-llama-v3-llama3-8b]
   # ------------- Disaggregated serving tests ---------------
-  - unittest/disaggregated/test_py_cache_transceiver_mp.py
+  # Split test_py_cache_transceiver_mp.py by workflow (4 × 12 = 48 combos).
+  # A single wrapper case ran ~3581 s on B200 and brushed the outer pytest
+  # 3600 s per-test timeout; per-workflow shards give each ~12 combos a
+  # fresh budget. Apply the same split on H100 for parity.
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "ctx_first and not ctx_first_sync"
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "ctx_first_sync"
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "gen_first1"
+  - unittest/disaggregated/test_py_cache_transceiver_mp.py -k "gen_first2"
   - disaggregated/test_disaggregated.py::test_disaggregated_multi_gpu[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated.py::test_disaggregated_multi_gpu_trt_backend[TinyLlama-1.1B-Chat-v1.0]
   - disaggregated/test_disaggregated.py::test_disaggregated_ctxpp2_genpp2[TinyLlama-1.1B-Chat-v1.0]

--- a/tests/unittest/disaggregated/test_agent.py
+++ b/tests/unittest/disaggregated/test_agent.py
@@ -1,9 +1,13 @@
+import os
 from dataclasses import dataclass, field
 from unittest import TestCase
 from unittest.mock import Mock
 
 import pytest
 import torch
+
+# Exclude IB (no fabric) and gdr_copy (UCX rcache SIGABRT at teardown).
+os.environ.setdefault("UCX_TLS", "^ib,gdr_copy")
 
 from tensorrt_llm import logger
 from tensorrt_llm._torch.disaggregation.base.agent import (

--- a/tests/unittest/disaggregated/test_agent_multi_backends.py
+++ b/tests/unittest/disaggregated/test_agent_multi_backends.py
@@ -3,6 +3,9 @@ import subprocess
 
 import pytest
 
+# Exclude IB (no fabric) and gdr_copy (UCX rcache SIGABRT at teardown).
+os.environ.setdefault("UCX_TLS", "^ib,gdr_copy")
+
 
 def test_load_agent_missing_module():
     """_load_agent returns (None, ImportError) for a non-existent module.

--- a/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
+++ b/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
@@ -8,6 +8,11 @@ TP/PP/DP/MLA/sliding-window configurations for both V1 and V2 cache managers.
 import os
 import threading
 import uuid
+
+# Exclude UCX IB transport (avoid NIXL setup hangs without IB) and gdr_copy
+# (avoid SIGSEGV at process exit from UCX rcache cleanup; gdr_copy disabled
+# falls back to cuda_ipc / cuda_copy without affecting correctness).
+os.environ.setdefault("UCX_TLS", "^ib,gdr_copy")
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
@@ -797,123 +802,126 @@ def run_transfer_test(
         gen_tp, gen_pp, gen_enable_dp, gen_managers, config, is_mla
     )
 
-    ctx_info_endpoint = ctx_tcs[0]._context_info_endpoint
+    try:
+        ctx_info_endpoint = ctx_tcs[0]._context_info_endpoint
 
-    # ===== 4. Create requests =====
-    ctx_handle_map: Dict[int, List] = {r: [] for r in range(ctx_world)}
-    gen_handle_map: Dict[int, List] = {r: [] for r in range(gen_world)}
-    ctx_request_ids: List[int] = []
-    gen_request_ids: List[int] = []
-    ctx_kv_caches: Dict[int, List] = {r: [] for r in range(ctx_world)}
-    gen_kv_caches: Dict[int, List] = {r: [] for r in range(gen_world)}
+        # ===== 4. Create requests =====
+        ctx_handle_map: Dict[int, List] = {r: [] for r in range(ctx_world)}
+        gen_handle_map: Dict[int, List] = {r: [] for r in range(gen_world)}
+        ctx_request_ids: List[int] = []
+        gen_request_ids: List[int] = []
+        ctx_kv_caches: Dict[int, List] = {r: [] for r in range(ctx_world)}
+        gen_kv_caches: Dict[int, List] = {r: [] for r in range(gen_world)}
 
-    sampling_params = SamplingParams()
+        sampling_params = SamplingParams()
 
-    for req_idx, req_len in enumerate(request_lengths):
-        unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
-        ctx_rid = req_idx * 2
-        gen_rid = req_idx * 2 + 1
-        ctx_request_ids.append(ctx_rid)
-        gen_request_ids.append(gen_rid)
+        for req_idx, req_len in enumerate(request_lengths):
+            unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
+            ctx_rid = req_idx * 2
+            gen_rid = req_idx * 2 + 1
+            ctx_request_ids.append(ctx_rid)
+            gen_request_ids.append(gen_rid)
 
-        ctx_dp_rank = req_idx % ctx_tp if ctx_enable_dp else 0
+            ctx_dp_rank = req_idx % ctx_tp if ctx_enable_dp else 0
 
-        ctx_request = LlmRequest(
-            request_id=ctx_rid,
-            max_new_tokens=1,
-            input_tokens=list(range(req_len)),
-            sampling_config=tensorrt_llm.bindings.SamplingConfig(
-                sampling_params._get_sampling_config()
-            ),
-            is_streaming=False,
-            llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
-        )
-        ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
+            ctx_request = LlmRequest(
+                request_id=ctx_rid,
+                max_new_tokens=1,
+                input_tokens=list(range(req_len)),
+                sampling_config=tensorrt_llm.bindings.SamplingConfig(
+                    sampling_params._get_sampling_config()
+                ),
+                is_streaming=False,
+                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
+            )
+            ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
 
-        gen_request = LlmRequest(
-            request_id=gen_rid,
-            max_new_tokens=1,
-            input_tokens=list(range(req_len)),
-            sampling_config=tensorrt_llm.bindings.SamplingConfig(
-                sampling_params._get_sampling_config()
-            ),
-            is_streaming=False,
-            llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
-        )
-        gen_request.py_disaggregated_params = DisaggregatedParams(
-            ctx_request_id=ctx_rid,
-            ctx_dp_rank=ctx_dp_rank,
-            ctx_info_endpoint=ctx_info_endpoint,
-            disagg_request_id=unique_rid,
-        )
+            gen_request = LlmRequest(
+                request_id=gen_rid,
+                max_new_tokens=1,
+                input_tokens=list(range(req_len)),
+                sampling_config=tensorrt_llm.bindings.SamplingConfig(
+                    sampling_params._get_sampling_config()
+                ),
+                is_streaming=False,
+                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+            )
+            gen_request.py_disaggregated_params = DisaggregatedParams(
+                ctx_request_id=ctx_rid,
+                ctx_dp_rank=ctx_dp_rank,
+                ctx_info_endpoint=ctx_info_endpoint,
+                disagg_request_id=unique_rid,
+            )
 
-        for rank in range(ctx_world):
-            tp_rank = rank % ctx_tp
-            should_handle = (not ctx_enable_dp) or (req_idx % ctx_tp == tp_rank)
-            if should_handle:
-                ctx_handle_map[rank].append((req_idx, ctx_request))
+            for rank in range(ctx_world):
+                tp_rank = rank % ctx_tp
+                should_handle = (not ctx_enable_dp) or (req_idx % ctx_tp == tp_rank)
+                if should_handle:
+                    ctx_handle_map[rank].append((req_idx, ctx_request))
 
+            for rank in range(gen_world):
+                tp_rank = rank % gen_tp
+                should_handle = (not gen_enable_dp) or (req_idx % gen_tp == tp_rank)
+                if should_handle:
+                    gen_handle_map[rank].append((req_idx, gen_request))
+
+        # 5. Add sequences and gen receive first
         for rank in range(gen_world):
-            tp_rank = rank % gen_tp
-            should_handle = (not gen_enable_dp) or (req_idx % gen_tp == tp_rank)
-            if should_handle:
-                gen_handle_map[rank].append((req_idx, gen_request))
+            for req_idx, req in gen_handle_map[rank]:
+                kv = _add_sequence(gen_managers[rank], req.py_request_id, req.prompt_len, use_v2)
+                if kv is not None:
+                    gen_kv_caches[rank].append(kv)
+                gen_tcs[rank].request_and_receive_async(req)
 
-    # 5. Add sequences and gen receive first
-    for rank in range(gen_world):
-        for req_idx, req in gen_handle_map[rank]:
-            kv = _add_sequence(gen_managers[rank], req.py_request_id, req.prompt_len, use_v2)
-            if kv is not None:
-                gen_kv_caches[rank].append(kv)
-            gen_tcs[rank].request_and_receive_async(req)
-
-    # 6. ctx send after
-    for rank in range(ctx_world):
-        for req_idx, req in ctx_handle_map[rank]:
-            kv = _add_sequence(ctx_managers[rank], req.py_request_id, req.prompt_len, use_v2)
-            if kv is not None:
-                ctx_kv_caches[rank].append(kv)
-            ctx_tcs[rank].respond_and_send_async(req)
-
-    # 7. Wait for completion (threaded, dist calls inside)
-    run_concurrent(ctx_tcs, lambda tc: tc.check_context_transfer_status(None, mark_complete=True))
-    run_concurrent(gen_tcs, lambda tc: tc.check_gen_transfer_status(None))
-
-    # 8. Verify
-    verify_all_requests(
-        request_lengths=request_lengths,
-        ctx_managers=ctx_managers,
-        gen_managers=gen_managers,
-        ctx_tp=ctx_tp,
-        ctx_pp=ctx_pp,
-        gen_tp=gen_tp,
-        gen_pp=gen_pp,
-        ctx_enable_dp=ctx_enable_dp,
-        gen_enable_dp=gen_enable_dp,
-        ctx_request_ids=ctx_request_ids,
-        gen_request_ids=gen_request_ids,
-        is_mla=is_mla,
-        use_v2=use_v2,
-        max_attention_window_vec=max_attention_window_vec,
-        num_layers=num_layers,
-    )
-
-    # 9. Cleanup
-    if use_v2:
-        torch.cuda.current_stream().synchronize()
+        # 6. ctx send after
         for rank in range(ctx_world):
-            for kv in ctx_kv_caches[rank]:
-                kv.close()
-        for rank in range(gen_world):
-            for kv in gen_kv_caches[rank]:
-                kv.close()
+            for req_idx, req in ctx_handle_map[rank]:
+                kv = _add_sequence(ctx_managers[rank], req.py_request_id, req.prompt_len, use_v2)
+                if kv is not None:
+                    ctx_kv_caches[rank].append(kv)
+                ctx_tcs[rank].respond_and_send_async(req)
 
-    for tc in ctx_tcs:
-        if hasattr(tc, "transfer_worker") and tc.transfer_worker is not None:
-            tc.transfer_worker.shutdown()
-    for tc in gen_tcs:
-        if hasattr(tc, "transfer_worker") and tc.transfer_worker is not None:
-            tc.transfer_worker.shutdown()
+        # 7. Wait for completion (threaded, dist calls inside)
+        run_concurrent(
+            ctx_tcs, lambda tc: tc.check_context_transfer_status(None, mark_complete=True)
+        )
+        run_concurrent(gen_tcs, lambda tc: tc.check_gen_transfer_status(None))
+
+        # 8. Verify
+        verify_all_requests(
+            request_lengths=request_lengths,
+            ctx_managers=ctx_managers,
+            gen_managers=gen_managers,
+            ctx_tp=ctx_tp,
+            ctx_pp=ctx_pp,
+            gen_tp=gen_tp,
+            gen_pp=gen_pp,
+            ctx_enable_dp=ctx_enable_dp,
+            gen_enable_dp=gen_enable_dp,
+            ctx_request_ids=ctx_request_ids,
+            gen_request_ids=gen_request_ids,
+            is_mla=is_mla,
+            use_v2=use_v2,
+            max_attention_window_vec=max_attention_window_vec,
+            num_layers=num_layers,
+        )
+
+        # 9. Cleanup
+        if use_v2:
+            torch.cuda.current_stream().synchronize()
+            for rank in range(ctx_world):
+                for kv in ctx_kv_caches[rank]:
+                    kv.close()
+            for rank in range(gen_world):
+                for kv in gen_kv_caches[rank]:
+                    kv.close()
+
+    finally:
+        for tc in ctx_tcs + gen_tcs:
+            try:
+                tc.shutdown()
+            except Exception:
+                pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
@@ -1,0 +1,962 @@
+"""Test KV Transfer for DeepseekV4CacheManager with KvCacheTransceiverV2.
+
+Uses threading + ThreadSafeDistributed to create KvCacheTransceiverV2 instances
+in a single process. Validates all DeepseekV4AttentionType cache transfers across
+different TP/PP/DP configurations.
+"""
+
+import os
+import threading
+import uuid
+
+# Exclude UCX IB transport (avoid NIXL setup hangs without IB) and gdr_copy
+# (avoid SIGSEGV at process exit from UCX rcache cleanup; gdr_copy disabled
+# falls back to cuda_ipc / cuda_copy without affecting correctness).
+os.environ.setdefault("UCX_TLS", "^ib,gdr_copy")
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+import torch
+
+import tensorrt_llm
+import tensorrt_llm.bindings
+import tensorrt_llm.tensorrt_llm_transfer_agent_binding  # noqa: F401
+from tensorrt_llm import DisaggregatedParams, Mapping, SamplingParams
+from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4 import DeepseekV4CacheManager
+from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4.deepseek_v4 import (
+    DEEPSEEK_V4_OVERLAP_COMPRESSOR_RATIO,
+    DEEPSEEK_V4_SPARSE_RATIO,
+    DeepseekV4AttentionType,
+)
+from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
+from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool, get_pool_bytes
+from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestType
+from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
+from tensorrt_llm._utils import TensorWrapper, convert_to_torch_tensor
+from tensorrt_llm.bindings import DataType
+from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
+from tensorrt_llm.llmapi.llm_args import (
+    CacheTransceiverConfig,
+    DeepSeekV4SparseAttentionConfig,
+    KvCacheConfig,
+)
+
+# Reduce NIXL threads for unit test: default 8 threads per agent causes heavy
+# contention when creating multiple agents on a single GPU in the same process.
+os.environ.setdefault("TRTLLM_NIXL_NUM_THREADS", "0")
+
+
+# ---------------------------------------------------------------------------
+# Constants matching DeepseekV4CacheManager defaults
+# ---------------------------------------------------------------------------
+HEAD_DIM = 256  # Reduced from 512: test validates transfer, not attention correctness
+INDEX_HEAD_DIM = 128
+WINDOW_SIZE = 128
+TOKENS_PER_BLOCK = 128
+MAX_SEQ_LEN = 512
+MAX_BATCH_SIZE = 16
+VOCAB_SIZE = 129280
+NUM_KV_HEADS = 1
+INDEXER_QUANT_BLOCK_SIZE = 128
+
+
+# DeepSeek-V4 specific ratios (mirrors module constants)
+SPARSE_RATIO = DEEPSEEK_V4_SPARSE_RATIO
+OVERLAP_COMPRESSOR_RATIO = DEEPSEEK_V4_OVERLAP_COMPRESSOR_RATIO
+
+
+# ---------------------------------------------------------------------------
+# ThreadSafeDistributed: threading.Barrier-based Distributed mock
+# ---------------------------------------------------------------------------
+class ThreadSafeDistributed:
+    """Distributed mock using threading.Barrier for single-process multi-rank testing.
+
+    Provides the same interface as TorchDistributedWrapper from test_py_cache_transceiver_mp.py
+    but uses Barrier + Lock + shared dict instead of torch.distributed.
+    """
+
+    def __init__(
+        self,
+        local_rank: int,
+        world_size: int,
+        tp_size: int,
+        pp_size: int,
+        tp_rank: int,
+        pp_rank: int,
+        shared: dict,
+    ):
+        self.rank = local_rank
+        self._world_size = world_size
+        self._tp_size = tp_size
+        self._pp_size = pp_size
+        self._tp_rank = tp_rank
+        self._pp_rank = pp_rank
+        self._s = shared
+        self._bcast_idx = 0
+        self._ag_idx = 0
+        self._pp_ag_idx = 0
+        self._tp_ag_idx = 0
+
+    @property
+    def tp_size(self):
+        return self._tp_size
+
+    @property
+    def pp_size(self):
+        return self._pp_size
+
+    @property
+    def world_size(self):
+        return self._world_size
+
+    def broadcast(self, obj, root=0):
+        idx = self._bcast_idx
+        self._bcast_idx += 1
+        key = f"bcast_{idx}"
+        if self.rank == root:
+            self._s[key] = obj
+        self._s["barrier"].wait()
+        result = self._s[key]
+        self._s["barrier"].wait()
+        return result
+
+    def allgather(self, obj):
+        idx = self._ag_idx
+        self._ag_idx += 1
+        key = f"ag_{idx}"
+        with self._s["lock"]:
+            if key not in self._s:
+                self._s[key] = [None] * self._world_size
+            self._s[key][self.rank] = obj
+        self._s["barrier"].wait()
+        result = list(self._s[key])
+        self._s["barrier"].wait()
+        return result
+
+    def pp_allgather(self, obj):
+        idx = self._pp_ag_idx
+        self._pp_ag_idx += 1
+        key = f"pp_ag_{idx}_tp{self._tp_rank}"
+        with self._s["lock"]:
+            if key not in self._s:
+                self._s[key] = [None] * self._pp_size
+            self._s[key][self._pp_rank] = obj
+        self._s["barrier"].wait()
+        result = list(self._s[key])
+        self._s["barrier"].wait()
+        return result
+
+    def tp_allgather(self, obj):
+        idx = self._tp_ag_idx
+        self._tp_ag_idx += 1
+        key = f"tp_ag_{idx}_pp{self._pp_rank}"
+        with self._s["lock"]:
+            if key not in self._s:
+                self._s[key] = [None] * self._tp_size
+            self._s[key][self._tp_rank] = obj
+        self._s["barrier"].wait()
+        result = list(self._s[key])
+        self._s["barrier"].wait()
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Threading helpers
+# ---------------------------------------------------------------------------
+def run_concurrent(items, fn):
+    """Run fn(item) for each item concurrently in threads and propagate errors."""
+    errors = [None] * len(items)
+    results = [None] * len(items)
+
+    def _worker(idx, item):
+        try:
+            results[idx] = fn(item)
+        except Exception as e:
+            errors[idx] = e
+
+    threads = [threading.Thread(target=_worker, args=(i, item)) for i, item in enumerate(items)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    for i, err in enumerate(errors):
+        if err is not None:
+            raise err
+    return results
+
+
+def _create_transceiver_in_thread(rank, mapping, cache_manager, dist_mock, config, results, errors):
+    """Thread target: create one KvCacheTransceiverV2."""
+    try:
+        tc = KvCacheTransceiverV2(
+            mapping=mapping,
+            dist=dist_mock,
+            kv_cache_manager=cache_manager,
+            cache_transceiver_config=config,
+        )
+        results[rank] = tc
+    except Exception as e:
+        errors[rank] = e
+
+
+def create_instance_transceivers(
+    tp: int, pp: int, enable_dp: bool, cache_managers: List, config: CacheTransceiverConfig
+) -> List[KvCacheTransceiverV2]:
+    """Create KvCacheTransceiverV2 for all ranks via threaded init."""
+    world_size = tp * pp
+    shared = {"barrier": threading.Barrier(world_size), "lock": threading.Lock()}
+    results = [None] * world_size
+    errors = [None] * world_size
+    threads = []
+
+    for rank in range(world_size):
+        pp_rank = rank // tp
+        tp_rank = rank % tp
+        mapping = Mapping(
+            world_size=world_size,
+            rank=rank,
+            tp_size=tp,
+            pp_size=pp,
+            enable_attention_dp=enable_dp,
+        )
+        dist_mock = ThreadSafeDistributed(rank, world_size, tp, pp, tp_rank, pp_rank, shared)
+        t = threading.Thread(
+            target=_create_transceiver_in_thread,
+            args=(
+                rank,
+                mapping,
+                cache_managers[rank],
+                dist_mock,
+                config,
+                results,
+                errors,
+            ),
+        )
+        threads.append(t)
+
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for rank, err in enumerate(errors):
+        if err is not None:
+            raise err
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# DeepseekV4CacheManager creation helpers
+# ---------------------------------------------------------------------------
+def _create_deepseek_v4_manager(
+    mapping: Mapping,
+    compress_ratios: List[int],
+    dtype: DataType = DataType.BF16,
+    compressor_dtype: DataType = DataType.FLOAT,
+) -> DeepseekV4CacheManager:
+    """Create a DeepseekV4CacheManager for the given mapping."""
+    sparse_attn_config = DeepSeekV4SparseAttentionConfig(
+        index_head_dim=INDEX_HEAD_DIM,
+        window_size=WINDOW_SIZE,
+        compress_ratios=compress_ratios,
+    )
+    max_num_tokens = MAX_SEQ_LEN * MAX_BATCH_SIZE
+    kv_cache_config = KvCacheConfig(
+        enable_block_reuse=False,
+        max_tokens=max_num_tokens,
+        event_buffer_max_size=0,
+    )
+    return DeepseekV4CacheManager(
+        kv_cache_config=kv_cache_config,
+        kv_cache_type=CacheTypeCpp.SELFKONLY,
+        num_layers=len(compress_ratios),
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        tokens_per_block=TOKENS_PER_BLOCK,
+        max_seq_len=MAX_SEQ_LEN,
+        max_batch_size=MAX_BATCH_SIZE,
+        mapping=mapping,
+        dtype=dtype,
+        compressor_dtype=compressor_dtype,
+        vocab_size=VOCAB_SIZE,
+        max_num_tokens=max_num_tokens,
+        sparse_attn_config=sparse_attn_config,
+    )
+
+
+def _create_managers_for_instance(
+    tp: int,
+    pp: int,
+    enable_dp: bool,
+    compress_ratios: List[int],
+) -> List[DeepseekV4CacheManager]:
+    """Create DeepseekV4CacheManagers for all ranks in an instance."""
+    world_size = tp * pp
+    managers = []
+    for rank in range(world_size):
+        mapping = Mapping(
+            world_size=world_size,
+            rank=rank,
+            tp_size=tp,
+            pp_size=pp,
+            enable_attention_dp=enable_dp,
+        )
+        managers.append(_create_deepseek_v4_manager(mapping, compress_ratios))
+    return managers
+
+
+def _init_pool_data(managers: List, tp: int, seed_base: int = 0, fill_random: bool = True):
+    """Initialize pool data for all managers.
+
+    Uses half-precision view of pool memory for initialization.
+    Since pools have mixed dtypes (BF16, FP32, FP8), we use HALF (2 bytes) as a
+    common element type that evenly divides all pool sizes.
+
+    Args:
+        managers: List of DeepseekV4CacheManagers.
+        tp: TP size.
+        seed_base: Base seed offset (different for ctx vs gen to avoid collisions).
+        fill_random: If True fill with random data (ctx), if False fill with zeros (gen).
+    """
+    for rank, mgr in enumerate(managers):
+        pp_rank = rank // tp
+        page_table = KVRegionExtractorV1(mgr).page_table
+
+        # Collect unique pools (deduplicate by base_address)
+        unique_pools: Dict[int, int] = {}
+        for lg_idx, lg in enumerate(page_table.layer_groups):
+            for pv in lg.pool_views:
+                pool = get_physical_pool(page_table, lg_idx, pv.pool_idx)
+                key = pool.base_address
+                if key not in unique_pools or get_pool_bytes(pool) > unique_pools[key]:
+                    unique_pools[key] = get_pool_bytes(pool)
+
+        # Use HALF (2 bytes) as element type - divides all pool sizes evenly
+        elem_bytes = 2  # sizeof(half)
+        for pool_base_ptr, pool_size in unique_pools.items():
+            pool_size_elements = pool_size // elem_bytes
+            pool_tensor = convert_to_torch_tensor(
+                TensorWrapper(pool_base_ptr, DataType.HALF, [pool_size_elements])
+            )
+            if fill_random:
+                # Same seed for same pp_rank across TP ranks (kv_heads=1)
+                seed = seed_base + pp_rank
+                generator = torch.Generator(device=pool_tensor.device).manual_seed(seed)
+                random_values = torch.rand(
+                    pool_tensor.shape,
+                    dtype=pool_tensor.dtype,
+                    device=pool_tensor.device,
+                    generator=generator,
+                )
+                pool_tensor.copy_(random_values)
+            else:
+                pool_tensor.zero_()
+
+
+# ---------------------------------------------------------------------------
+# Attention type helpers
+# ---------------------------------------------------------------------------
+def _get_attn_types_for_layer(
+    layer_idx: int, compress_ratios: List[int]
+) -> List[DeepseekV4AttentionType]:
+    """Get the attention types for a given layer based on its compress ratio."""
+    ratio = compress_ratios[layer_idx]
+    is_compress = ratio > 1
+    is_sparse = ratio == SPARSE_RATIO
+    types = [DeepseekV4AttentionType.SWA]
+    if is_compress:
+        types.extend(
+            [
+                DeepseekV4AttentionType.COMPRESS,
+                DeepseekV4AttentionType.COMPRESSOR_STATE,
+                DeepseekV4AttentionType.COMPRESSOR_SCORE,
+            ]
+        )
+    if is_sparse:
+        types.extend(
+            [
+                DeepseekV4AttentionType.INDEXER_COMPRESS,
+                DeepseekV4AttentionType.INDEXER_COMPRESSOR_STATE,
+                DeepseekV4AttentionType.INDEXER_COMPRESSOR_SCORE,
+            ]
+        )
+    return types
+
+
+# Mirror transceiver.py windowed-block trim: only in-window blocks are transferred.
+_WINDOWED_ATTN_TYPES = {
+    DeepseekV4AttentionType.SWA,
+    DeepseekV4AttentionType.COMPRESSOR_STATE,
+    DeepseekV4AttentionType.COMPRESSOR_SCORE,
+    DeepseekV4AttentionType.INDEXER_COMPRESSOR_STATE,
+    DeepseekV4AttentionType.INDEXER_COMPRESSOR_SCORE,
+}
+
+
+def _expected_valid_blocks(
+    attn_type: DeepseekV4AttentionType, compress_ratio: int, prompt_len: int
+) -> Optional[int]:
+    if attn_type == DeepseekV4AttentionType.SWA:
+        window = WINDOW_SIZE
+    elif attn_type in _WINDOWED_ATTN_TYPES:
+        state_factor = 2 if compress_ratio == OVERLAP_COMPRESSOR_RATIO else 1
+        window = state_factor * compress_ratio
+    else:
+        return None
+    total = (prompt_len + TOKENS_PER_BLOCK - 1) // TOKENS_PER_BLOCK
+    stale = max(0, (prompt_len + 1 - window) // TOKENS_PER_BLOCK)
+    return total - stale
+
+
+def _split_blockwise_buffer(
+    buffer: torch.Tensor,
+    index_head_dim: int = INDEX_HEAD_DIM,
+    quant_block_size: int = INDEXER_QUANT_BLOCK_SIZE,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Split a blockwise FP8 quantized buffer into value and scale buffers.
+
+    Args:
+        buffer: shape [num_blocks, tokens_per_block, bytes_per_token]
+
+    Returns:
+        (values_buffer, scales_buffer) where values are uint8 and scales are float32
+    """
+    num_blocks, tokens_per_block, bytes_per_token = buffer.shape
+    bytes_per_block = bytes_per_token * tokens_per_block
+
+    # Value buffer
+    value_shape = (num_blocks, tokens_per_block, index_head_dim)
+    value_stride = (bytes_per_block, index_head_dim, 1)
+    value_buffer = buffer.as_strided(value_shape, value_stride, 0).view(torch.uint8)
+
+    # Scale buffer
+    scale_dim = index_head_dim // quant_block_size
+    scale_bytes = scale_dim * 4  # float32 = 4 bytes
+    scale_shape = (num_blocks, tokens_per_block, scale_bytes)
+    scale_stride = (bytes_per_block, scale_bytes, 1)
+    scale_offset = index_head_dim * tokens_per_block
+    scale_buffer = buffer.as_strided(scale_shape, scale_stride, scale_offset).view(torch.float32)
+
+    return value_buffer, scale_buffer
+
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+def _read_cache_data(
+    mgr: DeepseekV4CacheManager,
+    layer_idx: int,
+    attn_type: DeepseekV4AttentionType,
+    request_id: int,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Read cache data for a layer/attn_type from a DeepseekV4CacheManager.
+
+    Returns all non-BAD block data. For INDEXER_COMPRESS returns (values, scales).
+    """
+    buffer = mgr.get_buffers(layer_idx, attn_type)
+    # get_cache_indices may contain BAD_PAGE_INDEX (-1) for evicted blocks; filter them out.
+    indices = [i for i in mgr.get_cache_indices(request_id, layer_idx, attn_type) if i >= 0]
+
+    if not indices:
+        return torch.tensor([]), None
+
+    if attn_type == DeepseekV4AttentionType.INDEXER_COMPRESS:
+        values_buf, scales_buf = _split_blockwise_buffer(buffer)
+        return values_buf[indices], scales_buf[indices]
+
+    return buffer[indices], None
+
+
+def _find_ctx_rank_for_layer(
+    layer_idx: int,
+    ctx_managers: List[DeepseekV4CacheManager],
+    ctx_tp: int,
+    ctx_enable_dp: bool,
+    req_idx: int,
+) -> int:
+    """Find the ctx rank that owns a given model layer.
+
+    Returns a rank with the correct PP rank and correct TP rank for DP.
+    """
+    for rank, mgr in enumerate(ctx_managers):
+        tp_rank = rank % ctx_tp
+        if ctx_enable_dp:
+            if req_idx % ctx_tp != tp_rank:
+                continue
+        elif tp_rank != 0:
+            # Without DP, all TP ranks have same data; use tp_rank=0
+            continue
+        if layer_idx in mgr.pp_layers:
+            return rank
+    raise ValueError(f"No ctx rank found for layer {layer_idx}")
+
+
+def verify_all_requests(
+    request_lengths: List[int],
+    compress_ratios: List[int],
+    ctx_managers: List[DeepseekV4CacheManager],
+    gen_managers: List[DeepseekV4CacheManager],
+    ctx_tp: int,
+    ctx_pp: int,
+    gen_tp: int,
+    gen_pp: int,
+    ctx_enable_dp: bool,
+    gen_enable_dp: bool,
+    ctx_request_ids: List[int],
+    gen_request_ids: List[int],
+):
+    """Verify transferred cache data for all requests across all gen ranks."""
+    gen_world = gen_tp * gen_pp
+
+    for req_idx, req_len in enumerate(request_lengths):
+        ctx_rid = ctx_request_ids[req_idx]
+        gen_rid = gen_request_ids[req_idx]
+
+        for gen_rank in range(gen_world):
+            tp_rank = gen_rank % gen_tp
+            # Skip ranks that didn't handle this request (DP mode)
+            if gen_enable_dp and req_idx % gen_tp != tp_rank:
+                continue
+
+            gen_mgr = gen_managers[gen_rank]
+            gen_pp_layers = gen_mgr.pp_layers
+
+            for layer_idx in gen_pp_layers:
+                # Find the ctx rank owning this layer
+                ctx_rank = _find_ctx_rank_for_layer(
+                    layer_idx,
+                    ctx_managers,
+                    ctx_tp,
+                    ctx_enable_dp,
+                    req_idx,
+                )
+                ctx_mgr = ctx_managers[ctx_rank]
+
+                for attn_type in _get_attn_types_for_layer(layer_idx, compress_ratios):
+                    ctx_data, ctx_scales = _read_cache_data(ctx_mgr, layer_idx, attn_type, ctx_rid)
+                    gen_data, gen_scales = _read_cache_data(gen_mgr, layer_idx, attn_type, gen_rid)
+
+                    expected_valid = _expected_valid_blocks(
+                        attn_type, compress_ratios[layer_idx], req_len
+                    )
+                    if expected_valid is not None:
+                        if expected_valid <= 0:
+                            ctx_data = ctx_data[:0]
+                            gen_data = gen_data[:0]
+                        else:
+                            ctx_data = ctx_data[-expected_valid:]
+                            gen_data = gen_data[-expected_valid:]
+
+                    assert ctx_data.shape == gen_data.shape, (
+                        f"Shape mismatch at req={req_idx} layer={layer_idx} "
+                        f"attn={attn_type.name}: ctx={ctx_data.shape} gen={gen_data.shape}"
+                    )
+
+                    torch.testing.assert_close(
+                        gen_data,
+                        ctx_data,
+                        rtol=0,
+                        atol=0,
+                        msg=lambda m: (
+                            f"Data mismatch at req={req_idx} layer={layer_idx} "
+                            f"attn={attn_type.name} gen_rank={gen_rank}: {m}"
+                        ),
+                    )
+
+                    if ctx_scales is not None:
+                        assert gen_scales is not None, (
+                            f"Expected scales at req={req_idx} layer={layer_idx} attn={attn_type.name}"
+                        )
+                        torch.testing.assert_close(
+                            gen_scales,
+                            ctx_scales,
+                            rtol=0,
+                            atol=0,
+                            msg=lambda m: (
+                                f"Scale mismatch at req={req_idx} layer={layer_idx} "
+                                f"attn={attn_type.name} gen_rank={gen_rank}: {m}"
+                            ),
+                        )
+                    else:
+                        assert gen_scales is None
+
+
+# ---------------------------------------------------------------------------
+# Main test function
+# ---------------------------------------------------------------------------
+def _get_ctx_info_endpoint(tc: KvCacheTransceiverV2) -> Optional[str]:
+    """Extract the context_info_endpoint from a transceiver's disaggregated params."""
+    endpoints = tc.get_disaggregated_params().get("ctx_info_endpoint") or []
+    return endpoints[0] if endpoints else None
+
+
+def run_deepseek_v4_transfer_test(
+    ctx_tp: int,
+    ctx_pp: int,
+    gen_tp: int,
+    gen_pp: int,
+    ctx_enable_dp: bool,
+    gen_enable_dp: bool,
+    compress_ratios: List[int],
+    update_before_transfer: bool = True,
+):
+    """Run a full DeepSeek-V4 KV transfer test."""
+    ctx_world = ctx_tp * ctx_pp
+    gen_world = gen_tp * gen_pp
+
+    # Mix of block-aligned and non-aligned lengths for boundary testing.
+    # TOKENS_PER_BLOCK=128: 65=half+1, 256=2x exact, 129=1x+1, 383=3x-1
+    request_lengths = [65, 256, 129, 383]
+
+    # ===== 1. Create DeepseekV4CacheManagers =====
+    ctx_managers = _create_managers_for_instance(ctx_tp, ctx_pp, ctx_enable_dp, compress_ratios)
+    gen_managers = _create_managers_for_instance(gen_tp, gen_pp, gen_enable_dp, compress_ratios)
+
+    # ===== 2. Initialize data =====
+    # ctx: random data, seed=pp_rank (same across TP, different across PP)
+    _init_pool_data(ctx_managers, ctx_tp, seed_base=1000, fill_random=True)
+    # gen: zeros
+    _init_pool_data(gen_managers, gen_tp, fill_random=False)
+
+    # ===== 3. Create KvCacheTransceiverV2 instances (threaded init) =====
+    config = CacheTransceiverConfig(
+        backend="NIXL",
+        transceiver_runtime="PYTHON",
+        max_tokens_in_buffer=512,
+    )
+    ctx_tcs = create_instance_transceivers(ctx_tp, ctx_pp, ctx_enable_dp, ctx_managers, config)
+    gen_tcs = create_instance_transceivers(gen_tp, gen_pp, gen_enable_dp, gen_managers, config)
+
+    try:
+        ctx_info_endpoint = _get_ctx_info_endpoint(ctx_tcs[0])
+
+        # ===== 4. Create requests and determine handle map =====
+        # handle_map: rank -> [(req_idx, ctx_request, gen_request)]
+        ctx_handle_map: Dict[int, List] = {r: [] for r in range(ctx_world)}
+        gen_handle_map: Dict[int, List] = {r: [] for r in range(gen_world)}
+        ctx_request_ids: List[int] = []
+        gen_request_ids: List[int] = []
+
+        sampling_params = SamplingParams()
+
+        for req_idx, req_len in enumerate(request_lengths):
+            unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
+            ctx_rid = req_idx * 2
+            gen_rid = req_idx * 2 + 1
+            ctx_request_ids.append(ctx_rid)
+            gen_request_ids.append(gen_rid)
+
+            ctx_dp_rank = req_idx % ctx_tp if ctx_enable_dp else 0
+
+            ctx_request = LlmRequest(
+                request_id=ctx_rid,
+                max_new_tokens=1,
+                input_tokens=list(range(req_len)),
+                sampling_config=tensorrt_llm.bindings.SamplingConfig(
+                    sampling_params._get_sampling_config()
+                ),
+                is_streaming=False,
+                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
+            )
+            ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
+
+            gen_request = LlmRequest(
+                request_id=gen_rid,
+                max_new_tokens=1,
+                input_tokens=list(range(req_len)),
+                sampling_config=tensorrt_llm.bindings.SamplingConfig(
+                    sampling_params._get_sampling_config()
+                ),
+                is_streaming=False,
+                llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+            )
+            gen_request.py_disaggregated_params = DisaggregatedParams(
+                ctx_request_id=ctx_rid,
+                ctx_dp_rank=ctx_dp_rank,
+                ctx_info_endpoint=ctx_info_endpoint,
+                disagg_request_id=unique_rid,
+            )
+
+            for rank in range(ctx_world):
+                tp_rank = rank % ctx_tp
+                should_handle = (not ctx_enable_dp) or (req_idx % ctx_tp == tp_rank)
+                if should_handle:
+                    ctx_handle_map[rank].append((req_idx, ctx_request))
+
+            for rank in range(gen_world):
+                tp_rank = rank % gen_tp
+                should_handle = (not gen_enable_dp) or (req_idx % gen_tp == tp_rank)
+                if should_handle:
+                    gen_handle_map[rank].append((req_idx, gen_request))
+
+        # ===== 5. Allocate KV cache for all ranks =====
+        # Uses prepare_context + resize_context (the V2 manager path).
+        # prepare_resources is a no-op for non-draft KVCacheManagerV2.
+        # All ranks must allocate BEFORE mutating shared request objects
+        # (add_new_token changes is_first_context_chunk).
+        gen_batches: Dict[int, ScheduledRequests] = {}
+        for rank in range(gen_world):
+            reqs = [req for _, req in gen_handle_map[rank]]
+            if reqs:
+                batch = ScheduledRequests()
+                batch.context_requests_last_chunk = reqs
+                for req in reqs:
+                    gen_managers[rank].prepare_context(req)
+                    gen_managers[rank].resize_context(req, req.context_chunk_size)
+                gen_batches[rank] = batch
+
+        ctx_batches: Dict[int, ScheduledRequests] = {}
+        for rank in range(ctx_world):
+            reqs = [req for _, req in ctx_handle_map[rank]]
+            if reqs:
+                batch = ScheduledRequests()
+                batch.context_requests_last_chunk = reqs
+                for req in reqs:
+                    ctx_managers[rank].prepare_context(req)
+                    ctx_managers[rank].resize_context(req, req.context_chunk_size)
+                ctx_batches[rank] = batch
+
+        # ===== 5.5. context_current_position + add_new_token =====
+        # Set position on each unique request once (needed for transfer metadata).
+        seen: set = set()
+        for rank in range(ctx_world):
+            for _, req in ctx_handle_map[rank]:
+                if req.py_request_id not in seen:
+                    req.context_current_position = req.prompt_len
+                    req.add_new_token(req.prompt_len, 0)
+                    seen.add(req.py_request_id)
+
+        seen = set()
+        for rank in range(gen_world):
+            for _, req in gen_handle_map[rank]:
+                if req.py_request_id not in seen:
+                    req.context_current_position = req.prompt_len
+                    req.add_new_token(req.prompt_len, 0)
+                    seen.add(req.py_request_id)
+
+        # ===== 5.6. update_resources BEFORE transfer (mode: update_before) =====
+        if update_before_transfer:
+            for rank, batch in ctx_batches.items():
+                ctx_managers[rank].update_resources(batch)
+            for rank, batch in gen_batches.items():
+                gen_managers[rank].update_resources(batch)
+
+        # ===== 6. gen receive + ctx send =====
+        for rank in range(gen_world):
+            for _, req in gen_handle_map[rank]:
+                gen_tcs[rank].request_and_receive_async(req)
+        for rank in range(ctx_world):
+            for _, req in ctx_handle_map[rank]:
+                ctx_tcs[rank].respond_and_send_async(req)
+
+        # ===== 7. Wait for completion (threaded, dist calls inside) =====
+        run_concurrent(
+            ctx_tcs, lambda tc: tc.check_context_transfer_status(None, mark_complete=True)
+        )
+        run_concurrent(gen_tcs, lambda tc: tc.check_gen_transfer_status(None))
+
+        # ===== 7.5. update_resources AFTER transfer (mode: update_after) =====
+        if not update_before_transfer:
+            for rank, batch in ctx_batches.items():
+                ctx_managers[rank].update_resources(batch)
+            for rank, batch in gen_batches.items():
+                gen_managers[rank].update_resources(batch)
+
+        # ===== 8. Verify =====
+        verify_all_requests(
+            request_lengths=request_lengths,
+            compress_ratios=compress_ratios,
+            ctx_managers=ctx_managers,
+            gen_managers=gen_managers,
+            ctx_tp=ctx_tp,
+            ctx_pp=ctx_pp,
+            gen_tp=gen_tp,
+            gen_pp=gen_pp,
+            ctx_enable_dp=ctx_enable_dp,
+            gen_enable_dp=gen_enable_dp,
+            ctx_request_ids=ctx_request_ids,
+            gen_request_ids=gen_request_ids,
+        )
+
+    finally:
+        for tc in ctx_tcs + gen_tcs:
+            try:
+                tc.shutdown()
+            except Exception:
+                pass
+        for mgr in ctx_managers + gen_managers:
+            try:
+                mgr.shutdown()
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Test configurations
+# ---------------------------------------------------------------------------
+TEST_CONFIGS = [
+    # (ctx_tp, ctx_pp, gen_tp, gen_pp, ctx_enable_dp, gen_enable_dp, test_id)
+    # Basic
+    (1, 1, 1, 1, False, False, "tp1_pp1"),
+    (2, 1, 2, 1, False, False, "tp2_pp1"),
+    (1, 2, 1, 2, False, False, "pp2_symmetric"),
+    (1, 2, 1, 1, False, False, "pp2_to_pp1"),
+    (2, 2, 2, 2, False, False, "tp2_pp2"),
+    # DP
+    (2, 1, 2, 1, True, True, "tp2_dp_both"),
+    (2, 1, 1, 2, True, False, "ctx_dp_gen_pp2"),
+    (2, 2, 2, 2, True, True, "tp2_pp2_dp_both"),
+]
+
+
+# @pytest.mark.threadleak(enabled=False)
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,gen_tp,gen_pp,ctx_enable_dp,gen_enable_dp",
+    [(c[0], c[1], c[2], c[3], c[4], c[5]) for c in TEST_CONFIGS],
+    ids=[c[6] for c in TEST_CONFIGS],
+)
+@pytest.mark.parametrize(
+    "compress_ratios",
+    [[1, 4, 128], [128, 1, 4, 128]],
+    ids=["cr_1_4_128", "cr_128_1_4_128"],
+)
+@pytest.mark.parametrize(
+    "update_before_transfer",
+    [True, False],
+    ids=["update_before", "update_after"],
+)
+def test_deepseek_v4_kv_transfer(
+    ctx_tp,
+    ctx_pp,
+    gen_tp,
+    gen_pp,
+    ctx_enable_dp,
+    gen_enable_dp,
+    compress_ratios,
+    update_before_transfer,
+):
+    """Test KvCacheTransceiverV2 with DeepseekV4CacheManager."""
+    mode = "update_before" if update_before_transfer else "update_after"
+    print(
+        f"\nRunning DeepSeek-V4 transfer test [{mode}]: "
+        f"ctx_tp={ctx_tp} ctx_pp={ctx_pp} gen_tp={gen_tp} gen_pp={gen_pp} "
+        f"ctx_dp={ctx_enable_dp} gen_dp={gen_enable_dp} "
+        f"compress_ratios={compress_ratios}"
+    )
+
+    run_deepseek_v4_transfer_test(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_enable_dp=gen_enable_dp,
+        compress_ratios=compress_ratios,
+        update_before_transfer=update_before_transfer,
+    )
+
+    print("PASSED")
+
+
+# ---------------------------------------------------------------------------
+# PP layer distribution helpers (mirrors C++ getLayerNumPPRank)
+# ---------------------------------------------------------------------------
+def _get_layers_per_pp(num_layers: int, pp_size: int) -> List[int]:
+    """Return a list of layer counts per PP rank.
+
+    When num_layers is not evenly divisible by pp_size, the first
+    (num_layers % pp_size) ranks get one extra layer.
+    Matches Mapping.pp_layers / torch.tensor_split behaviour.
+    """
+    base = num_layers // pp_size
+    extra = num_layers % pp_size
+    return [base + (1 if r < extra else 0) for r in range(pp_size)]
+
+
+# ---------------------------------------------------------------------------
+# Uneven PP layer test configurations
+# ---------------------------------------------------------------------------
+# compress_ratios templates for different num_layers (covering ratios 1, 4, 128)
+UNEVEN_PP_COMPRESS_RATIOS = {
+    5: [1, 4, 128, 1, 4],
+    7: [1, 4, 128, 1, 4, 128, 1],
+}
+
+UNEVEN_PP_CONFIGS = [
+    # (ctx_tp, ctx_pp, gen_tp, gen_pp, ctx_dp, gen_dp, num_layers, test_id)
+    # 5 layers, pp=2 → [3, 2]
+    (1, 2, 1, 2, False, False, 5, "5L_tp1_pp2"),
+    (2, 2, 2, 2, False, False, 5, "5L_tp2_pp2"),
+    # 5 layers, pp=3 → [2, 2, 1]
+    (1, 3, 1, 3, False, False, 5, "5L_tp1_pp3"),
+    # 7 layers, pp=2 → [4, 3]
+    (1, 2, 1, 2, False, False, 7, "7L_tp1_pp2"),
+    (2, 2, 2, 2, False, False, 7, "7L_tp2_pp2"),
+    # 7 layers, pp=3 → [3, 2, 2]
+    (1, 3, 1, 3, False, False, 7, "7L_tp1_pp3"),
+    # 7 layers, pp=4 → [2, 2, 2, 1]
+    (1, 4, 1, 4, False, False, 7, "7L_tp1_pp4"),
+    # Asymmetric TP/PP with uneven layers
+    (2, 1, 1, 2, False, False, 5, "5L_tp2_to_pp2"),
+    (1, 2, 2, 1, False, False, 5, "5L_pp2_to_tp2"),
+    (4, 1, 1, 4, False, False, 7, "7L_tp4_to_pp4"),
+    (1, 4, 4, 1, False, False, 7, "7L_pp4_to_tp4"),
+    (2, 2, 1, 4, False, False, 7, "7L_tp2pp2_to_pp4"),
+    # Uneven layers + DP
+    (2, 2, 2, 2, True, True, 5, "5L_tp2_pp2_dp_both"),
+]
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,gen_tp,gen_pp,ctx_enable_dp,gen_enable_dp,num_layers",
+    [(c[0], c[1], c[2], c[3], c[4], c[5], c[6]) for c in UNEVEN_PP_CONFIGS],
+    ids=[c[7] for c in UNEVEN_PP_CONFIGS],
+)
+@pytest.mark.parametrize(
+    "update_before_transfer",
+    [True, False],
+    ids=["update_before", "update_after"],
+)
+def test_deepseek_v4_kv_transfer_uneven_pp(
+    ctx_tp,
+    ctx_pp,
+    gen_tp,
+    gen_pp,
+    ctx_enable_dp,
+    gen_enable_dp,
+    num_layers,
+    update_before_transfer,
+):
+    """Test KvCacheTransceiverV2 with DeepseekV4CacheManager and uneven layers-per-PP-rank.
+
+    When num_layers is not evenly divisible by pp_size, the first
+    (num_layers % pp_size) PP ranks get one extra layer.
+    """
+    compress_ratios = UNEVEN_PP_COMPRESS_RATIOS[num_layers]
+    mode = "update_before" if update_before_transfer else "update_after"
+
+    print(
+        f"\nRunning DeepSeek-V4 uneven PP transfer test [{mode}]: "
+        f"ctx_tp={ctx_tp} ctx_pp={ctx_pp} gen_tp={gen_tp} gen_pp={gen_pp} "
+        f"ctx_dp={ctx_enable_dp} gen_dp={gen_enable_dp} "
+        f"num_layers={num_layers} compress_ratios={compress_ratios} "
+        f"layers_per_pp(ctx)={_get_layers_per_pp(num_layers, ctx_pp)} "
+        f"layers_per_pp(gen)={_get_layers_per_pp(num_layers, gen_pp)}"
+    )
+
+    run_deepseek_v4_transfer_test(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_enable_dp=gen_enable_dp,
+        compress_ratios=compress_ratios,
+        update_before_transfer=update_before_transfer,
+    )
+
+    print("PASSED")

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -1,8 +1,12 @@
 """Test KV Transfer with KVCacheManager (V1) and KVCacheManagerV2 (V2)."""
 
+import os
 import random
 import time
 import uuid
+
+# Exclude IB (no fabric) and gdr_copy (UCX rcache SIGABRT at teardown).
+os.environ.setdefault("UCX_TLS", "^ib,gdr_copy")
 from dataclasses import dataclass
 from typing import List, Optional
 

--- a/tests/unittest/disaggregated/test_kv_transfer_mp.py
+++ b/tests/unittest/disaggregated/test_kv_transfer_mp.py
@@ -7,6 +7,9 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
+# Exclude IB (no fabric) and gdr_copy (UCX rcache SIGABRT at teardown).
+os.environ.setdefault("UCX_TLS", "^ib,gdr_copy")
+
 import tensorrt_llm
 import tensorrt_llm.bindings
 import tensorrt_llm.bindings.executor as trtllm

--- a/tests/unittest/disaggregated/test_py_cache_transceiver_mp.py
+++ b/tests/unittest/disaggregated/test_py_cache_transceiver_mp.py
@@ -15,6 +15,9 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
+# Exclude IB (no fabric) and gdr_copy (UCX rcache SIGABRT at teardown).
+os.environ.setdefault("UCX_TLS", "^ib,gdr_copy")
+
 import tensorrt_llm
 import tensorrt_llm.bindings
 import tensorrt_llm.bindings.executor as trtllm


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Adds unit tests for DeepSeek V4 KV-cache disaggregation (`test_deepseek_v4_kv_transfer.py`, v1/v2 cache manager × MLA × TP/PP × DP × compression). Lands together with the C++/Python lifecycle fixes that surfaced while making these tests reliable.

Fixes bundled

  - NIXL agent teardown — explicit `NixlTransferAgent::shutdown()` + `~NixlTransferStatus()` releases handles deterministically, avoids `ucp_cleanup` SIGSEGV at process exit
  - Sender shutdown race — `listener` thread vs `invalidate_remote_agent` loop on shared `_loaded_remote_agents` set / C++ `mRemoteVramRegionInfo` map; fixed by lock + reordering `_messenger.stop()` before invalidate
  - Failure diagnostics — Sender errors now include NIXL status and agent name

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
