### PR TITLE
[None][feat] Keep DSv4 o_a_proj as FP8, and port vLLM's fused_inv_rope_fp8_quant

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/custom_ops/__init__.py
@@ -1,3 +1,5 @@
+# Imported first to register the op before the chain via ..modules.attention re-enters this package.
+from . import triton_fused_inv_rope_fp8_quant  # noqa: F401  # isort: skip
 from ..cuda_tile_utils import IS_CUDA_TILE_AVAILABLE
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
 from ..flashinfer_utils import IS_FLASHINFER_AVAILABLE

--- a/tensorrt_llm/_torch/custom_ops/triton_fused_inv_rope_fp8_quant.py
+++ b/tensorrt_llm/_torch/custom_ops/triton_fused_inv_rope_fp8_quant.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Adapted from vLLM:
+#   https://github.com/vllm-project/vllm/blob/ecd0b60aad2f4e28dd00ababfc1402690d88cbed/vllm/v1/attention/ops/deepseek_v4_ops/fused_inv_rope_fp8_quant.py
+#
+# Modifications relative to upstream vLLM (Apache-2.0, licensed identically to
+# TensorRT-LLM):
+#  * Added a NEOX RoPE branch (`IS_NEOX` constexpr). Upstream is interleaved
+#    (GPT-J style) only; DeepSeek-V4 in TensorRT-LLM uses NEOX layout for the
+#    inverse RoPE applied before `o_a_proj` (see
+#    `cpp/tensorrt_llm/kernels/mlaKernels.cu:1190-1276`).
+#  * Output FP8 buffer is returned without the trailing `transpose(0, 1)` so
+#    the result is directly consumable by `cute_dsl_fp8_bmm_blackwell` whose
+#    input layout is `[batch=n_groups, m=num_tokens, k=d]`. Likewise the scale
+#    buffer is returned as a contiguous `[n_groups, num_scale_blocks, pad_up(num_tokens, 4)]`
+#    FP32 tensor (matching the output of `fp8_batched_quantize_1x128_permute102`)
+#    rather than the strided `[T, G, num_scale_blocks]` view used by vLLM.
+#  * Drops the `tma_aligned_scales`/SM90 split — TensorRT-LLM's consumer is
+#    SM100 with FP32 a-side scales, so the upstream UE8M0-INT32 pack path is
+#    not needed here.
+#  * Rebound the cos/sin cache to TensorRT-LLM's NEOX layout
+#    `[max_pos, 2, half_rope]` (cos block then sin block per position) by
+#    advertising the contract as a flat `[max_pos, rope_dim]` view; the
+#    indexing math is identical for both kernels.
+#  * Replaces vLLM's `direct_register_custom_op` with `torch.library.custom_op`,
+#    matching the rest of `tensorrt_llm/_torch/custom_ops/`.
+#
+# Engaged from `tensorrt_llm/_torch/modules/attention.py:_deepseek_v4_o_proj`
+# when `use_cute_dsl_blockscaling_bmm` is enabled in `extra_llm_api_options` on
+# SM100; falls back to the legacy `mla_rope_inplace + permute102_quant` pair
+# otherwise.
+"""
+Fused inverse-RoPE + 1x128 block-scaled FP8 quantize, for DeepSeek-V4 ``o_a_proj``.
+
+Replaces the (``mla_rope_inplace`` -> ``fp8_batched_quantize_1x128_permute102``)
+two-kernel pair in ``_deepseek_v4_o_proj``. The output is consumed verbatim by
+``cute_dsl_fp8_bmm_blackwell``.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton  # type: ignore[import]
+import triton.language as tl  # type: ignore[import]
+
+
+@triton.jit
+def _fused_inv_rope_fp8_quant_per_head(
+    o_ptr,
+    positions_ptr,
+    cos_sin_cache_ptr,
+    fp8_ptr,
+    scale_ptr,
+    num_tokens,
+    heads_per_group: tl.constexpr,
+    o_stride_token,
+    o_stride_head,
+    cache_stride_pos,
+    fp8_stride_group,
+    fp8_stride_token,
+    scale_stride_group,
+    scale_stride_k,
+    fp8_max: tl.constexpr,
+    eps: tl.constexpr,
+    QUANT_GROUP_SIZE: tl.constexpr,
+    CHUNKS_PER_HEAD: tl.constexpr,
+    ROPE_START: tl.constexpr,
+    HALF_ROPE: tl.constexpr,
+    IS_NEOX: tl.constexpr,
+):
+    # int64: stride multiply overflows int32 past num_tokens=32768 (IMA).
+    pid_token = tl.program_id(0).to(tl.int64)
+    pid_gh = tl.program_id(1).to(tl.int64)
+
+    g = pid_gh // heads_per_group
+    head_in_group = pid_gh % heads_per_group
+    global_head = pid_gh
+    qb_start = head_in_group * CHUNKS_PER_HEAD
+
+    # Padding rows (M aligned up to 4): zero out the scale and skip quant.
+    if pid_token >= num_tokens:
+        block_offsets = tl.arange(0, CHUNKS_PER_HEAD)
+        qb_indices = qb_start + block_offsets
+        scale_addrs = scale_ptr + g * scale_stride_group + pid_token + qb_indices * scale_stride_k
+        tl.store(scale_addrs, tl.zeros((CHUNKS_PER_HEAD,), dtype=tl.float32))
+        return
+
+    input_base = o_ptr + pid_token * o_stride_token + global_head * o_stride_head
+
+    HEAD_DIM: tl.constexpr = CHUNKS_PER_HEAD * QUANT_GROUP_SIZE
+    offsets = tl.arange(0, HEAD_DIM)
+    x = tl.load(input_base + offsets).to(tl.float32)
+
+    rope_abs_start: tl.constexpr = (CHUNKS_PER_HEAD - 1) * QUANT_GROUP_SIZE + ROPE_START
+    pos = tl.load(positions_ptr + pid_token)
+    cache_base = cos_sin_cache_ptr + pos * cache_stride_pos
+    is_rope = offsets >= rope_abs_start
+    rope_local = offsets - rope_abs_start
+
+    if IS_NEOX:
+        # NEOX layout: rope half = [x1[0..H), x2[0..H)] where H = HALF_ROPE.
+        # For inverse RoPE (coef = (cos, -sin)):
+        #   new_x1[i] = cos[i] * x1[i] + sin[i] * x2[i]
+        #   new_x2[i] = cos[i] * x2[i] - sin[i] * x1[i]
+        # In a single per-element formulation:
+        #   partner_offset = (i < H) ? i + H : i - H
+        #   sign = (i < H) ? +1 : -1
+        #   new = cos * x[i] + sign * sin * x[partner]
+        is_first_half = rope_local < HALF_ROPE
+        partner_local = tl.where(is_first_half, rope_local + HALF_ROPE, rope_local - HALF_ROPE)
+        partner_abs = rope_abs_start + partner_local
+        x_partner = tl.load(input_base + partner_abs, mask=is_rope, other=0.0).to(tl.float32)
+        cs_idx = tl.where(is_first_half, rope_local, rope_local - HALF_ROPE)
+        cos_v = tl.load(cache_base + cs_idx, mask=is_rope, other=1.0)
+        sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope, other=0.0)
+        sign = tl.where(is_first_half, 1.0, -1.0)
+        rotated = x * cos_v + sign * sin_v * x_partner
+    else:
+        # GPT-J / interleaved layout: pairs (x[2i], x[2i+1]).
+        x_partner = tl.load(input_base + (offsets ^ 1), mask=is_rope, other=0.0).to(tl.float32)
+        cs_idx = tl.maximum(rope_local >> 1, 0)
+        cos_v = tl.load(cache_base + cs_idx, mask=is_rope, other=1.0)
+        sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope, other=0.0)
+        x_add = x * cos_v + x_partner * sin_v
+        x_sub = x * cos_v - x_partner * sin_v
+        is_even = (rope_local & 1) == 0
+        rotated = tl.where(is_even, x_add, x_sub)
+
+    x = tl.where(is_rope, rotated, x)
+
+    x_2d = tl.reshape(tl.abs(x), (CHUNKS_PER_HEAD, QUANT_GROUP_SIZE))
+    block_absmax = tl.maximum(tl.max(x_2d, axis=1), eps)
+    # Match `fp8_batched_quantize_1x128_permute102`'s raw FP32 scale layout
+    # (no UE8M0 round-up): scales = absmax / fp8_max so that quant value =
+    # x / scale = x * fp8_max / absmax. This keeps `cute_dsl_fp8_bmm_blackwell`
+    # bit-for-bit on parity with the legacy permute102 quant in the same gate.
+    scales = block_absmax * (1.0 / fp8_max)
+
+    scales_exp = tl.reshape(
+        tl.broadcast_to(
+            tl.reshape(scales, (CHUNKS_PER_HEAD, 1)),
+            (CHUNKS_PER_HEAD, QUANT_GROUP_SIZE),
+        ),
+        (HEAD_DIM,),
+    )
+    x_quant = tl.clamp(x / scales_exp, -fp8_max, fp8_max).to(tl.float8e4nv)
+
+    fp8_base = (
+        fp8_ptr + g * fp8_stride_group + pid_token * fp8_stride_token + qb_start * QUANT_GROUP_SIZE
+    )
+    tl.store(fp8_base + offsets, x_quant)
+
+    block_offsets = tl.arange(0, CHUNKS_PER_HEAD)
+    qb_indices = qb_start + block_offsets
+    scale_addrs = scale_ptr + g * scale_stride_group + pid_token + qb_indices * scale_stride_k
+    tl.store(scale_addrs, scales)
+
+
+def _tma_aligned_size(x: int, tma_align_size_in_elems: int = 4) -> int:
+    return (x + tma_align_size_in_elems - 1) // tma_align_size_in_elems * tma_align_size_in_elems
+
+
+def _fused_inv_rope_fp8_quant_impl(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    quant_group_size: int,
+    is_neox: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens, num_heads, head_dim = o.shape
+    assert num_heads == n_groups * heads_per_group, (
+        f"num_heads={num_heads} != n_groups({n_groups}) * heads_per_group({heads_per_group})"
+    )
+    assert head_dim == nope_dim + rope_dim, (
+        f"head_dim={head_dim} != nope_dim({nope_dim}) + rope_dim({rope_dim})"
+    )
+    assert head_dim % quant_group_size == 0
+    expected_nope_mod = quant_group_size - rope_dim
+    assert nope_dim % quant_group_size == expected_nope_mod, (
+        f"Layout requires nope_dim%{quant_group_size}=="
+        f"{quant_group_size}-rope_dim={expected_nope_mod}, "
+        f"got {nope_dim % quant_group_size}"
+    )
+    assert rope_dim % 2 == 0
+    assert cos_sin_cache.dtype == torch.float32, (
+        f"cos_sin_cache must be fp32, got {cos_sin_cache.dtype}"
+    )
+
+    d = heads_per_group * head_dim
+    num_scale_blocks = d // quant_group_size
+    chunks_per_head = head_dim // quant_group_size
+
+    fp8_dtype = torch.float8_e4m3fn
+    fp8_max = torch.finfo(fp8_dtype).max
+
+    tma_aligned_T = _tma_aligned_size(num_tokens, 4)
+
+    # FP8 output buffer: fully contiguous [n_groups, num_tokens, d] — must
+    # match `fp8_batched_quantize_1x128_permute102`'s contiguous output exactly,
+    # because `cute_dsl_fp8_bmm_blackwell` consumes the FP8 buffer via
+    # `make_ptr(.data_ptr())` and assumes contiguous `(G, T, K)` strides
+    # `(T*K, K, 1)`. Padding the M dim (tma_aligned_T) leaves stride[0] =
+    # tma_aligned_T*K, which silently shifts every batch's data when
+    # num_tokens % 4 != 0 — manifested as a catastrophic gsm8k regression
+    # (96.25 -> 37.38) on Pro TEP8 c128 in the first attempt.
+    fp8_buf = torch.empty(
+        (n_groups, num_tokens, d),
+        dtype=fp8_dtype,
+        device=o.device,
+    )
+
+    # Scale buffer: contiguous [n_groups, num_scale_blocks, tma_aligned_T] FP32.
+    scale_buf = torch.empty(
+        (n_groups, num_scale_blocks, tma_aligned_T),
+        dtype=torch.float32,
+        device=o.device,
+    )
+    # The kernel addresses scales via `scale_ptr + g * scale_stride_group +
+    # token_idx + qb_indices * scale_stride_k`, i.e. layout
+    # `[n_groups, num_scale_blocks, tma_aligned_T]` with the inner stride 1
+    # along tokens.  scale_stride_group = num_scale_blocks * tma_aligned_T,
+    # scale_stride_k = tma_aligned_T.
+
+    # Pass cos_sin_cache as a flat [max_pos, rope_dim] view. TensorRT-LLM
+    # stores it as [max_pos, 2, rope_dim/2] (cos block then sin block per
+    # position) which is bit-identical layout — just a different shape.
+    cos_sin_view = cos_sin_cache.view(cos_sin_cache.shape[0], -1)
+    assert cos_sin_view.shape[-1] == rope_dim, (
+        f"cos_sin_cache last dim {cos_sin_view.shape[-1]} != rope_dim {rope_dim}"
+    )
+
+    # positions can be int32 or int64; the kernel does an opaque tl.load.
+    if positions.dtype != torch.int32 and positions.dtype != torch.int64:
+        positions = positions.to(torch.int64)
+
+    grid = (tma_aligned_T, n_groups * heads_per_group)
+    _fused_inv_rope_fp8_quant_per_head[grid](
+        o,
+        positions,
+        cos_sin_view,
+        fp8_buf,
+        scale_buf,
+        num_tokens,
+        heads_per_group=heads_per_group,
+        o_stride_token=o.stride(0),
+        o_stride_head=o.stride(1),
+        cache_stride_pos=cos_sin_view.stride(0),
+        fp8_stride_group=fp8_buf.stride(0),
+        fp8_stride_token=fp8_buf.stride(1),
+        scale_stride_group=scale_buf.stride(0),
+        scale_stride_k=scale_buf.stride(1),
+        fp8_max=fp8_max,
+        eps=1e-10,
+        QUANT_GROUP_SIZE=quant_group_size,
+        CHUNKS_PER_HEAD=chunks_per_head,
+        ROPE_START=nope_dim % quant_group_size,
+        HALF_ROPE=rope_dim // 2,
+        IS_NEOX=is_neox,
+        num_warps=1,
+        num_stages=1,
+    )
+    return fp8_buf, scale_buf
+
+
+def _fused_inv_rope_fp8_quant_fake(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    quant_group_size: int,
+    is_neox: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens, num_heads, head_dim = o.shape
+    d = heads_per_group * head_dim
+    num_scale_blocks = d // quant_group_size
+    tma_aligned_T = _tma_aligned_size(num_tokens, 4)
+    fp8_buf = torch.empty(
+        (n_groups, num_tokens, d),
+        dtype=torch.float8_e4m3fn,
+        device=o.device,
+    )
+    scale_buf = torch.empty(
+        (n_groups, num_scale_blocks, tma_aligned_T),
+        dtype=torch.float32,
+        device=o.device,
+    )
+    return fp8_buf, scale_buf
+
+
+# Register as a torch custom op so dynamo / cudagraph see an opaque boundary.
+torch.library.define(
+    "trtllm::fused_inv_rope_fp8_quant_vllm_port",
+    "(Tensor o, Tensor positions, Tensor cos_sin_cache, "
+    "int n_groups, int heads_per_group, int nope_dim, int rope_dim, "
+    "int quant_group_size, bool is_neox) -> (Tensor, Tensor)",
+)
+torch.library.impl(
+    "trtllm::fused_inv_rope_fp8_quant_vllm_port",
+    "CUDA",
+)(_fused_inv_rope_fp8_quant_impl)
+torch.library.register_fake(
+    "trtllm::fused_inv_rope_fp8_quant_vllm_port",
+)(_fused_inv_rope_fp8_quant_fake)

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -671,7 +671,9 @@ class DeepseekV4WeightLoader:
                 if o_a_proj_scale is not None:
                     o_a_proj_scale = split_matrix_tp(o_a_proj_scale, tp_size, tp_rank, 0)
 
-            if o_a_proj_scale is not None:
+            # Skip the BF16 dequant when the destination is FP8 (the cute_dsl
+            # FP8 BMM path on SM100 consumes the native FP8 weight directly).
+            if o_a_proj_scale is not None and module.o_a_proj.dtype != torch.float8_e4m3fn:
                 o_a_proj = weight_dequant(
                     o_a_proj.reshape(-1, o_a_proj.shape[-1]).contiguous().cuda(),
                     o_a_proj_scale.reshape(-1, o_a_proj_scale.shape[-1]).contiguous().cuda(),

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1618,14 +1618,29 @@ class MLA(nn.Module):
                 requires_grad=False,
             )
             if is_sm_100f():
-                self.o_a_proj_dequant = nn.Parameter(
-                    torch.empty(
-                        (self.n_local_groups, self.o_lora_rank,
-                         self.num_heads * self.qk_head_dim // self.num_groups),
-                        dtype=self.dtype,
-                    ),
-                    requires_grad=False,
-                )
+                # On DSv4 with the cute_dsl FP8 BMM enabled, keep o_a_proj in
+                # its native FP8 e4m3 form (no load-time dequant) so
+                # cute_dsl_fp8_bmm_blackwell can consume it directly.
+                if self.is_deepseek_v4 and self.use_cute_dsl_blockscaling_bmm:
+                    self.o_a_proj = nn.Parameter(
+                        torch.empty(
+                            (self.n_local_groups, self.o_lora_rank,
+                             self.num_heads * self.qk_head_dim //
+                             self.num_groups),
+                            dtype=torch.float8_e4m3fn,
+                        ),
+                        requires_grad=False,
+                    )
+                else:
+                    self.o_a_proj_dequant = nn.Parameter(
+                        torch.empty(
+                            (self.n_local_groups, self.o_lora_rank,
+                             self.num_heads * self.qk_head_dim //
+                             self.num_groups),
+                            dtype=self.dtype,
+                        ),
+                        requires_grad=False,
+                    )
         else:
             self.k_b_proj_trans_scale = None
             self.v_b_proj_scale = None
@@ -1699,6 +1714,39 @@ class MLA(nn.Module):
         num_tokens = attn_out_latent.shape[0]
         attn_out_latent = attn_out_latent.view(num_tokens, self.num_heads_tp,
                                                -1)
+
+        # When o_a_proj is FP8 and the cute_dsl FP8 BMM is enabled on SM100,
+        # fuse the inverse-RoPE into the FP8-quant epilogue (vLLM-ported
+        # Triton kernel) and call cute_dsl_fp8_bmm_blackwell directly. Saves
+        # one BF16 read+write of the latent vs the
+        # mla_rope_inplace + fp8_batched_quantize_1x128_permute102 pair.
+        fused_inv_rope_fp8 = (self.o_a_proj.dtype == torch.float8_e4m3fn
+                              and self.use_cute_dsl_blockscaling_bmm
+                              and is_sm_100f())
+        if fused_inv_rope_fp8:
+            heads_per_group = self.num_heads_tp // self.n_local_groups
+            attn_fp8, attn_scale = (
+                torch.ops.trtllm.fused_inv_rope_fp8_quant_vllm_port(
+                    attn_out_latent,
+                    position_ids.view(-1),
+                    self.inverse_rotary_emb.rotary_cos_sin,
+                    self.n_local_groups,
+                    heads_per_group,
+                    self.qk_nope_head_dim,
+                    self.qk_rope_head_dim,
+                    128,
+                    self.inverse_rotary_emb.is_neox,
+                ))
+            o_lora = torch.empty(
+                [num_tokens, self.n_local_groups, self.o_lora_rank],
+                device=attn_out_latent.device,
+                dtype=self.dtype)
+            torch.ops.trtllm.cute_dsl_fp8_bmm_blackwell(attn_fp8, self.o_a_proj,
+                                                        attn_scale,
+                                                        self.o_a_proj_scale,
+                                                        o_lora.transpose(0, 1))
+            o_lora = o_lora.flatten(1)
+            return self.o_b_proj(o_lora)
 
         # Fused in-place inverse RoPE on the rope portion of each head
         torch.ops.trtllm.mla_rope_inplace(

--- a/tests/unittest/_torch/custom_ops/test_fused_inv_rope_fp8_quant.py
+++ b/tests/unittest/_torch/custom_ops/test_fused_inv_rope_fp8_quant.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Numerical-equivalence test for the vLLM-ported fused inverse-RoPE +
+FP8 1x128 quantize op.
+
+Compares (mla_rope_inplace -> fp8_batched_quantize_1x128_permute102) against
+the new fused op `trtllm::fused_inv_rope_fp8_quant_vllm_port`.
+
+Run inside a CUDA Blackwell (SM100f) container (the TRT-LLM build sqsh).
+"""
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.custom_ops  # noqa: F401  (registers the fused op)
+from tensorrt_llm._utils import is_sm_100f
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and is_sm_100f()),
+    reason="Requires SM100 family GPU",
+)
+
+
+def _ref_path(
+    o_bf16, position_ids, rotary_cos_sin, num_heads_tp, n_groups, nope_dim, rope_dim, is_neox
+):
+    """Reference: in-place mla_rope_inplace -> fp8_batched_quantize_1x128_permute102."""
+    o = o_bf16.clone().contiguous()
+    torch.ops.trtllm.mla_rope_inplace(
+        o, position_ids.view(-1), rotary_cos_sin, num_heads_tp, nope_dim, rope_dim, True, is_neox
+    )
+    # Reshape to [N, n_groups, heads_per_group * head_dim] to match the BMM site.
+    num_tokens = o.shape[0]
+    grouped = o.view(num_tokens, n_groups, -1)
+    fp8_ref, scale_ref = torch.ops.trtllm.fp8_batched_quantize_1x128_permute102(grouped)
+    return fp8_ref, scale_ref
+
+
+def _fused_path(
+    o_bf16, position_ids, rotary_cos_sin, n_groups, heads_per_group, nope_dim, rope_dim, is_neox
+):
+    o = o_bf16.contiguous()
+    fp8_fused, scale_fused = torch.ops.trtllm.fused_inv_rope_fp8_quant_vllm_port(
+        o,
+        position_ids.view(-1),
+        rotary_cos_sin,
+        n_groups,
+        heads_per_group,
+        nope_dim,
+        rope_dim,
+        128,
+        is_neox,
+    )
+    return fp8_fused, scale_fused
+
+
+@pytest.mark.parametrize("num_tokens", [3, 64, 257, 512])
+def test_fused_inv_rope_fp8_quant_neox(num_tokens):
+    torch.manual_seed(0)
+    device = "cuda"
+    n_groups = 4
+    heads_per_group = 8  # smaller for the test
+    num_heads = n_groups * heads_per_group
+    nope_dim, rope_dim = 448, 64
+    head_dim = nope_dim + rope_dim  # 512
+    max_pos = 2048
+
+    o_bf16 = torch.randn(num_tokens, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+    # Simulate the TRT-LLM rotary_cos_sin layout: (max_pos, 2, rope_dim/2) fp32.
+    half = rope_dim // 2
+    cos = torch.randn(max_pos, half, dtype=torch.float32, device=device).cos()
+    sin = torch.randn(max_pos, half, dtype=torch.float32, device=device).sin()
+    rotary_cos_sin = torch.stack([cos, sin], dim=1).contiguous()
+    assert rotary_cos_sin.shape == (max_pos, 2, half)
+
+    position_ids = torch.randint(0, max_pos, (num_tokens,), dtype=torch.int32, device=device)
+
+    fp8_ref, scale_ref = _ref_path(
+        o_bf16, position_ids, rotary_cos_sin, num_heads, n_groups, nope_dim, rope_dim, is_neox=True
+    )
+    fp8_fused, scale_fused = _fused_path(
+        o_bf16,
+        position_ids,
+        rotary_cos_sin,
+        n_groups,
+        heads_per_group,
+        nope_dim,
+        rope_dim,
+        is_neox=True,
+    )
+
+    assert fp8_ref.shape == fp8_fused.shape, (fp8_ref.shape, fp8_fused.shape)
+    assert scale_ref.shape == scale_fused.shape, (scale_ref.shape, scale_fused.shape)
+
+    # Compare in dequantized BF16 space (FP8 truncation + FMA reordering can
+    # differ by 1 ULP).
+    def dequant(fp8, scale):
+        # fp8: [G, T, D]; scale: [G, D/128, pad_up(T,4)]
+        G, T, D = fp8.shape
+        f = fp8.to(torch.float32)
+        # Expand scale to [G, T, D]
+        s = scale.permute(0, 2, 1).contiguous()  # [G, pad_up_T, D/128]
+        s = s[:, :T, :]
+        s = s.unsqueeze(-1).expand(G, T, D // 128, 128).reshape(G, T, D)
+        return f * s
+
+    deq_ref = dequant(fp8_ref, scale_ref)
+    deq_fused = dequant(fp8_fused, scale_fused)
+    abs_diff = (deq_ref - deq_fused).abs()
+    rel = abs_diff.mean() / (deq_ref.abs().mean() + 1e-9)
+    print(
+        f"[NEOX num_tokens={num_tokens}] mean abs diff = "
+        f"{abs_diff.mean().item():.4e}  rel = {rel.item():.4e}  "
+        f"max = {abs_diff.max().item():.4e}"
+    )
+    # FP8 e4m3 has ~3 mantissa bits; 1-ULP tolerance scales with the value.
+    # Allow a generous 1% relative bound.
+    assert rel.item() < 1e-2, f"relative mismatch {rel.item()}"
+
+
+if __name__ == "__main__":
+    test_fused_inv_rope_fp8_quant_neox(64)
+    test_fused_inv_rope_fp8_quant_neox(257)
+    print("OK")


### PR DESCRIPTION
## Issue Description

DeepSeek-V4 stores `o_a_proj` (the o_lora projection) natively as FP8 e4m3 with UE8M0 1×128 block scales — the same on-disk format as `o_b_proj` and the MoE expert weights. But while the rest of the model consumes those weights in their native FP8 form, the upstream MLA path upcasts `o_a_proj` to BF16 at load time (`weight_dequant`) and runs a BF16 BMM.

## What this PR does

Gated on the existing `use_cute_dsl_blockscaling_bmm` config flag in `extra_llm_api_options` (`TorchLlmArgs.use_cute_dsl_blockscaling_bmm`, default `False`). On SM100 with that flag enabled, on DSv4:

1. Skip the load-time `weight_dequant` of `o_a_proj`; dispatch the BMM through `cute_dsl_fp8_bmm_blackwell` with FP8 weights.
2. Replace the `mla_rope_inplace` + `fp8_batched_quantize_1x128_permute102` pair with a single Triton kernel `fused_inv_rope_fp8_quant` (ported from vLLM), so the BF16 latent is read once, RoPE-rotated in registers, FP8-quantized in registers, and FP8 + UE8M0 scales written once.

With the flag off (default), behavior is byte-identical to upstream.

### Per-step kernel sequence on the o_proj path

**Before (upstream BF16 BMM):**
```
[load-time]   weight_dequant      o_a_proj FP8 + UE8M0 -> BF16  (one shot)
[per-step 1]  mla_rope_inplace    in-place inverse RoPE on BF16 latent
[per-step 2]  bmm_out             BF16 BMM (latent x dequant'd o_a_proj)
[per-step 3]  o_b_proj GEMM       fp8_swap_ab_gemm
```

**After (FP8 BMM + fused front-end):**
```
[per-step 1]  fused_inv_rope_fp8_quant     in-place inverse RoPE +
                                            FP8 1x128 block-scaled quant +
                                            UE8M0-compatible scale layout
[per-step 2]  cute_dsl_fp8_bmm_blackwell   FP8 latent x FP8 weight
[per-step 3]  o_b_proj GEMM                fp8_swap_ab_gemm (unchanged)
```

### How to enable

```yaml
# extra_llm_api_options.yaml
use_cute_dsl_blockscaling_bmm: true
```

## Perf

Pro TEP8 c128 8k-1k, mtp=0, all other gates ON, MHC fused HC OFF:

| Kernel sequence | sys tok/s | Δ vs upstream |
|---|---|---|
| Upstream BF16 BMM (`mla_rope_inplace` + `bmm_out`) | 1730.52 | — |
| FP8 BMM only (`mla_rope_inplace` + `permute102_quant` + `cute_dsl_fp8_bmm`) | 1725.99 | -0.26% |
| **This PR (`fused_inv_rope_fp8_quant` + `cute_dsl_fp8_bmm`)** | **1756.88** | **+1.52%** |

The FP8-BMM-only intermediate is essentially flat-to-slightly-negative because the per-call `permute102_quant` adds ~9 MB HBM traffic that offsets the bandwidth saving from FP8 weight. The fusion eliminates that round-trip and lands the genuine bandwidth-savings on top.

## Accuracy

gsm8k Pro TEP8 c128 (`max_batch=16`, `max_num_tokens=8192`):

| Arm | flexible-extract | strict-match | avg |
|---|---|---|---|
| Upstream BF16 BMM | 96.21 | 96.29 | 96.25 |
| **This PR** | **96.36** | **96.36** | **96.36** |

Δ = +0.11 pp, within ±0.5 pp tolerance and ±1.34 pp eval stderr.

## Front-end fusion: vLLM port

The fused kernel is a port of vLLM's `fused_inv_rope_fp8_quant`:
- Source: https://github.com/vllm-project/vllm/blob/ecd0b60aad2f4e28dd00ababfc1402690d88cbed/vllm/v1/attention/ops/deepseek_v4_ops/fused_inv_rope_fp8_quant.py
- License: Apache-2.0 (compatible with TRT-LLM's Apache-2.0). Verbatim attribution + modifications block at the top of the new file.

Modifications relative to vLLM upstream:
1. Added `IS_NEOX: tl.constexpr` branch (DSv4 uses NEOX RoPE; vLLM upstream is interleaved-only).
2. Output FP8 buffer is fully contiguous `[n_groups, num_tokens, d]` so `cute_dsl_fp8_bmm_blackwell` consumes it via `make_ptr(.data_ptr())` without an adapter.
3. Dropped the UE8M0 INT32 packed-scale path (TRT-LLM's SM100 consumer takes raw FP32 a-side scales).
4. Rebound `cos_sin_cache` to TRT-LLM's `[max_pos, 2, rope_dim/2]` layout.
5. Replaced `direct_register_custom_op` with `torch.library.custom_op` to match the rest of `tensorrt_llm/_torch/custom_ops/`.

## Test Coverage

- [x] Unit test — `tests/unittest/_torch/custom_ops/test_fused_inv_rope_fp8_quant.py` compares the fused op vs the (`mla_rope_inplace` → `fp8_batched_quantize_1x128_permute102`) reference at `num_tokens in {3, 64, 257, 512}` on NEOX. Asserts <1% relative error in dequantized space.
- [x] Multi-rank end-to-end gsm8k accuracy A/B (numbers above).
- [x] Multi-rank perf A/B (numbers above).
- [x] ~~Cross-platform CI~~ — `cute_dsl_fp8_bmm_blackwell` is SM100-only; the dispatch gates on `is_sm_100f()`. Ops register cleanly on other SMs but fall back to the legacy path.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work)).
- Any new dependencies have been scanned for license and vulnerabilities (vLLM port: Apache-2.0, attribution preserved).
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes (no ownership changes).
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR (no architecture-level change).
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.