### PR TITLE
[None][doc] Gemma 4 support & eval task updates

### DIFF
--- a/docs/source/commands/trtllm-eval.rst
+++ b/docs/source/commands/trtllm-eval.rst
@@ -44,6 +44,16 @@ The following tasks are currently supported:
      - accuracy
      - 1,024
      - 512
+   * - AIME 2025
+     - QA; regex matching
+     - accuracy
+     - 4,096
+     - 32,768
+   * - AIME 2026
+     - QA; regex matching
+     - accuracy
+     - 4,096
+     - 32,768
 
 .. note::
 
@@ -72,6 +82,10 @@ Here are some examples:
 
    # Evaluate Llama-3.3-70B-Instruct on GPQA Diamond
    trtllm-eval --model meta-llama/Llama-3.3-70B-Instruct gpqa_diamond
+
+   # Evaluate a model on AIME 2025 / 2026 (long-CoT math; requires --max_seq_len >= 36864)
+   trtllm-eval --model <model> --max_seq_len 36864 aime25
+   trtllm-eval --model <model> --max_seq_len 36864 aime26
 
 The ``--model`` argument accepts either a Hugging Face model ID or a local checkpoint path. By default, ``trtllm-eval`` runs the model with the PyTorch backend; you can pass ``--backend tensorrt`` to switch to the TensorRT backend.
 

--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -14,7 +14,8 @@ The following is a table of supported models for the PyTorch backend:
 | `ExaoneMoEForCausalLM`               | K-EXAONE                           | `LGAI-EXAONE/K-EXAONE-236B-A23B`             |
 | `Gemma3ForCausalLM`                  | Gemma 3                            | `google/gemma-3-1b-it`                       |
 | `Gemma3nForConditionalGeneration` [^8]| Gemma 3n                           | `google/gemma-3n-E2B-it`, `google/gemma-3n-E4B-it` |
-| `Gemma4ForConditionalGeneration` [^7]| Gemma 4                            | `google/gemma-4-26B-A4B-it`, `google/gemma-4-31B-it` |
+| `Gemma4ForConditionalGeneration` [^10]| Gemma 4                            | `google/gemma-4-E2B-it`, `google/gemma-4-E4B-it`, `google/gemma-4-26B-A4B-it`, `google/gemma-4-31B-it` |
+| `Gemma4ForConditionalGeneration` [^7]| Gemma 4 (AutoDeploy, text-only)    | `google/gemma-4-26B-A4B-it`, `google/gemma-4-31B-it` |
 | `Glm4MoeForCausalLM`                 | GLM-4.5, GLM-4.6, GLM-4.7          | `THUDM/GLM-4-100B-A10B`                      |
 | `Glm4MoeLiteForCausalLM` [^6]        | GLM-4.7-Flash                      | `zai-org/GLM-4.7-Flash`                      |
 | `GlmMoeDsaForCausalLM`               | GLM-5                              | `zai-org/GLM-5`                              |
@@ -55,6 +56,7 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 | `Qwen3_5MoeForCausalLM` [^5]  | Yes               | Yes        | Untested                   | Untested              | Yes             | No  | No                                 | No                                  | No                        | Yes           | Untested         | Yes       | N/A                      | Untested              | Untested        |
 | `Glm4MoeLiteForCausalLM` [^6] | Yes               | Yes        | Untested                   | Untested              | Yes             | No  | No                                 | No                                  | No                        | Yes           | Untested         | Untested       | N/A                      | Untested              | Untested        |
 | `NemotronHForCausalLM` (Super) | Yes               | Yes        | Untested                   | Untested              | Yes             | Yes | No                                 | No                                  | No                        | Yes           | Yes              | Untested       | N/A                      | Untested              | Untested        |
+| `Gemma4ForConditionalGeneration` | Untested          | Yes        | Untested                   | No                    | No              | No  | No                                 | No                                  | No                        | Yes           | Untested         | No             | Yes                      | Untested              | Untested        |
 
 [^1]: Chunked Prefill for MLA can only be enabled on SM100/SM103.
 [^2]: KV cache reuse for MLA can only be enabled on SM90/SM100/SM103 and in BF16/FP8 KV cache dtype.
@@ -65,6 +67,8 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 [^7]: Text-only support via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See AD configs for [MoE](../../../examples/auto_deploy/model_registry/configs/gemma4_moe.yaml) and [dense](../../../examples/auto_deploy/model_registry/configs/gemma4_dense.yaml).
 [^8]: Text-only support via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD config](../../../examples/auto_deploy/model_registry/configs/gemma3n_e2b_it.yaml).
 [^9]: Supported via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD config](../../../examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml).
+[^10]: Requires manually upgrading transformers to 5.5.3 for Gemma 4.
+[^11]: Audio modality only supported on E2B/E4B variants.
 
 
 # Multimodal Feature Support Matrix (PyTorch Backend)
@@ -72,6 +76,7 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 | Model Architecture/Feature           | Overlap Scheduler | CUDA Graph | Chunked Prefill | Torch Sampler | TLLM C++ Sampler | KV Cache Reuse | Logits Post Processor | EPD Disaggregated Serving | Modality  |
 | ------------------------------------ | ----------------- | ---------- | --------------- | ------------- | ---------------- | -------------- | --------------------- | ------------------------- | --------- |
 | `Gemma3ForConditionalGeneration`     | Yes               | Yes        | N/A             | Yes           | Yes              | N/A            | Yes                   | No                        | L + I     |
+| `Gemma4ForConditionalGeneration`     | Untested          | Yes        | No              | Yes           | Untested         | No             | Untested              | No                        | L + I + A [^11] |
 | `HCXVisionForCausalLM`               | Yes               | Yes        | No              | Yes           | Yes              | Yes            | Yes                   | No                        | L + I     |
 | `LlavaLlamaModel (VILA)`             | Yes               | Yes        | No              | Yes           | Yes              | No             | Yes                   | No                        | L + I + V |
 | `LlavaNextForConditionalGeneration`  | Yes               | Yes        | Yes             | Yes           | Yes              | Yes            | Yes                   | Yes                       | L + I     |

--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -63,7 +63,7 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 [^4]: Overlap scheduler isn't supported when using EAGLE-3(Two Model Engine) for GPT-OSS.
 [^5]: Supported via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD config](../../../examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml).
 [^6]: Supported via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD config](../../../examples/auto_deploy/model_registry/configs/glm-4.7-flash.yaml).
-[^7]: Text-only support via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See AD configs for [MoE](../../../examples/auto_deploy/model_registry/configs/gemma4_moe.yaml) and [dense](../../../examples/auto_deploy/model_registry/configs/gemma4_dense.yaml).
+[^7]: Also supports text-only inference via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See AD configs for [MoE](../../../examples/auto_deploy/model_registry/configs/gemma4_moe.yaml) and [dense](../../../examples/auto_deploy/model_registry/configs/gemma4_dense.yaml).
 [^8]: Text-only support via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD config](../../../examples/auto_deploy/model_registry/configs/gemma3n_e2b_it.yaml).
 [^9]: Supported via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD config](../../../examples/auto_deploy/model_registry/configs/minimax_m2.7.yaml).
 [^10]: Requires manually upgrading transformers to 5.5.3 for Gemma 4.

--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -14,8 +14,7 @@ The following is a table of supported models for the PyTorch backend:
 | `ExaoneMoEForCausalLM`               | K-EXAONE                           | `LGAI-EXAONE/K-EXAONE-236B-A23B`             |
 | `Gemma3ForCausalLM`                  | Gemma 3                            | `google/gemma-3-1b-it`                       |
 | `Gemma3nForConditionalGeneration` [^8]| Gemma 3n                           | `google/gemma-3n-E2B-it`, `google/gemma-3n-E4B-it` |
-| `Gemma4ForConditionalGeneration` [^10]| Gemma 4                            | `google/gemma-4-E2B-it`, `google/gemma-4-E4B-it`, `google/gemma-4-26B-A4B-it`, `google/gemma-4-31B-it` |
-| `Gemma4ForConditionalGeneration` [^7]| Gemma 4 (AutoDeploy, text-only)    | `google/gemma-4-26B-A4B-it`, `google/gemma-4-31B-it` |
+| `Gemma4ForConditionalGeneration` [^10]| Gemma 4                            | `google/gemma-4-E2B-it`, `google/gemma-4-E4B-it`, `google/gemma-4-26B-A4B-it` [^7], `google/gemma-4-31B-it` [^7] |
 | `Glm4MoeForCausalLM`                 | GLM-4.5, GLM-4.6, GLM-4.7          | `THUDM/GLM-4-100B-A10B`                      |
 | `Glm4MoeLiteForCausalLM` [^6]        | GLM-4.7-Flash                      | `zai-org/GLM-4.7-Flash`                      |
 | `GlmMoeDsaForCausalLM`               | GLM-5                              | `zai-org/GLM-5`                              |


### PR DESCRIPTION
## Summary
  - Add Gemma 4 entries to `docs/source/models/supported-models.md`:
    - PyTorch backend supported-models row covering all four variants
      (E2B / E4B / 26B-A4B / 31B), with AutoDeploy text-only support
      indicated on the 26B / 31B variants.
    - Model-Feature Support Matrix (Key Models) row with conservative
      labels (Yes for CUDA Graph / Torch Sampler / Sliding Window;
      others No or Untested).
    - Multimodal Feature Support Matrix row with modality `L + I + A`
      and a footnote noting audio is supported only on E2B / E4B.
    - Footnote noting the manual `transformers==5.5.3` upgrade
      requirement for Gemma 4.
  - Document the AIME 2025 / AIME 2026 tasks in
    `docs/source/commands/trtllm-eval.rst` (QA / regex matching,
    accuracy, ISL 4,096 / OSL 32,768 — matching the harness yaml's
    greedy recipe), with an example invocation noting the
    `--max_seq_len >= 36864` requirement for long-CoT generation.

  ## Test Coverage
  Docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AIME 2025 and AIME 2026 evaluation tasks to supported evaluation options with accuracy metrics and default sequence length values
  * Included usage examples for running new AIME evaluation tasks (requires minimum `--max_seq_len >= 36864`)
  * Expanded Gemma 4 model documentation with multimodal feature support including audio modality capabilities and requirements

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/13947)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->