### PR TITLE
[None][feat] Multi-K (512/1024/2048) and Multi-dtype (fp32/bf16/fp16) GVR Top-K

### DIFF
--- a/cpp/tensorrt_llm/kernels/IndexerTopK.h
+++ b/cpp/tensorrt_llm/kernels/IndexerTopK.h
@@ -27,24 +27,32 @@ TRTLLM_NAMESPACE_BEGIN
 
 namespace kernels
 {
-/// fp32 indexer TopK decode — Scheme X v1.2 dispatcher (GVR Heuristic /
-/// Insertion / Radix / Radix-split-work). Production V2e path.
+/// fp32 indexer TopK decode — L2-aware BS-threshold dispatcher with four
+/// fallback tiers:
+///   - GVR Heuristic    (preIdx provided, kSeqSmall ≤ N < splitWork, BS < kBsLarge, K ∈ {512,1024,2048})
+///   - Insertion sort   (N < kSortingAlgorithmThreshold)
+///   - Radix sort       (kSortingAlgorithmThreshold ≤ N < splitWork)
+///   - Radix split-work (N ≥ splitWork — uses outLogitsAux / outIndicesAux)
 void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indices, float* outLogitsAux,
     int* outIndicesAux, int const splitWorkThreshold, int const numRows, int const numColumns, int const stride0,
     int const stride1, int const next_n, int const topK = 2048, int const* preIdx = nullptr, int const preIdxStride = 0,
     int const preIdxCount = 0, float* heuristicScratch = nullptr, cudaStream_t const stream = 0);
 
-/// bf16 indexer TopK decode (4d_multi_dtype_unified, 2026-05-06).
-/// GVR-Heuristic path only — bf16/fp16 inputs have no radix fallback (the
-/// production radix kernel is fp32-only). Caller MUST satisfy GVR conditions
-/// (preIdx provided, numRows < kBsLarge, numColumns ∈ [kSeqSmall, kSplitWork))
-/// or cast to fp32 first.
+/// bf16 indexer TopK decode — same dispatch axes as the fp32 entry, except
+/// kBsL2 uses sizeof(__nv_bfloat16) bytes/elem (L2 footprint is half) and
+/// the split-work tier is unsupported (the bf16/fp16 entry does not expose
+/// the float aux buffers required for split-work). Insertion + radix tiers
+/// share topKPerRowDecode with fp32 — histogram and sort run on float keys
+/// after a static_cast<float>(InputT) at HBM-read sites.
+///
+/// Aborts with TLLM_CHECK if numColumns ≥ splitWorkThreshold; callers in
+/// that regime must use the fp32 entry.
 void invokeIndexerTopKDecode(__nv_bfloat16 const* logits, int const* seqLens, int* indices,
     int const splitWorkThreshold, int const numRows, int const numColumns, int const stride0, int const stride1,
     int const next_n, int const topK = 2048, int const* preIdx = nullptr, int const preIdxStride = 0,
     int const preIdxCount = 0, __nv_bfloat16* heuristicScratch = nullptr, cudaStream_t const stream = 0);
 
-/// fp16 indexer TopK decode (4d_multi_dtype_unified, 2026-05-06). See bf16 doc.
+/// fp16 indexer TopK decode — see bf16 overload for dispatcher contract.
 void invokeIndexerTopKDecode(__half const* logits, int const* seqLens, int* indices, int const splitWorkThreshold,
     int const numRows, int const numColumns, int const stride0, int const stride1, int const next_n,
     int const topK = 2048, int const* preIdx = nullptr, int const preIdxStride = 0, int const preIdxCount = 0,
@@ -53,6 +61,21 @@ void invokeIndexerTopKDecode(__half const* logits, int const* seqLens, int* indi
 void invokeIndexerTopKPrefill(float const* logits, int const* rowStarts, int const* rowEnds, int* indices,
     int const numRows, int const numColumns, int const stride0, int const stride1, int const topK = 2048,
     cudaStream_t const stream = 0);
+
+/// Returns true iff invokeIndexerTopKDecode would route to the GVR Heuristic
+/// kernel for this (numRows, numColumns, topK) triple, assuming valid preIdx
+/// is provided and stride1 == 1. Useful for callers that need to provision a
+/// preIdx tensor or heuristicScratch buffer only when GVR will be selected.
+///
+/// Mirrors the gating logic of the dispatcher: K ∈ {512, 1024, 2048},
+/// numColumns ∈ [kSeqSmall, splitWorkThreshold), numRows < kBsLarge, where
+/// kBsLarge = min(kBsWave, kBsL2) and kBsL2 scales with bytesPerElem.
+///
+/// @param numRows         logits rows (batch · next_n)
+/// @param numColumns      logits columns (max sequence length)
+/// @param topK            requested output size
+/// @param bytesPerElem    element size of logits (4 for fp32, 2 for bf16/fp16)
+bool canIndexerTopKDecodeUseGvr(int numRows, int numColumns, int topK, int bytesPerElem = 4);
 
 } // namespace kernels
 

--- a/cpp/tensorrt_llm/kernels/IndexerTopK.h
+++ b/cpp/tensorrt_llm/kernels/IndexerTopK.h
@@ -27,10 +27,28 @@ TRTLLM_NAMESPACE_BEGIN
 
 namespace kernels
 {
+/// fp32 indexer TopK decode — Scheme X v1.2 dispatcher (GVR Heuristic /
+/// Insertion / Radix / Radix-split-work). Production V2e path.
 void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indices, float* outLogitsAux,
     int* outIndicesAux, int const splitWorkThreshold, int const numRows, int const numColumns, int const stride0,
     int const stride1, int const next_n, int const topK = 2048, int const* preIdx = nullptr, int const preIdxStride = 0,
     int const preIdxCount = 0, float* heuristicScratch = nullptr, cudaStream_t const stream = 0);
+
+/// bf16 indexer TopK decode (4d_multi_dtype_unified, 2026-05-06).
+/// GVR-Heuristic path only — bf16/fp16 inputs have no radix fallback (the
+/// production radix kernel is fp32-only). Caller MUST satisfy GVR conditions
+/// (preIdx provided, numRows < kBsLarge, numColumns ∈ [kSeqSmall, kSplitWork))
+/// or cast to fp32 first.
+void invokeIndexerTopKDecode(__nv_bfloat16 const* logits, int const* seqLens, int* indices,
+    int const splitWorkThreshold, int const numRows, int const numColumns, int const stride0, int const stride1,
+    int const next_n, int const topK = 2048, int const* preIdx = nullptr, int const preIdxStride = 0,
+    int const preIdxCount = 0, __nv_bfloat16* heuristicScratch = nullptr, cudaStream_t const stream = 0);
+
+/// fp16 indexer TopK decode (4d_multi_dtype_unified, 2026-05-06). See bf16 doc.
+void invokeIndexerTopKDecode(__half const* logits, int const* seqLens, int* indices, int const splitWorkThreshold,
+    int const numRows, int const numColumns, int const stride0, int const stride1, int const next_n,
+    int const topK = 2048, int const* preIdx = nullptr, int const preIdxStride = 0, int const preIdxCount = 0,
+    __half* heuristicScratch = nullptr, cudaStream_t const stream = 0);
 
 void invokeIndexerTopKPrefill(float const* logits, int const* rowStarts, int const* rowEnds, int* indices,
     int const numRows, int const numColumns, int const stride0, int const stride1, int const topK = 2048,

--- a/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
+++ b/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
@@ -108,8 +108,8 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernelDtype(I
     int const* __restrict__ seqLens, int const* __restrict__ preIdx, InputT* __restrict__ scratchValues,
     int* __restrict__ outIndices, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount)
 {
-    using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
-    using SmemT = KernelSmemTplK<SmemKey, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
+    // P0 (2026-05-07): dtype path uses fp32 keys[] in smem (deferred convert).
+    using SmemT = KernelSmemTplK<float, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
 
     int const rowIdx = blockIdx.x;
     int const seq_len = seqLens[rowIdx / next_n];
@@ -191,8 +191,8 @@ void launchHeuristicTopKDecodeDtype(InputT const* logits, int const* seqLens, in
 
     auto launchOne = [&]<int TopK>()
     {
-        using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
-        using SmemT = KernelSmemTplK<SmemKey, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
+        // P0 (2026-05-07): dtype path uses fp32 keys[] in smem.
+        using SmemT = KernelSmemTplK<float, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
         size_t const smemSize = sizeof(SmemT);
 
         auto kfn = heuristicTopKMultiRowKernelDtype<InputT, TopK>;

--- a/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
+++ b/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
@@ -174,27 +174,38 @@ template __global__ void heuristicTopKMultiRowKernel<2048>(
 // Dispatch on topK at runtime — each TopK-instantiation gets its own smem
 // size (driven by GvrParams<InputT, TopK>::kC/kNumBins) and own kfn pointer
 // (cudaFuncSetAttribute / cudaLaunchKernelEx target the right kernel).
+//
+// fp32 routes to heuristicTopKMultiRowKernel<TopK>; bf16/fp16 route to
+// heuristicTopKMultiRowKernelDtype<InputT, TopK>. Vector-load alignment
+// requirement is 4 elements for fp32 (float4) and 8 elements for bf16/fp16
+// (int4 of 16-bit). In TRT-LLM the logits stride is always a multiple of
+// tokens_per_block (≥64), so the alignment check is never hit at runtime
+// — it's an assert against caller misuse.
 template <typename InputT>
-void launchHeuristicTopKDecodeDtype(InputT const* logits, int const* seqLens, int const* preIdx, int* outIndices,
+void launchHeuristicTopKDecodeImpl(InputT const* logits, int const* seqLens, int const* preIdx, int* outIndices,
     InputT* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
     cudaStream_t stream)
 {
     TLLM_CHECK_WITH_INFO(
         topK == 512 || topK == 1024 || topK == 2048, "heuristicTopKDecode requires topK ∈ {512, 1024, 2048}");
 
-    // 8-wide vector loads require 16-byte-aligned row pointers (8 × 2-byte = 16-byte).
-    // In TRT-LLM the logits stride is always a multiple of tokens_per_block (≥64),
-    // so this condition is never hit. Assert rather than silently allocating.
-    TLLM_CHECK_WITH_INFO(stride0 % 8 == 0 || numRows <= 1,
-        "heuristicTopKDecode (bf16/fp16) requires logits stride0 divisible by 8 for multi-row launch");
+    constexpr int kAlign = std::is_same_v<InputT, float> ? 4 : 8;
+    TLLM_CHECK_WITH_INFO(stride0 % kAlign == 0 || numRows <= 1,
+        "heuristicTopKDecode requires logits stride0 divisible by %d for multi-row launch", kAlign);
 
     auto launchOne = [&]<int TopK>()
     {
-        // dtype path uses fp32 keys[] in smem.
+        // bf16/fp16 path also uses fp32 keys[] in smem (down-conversion deferred).
         using SmemT = KernelSmemTplK<float, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
         size_t const smemSize = sizeof(SmemT);
 
-        auto kfn = heuristicTopKMultiRowKernelDtype<InputT, TopK>;
+        auto kfn = []()
+        {
+            if constexpr (std::is_same_v<InputT, float>)
+                return heuristicTopKMultiRowKernel<TopK>;
+            else
+                return heuristicTopKMultiRowKernelDtype<InputT, TopK>;
+        }();
 
         if (smemSize > 48u * 1024u)
         {
@@ -221,6 +232,7 @@ void launchHeuristicTopKDecodeDtype(InputT const* logits, int const* seqLens, in
     case 512: launchOne.template operator()<512>(); break;
     case 1024: launchOne.template operator()<1024>(); break;
     case 2048: launchOne.template operator()<2048>(); break;
+    default: TLLM_THROW("heuristicTopKDecode: topK validated above; unreachable");
     }
 }
 
@@ -230,55 +242,15 @@ void launchHeuristicTopKDecode(float const* logits, int const* seqLens, int cons
     float* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
     cudaStream_t stream)
 {
-    TLLM_CHECK_WITH_INFO(
-        topK == 512 || topK == 1024 || topK == 2048, "heuristicTopKDecode requires topK ∈ {512, 1024, 2048}");
-
-    // float4 loads require 16-byte-aligned (4-float) row pointers.
-    // In TRT-LLM the logits stride is always a multiple of tokens_per_block (≥64),
-    // so this condition is never hit. Assert rather than silently allocating.
-    TLLM_CHECK_WITH_INFO(stride0 % 4 == 0 || numRows <= 1,
-        "heuristicTopKDecode requires logits stride0 divisible by 4 for multi-row launch");
-
-    auto launchOne = [&]<int TopK>()
-    {
-        using SmemT = KernelSmemTplK<float, GvrParams<float, TopK>::kC, GvrParams<float, TopK>::kNumBins>;
-        size_t const smemSize = sizeof(SmemT);
-
-        auto kfn = heuristicTopKMultiRowKernel<TopK>;
-
-        if (smemSize > 48u * 1024u)
-        {
-            cudaFuncSetAttribute(kfn, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
-        }
-
-        cudaLaunchConfig_t config;
-        config.gridDim = numRows;
-        config.blockDim = BLOCK_SIZE;
-        config.dynamicSmemBytes = smemSize;
-        config.stream = stream;
-        cudaLaunchAttribute attrs[1];
-        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-        attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
-        config.numAttrs = 1;
-        config.attrs = attrs;
-
-        cudaLaunchKernelEx(&config, kfn, logits, seqLens, preIdx, scratchValues, outIndices, stride0, next_n, topK,
-            preIdxStride, preIdxCount);
-    };
-
-    switch (topK)
-    {
-    case 512: launchOne.template operator()<512>(); break;
-    case 1024: launchOne.template operator()<1024>(); break;
-    case 2048: launchOne.template operator()<2048>(); break;
-    }
+    launchHeuristicTopKDecodeImpl<float>(logits, seqLens, preIdx, outIndices, scratchValues, stride0, next_n, topK,
+        preIdxStride, preIdxCount, numRows, stream);
 }
 
 void launchHeuristicTopKDecode(__nv_bfloat16 const* logits, int const* seqLens, int const* preIdx, int* outIndices,
     __nv_bfloat16* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
     cudaStream_t stream)
 {
-    launchHeuristicTopKDecodeDtype<__nv_bfloat16>(logits, seqLens, preIdx, outIndices, scratchValues, stride0, next_n,
+    launchHeuristicTopKDecodeImpl<__nv_bfloat16>(logits, seqLens, preIdx, outIndices, scratchValues, stride0, next_n,
         topK, preIdxStride, preIdxCount, numRows, stream);
 }
 
@@ -286,7 +258,7 @@ void launchHeuristicTopKDecode(__half const* logits, int const* seqLens, int con
     __half* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
     cudaStream_t stream)
 {
-    launchHeuristicTopKDecodeDtype<__half>(logits, seqLens, preIdx, outIndices, scratchValues, stride0, next_n, topK,
+    launchHeuristicTopKDecodeImpl<__half>(logits, seqLens, preIdx, outIndices, scratchValues, stride0, next_n, topK,
         preIdxStride, preIdxCount, numRows, stream);
 }
 

--- a/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
+++ b/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
@@ -38,19 +38,21 @@ namespace
 
 using heuristic_topk::BLOCK_SIZE;
 using heuristic_topk::GvrDtypeTraits;
+using heuristic_topk::GvrParams;
 using heuristic_topk::gvrTopKJob;
 using heuristic_topk::gvrTopKJobDtype;
-using heuristic_topk::KernelSmem;
-using heuristic_topk::KernelSmemTpl;
-using heuristic_topk::TOP_K;
+using heuristic_topk::KernelSmemTplK;
 
-// heuristicTopKMultiRowKernel — outer multi-row launch wrapper (1 CTA per row).
-// Computes per-row parameters, then dispatches to the GVR micro-kernel
-// (gvrTopKJob, single-CTA single-row, independently optimized device function).
+// 4d.D: heuristicTopKMultiRowKernel templated on TopK so launcher can
+// dispatch K=512/1024/2048 to the same kernel template. Smem layout
+// derived from GvrParams<float, TopK> at compile time.
+template <int TopK>
 __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float const* __restrict__ logits,
     int const* __restrict__ seqLens, int const* __restrict__ preIdx, float* __restrict__ scratchValues,
     int* __restrict__ outIndices, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount)
 {
+    using SmemT = KernelSmemTplK<float, GvrParams<float, TopK>::kC, GvrParams<float, TopK>::kNumBins>;
+
     int const rowIdx = blockIdx.x;
     int const seq_len = seqLens[rowIdx / next_n];
     int const N = seq_len - next_n + (rowIdx % next_n) + 1;
@@ -61,7 +63,7 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float 
     int* __restrict__ outputIndices = outIndices + static_cast<int64_t>(rowIdx) * topK;
 
     extern __shared__ unsigned char smem_raw[];
-    auto* smem = reinterpret_cast<KernelSmem*>(smem_raw);
+    auto* smem = reinterpret_cast<SmemT*>(smem_raw);
 
     if (N <= topK)
     {
@@ -85,7 +87,7 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float 
     // +1 accounts for the temporal shift: prev_topk indices were computed at
     // seq_len-1, but the current step has one additional KV token appended.
     int const preIdxOffset = (rowIdx % next_n) + 1;
-    gvrTopKJob(input, N, rowPreIdx, preIdxCount, topK, outputValues, outputIndices, smem, preIdxOffset);
+    gvrTopKJob<TopK>(input, N, rowPreIdx, preIdxCount, topK, outputValues, outputIndices, smem, preIdxOffset);
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaTriggerProgrammaticLaunchCompletion();
 #endif
@@ -99,12 +101,15 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float 
 // only the input/output dtype, the smem-key dtype, and the GVR job called
 // (gvrTopKJobDtype<InputT>) differ.
 
-template <typename InputT>
+// 4d.D: dtype multi-row kernel templated on (InputT, TopK). Smem layout
+// derived from GvrParams<InputT, TopK>.
+template <typename InputT, int TopK>
 __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernelDtype(InputT const* __restrict__ logits,
     int const* __restrict__ seqLens, int const* __restrict__ preIdx, InputT* __restrict__ scratchValues,
     int* __restrict__ outIndices, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount)
 {
     using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
+    using SmemT = KernelSmemTplK<SmemKey, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
 
     int const rowIdx = blockIdx.x;
     int const seq_len = seqLens[rowIdx / next_n];
@@ -116,7 +121,7 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernelDtype(I
     int* __restrict__ outputIndices = outIndices + static_cast<int64_t>(rowIdx) * topK;
 
     extern __shared__ unsigned char smem_raw[];
-    auto* smem = reinterpret_cast<KernelSmemTpl<SmemKey>*>(smem_raw);
+    auto* smem = reinterpret_cast<SmemT*>(smem_raw);
 
     if (N <= topK)
     {
@@ -139,36 +144,44 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernelDtype(I
     }
 
     int const preIdxOffset = (rowIdx % next_n) + 1;
-    gvrTopKJobDtype<InputT>(input, N, rowPreIdx, preIdxCount, topK, outputValues, outputIndices, smem, preIdxOffset);
+    gvrTopKJobDtype<InputT, TopK>(
+        input, N, rowPreIdx, preIdxCount, topK, outputValues, outputIndices, smem, preIdxOffset);
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }
 
-// Explicit instantiations for the two non-fp32 dtypes used at launch time
-// (kept inside the anonymous namespace so they share the function-pointer
-// identities used by cudaFuncSetAttribute / cudaLaunchKernelEx below).
-template __global__ void heuristicTopKMultiRowKernelDtype<__nv_bfloat16>(
+// Explicit instantiations — 6 (dtype × K) combos. Launchers dispatch on
+// runtime topK via switch, so all 6 must be available at link time.
+template __global__ void heuristicTopKMultiRowKernelDtype<__nv_bfloat16, 512>(
     __nv_bfloat16 const*, int const*, int const*, __nv_bfloat16*, int*, int, int, int, int, int);
-template __global__ void heuristicTopKMultiRowKernelDtype<__half>(
+template __global__ void heuristicTopKMultiRowKernelDtype<__nv_bfloat16, 1024>(
+    __nv_bfloat16 const*, int const*, int const*, __nv_bfloat16*, int*, int, int, int, int, int);
+template __global__ void heuristicTopKMultiRowKernelDtype<__nv_bfloat16, 2048>(
+    __nv_bfloat16 const*, int const*, int const*, __nv_bfloat16*, int*, int, int, int, int, int);
+template __global__ void heuristicTopKMultiRowKernelDtype<__half, 512>(
     __half const*, int const*, int const*, __half*, int*, int, int, int, int, int);
+template __global__ void heuristicTopKMultiRowKernelDtype<__half, 1024>(
+    __half const*, int const*, int const*, __half*, int*, int, int, int, int, int);
+template __global__ void heuristicTopKMultiRowKernelDtype<__half, 2048>(
+    __half const*, int const*, int const*, __half*, int*, int, int, int, int, int);
+template __global__ void heuristicTopKMultiRowKernel<512>(
+    float const*, int const*, int const*, float*, int*, int, int, int, int, int);
+template __global__ void heuristicTopKMultiRowKernel<1024>(
+    float const*, int const*, int const*, float*, int*, int, int, int, int, int);
+template __global__ void heuristicTopKMultiRowKernel<2048>(
+    float const*, int const*, int const*, float*, int*, int, int, int, int, int);
 
+// 4d.D: dispatch on topK at runtime — each TopK-instantiation gets its own
+// smem size (driven by GvrParams<InputT, TopK>::kC/kNumBins) and own kfn
+// pointer (cudaFuncSetAttribute / cudaLaunchKernelEx target the right kernel).
 template <typename InputT>
 void launchHeuristicTopKDecodeDtype(InputT const* logits, int const* seqLens, int const* preIdx, int* outIndices,
     InputT* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
     cudaStream_t stream)
 {
-    TLLM_CHECK_WITH_INFO(topK == TOP_K, "heuristicTopKDecode requires topK == 2048 (compile-time constant)");
-
-    using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
-    size_t const smemSize = sizeof(KernelSmemTpl<SmemKey>);
-
-    auto kfn = heuristicTopKMultiRowKernelDtype<InputT>;
-
-    if (smemSize > 48u * 1024u)
-    {
-        cudaFuncSetAttribute(kfn, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
-    }
+    TLLM_CHECK_WITH_INFO(
+        topK == 512 || topK == 1024 || topK == 2048, "heuristicTopKDecode requires topK ∈ {512, 1024, 2048}");
 
     // 8-wide vector loads require 16-byte-aligned row pointers (8 × 2-byte = 16-byte).
     // In TRT-LLM the logits stride is always a multiple of tokens_per_block (≥64),
@@ -176,19 +189,40 @@ void launchHeuristicTopKDecodeDtype(InputT const* logits, int const* seqLens, in
     TLLM_CHECK_WITH_INFO(stride0 % 8 == 0 || numRows <= 1,
         "heuristicTopKDecode (bf16/fp16) requires logits stride0 divisible by 8 for multi-row launch");
 
-    cudaLaunchConfig_t config;
-    config.gridDim = numRows;
-    config.blockDim = BLOCK_SIZE;
-    config.dynamicSmemBytes = smemSize;
-    config.stream = stream;
-    cudaLaunchAttribute attrs[1];
-    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-    attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
-    config.numAttrs = 1;
-    config.attrs = attrs;
+    auto launchOne = [&]<int TopK>()
+    {
+        using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
+        using SmemT = KernelSmemTplK<SmemKey, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
+        size_t const smemSize = sizeof(SmemT);
 
-    cudaLaunchKernelEx(&config, kfn, logits, seqLens, preIdx, scratchValues, outIndices, stride0, next_n, topK,
-        preIdxStride, preIdxCount);
+        auto kfn = heuristicTopKMultiRowKernelDtype<InputT, TopK>;
+
+        if (smemSize > 48u * 1024u)
+        {
+            cudaFuncSetAttribute(kfn, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
+        }
+
+        cudaLaunchConfig_t config;
+        config.gridDim = numRows;
+        config.blockDim = BLOCK_SIZE;
+        config.dynamicSmemBytes = smemSize;
+        config.stream = stream;
+        cudaLaunchAttribute attrs[1];
+        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+        config.numAttrs = 1;
+        config.attrs = attrs;
+
+        cudaLaunchKernelEx(&config, kfn, logits, seqLens, preIdx, scratchValues, outIndices, stride0, next_n, topK,
+            preIdxStride, preIdxCount);
+    };
+
+    switch (topK)
+    {
+    case 512: launchOne.template operator()<512>(); break;
+    case 1024: launchOne.template operator()<1024>(); break;
+    case 2048: launchOne.template operator()<2048>(); break;
+    }
 }
 
 } // anonymous namespace
@@ -197,17 +231,8 @@ void launchHeuristicTopKDecode(float const* logits, int const* seqLens, int cons
     float* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
     cudaStream_t stream)
 {
-    TLLM_CHECK_WITH_INFO(topK == TOP_K, "heuristicTopKDecode requires topK == 2048 (compile-time constant)");
-
-    size_t const smemSize = sizeof(KernelSmem);
-
-    // Opt-in to extended shared memory. cudaFuncSetAttribute is device-scoped
-    // and cheap — call unconditionally to be safe across multi-GPU processes.
-    if (smemSize > 48u * 1024u)
-    {
-        cudaFuncSetAttribute(
-            heuristicTopKMultiRowKernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
-    }
+    TLLM_CHECK_WITH_INFO(
+        topK == 512 || topK == 1024 || topK == 2048, "heuristicTopKDecode requires topK ∈ {512, 1024, 2048}");
 
     // float4 loads require 16-byte-aligned (4-float) row pointers.
     // In TRT-LLM the logits stride is always a multiple of tokens_per_block (≥64),
@@ -215,19 +240,39 @@ void launchHeuristicTopKDecode(float const* logits, int const* seqLens, int cons
     TLLM_CHECK_WITH_INFO(stride0 % 4 == 0 || numRows <= 1,
         "heuristicTopKDecode requires logits stride0 divisible by 4 for multi-row launch");
 
-    cudaLaunchConfig_t config;
-    config.gridDim = numRows;
-    config.blockDim = BLOCK_SIZE;
-    config.dynamicSmemBytes = smemSize;
-    config.stream = stream;
-    cudaLaunchAttribute attrs[1];
-    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-    attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
-    config.numAttrs = 1;
-    config.attrs = attrs;
+    auto launchOne = [&]<int TopK>()
+    {
+        using SmemT = KernelSmemTplK<float, GvrParams<float, TopK>::kC, GvrParams<float, TopK>::kNumBins>;
+        size_t const smemSize = sizeof(SmemT);
 
-    cudaLaunchKernelEx(&config, heuristicTopKMultiRowKernel, logits, seqLens, preIdx, scratchValues, outIndices,
-        stride0, next_n, topK, preIdxStride, preIdxCount);
+        auto kfn = heuristicTopKMultiRowKernel<TopK>;
+
+        if (smemSize > 48u * 1024u)
+        {
+            cudaFuncSetAttribute(kfn, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
+        }
+
+        cudaLaunchConfig_t config;
+        config.gridDim = numRows;
+        config.blockDim = BLOCK_SIZE;
+        config.dynamicSmemBytes = smemSize;
+        config.stream = stream;
+        cudaLaunchAttribute attrs[1];
+        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+        config.numAttrs = 1;
+        config.attrs = attrs;
+
+        cudaLaunchKernelEx(&config, kfn, logits, seqLens, preIdx, scratchValues, outIndices, stride0, next_n, topK,
+            preIdxStride, preIdxCount);
+    };
+
+    switch (topK)
+    {
+    case 512: launchOne.template operator()<512>(); break;
+    case 1024: launchOne.template operator()<1024>(); break;
+    case 2048: launchOne.template operator()<2048>(); break;
+    }
 }
 
 void launchHeuristicTopKDecode(__nv_bfloat16 const* logits, int const* seqLens, int const* preIdx, int* outIndices,

--- a/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
+++ b/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
@@ -26,6 +26,8 @@
 #include "tensorrt_llm/kernels/heuristic_topk.cuh"
 
 #include <cfloat>
+#include <cuda_bf16.h> // 4d: bf16 input dtype support
+#include <cuda_fp16.h> // 4d: fp16 input dtype support
 
 TRTLLM_NAMESPACE_BEGIN
 
@@ -35,8 +37,11 @@ namespace
 {
 
 using heuristic_topk::BLOCK_SIZE;
+using heuristic_topk::GvrDtypeTraits;
 using heuristic_topk::gvrTopKJob;
+using heuristic_topk::gvrTopKJobDtype;
 using heuristic_topk::KernelSmem;
+using heuristic_topk::KernelSmemTpl;
 using heuristic_topk::TOP_K;
 
 // heuristicTopKMultiRowKernel — outer multi-row launch wrapper (1 CTA per row).
@@ -86,6 +91,106 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float 
 #endif
 }
 
+// ============================================================================
+// Multi-dtype path (4d_multi_dtype_unified, 2026-05-06)
+// ============================================================================
+// Mirrors heuristicTopKMultiRowKernel for bf16/fp16 inputs. fp32 path stays
+// byte-untouched (option A). The kernel body is structurally identical;
+// only the input/output dtype, the smem-key dtype, and the GVR job called
+// (gvrTopKJobDtype<InputT>) differ.
+
+template <typename InputT>
+__global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernelDtype(InputT const* __restrict__ logits,
+    int const* __restrict__ seqLens, int const* __restrict__ preIdx, InputT* __restrict__ scratchValues,
+    int* __restrict__ outIndices, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount)
+{
+    using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
+
+    int const rowIdx = blockIdx.x;
+    int const seq_len = seqLens[rowIdx / next_n];
+    int const N = seq_len - next_n + (rowIdx % next_n) + 1;
+
+    InputT const* __restrict__ input = logits + static_cast<int64_t>(rowIdx) * stride0;
+    int const* __restrict__ rowPreIdx = preIdx + static_cast<int64_t>(rowIdx / next_n) * preIdxStride;
+    InputT* __restrict__ outputValues = scratchValues + static_cast<int64_t>(rowIdx) * topK;
+    int* __restrict__ outputIndices = outIndices + static_cast<int64_t>(rowIdx) * topK;
+
+    extern __shared__ unsigned char smem_raw[];
+    auto* smem = reinterpret_cast<KernelSmemTpl<SmemKey>*>(smem_raw);
+
+    if (N <= topK)
+    {
+        int const tid = threadIdx.x;
+        for (int i = tid; i < N; i += BLOCK_SIZE)
+        {
+            outputValues[i] = input[i];
+            outputIndices[i] = i;
+        }
+        InputT const neg_max = GvrDtypeTraits<InputT>::from_fp32(-FLT_MAX);
+        for (int i = N + tid; i < topK; i += BLOCK_SIZE)
+        {
+            outputValues[i] = neg_max;
+            outputIndices[i] = -1;
+        }
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+        cudaTriggerProgrammaticLaunchCompletion();
+#endif
+        return;
+    }
+
+    int const preIdxOffset = (rowIdx % next_n) + 1;
+    gvrTopKJobDtype<InputT>(input, N, rowPreIdx, preIdxCount, topK, outputValues, outputIndices, smem, preIdxOffset);
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+// Explicit instantiations for the two non-fp32 dtypes used at launch time
+// (kept inside the anonymous namespace so they share the function-pointer
+// identities used by cudaFuncSetAttribute / cudaLaunchKernelEx below).
+template __global__ void heuristicTopKMultiRowKernelDtype<__nv_bfloat16>(
+    __nv_bfloat16 const*, int const*, int const*, __nv_bfloat16*, int*, int, int, int, int, int);
+template __global__ void heuristicTopKMultiRowKernelDtype<__half>(
+    __half const*, int const*, int const*, __half*, int*, int, int, int, int, int);
+
+template <typename InputT>
+void launchHeuristicTopKDecodeDtype(InputT const* logits, int const* seqLens, int const* preIdx, int* outIndices,
+    InputT* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
+    cudaStream_t stream)
+{
+    TLLM_CHECK_WITH_INFO(topK == TOP_K, "heuristicTopKDecode requires topK == 2048 (compile-time constant)");
+
+    using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
+    size_t const smemSize = sizeof(KernelSmemTpl<SmemKey>);
+
+    auto kfn = heuristicTopKMultiRowKernelDtype<InputT>;
+
+    if (smemSize > 48u * 1024u)
+    {
+        cudaFuncSetAttribute(kfn, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
+    }
+
+    // 8-wide vector loads require 16-byte-aligned row pointers (8 × 2-byte = 16-byte).
+    // In TRT-LLM the logits stride is always a multiple of tokens_per_block (≥64),
+    // so this condition is never hit. Assert rather than silently allocating.
+    TLLM_CHECK_WITH_INFO(stride0 % 8 == 0 || numRows <= 1,
+        "heuristicTopKDecode (bf16/fp16) requires logits stride0 divisible by 8 for multi-row launch");
+
+    cudaLaunchConfig_t config;
+    config.gridDim = numRows;
+    config.blockDim = BLOCK_SIZE;
+    config.dynamicSmemBytes = smemSize;
+    config.stream = stream;
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+    config.numAttrs = 1;
+    config.attrs = attrs;
+
+    cudaLaunchKernelEx(&config, kfn, logits, seqLens, preIdx, scratchValues, outIndices, stride0, next_n, topK,
+        preIdxStride, preIdxCount);
+}
+
 } // anonymous namespace
 
 void launchHeuristicTopKDecode(float const* logits, int const* seqLens, int const* preIdx, int* outIndices,
@@ -123,6 +228,22 @@ void launchHeuristicTopKDecode(float const* logits, int const* seqLens, int cons
 
     cudaLaunchKernelEx(&config, heuristicTopKMultiRowKernel, logits, seqLens, preIdx, scratchValues, outIndices,
         stride0, next_n, topK, preIdxStride, preIdxCount);
+}
+
+void launchHeuristicTopKDecode(__nv_bfloat16 const* logits, int const* seqLens, int const* preIdx, int* outIndices,
+    __nv_bfloat16* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
+    cudaStream_t stream)
+{
+    launchHeuristicTopKDecodeDtype<__nv_bfloat16>(logits, seqLens, preIdx, outIndices, scratchValues, stride0, next_n,
+        topK, preIdxStride, preIdxCount, numRows, stream);
+}
+
+void launchHeuristicTopKDecode(__half const* logits, int const* seqLens, int const* preIdx, int* outIndices,
+    __half* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
+    cudaStream_t stream)
+{
+    launchHeuristicTopKDecodeDtype<__half>(logits, seqLens, preIdx, outIndices, scratchValues, stride0, next_n, topK,
+        preIdxStride, preIdxCount, numRows, stream);
 }
 
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
+++ b/cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu
@@ -26,8 +26,8 @@
 #include "tensorrt_llm/kernels/heuristic_topk.cuh"
 
 #include <cfloat>
-#include <cuda_bf16.h> // 4d: bf16 input dtype support
-#include <cuda_fp16.h> // 4d: fp16 input dtype support
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
 
 TRTLLM_NAMESPACE_BEGIN
 
@@ -43,9 +43,9 @@ using heuristic_topk::gvrTopKJob;
 using heuristic_topk::gvrTopKJobDtype;
 using heuristic_topk::KernelSmemTplK;
 
-// 4d.D: heuristicTopKMultiRowKernel templated on TopK so launcher can
-// dispatch K=512/1024/2048 to the same kernel template. Smem layout
-// derived from GvrParams<float, TopK> at compile time.
+// Templated on TopK so the launcher can dispatch K=512/1024/2048 to the
+// same kernel template. Smem layout is derived from GvrParams<float, TopK>
+// at compile time.
 template <int TopK>
 __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float const* __restrict__ logits,
     int const* __restrict__ seqLens, int const* __restrict__ preIdx, float* __restrict__ scratchValues,
@@ -94,21 +94,20 @@ __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernel(float 
 }
 
 // ============================================================================
-// Multi-dtype path (4d_multi_dtype_unified, 2026-05-06)
+// Multi-dtype path (bf16 / fp16)
 // ============================================================================
-// Mirrors heuristicTopKMultiRowKernel for bf16/fp16 inputs. fp32 path stays
-// byte-untouched (option A). The kernel body is structurally identical;
-// only the input/output dtype, the smem-key dtype, and the GVR job called
-// (gvrTopKJobDtype<InputT>) differ.
+// Mirrors heuristicTopKMultiRowKernel for bf16/fp16 inputs. The kernel body
+// is structurally identical; only the input/output dtype, the smem-key
+// dtype, and the GVR job (gvrTopKJobDtype<InputT>) differ.
 
-// 4d.D: dtype multi-row kernel templated on (InputT, TopK). Smem layout
-// derived from GvrParams<InputT, TopK>.
+// Templated on (InputT, TopK). Smem layout is derived from
+// GvrParams<InputT, TopK>.
 template <typename InputT, int TopK>
 __global__ void __launch_bounds__(BLOCK_SIZE) heuristicTopKMultiRowKernelDtype(InputT const* __restrict__ logits,
     int const* __restrict__ seqLens, int const* __restrict__ preIdx, InputT* __restrict__ scratchValues,
     int* __restrict__ outIndices, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount)
 {
-    // P0 (2026-05-07): dtype path uses fp32 keys[] in smem (deferred convert).
+    // dtype path uses fp32 keys[] in smem (down-conversion deferred to writeback).
     using SmemT = KernelSmemTplK<float, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
 
     int const rowIdx = blockIdx.x;
@@ -172,9 +171,9 @@ template __global__ void heuristicTopKMultiRowKernel<1024>(
 template __global__ void heuristicTopKMultiRowKernel<2048>(
     float const*, int const*, int const*, float*, int*, int, int, int, int, int);
 
-// 4d.D: dispatch on topK at runtime — each TopK-instantiation gets its own
-// smem size (driven by GvrParams<InputT, TopK>::kC/kNumBins) and own kfn
-// pointer (cudaFuncSetAttribute / cudaLaunchKernelEx target the right kernel).
+// Dispatch on topK at runtime — each TopK-instantiation gets its own smem
+// size (driven by GvrParams<InputT, TopK>::kC/kNumBins) and own kfn pointer
+// (cudaFuncSetAttribute / cudaLaunchKernelEx target the right kernel).
 template <typename InputT>
 void launchHeuristicTopKDecodeDtype(InputT const* logits, int const* seqLens, int const* preIdx, int* outIndices,
     InputT* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
@@ -191,7 +190,7 @@ void launchHeuristicTopKDecodeDtype(InputT const* logits, int const* seqLens, in
 
     auto launchOne = [&]<int TopK>()
     {
-        // P0 (2026-05-07): dtype path uses fp32 keys[] in smem.
+        // dtype path uses fp32 keys[] in smem.
         using SmemT = KernelSmemTplK<float, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
         size_t const smemSize = sizeof(SmemT);
 

--- a/cpp/tensorrt_llm/kernels/heuristicTopKDecode.h
+++ b/cpp/tensorrt_llm/kernels/heuristicTopKDecode.h
@@ -18,6 +18,8 @@
 
 #include "tensorrt_llm/common/config.h"
 #include <cstdint>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
 
 TRTLLM_NAMESPACE_BEGIN
@@ -28,11 +30,23 @@ namespace kernels
 inline constexpr int kHeuristicTopK = 2048;
 inline constexpr int kHeuristicSize = 2048;
 
-/// Launch heuristic TopK decode kernel.
+/// Launch heuristic TopK decode kernel — fp32 input (V2e production path).
 /// @param scratchValues Caller-owned buffer of size [numRows * topK] floats.
 ///        Required for CUDA Graph compatibility — must have a stable device address.
 void launchHeuristicTopKDecode(float const* logits, int const* seqLens, int const* preIdx, int* outIndices,
     float* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
+    cudaStream_t stream);
+
+/// Launch heuristic TopK decode kernel — bf16 input (4d_multi_dtype_unified, 2026-05-06).
+/// scratchValues is [numRows * topK] of bf16 (matches input dtype).
+void launchHeuristicTopKDecode(__nv_bfloat16 const* logits, int const* seqLens, int const* preIdx, int* outIndices,
+    __nv_bfloat16* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
+    cudaStream_t stream);
+
+/// Launch heuristic TopK decode kernel — fp16 input (4d_multi_dtype_unified, 2026-05-06).
+/// scratchValues is [numRows * topK] of fp16 (matches input dtype).
+void launchHeuristicTopKDecode(__half const* logits, int const* seqLens, int const* preIdx, int* outIndices,
+    __half* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
     cudaStream_t stream);
 
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/heuristicTopKDecode.h
+++ b/cpp/tensorrt_llm/kernels/heuristicTopKDecode.h
@@ -30,20 +30,20 @@ namespace kernels
 inline constexpr int kHeuristicTopK = 2048;
 inline constexpr int kHeuristicSize = 2048;
 
-/// Launch heuristic TopK decode kernel — fp32 input (V2e production path).
+/// Launch heuristic TopK decode kernel — fp32 input.
 /// @param scratchValues Caller-owned buffer of size [numRows * topK] floats.
 ///        Required for CUDA Graph compatibility — must have a stable device address.
 void launchHeuristicTopKDecode(float const* logits, int const* seqLens, int const* preIdx, int* outIndices,
     float* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
     cudaStream_t stream);
 
-/// Launch heuristic TopK decode kernel — bf16 input (4d_multi_dtype_unified, 2026-05-06).
+/// Launch heuristic TopK decode kernel — bf16 input.
 /// scratchValues is [numRows * topK] of bf16 (matches input dtype).
 void launchHeuristicTopKDecode(__nv_bfloat16 const* logits, int const* seqLens, int const* preIdx, int* outIndices,
     __nv_bfloat16* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,
     cudaStream_t stream);
 
-/// Launch heuristic TopK decode kernel — fp16 input (4d_multi_dtype_unified, 2026-05-06).
+/// Launch heuristic TopK decode kernel — fp16 input.
 /// scratchValues is [numRows * topK] of fp16 (matches input dtype).
 void launchHeuristicTopKDecode(__half const* logits, int const* seqLens, int const* preIdx, int* outIndices,
     __half* scratchValues, int stride0, int next_n, int topK, int preIdxStride, int preIdxCount, int numRows,

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -198,12 +198,16 @@ template <typename InputT, int TopK>
 struct GvrParams; // primary undefined → compile-time error for bad combos
 
 // fp32 specializations
+// kNumBins per Q1b-P0.5 sweep (2026-05-07): kNumBins=1024 saves -7.0% total
+// on K=512 fp32 vs default 2048; K=1024 fp32 saves -5.9% at kNumBins=1024.
+// Phase 4 histogram_clear + bin_search shrinks; fewer bins than candidate
+// count is fine because per-bin contention stays at ≤5 atomicAdds.
 template <>
 struct GvrParams<float, 512>
 {
     static constexpr int kFTarget = 512;
     static constexpr int kC = 5120;
-    static constexpr int kNumBins = NUM_BINS;
+    static constexpr int kNumBins = 1024;
 };
 
 template <>
@@ -211,7 +215,7 @@ struct GvrParams<float, 1024>
 {
     static constexpr int kFTarget = 3072;
     static constexpr int kC = 5120;
-    static constexpr int kNumBins = NUM_BINS;
+    static constexpr int kNumBins = 1024;
 };
 
 // fp32 K=2048: V2e production-identity preservation (Option B 2026-05-07).
@@ -230,12 +234,16 @@ struct GvrParams<float, 2048>
 };
 
 // bf16 specializations
+// Q1b-P0.5 (2026-05-07) chose folded rule for bf16: K=512 keeps kNumBins=K
+// (avoid K/2=256 atomic-contention edge), K=1024 takes K/2=512 (full
+// -7.8% saving). K=2048 unchanged since K=2048 sweep showed ~0 effect.
+// Captures ~90% of the optimal-per-cell saving with simpler dispatch.
 template <>
 struct GvrParams<__nv_bfloat16, 512>
 {
     static constexpr int kFTarget = 512;
     static constexpr int kC = 5120;
-    static constexpr int kNumBins = NUM_BINS;
+    static constexpr int kNumBins = 512;
 };
 
 template <>
@@ -243,7 +251,7 @@ struct GvrParams<__nv_bfloat16, 1024>
 {
     static constexpr int kFTarget = 3072;
     static constexpr int kC = 5120;
-    static constexpr int kNumBins = NUM_BINS;
+    static constexpr int kNumBins = 512;
 };
 
 template <>
@@ -255,12 +263,14 @@ struct GvrParams<__nv_bfloat16, 2048>
 };
 
 // fp16 specializations
+// Q1b-P0.5 (2026-05-07): kNumBins = K is the empirical optimum for fp16
+// (sweeping K/2 actually regressed K=512/1024 fp16). K=2048 unchanged.
 template <>
 struct GvrParams<__half, 512>
 {
     static constexpr int kFTarget = 512;
     static constexpr int kC = 5120;
-    static constexpr int kNumBins = NUM_BINS;
+    static constexpr int kNumBins = 512;
 };
 
 template <>
@@ -268,7 +278,7 @@ struct GvrParams<__half, 1024>
 {
     static constexpr int kFTarget = 3072;
     static constexpr int kC = 5120;
-    static constexpr int kNumBins = NUM_BINS;
+    static constexpr int kNumBins = 1024;
 };
 
 template <>

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -1695,8 +1695,94 @@ __global__ void __launch_bounds__(BLOCK_SIZE)
 }
 
 // ============================================================================
+// Explicit kernel instantiations — 9 (T × K) combos.
+// ============================================================================
+// Mirrors the same pattern used in heuristicTopKDecode.cu for the multi-row
+// kernels. Forces nvcc to emit each `gvrTopKKernel<K>` / `gvrTopKKernelDtype
+// <T,K>` host-side wrapper stub *before* `launchHeuristicTopK` takes their
+// address via `cudaLaunchKernelEx`. Without these declarations, certain nvcc
+// stubgen versions (CI containers on sm_89 / sm_120f) emit the implicit stub
+// inside the kernel body and then conflict with their own subsequent
+// "explicit specialization of __wrapper__device_stub_*<K>" pass — surfacing
+// as a "specialization after instantiation" build error against
+// cudafe1.stub.c. Header is included only by heuristicTopKDecode.cu (one TU)
+// so no ODR concern.
+template __global__ void gvrTopKKernel<512>(float const*, int, int const*, int, int, float*, int*);
+template __global__ void gvrTopKKernel<1024>(float const*, int, int const*, int, int, float*, int*);
+template __global__ void gvrTopKKernel<2048>(float const*, int, int const*, int, int, float*, int*);
+template __global__ void gvrTopKKernelDtype<__nv_bfloat16, 512>(
+    __nv_bfloat16 const*, int, int const*, int, int, __nv_bfloat16*, int*);
+template __global__ void gvrTopKKernelDtype<__nv_bfloat16, 1024>(
+    __nv_bfloat16 const*, int, int const*, int, int, __nv_bfloat16*, int*);
+template __global__ void gvrTopKKernelDtype<__nv_bfloat16, 2048>(
+    __nv_bfloat16 const*, int, int const*, int, int, __nv_bfloat16*, int*);
+template __global__ void gvrTopKKernelDtype<__half, 512>(__half const*, int, int const*, int, int, __half*, int*);
+template __global__ void gvrTopKKernelDtype<__half, 1024>(__half const*, int, int const*, int, int, __half*, int*);
+template __global__ void gvrTopKKernelDtype<__half, 2048>(__half const*, int, int const*, int, int, __half*, int*);
+
+// ============================================================================
 // Launch Wrapper
 // ============================================================================
+
+namespace detail
+{
+// Per-(T, TopK) launcher implementation. Hoisted out of `launchHeuristicTopK`
+// (was a C++20 templated lambda `[&]<int TopK>()`) because that pattern
+// confuses nvcc's cudafe1 stub generator: taking the address of
+// `gvrTopKKernel<TopK>` / `gvrTopKKernelDtype<T, TopK>` from inside a
+// templated capturing lambda triggers an "explicit specialization of
+// `__wrapper__device_stub_gvrTopKKernel<K>` after instantiation" error
+// against the auto-generated host wrapper stub. A regular function template
+// avoids the quirk and stays in C++17 (no templated-lambda extension warning).
+//
+// Kernel body, GvrParams traits, kfn selection, opt-in smem, PDL attr, and
+// cudaLaunchKernelEx call are byte-identical to the previous lambda body —
+// SASS is unchanged for all 9 (T, K) instantiations.
+template <typename T, int TopK>
+cudaError_t launchHeuristicTopKImpl(T const* input, int N, int const* preIdx, int M, int topK, T* outputValues,
+    int* outputIndices, cudaStream_t stream, bool enablePDL)
+{
+    // dtype path uses fp32 smem keys (deferred convert). Launcher
+    // allocates smem with float keys regardless of input dtype.
+    using SmemT = KernelSmemTplK<float, GvrParams<T, TopK>::kC, GvrParams<T, TopK>::kNumBins>;
+    size_t const smemSize = sizeof(SmemT);
+
+    // Resolve target kernel function pointer at compile time.
+    auto kfn = []()
+    {
+        if constexpr (std::is_same_v<T, float>)
+            return gvrTopKKernel<TopK>;
+        else
+            return gvrTopKKernelDtype<T, TopK>;
+    }();
+
+    if (smemSize > 48u * 1024u)
+    {
+        int device;
+        cudaGetDevice(&device);
+        int maxSmem;
+        cudaDeviceGetAttribute(&maxSmem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
+        if (smemSize > static_cast<size_t>(maxSmem))
+            return cudaErrorInvalidConfiguration;
+        cudaFuncSetAttribute(kfn, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
+    }
+
+    cudaLaunchConfig_t config{};
+    config.gridDim = dim3(1);
+    config.blockDim = dim3(BLOCK_SIZE);
+    config.dynamicSmemBytes = smemSize;
+    config.stream = stream;
+
+    cudaLaunchAttribute attrs[1];
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = enablePDL ? 1 : 0;
+    config.attrs = attrs;
+    config.numAttrs = 1;
+
+    cudaLaunchKernelEx(&config, kfn, input, N, preIdx, M, topK, outputValues, outputIndices);
+    return cudaGetLastError();
+}
+} // namespace detail
 
 template <typename T, typename IdxT = int>
 cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M, int topK, T* outputValues,
@@ -1714,7 +1800,7 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
     // instantiation captures its own (kFTarget, kC, kNumBins) tuple via
     // GvrParams<T, TopK> so all values are compile-time constants inside
     // the kernel body. Opt-in smem + cudaLaunchKernelEx + PDL handling is
-    // shared across all 9 paths via a template-parametric lambda.
+    // shared across all 9 paths via `detail::launchHeuristicTopKImpl`.
 
     // Honor the standard TRTLLM_ENABLE_PDL env var (default on; set "0" to
     // disable).
@@ -1725,54 +1811,17 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
             enablePDL = false;
     }
 
-    auto launchOne = [&]<int TopK>() -> cudaError_t
-    {
-        // dtype path uses fp32 smem keys (deferred convert). Launcher
-        // allocates smem with float keys regardless of input dtype.
-        using SmemT = KernelSmemTplK<float, GvrParams<T, TopK>::kC, GvrParams<T, TopK>::kNumBins>;
-        size_t const smemSize = sizeof(SmemT);
-
-        // Resolve target kernel function pointer at compile time.
-        auto kfn = []()
-        {
-            if constexpr (std::is_same_v<T, float>)
-                return gvrTopKKernel<TopK>;
-            else
-                return gvrTopKKernelDtype<T, TopK>;
-        }();
-
-        if (smemSize > 48u * 1024u)
-        {
-            int device;
-            cudaGetDevice(&device);
-            int maxSmem;
-            cudaDeviceGetAttribute(&maxSmem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
-            if (smemSize > static_cast<size_t>(maxSmem))
-                return cudaErrorInvalidConfiguration;
-            cudaFuncSetAttribute(kfn, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
-        }
-
-        cudaLaunchConfig_t config{};
-        config.gridDim = dim3(1);
-        config.blockDim = dim3(BLOCK_SIZE);
-        config.dynamicSmemBytes = smemSize;
-        config.stream = stream;
-
-        cudaLaunchAttribute attrs[1];
-        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-        attrs[0].val.programmaticStreamSerializationAllowed = enablePDL ? 1 : 0;
-        config.attrs = attrs;
-        config.numAttrs = 1;
-
-        cudaLaunchKernelEx(&config, kfn, input, N, preIdx, M, topK, outputValues, outputIndices);
-        return cudaGetLastError();
-    };
-
     switch (topK)
     {
-    case 512: return launchOne.template operator()<512>();
-    case 1024: return launchOne.template operator()<1024>();
-    case 2048: return launchOne.template operator()<2048>();
+    case 512:
+        return detail::launchHeuristicTopKImpl<T, 512>(
+            input, N, preIdx, M, topK, outputValues, outputIndices, stream, enablePDL);
+    case 1024:
+        return detail::launchHeuristicTopKImpl<T, 1024>(
+            input, N, preIdx, M, topK, outputValues, outputIndices, stream, enablePDL);
+    case 2048:
+        return detail::launchHeuristicTopKImpl<T, 2048>(
+            input, N, preIdx, M, topK, outputValues, outputIndices, stream, enablePDL);
     default: return cudaErrorInvalidValue;
     }
 }

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -1048,10 +1048,13 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
             smem->out_count = 0;
         __syncthreads();
 
-        // Opt-M fix: separate gt and eq into two sequential passes so that
-        // strictly-greater values are never dropped in favor of tie-values.
-        // The v0 interleaved version had a correctness bug when ties at the
-        // K-th value cross kK; this fix makes the selection rank-stable.
+        // Two-pass selection: pass 1 emits strictly-greater-than-threshold
+        // candidates, pass 2 fills remaining slots with tie-values. An
+        // interleaved single-pass implementation would be unstable across
+        // rows with many ties at the K-th rank — equal-valued candidates
+        // could displace strictly-greater ones depending on their relative
+        // order in the candidate buffer. Splitting the passes makes the
+        // selection deterministic regardless of buffer ordering.
 
         // Pass 1: strictly greater than sel_thr
         for (int base = warp_id * WARP_SIZE; base < cand_count; base += BLOCK_SIZE)

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -43,26 +43,25 @@
 
 #include <cfloat>
 #include <cstdint>
-#include <cstdio>      // for snap convergence warning printf
-#include <cstdlib>     // for std::getenv (PDL launcher env-gate)
-#include <cuda_bf16.h> // 4d: bf16 input dtype support
-#include <cuda_fp16.h> // 4d: fp16 input dtype support
+#include <cstdio>
+#include <cstdlib>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
-#include <type_traits> // 4d: std::is_same_v in launchHeuristicTopK dispatch
+#include <type_traits>
 
 namespace heuristic_topk
 {
 
 // ============================================================================
-// Multi-dtype Trait Layer (4d_multi_dtype_unified, 2026-05-06)
+// Multi-dtype Trait Layer
 // ============================================================================
 // Encapsulates dtype-specific cvt intrinsics + vector load width so the
-// kernel body can be templated cleanly. For fp32 the path is byte-
-// equivalent to the original V2e kernel (VEC_W=4, identity cvt).
+// kernel body can be templated cleanly. For fp32 the trait is identity.
 //
-// Tier-1 fp32 arithmetic (threshold, accumulators, bin index) — kernel-
-// internal, not in trait. Tier-2 InputT containers (HBM input, smem keys,
-// outputValues) — dtype-driven. Tier-3 ALU stays fp32 (GVR is HBM-bound).
+// Arithmetic (threshold, accumulators, bin index) is always fp32; only
+// the HBM input container, smem keys, and output values follow InputT.
+// GVR is HBM-bandwidth-bound, so fp32 ALU has no measurable cost.
 
 template <typename T>
 struct GvrDtypeTraits;
@@ -171,34 +170,38 @@ static_assert(TOP_K % BLOCK_SIZE == 0);
 static_assert(MAX_CANDIDATES % BLOCK_SIZE == 0);
 
 // ============================================================================
-// Multi-K Trait Layer (4d.D 9-combo sweep, 2026-05-06)
+// Multi-K Trait Layer
 // ============================================================================
-// Per-(InputT, TopK) compile-time trait class encoding the optimal
-// (f_target, max_candidates) tuple discovered by the SWE-Bench-64K
-// 9-combo sweep in 04_kernel_optimizations/4d_multi_dtype_unified/
-// data/D_param_sweep_9combos/REPORT.md.
+// Per-(InputT, TopK) compile-time trait encoding the secant-search target
+// `kFTarget`, candidate-buffer cap `kC`, and Phase-4 histogram bin count
+// `kNumBins`.
 //
-// Selection rationale:
-//   - kC=5120 unified across all 9 combos (smem-Occ jump 3→4 fp32 / 3→5
-//     bf16/fp16 buys ≤+10% sim cost vs C=6144; reg-bound limit may cap
-//     real occupancy at 3 — Step 2 must verify with cuobjdump).
-//   - kFTarget varies by K only:
-//       K=512:  f=K        (P1 pmean threshold lands near K → P2 idle)
-//       K=1024: f=3K       (U-shape minimum at high f)
-//       K=2048: f=2K       (monotone: higher f → fewer P2 iters)
-//   - kFTarget for fp32 K=2048 = 4096 deviates from V2e production
-//     (3072) — applied per REPORT.md recommendation; Step 3 must run
-//     Scheme X v1.2 4-report regression to confirm no real-world loss.
-//   - kNumBins=NUM_BINS=2048 unchanged across combos (P4 histogram).
+// kFTarget under V3.2-decode preIdx semantics (preIdx = top-K of prev row):
+// Phase-1 pmean lands near the right tail of the prev-row top-K, so the
+// Phase-2 secant initial bracket is biased high. A tighter K-proportional
+// target converges faster than the M=2048 era's flat target.
+//   K=512:  0.75K = 384
+//   K=1024: 2.5K  = 2560
+//   K=2048: kept at 1.5K (3072) for fp32 to preserve SASS byte-identity
+//          with the V2e production hot path. bf16/fp16 K=2048 use 2K
+//          (4096), where there is no prior production baseline to honor.
 //
-// Q10b-S2 (2026-05-08): kFTarget re-tuned for V4 production M=K (preIdx=K, not 2048).
-// Under M=K, pmean shifts to right tail (top-K of prev row); P2 secant needs a
-// tighter target to converge in fewer iterations. K-proportional K=512/1024 picks:
-//   K=512:  kFTarget=384  (= 0.75K)  — was K
-//   K=1024: kFTarget=2560 (= 2.5K)   — was 3K
-//   K=2048: unchanged (M=K=2048 trivially equals legacy M=2048)
-// Cross-layer 8-cell sweep on SWE-Bench-64K (`10_multi_cta_v1/M_eq_K_redesign/`):
-// 4 V4-hot cells (bf16/fp16 × K=512/1024) recover ~3.78 µs total wall.
+// kC = 5120 for K=512/1024 across all dtypes — drops smem footprint enough
+// to leave headroom for 4-5 CTA/SM theoretical occupancy when register
+// allocation permits. fp32 K=2048 keeps kC=6144 to preserve V2e SASS
+// byte-identity (production fp32 K=2048 hot path is the correctness
+// floor; smem layout change would alter SASS).
+//
+// kNumBins varies per (T, K) by atomic-contention vs Phase-4 setup-cost
+// trade-off:
+//   - Below ~1024 bins, atomicAdd contention on the bin-counter array
+//     dominates Phase-4 cost.
+//   - Above 1024 bins, the Phase-4 histogram clear+scan setup cost
+//     dominates over the contention savings.
+//   The optimum varies because (a) candidate-buffer size kC scales the
+//   atomic-contention denominator, and (b) bf16/fp16 paths read smem keys
+//   through Trait::to_fp32, shifting the Phase-3 ↔ Phase-4 ratio. Hence
+//   per-(T, K) tabulation rather than a closed-form rule.
 //
 // Primary template intentionally left undefined: any unsupported (T, K)
 // combination triggers a compile-time error rather than a runtime fall-
@@ -206,15 +209,10 @@ static_assert(MAX_CANDIDATES % BLOCK_SIZE == 0);
 template <typename InputT, int TopK>
 struct GvrParams; // primary undefined → compile-time error for bad combos
 
-// fp32 specializations
-// kNumBins per Q1b-P0.5 sweep (2026-05-07): kNumBins=1024 saves -7.0% total
-// on K=512 fp32 vs default 2048; K=1024 fp32 saves -5.9% at kNumBins=1024.
-// Phase 4 histogram_clear + bin_search shrinks; fewer bins than candidate
-// count is fine because per-bin contention stays at ≤5 atomicAdds.
 template <>
 struct GvrParams<float, 512>
 {
-    static constexpr int kFTarget = 384; // Q10b-S2 (M=K retune): was 512
+    static constexpr int kFTarget = 384;
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 1024;
 };
@@ -222,35 +220,26 @@ struct GvrParams<float, 512>
 template <>
 struct GvrParams<float, 1024>
 {
-    static constexpr int kFTarget = 2560; // Q10b-S2 (M=K retune): was 3072
+    static constexpr int kFTarget = 2560;
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 1024;
 };
 
-// fp32 K=2048: V2e production-identity preservation (Option B 2026-05-07).
-// Cuobjdump showed nvcc 13.1 regs/thread = 64 → reg-bound 2 CTA/SM regardless of
-// kC; the REPORT-recommended (4096, 5120) gives no occupancy benefit but
-// breaks V2e SMEM byte-identity. Reverting to V2e (3072, 6144) keeps the
-// production path byte-identical and avoids Scheme X v1.2 4-report
-// regression. The other 8 combos still use REPORT picks where there is
-// no production baseline to preserve.
+// fp32 K=2048 preserves V2e SASS byte-identity with the production hot path.
+// Changing kFTarget or kC would alter ptxas output for the existing
+// `gvrTopKJob<2048>` / `heuristicTopKMultiRowKernel<2048>` instantiations.
 template <>
 struct GvrParams<float, 2048>
 {
-    static constexpr int kFTarget = 3072; // V2e: TOP_K + SAFETY_MARGIN/2
-    static constexpr int kC = 6144;       // V2e: TOP_K + SAFETY_MARGIN*2
+    static constexpr int kFTarget = 3072;
+    static constexpr int kC = 6144;
     static constexpr int kNumBins = NUM_BINS;
 };
 
-// bf16 specializations
-// Q1b-P0.5 (2026-05-07) chose folded rule for bf16: K=512 keeps kNumBins=K
-// (avoid K/2=256 atomic-contention edge), K=1024 takes K/2=512 (full
-// -7.8% saving). K=2048 unchanged since K=2048 sweep showed ~0 effect.
-// Captures ~90% of the optimal-per-cell saving with simpler dispatch.
 template <>
 struct GvrParams<__nv_bfloat16, 512>
 {
-    static constexpr int kFTarget = 384; // Q10b-S2 (M=K retune): was 512
+    static constexpr int kFTarget = 384;
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 512;
 };
@@ -258,7 +247,7 @@ struct GvrParams<__nv_bfloat16, 512>
 template <>
 struct GvrParams<__nv_bfloat16, 1024>
 {
-    static constexpr int kFTarget = 2560; // Q10b-S2 (M=K retune): was 3072
+    static constexpr int kFTarget = 2560;
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 512;
 };
@@ -271,13 +260,10 @@ struct GvrParams<__nv_bfloat16, 2048>
     static constexpr int kNumBins = NUM_BINS;
 };
 
-// fp16 specializations
-// Q1b-P0.5 (2026-05-07): kNumBins = K is the empirical optimum for fp16
-// (sweeping K/2 actually regressed K=512/1024 fp16). K=2048 unchanged.
 template <>
 struct GvrParams<__half, 512>
 {
-    static constexpr int kFTarget = 384; // Q10b-S2 (M=K retune): was 512
+    static constexpr int kFTarget = 384;
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 512;
 };
@@ -285,7 +271,7 @@ struct GvrParams<__half, 512>
 template <>
 struct GvrParams<__half, 1024>
 {
-    static constexpr int kFTarget = 2560; // Q10b-S2 (M=K retune): was 3072
+    static constexpr int kFTarget = 2560;
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 1024;
 };
@@ -306,15 +292,12 @@ static_assert(GvrParams<float, 2048>::kC % BLOCK_SIZE == 0);
 // ============================================================================
 // Shared Memory Layout
 // ============================================================================
-// Default instantiation (CCap=MAX_CANDIDATES=6144, NumBinsT=NUM_BINS=2048):
-//   fp32  (KernelSmem = KernelSmemTpl<float>           = KernelSmemTplK<float, 6144, 2048>): ~59 KB
-//   bf16/fp16                                                                              : ~47 KB
-//
-// 4d.D K=512/1024 instantiations use kC=5120 (KernelSmemTplK<T, 5120, 2048>):
-//   fp32: 51 KB, bf16/fp16: 41 KB
-//
-// 4d_multi_dtype_unified (2026-05-06): templatized on SmemKey.
-// 4d.D 9-combo (2026-05-06): templatized on (CCap, NumBinsT) for multi-K paths.
+// Templated on (SmemKey, candidate-cap, num-bins). Default
+// (MAX_CANDIDATES=6144, NUM_BINS=2048) sizes:
+//   fp32      : ~59 KB
+//   bf16/fp16 : ~47 KB
+// K=512/1024 instantiations cap candidates at kC=5120 (~51 KB fp32 /
+//   ~41 KB bf16/fp16) per GvrParams<T, K>::kC.
 
 template <typename SmemKey, int CCap = MAX_CANDIDATES, int NumBinsT = NUM_BINS>
 struct KernelSmemTplK
@@ -337,14 +320,11 @@ struct KernelSmemTplK
     int out_count;
 };
 
-// Backwards-compat alias for K=2048 default — same layout as pre-4d.D
-// KernelSmemTpl. fp32 instantiation = KernelSmemTplK<float, 6144, 2048>.
+// Convenience alias for the default-cap layout (kC=6144, kNumBins=2048),
+// used by the K=2048 instantiations.
 template <typename SmemKey>
 using KernelSmemTpl = KernelSmemTplK<SmemKey>;
 
-// fp32 alias preserved so the original gvrTopKJob / gvrTopKKernel /
-// blockCountGE / blockFusedSnapIter and the TRT-LLM multi-row caller
-// `using heuristic_topk::gvrTopKJob` keep their byte-equivalent signature.
 using KernelSmem = KernelSmemTpl<float>;
 
 // ============================================================================
@@ -415,8 +395,8 @@ __device__ __forceinline__ float warpReduceMax(float val)
 // Device: Block count ≥ threshold in GLOBAL memory  (1-sync pattern)
 // ============================================================================
 
-// 4d.D: templated on SmemT so K=512/1024 fp32 paths can pass a smaller
-// KernelSmemTplK<float, 5120, 2048>* smem. Default = legacy KernelSmem.
+// Templated on SmemT so K=512/1024 paths can pass a kC=5120 layout.
+// Default (KernelSmem) targets the K=2048 kC=6144 layout.
 template <typename SmemT = KernelSmem>
 __device__ __forceinline__ void blockCountGE(
     float const* __restrict__ input, int N, float threshold, SmemT* smem, int tid, int warp_id, int lane)
@@ -452,9 +432,7 @@ __device__ __forceinline__ void blockCountGE(
 // Fused snap iteration (2 syncs per call)
 // ============================================================================
 
-// 4d.D: templated on (TopK, SmemT) so K=512/1024 paths reuse the same
-// helper. Default <TOP_K, KernelSmem> preserves byte-equivalence with
-// the V2e baseline call site.
+// Templated on (TopK, SmemT) so K=512/1024 paths reuse the same helper.
 template <int TopK = TOP_K, typename SmemT = KernelSmem>
 __device__ __forceinline__ void blockFusedSnapIter(SmemT* smem, int count, int tid, int warp_id, int lane)
 {
@@ -518,10 +496,10 @@ __device__ __forceinline__ void blockFusedSnapIter(SmemT* smem, int count, int t
 }
 
 // ============================================================================
-// Dtype-templated helpers (4d_multi_dtype_unified)
+// Dtype-templated helpers (bf16 / fp16)
 // ============================================================================
 // Mirror blockCountGE / blockFusedSnapIter for bf16/fp16 inputs. fp32
-// path keeps the originals untouched (byte-equivalent to V2e baseline).
+// path uses the originals.
 //
 // blockCountGEDtype:
 //   - 8-wide vector load (int4 = 8 × 16-bit) instead of 4-wide (float4 = 4 × fp32)
@@ -529,11 +507,10 @@ __device__ __forceinline__ void blockFusedSnapIter(SmemT* smem, int count, int t
 //
 // blockFusedSnapIterDtype:
 //   - reads SmemKey (bf16 / fp16) from smem->keys, up-casts to fp32 for
-//     min/max/count work; threshold remains fp32 (Tier-1 invariant).
+//     min/max/count work; threshold remains fp32.
 
-// 4d.D: add SmemT default to allow K=512/1024 dtype paths to pass a
-// smaller KernelSmemTplK<SmemKey, 5120, 2048>* smem. Default = legacy
-// 6144-cap layout (KernelSmemTpl<SmemKey>).
+// Templated on SmemT so K=512/1024 dtype paths can pass a kC=5120 layout.
+// Default targets the K=2048 kC=6144 layout.
 template <typename InputT, typename SmemT = KernelSmemTpl<typename GvrDtypeTraits<InputT>::SmemKey>>
 __device__ __forceinline__ void blockCountGEDtype(
     InputT const* __restrict__ input, int N, float threshold, SmemT* smem, int tid, int warp_id, int lane)
@@ -571,8 +548,7 @@ __device__ __forceinline__ void blockCountGEDtype(
     }
 }
 
-// 4d.D: templated on (TopK, SmemT). Default <SmemKey, TOP_K, KernelSmemTpl<SmemKey>>
-// preserves the K=2048 dtype path's pre-multi-K signature.
+// Templated on (SmemKey, TopK, SmemT). Default targets the K=2048 dtype path.
 template <typename SmemKey, int TopK = TOP_K, typename SmemT = KernelSmemTpl<SmemKey>>
 __device__ __forceinline__ void blockFusedSnapIterDtype(SmemT* smem, int count, int tid, int warp_id, int lane)
 {
@@ -643,13 +619,10 @@ __device__ __forceinline__ void blockFusedSnapIterDtype(SmemT* smem, int count, 
 // for this function independently from the caller, matching standalone SASS.
 // ============================================================================
 
-// 4d.D: templated on TopK so the K=512 / K=1024 fp32 paths share this
-// body with K=2048. Default <TOP_K> + KernelSmem (= KernelSmemTplK<float, 6144, 2048>)
-// matches the pre-multi-K signature for the legacy V2e call site.
-//
-// The runtime `topK` parameter is kept for header-API compatibility with
-// callers that pass it (assert at entry that it matches the template
-// instantiation).
+// Templated on TopK so K=512/1024/2048 fp32 paths share this body. The
+// runtime `topK` parameter is kept for header-API compatibility with
+// callers that pass it; the kernel asserts at entry that it matches
+// the template instantiation.
 template <int TopK = TOP_K>
 __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int const N, int const* __restrict__ preIdx,
     int const M, int const topK, float* __restrict__ outputValues, int* __restrict__ outputIndices,
@@ -1158,18 +1131,13 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
 // heuristicTopKDecode.cu — both share the same micro-kernel job.
 // ============================================================================
 
-// 4d.D: templated on TopK so launcher can dispatch K=512/1024/2048 to the
-// same kernel template. Default <TOP_K> matches the legacy non-templated
-// signature (callers that pass no template argument get K=2048 fp32).
+// Templated on TopK so the launcher can dispatch K=512/1024/2048 to the
+// same kernel template.
 //
-// 2026-05-08 alignment with production: __launch_bounds__ now matches
-// heuristicTopKMultiRowKernel (single-arg, no minBlocksPerSM hint) so nvcc
-// applies the same register heuristic to this standalone wrapper as to the
-// production multi-row kernel. Removing the trailing `, 1` lets ptxas pick
-// REG=40 (K=2048 fp32) instead of REG=64, restoring 75% theoretical
-// occupancy parity. NOTE: this changes the standalone gvrTopKKernel<2048>
-// SASS away from V2e LOCK byte-identity (production multi-row path is
-// unaffected — it uses its own __launch_bounds__).
+// __launch_bounds__ uses the single-arg form (no minBlocksPerSM hint) so
+// nvcc applies the same register heuristic as `heuristicTopKMultiRowKernel`
+// in heuristicTopKDecode.cu. Adding `, 1` would lower theoretical occupancy
+// from 75% (REG=40) to 50% (REG=64) for the K=2048 fp32 path.
 template <int TopK = TOP_K>
 __global__ void __launch_bounds__(BLOCK_SIZE)
     gvrTopKKernel(float const* __restrict__ input, int const N, int const* __restrict__ preIdx, int const M,
@@ -1186,28 +1154,23 @@ __global__ void __launch_bounds__(BLOCK_SIZE)
 }
 
 // ============================================================================
-// gvrTopKJobDtype<InputT, TopK> — bf16/fp16 device function (4d_multi_dtype_unified)
+// gvrTopKJobDtype<InputT, TopK> — bf16/fp16 device function
 // ============================================================================
 // Mirror of gvrTopKJob with trait-driven dtype substitutions:
 //   - HBM input read   : Trait::to_fp32(__ldg(&input[i]))
-//   - smem keys write  : Trait::from_fp32(v)   (Tier-2 SmemKey container)
 //   - smem keys read   : Trait::to_fp32(keys[i]) for arithmetic
-//   - outputValues     : InputT (SmemKey == InputT in templated path)
+//   - outputValues     : InputT
 //   - vector load      : 8-wide via Trait::unpack8
 //   - blockCountGE     : blockCountGEDtype<InputT>
 //   - blockFusedSnapIter: blockFusedSnapIterDtype<SmemKey>
-// All Tier-1 arithmetic stays fp32 (threshold, accumulators, bin index).
-// fp32 path is NOT routed here — fp32 keeps the original gvrTopKJob (option A,
-// guaranteed zero-regression). This template only instantiates for bf16/fp16.
+// All arithmetic (threshold, accumulators, bin index) stays fp32. The fp32
+// dtype path uses gvrTopKJob (above), not this template; instantiated only
+// for bf16 and fp16.
 //
-// 4d.D: templated on TopK so K=512/1024/2048 share the same body. Default
-// <InputT, TOP_K> with KernelSmemTpl<...> matches the pre-multi-K signature.
-
-// P0 (Q1b-P0, 2026-05-07): smem keys[] are kept as fp32 to defer the
-// Trait::from_fp32(val) write conversion out of the P3 hot loop. This trades
-// ~10 KB extra smem (5120 keys × +2B at K=2048 dtype) for ~2 µs P3 savings on
-// bf16/fp16 (P3 -10-25%, total -4.5-7.1% per Q1b-P0 snapshot bench).
-// fp32 path is unaffected — gvrTopKJob (separate function) keeps its layout.
+// smem `keys[]` are stored as fp32 even on the bf16/fp16 paths: deferring
+// the down-conversion out of the Phase-3 collect loop saves more than the
+// extra ~10 KB of smem costs. The fp32 keys move conversion to the output
+// writeback (one cvt per surviving candidate) instead of every smem store.
 template <typename InputT, int TopK = TOP_K>
 __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, int const N,
     int const* __restrict__ preIdx, int const M, int const topK, InputT* __restrict__ outputValues,
@@ -1216,7 +1179,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
     int const preIdxOffset = 0)
 {
     using Trait = GvrDtypeTraits<InputT>;
-    using SmemKey = float; // P0: keys stay fp32; conversion deferred to output writeback
+    using SmemKey = float; // keys stay fp32; conversion deferred to output writeback
     using Params = GvrParams<InputT, TopK>;
     constexpr int kK = TopK;
     constexpr int kCC = Params::kC;
@@ -1706,12 +1669,9 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
 // ============================================================================
 // gvrTopKKernelDtype<InputT, TopK> — bf16/fp16 single-row global wrapper
 // ============================================================================
-// 4d.D: templated on TopK alongside InputT. Default <InputT, TOP_K> matches
-// the pre-multi-K signature for the existing K=2048 dtype path.
-//
-// 2026-05-08: same alignment with heuristicTopKMultiRowKernelDtype — single-arg
-// __launch_bounds__ removes the minBlocksPerSM=1 hint so ptxas applies the
-// production register heuristic. See gvrTopKKernel<TopK> note above.
+// Templated on (InputT, TopK). __launch_bounds__ uses the single-arg form
+// so nvcc applies the same register heuristic as the multi-row dtype kernel
+// in heuristicTopKDecode.cu. See `gvrTopKKernel<TopK>` note above.
 
 template <typename InputT, int TopK = TOP_K>
 __global__ void __launch_bounds__(BLOCK_SIZE)
@@ -1720,7 +1680,7 @@ __global__ void __launch_bounds__(BLOCK_SIZE)
 {
     using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
     using SmemT
-        = KernelSmemTplK<float, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>; // P0: dtype keys fp32
+        = KernelSmemTplK<float, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>; // dtype keys fp32
     extern __shared__ unsigned char smem_raw[];
     auto* smem = reinterpret_cast<SmemT*>(smem_raw);
 
@@ -1743,24 +1703,18 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
     static_assert(std::is_same_v<T, float> || std::is_same_v<T, __nv_bfloat16> || std::is_same_v<T, __half>,
         "launchHeuristicTopK supports only fp32 / bf16 / fp16");
 
-    // 4d.D: validate K against the supported set. Compile-time GvrParams
-    // specializations cover {512, 1024, 2048}; any other value rejects.
+    // GvrParams specializations cover K ∈ {512, 1024, 2048}; reject others.
     if (topK != 512 && topK != 1024 && topK != 2048)
         return cudaErrorInvalidValue;
 
-    // 4d.D: dispatch on (T, topK) → 9 distinct kernel-pointer paths.
-    // Each instantiation captures its own (kFTarget, kC, kNumBins) tuple
-    // via GvrParams<T, TopK> so all values are compile-time constants
-    // inside the kernel body (zero runtime overhead vs hardcoded literals).
-    //
-    // NOTE: opt-in shared memory + cudaLaunchKernelEx + PDL handling
-    // shared across all 9 kernels. We keep that block runtime-shared by
-    // taking the smem size and kernel function pointer from a
-    // template-parametric lambda.
+    // Dispatch on (T, topK) → 9 distinct kernel-pointer paths. Each
+    // instantiation captures its own (kFTarget, kC, kNumBins) tuple via
+    // GvrParams<T, TopK> so all values are compile-time constants inside
+    // the kernel body. Opt-in smem + cudaLaunchKernelEx + PDL handling is
+    // shared across all 9 paths via a template-parametric lambda.
 
     // Honor the standard TRTLLM_ENABLE_PDL env var (default on; set "0" to
-    // disable). This launcher is also reused by the standalone JIT-compiled
-    // PyTorch extension under ablation_study/gvr_phase_timing/.
+    // disable).
     bool enablePDL = true;
     if (char const* env = std::getenv("TRTLLM_ENABLE_PDL"))
     {
@@ -1770,8 +1724,8 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
 
     auto launchOne = [&]<int TopK>() -> cudaError_t
     {
-        // P0 (2026-05-07): dtype path uses fp32 smem keys (deferred convert).
-        // Launcher allocates smem with float keys regardless of input dtype.
+        // dtype path uses fp32 smem keys (deferred convert). Launcher
+        // allocates smem with float keys regardless of input dtype.
         using SmemT = KernelSmemTplK<float, GvrParams<T, TopK>::kC, GvrParams<T, TopK>::kNumBins>;
         size_t const smemSize = sizeof(SmemT);
 
@@ -1820,7 +1774,7 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
     }
 }
 
-// Explicit instantiations — fp32 (V2e baseline path) + bf16/fp16 (4d dtype path)
+// Explicit instantiations — fp32 + bf16/fp16
 template cudaError_t launchHeuristicTopK<float, int>(
     float const*, int, int const*, int, int, float*, int*, cudaStream_t, int);
 template cudaError_t launchHeuristicTopK<__nv_bfloat16, int>(

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -1776,10 +1776,10 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
 
 // Explicit instantiations — fp32 + bf16/fp16
 template cudaError_t launchHeuristicTopK<float, int>(
-    float const*, int, int const*, int, int, float*, int*, cudaStream_t, int);
+    float const*, int, int const*, int, int, float*, int*, cudaStream_t);
 template cudaError_t launchHeuristicTopK<__nv_bfloat16, int>(
-    __nv_bfloat16 const*, int, int const*, int, int, __nv_bfloat16*, int*, cudaStream_t, int);
+    __nv_bfloat16 const*, int, int const*, int, int, __nv_bfloat16*, int*, cudaStream_t);
 template cudaError_t launchHeuristicTopK<__half, int>(
-    __half const*, int, int const*, int, int, __half*, int*, cudaStream_t, int);
+    __half const*, int, int const*, int, int, __half*, int*, cudaStream_t);
 
 } // namespace heuristic_topk

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -1040,7 +1040,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         int snap_limit = (cand_count > 128 ? cand_count / 4 : 32);
         for (int si = 0; si < snap_limit; si++)
         {
-            blockFusedSnapIter(smem, cand_count, tid, warp_id, lane);
+            blockFusedSnapIter<TopK>(smem, cand_count, tid, warp_id, lane);
             int cge = smem->cnt_lo;
             int cgt = smem->cnt_hi;
             if (cgt < kK && cge >= kK)
@@ -1581,7 +1581,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         int snap_limit = (cand_count > 128 ? cand_count / 4 : 32);
         for (int si = 0; si < snap_limit; si++)
         {
-            blockFusedSnapIterDtype<SmemKey>(smem, cand_count, tid, warp_id, lane);
+            blockFusedSnapIterDtype<SmemKey, TopK>(smem, cand_count, tid, warp_id, lane);
             int cge = smem->cnt_lo;
             int cgt = smem->cnt_hi;
             if (cgt < kK && cge >= kK)

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -191,6 +191,15 @@ static_assert(MAX_CANDIDATES % BLOCK_SIZE == 0);
 //     Scheme X v1.2 4-report regression to confirm no real-world loss.
 //   - kNumBins=NUM_BINS=2048 unchanged across combos (P4 histogram).
 //
+// Q10b-S2 (2026-05-08): kFTarget re-tuned for V4 production M=K (preIdx=K, not 2048).
+// Under M=K, pmean shifts to right tail (top-K of prev row); P2 secant needs a
+// tighter target to converge in fewer iterations. K-proportional K=512/1024 picks:
+//   K=512:  kFTarget=384  (= 0.75K)  — was K
+//   K=1024: kFTarget=2560 (= 2.5K)   — was 3K
+//   K=2048: unchanged (M=K=2048 trivially equals legacy M=2048)
+// Cross-layer 8-cell sweep on SWE-Bench-64K (`10_multi_cta_v1/M_eq_K_redesign/`):
+// 4 V4-hot cells (bf16/fp16 × K=512/1024) recover ~3.78 µs total wall.
+//
 // Primary template intentionally left undefined: any unsupported (T, K)
 // combination triggers a compile-time error rather than a runtime fall-
 // through.
@@ -205,7 +214,7 @@ struct GvrParams; // primary undefined → compile-time error for bad combos
 template <>
 struct GvrParams<float, 512>
 {
-    static constexpr int kFTarget = 512;
+    static constexpr int kFTarget = 384; // Q10b-S2 (M=K retune): was 512
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 1024;
 };
@@ -213,7 +222,7 @@ struct GvrParams<float, 512>
 template <>
 struct GvrParams<float, 1024>
 {
-    static constexpr int kFTarget = 3072;
+    static constexpr int kFTarget = 2560; // Q10b-S2 (M=K retune): was 3072
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 1024;
 };
@@ -241,7 +250,7 @@ struct GvrParams<float, 2048>
 template <>
 struct GvrParams<__nv_bfloat16, 512>
 {
-    static constexpr int kFTarget = 512;
+    static constexpr int kFTarget = 384; // Q10b-S2 (M=K retune): was 512
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 512;
 };
@@ -249,7 +258,7 @@ struct GvrParams<__nv_bfloat16, 512>
 template <>
 struct GvrParams<__nv_bfloat16, 1024>
 {
-    static constexpr int kFTarget = 3072;
+    static constexpr int kFTarget = 2560; // Q10b-S2 (M=K retune): was 3072
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 512;
 };
@@ -268,7 +277,7 @@ struct GvrParams<__nv_bfloat16, 2048>
 template <>
 struct GvrParams<__half, 512>
 {
-    static constexpr int kFTarget = 512;
+    static constexpr int kFTarget = 384; // Q10b-S2 (M=K retune): was 512
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 512;
 };
@@ -276,7 +285,7 @@ struct GvrParams<__half, 512>
 template <>
 struct GvrParams<__half, 1024>
 {
-    static constexpr int kFTarget = 3072;
+    static constexpr int kFTarget = 2560; // Q10b-S2 (M=K retune): was 3072
     static constexpr int kC = 5120;
     static constexpr int kNumBins = 1024;
 };

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -43,12 +43,113 @@
 
 #include <cfloat>
 #include <cstdint>
-#include <cstdio>  // for snap convergence warning printf
-#include <cstdlib> // for std::getenv (PDL launcher env-gate)
+#include <cstdio>      // for snap convergence warning printf
+#include <cstdlib>     // for std::getenv (PDL launcher env-gate)
+#include <cuda_bf16.h> // 4d: bf16 input dtype support
+#include <cuda_fp16.h> // 4d: fp16 input dtype support
 #include <cuda_runtime.h>
+#include <type_traits> // 4d: std::is_same_v in launchHeuristicTopK dispatch
 
 namespace heuristic_topk
 {
+
+// ============================================================================
+// Multi-dtype Trait Layer (4d_multi_dtype_unified, 2026-05-06)
+// ============================================================================
+// Encapsulates dtype-specific cvt intrinsics + vector load width so the
+// kernel body can be templated cleanly. For fp32 the path is byte-
+// equivalent to the original V2e kernel (VEC_W=4, identity cvt).
+//
+// Tier-1 fp32 arithmetic (threshold, accumulators, bin index) — kernel-
+// internal, not in trait. Tier-2 InputT containers (HBM input, smem keys,
+// outputValues) — dtype-driven. Tier-3 ALU stays fp32 (GVR is HBM-bound).
+
+template <typename T>
+struct GvrDtypeTraits;
+
+template <>
+struct GvrDtypeTraits<float>
+{
+    using SmemKey = float;
+    static constexpr int VEC_W = 4; // int4 = 4 × fp32
+    static constexpr int SMEM_KEY_BYTES = 4;
+
+    __device__ static __forceinline__ float to_fp32(float v)
+    {
+        return v;
+    }
+
+    __device__ static __forceinline__ float from_fp32(float v)
+    {
+        return v;
+    }
+
+    __device__ static __forceinline__ void unpack4(int4 raw, float* out)
+    {
+        out[0] = __int_as_float(raw.x);
+        out[1] = __int_as_float(raw.y);
+        out[2] = __int_as_float(raw.z);
+        out[3] = __int_as_float(raw.w);
+    }
+};
+
+template <>
+struct GvrDtypeTraits<__nv_bfloat16>
+{
+    using SmemKey = __nv_bfloat16;
+    static constexpr int VEC_W = 8; // int4 = 8 × bf16 = 4 × bf162
+    static constexpr int SMEM_KEY_BYTES = 2;
+
+    __device__ static __forceinline__ float to_fp32(__nv_bfloat16 v)
+    {
+        return __bfloat162float(v);
+    }
+
+    __device__ static __forceinline__ __nv_bfloat16 from_fp32(float v)
+    {
+        return __float2bfloat16_rn(v);
+    }
+
+    __device__ static __forceinline__ void unpack8(int4 raw, float* out)
+    {
+        auto* p = reinterpret_cast<__nv_bfloat162*>(&raw);
+#pragma unroll
+        for (int j = 0; j < 4; j++)
+        {
+            out[2 * j] = __low2float(p[j]);
+            out[2 * j + 1] = __high2float(p[j]);
+        }
+    }
+};
+
+template <>
+struct GvrDtypeTraits<__half>
+{
+    using SmemKey = __half;
+    static constexpr int VEC_W = 8; // int4 = 8 × fp16 = 4 × half2
+    static constexpr int SMEM_KEY_BYTES = 2;
+
+    __device__ static __forceinline__ float to_fp32(__half v)
+    {
+        return __half2float(v);
+    }
+
+    __device__ static __forceinline__ __half from_fp32(float v)
+    {
+        return __float2half_rn(v);
+    }
+
+    __device__ static __forceinline__ void unpack8(int4 raw, float* out)
+    {
+        auto* p = reinterpret_cast<__half2*>(&raw);
+#pragma unroll
+        for (int j = 0; j < 4; j++)
+        {
+            out[2 * j] = __low2float(p[j]);
+            out[2 * j + 1] = __high2float(p[j]);
+        }
+    }
+};
 
 // ============================================================================
 // Configuration Constants
@@ -70,17 +171,21 @@ static_assert(TOP_K % BLOCK_SIZE == 0);
 static_assert(MAX_CANDIDATES % BLOCK_SIZE == 0);
 
 // ============================================================================
-// Shared Memory Layout (~59 KB)
+// Shared Memory Layout
 // ============================================================================
+// fp32 instantiation (KernelSmem = KernelSmemTpl<float>): ~59 KB
+// bf16/fp16 instantiation (KernelSmemTpl<__nv_bfloat16/__half>): ~47 KB
+// (4d_multi_dtype_unified, 2026-05-06: templatized on SmemKey for trait path)
 
-struct KernelSmem
+template <typename SmemKey>
+struct KernelSmemTpl
 {
-    alignas(16) float keys[MAX_CANDIDATES]; // 24 KB
-    alignas(16) int vals[MAX_CANDIDATES];   // 24 KB
+    alignas(16) SmemKey keys[MAX_CANDIDATES]; // 24 KB (fp32) / 12 KB (bf16/fp16)
+    alignas(16) int vals[MAX_CANDIDATES];     // 24 KB
 
-    int warp_counts[NUM_WARPS];             // 64 B
-    int histogram[NUM_BINS];                // 8 KB
-    int per_thread_counts[BLOCK_SIZE];      // 2 KB — OPT7: cached from last blockCountGE
+    int warp_counts[NUM_WARPS];               // 64 B
+    int histogram[NUM_BINS];                  // 8 KB
+    int per_thread_counts[BLOCK_SIZE];        // 2 KB — OPT7: cached from last blockCountGE
 
     float threshold;
     int cand_count;
@@ -92,6 +197,11 @@ struct KernelSmem
     float pmax_saved;
     int out_count;
 };
+
+// fp32 alias preserved so the original gvrTopKJob / gvrTopKKernel /
+// blockCountGE / blockFusedSnapIter and the TRT-LLM multi-row caller
+// `using heuristic_topk::gvrTopKJob` keep their byte-equivalent signature.
+using KernelSmem = KernelSmemTpl<float>;
 
 // ============================================================================
 // ★ OPT4: Warp-Level Reduction Primitives
@@ -205,6 +315,122 @@ __device__ __forceinline__ void blockFusedSnapIter(KernelSmem* smem, int count, 
     for (int i = tid; i < count; i += BLOCK_SIZE)
     {
         float v = smem->keys[i];
+        lge += (v >= thr);
+        lgt += (v > thr);
+        if (v > thr)
+            s_up = fminf(s_up, v);
+        if (v < thr)
+            s_down = fmaxf(s_down, v);
+    }
+
+    int packed = (lge << 16) | lgt;
+    packed = warpReduceSum(packed);
+    s_up = warpReduceMin(s_up);
+    s_down = warpReduceMax(s_down);
+
+    if (lane == 0)
+    {
+        smem->warp_counts[warp_id] = packed;
+        smem->histogram[warp_id] = __float_as_int(s_up);
+        smem->histogram[NUM_WARPS + warp_id] = __float_as_int(s_down);
+    }
+    __syncthreads();
+
+    if (tid == 0)
+    {
+        int tp = 0;
+        float total_up = FLT_MAX, total_down = -FLT_MAX;
+        for (int w = 0; w < NUM_WARPS; w++)
+        {
+            tp += smem->warp_counts[w];
+            total_up = fminf(total_up, __int_as_float(smem->histogram[w]));
+            total_down = fmaxf(total_down, __int_as_float(smem->histogram[NUM_WARPS + w]));
+        }
+        smem->cnt_lo = tp >> 16;
+        smem->cnt_hi = tp & 0xFFFF;
+
+        int cge = smem->cnt_lo;
+        int cgt = smem->cnt_hi;
+
+        if (cgt >= TOP_K)
+        {
+            if (total_up < FLT_MAX)
+                smem->threshold = total_up;
+        }
+        else if (cge < TOP_K)
+        {
+            if (total_down > -FLT_MAX)
+                smem->threshold = total_down;
+        }
+    }
+    __syncthreads();
+}
+
+// ============================================================================
+// Dtype-templated helpers (4d_multi_dtype_unified)
+// ============================================================================
+// Mirror blockCountGE / blockFusedSnapIter for bf16/fp16 inputs. fp32
+// path keeps the originals untouched (byte-equivalent to V2e baseline).
+//
+// blockCountGEDtype:
+//   - 8-wide vector load (int4 = 8 × 16-bit) instead of 4-wide (float4 = 4 × fp32)
+//   - up-cast each element to fp32 before threshold compare
+//
+// blockFusedSnapIterDtype:
+//   - reads SmemKey (bf16 / fp16) from smem->keys, up-casts to fp32 for
+//     min/max/count work; threshold remains fp32 (Tier-1 invariant).
+
+template <typename InputT>
+__device__ __forceinline__ void blockCountGEDtype(InputT const* __restrict__ input, int N, float threshold,
+    KernelSmemTpl<typename GvrDtypeTraits<InputT>::SmemKey>* smem, int tid, int warp_id, int lane)
+{
+    using Trait = GvrDtypeTraits<InputT>;
+    static_assert(Trait::VEC_W == 8, "blockCountGEDtype is for bf16/fp16 (8-wide vector); use blockCountGE for fp32");
+
+    int c = 0;
+    for (int i = tid * 8; i + 7 < N; i += BLOCK_SIZE * 8)
+    {
+        int4 raw = __ldg(reinterpret_cast<int4 const*>(input + i));
+        float v[8];
+        Trait::unpack8(raw, v);
+#pragma unroll
+        for (int j = 0; j < 8; j++)
+            c += (v[j] >= threshold);
+    }
+    for (int i = (N & ~7) + tid; i < N; i += BLOCK_SIZE)
+        c += (Trait::to_fp32(__ldg(&input[i])) >= threshold);
+
+    smem->per_thread_counts[tid] = c;
+
+    c = warpReduceSum(c);
+
+    if (lane == 0)
+        smem->warp_counts[warp_id] = c;
+    __syncthreads();
+
+    if (tid == 0)
+    {
+        int t = 0;
+        for (int w = 0; w < NUM_WARPS; w++)
+            t += smem->warp_counts[w];
+        smem->cand_count = t;
+    }
+}
+
+template <typename SmemKey>
+__device__ __forceinline__ void blockFusedSnapIterDtype(
+    KernelSmemTpl<SmemKey>* smem, int count, int tid, int warp_id, int lane)
+{
+    using Trait = GvrDtypeTraits<SmemKey>;
+
+    float const thr = smem->threshold;
+
+    int lge = 0, lgt = 0;
+    float s_up = FLT_MAX, s_down = -FLT_MAX;
+
+    for (int i = tid; i < count; i += BLOCK_SIZE)
+    {
+        float v = Trait::to_fp32(smem->keys[i]);
         lge += (v >= thr);
         lgt += (v > thr);
         if (v > thr)
@@ -776,6 +1002,530 @@ __global__ void __launch_bounds__(BLOCK_SIZE, 1)
 }
 
 // ============================================================================
+// gvrTopKJobDtype<InputT> — bf16/fp16 device function (4d_multi_dtype_unified)
+// ============================================================================
+// Mirror of gvrTopKJob with trait-driven dtype substitutions:
+//   - HBM input read   : Trait::to_fp32(__ldg(&input[i]))
+//   - smem keys write  : Trait::from_fp32(v)   (Tier-2 SmemKey container)
+//   - smem keys read   : Trait::to_fp32(keys[i]) for arithmetic
+//   - outputValues     : InputT (SmemKey == InputT in templated path)
+//   - vector load      : 8-wide via Trait::unpack8
+//   - blockCountGE     : blockCountGEDtype<InputT>
+//   - blockFusedSnapIter: blockFusedSnapIterDtype<SmemKey>
+// All Tier-1 arithmetic stays fp32 (threshold, accumulators, bin index).
+// fp32 path is NOT routed here — fp32 keeps the original gvrTopKJob (option A,
+// guaranteed zero-regression). This template only instantiates for bf16/fp16.
+
+template <typename InputT>
+__device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, int const N,
+    int const* __restrict__ preIdx, int const M, int const topK, InputT* __restrict__ outputValues,
+    int* __restrict__ outputIndices, KernelSmemTpl<typename GvrDtypeTraits<InputT>::SmemKey>* smem,
+    int const preIdxOffset = 0)
+{
+    using Trait = GvrDtypeTraits<InputT>;
+    using SmemKey = typename Trait::SmemKey;
+    static_assert(Trait::VEC_W == 8, "gvrTopKJobDtype is for bf16/fp16 (8-wide); fp32 uses gvrTopKJob");
+
+    int const tid = threadIdx.x;
+    int const warp_id = tid / WARP_SIZE;
+    int const lane = tid & (WARP_SIZE - 1);
+    unsigned const full_mask = 0xffffffffu;
+
+    {
+        // ================================================================
+        // Phase 1 — Min/Max/Mean of pre-indexed values
+        // ================================================================
+
+        float local_min = FLT_MAX;
+        float local_max = -FLT_MAX;
+        float local_sum = 0.0f;
+        int local_cnt = 0;
+        for (int i = tid; i < M; i += BLOCK_SIZE)
+        {
+            int idx = __ldg(&preIdx[i]) + preIdxOffset;
+            if (idx >= 0 && idx < N)
+            {
+                float v = Trait::to_fp32(__ldg(&input[idx]));
+                local_min = fminf(local_min, v);
+                local_max = fmaxf(local_max, v);
+                local_sum += v;
+                local_cnt++;
+            }
+        }
+
+        float wmin = warpReduceMin(local_min);
+        float wmax = warpReduceMax(local_max);
+        float wsum = local_sum;
+#pragma unroll
+        for (int off = WARP_SIZE / 2; off > 0; off >>= 1)
+            wsum += __shfl_down_sync(0xffffffffu, wsum, off);
+        int wcnt = warpReduceSum(local_cnt);
+
+        if (lane == 0)
+        {
+            smem->histogram[warp_id] = __float_as_int(wmin);
+            smem->histogram[NUM_WARPS + warp_id] = __float_as_int(wmax);
+            smem->histogram[NUM_WARPS * 2 + warp_id] = __float_as_int(wsum);
+            smem->histogram[NUM_WARPS * 3 + warp_id] = wcnt;
+        }
+        __syncthreads();
+
+        if (tid == 0)
+        {
+            float pmin = FLT_MAX, pmax = -FLT_MAX, psum = 0.0f;
+            int pcnt = 0;
+            for (int w = 0; w < NUM_WARPS; w++)
+            {
+                pmin = fminf(pmin, __int_as_float(smem->histogram[w]));
+                pmax = fmaxf(pmax, __int_as_float(smem->histogram[NUM_WARPS + w]));
+                psum += __int_as_float(smem->histogram[NUM_WARPS * 2 + w]);
+                pcnt += smem->histogram[NUM_WARPS * 3 + w];
+            }
+            float pmean = (pcnt > 0) ? psum / (float) pcnt : (pmin + pmax) * 0.5f;
+
+            smem->pmax_saved = pmax;
+            smem->threshold = pmean;
+            smem->val_lo = pmin;
+            smem->val_hi = pmax;
+            smem->cnt_lo = M + M / 4;
+            smem->cnt_hi = 1;
+            smem->done = 0;
+        }
+        __syncthreads();
+
+        if (smem->val_hi <= -FLT_MAX || smem->val_lo >= smem->val_hi)
+        {
+            if (tid == 0)
+                for (int i = 0; i < topK && i < N; i++)
+                {
+                    outputIndices[i] = i;
+                    outputValues[i] = __ldg(&input[i]); // both InputT, no convert
+                }
+            return;
+        }
+
+        // ================================================================
+        // Phase 2 — Secant-interpolation threshold search
+        // ================================================================
+
+        blockCountGEDtype<InputT>(input, N, smem->threshold, smem, tid, warp_id, lane);
+
+        if (tid == 0)
+        {
+            int c = smem->cand_count;
+            if (c >= TOP_K && c <= MAX_CANDIDATES)
+                smem->done = 1;
+            else if (c > MAX_CANDIDATES)
+            {
+                smem->val_lo = smem->threshold;
+                smem->cnt_lo = c;
+            }
+            else
+            {
+                smem->val_hi = smem->threshold;
+                smem->cnt_hi = c;
+            }
+        }
+        __syncthreads();
+
+        for (int iter = 0; iter < MAX_REFINE_ITERS; iter++)
+        {
+            if (smem->done)
+                break;
+            if (tid == 0)
+            {
+                float vlo = smem->val_lo, vhi = smem->val_hi;
+                int clo = smem->cnt_lo, chi = smem->cnt_hi;
+                int target = TOP_K + SAFETY_MARGIN / 2;
+                float range = vhi - vlo;
+                float nv;
+                if (clo > chi && range > 1e-10f)
+                {
+                    float f = (float) (clo - target) / (float) (clo - chi);
+                    f = fmaxf(0.05f, fminf(0.95f, f));
+                    if (iter == 0)
+                        f = fminf(f, 0.50f);
+                    nv = vlo + range * f;
+                }
+                else
+                    nv = (vlo + vhi) * 0.5f;
+                if (nv <= vlo)
+                    nv = vlo + range * 0.05f;
+                if (nv >= vhi)
+                    nv = vhi - range * 0.05f;
+                if (nv == vlo || nv == vhi)
+                {
+                    nv = (vlo + vhi) * 0.5f;
+                    if (nv == vlo || nv == vhi)
+                    {
+                        smem->threshold = vlo;
+                        smem->done = 2;
+                    }
+                    else
+                        smem->threshold = nv;
+                }
+                else
+                    smem->threshold = nv;
+            }
+            __syncthreads();
+            if (smem->done)
+                break;
+            blockCountGEDtype<InputT>(input, N, smem->threshold, smem, tid, warp_id, lane);
+            if (tid == 0)
+            {
+                int c = smem->cand_count;
+                if (c >= TOP_K && c <= MAX_CANDIDATES)
+                    smem->done = 1;
+                else if (c > MAX_CANDIDATES)
+                {
+                    smem->val_lo = smem->threshold;
+                    smem->cnt_lo = c;
+                }
+                else
+                {
+                    smem->val_hi = smem->threshold;
+                    smem->cnt_hi = c;
+                }
+            }
+            __syncthreads();
+        }
+
+        if (tid == 0 && !smem->done)
+        {
+            if (smem->cnt_lo <= MAX_CANDIDATES * 2)
+                smem->threshold = smem->val_lo;
+            else
+                smem->threshold = smem->val_hi;
+            smem->done = 2;
+        }
+        __syncthreads();
+    } // end of P1+P2 scope
+
+    // ================================================================
+    // Phase 3 — Ballot-free candidate collect
+    // ================================================================
+
+    if (smem->done != 1)
+    {
+        blockCountGEDtype<InputT>(input, N, smem->threshold, smem, tid, warp_id, lane);
+        if (tid == 0 && smem->cand_count > MAX_CANDIDATES)
+            smem->val_lo = smem->threshold;
+        __syncthreads();
+
+        for (int retry = 0; retry < 10 && smem->cand_count > MAX_CANDIDATES; retry++)
+        {
+            if (tid == 0)
+            {
+                float lo = smem->val_lo, hi = smem->val_hi;
+                float mid = (lo + hi) * 0.5f;
+                if (mid == lo)
+                    mid = hi;
+                smem->threshold = mid;
+            }
+            __syncthreads();
+            blockCountGEDtype<InputT>(input, N, smem->threshold, smem, tid, warp_id, lane);
+            if (tid == 0)
+            {
+                int c = smem->cand_count;
+                if (c > MAX_CANDIDATES)
+                    smem->val_lo = smem->threshold;
+                else if (c < TOP_K)
+                    smem->val_hi = smem->threshold;
+            }
+            __syncthreads();
+        }
+    }
+
+    int my_total_qual = smem->per_thread_counts[tid];
+
+    int thread_prefix = my_total_qual;
+#pragma unroll
+    for (int off = 1; off < WARP_SIZE; off *= 2)
+    {
+        int other = __shfl_up_sync(full_mask, thread_prefix, off);
+        if (lane >= off)
+            thread_prefix += other;
+    }
+    int my_excl_offset = thread_prefix - my_total_qual;
+    int warp_total_qual = __shfl_sync(full_mask, thread_prefix, WARP_SIZE - 1);
+
+    if (lane == 0)
+        smem->warp_counts[warp_id] = warp_total_qual;
+    __syncthreads();
+
+    if (tid == 0)
+    {
+        int total = 0;
+        for (int w = 0; w < NUM_WARPS; w++)
+        {
+            int cnt = smem->warp_counts[w];
+            smem->warp_counts[w] = total;
+            total += cnt;
+        }
+        smem->cand_count = total;
+    }
+    __syncthreads();
+
+    int my_write_pos = smem->warp_counts[warp_id] + my_excl_offset;
+
+    {
+        float const thr = smem->threshold;
+        // 8-wide vector load (int4 = 8 × bf16/fp16)
+        for (int i = tid * 8; i + 7 < N; i += BLOCK_SIZE * 8)
+        {
+            int4 raw = __ldg(reinterpret_cast<int4 const*>(input + i));
+            float v[8];
+            Trait::unpack8(raw, v);
+#pragma unroll
+            for (int j = 0; j < 8; j++)
+            {
+                float val = v[j];
+                if (val >= thr && my_write_pos < MAX_CANDIDATES)
+                {
+                    smem->keys[my_write_pos] = Trait::from_fp32(val);
+                    smem->vals[my_write_pos] = i + j;
+                    my_write_pos++;
+                }
+            }
+        }
+        // Tail loop (N % 8)
+        for (int i = (N & ~7) + tid; i < N; i += BLOCK_SIZE)
+        {
+            float val = Trait::to_fp32(__ldg(&input[i]));
+            if (val >= thr && my_write_pos < MAX_CANDIDATES)
+            {
+                smem->keys[my_write_pos] = Trait::from_fp32(val);
+                smem->vals[my_write_pos] = i;
+                my_write_pos++;
+            }
+        }
+    }
+    __syncthreads();
+
+    // ================================================================
+    // Phase 4 — Histogram-based selection + partition
+    // ================================================================
+
+    int const cand_count = min(smem->cand_count, MAX_CANDIDATES);
+
+    if (cand_count == TOP_K)
+    {
+        for (int i = tid; i < TOP_K; i += BLOCK_SIZE)
+        {
+            outputValues[i] = smem->keys[i]; // both InputT, no convert
+            outputIndices[i] = smem->vals[i];
+        }
+        return;
+    }
+
+    if (cand_count > TOP_K)
+    {
+        float cmin = FLT_MAX, cmax = -FLT_MAX;
+        for (int i = tid; i < cand_count; i += BLOCK_SIZE)
+        {
+            float v = Trait::to_fp32(smem->keys[i]);
+            cmin = fminf(cmin, v);
+            cmax = fmaxf(cmax, v);
+        }
+        cmin = warpReduceMin(cmin);
+        cmax = warpReduceMax(cmax);
+        if (lane == 0)
+        {
+            smem->warp_counts[warp_id] = __float_as_int(cmin);
+            smem->histogram[warp_id] = __float_as_int(cmax);
+        }
+        __syncthreads();
+
+        float block_min = FLT_MAX, block_max = -FLT_MAX;
+        for (int w = 0; w < NUM_WARPS; w++)
+        {
+            block_min = fminf(block_min, __int_as_float(smem->warp_counts[w]));
+            block_max = fmaxf(block_max, __int_as_float(smem->histogram[w]));
+        }
+        if (block_max <= block_min)
+            block_max = block_min + 1e-6f;
+
+        for (int i = tid; i < NUM_BINS; i += BLOCK_SIZE)
+            smem->histogram[i] = 0;
+        __syncthreads();
+
+        float range1 = block_max - block_min;
+        float inv1 = (range1 > 0.0f) ? ((float) (NUM_BINS - 1) + 0.99f) / range1 : 0.0f;
+
+        for (int i = tid; i < cand_count; i += BLOCK_SIZE)
+        {
+            int bin = (int) ((Trait::to_fp32(smem->keys[i]) - block_min) * inv1);
+            bin = min(max(bin, 0), NUM_BINS - 1);
+            atomicAdd(&smem->histogram[bin], 1);
+        }
+        __syncthreads();
+
+        // Parallel K-th bin search (2-step)
+        {
+            constexpr int BINS_PER_WARP = NUM_BINS / NUM_WARPS;
+            static_assert(NUM_BINS % NUM_WARPS == 0, "NUM_BINS must be divisible by NUM_WARPS");
+            int warp_bin_sum = 0;
+            for (int j = 0; j < BINS_PER_WARP; j++)
+                warp_bin_sum += smem->histogram[NUM_BINS - 1 - warp_id * BINS_PER_WARP - j];
+            if (lane == 0)
+                smem->warp_counts[warp_id] = warp_bin_sum;
+        }
+        __syncthreads();
+
+        if (tid == 0)
+        {
+            int cum = 0, tw = NUM_WARPS - 1;
+            for (int w = 0; w < NUM_WARPS; w++)
+            {
+                cum += smem->warp_counts[w];
+                if (cum >= TOP_K)
+                {
+                    tw = w;
+                    break;
+                }
+            }
+            cum = 0;
+            for (int w = 0; w < tw; w++)
+                cum += smem->warp_counts[w];
+            smem->cnt_lo = cum;
+            smem->cnt_hi = tw;
+        }
+        __syncthreads();
+
+        if (warp_id == smem->cnt_hi && lane == 0)
+        {
+            constexpr int BINS_PER_WARP = NUM_BINS / NUM_WARPS;
+            int base_cum = smem->cnt_lo;
+            float thr = block_min;
+            for (int j = 0; j < BINS_PER_WARP; j++)
+            {
+                int b = NUM_BINS - 1 - smem->cnt_hi * BINS_PER_WARP - j;
+                base_cum += smem->histogram[b];
+                if (base_cum >= TOP_K)
+                {
+                    thr = block_min + (float) b * range1 / (float) NUM_BINS;
+                    break;
+                }
+            }
+            smem->threshold = thr;
+        }
+        __syncthreads();
+
+        bool snap_converged = false;
+        int snap_limit = (cand_count > 128 ? cand_count / 4 : 32);
+        for (int si = 0; si < snap_limit; si++)
+        {
+            blockFusedSnapIterDtype<SmemKey>(smem, cand_count, tid, warp_id, lane);
+            int cge = smem->cnt_lo;
+            int cgt = smem->cnt_hi;
+            if (cgt < TOP_K && cge >= TOP_K)
+            {
+                snap_converged = true;
+                break;
+            }
+        }
+        (void) snap_converged;
+
+        float sel_thr = smem->threshold;
+        if (tid == 0)
+            smem->out_count = 0;
+        __syncthreads();
+
+        // Pass 1: strictly greater than sel_thr
+        for (int base = warp_id * WARP_SIZE; base < cand_count; base += BLOCK_SIZE)
+        {
+            int i = base + lane;
+            float v = (i < cand_count) ? Trait::to_fp32(smem->keys[i]) : -FLT_MAX;
+
+            bool emit_gt = (i < cand_count) && (v > sel_thr);
+            unsigned mask_gt = __ballot_sync(full_mask, emit_gt);
+            if (mask_gt)
+            {
+                int cnt = __popc(mask_gt);
+                int moff = __popc(mask_gt & ((1u << lane) - 1u));
+                int bp = 0;
+                if (lane == 0)
+                    bp = atomicAdd(&smem->out_count, cnt);
+                bp = __shfl_sync(full_mask, bp, 0);
+                if (emit_gt && bp + moff < TOP_K)
+                {
+                    outputValues[bp + moff] = Trait::from_fp32(v);
+                    outputIndices[bp + moff] = smem->vals[i];
+                }
+            }
+        }
+        __syncthreads();
+
+        // Pass 2: equal to sel_thr (fills remaining slots)
+        for (int base = warp_id * WARP_SIZE; base < cand_count; base += BLOCK_SIZE)
+        {
+            int i = base + lane;
+            float v = (i < cand_count) ? Trait::to_fp32(smem->keys[i]) : -FLT_MAX;
+
+            bool emit_eq = (i < cand_count) && (v == sel_thr);
+            unsigned mask_eq = __ballot_sync(full_mask, emit_eq);
+            if (mask_eq)
+            {
+                int cnt = __popc(mask_eq);
+                int moff = __popc(mask_eq & ((1u << lane) - 1u));
+                int bp = 0;
+                if (lane == 0)
+                    bp = atomicAdd(&smem->out_count, cnt);
+                bp = __shfl_sync(full_mask, bp, 0);
+                if (emit_eq && bp + moff < TOP_K)
+                {
+                    outputValues[bp + moff] = Trait::from_fp32(v);
+                    outputIndices[bp + moff] = smem->vals[i];
+                }
+            }
+        }
+        __syncthreads();
+
+        int filled = min(smem->out_count, TOP_K);
+        InputT const neg_max = Trait::from_fp32(-FLT_MAX);
+        for (int i = filled + tid; i < TOP_K; i += BLOCK_SIZE)
+        {
+            outputValues[i] = neg_max;
+            outputIndices[i] = -1;
+        }
+        return;
+    }
+
+    // cand_count < TOP_K fallback
+    for (int i = tid; i < cand_count; i += BLOCK_SIZE)
+    {
+        outputValues[i] = smem->keys[i]; // both InputT
+        outputIndices[i] = smem->vals[i];
+    }
+    InputT const neg_max = Trait::from_fp32(-FLT_MAX);
+    for (int i = cand_count + tid; i < TOP_K; i += BLOCK_SIZE)
+    {
+        outputValues[i] = neg_max;
+        outputIndices[i] = -1;
+    }
+}
+
+// ============================================================================
+// gvrTopKKernelDtype<InputT> — bf16/fp16 single-row global wrapper
+// ============================================================================
+
+template <typename InputT>
+__global__ void __launch_bounds__(BLOCK_SIZE, 1)
+    gvrTopKKernelDtype(InputT const* __restrict__ input, int const N, int const* __restrict__ preIdx, int const M,
+        int const topK, InputT* __restrict__ outputValues, int* __restrict__ outputIndices, int const thresholdPos)
+{
+    using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
+    extern __shared__ unsigned char smem_raw[];
+    auto* smem = reinterpret_cast<KernelSmemTpl<SmemKey>*>(smem_raw);
+
+    gvrTopKJobDtype<InputT>(input, N, preIdx, M, topK, outputValues, outputIndices, smem,
+        /*preIdxOffset=*/0);
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+// ============================================================================
 // Launch Wrapper
 // ============================================================================
 
@@ -784,11 +1534,25 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
     IdxT* outputIndices, cudaStream_t stream = 0, int thresholdPos = -1)
 {
     static_assert(sizeof(IdxT) == sizeof(int), "launchHeuristicTopK only supports 32-bit indices");
+    static_assert(std::is_same_v<T, float> || std::is_same_v<T, __nv_bfloat16> || std::is_same_v<T, __half>,
+        "launchHeuristicTopK supports only fp32 / bf16 / fp16");
 
     if (topK != TOP_K)
         return cudaErrorInvalidValue;
 
-    size_t smemSize = sizeof(KernelSmem);
+    // 4d: smem size depends on InputT. fp32 path uses the original
+    // KernelSmem (~59 KB); bf16/fp16 use KernelSmemTpl<T> (~47 KB).
+    using SmemKey = typename GvrDtypeTraits<T>::SmemKey;
+    size_t smemSize = sizeof(KernelSmemTpl<SmemKey>);
+
+    // Resolve target kernel function pointer at compile time.
+    auto kfn = []()
+    {
+        if constexpr (std::is_same_v<T, float>)
+            return gvrTopKKernel;
+        else
+            return gvrTopKKernelDtype<T>;
+    }();
 
     // Opt-in to extended shared memory. cudaFuncSetAttribute is device-scoped
     // and cheap — call unconditionally to be safe across multi-GPU processes.
@@ -800,7 +1564,7 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
         cudaDeviceGetAttribute(&maxSmem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
         if (smemSize > static_cast<size_t>(maxSmem))
             return cudaErrorInvalidConfiguration;
-        cudaFuncSetAttribute(gvrTopKKernel, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
+        cudaFuncSetAttribute(kfn, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
     }
 
     // Use cudaLaunchKernelEx with PDL attribute so the kernel epilogue's
@@ -829,12 +1593,17 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
     config.attrs = attrs;
     config.numAttrs = 1;
 
-    cudaLaunchKernelEx(&config, gvrTopKKernel, input, N, preIdx, M, topK, outputValues, outputIndices, thresholdPos);
+    cudaLaunchKernelEx(&config, kfn, input, N, preIdx, M, topK, outputValues, outputIndices, thresholdPos);
 
     return cudaGetLastError();
 }
 
+// Explicit instantiations — fp32 (V2e baseline path) + bf16/fp16 (4d dtype path)
 template cudaError_t launchHeuristicTopK<float, int>(
     float const*, int, int const*, int, int, float*, int*, cudaStream_t, int);
+template cudaError_t launchHeuristicTopK<__nv_bfloat16, int>(
+    __nv_bfloat16 const*, int, int const*, int, int, __nv_bfloat16*, int*, cudaStream_t, int);
+template cudaError_t launchHeuristicTopK<__half, int>(
+    __half const*, int, int const*, int, int, __half*, int*, cudaStream_t, int);
 
 } // namespace heuristic_topk

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -307,7 +307,7 @@ struct KernelSmemTplK
 
     int warp_counts[NUM_WARPS];        // 64 B
     int histogram[NumBinsT];           // NumBinsT × 4B (default 2048 → 8 KB)
-    int per_thread_counts[BLOCK_SIZE]; // 2 KB — OPT7: cached from last blockCountGE
+    int per_thread_counts[BLOCK_SIZE]; // cached from the most recent blockCountGE call (Phase-3 reuse)
 
     float threshold;
     int cand_count;
@@ -328,7 +328,7 @@ using KernelSmemTpl = KernelSmemTplK<SmemKey>;
 using KernelSmem = KernelSmemTpl<float>;
 
 // ============================================================================
-// ★ OPT4: Warp-Level Reduction Primitives
+// Warp-Level Reduction Primitives
 // ============================================================================
 
 #if __CUDA_ARCH__ >= 800
@@ -410,7 +410,7 @@ __device__ __forceinline__ void blockCountGE(
     for (int i = (N & ~3) + tid; i < N; i += BLOCK_SIZE)
         c += (__ldg(&input[i]) >= threshold);
 
-    // OPT7: cache per-thread count for Phase 3 sub-pass 1 reuse
+    // cache per-thread count for Phase 3 sub-pass 1 reuse
     smem->per_thread_counts[tid] = c;
 
     c = warpReduceSum(c);
@@ -814,9 +814,8 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
     // Phase 3 (GVR Verify) — Ballot-free candidate collect
     // ================================================================
 
-    // OPT5: when done==1, Phase 2 already verified count in
-    //        [kK, kCC]; skip the redundant full-N
-    //        blockCountGE re-check entirely.
+    // When done==1, Phase 2 already verified the candidate count is in
+    // [kK, kCC]; skip the redundant full-N blockCountGE re-check.
     if (smem->done != 1)
     {
         blockCountGE(input, N, smem->threshold, smem, tid, warp_id, lane);
@@ -848,8 +847,8 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         }
     }
 
-    // OPT7: reuse per-thread counts cached by the last blockCountGE call;
-    //        saves one full N-scan (blockCountGE's __syncthreads guarantees visibility).
+    // Reuse per-thread counts cached by the last blockCountGE call (saves
+    // one full N-scan; blockCountGE's __syncthreads guarantees visibility).
     int my_total_qual = smem->per_thread_counts[tid];
 
     int thread_prefix = my_total_qual;
@@ -970,10 +969,11 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         }
         __syncthreads();
 
-        // OPT6: Parallel K-th bin search (2-step).
-        // Each warp sums BINS_PER_WARP consecutive bins (high→low); tid=0 locates the
-        // target warp in NUM_WARPS steps; one thread in that warp scans BINS_PER_WARP bins.
-        // Total serial depth: NUM_WARPS + BINS_PER_WARP = 16 + 128 = 144 steps vs 2048.
+        // Parallel K-th bin search (3-step).
+        // Step 1: each warp sums BINS_PER_WARP consecutive bins (high→low).
+        // Step 2: tid=0 locates the target warp in NUM_WARPS steps.
+        // Step 3: one thread in that warp scans its BINS_PER_WARP bins.
+        // Total serial depth: NUM_WARPS + BINS_PER_WARP steps vs full kBins.
         {
             constexpr int BINS_PER_WARP = kBins / NUM_WARPS;
             static_assert(kBins % NUM_WARPS == 0, "kBins must be divisible by NUM_WARPS");
@@ -1141,7 +1141,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
 template <int TopK = TOP_K>
 __global__ void __launch_bounds__(BLOCK_SIZE)
     gvrTopKKernel(float const* __restrict__ input, int const N, int const* __restrict__ preIdx, int const M,
-        int const topK, float* __restrict__ outputValues, int* __restrict__ outputIndices, int const thresholdPos)
+        int const topK, float* __restrict__ outputValues, int* __restrict__ outputIndices)
 {
     using SmemT = KernelSmemTplK<float, GvrParams<float, TopK>::kC, GvrParams<float, TopK>::kNumBins>;
     extern __shared__ unsigned char smem_raw[];
@@ -1676,7 +1676,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
 template <typename InputT, int TopK = TOP_K>
 __global__ void __launch_bounds__(BLOCK_SIZE)
     gvrTopKKernelDtype(InputT const* __restrict__ input, int const N, int const* __restrict__ preIdx, int const M,
-        int const topK, InputT* __restrict__ outputValues, int* __restrict__ outputIndices, int const thresholdPos)
+        int const topK, InputT* __restrict__ outputValues, int* __restrict__ outputIndices)
 {
     using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
     using SmemT
@@ -1697,7 +1697,7 @@ __global__ void __launch_bounds__(BLOCK_SIZE)
 
 template <typename T, typename IdxT = int>
 cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M, int topK, T* outputValues,
-    IdxT* outputIndices, cudaStream_t stream = 0, int thresholdPos = -1)
+    IdxT* outputIndices, cudaStream_t stream = 0)
 {
     static_assert(sizeof(IdxT) == sizeof(int), "launchHeuristicTopK only supports 32-bit indices");
     static_assert(std::is_same_v<T, float> || std::is_same_v<T, __nv_bfloat16> || std::is_same_v<T, __half>,
@@ -1761,7 +1761,7 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
         config.attrs = attrs;
         config.numAttrs = 1;
 
-        cudaLaunchKernelEx(&config, kfn, input, N, preIdx, M, topK, outputValues, outputIndices, thresholdPos);
+        cudaLaunchKernelEx(&config, kfn, input, N, preIdx, M, topK, outputValues, outputIndices);
         return cudaGetLastError();
     };
 

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -1185,16 +1185,20 @@ __global__ void __launch_bounds__(BLOCK_SIZE, 1)
 // 4d.D: templated on TopK so K=512/1024/2048 share the same body. Default
 // <InputT, TOP_K> with KernelSmemTpl<...> matches the pre-multi-K signature.
 
+// P0 (Q1b-P0, 2026-05-07): smem keys[] are kept as fp32 to defer the
+// Trait::from_fp32(val) write conversion out of the P3 hot loop. This trades
+// ~10 KB extra smem (5120 keys × +2B at K=2048 dtype) for ~2 µs P3 savings on
+// bf16/fp16 (P3 -10-25%, total -4.5-7.1% per Q1b-P0 snapshot bench).
+// fp32 path is unaffected — gvrTopKJob (separate function) keeps its layout.
 template <typename InputT, int TopK = TOP_K>
 __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, int const N,
     int const* __restrict__ preIdx, int const M, int const topK, InputT* __restrict__ outputValues,
     int* __restrict__ outputIndices,
-    KernelSmemTplK<typename GvrDtypeTraits<InputT>::SmemKey, GvrParams<InputT, TopK>::kC,
-        GvrParams<InputT, TopK>::kNumBins>* smem,
+    KernelSmemTplK<float, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>* smem,
     int const preIdxOffset = 0)
 {
     using Trait = GvrDtypeTraits<InputT>;
-    using SmemKey = typename Trait::SmemKey;
+    using SmemKey = float; // P0: keys stay fp32; conversion deferred to output writeback
     using Params = GvrParams<InputT, TopK>;
     constexpr int kK = TopK;
     constexpr int kCC = Params::kC;
@@ -1458,7 +1462,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
                 float val = v[j];
                 if (val >= thr && my_write_pos < kCC)
                 {
-                    smem->keys[my_write_pos] = Trait::from_fp32(val);
+                    smem->keys[my_write_pos] = val; // P0: defer convert to output
                     smem->vals[my_write_pos] = i + j;
                     my_write_pos++;
                 }
@@ -1470,7 +1474,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
             float val = Trait::to_fp32(__ldg(&input[i]));
             if (val >= thr && my_write_pos < kCC)
             {
-                smem->keys[my_write_pos] = Trait::from_fp32(val);
+                smem->keys[my_write_pos] = val; // P0: defer convert to output
                 smem->vals[my_write_pos] = i;
                 my_write_pos++;
             }
@@ -1488,7 +1492,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
     {
         for (int i = tid; i < kK; i += BLOCK_SIZE)
         {
-            outputValues[i] = smem->keys[i]; // both InputT, no convert
+            outputValues[i] = Trait::from_fp32(smem->keys[i]); // P0: convert at output
             outputIndices[i] = smem->vals[i];
         }
         return;
@@ -1499,7 +1503,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         float cmin = FLT_MAX, cmax = -FLT_MAX;
         for (int i = tid; i < cand_count; i += BLOCK_SIZE)
         {
-            float v = Trait::to_fp32(smem->keys[i]);
+            float v = smem->keys[i]; // P0: keys already fp32
             cmin = fminf(cmin, v);
             cmax = fmaxf(cmax, v);
         }
@@ -1530,7 +1534,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
 
         for (int i = tid; i < cand_count; i += BLOCK_SIZE)
         {
-            int bin = (int) ((Trait::to_fp32(smem->keys[i]) - block_min) * inv1);
+            int bin = (int) ((smem->keys[i] - block_min) * inv1); // P0: keys fp32
             bin = min(max(bin, 0), kBins - 1);
             atomicAdd(&smem->histogram[bin], 1);
         }
@@ -1591,7 +1595,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         int snap_limit = (cand_count > 128 ? cand_count / 4 : 32);
         for (int si = 0; si < snap_limit; si++)
         {
-            blockFusedSnapIterDtype<SmemKey, TopK>(smem, cand_count, tid, warp_id, lane);
+            blockFusedSnapIter<TopK>(smem, cand_count, tid, warp_id, lane); // P0: keys fp32 → use fp32 snap helper
             int cge = smem->cnt_lo;
             int cgt = smem->cnt_hi;
             if (cgt < kK && cge >= kK)
@@ -1611,7 +1615,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         for (int base = warp_id * WARP_SIZE; base < cand_count; base += BLOCK_SIZE)
         {
             int i = base + lane;
-            float v = (i < cand_count) ? Trait::to_fp32(smem->keys[i]) : -FLT_MAX;
+            float v = (i < cand_count) ? smem->keys[i] : -FLT_MAX; // P0: keys fp32
 
             bool emit_gt = (i < cand_count) && (v > sel_thr);
             unsigned mask_gt = __ballot_sync(full_mask, emit_gt);
@@ -1636,7 +1640,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         for (int base = warp_id * WARP_SIZE; base < cand_count; base += BLOCK_SIZE)
         {
             int i = base + lane;
-            float v = (i < cand_count) ? Trait::to_fp32(smem->keys[i]) : -FLT_MAX;
+            float v = (i < cand_count) ? smem->keys[i] : -FLT_MAX; // P0: keys fp32
 
             bool emit_eq = (i < cand_count) && (v == sel_thr);
             unsigned mask_eq = __ballot_sync(full_mask, emit_eq);
@@ -1670,7 +1674,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
     // cand_count < kK fallback
     for (int i = tid; i < cand_count; i += BLOCK_SIZE)
     {
-        outputValues[i] = smem->keys[i]; // both InputT
+        outputValues[i] = Trait::from_fp32(smem->keys[i]); // P0: convert at output
         outputIndices[i] = smem->vals[i];
     }
     InputT const neg_max = Trait::from_fp32(-FLT_MAX);
@@ -1693,7 +1697,8 @@ __global__ void __launch_bounds__(BLOCK_SIZE, 1)
         int const topK, InputT* __restrict__ outputValues, int* __restrict__ outputIndices, int const thresholdPos)
 {
     using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
-    using SmemT = KernelSmemTplK<SmemKey, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
+    using SmemT
+        = KernelSmemTplK<float, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>; // P0: dtype keys fp32
     extern __shared__ unsigned char smem_raw[];
     auto* smem = reinterpret_cast<SmemT*>(smem_raw);
 
@@ -1743,8 +1748,9 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
 
     auto launchOne = [&]<int TopK>() -> cudaError_t
     {
-        using SmemKey = typename GvrDtypeTraits<T>::SmemKey;
-        using SmemT = KernelSmemTplK<SmemKey, GvrParams<T, TopK>::kC, GvrParams<T, TopK>::kNumBins>;
+        // P0 (2026-05-07): dtype path uses fp32 smem keys (deferred convert).
+        // Launcher allocates smem with float keys regardless of input dtype.
+        using SmemT = KernelSmemTplK<float, GvrParams<T, TopK>::kC, GvrParams<T, TopK>::kNumBins>;
         size_t const smemSize = sizeof(SmemT);
 
         // Resolve target kernel function pointer at compile time.

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -1028,8 +1028,18 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         }
         __syncthreads(); // S-4b3c
 
+        // snap_limit must equal cand_count to guarantee convergence: each
+        // iteration either strictly decreases cgt (raise thr to next
+        // distinct value above) or strictly increases cge (lower thr to
+        // next distinct value below) by >= 1, so worst-case convergence
+        // takes cand_count - kK + 1 iters. The older bound `cand_count/4`
+        // silently accepted a non-converged threshold; Pass 1 then picked
+        // K elements in scan order from `cgt > kK` candidates, missing
+        // some true top-K members (~0.09 % intermittent at small-kNumBins
+        // mean-zero distributions). Common path still converges in 1-3
+        // iters; the higher upper bound only affects the long-tail cells.
         bool snap_converged = false;
-        int snap_limit = (cand_count > 128 ? cand_count / 4 : 32);
+        int snap_limit = cand_count;
         for (int si = 0; si < snap_limit; si++)
         {
             blockFusedSnapIter<TopK>(smem, cand_count, tid, warp_id, lane);
@@ -1575,8 +1585,10 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         }
         __syncthreads();
 
+        // snap_limit must equal cand_count to guarantee convergence; see
+        // detailed rationale in the fp32 `gvrTopKJob` path.
         bool snap_converged = false;
-        int snap_limit = (cand_count > 128 ? cand_count / 4 : 32);
+        int snap_limit = cand_count;
         for (int si = 0; si < snap_limit; si++)
         {
             blockFusedSnapIter<TopK>(smem, cand_count, tid, warp_id, lane); // P0: keys fp32 → use fp32 snap helper

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -1161,8 +1161,17 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
 // 4d.D: templated on TopK so launcher can dispatch K=512/1024/2048 to the
 // same kernel template. Default <TOP_K> matches the legacy non-templated
 // signature (callers that pass no template argument get K=2048 fp32).
+//
+// 2026-05-08 alignment with production: __launch_bounds__ now matches
+// heuristicTopKMultiRowKernel (single-arg, no minBlocksPerSM hint) so nvcc
+// applies the same register heuristic to this standalone wrapper as to the
+// production multi-row kernel. Removing the trailing `, 1` lets ptxas pick
+// REG=40 (K=2048 fp32) instead of REG=64, restoring 75% theoretical
+// occupancy parity. NOTE: this changes the standalone gvrTopKKernel<2048>
+// SASS away from V2e LOCK byte-identity (production multi-row path is
+// unaffected — it uses its own __launch_bounds__).
 template <int TopK = TOP_K>
-__global__ void __launch_bounds__(BLOCK_SIZE, 1)
+__global__ void __launch_bounds__(BLOCK_SIZE)
     gvrTopKKernel(float const* __restrict__ input, int const N, int const* __restrict__ preIdx, int const M,
         int const topK, float* __restrict__ outputValues, int* __restrict__ outputIndices, int const thresholdPos)
 {
@@ -1699,9 +1708,13 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
 // ============================================================================
 // 4d.D: templated on TopK alongside InputT. Default <InputT, TOP_K> matches
 // the pre-multi-K signature for the existing K=2048 dtype path.
+//
+// 2026-05-08: same alignment with heuristicTopKMultiRowKernelDtype — single-arg
+// __launch_bounds__ removes the minBlocksPerSM=1 hint so ptxas applies the
+// production register heuristic. See gvrTopKKernel<TopK> note above.
 
 template <typename InputT, int TopK = TOP_K>
-__global__ void __launch_bounds__(BLOCK_SIZE, 1)
+__global__ void __launch_bounds__(BLOCK_SIZE)
     gvrTopKKernelDtype(InputT const* __restrict__ input, int const N, int const* __restrict__ preIdx, int const M,
         int const topK, InputT* __restrict__ outputValues, int* __restrict__ outputIndices, int const thresholdPos)
 {

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -180,6 +180,18 @@ static_assert(MAX_CANDIDATES % BLOCK_SIZE == 0);
 // Phase-1 pmean lands near the right tail of the prev-row top-K, so the
 // Phase-2 secant initial bracket is biased high. A tighter K-proportional
 // target converges faster than the M=2048 era's flat target.
+//
+// `kFTarget` is the secant solver's **soft steering target**, not the
+// convergence condition. The Phase-2 loop converges whenever the
+// candidate count falls within `[kK, kCC]` (see the `done = 1` check at
+// the end of `gvrTopKJob`'s P1+P2 scope). A `kFTarget` below `kK` is
+// intentional and useful for small K — with preIdx-seeded P1 landing
+// the initial threshold near the right tail of the prev-row top-K, the
+// secant's first interpolation often overshoots; biasing the target
+// below kK pulls the next iteration's threshold down more aggressively
+// and reaches the legal `[kK, kCC]` band in fewer secant steps. The
+// concrete multipliers below were tuned empirically over V4 M=K cells
+// (commit 8 in this PR):
 //   K=512:  0.75K = 384
 //   K=1024: 2.5K  = 2560
 //   K=2048: kept at 1.5K (3072) for fp32 to preserve SASS byte-identity
@@ -498,16 +510,12 @@ __device__ __forceinline__ void blockFusedSnapIter(SmemT* smem, int count, int t
 // ============================================================================
 // Dtype-templated helpers (bf16 / fp16)
 // ============================================================================
-// Mirror blockCountGE / blockFusedSnapIter for bf16/fp16 inputs. fp32
-// path uses the originals.
-//
-// blockCountGEDtype:
-//   - 8-wide vector load (int4 = 8 × 16-bit) instead of 4-wide (float4 = 4 × fp32)
-//   - up-cast each element to fp32 before threshold compare
-//
-// blockFusedSnapIterDtype:
-//   - reads SmemKey (bf16 / fp16) from smem->keys, up-casts to fp32 for
-//     min/max/count work; threshold remains fp32.
+// Mirror of `blockCountGE` for bf16/fp16 inputs (8-wide vector load via
+// `Trait::unpack8` + fp32 up-cast before threshold compare). The Phase-4
+// snap iter is NOT mirrored: `gvrTopKJobDtype` stores smem `keys[]` as
+// fp32 even on bf16/fp16 paths (deferred-conversion optimization, see
+// the `gvrTopKJobDtype` comment block below), so it reuses the fp32
+// `blockFusedSnapIter<TopK>` helper directly.
 
 // Templated on SmemT so K=512/1024 dtype paths can pass a kC=5120 layout.
 // Default targets the K=2048 kC=6144 layout.
@@ -546,71 +554,6 @@ __device__ __forceinline__ void blockCountGEDtype(
             t += smem->warp_counts[w];
         smem->cand_count = t;
     }
-}
-
-// Templated on (SmemKey, TopK, SmemT). Default targets the K=2048 dtype path.
-template <typename SmemKey, int TopK = TOP_K, typename SmemT = KernelSmemTpl<SmemKey>>
-__device__ __forceinline__ void blockFusedSnapIterDtype(SmemT* smem, int count, int tid, int warp_id, int lane)
-{
-    using Trait = GvrDtypeTraits<SmemKey>;
-
-    float const thr = smem->threshold;
-
-    int lge = 0, lgt = 0;
-    float s_up = FLT_MAX, s_down = -FLT_MAX;
-
-    for (int i = tid; i < count; i += BLOCK_SIZE)
-    {
-        float v = Trait::to_fp32(smem->keys[i]);
-        lge += (v >= thr);
-        lgt += (v > thr);
-        if (v > thr)
-            s_up = fminf(s_up, v);
-        if (v < thr)
-            s_down = fmaxf(s_down, v);
-    }
-
-    int packed = (lge << 16) | lgt;
-    packed = warpReduceSum(packed);
-    s_up = warpReduceMin(s_up);
-    s_down = warpReduceMax(s_down);
-
-    if (lane == 0)
-    {
-        smem->warp_counts[warp_id] = packed;
-        smem->histogram[warp_id] = __float_as_int(s_up);
-        smem->histogram[NUM_WARPS + warp_id] = __float_as_int(s_down);
-    }
-    __syncthreads();
-
-    if (tid == 0)
-    {
-        int tp = 0;
-        float total_up = FLT_MAX, total_down = -FLT_MAX;
-        for (int w = 0; w < NUM_WARPS; w++)
-        {
-            tp += smem->warp_counts[w];
-            total_up = fminf(total_up, __int_as_float(smem->histogram[w]));
-            total_down = fmaxf(total_down, __int_as_float(smem->histogram[NUM_WARPS + w]));
-        }
-        smem->cnt_lo = tp >> 16;
-        smem->cnt_hi = tp & 0xFFFF;
-
-        int cge = smem->cnt_lo;
-        int cgt = smem->cnt_hi;
-
-        if (cgt >= TopK)
-        {
-            if (total_up < FLT_MAX)
-                smem->threshold = total_up;
-        }
-        else if (cge < TopK)
-        {
-            if (total_down > -FLT_MAX)
-                smem->threshold = total_down;
-        }
-    }
-    __syncthreads();
 }
 
 // ============================================================================
@@ -1171,11 +1114,12 @@ __global__ void __launch_bounds__(BLOCK_SIZE)
 // ============================================================================
 // Mirror of gvrTopKJob with trait-driven dtype substitutions:
 //   - HBM input read   : Trait::to_fp32(__ldg(&input[i]))
-//   - smem keys read   : Trait::to_fp32(keys[i]) for arithmetic
-//   - outputValues     : InputT
+//   - outputValues     : InputT (Trait::from_fp32 at writeback)
 //   - vector load      : 8-wide via Trait::unpack8
 //   - blockCountGE     : blockCountGEDtype<InputT>
-//   - blockFusedSnapIter: blockFusedSnapIterDtype<SmemKey>
+// `blockFusedSnapIter<TopK>` is reused directly from the fp32 path —
+// smem `keys[]` are stored as fp32 here (see deferred-conversion note
+// below) so no dtype-specialized snap helper is needed.
 // All arithmetic (threshold, accumulators, bin index) stays fp32. The fp32
 // dtype path uses gvrTopKJob (above), not this template; instantiated only
 // for bf16 and fp16.

--- a/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+++ b/cpp/tensorrt_llm/kernels/heuristic_topk.cuh
@@ -171,21 +171,141 @@ static_assert(TOP_K % BLOCK_SIZE == 0);
 static_assert(MAX_CANDIDATES % BLOCK_SIZE == 0);
 
 // ============================================================================
+// Multi-K Trait Layer (4d.D 9-combo sweep, 2026-05-06)
+// ============================================================================
+// Per-(InputT, TopK) compile-time trait class encoding the optimal
+// (f_target, max_candidates) tuple discovered by the SWE-Bench-64K
+// 9-combo sweep in 04_kernel_optimizations/4d_multi_dtype_unified/
+// data/D_param_sweep_9combos/REPORT.md.
+//
+// Selection rationale:
+//   - kC=5120 unified across all 9 combos (smem-Occ jump 3→4 fp32 / 3→5
+//     bf16/fp16 buys ≤+10% sim cost vs C=6144; reg-bound limit may cap
+//     real occupancy at 3 — Step 2 must verify with cuobjdump).
+//   - kFTarget varies by K only:
+//       K=512:  f=K        (P1 pmean threshold lands near K → P2 idle)
+//       K=1024: f=3K       (U-shape minimum at high f)
+//       K=2048: f=2K       (monotone: higher f → fewer P2 iters)
+//   - kFTarget for fp32 K=2048 = 4096 deviates from V2e production
+//     (3072) — applied per REPORT.md recommendation; Step 3 must run
+//     Scheme X v1.2 4-report regression to confirm no real-world loss.
+//   - kNumBins=NUM_BINS=2048 unchanged across combos (P4 histogram).
+//
+// Primary template intentionally left undefined: any unsupported (T, K)
+// combination triggers a compile-time error rather than a runtime fall-
+// through.
+template <typename InputT, int TopK>
+struct GvrParams; // primary undefined → compile-time error for bad combos
+
+// fp32 specializations
+template <>
+struct GvrParams<float, 512>
+{
+    static constexpr int kFTarget = 512;
+    static constexpr int kC = 5120;
+    static constexpr int kNumBins = NUM_BINS;
+};
+
+template <>
+struct GvrParams<float, 1024>
+{
+    static constexpr int kFTarget = 3072;
+    static constexpr int kC = 5120;
+    static constexpr int kNumBins = NUM_BINS;
+};
+
+// fp32 K=2048: V2e production-identity preservation (Option B 2026-05-07).
+// Cuobjdump showed nvcc 13.1 regs/thread = 64 → reg-bound 2 CTA/SM regardless of
+// kC; the REPORT-recommended (4096, 5120) gives no occupancy benefit but
+// breaks V2e SMEM byte-identity. Reverting to V2e (3072, 6144) keeps the
+// production path byte-identical and avoids Scheme X v1.2 4-report
+// regression. The other 8 combos still use REPORT picks where there is
+// no production baseline to preserve.
+template <>
+struct GvrParams<float, 2048>
+{
+    static constexpr int kFTarget = 3072; // V2e: TOP_K + SAFETY_MARGIN/2
+    static constexpr int kC = 6144;       // V2e: TOP_K + SAFETY_MARGIN*2
+    static constexpr int kNumBins = NUM_BINS;
+};
+
+// bf16 specializations
+template <>
+struct GvrParams<__nv_bfloat16, 512>
+{
+    static constexpr int kFTarget = 512;
+    static constexpr int kC = 5120;
+    static constexpr int kNumBins = NUM_BINS;
+};
+
+template <>
+struct GvrParams<__nv_bfloat16, 1024>
+{
+    static constexpr int kFTarget = 3072;
+    static constexpr int kC = 5120;
+    static constexpr int kNumBins = NUM_BINS;
+};
+
+template <>
+struct GvrParams<__nv_bfloat16, 2048>
+{
+    static constexpr int kFTarget = 4096;
+    static constexpr int kC = 5120;
+    static constexpr int kNumBins = NUM_BINS;
+};
+
+// fp16 specializations
+template <>
+struct GvrParams<__half, 512>
+{
+    static constexpr int kFTarget = 512;
+    static constexpr int kC = 5120;
+    static constexpr int kNumBins = NUM_BINS;
+};
+
+template <>
+struct GvrParams<__half, 1024>
+{
+    static constexpr int kFTarget = 3072;
+    static constexpr int kC = 5120;
+    static constexpr int kNumBins = NUM_BINS;
+};
+
+template <>
+struct GvrParams<__half, 2048>
+{
+    static constexpr int kFTarget = 4096;
+    static constexpr int kC = 5120;
+    static constexpr int kNumBins = NUM_BINS;
+};
+
+// kC must remain divisible by BLOCK_SIZE (vector loads).
+static_assert(GvrParams<float, 512>::kC % BLOCK_SIZE == 0);
+static_assert(GvrParams<float, 1024>::kC % BLOCK_SIZE == 0);
+static_assert(GvrParams<float, 2048>::kC % BLOCK_SIZE == 0);
+
+// ============================================================================
 // Shared Memory Layout
 // ============================================================================
-// fp32 instantiation (KernelSmem = KernelSmemTpl<float>): ~59 KB
-// bf16/fp16 instantiation (KernelSmemTpl<__nv_bfloat16/__half>): ~47 KB
-// (4d_multi_dtype_unified, 2026-05-06: templatized on SmemKey for trait path)
+// Default instantiation (CCap=MAX_CANDIDATES=6144, NumBinsT=NUM_BINS=2048):
+//   fp32  (KernelSmem = KernelSmemTpl<float>           = KernelSmemTplK<float, 6144, 2048>): ~59 KB
+//   bf16/fp16                                                                              : ~47 KB
+//
+// 4d.D K=512/1024 instantiations use kC=5120 (KernelSmemTplK<T, 5120, 2048>):
+//   fp32: 51 KB, bf16/fp16: 41 KB
+//
+// 4d_multi_dtype_unified (2026-05-06): templatized on SmemKey.
+// 4d.D 9-combo (2026-05-06): templatized on (CCap, NumBinsT) for multi-K paths.
 
-template <typename SmemKey>
-struct KernelSmemTpl
+template <typename SmemKey, int CCap = MAX_CANDIDATES, int NumBinsT = NUM_BINS>
+struct KernelSmemTplK
 {
-    alignas(16) SmemKey keys[MAX_CANDIDATES]; // 24 KB (fp32) / 12 KB (bf16/fp16)
-    alignas(16) int vals[MAX_CANDIDATES];     // 24 KB
+    alignas(16) SmemKey keys[CCap];    // CCap × sizeof(SmemKey) (4B fp32 / 2B bf16/fp16)
+    alignas(16) int vals[CCap];        // CCap × 4B
 
-    int warp_counts[NUM_WARPS];               // 64 B
-    int histogram[NUM_BINS];                  // 8 KB
-    int per_thread_counts[BLOCK_SIZE];        // 2 KB — OPT7: cached from last blockCountGE
+    int warp_counts[NUM_WARPS];        // 64 B
+    int histogram[NumBinsT];           // NumBinsT × 4B (default 2048 → 8 KB)
+    int per_thread_counts[BLOCK_SIZE]; // 2 KB — OPT7: cached from last blockCountGE
 
     float threshold;
     int cand_count;
@@ -197,6 +317,11 @@ struct KernelSmemTpl
     float pmax_saved;
     int out_count;
 };
+
+// Backwards-compat alias for K=2048 default — same layout as pre-4d.D
+// KernelSmemTpl. fp32 instantiation = KernelSmemTplK<float, 6144, 2048>.
+template <typename SmemKey>
+using KernelSmemTpl = KernelSmemTplK<SmemKey>;
 
 // fp32 alias preserved so the original gvrTopKJob / gvrTopKKernel /
 // blockCountGE / blockFusedSnapIter and the TRT-LLM multi-row caller
@@ -271,8 +396,11 @@ __device__ __forceinline__ float warpReduceMax(float val)
 // Device: Block count ≥ threshold in GLOBAL memory  (1-sync pattern)
 // ============================================================================
 
+// 4d.D: templated on SmemT so K=512/1024 fp32 paths can pass a smaller
+// KernelSmemTplK<float, 5120, 2048>* smem. Default = legacy KernelSmem.
+template <typename SmemT = KernelSmem>
 __device__ __forceinline__ void blockCountGE(
-    float const* __restrict__ input, int N, float threshold, KernelSmem* smem, int tid, int warp_id, int lane)
+    float const* __restrict__ input, int N, float threshold, SmemT* smem, int tid, int warp_id, int lane)
 {
     int c = 0;
     for (int i = tid * 4; i + 3 < N; i += BLOCK_SIZE * 4)
@@ -305,7 +433,11 @@ __device__ __forceinline__ void blockCountGE(
 // Fused snap iteration (2 syncs per call)
 // ============================================================================
 
-__device__ __forceinline__ void blockFusedSnapIter(KernelSmem* smem, int count, int tid, int warp_id, int lane)
+// 4d.D: templated on (TopK, SmemT) so K=512/1024 paths reuse the same
+// helper. Default <TOP_K, KernelSmem> preserves byte-equivalence with
+// the V2e baseline call site.
+template <int TopK = TOP_K, typename SmemT = KernelSmem>
+__device__ __forceinline__ void blockFusedSnapIter(SmemT* smem, int count, int tid, int warp_id, int lane)
 {
     float const thr = smem->threshold;
 
@@ -352,12 +484,12 @@ __device__ __forceinline__ void blockFusedSnapIter(KernelSmem* smem, int count, 
         int cge = smem->cnt_lo;
         int cgt = smem->cnt_hi;
 
-        if (cgt >= TOP_K)
+        if (cgt >= TopK)
         {
             if (total_up < FLT_MAX)
                 smem->threshold = total_up;
         }
-        else if (cge < TOP_K)
+        else if (cge < TopK)
         {
             if (total_down > -FLT_MAX)
                 smem->threshold = total_down;
@@ -380,9 +512,12 @@ __device__ __forceinline__ void blockFusedSnapIter(KernelSmem* smem, int count, 
 //   - reads SmemKey (bf16 / fp16) from smem->keys, up-casts to fp32 for
 //     min/max/count work; threshold remains fp32 (Tier-1 invariant).
 
-template <typename InputT>
-__device__ __forceinline__ void blockCountGEDtype(InputT const* __restrict__ input, int N, float threshold,
-    KernelSmemTpl<typename GvrDtypeTraits<InputT>::SmemKey>* smem, int tid, int warp_id, int lane)
+// 4d.D: add SmemT default to allow K=512/1024 dtype paths to pass a
+// smaller KernelSmemTplK<SmemKey, 5120, 2048>* smem. Default = legacy
+// 6144-cap layout (KernelSmemTpl<SmemKey>).
+template <typename InputT, typename SmemT = KernelSmemTpl<typename GvrDtypeTraits<InputT>::SmemKey>>
+__device__ __forceinline__ void blockCountGEDtype(
+    InputT const* __restrict__ input, int N, float threshold, SmemT* smem, int tid, int warp_id, int lane)
 {
     using Trait = GvrDtypeTraits<InputT>;
     static_assert(Trait::VEC_W == 8, "blockCountGEDtype is for bf16/fp16 (8-wide vector); use blockCountGE for fp32");
@@ -417,9 +552,10 @@ __device__ __forceinline__ void blockCountGEDtype(InputT const* __restrict__ inp
     }
 }
 
-template <typename SmemKey>
-__device__ __forceinline__ void blockFusedSnapIterDtype(
-    KernelSmemTpl<SmemKey>* smem, int count, int tid, int warp_id, int lane)
+// 4d.D: templated on (TopK, SmemT). Default <SmemKey, TOP_K, KernelSmemTpl<SmemKey>>
+// preserves the K=2048 dtype path's pre-multi-K signature.
+template <typename SmemKey, int TopK = TOP_K, typename SmemT = KernelSmemTpl<SmemKey>>
+__device__ __forceinline__ void blockFusedSnapIterDtype(SmemT* smem, int count, int tid, int warp_id, int lane)
 {
     using Trait = GvrDtypeTraits<SmemKey>;
 
@@ -468,12 +604,12 @@ __device__ __forceinline__ void blockFusedSnapIterDtype(
         int cge = smem->cnt_lo;
         int cgt = smem->cnt_hi;
 
-        if (cgt >= TOP_K)
+        if (cgt >= TopK)
         {
             if (total_up < FLT_MAX)
                 smem->threshold = total_up;
         }
-        else if (cge < TOP_K)
+        else if (cge < TopK)
         {
             if (total_down > -FLT_MAX)
                 smem->threshold = total_down;
@@ -488,10 +624,25 @@ __device__ __forceinline__ void blockFusedSnapIterDtype(
 // for this function independently from the caller, matching standalone SASS.
 // ============================================================================
 
+// 4d.D: templated on TopK so the K=512 / K=1024 fp32 paths share this
+// body with K=2048. Default <TOP_K> + KernelSmem (= KernelSmemTplK<float, 6144, 2048>)
+// matches the pre-multi-K signature for the legacy V2e call site.
+//
+// The runtime `topK` parameter is kept for header-API compatibility with
+// callers that pass it (assert at entry that it matches the template
+// instantiation).
+template <int TopK = TOP_K>
 __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int const N, int const* __restrict__ preIdx,
-    int const M, int const topK, float* __restrict__ outputValues, int* __restrict__ outputIndices, KernelSmem* smem,
+    int const M, int const topK, float* __restrict__ outputValues, int* __restrict__ outputIndices,
+    KernelSmemTplK<float, GvrParams<float, TopK>::kC, GvrParams<float, TopK>::kNumBins>* smem,
     int const preIdxOffset = 0)
 {
+    using Params = GvrParams<float, TopK>;
+    constexpr int kK = TopK;
+    constexpr int kCC = Params::kC;
+    constexpr int kBins = Params::kNumBins;
+    constexpr int kFTarget = Params::kFTarget;
+
     int const tid = threadIdx.x;
     int const warp_id = tid / WARP_SIZE;
     int const lane = tid & (WARP_SIZE - 1);
@@ -579,9 +730,9 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         if (tid == 0)
         {
             int c = smem->cand_count;
-            if (c >= TOP_K && c <= MAX_CANDIDATES)
+            if (c >= kK && c <= kCC)
                 smem->done = 1;
-            else if (c > MAX_CANDIDATES)
+            else if (c > kCC)
             {
                 smem->val_lo = smem->threshold;
                 smem->cnt_lo = c;
@@ -602,7 +753,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
             {
                 float vlo = smem->val_lo, vhi = smem->val_hi;
                 int clo = smem->cnt_lo, chi = smem->cnt_hi;
-                int target = TOP_K + SAFETY_MARGIN / 2;
+                constexpr int target = kFTarget;
                 float range = vhi - vlo;
                 float nv;
                 if (clo > chi && range > 1e-10f)
@@ -640,9 +791,9 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
             if (tid == 0)
             {
                 int c = smem->cand_count;
-                if (c >= TOP_K && c <= MAX_CANDIDATES)
+                if (c >= kK && c <= kCC)
                     smem->done = 1;
-                else if (c > MAX_CANDIDATES)
+                else if (c > kCC)
                 {
                     smem->val_lo = smem->threshold;
                     smem->cnt_lo = c;
@@ -658,7 +809,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
 
         if (tid == 0 && !smem->done)
         {
-            if (smem->cnt_lo <= MAX_CANDIDATES * 2)
+            if (smem->cnt_lo <= kCC * 2)
                 smem->threshold = smem->val_lo;
             else
                 smem->threshold = smem->val_hi;
@@ -672,16 +823,16 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
     // ================================================================
 
     // OPT5: when done==1, Phase 2 already verified count in
-    //        [TOP_K, MAX_CANDIDATES]; skip the redundant full-N
+    //        [kK, kCC]; skip the redundant full-N
     //        blockCountGE re-check entirely.
     if (smem->done != 1)
     {
         blockCountGE(input, N, smem->threshold, smem, tid, warp_id, lane);
-        if (tid == 0 && smem->cand_count > MAX_CANDIDATES)
+        if (tid == 0 && smem->cand_count > kCC)
             smem->val_lo = smem->threshold;
         __syncthreads();
 
-        for (int retry = 0; retry < 10 && smem->cand_count > MAX_CANDIDATES; retry++)
+        for (int retry = 0; retry < 10 && smem->cand_count > kCC; retry++)
         {
             if (tid == 0)
             {
@@ -696,9 +847,9 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
             if (tid == 0)
             {
                 int c = smem->cand_count;
-                if (c > MAX_CANDIDATES)
+                if (c > kCC)
                     smem->val_lo = smem->threshold;
-                else if (c < TOP_K)
+                else if (c < kK)
                     smem->val_hi = smem->threshold;
             }
             __syncthreads();
@@ -748,7 +899,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
             for (int j = 0; j < 4; j++)
             {
                 float val = (&v4.x)[j];
-                if (val >= thr && my_write_pos < MAX_CANDIDATES)
+                if (val >= thr && my_write_pos < kCC)
                 {
                     smem->keys[my_write_pos] = val;
                     smem->vals[my_write_pos] = i + j;
@@ -759,7 +910,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         for (int i = (N & ~3) + tid; i < N; i += BLOCK_SIZE)
         {
             float val = __ldg(&input[i]);
-            if (val >= thr && my_write_pos < MAX_CANDIDATES)
+            if (val >= thr && my_write_pos < kCC)
             {
                 smem->keys[my_write_pos] = val;
                 smem->vals[my_write_pos] = i;
@@ -773,11 +924,11 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
     // Phase 4 (GVR Refine) — Histogram-based selection + partition
     // ================================================================
 
-    int const cand_count = min(smem->cand_count, MAX_CANDIDATES);
+    int const cand_count = min(smem->cand_count, kCC);
 
-    if (cand_count == TOP_K)
+    if (cand_count == kK)
     {
-        for (int i = tid; i < TOP_K; i += BLOCK_SIZE)
+        for (int i = tid; i < kK; i += BLOCK_SIZE)
         {
             outputValues[i] = smem->keys[i];
             outputIndices[i] = smem->vals[i];
@@ -785,7 +936,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         return;
     }
 
-    if (cand_count > TOP_K)
+    if (cand_count > kK)
     {
         float cmin = FLT_MAX, cmax = -FLT_MAX;
         for (int i = tid; i < cand_count; i += BLOCK_SIZE)
@@ -812,17 +963,17 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         if (block_max <= block_min)
             block_max = block_min + 1e-6f;
 
-        for (int i = tid; i < NUM_BINS; i += BLOCK_SIZE)
+        for (int i = tid; i < kBins; i += BLOCK_SIZE)
             smem->histogram[i] = 0;
         __syncthreads();
 
         float range1 = block_max - block_min;
-        float inv1 = (range1 > 0.0f) ? ((float) (NUM_BINS - 1) + 0.99f) / range1 : 0.0f;
+        float inv1 = (range1 > 0.0f) ? ((float) (kBins - 1) + 0.99f) / range1 : 0.0f;
 
         for (int i = tid; i < cand_count; i += BLOCK_SIZE)
         {
             int bin = (int) ((smem->keys[i] - block_min) * inv1);
-            bin = min(max(bin, 0), NUM_BINS - 1);
+            bin = min(max(bin, 0), kBins - 1);
             atomicAdd(&smem->histogram[bin], 1);
         }
         __syncthreads();
@@ -832,12 +983,12 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         // target warp in NUM_WARPS steps; one thread in that warp scans BINS_PER_WARP bins.
         // Total serial depth: NUM_WARPS + BINS_PER_WARP = 16 + 128 = 144 steps vs 2048.
         {
-            constexpr int BINS_PER_WARP = NUM_BINS / NUM_WARPS;
-            static_assert(NUM_BINS % NUM_WARPS == 0, "NUM_BINS must be divisible by NUM_WARPS");
+            constexpr int BINS_PER_WARP = kBins / NUM_WARPS;
+            static_assert(kBins % NUM_WARPS == 0, "kBins must be divisible by NUM_WARPS");
             // Step 1: each warp accumulates its slice of bins (high→low)
             int warp_bin_sum = 0;
             for (int j = 0; j < BINS_PER_WARP; j++)
-                warp_bin_sum += smem->histogram[NUM_BINS - 1 - warp_id * BINS_PER_WARP - j];
+                warp_bin_sum += smem->histogram[kBins - 1 - warp_id * BINS_PER_WARP - j];
             if (lane == 0)
                 smem->warp_counts[warp_id] = warp_bin_sum;
         }
@@ -850,7 +1001,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
             for (int w = 0; w < NUM_WARPS; w++)
             {
                 cum += smem->warp_counts[w];
-                if (cum >= TOP_K)
+                if (cum >= kK)
                 {
                     tw = w;
                     break;
@@ -868,16 +1019,16 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         // Step 3: one thread in target warp scans its BINS_PER_WARP bins
         if (warp_id == smem->cnt_hi && lane == 0)
         {
-            constexpr int BINS_PER_WARP = NUM_BINS / NUM_WARPS;
+            constexpr int BINS_PER_WARP = kBins / NUM_WARPS;
             int base_cum = smem->cnt_lo;
             float thr = block_min;
             for (int j = 0; j < BINS_PER_WARP; j++)
             {
-                int b = NUM_BINS - 1 - smem->cnt_hi * BINS_PER_WARP - j;
+                int b = kBins - 1 - smem->cnt_hi * BINS_PER_WARP - j;
                 base_cum += smem->histogram[b];
-                if (base_cum >= TOP_K)
+                if (base_cum >= kK)
                 {
-                    thr = block_min + (float) b * range1 / (float) NUM_BINS;
+                    thr = block_min + (float) b * range1 / (float) kBins;
                     break;
                 }
             }
@@ -892,7 +1043,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
             blockFusedSnapIter(smem, cand_count, tid, warp_id, lane);
             int cge = smem->cnt_lo;
             int cgt = smem->cnt_hi;
-            if (cgt < TOP_K && cge >= TOP_K)
+            if (cgt < kK && cge >= kK)
             {
                 snap_converged = true;
                 break;
@@ -908,7 +1059,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         // Opt-M fix: separate gt and eq into two sequential passes so that
         // strictly-greater values are never dropped in favor of tie-values.
         // The v0 interleaved version had a correctness bug when ties at the
-        // K-th value cross TOP_K; this fix makes the selection rank-stable.
+        // K-th value cross kK; this fix makes the selection rank-stable.
 
         // Pass 1: strictly greater than sel_thr
         for (int base = warp_id * WARP_SIZE; base < cand_count; base += BLOCK_SIZE)
@@ -926,7 +1077,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
                 if (lane == 0)
                     bp = atomicAdd(&smem->out_count, cnt);
                 bp = __shfl_sync(full_mask, bp, 0);
-                if (emit_gt && bp + moff < TOP_K)
+                if (emit_gt && bp + moff < kK)
                 {
                     outputValues[bp + moff] = v;
                     outputIndices[bp + moff] = smem->vals[i];
@@ -951,7 +1102,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
                 if (lane == 0)
                     bp = atomicAdd(&smem->out_count, cnt);
                 bp = __shfl_sync(full_mask, bp, 0);
-                if (emit_eq && bp + moff < TOP_K)
+                if (emit_eq && bp + moff < kK)
                 {
                     outputValues[bp + moff] = v;
                     outputIndices[bp + moff] = smem->vals[i];
@@ -960,8 +1111,8 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         }
         __syncthreads();
 
-        int filled = min(smem->out_count, TOP_K);
-        for (int i = filled + tid; i < TOP_K; i += BLOCK_SIZE)
+        int filled = min(smem->out_count, kK);
+        for (int i = filled + tid; i < kK; i += BLOCK_SIZE)
         {
             outputValues[i] = -FLT_MAX;
             outputIndices[i] = -1;
@@ -974,7 +1125,7 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
         outputValues[i] = smem->keys[i];
         outputIndices[i] = smem->vals[i];
     }
-    for (int i = cand_count + tid; i < TOP_K; i += BLOCK_SIZE)
+    for (int i = cand_count + tid; i < kK; i += BLOCK_SIZE)
     {
         outputValues[i] = -FLT_MAX;
         outputIndices[i] = -1;
@@ -988,21 +1139,26 @@ __device__ __noinline__ void gvrTopKJob(float const* __restrict__ input, int con
 // heuristicTopKDecode.cu — both share the same micro-kernel job.
 // ============================================================================
 
+// 4d.D: templated on TopK so launcher can dispatch K=512/1024/2048 to the
+// same kernel template. Default <TOP_K> matches the legacy non-templated
+// signature (callers that pass no template argument get K=2048 fp32).
+template <int TopK = TOP_K>
 __global__ void __launch_bounds__(BLOCK_SIZE, 1)
     gvrTopKKernel(float const* __restrict__ input, int const N, int const* __restrict__ preIdx, int const M,
         int const topK, float* __restrict__ outputValues, int* __restrict__ outputIndices, int const thresholdPos)
 {
+    using SmemT = KernelSmemTplK<float, GvrParams<float, TopK>::kC, GvrParams<float, TopK>::kNumBins>;
     extern __shared__ unsigned char smem_raw[];
-    auto* smem = reinterpret_cast<KernelSmem*>(smem_raw);
+    auto* smem = reinterpret_cast<SmemT*>(smem_raw);
 
-    gvrTopKJob(input, N, preIdx, M, topK, outputValues, outputIndices, smem, /*preIdxOffset=*/0);
+    gvrTopKJob<TopK>(input, N, preIdx, M, topK, outputValues, outputIndices, smem, /*preIdxOffset=*/0);
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }
 
 // ============================================================================
-// gvrTopKJobDtype<InputT> — bf16/fp16 device function (4d_multi_dtype_unified)
+// gvrTopKJobDtype<InputT, TopK> — bf16/fp16 device function (4d_multi_dtype_unified)
 // ============================================================================
 // Mirror of gvrTopKJob with trait-driven dtype substitutions:
 //   - HBM input read   : Trait::to_fp32(__ldg(&input[i]))
@@ -1015,15 +1171,25 @@ __global__ void __launch_bounds__(BLOCK_SIZE, 1)
 // All Tier-1 arithmetic stays fp32 (threshold, accumulators, bin index).
 // fp32 path is NOT routed here — fp32 keeps the original gvrTopKJob (option A,
 // guaranteed zero-regression). This template only instantiates for bf16/fp16.
+//
+// 4d.D: templated on TopK so K=512/1024/2048 share the same body. Default
+// <InputT, TOP_K> with KernelSmemTpl<...> matches the pre-multi-K signature.
 
-template <typename InputT>
+template <typename InputT, int TopK = TOP_K>
 __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, int const N,
     int const* __restrict__ preIdx, int const M, int const topK, InputT* __restrict__ outputValues,
-    int* __restrict__ outputIndices, KernelSmemTpl<typename GvrDtypeTraits<InputT>::SmemKey>* smem,
+    int* __restrict__ outputIndices,
+    KernelSmemTplK<typename GvrDtypeTraits<InputT>::SmemKey, GvrParams<InputT, TopK>::kC,
+        GvrParams<InputT, TopK>::kNumBins>* smem,
     int const preIdxOffset = 0)
 {
     using Trait = GvrDtypeTraits<InputT>;
     using SmemKey = typename Trait::SmemKey;
+    using Params = GvrParams<InputT, TopK>;
+    constexpr int kK = TopK;
+    constexpr int kCC = Params::kC;
+    constexpr int kBins = Params::kNumBins;
+    constexpr int kFTarget = Params::kFTarget;
     static_assert(Trait::VEC_W == 8, "gvrTopKJobDtype is for bf16/fp16 (8-wide); fp32 uses gvrTopKJob");
 
     int const tid = threadIdx.x;
@@ -1113,9 +1279,9 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         if (tid == 0)
         {
             int c = smem->cand_count;
-            if (c >= TOP_K && c <= MAX_CANDIDATES)
+            if (c >= kK && c <= kCC)
                 smem->done = 1;
-            else if (c > MAX_CANDIDATES)
+            else if (c > kCC)
             {
                 smem->val_lo = smem->threshold;
                 smem->cnt_lo = c;
@@ -1136,7 +1302,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
             {
                 float vlo = smem->val_lo, vhi = smem->val_hi;
                 int clo = smem->cnt_lo, chi = smem->cnt_hi;
-                int target = TOP_K + SAFETY_MARGIN / 2;
+                constexpr int target = kFTarget;
                 float range = vhi - vlo;
                 float nv;
                 if (clo > chi && range > 1e-10f)
@@ -1174,9 +1340,9 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
             if (tid == 0)
             {
                 int c = smem->cand_count;
-                if (c >= TOP_K && c <= MAX_CANDIDATES)
+                if (c >= kK && c <= kCC)
                     smem->done = 1;
-                else if (c > MAX_CANDIDATES)
+                else if (c > kCC)
                 {
                     smem->val_lo = smem->threshold;
                     smem->cnt_lo = c;
@@ -1192,7 +1358,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
 
         if (tid == 0 && !smem->done)
         {
-            if (smem->cnt_lo <= MAX_CANDIDATES * 2)
+            if (smem->cnt_lo <= kCC * 2)
                 smem->threshold = smem->val_lo;
             else
                 smem->threshold = smem->val_hi;
@@ -1208,11 +1374,11 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
     if (smem->done != 1)
     {
         blockCountGEDtype<InputT>(input, N, smem->threshold, smem, tid, warp_id, lane);
-        if (tid == 0 && smem->cand_count > MAX_CANDIDATES)
+        if (tid == 0 && smem->cand_count > kCC)
             smem->val_lo = smem->threshold;
         __syncthreads();
 
-        for (int retry = 0; retry < 10 && smem->cand_count > MAX_CANDIDATES; retry++)
+        for (int retry = 0; retry < 10 && smem->cand_count > kCC; retry++)
         {
             if (tid == 0)
             {
@@ -1227,9 +1393,9 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
             if (tid == 0)
             {
                 int c = smem->cand_count;
-                if (c > MAX_CANDIDATES)
+                if (c > kCC)
                     smem->val_lo = smem->threshold;
-                else if (c < TOP_K)
+                else if (c < kK)
                     smem->val_hi = smem->threshold;
             }
             __syncthreads();
@@ -1280,7 +1446,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
             for (int j = 0; j < 8; j++)
             {
                 float val = v[j];
-                if (val >= thr && my_write_pos < MAX_CANDIDATES)
+                if (val >= thr && my_write_pos < kCC)
                 {
                     smem->keys[my_write_pos] = Trait::from_fp32(val);
                     smem->vals[my_write_pos] = i + j;
@@ -1292,7 +1458,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         for (int i = (N & ~7) + tid; i < N; i += BLOCK_SIZE)
         {
             float val = Trait::to_fp32(__ldg(&input[i]));
-            if (val >= thr && my_write_pos < MAX_CANDIDATES)
+            if (val >= thr && my_write_pos < kCC)
             {
                 smem->keys[my_write_pos] = Trait::from_fp32(val);
                 smem->vals[my_write_pos] = i;
@@ -1306,11 +1472,11 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
     // Phase 4 — Histogram-based selection + partition
     // ================================================================
 
-    int const cand_count = min(smem->cand_count, MAX_CANDIDATES);
+    int const cand_count = min(smem->cand_count, kCC);
 
-    if (cand_count == TOP_K)
+    if (cand_count == kK)
     {
-        for (int i = tid; i < TOP_K; i += BLOCK_SIZE)
+        for (int i = tid; i < kK; i += BLOCK_SIZE)
         {
             outputValues[i] = smem->keys[i]; // both InputT, no convert
             outputIndices[i] = smem->vals[i];
@@ -1318,7 +1484,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         return;
     }
 
-    if (cand_count > TOP_K)
+    if (cand_count > kK)
     {
         float cmin = FLT_MAX, cmax = -FLT_MAX;
         for (int i = tid; i < cand_count; i += BLOCK_SIZE)
@@ -1345,28 +1511,28 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         if (block_max <= block_min)
             block_max = block_min + 1e-6f;
 
-        for (int i = tid; i < NUM_BINS; i += BLOCK_SIZE)
+        for (int i = tid; i < kBins; i += BLOCK_SIZE)
             smem->histogram[i] = 0;
         __syncthreads();
 
         float range1 = block_max - block_min;
-        float inv1 = (range1 > 0.0f) ? ((float) (NUM_BINS - 1) + 0.99f) / range1 : 0.0f;
+        float inv1 = (range1 > 0.0f) ? ((float) (kBins - 1) + 0.99f) / range1 : 0.0f;
 
         for (int i = tid; i < cand_count; i += BLOCK_SIZE)
         {
             int bin = (int) ((Trait::to_fp32(smem->keys[i]) - block_min) * inv1);
-            bin = min(max(bin, 0), NUM_BINS - 1);
+            bin = min(max(bin, 0), kBins - 1);
             atomicAdd(&smem->histogram[bin], 1);
         }
         __syncthreads();
 
         // Parallel K-th bin search (2-step)
         {
-            constexpr int BINS_PER_WARP = NUM_BINS / NUM_WARPS;
-            static_assert(NUM_BINS % NUM_WARPS == 0, "NUM_BINS must be divisible by NUM_WARPS");
+            constexpr int BINS_PER_WARP = kBins / NUM_WARPS;
+            static_assert(kBins % NUM_WARPS == 0, "kBins must be divisible by NUM_WARPS");
             int warp_bin_sum = 0;
             for (int j = 0; j < BINS_PER_WARP; j++)
-                warp_bin_sum += smem->histogram[NUM_BINS - 1 - warp_id * BINS_PER_WARP - j];
+                warp_bin_sum += smem->histogram[kBins - 1 - warp_id * BINS_PER_WARP - j];
             if (lane == 0)
                 smem->warp_counts[warp_id] = warp_bin_sum;
         }
@@ -1378,7 +1544,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
             for (int w = 0; w < NUM_WARPS; w++)
             {
                 cum += smem->warp_counts[w];
-                if (cum >= TOP_K)
+                if (cum >= kK)
                 {
                     tw = w;
                     break;
@@ -1394,16 +1560,16 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
 
         if (warp_id == smem->cnt_hi && lane == 0)
         {
-            constexpr int BINS_PER_WARP = NUM_BINS / NUM_WARPS;
+            constexpr int BINS_PER_WARP = kBins / NUM_WARPS;
             int base_cum = smem->cnt_lo;
             float thr = block_min;
             for (int j = 0; j < BINS_PER_WARP; j++)
             {
-                int b = NUM_BINS - 1 - smem->cnt_hi * BINS_PER_WARP - j;
+                int b = kBins - 1 - smem->cnt_hi * BINS_PER_WARP - j;
                 base_cum += smem->histogram[b];
-                if (base_cum >= TOP_K)
+                if (base_cum >= kK)
                 {
-                    thr = block_min + (float) b * range1 / (float) NUM_BINS;
+                    thr = block_min + (float) b * range1 / (float) kBins;
                     break;
                 }
             }
@@ -1418,7 +1584,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
             blockFusedSnapIterDtype<SmemKey>(smem, cand_count, tid, warp_id, lane);
             int cge = smem->cnt_lo;
             int cgt = smem->cnt_hi;
-            if (cgt < TOP_K && cge >= TOP_K)
+            if (cgt < kK && cge >= kK)
             {
                 snap_converged = true;
                 break;
@@ -1447,7 +1613,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
                 if (lane == 0)
                     bp = atomicAdd(&smem->out_count, cnt);
                 bp = __shfl_sync(full_mask, bp, 0);
-                if (emit_gt && bp + moff < TOP_K)
+                if (emit_gt && bp + moff < kK)
                 {
                     outputValues[bp + moff] = Trait::from_fp32(v);
                     outputIndices[bp + moff] = smem->vals[i];
@@ -1472,7 +1638,7 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
                 if (lane == 0)
                     bp = atomicAdd(&smem->out_count, cnt);
                 bp = __shfl_sync(full_mask, bp, 0);
-                if (emit_eq && bp + moff < TOP_K)
+                if (emit_eq && bp + moff < kK)
                 {
                     outputValues[bp + moff] = Trait::from_fp32(v);
                     outputIndices[bp + moff] = smem->vals[i];
@@ -1481,9 +1647,9 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         }
         __syncthreads();
 
-        int filled = min(smem->out_count, TOP_K);
+        int filled = min(smem->out_count, kK);
         InputT const neg_max = Trait::from_fp32(-FLT_MAX);
-        for (int i = filled + tid; i < TOP_K; i += BLOCK_SIZE)
+        for (int i = filled + tid; i < kK; i += BLOCK_SIZE)
         {
             outputValues[i] = neg_max;
             outputIndices[i] = -1;
@@ -1491,14 +1657,14 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
         return;
     }
 
-    // cand_count < TOP_K fallback
+    // cand_count < kK fallback
     for (int i = tid; i < cand_count; i += BLOCK_SIZE)
     {
         outputValues[i] = smem->keys[i]; // both InputT
         outputIndices[i] = smem->vals[i];
     }
     InputT const neg_max = Trait::from_fp32(-FLT_MAX);
-    for (int i = cand_count + tid; i < TOP_K; i += BLOCK_SIZE)
+    for (int i = cand_count + tid; i < kK; i += BLOCK_SIZE)
     {
         outputValues[i] = neg_max;
         outputIndices[i] = -1;
@@ -1506,19 +1672,22 @@ __device__ __noinline__ void gvrTopKJobDtype(InputT const* __restrict__ input, i
 }
 
 // ============================================================================
-// gvrTopKKernelDtype<InputT> — bf16/fp16 single-row global wrapper
+// gvrTopKKernelDtype<InputT, TopK> — bf16/fp16 single-row global wrapper
 // ============================================================================
+// 4d.D: templated on TopK alongside InputT. Default <InputT, TOP_K> matches
+// the pre-multi-K signature for the existing K=2048 dtype path.
 
-template <typename InputT>
+template <typename InputT, int TopK = TOP_K>
 __global__ void __launch_bounds__(BLOCK_SIZE, 1)
     gvrTopKKernelDtype(InputT const* __restrict__ input, int const N, int const* __restrict__ preIdx, int const M,
         int const topK, InputT* __restrict__ outputValues, int* __restrict__ outputIndices, int const thresholdPos)
 {
     using SmemKey = typename GvrDtypeTraits<InputT>::SmemKey;
+    using SmemT = KernelSmemTplK<SmemKey, GvrParams<InputT, TopK>::kC, GvrParams<InputT, TopK>::kNumBins>;
     extern __shared__ unsigned char smem_raw[];
-    auto* smem = reinterpret_cast<KernelSmemTpl<SmemKey>*>(smem_raw);
+    auto* smem = reinterpret_cast<SmemT*>(smem_raw);
 
-    gvrTopKJobDtype<InputT>(input, N, preIdx, M, topK, outputValues, outputIndices, smem,
+    gvrTopKJobDtype<InputT, TopK>(input, N, preIdx, M, topK, outputValues, outputIndices, smem,
         /*preIdxOffset=*/0);
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaTriggerProgrammaticLaunchCompletion();
@@ -1537,43 +1706,24 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
     static_assert(std::is_same_v<T, float> || std::is_same_v<T, __nv_bfloat16> || std::is_same_v<T, __half>,
         "launchHeuristicTopK supports only fp32 / bf16 / fp16");
 
-    if (topK != TOP_K)
+    // 4d.D: validate K against the supported set. Compile-time GvrParams
+    // specializations cover {512, 1024, 2048}; any other value rejects.
+    if (topK != 512 && topK != 1024 && topK != 2048)
         return cudaErrorInvalidValue;
 
-    // 4d: smem size depends on InputT. fp32 path uses the original
-    // KernelSmem (~59 KB); bf16/fp16 use KernelSmemTpl<T> (~47 KB).
-    using SmemKey = typename GvrDtypeTraits<T>::SmemKey;
-    size_t smemSize = sizeof(KernelSmemTpl<SmemKey>);
+    // 4d.D: dispatch on (T, topK) → 9 distinct kernel-pointer paths.
+    // Each instantiation captures its own (kFTarget, kC, kNumBins) tuple
+    // via GvrParams<T, TopK> so all values are compile-time constants
+    // inside the kernel body (zero runtime overhead vs hardcoded literals).
+    //
+    // NOTE: opt-in shared memory + cudaLaunchKernelEx + PDL handling
+    // shared across all 9 kernels. We keep that block runtime-shared by
+    // taking the smem size and kernel function pointer from a
+    // template-parametric lambda.
 
-    // Resolve target kernel function pointer at compile time.
-    auto kfn = []()
-    {
-        if constexpr (std::is_same_v<T, float>)
-            return gvrTopKKernel;
-        else
-            return gvrTopKKernelDtype<T>;
-    }();
-
-    // Opt-in to extended shared memory. cudaFuncSetAttribute is device-scoped
-    // and cheap — call unconditionally to be safe across multi-GPU processes.
-    if (smemSize > 48u * 1024u)
-    {
-        int device;
-        cudaGetDevice(&device);
-        int maxSmem;
-        cudaDeviceGetAttribute(&maxSmem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
-        if (smemSize > static_cast<size_t>(maxSmem))
-            return cudaErrorInvalidConfiguration;
-        cudaFuncSetAttribute(kfn, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
-    }
-
-    // Use cudaLaunchKernelEx with PDL attribute so the kernel epilogue's
-    // cudaTriggerProgrammaticLaunchCompletion() takes effect on Hopper+. The
-    // attribute is a no-op on pre-Hopper architectures. Honor the standard
-    // TRTLLM_ENABLE_PDL env var (default on; set "0" to disable) without
-    // depending on TRT-LLM common headers, since this launcher is also reused
-    // by the standalone JIT-compiled PyTorch extension under
-    // ablation_study/gvr_phase_timing/.
+    // Honor the standard TRTLLM_ENABLE_PDL env var (default on; set "0" to
+    // disable). This launcher is also reused by the standalone JIT-compiled
+    // PyTorch extension under ablation_study/gvr_phase_timing/.
     bool enablePDL = true;
     if (char const* env = std::getenv("TRTLLM_ENABLE_PDL"))
     {
@@ -1581,21 +1731,55 @@ cudaError_t launchHeuristicTopK(T const* input, int N, IdxT const* preIdx, int M
             enablePDL = false;
     }
 
-    cudaLaunchConfig_t config{};
-    config.gridDim = dim3(1);
-    config.blockDim = dim3(BLOCK_SIZE);
-    config.dynamicSmemBytes = smemSize;
-    config.stream = stream;
+    auto launchOne = [&]<int TopK>() -> cudaError_t
+    {
+        using SmemKey = typename GvrDtypeTraits<T>::SmemKey;
+        using SmemT = KernelSmemTplK<SmemKey, GvrParams<T, TopK>::kC, GvrParams<T, TopK>::kNumBins>;
+        size_t const smemSize = sizeof(SmemT);
 
-    cudaLaunchAttribute attrs[1];
-    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
-    attrs[0].val.programmaticStreamSerializationAllowed = enablePDL ? 1 : 0;
-    config.attrs = attrs;
-    config.numAttrs = 1;
+        // Resolve target kernel function pointer at compile time.
+        auto kfn = []()
+        {
+            if constexpr (std::is_same_v<T, float>)
+                return gvrTopKKernel<TopK>;
+            else
+                return gvrTopKKernelDtype<T, TopK>;
+        }();
 
-    cudaLaunchKernelEx(&config, kfn, input, N, preIdx, M, topK, outputValues, outputIndices, thresholdPos);
+        if (smemSize > 48u * 1024u)
+        {
+            int device;
+            cudaGetDevice(&device);
+            int maxSmem;
+            cudaDeviceGetAttribute(&maxSmem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device);
+            if (smemSize > static_cast<size_t>(maxSmem))
+                return cudaErrorInvalidConfiguration;
+            cudaFuncSetAttribute(kfn, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(smemSize));
+        }
 
-    return cudaGetLastError();
+        cudaLaunchConfig_t config{};
+        config.gridDim = dim3(1);
+        config.blockDim = dim3(BLOCK_SIZE);
+        config.dynamicSmemBytes = smemSize;
+        config.stream = stream;
+
+        cudaLaunchAttribute attrs[1];
+        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attrs[0].val.programmaticStreamSerializationAllowed = enablePDL ? 1 : 0;
+        config.attrs = attrs;
+        config.numAttrs = 1;
+
+        cudaLaunchKernelEx(&config, kfn, input, N, preIdx, M, topK, outputValues, outputIndices, thresholdPos);
+        return cudaGetLastError();
+    };
+
+    switch (topK)
+    {
+    case 512: return launchOne.template operator()<512>();
+    case 1024: return launchOne.template operator()<1024>();
+    case 2048: return launchOne.template operator()<2048>();
+    default: return cudaErrorInvalidValue;
+    }
 }
 
 // Explicit instantiations — fp32 (V2e baseline path) + bf16/fp16 (4d dtype path)

--- a/cpp/tensorrt_llm/kernels/indexerTopK.cu
+++ b/cpp/tensorrt_llm/kernels/indexerTopK.cu
@@ -788,9 +788,10 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
         });
     int const kSeqSmall = sCachedNMin;
 
-    bool const canUseHeuristic = preIdx != nullptr && stride1 == 1 && topK == kHeuristicTopK
-        && preIdxCount == kHeuristicSize && preIdxStride >= preIdxCount && numColumns < effectiveSplitWorkThreshold
-        && numColumns >= kSeqSmall && heuristicScratch != nullptr && numRows < kBsLarge;
+    bool const isSupportedTopK = (topK == 512 || topK == 1024 || topK == 2048);
+    bool const canUseHeuristic = preIdx != nullptr && stride1 == 1 && isSupportedTopK && preIdxCount == topK
+        && preIdxStride >= preIdxCount && numColumns < effectiveSplitWorkThreshold && numColumns >= kSeqSmall
+        && heuristicScratch != nullptr && numRows < kBsLarge;
 
     // Optional env-gated dispatch trace (set TRTLLM_SCHEMEX_DEBUG=1 to enable)
     {
@@ -963,18 +964,19 @@ void invokeIndexerTopKDecodeDtype(InputT const* logits, int const* seqLens, int*
         });
     int const kSeqSmall = sCachedNMin;
 
-    bool const canUseHeuristic = preIdx != nullptr && stride1 == 1 && topK == kHeuristicTopK
-        && preIdxCount == kHeuristicSize && preIdxStride >= preIdxCount && numColumns < effectiveSplitWorkThreshold
-        && numColumns >= kSeqSmall && heuristicScratch != nullptr && numRows < kBsLarge;
+    bool const isSupportedTopK = (topK == 512 || topK == 1024 || topK == 2048);
+    bool const canUseHeuristic = preIdx != nullptr && stride1 == 1 && isSupportedTopK && preIdxCount == topK
+        && preIdxStride >= preIdxCount && numColumns < effectiveSplitWorkThreshold && numColumns >= kSeqSmall
+        && heuristicScratch != nullptr && numRows < kBsLarge;
 
     TLLM_CHECK_WITH_INFO(canUseHeuristic,
         "indexer_topk_decode bf16/fp16 path requires GVR-Heuristic preconditions: preIdx != nullptr, "
-        "stride1 == 1, topK == 2048, preIdxCount == 2048, kSeqSmall=%d <= numColumns < kSplitWork=%d, "
-        "numRows < kBsLarge=%d, heuristicScratch != nullptr. "
-        "Got numRows=%d numColumns=%d preIdx=%s heuristicScratch=%s. "
+        "stride1 == 1, topK ∈ {512, 1024, 2048}, preIdxCount == topK, "
+        "kSeqSmall=%d <= numColumns < kSplitWork=%d, numRows < kBsLarge=%d, heuristicScratch != nullptr. "
+        "Got topK=%d preIdxCount=%d numRows=%d numColumns=%d preIdx=%s heuristicScratch=%s. "
         "(bf16/fp16 has no radix fallback — caller must cast to fp32 if conditions not met.)",
-        kSeqSmall, effectiveSplitWorkThreshold, kBsLarge, numRows, numColumns, preIdx ? "ok" : "null",
-        heuristicScratch ? "ok" : "null");
+        kSeqSmall, effectiveSplitWorkThreshold, kBsLarge, topK, preIdxCount, numRows, numColumns,
+        preIdx ? "ok" : "null", heuristicScratch ? "ok" : "null");
 
     launchHeuristicTopKDecode(logits, seqLens, preIdx, indices, heuristicScratch, stride0, next_n, topK, preIdxStride,
         preIdxCount, numRows, stream);

--- a/cpp/tensorrt_llm/kernels/indexerTopK.cu
+++ b/cpp/tensorrt_llm/kernels/indexerTopK.cu
@@ -164,8 +164,8 @@ __device__ void vectorized_process(size_t thread_rank, size_t num_threads, T con
 }
 
 template <int step, int kNumThreadsPerBlock, int kNumBins, int kNumFinalItems, bool multipleBlocksPerRow,
-    bool mergeBlocks, typename SmemFinalType, typename SmemOutputType>
-__device__ bool processHistogramStep(int const* indices, float const* logits, int rowEnd, uint32_t& logitPattern,
+    bool mergeBlocks, typename SmemFinalType, typename SmemOutputType, typename InputT = float>
+__device__ bool processHistogramStep(int const* indices, InputT const* logits, int rowEnd, uint32_t& logitPattern,
     int& thresholdBinIdx, SmemOutputType& smemOutput, int* smemThresholdBinIdx, int* smemFinalDstIdx,
     int* smemFinalBinSize, int* smemFoundTopKValues, SmemFinalType& smemFinal, int stride1, int rowStart, int topK)
 {
@@ -190,8 +190,9 @@ __device__ bool processHistogramStep(int const* indices, float const* logits, in
         logitPattern |= static_cast<uint32_t>(thresholdBinIdx & 0x7ff) << patternShift;
     }
 
-    auto distributeToBins = [&](float logit, int /* idx */ = 0)
+    auto distributeToBins = [&](InputT logitIn, int /* idx */ = 0)
     {
+        float const logit = static_cast<float>(logitIn);
         if (isPartialMatch<patternShift>(logit, logitPattern))
         {
             uint32_t binIdx = extractBinIdx<step>(logit);
@@ -208,8 +209,7 @@ __device__ bool processHistogramStep(int const* indices, float const* logits, in
     {
         for (int idx = rowStart + threadIdx.x; idx < rowEnd; idx += kNumThreadsPerBlock)
         {
-            float logit = logits[idx * stride1];
-            distributeToBins(logit, idx);
+            distributeToBins(logits[idx * stride1], idx);
         }
     }
     // Make sure the histogram is ready.
@@ -271,8 +271,9 @@ __device__ bool processHistogramStep(int const* indices, float const* logits, in
     // The threshold bin.
     thresholdBinIdx = smemThresholdBinIdx[0];
 
-    auto processBins = [&](float logit, int idx)
+    auto processBins = [&](InputT logitIn, int idx)
     {
+        float const logit = static_cast<float>(logitIn);
         if (isPartialMatch<patternShift>(logit, logitPattern))
         {
             uint32_t binIdx = extractBinIdx<step>(logit);
@@ -351,8 +352,7 @@ __device__ bool processHistogramStep(int const* indices, float const* logits, in
     {
         for (int idx = rowStart + threadIdx.x; idx < rowEnd; idx += kNumThreadsPerBlock)
         {
-            float logit = logits[idx * stride1];
-            processBins(logit, idx);
+            processBins(logits[idx * stride1], idx);
         }
     }
 
@@ -365,9 +365,9 @@ __device__ bool processHistogramStep(int const* indices, float const* logits, in
 
 // Follows half - 11 - 11 - 10 bit iterations
 template <int kNumThreadsPerBlock, int kNumBins, bool useRadixSort, bool multipleBlocksPerRow = false,
-    bool mergeBlocks = false>
-static __device__ void topKPerRowJob(int const* indices, float const* logits, int rowStart, int rowEnd, int* outIndices,
-    float* outLogits, int stride1, int topK)
+    bool mergeBlocks = false, typename InputT = float>
+static __device__ void topKPerRowJob(int const* indices, InputT const* logits, int rowStart, int rowEnd,
+    int* outIndices, float* outLogits, int stride1, int topK)
 {
     // The number of slots for the final pass.
     static constexpr int kNumFinalItems = 2048;
@@ -429,7 +429,7 @@ static __device__ void topKPerRowJob(int const* indices, float const* logits, in
             if constexpr (multipleBlocksPerRow)
             {
                 outIndices[rowIt] = rowIt + rowStart;
-                outLogits[rowIt] = logits[rowIt + rowStart];
+                outLogits[rowIt] = static_cast<float>(logits[rowIt + rowStart]);
             }
             else
             {
@@ -597,8 +597,8 @@ static __device__ void topKPerRowJob(int const* indices, float const* logits, in
 }
 } // namespace
 
-template <int kNumThreadsPerBlock, bool useRadixSort>
-static __global__ __launch_bounds__(kNumThreadsPerBlock) void topKPerRowPrefill(float const* logits,
+template <int kNumThreadsPerBlock, bool useRadixSort, typename InputT = float>
+static __global__ __launch_bounds__(kNumThreadsPerBlock) void topKPerRowPrefill(InputT const* logits,
     int const* rowStarts, int const* rowEnds, int* outIndices, int stride0, int stride1, int const topK,
     int const offsetIndex)
 {
@@ -626,8 +626,9 @@ static __global__ __launch_bounds__(kNumThreadsPerBlock) void topKPerRowPrefill(
 #endif
 }
 
-template <int kNumThreadsPerBlock, bool useRadixSort, bool multipleBlocksPerRow = false, bool mergeBlocks = false>
-static __global__ __launch_bounds__(kNumThreadsPerBlock) void topKPerRowDecode(float const* logits, int const* seqLens,
+template <int kNumThreadsPerBlock, bool useRadixSort, bool multipleBlocksPerRow = false, bool mergeBlocks = false,
+    typename InputT = float>
+static __global__ __launch_bounds__(kNumThreadsPerBlock) void topKPerRowDecode(InputT const* logits, int const* seqLens,
     int* outIndices, int stride0, int stride1, int const topK, int next_n, float* outLogits = nullptr,
     int const numBlocksToMerge = 0, int const* indices = nullptr)
 {
@@ -913,17 +914,25 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
 // ============================================================================
 // bf16 / fp16 dispatcher overloads
 // ============================================================================
-// Reuse the BS-threshold + small-N dispatch axes (kBsLarge, kSeqSmall) from
-// the fp32 dispatcher, except kBsL2 uses 2 bytes/element instead of 4
-// (L2 footprint is half) — this means bf16/fp16 path remains valid for
-// larger BS than fp32 at the same N.
+// Reuses the BS-threshold + small-N dispatch axes (kBsLarge, kSeqSmall) from
+// the fp32 dispatcher, except kBsL2 uses sizeof(InputT) bytes/element instead
+// of 4 — L2 footprint is half, so bf16/fp16 path remains valid for larger BS
+// than fp32 at the same N.
 //
-// bf16/fp16 input has NO radix fallback — the production radix kernel
-// (topKPerRowDecode) is fp32-only. If GVR-Heuristic preconditions are not
-// met (preIdx missing, BS too large, N too small), this overload aborts
-// with a TLLM_CHECK error instead of casting to fp32 silently. Callers
-// must either (a) ensure GVR conditions are met, or (b) explicitly cast
-// logits to fp32 and call the fp32 entry.
+// Fallback chain when GVR-Heuristic preconditions are not met (preIdx
+// missing, BS too large, or numColumns < kSeqSmall):
+//   numColumns < kSortingAlgorithmThreshold (12288)            → insertion sort
+//   kSortingAlgorithmThreshold ≤ numColumns < splitWorkThreshold → radix sort
+//   numColumns ≥ splitWorkThreshold (200K default)             → unsupported
+//
+// Insertion + radix tiers use the same topKPerRowDecode kernel as fp32 with
+// InputT propagated through; the histogram and sort steps operate on float
+// keys after a static_cast<float>(InputT) at HBM-read sites, so accuracy is
+// identical to casting input to fp32 before the kernel.
+//
+// The split-work tier requires float aux buffers (outLogitsAux /
+// outIndicesAux) that the bf16/fp16 entry does not expose; callers in that
+// regime must use the fp32 entry.
 
 namespace
 {
@@ -937,7 +946,9 @@ void invokeIndexerTopKDecodeDtype(InputT const* logits, int const* seqLens, int*
     static_assert(std::is_same_v<InputT, __nv_bfloat16> || std::is_same_v<InputT, __half>,
         "invokeIndexerTopKDecodeDtype is for bf16/fp16 only");
 
+    constexpr int kSortingAlgorithmThreshold = 12288;
     constexpr int kDefaultSplitWorkThreshold = 200 * 1000;
+    constexpr int kNumThreadsPerBlock = 512;
     int const effectiveSplitWorkThreshold = splitWorkThreshold > 0 ? splitWorkThreshold : kDefaultSplitWorkThreshold;
 
     // bf16/fp16: bytes_per_element = sizeof(InputT) = 2 → kBsL2 doubles vs fp32.
@@ -950,17 +961,59 @@ void invokeIndexerTopKDecodeDtype(InputT const* logits, int const* seqLens, int*
         && preIdxStride >= preIdxCount && numColumns < effectiveSplitWorkThreshold && numColumns >= kSeqSmall
         && heuristicScratch != nullptr && numRows < kBsLarge;
 
-    TLLM_CHECK_WITH_INFO(canUseHeuristic,
-        "indexer_topk_decode bf16/fp16 path requires GVR-Heuristic preconditions: preIdx != nullptr, "
-        "stride1 == 1, topK ∈ {512, 1024, 2048}, preIdxCount == topK, "
-        "kSeqSmall=%d <= numColumns < kSplitWork=%d, numRows < kBsLarge=%d, heuristicScratch != nullptr. "
-        "Got topK=%d preIdxCount=%d numRows=%d numColumns=%d preIdx=%s heuristicScratch=%s. "
-        "(bf16/fp16 has no radix fallback — caller must cast to fp32 if conditions not met.)",
-        kSeqSmall, effectiveSplitWorkThreshold, kBsLarge, topK, preIdxCount, numRows, numColumns,
-        preIdx ? "ok" : "null", heuristicScratch ? "ok" : "null");
+    if (canUseHeuristic)
+    {
+        launchHeuristicTopKDecode(logits, seqLens, preIdx, indices, heuristicScratch, stride0, next_n, topK,
+            preIdxStride, preIdxCount, numRows, stream);
+    }
+    else if (numColumns < kSortingAlgorithmThreshold)
+    {
+        // Insertion sort path — InputT propagated; histogram/sort run on float keys.
+        auto* kernel_instance = &topKPerRowDecode<kNumThreadsPerBlock, /*useRadixSort=*/false,
+            /*multipleBlocksPerRow=*/false, /*mergeBlocks=*/false, InputT>;
 
-    launchHeuristicTopKDecode(logits, seqLens, preIdx, indices, heuristicScratch, stride0, next_n, topK, preIdxStride,
-        preIdxCount, numRows, stream);
+        cudaLaunchConfig_t config;
+        config.gridDim = numRows;
+        config.blockDim = kNumThreadsPerBlock;
+        config.dynamicSmemBytes = topK * sizeof(int32_t);
+        config.stream = stream;
+        cudaLaunchAttribute attrs[1];
+        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+        config.numAttrs = 1;
+        config.attrs = attrs;
+
+        cudaLaunchKernelEx(
+            &config, kernel_instance, logits, seqLens, indices, stride0, stride1, topK, next_n, nullptr, 0, nullptr);
+    }
+    else if (numColumns < effectiveSplitWorkThreshold)
+    {
+        // Radix sort path — InputT propagated; histogram/sort run on float keys.
+        auto* kernel_instance = &topKPerRowDecode<kNumThreadsPerBlock, /*useRadixSort=*/true,
+            /*multipleBlocksPerRow=*/false, /*mergeBlocks=*/false, InputT>;
+
+        cudaLaunchConfig_t config;
+        config.gridDim = numRows;
+        config.blockDim = kNumThreadsPerBlock;
+        config.dynamicSmemBytes = topK * sizeof(int32_t);
+        config.stream = stream;
+        cudaLaunchAttribute attrs[1];
+        attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+        attrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL();
+        config.numAttrs = 1;
+        config.attrs = attrs;
+
+        cudaLaunchKernelEx(
+            &config, kernel_instance, logits, seqLens, indices, stride0, stride1, topK, next_n, nullptr, 0, nullptr);
+    }
+    else
+    {
+        TLLM_CHECK_WITH_INFO(false,
+            "indexer_topk_decode bf16/fp16 path does not support numColumns >= splitWorkThreshold "
+            "(split-work path requires float aux buffers not exposed in the bf16/fp16 entry). "
+            "Got numColumns=%d splitWorkThreshold=%d. Use the fp32 entry for this regime.",
+            numColumns, effectiveSplitWorkThreshold);
+    }
 
     sync_check_cuda_error(stream);
 }
@@ -1006,6 +1059,18 @@ void invokeIndexerTopKPrefill(float const* logits, int const* rowStarts, int con
     }
 
     sync_check_cuda_error(stream);
+}
+
+bool canIndexerTopKDecodeUseGvr(int numRows, int numColumns, int topK, int bytesPerElem)
+{
+    bool const isSupportedTopK = (topK == 512 || topK == 1024 || topK == 2048);
+    if (!isSupportedTopK)
+    {
+        return false;
+    }
+    constexpr int kDefaultSplitWorkThreshold = 200 * 1000;
+    auto const bounds = getSchemeXBounds(numColumns, bytesPerElem);
+    return numColumns >= bounds.kSeqSmall && numColumns < kDefaultSplitWorkThreshold && numRows < bounds.kBsLarge;
 }
 
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/indexerTopK.cu
+++ b/cpp/tensorrt_llm/kernels/indexerTopK.cu
@@ -28,8 +28,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <cuda_bf16.h> // 4d: bf16 dispatcher overload
-#include <cuda_fp16.h> // 4d: fp16 dispatcher overload
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #include <mutex>
 
 namespace cg = cooperative_groups;
@@ -673,6 +673,63 @@ static __global__ __launch_bounds__(kNumThreadsPerBlock) void topKPerRowDecode(f
 #endif
 }
 
+namespace
+{
+
+// Scheme X bound calculator — shared between fp32 and bf16/fp16 dispatchers.
+// Caches hardware attrs (SM count, L2 capacity) and the small-N threshold
+// once per process via std::call_once. Per-call cost is just two reads
+// from cached static variables plus a small arithmetic block, no syscalls.
+struct SchemeXBounds
+{
+    int smCount;
+    int l2Bytes;
+    int kBsWave;
+    int kBsL2;
+    int kBsLarge;
+    int kSeqSmall;
+};
+
+inline SchemeXBounds getSchemeXBounds(int numColumns, int bytesPerElem)
+{
+    static std::once_flag sOnce;
+    static int sSm = 0;
+    static int sL2 = 0;
+    static int sNMin = 0;
+    std::call_once(sOnce,
+        []()
+        {
+            int dev = 0;
+            cudaGetDevice(&dev);
+            cudaDeviceGetAttribute(&sSm, cudaDevAttrMultiProcessorCount, dev);
+            cudaDeviceGetAttribute(&sL2, cudaDevAttrL2CacheSize, dev);
+            constexpr int kSeqSmallDefault = 12288;
+            char const* env = std::getenv("TRTLLM_HEURISTIC_NMIN");
+            if (env != nullptr)
+            {
+                int const v = std::atoi(env);
+                sNMin = (v >= 1024 && v <= 200000) ? v : kSeqSmallDefault;
+            }
+            else
+            {
+                sNMin = kSeqSmallDefault;
+            }
+        });
+
+    SchemeXBounds b;
+    b.smCount = sSm;
+    b.l2Bytes = sL2;
+    b.kBsWave = (sSm > 0) ? (sSm * 3 - sSm / 8) : 426;
+    b.kBsL2 = (sL2 > 0 && numColumns > 0)
+        ? static_cast<int>(static_cast<int64_t>(sL2) * 9 / 10 / (static_cast<int64_t>(numColumns) * bytesPerElem))
+        : b.kBsWave;
+    b.kBsLarge = std::min(b.kBsWave, b.kBsL2 > 0 ? b.kBsL2 : b.kBsWave);
+    b.kSeqSmall = sNMin;
+    return b;
+}
+
+} // anonymous namespace
+
 void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indices, float* outLogitsAux,
     int* outIndicesAux, int const splitWorkThreshold, int const numRows, int const numColumns, int const stride0,
     int const stride1, int const next_n, int const topK, int const* preIdx, int const preIdxStride,
@@ -733,54 +790,20 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
     // Dispatch threshold = min(kBsWave, kBsL2), still data-agnostic (only
     // queries hardware attrs). At N≈70K both bounds produce ~426, so the
     // L2 axis is a no-op there; for larger N it auto-tightens the threshold.
+    //
+    // Small-N lower bound `kSeqSmall` (default 12288) lets the Heuristic
+    // axis take over wherever the original Radix-radix branch would have
+    // triggered. Random-data benchmarks suggest the crossover is 16384,
+    // but workloads with strongly preIdx-correlated logits make P1 stats
+    // accurate and P2 converge in 1-2 iterations, shifting the real
+    // crossover into the [12288, 16384] band. Configurable via
+    // TRTLLM_HEURISTIC_NMIN env (>=1024).
     // ========================================================================
-    // Hardware-attribute cache (sm count, L2 capacity). std::call_once keeps
-    // the first concurrent caller from racing on cudaDeviceGetAttribute and
-    // ensures every later caller observes the populated values without an
-    // atomic compare-exchange of its own.
-    static std::once_flag sHwOnceFlag;
-    static int sCachedSmCount = 0;
-    static int sCachedL2Bytes = 0;
-    std::call_once(sHwOnceFlag,
-        []()
-        {
-            int dev = 0;
-            cudaGetDevice(&dev);
-            cudaDeviceGetAttribute(&sCachedSmCount, cudaDevAttrMultiProcessorCount, dev);
-            cudaDeviceGetAttribute(&sCachedL2Bytes, cudaDevAttrL2CacheSize, dev);
-        });
-    int const kBsWave = (sCachedSmCount > 0) ? (sCachedSmCount * 3 - sCachedSmCount / 8) : 426;
-    int const kBsL2 = (sCachedL2Bytes > 0 && numColumns > 0)
-        ? (int) ((int64_t) sCachedL2Bytes * 9 / 10 / ((int64_t) numColumns * 4))
-        : kBsWave;
-    int const kBsLarge = std::min(kBsWave, kBsL2 > 0 ? kBsL2 : kBsWave);
-
-    // Small-N lower bound — set to kSortingAlgorithmThreshold (12288) so the
-    // Heuristic axis takes over wherever the original Radix-radix branch
-    // would have triggered. Random-data benchmarks suggest the crossover is
-    // 16384, but workloads with strongly preIdx-correlated logits make P1
-    // stats accurate and P2 converge in 1-2 iterations, shifting the real
-    // crossover into the [12288, 16384] band. Below 12288 the Insertion path
-    // is still used (canUseHeuristic gating + dispatcher fallback both route
-    // there). Configurable via TRTLLM_HEURISTIC_NMIN env (>=1024).
-    static std::once_flag sNMinOnceFlag;
-    static int sCachedNMin = 0;
-    std::call_once(sNMinOnceFlag,
-        []()
-        {
-            constexpr int kSeqSmallDefault = 12288;
-            char const* env = std::getenv("TRTLLM_HEURISTIC_NMIN");
-            if (env != nullptr)
-            {
-                int const v = std::atoi(env);
-                sCachedNMin = (v >= 1024 && v <= 200000) ? v : kSeqSmallDefault;
-            }
-            else
-            {
-                sCachedNMin = kSeqSmallDefault;
-            }
-        });
-    int const kSeqSmall = sCachedNMin;
+    auto const bounds = getSchemeXBounds(numColumns, /*bytesPerElem=*/4);
+    int const kBsWave = bounds.kBsWave;
+    int const kBsL2 = bounds.kBsL2;
+    int const kBsLarge = bounds.kBsLarge;
+    int const kSeqSmall = bounds.kSeqSmall;
 
     bool const isSupportedTopK = (topK == 512 || topK == 1024 || topK == 2048);
     bool const canUseHeuristic = preIdx != nullptr && stride1 == 1 && isSupportedTopK && preIdxCount == topK
@@ -800,10 +823,10 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
         if (sDebug)
         {
             fprintf(stderr,
-                "[Scheme X v1.2] numRows=%d numColumns=%d kBsWave=%d kBsL2=%d kBsLarge=%d kSeqSmall=%d smCount=%d "
+                "[Scheme X] numRows=%d numColumns=%d kBsWave=%d kBsL2=%d kBsLarge=%d kSeqSmall=%d smCount=%d "
                 "L2=%dMB -> %s path%s\n",
-                numRows, numColumns, kBsWave, kBsL2, kBsLarge, kSeqSmall, sCachedSmCount,
-                sCachedL2Bytes / (1024 * 1024), canUseHeuristic ? "Heuristic" : "Radix",
+                numRows, numColumns, kBsWave, kBsL2, kBsLarge, kSeqSmall, bounds.smCount,
+                bounds.l2Bytes / (1024 * 1024), canUseHeuristic ? "Heuristic" : "Radix",
                 (numColumns < kSeqSmall) ? " (small-N route)" : "");
         }
     }
@@ -917,46 +940,10 @@ void invokeIndexerTopKDecodeDtype(InputT const* logits, int const* seqLens, int*
     constexpr int kDefaultSplitWorkThreshold = 200 * 1000;
     int const effectiveSplitWorkThreshold = splitWorkThreshold > 0 ? splitWorkThreshold : kDefaultSplitWorkThreshold;
 
-    // Hardware caching — share with fp32 dispatcher's once_flag would require
-    // hoisting; cheaper to use a new once_flag per dtype overload.
-    static std::once_flag sHwOnceFlag;
-    static int sCachedSmCount = 0;
-    static int sCachedL2Bytes = 0;
-    std::call_once(sHwOnceFlag,
-        []()
-        {
-            int dev = 0;
-            cudaGetDevice(&dev);
-            cudaDeviceGetAttribute(&sCachedSmCount, cudaDevAttrMultiProcessorCount, dev);
-            cudaDeviceGetAttribute(&sCachedL2Bytes, cudaDevAttrL2CacheSize, dev);
-        });
-
-    int const kBsWave = (sCachedSmCount > 0) ? (sCachedSmCount * 3 - sCachedSmCount / 8) : 426;
     // bf16/fp16: bytes_per_element = sizeof(InputT) = 2 → kBsL2 doubles vs fp32.
-    int const bytesPerElem = static_cast<int>(sizeof(InputT));
-    int const kBsL2 = (sCachedL2Bytes > 0 && numColumns > 0)
-        ? (int) ((int64_t) sCachedL2Bytes * 9 / 10 / ((int64_t) numColumns * bytesPerElem))
-        : kBsWave;
-    int const kBsLarge = std::min(kBsWave, kBsL2 > 0 ? kBsL2 : kBsWave);
-
-    static std::once_flag sNMinOnceFlag;
-    static int sCachedNMin = 0;
-    std::call_once(sNMinOnceFlag,
-        []()
-        {
-            constexpr int kSeqSmallDefault = 12288;
-            char const* env = std::getenv("TRTLLM_HEURISTIC_NMIN");
-            if (env != nullptr)
-            {
-                int const v = std::atoi(env);
-                sCachedNMin = (v >= 1024 && v <= 200000) ? v : kSeqSmallDefault;
-            }
-            else
-            {
-                sCachedNMin = kSeqSmallDefault;
-            }
-        });
-    int const kSeqSmall = sCachedNMin;
+    auto const bounds = getSchemeXBounds(numColumns, /*bytesPerElem=*/static_cast<int>(sizeof(InputT)));
+    int const kBsLarge = bounds.kBsLarge;
+    int const kSeqSmall = bounds.kSeqSmall;
 
     bool const isSupportedTopK = (topK == 512 || topK == 1024 || topK == 2048);
     bool const canUseHeuristic = preIdx != nullptr && stride1 == 1 && isSupportedTopK && preIdxCount == topK

--- a/cpp/tensorrt_llm/kernels/indexerTopK.cu
+++ b/cpp/tensorrt_llm/kernels/indexerTopK.cu
@@ -28,6 +28,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cuda_bf16.h> // 4d: bf16 dispatcher overload
+#include <cuda_fp16.h> // 4d: fp16 dispatcher overload
 #include <mutex>
 
 namespace cg = cooperative_groups;
@@ -888,6 +890,116 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
             multipleBlocksPerRowConfig * topK, 1, topK, next_n, nullptr, multipleBlocksPerRowConfig, outIndicesAux);
     }
     sync_check_cuda_error(stream);
+}
+
+// ============================================================================
+// bf16 / fp16 dispatcher overloads (4d_multi_dtype_unified, 2026-05-06)
+// ============================================================================
+// Reuse Scheme X v1.1 BS-threshold + v1.2 small-N axis (kBsLarge, kSeqSmall)
+// from the fp32 dispatcher, except kBsL2 uses 2 bytes/element instead of 4
+// (L2 footprint is half) — this means bf16/fp16 path remains valid for
+// LARGER BS than fp32, anticipating the Stage C re-tune.
+//
+// bf16/fp16 input has NO radix fallback — the production radix kernel
+// (topKPerRowDecode) is fp32-only. If GVR-Heuristic preconditions are not
+// met (preIdx missing, BS too large, N too small), this overload aborts
+// with a TLLM_CHECK error instead of casting to fp32 silently. Callers
+// must either (a) ensure GVR conditions are met, or (b) explicitly cast
+// logits to fp32 and call the fp32 entry.
+
+namespace
+{
+
+template <typename InputT>
+void invokeIndexerTopKDecodeDtype(InputT const* logits, int const* seqLens, int* indices, int const splitWorkThreshold,
+    int const numRows, int const numColumns, int const stride0, int const stride1, int const next_n, int const topK,
+    int const* preIdx, int const preIdxStride, int const preIdxCount, InputT* heuristicScratch,
+    cudaStream_t const stream)
+{
+    static_assert(std::is_same_v<InputT, __nv_bfloat16> || std::is_same_v<InputT, __half>,
+        "invokeIndexerTopKDecodeDtype is for bf16/fp16 only");
+
+    constexpr int kDefaultSplitWorkThreshold = 200 * 1000;
+    int const effectiveSplitWorkThreshold = splitWorkThreshold > 0 ? splitWorkThreshold : kDefaultSplitWorkThreshold;
+
+    // Hardware caching — share with fp32 dispatcher's once_flag would require
+    // hoisting; cheaper to use a new once_flag per dtype overload.
+    static std::once_flag sHwOnceFlag;
+    static int sCachedSmCount = 0;
+    static int sCachedL2Bytes = 0;
+    std::call_once(sHwOnceFlag,
+        []()
+        {
+            int dev = 0;
+            cudaGetDevice(&dev);
+            cudaDeviceGetAttribute(&sCachedSmCount, cudaDevAttrMultiProcessorCount, dev);
+            cudaDeviceGetAttribute(&sCachedL2Bytes, cudaDevAttrL2CacheSize, dev);
+        });
+
+    int const kBsWave = (sCachedSmCount > 0) ? (sCachedSmCount * 3 - sCachedSmCount / 8) : 426;
+    // bf16/fp16: bytes_per_element = sizeof(InputT) = 2 → kBsL2 doubles vs fp32.
+    int const bytesPerElem = static_cast<int>(sizeof(InputT));
+    int const kBsL2 = (sCachedL2Bytes > 0 && numColumns > 0)
+        ? (int) ((int64_t) sCachedL2Bytes * 9 / 10 / ((int64_t) numColumns * bytesPerElem))
+        : kBsWave;
+    int const kBsLarge = std::min(kBsWave, kBsL2 > 0 ? kBsL2 : kBsWave);
+
+    static std::once_flag sNMinOnceFlag;
+    static int sCachedNMin = 0;
+    std::call_once(sNMinOnceFlag,
+        []()
+        {
+            constexpr int kSeqSmallDefault = 12288;
+            char const* env = std::getenv("TRTLLM_HEURISTIC_NMIN");
+            if (env != nullptr)
+            {
+                int const v = std::atoi(env);
+                sCachedNMin = (v >= 1024 && v <= 200000) ? v : kSeqSmallDefault;
+            }
+            else
+            {
+                sCachedNMin = kSeqSmallDefault;
+            }
+        });
+    int const kSeqSmall = sCachedNMin;
+
+    bool const canUseHeuristic = preIdx != nullptr && stride1 == 1 && topK == kHeuristicTopK
+        && preIdxCount == kHeuristicSize && preIdxStride >= preIdxCount && numColumns < effectiveSplitWorkThreshold
+        && numColumns >= kSeqSmall && heuristicScratch != nullptr && numRows < kBsLarge;
+
+    TLLM_CHECK_WITH_INFO(canUseHeuristic,
+        "indexer_topk_decode bf16/fp16 path requires GVR-Heuristic preconditions: preIdx != nullptr, "
+        "stride1 == 1, topK == 2048, preIdxCount == 2048, kSeqSmall=%d <= numColumns < kSplitWork=%d, "
+        "numRows < kBsLarge=%d, heuristicScratch != nullptr. "
+        "Got numRows=%d numColumns=%d preIdx=%s heuristicScratch=%s. "
+        "(bf16/fp16 has no radix fallback — caller must cast to fp32 if conditions not met.)",
+        kSeqSmall, effectiveSplitWorkThreshold, kBsLarge, numRows, numColumns, preIdx ? "ok" : "null",
+        heuristicScratch ? "ok" : "null");
+
+    launchHeuristicTopKDecode(logits, seqLens, preIdx, indices, heuristicScratch, stride0, next_n, topK, preIdxStride,
+        preIdxCount, numRows, stream);
+
+    sync_check_cuda_error(stream);
+}
+
+} // anonymous namespace
+
+void invokeIndexerTopKDecode(__nv_bfloat16 const* logits, int const* seqLens, int* indices,
+    int const splitWorkThreshold, int const numRows, int const numColumns, int const stride0, int const stride1,
+    int const next_n, int const topK, int const* preIdx, int const preIdxStride, int const preIdxCount,
+    __nv_bfloat16* heuristicScratch, cudaStream_t const stream)
+{
+    invokeIndexerTopKDecodeDtype<__nv_bfloat16>(logits, seqLens, indices, splitWorkThreshold, numRows, numColumns,
+        stride0, stride1, next_n, topK, preIdx, preIdxStride, preIdxCount, heuristicScratch, stream);
+}
+
+void invokeIndexerTopKDecode(__half const* logits, int const* seqLens, int* indices, int const splitWorkThreshold,
+    int const numRows, int const numColumns, int const stride0, int const stride1, int const next_n, int const topK,
+    int const* preIdx, int const preIdxStride, int const preIdxCount, __half* heuristicScratch,
+    cudaStream_t const stream)
+{
+    invokeIndexerTopKDecodeDtype<__half>(logits, seqLens, indices, splitWorkThreshold, numRows, numColumns, stride0,
+        stride1, next_n, topK, preIdx, preIdxStride, preIdxCount, heuristicScratch, stream);
 }
 
 void invokeIndexerTopKPrefill(float const* logits, int const* rowStarts, int const* rowEnds, int* indices,

--- a/cpp/tensorrt_llm/kernels/indexerTopK.cu
+++ b/cpp/tensorrt_llm/kernels/indexerTopK.cu
@@ -691,28 +691,25 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
     int const effectiveSplitWorkThreshold = splitWorkThreshold > 0 ? splitWorkThreshold : kDefaultSplitWorkThreshold;
 
     // ========================================================================
-    // Scheme X v1.2 (2026-04-25): adds small-N dispatch axis.
+    // Small-N dispatch axis.
     //
     // GVR Heuristic Top-K has a *fixed* per-launch overhead from Phase-1
     // (preIdx stats reduction over M=2048) and Phase-4 (2048-bin histogram
     // snap), totaling ~11 µs regardless of N. For small N (≤16K), this
-    // fixed cost dominates and the kernel loses to TRT-LLM's own
+    // fixed cost dominates and the kernel loses to the existing
     // insertion-sort/radix path. Empirically (random data, B200 BS=1):
     //   N=8192   : Heuristic 16.5 µs vs Radix 11.2 µs (radix 1.47× faster)
     //   N=16384  : Heuristic 21.9 µs vs Radix 22.0 µs (parity)
     //   N=32768  : Heuristic 26.1 µs vs Radix 32.9 µs (heuristic 1.26× faster)
     //   N=131072 : Heuristic 43.4 µs vs Radix 76.1 µs (heuristic 1.75× faster)
     //
-    // We therefore route N < kSeqSmall to the existing Radix/Insertion path
-    // (which itself splits at kSortingAlgorithmThreshold=12288), giving the
-    // best of both worlds. kSeqSmall is set at the empirical crossover point.
-    //
-    // See ablation_study/gvr_phase_timing/05_scheme_x_production/v1.2_smallN_dispatch/
-    // for the full N-scaling sweep and per-layer validation.
+    // Route N < kSeqSmall to the existing Radix/Insertion path (which itself
+    // splits at kSortingAlgorithmThreshold=12288). kSeqSmall is set at the
+    // empirical crossover point.
     //
     // ========================================================================
-    // Scheme X v1.1 (2026-04-23): architecture-derived BS-threshold dispatch,
-    // now jointly bounded by occupancy AND L2 cache capacity.
+    // Architecture-derived BS-threshold dispatch — jointly bounded by
+    // occupancy AND L2 cache capacity.
     //
     // Two physical constraints bound when the per-row heuristic kernel
     // remains faster than a radix streaming kernel:
@@ -734,11 +731,8 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
     //        over; e.g. N=128K → kBsL2=238, N=196K → kBsL2=155.
     //
     // Dispatch threshold = min(kBsWave, kBsL2), still data-agnostic (only
-    // queries hardware attrs). For the SWE-Bench scenario (N≈70K) this is
-    // equivalent to Scheme X v1.0 (both produce 426), so v1.1 is a
-    // zero-regression upgrade; for larger N it auto-tightens the threshold.
-    // See ablation_study/gvr_phase_timing/optM_unified/Scheme_X_Report_20260422.md
-    // §9 for the full N-scaling analysis.
+    // queries hardware attrs). At N≈70K both bounds produce ~426, so the
+    // L2 axis is a no-op there; for larger N it auto-tightens the threshold.
     // ========================================================================
     // Hardware-attribute cache (sm count, L2 capacity). std::call_once keeps
     // the first concurrent caller from racing on cudaDeviceGetAttribute and
@@ -761,14 +755,14 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
         : kBsWave;
     int const kBsLarge = std::min(kBsWave, kBsL2 > 0 ? kBsL2 : kBsWave);
 
-    // v1.2: small-N lower bound — set to kSortingAlgorithmThreshold (12288) so
-    // the Heuristic axis takes over wherever the original Radix-radix branch
-    // would have triggered. Random-data benchmarks suggested 16384, but real
-    // SWE-Bench workloads see Heuristic ~6.3 us faster than random (preIdx-vs-
-    // logits ~99% correlated → P1 stats accurate → P2 secant 1-2 iter), shifting
-    // the real crossover into the [12288, 16384] band. Below 12288 the Insertion
-    // path is still used (canUseHeuristic gating + dispatcher fallback both
-    // route there). Configurable via TRTLLM_HEURISTIC_NMIN env (>=1024).
+    // Small-N lower bound — set to kSortingAlgorithmThreshold (12288) so the
+    // Heuristic axis takes over wherever the original Radix-radix branch
+    // would have triggered. Random-data benchmarks suggest the crossover is
+    // 16384, but workloads with strongly preIdx-correlated logits make P1
+    // stats accurate and P2 converge in 1-2 iterations, shifting the real
+    // crossover into the [12288, 16384] band. Below 12288 the Insertion path
+    // is still used (canUseHeuristic gating + dispatcher fallback both route
+    // there). Configurable via TRTLLM_HEURISTIC_NMIN env (>=1024).
     static std::once_flag sNMinOnceFlag;
     static int sCachedNMin = 0;
     std::call_once(sNMinOnceFlag,
@@ -894,12 +888,12 @@ void invokeIndexerTopKDecode(float const* logits, int const* seqLens, int* indic
 }
 
 // ============================================================================
-// bf16 / fp16 dispatcher overloads (4d_multi_dtype_unified, 2026-05-06)
+// bf16 / fp16 dispatcher overloads
 // ============================================================================
-// Reuse Scheme X v1.1 BS-threshold + v1.2 small-N axis (kBsLarge, kSeqSmall)
-// from the fp32 dispatcher, except kBsL2 uses 2 bytes/element instead of 4
+// Reuse the BS-threshold + small-N dispatch axes (kBsLarge, kSeqSmall) from
+// the fp32 dispatcher, except kBsL2 uses 2 bytes/element instead of 4
 // (L2 footprint is half) — this means bf16/fp16 path remains valid for
-// LARGER BS than fp32, anticipating the Stage C re-tune.
+// larger BS than fp32 at the same N.
 //
 // bf16/fp16 input has NO radix fallback — the production radix kernel
 // (topKPerRowDecode) is fp32-only. If GVR-Heuristic preconditions are not

--- a/cpp/tensorrt_llm/thop/IndexerTopKOp.cpp
+++ b/cpp/tensorrt_llm/thop/IndexerTopKOp.cpp
@@ -88,7 +88,7 @@ void indexer_topk_decode(th::Tensor const& logits, th::Tensor const& seq_lens, t
 
     // Caller-owned scratch buffer for heuristic TopK output values.
     // Must be pre-allocated with stable address for CUDA Graph compatibility.
-    // 4d_multi_dtype_unified: scratch dtype must match input dtype.
+    // scratch dtype must match input dtype.
     auto const logits_dtype = logits.scalar_type();
     TORCH_CHECK(logits_dtype == at::ScalarType::Float || logits_dtype == at::ScalarType::BFloat16
             || logits_dtype == at::ScalarType::Half,

--- a/cpp/tensorrt_llm/thop/IndexerTopKOp.cpp
+++ b/cpp/tensorrt_llm/thop/IndexerTopKOp.cpp
@@ -88,7 +88,12 @@ void indexer_topk_decode(th::Tensor const& logits, th::Tensor const& seq_lens, t
 
     // Caller-owned scratch buffer for heuristic TopK output values.
     // Must be pre-allocated with stable address for CUDA Graph compatibility.
-    float* heuristicScratchPtr = nullptr;
+    // 4d_multi_dtype_unified: scratch dtype must match input dtype.
+    auto const logits_dtype = logits.scalar_type();
+    TORCH_CHECK(logits_dtype == at::ScalarType::Float || logits_dtype == at::ScalarType::BFloat16
+            || logits_dtype == at::ScalarType::Half,
+        "indexer_topk_decode: logits dtype must be float32, bfloat16, or float16; got ", logits_dtype);
+    void* heuristicScratchPtr = nullptr;
     if (heuristic_scratch.has_value())
     {
         auto const& scratchTensor = heuristic_scratch.value();
@@ -98,25 +103,48 @@ void indexer_topk_decode(th::Tensor const& logits, th::Tensor const& seq_lens, t
         TORCH_CHECK(scratchTensor.is_contiguous(), "heuristic_scratch must be contiguous");
         TORCH_CHECK(scratchTensor.numel() >= static_cast<int64_t>(num_rows) * index_topk,
             "heuristic_scratch must have at least numRows * index_topk elements");
-        heuristicScratchPtr = scratchTensor.data_ptr<float>();
+        TORCH_CHECK(scratchTensor.scalar_type() == logits_dtype,
+            "heuristic_scratch dtype must match logits dtype (got scratch=", scratchTensor.scalar_type(),
+            ", logits=", logits_dtype, ")");
+        heuristicScratchPtr = scratchTensor.data_ptr();
     }
 
     int32_t splitWorkThreshold = 200 * 1000;
-    th::Tensor aux_indices = th::empty({0}, th::TensorOptions().dtype(th::kInt32).device(logits.device()));
-    th::Tensor aux_logits = th::empty({0}, th::TensorOptions().dtype(th::kFloat32).device(logits.device()));
-    constexpr auto multipleBlocksPerRowConfig = 10;
-    if (num_columns >= splitWorkThreshold)
-    {
-        aux_indices = th::empty({num_rows, multipleBlocksPerRowConfig, index_topk},
-            th::TensorOptions().dtype(th::kInt32).device(logits.device()));
-        aux_logits = th::empty({num_rows, multipleBlocksPerRowConfig, index_topk},
-            th::TensorOptions().dtype(th::kFloat32).device(logits.device()));
-    }
     auto stream = at::cuda::getCurrentCUDAStream(logits.get_device());
-    tk::invokeIndexerTopKDecode(logits.data_ptr<float>(), seq_lens.data_ptr<int32_t>(), indices.data_ptr<int32_t>(),
-        aux_logits.data_ptr<float>(), aux_indices.data_ptr<int32_t>(), splitWorkThreshold, num_rows, num_columns,
-        logits_stride_0, logits_stride_1, static_cast<int32_t>(next_n), static_cast<int32_t>(index_topk), preIdxPtr,
-        preIdxStride, preIdxCount, heuristicScratchPtr, stream);
+
+    if (logits_dtype == at::ScalarType::Float)
+    {
+        // fp32 path — full Scheme X v1.2 dispatcher (GVR / Insertion / Radix /
+        // Radix-split-work). aux_logits/aux_indices needed only by split-work.
+        th::Tensor aux_indices = th::empty({0}, th::TensorOptions().dtype(th::kInt32).device(logits.device()));
+        th::Tensor aux_logits = th::empty({0}, th::TensorOptions().dtype(th::kFloat32).device(logits.device()));
+        constexpr auto multipleBlocksPerRowConfig = 10;
+        if (num_columns >= splitWorkThreshold)
+        {
+            aux_indices = th::empty({num_rows, multipleBlocksPerRowConfig, index_topk},
+                th::TensorOptions().dtype(th::kInt32).device(logits.device()));
+            aux_logits = th::empty({num_rows, multipleBlocksPerRowConfig, index_topk},
+                th::TensorOptions().dtype(th::kFloat32).device(logits.device()));
+        }
+        tk::invokeIndexerTopKDecode(logits.data_ptr<float>(), seq_lens.data_ptr<int32_t>(), indices.data_ptr<int32_t>(),
+            aux_logits.data_ptr<float>(), aux_indices.data_ptr<int32_t>(), splitWorkThreshold, num_rows, num_columns,
+            logits_stride_0, logits_stride_1, static_cast<int32_t>(next_n), static_cast<int32_t>(index_topk), preIdxPtr,
+            preIdxStride, preIdxCount, static_cast<float*>(heuristicScratchPtr), stream);
+    }
+    else if (logits_dtype == at::ScalarType::BFloat16)
+    {
+        tk::invokeIndexerTopKDecode(reinterpret_cast<__nv_bfloat16 const*>(logits.data_ptr()),
+            seq_lens.data_ptr<int32_t>(), indices.data_ptr<int32_t>(), splitWorkThreshold, num_rows, num_columns,
+            logits_stride_0, logits_stride_1, static_cast<int32_t>(next_n), static_cast<int32_t>(index_topk), preIdxPtr,
+            preIdxStride, preIdxCount, static_cast<__nv_bfloat16*>(heuristicScratchPtr), stream);
+    }
+    else // Half
+    {
+        tk::invokeIndexerTopKDecode(reinterpret_cast<__half const*>(logits.data_ptr()), seq_lens.data_ptr<int32_t>(),
+            indices.data_ptr<int32_t>(), splitWorkThreshold, num_rows, num_columns, logits_stride_0, logits_stride_1,
+            static_cast<int32_t>(next_n), static_cast<int32_t>(index_topk), preIdxPtr, preIdxStride, preIdxCount,
+            static_cast<__half*>(heuristicScratchPtr), stream);
+    }
 }
 
 void indexer_topk_prefill(th::Tensor const& logits, th::Tensor const& row_starts, th::Tensor const& row_ends,

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -1,8 +1,9 @@
 """Dense Sparse Attention (DSA) backend for TRT-LLM with indexer-based TopK selection."""
 import math
+import threading
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -49,6 +50,58 @@ try:
 except ImportError:
     hadamard_transform = None
     HAS_FAST_HADAMARD = False
+
+# Idempotency guard for warmup_heuristic_topk_decode — keyed by
+# (device_index, top_k, hint_size, num_cols). Prevents repeated allocations
+# and synchronizations when multiple Indexer modules invoke the warmup with
+# the same parameters during model construction.
+_HEURISTIC_TOPK_WARMUP_DONE: Set[Tuple[int, int, int, int]] = set()
+_HEURISTIC_TOPK_WARMUP_LOCK = threading.Lock()
+
+
+def warmup_heuristic_topk_decode(top_k: int = 2048,
+                                 hint_size: int = 2048,
+                                 num_cols: int = 4096) -> None:
+    """Pre-initialize cached hardware attributes in the C++ Scheme X dispatcher.
+
+    The dispatcher inside ``invokeIndexerTopKDecode`` lazily queries
+    ``cudaDeviceGetAttribute`` for ``MultiProcessorCount`` and
+    ``L2CacheSize`` on its first call. Those host-side queries must not
+    be issued during ``cudaStreamBeginCapture / EndCapture``: the values
+    captured there become frozen into the graph and cannot be refreshed
+    across replays on a different device.
+
+    This warmup issues one small heuristic decode call so the static
+    caches are populated before any CUDA Graph capture begins. Must be
+    called from the Indexer setup hook (``layer_idx == 0``) when
+    ``enable_heuristic_topk`` is true.
+
+    Repeated invocations with the same ``(device, top_k, hint_size,
+    num_cols)`` key are short-circuited so that constructing many Indexer
+    modules in the same process does not re-allocate scratch tensors or
+    issue redundant synchronizations.
+    """
+    key = (torch.cuda.current_device(), top_k, hint_size, num_cols)
+    with _HEURISTIC_TOPK_WARMUP_LOCK:
+        if key in _HEURISTIC_TOPK_WARMUP_DONE:
+            return
+        _HEURISTIC_TOPK_WARMUP_DONE.add(key)
+
+    device = torch.device("cuda")
+    logits = torch.zeros((1, num_cols), dtype=torch.float32, device=device)
+    seq_lens = torch.tensor([num_cols], dtype=torch.int32, device=device)
+    indices = torch.empty((1, top_k), dtype=torch.int32, device=device)
+    pre_idx = torch.zeros((1, hint_size), dtype=torch.int32, device=device)
+    scratch = torch.empty((top_k, ), dtype=torch.float32, device=device)
+    torch.ops.trtllm.indexer_topk_decode(logits,
+                                         seq_lens,
+                                         indices,
+                                         1,
+                                         top_k,
+                                         pre_idx=pre_idx,
+                                         heuristic_scratch=scratch)
+    torch.cuda.synchronize()
+
 
 # `block_kv` arg passed to DeepGEMM's `get_paged_mqa_logits_metadata`. This is
 # a SCHEDULE-granularity parameter, not the cache page size. The DG metadata
@@ -1249,8 +1302,7 @@ class Indexer(nn.Module):
             # Populate static caches (sm_count, L2 cache size) inside the C++
             # Scheme X dispatcher before any CUDA Graph capture so the host
             # attribute queries do not end up frozen into a captured graph.
-            from tensorrt_llm._torch.custom_ops import cpp_custom_ops
-            cpp_custom_ops.warmup_heuristic_topk_decode(top_k=self.index_topk)
+            warmup_heuristic_topk_decode(top_k=self.index_topk)
 
     def post_load_weights(self):
         """Fuse wk + weights_proj into single FP32 weight for F.linear GEMM under allow_tf32 (TF32 tensor cores on Ampere+)."""

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -1,5 +1,4 @@
-import threading
-from typing import List, Optional, Set, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 
@@ -7,13 +6,6 @@ import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
 
 from ..._utils import get_sm_version
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
-
-# Idempotency guard for warmup_heuristic_topk_decode — keyed by
-# (device_index, top_k, hint_size, num_cols). Prevents repeated allocations
-# and synchronizations when multiple Indexer modules invoke the warmup with
-# the same parameters during model construction.
-_HEURISTIC_TOPK_WARMUP_DONE: Set[Tuple[int, int, int, int]] = set()
-_HEURISTIC_TOPK_WARMUP_LOCK = threading.Lock()
 
 if IS_CUTLASS_DSL_AVAILABLE:
     from .cute_dsl_custom_ops import GroupedGemmInputsHelper
@@ -1198,47 +1190,3 @@ def _register_fake():
         out_shape = shape if shape is not None else list(like.shape)
         dtype = out_dtype if out_dtype is not None else like.dtype
         return like.new_empty(out_shape, dtype=dtype), output_buffer_kind
-
-
-def warmup_heuristic_topk_decode(top_k: int = 2048,
-                                 hint_size: int = 2048,
-                                 num_cols: int = 4096) -> None:
-    """Pre-initialize cached hardware attributes in the C++ Scheme X dispatcher.
-
-    The dispatcher inside ``invokeIndexerTopKDecode`` lazily queries
-    ``cudaDeviceGetAttribute`` for ``MultiProcessorCount`` and
-    ``L2CacheSize`` on its first call. Those host-side queries must not
-    be issued during ``cudaStreamBeginCapture / EndCapture``: the values
-    captured there become frozen into the graph and cannot be refreshed
-    across replays on a different device.
-
-    This warmup issues one small heuristic decode call so the static
-    caches are populated before any CUDA Graph capture begins. Must be
-    called from the Indexer setup hook (``layer_idx == 0``) when
-    ``enable_heuristic_topk`` is true.
-
-    Repeated invocations with the same ``(device, top_k, hint_size,
-    num_cols)`` key are short-circuited so that constructing many Indexer
-    modules in the same process does not re-allocate scratch tensors or
-    issue redundant synchronizations.
-    """
-    key = (torch.cuda.current_device(), top_k, hint_size, num_cols)
-    with _HEURISTIC_TOPK_WARMUP_LOCK:
-        if key in _HEURISTIC_TOPK_WARMUP_DONE:
-            return
-        _HEURISTIC_TOPK_WARMUP_DONE.add(key)
-
-    device = torch.device("cuda")
-    logits = torch.zeros((1, num_cols), dtype=torch.float32, device=device)
-    seq_lens = torch.tensor([num_cols], dtype=torch.int32, device=device)
-    indices = torch.empty((1, top_k), dtype=torch.int32, device=device)
-    pre_idx = torch.zeros((1, hint_size), dtype=torch.int32, device=device)
-    scratch = torch.empty((top_k, ), dtype=torch.float32, device=device)
-    torch.ops.trtllm.indexer_topk_decode(logits,
-                                         seq_lens,
-                                         indices,
-                                         1,
-                                         top_k,
-                                         pre_idx=pre_idx,
-                                         heuristic_scratch=scratch)
-    torch.cuda.synchronize()

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -965,23 +965,7 @@ def test_cute_dsl_topk_decode_single_pass_multi_cta_cluster(
 @pytest.mark.parametrize("dist_cfg", _DECODE_DIST_CONFIGS, ids=_DECODE_DIST_IDS)
 @pytest.mark.parametrize("batch_size", [1, 64, 128])
 @pytest.mark.parametrize("next_n", [1, 2, 3])
-@pytest.mark.parametrize(
-    "index_topk",
-    [
-        # K=512 / K=1024 hit a known ~0.09 % kernel-side intermittent at the
-        # edge corner (numRows ~= 384, success_ratio in {0.5, 0.9}, mean-zero
-        # distributions). Root cause is in P4's atomic-snap step at small
-        # kNumBins (cpp/tensorrt_llm/kernels/heuristic_topk.cuh
-        # GvrParams<*, 512|1024>); tracked as a kernel-side follow-up. Mark as
-        # flaky with 2 reruns to absorb the noise without widening the
-        # value-comparison tolerance (which would silently mask real
-        # wrong-answer regressions). K=2048 is the production-blessed path,
-        # observed 100 % stable across 6804 cells of local validation.
-        pytest.param(512, marks=pytest.mark.flaky(reruns=2)),
-        pytest.param(1024, marks=pytest.mark.flaky(reruns=2)),
-        2048,
-    ],
-)
+@pytest.mark.parametrize("index_topk", [512, 1024, 2048])
 @pytest.mark.parametrize("num_tokens", [8192, 16384])
 @pytest.mark.parametrize(
     "dtype",
@@ -1043,13 +1027,12 @@ def test_indexer_topk_decode_dist(
     mask_hi = (torch_indices - (row_ends - row_starts)[:, None]) < 0
     torch_indices = torch_indices.masked_fill(~(mask_lo & mask_hi), -1)
 
-    # Tolerance reflects the kernel's histogram precision (full_range/256 is a
-    # safe upper bound across all (T,K) specializations) plus dtype quantization
-    # noise: bf16/fp16 may collapse near-K-th values into ties, causing the
-    # kernel and torch.topk to pick different but equivalent tie members.
-    bin_tolerance = dist_cfg["full_range"] / 256
-    if dtype != torch.float32:
-        bin_tolerance = max(bin_tolerance, abs(dist_cfg["mean"]) * torch.finfo(dtype).eps * 4)
+    # GVR Top-K is an exact algorithm: with same-dtype `logits.topk` as the
+    # reference, the sorted output values must be bit-identical (bf16 -> fp32
+    # promotion inside the kernel is lossless and order-preserving, so the
+    # K-th cutoff is identical in both comparison spaces). Any value gap is
+    # a real kernel bug, not algorithmic noise — keep the default 1e-5
+    # tolerance and let CI surface regressions.
     assert compare_top_k_results(
         logits,
         indices,
@@ -1057,7 +1040,6 @@ def test_indexer_topk_decode_dist(
         row_starts,
         row_ends,
         index_topk,
-        tolerance=bin_tolerance,
     ), (
         f"heuristic indexer_topk_decode mismatch: dist={dist_cfg['dist']}, "
         f"mean={dist_cfg['mean']}, std={dist_cfg['std']}, "

--- a/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
+++ b/tests/unittest/_torch/thop/parallel/test_indexer_topk.py
@@ -98,10 +98,11 @@ def create_random_logits(
     torch.manual_seed(seed)
     num_rows = row_starts.shape[0]
     max_len = int(row_ends.max().item())
-    # Pad to multiple of 4 so stride0 satisfies the float4-alignment requirement
-    # of launchHeuristicTopKDecode (matches TRT-LLM runtime where strides are
-    # always multiples of tokens_per_block >= 64).
-    max_len = (max_len + 3) & ~3
+    # Pad to multiple of 8 so stride0 satisfies the alignment requirement of
+    # launchHeuristicTopKDecode for both fp32 (float4 = 4 elements) and
+    # bf16/fp16 (int4 = 16 B = 8 elements) in multi-row mode (matches TRT-LLM
+    # runtime where strides are always multiples of tokens_per_block >= 64).
+    max_len = (max_len + 7) & ~7
 
     logits = torch.rand(num_rows, max_len, dtype=dtype, device="cuda")
 
@@ -571,10 +572,11 @@ def create_distributed_logits(
     rng = np.random.default_rng(seed)
     num_rows = int(row_starts.shape[0])
     max_len = int(row_ends.cpu().max().item())
-    # Pad to multiple of 4 so stride0 satisfies the float4-alignment requirement
-    # of launchHeuristicTopKDecode (matches TRT-LLM runtime where strides are
-    # always multiples of tokens_per_block >= 64).
-    max_len = (max_len + 3) & ~3
+    # Pad to multiple of 8 so stride0 satisfies the alignment requirement of
+    # launchHeuristicTopKDecode for both fp32 (float4 = 4 elements) and
+    # bf16/fp16 (int4 = 16 B = 8 elements) in multi-row mode (matches TRT-LLM
+    # runtime where strides are always multiples of tokens_per_block >= 64).
+    max_len = (max_len + 7) & ~7
     size = (num_rows, max_len)
 
     dist = cfg["dist"]
@@ -694,6 +696,19 @@ def generate_pre_idx(
     """
     Build the heuristic pre-prediction index tensor for each batch element.
 
+    The V3.2 multi-row kernel (`heuristicTopKMultiRowKernel{,Dtype}` in
+    cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu) internally adds
+    `preIdxOffset = (rowIdx % next_n) + 1` to every pre_idx slot during its
+    Phase-1 stats reduction (heuristic_topk.cuh:654/1209). Production V3.2
+    callers therefore pass pre_idx in PREVIOUS-step coordinates so the
+    kernel's +1 / +2 / +3 shift maps prev positions to current-step
+    positions correctly.
+
+    This test builds pre_idx from `current_logits.topk()`, then applies a
+    `-1` shift before returning, so the kernel's internal `+1` brings every
+    hint back to its intended current-step position (preserves the kernel's
+    argmax invariant: kernel reads `input[(argmax_pos - 1) + 1] = input[argmax_pos]`).
+
     For batch element b (base row = b*next_n):
       - pre_idx[b, 0]       = argmax of the base row  (kernel invariant)
       - n_hit slots          = floor(index_topk * success_ratio) indices drawn
@@ -772,6 +787,12 @@ def generate_pre_idx(
                         :take
                     ].int()
 
+    # V3.2 compensation: kernel adds `(rowIdx % next_n) + 1` to every pre_idx
+    # entry during P1 stats reduction. Shifting by -1 here means that for the
+    # base row (rowIdx % next_n == 0, offset = +1) the kernel reads the exact
+    # current-step positions our `topk()` selected. Negative entries are
+    # silently dropped by the kernel's `idx >= 0 && idx < N` range check.
+    pre_idx -= 1
     return pre_idx
 
 
@@ -944,14 +965,36 @@ def test_cute_dsl_topk_decode_single_pass_multi_cta_cluster(
 @pytest.mark.parametrize("dist_cfg", _DECODE_DIST_CONFIGS, ids=_DECODE_DIST_IDS)
 @pytest.mark.parametrize("batch_size", [1, 64, 128])
 @pytest.mark.parametrize("next_n", [1, 2, 3])
-@pytest.mark.parametrize("index_topk", [2048])
+@pytest.mark.parametrize(
+    "index_topk",
+    [
+        # K=512 / K=1024 hit a known ~0.09 % kernel-side intermittent at the
+        # edge corner (numRows ~= 384, success_ratio in {0.5, 0.9}, mean-zero
+        # distributions). Root cause is in P4's atomic-snap step at small
+        # kNumBins (cpp/tensorrt_llm/kernels/heuristic_topk.cuh
+        # GvrParams<*, 512|1024>); tracked as a kernel-side follow-up. Mark as
+        # flaky with 2 reruns to absorb the noise without widening the
+        # value-comparison tolerance (which would silently mask real
+        # wrong-answer regressions). K=2048 is the production-blessed path,
+        # observed 100 % stable across 6804 cells of local validation.
+        pytest.param(512, marks=pytest.mark.flaky(reruns=2)),
+        pytest.param(1024, marks=pytest.mark.flaky(reruns=2)),
+        2048,
+    ],
+)
 @pytest.mark.parametrize("num_tokens", [8192, 16384])
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.bfloat16, torch.float16],
+    ids=["fp32", "bf16", "fp16"],
+)
 def test_indexer_topk_decode_dist(
-    dist_cfg, batch_size, next_n, index_topk, num_tokens, success_ratio
+    dist_cfg, batch_size, next_n, index_topk, num_tokens, success_ratio, dtype
 ):
     """
     Correctness test for the heuristic indexer_topk_decode across realistic
-    logit distributions, MTP correlation structures, and pre_idx accuracy levels.
+    logit distributions, MTP correlation structures, pre_idx accuracy levels,
+    GVR-supported K values, and supported logit dtypes.
     """
     torch.manual_seed(24)
     torch.cuda.manual_seed(24)
@@ -968,7 +1011,7 @@ def test_indexer_topk_decode_dist(
     row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
 
     # 1. Sample logits from the target distribution
-    logits = create_distributed_logits(dist_cfg, row_starts, row_ends, torch.float32, seed=42)
+    logits = create_distributed_logits(dist_cfg, row_starts, row_ends, dtype, seed=42)
 
     # 2. Apply MTP correlation: consecutive rows share their tail logits
     if next_n > 1:
@@ -985,9 +1028,9 @@ def test_indexer_topk_decode_dist(
         seed=7,
     )
 
-    # 4. Run heuristic CUDA kernel
+    # 4. Run heuristic CUDA kernel — heuristic_scratch dtype must match logits.
     indices = torch.empty((num_gen_tokens, index_topk), dtype=torch.int32, device="cuda")
-    heuristic_scratch = torch.empty(num_gen_tokens * index_topk, dtype=torch.float32, device="cuda")
+    heuristic_scratch = torch.empty(num_gen_tokens * index_topk, dtype=dtype, device="cuda")
     torch.ops.trtllm.indexer_topk_decode(
         logits, seq_lens, indices, next_n, index_topk, pre_idx, heuristic_scratch
     )
@@ -1000,10 +1043,13 @@ def test_indexer_topk_decode_dist(
     mask_hi = (torch_indices - (row_ends - row_starts)[:, None]) < 0
     torch_indices = torch_indices.masked_fill(~(mask_lo & mask_hi), -1)
 
-    # Tolerance reflects the kernel's 256-bin histogram precision:
-    # elements within one bin width (full_range/256) of the K-th boundary are
-    # ambiguous and may be selected or excluded; either is a valid top-K answer.
+    # Tolerance reflects the kernel's histogram precision (full_range/256 is a
+    # safe upper bound across all (T,K) specializations) plus dtype quantization
+    # noise: bf16/fp16 may collapse near-K-th values into ties, causing the
+    # kernel and torch.topk to pick different but equivalent tie members.
     bin_tolerance = dist_cfg["full_range"] / 256
+    if dtype != torch.float32:
+        bin_tolerance = max(bin_tolerance, abs(dist_cfg["mean"]) * torch.finfo(dtype).eps * 4)
     assert compare_top_k_results(
         logits,
         indices,
@@ -1015,5 +1061,5 @@ def test_indexer_topk_decode_dist(
     ), (
         f"heuristic indexer_topk_decode mismatch: dist={dist_cfg['dist']}, "
         f"mean={dist_cfg['mean']}, std={dist_cfg['std']}, "
-        f"next_n={next_n}, success_ratio={success_ratio}"
+        f"next_n={next_n}, success_ratio={success_ratio}, dtype={dtype}"
     )


### PR DESCRIPTION
## Summary

Follow-up to #13477 (Scheme X dispatcher). Extends the GVR (Guess-Verify-Refine) Top-K micro-kernel to:

- **Multi-K**: 512 / 1024 / 2048 (was: 2048 only)
- **Multi-dtype**: fp32 / bf16 / fp16 logits (was: fp32 only)

via a `GvrParams<T, K>` trait class with 9 specializations. K=2048 fp32 production path is byte-identical SASS-wise (V2e LOCK preserved across all 3 production K=2048 kernel variants).

### Commit Breakdown (16 commits)

1. **feat**: Multi-dtype GVR Top-K kernel: fp32/bf16/fp16
2. **feat**: Multi-dtype GVR Top-K dispatcher: bf16/fp16 path
3. **feat**: Multi-K (512/1024/2048) GVR Top-K via `GvrParams` trait class
4. **fix**: Forward `TopK` template arg into `blockFusedSnapIter` helpers
5. **feat**: Relax GVR Top-K caller gate to K ∈ {512, 1024, 2048}
6. **feat**: Per-(T, K) `kNumBins` tuning saves 5-9 % on K=512/1024 cells
7. **feat**: Defer dtype P3 conversion → −6 to −13 % on bf16/fp16 cells
8. **feat**: `kFTarget` retune for V4 M=K (K=512/1024 cells)
9. **feat**: Align standalone `gvrTopKKernel` `launch_bounds` with production
10. **chore**: Strip internal experiment-ID lineage from GVR Top-K comments
11. **chore**: Drop dead `thresholdPos` param + remove internal opt-registry tags
12. **refactor**: Hoist Scheme X bounds + collapse `heuristicTopKDecode` launcher
13. **chore**: Strip residual Opt-M / v0 references from selection-pass comment
14. **feat**: Symmetric Radix / Insertion fallback for indexer Top-K bf16/fp16 path
15. **fix**: GVR Top-K P4 snap-iter convergence + drop test tolerance widening (round-3 review fix)
16. **chore**: GVR Top-K drop dead `blockFusedSnapIterDtype` + clarify `kFTarget` docstring (round-3 review fix)

### Key Files (6 files / +1621 / −355)

| File | Change |
|------|--------|
| `cpp/tensorrt_llm/kernels/heuristic_topk.cuh` | `GvrParams<T,K>` trait class; 9-way template specialization; per-(T,K) `kNumBins` / `kFTarget` tuning; deferred fp32 P3 conversion |
| `cpp/tensorrt_llm/kernels/heuristicTopKDecode.cu` | 3 launcher overloads (fp32/bf16/fp16); `GvrParams`-driven kernel dispatch |
| `cpp/tensorrt_llm/kernels/heuristicTopKDecode.h` | Multi-dtype API surface |
| `cpp/tensorrt_llm/kernels/indexerTopK.cu` | Multi-dtype dispatcher; symmetric Insertion / Radix fallback for bf16/fp16 |
| `cpp/tensorrt_llm/kernels/IndexerTopK.h` | dtype-templated `invokeIndexerTopKDecode` |
| `cpp/tensorrt_llm/thop/IndexerTopKOp.cpp` | Python op auto-routes by `tensor.scalar_type()` |

### API

No public API change. The Python op `torch.ops.trtllm.indexer_topk_decode`
now auto-routes by `logits.scalar_type()` to the matching dispatcher;
bf16/fp16 paths require `pre_idx` and `heuristic_scratch` (matching
dtype). K is selected via the `index_topk` argument as before; values
outside {512, 1024, 2048} fall back to Radix / Insertion.

## Test plan

- [x] **Unit tests** (`pytest tests/unittest/_torch/thop/parallel/test_indexer_topk.py -k test_indexer_topk_decode`):
  - `test_indexer_topk_decode` (5-arg / no `pre_idx`) — fp32 K∈{128, 2048} Radix/Insertion fallback covered (32 cases).
  - `test_indexer_topk_decode_dist` (7-arg / GVR Heuristic, parametrized in this PR over `index_topk × dtype × num_tokens × batch_size × next_n × dist × success_ratio` = 2268 cases) — all 9 new GVR `(T, K)` specializations covered. `num_tokens=16384` cells hit GVR (1134); `num_tokens=8192` cells route through Radix/Insertion fallback via Scheme X dispatcher (`kSeqSmall=12288` gate). **Post round-3 fix** (commit 15): all 2268 cells pass under the strict default tolerance (`1e-5`) — `flaky` markers and the `bin_tolerance` widening are removed; the former 0.09 % K=512 / K=1024 intermittent at `numRows ≈ 384` is fixed by the P4 snap-iter convergence guarantee.
- [x] **Q9 ablation suite** on B200 sm_100 — multi-K × multi-dtype × multi-BS perf characterization with bit-equivalence to `torch.topk` set (9 combos × 9 SWE-Bench-64K layers × 12 BS cells).
- [x] **V2e LOCK SASS byte-identity** verified (production K=2048 path).
- [x] **CUDA Graph capture / replay** safe via the warmup helper introduced in #13477 (no new framework hooks; static caches in dispatcher are dtype-independent).

### V2e LOCK SASS byte-identity (production K=2048)

| Production kernel | md5 baseline / md5 post-PR |
|---|---|
| `heuristicTopKMultiRowKernel<2048>` fp32 | `a9f5c6b8` / `a9f5c6b8` ✅ |
| `heuristicTopKMultiRowKernelDtype<__half, 2048>` | `9caa920c` / `9caa920c` ✅ |
| `heuristicTopKMultiRowKernelDtype<__nv_bfloat16, 2048>` | `aede08cc` / `aede08cc` ✅ |

K=2048 production SASS is byte-identical with pre-PR baseline for all
three dtypes. New K=512 / K=1024 specializations have stable SASS produced
fresh by the `GvrParams<T,K>` template.

### Performance Results (B200 sm_100, SWE-Bench-64K decode logits)

#### BS=1 cross-layer pooled (Q9d 04b — 9 layers × 9 GVR combos vs Radix fp32 K=2048 baseline, **production path**)

Routed through `torch.ops.trtllm.indexer_topk_decode` (Scheme X v1.2 dispatcher
→ `heuristicTopKMultiRowKernel{,Dtype}<TopK>` with `preIdxOffset=+1`, V3.2
decode semantics). 1 827 timed rows / variant (9 layers × stride-10 over rows
1..2024), 5 reps + 3 warmup, 128 MiB L2 flush before every launch.

| Variant                       | Latency (µs) | Speedup vs Radix |
|-------------------------------|-------------:|-----------------:|
| Radix fp32 K=2048 (baseline)  |        50.98 |            1.00× |
| K=512  fp32                   |        20.16 |            2.53× |
| K=512  bf16                   |        17.15 |        **2.97×** |
| K=512  fp16                   |        18.02 |            2.83× |
| K=1024 fp32                   |        22.85 |            2.23× |
| K=1024 bf16                   |        19.26 |            2.65× |
| K=1024 fp16                   |        18.82 |            2.71× |
| K=2048 fp32                   |        26.27 |            1.94× |
| K=2048 bf16                   |        21.15 |            2.41× |
| K=2048 fp16                   |        21.25 |            2.40× |

GVR wins **all 9 combos × 9 layers**. K↓ and dtype↓ are both monotonic
(smaller K = smaller smem residency / higher occupancy; smaller dtype =
smaller HBM-load + smem footprint). Cross-validates the BS=1 column of
Table 2 (Q9e 05) within ±10 % wall — both tables are now production path.

#### BS scaling — pooled across 9 layers, last row replicated (Q9e 05, production path)

Speedup vs Radix fp32 K=2048 baseline (50.1 µs at BS=1 → 93.5 µs at BS=400):

| Variant       |  BS=1 |  BS=8 | BS=32 | BS=128 | BS=200 | BS=256 | BS=400 |
|---------------|------:|------:|------:|-------:|-------:|-------:|-------:|
| K=2048 fp32   | 1.82× | 1.85× | 1.82× |  1.71× |  1.74× |  1.46× |  1.28× |
| K=2048 bf16   | 2.22× | 2.28× | 2.28× |  2.20× |  2.31× |  2.08× |  2.09× |
| K=2048 fp16   | 2.13× | 2.21× | 2.19× |  2.13× |  2.22× |  2.07× |  2.05× |
| K=1024 bf16   | 2.30× | 2.37× | 2.33× |  2.30× |  2.38× |  2.24× |  2.24× |
| K=512  bf16   | 2.62× | 2.70× | 2.67× |  2.54× |  2.55× |  2.34× |  2.29× |

bf16 / fp16 maintain **2.0 – 2.3× speedup** across the full BS range
(1 .. 400). fp32 fades from 1.85× to 1.28× as BS grows past 200 (smem
residency tightens). Half-precision dtypes scale gracefully because
their lower smem footprint preserves occupancy beyond 1 wave.

#### Reproducibility

- BS=1 (Q9d 04b, production path): single-GPU nsys, ~3 min wall, 91 350 NVTX-tagged launches.
- BS scaling (Q9e): single-GPU nsys, ~3 min wall, 5 400 NVTX-tagged
  launches (9 GVR combos × 12 BS × 9 layers × 5 reps).
- All variants use 128 MiB L2 flush before every launch (cold-cache).

### Round-3 review fixes (commit 15)

Addresses lfr-0531 and mingyangHao review comments on the 0.09 %
intermittent at K=512 / K=1024:

- **Kernel** (`cpp/tensorrt_llm/kernels/heuristic_topk.cuh`): P4 snap
  loop's `snap_limit = cand_count/4` was insufficient for cells where
  the initial bin-edge threshold sits far from the true K-th value. Bug:
  on `cgt >= kK` non-convergence, Pass 1 emitted K elements in scan
  order from the `cgt > kK` strictly-greater set, missing some true
  top-K members. Fix: tighten `snap_limit = cand_count`, which is the
  provably-sufficient bound (each snap iter strictly decreases `cgt` or
  strictly increases `cge` by ≥ 1, so worst-case convergence takes
  `cand_count − kK + 1` iters). Common path still breaks early at iter
  1–3, so steady-state perf is unchanged.
- **Test** (`tests/unittest/_torch/thop/parallel/test_indexer_topk.py`):
  remove `pytest.mark.flaky(reruns=2)` markers on K=512 / K=1024; drop
  the `full_range/256` bin-quantized tolerance and the unsound
  `|mean| * eps * 4` bf16/fp16 branch (bf16 → fp32 promotion inside the
  kernel is bit-exact and order-preserving, so no eps slack is
  warranted); restore `compare_top_k_results` default
  `tolerance = 1e-5`.

Additional cleanup in commit **4880bb600e** (chore, no live SASS impact):
- Removed dead `blockFusedSnapIterDtype` helper (-64 lines) and stale doc paragraphs — the dtype P4 snap path uses the fp32 `blockFusedSnapIter<TopK>` directly after commit 7's deferred-conversion optimization stored smem `keys[]` as fp32.
- Expanded the `kFTarget` docstring to call out that the value is the secant solver's *soft steering target* (not the convergence condition), and that `kFTarget < kK` is intentional for small K — addresses the line-215 review question.

Local validation on B200 sm_100 with the fix + strict default
tolerance:

| Scope                                                  | Cells | Result      | Wall  |
|--------------------------------------------------------|------:|------------:|------:|
| K=512 + K=1024 (all dist / dtype / BS / next_n / ratio)|  1512 |   1512/1512 | 137 s |
| K=2048 (same axes)                                     |   756 |    756/756  |  70 s |
| Stress: 5× focused corner (logistic m0.47, BS=128,     |  5×36 |    180/180  | ~5 min|
|   next_n=3 → numRows=384)                              |       |             |       |

0 failures across **2484 invocations** under default strict tolerance.
The former 0.09 % intermittent corner is now stable.

## Risks

- **Smem ceiling at K=2048 + fp32 + BS=200..256**: the K=512 fp32 path
  shows an anomalous BS=200→256 latency spike (29 → 77 µs).
  Production deployment is bounded by Scheme X dispatcher (`kBsLarge`
  derived from L2 capacity), so the cliff is **not reached** in
  serving traffic — but flagged for follow-up perf work.
- **bf16 / fp16 path is decode-only**: bf16 / fp16 prefill has not been
  added in this PR. Prefill remains fp32-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for bfloat16 and float16 data types in TopK decoding operations (previously fp32-only)
  * Extended topK parameter support to values of 512, 1024, and 2048
  * Introduced utility function to determine GVR heuristic optimization eligibility

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/13948)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

