### PR TITLE
[None][fix] Workaround: TLLM_DISABLE_HF_PREFETCH to skip HF page-cache warmup on GB200

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -83,7 +83,19 @@ class HfWeightLoader(BaseWeightLoader):
             # If the layer number is overridden, it indicates that only a subset of layers are loaded.
             # Prefetching all layers is unnecessary.
             num_layers = int(os.environ.get("TLLM_OVERRIDE_LAYER_NUM", "0"))
-            enable_prefetch = (prefetch_size
+            # On platforms with NVLink-C2C unified-memory addressing (e.g.,
+            # GB200), `_prefetch_one_file`'s `f.read()` populates the OS page
+            # cache with safetensors content; those host pages can then be
+            # counted toward `cuda.mem_get_info()` GPU usage non-deterministically
+            # per rank. Downstream KV-cache budgeting (which is sized as a
+            # fraction of free GPU memory) underestimates the available budget
+            # asymmetrically across ranks, leading to `cuMemCreate` OOM at KV
+            # cache init even when the actual GPU memory is plentiful. The
+            # `TLLM_DISABLE_HF_PREFETCH=1` env var lets users opt out of the
+            # page-cache warmup on those platforms.
+            disable_prefetch = os.environ.get("TLLM_DISABLE_HF_PREFETCH",
+                                              "0") == "1"
+            enable_prefetch = (not disable_prefetch and prefetch_size
                                < self._get_local_available_host_memory() * 0.9
                                and num_layers == 0)
             if enable_prefetch:


### PR DESCRIPTION
## Description

**This is a workaround, not a root fix.** It papers over a CUDA-driver / NVLink-C2C accounting issue at the application level, by giving users an env-var to opt out of an optimization that backfires on GB200.

### The problem

`HfWeightLoader.prefetch_files()` (`tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py`) calls `f.read()` on each safetensors file to populate the OS page cache so that the subsequent `safetensors.torch.load_file` runs faster. This is a host-side optimization with no intentional GPU side-effects.

On GB200 with NVLink-C2C unified-memory addressing, those host page-cache pages **are counted toward `cuda.mem_get_info()` GPU usage by the driver**, non-deterministically across ranks. Why "non-deterministic" — the attribution depends on which CPU socket cached the page first and how the driver decides which device's accounting bucket to charge for a unified-memory page; we observed the same code path producing wildly different per-rank outcomes from one launch to the next.

Downstream, `KVCacheManagerV2` budgets the KV slab as
```python
free_mem, _ = cuda.mem_get_info()
max_memory = kv_cache_free_gpu_memory_fraction * free_mem
```
with e.g. `kv_cache_free_gpu_memory_fraction=0.85`. The asymmetric "used GPU memory" inflation causes some ranks to under-budget. `cuMemCreate(CU_MEM_ALLOCATION_TYPE_PINNED)` then refuses the slab on the lowest-`free_mem` rank → `CuOOMError` at KV cache init even when the actual GPU memory is plentiful.

### Solid evidence

DSv4-Pro TEP8 (`tp=8`, `ep=8`, `attn_dp=false`), 8 GPUs across 2 GB200 nodes, `kv_cache_free_gpu_memory_fraction=0.85`. Instrumented `HfWeightLoader.load_weights` to log per-rank `outside_pytorch_GPU = (total - free) - torch.cuda.memory_reserved()` at 4 phases: `pre-prefetch_files`, `post-prefetch_files-pre-barrier`, `post-prefetch_files-post-barrier`, `post-load_weights_in_parallel`.

**Without the env var (broken)**:

| Rank | pre-prefetch | post-prefetch (pre-barrier) | post-prefetch (post-barrier) | post-load_weights |
|------|--------------|------------------------------|------------------------------|-------------------|
| R0   | 2.59         | **40.23**                    | 40.23                        | 40.21             |
| R1   | 1.85         | **32.82**                    | 28.93                        | 26.39             |
| R2   | 1.85         | **44.33**                    | 42.95                        | 41.83             |
| R3   | 1.85         | **42.76**                    | 42.76                        | 41.95             |
| R4   | 1.85         | **38.41**                    | 38.41                        | 38.37             |
| R5   | 1.85         | 1.85                         | 1.85                         | 1.85              |
| R6   | 1.85         | 2.95                         | 2.91                         | 2.88              |
| R7   | 1.85         | **43.74**                    | 43.67                        | 41.72             |

*Values are GiB outside-PyTorch GPU memory. The 30-44 GiB jump appears AT prefetch_files() — before any actual weight load. The `safetensors.torch.load_file` call (between post-prefetch and post-load_weights) does not add memory; for some ranks it slightly decreases (R1: 32.82 → 26.39).*

Result: `cuMemCreate` OOM during `KVCacheManagerV2.__init__` on the rank with the smallest computed budget.

**With `TLLM_DISABLE_HF_PREFETCH=1` (this PR)**:

| Rank | pre-prefetch | post-prefetch (pre-barrier) | post-prefetch (post-barrier) | post-load_weights |
|------|--------------|------------------------------|------------------------------|-------------------|
| R0   | 2.60         | 2.60                         | 2.60                         | 2.60              |
| R1   | 1.85         | 1.85                         | 1.85                         | 1.85              |
| R2-7 | 1.85         | 1.85                         | 1.85                         | 1.85              |

Downstream `[MemDump]` at `warmup-start` shows free GPU in [42.30, 43.04] GiB across all 8 ranks (0.75 GiB cross-rank spread vs prior 50 GiB spread). KV cache init succeeds at fraction=0.85 with no OOM and no fragmentation margin.

### Hypotheses ruled out by bisection

1. `use_cute_dsl_blockscaling_bmm` autotuner workspace fragmentation — `MemDump` deltas across warmup phases were uniform, ruling out workspace asymmetry.
2. MNNVL allreduce strategy — A/B test with `TLLM_ALLREDUCE_STRATEGY=NCCL` only reduced spread 44→39 GiB, not the cause.
3. Stale `free_mem` budget computation — `KVCacheManagerV2.__init__` already does `allreduce(MIN)` on `max_tokens`; the per-rank coordination is correct.
4. Python-side leaks in `ModelLoader.load()` — `del weights; gc.collect(); torch.cuda.empty_cache()` after `_call_load_weights` freed only ~2 GiB; spread persisted at 45 GiB. The memory is held outside Python GC scope (OS page cache).

### Why this is a workaround, not a root fix

A true root fix would need one of:
- **CUDA driver behavior change**: don't count generic OS page-cache pages toward GPU `mem_get_info()` on NVLink-C2C platforms (unless they're explicitly registered or pinned for GPU access).
- **Kernel/OS change**: separate accounting for host-pages-touched-by-GPU vs host-pages-cached-from-disk-IO.
- **Application redesign**: detect GB200, use a different prefetch mechanism (e.g., `posix_fadvise(POSIX_FADV_WILLNEED)`) that warms cache without populating actual memory.

None of these are appropriate for this single-line application-side fix. Filing this as a workaround so users hitting the OOM today have a recovery path; flagging the underlying issue for whoever owns the GB200 unified-memory accounting story.

## Test Coverage

- [x] Verified on DSv4-Pro TEP8 across 2 GB200 nodes (jobs 1728562 / 1728652) — see evidence tables above.
- [ ] No new unit tests added — the env-var gate is a one-line behavior toggle and the existing prefetch path is exercised by current integration coverage. ~~Adding a unit test would require a multi-rank GB200 fixture, which is not in the unit-test infrastructure.~~

## PR Checklist

- [x] I have read the [contributing guidelines](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CONTRIBUTING.md)
- [x] My code follows the [code style](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) of this project
- [x] I have made corresponding changes to the documentation (n/a — env var documented in code comment)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (manual evidence above; no automated test feasible)
- [x] New and existing unit tests pass locally with my changes
- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot help` for usage.