### PR TITLE
[None][fix] Gate cudaProfilerStart/Stop on iter_counter, not loop counter

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -944,13 +944,15 @@ class PyExecutor:
         def profile_step():
             nonlocal it, enabled, start_time, start_event_1, end_event_1, start_event_2, end_event_2, prev_device_step_time
             calibrator.post_step(it)
-            if it in self.profile_stop_iters and not self.is_warmup:
+            if (self.iter_counter in self.profile_stop_iters
+                    and not self.is_warmup):
                 assert enabled, "Inconsistent CUDA profiling state"
                 if enable_torch_trace:
                     torch_profiler.stop()
                     torch_profiler.export_chrome_trace(torch_trace_path)
-                    logger.info(f"Profiling stopped at iteration {it}, "
-                                f"trace saved to {torch_trace_path}")
+                    logger.info(
+                        f"Profiling stopped at iteration {self.iter_counter}, "
+                        f"trace saved to {torch_trace_path}")
                 torch.cuda.cudart().cudaProfilerStop()
                 calibrator.stop()
                 enabled = False
@@ -992,13 +994,15 @@ class PyExecutor:
 
             it += 1
 
-            if it in self.profile_start_iters and not self.is_warmup:
+            if (self.iter_counter in self.profile_start_iters
+                    and not self.is_warmup):
                 assert not enabled, "Inconsistent CUDA profiling state"
                 calibrator.start()
                 torch.cuda.cudart().cudaProfilerStart()
                 if enable_torch_trace:
                     torch_profiler.start()
-                logger.info(f"Profiling started at iteration {it}.")
+                logger.info(
+                    f"Profiling started at iteration {self.iter_counter}.")
                 enabled = True
             calibrator.pre_step(it)
             start_time = time.time()


### PR DESCRIPTION
## Summary

Cherry-pick of #13744 onto `feat/deepseek_v4`.

## Description

The local `it` variable inside `profile_step()` (`py_executor.py`) increments on every call to `profile_step()` — which includes worker-loop iterations that perform no actual forward pass (e.g. disagg gen workers spinning while waiting for KV transfer to complete from the ctx side).

The user-facing iter log line and `self.iter_counter` only advance when a real forward pass executes, so `it` and `self.iter_counter` diverge dramatically during gen-side startup. With the existing gating on `it`, `cudaProfilerStart` fires after N idle spins (where N happens to land on `profile_start_iters`) — long before any benchmark request reaches the gen worker. The captured nsys trace then contains only empty loop iterations: no kernel events, no GPU activity. The user-visible "Profiling started at iteration 5" message is misleading because it's logged with `it`, not the real iter the user asked for via `TLLM_PROFILE_START_STOP`.

This switches the profile-start/stop gating (and the log lines) to `self.iter_counter`, which matches the iter semantics used in the per-iter log and in `iter_stats.iter`. After the fix, `cudaProfilerStart` fires when the real benchmark iter reaches the configured range, and the captured nsys trace contains the intended decode kernels.

## Test Coverage

Reproduced the bug and verified the fix on the disagg gen-server path:

- DSv4-Pro 8k/1k DEP16 conc=1024 b=64 with \`TLLM_PROFILE_START_STOP=5-15\` on the gen worker.
- Before: gen \`nsys_worker_proc_GEN_0_*.nsys-rep\` files ~0.6 MB each, no CUDA kernel rows. Log shows \`Profiling started at iteration 5\` while \`iter = 0\` is logged repeatedly throughout the run.
- After: kernels captured during configured iter range. \`Profiling started/stopped at iteration N\` log lines now match \`self.iter_counter\`.

## PR Checklist

- [x] I have read the [contributing guidelines](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CONTRIBUTING.md).
- [x] My change is appropriately scoped (single-file change, surgical fix).
- [ ] New tests cover this code path. *(Existing profile-gating logic has no unit-test harness; manual repro on a multi-node cluster is the standard verification path.)*
- [x] Pre-commit hooks pass.