### PR TITLE
[None][perf] Workaround: route DSv4-Pro hidden=7168 eager-cache-miss fallback to FMA to fit the bench within wall budget

### DIFF
--- a/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
+++ b/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
@@ -762,11 +762,31 @@ def _alloc_fused_hc_outputs(
 _FUSED_HC_FALLBACK_TACTIC_MMA = ("fused_half_mma", 0, 0, 0, 1)
 _FUSED_HC_FALLBACK_TACTIC_FMA = ("fused_half_fma", 2, 1, 256, 1)
 
+# Hidden sizes for which the half-fused tcgen05 MMA path makes DSv4-Pro
+# bench warmup exceed practical wall budgets (25-40 min SLURM walls hit
+# TIME LIMIT before iterations begin). Observed on hidden=7168.
+#
+# The kernel itself completes correctly per call (verified via OpTrace
+# inside the failing bench: 9260+ mhc_fused_hc calls per rank in 10 min,
+# including the supposedly-bad ('fused_half_mma', 0, 16, 512, 1) tactic at
+# M=320 in sub-ms steady state). What appears to be a hang is in fact the
+# cumulative cost of (autotuner profiling × all M-buckets × all ops) +
+# cudagraph capture for ~15 batch sizes — slower with MMA tactics cached
+# in than with FMA. The FMA fallback fits the bench within 20-25 min;
+# the MMA fallback consistently times out at 40 min.
+#
+# This is a perf workaround, not a kernel fix. The autotuner-cached tactics
+# for inference-time shapes are unaffected; only the rare eager-mode
+# cache-miss fallback is routed to FMA here.
+_FUSED_HC_MMA_FALLBACK_BLOCKED_HIDDEN_SIZES = {7168}
+
 
 def _get_fused_hc_fallback_tactic(hidden_size: int | None = None):
     mma_ok = _fused_hc_mma_supported()
     if hidden_size is not None:
         mma_ok = mma_ok and hidden_size in _FUSED_HC_MMA_SUPPORTED_HIDDEN_SIZES
+        if hidden_size in _FUSED_HC_MMA_FALLBACK_BLOCKED_HIDDEN_SIZES:
+            mma_ok = False
     return _FUSED_HC_FALLBACK_TACTIC_MMA if mma_ok else _FUSED_HC_FALLBACK_TACTIC_FMA
 
 


### PR DESCRIPTION
## Description

**This is a perf workaround for a slow warmup path, not a fix for a kernel hang.** Earlier revisions of this PR framed it as a fix for a `mhc_fused_hc` kernel hang at hidden=7168, M=1, eager mode. Subsequent isolation work (summarized below) **disproved the kernel-hang hypothesis**: `mhc_fused_hc` runs correctly even with the MMA fallback. What it does instead is make the cumulative bench warmup wall (general warmup + autotuner warmup + cudagraph capture for ~13 M-buckets) large enough that a 25-40 min SLURM wall hits TIME LIMIT before any actual benchmark iterations start. Routing the eager-mode cache-miss fallback to FMA on the affected hidden sizes cuts that warmup wall enough to let the bench finish on the same hardware/budget.

### The problem (bench-level)

On DSv4-Pro TEP8 with `hidden_size=7168`, kicking off the bench with the default MMA fallback (`_FUSED_HC_FALLBACK_TACTIC_MMA = ("fused_half_mma", 0, 0, 0, 1)`) leaves the bench in a silent state for the rest of the wall:

```
[AutoTuner] trtllm::mhc_fused_hc using the fallback tactic, due to cache miss on input shapes=
  (torch.Size([1, 7168]), torch.Size([1, 4, 7168]), torch.Size([1, 4]),
   torch.Size([1, 4, 4]), torch.Size([24, 28672]), torch.Size([3]), torch.Size([24]))
srun: Job step aborted: Waiting up to 122 seconds for job step to finish.
*** STEP ... CANCELLED ... DUE TO TIME LIMIT ***
```

Definitively reproduced today on a 40-min wall (job 1733981): same signature, same 35-min silence after the `mhc_fused_hc` fallback warning, same TIME LIMIT. The previous workaround `TRTLLM_MHC_ENABLE_FUSED_HC=0` disabled fused HC entirely.

### Bench-level bisection

DSv4-Pro TEP8, GB200, 2 nodes × 4 GPU, ISL=8192/OSL=1024, conc=128, kv=0.85, fused HC ENABLED:

| Fallback tactic for hidden=7168 | Wall | Result |
|---|---|---|
| `("fused_half_mma", 0, 0, 0, 1)` (heuristic-default) | 40 min | TIME LIMIT (job 1733981) |
| `("fused_half_mma", 0, 1, 256, 1)` (explicit ks=1, bs=256) | 25 min | TIME LIMIT (earlier verification) |
| **`("fused_half_fma", 2, 1, 256, 1)` (this PR)** | 25 min | **complete, 1704.18 sys tok/s** |

FMA fallback consistently fits within practical wall budgets; MMA fallback doesn't.

### Kernel itself is NOT buggy (corrected diagnosis)

A single-rank standalone repro of `MhcFusedHcRunner.forward(...)` at the same shape and same tactic completes in milliseconds — including 50-iter loops, PDL on/off, multi-rank NCCL state, and 8-rank MNNVL state. Per-tactic autotuner profiling of `mhc_fused_hc` across all M-buckets completes in 1.55s total. None of these reproduce a hang.

Instrumenting `mhc_fused_hc` with `[OpTrace]` markers inside the failing bench config (with MMA fallback forced) showed **9260+ successful `mhc_fused_hc` calls per rank** in 10 minutes — including 800+ calls at M=320 with the exact `('fused_half_mma', 0, 16, 512, 1)` tactic we previously accused of hanging. The kernel returns in sub-ms steady state.

So there's no kernel hang. The bench's silent gap after the `mhc_fused_hc` warning is the rest of warmup (autotuner across all M-buckets × all ops, then cudagraph capture for ~15 batch sizes) proceeding slowly enough that the SLURM wall runs out before bench iterations begin. With MMA tactics cached into the warmup graphs the cumulative wall exceeds 40 min; with FMA tactics it fits in ~20 min.

#### Standalone confirmations (kernel is not the hang)

| Case | Result |
|---|---|
| 1-rank `MhcFusedHcRunner.forward(tactic=fused_half_mma 0/0/0/1)` at M=1 hidden=7168 | OK 6.6ms |
| Same, 50 iterations | OK |
| Same, PDL on/off | OK |
| 8-rank, NCCL init / allreduce | OK |
| 8-rank, TRT-LLM MNNVL AllReduce (bench's actual AR strategy) | OK |
| Autotuner `choose_one` for `mhc_fused_hc` at M=1 hidden=7168 (706 tactic profiles) | 1.55s total, no outliers |
| OpTrace in bench: `mhc_fused_hc` calls observed | 9260+ per rank in 10 min |

### The fix

Add `_FUSED_HC_MMA_FALLBACK_BLOCKED_HIDDEN_SIZES = {7168}` and route those hidden sizes to the FMA fallback in `_get_fused_hc_fallback_tactic`. Autotuner-selected tactics for cached shapes (the steady-state path) are unaffected — only the rare eager cache-miss fallback uses FMA.

```python
_FUSED_HC_MMA_FALLBACK_BLOCKED_HIDDEN_SIZES = {7168}

def _get_fused_hc_fallback_tactic(hidden_size: int | None = None):
    mma_ok = _fused_hc_mma_supported()
    if hidden_size is not None:
        mma_ok = mma_ok and hidden_size in _FUSED_HC_MMA_SUPPORTED_HIDDEN_SIZES
        if hidden_size in _FUSED_HC_MMA_FALLBACK_BLOCKED_HIDDEN_SIZES:
            mma_ok = False
    return _FUSED_HC_FALLBACK_TACTIC_MMA if mma_ok else _FUSED_HC_FALLBACK_TACTIC_FMA
```

With this in place, `TRTLLM_MHC_ENABLE_FUSED_HC=0` is no longer required for DSv4-Pro benchmarking, and the bench fits the wall budget.

### What this PR is NOT

- It is not a fix for a hung kernel. The kernel runs fine.
- It is not a permanent solution. The right fix is to identify which downstream consumer of the cached MMA tactic balloons the warmup wall (autotuner across more shapes? cudagraph capture with tcgen05 barriers? something MoE-adjacent?) and fix that instead.
- It is not load-bearing on autotuner-cached tactic selection. The autotuner is free to pick MMA tactics for cached shapes, and indeed picks them at M ≥ 48 in our measurements. Only the eager-mode cache-miss path uses the fallback.

### Open question for upstream

Why does the MMA cache-miss fallback path cause a > 30-min warmup cumulative cost when the kernel itself completes in sub-ms? Candidate culprits we haven't bisected:

- Autotuner profiles many additional MMA-tactic combinations across M-buckets after the cache-miss warning, and tcgen05 setup amortizes poorly across captures.
- CUDA-graph capture of `fused_half_mma`-tactic kernels has higher per-graph cost than `fused_half_fma`-tactic kernels.
- A specific shape/tactic combo enters a slow path that the autotuner eventually rejects (e.g. the `mxe4m3_mxe2m1_block_scale_moe_runner` "No valid runner/tactic was found" warning appears 3 min after the mhc_fused_hc cache-miss in our instrumented runs).

If an upstream kernel/autotuner owner has insight here we'd happily replace this workaround with a real fix.

## Test Coverage

- [x] Verified on DSv4-Pro TEP8 across 2 GB200 nodes: bench completes at 1704.18 sys tok/s with fused HC ON and this workaround in place.
- [x] Standalone single-rank repros: kernel completes in 6.6ms for the supposedly-hanging tactic at the supposedly-hanging shape.
- [x] 8-rank multi-node repros (NCCL and TRT-LLM MNNVL): kernel completes cleanly.
- [x] OpTrace inside the bench: 9260+ kernel calls per rank in 10 min with MMA fallback forced.
- [x] Definitive 40-min MMA-fallback bench (job 1733981): TIME LIMIT confirmed, matches the original signature.
- [ ] No new unit tests added — there is no kernel-level failure to assert on. A unit test that captures the bench-level slowdown would need to replicate the full warmup graph (autotuner, cudagraph capture across all M-buckets), which is out of scope for unit testing.

## PR Checklist

- [x] I have read the [contributing guidelines](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CONTRIBUTING.md)
- [x] My code follows the [code style](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) of this project
- [x] I have made corresponding changes to the documentation (n/a — internal Python comment documents the workaround)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (bench-level evidence + extensive isolation table above)
- [x] New and existing unit tests pass locally with my changes
- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

`/bot help` for usage.