### PR TITLE
[None][fix] Restore overlap headroom in seq slot pool sizing

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1180,7 +1180,13 @@ def create_py_executor_instance(
 
     spec_config = model_engine.spec_config
 
-    max_num_sequences = max_batch_size * mapping.pp_size
+    # Slot pool needs headroom for two iterations under overlap (prev-iter
+    # finished requests still hold slots when next-iter prepare_resources runs).
+    if mapping.has_pp():
+        num_micro_batches = mapping.pp_size
+    else:
+        num_micro_batches = 1 if llm_args.disable_overlap_scheduler else 2
+    max_num_sequences = max_batch_size * num_micro_batches
 
     logger.info(
         f"max_seq_len={max_seq_len}, max_num_requests={max_num_sequences}, max_num_tokens={max_num_tokens}, max_batch_size={max_batch_size}"
@@ -1353,7 +1359,8 @@ def create_py_executor_instance(
 
     # When scheduler_capacity == 1, attention dp dummy request will prevent the scheduling of DISAGG_GENERATION_INIT.
     # Enlarge scheduler capacity to avoid DISAGG_GENERATION_INIT stuck in the scheduler.
-    scheduler_capacity = max_num_sequences
+    # V1 scheduler handles overlap via two_step_lookahead, so skip the slot-pool overlap factor here.
+    scheduler_capacity = max_batch_size * mapping.pp_size
     if scheduler_capacity == 1 and mapping.enable_attention_dp and kv_cache_manager:
         scheduler_capacity += 1
 
@@ -1469,7 +1476,12 @@ def create_torch_sampler_args(
     disable_flashinfer_sampling: bool,
     enable_async_worker: bool,
 ):
-    max_num_sequences = max_batch_size * mapping.pp_size
+    # Must match create_py_executor_instance's slot-pool sizing.
+    if mapping.has_pp():
+        num_micro_batches = mapping.pp_size
+    else:
+        num_micro_batches = 1 if disable_overlap_scheduler else 2
+    max_num_sequences = max_batch_size * num_micro_batches
     max_draft_len = (0 if speculative_config is None else
                      speculative_config.max_draft_len)
     max_total_draft_tokens = (0 if speculative_config is None else

--- a/tests/unittest/_torch/executor/test_resource_manager.py
+++ b/tests/unittest/_torch/executor/test_resource_manager.py
@@ -913,5 +913,38 @@ class TestResourceManager(unittest.TestCase):
         self.assertTrue(peft_cache_manager.impl.enabled)
 
 
+def test_torch_sampler_args_overlap_doubles_slot_pool():
+    """Regression: under overlap + PP=1 the slot pool must be 2 * max_batch_size
+    so finished previous-iter requests holding slots cannot starve the next
+    iter's prepare_resources (nvbugs/disagg + max_batch_size=2 + ADP)."""
+    from tensorrt_llm._torch.pyexecutor._util import create_torch_sampler_args
+
+    mapping = Mapping(world_size=1, tp_size=1, pp_size=1)
+
+    overlap_args = create_torch_sampler_args(
+        mapping,
+        max_seq_len=64,
+        max_batch_size=2,
+        speculative_config=None,
+        max_beam_width=1,
+        disable_overlap_scheduler=False,
+        disable_flashinfer_sampling=False,
+        enable_async_worker=False,
+    )
+    assert overlap_args.max_num_sequences == 4
+
+    no_overlap_args = create_torch_sampler_args(
+        mapping,
+        max_seq_len=64,
+        max_batch_size=2,
+        speculative_config=None,
+        max_beam_width=1,
+        disable_overlap_scheduler=True,
+        disable_flashinfer_sampling=False,
+        enable_async_worker=False,
+    )
+    assert no_overlap_args.max_num_sequences == 2
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
