### PR TITLE
[None][fix] Treat missing layer in offline EPLB initial_global_assignments as non-fatal

### DIFF
--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -549,14 +549,28 @@ class MoeLoadBalancerConfig(StrictBaseModel):
             self, layer_idx: int) -> Optional[List[int]]:
         """
         Retrieves the initial global assignments for a specific layer.
+
+        Returns None when no assignments file was provided, or when the
+        provided file does not contain an entry for ``layer_idx``. The
+        missing-layer case is treated as advisory (warn and fall back to
+        auto-derived assignments) instead of fatal, because offline EPLB
+        dumps are typically produced from a base-model trace and do not
+        cover dynamically added layers such as MTP / speculative-decoding
+        decoder layers (e.g. ``layer_idx == num_hidden_layers``).
         """
         if self.initial_global_assignments is None:
             return None
 
         if layer_idx not in self.initial_global_assignments:
-            raise KeyError(
-                f"layer_idx {layer_idx} not found in `initial_global_assignments`."
-            )
+            logger.warning(
+                f"layer_idx {layer_idx} not found in `initial_global_assignments` "
+                f"(file covers layers "
+                f"{min(self.initial_global_assignments)}.."
+                f"{max(self.initial_global_assignments)}); "
+                f"falling back to auto-derived assignments for this layer. "
+                f"This is expected for MTP / speculative-decoding layers "
+                f"appended after the base model.")
+            return None
 
         assignments = self.initial_global_assignments[layer_idx]
 

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -34,7 +34,8 @@ from tensorrt_llm.llmapi.llm_args import (BaseLlmArgs, CacheTransceiverConfig,
                                           ExecutorMemoryType,
                                           ExtendedRuntimePerfKnobConfig,
                                           KvCacheConfig,
-                                          LookaheadDecodingConfig, MoeConfig,
+                                          LookaheadDecodingConfig,
+                                          MoeLoadBalancerConfig, MoeConfig,
                                           PeftCacheConfig, PybindMirror,
                                           RayPlacementConfig, SleepConfig,
                                           SpeculativeConfig, StrictBaseModel,
@@ -774,6 +775,33 @@ class TestTorchLlmArgs:
         with pytest.raises(ValueError):
             args = TorchLlmArgs(model=llama_model_path)
             args.invalid_arg = 1
+
+    @print_traceback_on_error
+    def test_moe_load_balancer_missing_layer_returns_none(self):
+        # `initial_global_assignments` files are usually dumped from a
+        # base-model trace and do not contain entries for dynamically
+        # appended layers (MTP, speculative-decoding decoder layers).
+        # `get_layer_initial_global_assignments` should warn and return None
+        # for those layers instead of raising KeyError, so that callers can
+        # fall back to auto-derived assignments.
+        num_slots = 4
+        cfg = MoeLoadBalancerConfig(
+            num_slots=num_slots,
+            initial_global_assignments={
+                0: [0, 1, 2, 3],
+                1: [3, 2, 1, 0],
+            },
+        )
+        cfg.setup(ep_rank=0, ep_size=1)
+        # Present layer: returns the recorded list.
+        assert cfg.get_layer_initial_global_assignments(0) == [0, 1, 2, 3]
+        # Missing layer (e.g. MTP at layer_idx == num_hidden_layers):
+        # returns None instead of raising KeyError.
+        assert cfg.get_layer_initial_global_assignments(99) is None
+        # No file at all: returns None for any layer.
+        cfg_none = MoeLoadBalancerConfig(num_slots=num_slots)
+        cfg_none.setup(ep_rank=0, ep_size=1)
+        assert cfg_none.get_layer_initial_global_assignments(0) is None
 
     def test_speculative_model_alias(self):
         spec_config = EagleDecodingConfig(


### PR DESCRIPTION
## Summary

Offline EPLB dumps (the file pointed to by `moe_config.load_balancer`) are typically produced from a base-model trace and only cover layers `0..num_hidden_layers-1`. When MTP / speculative-decoding is enabled, the model appends extra decoder layers at `layer_idx == num_hidden_layers`. The current strict lookup in `MoeLoadBalancerConfig.get_layer_initial_global_assignments` then raises:

```
KeyError: 'layer_idx 61 not found in `initial_global_assignments`.'
```

…and the executor worker dies during model init. Concretely, on a DeepSeek-V4-Pro disagg + MTP-1 run on GB300 (`num_hidden_layers=61`), the MTP layer at `layer_idx=61` is not in the dumped file (which only has keys `0..60`), and the run never reaches benchmarking.

Stack (from `modeling_speculative.py:829` → `mtp_layer(model_config, layer_idx + start_layer_idx, …)`):
```
modeling_speculative.py:829   mtp_layer(model_config, layer_idx + start_layer_idx, ...)
modeling_deepseekv4.py:2100   super().__init__(...)
modeling_deepseekv4.py:1744   self.mlp = DeepseekV4MoE(...)
modeling_deepseekv4.py:1428   self.experts = create_moe(...)
fused_moe/create_moe.py:402   ConfigurableMoE(...)
fused_moe/configurable_moe.py:146   super().__init__(...)
fused_moe/interface.py:302    self._init_load_balancer(model_config, aux_stream_dict)
fused_moe/interface.py:434    moe_load_balancer_config.get_layer_initial_global_assignments(self.layer_idx)
llmapi/llm_args.py:557        raise KeyError(...)
```

## Fix

Change `MoeLoadBalancerConfig.get_layer_initial_global_assignments` to log a warning and return `None` when the requested `layer_idx` is missing, instead of raising. The single caller in `fused_moe/interface.py:_init_load_balancer` already handles `None` by falling back to the auto-derived initial assignments computed at `interface.py:407-411`, so missing layers just lose the offline warm-start (a soft EPLB-quality regression) without preventing the model from starting.

This matches the spirit of the offline assignments file: it is a learned warm-start hint, not a complete contract. Layers not in the trace simply use the default uniform assignment.

## Test plan
- [ ] `pytest tests/unittest/llmapi/test_llm_args.py::TestTorchLlmArgs::test_moe_load_balancer_missing_layer_returns_none`
- [ ] Rerun the failing DeepSeek-V4-Pro disagg + MTP-1 + offline-EPLB bench on GB300: now starts and produces tokens; warning line logged once per MTP-layer build.
- [ ] Spot-check that runs *without* MTP and *without* an offline EPLB file are unaffected (the function still returns the recorded list for present layers, and still returns `None` when no file is provided at all).
- [ ] CI: `/bot run`