### PR TITLE
[None][perf] Enable in-flight batching for Nemotron3 Nano Omni multimodal encoder

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -4,7 +4,7 @@ import math
 import os
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -694,34 +694,37 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
     def forward(
         self, multimodal_params: List[MultimodalParams]
     ) -> Tuple[List[torch.Tensor], List[List[int] | None]]:
-        # Bucket params by encoder sub-path so each bucket runs in a single
+        # Group params by encoder sub-path so each group runs in a single
         # ViT forward. RADIO's temporal path packs each tubelet as its own
         # attention sequence, so cross-request video batching is safe as
-        # long as videos within a bucket share frame shape and tubelet
-        # alignment (handled in `_encode_temporal_video_bucket`).
+        # long as videos in the same group share frame shape and tubelet
+        # alignment (handled in `_encode_temporal_video`).
         multimodal_data_list = [p.multimodal_data for p in multimodal_params]
         plan = [self._classify(mm_data) for mm_data in multimodal_data_list]
 
-        def _bucket(kind: str) -> List[Dict[str, Any]]:
+        def _data_for(modality: str) -> List[Dict[str, Any]]:
             return [
                 mm_data[mm_data["modality_type"]]
-                for mm_data, k in zip(multimodal_data_list, plan)
-                if k == kind
+                for mm_data, assigned in zip(multimodal_data_list, plan)
+                if assigned == modality
             ]
 
-        dynamic_image_iter = iter(self._encode_dynamic_image_bucket(_bucket("dynamic_image")))
-        fixed_tile_iter = iter(self._encode_fixed_tile_bucket(_bucket("fixed_tile")))
-        video_temporal_iter = iter(self._encode_temporal_video_bucket(_bucket("video_temporal")))
-
-        bucket_iters = {
-            "dynamic_image": dynamic_image_iter,
-            "fixed_tile": fixed_tile_iter,
-            "video_temporal": video_temporal_iter,
+        outputs_by_modality: Dict[str, List[torch.Tensor]] = {
+            "dynamic_image": self._encode_dynamic_image(_data_for("dynamic_image")),
+            "fixed_tile": self._encode_fixed_tile(_data_for("fixed_tile")),
+            "video_temporal": self._encode_temporal_video(_data_for("video_temporal")),
         }
-        mm_embedding = [next(bucket_iters[kind]) for kind in plan]
+        # Reassemble in input order. Each modality's output list is in
+        # input-param order (helpers preserve it), so an independent
+        # cursor per modality suffices.
+        cursor_by_modality = {modality: 0 for modality in outputs_by_modality}
+        mm_embedding: List[torch.Tensor] = []
+        for modality in plan:
+            mm_embedding.append(outputs_by_modality[modality][cursor_by_modality[modality]])
+            cursor_by_modality[modality] += 1
 
         mm_embedding, num_tokens_in_videos = self.apply_evs(mm_embedding, multimodal_data_list)
-        mm_embedding = [m.reshape(-1, self.llm_hidden_size) for m in mm_embedding]
+        mm_embedding = [embed.reshape(-1, self.llm_hidden_size) for embed in mm_embedding]
         return mm_embedding, num_tokens_in_videos
 
     def _classify(self, multimodal_data: Dict[str, Any]) -> str:
@@ -731,7 +734,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
           - ``"dynamic_image"``: variable-size images via ``extract_feature_dynamic``.
           - ``"fixed_tile"``: fixed-tile images and T==1 videos via ``extract_feature``.
           - ``"video_temporal"``: T>1 videos (or videos with mixed-shape
-            per-video pixel lists) batched through ``_encode_temporal_video_bucket``.
+            per-video pixel lists) batched through ``_encode_temporal_video``.
         """
         modality = multimodal_data["modality_type"]
         data = multimodal_data[modality]
@@ -745,9 +748,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         # shape and call signature to fixed-tile images.
         return "fixed_tile"
 
-    def _encode_dynamic_image_bucket(
-        self, image_data_list: List[Dict[str, Any]]
-    ) -> List[torch.Tensor]:
+    def _encode_dynamic_image(self, image_data_list: List[Dict[str, Any]]) -> List[torch.Tensor]:
         """Encode all dynamic-resolution image requests in a single ViT forward.
 
         Returns one 3-D embedding tensor per request, in input order.
@@ -785,7 +786,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
             cursor += n_images
         return list(torch.split(batched_embeds, per_request_token_counts, dim=1))
 
-    def _encode_fixed_tile_bucket(self, data_list: List[Dict[str, Any]]) -> List[torch.Tensor]:
+    def _encode_fixed_tile(self, data_list: List[Dict[str, Any]]) -> List[torch.Tensor]:
         """Encode all fixed-tile requests (images + T==1 videos) in a single ViT forward.
 
         Returns one 3-D embedding tensor per request, in input order.
@@ -797,9 +798,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         batched_embeds = self.extract_feature(pixel_values)
         return list(torch.split(batched_embeds, patches_per_request, dim=0))
 
-    def _encode_temporal_video_bucket(
-        self, video_data_list: List[Dict[str, Any]]
-    ) -> List[torch.Tensor]:
+    def _encode_temporal_video(self, video_data_list: List[Dict[str, Any]]) -> List[torch.Tensor]:
         """Encode all temporal video requests, batching same-shape videos in one ViT pass.
 
         Each video contributes ``t * num_tiles_per_frame`` input tiles. Videos that
@@ -842,7 +841,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
 
         # Misaligned videos (`t * p` not divisible by `T`) fall back to a
         # per-video call so `forward_video`'s end-padding stays inside the
-        # video. The remaining videos are bucketed by frame shape and dtype.
+        # video. The remaining videos are grouped by frame shape and dtype.
         aligned_groups: Dict[Tuple, List[int]] = {}
         for i, (_, _, frames_tensor, t, p) in enumerate(entries):
             if T > 1 and (t * p) % T != 0:
@@ -1955,7 +1954,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         if len(shapes) == 1:
             all_pixel_values = torch.cat(pixel_values_list, dim=0)
         else:
-            # Store as a list - `_encode_temporal_video_bucket` handles both layouts.
+            # Store as a list - `_encode_temporal_video` handles both layouts.
             all_pixel_values = pixel_values_list
         result = {
             "num_patches": torch.tensor(
@@ -2770,47 +2769,41 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
 
         return input_ids
 
-    def _encode_audio_bucket(
-        self, audio_inputs: List[dict]
-    ) -> List[Tuple[torch.Tensor, List[int]]]:
+    def _encode_audio(self, audio_data_list: List[dict]) -> List[Tuple[torch.Tensor, List[int]]]:
         """Encode a batch of audio feature dicts in a single ``sound_encoder`` call.
 
         Inputs may have different time dimensions (variable mel-feature
-        lengths). They are zero-padded to the max time within the bucket
+        lengths). They are zero-padded to the max time across the inputs
         and the per-clip ``feature_attention_mask`` is padded to match;
         the encoder uses the mask to keep valid output lengths intact, so
         padded positions don't leak into the kept slice. Returns one
-        ``(flat_embeddings, per_clip_token_counts)`` tuple per input,
-        in input order — same shape as a per-input ``_encode_audio_data``
-        call.
+        ``(per_input_embeddings, per_clip_token_counts)`` tuple per input,
+        in input order.
         """
-        if not audio_inputs:
+        if not audio_data_list:
             return []
 
         target_device = next(self.sound_encoder.parameters()).device
-        max_time = max(ad["input_audio_features"].shape[1] for ad in audio_inputs)
+        max_time = max(ad["input_audio_features"].shape[1] for ad in audio_data_list)
 
-        feature_chunks: List[torch.Tensor] = []
-        mask_chunks: List[torch.Tensor] = []
+        padded_features: List[torch.Tensor] = []
+        padded_masks: List[torch.Tensor] = []
         clips_per_input: List[int] = []
-        for audio_data in audio_inputs:
+        for audio_data in audio_data_list:
             features = audio_data["input_audio_features"].to(
                 dtype=self.model_dtype, device=target_device
             )
             mask = audio_data["feature_attention_mask"].to(device=target_device)
-            time_len = features.shape[1]
-            if time_len < max_time:
-                pad_t = max_time - time_len
-                # Zero-pad the trailing time positions; mask keeps those
-                # positions invalid so they don't affect the kept output.
-                features = torch.nn.functional.pad(features, (0, 0, 0, pad_t))
-                mask = torch.nn.functional.pad(mask, (0, pad_t))
-            feature_chunks.append(features)
-            mask_chunks.append(mask)
+            pad_amount = max_time - features.shape[1]
+            if pad_amount > 0:
+                features = torch.nn.functional.pad(features, (0, 0, 0, pad_amount))
+                mask = torch.nn.functional.pad(mask, (0, pad_amount))
+            padded_features.append(features)
+            padded_masks.append(mask)
             clips_per_input.append(features.shape[0])
 
-        all_features = torch.cat(feature_chunks, dim=0)
-        all_masks = torch.cat(mask_chunks, dim=0)
+        all_features = torch.cat(padded_features, dim=0)
+        all_masks = torch.cat(padded_masks, dim=0)
 
         sound_embeds = self.sound_encoder(all_features, all_masks)
 
@@ -2819,37 +2812,21 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
             valid_input_lens
         )
 
-        # Per-clip truncate to valid output length.
-        truncated_per_clip: List[torch.Tensor] = []
-        counts_per_clip: List[int] = []
+        per_clip_embeds: List[torch.Tensor] = []
+        per_clip_counts: List[int] = []
         for i in range(sound_embeds.shape[0]):
             valid_len = int(valid_output_lens[i].item())
-            truncated_per_clip.append(sound_embeds[i, :valid_len])
-            counts_per_clip.append(valid_len)
+            per_clip_embeds.append(sound_embeds[i, :valid_len])
+            per_clip_counts.append(valid_len)
 
-        # Group per input.
         results: List[Tuple[torch.Tensor, List[int]]] = []
         cursor = 0
         for n_clips in clips_per_input:
-            flat_emb = torch.cat(truncated_per_clip[cursor : cursor + n_clips], dim=0)
-            per_clip = counts_per_clip[cursor : cursor + n_clips]
-            results.append((flat_emb, per_clip))
+            input_embeds = torch.cat(per_clip_embeds[cursor : cursor + n_clips], dim=0)
+            input_counts = per_clip_counts[cursor : cursor + n_clips]
+            results.append((input_embeds, input_counts))
             cursor += n_clips
         return results
-
-    def _encode_audio_data(self, audio_data: dict) -> Tuple[torch.Tensor, List[int]]:
-        """Encode a single audio feature dict into LLM-space embeddings.
-
-        Thin wrapper over ``_encode_audio_bucket``. Returns a tuple of
-        ``(flat_embeddings, per_clip_token_counts)`` where
-        ``flat_embeddings`` has shape ``[total_tokens, llm_hidden_size]``.
-        """
-        return self._encode_audio_bucket([audio_data])[0]
-
-    def _encode_audio(self, param: MultimodalParams) -> torch.Tensor:
-        """Encode audio features for a standalone audio param."""
-        emb, _ = self._encode_audio_data(param.multimodal_data["audio"])
-        return emb
 
     def _interleave_video_audio_embeddings(
         self,
@@ -2938,31 +2915,35 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         image_params = [
             p for p in multimodal_params if p.multimodal_data["modality_type"] == "image"
         ]
-        image_embeds_iter: Iterator[torch.Tensor] = iter([])
+        image_embeds: List[torch.Tensor] = []
         if image_params:
             image_embeds, _ = self.vision_encoder(image_params)
-            image_embeds_iter = iter(image_embeds)
 
         # Collect all audio inputs (standalone + video-extracted) in
         # encounter order and run them through one sound_encoder call.
-        audio_inputs: List[dict] = []
+        audio_data_list: List[dict] = []
         for param in multimodal_params:
             modality_type = param.multimodal_data["modality_type"]
             if modality_type == "audio":
-                audio_inputs.append(param.multimodal_data["audio"])
+                audio_data_list.append(param.multimodal_data["audio"])
             elif modality_type == "video" and self.sound_encoder is not None:
                 audio_data = param.multimodal_data["video"].get("audio")
                 if audio_data is not None:
-                    audio_inputs.append(audio_data)
-        audio_results_iter: Iterator[Tuple[torch.Tensor, List[int]]] = iter([])
-        if audio_inputs:
-            audio_results_iter = iter(self._encode_audio_bucket(audio_inputs))
+                    audio_data_list.append(audio_data)
+        audio_outputs: List[Tuple[torch.Tensor, List[int]]] = (
+            self._encode_audio(audio_data_list) if audio_data_list else []
+        )
 
+        # Walk params in input order, drawing pre-computed outputs by
+        # incrementing per-modality cursors.
         mm_embeddings: List[torch.Tensor] = []
+        image_idx = 0
+        audio_idx = 0
         for param in multimodal_params:
             modality_type = param.multimodal_data["modality_type"]
             if modality_type == "image":
-                mm_embeddings.append(next(image_embeds_iter))
+                mm_embeddings.append(image_embeds[image_idx])
+                image_idx += 1
             elif modality_type == "video":
                 embs, num_tokens = self.vision_encoder([param])
                 vision_emb = embs[0]
@@ -2973,7 +2954,8 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                 # (v1_img_context, v1_sound_context, v2_img_context, ...).
                 audio_data = param.multimodal_data["video"].get("audio")
                 if audio_data is not None and self.sound_encoder is not None:
-                    audio_emb, per_clip_audio_counts = next(audio_results_iter)
+                    audio_emb, per_clip_audio_counts = audio_outputs[audio_idx]
+                    audio_idx += 1
                     vision_emb = self._interleave_video_audio_embeddings(
                         vision_emb,
                         audio_emb,
@@ -2985,7 +2967,8 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                     )
                 mm_embeddings.append(vision_emb)
             elif modality_type == "audio":
-                audio_emb, _ = next(audio_results_iter)
+                audio_emb, _ = audio_outputs[audio_idx]
+                audio_idx += 1
                 mm_embeddings.append(audio_emb)
             else:
                 raise ValueError(f"Unknown modality: {modality_type}")

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -4,7 +4,7 @@ import math
 import os
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -727,74 +727,107 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
     def forward(
         self, multimodal_params: List[MultimodalParams]
     ) -> Tuple[List[torch.Tensor], List[List[int] | None]]:
-        mm_embedding = []
-        multimodal_data_lst = [
-            multimodal_param.multimodal_data for multimodal_param in multimodal_params
-        ]
-        modality_types = [
-            multimodal_data["modality_type"] for multimodal_data in multimodal_data_lst
-        ]
+        # Image params share an extractor across requests, so we bucket them
+        # by sub-path (dynamic-resolution vs fixed-tile) and run each bucket
+        # in a single ViT forward. Videos still run per-request because of
+        # tubelet alignment and per-video EVS bookkeeping.
+        multimodal_data_list = [p.multimodal_data for p in multimodal_params]
+        plan = [self._classify(mm_data) for mm_data in multimodal_data_list]
 
-        for modality_type, multimodal_data in zip(modality_types, multimodal_data_lst):
-            data = multimodal_data[modality_type]
-            # Dynamic resolution path is indicated by the presence of "image_sizes". For now, it is
-            # only meant to be applied to images.
-            if modality_type == "image" and "image_sizes" in data:
-                image_sizes = data["image_sizes"]
-                if self.norm_mean is not None:
-                    pixel_values_flat = self._preprocess_raw_images(
-                        data["pixel_values"],
-                        image_sizes,
-                    )
-                else:
-                    pixel_values_flat = data["pixel_values"]
-                embeds = self.extract_feature_dynamic(pixel_values_flat, image_sizes)
-                # Keep 3D shape for apply_evs, will reshape to 2D after EVS
-                mm_embedding.append(embeds)
-            elif modality_type == "video" and (
-                self.video_temporal_patch_size > 1 or isinstance(data["pixel_values"], list)
-            ):
-                # Process each video separately when temporal compression is
-                # enabled or when videos cannot be concatenated due to mixed
-                # resized shapes.
-                embeds = self._extract_video_embeddings_temporal(data)
-                mm_embedding.append(embeds)
-            # This applies to images without dynamic resolution, or videos with T=1.
-            else:
-                # Fallback to fixed-tile extraction for this modality.
-                pixel_values = data["pixel_values"]
-                embeds = self.extract_feature(pixel_values)
-                # Keep 3D shape [num_patches, h*w, hidden] for apply_evs
-                mm_embedding.append(embeds)
+        dynamic_image_data = [
+            mm_data[mm_data["modality_type"]]
+            for mm_data, kind in zip(multimodal_data_list, plan)
+            if kind == "dynamic_image"
+        ]
+        fixed_image_data = [
+            mm_data[mm_data["modality_type"]]
+            for mm_data, kind in zip(multimodal_data_list, plan)
+            if kind == "fixed_image"
+        ]
+        dynamic_image_iter = iter(self._encode_dynamic_image_bucket(dynamic_image_data))
+        fixed_image_iter = iter(self._encode_fixed_image_bucket(fixed_image_data))
 
-        # Apply EVS if video_pruning_rate > 0
-        mm_embedding, num_tokens_in_videos = self.apply_evs(mm_embedding, multimodal_data_lst)
-        # Reshape to 2D after EVS: [num_patches*h*w, hidden_size]
+        mm_embedding: List[torch.Tensor] = []
+        for kind, mm_data in zip(plan, multimodal_data_list):
+            data = mm_data[mm_data["modality_type"]]
+            if kind == "dynamic_image":
+                mm_embedding.append(next(dynamic_image_iter))
+            elif kind == "fixed_image":
+                mm_embedding.append(next(fixed_image_iter))
+            elif kind == "video_temporal":
+                mm_embedding.append(self._extract_video_embeddings_temporal(data))
+            else:  # "fixed_other": currently only T==1 video.
+                mm_embedding.append(self.extract_feature(data["pixel_values"]))
+
+        mm_embedding, num_tokens_in_videos = self.apply_evs(mm_embedding, multimodal_data_list)
         mm_embedding = [m.reshape(-1, self.llm_hidden_size) for m in mm_embedding]
         return mm_embedding, num_tokens_in_videos
 
-        # Existing fixed-tile path (unreachable, kept for reference).
-        pixel_values = [
-            multimodal_data[modality_type]["pixel_values"]
-            for modality_type, multimodal_data in zip(modality_types, multimodal_data_lst)
-        ]
-        batched_pixel_values = torch.cat(pixel_values, dim=0)
-        # -> [num_patches, channel, height, width]
-        patch_list = [
-            multimodal_data[modality_type]["num_patches"]
-            for modality_type, multimodal_data in zip(modality_types, multimodal_data_lst)
-        ]
-        batched_num_patches = torch.cat(patch_list, dim=0).tolist()
-        # -> list of[num_patches1, num_patches2, ...]
-        batched_image_embeds = self.extract_feature(batched_pixel_values)
-        # -> [num_patches, num_image_token, hidden_size]
-        mm_embedding = torch.split(batched_image_embeds, batched_num_patches, dim=0)
+    def _classify(self, multimodal_data: Dict[str, Any]) -> str:
+        """Return the encoder sub-path for one request's multimodal_data."""
+        modality = multimodal_data["modality_type"]
+        data = multimodal_data[modality]
+        if modality == "image":
+            return "dynamic_image" if "image_sizes" in data else "fixed_image"
+        if modality == "video" and (
+            self.video_temporal_patch_size > 1 or isinstance(data["pixel_values"], list)
+        ):
+            return "video_temporal"
+        return "fixed_other"
 
-        mm_embedding, num_tokens_in_videos = self.apply_evs(mm_embedding, multimodal_data_lst)
+    def _encode_dynamic_image_bucket(
+        self, image_data_list: List[Dict[str, Any]]
+    ) -> List[torch.Tensor]:
+        """Encode all dynamic-resolution image requests in a single ViT forward.
 
-        mm_embedding = [m.reshape(-1, self.llm_hidden_size) for m in mm_embedding]
-        # -> list of [num_patches*num_image_token, hidden_size]
-        return mm_embedding, num_tokens_in_videos
+        Returns one 3-D embedding tensor per request, in input order.
+        """
+        if not image_data_list:
+            return []
+
+        raw_pixel_values: List[torch.Tensor] = []
+        image_sizes: List[Tuple[int, int]] = []
+        images_per_request: List[int] = []
+        for data in image_data_list:
+            raw_pixel_values.extend(data["pixel_values"])
+            image_sizes.extend(data["image_sizes"])
+            images_per_request.append(len(data["image_sizes"]))
+
+        if self.norm_mean is not None:
+            pixel_values_flat = self._preprocess_raw_images(raw_pixel_values, image_sizes)
+        elif len(raw_pixel_values) == 1:
+            pixel_values_flat = raw_pixel_values[0]
+        else:
+            pixel_values_flat = torch.cat(raw_pixel_values, dim=0)
+
+        # `extract_feature_dynamic` concatenates per-image embeddings along
+        # dim=1, so we split by cumulative per-request post-shuffle token count.
+        batched_embeds = self.extract_feature_dynamic(pixel_values_flat, image_sizes)
+        scale_squared = self.downsample_ratio**2
+        per_image_token_counts = [
+            int(round(seq_len * scale_squared))
+            for seq_len in calc_seq_lens(image_sizes, self.patch_size)
+        ]
+        per_request_token_counts: List[int] = []
+        cursor = 0
+        for n_images in images_per_request:
+            per_request_token_counts.append(sum(per_image_token_counts[cursor : cursor + n_images]))
+            cursor += n_images
+        return list(torch.split(batched_embeds, per_request_token_counts, dim=1))
+
+    def _encode_fixed_image_bucket(
+        self, image_data_list: List[Dict[str, Any]]
+    ) -> List[torch.Tensor]:
+        """Encode all fixed-tile image requests in a single ViT forward.
+
+        Returns one 3-D embedding tensor per request, in input order.
+        """
+        if not image_data_list:
+            return []
+        pixel_values = torch.cat([d["pixel_values"] for d in image_data_list], dim=0)
+        patches_per_request = [d["pixel_values"].shape[0] for d in image_data_list]
+        batched_embeds = self.extract_feature(pixel_values)
+        return list(torch.split(batched_embeds, patches_per_request, dim=0))
 
     def _video_tubelet_geometry(self, t: int, T: int, ih: int, iw: int) -> Tuple[int, int]:
         """Return `(num_tubelets, wh)` for one video.
@@ -2809,52 +2842,60 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
 
         Returns a single-element `List[torch.Tensor]` (all per-request
         embeddings concatenated) to conform to the contract expected by
-        `get_multimodal_embeddings`, which enables chunked-prefill
-        caching.  Per-request `num_tokens_in_video` (needed by EVS) is
-        stashed in each param's `multimodal_data` dict as a
-        side-channel.
+        `get_multimodal_embeddings`, which enables chunked-prefill caching.
+        Per-request `num_tokens_in_video` (needed by EVS) is stashed in
+        each param's `multimodal_data` dict as a side-channel.
+
+        Image requests are batched into a single `vision_encoder` call;
+        videos and standalone audio still run per-request because their
+        side effects (per-video audio interleaving, EVS token-count
+        stashing) are tied to a single request's data layout.
         """
-        mm_embeddings = []
+        # Encode all image params in one batched vision_encoder call.
+        image_params = [
+            p for p in multimodal_params if p.multimodal_data["modality_type"] == "image"
+        ]
+        image_embeds_iter: Iterator[torch.Tensor] = iter([])
+        if image_params:
+            image_embeds, _ = self.vision_encoder(image_params)
+            image_embeds_iter = iter(image_embeds)
+
+        mm_embeddings: List[torch.Tensor] = []
         for param in multimodal_params:
             modality_type = param.multimodal_data["modality_type"]
-            if modality_type in ("image", "video"):
+            if modality_type == "image":
+                mm_embeddings.append(next(image_embeds_iter))
+            elif modality_type == "video":
                 embs, num_tokens = self.vision_encoder([param])
                 vision_emb = embs[0]
-
-                # If audio was extracted from video, encode it and interleave
-                # with per-video vision embeddings so that the combined tensor
-                # matches the token order in input_ids
+                if num_tokens is not None:
+                    param.multimodal_data["num_tokens_in_video"] = num_tokens[0]
+                # If audio was extracted from video, interleave it per-video so
+                # the combined tensor matches input_ids order
                 # (v1_img_context, v1_sound_context, v2_img_context, ...).
-                audio_data = param.multimodal_data[modality_type].get("audio")
+                audio_data = param.multimodal_data["video"].get("audio")
                 if audio_data is not None and self.sound_encoder is not None:
                     audio_emb, per_clip_audio_counts = self._encode_audio_data(audio_data)
-                    video_sizes = param.multimodal_data[modality_type].get("video_size", [])
                     vision_emb = self._interleave_video_audio_embeddings(
                         vision_emb,
                         audio_emb,
                         per_clip_audio_counts,
                         has_audio=audio_data["has_audio"],
                         audio_num_clips=audio_data["audio_num_clips"],
-                        video_sizes=video_sizes,
+                        video_sizes=param.multimodal_data["video"].get("video_size", []),
                         evs_num_tokens=(num_tokens[0] if num_tokens is not None else None),
                     )
-
                 mm_embeddings.append(vision_emb)
-
-                # Stash per-request token counts for later EVS adjustment.
-                if num_tokens is not None:
-                    param.multimodal_data["num_tokens_in_video"] = num_tokens[0]
             elif modality_type == "audio":
                 mm_embeddings.append(self._encode_audio(param))
             else:
                 raise ValueError(f"Unknown modality: {modality_type}")
 
-        # Concatenate per-request embeddings into a single tensor.
-        # `get_multimodal_embeddings` expects a single-element list containing one tensor (all
-        # items' embeddings concatenated).
-        if mm_embeddings:
-            return [torch.cat(mm_embeddings, dim=0)]
-        return []
+        if not mm_embeddings:
+            return []
+        # `get_multimodal_embeddings` requires a single concatenated tensor
+        # in input-param order so it can split per-request and cache.
+        return [torch.cat(mm_embeddings, dim=0)]
 
     @torch.inference_mode()
     def forward(

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2770,44 +2770,84 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
 
         return input_ids
 
-    def _encode_audio_data(self, audio_data: dict) -> Tuple[torch.Tensor, List[int]]:
-        """Encode audio feature dict into LLM-space embeddings.
+    def _encode_audio_bucket(
+        self, audio_inputs: List[dict]
+    ) -> List[Tuple[torch.Tensor, List[int]]]:
+        """Encode a batch of audio feature dicts in a single ``sound_encoder`` call.
 
-        Unlike `_encode_audio` which reads from `param.multimodal_data["audio"]`, this helper
-        accepts the audio feature dict directly so it can be reused for audio extracted from video
-        metadata.
-
-        Returns:
-            A tuple of (flat_embeddings, per_clip_token_counts) where
-            `flat_embeddings` has shape `[total_tokens, llm_hidden_size]` and
-            `per_clip_token_counts` contains the number of output tokens for
-            each audio clip.
+        Inputs may have different time dimensions (variable mel-feature
+        lengths). They are zero-padded to the max time within the bucket
+        and the per-clip ``feature_attention_mask`` is padded to match;
+        the encoder uses the mask to keep valid output lengths intact, so
+        padded positions don't leak into the kept slice. Returns one
+        ``(flat_embeddings, per_clip_token_counts)`` tuple per input,
+        in input order — same shape as a per-input ``_encode_audio_data``
+        call.
         """
-        input_features = audio_data["input_audio_features"]  # [num_clips, time, mel_bins]
-        attention_mask = audio_data["feature_attention_mask"]  # [num_clips, time]
+        if not audio_inputs:
+            return []
 
         target_device = next(self.sound_encoder.parameters()).device
-        input_features = input_features.to(dtype=self.model_dtype, device=target_device)
-        attention_mask = attention_mask.to(device=target_device)
+        max_time = max(ad["input_audio_features"].shape[1] for ad in audio_inputs)
 
-        sound_embeds = self.sound_encoder(input_features, attention_mask)
+        feature_chunks: List[torch.Tensor] = []
+        mask_chunks: List[torch.Tensor] = []
+        clips_per_input: List[int] = []
+        for audio_data in audio_inputs:
+            features = audio_data["input_audio_features"].to(
+                dtype=self.model_dtype, device=target_device
+            )
+            mask = audio_data["feature_attention_mask"].to(device=target_device)
+            time_len = features.shape[1]
+            if time_len < max_time:
+                pad_t = max_time - time_len
+                # Zero-pad the trailing time positions; mask keeps those
+                # positions invalid so they don't affect the kept output.
+                features = torch.nn.functional.pad(features, (0, 0, 0, pad_t))
+                mask = torch.nn.functional.pad(mask, (0, pad_t))
+            feature_chunks.append(features)
+            mask_chunks.append(mask)
+            clips_per_input.append(features.shape[0])
 
-        valid_input_lens = attention_mask.sum(dim=1)
+        all_features = torch.cat(feature_chunks, dim=0)
+        all_masks = torch.cat(mask_chunks, dim=0)
+
+        sound_embeds = self.sound_encoder(all_features, all_masks)
+
+        valid_input_lens = all_masks.sum(dim=1)
         valid_output_lens = self.sound_encoder.encoder._get_subsampling_output_length(
             valid_input_lens
         )
 
-        truncated = []
-        per_clip_counts: List[int] = []
+        # Per-clip truncate to valid output length.
+        truncated_per_clip: List[torch.Tensor] = []
+        counts_per_clip: List[int] = []
         for i in range(sound_embeds.shape[0]):
             valid_len = int(valid_output_lens[i].item())
-            truncated.append(sound_embeds[i, :valid_len])
-            per_clip_counts.append(valid_len)
+            truncated_per_clip.append(sound_embeds[i, :valid_len])
+            counts_per_clip.append(valid_len)
 
-        return torch.cat(truncated, dim=0), per_clip_counts  # [total_tokens, llm_hidden_size]
+        # Group per input.
+        results: List[Tuple[torch.Tensor, List[int]]] = []
+        cursor = 0
+        for n_clips in clips_per_input:
+            flat_emb = torch.cat(truncated_per_clip[cursor : cursor + n_clips], dim=0)
+            per_clip = counts_per_clip[cursor : cursor + n_clips]
+            results.append((flat_emb, per_clip))
+            cursor += n_clips
+        return results
+
+    def _encode_audio_data(self, audio_data: dict) -> Tuple[torch.Tensor, List[int]]:
+        """Encode a single audio feature dict into LLM-space embeddings.
+
+        Thin wrapper over ``_encode_audio_bucket``. Returns a tuple of
+        ``(flat_embeddings, per_clip_token_counts)`` where
+        ``flat_embeddings`` has shape ``[total_tokens, llm_hidden_size]``.
+        """
+        return self._encode_audio_bucket([audio_data])[0]
 
     def _encode_audio(self, param: MultimodalParams) -> torch.Tensor:
-        """Encode audio features into LLM-space embeddings."""
+        """Encode audio features for a standalone audio param."""
         emb, _ = self._encode_audio_data(param.multimodal_data["audio"])
         return emb
 
@@ -2887,10 +2927,12 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         Per-request `num_tokens_in_video` (needed by EVS) is stashed in
         each param's `multimodal_data` dict as a side-channel.
 
-        Image requests are batched into a single `vision_encoder` call;
-        videos and standalone audio still run per-request because their
-        side effects (per-video audio interleaving, EVS token-count
-        stashing) are tied to a single request's data layout.
+        Image params are batched into a single ``vision_encoder`` call;
+        all audio inputs (standalone audio params and audio extracted
+        from video) are batched into a single ``sound_encoder`` call.
+        Videos still run per-request because per-video audio
+        interleaving and EVS token-count stashing are tied to one
+        request's data layout.
         """
         # Encode all image params in one batched vision_encoder call.
         image_params = [
@@ -2900,6 +2942,21 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         if image_params:
             image_embeds, _ = self.vision_encoder(image_params)
             image_embeds_iter = iter(image_embeds)
+
+        # Collect all audio inputs (standalone + video-extracted) in
+        # encounter order and run them through one sound_encoder call.
+        audio_inputs: List[dict] = []
+        for param in multimodal_params:
+            modality_type = param.multimodal_data["modality_type"]
+            if modality_type == "audio":
+                audio_inputs.append(param.multimodal_data["audio"])
+            elif modality_type == "video" and self.sound_encoder is not None:
+                audio_data = param.multimodal_data["video"].get("audio")
+                if audio_data is not None:
+                    audio_inputs.append(audio_data)
+        audio_results_iter: Iterator[Tuple[torch.Tensor, List[int]]] = iter([])
+        if audio_inputs:
+            audio_results_iter = iter(self._encode_audio_bucket(audio_inputs))
 
         mm_embeddings: List[torch.Tensor] = []
         for param in multimodal_params:
@@ -2916,7 +2973,7 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                 # (v1_img_context, v1_sound_context, v2_img_context, ...).
                 audio_data = param.multimodal_data["video"].get("audio")
                 if audio_data is not None and self.sound_encoder is not None:
-                    audio_emb, per_clip_audio_counts = self._encode_audio_data(audio_data)
+                    audio_emb, per_clip_audio_counts = next(audio_results_iter)
                     vision_emb = self._interleave_video_audio_embeddings(
                         vision_emb,
                         audio_emb,
@@ -2928,7 +2985,8 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                     )
                 mm_embeddings.append(vision_emb)
             elif modality_type == "audio":
-                mm_embeddings.append(self._encode_audio(param))
+                audio_emb, _ = next(audio_results_iter)
+                mm_embeddings.append(audio_emb)
             else:
                 raise ValueError(f"Unknown modality: {modality_type}")
 

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -769,7 +769,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         batched_embeds = self.extract_feature_dynamic(pixel_values_flat, image_sizes)
         scale_squared = self.downsample_ratio**2
         per_image_token_counts = [
-            int(round(seq_len * scale_squared))
+            round(seq_len * scale_squared)
             for seq_len in calc_seq_lens(image_sizes, self.patch_size)
         ]
         per_request_token_counts: List[int] = []

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -786,8 +786,8 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         """
         if not data_list:
             return []
-        pixel_values = torch.cat([d["pixel_values"] for d in data_list], dim=0)
-        patches_per_request = [d["pixel_values"].shape[0] for d in data_list]
+        pixel_values = torch.cat([data["pixel_values"] for data in data_list], dim=0)
+        patches_per_request = [data["pixel_values"].shape[0] for data in data_list]
         batched_embeds = self.extract_feature(pixel_values)
         return list(torch.split(batched_embeds, patches_per_request, dim=0))
 
@@ -2491,6 +2491,19 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
             model_config.video_pruning_rate if model_config.video_pruning_rate is not None else 0.0
         )
 
+    @property
+    def multimodal_data_device_paths(self) -> List[str]:
+        return [
+            "image.pixel_values",
+            "image.evs_ids",
+            "video.pixel_values",
+            "video.evs_ids",
+            "video.audio.input_audio_features",
+            "video.audio.feature_attention_mask",
+            "audio.input_audio_features",
+            "audio.feature_attention_mask",
+        ]
+
     def load_weights(self, weights):
         # Construct vision/sound encoders here (outside MetaInitMode) so their
         # HF-based submodules allocate regular CPU tensors. Then move them to
@@ -2776,17 +2789,14 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         if not audio_data_list:
             return []
 
-        target_device = next(self.sound_encoder.parameters()).device
         max_time = max(ad["input_audio_features"].shape[1] for ad in audio_data_list)
 
         padded_features: List[torch.Tensor] = []
         padded_masks: List[torch.Tensor] = []
         clips_per_input: List[int] = []
         for audio_data in audio_data_list:
-            features = audio_data["input_audio_features"].to(
-                dtype=self.model_dtype, device=target_device
-            )
-            mask = audio_data["feature_attention_mask"].to(device=target_device)
+            features = audio_data["input_audio_features"].to(dtype=self.model_dtype)
+            mask = audio_data["feature_attention_mask"]
             pad_amount = max_time - features.shape[1]
             if pad_amount > 0:
                 features = torch.nn.functional.pad(features, (0, 0, 0, pad_amount))
@@ -2803,12 +2813,12 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         valid_input_lens = all_masks.sum(dim=1)
         valid_output_lens = self.sound_encoder.encoder._get_subsampling_output_length(
             valid_input_lens
-        )
+        ).tolist()
 
         per_clip_embeds: List[torch.Tensor] = []
         per_clip_counts: List[int] = []
         for i in range(sound_embeds.shape[0]):
-            valid_len = int(valid_output_lens[i].item())
+            valid_len = valid_output_lens[i]
             per_clip_embeds.append(sound_embeds[i, :valid_len])
             per_clip_counts.append(valid_len)
 

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2491,19 +2491,6 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
             model_config.video_pruning_rate if model_config.video_pruning_rate is not None else 0.0
         )
 
-    @property
-    def multimodal_data_device_paths(self) -> List[str]:
-        return [
-            "image.pixel_values",
-            "image.evs_ids",
-            "video.pixel_values",
-            "video.evs_ids",
-            "video.audio.input_audio_features",
-            "video.audio.feature_attention_mask",
-            "audio.input_audio_features",
-            "audio.feature_attention_mask",
-        ]
-
     def load_weights(self, weights):
         # Construct vision/sound encoders here (outside MetaInitMode) so their
         # HF-based submodules allocate regular CPU tensors. Then move them to

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -727,10 +727,12 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
     def forward(
         self, multimodal_params: List[MultimodalParams]
     ) -> Tuple[List[torch.Tensor], List[List[int] | None]]:
-        # Image params share an extractor across requests, so we bucket them
-        # by sub-path (dynamic-resolution vs fixed-tile) and run each bucket
-        # in a single ViT forward. Videos still run per-request because of
-        # tubelet alignment and per-video EVS bookkeeping.
+        # Bucket params by encoder sub-path so each bucket runs in a single
+        # ViT forward. The fixed-tile bucket also covers T==1 videos, since
+        # those use the exact same `extract_feature` call as fixed-tile
+        # images. T>1 videos still run per-request: cross-video tubelet
+        # boundaries and RADIO's mask-free temporal attention make
+        # cross-request batching unsafe.
         multimodal_data_list = [p.multimodal_data for p in multimodal_params]
         plan = [self._classify(mm_data) for mm_data in multimodal_data_list]
 
@@ -739,41 +741,48 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
             for mm_data, kind in zip(multimodal_data_list, plan)
             if kind == "dynamic_image"
         ]
-        fixed_image_data = [
+        fixed_tile_data = [
             mm_data[mm_data["modality_type"]]
             for mm_data, kind in zip(multimodal_data_list, plan)
-            if kind == "fixed_image"
+            if kind == "fixed_tile"
         ]
         dynamic_image_iter = iter(self._encode_dynamic_image_bucket(dynamic_image_data))
-        fixed_image_iter = iter(self._encode_fixed_image_bucket(fixed_image_data))
+        fixed_tile_iter = iter(self._encode_fixed_tile_bucket(fixed_tile_data))
 
         mm_embedding: List[torch.Tensor] = []
         for kind, mm_data in zip(plan, multimodal_data_list):
             data = mm_data[mm_data["modality_type"]]
             if kind == "dynamic_image":
                 mm_embedding.append(next(dynamic_image_iter))
-            elif kind == "fixed_image":
-                mm_embedding.append(next(fixed_image_iter))
-            elif kind == "video_temporal":
+            elif kind == "fixed_tile":
+                mm_embedding.append(next(fixed_tile_iter))
+            else:  # "video_temporal"
                 mm_embedding.append(self._extract_video_embeddings_temporal(data))
-            else:  # "fixed_other": currently only T==1 video.
-                mm_embedding.append(self.extract_feature(data["pixel_values"]))
 
         mm_embedding, num_tokens_in_videos = self.apply_evs(mm_embedding, multimodal_data_list)
         mm_embedding = [m.reshape(-1, self.llm_hidden_size) for m in mm_embedding]
         return mm_embedding, num_tokens_in_videos
 
     def _classify(self, multimodal_data: Dict[str, Any]) -> str:
-        """Return the encoder sub-path for one request's multimodal_data."""
+        """Return the encoder sub-path for one request's multimodal_data.
+
+        Returns one of:
+          - ``"dynamic_image"``: variable-size images via ``extract_feature_dynamic``.
+          - ``"fixed_tile"``: fixed-tile images and T==1 videos via ``extract_feature``.
+          - ``"video_temporal"``: T>1 videos (or videos with mixed-shape
+            per-video pixel lists) via ``_extract_video_embeddings_temporal``.
+        """
         modality = multimodal_data["modality_type"]
         data = multimodal_data[modality]
         if modality == "image":
-            return "dynamic_image" if "image_sizes" in data else "fixed_image"
+            return "dynamic_image" if "image_sizes" in data else "fixed_tile"
         if modality == "video" and (
             self.video_temporal_patch_size > 1 or isinstance(data["pixel_values"], list)
         ):
             return "video_temporal"
-        return "fixed_other"
+        # Remaining: T==1 video with a tensor pixel_values, identical in
+        # shape and call signature to fixed-tile images.
+        return "fixed_tile"
 
     def _encode_dynamic_image_bucket(
         self, image_data_list: List[Dict[str, Any]]
@@ -815,17 +824,15 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
             cursor += n_images
         return list(torch.split(batched_embeds, per_request_token_counts, dim=1))
 
-    def _encode_fixed_image_bucket(
-        self, image_data_list: List[Dict[str, Any]]
-    ) -> List[torch.Tensor]:
-        """Encode all fixed-tile image requests in a single ViT forward.
+    def _encode_fixed_tile_bucket(self, data_list: List[Dict[str, Any]]) -> List[torch.Tensor]:
+        """Encode all fixed-tile requests (images + T==1 videos) in a single ViT forward.
 
         Returns one 3-D embedding tensor per request, in input order.
         """
-        if not image_data_list:
+        if not data_list:
             return []
-        pixel_values = torch.cat([d["pixel_values"] for d in image_data_list], dim=0)
-        patches_per_request = [d["pixel_values"].shape[0] for d in image_data_list]
+        pixel_values = torch.cat([d["pixel_values"] for d in data_list], dim=0)
+        patches_per_request = [d["pixel_values"].shape[0] for d in data_list]
         batched_embeds = self.extract_feature(pixel_values)
         return list(torch.split(batched_embeds, patches_per_request, dim=0))
 

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2907,32 +2907,37 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         Per-request `num_tokens_in_video` (needed by EVS) is stashed in
         each param's `multimodal_data` dict as a side-channel.
 
-        Image params are batched into a single ``vision_encoder`` call;
-        all audio inputs (standalone audio params and audio extracted
+        Image and video params are batched into single ``vision_encoder``
+        calls; all audio inputs (standalone audio params and audio extracted
         from video) are batched into a single ``sound_encoder`` call.
-        Videos still run per-request because per-video audio
-        interleaving and EVS token-count stashing are tied to one
-        request's data layout.
+        Per-video audio interleaving and EVS token-count stashing happen in
+        the second pass that walks params in input order.
         """
-        # Collect all image params and all audio inputs (standalone +
-        # video-extracted) in a single pass, then run each encoder once
-        # over its bucket.
+        # Collect all image, video, and audio inputs in a single pass, then
+        # run each encoder once over its bucket.
         image_params: List[MultimodalParams] = []
+        video_params: List[MultimodalParams] = []
         audio_data_list: List[dict] = []
         for param in multimodal_params:
             modality_type = param.multimodal_data["modality_type"]
             if modality_type == "image":
                 image_params.append(param)
+            elif modality_type == "video":
+                video_params.append(param)
+                if self.sound_encoder is not None:
+                    audio_data = param.multimodal_data["video"].get("audio")
+                    if audio_data is not None:
+                        audio_data_list.append(audio_data)
             elif modality_type == "audio":
                 audio_data_list.append(param.multimodal_data["audio"])
-            elif modality_type == "video" and self.sound_encoder is not None:
-                audio_data = param.multimodal_data["video"].get("audio")
-                if audio_data is not None:
-                    audio_data_list.append(audio_data)
 
         image_embeds: List[torch.Tensor] = []
         if image_params:
             image_embeds, _ = self.vision_encoder(image_params)
+        video_embeds: List[torch.Tensor] = []
+        video_num_tokens: Optional[List[List[int] | None]] = None
+        if video_params:
+            video_embeds, video_num_tokens = self.vision_encoder(video_params)
         audio_outputs: List[Tuple[torch.Tensor, List[int]]] = (
             self._encode_audio(audio_data_list) if audio_data_list else []
         )
@@ -2941,6 +2946,7 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         # incrementing per-modality cursors.
         mm_embeddings: List[torch.Tensor] = []
         image_idx = 0
+        video_idx = 0
         audio_idx = 0
         for param in multimodal_params:
             modality_type = param.multimodal_data["modality_type"]
@@ -2948,10 +2954,11 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                 mm_embeddings.append(image_embeds[image_idx])
                 image_idx += 1
             elif modality_type == "video":
-                embs, num_tokens = self.vision_encoder([param])
-                vision_emb = embs[0]
+                vision_emb = video_embeds[video_idx]
+                num_tokens = video_num_tokens[video_idx] if video_num_tokens is not None else None
+                video_idx += 1
                 if num_tokens is not None:
-                    param.multimodal_data["num_tokens_in_video"] = num_tokens[0]
+                    param.multimodal_data["num_tokens_in_video"] = num_tokens
                 # If audio was extracted from video, interleave it per-video so
                 # the combined tensor matches input_ids order
                 # (v1_img_context, v1_sound_context, v2_img_context, ...).
@@ -2966,7 +2973,7 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
                         has_audio=audio_data["has_audio"],
                         audio_num_clips=audio_data["audio_num_clips"],
                         video_sizes=param.multimodal_data["video"].get("video_size", []),
-                        evs_num_tokens=(num_tokens[0] if num_tokens is not None else None),
+                        evs_num_tokens=num_tokens,
                     )
                 mm_embeddings.append(vision_emb)
             elif modality_type == "audio":

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -691,73 +691,34 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
                 num_tokens_in_videos.append(num_tokens_per_frames)
         return mm_embedding_evs, num_tokens_in_videos
 
-    def _extract_video_embeddings_temporal(self, video_data: Dict[str, Any]) -> torch.Tensor:
-        """Extract video embeddings with temporal compression.
-
-        Each video is processed separately through extract_feature with num_frames, which enables
-        the tubelet embedding path in RADIO.
-
-        `pixel_values` may be a single concatenated tensor (all videos share the same frame size)
-        or a list of per-video tensors (mixed aspect ratios).
-        """
-        pixel_values = video_data["pixel_values"]
-        video_size_list = video_data.get("video_size", [])
-        per_video = isinstance(pixel_values, list)
-
-        all_embeds = []
-        frame_offset = 0
-        for idx, video_size in enumerate(video_size_list):
-            num_frames = video_size[0]
-            num_tiles_per_frame = video_size[1]
-            total_tiles = num_frames * num_tiles_per_frame
-            if per_video:
-                video_frames = pixel_values[idx]
-            else:
-                video_frames = pixel_values[frame_offset : frame_offset + total_tiles]
-                frame_offset += total_tiles
-
-            vit_embeds = self.extract_feature(video_frames, num_frames=num_frames)
-            # Flatten to 2D [tokens, hidden] so videos with different spatial
-            # resolutions (different dim-1) can be concatenated.
-            all_embeds.append(vit_embeds.reshape(-1, vit_embeds.shape[-1]))
-
-        # Concatenate all videos' embeddings (2D).
-        return torch.cat(all_embeds, dim=0)
-
     def forward(
         self, multimodal_params: List[MultimodalParams]
     ) -> Tuple[List[torch.Tensor], List[List[int] | None]]:
         # Bucket params by encoder sub-path so each bucket runs in a single
-        # ViT forward. The fixed-tile bucket also covers T==1 videos, since
-        # those use the exact same `extract_feature` call as fixed-tile
-        # images. T>1 videos still run per-request: cross-video tubelet
-        # boundaries and RADIO's mask-free temporal attention make
-        # cross-request batching unsafe.
+        # ViT forward. RADIO's temporal path packs each tubelet as its own
+        # attention sequence, so cross-request video batching is safe as
+        # long as videos within a bucket share frame shape and tubelet
+        # alignment (handled in `_encode_temporal_video_bucket`).
         multimodal_data_list = [p.multimodal_data for p in multimodal_params]
         plan = [self._classify(mm_data) for mm_data in multimodal_data_list]
 
-        dynamic_image_data = [
-            mm_data[mm_data["modality_type"]]
-            for mm_data, kind in zip(multimodal_data_list, plan)
-            if kind == "dynamic_image"
-        ]
-        fixed_tile_data = [
-            mm_data[mm_data["modality_type"]]
-            for mm_data, kind in zip(multimodal_data_list, plan)
-            if kind == "fixed_tile"
-        ]
-        dynamic_image_iter = iter(self._encode_dynamic_image_bucket(dynamic_image_data))
-        fixed_tile_iter = iter(self._encode_fixed_tile_bucket(fixed_tile_data))
+        def _bucket(kind: str) -> List[Dict[str, Any]]:
+            return [
+                mm_data[mm_data["modality_type"]]
+                for mm_data, k in zip(multimodal_data_list, plan)
+                if k == kind
+            ]
 
-        mm_embedding: List[torch.Tensor] = []
-        for kind, mm_data in zip(plan, multimodal_data_list):
-            data = mm_data[mm_data["modality_type"]]
-            if kind == "dynamic_image":
-                mm_embedding.append(next(dynamic_image_iter))
-            elif kind == "fixed_tile":
-                mm_embedding.append(next(fixed_tile_iter))
-            else:  # "video_temporal"
-                mm_embedding.append(self._extract_video_embeddings_temporal(data))
+        dynamic_image_iter = iter(self._encode_dynamic_image_bucket(_bucket("dynamic_image")))
+        fixed_tile_iter = iter(self._encode_fixed_tile_bucket(_bucket("fixed_tile")))
+        video_temporal_iter = iter(self._encode_temporal_video_bucket(_bucket("video_temporal")))
+
+        bucket_iters = {
+            "dynamic_image": dynamic_image_iter,
+            "fixed_tile": fixed_tile_iter,
+            "video_temporal": video_temporal_iter,
+        }
+        mm_embedding = [next(bucket_iters[kind]) for kind in plan]
 
         mm_embedding, num_tokens_in_videos = self.apply_evs(mm_embedding, multimodal_data_list)
         mm_embedding = [m.reshape(-1, self.llm_hidden_size) for m in mm_embedding]
@@ -770,7 +731,7 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
           - ``"dynamic_image"``: variable-size images via ``extract_feature_dynamic``.
           - ``"fixed_tile"``: fixed-tile images and T==1 videos via ``extract_feature``.
           - ``"video_temporal"``: T>1 videos (or videos with mixed-shape
-            per-video pixel lists) via ``_extract_video_embeddings_temporal``.
+            per-video pixel lists) batched through ``_encode_temporal_video_bucket``.
         """
         modality = multimodal_data["modality_type"]
         data = multimodal_data[modality]
@@ -835,6 +796,79 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         patches_per_request = [d["pixel_values"].shape[0] for d in data_list]
         batched_embeds = self.extract_feature(pixel_values)
         return list(torch.split(batched_embeds, patches_per_request, dim=0))
+
+    def _encode_temporal_video_bucket(
+        self, video_data_list: List[Dict[str, Any]]
+    ) -> List[torch.Tensor]:
+        """Encode all temporal video requests, batching same-shape videos in one ViT pass.
+
+        Each video contributes ``t * num_tiles_per_frame`` input tiles. Videos that
+        share ``(frame H, frame W, num_tiles_per_frame, dtype)`` and have an input
+        tile count divisible by ``T`` are concatenated and run through a single
+        ``extract_feature`` call. RADIO packs each tubelet as its own attention
+        sequence, so cross-video tubelets cannot attend to one another. Misaligned
+        videos (``t * p`` not divisible by ``T``) fall back to a per-video call so
+        ``forward_video``'s implicit end-padding stays self-contained.
+
+        Returns one per-request 2-D tensor (in ``video_data_list`` order).
+        Each per-video block has shape ``[num_tubelets * spatial_tokens, hidden]``,
+        matching what ``apply_evs_per_video`` slices and reshapes downstream.
+        """
+        if not video_data_list:
+            return []
+
+        T = self.video_temporal_patch_size
+
+        # Walk all videos across all requests and collect per-video metadata.
+        # `entries[i]` is (request_index, video_index_in_request, frames_tensor, t, p).
+        entries: List[Tuple[int, int, torch.Tensor, int, int]] = []
+        for req_idx, data in enumerate(video_data_list):
+            pixel_values = data["pixel_values"]
+            video_size_list = data.get("video_size", [])
+            per_video = isinstance(pixel_values, list)
+            frame_offset = 0
+            for vid_idx, video_size in enumerate(video_size_list):
+                t = video_size[0]
+                p = video_size[1]
+                total_tiles = t * p
+                if per_video:
+                    frames_tensor = pixel_values[vid_idx]
+                else:
+                    frames_tensor = pixel_values[frame_offset : frame_offset + total_tiles]
+                    frame_offset += total_tiles
+                entries.append((req_idx, vid_idx, frames_tensor, t, p))
+
+        per_video_outputs: List[Optional[torch.Tensor]] = [None] * len(entries)
+
+        # Misaligned videos (`t * p` not divisible by `T`) fall back to a
+        # per-video call so `forward_video`'s end-padding stays inside the
+        # video. The remaining videos are bucketed by frame shape and dtype.
+        aligned_groups: Dict[Tuple, List[int]] = {}
+        for i, (_, _, frames_tensor, t, p) in enumerate(entries):
+            if T > 1 and (t * p) % T != 0:
+                vit_embeds = self.extract_feature(frames_tensor, num_frames=t)
+                per_video_outputs[i] = vit_embeds.reshape(-1, vit_embeds.shape[-1])
+                continue
+            key = (frames_tensor.shape[-2], frames_tensor.shape[-1], p, frames_tensor.dtype)
+            aligned_groups.setdefault(key, []).append(i)
+
+        for idxs in aligned_groups.values():
+            cat_frames = torch.cat([entries[i][2] for i in idxs], dim=0)
+            per_video_tile_counts = [entries[i][2].shape[0] for i in idxs]
+            # `num_frames` is a non-None flag enabling the temporal path; the
+            # actual per-tubelet grouping uses `T` and the cat tensor's shape.
+            vit_embeds = self.extract_feature(cat_frames, num_frames=cat_frames.shape[0])
+            per_video_tubelet_counts = [n // T if T > 1 else n for n in per_video_tile_counts]
+            chunks = torch.split(vit_embeds, per_video_tubelet_counts, dim=0)
+            for i, chunk in zip(idxs, chunks):
+                per_video_outputs[i] = chunk.reshape(-1, chunk.shape[-1])
+
+        # Re-aggregate per request. Videos within each request appear in the
+        # original `vid_idx` order because `entries` was built that way.
+        per_request_outputs: List[List[torch.Tensor]] = [[] for _ in video_data_list]
+        for entry, output in zip(entries, per_video_outputs):
+            per_request_outputs[entry[0]].append(output)
+        return [torch.cat(req_outs, dim=0) for req_outs in per_request_outputs]
 
     def _video_tubelet_geometry(self, t: int, T: int, ih: int, iw: int) -> Tuple[int, int]:
         """Return `(num_tubelets, wh)` for one video.
@@ -1921,7 +1955,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         if len(shapes) == 1:
             all_pixel_values = torch.cat(pixel_values_list, dim=0)
         else:
-            # Store as a list - `_extract_video_embeddings_temporal` handles both.
+            # Store as a list - `_encode_temporal_video_bucket` handles both layouts.
             all_pixel_values = pixel_values_list
         result = {
             "num_patches": torch.tensor(

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -694,25 +694,39 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
     def forward(
         self, multimodal_params: List[MultimodalParams]
     ) -> Tuple[List[torch.Tensor], List[List[int] | None]]:
-        # Group params by encoder sub-path so each group runs in a single
-        # ViT forward. RADIO's temporal path packs each tubelet as its own
-        # attention sequence, so cross-request video batching is safe as
-        # long as videos in the same group share frame shape and tubelet
-        # alignment (handled in `_encode_temporal_video`).
+        # Group each param into one of three encoder sub-paths and call
+        # each encoder once over its bucket. RADIO's temporal path packs
+        # each tubelet as its own attention sequence, so cross-request
+        # video batching is safe as long as videos in the same group
+        # share frame shape and tubelet alignment (handled in
+        # `_encode_temporal_video`).
         multimodal_data_list = [p.multimodal_data for p in multimodal_params]
-        plan = [self._classify(mm_data) for mm_data in multimodal_data_list]
-
-        def _data_for(modality: str) -> List[Dict[str, Any]]:
-            return [
-                mm_data[mm_data["modality_type"]]
-                for mm_data, assigned in zip(multimodal_data_list, plan)
-                if assigned == modality
-            ]
+        buckets: Dict[str, List[Dict[str, Any]]] = {
+            "dynamic_image": [],
+            "fixed_tile": [],
+            "video_temporal": [],
+        }
+        plan: List[str] = []
+        for multimodal_data in multimodal_data_list:
+            modality_type = multimodal_data["modality_type"]
+            data = multimodal_data[modality_type]
+            if modality_type == "image":
+                modality = "dynamic_image" if "image_sizes" in data else "fixed_tile"
+            elif modality_type == "video" and (
+                self.video_temporal_patch_size > 1 or isinstance(data["pixel_values"], list)
+            ):
+                modality = "video_temporal"
+            else:
+                # T==1 video with a tensor `pixel_values` is shape-identical
+                # to a fixed-tile image, so it rides the same encoder.
+                modality = "fixed_tile"
+            plan.append(modality)
+            buckets[modality].append(data)
 
         outputs_by_modality: Dict[str, List[torch.Tensor]] = {
-            "dynamic_image": self._encode_dynamic_image(_data_for("dynamic_image")),
-            "fixed_tile": self._encode_fixed_tile(_data_for("fixed_tile")),
-            "video_temporal": self._encode_temporal_video(_data_for("video_temporal")),
+            "dynamic_image": self._encode_dynamic_image(buckets["dynamic_image"]),
+            "fixed_tile": self._encode_fixed_tile(buckets["fixed_tile"]),
+            "video_temporal": self._encode_temporal_video(buckets["video_temporal"]),
         }
         # Reassemble in input order. Each modality's output list is in
         # input-param order (helpers preserve it), so an independent
@@ -726,27 +740,6 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
         mm_embedding, num_tokens_in_videos = self.apply_evs(mm_embedding, multimodal_data_list)
         mm_embedding = [embed.reshape(-1, self.llm_hidden_size) for embed in mm_embedding]
         return mm_embedding, num_tokens_in_videos
-
-    def _classify(self, multimodal_data: Dict[str, Any]) -> str:
-        """Return the encoder sub-path for one request's multimodal_data.
-
-        Returns one of:
-          - ``"dynamic_image"``: variable-size images via ``extract_feature_dynamic``.
-          - ``"fixed_tile"``: fixed-tile images and T==1 videos via ``extract_feature``.
-          - ``"video_temporal"``: T>1 videos (or videos with mixed-shape
-            per-video pixel lists) batched through ``_encode_temporal_video``.
-        """
-        modality = multimodal_data["modality_type"]
-        data = multimodal_data[modality]
-        if modality == "image":
-            return "dynamic_image" if "image_sizes" in data else "fixed_tile"
-        if modality == "video" and (
-            self.video_temporal_patch_size > 1 or isinstance(data["pixel_values"], list)
-        ):
-            return "video_temporal"
-        # Remaining: T==1 video with a tensor pixel_values, identical in
-        # shape and call signature to fixed-tile images.
-        return "fixed_tile"
 
     def _encode_dynamic_image(self, image_data_list: List[Dict[str, Any]]) -> List[torch.Tensor]:
         """Encode all dynamic-resolution image requests in a single ViT forward.
@@ -2911,25 +2904,25 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         interleaving and EVS token-count stashing are tied to one
         request's data layout.
         """
-        # Encode all image params in one batched vision_encoder call.
-        image_params = [
-            p for p in multimodal_params if p.multimodal_data["modality_type"] == "image"
-        ]
-        image_embeds: List[torch.Tensor] = []
-        if image_params:
-            image_embeds, _ = self.vision_encoder(image_params)
-
-        # Collect all audio inputs (standalone + video-extracted) in
-        # encounter order and run them through one sound_encoder call.
+        # Collect all image params and all audio inputs (standalone +
+        # video-extracted) in a single pass, then run each encoder once
+        # over its bucket.
+        image_params: List[MultimodalParams] = []
         audio_data_list: List[dict] = []
         for param in multimodal_params:
             modality_type = param.multimodal_data["modality_type"]
-            if modality_type == "audio":
+            if modality_type == "image":
+                image_params.append(param)
+            elif modality_type == "audio":
                 audio_data_list.append(param.multimodal_data["audio"])
             elif modality_type == "video" and self.sound_encoder is not None:
                 audio_data = param.multimodal_data["video"].get("audio")
                 if audio_data is not None:
                     audio_data_list.append(audio_data)
+
+        image_embeds: List[torch.Tensor] = []
+        if image_params:
+            image_embeds, _ = self.vision_encoder(image_params)
         audio_outputs: List[Tuple[torch.Tensor, List[int]]] = (
             self._encode_audio(audio_data_list) if audio_data_list else []
         )

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
@@ -388,8 +388,8 @@ class TestEncodeMultimodalDispatch:
     def test_encode_multimodal_dispatches_audio(self):
         model = self._make_mock_model()
         fake_audio_embeds = torch.randn(10, 128)
-        # All audio is encoded via the batched bucket helper.
-        model._encode_audio_bucket = mock.MagicMock(return_value=[(fake_audio_embeds, [10])])
+        # All audio is encoded via the batched `_encode_audio` helper.
+        model._encode_audio = mock.MagicMock(return_value=[(fake_audio_embeds, [10])])
 
         mm_param = mock.MagicMock()
         audio_data = {"foo": "bar"}
@@ -398,7 +398,7 @@ class TestEncodeMultimodalDispatch:
         # Call the real method on our mock
         result = NemotronH_Nano_VL_V2._encode_multimodal(model, [mm_param])
 
-        model._encode_audio_bucket.assert_called_once_with([audio_data])
+        model._encode_audio.assert_called_once_with([audio_data])
         model.vision_encoder.assert_not_called()
         self._assert_compatible_with_chunked_prefill(result)
         assert torch.equal(result[0], fake_audio_embeds)
@@ -537,9 +537,9 @@ class TestEncodeMultimodalAudioOrder:
             ([v2_emb], [list(range(v2_len))]),
         ]
 
-        # All audio (across both videos) is encoded in a single bucket call;
-        # the bucket returns one (emb, per_clip_counts) per input in order.
-        audio_bucket_returns = [(a1_emb, [a1_len]), (a2_emb, [a2_len])]
+        # All audio (across both videos) is encoded in a single batched call;
+        # the helper returns one (emb, per_clip_counts) per input in order.
+        audio_returns = [(a1_emb, [a1_len]), (a2_emb, [a2_len])]
 
         params = [
             self._make_video_param(has_audio=True),
@@ -551,7 +551,7 @@ class TestEncodeMultimodalAudioOrder:
         model = MagicMock()
         model.vision_encoder = MagicMock(side_effect=vision_returns)
         model.sound_encoder = MagicMock()  # not None -> audio path taken
-        model._encode_audio_bucket = MagicMock(return_value=audio_bucket_returns)
+        model._encode_audio = MagicMock(return_value=audio_returns)
         # Mock the interleaver to simply concatenate vision + audio, since this test only verifies
         # per-param dispatch, not interleaving math.
         model._interleave_video_audio_embeddings = MagicMock(
@@ -589,13 +589,13 @@ class TestEncodeMultimodalAudioOrder:
         model = MagicMock()
         model.vision_encoder = MagicMock(return_value=([v_emb], [list(range(v_len))]))
         model.sound_encoder = MagicMock()
-        model._encode_audio_bucket = MagicMock()
+        model._encode_audio = MagicMock()
 
         result = NemotronH_Nano_VL_V2._encode_multimodal(model, [param])
 
         assert len(result) == 1
         assert torch.equal(result[0], v_emb), "Vision-only video should not have audio appended"
-        model._encode_audio_bucket.assert_not_called()
+        model._encode_audio.assert_not_called()
 
     def test_no_audio_concat_when_sound_encoder_is_none(self):
         hidden = 16
@@ -607,13 +607,13 @@ class TestEncodeMultimodalAudioOrder:
         model = MagicMock()
         model.vision_encoder = MagicMock(return_value=([v_emb], [list(range(v_len))]))
         model.sound_encoder = None  # no audio support
-        model._encode_audio_bucket = MagicMock()
+        model._encode_audio = MagicMock()
 
         result = NemotronH_Nano_VL_V2._encode_multimodal(model, [param])
 
         assert len(result) == 1
         assert torch.equal(result[0], v_emb)
-        model._encode_audio_bucket.assert_not_called()
+        model._encode_audio.assert_not_called()
 
 
 class TestInterleaveVideoAudioEmbeddings:
@@ -729,8 +729,8 @@ class TestInterleaveVideoAudioEmbeddings:
         assert torch.equal(result, expected)
 
 
-class TestEncodeAudioBucket:
-    """Numerical equivalence: batched audio bucket vs per-input encoding.
+class TestEncodeAudio:
+    """Numerical equivalence: batched audio vs per-input encoding.
 
     Uses a deterministic stub for `sound_encoder` so the test does not
     depend on a checkpoint that ships sound weights (the test fixture's
@@ -756,9 +756,7 @@ class TestEncodeAudioBucket:
                 super().__init__()
 
             def _get_subsampling_output_length(self_inner, valid_input_lens):
-                return torch.div(
-                    valid_input_lens, TestEncodeAudioBucket.SUBSAMPLE, rounding_mode="floor"
-                )
+                return torch.div(valid_input_lens, TestEncodeAudio.SUBSAMPLE, rounding_mode="floor")
 
         class _Stub(torch.nn.Module):
             def __init__(self_inner):
@@ -771,11 +769,11 @@ class TestEncodeAudioBucket:
                 # SUBSAMPLE timesteps to mimic temporal subsampling.
                 x = self_inner.proj(features)  # [N, T, hidden]
                 T = x.shape[1]
-                T_trim = (T // TestEncodeAudioBucket.SUBSAMPLE) * TestEncodeAudioBucket.SUBSAMPLE
+                T_trim = (T // TestEncodeAudio.SUBSAMPLE) * TestEncodeAudio.SUBSAMPLE
                 x = x[:, :T_trim].reshape(
                     x.shape[0],
-                    T_trim // TestEncodeAudioBucket.SUBSAMPLE,
-                    TestEncodeAudioBucket.SUBSAMPLE,
+                    T_trim // TestEncodeAudio.SUBSAMPLE,
+                    TestEncodeAudio.SUBSAMPLE,
                     -1,
                 )
                 return x.mean(dim=2)  # [N, T_out, hidden]
@@ -789,10 +787,10 @@ class TestEncodeAudioBucket:
             mask[i, :vl] = 1
         return {"input_audio_features": features, "feature_attention_mask": mask}
 
-    def test_bucket_matches_per_input(self):
-        """Bucket output equals N singleton `_encode_audio_bucket` calls.
+    def test_batched_matches_per_input(self):
+        """Bucket output equals N singleton `_encode_audio` calls.
 
-        Compares ``bucket([a1, a2])`` against ``[bucket([a1])[0], bucket([a2])[0]]``
+        Compares ``encode([a1, a2])`` against ``[encode([a1])[0], encode([a2])[0]]``
         — the contract is that the i-th batched result is identical to a
         per-input call for input i.
         """
@@ -807,19 +805,19 @@ class TestEncodeAudioBucket:
         a2 = self._make_audio_data(num_clips=1, time_len=14, valid_lens=[12])
 
         per_input_results = [
-            NemotronH_Nano_VL_V2._encode_audio_bucket(model, [a1])[0],
-            NemotronH_Nano_VL_V2._encode_audio_bucket(model, [a2])[0],
+            NemotronH_Nano_VL_V2._encode_audio(model, [a1])[0],
+            NemotronH_Nano_VL_V2._encode_audio(model, [a2])[0],
         ]
-        bucket_results = NemotronH_Nano_VL_V2._encode_audio_bucket(model, [a1, a2])
+        batched_results = NemotronH_Nano_VL_V2._encode_audio(model, [a1, a2])
 
-        assert len(bucket_results) == 2
-        for (b_emb, b_counts), (s_emb, s_counts) in zip(bucket_results, per_input_results):
+        assert len(batched_results) == 2
+        for (b_emb, b_counts), (s_emb, s_counts) in zip(batched_results, per_input_results):
             assert b_counts == s_counts
             assert torch.allclose(b_emb, s_emb, atol=1e-6, rtol=1e-6)
 
-    def test_bucket_empty_input(self):
+    def test_empty_input(self):
         model = mock.MagicMock(spec=NemotronH_Nano_VL_V2)
-        assert NemotronH_Nano_VL_V2._encode_audio_bucket(model, []) == []
+        assert NemotronH_Nano_VL_V2._encode_audio(model, []) == []
 
 
 class TestEncodeMultimodalContract:
@@ -892,7 +890,7 @@ class TestEncodeMultimodalContract:
         img_emb = torch.randn(5, self.HIDDEN)
         audio_emb = torch.randn(3, self.HIDDEN)
         model.vision_encoder.return_value = ([img_emb], [None])
-        model._encode_audio_bucket = mock.MagicMock(return_value=[(audio_emb, [3])])
+        model._encode_audio = mock.MagicMock(return_value=[(audio_emb, [3])])
 
         params = [
             self._make_mm_param("image"),
@@ -1002,8 +1000,8 @@ class TestChunkedPrefillCaching:
     def test_audio_encoder_not_called_on_second_chunk(self):
         model = self._make_mock_model()
         fake_emb = torch.randn(self.NUM_TOKENS, self.HIDDEN)
-        # Audio is encoded via the batched bucket helper.
-        model._encode_audio_bucket = mock.MagicMock(return_value=[(fake_emb, [self.NUM_TOKENS])])
+        # Audio is encoded via the batched `_encode_audio` helper.
+        model._encode_audio = mock.MagicMock(return_value=[(fake_emb, [self.NUM_TOKENS])])
 
         param = self._make_param_with_runtime("audio", self.NUM_TOKENS, audio={})
         encoder_fn = self._make_encoder_fn(model)
@@ -1014,15 +1012,15 @@ class TestChunkedPrefillCaching:
             multimodal_params=[param],
         )
         assert len(result) == 1
-        assert model._encode_audio_bucket.call_count == 1
+        assert model._encode_audio.call_count == 1
 
         # Second call - should use cache.
         result2 = get_multimodal_embeddings(
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param],
         )
-        assert model._encode_audio_bucket.call_count == 1, (
-            "`_encode_audio_bucket` was called again on the second chunk. "
+        assert model._encode_audio.call_count == 1, (
+            "`_encode_audio` was called again on the second chunk. "
             "Caching is broken - `_encode_multimodal` likely violates the "
             "`get_multimodal_embeddings` return type contract."
         )
@@ -1040,7 +1038,7 @@ class TestChunkedPrefillCaching:
         param_b = self._make_param_with_runtime("image", 3)
         encoder_fn = self._make_encoder_fn(model)
 
-        # First call: encoder runs once for the whole image bucket.
+        # First call: encoder runs once for the whole image batch.
         result = get_multimodal_embeddings(
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param_a, param_b],

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
@@ -388,15 +388,17 @@ class TestEncodeMultimodalDispatch:
     def test_encode_multimodal_dispatches_audio(self):
         model = self._make_mock_model()
         fake_audio_embeds = torch.randn(10, 128)
-        model._encode_audio = mock.MagicMock(return_value=fake_audio_embeds)
+        # All audio is encoded via the batched bucket helper.
+        model._encode_audio_bucket = mock.MagicMock(return_value=[(fake_audio_embeds, [10])])
 
         mm_param = mock.MagicMock()
-        mm_param.multimodal_data = {"modality_type": "audio", "audio": {}}
+        audio_data = {"foo": "bar"}
+        mm_param.multimodal_data = {"modality_type": "audio", "audio": audio_data}
 
         # Call the real method on our mock
         result = NemotronH_Nano_VL_V2._encode_multimodal(model, [mm_param])
 
-        model._encode_audio.assert_called_once_with(mm_param)
+        model._encode_audio_bucket.assert_called_once_with([audio_data])
         model.vision_encoder.assert_not_called()
         self._assert_compatible_with_chunked_prefill(result)
         assert torch.equal(result[0], fake_audio_embeds)
@@ -535,7 +537,9 @@ class TestEncodeMultimodalAudioOrder:
             ([v2_emb], [list(range(v2_len))]),
         ]
 
-        audio_returns = [(a1_emb, [a1_len]), (a2_emb, [a2_len])]
+        # All audio (across both videos) is encoded in a single bucket call;
+        # the bucket returns one (emb, per_clip_counts) per input in order.
+        audio_bucket_returns = [(a1_emb, [a1_len]), (a2_emb, [a2_len])]
 
         params = [
             self._make_video_param(has_audio=True),
@@ -547,7 +551,7 @@ class TestEncodeMultimodalAudioOrder:
         model = MagicMock()
         model.vision_encoder = MagicMock(side_effect=vision_returns)
         model.sound_encoder = MagicMock()  # not None -> audio path taken
-        model._encode_audio_data = MagicMock(side_effect=audio_returns)
+        model._encode_audio_bucket = MagicMock(return_value=audio_bucket_returns)
         # Mock the interleaver to simply concatenate vision + audio, since this test only verifies
         # per-param dispatch, not interleaving math.
         model._interleave_video_audio_embeddings = MagicMock(
@@ -585,13 +589,13 @@ class TestEncodeMultimodalAudioOrder:
         model = MagicMock()
         model.vision_encoder = MagicMock(return_value=([v_emb], [list(range(v_len))]))
         model.sound_encoder = MagicMock()
-        model._encode_audio_data = MagicMock()
+        model._encode_audio_bucket = MagicMock()
 
         result = NemotronH_Nano_VL_V2._encode_multimodal(model, [param])
 
         assert len(result) == 1
         assert torch.equal(result[0], v_emb), "Vision-only video should not have audio appended"
-        model._encode_audio_data.assert_not_called()
+        model._encode_audio_bucket.assert_not_called()
 
     def test_no_audio_concat_when_sound_encoder_is_none(self):
         hidden = 16
@@ -603,13 +607,13 @@ class TestEncodeMultimodalAudioOrder:
         model = MagicMock()
         model.vision_encoder = MagicMock(return_value=([v_emb], [list(range(v_len))]))
         model.sound_encoder = None  # no audio support
-        model._encode_audio_data = MagicMock()
+        model._encode_audio_bucket = MagicMock()
 
         result = NemotronH_Nano_VL_V2._encode_multimodal(model, [param])
 
         assert len(result) == 1
         assert torch.equal(result[0], v_emb)
-        model._encode_audio_data.assert_not_called()
+        model._encode_audio_bucket.assert_not_called()
 
 
 class TestInterleaveVideoAudioEmbeddings:
@@ -725,6 +729,99 @@ class TestInterleaveVideoAudioEmbeddings:
         assert torch.equal(result, expected)
 
 
+class TestEncodeAudioBucket:
+    """Numerical equivalence: batched audio bucket vs per-input encoding.
+
+    Uses a deterministic stub for `sound_encoder` so the test does not
+    depend on a checkpoint that ships sound weights (the test fixture's
+    12B-v2-VL has none). The stub mirrors what the real encoder
+    contracts: maps ``[N, T_in, mel]`` to ``[N, T_out, hidden]`` with
+    a fixed temporal subsampling factor and exposes
+    ``encoder._get_subsampling_output_length``.
+    """
+
+    MEL_BINS = 4
+    HIDDEN = 8
+    SUBSAMPLE = 2  # 2 input timesteps -> 1 output timestep
+
+    def _make_stub_sound_encoder(self):
+        # The model invokes:
+        #   sound_embeds = sound_encoder(features, mask)
+        #   valid_output_lens = sound_encoder.encoder._get_subsampling_output_length(valid_input_lens)
+        # so the stub is a small Linear over the time dim plus a method.
+        proj = torch.nn.Linear(self.MEL_BINS, self.HIDDEN, bias=False)
+
+        class _StubEncoder(torch.nn.Module):
+            def __init__(self_inner):
+                super().__init__()
+
+            def _get_subsampling_output_length(self_inner, valid_input_lens):
+                return torch.div(
+                    valid_input_lens, TestEncodeAudioBucket.SUBSAMPLE, rounding_mode="floor"
+                )
+
+        class _Stub(torch.nn.Module):
+            def __init__(self_inner):
+                super().__init__()
+                self_inner.proj = proj
+                self_inner.encoder = _StubEncoder()
+
+            def forward(self_inner, features, mask):
+                # features: [N, T, mel] -> mel-projected, then mean-pool every
+                # SUBSAMPLE timesteps to mimic temporal subsampling.
+                x = self_inner.proj(features)  # [N, T, hidden]
+                T = x.shape[1]
+                T_trim = (T // TestEncodeAudioBucket.SUBSAMPLE) * TestEncodeAudioBucket.SUBSAMPLE
+                x = x[:, :T_trim].reshape(
+                    x.shape[0],
+                    T_trim // TestEncodeAudioBucket.SUBSAMPLE,
+                    TestEncodeAudioBucket.SUBSAMPLE,
+                    -1,
+                )
+                return x.mean(dim=2)  # [N, T_out, hidden]
+
+        return _Stub()
+
+    def _make_audio_data(self, num_clips, time_len, valid_lens):
+        features = torch.randn(num_clips, time_len, self.MEL_BINS)
+        mask = torch.zeros(num_clips, time_len, dtype=torch.long)
+        for i, vl in enumerate(valid_lens):
+            mask[i, :vl] = 1
+        return {"input_audio_features": features, "feature_attention_mask": mask}
+
+    def test_bucket_matches_per_input(self):
+        """Bucket output equals N singleton `_encode_audio_bucket` calls.
+
+        Compares ``bucket([a1, a2])`` against ``[bucket([a1])[0], bucket([a2])[0]]``
+        — the contract is that the i-th batched result is identical to a
+        per-input call for input i.
+        """
+        torch.manual_seed(0)
+        stub = self._make_stub_sound_encoder()
+        model = mock.MagicMock(spec=NemotronH_Nano_VL_V2)
+        model.sound_encoder = stub
+        model.model_dtype = torch.float32
+
+        # Two inputs with different time / clip counts.
+        a1 = self._make_audio_data(num_clips=2, time_len=10, valid_lens=[10, 6])
+        a2 = self._make_audio_data(num_clips=1, time_len=14, valid_lens=[12])
+
+        per_input_results = [
+            NemotronH_Nano_VL_V2._encode_audio_bucket(model, [a1])[0],
+            NemotronH_Nano_VL_V2._encode_audio_bucket(model, [a2])[0],
+        ]
+        bucket_results = NemotronH_Nano_VL_V2._encode_audio_bucket(model, [a1, a2])
+
+        assert len(bucket_results) == 2
+        for (b_emb, b_counts), (s_emb, s_counts) in zip(bucket_results, per_input_results):
+            assert b_counts == s_counts
+            assert torch.allclose(b_emb, s_emb, atol=1e-6, rtol=1e-6)
+
+    def test_bucket_empty_input(self):
+        model = mock.MagicMock(spec=NemotronH_Nano_VL_V2)
+        assert NemotronH_Nano_VL_V2._encode_audio_bucket(model, []) == []
+
+
 class TestEncodeMultimodalContract:
     """Verify `_encode_multimodal` conforms to the contract expected by `get_multimodal_embeddings`.
 
@@ -795,7 +892,7 @@ class TestEncodeMultimodalContract:
         img_emb = torch.randn(5, self.HIDDEN)
         audio_emb = torch.randn(3, self.HIDDEN)
         model.vision_encoder.return_value = ([img_emb], [None])
-        model._encode_audio = mock.MagicMock(return_value=audio_emb)
+        model._encode_audio_bucket = mock.MagicMock(return_value=[(audio_emb, [3])])
 
         params = [
             self._make_mm_param("image"),
@@ -905,7 +1002,8 @@ class TestChunkedPrefillCaching:
     def test_audio_encoder_not_called_on_second_chunk(self):
         model = self._make_mock_model()
         fake_emb = torch.randn(self.NUM_TOKENS, self.HIDDEN)
-        model._encode_audio = mock.MagicMock(return_value=fake_emb)
+        # Audio is encoded via the batched bucket helper.
+        model._encode_audio_bucket = mock.MagicMock(return_value=[(fake_emb, [self.NUM_TOKENS])])
 
         param = self._make_param_with_runtime("audio", self.NUM_TOKENS, audio={})
         encoder_fn = self._make_encoder_fn(model)
@@ -916,15 +1014,15 @@ class TestChunkedPrefillCaching:
             multimodal_params=[param],
         )
         assert len(result) == 1
-        assert model._encode_audio.call_count == 1
+        assert model._encode_audio_bucket.call_count == 1
 
         # Second call - should use cache.
         result2 = get_multimodal_embeddings(
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param],
         )
-        assert model._encode_audio.call_count == 1, (
-            "`_encode_audio` was called again on the second chunk. "
+        assert model._encode_audio_bucket.call_count == 1, (
+            "`_encode_audio_bucket` was called again on the second chunk. "
             "Caching is broken - `_encode_multimodal` likely violates the "
             "`get_multimodal_embeddings` return type contract."
         )

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
@@ -221,6 +221,82 @@ def test_nemotron_nano_v2_vl_model_sanity_check(
         print("Passed! Max difference is within tolerance")
 
 
+@pytest.mark.threadleak(enabled=False)
+def test_nemotron_nano_v2_vl_image_batch_equivalence(nano_llm_model):
+    """End-to-end equivalence check for cross-request image batching.
+
+    Two distinct image+prompt requests are sent (a) together in one
+    `generate` call so the engine batches them in a single forward step
+    (and thus a single `_encode_multimodal` invocation with two
+    multimodal_params), and (b) separately in two `generate` calls. With
+    greedy decoding, the resulting token IDs must be identical and the
+    logprobs must match within bf16 tolerance. This is intended to detect
+    cross-request leakage or ordering bugs introduced by a future change
+    that batches per-modality across requests inside the vision encoder.
+    """
+    nano_llm = nano_llm_model
+    test_data_root = Path(os.path.join(llm_models_root(), "multimodals", "test_data"))
+    prompts = [
+        "Describe the natural environment in the image.",
+        "Describe the object and the weather condition in the image.",
+    ]
+    media = [str(test_data_root / "seashore.png"), str(test_data_root / "inpaint.png")]
+
+    sampling_params = SamplingParams(
+        max_tokens=16,
+        temperature=0.0,
+        add_special_tokens=False,
+        return_generation_logits=True,
+    )
+
+    def _build_inputs(prompts_subset, media_subset):
+        return default_multimodal_input_loader(
+            tokenizer=nano_llm.tokenizer,
+            model_dir=MODEL_PATH,
+            model_type="NemotronH_Nano_VL_V2",
+            modality="image",
+            prompts=prompts_subset,
+            media=media_subset,
+            image_data_format="pt",
+            num_frames=8,
+            device="cpu",
+        )
+
+    # Path A: both requests in one generate call -> engine batches them.
+    batched_inputs = _build_inputs(prompts, media)
+    batched_outputs = nano_llm.generate(batched_inputs, sampling_params)
+    assert len(batched_outputs) == 2
+
+    # Path B: each request in its own generate call.
+    sep_outputs = []
+    for p, m in zip(prompts, media):
+        sep_inputs = _build_inputs([p], [m])
+        sep_outputs.append(nano_llm.generate(sep_inputs, sampling_params)[0])
+
+    for i, (b_out, s_out) in enumerate(zip(batched_outputs, sep_outputs)):
+        b_token_ids = list(b_out.outputs[0].token_ids)
+        s_token_ids = list(s_out.outputs[0].token_ids)
+        assert b_token_ids == s_token_ids, (
+            f"Request {i}: token_ids differ between batched and separate runs.\n"
+            f"  batched : {b_token_ids}\n"
+            f"  separate: {s_token_ids}"
+        )
+
+        b_logp = extract_decode_logprobs(b_out).cpu()
+        s_logp = extract_decode_logprobs(s_out).cpu()
+        max_diff = (b_logp - s_logp).abs().max().item()
+        # bf16 reductions in attention / layernorm produce small but
+        # nonzero diffs between batched-forward and per-request-forward
+        # even for the same input. Token IDs (greedy) are the stronger
+        # equivalence signal; logprobs use a looser tolerance, well
+        # below the 0.3 threshold used by the sanity test.
+        assert max_diff < 0.15, (
+            f"Request {i}: logprob diff too large ({max_diff:.4f}).\n"
+            f"  batched : {b_logp}\n"
+            f"  separate: {s_logp}"
+        )
+
+
 class TestEncodeMultimodalDispatch:
     def _make_mock_model(self):
         """Create a minimal mock with the attributes `_encode_multimodal` needs."""
@@ -621,18 +697,21 @@ class TestEncodeMultimodalContract:
 
         `get_multimodal_embeddings` requires `len(embeddings) == 1` and splits by per-request token
         counts in order to cache the embeddings.
+
+        Image params are batched into a single `vision_encoder` call that
+        returns a per-param embedding list.
         """
         model = self._make_mock_model()
         emb_a = torch.randn(5, self.HIDDEN)
         emb_b = torch.randn(3, self.HIDDEN)
-        model.vision_encoder.side_effect = [
-            ([emb_a], [None]),
-            ([emb_b], [None]),
-        ]
+        model.vision_encoder.return_value = ([emb_a, emb_b], [None, None])
 
         params = [self._make_mm_param("image"), self._make_mm_param("image")]
         result = NemotronH_Nano_VL_V2._encode_multimodal(model, params)
 
+        # All image params go through a single batched vision_encoder call.
+        assert model.vision_encoder.call_count == 1
+        assert model.vision_encoder.call_args.args == (params,)
         assert len(result) == 1
         assert result[0].shape == (8, self.HIDDEN)
         # Verify concatenation order is preserved.
@@ -781,27 +860,27 @@ class TestChunkedPrefillCaching:
         assert torch.equal(result2[0], result[0])
 
     def test_multi_request_batch_caching(self):
-        """Two image requests in one batch: both cached after one call."""
+        """Two image requests in one batch: both cached after a single batched call."""
         model = self._make_mock_model()
         emb_a = torch.randn(5, self.HIDDEN)
         emb_b = torch.randn(3, self.HIDDEN)
-        model.vision_encoder.side_effect = [
-            ([emb_a], [None]),
-            ([emb_b], [None]),
-        ]
+        # All image params are encoded in a single batched call.
+        model.vision_encoder.return_value = ([emb_a, emb_b], [None, None])
 
         param_a = self._make_param_with_runtime("image", 5)
         param_b = self._make_param_with_runtime("image", 3)
         encoder_fn = self._make_encoder_fn(model)
 
-        # First call: encoder runs for both.
+        # First call: encoder runs once for the whole image bucket.
         result = get_multimodal_embeddings(
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param_a, param_b],
         )
         assert len(result) == 1
         assert result[0].shape == (8, self.HIDDEN)
-        assert model.vision_encoder.call_count == 2  # once per param
+        assert model.vision_encoder.call_count == 1, (
+            "image params should be encoded in a single batched vision_encoder call"
+        )
 
         # Both should be cached.
         assert "multimodal_embedding" in param_a.multimodal_data
@@ -812,7 +891,7 @@ class TestChunkedPrefillCaching:
             encoder_forward_fn=encoder_fn,
             multimodal_params=[param_a, param_b],
         )
-        assert model.vision_encoder.call_count == 2, (
+        assert model.vision_encoder.call_count == 1, (
             "`vision_encoder` was called again on the second chunk. "
             "Caching is broken - `_encode_multimodal` likely violates the "
             "`get_multimodal_embeddings` return type contract."

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
@@ -297,6 +297,77 @@ def test_nemotron_nano_v2_vl_image_batch_equivalence(nano_llm_model):
         )
 
 
+@pytest.mark.threadleak(enabled=False)
+def test_nemotron_nano_v2_vl_video_batch_equivalence(nano_llm_model):
+    """End-to-end equivalence check for cross-request video batching.
+
+    Mirror of `test_nemotron_nano_v2_vl_image_batch_equivalence` for
+    video: two distinct video+prompt requests sent (a) together in one
+    `generate` call (engine batches them, vision_encoder sees both
+    multimodal_params at once) and (b) separately in two `generate`
+    calls. With greedy decoding, token IDs must match and logprobs stay
+    within bf16 tolerance.
+
+    Intended to detect cross-video tubelet leakage if a future change
+    batches the temporal-video path across requests inside the vision
+    encoder.
+    """
+    nano_llm = nano_llm_model
+    test_data_root = Path(os.path.join(llm_models_root(), "multimodals", "test_data"))
+    prompts = [
+        "Describe the natural environment in the video.",
+        "Describe the scene in the video briefly.",
+    ]
+    media = [str(test_data_root / "world.mp4"), str(test_data_root / "world.mp4")]
+
+    sampling_params = SamplingParams(
+        max_tokens=16,
+        temperature=0.0,
+        add_special_tokens=False,
+        return_generation_logits=True,
+    )
+
+    def _build_inputs(prompts_subset, media_subset):
+        return default_multimodal_input_loader(
+            tokenizer=nano_llm.tokenizer,
+            model_dir=MODEL_PATH,
+            model_type="NemotronH_Nano_VL_V2",
+            modality="video",
+            prompts=prompts_subset,
+            media=media_subset,
+            image_data_format="pt",
+            num_frames=8,
+            device="cpu",
+        )
+
+    batched_inputs = _build_inputs(prompts, media)
+    batched_outputs = nano_llm.generate(batched_inputs, sampling_params)
+    assert len(batched_outputs) == 2
+
+    sep_outputs = []
+    for p, m in zip(prompts, media):
+        sep_inputs = _build_inputs([p], [m])
+        sep_outputs.append(nano_llm.generate(sep_inputs, sampling_params)[0])
+
+    for i, (b_out, s_out) in enumerate(zip(batched_outputs, sep_outputs)):
+        b_token_ids = list(b_out.outputs[0].token_ids)
+        s_token_ids = list(s_out.outputs[0].token_ids)
+        assert b_token_ids == s_token_ids, (
+            f"Request {i}: token_ids differ between batched and separate runs.\n"
+            f"  batched : {b_token_ids}\n"
+            f"  separate: {s_token_ids}"
+        )
+
+        b_logp = extract_decode_logprobs(b_out).cpu()
+        s_logp = extract_decode_logprobs(s_out).cpu()
+        max_diff = (b_logp - s_logp).abs().max().item()
+        assert max_diff < 0.15, (
+            f"Request {i}: logprob diff too large ({max_diff:.4f}).\n"
+            f"  batched : {b_logp}\n"
+            f"  separate: {s_logp}"
+        )
+
+
 class TestEncodeMultimodalDispatch:
     def _make_mock_model(self):
         """Create a minimal mock with the attributes `_encode_multimodal` needs."""

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_nano_v2_vl.py
@@ -531,11 +531,12 @@ class TestEncodeMultimodalAudioOrder:
         v2_emb = torch.randn(v2_len, hidden)
         a2_emb = torch.randn(a2_len, hidden)
 
-        # vision_encoder is called once per param; return the right tensor.
-        vision_returns = [
-            ([v1_emb], [list(range(v1_len))]),
-            ([v2_emb], [list(range(v2_len))]),
-        ]
+        # All video params are encoded in a single batched call; the encoder
+        # returns one embedding per param, in input order.
+        vision_return = (
+            [v1_emb, v2_emb],
+            [list(range(v1_len)), list(range(v2_len))],
+        )
 
         # All audio (across both videos) is encoded in a single batched call;
         # the helper returns one (emb, per_clip_counts) per input in order.
@@ -549,7 +550,7 @@ class TestEncodeMultimodalAudioOrder:
         # Build a minimal mock of NemotronH_Nano_VL_V2 with only the attributes `_encode_multimodal`
         # touches.
         model = MagicMock()
-        model.vision_encoder = MagicMock(side_effect=vision_returns)
+        model.vision_encoder = MagicMock(return_value=vision_return)
         model.sound_encoder = MagicMock()  # not None -> audio path taken
         model._encode_audio = MagicMock(return_value=audio_returns)
         # Mock the interleaver to simply concatenate vision + audio, since this test only verifies

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -388,11 +388,35 @@ def vision_encoder():
     return encoder
 
 
+def _wire_bucket_helpers_to_extract_feature(vision_encoder):
+    """Make `_encode_*` buckets call `extract_feature*` once per non-empty bucket.
+
+    `forward` now delegates to per-modality bucket helpers, which `MagicMock(spec=...)`
+    auto-mocks alongside the encoder. Stub the buckets so they forward to the real
+    `extract_feature*` mocks the tests configure — keeping the original
+    "did we route through the dynamic/fixed path?" assertions valid.
+    """
+
+    def _dynamic(image_data_list):
+        return [vision_encoder.extract_feature_dynamic()] if image_data_list else []
+
+    def _fixed(image_data_list):
+        return [vision_encoder.extract_feature()] if image_data_list else []
+
+    def _video(video_data_list):
+        return []
+
+    vision_encoder._encode_dynamic_image.side_effect = _dynamic
+    vision_encoder._encode_fixed_tile.side_effect = _fixed
+    vision_encoder._encode_temporal_video.side_effect = _video
+
+
 def test_forward_dynamic_path(vision_encoder):
     fake_embeds = torch.randn(1, 10, 512)
     vision_encoder.extract_feature_dynamic = mock.MagicMock(return_value=fake_embeds)
     vision_encoder.extract_feature = mock.MagicMock()
-    vision_encoder.apply_evs = mock.MagicMock(return_value=(fake_embeds, []))
+    vision_encoder.apply_evs = mock.MagicMock(return_value=([fake_embeds], []))
+    _wire_bucket_helpers_to_extract_feature(vision_encoder)
 
     mm_data = {
         "modality_type": "image",
@@ -414,7 +438,8 @@ def test_forward_fixed_tile_path(vision_encoder):
     fake_embeds = torch.randn(2, 8, 512)
     vision_encoder.extract_feature = mock.MagicMock(return_value=fake_embeds)
     vision_encoder.extract_feature_dynamic = mock.MagicMock()
-    vision_encoder.apply_evs = mock.MagicMock(return_value=(fake_embeds, []))
+    vision_encoder.apply_evs = mock.MagicMock(return_value=([fake_embeds], []))
+    _wire_bucket_helpers_to_extract_feature(vision_encoder)
 
     mm_data = {
         "modality_type": "image",


### PR DESCRIPTION
## Headline numbers

| Modality | branch | main | Speedup |
|---|---:|---:|---:|
| Image (256×256, ISL=325) | **2.61 s** | 3.13 s | **1.20× (+19.9% throughput)** |
| Audio (30 s,    ISL=444) | **3.41 s** | 4.26 s | **1.25× (+25.2% throughput)** |

## Image detailed (256×256, ISL=325, CONC=32, OSL=64)

| Metric | branch run2 | branch run3 | **branch avg\*** | main run2 | main run3 | **main avg\*** | Δ (branch faster) |
|---|---:|---:|---:|---:|---:|---:|---:|
| Benchmark Duration (s)         | 2.632 | 2.597 | **2.614** | 3.134 | 3.134 | **3.134** | **-16.6%** (1.20×) |
| Request Throughput (req/s)     | 36.48 | 36.97 | **36.73** | 30.63 | 30.63 | **30.63** | **+19.9%** |
| Output Tput (tok/s)            | 2,335 | 2,366 | **2,350** | 1,961 | 1,960 | **1,961** | **+19.9%** |
| TTFT avg (ms)                  | 399.6 | 393.6 | **396.7** | 540.4 | 543.4 | **541.9** | **-26.8%** |
| TTFT p50 (ms)                  | 425.2 | 415.4 | **420.3** | 559.2 | 557.5 | **558.4** | **-24.7%** |
| TTFT p90 (ms)                  | 449.6 | 432.4 | **441.0** | 570.3 | 563.0 | **566.6** | **-22.2%** |
| TTFT p99 (ms)                  | 459.0 | 434.1 | **446.6** | 572.8 | 567.0 | **569.9** | **-21.6%** |
| Request Latency avg (ms)       | 873.6 | 862.4 | **868.0** | 1,038.7 | 1,038.5 | **1,038.6** | **-16.4%** |
| Inter-Token Latency (ms)       | 7.52  | 7.44  | **7.48**  | 7.91  | 7.86  | **7.88**  | -5.1% |

## Audio detailed (30 s @ 16 kHz, ISL=444, CONC=32, OSL=64)

| Metric | branch run1 | branch run2 | branch run3 | **branch avg** | main run1 | main run2 | main run3 | **main avg** | Δ (branch faster) |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Benchmark Duration (s)        | 3.620   | 3.402   | 3.201   | **3.408** | 4.294   | 4.086   | 4.396   | **4.259** | **-20.0%** (1.25×) |
| Request Throughput (req/s)    | 26.52   | 28.22   | 29.99   | **28.24** | 22.35   | 23.49   | 21.84   | **22.56** | **+25.2%** |
| Output Tput (tok/s)           | 1,697   | 1,806   | 1,920   | **1,808** | 1,431   | 1,504   | 1,398   | **1,444** | **+25.2%** |
| TTFT avg (ms)                 | 636.1   | 616.3   | 477.0   | **576.5** | 827.1   | 697.2   | 812.4   | **778.9** | **-26.0%** |
| TTFT p50 (ms)                 | 655.7   | 599.3   | 477.3   | **577.4** | 872.3   | 761.4   | 930.8   | **854.8** | **-32.5%** |
| TTFT p90 (ms)                 | 813.4   | 736.9   | 645.2   | **731.8** | 1,024.3 | 883.3   | 1,022.2 | **976.6** | **-25.1%** |
| TTFT p99 (ms)                 | 815.4   | 741.7   | 647.4   | **734.8** | 1,029.0 | 884.9   | 1,037.1 | **983.7** | **-25.3%** |
| Request Latency avg (ms)      | 1,189   | 1,116   | 1,049   | **1,118** | 1,419   | 1,335   | 1,427   | **1,393** | **-19.7%** |
| Inter-Token Latency (ms)      | 8.78    | 7.93    | 9.09    | **8.60**  | 9.39    | 10.12   | 9.75    | **9.75**  | **-11.8%** |

  ## Accuracy

  | Metric | Direction | Branch (n=10) | Baseline (n=10) | Δ (branch − baseline) | Welch t | df | p (two-tailed) | Verdict |
  |---|:--:|---:|---:|---:|---:|---:|---:|---|
  | **MMMU** (image) | higher better | 38.81 ± 1.29 | 38.31 ± 1.33 | **+0.50** | 0.86 | 18 | 0.40 | no regression |
  | **VoxPopuli WER** (audio) | lower better | 6.152 ± 0.020 | 6.146 ± 0.018 | +0.006 | 0.71 | 18 | 0.49 | no regression |
  | **VideoMME** (video) | higher better | 68.43 ± 0.77 | 68.70 ± 0.79 | −0.27 | 0.77 | 18 | 0.45 | no regression |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Enhanced multimodal encoding efficiency through optimized batching of image, video, and audio inputs.
  * Improved support for advanced caching operations.

* **Tests**
  * Added end-to-end correctness tests validating batch processing for multimodal requests.
  * Expanded test coverage for audio encoding and multimodal input handling scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/13977)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->